### PR TITLE
feat(analyzer): add SteepGradientAnalyzer for steep climb detection

### DIFF
--- a/api/src/Analyzer/Rules/SteepGradientAnalyzer.php
+++ b/api/src/Analyzer/Rules/SteepGradientAnalyzer.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Analyzer\Rules;
+
+use App\Analyzer\StageAnalyzerInterface;
+use App\ApiResource\Model\Alert;
+use App\ApiResource\Model\Coordinate;
+use App\ApiResource\Stage;
+use App\Engine\DistanceCalculatorInterface;
+use App\Enum\AlertType;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final readonly class SteepGradientAnalyzer implements StageAnalyzerInterface
+{
+    private const float MIN_GRADIENT_PERCENT = 8.0;
+
+    private const float MIN_DISTANCE_METERS = 500.0;
+
+    public function __construct(
+        private DistanceCalculatorInterface $distanceCalculator,
+        private TranslatorInterface $translator,
+    ) {
+    }
+
+    public function analyze(Stage $stage, array $context = []): array
+    {
+        $geometry = $stage->geometry;
+        if (\count($geometry) < 2) {
+            return [];
+        }
+
+        /** @var string $locale */
+        $locale = $context['locale'] ?? 'en';
+
+        $alerts = [];
+        $sectionStart = 0;
+        $sectionDistance = 0.0;
+        $sectionElevationGain = 0.0;
+        $inSteepSection = false;
+
+        for ($i = 1, $count = \count($geometry); $i < $count; ++$i) {
+            $prev = $geometry[$i - 1];
+            $curr = $geometry[$i];
+            $segmentDistance = $this->distanceCalculator->distanceBetween($prev, $curr);
+            $elevationDiff = $curr->ele - $prev->ele;
+
+            $gradient = $segmentDistance > 0 ? ($elevationDiff / $segmentDistance) * 100.0 : 0.0;
+
+            if ($gradient >= self::MIN_GRADIENT_PERCENT) {
+                if (!$inSteepSection) {
+                    $inSteepSection = true;
+                    $sectionStart = $i - 1;
+                    $sectionDistance = 0.0;
+                    $sectionElevationGain = 0.0;
+                }
+
+                $sectionDistance += $segmentDistance;
+                $sectionElevationGain += $elevationDiff;
+            } elseif ($inSteepSection) {
+                $alert = $this->buildAlertIfQualified($geometry[$sectionStart], $sectionDistance, $sectionElevationGain, $locale);
+                if ($alert instanceof Alert) {
+                    $alerts[] = $alert;
+                }
+
+                $inSteepSection = false;
+            }
+        }
+
+        // Flush trailing steep section
+        if ($inSteepSection) {
+            $alert = $this->buildAlertIfQualified($geometry[$sectionStart], $sectionDistance, $sectionElevationGain, $locale);
+            if ($alert instanceof Alert) {
+                $alerts[] = $alert;
+            }
+        }
+
+        return $alerts;
+    }
+
+    public static function getPriority(): int
+    {
+        return 20;
+    }
+
+    private function buildAlertIfQualified(Coordinate $start, float $distance, float $elevationGain, string $locale): ?Alert
+    {
+        if ($distance < self::MIN_DISTANCE_METERS) {
+            return null;
+        }
+
+        $averageGradient = $distance > 0 ? ($elevationGain / $distance) * 100.0 : 0.0;
+
+        return new Alert(
+            type: AlertType::WARNING,
+            message: $this->translator->trans(
+                'alert.steep_gradient.warning',
+                [
+                    '%gradient%' => round($averageGradient, 1),
+                    '%distance%' => (int) $distance,
+                ],
+                'alerts',
+                $locale,
+            ),
+            lat: $start->lat,
+            lon: $start->lon,
+        );
+    }
+}

