### PR TITLE
chore(prettier): ignore generated OpenAPI spec files

### DIFF
--- a/pwa/.prettierignore
+++ b/pwa/.prettierignore
@@ -1,0 +1,2 @@
+openapi.json
+openapi.yaml


### PR DESCRIPTION
## Summary

- Add `pwa/.prettierignore` to exclude `openapi.json` and `openapi.yaml` from Prettier checks
- These files are generated artifacts (used by MCP openapi-spec and Redocly), not hand-written code

## Test plan

- [x] `make prettier` passes without false positives on `openapi.json`

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- claude-review-start -->
## Claude Review

Reviewed commit `5aa4897f22596125f1654778a45e4398392c5a4b`.

Minimal, well-scoped change that correctly excludes generated OpenAPI artifacts from Prettier formatting. The PR title, description, and test plan are all consistent and accurate.

**Review checklist**
- [x] Code respects the project architecture (tooling config only, no logic changed)
- [x] SOLID principles and Law of Demeter followed (N/A — config file)
- [x] Design patterns used where appropriate (N/A — config file)
- [x] Tests cover new/changed cases (`make prettier` verified per test plan)
- [x] Documentation is up to date (N/A — no public APIs modified)
- [x] Dependent tickets accounted for (N/A)

No inline comments.

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->