### PR TITLE
ci(review): add remaining MCP tool names to allowedTools

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
-            --allowedTools "mcp__github__add_comment_to_pending_review,mcp__github__pull_request_review_write,mcp__github__pull_request_read,mcp__github__get_pull_request,mcp__github__get_pull_request_diff,mcp__github__create_pending_pull_request_review,mcp__github__create_and_submit_pull_request_review,mcp__github__get_file_contents,mcp__github__update_pull_request,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*),Bash(git log:*),Read,Glob,Grep"
+            --allowedTools "mcp__github__add_comment_to_pending_review,mcp__github__pull_request_review_write,mcp__github__pull_request_read,mcp__github__get_pull_request,mcp__github__get_pull_request_diff,mcp__github__get_pull_request_reviews,mcp__github__get_pull_request_review_comments,mcp__github__create_pending_pull_request_review,mcp__github__create_and_submit_pull_request_review,mcp__github__submit_pending_pull_request_review,mcp__github__delete_pending_pull_request_review,mcp__github__get_file_contents,mcp__github__update_pull_request,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*),Bash(git log:*),Read,Glob,Grep,Write"
           prompt: |
             You are a senior code reviewer for the Bike Trip Planner project.
             Review pull request #${{ github.event.pull_request.number }} following the project's review standards.


### PR DESCRIPTION
## Summary

- PR #119 added 4 missing MCP tool names but missed 4 more that Claude uses during the resolve-threads and submit-review steps
- Both PR #116 and #117 still had permission denials after #119 was merged

## Added tools

| Tool name | Used for |
|---|---|
| `mcp__github__get_pull_request_reviews` | Step 10 — fetch existing reviews to resolve addressed threads |
| `mcp__github__get_pull_request_review_comments` | Step 10 — read review comment bodies |
| `mcp__github__submit_pending_pull_request_review` | Step 11E — submit the pending review |
| `mcp__github__delete_pending_pull_request_review` | Cleanup — delete stale pending review on retry |
| `Write` | Temporary file creation (used as fallback for complex review bodies) |

## Test plan

- [ ] Trigger a review on an open PR and verify zero permission denials
- [ ] Verify the "Check for permission denials" step passes green

## Auto-critique

- [x] Minimal change — only adds missing tool names
- [x] No debug statements, no dead code
- [x] Identified from actual CI execution artifacts (PR #116 and #117)

🤖 Generated with [Claude Code](https://claude.ai/code)