### PR TITLE
chore(skills): use git worktree in pick skill

### DIFF
--- a/.claude/skills/pick/SKILL.md
+++ b/.claude/skills/pick/SKILL.md
@@ -62,4 +62,5 @@ Run `gh pr checks --watch`. If CI fails, read the logs, fix the issues, push, an
 ## Step 10 -- Finalize
 
 - If TRACKING.md exists, update the row for this issue: change status to "En cours" and branch to `feature/<issue-number>`. Commit and push.
+- Remove the worktree: `git worktree remove .claude/worktrees/feature-<issue-number>`
 - Report the PR URL to the user.


### PR DESCRIPTION
## Summary

- Le skill `/pick` utilise désormais `git worktree add` au lieu de `git checkout -b` pour travailler dans un worktree isolé
- Toutes les étapes suivantes (implémentation, tests, review, PR) s'exécutent depuis le répertoire du worktree

## Auto-critique

- [x] Changement minimal et ciblé
- [x] Pas de code mort, debug statements ou TODO
- [x] Cohérence maintenue entre les étapes du skill (steps 7 et 8 mis à jour)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

The previous suggestion (worktree cleanup at Step 10) has been addressed in the second commit. The skill now correctly creates an isolated worktree, instructs all subsequent steps to operate from that directory, and tears it down cleanly at finalization. No findings remain.

**Reviewed commit:** `0f5358e3ad4f732f12c8b1f3d0a8ae368d4d3c3b`

**Review checklist**

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases (N/A — skill/docs only)
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**No inline comments.**

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->