### PR TITLE
feat(charging): add charging point detection and alerts

### DIFF
--- a/api/src/Enum/ComputationName.php
+++ b/api/src/Enum/ComputationName.php
@@ -16,6 +16,7 @@ enum ComputationName: string
     case CALENDAR = 'calendar';
     case WIND = 'wind';
     case BIKE_SHOPS = 'bike_shops';
+    case CHARGING_POINTS = 'charging_points';
     case ROUTE_SEGMENT = 'route_segment';
 
     /**

--- a/api/src/Mercure/MercureEventType.php
+++ b/api/src/Mercure/MercureEventType.php
@@ -15,6 +15,7 @@ enum MercureEventType: string
     case CALENDAR_ALERTS = 'calendar_alerts';
     case WIND_ALERTS = 'wind_alerts';
     case BIKE_SHOP_ALERTS = 'bike_shop_alerts';
+    case CHARGING_POINT_ALERTS = 'charging_point_alerts';
     case ROUTE_SEGMENT_RECALCULATED = 'route_segment_recalculated';
     case VALIDATION_ERROR = 'validation_error';
     case COMPUTATION_ERROR = 'computation_error';

--- a/api/src/Message/CheckChargingPoints.php
+++ b/api/src/Message/CheckChargingPoints.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Message;
+
+final readonly class CheckChargingPoints
+{
+    public function __construct(
+        public string $tripId,
+    ) {
+    }
+}

--- a/api/src/MessageHandler/CheckChargingPointsHandler.php
+++ b/api/src/MessageHandler/CheckChargingPointsHandler.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MessageHandler;
+
+use App\ApiResource\Model\Coordinate;
+use App\ApiResource\Stage;
+use App\ComputationTracker\ComputationTrackerInterface;
+use App\Enum\AlertType;
+use App\Enum\ComputationName;
+use App\Geo\GeoDistanceInterface;
+use App\Mercure\MercureEventType;
+use App\Mercure\TripUpdatePublisherInterface;
+use App\Message\CheckChargingPoints;
+use App\Repository\TripRequestRepositoryInterface;
+use App\Scanner\QueryBuilderInterface;
+use App\Scanner\ScannerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+#[AsMessageHandler]
+final readonly class CheckChargingPointsHandler extends AbstractTripMessageHandler
+{
+    private const float CHARGING_POINT_PROXIMITY_METERS = 5000.0;
+
+    public function __construct(
+        ComputationTrackerInterface $computationTracker,
+        TripUpdatePublisherInterface $publisher,
+        private TripRequestRepositoryInterface $tripStateManager,
+        private ScannerInterface $scanner,
+        private QueryBuilderInterface $queryBuilder,
+        private GeoDistanceInterface $haversine,
+        private TranslatorInterface $translator,
+    ) {
+        parent::__construct($computationTracker, $publisher);
+    }
+
+    public function __invoke(CheckChargingPoints $message): void
+    {
+        $tripId = $message->tripId;
+        $stages = $this->tripStateManager->getStages($tripId);
+
+        if (null === $stages) {
+            return;
+        }
+
+        $locale = $this->tripStateManager->getLocale($tripId) ?? 'en';
+
+        $this->executeWithTracking($tripId, ComputationName::CHARGING_POINTS, function () use ($tripId, $stages, $locale): void {
+            $decimatedData = $this->tripStateManager->getDecimatedPoints($tripId);
+            $points = null !== $decimatedData
+                ? array_map(static fn (array $p): Coordinate => new Coordinate($p['lat'], $p['lon'], $p['ele']), $decimatedData)
+                : array_merge(...array_map(
+                    static fn (Stage $stage): array => $stage->geometry ?: [$stage->startPoint, $stage->endPoint],
+                    $stages,
+                ));
+
+            $query = $this->queryBuilder->buildChargingPointQuery($points);
+            $result = $this->scanner->query($query);
+
+            /** @var list<array{lat?: float, lon?: float, center?: array{lat: float, lon: float}}> $elements */
+            $elements = \is_array($result['elements'] ?? null) ? $result['elements'] : [];
+
+            $chargingPointLocations = [];
+            foreach ($elements as $element) {
+                $lat = $element['lat'] ?? ($element['center']['lat'] ?? null);
+                $lon = $element['lon'] ?? ($element['center']['lon'] ?? null);
+
+                if (null === $lat || null === $lon) {
+                    continue;
+                }
+
+                $chargingPointLocations[] = ['lat' => (float) $lat, 'lon' => (float) $lon];
+            }
+
+            $stagesWithoutCharging = [];
+            foreach ($stages as $i => $stage) {
+                $hasNearby = false;
+                $endPoint = $stage->endPoint;
+
+                foreach ($chargingPointLocations as $point) {
+                    if ($this->haversine->inMeters($endPoint->lat, $endPoint->lon, $point['lat'], $point['lon']) < self::CHARGING_POINT_PROXIMITY_METERS) {
+                        $hasNearby = true;
+                        break;
+                    }
+                }
+
+                if (!$hasNearby) {
+                    $stagesWithoutCharging[] = [
+                        'stageIndex' => $i,
+                        'dayNumber' => $stage->dayNumber,
+                        'type' => AlertType::NUDGE->value,
+                        'message' => $this->translator->trans(
+                            'alert.charging_point.nudge',
+                            ['%stage%' => $stage->dayNumber],
+                            'alerts',
+                            $locale,
+                        ),
+                    ];
+                }
+            }
+
+            $this->publisher->publish($tripId, MercureEventType::CHARGING_POINT_ALERTS, [
+                'alerts' => $stagesWithoutCharging,
+            ]);
+        });
+    }
+}

