### PR TITLE
perf(scraping): reduce accommodation scraping timeouts

### DIFF
--- a/api/src/MessageHandler/ScanAccommodationsHandler.php
+++ b/api/src/MessageHandler/ScanAccommodationsHandler.php
@@ -302,7 +302,7 @@ final readonly class ScanAccommodationsHandler extends AbstractTripMessageHandle
         $mainResponses = [];
         foreach ($scrapableItems as $key => $item) {
             try {
-                $mainResponses[$key] = $this->scraperClient->request('GET', $item['url'], ['timeout' => 5]);
+                $mainResponses[$key] = $this->scraperClient->request('GET', $item['url'], ['timeout' => 3]);
             } catch (\Throwable) {
                 // Skip malformed URLs
             }
@@ -360,7 +360,7 @@ final readonly class ScanAccommodationsHandler extends AbstractTripMessageHandle
                     $priceResponses[] = [
                         'stageIdx' => $item['stageIdx'],
                         'candidateIdx' => $item['candidateIdx'],
-                        'response' => $this->scraperClient->request('GET', $pricePageUrl, ['timeout' => 3]),
+                        'response' => $this->scraperClient->request('GET', $pricePageUrl, ['timeout' => 2]),
                     ];
                 } catch (\Throwable) {
                     // Skip malformed URLs

--- a/api/tests/Unit/MessageHandler/ScanAccommodationsHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/ScanAccommodationsHandlerTest.php
@@ -24,7 +24,9 @@ use App\Scanner\ScannerInterface;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\Exception\TimeoutException;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 final class ScanAccommodationsHandlerTest extends TestCase
@@ -48,6 +50,7 @@ final class ScanAccommodationsHandlerTest extends TestCase
         QueryBuilderInterface $queryBuilder,
         GeoDistanceInterface $haversine,
         GeometryDistributorInterface $distributor,
+        ?HttpClientInterface $scraperClient = null,
     ): ScanAccommodationsHandler {
         $computationTracker = $this->createStub(ComputationTrackerInterface::class);
         $computationTracker->method('isAllComplete')->willReturn(false);
@@ -64,7 +67,7 @@ final class ScanAccommodationsHandlerTest extends TestCase
             static fn (string $id, array $params): string => $id.': '.json_encode($params),
         );
 
-        $scraperClient = $this->createStub(HttpClientInterface::class);
+        $scraperClient ??= $this->createStub(HttpClientInterface::class);
 
         $generationTracker = $this->createStub(TripGenerationTrackerInterface::class);
 
@@ -442,5 +445,192 @@ final class ScanAccommodationsHandlerTest extends TestCase
 
         // Stage accommodations must contain both entries after the expand scan
         $this->assertCount(2, $stage->accommodations);
