### PR TITLE
feat(calendar): add Sunday detection to calendar alerts

### DIFF
--- a/api/src/MessageHandler/CheckCalendarHandler.php
+++ b/api/src/MessageHandler/CheckCalendarHandler.php
@@ -49,9 +49,10 @@ final readonly class CheckCalendarHandler extends AbstractTripMessageHandler
 
             foreach ($stages as $i => $stage) {
                 $stageDate = $startDate->modify(\sprintf('+%d days', $i));
+                $isHoliday = $holidays->isHoliday($stageDate);
+                $isSunday = '7' === $stageDate->format('N');
 
-                if ($holidays->isHoliday($stageDate)) {
-                    // Find the matching holiday name by iterating
+                if ($isHoliday) {
                     $holidayName = null;
                     foreach ($holidays->getHolidays() as $holiday) {
                         if ($holiday->format('Y-m-d') === $stageDate->format('Y-m-d')) {
@@ -63,6 +64,7 @@ final readonly class CheckCalendarHandler extends AbstractTripMessageHandler
                     $fallback = $this->translator->trans('alert.calendar.fallback', [], 'alerts', $locale);
                     $nudges[] = [
                         'stageIndex' => $i,
+                        'type' => 'holiday',
                         'date' => $stageDate->format('Y-m-d'),
                         'holiday' => $holidayName ?? $fallback,
                         'message' => $this->translator->trans(
@@ -71,6 +73,18 @@ final readonly class CheckCalendarHandler extends AbstractTripMessageHandler
                                 '%stage%' => $stage->dayNumber,
                                 '%holiday%' => $holidayName ?? $fallback,
                             ],
+                            'alerts',
+                            $locale,
+                        ),
+                    ];
+                } elseif ($isSunday) {
+                    $nudges[] = [
+                        'stageIndex' => $i,
+                        'type' => 'sunday',
+                        'date' => $stageDate->format('Y-m-d'),
+                        'message' => $this->translator->trans(
+                            'alert.calendar.sunday_nudge',
+                            ['%stage%' => $stage->dayNumber],
                             'alerts',
                             $locale,
                         ),

--- a/api/tests/Unit/MessageHandler/CheckCalendarHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/CheckCalendarHandlerTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\MessageHandler;
+
+use App\ApiResource\Model\Coordinate;
+use App\ApiResource\Stage;
+use App\ApiResource\TripRequest;
+use App\ComputationTracker\ComputationTrackerInterface;
+use App\Mercure\MercureEventType;
+use App\Mercure\TripUpdatePublisherInterface;
+use App\Message\CheckCalendar;
+use App\MessageHandler\CheckCalendarHandler;
+use App\Repository\TripRequestRepositoryInterface;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class CheckCalendarHandlerTest extends TestCase
+{
+    private function createStage(string $tripId, int $dayNumber): Stage
+    {
+        return new Stage(
+            tripId: $tripId,
+            dayNumber: $dayNumber,
+            distance: 80000.0,
+            elevation: 500.0,
+            startPoint: new Coordinate(48.0, 2.0),
+            endPoint: new Coordinate(48.1, 2.1),
+        );
+    }
+
+    private function createHandler(
+        TripRequestRepositoryInterface $tripStateManager,
+        TripUpdatePublisherInterface $publisher,
+    ): CheckCalendarHandler {
+        $computationTracker = $this->createStub(ComputationTrackerInterface::class);
+        $computationTracker->method('isAllComplete')->willReturn(false);
+
+        $translator = $this->createStub(TranslatorInterface::class);
+        $translator->method('trans')->willReturnCallback(
+            static fn (string $id, array $params): string => match ($id) {
+                'alert.calendar.sunday_nudge' => \sprintf('Stage %s falls on a Sunday.', $params['%stage%']),
+                'alert.calendar.nudge' => \sprintf('Stage %s: holiday %s.', $params['%stage%'], $params['%holiday%']),
+                'alert.calendar.fallback' => 'Public holiday',
+                default => $id,
+            },
+        );
+
+        return new CheckCalendarHandler(
+            $computationTracker,
+            $publisher,
+            $tripStateManager,
+            $translator,
+        );
+    }
+
+    #[Test]
+    public function sundayNonHolidayEmitsSundayNudge(): void
+    {
+        // 2026-03-15 is a Sunday, not a French holiday
+        $request = new TripRequest();
+        $request->startDate = new \DateTimeImmutable('2026-03-15');
+
+        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
+        $tripStateManager->method('getRequest')->willReturn($request);
+        $tripStateManager->method('getStages')->willReturn([$this->createStage('trip-1', 1)]);
+        $tripStateManager->method('getLocale')->willReturn('en');
+
+        $publisher = $this->createMock(TripUpdatePublisherInterface::class);
+        $publisher->expects($this->once())
+            ->method('publish')
+            ->with(
+                'trip-1',
+                MercureEventType::CALENDAR_ALERTS,
+                $this->callback(static function (array $data): bool {
+                    $nudges = $data['nudges'];
+
+                    return 1 === \count($nudges)
+                        && 'sunday' === $nudges[0]['type']
+                        && 0 === $nudges[0]['stageIndex']
+                        && str_contains((string) $nudges[0]['message'], 'Sunday');
+                }),
+            );
+
+        $handler = $this->createHandler($tripStateManager, $publisher);
+        $handler(new CheckCalendar('trip-1'));
+    }
+
+    #[Test]
+    public function sundayHolidayEmitsOnlyHolidayNudge(): void
+    {
+        // 2026-12-25 is a Friday... let's find a Sunday that is also a holiday in France.
+        // In France, May 1st (Labour Day) — check if 2033-05-01 is a Sunday: yes!
+        // Actually, let's use a simpler approach: 2022-01-01 was a Saturday... no.
+        // 2023-01-01 is a Sunday and is New Year's Day (holiday in France).
+        $request = new TripRequest();
+        $request->startDate = new \DateTimeImmutable('2023-01-01');
+
+        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
+        $tripStateManager->method('getRequest')->willReturn($request);
+        $tripStateManager->method('getStages')->willReturn([$this->createStage('trip-1', 1)]);
+        $tripStateManager->method('getLocale')->willReturn('en');
+
+        $publisher = $this->createMock(TripUpdatePublisherInterface::class);
+        $publisher->expects($this->once())
+            ->method('publish')
+            ->with(
+                'trip-1',
+                MercureEventType::CALENDAR_ALERTS,
+                $this->callback(static function (array $data): bool {
+                    $nudges = $data['nudges'];
+
+                    return 1 === \count($nudges)
+                        && 'holiday' === $nudges[0]['type']
+                        && 0 === $nudges[0]['stageIndex'];
+                }),
+            );
+
+        $handler = $this->createHandler($tripStateManager, $publisher);
+        $handler(new CheckCalendar('trip-1'));
+    }
+
+    #[Test]
+    public function weekdayNonHolidayEmitsNoNudge(): void
+    {
+        // 2026-03-10 is a Tuesday, not a holiday
+        $request = new TripRequest();
+        $request->startDate = new \DateTimeImmutable('2026-03-10');
+
+        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
+        $tripStateManager->method('getRequest')->willReturn($request);
+        $tripStateManager->method('getStages')->willReturn([$this->createStage('trip-1', 1)]);
+        $tripStateManager->method('getLocale')->willReturn('en');
+
+        $publisher = $this->createMock(TripUpdatePublisherInterface::class);
+        $publisher->expects($this->once())
+            ->method('publish')
+            ->with(
+                'trip-1',
+                MercureEventType::CALENDAR_ALERTS,
+                $this->callback(static fn (array $data): bool => [] === $data['nudges']),
+            );
+
+        $handler = $this->createHandler($tripStateManager, $publisher);
+        $handler(new CheckCalendar('trip-1'));
+    }
+}

--- a/api/translations/alerts.en.yaml
+++ b/api/translations/alerts.en.yaml
@@ -8,6 +8,8 @@ alert.traffic.critical: "%count% segment(s) on main road (primary/secondary) wit
 alert.bike_shop.nudge: "No bike shops detected on stage %stage%. In case of a breakdown, the next town may be far away."
 alert.calendar.nudge: "Stage %stage% coincides with a public holiday (%holiday%). Some businesses may be closed."
 alert.calendar.fallback: "Public holiday"
+alert.calendar.sunday_nudge: "Stage %stage% falls on a Sunday. Some businesses may be closed, especially in the afternoon."
+alert.steep_gradient.warning: "Steep climb detected: %gradient%% gradient over %distance%m. Tough with a loaded bike."
 alert.wind.warning: "Headwinds expected for %count%/%total% stages (>25 km/h). Allow extra time."
 stage.label: "Stage %day%"
 weather.clear_sky: "Clear sky"

--- a/pwa/src/lib/mercure/types.ts
+++ b/pwa/src/lib/mercure/types.ts
@@ -88,7 +88,7 @@ export type MercureEvent =
   | {
       type: "calendar_alerts";
       data: {
-        nudges: { stageIndex: number; message: string; date: string }[];
+        nudges: { stageIndex: number; type: "holiday" | "sunday"; message: string; date: string }[];
       };
     }
   | {


### PR DESCRIPTION
Extend CheckCalendarHandler to emit nudges for stages falling on Sundays,
warning users that some businesses may be closed (especially afternoons).

- Add Sunday detection via date format 'N' check
- Holiday takes priority: no duplicate nudge when Sunday is also a holiday
- Add 'type' field ('holiday'|'sunday') to nudge payload for frontend distinction
- Add translations for alert.calendar.sunday_nudge (EN + FR)
- Add 3 unit tests: Sunday non-holiday, Sunday+holiday, weekday non-holiday
- Update frontend MercureEvent type with new nudge type field

Closes #88

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>