### PR TITLE
fix(test): use Foundry ResetDatabase with migrate mode for functional tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,25 @@ jobs:
     container:
       image: docker.io/esoledad/php:8.5
       options: --user root
+    services:
+      database:
+        image: postgres:18-alpine
+        env:
+          POSTGRES_USER: app
+          POSTGRES_PASSWORD: "!ChangeMe!"
+          POSTGRES_DB: app_test
+        options: >-
+          --health-cmd "pg_isready -U app -d app_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis:7-alpine
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
     strategy:
       fail-fast: false
       matrix:
@@ -53,6 +72,8 @@ jobs:
         working-directory: ${{ matrix.project }}
         env:
           XDEBUG_MODE: coverage
+          DATABASE_URL: "postgresql://app:!ChangeMe!@database:5432/app?serverVersion=18&charset=utf8"
+          REDIS_URL: "redis://redis:6379"
         run: vendor/bin/phpunit --coverage-clover coverage/clover.xml
       - name: Upload coverage report
         if: always()

--- a/api/config/packages/zenstruck_foundry.php
+++ b/api/config/packages/zenstruck_foundry.php
@@ -10,6 +10,11 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             'persistence' => [
                 'flush_once' => true,
             ],
+            'orm' => [
+                'reset' => [
+                    'mode' => 'migrate',
+                ],
+            ],
         ]);
     }
 };

--- a/api/tests/Functional/StageCreateTest.php
+++ b/api/tests/Functional/StageCreateTest.php
@@ -16,9 +16,14 @@ use App\Repository\TripRequestRepositoryInterface;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
 
+#[ResetDatabase]
 final class StageCreateTest extends ApiTestCase
 {
+    use Factories;
+
     private const string TRIP_ID = '01936f6e-0000-7000-8000-000000000010';
 
     private function seedTripWithStages(string $tripId, int $stageCount = 3): void
@@ -56,12 +61,6 @@ final class StageCreateTest extends ApiTestCase
         /** @var ComputationTrackerInterface $tracker */
         $tracker = $container->get(ComputationTrackerInterface::class);
         $tracker->initializeComputations($tripId, ComputationName::cases());
-    }
-
-    #[\Override]
-    public static function setUpBeforeClass(): void
-    {
-        self::$alwaysBootKernel = false;
     }
 
     #[Test]

--- a/api/tests/Functional/StageDeleteTest.php
+++ b/api/tests/Functional/StageDeleteTest.php
@@ -16,9 +16,14 @@ use App\Repository\TripRequestRepositoryInterface;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
 
+#[ResetDatabase]
 final class StageDeleteTest extends ApiTestCase
 {
+    use Factories;
+
     private const string TRIP_ID = '01936f6e-0000-7000-8000-000000000040';
 
     private function seedTripWithStages(string $tripId, int $stageCount = 4, string $sourceType = SourceType::KOMOOT_TOUR->value): void
@@ -57,12 +62,6 @@ final class StageDeleteTest extends ApiTestCase
         /** @var ComputationTrackerInterface $tracker */
         $tracker = $container->get(ComputationTrackerInterface::class);
         $tracker->initializeComputations($tripId, ComputationName::cases());
-    }
-
-    #[\Override]
-    public static function setUpBeforeClass(): void
-    {
-        self::$alwaysBootKernel = false;
     }
 
     #[Test]

--- a/api/tests/Functional/StageMoveTest.php
+++ b/api/tests/Functional/StageMoveTest.php
@@ -16,9 +16,14 @@ use App\Repository\TripRequestRepositoryInterface;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
 
+#[ResetDatabase]
 final class StageMoveTest extends ApiTestCase
 {
+    use Factories;
+
     private const string TRIP_ID = '01936f6e-0000-7000-8000-000000000030';
 
     private function seedTripWithStages(string $tripId, int $stageCount = 4): void
@@ -57,12 +62,6 @@ final class StageMoveTest extends ApiTestCase
         /** @var ComputationTrackerInterface $tracker */
         $tracker = $container->get(ComputationTrackerInterface::class);
         $tracker->initializeComputations($tripId, ComputationName::cases());
-    }
-
-    #[\Override]
-    public static function setUpBeforeClass(): void
-    {
-        self::$alwaysBootKernel = false;
     }
 
     #[Test]

