### PR TITLE
docs: mise à jour TRACKING.md sprint 4

### DIFF
--- a/TRACKING.md
+++ b/TRACKING.md
@@ -69,10 +69,10 @@ Backend pur, pattern `StageAnalyzerInterface` + `#[AutoconfigureTag]`. Reviews r
 
 | Ordre | ID | Titre | Effort | PRs | Dépend de |
 |-------|----|-------|--------|-----|-----------|
-| 1 | [#48](https://github.com/vincentchalamon/bike-trip-planner/issues/48) | Profil cyclo + presets | M | 1 | — |
-| 2 | [#49](https://github.com/vincentchalamon/bike-trip-planner/issues/49) | Panneau configuration (sidebar) | M | 1 | [#48](https://github.com/vincentchalamon/bike-trip-planner/issues/48) |
-| 3 | [#36](https://github.com/vincentchalamon/bike-trip-planner/issues/36) | Filtre types d'hébergements | M | 1 | [#49](https://github.com/vincentchalamon/bike-trip-planner/issues/49) |
-| 4 | [#55](https://github.com/vincentchalamon/bike-trip-planner/issues/55) | Insertion jours de repos | M | 1 | — |
+| 1 | [#48](https://github.com/vincentchalamon/bike-trip-planner/issues/48) | Profil cyclo + presets | M | [#170](https://github.com/vincentchalamon/bike-trip-planner/pull/170) `feature/48` | — |
+| 2 | [#49](https://github.com/vincentchalamon/bike-trip-planner/issues/49) | Panneau configuration (sidebar) | M | [#172](https://github.com/vincentchalamon/bike-trip-planner/pull/172) `feature/49` | [#48](https://github.com/vincentchalamon/bike-trip-planner/issues/48) |
+| 3 | [#36](https://github.com/vincentchalamon/bike-trip-planner/issues/36) | Filtre types d'hébergements | M | [#173](https://github.com/vincentchalamon/bike-trip-planner/pull/173) `feature/36` | [#49](https://github.com/vincentchalamon/bike-trip-planner/issues/49) |
+| 4 | [#55](https://github.com/vincentchalamon/bike-trip-planner/issues/55) | Insertion jours de repos | M | [#171](https://github.com/vincentchalamon/bike-trip-planner/pull/171) `feature/55` | — |
 
 ### Recette Sprint 4
 


### PR DESCRIPTION
Mise à jour du suivi sprint 4 avec les liens vers les PRs créées :

- #48 → PR #170 `feature/48`
- #49 → PR #172 `feature/49`
- #36 → PR #173 `feature/36`
- #55 → PR #171 `feature/55`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 findings. Pure documentation update linking sprint 4 issues to their implementation PRs — no code changes, no security/performance/architecture concerns.

**Resolved threads:** No previously open threads.

**PR title check:** `docs: mise à jour TRACKING.md sprint 4` — description is a noun phrase ("mise à jour") rather than imperative mood verb. Conventional Commits requires imperative mood (e.g. `docs: update TRACKING.md for sprint 4 PRs`). No blocking issue for a docs-only PR, but worth aligning for consistency.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases (N/A — documentation only)
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

---
Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->
