### PR TITLE
feat(alerts): add border crossing nudge analyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,9 @@ Rules are executed in priority order (lower = higher priority):
 | **Cultural POI** | -- | ![nudge](https://img.shields.io/badge/-nudge-0288d1) | Museum, monument, castle, church, viewpoint, or attraction within 500 m of route |
 | **Railway station** | -- | ![nudge](https://img.shields.io/badge/-nudge-0288d1) | No train station within 10 km of a stage endpoint (emergency evacuation) |
 | **Health services** | -- | ![nudge](https://img.shields.io/badge/-nudge-0288d1) | No pharmacy, hospital, or clinic within 15 km of a stage |
+| **Border crossing** | -- | ![nudge](https://img.shields.io/badge/-nudge-0288d1) | Route crosses an international border (country change detected via Overpass is_in) |
 
-**Terrain rules** (Continuity, Elevation, Steep gradient, Surface, Traffic, E-bike range, Sunset, Rest day) implement `StageAnalyzerInterface` and are auto-discovered via `#[AutoconfigureTag('app.stage_analyzer')]`. Rules with `--` priority (Calendar, Wind + Comfort, Bike shops, Resupply, Accommodation, Water points, Cultural POI, Railway station, Health services) are separate async Symfony Message handlers; Comfort is co-located with Wind inside `AnalyzeWindHandler`.
+**Terrain rules** (Continuity, Elevation, Steep gradient, Surface, Traffic, E-bike range, Sunset, Rest day) implement `StageAnalyzerInterface` and are auto-discovered via `#[AutoconfigureTag('app.stage_analyzer')]`. Rules with `--` priority (Calendar, Wind + Comfort, Bike shops, Resupply, Accommodation, Water points, Cultural POI, Railway station, Health services, Border crossing) are separate async Symfony Message handlers; Comfort is co-located with Wind inside `AnalyzeWindHandler`.
 
 ---
 

--- a/api/src/Enum/ComputationName.php
+++ b/api/src/Enum/ComputationName.php
@@ -21,6 +21,7 @@ enum ComputationName: string
     case CULTURAL_POIS = 'cultural_pois';
     case RAILWAY_STATIONS = 'railway_stations';
     case HEALTH_SERVICES = 'health_services';
+    case BORDER_CROSSING = 'border_crossing';
 
     /**
      * Computations initialized at trip creation (the main pipeline).

--- a/api/src/Mercure/MercureEventType.php
+++ b/api/src/Mercure/MercureEventType.php
@@ -21,6 +21,7 @@ enum MercureEventType: string
     case CULTURAL_POI_ALERTS = 'cultural_poi_alerts';
     case RAILWAY_STATION_ALERTS = 'railway_station_alerts';
     case HEALTH_SERVICE_ALERTS = 'health_service_alerts';
+    case BORDER_CROSSING_ALERTS = 'border_crossing_alerts';
     case VALIDATION_ERROR = 'validation_error';
     case COMPUTATION_ERROR = 'computation_error';
     case TRIP_COMPLETE = 'trip_complete';

--- a/api/src/Message/CheckBorderCrossing.php
+++ b/api/src/Message/CheckBorderCrossing.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Message;
+
+final readonly class CheckBorderCrossing
+{
+    public function __construct(
+        public string $tripId,
+        public ?int $generation = null,
+    ) {
+    }
+}

--- a/api/src/MessageHandler/CheckBorderCrossingHandler.php
+++ b/api/src/MessageHandler/CheckBorderCrossingHandler.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MessageHandler;
+
+use App\ApiResource\Model\Coordinate;
+use App\ApiResource\Stage;
+use App\ComputationTracker\ComputationTrackerInterface;
+use App\ComputationTracker\TripGenerationTrackerInterface;
+use App\Enum\AlertType;
+use App\Enum\ComputationName;
+use App\Mercure\MercureEventType;
+use App\Mercure\TripUpdatePublisherInterface;
+use App\Message\CheckBorderCrossing;
+use App\Repository\TripRequestRepositoryInterface;
+use App\Scanner\QueryBuilderInterface;
+use App\Scanner\ScannerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * Detects international border crossings along the route.
+ *
+ * For each stage, queries the country at start and end points via Overpass `is_in`.
+ * When consecutive points belong to different countries, a nudge is emitted
+ * indicating the border crossing. Deduplicates: each unique country pair
+ * (A→B) produces at most one nudge.
+ */
+#[AsMessageHandler]
+final readonly class CheckBorderCrossingHandler extends AbstractTripMessageHandler
+{
+    public function __construct(
+        ComputationTrackerInterface $computationTracker,
+        TripUpdatePublisherInterface $publisher,
+        TripGenerationTrackerInterface $generationTracker,
+        LoggerInterface $logger,
+        private TripRequestRepositoryInterface $tripStateManager,
+        private ScannerInterface $scanner,
+        private QueryBuilderInterface $queryBuilder,
+        private TranslatorInterface $translator,
+    ) {
+        parent::__construct($computationTracker, $publisher, $generationTracker, $logger);
+    }
+
+    public function __invoke(CheckBorderCrossing $message): void
+    {
+        $tripId = $message->tripId;
+        $generation = $message->generation;
+        $stages = $this->tripStateManager->getStages($tripId);
+
+        if (null === $stages) {
+            return;
+        }
+
+        $locale = $this->tripStateManager->getLocale($tripId) ?? 'en';
+
+        $this->executeWithTracking($tripId, ComputationName::BORDER_CROSSING, function () use ($tripId, $stages, $locale): void {
+            // Collect unique points to query: start of first stage + end of each stage
+            $checkPoints = $this->buildCheckPoints($stages);
+
+            if (\count($checkPoints) < 2) {
+                $this->publisher->publish($tripId, MercureEventType::BORDER_CROSSING_ALERTS, [
+                    'alerts' => [],
+                ]);
+
+                return;
+            }
+
+            // Resolve country for each checkpoint via Overpass is_in
+            $countries = $this->resolveCountries($checkPoints);
+
+            // Detect border crossings: when consecutive countries differ
+            $alerts = [];
+            /** @var list<string> $seenCrossings */
+            $seenCrossings = [];
+
+            for ($i = 1, $count = \count($countries); $i < $count; ++$i) {
+                $prevCountry = $countries[$i - 1];
+                $currentCountry = $countries[$i];
+
+                if (null === $prevCountry || null === $currentCountry) {
+                    continue;
+                }
+
+                if ($prevCountry === $currentCountry) {
+                    continue;
+                }
+
+                // Deduplicate: same crossing (A→B) only once
+                $crossingKey = $prevCountry.'->'.$currentCountry;
+                if (\in_array($crossingKey, $seenCrossings, true)) {
+                    continue;
+                }
+
+                $seenCrossings[] = $crossingKey;
+
+                $crossingPoint = $checkPoints[$i];
+
+                // Find which stage this crossing belongs to
+                $stageIndex = min($i - 1, \count($stages) - 1);
+                $stage = $stages[$stageIndex];
+
+                $alerts[] = [
+                    'stageIndex' => $stageIndex,
+                    'dayNumber' => $stage->dayNumber,
+                    'type' => AlertType::NUDGE->value,
+                    'message' => $this->translator->trans(
+                        'alert.border_crossing.nudge',
+                        [
+                            '%country%' => $currentCountry,
+                        ],
+                        'alerts',
+                        $locale,
+                    ),
+                    'action' => 'navigate',
+                    'lat' => $crossingPoint->lat,
+                    'lon' => $crossingPoint->lon,
+                ];
+            }
+
+            $this->publisher->publish($tripId, MercureEventType::BORDER_CROSSING_ALERTS, [
+                'alerts' => $alerts,
+            ]);
+        }, $generation);
+    }
+
+    /**
+     * Builds the list of coordinates to check for country boundaries.
+     *
+     * Uses the start point of the first stage, then the end point of each stage.
+     * This produces N+1 checkpoints for N stages, covering every stage transition.
+     *
+     * @param list<Stage> $stages
+     *
+     * @return list<Coordinate>
+     */
+    private function buildCheckPoints(array $stages): array
+    {
+        if ([] === $stages) {
+            return [];
+        }
+
+        $points = [$stages[0]->startPoint];
+
+        foreach ($stages as $stage) {
+            $points[] = $stage->endPoint;
+        }
+
+        return $points;
+    }
+
+    /**
+     * Resolves the country name for each coordinate via Overpass is_in queries.
+     *
+     * @param list<Coordinate> $points
+     *
+     * @return list<string|null>
+     */
+    private function resolveCountries(array $points): array
+    {
+        $queries = [];
+        foreach ($points as $i => $point) {
+            $queries['point_'.$i] = $this->queryBuilder->buildCountryQuery($point);
+        }
+
+        $results = $this->scanner->queryBatch($queries);
+
+        $countries = [];
+        foreach (array_keys($points) as $i) {
+            $result = $results['point_'.$i] ?? [];
+            $countries[] = $this->extractCountryName($result);
+        }
+
+        return $countries;
+    }
+
+    /**
+     * Extracts the country name from an Overpass is_in result.
+     *
+     * @param array<string, mixed> $result
+     */
+    private function extractCountryName(array $result): ?string
+    {
+        /** @var list<array{tags?: array<string, string>}> $elements */
+        $elements = \is_array($result['elements'] ?? null) ? $result['elements'] : [];
+
+        foreach ($elements as $element) {
+            $tags = $element['tags'] ?? [];
+
+            if (isset($tags['name:en'])) {
+                return $tags['name:en'];
+            }
+
+            if (isset($tags['name'])) {
+                return $tags['name'];
+            }
+        }
+
+        return null;
+    }
+}

--- a/api/src/MessageHandler/CheckBorderCrossingHandler.php
+++ b/api/src/MessageHandler/CheckBorderCrossingHandler.php
@@ -69,7 +69,7 @@ final readonly class CheckBorderCrossingHandler extends AbstractTripMessageHandl
             }
 
             // Resolve country for each checkpoint via Overpass is_in
-            $countries = $this->resolveCountries($checkPoints);
+            $countries = $this->resolveCountries($checkPoints, $locale);
 
             // Detect border crossings: when consecutive countries differ
             $alerts = [];
@@ -158,7 +158,7 @@ final readonly class CheckBorderCrossingHandler extends AbstractTripMessageHandl
      *
      * @return list<string|null>
      */
-    private function resolveCountries(array $points): array
+    private function resolveCountries(array $points, string $locale): array
     {
         $queries = [];
         foreach ($points as $i => $point) {
@@ -170,7 +170,7 @@ final readonly class CheckBorderCrossingHandler extends AbstractTripMessageHandl
         $countries = [];
         foreach (array_keys($points) as $i) {
             $result = $results['point_'.$i] ?? [];
-            $countries[] = $this->extractCountryName($result);
+            $countries[] = $this->extractCountryName($result, $locale);
         }
 
         return $countries;
@@ -179,15 +179,23 @@ final readonly class CheckBorderCrossingHandler extends AbstractTripMessageHandl
     /**
      * Extracts the country name from an Overpass is_in result.
      *
+     * Tries locale-specific name first (e.g. name:fr → "Belgique"),
+     * then falls back to name:en, then the generic name tag.
+     *
      * @param array<string, mixed> $result
      */
-    private function extractCountryName(array $result): ?string
+    private function extractCountryName(array $result, string $locale): ?string
     {
         /** @var list<array{tags?: array<string, string>}> $elements */
         $elements = \is_array($result['elements'] ?? null) ? $result['elements'] : [];
 
         foreach ($elements as $element) {
             $tags = $element['tags'] ?? [];
+
+            $localeKey = 'name:'.$locale;
+            if (isset($tags[$localeKey])) {
+                return $tags[$localeKey];
+            }
 
             if (isset($tags['name:en'])) {
                 return $tags['name:en'];

--- a/api/src/MessageHandler/GenerateStagesHandler.php
+++ b/api/src/MessageHandler/GenerateStagesHandler.php
@@ -19,6 +19,7 @@ use App\Mercure\MercureEventType;
 use App\Mercure\TripUpdatePublisherInterface;
 use App\Message\AnalyzeTerrain;
 use App\Message\CheckBikeShops;
+use App\Message\CheckBorderCrossing;
 use App\Message\CheckCalendar;
 use App\Message\CheckCulturalPois;
 use App\Message\CheckHealthServices;
@@ -113,6 +114,7 @@ final readonly class GenerateStagesHandler extends AbstractTripMessageHandler
             $this->messageBus->dispatch(new CheckHealthServices($tripId, $generation));
             $this->messageBus->dispatch(new CheckCulturalPois($tripId, $generation));
             $this->messageBus->dispatch(new CheckRailwayStations($tripId, $generation));
+            $this->messageBus->dispatch(new CheckBorderCrossing($tripId, $generation));
         }, $generation);
     }
 

--- a/api/src/Scanner/OsmOverpassQueryBuilder.php
+++ b/api/src/Scanner/OsmOverpassQueryBuilder.php
@@ -151,6 +151,15 @@ final readonly class OsmOverpassQueryBuilder implements QueryBuilderInterface
         );
     }
 
+    public function buildCountryQuery(Coordinate $point): string
+    {
+        return \sprintf(
+            '[out:json][timeout:10];is_in(%F,%F)->.a;area.a["admin_level"="2"]["boundary"="administrative"];out tags 1;',
+            $point->lat,
+            $point->lon,
+        );
+    }
+
     /** @param list<Coordinate> $points */
     private function buildPolyline(array $points): string
     {

--- a/api/src/Scanner/QueryBuilderInterface.php
+++ b/api/src/Scanner/QueryBuilderInterface.php
@@ -83,4 +83,12 @@ interface QueryBuilderInterface
      * @param list<list<Coordinate>> $stageGeometries geometry points per stage
      */
     public function buildBatchCulturalPoiQuery(array $stageGeometries, int $radiusMeters = 500): string;
+
+    /**
+     * Queries the country (admin_level=2) for a given coordinate using Overpass is_in.
+     *
+     * Returns relations with admin_level=2 and boundary=administrative that contain the point,
+     * allowing border crossing detection by comparing countries at different route positions.
+     */
+    public function buildCountryQuery(Coordinate $point): string;
 }

--- a/api/tests/Functional/trip-schema.json
+++ b/api/tests/Functional/trip-schema.json
@@ -44,7 +44,8 @@
         "water_points",
         "cultural_pois",
         "railway_stations",
-        "health_services"
+        "health_services",
+        "border_crossing"
       ],
       "additionalProperties": false,
       "properties": {
@@ -166,6 +167,15 @@
           ]
         },
         "health_services": {
+          "type": "string",
+          "enum": [
+            "pending",
+            "running",
+            "done",
+            "failed"
+          ]
+        },
+        "border_crossing": {
           "type": "string",
           "enum": [
             "pending",

--- a/api/tests/Unit/AlertDocumentationTest.php
+++ b/api/tests/Unit/AlertDocumentationTest.php
@@ -46,6 +46,7 @@ final class AlertDocumentationTest extends TestCase
         'cultural_poi' => 'Cultural POI',
         'railway_station' => 'Railway station',
         'health_service' => 'Health services',
+        'border_crossing' => 'Border crossing',
     ];
 
     /**

--- a/api/tests/Unit/MessageHandler/CheckBorderCrossingHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/CheckBorderCrossingHandlerTest.php
@@ -1,0 +1,379 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\MessageHandler;
+
+use App\ApiResource\Model\Coordinate;
+use App\ApiResource\Stage;
+use App\ComputationTracker\ComputationTrackerInterface;
+use App\ComputationTracker\TripGenerationTrackerInterface;
+use App\Mercure\MercureEventType;
+use App\Mercure\TripUpdatePublisherInterface;
+use App\Message\CheckBorderCrossing;
+use App\MessageHandler\CheckBorderCrossingHandler;
+use App\Repository\TripRequestRepositoryInterface;
+use App\Scanner\QueryBuilderInterface;
+use App\Scanner\ScannerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class CheckBorderCrossingHandlerTest extends TestCase
+{
+    private function createHandler(
+        TripRequestRepositoryInterface $tripStateManager,
+        TripUpdatePublisherInterface $publisher,
+        ScannerInterface $scanner,
+        QueryBuilderInterface $queryBuilder,
+    ): CheckBorderCrossingHandler {
+        $computationTracker = $this->createStub(ComputationTrackerInterface::class);
+        $computationTracker->method('isAllComplete')->willReturn(false);
+
+        $translator = $this->createStub(TranslatorInterface::class);
+        $translator->method('trans')->willReturnCallback(
+            static fn (string $id, array $params): string => match ($id) {
+                'alert.border_crossing.nudge' => \sprintf('You are entering %s.', $params['%country%']),
+                default => $id,
+            },
+        );
+
+        $generationTracker = $this->createStub(TripGenerationTrackerInterface::class);
+
+        return new CheckBorderCrossingHandler(
+            $computationTracker,
+            $publisher,
+            $generationTracker,
+            new NullLogger(),
+            $tripStateManager,
+            $scanner,
+            $queryBuilder,
+            $translator,
+        );
+    }
+
+    private function createTripStateManager(?array $stages): TripRequestRepositoryInterface
+    {
+        $manager = $this->createStub(TripRequestRepositoryInterface::class);
+        $manager->method('getStages')->willReturn($stages);
+        $manager->method('getLocale')->willReturn('en');
+
+        return $manager;
+    }
+
+    #[Test]
+    public function borderCrossingDetectedBetweenFranceAndBelgium(): void
+    {
+        // Stage 1: starts in France (Lille), ends in Belgium (Courtrai)
+        $stages = [
+            new Stage(
+                tripId: 'trip-1',
+                dayNumber: 1,
+                distance: 80.0,
+                elevation: 200.0,
+                startPoint: new Coordinate(50.6292, 3.0573),  // Lille, France
+                endPoint: new Coordinate(50.8279, 3.2646),    // Courtrai, Belgium
+            ),
+            new Stage(
+                tripId: 'trip-1',
+                dayNumber: 2,
+                distance: 60.0,
+                elevation: 150.0,
+                startPoint: new Coordinate(50.8279, 3.2646),  // Courtrai, Belgium
+                endPoint: new Coordinate(50.7500, 3.8833),    // Renaix, Belgium
+            ),
+        ];
+
+        $tripStateManager = $this->createTripStateManager($stages);
+
+        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
+        $queryBuilder->method('buildCountryQuery')->willReturn('query');
+
+        // Overpass queryBatch returns: point_0 = France, point_1 = Belgium, point_2 = Belgium
+        $scanner = $this->createStub(ScannerInterface::class);
+        $scanner->method('queryBatch')->willReturn([
+            'point_0' => ['elements' => [['tags' => ['name:en' => 'France', 'admin_level' => '2']]]],
+            'point_1' => ['elements' => [['tags' => ['name:en' => 'Belgium', 'admin_level' => '2']]]],
+            'point_2' => ['elements' => [['tags' => ['name:en' => 'Belgium', 'admin_level' => '2']]]],
+        ]);
+
+        $publisher = $this->createMock(TripUpdatePublisherInterface::class);
+        $publisher->expects($this->once())
+            ->method('publish')
+            ->with(
+                'trip-1',
+                MercureEventType::BORDER_CROSSING_ALERTS,
+                $this->callback(static function (array $data): bool {
+                    $alerts = $data['alerts'];
+
+                    return 1 === \count($alerts)
+                        && 'nudge' === $alerts[0]['type']
+                        && str_contains((string) $alerts[0]['message'], 'Belgium')
+                        && 'navigate' === $alerts[0]['action']
+                        && 0 === $alerts[0]['stageIndex'];
+                }),
+            );
+
+        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder);
+        $handler(new CheckBorderCrossing('trip-1'));
+    }
+
+    #[Test]
+    public function noBorderCrossingOnDomesticRoute(): void
+    {
+        // Both stages are within France
+        $stages = [
+            new Stage(
+                tripId: 'trip-1',
+                dayNumber: 1,
+                distance: 80.0,
+                elevation: 200.0,
+                startPoint: new Coordinate(48.8566, 2.3522),  // Paris
+                endPoint: new Coordinate(48.1120, 1.6803),    // Chartres
+            ),
+            new Stage(
+                tripId: 'trip-1',
+                dayNumber: 2,
+                distance: 70.0,
+                elevation: 180.0,
+                startPoint: new Coordinate(48.1120, 1.6803),  // Chartres
+                endPoint: new Coordinate(47.3900, 0.6890),    // Tours
+            ),
+        ];
+
+        $tripStateManager = $this->createTripStateManager($stages);
+
+        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
+        $queryBuilder->method('buildCountryQuery')->willReturn('query');
+
+        // All points are in France
+        $scanner = $this->createStub(ScannerInterface::class);
+        $scanner->method('queryBatch')->willReturn([
+            'point_0' => ['elements' => [['tags' => ['name:en' => 'France', 'admin_level' => '2']]]],
+            'point_1' => ['elements' => [['tags' => ['name:en' => 'France', 'admin_level' => '2']]]],
+            'point_2' => ['elements' => [['tags' => ['name:en' => 'France', 'admin_level' => '2']]]],
+        ]);
+
+        $publisher = $this->createMock(TripUpdatePublisherInterface::class);
+        $publisher->expects($this->once())
+            ->method('publish')
+            ->with(
+                'trip-1',
+                MercureEventType::BORDER_CROSSING_ALERTS,
+                $this->callback(static fn (array $data): bool => [] === $data['alerts']),
+            );
+
+        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder);
+        $handler(new CheckBorderCrossing('trip-1'));
+    }
+
+    #[Test]
+    public function duplicateBorderCrossingIsDeduplicatedForSameDirection(): void
+    {
+        // Route: France → Belgium → France → Belgium
+        // The France→Belgium crossing should appear once,
+        // and the Belgium→France crossing should also appear once
+        $stages = [
+            new Stage(
+                tripId: 'trip-1',
+                dayNumber: 1,
+                distance: 80.0,
+                elevation: 200.0,
+                startPoint: new Coordinate(50.6292, 3.0573),
+                endPoint: new Coordinate(50.8279, 3.2646),
+            ),
+            new Stage(
+                tripId: 'trip-1',
+                dayNumber: 2,
+                distance: 60.0,
+                elevation: 150.0,
+                startPoint: new Coordinate(50.8279, 3.2646),
+                endPoint: new Coordinate(50.6000, 3.4000),
+            ),
+            new Stage(
+                tripId: 'trip-1',
+                dayNumber: 3,
+                distance: 50.0,
+                elevation: 100.0,
+                startPoint: new Coordinate(50.6000, 3.4000),
+                endPoint: new Coordinate(50.8500, 3.5000),
+            ),
+        ];
+
+        $tripStateManager = $this->createTripStateManager($stages);
+
+        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
+        $queryBuilder->method('buildCountryQuery')->willReturn('query');
+
+        // France → Belgium → France → Belgium
+        $scanner = $this->createStub(ScannerInterface::class);
+        $scanner->method('queryBatch')->willReturn([
+            'point_0' => ['elements' => [['tags' => ['name:en' => 'France']]]],
+            'point_1' => ['elements' => [['tags' => ['name:en' => 'Belgium']]]],
+            'point_2' => ['elements' => [['tags' => ['name:en' => 'France']]]],
+            'point_3' => ['elements' => [['tags' => ['name:en' => 'Belgium']]]],
+        ]);
+
+        $publisher = $this->createMock(TripUpdatePublisherInterface::class);
+        $publisher->expects($this->once())
+            ->method('publish')
+            ->with(
+                'trip-1',
+                MercureEventType::BORDER_CROSSING_ALERTS,
+                $this->callback(static function (array $data): bool {
+                    $alerts = $data['alerts'];
+
+                    // France→Belgium (once) + Belgium→France (once) = 2 alerts
+                    return 2 === \count($alerts)
+                        && str_contains((string) $alerts[0]['message'], 'Belgium')
+                        && str_contains((string) $alerts[1]['message'], 'France');
+                }),
+            );
+
+        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder);
+        $handler(new CheckBorderCrossing('trip-1'));
+    }
+
+    #[Test]
+    public function nullStagesYieldsNoPublish(): void
+    {
+        $tripStateManager = $this->createTripStateManager(null);
+
+        $publisher = $this->createMock(TripUpdatePublisherInterface::class);
+        $publisher->expects($this->never())->method('publish');
+
+        $scanner = $this->createStub(ScannerInterface::class);
+        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
+
+        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder);
+        $handler(new CheckBorderCrossing('trip-1'));
+    }
+
+    #[Test]
+    public function nullCountryFromOverpassIsIgnored(): void
+    {
+        $stages = [
+            new Stage(
+                tripId: 'trip-1',
+                dayNumber: 1,
+                distance: 80.0,
+                elevation: 200.0,
+                startPoint: new Coordinate(50.6292, 3.0573),
+                endPoint: new Coordinate(50.8279, 3.2646),
+            ),
+        ];
+
+        $tripStateManager = $this->createTripStateManager($stages);
+
+        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
+        $queryBuilder->method('buildCountryQuery')->willReturn('query');
+
+        // One point resolves to France, the other has no country data
+        $scanner = $this->createStub(ScannerInterface::class);
+        $scanner->method('queryBatch')->willReturn([
+            'point_0' => ['elements' => [['tags' => ['name:en' => 'France']]]],
+            'point_1' => ['elements' => []],
+        ]);
+
+        $publisher = $this->createMock(TripUpdatePublisherInterface::class);
+        $publisher->expects($this->once())
+            ->method('publish')
+            ->with(
+                'trip-1',
+                MercureEventType::BORDER_CROSSING_ALERTS,
+                $this->callback(static fn (array $data): bool => [] === $data['alerts']),
+            );
+
+        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder);
+        $handler(new CheckBorderCrossing('trip-1'));
+    }
+
+    #[Test]
+    public function alertIncludesNavigateActionAndCoordinates(): void
+    {
+        $stages = [
+            new Stage(
+                tripId: 'trip-1',
+                dayNumber: 1,
+                distance: 80.0,
+                elevation: 200.0,
+                startPoint: new Coordinate(50.6292, 3.0573),
+                endPoint: new Coordinate(50.8279, 3.2646),
+            ),
+        ];
+
+        $tripStateManager = $this->createTripStateManager($stages);
+
+        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
+        $queryBuilder->method('buildCountryQuery')->willReturn('query');
+
+        $scanner = $this->createStub(ScannerInterface::class);
+        $scanner->method('queryBatch')->willReturn([
+            'point_0' => ['elements' => [['tags' => ['name:en' => 'France']]]],
+            'point_1' => ['elements' => [['tags' => ['name:en' => 'Belgium']]]],
+        ]);
+
+        $publisher = $this->createMock(TripUpdatePublisherInterface::class);
+        $publisher->expects($this->once())
+            ->method('publish')
+            ->with(
+                'trip-1',
+                MercureEventType::BORDER_CROSSING_ALERTS,
+                $this->callback(static function (array $data): bool {
+                    $alert = $data['alerts'][0] ?? null;
+                    if (null === $alert) {
+                        return false;
+                    }
+
+                    // The crossing point should be the end point of stage 1 (entry into Belgium)
+                    return 'navigate' === $alert['action']
+                        && abs($alert['lat'] - 50.8279) < 0.001
+                        && abs($alert['lon'] - 3.2646) < 0.001;
+                }),
+            );
+
+        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder);
+        $handler(new CheckBorderCrossing('trip-1'));
+    }
+
+    #[Test]
+    public function fallsBackToNameTagWhenNameEnNotAvailable(): void
+    {
+        $stages = [
+            new Stage(
+                tripId: 'trip-1',
+                dayNumber: 1,
+                distance: 80.0,
+                elevation: 200.0,
+                startPoint: new Coordinate(50.6292, 3.0573),
+                endPoint: new Coordinate(50.8279, 3.2646),
+            ),
+        ];
+
+        $tripStateManager = $this->createTripStateManager($stages);
+
+        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
+        $queryBuilder->method('buildCountryQuery')->willReturn('query');
+
+        // name:en missing, falls back to name tag
+        $scanner = $this->createStub(ScannerInterface::class);
+        $scanner->method('queryBatch')->willReturn([
+            'point_0' => ['elements' => [['tags' => ['name' => 'France']]]],
+            'point_1' => ['elements' => [['tags' => ['name' => 'Belgique / België']]]],
+        ]);
+
+        $publisher = $this->createMock(TripUpdatePublisherInterface::class);
+        $publisher->expects($this->once())
+            ->method('publish')
+            ->with(
+                'trip-1',
+                MercureEventType::BORDER_CROSSING_ALERTS,
+                $this->callback(static fn (array $data): bool => 1 === \count($data['alerts'])
+                    && str_contains((string) $data['alerts'][0]['message'], 'Belgique')),
+            );
+
+        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder);
+        $handler(new CheckBorderCrossing('trip-1'));
+    }
+}

--- a/api/tests/Unit/MessageHandler/CheckBorderCrossingHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/CheckBorderCrossingHandlerTest.php
@@ -54,11 +54,11 @@ final class CheckBorderCrossingHandlerTest extends TestCase
     }
 
     /** @param list<Stage>|null $stages */
-    private function createTripStateManager(?array $stages): TripRequestRepositoryInterface
+    private function createTripStateManager(?array $stages, string $locale = 'en'): TripRequestRepositoryInterface
     {
         $manager = $this->createStub(TripRequestRepositoryInterface::class);
         $manager->method('getStages')->willReturn($stages);
-        $manager->method('getLocale')->willReturn('en');
+        $manager->method('getLocale')->willReturn($locale);
 
         return $manager;
     }
@@ -362,6 +362,47 @@ final class CheckBorderCrossingHandlerTest extends TestCase
         $scanner->method('queryBatch')->willReturn([
             'point_0' => ['elements' => [['tags' => ['name' => 'France']]]],
             'point_1' => ['elements' => [['tags' => ['name' => 'Belgique / België']]]],
+        ]);
+
+        $publisher = $this->createMock(TripUpdatePublisherInterface::class);
+        $publisher->expects($this->once())
+            ->method('publish')
+            ->with(
+                'trip-1',
+                MercureEventType::BORDER_CROSSING_ALERTS,
+                $this->callback(static fn (array $data): bool => 1 === \count($data['alerts'])
+                    && str_contains((string) $data['alerts'][0]['message'], 'Belgique')),
+            );
+
+        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder);
+        $handler(new CheckBorderCrossing('trip-1'));
+    }
+
+    #[Test]
+    public function localeAwareCountryNameUsesLocalizedName(): void
+    {
+        $stages = [
+            new Stage(
+                tripId: 'trip-1',
+                dayNumber: 1,
+                distance: 80.0,
+                elevation: 200.0,
+                startPoint: new Coordinate(50.6292, 3.0573),
+                endPoint: new Coordinate(50.8279, 3.2646),
+            ),
+        ];
+
+        // French locale: should prefer name:fr over name:en
+        $tripStateManager = $this->createTripStateManager($stages, 'fr');
+
+        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
+        $queryBuilder->method('buildCountryQuery')->willReturn('query');
+
+        // Both name:fr and name:en available — should pick name:fr
+        $scanner = $this->createStub(ScannerInterface::class);
+        $scanner->method('queryBatch')->willReturn([
+            'point_0' => ['elements' => [['tags' => ['name:fr' => 'France', 'name:en' => 'France']]]],
+            'point_1' => ['elements' => [['tags' => ['name:fr' => 'Belgique', 'name:en' => 'Belgium']]]],
         ]);
 
         $publisher = $this->createMock(TripUpdatePublisherInterface::class);

--- a/api/tests/Unit/MessageHandler/CheckBorderCrossingHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/CheckBorderCrossingHandlerTest.php
@@ -53,6 +53,7 @@ final class CheckBorderCrossingHandlerTest extends TestCase
         );
     }
 