--- a/api/src/MessageHandler/GenerateStagesHandler.php
+++ b/api/src/MessageHandler/GenerateStagesHandler.php
@@ -19,6 +19,7 @@ use App\Mercure\TripUpdatePublisherInterface;
 use App\Message\AnalyzeTerrain;
 use App\Message\CheckBikeShops;
 use App\Message\CheckCalendar;
+use App\Message\CheckChargingPoints;
 use App\Message\FetchWeather;
 use App\Message\GenerateStages;
 use App\Message\ScanAccommodations;
@@ -96,6 +97,7 @@ final readonly class GenerateStagesHandler extends AbstractTripMessageHandler
             $this->messageBus->dispatch(new FetchWeather($tripId));
             $this->messageBus->dispatch(new CheckCalendar($tripId));
             $this->messageBus->dispatch(new CheckBikeShops($tripId));
+            $this->messageBus->dispatch(new CheckChargingPoints($tripId));
         });
     }
 

--- a/api/src/MessageHandler/ScanAllOsmDataHandler.php
+++ b/api/src/MessageHandler/ScanAllOsmDataHandler.php
@@ -43,11 +43,12 @@ final readonly class ScanAllOsmDataHandler extends AbstractTripMessageHandler
                 $decimatedData,
             );
 
-            // Execute all 3 Overpass queries — each call caches the result.
+            // Execute all 4 Overpass queries — each call caches the result.
             // Leaf handlers will hit the cache when they build the same queries.
             $this->scanner->query($this->queryBuilder->buildPoiQuery($points));
             $this->scanner->query($this->queryBuilder->buildAccommodationQuery($points));
             $this->scanner->query($this->queryBuilder->buildBikeShopQuery($points));
+            $this->scanner->query($this->queryBuilder->buildChargingPointQuery($points));
         });
     }
 }

--- a/api/src/Scanner/OsmOverpassQueryBuilder.php
+++ b/api/src/Scanner/OsmOverpassQueryBuilder.php
@@ -92,6 +92,20 @@ final readonly class OsmOverpassQueryBuilder implements QueryBuilderInterface
         );
     }
 
+    /**
+     * @param list<Coordinate> $decimatedPoints
+     */
+    public function buildChargingPointQuery(array $decimatedPoints): string
+    {
+        $polyline = $this->buildPolyline($decimatedPoints);
+
+        return \sprintf(
+            '[out:json][timeout:15];(nwr["amenity"="charging_station"]["bicycle"="yes"](around:%d,%s););out center 50;',
+            self::AROUND_RADIUS_METERS,
+            $polyline,
+        );
+    }
+
     /** @param list<Coordinate> $points */
     private function buildPolyline(array $points): string
     {

--- a/api/src/Scanner/QueryBuilderInterface.php
+++ b/api/src/Scanner/QueryBuilderInterface.php
@@ -39,4 +39,9 @@ interface QueryBuilderInterface
      * @param list<list<Coordinate>> $stageGeometries geometry points per stage
      */
     public function buildBatchBikeShopQuery(array $stageGeometries): string;
+
+    /**
+     * @param list<Coordinate> $decimatedPoints
+     */
+    public function buildChargingPointQuery(array $decimatedPoints): string;
 }

