### PR TITLE
chore: remove empty .env.dev and move KERNEL_CLASS to phpunit config

### DIFF
--- a/api/.env.dev
+++ b/api/.env.dev
@@ -1,2 +1,0 @@
-###> symfony/framework-bundle ###
-###< symfony/framework-bundle ###

--- a/api/.env.test
+++ b/api/.env.test
@@ -1,2 +1,0 @@
-# define your env variables for the test env here
-KERNEL_CLASS='App\Kernel'

--- a/api/phpunit.dist.xml
+++ b/api/phpunit.dist.xml
@@ -24,6 +24,7 @@
         <ini name="error_reporting" value="-1" />
         <server name="APP_ENV" value="test" force="true" />
         <server name="SHELL_VERBOSITY" value="-1" />
+        <env name="KERNEL_CLASS" value="App\Kernel" force="true" />
         <!-- Override environment variables set in Docker Compose -->
         <env name="MESSENGER_TRANSPORT_DSN" value="in-memory://" force="true" />
         <env name="MESSENGER_FAILED_DSN" value="in-memory://" force="true" />


### PR DESCRIPTION
## Summary

- Delete `api/.env.dev` — file was empty (only framework-bundle placeholder comments), serves no purpose
- Move `KERNEL_CLASS='App\Kernel'` from `api/.env.test` to `api/phpunit.dist.xml` as `<env name="KERNEL_CLASS" ...>`
- Delete `api/.env.test` — now empty after migration

## Test plan

- [x] `make test-php` passes after removing these files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

**Reviewed commit:** 41e26b20ffac823f55219541150a43f0e1a80144

### Summary

Clean housekeeping PR with no issues. Removing the empty `.env.dev` placeholder and consolidating the PHPUnit-specific `KERNEL_CLASS` env var into `phpunit.dist.xml` (with `force="true"`, consistent with the existing entries) is the correct approach.

### Findings: 0 total (0 critical, 0 warning, 0 suggestion)

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

No inline comments. No previous bot threads to resolve.

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->