+    /** @param list<Stage>|null $stages */
     private function createTripStateManager(?array $stages): TripRequestRepositoryInterface
     {
         $manager = $this->createStub(TripRequestRepositoryInterface::class);

--- a/api/translations/alerts.en.yaml
+++ b/api/translations/alerts.en.yaml
@@ -25,6 +25,7 @@ alert.sunset.warning: "Stage %stage%: estimated arrival after twilight end (%twi
 alert.railway_station.nudge: "No train station within 10 km of stage %stage%. In case of emergency, the nearest station may be far away."
 alert.health_service.nudge: "No pharmacy, hospital, or clinic detected within 15 km of stage %stage%. Carry a first-aid kit and check nearby towns before departure."
 alert.cultural_poi.suggestion: "Cultural POI nearby on stage %stage%: %name% (%type%, %distance%m from route). Add it to your itinerary?"
+alert.border_crossing.nudge: "You are entering %country%. Check phone coverage, payment methods, and local regulations."
 stage.label: "Stage %day%"
 weather.clear_sky: "Clear sky"
 weather.mainly_clear: "Mainly clear"

--- a/api/translations/alerts.fr.yaml
+++ b/api/translations/alerts.fr.yaml
@@ -25,6 +25,7 @@ alert.sunset.warning: "Étape %stage% : arrivée estimée après le crépuscule 
 alert.railway_station.nudge: "Aucune gare ferroviaire à moins de 10 km de l'étape %stage%. En cas d'urgence, la gare la plus proche peut être éloignée."
 alert.health_service.nudge: "Aucune pharmacie, hôpital ni clinique détecté dans un rayon de 15 km autour de l'étape %stage%. Emportez une trousse de premiers secours et vérifiez les villes proches avant le départ."
 alert.cultural_poi.suggestion: "Point d'intérêt culturel à proximité de l'étape %stage% : %name% (%type%, %distance%m du tracé). L'ajouter à votre itinéraire ?"
+alert.border_crossing.nudge: "Vous passez en %country%. Vérifiez la couverture téléphonique, les moyens de paiement et la réglementation locale."
 stage.label: "Étape %day%"
 weather.clear_sky: "Ciel dégagé"
 weather.mainly_clear: "Plutôt dégagé"

--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -243,7 +243,8 @@
   },
   "alertList": {
     "addToItinerary": "Add to itinerary",
-    "navigateToStation": "Navigate to station"
+    "navigateToStation": "Navigate to station",
+    "navigateToCrossing": "Navigate to crossing"
   },
   "onboarding": {
     "nextBtn": "Next",

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -243,7 +243,8 @@
   },
   "alertList": {
     "addToItinerary": "Ajouter à l'itinéraire",
-    "navigateToStation": "Aller à la gare"
+    "navigateToStation": "Aller à la gare",
+    "navigateToCrossing": "Aller au passage frontière"
   },
   "onboarding": {
     "nextBtn": "Suivant",

--- a/pwa/src/components/alert-list.tsx
+++ b/pwa/src/components/alert-list.tsx
@@ -103,7 +103,10 @@ export function AlertList({ alerts, onAddPoiWaypoint }: AlertListProps) {
                 {action.kind === "navigate" &&
                 alert.source === "railway_station"
                   ? t("navigateToStation")
-                  : action.label}
+                  : action.kind === "navigate" &&
+                      alert.source === "border_crossing"
+                    ? t("navigateToCrossing")
+                    : action.label}
               </Button>
             )}
           </div>

