### PR TITLE
perf(overpass): batch Overpass queries for POIs and cultural POIs

### DIFF
--- a/api/src/MessageHandler/CheckCulturalPoisHandler.php
+++ b/api/src/MessageHandler/CheckCulturalPoisHandler.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace App\MessageHandler;
 
 use App\ApiResource\Model\Coordinate;
+use App\ApiResource\Stage;
 use App\ComputationTracker\ComputationTrackerInterface;
 use App\ComputationTracker\TripGenerationTrackerInterface;
 use App\Enum\AlertType;
 use App\Enum\ComputationName;
 use App\Geo\GeoDistanceInterface;
+use App\Geo\GeometryDistributorInterface;
 use App\Mercure\MercureEventType;
 use App\Mercure\TripUpdatePublisherInterface;
 use App\Message\CheckCulturalPois;
@@ -64,6 +66,7 @@ final readonly class CheckCulturalPoisHandler extends AbstractTripMessageHandler
         private TripRequestRepositoryInterface $tripStateManager,
         private ScannerInterface $scanner,
         private QueryBuilderInterface $queryBuilder,
+        private GeometryDistributorInterface $distributor,
         private GeoDistanceInterface $haversine,
         private TranslatorInterface $translator,
     ) {
@@ -83,47 +86,83 @@ final readonly class CheckCulturalPoisHandler extends AbstractTripMessageHandler
         $locale = $this->tripStateManager->getLocale($tripId) ?? 'en';
 
         $this->executeWithTracking($tripId, ComputationName::CULTURAL_POIS, function () use ($tripId, $stages, $locale): void {
-            $alerts = [];
-
+            // Collect geometries for non-rest-day stages
+            /** @var list<list<Coordinate>> $stageGeometries */
+            $stageGeometries = [];
+            /** @var list<int> $activeStageIndices */
+            $activeStageIndices = [];
+            /** @var list<Stage> $activeStages */
+            $activeStages = [];
             foreach ($stages as $i => $stage) {
                 if ($stage->isRestDay) {
                     continue;
                 }
+                $activeStageIndices[] = $i;
+                $activeStages[] = $stage;
+                $stageGeometries[] = $stage->geometry ?: [$stage->startPoint, $stage->endPoint];
+            }
 
+            if ([] === $stageGeometries) {
+                $this->publisher->publish($tripId, MercureEventType::CULTURAL_POI_ALERTS, [
+                    'alerts' => [],
+                ]);
+
+                return;
+            }
+
+            // Single batch query for all active stages
+            $query = $this->queryBuilder->buildBatchCulturalPoiQuery($stageGeometries, self::CULTURAL_POI_RADIUS_METERS);
+            $result = $this->scanner->query($query);
+
+            /** @var list<array{tags?: array<string, string>, lat?: float, lon?: float, center?: array{lat: float, lon: float}}> $elements */
+            $elements = \is_array($result['elements'] ?? null) ? $result['elements'] : [];
+
+            // Parse all cultural POIs from the batch result
+            /** @var list<array{name: string, type: string, lat: float, lon: float}> $allCulturalPois */
+            $allCulturalPois = [];
+            foreach ($elements as $element) {
+                $lat = $element['lat'] ?? ($element['center']['lat'] ?? null);
+                $lon = $element['lon'] ?? ($element['center']['lon'] ?? null);
+
+                if (null === $lat || null === $lon) {
+                    continue;
+                }
+
+                $tags = $element['tags'] ?? [];
+                $poiType = $this->resolveCulturalPoiType($tags);
+
+                if (null === $poiType) {
+                    continue;
+                }
+
+                $name = $tags['name'] ?? $poiType;
+
+                $allCulturalPois[] = [
+                    'name' => $name,
+                    'type' => $poiType,
+                    'lat' => (float) $lat,
+                    'lon' => (float) $lon,
+                ];
+            }
+
+            // Distribute POIs to the nearest active stage via geometry
+            /** @var array<int, list<array{name: string, type: string, lat: float, lon: float}>> $poisByActiveStage */
+            $poisByActiveStage = $this->distributor->distributeByGeometry($allCulturalPois, $activeStages);
+
+            $alerts = [];
+            foreach ($activeStages as $activeIdx => $stage) {
+                $originalIndex = $activeStageIndices[$activeIdx];
                 $geometry = $stage->geometry ?: [$stage->startPoint, $stage->endPoint];
 
-                $query = $this->queryBuilder->buildCulturalPoiQuery($geometry, self::CULTURAL_POI_RADIUS_METERS);
-                $result = $this->scanner->query($query);
-
-                /** @var list<array{tags?: array<string, string>, lat?: float, lon?: float, center?: array{lat: float, lon: float}}> $elements */
-                $elements = \is_array($result['elements'] ?? null) ? $result['elements'] : [];
-
                 $stagePois = [];
-                foreach ($elements as $element) {
-                    $lat = $element['lat'] ?? ($element['center']['lat'] ?? null);
-                    $lon = $element['lon'] ?? ($element['center']['lon'] ?? null);
-
-                    if (null === $lat || null === $lon) {
-                        continue;
-                    }
-
-                    $tags = $element['tags'] ?? [];
-                    $poiType = $this->resolveCulturalPoiType($tags);
-
-                    if (null === $poiType) {
-                        continue;
-                    }
-
-                    $name = $tags['name'] ?? $poiType;
-
-                    // Find the nearest geometry point and its distance to the POI
-                    $distanceFromRoute = $this->findMinDistanceToRoute($geometry, (float) $lat, (float) $lon);
+                foreach ($poisByActiveStage[$activeIdx] ?? [] as $poi) {
+                    $distanceFromRoute = $this->findMinDistanceToRoute($geometry, $poi['lat'], $poi['lon']);
 
                     $stagePois[] = [
-                        'name' => $name,
-                        'type' => $poiType,
-                        'lat' => (float) $lat,
-                        'lon' => (float) $lon,
+                        'name' => $poi['name'],
+                        'type' => $poi['type'],
+                        'lat' => $poi['lat'],
+                        'lon' => $poi['lon'],
                         'distanceFromRoute' => $distanceFromRoute,
                     ];
                 }
@@ -146,7 +185,7 @@ final readonly class CheckCulturalPoisHandler extends AbstractTripMessageHandler
                     );
 
                     $alerts[] = [
-                        'stageIndex' => $i,
+                        'stageIndex' => $originalIndex,
                         'dayNumber' => $stage->dayNumber,
                         'type' => AlertType::NUDGE->value,
                         'message' => $alertMessage,

--- a/api/src/MessageHandler/CheckCulturalPoisHandler.php
+++ b/api/src/MessageHandler/CheckCulturalPoisHandler.php
@@ -97,6 +97,7 @@ final readonly class CheckCulturalPoisHandler extends AbstractTripMessageHandler
                 if ($stage->isRestDay) {
                     continue;
                 }
+
                 $activeStageIndices[] = $i;
                 $activeStages[] = $stage;
                 $stageGeometries[] = $stage->geometry ?: [$stage->startPoint, $stage->endPoint];

--- a/api/src/MessageHandler/ScanPoisHandler.php
+++ b/api/src/MessageHandler/ScanPoisHandler.php
@@ -71,7 +71,7 @@ final readonly class ScanPoisHandler extends AbstractTripMessageHandler
         $averageSpeed = $request instanceof TripRequest ? $request->averageSpeed : 15.0;
 
         $this->executeWithTracking($tripId, ComputationName::POIS, function () use ($tripId, $stages, $locale, $departureHour, $averageSpeed): void {
-            // Build one POI query per stage + one global cemetery query (concurrent via queryBatch)
+            // Build one batch POI query + one global cemetery query (concurrent via queryBatch)
             /** @var list<list<Coordinate>> $stageGeometries */
             $stageGeometries = array_map(
                 static fn (Stage $stage): array => $stage->geometry ?: [$stage->startPoint, $stage->endPoint],
@@ -81,40 +81,38 @@ final readonly class ScanPoisHandler extends AbstractTripMessageHandler
             $allPoints = array_merge(...$stageGeometries);
 
             /** @var array<string, string> $queries */
-            $queries = ['cemetery' => $this->queryBuilder->buildCemeteryQuery($allPoints)];
-            foreach ($stages as $i => $stage) {
-                $queries['poi_'.$i] = $this->queryBuilder->buildPoiQuery($stageGeometries[$i]);
-            }
+            $queries = [
+                'cemetery' => $this->queryBuilder->buildCemeteryQuery($allPoints),
+                'poi' => $this->queryBuilder->buildBatchPoiQuery($stageGeometries),
+            ];
 
             $results = $this->scanner->queryBatch($queries);
 
-            // Parse POIs per stage, then redistribute via geometry to deduplicate boundary overlaps
+            // Parse all POIs from the single batch result, then redistribute via geometry
             /** @var list<array{name: string, category: string, lat: float, lon: float}> $allPois */
             $allPois = [];
-            foreach ($stages as $i => $stage) {
-                $poiResult = $results['poi_'.$i] ?? [];
-                /** @var list<array{tags?: array<string, string>, lat?: float, lon?: float, center?: array{lat: float, lon: float}}> $elements */
-                $elements = \is_array($poiResult['elements'] ?? null) ? $poiResult['elements'] : [];
+            $poiResult = $results['poi'] ?? [];
+            /** @var list<array{tags?: array<string, string>, lat?: float, lon?: float, center?: array{lat: float, lon: float}}> $elements */
+            $elements = \is_array($poiResult['elements'] ?? null) ? $poiResult['elements'] : [];
 
-                foreach ($elements as $element) {
-                    $tags = $element['tags'] ?? [];
-                    $lat = $element['lat'] ?? ($element['center']['lat'] ?? null);
-                    $lon = $element['lon'] ?? ($element['center']['lon'] ?? null);
+            foreach ($elements as $element) {
+                $tags = $element['tags'] ?? [];
+                $lat = $element['lat'] ?? ($element['center']['lat'] ?? null);
+                $lon = $element['lon'] ?? ($element['center']['lon'] ?? null);
 
-                    if (null === $lat || null === $lon) {
-                        continue;
-                    }
-
-                    $category = $tags['amenity'] ?? $tags['shop'] ?? $tags['tourism'] ?? 'unknown';
-                    $name = $tags['name'] ?? $category;
-
-                    $allPois[] = [
-                        'name' => $name,
-                        'category' => $category,
-                        'lat' => (float) $lat,
-                        'lon' => (float) $lon,
-                    ];
+                if (null === $lat || null === $lon) {
+                    continue;
                 }
+
+                $category = $tags['amenity'] ?? $tags['shop'] ?? $tags['tourism'] ?? 'unknown';
+                $name = $tags['name'] ?? $category;
+
+                $allPois[] = [
+                    'name' => $name,
+                    'category' => $category,
+                    'lat' => (float) $lat,
+                    'lon' => (float) $lon,
+                ];
             }
 
             /** @var array<int, list<array{name: string, category: string, lat: float, lon: float}>> $poisByStage */

--- a/api/src/Scanner/OsmOverpassQueryBuilder.php
+++ b/api/src/Scanner/OsmOverpassQueryBuilder.php
@@ -151,6 +151,21 @@ final readonly class OsmOverpassQueryBuilder implements QueryBuilderInterface
         );
     }
 
+    /**
+     * @param list<list<Coordinate>> $stageGeometries
+     */
+    public function buildBatchCulturalPoiQuery(array $stageGeometries, int $radiusMeters = 500): string
+    {
+        $allPoints = array_merge(...$stageGeometries);
+        $polyline = $this->buildPolyline($allPoints);
+
+        return \sprintf(
+            '[out:json][timeout:15];(nwr["tourism"="museum"](around:%1$d,%2$s);nwr["tourism"="attraction"](around:%1$d,%2$s);nwr["tourism"="viewpoint"](around:%1$d,%2$s);nwr["historic"~"^(castle|monument|memorial|ruins|archaeological_site|church|cathedral|abbey|fort)$"](around:%1$d,%2$s););out center tags 100;',
+            $radiusMeters,
+            $polyline,
+        );
+    }
+
     /** @param list<Coordinate> $points */
     private function buildPolyline(array $points): string
     {

--- a/api/src/Scanner/OsmOverpassQueryBuilder.php
+++ b/api/src/Scanner/OsmOverpassQueryBuilder.php
@@ -153,6 +153,9 @@ final readonly class OsmOverpassQueryBuilder implements QueryBuilderInterface
 
     /**
      * @param list<list<Coordinate>> $stageGeometries
+     *
+     * Note: 'out center tags 100' caps the result set globally across all stages.
+     * Acceptable for typical bikepacking trips (≤7 stages, sparse cultural POIs).
      */
     public function buildBatchCulturalPoiQuery(array $stageGeometries, int $radiusMeters = 500): string
     {

--- a/api/src/Scanner/OsmOverpassQueryBuilder.php
+++ b/api/src/Scanner/OsmOverpassQueryBuilder.php
@@ -138,20 +138,6 @@ final readonly class OsmOverpassQueryBuilder implements QueryBuilderInterface
     }
 
     /**
-     * @param list<Coordinate> $stageGeometry
-     */
-    public function buildCulturalPoiQuery(array $stageGeometry, int $radiusMeters = 500): string
-    {
-        $polyline = $this->buildPolyline($stageGeometry);
-
-        return \sprintf(
-            '[out:json][timeout:15];(nwr["tourism"="museum"](around:%1$d,%2$s);nwr["tourism"="attraction"](around:%1$d,%2$s);nwr["tourism"="viewpoint"](around:%1$d,%2$s);nwr["historic"~"^(castle|monument|memorial|ruins|archaeological_site|church|cathedral|abbey|fort)$"](around:%1$d,%2$s););out center tags 100;',
-            $radiusMeters,
-            $polyline,
-        );
-    }
-
-    /**
      * @param list<list<Coordinate>> $stageGeometries
      *
      * Note: 'out center tags 100' caps the result set globally across all stages.

--- a/api/src/Scanner/QueryBuilderInterface.php
+++ b/api/src/Scanner/QueryBuilderInterface.php
@@ -78,4 +78,11 @@ interface QueryBuilderInterface
      * @param list<Coordinate> $stageGeometry
      */
     public function buildCulturalPoiQuery(array $stageGeometry, int $radiusMeters = 500): string;
+
+    /**
+     * Build a single Overpass query for cultural POIs along all stages.
+     *
+     * @param list<list<Coordinate>> $stageGeometries geometry points per stage
+     */
+    public function buildBatchCulturalPoiQuery(array $stageGeometries, int $radiusMeters = 500): string;
 }

--- a/api/src/Scanner/QueryBuilderInterface.php
+++ b/api/src/Scanner/QueryBuilderInterface.php
@@ -72,14 +72,6 @@ interface QueryBuilderInterface
     public function buildCemeteryQuery(array $decimatedPoints): string;
 
     /**
-     * Queries cultural POIs (museums, monuments, churches, castles, viewpoints)
-     * within a given radius of each stage geometry point.
-     *
-     * @param list<Coordinate> $stageGeometry
-     */
-    public function buildCulturalPoiQuery(array $stageGeometry, int $radiusMeters = 500): string;
-
-    /**
      * Build a single Overpass query for cultural POIs along all stages.
      *
      * @param list<list<Coordinate>> $stageGeometries geometry points per stage

--- a/api/tests/Unit/MessageHandler/CheckCulturalPoisHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/CheckCulturalPoisHandlerTest.php
@@ -158,7 +158,7 @@ final class CheckCulturalPoisHandlerTest extends TestCase
             });
 
         $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildCulturalPoiQuery')->willReturn('query');
+        $queryBuilder->method('buildBatchCulturalPoiQuery')->willReturn('query');
 
         $haversine = $this->createStub(GeoDistanceInterface::class);
         $haversine->method('inMeters')->willReturn(200.0);
@@ -194,7 +194,7 @@ final class CheckCulturalPoisHandlerTest extends TestCase
             });
 
         $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildCulturalPoiQuery')->willReturn('query');
+        $queryBuilder->method('buildBatchCulturalPoiQuery')->willReturn('query');
 
         $haversine = $this->createStub(GeoDistanceInterface::class);
         $haversine->method('inMeters')->willReturn(100.0);

--- a/api/tests/Unit/MessageHandler/CheckCulturalPoisHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/CheckCulturalPoisHandlerTest.php
@@ -163,7 +163,12 @@ final class CheckCulturalPoisHandlerTest extends TestCase
         $haversine = $this->createStub(GeoDistanceInterface::class);
         $haversine->method('inMeters')->willReturn(200.0);
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine);
+        $distributor = $this->createStub(GeometryDistributorInterface::class);
+        $distributor->method('distributeByGeometry')->willReturnCallback(
+            static fn (array $items): array => [0 => $items],
+        );
+
+        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine, $distributor);
         $handler(new CheckCulturalPois('trip-1'));
 
         $alertEvents = array_filter($publishedEvents, static fn (array $e): bool => MercureEventType::CULTURAL_POI_ALERTS === $e['type']);
@@ -199,7 +204,12 @@ final class CheckCulturalPoisHandlerTest extends TestCase
         $haversine = $this->createStub(GeoDistanceInterface::class);
         $haversine->method('inMeters')->willReturn(100.0);
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine);
+        $distributor = $this->createStub(GeometryDistributorInterface::class);
+        $distributor->method('distributeByGeometry')->willReturnCallback(
+            static fn (array $items): array => [0 => $items],
+        );
+
+        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine, $distributor);
         $handler(new CheckCulturalPois('trip-1'));
 
         $alertEvents = array_filter($publishedEvents, static fn (array $e): bool => MercureEventType::CULTURAL_POI_ALERTS === $e['type']);

--- a/api/tests/Unit/MessageHandler/CheckCulturalPoisHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/CheckCulturalPoisHandlerTest.php
@@ -9,6 +9,7 @@ use App\ApiResource\Stage;
 use App\ComputationTracker\ComputationTrackerInterface;
 use App\ComputationTracker\TripGenerationTrackerInterface;
 use App\Geo\GeoDistanceInterface;
+use App\Geo\GeometryDistributorInterface;
 use App\Mercure\MercureEventType;
 use App\Mercure\TripUpdatePublisherInterface;
 use App\Message\CheckCulturalPois;
@@ -59,6 +60,7 @@ final class CheckCulturalPoisHandlerTest extends TestCase
         );
 
         $generationTracker = $this->createStub(TripGenerationTrackerInterface::class);
+        $distributor = $this->createStub(GeometryDistributorInterface::class);
 
         return new CheckCulturalPoisHandler(
             $computationTracker,
@@ -68,6 +70,7 @@ final class CheckCulturalPoisHandlerTest extends TestCase
             $tripStateManager,
             $scanner,
             $queryBuilder,
+            $distributor,
             $haversine,
             $translator,
         );

--- a/api/tests/Unit/MessageHandler/CheckCulturalPoisHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/CheckCulturalPoisHandlerTest.php
@@ -50,6 +50,7 @@ final class CheckCulturalPoisHandlerTest extends TestCase
         ScannerInterface $scanner,
         QueryBuilderInterface $queryBuilder,
         GeoDistanceInterface $haversine,
+        ?GeometryDistributorInterface $distributor = null,
     ): CheckCulturalPoisHandler {
         $computationTracker = $this->createStub(ComputationTrackerInterface::class);
         $computationTracker->method('isAllComplete')->willReturn(false);
@@ -60,7 +61,7 @@ final class CheckCulturalPoisHandlerTest extends TestCase
         );
 
         $generationTracker = $this->createStub(TripGenerationTrackerInterface::class);
-        $distributor = $this->createStub(GeometryDistributorInterface::class);
+        $distributor ??= $this->createStub(GeometryDistributorInterface::class);
 
         return new CheckCulturalPoisHandler(
             $computationTracker,
@@ -233,7 +234,7 @@ final class CheckCulturalPoisHandlerTest extends TestCase
             });
 
         $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildCulturalPoiQuery')->willReturn('query');
+        $queryBuilder->method('buildBatchCulturalPoiQuery')->willReturn('query');
 
         $haversine = $this->createStub(GeoDistanceInterface::class);
         // Museum D is farthest from all geometry points
@@ -257,7 +258,13 @@ final class CheckCulturalPoisHandlerTest extends TestCase
             },
         );
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine);
+        // Distributor returns all 4 POIs assigned to stage 0
+        $distributor = $this->createStub(GeometryDistributorInterface::class);
+        $distributor->method('distributeByGeometry')->willReturnCallback(
+            static fn (array $items): array => [0 => $items],
+        );
+
+        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine, $distributor);
         $handler(new CheckCulturalPois('trip-1'));
 
         $alertEvents = array_filter($publishedEvents, static fn (array $e): bool => MercureEventType::CULTURAL_POI_ALERTS === $e['type']);
@@ -293,12 +300,18 @@ final class CheckCulturalPoisHandlerTest extends TestCase
             });
 
         $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildCulturalPoiQuery')->willReturn('query');
+        $queryBuilder->method('buildBatchCulturalPoiQuery')->willReturn('query');
 
         $haversine = $this->createStub(GeoDistanceInterface::class);
         $haversine->method('inMeters')->willReturn(250.0);
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine);
+        // Distributor returns the single POI assigned to stage 0
+        $distributor = $this->createStub(GeometryDistributorInterface::class);
+        $distributor->method('distributeByGeometry')->willReturnCallback(
+            static fn (array $items): array => [0 => $items],
+        );
+
+        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine, $distributor);
         $handler(new CheckCulturalPois('trip-1'));
 
         $alertEvents = array_filter($publishedEvents, static fn (array $e): bool => MercureEventType::CULTURAL_POI_ALERTS === $e['type']);

--- a/api/tests/Unit/MessageHandler/ScanPoisHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/ScanPoisHandlerTest.php
@@ -109,6 +109,7 @@ final class ScanPoisHandlerTest extends TestCase
     {
         $queryBuilder = $this->createStub(QueryBuilderInterface::class);
         $queryBuilder->method('buildPoiQuery')->willReturn('query');
+        $queryBuilder->method('buildBatchPoiQuery')->willReturn('batch_poi_query');
         $queryBuilder->method('buildCemeteryQuery')->willReturn('cemetery_query');
 
         $haversine = $this->createStub(GeoDistanceInterface::class);
@@ -455,7 +456,7 @@ final class ScanPoisHandlerTest extends TestCase
     }
 
     #[Test]
-    public function poiQueryIsBuiltPerStageNotGlobally(): void
+    public function poiQueryUsesBatchForAllStages(): void
     {
         $stage1 = $this->createStage('trip-1', 1, 50.0);
         $stage2 = $this->createStage('trip-1', 2, 50.0);
@@ -463,23 +464,22 @@ final class ScanPoisHandlerTest extends TestCase
         $tripStateManager = $this->createTripStateManager([$stage1, $stage2]);
 
         $queryBuilder = $this->createMock(QueryBuilderInterface::class);
-        // buildPoiQuery should be called twice: once per stage
-        $queryBuilder->expects($this->exactly(2))
-            ->method('buildPoiQuery')
-            ->willReturn('stage_query');
+        // buildBatchPoiQuery should be called once with all stage geometries
+        $queryBuilder->expects($this->once())
+            ->method('buildBatchPoiQuery')
+            ->willReturn('batch_poi_query');
         $queryBuilder->method('buildCemeteryQuery')->willReturn('cemetery_query');
 
         $scanner = $this->createMock(ScannerInterface::class);
         $scanner->expects($this->once())
             ->method('queryBatch')
             ->with($this->callback(
-                // Must have poi_0, poi_1, and cemetery keys
-                static fn (array $queries): bool => isset($queries['poi_0'], $queries['poi_1'], $queries['cemetery'])
-                && 3 === \count($queries)
+                // Must have poi and cemetery keys (batch format)
+                static fn (array $queries): bool => isset($queries['poi'], $queries['cemetery'])
+                && 2 === \count($queries)
             ))
             ->willReturn([
-                'poi_0' => ['elements' => []],
-                'poi_1' => ['elements' => []],
+                'poi' => ['elements' => []],
                 'cemetery' => ['elements' => []],
             ]);
 

--- a/api/tests/Unit/MessageHandler/ScanPoisHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/ScanPoisHandlerTest.php
@@ -340,7 +340,7 @@ final class ScanPoisHandlerTest extends TestCase
 
         $scanner = $this->createStub(ScannerInterface::class);
         $scanner->method('queryBatch')->willReturn([
-            'poi_0' => [
+            'poi' => [
                 'elements' => [
                     ['lat' => 48.2, 'lon' => 2.2, 'tags' => ['shop' => 'bakery', 'name' => 'Boulangerie']],
                 ],
@@ -392,7 +392,7 @@ final class ScanPoisHandlerTest extends TestCase
 
         $scanner = $this->createStub(ScannerInterface::class);
         $scanner->method('queryBatch')->willReturn([
-            'poi_0' => [
+            'poi' => [
                 'elements' => [
                     ['lat' => 48.2, 'lon' => 2.2, 'tags' => ['amenity' => 'restaurant', 'name' => 'Bistrot A']],
                     ['lat' => 48.2, 'lon' => 2.2001, 'tags' => ['amenity' => 'restaurant', 'name' => 'Bistrot B']],
@@ -509,7 +509,7 @@ final class ScanPoisHandlerTest extends TestCase
 
         $scanner = $this->createStub(ScannerInterface::class);
         $scanner->method('queryBatch')->willReturn([
-            'poi_0' => [
+            'poi' => [
                 'elements' => [
                     ['lat' => 48.0, 'lon' => 2.0, 'tags' => ['amenity' => 'restaurant', 'name' => 'POI A']],
                     ['lat' => 48.0, 'lon' => 2.005, 'tags' => ['amenity' => 'restaurant', 'name' => 'POI B']],

--- a/api/tests/Unit/MessageHandler/ScanPoisHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/ScanPoisHandlerTest.php
@@ -108,7 +108,6 @@ final class ScanPoisHandlerTest extends TestCase
     private function createDefaultStubs(): array
     {
         $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildPoiQuery')->willReturn('query');
         $queryBuilder->method('buildBatchPoiQuery')->willReturn('batch_poi_query');
         $queryBuilder->method('buildCemeteryQuery')->willReturn('cemetery_query');
 
@@ -133,7 +132,7 @@ final class ScanPoisHandlerTest extends TestCase
 
         $scanner = $this->createStub(ScannerInterface::class);
         $scanner->method('queryBatch')->willReturn([
-            'poi_0' => [
+            'poi' => [
                 'elements' => [
                     ['lat' => 48.2, 'lon' => 2.2, 'tags' => ['amenity' => 'restaurant', 'name' => 'Le Bistrot']],
                     ['lat' => 48.3, 'lon' => 2.3, 'tags' => ['amenity' => 'restaurant', 'name' => 'Chez Paul']],
@@ -186,7 +185,7 @@ final class ScanPoisHandlerTest extends TestCase
 
         $scanner = $this->createStub(ScannerInterface::class);
         $scanner->method('queryBatch')->willReturn([
-            'poi_0' => [
+            'poi' => [
                 'elements' => [
                     ['lat' => 48.2, 'lon' => 2.2, 'tags' => ['amenity' => 'restaurant', 'name' => 'Le Bistrot']],
                     ['lat' => 48.3, 'lon' => 2.3, 'tags' => ['shop' => 'supermarket', 'name' => 'Carrefour']],
@@ -239,7 +238,7 @@ final class ScanPoisHandlerTest extends TestCase
 
         $scanner = $this->createStub(ScannerInterface::class);
         $scanner->method('queryBatch')->willReturn([
-            'poi_0' => [
+            'poi' => [
                 'elements' => [
                     ['lat' => 48.2, 'lon' => 2.2, 'tags' => ['tourism' => 'viewpoint', 'name' => 'Belvedere']],
                 ],
@@ -303,7 +302,7 @@ final class ScanPoisHandlerTest extends TestCase
 
         $scanner = $this->createStub(ScannerInterface::class);
         $scanner->method('queryBatch')->willReturn([
-            'poi_0' => ['elements' => []],
+            'poi' => ['elements' => []],
             'cemetery' => ['elements' => []],
         ]);
 

--- a/api/tests/Unit/MessageHandler/ScanPoisHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/ScanPoisHandlerTest.php
@@ -412,7 +412,7 @@ final class ScanPoisHandlerTest extends TestCase
         );
 
         [$queryBuilder, $riderTimeEstimator] = [$this->createStub(QueryBuilderInterface::class), $this->createStub(RiderTimeEstimatorInterface::class)];
-        $queryBuilder->method('buildPoiQuery')->willReturn('query');
+        $queryBuilder->method('buildBatchPoiQuery')->willReturn('batch_poi_query');
         $queryBuilder->method('buildCemeteryQuery')->willReturn('cemetery_query');
 
         $haversine = $this->createStub(GeoDistanceInterface::class);
@@ -532,7 +532,7 @@ final class ScanPoisHandlerTest extends TestCase
             $this->createStub(QueryBuilderInterface::class),
             $this->createStub(RiderTimeEstimatorInterface::class),
         ];
-        $queryBuilder->method('buildPoiQuery')->willReturn('query');
+        $queryBuilder->method('buildBatchPoiQuery')->willReturn('batch_poi_query');
         $queryBuilder->method('buildCemeteryQuery')->willReturn('cemetery_query');
 
         $haversine = $this->createStub(GeoDistanceInterface::class);

--- a/api/tests/Unit/Scanner/OsmOverpassQueryBuilderTest.php
+++ b/api/tests/Unit/Scanner/OsmOverpassQueryBuilderTest.php
@@ -227,6 +227,33 @@ final class OsmOverpassQueryBuilderTest extends TestCase
     }
 
     #[Test]
+    public function buildBatchCulturalPoiQueryMergesAllStages(): void
+    {
+        $stage1 = [new Coordinate(45.0, 5.0), new Coordinate(45.1, 5.1)];
+        $stage2 = [new Coordinate(46.0, 6.0), new Coordinate(46.1, 6.1)];
+
+        $query = $this->builder->buildBatchCulturalPoiQuery([$stage1, $stage2]);
+
+        // All points from both stages should be in the polyline
+        $this->assertStringContainsString('45.000000,5.000000', $query);
+        $this->assertStringContainsString('46.000000,6.000000', $query);
+        $this->assertStringContainsString('"tourism"="museum"', $query);
+        $this->assertStringContainsString('"historic"~"^(castle|monument|memorial|ruins|archaeological_site|church|cathedral|abbey|fort)$"', $query);
+        $this->assertStringContainsString('out center tags 100', $query);
+    }
+
+    #[Test]
+    public function buildBatchCulturalPoiQueryUsesCustomRadius(): void
+    {
+        $stage1 = [new Coordinate(45.0, 5.0)];
+
+        $query = $this->builder->buildBatchCulturalPoiQuery([$stage1], 1000);
+
+        $this->assertStringContainsString('around:1000', $query);
+        $this->assertStringNotContainsString('around:500', $query);
+    }
+
+    #[Test]
     public function buildBatchBikeShopQueryMergesAllStages(): void
     {
         $stage1 = [new Coordinate(45.0, 5.0)];

--- a/pwa/src/store/trip-store.ts
+++ b/pwa/src/store/trip-store.ts
@@ -467,7 +467,11 @@ export const useTripStore = create<TripState>()(
     loadFromSavedTrip: (trip) => {
       useTripTemporalStore.getState().clear();
       set((state) => {
-        state.trip = { id: trip.id, title: trip.title, sourceUrl: trip.sourceUrl };
+        state.trip = {
+          id: trip.id,
+          title: trip.title,
+          sourceUrl: trip.sourceUrl,
+        };
         state.startDate = trip.startDate;
         state.endDate = trip.endDate;
         state.fatigueFactor = trip.fatigueFactor;

--- a/pwa/tests/recette/steps/accommodations.steps.ts
+++ b/pwa/tests/recette/steps/accommodations.steps.ts
@@ -10,7 +10,7 @@ import { getCurrentRecettePage } from "../support/current-recette-page";
 
 function getAccommodationTextAlias(text: string): string {
   const aliases: Record<string, string> = {
-    "Hôtel": "Hotel",
+    Hôtel: "Hotel",
     "Ajouter un hébergement": "Add accommodation",
   };
 
@@ -323,33 +323,30 @@ When(
   },
 );
 
-When(
-  "an accommodation is exactly at the endpoint",
-  async () => {
-    await injectSseSequence(getCurrentRecettePage(), [
-      {
-        type: "accommodations_found",
-        data: {
-          stageIndex: 0,
-          searchRadiusKm: 5,
-          accommodations: [
-            {
-              name: "Gîte du Terminus",
-              type: "guest_house",
-              lat: 44.532,
-              lon: 4.392,
-              estimatedPriceMin: 45,
-              estimatedPriceMax: 60,
-              isExactPrice: false,
-              possibleClosed: false,
-              distanceToEndPoint: 0,
-            },
-          ],
-        },
+When("an accommodation is exactly at the endpoint", async () => {
+  await injectSseSequence(getCurrentRecettePage(), [
+    {
+      type: "accommodations_found",
+      data: {
+        stageIndex: 0,
+        searchRadiusKm: 5,
+        accommodations: [
+          {
+            name: "Gîte du Terminus",
+            type: "guest_house",
+            lat: 44.532,
+            lon: 4.392,
+            estimatedPriceMin: 45,
+            estimatedPriceMax: 60,
+            isExactPrice: false,
+            possibleClosed: false,
+            distanceToEndPoint: 0,
+          },
+        ],
       },
-    ]);
-  },
-);
+    },
+  ]);
+});
 
 Then(
   "aucun badge de distance n'est affiché pour cet hébergement",
@@ -363,13 +360,13 @@ Then(
   },
 );
 
-Then(
-  "no distance badge is displayed for that accommodation",
-  async () => {
-    const stageCard = getCurrentRecettePage().getByTestId("stage-card-1");
-    await expect(stageCard).toContainText(/Gîte du Terminus|Terminus Guest House/, {
+Then("no distance badge is displayed for that accommodation", async () => {
+  const stageCard = getCurrentRecettePage().getByTestId("stage-card-1");
+  await expect(stageCard).toContainText(
+    /Gîte du Terminus|Terminus Guest House/,
+    {
       timeout: 5000,
-    });
-    await expect(stageCard.locator('[aria-label*="0 km"]')).toHaveCount(0);
-  },
-);
+    },
+  );
+  await expect(stageCard.locator('[aria-label*="0 km"]')).toHaveCount(0);
+});

--- a/pwa/tests/recette/steps/configuration.steps.ts
+++ b/pwa/tests/recette/steps/configuration.steps.ts
@@ -6,11 +6,13 @@ import { When, Then } from "../support/fixtures";
 // ---------------------------------------------------------------------------
 
 const SETTINGS_BUTTON_NAME = /Ouvrir les paramètres|Open settings/i;
-const SPEED_SLIDER_NAME = /Vitesse moyenne \(km\/h\)|Average cycling speed \(km\/h\)/i;
+const SPEED_SLIDER_NAME =
+  /Vitesse moyenne \(km\/h\)|Average cycling speed \(km\/h\)/i;
 const MAX_DISTANCE_SLIDER_NAME =
   /Distance maximale par jour \(km\)|Maximum distance per day \(km\)/i;
 const EBIKE_SWITCH_NAME = /Mode VAE|E-bike mode/i;
-const DEPARTURE_SLIDER_NAME = /Heure de départ \(0-23\)|Departure hour \(0-23\)/i;
+const DEPARTURE_SLIDER_NAME =
+  /Heure de départ \(0-23\)|Departure hour \(0-23\)/i;
 const ACCOMMODATION_SECTION_HEADING =
   /Types d'hébergements|Accommodation types/i;
 
@@ -95,12 +97,9 @@ Then(
   },
 );
 
-Then(
-  "the last switch is disabled and cannot be toggled",
-  async ({ $test }) => {
-    $test.fixme();
-  },
-);
+Then("the last switch is disabled and cannot be toggled", async ({ $test }) => {
+  $test.fixme();
+});
 
 // --- Additional missing steps ---
 // "je suis sur la page du voyage avec les étapes calculées" / "I am on the trip page with computed stages" defined in common.steps.ts
@@ -178,12 +177,16 @@ Then(
 );
 
 When("j'active le mode e-bike", async ({ mockedPage }) => {
-  const ebikeToggle = mockedPage.getByRole("switch", { name: EBIKE_SWITCH_NAME });
+  const ebikeToggle = mockedPage.getByRole("switch", {
+    name: EBIKE_SWITCH_NAME,
+  });
   await ebikeToggle.click();
 });
 
 When("I enable e-bike mode", async ({ mockedPage }) => {
-  const ebikeToggle = mockedPage.getByRole("switch", { name: EBIKE_SWITCH_NAME });
+  const ebikeToggle = mockedPage.getByRole("switch", {
+    name: EBIKE_SWITCH_NAME,
+  });
   await ebikeToggle.click();
 });
 

--- a/pwa/tests/recette/steps/cross-cutting-ux.steps.ts
+++ b/pwa/tests/recette/steps/cross-cutting-ux.steps.ts
@@ -420,12 +420,9 @@ Then(
   },
 );
 
-Then(
-  "un toast de confirmation s'affiche brièvement",
-  async ({ $test }) => {
-    $test.fixme();
-  },
-);
+Then("un toast de confirmation s'affiche brièvement", async ({ $test }) => {
+  $test.fixme();
+});
 
 Then(
   "un message d'erreur compréhensible est affiché à l'utilisateur",

--- a/pwa/tests/recette/steps/dates-calendar.steps.ts
+++ b/pwa/tests/recette/steps/dates-calendar.steps.ts
@@ -103,7 +103,10 @@ async function selectCalendarDate(
     'button[aria-label*="suivant"], button[aria-label*="next"], button[aria-label*="Next"]',
   );
   for (let i = 0; i < 24; i++) {
-    const header = mockedPage.locator('[class*="font-semibold"]').filter({ hasText: /\d{4}/ }).first();
+    const header = mockedPage
+      .locator('[class*="font-semibold"]')
+      .filter({ hasText: /\d{4}/ })
+      .first();
     const headerText = await header.textContent();
     if (!headerText) {
       await nextButton.first().click();
@@ -376,12 +379,9 @@ When("I navigate to the next month", async ({ mockedPage }) => {
 
 // --- Then steps FR ---
 
-Then(
-  "la date de départ affichée est {string}",
-  async ({ $test }) => {
-    $test.fixme();
-  },
-);
+Then("la date de départ affichée est {string}", async ({ $test }) => {
+  $test.fixme();
+});
 
 Then(/^l'étape (\d+) est prévue le \d+ \w+ \d+$/, async ({ mockedPage }) => {
   // Stage cards show sunrise/sunset times when a start date is set,
@@ -428,12 +428,9 @@ Then("le mois suivant est affiché", async ({ mockedPage }) => {
 
 // --- Then steps EN ---
 
-Then(
-  "the displayed departure date is {string}",
-  async ({ $test }) => {
-    $test.fixme();
-  },
-);
+Then("the displayed departure date is {string}", async ({ $test }) => {
+  $test.fixme();
+});
 
 Then(/^stage (\d+) is scheduled for \w+ \d+, \d+$/, async ({ mockedPage }) => {
   const stageCards = mockedPage.locator('[data-testid^="stage-card-"]');

--- a/pwa/tests/recette/steps/export.steps.ts
+++ b/pwa/tests/recette/steps/export.steps.ts
@@ -73,13 +73,10 @@ When(
   },
 );
 
-When(
-  "le calcul des étapes est en cours",
-  async ({ $test }) => {
-    // The current UI does not disable FIT downloads based on computation state alone.
-    $test.fixme();
-  },
-);
+When("le calcul des étapes est en cours", async ({ $test }) => {
+  // The current UI does not disable FIT downloads based on computation state alone.
+  $test.fixme();
+});
 
 When(
   "je clique sur le bouton export de format {string} de l'étape {int}",
@@ -96,18 +93,15 @@ When(
 
 // --- When steps EN ---
 
-When(
-  'I click "Download GPX" for stage {int}',
-  async ({}, stage: number) => {
-    const page = getCurrentRecettePage();
-    await trackStageGpxDownload(page);
-    const stageCard = page.getByTestId(`stage-card-${stage}`);
-    const gpxButton = stageCard.getByRole("button", {
-      name: /Download GPX/,
-    });
-    await gpxButton.click();
-  },
-);
+When('I click "Download GPX" for stage {int}', async ({}, stage: number) => {
+  const page = getCurrentRecettePage();
+  await trackStageGpxDownload(page);
+  const stageCard = page.getByTestId(`stage-card-${stage}`);
+  const gpxButton = stageCard.getByRole("button", {
+    name: /Download GPX/,
+  });
+  await gpxButton.click();
+});
 
 When("I select a valid GPX file", async ({ $test }) => {
   // $test.fixme: file upload requires a real GPX file fixture — part of @fixme scenario
@@ -119,26 +113,20 @@ When("I try to import a non-GPX file", async ({ $test }) => {
   $test.fixme();
 });
 
-When(
-  'I click "Download FIT" for stage {int}',
-  async ({}, stage: number) => {
-    const page = getCurrentRecettePage();
-    await trackStageFitDownload(page);
-    const stageCard = page.getByTestId(`stage-card-${stage}`);
-    const fitButton = stageCard.getByRole("button", {
-      name: /Download FIT/,
-    });
-    await fitButton.click();
-  },
-);
+When('I click "Download FIT" for stage {int}', async ({}, stage: number) => {
+  const page = getCurrentRecettePage();
+  await trackStageFitDownload(page);
+  const stageCard = page.getByTestId(`stage-card-${stage}`);
+  const fitButton = stageCard.getByRole("button", {
+    name: /Download FIT/,
+  });
+  await fitButton.click();
+});
 
-When(
-  "stage computation is in progress",
-  async ({ $test }) => {
-    // The current UI does not disable FIT downloads based on computation state alone.
-    $test.fixme();
-  },
-);
+When("stage computation is in progress", async ({ $test }) => {
+  // The current UI does not disable FIT downloads based on computation state alone.
+  $test.fixme();
+});
 
 When(
   "I click the export button for format {string} on stage {int}",
@@ -190,16 +178,13 @@ Then(
   },
 );
 
-Then(
-  /^une requête GET vers \/trips\/\*\.gpx est envoyée$/,
-  async () => {
-    const tripGpxRequests = getTrackedTripGpxRequests();
-    await expect
-      .poll(() => tripGpxRequests.length, { timeout: 5000 })
-      .toBeGreaterThan(0);
-    expect(tripGpxRequests[0]).toMatch(/\/trips\/[^/]+\.gpx$/);
-  },
-);
+Then(/^une requête GET vers \/trips\/\*\.gpx est envoyée$/, async () => {
+  const tripGpxRequests = getTrackedTripGpxRequests();
+  await expect
+    .poll(() => tripGpxRequests.length, { timeout: 5000 })
+    .toBeGreaterThan(0);
+  expect(tripGpxRequests[0]).toMatch(/\/trips\/[^/]+\.gpx$/);
+});
 
 Then("le voyage est créé à partir du fichier GPX", async ({ $test }) => {
   // $test.fixme: part of @fixme scenario (GPX file upload not yet testable)
@@ -261,16 +246,13 @@ Then(
   },
 );
 
-Then(
-  /^a GET request to \/trips\/\*\/stages\/0\.gpx is sent$/,
-  async () => {
-    const gpxRequests = getTrackedStageGpxRequests();
-    await expect
-      .poll(() => gpxRequests.length, { timeout: 5000 })
-      .toBeGreaterThan(0);
-    expect(gpxRequests[0]).toContain("/stages/0.gpx");
-  },
-);
+Then(/^a GET request to \/trips\/\*\/stages\/0\.gpx is sent$/, async () => {
+  const gpxRequests = getTrackedStageGpxRequests();
+  await expect
+    .poll(() => gpxRequests.length, { timeout: 5000 })
+    .toBeGreaterThan(0);
+  expect(gpxRequests[0]).toContain("/stages/0.gpx");
+});
 
 Then(
   'the "Télécharger le GPX complet" button is visible and enabled',
@@ -305,16 +287,13 @@ Then("an error message is displayed", async ({ mockedPage }) => {
   ).toBeVisible({ timeout: 5000 });
 });
 
-Then(
-  /^a GET request to \/trips\/\*\/stages\/0\.fit is sent$/,
-  async () => {
-    const fitRequests = getTrackedStageFitRequests();
-    await expect
-      .poll(() => fitRequests.length, { timeout: 5000 })
-      .toBeGreaterThan(0);
-    expect(fitRequests[0]).toContain("/stages/0.fit");
-  },
-);
+Then(/^a GET request to \/trips\/\*\/stages\/0\.fit is sent$/, async () => {
+  const fitRequests = getTrackedStageFitRequests();
+  await expect
+    .poll(() => fitRequests.length, { timeout: 5000 })
+    .toBeGreaterThan(0);
+  expect(fitRequests[0]).toContain("/stages/0.fit");
+});
 
 Then(
   "the FIT button for stage {int} is disabled",
@@ -328,14 +307,11 @@ Then(
   },
 );
 
-Then(
-  "the downloaded file has extension {string}",
-  async ({}, ext: string) => {
-    const downloadRequests = getTrackedStageExportRequests();
-    const normalizedExt = ext.replace(/^\./, "");
-    await expect
-      .poll(() => downloadRequests.length, { timeout: 5000 })
-      .toBeGreaterThan(0);
-    expect(downloadRequests[0]).toContain(`.${normalizedExt}`);
-  },
-);
+Then("the downloaded file has extension {string}", async ({}, ext: string) => {
+  const downloadRequests = getTrackedStageExportRequests();
+  const normalizedExt = ext.replace(/^\./, "");
+  await expect
+    .poll(() => downloadRequests.length, { timeout: 5000 })
+    .toBeGreaterThan(0);
+  expect(downloadRequests[0]).toContain(`.${normalizedExt}`);
+});

--- a/pwa/tests/recette/steps/weather-time.steps.ts
+++ b/pwa/tests/recette/steps/weather-time.steps.ts
@@ -13,7 +13,8 @@ import type { MercureEvent } from "../../../src/lib/mercure/types";
 
 const SETTINGS_BUTTON_NAME = /Ouvrir les paramètres|Open settings/i;
 const SETTINGS_DIALOG_NAME = /Paramètres|Settings/i;
-const SPEED_SLIDER_NAME = /Vitesse moyenne \(km\/h\)|Average cycling speed \(km\/h\)/i;
+const SPEED_SLIDER_NAME =
+  /Vitesse moyenne \(km\/h\)|Average cycling speed \(km\/h\)/i;
 const FATIGUE_SLIDER_NAME =
   /Indice de fatigue accumulée|Accumulated fatigue index/i;
 const EBIKE_SWITCH_NAME = /Mode VAE|E-bike mode/i;
@@ -102,9 +103,7 @@ When(
 );
 
 When("le facteur de fatigue est activé", async ({ mockedPage }) => {
-  await mockedPage
-    .getByRole("button", { name: SETTINGS_BUTTON_NAME })
-    .click();
+  await mockedPage.getByRole("button", { name: SETTINGS_BUTTON_NAME }).click();
   await expect(
     mockedPage.getByRole("dialog", { name: SETTINGS_DIALOG_NAME }),
   ).toBeInViewport();
@@ -115,13 +114,13 @@ When("le facteur de fatigue est activé", async ({ mockedPage }) => {
 });
 
 When("le mode e-bike est activé", async ({ mockedPage }) => {
-  await mockedPage
-    .getByRole("button", { name: SETTINGS_BUTTON_NAME })
-    .click();
+  await mockedPage.getByRole("button", { name: SETTINGS_BUTTON_NAME }).click();
   await expect(
     mockedPage.getByRole("dialog", { name: SETTINGS_DIALOG_NAME }),
   ).toBeInViewport();
-  const ebikeToggle = mockedPage.getByRole("switch", { name: EBIKE_SWITCH_NAME });
+  const ebikeToggle = mockedPage.getByRole("switch", {
+    name: EBIKE_SWITCH_NAME,
+  });
   await ebikeToggle.click();
 });
 
@@ -208,9 +207,7 @@ When(
 );
 
 When("the fatigue factor is enabled", async ({ mockedPage }) => {
-  await mockedPage
-    .getByRole("button", { name: SETTINGS_BUTTON_NAME })
-    .click();
+  await mockedPage.getByRole("button", { name: SETTINGS_BUTTON_NAME }).click();
   await expect(
     mockedPage.getByRole("dialog", { name: SETTINGS_DIALOG_NAME }),
   ).toBeInViewport();
@@ -221,13 +218,13 @@ When("the fatigue factor is enabled", async ({ mockedPage }) => {
 });
 
 When("e-bike mode is enabled", async ({ mockedPage }) => {
-  await mockedPage
-    .getByRole("button", { name: SETTINGS_BUTTON_NAME })
-    .click();
+  await mockedPage.getByRole("button", { name: SETTINGS_BUTTON_NAME }).click();
   await expect(
     mockedPage.getByRole("dialog", { name: SETTINGS_DIALOG_NAME }),
   ).toBeInViewport();
-  const ebikeToggle = mockedPage.getByRole("switch", { name: EBIKE_SWITCH_NAME });
+  const ebikeToggle = mockedPage.getByRole("switch", {
+    name: EBIKE_SWITCH_NAME,
+  });
   await ebikeToggle.click();
 });
 
@@ -383,13 +380,10 @@ Then(
   },
 );
 
-Then(
-  "I see a rain alert on stage {int}",
-  async ({ mockedPage }, n: number) => {
-    const card = mockedPage.getByTestId(`stage-card-${n}`);
-    await expect(card).toContainText(/Heavy rain/, { timeout: 10000 });
-  },
-);
+Then("I see a rain alert on stage {int}", async ({ mockedPage }, n: number) => {
+  const card = mockedPage.getByTestId(`stage-card-${n}`);
+  await expect(card).toContainText(/Heavy rain/, { timeout: 10000 });
+});
 
 Then(
   "each stage shows a weather icon matching its conditions",
@@ -401,15 +395,12 @@ Then(
   },
 );
 
-Then(
-  "the travel times of all stages are updated",
-  async ({ mockedPage }) => {
-    for (let i = 1; i <= 3; i++) {
-      const card = mockedPage.getByTestId(`stage-card-${i}`);
-      await expect(card).toContainText(/\d+h\d{2}/, { timeout: 10000 });
-    }
-  },
-);
+Then("the travel times of all stages are updated", async ({ mockedPage }) => {
+  for (let i = 1; i <= 3; i++) {
+    const card = mockedPage.getByTestId(`stage-card-${i}`);
+    await expect(card).toContainText(/\d+h\d{2}/, { timeout: 10000 });
+  }
+});
 
 Then(
   "the target distance decreases progressively across stages",

--- a/pwa/tests/recette/support/accommodation-scan-tracker.ts
+++ b/pwa/tests/recette/support/accommodation-scan-tracker.ts
@@ -4,14 +4,17 @@ let pendingAccommodationScanRequest: Promise<Request> | undefined;
 
 export function trackAccommodationScanRequest(page: Page): void {
   pendingAccommodationScanRequest = page.waitForRequest(
-    (req) => req.url().includes("/accommodations/scan") && req.method() === "POST",
+    (req) =>
+      req.url().includes("/accommodations/scan") && req.method() === "POST",
     { timeout: 5000 },
   );
 }
 
 export async function takeAccommodationScanRequest(): Promise<Request> {
   if (!pendingAccommodationScanRequest) {
-    throw new Error("Accommodation scan request was not tracked before assertion");
+    throw new Error(
+      "Accommodation scan request was not tracked before assertion",
+    );
   }
 
   const request = await pendingAccommodationScanRequest;

--- a/pwa/tests/recette/support/export-download-tracker.ts
+++ b/pwa/tests/recette/support/export-download-tracker.ts
@@ -80,7 +80,9 @@ export async function trackStageExportDownload(
       return route.fulfill({
         status: 200,
         contentType:
-          extension === "gpx" ? "application/gpx+xml" : "application/octet-stream",
+          extension === "gpx"
+            ? "application/gpx+xml"
+            : "application/octet-stream",
         body: extension === "gpx" ? GPX_BODY : "",
       });
     },

--- a/pwa/tsconfig.json
+++ b/pwa/tsconfig.json
@@ -31,5 +31,10 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules", "capacitor.config.ts", "playwright.bdd.config.ts", "tests/recette"]
+  "exclude": [
+    "node_modules",
+    "capacitor.config.ts",
+    "playwright.bdd.config.ts",
+    "tests/recette"
+  ]
 }


### PR DESCRIPTION
## Summary
- Add `buildBatchCulturalPoiQuery()` to `QueryBuilderInterface` and `OsmOverpassQueryBuilder`
- Refactor `ScanPoisHandler` to use single batch POI query instead of N per-stage queries
- Refactor `CheckCulturalPoisHandler` to use single batch query with `GeometryDistributor` redistribution
- Reduces N Overpass API calls to 1 per handler

## Tests
- Updated `OsmOverpassQueryBuilderTest` with batch query tests
- Updated `CheckCulturalPoisHandlerTest` and `ScanPoisHandlerTest` for new batch pattern
- `make qa` ✅ `make phpunit` ✅ (786 tests)

Closes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

The batch-query refactor is clean and complete. All seven previous review threads are now resolved: stale query keys, orphaned stubs, and the dead `buildCulturalPoiQuery` method have all been addressed. No new findings.

**Findings: 0**

### Resolved threads
Resolved 1 previously open thread that was addressed:
- ✅ Dead `buildCulturalPoiQuery` method removed from `QueryBuilderInterface` and `OsmOverpassQueryBuilder` (last commit `fcffbc35`)

All 7 bot-authored threads are now resolved.

### Review checklist
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Inline comments
No inline comments.

---
Reviewed at commit `fcffbc35e18184062858e0d49fcb6bed935ebe6b`

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->