### PR TITLE
feat(faq): add FAQ page with accordion and footer links (#289)

### DIFF
--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -400,5 +400,34 @@
       "noDate": "No date",
       "offlineBadge": "Offline"
     }
+  },
+  "faq": {
+    "title": "Frequently Asked Questions",
+    "description": "Everything you need to know about Bike Trip Planner.",
+    "backToHome": "Back to home",
+    "categoryProject": "The project",
+    "categoryHowItWorks": "How it works",
+    "categoryAccess": "Access",
+    "q1": "What sets Bike Trip Planner apart from Komoot or RideWithGPS?",
+    "a1": "Komoot and RideWithGPS are GPS navigation platforms. Bike Trip Planner is a multi-day itinerary planning tool: it automatically splits your route into daily stages based on your cyclist profile (speed, accumulated fatigue, elevation), suggests accommodations at each stage endpoint, and generates contextual alerts (weather, resupply, health services, etc.). It complements your navigation apps rather than replacing them.",
+    "q2": "Why use this tool instead of planning manually on a map?",
+    "a2": "Manual planning is time-consuming and often underestimates accumulated fatigue over multiple days. Bike Trip Planner applies an automatic pacing formula that progressively reduces daily distance to account for fatigue, incorporates elevation into the calculation, and suggests accommodations directly at each stage endpoint — all within seconds.",
+    "q3": "Is the project independent of platforms like Komoot or Strava?",
+    "a3": "Yes. Bike Trip Planner is an independent project. It uses GPX exports or shared links from Komoot, Strava, and RideWithGPS only to retrieve route data, but does not depend on any commercial partnership with those platforms.",
+    "q4": "What data is stored on the server?",
+    "a4": "Your trip configuration (dates, profile, stages) is stored in a database so you can access it from any device. Raw route data (GPS points) is cached temporarily in Redis and deleted automatically. No personal data other than your email address is collected.",
+    "q5": "Which route sources are supported?",
+    "a5": "Bike Trip Planner accepts Komoot tour and collection links, Strava routes, and RideWithGPS routes. You can also import a GPX file directly from your computer.",
+    "q6": "Does the app work offline?",
+    "a6": "Partially. In offline mode, you can view previously loaded trips in read-only mode. Creating or editing a trip requires an internet connection, as computations (pacing, alerts, accommodation suggestions) are performed server-side.",
+    "q7": "Can I use the app on mobile?",
+    "a7": "Yes. The app is a responsive PWA (Progressive Web App) optimised for mobile and tablet. You can install it on your home screen from your mobile browser for quick access, without going through an app store.",
+    "q8": "How do I get access to the app?",
+    "a8": "The app uses a magic link sign-in system: enter your email address on the sign-in page and you will receive a secure sign-in link. No password is required.",
+    "q9": "Is the app free and open source?",
+    "a9": "The source code is open source and available on GitHub. The hosted app is free to use. Infrastructure costs may eventually justify a freemium model, but no paid access is planned at this stage."
+  },
+  "footer": {
+    "faq": "FAQ"
   }
 }

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -400,5 +400,34 @@
       "noDate": "Non daté",
       "offlineBadge": "Hors ligne"
     }
