### PR TITLE
feat(stepper): add 4-step navigation stepper component

### DIFF
--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -322,6 +322,14 @@
     "viewAll": "View all ({count})",
     "noDate": "No date"
   },
+  "stepper": {
+    "ariaLabel": "Process steps",
+    "preparation": "Preparation",
+    "preview": "Preview",
+    "analysis": "Analysis",
+    "myTrip": "My Trip",
+    "mobileLabel": "Step {current}/{total} — {stepName}"
+  },
   "planner": {
     "closeTrip": "Close this trip"
   },

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -322,6 +322,14 @@
     "viewAll": "Voir tous ({count})",
     "noDate": "Non daté"
   },
+  "stepper": {
+    "ariaLabel": "Étapes du processus",
+    "preparation": "Préparation",
+    "preview": "Aperçu",
+    "analysis": "Analyse",
+    "myTrip": "Mon voyage",
+    "mobileLabel": "Étape {current}/{total} — {stepName}"
+  },
   "planner": {
     "closeTrip": "Fermer ce trip"
   },

--- a/pwa/src/components/stepper.tsx
+++ b/pwa/src/components/stepper.tsx
@@ -72,10 +72,7 @@ export function Stepper() {
       </div>
 
       {/* Desktop horizontal stepper */}
-      <ol
-        className="hidden sm:flex items-center w-full"
-        aria-label={t("ariaLabel")}
-      >
+      <ol className="hidden sm:flex items-center w-full">
         {STEPS.map((step, index) => {
           const isActive = step === currentStep;
           const isCompleted = completedSteps.has(step);

--- a/pwa/src/components/stepper.tsx
+++ b/pwa/src/components/stepper.tsx
@@ -111,9 +111,7 @@ export function Stepper() {
                     {isCompleted ? (
                       <Check className="w-4 h-4" aria-hidden="true" />
                     ) : (
-                      <span className="text-xs font-semibold">
-                        {index + 1}
-                      </span>
+                      <span className="text-xs font-semibold">{index + 1}</span>
                     )}
                   </button>
                 ) : (
@@ -136,9 +134,7 @@ export function Stepper() {
                     {isCompleted || isPast ? (
                       <Check className="w-4 h-4" aria-hidden="true" />
                     ) : (
-                      <span className="text-xs font-semibold">
-                        {index + 1}
-                      </span>
+                      <span className="text-xs font-semibold">{index + 1}</span>
                     )}
                   </div>
                 )}

--- a/pwa/src/components/stepper.tsx
+++ b/pwa/src/components/stepper.tsx
@@ -116,7 +116,6 @@ export function Stepper() {
                   </button>
                 ) : (
                   <div
-                    role="listitem"
                     aria-current={isActive ? "step" : undefined}
                     aria-label={stepLabels[step]}
                     data-testid={`stepper-step-${step}`}

--- a/pwa/src/components/stepper.tsx
+++ b/pwa/src/components/stepper.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { Check } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { cn } from "@/lib/utils";
+import { useUiStore, STEPS } from "@/store/ui-store";
+import type { StepId } from "@/store/ui-store";
+
+/**
+ * Visual 4-step progress indicator for the trip planning workflow.
+ *
+ * ```
+ *   ●━━━━━━━━━━●━━━━━━━━━━○━━━━━━━━━━○
+ *   Préparation  Aperçu    Analyse    Mon voyage
+ * ```
+ *
+ * - Completed steps show a checkmark and are clickable (backwards navigation).
+ * - The active step is visually highlighted.
+ * - "Analyse" (system step) is **never** clickable.
+ * - At step "Mon voyage" the stepper becomes a non-interactive visual indicator.
+ * - On mobile a compact "Étape 2/4 — Aperçu" label is shown.
+ */
+export function Stepper() {
+  const t = useTranslations("stepper");
+  const currentStep = useUiStore((s) => s.currentStep);
+  const completedSteps = useUiStore((s) => s.completedSteps);
+  const goToStep = useUiStore((s) => s.goToStep);
+
+  const isMyTrip = currentStep === "my_trip";
+  const currentIndex = STEPS.indexOf(currentStep);
+
+  /** Human-readable labels for each step, in order. */
+  const stepLabels: Record<StepId, string> = {
+    preparation: t("preparation"),
+    preview: t("preview"),
+    analysis: t("analysis"),
+    my_trip: t("myTrip"),
+  };
+
+  function isClickable(step: StepId): boolean {
+    // Non-interactive at "my_trip" (Act 3 lock)
+    if (isMyTrip) return false;
+    // "analysis" is always a system step
+    if (step === "analysis") return false;
+    // Cannot click the current active step
+    if (step === currentStep) return false;
+    // Only completed steps are backwards-navigable
+    const stepIdx = STEPS.indexOf(step);
+    if (stepIdx < currentIndex) return completedSteps.has(step);
+    // Forward steps are not navigable directly (flow is driven by app logic)
+    return false;
+  }
+
+  return (
+    <nav
+      role="navigation"
+      aria-label={t("ariaLabel")}
+      data-testid="stepper"
+      className="w-full"
+    >
+      {/* Mobile compact label */}
+      <div
+        className="sm:hidden text-sm text-muted-foreground text-center py-2"
+        data-testid="stepper-mobile-label"
+        aria-hidden="true"
+      >
+        {t("mobileLabel", {
+          current: currentIndex + 1,
+          total: STEPS.length,
+          stepName: stepLabels[currentStep],
+        })}
+      </div>
+
+      {/* Desktop horizontal stepper */}
+      <ol
+        className="hidden sm:flex items-center w-full"
+        aria-label={t("ariaLabel")}
+      >
+        {STEPS.map((step, index) => {
+          const isActive = step === currentStep;
+          const isCompleted = completedSteps.has(step);
+          const isPast = index < currentIndex;
+          const isFuture = index > currentIndex;
+          const clickable = isClickable(step);
+
+          return (
+            <li
+              key={step}
+              className={cn(
+                "flex items-center",
+                index < STEPS.length - 1 ? "flex-1" : "",
+              )}
+            >
+              {/* Step button / indicator */}
+              <div className="flex flex-col items-center gap-1 relative">
+                {clickable ? (
+                  <button
+                    type="button"
+                    onClick={() => goToStep(step)}
+                    aria-current={isActive ? "step" : undefined}
+                    aria-label={stepLabels[step]}
+                    data-testid={`stepper-step-${step}`}
+                    className={cn(
+                      "flex items-center justify-center w-8 h-8 rounded-full border-2 transition-colors duration-200 cursor-pointer",
+                      "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand",
+                      isCompleted
+                        ? "border-brand bg-brand text-white hover:bg-brand/80"
+                        : "border-brand bg-background text-brand hover:bg-brand/10",
+                    )}
+                  >
+                    {isCompleted ? (
+                      <Check className="w-4 h-4" aria-hidden="true" />
+                    ) : (
+                      <span className="text-xs font-semibold">
+                        {index + 1}
+                      </span>
+                    )}
+                  </button>
+                ) : (
+                  <div
+                    role="listitem"
+                    aria-current={isActive ? "step" : undefined}
+                    aria-label={stepLabels[step]}
+                    data-testid={`stepper-step-${step}`}
+                    className={cn(
+                      "flex items-center justify-center w-8 h-8 rounded-full border-2 transition-colors duration-200",
+                      isActive
+                        ? "border-brand bg-brand text-white"
+                        : isCompleted || isPast
+                          ? "border-brand bg-brand text-white"
+                          : isFuture
+                            ? "border-muted-foreground/30 bg-background text-muted-foreground/50"
+                            : "border-brand bg-background text-brand",
+                    )}
+                  >
+                    {isCompleted || isPast ? (
+                      <Check className="w-4 h-4" aria-hidden="true" />
+                    ) : (
+                      <span className="text-xs font-semibold">
+                        {index + 1}
+                      </span>
+                    )}
+                  </div>
+                )}
+
+                {/* Step label */}
+                <span
+                  className={cn(
+                    "text-xs whitespace-nowrap absolute top-full mt-1",
+                    isActive
+                      ? "text-foreground font-semibold"
+                      : isCompleted || isPast
+                        ? "text-muted-foreground"
+                        : "text-muted-foreground/50",
+                  )}
+                >
+                  {stepLabels[step]}
+                </span>
+              </div>
+
+              {/* Connector line between steps */}
+              {index < STEPS.length - 1 && (
+                <div
+                  className={cn(
+                    "flex-1 h-0.5 mx-2 transition-colors duration-200",
+                    index < currentIndex
+                      ? "bg-brand"
+                      : "bg-muted-foreground/20",
+                  )}
+                  aria-hidden="true"
+                />
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}

--- a/pwa/src/components/trip-planner.tsx
+++ b/pwa/src/components/trip-planner.tsx
@@ -21,6 +21,7 @@ import { MapPanel } from "@/components/Map";
 import { ViewModeToggle } from "@/components/ViewModeToggle";
 import { Button } from "@/components/ui/button";
 import { UndoRedoButtons } from "@/components/undo-redo-buttons";
+import { Stepper } from "@/components/stepper";
 import { RecentTrips } from "@/components/recent-trips";
 import { SavedTripsSection } from "@/components/saved-trips-section";
 import { OfflineBanner } from "@/components/offline-banner";
@@ -100,6 +101,8 @@ export function TripPlanner({ onClose }: { onClose?: () => void } = {}) {
   const setFocusedMapStageIndex = useUiStore((s) => s.setFocusedMapStageIndex);
   const viewMode = useUiStore((s) => s.viewMode);
   const setViewMode = useUiStore((s) => s.setViewMode);
+  const goToStep = useUiStore((s) => s.goToStep);
+  const completeStep = useUiStore((s) => s.completeStep);
   const activeStages = useMemo(
     () => stages.filter((s) => !s.isRestDay),
     [stages],
@@ -150,6 +153,30 @@ export function TripPlanner({ onClose }: { onClose?: () => void } = {}) {
     return () =>
       window.removeEventListener("__test_set_focused_map_stage", handler);
   }, [setFocusedMapStageIndex]);
+
+  // Drive stepper state transitions based on trip lifecycle:
+  // - URL submitted / GPX uploading → "analysis" (background computation)
+  // - Computation complete (trip + stages) → "my_trip"
+  // - Trip loaded but no stages (loading state) → "preview"
+  useEffect(() => {
+    if (isProcessing) {
+      // Computation is running: advance past preparation/preview into analysis
+      completeStep("preparation");
+      completeStep("preview");
+      goToStep("analysis");
+    } else if (trip && stages.length > 0) {
+      // Computation complete: all prior steps done, advance to my_trip
+      completeStep("preparation");
+      completeStep("preview");
+      completeStep("analysis");
+      goToStep("my_trip");
+    } else if (trip && stages.length === 0) {
+      // Trip identity loaded but no stages yet: preview state
+      completeStep("preparation");
+      goToStep("preview");
+    }
+    // else: no trip, not processing → stay on preparation (initial state)
+  }, [isProcessing, trip, stages.length, completeStep, goToStep]);
 
   // Mobile swipe: left → map, right → timeline (cycle: timeline ↔ map on mobile)
   const swipeHandlers = useSwipe({
@@ -318,6 +345,13 @@ export function TripPlanner({ onClose }: { onClose?: () => void } = {}) {
 
         {/* Offline status banner */}
         <OfflineBanner />
+
+        {/* Stepper — visible in all planning states (welcome, loading, trip loaded).
+            Hidden on landing page, FAQ and trips list since those pages don't
+            render TripPlanner at all. */}
+        <div className="mb-8 pb-6" data-testid="stepper-wrapper">
+          <Stepper />
+        </div>
 
         {/* === State 1: Welcome (no trip, not processing) === */}
         {isWelcome && (

--- a/pwa/src/components/trip-planner.tsx
+++ b/pwa/src/components/trip-planner.tsx
@@ -103,6 +103,7 @@ export function TripPlanner({ onClose }: { onClose?: () => void } = {}) {
   const setViewMode = useUiStore((s) => s.setViewMode);
   const goToStep = useUiStore((s) => s.goToStep);
   const completeStep = useUiStore((s) => s.completeStep);
+  const resetStepper = useUiStore((s) => s.resetStepper);
   const activeStages = useMemo(
     () => stages.filter((s) => !s.isRestDay),
     [stages],
@@ -174,9 +175,12 @@ export function TripPlanner({ onClose }: { onClose?: () => void } = {}) {
       // Trip identity loaded but no stages yet: preview state
       completeStep("preparation");
       goToStep("preview");
+    } else {
+      // No trip, not processing: trip was cleared (or initial mount) — rewind
+      // past the "my_trip" lock and back to "preparation".
+      resetStepper();
     }
-    // else: no trip, not processing → stay on preparation (initial state)
-  }, [isProcessing, trip, stages.length, completeStep, goToStep]);
+  }, [isProcessing, trip, stages.length, completeStep, goToStep, resetStepper]);
 
   // Mobile swipe: left → map, right → timeline (cycle: timeline ↔ map on mobile)
   const swipeHandlers = useSwipe({

--- a/pwa/src/store/ui-store.ts
+++ b/pwa/src/store/ui-store.ts
@@ -2,6 +2,10 @@
 
 import { create } from "zustand";
 import { immer } from "zustand/middleware/immer";
+import { enableMapSet } from "immer";
+
+// Required for Immer to allow mutating Set/Map drafts (used by completedSteps).
+enableMapSet();
 
 export type ViewMode = "timeline" | "map" | "split";
 

--- a/pwa/src/store/ui-store.ts
+++ b/pwa/src/store/ui-store.ts
@@ -79,6 +79,8 @@ interface UiState {
   goToStep: (step: StepId) => void;
   /** Mark a step as completed (enabling backwards navigation to it). */
   completeStep: (step: StepId) => void;
+  /** Reset the stepper to "preparation" and clear completed steps (called on `clearTrip`). */
+  resetStepper: () => void;
 }
 
 /**
@@ -212,6 +214,12 @@ export const useUiStore = create<UiState>()(
     completeStep: (step) =>
       set((state) => {
         state.completedSteps.add(step);
+      }),
+
+    resetStepper: () =>
+      set((state) => {
+        state.currentStep = "preparation";
+        state.completedSteps = new Set<StepId>();
       }),
   })),
 );

--- a/pwa/src/store/ui-store.ts
+++ b/pwa/src/store/ui-store.ts
@@ -5,6 +5,23 @@ import { immer } from "zustand/middleware/immer";
 
 export type ViewMode = "timeline" | "map" | "split";
 
+/**
+ * The 4 sequential steps of the trip planning workflow.
+ *
+ * - `preparation` — user inputs a route URL or uploads a GPX file
+ * - `preview`     — the route has been parsed and stages are displayed
+ * - `analysis`    — backend async computation is running (system step, never clickable)
+ * - `my_trip`     — computation complete; the user explores their trip
+ */
+export type StepId = "preparation" | "preview" | "analysis" | "my_trip";
+
+export const STEPS: StepId[] = [
+  "preparation",
+  "preview",
+  "analysis",
+  "my_trip",
+];
+
 interface UiState {
   isProcessing: boolean;
   isAccommodationScanning: boolean;
@@ -28,6 +45,13 @@ interface UiState {
   viewMode: ViewMode;
   /** Section to scroll to when ConfigPanel opens (e.g. from TripSummary chips). */
   configPanelFocusSection: "dates" | "pacing" | null;
+  /**
+   * Current step in the 4-step trip planning workflow.
+   * Guards prevent navigating to "analysis" or backwards from "my_trip".
+   */
+  currentStep: StepId;
+  /** Set of steps the user has already completed (enables backwards navigation). */
+  completedSteps: Set<StepId>;
 
   setProcessing: (value: boolean) => void;
   setAccommodationScanning: (value: boolean) => void;
@@ -44,6 +68,17 @@ interface UiState {
   setViewMode: (mode: ViewMode) => void;
   setConfigPanelFocusSection: (section: "dates" | "pacing" | null) => void;
   openConfigPanelAt: (section: "dates" | "pacing") => void;
+  /**
+   * Navigate to a specific step.
+   * Guards:
+   * - Forward navigation (including programmatic advance to "analysis") is always allowed.
+   * - "analysis" cannot be navigated back to (system-only, forward-only).
+   * - Backwards navigation from "my_trip" is blocked (Act 3 lock).
+   * - Backwards navigation to other steps requires the step to be completed.
+   */
+  goToStep: (step: StepId) => void;
+  /** Mark a step as completed (enabling backwards navigation to it). */
+  completeStep: (step: StepId) => void;
 }
 
 /**
@@ -61,6 +96,8 @@ interface UiState {
  * - `focusedMapStageIndex` — which active-stage index is currently zoomed on
  *   the map; `null` means global view (all stages visible)
  * - `viewMode` — current layout mode: "timeline", "map", or "split"
+ * - `currentStep` — active step in the 4-step workflow (preparation → preview → analysis → my_trip)
+ * - `completedSteps` — set of already-visited steps (enables backwards navigation)
  *
  * This store is intentionally separate from {@link useTripStore} to avoid
  * unnecessary re-renders of trip-dependent components when only UI flags change.
@@ -85,6 +122,8 @@ export const useUiStore = create<UiState>()(
     // on first render via a useEffect that detects the viewport width.
     viewMode: "split",
     configPanelFocusSection: null,
+    currentStep: "preparation",
+    completedSteps: new Set<StepId>(),
 
     setProcessing: (value) =>
       set((state) => {
@@ -150,6 +189,29 @@ export const useUiStore = create<UiState>()(
       set((state) => {
         state.configPanelFocusSection = section;
         state.isConfigPanelOpen = true;
+      }),
+
+    goToStep: (step) =>
+      set((state) => {
+        // Once at "my_trip", no navigation is possible (Act 3 lock)
+        if (state.currentStep === "my_trip") return;
+        const currentIdx = STEPS.indexOf(state.currentStep);
+        const targetIdx = STEPS.indexOf(step);
+        // Forward navigation: always allowed (system can advance to "analysis")
+        if (targetIdx > currentIdx) {
+          state.currentStep = step;
+          return;
+        }
+        // Backwards navigation: "analysis" is a system step and can never be
+        // navigated back to; other completed steps allow backwards navigation.
+        if (step !== "analysis" && state.completedSteps.has(step)) {
+          state.currentStep = step;
+        }
+      }),
+
+    completeStep: (step) =>
+      set((state) => {
+        state.completedSteps.add(step);
       }),
   })),
 );

--- a/pwa/tests/mocked/stepper-flow.spec.ts
+++ b/pwa/tests/mocked/stepper-flow.spec.ts
@@ -1,0 +1,177 @@
+import { test, expect } from "../fixtures/base.fixture";
+import { routeParsedEvent, stagesComputedEvent } from "../fixtures/mock-data";
+
+test.describe("Stepper — initial state", () => {
+  test("stepper is visible on the planner page", async ({ mockedPage }) => {
+    await expect(mockedPage.getByTestId("stepper")).toBeVisible();
+  });
+
+  test("first step 'preparation' is active initially", async ({
+    mockedPage,
+  }) => {
+    const stepEl = mockedPage.getByTestId("stepper-step-preparation");
+    await expect(stepEl).toHaveAttribute("aria-current", "step");
+  });
+
+  test("all 4 steps are rendered", async ({ mockedPage }) => {
+    await expect(
+      mockedPage.getByTestId("stepper-step-preparation"),
+    ).toBeVisible();
+    await expect(mockedPage.getByTestId("stepper-step-preview")).toBeVisible();
+    await expect(mockedPage.getByTestId("stepper-step-analysis")).toBeVisible();
+    await expect(mockedPage.getByTestId("stepper-step-my_trip")).toBeVisible();
+  });
+});
+
+test.describe("Stepper — step transitions", () => {
+  test("advances to 'analysis' after URL submission", async ({
+    submitUrl,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    // After URL submit + trip creation, isProcessing=true → analysis step
+    const analysisStep = mockedPage.getByTestId("stepper-step-analysis");
+    await expect(analysisStep).toHaveAttribute("aria-current", "step", {
+      timeout: 5000,
+    });
+  });
+
+  test("advances to 'my_trip' after trip computation completes", async ({
+    createFullTrip,
+    mockedPage,
+  }) => {
+    await createFullTrip();
+    const myTripStep = mockedPage.getByTestId("stepper-step-my_trip");
+    await expect(myTripStep).toHaveAttribute("aria-current", "step", {
+      timeout: 5000,
+    });
+  });
+
+  test("'preparation' step is completed after URL submission", async ({
+    submitUrl,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    // Wait until we move past preparation
+    await expect(
+      mockedPage.getByTestId("stepper-step-analysis"),
+    ).toHaveAttribute("aria-current", "step", { timeout: 5000 });
+    // preparation step should no longer be the active one
+    await expect(
+      mockedPage.getByTestId("stepper-step-preparation"),
+    ).not.toHaveAttribute("aria-current");
+  });
+});
+
+test.describe("Stepper — non-interactive at 'my_trip'", () => {
+  test("no step is clickable once at my_trip", async ({
+    createFullTrip,
+    mockedPage,
+  }) => {
+    await createFullTrip();
+    // At "my_trip" the stepper is a visual indicator — no buttons for navigation
+    // Verify that completed steps are rendered as non-interactive divs, not buttons
+    const preparationEl = mockedPage.getByTestId("stepper-step-preparation");
+    await expect(preparationEl).toBeVisible({ timeout: 5000 });
+    // It should be a div (non-interactive), not a button
+    const tagName = await preparationEl.evaluate((el) =>
+      el.tagName.toLowerCase(),
+    );
+    expect(tagName).toBe("div");
+  });
+
+  test("'analysis' step is never a button (never clickable)", async ({
+    mockedPage,
+  }) => {
+    const analysisEl = mockedPage.getByTestId("stepper-step-analysis");
+    await expect(analysisEl).toBeVisible();
+    const tagName = await analysisEl.evaluate((el) => el.tagName.toLowerCase());
+    expect(tagName).toBe("div");
+  });
+});
+
+test.describe("Stepper — accessibility", () => {
+  test("stepper has role=navigation", async ({ mockedPage }) => {
+    const stepper = mockedPage.getByTestId("stepper");
+    await expect(stepper).toHaveAttribute("role", "navigation");
+  });
+
+  test("active step has aria-current=step", async ({ mockedPage }) => {
+    const preparationStep = mockedPage.getByTestId("stepper-step-preparation");
+    await expect(preparationStep).toHaveAttribute("aria-current", "step");
+  });
+
+  test("inactive steps do not have aria-current", async ({ mockedPage }) => {
+    await expect(
+      mockedPage.getByTestId("stepper-step-preview"),
+    ).not.toHaveAttribute("aria-current");
+    await expect(
+      mockedPage.getByTestId("stepper-step-analysis"),
+    ).not.toHaveAttribute("aria-current");
+    await expect(
+      mockedPage.getByTestId("stepper-step-my_trip"),
+    ).not.toHaveAttribute("aria-current");
+  });
+});
+
+test.describe("Stepper — responsive mobile", () => {
+  test("mobile compact label is visible on small viewport", async ({
+    mockedPage,
+  }) => {
+    await mockedPage.setViewportSize({ width: 375, height: 812 });
+    const mobileLabel = mockedPage.getByTestId("stepper-mobile-label");
+    await expect(mobileLabel).toBeVisible();
+  });
+
+  test("mobile label shows correct step number and name", async ({
+    mockedPage,
+  }) => {
+    await mockedPage.setViewportSize({ width: 375, height: 812 });
+    const mobileLabel = mockedPage.getByTestId("stepper-mobile-label");
+    // At preparation step: "Étape 1/4 — Préparation"
+    await expect(mobileLabel).toContainText("1/4");
+    await expect(mobileLabel).toContainText("Préparation");
+  });
+
+  test("mobile label updates when step changes", async ({
+    submitUrl,
+    mockedPage,
+  }) => {
+    await mockedPage.setViewportSize({ width: 375, height: 812 });
+    await submitUrl();
+    const mobileLabel = mockedPage.getByTestId("stepper-mobile-label");
+    // After URL submit: moves to analysis (step 3)
+    await expect(mobileLabel).toContainText("3/4", { timeout: 5000 });
+    await expect(mobileLabel).toContainText("Analyse", { timeout: 5000 });
+  });
+});
+
+test.describe("Stepper — backwards navigation", () => {
+  test("completed step is clickable before reaching my_trip", async ({
+    submitUrl,
+    injectEvent,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    await injectEvent(routeParsedEvent());
+    // After route_parsed: preparation is complete, but we may still be in analysis
+    // Inject stages to reach preview
+    await injectEvent(stagesComputedEvent());
+
+    // Wait until we're past preparation
+    await expect(
+      mockedPage.getByTestId("stepper-step-analysis"),
+    ).toHaveAttribute("aria-current", "step", { timeout: 5000 });
+
+    // Inject a trip_complete event to move to my_trip is not done yet,
+    // so we're still on analysis — preparation step should now be a button
+    // (since it's completed and we're not at my_trip)
+    // Note: this test validates the state just before reaching my_trip
+    const preparationEl = mockedPage.getByTestId("stepper-step-preparation");
+    const tagName = await preparationEl.evaluate((el) =>
+      el.tagName.toLowerCase(),
+    );
+    // It should be a button since: it's completed, not "my_trip" step yet, not "analysis"
+    expect(tagName).toBe("button");
+  });
+});

--- a/pwa/tests/mocked/stepper-flow.spec.ts
+++ b/pwa/tests/mocked/stepper-flow.spec.ts
@@ -146,6 +146,34 @@ test.describe("Stepper — responsive mobile", () => {
   });
 });
 
+test.describe("Stepper — reset on clearTrip", () => {
+  test("stepper rewinds from my_trip to preparation when the trip is closed, and advances again on resubmit", async ({
+    createFullTrip,
+    submitUrl,
+    mockedPage,
+  }) => {
+    await createFullTrip();
+    await expect(
+      mockedPage.getByTestId("stepper-step-my_trip"),
+    ).toHaveAttribute("aria-current", "step", { timeout: 5000 });
+
+    // Close the trip from the UI — same button the user would click.
+    await mockedPage.getByTestId("close-trip-button").click();
+
+    // The Act-3 lock in goToStep used to prevent any rewind here; resetStepper
+    // bypasses it, so the stepper should land back on "preparation".
+    await expect(
+      mockedPage.getByTestId("stepper-step-preparation"),
+    ).toHaveAttribute("aria-current", "step", { timeout: 5000 });
+
+    // Submitting a new URL must advance again instead of being stuck.
+    await submitUrl();
+    await expect(
+      mockedPage.getByTestId("stepper-step-analysis"),
+    ).toHaveAttribute("aria-current", "step", { timeout: 5000 });
+  });
+});
+
 test.describe("Stepper — backwards navigation", () => {
   test("completed step is clickable before reaching my_trip", async ({
     submitUrl,


### PR DESCRIPTION
## Summary

- Add `StepId` type, `STEPS` array, `currentStep`, `completedSteps`, `goToStep`, and `completeStep` to `ui-store.ts`
- Create `pwa/src/components/stepper.tsx`: horizontal 4-step bar, checkmarks for completed steps, `aria-current="step"` on active step, mobile compact label (`Étape 2/4 — Aperçu`), and Act-3 lock (fully non-interactive at `my_trip`)
- Wire step transitions in `trip-planner.tsx` via a `useEffect` driven by `isProcessing`, `trip`, and `stages.length`
- Add i18n keys under `"stepper"` in `fr.json` and `en.json`
- Add Playwright mocked tests in `pwa/tests/mocked/stepper-flow.spec.ts` covering navigation, accessibility (`role="navigation"`, `aria-current="step"`), non-interactive state at `my_trip`, backwards navigation guards, and responsive mobile label

## Test plan

- [ ] Stepper is visible on the planner page at initial load
- [ ] `preparation` step shows `aria-current="step"` on first render
- [ ] All 4 steps are rendered (`preparation`, `preview`, `analysis`, `my_trip`)
- [ ] Stepper advances to `analysis` after URL submission (isProcessing=true)
- [ ] Stepper advances to `my_trip` after full trip computation
- [ ] At `my_trip`, all step indicators render as `div` (non-interactive)
- [ ] `analysis` step is always a `div` (never a `button`)
- [ ] Completed steps before `my_trip` render as `button` (backwards navigation)
- [ ] Mobile compact label visible at 375px viewport
- [ ] Mobile label shows correct step number and name
- [ ] Mobile label updates when step changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

**Reviewed commit:** `1e7d3fa`

### Summary

Clean PR. All previously flagged issues are fully resolved: `enableMapSet()` is wired before store creation, the duplicate `aria-label` on `<ol>` is gone, the `clearTrip → resetStepper → resubmit` regression path is covered by a new Playwright test, and the invalid nested `role="listitem"` is removed. No new findings in this pass.

### Resolved threads

All 6 prior bot-authored threads were already resolved before this review pass — no new resolutions needed.

### PR title check

`feat(stepper): add 4-step navigation stepper component` — conforms to Conventional Commits. ✓

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Findings by severity

| Severity | Count |
|----------|-------|
| (none)   | —     |

### Inline comments

No inline comments.

---
Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->