### PR TITLE
ci(review): allow all Bash commands in claude-review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
-            --allowedTools "mcp__github__*,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*),Bash(git log:*),Read,Glob,Grep,Write"
+            --allowedTools "mcp__github__*,Bash(*),Read,Glob,Grep,Write"
           prompt: |
             You are a senior code reviewer for the Bike Trip Planner project.
             Review pull request #${{ github.event.pull_request.number }} following the project's review standards.


### PR DESCRIPTION
## Summary

- Replace `Bash(gh pr diff:*)`, `Bash(gh pr view:*)`, etc. with `Bash(*)` 
- Claude pipes commands like `gh pr diff 116 | grep ...` which don't match the specific patterns, causing a permission denial

## Why not restrict Bash patterns?

The CI runner is ephemeral and the `GITHUB_TOKEN` is already scoped by the workflow's `permissions:` block. Restricting Bash patterns provides no meaningful security benefit while causing recurring false denials when Claude uses pipes, subshells, or other shell constructs.

## Test plan

- [ ] Verify zero permission denials on next PR review

🤖 Generated with [Claude Code](https://claude.ai/code)