--- a/api/tests/Functional/trip-schema.json
+++ b/api/tests/Functional/trip-schema.json
@@ -37,7 +37,8 @@
         "weather",
         "calendar",
         "wind",
-        "bike_shops"
+        "bike_shops",
+        "charging_points"
       ],
       "additionalProperties": false,
       "properties": {
@@ -123,6 +124,15 @@
           ]
         },
         "bike_shops": {
+          "type": "string",
+          "enum": [
+            "pending",
+            "running",
+            "done",
+            "failed"
+          ]
+        },
+        "charging_points": {
           "type": "string",
           "enum": [
             "pending",

--- a/api/tests/Unit/MessageHandler/CheckChargingPointsHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/CheckChargingPointsHandlerTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\MessageHandler;
+
+use App\ApiResource\Model\Coordinate;
+use App\ApiResource\Stage;
+use App\ComputationTracker\ComputationTrackerInterface;
+use App\Geo\GeoDistanceInterface;
+use App\Mercure\MercureEventType;
+use App\Mercure\TripUpdatePublisherInterface;
+use App\Message\CheckChargingPoints;
+use App\MessageHandler\CheckChargingPointsHandler;
+use App\Repository\TripRequestRepositoryInterface;
+use App\Scanner\QueryBuilderInterface;
+use App\Scanner\ScannerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class CheckChargingPointsHandlerTest extends TestCase
+{
+    private function createStage(string $tripId, int $dayNumber, float $endLat = 48.1, float $endLon = 2.1): Stage
+    {
+        return new Stage(
+            tripId: $tripId,
+            dayNumber: $dayNumber,
+            distance: 80000.0,
+            elevation: 500.0,
+            startPoint: new Coordinate(48.0, 2.0),
+            endPoint: new Coordinate($endLat, $endLon),
+        );
+    }
+
+    private function createHandler(
+        TripRequestRepositoryInterface $tripStateManager,
+        TripUpdatePublisherInterface $publisher,
+        ScannerInterface $scanner,
+        QueryBuilderInterface $queryBuilder,
+        GeoDistanceInterface $haversine,
+    ): CheckChargingPointsHandler {
+        $computationTracker = $this->createStub(ComputationTrackerInterface::class);
+        $computationTracker->method('isAllComplete')->willReturn(false);
+
+        $translator = $this->createStub(TranslatorInterface::class);
+        $translator->method('trans')->willReturnCallback(
+            static fn (string $id, array $params): string => \sprintf('No charging point near stage %s.', $params['%stage%']),
+        );
+
+        return new CheckChargingPointsHandler(
+            $computationTracker,
+            $publisher,
+            $tripStateManager,
+            $scanner,
+            $queryBuilder,
+            $haversine,
+            $translator,
+        );
+    }
+
+    #[Test]
+    public function stageWithNearbyChargingPointEmitsNoAlert(): void
+    {
+        $stages = [$this->createStage('trip-1', 1)];
+
+        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
+        $tripStateManager->method('getStages')->willReturn($stages);
+        $tripStateManager->method('getLocale')->willReturn('en');
+        $tripStateManager->method('getDecimatedPoints')->willReturn([
+            ['lat' => 48.0, 'lon' => 2.0, 'ele' => 0.0],
+            ['lat' => 48.1, 'lon' => 2.1, 'ele' => 0.0],
+        ]);
+
+        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
+        $queryBuilder->method('buildChargingPointQuery')->willReturn('query');
+
+        $scanner = $this->createStub(ScannerInterface::class);
+        $scanner->method('query')->willReturn([
+            'elements' => [
+                ['lat' => 48.1, 'lon' => 2.1],
+            ],
+        ]);
+
+        $haversine = $this->createStub(GeoDistanceInterface::class);
+        // Charging point is very close to endpoint
+        $haversine->method('inMeters')->willReturn(100.0);
+
+        $publisher = $this->createMock(TripUpdatePublisherInterface::class);
+        $publisher->expects($this->once())
+            ->method('publish')
+            ->with(
+                'trip-1',
+                MercureEventType::CHARGING_POINT_ALERTS,
+                $this->callback(static fn (array $data): bool => [] === $data['alerts']),
+            );
+
+        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine);
+        $handler(new CheckChargingPoints('trip-1'));
+    }
+
+    #[Test]
+    public function stageWithoutChargingPointEmitsNudge(): void
+    {
+        $stages = [$this->createStage('trip-1', 1)];
+
+        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
+        $tripStateManager->method('getStages')->willReturn($stages);
+        $tripStateManager->method('getLocale')->willReturn('en');
+        $tripStateManager->method('getDecimatedPoints')->willReturn([
+            ['lat' => 48.0, 'lon' => 2.0, 'ele' => 0.0],
+            ['lat' => 48.1, 'lon' => 2.1, 'ele' => 0.0],
+        ]);
+
+        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
+        $queryBuilder->method('buildChargingPointQuery')->willReturn('query');
+
+        $scanner = $this->createStub(ScannerInterface::class);
+        $scanner->method('query')->willReturn(['elements' => []]);
+
+        $haversine = $this->createStub(GeoDistanceInterface::class);
+
+        $publisher = $this->createMock(TripUpdatePublisherInterface::class);
+        $publisher->expects($this->once())
+            ->method('publish')
+            ->with(
+                'trip-1',
+                MercureEventType::CHARGING_POINT_ALERTS,
+                $this->callback(static function (array $data): bool {
+                    $alerts = $data['alerts'];
+
+                    return 1 === \count($alerts)
+                        && 'nudge' === $alerts[0]['type']
+                        && 0 === $alerts[0]['stageIndex']
+                        && 1 === $alerts[0]['dayNumber'];
+                }),
+            );
+
+        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine);
+        $handler(new CheckChargingPoints('trip-1'));
+    }
+
+    #[Test]
+    public function noStagesReturnsEarly(): void
+    {
+        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
+        $tripStateManager->method('getStages')->willReturn(null);
+
+        $publisher = $this->createMock(TripUpdatePublisherInterface::class);
+        $publisher->expects($this->never())->method('publish');
+
+        $scanner = $this->createStub(ScannerInterface::class);
+        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
+        $haversine = $this->createStub(GeoDistanceInterface::class);
+
+        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine);
+        $handler(new CheckChargingPoints('trip-1'));
+    }
+}