--- a/api/tests/Unit/Analyzer/SteepGradientAnalyzerTest.php
+++ b/api/tests/Unit/Analyzer/SteepGradientAnalyzerTest.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Analyzer;
+
+use App\Analyzer\Rules\SteepGradientAnalyzer;
+use App\ApiResource\Model\Coordinate;
+use App\ApiResource\Stage;
+use App\Engine\DistanceCalculatorInterface;
+use App\Enum\AlertType;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class SteepGradientAnalyzerTest extends TestCase
+{
+    private SteepGradientAnalyzer $analyzer;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $distanceCalculator = $this->createStub(DistanceCalculatorInterface::class);
+        $distanceCalculator->method('distanceBetween')->willReturnCallback(
+            static function (Coordinate $from, Coordinate $to): float {
+                // Haversine approximation for test purposes
+                $latDiff = deg2rad($to->lat - $from->lat);
+                $lonDiff = deg2rad($to->lon - $from->lon);
+                $a = sin($latDiff / 2) ** 2
+                    + cos(deg2rad($from->lat)) * cos(deg2rad($to->lat)) * sin($lonDiff / 2) ** 2;
+
+                return 6_371_000 * 2 * atan2(sqrt($a), sqrt(1 - $a));
+            },
+        );
+
+        $translator = $this->createStub(TranslatorInterface::class);
+        $translator->method('trans')->willReturnCallback(
+            static fn (string $id, array $parameters = []): string => $id.': '.json_encode($parameters),
+        );
+
+        $this->analyzer = new SteepGradientAnalyzer($distanceCalculator, $translator);
+    }
+
+    #[Test]
+    public function noAlertOnFlatTerrain(): void
+    {
+        $stage = $this->createStageWithGeometry([
+            new Coordinate(45.0, 5.0, 200.0),
+            new Coordinate(45.01, 5.0, 201.0),
+            new Coordinate(45.02, 5.0, 202.0),
+        ]);
+
+        $alerts = $this->analyzer->analyze($stage);
+
+        $this->assertSame([], $alerts);
+    }
+
+    #[Test]
+    public function noAlertOnEmptyGeometry(): void
+    {
+        $stage = $this->createStageWithGeometry([]);
+
+        $alerts = $this->analyzer->analyze($stage);
+
+        $this->assertSame([], $alerts);
+    }
+
+    #[Test]
+    public function noAlertOnSinglePoint(): void
+    {
+        $stage = $this->createStageWithGeometry([
+            new Coordinate(45.0, 5.0, 200.0),
+        ]);
+
+        $alerts = $this->analyzer->analyze($stage);
+
+        $this->assertSame([], $alerts);
+    }
+
+    #[Test]
+    public function noAlertWhenSteepButTooShort(): void
+    {
+        // Two points ~111m apart with 10m elevation gain (~9% gradient) — under 500m distance
+        $stage = $this->createStageWithGeometry([
+            new Coordinate(45.0, 5.0, 200.0),
+            new Coordinate(45.001, 5.0, 210.0),
+        ]);
+
+        $alerts = $this->analyzer->analyze($stage);
+
+        $this->assertSame([], $alerts);
+    }
+
+    #[Test]
+    public function warningOnSteepGradientOverMinDistance(): void
+    {
+        // Build a climb: ~10% gradient over ~550m (5 segments of ~111m each, 11m elevation gain each)
+        $stage = $this->createStageWithGeometry([
+            new Coordinate(45.0, 5.0, 200.0),
+            new Coordinate(45.001, 5.0, 211.0),
+            new Coordinate(45.002, 5.0, 222.0),
+            new Coordinate(45.003, 5.0, 233.0),
+            new Coordinate(45.004, 5.0, 244.0),
+            new Coordinate(45.005, 5.0, 255.0),
+        ]);
+
+        $alerts = $this->analyzer->analyze($stage);
+
+        $this->assertCount(1, $alerts);
+        $this->assertSame(AlertType::WARNING, $alerts[0]->type);
+        $this->assertEqualsWithDelta(45.0, $alerts[0]->lat, 0.001);
+        $this->assertEqualsWithDelta(5.0, $alerts[0]->lon, 0.001);
+    }
+
+    #[Test]
+    public function multipleAlerts(): void
+    {
+        // First steep section, then flat, then second steep section
+        $stage = $this->createStageWithGeometry([
+            // Steep section 1
+            new Coordinate(45.0, 5.0, 200.0),
+            new Coordinate(45.001, 5.0, 211.0),
+            new Coordinate(45.002, 5.0, 222.0),
+            new Coordinate(45.003, 5.0, 233.0),
+            new Coordinate(45.004, 5.0, 244.0),
+            new Coordinate(45.005, 5.0, 255.0),
+            // Flat section
+            new Coordinate(45.006, 5.0, 255.0),
+            new Coordinate(45.007, 5.0, 255.0),
+            // Steep section 2
+            new Coordinate(45.008, 5.0, 255.0),
+            new Coordinate(45.009, 5.0, 266.0),
+            new Coordinate(45.010, 5.0, 277.0),
+            new Coordinate(45.011, 5.0, 288.0),
+            new Coordinate(45.012, 5.0, 299.0),
+            new Coordinate(45.013, 5.0, 310.0),
+        ]);
+
+        $alerts = $this->analyzer->analyze($stage);
+
+        $this->assertCount(2, $alerts);
+        $this->assertSame(AlertType::WARNING, $alerts[0]->type);
+        $this->assertSame(AlertType::WARNING, $alerts[1]->type);
+        // First alert at section 1 start
+        $this->assertEqualsWithDelta(45.0, $alerts[0]->lat, 0.001);
+        // Second alert at section 2 start
+        $this->assertEqualsWithDelta(45.008, $alerts[1]->lat, 0.001);
+    }
+
+    #[Test]
+    public function noAlertOnDescent(): void
+    {
+        // Steep descent (-10%) should not trigger
+        $stage = $this->createStageWithGeometry([
+            new Coordinate(45.0, 5.0, 300.0),
+            new Coordinate(45.001, 5.0, 289.0),
+            new Coordinate(45.002, 5.0, 278.0),
+            new Coordinate(45.003, 5.0, 267.0),
+            new Coordinate(45.004, 5.0, 256.0),
+            new Coordinate(45.005, 5.0, 245.0),
+        ]);
+
+        $alerts = $this->analyzer->analyze($stage);
+
+        $this->assertSame([], $alerts);
+    }
+
+    #[Test]
+    public function trailingSteepSectionIsFlushed(): void
+    {
+        // Steep section at the end of geometry (no flat after it)
+        $stage = $this->createStageWithGeometry([
+            new Coordinate(45.0, 5.0, 200.0),
+            new Coordinate(45.001, 5.0, 200.0),
+            new Coordinate(45.002, 5.0, 211.0),
+            new Coordinate(45.003, 5.0, 222.0),
+            new Coordinate(45.004, 5.0, 233.0),
+            new Coordinate(45.005, 5.0, 244.0),
+            new Coordinate(45.006, 5.0, 255.0),
+        ]);
+
+        $alerts = $this->analyzer->analyze($stage);
+
+        $this->assertCount(1, $alerts);
+    }
+
+    #[Test]
+    public function usesLocaleFromContext(): void
+    {
+        $distanceCalculator = $this->createStub(DistanceCalculatorInterface::class);
+        $distanceCalculator->method('distanceBetween')->willReturn(120.0);
+
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->expects($this->once())->method('trans')->with(
+            'alert.steep_gradient.warning',
+            $this->anything(),
+            'alerts',
+            'fr',
+        )->willReturn('Montée raide');
+
+        $analyzer = new SteepGradientAnalyzer($distanceCalculator, $translator);
+
+        $stage = $this->createStageWithGeometry([
+            new Coordinate(45.0, 5.0, 200.0),
+            new Coordinate(45.001, 5.0, 210.0),
+            new Coordinate(45.002, 5.0, 220.0),
+            new Coordinate(45.003, 5.0, 230.0),
+            new Coordinate(45.004, 5.0, 240.0),
+            new Coordinate(45.005, 5.0, 250.0),
+        ]);
+
+        $alerts = $analyzer->analyze($stage, ['locale' => 'fr']);
+
+        $this->assertCount(1, $alerts);
+    }
+
+    #[Test]
+    public function priority(): void
+    {
+        $this->assertSame(20, SteepGradientAnalyzer::getPriority());
+    }
+
+    /**
+     * @param list<Coordinate> $geometry
+     */
+    private function createStageWithGeometry(array $geometry): Stage
+    {
+        return new Stage(
+            tripId: 'trip-1',
+            dayNumber: 1,
+            distance: 80.0,
+            elevation: 500.0,
+            startPoint: new Coordinate(45.0, 5.0),
+            endPoint: new Coordinate(45.5, 5.5),
+            geometry: $geometry,
+        );
+    }
+}

