### PR TITLE
feat(alerts): add railway station emergency nudge analyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,9 @@ Rules are executed in priority order (lower = higher priority):
 | **Water points** | -- | ![nudge](https://img.shields.io/badge/-nudge-0288d1) | Stretch > 30 km without a detected drinking water source |
 | **Rest day** | 100 | ![nudge](https://img.shields.io/badge/-nudge-0288d1) | Every N consecutive cycling days without a rest day (default: every 3 days) |
 | **Cultural POI** | -- | ![nudge](https://img.shields.io/badge/-nudge-0288d1) | Museum, monument, castle, church, viewpoint, or attraction within 500 m of route |
+| **Railway station** | -- | ![nudge](https://img.shields.io/badge/-nudge-0288d1) | No train station within 10 km of a stage endpoint (emergency evacuation) |
 
-**Terrain rules** (Continuity, Elevation, Steep gradient, Surface, Traffic, E-bike range, Sunset, Rest day) implement `StageAnalyzerInterface` and are auto-discovered via `#[AutoconfigureTag('app.stage_analyzer')]`. Rules with `--` priority (Calendar, Wind + Comfort, Bike shops, Resupply, Accommodation, Water points, Cultural POI) are separate async Symfony Message handlers; Comfort is co-located with Wind inside `AnalyzeWindHandler`.
+**Terrain rules** (Continuity, Elevation, Steep gradient, Surface, Traffic, E-bike range, Sunset, Rest day) implement `StageAnalyzerInterface` and are auto-discovered via `#[AutoconfigureTag('app.stage_analyzer')]`. Rules with `--` priority (Calendar, Wind + Comfort, Bike shops, Resupply, Accommodation, Water points, Cultural POI, Railway station) are separate async Symfony Message handlers; Comfort is co-located with Wind inside `AnalyzeWindHandler`.
 
 ---
 

--- a/api/src/Enum/ComputationName.php
+++ b/api/src/Enum/ComputationName.php
@@ -19,6 +19,7 @@ enum ComputationName: string
     case WATER_POINTS = 'water_points';
     case ROUTE_SEGMENT = 'route_segment';
     case CULTURAL_POIS = 'cultural_pois';
+    case RAILWAY_STATIONS = 'railway_stations';
 
     /**
      * Computations initialized at trip creation (the main pipeline).

--- a/api/src/Mercure/MercureEventType.php
+++ b/api/src/Mercure/MercureEventType.php
@@ -19,6 +19,7 @@ enum MercureEventType: string
     case SUPPLY_TIMELINE = 'supply_timeline';
     case ROUTE_SEGMENT_RECALCULATED = 'route_segment_recalculated';
     case CULTURAL_POI_ALERTS = 'cultural_poi_alerts';
+    case RAILWAY_STATION_ALERTS = 'railway_station_alerts';
     case VALIDATION_ERROR = 'validation_error';
     case COMPUTATION_ERROR = 'computation_error';
     case TRIP_COMPLETE = 'trip_complete';

--- a/api/src/Message/CheckRailwayStations.php
+++ b/api/src/Message/CheckRailwayStations.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Message;
+
+final readonly class CheckRailwayStations
+{
+    public function __construct(
+        public string $tripId,
+        public ?int $generation = null,
+    ) {
+    }
+}

--- a/api/src/MessageHandler/CheckRailwayStationsHandler.php
+++ b/api/src/MessageHandler/CheckRailwayStationsHandler.php
@@ -64,7 +64,7 @@ final readonly class CheckRailwayStationsHandler extends AbstractTripMessageHand
             // Collect all stage endpoints (start + end of each stage)
             $endPoints = $this->collectEndpoints($stages);
 
-            $query = $this->queryBuilder->buildRailwayStationQuery($endPoints);
+            $query = $this->queryBuilder->buildRailwayStationQuery($endPoints, self::STATION_PROXIMITY_METERS);
             $result = $this->scanner->query($query);
 
             /** @var list<array{lat?: float, lon?: float, center?: array{lat: float, lon: float}, tags?: array<string, string>}> $elements */

--- a/api/src/MessageHandler/CheckRailwayStationsHandler.php
+++ b/api/src/MessageHandler/CheckRailwayStationsHandler.php
@@ -127,7 +127,7 @@ final readonly class CheckRailwayStationsHandler extends AbstractTripMessageHand
     }
 
     /**
-     * Collects start and end points from all stages (deduplicated).
+     * Collects start and end points from all stages.
      *
      * @param list<Stage> $stages
      *

--- a/api/src/MessageHandler/CheckRailwayStationsHandler.php
+++ b/api/src/MessageHandler/CheckRailwayStationsHandler.php
@@ -135,6 +135,10 @@ final readonly class CheckRailwayStationsHandler extends AbstractTripMessageHand
     {
         $points = [];
         foreach ($stages as $stage) {
+            if ($stage->isRestDay) {
+                continue;
+            }
+
             $points[] = $stage->startPoint;
             $points[] = $stage->endPoint;
         }

--- a/api/src/MessageHandler/CheckRailwayStationsHandler.php
+++ b/api/src/MessageHandler/CheckRailwayStationsHandler.php
@@ -64,6 +64,12 @@ final readonly class CheckRailwayStationsHandler extends AbstractTripMessageHand
             // Collect all stage endpoints (start + end of each stage)
             $endPoints = $this->collectEndpoints($stages);
 
+            if ([] === $endPoints) {
+                $this->publisher->publish($tripId, MercureEventType::RAILWAY_STATION_ALERTS, ['alerts' => []]);
+
+                return;
+            }
+
             $query = $this->queryBuilder->buildRailwayStationQuery($endPoints, self::STATION_PROXIMITY_METERS);
             $result = $this->scanner->query($query);
 

--- a/api/src/MessageHandler/CheckRailwayStationsHandler.php
+++ b/api/src/MessageHandler/CheckRailwayStationsHandler.php
@@ -87,6 +87,10 @@ final readonly class CheckRailwayStationsHandler extends AbstractTripMessageHand
             // Check each stage for nearby stations and build alerts
             $alerts = [];
             foreach ($stages as $i => $stage) {
+                if ($stage->isRestDay) {
+                    continue;
+                }
+
                 if ($this->hasNearbyStation($stage, $stationLocations)) {
                     continue;
                 }

--- a/api/src/MessageHandler/CheckRailwayStationsHandler.php
+++ b/api/src/MessageHandler/CheckRailwayStationsHandler.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MessageHandler;
+
+use App\ApiResource\Model\Coordinate;
+use App\ApiResource\Stage;
+use App\ComputationTracker\ComputationTrackerInterface;
+use App\ComputationTracker\TripGenerationTrackerInterface;
+use App\Enum\AlertType;
+use App\Enum\ComputationName;
+use App\Geo\GeoDistanceInterface;
+use App\Mercure\MercureEventType;
+use App\Mercure\TripUpdatePublisherInterface;
+use App\Message\CheckRailwayStations;
+use App\Repository\TripRequestRepositoryInterface;
+use App\Scanner\QueryBuilderInterface;
+use App\Scanner\ScannerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * Checks for railway stations within 10 km of each stage endpoint.
+ *
+ * Generates a nudge alert when no station is reachable, with a `navigate`
+ * action pointing to the nearest station found across the entire trip.
+ * This gives cyclists an emergency evacuation option in case of mechanical
+ * failure, injury, or extreme weather.
+ */
+#[AsMessageHandler]
+final readonly class CheckRailwayStationsHandler extends AbstractTripMessageHandler
+{
+    private const int STATION_PROXIMITY_METERS = 10_000;
+
+    public function __construct(
+        ComputationTrackerInterface $computationTracker,
+        TripUpdatePublisherInterface $publisher,
+        TripGenerationTrackerInterface $generationTracker,
+        LoggerInterface $logger,
+        private TripRequestRepositoryInterface $tripStateManager,
+        private ScannerInterface $scanner,
+        private QueryBuilderInterface $queryBuilder,
+        private GeoDistanceInterface $haversine,
+        private TranslatorInterface $translator,
+    ) {
+        parent::__construct($computationTracker, $publisher, $generationTracker, $logger);
+    }
+
+    public function __invoke(CheckRailwayStations $message): void
+    {
+        $tripId = $message->tripId;
+        $generation = $message->generation;
+        $stages = $this->tripStateManager->getStages($tripId);
+
+        if (null === $stages) {
+            return;
+        }
+
+        $locale = $this->tripStateManager->getLocale($tripId) ?? 'en';
+
+        $this->executeWithTracking($tripId, ComputationName::RAILWAY_STATIONS, function () use ($tripId, $stages, $locale): void {
+            // Collect all stage endpoints (start + end of each stage)
+            $endPoints = $this->collectEndpoints($stages);
+
+            $query = $this->queryBuilder->buildRailwayStationQuery($endPoints);
+            $result = $this->scanner->query($query);
+
+            /** @var list<array{lat?: float, lon?: float, center?: array{lat: float, lon: float}, tags?: array<string, string>}> $elements */
+            $elements = \is_array($result['elements'] ?? null) ? $result['elements'] : [];
+
+            // Parse station locations
+            $stationLocations = [];
+            foreach ($elements as $element) {
+                $lat = $element['lat'] ?? ($element['center']['lat'] ?? null);
+                $lon = $element['lon'] ?? ($element['center']['lon'] ?? null);
+
+                if (null === $lat || null === $lon) {
+                    continue;
+                }
+
+                $name = $element['tags']['name'] ?? null;
+                $stationLocations[] = ['lat' => (float) $lat, 'lon' => (float) $lon, 'name' => $name];
+            }
+
+            // Check each stage for nearby stations and build alerts
+            $alerts = [];
+            foreach ($stages as $i => $stage) {
+                if ($this->hasNearbyStation($stage, $stationLocations)) {
+                    continue;
+                }
+
+                // Find the nearest station across the entire trip for navigation
+                $nearestStation = $this->findNearestStation($stage->endPoint, $stationLocations);
+
+                $alert = [
+                    'stageIndex' => $i,
+                    'dayNumber' => $stage->dayNumber,
+                    'type' => AlertType::NUDGE->value,
+                    'message' => $this->translator->trans(
+                        'alert.railway_station.nudge',
+                        ['%stage%' => $stage->dayNumber],
+                        'alerts',
+                        $locale,
+                    ),
+                ];
+
+                if (null !== $nearestStation) {
+                    $alert['action'] = 'navigate';
+                    $alert['actionLat'] = $nearestStation['lat'];
+                    $alert['actionLon'] = $nearestStation['lon'];
+                    $alert['stationName'] = $nearestStation['name'];
+                }
+
+                $alerts[] = $alert;
+            }
+
+            $this->publisher->publish($tripId, MercureEventType::RAILWAY_STATION_ALERTS, [
+                'alerts' => $alerts,
+            ]);
+        }, $generation);
+    }
+
+    /**
+     * Collects start and end points from all stages (deduplicated).
+     *
+     * @param list<Stage> $stages
+     *
+     * @return list<Coordinate>
+     */
+    private function collectEndpoints(array $stages): array
+    {
+        $points = [];
+        foreach ($stages as $stage) {
+            $points[] = $stage->startPoint;
+            $points[] = $stage->endPoint;
+        }
+
+        return $points;
+    }
+
+    /**
+     * Checks whether a station is within proximity of either endpoint of the stage.
+     *
+     * @param list<array{lat: float, lon: float, name: string|null}> $stationLocations
+     */
+    private function hasNearbyStation(Stage $stage, array $stationLocations): bool
+    {
+        foreach ($stationLocations as $station) {
+            $distToStart = $this->haversine->inMeters($stage->startPoint->lat, $stage->startPoint->lon, $station['lat'], $station['lon']);
+            $distToEnd = $this->haversine->inMeters($stage->endPoint->lat, $stage->endPoint->lon, $station['lat'], $station['lon']);
+
+            if ($distToStart < self::STATION_PROXIMITY_METERS || $distToEnd < self::STATION_PROXIMITY_METERS) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Finds the nearest station to a given point across all discovered stations.
+     *
+     * @param list<array{lat: float, lon: float, name: string|null}> $stationLocations
+     *
+     * @return array{lat: float, lon: float, name: string|null}|null
+     */
+    private function findNearestStation(Coordinate $point, array $stationLocations): ?array
+    {
+        if ([] === $stationLocations) {
+            return null;
+        }
+
+        $minDist = PHP_FLOAT_MAX;
+        $nearest = null;
+
+        foreach ($stationLocations as $station) {
+            $dist = $this->haversine->inMeters($point->lat, $point->lon, $station['lat'], $station['lon']);
+            if ($dist < $minDist) {
+                $minDist = $dist;
+                $nearest = $station;
+            }
+        }
+
+        return $nearest;
+    }
+}

--- a/api/src/MessageHandler/CheckRailwayStationsHandler.php
+++ b/api/src/MessageHandler/CheckRailwayStationsHandler.php
@@ -80,8 +80,7 @@ final readonly class CheckRailwayStationsHandler extends AbstractTripMessageHand
                     continue;
                 }
 
-                $name = $element['tags']['name'] ?? null;
-                $stationLocations[] = ['lat' => (float) $lat, 'lon' => (float) $lon, 'name' => $name];
+                $stationLocations[] = ['lat' => (float) $lat, 'lon' => (float) $lon];
             }
 
             // Check each stage for nearby stations and build alerts
@@ -114,7 +113,6 @@ final readonly class CheckRailwayStationsHandler extends AbstractTripMessageHand
                     $alert['action'] = 'navigate';
                     $alert['actionLat'] = $nearestStation['lat'];
                     $alert['actionLon'] = $nearestStation['lon'];
-                    $alert['stationName'] = $nearestStation['name'];
                 }
 
                 $alerts[] = $alert;
@@ -147,7 +145,7 @@ final readonly class CheckRailwayStationsHandler extends AbstractTripMessageHand
     /**
      * Checks whether a station is within proximity of either endpoint of the stage.
      *
-     * @param list<array{lat: float, lon: float, name: string|null}> $stationLocations
+     * @param list<array{lat: float, lon: float}> $stationLocations
      */
     private function hasNearbyStation(Stage $stage, array $stationLocations): bool
     {
@@ -166,9 +164,9 @@ final readonly class CheckRailwayStationsHandler extends AbstractTripMessageHand
     /**
      * Finds the nearest station to a given point across all discovered stations.
      *
-     * @param list<array{lat: float, lon: float, name: string|null}> $stationLocations
+     * @param list<array{lat: float, lon: float}> $stationLocations
      *
-     * @return array{lat: float, lon: float, name: string|null}|null
+     * @return array{lat: float, lon: float}|null
      */
     private function findNearestStation(Coordinate $point, array $stationLocations): ?array
     {

--- a/api/src/MessageHandler/GenerateStagesHandler.php
+++ b/api/src/MessageHandler/GenerateStagesHandler.php
@@ -21,6 +21,7 @@ use App\Message\AnalyzeTerrain;
 use App\Message\CheckBikeShops;
 use App\Message\CheckCalendar;
 use App\Message\CheckCulturalPois;
+use App\Message\CheckRailwayStations;
 use App\Message\CheckWaterPoints;
 use App\Message\FetchWeather;
 use App\Message\GenerateStages;
@@ -109,6 +110,7 @@ final readonly class GenerateStagesHandler extends AbstractTripMessageHandler
             $this->messageBus->dispatch(new CheckBikeShops($tripId, $generation));
             $this->messageBus->dispatch(new CheckWaterPoints($tripId, $generation));
             $this->messageBus->dispatch(new CheckCulturalPois($tripId, $generation));
+            $this->messageBus->dispatch(new CheckRailwayStations($tripId, $generation));
         }, $generation);
     }
 

--- a/api/src/Scanner/OsmOverpassQueryBuilder.php
+++ b/api/src/Scanner/OsmOverpassQueryBuilder.php
@@ -104,6 +104,20 @@ final readonly class OsmOverpassQueryBuilder implements QueryBuilderInterface
     }
 
     /**
+     * @param list<Coordinate> $endPoints
+     */
+    public function buildRailwayStationQuery(array $endPoints, int $radiusMeters = 10000): string
+    {
+        $polyline = $this->buildPolyline($endPoints);
+
+        return \sprintf(
+            '[out:json][timeout:15];nwr["railway"="station"]["usage"!="tourism"](around:%d,%s);out center tags 100;',
+            $radiusMeters,
+            $polyline,
+        );
+    }
+
+    /**
      * @param list<list<Coordinate>> $stageGeometries
      *
      * Note: 'out center tags 100' caps the result set globally across all stages.

--- a/api/src/Scanner/OsmOverpassQueryBuilder.php
+++ b/api/src/Scanner/OsmOverpassQueryBuilder.php
@@ -111,7 +111,7 @@ final readonly class OsmOverpassQueryBuilder implements QueryBuilderInterface
         $polyline = $this->buildPolyline($endPoints);
 
         return \sprintf(
-            '[out:json][timeout:15];nwr["railway"="station"]["usage"!="tourism"](around:%d,%s);out center tags 100;',
+            '[out:json][timeout:15];nwr["railway"="station"]["usage"!="tourism"](around:%d,%s);out center tags 500;',
             $radiusMeters,
             $polyline,
         );

--- a/api/src/Scanner/QueryBuilderInterface.php
+++ b/api/src/Scanner/QueryBuilderInterface.php
@@ -58,6 +58,16 @@ interface QueryBuilderInterface
     public function buildCemeteryQuery(array $decimatedPoints): string;
 
     /**
+     * Queries railway stations (excluding tourist railways) around stage endpoints.
+     *
+     * Used to detect whether a cyclist can reach a train station in case of
+     * emergency (mechanical failure, injury, extreme weather).
+     *
+     * @param list<Coordinate> $endPoints stage start/end points
+     */
+    public function buildRailwayStationQuery(array $endPoints, int $radiusMeters = 10000): string;
+
+    /**
      * Build a single Overpass query for cultural POIs along all stages.
      *
      * @param list<list<Coordinate>> $stageGeometries geometry points per stage

--- a/api/tests/Functional/trip-schema.json
+++ b/api/tests/Functional/trip-schema.json
@@ -42,7 +42,8 @@
         "wind",
         "bike_shops",
         "water_points",
-        "cultural_pois"
+        "cultural_pois",
+        "railway_stations"
       ],
       "additionalProperties": false,
       "properties": {
@@ -146,6 +147,15 @@
           ]
         },
         "cultural_pois": {
+          "type": "string",
+          "enum": [
+            "pending",
+            "running",
+            "done",
+            "failed"
+          ]
+        },
+        "railway_stations": {
           "type": "string",
           "enum": [
             "pending",

--- a/api/tests/Unit/AlertDocumentationTest.php
+++ b/api/tests/Unit/AlertDocumentationTest.php
@@ -44,6 +44,7 @@ final class AlertDocumentationTest extends TestCase
         'rest_day' => 'Rest day',
         'sunset' => 'Sunset',
         'cultural_poi' => 'Cultural POI',
+        'railway_station' => 'Railway station',
     ];
 
     /**

--- a/api/tests/Unit/MessageHandler/CheckRailwayStationsHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/CheckRailwayStationsHandlerTest.php
@@ -182,7 +182,7 @@ final class CheckRailwayStationsHandlerTest extends TestCase
         // lat1 is the stage endpoint lat; lat1 < 48.5 means Stage 1 endpoints (near), lat1 >= 48.5 means Stage 2 endpoints (far)
         $haversine = $this->createStub(GeoDistanceInterface::class);
         $haversine->method('inMeters')->willReturnCallback(
-            static fn(float $lat1): float => $lat1 >= 48.5 ? 15000.0 : 5000.0,
+            static fn (float $lat1): float => $lat1 >= 48.5 ? 15000.0 : 5000.0,
         );
 
         $publisher = $this->createMock(TripUpdatePublisherInterface::class);

--- a/api/tests/Unit/MessageHandler/CheckRailwayStationsHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/CheckRailwayStationsHandlerTest.php
@@ -208,6 +208,48 @@ final class CheckRailwayStationsHandlerTest extends TestCase
     }
 
     #[Test]
+    public function restDayStageIsSkippedAndEmitsNoAlert(): void
+    {
+        $stages = $this->createStages('trip-1', 2);
+        // Override stage 1 as a rest day — stage 2 remains a cycling stage
+        $stages[0] = new Stage(
+            tripId: 'trip-1',
+            dayNumber: 1,
+            distance: 0.0,
+            elevation: 0.0,
+            startPoint: new Coordinate(48.0, 2.0),
+            endPoint: new Coordinate(48.0, 2.0),
+            isRestDay: true,
+        );
+
+        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
+        $tripStateManager->method('getStages')->willReturn($stages);
+        $tripStateManager->method('getLocale')->willReturn('en');
+
+        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
+        $queryBuilder->method('buildRailwayStationQuery')->willReturn('query');
+
+        // No stations found — without the rest-day guard, both stages would produce alerts
+        $scanner = $this->createStub(ScannerInterface::class);
+        $scanner->method('query')->willReturn(['elements' => []]);
+
+        $haversine = $this->createStub(GeoDistanceInterface::class);
+
+        $publisher = $this->createMock(TripUpdatePublisherInterface::class);
+        $publisher->expects($this->once())
+            ->method('publish')
+            ->with(
+                'trip-1',
+                MercureEventType::RAILWAY_STATION_ALERTS,
+                // Only stage 2 gets an alert — stage 1 is a rest day and must be skipped
+                $this->callback(static fn (array $data): bool => 1 === \count($data['alerts'])),
+            );
+
+        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine);
+        $handler(new CheckRailwayStations('trip-1'));
+    }
+
+    #[Test]
     public function nullStagesReturnsEarly(): void
     {
         $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);

--- a/api/tests/Unit/MessageHandler/CheckRailwayStationsHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/CheckRailwayStationsHandlerTest.php
@@ -1,0 +1,289 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\MessageHandler;
+
+use App\ApiResource\Model\Coordinate;
+use App\ApiResource\Stage;
+use App\ComputationTracker\ComputationTrackerInterface;
+use App\ComputationTracker\TripGenerationTrackerInterface;
+use App\Geo\GeoDistanceInterface;
+use App\Mercure\MercureEventType;
+use App\Mercure\TripUpdatePublisherInterface;
+use App\Message\CheckRailwayStations;
+use App\MessageHandler\CheckRailwayStationsHandler;
+use App\Repository\TripRequestRepositoryInterface;
+use App\Scanner\QueryBuilderInterface;
+use App\Scanner\ScannerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class CheckRailwayStationsHandlerTest extends TestCase
+{
+    /**
+     * @return list<Stage>
+     */
+    private function createStages(string $tripId, int $count = 3): array
+    {
+        $stages = [];
+        for ($i = 1; $i <= $count; ++$i) {
+            $stages[] = new Stage(
+                tripId: $tripId,
+                dayNumber: $i,
+                distance: 80.0,
+                elevation: 500.0,
+                startPoint: new Coordinate(48.0 + ($i - 1) * 0.5, 2.0 + ($i - 1) * 0.5),
+                endPoint: new Coordinate(48.0 + $i * 0.5, 2.0 + $i * 0.5),
+            );
+        }
+
+        return $stages;
+    }
+
+    private function createHandler(
+        TripRequestRepositoryInterface $tripStateManager,
+        TripUpdatePublisherInterface $publisher,
+        ScannerInterface $scanner,
+        QueryBuilderInterface $queryBuilder,
+        GeoDistanceInterface $haversine,
+    ): CheckRailwayStationsHandler {
+        $computationTracker = $this->createStub(ComputationTrackerInterface::class);
+        $computationTracker->method('isAllComplete')->willReturn(false);
+
+        $translator = $this->createStub(TranslatorInterface::class);
+        $translator->method('trans')->willReturnCallback(
+            static fn (string $id, array $params): string => match ($id) {
+                'alert.railway_station.nudge' => \sprintf('No train station near stage %s.', $params['%stage%']),
+                default => $id,
+            },
+        );
+
+        $generationTracker = $this->createStub(TripGenerationTrackerInterface::class);
+
+        return new CheckRailwayStationsHandler(
+            $computationTracker,
+            $publisher,
+            $generationTracker,
+            new NullLogger(),
+            $tripStateManager,
+            $scanner,
+            $queryBuilder,
+            $haversine,
+            $translator,
+        );
+    }
+
+    #[Test]
+    public function stationNearbyEmitsNoAlert(): void
+    {
+        $stages = $this->createStages('trip-1');
+
+        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
+        $tripStateManager->method('getStages')->willReturn($stages);
+        $tripStateManager->method('getLocale')->willReturn('en');
+
+        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
+        $queryBuilder->method('buildRailwayStationQuery')->willReturn('query');
+
+        $scanner = $this->createStub(ScannerInterface::class);
+        $scanner->method('query')->willReturn([
+            'elements' => [
+                [
+                    'lat' => 48.5,
+                    'lon' => 2.5,
+                    'tags' => ['name' => 'Gare de Lyon'],
+                ],
+            ],
+        ]);
+
+        // Station is within 10 km of every stage endpoint
+        $haversine = $this->createStub(GeoDistanceInterface::class);
+        $haversine->method('inMeters')->willReturn(5000.0);
+
+        $publisher = $this->createMock(TripUpdatePublisherInterface::class);
+        $publisher->expects($this->once())
+            ->method('publish')
+            ->with(
+                'trip-1',
+                MercureEventType::RAILWAY_STATION_ALERTS,
+                $this->callback(static fn (array $data): bool => [] === $data['alerts']),
+            );
+
+        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine);
+        $handler(new CheckRailwayStations('trip-1'));
+    }
+
+    #[Test]
+    public function noStationNearbyEmitsNudgeForEveryStage(): void
+    {
+        $stages = $this->createStages('trip-1');
+
+        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
+        $tripStateManager->method('getStages')->willReturn($stages);
+        $tripStateManager->method('getLocale')->willReturn('en');
+
+        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
+        $queryBuilder->method('buildRailwayStationQuery')->willReturn('query');
+
+        $scanner = $this->createStub(ScannerInterface::class);
+        $scanner->method('query')->willReturn(['elements' => []]);
+
+        $haversine = $this->createStub(GeoDistanceInterface::class);
+
+        $publisher = $this->createMock(TripUpdatePublisherInterface::class);
+        $publisher->expects($this->once())
+            ->method('publish')
+            ->with(
+                'trip-1',
+                MercureEventType::RAILWAY_STATION_ALERTS,
+                $this->callback(static function (array $data): bool {
+                    $alerts = $data['alerts'];
+
+                    return 3 === \count($alerts)
+                        && 'nudge' === $alerts[0]['type']
+                        && str_contains((string) $alerts[0]['message'], 'No train station near stage 1')
+                        && !isset($alerts[0]['action']);
+                }),
+            );
+
+        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine);
+        $handler(new CheckRailwayStations('trip-1'));
+    }
+
+    #[Test]
+    public function stationFarFromOneStageEmitsNudgeWithNavigateAction(): void
+    {
+        $stages = $this->createStages('trip-1', 2);
+
+        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
+        $tripStateManager->method('getStages')->willReturn($stages);
+        $tripStateManager->method('getLocale')->willReturn('en');
+
+        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
+        $queryBuilder->method('buildRailwayStationQuery')->willReturn('query');
+
+        // One station found, near stage 1 but far from stage 2
+        $scanner = $this->createStub(ScannerInterface::class);
+        $scanner->method('query')->willReturn([
+            'elements' => [
+                [
+                    'lat' => 48.5,
+                    'lon' => 2.5,
+                    'tags' => ['name' => 'Gare de Lyon'],
+                ],
+            ],
+        ]);
+
+        // Return different distances based on which points are being compared:
+        // - Stage 1 endpoints are near the station (5 km)
+        // - Stage 2 endpoints are far (15 km)
+        $haversine = $this->createStub(GeoDistanceInterface::class);
+        $haversine->method('inMeters')->willReturnCallback(
+            static function (float $lat1, float $lon1, float $lat2, float $lon2): float {
+                // Station is at (48.5, 2.5)
+                // Stage 1: start(48.0,2.0) end(48.5,2.5) — end is close
+                // Stage 2: start(48.5,2.5) end(49.0,3.0) — start is close
+                if (48.5 === $lat1 && 2.5 === $lon1 && 48.5 === $lat2 && 2.5 === $lon2) {
+                    return 0.0;
+                }
+                if (48.5 === $lat2 && 2.5 === $lon2) {
+                    // Check proximity to station
+                    if (48.5 === $lat1 && 2.5 === $lon1) {
+                        return 0.0;
+                    }
+
+                    return 15000.0; // Far from station
+                }
+
+                return 5000.0; // Near station
+            },
+        );
+
+        $publisher = $this->createMock(TripUpdatePublisherInterface::class);
+        $publisher->expects($this->once())
+            ->method('publish')
+            ->with(
+                'trip-1',
+                MercureEventType::RAILWAY_STATION_ALERTS,
+                $this->callback(static function (array $data): bool {
+                    $alerts = $data['alerts'];
+
+                    // Some stages may or may not have alerts depending on distance calculation
+                    // We just verify that alerts with navigate action exist when a station is found
+                    foreach ($alerts as $alert) {
+                        if ('nudge' !== $alert['type']) {
+                            return false;
+                        }
+                        if (isset($alert['action']) && 'navigate' !== $alert['action']) {
+                            return false;
+                        }
+                    }
+
+                    return true;
+                }),
+            );
+
+        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine);
+        $handler(new CheckRailwayStations('trip-1'));
+    }
+
+    #[Test]
+    public function nullStagesReturnsEarly(): void
+    {
+        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
+        $tripStateManager->method('getStages')->willReturn(null);
+
+        $publisher = $this->createMock(TripUpdatePublisherInterface::class);
+        $publisher->expects($this->never())->method('publish');
+
+        $scanner = $this->createStub(ScannerInterface::class);
+        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
+        $haversine = $this->createStub(GeoDistanceInterface::class);
+
+        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine);
+        $handler(new CheckRailwayStations('trip-1'));
+    }
+
+    #[Test]
+    public function stationWithCenterCoordinatesIsParsedCorrectly(): void
+    {
+        $stages = $this->createStages('trip-1', 1);
+
+        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
+        $tripStateManager->method('getStages')->willReturn($stages);
+        $tripStateManager->method('getLocale')->willReturn('en');
+
+        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
+        $queryBuilder->method('buildRailwayStationQuery')->willReturn('query');
+
+        // Station returned with center coordinates (way/relation)
+        $scanner = $this->createStub(ScannerInterface::class);
+        $scanner->method('query')->willReturn([
+            'elements' => [
+                [
+                    'center' => ['lat' => 48.5, 'lon' => 2.5],
+                    'tags' => ['name' => 'Gare du Nord'],
+                ],
+            ],
+        ]);
+
+        // Station within range
+        $haversine = $this->createStub(GeoDistanceInterface::class);
+        $haversine->method('inMeters')->willReturn(3000.0);
+
+        $publisher = $this->createMock(TripUpdatePublisherInterface::class);
+        $publisher->expects($this->once())
+            ->method('publish')
+            ->with(
+                'trip-1',
+                MercureEventType::RAILWAY_STATION_ALERTS,
+                $this->callback(static fn (array $data): bool => [] === $data['alerts']),
+            );
+
+        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine);
+        $handler(new CheckRailwayStations('trip-1'));
+    }
+}

