### PR TITLE
chore(review): exclude nitpick comments from automated code reviews

### DIFF
--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -22,7 +22,7 @@ To do this, follow these steps precisely:
    a. Agent #1: Audit the changes to make sure they comply with the CLAUDE.md. Note that CLAUDE.md is guidance for Claude as it writes code, so not all instructions will be applicable during code
    review.
    b. Agent #2: Read the file changes in the pull request, then do a shallow scan for obvious bugs. Avoid reading extra context beyond the changes, focusing just on the changes themselves. Focus on
-   large bugs, and avoid small issues and nitpicks. Ignore likely false positives. Before claiming any API does not exist or was renamed, the agent MUST verify using these methods in order of reliability:
+   large bugs, and avoid small issues and nitpicks. Do NOT flag nitpicks — only flag issues that impact correctness, security, performance, architecture, maintainability, test coverage, or debug leftovers. Ignore likely false positives. Before claiming any API does not exist or was renamed, the agent MUST verify using these methods in order of reliability:
    (1) Read the actual vendor source file (e.g. `api/vendor/symfony/console/Application.php`) — this is the ground truth.
    (2) Query context7 (`mcp__context7__resolve-library-id` then `mcp__context7__query-docs`) for current documentation.
    If neither verification method is possible, do NOT flag the issue.
@@ -35,8 +35,7 @@ To do this, follow these steps precisely:
    a. 0: Not confident at all. This is a false positive that doesn't stand up to light scrutiny, or is a pre-existing issue.
    b. 25: Somewhat confident. This might be a real issue, but may also be a false positive. The agent wasn't able to verify that it's a real issue. If the issue is stylistic, it is one that was not
    explicitly called out in the relevant CLAUDE.md.
-   c. 50: Moderately confident. The agent was able to verify this is a real issue, but it might be a nitpick or not happen very often in practice. Relative to the rest of the PR, it's not very
-   important.
+   c. 50: Moderately confident. The agent was able to verify this is a real issue, but it is a nitpick or minor style issue that doesn't impact correctness, security, performance, architecture, maintainability, test coverage, or debug leftovers. These are always filtered out.
    d. 75: Highly confident. The agent double checked the issue, and verified that it is very likely it is a real issue that will be hit in practice. The existing approach in the PR is insufficient.
    The issue is very important and will directly impact the code's functionality, or it is an issue that is directly mentioned in the relevant CLAUDE.md.
    e. 100: Absolutely certain. The agent double checked the issue, and confirmed that it is definitely a real issue, that will happen frequently in practice. The evidence directly confirms this.
@@ -100,6 +99,7 @@ Examples of false positives, for steps 4 and 5:
 - Pre-existing issues
 - Something that looks like a bug but is not actually a bug
 - Pedantic nitpicks that a senior engineer wouldn't call out
+- Nitpicks: minor style preferences, naming bikeshedding, trivial formatting, missing documentation, or suggestions that don't impact correctness, security, performance, architecture, maintainability, test coverage, or debug leftovers. If a comment would use the `nitpick` label, do not post it.
 - Issues that a linter, typechecker, or compiler would catch (eg. missing or incorrect imports, type errors, broken tests, formatting issues, pedantic style issues like newlines). No need to run these
   build steps yourself -- it is safe to assume that they will be run separately as part of CI.
 - General code quality issues (eg. lack of test coverage, general security issues, poor documentation), unless explicitly required in CLAUDE.md

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -52,6 +52,8 @@ jobs:
 
             Use the **Review Comment Format** section in CLAUDE.md for all comments (Conventional Comments labels, inline threads, review body structure).
 
+            **IMPORTANT: Do NOT post nitpick comments.** Only flag issues that impact: correctness, security, performance, architecture, maintainability (dead code/orphaned imports), test coverage, or debug leftovers. Minor style preferences, naming suggestions, missing documentation, and trivial formatting must be ignored — the project's linters and formatters handle those.
+
             ## Step 0 -- Dependency awareness
 
             Before reviewing code, establish the project's dependency versions:
@@ -78,7 +80,7 @@ jobs:
             Scan the diff for:
             - Leftover `console.log`, `dump()`, `dd()`, or debug statements
             - Stale TODO/FIXME comments
-            - Unintended technical debt
+            - Significant unintended technical debt
 
             ## Step 4 -- Security review
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,6 +188,8 @@ All code review comments (CI workflow, `/code-review`, `/review`) follow [Conven
 | Nitpick | `nitpick (non-blocking): <subject>` |
 | Positive feedback | `praise: <subject>` |
 
+> **Note:** Automated reviews (CI workflow and `/code-review` skill) must NOT post `nitpick` comments. Only flag issues that impact: correctness, security, performance, architecture, maintainability (dead code), test coverage, or debug leftovers. The `nitpick` label is reserved for manual human reviews.
+
 ### Inline Comments
 
 - Each code-level finding gets its own **inline thread** on the relevant line(s)


### PR DESCRIPTION
## Summary

- Exclude `nitpick` comments from automated reviews (CI workflow and `/code-review` skill) to reduce noise and unnecessary review cycles
- Add explicit anti-nitpick directives in CLAUDE.md, SKILL.md, and the CI workflow prompt
- Redefine confidence score 50 as "nitpick territory" that is always filtered out

## Changes

| File | Change |
|------|--------|
| `CLAUDE.md` | Note under labels table: nitpicks reserved for manual human reviews |
| `.claude/skills/code-review/SKILL.md` | Agent #2 anti-nitpick directive, score 50 redefined, nitpicks added to false positives list |
| `.github/workflows/claude-code-review.yml` | Global anti-nitpick directive, "Significant unintended technical debt" |

## Allowed review categories (automated)

1. Correctness — bugs, logic errors, edge cases
2. Security — OWASP Top 10, SSRF, XXE, injection
3. Performance — N+1, unbounded loops, memory
4. Architecture — DTO contract, stateless backend, SOLID
5. Maintainability — dead code, orphaned imports
6. Test coverage — untested new/changed behavior
7. Debug leftovers — `console.log`, `dump()`, `dd()`

## Auto-critique

- [x] Changes are consistent across all 3 files
- [x] No dead code or debug leftovers
- [x] Conventional Commits format respected
- [x] No functional code changed — documentation/config only

🤖 Generated with [Claude Code](https://claude.ai/code)