--- a/api/tests/Functional/StageSelectAccommodationTest.php
+++ b/api/tests/Functional/StageSelectAccommodationTest.php
@@ -20,9 +20,14 @@ use App\Repository\TripRequestRepositoryInterface;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
 
+#[ResetDatabase]
 final class StageSelectAccommodationTest extends ApiTestCase
 {
+    use Factories;
+
     private const string TRIP_ID = '01936f6e-0000-7000-8000-000000000039';
 
     private function seedTripWithStages(string $tripId): void
@@ -73,12 +78,6 @@ final class StageSelectAccommodationTest extends ApiTestCase
         /** @var ComputationTrackerInterface $tracker */
         $tracker = $container->get(ComputationTrackerInterface::class);
         $tracker->initializeComputations($tripId, ComputationName::cases());
-    }
-
-    #[\Override]
-    public static function setUpBeforeClass(): void
-    {
-        self::$alwaysBootKernel = false;
     }
 
     #[Test]

--- a/api/tests/Functional/StageUpdateTest.php
+++ b/api/tests/Functional/StageUpdateTest.php
@@ -16,9 +16,14 @@ use App\Repository\TripRequestRepositoryInterface;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
 
+#[ResetDatabase]
 final class StageUpdateTest extends ApiTestCase
 {
+    use Factories;
+
     private const string TRIP_ID = '01936f6e-0000-7000-8000-000000000020';
 
     private function seedTripWithStages(string $tripId, int $stageCount = 3): void
@@ -57,12 +62,6 @@ final class StageUpdateTest extends ApiTestCase
         /** @var ComputationTrackerInterface $tracker */
         $tracker = $container->get(ComputationTrackerInterface::class);
         $tracker->initializeComputations($tripId, ComputationName::cases());
-    }
-
-    #[\Override]
-    public static function setUpBeforeClass(): void
-    {
-        self::$alwaysBootKernel = false;
     }
 
     #[Test]

--- a/api/tests/Functional/TripUpdateTest.php
+++ b/api/tests/Functional/TripUpdateTest.php
@@ -17,9 +17,14 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
 
+#[ResetDatabase]
 final class TripUpdateTest extends ApiTestCase
 {
+    use Factories;
+
     private const string TRIP_ID = '01936f6e-0000-7000-8000-000000000001';
 
     private function seedTrip(
@@ -50,12 +55,6 @@ final class TripUpdateTest extends ApiTestCase
         /** @var IdempotencyCheckerInterface $idempotencyChecker */
         $idempotencyChecker = $container->get(IdempotencyCheckerInterface::class);
         $idempotencyChecker->saveHash($tripId, $request);
-    }
-
-    #[\Override]
-    public static function setUpBeforeClass(): void
-    {
-        self::$alwaysBootKernel = false;
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

- Configure Foundry ORM reset mode to `migrate` so `doctrine:migrations:migrate` runs before each test class
- Add `ResetDatabase` + `Factories` traits to all 6 functional tests that access the database (`StageCreateTest`, `StageDeleteTest`, `StageMoveTest`, `StageSelectAccommodationTest`, `StageUpdateTest`, `TripUpdateTest`)

Without this, functional tests that call `DoctrineTripRequestRepository::initializeTrip()` fail in CI because the database schema is never created.

## Test plan

- [ ] `make test-php` passes locally
- [ ] CI PHPUnit (api) passes with the PostgreSQL + Redis services

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

Clean, focused fix. The CI service configuration (PostgreSQL + Redis), Foundry `migrate` reset mode, and `ResetDatabase`/`Factories` traits on all 6 functional test classes are correct and consistent with the project architecture. Verified that the `dbname_suffix: '_test'` in `doctrine.php` intentionally resolves `DATABASE_URL` base name `app` → `app_test`, which correctly matches `POSTGRES_DB: app_test` in the CI service definition.

**Findings:** 0 critical · 0 warning · 0 info

**Commit reviewed:** `c2c202348346ffb8b78117fd5aff1f5acf2b54c9`

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

No inline comments. No previously open threads to resolve.

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->