--- a/api/translations/alerts.fr.yaml
+++ b/api/translations/alerts.fr.yaml
@@ -8,6 +8,8 @@ alert.traffic.critical: "%count% segment(s) sur route principale (primary/second
 alert.bike_shop.nudge: "Aucun atelier vélo détecté sur l'étape %stage%. En cas de panne, la prochaine ville peut être loin."
 alert.calendar.nudge: "L'étape %stage% coïncide avec un jour férié (%holiday%). Certains commerces peuvent être fermés."
 alert.calendar.fallback: "Jour férié"
+alert.calendar.sunday_nudge: "L'étape %stage% tombe un dimanche : certains commerces peuvent être fermés, notamment l'après-midi."
+alert.steep_gradient.warning: "Montée raide détectée : %gradient%% de pente sur %distance%m. Difficile avec un vélo chargé."
 alert.wind.warning: "Vents de face attendus pour %count%/%total% étapes (>25 km/h). Prévoyez du temps supplémentaire."
 stage.label: "Étape %day%"
 weather.clear_sky: "Ciel dégagé"


### PR DESCRIPTION
Detect sections with gradient > 8% over 500m+ in stage geometry.
Produces WARNING alerts with location and average gradient percentage.
Crucial for bikepacking with loaded bikes.

Closes #63

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>