### PR TITLE
docs: add dead code and lingering TODO review checks

### DIFF
--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -26,7 +26,8 @@ Verify every commit message follows `<type>(<scope>): <description>`:
 
 Scan the diff for:
 - Leftover `console.log`, `dump()`, `dd()`, or debug statements
-- Stale TODO/FIXME comments
+- Stale TODO/FIXME comments (must be resolved or tracked in a ticket)
+- Dead code: unused methods, unreachable branches, orphaned imports
 - Unintended technical debt
 
 ## Step 4 -- Security review
@@ -77,6 +78,8 @@ Produce a structured review report with:
   - [ ] Code respects the project architecture
   - [ ] SOLID principles and Law of Demeter followed
   - [ ] Design patterns used where appropriate
+  - [ ] No dead code (unused methods, unreachable branches, orphaned imports)
+  - [ ] No lingering TODO/FIXME comments
   - [ ] Tests cover new/changed cases
   - [ ] Documentation is up to date
   - [ ] Dependent tickets accounted for

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,7 +17,8 @@
 ## Auto-critique
 
 - [ ] No leftover `console.log`, `dump()`, `dd()`, or debug statements
-- [ ] No stale TODO/FIXME comments
+- [ ] No stale TODO/FIXME comments (resolved or tracked in a ticket)
+- [ ] No dead code (unused methods, unreachable branches, orphaned imports)
 - [ ] Code respects the project architecture (stateless backend, local-first frontend, DTO contract)
 - [ ] SOLID principles and Law of Demeter are followed
 - [ ] Documentation (PHPDoc, JSDoc) is up to date for modified public APIs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,7 @@ Run `git diff` and review all changes for:
 
 - Leftover `console.log`, `dump()`, `dd()`, or debug statements
 - Stale TODO/FIXME comments
+- Dead code (unused methods, unreachable branches, orphaned imports)
 - Unintended technical debt
 
 ### 2. Review Checklist
@@ -153,6 +154,8 @@ Run `git diff` and review all changes for:
 - [ ] SOLID principles and Law of Demeter are followed (deviations documented)
 - [ ] Design patterns are used where appropriate (no unjustified quick & dirty)
 - [ ] Tests cover new/changed cases: unit (`make test-php`), E2E (`make test-e2e`)
+- [ ] No dead code (unused methods, unreachable branches, orphaned imports)
+- [ ] No lingering TODO/FIXME comments (resolve or create a ticket)
 - [ ] Documentation (PHPDoc, JSDoc, Diataxis docs) is up to date for modified public APIs
 - [ ] Dependent tickets (if applicable) are accounted for
 


### PR DESCRIPTION
## Summary

- Adds two review checkpoints to catch dead code and lingering TODOs before merge
- Updated issue #89 verification checklist with matching items

## Changes

- **CLAUDE.md**: Added "dead code" to diff analysis list + two checklist items in review section
- **`.claude/skills/review/SKILL.md`**: Added dead code scanning to step 3 + two checklist items in step 10
- **`.github/PULL_REQUEST_TEMPLATE.md`**: Added dead code check to auto-critique section
- **Issue #89**: Added items 6 and 7 to "Vérification finale"

## Test plan

- [x] `make qa` passes (docs-only change)
- [x] No code changes, no tests needed

## Auto-critique

- [x] No leftover debug statements
- [x] No stale TODO/FIXME comments
- [x] No dead code
- [x] All four locations updated consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)