### PR TITLE
refactor(pwa): Lot 3 frontend refactoring (#89)

### DIFF
--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -119,6 +119,7 @@
     "failedMoveStage": "Failed to move stage.",
     "failedAddStage": "Failed to add stage.",
     "failedUpdateLocation": "Failed to update stage location.",
-    "failedUpdatePacing": "Failed to update pacing settings."
+    "failedUpdatePacing": "Failed to update pacing settings.",
+    "retry": "Try again"
   }
 }

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -119,6 +119,7 @@
     "failedMoveStage": "Impossible de déplacer l'étape.",
     "failedAddStage": "Impossible d'ajouter l'étape.",
     "failedUpdateLocation": "Impossible de mettre à jour la localisation.",
-    "failedUpdatePacing": "Impossible de mettre à jour les réglages."
+    "failedUpdatePacing": "Impossible de mettre à jour les réglages.",
+    "retry": "Réessayer"
   }
 }

--- a/pwa/src/app/error.tsx
+++ b/pwa/src/app/error.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useEffect } from "react";
+import { useTranslations } from "next-intl";
+
+interface ErrorBoundaryProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function ErrorBoundary({ error, reset }: ErrorBoundaryProps) {
+  const t = useTranslations("errors");
+
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-screen items-center justify-center px-4">
+      <div className="text-center space-y-4 max-w-md">
+        <h2 className="text-2xl font-semibold">{t("unexpectedError")}</h2>
+        <p className="text-muted-foreground">{error.message}</p>
+        <button
+          onClick={reset}
+          className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+        >
+          {t("retry")}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/pwa/src/components/accommodation-item.tsx
+++ b/pwa/src/components/accommodation-item.tsx
@@ -16,6 +16,9 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import type { AccommodationData } from "@/lib/validation/schemas";
+import { scrapeAccommodation } from "@/lib/api/client";
+import { isValidHttpsUrl } from "@/lib/validation/url";
+import { SCRAPE_DEBOUNCE_MS } from "@/lib/constants";
 
 const typeIcons: Record<string, React.ElementType> = {
   hotel: Hotel,
@@ -44,32 +47,6 @@ function formatPrice(acc: AccommodationData): string | null {
     return fmt.format(max);
   }
   return `${fmt.format(min)} – ${fmt.format(max)}`;
-}
-
-interface ScrapedData {
-  name: string | null;
-  type: string | null;
-  priceMin: number | null;
-  priceMax: number | null;
-}
-
-async function scrapeUrl(url: string): Promise<ScrapedData | null> {
-  const res = await fetch("/accommodations/scrape", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ url }),
-  });
-  if (!res.ok) return null;
-  return res.json() as Promise<ScrapedData>;
-}
-
-function isValidUrl(value: string): boolean {
-  try {
-    const u = new URL(value);
-    return u.protocol === "https:";
-  } catch {
-    return false;
-  }
 }
 
 interface AccommodationItemProps {
@@ -108,10 +85,10 @@ export function AccommodationItem({
   }, [initialEditing]);
 
   const handleScrape = useCallback(async (url: string) => {
-    if (!isValidUrl(url)) return;
+    if (!isValidHttpsUrl(url)) return;
     setIsScraping(true);
     try {
-      const data = await scrapeUrl(url);
+      const data = await scrapeAccommodation(url);
       if (data) {
         if (data.name) setEditName(data.name);
         if (data.type) setEditType(data.type);
@@ -128,11 +105,24 @@ export function AccommodationItem({
     if (debounceRef.current) clearTimeout(debounceRef.current);
     debounceRef.current = setTimeout(() => {
       void handleScrape(value);
-    }, 500);
+    }, SCRAPE_DEBOUNCE_MS);
   }
 
   const TypeIcon = typeIcons[accommodation.type] ?? MapPin;
-  const typeLabel = t(`type_${accommodation.type}` as Parameters<typeof t>[0]);
+  const typeLabelKeys = {
+    hotel: "type_hotel",
+    hostel: "type_hostel",
+    camp_site: "type_camp_site",
+    chalet: "type_chalet",
+    guest_house: "type_guest_house",
+    motel: "type_motel",
+    alpine_hut: "type_alpine_hut",
+    other: "type_other",
+  } as const;
+  const typeKey =
+    typeLabelKeys[accommodation.type as keyof typeof typeLabelKeys] ??
+    "type_other";
+  const typeLabel = t(typeKey);
 
   function startEditing() {
     setEditUrl(accommodation.url ?? "");

--- a/pwa/src/components/magic-link-input.tsx
+++ b/pwa/src/components/magic-link-input.tsx
@@ -5,15 +5,7 @@ import { useTranslations } from "next-intl";
 import { Check } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
-
-function isValidUrl(value: string): boolean {
-  try {
-    const url = new URL(value);
-    return url.protocol === "https:" || url.protocol === "http:";
-  } catch {
-    return false;
-  }
-}
+import { isValidUrl } from "@/lib/validation/url";
 
 interface MagicLinkInputProps {
   onSubmit: (url: string) => Promise<void>;

--- a/pwa/src/components/stage-card.tsx
+++ b/pwa/src/components/stage-card.tsx
@@ -2,43 +2,31 @@
 
 import { useState } from "react";
 import { useTranslations } from "next-intl";
-import { X, Download, Loader2, Pencil, Check } from "lucide-react";
+import { X, Pencil, Loader2 } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
 import { StageLocations } from "@/components/stage-locations";
 import { StageMetadata } from "@/components/stage-metadata";
 import { AlertList } from "@/components/alert-list";
 import { AccommodationPanel } from "@/components/accommodation-panel";
+import { StageDownloads } from "@/components/stage-downloads";
+import { StageDistanceEditor } from "@/components/stage-distance-editor";
 import type { StageData, AccommodationData } from "@/lib/validation/schemas";
 import { useTripStore } from "@/store/trip-store";
+import { getDifficulty, DIFFICULTY_COLORS } from "@/lib/constants";
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "https://localhost";
+const difficultyLabelKeys = {
+  easy: "difficultyEasy",
+  medium: "difficultyMedium",
+  hard: "difficultyHard",
+} as const;
 
 function formatCoords(point: { lat: number; lon: number }): string {
   const latDir = point.lat >= 0 ? "N" : "S";
   const lonDir = point.lon >= 0 ? "E" : "W";
   return `${Math.abs(point.lat).toFixed(3)}°${latDir}, ${Math.abs(point.lon).toFixed(3)}°${lonDir}`;
 }
-
-function getDifficulty(
-  distance: number | null,
-  elevation: number | null,
-): "easy" | "medium" | "hard" {
-  const d = distance ?? 0;
-  const e = elevation ?? 0;
-  if (d < 60 && e < 800) return "easy";
-  if (d < 100 && e < 1500) return "medium";
-  return "hard";
-}
-
-const difficultyColors = {
-  easy: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
-  medium:
-    "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-400",
-  hard: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400",
-} as const;
 
 interface StageCardProps {
   stage: StageData;
@@ -79,31 +67,6 @@ export function StageCard({
   const t = useTranslations("stage");
   const tripId = useTripStore((s) => s.trip?.id);
   const [editingDistance, setEditingDistance] = useState(false);
-  const [editValue, setEditValue] = useState("");
-  const [downloading, setDownloading] = useState<"gpx" | "fit" | false>(false);
-
-  function startEditDistance() {
-    setEditValue(
-      stage.distance !== null ? String(Math.round(stage.distance)) : "",
-    );
-    setEditingDistance(true);
-  }
-
-  function commitDistance() {
-    const km = parseFloat(editValue);
-    if (!isNaN(km) && km > 0 && onDistanceChange) {
-      onDistanceChange(km);
-    }
-    setEditingDistance(false);
-  }
-
-  function handleDistanceKeyDown(e: React.KeyboardEvent) {
-    if (e.key === "Enter") {
-      commitDistance();
-    } else if (e.key === "Escape") {
-      setEditingDistance(false);
-    }
-  }
 
   return (
     <Card
@@ -118,11 +81,7 @@ export function StageCard({
           className="absolute top-3 right-3 h-6 w-6 text-muted-icon"
           onClick={onDelete}
           disabled={!canDelete}
-          title={
-            !canDelete
-              ? t("minStagesReached" as Parameters<typeof t>[0])
-              : undefined
-          }
+          title={!canDelete ? t("minStagesReached") : undefined}
           aria-label={t("deleteStage", { dayNumber: stage.dayNumber })}
           data-testid={`delete-stage-${stage.dayNumber}`}
         >
@@ -131,80 +90,19 @@ export function StageCard({
 
         {/* Action buttons */}
         <div className="absolute top-3 right-10 flex gap-0.5">
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-6 gap-1 text-muted-icon px-1.5 cursor-pointer"
-            disabled={!tripId || !!downloading}
-            onClick={async () => {
-              if (!tripId) return;
-              setDownloading("gpx");
-              try {
-                const res = await fetch(
-                  `${API_URL}/trips/${tripId}/stages/${stageIndex}.gpx`,
-                );
-                const blob = await res.blob();
-                const url = URL.createObjectURL(blob);
-                const a = document.createElement("a");
-                a.href = url;
-                a.download = `stage-${stage.dayNumber}.gpx`;
-                a.click();
-                URL.revokeObjectURL(url);
-              } finally {
-                setDownloading(false);
-              }
-            }}
-            aria-label={t("downloadGpx", { dayNumber: stage.dayNumber })}
-            title={t("downloadGpx", { dayNumber: stage.dayNumber })}
-          >
-            {downloading === "gpx" ? (
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
-            ) : (
-              <Download className="h-3.5 w-3.5" />
-            )}
-            <span className="text-[10px] font-medium">GPX</span>
-          </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-6 gap-1 text-muted-icon px-1.5 cursor-pointer"
-            disabled={!tripId || !!downloading}
-            onClick={async () => {
-              if (!tripId) return;
-              setDownloading("fit");
-              try {
-                const res = await fetch(
-                  `${API_URL}/trips/${tripId}/stages/${stageIndex}.fit`,
-                );
-                const blob = await res.blob();
-                const url = URL.createObjectURL(blob);
-                const a = document.createElement("a");
-                a.href = url;
-                a.download = `stage-${stage.dayNumber}.fit`;
-                a.click();
-                URL.revokeObjectURL(url);
-              } finally {
-                setDownloading(false);
-              }
-            }}
-            aria-label={t("downloadFit", { dayNumber: stage.dayNumber })}
-            title={t("downloadFit", { dayNumber: stage.dayNumber })}
-          >
-            {downloading === "fit" ? (
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
-            ) : (
-              <Download className="h-3.5 w-3.5" />
-            )}
-            <span className="text-[10px] font-medium">FIT</span>
-          </Button>
+          <StageDownloads
+            tripId={tripId}
+            stageIndex={stageIndex}
+            dayNumber={stage.dayNumber}
+          />
           {onDistanceChange && (
             <Button
               variant="ghost"
               size="icon"
               className="h-6 w-6 text-muted-icon cursor-pointer"
-              onClick={startEditDistance}
-              aria-label={t("editDistance" as Parameters<typeof t>[0])}
-              title={t("editDistance" as Parameters<typeof t>[0])}
+              onClick={() => setEditingDistance(true)}
+              aria-label={t("editDistance")}
+              title={t("editDistance")}
             >
               <Pencil className="h-3.5 w-3.5" />
             </Button>
@@ -221,28 +119,14 @@ export function StageCard({
         {/* Metadata + difficulty + edit distance */}
         <div className="mt-3 flex items-center gap-3 flex-wrap">
           {editingDistance ? (
-            <div className="flex items-center gap-2">
-              <Input
-                type="number"
-                value={editValue}
-                onChange={(e) => setEditValue(e.target.value)}
-                onKeyDown={handleDistanceKeyDown}
-                className="h-7 w-20 text-sm"
-                min={1}
-                aria-label={t("distanceLabel" as Parameters<typeof t>[0])}
-                autoFocus
-              />
-              <span className="text-sm text-muted-foreground">km</span>
-              <Button
-                variant="outline"
-                size="icon"
-                className="h-7 w-7 cursor-pointer"
-                onClick={commitDistance}
-                aria-label={t("saveDistance" as Parameters<typeof t>[0])}
-              >
-                <Check className="h-3.5 w-3.5" />
-              </Button>
-            </div>
+            <StageDistanceEditor
+              initialDistance={stage.distance}
+              onCommit={(km) => {
+                onDistanceChange?.(km);
+                setEditingDistance(false);
+              }}
+              onCancel={() => setEditingDistance(false)}
+            />
           ) : (
             <>
               <StageMetadata
@@ -254,12 +138,12 @@ export function StageCard({
               />
               {stage.distance !== null && (
                 <span
-                  className={`text-xs font-medium px-2 py-0.5 rounded-full ${difficultyColors[getDifficulty(stage.distance, stage.elevation)]}`}
+                  className={`text-xs font-medium px-2 py-0.5 rounded-full ${DIFFICULTY_COLORS[getDifficulty(stage.distance, stage.elevation)]}`}
                 >
                   {t(
-                    `difficulty${getDifficulty(stage.distance, stage.elevation).charAt(0).toUpperCase()}${getDifficulty(stage.distance, stage.elevation).slice(1)}` as Parameters<
-                      typeof t
-                    >[0],
+                    difficultyLabelKeys[
+                      getDifficulty(stage.distance, stage.elevation)
+                    ],
                   )}
                 </span>
               )}
@@ -276,7 +160,7 @@ export function StageCard({
         {isProcessing && stage.alerts.length === 0 && (
           <div className="mt-3 flex items-center gap-2 text-xs text-muted-foreground">
             <Loader2 className="h-3.5 w-3.5 animate-spin" />
-            <span>{t("loadingAlerts" as Parameters<typeof t>[0])}</span>
+            <span>{t("loadingAlerts")}</span>
           </div>
         )}
 

--- a/pwa/src/components/stage-distance-editor.tsx
+++ b/pwa/src/components/stage-distance-editor.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import { Check } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+interface StageDistanceEditorProps {
+  initialDistance: number | null;
+  onCommit: (km: number) => void;
+  onCancel: () => void;
+}
+
+export function StageDistanceEditor({
+  initialDistance,
+  onCommit,
+  onCancel,
+}: StageDistanceEditorProps) {
+  const t = useTranslations("stage");
+  const [editValue, setEditValue] = useState(
+    initialDistance !== null ? String(Math.round(initialDistance)) : "",
+  );
+
+  function commitDistance() {
+    const km = parseFloat(editValue);
+    if (!isNaN(km) && km > 0) {
+      onCommit(km);
+    }
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Enter") {
+      commitDistance();
+    } else if (e.key === "Escape") {
+      onCancel();
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <Input
+        type="number"
+        value={editValue}
+        onChange={(e) => setEditValue(e.target.value)}
+        onKeyDown={handleKeyDown}
+        className="h-7 w-20 text-sm"
+        min={1}
+        aria-label={t("distanceLabel")}
+        autoFocus
+      />
+      <span className="text-sm text-muted-foreground">km</span>
+      <Button
+        variant="outline"
+        size="icon"
+        className="h-7 w-7 cursor-pointer"
+        onClick={commitDistance}
+        aria-label={t("saveDistance")}
+      >
+        <Check className="h-3.5 w-3.5" />
+      </Button>
+    </div>
+  );
+}

--- a/pwa/src/components/stage-downloads.tsx
+++ b/pwa/src/components/stage-downloads.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import { Download, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { downloadStageFile } from "@/lib/api/client";
+
+interface StageDownloadsProps {
+  tripId: string | undefined;
+  stageIndex: number;
+  dayNumber: number;
+}
+
+export function StageDownloads({
+  tripId,
+  stageIndex,
+  dayNumber,
+}: StageDownloadsProps) {
+  const t = useTranslations("stage");
+  const [downloading, setDownloading] = useState<"gpx" | "fit" | false>(false);
+
+  async function handleDownload(format: "gpx" | "fit") {
+    if (!tripId) return;
+    setDownloading(format);
+    try {
+      await downloadStageFile(tripId, stageIndex, format, dayNumber);
+    } finally {
+      setDownloading(false);
+    }
+  }
+
+  return (
+    <>
+      <Button
+        variant="ghost"
+        size="sm"
+        className="h-6 gap-1 text-muted-icon px-1.5 cursor-pointer"
+        disabled={!tripId || !!downloading}
+        onClick={() => void handleDownload("gpx")}
+        aria-label={t("downloadGpx", { dayNumber })}
+        title={t("downloadGpx", { dayNumber })}
+      >
+        {downloading === "gpx" ? (
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+        ) : (
+          <Download className="h-3.5 w-3.5" />
+        )}
+        <span className="text-[10px] font-medium">GPX</span>
+      </Button>
+      <Button
+        variant="ghost"
+        size="sm"
+        className="h-6 gap-1 text-muted-icon px-1.5 cursor-pointer"
+        disabled={!tripId || !!downloading}
+        onClick={() => void handleDownload("fit")}
+        aria-label={t("downloadFit", { dayNumber })}
+        title={t("downloadFit", { dayNumber })}
+      >
+        {downloading === "fit" ? (
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+        ) : (
+          <Download className="h-3.5 w-3.5" />
+        )}
+        <span className="text-[10px] font-medium">FIT</span>
+      </Button>
+    </>
+  );
+}

--- a/pwa/src/components/trip-planner.tsx
+++ b/pwa/src/components/trip-planner.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { useState } from "react";
-import { toast } from "sonner";
 import { useTranslations } from "next-intl";
 import { MagicLinkInput } from "@/components/magic-link-input";
 import { TripSummary } from "@/components/trip-summary";
@@ -9,283 +7,36 @@ import { TripHeader } from "@/components/trip-header";
 import { PacingSettings } from "@/components/pacing-settings";
 import { Timeline } from "@/components/timeline";
 import { ThemeToggle } from "@/components/theme-toggle";
-import { useTripStore } from "@/store/trip-store";
-import { useUiStore } from "@/store/ui-store";
-import { useMercure } from "@/hooks/use-mercure";
-import { apiClient, parseApiError, isNetworkError } from "@/lib/api/client";
-import { getRandomTripName } from "@/components/trip-title";
-import type { AccommodationData, StageData } from "@/lib/validation/schemas";
+import { useTripActions } from "@/hooks/use-trip-actions";
 
 export function TripPlanner() {
   const t = useTranslations();
-  const trip = useTripStore((s) => s.trip);
-  const totalDistance = useTripStore((s) => s.totalDistance);
-  const totalElevation = useTripStore((s) => s.totalElevation);
-  const totalElevationLoss = useTripStore((s) => s.totalElevationLoss);
-  const stages = useTripStore((s) => s.stages);
-  const startDate = useTripStore((s) => s.startDate);
-  const endDate = useTripStore((s) => s.endDate);
-  const setTrip = useTripStore((s) => s.setTrip);
-  const updateTitle = useTripStore((s) => s.updateTitle);
-  const updateDates = useTripStore((s) => s.updateDates);
-  const clearTrip = useTripStore((s) => s.clearTrip);
-  const addLocalAccommodation = useTripStore((s) => s.addLocalAccommodation);
-  const removeLocalAccommodation = useTripStore(
-    (s) => s.removeLocalAccommodation,
-  );
-  const updateLocalAccommodation = useTripStore(
-    (s) => s.updateLocalAccommodation,
-  );
-  const deleteStage = useTripStore((s) => s.deleteStage);
-  const fatigueFactor = useTripStore((s) => s.fatigueFactor);
-  const elevationPenalty = useTripStore((s) => s.elevationPenalty);
-  const updatePacingSettings = useTripStore((s) => s.updatePacingSettings);
-  const isProcessing = useUiStore((s) => s.isProcessing);
-  const setProcessing = useUiStore((s) => s.setProcessing);
-
-  const [newAccKey, setNewAccKey] = useState<string | null>(null);
-
-  const tripId = trip?.id ?? null;
-  useMercure(tripId);
-
-  // --- Trip creation ---
-  async function handleMagicLink(sourceUrl: string) {
-    clearTrip();
-    setProcessing(true);
-
-    try {
-      const today = new Date().toISOString().split("T")[0] ?? null;
-      const { data, error, response } = await apiClient.POST("/trips", {
-        body: {
-          sourceUrl,
-          fatigueFactor,
-          elevationPenalty,
-          startDate: startDate ?? today,
-        },
-      });
-
-      if (error || !data) {
-        const apiError = parseApiError(response.status, error);
-        toast.error(apiError.message);
-        setProcessing(false);
-        return;
-      }
-
-      if (!startDate && today) {
-        updateDates(today, null);
-      }
-
-      setTrip({
-        id: data.id ?? "",
-        title: getRandomTripName(),
-        sourceUrl,
-      });
-    } catch (err) {
-      if (isNetworkError(err)) {
-        toast.error(t("errors.networkError"));
-      } else {
-        toast.error(t("errors.unexpectedError"));
-      }
-      setProcessing(false);
-    }
-  }
-
-  // --- Dates change ---
-  async function handleDatesChange(
-    newStart: string | null,
-    newEnd: string | null,
-  ) {
-    updateDates(newStart, newEnd);
-    if (!tripId) return;
-
-    try {
-      const { error, response } = await apiClient.PATCH("/trips/{id}", {
-        params: { path: { id: tripId } },
-        headers: { "Content-Type": "application/merge-patch+json" },
-        body: {
-          startDate: newStart,
-          endDate: newEnd,
-          fatigueFactor,
-          elevationPenalty,
-        },
-      });
-
-      if (error) {
-        const apiError = parseApiError(response.status, error);
-        toast.error(apiError.message);
-      } else {
-        setProcessing(true);
-      }
-    } catch {
-      toast.error(t("errors.failedUpdateDates"));
-    }
-  }
-
-  // --- Stage operations ---
-  async function handleDeleteStage(index: number) {
-    if (!tripId) return;
-
-    const snapshot = [...stages];
-    deleteStage(index);
-
-    try {
-      const { error, response } = await apiClient.DELETE(
-        "/trips/{tripId}/stages/{index}",
-        {
-          params: { path: { tripId, index: String(index) } },
-        },
-      );
-      if (error) {
-        const apiError = parseApiError(response.status, error);
-        toast.error(apiError.message);
-        useTripStore.getState().setStages(snapshot);
-      } else {
-        setProcessing(true);
-      }
-    } catch {
-      toast.error(t("errors.failedDeleteStage"));
-      useTripStore.getState().setStages(snapshot);
-    }
-  }
-
-  async function handleAddStage(afterIndex: number) {
-    if (!tripId) return;
-
-    const prevStage = stages[afterIndex];
-    const nextStage = stages[afterIndex + 1];
-    const startPoint = prevStage?.endPoint ?? prevStage?.startPoint;
-    const endPoint = nextStage?.startPoint ?? prevStage?.endPoint;
-
-    if (!startPoint || !endPoint) {
-      toast.error(t("errors.failedAddStage"));
-      return;
-    }
-
-    // Optimistically insert a placeholder stage
-    const placeholder: StageData = {
-      dayNumber: afterIndex + 2,
-      distance: 0,
-      elevation: 0,
-      elevationLoss: 0,
-      startPoint: {
-        lat: startPoint.lat,
-        lon: startPoint.lon,
-        ele: startPoint.ele ?? 0,
-      },
-      endPoint: {
-        lat: endPoint.lat,
-        lon: endPoint.lon,
-        ele: endPoint.ele ?? 0,
-      },
-      geometry: [],
-      label: null,
-      startLabel: prevStage?.endLabel ?? null,
-      endLabel: nextStage?.startLabel ?? null,
-      weather: null,
-      alerts: [],
-      pois: [],
-      accommodations: [],
-    };
-    const updatedStages = stages.map((s) => ({ ...s }));
-    updatedStages.splice(afterIndex + 1, 0, placeholder);
-    updatedStages.forEach((s, i) => {
-      s.dayNumber = i + 1;
-    });
-    useTripStore.getState().setStages(updatedStages);
-
-    try {
-      const { error, response } = await apiClient.POST(
-        "/trips/{tripId}/stages",
-        {
-          params: { path: { tripId } },
-          body: { position: afterIndex + 1, startPoint, endPoint },
-        },
-      );
-      if (error) {
-        const apiError = parseApiError(response.status, error);
-        toast.error(apiError.message);
-        // Revert on error
-        useTripStore.getState().setStages(stages);
-      } else {
-        setProcessing(true);
-      }
-    } catch {
-      toast.error(t("errors.failedAddStage"));
-      useTripStore.getState().setStages(stages);
-    }
-  }
-
-  async function handleDistanceChange(index: number, distance: number) {
-    if (!tripId) return;
-
-    try {
-      const { error, response } = await apiClient.PATCH(
-        "/trips/{tripId}/stages/{index}",
-        {
-          params: { path: { tripId, index: String(index) } },
-          headers: { "Content-Type": "application/merge-patch+json" },
-          body: { distance },
-        },
-      );
-      if (error) {
-        const apiError = parseApiError(response.status, error);
-        toast.error(apiError.message);
-      } else {
-        setProcessing(true);
-      }
-    } catch {
-      toast.error(t("errors.failedUpdateLocation"));
-    }
-  }
-
-  // --- Pacing settings ---
-  async function handlePacingChange(newFatigue: number, newElevation: number) {
-    updatePacingSettings(newFatigue, newElevation);
-    if (!tripId) return;
-
-    try {
-      const { error, response } = await apiClient.PATCH("/trips/{id}", {
-        params: { path: { id: tripId } },
-        headers: { "Content-Type": "application/merge-patch+json" },
-        body: {
-          fatigueFactor: newFatigue,
-          elevationPenalty: newElevation,
-        },
-      });
-
-      if (error) {
-        const apiError = parseApiError(response.status, error);
-        toast.error(apiError.message);
-      } else {
-        setProcessing(true);
-        useTripStore.getState().setStages([]);
-      }
-    } catch {
-      toast.error(t("errors.failedUpdatePacing"));
-    }
-  }
-
-  // --- Accommodations ---
-  function handleAddAccommodation(stageIndex: number) {
-    const stage = stages[stageIndex];
-    const accIndex = stage?.accommodations.length ?? 0;
-    const newAcc: AccommodationData = {
-      name: t("accommodation.new"),
-      type: "other",
-      lat: 0,
-      lon: 0,
-      estimatedPriceMin: 0,
-      estimatedPriceMax: 0,
-      isExactPrice: false,
-    };
-    addLocalAccommodation(stageIndex, newAcc);
-    setNewAccKey(`${stageIndex}-${accIndex}`);
-  }
-
-  // --- Derived data ---
-  const firstStage = stages[0];
-  const firstWeather = firstStage?.weather ?? null;
-  const isWeatherLoading = isProcessing && stages.length > 0 && !firstWeather;
+  const {
+    trip,
+    totalDistance,
+    totalElevation,
+    totalElevationLoss,
+    stages,
+    startDate,
+    endDate,
+    isProcessing,
+    newAccKey,
+    firstWeather,
+    isWeatherLoading,
+    fatigueFactor,
+    elevationPenalty,
+    updateTitle,
+    updateLocalAccommodation,
+    removeLocalAccommodation,
+    handleMagicLink,
+    handleDatesChange,
+    handleDeleteStage,
+    handleAddStage,
+    handleDistanceChange,
+    handlePacingChange,
+    handleAddAccommodation,
+    clearNewAccKey,
+  } = useTripActions();
 
   return (
     <main className="max-w-[1200px] mx-auto px-4 md:px-6 py-8 md:py-12 relative">
@@ -352,7 +103,7 @@ export function TripPlanner() {
               onUpdateAccommodation={updateLocalAccommodation}
               onRemoveAccommodation={removeLocalAccommodation}
               newAccKey={newAccKey}
-              onClearNewAcc={() => setNewAccKey(null)}
+              onClearNewAcc={clearNewAccKey}
             />
           </div>
         </div>

--- a/pwa/src/components/trip-summary.tsx
+++ b/pwa/src/components/trip-summary.tsx
@@ -1,41 +1,8 @@
 import { useTranslations } from "next-intl";
-import {
-  Sun,
-  CloudSun,
-  Cloud,
-  CloudRain,
-  CloudLightning,
-  Snowflake,
-  CloudFog,
-  ArrowUp,
-  ArrowDown,
-  Bike,
-  Mountain,
-  Info,
-} from "lucide-react";
+import { ArrowUp, ArrowDown, Bike, Mountain, Info } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
+import { weatherIconMap, DefaultWeatherIcon } from "@/lib/weather-icons";
 import type { WeatherData } from "@/lib/validation/schemas";
-
-const weatherIconMap: Record<string, React.ElementType> = {
-  "01d": Sun,
-  "01n": Sun,
-  "02d": CloudSun,
-  "02n": CloudSun,
-  "03d": Cloud,
-  "03n": Cloud,
-  "04d": Cloud,
-  "04n": Cloud,
-  "09d": CloudRain,
-  "09n": CloudRain,
-  "10d": CloudRain,
-  "10n": CloudRain,
-  "11d": CloudLightning,
-  "11n": CloudLightning,
-  "13d": Snowflake,
-  "13n": Snowflake,
-  "50d": CloudFog,
-  "50n": CloudFog,
-};
 
 interface TripSummaryProps {
   totalDistance: number | null;
@@ -61,7 +28,9 @@ export function TripSummary({
   if (!showSkeleton && totalDistance === null && totalElevation === null)
     return null;
 
-  const WeatherIcon = weather ? (weatherIconMap[weather.icon] ?? Cloud) : Cloud;
+  const WeatherIcon = weather
+    ? (weatherIconMap[weather.icon] ?? DefaultWeatherIcon)
+    : DefaultWeatherIcon;
 
   return (
     <div className="space-y-2">

--- a/pwa/src/components/weather-indicator.tsx
+++ b/pwa/src/components/weather-indicator.tsx
@@ -1,34 +1,5 @@
-import {
-  Sun,
-  CloudSun,
-  Cloud,
-  CloudRain,
-  CloudLightning,
-  Snowflake,
-  CloudFog,
-} from "lucide-react";
+import { weatherIconMap, DefaultWeatherIcon } from "@/lib/weather-icons";
 import type { WeatherData } from "@/lib/validation/schemas";
-
-const iconMap: Record<string, React.ElementType> = {
-  "01d": Sun,
-  "01n": Sun,
-  "02d": CloudSun,
-  "02n": CloudSun,
-  "03d": Cloud,
-  "03n": Cloud,
-  "04d": Cloud,
-  "04n": Cloud,
-  "09d": CloudRain,
-  "09n": CloudRain,
-  "10d": CloudRain,
-  "10n": CloudRain,
-  "11d": CloudLightning,
-  "11n": CloudLightning,
-  "13d": Snowflake,
-  "13n": Snowflake,
-  "50d": CloudFog,
-  "50n": CloudFog,
-};
 
 interface WeatherIndicatorProps {
   weather: WeatherData | null;
@@ -37,7 +8,7 @@ interface WeatherIndicatorProps {
 export function WeatherIndicator({ weather }: WeatherIndicatorProps) {
   if (!weather) return null;
 
-  const Icon = iconMap[weather.icon] ?? Cloud;
+  const Icon = weatherIconMap[weather.icon] ?? DefaultWeatherIcon;
 
   return (
     <div className="flex items-center gap-1.5 text-sm text-muted-foreground">

--- a/pwa/src/hooks/use-trip-actions.ts
+++ b/pwa/src/hooks/use-trip-actions.ts
@@ -1,0 +1,302 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import { useTranslations } from "next-intl";
+import { useTripStore } from "@/store/trip-store";
+import { useUiStore } from "@/store/ui-store";
+import { useMercure } from "@/hooks/use-mercure";
+import { apiClient, parseApiError, isNetworkError } from "@/lib/api/client";
+import { getRandomTripName } from "@/components/trip-title";
+import type { AccommodationData, StageData } from "@/lib/validation/schemas";
+
+export function useTripActions() {
+  const t = useTranslations();
+  const trip = useTripStore((s) => s.trip);
+  const totalDistance = useTripStore((s) => s.totalDistance);
+  const totalElevation = useTripStore((s) => s.totalElevation);
+  const totalElevationLoss = useTripStore((s) => s.totalElevationLoss);
+  const stages = useTripStore((s) => s.stages);
+  const startDate = useTripStore((s) => s.startDate);
+  const endDate = useTripStore((s) => s.endDate);
+  const setTrip = useTripStore((s) => s.setTrip);
+  const updateTitle = useTripStore((s) => s.updateTitle);
+  const updateDates = useTripStore((s) => s.updateDates);
+  const clearTrip = useTripStore((s) => s.clearTrip);
+  const addLocalAccommodation = useTripStore((s) => s.addLocalAccommodation);
+  const removeLocalAccommodation = useTripStore(
+    (s) => s.removeLocalAccommodation,
+  );
+  const updateLocalAccommodation = useTripStore(
+    (s) => s.updateLocalAccommodation,
+  );
+  const deleteStage = useTripStore((s) => s.deleteStage);
+  const fatigueFactor = useTripStore((s) => s.fatigueFactor);
+  const elevationPenalty = useTripStore((s) => s.elevationPenalty);
+  const updatePacingSettings = useTripStore((s) => s.updatePacingSettings);
+  const isProcessing = useUiStore((s) => s.isProcessing);
+  const setProcessing = useUiStore((s) => s.setProcessing);
+
+  const [newAccKey, setNewAccKey] = useState<string | null>(null);
+
+  const tripId = trip?.id ?? null;
+  useMercure(tripId);
+
+  async function handleMagicLink(sourceUrl: string) {
+    clearTrip();
+    setProcessing(true);
+
+    try {
+      const today = new Date().toISOString().split("T")[0] ?? null;
+      const { data, error, response } = await apiClient.POST("/trips", {
+        body: {
+          sourceUrl,
+          fatigueFactor,
+          elevationPenalty,
+          startDate: startDate ?? today,
+        },
+      });
+
+      if (error || !data) {
+        const apiError = parseApiError(response.status, error);
+        toast.error(apiError.message);
+        setProcessing(false);
+        return;
+      }
+
+      if (!startDate && today) {
+        updateDates(today, null);
+      }
+
+      setTrip({
+        id: data.id ?? "",
+        title: getRandomTripName(),
+        sourceUrl,
+      });
+    } catch (err) {
+      if (isNetworkError(err)) {
+        toast.error(t("errors.networkError"));
+      } else {
+        toast.error(t("errors.unexpectedError"));
+      }
+      setProcessing(false);
+    }
+  }
+
+  async function handleDatesChange(
+    newStart: string | null,
+    newEnd: string | null,
+  ) {
+    updateDates(newStart, newEnd);
+    if (!tripId) return;
+
+    try {
+      const { error, response } = await apiClient.PATCH("/trips/{id}", {
+        params: { path: { id: tripId } },
+        headers: { "Content-Type": "application/merge-patch+json" },
+        body: {
+          startDate: newStart,
+          endDate: newEnd,
+          fatigueFactor,
+          elevationPenalty,
+        },
+      });
+
+      if (error) {
+        const apiError = parseApiError(response.status, error);
+        toast.error(apiError.message);
+      } else {
+        setProcessing(true);
+      }
+    } catch {
+      toast.error(t("errors.failedUpdateDates"));
+    }
+  }
+
+  async function handleDeleteStage(index: number) {
+    if (!tripId) return;
+
+    const snapshot = [...stages];
+    deleteStage(index);
+
+    try {
+      const { error, response } = await apiClient.DELETE(
+        "/trips/{tripId}/stages/{index}",
+        {
+          params: { path: { tripId, index: String(index) } },
+        },
+      );
+      if (error) {
+        const apiError = parseApiError(response.status, error);
+        toast.error(apiError.message);
+        useTripStore.getState().setStages(snapshot);
+      } else {
+        setProcessing(true);
+      }
+    } catch {
+      toast.error(t("errors.failedDeleteStage"));
+      useTripStore.getState().setStages(snapshot);
+    }
+  }
+
+  async function handleAddStage(afterIndex: number) {
+    if (!tripId) return;
+
+    const prevStage = stages[afterIndex];
+    const nextStage = stages[afterIndex + 1];
+    const startPoint = prevStage?.endPoint ?? prevStage?.startPoint;
+    const endPoint = nextStage?.startPoint ?? prevStage?.endPoint;
+
+    if (!startPoint || !endPoint) {
+      toast.error(t("errors.failedAddStage"));
+      return;
+    }
+
+    const placeholder: StageData = {
+      dayNumber: afterIndex + 2,
+      distance: 0,
+      elevation: 0,
+      elevationLoss: 0,
+      startPoint: {
+        lat: startPoint.lat,
+        lon: startPoint.lon,
+        ele: startPoint.ele ?? 0,
+      },
+      endPoint: {
+        lat: endPoint.lat,
+        lon: endPoint.lon,
+        ele: endPoint.ele ?? 0,
+      },
+      geometry: [],
+      label: null,
+      startLabel: prevStage?.endLabel ?? null,
+      endLabel: nextStage?.startLabel ?? null,
+      weather: null,
+      alerts: [],
+      pois: [],
+      accommodations: [],
+    };
+    const updatedStages = stages.map((s) => ({ ...s }));
+    updatedStages.splice(afterIndex + 1, 0, placeholder);
+    updatedStages.forEach((s, i) => {
+      s.dayNumber = i + 1;
+    });
+    useTripStore.getState().setStages(updatedStages);
+
+    try {
+      const { error, response } = await apiClient.POST(
+        "/trips/{tripId}/stages",
+        {
+          params: { path: { tripId } },
+          body: { position: afterIndex + 1, startPoint, endPoint },
+        },
+      );
+      if (error) {
+        const apiError = parseApiError(response.status, error);
+        toast.error(apiError.message);
+        useTripStore.getState().setStages(stages);
+      } else {
+        setProcessing(true);
+      }
+    } catch {
+      toast.error(t("errors.failedAddStage"));
+      useTripStore.getState().setStages(stages);
+    }
+  }
+
+  async function handleDistanceChange(index: number, distance: number) {
+    if (!tripId) return;
+
+    try {
+      const { error, response } = await apiClient.PATCH(
+        "/trips/{tripId}/stages/{index}",
+        {
+          params: { path: { tripId, index: String(index) } },
+          headers: { "Content-Type": "application/merge-patch+json" },
+          body: { distance },
+        },
+      );
+      if (error) {
+        const apiError = parseApiError(response.status, error);
+        toast.error(apiError.message);
+      } else {
+        setProcessing(true);
+      }
+    } catch {
+      toast.error(t("errors.failedUpdateLocation"));
+    }
+  }
+
+  async function handlePacingChange(newFatigue: number, newElevation: number) {
+    updatePacingSettings(newFatigue, newElevation);
+    if (!tripId) return;
+
+    try {
+      const { error, response } = await apiClient.PATCH("/trips/{id}", {
+        params: { path: { id: tripId } },
+        headers: { "Content-Type": "application/merge-patch+json" },
+        body: {
+          fatigueFactor: newFatigue,
+          elevationPenalty: newElevation,
+        },
+      });
+
+      if (error) {
+        const apiError = parseApiError(response.status, error);
+        toast.error(apiError.message);
+      } else {
+        setProcessing(true);
+        useTripStore.getState().setStages([]);
+      }
+    } catch {
+      toast.error(t("errors.failedUpdatePacing"));
+    }
+  }
+
+  function handleAddAccommodation(stageIndex: number) {
+    const stage = stages[stageIndex];
+    const accIndex = stage?.accommodations.length ?? 0;
+    const newAcc: AccommodationData = {
+      name: t("accommodation.new"),
+      type: "other",
+      lat: 0,
+      lon: 0,
+      estimatedPriceMin: 0,
+      estimatedPriceMax: 0,
+      isExactPrice: false,
+    };
+    addLocalAccommodation(stageIndex, newAcc);
+    setNewAccKey(`${stageIndex}-${accIndex}`);
+  }
+
+  const firstStage = stages[0];
+  const firstWeather = firstStage?.weather ?? null;
+  const isWeatherLoading = isProcessing && stages.length > 0 && !firstWeather;
+
+  return {
+    trip,
+    totalDistance,
+    totalElevation,
+    totalElevationLoss,
+    stages,
+    startDate,
+    endDate,
+    isProcessing,
+    newAccKey,
+    firstWeather,
+    isWeatherLoading,
+    fatigueFactor,
+    elevationPenalty,
+    updateTitle,
+    updateLocalAccommodation,
+    removeLocalAccommodation,
+    handleMagicLink,
+    handleDatesChange,
+    handleDeleteStage,
+    handleAddStage,
+    handleDistanceChange,
+    handlePacingChange,
+    handleAddAccommodation,
+    clearNewAccKey: () => setNewAccKey(null),
+  };
+}

--- a/pwa/src/lib/api/client.ts
+++ b/pwa/src/lib/api/client.ts
@@ -1,5 +1,6 @@
 import createClient from "openapi-fetch";
 import type { paths } from "./schema";
+import { API_URL } from "@/lib/constants";
 
 function getBrowserLocale(): string {
   if (typeof navigator !== "undefined") {
@@ -22,16 +23,30 @@ export interface ApiError {
   violations?: { propertyPath: string; message: string }[];
 }
 
-export function parseApiError(status: number, body: unknown): ApiError {
-  if (
-    status === 422 &&
-    body &&
+interface ViolationBody {
+  violations?: { propertyPath: string; message: string }[];
+}
+
+interface DetailBody {
+  detail?: string;
+}
+
+function hasViolations(body: unknown): body is ViolationBody {
+  return (
+    body !== null &&
     typeof body === "object" &&
-    "violations" in body
-  ) {
-    const violations =
-      (body as { violations?: { propertyPath: string; message: string }[] })
-        .violations ?? [];
+    "violations" in body &&
+    Array.isArray((body as ViolationBody).violations)
+  );
+}
+
+function hasDetail(body: unknown): body is DetailBody {
+  return body !== null && typeof body === "object" && "detail" in body;
+}
+
+export function parseApiError(status: number, body: unknown): ApiError {
+  if (status === 422 && hasViolations(body)) {
+    const violations = body.violations ?? [];
     return {
       type: "validation",
       message:
@@ -41,10 +56,7 @@ export function parseApiError(status: number, body: unknown): ApiError {
   }
 
   if (status === 400) {
-    const detail =
-      body && typeof body === "object" && "detail" in body
-        ? (body as { detail?: string }).detail
-        : undefined;
+    const detail = hasDetail(body) ? body.detail : undefined;
     return {
       type: "bad_request",
       message: detail ?? "Bad request",
@@ -66,4 +78,41 @@ export function parseApiError(status: number, body: unknown): ApiError {
 
 export function isNetworkError(error: unknown): error is TypeError {
   return error instanceof TypeError && error.message === "Failed to fetch";
+}
+
+export interface ScrapedData {
+  name: string | null;
+  type: string | null;
+  priceMin: number | null;
+  priceMax: number | null;
+}
+
+export async function scrapeAccommodation(
+  url: string,
+): Promise<ScrapedData | null> {
+  const res = await fetch("/accommodations/scrape", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ url }),
+  });
+  if (!res.ok) return null;
+  return res.json() as Promise<ScrapedData>;
+}
+
+export async function downloadStageFile(
+  tripId: string,
+  stageIndex: number,
+  format: "gpx" | "fit",
+  dayNumber: number,
+): Promise<void> {
+  const res = await fetch(
+    `${API_URL}/trips/${tripId}/stages/${stageIndex}.${format}`,
+  );
+  const blob = await res.blob();
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `stage-${dayNumber}.${format}`;
+  a.click();
+  URL.revokeObjectURL(url);
 }

--- a/pwa/src/lib/constants.ts
+++ b/pwa/src/lib/constants.ts
@@ -1,0 +1,40 @@
+/** Difficulty thresholds for stage classification */
+export const DIFFICULTY_THRESHOLDS = {
+  easy: { maxDistance: 60, maxElevation: 800 },
+  medium: { maxDistance: 100, maxElevation: 1500 },
+} as const;
+
+/** CSS classes for difficulty badges */
+export const DIFFICULTY_COLORS = {
+  easy: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
+  medium:
+    "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-400",
+  hard: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400",
+} as const;
+
+export type Difficulty = keyof typeof DIFFICULTY_COLORS;
+
+export function getDifficulty(
+  distance: number | null,
+  elevation: number | null,
+): Difficulty {
+  const d = distance ?? 0;
+  const e = elevation ?? 0;
+  if (
+    d < DIFFICULTY_THRESHOLDS.easy.maxDistance &&
+    e < DIFFICULTY_THRESHOLDS.easy.maxElevation
+  )
+    return "easy";
+  if (
+    d < DIFFICULTY_THRESHOLDS.medium.maxDistance &&
+    e < DIFFICULTY_THRESHOLDS.medium.maxElevation
+  )
+    return "medium";
+  return "hard";
+}
+
+/** Debounce delay for accommodation URL scraping (ms) */
+export const SCRAPE_DEBOUNCE_MS = 500;
+
+/** Backend API base URL */
+export const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "https://localhost";

--- a/pwa/src/lib/validation/url.ts
+++ b/pwa/src/lib/validation/url.ts
@@ -1,0 +1,19 @@
+/** Validate URL with http or https protocol */
+export function isValidUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" || url.protocol === "http:";
+  } catch {
+    return false;
+  }
+}
+
+/** Validate URL with https protocol only */
+export function isValidHttpsUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}

--- a/pwa/src/lib/weather-icons.ts
+++ b/pwa/src/lib/weather-icons.ts
@@ -1,0 +1,34 @@
+import {
+  Sun,
+  CloudSun,
+  Cloud,
+  CloudRain,
+  CloudLightning,
+  Snowflake,
+  CloudFog,
+} from "lucide-react";
+
+/** Map OpenWeather icon codes to lucide-react components */
+export const weatherIconMap: Record<string, React.ElementType> = {
+  "01d": Sun,
+  "01n": Sun,
+  "02d": CloudSun,
+  "02n": CloudSun,
+  "03d": Cloud,
+  "03n": Cloud,
+  "04d": Cloud,
+  "04n": Cloud,
+  "09d": CloudRain,
+  "09n": CloudRain,
+  "10d": CloudRain,
+  "10n": CloudRain,
+  "11d": CloudLightning,
+  "11n": CloudLightning,
+  "13d": Snowflake,
+  "13n": Snowflake,
+  "50d": CloudFog,
+  "50n": CloudFog,
+};
+
+/** Default weather icon when code is not found */
+export const DefaultWeatherIcon = Cloud;


### PR DESCRIPTION
## Summary

- **Extract shared constants & helpers** (`constants.ts`, `weather-icons.ts`, `validation/url.ts`) — deduplicate weather icon map, `isValidUrl`, difficulty thresholds, and `API_URL`
- **Replace raw `fetch` with typed helpers** — `downloadStageFile()` and `scrapeAccommodation()` in `client.ts`; `ScrapedData` interface moved to shared module
- **Remove all `as Parameters<typeof t>` type assertion hacks** — use static lookup maps (`difficultyLabelKeys`, `typeLabelKeys`) for type-safe i18n keys
- **Replace `as` casts in `parseApiError`** with proper type guard functions (`hasViolations`, `hasDetail`)
- **Extract `useTripActions` hook** — all store selectors + 7 async handlers moved out of `trip-planner.tsx` (363 → ~100 lines)
- **Extract sub-components** — `StageDownloads` (GPX/FIT buttons) and `StageDistanceEditor` (inline edit form) from `stage-card.tsx` (303 → ~170 lines)
- **Add Next.js App Router error boundary** (`app/error.tsx`) with retry button and i18n support

## Changes

- `pwa/src/lib/constants.ts` — difficulty thresholds/colors, `getDifficulty()`, `SCRAPE_DEBOUNCE_MS`, `API_URL`
- `pwa/src/lib/weather-icons.ts` — single weather icon map + `DefaultWeatherIcon`
- `pwa/src/lib/validation/url.ts` — `isValidUrl()` (HTTP+HTTPS) and `isValidHttpsUrl()` (HTTPS-only)
- `pwa/src/lib/api/client.ts` — `downloadStageFile()`, `scrapeAccommodation()`, type guards
- `pwa/src/hooks/use-trip-actions.ts` — extracted hook with all trip logic
- `pwa/src/components/stage-downloads.tsx` — GPX/FIT download buttons
- `pwa/src/components/stage-distance-editor.tsx` — inline distance edit form
- `pwa/src/app/error.tsx` — Next.js error boundary
- `pwa/src/components/stage-card.tsx` — uses new sub-components and shared constants
- `pwa/src/components/trip-planner.tsx` — thin presentation layer via `useTripActions()`
- `pwa/src/components/accommodation-item.tsx` — uses `scrapeAccommodation()`, `isValidHttpsUrl()`, lookup map
- `pwa/src/components/magic-link-input.tsx` — uses shared `isValidUrl()`
- `pwa/src/components/weather-indicator.tsx` — uses shared `weatherIconMap`
- `pwa/src/components/trip-summary.tsx` — uses shared `weatherIconMap`
- `pwa/messages/en.json`, `pwa/messages/fr.json` — added `errors.retry` key

## Test plan

- [x] `make qa` passes (PHP-CS-Fixer, Rector, PHPStan, ESLint, Prettier, TypeScript)
- [x] 40/40 mocked Playwright E2E tests pass
- [x] No debug statements or stale TODO/FIXME
- [ ] Manual smoke test in browser

## Auto-critique

- [x] No leftover `console.log`, `dump()`, `dd()`, or debug statements
- [x] No stale TODO/FIXME comments (resolved or tracked in a ticket)
- [x] No dead code (unused methods, unreachable branches, orphaned imports)
- [x] Code respects the project architecture (stateless backend, local-first frontend, DTO contract)
- [x] SOLID principles and Law of Demeter are followed
- [x] Documentation (PHPDoc, JSDoc) is up to date for modified public APIs
- [x] If backend DTOs changed: N/A — frontend-only refactoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)