--- a/api/tests/Unit/Scanner/OsmOverpassQueryBuilderTest.php
+++ b/api/tests/Unit/Scanner/OsmOverpassQueryBuilderTest.php
@@ -130,6 +130,20 @@ final class OsmOverpassQueryBuilderTest extends TestCase
     }
 
     #[Test]
+    public function buildChargingPointQuery(): void
+    {
+        $points = [new Coordinate(45.0, 5.0)];
+
+        $query = $this->builder->buildChargingPointQuery($points);
+
+        $this->assertStringContainsString('[out:json][timeout:15]', $query);
+        $this->assertStringContainsString('"amenity"="charging_station"', $query);
+        $this->assertStringContainsString('"bicycle"="yes"', $query);
+        $this->assertStringContainsString('around:2000', $query);
+        $this->assertStringContainsString('out center 50', $query);
+    }
+
+    #[Test]
     public function buildBatchBikeShopQueryMergesAllStages(): void
     {
         $stage1 = [new Coordinate(45.0, 5.0)];

--- a/api/translations/alerts.en.yaml
+++ b/api/translations/alerts.en.yaml
@@ -6,6 +6,7 @@ alert.surface.warning: "Unpaved section of %length%m detected (%surface%). Check
 alert.surface.fallback: "non-asphalt surface"
 alert.traffic.critical: "%count% segment(s) on main road (primary/secondary) without bike lane detected."
 alert.bike_shop.nudge: "No bike shops detected on stage %stage%. In case of a breakdown, the next town may be far away."
+alert.charging_point.nudge: "No e-bike charging point detected near the end of stage %stage%. Plan battery management accordingly."
 alert.calendar.nudge: "Stage %stage% coincides with a public holiday (%holiday%). Some businesses may be closed."
 alert.calendar.fallback: "Public holiday"
 alert.calendar.sunday_nudge: "Stage %stage% falls on a Sunday. Some businesses may be closed, especially in the afternoon."

--- a/api/translations/alerts.fr.yaml
+++ b/api/translations/alerts.fr.yaml
@@ -6,6 +6,7 @@ alert.surface.warning: "Section non-pavée de %length%m détectée (%surface%). 
 alert.surface.fallback: "surface non-asphaltée"
 alert.traffic.critical: "%count% segment(s) sur route principale (primary/secondary) sans piste cyclable détecté(s)."
 alert.bike_shop.nudge: "Aucun atelier vélo détecté sur l'étape %stage%. En cas de panne, la prochaine ville peut être loin."
+alert.charging_point.nudge: "Aucun point de charge VAE détecté à proximité de la fin de l'étape %stage%. Anticipez la gestion de votre batterie."
 alert.calendar.nudge: "L'étape %stage% coïncide avec un jour férié (%holiday%). Certains commerces peuvent être fermés."
 alert.calendar.fallback: "Jour férié"
 alert.calendar.sunday_nudge: "L'étape %stage% tombe un dimanche : certains commerces peuvent être fermés, notamment l'après-midi."

--- a/pwa/src/hooks/use-mercure.ts
+++ b/pwa/src/hooks/use-mercure.ts
@@ -28,7 +28,7 @@ const MERCURE_URL =
  * - `weather_fetched` — per-stage weather forecasts
  * - `pois_scanned` — points of interest with optional alerts
  * - `accommodations_found` — accommodation options per stage
- * - `terrain_alerts` / `calendar_alerts` / `wind_alerts` / `bike_shop_alerts` — alert categories
+ * - `terrain_alerts` / `calendar_alerts` / `wind_alerts` / `bike_shop_alerts` / `charging_point_alerts` — alert categories
  * - `trip_complete` — final computation status, stops processing spinner
  * - `validation_error` / `computation_error` — error toasts and recovery
  */
@@ -210,6 +210,28 @@ function dispatchEvent(event: MercureEvent): void {
             lon: null,
           })),
           "bike_shop",
