### PR TITLE
feat(upload): increase GPX upload limit to 30 MB

### DIFF
--- a/.docker/caddy/Caddyfile
+++ b/.docker/caddy/Caddyfile
@@ -8,6 +8,11 @@
 	log
 	encode zstd gzip
 
+	# Limit request body to 30 MB (GPX upload)
+	request_body {
+		max_size 30MB
+	}
+
 	handle /.well-known/mercure* {
 		reverse_proxy {$MERCURE_UPSTREAM:mercure:80}
 	}

--- a/.docker/php/Caddyfile
+++ b/.docker/php/Caddyfile
@@ -27,6 +27,11 @@
     root /app/public
     encode zstd br gzip
 
+    # Limit request body to 30 MB (GPX upload)
+    request_body {
+        max_size 30MB
+    }
+
     mercure {
         # Transport to use (default to Bolt)
         transport bolt {

--- a/.docker/php/conf.d/10-app.ini
+++ b/.docker/php/conf.d/10-app.ini
@@ -5,6 +5,10 @@ session.use_strict_mode = 1
 zend.detect_unicode = 0
 memory_limit = 256M
 
+; GPX upload limits (30 MB max file, 32 MB post to accommodate multipart headers)
+upload_max_filesize = 30M
+post_max_size = 32M
+
 ; https://symfony.com/doc/current/performance.html
 realpath_cache_size = 4096K
 realpath_cache_ttl = 600

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,7 @@ Backend PHP DTOs define the schema → API Platform exports OpenAPI spec → `np
   - RideWithGPS route: `^https://ridewithgps\.com/routes/\d+`
 - HTTP clients scoped to specific base URIs, max 2 redirects, 10s timeout
 - XMLReader hardened with `LIBXML_NONET` + `LIBXML_NOENT` (XXE prevention)
-- Upload limits: 15MB (Caddy + PHP), 128MB PHP memory limit
+- Upload limits: 30MB (Caddy + PHP), 128MB PHP memory limit
 
 ## ADR Documentation
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@
 | **Komoot** | `komoot.com/[xx-xx/]tour/123` and `komoot.com/[xx-xx/]collection/123` |
 | **Strava** | `strava.com/routes/123` |
 | **RideWithGPS** | `ridewithgps.com/routes/123` |
-| **GPX upload** | Direct file upload (up to 15 MB) |
+| **GPX upload** | Direct file upload (up to 30 MB) |
 
 ---
 

--- a/api/src/Controller/GpxUploadController.php
+++ b/api/src/Controller/GpxUploadController.php
@@ -20,7 +20,7 @@ use Symfony\Component\Routing\Attribute\Route;
  */
 final readonly class GpxUploadController
 {
-    private const int MAX_FILE_SIZE = 15 * 1024 * 1024; // 15 MB
+    private const int MAX_FILE_SIZE = 30 * 1024 * 1024; // 30 MB
 
     public function __construct(
         private GpxUploadService $gpxUploadService,
@@ -48,7 +48,7 @@ final readonly class GpxUploadController
 
         if ($file->getSize() > self::MAX_FILE_SIZE) {
             return new JsonResponse(
-                ['error' => 'File exceeds maximum size of 15 MB.'],
+                ['error' => 'File exceeds maximum size of 30 MB.'],
                 Response::HTTP_BAD_REQUEST,
             );
         }

--- a/api/src/OpenApi/GpxUploadOpenApiDecorator.php
+++ b/api/src/OpenApi/GpxUploadOpenApiDecorator.php
@@ -98,7 +98,7 @@ final readonly class GpxUploadOpenApiDecorator implements OpenApiFactoryInterfac
                             schema: new \ArrayObject([
                                 'type' => 'object',
                                 'properties' => [
-                                    'gpxFile' => ['type' => 'string', 'format' => 'binary', 'description' => 'GPX file (max 15 MB)'],
+                                    'gpxFile' => ['type' => 'string', 'format' => 'binary', 'description' => 'GPX file (max 30 MB)'],
                                     'startDate' => ['type' => 'string', 'format' => 'date', 'description' => 'Trip start date'],
                                     'endDate' => ['type' => 'string', 'format' => 'date', 'description' => 'Trip end date'],
                                     'fatigueFactor' => ['type' => 'number', 'description' => 'Fatigue factor (0-1)'],

--- a/api/tests/Functional/GpxUploadTest.php
+++ b/api/tests/Functional/GpxUploadTest.php
@@ -215,6 +215,43 @@ final class GpxUploadTest extends ApiTestCase
     }
 
     #[Test]
+    public function rejectsOversizedFile(): void
+    {
+        $tempFile = tempnam(sys_get_temp_dir(), 'test');
+        \assert(false !== $tempFile);
+
+        // Create a sparse file just over 30 MB without writing actual data
+        $handle = fopen($tempFile, 'r+');
+        \assert(false !== $handle);
+        ftruncate($handle, 30 * 1024 * 1024 + 1);
+        fclose($handle);
+
+        try {
+            $file = new UploadedFile(
+                $tempFile,
+                'oversized.gpx',
+                'application/gpx+xml',
+                null,
+                true,
+            );
+
+            $response = $this->client->request('POST', '/trips/gpx-upload', [
+                'headers' => array_merge(['Content-Type' => 'multipart/form-data'], $this->authHeader($this->jwtToken)),
+                'extra' => [
+                    'files' => ['gpxFile' => $file],
+                ],
+            ]);
+
+            $this->assertResponseStatusCodeSame(400);
+
+            $data = $response->toArray(false);
+            $this->assertStringContainsString('30 MB', $data['error']);
+        } finally {
+            unlink($tempFile);
+        }
+    }
+
+    #[Test]
     public function applyOptionalParametersIgnoresInvalidValues(): void
     {
         $file = new UploadedFile(

--- a/api/tests/Functional/GpxUploadTest.php
+++ b/api/tests/Functional/GpxUploadTest.php
@@ -236,7 +236,6 @@ final class GpxUploadTest extends ApiTestCase
             ]);
 
             $this->assertResponseStatusCodeSame(400);
-            $this->assertJsonContains(['error' => 'File exceeds maximum size of 30 MB.']);
         } finally {
             unlink($tempFile);
         }

--- a/api/tests/Functional/GpxUploadTest.php
+++ b/api/tests/Functional/GpxUploadTest.php
@@ -226,7 +226,7 @@ final class GpxUploadTest extends ApiTestCase
                 ->setConstructorArgs([$tempFile, 'big.gpx', 'application/gpx+xml', null, true])
                 ->onlyMethods(['getSize'])
                 ->getMock();
-            $file->method('getSize')->willReturn(31 * 1024 * 1024);
+            $file->expects($this->any())->method('getSize')->willReturn(31 * 1024 * 1024);
 
             $this->client->request('POST', '/trips/gpx-upload', [
                 'headers' => array_merge(['Content-Type' => 'multipart/form-data'], $this->authHeader($this->jwtToken)),

--- a/api/tests/Functional/GpxUploadTest.php
+++ b/api/tests/Functional/GpxUploadTest.php
@@ -6,11 +6,13 @@ namespace App\Tests\Functional;
 
 use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
 use ApiPlatform\Symfony\Bundle\Test\Client;
+use App\Controller\GpxUploadController;
 use App\Enum\ComputationName;
 use App\Message\GenerateStages;
 use App\Message\ScanAllOsmData;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport;
 
 final class GpxUploadTest extends ApiTestCase

--- a/api/tests/Functional/GpxUploadTest.php
+++ b/api/tests/Functional/GpxUploadTest.php
@@ -224,7 +224,7 @@ final class GpxUploadTest extends ApiTestCase
     #[Test]
     public function rejectsOversizedFile(): void
     {
-        $file = $this->createMock(UploadedFile::class);
+        $file = $this->createStub(UploadedFile::class);
         $file->method('isValid')->willReturn(true);
         $file->method('getSize')->willReturn(31 * 1024 * 1024);
 

--- a/api/tests/Functional/GpxUploadTest.php
+++ b/api/tests/Functional/GpxUploadTest.php
@@ -215,43 +215,6 @@ final class GpxUploadTest extends ApiTestCase
     }
 
     #[Test]
-    public function rejectsOversizedFile(): void
-    {
-        $tempFile = tempnam(sys_get_temp_dir(), 'test');
-        \assert(false !== $tempFile);
-
-        // Create a sparse file just over 30 MB without writing actual data
-        $handle = fopen($tempFile, 'r+');
-        \assert(false !== $handle);
-        ftruncate($handle, 30 * 1024 * 1024 + 1);
-        fclose($handle);
-
-        try {
-            $file = new UploadedFile(
-                $tempFile,
-                'oversized.gpx',
-                'application/gpx+xml',
-                null,
-                true,
-            );
-
-            $response = $this->client->request('POST', '/trips/gpx-upload', [
-                'headers' => array_merge(['Content-Type' => 'multipart/form-data'], $this->authHeader($this->jwtToken)),
-                'extra' => [
-                    'files' => ['gpxFile' => $file],
-                ],
-            ]);
-
-            $this->assertResponseStatusCodeSame(400);
-
-            $data = $response->toArray(false);
-            $this->assertStringContainsString('30 MB', $data['error']);
-        } finally {
-            unlink($tempFile);
-        }
-    }
-
-    #[Test]
     public function applyOptionalParametersIgnoresInvalidValues(): void
     {
         $file = new UploadedFile(

--- a/api/tests/Functional/GpxUploadTest.php
+++ b/api/tests/Functional/GpxUploadTest.php
@@ -215,32 +215,28 @@ final class GpxUploadTest extends ApiTestCase
     }
 
     /**
-     * Oversized files must be rejected with HTTP 400.
-     *
-     * Note: Symfony BrowserKit reconstructs UploadedFile objects internally,
-     * so mock overrides (getSize, isValid) are lost. In CI where
-     * upload_max_filesize=2MB, PHP rejects the file before the controller.
-     * Both paths return 400 — only the message differs.
+     * Tests the application-level MAX_FILE_SIZE guard by calling the controller
+     * directly — bypasses BrowserKit, which reconstructs UploadedFile objects
+     * and discards mock overrides.
      */
     #[Test]
     public function rejectsOversizedFile(): void
     {
-        $file = new UploadedFile(
-            self::FIXTURES_DIR.'/valid-route.gpx',
-            'oversized.gpx',
-            'application/gpx+xml',
-            \UPLOAD_ERR_INI_SIZE,
-            true,
+        $file = $this->createMock(UploadedFile::class);
+        $file->method('isValid')->willReturn(true);
+        $file->method('getSize')->willReturn(31 * 1024 * 1024);
+
+        $request = new Request([], [], [], [], ['gpxFile' => $file]);
+
+        /** @var GpxUploadController $controller */
+        $controller = self::getContainer()->get(GpxUploadController::class);
+        $response = $controller($request);
+
+        $this->assertSame(400, $response->getStatusCode());
+        $this->assertSame(
+            ['error' => 'File exceeds maximum size of 30 MB.'],
+            json_decode((string) $response->getContent(), true),
         );
-
-        $this->client->request('POST', '/trips/gpx-upload', [
-            'headers' => array_merge(['Content-Type' => 'multipart/form-data'], $this->authHeader($this->jwtToken)),
-            'extra' => [
-                'files' => ['gpxFile' => $file],
-            ],
-        ]);
-
-        $this->assertResponseStatusCodeSame(400);
     }
 
     #[Test]

--- a/api/tests/Functional/GpxUploadTest.php
+++ b/api/tests/Functional/GpxUploadTest.php
@@ -215,6 +215,34 @@ final class GpxUploadTest extends ApiTestCase
     }
 
     #[Test]
+    public function rejectsOversizedFile(): void
+    {
+        $tempFile = tempnam(sys_get_temp_dir(), 'test');
+        \assert(false !== $tempFile);
+        file_put_contents($tempFile, str_repeat('x', 1024));
+
+        try {
+            $file = $this->getMockBuilder(UploadedFile::class)
+                ->setConstructorArgs([$tempFile, 'big.gpx', 'application/gpx+xml', null, true])
+                ->onlyMethods(['getSize'])
+                ->getMock();
+            $file->method('getSize')->willReturn(31 * 1024 * 1024);
+
+            $this->client->request('POST', '/trips/gpx-upload', [
+                'headers' => array_merge(['Content-Type' => 'multipart/form-data'], $this->authHeader($this->jwtToken)),
+                'extra' => [
+                    'files' => ['gpxFile' => $file],
+                ],
+            ]);
+
+            $this->assertResponseStatusCodeSame(400);
+            $this->assertJsonContains(['error' => 'File exceeds maximum size of 30 MB.']);
+        } finally {
+            unlink($tempFile);
+        }
+    }
+
+    #[Test]
     public function applyOptionalParametersIgnoresInvalidValues(): void
     {
         $file = new UploadedFile(

--- a/api/tests/Functional/GpxUploadTest.php
+++ b/api/tests/Functional/GpxUploadTest.php
@@ -224,9 +224,10 @@ final class GpxUploadTest extends ApiTestCase
         try {
             $file = $this->getMockBuilder(UploadedFile::class)
                 ->setConstructorArgs([$tempFile, 'big.gpx', 'application/gpx+xml', null, true])
-                ->onlyMethods(['getSize'])
+                ->onlyMethods(['getSize', 'isValid'])
                 ->getMock();
             $file->expects($this->any())->method('getSize')->willReturn(31 * 1024 * 1024);
+            $file->expects($this->any())->method('isValid')->willReturn(true);
 
             $this->client->request('POST', '/trips/gpx-upload', [
                 'headers' => array_merge(['Content-Type' => 'multipart/form-data'], $this->authHeader($this->jwtToken)),
@@ -236,6 +237,7 @@ final class GpxUploadTest extends ApiTestCase
             ]);
 
             $this->assertResponseStatusCodeSame(400);
+            $this->assertJsonContains(['error' => 'File exceeds maximum size of 30 MB.']);
         } finally {
             unlink($tempFile);
         }

--- a/api/tests/Functional/GpxUploadTest.php
+++ b/api/tests/Functional/GpxUploadTest.php
@@ -214,33 +214,33 @@ final class GpxUploadTest extends ApiTestCase
         }
     }
 
+    /**
+     * Oversized files must be rejected with HTTP 400.
+     *
+     * Note: Symfony BrowserKit reconstructs UploadedFile objects internally,
+     * so mock overrides (getSize, isValid) are lost. In CI where
+     * upload_max_filesize=2MB, PHP rejects the file before the controller.
+     * Both paths return 400 — only the message differs.
+     */
     #[Test]
     public function rejectsOversizedFile(): void
     {
-        $tempFile = tempnam(sys_get_temp_dir(), 'test');
-        \assert(false !== $tempFile);
-        file_put_contents($tempFile, str_repeat('x', 1024));
+        $file = new UploadedFile(
+            self::FIXTURES_DIR.'/valid-route.gpx',
+            'oversized.gpx',
+            'application/gpx+xml',
+            \UPLOAD_ERR_INI_SIZE,
+            true,
+        );
 
-        try {
-            $file = $this->getMockBuilder(UploadedFile::class)
-                ->setConstructorArgs([$tempFile, 'big.gpx', 'application/gpx+xml', null, true])
-                ->onlyMethods(['getSize', 'isValid'])
-                ->getMock();
-            $file->expects($this->any())->method('getSize')->willReturn(31 * 1024 * 1024);
-            $file->expects($this->any())->method('isValid')->willReturn(true);
+        $this->client->request('POST', '/trips/gpx-upload', [
+            'headers' => array_merge(['Content-Type' => 'multipart/form-data'], $this->authHeader($this->jwtToken)),
+            'extra' => [
+                'files' => ['gpxFile' => $file],
+            ],
+        ]);
 
-            $this->client->request('POST', '/trips/gpx-upload', [
-                'headers' => array_merge(['Content-Type' => 'multipart/form-data'], $this->authHeader($this->jwtToken)),
-                'extra' => [
-                    'files' => ['gpxFile' => $file],
-                ],
-            ]);
-
-            $this->assertResponseStatusCodeSame(400);
-            $this->assertJsonContains(['error' => 'File exceeds maximum size of 30 MB.']);
-        } finally {
-            unlink($tempFile);
-        }
+        $this->assertResponseStatusCodeSame(400);
     }
 
     #[Test]

--- a/docs/adr/adr-011-security-input-validation-and-ssrf-prevention-for-gpx-url-ingestion.md
+++ b/docs/adr/adr-011-security-input-validation-and-ssrf-prevention-for-gpx-url-ingestion.md
@@ -184,8 +184,8 @@ at the infrastructure level (Nginx) and the PHP-FPM level.
 ```nginx
 server {
     # ...
-    # Limit file uploads to 15MB (A massive 1500km GPX is rarely larger than 10MB)
-    client_max_body_size 15M; 
+    # Limit file uploads to 30MB (A massive 1500km GPX is rarely larger than 10MB)
+    client_max_body_size 30M; 
 }
 ```
 
@@ -193,8 +193,8 @@ server {
 
 ```ini
 ; Restrict execution time and memory for the parsing scripts
-upload_max_filesize = 15M
-post_max_size = 15M
+upload_max_filesize = 30M
+post_max_size = 30M
 memory_limit = 128M
 max_execution_time = 30
 ```
@@ -244,7 +244,7 @@ max_execution_time = 30
 ### Negative
 
 * **Legitimate Edge Cases:** If a user attempts to upload an exceptionally highly-detailed, uncompressed GPX file larger
-  than 15MB, they will be blocked. They will need to compress or decimate their file using a third-party tool before
+  than 30MB, they will be blocked. They will need to compress or decimate their file using a third-party tool before
   using Bike Trip Planner.
 
 ### Neutral

--- a/docs/adr/adr-011-security-input-validation-and-ssrf-prevention-for-gpx-url-ingestion.md
+++ b/docs/adr/adr-011-security-input-validation-and-ssrf-prevention-for-gpx-url-ingestion.md
@@ -194,7 +194,7 @@ server {
 ```ini
 ; Restrict execution time and memory for the parsing scripts
 upload_max_filesize = 30M
-post_max_size = 30M
+post_max_size = 32M
 memory_limit = 128M
 max_execution_time = 30
 ```

--- a/pwa/src/lib/api/schema.d.ts
+++ b/pwa/src/lib/api/schema.d.ts
@@ -2045,7 +2045,7 @@ export interface operations {
                 "multipart/form-data": {
                     /**
                      * Format: binary
-                     * @description GPX file (max 15 MB)
+                     * @description GPX file (max 30 MB)
                      */
                     gpxFile: string;
                     /**

--- a/pwa/src/store/trip-store.ts
+++ b/pwa/src/store/trip-store.ts
@@ -467,7 +467,11 @@ export const useTripStore = create<TripState>()(
     loadFromSavedTrip: (trip) => {
       useTripTemporalStore.getState().clear();
       set((state) => {
-        state.trip = { id: trip.id, title: trip.title, sourceUrl: trip.sourceUrl };
+        state.trip = {
+          id: trip.id,
+          title: trip.title,
+          sourceUrl: trip.sourceUrl,
+        };
         state.startDate = trip.startDate;
         state.endDate = trip.endDate;
         state.fatigueFactor = trip.fatigueFactor;

--- a/pwa/tests/recette/features/edge-cases.en.feature
+++ b/pwa/tests/recette/features/edge-cases.en.feature
@@ -60,8 +60,8 @@ Feature: Edge cases and robustness
     Then tab 2 reflects the change or shows a warning
 
   @desktop @performance
-  Scenario: Large GPX file import (15MB)
-    When I import a 15MB GPX file
+  Scenario: Large GPX file import (30MB)
+    When I import a 30MB GPX file
     Then the import is processed in under 30 seconds
     And no memory error occurs
 

--- a/pwa/tests/recette/features/edge-cases.fr.feature
+++ b/pwa/tests/recette/features/edge-cases.fr.feature
@@ -61,8 +61,8 @@ Fonctionnalité: Cas limites et robustesse
     Alors l'onglet 2 reflète le changement ou affiche un avertissement
 
   @desktop @performance
-  Scénario: Import d'un fichier GPX de grande taille (15MB)
-    Quand j'importe un fichier GPX de 15MB
+  Scénario: Import d'un fichier GPX de grande taille (30MB)
+    Quand j'importe un fichier GPX de 30MB
     Alors l'import est traité en moins de 30 secondes
     Et aucune erreur de mémoire ne se produit
 

--- a/pwa/tests/recette/steps/accommodations.steps.ts
+++ b/pwa/tests/recette/steps/accommodations.steps.ts
@@ -10,7 +10,7 @@ import { getCurrentRecettePage } from "../support/current-recette-page";
 
 function getAccommodationTextAlias(text: string): string {
   const aliases: Record<string, string> = {
-    "Hôtel": "Hotel",
+    Hôtel: "Hotel",
     "Ajouter un hébergement": "Add accommodation",
   };
 
@@ -323,33 +323,30 @@ When(
   },
 );
 
-When(
-  "an accommodation is exactly at the endpoint",
-  async () => {
-    await injectSseSequence(getCurrentRecettePage(), [
-      {
-        type: "accommodations_found",
-        data: {
-          stageIndex: 0,
-          searchRadiusKm: 5,
-          accommodations: [
-            {
-              name: "Gîte du Terminus",
-              type: "guest_house",
-              lat: 44.532,
-              lon: 4.392,
-              estimatedPriceMin: 45,
-              estimatedPriceMax: 60,
-              isExactPrice: false,
-              possibleClosed: false,
-              distanceToEndPoint: 0,
-            },
-          ],
-        },
+When("an accommodation is exactly at the endpoint", async () => {
+  await injectSseSequence(getCurrentRecettePage(), [
+    {
+      type: "accommodations_found",
+      data: {
+        stageIndex: 0,
+        searchRadiusKm: 5,
+        accommodations: [
+          {
+            name: "Gîte du Terminus",
+            type: "guest_house",
+            lat: 44.532,
+            lon: 4.392,
+            estimatedPriceMin: 45,
+            estimatedPriceMax: 60,
+            isExactPrice: false,
+            possibleClosed: false,
+            distanceToEndPoint: 0,
+          },
+        ],
       },
-    ]);
-  },
-);
+    },
+  ]);
+});
 
 Then(
   "aucun badge de distance n'est affiché pour cet hébergement",
@@ -363,13 +360,13 @@ Then(
   },
 );
 
-Then(
-  "no distance badge is displayed for that accommodation",
-  async () => {
-    const stageCard = getCurrentRecettePage().getByTestId("stage-card-1");
-    await expect(stageCard).toContainText(/Gîte du Terminus|Terminus Guest House/, {
+Then("no distance badge is displayed for that accommodation", async () => {
+  const stageCard = getCurrentRecettePage().getByTestId("stage-card-1");
+  await expect(stageCard).toContainText(
+    /Gîte du Terminus|Terminus Guest House/,
+    {
       timeout: 5000,
-    });
-    await expect(stageCard.locator('[aria-label*="0 km"]')).toHaveCount(0);
-  },
-);
+    },
+  );
+  await expect(stageCard.locator('[aria-label*="0 km"]')).toHaveCount(0);
+});

--- a/pwa/tests/recette/steps/configuration.steps.ts
+++ b/pwa/tests/recette/steps/configuration.steps.ts
@@ -6,11 +6,13 @@ import { When, Then } from "../support/fixtures";
 // ---------------------------------------------------------------------------
 
 const SETTINGS_BUTTON_NAME = /Ouvrir les paramètres|Open settings/i;
-const SPEED_SLIDER_NAME = /Vitesse moyenne \(km\/h\)|Average cycling speed \(km\/h\)/i;
+const SPEED_SLIDER_NAME =
+  /Vitesse moyenne \(km\/h\)|Average cycling speed \(km\/h\)/i;
 const MAX_DISTANCE_SLIDER_NAME =
   /Distance maximale par jour \(km\)|Maximum distance per day \(km\)/i;
 const EBIKE_SWITCH_NAME = /Mode VAE|E-bike mode/i;
-const DEPARTURE_SLIDER_NAME = /Heure de départ \(0-23\)|Departure hour \(0-23\)/i;
+const DEPARTURE_SLIDER_NAME =
+  /Heure de départ \(0-23\)|Departure hour \(0-23\)/i;
 const ACCOMMODATION_SECTION_HEADING =
   /Types d'hébergements|Accommodation types/i;
 
@@ -95,12 +97,9 @@ Then(
   },
 );
 
-Then(
-  "the last switch is disabled and cannot be toggled",
-  async ({ $test }) => {
-    $test.fixme();
-  },
-);
+Then("the last switch is disabled and cannot be toggled", async ({ $test }) => {
+  $test.fixme();
+});
 
 // --- Additional missing steps ---
 // "je suis sur la page du voyage avec les étapes calculées" / "I am on the trip page with computed stages" defined in common.steps.ts
@@ -178,12 +177,16 @@ Then(
 );
 
 When("j'active le mode e-bike", async ({ mockedPage }) => {
-  const ebikeToggle = mockedPage.getByRole("switch", { name: EBIKE_SWITCH_NAME });
+  const ebikeToggle = mockedPage.getByRole("switch", {
+    name: EBIKE_SWITCH_NAME,
+  });
   await ebikeToggle.click();
 });
 
 When("I enable e-bike mode", async ({ mockedPage }) => {
-  const ebikeToggle = mockedPage.getByRole("switch", { name: EBIKE_SWITCH_NAME });
+  const ebikeToggle = mockedPage.getByRole("switch", {
+    name: EBIKE_SWITCH_NAME,
+  });
   await ebikeToggle.click();
 });
 

--- a/pwa/tests/recette/steps/cross-cutting-ux.steps.ts
+++ b/pwa/tests/recette/steps/cross-cutting-ux.steps.ts
@@ -420,12 +420,9 @@ Then(
   },
 );
 
-Then(
-  "un toast de confirmation s'affiche brièvement",
-  async ({ $test }) => {
-    $test.fixme();
-  },
-);
+Then("un toast de confirmation s'affiche brièvement", async ({ $test }) => {
+  $test.fixme();
+});
 
 Then(
   "un message d'erreur compréhensible est affiché à l'utilisateur",

--- a/pwa/tests/recette/steps/dates-calendar.steps.ts
+++ b/pwa/tests/recette/steps/dates-calendar.steps.ts
@@ -103,7 +103,10 @@ async function selectCalendarDate(
     'button[aria-label*="suivant"], button[aria-label*="next"], button[aria-label*="Next"]',
   );
   for (let i = 0; i < 24; i++) {
-    const header = mockedPage.locator('[class*="font-semibold"]').filter({ hasText: /\d{4}/ }).first();
+    const header = mockedPage
+      .locator('[class*="font-semibold"]')
+      .filter({ hasText: /\d{4}/ })
+      .first();
     const headerText = await header.textContent();
     if (!headerText) {
       await nextButton.first().click();
@@ -376,12 +379,9 @@ When("I navigate to the next month", async ({ mockedPage }) => {
 
 // --- Then steps FR ---
 
-Then(
-  "la date de départ affichée est {string}",
-  async ({ $test }) => {
-    $test.fixme();
-  },
-);
+Then("la date de départ affichée est {string}", async ({ $test }) => {
+  $test.fixme();
+});
 
 Then(/^l'étape (\d+) est prévue le \d+ \w+ \d+$/, async ({ mockedPage }) => {
   // Stage cards show sunrise/sunset times when a start date is set,
@@ -428,12 +428,9 @@ Then("le mois suivant est affiché", async ({ mockedPage }) => {
 
 // --- Then steps EN ---
 
-Then(
-  "the displayed departure date is {string}",
-  async ({ $test }) => {
-    $test.fixme();
-  },
-);
+Then("the displayed departure date is {string}", async ({ $test }) => {
+  $test.fixme();
+});
 
 Then(/^stage (\d+) is scheduled for \w+ \d+, \d+$/, async ({ mockedPage }) => {
   const stageCards = mockedPage.locator('[data-testid^="stage-card-"]');

--- a/pwa/tests/recette/steps/export.steps.ts
+++ b/pwa/tests/recette/steps/export.steps.ts
@@ -73,13 +73,10 @@ When(
   },
 );
 
-When(
-  "le calcul des étapes est en cours",
-  async ({ $test }) => {
-    // The current UI does not disable FIT downloads based on computation state alone.
-    $test.fixme();
-  },
-);
+When("le calcul des étapes est en cours", async ({ $test }) => {
+  // The current UI does not disable FIT downloads based on computation state alone.
+  $test.fixme();
+});
 
 When(
   "je clique sur le bouton export de format {string} de l'étape {int}",
@@ -96,18 +93,15 @@ When(
 
 // --- When steps EN ---
 
-When(
-  'I click "Download GPX" for stage {int}',
-  async ({}, stage: number) => {
-    const page = getCurrentRecettePage();
-    await trackStageGpxDownload(page);
-    const stageCard = page.getByTestId(`stage-card-${stage}`);
-    const gpxButton = stageCard.getByRole("button", {
-      name: /Download GPX/,
-    });
-    await gpxButton.click();
-  },
-);
+When('I click "Download GPX" for stage {int}', async ({}, stage: number) => {
+  const page = getCurrentRecettePage();
+  await trackStageGpxDownload(page);
+  const stageCard = page.getByTestId(`stage-card-${stage}`);
+  const gpxButton = stageCard.getByRole("button", {
+    name: /Download GPX/,
+  });
+  await gpxButton.click();
+});
 
 When("I select a valid GPX file", async ({ $test }) => {
   // $test.fixme: file upload requires a real GPX file fixture — part of @fixme scenario
@@ -119,26 +113,20 @@ When("I try to import a non-GPX file", async ({ $test }) => {
   $test.fixme();
 });
 
-When(
-  'I click "Download FIT" for stage {int}',
-  async ({}, stage: number) => {
-    const page = getCurrentRecettePage();
-    await trackStageFitDownload(page);
-    const stageCard = page.getByTestId(`stage-card-${stage}`);
-    const fitButton = stageCard.getByRole("button", {
-      name: /Download FIT/,
-    });
-    await fitButton.click();
-  },
-);
+When('I click "Download FIT" for stage {int}', async ({}, stage: number) => {
+  const page = getCurrentRecettePage();
+  await trackStageFitDownload(page);
+  const stageCard = page.getByTestId(`stage-card-${stage}`);
+  const fitButton = stageCard.getByRole("button", {
+    name: /Download FIT/,
+  });
+  await fitButton.click();
+});
 
-When(
-  "stage computation is in progress",
-  async ({ $test }) => {
-    // The current UI does not disable FIT downloads based on computation state alone.
-    $test.fixme();
-  },
-);
+When("stage computation is in progress", async ({ $test }) => {
+  // The current UI does not disable FIT downloads based on computation state alone.
+  $test.fixme();
+});
 
 When(
   "I click the export button for format {string} on stage {int}",
@@ -190,16 +178,13 @@ Then(
   },
 );
 
-Then(
-  /^une requête GET vers \/trips\/\*\.gpx est envoyée$/,
-  async () => {
-    const tripGpxRequests = getTrackedTripGpxRequests();
-    await expect
-      .poll(() => tripGpxRequests.length, { timeout: 5000 })
-      .toBeGreaterThan(0);
-    expect(tripGpxRequests[0]).toMatch(/\/trips\/[^/]+\.gpx$/);
-  },
-);
+Then(/^une requête GET vers \/trips\/\*\.gpx est envoyée$/, async () => {
+  const tripGpxRequests = getTrackedTripGpxRequests();
+  await expect
+    .poll(() => tripGpxRequests.length, { timeout: 5000 })
+    .toBeGreaterThan(0);
+  expect(tripGpxRequests[0]).toMatch(/\/trips\/[^/]+\.gpx$/);
+});
 
 Then("le voyage est créé à partir du fichier GPX", async ({ $test }) => {
   // $test.fixme: part of @fixme scenario (GPX file upload not yet testable)
@@ -261,16 +246,13 @@ Then(
   },
 );
 
-Then(
-  /^a GET request to \/trips\/\*\/stages\/0\.gpx is sent$/,
-  async () => {
-    const gpxRequests = getTrackedStageGpxRequests();
-    await expect
-      .poll(() => gpxRequests.length, { timeout: 5000 })
-      .toBeGreaterThan(0);
-    expect(gpxRequests[0]).toContain("/stages/0.gpx");
-  },
-);
+Then(/^a GET request to \/trips\/\*\/stages\/0\.gpx is sent$/, async () => {
+  const gpxRequests = getTrackedStageGpxRequests();
+  await expect
+    .poll(() => gpxRequests.length, { timeout: 5000 })
+    .toBeGreaterThan(0);
+  expect(gpxRequests[0]).toContain("/stages/0.gpx");
+});
 
 Then(
   'the "Télécharger le GPX complet" button is visible and enabled',
@@ -305,16 +287,13 @@ Then("an error message is displayed", async ({ mockedPage }) => {
   ).toBeVisible({ timeout: 5000 });
 });
 
-Then(
-  /^a GET request to \/trips\/\*\/stages\/0\.fit is sent$/,
-  async () => {
-    const fitRequests = getTrackedStageFitRequests();
-    await expect
-      .poll(() => fitRequests.length, { timeout: 5000 })
-      .toBeGreaterThan(0);
-    expect(fitRequests[0]).toContain("/stages/0.fit");
-  },
-);
+Then(/^a GET request to \/trips\/\*\/stages\/0\.fit is sent$/, async () => {
+  const fitRequests = getTrackedStageFitRequests();
+  await expect
+    .poll(() => fitRequests.length, { timeout: 5000 })
+    .toBeGreaterThan(0);
+  expect(fitRequests[0]).toContain("/stages/0.fit");
+});
 
 Then(
   "the FIT button for stage {int} is disabled",
@@ -328,14 +307,11 @@ Then(
   },
 );
 
-Then(
-  "the downloaded file has extension {string}",
-  async ({}, ext: string) => {
-    const downloadRequests = getTrackedStageExportRequests();
-    const normalizedExt = ext.replace(/^\./, "");
-    await expect
-      .poll(() => downloadRequests.length, { timeout: 5000 })
-      .toBeGreaterThan(0);
-    expect(downloadRequests[0]).toContain(`.${normalizedExt}`);
-  },
-);
+Then("the downloaded file has extension {string}", async ({}, ext: string) => {
+  const downloadRequests = getTrackedStageExportRequests();
+  const normalizedExt = ext.replace(/^\./, "");
+  await expect
+    .poll(() => downloadRequests.length, { timeout: 5000 })
+    .toBeGreaterThan(0);
+  expect(downloadRequests[0]).toContain(`.${normalizedExt}`);
+});

--- a/pwa/tests/recette/steps/weather-time.steps.ts
+++ b/pwa/tests/recette/steps/weather-time.steps.ts
@@ -13,7 +13,8 @@ import type { MercureEvent } from "../../../src/lib/mercure/types";
 
 const SETTINGS_BUTTON_NAME = /Ouvrir les paramètres|Open settings/i;
 const SETTINGS_DIALOG_NAME = /Paramètres|Settings/i;
-const SPEED_SLIDER_NAME = /Vitesse moyenne \(km\/h\)|Average cycling speed \(km\/h\)/i;
+const SPEED_SLIDER_NAME =
+  /Vitesse moyenne \(km\/h\)|Average cycling speed \(km\/h\)/i;
 const FATIGUE_SLIDER_NAME =
   /Indice de fatigue accumulée|Accumulated fatigue index/i;
 const EBIKE_SWITCH_NAME = /Mode VAE|E-bike mode/i;
@@ -102,9 +103,7 @@ When(
 );
 
 When("le facteur de fatigue est activé", async ({ mockedPage }) => {
-  await mockedPage
-    .getByRole("button", { name: SETTINGS_BUTTON_NAME })
-    .click();
+  await mockedPage.getByRole("button", { name: SETTINGS_BUTTON_NAME }).click();
   await expect(
     mockedPage.getByRole("dialog", { name: SETTINGS_DIALOG_NAME }),
   ).toBeInViewport();
@@ -115,13 +114,13 @@ When("le facteur de fatigue est activé", async ({ mockedPage }) => {
 });
 
 When("le mode e-bike est activé", async ({ mockedPage }) => {
-  await mockedPage
-    .getByRole("button", { name: SETTINGS_BUTTON_NAME })
-    .click();
+  await mockedPage.getByRole("button", { name: SETTINGS_BUTTON_NAME }).click();
   await expect(
     mockedPage.getByRole("dialog", { name: SETTINGS_DIALOG_NAME }),
   ).toBeInViewport();
-  const ebikeToggle = mockedPage.getByRole("switch", { name: EBIKE_SWITCH_NAME });
+  const ebikeToggle = mockedPage.getByRole("switch", {
+    name: EBIKE_SWITCH_NAME,
+  });
   await ebikeToggle.click();
 });
 
@@ -208,9 +207,7 @@ When(
 );
 
 When("the fatigue factor is enabled", async ({ mockedPage }) => {
-  await mockedPage
-    .getByRole("button", { name: SETTINGS_BUTTON_NAME })
-    .click();
+  await mockedPage.getByRole("button", { name: SETTINGS_BUTTON_NAME }).click();
   await expect(
     mockedPage.getByRole("dialog", { name: SETTINGS_DIALOG_NAME }),
   ).toBeInViewport();
@@ -221,13 +218,13 @@ When("the fatigue factor is enabled", async ({ mockedPage }) => {
 });
 
 When("e-bike mode is enabled", async ({ mockedPage }) => {
-  await mockedPage
-    .getByRole("button", { name: SETTINGS_BUTTON_NAME })
-    .click();
+  await mockedPage.getByRole("button", { name: SETTINGS_BUTTON_NAME }).click();
   await expect(
     mockedPage.getByRole("dialog", { name: SETTINGS_DIALOG_NAME }),
   ).toBeInViewport();
-  const ebikeToggle = mockedPage.getByRole("switch", { name: EBIKE_SWITCH_NAME });
+  const ebikeToggle = mockedPage.getByRole("switch", {
+    name: EBIKE_SWITCH_NAME,
+  });
   await ebikeToggle.click();
 });
 
@@ -383,13 +380,10 @@ Then(
   },
 );
 
-Then(
-  "I see a rain alert on stage {int}",
-  async ({ mockedPage }, n: number) => {
-    const card = mockedPage.getByTestId(`stage-card-${n}`);
-    await expect(card).toContainText(/Heavy rain/, { timeout: 10000 });
-  },
-);
+Then("I see a rain alert on stage {int}", async ({ mockedPage }, n: number) => {
+  const card = mockedPage.getByTestId(`stage-card-${n}`);
+  await expect(card).toContainText(/Heavy rain/, { timeout: 10000 });
+});
 
 Then(
   "each stage shows a weather icon matching its conditions",
@@ -401,15 +395,12 @@ Then(
   },
 );
 
-Then(
-  "the travel times of all stages are updated",
-  async ({ mockedPage }) => {
-    for (let i = 1; i <= 3; i++) {
-      const card = mockedPage.getByTestId(`stage-card-${i}`);
-      await expect(card).toContainText(/\d+h\d{2}/, { timeout: 10000 });
-    }
-  },
-);
+Then("the travel times of all stages are updated", async ({ mockedPage }) => {
+  for (let i = 1; i <= 3; i++) {
+    const card = mockedPage.getByTestId(`stage-card-${i}`);
+    await expect(card).toContainText(/\d+h\d{2}/, { timeout: 10000 });
+  }
+});
 
 Then(
   "the target distance decreases progressively across stages",

--- a/pwa/tests/recette/support/accommodation-scan-tracker.ts
+++ b/pwa/tests/recette/support/accommodation-scan-tracker.ts
@@ -4,14 +4,17 @@ let pendingAccommodationScanRequest: Promise<Request> | undefined;
 
 export function trackAccommodationScanRequest(page: Page): void {
   pendingAccommodationScanRequest = page.waitForRequest(
-    (req) => req.url().includes("/accommodations/scan") && req.method() === "POST",
+    (req) =>
+      req.url().includes("/accommodations/scan") && req.method() === "POST",
     { timeout: 5000 },
   );
 }
 
 export async function takeAccommodationScanRequest(): Promise<Request> {
   if (!pendingAccommodationScanRequest) {
-    throw new Error("Accommodation scan request was not tracked before assertion");
+    throw new Error(
+      "Accommodation scan request was not tracked before assertion",
+    );
   }
 
   const request = await pendingAccommodationScanRequest;

--- a/pwa/tests/recette/support/export-download-tracker.ts
+++ b/pwa/tests/recette/support/export-download-tracker.ts
@@ -80,7 +80,9 @@ export async function trackStageExportDownload(
       return route.fulfill({
         status: 200,
         contentType:
-          extension === "gpx" ? "application/gpx+xml" : "application/octet-stream",
+          extension === "gpx"
+            ? "application/gpx+xml"
+            : "application/octet-stream",
         body: extension === "gpx" ? GPX_BODY : "",
       });
     },

--- a/pwa/tsconfig.json
+++ b/pwa/tsconfig.json
@@ -31,5 +31,10 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules", "capacitor.config.ts", "playwright.bdd.config.ts", "tests/recette"]
+  "exclude": [
+    "node_modules",
+    "capacitor.config.ts",
+    "playwright.bdd.config.ts",
+    "tests/recette"
+  ]
 }


### PR DESCRIPTION
## Summary
- Update Caddy `request_body` limit to 30 MB (both reverse proxy and FrankenPHP)
- Update PHP `upload_max_filesize` to 30M, `post_max_size` to 32M
- Update `GpxUploadController::MAX_FILE_SIZE` constant to 30 MB
- Update OpenAPI description, CLAUDE.md, README.md, and Gherkin feature files

## Tests
- Updated E2E Gherkin scenarios for new 30 MB limit
- `make qa` ✅ `make phpunit` ✅ (784 tests)

Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

**Summary:** Clean, well-executed limit increase. All seven prior review threads are resolved. The limit propagates consistently across every layer — Caddy reverse proxy, FrankenPHP, PHP ini (`upload_max_filesize=30M` / `post_max_size=32M`), controller constant, OpenAPI decorator, generated TypeScript types, ADR-011, CLAUDE.md, and README.md. The final `rejectsOversizedFile()` test correctly targets the `MAX_FILE_SIZE` guard (controller line 49) by calling the controller directly with a `createStub()` override for both `isValid()` and `getSize()`, and asserts both the 400 status code and the exact error message body.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases — `MAX_FILE_SIZE` branch exercised via direct controller call with `createStub()`; error message asserted
- [x] Documentation is up to date — ADR-011, CLAUDE.md, README.md, `schema.d.ts` all updated
- [x] Dependent tickets accounted for (closes #280)

**Inline comments:** No inline comments.

**Commit reviewed:** `daf55c52f57f120fb0c20b3ce5c98f23076764a3`

---
Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->