### PR TITLE
feat(data-sources): ADR-026, README sources, attribution footer (sprint 20 Part F)

### DIFF
--- a/.github/workflows/import-markets.yml
+++ b/.github/workflows/import-markets.yml
@@ -17,7 +17,26 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.5'
+          extensions: pdo_pgsql, redis
+
+      - name: Install Composer dependencies
+        working-directory: api
+        run: composer install --no-interaction --prefer-dist
+
       - name: Import markets
+        working-directory: api
         env:
-          DRY_RUN: ${{ inputs.dry_run }}
-        run: make markets-import
+          APP_ENV: prod
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          MARKETS_DATASET_URL: ${{ vars.MARKETS_DATASET_URL }}
+          INPUT_DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          DRY_RUN_FLAG=""
+          if [ "$INPUT_DRY_RUN" = "true" ]; then
+            DRY_RUN_FLAG="--dry-run"
+          fi
+          php bin/console app:markets:import $DRY_RUN_FLAG

--- a/.github/workflows/import-markets.yml
+++ b/.github/workflows/import-markets.yml
@@ -1,0 +1,23 @@
+name: Import Markets
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (no database writes)'
+        required: false
+        default: 'false'
+        type: boolean
+
+jobs:
+  import:
+    name: Import weekly markets from data.gouv.fr
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Import markets
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: make markets-import

--- a/Makefile
+++ b/Makefile
@@ -162,3 +162,6 @@ flush-queue: ## Stop workers, clear all Messenger queues, and purge trip state c
 	@# Redis visibility timeouts prevent double-processing of in-flight messages.
 	@docker compose exec php bin/console app:messenger:clear --all
 	@docker compose exec php bin/console cache:pool:clear cache.trip_state
+
+markets-import: ## Import weekly markets from data.gouv.fr into the database
+	@docker compose exec php bin/console app:markets:import

--- a/README.md
+++ b/README.md
@@ -210,6 +210,22 @@ When `DATATOURISME_ENABLED=false` (the default) or the API key is absent, all Da
 
 ---
 
+### Wikidata
+
+[Wikidata](https://www.wikidata.org) enriches POI, accommodation, and event data already returned by other sources that carry a Wikidata Q-ID (via OSM tag `wikidata=Q12345` or DataTourisme property `owl:sameAs`). Coverage is **European**. Licence is **CC0** — no attribution required.
+
+Fields added: multilingual description (FR/EN/DE/ES/IT), Wikimedia Commons thumbnail, Wikipedia article link, official website, and structured opening hours when available.
+
+**Configuration:**
+
+```env
+WIKIDATA_USER_AGENT=BikeTripPlanner/1.0 (contact@example.org)
+```
+
+Wikidata is always enabled. Results are cached in Redis for 7 days. Errors (timeout, 5xx) are handled silently — the application continues without enrichment.
+
+---
+
 ## Contributing
 
 Contributions are welcome! Please read the [Contributing Guide](docs/contributing.md) before submitting a pull request.

--- a/README.md
+++ b/README.md
@@ -171,6 +171,29 @@ Type safety is enforced end-to-end: PHP DTOs define the schema -> API Platform e
 
 ---
 
+## External data sources
+
+### DataTourisme
+
+[DataTourisme](https://www.datatourisme.fr) provides enriched POI data (accommodations, cultural sites, events) for France. It is used as an optional supplementary source alongside OpenStreetMap.
+
+**Licence:** [Licence Ouverte 2.0 Etalab](https://www.etalab.gouv.fr/licence-ouverte-open-licence) — commercial use and modification permitted; attribution required.
+
+**Quota:** 1 000 requests/hour, ~10 req/s sustained. Rate limiting is enforced server-side via a `fixed_window` limiter.
+
+**Registration:** [https://www.datatourisme.fr/](https://www.datatourisme.fr/) — free sign-up, personal API key delivered by email.
+
+To enable DataTourisme integration, set the following environment variables:
+
+```env
+DATATOURISME_API_KEY=your-api-key
+DATATOURISME_ENABLED=true
+```
+
+When `DATATOURISME_ENABLED=false` (the default) or the API key is absent, all DataTourisme calls are skipped and the application falls back to OpenStreetMap data exclusively.
+
+---
+
 ## Contributing
 
 Contributions are welcome! Please read the [Contributing Guide](docs/contributing.md) before submitting a pull request.

--- a/README.md
+++ b/README.md
@@ -65,6 +65,22 @@
 
 ---
 
+## Supported OSM accommodation tags
+
+| Logical type | OSM query | Pricing heuristic |
+|---|---|---|
+| `hotel` | `tourism=hotel` | €50–€120 |
+| `motel` | `tourism=motel` | €45–€90 |
+| `guest_house` | `tourism=guest_house` | €40–€80 |
+| `chalet` | `tourism=chalet` | €30–€70 |
+| `hostel` | `tourism=hostel` | €20–€35 |
+| `alpine_hut` | `tourism=alpine_hut` | €25–€45 |
+| `camp_site` | `tourism=camp_site` | €8–€25 (€8–€15 if `backpack=yes` or `tents=yes`) |
+| `wilderness_hut` | `tourism=wilderness_hut` | free / donation (€0–€10) |
+| `shelter` | `amenity=shelter` + `shelter_type~basic_hut\|weather_shelter\|lean_to` | free (€0) |
+
+---
+
 ## Quick start
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -182,16 +182,29 @@ Type safety is enforced end-to-end: PHP DTOs define the schema -> API Platform e
 |---|---|
 | [Getting Started](docs/getting-started.md) | Requirements, installation, and local setup |
 | [Contributing](docs/contributing.md) | Development workflow, standards, and tooling |
-| [Architecture Decisions](docs/adr/) | 24 ADRs explaining every major technical choice |
+| [Architecture Decisions](docs/adr/) | 26 ADRs explaining every major technical choice |
 | [Claude Code Tooling](docs/claude-code-tooling.md) | MCP servers, hooks, and skills for AI-assisted development |
 
 ---
 
 ## External data sources
 
+| Source | Role | Licence | Coverage | Prerequisite |
+|--------|------|---------|----------|-------------|
+| **OpenStreetMap** | Primary: roads, bike infra, water points, bike shops, resupply, base POIs & accommodations | [ODbL](https://opendatacommons.org/licenses/odbl/) | Global | None |
+| **DataTourisme** | Complementary: enriched accommodations and cultural POIs; exclusive: dated events | [Licence Ouverte 2.0](https://www.etalab.gouv.fr/licence-ouverte-open-licence) | France | `DATATOURISME_API_KEY` |
+| **Wikidata** | Cross-cutting enricher: multilingual descriptions, images, Wikipedia links via Q-IDs | [CC0](https://creativecommons.org/publicdomain/zero/1.0/) | Europe | None |
+| **data.gouv.fr** | Weekly recurring markets (offline import) | [Licence Ouverte 2.0](https://www.etalab.gouv.fr/licence-ouverte-open-licence) | France | `make markets-import` |
+
+### OpenStreetMap
+
+All geographic and infrastructure data is sourced from [OpenStreetMap](https://www.openstreetmap.org) via the public Overpass API. OSM data is cached in Redis for 24 hours per query.
+
+**Licence:** [ODbL 1.0](https://opendatacommons.org/licenses/odbl/) — attribution required: "© OpenStreetMap contributors".
+
 ### DataTourisme
 
-[DataTourisme](https://www.datatourisme.fr) provides enriched POI data (accommodations, cultural sites, events) for France. It is used as an optional supplementary source alongside OpenStreetMap.
+[DataTourisme](https://www.datatourisme.fr) provides enriched POI data (accommodations, cultural sites, dated events) for France. It is used as an optional supplementary source alongside OpenStreetMap.
 
 **Licence:** [Licence Ouverte 2.0 Etalab](https://www.etalab.gouv.fr/licence-ouverte-open-licence) — commercial use and modification permitted; attribution required.
 
@@ -208,15 +221,13 @@ DATATOURISME_ENABLED=true
 
 When `DATATOURISME_ENABLED=false` (the default) or the API key is absent, all DataTourisme calls are skipped and the application falls back to OpenStreetMap data exclusively.
 
----
-
 ### Wikidata
 
 [Wikidata](https://www.wikidata.org) enriches POI, accommodation, and event data already returned by other sources that carry a Wikidata Q-ID (via OSM tag `wikidata=Q12345` or DataTourisme property `owl:sameAs`). Coverage is **European**. Licence is **CC0** — no attribution required.
 
 Fields added: multilingual description (FR/EN/DE/ES/IT), Wikimedia Commons thumbnail, Wikipedia article link, official website, and structured opening hours when available.
 
-**Configuration:**
+**Configuration (optional):**
 
 ```env
 WIKIDATA_USER_AGENT=BikeTripPlanner/1.0 (contact@example.org)
@@ -224,17 +235,13 @@ WIKIDATA_USER_AGENT=BikeTripPlanner/1.0 (contact@example.org)
 
 Wikidata is always enabled. Results are cached in Redis for 7 days. Errors (timeout, 5xx) are handled silently — the application continues without enrichment.
 
----
+### data.gouv.fr — Weekly markets
 
-## Administration commands
-
-### Import weekly markets
+The weekly market dataset from [data.gouv.fr](https://www.data.gouv.fr/) is imported into the PostgreSQL `market` table via a one-time (or periodic) CLI command. Markets are included automatically in the event scan for each stage.
 
 ```bash
 make markets-import
 ```
-
-Downloads and imports the weekly market dataset from [data.gouv.fr](https://www.data.gouv.fr/) (Licence Ouverte 2.0). Markets are then included automatically in the event scan for each stage.
 
 Options available via `bin/console app:markets:import`:
 

--- a/README.md
+++ b/README.md
@@ -194,6 +194,27 @@ When `DATATOURISME_ENABLED=false` (the default) or the API key is absent, all Da
 
 ---
 
+## Commandes d'administration
+
+### Import des marchés forains
+
+```bash
+make markets-import
+```
+
+Télécharge et importe le dataset des marchés forains hebdomadaires depuis [data.gouv.fr](https://www.data.gouv.fr/) (Licence Ouverte 2.0). Les marchés sont ensuite inclus automatiquement dans le scan d'événements de chaque étape.
+
+Options disponibles via `bin/console app:markets:import` :
+
+| Option | Description |
+|--------|-------------|
+| `--dry-run` | Affiche les statistiques sans écrire en base de données |
+| `--limit N` | Limite le nombre de lignes traitées (debug / CI) |
+
+La variable d'environnement `MARKETS_DATASET_URL` permet de surcharger l'URL du dataset.
+
+---
+
 ## Contributing
 
 Contributions are welcome! Please read the [Contributing Guide](docs/contributing.md) before submitting a pull request.

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Rules are executed in priority order (lower = higher priority):
 | **Accommodation** | -- | ![warning](https://img.shields.io/badge/-warning-ed6c02) | All detected accommodations on the stage are likely closed due to seasonality |
 | **Water points** | -- | ![nudge](https://img.shields.io/badge/-nudge-0288d1) | Stretch > 30 km without a detected drinking water source |
 | **Rest day** | 100 | ![nudge](https://img.shields.io/badge/-nudge-0288d1) | Every N consecutive cycling days without a rest day (default: every 3 days) |
-| **Cultural POI** | -- | ![nudge](https://img.shields.io/badge/-nudge-0288d1) | Museum, monument, castle, church, viewpoint, or attraction within 500 m of route |
+| **Cultural POI** | -- | ![nudge](https://img.shields.io/badge/-nudge-0288d1) | Museum, monument, castle, church, viewpoint, or attraction within 500 m of route — enriched with opening hours, price and description when sourced from DataTourisme |
 | **Railway station** | -- | ![nudge](https://img.shields.io/badge/-nudge-0288d1) | No train station within 10 km of a stage endpoint (emergency evacuation) |
 | **Health services** | -- | ![nudge](https://img.shields.io/badge/-nudge-0288d1) | No pharmacy, hospital, or clinic within 15 km of a stage |
 | **Border crossing** | -- | ![nudge](https://img.shields.io/badge/-nudge-0288d1) | Route crosses an international border (country change detected via Overpass is_in) |

--- a/TRACKING.md
+++ b/TRACKING.md
@@ -394,16 +394,16 @@ Page d'accueil marketing, système d'accès anticipé (HMAC, throttling, CLI), p
 
 Intégration multi-sources : DataTourisme (hébergements, POI culturels, événements datés) en complément d'OSM, Wikidata en enrichisseur transversal (descriptions multilingues, images, horaires) via SPARQL batch, marchés forains data.gouv.fr pour les événements récurrents. Architecture extensible via interfaces + registries auto-discovered. ADR-025.
 
-| Ordre | ID                                                                      | Titre                                                                          | Effort | PRs | Dépend de      |
-|-------|-------------------------------------------------------------------------|--------------------------------------------------------------------------------|--------|-----|----------------|
-| 1     | [#345](https://github.com/vincentchalamon/bike-trip-planner/issues/345) | Partie A — Enrichir requête OSM hébergements (wilderness_hut, shelter)         | S      |     | —              |
-| 2     | [#346](https://github.com/vincentchalamon/bike-trip-planner/issues/346) | Partie B — Infrastructure DataTourisme (client, cache, rate limiter)           | M      |     | —              |
-| 3     | [#347](https://github.com/vincentchalamon/bike-trip-planner/issues/347) | Partie C — Hébergements multi-sources (OSM + DataTourisme)                     | L      |     | #345 #346      |
-| 4     | [#348](https://github.com/vincentchalamon/bike-trip-planner/issues/348) | Partie D — POI culturels multi-sources (horaires, prix, description)           | L      |     | #346           |
-| 5     | [#349](https://github.com/vincentchalamon/bike-trip-planner/issues/349) | Partie E — Scan événements datés DataTourisme (festivals, expos)               | L      |     | #346           |
-| 6     | [#350](https://github.com/vincentchalamon/bike-trip-planner/issues/350) | Partie G — Wikidata enricher transversal (SPARQL batch)                        | L      |     | #347 #348 #349 |
-| 7     | [#351](https://github.com/vincentchalamon/bike-trip-planner/issues/351) | Partie H — Import marchés forains data.gouv.fr                                 | M      |     | #349           |
-| 8     | [#352](https://github.com/vincentchalamon/bike-trip-planner/issues/352) | Partie F — Documentation & attribution globale (ADR-025)                       | S      |     | #345..#351     |
+| Ordre | ID                                                                      | Titre                                                                          | Effort | PRs                                                                     | Dépend de      |
+|-------|-------------------------------------------------------------------------|--------------------------------------------------------------------------------|--------|-------------------------------------------------------------------------|----------------|
+| 1     | [#345](https://github.com/vincentchalamon/bike-trip-planner/issues/345) | Partie A — Enrichir requête OSM hébergements (wilderness_hut, shelter)         | S      | [#355](https://github.com/vincentchalamon/bike-trip-planner/pull/355)   | —              |
+| 2     | [#346](https://github.com/vincentchalamon/bike-trip-planner/issues/346) | Partie B — Infrastructure DataTourisme (client, cache, rate limiter)           | M      | [#356](https://github.com/vincentchalamon/bike-trip-planner/pull/356)   | —              |
+| 3     | [#347](https://github.com/vincentchalamon/bike-trip-planner/issues/347) | Partie C — Hébergements multi-sources (OSM + DataTourisme)                     | L      | [#357](https://github.com/vincentchalamon/bike-trip-planner/pull/357)   | #345 #346      |
+| 4     | [#348](https://github.com/vincentchalamon/bike-trip-planner/issues/348) | Partie D — POI culturels multi-sources (horaires, prix, description)           | L      | [#358](https://github.com/vincentchalamon/bike-trip-planner/pull/358)   | #346           |
+| 5     | [#349](https://github.com/vincentchalamon/bike-trip-planner/issues/349) | Partie E — Scan événements datés DataTourisme (festivals, expos)               | L      | [#359](https://github.com/vincentchalamon/bike-trip-planner/pull/359)   | #346           |
+| 6     | [#350](https://github.com/vincentchalamon/bike-trip-planner/issues/350) | Partie G — Wikidata enricher transversal (SPARQL batch)                        | L      | [#360](https://github.com/vincentchalamon/bike-trip-planner/pull/360)   | #347 #348 #349 |
+| 7     | [#351](https://github.com/vincentchalamon/bike-trip-planner/issues/351) | Partie H — Import marchés forains data.gouv.fr                                 | M      | [#361](https://github.com/vincentchalamon/bike-trip-planner/pull/361)   | #349           |
+| 8     | [#352](https://github.com/vincentchalamon/bike-trip-planner/issues/352) | Partie F — Documentation & attribution globale (ADR-025)                       | S      | [#354](https://github.com/vincentchalamon/bike-trip-planner/pull/354)   | #345..#351     |
 
 ---
 

--- a/api/.env
+++ b/api/.env
@@ -80,4 +80,5 @@ ACCESS_REQUEST_HMAC_SECRET=
 MAILER_SENDER_EMAIL=noreply@bike-trip-planner.com
 DATATOURISME_API_KEY=
 DATATOURISME_ENABLED=false
+WIKIDATA_USER_AGENT=BikeTripPlanner/1.0 (contact@example.org)
 ###< app ###

--- a/api/.env
+++ b/api/.env
@@ -78,4 +78,6 @@ BACKEND_URL=https://localhost
 # Generate a distinct random value in production (e.g. openssl rand -hex 32)
 ACCESS_REQUEST_HMAC_SECRET=
 MAILER_SENDER_EMAIL=noreply@bike-trip-planner.com
+DATATOURISME_API_KEY=
+DATATOURISME_ENABLED=false
 ###< app ###

--- a/api/.env
+++ b/api/.env
@@ -80,5 +80,5 @@ ACCESS_REQUEST_HMAC_SECRET=
 MAILER_SENDER_EMAIL=noreply@bike-trip-planner.com
 DATATOURISME_API_KEY=
 DATATOURISME_ENABLED=false
-WIKIDATA_USER_AGENT=BikeTripPlanner/1.0 (contact@example.org)
+WIKIDATA_USER_AGENT="BikeTripPlanner/1.0 (contact@example.org)"
 ###< app ###

--- a/api/config/packages/cache.php
+++ b/api/config/packages/cache.php
@@ -33,6 +33,10 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                     'adapter' => 'cache.adapter.redis',
                     'default_lifetime' => 86400, // 24 hours
                 ],
+                'cache.wikidata' => [
+                    'adapter' => 'cache.adapter.redis',
+                    'default_lifetime' => 604800, // 7 days
+                ],
             ],
         ],
     ]);
@@ -56,6 +60,9 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                         'adapter' => 'cache.adapter.array',
                     ],
                     'cache.datatourisme' => [
+                        'adapter' => 'cache.adapter.array',
+                    ],
+                    'cache.wikidata' => [
                         'adapter' => 'cache.adapter.array',
                     ],
                 ],

--- a/api/config/packages/cache.php
+++ b/api/config/packages/cache.php
@@ -29,6 +29,10 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                     'adapter' => 'cache.adapter.redis',
                     'default_lifetime' => 86400, // 24 hours
                 ],
+                'cache.datatourisme' => [
+                    'adapter' => 'cache.adapter.redis',
+                    'default_lifetime' => 86400, // 24 hours
+                ],
             ],
         ],
     ]);
@@ -49,6 +53,9 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                         'adapter' => 'cache.adapter.array',
                     ],
                     'cache.routing' => [
+                        'adapter' => 'cache.adapter.array',
+                    ],
+                    'cache.datatourisme' => [
                         'adapter' => 'cache.adapter.array',
                     ],
                 ],

--- a/api/config/packages/framework.php
+++ b/api/config/packages/framework.php
@@ -77,6 +77,15 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                         'User-Agent' => 'Mozilla/5.0 (compatible; BikeTripPlanner/1.0)',
                     ],
                 ],
+                'datatourisme.client' => [
+                    'scope' => '^https://api\\.datatourisme\\.fr',
+                    'max_redirects' => 2,
+                    'timeout' => 10,
+                    'headers' => [
+                        'X-API-Key' => '%env(default::DATATOURISME_API_KEY)%',
+                        'Accept' => 'application/json',
+                    ],
+                ],
             ],
         ],
     ]);

--- a/api/config/packages/framework.php
+++ b/api/config/packages/framework.php
@@ -89,11 +89,16 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 'wikidata.client' => [
                     'scope' => '^https://query\\.wikidata\\.org',
                     'max_redirects' => 2,
-                    'timeout' => 15,
+                    'timeout' => 10,
                     'headers' => [
                         'User-Agent' => '%env(WIKIDATA_USER_AGENT)%',
                         'Accept' => 'application/sparql-results+json',
                     ],
+                ],
+                'markets_dataset.client' => [
+                    'scope' => '^https://www\\.data\\.gouv\\.fr',
+                    'max_redirects' => 2,
+                    'timeout' => 60,
                 ],
             ],
         ],

--- a/api/config/packages/framework.php
+++ b/api/config/packages/framework.php
@@ -86,6 +86,15 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                         'Accept' => 'application/json',
                     ],
                 ],
+                'wikidata.client' => [
+                    'scope' => '^https://query\\.wikidata\\.org',
+                    'max_redirects' => 2,
+                    'timeout' => 15,
+                    'headers' => [
+                        'User-Agent' => '%env(WIKIDATA_USER_AGENT)%',
+                        'Accept' => 'application/sparql-results+json',
+                    ],
+                ],
             ],
         ],
     ]);

--- a/api/config/packages/rate_limiter.php
+++ b/api/config/packages/rate_limiter.php
@@ -37,6 +37,12 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 'interval' => '60 seconds',
                 'cache_pool' => 'cache.rate_limiter',
             ],
+            'datatourisme' => [
+                'policy' => 'fixed_window',
+                'limit' => 1000,
+                'interval' => '3600 seconds',
+                'cache_pool' => 'cache.rate_limiter',
+            ],
         ],
         'cache' => [
             'pools' => [

--- a/api/migrations/Version20260418000000.php
+++ b/api/migrations/Version20260418000000.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260418000000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add market table for weekly market import from data.gouv.fr';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE market (
+                id UUID NOT NULL,
+                external_id VARCHAR(255) NOT NULL,
+                name VARCHAR(255) NOT NULL,
+                lat DOUBLE PRECISION NOT NULL,
+                lon DOUBLE PRECISION NOT NULL,
+                day_of_week INT NOT NULL,
+                start_time VARCHAR(5) DEFAULT NULL,
+                end_time VARCHAR(5) DEFAULT NULL,
+                commune VARCHAR(255) NOT NULL,
+                department VARCHAR(255) NOT NULL,
+                source VARCHAR(50) NOT NULL,
+                imported_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+                PRIMARY KEY(id)
+            )
+        SQL);
+        $this->addSql('CREATE UNIQUE INDEX uniq_market_external_id ON market (external_id)');
+        $this->addSql('CREATE INDEX idx_market_day_of_week ON market (day_of_week)');
+        $this->addSql("COMMENT ON COLUMN market.id IS '(DC2Type:uuid)'");
+        $this->addSql("COMMENT ON COLUMN market.imported_at IS '(DC2Type:datetime_immutable)'");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE market');
+    }
+}

--- a/api/src/AccommodationSource/AccommodationSourceInterface.php
+++ b/api/src/AccommodationSource/AccommodationSourceInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\AccommodationSource;
+
+use App\ApiResource\Model\Coordinate;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+#[AutoconfigureTag('app.accommodation_source')]
+interface AccommodationSourceInterface
+{
+    /**
+     * @param array<int, Coordinate> $endPoints
+     * @param list<string>           $enabledTypes
+     *
+     * @return list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, source: string, wikidataId: ?string}>
+     */
+    public function fetch(array $endPoints, int $radiusMeters, array $enabledTypes): array;
+
+    public function isEnabled(): bool;
+
+    public function getName(): string;
+}

--- a/api/src/AccommodationSource/AccommodationSourceRegistry.php
+++ b/api/src/AccommodationSource/AccommodationSourceRegistry.php
@@ -7,10 +7,10 @@ namespace App\AccommodationSource;
 use App\ApiResource\Model\Coordinate;
 use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 
-final readonly class AccommodationSourceRegistry
+class AccommodationSourceRegistry
 {
     /** @var list<AccommodationSourceInterface> */
-    private array $sources;
+    private readonly array $sources;
 
     /**
      * @param iterable<AccommodationSourceInterface> $sources

--- a/api/src/AccommodationSource/AccommodationSourceRegistry.php
+++ b/api/src/AccommodationSource/AccommodationSourceRegistry.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\AccommodationSource;
+
+use App\ApiResource\Model\Coordinate;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
+
+final readonly class AccommodationSourceRegistry
+{
+    /** @var list<AccommodationSourceInterface> */
+    private array $sources;
+
+    /**
+     * @param iterable<AccommodationSourceInterface> $sources
+     */
+    public function __construct(
+        #[AutowireIterator('app.accommodation_source')]
+        iterable $sources,
+    ) {
+        $this->sources = iterator_to_array($sources, false);
+    }
+
+    /**
+     * Fetches candidates from all enabled sources and concatenates results.
+     *
+     * @param array<int, Coordinate> $endPoints
+     * @param list<string>           $enabledTypes
+     *
+     * @return list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, source: string, wikidataId: ?string}>
+     */
+    public function fetchAll(array $endPoints, int $radiusMeters, array $enabledTypes): array
+    {
+        $all = [];
+
+        foreach ($this->sources as $source) {
+            if (!$source->isEnabled()) {
+                continue;
+            }
+
+            foreach ($source->fetch($endPoints, $radiusMeters, $enabledTypes) as $candidate) {
+                $all[] = $candidate;
+            }
+        }
+
+        return $all;
+    }
+}

--- a/api/src/AccommodationSource/DataTourismeAccommodationSource.php
+++ b/api/src/AccommodationSource/DataTourismeAccommodationSource.php
@@ -89,7 +89,9 @@ final readonly class DataTourismeAccommodationSource implements AccommodationSou
     {
         $degreeOffset = $radiusMeters / 111_000.0;
 
+        /** @var non-empty-array<int, float> $lats */
         $lats = array_map(static fn (Coordinate $c): float => $c->lat, $endPoints);
+        /** @var non-empty-array<int, float> $lons */
         $lons = array_map(static fn (Coordinate $c): float => $c->lon, $endPoints);
 
         return [

--- a/api/src/AccommodationSource/DataTourismeAccommodationSource.php
+++ b/api/src/AccommodationSource/DataTourismeAccommodationSource.php
@@ -1,0 +1,276 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\AccommodationSource;
+
+use App\ApiResource\Model\Coordinate;
+use App\DataTourisme\DataTourismeClientInterface;
+use App\Engine\PricingHeuristicEngine;
+
+final readonly class DataTourismeAccommodationSource implements AccommodationSourceInterface
+{
+    private const array ACCOMMODATION_CLASSES = [
+        'schema:Campground',
+        'schema:Hostel',
+        'schema:Hotel',
+        'schema:LodgingBusiness',
+        'urn:resource:CampingLocation',
+    ];
+
+    private const array CLASS_TO_TYPE = [
+        'schema:Campground' => 'camp_site',
+        'urn:resource:CampingLocation' => 'camp_site',
+        'schema:Hostel' => 'hostel',
+        'schema:Hotel' => 'hotel',
+        'schema:LodgingBusiness' => 'hotel',
+    ];
+
+    public function __construct(
+        private DataTourismeClientInterface $client,
+        private PricingHeuristicEngine $pricingEngine,
+    ) {
+    }
+
+    /**
+     * @param array<int, Coordinate> $endPoints
+     * @param list<string>           $enabledTypes
+     *
+     * @return list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, source: string, wikidataId: ?string}>
+     */
+    public function fetch(array $endPoints, int $radiusMeters, array $enabledTypes): array
+    {
+        if ([] === $endPoints) {
+            return [];
+        }
+
+        $bbox = $this->buildBbox($endPoints, $radiusMeters);
+
+        $result = $this->client->request('/api/v1/places', [
+            'filters[0][path]' => '@type',
+            'filters[0][operator]' => 'in',
+            'filters[0][value]' => implode(',', self::ACCOMMODATION_CLASSES),
+            'filters[1][path]' => 'hasGeometry.longitude',
+            'filters[1][operator]' => 'gte',
+            'filters[1][value]' => $bbox['lonMin'],
+            'filters[2][path]' => 'hasGeometry.longitude',
+            'filters[2][operator]' => 'lte',
+            'filters[2][value]' => $bbox['lonMax'],
+            'filters[3][path]' => 'hasGeometry.latitude',
+            'filters[3][operator]' => 'gte',
+            'filters[3][value]' => $bbox['latMin'],
+            'filters[4][path]' => 'hasGeometry.latitude',
+            'filters[4][operator]' => 'lte',
+            'filters[4][value]' => $bbox['latMax'],
+        ]);
+
+        /** @var list<array<string, mixed>> $items */
+        $items = \is_array($result['results'] ?? null) ? $result['results'] : [];
+
+        return $this->mapItems($items, $enabledTypes);
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->client->isEnabled();
+    }
+
+    public function getName(): string
+    {
+        return 'datatourisme';
+    }
+
+    /**
+     * @param array<int, Coordinate> $endPoints
+     *
+     * @return array{latMin: float, latMax: float, lonMin: float, lonMax: float}
+     */
+    private function buildBbox(array $endPoints, int $radiusMeters): array
+    {
+        $degreeOffset = $radiusMeters / 111_000.0;
+
+        $lats = array_map(static fn (Coordinate $c): float => $c->lat, $endPoints);
+        $lons = array_map(static fn (Coordinate $c): float => $c->lon, $endPoints);
+
+        return [
+            'latMin' => min($lats) - $degreeOffset,
+            'latMax' => max($lats) + $degreeOffset,
+            'lonMin' => min($lons) - $degreeOffset,
+            'lonMax' => max($lons) + $degreeOffset,
+        ];
+    }
+
+    /**
+     * @param list<array<string, mixed>> $items
+     * @param list<string>               $enabledTypes
+     *
+     * @return list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, source: string, wikidataId: ?string}>
+     */
+    private function mapItems(array $items, array $enabledTypes): array
+    {
+        $candidates = [];
+
+        foreach ($items as $item) {
+            $geometry = \is_array($item['hasGeometry'] ?? null) ? $item['hasGeometry'] : null;
+            $lat = \is_float($geometry['latitude'] ?? null) || \is_int($geometry['latitude'] ?? null)
+                ? (float) $geometry['latitude']
+                : null;
+            $lon = \is_float($geometry['longitude'] ?? null) || \is_int($geometry['longitude'] ?? null)
+                ? (float) $geometry['longitude']
+                : null;
+
+            if (null === $lat || null === $lon) {
+                continue;
+            }
+
+            $type = $this->resolveType($item);
+
+            if ([] !== $enabledTypes && !\in_array($type, $enabledTypes, true)) {
+                continue;
+            }
+
+            $name = $this->resolveName($item) ?? $type;
+            $url = $this->resolveUrl($item);
+            $pricing = $this->resolvePricing($item, $type);
+            $wikidataId = $this->resolveWikidataId($item);
+
+            $candidates[] = [
+                'name' => $name,
+                'type' => $type,
+                'lat' => $lat,
+                'lon' => $lon,
+                'priceMin' => $pricing['min'],
+                'priceMax' => $pricing['max'],
+                'isExact' => $pricing['isExact'],
+                'url' => $url,
+                'tagCount' => 0,
+                'hasWebsite' => null !== $url,
+                'tags' => [],
+                'source' => 'datatourisme',
+                'wikidataId' => $wikidataId,
+            ];
+        }
+
+        return $candidates;
+    }
+
+    /** @param array<string, mixed> $item */
+    private function resolveType(array $item): string
+    {
+        $types = \is_array($item['@type'] ?? null) ? $item['@type'] : [$item['@type'] ?? ''];
+
+        foreach (self::CLASS_TO_TYPE as $class => $type) {
+            if (\in_array($class, $types, true)) {
+                return $type;
+            }
+        }
+
+        return 'hotel';
+    }
+
+    /** @param array<string, mixed> $item */
+    private function resolveName(array $item): ?string
+    {
+        $label = $item['rdfs:label'] ?? null;
+
+        if (\is_string($label) && '' !== $label) {
+            return $label;
+        }
+
+        if (\is_array($label)) {
+            foreach ($label as $value) {
+                if (\is_string($value) && '' !== $value) {
+                    return $value;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /** @param array<string, mixed> $item */
+    private function resolveUrl(array $item): ?string
+    {
+        $homepage = $item['foaf:homepage'] ?? null;
+
+        if (\is_string($homepage) && '' !== $homepage) {
+            return $homepage;
+        }
+
+        if (\is_array($homepage)) {
+            foreach ($homepage as $value) {
+                if (\is_string($value) && '' !== $value) {
+                    return $value;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, mixed> $item
+     *
+     * @return array{min: float, max: float, isExact: bool}
+     */
+    private function resolvePricing(array $item, string $type): array
+    {
+        $offers = \is_array($item['offers'] ?? null) ? $item['offers'] : [];
+
+        $mins = [];
+        $maxs = [];
+
+        foreach ($offers as $offer) {
+            if (!\is_array($offer)) {
+                continue;
+            }
+
+            $specs = \is_array($offer['priceSpecification'] ?? null) ? $offer['priceSpecification'] : [];
+
+            foreach ($specs as $spec) {
+                if (!\is_array($spec)) {
+                    continue;
+                }
+
+                if (isset($spec['minPrice']) && is_numeric($spec['minPrice'])) {
+                    $mins[] = (float) $spec['minPrice'];
+                }
+
+                if (isset($spec['maxPrice']) && is_numeric($spec['maxPrice'])) {
+                    $maxs[] = (float) $spec['maxPrice'];
+                }
+
+                if (isset($spec['price']) && is_numeric($spec['price'])) {
+                    $mins[] = (float) $spec['price'];
+                    $maxs[] = (float) $spec['price'];
+                }
+            }
+        }
+
+        if ([] !== $mins && [] !== $maxs) {
+            return ['min' => min($mins), 'max' => max($maxs), 'isExact' => true];
+        }
+
+        $heuristic = $this->pricingEngine->estimatePrice($type);
+
+        return ['min' => $heuristic['min'], 'max' => $heuristic['max'], 'isExact' => false];
+    }
+
+    /** @param array<string, mixed> $item */
+    private function resolveWikidataId(array $item): ?string
+    {
+        $sameAs = $item['owl:sameAs'] ?? null;
+
+        $candidates = \is_array($sameAs) ? $sameAs : (\is_string($sameAs) ? [$sameAs] : []);
+
+        foreach ($candidates as $uri) {
+            if (\is_string($uri) && str_contains($uri, 'wikidata.org')) {
+                $parts = explode('/', rtrim($uri, '/'));
+
+                return end($parts) ?: null;
+            }
+        }
+
+        return null;
+    }
+}

--- a/api/src/AccommodationSource/OsmAccommodationSource.php
+++ b/api/src/AccommodationSource/OsmAccommodationSource.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\AccommodationSource;
+
+use App\ApiResource\Model\Coordinate;
+use App\ApiResource\TripRequest;
+use App\Engine\PricingHeuristicEngine;
+use App\Scanner\QueryBuilderInterface;
+use App\Scanner\ScannerInterface;
+
+final readonly class OsmAccommodationSource implements AccommodationSourceInterface
+{
+    public function __construct(
+        private ScannerInterface $scanner,
+        private QueryBuilderInterface $queryBuilder,
+        private PricingHeuristicEngine $pricingEngine,
+    ) {
+    }
+
+    /**
+     * @param array<int, Coordinate> $endPoints
+     * @param list<string>           $enabledTypes
+     *
+     * @return list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, source: string, wikidataId: ?string}>
+     */
+    public function fetch(array $endPoints, int $radiusMeters, array $enabledTypes = TripRequest::ALL_ACCOMMODATION_TYPES): array
+    {
+        $query = $this->queryBuilder->buildAccommodationQuery($endPoints, $radiusMeters, $enabledTypes);
+        $result = $this->scanner->query($query);
+
+        /** @var list<array{id?: int, type?: string, tags?: array<string, string>, lat?: float, lon?: float, center?: array{lat: float, lon: float}}> $elements */
+        $elements = \is_array($result['elements'] ?? null) ? $result['elements'] : [];
+
+        return $this->parseElements($elements);
+    }
+
+    public function isEnabled(): bool
+    {
+        return true;
+    }
+
+    public function getName(): string
+    {
+        return 'osm';
+    }
+
+    /**
+     * @param list<array{id?: int, type?: string, tags?: array<string, string>, lat?: float, lon?: float, center?: array{lat: float, lon: float}}> $elements
+     *
+     * @return list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, source: string, wikidataId: ?string}>
+     */
+    private function parseElements(array $elements): array
+    {
+        $candidates = [];
+
+        foreach ($elements as $element) {
+            $tags = $element['tags'] ?? [];
+            $lat = $element['lat'] ?? ($element['center']['lat'] ?? null);
+            $lon = $element['lon'] ?? ($element['center']['lon'] ?? null);
+
+            if (null === $lat || null === $lon) {
+                continue;
+            }
+
+            $url = $tags['website']
+                ?? $tags['contact:website']
+                ?? (isset($element['id'], $element['type'])
+                    ? \sprintf('https://www.openstreetmap.org/%s/%d', $element['type'], $element['id'])
+                    : null);
+
+            $type = $tags['tourism'] ?? ('shelter' === ($tags['amenity'] ?? null) ? 'shelter' : 'hotel');
+            $name = $tags['name'] ?? $type;
+            $tagCount = \count($tags);
+            $pricing = $this->pricingEngine->estimatePrice($type, $tags);
+
+            $candidates[] = [
+                'name' => $name,
+                'type' => $type,
+                'lat' => (float) $lat,
+                'lon' => (float) $lon,
+                'priceMin' => $pricing['min'],
+                'priceMax' => $pricing['max'],
+                'isExact' => $pricing['isExact'],
+                'url' => $url,
+                'tagCount' => $tagCount,
+                'hasWebsite' => isset($tags['website']) || isset($tags['contact:website']),
+                'tags' => $tags,
+                'source' => 'osm',
+                'wikidataId' => $tags['wikidata'] ?? null,
+            ];
+        }
+
+        return $candidates;
+    }
+}

--- a/api/src/ApiResource/Model/Accommodation.php
+++ b/api/src/ApiResource/Model/Accommodation.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\ApiResource\Model;
 
+use ApiPlatform\Metadata\ApiProperty;
+
 final readonly class Accommodation
 {
     public function __construct(
@@ -18,6 +20,14 @@ final readonly class Accommodation
         public bool $possibleClosed = false,
         public float $distanceToEndPoint = 0.0,
         public string $source = 'osm',
+        #[ApiProperty(description: 'Short description from Wikidata.')]
+        public ?string $description = null,
+        #[ApiProperty(description: 'Thumbnail image URL from Wikimedia Commons.')]
+        public ?string $imageUrl = null,
+        #[ApiProperty(description: 'Wikipedia article URL.')]
+        public ?string $wikipediaUrl = null,
+        #[ApiProperty(description: 'Opening hours (Wikidata P8989 or DataTourisme).')]
+        public ?string $openingHours = null,
     ) {
     }
 }

--- a/api/src/ApiResource/Model/Accommodation.php
+++ b/api/src/ApiResource/Model/Accommodation.php
@@ -17,6 +17,7 @@ final readonly class Accommodation
         public ?string $url = null,
         public bool $possibleClosed = false,
         public float $distanceToEndPoint = 0.0,
+        public string $source = 'osm',
     ) {
     }
 }

--- a/api/src/ApiResource/Model/CulturalPoiAlert.php
+++ b/api/src/ApiResource/Model/CulturalPoiAlert.php
@@ -13,6 +13,9 @@ use App\Enum\AlertType;
  * Carries the POI coordinates and metadata needed to allow the frontend
  * to offer an "add to itinerary" action (triggering route recalculation
  * via the RecalculateRouteSegment Messenger message — ADR-017).
+ *
+ * Optional enrichment fields (openingHours, estimatedPrice, description,
+ * wikidataId, source) are populated when the POI comes from DataTourisme.
  */
 final readonly class CulturalPoiAlert extends Alert
 {
@@ -21,7 +24,7 @@ final readonly class CulturalPoiAlert extends Alert
         string $message,
         ?float $lat = null,
         ?float $lon = null,
-        #[ApiProperty(description: 'POI name as found in OpenStreetMap.')]
+        #[ApiProperty(description: 'POI name as found in OpenStreetMap or DataTourisme.')]
         public string $poiName = '',
         #[ApiProperty(description: 'POI type: museum, monument, castle, church, viewpoint, attraction, or historic.')]
         public string $poiType = '',
@@ -32,6 +35,16 @@ final readonly class CulturalPoiAlert extends Alert
         #[ApiProperty(description: 'Approximate distance from the nearest route point, in metres.')]
         public int $distanceFromRoute = 0,
         ?AlertAction $action = null,
+        #[ApiProperty(description: 'Opening hours as a human-readable string (DataTourisme only).')]
+        public ?string $openingHours = null,
+        #[ApiProperty(description: 'Estimated entrance price in euros (DataTourisme only).')]
+        public ?float $estimatedPrice = null,
+        #[ApiProperty(description: 'Short description of the POI (DataTourisme only).')]
+        public ?string $description = null,
+        #[ApiProperty(description: 'Wikidata entity ID (e.g. Q12345) when available.')]
+        public ?string $wikidataId = null,
+        #[ApiProperty(description: 'Data source: osm or datatourisme.')]
+        public ?string $source = null,
     ) {
         parent::__construct($type, $message, $lat, $lon, $action);
     }

--- a/api/src/ApiResource/Model/CulturalPoiAlert.php
+++ b/api/src/ApiResource/Model/CulturalPoiAlert.php
@@ -45,6 +45,10 @@ final readonly class CulturalPoiAlert extends Alert
         public ?string $wikidataId = null,
         #[ApiProperty(description: 'Data source: osm or datatourisme.')]
         public ?string $source = null,
+        #[ApiProperty(description: 'Thumbnail image URL from Wikimedia Commons.')]
+        public ?string $imageUrl = null,
+        #[ApiProperty(description: 'Wikipedia article URL.')]
+        public ?string $wikipediaUrl = null,
     ) {
         parent::__construct($type, $message, $lat, $lon, $action);
     }

--- a/api/src/ApiResource/Model/Event.php
+++ b/api/src/ApiResource/Model/Event.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ApiResource\Model;
+
+final readonly class Event
+{
+    public function __construct(
+        public string $name,
+        public string $type,
+        public float $lat,
+        public float $lon,
+        public \DateTimeImmutable $startDate,
+        public \DateTimeImmutable $endDate,
+        public ?string $url = null,
+        public ?string $description = null,
+        public ?float $priceMin = null,
+        public float $distanceToEndPoint = 0.0,
+        public string $source = 'datatourisme',
+        public ?string $wikidataId = null,
+    ) {
+    }
+}

--- a/api/src/ApiResource/Model/Event.php
+++ b/api/src/ApiResource/Model/Event.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\ApiResource\Model;
 
+use ApiPlatform\Metadata\ApiProperty;
+
 final readonly class Event
 {
     public function __construct(
@@ -19,6 +21,12 @@ final readonly class Event
         public float $distanceToEndPoint = 0.0,
         public string $source = 'datatourisme',
         public ?string $wikidataId = null,
+        #[ApiProperty(description: 'Thumbnail image URL from Wikimedia Commons.')]
+        public ?string $imageUrl = null,
+        #[ApiProperty(description: 'Wikipedia article URL.')]
+        public ?string $wikipediaUrl = null,
+        #[ApiProperty(description: 'Opening hours (Wikidata P8989).')]
+        public ?string $openingHours = null,
     ) {
     }
 }

--- a/api/src/ApiResource/Stage.php
+++ b/api/src/ApiResource/Stage.php
@@ -14,6 +14,7 @@ use ApiPlatform\OpenApi\Model\Operation;
 use App\ApiResource\Model\Accommodation;
 use App\ApiResource\Model\Alert;
 use App\ApiResource\Model\Coordinate;
+use App\ApiResource\Model\Event;
 use App\ApiResource\Model\PointOfInterest;
 use App\ApiResource\Model\WeatherForecast;
 use App\State\RestDayInsertProcessor;
@@ -155,6 +156,9 @@ final class Stage
 
     public ?Accommodation $selectedAccommodation = null;
 
+    /** @var Event[] */
+    public array $events = [];
+
     /**
      * @param list<Coordinate> $geometry
      */
@@ -186,5 +190,10 @@ final class Stage
     public function addAccommodation(Accommodation $accommodation): void
     {
         $this->accommodations[] = $accommodation;
+    }
+
+    public function addEvent(Event $event): void
+    {
+        $this->events[] = $event;
     }
 }

--- a/api/src/ApiResource/StageResponse.php
+++ b/api/src/ApiResource/StageResponse.php
@@ -9,6 +9,7 @@ use ApiPlatform\Metadata\NotExposed;
 use App\ApiResource\Model\Accommodation;
 use App\ApiResource\Model\Alert;
 use App\ApiResource\Model\Coordinate;
+use App\ApiResource\Model\Event;
 use App\ApiResource\Model\PointOfInterest;
 use App\ApiResource\Model\WeatherForecast;
 
@@ -34,6 +35,9 @@ final class StageResponse
     public array $accommodations = [];
 
     public ?Accommodation $selectedAccommodation = null;
+
+    /** @var Event[] */
+    public array $events = [];
 
     public Trip $trip;
 

--- a/api/src/ApiResource/TripRequest.php
+++ b/api/src/ApiResource/TripRequest.php
@@ -87,18 +87,18 @@ final class TripRequest
     #[Assert\Range(min: 5, max: 50)]
     public float $averageSpeed = 15.0;
 
-    /** @var list<string> Single source of truth for all supported OSM tourism types. */
-    public const array ALL_ACCOMMODATION_TYPES = ['camp_site', 'hostel', 'alpine_hut', 'chalet', 'guest_house', 'motel', 'hotel'];
+    /** @var list<string> Single source of truth for all supported OSM accommodation types (tourism= and logical types). */
+    public const array ALL_ACCOMMODATION_TYPES = ['camp_site', 'hostel', 'alpine_hut', 'chalet', 'guest_house', 'motel', 'hotel', 'wilderness_hut', 'shelter'];
 
     /**
      * Enabled accommodation types for Overpass filtering.
-     * All 7 OSM tourism types are enabled by default.
+     * All 9 accommodation types are enabled by default.
      * At least one type must remain enabled.
      *
      * @var list<string>
      */
     #[ORM\Column(type: 'text[]')]
-    #[ApiProperty(description: 'Enabled OSM tourism types for accommodation search (default: all 7 types)')]
+    #[ApiProperty(description: 'Enabled OSM accommodation types for search (default: all 9 types)')]
     #[Assert\Count(min: 1, minMessage: 'At least one accommodation type must be enabled.')]
     #[Assert\All([
         new Assert\Choice(choices: self::ALL_ACCOMMODATION_TYPES),

--- a/api/src/Command/ImportMarketsCommand.php
+++ b/api/src/Command/ImportMarketsCommand.php
@@ -47,8 +47,8 @@ final class ImportMarketsCommand extends Command
         private readonly LoggerInterface $logger,
         #[Autowire(service: 'http_client')]
         private readonly HttpClientInterface $httpClient,
-        #[Autowire(env: 'default:https://www.data.gouv.fr/fr/datasets/r/8067f5e0-15a7-48c3-9eb9-c9df2de96a1c:MARKETS_DATASET_URL')]
-        private readonly string $datasetUrl,
+        #[Autowire(env: 'default::MARKETS_DATASET_URL')]
+        private readonly ?string $datasetUrl = null,
     ) {
         parent::__construct();
     }
@@ -68,7 +68,7 @@ final class ImportMarketsCommand extends Command
         $isDryRun = (bool) $input->getOption('dry-run');
         $limit = (int) $input->getOption('limit');
 
-        $url = $this->datasetUrl;
+        $url = $this->datasetUrl ?? 'https://www.data.gouv.fr/fr/datasets/r/8067f5e0-15a7-48c3-9eb9-c9df2de96a1c';
 
         $io->title('Import weekly markets from data.gouv.fr');
 

--- a/api/src/Command/ImportMarketsCommand.php
+++ b/api/src/Command/ImportMarketsCommand.php
@@ -47,8 +47,8 @@ final class ImportMarketsCommand extends Command
         private readonly LoggerInterface $logger,
         #[Autowire(service: 'http_client')]
         private readonly HttpClientInterface $httpClient,
-        #[Autowire(env: 'default::MARKETS_DATASET_URL')]
-        private readonly string $datasetUrl = '',
+        #[Autowire(env: 'default:https://www.data.gouv.fr/fr/datasets/r/8067f5e0-15a7-48c3-9eb9-c9df2de96a1c:MARKETS_DATASET_URL')]
+        private readonly string $datasetUrl,
     ) {
         parent::__construct();
     }
@@ -68,9 +68,7 @@ final class ImportMarketsCommand extends Command
         $isDryRun = (bool) $input->getOption('dry-run');
         $limit = (int) $input->getOption('limit');
 
-        $url = '' !== $this->datasetUrl
-            ? $this->datasetUrl
-            : 'https://www.data.gouv.fr/fr/datasets/r/8067f5e0-15a7-48c3-9eb9-c9df2de96a1c';
+        $url = $this->datasetUrl;
 
         $io->title('Import weekly markets from data.gouv.fr');
 
@@ -89,7 +87,7 @@ final class ImportMarketsCommand extends Command
         }
 
         try {
-            [$inserted, $updated, $skipped] = $this->processFile($tmpFile, $isDryRun, $limit, $io);
+            [$inserted, $updated, $skipped] = $this->processFile($tmpFile, $isDryRun, $limit);
         } finally {
             @unlink($tmpFile);
         }
@@ -129,8 +127,8 @@ final class ImportMarketsCommand extends Command
             }
 
             fclose($fileHandle);
-        } catch (\Throwable $e) {
-            $this->logger->error('Failed to download markets dataset.', ['url' => $url, 'error' => $e->getMessage()]);
+        } catch (\Throwable $throwable) {
+            $this->logger->error('Failed to download markets dataset.', ['url' => $url, 'error' => $throwable->getMessage()]);
             @unlink($tmpFile);
 
             return null;
@@ -142,7 +140,7 @@ final class ImportMarketsCommand extends Command
     /**
      * @return array{int, int, int}
      */
-    private function processFile(string $filePath, bool $isDryRun, int $limit, SymfonyStyle $io): array
+    private function processFile(string $filePath, bool $isDryRun, int $limit): array
     {
         $handle = fopen($filePath, 'r');
 
@@ -150,7 +148,7 @@ final class ImportMarketsCommand extends Command
             return [0, 0, 0];
         }
 
-        $headers = fgetcsv($handle, 0, ';');
+        $headers = fgetcsv($handle, 0, ';', escape: '\\');
 
         if (false === $headers || [] === $headers) {
             fclose($handle);
@@ -158,7 +156,7 @@ final class ImportMarketsCommand extends Command
             return [0, 0, 0];
         }
 
-        $headers = array_map('trim', $headers);
+        $headers = array_map(trim(...), $headers);
         $headerIndex = array_flip($headers);
 
         $inserted = 0;
@@ -167,7 +165,7 @@ final class ImportMarketsCommand extends Command
         $processed = 0;
         $batchSize = 200;
 
-        while (false !== ($row = fgetcsv($handle, 0, ';'))) {
+        while (false !== ($row = fgetcsv($handle, 0, ';', escape: '\\'))) {
             if (0 < $limit && $processed >= $limit) {
                 break;
             }
@@ -175,7 +173,7 @@ final class ImportMarketsCommand extends Command
             /** @var array<string, string> $data */
             $data = [];
             foreach ($headers as $i => $header) {
-                $data[$header] = isset($row[$i]) ? trim((string) $row[$i]) : '';
+                $data[$header] = isset($row[$i]) ? trim($row[$i]) : '';
             }
 
             [$lat, $lon] = $this->extractLatLon($data, $headerIndex);
@@ -214,7 +212,7 @@ final class ImportMarketsCommand extends Command
             if (!$isDryRun) {
                 $existing = $this->marketRepository->findByExternalId($externalId);
 
-                if (null !== $existing) {
+                if ($existing instanceof Market) {
                     $existing->setName($name);
                     $existing->setLat($lat);
                     $existing->setLon($lon);
@@ -244,7 +242,7 @@ final class ImportMarketsCommand extends Command
                 }
             } else {
                 $existing = $this->marketRepository->findByExternalId($externalId);
-                if (null !== $existing) {
+                if ($existing instanceof Market) {
                     ++$updated;
                 } else {
                     ++$inserted;
@@ -273,7 +271,7 @@ final class ImportMarketsCommand extends Command
      *  - A combined "Geo Point" column with "lat,lon" or "lat lon" format
      *
      * @param array<string, string> $data
-     * @param array<string, int> $headerIndex
+     * @param array<string, int>    $headerIndex
      *
      * @return array{?float, ?float}
      */
@@ -314,8 +312,8 @@ final class ImportMarketsCommand extends Command
 
     /**
      * @param array<string, string> $data
-     * @param array<string, int> $headerIndex
-     * @param list<string> $candidates
+     * @param array<string, int>    $headerIndex
+     * @param list<string>          $candidates
      */
     private function extractScalarFloat(array $data, array $headerIndex, array $candidates): ?float
     {
@@ -341,8 +339,8 @@ final class ImportMarketsCommand extends Command
 
     /**
      * @param array<string, string> $data
-     * @param array<string, int> $headerIndex
-     * @param list<string> $candidates
+     * @param array<string, int>    $headerIndex
+     * @param list<string>          $candidates
      */
     private function extractString(array $data, array $headerIndex, array $candidates): string
     {
@@ -363,7 +361,7 @@ final class ImportMarketsCommand extends Command
 
     /**
      * @param array<string, string> $data
-     * @param array<string, int> $headerIndex
+     * @param array<string, int>    $headerIndex
      */
     private function extractDayOfWeek(array $data, array $headerIndex): ?int
     {
@@ -382,8 +380,8 @@ final class ImportMarketsCommand extends Command
 
     /**
      * @param array<string, string> $data
-     * @param array<string, int> $headerIndex
-     * @param list<string> $candidates
+     * @param array<string, int>    $headerIndex
+     * @param list<string>          $candidates
      */
     private function extractTime(array $data, array $headerIndex, array $candidates): ?string
     {

--- a/api/src/Command/ImportMarketsCommand.php
+++ b/api/src/Command/ImportMarketsCommand.php
@@ -1,0 +1,406 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Entity\Market;
+use App\Repository\MarketRepositoryInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+#[AsCommand(
+    name: 'app:markets:import',
+    description: 'Import weekly markets from data.gouv.fr (Licence Ouverte 2.0)',
+)]
+final class ImportMarketsCommand extends Command
+{
+    /** Maps French weekday names to ISO 8601 day numbers (1=Monday … 7=Sunday). */
+    private const array DAY_OF_WEEK_MAP = [
+        'lundi' => 1,
+        'mardi' => 2,
+        'mercredi' => 3,
+        'jeudi' => 4,
+        'vendredi' => 5,
+        'samedi' => 6,
+        'dimanche' => 7,
+        'monday' => 1,
+        'tuesday' => 2,
+        'wednesday' => 3,
+        'thursday' => 4,
+        'friday' => 5,
+        'saturday' => 6,
+        'sunday' => 7,
+    ];
+
+    public function __construct(
+        private readonly MarketRepositoryInterface $marketRepository,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly LoggerInterface $logger,
+        #[Autowire(service: 'http_client')]
+        private readonly HttpClientInterface $httpClient,
+        #[Autowire(env: 'default::MARKETS_DATASET_URL')]
+        private readonly string $datasetUrl = '',
+    ) {
+        parent::__construct();
+    }
+
+    #[\Override]
+    protected function configure(): void
+    {
+        $this
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Show stats without writing to the database')
+            ->addOption('limit', null, InputOption::VALUE_REQUIRED, 'Limit the number of rows processed (for debug / CI)', 0);
+    }
+
+    #[\Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $isDryRun = (bool) $input->getOption('dry-run');
+        $limit = (int) $input->getOption('limit');
+
+        $url = '' !== $this->datasetUrl
+            ? $this->datasetUrl
+            : 'https://www.data.gouv.fr/fr/datasets/r/8067f5e0-15a7-48c3-9eb9-c9df2de96a1c';
+
+        $io->title('Import weekly markets from data.gouv.fr');
+
+        if ($isDryRun) {
+            $io->note('Dry-run mode: no data will be written.');
+        }
+
+        $io->text(\sprintf('Downloading dataset from: %s', $url));
+
+        $tmpFile = $this->downloadToTempFile($url);
+
+        if (null === $tmpFile) {
+            $io->error('Failed to download the dataset.');
+
+            return Command::FAILURE;
+        }
+
+        try {
+            [$inserted, $updated, $skipped] = $this->processFile($tmpFile, $isDryRun, $limit, $io);
+        } finally {
+            @unlink($tmpFile);
+        }
+
+        if (!$isDryRun) {
+            $this->entityManager->flush();
+        }
+
+        $io->success(\sprintf(
+            '%d inserted, %d updated, %d skipped (missing geo)',
+            $inserted,
+            $updated,
+            $skipped,
+        ));
+
+        return Command::SUCCESS;
+    }
+
+    private function downloadToTempFile(string $url): ?string
+    {
+        $tmpFile = tempnam(sys_get_temp_dir(), 'markets_import_');
+
+        if (false === $tmpFile) {
+            return null;
+        }
+
+        try {
+            $response = $this->httpClient->request('GET', $url, ['timeout' => 60]);
+            $fileHandle = fopen($tmpFile, 'w');
+
+            if (false === $fileHandle) {
+                return null;
+            }
+
+            foreach ($this->httpClient->stream($response) as $chunk) {
+                fwrite($fileHandle, $chunk->getContent());
+            }
+
+            fclose($fileHandle);
+        } catch (\Throwable $e) {
+            $this->logger->error('Failed to download markets dataset.', ['url' => $url, 'error' => $e->getMessage()]);
+            @unlink($tmpFile);
+
+            return null;
+        }
+
+        return $tmpFile;
+    }
+
+    /**
+     * @return array{int, int, int}
+     */
+    private function processFile(string $filePath, bool $isDryRun, int $limit, SymfonyStyle $io): array
+    {
+        $handle = fopen($filePath, 'r');
+
+        if (false === $handle) {
+            return [0, 0, 0];
+        }
+
+        $headers = fgetcsv($handle, 0, ';');
+
+        if (false === $headers || [] === $headers) {
+            fclose($handle);
+
+            return [0, 0, 0];
+        }
+
+        $headers = array_map('trim', $headers);
+        $headerIndex = array_flip($headers);
+
+        $inserted = 0;
+        $updated = 0;
+        $skipped = 0;
+        $processed = 0;
+        $batchSize = 200;
+
+        while (false !== ($row = fgetcsv($handle, 0, ';'))) {
+            if (0 < $limit && $processed >= $limit) {
+                break;
+            }
+
+            /** @var array<string, string> $data */
+            $data = [];
+            foreach ($headers as $i => $header) {
+                $data[$header] = isset($row[$i]) ? trim((string) $row[$i]) : '';
+            }
+
+            [$lat, $lon] = $this->extractLatLon($data, $headerIndex);
+
+            if (null === $lat || null === $lon) {
+                ++$skipped;
+                ++$processed;
+                continue;
+            }
+
+            $externalId = $this->extractString($data, $headerIndex, ['id', 'ID', 'identifiant']);
+
+            if ('' === $externalId) {
+                $externalId = \sprintf('%F:%F', $lat, $lon);
+            }
+
+            $name = $this->extractString($data, $headerIndex, ['Nom du marché', 'nom_marche', 'nom', 'name', 'libelle']);
+
+            if ('' === $name) {
+                $name = 'Marché';
+            }
+
+            $dayOfWeek = $this->extractDayOfWeek($data, $headerIndex);
+
+            if (null === $dayOfWeek) {
+                ++$skipped;
+                ++$processed;
+                continue;
+            }
+
+            $commune = $this->extractString($data, $headerIndex, ['Commune', 'commune', 'ville', 'city']);
+            $department = $this->extractString($data, $headerIndex, ['Département', 'departement', 'department', 'dep', 'code_departement']);
+            $startTime = $this->extractTime($data, $headerIndex, ['Heure début', 'heure_debut', 'start_time', 'ouverture']);
+            $endTime = $this->extractTime($data, $headerIndex, ['Heure fin', 'heure_fin', 'end_time', 'fermeture']);
+
+            if (!$isDryRun) {
+                $existing = $this->marketRepository->findByExternalId($externalId);
+
+                if (null !== $existing) {
+                    $existing->setName($name);
+                    $existing->setLat($lat);
+                    $existing->setLon($lon);
+                    $existing->setDayOfWeek($dayOfWeek);
+                    $existing->setStartTime($startTime);
+                    $existing->setEndTime($endTime);
+                    $existing->setCommune($commune);
+                    $existing->setDepartment($department);
+                    $existing->setImportedAt(new \DateTimeImmutable());
+                    ++$updated;
+                } else {
+                    $market = new Market($externalId, $name);
+                    $market->setLat($lat);
+                    $market->setLon($lon);
+                    $market->setDayOfWeek($dayOfWeek);
+                    $market->setStartTime($startTime);
+                    $market->setEndTime($endTime);
+                    $market->setCommune($commune);
+                    $market->setDepartment($department);
+                    $this->marketRepository->save($market);
+                    ++$inserted;
+                }
+
+                if (0 === ($processed + 1) % $batchSize) {
+                    $this->entityManager->flush();
+                    $this->entityManager->clear();
+                }
+            } else {
+                $existing = $this->marketRepository->findByExternalId($externalId);
+                if (null !== $existing) {
+                    ++$updated;
+                } else {
+                    ++$inserted;
+                }
+            }
+
+            ++$processed;
+        }
+
+        fclose($handle);
+
+        $this->logger->info('Markets import processed.', [
+            'inserted' => $inserted,
+            'updated' => $updated,
+            'skipped' => $skipped,
+        ]);
+
+        return [$inserted, $updated, $skipped];
+    }
+
+    /**
+     * Extract lat/lon pair from row data.
+     *
+     * Handles three field layouts:
+     *  - Separate "latitude" / "longitude" columns
+     *  - A combined "Geo Point" column with "lat,lon" or "lat lon" format
+     *
+     * @param array<string, string> $data
+     * @param array<string, int> $headerIndex
+     *
+     * @return array{?float, ?float}
+     */
+    private function extractLatLon(array $data, array $headerIndex): array
+    {
+        // Try separate columns first
+        $latValue = $this->extractScalarFloat($data, $headerIndex, ['latitude', 'lat']);
+        $lonValue = $this->extractScalarFloat($data, $headerIndex, ['longitude', 'lon']);
+
+        if (null !== $latValue && null !== $lonValue) {
+            return [$latValue, $lonValue];
+        }
+
+        // Try combined geo_point "lat,lon" or "lat lon" column
+        foreach (['Geo Point', 'geo_point', 'coordonnees', 'geolocalisation'] as $key) {
+            if (!isset($headerIndex[$key])) {
+                continue;
+            }
+
+            $value = trim($data[$key] ?? '');
+
+            if ('' === $value) {
+                continue;
+            }
+
+            // "lat,lon" format
+            if (preg_match('/^(-?\d+\.?\d*)[,\s]+(-?\d+\.?\d*)$/', $value, $matches)) {
+                $latParsed = filter_var($matches[1], \FILTER_VALIDATE_FLOAT);
+                $lonParsed = filter_var($matches[2], \FILTER_VALIDATE_FLOAT);
+                if (false !== $latParsed && false !== $lonParsed) {
+                    return [$latParsed, $lonParsed];
+                }
+            }
+        }
+
+        return [null, null];
+    }
+
+    /**
+     * @param array<string, string> $data
+     * @param array<string, int> $headerIndex
+     * @param list<string> $candidates
+     */
+    private function extractScalarFloat(array $data, array $headerIndex, array $candidates): ?float
+    {
+        foreach ($candidates as $key) {
+            if (!isset($headerIndex[$key])) {
+                continue;
+            }
+
+            $value = trim($data[$key] ?? '');
+
+            if ('' === $value) {
+                continue;
+            }
+
+            $floatVal = filter_var(str_replace(',', '.', $value), \FILTER_VALIDATE_FLOAT);
+            if (false !== $floatVal) {
+                return $floatVal;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, string> $data
+     * @param array<string, int> $headerIndex
+     * @param list<string> $candidates
+     */
+    private function extractString(array $data, array $headerIndex, array $candidates): string
+    {
+        foreach ($candidates as $key) {
+            if (!isset($headerIndex[$key])) {
+                continue;
+            }
+
+            $value = $data[$key] ?? '';
+
+            if ('' !== $value) {
+                return $value;
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * @param array<string, string> $data
+     * @param array<string, int> $headerIndex
+     */
+    private function extractDayOfWeek(array $data, array $headerIndex): ?int
+    {
+        $dayCandidates = ['Jour', 'jour', 'day_of_week', 'jour_semaine', 'jour_marche', 'jours'];
+
+        $rawDay = $this->extractString($data, $headerIndex, $dayCandidates);
+
+        if ('' === $rawDay) {
+            return null;
+        }
+
+        $normalised = mb_strtolower(trim($rawDay));
+
+        return self::DAY_OF_WEEK_MAP[$normalised] ?? null;
+    }
+
+    /**
+     * @param array<string, string> $data
+     * @param array<string, int> $headerIndex
+     * @param list<string> $candidates
+     */
+    private function extractTime(array $data, array $headerIndex, array $candidates): ?string
+    {
+        $raw = $this->extractString($data, $headerIndex, $candidates);
+
+        if ('' === $raw) {
+            return null;
+        }
+
+        if (preg_match('/^(\d{1,2})[hH:](\d{2})/', $raw, $matches)) {
+            return \sprintf('%02d:%02d', (int) $matches[1], (int) $matches[2]);
+        }
+
+        if (preg_match('/^(\d{1,2})h$/', $raw, $matches)) {
+            return \sprintf('%02d:00', (int) $matches[1]);
+        }
+
+        return null;
+    }
+}

--- a/api/src/Command/ImportMarketsCommand.php
+++ b/api/src/Command/ImportMarketsCommand.php
@@ -150,13 +150,13 @@ final class ImportMarketsCommand extends Command
 
         $headers = fgetcsv($handle, 0, ';', escape: '\\');
 
-        if (false === $headers || [] === $headers) {
+        if (false === $headers) {
             fclose($handle);
 
             return [0, 0, 0];
         }
 
-        $headers = array_map(trim(...), $headers);
+        $headers = array_map(static fn (?string $h): string => trim((string) $h), $headers);
         $headerIndex = array_flip($headers);
 
         $inserted = 0;

--- a/api/src/Command/ImportMarketsCommand.php
+++ b/api/src/Command/ImportMarketsCommand.php
@@ -45,7 +45,7 @@ final class ImportMarketsCommand extends Command
         private readonly MarketRepositoryInterface $marketRepository,
         private readonly EntityManagerInterface $entityManager,
         private readonly LoggerInterface $logger,
-        #[Autowire(service: 'http_client')]
+        #[Autowire(service: 'markets_dataset.client')]
         private readonly HttpClientInterface $httpClient,
         #[Autowire(env: 'default::MARKETS_DATASET_URL')]
         private readonly ?string $datasetUrl = null,

--- a/api/src/CulturalPoiSource/CulturalPoiSourceInterface.php
+++ b/api/src/CulturalPoiSource/CulturalPoiSourceInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\CulturalPoiSource;
+
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+#[AutoconfigureTag('app.cultural_poi_source')]
+interface CulturalPoiSourceInterface
+{
+    /**
+     * @param list<list<array{lat: float, lon: float}>> $stageGeometries
+     *
+     * @return list<array>
+     */
+    public function fetchForStages(array $stageGeometries, int $radiusMeters): array;
+
+    public function isEnabled(): bool;
+
+    public function getName(): string;
+}

--- a/api/src/CulturalPoiSource/CulturalPoiSourceInterface.php
+++ b/api/src/CulturalPoiSource/CulturalPoiSourceInterface.php
@@ -12,7 +12,7 @@ interface CulturalPoiSourceInterface
     /**
      * @param list<list<array{lat: float, lon: float}>> $stageGeometries
      *
-     * @return list<array>
+     * @return list<array{name: string, type: string, lat: float, lon: float, openingHours: string|null, estimatedPrice: float|null, description: string|null, wikidataId: string|null, source: string}>
      */
     public function fetchForStages(array $stageGeometries, int $radiusMeters): array;
 

--- a/api/src/CulturalPoiSource/CulturalPoiSourceRegistry.php
+++ b/api/src/CulturalPoiSource/CulturalPoiSourceRegistry.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\CulturalPoiSource;
+
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
+
+final readonly class CulturalPoiSourceRegistry
+{
+    /** @var list<CulturalPoiSourceInterface> */
+    private array $sources;
+
+    /**
+     * @param iterable<CulturalPoiSourceInterface> $sources
+     */
+    public function __construct(
+        #[AutowireIterator('app.cultural_poi_source')]
+        iterable $sources,
+    ) {
+        $this->sources = iterator_to_array($sources, false);
+    }
+
+    /**
+     * Fetches POIs from all enabled sources and merges the results.
+     *
+     * @param list<list<array{lat: float, lon: float}>> $stageGeometries
+     *
+     * @return list<array>
+     */
+    public function fetchAllForStages(array $stageGeometries, int $radiusMeters): array
+    {
+        $all = [];
+
+        foreach ($this->sources as $source) {
+            if (!$source->isEnabled()) {
+                continue;
+            }
+
+            foreach ($source->fetchForStages($stageGeometries, $radiusMeters) as $poi) {
+                $all[] = $poi;
+            }
+        }
+
+        return $all;
+    }
+}

--- a/api/src/CulturalPoiSource/CulturalPoiSourceRegistry.php
+++ b/api/src/CulturalPoiSource/CulturalPoiSourceRegistry.php
@@ -6,10 +6,10 @@ namespace App\CulturalPoiSource;
 
 use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 
-final readonly class CulturalPoiSourceRegistry
+class CulturalPoiSourceRegistry
 {
     /** @var list<CulturalPoiSourceInterface> */
-    private array $sources;
+    private readonly array $sources;
 
     /**
      * @param iterable<CulturalPoiSourceInterface> $sources
@@ -26,7 +26,7 @@ final readonly class CulturalPoiSourceRegistry
      *
      * @param list<list<array{lat: float, lon: float}>> $stageGeometries
      *
-     * @return list<array>
+     * @return list<array{name: string, type: string, lat: float, lon: float, openingHours: string|null, estimatedPrice: float|null, description: string|null, wikidataId: string|null, source: string}>
      */
     public function fetchAllForStages(array $stageGeometries, int $radiusMeters): array
     {

--- a/api/src/CulturalPoiSource/DataTourismeCulturalPoiSource.php
+++ b/api/src/CulturalPoiSource/DataTourismeCulturalPoiSource.php
@@ -1,0 +1,357 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\CulturalPoiSource;
+
+use App\DataTourisme\DataTourismeClientInterface;
+
+final readonly class DataTourismeCulturalPoiSource implements CulturalPoiSourceInterface
+{
+    /**
+     * DataTourisme ontology types that qualify as cultural POIs.
+     *
+     * @var list<string>
+     */
+    private const array CULTURAL_ONTOLOGY_TYPES = [
+        'schema:Museum',
+        'schema:TouristAttraction',
+        'schema:Landmark',
+        'urn:resource:CulturalSite',
+        'urn:resource:NaturalHeritage',
+    ];
+
+    public function __construct(
+        private DataTourismeClientInterface $client,
+    ) {
+    }
+
+    /**
+     * @param list<list<array{lat: float, lon: float}>> $stageGeometries
+     *
+     * @return list<array{name: string, type: string, lat: float, lon: float, openingHours: string|null, estimatedPrice: float|null, description: string|null, wikidataId: string|null, source: string}>
+     */
+    public function fetchForStages(array $stageGeometries, int $radiusMeters): array
+    {
+        if (!$this->client->isEnabled()) {
+            return [];
+        }
+
+        [$minLat, $minLon, $maxLat, $maxLon] = $this->buildBbox($stageGeometries, $radiusMeters);
+
+        $response = $this->client->request('/', [
+            'query' => json_encode([
+                '@context' => 'https://schema.org',
+                '@type' => self::CULTURAL_ONTOLOGY_TYPES,
+                'isLocatedAt' => [
+                    'schema:geo' => [
+                        'schema:latitude' => ['>=', $minLat, '<=', $maxLat],
+                        'schema:longitude' => ['>=', $minLon, '<=', $maxLon],
+                    ],
+                ],
+            ]),
+        ]);
+
+        /** @var list<array<string, mixed>> $results */
+        $results = \is_array($response['results'] ?? null) ? $response['results'] : (
+            \is_array($response['member'] ?? null) ? $response['member'] : []
+        );
+
+        $pois = [];
+        foreach ($results as $item) {
+            $poi = $this->mapItem($item);
+            if (null !== $poi) {
+                $pois[] = $poi;
+            }
+        }
+
+        return $pois;
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->client->isEnabled();
+    }
+
+    public function getName(): string
+    {
+        return 'datatourisme';
+    }
+
+    /**
+     * @param list<list<array{lat: float, lon: float}>> $stageGeometries
+     *
+     * @return array{float, float, float, float}
+     */
+    private function buildBbox(array $stageGeometries, int $radiusMeters): array
+    {
+        $allLats = [];
+        $allLons = [];
+
+        foreach ($stageGeometries as $geometry) {
+            foreach ($geometry as $point) {
+                $allLats[] = $point['lat'];
+                $allLons[] = $point['lon'];
+            }
+        }
+
+        if ([] === $allLats) {
+            return [0.0, 0.0, 0.0, 0.0];
+        }
+
+        $degreeOffset = $radiusMeters / 111_000.0;
+
+        return [
+            min($allLats) - $degreeOffset,
+            min($allLons) - $degreeOffset,
+            max($allLats) + $degreeOffset,
+            max($allLons) + $degreeOffset,
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $item
+     *
+     * @return array{name: string, type: string, lat: float, lon: float, openingHours: string|null, estimatedPrice: float|null, description: string|null, wikidataId: string|null, source: string}|null
+     */
+    private function mapItem(array $item): ?array
+    {
+        $name = $this->extractLabel($item['rdfs:label'] ?? null);
+        if (null === $name || '' === $name) {
+            return null;
+        }
+
+        $coords = $this->extractCoordinates($item);
+        if (null === $coords) {
+            return null;
+        }
+
+        return [
+            'name' => $name,
+            'type' => $this->resolveType($item['@type'] ?? []),
+            'lat' => $coords['lat'],
+            'lon' => $coords['lon'],
+            'openingHours' => $this->extractOpeningHours($item['openingHoursSpecification'] ?? null),
+            'estimatedPrice' => $this->extractPrice($item['offers'] ?? null),
+            'description' => $this->extractDescription($item),
+            'wikidataId' => $this->extractWikidataId($item['owl:sameAs'] ?? null),
+            'source' => 'datatourisme',
+        ];
+    }
+
+    /**
+     * @param mixed $label
+     */
+    private function extractLabel(mixed $label): ?string
+    {
+        if (\is_string($label)) {
+            return $label;
+        }
+
+        if (\is_array($label)) {
+            foreach ($label as $entry) {
+                if (\is_array($entry) && isset($entry['@value'])) {
+                    return (string) $entry['@value'];
+                }
+                if (\is_string($entry)) {
+                    return $entry;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, mixed> $item
+     *
+     * @return array{lat: float, lon: float}|null
+     */
+    private function extractCoordinates(array $item): ?array
+    {
+        $geometry = $item['hasGeometry'] ?? $item['schema:geo'] ?? null;
+        if (!\is_array($geometry)) {
+            return null;
+        }
+
+        $lat = $geometry['schema:latitude'] ?? $geometry['lat'] ?? null;
+        $lon = $geometry['schema:longitude'] ?? $geometry['lon'] ?? null;
+
+        if (null === $lat || null === $lon) {
+            return null;
+        }
+
+        return ['lat' => (float) $lat, 'lon' => (float) $lon];
+    }
+
+    /**
+     * @param mixed $types
+     */
+    private function resolveType(mixed $types): string
+    {
+        if (\is_string($types)) {
+            $types = [$types];
+        }
+
+        if (!\is_array($types)) {
+            return 'attraction';
+        }
+
+        foreach ($types as $type) {
+            $resolved = match ($type) {
+                'schema:Museum', 'urn:resource:Museum' => 'museum',
+                'schema:Landmark', 'urn:resource:Monument', 'urn:resource:CulturalSite' => 'monument',
+                'urn:resource:NaturalHeritage' => 'viewpoint',
+                default => null,
+            };
+
+            if (null !== $resolved) {
+                return $resolved;
+            }
+        }
+
+        return 'attraction';
+    }
+
+    /**
+     * @param mixed $specs
+     */
+    private function extractOpeningHours(mixed $specs): ?string
+    {
+        if (!\is_array($specs)) {
+            return null;
+        }
+
+        if (isset($specs['schema:opens'])) {
+            $specs = [$specs];
+        }
+
+        $parts = [];
+        foreach ($specs as $spec) {
+            if (!\is_array($spec)) {
+                continue;
+            }
+
+            $days = $spec['schema:dayOfWeek'] ?? null;
+            $opens = $spec['schema:opens'] ?? null;
+            $closes = $spec['schema:closes'] ?? null;
+
+            if (null === $opens || null === $closes) {
+                continue;
+            }
+
+            $dayStr = \is_array($days) ? implode(', ', array_map([$this, 'formatDay'], $days)) : ($days ?? '');
+            $parts[] = trim(\sprintf('%s %s–%s', $dayStr, $opens, $closes));
+        }
+
+        return [] === $parts ? null : implode(' | ', $parts);
+    }
+
+    private function formatDay(string $day): string
+    {
+        $map = [
+            'schema:Monday' => 'Mon',
+            'schema:Tuesday' => 'Tue',
+            'schema:Wednesday' => 'Wed',
+            'schema:Thursday' => 'Thu',
+            'schema:Friday' => 'Fri',
+            'schema:Saturday' => 'Sat',
+            'schema:Sunday' => 'Sun',
+        ];
+
+        return $map[$day] ?? $day;
+    }
+
+    /**
+     * @param mixed $offers
+     */
+    private function extractPrice(mixed $offers): ?float
+    {
+        if (!\is_array($offers)) {
+            return null;
+        }
+
+        if (isset($offers['priceSpecification'])) {
+            $offers = [$offers];
+        }
+
+        foreach ($offers as $offer) {
+            if (!\is_array($offer)) {
+                continue;
+            }
+
+            $priceSpec = $offer['priceSpecification'] ?? null;
+            if (!\is_array($priceSpec)) {
+                continue;
+            }
+
+            if (isset($priceSpec['schema:price'])) {
+                $priceSpec = [$priceSpec];
+            }
+
+            foreach ($priceSpec as $spec) {
+                if (!\is_array($spec)) {
+                    continue;
+                }
+
+                $price = $spec['schema:price'] ?? $spec['price'] ?? null;
+                $currency = $spec['schema:priceCurrency'] ?? $spec['priceCurrency'] ?? null;
+
+                if (null !== $price && (null === $currency || 'EUR' === $currency)) {
+                    return (float) $price;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, mixed> $item
+     */
+    private function extractDescription(array $item): ?string
+    {
+        $raw = $item['rdfs:comment'] ?? $item['shortDescription'] ?? $item['schema:description'] ?? null;
+
+        if (\is_string($raw)) {
+            return $raw;
+        }
+
+        if (\is_array($raw)) {
+            foreach ($raw as $entry) {
+                if (\is_array($entry) && isset($entry['@value'])) {
+                    return (string) $entry['@value'];
+                }
+                if (\is_string($entry)) {
+                    return $entry;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param mixed $sameAs
+     */
+    private function extractWikidataId(mixed $sameAs): ?string
+    {
+        if (\is_string($sameAs)) {
+            $sameAs = [$sameAs];
+        }
+
+        if (!\is_array($sameAs)) {
+            return null;
+        }
+
+        foreach ($sameAs as $uri) {
+            if (\is_string($uri) && str_contains($uri, 'wikidata.org/entity/')) {
+                $parts = explode('/', $uri);
+
+                return end($parts) ?: null;
+            }
+        }
+
+        return null;
+    }
+}

--- a/api/src/CulturalPoiSource/DataTourismeCulturalPoiSource.php
+++ b/api/src/CulturalPoiSource/DataTourismeCulturalPoiSource.php
@@ -95,7 +95,7 @@ final readonly class DataTourismeCulturalPoiSource implements CulturalPoiSourceI
             }
         }
 
-        if ([] === $allLats) {
+        if ([] === $allLats || [] === $allLons) {
             return [0.0, 0.0, 0.0, 0.0];
         }
 
@@ -139,9 +139,6 @@ final readonly class DataTourismeCulturalPoiSource implements CulturalPoiSourceI
         ];
     }
 
-    /**
-     * @param mixed $label
-     */
     private function extractLabel(mixed $label): ?string
     {
         if (\is_string($label)) {
@@ -150,9 +147,10 @@ final readonly class DataTourismeCulturalPoiSource implements CulturalPoiSourceI
 
         if (\is_array($label)) {
             foreach ($label as $entry) {
-                if (\is_array($entry) && isset($entry['@value'])) {
+                if (\is_array($entry) && isset($entry['@value']) && \is_scalar($entry['@value'])) {
                     return (string) $entry['@value'];
                 }
+
                 if (\is_string($entry)) {
                     return $entry;
                 }
@@ -177,16 +175,13 @@ final readonly class DataTourismeCulturalPoiSource implements CulturalPoiSourceI
         $lat = $geometry['schema:latitude'] ?? $geometry['lat'] ?? null;
         $lon = $geometry['schema:longitude'] ?? $geometry['lon'] ?? null;
 
-        if (null === $lat || null === $lon) {
+        if (!is_numeric($lat) || !is_numeric($lon)) {
             return null;
         }
 
         return ['lat' => (float) $lat, 'lon' => (float) $lon];
     }
 
-    /**
-     * @param mixed $types
-     */
     private function resolveType(mixed $types): string
     {
         if (\is_string($types)) {
@@ -213,9 +208,6 @@ final readonly class DataTourismeCulturalPoiSource implements CulturalPoiSourceI
         return 'attraction';
     }
 
-    /**
-     * @param mixed $specs
-     */
     private function extractOpeningHours(mixed $specs): ?string
     {
         if (!\is_array($specs)) {
@@ -236,11 +228,23 @@ final readonly class DataTourismeCulturalPoiSource implements CulturalPoiSourceI
             $opens = $spec['schema:opens'] ?? null;
             $closes = $spec['schema:closes'] ?? null;
 
-            if (null === $opens || null === $closes) {
+            if (!\is_string($opens) || !\is_string($closes)) {
                 continue;
             }
 
-            $dayStr = \is_array($days) ? implode(', ', array_map([$this, 'formatDay'], $days)) : ($days ?? '');
+            if (\is_array($days)) {
+                $dayParts = [];
+                foreach ($days as $day) {
+                    if (\is_string($day)) {
+                        $dayParts[] = $this->formatDay($day);
+                    }
+                }
+
+                $dayStr = implode(', ', $dayParts);
+            } else {
+                $dayStr = \is_string($days) ? $days : '';
+            }
+
             $parts[] = trim(\sprintf('%s %s–%s', $dayStr, $opens, $closes));
         }
 
@@ -262,9 +266,6 @@ final readonly class DataTourismeCulturalPoiSource implements CulturalPoiSourceI
         return $map[$day] ?? $day;
     }
 
-    /**
-     * @param mixed $offers
-     */
     private function extractPrice(mixed $offers): ?float
     {
         if (!\is_array($offers)) {
@@ -297,7 +298,7 @@ final readonly class DataTourismeCulturalPoiSource implements CulturalPoiSourceI
                 $price = $spec['schema:price'] ?? $spec['price'] ?? null;
                 $currency = $spec['schema:priceCurrency'] ?? $spec['priceCurrency'] ?? null;
 
-                if (null !== $price && (null === $currency || 'EUR' === $currency)) {
+                if (is_numeric($price) && (null === $currency || 'EUR' === $currency)) {
                     return (float) $price;
                 }
             }
@@ -319,9 +320,10 @@ final readonly class DataTourismeCulturalPoiSource implements CulturalPoiSourceI
 
         if (\is_array($raw)) {
             foreach ($raw as $entry) {
-                if (\is_array($entry) && isset($entry['@value'])) {
+                if (\is_array($entry) && isset($entry['@value']) && \is_scalar($entry['@value'])) {
                     return (string) $entry['@value'];
                 }
+
                 if (\is_string($entry)) {
                     return $entry;
                 }
@@ -331,9 +333,6 @@ final readonly class DataTourismeCulturalPoiSource implements CulturalPoiSourceI
         return null;
     }
 
-    /**
-     * @param mixed $sameAs
-     */
     private function extractWikidataId(mixed $sameAs): ?string
     {
         if (\is_string($sameAs)) {

--- a/api/src/CulturalPoiSource/DataTourismeCulturalPoiSource.php
+++ b/api/src/CulturalPoiSource/DataTourismeCulturalPoiSource.php
@@ -39,17 +39,22 @@ final readonly class DataTourismeCulturalPoiSource implements CulturalPoiSourceI
 
         [$minLat, $minLon, $maxLat, $maxLon] = $this->buildBbox($stageGeometries, $radiusMeters);
 
-        $response = $this->client->request('/', [
-            'query' => json_encode([
-                '@context' => 'https://schema.org',
-                '@type' => self::CULTURAL_ONTOLOGY_TYPES,
-                'isLocatedAt' => [
-                    'schema:geo' => [
-                        'schema:latitude' => ['>=', $minLat, '<=', $maxLat],
-                        'schema:longitude' => ['>=', $minLon, '<=', $maxLon],
-                    ],
-                ],
-            ]),
+        $response = $this->client->request('/api/v1/places', [
+            'filters[0][path]' => '@type',
+            'filters[0][operator]' => 'in',
+            'filters[0][value]' => implode(',', self::CULTURAL_ONTOLOGY_TYPES),
+            'filters[1][path]' => 'hasGeometry.latitude',
+            'filters[1][operator]' => 'gte',
+            'filters[1][value]' => $minLat,
+            'filters[2][path]' => 'hasGeometry.latitude',
+            'filters[2][operator]' => 'lte',
+            'filters[2][value]' => $maxLat,
+            'filters[3][path]' => 'hasGeometry.longitude',
+            'filters[3][operator]' => 'gte',
+            'filters[3][value]' => $minLon,
+            'filters[4][path]' => 'hasGeometry.longitude',
+            'filters[4][operator]' => 'lte',
+            'filters[4][value]' => $maxLon,
         ]);
 
         /** @var list<array<string, mixed>> $results */

--- a/api/src/CulturalPoiSource/OsmCulturalPoiSource.php
+++ b/api/src/CulturalPoiSource/OsmCulturalPoiSource.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\CulturalPoiSource;
+
+use App\ApiResource\Model\Coordinate;
+use App\Scanner\QueryBuilderInterface;
+use App\Scanner\ScannerInterface;
+
+final readonly class OsmCulturalPoiSource implements CulturalPoiSourceInterface
+{
+    /**
+     * @var list<string>
+     */
+    private const array NOTABLE_HISTORIC_VALUES = [
+        'castle',
+        'monument',
+        'memorial',
+        'ruins',
+        'archaeological_site',
+        'church',
+        'cathedral',
+        'abbey',
+        'fort',
+    ];
+
+    public function __construct(
+        private ScannerInterface $scanner,
+        private QueryBuilderInterface $queryBuilder,
+    ) {
+    }
+
+    /**
+     * @param list<list<array{lat: float, lon: float}>> $stageGeometries
+     *
+     * @return list<array{name: string, type: string, lat: float, lon: float, openingHours: null, estimatedPrice: null, description: null, wikidataId: string|null, source: string}>
+     */
+    public function fetchForStages(array $stageGeometries, int $radiusMeters): array
+    {
+        $coordinateGeometries = array_map(
+            static fn (array $geometry): array => array_map(
+                static fn (array $point): Coordinate => new Coordinate($point['lat'], $point['lon']),
+                $geometry,
+            ),
+            $stageGeometries,
+        );
+
+        $query = $this->queryBuilder->buildBatchCulturalPoiQuery($coordinateGeometries, $radiusMeters);
+        $result = $this->scanner->query($query);
+
+        /** @var list<array{tags?: array<string, string>, lat?: float, lon?: float, center?: array{lat: float, lon: float}}> $elements */
+        $elements = \is_array($result['elements'] ?? null) ? $result['elements'] : [];
+
+        $pois = [];
+        foreach ($elements as $element) {
+            $lat = $element['lat'] ?? ($element['center']['lat'] ?? null);
+            $lon = $element['lon'] ?? ($element['center']['lon'] ?? null);
+
+            if (null === $lat || null === $lon) {
+                continue;
+            }
+
+            $tags = $element['tags'] ?? [];
+            $poiType = $this->resolveCulturalPoiType($tags);
+
+            if (null === $poiType) {
+                continue;
+            }
+
+            $pois[] = [
+                'name' => $tags['name'] ?? $poiType,
+                'type' => $poiType,
+                'lat' => (float) $lat,
+                'lon' => (float) $lon,
+                'openingHours' => null,
+                'estimatedPrice' => null,
+                'description' => null,
+                'wikidataId' => isset($tags['wikidata']) && '' !== $tags['wikidata'] ? $tags['wikidata'] : null,
+                'source' => 'osm',
+            ];
+        }
+
+        return $pois;
+    }
+
+    public function isEnabled(): bool
+    {
+        return true;
+    }
+
+    public function getName(): string
+    {
+        return 'osm';
+    }
+
+    /**
+     * @param array<string, string> $tags
+     */
+    private function resolveCulturalPoiType(array $tags): ?string
+    {
+        if (isset($tags['tourism'])) {
+            return match ($tags['tourism']) {
+                'museum' => 'museum',
+                'attraction' => 'attraction',
+                'viewpoint' => 'viewpoint',
+                default => null,
+            };
+        }
+
+        if (isset($tags['historic']) && \in_array($tags['historic'], self::NOTABLE_HISTORIC_VALUES, true)) {
+            return $tags['historic'];
+        }
+
+        return null;
+    }
+}

--- a/api/src/CulturalPoiSource/OsmCulturalPoiSource.php
+++ b/api/src/CulturalPoiSource/OsmCulturalPoiSource.php
@@ -34,7 +34,7 @@ final readonly class OsmCulturalPoiSource implements CulturalPoiSourceInterface
     /**
      * @param list<list<array{lat: float, lon: float}>> $stageGeometries
      *
-     * @return list<array{name: string, type: string, lat: float, lon: float, openingHours: null, estimatedPrice: null, description: null, wikidataId: string|null, source: string}>
+     * @return list<array{name: string, type: string, lat: float, lon: float, openingHours: string|null, estimatedPrice: float|null, description: string|null, wikidataId: string|null, source: string}>
      */
     public function fetchForStages(array $stageGeometries, int $radiusMeters): array
     {

--- a/api/src/DataTourisme/DataTourismeClient.php
+++ b/api/src/DataTourisme/DataTourismeClient.php
@@ -6,7 +6,7 @@ namespace App\DataTourisme;
 
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -21,7 +21,7 @@ final readonly class DataTourismeClient implements DataTourismeClientInterface
         #[Autowire(service: 'cache.datatourisme')]
         private CacheInterface $cache,
         #[Autowire(service: 'limiter.datatourisme')]
-        private RateLimiterFactory $rateLimiter,
+        private RateLimiterFactoryInterface $rateLimiter,
         private LoggerInterface $logger,
         #[Autowire(env: 'default::DATATOURISME_API_KEY')]
         private string $apiKey,
@@ -46,8 +46,8 @@ final readonly class DataTourismeClient implements DataTourismeClientInterface
         $ttl = $ttlSeconds ?? self::DEFAULT_TTL;
 
         try {
-            /** @var array<string, mixed> */
-            return $this->cache->get($cacheKey, function (ItemInterface $item) use ($path, $query, $ttl): array {
+            /** @var array<string, mixed> $result */
+            $result = $this->cache->get($cacheKey, function (ItemInterface $item) use ($path, $query, $ttl): array {
                 $item->expiresAfter($ttl);
 
                 $limiter = $this->rateLimiter->create('datatourisme');
@@ -57,20 +57,21 @@ final readonly class DataTourismeClient implements DataTourismeClientInterface
 
                 $response = $this->httpClient->request('GET', $path, ['query' => $query]);
 
-                /** @var array<string, mixed> */
                 return $response->toArray();
             });
-        } catch (DataTourismeRateLimitException $e) {
-            $this->logger->warning('DataTourisme rate limit reached, returning empty result.', [
-                'error' => $e->getMessage(),
-            ]);
 
-            return ['results' => []];
-        } catch (\Throwable $e) {
-            $this->logger->warning('DataTourisme request failed, returning empty result.', [
-                'path' => $path,
-                'error' => $e->getMessage(),
-            ]);
+            return $result;
+        } catch (\Throwable $throwable) {
+            if ($throwable instanceof DataTourismeRateLimitException) {
+                $this->logger->warning('DataTourisme rate limit reached, returning empty result.', [
+                    'error' => $throwable->getMessage(),
+                ]);
+            } else {
+                $this->logger->warning('DataTourisme request failed, returning empty result.', [
+                    'path' => $path,
+                    'error' => $throwable->getMessage(),
+                ]);
+            }
 
             return ['results' => []];
         }

--- a/api/src/DataTourisme/DataTourismeClient.php
+++ b/api/src/DataTourisme/DataTourismeClient.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DataTourisme;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+final readonly class DataTourismeClient implements DataTourismeClientInterface
+{
+    private const int DEFAULT_TTL = 86400; // 24 hours
+
+    public function __construct(
+        #[Autowire(service: 'datatourisme.client')]
+        private HttpClientInterface $httpClient,
+        #[Autowire(service: 'cache.datatourisme')]
+        private CacheInterface $cache,
+        #[Autowire(service: 'limiter.datatourisme')]
+        private RateLimiterFactory $rateLimiter,
+        private LoggerInterface $logger,
+        #[Autowire(env: 'default::DATATOURISME_API_KEY')]
+        private string $apiKey,
+        #[Autowire(env: 'bool:default::DATATOURISME_ENABLED')]
+        private bool $enabled,
+    ) {
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->enabled && '' !== $this->apiKey;
+    }
+
+    /**
+     * @param array<string, mixed> $query
+     *
+     * @return array<string, mixed>
+     */
+    public function request(string $path, array $query = [], ?int $ttlSeconds = null): array
+    {
+        $cacheKey = $this->cacheKey($path, $query);
+        $ttl = $ttlSeconds ?? self::DEFAULT_TTL;
+
+        try {
+            /** @var array<string, mixed> */
+            return $this->cache->get($cacheKey, function (ItemInterface $item) use ($path, $query, $ttl): array {
+                $item->expiresAfter($ttl);
+
+                $limiter = $this->rateLimiter->create('datatourisme');
+                if (!$limiter->consume()->isAccepted()) {
+                    throw new DataTourismeRateLimitException('DataTourisme rate limit reached.');
+                }
+
+                $response = $this->httpClient->request('GET', $path, ['query' => $query]);
+
+                /** @var array<string, mixed> */
+                return $response->toArray();
+            });
+        } catch (DataTourismeRateLimitException $e) {
+            $this->logger->warning('DataTourisme rate limit reached, returning empty result.', [
+                'error' => $e->getMessage(),
+            ]);
+
+            return ['results' => []];
+        } catch (\Throwable $e) {
+            $this->logger->warning('DataTourisme request failed, returning empty result.', [
+                'path' => $path,
+                'error' => $e->getMessage(),
+            ]);
+
+            return ['results' => []];
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $query
+     */
+    private function cacheKey(string $path, array $query): string
+    {
+        return 'datatourisme.'.hash('xxh128', $path.serialize($query));
+    }
+}

--- a/api/src/DataTourisme/DataTourismeClientInterface.php
+++ b/api/src/DataTourisme/DataTourismeClientInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DataTourisme;
+
+interface DataTourismeClientInterface
+{
+    public function isEnabled(): bool;
+
+    /**
+     * Fetches data from the DataTourisme API with Redis caching and rate limiting.
+     * Returns ['results' => []] silently on network error or quota exhaustion.
+     *
+     * @param array<string, mixed> $query
+     *
+     * @return array<string, mixed>
+     */
+    public function request(string $path, array $query = [], ?int $ttlSeconds = null): array;
+}

--- a/api/src/DataTourisme/DataTourismeRateLimitException.php
+++ b/api/src/DataTourisme/DataTourismeRateLimitException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DataTourisme;
+
+final class DataTourismeRateLimitException extends \RuntimeException
+{
+}

--- a/api/src/Engine/PricingHeuristicEngine.php
+++ b/api/src/Engine/PricingHeuristicEngine.php
@@ -16,11 +16,16 @@ final readonly class PricingHeuristicEngine
         'guest_house' => ['min' => 40.0, 'max' => 80.0],
         'motel' => ['min' => 45.0, 'max' => 90.0],
         'hotel' => ['min' => 50.0, 'max' => 120.0],
+        'wilderness_hut' => ['min' => 0.0, 'max' => 10.0],
+        'shelter' => ['min' => 0.0, 'max' => 0.0],
     ];
+
+    private const float BIKEPACKER_CAMP_SITE_MAX = 15.0;
 
     /**
      * Returns estimated price range for an accommodation type.
      * If an exact charge tag is provided, returns it as both min and max.
+     * Recognises backpack=yes and tents=yes as bikepacker-friendly signals for camp_site.
      *
      * @param array<string, string> $osmTags OSM tags for the accommodation element
      *
@@ -37,6 +42,11 @@ final readonly class PricingHeuristicEngine
         }
 
         $bracket = self::PRICE_BRACKETS[$accommodationType] ?? self::PRICE_BRACKETS['hotel'];
+
+        // Bikepacker-friendly camp sites (backpack=yes or tents=yes) tend to be cheaper
+        if ('camp_site' === $accommodationType && ('yes' === ($osmTags['backpack'] ?? null) || 'yes' === ($osmTags['tents'] ?? null))) {
+            return ['min' => $bracket['min'], 'max' => self::BIKEPACKER_CAMP_SITE_MAX, 'isExact' => false];
+        }
 
         return ['min' => $bracket['min'], 'max' => $bracket['max'], 'isExact' => false];
     }

--- a/api/src/Entity/Market.php
+++ b/api/src/Entity/Market.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Repository\MarketRepository;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Uid\Uuid;
+
+#[ORM\Entity(repositoryClass: MarketRepository::class)]
+#[ORM\Table(name: 'market')]
+#[ORM\UniqueConstraint(name: 'uniq_market_external_id', columns: ['external_id'])]
+#[ORM\Index(name: 'idx_market_day_of_week', columns: ['day_of_week'])]
+class Market
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'uuid')]
+    private Uuid $id;
+
+    #[ORM\Column]
+    private float $lat;
+
+    #[ORM\Column]
+    private float $lon;
+
+    #[ORM\Column]
+    private int $dayOfWeek;
+
+    #[ORM\Column(length: 5, nullable: true)]
+    private ?string $startTime = null;
+
+    #[ORM\Column(length: 5, nullable: true)]
+    private ?string $endTime = null;
+
+    #[ORM\Column(length: 255)]
+    private string $commune;
+
+    #[ORM\Column(length: 255)]
+    private string $department;
+
+    #[ORM\Column(length: 50)]
+    private string $source = 'data.gouv.fr';
+
+    #[ORM\Column]
+    private \DateTimeImmutable $importedAt;
+
+    public function __construct(
+        #[ORM\Column(length: 255)]
+        private string $externalId,
+        #[ORM\Column(length: 255)]
+        private string $name,
+        ?Uuid $id = null,
+    ) {
+        $this->id = $id ?? Uuid::v7();
+        $this->importedAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getExternalId(): string
+    {
+        return $this->externalId;
+    }
+
+    public function setExternalId(string $externalId): self
+    {
+        $this->externalId = $externalId;
+
+        return $this;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getLat(): float
+    {
+        return $this->lat;
+    }
+
+    public function setLat(float $lat): self
+    {
+        $this->lat = $lat;
+
+        return $this;
+    }
+
+    public function getLon(): float
+    {
+        return $this->lon;
+    }
+
+    public function setLon(float $lon): self
+    {
+        $this->lon = $lon;
+
+        return $this;
+    }
+
+    public function getDayOfWeek(): int
+    {
+        return $this->dayOfWeek;
+    }
+
+    public function setDayOfWeek(int $dayOfWeek): self
+    {
+        $this->dayOfWeek = $dayOfWeek;
+
+        return $this;
+    }
+
+    public function getStartTime(): ?string
+    {
+        return $this->startTime;
+    }
+
+    public function setStartTime(?string $startTime): self
+    {
+        $this->startTime = $startTime;
+
+        return $this;
+    }
+
+    public function getEndTime(): ?string
+    {
+        return $this->endTime;
+    }
+
+    public function setEndTime(?string $endTime): self
+    {
+        $this->endTime = $endTime;
+
+        return $this;
+    }
+
+    public function getCommune(): string
+    {
+        return $this->commune;
+    }
+
+    public function setCommune(string $commune): self
+    {
+        $this->commune = $commune;
+
+        return $this;
+    }
+
+    public function getDepartment(): string
+    {
+        return $this->department;
+    }
+
+    public function setDepartment(string $department): self
+    {
+        $this->department = $department;
+
+        return $this;
+    }
+
+    public function getSource(): string
+    {
+        return $this->source;
+    }
+
+    public function setSource(string $source): self
+    {
+        $this->source = $source;
+
+        return $this;
+    }
+
+    public function getImportedAt(): \DateTimeImmutable
+    {
+        return $this->importedAt;
+    }
+
+    public function setImportedAt(\DateTimeImmutable $importedAt): self
+    {
+        $this->importedAt = $importedAt;
+
+        return $this;
+    }
+}

--- a/api/src/Enum/ComputationName.php
+++ b/api/src/Enum/ComputationName.php
@@ -22,6 +22,7 @@ enum ComputationName: string
     case RAILWAY_STATIONS = 'railway_stations';
     case HEALTH_SERVICES = 'health_services';
     case BORDER_CROSSING = 'border_crossing';
+    case EVENTS = 'events';
 
     /**
      * Computations initialized at trip creation (the main pipeline).

--- a/api/src/Mercure/MercureEventType.php
+++ b/api/src/Mercure/MercureEventType.php
@@ -22,6 +22,7 @@ enum MercureEventType: string
     case RAILWAY_STATION_ALERTS = 'railway_station_alerts';
     case HEALTH_SERVICE_ALERTS = 'health_service_alerts';
     case BORDER_CROSSING_ALERTS = 'border_crossing_alerts';
+    case EVENTS_FOUND = 'events_found';
     case VALIDATION_ERROR = 'validation_error';
     case COMPUTATION_ERROR = 'computation_error';
     case TRIP_COMPLETE = 'trip_complete';

--- a/api/src/Message/ScanEvents.php
+++ b/api/src/Message/ScanEvents.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Message;
+
+final readonly class ScanEvents
+{
+    public function __construct(
+        public string $tripId,
+        public ?int $generation = null,
+    ) {
+    }
+}

--- a/api/src/MessageHandler/CheckCulturalPoisHandler.php
+++ b/api/src/MessageHandler/CheckCulturalPoisHandler.php
@@ -17,6 +17,7 @@ use App\Mercure\MercureEventType;
 use App\Mercure\TripUpdatePublisherInterface;
 use App\Message\CheckCulturalPois;
 use App\Repository\TripRequestRepositoryInterface;
+use App\Wikidata\WikidataEnricherInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -53,6 +54,7 @@ final readonly class CheckCulturalPoisHandler extends AbstractTripMessageHandler
         private GeometryDistributorInterface $distributor,
         private GeoDistanceInterface $haversine,
         private TranslatorInterface $translator,
+        private WikidataEnricherInterface $wikidataEnricher,
     ) {
         parent::__construct($computationTracker, $publisher, $generationTracker, $logger);
     }
@@ -101,6 +103,21 @@ final readonly class CheckCulturalPoisHandler extends AbstractTripMessageHandler
 
             // Fetch all POIs from all enabled sources
             $allCulturalPois = $this->registry->fetchAllForStages($stageGeometries, self::CULTURAL_POI_RADIUS_METERS);
+
+            // Wikidata enrichment pass over all POIs (batch SPARQL)
+            $qIds = array_values(array_filter(array_unique(array_column($allCulturalPois, 'wikidataId'))));
+            $wikidataEnrichments = [] !== $qIds ? $this->wikidataEnricher->enrichBatch($qIds, $locale) : [];
+
+            if ([] !== $wikidataEnrichments) {
+                foreach ($allCulturalPois as $k => $poi) {
+                    $qId = $poi['wikidataId'] ?? null;
+                    if (null !== $qId && isset($wikidataEnrichments[$qId])) {
+                        $wikidata = $wikidataEnrichments[$qId];
+                        // Wikidata never overwrites an already-filled field
+                        $allCulturalPois[$k] = array_merge($wikidata, $poi);
+                    }
+                }
+            }
 
             // Distribute POIs to the nearest active stage via geometry
             /** @var array<int, list<array>> $poisByActiveStage */
@@ -167,6 +184,14 @@ final readonly class CheckCulturalPoisHandler extends AbstractTripMessageHandler
 
                     if (null !== ($poi['source'] ?? null)) {
                         $alert['source'] = $poi['source'];
+                    }
+
+                    if (null !== ($poi['imageUrl'] ?? null)) {
+                        $alert['imageUrl'] = $poi['imageUrl'];
+                    }
+
+                    if (null !== ($poi['wikipediaUrl'] ?? null)) {
+                        $alert['wikipediaUrl'] = $poi['wikipediaUrl'];
                     }
 
                     $alerts[] = $alert;

--- a/api/src/MessageHandler/CheckCulturalPoisHandler.php
+++ b/api/src/MessageHandler/CheckCulturalPoisHandler.php
@@ -8,6 +8,7 @@ use App\ApiResource\Model\Coordinate;
 use App\ApiResource\Stage;
 use App\ComputationTracker\ComputationTrackerInterface;
 use App\ComputationTracker\TripGenerationTrackerInterface;
+use App\CulturalPoiSource\CulturalPoiSourceRegistry;
 use App\Enum\AlertType;
 use App\Enum\ComputationName;
 use App\Geo\GeoDistanceInterface;
@@ -16,8 +17,6 @@ use App\Mercure\MercureEventType;
 use App\Mercure\TripUpdatePublisherInterface;
 use App\Message\CheckCulturalPois;
 use App\Repository\TripRequestRepositoryInterface;
-use App\Scanner\QueryBuilderInterface;
-use App\Scanner\ScannerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -29,6 +28,9 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  * Each alert carries the POI coordinates so the frontend can display an
  * "add to itinerary" button that triggers route recalculation via
  * RecalculateRouteSegment (ADR-017).
+ *
+ * POIs are fetched from all enabled sources via CulturalPoiSourceRegistry
+ * (OSM via Overpass, DataTourisme when configured).
  */
 #[AsMessageHandler]
 final readonly class CheckCulturalPoisHandler extends AbstractTripMessageHandler
@@ -41,31 +43,13 @@ final readonly class CheckCulturalPoisHandler extends AbstractTripMessageHandler
      */
     private const int MAX_SUGGESTIONS_PER_STAGE = 3;
 
-    /**
-     * Overpass `historic=*` values that are considered notable enough to suggest.
-     *
-     * @var list<string>
-     */
-    private const array NOTABLE_HISTORIC_VALUES = [
-        'castle',
-        'monument',
-        'memorial',
-        'ruins',
-        'archaeological_site',
-        'church',
-        'cathedral',
-        'abbey',
-        'fort',
-    ];
-
     public function __construct(
         ComputationTrackerInterface $computationTracker,
         TripUpdatePublisherInterface $publisher,
         TripGenerationTrackerInterface $generationTracker,
         LoggerInterface $logger,
         private TripRequestRepositoryInterface $tripStateManager,
-        private ScannerInterface $scanner,
-        private QueryBuilderInterface $queryBuilder,
+        private CulturalPoiSourceRegistry $registry,
         private GeometryDistributorInterface $distributor,
         private GeoDistanceInterface $haversine,
         private TranslatorInterface $translator,
@@ -87,7 +71,7 @@ final readonly class CheckCulturalPoisHandler extends AbstractTripMessageHandler
 
         $this->executeWithTracking($tripId, ComputationName::CULTURAL_POIS, function () use ($tripId, $stages, $locale): void {
             // Collect geometries for non-rest-day stages
-            /** @var list<list<Coordinate>> $stageGeometries */
+            /** @var list<list<array{lat: float, lon: float}>> $stageGeometries */
             $stageGeometries = [];
             /** @var list<int> $activeStageIndices */
             $activeStageIndices = [];
@@ -100,7 +84,11 @@ final readonly class CheckCulturalPoisHandler extends AbstractTripMessageHandler
 
                 $activeStageIndices[] = $i;
                 $activeStages[] = $stage;
-                $stageGeometries[] = $stage->geometry ?: [$stage->startPoint, $stage->endPoint];
+                $geometry = $stage->geometry ?: [$stage->startPoint, $stage->endPoint];
+                $stageGeometries[] = array_map(
+                    static fn (Coordinate $c): array => ['lat' => $c->lat, 'lon' => $c->lon],
+                    $geometry,
+                );
             }
 
             if ([] === $stageGeometries) {
@@ -111,43 +99,11 @@ final readonly class CheckCulturalPoisHandler extends AbstractTripMessageHandler
                 return;
             }
 
-            // Single batch query for all active stages
-            $query = $this->queryBuilder->buildBatchCulturalPoiQuery($stageGeometries, self::CULTURAL_POI_RADIUS_METERS);
-            $result = $this->scanner->query($query);
-
-            /** @var list<array{tags?: array<string, string>, lat?: float, lon?: float, center?: array{lat: float, lon: float}}> $elements */
-            $elements = \is_array($result['elements'] ?? null) ? $result['elements'] : [];
-
-            // Parse all cultural POIs from the batch result
-            /** @var list<array{name: string, type: string, lat: float, lon: float}> $allCulturalPois */
-            $allCulturalPois = [];
-            foreach ($elements as $element) {
-                $lat = $element['lat'] ?? ($element['center']['lat'] ?? null);
-                $lon = $element['lon'] ?? ($element['center']['lon'] ?? null);
-
-                if (null === $lat || null === $lon) {
-                    continue;
-                }
-
-                $tags = $element['tags'] ?? [];
-                $poiType = $this->resolveCulturalPoiType($tags);
-
-                if (null === $poiType) {
-                    continue;
-                }
-
-                $name = $tags['name'] ?? $poiType;
-
-                $allCulturalPois[] = [
-                    'name' => $name,
-                    'type' => $poiType,
-                    'lat' => (float) $lat,
-                    'lon' => (float) $lon,
-                ];
-            }
+            // Fetch all POIs from all enabled sources
+            $allCulturalPois = $this->registry->fetchAllForStages($stageGeometries, self::CULTURAL_POI_RADIUS_METERS);
 
             // Distribute POIs to the nearest active stage via geometry
-            /** @var array<int, list<array{name: string, type: string, lat: float, lon: float}>> $poisByActiveStage */
+            /** @var array<int, list<array>> $poisByActiveStage */
             $poisByActiveStage = $this->distributor->distributeByGeometry($allCulturalPois, $activeStages);
 
             $alerts = [];
@@ -159,13 +115,7 @@ final readonly class CheckCulturalPoisHandler extends AbstractTripMessageHandler
                 foreach ($poisByActiveStage[$activeIdx] ?? [] as $poi) {
                     $distanceFromRoute = $this->findMinDistanceToRoute($geometry, $poi['lat'], $poi['lon']);
 
-                    $stagePois[] = [
-                        'name' => $poi['name'],
-                        'type' => $poi['type'],
-                        'lat' => $poi['lat'],
-                        'lon' => $poi['lon'],
-                        'distanceFromRoute' => $distanceFromRoute,
-                    ];
+                    $stagePois[] = array_merge($poi, ['distanceFromRoute' => $distanceFromRoute]);
                 }
 
                 // Sort by proximity and keep only the closest N suggestions
@@ -185,7 +135,7 @@ final readonly class CheckCulturalPoisHandler extends AbstractTripMessageHandler
                         $locale,
                     );
 
-                    $alerts[] = [
+                    $alert = [
                         'stageIndex' => $originalIndex,
                         'dayNumber' => $stage->dayNumber,
                         'type' => AlertType::NUDGE->value,
@@ -198,6 +148,28 @@ final readonly class CheckCulturalPoisHandler extends AbstractTripMessageHandler
                         'poiLon' => $poi['lon'],
                         'distanceFromRoute' => $poi['distanceFromRoute'],
                     ];
+
+                    if (null !== ($poi['openingHours'] ?? null)) {
+                        $alert['openingHours'] = $poi['openingHours'];
+                    }
+
+                    if (null !== ($poi['estimatedPrice'] ?? null)) {
+                        $alert['estimatedPrice'] = $poi['estimatedPrice'];
+                    }
+
+                    if (null !== ($poi['description'] ?? null)) {
+                        $alert['description'] = $poi['description'];
+                    }
+
+                    if (null !== ($poi['wikidataId'] ?? null)) {
+                        $alert['wikidataId'] = $poi['wikidataId'];
+                    }
+
+                    if (null !== ($poi['source'] ?? null)) {
+                        $alert['source'] = $poi['source'];
+                    }
+
+                    $alerts[] = $alert;
                 }
             }
 
@@ -205,30 +177,6 @@ final readonly class CheckCulturalPoisHandler extends AbstractTripMessageHandler
                 'alerts' => $alerts,
             ]);
         }, $generation);
-    }
-
-    /**
-     * Resolves the human-readable POI type from OSM tags.
-     * Returns null when the element does not qualify as a notable cultural POI.
-     *
-     * @param array<string, string> $tags
-     */
-    private function resolveCulturalPoiType(array $tags): ?string
-    {
-        if (isset($tags['tourism'])) {
-            return match ($tags['tourism']) {
-                'museum' => 'museum',
-                'attraction' => 'attraction',
-                'viewpoint' => 'viewpoint',
-                default => null,
-            };
-        }
-
-        if (isset($tags['historic']) && \in_array($tags['historic'], self::NOTABLE_HISTORIC_VALUES, true)) {
-            return $tags['historic'];
-        }
-
-        return null;
     }
 
     /**

--- a/api/src/MessageHandler/GenerateStagesHandler.php
+++ b/api/src/MessageHandler/GenerateStagesHandler.php
@@ -28,6 +28,7 @@ use App\Message\CheckWaterPoints;
 use App\Message\FetchWeather;
 use App\Message\GenerateStages;
 use App\Message\ScanAccommodations;
+use App\Message\ScanEvents;
 use App\Message\ScanPois;
 use App\Repository\TripRequestRepositoryInterface;
 use Psr\Log\LoggerInterface;
@@ -115,6 +116,7 @@ final readonly class GenerateStagesHandler extends AbstractTripMessageHandler
             $this->messageBus->dispatch(new CheckCulturalPois($tripId, $generation));
             $this->messageBus->dispatch(new CheckRailwayStations($tripId, $generation));
             $this->messageBus->dispatch(new CheckBorderCrossing($tripId, $generation));
+            $this->messageBus->dispatch(new ScanEvents($tripId, $generation));
         }, $generation);
     }
 

--- a/api/src/MessageHandler/RecalculateStagesHandler.php
+++ b/api/src/MessageHandler/RecalculateStagesHandler.php
@@ -15,6 +15,7 @@ use App\Message\AnalyzeTerrain;
 use App\Message\CheckBikeShops;
 use App\Message\RecalculateStages;
 use App\Message\ScanAccommodations;
+use App\Message\ScanEvents;
 use App\Message\ScanPois;
 use App\Repository\TripRequestRepositoryInterface;
 use Psr\Log\LoggerInterface;
@@ -110,6 +111,7 @@ final readonly class RecalculateStagesHandler extends AbstractTripMessageHandler
 
             $this->messageBus->dispatch(new CheckBikeShops($tripId, $generation));
             $this->messageBus->dispatch(new AnalyzeTerrain($tripId, $generation));
+            $this->messageBus->dispatch(new ScanEvents($tripId, $generation));
         }
     }
 }

--- a/api/src/MessageHandler/ScanAccommodationsHandler.php
+++ b/api/src/MessageHandler/ScanAccommodationsHandler.php
@@ -22,6 +22,7 @@ use App\Mercure\MercureEventType;
 use App\Mercure\TripUpdatePublisherInterface;
 use App\Message\ScanAccommodations;
 use App\Repository\TripRequestRepositoryInterface;
+use App\Wikidata\WikidataEnricherInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
@@ -49,6 +50,7 @@ final readonly class ScanAccommodationsHandler extends AbstractTripMessageHandle
         private TranslatorInterface $translator,
         #[Autowire(service: 'accommodation_scraper.client')]
         private HttpClientInterface $scraperClient,
+        private WikidataEnricherInterface $wikidataEnricher,
     ) {
         parent::__construct($computationTracker, $publisher, $generationTracker, $logger);
     }
@@ -97,6 +99,22 @@ final readonly class ScanAccommodationsHandler extends AbstractTripMessageHandle
             // Async scraping: 2 waves of parallel HTTP requests
             $retainedByStage = $this->scrapeAsync($retainedByStage);
 
+            // Wikidata enrichment: one batch SPARQL query for all retained candidates
+            $allRetained = [] !== $retainedByStage ? array_merge(...array_values($retainedByStage)) : [];
+            $qIds = array_values(array_filter(array_unique(array_column($allRetained, 'wikidataId'))));
+            $wikidataEnrichments = [] !== $qIds ? $this->wikidataEnricher->enrichBatch($qIds, $locale) : [];
+
+            foreach ($retainedByStage as $i => $candidates) {
+                foreach ($candidates as $j => $candidate) {
+                    $qId = $candidate['wikidataId'] ?? null;
+                    if (null !== $qId && isset($wikidataEnrichments[$qId])) {
+                        $wikidata = $wikidataEnrichments[$qId];
+                        // Wikidata never overwrites an already-filled field
+                        $retainedByStage[$i][$j] = array_merge($wikidata, $candidate);
+                    }
+                }
+            }
+
             // Build Accommodation DTOs, publish per stage, and store
             $startDate = $request?->startDate;
             foreach ($stagesToProcess as $i => $stage) {
@@ -119,6 +137,10 @@ final readonly class ScanAccommodationsHandler extends AbstractTripMessageHandle
                             'possibleClosed' => $existing->possibleClosed,
                             'distanceToEndPoint' => $existing->distanceToEndPoint,
                             'source' => $existing->source,
+                            'description' => $existing->description,
+                            'imageUrl' => $existing->imageUrl,
+                            'wikipediaUrl' => $existing->wikipediaUrl,
+                            'openingHours' => $existing->openingHours,
                         ];
                     }
                 } else {
@@ -158,6 +180,10 @@ final readonly class ScanAccommodationsHandler extends AbstractTripMessageHandle
                         possibleClosed: $possibleClosed,
                         distanceToEndPoint: $distanceToEndPoint,
                         source: $raw['source'] ?? 'osm',
+                        description: $raw['description'] ?? null,
+                        imageUrl: $raw['imageUrl'] ?? null,
+                        wikipediaUrl: $raw['wikipediaUrl'] ?? null,
+                        openingHours: $raw['openingHours'] ?? null,
                     );
 
                     $stage->addAccommodation($accommodation);
@@ -173,6 +199,10 @@ final readonly class ScanAccommodationsHandler extends AbstractTripMessageHandle
                         'possibleClosed' => $accommodation->possibleClosed,
                         'distanceToEndPoint' => $accommodation->distanceToEndPoint,
                         'source' => $accommodation->source,
+                        'description' => $accommodation->description,
+                        'imageUrl' => $accommodation->imageUrl,
+                        'wikipediaUrl' => $accommodation->wikipediaUrl,
+                        'openingHours' => $accommodation->openingHours,
                     ];
                 }
 

--- a/api/src/MessageHandler/ScanAccommodationsHandler.php
+++ b/api/src/MessageHandler/ScanAccommodationsHandler.php
@@ -7,13 +7,13 @@ namespace App\MessageHandler;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 use App\Accommodation\AccommodationMetadataExtractor;
 use App\Accommodation\SeasonalityCheckerInterface;
+use App\AccommodationSource\AccommodationSourceRegistry;
 use App\ApiResource\Model\Accommodation;
 use App\ApiResource\Model\Alert;
 use App\ApiResource\Model\Coordinate;
 use App\ApiResource\Stage;
 use App\ComputationTracker\ComputationTrackerInterface;
 use App\ComputationTracker\TripGenerationTrackerInterface;
-use App\Engine\PricingHeuristicEngine;
 use App\Enum\AlertType;
 use App\Enum\ComputationName;
 use App\Geo\GeoDistanceInterface;
@@ -22,15 +22,12 @@ use App\Mercure\MercureEventType;
 use App\Mercure\TripUpdatePublisherInterface;
 use App\Message\ScanAccommodations;
 use App\Repository\TripRequestRepositoryInterface;
-use App\Scanner\QueryBuilderInterface;
-use App\Scanner\ScannerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-// @todo #89 SRP: extract OsmAccommodationParser, AccommodationDeduplicator, AccommodationScraper
 #[AsMessageHandler]
 final readonly class ScanAccommodationsHandler extends AbstractTripMessageHandler
 {
@@ -44,9 +41,7 @@ final readonly class ScanAccommodationsHandler extends AbstractTripMessageHandle
         TripGenerationTrackerInterface $generationTracker,
         LoggerInterface $logger,
         private TripRequestRepositoryInterface $tripStateManager,
-        private ScannerInterface $scanner,
-        private QueryBuilderInterface $queryBuilder,
-        private PricingHeuristicEngine $pricingEngine,
+        private AccommodationSourceRegistry $registry,
         private GeoDistanceInterface $haversine,
         private GeometryDistributorInterface $distributor,
         private AccommodationMetadataExtractor $metadataExtractor,
@@ -83,17 +78,12 @@ final readonly class ScanAccommodationsHandler extends AbstractTripMessageHandle
 
             // Use stage endpoints (not the full decimated route) so the radius applies to overnight stops only
             $endPoints = array_map(static fn (Stage $stage): Coordinate => $stage->endPoint, $stagesToProcess);
-            $query = $this->queryBuilder->buildAccommodationQuery($endPoints, $radiusMeters, $enabledAccommodationTypes);
-            $result = $this->scanner->query($query);
 
-            /** @var list<array{id?: int, type?: string, tags?: array<string, string>, lat?: float, lon?: float, center?: array{lat: float, lon: float}}> $elements */
-            $elements = \is_array($result['elements'] ?? null) ? $result['elements'] : [];
-
-            // Phase 1: Parse OSM elements into candidates (no HTTP)
-            $allCandidates = $this->parseOsmElements($elements);
+            // Fetch candidates from all enabled sources (OSM + DataTourisme + …)
+            $allCandidates = $this->registry->fetchAll($endPoints, $radiusMeters, $enabledAccommodationTypes);
 
             // Distribute candidates to their nearest stage endpoint (output keys match $stagesToProcess keys)
-            /** @var array<int, list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>}>> $candidatesByStage */
+            /** @var array<int, list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, source: string, wikidataId: ?string}>> $candidatesByStage */
             $candidatesByStage = $this->distributor->distributeByEndpoint($allCandidates, $stagesToProcess);
 
             // Deduplicate + limit per stage BEFORE any scraping
@@ -128,6 +118,7 @@ final readonly class ScanAccommodationsHandler extends AbstractTripMessageHandle
                             'url' => $existing->url,
                             'possibleClosed' => $existing->possibleClosed,
                             'distanceToEndPoint' => $existing->distanceToEndPoint,
+                            'source' => $existing->source,
                         ];
                     }
                 } else {
@@ -166,6 +157,7 @@ final readonly class ScanAccommodationsHandler extends AbstractTripMessageHandle
                         url: $raw['url'],
                         possibleClosed: $possibleClosed,
                         distanceToEndPoint: $distanceToEndPoint,
+                        source: $raw['source'] ?? 'osm',
                     );
 
                     $stage->addAccommodation($accommodation);
@@ -180,6 +172,7 @@ final readonly class ScanAccommodationsHandler extends AbstractTripMessageHandle
                         'url' => $accommodation->url,
                         'possibleClosed' => $accommodation->possibleClosed,
                         'distanceToEndPoint' => $accommodation->distanceToEndPoint,
+                        'source' => $accommodation->source,
                     ];
                 }
 
@@ -219,63 +212,14 @@ final readonly class ScanAccommodationsHandler extends AbstractTripMessageHandle
     }
 
     /**
-     * Parse OSM elements into candidate arrays without any HTTP requests.
-     *
-     * @param list<array{id?: int, type?: string, tags?: array<string, string>, lat?: float, lon?: float, center?: array{lat: float, lon: float}}> $elements
-     *
-     * @return list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>}>
-     */
-    private function parseOsmElements(array $elements): array
-    {
-        $candidates = [];
-
-        foreach ($elements as $element) {
-            $tags = $element['tags'] ?? [];
-            $lat = $element['lat'] ?? ($element['center']['lat'] ?? null);
-            $lon = $element['lon'] ?? ($element['center']['lon'] ?? null);
-
-            if (null === $lat || null === $lon) {
-                continue;
-            }
-
-            $url = $tags['website']
-                ?? $tags['contact:website']
-                ?? (isset($element['id'], $element['type'])
-                    ? \sprintf('https://www.openstreetmap.org/%s/%d', $element['type'], $element['id'])
-                    : null);
-
-            $type = $tags['tourism'] ?? ('shelter' === ($tags['amenity'] ?? null) ? 'shelter' : 'hotel');
-            $name = $tags['name'] ?? $type;
-            $tagCount = \count($tags);
-            $pricing = $this->pricingEngine->estimatePrice($type, $tags);
-
-            $candidates[] = [
-                'name' => $name,
-                'type' => $type,
-                'lat' => (float) $lat,
-                'lon' => (float) $lon,
-                'priceMin' => $pricing['min'],
-                'priceMax' => $pricing['max'],
-                'isExact' => $pricing['isExact'],
-                'url' => $url,
-                'tagCount' => $tagCount,
-                'hasWebsite' => isset($tags['website']) || isset($tags['contact:website']),
-                'tags' => $tags,
-            ];
-        }
-
-        return $candidates;
-    }
-
-    /**
      * Scrape accommodation metadata in 2 parallel waves via Symfony HttpClient multiplexing.
      *
      * Wave 1: main-page requests for all candidates with a website URL.
      * Wave 2: price-page requests for candidates whose main page had no price.
      *
-     * @param array<int, list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>}>> $retainedByStage
+     * @param array<int, list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, source: string, wikidataId: ?string}>> $retainedByStage
      *
-     * @return array<int, list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>}>>
+     * @return array<int, list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, source: string, wikidataId: ?string}>>
      */
     private function scrapeAsync(array $retainedByStage): array
     {
@@ -343,7 +287,7 @@ final readonly class ScanAccommodationsHandler extends AbstractTripMessageHandle
         }
 
         if ([] === $needsPricePage) {
-            /** @var array<int, list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>}>> $result */
+            /** @var array<int, list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, source: string, wikidataId: ?string}>> $result */
             $result = $retainedByStage;
 
             return $result;
@@ -391,16 +335,16 @@ final readonly class ScanAccommodationsHandler extends AbstractTripMessageHandle
             }
         }
 
-        /** @var array<int, list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>}>> $result */
+        /** @var array<int, list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, source: string, wikidataId: ?string}>> $result */
         $result = $retainedByStage;
 
         return $result;
     }
 
     /**
-     * @param list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>}> $accommodations
+     * @param list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, source: string, wikidataId: ?string}> $accommodations
      *
-     * @return list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>}>
+     * @return list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, source: string, wikidataId: ?string}>
      */
     private function deduplicate(array $accommodations): array
     {

--- a/api/src/MessageHandler/ScanAccommodationsHandler.php
+++ b/api/src/MessageHandler/ScanAccommodationsHandler.php
@@ -244,7 +244,7 @@ final readonly class ScanAccommodationsHandler extends AbstractTripMessageHandle
                     ? \sprintf('https://www.openstreetmap.org/%s/%d', $element['type'], $element['id'])
                     : null);
 
-            $type = $tags['tourism'] ?? 'hotel';
+            $type = $tags['tourism'] ?? ('shelter' === ($tags['amenity'] ?? null) ? 'shelter' : 'hotel');
             $name = $tags['name'] ?? $type;
             $tagCount = \count($tags);
             $pricing = $this->pricingEngine->estimatePrice($type, $tags);

--- a/api/src/MessageHandler/ScanEventsHandler.php
+++ b/api/src/MessageHandler/ScanEventsHandler.php
@@ -9,11 +9,13 @@ use App\ApiResource\Stage;
 use App\ComputationTracker\ComputationTrackerInterface;
 use App\ComputationTracker\TripGenerationTrackerInterface;
 use App\DataTourisme\DataTourismeClientInterface;
+use App\Entity\Market;
 use App\Enum\ComputationName;
 use App\Geo\GeoDistanceInterface;
 use App\Mercure\MercureEventType;
 use App\Mercure\TripUpdatePublisherInterface;
 use App\Message\ScanEvents;
+use App\Repository\MarketRepositoryInterface;
 use App\Repository\TripRequestRepositoryInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
@@ -41,6 +43,7 @@ final readonly class ScanEventsHandler extends AbstractTripMessageHandler
         private TripRequestRepositoryInterface $tripStateManager,
         private DataTourismeClientInterface $dataTourismeClient,
         private GeoDistanceInterface $haversine,
+        private MarketRepositoryInterface $marketRepository,
     ) {
         parent::__construct($computationTracker, $publisher, $generationTracker, $logger);
     }
@@ -75,6 +78,7 @@ final readonly class ScanEventsHandler extends AbstractTripMessageHandler
 
                 $stageDate = $startDate->modify(\sprintf('+%d days', $i));
                 $events = $this->fetchEventsForStage($stage, $stageDate);
+                $events = [...$events, ...$this->fetchMarketsForStage($stage, $stageDate)];
 
                 foreach ($events as $event) {
                     $stage->addEvent($event);
@@ -201,6 +205,57 @@ final readonly class ScanEventsHandler extends AbstractTripMessageHandler
         }
 
         usort($events, static fn (Event $a, Event $b): int => $a->startDate <=> $b->startDate);
+
+        return $events;
+    }
+
+    /**
+     * @return list<Event>
+     */
+    private function fetchMarketsForStage(Stage $stage, \DateTimeImmutable $stageDate): array
+    {
+        $dayOfWeek = (int) $stageDate->format('N');
+
+        $markets = $this->marketRepository->findNearEndpoint(
+            $stage->endPoint->lat,
+            $stage->endPoint->lon,
+            self::EVENT_RADIUS_METERS,
+            $dayOfWeek,
+        );
+
+        $events = [];
+
+        foreach ($markets as $market) {
+            $startDate = $stageDate;
+            $endDate = $stageDate;
+
+            if (null !== $market->getStartTime()) {
+                $startDate = \DateTimeImmutable::createFromFormat('Y-m-d H:i', $stageDate->format('Y-m-d').' '.$market->getStartTime()) ?: $stageDate;
+            }
+
+            if (null !== $market->getEndTime()) {
+                $endDate = \DateTimeImmutable::createFromFormat('Y-m-d H:i', $stageDate->format('Y-m-d').' '.$market->getEndTime()) ?: $stageDate;
+            }
+
+            $distanceToEndPoint = $this->haversine->inMeters(
+                $market->getLat(),
+                $market->getLon(),
+                $stage->endPoint->lat,
+                $stage->endPoint->lon,
+            );
+
+            $events[] = new Event(
+                name: $market->getName(),
+                type: 'market',
+                lat: $market->getLat(),
+                lon: $market->getLon(),
+                startDate: $startDate,
+                endDate: $endDate,
+                description: 'Marché hebdomadaire',
+                distanceToEndPoint: $distanceToEndPoint,
+                source: 'data_gouv_markets',
+            );
+        }
 
         return $events;
     }

--- a/api/src/MessageHandler/ScanEventsHandler.php
+++ b/api/src/MessageHandler/ScanEventsHandler.php
@@ -9,7 +9,6 @@ use App\ApiResource\Stage;
 use App\ComputationTracker\ComputationTrackerInterface;
 use App\ComputationTracker\TripGenerationTrackerInterface;
 use App\DataTourisme\DataTourismeClientInterface;
-use App\Entity\Market;
 use App\Enum\ComputationName;
 use App\Geo\GeoDistanceInterface;
 use App\Mercure\MercureEventType;
@@ -74,7 +73,7 @@ final readonly class ScanEventsHandler extends AbstractTripMessageHandler
 
         $locale = $this->tripStateManager->getLocale($tripId) ?? 'en';
 
-        $this->executeWithTracking($tripId, ComputationName::EVENTS, function () use ($tripId, $stages, $startDate, $locale, $generation): void {
+        $this->executeWithTracking($tripId, ComputationName::EVENTS, function () use ($tripId, $stages, $startDate, $locale): void {
             // Collect raw events per stage first, then enrich with Wikidata in one batch
             /** @var array<int, list<Event>> $eventsByStage */
             $eventsByStage = [];
@@ -197,13 +196,7 @@ final readonly class ScanEventsHandler extends AbstractTripMessageHandler
 
         foreach ($results as $result) {
             $types = (array) ($result['@type'] ?? []);
-            $matchedType = null;
-            foreach (self::TARGETED_TYPES as $targeted) {
-                if (\in_array($targeted, $types, true)) {
-                    $matchedType = $targeted;
-                    break;
-                }
-            }
+            $matchedType = array_find(self::TARGETED_TYPES, fn ($targeted): bool => \in_array($targeted, $types, true));
 
             if (null === $matchedType) {
                 continue;
@@ -219,7 +212,7 @@ final readonly class ScanEventsHandler extends AbstractTripMessageHandler
             $startDate = $this->extractDate($result, 'startDate');
             $endDate = $this->extractDate($result, 'endDate');
 
-            if (null === $startDate || null === $endDate) {
+            if (!$startDate instanceof \DateTimeImmutable || !$endDate instanceof \DateTimeImmutable) {
                 continue;
             }
 
@@ -317,7 +310,7 @@ final readonly class ScanEventsHandler extends AbstractTripMessageHandler
 
         if (\is_array($geometry)) {
             $lat = $geometry['latitude'] ?? $geometry['lat'] ?? null;
-            if (null !== $lat) {
+            if (is_numeric($lat)) {
                 return (float) $lat;
             }
         }
@@ -334,7 +327,7 @@ final readonly class ScanEventsHandler extends AbstractTripMessageHandler
 
         if (\is_array($geometry)) {
             $lon = $geometry['longitude'] ?? $geometry['lon'] ?? null;
-            if (null !== $lon) {
+            if (is_numeric($lon)) {
                 return (float) $lon;
             }
         }
@@ -372,7 +365,7 @@ final readonly class ScanEventsHandler extends AbstractTripMessageHandler
         }
 
         if (\is_array($label)) {
-            $first = array_values($label)[0] ?? null;
+            $first = array_first($label) ?? null;
 
             return \is_string($first) ? $first : null;
         }
@@ -402,7 +395,7 @@ final readonly class ScanEventsHandler extends AbstractTripMessageHandler
         }
 
         if (\is_array($desc)) {
-            $first = array_values($desc)[0] ?? null;
+            $first = array_first($desc) ?? null;
 
             return \is_string($first) ? $first : null;
         }
@@ -438,7 +431,7 @@ final readonly class ScanEventsHandler extends AbstractTripMessageHandler
                 }
 
                 $price = $spec['minPrice'] ?? $spec['price'] ?? null;
-                if (null !== $price) {
+                if (is_numeric($price)) {
                     return (float) $price;
                 }
             }

--- a/api/src/MessageHandler/ScanEventsHandler.php
+++ b/api/src/MessageHandler/ScanEventsHandler.php
@@ -55,6 +55,8 @@ final readonly class ScanEventsHandler extends AbstractTripMessageHandler
         $generation = $message->generation;
 
         if (!$this->dataTourismeClient->isEnabled()) {
+            $this->executeWithTracking($tripId, ComputationName::EVENTS, static fn (): null => null, $generation);
+
             return;
         }
 

--- a/api/src/MessageHandler/ScanEventsHandler.php
+++ b/api/src/MessageHandler/ScanEventsHandler.php
@@ -19,6 +19,7 @@ use App\Repository\TripRequestRepositoryInterface;
 use App\Wikidata\WikidataEnricherInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 #[AsMessageHandler]
 final readonly class ScanEventsHandler extends AbstractTripMessageHandler
@@ -45,6 +46,7 @@ final readonly class ScanEventsHandler extends AbstractTripMessageHandler
         private GeoDistanceInterface $haversine,
         private WikidataEnricherInterface $wikidataEnricher,
         private MarketRepositoryInterface $marketRepository,
+        private TranslatorInterface $translator,
     ) {
         parent::__construct($computationTracker, $publisher, $generationTracker, $logger);
     }
@@ -54,26 +56,52 @@ final readonly class ScanEventsHandler extends AbstractTripMessageHandler
         $tripId = $message->tripId;
         $generation = $message->generation;
 
-        if (!$this->dataTourismeClient->isEnabled()) {
+        $stages = $this->tripStateManager->getStages($tripId);
+        if (null === $stages) {
             $this->executeWithTracking($tripId, ComputationName::EVENTS, static fn (): null => null, $generation);
 
             return;
         }
 
-        $stages = $this->tripStateManager->getStages($tripId);
-
-        if (null === $stages) {
-            return;
-        }
-
         $request = $this->tripStateManager->getRequest($tripId);
         $startDate = $request?->startDate;
-
         if (!$startDate instanceof \DateTimeImmutable) {
+            $this->executeWithTracking($tripId, ComputationName::EVENTS, static fn (): null => null, $generation);
+
             return;
         }
 
         $locale = $this->tripStateManager->getLocale($tripId) ?? 'en';
+
+        if (!$this->dataTourismeClient->isEnabled()) {
+            $this->executeWithTracking($tripId, ComputationName::EVENTS, function () use ($tripId, $stages, $startDate, $locale): void {
+                foreach ($stages as $i => $stage) {
+                    if ($stage->isRestDay) {
+                        continue;
+                    }
+
+                    $stageDate = $startDate->modify(\sprintf('+%d days', $i));
+                    $events = $this->fetchMarketsForStage($stage, $stageDate, $locale);
+
+                    foreach ($events as $event) {
+                        $stage->addEvent($event);
+                    }
+
+                    if ([] !== $events) {
+                        $this->publisher->publish($tripId, MercureEventType::EVENTS_FOUND, [
+                            'stageIndex' => $i,
+                            'events' => array_map($this->eventToArray(...), $events),
+                        ]);
+                    }
+
+                    $stages[$i] = $stage;
+                }
+
+                $this->tripStateManager->storeStages($tripId, array_values($stages));
+            }, $generation);
+
+            return;
+        }
 
         $this->executeWithTracking($tripId, ComputationName::EVENTS, function () use ($tripId, $stages, $startDate, $locale): void {
             // Collect raw events per stage first, then enrich with Wikidata in one batch
@@ -86,7 +114,7 @@ final readonly class ScanEventsHandler extends AbstractTripMessageHandler
 
                 $stageDate = $startDate->modify(\sprintf('+%d days', $i));
                 $events = $this->fetchEventsForStage($stage, $stageDate);
-                $events = [...$events, ...$this->fetchMarketsForStage($stage, $stageDate)];
+                $events = [...$events, ...$this->fetchMarketsForStage($stage, $stageDate, $locale)];
                 $eventsByStage[$i] = $events;
             }
 
@@ -130,31 +158,10 @@ final readonly class ScanEventsHandler extends AbstractTripMessageHandler
                     $stage->addEvent($event);
                 }
 
-                $payload = [
+                $this->publisher->publish($tripId, MercureEventType::EVENTS_FOUND, [
                     'stageIndex' => $i,
-                    'events' => array_map(
-                        static fn (Event $e): array => [
-                            'name' => $e->name,
-                            'type' => $e->type,
-                            'lat' => $e->lat,
-                            'lon' => $e->lon,
-                            'startDate' => $e->startDate->format(\DateTimeInterface::ATOM),
-                            'endDate' => $e->endDate->format(\DateTimeInterface::ATOM),
-                            'url' => $e->url,
-                            'description' => $e->description,
-                            'priceMin' => $e->priceMin,
-                            'distanceToEndPoint' => $e->distanceToEndPoint,
-                            'source' => $e->source,
-                            'wikidataId' => $e->wikidataId,
-                            'imageUrl' => $e->imageUrl,
-                            'wikipediaUrl' => $e->wikipediaUrl,
-                            'openingHours' => $e->openingHours,
-                        ],
-                        $enrichedEvents,
-                    ),
-                ];
-
-                $this->publisher->publish($tripId, MercureEventType::EVENTS_FOUND, $payload);
+                    'events' => array_map($this->eventToArray(...), $enrichedEvents),
+                ]);
 
                 $stages[$i] = $stage;
             }
@@ -181,18 +188,34 @@ final readonly class ScanEventsHandler extends AbstractTripMessageHandler
 
         $dateStr = $stageDate->format('Y-m-d');
 
-        $response = $this->dataTourismeClient->request('/', [
-            '@type' => 'schema:Event',
-            'startDate[before]' => $dateStr,
-            'endDate[after]' => $dateStr,
-            'latitude[gte]' => $minLat,
-            'latitude[lte]' => $maxLat,
-            'longitude[gte]' => $minLon,
-            'longitude[lte]' => $maxLon,
+        $response = $this->dataTourismeClient->request('/api/v1/events', [
+            'filters[0][path]' => '@type',
+            'filters[0][operator]' => 'in',
+            'filters[0][value]' => implode(',', self::TARGETED_TYPES),
+            'filters[1][path]' => 'startDate',
+            'filters[1][operator]' => 'lte',
+            'filters[1][value]' => $dateStr,
+            'filters[2][path]' => 'endDate',
+            'filters[2][operator]' => 'gte',
+            'filters[2][value]' => $dateStr,
+            'filters[3][path]' => 'hasGeometry.latitude',
+            'filters[3][operator]' => 'gte',
+            'filters[3][value]' => $minLat,
+            'filters[4][path]' => 'hasGeometry.latitude',
+            'filters[4][operator]' => 'lte',
+            'filters[4][value]' => $maxLat,
+            'filters[5][path]' => 'hasGeometry.longitude',
+            'filters[5][operator]' => 'gte',
+            'filters[5][value]' => $minLon,
+            'filters[6][path]' => 'hasGeometry.longitude',
+            'filters[6][operator]' => 'lte',
+            'filters[6][value]' => $maxLon,
         ]);
 
         /** @var list<array<string, mixed>> $results */
-        $results = \is_array($response['results'] ?? null) ? $response['results'] : [];
+        $results = \is_array($response['results'] ?? null) ? $response['results'] : (
+            \is_array($response['member'] ?? null) ? $response['member'] : []
+        );
 
         $events = [];
 
@@ -255,7 +278,7 @@ final readonly class ScanEventsHandler extends AbstractTripMessageHandler
     /**
      * @return list<Event>
      */
-    private function fetchMarketsForStage(Stage $stage, \DateTimeImmutable $stageDate): array
+    private function fetchMarketsForStage(Stage $stage, \DateTimeImmutable $stageDate, string $locale): array
     {
         $dayOfWeek = (int) $stageDate->format('N');
 
@@ -294,7 +317,7 @@ final readonly class ScanEventsHandler extends AbstractTripMessageHandler
                 lon: $market->getLon(),
                 startDate: $startDate,
                 endDate: $endDate,
-                description: 'Marché hebdomadaire',
+                description: $this->translator->trans('market.weekly_description', [], 'messages', $locale),
                 distanceToEndPoint: $distanceToEndPoint,
                 source: 'data_gouv_markets',
             );
@@ -478,5 +501,29 @@ final readonly class ScanEventsHandler extends AbstractTripMessageHandler
         }
 
         return null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function eventToArray(Event $e): array
+    {
+        return [
+            'name' => $e->name,
+            'type' => $e->type,
+            'lat' => $e->lat,
+            'lon' => $e->lon,
+            'startDate' => $e->startDate->format(\DateTimeInterface::ATOM),
+            'endDate' => $e->endDate->format(\DateTimeInterface::ATOM),
+            'url' => $e->url,
+            'description' => $e->description,
+            'priceMin' => $e->priceMin,
+            'distanceToEndPoint' => $e->distanceToEndPoint,
+            'source' => $e->source,
+            'wikidataId' => $e->wikidataId,
+            'imageUrl' => $e->imageUrl,
+            'wikipediaUrl' => $e->wikipediaUrl,
+            'openingHours' => $e->openingHours,
+        ];
     }
 }

--- a/api/src/MessageHandler/ScanEventsHandler.php
+++ b/api/src/MessageHandler/ScanEventsHandler.php
@@ -15,6 +15,7 @@ use App\Mercure\MercureEventType;
 use App\Mercure\TripUpdatePublisherInterface;
 use App\Message\ScanEvents;
 use App\Repository\TripRequestRepositoryInterface;
+use App\Wikidata\WikidataEnricherInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
@@ -41,6 +42,7 @@ final readonly class ScanEventsHandler extends AbstractTripMessageHandler
         private TripRequestRepositoryInterface $tripStateManager,
         private DataTourismeClientInterface $dataTourismeClient,
         private GeoDistanceInterface $haversine,
+        private WikidataEnricherInterface $wikidataEnricher,
     ) {
         parent::__construct($computationTracker, $publisher, $generationTracker, $logger);
     }
@@ -67,16 +69,58 @@ final readonly class ScanEventsHandler extends AbstractTripMessageHandler
             return;
         }
 
-        $this->executeWithTracking($tripId, ComputationName::EVENTS, function () use ($tripId, $stages, $startDate, $generation): void {
+        $locale = $this->tripStateManager->getLocale($tripId) ?? 'en';
+
+        $this->executeWithTracking($tripId, ComputationName::EVENTS, function () use ($tripId, $stages, $startDate, $locale, $generation): void {
+            // Collect raw events per stage first, then enrich with Wikidata in one batch
+            /** @var array<int, list<Event>> $eventsByStage */
+            $eventsByStage = [];
             foreach ($stages as $i => $stage) {
                 if ($stage->isRestDay) {
                     continue;
                 }
 
                 $stageDate = $startDate->modify(\sprintf('+%d days', $i));
-                $events = $this->fetchEventsForStage($stage, $stageDate);
+                $eventsByStage[$i] = $this->fetchEventsForStage($stage, $stageDate);
+            }
 
+            // Wikidata enrichment: collect all Q-IDs and fetch in one batch
+            $allEvents = [] !== $eventsByStage ? array_merge(...array_values($eventsByStage)) : [];
+            $qIds = array_values(array_filter(array_unique(array_map(
+                static fn (Event $e): ?string => $e->wikidataId,
+                $allEvents,
+            ))));
+            $wikidataEnrichments = [] !== $qIds ? $this->wikidataEnricher->enrichBatch($qIds, $locale) : [];
+
+            foreach ($eventsByStage as $i => $events) {
+                $enrichedEvents = [];
                 foreach ($events as $event) {
+                    if (null !== $event->wikidataId && isset($wikidataEnrichments[$event->wikidataId])) {
+                        $wikidata = $wikidataEnrichments[$event->wikidataId];
+                        $event = new Event(
+                            name: $event->name,
+                            type: $event->type,
+                            lat: $event->lat,
+                            lon: $event->lon,
+                            startDate: $event->startDate,
+                            endDate: $event->endDate,
+                            url: $event->url,
+                            description: $event->description,
+                            priceMin: $event->priceMin,
+                            distanceToEndPoint: $event->distanceToEndPoint,
+                            source: $event->source,
+                            wikidataId: $event->wikidataId,
+                            imageUrl: $event->imageUrl ?? $wikidata['imageUrl'] ?? null,
+                            wikipediaUrl: $event->wikipediaUrl ?? $wikidata['wikipediaUrl'] ?? null,
+                            openingHours: $event->openingHours ?? $wikidata['openingHours'] ?? null,
+                        );
+                    }
+
+                    $enrichedEvents[] = $event;
+                }
+
+                $stage = $stages[$i];
+                foreach ($enrichedEvents as $event) {
                     $stage->addEvent($event);
                 }
 
@@ -96,8 +140,11 @@ final readonly class ScanEventsHandler extends AbstractTripMessageHandler
                             'distanceToEndPoint' => $e->distanceToEndPoint,
                             'source' => $e->source,
                             'wikidataId' => $e->wikidataId,
+                            'imageUrl' => $e->imageUrl,
+                            'wikipediaUrl' => $e->wikipediaUrl,
+                            'openingHours' => $e->openingHours,
                         ],
-                        $events,
+                        $enrichedEvents,
                     ),
                 ];
 

--- a/api/src/MessageHandler/ScanEventsHandler.php
+++ b/api/src/MessageHandler/ScanEventsHandler.php
@@ -1,0 +1,384 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MessageHandler;
+
+use App\ApiResource\Model\Event;
+use App\ApiResource\Stage;
+use App\ComputationTracker\ComputationTrackerInterface;
+use App\ComputationTracker\TripGenerationTrackerInterface;
+use App\DataTourisme\DataTourismeClientInterface;
+use App\Enum\ComputationName;
+use App\Geo\GeoDistanceInterface;
+use App\Mercure\MercureEventType;
+use App\Mercure\TripUpdatePublisherInterface;
+use App\Message\ScanEvents;
+use App\Repository\TripRequestRepositoryInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler]
+final readonly class ScanEventsHandler extends AbstractTripMessageHandler
+{
+    private const int EVENT_RADIUS_METERS = 20_000;
+
+    private const float DEGREES_PER_METER = 1.0 / 111_320.0;
+
+    /** @var list<string> */
+    private const array TARGETED_TYPES = [
+        'schema:Festival',
+        'schema:Exhibition',
+        'schema:MusicEvent',
+        'urn:resource:FairOrShow',
+    ];
+
+    public function __construct(
+        ComputationTrackerInterface $computationTracker,
+        TripUpdatePublisherInterface $publisher,
+        TripGenerationTrackerInterface $generationTracker,
+        LoggerInterface $logger,
+        private TripRequestRepositoryInterface $tripStateManager,
+        private DataTourismeClientInterface $dataTourismeClient,
+        private GeoDistanceInterface $haversine,
+    ) {
+        parent::__construct($computationTracker, $publisher, $generationTracker, $logger);
+    }
+
+    public function __invoke(ScanEvents $message): void
+    {
+        $tripId = $message->tripId;
+        $generation = $message->generation;
+
+        if (!$this->dataTourismeClient->isEnabled()) {
+            return;
+        }
+
+        $stages = $this->tripStateManager->getStages($tripId);
+
+        if (null === $stages) {
+            return;
+        }
+
+        $request = $this->tripStateManager->getRequest($tripId);
+        $startDate = $request?->startDate;
+
+        if (!$startDate instanceof \DateTimeImmutable) {
+            return;
+        }
+
+        $this->executeWithTracking($tripId, ComputationName::EVENTS, function () use ($tripId, $stages, $startDate, $generation): void {
+            foreach ($stages as $i => $stage) {
+                if ($stage->isRestDay) {
+                    continue;
+                }
+
+                $stageDate = $startDate->modify(\sprintf('+%d days', $i));
+                $events = $this->fetchEventsForStage($stage, $stageDate);
+
+                foreach ($events as $event) {
+                    $stage->addEvent($event);
+                }
+
+                $payload = [
+                    'stageIndex' => $i,
+                    'events' => array_map(
+                        static fn (Event $e): array => [
+                            'name' => $e->name,
+                            'type' => $e->type,
+                            'lat' => $e->lat,
+                            'lon' => $e->lon,
+                            'startDate' => $e->startDate->format(\DateTimeInterface::ATOM),
+                            'endDate' => $e->endDate->format(\DateTimeInterface::ATOM),
+                            'url' => $e->url,
+                            'description' => $e->description,
+                            'priceMin' => $e->priceMin,
+                            'distanceToEndPoint' => $e->distanceToEndPoint,
+                            'source' => $e->source,
+                            'wikidataId' => $e->wikidataId,
+                        ],
+                        $events,
+                    ),
+                ];
+
+                $this->publisher->publish($tripId, MercureEventType::EVENTS_FOUND, $payload);
+
+                $stages[$i] = $stage;
+            }
+
+            $this->tripStateManager->storeStages($tripId, array_values($stages));
+        }, $generation);
+    }
+
+    /**
+     * @return list<Event>
+     */
+    private function fetchEventsForStage(Stage $stage, \DateTimeImmutable $stageDate): array
+    {
+        $lat = $stage->endPoint->lat;
+        $lon = $stage->endPoint->lon;
+
+        $radiusDeg = self::EVENT_RADIUS_METERS * self::DEGREES_PER_METER;
+        $minLat = $lat - $radiusDeg;
+        $maxLat = $lat + $radiusDeg;
+        $lonFactor = abs(cos(deg2rad($lat)));
+        $lonDeg = 0.0 < $lonFactor ? $radiusDeg / $lonFactor : $radiusDeg;
+        $minLon = $lon - $lonDeg;
+        $maxLon = $lon + $lonDeg;
+
+        $dateStr = $stageDate->format('Y-m-d');
+
+        $response = $this->dataTourismeClient->request('/', [
+            '@type' => 'schema:Event',
+            'startDate[before]' => $dateStr,
+            'endDate[after]' => $dateStr,
+            'latitude[gte]' => $minLat,
+            'latitude[lte]' => $maxLat,
+            'longitude[gte]' => $minLon,
+            'longitude[lte]' => $maxLon,
+        ]);
+
+        /** @var list<array<string, mixed>> $results */
+        $results = \is_array($response['results'] ?? null) ? $response['results'] : [];
+
+        $events = [];
+
+        foreach ($results as $result) {
+            $types = (array) ($result['@type'] ?? []);
+            $matchedType = null;
+            foreach (self::TARGETED_TYPES as $targeted) {
+                if (\in_array($targeted, $types, true)) {
+                    $matchedType = $targeted;
+                    break;
+                }
+            }
+
+            if (null === $matchedType) {
+                continue;
+            }
+
+            $eventLat = $this->extractLat($result);
+            $eventLon = $this->extractLon($result);
+
+            if (null === $eventLat || null === $eventLon) {
+                continue;
+            }
+
+            $startDate = $this->extractDate($result, 'startDate');
+            $endDate = $this->extractDate($result, 'endDate');
+
+            if (null === $startDate || null === $endDate) {
+                continue;
+            }
+
+            $name = $this->extractLabel($result);
+
+            if (null === $name) {
+                continue;
+            }
+
+            $distanceToEndPoint = $this->haversine->inMeters(
+                $eventLat,
+                $eventLon,
+                $stage->endPoint->lat,
+                $stage->endPoint->lon,
+            );
+
+            $events[] = new Event(
+                name: $name,
+                type: $matchedType,
+                lat: $eventLat,
+                lon: $eventLon,
+                startDate: $startDate,
+                endDate: $endDate,
+                url: $this->extractUrl($result),
+                description: $this->extractDescription($result),
+                priceMin: $this->extractPriceMin($result),
+                distanceToEndPoint: $distanceToEndPoint,
+                source: 'datatourisme',
+                wikidataId: $this->extractWikidataId($result),
+            );
+        }
+
+        usort($events, static fn (Event $a, Event $b): int => $a->startDate <=> $b->startDate);
+
+        return $events;
+    }
+
+    /**
+     * @param array<string, mixed> $result
+     */
+    private function extractLat(array $result): ?float
+    {
+        $geometry = $result['hasGeometry'] ?? null;
+
+        if (\is_array($geometry)) {
+            $lat = $geometry['latitude'] ?? $geometry['lat'] ?? null;
+            if (null !== $lat) {
+                return (float) $lat;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, mixed> $result
+     */
+    private function extractLon(array $result): ?float
+    {
+        $geometry = $result['hasGeometry'] ?? null;
+
+        if (\is_array($geometry)) {
+            $lon = $geometry['longitude'] ?? $geometry['lon'] ?? null;
+            if (null !== $lon) {
+                return (float) $lon;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, mixed> $result
+     */
+    private function extractDate(array $result, string $field): ?\DateTimeImmutable
+    {
+        $value = $result[$field] ?? null;
+
+        if (!\is_string($value)) {
+            return null;
+        }
+
+        try {
+            return new \DateTimeImmutable($value);
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $result
+     */
+    private function extractLabel(array $result): ?string
+    {
+        $label = $result['rdfs:label'] ?? null;
+
+        if (\is_string($label)) {
+            return $label;
+        }
+
+        if (\is_array($label)) {
+            $first = array_values($label)[0] ?? null;
+
+            return \is_string($first) ? $first : null;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, mixed> $result
+     */
+    private function extractUrl(array $result): ?string
+    {
+        $url = $result['foaf:homepage'] ?? null;
+
+        return \is_string($url) ? $url : null;
+    }
+
+    /**
+     * @param array<string, mixed> $result
+     */
+    private function extractDescription(array $result): ?string
+    {
+        $desc = $result['shortDescription'] ?? null;
+
+        if (\is_string($desc)) {
+            return $desc;
+        }
+
+        if (\is_array($desc)) {
+            $first = array_values($desc)[0] ?? null;
+
+            return \is_string($first) ? $first : null;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, mixed> $result
+     */
+    private function extractPriceMin(array $result): ?float
+    {
+        $offers = $result['offers'] ?? null;
+
+        if (!\is_array($offers)) {
+            return null;
+        }
+
+        foreach ($offers as $offer) {
+            if (!\is_array($offer)) {
+                continue;
+            }
+
+            $priceSpec = $offer['priceSpecification'] ?? null;
+
+            if (!\is_array($priceSpec)) {
+                continue;
+            }
+
+            foreach ($priceSpec as $spec) {
+                if (!\is_array($spec)) {
+                    continue;
+                }
+
+                $price = $spec['minPrice'] ?? $spec['price'] ?? null;
+                if (null !== $price) {
+                    return (float) $price;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, mixed> $result
+     */
+    private function extractWikidataId(array $result): ?string
+    {
+        $sameAs = $result['owl:sameAs'] ?? null;
+
+        if (\is_string($sameAs)) {
+            return $this->parseWikidataId($sameAs);
+        }
+
+        if (\is_array($sameAs)) {
+            foreach ($sameAs as $uri) {
+                if (!\is_string($uri)) {
+                    continue;
+                }
+
+                $id = $this->parseWikidataId($uri);
+                if (null !== $id) {
+                    return $id;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private function parseWikidataId(string $uri): ?string
+    {
+        if (str_contains($uri, 'wikidata.org/entity/')) {
+            $parts = explode('/', $uri);
+
+            return end($parts) ?: null;
+        }
+
+        return null;
+    }
+}

--- a/api/src/Repository/MarketRepository.php
+++ b/api/src/Repository/MarketRepository.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\Market;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<Market>
+ */
+final class MarketRepository extends ServiceEntityRepository implements MarketRepositoryInterface
+{
+    private const float DEGREES_PER_METER = 1.0 / 111_320.0;
+
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Market::class);
+    }
+
+    /**
+     * @return list<Market>
+     */
+    public function findNearEndpoint(
+        float $lat,
+        float $lon,
+        int $radiusMeters,
+        int $dayOfWeek,
+    ): array {
+        $radiusDeg = $radiusMeters * self::DEGREES_PER_METER;
+        $lonFactor = abs(cos(deg2rad($lat)));
+        $lonDeg = 0.0 < $lonFactor ? $radiusDeg / $lonFactor : $radiusDeg;
+
+        $minLat = $lat - $radiusDeg;
+        $maxLat = $lat + $radiusDeg;
+        $minLon = $lon - $lonDeg;
+        $maxLon = $lon + $lonDeg;
+
+        /** @var list<Market> $candidates */
+        $candidates = $this->createQueryBuilder('m')
+            ->where('m.dayOfWeek = :dayOfWeek')
+            ->andWhere('m.lat BETWEEN :minLat AND :maxLat')
+            ->andWhere('m.lon BETWEEN :minLon AND :maxLon')
+            ->setParameter('dayOfWeek', $dayOfWeek)
+            ->setParameter('minLat', $minLat)
+            ->setParameter('maxLat', $maxLat)
+            ->setParameter('minLon', $minLon)
+            ->setParameter('maxLon', $maxLon)
+            ->getQuery()
+            ->getResult();
+
+        return array_values(array_filter(
+            $candidates,
+            fn (Market $market): bool => $this->haversineMeters(
+                $lat,
+                $lon,
+                $market->getLat(),
+                $market->getLon(),
+            ) <= $radiusMeters,
+        ));
+    }
+
+    public function findByExternalId(string $externalId): ?Market
+    {
+        return $this->findOneBy(['externalId' => $externalId]);
+    }
+
+    public function save(Market $market, bool $flush = false): void
+    {
+        $this->getEntityManager()->persist($market);
+
+        if ($flush) {
+            $this->getEntityManager()->flush();
+        }
+    }
+
+    private function haversineMeters(float $lat1, float $lon1, float $lat2, float $lon2): float
+    {
+        $earthRadius = 6_371_000.0;
+        $dLat = deg2rad($lat2 - $lat1);
+        $dLon = deg2rad($lon2 - $lon1);
+        $a = sin($dLat / 2) ** 2
+            + cos(deg2rad($lat1)) * cos(deg2rad($lat2)) * sin($dLon / 2) ** 2;
+
+        return $earthRadius * 2 * asin(sqrt($a));
+    }
+}

--- a/api/src/Repository/MarketRepositoryInterface.php
+++ b/api/src/Repository/MarketRepositoryInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\Market;
+
+interface MarketRepositoryInterface
+{
+    /**
+     * Find markets near a geographic point filtered by day of week.
+     *
+     * Uses a bounding-box pre-filter for speed, then haversine for precision.
+     *
+     * @return list<Market>
+     */
+    public function findNearEndpoint(
+        float $lat,
+        float $lon,
+        int $radiusMeters,
+        int $dayOfWeek,
+    ): array;
+
+    public function findByExternalId(string $externalId): ?Market;
+
+    public function save(Market $market, bool $flush = false): void;
+}

--- a/api/src/Scanner/OsmOverpassQueryBuilder.php
+++ b/api/src/Scanner/OsmOverpassQueryBuilder.php
@@ -35,21 +35,34 @@ final readonly class OsmOverpassQueryBuilder implements QueryBuilderInterface
 
     /**
      * @param array<int, Coordinate> $endPoints
-     * @param list<string>           $enabledTypes OSM tourism types to include (default: all 7)
+     * @param list<string>           $enabledTypes OSM accommodation types to include (default: all 9)
      */
     public function buildAccommodationQuery(array $endPoints, int $radiusMeters = self::DEFAULT_ACCOMMODATION_RADIUS_METERS, array $enabledTypes = TripRequest::ALL_ACCOMMODATION_TYPES): string
     {
-        $typesPattern = implode('|', array_map(preg_quote(...), $enabledTypes, array_fill(0, \count($enabledTypes), '/')));
+        $tourismTypes = array_values(array_filter($enabledTypes, static fn (string $t): bool => 'shelter' !== $t));
+        $includeShelter = \in_array('shelter', $enabledTypes, true);
 
         $filters = '';
         foreach ($endPoints as $point) {
-            $filters .= \sprintf(
-                'nwr["tourism"~"^(%s)$"](around:%d,%F,%F);',
-                $typesPattern,
-                $radiusMeters,
-                $point->lat,
-                $point->lon,
-            );
+            if ([] !== $tourismTypes) {
+                $typesPattern = implode('|', array_map(preg_quote(...), $tourismTypes, array_fill(0, \count($tourismTypes), '/')));
+                $filters .= \sprintf(
+                    'nwr["tourism"~"^(%s)$"](around:%d,%F,%F);',
+                    $typesPattern,
+                    $radiusMeters,
+                    $point->lat,
+                    $point->lon,
+                );
+            }
+
+            if ($includeShelter) {
+                $filters .= \sprintf(
+                    'nwr["amenity"="shelter"]["shelter_type"~"^(basic_hut|weather_shelter|lean_to)$"](around:%d,%F,%F);',
+                    $radiusMeters,
+                    $point->lat,
+                    $point->lon,
+                );
+            }
         }
 
         return \sprintf('[out:json][timeout:15];(%s);out center 100;', $filters);

--- a/api/src/Scanner/QueryBuilderInterface.php
+++ b/api/src/Scanner/QueryBuilderInterface.php
@@ -27,7 +27,7 @@ interface QueryBuilderInterface
 
     /**
      * @param array<int, Coordinate> $endPoints
-     * @param list<string>           $enabledTypes OSM tourism types to include (default: all 7)
+     * @param list<string>           $enabledTypes OSM accommodation types to include (default: all 9)
      */
     public function buildAccommodationQuery(array $endPoints, int $radiusMeters = self::DEFAULT_ACCOMMODATION_RADIUS_METERS, array $enabledTypes = TripRequest::ALL_ACCOMMODATION_TYPES): string;
 

--- a/api/src/Wikidata/WikidataClient.php
+++ b/api/src/Wikidata/WikidataClient.php
@@ -31,23 +31,32 @@ final readonly class WikidataClient implements WikidataClientInterface
         $cacheKey = 'wikidata.'.hash('xxh128', $sparql);
 
         try {
-            /** @var list<array<string, array{type: string, value: string}>> */
-            return $this->cache->get($cacheKey, function (ItemInterface $item) use ($sparql): array {
+            /** @var list<array<string, array{type: string, value: string}>> $result */
+            $result = $this->cache->get($cacheKey, function (ItemInterface $item) use ($sparql): array {
                 $item->expiresAfter(self::DEFAULT_TTL);
 
                 $response = $this->httpClient->request('GET', 'https://query.wikidata.org/sparql', [
                     'query' => ['query' => $sparql, 'format' => 'json'],
                 ]);
 
-                /** @var array<string, mixed> $data */
                 $data = $response->toArray();
+                $results = $data['results'] ?? [];
+                if (!\is_array($results)) {
+                    return [];
+                }
 
-                /** @var list<array<string, array{type: string, value: string}>> */
-                return $data['results']['bindings'] ?? [];
+                $bindings = $results['bindings'] ?? [];
+                if (!\is_array($bindings)) {
+                    return [];
+                }
+
+                return array_values($bindings);
             });
-        } catch (\Throwable $e) {
+
+            return $result;
+        } catch (\Throwable $throwable) {
             $this->logger->warning('Wikidata SPARQL query failed, returning empty result.', [
-                'error' => $e->getMessage(),
+                'error' => $throwable->getMessage(),
             ]);
 
             return [];

--- a/api/src/Wikidata/WikidataClient.php
+++ b/api/src/Wikidata/WikidataClient.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Wikidata;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+final readonly class WikidataClient implements WikidataClientInterface
+{
+    private const int DEFAULT_TTL = 604800; // 7 days
+
+    public function __construct(
+        #[Autowire(service: 'wikidata.client')]
+        private HttpClientInterface $httpClient,
+        #[Autowire(service: 'cache.wikidata')]
+        private CacheInterface $cache,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @return list<array<string, array{type: string, value: string}>>
+     */
+    public function query(string $sparql): array
+    {
+        $cacheKey = 'wikidata.'.hash('xxh128', $sparql);
+
+        try {
+            /** @var list<array<string, array{type: string, value: string}>> */
+            return $this->cache->get($cacheKey, function (ItemInterface $item) use ($sparql): array {
+                $item->expiresAfter(self::DEFAULT_TTL);
+
+                $response = $this->httpClient->request('GET', 'https://query.wikidata.org/sparql', [
+                    'query' => ['query' => $sparql, 'format' => 'json'],
+                ]);
+
+                /** @var array<string, mixed> $data */
+                $data = $response->toArray();
+
+                /** @var list<array<string, array{type: string, value: string}>> */
+                return $data['results']['bindings'] ?? [];
+            });
+        } catch (\Throwable $e) {
+            $this->logger->warning('Wikidata SPARQL query failed, returning empty result.', [
+                'error' => $e->getMessage(),
+            ]);
+
+            return [];
+        }
+    }
+}

--- a/api/src/Wikidata/WikidataClientInterface.php
+++ b/api/src/Wikidata/WikidataClientInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Wikidata;
+
+interface WikidataClientInterface
+{
+    /**
+     * Executes a SPARQL query against the Wikidata Query Service.
+     * Returns the decoded JSON bindings array, or an empty array on error.
+     *
+     * @return list<array<string, array{type: string, value: string}>>
+     */
+    public function query(string $sparql): array;
+}

--- a/api/src/Wikidata/WikidataEnricher.php
+++ b/api/src/Wikidata/WikidataEnricher.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Wikidata;
+
+final readonly class WikidataEnricher implements WikidataEnricherInterface
+{
+    private const int BATCH_SIZE = 50;
+
+    public function __construct(
+        private WikidataClientInterface $client,
+    ) {
+    }
+
+    /**
+     * @param list<string> $qIds
+     *
+     * @return array<string, array{label?: string, description?: string, imageUrl?: string, website?: string, openingHours?: string, wikipediaUrl?: string}>
+     */
+    public function enrichBatch(array $qIds, string $locale): array
+    {
+        if ([] === $qIds) {
+            return [];
+        }
+
+        $result = [];
+        $batches = array_chunk($qIds, self::BATCH_SIZE);
+
+        foreach ($batches as $batch) {
+            $batchResult = $this->fetchBatch($batch, $locale);
+            $result = array_merge($result, $batchResult);
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param list<string> $qIds
+     *
+     * @return array<string, array{label?: string, description?: string, imageUrl?: string, website?: string, openingHours?: string, wikipediaUrl?: string}>
+     */
+    private function fetchBatch(array $qIds, string $locale): array
+    {
+        $values = implode(' ', array_map(static fn (string $id): string => 'wd:'.$id, $qIds));
+        $lang = strtolower(substr($locale, 0, 2));
+
+        $sparql = <<<SPARQL
+SELECT ?item ?itemLabel ?itemDescription ?image ?website ?openingHours ?article WHERE {
+  VALUES ?item { {$values} }
+  OPTIONAL { ?item wdt:P18 ?image. }
+  OPTIONAL { ?item wdt:P856 ?website. }
+  OPTIONAL { ?item wdt:P8989 ?openingHours. }
+  OPTIONAL {
+    ?article schema:about ?item ;
+             schema:isPartOf <https://{$lang}.wikipedia.org/>.
+  }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "{$lang},en". }
+}
+SPARQL;
+
+        $bindings = $this->client->query($sparql);
+
+        $enrichments = [];
+
+        foreach ($bindings as $row) {
+            $itemUri = $row['item']['value'] ?? null;
+            if (!\is_string($itemUri)) {
+                continue;
+            }
+
+            $parts = explode('/', $itemUri);
+            $qId = end($parts);
+            if (!\is_string($qId) || !str_starts_with($qId, 'Q')) {
+                continue;
+            }
+
+            $entry = $enrichments[$qId] ?? [];
+
+            $label = $row['itemLabel']['value'] ?? null;
+            if (\is_string($label) && '' !== $label && !isset($entry['label'])) {
+                $entry['label'] = $label;
+            }
+
+            $description = $row['itemDescription']['value'] ?? null;
+            if (\is_string($description) && '' !== $description && !isset($entry['description'])) {
+                $entry['description'] = $description;
+            }
+
+            $image = $row['image']['value'] ?? null;
+            if (\is_string($image) && '' !== $image && !isset($entry['imageUrl'])) {
+                $entry['imageUrl'] = $this->buildCommonsThumbUrl($image);
+            }
+
+            $website = $row['website']['value'] ?? null;
+            if (\is_string($website) && '' !== $website && !isset($entry['website'])) {
+                $entry['website'] = $website;
+            }
+
+            $openingHours = $row['openingHours']['value'] ?? null;
+            if (\is_string($openingHours) && '' !== $openingHours && !isset($entry['openingHours'])) {
+                $entry['openingHours'] = $openingHours;
+            }
+
+            $article = $row['article']['value'] ?? null;
+            if (\is_string($article) && '' !== $article && !isset($entry['wikipediaUrl'])) {
+                $entry['wikipediaUrl'] = $article;
+            }
+
+            $enrichments[$qId] = $entry;
+        }
+
+        return $enrichments;
+    }
+
+    /**
+     * Converts a Wikimedia Commons file URI to a direct thumbnail URL (400 px wide).
+     *
+     * Uses the standard Wikimedia Commons thumb URL format.
+     * See https://www.mediawiki.org/wiki/Manual:$wgHashedUploadDirectory
+     */
+    private function buildCommonsThumbUrl(string $fileUri): string
+    {
+        // fileUri looks like: http://commons.wikimedia.org/wiki/Special:FilePath/Foo.jpg
+        // We want: https://commons.wikimedia.org/wiki/Special:FilePath/Foo.jpg?width=400
+        $cleaned = str_replace('http://', 'https://', $fileUri);
+
+        return $cleaned.'?width=400';
+    }
+}

--- a/api/src/Wikidata/WikidataEnricher.php
+++ b/api/src/Wikidata/WikidataEnricher.php
@@ -42,7 +42,12 @@ final readonly class WikidataEnricher implements WikidataEnricherInterface
      */
     private function fetchBatch(array $qIds, string $locale): array
     {
-        $values = implode(' ', array_map(static fn (string $id): string => 'wd:'.$id, $qIds));
+        $safeIds = array_values(array_filter($qIds, static fn (string $id): bool => (bool) preg_match('/^Q\d+$/', $id)));
+        if ([] === $safeIds) {
+            return [];
+        }
+
+        $values = implode(' ', array_map(static fn (string $id): string => 'wd:'.$id, $safeIds));
         $lang = strtolower(substr($locale, 0, 2));
 
         $sparql = <<<SPARQL

--- a/api/src/Wikidata/WikidataEnricherInterface.php
+++ b/api/src/Wikidata/WikidataEnricherInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Wikidata;
+
+interface WikidataEnricherInterface
+{
+    /**
+     * Enriches a batch of Wikidata entities with label, description, image, website,
+     * opening hours, and Wikipedia link. One SPARQL query per 50 Q-IDs.
+     *
+     * Returns an associative array keyed by Q-ID (e.g. "Q12345").
+     * Fields present only when available: label, description, imageUrl, website,
+     * openingHours, wikipediaUrl.
+     *
+     * Errors (timeout, 5xx) are handled silently — returns empty array.
+     *
+     * @param list<string> $qIds   Wikidata entity IDs (e.g. ["Q12345", "Q67890"])
+     * @param string       $locale BCP-47 language tag used as primary language for labels
+     *
+     * @return array<string, array{label?: string, description?: string, imageUrl?: string, website?: string, openingHours?: string, wikipediaUrl?: string}>
+     */
+    public function enrichBatch(array $qIds, string $locale): array;
+}

--- a/api/tests/Fixtures/wikidata/batch-response.json
+++ b/api/tests/Fixtures/wikidata/batch-response.json
@@ -1,0 +1,22 @@
+{
+  "results": {
+    "bindings": [
+      {
+        "item": { "type": "uri", "value": "http://www.wikidata.org/entity/Q12345" },
+        "itemLabel": { "type": "literal", "value": "Château de Versailles" },
+        "itemDescription": { "type": "literal", "value": "Palais royal situé à Versailles, France." },
+        "image": { "type": "uri", "value": "http://commons.wikimedia.org/wiki/Special:FilePath/Versailles_Palace.jpg" },
+        "website": { "type": "uri", "value": "https://www.chateauversailles.fr" },
+        "openingHours": { "type": "literal", "value": "Tu-Su 09:00-17:30" },
+        "article": { "type": "uri", "value": "https://fr.wikipedia.org/wiki/Château_de_Versailles" }
+      },
+      {
+        "item": { "type": "uri", "value": "http://www.wikidata.org/entity/Q67890" },
+        "itemLabel": { "type": "literal", "value": "Tour Eiffel" },
+        "itemDescription": { "type": "literal", "value": "Monument emblématique de Paris." },
+        "image": { "type": "uri", "value": "http://commons.wikimedia.org/wiki/Special:FilePath/Tour_Eiffel.jpg" },
+        "article": { "type": "uri", "value": "https://fr.wikipedia.org/wiki/Tour_Eiffel" }
+      }
+    ]
+  }
+}

--- a/api/tests/Functional/stage-schema.json
+++ b/api/tests/Functional/stage-schema.json
@@ -8,6 +8,7 @@
     "alerts",
     "pois",
     "accommodations",
+    "events",
     "trip",
     "dayNumber",
     "distance",
@@ -53,6 +54,15 @@
       }
     },
     "accommodations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [],
+        "additionalProperties": false,
+        "properties": {}
+      }
+    },
+    "events": {
       "type": "array",
       "items": {
         "type": "object",

--- a/api/tests/Functional/trip-schema.json
+++ b/api/tests/Functional/trip-schema.json
@@ -45,7 +45,8 @@
         "cultural_pois",
         "railway_stations",
         "health_services",
-        "border_crossing"
+        "border_crossing",
+        "events"
       ],
       "additionalProperties": false,
       "properties": {
@@ -176,6 +177,15 @@
           ]
         },
         "border_crossing": {
+          "type": "string",
+          "enum": [
+            "pending",
+            "running",
+            "done",
+            "failed"
+          ]
+        },
+        "events": {
           "type": "string",
           "enum": [
             "pending",

--- a/api/tests/Unit/AccommodationSource/AccommodationSourceRegistryTest.php
+++ b/api/tests/Unit/AccommodationSource/AccommodationSourceRegistryTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\AccommodationSource;
+
+use App\AccommodationSource\AccommodationSourceInterface;
+use App\AccommodationSource\AccommodationSourceRegistry;
+use App\ApiResource\Model\Coordinate;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class AccommodationSourceRegistryTest extends TestCase
+{
+    #[Test]
+    public function fetchAllConcatenatesResultsFromAllEnabledSources(): void
+    {
+        $endPoints = [new Coordinate(48.5, 2.5)];
+
+        $candidateA = $this->makeCandidate('Hotel A', 'osm');
+        $candidateB = $this->makeCandidate('Hotel B', 'datatourisme');
+
+        $sourceA = $this->createStub(AccommodationSourceInterface::class);
+        $sourceA->method('isEnabled')->willReturn(true);
+        $sourceA->method('fetch')->willReturn([$candidateA]);
+
+        $sourceB = $this->createStub(AccommodationSourceInterface::class);
+        $sourceB->method('isEnabled')->willReturn(true);
+        $sourceB->method('fetch')->willReturn([$candidateB]);
+
+        $registry = new AccommodationSourceRegistry([$sourceA, $sourceB]);
+        $results = $registry->fetchAll($endPoints, 5000, ['hotel']);
+
+        $this->assertCount(2, $results);
+        $this->assertSame('Hotel A', $results[0]['name']);
+        $this->assertSame('Hotel B', $results[1]['name']);
+    }
+
+    #[Test]
+    public function fetchAllSkipsDisabledSources(): void
+    {
+        $endPoints = [new Coordinate(48.5, 2.5)];
+
+        $candidateA = $this->makeCandidate('Hotel A', 'osm');
+
+        $sourceA = $this->createStub(AccommodationSourceInterface::class);
+        $sourceA->method('isEnabled')->willReturn(true);
+        $sourceA->method('fetch')->willReturn([$candidateA]);
+
+        $sourceB = $this->createStub(AccommodationSourceInterface::class);
+        $sourceB->method('isEnabled')->willReturn(false);
+        $sourceB->expects($this->never())->method('fetch');
+
+        $registry = new AccommodationSourceRegistry([$sourceA, $sourceB]);
+        $results = $registry->fetchAll($endPoints, 5000, ['hotel']);
+
+        $this->assertCount(1, $results);
+        $this->assertSame('Hotel A', $results[0]['name']);
+    }
+
+    #[Test]
+    public function fetchAllReturnsEmptyArrayWhenNoSourcesEnabled(): void
+    {
+        $source = $this->createStub(AccommodationSourceInterface::class);
+        $source->method('isEnabled')->willReturn(false);
+
+        $registry = new AccommodationSourceRegistry([$source]);
+        $results = $registry->fetchAll([new Coordinate(48.5, 2.5)], 5000, ['hotel']);
+
+        $this->assertSame([], $results);
+    }
+
+    #[Test]
+    public function fetchAllReturnsEmptyArrayWhenNoSources(): void
+    {
+        $registry = new AccommodationSourceRegistry([]);
+        $results = $registry->fetchAll([new Coordinate(48.5, 2.5)], 5000, ['hotel']);
+
+        $this->assertSame([], $results);
+    }
+
+    #[Test]
+    public function fetchAllPassesArgumentsToEachSource(): void
+    {
+        $endPoints = [new Coordinate(48.5, 2.5)];
+        $radiusMeters = 10000;
+        $enabledTypes = ['hotel', 'hostel'];
+
+        $source = $this->createMock(AccommodationSourceInterface::class);
+        $source->method('isEnabled')->willReturn(true);
+        $source->expects($this->once())
+            ->method('fetch')
+            ->with($endPoints, $radiusMeters, $enabledTypes)
+            ->willReturn([]);
+
+        $registry = new AccommodationSourceRegistry([$source]);
+        $registry->fetchAll($endPoints, $radiusMeters, $enabledTypes);
+    }
+
+    /**
+     * @return array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, source: string, wikidataId: ?string}
+     */
+    private function makeCandidate(string $name, string $source): array
+    {
+        return [
+            'name' => $name,
+            'type' => 'hotel',
+            'lat' => 48.6,
+            'lon' => 2.6,
+            'priceMin' => 50.0,
+            'priceMax' => 120.0,
+            'isExact' => false,
+            'url' => null,
+            'tagCount' => 0,
+            'hasWebsite' => false,
+            'tags' => [],
+            'source' => $source,
+            'wikidataId' => null,
+        ];
+    }
+}

--- a/api/tests/Unit/AccommodationSource/AccommodationSourceRegistryTest.php
+++ b/api/tests/Unit/AccommodationSource/AccommodationSourceRegistryTest.php
@@ -47,7 +47,7 @@ final class AccommodationSourceRegistryTest extends TestCase
         $sourceA->method('isEnabled')->willReturn(true);
         $sourceA->method('fetch')->willReturn([$candidateA]);
 
-        $sourceB = $this->createStub(AccommodationSourceInterface::class);
+        $sourceB = $this->createMock(AccommodationSourceInterface::class);
         $sourceB->method('isEnabled')->willReturn(false);
         $sourceB->expects($this->never())->method('fetch');
 

--- a/api/tests/Unit/AccommodationSource/DataTourismeAccommodationSourceTest.php
+++ b/api/tests/Unit/AccommodationSource/DataTourismeAccommodationSourceTest.php
@@ -1,0 +1,254 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\AccommodationSource;
+
+use App\AccommodationSource\DataTourismeAccommodationSource;
+use App\ApiResource\Model\Coordinate;
+use App\DataTourisme\DataTourismeClientInterface;
+use App\Engine\PricingHeuristicEngine;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class DataTourismeAccommodationSourceTest extends TestCase
+{
+    #[Test]
+    public function getNameReturnsDatatourisme(): void
+    {
+        $source = $this->createSource();
+
+        $this->assertSame('datatourisme', $source->getName());
+    }
+
+    #[Test]
+    public function isEnabledDelegatesToClient(): void
+    {
+        $client = $this->createStub(DataTourismeClientInterface::class);
+        $client->method('isEnabled')->willReturn(true);
+
+        $source = $this->createSource($client);
+
+        $this->assertTrue($source->isEnabled());
+    }
+
+    #[Test]
+    public function isEnabledReturnsFalseWhenClientDisabled(): void
+    {
+        $client = $this->createStub(DataTourismeClientInterface::class);
+        $client->method('isEnabled')->willReturn(false);
+
+        $source = $this->createSource($client);
+
+        $this->assertFalse($source->isEnabled());
+    }
+
+    #[Test]
+    public function fetchReturnsEmptyArrayForEmptyEndPoints(): void
+    {
+        $client = $this->createMock(DataTourismeClientInterface::class);
+        $client->expects($this->never())->method('request');
+
+        $source = $this->createSource($client);
+        $results = $source->fetch([], 5000, ['hotel']);
+
+        $this->assertSame([], $results);
+    }
+
+    #[Test]
+    public function fetchMapsHotelItemCorrectly(): void
+    {
+        $client = $this->createStub(DataTourismeClientInterface::class);
+        $client->method('request')->willReturn([
+            'results' => [
+                [
+                    '@type' => ['schema:Hotel'],
+                    'rdfs:label' => 'Hotel du Midi',
+                    'hasGeometry' => ['latitude' => 48.6, 'longitude' => 2.6],
+                    'foaf:homepage' => 'https://hotel-du-midi.fr',
+                ],
+            ],
+        ]);
+
+        $source = $this->createSource($client);
+        $results = $source->fetch([new Coordinate(48.5, 2.5)], 5000, ['hotel']);
+
+        $this->assertCount(1, $results);
+        $this->assertSame('Hotel du Midi', $results[0]['name']);
+        $this->assertSame('hotel', $results[0]['type']);
+        $this->assertSame(48.6, $results[0]['lat']);
+        $this->assertSame(2.6, $results[0]['lon']);
+        $this->assertSame('https://hotel-du-midi.fr', $results[0]['url']);
+        $this->assertSame('datatourisme', $results[0]['source']);
+    }
+
+    #[Test]
+    public function fetchMapsCampgroundToCampSiteType(): void
+    {
+        $client = $this->createStub(DataTourismeClientInterface::class);
+        $client->method('request')->willReturn([
+            'results' => [
+                [
+                    '@type' => ['schema:Campground'],
+                    'rdfs:label' => 'Camping du Lac',
+                    'hasGeometry' => ['latitude' => 47.0, 'longitude' => 3.0],
+                ],
+            ],
+        ]);
+
+        $source = $this->createSource($client);
+        $results = $source->fetch([new Coordinate(47.0, 3.0)], 5000, ['camp_site']);
+
+        $this->assertCount(1, $results);
+        $this->assertSame('camp_site', $results[0]['type']);
+    }
+
+    #[Test]
+    public function fetchExtractsPriceFromOffers(): void
+    {
+        $client = $this->createStub(DataTourismeClientInterface::class);
+        $client->method('request')->willReturn([
+            'results' => [
+                [
+                    '@type' => ['schema:Hotel'],
+                    'rdfs:label' => 'Hotel Pricey',
+                    'hasGeometry' => ['latitude' => 48.6, 'longitude' => 2.6],
+                    'offers' => [
+                        [
+                            'priceSpecification' => [
+                                ['minPrice' => 80, 'maxPrice' => 150],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $source = $this->createSource($client);
+        $results = $source->fetch([new Coordinate(48.5, 2.5)], 5000, ['hotel']);
+
+        $this->assertCount(1, $results);
+        $this->assertSame(80.0, $results[0]['priceMin']);
+        $this->assertSame(150.0, $results[0]['priceMax']);
+        $this->assertTrue($results[0]['isExact']);
+    }
+
+    #[Test]
+    public function fetchUsesHeuristicPricingWhenNoOffers(): void
+    {
+        $client = $this->createStub(DataTourismeClientInterface::class);
+        $client->method('request')->willReturn([
+            'results' => [
+                [
+                    '@type' => ['schema:Hotel'],
+                    'rdfs:label' => 'Hotel Simple',
+                    'hasGeometry' => ['latitude' => 48.6, 'longitude' => 2.6],
+                ],
+            ],
+        ]);
+
+        $source = $this->createSource($client);
+        $results = $source->fetch([new Coordinate(48.5, 2.5)], 5000, ['hotel']);
+
+        $this->assertCount(1, $results);
+        $this->assertFalse($results[0]['isExact']);
+        $this->assertSame(50.0, $results[0]['priceMin']);
+        $this->assertSame(120.0, $results[0]['priceMax']);
+    }
+
+    #[Test]
+    public function fetchExtractsWikidataIdFromOwlSameAs(): void
+    {
+        $client = $this->createStub(DataTourismeClientInterface::class);
+        $client->method('request')->willReturn([
+            'results' => [
+                [
+                    '@type' => ['schema:Hotel'],
+                    'rdfs:label' => 'Hotel Wiki',
+                    'hasGeometry' => ['latitude' => 48.6, 'longitude' => 2.6],
+                    'owl:sameAs' => ['https://www.wikidata.org/wiki/Q99999'],
+                ],
+            ],
+        ]);
+
+        $source = $this->createSource($client);
+        $results = $source->fetch([new Coordinate(48.5, 2.5)], 5000, ['hotel']);
+
+        $this->assertCount(1, $results);
+        $this->assertSame('Q99999', $results[0]['wikidataId']);
+    }
+
+    #[Test]
+    public function fetchSetsNullWikidataIdWhenNoSameAs(): void
+    {
+        $client = $this->createStub(DataTourismeClientInterface::class);
+        $client->method('request')->willReturn([
+            'results' => [
+                [
+                    '@type' => ['schema:Hostel'],
+                    'rdfs:label' => 'Auberge de Jeunesse',
+                    'hasGeometry' => ['latitude' => 45.0, 'longitude' => 4.0],
+                ],
+            ],
+        ]);
+
+        $source = $this->createSource($client);
+        $results = $source->fetch([new Coordinate(45.0, 4.0)], 5000, ['hostel']);
+
+        $this->assertCount(1, $results);
+        $this->assertNull($results[0]['wikidataId']);
+    }
+
+    #[Test]
+    public function fetchSkipsItemsWithoutGeometry(): void
+    {
+        $client = $this->createStub(DataTourismeClientInterface::class);
+        $client->method('request')->willReturn([
+            'results' => [
+                [
+                    '@type' => ['schema:Hotel'],
+                    'rdfs:label' => 'No Geo Hotel',
+                ],
+            ],
+        ]);
+
+        $source = $this->createSource($client);
+        $results = $source->fetch([new Coordinate(48.5, 2.5)], 5000, ['hotel']);
+
+        $this->assertSame([], $results);
+    }
+
+    #[Test]
+    public function fetchFiltersOutDisabledTypes(): void
+    {
+        $client = $this->createStub(DataTourismeClientInterface::class);
+        $client->method('request')->willReturn([
+            'results' => [
+                [
+                    '@type' => ['schema:Hotel'],
+                    'rdfs:label' => 'Hotel Only',
+                    'hasGeometry' => ['latitude' => 48.6, 'longitude' => 2.6],
+                ],
+                [
+                    '@type' => ['schema:Hostel'],
+                    'rdfs:label' => 'Hostel One',
+                    'hasGeometry' => ['latitude' => 48.7, 'longitude' => 2.7],
+                ],
+            ],
+        ]);
+
+        $source = $this->createSource($client);
+        $results = $source->fetch([new Coordinate(48.5, 2.5)], 5000, ['hotel']);
+
+        $this->assertCount(1, $results);
+        $this->assertSame('hotel', $results[0]['type']);
+    }
+
+    private function createSource(?DataTourismeClientInterface $client = null): DataTourismeAccommodationSource
+    {
+        return new DataTourismeAccommodationSource(
+            client: $client ?? $this->createStub(DataTourismeClientInterface::class),
+            pricingEngine: new PricingHeuristicEngine(),
+        );
+    }
+}

--- a/api/tests/Unit/AccommodationSource/OsmAccommodationSourceTest.php
+++ b/api/tests/Unit/AccommodationSource/OsmAccommodationSourceTest.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\AccommodationSource;
+
+use App\AccommodationSource\OsmAccommodationSource;
+use App\ApiResource\Model\Coordinate;
+use App\Engine\PricingHeuristicEngine;
+use App\Scanner\QueryBuilderInterface;
+use App\Scanner\ScannerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class OsmAccommodationSourceTest extends TestCase
+{
+    #[Test]
+    public function getNameReturnsOsm(): void
+    {
+        $source = $this->createSource();
+
+        $this->assertSame('osm', $source->getName());
+    }
+
+    #[Test]
+    public function isEnabledAlwaysReturnsTrue(): void
+    {
+        $source = $this->createSource();
+
+        $this->assertTrue($source->isEnabled());
+    }
+
+    #[Test]
+    public function fetchParsesNodeElementWithTourismTag(): void
+    {
+        $scanner = $this->createStub(ScannerInterface::class);
+        $scanner->method('query')->willReturn([
+            'elements' => [
+                [
+                    'id' => 123,
+                    'type' => 'node',
+                    'lat' => 48.6,
+                    'lon' => 2.6,
+                    'tags' => ['tourism' => 'hotel', 'name' => 'Hotel du Nord'],
+                ],
+            ],
+        ]);
+
+        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
+        $queryBuilder->method('buildAccommodationQuery')->willReturn('query');
+
+        $source = $this->createSource($scanner, $queryBuilder);
+        $results = $source->fetch([new Coordinate(48.5, 2.5)], 5000, ['hotel']);
+
+        $this->assertCount(1, $results);
+        $this->assertSame('Hotel du Nord', $results[0]['name']);
+        $this->assertSame('hotel', $results[0]['type']);
+        $this->assertSame(48.6, $results[0]['lat']);
+        $this->assertSame(2.6, $results[0]['lon']);
+        $this->assertSame('osm', $results[0]['source']);
+    }
+
+    #[Test]
+    public function fetchExtractsWikidataIdFromTags(): void
+    {
+        $scanner = $this->createStub(ScannerInterface::class);
+        $scanner->method('query')->willReturn([
+            'elements' => [
+                [
+                    'id' => 456,
+                    'type' => 'node',
+                    'lat' => 48.6,
+                    'lon' => 2.6,
+                    'tags' => ['tourism' => 'hotel', 'name' => 'Hotel Wikidata', 'wikidata' => 'Q12345'],
+                ],
+            ],
+        ]);
+
+        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
+        $queryBuilder->method('buildAccommodationQuery')->willReturn('query');
+
+        $source = $this->createSource($scanner, $queryBuilder);
+        $results = $source->fetch([new Coordinate(48.5, 2.5)], 5000, ['hotel']);
+
+        $this->assertCount(1, $results);
+        $this->assertSame('Q12345', $results[0]['wikidataId']);
+    }
+
+    #[Test]
+    public function fetchSetsNullWikidataIdWhenTagAbsent(): void
+    {
+        $scanner = $this->createStub(ScannerInterface::class);
+        $scanner->method('query')->willReturn([
+            'elements' => [
+                [
+                    'id' => 789,
+                    'type' => 'node',
+                    'lat' => 48.6,
+                    'lon' => 2.6,
+                    'tags' => ['tourism' => 'hostel', 'name' => 'Hostel Central'],
+                ],
+            ],
+        ]);
+
+        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
+        $queryBuilder->method('buildAccommodationQuery')->willReturn('query');
+
+        $source = $this->createSource($scanner, $queryBuilder);
+        $results = $source->fetch([new Coordinate(48.5, 2.5)], 5000, ['hostel']);
+
+        $this->assertCount(1, $results);
+        $this->assertNull($results[0]['wikidataId']);
+    }
+
+    #[Test]
+    public function fetchUsesWayCenterCoordinatesWhenLatLonAbsent(): void
+    {
+        $scanner = $this->createStub(ScannerInterface::class);
+        $scanner->method('query')->willReturn([
+            'elements' => [
+                [
+                    'id' => 101,
+                    'type' => 'way',
+                    'center' => ['lat' => 47.1, 'lon' => 3.2],
+                    'tags' => ['tourism' => 'camp_site', 'name' => 'Camping du Lac'],
+                ],
+            ],
+        ]);
+
+        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
+        $queryBuilder->method('buildAccommodationQuery')->willReturn('query');
+
+        $source = $this->createSource($scanner, $queryBuilder);
+        $results = $source->fetch([new Coordinate(47.0, 3.0)], 5000, ['camp_site']);
+
+        $this->assertCount(1, $results);
+        $this->assertSame(47.1, $results[0]['lat']);
+        $this->assertSame(3.2, $results[0]['lon']);
+    }
+
+    #[Test]
+    public function fetchSkipsElementsWithoutCoordinates(): void
+    {
+        $scanner = $this->createStub(ScannerInterface::class);
+        $scanner->method('query')->willReturn([
+            'elements' => [
+                [
+                    'id' => 999,
+                    'type' => 'way',
+                    'tags' => ['tourism' => 'hotel', 'name' => 'No Coords Hotel'],
+                ],
+            ],
+        ]);
+
+        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
+        $queryBuilder->method('buildAccommodationQuery')->willReturn('query');
+
+        $source = $this->createSource($scanner, $queryBuilder);
+        $results = $source->fetch([new Coordinate(48.5, 2.5)], 5000, ['hotel']);
+
+        $this->assertCount(0, $results);
+    }
+
+    #[Test]
+    public function fetchMapsAmenityShelterToShelterType(): void
+    {
+        $scanner = $this->createStub(ScannerInterface::class);
+        $scanner->method('query')->willReturn([
+            'elements' => [
+                [
+                    'id' => 200,
+                    'type' => 'node',
+                    'lat' => 46.0,
+                    'lon' => 1.0,
+                    'tags' => ['amenity' => 'shelter', 'shelter_type' => 'lean_to', 'name' => 'Lean-To'],
+                ],
+            ],
+        ]);
+
+        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
+        $queryBuilder->method('buildAccommodationQuery')->willReturn('query');
+
+        $source = $this->createSource($scanner, $queryBuilder);
+        $results = $source->fetch([new Coordinate(46.0, 1.0)], 5000, ['shelter']);
+
+        $this->assertCount(1, $results);
+        $this->assertSame('shelter', $results[0]['type']);
+        $this->assertSame(0.0, $results[0]['priceMin']);
+        $this->assertSame(0.0, $results[0]['priceMax']);
+    }
+
+    #[Test]
+    public function fetchReturnsEmptyArrayWhenNoElements(): void
+    {
+        $scanner = $this->createStub(ScannerInterface::class);
+        $scanner->method('query')->willReturn(['elements' => []]);
+
+        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
+        $queryBuilder->method('buildAccommodationQuery')->willReturn('query');
+
+        $source = $this->createSource($scanner, $queryBuilder);
+        $results = $source->fetch([new Coordinate(48.5, 2.5)], 5000, ['hotel']);
+
+        $this->assertSame([], $results);
+    }
+
+    private function createSource(
+        ?ScannerInterface $scanner = null,
+        ?QueryBuilderInterface $queryBuilder = null,
+    ): OsmAccommodationSource {
+        return new OsmAccommodationSource(
+            scanner: $scanner ?? $this->createStub(ScannerInterface::class),
+            queryBuilder: $queryBuilder ?? $this->createStub(QueryBuilderInterface::class),
+            pricingEngine: new PricingHeuristicEngine(),
+        );
+    }
+}

--- a/api/tests/Unit/ApiResource/EventTest.php
+++ b/api/tests/Unit/ApiResource/EventTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\ApiResource;
+
+use App\ApiResource\Model\Event;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class EventTest extends TestCase
+{
+    #[Test]
+    public function eventHasCorrectRequiredProperties(): void
+    {
+        $startDate = new \DateTimeImmutable('2025-07-10');
+        $endDate = new \DateTimeImmutable('2025-07-12');
+
+        $event = new Event(
+            name: 'Festival de Jazz',
+            type: 'schema:Festival',
+            lat: 48.5,
+            lon: 2.5,
+            startDate: $startDate,
+            endDate: $endDate,
+        );
+
+        $this->assertSame('Festival de Jazz', $event->name);
+        $this->assertSame('schema:Festival', $event->type);
+        $this->assertSame(48.5, $event->lat);
+        $this->assertSame(2.5, $event->lon);
+        $this->assertSame($startDate, $event->startDate);
+        $this->assertSame($endDate, $event->endDate);
+    }
+
+    #[Test]
+    public function eventHasCorrectDefaultValues(): void
+    {
+        $event = new Event(
+            name: 'Concert',
+            type: 'schema:MusicEvent',
+            lat: 44.0,
+            lon: 3.0,
+            startDate: new \DateTimeImmutable('2025-08-01'),
+            endDate: new \DateTimeImmutable('2025-08-01'),
+        );
+
+        $this->assertNull($event->url);
+        $this->assertNull($event->description);
+        $this->assertNull($event->priceMin);
+        $this->assertSame(0.0, $event->distanceToEndPoint);
+        $this->assertSame('datatourisme', $event->source);
+        $this->assertNull($event->wikidataId);
+    }
+
+    #[Test]
+    public function eventHasCorrectOptionalProperties(): void
+    {
+        $event = new Event(
+            name: 'Exposition Renoir',
+            type: 'schema:Exhibition',
+            lat: 48.86,
+            lon: 2.35,
+            startDate: new \DateTimeImmutable('2025-06-01'),
+            endDate: new \DateTimeImmutable('2025-09-30'),
+            url: 'https://example.com/expo',
+            description: 'Grande exposition impressionniste',
+            priceMin: 12.0,
+            distanceToEndPoint: 3500.0,
+            source: 'datatourisme',
+            wikidataId: 'Q123456',
+        );
+
+        $this->assertSame('https://example.com/expo', $event->url);
+        $this->assertSame('Grande exposition impressionniste', $event->description);
+        $this->assertSame(12.0, $event->priceMin);
+        $this->assertSame(3500.0, $event->distanceToEndPoint);
+        $this->assertSame('datatourisme', $event->source);
+        $this->assertSame('Q123456', $event->wikidataId);
+    }
+}

--- a/api/tests/Unit/Command/ImportMarketsCommandTest.php
+++ b/api/tests/Unit/Command/ImportMarketsCommandTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Command;
+
+use App\Command\ImportMarketsCommand;
+use App\Entity\Market;
+use App\Repository\MarketRepositoryInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Contracts\HttpClient\ChunkInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+use Symfony\Contracts\HttpClient\ResponseStreamInterface;
+
+final class ImportMarketsCommandTest extends TestCase
+{
+    private const string FIXTURE_CSV = <<<'CSV'
+        id;Nom du marché;Geo Point;Jour;Heure début;Heure fin;Commune;Département
+        MKT-001;Marché de la Bastille;48.8534,2.3699;lundi;08:00;13:00;Paris;75
+        MKT-002;Marché de Noailles;43.2964,5.3820;mardi;07:30;12:30;Marseille;13
+        MKT-003;Marché Victor Hugo;43.6047,1.4442;mercredi;07:00;13:30;Toulouse;31
+        MKT-004;Marché des Capucins;44.8378,-0.5792;samedi;06:00;14:00;Bordeaux;33
+        MKT-005;;INVALID_GEO;vendredi;;; ;
+        CSV;
+
+    /** @var MarketRepositoryInterface&MockObject */
+    private MarketRepositoryInterface $marketRepository;
+
+    /** @var EntityManagerInterface&MockObject */
+    private EntityManagerInterface $entityManager;
+
+    /** @var HttpClientInterface&MockObject */
+    private HttpClientInterface $httpClient;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->marketRepository = $this->createMock(MarketRepositoryInterface::class);
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+        $this->httpClient = $this->createMock(HttpClientInterface::class);
+    }
+
+    private function createCommandWithFixtureCsv(string $csvContent): CommandTester
+    {
+        $tmpFile = tempnam(sys_get_temp_dir(), 'market_test_');
+        file_put_contents($tmpFile, $csvContent);
+
+        $response = $this->createStub(ResponseInterface::class);
+
+        $chunk = $this->createStub(ChunkInterface::class);
+        $chunk->method('getContent')->willReturn(file_get_contents($tmpFile) ?: '');
+        $chunk->method('isLast')->willReturn(true);
+
+        $stream = $this->createMock(ResponseStreamInterface::class);
+        $stream->method('current')->willReturn($chunk);
+        $stream->method('valid')->willReturnOnConsecutiveCalls(true, false);
+        $stream->method('rewind')->willReturn(null);
+        $stream->method('next')->willReturn(null);
+
+        $this->httpClient->method('request')->willReturn($response);
+        $this->httpClient->method('stream')->willReturn($stream);
+
+        @unlink($tmpFile);
+
+        $command = new ImportMarketsCommand(
+            $this->marketRepository,
+            $this->entityManager,
+            new NullLogger(),
+            $this->httpClient,
+            'https://example.com/markets.csv',
+        );
+
+        return new CommandTester($command);
+    }
+
+    #[Test]
+    public function insertsNewMarketsAndSkipsMissingGeo(): void
+    {
+        $this->marketRepository
+            ->method('findByExternalId')
+            ->willReturn(null);
+
+        $this->marketRepository
+            ->expects($this->exactly(4))
+            ->method('save');
+
+        $this->entityManager
+            ->expects($this->once())
+            ->method('flush');
+
+        $tester = $this->createCommandWithFixtureCsv(self::FIXTURE_CSV);
+        $exitCode = $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $exitCode);
+        $this->assertStringContainsString('4 inserted', $tester->getDisplay());
+        $this->assertStringContainsString('0 updated', $tester->getDisplay());
+        $this->assertStringContainsString('1 skipped', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function updatesExistingMarketsOnUpsert(): void
+    {
+        $existing = new Market('MKT-001', 'Old Name');
+        $existing->setLat(0.0);
+        $existing->setLon(0.0);
+        $existing->setDayOfWeek(1);
+        $existing->setCommune('Old');
+        $existing->setDepartment('00');
+
+        $this->marketRepository
+            ->method('findByExternalId')
+            ->willReturnCallback(static fn (string $id): ?Market => 'MKT-001' === $id ? $existing : null);
+
+        $this->marketRepository
+            ->expects($this->exactly(3))
+            ->method('save');
+
+        $this->entityManager
+            ->expects($this->once())
+            ->method('flush');
+
+        $tester = $this->createCommandWithFixtureCsv(self::FIXTURE_CSV);
+        $exitCode = $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $exitCode);
+        $this->assertStringContainsString('3 inserted', $tester->getDisplay());
+        $this->assertStringContainsString('1 updated', $tester->getDisplay());
+
+        $this->assertSame('Marché de la Bastille', $existing->getName());
+        $this->assertSame(48.8534, $existing->getLat());
+        $this->assertSame(1, $existing->getDayOfWeek());
+        $this->assertSame('08:00', $existing->getStartTime());
+        $this->assertSame('13:00', $existing->getEndTime());
+    }
+
+    #[Test]
+    public function dryRunDoesNotWriteToDatabase(): void
+    {
+        $this->marketRepository
+            ->method('findByExternalId')
+            ->willReturn(null);
+
+        $this->marketRepository
+            ->expects($this->never())
+            ->method('save');
+
+        $this->entityManager
+            ->expects($this->never())
+            ->method('flush');
+
+        $tester = $this->createCommandWithFixtureCsv(self::FIXTURE_CSV);
+        $exitCode = $tester->execute(['--dry-run' => true]);
+
+        $this->assertSame(Command::SUCCESS, $exitCode);
+        $this->assertStringContainsString('4 inserted', $tester->getDisplay());
+        $this->assertStringContainsString('1 skipped', $tester->getDisplay());
+        $this->assertStringContainsString('Dry-run mode', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function limitOptionCapsProcessedRows(): void
+    {
+        $this->marketRepository
+            ->method('findByExternalId')
+            ->willReturn(null);
+
+        $this->marketRepository
+            ->expects($this->exactly(2))
+            ->method('save');
+
+        $tester = $this->createCommandWithFixtureCsv(self::FIXTURE_CSV);
+        $exitCode = $tester->execute(['--limit' => '2']);
+
+        $this->assertSame(Command::SUCCESS, $exitCode);
+        $this->assertStringContainsString('2 inserted', $tester->getDisplay());
+    }
+}

--- a/api/tests/Unit/Command/ImportMarketsCommandTest.php
+++ b/api/tests/Unit/Command/ImportMarketsCommandTest.php
@@ -10,6 +10,7 @@ use App\Repository\MarketRepositoryInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Symfony\Component\Console\Command\Command;
@@ -31,20 +32,20 @@ final class ImportMarketsCommandTest extends TestCase
         CSV;
 
     /** @var MarketRepositoryInterface&MockObject */
-    private MarketRepositoryInterface $marketRepository;
+    private MockObject $marketRepository;
 
     /** @var EntityManagerInterface&MockObject */
-    private EntityManagerInterface $entityManager;
+    private MockObject $entityManager;
 
-    /** @var HttpClientInterface&MockObject */
-    private HttpClientInterface $httpClient;
+    /** @var HttpClientInterface&Stub */
+    private Stub $httpClient;
 
     #[\Override]
     protected function setUp(): void
     {
         $this->marketRepository = $this->createMock(MarketRepositoryInterface::class);
         $this->entityManager = $this->createMock(EntityManagerInterface::class);
-        $this->httpClient = $this->createMock(HttpClientInterface::class);
+        $this->httpClient = $this->createStub(HttpClientInterface::class);
     }
 
     private function createCommandWithFixtureCsv(string $csvContent): CommandTester
@@ -58,11 +59,9 @@ final class ImportMarketsCommandTest extends TestCase
         $chunk->method('getContent')->willReturn(file_get_contents($tmpFile) ?: '');
         $chunk->method('isLast')->willReturn(true);
 
-        $stream = $this->createMock(ResponseStreamInterface::class);
+        $stream = $this->createStub(ResponseStreamInterface::class);
         $stream->method('current')->willReturn($chunk);
         $stream->method('valid')->willReturnOnConsecutiveCalls(true, false);
-        $stream->method('rewind')->willReturn(null);
-        $stream->method('next')->willReturn(null);
 
         $this->httpClient->method('request')->willReturn($response);
         $this->httpClient->method('stream')->willReturn($stream);
@@ -174,6 +173,10 @@ final class ImportMarketsCommandTest extends TestCase
         $this->marketRepository
             ->expects($this->exactly(2))
             ->method('save');
+
+        $this->entityManager
+            ->expects($this->once())
+            ->method('flush');
 
         $tester = $this->createCommandWithFixtureCsv(self::FIXTURE_CSV);
         $exitCode = $tester->execute(['--limit' => '2']);

--- a/api/tests/Unit/CulturalPoiSource/CulturalPoiSourceRegistryTest.php
+++ b/api/tests/Unit/CulturalPoiSource/CulturalPoiSourceRegistryTest.php
@@ -11,6 +11,9 @@ use PHPUnit\Framework\TestCase;
 
 final class CulturalPoiSourceRegistryTest extends TestCase
 {
+    /**
+     * @return list<list<array{lat: float, lon: float}>>
+     */
     private function stageGeometries(): array
     {
         return [

--- a/api/tests/Unit/CulturalPoiSource/CulturalPoiSourceRegistryTest.php
+++ b/api/tests/Unit/CulturalPoiSource/CulturalPoiSourceRegistryTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\CulturalPoiSource;
+
+use App\CulturalPoiSource\CulturalPoiSourceInterface;
+use App\CulturalPoiSource\CulturalPoiSourceRegistry;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class CulturalPoiSourceRegistryTest extends TestCase
+{
+    private function stageGeometries(): array
+    {
+        return [
+            [['lat' => 48.0, 'lon' => 2.0], ['lat' => 48.5, 'lon' => 2.5]],
+        ];
+    }
+
+    #[Test]
+    public function fetchAllForStagesMergesResultsFromEnabledSources(): void
+    {
+        $sourceA = $this->createStub(CulturalPoiSourceInterface::class);
+        $sourceA->method('isEnabled')->willReturn(true);
+        $sourceA->method('fetchForStages')->willReturn([
+            ['name' => 'Museum A', 'type' => 'museum', 'lat' => 48.1, 'lon' => 2.1, 'source' => 'osm'],
+        ]);
+
+        $sourceB = $this->createStub(CulturalPoiSourceInterface::class);
+        $sourceB->method('isEnabled')->willReturn(true);
+        $sourceB->method('fetchForStages')->willReturn([
+            ['name' => 'Museum B', 'type' => 'museum', 'lat' => 48.2, 'lon' => 2.2, 'source' => 'datatourisme'],
+        ]);
+
+        $registry = new CulturalPoiSourceRegistry([$sourceA, $sourceB]);
+        $result = $registry->fetchAllForStages($this->stageGeometries(), 500);
+
+        self::assertCount(2, $result);
+        self::assertSame('Museum A', $result[0]['name']);
+        self::assertSame('Museum B', $result[1]['name']);
+    }
+
+    #[Test]
+    public function disabledSourceIsSkipped(): void
+    {
+        $enabled = $this->createStub(CulturalPoiSourceInterface::class);
+        $enabled->method('isEnabled')->willReturn(true);
+        $enabled->method('fetchForStages')->willReturn([
+            ['name' => 'Active POI', 'type' => 'museum', 'lat' => 48.1, 'lon' => 2.1, 'source' => 'osm'],
+        ]);
+
+        $disabled = $this->createMock(CulturalPoiSourceInterface::class);
+        $disabled->method('isEnabled')->willReturn(false);
+        $disabled->expects($this->never())->method('fetchForStages');
+
+        $registry = new CulturalPoiSourceRegistry([$enabled, $disabled]);
+        $result = $registry->fetchAllForStages($this->stageGeometries(), 500);
+
+        self::assertCount(1, $result);
+    }
+
+    #[Test]
+    public function emptySourcesReturnsEmptyArray(): void
+    {
+        $registry = new CulturalPoiSourceRegistry([]);
+        $result = $registry->fetchAllForStages($this->stageGeometries(), 500);
+
+        self::assertSame([], $result);
+    }
+
+    #[Test]
+    public function radiusIsForwardedToSources(): void
+    {
+        $source = $this->createMock(CulturalPoiSourceInterface::class);
+        $source->method('isEnabled')->willReturn(true);
+        $source->expects($this->once())
+            ->method('fetchForStages')
+            ->with($this->stageGeometries(), 1000)
+            ->willReturn([]);
+
+        $registry = new CulturalPoiSourceRegistry([$source]);
+        $registry->fetchAllForStages($this->stageGeometries(), 1000);
+    }
+}

--- a/api/tests/Unit/CulturalPoiSource/DataTourismeCulturalPoiSourceTest.php
+++ b/api/tests/Unit/CulturalPoiSource/DataTourismeCulturalPoiSourceTest.php
@@ -1,0 +1,340 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\CulturalPoiSource;
+
+use App\CulturalPoiSource\DataTourismeCulturalPoiSource;
+use App\DataTourisme\DataTourismeClientInterface;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class DataTourismeCulturalPoiSourceTest extends TestCase
+{
+    private function makeSource(DataTourismeClientInterface $client): DataTourismeCulturalPoiSource
+    {
+        return new DataTourismeCulturalPoiSource($client);
+    }
+
+    private function stageGeometries(): array
+    {
+        return [
+            [['lat' => 48.0, 'lon' => 2.0], ['lat' => 48.5, 'lon' => 2.5]],
+        ];
+    }
+
+    #[Test]
+    public function getNameReturnsDatatourisme(): void
+    {
+        $client = $this->createStub(DataTourismeClientInterface::class);
+        $client->method('isEnabled')->willReturn(true);
+
+        $source = $this->makeSource($client);
+
+        self::assertSame('datatourisme', $source->getName());
+    }
+
+    #[Test]
+    public function isEnabledDelegatesToClient(): void
+    {
+        $client = $this->createStub(DataTourismeClientInterface::class);
+        $client->method('isEnabled')->willReturn(false);
+
+        $source = $this->makeSource($client);
+
+        self::assertFalse($source->isEnabled());
+    }
+
+    #[Test]
+    public function fetchForStagesReturnsEmptyWhenClientIsDisabled(): void
+    {
+        $client = $this->createMock(DataTourismeClientInterface::class);
+        $client->method('isEnabled')->willReturn(false);
+        $client->expects($this->never())->method('request');
+
+        $source = $this->makeSource($client);
+        $result = $source->fetchForStages($this->stageGeometries(), 500);
+
+        self::assertSame([], $result);
+    }
+
+    #[Test]
+    public function museumItemIsMapped(): void
+    {
+        $client = $this->createStub(DataTourismeClientInterface::class);
+        $client->method('isEnabled')->willReturn(true);
+        $client->method('request')->willReturn([
+            'results' => [
+                [
+                    '@type' => ['schema:Museum'],
+                    'rdfs:label' => [['@value' => 'Musée du Louvre', '@language' => 'fr']],
+                    'hasGeometry' => ['schema:latitude' => 48.8606, 'schema:longitude' => 2.3376],
+                ],
+            ],
+        ]);
+
+        $source = $this->makeSource($client);
+        $result = $source->fetchForStages($this->stageGeometries(), 500);
+
+        self::assertCount(1, $result);
+        self::assertSame('Musée du Louvre', $result[0]['name']);
+        self::assertSame('museum', $result[0]['type']);
+        self::assertSame('datatourisme', $result[0]['source']);
+        self::assertSame(48.8606, $result[0]['lat']);
+        self::assertSame(2.3376, $result[0]['lon']);
+    }
+
+    #[Test]
+    public function openingHoursAreMapped(): void
+    {
+        $client = $this->createStub(DataTourismeClientInterface::class);
+        $client->method('isEnabled')->willReturn(true);
+        $client->method('request')->willReturn([
+            'results' => [
+                [
+                    '@type' => ['schema:Museum'],
+                    'rdfs:label' => 'Château de Versailles',
+                    'hasGeometry' => ['schema:latitude' => 48.8, 'schema:longitude' => 2.1],
+                    'openingHoursSpecification' => [
+                        [
+                            'schema:dayOfWeek' => ['schema:Tuesday', 'schema:Wednesday'],
+                            'schema:opens' => '09:00',
+                            'schema:closes' => '18:00',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $source = $this->makeSource($client);
+        $result = $source->fetchForStages($this->stageGeometries(), 500);
+
+        self::assertCount(1, $result);
+        self::assertNotNull($result[0]['openingHours']);
+        self::assertStringContainsString('09:00', $result[0]['openingHours']);
+        self::assertStringContainsString('18:00', $result[0]['openingHours']);
+    }
+
+    #[Test]
+    public function estimatedPriceIsExtracted(): void
+    {
+        $client = $this->createStub(DataTourismeClientInterface::class);
+        $client->method('isEnabled')->willReturn(true);
+        $client->method('request')->willReturn([
+            'results' => [
+                [
+                    '@type' => ['schema:Museum'],
+                    'rdfs:label' => 'Musée Picasso',
+                    'hasGeometry' => ['schema:latitude' => 48.8, 'schema:longitude' => 2.1],
+                    'offers' => [
+                        [
+                            'priceSpecification' => [
+                                ['schema:price' => 12.5, 'schema:priceCurrency' => 'EUR'],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $source = $this->makeSource($client);
+        $result = $source->fetchForStages($this->stageGeometries(), 500);
+
+        self::assertCount(1, $result);
+        self::assertSame(12.5, $result[0]['estimatedPrice']);
+    }
+
+    #[Test]
+    public function descriptionFromRdfsCommentIsExtracted(): void
+    {
+        $client = $this->createStub(DataTourismeClientInterface::class);
+        $client->method('isEnabled')->willReturn(true);
+        $client->method('request')->willReturn([
+            'results' => [
+                [
+                    '@type' => ['schema:Landmark'],
+                    'rdfs:label' => 'Tour Eiffel',
+                    'hasGeometry' => ['schema:latitude' => 48.858, 'schema:longitude' => 2.294],
+                    'rdfs:comment' => [['@value' => 'Iconic iron tower', '@language' => 'en']],
+                ],
+            ],
+        ]);
+
+        $source = $this->makeSource($client);
+        $result = $source->fetchForStages($this->stageGeometries(), 500);
+
+        self::assertCount(1, $result);
+        self::assertSame('Iconic iron tower', $result[0]['description']);
+    }
+
+    #[Test]
+    public function wikidataIdIsExtractedFromOwlSameAs(): void
+    {
+        $client = $this->createStub(DataTourismeClientInterface::class);
+        $client->method('isEnabled')->willReturn(true);
+        $client->method('request')->willReturn([
+            'results' => [
+                [
+                    '@type' => ['schema:Museum'],
+                    'rdfs:label' => 'Orsay',
+                    'hasGeometry' => ['schema:latitude' => 48.8, 'schema:longitude' => 2.3],
+                    'owl:sameAs' => ['https://www.wikidata.org/entity/Q23402', 'https://dbpedia.org/resource/Mus%C3%A9e_d%27Orsay'],
+                ],
+            ],
+        ]);
+
+        $source = $this->makeSource($client);
+        $result = $source->fetchForStages($this->stageGeometries(), 500);
+
+        self::assertCount(1, $result);
+        self::assertSame('Q23402', $result[0]['wikidataId']);
+    }
+
+    #[Test]
+    public function itemWithoutNameIsSkipped(): void
+    {
+        $client = $this->createStub(DataTourismeClientInterface::class);
+        $client->method('isEnabled')->willReturn(true);
+        $client->method('request')->willReturn([
+            'results' => [
+                [
+                    '@type' => ['schema:Museum'],
+                    'hasGeometry' => ['schema:latitude' => 48.8, 'schema:longitude' => 2.3],
+                ],
+            ],
+        ]);
+
+        $source = $this->makeSource($client);
+        $result = $source->fetchForStages($this->stageGeometries(), 500);
+
+        self::assertCount(0, $result);
+    }
+
+    #[Test]
+    public function itemWithoutCoordinatesIsSkipped(): void
+    {
+        $client = $this->createStub(DataTourismeClientInterface::class);
+        $client->method('isEnabled')->willReturn(true);
+        $client->method('request')->willReturn([
+            'results' => [
+                [
+                    '@type' => ['schema:Museum'],
+                    'rdfs:label' => 'No Coords Museum',
+                ],
+            ],
+        ]);
+
+        $source = $this->makeSource($client);
+        $result = $source->fetchForStages($this->stageGeometries(), 500);
+
+        self::assertCount(0, $result);
+    }
+
+    #[Test]
+    public function emptyResultsReturnEmptyArray(): void
+    {
+        $client = $this->createStub(DataTourismeClientInterface::class);
+        $client->method('isEnabled')->willReturn(true);
+        $client->method('request')->willReturn(['results' => []]);
+
+        $source = $this->makeSource($client);
+        $result = $source->fetchForStages($this->stageGeometries(), 500);
+
+        self::assertSame([], $result);
+    }
+
+    #[Test]
+    public function memberKeyIsAcceptedAsAlternativeToResults(): void
+    {
+        $client = $this->createStub(DataTourismeClientInterface::class);
+        $client->method('isEnabled')->willReturn(true);
+        $client->method('request')->willReturn([
+            'member' => [
+                [
+                    '@type' => ['schema:Museum'],
+                    'rdfs:label' => 'Cluny',
+                    'hasGeometry' => ['schema:latitude' => 48.85, 'schema:longitude' => 2.34],
+                ],
+            ],
+        ]);
+
+        $source = $this->makeSource($client);
+        $result = $source->fetchForStages($this->stageGeometries(), 500);
+
+        self::assertCount(1, $result);
+        self::assertSame('Cluny', $result[0]['name']);
+    }
+
+    #[Test]
+    public function naturalHeritageIsMappedAsViewpoint(): void
+    {
+        $client = $this->createStub(DataTourismeClientInterface::class);
+        $client->method('isEnabled')->willReturn(true);
+        $client->method('request')->willReturn([
+            'results' => [
+                [
+                    '@type' => ['urn:resource:NaturalHeritage'],
+                    'rdfs:label' => 'Gorges du Verdon',
+                    'hasGeometry' => ['schema:latitude' => 43.7, 'schema:longitude' => 6.3],
+                ],
+            ],
+        ]);
+
+        $source = $this->makeSource($client);
+        $result = $source->fetchForStages($this->stageGeometries(), 500);
+
+        self::assertCount(1, $result);
+        self::assertSame('viewpoint', $result[0]['type']);
+    }
+
+    #[Test]
+    public function culturalSiteIsMappedAsMonument(): void
+    {
+        $client = $this->createStub(DataTourismeClientInterface::class);
+        $client->method('isEnabled')->willReturn(true);
+        $client->method('request')->willReturn([
+            'results' => [
+                [
+                    '@type' => ['urn:resource:CulturalSite'],
+                    'rdfs:label' => 'Abbaye de Fontenay',
+                    'hasGeometry' => ['schema:latitude' => 47.6, 'schema:longitude' => 4.4],
+                ],
+            ],
+        ]);
+
+        $source = $this->makeSource($client);
+        $result = $source->fetchForStages($this->stageGeometries(), 500);
+
+        self::assertCount(1, $result);
+        self::assertSame('monument', $result[0]['type']);
+    }
+
+    #[Test]
+    public function nonEuroPriceIsIgnored(): void
+    {
+        $client = $this->createStub(DataTourismeClientInterface::class);
+        $client->method('isEnabled')->willReturn(true);
+        $client->method('request')->willReturn([
+            'results' => [
+                [
+                    '@type' => ['schema:Museum'],
+                    'rdfs:label' => 'British Museum',
+                    'hasGeometry' => ['schema:latitude' => 51.5, 'schema:longitude' => -0.1],
+                    'offers' => [
+                        [
+                            'priceSpecification' => [
+                                ['schema:price' => 20.0, 'schema:priceCurrency' => 'GBP'],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $source = $this->makeSource($client);
+        $result = $source->fetchForStages($this->stageGeometries(), 500);
+
+        self::assertCount(1, $result);
+        self::assertNull($result[0]['estimatedPrice']);
+    }
+}

--- a/api/tests/Unit/CulturalPoiSource/DataTourismeCulturalPoiSourceTest.php
+++ b/api/tests/Unit/CulturalPoiSource/DataTourismeCulturalPoiSourceTest.php
@@ -16,6 +16,9 @@ final class DataTourismeCulturalPoiSourceTest extends TestCase
         return new DataTourismeCulturalPoiSource($client);
     }
 
+    /**
+     * @return list<list<array{lat: float, lon: float}>>
+     */
     private function stageGeometries(): array
     {
         return [

--- a/api/tests/Unit/CulturalPoiSource/OsmCulturalPoiSourceTest.php
+++ b/api/tests/Unit/CulturalPoiSource/OsmCulturalPoiSourceTest.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\CulturalPoiSource;
+
+use App\CulturalPoiSource\OsmCulturalPoiSource;
+use App\Scanner\QueryBuilderInterface;
+use App\Scanner\ScannerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class OsmCulturalPoiSourceTest extends TestCase
+{
+    private function makeSource(
+        ScannerInterface $scanner,
+        QueryBuilderInterface $queryBuilder,
+    ): OsmCulturalPoiSource {
+        return new OsmCulturalPoiSource($scanner, $queryBuilder);
+    }
+
+    private function stageGeometries(): array
+    {
+        return [
+            [['lat' => 48.0, 'lon' => 2.0], ['lat' => 48.5, 'lon' => 2.5]],
+        ];
+    }
+
+    #[Test]
+    public function isEnabledAlwaysReturnsTrue(): void
+    {
+        $source = $this->makeSource(
+            $this->createStub(ScannerInterface::class),
+            $this->createStub(QueryBuilderInterface::class),
+        );
+
+        self::assertTrue($source->isEnabled());
+    }
+
+    #[Test]
+    public function getNameReturnsOsm(): void
+    {
+        $source = $this->makeSource(
+            $this->createStub(ScannerInterface::class),
+            $this->createStub(QueryBuilderInterface::class),
+        );
+
+        self::assertSame('osm', $source->getName());
+    }
+
+    #[Test]
+    public function museumIsMapped(): void
+    {
+        $scanner = $this->createStub(ScannerInterface::class);
+        $scanner->method('query')->willReturn([
+            'elements' => [
+                ['lat' => 48.2, 'lon' => 2.2, 'tags' => ['tourism' => 'museum', 'name' => 'Louvre']],
+            ],
+        ]);
+
+        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
+        $queryBuilder->method('buildBatchCulturalPoiQuery')->willReturn('query');
+
+        $source = $this->makeSource($scanner, $queryBuilder);
+        $result = $source->fetchForStages($this->stageGeometries(), 500);
+
+        self::assertCount(1, $result);
+        self::assertSame('Louvre', $result[0]['name']);
+        self::assertSame('museum', $result[0]['type']);
+        self::assertSame('osm', $result[0]['source']);
+        self::assertNull($result[0]['openingHours']);
+        self::assertNull($result[0]['estimatedPrice']);
+        self::assertNull($result[0]['description']);
+    }
+
+    #[Test]
+    public function wikidataTagIsExtracted(): void
+    {
+        $scanner = $this->createStub(ScannerInterface::class);
+        $scanner->method('query')->willReturn([
+            'elements' => [
+                ['lat' => 48.2, 'lon' => 2.2, 'tags' => ['tourism' => 'museum', 'name' => 'Louvre', 'wikidata' => 'Q19675']],
+            ],
+        ]);
+
+        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
+        $queryBuilder->method('buildBatchCulturalPoiQuery')->willReturn('query');
+
+        $source = $this->makeSource($scanner, $queryBuilder);
+        $result = $source->fetchForStages($this->stageGeometries(), 500);
+
+        self::assertCount(1, $result);
+        self::assertSame('Q19675', $result[0]['wikidataId']);
+    }
+
+    #[Test]
+    public function elementWithMissingCoordinatesIsSkipped(): void
+    {
+        $scanner = $this->createStub(ScannerInterface::class);
+        $scanner->method('query')->willReturn([
+            'elements' => [
+                ['tags' => ['tourism' => 'museum', 'name' => 'No Coords Museum']],
+            ],
+        ]);
+
+        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
+        $queryBuilder->method('buildBatchCulturalPoiQuery')->willReturn('query');
+
+        $source = $this->makeSource($scanner, $queryBuilder);
+        $result = $source->fetchForStages($this->stageGeometries(), 500);
+
+        self::assertCount(0, $result);
+    }
+
+    #[Test]
+    public function nonNotableHistoricTagIsSkipped(): void
+    {
+        $scanner = $this->createStub(ScannerInterface::class);
+        $scanner->method('query')->willReturn([
+            'elements' => [
+                ['lat' => 48.2, 'lon' => 2.2, 'tags' => ['historic' => 'milestone', 'name' => 'Old Stone']],
+            ],
+        ]);
+
+        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
+        $queryBuilder->method('buildBatchCulturalPoiQuery')->willReturn('query');
+
+        $source = $this->makeSource($scanner, $queryBuilder);
+        $result = $source->fetchForStages($this->stageGeometries(), 500);
+
+        self::assertCount(0, $result);
+    }
+
+    #[Test]
+    public function notableHistoricCastleIsMapped(): void
+    {
+        $scanner = $this->createStub(ScannerInterface::class);
+        $scanner->method('query')->willReturn([
+            'elements' => [
+                ['lat' => 48.2, 'lon' => 2.2, 'tags' => ['historic' => 'castle', 'name' => 'Château Frontenac']],
+            ],
+        ]);
+
+        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
+        $queryBuilder->method('buildBatchCulturalPoiQuery')->willReturn('query');
+
+        $source = $this->makeSource($scanner, $queryBuilder);
+        $result = $source->fetchForStages($this->stageGeometries(), 500);
+
+        self::assertCount(1, $result);
+        self::assertSame('castle', $result[0]['type']);
+    }
+
+    #[Test]
+    public function unknownTourismTagIsSkipped(): void
+    {
+        $scanner = $this->createStub(ScannerInterface::class);
+        $scanner->method('query')->willReturn([
+            'elements' => [
+                ['lat' => 48.2, 'lon' => 2.2, 'tags' => ['tourism' => 'hotel', 'name' => 'Grand Hotel']],
+            ],
+        ]);
+
+        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
+        $queryBuilder->method('buildBatchCulturalPoiQuery')->willReturn('query');
+
+        $source = $this->makeSource($scanner, $queryBuilder);
+        $result = $source->fetchForStages($this->stageGeometries(), 500);
+
+        self::assertCount(0, $result);
+    }
+
+    #[Test]
+    public function centerCoordinatesAreUsedForWayElements(): void
+    {
+        $scanner = $this->createStub(ScannerInterface::class);
+        $scanner->method('query')->willReturn([
+            'elements' => [
+                [
+                    'center' => ['lat' => 48.3, 'lon' => 2.3],
+                    'tags' => ['tourism' => 'attraction', 'name' => 'Big Park'],
+                ],
+            ],
+        ]);
+
+        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
+        $queryBuilder->method('buildBatchCulturalPoiQuery')->willReturn('query');
+
+        $source = $this->makeSource($scanner, $queryBuilder);
+        $result = $source->fetchForStages($this->stageGeometries(), 500);
+
+        self::assertCount(1, $result);
+        self::assertSame(48.3, $result[0]['lat']);
+        self::assertSame(2.3, $result[0]['lon']);
+    }
+
+    #[Test]
+    public function emptyWikidataTagResultsInNullWikidataId(): void
+    {
+        $scanner = $this->createStub(ScannerInterface::class);
+        $scanner->method('query')->willReturn([
+            'elements' => [
+                ['lat' => 48.2, 'lon' => 2.2, 'tags' => ['tourism' => 'museum', 'name' => 'Museum', 'wikidata' => '']],
+            ],
+        ]);
+
+        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
+        $queryBuilder->method('buildBatchCulturalPoiQuery')->willReturn('query');
+
+        $source = $this->makeSource($scanner, $queryBuilder);
+        $result = $source->fetchForStages($this->stageGeometries(), 500);
+
+        self::assertCount(1, $result);
+        self::assertNull($result[0]['wikidataId']);
+    }
+}

--- a/api/tests/Unit/CulturalPoiSource/OsmCulturalPoiSourceTest.php
+++ b/api/tests/Unit/CulturalPoiSource/OsmCulturalPoiSourceTest.php
@@ -19,6 +19,9 @@ final class OsmCulturalPoiSourceTest extends TestCase
         return new OsmCulturalPoiSource($scanner, $queryBuilder);
     }
 
+    /**
+     * @return list<list<array{lat: float, lon: float}>>
+     */
     private function stageGeometries(): array
     {
         return [

--- a/api/tests/Unit/DataTourisme/DataTourismeClientTest.php
+++ b/api/tests/Unit/DataTourisme/DataTourismeClientTest.php
@@ -1,0 +1,264 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\DataTourisme;
+
+use App\DataTourisme\DataTourismeClient;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\RateLimiter\LimiterInterface;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\RateLimiter\RateLimit;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+final class DataTourismeClientTest extends TestCase
+{
+    // -------------------------------------------------------------------------
+    // isEnabled()
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function isEnabledReturnsTrueWhenFlagAndKeyAreSet(): void
+    {
+        $client = $this->makeClient(apiKey: 'secret', enabled: true);
+
+        $this->assertTrue($client->isEnabled());
+    }
+
+    #[Test]
+    public function isEnabledReturnsFalseWhenFlagIsOff(): void
+    {
+        $client = $this->makeClient(apiKey: 'secret', enabled: false);
+
+        $this->assertFalse($client->isEnabled());
+    }
+
+    #[Test]
+    public function isEnabledReturnsFalseWhenKeyIsEmpty(): void
+    {
+        $client = $this->makeClient(apiKey: '', enabled: true);
+
+        $this->assertFalse($client->isEnabled());
+    }
+
+    #[Test]
+    public function isEnabledReturnsFalseWhenBothFlagAndKeyAreAbsent(): void
+    {
+        $client = $this->makeClient(apiKey: '', enabled: false);
+
+        $this->assertFalse($client->isEnabled());
+    }
+
+    // -------------------------------------------------------------------------
+    // request() — cache hit
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function requestReturnsCachedResultWithoutHttpCall(): void
+    {
+        $cached = ['results' => [['id' => 'poi-1']]];
+
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->expects($this->once())
+            ->method('get')
+            ->willReturn($cached);
+
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient->expects($this->never())->method('request');
+
+        $rateLimiter = $this->createMock(RateLimiterFactory::class);
+        $rateLimiter->expects($this->never())->method('create');
+
+        $client = $this->makeClient(cache: $cache, httpClient: $httpClient, rateLimiter: $rateLimiter);
+
+        $result = $client->request('/api/v1/places', ['type' => 'museum']);
+
+        $this->assertSame($cached, $result);
+    }
+
+    // -------------------------------------------------------------------------
+    // request() — cache miss → HTTP call
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function requestFetchesAndCachesOnCacheMiss(): void
+    {
+        $apiResponse = ['results' => [['id' => 'poi-2']]];
+
+        $item = $this->createMock(ItemInterface::class);
+        $item->expects($this->once())->method('expiresAfter')->with(86400);
+
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->expects($this->once())
+            ->method('get')
+            ->willReturnCallback(static function (string $key, callable $callback) use ($item): mixed {
+                return $callback($item);
+            });
+
+        $rateLimit = $this->createMock(RateLimit::class);
+        $rateLimit->method('isAccepted')->willReturn(true);
+
+        $limiter = $this->createMock(LimiterInterface::class);
+        $limiter->method('consume')->willReturn($rateLimit);
+
+        $rateLimiter = $this->createMock(RateLimiterFactory::class);
+        $rateLimiter->method('create')->willReturn($limiter);
+
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('toArray')->willReturn($apiResponse);
+
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient->expects($this->once())
+            ->method('request')
+            ->with('GET', '/api/v1/places', ['query' => ['type' => 'museum']])
+            ->willReturn($response);
+
+        $client = $this->makeClient(cache: $cache, httpClient: $httpClient, rateLimiter: $rateLimiter);
+
+        $result = $client->request('/api/v1/places', ['type' => 'museum']);
+
+        $this->assertSame($apiResponse, $result);
+    }
+
+    #[Test]
+    public function requestUsesTtlFromArgumentOnCacheMiss(): void
+    {
+        $item = $this->createMock(ItemInterface::class);
+        $item->expects($this->once())->method('expiresAfter')->with(3600);
+
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->expects($this->once())
+            ->method('get')
+            ->willReturnCallback(static function (string $key, callable $callback) use ($item): mixed {
+                return $callback($item);
+            });
+
+        $rateLimit = $this->createMock(RateLimit::class);
+        $rateLimit->method('isAccepted')->willReturn(true);
+
+        $limiter = $this->createMock(LimiterInterface::class);
+        $limiter->method('consume')->willReturn($rateLimit);
+
+        $rateLimiter = $this->createMock(RateLimiterFactory::class);
+        $rateLimiter->method('create')->willReturn($limiter);
+
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('toArray')->willReturn([]);
+
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient->method('request')->willReturn($response);
+
+        $client = $this->makeClient(cache: $cache, httpClient: $httpClient, rateLimiter: $rateLimiter);
+
+        $client->request('/api/v1/places', [], 3600);
+    }
+
+    // -------------------------------------------------------------------------
+    // request() — rate limit exhausted
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function requestReturnsEmptyAndLogsWarningWhenRateLimitExhausted(): void
+    {
+        $item = $this->createMock(ItemInterface::class);
+        $item->method('expiresAfter')->willReturnSelf();
+
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->expects($this->once())
+            ->method('get')
+            ->willReturnCallback(static function (string $key, callable $callback) use ($item): mixed {
+                return $callback($item);
+            });
+
+        $rateLimit = $this->createMock(RateLimit::class);
+        $rateLimit->method('isAccepted')->willReturn(false);
+
+        $limiter = $this->createMock(LimiterInterface::class);
+        $limiter->method('consume')->willReturn($rateLimit);
+
+        $rateLimiter = $this->createMock(RateLimiterFactory::class);
+        $rateLimiter->method('create')->willReturn($limiter);
+
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient->expects($this->never())->method('request');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('warning')
+            ->with($this->stringContains('rate limit'));
+
+        $client = $this->makeClient(cache: $cache, httpClient: $httpClient, rateLimiter: $rateLimiter, logger: $logger);
+
+        $result = $client->request('/api/v1/places');
+
+        $this->assertSame(['results' => []], $result);
+    }
+
+    // -------------------------------------------------------------------------
+    // request() — HTTP 5xx / network error
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function requestReturnsEmptyAndLogsWarningOnHttpError(): void
+    {
+        $item = $this->createMock(ItemInterface::class);
+        $item->method('expiresAfter')->willReturnSelf();
+
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->expects($this->once())
+            ->method('get')
+            ->willReturnCallback(static function (string $key, callable $callback) use ($item): mixed {
+                return $callback($item);
+            });
+
+        $rateLimit = $this->createMock(RateLimit::class);
+        $rateLimit->method('isAccepted')->willReturn(true);
+
+        $limiter = $this->createMock(LimiterInterface::class);
+        $limiter->method('consume')->willReturn($rateLimit);
+
+        $rateLimiter = $this->createMock(RateLimiterFactory::class);
+        $rateLimiter->method('create')->willReturn($limiter);
+
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient->method('request')->willThrowException(new \RuntimeException('Connection refused'));
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('warning')
+            ->with($this->stringContains('failed'));
+
+        $client = $this->makeClient(cache: $cache, httpClient: $httpClient, rateLimiter: $rateLimiter, logger: $logger);
+
+        $result = $client->request('/api/v1/places');
+
+        $this->assertSame(['results' => []], $result);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private function makeClient(
+        ?CacheInterface $cache = null,
+        ?HttpClientInterface $httpClient = null,
+        ?RateLimiterFactory $rateLimiter = null,
+        ?LoggerInterface $logger = null,
+        string $apiKey = 'test-api-key',
+        bool $enabled = true,
+    ): DataTourismeClient {
+        return new DataTourismeClient(
+            httpClient: $httpClient ?? $this->createStub(HttpClientInterface::class),
+            cache: $cache ?? $this->createStub(CacheInterface::class),
+            rateLimiter: $rateLimiter ?? $this->createStub(RateLimiterFactory::class),
+            logger: $logger ?? $this->createStub(LoggerInterface::class),
+            apiKey: $apiKey,
+            enabled: $enabled,
+        );
+    }
+}

--- a/api/tests/Unit/DataTourisme/DataTourismeClientTest.php
+++ b/api/tests/Unit/DataTourisme/DataTourismeClientTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\RateLimiter\LimiterInterface;
-use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
 use Symfony\Component\RateLimiter\RateLimit;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
@@ -71,7 +71,7 @@ final class DataTourismeClientTest extends TestCase
         $httpClient = $this->createMock(HttpClientInterface::class);
         $httpClient->expects($this->never())->method('request');
 
-        $rateLimiter = $this->createMock(RateLimiterFactory::class);
+        $rateLimiter = $this->createMock(RateLimiterFactoryInterface::class);
         $rateLimiter->expects($this->never())->method('create');
 
         $client = $this->makeClient(cache: $cache, httpClient: $httpClient, rateLimiter: $rateLimiter);
@@ -96,20 +96,18 @@ final class DataTourismeClientTest extends TestCase
         $cache = $this->createMock(CacheInterface::class);
         $cache->expects($this->once())
             ->method('get')
-            ->willReturnCallback(static function (string $key, callable $callback) use ($item): mixed {
-                return $callback($item);
-            });
+            ->willReturnCallback(static fn (string $key, callable $callback): mixed => $callback($item));
 
-        $rateLimit = $this->createMock(RateLimit::class);
+        $rateLimit = $this->createStub(RateLimit::class);
         $rateLimit->method('isAccepted')->willReturn(true);
 
-        $limiter = $this->createMock(LimiterInterface::class);
+        $limiter = $this->createStub(LimiterInterface::class);
         $limiter->method('consume')->willReturn($rateLimit);
 
-        $rateLimiter = $this->createMock(RateLimiterFactory::class);
+        $rateLimiter = $this->createStub(RateLimiterFactoryInterface::class);
         $rateLimiter->method('create')->willReturn($limiter);
 
-        $response = $this->createMock(ResponseInterface::class);
+        $response = $this->createStub(ResponseInterface::class);
         $response->method('toArray')->willReturn($apiResponse);
 
         $httpClient = $this->createMock(HttpClientInterface::class);
@@ -134,23 +132,21 @@ final class DataTourismeClientTest extends TestCase
         $cache = $this->createMock(CacheInterface::class);
         $cache->expects($this->once())
             ->method('get')
-            ->willReturnCallback(static function (string $key, callable $callback) use ($item): mixed {
-                return $callback($item);
-            });
+            ->willReturnCallback(static fn (string $key, callable $callback): mixed => $callback($item));
 
-        $rateLimit = $this->createMock(RateLimit::class);
+        $rateLimit = $this->createStub(RateLimit::class);
         $rateLimit->method('isAccepted')->willReturn(true);
 
-        $limiter = $this->createMock(LimiterInterface::class);
+        $limiter = $this->createStub(LimiterInterface::class);
         $limiter->method('consume')->willReturn($rateLimit);
 
-        $rateLimiter = $this->createMock(RateLimiterFactory::class);
+        $rateLimiter = $this->createStub(RateLimiterFactoryInterface::class);
         $rateLimiter->method('create')->willReturn($limiter);
 
-        $response = $this->createMock(ResponseInterface::class);
+        $response = $this->createStub(ResponseInterface::class);
         $response->method('toArray')->willReturn([]);
 
-        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient = $this->createStub(HttpClientInterface::class);
         $httpClient->method('request')->willReturn($response);
 
         $client = $this->makeClient(cache: $cache, httpClient: $httpClient, rateLimiter: $rateLimiter);
@@ -165,23 +161,21 @@ final class DataTourismeClientTest extends TestCase
     #[Test]
     public function requestReturnsEmptyAndLogsWarningWhenRateLimitExhausted(): void
     {
-        $item = $this->createMock(ItemInterface::class);
+        $item = $this->createStub(ItemInterface::class);
         $item->method('expiresAfter')->willReturnSelf();
 
         $cache = $this->createMock(CacheInterface::class);
         $cache->expects($this->once())
             ->method('get')
-            ->willReturnCallback(static function (string $key, callable $callback) use ($item): mixed {
-                return $callback($item);
-            });
+            ->willReturnCallback(static fn (string $key, callable $callback): mixed => $callback($item));
 
-        $rateLimit = $this->createMock(RateLimit::class);
+        $rateLimit = $this->createStub(RateLimit::class);
         $rateLimit->method('isAccepted')->willReturn(false);
 
-        $limiter = $this->createMock(LimiterInterface::class);
+        $limiter = $this->createStub(LimiterInterface::class);
         $limiter->method('consume')->willReturn($rateLimit);
 
-        $rateLimiter = $this->createMock(RateLimiterFactory::class);
+        $rateLimiter = $this->createStub(RateLimiterFactoryInterface::class);
         $rateLimiter->method('create')->willReturn($limiter);
 
         $httpClient = $this->createMock(HttpClientInterface::class);
@@ -206,26 +200,24 @@ final class DataTourismeClientTest extends TestCase
     #[Test]
     public function requestReturnsEmptyAndLogsWarningOnHttpError(): void
     {
-        $item = $this->createMock(ItemInterface::class);
+        $item = $this->createStub(ItemInterface::class);
         $item->method('expiresAfter')->willReturnSelf();
 
         $cache = $this->createMock(CacheInterface::class);
         $cache->expects($this->once())
             ->method('get')
-            ->willReturnCallback(static function (string $key, callable $callback) use ($item): mixed {
-                return $callback($item);
-            });
+            ->willReturnCallback(static fn (string $key, callable $callback): mixed => $callback($item));
 
-        $rateLimit = $this->createMock(RateLimit::class);
+        $rateLimit = $this->createStub(RateLimit::class);
         $rateLimit->method('isAccepted')->willReturn(true);
 
-        $limiter = $this->createMock(LimiterInterface::class);
+        $limiter = $this->createStub(LimiterInterface::class);
         $limiter->method('consume')->willReturn($rateLimit);
 
-        $rateLimiter = $this->createMock(RateLimiterFactory::class);
+        $rateLimiter = $this->createStub(RateLimiterFactoryInterface::class);
         $rateLimiter->method('create')->willReturn($limiter);
 
-        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient = $this->createStub(HttpClientInterface::class);
         $httpClient->method('request')->willThrowException(new \RuntimeException('Connection refused'));
 
         $logger = $this->createMock(LoggerInterface::class);
@@ -247,7 +239,7 @@ final class DataTourismeClientTest extends TestCase
     private function makeClient(
         ?CacheInterface $cache = null,
         ?HttpClientInterface $httpClient = null,
-        ?RateLimiterFactory $rateLimiter = null,
+        ?RateLimiterFactoryInterface $rateLimiter = null,
         ?LoggerInterface $logger = null,
         string $apiKey = 'test-api-key',
         bool $enabled = true,
@@ -255,7 +247,7 @@ final class DataTourismeClientTest extends TestCase
         return new DataTourismeClient(
             httpClient: $httpClient ?? $this->createStub(HttpClientInterface::class),
             cache: $cache ?? $this->createStub(CacheInterface::class),
-            rateLimiter: $rateLimiter ?? $this->createStub(RateLimiterFactory::class),
+            rateLimiter: $rateLimiter ?? $this->createStub(RateLimiterFactoryInterface::class),
             logger: $logger ?? $this->createStub(LoggerInterface::class),
             apiKey: $apiKey,
             enabled: $enabled,

--- a/api/tests/Unit/Engine/PricingHeuristicEngineTest.php
+++ b/api/tests/Unit/Engine/PricingHeuristicEngineTest.php
@@ -31,6 +31,8 @@ final class PricingHeuristicEngineTest extends TestCase
         yield 'guest_house' => ['guest_house', 40.0, 80.0];
         yield 'motel' => ['motel', 45.0, 90.0];
         yield 'hotel' => ['hotel', 50.0, 120.0];
+        yield 'wilderness_hut' => ['wilderness_hut', 0.0, 10.0];
+        yield 'shelter' => ['shelter', 0.0, 0.0];
     }
 
     #[DataProvider('priceBracketProvider')]
@@ -111,6 +113,56 @@ final class PricingHeuristicEngineTest extends TestCase
 
         $this->assertSame(20.0, $result['min']);
         $this->assertSame(35.0, $result['max']);
+        $this->assertFalse($result['isExact']);
+    }
+
+    #[Test]
+    public function estimatePriceAppliesBikepackerCapForCampSiteWithBackpackYes(): void
+    {
+        $result = $this->engine->estimatePrice('camp_site', ['backpack' => 'yes']);
+
+        $this->assertSame(8.0, $result['min']);
+        $this->assertSame(15.0, $result['max']);
+        $this->assertFalse($result['isExact']);
+    }
+
+    #[Test]
+    public function estimatePriceAppliesBikepackerCapForCampSiteWithTentsYes(): void
+    {
+        $result = $this->engine->estimatePrice('camp_site', ['tents' => 'yes']);
+
+        $this->assertSame(8.0, $result['min']);
+        $this->assertSame(15.0, $result['max']);
+        $this->assertFalse($result['isExact']);
+    }
+
+    #[Test]
+    public function estimatePriceDoesNotApplyBikepackerCapForCampSiteWithoutBikepackerTags(): void
+    {
+        $result = $this->engine->estimatePrice('camp_site', ['name' => 'Camping Standard']);
+
+        $this->assertSame(8.0, $result['min']);
+        $this->assertSame(25.0, $result['max']);
+        $this->assertFalse($result['isExact']);
+    }
+
+    #[Test]
+    public function estimatePriceReturnsFreeForShelter(): void
+    {
+        $result = $this->engine->estimatePrice('shelter');
+
+        $this->assertSame(0.0, $result['min']);
+        $this->assertSame(0.0, $result['max']);
+        $this->assertFalse($result['isExact']);
+    }
+
+    #[Test]
+    public function estimatePriceReturnsFreeDonationRangeForWildernessHut(): void
+    {
+        $result = $this->engine->estimatePrice('wilderness_hut');
+
+        $this->assertSame(0.0, $result['min']);
+        $this->assertSame(10.0, $result['max']);
         $this->assertFalse($result['isExact']);
     }
 }

--- a/api/tests/Unit/MessageHandler/CheckCulturalPoisHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/CheckCulturalPoisHandlerTest.php
@@ -16,6 +16,7 @@ use App\Mercure\TripUpdatePublisherInterface;
 use App\Message\CheckCulturalPois;
 use App\MessageHandler\CheckCulturalPoisHandler;
 use App\Repository\TripRequestRepositoryInterface;
+use App\Wikidata\WikidataEnricherInterface;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
@@ -71,6 +72,7 @@ final class CheckCulturalPoisHandlerTest extends TestCase
             $distributor,
             $haversine,
             $translator,
+            $this->createStub(WikidataEnricherInterface::class),
         );
     }
 

--- a/api/tests/Unit/MessageHandler/CheckCulturalPoisHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/CheckCulturalPoisHandlerTest.php
@@ -8,6 +8,7 @@ use App\ApiResource\Model\Coordinate;
 use App\ApiResource\Stage;
 use App\ComputationTracker\ComputationTrackerInterface;
 use App\ComputationTracker\TripGenerationTrackerInterface;
+use App\CulturalPoiSource\CulturalPoiSourceRegistry;
 use App\Geo\GeoDistanceInterface;
 use App\Geo\GeometryDistributorInterface;
 use App\Mercure\MercureEventType;
@@ -15,8 +16,6 @@ use App\Mercure\TripUpdatePublisherInterface;
 use App\Message\CheckCulturalPois;
 use App\MessageHandler\CheckCulturalPoisHandler;
 use App\Repository\TripRequestRepositoryInterface;
-use App\Scanner\QueryBuilderInterface;
-use App\Scanner\ScannerInterface;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
@@ -47,8 +46,7 @@ final class CheckCulturalPoisHandlerTest extends TestCase
     private function createHandler(
         TripRequestRepositoryInterface $tripStateManager,
         TripUpdatePublisherInterface $publisher,
-        ScannerInterface $scanner,
-        QueryBuilderInterface $queryBuilder,
+        CulturalPoiSourceRegistry $registry,
         GeoDistanceInterface $haversine,
         ?GeometryDistributorInterface $distributor = null,
     ): CheckCulturalPoisHandler {
@@ -69,8 +67,7 @@ final class CheckCulturalPoisHandlerTest extends TestCase
             $generationTracker,
             new NullLogger(),
             $tripStateManager,
-            $scanner,
-            $queryBuilder,
+            $registry,
             $distributor,
             $haversine,
             $translator,
@@ -89,6 +86,14 @@ final class CheckCulturalPoisHandlerTest extends TestCase
         return $manager;
     }
 
+    private function makeRegistryWithPois(array $pois): CulturalPoiSourceRegistry
+    {
+        $registry = $this->createStub(CulturalPoiSourceRegistry::class);
+        $registry->method('fetchAllForStages')->willReturn($pois);
+
+        return $registry;
+    }
+
     #[Test]
     public function nullStagesYieldsNoPublish(): void
     {
@@ -97,22 +102,21 @@ final class CheckCulturalPoisHandlerTest extends TestCase
         $publisher = $this->createMock(TripUpdatePublisherInterface::class);
         $publisher->expects($this->never())->method('publish');
 
-        $scanner = $this->createStub(ScannerInterface::class);
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
+        $registry = $this->makeRegistryWithPois([]);
         $haversine = $this->createStub(GeoDistanceInterface::class);
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine);
+        $handler = $this->createHandler($tripStateManager, $publisher, $registry, $haversine);
         $handler(new CheckCulturalPois('trip-1'));
     }
 
     #[Test]
-    public function restDayStageIsSkippedAndScannerIsNeverCalled(): void
+    public function restDayStageIsSkippedAndRegistryIsNeverCalled(): void
     {
         $restDay = $this->createStage(1, true);
         $tripStateManager = $this->createTripStateManager([$restDay]);
 
-        $scanner = $this->createMock(ScannerInterface::class);
-        $scanner->expects($this->never())->method('query');
+        $registry = $this->createMock(CulturalPoiSourceRegistry::class);
+        $registry->expects($this->never())->method('fetchAllForStages');
 
         $publishedEvents = [];
         $publisher = $this->createStub(TripUpdatePublisherInterface::class);
@@ -121,10 +125,9 @@ final class CheckCulturalPoisHandlerTest extends TestCase
                 $publishedEvents[] = ['type' => $type, 'payload' => $payload];
             });
 
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
         $haversine = $this->createStub(GeoDistanceInterface::class);
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine);
+        $handler = $this->createHandler($tripStateManager, $publisher, $registry, $haversine);
         $handler(new CheckCulturalPois('trip-1'));
 
         $alertEvents = array_filter($publishedEvents, static fn (array $e): bool => MercureEventType::CULTURAL_POI_ALERTS === $e['type']);
@@ -135,20 +138,12 @@ final class CheckCulturalPoisHandlerTest extends TestCase
     }
 
     #[Test]
-    public function unknownTagsYieldNoAlert(): void
+    public function noPoisFromRegistryYieldsEmptyAlerts(): void
     {
         $stage = $this->createStage(1);
         $tripStateManager = $this->createTripStateManager([$stage]);
 
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('query')->willReturn([
-            'elements' => [
-                // tourism=hotel is not a notable type
-                ['lat' => 48.2, 'lon' => 2.2, 'tags' => ['tourism' => 'hotel', 'name' => 'Hotel des Alpes']],
-                // amenity=parking is unknown
-                ['lat' => 48.3, 'lon' => 2.3, 'tags' => ['amenity' => 'parking']],
-            ],
-        ]);
+        $registry = $this->makeRegistryWithPois([]);
 
         $publishedEvents = [];
         $publisher = $this->createStub(TripUpdatePublisherInterface::class);
@@ -157,59 +152,12 @@ final class CheckCulturalPoisHandlerTest extends TestCase
                 $publishedEvents[] = ['type' => $type, 'payload' => $payload];
             });
 
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildBatchCulturalPoiQuery')->willReturn('query');
-
         $haversine = $this->createStub(GeoDistanceInterface::class);
-        $haversine->method('inMeters')->willReturn(200.0);
 
         $distributor = $this->createStub(GeometryDistributorInterface::class);
-        $distributor->method('distributeByGeometry')->willReturnCallback(
-            static fn (array $items): array => [0 => $items],
-        );
+        $distributor->method('distributeByGeometry')->willReturn([]);
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine, $distributor);
-        $handler(new CheckCulturalPois('trip-1'));
-
-        $alertEvents = array_filter($publishedEvents, static fn (array $e): bool => MercureEventType::CULTURAL_POI_ALERTS === $e['type']);
-        $event = array_first($alertEvents);
-        self::assertNotNull($event);
-        self::assertSame([], $event['payload']['alerts']);
-    }
-
-    #[Test]
-    public function historicValueNotInNotableListIsSkipped(): void
-    {
-        $stage = $this->createStage(1);
-        $tripStateManager = $this->createTripStateManager([$stage]);
-
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('query')->willReturn([
-            'elements' => [
-                // historic=milestone is not in NOTABLE_HISTORIC_VALUES
-                ['lat' => 48.2, 'lon' => 2.2, 'tags' => ['historic' => 'milestone', 'name' => 'Old Milestone']],
-            ],
-        ]);
-
-        $publishedEvents = [];
-        $publisher = $this->createStub(TripUpdatePublisherInterface::class);
-        $publisher->method('publish')
-            ->willReturnCallback(static function (string $tripId, MercureEventType $type, array $payload) use (&$publishedEvents): void {
-                $publishedEvents[] = ['type' => $type, 'payload' => $payload];
-            });
-
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildBatchCulturalPoiQuery')->willReturn('query');
-
-        $haversine = $this->createStub(GeoDistanceInterface::class);
-        $haversine->method('inMeters')->willReturn(100.0);
-
-        $distributor = $this->createStub(GeometryDistributorInterface::class);
-        $distributor->method('distributeByGeometry')->willReturnCallback(
-            static fn (array $items): array => [0 => $items],
-        );
-
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine, $distributor);
+        $handler = $this->createHandler($tripStateManager, $publisher, $registry, $haversine, $distributor);
         $handler(new CheckCulturalPois('trip-1'));
 
         $alertEvents = array_filter($publishedEvents, static fn (array $e): bool => MercureEventType::CULTURAL_POI_ALERTS === $e['type']);
@@ -224,17 +172,14 @@ final class CheckCulturalPoisHandlerTest extends TestCase
         $stage = $this->createStage(1);
         $tripStateManager = $this->createTripStateManager([$stage]);
 
-        $scanner = $this->createStub(ScannerInterface::class);
-        // 4 valid cultural POIs — only the 3 closest should be kept
-        $scanner->method('query')->willReturn([
-            'elements' => [
-                ['lat' => 48.1, 'lon' => 2.1, 'tags' => ['tourism' => 'museum', 'name' => 'Museum A']],
-                ['lat' => 48.15, 'lon' => 2.15, 'tags' => ['tourism' => 'museum', 'name' => 'Museum B']],
-                ['lat' => 48.2, 'lon' => 2.2, 'tags' => ['tourism' => 'museum', 'name' => 'Museum C']],
-                // Museum D is the farthest — should be excluded
-                ['lat' => 48.4, 'lon' => 2.4, 'tags' => ['tourism' => 'museum', 'name' => 'Museum D']],
-            ],
-        ]);
+        $pois = [
+            ['name' => 'Museum A', 'type' => 'museum', 'lat' => 48.1, 'lon' => 2.1, 'source' => 'osm'],
+            ['name' => 'Museum B', 'type' => 'museum', 'lat' => 48.15, 'lon' => 2.15, 'source' => 'osm'],
+            ['name' => 'Museum C', 'type' => 'museum', 'lat' => 48.2, 'lon' => 2.2, 'source' => 'osm'],
+            ['name' => 'Museum D', 'type' => 'museum', 'lat' => 48.4, 'lon' => 2.4, 'source' => 'osm'],
+        ];
+
+        $registry = $this->makeRegistryWithPois($pois);
 
         $publishedEvents = [];
         $publisher = $this->createStub(TripUpdatePublisherInterface::class);
@@ -243,38 +188,31 @@ final class CheckCulturalPoisHandlerTest extends TestCase
                 $publishedEvents[] = ['type' => $type, 'payload' => $payload];
             });
 
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildBatchCulturalPoiQuery')->willReturn('query');
-
         $haversine = $this->createStub(GeoDistanceInterface::class);
-        // Museum D is farthest from all geometry points
         $haversine->method('inMeters')->willReturnCallback(
             static function (float $lat1, float $lon1, float $lat2, float $lon2): float {
                 if (abs($lat2 - 48.4) < 0.01) {
-                    return 400.0;
+                    return 400.0; // Museum D — farthest
                 }
 
-                // Museum D — farthest
                 if (abs($lat2 - 48.2) < 0.01) {
-                    return 300.0;
+                    return 300.0; // Museum C
                 }
 
-                // Museum C
                 if (abs($lat2 - 48.15) < 0.01) {
-                    return 200.0;
-                } // Museum B
+                    return 200.0; // Museum B
+                }
 
                 return 100.0; // Museum A — closest
             },
         );
 
-        // Distributor returns all 4 POIs assigned to stage 0
         $distributor = $this->createStub(GeometryDistributorInterface::class);
         $distributor->method('distributeByGeometry')->willReturnCallback(
             static fn (array $items): array => [0 => $items],
         );
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine, $distributor);
+        $handler = $this->createHandler($tripStateManager, $publisher, $registry, $haversine, $distributor);
         $handler(new CheckCulturalPois('trip-1'));
 
         $alertEvents = array_filter($publishedEvents, static fn (array $e): bool => MercureEventType::CULTURAL_POI_ALERTS === $e['type']);
@@ -290,17 +228,26 @@ final class CheckCulturalPoisHandlerTest extends TestCase
     }
 
     #[Test]
-    public function notableHistoricValueIsIncluded(): void
+    public function enrichmentFieldsFromDataTourismeAreIncludedInAlert(): void
     {
         $stage = $this->createStage(1);
         $tripStateManager = $this->createTripStateManager([$stage]);
 
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('query')->willReturn([
-            'elements' => [
-                ['lat' => 48.2, 'lon' => 2.2, 'tags' => ['historic' => 'castle', 'name' => 'Castle Rock']],
+        $pois = [
+            [
+                'name' => 'Louvre',
+                'type' => 'museum',
+                'lat' => 48.8606,
+                'lon' => 2.3376,
+                'openingHours' => 'Mon–Sat 09:00–18:00',
+                'estimatedPrice' => 15.0,
+                'description' => 'World-famous art museum.',
+                'wikidataId' => 'Q19675',
+                'source' => 'datatourisme',
             ],
-        ]);
+        ];
+
+        $registry = $this->makeRegistryWithPois($pois);
 
         $publishedEvents = [];
         $publisher = $this->createStub(TripUpdatePublisherInterface::class);
@@ -309,19 +256,68 @@ final class CheckCulturalPoisHandlerTest extends TestCase
                 $publishedEvents[] = ['type' => $type, 'payload' => $payload];
             });
 
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildBatchCulturalPoiQuery')->willReturn('query');
-
         $haversine = $this->createStub(GeoDistanceInterface::class);
-        $haversine->method('inMeters')->willReturn(250.0);
+        $haversine->method('inMeters')->willReturn(200.0);
 
-        // Distributor returns the single POI assigned to stage 0
         $distributor = $this->createStub(GeometryDistributorInterface::class);
         $distributor->method('distributeByGeometry')->willReturnCallback(
             static fn (array $items): array => [0 => $items],
         );
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine, $distributor);
+        $handler = $this->createHandler($tripStateManager, $publisher, $registry, $haversine, $distributor);
+        $handler(new CheckCulturalPois('trip-1'));
+
+        $alertEvents = array_filter($publishedEvents, static fn (array $e): bool => MercureEventType::CULTURAL_POI_ALERTS === $e['type']);
+        $event = array_first($alertEvents);
+        self::assertNotNull($event);
+        $alerts = $event['payload']['alerts'];
+
+        self::assertCount(1, $alerts);
+        self::assertSame('Mon–Sat 09:00–18:00', $alerts[0]['openingHours']);
+        self::assertSame(15.0, $alerts[0]['estimatedPrice']);
+        self::assertSame('World-famous art museum.', $alerts[0]['description']);
+        self::assertSame('Q19675', $alerts[0]['wikidataId']);
+        self::assertSame('datatourisme', $alerts[0]['source']);
+    }
+
+    #[Test]
+    public function osmPoiWithoutEnrichmentFieldsDoesNotIncludeThemInAlert(): void
+    {
+        $stage = $this->createStage(1);
+        $tripStateManager = $this->createTripStateManager([$stage]);
+
+        $pois = [
+            [
+                'name' => 'Castle Rock',
+                'type' => 'castle',
+                'lat' => 48.2,
+                'lon' => 2.2,
+                'openingHours' => null,
+                'estimatedPrice' => null,
+                'description' => null,
+                'wikidataId' => null,
+                'source' => 'osm',
+            ],
+        ];
+
+        $registry = $this->makeRegistryWithPois($pois);
+
+        $publishedEvents = [];
+        $publisher = $this->createStub(TripUpdatePublisherInterface::class);
+        $publisher->method('publish')
+            ->willReturnCallback(static function (string $tripId, MercureEventType $type, array $payload) use (&$publishedEvents): void {
+                $publishedEvents[] = ['type' => $type, 'payload' => $payload];
+            });
+
+        $haversine = $this->createStub(GeoDistanceInterface::class);
+        $haversine->method('inMeters')->willReturn(250.0);
+
+        $distributor = $this->createStub(GeometryDistributorInterface::class);
+        $distributor->method('distributeByGeometry')->willReturnCallback(
+            static fn (array $items): array => [0 => $items],
+        );
+
+        $handler = $this->createHandler($tripStateManager, $publisher, $registry, $haversine, $distributor);
         $handler(new CheckCulturalPois('trip-1'));
 
         $alertEvents = array_filter($publishedEvents, static fn (array $e): bool => MercureEventType::CULTURAL_POI_ALERTS === $e['type']);
@@ -334,5 +330,9 @@ final class CheckCulturalPoisHandlerTest extends TestCase
         self::assertSame('Castle Rock', $alerts[0]['poiName']);
         self::assertSame('nudge', $alerts[0]['type']);
         self::assertSame(250, $alerts[0]['distanceFromRoute']);
+        self::assertArrayNotHasKey('openingHours', $alerts[0]);
+        self::assertArrayNotHasKey('estimatedPrice', $alerts[0]);
+        self::assertArrayNotHasKey('description', $alerts[0]);
+        self::assertArrayNotHasKey('wikidataId', $alerts[0]);
     }
 }

--- a/api/tests/Unit/MessageHandler/CheckCulturalPoisHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/CheckCulturalPoisHandlerTest.php
@@ -88,6 +88,9 @@ final class CheckCulturalPoisHandlerTest extends TestCase
         return $manager;
     }
 
+    /**
+     * @param list<array<string, mixed>> $pois
+     */
     private function makeRegistryWithPois(array $pois): CulturalPoiSourceRegistry
     {
         $registry = $this->createStub(CulturalPoiSourceRegistry::class);

--- a/api/tests/Unit/MessageHandler/ScanAccommodationsHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/ScanAccommodationsHandlerTest.php
@@ -19,6 +19,7 @@ use App\Mercure\TripUpdatePublisherInterface;
 use App\Message\ScanAccommodations;
 use App\MessageHandler\ScanAccommodationsHandler;
 use App\Repository\TripRequestRepositoryInterface;
+use App\Wikidata\WikidataEnricherInterface;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
@@ -79,6 +80,7 @@ final class ScanAccommodationsHandlerTest extends TestCase
             $seasonalityChecker,
             $translator,
             $scraperClient,
+            $this->createStub(WikidataEnricherInterface::class),
         );
     }
 

--- a/api/tests/Unit/MessageHandler/ScanAccommodationsHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/ScanAccommodationsHandlerTest.php
@@ -626,6 +626,192 @@ final class ScanAccommodationsHandlerTest extends TestCase
     }
 
     #[Test]
+    public function wildernessHutIsRecognisedAsTypeWildernessHut(): void
+    {
+        $stage = $this->createStage('trip-wilderness', 48.5, 2.5);
+
+        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
+        $tripStateManager->method('getStages')->willReturn([$stage]);
+        $tripStateManager->method('getLocale')->willReturn('en');
+        $tripStateManager->method('getRequest')->willReturn(null);
+
+        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
+        $queryBuilder->method('buildAccommodationQuery')->willReturn('query');
+
+        $scanner = $this->createStub(ScannerInterface::class);
+        $scanner->method('query')->willReturn([
+            'elements' => [
+                ['lat' => 48.6, 'lon' => 2.6, 'tags' => ['tourism' => 'wilderness_hut', 'name' => 'Refuge du Sommet']],
+            ],
+        ]);
+
+        $distributor = $this->createStub(GeometryDistributorInterface::class);
+        $distributor->method('distributeByEndpoint')->willReturn([
+            0 => [
+                [
+                    'name' => 'Refuge du Sommet',
+                    'type' => 'wilderness_hut',
+                    'lat' => 48.6,
+                    'lon' => 2.6,
+                    'priceMin' => 0.0,
+                    'priceMax' => 10.0,
+                    'isExact' => false,
+                    'url' => null,
+                    'tagCount' => 2,
+                    'hasWebsite' => false,
+                    'tags' => ['tourism' => 'wilderness_hut', 'name' => 'Refuge du Sommet'],
+                ],
+            ],
+        ]);
+
+        $haversine = $this->createStub(GeoDistanceInterface::class);
+        $haversine->method('inKilometers')->willReturn(1.0);
+
+        $publisher = $this->createMock(TripUpdatePublisherInterface::class);
+        $publisher->expects($this->once())
+            ->method('publish')
+            ->with(
+                'trip-wilderness',
+                MercureEventType::ACCOMMODATIONS_FOUND,
+                $this->callback(static function (array $data): bool {
+                    $acc = $data['accommodations'][0] ?? null;
+
+                    return null !== $acc
+                        && 'wilderness_hut' === $acc['type']
+                        && 0.0 === $acc['estimatedPriceMin']
+                        && 10.0 === $acc['estimatedPriceMax'];
+                }),
+            );
+
+        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine, $distributor);
+        $handler(new ScanAccommodations('trip-wilderness'));
+    }
+
+    #[Test]
+    public function amenityShelterElementIsMappedToTypeShelt(): void
+    {
+        $stage = $this->createStage('trip-shelter', 48.5, 2.5);
+
+        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
+        $tripStateManager->method('getStages')->willReturn([$stage]);
+        $tripStateManager->method('getLocale')->willReturn('en');
+        $tripStateManager->method('getRequest')->willReturn(null);
+
+        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
+        $queryBuilder->method('buildAccommodationQuery')->willReturn('query');
+
+        $scanner = $this->createStub(ScannerInterface::class);
+        $scanner->method('query')->willReturn([
+            'elements' => [
+                ['lat' => 48.6, 'lon' => 2.6, 'tags' => ['amenity' => 'shelter', 'shelter_type' => 'lean_to', 'name' => 'Lean-To Shelter']],
+            ],
+        ]);
+
+        $distributor = $this->createStub(GeometryDistributorInterface::class);
+        $distributor->method('distributeByEndpoint')->willReturn([
+            0 => [
+                [
+                    'name' => 'Lean-To Shelter',
+                    'type' => 'shelter',
+                    'lat' => 48.6,
+                    'lon' => 2.6,
+                    'priceMin' => 0.0,
+                    'priceMax' => 0.0,
+                    'isExact' => false,
+                    'url' => null,
+                    'tagCount' => 3,
+                    'hasWebsite' => false,
+                    'tags' => ['amenity' => 'shelter', 'shelter_type' => 'lean_to', 'name' => 'Lean-To Shelter'],
+                ],
+            ],
+        ]);
+
+        $haversine = $this->createStub(GeoDistanceInterface::class);
+        $haversine->method('inKilometers')->willReturn(0.5);
+
+        $publisher = $this->createMock(TripUpdatePublisherInterface::class);
+        $publisher->expects($this->once())
+            ->method('publish')
+            ->with(
+                'trip-shelter',
+                MercureEventType::ACCOMMODATIONS_FOUND,
+                $this->callback(static function (array $data): bool {
+                    $acc = $data['accommodations'][0] ?? null;
+
+                    return null !== $acc
+                        && 'shelter' === $acc['type']
+                        && 0.0 === $acc['estimatedPriceMin']
+                        && 0.0 === $acc['estimatedPriceMax'];
+                }),
+            );
+
+        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine, $distributor);
+        $handler(new ScanAccommodations('trip-shelter'));
+    }
+
+    #[Test]
+    public function campSiteWithBackpackYesReceivesBikepackerFriendlyPricing(): void
+    {
+        $stage = $this->createStage('trip-backpack', 48.5, 2.5);
+
+        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
+        $tripStateManager->method('getStages')->willReturn([$stage]);
+        $tripStateManager->method('getLocale')->willReturn('en');
+        $tripStateManager->method('getRequest')->willReturn(null);
+
+        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
+        $queryBuilder->method('buildAccommodationQuery')->willReturn('query');
+
+        $scanner = $this->createStub(ScannerInterface::class);
+        $scanner->method('query')->willReturn([
+            'elements' => [
+                ['lat' => 48.6, 'lon' => 2.6, 'tags' => ['tourism' => 'camp_site', 'backpack' => 'yes', 'name' => 'Wild Camp']],
+            ],
+        ]);
+
+        $distributor = $this->createStub(GeometryDistributorInterface::class);
+        $distributor->method('distributeByEndpoint')->willReturn([
+            0 => [
+                [
+                    'name' => 'Wild Camp',
+                    'type' => 'camp_site',
+                    'lat' => 48.6,
+                    'lon' => 2.6,
+                    'priceMin' => 8.0,
+                    'priceMax' => 15.0,
+                    'isExact' => false,
+                    'url' => null,
+                    'tagCount' => 3,
+                    'hasWebsite' => false,
+                    'tags' => ['tourism' => 'camp_site', 'backpack' => 'yes', 'name' => 'Wild Camp'],
+                ],
+            ],
+        ]);
+
+        $haversine = $this->createStub(GeoDistanceInterface::class);
+        $haversine->method('inKilometers')->willReturn(2.0);
+
+        $publisher = $this->createMock(TripUpdatePublisherInterface::class);
+        $publisher->expects($this->once())
+            ->method('publish')
+            ->with(
+                'trip-backpack',
+                MercureEventType::ACCOMMODATIONS_FOUND,
+                $this->callback(static function (array $data): bool {
+                    $acc = $data['accommodations'][0] ?? null;
+
+                    return null !== $acc
+                        && 'camp_site' === $acc['type']
+                        && 8.0 === $acc['estimatedPriceMin']
+                        && 15.0 === $acc['estimatedPriceMax'];
+                }),
+            );
+
+        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine, $distributor);
+        $handler(new ScanAccommodations('trip-backpack'));
+    }
+
+    #[Test]
     public function wave2TimeoutPreservesHeuristicPriceAndDoesNotThrow(): void
     {
         $stage = $this->createStage('trip-wave2', 48.5, 2.5);

--- a/api/tests/Unit/MessageHandler/ScanAccommodationsHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/ScanAccommodationsHandlerTest.php
@@ -6,12 +6,12 @@ namespace App\Tests\Unit\MessageHandler;
 
 use App\Accommodation\AccommodationMetadataExtractor;
 use App\Accommodation\SeasonalityCheckerInterface;
+use App\AccommodationSource\AccommodationSourceRegistry;
 use App\ApiResource\Model\Accommodation;
 use App\ApiResource\Model\Coordinate;
 use App\ApiResource\Stage;
 use App\ComputationTracker\ComputationTrackerInterface;
 use App\ComputationTracker\TripGenerationTrackerInterface;
-use App\Engine\PricingHeuristicEngine;
 use App\Geo\GeoDistanceInterface;
 use App\Geo\GeometryDistributorInterface;
 use App\Mercure\MercureEventType;
@@ -19,8 +19,6 @@ use App\Mercure\TripUpdatePublisherInterface;
 use App\Message\ScanAccommodations;
 use App\MessageHandler\ScanAccommodationsHandler;
 use App\Repository\TripRequestRepositoryInterface;
-use App\Scanner\QueryBuilderInterface;
-use App\Scanner\ScannerInterface;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
@@ -46,16 +44,13 @@ final class ScanAccommodationsHandlerTest extends TestCase
     private function createHandler(
         TripRequestRepositoryInterface $tripStateManager,
         TripUpdatePublisherInterface $publisher,
-        ScannerInterface $scanner,
-        QueryBuilderInterface $queryBuilder,
+        AccommodationSourceRegistry $registry,
         GeoDistanceInterface $haversine,
         GeometryDistributorInterface $distributor,
         ?HttpClientInterface $scraperClient = null,
     ): ScanAccommodationsHandler {
         $computationTracker = $this->createStub(ComputationTrackerInterface::class);
         $computationTracker->method('isAllComplete')->willReturn(false);
-
-        $pricingEngine = new PricingHeuristicEngine();
 
         $metadataExtractor = new AccommodationMetadataExtractor();
 
@@ -77,9 +72,7 @@ final class ScanAccommodationsHandlerTest extends TestCase
             $generationTracker,
             new NullLogger(),
             $tripStateManager,
-            $scanner,
-            $queryBuilder,
-            $pricingEngine,
+            $registry,
             $haversine,
             $distributor,
             $metadataExtractor,
@@ -87,6 +80,17 @@ final class ScanAccommodationsHandlerTest extends TestCase
             $translator,
             $scraperClient,
         );
+    }
+
+    /**
+     * @param array<int, list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>}>> $candidatesByStage
+     */
+    private function createRegistryWithCandidates(array $candidatesByStage): AccommodationSourceRegistry
+    {
+        $registry = $this->createStub(AccommodationSourceRegistry::class);
+        $registry->method('fetchAll')->willReturn(array_merge(...array_values($candidatesByStage)));
+
+        return $registry;
     }
 
     #[Test]
@@ -99,20 +103,25 @@ final class ScanAccommodationsHandlerTest extends TestCase
         $tripStateManager->method('getLocale')->willReturn('en');
         $tripStateManager->method('getRequest')->willReturn(null);
 
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildAccommodationQuery')->willReturn('query');
-
         $accommodationLat = 48.6;
         $accommodationLon = 2.6;
 
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('query')->willReturn([
-            'elements' => [
-                [
-                    'lat' => $accommodationLat,
-                    'lon' => $accommodationLon,
-                    'tags' => ['tourism' => 'hotel', 'name' => 'Hotel du Nord'],
-                ],
+        $registry = $this->createStub(AccommodationSourceRegistry::class);
+        $registry->method('fetchAll')->willReturn([
+            [
+                'name' => 'Hotel du Nord',
+                'type' => 'hotel',
+                'lat' => $accommodationLat,
+                'lon' => $accommodationLon,
+                'priceMin' => 50.0,
+                'priceMax' => 120.0,
+                'isExact' => false,
+                'url' => null,
+                'tagCount' => 2,
+                'hasWebsite' => false,
+                'tags' => ['tourism' => 'hotel', 'name' => 'Hotel du Nord'],
+                'source' => 'osm',
+                'wikidataId' => null,
             ],
         ]);
 
@@ -131,6 +140,8 @@ final class ScanAccommodationsHandlerTest extends TestCase
                     'tagCount' => 2,
                     'hasWebsite' => false,
                     'tags' => ['tourism' => 'hotel', 'name' => 'Hotel du Nord'],
+                    'source' => 'osm',
+                    'wikidataId' => null,
                 ],
             ],
         ]);
@@ -156,7 +167,7 @@ final class ScanAccommodationsHandlerTest extends TestCase
                 }),
             );
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine, $distributor);
+        $handler = $this->createHandler($tripStateManager, $publisher, $registry, $haversine, $distributor);
         $handler(new ScanAccommodations('trip-1'));
     }
 
@@ -170,19 +181,8 @@ final class ScanAccommodationsHandlerTest extends TestCase
         $tripStateManager->method('getLocale')->willReturn('en');
         $tripStateManager->method('getRequest')->willReturn(null);
 
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildAccommodationQuery')->willReturn('query');
-
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('query')->willReturn([
-            'elements' => [
-                [
-                    'lat' => 48.6,
-                    'lon' => 2.6,
-                    'tags' => ['tourism' => 'camp_site', 'name' => 'Camping du Lac'],
-                ],
-            ],
-        ]);
+        $registry = $this->createStub(AccommodationSourceRegistry::class);
+        $registry->method('fetchAll')->willReturn([]);
 
         $distributor = $this->createStub(GeometryDistributorInterface::class);
         $distributor->method('distributeByEndpoint')->willReturn([
@@ -199,6 +199,8 @@ final class ScanAccommodationsHandlerTest extends TestCase
                     'tagCount' => 2,
                     'hasWebsite' => false,
                     'tags' => ['tourism' => 'camp_site', 'name' => 'Camping du Lac'],
+                    'source' => 'osm',
+                    'wikidataId' => null,
                 ],
             ],
         ]);
@@ -223,14 +225,13 @@ final class ScanAccommodationsHandlerTest extends TestCase
                 }),
             );
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine, $distributor);
+        $handler = $this->createHandler($tripStateManager, $publisher, $registry, $haversine, $distributor);
         $handler(new ScanAccommodations('trip-1'));
     }
 
     #[Test]
     public function zeroDistanceAccommodationPublishesZeroPointZero(): void
     {
-        // Accommodation at the exact same coordinates as the stage endpoint
         $endLat = 48.5;
         $endLon = 2.5;
         $stage = $this->createStage('trip-1', $endLat, $endLon);
@@ -240,19 +241,8 @@ final class ScanAccommodationsHandlerTest extends TestCase
         $tripStateManager->method('getLocale')->willReturn('en');
         $tripStateManager->method('getRequest')->willReturn(null);
 
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildAccommodationQuery')->willReturn('query');
-
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('query')->willReturn([
-            'elements' => [
-                [
-                    'lat' => $endLat,
-                    'lon' => $endLon,
-                    'tags' => ['tourism' => 'hostel', 'name' => 'Hostel Central'],
-                ],
-            ],
-        ]);
+        $registry = $this->createStub(AccommodationSourceRegistry::class);
+        $registry->method('fetchAll')->willReturn([]);
 
         $distributor = $this->createStub(GeometryDistributorInterface::class);
         $distributor->method('distributeByEndpoint')->willReturn([
@@ -269,11 +259,12 @@ final class ScanAccommodationsHandlerTest extends TestCase
                     'tagCount' => 2,
                     'hasWebsite' => false,
                     'tags' => ['tourism' => 'hostel', 'name' => 'Hostel Central'],
+                    'source' => 'osm',
+                    'wikidataId' => null,
                 ],
             ],
         ]);
 
-        // haversine returns 0.0 when accommodation is at the same location as endpoint
         $haversine = $this->createStub(GeoDistanceInterface::class);
         $haversine->method('inKilometers')->willReturn(0.0);
 
@@ -291,12 +282,12 @@ final class ScanAccommodationsHandlerTest extends TestCase
                 }),
             );
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine, $distributor);
+        $handler = $this->createHandler($tripStateManager, $publisher, $registry, $haversine, $distributor);
         $handler(new ScanAccommodations('trip-1'));
     }
 
     #[Test]
-    public function buildAccommodationQueryReceivesStageEndPoints(): void
+    public function registryReceivesStageEndPointsAndRadiusAndEnabledTypes(): void
     {
         $stage = $this->createStage('trip-1', 48.5, 2.5);
 
@@ -305,28 +296,25 @@ final class ScanAccommodationsHandlerTest extends TestCase
         $tripStateManager->method('getLocale')->willReturn('en');
         $tripStateManager->method('getRequest')->willReturn(null);
 
-        $queryBuilder = $this->createMock(QueryBuilderInterface::class);
-        $queryBuilder->expects($this->once())
-            ->method('buildAccommodationQuery')
+        $registry = $this->createMock(AccommodationSourceRegistry::class);
+        $registry->expects($this->once())
+            ->method('fetchAll')
             ->with(
                 $this->callback(static fn (array $points): bool => 1 === \count($points)
                     && 48.5 === $points[0]->lat
                     && 2.5 === $points[0]->lon),
                 $this->anything(),
+                $this->anything(),
             )
-            ->willReturn('query');
-
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('query')->willReturn(['elements' => []]);
+            ->willReturn([]);
 
         $distributor = $this->createStub(GeometryDistributorInterface::class);
         $distributor->method('distributeByEndpoint')->willReturn([]);
 
         $haversine = $this->createStub(GeoDistanceInterface::class);
-
         $publisher = $this->createStub(TripUpdatePublisherInterface::class);
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine, $distributor);
+        $handler = $this->createHandler($tripStateManager, $publisher, $registry, $haversine, $distributor);
         $handler(new ScanAccommodations('trip-1'));
     }
 
@@ -340,21 +328,15 @@ final class ScanAccommodationsHandlerTest extends TestCase
         $tripStateManager->method('getLocale')->willReturn('en');
         $tripStateManager->method('getRequest')->willReturn(null);
 
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildAccommodationQuery')->willReturn('query');
-
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('query')->willReturn([
-            'elements' => [
-                ['lat' => 48.6, 'lon' => 2.6, 'tags' => ['tourism' => 'hotel', 'name' => 'Hotel A']],
-            ],
-        ]);
+        $registry = $this->createStub(AccommodationSourceRegistry::class);
+        $registry->method('fetchAll')->willReturn([]);
 
         $distributor = $this->createStub(GeometryDistributorInterface::class);
         $distributor->method('distributeByEndpoint')->willReturn([
             0 => [['name' => 'Hotel A', 'type' => 'hotel', 'lat' => 48.6, 'lon' => 2.6,
                 'priceMin' => 50.0, 'priceMax' => 100.0, 'isExact' => false,
-                'url' => null, 'tagCount' => 2, 'hasWebsite' => false, 'tags' => []]],
+                'url' => null, 'tagCount' => 2, 'hasWebsite' => false, 'tags' => [],
+                'source' => 'osm', 'wikidataId' => null]],
         ]);
 
         $haversine = $this->createStub(GeoDistanceInterface::class);
@@ -369,7 +351,7 @@ final class ScanAccommodationsHandlerTest extends TestCase
                 $this->callback(static fn (array $d): bool => 1 === \count($d['accommodations']))
             );
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine, $distributor);
+        $handler = $this->createHandler($tripStateManager, $publisher, $registry, $haversine, $distributor);
         $handler(new ScanAccommodations('trip-2'));
         $handler(new ScanAccommodations('trip-2'));
 
@@ -381,7 +363,6 @@ final class ScanAccommodationsHandlerTest extends TestCase
     {
         $stage = $this->createStage('trip-3', 48.5, 2.5);
 
-        // Pre-populate the stage with one existing accommodation
         $existing = new Accommodation(
             name: 'Camping du Lac',
             type: 'camp_site',
@@ -399,22 +380,15 @@ final class ScanAccommodationsHandlerTest extends TestCase
         $tripStateManager->method('getLocale')->willReturn('en');
         $tripStateManager->method('getRequest')->willReturn(null);
 
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildAccommodationQuery')->willReturn('query');
-
-        // Scanner returns a new accommodation (different coordinates — not a duplicate)
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('query')->willReturn([
-            'elements' => [
-                ['lat' => 48.7, 'lon' => 2.7, 'tags' => ['tourism' => 'hotel', 'name' => 'Hotel du Nord']],
-            ],
-        ]);
+        $registry = $this->createStub(AccommodationSourceRegistry::class);
+        $registry->method('fetchAll')->willReturn([]);
 
         $distributor = $this->createStub(GeometryDistributorInterface::class);
         $distributor->method('distributeByEndpoint')->willReturn([
             0 => [['name' => 'Hotel du Nord', 'type' => 'hotel', 'lat' => 48.7, 'lon' => 2.7,
                 'priceMin' => 60.0, 'priceMax' => 120.0, 'isExact' => false,
-                'url' => null, 'tagCount' => 2, 'hasWebsite' => false, 'tags' => []]],
+                'url' => null, 'tagCount' => 2, 'hasWebsite' => false, 'tags' => [],
+                'source' => 'osm', 'wikidataId' => null]],
         ]);
 
         $haversine = $this->createStub(GeoDistanceInterface::class);
@@ -427,7 +401,6 @@ final class ScanAccommodationsHandlerTest extends TestCase
                 'trip-3',
                 MercureEventType::ACCOMMODATIONS_FOUND,
                 $this->callback(static function (array $data): bool {
-                    // Both the existing and the new accommodation must be present
                     $accommodations = $data['accommodations'];
                     if (2 !== \count($accommodations)) {
                         return false;
@@ -440,10 +413,9 @@ final class ScanAccommodationsHandlerTest extends TestCase
                 }),
             );
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine, $distributor);
+        $handler = $this->createHandler($tripStateManager, $publisher, $registry, $haversine, $distributor);
         $handler(new ScanAccommodations('trip-3', isExpandScan: true));
 
-        // Stage accommodations must contain both entries after the expand scan
         $this->assertCount(2, $stage->accommodations);
     }
 
@@ -457,22 +429,16 @@ final class ScanAccommodationsHandlerTest extends TestCase
         $tripStateManager->method('getLocale')->willReturn('en');
         $tripStateManager->method('getRequest')->willReturn(null);
 
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildAccommodationQuery')->willReturn('query');
-
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('query')->willReturn([
-            'elements' => [
-                ['lat' => 48.6, 'lon' => 2.6, 'tags' => ['tourism' => 'hotel', 'name' => 'Hotel Test', 'website' => 'https://example.com']],
-            ],
-        ]);
+        $registry = $this->createStub(AccommodationSourceRegistry::class);
+        $registry->method('fetchAll')->willReturn([]);
 
         $distributor = $this->createStub(GeometryDistributorInterface::class);
         $distributor->method('distributeByEndpoint')->willReturn([
             0 => [['name' => 'Hotel Test', 'type' => 'hotel', 'lat' => 48.6, 'lon' => 2.6,
                 'priceMin' => 50.0, 'priceMax' => 100.0, 'isExact' => false,
                 'url' => 'https://example.com', 'tagCount' => 3, 'hasWebsite' => true,
-                'tags' => ['tourism' => 'hotel', 'name' => 'Hotel Test', 'website' => 'https://example.com']]],
+                'tags' => ['tourism' => 'hotel', 'name' => 'Hotel Test', 'website' => 'https://example.com'],
+                'source' => 'osm', 'wikidataId' => null]],
         ]);
 
         $haversine = $this->createStub(GeoDistanceInterface::class);
@@ -489,12 +455,12 @@ final class ScanAccommodationsHandlerTest extends TestCase
 
         $publisher = $this->createStub(TripUpdatePublisherInterface::class);
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine, $distributor, $scraperClient);
+        $handler = $this->createHandler($tripStateManager, $publisher, $registry, $haversine, $distributor, $scraperClient);
         $handler(new ScanAccommodations('trip-timeout'));
     }
 
     #[Test]
-    public function wave1TimeoutPreservesOsmDataAndDoesNotThrow(): void
+    public function wave1TimeoutPreservesSourceDataAndDoesNotThrow(): void
     {
         $stage = $this->createStage('trip-fallback', 48.5, 2.5);
 
@@ -503,28 +469,21 @@ final class ScanAccommodationsHandlerTest extends TestCase
         $tripStateManager->method('getLocale')->willReturn('en');
         $tripStateManager->method('getRequest')->willReturn(null);
 
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildAccommodationQuery')->willReturn('query');
-
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('query')->willReturn([
-            'elements' => [
-                ['lat' => 48.6, 'lon' => 2.6, 'tags' => ['tourism' => 'hotel', 'name' => 'Hotel Timeout', 'website' => 'https://slow-site.example.com']],
-            ],
-        ]);
+        $registry = $this->createStub(AccommodationSourceRegistry::class);
+        $registry->method('fetchAll')->willReturn([]);
 
         $distributor = $this->createStub(GeometryDistributorInterface::class);
         $distributor->method('distributeByEndpoint')->willReturn([
             0 => [['name' => 'Hotel Timeout', 'type' => 'hotel', 'lat' => 48.6, 'lon' => 2.6,
                 'priceMin' => 50.0, 'priceMax' => 100.0, 'isExact' => false,
                 'url' => 'https://slow-site.example.com', 'tagCount' => 3, 'hasWebsite' => true,
-                'tags' => ['tourism' => 'hotel', 'name' => 'Hotel Timeout', 'website' => 'https://slow-site.example.com']]],
+                'tags' => ['tourism' => 'hotel', 'name' => 'Hotel Timeout', 'website' => 'https://slow-site.example.com'],
+                'source' => 'osm', 'wikidataId' => null]],
         ]);
 
         $haversine = $this->createStub(GeoDistanceInterface::class);
         $haversine->method('inKilometers')->willReturn(2.5);
 
-        // Simulate a timeout: request succeeds (non-blocking) but getContent() throws
         $response = $this->createStub(ResponseInterface::class);
         $response->method('getContent')->willThrowException(new TimeoutException('Idle timeout reached'));
 
@@ -540,7 +499,6 @@ final class ScanAccommodationsHandlerTest extends TestCase
                 $this->callback(static function (array $data): bool {
                     $accommodations = $data['accommodations'];
 
-                    // Accommodation must still be present with its original OSM data
                     return 1 === \count($accommodations)
                         && 'Hotel Timeout' === $accommodations[0]['name']
                         && 'hotel' === $accommodations[0]['type']
@@ -553,10 +511,9 @@ final class ScanAccommodationsHandlerTest extends TestCase
                 }),
             );
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine, $distributor, $scraperClient);
+        $handler = $this->createHandler($tripStateManager, $publisher, $registry, $haversine, $distributor, $scraperClient);
         $handler(new ScanAccommodations('trip-fallback'));
 
-        // Accommodation is still added to the stage despite scraping failure
         $this->assertCount(1, $stage->accommodations);
         $this->assertSame('Hotel Timeout', $stage->accommodations[0]->name);
         $this->assertFalse($stage->accommodations[0]->possibleClosed);
@@ -572,32 +529,24 @@ final class ScanAccommodationsHandlerTest extends TestCase
         $tripStateManager->method('getLocale')->willReturn('en');
         $tripStateManager->method('getRequest')->willReturn(null);
 
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildAccommodationQuery')->willReturn('query');
-
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('query')->willReturn([
-            'elements' => [
-                ['lat' => 48.6, 'lon' => 2.6, 'tags' => ['tourism' => 'hotel', 'name' => 'Hotel Test', 'website' => 'https://example.com']],
-            ],
-        ]);
+        $registry = $this->createStub(AccommodationSourceRegistry::class);
+        $registry->method('fetchAll')->willReturn([]);
 
         $distributor = $this->createStub(GeometryDistributorInterface::class);
         $distributor->method('distributeByEndpoint')->willReturn([
             0 => [['name' => 'Hotel Test', 'type' => 'hotel', 'lat' => 48.6, 'lon' => 2.6,
                 'priceMin' => 50.0, 'priceMax' => 100.0, 'isExact' => false,
                 'url' => 'https://example.com', 'tagCount' => 3, 'hasWebsite' => true,
-                'tags' => ['tourism' => 'hotel', 'name' => 'Hotel Test', 'website' => 'https://example.com']]],
+                'tags' => ['tourism' => 'hotel', 'name' => 'Hotel Test', 'website' => 'https://example.com'],
+                'source' => 'osm', 'wikidataId' => null]],
         ]);
 
         $haversine = $this->createStub(GeoDistanceInterface::class);
         $haversine->method('inKilometers')->willReturn(1.0);
 
-        // Wave 1: return HTML with no price but with a price-page link (triggers wave 2)
         $wave1Response = $this->createStub(ResponseInterface::class);
         $wave1Response->method('getContent')->willReturn('<html><body><a href="https://example.com/tarifs">Tarifs</a></body></html>');
 
-        // Wave 2: return simple HTML
         $wave2Response = $this->createStub(ResponseInterface::class);
         $wave2Response->method('getContent')->willReturn('<html><body>65€ per night</body></html>');
 
@@ -621,7 +570,7 @@ final class ScanAccommodationsHandlerTest extends TestCase
 
         $publisher = $this->createStub(TripUpdatePublisherInterface::class);
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine, $distributor, $scraperClient);
+        $handler = $this->createHandler($tripStateManager, $publisher, $registry, $haversine, $distributor, $scraperClient);
         $handler(new ScanAccommodations('trip-timeout2'));
     }
 
@@ -635,15 +584,8 @@ final class ScanAccommodationsHandlerTest extends TestCase
         $tripStateManager->method('getLocale')->willReturn('en');
         $tripStateManager->method('getRequest')->willReturn(null);
 
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildAccommodationQuery')->willReturn('query');
-
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('query')->willReturn([
-            'elements' => [
-                ['lat' => 48.6, 'lon' => 2.6, 'tags' => ['tourism' => 'wilderness_hut', 'name' => 'Refuge du Sommet']],
-            ],
-        ]);
+        $registry = $this->createStub(AccommodationSourceRegistry::class);
+        $registry->method('fetchAll')->willReturn([]);
 
         $distributor = $this->createStub(GeometryDistributorInterface::class);
         $distributor->method('distributeByEndpoint')->willReturn([
@@ -660,6 +602,8 @@ final class ScanAccommodationsHandlerTest extends TestCase
                     'tagCount' => 2,
                     'hasWebsite' => false,
                     'tags' => ['tourism' => 'wilderness_hut', 'name' => 'Refuge du Sommet'],
+                    'source' => 'osm',
+                    'wikidataId' => null,
                 ],
             ],
         ]);
@@ -683,12 +627,12 @@ final class ScanAccommodationsHandlerTest extends TestCase
                 }),
             );
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine, $distributor);
+        $handler = $this->createHandler($tripStateManager, $publisher, $registry, $haversine, $distributor);
         $handler(new ScanAccommodations('trip-wilderness'));
     }
 
     #[Test]
-    public function amenityShelterElementIsMappedToTypeShelt(): void
+    public function amenityShelterElementIsMappedToTypeShelter(): void
     {
         $stage = $this->createStage('trip-shelter', 48.5, 2.5);
 
@@ -697,15 +641,8 @@ final class ScanAccommodationsHandlerTest extends TestCase
         $tripStateManager->method('getLocale')->willReturn('en');
         $tripStateManager->method('getRequest')->willReturn(null);
 
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildAccommodationQuery')->willReturn('query');
-
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('query')->willReturn([
-            'elements' => [
-                ['lat' => 48.6, 'lon' => 2.6, 'tags' => ['amenity' => 'shelter', 'shelter_type' => 'lean_to', 'name' => 'Lean-To Shelter']],
-            ],
-        ]);
+        $registry = $this->createStub(AccommodationSourceRegistry::class);
+        $registry->method('fetchAll')->willReturn([]);
 
         $distributor = $this->createStub(GeometryDistributorInterface::class);
         $distributor->method('distributeByEndpoint')->willReturn([
@@ -722,6 +659,8 @@ final class ScanAccommodationsHandlerTest extends TestCase
                     'tagCount' => 3,
                     'hasWebsite' => false,
                     'tags' => ['amenity' => 'shelter', 'shelter_type' => 'lean_to', 'name' => 'Lean-To Shelter'],
+                    'source' => 'osm',
+                    'wikidataId' => null,
                 ],
             ],
         ]);
@@ -745,7 +684,7 @@ final class ScanAccommodationsHandlerTest extends TestCase
                 }),
             );
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine, $distributor);
+        $handler = $this->createHandler($tripStateManager, $publisher, $registry, $haversine, $distributor);
         $handler(new ScanAccommodations('trip-shelter'));
     }
 
@@ -759,15 +698,8 @@ final class ScanAccommodationsHandlerTest extends TestCase
         $tripStateManager->method('getLocale')->willReturn('en');
         $tripStateManager->method('getRequest')->willReturn(null);
 
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildAccommodationQuery')->willReturn('query');
-
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('query')->willReturn([
-            'elements' => [
-                ['lat' => 48.6, 'lon' => 2.6, 'tags' => ['tourism' => 'camp_site', 'backpack' => 'yes', 'name' => 'Wild Camp']],
-            ],
-        ]);
+        $registry = $this->createStub(AccommodationSourceRegistry::class);
+        $registry->method('fetchAll')->willReturn([]);
 
         $distributor = $this->createStub(GeometryDistributorInterface::class);
         $distributor->method('distributeByEndpoint')->willReturn([
@@ -784,6 +716,8 @@ final class ScanAccommodationsHandlerTest extends TestCase
                     'tagCount' => 3,
                     'hasWebsite' => false,
                     'tags' => ['tourism' => 'camp_site', 'backpack' => 'yes', 'name' => 'Wild Camp'],
+                    'source' => 'osm',
+                    'wikidataId' => null,
                 ],
             ],
         ]);
@@ -807,7 +741,7 @@ final class ScanAccommodationsHandlerTest extends TestCase
                 }),
             );
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine, $distributor);
+        $handler = $this->createHandler($tripStateManager, $publisher, $registry, $haversine, $distributor);
         $handler(new ScanAccommodations('trip-backpack'));
     }
 
@@ -821,32 +755,24 @@ final class ScanAccommodationsHandlerTest extends TestCase
         $tripStateManager->method('getLocale')->willReturn('en');
         $tripStateManager->method('getRequest')->willReturn(null);
 
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildAccommodationQuery')->willReturn('query');
-
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('query')->willReturn([
-            'elements' => [
-                ['lat' => 48.6, 'lon' => 2.6, 'tags' => ['tourism' => 'hotel', 'name' => 'Hotel Wave2', 'website' => 'https://wave2.example.com']],
-            ],
-        ]);
+        $registry = $this->createStub(AccommodationSourceRegistry::class);
+        $registry->method('fetchAll')->willReturn([]);
 
         $distributor = $this->createStub(GeometryDistributorInterface::class);
         $distributor->method('distributeByEndpoint')->willReturn([
             0 => [['name' => 'Hotel Wave2', 'type' => 'hotel', 'lat' => 48.6, 'lon' => 2.6,
                 'priceMin' => 50.0, 'priceMax' => 100.0, 'isExact' => false,
                 'url' => 'https://wave2.example.com', 'tagCount' => 3, 'hasWebsite' => true,
-                'tags' => ['tourism' => 'hotel', 'name' => 'Hotel Wave2', 'website' => 'https://wave2.example.com']]],
+                'tags' => ['tourism' => 'hotel', 'name' => 'Hotel Wave2', 'website' => 'https://wave2.example.com'],
+                'source' => 'osm', 'wikidataId' => null]],
         ]);
 
         $haversine = $this->createStub(GeoDistanceInterface::class);
         $haversine->method('inKilometers')->willReturn(1.5);
 
-        // Wave 1: return HTML with price-page link (triggers wave 2)
         $wave1Response = $this->createStub(ResponseInterface::class);
         $wave1Response->method('getContent')->willReturn('<html><body><a href="https://wave2.example.com/tarifs">Tarifs</a></body></html>');
 
-        // Wave 2: timeout on price page
         $wave2Response = $this->createStub(ResponseInterface::class);
         $wave2Response->method('getContent')->willThrowException(new TimeoutException('Idle timeout reached'));
 
@@ -867,7 +793,6 @@ final class ScanAccommodationsHandlerTest extends TestCase
                 $this->callback(static function (array $data): bool {
                     $accommodations = $data['accommodations'];
 
-                    // Accommodation retains heuristic price (wave 2 failed)
                     return 1 === \count($accommodations)
                         && 'Hotel Wave2' === $accommodations[0]['name']
                         && 50.0 === $accommodations[0]['estimatedPriceMin']
@@ -876,10 +801,69 @@ final class ScanAccommodationsHandlerTest extends TestCase
                 }),
             );
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine, $distributor, $scraperClient);
+        $handler = $this->createHandler($tripStateManager, $publisher, $registry, $haversine, $distributor, $scraperClient);
         $handler(new ScanAccommodations('trip-wave2'));
 
         $this->assertCount(1, $stage->accommodations);
         $this->assertFalse($stage->accommodations[0]->isExactPrice);
+    }
+
+    #[Test]
+    public function sourceFieldIsPublishedInMercurePayload(): void
+    {
+        $stage = $this->createStage('trip-source', 48.5, 2.5);
+
+        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
+        $tripStateManager->method('getStages')->willReturn([$stage]);
+        $tripStateManager->method('getLocale')->willReturn('en');
+        $tripStateManager->method('getRequest')->willReturn(null);
+
+        $registry = $this->createStub(AccommodationSourceRegistry::class);
+        $registry->method('fetchAll')->willReturn([]);
+
+        $distributor = $this->createStub(GeometryDistributorInterface::class);
+        $distributor->method('distributeByEndpoint')->willReturn([
+            0 => [
+                [
+                    'name' => 'Hotel DataTourisme',
+                    'type' => 'hotel',
+                    'lat' => 48.6,
+                    'lon' => 2.6,
+                    'priceMin' => 80.0,
+                    'priceMax' => 150.0,
+                    'isExact' => true,
+                    'url' => 'https://hotel.example.fr',
+                    'tagCount' => 0,
+                    'hasWebsite' => true,
+                    'tags' => [],
+                    'source' => 'datatourisme',
+                    'wikidataId' => null,
+                ],
+            ],
+        ]);
+
+        $haversine = $this->createStub(GeoDistanceInterface::class);
+        $haversine->method('inKilometers')->willReturn(1.0);
+
+        $scraperClient = $this->createStub(HttpClientInterface::class);
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getContent')->willReturn('<html></html>');
+        $scraperClient->method('request')->willReturn($response);
+
+        $publisher = $this->createMock(TripUpdatePublisherInterface::class);
+        $publisher->expects($this->once())
+            ->method('publish')
+            ->with(
+                'trip-source',
+                MercureEventType::ACCOMMODATIONS_FOUND,
+                $this->callback(static function (array $data): bool {
+                    $acc = $data['accommodations'][0] ?? null;
+
+                    return null !== $acc && 'datatourisme' === $acc['source'];
+                }),
+            );
+
+        $handler = $this->createHandler($tripStateManager, $publisher, $registry, $haversine, $distributor, $scraperClient);
+        $handler(new ScanAccommodations('trip-source'));
     }
 }

--- a/api/tests/Unit/MessageHandler/ScanAccommodationsHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/ScanAccommodationsHandlerTest.php
@@ -84,17 +84,6 @@ final class ScanAccommodationsHandlerTest extends TestCase
         );
     }
 
-    /**
-     * @param array<int, list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>}>> $candidatesByStage
-     */
-    private function createRegistryWithCandidates(array $candidatesByStage): AccommodationSourceRegistry
-    {
-        $registry = $this->createStub(AccommodationSourceRegistry::class);
-        $registry->method('fetchAll')->willReturn(array_merge(...array_values($candidatesByStage)));
-
-        return $registry;
-    }
-
     #[Test]
     public function distanceToEndPointIsComputedFromAccommodationCoordinatesToStageEndPoint(): void
     {

--- a/api/tests/Unit/MessageHandler/ScanEventsHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/ScanEventsHandlerTest.php
@@ -289,7 +289,7 @@ final class ScanEventsHandlerTest extends TestCase
             static fn (array $e): bool => MercureEventType::EVENTS_FOUND === $e['type'],
         );
 
-        $event = array_values($eventsPublished)[0] ?? null;
+        $event = array_first($eventsPublished) ?? null;
         self::assertNotNull($event);
         self::assertCount(0, $event['payload']['events']);
     }

--- a/api/tests/Unit/MessageHandler/ScanEventsHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/ScanEventsHandlerTest.php
@@ -16,6 +16,7 @@ use App\Mercure\TripUpdatePublisherInterface;
 use App\Message\ScanEvents;
 use App\MessageHandler\ScanEventsHandler;
 use App\Repository\TripRequestRepositoryInterface;
+use App\Wikidata\WikidataEnricherInterface;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
@@ -54,6 +55,7 @@ final class ScanEventsHandlerTest extends TestCase
             $tripStateManager,
             $dataTourismeClient,
             $haversine,
+            $this->createStub(WikidataEnricherInterface::class),
         );
     }
 

--- a/api/tests/Unit/MessageHandler/ScanEventsHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/ScanEventsHandlerTest.php
@@ -22,6 +22,7 @@ use App\Wikidata\WikidataEnricherInterface;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 final class ScanEventsHandlerTest extends TestCase
 {
@@ -44,6 +45,7 @@ final class ScanEventsHandlerTest extends TestCase
         DataTourismeClientInterface $dataTourismeClient,
         GeoDistanceInterface $haversine,
         ?MarketRepositoryInterface $marketRepository = null,
+        ?TranslatorInterface $translator = null,
     ): ScanEventsHandler {
         $computationTracker = $this->createStub(ComputationTrackerInterface::class);
         $computationTracker->method('isAllComplete')->willReturn(false);
@@ -51,6 +53,7 @@ final class ScanEventsHandlerTest extends TestCase
         $generationTracker = $this->createStub(TripGenerationTrackerInterface::class);
 
         $marketRepository ??= $this->createStub(MarketRepositoryInterface::class);
+        $translator ??= $this->createStub(TranslatorInterface::class);
 
         return new ScanEventsHandler(
             $computationTracker,
@@ -62,6 +65,7 @@ final class ScanEventsHandlerTest extends TestCase
             $haversine,
             $this->createStub(WikidataEnricherInterface::class),
             $marketRepository,
+            $translator,
         );
     }
 
@@ -191,12 +195,12 @@ final class ScanEventsHandlerTest extends TestCase
         $dataTourismeClient->method('request')->willReturnCallback(
             static function (string $path, array $query) use ($festivalResult, $exhibitionResult): array {
                 // stage 0: 2025-07-10 → festival is ongoing
-                if ('2025-07-10' === ($query['startDate[before]'] ?? null)) {
+                if ('2025-07-10' === ($query['filters[1][value]'] ?? null)) {
                     return ['results' => [$festivalResult]];
                 }
 
                 // stage 1: 2025-07-11 → exhibition starts
-                if ('2025-07-11' === ($query['startDate[before]'] ?? null)) {
+                if ('2025-07-11' === ($query['filters[1][value]'] ?? null)) {
                     return ['results' => [$exhibitionResult]];
                 }
 
@@ -378,6 +382,9 @@ final class ScanEventsHandlerTest extends TestCase
         $marketRepository = $this->createStub(MarketRepositoryInterface::class);
         $marketRepository->method('findNearEndpoint')->willReturn([$market]);
 
+        $translator = $this->createStub(TranslatorInterface::class);
+        $translator->method('trans')->willReturn('Weekly market');
+
         $publishedEvents = [];
         $publisher = $this->createStub(TripUpdatePublisherInterface::class);
         $publisher->method('publish')
@@ -392,7 +399,7 @@ final class ScanEventsHandlerTest extends TestCase
         $haversine = $this->createStub(GeoDistanceInterface::class);
         $haversine->method('inMeters')->willReturn(400.0);
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $dataTourismeClient, $haversine, $marketRepository);
+        $handler = $this->createHandler($tripStateManager, $publisher, $dataTourismeClient, $haversine, $marketRepository, $translator);
         $handler(new ScanEvents('trip-1'));
 
         $eventsPublished = array_values(array_filter(
@@ -412,6 +419,6 @@ final class ScanEventsHandlerTest extends TestCase
         self::assertCount(1, $marketEvents);
         self::assertSame('Marché du Lundi', $marketEvents[0]['name']);
         self::assertSame('market', $marketEvents[0]['type']);
-        self::assertSame('Marché hebdomadaire', $marketEvents[0]['description']);
+        self::assertSame('Weekly market', $marketEvents[0]['description']);
     }
 }

--- a/api/tests/Unit/MessageHandler/ScanEventsHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/ScanEventsHandlerTest.php
@@ -10,11 +10,13 @@ use App\ApiResource\TripRequest;
 use App\ComputationTracker\ComputationTrackerInterface;
 use App\ComputationTracker\TripGenerationTrackerInterface;
 use App\DataTourisme\DataTourismeClientInterface;
+use App\Entity\Market;
 use App\Geo\GeoDistanceInterface;
 use App\Mercure\MercureEventType;
 use App\Mercure\TripUpdatePublisherInterface;
 use App\Message\ScanEvents;
 use App\MessageHandler\ScanEventsHandler;
+use App\Repository\MarketRepositoryInterface;
 use App\Repository\TripRequestRepositoryInterface;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -40,11 +42,14 @@ final class ScanEventsHandlerTest extends TestCase
         TripUpdatePublisherInterface $publisher,
         DataTourismeClientInterface $dataTourismeClient,
         GeoDistanceInterface $haversine,
+        ?MarketRepositoryInterface $marketRepository = null,
     ): ScanEventsHandler {
         $computationTracker = $this->createStub(ComputationTrackerInterface::class);
         $computationTracker->method('isAllComplete')->willReturn(false);
 
         $generationTracker = $this->createStub(TripGenerationTrackerInterface::class);
+
+        $marketRepository ??= $this->createStub(MarketRepositoryInterface::class);
 
         return new ScanEventsHandler(
             $computationTracker,
@@ -54,6 +59,7 @@ final class ScanEventsHandlerTest extends TestCase
             $tripStateManager,
             $dataTourismeClient,
             $haversine,
+            $marketRepository,
         );
     }
 
@@ -329,5 +335,81 @@ final class ScanEventsHandlerTest extends TestCase
 
         self::assertCount(1, $eventsPublished);
         self::assertSame('Q12345', $eventsPublished[0]['payload']['events'][0]['wikidataId']);
+    }
+
+    #[Test]
+    public function mergesDataTourismeAndMarketEventsForSameStage(): void
+    {
+        // 2025-07-14 is a Monday (ISO day 1)
+        $startDate = new \DateTimeImmutable('2025-07-14');
+        $stage = $this->createStage(1);
+
+        $festivalResult = [
+            '@type' => ['schema:Festival'],
+            'rdfs:label' => 'Festival Jazz',
+            'hasGeometry' => ['latitude' => 48.5, 'longitude' => 2.5],
+            'startDate' => '2025-07-14',
+            'endDate' => '2025-07-18',
+        ];
+
+        $exhibitionResult = [
+            '@type' => ['schema:Exhibition'],
+            'rdfs:label' => 'Expo Impressionnisme',
+            'hasGeometry' => ['latitude' => 48.51, 'longitude' => 2.51],
+            'startDate' => '2025-07-12',
+            'endDate' => '2025-07-20',
+        ];
+
+        $dataTourismeClient = $this->createStub(DataTourismeClientInterface::class);
+        $dataTourismeClient->method('isEnabled')->willReturn(true);
+        $dataTourismeClient->method('request')->willReturn(['results' => [$festivalResult, $exhibitionResult]]);
+
+        $market = new Market('MKT-MON-001', 'Marché du Lundi');
+        $market->setLat(48.49);
+        $market->setLon(2.49);
+        $market->setDayOfWeek(1);
+        $market->setStartTime('07:00');
+        $market->setEndTime('13:00');
+        $market->setCommune('Paris');
+        $market->setDepartment('75');
+
+        $marketRepository = $this->createStub(MarketRepositoryInterface::class);
+        $marketRepository->method('findNearEndpoint')->willReturn([$market]);
+
+        $publishedEvents = [];
+        $publisher = $this->createStub(TripUpdatePublisherInterface::class);
+        $publisher->method('publish')
+            ->willReturnCallback(static function (string $tripId, MercureEventType $type, array $payload) use (&$publishedEvents): void {
+                $publishedEvents[] = ['type' => $type, 'payload' => $payload];
+            });
+
+        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
+        $tripStateManager->method('getStages')->willReturn([$stage]);
+        $tripStateManager->method('getRequest')->willReturn($this->createTripRequest($startDate));
+
+        $haversine = $this->createStub(GeoDistanceInterface::class);
+        $haversine->method('inMeters')->willReturn(400.0);
+
+        $handler = $this->createHandler($tripStateManager, $publisher, $dataTourismeClient, $haversine, $marketRepository);
+        $handler(new ScanEvents('trip-1'));
+
+        $eventsPublished = array_values(array_filter(
+            $publishedEvents,
+            static fn (array $e): bool => MercureEventType::EVENTS_FOUND === $e['type'],
+        ));
+
+        self::assertCount(1, $eventsPublished);
+        $events = $eventsPublished[0]['payload']['events'];
+        self::assertCount(3, $events);
+
+        $sources = array_column($events, 'source');
+        self::assertContains('datatourisme', $sources);
+        self::assertContains('data_gouv_markets', $sources);
+
+        $marketEvents = array_values(array_filter($events, static fn (array $e): bool => 'data_gouv_markets' === $e['source']));
+        self::assertCount(1, $marketEvents);
+        self::assertSame('Marché du Lundi', $marketEvents[0]['name']);
+        self::assertSame('market', $marketEvents[0]['type']);
+        self::assertSame('Marché hebdomadaire', $marketEvents[0]['description']);
     }
 }

--- a/api/tests/Unit/MessageHandler/ScanEventsHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/ScanEventsHandlerTest.php
@@ -1,0 +1,333 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\MessageHandler;
+
+use App\ApiResource\Model\Coordinate;
+use App\ApiResource\Stage;
+use App\ApiResource\TripRequest;
+use App\ComputationTracker\ComputationTrackerInterface;
+use App\ComputationTracker\TripGenerationTrackerInterface;
+use App\DataTourisme\DataTourismeClientInterface;
+use App\Geo\GeoDistanceInterface;
+use App\Mercure\MercureEventType;
+use App\Mercure\TripUpdatePublisherInterface;
+use App\Message\ScanEvents;
+use App\MessageHandler\ScanEventsHandler;
+use App\Repository\TripRequestRepositoryInterface;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+final class ScanEventsHandlerTest extends TestCase
+{
+    private function createStage(int $dayNumber, bool $isRestDay = false): Stage
+    {
+        return new Stage(
+            tripId: 'trip-1',
+            dayNumber: $dayNumber,
+            distance: $isRestDay ? 0.0 : 80.0,
+            elevation: 500.0,
+            startPoint: new Coordinate(lat: 48.0, lon: 2.0),
+            endPoint: new Coordinate(lat: 48.5, lon: 2.5),
+            isRestDay: $isRestDay,
+        );
+    }
+
+    private function createHandler(
+        TripRequestRepositoryInterface $tripStateManager,
+        TripUpdatePublisherInterface $publisher,
+        DataTourismeClientInterface $dataTourismeClient,
+        GeoDistanceInterface $haversine,
+    ): ScanEventsHandler {
+        $computationTracker = $this->createStub(ComputationTrackerInterface::class);
+        $computationTracker->method('isAllComplete')->willReturn(false);
+
+        $generationTracker = $this->createStub(TripGenerationTrackerInterface::class);
+
+        return new ScanEventsHandler(
+            $computationTracker,
+            $publisher,
+            $generationTracker,
+            new NullLogger(),
+            $tripStateManager,
+            $dataTourismeClient,
+            $haversine,
+        );
+    }
+
+    private function createTripRequest(\DateTimeImmutable $startDate): TripRequest
+    {
+        $request = new TripRequest();
+        $request->startDate = $startDate;
+
+        return $request;
+    }
+
+    #[Test]
+    public function disabledClientSkipsPublish(): void
+    {
+        $dataTourismeClient = $this->createStub(DataTourismeClientInterface::class);
+        $dataTourismeClient->method('isEnabled')->willReturn(false);
+
+        $publisher = $this->createMock(TripUpdatePublisherInterface::class);
+        $publisher->expects($this->never())->method('publish');
+
+        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
+
+        $haversine = $this->createStub(GeoDistanceInterface::class);
+
+        $handler = $this->createHandler($tripStateManager, $publisher, $dataTourismeClient, $haversine);
+        $handler(new ScanEvents('trip-1'));
+    }
+
+    #[Test]
+    public function nullStagesSkipsPublish(): void
+    {
+        $dataTourismeClient = $this->createStub(DataTourismeClientInterface::class);
+        $dataTourismeClient->method('isEnabled')->willReturn(true);
+
+        $publisher = $this->createMock(TripUpdatePublisherInterface::class);
+        $publisher->expects($this->never())->method('publish');
+
+        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
+        $tripStateManager->method('getStages')->willReturn(null);
+
+        $haversine = $this->createStub(GeoDistanceInterface::class);
+
+        $handler = $this->createHandler($tripStateManager, $publisher, $dataTourismeClient, $haversine);
+        $handler(new ScanEvents('trip-1'));
+    }
+
+    #[Test]
+    public function noStartDateSkipsPublish(): void
+    {
+        $dataTourismeClient = $this->createStub(DataTourismeClientInterface::class);
+        $dataTourismeClient->method('isEnabled')->willReturn(true);
+
+        $publisher = $this->createMock(TripUpdatePublisherInterface::class);
+        $publisher->expects($this->never())->method('publish');
+
+        $stage = $this->createStage(1);
+        $request = new TripRequest();
+        // startDate is null
+
+        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
+        $tripStateManager->method('getStages')->willReturn([$stage]);
+        $tripStateManager->method('getRequest')->willReturn($request);
+
+        $haversine = $this->createStub(GeoDistanceInterface::class);
+
+        $handler = $this->createHandler($tripStateManager, $publisher, $dataTourismeClient, $haversine);
+        $handler(new ScanEvents('trip-1'));
+    }
+
+    #[Test]
+    public function restDayStageIsSkipped(): void
+    {
+        $startDate = new \DateTimeImmutable('2025-07-01');
+        $restDay = $this->createStage(1, true);
+
+        $dataTourismeClient = $this->createMock(DataTourismeClientInterface::class);
+        $dataTourismeClient->method('isEnabled')->willReturn(true);
+        $dataTourismeClient->expects($this->never())->method('request');
+
+        $publishedEvents = [];
+        $publisher = $this->createStub(TripUpdatePublisherInterface::class);
+        $publisher->method('publish')
+            ->willReturnCallback(static function (string $tripId, MercureEventType $type, array $payload) use (&$publishedEvents): void {
+                $publishedEvents[] = ['type' => $type, 'payload' => $payload];
+            });
+
+        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
+        $tripStateManager->method('getStages')->willReturn([$restDay]);
+        $tripStateManager->method('getRequest')->willReturn($this->createTripRequest($startDate));
+
+        $haversine = $this->createStub(GeoDistanceInterface::class);
+
+        $handler = $this->createHandler($tripStateManager, $publisher, $dataTourismeClient, $haversine);
+        $handler(new ScanEvents('trip-1'));
+
+        self::assertCount(0, $publishedEvents);
+    }
+
+    #[Test]
+    public function threeStagesWithTemporalFilterPublishesEventsFound(): void
+    {
+        $startDate = new \DateTimeImmutable('2025-07-10');
+        $stage0 = $this->createStage(1);
+        $stage1 = $this->createStage(2);
+        $stage2 = $this->createStage(3);
+
+        $festivalResult = [
+            '@type' => ['schema:Festival'],
+            'rdfs:label' => 'Festival de Jazz',
+            'hasGeometry' => ['latitude' => 48.5, 'longitude' => 2.5],
+            'startDate' => '2025-07-10',
+            'endDate' => '2025-07-14',
+            'foaf:homepage' => 'https://festival.example.com',
+            'shortDescription' => 'Grand festival annuel',
+        ];
+
+        $exhibitionResult = [
+            '@type' => ['schema:Exhibition'],
+            'rdfs:label' => 'Expo Renoir',
+            'hasGeometry' => ['latitude' => 48.51, 'longitude' => 2.51],
+            'startDate' => '2025-07-11',
+            'endDate' => '2025-07-30',
+        ];
+
+        $dataTourismeClient = $this->createStub(DataTourismeClientInterface::class);
+        $dataTourismeClient->method('isEnabled')->willReturn(true);
+        $dataTourismeClient->method('request')->willReturnCallback(
+            static function (string $path, array $query) use ($festivalResult, $exhibitionResult): array {
+                // stage 0: 2025-07-10 → festival is ongoing
+                if ('2025-07-10' === ($query['startDate[before]'] ?? null)) {
+                    return ['results' => [$festivalResult]];
+                }
+
+                // stage 1: 2025-07-11 → exhibition starts
+                if ('2025-07-11' === ($query['startDate[before]'] ?? null)) {
+                    return ['results' => [$exhibitionResult]];
+                }
+
+                return ['results' => []];
+            },
+        );
+
+        $publishedEvents = [];
+        $publisher = $this->createStub(TripUpdatePublisherInterface::class);
+        $publisher->method('publish')
+            ->willReturnCallback(static function (string $tripId, MercureEventType $type, array $payload) use (&$publishedEvents): void {
+                $publishedEvents[] = ['type' => $type, 'payload' => $payload];
+            });
+
+        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
+        $tripStateManager->method('getStages')->willReturn([$stage0, $stage1, $stage2]);
+        $tripStateManager->method('getRequest')->willReturn($this->createTripRequest($startDate));
+
+        $haversine = $this->createStub(GeoDistanceInterface::class);
+        $haversine->method('inMeters')->willReturn(500.0);
+
+        $handler = $this->createHandler($tripStateManager, $publisher, $dataTourismeClient, $haversine);
+        $handler(new ScanEvents('trip-1'));
+
+        $eventsPublished = array_filter(
+            $publishedEvents,
+            static fn (array $e): bool => MercureEventType::EVENTS_FOUND === $e['type'],
+        );
+
+        // stage 0 and stage 1 publish events; stage 2 publishes empty
+        self::assertCount(3, $eventsPublished);
+
+        $eventsPublished = array_values($eventsPublished);
+
+        // stage 0
+        self::assertSame(0, $eventsPublished[0]['payload']['stageIndex']);
+        self::assertCount(1, $eventsPublished[0]['payload']['events']);
+        self::assertSame('Festival de Jazz', $eventsPublished[0]['payload']['events'][0]['name']);
+        self::assertSame('schema:Festival', $eventsPublished[0]['payload']['events'][0]['type']);
+        self::assertSame('https://festival.example.com', $eventsPublished[0]['payload']['events'][0]['url']);
+        self::assertSame('Grand festival annuel', $eventsPublished[0]['payload']['events'][0]['description']);
+        self::assertSame('datatourisme', $eventsPublished[0]['payload']['events'][0]['source']);
+
+        // stage 1
+        self::assertSame(1, $eventsPublished[1]['payload']['stageIndex']);
+        self::assertCount(1, $eventsPublished[1]['payload']['events']);
+        self::assertSame('Expo Renoir', $eventsPublished[1]['payload']['events'][0]['name']);
+
+        // stage 2 → empty
+        self::assertSame(2, $eventsPublished[2]['payload']['stageIndex']);
+        self::assertCount(0, $eventsPublished[2]['payload']['events']);
+    }
+
+    #[Test]
+    public function unknownTypeIsFiltered(): void
+    {
+        $startDate = new \DateTimeImmutable('2025-08-01');
+        $stage = $this->createStage(1);
+
+        $unknownResult = [
+            '@type' => ['schema:SportsEvent'],
+            'rdfs:label' => 'Triathlon',
+            'hasGeometry' => ['latitude' => 48.5, 'longitude' => 2.5],
+            'startDate' => '2025-08-01',
+            'endDate' => '2025-08-02',
+        ];
+
+        $dataTourismeClient = $this->createStub(DataTourismeClientInterface::class);
+        $dataTourismeClient->method('isEnabled')->willReturn(true);
+        $dataTourismeClient->method('request')->willReturn(['results' => [$unknownResult]]);
+
+        $publishedEvents = [];
+        $publisher = $this->createStub(TripUpdatePublisherInterface::class);
+        $publisher->method('publish')
+            ->willReturnCallback(static function (string $tripId, MercureEventType $type, array $payload) use (&$publishedEvents): void {
+                $publishedEvents[] = ['type' => $type, 'payload' => $payload];
+            });
+
+        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
+        $tripStateManager->method('getStages')->willReturn([$stage]);
+        $tripStateManager->method('getRequest')->willReturn($this->createTripRequest($startDate));
+
+        $haversine = $this->createStub(GeoDistanceInterface::class);
+
+        $handler = $this->createHandler($tripStateManager, $publisher, $dataTourismeClient, $haversine);
+        $handler(new ScanEvents('trip-1'));
+
+        $eventsPublished = array_filter(
+            $publishedEvents,
+            static fn (array $e): bool => MercureEventType::EVENTS_FOUND === $e['type'],
+        );
+
+        $event = array_values($eventsPublished)[0] ?? null;
+        self::assertNotNull($event);
+        self::assertCount(0, $event['payload']['events']);
+    }
+
+    #[Test]
+    public function wikidataIdIsExtracted(): void
+    {
+        $startDate = new \DateTimeImmutable('2025-09-01');
+        $stage = $this->createStage(1);
+
+        $result = [
+            '@type' => ['schema:MusicEvent'],
+            'rdfs:label' => 'Concert en plein air',
+            'hasGeometry' => ['latitude' => 48.5, 'longitude' => 2.5],
+            'startDate' => '2025-09-01',
+            'endDate' => '2025-09-01',
+            'owl:sameAs' => ['https://www.wikidata.org/entity/Q12345', 'https://dbpedia.org/page/Concert'],
+        ];
+
+        $dataTourismeClient = $this->createStub(DataTourismeClientInterface::class);
+        $dataTourismeClient->method('isEnabled')->willReturn(true);
+        $dataTourismeClient->method('request')->willReturn(['results' => [$result]]);
+
+        $publishedEvents = [];
+        $publisher = $this->createStub(TripUpdatePublisherInterface::class);
+        $publisher->method('publish')
+            ->willReturnCallback(static function (string $tripId, MercureEventType $type, array $payload) use (&$publishedEvents): void {
+                $publishedEvents[] = ['type' => $type, 'payload' => $payload];
+            });
+
+        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
+        $tripStateManager->method('getStages')->willReturn([$stage]);
+        $tripStateManager->method('getRequest')->willReturn($this->createTripRequest($startDate));
+
+        $haversine = $this->createStub(GeoDistanceInterface::class);
+        $haversine->method('inMeters')->willReturn(300.0);
+
+        $handler = $this->createHandler($tripStateManager, $publisher, $dataTourismeClient, $haversine);
+        $handler(new ScanEvents('trip-1'));
+
+        $eventsPublished = array_values(array_filter(
+            $publishedEvents,
+            static fn (array $e): bool => MercureEventType::EVENTS_FOUND === $e['type'],
+        ));
+
+        self::assertCount(1, $eventsPublished);
+        self::assertSame('Q12345', $eventsPublished[0]['payload']['events'][0]['wikidataId']);
+    }
+}

--- a/api/tests/Unit/Repository/MarketRepositoryTest.php
+++ b/api/tests/Unit/Repository/MarketRepositoryTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Repository;
 
+use Doctrine\ORM\UnitOfWork;
+use Doctrine\ORM\Persisters\Entity\EntityPersister;
 use App\Entity\Market;
 use App\Repository\MarketRepository;
 use Doctrine\ORM\EntityManagerInterface;
@@ -97,9 +99,9 @@ final class MarketRepositoryTest extends TestCase
     #[Test]
     public function findByExternalIdReturnsNullWhenNotFound(): void
     {
-        $unitOfWork = $this->createStub(\Doctrine\ORM\UnitOfWork::class);
+        $unitOfWork = $this->createStub(UnitOfWork::class);
         $unitOfWork->method('getEntityPersister')->willReturn(
-            $this->createConfiguredStub(\Doctrine\ORM\Persisters\Entity\EntityPersister::class, [
+            $this->createConfiguredStub(EntityPersister::class, [
                 'load' => null,
             ])
         );

--- a/api/tests/Unit/Repository/MarketRepositoryTest.php
+++ b/api/tests/Unit/Repository/MarketRepositoryTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Repository;
+
+use App\Entity\Market;
+use App\Repository\MarketRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Query;
+use Doctrine\ORM\QueryBuilder;
+use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\Stub;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(MarketRepository::class)]
+final class MarketRepositoryTest extends TestCase
+{
+    private MarketRepository $repository;
+
+    /** @var EntityManagerInterface&Stub */
+    private EntityManagerInterface $entityManager;
+
+    /** @var QueryBuilder&Stub */
+    private QueryBuilder $queryBuilder;
+
+    /** @var Query&Stub */
+    private Query $query;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->entityManager = $this->createStub(EntityManagerInterface::class);
+        $this->entityManager->method('getClassMetadata')
+            ->willReturn(new ClassMetadata(Market::class));
+
+        $registry = $this->createStub(ManagerRegistry::class);
+        $registry->method('getManagerForClass')->willReturn($this->entityManager);
+
+        $this->query = $this->createStub(Query::class);
+
+        $this->queryBuilder = $this->createStub(QueryBuilder::class);
+        $this->queryBuilder->method('select')->willReturnSelf();
+        $this->queryBuilder->method('from')->willReturnSelf();
+        $this->queryBuilder->method('where')->willReturnSelf();
+        $this->queryBuilder->method('andWhere')->willReturnSelf();
+        $this->queryBuilder->method('setParameter')->willReturnSelf();
+        $this->queryBuilder->method('getQuery')->willReturn($this->query);
+
+        $this->entityManager->method('createQueryBuilder')->willReturn($this->queryBuilder);
+
+        $this->repository = new MarketRepository($registry);
+    }
+
+    #[Test]
+    public function findNearEndpointFiltersOutMarketsBeyondRadius(): void
+    {
+        $marketClose = $this->makeMarket('MKT-1', 48.5, 2.5, 3);
+        $marketFar = $this->makeMarket('MKT-2', 52.0, 5.0, 3);
+
+        $this->query->method('getResult')->willReturn([$marketClose, $marketFar]);
+
+        $results = $this->repository->findNearEndpoint(48.5, 2.5, 20_000, 3);
+
+        $this->assertCount(1, $results);
+        $this->assertSame('MKT-1', $results[0]->getExternalId());
+    }
+
+    #[Test]
+    public function findNearEndpointReturnsEmptyWhenNoMarketsInBbox(): void
+    {
+        $this->query->method('getResult')->willReturn([]);
+
+        $results = $this->repository->findNearEndpoint(48.5, 2.5, 20_000, 2);
+
+        $this->assertCount(0, $results);
+    }
+
+    #[Test]
+    public function findNearEndpointOnlyIncludesMatchingDayOfWeek(): void
+    {
+        // The day-of-week filter happens in the DQL query (mocked), so this verifies
+        // that only markets returned by the query (already filtered by day) pass through.
+        $marketWedThursday = $this->makeMarket('MKT-3', 48.5, 2.5, 4);
+
+        $this->query->method('getResult')->willReturn([$marketWedThursday]);
+
+        $results = $this->repository->findNearEndpoint(48.5, 2.5, 20_000, 4);
+
+        $this->assertCount(1, $results);
+        $this->assertSame(4, $results[0]->getDayOfWeek());
+    }
+
+    #[Test]
+    public function findByExternalIdReturnsNullWhenNotFound(): void
+    {
+        $unitOfWork = $this->createStub(\Doctrine\ORM\UnitOfWork::class);
+        $unitOfWork->method('getEntityPersister')->willReturn(
+            $this->createConfiguredStub(\Doctrine\ORM\Persisters\Entity\EntityPersister::class, [
+                'load' => null,
+            ])
+        );
+        $this->entityManager->method('getUnitOfWork')->willReturn($unitOfWork);
+
+        $result = $this->repository->findByExternalId('NON-EXISTENT');
+
+        $this->assertNull($result);
+    }
+
+    private function makeMarket(string $externalId, float $lat, float $lon, int $dayOfWeek): Market
+    {
+        $market = new Market($externalId, 'Test Market');
+        $market->setLat($lat);
+        $market->setLon($lon);
+        $market->setDayOfWeek($dayOfWeek);
+        $market->setCommune('Test');
+        $market->setDepartment('00');
+
+        return $market;
+    }
+}

--- a/api/tests/Unit/Scanner/OsmOverpassQueryBuilderTest.php
+++ b/api/tests/Unit/Scanner/OsmOverpassQueryBuilderTest.php
@@ -129,6 +129,23 @@ final class OsmOverpassQueryBuilderTest extends TestCase
         $this->assertStringContainsString('guest_house', $query);
         $this->assertStringContainsString('chalet', $query);
         $this->assertStringContainsString('alpine_hut', $query);
+        $this->assertStringContainsString('wilderness_hut', $query);
+        $this->assertStringContainsString('"amenity"="shelter"', $query);
+        $this->assertStringContainsString('basic_hut', $query);
+        $this->assertStringContainsString('weather_shelter', $query);
+        $this->assertStringContainsString('lean_to', $query);
+    }
+
+    #[Test]
+    public function buildAccommodationQueryWithShelterOnlyEmitsAmenityFilter(): void
+    {
+        $points = [new Coordinate(45.0, 5.0)];
+
+        $query = $this->builder->buildAccommodationQuery($points, 5000, ['shelter']);
+
+        $this->assertStringContainsString('"amenity"="shelter"', $query);
+        $this->assertStringContainsString('"shelter_type"~"^(basic_hut|weather_shelter|lean_to)$"', $query);
+        $this->assertStringNotContainsString('"tourism"', $query);
     }
 
     #[Test]
@@ -145,6 +162,7 @@ final class OsmOverpassQueryBuilderTest extends TestCase
         $this->assertStringNotContainsString('guest_house', $query);
         $this->assertStringNotContainsString('chalet', $query);
         $this->assertStringNotContainsString('alpine_hut', $query);
+        $this->assertStringNotContainsString('"amenity"="shelter"', $query);
     }
 
     #[Test]

--- a/api/tests/Unit/Wikidata/WikidataClientTest.php
+++ b/api/tests/Unit/Wikidata/WikidataClientTest.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Wikidata;
+
+use App\Wikidata\WikidataClient;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+final class WikidataClientTest extends TestCase
+{
+    // -------------------------------------------------------------------------
+    // query() — cache hit
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function queryCachedResultSkipsHttpCall(): void
+    {
+        $bindings = [
+            ['item' => ['type' => 'uri', 'value' => 'http://www.wikidata.org/entity/Q1']],
+        ];
+
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->expects($this->once())
+            ->method('get')
+            ->willReturn($bindings);
+
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient->expects($this->never())->method('request');
+
+        $client = $this->makeClient(cache: $cache, httpClient: $httpClient);
+
+        $result = $client->query('SELECT ?item WHERE { wd:Q1 ?p ?o }');
+
+        $this->assertSame($bindings, $result);
+    }
+
+    // -------------------------------------------------------------------------
+    // query() — cache miss → HTTP call
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function queryCacheMissFetchesAndCaches(): void
+    {
+        $fixture = json_decode(
+            (string) file_get_contents(__DIR__.'/../../Fixtures/wikidata/batch-response.json'),
+            true,
+        );
+        /** @var array<string, mixed> $fixture */
+        $bindings = $fixture['results']['bindings'];
+
+        $item = $this->createMock(ItemInterface::class);
+        $item->expects($this->once())->method('expiresAfter')->with(604800);
+
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->expects($this->once())
+            ->method('get')
+            ->willReturnCallback(static function (string $key, callable $callback) use ($item): mixed {
+                return $callback($item);
+            });
+
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('toArray')->willReturn($fixture);
+
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient->expects($this->once())
+            ->method('request')
+            ->with('GET', 'https://query.wikidata.org/sparql', $this->arrayHasKey('query'))
+            ->willReturn($response);
+
+        $client = $this->makeClient(cache: $cache, httpClient: $httpClient);
+
+        $result = $client->query('SELECT ?item WHERE { VALUES ?item { wd:Q12345 wd:Q67890 } }');
+
+        $this->assertSame($bindings, $result);
+    }
+
+    // -------------------------------------------------------------------------
+    // query() — User-Agent is forwarded (HTTP client must be the scoped one)
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function queryPassesQueryParamsToHttpClient(): void
+    {
+        $sparql = 'SELECT ?item WHERE { wd:Q1 ?p ?o }';
+
+        $item = $this->createMock(ItemInterface::class);
+        $item->method('expiresAfter');
+
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->method('get')
+            ->willReturnCallback(static function (string $key, callable $callback) use ($item): mixed {
+                return $callback($item);
+            });
+
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('toArray')->willReturn(['results' => ['bindings' => []]]);
+
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient->expects($this->once())
+            ->method('request')
+            ->with(
+                'GET',
+                'https://query.wikidata.org/sparql',
+                $this->callback(static function (array $options) use ($sparql): bool {
+                    return isset($options['query']['query'])
+                        && $sparql === $options['query']['query']
+                        && 'json' === $options['query']['format'];
+                }),
+            )
+            ->willReturn($response);
+
+        $client = $this->makeClient(cache: $cache, httpClient: $httpClient);
+        $client->query($sparql);
+    }
+
+    // -------------------------------------------------------------------------
+    // query() — network error / timeout → silent empty result
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function queryLogsWarningAndReturnsEmptyOnHttpError(): void
+    {
+        $item = $this->createMock(ItemInterface::class);
+        $item->method('expiresAfter');
+
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->method('get')
+            ->willReturnCallback(static function (string $key, callable $callback) use ($item): mixed {
+                return $callback($item);
+            });
+
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient->method('request')->willThrowException(new \RuntimeException('Connection timeout'));
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('warning')
+            ->with($this->stringContains('failed'));
+
+        $client = $this->makeClient(cache: $cache, httpClient: $httpClient, logger: $logger);
+
+        $result = $client->query('SELECT ?item WHERE { wd:Q1 ?p ?o }');
+
+        $this->assertSame([], $result);
+    }
+
+    #[Test]
+    public function queryReturnsEmptyArrayWhenBindingsMissing(): void
+    {
+        $item = $this->createMock(ItemInterface::class);
+        $item->method('expiresAfter');
+
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->method('get')
+            ->willReturnCallback(static function (string $key, callable $callback) use ($item): mixed {
+                return $callback($item);
+            });
+
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('toArray')->willReturn(['results' => []]);
+
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient->method('request')->willReturn($response);
+
+        $client = $this->makeClient(cache: $cache, httpClient: $httpClient);
+
+        $result = $client->query('SELECT ?item WHERE { wd:Q1 ?p ?o }');
+
+        $this->assertSame([], $result);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private function makeClient(
+        ?CacheInterface $cache = null,
+        ?HttpClientInterface $httpClient = null,
+        ?LoggerInterface $logger = null,
+    ): WikidataClient {
+        return new WikidataClient(
+            httpClient: $httpClient ?? $this->createStub(HttpClientInterface::class),
+            cache: $cache ?? $this->createStub(CacheInterface::class),
+            logger: $logger ?? $this->createStub(LoggerInterface::class),
+        );
+    }
+}

--- a/api/tests/Unit/Wikidata/WikidataClientTest.php
+++ b/api/tests/Unit/Wikidata/WikidataClientTest.php
@@ -52,7 +52,9 @@ final class WikidataClientTest extends TestCase
             (string) file_get_contents(__DIR__.'/../../Fixtures/wikidata/batch-response.json'),
             true,
         );
-        /** @var array<string, mixed> $fixture */
+        \assert(\is_array($fixture));
+        \assert(isset($fixture['results']) && \is_array($fixture['results']));
+        \assert(isset($fixture['results']['bindings']) && \is_array($fixture['results']['bindings']));
         $bindings = $fixture['results']['bindings'];
 
         $item = $this->createMock(ItemInterface::class);
@@ -61,11 +63,9 @@ final class WikidataClientTest extends TestCase
         $cache = $this->createMock(CacheInterface::class);
         $cache->expects($this->once())
             ->method('get')
-            ->willReturnCallback(static function (string $key, callable $callback) use ($item): mixed {
-                return $callback($item);
-            });
+            ->willReturnCallback(static fn (string $key, callable $callback): mixed => $callback($item));
 
-        $response = $this->createMock(ResponseInterface::class);
+        $response = $this->createStub(ResponseInterface::class);
         $response->method('toArray')->willReturn($fixture);
 
         $httpClient = $this->createMock(HttpClientInterface::class);
@@ -90,16 +90,13 @@ final class WikidataClientTest extends TestCase
     {
         $sparql = 'SELECT ?item WHERE { wd:Q1 ?p ?o }';
 
-        $item = $this->createMock(ItemInterface::class);
-        $item->method('expiresAfter');
+        $item = $this->createStub(ItemInterface::class);
 
-        $cache = $this->createMock(CacheInterface::class);
+        $cache = $this->createStub(CacheInterface::class);
         $cache->method('get')
-            ->willReturnCallback(static function (string $key, callable $callback) use ($item): mixed {
-                return $callback($item);
-            });
+            ->willReturnCallback(static fn (string $key, callable $callback): mixed => $callback($item));
 
-        $response = $this->createMock(ResponseInterface::class);
+        $response = $this->createStub(ResponseInterface::class);
         $response->method('toArray')->willReturn(['results' => ['bindings' => []]]);
 
         $httpClient = $this->createMock(HttpClientInterface::class);
@@ -108,11 +105,9 @@ final class WikidataClientTest extends TestCase
             ->with(
                 'GET',
                 'https://query.wikidata.org/sparql',
-                $this->callback(static function (array $options) use ($sparql): bool {
-                    return isset($options['query']['query'])
-                        && $sparql === $options['query']['query']
-                        && 'json' === $options['query']['format'];
-                }),
+                $this->callback(static fn (array $options): bool => isset($options['query']['query'])
+                    && $sparql === $options['query']['query']
+                    && 'json' === $options['query']['format']),
             )
             ->willReturn($response);
 
@@ -127,16 +122,13 @@ final class WikidataClientTest extends TestCase
     #[Test]
     public function queryLogsWarningAndReturnsEmptyOnHttpError(): void
     {
-        $item = $this->createMock(ItemInterface::class);
-        $item->method('expiresAfter');
+        $item = $this->createStub(ItemInterface::class);
 
-        $cache = $this->createMock(CacheInterface::class);
+        $cache = $this->createStub(CacheInterface::class);
         $cache->method('get')
-            ->willReturnCallback(static function (string $key, callable $callback) use ($item): mixed {
-                return $callback($item);
-            });
+            ->willReturnCallback(static fn (string $key, callable $callback): mixed => $callback($item));
 
-        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient = $this->createStub(HttpClientInterface::class);
         $httpClient->method('request')->willThrowException(new \RuntimeException('Connection timeout'));
 
         $logger = $this->createMock(LoggerInterface::class);
@@ -154,19 +146,16 @@ final class WikidataClientTest extends TestCase
     #[Test]
     public function queryReturnsEmptyArrayWhenBindingsMissing(): void
     {
-        $item = $this->createMock(ItemInterface::class);
-        $item->method('expiresAfter');
+        $item = $this->createStub(ItemInterface::class);
 
-        $cache = $this->createMock(CacheInterface::class);
+        $cache = $this->createStub(CacheInterface::class);
         $cache->method('get')
-            ->willReturnCallback(static function (string $key, callable $callback) use ($item): mixed {
-                return $callback($item);
-            });
+            ->willReturnCallback(static fn (string $key, callable $callback): mixed => $callback($item));
 
-        $response = $this->createMock(ResponseInterface::class);
+        $response = $this->createStub(ResponseInterface::class);
         $response->method('toArray')->willReturn(['results' => []]);
 
-        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient = $this->createStub(HttpClientInterface::class);
         $httpClient->method('request')->willReturn($response);
 
         $client = $this->makeClient(cache: $cache, httpClient: $httpClient);

--- a/api/tests/Unit/Wikidata/WikidataEnricherTest.php
+++ b/api/tests/Unit/Wikidata/WikidataEnricherTest.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Wikidata;
+
+use App\Wikidata\WikidataClientInterface;
+use App\Wikidata\WikidataEnricher;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class WikidataEnricherTest extends TestCase
+{
+    // -------------------------------------------------------------------------
+    // enrichBatch() — empty input
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function enrichBatchWithEmptyQIdsReturnsEmpty(): void
+    {
+        $client = $this->createMock(WikidataClientInterface::class);
+        $client->expects($this->never())->method('query');
+
+        $enricher = new WikidataEnricher($client);
+
+        $this->assertSame([], $enricher->enrichBatch([], 'fr'));
+    }
+
+    // -------------------------------------------------------------------------
+    // enrichBatch() — fixture response
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function enrichBatchParsesFixtureResponse(): void
+    {
+        $fixture = json_decode(
+            (string) file_get_contents(__DIR__.'/../../Fixtures/wikidata/batch-response.json'),
+            true,
+        );
+        /** @var array<string, mixed> $fixture */
+        $bindings = $fixture['results']['bindings'];
+
+        $client = $this->createMock(WikidataClientInterface::class);
+        $client->expects($this->once())
+            ->method('query')
+            ->willReturn($bindings);
+
+        $enricher = new WikidataEnricher($client);
+
+        $result = $enricher->enrichBatch(['Q12345', 'Q67890'], 'fr');
+
+        $this->assertArrayHasKey('Q12345', $result);
+        $this->assertSame('Château de Versailles', $result['Q12345']['label']);
+        $this->assertSame('Palais royal situé à Versailles, France.', $result['Q12345']['description']);
+        $this->assertStringContainsString('Versailles_Palace', $result['Q12345']['imageUrl']);
+        $this->assertStringContainsString('width=400', $result['Q12345']['imageUrl']);
+        $this->assertSame('https://www.chateauversailles.fr', $result['Q12345']['website']);
+        $this->assertSame('Tu-Su 09:00-17:30', $result['Q12345']['openingHours']);
+        $this->assertSame('https://fr.wikipedia.org/wiki/Château_de_Versailles', $result['Q12345']['wikipediaUrl']);
+
+        $this->assertArrayHasKey('Q67890', $result);
+        $this->assertSame('Tour Eiffel', $result['Q67890']['label']);
+        $this->assertArrayNotHasKey('website', $result['Q67890']);
+        $this->assertArrayNotHasKey('openingHours', $result['Q67890']);
+    }
+
+    // -------------------------------------------------------------------------
+    // enrichBatch() — batching 50 per 50
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function enrichBatchSplitsInto50PerBatch(): void
+    {
+        $qIds = array_map(static fn (int $i): string => 'Q'.$i, range(1, 110));
+
+        $client = $this->createMock(WikidataClientInterface::class);
+        $client->expects($this->exactly(3))
+            ->method('query')
+            ->willReturn([]);
+
+        $enricher = new WikidataEnricher($client);
+        $enricher->enrichBatch($qIds, 'en');
+    }
+
+    #[Test]
+    public function enrichBatchExactly50QIdsMakesOneBatch(): void
+    {
+        $qIds = array_map(static fn (int $i): string => 'Q'.$i, range(1, 50));
+
+        $client = $this->createMock(WikidataClientInterface::class);
+        $client->expects($this->once())
+            ->method('query')
+            ->willReturn([]);
+
+        $enricher = new WikidataEnricher($client);
+        $enricher->enrichBatch($qIds, 'en');
+    }
+
+    // -------------------------------------------------------------------------
+    // enrichBatch() — locale fallback
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function enrichBatchUsesLocaleInSparql(): void
+    {
+        $client = $this->createMock(WikidataClientInterface::class);
+        $client->expects($this->once())
+            ->method('query')
+            ->with($this->stringContains('"de,en"'))
+            ->willReturn([]);
+
+        $enricher = new WikidataEnricher($client);
+        $enricher->enrichBatch(['Q1'], 'de');
+    }
+
+    #[Test]
+    public function enrichBatchUsesFirstTwoCharsOfLocale(): void
+    {
+        $client = $this->createMock(WikidataClientInterface::class);
+        $client->expects($this->once())
+            ->method('query')
+            ->with($this->stringContains('"fr,en"'))
+            ->willReturn([]);
+
+        $enricher = new WikidataEnricher($client);
+        $enricher->enrichBatch(['Q1'], 'fr-FR');
+    }
+
+    // -------------------------------------------------------------------------
+    // enrichBatch() — no-overwrite merge
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function enrichBatchDoesNotOverwriteExistingFieldsWhenMerged(): void
+    {
+        $bindings = [
+            [
+                'item' => ['type' => 'uri', 'value' => 'http://www.wikidata.org/entity/Q999'],
+                'itemLabel' => ['type' => 'literal', 'value' => 'Wikidata Label'],
+                'itemDescription' => ['type' => 'literal', 'value' => 'Wikidata description'],
+                'openingHours' => ['type' => 'literal', 'value' => 'Mo-Fr 09:00-18:00'],
+            ],
+        ];
+
+        $client = $this->createMock(WikidataClientInterface::class);
+        $client->method('query')->willReturn($bindings);
+
+        $enricher = new WikidataEnricher($client);
+        $enrichments = $enricher->enrichBatch(['Q999'], 'en');
+
+        $existing = [
+            'name' => 'Local Name',
+            'openingHours' => 'Sa-Su 10:00-20:00',
+            'wikidataId' => 'Q999',
+        ];
+
+        // Simulate the merge strategy used in handlers: array_merge($wikidata, $candidate)
+        // The candidate (right side) wins for all existing fields
+        $merged = array_merge($enrichments['Q999'], $existing);
+
+        $this->assertSame('Local Name', $merged['name']);
+        $this->assertSame('Sa-Su 10:00-20:00', $merged['openingHours'], 'Existing openingHours must not be overwritten');
+        $this->assertSame('Wikidata Label', $merged['label'], 'Wikidata-only field is still present');
+    }
+
+    // -------------------------------------------------------------------------
+    // enrichBatch() — client error returns empty
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function enrichBatchReturnsEmptyOnClientError(): void
+    {
+        $client = $this->createMock(WikidataClientInterface::class);
+        $client->method('query')->willReturn([]);
+
+        $enricher = new WikidataEnricher($client);
+
+        $result = $enricher->enrichBatch(['Q1', 'Q2'], 'en');
+
+        $this->assertSame([], $result);
+    }
+
+    // -------------------------------------------------------------------------
+    // enrichBatch() — invalid item URI is skipped
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function enrichBatchSkipsBindingWithInvalidItemUri(): void
+    {
+        $bindings = [
+            [
+                'item' => ['type' => 'uri', 'value' => 'http://www.wikidata.org/entity/P31'],
+                'itemLabel' => ['type' => 'literal', 'value' => 'Some property'],
+            ],
+        ];
+
+        $client = $this->createMock(WikidataClientInterface::class);
+        $client->method('query')->willReturn($bindings);
+
+        $enricher = new WikidataEnricher($client);
+
+        $result = $enricher->enrichBatch(['Q1'], 'en');
+
+        $this->assertSame([], $result);
+    }
+}

--- a/api/tests/Unit/Wikidata/WikidataEnricherTest.php
+++ b/api/tests/Unit/Wikidata/WikidataEnricherTest.php
@@ -37,7 +37,9 @@ final class WikidataEnricherTest extends TestCase
             (string) file_get_contents(__DIR__.'/../../Fixtures/wikidata/batch-response.json'),
             true,
         );
-        /** @var array<string, mixed> $fixture */
+        \assert(\is_array($fixture));
+        \assert(isset($fixture['results']) && \is_array($fixture['results']));
+        \assert(isset($fixture['results']['bindings']) && \is_array($fixture['results']['bindings']));
         $bindings = $fixture['results']['bindings'];
 
         $client = $this->createMock(WikidataClientInterface::class);
@@ -50,18 +52,27 @@ final class WikidataEnricherTest extends TestCase
         $result = $enricher->enrichBatch(['Q12345', 'Q67890'], 'fr');
 
         $this->assertArrayHasKey('Q12345', $result);
-        $this->assertSame('Château de Versailles', $result['Q12345']['label']);
-        $this->assertSame('Palais royal situé à Versailles, France.', $result['Q12345']['description']);
-        $this->assertStringContainsString('Versailles_Palace', $result['Q12345']['imageUrl']);
-        $this->assertStringContainsString('width=400', $result['Q12345']['imageUrl']);
-        $this->assertSame('https://www.chateauversailles.fr', $result['Q12345']['website']);
-        $this->assertSame('Tu-Su 09:00-17:30', $result['Q12345']['openingHours']);
-        $this->assertSame('https://fr.wikipedia.org/wiki/Château_de_Versailles', $result['Q12345']['wikipediaUrl']);
+        $versailles = $result['Q12345'];
+        $this->assertArrayHasKey('label', $versailles);
+        $this->assertArrayHasKey('description', $versailles);
+        $this->assertArrayHasKey('imageUrl', $versailles);
+        $this->assertArrayHasKey('website', $versailles);
+        $this->assertArrayHasKey('openingHours', $versailles);
+        $this->assertArrayHasKey('wikipediaUrl', $versailles);
+        $this->assertSame('Château de Versailles', $versailles['label']);
+        $this->assertSame('Palais royal situé à Versailles, France.', $versailles['description']);
+        $this->assertStringContainsString('Versailles_Palace', $versailles['imageUrl']);
+        $this->assertStringContainsString('width=400', $versailles['imageUrl']);
+        $this->assertSame('https://www.chateauversailles.fr', $versailles['website']);
+        $this->assertSame('Tu-Su 09:00-17:30', $versailles['openingHours']);
+        $this->assertSame('https://fr.wikipedia.org/wiki/Château_de_Versailles', $versailles['wikipediaUrl']);
 
         $this->assertArrayHasKey('Q67890', $result);
-        $this->assertSame('Tour Eiffel', $result['Q67890']['label']);
-        $this->assertArrayNotHasKey('website', $result['Q67890']);
-        $this->assertArrayNotHasKey('openingHours', $result['Q67890']);
+        $eiffel = $result['Q67890'];
+        $this->assertArrayHasKey('label', $eiffel);
+        $this->assertSame('Tour Eiffel', $eiffel['label']);
+        $this->assertArrayNotHasKey('website', $eiffel);
+        $this->assertArrayNotHasKey('openingHours', $eiffel);
     }
 
     // -------------------------------------------------------------------------
@@ -142,7 +153,7 @@ final class WikidataEnricherTest extends TestCase
             ],
         ];
 
-        $client = $this->createMock(WikidataClientInterface::class);
+        $client = $this->createStub(WikidataClientInterface::class);
         $client->method('query')->willReturn($bindings);
 
         $enricher = new WikidataEnricher($client);
@@ -158,6 +169,7 @@ final class WikidataEnricherTest extends TestCase
         // The candidate (right side) wins for all existing fields
         $merged = array_merge($enrichments['Q999'], $existing);
 
+        $this->assertArrayHasKey('label', $merged);
         $this->assertSame('Local Name', $merged['name']);
         $this->assertSame('Sa-Su 10:00-20:00', $merged['openingHours'], 'Existing openingHours must not be overwritten');
         $this->assertSame('Wikidata Label', $merged['label'], 'Wikidata-only field is still present');
@@ -170,7 +182,7 @@ final class WikidataEnricherTest extends TestCase
     #[Test]
     public function enrichBatchReturnsEmptyOnClientError(): void
     {
-        $client = $this->createMock(WikidataClientInterface::class);
+        $client = $this->createStub(WikidataClientInterface::class);
         $client->method('query')->willReturn([]);
 
         $enricher = new WikidataEnricher($client);
@@ -194,7 +206,7 @@ final class WikidataEnricherTest extends TestCase
             ],
         ];
 
-        $client = $this->createMock(WikidataClientInterface::class);
+        $client = $this->createStub(WikidataClientInterface::class);
         $client->method('query')->willReturn($bindings);
 
         $enricher = new WikidataEnricher($client);

--- a/api/translations/messages.en.yaml
+++ b/api/translations/messages.en.yaml
@@ -1,0 +1,1 @@
+market.weekly_description: 'Weekly market'

--- a/api/translations/messages.fr.yaml
+++ b/api/translations/messages.fr.yaml
@@ -1,0 +1,1 @@
+market.weekly_description: 'Marché hebdomadaire'

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -46,6 +46,8 @@ services:
       JWT_PASSPHRASE: "${JWT_PASSPHRASE}"
       FRONTEND_URL: "${FRONTEND_URL}"
       MAILER_DSN: "${MAILER_DSN}"
+      DATATOURISME_API_KEY: "${DATATOURISME_API_KEY:-}"
+      DATATOURISME_ENABLED: "${DATATOURISME_ENABLED:-false}"
     secrets:
       - jwt_private_key
       - jwt_public_key
@@ -114,6 +116,8 @@ services:
       JWT_PASSPHRASE: "${JWT_PASSPHRASE}"
       FRONTEND_URL: "${FRONTEND_URL}"
       MAILER_DSN: "${MAILER_DSN}"
+      DATATOURISME_API_KEY: "${DATATOURISME_API_KEY:-}"
+      DATATOURISME_ENABLED: "${DATATOURISME_ENABLED:-false}"
     secrets:
       - jwt_private_key
       - jwt_public_key

--- a/compose.yaml
+++ b/compose.yaml
@@ -55,6 +55,8 @@ services:
       MESSENGER_FAILED_DSN: redis://redis:6379/failed
       REDIS_URL: redis://redis:6379
       DATABASE_URL: "postgresql://${DATABASE_USERNAME:-app}:${DATABASE_PASSWORD:-!ChangeMe!}@database:5432/${DATABASE_NAME:-bike_trip_planner}?serverVersion=18&charset=utf8"
+      DATATOURISME_API_KEY: "${DATATOURISME_API_KEY:-}"
+      DATATOURISME_ENABLED: "${DATATOURISME_ENABLED:-false}"
       # See https://xdebug.org/docs/all_settings#mode
       XDEBUG_MODE: "${XDEBUG_MODE:-off}"
     extra_hosts:
@@ -111,6 +113,8 @@ services:
       MESSENGER_FAILED_DSN: redis://redis:6379/failed
       REDIS_URL: redis://redis:6379
       DATABASE_URL: "postgresql://${DATABASE_USERNAME:-app}:${DATABASE_PASSWORD:-!ChangeMe!}@database:5432/${DATABASE_NAME:-bike_trip_planner}?serverVersion=18&charset=utf8"
+      DATATOURISME_API_KEY: "${DATATOURISME_API_KEY:-}"
+      DATATOURISME_ENABLED: "${DATATOURISME_ENABLED:-false}"
       # See https://xdebug.org/docs/all_settings#mode
       XDEBUG_MODE: "${XDEBUG_MODE:-off}"
     extra_hosts:

--- a/compose.yaml
+++ b/compose.yaml
@@ -57,6 +57,7 @@ services:
       DATABASE_URL: "postgresql://${DATABASE_USERNAME:-app}:${DATABASE_PASSWORD:-!ChangeMe!}@database:5432/${DATABASE_NAME:-bike_trip_planner}?serverVersion=18&charset=utf8"
       DATATOURISME_API_KEY: "${DATATOURISME_API_KEY:-}"
       DATATOURISME_ENABLED: "${DATATOURISME_ENABLED:-false}"
+      WIKIDATA_USER_AGENT: "${WIKIDATA_USER_AGENT:-BikeTripPlanner/1.0 (contact@example.org)}"
       # See https://xdebug.org/docs/all_settings#mode
       XDEBUG_MODE: "${XDEBUG_MODE:-off}"
     extra_hosts:
@@ -115,6 +116,7 @@ services:
       DATABASE_URL: "postgresql://${DATABASE_USERNAME:-app}:${DATABASE_PASSWORD:-!ChangeMe!}@database:5432/${DATABASE_NAME:-bike_trip_planner}?serverVersion=18&charset=utf8"
       DATATOURISME_API_KEY: "${DATATOURISME_API_KEY:-}"
       DATATOURISME_ENABLED: "${DATATOURISME_ENABLED:-false}"
+      WIKIDATA_USER_AGENT: "${WIKIDATA_USER_AGENT:-BikeTripPlanner/1.0 (contact@example.org)}"
       # See https://xdebug.org/docs/all_settings#mode
       XDEBUG_MODE: "${XDEBUG_MODE:-off}"
     extra_hosts:

--- a/docs/adr/adr-013-accomodation-discovery-and-heuristic-pricing-strategy.md
+++ b/docs/adr/adr-013-accomodation-discovery-and-heuristic-pricing-strategy.md
@@ -1,6 +1,8 @@
 # ADR-013: Accommodation Discovery and Heuristic Pricing Strategy
 
-**Status:** Accepted
+**Status:** Accepted — Extended by ADR-026
+
+> **Note (Sprint 20):** This ADR describes the initial OSM-only accommodation discovery strategy. Sprint 20 extended it with a multi-source architecture: DataTourisme is now a complementary source for accommodations (gîtes d'étape, auberges routières) and cultural POIs, and Wikidata provides cross-cutting enrichment via Q-IDs. The interface registry pattern (`AccommodationSourceInterface`, `#[AutowireIterator]`) was introduced to abstract source origin from consumers. See [ADR-026: Multi-Source Data Integration](adr-026-multi-source-data-integration.md) for the full decision and consequences.
 
 **Date:** 2026-02-19
 

--- a/docs/adr/adr-022-persistent-storage-strategy.md
+++ b/docs/adr/adr-022-persistent-storage-strategy.md
@@ -146,7 +146,7 @@ Use PostgreSQL as the storage engine with Doctrine ORM for entity mapping, but s
 - Computation status tracking (transient lifecycle: pending → running → done)
 - Generation counter (stale-message detection for Messenger workers)
 - Messenger transport (async job queue)
-- External API caches (OSM 24h, weather 3h, routing 24h)
+- External API caches (OSM 24h, weather 3h, routing 24h, DataTourisme 24h)
 
 ### Entity Design
 

--- a/docs/adr/adr-026-multi-source-data-integration.md
+++ b/docs/adr/adr-026-multi-source-data-integration.md
@@ -1,0 +1,131 @@
+# ADR-026: Multi-Source Data Integration
+
+- **Status:** Accepted
+- **Date:** 2026-04-18
+- **Depends on:** ADR-005 (External API caching), ADR-012 (Alert engine), ADR-013 (Accommodation discovery), ADR-022 (Persistent storage)
+- **Extends:** ADR-013 (adds DataTourisme and Wikidata as complementary sources)
+
+## Context and Problem Statement
+
+OpenStreetMap provides a reliable baseline for geographic data (roads, bike infrastructure, water points, basic POIs). However, several categories of information are systematically under-represented in OSM for itinerant cyclists in France:
+
+| Gap | OSM limitation |
+|-----|---------------|
+| **Bikepacker-friendly accommodation** | Gîtes d'étape and auberges routières rarely carry `backpack=yes` or structured bike tags in OSM |
+| **Cultural POIs without opening hours** | Many châteaux, abbeys, and museums are mapped but lack `opening_hours`, `fee`, or multilingual descriptions |
+| **Dated events** | OSM does not model time-bound events (festivals, exhibitions, fairs) |
+| **Weekly markets** | Market data exists on `data.gouv.fr` but is rarely reflected in OSM |
+
+Three open data sources are available to address these gaps without proprietary API dependencies:
+
+- **DataTourisme** — the French national tourism data aggregator (Ministry of Tourism), covering accommodations, cultural POIs, and dated events with structured JSON-LD. Published under Licence Ouverte 2.0 (Etalab). Available via a free-registration REST API.
+- **Wikidata** — the structured knowledge base of the Wikimedia Foundation. Q-ID references appear on OSM objects (`wikidata=Q12345`) and in DataTourisme payloads (`owl:sameAs`). Published under CC0. No registration required.
+- **data.gouv.fr** — the French open data portal. The "Marchés forains et brocantes" dataset provides geocoded weekly market data with day-of-week and time slots. Published under Licence Ouverte 2.0.
+
+## Decision Drivers
+
+- **Coverage** — Dated events and weekly markets cannot be sourced from OSM alone.
+- **Legal compliance** — All sources must be open-licensed and permit attribution-free or low-burden attribution.
+- **Operational cost** — Sources must be either free or offer sufficient quota for the application's usage pattern.
+- **Architecture consistency** — New sources must plug into the existing alert and enrichment pipelines without requiring a global refactor.
+- **Graceful degradation** — The application must remain fully functional when any optional source is unavailable or unconfigured.
+
+---
+
+## Considered Options
+
+### Option A: Scrape RandoCamping.fr
+
+Parse HTML from RandoCamping.fr to extract bikepacker-oriented accommodation listings.
+
+**Rejected.** RandoCamping's terms of service explicitly prohibit automated scraping. Blocked by anti-bot protections (Cloudflare). Technically fragile to DOM changes. Legally untenable.
+
+### Option B: OSM only
+
+Restrict all data to OpenStreetMap. Accept the gaps as known limitations.
+
+**Rejected.** This option leaves the "dated events" use case entirely unaddressed — OSM does not model events. The accommodation gap means bikepackers will miss gîtes d'étape that are the most common overnight stop in France.
+
+### Option C: Duplicate DataTourisme auth per scanner
+
+Add DataTourisme credentials to each scanner class that needs POI or accommodation data, creating N independent HTTP clients.
+
+**Rejected.** Violates DRY. Rate limiting (1 000 req/h) must be enforced at a single point. Auth rotation or key changes would require N code modifications.
+
+### Option D: Multi-source architecture with interface registries and a single DataTourisme client (chosen)
+
+Introduce `AccommodationSourceInterface` and `CulturalPoiSourceInterface` to abstract data origin from consumers. Implement OSM and DataTourisme sources behind each interface, auto-discovered via `#[AutowireIterator]`. A single `DataTourismeClient` handles auth, rate limiting, and caching for all DataTourisme consumers. Wikidata enrichment runs as a cross-cutting batch pass after primary source data is collected.
+
+---
+
+## Decision Outcome
+
+**Chosen: Option D — multi-source architecture with interface registries.**
+
+### Source roles
+
+| Source | Role | Coverage | Licence | Prerequisite |
+|--------|------|----------|---------|-------------|
+| **OpenStreetMap** | Primary source for all geographic data, bike infrastructure, water points, bike shops, resupply POIs | Global | ODbL | None |
+| **DataTourisme** | Complementary source for accommodations and cultural POIs; exclusive source for dated events (festivals, exhibitions, fairs) | France | Licence Ouverte 2.0 | `DATATOURISME_API_KEY` |
+| **Wikidata** | Cross-cutting enricher: adds multilingual descriptions, images, Wikipedia links, and structured opening hours to any object carrying a Q-ID | Europe | CC0 | None (optional `WIKIDATA_USER_AGENT`) |
+| **data.gouv.fr** | Source for recurring weekly markets (import only — not a live API) | France | Licence Ouverte 2.0 | `make markets-import` |
+
+### Architecture
+
+```text
+AccommodationSourceInterface          CulturalPoiSourceInterface
+  ├── OsmAccommodationSource            ├── OsmCulturalPoiSource
+  └── DataTourismeAccommodationSource   └── DataTourismeCulturalPoiSource
+         │                                       │
+         └──────────────┬────────────────────────┘
+                        │
+               DataTourismeClient
+               (single instance, rate-limited, Redis-cached)
+                        │
+               WikidataEnricher  ← batch Q-ID resolution after primary collection
+                        │
+               MarketRepository  ← PostgreSQL table populated by CLI import
+```
+
+**Registry pattern:** each interface is consumed via `#[AutowireIterator]` — new sources implement the interface and are discovered automatically without modifying existing consumers.
+
+**DataTourisme client** (`DataTourismeClientInterface`): single HTTP client scoped to `datatourisme.fr`, rate-limited at 1 000 req/h via Symfony Rate Limiter (`fixed_window` policy), responses cached in a dedicated `cache.datatourisme` Redis pool (TTL 24h).
+
+**Wikidata enricher** (`WikidataEnricherInterface`): batch SPARQL queries via the public Wikidata endpoint. Results cached in `cache.wikidata` Redis pool (TTL 7 days). Errors (timeout, 5xx) are silently swallowed — the application continues without enrichment.
+
+**Market import** (`app:markets:import` CLI command): downloads the `data.gouv.fr` market CSV, geocodes entries, and inserts them into the `market` PostgreSQL table. Not a live API — no rate limiting or auth required.
+
+### Consequences
+
+#### Positive
+
+- **Dated events now supported** — The first alert rule covering cultural/social events around stage endpoints is enabled by DataTourisme.
+- **Richer accommodation data** — Gîtes d'étape and accommodation types absent from OSM are now discoverable.
+- **Multilingual enrichment** — Wikidata Q-IDs unlock descriptions, images, and Wikipedia links in FR/EN/DE/ES/IT without per-source effort.
+- **Weekly markets** — A recurring event type (day-of-week, time slot) is covered without requiring a live API call per trip computation.
+- **Interface abstraction** — Adding a new source (e.g., regional tourism APIs) requires only a new class implementing the relevant interface.
+
+#### Negative
+
+- **New Redis pools** — `cache.datatourisme` and `cache.wikidata` add two named pools to the Redis configuration. Memory quota monitoring is required.
+- **New PostgreSQL table** — The `market` table must be provisioned and kept fresh via periodic `make markets-import` runs.
+- **DataTourisme quota** — 1 000 req/h requires monitoring. A single trip computation may consume up to ~20 requests (one per stage × two queries: events + POIs).
+- **Multi-source attribution required in the UI** — ODbL (OSM), Licence Ouverte 2.0 (DataTourisme, data.gouv.fr), and CC0 (Wikidata) must all be credited in the application footer (see F.4 implementation).
+
+#### Neutral
+
+- DataTourisme is opt-in: `DATATOURISME_ENABLED=false` (the default) skips all DataTourisme queries and falls back to OSM only. The application is fully functional without a DataTourisme API key.
+- Wikidata is always enabled but degrades silently on errors — it is never a blocking dependency.
+- The `market` table is populated independently of trip computation — a missing or empty table results in no market events, not an error.
+
+---
+
+## Sources
+
+- [DataTourisme — Licence Ouverte 2.0](https://www.etalab.gouv.fr/licence-ouverte-open-licence)
+- [Wikidata — CC0](https://creativecommons.org/publicdomain/zero/1.0/)
+- [data.gouv.fr — Marchés forains dataset](https://www.data.gouv.fr/)
+- [ADR-005: Orchestration, Optimization, and Caching of External APIs](adr-005-orchestration-optimization-and-caching-of-external-apis.md)
+- [ADR-013: Accommodation Discovery and Heuristic Pricing Strategy](adr-013-accomodation-discovery-and-heuristic-pricing-strategy.md)
+- [ADR-022: Persistent Storage Strategy](adr-022-persistent-storage-strategy.md)

--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -555,6 +555,18 @@
     "q9": "Is the app free and open source?",
     "a9": "The source code is open source and available on GitHub. The hosted app is free to use. Infrastructure costs may eventually justify a freemium model, but no paid access is planned at this stage."
   },
+  "events": {
+    "type_festival": "Festival",
+    "type_exhibition": "Exhibition",
+    "type_music_event": "Concert",
+    "type_fair_or_show": "Fair / Show",
+    "type_market": "Market",
+    "from_price": "From {price} €",
+    "see_on_wikipedia": "See on Wikipedia",
+    "see_on_wikipedia_label": "See {name} on Wikipedia",
+    "see_website": "Visit website",
+    "see_website_label": "Visit {name}'s website"
+  },
   "footer": {
     "faq": "FAQ"
   },

--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -555,5 +555,15 @@
   },
   "footer": {
     "faq": "FAQ"
+  },
+  "attribution": {
+    "link": "About data",
+    "title": "Data sources",
+    "description": "Bike Trip Planner uses the following open data sources.",
+    "osmCredit": "© OpenStreetMap contributors —",
+    "datatourismeCredit": "© DataTourisme —",
+    "wikidataCredit": "Data under",
+    "datagouvCredit": "Weekly markets (data.gouv.fr) —",
+    "licenceOuverte": "Licence Ouverte 2.0"
   }
 }

--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -85,6 +85,8 @@
     "type_guest_house": "Guest house",
     "type_motel": "Motel",
     "type_alpine_hut": "Alpine hut",
+    "type_wilderness_hut": "Wilderness hut",
+    "type_shelter": "Shelter",
     "type_other": "Other",
     "hotel": "Hotel",
     "gite": "Gite",

--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -244,7 +244,8 @@
   "alertList": {
     "addToItinerary": "Add to itinerary",
     "navigateToStation": "Navigate to station",
-    "navigateToCrossing": "Navigate to crossing"
+    "navigateToCrossing": "Navigate to crossing",
+    "free": "Free admission"
   },
   "onboarding": {
     "nextBtn": "Next",

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -244,7 +244,8 @@
   "alertList": {
     "addToItinerary": "Ajouter à l'itinéraire",
     "navigateToStation": "Aller à la gare",
-    "navigateToCrossing": "Aller au passage frontière"
+    "navigateToCrossing": "Aller au passage frontière",
+    "free": "Entrée gratuite"
   },
   "onboarding": {
     "nextBtn": "Suivant",

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -555,6 +555,18 @@
     "q9": "L'application est-elle gratuite et open source ?",
     "a9": "Le code source est open source et disponible sur GitHub. L'application hébergée est accessible gratuitement. Des coûts d'infrastructure peuvent à terme justifier une offre freemium, mais aucun accès payant n'est prévu à ce stade."
   },
+  "events": {
+    "type_festival": "Festival",
+    "type_exhibition": "Exposition",
+    "type_music_event": "Concert",
+    "type_fair_or_show": "Foire / Salon",
+    "type_market": "Marché",
+    "from_price": "À partir de {price} €",
+    "see_on_wikipedia": "Voir sur Wikipedia",
+    "see_on_wikipedia_label": "Voir {name} sur Wikipedia",
+    "see_website": "Voir le site",
+    "see_website_label": "Voir le site de {name}"
+  },
   "footer": {
     "faq": "FAQ"
   },

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -85,6 +85,8 @@
     "type_guest_house": "Chambre d'hôte",
     "type_motel": "Motel",
     "type_alpine_hut": "Refuge",
+    "type_wilderness_hut": "Bivouac",
+    "type_shelter": "Abri",
     "type_other": "Autre",
     "hotel": "Hôtel",
     "gite": "Gîte",

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -555,5 +555,15 @@
   },
   "footer": {
     "faq": "FAQ"
+  },
+  "attribution": {
+    "link": "À propos des données",
+    "title": "Sources de données",
+    "description": "Bike Trip Planner utilise les sources de données ouvertes suivantes.",
+    "osmCredit": "© les contributeurs OpenStreetMap —",
+    "datatourismeCredit": "© DataTourisme —",
+    "wikidataCredit": "Données sous",
+    "datagouvCredit": "Marchés hebdomadaires (data.gouv.fr) —",
+    "licenceOuverte": "Licence Ouverte 2.0"
   }
 }

--- a/pwa/package-lock.json
+++ b/pwa/package-lock.json
@@ -180,6 +180,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -733,6 +734,7 @@
       "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-7.6.1.tgz",
       "integrity": "sha512-nsNouCMxgYenyemy20sZwZYMtFi93LSZVWm2KqHTYIPIDgwx24+PzwHIdRQBZdK7hpvD5jQEhWuo/QyLLnAyBQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -836,6 +838,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -884,6 +887,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1004,6 +1008,7 @@
       "integrity": "sha512-f2o/HqKHgsqzFLdq6fAhfG1FNOQPdBdyMGpKwhb7hZqg0yZtx9BVqkTyuoNk83Fcvk3wjMVfouFXXHNEk4nddA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/uuid": "10.0.0",
         "class-transformer": "0.5.1",
@@ -1203,6 +1208,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1256,28 +1262,6 @@
       },
       "peerDependencies": {
         "@noble/ciphers": "^1.0.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.0.tgz",
-      "integrity": "sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.0",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.0.tgz",
-      "integrity": "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -2800,6 +2784,7 @@
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -3232,6 +3217,7 @@
       "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright": "1.58.2"
       },
@@ -6587,7 +6573,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -6608,7 +6593,6 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -6765,8 +6749,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -6839,6 +6822,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -6849,6 +6833,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -6935,6 +6920,7 @@
       "integrity": "sha512-k4eNDan0EIMTT/dUKc/g+rsJ6wcHYhNPdY19VoX/EOtaAG8DLtKCykhrUnuHPYvinn5jhAPgD2Qw9hXBwrahsw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.1",
         "@typescript-eslint/types": "8.57.1",
@@ -7609,6 +7595,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8161,6 +8148,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -9041,7 +9029,6 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -9089,8 +9076,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dotenv": {
       "version": "17.3.1",
@@ -9462,6 +9448,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -9647,6 +9634,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -10004,6 +9992,7 @@
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -10343,6 +10332,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -10812,6 +10802,7 @@
       "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -10927,6 +10918,7 @@
       "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
       "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -11949,6 +11941,7 @@
       "resolved": "https://registry.npmjs.org/ky/-/ky-0.25.1.tgz",
       "integrity": "sha512-PjpCEWlIU7VpiMVrTwssahkYXX1by6NCT0fhTUX34F3DTinARlgMpriuroolugFPcMgpPWrOW4mTb984Qm1RXA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -12451,7 +12444,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -13904,7 +13896,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -13920,7 +13911,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -13931,7 +13921,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -13944,8 +13933,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/pretty-ms": {
       "version": "9.3.0",
@@ -14215,6 +14203,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14224,6 +14213,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -15742,6 +15732,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -16035,6 +16026,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16359,6 +16351,7 @@
       "integrity": "sha512-nmu43Qvq9UopTRfMx2jOYW5l16pb3iDC1JH6yMuPkpVbzK0k+L7dfsEDH4jRgYFmsg0sTAqkojoZgzLMlwHsCQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -16834,6 +16827,7 @@
       "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 8"
       }
@@ -17293,6 +17287,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/pwa/package-lock.json
+++ b/pwa/package-lock.json
@@ -180,7 +180,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -734,7 +733,6 @@
       "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-7.6.1.tgz",
       "integrity": "sha512-nsNouCMxgYenyemy20sZwZYMtFi93LSZVWm2KqHTYIPIDgwx24+PzwHIdRQBZdK7hpvD5jQEhWuo/QyLLnAyBQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -838,7 +836,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -887,7 +884,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1008,7 +1004,6 @@
       "integrity": "sha512-f2o/HqKHgsqzFLdq6fAhfG1FNOQPdBdyMGpKwhb7hZqg0yZtx9BVqkTyuoNk83Fcvk3wjMVfouFXXHNEk4nddA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/uuid": "10.0.0",
         "class-transformer": "0.5.1",
@@ -1208,7 +1203,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1262,6 +1256,28 @@
       },
       "peerDependencies": {
         "@noble/ciphers": "^1.0.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.0.tgz",
+      "integrity": "sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.0.tgz",
+      "integrity": "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -2784,7 +2800,6 @@
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -3217,7 +3232,6 @@
       "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright": "1.58.2"
       },
@@ -6573,6 +6587,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -6593,6 +6608,7 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -6749,7 +6765,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -6822,7 +6839,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -6833,7 +6849,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -6920,7 +6935,6 @@
       "integrity": "sha512-k4eNDan0EIMTT/dUKc/g+rsJ6wcHYhNPdY19VoX/EOtaAG8DLtKCykhrUnuHPYvinn5jhAPgD2Qw9hXBwrahsw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.1",
         "@typescript-eslint/types": "8.57.1",
@@ -7595,7 +7609,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8148,7 +8161,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -9029,6 +9041,7 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -9076,7 +9089,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dotenv": {
       "version": "17.3.1",
@@ -9448,7 +9462,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -9634,7 +9647,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -9992,7 +10004,6 @@
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -10332,7 +10343,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -10802,7 +10812,6 @@
       "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -10918,7 +10927,6 @@
       "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
       "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -11941,7 +11949,6 @@
       "resolved": "https://registry.npmjs.org/ky/-/ky-0.25.1.tgz",
       "integrity": "sha512-PjpCEWlIU7VpiMVrTwssahkYXX1by6NCT0fhTUX34F3DTinARlgMpriuroolugFPcMgpPWrOW4mTb984Qm1RXA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -12444,6 +12451,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -13896,6 +13904,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -13911,6 +13920,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -13921,6 +13931,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -13933,7 +13944,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/pretty-ms": {
       "version": "9.3.0",
@@ -14203,7 +14215,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14213,7 +14224,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -15732,7 +15742,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -16026,7 +16035,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16351,7 +16359,6 @@
       "integrity": "sha512-nmu43Qvq9UopTRfMx2jOYW5l16pb3iDC1JH6yMuPkpVbzK0k+L7dfsEDH4jRgYFmsg0sTAqkojoZgzLMlwHsCQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -16827,7 +16834,6 @@
       "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 8"
       }
@@ -17287,7 +17293,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/pwa/src/app/login/page.tsx
+++ b/pwa/src/app/login/page.tsx
@@ -7,6 +7,7 @@ import { useTranslations } from "next-intl";
 import { useAuthStore } from "@/store/auth-store";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { AttributionFooter } from "@/components/attribution-footer";
 
 export default function LoginPage() {
   const t = useTranslations("auth");
@@ -105,14 +106,19 @@ export default function LoginPage() {
           </Link>
         </div>
       </div>
-      <footer className="mt-8 text-center">
-        <Link
-          href="/faq"
-          className="text-xs text-muted-foreground hover:text-foreground transition-colors"
-          data-testid="footer-faq-link"
-        >
-          {tFooter("faq")}
-        </Link>
+      <footer className="mt-8 text-center space-y-2">
+        <div>
+          <Link
+            href="/faq"
+            className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+            data-testid="footer-faq-link"
+          >
+            {tFooter("faq")}
+          </Link>
+        </div>
+        <div>
+          <AttributionFooter />
+        </div>
       </footer>
     </div>
   );

--- a/pwa/src/app/s/[code]/shared-trip-page.tsx
+++ b/pwa/src/app/s/[code]/shared-trip-page.tsx
@@ -93,6 +93,7 @@ function SharedTripLoader({ code }: { code: string }) {
           accommodationSearchRadiusKm: 5,
           isRestDay: (s.isRestDay as boolean) ?? false,
           supplyTimeline: [],
+          events: [],
         }));
 
         setStages(parsedStages);

--- a/pwa/src/app/trips/[id]/trip-page.tsx
+++ b/pwa/src/app/trips/[id]/trip-page.tsx
@@ -118,6 +118,7 @@ function TripLoader({ tripId }: { tripId: string }) {
             accommodationSearchRadiusKm: 5,
             isRestDay: s.isRestDay ?? false,
             supplyTimeline: [],
+            events: [],
           };
         });
 

--- a/pwa/src/components/accommodation-item.tsx
+++ b/pwa/src/components/accommodation-item.tsx
@@ -354,7 +354,9 @@ export function AccommodationItem({
         )}
         {accommodation.source && accommodation.source !== "osm" && (
           <span className="inline-flex items-center text-[10px] font-medium uppercase tracking-wide text-muted-foreground/70 bg-muted rounded px-1.5 py-0.5">
-            {accommodation.source === "datatourisme" ? "DataTourisme" : accommodation.source}
+            {accommodation.source === "datatourisme"
+              ? "DataTourisme"
+              : accommodation.source}
           </span>
         )}
       </div>

--- a/pwa/src/components/accommodation-item.tsx
+++ b/pwa/src/components/accommodation-item.tsx
@@ -340,6 +340,11 @@ export function AccommodationItem({
             <span>{distLabel}</span>
           </div>
         )}
+        {accommodation.source && accommodation.source !== "osm" && (
+          <span className="inline-flex items-center text-[10px] font-medium uppercase tracking-wide text-muted-foreground/70 bg-muted rounded px-1.5 py-0.5">
+            {accommodation.source === "datatourisme" ? "DataTourisme" : accommodation.source}
+          </span>
+        )}
       </div>
     </div>
   );

--- a/pwa/src/components/accommodation-item.tsx
+++ b/pwa/src/components/accommodation-item.tsx
@@ -322,8 +322,20 @@ export function AccommodationItem({
         )}
       </div>
 
+      {/* Wikidata thumbnail */}
+      {accommodation.imageUrl && (
+        <div className="mt-2">
+          <img
+            src={accommodation.imageUrl}
+            alt={accommodation.name}
+            loading="lazy"
+            className="rounded aspect-[3/2] object-cover w-full max-w-[180px]"
+          />
+        </div>
+      )}
+
       {/* Type icon + label + price + distance to end point */}
-      <div className="flex items-center gap-3 mt-1 text-sm text-muted-foreground">
+      <div className="flex items-center gap-3 mt-1 text-sm text-muted-foreground flex-wrap">
         <div className="flex items-center gap-1.5">
           <TypeIcon className="h-3.5 w-3.5" />
           <span>{typeLabel}</span>
@@ -346,6 +358,21 @@ export function AccommodationItem({
           </span>
         )}
       </div>
+
+      {/* Wikipedia link */}
+      {accommodation.wikipediaUrl && (
+        <div className="mt-1">
+          <a
+            href={accommodation.wikipediaUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs text-primary flex items-center gap-0.5 hover:underline"
+          >
+            <ExternalLink className="h-3 w-3" />
+            Voir sur Wikipedia
+          </a>
+        </div>
+      )}
     </div>
   );
 }

--- a/pwa/src/components/alert-list.tsx
+++ b/pwa/src/components/alert-list.tsx
@@ -62,6 +62,28 @@ export function AlertList({ alerts, onAddPoiWaypoint }: AlertListProps) {
             data-testid={isDismissed ? "alert-dismissed" : undefined}
           >
             <AlertBadge type={alert.type} message={alert.message} />
+            {isCulturalPoiAlert(alert) && (
+              <div className="mt-1 ml-1 flex flex-col gap-0.5">
+                {alert.openingHours && (
+                  <span
+                    className="text-xs text-muted-foreground"
+                    data-testid="poi-opening-hours"
+                  >
+                    {alert.openingHours}
+                  </span>
+                )}
+                {typeof alert.estimatedPrice === "number" && (
+                  <span
+                    className="text-xs text-muted-foreground"
+                    data-testid="poi-estimated-price"
+                  >
+                    {alert.estimatedPrice === 0
+                      ? t("free")
+                      : `${alert.estimatedPrice.toFixed(2)} €`}
+                  </span>
+                )}
+              </div>
+            )}
             {isCulturalPoiAlert(alert) && onAddPoiWaypoint && (
               <Button
                 variant="outline"

--- a/pwa/src/components/alert-list.tsx
+++ b/pwa/src/components/alert-list.tsx
@@ -64,6 +64,14 @@ export function AlertList({ alerts, onAddPoiWaypoint }: AlertListProps) {
             <AlertBadge type={alert.type} message={alert.message} />
             {isCulturalPoiAlert(alert) && (
               <div className="mt-1 ml-1 flex flex-col gap-0.5">
+                {alert.description && (
+                  <p
+                    className="text-xs text-muted-foreground line-clamp-2"
+                    data-testid="poi-description"
+                  >
+                    {alert.description}
+                  </p>
+                )}
                 {alert.openingHours && (
                   <span
                     className="text-xs text-muted-foreground"
@@ -81,6 +89,17 @@ export function AlertList({ alerts, onAddPoiWaypoint }: AlertListProps) {
                       ? t("free")
                       : `${alert.estimatedPrice.toFixed(2)} €`}
                   </span>
+                )}
+                {alert.wikipediaUrl && (
+                  <a
+                    href={alert.wikipediaUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-xs text-primary flex items-center gap-0.5 hover:underline"
+                    data-testid="poi-wikipedia-link"
+                  >
+                    Voir sur Wikipedia
+                  </a>
                 )}
               </div>
             )}

--- a/pwa/src/components/attribution-footer.tsx
+++ b/pwa/src/components/attribution-footer.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+
+export function AttributionFooter() {
+  const t = useTranslations("attribution");
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <button
+        onClick={() => setOpen(true)}
+        className="text-xs text-muted-foreground hover:text-foreground transition-colors underline underline-offset-2"
+        data-testid="attribution-footer-link"
+      >
+        {t("link")}
+      </button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent
+          className="max-w-md"
+          data-testid="attribution-modal"
+        >
+          <DialogHeader>
+            <DialogTitle>{t("title")}</DialogTitle>
+            <DialogDescription>{t("description")}</DialogDescription>
+          </DialogHeader>
+
+          <ul className="space-y-3 text-sm" data-testid="attribution-list">
+            <li>
+              <p className="font-medium">OpenStreetMap</p>
+              <p className="text-muted-foreground">
+                {t("osmCredit")}{" "}
+                <a
+                  href="https://opendatacommons.org/licenses/odbl/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline hover:text-foreground"
+                  data-testid="attribution-osm-link"
+                >
+                  ODbL
+                </a>
+              </p>
+            </li>
+            <li>
+              <p className="font-medium">DataTourisme</p>
+              <p className="text-muted-foreground">
+                {t("datatourismeCredit")}{" "}
+                <a
+                  href="https://www.etalab.gouv.fr/licence-ouverte-open-licence"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline hover:text-foreground"
+                  data-testid="attribution-datatourisme-link"
+                >
+                  {t("licenceOuverte")}
+                </a>
+              </p>
+            </li>
+            <li>
+              <p className="font-medium">Wikidata</p>
+              <p className="text-muted-foreground">
+                {t("wikidataCredit")}{" "}
+                <a
+                  href="https://creativecommons.org/publicdomain/zero/1.0/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline hover:text-foreground"
+                  data-testid="attribution-wikidata-link"
+                >
+                  CC0
+                </a>
+              </p>
+            </li>
+            <li>
+              <p className="font-medium">data.gouv.fr</p>
+              <p className="text-muted-foreground">
+                {t("datagouvCredit")}{" "}
+                <a
+                  href="https://www.etalab.gouv.fr/licence-ouverte-open-licence"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline hover:text-foreground"
+                  data-testid="attribution-datagouv-link"
+                >
+                  {t("licenceOuverte")}
+                </a>
+              </p>
+            </li>
+          </ul>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/pwa/src/components/attribution-footer.tsx
+++ b/pwa/src/components/attribution-footer.tsx
@@ -25,10 +25,7 @@ export function AttributionFooter() {
       </button>
 
       <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent
-          className="max-w-md"
-          data-testid="attribution-modal"
-        >
+        <DialogContent className="max-w-md" data-testid="attribution-modal">
           <DialogHeader>
             <DialogTitle>{t("title")}</DialogTitle>
             <DialogDescription>{t("description")}</DialogDescription>

--- a/pwa/src/components/event-item.tsx
+++ b/pwa/src/components/event-item.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ExternalLink } from "lucide-react";
+import { useLocale } from "next-intl";
 import type { EventData } from "@/lib/validation/schemas";
 
 const EVENT_TYPE_LABELS: Record<string, string> = {
@@ -10,11 +11,15 @@ const EVENT_TYPE_LABELS: Record<string, string> = {
   "urn:resource:FairOrShow": "Foire / Salon",
 };
 
-function formatDateRange(startDate: string, endDate: string): string {
+function formatDateRange(
+  startDate: string,
+  endDate: string,
+  locale: string,
+): string {
   const start = new Date(startDate);
   const end = new Date(endDate);
 
-  const fmt = new Intl.DateTimeFormat("fr-FR", {
+  const fmt = new Intl.DateTimeFormat(locale, {
     day: "numeric",
     month: "short",
   });
@@ -30,8 +35,9 @@ interface EventItemProps {
 }
 
 export function EventItem({ event }: EventItemProps) {
+  const locale = useLocale();
   const typeLabel = EVENT_TYPE_LABELS[event.type] ?? event.type;
-  const dateRange = formatDateRange(event.startDate, event.endDate);
+  const dateRange = formatDateRange(event.startDate, event.endDate, locale);
 
   return (
     <div className="py-2 first:pt-0 last:pb-0">

--- a/pwa/src/components/event-item.tsx
+++ b/pwa/src/components/event-item.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { ExternalLink } from "lucide-react";
+import type { EventData } from "@/lib/validation/schemas";
+
+const EVENT_TYPE_LABELS: Record<string, string> = {
+  "schema:Festival": "Festival",
+  "schema:Exhibition": "Exposition",
+  "schema:MusicEvent": "Concert",
+  "urn:resource:FairOrShow": "Foire / Salon",
+};
+
+function formatDateRange(startDate: string, endDate: string): string {
+  const start = new Date(startDate);
+  const end = new Date(endDate);
+
+  const fmt = new Intl.DateTimeFormat("fr-FR", {
+    day: "numeric",
+    month: "short",
+  });
+
+  const startStr = fmt.format(start);
+  const endStr = fmt.format(end);
+
+  return startStr === endStr ? startStr : `${startStr} – ${endStr}`;
+}
+
+interface EventItemProps {
+  event: EventData;
+}
+
+export function EventItem({ event }: EventItemProps) {
+  const typeLabel = EVENT_TYPE_LABELS[event.type] ?? event.type;
+  const dateRange = formatDateRange(event.startDate, event.endDate);
+
+  return (
+    <div className="py-2 first:pt-0 last:pb-0">
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-medium leading-tight truncate">
+            {event.name}
+          </p>
+          <div className="flex items-center gap-2 mt-0.5">
+            <span className="text-xs text-muted-foreground">{dateRange}</span>
+            <span className="text-xs text-muted-foreground">·</span>
+            <span className="text-xs text-muted-foreground">{typeLabel}</span>
+            {event.priceMin !== null && event.priceMin !== undefined && (
+              <>
+                <span className="text-xs text-muted-foreground">·</span>
+                <span className="text-xs text-muted-foreground">
+                  {`À partir de ${event.priceMin} €`}
+                </span>
+              </>
+            )}
+          </div>
+          {event.description && (
+            <p className="text-xs text-muted-foreground mt-1 line-clamp-2">
+              {event.description}
+            </p>
+          )}
+        </div>
+        {event.url && (
+          <a
+            href={event.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="shrink-0 flex items-center gap-1 text-xs text-primary hover:underline"
+            aria-label={`Voir le site de ${event.name}`}
+          >
+            <ExternalLink className="h-3 w-3" />
+            <span className="hidden sm:inline">Voir le site</span>
+          </a>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/pwa/src/components/event-item.tsx
+++ b/pwa/src/components/event-item.tsx
@@ -1,14 +1,15 @@
 "use client";
 
 import { ExternalLink } from "lucide-react";
-import { useLocale } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import type { EventData } from "@/lib/validation/schemas";
 
-const EVENT_TYPE_LABELS: Record<string, string> = {
-  "schema:Festival": "Festival",
-  "schema:Exhibition": "Exposition",
-  "schema:MusicEvent": "Concert",
-  "urn:resource:FairOrShow": "Foire / Salon",
+const EVENT_TYPE_KEYS: Record<string, string> = {
+  "schema:Festival": "type_festival",
+  "schema:Exhibition": "type_exhibition",
+  "schema:MusicEvent": "type_music_event",
+  "urn:resource:FairOrShow": "type_fair_or_show",
+  market: "type_market",
 };
 
 function formatDateRange(
@@ -36,7 +37,9 @@ interface EventItemProps {
 
 export function EventItem({ event }: EventItemProps) {
   const locale = useLocale();
-  const typeLabel = EVENT_TYPE_LABELS[event.type] ?? event.type;
+  const t = useTranslations("events");
+  const typeKey = EVENT_TYPE_KEYS[event.type];
+  const typeLabel = typeKey ? t(typeKey) : event.type;
   const dateRange = formatDateRange(event.startDate, event.endDate, locale);
 
   return (
@@ -54,7 +57,7 @@ export function EventItem({ event }: EventItemProps) {
               <>
                 <span className="text-xs text-muted-foreground">·</span>
                 <span className="text-xs text-muted-foreground">
-                  {`À partir de ${event.priceMin} €`}
+                  {t("from_price", { price: event.priceMin })}
                 </span>
               </>
             )}
@@ -75,10 +78,10 @@ export function EventItem({ event }: EventItemProps) {
               target="_blank"
               rel="noopener noreferrer"
               className="mt-0.5 flex items-center gap-0.5 text-xs text-primary hover:underline"
-              aria-label={`Voir ${event.name} sur Wikipedia`}
+              aria-label={t("see_on_wikipedia_label", { name: event.name })}
             >
               <ExternalLink className="h-3 w-3" />
-              Voir sur Wikipedia
+              {t("see_on_wikipedia")}
             </a>
           )}
         </div>
@@ -97,10 +100,10 @@ export function EventItem({ event }: EventItemProps) {
               target="_blank"
               rel="noopener noreferrer"
               className="flex items-center gap-1 text-xs text-primary hover:underline"
-              aria-label={`Voir le site de ${event.name}`}
+              aria-label={t("see_website_label", { name: event.name })}
             >
               <ExternalLink className="h-3 w-3" />
-              <span className="hidden sm:inline">Voir le site</span>
+              <span className="hidden sm:inline">{t("see_website")}</span>
             </a>
           )}
         </div>

--- a/pwa/src/components/event-item.tsx
+++ b/pwa/src/components/event-item.tsx
@@ -40,7 +40,7 @@ export function EventItem({ event }: EventItemProps) {
           <p className="text-sm font-medium leading-tight truncate">
             {event.name}
           </p>
-          <div className="flex items-center gap-2 mt-0.5">
+          <div className="flex items-center gap-2 mt-0.5 flex-wrap">
             <span className="text-xs text-muted-foreground">{dateRange}</span>
             <span className="text-xs text-muted-foreground">·</span>
             <span className="text-xs text-muted-foreground">{typeLabel}</span>
@@ -58,19 +58,46 @@ export function EventItem({ event }: EventItemProps) {
               {event.description}
             </p>
           )}
+          {event.openingHours && (
+            <p className="text-xs text-muted-foreground mt-0.5">
+              {event.openingHours}
+            </p>
+          )}
+          {event.wikipediaUrl && (
+            <a
+              href={event.wikipediaUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-0.5 flex items-center gap-0.5 text-xs text-primary hover:underline"
+              aria-label={`Voir ${event.name} sur Wikipedia`}
+            >
+              <ExternalLink className="h-3 w-3" />
+              Voir sur Wikipedia
+            </a>
+          )}
         </div>
-        {event.url && (
-          <a
-            href={event.url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="shrink-0 flex items-center gap-1 text-xs text-primary hover:underline"
-            aria-label={`Voir le site de ${event.name}`}
-          >
-            <ExternalLink className="h-3 w-3" />
-            <span className="hidden sm:inline">Voir le site</span>
-          </a>
-        )}
+        <div className="flex flex-col items-end gap-1 shrink-0">
+          {event.imageUrl && (
+            <img
+              src={event.imageUrl}
+              alt={event.name}
+              loading="lazy"
+              className="rounded aspect-[3/2] object-cover w-16"
+            />
+          )}
+          {event.url && (
+            <a
+              href={event.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-1 text-xs text-primary hover:underline"
+              aria-label={`Voir le site de ${event.name}`}
+            >
+              <ExternalLink className="h-3 w-3" />
+              <span className="hidden sm:inline">Voir le site</span>
+            </a>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/pwa/src/components/events-panel.tsx
+++ b/pwa/src/components/events-panel.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useState } from "react";
+import { CalendarDays, ChevronDown, ChevronUp } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { EventItem } from "@/components/event-item";
+import type { EventData } from "@/lib/validation/schemas";
+
+interface EventsPanelProps {
+  events: EventData[];
+}
+
+export function EventsPanel({ events }: EventsPanelProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  if (events.length === 0) {
+    return null;
+  }
+
+  const sorted = [...events].sort(
+    (a, b) => new Date(a.startDate).getTime() - new Date(b.startDate).getTime(),
+  );
+
+  return (
+    <div data-testid="events-panel">
+      <Separator className="mt-4 mb-3" />
+      <Button
+        variant="ghost"
+        className="w-full justify-between px-0 h-auto py-1 text-sm font-medium hover:bg-transparent"
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+        data-testid="events-panel-toggle"
+      >
+        <span className="flex items-center gap-1.5">
+          <CalendarDays className="h-4 w-4 text-muted-foreground" />
+          <span>{`Événements (${events.length})`}</span>
+        </span>
+        {expanded ? (
+          <ChevronUp className="h-4 w-4 text-muted-foreground" />
+        ) : (
+          <ChevronDown className="h-4 w-4 text-muted-foreground" />
+        )}
+      </Button>
+
+      {expanded && (
+        <div
+          className="mt-2 divide-y divide-border"
+          data-testid="events-panel-content"
+        >
+          {sorted.map((event, i) => (
+            <EventItem key={`${event.name}-${i}`} event={event} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/pwa/src/components/landing-page.tsx
+++ b/pwa/src/components/landing-page.tsx
@@ -563,8 +563,19 @@ function LandingFooter() {
           </nav>
         </div>
 
-        <div className="mt-8 pt-6 border-t text-center text-xs text-muted-foreground">
-          {t("copyright", { year })}
+        <div className="mt-8 pt-6 border-t text-center text-xs text-muted-foreground space-y-1">
+          <p>{t("copyright", { year })}</p>
+          <p>Données enrichies par{" "}
+            <a
+              href="https://www.wikidata.org"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:underline"
+            >
+              Wikidata
+            </a>
+            {" "}(CC0)
+          </p>
         </div>
       </div>
     </footer>

--- a/pwa/src/components/landing-page.tsx
+++ b/pwa/src/components/landing-page.tsx
@@ -24,6 +24,7 @@ import { Button } from "@/components/ui/button";
 import { CtaButton } from "@/components/cta-button";
 import { ScreenshotsSection } from "@/components/screenshots-section";
 import { EarlyAccessSection } from "@/components/early-access-section";
+import { AttributionFooter } from "@/components/attribution-footer";
 
 // ─── Section 1: Hero ─────────────────────────────────────────────────────────
 
@@ -565,17 +566,7 @@ function LandingFooter() {
 
         <div className="mt-8 pt-6 border-t text-center text-xs text-muted-foreground space-y-1">
           <p>{t("copyright", { year })}</p>
-          <p>Données enrichies par{" "}
-            <a
-              href="https://www.wikidata.org"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="hover:underline"
-            >
-              Wikidata
-            </a>
-            {" "}(CC0)
-          </p>
+          <AttributionFooter />
         </div>
       </div>
     </footer>

--- a/pwa/src/components/stage-card.tsx
+++ b/pwa/src/components/stage-card.tsx
@@ -10,6 +10,7 @@ import { StageLocations } from "@/components/stage-locations";
 import { StageMetadata } from "@/components/stage-metadata";
 import { AlertList } from "@/components/alert-list";
 import { AccommodationPanel } from "@/components/accommodation-panel";
+import { EventsPanel } from "@/components/events-panel";
 import { StageDownloads } from "@/components/stage-downloads";
 import { StageDistanceEditor } from "@/components/stage-distance-editor";
 import { DifficultyGauge } from "@/components/difficulty-gauge";
@@ -199,6 +200,11 @@ export function StageCard({
             <Loader2 className="h-3.5 w-3.5 animate-spin" />
             <span>{t("loadingAlerts")}</span>
           </div>
+        )}
+
+        {/* Events */}
+        {(stage.events?.length ?? 0) > 0 && (
+          <EventsPanel events={stage.events ?? []} />
         )}
 
         {/* Accommodations */}

--- a/pwa/src/components/trip-planner.tsx
+++ b/pwa/src/components/trip-planner.tsx
@@ -24,6 +24,7 @@ import { UndoRedoButtons } from "@/components/undo-redo-buttons";
 import { RecentTrips } from "@/components/recent-trips";
 import { SavedTripsSection } from "@/components/saved-trips-section";
 import { OfflineBanner } from "@/components/offline-banner";
+import { AttributionFooter } from "@/components/attribution-footer";
 import { useTripPlanner } from "@/hooks/use-trip-planner";
 import { useLinkParam } from "@/hooks/use-link-param";
 import { useKeyboardShortcuts } from "@/hooks/use-keyboard-shortcuts";
@@ -337,14 +338,19 @@ export function TripPlanner({ onClose }: { onClose?: () => void } = {}) {
             {actionButtons}
             <RecentTrips />
             <SavedTripsSection />
-            <footer className="mt-4 text-center">
-              <Link
-                href="/faq"
-                className="text-xs text-muted-foreground hover:text-foreground transition-colors"
-                data-testid="footer-faq-link"
-              >
-                {t("footer.faq")}
-              </Link>
+            <footer className="mt-4 text-center space-y-2">
+              <div>
+                <Link
+                  href="/faq"
+                  className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+                  data-testid="footer-faq-link"
+                >
+                  {t("footer.faq")}
+                </Link>
+              </div>
+              <div>
+                <AttributionFooter />
+              </div>
             </footer>
           </div>
         )}

--- a/pwa/src/hooks/use-mercure.ts
+++ b/pwa/src/hooks/use-mercure.ts
@@ -31,6 +31,7 @@ const MERCURE_URL =
  * - `weather_fetched` — per-stage weather forecasts
  * - `pois_scanned` — points of interest with optional alerts
  * - `accommodations_found` — accommodation options per stage
+ * - `events_found` — DataTourisme dated events per stage
  * - `supply_timeline` — clustered supply markers per stage (water + food POIs)
  * - `terrain_alerts` / `calendar_alerts` / `wind_alerts` / `bike_shop_alerts` / `water_point_alerts` / `railway_station_alerts` / `health_service_alerts` / `border_crossing_alerts` — alert categories
  * - `trip_complete` — final computation status, stops processing spinner
@@ -86,6 +87,7 @@ function dispatchEvent(event: MercureEvent): void {
             alerts: [],
             pois: [],
             supplyTimeline: [],
+            events: [],
             accommodations: existing?.accommodations ?? [],
             selectedAccommodation: existing?.selectedAccommodation ?? null,
             accommodationSearchRadiusKm:
@@ -125,6 +127,7 @@ function dispatchEvent(event: MercureEvent): void {
             alerts: [],
             pois: [],
             supplyTimeline: [],
+            events: [],
             accommodations: endMatch ? prev.accommodations : [],
             accommodationSearchRadiusKm: endMatch
               ? (prev.accommodationSearchRadiusKm ??
@@ -187,6 +190,10 @@ function dispatchEvent(event: MercureEvent): void {
           "accommodations",
         );
       }
+      break;
+
+    case "events_found":
+      store.setStageEvents(event.data.stageIndex, event.data.events);
       break;
 
     case "terrain_alerts":

--- a/pwa/src/hooks/use-trip-planner.ts
+++ b/pwa/src/hooks/use-trip-planner.ts
@@ -692,6 +692,7 @@ export function useTripPlanner() {
       isExactPrice: false,
       possibleClosed: false,
       distanceToEndPoint: 0,
+      source: "osm",
     };
     actions.addLocalAccommodation(stageIndex, newAcc);
     setNewAccKey(`${stageIndex}-${accIndex}`);

--- a/pwa/src/hooks/use-trip-planner.ts
+++ b/pwa/src/hooks/use-trip-planner.ts
@@ -374,6 +374,7 @@ export function useTripPlanner() {
       accommodations: [],
       accommodationSearchRadiusKm: DEFAULT_ACCOMMODATION_RADIUS_KM,
       supplyTimeline: [],
+      events: [],
       isRestDay: false,
     };
     // insertStagePlaceholder pushes an undo snapshot internally before mutating.

--- a/pwa/src/lib/accommodation-types.ts
+++ b/pwa/src/lib/accommodation-types.ts
@@ -1,7 +1,7 @@
 /**
  * All supported accommodation types for filtering.
- * Mirrors OSM tourism tags used in App\Scanner\OsmOverpassQueryBuilder on the backend.
- * Keep in sync with the PHP source.
+ * Mirrors OSM tags used in App\Scanner\OsmOverpassQueryBuilder on the backend.
+ * Keep in sync with the PHP source (TripRequest::ALL_ACCOMMODATION_TYPES).
  */
 export const ACCOMMODATION_TYPES = [
   "hotel",
@@ -11,13 +11,15 @@ export const ACCOMMODATION_TYPES = [
   "guest_house",
   "motel",
   "alpine_hut",
+  "wilderness_hut",
+  "shelter",
   "other",
 ] as const;
 
 export type AccommodationType = (typeof ACCOMMODATION_TYPES)[number];
 
 /**
- * The 7 OSM tourism types that can be used for backend Overpass filtering.
+ * The 9 accommodation types that can be used for backend Overpass filtering.
  * "other" is excluded as it is reserved for manually-added accommodations.
  */
 export const FILTERABLE_ACCOMMODATION_TYPES = [
@@ -28,6 +30,8 @@ export const FILTERABLE_ACCOMMODATION_TYPES = [
   "guest_house",
   "motel",
   "alpine_hut",
+  "wilderness_hut",
+  "shelter",
 ] as const satisfies ReadonlyArray<AccommodationType>;
 
 export type FilterableAccommodationType =

--- a/pwa/src/lib/api/schema.d.ts
+++ b/pwa/src/lib/api/schema.d.ts
@@ -471,6 +471,15 @@ export interface components {
             url?: string | null;
             possibleClosed?: boolean;
             distanceToEndPoint?: number;
+            source?: string;
+            /** @description Short description from Wikidata. */
+            description?: string | null;
+            /** @description Thumbnail image URL from Wikimedia Commons. */
+            imageUrl?: string | null;
+            /** @description Wikipedia article URL. */
+            wikipediaUrl?: string | null;
+            /** @description Opening hours (Wikidata P8989 or DataTourisme). */
+            openingHours?: string | null;
         };
         "Accommodation.gpx": {
             name?: string;
@@ -483,6 +492,15 @@ export interface components {
             url?: string | null;
             possibleClosed?: boolean;
             distanceToEndPoint?: number;
+            source?: string;
+            /** @description Short description from Wikidata. */
+            description?: string | null;
+            /** @description Thumbnail image URL from Wikimedia Commons. */
+            imageUrl?: string | null;
+            /** @description Wikipedia article URL. */
+            wikipediaUrl?: string | null;
+            /** @description Opening hours (Wikidata P8989 or DataTourisme). */
+            openingHours?: string | null;
         };
         "Accommodation.jsonld": {
             name?: string;
@@ -495,6 +513,15 @@ export interface components {
             url?: string | null;
             possibleClosed?: boolean;
             distanceToEndPoint?: number;
+            source?: string;
+            /** @description Short description from Wikidata. */
+            description?: string | null;
+            /** @description Thumbnail image URL from Wikimedia Commons. */
+            imageUrl?: string | null;
+            /** @description Wikipedia article URL. */
+            wikipediaUrl?: string | null;
+            /** @description Opening hours (Wikidata P8989 or DataTourisme). */
+            openingHours?: string | null;
         };
         "AccommodationScan.AccommodationScanRequest": {
             /**
@@ -681,6 +708,72 @@ export interface components {
             readonly type?: string;
             readonly description?: string | null;
         };
+        "Event.fit": {
+            name?: string;
+            type?: string;
+            lat?: number;
+            lon?: number;
+            /** Format: date-time */
+            startDate?: string;
+            /** Format: date-time */
+            endDate?: string;
+            url?: string | null;
+            description?: string | null;
+            priceMin?: number | null;
+            distanceToEndPoint?: number;
+            source?: string;
+            wikidataId?: string | null;
+            /** @description Thumbnail image URL from Wikimedia Commons. */
+            imageUrl?: string | null;
+            /** @description Wikipedia article URL. */
+            wikipediaUrl?: string | null;
+            /** @description Opening hours (Wikidata P8989). */
+            openingHours?: string | null;
+        };
+        "Event.gpx": {
+            name?: string;
+            type?: string;
+            lat?: number;
+            lon?: number;
+            /** Format: date-time */
+            startDate?: string;
+            /** Format: date-time */
+            endDate?: string;
+            url?: string | null;
+            description?: string | null;
+            priceMin?: number | null;
+            distanceToEndPoint?: number;
+            source?: string;
+            wikidataId?: string | null;
+            /** @description Thumbnail image URL from Wikimedia Commons. */
+            imageUrl?: string | null;
+            /** @description Wikipedia article URL. */
+            wikipediaUrl?: string | null;
+            /** @description Opening hours (Wikidata P8989). */
+            openingHours?: string | null;
+        };
+        "Event.jsonld": {
+            name?: string;
+            type?: string;
+            lat?: number;
+            lon?: number;
+            /** Format: date-time */
+            startDate?: string;
+            /** Format: date-time */
+            endDate?: string;
+            url?: string | null;
+            description?: string | null;
+            priceMin?: number | null;
+            distanceToEndPoint?: number;
+            source?: string;
+            wikidataId?: string | null;
+            /** @description Thumbnail image URL from Wikimedia Commons. */
+            imageUrl?: string | null;
+            /** @description Wikipedia article URL. */
+            wikipediaUrl?: string | null;
+            /** @description Opening hours (Wikidata P8989). */
+            openingHours?: string | null;
+        };
         HydraCollectionBaseSchema: components["schemas"]["HydraCollectionBaseSchemaNoPagination"] & {
             /**
              * @example {
@@ -780,6 +873,7 @@ export interface components {
             pois?: components["schemas"]["PointOfInterest.jsonld"][];
             accommodations?: components["schemas"]["Accommodation.jsonld"][];
             selectedAccommodation?: components["schemas"]["Accommodation.jsonld"] | null;
+            events?: components["schemas"]["Event.jsonld"][];
             /**
              * Format: iri-reference
              * @example https://example.com/
@@ -808,6 +902,7 @@ export interface components {
             pois?: components["schemas"]["PointOfInterest.fit"][];
             accommodations?: components["schemas"]["Accommodation.fit"][];
             selectedAccommodation?: components["schemas"]["Accommodation.fit"] | null;
+            events?: components["schemas"]["Event.fit"][];
             tripId?: string;
             dayNumber?: number;
             distance?: number;
@@ -825,6 +920,7 @@ export interface components {
             pois?: components["schemas"]["PointOfInterest.gpx"][];
             accommodations?: components["schemas"]["Accommodation.gpx"][];
             selectedAccommodation?: components["schemas"]["Accommodation.gpx"] | null;
+            events?: components["schemas"]["Event.gpx"][];
             tripId?: string;
             dayNumber?: number;
             distance?: number;
@@ -842,6 +938,7 @@ export interface components {
             pois?: components["schemas"]["PointOfInterest.jsonld"][];
             accommodations?: components["schemas"]["Accommodation.jsonld"][];
             selectedAccommodation?: components["schemas"]["Accommodation.jsonld"] | null;
+            events?: components["schemas"]["Event.jsonld"][];
             tripId?: string;
             dayNumber?: number;
             distance?: number;
@@ -895,7 +992,7 @@ export interface components {
              */
             averageSpeed: number;
             /**
-             * @description Enabled OSM tourism types for accommodation search (default: all 7 types)
+             * @description Enabled OSM accommodation types for search (default: all 9 types)
              * @default [
              *       "camp_site",
              *       "hostel",
@@ -903,7 +1000,9 @@ export interface components {
              *       "chalet",
              *       "guest_house",
              *       "motel",
-             *       "hotel"
+             *       "hotel",
+             *       "wilderness_hut",
+             *       "shelter"
              *     ]
              */
             enabledAccommodationTypes: string[];
@@ -938,7 +1037,7 @@ export interface components {
              */
             averageSpeed: number;
             /**
-             * @description Enabled OSM tourism types for accommodation search (default: all 7 types)
+             * @description Enabled OSM accommodation types for search (default: all 9 types)
              * @default [
              *       "camp_site",
              *       "hostel",
@@ -946,7 +1045,9 @@ export interface components {
              *       "chalet",
              *       "guest_house",
              *       "motel",
-             *       "hotel"
+             *       "hotel",
+             *       "wilderness_hut",
+             *       "shelter"
              *     ]
              */
             enabledAccommodationTypes: string[];
@@ -1084,6 +1185,7 @@ export interface components {
             pois?: components["schemas"]["PointOfInterest.fit"][];
             accommodations?: components["schemas"]["Accommodation.fit"][];
             selectedAccommodation?: components["schemas"]["Accommodation.fit"] | null;
+            events?: components["schemas"]["Event.fit"][];
             tripId?: string;
             dayNumber?: number;
             distance?: number;
@@ -1101,6 +1203,7 @@ export interface components {
             pois?: components["schemas"]["PointOfInterest.gpx"][];
             accommodations?: components["schemas"]["Accommodation.gpx"][];
             selectedAccommodation?: components["schemas"]["Accommodation.gpx"] | null;
+            events?: components["schemas"]["Event.gpx"][];
             tripId?: string;
             dayNumber?: number;
             distance?: number;

--- a/pwa/src/lib/mercure/types.ts
+++ b/pwa/src/lib/mercure/types.ts
@@ -64,6 +64,7 @@ export interface AccommodationPayload {
   isExactPrice: boolean;
   possibleClosed: boolean;
   distanceToEndPoint: number;
+  source: "osm" | "datatourisme";
 }
 
 export interface SupplyWaterPoint {

--- a/pwa/src/lib/mercure/types.ts
+++ b/pwa/src/lib/mercure/types.ts
@@ -65,6 +65,10 @@ export interface AccommodationPayload {
   possibleClosed: boolean;
   distanceToEndPoint: number;
   source: "osm" | "datatourisme";
+  description?: string | null;
+  imageUrl?: string | null;
+  wikipediaUrl?: string | null;
+  openingHours?: string | null;
 }
 
 export interface EventPayload {
@@ -80,6 +84,9 @@ export interface EventPayload {
   distanceToEndPoint: number;
   source: string;
   wikidataId: string | null;
+  imageUrl?: string | null;
+  wikipediaUrl?: string | null;
+  openingHours?: string | null;
 }
 
 export interface SupplyWaterPoint {
@@ -226,6 +233,8 @@ export type MercureEvent =
           description?: string;
           wikidataId?: string;
           source?: string;
+          imageUrl?: string;
+          wikipediaUrl?: string;
         }[];
       };
     }

--- a/pwa/src/lib/mercure/types.ts
+++ b/pwa/src/lib/mercure/types.ts
@@ -66,6 +66,21 @@ export interface AccommodationPayload {
   distanceToEndPoint: number;
 }
 
+export interface EventPayload {
+  name: string;
+  type: string;
+  lat: number;
+  lon: number;
+  startDate: string;
+  endDate: string;
+  url: string | null;
+  description: string | null;
+  priceMin: number | null;
+  distanceToEndPoint: number;
+  source: string;
+  wikidataId: string | null;
+}
+
 export interface SupplyWaterPoint {
   name: string | null;
   lat: number;
@@ -245,6 +260,13 @@ export type MercureEvent =
         elevationGain: number;
         duration: number;
         coordinates: { lat: number; lon: number; ele: number }[];
+      };
+    }
+  | {
+      type: "events_found";
+      data: {
+        stageIndex: number;
+        events: EventPayload[];
       };
     }
   | { type: "validation_error"; data: { code: string; message: string } }

--- a/pwa/src/lib/mercure/types.ts
+++ b/pwa/src/lib/mercure/types.ts
@@ -205,6 +205,11 @@ export type MercureEvent =
           poiLat: number;
           poiLon: number;
           distanceFromRoute: number;
+          openingHours?: string;
+          estimatedPrice?: number;
+          description?: string;
+          wikidataId?: string;
+          source?: string;
         }[];
       };
     }

--- a/pwa/src/lib/validation/schemas.ts
+++ b/pwa/src/lib/validation/schemas.ts
@@ -25,6 +25,10 @@ export const AlertSchema = z.object({
   poiLat: z.number().optional(),
   poiLon: z.number().optional(),
   distanceFromRoute: z.number().optional(),
+  openingHours: z.string().optional(),
+  estimatedPrice: z.number().optional(),
+  description: z.string().optional(),
+  wikidataId: z.string().optional(),
   // Optional contextual action
   action: AlertActionSchema.nullable().optional(),
 });

--- a/pwa/src/lib/validation/schemas.ts
+++ b/pwa/src/lib/validation/schemas.ts
@@ -87,6 +87,7 @@ export const AccommodationSchema = z.object({
   url: z.string().nullable().optional(),
   possibleClosed: z.boolean().default(false),
   distanceToEndPoint: z.number().default(0),
+  source: z.enum(["osm", "datatourisme"]).default("osm"),
 });
 
 export const StageDataSchema = z.object({

--- a/pwa/src/lib/validation/schemas.ts
+++ b/pwa/src/lib/validation/schemas.ts
@@ -29,6 +29,8 @@ export const AlertSchema = z.object({
   estimatedPrice: z.number().optional(),
   description: z.string().optional(),
   wikidataId: z.string().optional(),
+  imageUrl: z.string().optional(),
+  wikipediaUrl: z.string().optional(),
   // Optional contextual action
   action: AlertActionSchema.nullable().optional(),
 });
@@ -93,6 +95,9 @@ export const EventSchema = z.object({
   distanceToEndPoint: z.number().default(0),
   source: z.string().default("datatourisme"),
   wikidataId: z.string().nullable().optional(),
+  imageUrl: z.string().nullable().optional(),
+  wikipediaUrl: z.string().nullable().optional(),
+  openingHours: z.string().nullable().optional(),
 });
 
 export const AccommodationSchema = z.object({
@@ -107,6 +112,10 @@ export const AccommodationSchema = z.object({
   possibleClosed: z.boolean().default(false),
   distanceToEndPoint: z.number().default(0),
   source: z.enum(["osm", "datatourisme"]).default("osm"),
+  description: z.string().nullable().optional(),
+  imageUrl: z.string().nullable().optional(),
+  wikipediaUrl: z.string().nullable().optional(),
+  openingHours: z.string().nullable().optional(),
 });
 
 export const StageDataSchema = z.object({

--- a/pwa/src/lib/validation/schemas.ts
+++ b/pwa/src/lib/validation/schemas.ts
@@ -76,6 +76,21 @@ export const SupplyMarkerSchema = z.object({
   food: z.array(SupplyFoodPointSchema),
 });
 
+export const EventSchema = z.object({
+  name: z.string(),
+  type: z.string(),
+  lat: z.number(),
+  lon: z.number(),
+  startDate: z.string(),
+  endDate: z.string(),
+  url: z.string().nullable().optional(),
+  description: z.string().nullable().optional(),
+  priceMin: z.number().nullable().optional(),
+  distanceToEndPoint: z.number().default(0),
+  source: z.string().default("datatourisme"),
+  wikidataId: z.string().nullable().optional(),
+});
+
 export const AccommodationSchema = z.object({
   name: z.string(),
   type: z.string(),
@@ -112,6 +127,7 @@ export const StageDataSchema = z.object({
     .default(DEFAULT_ACCOMMODATION_RADIUS_KM),
   isRestDay: z.boolean().default(false),
   supplyTimeline: z.array(SupplyMarkerSchema).default([]),
+  events: z.array(EventSchema).default([]),
 });
 
 export const TripStateSchema = z.object({
@@ -143,5 +159,6 @@ export type PoiData = z.infer<typeof PointOfInterestSchema>;
 export type SupplyWaterPointData = z.infer<typeof SupplyWaterPointSchema>;
 export type SupplyFoodPointData = z.infer<typeof SupplyFoodPointSchema>;
 export type SupplyMarkerData = z.infer<typeof SupplyMarkerSchema>;
+export type EventData = z.infer<typeof EventSchema>;
 export type AccommodationData = z.infer<typeof AccommodationSchema>;
 export type StageData = z.infer<typeof StageDataSchema>;

--- a/pwa/src/store/trip-store.test.ts
+++ b/pwa/src/store/trip-store.test.ts
@@ -23,6 +23,7 @@ describe("getUndoableSlice", () => {
           accommodationSearchRadiusKm: 5,
           isRestDay: false,
           supplyTimeline: [],
+          events: [],
         },
       ],
       startDate: "2026-07-01",
@@ -65,6 +66,7 @@ describe("getUndoableSlice", () => {
       accommodationSearchRadiusKm: 5,
       isRestDay: false,
       supplyTimeline: [],
+      events: [],
     };
 
     const state = {

--- a/pwa/src/store/trip-store.ts
+++ b/pwa/src/store/trip-store.ts
@@ -10,6 +10,7 @@ import type {
   AccommodationData,
   AlertData,
   SupplyMarkerData,
+  EventData,
 } from "@/lib/validation/schemas";
 import type { AccommodationType } from "@/lib/accommodation-types";
 import { FILTERABLE_ACCOMMODATION_TYPES } from "@/lib/accommodation-types";
@@ -56,6 +57,8 @@ interface TripState {
     stageIndex: number,
     markers: SupplyMarkerData[],
   ) => void;
+  setStageEvents: (stageIndex: number, events: EventData[]) => void;
+  clearEvents: () => void;
   updateStageAccommodations: (
     stageIndex: number,
     accs: AccommodationData[],
@@ -254,6 +257,20 @@ export const useTripStore = create<TripState>()(
         }
       }),
 
+    setStageEvents: (stageIndex, events) =>
+      set((state) => {
+        if (state.stages[stageIndex]) {
+          state.stages[stageIndex].events = events;
+        }
+      }),
+
+    clearEvents: () =>
+      set((state) => {
+        for (const stage of state.stages) {
+          stage.events = [];
+        }
+      }),
+
     updateStageAccommodations: (stageIndex, accs, searchRadiusKm) =>
       set((state) => {
         const stage = state.stages[stageIndex];
@@ -433,6 +450,7 @@ export const useTripStore = create<TripState>()(
           accommodationSearchRadiusKm: DEFAULT_ACCOMMODATION_RADIUS_KM,
           isRestDay: true,
           supplyTimeline: [],
+          events: [],
         };
 
         state.stages.splice(afterIndex + 1, 0, restDay);

--- a/pwa/tests/fixtures/mock-data.ts
+++ b/pwa/tests/fixtures/mock-data.ts
@@ -128,6 +128,7 @@ export function accommodationsFoundEvent(
           isExactPrice: false,
           possibleClosed: false,
           distanceToEndPoint: 1.2,
+          source: "osm",
         },
         {
           name: "Hotel du Pont",
@@ -139,6 +140,7 @@ export function accommodationsFoundEvent(
           isExactPrice: false,
           possibleClosed: false,
           distanceToEndPoint: 0.5,
+          source: "osm",
         },
       ],
     },

--- a/pwa/tests/mocked/accommodation.spec.ts
+++ b/pwa/tests/mocked/accommodation.spec.ts
@@ -91,6 +91,7 @@ test.describe("Accommodations", () => {
               isExactPrice: false,
               possibleClosed: false,
               distanceToEndPoint: 0,
+              source: "osm",
             },
           ],
         },

--- a/pwa/tests/mocked/attribution-footer.spec.ts
+++ b/pwa/tests/mocked/attribution-footer.spec.ts
@@ -50,7 +50,9 @@ test.describe("attribution footer", () => {
     await expect(list).toBeVisible();
 
     await expect(page.getByTestId("attribution-osm-link")).toBeVisible();
-    await expect(page.getByTestId("attribution-datatourisme-link")).toBeVisible();
+    await expect(
+      page.getByTestId("attribution-datatourisme-link"),
+    ).toBeVisible();
     await expect(page.getByTestId("attribution-wikidata-link")).toBeVisible();
     await expect(page.getByTestId("attribution-datagouv-link")).toBeVisible();
   });

--- a/pwa/tests/mocked/attribution-footer.spec.ts
+++ b/pwa/tests/mocked/attribution-footer.spec.ts
@@ -1,0 +1,97 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("attribution footer", () => {
+  test.beforeEach(async ({ page }) => {
+    // Render unauthenticated so the landing page is shown
+    await page.route("**/auth/refresh", (route, request) => {
+      if (request.method() !== "POST") return route.fallback();
+      return route.fulfill({ status: 401, body: "" });
+    });
+  });
+
+  test('shows "À propos des données" link on the landing page', async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    const link = page.getByTestId("attribution-footer-link");
+    await expect(link).toBeVisible();
+  });
+
+  test('shows "À propos des données" link on the login page', async ({
+    page,
+  }) => {
+    await page.goto("/login");
+    await page.waitForLoadState("networkidle");
+
+    const link = page.getByTestId("attribution-footer-link");
+    await expect(link).toBeVisible();
+  });
+
+  test("clicking the link opens the attribution modal", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    const link = page.getByTestId("attribution-footer-link");
+    await link.click();
+
+    const modal = page.getByTestId("attribution-modal");
+    await expect(modal).toBeVisible();
+  });
+
+  test("modal contains all four data sources", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    await page.getByTestId("attribution-footer-link").click();
+
+    const list = page.getByTestId("attribution-list");
+    await expect(list).toBeVisible();
+
+    await expect(page.getByTestId("attribution-osm-link")).toBeVisible();
+    await expect(page.getByTestId("attribution-datatourisme-link")).toBeVisible();
+    await expect(page.getByTestId("attribution-wikidata-link")).toBeVisible();
+    await expect(page.getByTestId("attribution-datagouv-link")).toBeVisible();
+  });
+
+  test("ODbL link points to the correct URL", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    await page.getByTestId("attribution-footer-link").click();
+
+    const osmLink = page.getByTestId("attribution-osm-link");
+    await expect(osmLink).toHaveAttribute(
+      "href",
+      "https://opendatacommons.org/licenses/odbl/",
+    );
+  });
+
+  test("Wikidata CC0 link points to the correct URL", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    await page.getByTestId("attribution-footer-link").click();
+
+    const wikidataLink = page.getByTestId("attribution-wikidata-link");
+    await expect(wikidataLink).toHaveAttribute(
+      "href",
+      "https://creativecommons.org/publicdomain/zero/1.0/",
+    );
+  });
+
+  test("modal can be closed", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    await page.getByTestId("attribution-footer-link").click();
+
+    const modal = page.getByTestId("attribution-modal");
+    await expect(modal).toBeVisible();
+
+    // Close via the X button (DialogClose)
+    await page.keyboard.press("Escape");
+    await expect(modal).not.toBeVisible();
+  });
+});

--- a/pwa/tests/mocked/events-panel.spec.ts
+++ b/pwa/tests/mocked/events-panel.spec.ts
@@ -61,9 +61,7 @@ test.describe("Events panel", () => {
 
     const stageCard = mockedPage.getByTestId("stage-card-1");
     await expect(stageCard.getByTestId("events-panel")).toBeVisible();
-    await expect(
-      stageCard.getByTestId("events-panel-toggle"),
-    ).toBeVisible();
+    await expect(stageCard.getByTestId("events-panel-toggle")).toBeVisible();
     await expect(stageCard.getByTestId("events-panel-toggle")).toContainText(
       "Événements (2)",
     );
@@ -183,14 +181,14 @@ test.describe("Events panel", () => {
 
     // stage 1 has its own events
     await stageCard1.getByTestId("events-panel-toggle").click();
-    await expect(
-      stageCard1.getByTestId("events-panel-content"),
-    ).toContainText("Festival de Jazz de Vals");
+    await expect(stageCard1.getByTestId("events-panel-content")).toContainText(
+      "Festival de Jazz de Vals",
+    );
 
     // stage 2 has its own events
     await stageCard2.getByTestId("events-panel-toggle").click();
-    await expect(
-      stageCard2.getByTestId("events-panel-content"),
-    ).toContainText("Festival de Jazz de Vals");
+    await expect(stageCard2.getByTestId("events-panel-content")).toContainText(
+      "Festival de Jazz de Vals",
+    );
   });
 });

--- a/pwa/tests/mocked/events-panel.spec.ts
+++ b/pwa/tests/mocked/events-panel.spec.ts
@@ -1,0 +1,196 @@
+import { test, expect } from "../fixtures/base.fixture";
+import {
+  routeParsedEvent,
+  stagesComputedEvent,
+  tripCompleteEvent,
+} from "../fixtures/mock-data";
+import type { MercureEvent } from "../../src/lib/mercure/types";
+
+function eventsFoundEvent(stageIndex: number): MercureEvent {
+  return {
+    type: "events_found",
+    data: {
+      stageIndex,
+      events: [
+        {
+          name: "Festival de Jazz de Vals",
+          type: "schema:Festival",
+          lat: 44.53,
+          lon: 4.37,
+          startDate: "2025-07-10T00:00:00+02:00",
+          endDate: "2025-07-14T00:00:00+02:00",
+          url: "https://festival-jazz.example.com",
+          description: "Grand festival annuel de jazz en plein air",
+          priceMin: 15,
+          distanceToEndPoint: 2500,
+          source: "datatourisme",
+          wikidataId: null,
+        },
+        {
+          name: "Exposition Renoir",
+          type: "schema:Exhibition",
+          lat: 44.54,
+          lon: 4.39,
+          startDate: "2025-07-01T00:00:00+02:00",
+          endDate: "2025-08-31T00:00:00+02:00",
+          url: null,
+          description: null,
+          priceMin: null,
+          distanceToEndPoint: 5000,
+          source: "datatourisme",
+          wikidataId: "Q12345",
+        },
+      ],
+    },
+  };
+}
+
+test.describe("Events panel", () => {
+  test("shows events panel toggle when events are present", async ({
+    submitUrl,
+    injectSequence,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    await injectSequence([
+      routeParsedEvent(),
+      stagesComputedEvent(),
+      eventsFoundEvent(0),
+      tripCompleteEvent(),
+    ]);
+
+    const stageCard = mockedPage.getByTestId("stage-card-1");
+    await expect(stageCard.getByTestId("events-panel")).toBeVisible();
+    await expect(
+      stageCard.getByTestId("events-panel-toggle"),
+    ).toBeVisible();
+    await expect(stageCard.getByTestId("events-panel-toggle")).toContainText(
+      "Événements (2)",
+    );
+  });
+
+  test("expands and shows event list on toggle click", async ({
+    submitUrl,
+    injectSequence,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    await injectSequence([
+      routeParsedEvent(),
+      stagesComputedEvent(),
+      eventsFoundEvent(0),
+      tripCompleteEvent(),
+    ]);
+
+    const stageCard = mockedPage.getByTestId("stage-card-1");
+    const toggle = stageCard.getByTestId("events-panel-toggle");
+
+    await toggle.click();
+
+    const content = stageCard.getByTestId("events-panel-content");
+    await expect(content).toBeVisible();
+    await expect(content).toContainText("Festival de Jazz de Vals");
+    await expect(content).toContainText("Exposition Renoir");
+  });
+
+  test("shows event metadata including type and date range", async ({
+    submitUrl,
+    injectSequence,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    await injectSequence([
+      routeParsedEvent(),
+      stagesComputedEvent(),
+      eventsFoundEvent(0),
+      tripCompleteEvent(),
+    ]);
+
+    const stageCard = mockedPage.getByTestId("stage-card-1");
+    await stageCard.getByTestId("events-panel-toggle").click();
+
+    const content = stageCard.getByTestId("events-panel-content");
+    await expect(content).toContainText("Festival");
+    await expect(content).toContainText("Exposition");
+    await expect(content).toContainText("À partir de 15 €");
+  });
+
+  test("shows external link for events with url", async ({
+    submitUrl,
+    injectSequence,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    await injectSequence([
+      routeParsedEvent(),
+      stagesComputedEvent(),
+      eventsFoundEvent(0),
+      tripCompleteEvent(),
+    ]);
+
+    const stageCard = mockedPage.getByTestId("stage-card-1");
+    await stageCard.getByTestId("events-panel-toggle").click();
+
+    const link = stageCard.getByRole("link", {
+      name: "Voir le site de Festival de Jazz de Vals",
+    });
+    await expect(link).toBeVisible();
+    await expect(link).toHaveAttribute(
+      "href",
+      "https://festival-jazz.example.com",
+    );
+  });
+
+  test("does not render events panel when no events", async ({
+    submitUrl,
+    injectSequence,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    await injectSequence([
+      routeParsedEvent(),
+      stagesComputedEvent(),
+      {
+        type: "events_found",
+        data: { stageIndex: 0, events: [] },
+      },
+      tripCompleteEvent(),
+    ]);
+
+    const stageCard = mockedPage.getByTestId("stage-card-1");
+    await expect(stageCard.getByTestId("events-panel")).not.toBeAttached();
+  });
+
+  test("events are grouped by stage index", async ({
+    submitUrl,
+    injectSequence,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    await injectSequence([
+      routeParsedEvent(),
+      stagesComputedEvent(),
+      eventsFoundEvent(0),
+      eventsFoundEvent(1),
+      tripCompleteEvent(),
+    ]);
+
+    const stageCard1 = mockedPage.getByTestId("stage-card-1");
+    const stageCard2 = mockedPage.getByTestId("stage-card-2");
+
+    await expect(stageCard1.getByTestId("events-panel")).toBeVisible();
+    await expect(stageCard2.getByTestId("events-panel")).toBeVisible();
+
+    // stage 1 has its own events
+    await stageCard1.getByTestId("events-panel-toggle").click();
+    await expect(
+      stageCard1.getByTestId("events-panel-content"),
+    ).toContainText("Festival de Jazz de Vals");
+
+    // stage 2 has its own events
+    await stageCard2.getByTestId("events-panel-toggle").click();
+    await expect(
+      stageCard2.getByTestId("events-panel-content"),
+    ).toContainText("Festival de Jazz de Vals");
+  });
+});

--- a/pwa/tests/mocked/offline-consultation.spec.ts
+++ b/pwa/tests/mocked/offline-consultation.spec.ts
@@ -46,6 +46,7 @@ const SEED_TRIP = {
       accommodationSearchRadiusKm: 20,
       isRestDay: false,
       supplyTimeline: [],
+      events: [],
     },
     {
       dayNumber: 2,
@@ -65,6 +66,7 @@ const SEED_TRIP = {
       accommodationSearchRadiusKm: 20,
       isRestDay: false,
       supplyTimeline: [],
+      events: [],
     },
     {
       dayNumber: 3,
@@ -84,6 +86,7 @@ const SEED_TRIP = {
       accommodationSearchRadiusKm: 20,
       isRestDay: false,
       supplyTimeline: [],
+      events: [],
     },
   ],
   savedAt: new Date().toISOString(),

--- a/pwa/tests/recette/features/configuration.en.feature
+++ b/pwa/tests/recette/features/configuration.en.feature
@@ -32,7 +32,7 @@ Feature: Configuration and settings
   @desktop @critical
   Scenario: Accommodation type filter switches visible
     When I open the settings panel
-    Then I see switches for types "Hôtel, Auberge, Camping, Gîte, Chambre d'hôte, Motel, Refuge"
+    Then I see switches for types "Hôtel, Auberge, Camping, Gîte, Chambre d'hôte, Motel, Refuge, Bivouac, Abri"
 
   @desktop @critical
   Scenario: Last enabled accommodation type cannot be disabled

--- a/pwa/tests/recette/features/configuration.fr.feature
+++ b/pwa/tests/recette/features/configuration.fr.feature
@@ -33,7 +33,7 @@ Fonctionnalité: Configuration et paramètres
   @desktop @critique
   Scénario: Filtrage des types d'hébergement
     Quand j'ouvre le panneau de paramètres
-    Alors je vois les interrupteurs pour les types "Hôtel, Auberge, Camping, Gîte, Chambre d'hôte, Motel, Refuge"
+    Alors je vois les interrupteurs pour les types "Hôtel, Auberge, Camping, Gîte, Chambre d'hôte, Motel, Refuge, Bivouac, Abri"
 
   @desktop @critique
   Scénario: Le dernier type d'hébergement activé ne peut pas être désactivé

--- a/pwa/tests/recette/steps/configuration.steps.ts
+++ b/pwa/tests/recette/steps/configuration.steps.ts
@@ -79,14 +79,14 @@ When(
 Then(
   "je vois les interrupteurs pour les types {string}",
   async ({ mockedPage }, _typesStr: string) => {
-    await expect(getAccommodationSwitches(mockedPage)).toHaveCount(7);
+    await expect(getAccommodationSwitches(mockedPage)).toHaveCount(9);
   },
 );
 
 Then(
   "I see switches for types {string}",
   async ({ mockedPage }, _typesStr: string) => {
-    await expect(getAccommodationSwitches(mockedPage)).toHaveCount(7);
+    await expect(getAccommodationSwitches(mockedPage)).toHaveCount(9);
   },
 );
 

--- a/pwa/tests/recette/steps/mobile-offline.steps.ts
+++ b/pwa/tests/recette/steps/mobile-offline.steps.ts
@@ -43,6 +43,7 @@ const SEED_TRIP = {
       accommodationSearchRadiusKm: 20,
       isRestDay: false,
       supplyTimeline: [],
+      events: [],
     },
     {
       dayNumber: 2,
@@ -62,6 +63,7 @@ const SEED_TRIP = {
       accommodationSearchRadiusKm: 20,
       isRestDay: false,
       supplyTimeline: [],
+      events: [],
     },
     {
       dayNumber: 3,
@@ -81,6 +83,7 @@ const SEED_TRIP = {
       accommodationSearchRadiusKm: 20,
       isRestDay: false,
       supplyTimeline: [],
+      events: [],
     },
   ],
   savedAt: new Date().toISOString(),

--- a/pwa/tests/recette/steps/trip-management.steps.ts
+++ b/pwa/tests/recette/steps/trip-management.steps.ts
@@ -80,6 +80,7 @@ const SEED_TRIP_TEMPLATE = {
       accommodationSearchRadiusKm: 20,
       isRestDay: false,
       supplyTimeline: [],
+      events: [],
     },
   ],
   savedAt: new Date().toISOString(),


### PR DESCRIPTION
## Summary

- **ADR-026** (`docs/adr/adr-026-multi-source-data-integration.md`): new Architecture Decision Record documenting the multi-source data integration strategy (DataTourisme, Wikidata, data.gouv.fr alongside OSM), with source roles table, rejected alternatives, interface registry pattern, and consequences
- **ADR-013 updated**: added a note at the top referencing ADR-026 and the sprint 20 evolution toward multi-source accommodation/POI discovery
- **README**: consolidated all external data sources into a single summary table + detailed per-source sections (OSM, DataTourisme, Wikidata, data.gouv.fr markets); updated ADR count (24 → 26); integrated admin commands into the data sources section
- **Attribution footer** (`pwa/src/components/attribution-footer.tsx`): new `AttributionFooter` component — a button that opens a modal listing all four data sources with correct licences (ODbL, Licence Ouverte 2.0, CC0); wired into landing page, login page, and trip planner footers
- **i18n**: added `attribution.*` keys in `en.json` and `fr.json`
- **Playwright test** (`pwa/tests/mocked/attribution-footer.spec.ts`): 7 tests covering link visibility on landing/login pages, modal open/close, presence of all four source entries, and correct licence URLs

## Test plan

- [ ] `make test-e2e -- tests/mocked/attribution-footer.spec.ts` — all 7 tests pass
- [ ] Navigate to `/` (landing page) — "À propos des données" link visible in footer
- [ ] Navigate to `/login` — "À propos des données" link visible in footer alongside FAQ link
- [ ] Click "À propos des données" — modal opens with OpenStreetMap, DataTourisme, Wikidata, data.gouv.fr entries
- [ ] ODbL link → `opendatacommons.org/licenses/odbl/`; Wikidata → CC0; DataTourisme + data.gouv.fr → Licence Ouverte 2.0
- [ ] Press Escape — modal closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

**Commit reviewed:** `e3169d458d13715b04e46233b4aeaad59add98ff`

**Summary:** All previously flagged correctness issues have been addressed in the latest fix commits. The `ScanEventsHandler` now correctly uses `/api/v1/events` with flat filter params, guards against null stages/startDate by calling `executeWithTracking` before any early return, runs the market scan independently of DataTourisme availability, and uses the `TranslatorInterface` for the market description. The `event-item.tsx` component correctly uses `useTranslations` and `useLocale`. The `WikidataEnricher` validates Q-IDs before SPARQL interpolation. No new issues were introduced.

**Resolved threads:** Resolved 8 previously open bot-authored threads that were addressed in the latest push.

**PR title check:** `feat(data-sources): ADR-026, README sources, attribution footer (sprint 20 Part F)` — description contains uppercase tokens (`ADR-026`, `README`) and a trailing parenthetical `(sprint 20 Part F)`, which deviates from Conventional Commits style. Suggest: `feat(data-sources): add adr-026, readme data sources, and attribution footer`. (Non-blocking — the branch is squash-merged.)

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate (registry pattern consistently applied across accommodation, cultural-POI, and event sources)
- [x] Tests cover new/changed cases
- [x] Documentation is up to date (ADR-026 added, README updated, TRACKING.md PRs filled)
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

Generated with [Claude Code](https://claude.com/claude-code)
<!-- claude-review-end -->