### PR TITLE
ci(review): skip claude-review for dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   claude-review:
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ !github.event.pull_request.draft && github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     permissions:
       actions: read


### PR DESCRIPTION
## Summary

- Skip le workflow `claude-code-review` lorsque la PR est ouverte par `dependabot[bot]`, en ajoutant `github.actor != 'dependabot[bot]'` à la condition `if` du job

## Contexte

La PR #124 (dependabot) a fait planter claude-review avec l'erreur :
> Workflow initiated by non-human actor: dependabot (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.

Plutôt que d'ajouter dependabot à une liste autorisée, on skip simplement le workflow pour ces PRs.

## Test plan

- [x] Vérifier que le workflow est ignoré sur les PRs dependabot
- [x] Vérifier que le workflow s'exécute toujours sur les PRs humaines

🤖 Generated with [Claude Code](https://claude.com/claude-code)