+  },
+  "faq": {
+    "title": "Foire aux questions",
+    "description": "Tout ce que vous devez savoir sur Bike Trip Planner.",
+    "backToHome": "Retour à l'accueil",
+    "categoryProject": "Le projet",
+    "categoryHowItWorks": "Fonctionnement",
+    "categoryAccess": "Accès",
+    "q1": "Qu'est-ce qui différencie Bike Trip Planner de Komoot ou RideWithGPS ?",
+    "a1": "Komoot et RideWithGPS sont des plateformes de navigation GPS. Bike Trip Planner est un outil de planification d'itinéraire multi-étapes : il découpe automatiquement votre parcours en étapes journalières en tenant compte de votre profil cycliste (vitesse, fatigue accumulée, dénivelé), suggère des hébergements au point d'arrivée de chaque étape, et génère des alertes contextuelles (météo, ravitaillement, services de santé, etc.). Il complète vos outils de navigation plutôt qu'il ne les remplace.",
+    "q2": "Pourquoi utiliser cet outil plutôt que de planifier manuellement sur une carte ?",
+    "a2": "La planification manuelle prend du temps et sous-estime souvent la fatigue accumulée sur plusieurs jours. Bike Trip Planner applique une formule de pacing automatique qui réduit progressivement la distance journalière pour tenir compte de la fatigue, intègre le dénivelé dans le calcul, et propose des hébergements directement au point d'arrivée de chaque étape — le tout en quelques secondes.",
+    "q3": "Le projet est-il indépendant des plateformes comme Komoot ou Strava ?",
+    "a3": "Oui. Bike Trip Planner est un projet indépendant. Il utilise les exports GPX ou les liens partagés de Komoot, Strava et RideWithGPS uniquement pour récupérer les données de tracé, mais ne dépend d'aucun partenariat commercial avec ces plateformes.",
+    "q4": "Quelles données sont stockées sur le serveur ?",
+    "a4": "Votre configuration de voyage (dates, profil, étapes) est stockée en base de données pour vous permettre d'y accéder depuis n'importe quel appareil. Les données de tracé brutes (points GPS) sont conservées temporairement en cache Redis et supprimées automatiquement. Aucune donnée personnelle autre que votre adresse email n'est collectée.",
+    "q5": "Quelles sources d'itinéraires sont supportées ?",
+    "a5": "Bike Trip Planner accepte les liens de tours et collections Komoot, les routes Strava et les routes RideWithGPS. Vous pouvez également importer directement un fichier GPX depuis votre ordinateur.",
+    "q6": "L'application fonctionne-t-elle hors ligne ?",
+    "a6": "Partiellement. En mode hors ligne, vous pouvez consulter vos voyages déjà chargés en lecture seule. La création ou modification d'un voyage nécessite une connexion internet, car les calculs (pacing, alertes, suggestions d'hébergements) sont effectués côté serveur.",
+    "q7": "L'application est-elle utilisable sur mobile ?",
+    "a7": "Oui. L'application est une PWA (Progressive Web App) responsive, optimisée pour mobile et tablette. Vous pouvez l'installer sur votre écran d'accueil depuis votre navigateur mobile pour un accès rapide, même sans passer par un store d'applications.",
+    "q8": "Comment obtenir un accès à l'application ?",
+    "a8": "L'application utilise un système de connexion par lien magique : entrez votre adresse email sur la page de connexion et vous recevrez un lien de connexion sécurisé. Aucun mot de passe n'est requis.",
+    "q9": "L'application est-elle gratuite et open source ?",
+    "a9": "Le code source est open source et disponible sur GitHub. L'application hébergée est accessible gratuitement. Des coûts d'infrastructure peuvent à terme justifier une offre freemium, mais aucun accès payant n'est prévu à ce stade."
+  },
+  "footer": {
+    "faq": "FAQ"
   }
 }