--- a/api/tests/Unit/MessageHandler/CheckRailwayStationsHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/CheckRailwayStationsHandlerTest.php
@@ -189,6 +189,7 @@ final class CheckRailwayStationsHandlerTest extends TestCase
                 if (48.5 === $lat1 && 2.5 === $lon1 && 48.5 === $lat2 && 2.5 === $lon2) {
                     return 0.0;
                 }
+
                 if (48.5 === $lat2 && 2.5 === $lon2) {
                     // Check proximity to station
                     if (48.5 === $lat1 && 2.5 === $lon1) {

--- a/api/tests/Unit/MessageHandler/CheckRailwayStationsHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/CheckRailwayStationsHandlerTest.php
@@ -218,6 +218,7 @@ final class CheckRailwayStationsHandlerTest extends TestCase
                         if ('nudge' !== $alert['type']) {
                             return false;
                         }
+
                         if (isset($alert['action']) && 'navigate' !== $alert['action']) {
                             return false;
                         }

--- a/api/tests/Unit/MessageHandler/CheckRailwayStationsHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/CheckRailwayStationsHandlerTest.php
@@ -156,6 +156,8 @@ final class CheckRailwayStationsHandlerTest extends TestCase
     #[Test]
     public function stationFarFromOneStageEmitsNudgeWithNavigateAction(): void
     {
+        // Stage 1: start(48.0,2.0) end(48.5,2.5) — station at start, within range
+        // Stage 2: start(48.5,2.5) end(49.0,3.0) — both endpoints far from station
         $stages = $this->createStages('trip-1', 2);
 
         $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
@@ -165,42 +167,22 @@ final class CheckRailwayStationsHandlerTest extends TestCase
         $queryBuilder = $this->createStub(QueryBuilderInterface::class);
         $queryBuilder->method('buildRailwayStationQuery')->willReturn('query');
 
-        // One station found, near stage 1 but far from stage 2
+        // Station at Stage 1's start point — near Stage 1, far from Stage 2
         $scanner = $this->createStub(ScannerInterface::class);
         $scanner->method('query')->willReturn([
             'elements' => [
                 [
-                    'lat' => 48.5,
-                    'lon' => 2.5,
+                    'lat' => 48.0,
+                    'lon' => 2.0,
                     'tags' => ['name' => 'Gare de Lyon'],
                 ],
             ],
         ]);
 
-        // Return different distances based on which points are being compared:
-        // - Stage 1 endpoints are near the station (5 km)
-        // - Stage 2 endpoints are far (15 km)
+        // lat1 is the stage endpoint lat; lat1 < 48.5 means Stage 1 endpoints (near), lat1 >= 48.5 means Stage 2 endpoints (far)
         $haversine = $this->createStub(GeoDistanceInterface::class);
         $haversine->method('inMeters')->willReturnCallback(
-            static function (float $lat1, float $lon1, float $lat2, float $lon2): float {
-                // Station is at (48.5, 2.5)
-                // Stage 1: start(48.0,2.0) end(48.5,2.5) — end is close
-                // Stage 2: start(48.5,2.5) end(49.0,3.0) — start is close
-                if (48.5 === $lat1 && 2.5 === $lon1 && 48.5 === $lat2 && 2.5 === $lon2) {
-                    return 0.0;
-                }
-
-                if (48.5 === $lat2 && 2.5 === $lon2) {
-                    // Check proximity to station
-                    if (48.5 === $lat1 && 2.5 === $lon1) {
-                        return 0.0;
-                    }
-
-                    return 15000.0; // Far from station
-                }
-
-                return 5000.0; // Near station
-            },
+            static fn(float $lat1): float => $lat1 >= 48.5 ? 15000.0 : 5000.0,
         );
 
         $publisher = $this->createMock(TripUpdatePublisherInterface::class);
@@ -212,19 +194,12 @@ final class CheckRailwayStationsHandlerTest extends TestCase
                 $this->callback(static function (array $data): bool {
                     $alerts = $data['alerts'];
 
-                    // Some stages may or may not have alerts depending on distance calculation
-                    // We just verify that alerts with navigate action exist when a station is found
-                    foreach ($alerts as $alert) {
-                        if ('nudge' !== $alert['type']) {
-                            return false;
-                        }
-
-                        if (isset($alert['action']) && 'navigate' !== $alert['action']) {
-                            return false;
-                        }
-                    }
-
-                    return true;
+                    // Only Stage 2 has no nearby station and gets a nudge alert
+                    return 1 === \count($alerts)
+                        && 'nudge' === $alerts[0]['type']
+                        && 'navigate' === $alerts[0]['action']
+                        && isset($alerts[0]['actionLat'])
+                        && isset($alerts[0]['actionLon']);
                 }),
             );
 

--- a/api/translations/alerts.en.yaml
+++ b/api/translations/alerts.en.yaml
@@ -22,6 +22,7 @@ alert.comfort.warning: "Poor cycling conditions (comfort index < 40/100) on %cou
 alert.accommodation.seasonal_warning: "All detected accommodations on stage %stage% may be closed during this period."
 alert.rest_day.nudge: "Stage %stage% is day %days% of cycling without a break. Consider inserting a rest day."
 alert.sunset.warning: "Stage %stage%: estimated arrival after twilight end (%twilight%, sunset %sunset%). You may be riding in the dark."
+alert.railway_station.nudge: "No train station within 10 km of stage %stage%. In case of emergency, the nearest station may be far away."
 alert.cultural_poi.suggestion: "Cultural POI nearby on stage %stage%: %name% (%type%, %distance%m from route). Add it to your itinerary?"
 stage.label: "Stage %day%"
 weather.clear_sky: "Clear sky"

--- a/api/translations/alerts.fr.yaml
+++ b/api/translations/alerts.fr.yaml
@@ -22,6 +22,7 @@ alert.comfort.warning: "Conditions de cyclisme défavorables (indice de confort 
 alert.accommodation.seasonal_warning: "Tous les hébergements détectés à l'étape %stage% sont potentiellement fermés à cette période."
 alert.rest_day.nudge: "L'étape %stage% est le %days%e jour consécutif de vélo sans pause. Envisagez d'insérer un jour de repos."
 alert.sunset.warning: "Étape %stage% : arrivée estimée après le crépuscule (%twilight%, coucher %sunset%). Vous risquez de rouler de nuit."
+alert.railway_station.nudge: "Aucune gare ferroviaire à moins de 10 km de l'étape %stage%. En cas d'urgence, la gare la plus proche peut être éloignée."
 alert.cultural_poi.suggestion: "Point d'intérêt culturel à proximité de l'étape %stage% : %name% (%type%, %distance%m du tracé). L'ajouter à votre itinéraire ?"
 stage.label: "Étape %day%"
 weather.clear_sky: "Ciel dégagé"

--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -242,7 +242,8 @@
     "elevationProfileAriaLabel": "Interactive elevation profile for the trip"
   },
   "alertList": {
-    "addToItinerary": "Add to itinerary"
+    "addToItinerary": "Add to itinerary",
+    "navigateToStation": "Navigate to station"
   },
   "onboarding": {
     "nextBtn": "Next",

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -242,7 +242,8 @@
     "elevationProfileAriaLabel": "Profil altimétrique interactif du voyage"
   },
   "alertList": {
-    "addToItinerary": "Ajouter à l'itinéraire"
+    "addToItinerary": "Ajouter à l'itinéraire",
+    "navigateToStation": "Aller à la gare"
   },
   "onboarding": {
     "nextBtn": "Suivant",

--- a/pwa/src/components/alert-list.tsx
+++ b/pwa/src/components/alert-list.tsx
@@ -79,16 +79,29 @@ export function AlertList({ alerts, onAddPoiWaypoint }: AlertListProps) {
                 variant="outline"
                 size="sm"
                 className="mt-1 ml-1 h-6 px-2 text-xs text-emerald-700 dark:text-emerald-400 border-emerald-300 dark:border-emerald-700 hover:bg-emerald-50 dark:hover:bg-emerald-900/20"
-                disabled={action.kind !== "dismiss"}
+                disabled={
+                  action.kind !== "dismiss" && action.kind !== "navigate"
+                }
                 onClick={() => {
                   if (action.kind === "dismiss") {
                     handleDismiss(alertKey);
+                  } else if (action.kind === "navigate") {
+                    const { lat, lon } = action.payload as {
+                      lat: number;
+                      lon: number;
+                    };
+                    window.open(
+                      `https://www.openstreetmap.org/?mlat=${lat}&mlon=${lon}&zoom=15`,
+                      "_blank",
+                      "noopener,noreferrer",
+                    );
                   }
                 }}
                 data-testid="alert-action-button"
               >
                 {ActionIcon && <ActionIcon className="h-3 w-3 mr-1" />}
-                {action.kind === "navigate"
+                {action.kind === "navigate" &&
+                alert.source === "railway_station"
                   ? t("navigateToStation")
                   : action.label}
               </Button>

--- a/pwa/src/components/alert-list.tsx
+++ b/pwa/src/components/alert-list.tsx
@@ -88,7 +88,9 @@ export function AlertList({ alerts, onAddPoiWaypoint }: AlertListProps) {
                 data-testid="alert-action-button"
               >
                 {ActionIcon && <ActionIcon className="h-3 w-3 mr-1" />}
-                {action.label}
+                {action.kind === "navigate"
+                  ? t("navigateToStation")
+                  : action.label}
               </Button>
             )}
           </div>

--- a/pwa/src/hooks/use-mercure.ts
+++ b/pwa/src/hooks/use-mercure.ts
@@ -32,7 +32,7 @@ const MERCURE_URL =
  * - `pois_scanned` — points of interest with optional alerts
  * - `accommodations_found` — accommodation options per stage
  * - `supply_timeline` — clustered supply markers per stage (water + food POIs)
- * - `terrain_alerts` / `calendar_alerts` / `wind_alerts` / `bike_shop_alerts` / `water_point_alerts` — alert categories
+ * - `terrain_alerts` / `calendar_alerts` / `wind_alerts` / `bike_shop_alerts` / `water_point_alerts` / `railway_station_alerts` — alert categories
  * - `trip_complete` — final computation status, stops processing spinner
  * - `validation_error` / `computation_error` — error toasts and recovery
  */
@@ -293,6 +293,28 @@ function dispatchEvent(event: MercureEvent): void {
             distanceFromRoute: a.distanceFromRoute,
           })),
           "cultural_poi",
+        );
+      }
+      break;
+    }
+
+    case "railway_station_alerts": {
+      const railwayByStage = new Map<number, typeof event.data.alerts>();
+      for (const alert of event.data.alerts) {
+        const existing = railwayByStage.get(alert.stageIndex) ?? [];
+        existing.push(alert);
+        railwayByStage.set(alert.stageIndex, existing);
+      }
+      for (const [stageIndex, alerts] of railwayByStage) {
+        store.updateStageAlerts(
+          stageIndex,
+          alerts.map((a) => ({
+            type: a.type as "nudge",
+            message: a.message,
+            lat: a.actionLat ?? null,
+            lon: a.actionLon ?? null,
+          })),
+          "railway_station",
         );
       }
       break;

--- a/pwa/src/hooks/use-mercure.ts
+++ b/pwa/src/hooks/use-mercure.ts
@@ -309,10 +309,21 @@ function dispatchEvent(event: MercureEvent): void {
         store.updateStageAlerts(
           stageIndex,
           alerts.map((a) => ({
-            type: a.type as "nudge",
+            type: "nudge" as const,
             message: a.message,
             lat: a.actionLat ?? null,
             lon: a.actionLon ?? null,
+            ...(a.action === "navigate" &&
+            a.actionLat != null &&
+            a.actionLon != null
+              ? {
+                  action: {
+                    kind: "navigate" as const,
+                    label: "Navigate to station",
+                    payload: { lat: a.actionLat, lon: a.actionLon },
+                  },
+                }
+              : {}),
           })),
           "railway_station",
         );

--- a/pwa/src/lib/mercure/types.ts
+++ b/pwa/src/lib/mercure/types.ts
@@ -208,7 +208,6 @@ export type MercureEvent =
           action?: "navigate";
           actionLat?: number;
           actionLon?: number;
-          stationName?: string | null;
         }[];
       };
     }

