### PR TITLE
feat(alerts): add action field to Alert model

### DIFF
--- a/TRACKING.md
+++ b/TRACKING.md
@@ -666,7 +666,7 @@ Mise en production basée sur [ADR-019](docs/adr/adr-019-deployment-infrastructu
 | 5     | Docker configs production (PostgreSQL, Redis, Mercure, Caddy) | L      |
 | 6     | Monitoring & healthchecks                          | M      |
 | 7     | Migration données + smoke test production          | M      |
-| 8     | [#312](https://github.com/vincentchalamon/bike-trip-planner/issues/312) | Feature-deploy : preview par PR | L | Étapes 1-7 |
+| 8     | [#312](https://github.com/vincentchalamon/bike-trip-planner/issues/312) Feature-deploy : preview par PR (dépend étapes 1-7) | L      |
 
 ### Recette Sprint 30
 

--- a/api/src/ApiResource/Model/Alert.php
+++ b/api/src/ApiResource/Model/Alert.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\ApiResource\Model;
 
+use ApiPlatform\Metadata\ApiProperty;
 use App\Enum\AlertType;
 
 readonly class Alert
@@ -13,6 +14,8 @@ readonly class Alert
         public string $message,
         public ?float $lat = null,
         public ?float $lon = null,
+        #[ApiProperty(description: 'Optional contextual action for this alert.')]
+        public ?AlertAction $action = null,
     ) {
     }
 }

--- a/api/src/ApiResource/Model/AlertAction.php
+++ b/api/src/ApiResource/Model/AlertAction.php
@@ -14,10 +14,8 @@ final readonly class AlertAction
     public function __construct(
         #[ApiProperty(description: 'Type of action: auto_fix, detour, navigate, dismiss.')]
         public AlertActionKind $kind,
-
         #[ApiProperty(description: 'Human-readable label for the action button.')]
         public string $label,
-
         #[ApiProperty(description: 'Machine-readable payload for the action.')]
         public array $payload = [],
     ) {

--- a/api/src/ApiResource/Model/AlertAction.php
+++ b/api/src/ApiResource/Model/AlertAction.php
@@ -12,9 +12,9 @@ final readonly class AlertAction
      * @param array<string, mixed> $payload
      */
     public function __construct(
-        #[ApiProperty(description: 'Type of action: auto_fix, detour, navigate, dismiss.')]
+        #[ApiProperty(description: 'Type of action: auto_fix, detour, navigate, dismiss.', required: true)]
         public AlertActionKind $kind,
-        #[ApiProperty(description: 'Human-readable label for the action button.')]
+        #[ApiProperty(description: 'Human-readable label for the action button.', required: true)]
         public string $label,
         #[ApiProperty(
             description: 'Machine-readable payload for the action.',

--- a/api/src/ApiResource/Model/AlertAction.php
+++ b/api/src/ApiResource/Model/AlertAction.php
@@ -16,7 +16,10 @@ final readonly class AlertAction
         public AlertActionKind $kind,
         #[ApiProperty(description: 'Human-readable label for the action button.')]
         public string $label,
-        #[ApiProperty(description: 'Machine-readable payload for the action.')]
+        #[ApiProperty(
+            description: 'Machine-readable payload for the action.',
+            openapiContext: ['type' => 'object', 'additionalProperties' => true],
+        )]
         public array $payload = [],
     ) {
     }

--- a/api/src/ApiResource/Model/AlertAction.php
+++ b/api/src/ApiResource/Model/AlertAction.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ApiResource\Model;
+
+use ApiPlatform\Metadata\ApiProperty;
+
+final readonly class AlertAction
+{
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public function __construct(
+        #[ApiProperty(description: 'Type of action: auto_fix, detour, navigate, dismiss.')]
+        public AlertActionKind $kind,
+
+        #[ApiProperty(description: 'Human-readable label for the action button.')]
+        public string $label,
+
+        #[ApiProperty(description: 'Machine-readable payload for the action.')]
+        public array $payload = [],
+    ) {
+    }
+}

--- a/api/src/ApiResource/Model/AlertActionKind.php
+++ b/api/src/ApiResource/Model/AlertActionKind.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ApiResource\Model;
+
+enum AlertActionKind: string
+{
+    case AUTO_FIX = 'auto_fix';
+    case DETOUR = 'detour';
+    case NAVIGATE = 'navigate';
+    case DISMISS = 'dismiss';
+}

