### PR TITLE
docs(persistence): add ADR-022 persistent storage strategy

### DIFF
--- a/docs/adr/adr-022-persistent-storage-strategy.md
+++ b/docs/adr/adr-022-persistent-storage-strategy.md
@@ -93,7 +93,7 @@ Use PostgreSQL as the storage engine with Doctrine ORM for entity mapping, but s
 - **Full Symfony ecosystem.** Doctrine Migrations for schema versioning, Zenstruck Foundry for test factories and dev fixtures, PHPStan Doctrine extensions, Symfony Maker recipes — all work out of the box.
 - **Minimal ORM overhead.** The project already uses custom State Providers/Processors; Doctrine is used purely as a hydration/persistence mapper, not as a framework. No auto-generated providers, no lazy loading (explicit `JOIN FETCH`), no lifecycle listeners beyond `PreUpdate` for timestamps.
 - **PostgreSQL JSONB** provides the document-model flexibility of MongoDB for nested computed data, with the added benefit of indexable JSON paths if needed later.
-- **Lightweight Docker footprint.** `postgres:17-alpine` uses ~50 MB RAM at idle.
+- **Lightweight Docker footprint.** `postgres:18-alpine` uses ~50 MB RAM at idle.
 - **Future-proof.** `User → Trip` ownership (Sprint 12), shared-trip tokens (Sprint 14), and trip listing with pagination (Sprint 13) are natural relational operations.
 
 **Disadvantages:**
@@ -105,7 +105,7 @@ Use PostgreSQL as the storage engine with Doctrine ORM for entity mapping, but s
 
 ## Decision Outcome
 
-**Chosen: Option C — PostgreSQL 17 + Doctrine ORM with JSONB strategy.**
+**Chosen: Option C — PostgreSQL 18 + Doctrine ORM with JSONB strategy.**
 
 ### Architecture
 
@@ -126,7 +126,7 @@ Use PostgreSQL as the storage engine with Doctrine ORM for entity mapping, but s
     │ (User)  │              │ Tracks data   │
     └────┬────┘              │ Computation   │
          │                   │   tracking    │
-    PostgreSQL 17            │ Generation    │
+    PostgreSQL 18            │ Generation    │
                              │   tracking    │
                              └───────┬───────┘
                                   Redis 8
@@ -199,7 +199,7 @@ Redis remains fully operational throughout the migration for Messenger transport
 
 ## Sources
 
-- [PostgreSQL JSONB Documentation](https://www.postgresql.org/docs/17/datatype-json.html)
+- [PostgreSQL JSONB Documentation](https://www.postgresql.org/docs/18/datatype-json.html)
 - [Doctrine ORM 3.x Documentation](https://www.doctrine-project.org/projects/doctrine-orm/en/3.4/index.html)
 - [Zenstruck Foundry](https://github.com/zenstruck/foundry)
 - [Pomm Project (archived)](https://github.com/pomm-project/Foundation) — last activity 2020


### PR DESCRIPTION
## Summary

- Adds ADR-022 documenting the persistent storage strategy for issue #56
- Evaluates three options: MongoDB + Doctrine ODM, PostgreSQL + Pomm Project, PostgreSQL + Doctrine ORM
- Chosen: **PostgreSQL 17 + Doctrine ORM with JSONB strategy** for computed sub-objects
- Documents what moves to PostgreSQL vs what stays in Redis
- Details the 7-PR incremental migration plan

## Context

Prerequisite documentation for Sprint 11 (Persistance). This ADR establishes the rationale before implementation begins.

Closes part of #56

## Test plan

- [ ] ADR file renders correctly in Markdown
- [ ] No impact on existing code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

Clean documentation PR with no new findings. The ADR is technically sound and well-structured. All three previously open bot threads were already resolved in earlier commits. The two unresolved threads were opened by the author and are intentionally left for them to close.

**Note:** The PR description summary still reads "PostgreSQL 17" while the ADR file now references PostgreSQL 18 (updated in commit `001e1089`). Consider updating the PR description for consistency, though this has no impact on the ADR content itself.

**Findings summary:** 0 findings.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases — N/A (docs-only PR)
- [x] Documentation is up to date — ADR-022 added; CLAUDE.md update included as step 7 of migration plan
- [x] Dependent tickets accounted for (#56, #76, #50, #45, #52)

**PR title check:** Conforms to Conventional Commits. ✓

No inline comments.

Minimized 4 previously outdated bot reviews.

Reviewed commit: `001e1089a0392e593fe0cca5ff1920df7eb6a89f`

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->