+    }
+
+    #[Test]
+    public function scraperClientUsesThreeSecondTimeoutForWaveOne(): void
+    {
+        $stage = $this->createStage('trip-timeout', 48.5, 2.5);
+
+        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
+        $tripStateManager->method('getStages')->willReturn([$stage]);
+        $tripStateManager->method('getLocale')->willReturn('en');
+        $tripStateManager->method('getRequest')->willReturn(null);
+
+        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
+        $queryBuilder->method('buildAccommodationQuery')->willReturn('query');
+
+        $scanner = $this->createStub(ScannerInterface::class);
+        $scanner->method('query')->willReturn([
+            'elements' => [
+                ['lat' => 48.6, 'lon' => 2.6, 'tags' => ['tourism' => 'hotel', 'name' => 'Hotel Test', 'website' => 'https://example.com']],
+            ],
+        ]);
+
+        $distributor = $this->createStub(GeometryDistributorInterface::class);
+        $distributor->method('distributeByEndpoint')->willReturn([
+            0 => [['name' => 'Hotel Test', 'type' => 'hotel', 'lat' => 48.6, 'lon' => 2.6,
+                'priceMin' => 50.0, 'priceMax' => 100.0, 'isExact' => false,
+                'url' => 'https://example.com', 'tagCount' => 3, 'hasWebsite' => true,
+                'tags' => ['tourism' => 'hotel', 'name' => 'Hotel Test', 'website' => 'https://example.com']]],
+        ]);
+
+        $haversine = $this->createStub(GeoDistanceInterface::class);
+        $haversine->method('inKilometers')->willReturn(1.0);
+
+        $scraperClient = $this->createMock(HttpClientInterface::class);
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getContent')->willReturn('<html></html>');
+
+        $scraperClient->expects($this->once())
+            ->method('request')
+            ->with('GET', 'https://example.com', ['timeout' => 3])
+            ->willReturn($response);
+
+        $publisher = $this->createStub(TripUpdatePublisherInterface::class);
+
+        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine, $distributor, $scraperClient);
+        $handler(new ScanAccommodations('trip-timeout'));
+    }
+
+    #[Test]
+    public function wave1TimeoutPreservesOsmDataAndDoesNotThrow(): void
+    {
+        $stage = $this->createStage('trip-fallback', 48.5, 2.5);
+
+        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
+        $tripStateManager->method('getStages')->willReturn([$stage]);
+        $tripStateManager->method('getLocale')->willReturn('en');
+        $tripStateManager->method('getRequest')->willReturn(null);
+
+        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
+        $queryBuilder->method('buildAccommodationQuery')->willReturn('query');
+
+        $scanner = $this->createStub(ScannerInterface::class);
+        $scanner->method('query')->willReturn([
+            'elements' => [
+                ['lat' => 48.6, 'lon' => 2.6, 'tags' => ['tourism' => 'hotel', 'name' => 'Hotel Timeout', 'website' => 'https://slow-site.example.com']],
+            ],
+        ]);
+
+        $distributor = $this->createStub(GeometryDistributorInterface::class);
+        $distributor->method('distributeByEndpoint')->willReturn([
+            0 => [['name' => 'Hotel Timeout', 'type' => 'hotel', 'lat' => 48.6, 'lon' => 2.6,
+                'priceMin' => 50.0, 'priceMax' => 100.0, 'isExact' => false,
+                'url' => 'https://slow-site.example.com', 'tagCount' => 3, 'hasWebsite' => true,
+                'tags' => ['tourism' => 'hotel', 'name' => 'Hotel Timeout', 'website' => 'https://slow-site.example.com']]],
+        ]);
+
+        $haversine = $this->createStub(GeoDistanceInterface::class);
+        $haversine->method('inKilometers')->willReturn(2.5);
+
+        // Simulate a timeout: request succeeds (non-blocking) but getContent() throws
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getContent')->willThrowException(new TimeoutException('Idle timeout reached'));
+
+        $scraperClient = $this->createStub(HttpClientInterface::class);
+        $scraperClient->method('request')->willReturn($response);
+
+        $publisher = $this->createMock(TripUpdatePublisherInterface::class);
+        $publisher->expects($this->once())
+            ->method('publish')
+            ->with(
+                'trip-fallback',
+                MercureEventType::ACCOMMODATIONS_FOUND,
+                $this->callback(static function (array $data): bool {
+                    $accommodations = $data['accommodations'];
+
+                    // Accommodation must still be present with its original OSM data
+                    return 1 === \count($accommodations)
+                        && 'Hotel Timeout' === $accommodations[0]['name']
+                        && 'hotel' === $accommodations[0]['type']
+                        && 48.6 === $accommodations[0]['lat']
+                        && 2.6 === $accommodations[0]['lon']
+                        && 50.0 === $accommodations[0]['estimatedPriceMin']
+                        && 100.0 === $accommodations[0]['estimatedPriceMax']
+                        && false === $accommodations[0]['isExactPrice']
+                        && 'https://slow-site.example.com' === $accommodations[0]['url'];
+                }),
+            );
+
+        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine, $distributor, $scraperClient);
+        $handler(new ScanAccommodations('trip-fallback'));
+
+        // Accommodation is still added to the stage despite scraping failure
+        $this->assertCount(1, $stage->accommodations);
+        $this->assertSame('Hotel Timeout', $stage->accommodations[0]->name);
+        $this->assertFalse($stage->accommodations[0]->possibleClosed);
+    }
+
+    #[Test]
+    public function wave2TimeoutPreservesHeuristicPriceAndDoesNotThrow(): void
+    {
+        $stage = $this->createStage('trip-wave2', 48.5, 2.5);
+
+        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
+        $tripStateManager->method('getStages')->willReturn([$stage]);
+        $tripStateManager->method('getLocale')->willReturn('en');
+        $tripStateManager->method('getRequest')->willReturn(null);
+
+        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
+        $queryBuilder->method('buildAccommodationQuery')->willReturn('query');
+
+        $scanner = $this->createStub(ScannerInterface::class);
+        $scanner->method('query')->willReturn([
+            'elements' => [
+                ['lat' => 48.6, 'lon' => 2.6, 'tags' => ['tourism' => 'hotel', 'name' => 'Hotel Wave2', 'website' => 'https://wave2.example.com']],
+            ],
+        ]);
+
+        $distributor = $this->createStub(GeometryDistributorInterface::class);
+        $distributor->method('distributeByEndpoint')->willReturn([
+            0 => [['name' => 'Hotel Wave2', 'type' => 'hotel', 'lat' => 48.6, 'lon' => 2.6,
+                'priceMin' => 50.0, 'priceMax' => 100.0, 'isExact' => false,
+                'url' => 'https://wave2.example.com', 'tagCount' => 3, 'hasWebsite' => true,
+                'tags' => ['tourism' => 'hotel', 'name' => 'Hotel Wave2', 'website' => 'https://wave2.example.com']]],
+        ]);
+
+        $haversine = $this->createStub(GeoDistanceInterface::class);
+        $haversine->method('inKilometers')->willReturn(1.5);
+
+        // Wave 1: return HTML with no price (triggers wave 2)
+        $wave1Response = $this->createStub(ResponseInterface::class);
+        $wave1Response->method('getContent')->willReturn('<html><body><h1>Hotel Wave2</h1></body></html>');
+
+        // Wave 2: timeout on price page
+        $wave2Response = $this->createStub(ResponseInterface::class);
+        $wave2Response->method('getContent')->willThrowException(new TimeoutException('Idle timeout reached'));
+
+        $scraperClient = $this->createStub(HttpClientInterface::class);
+        $callCount = 0;
+        $scraperClient->method('request')->willReturnCallback(
+            function () use (&$callCount, $wave1Response, $wave2Response): ResponseInterface {
+                return 0 === $callCount++ ? $wave1Response : $wave2Response;
+            },
+        );
+
+        $publisher = $this->createMock(TripUpdatePublisherInterface::class);
+        $publisher->expects($this->once())
+            ->method('publish')
+            ->with(
+                'trip-wave2',
+                MercureEventType::ACCOMMODATIONS_FOUND,
+                $this->callback(static function (array $data): bool {
+                    $accommodations = $data['accommodations'];
+
+                    // Accommodation retains heuristic price (wave 2 failed)
+                    return 1 === \count($accommodations)
+                        && 'Hotel Wave2' === $accommodations[0]['name']
+                        && 50.0 === $accommodations[0]['estimatedPriceMin']
+                        && 100.0 === $accommodations[0]['estimatedPriceMax']
+                        && false === $accommodations[0]['isExactPrice'];
+                }),
+            );
+
+        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine, $distributor, $scraperClient);
+        $handler(new ScanAccommodations('trip-wave2'));
+
+        $this->assertCount(1, $stage->accommodations);
+        $this->assertFalse($stage->accommodations[0]->isExactPrice);
     }
 }

