### PR TITLE
ci(review): fix false positive in permission denial check

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -255,9 +255,10 @@ jobs:
         run: |
           EXEC_FILE="${{ steps.claude-review.outputs.execution_file }}"
           if [ -f "$EXEC_FILE" ]; then
-            if grep -q 'permission_denial' "$EXEC_FILE"; then
-              echo "::error::Claude encountered permission denials. See uploaded artifact."
-              grep 'permission_denial' "$EXEC_FILE"
+            DENIAL_COUNT=$(jq '.[- 1].permission_denials | length' "$EXEC_FILE" 2>/dev/null || echo 0)
+            if [ "$DENIAL_COUNT" -gt 0 ]; then
+              echo "::error::Claude encountered $DENIAL_COUNT permission denial(s). See uploaded artifact."
+              jq '.[- 1].permission_denials' "$EXEC_FILE"
               exit 1
             fi
             echo "No permission denials found."


### PR DESCRIPTION
## Summary

- The "Check for permission denials" step used `grep 'permission_denial'` which matched the JSON key `"permission_denials": []` even when the array was empty
- This caused the step to fail with exit code 1 despite zero actual denials
- Replace with `jq` to properly check the array length before failing

## Root cause

```json
"permission_denials": []
```

`grep -q 'permission_denial'` matches the key name itself, not just populated entries. Both PR #116 and #117 had 0 denials but the step still failed.

## Test plan

- [ ] Verify the step passes when `permission_denials` is an empty array
- [ ] Verify the step still fails when there are actual denials

## Auto-critique

- [x] Minimal one-line logic change
- [x] `jq` is pre-installed on `ubuntu-latest` runners
- [x] Fallback `|| echo 0` handles malformed JSON gracefully

🤖 Generated with [Claude Code](https://claude.ai/code)