### PR TITLE
docs: update TRACKING.md with Sprint 12 PR links

### DIFF
--- a/TRACKING.md
+++ b/TRACKING.md
@@ -236,9 +236,9 @@ Backend pur, pattern `StageAnalyzerInterface` + `#[AutoconfigureTag]`. Reviews r
 
 | Ordre | ID                                                                    | Titre                     | Effort | PRs | Dépend de                                                             |
 |-------|-----------------------------------------------------------------------|---------------------------|--------|-----|-----------------------------------------------------------------------|
-| 1     | [#50](https://github.com/vincentchalamon/bike-trip-planner/issues/50) | Liste des trips           | L      | 2   | [#56](https://github.com/vincentchalamon/bike-trip-planner/issues/56) |
-| 2     | [#45](https://github.com/vincentchalamon/bike-trip-planner/issues/45) | Duplication de trip       | M      | 1   | [#56](https://github.com/vincentchalamon/bike-trip-planner/issues/56) |
-| 3     | [#52](https://github.com/vincentchalamon/bike-trip-planner/issues/52) | Verrouillage trips passés | M      | 1   | [#56](https://github.com/vincentchalamon/bike-trip-planner/issues/56) |
+| 1     | [#50](https://github.com/vincentchalamon/bike-trip-planner/issues/50) | Liste des trips           | L      | [#233](https://github.com/vincentchalamon/bike-trip-planner/pull/233) | [#56](https://github.com/vincentchalamon/bike-trip-planner/issues/56) |
+| 2     | [#45](https://github.com/vincentchalamon/bike-trip-planner/issues/45) | Duplication de trip       | M      | [#235](https://github.com/vincentchalamon/bike-trip-planner/pull/235) | [#56](https://github.com/vincentchalamon/bike-trip-planner/issues/56) |
+| 3     | [#52](https://github.com/vincentchalamon/bike-trip-planner/issues/52) | Verrouillage trips passés | M      | [#234](https://github.com/vincentchalamon/bike-trip-planner/pull/234) | [#56](https://github.com/vincentchalamon/bike-trip-planner/issues/56) |
 
 ### Recette Sprint 12
 


### PR DESCRIPTION
## Summary

- Link Sprint 12 issues to their implementation PRs:
  - #50 (liste des trips) → PR #233
  - #45 (duplication de trip) → PR #235
  - #52 (verrouillage trips passés) → PR #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

**Reviewed commit:** `cdbc5689fe847445876e6818c56b3f838b10adf5`

**Findings:** 0 (no issues found)

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases *(documentation-only change — no tests required)*
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

No inline comments.

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->