### PR TITLE
docs: update TRACKING for sprint 7

### DIFF
--- a/TRACKING.md
+++ b/TRACKING.md
@@ -128,10 +128,10 @@ Backend pur, pattern `StageAnalyzerInterface` + `#[AutoconfigureTag]`. Reviews r
 
 | Ordre | ID | Titre | Effort | PRs | Dépend de |
 |-------|----|-------|--------|-----|-----------|
-| 1 | [#30](https://github.com/vincentchalamon/bike-trip-planner/issues/30) | Carte interactive + profil altimétrique | XL | 5 | — |
-| 2 | [#31](https://github.com/vincentchalamon/bike-trip-planner/issues/31) | Split view carte / timeline | M | 1 | [#30](https://github.com/vincentchalamon/bike-trip-planner/issues/30) |
-| 3 | [#34](https://github.com/vincentchalamon/bike-trip-planner/issues/34) | Timeline ravitaillement | L | 2 | [#58](https://github.com/vincentchalamon/bike-trip-planner/issues/58) |
-| 4 | [#35](https://github.com/vincentchalamon/bike-trip-planner/issues/35) | Points d'intérêt culturels | M | 1 | — |
+| 1 | [#30](https://github.com/vincentchalamon/bike-trip-planner/issues/30) | Carte interactive + profil altimétrique | XL | [#187](https://github.com/vincentchalamon/bike-trip-planner/pull/187) `feature/30` | — |
+| 2 | [#31](https://github.com/vincentchalamon/bike-trip-planner/issues/31) | Split view carte / timeline | M | [#190](https://github.com/vincentchalamon/bike-trip-planner/pull/190) `feature/31` | [#30](https://github.com/vincentchalamon/bike-trip-planner/issues/30) |
+| 3 | [#34](https://github.com/vincentchalamon/bike-trip-planner/issues/34) | Timeline ravitaillement | L | [#189](https://github.com/vincentchalamon/bike-trip-planner/pull/189) `feature/34` | [#58](https://github.com/vincentchalamon/bike-trip-planner/issues/58) |
+| 4 | [#35](https://github.com/vincentchalamon/bike-trip-planner/issues/35) | Points d'intérêt culturels | M | [#188](https://github.com/vincentchalamon/bike-trip-planner/pull/188) `feature/35` | — |
 
 ### Recette Sprint 7
 


### PR DESCRIPTION
## Summary

- Updates TRACKING.md Sprint 7 table with PR links for all 4 issues

| Issue | PR |
|-------|-----|
| #30 Carte interactive + profil altimétrique | [#187](https://github.com/vincentchalamon/bike-trip-planner/pull/187) `feature/30` |
| #31 Split view carte / timeline | [#190](https://github.com/vincentchalamon/bike-trip-planner/pull/190) `feature/31` |
| #34 Timeline ravitaillement | [#189](https://github.com/vincentchalamon/bike-trip-planner/pull/189) `feature/34` |
| #35 Points d'intérêt culturels | [#188](https://github.com/vincentchalamon/bike-trip-planner/pull/188) `feature/35` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

**Reviewed commit:** 5e50a5a

**Summary:** 0 findings. Docs-only change replacing raw PR count numbers with hyperlinked PR references in TRACKING.md — clean and correct.

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases *(N/A — docs only)*
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

No inline comments.

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->