--- a/api/tests/Unit/MessageHandler/ScanAccommodationsHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/ScanAccommodationsHandlerTest.php
@@ -656,9 +656,9 @@ final class ScanAccommodationsHandlerTest extends TestCase
         $haversine = $this->createStub(GeoDistanceInterface::class);
         $haversine->method('inKilometers')->willReturn(1.5);
 
-        // Wave 1: return HTML with no price (triggers wave 2)
+        // Wave 1: return HTML with price-page link (triggers wave 2)
         $wave1Response = $this->createStub(ResponseInterface::class);
-        $wave1Response->method('getContent')->willReturn('<html><body><h1>Hotel Wave2</h1></body></html>');
+        $wave1Response->method('getContent')->willReturn('<html><body><a href="https://wave2.example.com/tarifs">Tarifs</a></body></html>');
 
         // Wave 2: timeout on price page
         $wave2Response = $this->createStub(ResponseInterface::class);

--- a/api/tests/Unit/MessageHandler/ScanAccommodationsHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/ScanAccommodationsHandlerTest.php
@@ -563,6 +563,69 @@ final class ScanAccommodationsHandlerTest extends TestCase
     }
 
     #[Test]
+    public function scraperClientUsesTwoSecondTimeoutForWaveTwo(): void
+    {
+        $stage = $this->createStage('trip-timeout2', 48.5, 2.5);
+
+        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
+        $tripStateManager->method('getStages')->willReturn([$stage]);
+        $tripStateManager->method('getLocale')->willReturn('en');
+        $tripStateManager->method('getRequest')->willReturn(null);
+
+        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
+        $queryBuilder->method('buildAccommodationQuery')->willReturn('query');
+
+        $scanner = $this->createStub(ScannerInterface::class);
+        $scanner->method('query')->willReturn([
+            'elements' => [
+                ['lat' => 48.6, 'lon' => 2.6, 'tags' => ['tourism' => 'hotel', 'name' => 'Hotel Test', 'website' => 'https://example.com']],
+            ],
+        ]);
+
+        $distributor = $this->createStub(GeometryDistributorInterface::class);
+        $distributor->method('distributeByEndpoint')->willReturn([
+            0 => [['name' => 'Hotel Test', 'type' => 'hotel', 'lat' => 48.6, 'lon' => 2.6,
+                'priceMin' => 50.0, 'priceMax' => 100.0, 'isExact' => false,
+                'url' => 'https://example.com', 'tagCount' => 3, 'hasWebsite' => true,
+                'tags' => ['tourism' => 'hotel', 'name' => 'Hotel Test', 'website' => 'https://example.com']]],
+        ]);
+
+        $haversine = $this->createStub(GeoDistanceInterface::class);
+        $haversine->method('inKilometers')->willReturn(1.0);
+
+        // Wave 1: return HTML with no price but with a price-page link (triggers wave 2)
+        $wave1Response = $this->createStub(ResponseInterface::class);
+        $wave1Response->method('getContent')->willReturn('<html><body><a href="https://example.com/tarifs">Tarifs</a></body></html>');
+
+        // Wave 2: return simple HTML
+        $wave2Response = $this->createStub(ResponseInterface::class);
+        $wave2Response->method('getContent')->willReturn('<html><body>65€ per night</body></html>');
+
+        $scraperClient = $this->createMock(HttpClientInterface::class);
+        $scraperClient->expects($this->exactly(2))
+            ->method('request')
+            ->willReturnCallback(
+                function (string $method, string $url, array $options) use ($wave1Response, $wave2Response): ResponseInterface {
+                    if ('https://example.com' === $url) {
+                        $this->assertSame(['timeout' => 3], $options);
+
+                        return $wave1Response;
+                    }
+
+                    $this->assertSame('https://example.com/tarifs', $url);
+                    $this->assertSame(['timeout' => 2], $options);
+
+                    return $wave2Response;
+                },
+            );
+
+        $publisher = $this->createStub(TripUpdatePublisherInterface::class);
+
+        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine, $distributor, $scraperClient);
+        $handler(new ScanAccommodations('trip-timeout2'));
+    }
+
+    #[Test]
     public function wave2TimeoutPreservesHeuristicPriceAndDoesNotThrow(): void
     {
         $stage = $this->createStage('trip-wave2', 48.5, 2.5);

--- a/pwa/src/store/trip-store.ts
+++ b/pwa/src/store/trip-store.ts
@@ -467,7 +467,11 @@ export const useTripStore = create<TripState>()(
     loadFromSavedTrip: (trip) => {
       useTripTemporalStore.getState().clear();
       set((state) => {
-        state.trip = { id: trip.id, title: trip.title, sourceUrl: trip.sourceUrl };
+        state.trip = {
+          id: trip.id,
+          title: trip.title,
+          sourceUrl: trip.sourceUrl,
+        };
         state.startDate = trip.startDate;
         state.endDate = trip.endDate;
         state.fatigueFactor = trip.fatigueFactor;

--- a/pwa/tests/recette/steps/accommodations.steps.ts
+++ b/pwa/tests/recette/steps/accommodations.steps.ts
@@ -10,7 +10,7 @@ import { getCurrentRecettePage } from "../support/current-recette-page";
 
 function getAccommodationTextAlias(text: string): string {
   const aliases: Record<string, string> = {
-    "Hôtel": "Hotel",
+    Hôtel: "Hotel",
     "Ajouter un hébergement": "Add accommodation",
   };
 
@@ -323,33 +323,30 @@ When(
   },
 );
 
-When(
-  "an accommodation is exactly at the endpoint",
-  async () => {
-    await injectSseSequence(getCurrentRecettePage(), [
-      {
-        type: "accommodations_found",
-        data: {
-          stageIndex: 0,
-          searchRadiusKm: 5,
-          accommodations: [
-            {
-              name: "Gîte du Terminus",
-              type: "guest_house",
-              lat: 44.532,
-              lon: 4.392,
-              estimatedPriceMin: 45,
-              estimatedPriceMax: 60,
-              isExactPrice: false,
-              possibleClosed: false,
-              distanceToEndPoint: 0,
-            },
-          ],
-        },
+When("an accommodation is exactly at the endpoint", async () => {
+  await injectSseSequence(getCurrentRecettePage(), [
+    {
+      type: "accommodations_found",
+      data: {
+        stageIndex: 0,
+        searchRadiusKm: 5,
+        accommodations: [
+          {
+            name: "Gîte du Terminus",
+            type: "guest_house",
+            lat: 44.532,
+            lon: 4.392,
+            estimatedPriceMin: 45,
+            estimatedPriceMax: 60,
+            isExactPrice: false,
+            possibleClosed: false,
+            distanceToEndPoint: 0,
+          },
+        ],
       },
-    ]);
-  },
-);
+    },
+  ]);
+});
 
 Then(
   "aucun badge de distance n'est affiché pour cet hébergement",
@@ -363,13 +360,13 @@ Then(
   },
 );
 
-Then(
-  "no distance badge is displayed for that accommodation",
-  async () => {
-    const stageCard = getCurrentRecettePage().getByTestId("stage-card-1");
-    await expect(stageCard).toContainText(/Gîte du Terminus|Terminus Guest House/, {
+Then("no distance badge is displayed for that accommodation", async () => {
+  const stageCard = getCurrentRecettePage().getByTestId("stage-card-1");
+  await expect(stageCard).toContainText(
+    /Gîte du Terminus|Terminus Guest House/,
+    {
       timeout: 5000,
-    });
-    await expect(stageCard.locator('[aria-label*="0 km"]')).toHaveCount(0);
-  },
-);
+    },
+  );
+  await expect(stageCard.locator('[aria-label*="0 km"]')).toHaveCount(0);
+});

--- a/pwa/tests/recette/steps/configuration.steps.ts
+++ b/pwa/tests/recette/steps/configuration.steps.ts
@@ -6,11 +6,13 @@ import { When, Then } from "../support/fixtures";
 // ---------------------------------------------------------------------------
 
 const SETTINGS_BUTTON_NAME = /Ouvrir les paramètres|Open settings/i;
-const SPEED_SLIDER_NAME = /Vitesse moyenne \(km\/h\)|Average cycling speed \(km\/h\)/i;
+const SPEED_SLIDER_NAME =
+  /Vitesse moyenne \(km\/h\)|Average cycling speed \(km\/h\)/i;
 const MAX_DISTANCE_SLIDER_NAME =
   /Distance maximale par jour \(km\)|Maximum distance per day \(km\)/i;
 const EBIKE_SWITCH_NAME = /Mode VAE|E-bike mode/i;
-const DEPARTURE_SLIDER_NAME = /Heure de départ \(0-23\)|Departure hour \(0-23\)/i;
+const DEPARTURE_SLIDER_NAME =
+  /Heure de départ \(0-23\)|Departure hour \(0-23\)/i;
 const ACCOMMODATION_SECTION_HEADING =
   /Types d'hébergements|Accommodation types/i;
 
@@ -95,12 +97,9 @@ Then(
   },
 );
 
-Then(
-  "the last switch is disabled and cannot be toggled",
-  async ({ $test }) => {
-    $test.fixme();
-  },
-);
+Then("the last switch is disabled and cannot be toggled", async ({ $test }) => {
+  $test.fixme();
+});
 
 // --- Additional missing steps ---
 // "je suis sur la page du voyage avec les étapes calculées" / "I am on the trip page with computed stages" defined in common.steps.ts
@@ -178,12 +177,16 @@ Then(
 );
 
 When("j'active le mode e-bike", async ({ mockedPage }) => {
-  const ebikeToggle = mockedPage.getByRole("switch", { name: EBIKE_SWITCH_NAME });
+  const ebikeToggle = mockedPage.getByRole("switch", {
+    name: EBIKE_SWITCH_NAME,
+  });
   await ebikeToggle.click();
 });
 
 When("I enable e-bike mode", async ({ mockedPage }) => {
-  const ebikeToggle = mockedPage.getByRole("switch", { name: EBIKE_SWITCH_NAME });
+  const ebikeToggle = mockedPage.getByRole("switch", {
+    name: EBIKE_SWITCH_NAME,
+  });
   await ebikeToggle.click();
 });
 

--- a/pwa/tests/recette/steps/cross-cutting-ux.steps.ts
+++ b/pwa/tests/recette/steps/cross-cutting-ux.steps.ts
@@ -420,12 +420,9 @@ Then(
   },
 );
 
-Then(
-  "un toast de confirmation s'affiche brièvement",
-  async ({ $test }) => {
-    $test.fixme();
-  },
-);
+Then("un toast de confirmation s'affiche brièvement", async ({ $test }) => {
+  $test.fixme();
+});
 
 Then(
   "un message d'erreur compréhensible est affiché à l'utilisateur",

--- a/pwa/tests/recette/steps/dates-calendar.steps.ts
+++ b/pwa/tests/recette/steps/dates-calendar.steps.ts
@@ -103,7 +103,10 @@ async function selectCalendarDate(
     'button[aria-label*="suivant"], button[aria-label*="next"], button[aria-label*="Next"]',
   );
   for (let i = 0; i < 24; i++) {
-    const header = mockedPage.locator('[class*="font-semibold"]').filter({ hasText: /\d{4}/ }).first();
+    const header = mockedPage
+      .locator('[class*="font-semibold"]')
+      .filter({ hasText: /\d{4}/ })
+      .first();
     const headerText = await header.textContent();
     if (!headerText) {
       await nextButton.first().click();
@@ -376,12 +379,9 @@ When("I navigate to the next month", async ({ mockedPage }) => {
 
 // --- Then steps FR ---
 
-Then(
-  "la date de départ affichée est {string}",
-  async ({ $test }) => {
-    $test.fixme();
-  },
-);
+Then("la date de départ affichée est {string}", async ({ $test }) => {
+  $test.fixme();
+});
 
 Then(/^l'étape (\d+) est prévue le \d+ \w+ \d+$/, async ({ mockedPage }) => {
   // Stage cards show sunrise/sunset times when a start date is set,
@@ -428,12 +428,9 @@ Then("le mois suivant est affiché", async ({ mockedPage }) => {
 
 // --- Then steps EN ---
 
-Then(
-  "the displayed departure date is {string}",
-  async ({ $test }) => {
-    $test.fixme();
-  },
-);
+Then("the displayed departure date is {string}", async ({ $test }) => {
+  $test.fixme();
+});
 
 Then(/^stage (\d+) is scheduled for \w+ \d+, \d+$/, async ({ mockedPage }) => {
   const stageCards = mockedPage.locator('[data-testid^="stage-card-"]');

--- a/pwa/tests/recette/steps/export.steps.ts
+++ b/pwa/tests/recette/steps/export.steps.ts
@@ -73,13 +73,10 @@ When(
   },
 );
 
-When(
-  "le calcul des étapes est en cours",
-  async ({ $test }) => {
-    // The current UI does not disable FIT downloads based on computation state alone.
-    $test.fixme();
-  },
-);
+When("le calcul des étapes est en cours", async ({ $test }) => {
+  // The current UI does not disable FIT downloads based on computation state alone.
+  $test.fixme();
+});
 
 When(
   "je clique sur le bouton export de format {string} de l'étape {int}",
@@ -96,18 +93,15 @@ When(
 
 // --- When steps EN ---
 
-When(
-  'I click "Download GPX" for stage {int}',
-  async ({}, stage: number) => {
-    const page = getCurrentRecettePage();
-    await trackStageGpxDownload(page);
-    const stageCard = page.getByTestId(`stage-card-${stage}`);
-    const gpxButton = stageCard.getByRole("button", {
-      name: /Download GPX/,
-    });
-    await gpxButton.click();
-  },
-);
+When('I click "Download GPX" for stage {int}', async ({}, stage: number) => {
+  const page = getCurrentRecettePage();
+  await trackStageGpxDownload(page);
+  const stageCard = page.getByTestId(`stage-card-${stage}`);
+  const gpxButton = stageCard.getByRole("button", {
+    name: /Download GPX/,
+  });
+  await gpxButton.click();
+});
 
 When("I select a valid GPX file", async ({ $test }) => {
   // $test.fixme: file upload requires a real GPX file fixture — part of @fixme scenario
@@ -119,26 +113,20 @@ When("I try to import a non-GPX file", async ({ $test }) => {
   $test.fixme();
 });
 
-When(
-  'I click "Download FIT" for stage {int}',
-  async ({}, stage: number) => {
-    const page = getCurrentRecettePage();
-    await trackStageFitDownload(page);
-    const stageCard = page.getByTestId(`stage-card-${stage}`);
-    const fitButton = stageCard.getByRole("button", {
-      name: /Download FIT/,
-    });
-    await fitButton.click();
-  },
-);
+When('I click "Download FIT" for stage {int}', async ({}, stage: number) => {
+  const page = getCurrentRecettePage();
+  await trackStageFitDownload(page);
+  const stageCard = page.getByTestId(`stage-card-${stage}`);
+  const fitButton = stageCard.getByRole("button", {
+    name: /Download FIT/,
+  });
+  await fitButton.click();
+});
 
-When(
-  "stage computation is in progress",
-  async ({ $test }) => {
-    // The current UI does not disable FIT downloads based on computation state alone.
-    $test.fixme();
-  },
-);
+When("stage computation is in progress", async ({ $test }) => {
+  // The current UI does not disable FIT downloads based on computation state alone.
+  $test.fixme();
+});
 
 When(
   "I click the export button for format {string} on stage {int}",
@@ -190,16 +178,13 @@ Then(
   },
 );
 
-Then(
-  /^une requête GET vers \/trips\/\*\.gpx est envoyée$/,
-  async () => {
-    const tripGpxRequests = getTrackedTripGpxRequests();
-    await expect
-      .poll(() => tripGpxRequests.length, { timeout: 5000 })
-      .toBeGreaterThan(0);
-    expect(tripGpxRequests[0]).toMatch(/\/trips\/[^/]+\.gpx$/);
-  },
-);
+Then(/^une requête GET vers \/trips\/\*\.gpx est envoyée$/, async () => {
+  const tripGpxRequests = getTrackedTripGpxRequests();
+  await expect
+    .poll(() => tripGpxRequests.length, { timeout: 5000 })
+    .toBeGreaterThan(0);
+  expect(tripGpxRequests[0]).toMatch(/\/trips\/[^/]+\.gpx$/);
+});
 
 Then("le voyage est créé à partir du fichier GPX", async ({ $test }) => {
   // $test.fixme: part of @fixme scenario (GPX file upload not yet testable)
@@ -261,16 +246,13 @@ Then(
   },
 );
 
-Then(
-  /^a GET request to \/trips\/\*\/stages\/0\.gpx is sent$/,
-  async () => {
-    const gpxRequests = getTrackedStageGpxRequests();
-    await expect
-      .poll(() => gpxRequests.length, { timeout: 5000 })
-      .toBeGreaterThan(0);
-    expect(gpxRequests[0]).toContain("/stages/0.gpx");
-  },
-);
+Then(/^a GET request to \/trips\/\*\/stages\/0\.gpx is sent$/, async () => {
+  const gpxRequests = getTrackedStageGpxRequests();
+  await expect
+    .poll(() => gpxRequests.length, { timeout: 5000 })
+    .toBeGreaterThan(0);
+  expect(gpxRequests[0]).toContain("/stages/0.gpx");
+});
 
 Then(
   'the "Télécharger le GPX complet" button is visible and enabled',
@@ -305,16 +287,13 @@ Then("an error message is displayed", async ({ mockedPage }) => {
   ).toBeVisible({ timeout: 5000 });
 });
 
-Then(
-  /^a GET request to \/trips\/\*\/stages\/0\.fit is sent$/,
-  async () => {
-    const fitRequests = getTrackedStageFitRequests();
-    await expect
-      .poll(() => fitRequests.length, { timeout: 5000 })
-      .toBeGreaterThan(0);
-    expect(fitRequests[0]).toContain("/stages/0.fit");
-  },
-);
+Then(/^a GET request to \/trips\/\*\/stages\/0\.fit is sent$/, async () => {
+  const fitRequests = getTrackedStageFitRequests();
+  await expect
+    .poll(() => fitRequests.length, { timeout: 5000 })
+    .toBeGreaterThan(0);
+  expect(fitRequests[0]).toContain("/stages/0.fit");
+});
 
 Then(
   "the FIT button for stage {int} is disabled",
@@ -328,14 +307,11 @@ Then(
   },
 );
 
-Then(
-  "the downloaded file has extension {string}",
-  async ({}, ext: string) => {
-    const downloadRequests = getTrackedStageExportRequests();
-    const normalizedExt = ext.replace(/^\./, "");
-    await expect
-      .poll(() => downloadRequests.length, { timeout: 5000 })
-      .toBeGreaterThan(0);
-    expect(downloadRequests[0]).toContain(`.${normalizedExt}`);
-  },
-);
+Then("the downloaded file has extension {string}", async ({}, ext: string) => {
+  const downloadRequests = getTrackedStageExportRequests();
+  const normalizedExt = ext.replace(/^\./, "");
+  await expect
+    .poll(() => downloadRequests.length, { timeout: 5000 })
+    .toBeGreaterThan(0);
+  expect(downloadRequests[0]).toContain(`.${normalizedExt}`);
+});

--- a/pwa/tests/recette/steps/weather-time.steps.ts
+++ b/pwa/tests/recette/steps/weather-time.steps.ts
@@ -13,7 +13,8 @@ import type { MercureEvent } from "../../../src/lib/mercure/types";
 
 const SETTINGS_BUTTON_NAME = /Ouvrir les paramètres|Open settings/i;
 const SETTINGS_DIALOG_NAME = /Paramètres|Settings/i;
-const SPEED_SLIDER_NAME = /Vitesse moyenne \(km\/h\)|Average cycling speed \(km\/h\)/i;
+const SPEED_SLIDER_NAME =
+  /Vitesse moyenne \(km\/h\)|Average cycling speed \(km\/h\)/i;
 const FATIGUE_SLIDER_NAME =
   /Indice de fatigue accumulée|Accumulated fatigue index/i;
 const EBIKE_SWITCH_NAME = /Mode VAE|E-bike mode/i;
@@ -102,9 +103,7 @@ When(
 );
 
 When("le facteur de fatigue est activé", async ({ mockedPage }) => {
-  await mockedPage
-    .getByRole("button", { name: SETTINGS_BUTTON_NAME })
-    .click();
+  await mockedPage.getByRole("button", { name: SETTINGS_BUTTON_NAME }).click();
   await expect(
     mockedPage.getByRole("dialog", { name: SETTINGS_DIALOG_NAME }),
   ).toBeInViewport();
@@ -115,13 +114,13 @@ When("le facteur de fatigue est activé", async ({ mockedPage }) => {
 });
 
 When("le mode e-bike est activé", async ({ mockedPage }) => {
-  await mockedPage
-    .getByRole("button", { name: SETTINGS_BUTTON_NAME })
-    .click();
+  await mockedPage.getByRole("button", { name: SETTINGS_BUTTON_NAME }).click();
   await expect(
     mockedPage.getByRole("dialog", { name: SETTINGS_DIALOG_NAME }),
   ).toBeInViewport();
-  const ebikeToggle = mockedPage.getByRole("switch", { name: EBIKE_SWITCH_NAME });
+  const ebikeToggle = mockedPage.getByRole("switch", {
+    name: EBIKE_SWITCH_NAME,
+  });
   await ebikeToggle.click();
 });
 
@@ -208,9 +207,7 @@ When(
 );
 
 When("the fatigue factor is enabled", async ({ mockedPage }) => {
-  await mockedPage
-    .getByRole("button", { name: SETTINGS_BUTTON_NAME })
-    .click();
+  await mockedPage.getByRole("button", { name: SETTINGS_BUTTON_NAME }).click();
   await expect(
     mockedPage.getByRole("dialog", { name: SETTINGS_DIALOG_NAME }),
   ).toBeInViewport();
@@ -221,13 +218,13 @@ When("the fatigue factor is enabled", async ({ mockedPage }) => {
 });
 
 When("e-bike mode is enabled", async ({ mockedPage }) => {
-  await mockedPage
-    .getByRole("button", { name: SETTINGS_BUTTON_NAME })
-    .click();
+  await mockedPage.getByRole("button", { name: SETTINGS_BUTTON_NAME }).click();
   await expect(
     mockedPage.getByRole("dialog", { name: SETTINGS_DIALOG_NAME }),
   ).toBeInViewport();
-  const ebikeToggle = mockedPage.getByRole("switch", { name: EBIKE_SWITCH_NAME });
+  const ebikeToggle = mockedPage.getByRole("switch", {
+    name: EBIKE_SWITCH_NAME,
+  });
   await ebikeToggle.click();
 });
 
@@ -383,13 +380,10 @@ Then(
   },
 );
 
-Then(
-  "I see a rain alert on stage {int}",
-  async ({ mockedPage }, n: number) => {
-    const card = mockedPage.getByTestId(`stage-card-${n}`);
-    await expect(card).toContainText(/Heavy rain/, { timeout: 10000 });
-  },
-);
+Then("I see a rain alert on stage {int}", async ({ mockedPage }, n: number) => {
+  const card = mockedPage.getByTestId(`stage-card-${n}`);
+  await expect(card).toContainText(/Heavy rain/, { timeout: 10000 });
+});
 
 Then(
   "each stage shows a weather icon matching its conditions",
@@ -401,15 +395,12 @@ Then(
   },
 );
 
-Then(
-  "the travel times of all stages are updated",
-  async ({ mockedPage }) => {
-    for (let i = 1; i <= 3; i++) {
-      const card = mockedPage.getByTestId(`stage-card-${i}`);
-      await expect(card).toContainText(/\d+h\d{2}/, { timeout: 10000 });
-    }
-  },
-);
+Then("the travel times of all stages are updated", async ({ mockedPage }) => {
+  for (let i = 1; i <= 3; i++) {
+    const card = mockedPage.getByTestId(`stage-card-${i}`);
+    await expect(card).toContainText(/\d+h\d{2}/, { timeout: 10000 });
+  }
+});
 
 Then(
   "the target distance decreases progressively across stages",

--- a/pwa/tests/recette/support/accommodation-scan-tracker.ts
+++ b/pwa/tests/recette/support/accommodation-scan-tracker.ts
@@ -4,14 +4,17 @@ let pendingAccommodationScanRequest: Promise<Request> | undefined;
 
 export function trackAccommodationScanRequest(page: Page): void {
   pendingAccommodationScanRequest = page.waitForRequest(
-    (req) => req.url().includes("/accommodations/scan") && req.method() === "POST",
+    (req) =>
+      req.url().includes("/accommodations/scan") && req.method() === "POST",
     { timeout: 5000 },
   );
 }
 
 export async function takeAccommodationScanRequest(): Promise<Request> {
   if (!pendingAccommodationScanRequest) {
-    throw new Error("Accommodation scan request was not tracked before assertion");
+    throw new Error(
+      "Accommodation scan request was not tracked before assertion",
+    );
   }
 
   const request = await pendingAccommodationScanRequest;

--- a/pwa/tests/recette/support/export-download-tracker.ts
+++ b/pwa/tests/recette/support/export-download-tracker.ts
@@ -80,7 +80,9 @@ export async function trackStageExportDownload(
       return route.fulfill({
         status: 200,
         contentType:
-          extension === "gpx" ? "application/gpx+xml" : "application/octet-stream",
+          extension === "gpx"
+            ? "application/gpx+xml"
+            : "application/octet-stream",
         body: extension === "gpx" ? GPX_BODY : "",
       });
     },

--- a/pwa/tsconfig.json
+++ b/pwa/tsconfig.json
@@ -31,5 +31,10 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules", "capacitor.config.ts", "playwright.bdd.config.ts", "tests/recette"]
+  "exclude": [
+    "node_modules",
+    "capacitor.config.ts",
+    "playwright.bdd.config.ts",
+    "tests/recette"
+  ]
 }


### PR DESCRIPTION
## Summary
- Reduce Wave 1 (homepage scraping) timeout from 5s to 3s
- Reduce Wave 2 (price page scraping) timeout from 3s to 2s
- Total max latency reduced from 8s to 5s
- Graceful fallback already in place: timed-out accommodations keep OSM data

## Tests
- New tests for timeout values and graceful fallback behavior
- `make qa` ✅ `make phpunit` ✅ (787 tests)

Closes #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

**Commit reviewed:** `2f1be34498fd420ea8cb4ff31d47296f9512b859`

**Summary:** All previous findings have been addressed. The Wave 2 timeout test now correctly triggers Wave 2 by supplying a Wave 1 HTML fixture with a price-page link, and all four new tests accurately exercise their intended code paths.

**Resolved threads:** Resolved 1 previously open thread (Wave 2 not triggered by test fixture — fixed in commit `2f1be34`).

### Review checklist
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Inline comments
No inline comments.

---
Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->