### PR TITLE
chore(mcp): remove project-level .mcp.json in favor of user-level config

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,0 @@
-{
-  "mcpServers": {
-    "openapi-spec": {
-      "command": "npx",
-      "args": ["-y", "apidog-mcp-server@latest", "--oas=https://localhost/docs.json"]
-    }
-  }
-}


### PR DESCRIPTION
## Summary

- Remove `.mcp.json` from the repository — MCP server configurations are now managed in user-level `~/.claude.json` instead of being committed to the project

## Auto-critique

- [x] No dead code or debug statements
- [x] No impact on architecture (simple config file removal)
- [x] No tests needed (configuration change only)

🤖 Generated with [Claude Code](https://claude.ai/code)