--- a/pwa/src/hooks/use-mercure.ts
+++ b/pwa/src/hooks/use-mercure.ts
@@ -362,10 +362,15 @@ function dispatchEvent(event: MercureEvent): void {
         store.updateStageAlerts(
           stageIndex,
           alerts.map((a) => ({
-            type: a.type as "nudge",
+            type: a.type,
             message: a.message,
             lat: a.lat,
             lon: a.lon,
+            action: {
+              kind: "navigate" as const,
+              label: "Navigate to crossing",
+              payload: { lat: a.lat, lon: a.lon },
+            },
           })),
           "border_crossing",
         );

--- a/pwa/src/hooks/use-mercure.ts
+++ b/pwa/src/hooks/use-mercure.ts
@@ -32,7 +32,7 @@ const MERCURE_URL =
  * - `pois_scanned` — points of interest with optional alerts
  * - `accommodations_found` — accommodation options per stage
  * - `supply_timeline` — clustered supply markers per stage (water + food POIs)
- * - `terrain_alerts` / `calendar_alerts` / `wind_alerts` / `bike_shop_alerts` / `water_point_alerts` / `railway_station_alerts` / `health_service_alerts` — alert categories
+ * - `terrain_alerts` / `calendar_alerts` / `wind_alerts` / `bike_shop_alerts` / `water_point_alerts` / `railway_station_alerts` / `health_service_alerts` / `border_crossing_alerts` — alert categories
  * - `trip_complete` — final computation status, stops processing spinner
  * - `validation_error` / `computation_error` — error toasts and recovery
  */
@@ -346,6 +346,28 @@ function dispatchEvent(event: MercureEvent): void {
               : {}),
           })),
           "railway_station",
