### PR TITLE
ci: exclude @integration Playwright smoke test from CI run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,7 +278,7 @@ jobs:
           -w /app -v ./pwa:/app
           --rm --ipc=host
           mcr.microsoft.com/playwright:v1.58.2-noble
-          /bin/sh -c 'npm ci; npx playwright test'
+          /bin/sh -c 'npm ci; npx playwright test --grep-invert @integration'
       - uses: actions/upload-artifact@v7
         if: failure()
         with:

--- a/pwa/tests/integration/smoke.spec.ts
+++ b/pwa/tests/integration/smoke.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "@playwright/test";
 
 test.describe("Integration smoke test", () => {
-  test("backend accepts and processes a real Komoot tour", async ({ page }) => {
+  test("backend accepts and processes a real Komoot tour @integration", async ({ page }) => {
     test.slow();
 
     let capturedTripId: string | null = null;


### PR DESCRIPTION
**Fermée** — remplacée par une approche mock Komoot dans le smoke test, plus robuste qu'un simple skip en CI.