--- a/api/src/ApiResource/Model/CulturalPoiAlert.php
+++ b/api/src/ApiResource/Model/CulturalPoiAlert.php
@@ -31,7 +31,8 @@ final readonly class CulturalPoiAlert extends Alert
         public float $poiLon = 0.0,
         #[ApiProperty(description: 'Approximate distance from the nearest route point, in metres.')]
         public int $distanceFromRoute = 0,
+        ?AlertAction $action = null,
     ) {
-        parent::__construct($type, $message, $lat, $lon);
+        parent::__construct($type, $message, $lat, $lon, $action);
     }
 }

--- a/api/tests/Unit/ApiResource/AlertActionTest.php
+++ b/api/tests/Unit/ApiResource/AlertActionTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\ApiResource;
+
+use App\ApiResource\Model\Alert;
+use App\ApiResource\Model\AlertAction;
+use App\ApiResource\Model\AlertActionKind;
+use App\Enum\AlertType;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class AlertActionTest extends TestCase
+{
+    #[Test]
+    public function alertActionHasCorrectProperties(): void
+    {
+        $action = new AlertAction(
+            kind: AlertActionKind::AUTO_FIX,
+            label: 'Split stage',
+            payload: ['splitAt' => 45.0],
+        );
+
+        $this->assertSame(AlertActionKind::AUTO_FIX, $action->kind);
+        $this->assertSame('Split stage', $action->label);
+        $this->assertSame(['splitAt' => 45.0], $action->payload);
+    }
+
+    #[Test]
+    public function alertActionDefaultsToEmptyPayload(): void
+    {
+        $action = new AlertAction(
+            kind: AlertActionKind::DISMISS,
+            label: 'Dismiss',
+        );
+
+        $this->assertSame([], $action->payload);
+    }
+
+    #[Test]
+    public function alertActionKindEnumValues(): void
+    {
+        $this->assertSame('auto_fix', AlertActionKind::AUTO_FIX->value);
+        $this->assertSame('detour', AlertActionKind::DETOUR->value);
+        $this->assertSame('navigate', AlertActionKind::NAVIGATE->value);
+        $this->assertSame('dismiss', AlertActionKind::DISMISS->value);
+    }
+
+    #[Test]
+    public function alertActionKindFromString(): void
+    {
+        $this->assertSame(AlertActionKind::AUTO_FIX, AlertActionKind::from('auto_fix'));
+        $this->assertSame(AlertActionKind::DETOUR, AlertActionKind::from('detour'));
+        $this->assertSame(AlertActionKind::NAVIGATE, AlertActionKind::from('navigate'));
+        $this->assertSame(AlertActionKind::DISMISS, AlertActionKind::from('dismiss'));
+    }
+
+    #[Test]
+    public function alertWithAction(): void
+    {
+        $action = new AlertAction(
+            kind: AlertActionKind::NAVIGATE,
+            label: 'Zoom to location',
+            payload: ['lat' => 44.6, 'lon' => 4.5],
+        );
+
+        $alert = new Alert(
+            type: AlertType::WARNING,
+            message: 'Steep gradient detected',
+            lat: 44.6,
+            lon: 4.5,
+            action: $action,
+        );
+
+        $this->assertSame(AlertType::WARNING, $alert->type);
+        $this->assertSame('Steep gradient detected', $alert->message);
+        $this->assertNotNull($alert->action);
+        $this->assertSame(AlertActionKind::NAVIGATE, $alert->action->kind);
+        $this->assertSame('Zoom to location', $alert->action->label);
+        $this->assertSame(['lat' => 44.6, 'lon' => 4.5], $alert->action->payload);
+    }
+
+    #[Test]
+    public function alertWithoutAction(): void
+    {
+        $alert = new Alert(
+            type: AlertType::WARNING,
+            message: 'Route non goudronnée sur 3km',
+        );
+
+        $this->assertNull($alert->action);
+    }
+
+    #[Test]
+    public function alertActionWithComplexPayload(): void
+    {
+        $action = new AlertAction(
+            kind: AlertActionKind::AUTO_FIX,
+            label: 'Apply fix',
+            payload: [
+                'stageIndex' => 0,
+                'adjustments' => ['splitAt' => 45.0, 'newTarget' => 60.0],
+                'reason' => 'ebike_range',
+            ],
+        );
+
+        $this->assertSame(AlertActionKind::AUTO_FIX, $action->kind);
+        $this->assertArrayHasKey('stageIndex', $action->payload);
+        $this->assertArrayHasKey('adjustments', $action->payload);
+        $this->assertArrayHasKey('reason', $action->payload);
+    }
+}