+        );
+      }
+      break;
+    }
+
+    case "charging_point_alerts": {
+      const chargingByStage = new Map<number, typeof event.data.alerts>();
+      for (const alert of event.data.alerts) {
+        const existing = chargingByStage.get(alert.stageIndex) ?? [];
+        existing.push(alert);
+        chargingByStage.set(alert.stageIndex, existing);
+      }
+      for (const [stageIndex, alerts] of chargingByStage) {
+        store.updateStageAlerts(
+          stageIndex,
+          alerts.map((a) => ({
+            type: a.type as "nudge",
+            message: a.message,
+            lat: null,
+            lon: null,
+          })),
+          "charging_point",
         );
       }
       break;

--- a/pwa/src/lib/mercure/types.ts
+++ b/pwa/src/lib/mercure/types.ts
@@ -88,7 +88,12 @@ export type MercureEvent =
   | {
       type: "calendar_alerts";
       data: {
-        nudges: { stageIndex: number; type: "holiday" | "sunday"; message: string; date: string }[];
+        nudges: {
+          stageIndex: number;
+          type: "holiday" | "sunday";
+          message: string;
+          date: string;
+        }[];
       };
     }
   | {
@@ -97,6 +102,17 @@ export type MercureEvent =
     }
   | {
       type: "bike_shop_alerts";
+      data: {
+        alerts: {
+          stageIndex: number;
+          type: string;
+          message: string;
+          dayNumber: number;
+        }[];
+      };
+    }
+  | {
+      type: "charging_point_alerts";
       data: {
         alerts: {
           stageIndex: number;


### PR DESCRIPTION
Closes #66

Introduce charging point support across backend and frontend: add a new
ComputationName and Mercure event type for charging points; implement
CheckChargingPoints message and handler to scan OSM for e-bike charging
stations, compute proximity, and publish nudges for stages without
nearby chargers. Update ScanAllOsmDataHandler to include charging
queries, extend the query builder with buildChargingPointQuery, add
corresponding tests, translations (en/fr), and frontend Mercure handling
to display charging_point_alerts.