### PR TITLE
ci(claude): set defaultMode to plan in project settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -87,6 +87,6 @@
       "Read(./api/.env.*.local)",
       "Read(./pwa/.env*)"
     ],
-    "defaultMode": "acceptEdits"
+    "defaultMode": "plan"
   }
 }


### PR DESCRIPTION
## Summary

- Switch `defaultMode` from `acceptEdits` to `plan` in `.claude/settings.json`
- In plan mode, Claude requests approval before executing tools — more appropriate for CI where actions should be controlled

## Test plan

- [ ] Verify `.claude/settings.json` remains valid JSON
- [ ] Trigger `@claude` on a test issue and confirm Claude operates in plan mode

## Auto-critique

- [x] Single-line change, minimal risk
- [x] JSON validity preserved
- [x] No other settings affected

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- claude-review-start -->
## Claude Review

**Reviewed commit:** `3f89b825f86b1a3e5d013ff14a62cf15c779b538`

Clean, minimal config change. The switch from `acceptEdits` to `plan` is well-reasoned: plan mode prevents Claude from autonomously executing tools in CI, ensuring all actions remain human-approved.

**Findings:** 0 critical · 0 warnings · 0 suggestions

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed (N/A — config only)
- [x] Design patterns used where appropriate (N/A — config only)
- [x] Tests cover new/changed cases (N/A — no executable code changed)
- [x] Documentation is up to date (N/A — self-documenting config key)
- [x] Dependent tickets accounted for

**No inline comments.**

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->