### PR TITLE
ci(review): use wildcard for MCP GitHub tools in allowedTools

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
-            --allowedTools "mcp__github__add_comment_to_pending_review,mcp__github__pull_request_review_write,mcp__github__pull_request_read,mcp__github__get_pull_request,mcp__github__get_pull_request_diff,mcp__github__get_pull_request_reviews,mcp__github__get_pull_request_review_comments,mcp__github__create_pending_pull_request_review,mcp__github__create_and_submit_pull_request_review,mcp__github__submit_pending_pull_request_review,mcp__github__delete_pending_pull_request_review,mcp__github__get_file_contents,mcp__github__update_pull_request,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*),Bash(git log:*),Read,Glob,Grep,Write"
+            --allowedTools "mcp__github__*,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*),Bash(git log:*),Read,Glob,Grep,Write"
           prompt: |
             You are a senior code reviewer for the Bike Trip Planner project.
             Review pull request #${{ github.event.pull_request.number }} following the project's review standards.


### PR DESCRIPTION
## Summary

- Replace the explicit list of 13 MCP GitHub tool names with `mcp__github__*` wildcard
- The action's MCP server keeps exposing new tool names (`get_pull_request_files`, etc.) that we keep missing, causing recurring permission denials (PRs #119, #120, and now this)

## Why

| PR | Missing tool | 
|---|---|
| #119 | `get_pull_request`, `get_pull_request_diff`, `create_pending_pull_request_review`, `create_and_submit_pull_request_review` |
| #120 | `get_pull_request_reviews`, `get_pull_request_review_comments`, `submit_pending_pull_request_review`, `delete_pending_pull_request_review` |
| This | `get_pull_request_files` |

This is a game of whack-a-mole. The wildcard stops it permanently.

## Security consideration

The `claude-code-action` already scopes the MCP GitHub server to the repository's `GITHUB_TOKEN` permissions (defined in the workflow's `permissions:` block). The wildcard doesn't grant any new GitHub API access — it just stops Claude from being denied tools that are already available to it.

## Test plan

- [ ] Verify zero permission denials on next PR review

🤖 Generated with [Claude Code](https://claude.ai/code)