### PR TITLE
docs(tracking): add sprint 8 PR links

### DIFF
--- a/TRACKING.md
+++ b/TRACKING.md
@@ -151,9 +151,9 @@ Backend pur, pattern `StageAnalyzerInterface` + `#[AutoconfigureTag]`. Reviews r
 
 | Ordre | ID | Titre | Effort | PRs | Dépend de |
 |-------|----|-------|--------|-----|-----------|
-| 1 | [#32](https://github.com/vincentchalamon/bike-trip-planner/issues/32) | Onboarding guide | S | 1 | — |
-| 2 | [#57](https://github.com/vincentchalamon/bike-trip-planner/issues/57) | Undo/Redo | L | 2 | — |
-| 3 | [#33](https://github.com/vincentchalamon/bike-trip-planner/issues/33) | Raccourcis clavier + aide | M | 1 | [#57](https://github.com/vincentchalamon/bike-trip-planner/issues/57) |
+| 1 | [#32](https://github.com/vincentchalamon/bike-trip-planner/issues/32) | Onboarding guide | S | [#200](https://github.com/vincentchalamon/bike-trip-planner/pull/200) `feature/32`, [#203](https://github.com/vincentchalamon/bike-trip-planner/pull/203) `fix/sprint-8` | — |
+| 2 | [#57](https://github.com/vincentchalamon/bike-trip-planner/issues/57) | Undo/Redo | L | [#201](https://github.com/vincentchalamon/bike-trip-planner/pull/201) `feature/57` | — |
+| 3 | [#33](https://github.com/vincentchalamon/bike-trip-planner/issues/33) | Raccourcis clavier + aide | M | [#202](https://github.com/vincentchalamon/bike-trip-planner/pull/202) `feature/33`, [#203](https://github.com/vincentchalamon/bike-trip-planner/pull/203) `fix/sprint-8` | [#57](https://github.com/vincentchalamon/bike-trip-planner/issues/57) |
 
 ### Recette Sprint 8
 


### PR DESCRIPTION
## Summary

- Ajoute les liens vers les PRs mergées du sprint 8 dans `TRACKING.md`
  - **#32** (Onboarding guide) → PR #200 + fix #203
  - **#57** (Undo/Redo) → PR #201
  - **#33** (Raccourcis clavier) → PR #202 + fix #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)