### PR TITLE
chore: fix make flush-queue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,4 +132,4 @@ flush-queue: ## Stop workers, clear all Messenger queues, and purge trip state c
 	@# Workers receive a stop signal and finish their current message before exiting.
 	@# Redis visibility timeouts prevent double-processing of in-flight messages.
 	@docker compose exec php bin/console app:messenger:clear --all
-	@docker compose exec php bin/console cache:pool:clear trip_state
+	@docker compose exec php bin/console cache:pool:clear cache.trip_state


### PR DESCRIPTION
<!-- claude-review-start -->
## Claude Review

**Summary:** Single-line Makefile fix correcting the Symfony cache pool service ID from `trip_state` to `cache.trip_state`. The fix is correct — confirmed against `api/config/packages/cache.php` and all `#[Autowire(service: 'cache.trip_state')]` usages in the codebase.

**Findings:** 0 critical, 0 warnings, 0 suggestions.

**Commit reviewed:** `f904ebc4`

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases _(N/A — Makefile operational fix)_
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** None.

---
Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->