### PR TITLE
fix(ci): fix review tool parameters in claude-code-review workflow

### DIFF
--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -61,7 +61,7 @@ To do this, follow these steps precisely:
 
    ### C. Create pending review
 
-   Use `mcp__github__pull_request_review_write` with `event: "PENDING"` and `body: ""`.
+   Use `mcp__github__pull_request_review_write` with `method: "create"`. Do NOT pass `event` (omitting it creates a pending review). Do NOT pass `body` (it will be set on submit).
 
    ### D. Post inline comments
 
@@ -78,6 +78,7 @@ To do this, follow these steps precisely:
    ### E. Submit the review
 
    Use `mcp__github__pull_request_review_write` with:
+   - `method`: "submit_pending"
    - `event`: the event determined in step B
    - `body`: structured review body containing:
      1. **Summary** — 1-3 sentences describing the overall quality
@@ -89,7 +90,7 @@ To do this, follow these steps precisely:
         If this code review was useful, please react with a thumbs up. Otherwise, react with a thumbs down.
         ```
 
-   If `mcp__github__pull_request_review_write` fails on submit, retry once with `event: "COMMENT"` as fallback.
+   If `submit_pending` fails, retry once with `method: "create"`, `event: "COMMENT"` as fallback (this creates and submits in one call).
 
 Examples of false positives, for steps 4 and 5:
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -174,11 +174,12 @@ jobs:
             ### C. Create pending review
 
             Use `mcp__github__pull_request_review_write` with:
+            - `method`: "create"
             - `owner`: "vincentchalamon"
             - `repo`: "bike-trip-planner"
-            - `pull_number`: ${{ github.event.pull_request.number }}
-            - `event`: "PENDING"
-            - `body`: "" (empty — body will be set on submit)
+            - `pullNumber`: ${{ github.event.pull_request.number }}
+            - Do NOT pass `event` — omitting it creates a pending (draft) review
+            - Do NOT pass `body` — it will be set on submit
 
             ### D. Post inline comments
 
@@ -202,9 +203,10 @@ jobs:
             ### E. Submit the review
 
             Use `mcp__github__pull_request_review_write` with:
+            - `method`: "submit_pending"
             - `owner`: "vincentchalamon"
             - `repo`: "bike-trip-planner"
-            - `pull_number`: ${{ github.event.pull_request.number }}
+            - `pullNumber`: ${{ github.event.pull_request.number }}
             - `event`: the event determined in step B
             - `body`: structured review body containing:
               1. **Summary** — 1-3 sentences describing the overall quality
@@ -223,4 +225,4 @@ jobs:
             **IMPORTANT: This step is NOT optional.** You must ALWAYS reach this step and submit the review.
             If you created a PENDING review, you MUST submit it — an unsubmitted pending review is invisible on GitHub.
 
-            If `mcp__github__pull_request_review_write` fails on submit, retry once with `event: "COMMENT"` as fallback.
+            If `submit_pending` fails, retry once with `method: "create"`, `event: "COMMENT"` as fallback (this creates and submits in one call).


### PR DESCRIPTION
## Summary

- Fix `mcp__github__pull_request_review_write` calls in CI workflow and `/code-review` skill
- Add required `method` parameter (`"create"` / `"submit_pending"`) that was missing
- Remove invalid `event: "PENDING"` — omitting `event` is what creates a pending review
- Fix parameter name `pull_number` → `pullNumber`

**Root cause:** Claude received instructions with incorrect tool parameters, the tool calls failed silently, and no review was ever submitted.

## Test plan

- [ ] Merge this PR, then rebase PR #108 from `main`
- [ ] Verify that the `claude-review` job on #108 posts an actual review

## Auto-critique

- [x] Both the CI workflow and the local skill are fixed consistently
- [x] Fallback logic updated to use `method: "create"` with `event: "COMMENT"`
- [x] No unrelated changes

🤖 Generated with [Claude Code](https://claude.ai/code)