--- a/pwa/src/app/faq/page.tsx
+++ b/pwa/src/app/faq/page.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { ChevronDown, ArrowLeft } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+interface FaqItem {
+  question: string;
+  answer: string;
+}
+
+interface FaqCategory {
+  label: string;
+  items: FaqItem[];
+}
+
+interface AccordionItemProps {
+  question: string;
+  answer: string;
+  isOpen: boolean;
+  onToggle: () => void;
+}
+
+function AccordionItem({
+  question,
+  answer,
+  isOpen,
+  onToggle,
+}: AccordionItemProps) {
+  return (
+    <div className="border-b border-border last:border-0">
+      <button
+        type="button"
+        className="flex w-full items-center justify-between gap-4 py-4 text-left text-sm font-medium transition-colors hover:text-foreground/80"
+        aria-expanded={isOpen}
+        onClick={onToggle}
+      >
+        <span>{question}</span>
+        <ChevronDown
+          className={`h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200 ${
+            isOpen ? "rotate-180" : ""
+          }`}
+          aria-hidden="true"
+        />
+      </button>
+      <div
+        className={`overflow-hidden transition-all duration-200 ${
+          isOpen ? "max-h-96 pb-4" : "max-h-0"
+        }`}
+      >
+        <p className="text-sm text-muted-foreground leading-relaxed">{answer}</p>
+      </div>
+    </div>
+  );
+}
+
+export default function FaqPage() {
+  const t = useTranslations("faq");
+  const [openItems, setOpenItems] = useState<Record<string, boolean>>({});
+
+  const categories: FaqCategory[] = [
+    {
+      label: t("categoryProject"),
+      items: [
+        { question: t("q1"), answer: t("a1") },
+        { question: t("q2"), answer: t("a2") },
+        { question: t("q3"), answer: t("a3") },
+        { question: t("q4"), answer: t("a4") },
+      ],
+    },
+    {
+      label: t("categoryHowItWorks"),
+      items: [
+        { question: t("q5"), answer: t("a5") },
+        { question: t("q6"), answer: t("a6") },
+        { question: t("q7"), answer: t("a7") },
+      ],
+    },
+    {
+      label: t("categoryAccess"),
+      items: [
+        { question: t("q8"), answer: t("a8") },
+        { question: t("q9"), answer: t("a9") },
+      ],
+    },
+  ];
+
+  function toggleItem(key: string) {
+    setOpenItems((prev) => ({ ...prev, [key]: !prev[key] }));
+  }
+
+  return (
+    <main className="max-w-2xl mx-auto px-4 md:px-6 py-12">
+      {/* Back link */}
+      <Link
+        href="/"
+        className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground mb-8 transition-colors"
+        data-testid="faq-back-link"
+      >
+        <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+        {t("backToHome")}
+      </Link>
+
+      {/* Header */}
+      <div className="mb-10">
+        <h1 className="text-3xl font-bold tracking-tight mb-2">{t("title")}</h1>
+        <p className="text-muted-foreground">{t("description")}</p>
+      </div>
+
+      {/* FAQ Categories */}
+      <div className="space-y-10">
+        {categories.map((category) => (
+          <section key={category.label} aria-labelledby={`faq-category-${category.label}`}>
+            <h2
+              id={`faq-category-${category.label}`}
+              className="text-lg font-semibold mb-4"
+            >
+              {category.label}
+            </h2>
+            <div className="rounded-lg border bg-card px-5">
+              {category.items.map((item) => {
+                const key = `${category.label}-${item.question}`;
+                return (
+                  <AccordionItem
+                    key={key}
+                    question={item.question}
+                    answer={item.answer}
+                    isOpen={!!openItems[key]}
+                    onToggle={() => toggleItem(key)}
+                  />
+                );
+              })}
+            </div>
+          </section>
+        ))}
+      </div>
+
+      {/* Footer link back */}
+      <div className="mt-12 pt-6 border-t text-center">
+        <Link
+          href="/"
+          className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
+          {t("backToHome")}
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/pwa/src/app/faq/page.tsx
+++ b/pwa/src/app/faq/page.tsx
@@ -1,66 +1,14 @@
-"use client";
-
-import { useState } from "react";
 import Link from "next/link";
-import { ChevronDown, ArrowLeft } from "lucide-react";
-import { useTranslations } from "next-intl";
+import { ArrowLeft } from "lucide-react";
+import { getTranslations } from "next-intl/server";
+import { FaqAccordion, type FaqCategory } from "@/components/faq-accordion";
 
-interface FaqItem {
-  question: string;
-  answer: string;
-}
-
-interface FaqCategory {
-  label: string;
-  items: FaqItem[];
-}
-
-interface AccordionItemProps {
-  question: string;
-  answer: string;
-  isOpen: boolean;
-  onToggle: () => void;
-}
-
-function AccordionItem({
-  question,
-  answer,
-  isOpen,
-  onToggle,
-}: AccordionItemProps) {
-  return (
-    <div className="border-b border-border last:border-0">
-      <button
-        type="button"
-        className="flex w-full items-center justify-between gap-4 py-4 text-left text-sm font-medium transition-colors hover:text-foreground/80"
-        aria-expanded={isOpen}
-        onClick={onToggle}
-      >
-        <span>{question}</span>
-        <ChevronDown
-          className={`h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200 ${
-            isOpen ? "rotate-180" : ""
-          }`}
-          aria-hidden="true"
-        />
-      </button>
-      <div
-        className={`overflow-hidden transition-all duration-200 ${
-          isOpen ? "max-h-96 pb-4" : "max-h-0"
-        }`}
-      >
-        <p className="text-sm text-muted-foreground leading-relaxed">{answer}</p>
-      </div>
-    </div>
-  );
-}
-
-export default function FaqPage() {
-  const t = useTranslations("faq");
-  const [openItems, setOpenItems] = useState<Record<string, boolean>>({});
+export default async function FaqPage() {
+  const t = await getTranslations("faq");
 
   const categories: FaqCategory[] = [
     {
+      id: "project",
       label: t("categoryProject"),
       items: [
         { question: t("q1"), answer: t("a1") },
@@ -70,6 +18,7 @@ export default function FaqPage() {
       ],
     },
     {
+      id: "how-it-works",
       label: t("categoryHowItWorks"),
       items: [
         { question: t("q5"), answer: t("a5") },
@@ -78,6 +27,7 @@ export default function FaqPage() {
       ],
     },
     {
+      id: "access",
       label: t("categoryAccess"),
       items: [
         { question: t("q8"), answer: t("a8") },
@@ -85,10 +35,6 @@ export default function FaqPage() {
       ],
     },
   ];
-
-  function toggleItem(key: string) {
-    setOpenItems((prev) => ({ ...prev, [key]: !prev[key] }));
-  }
 
   return (
     <main className="max-w-2xl mx-auto px-4 md:px-6 py-12">
@@ -109,32 +55,7 @@ export default function FaqPage() {
       </div>
 
       {/* FAQ Categories */}
-      <div className="space-y-10">
-        {categories.map((category) => (
-          <section key={category.label} aria-labelledby={`faq-category-${category.label}`}>
-            <h2
-              id={`faq-category-${category.label}`}
-              className="text-lg font-semibold mb-4"
-            >
-              {category.label}
-            </h2>
-            <div className="rounded-lg border bg-card px-5">
-              {category.items.map((item) => {
-                const key = `${category.label}-${item.question}`;
-                return (
-                  <AccordionItem
-                    key={key}
-                    question={item.question}
-                    answer={item.answer}
-                    isOpen={!!openItems[key]}
-                    onToggle={() => toggleItem(key)}
-                  />
-                );
-              })}
-            </div>
-          </section>
-        ))}
-      </div>
+      <FaqAccordion categories={categories} />
 
       {/* Footer link back */}
       <div className="mt-12 pt-6 border-t text-center">

--- a/pwa/src/app/login/page.tsx
+++ b/pwa/src/app/login/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { useAuthStore } from "@/store/auth-store";
 import { Button } from "@/components/ui/button";
@@ -9,6 +10,7 @@ import { Input } from "@/components/ui/input";
 
 export default function LoginPage() {
   const t = useTranslations("auth");
+  const tFooter = useTranslations("footer");
   const router = useRouter();
   const { isAuthenticated, requestMagicLink } = useAuthStore();
   const [email, setEmail] = useState("");
@@ -42,7 +44,7 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="flex min-h-screen items-center justify-center p-4">
+    <div className="flex min-h-screen flex-col items-center justify-center p-4">
       <div className="w-full max-w-sm space-y-6">
         <div className="space-y-2 text-center">
           <h1 className="text-2xl font-bold tracking-tight">
@@ -84,6 +86,15 @@ export default function LoginPage() {
           </form>
         )}
       </div>
+      <footer className="mt-8 text-center">
+        <Link
+          href="/faq"
+          className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+          data-testid="footer-faq-link"
+        >
+          {tFooter("faq")}
+        </Link>
+      </footer>
     </div>
   );
 }

--- a/pwa/src/components/auth-guard.tsx
+++ b/pwa/src/components/auth-guard.tsx
@@ -8,8 +8,8 @@ import { useAuthStore } from "@/store/auth-store";
  * Paths that do not require authentication.
  * "/" is matched exactly; other entries use startsWith so nested routes are also public.
  */
-const PUBLIC_EXACT_PATHS = ["/"];
-const PUBLIC_PREFIX_PATHS = ["/login", "/auth/verify", "/s/", "/faq"];
+const PUBLIC_EXACT_PATHS = ["/", "/faq"];
+const PUBLIC_PREFIX_PATHS = ["/login", "/auth/verify", "/s/"];
 
 function isPublicPath(pathname: string): boolean {
   return (
@@ -26,7 +26,7 @@ function isPublicPath(pathname: string): boolean {
  *    from the httpOnly refresh_token cookie.
  * 2. If the user is not authenticated and the current path is protected,
  *    redirects to `/login`.
- * 3. Public pages (`/`, `/login`, `/auth/verify/*`, `/s/*`) are always
+ * 3. Public pages (`/`, `/faq`, `/login`, `/auth/verify/*`, `/s/*`) are always
  *    accessible without authentication.
  *
  * Renders a blank screen during the initial auth check to prevent

--- a/pwa/src/components/auth-guard.tsx
+++ b/pwa/src/components/auth-guard.tsx
@@ -8,7 +8,7 @@ import { useAuthStore } from "@/store/auth-store";
  * Paths that do not require authentication.
  * Uses startsWith matching so that nested routes are also public.
  */
-const PUBLIC_PATHS = ["/login", "/auth/verify", "/s/"];
+const PUBLIC_PATHS = ["/login", "/auth/verify", "/s/", "/faq"];
 
 function isPublicPath(pathname: string): boolean {
   return PUBLIC_PATHS.some((p) => pathname.startsWith(p));

--- a/pwa/src/components/faq-accordion.tsx
+++ b/pwa/src/components/faq-accordion.tsx
@@ -19,6 +19,7 @@ interface AccordionItemProps {
   answer: string;
   isOpen: boolean;
   onToggle: () => void;
+  panelId: string;
 }
 
 function AccordionItem({
@@ -26,6 +27,7 @@ function AccordionItem({
   answer,
   isOpen,
   onToggle,
+  panelId,
 }: AccordionItemProps) {
   return (
     <div className="border-b border-border last:border-0">
@@ -33,6 +35,7 @@ function AccordionItem({
         type="button"
         className="flex w-full items-center justify-between gap-4 py-4 text-left text-sm font-medium transition-colors hover:text-foreground/80"
         aria-expanded={isOpen}
+        aria-controls={panelId}
         onClick={onToggle}
       >
         <span>{question}</span>
@@ -44,6 +47,8 @@ function AccordionItem({
         />
       </button>
       <div
+        id={panelId}
+        role="region"
         className={`overflow-hidden transition-all duration-200 ${
           isOpen ? "max-h-[9999px] pb-4" : "max-h-0"
         }`}
@@ -86,6 +91,7 @@ export function FaqAccordion({ categories }: FaqAccordionProps) {
               return (
                 <AccordionItem
                   key={key}
+                  panelId={`${key}-panel`}
                   question={item.question}
                   answer={item.answer}
                   isOpen={!!openItems[key]}

--- a/pwa/src/components/faq-accordion.tsx
+++ b/pwa/src/components/faq-accordion.tsx
@@ -45,7 +45,7 @@ function AccordionItem({
       </button>
       <div
         className={`overflow-hidden transition-all duration-200 ${
-          isOpen ? "max-h-96 pb-4" : "max-h-0"
+          isOpen ? "max-h-[9999px] pb-4" : "max-h-0"
         }`}
       >
         <p className="text-sm text-muted-foreground leading-relaxed">

--- a/pwa/src/components/faq-accordion.tsx
+++ b/pwa/src/components/faq-accordion.tsx
@@ -48,7 +48,6 @@ function AccordionItem({
       </button>
       <div
         id={panelId}
-        role="region"
         className={`overflow-hidden transition-all duration-200 ${
           isOpen ? "max-h-[9999px] pb-4" : "max-h-0"
         }`}

--- a/pwa/src/components/faq-accordion.tsx
+++ b/pwa/src/components/faq-accordion.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronDown } from "lucide-react";
+
+export interface FaqItem {
+  question: string;
+  answer: string;
+}
+
+export interface FaqCategory {
+  id: string;
+  label: string;
+  items: FaqItem[];
+}
+
+interface AccordionItemProps {
+  question: string;
+  answer: string;
+  isOpen: boolean;
+  onToggle: () => void;
+}
+
+function AccordionItem({
+  question,
+  answer,
+  isOpen,
+  onToggle,
+}: AccordionItemProps) {
+  return (
+    <div className="border-b border-border last:border-0">
+      <button
+        type="button"
+        className="flex w-full items-center justify-between gap-4 py-4 text-left text-sm font-medium transition-colors hover:text-foreground/80"
+        aria-expanded={isOpen}
+        onClick={onToggle}
+      >
+        <span>{question}</span>
+        <ChevronDown
+          className={`h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200 ${
+            isOpen ? "rotate-180" : ""
+          }`}
+          aria-hidden="true"
+        />
+      </button>
+      <div
+        className={`overflow-hidden transition-all duration-200 ${
+          isOpen ? "max-h-96 pb-4" : "max-h-0"
+        }`}
+      >
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          {answer}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+interface FaqAccordionProps {
+  categories: FaqCategory[];
+}
+
+export function FaqAccordion({ categories }: FaqAccordionProps) {
+  const [openItems, setOpenItems] = useState<Record<string, boolean>>({});
+
+  function toggleItem(key: string) {
+    setOpenItems((prev) => ({ ...prev, [key]: !prev[key] }));
+  }
+
+  return (
+    <div className="space-y-10">
+      {categories.map((category) => (
+        <section
+          key={category.id}
+          aria-labelledby={`faq-category-${category.id}`}
+        >
+          <h2
+            id={`faq-category-${category.id}`}
+            className="text-lg font-semibold mb-4"
+          >
+            {category.label}
+          </h2>
+          <div className="rounded-lg border bg-card px-5">
+            {category.items.map((item, index) => {
+              const key = `${category.id}-${index}`;
+              return (
+                <AccordionItem
+                  key={key}
+                  question={item.question}
+                  answer={item.answer}
+                  isOpen={!!openItems[key]}
+                  onToggle={() => toggleItem(key)}
+                />
+              );
+            })}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/pwa/src/components/trip-planner.tsx
+++ b/pwa/src/components/trip-planner.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
 import { Settings, HelpCircle, Loader2, X, Share2 } from "lucide-react";
 import { MagicLinkInput } from "@/components/magic-link-input";
 import { GpxUploadButton } from "@/components/gpx-upload-button";
@@ -319,6 +320,15 @@ export function TripPlanner({ onClose }: { onClose?: () => void } = {}) {
             {actionButtons}
             <RecentTrips />
             <SavedTripsSection />
+            <footer className="mt-4 text-center">
+              <Link
+                href="/faq"
+                className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+                data-testid="footer-faq-link"
+              >
+                {t("footer.faq")}
+              </Link>
+            </footer>
           </div>
         )}
 

--- a/pwa/tests/mocked/faq.spec.ts
+++ b/pwa/tests/mocked/faq.spec.ts
@@ -1,0 +1,144 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("/faq page", () => {
+  test("loads the FAQ page and shows the title", async ({ page }) => {
+    await page.goto("/faq");
+    await page.waitForLoadState("networkidle");
+
+    await expect(
+      page.getByRole("heading", { level: 1 }),
+    ).toBeVisible({ timeout: 5000 });
+  });
+
+  test("displays all three FAQ categories", async ({ page }) => {
+    await page.goto("/faq");
+    await page.waitForLoadState("networkidle");
+
+    const headings = page.getByRole("heading", { level: 2 });
+    await expect(headings).toHaveCount(3);
+  });
+
+  test("accordion items are collapsed by default", async ({ page }) => {
+    await page.goto("/faq");
+    await page.waitForLoadState("networkidle");
+
+    // All accordion buttons should have aria-expanded="false" initially
+    const buttons = page.locator("button[aria-expanded]");
+    const count = await buttons.count();
+    expect(count).toBeGreaterThan(0);
+
+    for (let i = 0; i < count; i++) {
+      await expect(buttons.nth(i)).toHaveAttribute("aria-expanded", "false");
+    }
+  });
+
+  test("clicking an accordion item expands it and shows the answer", async ({
+    page,
+  }) => {
+    await page.goto("/faq");
+    await page.waitForLoadState("networkidle");
+
+    const firstButton = page.locator("button[aria-expanded]").first();
+    await expect(firstButton).toHaveAttribute("aria-expanded", "false");
+
+    await firstButton.click();
+    await expect(firstButton).toHaveAttribute("aria-expanded", "true");
+  });
+
+  test("clicking an expanded accordion item collapses it", async ({ page }) => {
+    await page.goto("/faq");
+    await page.waitForLoadState("networkidle");
+
+    const firstButton = page.locator("button[aria-expanded]").first();
+
+    // Open
+    await firstButton.click();
+    await expect(firstButton).toHaveAttribute("aria-expanded", "true");
+
+    // Close
+    await firstButton.click();
+    await expect(firstButton).toHaveAttribute("aria-expanded", "false");
+  });
+
+  test("multiple accordion items can be open simultaneously", async ({
+    page,
+  }) => {
+    await page.goto("/faq");
+    await page.waitForLoadState("networkidle");
+
+    const buttons = page.locator("button[aria-expanded]");
+    const firstButton = buttons.nth(0);
+    const secondButton = buttons.nth(1);
+
+    await firstButton.click();
+    await secondButton.click();
+
+    await expect(firstButton).toHaveAttribute("aria-expanded", "true");
+    await expect(secondButton).toHaveAttribute("aria-expanded", "true");
+  });
+
+  test("back-to-home link navigates to /", async ({ page }) => {
+    // Mock auth so the home page doesn't bounce to /login
+    await page.route("**/auth/refresh", (route, request) => {
+      if (request.method() !== "POST") return route.fallback();
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          token:
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0LXVzZXItaWQiLCJ1c2VybmFtZSI6InRlc3RAZXhhbXBsZS5jb20iLCJleHAiOjk5OTk5OTk5OTl9.ZmFrZS1zaWduYXR1cmU",
+        }),
+      });
+    });
+
+    await page.goto("/faq");
+    await page.waitForLoadState("networkidle");
+
+    const backLink = page.getByTestId("faq-back-link");
+    await expect(backLink).toBeVisible();
+    await backLink.click();
+    await expect(page).toHaveURL("/");
+  });
+
+  test("FAQ page is publicly accessible without authentication", async ({
+    page,
+  }) => {
+    // Mock auth/refresh as 401 (unauthenticated)
+    await page.route("**/auth/refresh", (route, request) => {
+      if (request.method() !== "POST") return route.fallback();
+      return route.fulfill({ status: 401, body: "" });
+    });
+
+    await page.goto("/faq");
+    await page.waitForLoadState("networkidle");
+
+    // Should NOT redirect to /login
+    await expect(page).toHaveURL("/faq");
+    await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+  });
+
+  test("FAQ footer link is present on the login page", async ({ page }) => {
+    // Mock auth/refresh as 401 (not authenticated)
+    await page.route("**/auth/refresh", (route, request) => {
+      if (request.method() !== "POST") return route.fallback();
+      return route.fulfill({ status: 401, body: "" });
+    });
+
+    await page.goto("/login");
+    await page.waitForLoadState("networkidle");
+
+    const faqLink = page.getByTestId("footer-faq-link");
+    await expect(faqLink).toBeVisible();
+    await expect(faqLink).toHaveAttribute("href", "/faq");
+  });
+
+  test("page renders in French by default", async ({ page }) => {
+    await page.goto("/faq");
+    await page.waitForLoadState("networkidle");
+
+    // French title
+    await expect(
+      page.getByRole("heading", { name: "Foire aux questions" }),
+    ).toBeVisible({ timeout: 5000 });
+  });
+});

--- a/pwa/tests/mocked/faq.spec.ts
+++ b/pwa/tests/mocked/faq.spec.ts
@@ -5,9 +5,9 @@ test.describe("/faq page", () => {
     await page.goto("/faq");
     await page.waitForLoadState("networkidle");
 
-    await expect(
-      page.getByRole("heading", { level: 1 }),
-    ).toBeVisible({ timeout: 5000 });
+    await expect(page.getByRole("heading", { level: 1 })).toBeVisible({
+      timeout: 5000,
+    });
   });
 
   test("displays all three FAQ categories", async ({ page }) => {
@@ -125,6 +125,28 @@ test.describe("/faq page", () => {
     });
 
     await page.goto("/login");
+    await page.waitForLoadState("networkidle");
+
+    const faqLink = page.getByTestId("footer-faq-link");
+    await expect(faqLink).toBeVisible();
+    await expect(faqLink).toHaveAttribute("href", "/faq");
+  });
+
+  test("FAQ footer link is present on the landing page", async ({ page }) => {
+    // Mock successful auth so the landing page renders
+    await page.route("**/auth/refresh", (route, request) => {
+      if (request.method() !== "POST") return route.fallback();
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          token:
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0LXVzZXItaWQiLCJ1c2VybmFtZSI6InRlc3RAZXhhbXBsZS5jb20iLCJleHAiOjk5OTk5OTk5OTl9.ZmFrZS1zaWduYXR1cmU",
+        }),
+      });
+    });
+
+    await page.goto("/");
     await page.waitForLoadState("networkidle");
 
     const faqLink = page.getByTestId("footer-faq-link");


### PR DESCRIPTION
## Summary

- Add `/faq` page with accordion component (3 categories, 9 Q&A)
- Add FAQ footer link on landing page and login page
- Full FR/EN translations in `pwa/messages/`
- Playwright mocked tests (`faq.spec.ts`)

## Test plan

- [ ] `/faq` is accessible without authentication
- [ ] Accordion items expand/collapse correctly
- [ ] Multiple items can be open simultaneously
- [ ] Footer FAQ link navigates to `/faq`
- [ ] FR/EN translations display correctly
- [ ] `make qa` passes
- [ ] `make test-e2e` passes

Closes #289

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- claude-review-start -->
## Claude Review

All previously raised issues have been addressed: stable category IDs, Server/Client component split, `aria-controls`/`id` wiring, `PUBLIC_EXACT_PATHS` placement, and removal of `role="region"` without an accessible name. No new findings.

**Findings: 0 blocking, 0 warnings** (reviewed commit `b76da568`)

**Resolved 1 previously open thread that was addressed.**

**Review checklist**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

---

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->