### PR TITLE
ci(review): add inline comment MCP server to allowedTools

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -45,7 +45,7 @@ jobs:
           allowed_bots: "claude[bot]"
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
-            --allowedTools "mcp__github__*,Bash(*),Read,Glob,Grep,Write"
+            --allowedTools "mcp__github__*,mcp__github_inline_comment__*,Bash(*),Read,Glob,Grep,Write"
           prompt: |
             You are a senior code reviewer for the Bike Trip Planner project.
             Review pull request #${{ github.event.pull_request.number }} following the project's review standards.


### PR DESCRIPTION
## Summary

The `mcp__github__*` wildcard in `claude_args --allowedTools` does not match `mcp__github_inline_comment__*` because they are separate MCP servers. This caused permission denials when the review bot tried to post inline comments on PRs (observed on PR #126 CI run).

Adding `mcp__github_inline_comment__*` to the allowedTools list fixes the issue.

## Auto-critique

- [x] Root cause identified: separate MCP server namespaces
- [x] Minimal change (single line)
- [x] No functional code affected — CI workflow only
- [x] Verified against [claude-code-action documentation](https://github.com/anthropics/claude-code-action)

## Test plan

- [ ] Trigger a code review on any PR and verify inline comments are posted successfully
- [ ] Check the execution artifact for zero permission denials

Generated with [Claude Code](https://claude.ai/code)