### PR TITLE
chore(claude): improve Claude settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,10 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "alwaysThinkingEnabled": true,
+  "enableAllProjectMcpServers": true,
+  "enabledMcpjsonServers": [
+    "openapi-spec"
+  ],
   "hooks": {
     "PreToolUse": [
       {
@@ -6,7 +12,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c 'FILE=$(jq -r \".tool_input.file_path\" <<< \"$(cat)\"); for p in \".env\" \"schema.d.ts\" \"compose.override\" \"vendor/\" \"node_modules/\"; do if [[ \"$FILE\" == *\"$p\"* ]]; then echo \"Fichier protégé: $p\" >&2; exit 2; fi; done; exit 0'"
+            "command": "bash -c 'FILE=$(jq -r \".tool_input.file_path\" <<< \"$(cat)\"); for p in \".env\" \"schema.d.ts\" \"compose.override\" \"vendor/\" \"node_modules/\" \".claude/\"; do if [[ \"$FILE\" == *\"$p\"* ]]; then echo \"Fichier protégé: $p\" >&2; exit 2; fi; done; exit 0'"
           }
         ]
       }
@@ -40,5 +46,48 @@
         ]
       }
     ]
+  },
+  "permissions": {
+    "allow": [
+      "Bash(cat:*)",
+      "Bash(curl:http://localhost*)",
+      "Bash(curl:https://localhost*)",
+      "Bash(diff:*)",
+      "Bash(echo:*)",
+      "Bash(find:*)",
+      "Bash(gh:*)",
+      "Bash(git:*)",
+      "Bash(grep:*)",
+      "Bash(head:*)",
+      "Bash(ls:*)",
+      "Bash(pwd)",
+      "Bash(tail:*)",
+      "Bash(tree:*)",
+      "Bash(wc:*)",
+      "Bash(which:*)",
+      "Bash(make:*)",
+      "Bash(php:*)",
+      "Bash(npx markdownlint-cli2:*)",
+      "Bash(vendor/bin/php-cs-fixer:*)",
+      "Bash(vendor/bin/phpstan:*)",
+      "Bash(vendor/bin/phpunit:*)",
+      "Bash(symfony:*)",
+      "Bash(bin/console:*)",
+      "Bash(composer:*)",
+      "Bash(shellcheck:*)",
+      "Bash(docker compose:*)",
+      "WebSearch",
+      "WebFetch"
+    ],
+    "deny": [
+      "Bash(rm:*)",
+      "Read(./.env)",
+      "Read(./api/config/secrets/*)",
+      "Read(./api/.env.local)",
+      "Read(./api/.env.local.php)",
+      "Read(./api/.env.*.local)",
+      "Read(./pwa/.env*)"
+    ],
+    "defaultMode": "acceptEdits"
   }
 }

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -95,6 +95,15 @@ jobs:
 
             ## Step 10 -- Report
 
+            ### Inline comments with suggestions
+
+            For every finding that involves a code change, post an **inline review comment** on the relevant line(s) using `mcp__github__add_comment_to_pending_review`.
+            - ALWAYS include a concrete fix using a GitHub suggestion block (` ```suggestion `), so the author can apply the fix in one click.
+            - ALWAYS propose a solution — never just point out a problem without suggesting how to fix it.
+            - Keep the suggestion minimal: only change what is necessary.
+
+            ### Summary comment
+
             Post a summary comment on the PR using `gh pr comment` with:
             - Severity levels: **critical**, **warning**, **info**
             - Specific `file:line` references for each finding


### PR DESCRIPTION
## Summary

- Scope `curl` permissions to localhost only (no arbitrary outbound HTTP)
- Move `.env` files to `deny` list with granular rules aligned with `.gitignore` (Symfony and Next.js patterns)
- Protect `api/config/secrets/` from reads (Symfony decrypt keys)
- Add `.claude/` to PreToolUse hook protected paths (prevent self-modification of settings)

## Auto-critique

- [x] Verified all `allow`/`deny` permission entries are intentional and scoped appropriately
- [x] Confirmed PreToolUse hook protects sensitive files from writes (`.env`, `schema.d.ts`, `compose.override`, `vendor/`, `node_modules/`, `.claude/`)
- [x] Confirmed PostToolUse hooks auto-format PHP and TypeScript files after edits
- [x] Verified `enabledMcpjsonServers` matches `.mcp.json` (`openapi-spec`)
- [x] Deny rules aligned with `api/.gitignore` (Symfony) and `pwa/.gitignore` (Next.js) patterns
- [x] `api/config/secrets/*` protected from reads
- [x] No application logic changed; no tests required

🤖 Generated with [Claude Code](https://claude.com/claude-code)