### PR TITLE
ci(coverage): add PHPUnit coverage tracking and CI integration (#89)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,18 @@ jobs:
       - name: Install dependencies
         working-directory: ${{ matrix.project }}
         run: composer install --no-interaction --prefer-dist --no-scripts --no-progress
-      - name: Run PHPUnit
+      - name: Run PHPUnit with coverage
         working-directory: ${{ matrix.project }}
-        run: vendor/bin/phpunit
+        env:
+          XDEBUG_MODE: coverage
+        run: vendor/bin/phpunit --coverage-clover coverage/clover.xml
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-${{ matrix.project }}
+          path: ${{ matrix.project }}/coverage/clover.xml
+          retention-days: 7
 
   openapi-lint:
     name: OpenAPI Lint

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ compose.override.yml
 
 .docker/osm/data/*
 !.docker/osm/data/.gitkeep
+
+coverage/

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := help
-.PHONY: help start stop install qa test php-shell pwa-shell ensure-default-pbf provision
+.PHONY: help start stop install qa test php-shell pwa-shell ensure-default-pbf provision coverage coverage-ci
 
 help: ## Show this help message
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n\nTargets:\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
@@ -87,6 +87,14 @@ test-e2e: ## Run Playwright End-to-End tests
 	@docker compose exec pwa npx playwright test
 
 playwright: test-e2e ## Alias for "test-e2e"
+
+coverage: ## Run PHPUnit with coverage (HTML report)
+	@docker compose exec -e XDEBUG_MODE=coverage php vendor/bin/phpunit --coverage-html coverage/api
+	@docker compose --profile provisioning run -e XDEBUG_MODE=coverage --entrypoint "" provisioner vendor/bin/phpunit --coverage-html coverage/provisioner
+
+coverage-ci: ## Run PHPUnit with coverage (Clover XML for CI)
+	@docker compose exec -e XDEBUG_MODE=coverage php vendor/bin/phpunit --coverage-clover coverage/api/clover.xml
+	@docker compose --profile provisioning run -e XDEBUG_MODE=coverage --entrypoint "" provisioner vendor/bin/phpunit --coverage-clover coverage/provisioner/clover.xml
 
 test: qa test-php test-e2e openapi-lint security-check ## Run full test suite (Requires QA to pass first)
 

--- a/api/phpunit.dist.xml
+++ b/api/phpunit.dist.xml
@@ -49,6 +49,13 @@
         </deprecationTrigger>
     </source>
 
+    <coverage>
+        <report>
+            <clover outputFile="coverage/clover.xml"/>
+            <html outputDirectory="coverage/html"/>
+        </report>
+    </coverage>
+
     <extensions>
     </extensions>
 </phpunit>

--- a/provisioner/phpunit.xml.dist
+++ b/provisioner/phpunit.xml.dist
@@ -44,6 +44,13 @@
         </deprecationTrigger>
     </source>
 
+    <coverage>
+        <report>
+            <clover outputFile="coverage/clover.xml"/>
+            <html outputDirectory="coverage/html"/>
+        </report>
+    </coverage>
+
     <extensions>
     </extensions>
 </phpunit>


### PR DESCRIPTION
## Summary

- Ajout des targets Makefile `coverage` (rapport HTML local) et `coverage-ci` (Clover XML pour CI)
- Configuration des rapports de couverture dans `api/phpunit.dist.xml` et `provisioner/phpunit.xml.dist` (Clover XML + HTML)
- Activation de Xdebug coverage dans le job CI `phpunit` avec upload du rapport Clover XML en artifact
- Ajout de `coverage/` au `.gitignore`

## Auto-critique

- [x] Pas de code mort, debug statements ou TODO/FIXME
- [x] Les targets Makefile suivent les patterns existants (docker compose exec/run, préfixe `@`)
- [x] La configuration PHPUnit utilise le format XML natif de PHPUnit 13 (`<coverage><report>`)
- [x] Le CI utilise `XDEBUG_MODE=coverage` via `env:` (pas d'injection de commande)
- [x] L'artifact est uploadé avec `if: always()` pour conserver le rapport même en cas d'échec des tests
- [x] Le `.gitignore` empêche le commit accidentel des rapports de couverture
- [x] Pas de modification du Dockerfile nécessaire (xdebug déjà installé dans le stage dev)

## Test plan

- [ ] Vérifier que `make coverage` génère les rapports HTML dans `coverage/api/` et `coverage/provisioner/`
- [ ] Vérifier que le job CI `phpunit` génère et uploade l'artifact de couverture
- [ ] Vérifier que `coverage/` est bien ignoré par git

🤖 Generated with [Claude Code](https://claude.ai/code)