### PR TITLE
ci(review): allow claude bot to trigger code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -42,6 +42,7 @@ jobs:
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
+          allowed_bots: "claude[bot]"
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
             --allowedTools "mcp__github__*,Bash(*),Read,Glob,Grep,Write"


### PR DESCRIPTION
## Summary

- Add `allowed_bots: "claude[bot]"` to the `claude-code-review.yml` workflow so that PRs created/updated by the Claude bot trigger the code review instead of failing with "Workflow initiated by non-human actor"

## Test plan

- [ ] Open or update a PR authored by `claude[bot]` and verify the `Claude Code Review` workflow runs without the "non-human actor" error

## Auto-critique

- [x] Change is minimal and scoped to the CI workflow
- [x] No security risk: `allowed_bots` is a static string, no user input injection
- [x] No dead code or debug statements introduced

🤖 Generated with [Claude Code](https://claude.ai/code)