+        );
+      }
+      break;
+    }
+
+    case "border_crossing_alerts": {
+      const borderByStage = new Map<number, typeof event.data.alerts>();
+      for (const alert of event.data.alerts) {
+        const existing = borderByStage.get(alert.stageIndex) ?? [];
+        existing.push(alert);
+        borderByStage.set(alert.stageIndex, existing);
+      }
+      for (const [stageIndex, alerts] of borderByStage) {
+        store.updateStageAlerts(
+          stageIndex,
+          alerts.map((a) => ({
+            type: a.type as "nudge",
+            message: a.message,
+            lat: a.lat,
+            lon: a.lon,
+          })),
+          "border_crossing",
         );
       }
       break;

--- a/pwa/src/lib/mercure/types.ts
+++ b/pwa/src/lib/mercure/types.ts
@@ -228,9 +228,9 @@ export type MercureEvent =
         alerts: {
           stageIndex: number;
           dayNumber: number;
-          type: string;
+          type: "nudge";
           message: string;
-          action: string;
+          action: "navigate";
           lat: number;
           lon: number;
         }[];

--- a/pwa/src/lib/mercure/types.ts
+++ b/pwa/src/lib/mercure/types.ts
@@ -223,6 +223,20 @@ export type MercureEvent =
       };
     }
   | {
+      type: "border_crossing_alerts";
+      data: {
+        alerts: {
+          stageIndex: number;
+          dayNumber: number;
+          type: string;
+          message: string;
+          action: string;
+          lat: number;
+          lon: number;
+        }[];
+      };
+    }
+  | {
       type: "route_segment_recalculated";
       data: {
         stageIndex: number;


### PR DESCRIPTION
## Summary

- New `CheckBorderCrossingHandler` async handler: detects international border crossings via Overpass `is_in` queries
- Compares country at start/end of each stage, deduplicates crossings by direction pair
- Emits nudge alert with `navigate` action pointing to crossing coordinates
- Adds `BORDER_CROSSING` computation tracking and `border_crossing_alerts` Mercure event
- Updated `trip-schema.json` functional test fixture

## Test plan

- [x] PHPUnit: 7 unit tests covering France→Belgium crossing, domestic route, deduplication, null stages, navigate action
- [x] README.md and AlertDocumentationTest updated
- [x] `make qa` passes
- [x] `make test-php` passes (803 tests)

Closes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

All previously flagged issues have been addressed: the `action` field is now correctly wired in `use-mercure.ts`, literal types are applied in `types.ts`, and the locale-aware country name fallback is implemented in `extractCountryName`. The implementation is clean, well-tested, and consistent with the project's async alert handler patterns.

**Findings:** 0 critical · 0 warnings · 0 suggestions

Resolved 1 previously open thread that was addressed.

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases — 8 unit tests covering France→Belgium crossing, domestic route, deduplication, null stages, null country, navigate action coordinates, name tag fallback, and locale preference
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Inline comments

No inline comments.

---
*Reviewed commit: `21b5690de83db6286726fa9cf625fefadc77c756`*

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->