--- a/pwa/src/components/alert-list.tsx
+++ b/pwa/src/components/alert-list.tsx
@@ -35,9 +35,7 @@ function isCulturalPoiAlert(alert: AlertData): boolean {
 
 export function AlertList({ alerts, onAddPoiWaypoint }: AlertListProps) {
   const t = useTranslations("alertList");
-  const [dismissedKeys, setDismissedKeys] = useState<Set<string>>(
-    new Set(),
-  );
+  const [dismissedKeys, setDismissedKeys] = useState<Set<string>>(new Set());
 
   const handleDismiss = useCallback((key: string) => {
     setDismissedKeys((prev) => new Set(prev).add(key));

--- a/pwa/src/components/alert-list.tsx
+++ b/pwa/src/components/alert-list.tsx
@@ -1,10 +1,24 @@
+import { useState, useCallback } from "react";
 import { AlertBadge } from "@/components/alert-badge";
 import type { AlertData } from "@/lib/validation/schemas";
 import { Button } from "@/components/ui/button";
-import { MapPin } from "lucide-react";
+import {
+  MapPin,
+  Wrench,
+  Map as MapIcon,
+  Navigation,
+  Check,
+} from "lucide-react";
 import { useTranslations } from "next-intl";
 
 const severityOrder = { critical: 0, warning: 1, nudge: 2 } as const;
+
+const actionIcons = {
+  auto_fix: Wrench,
+  detour: MapIcon,
+  navigate: Navigation,
+  dismiss: Check,
+} as const;
 
 interface AlertListProps {
   alerts: AlertData[];
@@ -21,6 +35,13 @@ function isCulturalPoiAlert(alert: AlertData): boolean {
 
 export function AlertList({ alerts, onAddPoiWaypoint }: AlertListProps) {
   const t = useTranslations("alertList");
+  const [dismissedIndices, setDismissedIndices] = useState<Set<number>>(
+    new Set(),
+  );
+
+  const handleDismiss = useCallback((index: number) => {
+    setDismissedIndices((prev) => new Set(prev).add(index));
+  }, []);
 
   if (alerts.length === 0) return null;
 
@@ -30,23 +51,51 @@ export function AlertList({ alerts, onAddPoiWaypoint }: AlertListProps) {
 
   return (
     <div className="flex flex-col gap-2">
-      {sorted.map((alert, index) => (
-        <div key={`${alert.type}-${alert.source}-${index}`}>
-          <AlertBadge type={alert.type} message={alert.message} />
-          {isCulturalPoiAlert(alert) && onAddPoiWaypoint && (
-            <Button
-              variant="outline"
-              size="sm"
-              className="mt-1 ml-1 h-6 px-2 text-xs text-blue-700 dark:text-blue-400 border-blue-300 dark:border-blue-700 hover:bg-blue-50 dark:hover:bg-blue-900/20"
-              onClick={() => onAddPoiWaypoint(alert.poiLat!, alert.poiLon!)}
-              data-testid="add-poi-to-itinerary"
-            >
-              <MapPin className="h-3 w-3 mr-1" />
-              {t("addToItinerary")}
-            </Button>
-          )}
-        </div>
-      ))}
+      {sorted.map((alert, index) => {
+        const isDismissed = dismissedIndices.has(index);
+        const action = alert.action;
+        const ActionIcon = action ? actionIcons[action.kind] : null;
+
+        return (
+          <div
+            key={`${alert.type}-${alert.source}-${index}`}
+            className={isDismissed ? "opacity-50" : undefined}
+            data-testid={isDismissed ? "alert-dismissed" : undefined}
+          >
+            <AlertBadge type={alert.type} message={alert.message} />
+            {isCulturalPoiAlert(alert) && onAddPoiWaypoint && (
+              <Button
+                variant="outline"
+                size="sm"
+                className="mt-1 ml-1 h-6 px-2 text-xs text-blue-700 dark:text-blue-400 border-blue-300 dark:border-blue-700 hover:bg-blue-50 dark:hover:bg-blue-900/20"
+                onClick={() => onAddPoiWaypoint(alert.poiLat!, alert.poiLon!)}
+                data-testid="add-poi-to-itinerary"
+              >
+                <MapPin className="h-3 w-3 mr-1" />
+                {t("addToItinerary")}
+              </Button>
+            )}
+            {action && !isDismissed && (
+              <Button
+                variant="outline"
+                size="sm"
+                className="mt-1 ml-1 h-6 px-2 text-xs text-emerald-700 dark:text-emerald-400 border-emerald-300 dark:border-emerald-700 hover:bg-emerald-50 dark:hover:bg-emerald-900/20"
+                onClick={() => {
+                  if (action.kind === "dismiss") {
+                    handleDismiss(index);
+                  }
+                  // auto_fix and detour: backend handlers not yet implemented
+                  // navigate: could zoom to lat/lon if available
+                }}
+                data-testid="alert-action-button"
+              >
+                {ActionIcon && <ActionIcon className="h-3 w-3 mr-1" />}
+                {action.label}
+              </Button>
+            )}
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/pwa/src/components/alert-list.tsx
+++ b/pwa/src/components/alert-list.tsx
@@ -35,12 +35,12 @@ function isCulturalPoiAlert(alert: AlertData): boolean {
 
 export function AlertList({ alerts, onAddPoiWaypoint }: AlertListProps) {
   const t = useTranslations("alertList");
-  const [dismissedIndices, setDismissedIndices] = useState<Set<number>>(
+  const [dismissedKeys, setDismissedKeys] = useState<Set<string>>(
     new Set(),
   );
 
-  const handleDismiss = useCallback((index: number) => {
-    setDismissedIndices((prev) => new Set(prev).add(index));
+  const handleDismiss = useCallback((key: string) => {
+    setDismissedKeys((prev) => new Set(prev).add(key));
   }, []);
 
   if (alerts.length === 0) return null;
@@ -51,14 +51,15 @@ export function AlertList({ alerts, onAddPoiWaypoint }: AlertListProps) {
 
   return (
     <div className="flex flex-col gap-2">
-      {sorted.map((alert, index) => {
-        const isDismissed = dismissedIndices.has(index);
+      {sorted.map((alert) => {
+        const alertKey = `${alert.type}-${alert.source ?? ""}-${alert.message}`;
+        const isDismissed = dismissedKeys.has(alertKey);
         const action = alert.action;
         const ActionIcon = action ? actionIcons[action.kind] : null;
 
         return (
           <div
-            key={`${alert.type}-${alert.source}-${index}`}
+            key={alertKey}
             className={isDismissed ? "opacity-50" : undefined}
             data-testid={isDismissed ? "alert-dismissed" : undefined}
           >
@@ -80,12 +81,11 @@ export function AlertList({ alerts, onAddPoiWaypoint }: AlertListProps) {
                 variant="outline"
                 size="sm"
                 className="mt-1 ml-1 h-6 px-2 text-xs text-emerald-700 dark:text-emerald-400 border-emerald-300 dark:border-emerald-700 hover:bg-emerald-50 dark:hover:bg-emerald-900/20"
+                disabled={action.kind !== "dismiss"}
                 onClick={() => {
                   if (action.kind === "dismiss") {
-                    handleDismiss(index);
+                    handleDismiss(alertKey);
                   }
-                  // auto_fix and detour: backend handlers not yet implemented
-                  // navigate: could zoom to lat/lon if available
                 }}
                 data-testid="alert-action-button"
               >

--- a/pwa/src/lib/api/schema.d.ts
+++ b/pwa/src/lib/api/schema.d.ts
@@ -518,9 +518,9 @@ export interface components {
              * @description Type of action: auto_fix, detour, navigate, dismiss.
              * @enum {string}
              */
-            kind?: "auto_fix" | "detour" | "navigate" | "dismiss";
+            kind: "auto_fix" | "detour" | "navigate" | "dismiss";
             /** @description Human-readable label for the action button. */
-            label?: string;
+            label: string;
             /** @description Machine-readable payload for the action. */
             payload?: {
                 [key: string]: unknown;
@@ -531,9 +531,9 @@ export interface components {
              * @description Type of action: auto_fix, detour, navigate, dismiss.
              * @enum {string}
              */
-            kind?: "auto_fix" | "detour" | "navigate" | "dismiss";
+            kind: "auto_fix" | "detour" | "navigate" | "dismiss";
             /** @description Human-readable label for the action button. */
-            label?: string;
+            label: string;
             /** @description Machine-readable payload for the action. */
             payload?: {
                 [key: string]: unknown;
@@ -544,9 +544,9 @@ export interface components {
              * @description Type of action: auto_fix, detour, navigate, dismiss.
              * @enum {string}
              */
-            kind?: "auto_fix" | "detour" | "navigate" | "dismiss";
+            kind: "auto_fix" | "detour" | "navigate" | "dismiss";
             /** @description Human-readable label for the action button. */
-            label?: string;
+            label: string;
             /** @description Machine-readable payload for the action. */
             payload?: {
                 [key: string]: unknown;

--- a/pwa/src/lib/api/schema.d.ts
+++ b/pwa/src/lib/api/schema.d.ts
@@ -495,6 +495,7 @@ export interface components {
             message?: string;
             lat?: number | null;
             lon?: number | null;
+            action?: components["schemas"]["AlertAction.fit"] | null;
         };
         "Alert.gpx": {
             /** @enum {string} */
@@ -502,6 +503,7 @@ export interface components {
             message?: string;
             lat?: number | null;
             lon?: number | null;
+            action?: components["schemas"]["AlertAction.gpx"] | null;
         };
         "Alert.jsonld": {
             /** @enum {string} */
@@ -509,6 +511,46 @@ export interface components {
             message?: string;
             lat?: number | null;
             lon?: number | null;
+            action?: components["schemas"]["AlertAction.jsonld"] | null;
+        };
+        "AlertAction.fit": {
+            /**
+             * @description Type of action: auto_fix, detour, navigate, dismiss.
+             * @enum {string}
+             */
+            kind?: "auto_fix" | "detour" | "navigate" | "dismiss";
+            /** @description Human-readable label for the action button. */
+            label?: string;
+            /** @description Machine-readable payload for the action. */
+            payload?: {
+                [key: string]: string | null;
+            };
+        };
+        "AlertAction.gpx": {
+            /**
+             * @description Type of action: auto_fix, detour, navigate, dismiss.
+             * @enum {string}
+             */
+            kind?: "auto_fix" | "detour" | "navigate" | "dismiss";
+            /** @description Human-readable label for the action button. */
+            label?: string;
+            /** @description Machine-readable payload for the action. */
+            payload?: {
+                [key: string]: string | null;
+            };
+        };
+        "AlertAction.jsonld": {
+            /**
+             * @description Type of action: auto_fix, detour, navigate, dismiss.
+             * @enum {string}
+             */
+            kind?: "auto_fix" | "detour" | "navigate" | "dismiss";
+            /** @description Human-readable label for the action button. */
+            label?: string;
+            /** @description Machine-readable payload for the action. */
+            payload?: {
+                [key: string]: string | null;
+            };
         };
         Auth: {
             /** Format: email */

--- a/pwa/src/lib/api/schema.d.ts
+++ b/pwa/src/lib/api/schema.d.ts
@@ -523,7 +523,7 @@ export interface components {
             label?: string;
             /** @description Machine-readable payload for the action. */
             payload?: {
-                [key: string]: string | null;
+                [key: string]: unknown;
             };
         };
         "AlertAction.gpx": {
@@ -536,7 +536,7 @@ export interface components {
             label?: string;
             /** @description Machine-readable payload for the action. */
             payload?: {
-                [key: string]: string | null;
+                [key: string]: unknown;
             };
         };
         "AlertAction.jsonld": {
@@ -549,7 +549,7 @@ export interface components {
             label?: string;
             /** @description Machine-readable payload for the action. */
             payload?: {
-                [key: string]: string | null;
+                [key: string]: unknown;
             };
         };
         Auth: {

--- a/pwa/src/lib/mercure/types.ts
+++ b/pwa/src/lib/mercure/types.ts
@@ -32,11 +32,18 @@ export interface WeatherPayload {
   } | null;
 }
 
+export interface AlertActionPayload {
+  kind: "auto_fix" | "detour" | "navigate" | "dismiss";
+  label: string;
+  payload?: Record<string, unknown>;
+}
+
 export interface AlertPayload {
   type: "critical" | "warning" | "nudge";
   message: string;
   lat: number | null;
   lon: number | null;
+  action?: AlertActionPayload | null;
 }
 
 export interface PoiPayload {

--- a/pwa/src/lib/mercure/types.ts
+++ b/pwa/src/lib/mercure/types.ts
@@ -35,7 +35,7 @@ export interface WeatherPayload {
 export interface AlertActionPayload {
   kind: "auto_fix" | "detour" | "navigate" | "dismiss";
   label: string;
-  payload?: Record<string, unknown>;
+  payload: Record<string, unknown>;
 }
 
 export interface AlertPayload {

--- a/pwa/src/lib/validation/schemas.ts
+++ b/pwa/src/lib/validation/schemas.ts
@@ -7,6 +7,12 @@ export const CoordinateSchema = z.object({
   ele: z.number().default(0),
 });
 
+export const AlertActionSchema = z.object({
+  kind: z.enum(["auto_fix", "detour", "navigate", "dismiss"]),
+  label: z.string(),
+  payload: z.record(z.string(), z.unknown()).optional().default({}),
+});
+
 export const AlertSchema = z.object({
   type: z.enum(["critical", "warning", "nudge"]),
   message: z.string(),
@@ -19,6 +25,8 @@ export const AlertSchema = z.object({
   poiLat: z.number().optional(),
   poiLon: z.number().optional(),
   distanceFromRoute: z.number().optional(),
+  // Optional contextual action
+  action: AlertActionSchema.nullable().optional(),
 });
 
 export const WeatherForecastSchema = z.object({
@@ -128,6 +136,7 @@ export const TripStateSchema = z.object({
 });
 
 export type CoordinateData = z.infer<typeof CoordinateSchema>;
+export type AlertActionData = z.infer<typeof AlertActionSchema>;
 export type AlertData = z.infer<typeof AlertSchema>;
 export type WeatherData = z.infer<typeof WeatherForecastSchema>;
 export type PoiData = z.infer<typeof PointOfInterestSchema>;

--- a/pwa/tests/fixtures/mock-data.ts
+++ b/pwa/tests/fixtures/mock-data.ts
@@ -227,6 +227,19 @@ export function alertsWithActionsEvent(): MercureEvent {
             },
           },
         ],
+        "2": [
+          {
+            type: "warning",
+            message: "Difficult terrain ahead",
+            lat: 44.295,
+            lon: 4.087,
+            action: {
+              kind: "detour",
+              label: "Take detour",
+              payload: {},
+            },
+          },
+        ],
       },
     },
   };

--- a/pwa/tests/fixtures/mock-data.ts
+++ b/pwa/tests/fixtures/mock-data.ts
@@ -170,11 +170,6 @@ export function terrainAlertsEvent(): MercureEvent {
             message: "Route non goudronnee sur 3km",
             lat: 44.6,
             lon: 4.5,
-            action: {
-              kind: "detour",
-              label: "Show alternative",
-              payload: { alternativeId: "alt-1" },
-            },
           },
         ],
         "1": [
@@ -183,11 +178,6 @@ export function terrainAlertsEvent(): MercureEvent {
             message: "Passage en altitude (820m)",
             lat: 44.4,
             lon: 4.2,
-            action: {
-              kind: "dismiss",
-              label: "Dismiss",
-              payload: {},
-            },
           },
         ],
       },

--- a/pwa/tests/fixtures/mock-data.ts
+++ b/pwa/tests/fixtures/mock-data.ts
@@ -170,6 +170,11 @@ export function terrainAlertsEvent(): MercureEvent {
             message: "Route non goudronnee sur 3km",
             lat: 44.6,
             lon: 4.5,
+            action: {
+              kind: "detour",
+              label: "Show alternative",
+              payload: { alternativeId: "alt-1" },
+            },
           },
         ],
         "1": [
@@ -178,6 +183,58 @@ export function terrainAlertsEvent(): MercureEvent {
             message: "Passage en altitude (820m)",
             lat: 44.4,
             lon: 4.2,
+            action: {
+              kind: "dismiss",
+              label: "Dismiss",
+              payload: {},
+            },
+          },
+        ],
+      },
+    },
+  };
+}
+
+export function alertsWithActionsEvent(): MercureEvent {
+  return {
+    type: "terrain_alerts",
+    data: {
+      alertsByStage: {
+        "0": [
+          {
+            type: "warning",
+            message: "Steep gradient detected (12%)",
+            lat: 44.6,
+            lon: 4.5,
+            action: {
+              kind: "navigate",
+              label: "Zoom to location",
+              payload: { lat: 44.6, lon: 4.5 },
+            },
+          },
+          {
+            type: "nudge",
+            message: "Minor road surface issue",
+            lat: 44.55,
+            lon: 4.45,
+            action: {
+              kind: "dismiss",
+              label: "Got it",
+              payload: {},
+            },
+          },
+        ],
+        "1": [
+          {
+            type: "critical",
+            message: "E-bike range exceeded",
+            lat: 44.4,
+            lon: 4.2,
+            action: {
+              kind: "auto_fix",
+              label: "Split stage",
+              payload: { splitAt: 45.0 },
+            },
           },
         ],
       },

--- a/pwa/tests/mocked/alert-actions.spec.ts
+++ b/pwa/tests/mocked/alert-actions.spec.ts
@@ -95,8 +95,6 @@ test.describe("Alert actions", () => {
 
     // Stage 3 has no alerts at all
     const stage3 = mockedPage.getByTestId("stage-card-3");
-    await expect(
-      stage3.getByTestId("alert-action-button"),
-    ).not.toBeVisible();
+    await expect(stage3.getByTestId("alert-action-button")).not.toBeVisible();
   });
 });

--- a/pwa/tests/mocked/alert-actions.spec.ts
+++ b/pwa/tests/mocked/alert-actions.spec.ts
@@ -78,6 +78,7 @@ test.describe("Alert actions", () => {
     const stage2 = mockedPage.getByTestId("stage-card-2");
     await expect(stage2).toContainText("E-bike range exceeded");
     await expect(stage2.getByText("Split stage")).toBeVisible();
+    await expect(stage2.getByText("Split stage")).toBeDisabled();
   });
 
   test("alerts without actions do not show action buttons", async ({

--- a/pwa/tests/mocked/alert-actions.spec.ts
+++ b/pwa/tests/mocked/alert-actions.spec.ts
@@ -101,4 +101,23 @@ test.describe("Alert actions", () => {
     await expect(stage1).toContainText("Route non goudronnee sur 3km");
     await expect(stage1.getByTestId("alert-action-button")).not.toBeVisible();
   });
+
+  test("detour action button is displayed and disabled", async ({
+    submitUrl,
+    injectSequence,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    await injectSequence([
+      routeParsedEvent(),
+      stagesComputedEvent(),
+      alertsWithActionsEvent(),
+      tripCompleteEvent(),
+    ]);
+
+    const stage3 = mockedPage.getByTestId("stage-card-3");
+    await expect(stage3).toContainText("Difficult terrain ahead");
+    await expect(stage3.getByText("Take detour")).toBeVisible();
+    await expect(stage3.getByText("Take detour")).toBeDisabled();
+  });
 });

--- a/pwa/tests/mocked/alert-actions.spec.ts
+++ b/pwa/tests/mocked/alert-actions.spec.ts
@@ -3,6 +3,7 @@ import {
   routeParsedEvent,
   stagesComputedEvent,
   alertsWithActionsEvent,
+  terrainAlertsEvent,
   tripCompleteEvent,
 } from "../fixtures/mock-data";
 
@@ -88,13 +89,13 @@ test.describe("Alert actions", () => {
     await injectSequence([
       routeParsedEvent(),
       stagesComputedEvent(),
-      // Use terrain alerts event which now has actions, but stage 3 has no alerts
-      alertsWithActionsEvent(),
+      terrainAlertsEvent(),
       tripCompleteEvent(),
     ]);
 
-    // Stage 3 has no alerts at all
-    const stage3 = mockedPage.getByTestId("stage-card-3");
-    await expect(stage3.getByTestId("alert-action-button")).not.toBeVisible();
+    // terrainAlertsEvent has alerts on stages 0 and 1 but without actions
+    const stage1 = mockedPage.getByTestId("stage-card-1");
+    await expect(stage1).toContainText("Route non goudronnee sur 3km");
+    await expect(stage1.getByTestId("alert-action-button")).not.toBeVisible();
   });
 });

--- a/pwa/tests/mocked/alert-actions.spec.ts
+++ b/pwa/tests/mocked/alert-actions.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect } from "../fixtures/base.fixture";
+import {
+  routeParsedEvent,
+  stagesComputedEvent,
+  alertsWithActionsEvent,
+  tripCompleteEvent,
+} from "../fixtures/mock-data";
+
+test.describe("Alert actions", () => {
+  test("shows action buttons on alerts that have actions", async ({
+    submitUrl,
+    injectSequence,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    await injectSequence([
+      routeParsedEvent(),
+      stagesComputedEvent(),
+      alertsWithActionsEvent(),
+      tripCompleteEvent(),
+    ]);
+
+    // Stage 1 has two alerts with actions
+    const stage1 = mockedPage.getByTestId("stage-card-1");
+    await expect(stage1).toContainText("Steep gradient detected (12%)");
+    await expect(stage1).toContainText("Minor road surface issue");
+
+    // Both action buttons should be visible
+    const actionButtons = stage1.getByTestId("alert-action-button");
+    await expect(actionButtons).toHaveCount(2);
+
+    // Verify labels
+    await expect(stage1.getByText("Zoom to location")).toBeVisible();
+    await expect(stage1.getByText("Got it")).toBeVisible();
+  });
+
+  test("dismiss action marks alert as read", async ({
+    submitUrl,
+    injectSequence,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    await injectSequence([
+      routeParsedEvent(),
+      stagesComputedEvent(),
+      alertsWithActionsEvent(),
+      tripCompleteEvent(),
+    ]);
+
+    const stage1 = mockedPage.getByTestId("stage-card-1");
+
+    // Click the dismiss button ("Got it")
+    await stage1.getByText("Got it").click();
+
+    // The dismissed alert should have reduced opacity
+    const dismissed = stage1.getByTestId("alert-dismissed");
+    await expect(dismissed).toBeVisible();
+
+    // The dismiss button should no longer be visible on the dismissed alert
+    await expect(stage1.getByText("Got it")).not.toBeVisible();
+  });
+
+  test("auto_fix action button is displayed on critical alerts", async ({
+    submitUrl,
+    injectSequence,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    await injectSequence([
+      routeParsedEvent(),
+      stagesComputedEvent(),
+      alertsWithActionsEvent(),
+      tripCompleteEvent(),
+    ]);
+
+    // Stage 2 has a critical alert with auto_fix action
+    const stage2 = mockedPage.getByTestId("stage-card-2");
+    await expect(stage2).toContainText("E-bike range exceeded");
+    await expect(stage2.getByText("Split stage")).toBeVisible();
+  });
+
+  test("alerts without actions do not show action buttons", async ({
+    submitUrl,
+    injectSequence,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    await injectSequence([
+      routeParsedEvent(),
+      stagesComputedEvent(),
+      // Use terrain alerts event which now has actions, but stage 3 has no alerts
+      alertsWithActionsEvent(),
+      tripCompleteEvent(),
+    ]);
+
+    // Stage 3 has no alerts at all
+    const stage3 = mockedPage.getByTestId("stage-card-3");
+    await expect(
+      stage3.getByTestId("alert-action-button"),
+    ).not.toBeVisible();
+  });
+});

--- a/pwa/tests/mocked/alert-actions.spec.ts
+++ b/pwa/tests/mocked/alert-actions.spec.ts
@@ -30,9 +30,11 @@ test.describe("Alert actions", () => {
     const actionButtons = stage1.getByTestId("alert-action-button");
     await expect(actionButtons).toHaveCount(2);
 
-    // Verify labels
+    // Verify labels and disabled state of unimplemented actions
     await expect(stage1.getByText("Zoom to location")).toBeVisible();
+    await expect(stage1.getByText("Zoom to location")).toBeDisabled();
     await expect(stage1.getByText("Got it")).toBeVisible();
+    await expect(stage1.getByText("Got it")).not.toBeDisabled();
   });
 
   test("dismiss action marks alert as read", async ({


### PR DESCRIPTION
## Summary

- Add `AlertAction` DTO with `kind` (enum: auto_fix, detour, navigate, dismiss), `label`, and `payload` fields
- Add optional `action` field to the `Alert` model
- Frontend renders action buttons with contextual icons per action kind
- Dismiss action marks alerts as read (UI-only)
- Regenerated TypeScript types from updated OpenAPI spec

## Test plan

- [x] PHPUnit: AlertAction serialization and typing tests (7 tests)
- [x] Playwright: alert action buttons display and dismiss behavior (4 tests)
- [x] `make qa` passes
- [x] `make test-php` passes (803 tests)

Closes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

Reviewed commit `93c6d790f17dfd8c5fb03d9b2eb197453be3c876`.

Clean iteration — both blocking findings from the previous round are fully addressed: `kind` and `label` are now required (non-optional) in all three `AlertAction.*` schema variants, and the `detour` action kind has dedicated E2E coverage. No new issues found.

**Findings summary:** 0 findings

Resolved 2 previously open threads that were addressed.

**Review checklist**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

No inline comments.

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->