### PR TITLE
fix(review): add API verification guardrail to prevent hallucinations

### DIFF
--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -2,7 +2,7 @@
 name: code-review
 description: Code review a pull request
 argument-hint: <pr-number>
-allowed-tools: Bash(gh issue view:*), Bash(gh search:*), Bash(gh issue list:*), Bash(gh pr diff:*), Bash(gh pr view:*), Bash(gh pr list:*), Bash(gh api:*), mcp__github__add_comment_to_pending_review, mcp__github__pull_request_review_write, mcp__github__pull_request_read, Read, Glob, Grep
+allowed-tools: Bash(gh issue view:*), Bash(gh search:*), Bash(gh issue list:*), Bash(gh pr diff:*), Bash(gh pr view:*), Bash(gh pr list:*), Bash(gh api:*), mcp__github__add_comment_to_pending_review, mcp__github__pull_request_review_write, mcp__github__pull_request_read, mcp__context7__resolve-library-id, mcp__context7__query-docs, Read, Glob, Grep
 disable-model-invocation: false
 ---
 
@@ -22,7 +22,10 @@ To do this, follow these steps precisely:
    a. Agent #1: Audit the changes to make sure they comply with the CLAUDE.md. Note that CLAUDE.md is guidance for Claude as it writes code, so not all instructions will be applicable during code
    review.
    b. Agent #2: Read the file changes in the pull request, then do a shallow scan for obvious bugs. Avoid reading extra context beyond the changes, focusing just on the changes themselves. Focus on
-   large bugs, and avoid small issues and nitpicks. Ignore likely false positives.
+   large bugs, and avoid small issues and nitpicks. Ignore likely false positives. Before claiming any API does not exist or was renamed, the agent MUST verify using these methods in order of reliability:
+   (1) Read the actual vendor source file (e.g. `api/vendor/symfony/console/Application.php`) — this is the ground truth.
+   (2) Query context7 (`mcp__context7__resolve-library-id` then `mcp__context7__query-docs`) for current documentation.
+   If neither verification method is possible, do NOT flag the issue.
    c. Agent #3: Read the git blame and history of the code modified, to identify any bugs in light of that historical context
    d. Agent #4: Read previous pull requests that touched these files, and check for any comments on those pull requests that may also apply to the current pull request.
    e. Agent #5: Read code comments in the modified files, and make sure the changes in the pull request comply with any guidance in the comments.
@@ -103,6 +106,7 @@ Examples of false positives, for steps 4 and 5:
 - Issues that are called out in CLAUDE.md, but explicitly silenced in the code (eg. due to a lint ignore comment)
 - Changes in functionality that are likely intentional or are directly related to the broader change
 - Real issues, but on lines that the user did not modify in their pull request
+- API existence claims based on training data alone — this project uses cutting-edge frameworks (Symfony 8, Next.js 16, PHP 8.5) where APIs may have changed. Never claim an API "does not exist" without verifying against vendor source or context7 documentation
 
 Notes:
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -52,6 +52,14 @@ jobs:
 
             Use the **Review Comment Format** section in CLAUDE.md for all comments (Conventional Comments labels, inline threads, review body structure).
 
+            ## Step 0 -- Dependency awareness
+
+            Before reviewing code, establish the project's dependency versions:
+
+            1. Read `api/composer.json` and `pwa/package.json` to identify exact framework versions.
+            2. Note that this project uses cutting-edge frameworks that may differ significantly from your training data.
+            3. Follow the **API Verification Guardrail** in CLAUDE.md for any claims about API existence.
+
             ## Step 1 -- Fetch PR context
 
             Run `gh pr view ${{ github.event.pull_request.number }}` and `gh pr diff ${{ github.event.pull_request.number }}` to get the full diff and PR metadata.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,6 +208,16 @@ The review submission body contains only PR-level findings:
 
 Since PRs are **squash-merged**, only the **PR title** must follow Conventional Commits format. Do NOT check individual commit messages.
 
+### API Verification Guardrail
+
+This project uses cutting-edge framework versions (Symfony 8, PHP 8.5, Next.js 16, React 19) that have breaking changes compared to earlier versions in Claude's training data.
+
+**Rules for code reviewers:**
+
+- NEVER claim a method, class, or function "does not exist" or "was removed" based on training knowledge alone
+- ALWAYS verify against actual vendor source code (`api/vendor/`, `pwa/node_modules/`) or up-to-date documentation (context7 MCP) before making API existence claims
+- If verification is not possible, downgrade the finding to `suggestion (non-blocking)` and explicitly state that verification was not possible for the framework version used
+
 ## ADR Documentation
 
 Architecture Decision Records in `docs/adr/` document all major technical choices with context, alternatives considered, and rationale. Consult these before proposing architectural changes.


### PR DESCRIPTION
## Summary

- Adds an **API Verification Guardrail** section to `CLAUDE.md` preventing reviewers from claiming APIs don't exist based on training data alone
- Adds a **Step 0 -- Dependency awareness** to the CI review workflow requiring reviewers to read `composer.json`/`package.json` before reviewing
- Enriches the `/code-review` skill with context7 MCP tools and vendor source verification instructions for Agent #2
- Adds API existence hallucinations to the false-positive examples list

## Motivation

PR #130 review produced a blocking `issue` claiming `Application::addCommand()` doesn't exist in Symfony and suggesting `add()` instead. This was an **hallucination** — Symfony 8 replaced `add()` with `addCommand()`, but Claude's training data covers Symfony ≤7.

This PR adds guardrails at three levels:
1. **`CLAUDE.md`** (source of truth) — explicit rule for all reviewers
2. **CI workflow** — Step 0 forces reading dependency versions before review
3. **`/code-review` skill** — Agent #2 must verify via vendor source (ground truth) or context7 (current docs) before flagging API issues

## Verification hierarchy

| Method | Reliability | Availability |
|--------|------------|-------------|
| Vendor source (`api/vendor/`) | Highest (ground truth) | Local only |
| context7 MCP docs | High (may have doc residue) | Local only |
| `composer.json` + CLAUDE.md guardrail | Medium (prevents false claims) | CI + Local |

## Auto-critique

- [x] Changes are purely additive — no existing behavior modified
- [x] CLAUDE.md passes markdownlint
- [x] context7 tested on the exact hallucination case (confirms `addCommand()` in Symfony 8.0 docs)
- [x] Graceful degradation: if verification is impossible, finding must be downgraded to non-blocking

## Test plan

- [ ] Run `/code-review` on a PR using Symfony 8 APIs to verify Agent #2 checks vendor source
- [ ] Verify CI review reads `composer.json` in Step 0 on next PR

🤖 Generated with [Claude Code](https://claude.ai/code)