--- a/pwa/src/lib/mercure/types.ts
+++ b/pwa/src/lib/mercure/types.ts
@@ -198,6 +198,21 @@ export type MercureEvent =
       };
     }
   | {
+      type: "railway_station_alerts";
+      data: {
+        alerts: {
+          stageIndex: number;
+          dayNumber: number;
+          type: string;
+          message: string;
+          action?: "navigate";
+          actionLat?: number;
+          actionLon?: number;
+          stationName?: string | null;
+        }[];
+      };
+    }
+  | {
       type: "route_segment_recalculated";
       data: {
         stageIndex: number;

--- a/pwa/tests/mocked/alert-actions.spec.ts
+++ b/pwa/tests/mocked/alert-actions.spec.ts
@@ -30,9 +30,9 @@ test.describe("Alert actions", () => {
     const actionButtons = stage1.getByTestId("alert-action-button");
     await expect(actionButtons).toHaveCount(2);
 
-    // Verify labels and disabled state of unimplemented actions
+    // Navigate action is enabled and opens a map URL
     await expect(stage1.getByText("Zoom to location")).toBeVisible();
-    await expect(stage1.getByText("Zoom to location")).toBeDisabled();
+    await expect(stage1.getByText("Zoom to location")).not.toBeDisabled();
     await expect(stage1.getByText("Got it")).toBeVisible();
     await expect(stage1.getByText("Got it")).not.toBeDisabled();
   });


### PR DESCRIPTION
## Summary

- New `CheckRailwayStationsHandler` async handler: queries Overpass for train stations within 10 km of stage endpoints
- Emits nudge alert with `navigate` action when no station is found
- Adds `RAILWAY_STATIONS` computation tracking and `railway_station_alerts` Mercure event
- Frontend routes the new event type to stage alerts

## Test plan

- [x] PHPUnit: 5 unit tests covering station nearby/absent, navigate action, null stages
- [x] README.md and AlertDocumentationTest updated
- [x] `make qa` passes
- [x] `make test-php` passes (796 tests)

Closes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

All previously flagged issues have been addressed across the commit series. The navigate button is now enabled with a proper click handler, the empty-endpoints guard prevents an invalid Overpass query, rest-day stages are excluded from both the alert loop and the polyline, and the i18n label is surfaced via the component-level override. The only outstanding gap is the missing Playwright spec for the `railway_station_alerts` event type.

**Findings summary:** 0 blocking findings. 1 `test` gap — no `pwa/tests/mocked/railway-station.spec.ts` for the new event type.

**Resolved threads:** Resolved 2 previously open bot-authored threads:
- Navigate button disabled / no click handler → fixed in `fix(railway): enable navigate action` (commit `640bbe1`)
- Empty `$endPoints` produces invalid Overpass query → fixed by early-return guard (commit `640bbe1`)

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [ ] Tests cover new/changed cases — no `pwa/tests/mocked/railway-station.spec.ts`
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

Reviewed commit: `640bbe1045bdfac72610882714e6e4a06a748f78`

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->