### PR TITLE
fix(ci): prevent pick job from closing/reopening PRs to re-trigger CI

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
+    types: [opened, synchronize, ready_for_review]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -114,6 +114,8 @@ jobs:
 
             Repeat up to 3 times. If still failing after 3 attempts, comment on the PR explaining the remaining failures.
 
+            **IMPORTANT: NEVER close and reopen the PR to re-trigger CI. Pushing commits automatically re-triggers all CI checks via the `synchronize` event. Closing/reopening creates noise in the PR timeline and triggers unnecessary workflow re-runs.**
+
             ## Step 8 — Report
 
             Comment on issue #${{ github.event.issue.number }} with the PR URL.


### PR DESCRIPTION
## Summary

- Add explicit instruction in `claude.yml` pick job Step 7 forbidding close/reopen of PRs to re-trigger CI (pushing commits already triggers `synchronize`)
- Remove `reopened` from `claude-code-review.yml` triggers to prevent cascading review re-runs on reopen events

## Context

PR #154 suffered 4 close/reopen cycles by `claude[bot]` during CI monitoring. The pick job's Claude was using `mcp__github__update_pull_request` to close then reopen PRs as a strategy to re-trigger CI checks. This is unnecessary and harmful: it creates noise in the PR timeline and triggers unnecessary `claude-code-review` workflow re-runs (which listened to `reopened` events).

## Auto-critique

- [x] No security implications (no untrusted input in `run:` commands)
- [x] YAML syntax validated
- [x] Minimal change — only adds instruction text and removes one trigger type
- [x] No code changes, only CI workflow configuration

🤖 Generated with [Claude Code](https://claude.ai/code)