### PR TITLE
feat(trips): add trip statuses and "Mes voyages" header link

### DIFF
--- a/api/src/ApiResource/TripListItem.php
+++ b/api/src/ApiResource/TripListItem.php
@@ -29,7 +29,10 @@ final readonly class TripListItem
         public int $stageCount,
         public \DateTimeImmutable $createdAt,
         public \DateTimeImmutable $updatedAt,
-        #[ApiProperty(description: 'Computed trip status: draft | analyzing | analyzed')]
+        #[ApiProperty(
+            description: 'Computed trip status: draft | analyzing | analyzed',
+            schema: ['type' => 'string', 'enum' => ['draft', 'analyzing', 'analyzed']],
+        )]
         public string $status = 'draft',
     ) {
     }

--- a/api/src/ApiResource/TripListItem.php
+++ b/api/src/ApiResource/TripListItem.php
@@ -4,12 +4,19 @@ declare(strict_types=1);
 
 namespace App\ApiResource;
 
+use ApiPlatform\Metadata\ApiProperty;
+
 /**
  * Lightweight read-only DTO for the trip collection list endpoint.
  *
  * Exposes only the fields needed to render a trip summary row: identity,
- * dates, distance/stage counts, and the title. Full trip data (stages,
- * computation status…) is fetched separately on the detail page.
+ * dates, distance/stage counts, title, and computed status.
+ * Full trip data (stages, computation status…) is fetched separately on the detail page.
+ *
+ * Status values:
+ *   - "draft"     : trip has no computed stages yet (no analysis run)
+ *   - "analyzing" : analysis is currently in progress (computations pending/running)
+ *   - "analyzed"  : all computations are done or failed (full results available)
  */
 final readonly class TripListItem
 {
@@ -22,6 +29,8 @@ final readonly class TripListItem
         public int $stageCount,
         public \DateTimeImmutable $createdAt,
         public \DateTimeImmutable $updatedAt,
+        #[ApiProperty(description: 'Computed trip status: draft | analyzing | analyzed')]
+        public string $status = 'draft',
     ) {
     }
 }

--- a/api/src/ComputationTracker/ComputationTracker.php
+++ b/api/src/ComputationTracker/ComputationTracker.php
@@ -76,6 +76,38 @@ final readonly class ComputationTracker implements ComputationTrackerInterface
         return $value;
     }
 
+    public function getStatusesBatch(array $tripIds): array
+    {
+        if ([] === $tripIds) {
+            return [];
+        }
+
+        $keysByTripId = [];
+        foreach ($tripIds as $tripId) {
+            $keysByTripId[$tripId] = $this->statusKey($tripId);
+        }
+
+        $itemsByKey = [];
+        foreach ($this->tripStateCache->getItems(array_values($keysByTripId)) as $key => $item) {
+            $itemsByKey[$key] = $item;
+        }
+
+        $result = [];
+        foreach ($keysByTripId as $tripId => $key) {
+            $item = $itemsByKey[$key] ?? null;
+            if (null === $item || !$item->isHit()) {
+                $result[$tripId] = null;
+                continue;
+            }
+
+            /** @var array<string, string>|null $value */
+            $value = $item->get();
+            $result[$tripId] = $value;
+        }
+
+        return $result;
+    }
+
     private function updateStatus(string $tripId, ComputationName $computation, string $status): void
     {
         $statuses = $this->getStatuses($tripId) ?? [];

--- a/api/src/ComputationTracker/ComputationTrackerInterface.php
+++ b/api/src/ComputationTracker/ComputationTrackerInterface.php
@@ -28,4 +28,16 @@ interface ComputationTrackerInterface
 
     /** @return array<string, string>|null */
     public function getStatuses(string $tripId): ?array;
+
+    /**
+     * Batch-fetches the status maps of several trips in a single cache round-trip.
+     *
+     * Returns an array keyed by `$tripId`. Trips with no tracked computations
+     * are mapped to `null`, matching the shape of {@see getStatuses()}.
+     *
+     * @param list<string> $tripIds
+     *
+     * @return array<string, array<string, string>|null>
+     */
+    public function getStatusesBatch(array $tripIds): array;
 }

--- a/api/src/State/TripCollectionProvider.php
+++ b/api/src/State/TripCollectionProvider.php
@@ -107,10 +107,18 @@ final readonly class TripCollectionProvider implements ProviderInterface
         /** @var list<TripRequest> $entities */
         $entities = iterator_to_array($paginator->getIterator());
 
-        $items = array_map(function (TripRequest $entity): TripListItem {
+        $tripIds = array_map(static function (TripRequest $entity): string {
             \assert($entity->id instanceof Uuid);
 
-            return $this->toListItem($entity, $this->computationTracker->getStatuses($entity->id->toRfc4122()));
+            return $entity->id->toRfc4122();
+        }, $entities);
+
+        $statusesByTripId = $this->computationTracker->getStatusesBatch($tripIds);
+
+        $items = array_map(function (TripRequest $entity) use ($statusesByTripId): TripListItem {
+            \assert($entity->id instanceof Uuid);
+
+            return $this->toListItem($entity, $statusesByTripId[$entity->id->toRfc4122()] ?? null);
         }, $entities);
 
         return new TripListPaginator($items, $page, $limit, $totalItems);
@@ -149,30 +157,35 @@ final readonly class TripCollectionProvider implements ProviderInterface
     /**
      * Derives the trip status from the computation tracker data and stage count.
      *
-     * - "draft"     : no computations tracked yet (new / unanalysed trip)
+     * - "draft"     : no computations tracked yet, or every tracked computation
+     *                failed without ever producing a `done` state
      * - "analyzing" : at least one computation is still pending or running
-     * - "analyzed"  : all computations are done or failed (full results available)
+     * - "analyzed"  : at least one computation reached `done` (results available)
      *
      * @param array<string, string>|null $statuses
      */
     private function computeStatus(?array $statuses, int $stageCount): string
     {
-        // No computation has ever been started → draft
         if (null === $statuses || [] === $statuses) {
             return 'draft';
         }
 
-        // If any computation is still pending or running → analyzing
+        $hasDone = false;
         foreach ($statuses as $status) {
             if ('pending' === $status || 'running' === $status) {
                 return 'analyzing';
             }
+
+            if ('done' === $status) {
+                $hasDone = true;
+            }
         }
 
-        // All computations are done/failed but no stages persisted yet → still analyzing
-        // (stages are persisted as part of the pipeline; absence means it's not complete)
-        if (0 === $stageCount) {
-            return 'analyzing';
+        // Terminal state: if nothing ever succeeded (all failed) and no stages
+        // were persisted, the analysis effectively did not happen → draft,
+        // so the user can retry without the list being stuck on "analyzed".
+        if (!$hasDone && 0 === $stageCount) {
+            return 'draft';
         }
 
         return 'analyzed';

--- a/api/src/State/TripCollectionProvider.php
+++ b/api/src/State/TripCollectionProvider.php
@@ -10,6 +10,7 @@ use ApiPlatform\State\Pagination\Pagination;
 use ApiPlatform\State\ProviderInterface;
 use App\ApiResource\TripListItem;
 use App\ApiResource\TripRequest;
+use App\ComputationTracker\ComputationTrackerInterface;
 use App\Entity\User;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
@@ -33,6 +34,7 @@ final readonly class TripCollectionProvider implements ProviderInterface
         private EntityManagerInterface $entityManager,
         private Pagination $pagination,
         private Security $security,
+        private ComputationTrackerInterface $computationTracker,
     ) {
     }
 
@@ -105,12 +107,19 @@ final readonly class TripCollectionProvider implements ProviderInterface
         /** @var list<TripRequest> $entities */
         $entities = iterator_to_array($paginator->getIterator());
 
-        $items = array_map($this->toListItem(...), $entities);
+        $items = array_map(function (TripRequest $entity): TripListItem {
+            \assert($entity->id instanceof Uuid);
+
+            return $this->toListItem($entity, $this->computationTracker->getStatuses($entity->id->toRfc4122()));
+        }, $entities);
 
         return new TripListPaginator($items, $page, $limit, $totalItems);
     }
 
-    private function toListItem(TripRequest $entity): TripListItem
+    /**
+     * @param array<string, string>|null $computationStatuses
+     */
+    private function toListItem(TripRequest $entity, ?array $computationStatuses): TripListItem
     {
         \assert($entity->id instanceof Uuid);
 
@@ -133,6 +142,39 @@ final readonly class TripCollectionProvider implements ProviderInterface
             stageCount: $stageCount,
             createdAt: $entity->createdAt,
             updatedAt: $entity->updatedAt,
+            status: $this->computeStatus($computationStatuses, $stageCount),
         );
+    }
+
+    /**
+     * Derives the trip status from the computation tracker data and stage count.
+     *
+     * - "draft"     : no computations tracked yet (new / unanalysed trip)
+     * - "analyzing" : at least one computation is still pending or running
+     * - "analyzed"  : all computations are done or failed (full results available)
+     *
+     * @param array<string, string>|null $statuses
+     */
+    private function computeStatus(?array $statuses, int $stageCount): string
+    {
+        // No computation has ever been started → draft
+        if (null === $statuses || [] === $statuses) {
+            return 'draft';
+        }
+
+        // If any computation is still pending or running → analyzing
+        foreach ($statuses as $status) {
+            if ('pending' === $status || 'running' === $status) {
+                return 'analyzing';
+            }
+        }
+
+        // All computations are done/failed but no stages persisted yet → still analyzing
+        // (stages are persisted as part of the pipeline; absence means it's not complete)
+        if (0 === $stageCount) {
+            return 'analyzing';
+        }
+
+        return 'analyzed';
     }
 }

--- a/api/src/State/TripCollectionProvider.php
+++ b/api/src/State/TripCollectionProvider.php
@@ -162,12 +162,17 @@ final readonly class TripCollectionProvider implements ProviderInterface
      * - "analyzing" : at least one computation is still pending or running
      * - "analyzed"  : at least one computation reached `done` (results available)
      *
+     * The computation-tracking cache has a 30-minute TTL, so a fully analyzed
+     * trip eventually loses its `$statuses` map. In that case we fall back to
+     * the durable `$stageCount` (persisted in PostgreSQL) so the trip keeps
+     * reporting "analyzed" instead of reverting to "draft".
+     *
      * @param array<string, string>|null $statuses
      */
     private function computeStatus(?array $statuses, int $stageCount): string
     {
         if (null === $statuses || [] === $statuses) {
-            return 'draft';
+            return $stageCount > 0 ? 'analyzed' : 'draft';
         }
 
         $hasDone = false;

--- a/api/tests/Unit/ComputationTracker/ComputationTrackerTest.php
+++ b/api/tests/Unit/ComputationTracker/ComputationTrackerTest.php
@@ -203,4 +203,40 @@ final class ComputationTrackerTest extends TestCase
         $this->assertNotNull($statuses2);
         $this->assertSame('pending', $statuses2['route']);
     }
+
+    #[Test]
+    public function getStatusesBatchReturnsEmptyArrayForEmptyInput(): void
+    {
+        $this->assertSame([], $this->tracker->getStatusesBatch([]));
+    }
+
+    #[Test]
+    public function getStatusesBatchReturnsNullForUntrackedTrips(): void
+    {
+        $result = $this->tracker->getStatusesBatch(['untracked-1', 'untracked-2']);
+
+        $this->assertArrayHasKey('untracked-1', $result);
+        $this->assertArrayHasKey('untracked-2', $result);
+        $this->assertNull($result['untracked-1']);
+        $this->assertNull($result['untracked-2']);
+    }
+
+    #[Test]
+    public function getStatusesBatchReturnsMapsForTrackedTrips(): void
+    {
+        $this->tracker->initializeComputations('trip-1', [ComputationName::ROUTE]);
+        $this->tracker->initializeComputations('trip-2', [ComputationName::STAGES]);
+        $this->tracker->markDone('trip-1', ComputationName::ROUTE);
+        $this->tracker->markRunning('trip-2', ComputationName::STAGES);
+
+        $result = $this->tracker->getStatusesBatch(['trip-1', 'trip-2', 'untracked']);
+
+        $this->assertNotNull($result['trip-1']);
+        $this->assertSame('done', $result['trip-1']['route']);
+
+        $this->assertNotNull($result['trip-2']);
+        $this->assertSame('running', $result['trip-2']['stages']);
+
+        $this->assertNull($result['untracked']);
+    }
 }

--- a/api/tests/Unit/State/TripCollectionProviderTest.php
+++ b/api/tests/Unit/State/TripCollectionProviderTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\State;
+
+use App\State\TripCollectionProvider;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Exercises the pure `computeStatus` logic via reflection so every branch of
+ * the derivation table documented on the method is covered. The helper has no
+ * constructor dependencies, so we bypass Pagination/EntityManager wiring.
+ */
+final class TripCollectionProviderTest extends TestCase
+{
+    /**
+     * @param array<string, string>|null $statuses
+     */
+    #[Test]
+    #[DataProvider('computeStatusProvider')]
+    public function computeStatusMatchesDocumentedRules(
+        ?array $statuses,
+        int $stageCount,
+        string $expected,
+    ): void {
+        $provider = new \ReflectionClass(TripCollectionProvider::class)
+            ->newInstanceWithoutConstructor();
+
+        $ref = new \ReflectionMethod($provider, 'computeStatus');
+        $result = $ref->invoke($provider, $statuses, $stageCount);
+
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * @return iterable<string, array{0: array<string, string>|null, 1: int, 2: string}>
+     */
+    public static function computeStatusProvider(): iterable
+    {
+        yield 'null statuses → draft' => [null, 0, 'draft'];
+
+        yield 'empty statuses → draft' => [[], 0, 'draft'];
+
+        yield 'any pending → analyzing' => [
+            ['route' => 'pending', 'stages' => 'done'],
+            3,
+            'analyzing',
+        ];
+
+        yield 'any running → analyzing' => [
+            ['route' => 'done', 'stages' => 'running'],
+            3,
+            'analyzing',
+        ];
+
+        yield 'at least one done with stages → analyzed' => [
+            ['route' => 'done', 'stages' => 'failed'],
+            3,
+            'analyzed',
+        ];
+
+        yield 'all failed with no stages → draft' => [
+            ['route' => 'failed', 'stages' => 'failed'],
+            0,
+            'draft',
+        ];
+
+        yield 'all failed but some stages persisted → analyzed' => [
+            ['route' => 'failed', 'stages' => 'failed'],
+            2,
+            'analyzed',
+        ];
+
+        yield 'mixed done + failed → analyzed' => [
+            ['route' => 'done', 'stages' => 'failed', 'weather' => 'done'],
+            5,
+            'analyzed',
+        ];
+    }
+}

--- a/api/tests/Unit/State/TripCollectionProviderTest.php
+++ b/api/tests/Unit/State/TripCollectionProviderTest.php
@@ -40,9 +40,13 @@ final class TripCollectionProviderTest extends TestCase
      */
     public static function computeStatusProvider(): iterable
     {
-        yield 'null statuses → draft' => [null, 0, 'draft'];
+        yield 'null statuses with no stages → draft' => [null, 0, 'draft'];
 
-        yield 'empty statuses → draft' => [[], 0, 'draft'];
+        yield 'empty statuses with no stages → draft' => [[], 0, 'draft'];
+
+        yield 'null statuses but stages persisted → analyzed (TTL-expired fallback)' => [null, 2, 'analyzed'];
+
+        yield 'empty statuses but stages persisted → analyzed (TTL-expired fallback)' => [[], 5, 'analyzed'];
 
         yield 'any pending → analyzing' => [
             ['route' => 'pending', 'stages' => 'done'],

--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -311,7 +311,10 @@
     "page": "Page {current} of {total}",
     "retry": "Try again",
     "untitled": "Untitled trip",
-    "close": "Back to home"
+    "close": "Back to home",
+    "status_draft": "Draft",
+    "status_analyzing": "Analyzing...",
+    "status_analyzed": "Analyzed"
   },
   "noDates": {
     "banner": "Dates not set — Displaying from today",

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -311,7 +311,10 @@
     "page": "Page {current} sur {total}",
     "retry": "Réessayer",
     "untitled": "Voyage sans titre",
-    "close": "Retour à l'accueil"
+    "close": "Retour à l'accueil",
+    "status_draft": "Brouillon",
+    "status_analyzing": "En cours d'analyse",
+    "status_analyzed": "Analysé"
   },
   "noDates": {
     "banner": "Dates non renseignées — Affichage depuis aujourd'hui",

--- a/pwa/src/app/trips/page.tsx
+++ b/pwa/src/app/trips/page.tsx
@@ -19,50 +19,13 @@ import {
 import { apiFetch } from "@/lib/api/client";
 import { formatDistanceKm } from "@/lib/formatters";
 import { API_URL } from "@/lib/constants";
-import { Badge } from "@/components/ui/badge";
+import { TripStatusBadge } from "@/components/trip-status-badge";
 import type { components } from "@/lib/api/schema";
 
-type TripListItem = components["schemas"]["Trip.TripListItem.jsonld"] & {
-  status?: string;
-};
+type TripListItem = components["schemas"]["Trip.TripListItem.jsonld"];
 type TripCollection = components["schemas"]["HydraCollectionBaseSchema"] & {
   member: TripListItem[];
 };
-
-function TripStatusBadge({ status }: { status?: string }) {
-  const t = useTranslations("tripList");
-
-  if (status === "analyzing") {
-    return (
-      <Badge
-        variant="secondary"
-        className="bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300 border-amber-200 dark:border-amber-700"
-        data-testid="status-analyzing"
-      >
-        {t("status_analyzing")}
-      </Badge>
-    );
-  }
-
-  if (status === "analyzed") {
-    return (
-      <Badge
-        variant="secondary"
-        className="bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300 border-green-200 dark:border-green-700"
-        data-testid="status-analyzed"
-      >
-        {t("status_analyzed")}
-      </Badge>
-    );
-  }
-
-  // draft (default)
-  return (
-    <Badge variant="outline" data-testid="status-draft">
-      {t("status_draft")}
-    </Badge>
-  );
-}
 
 const ITEMS_PER_PAGE = 10;
 

--- a/pwa/src/app/trips/page.tsx
+++ b/pwa/src/app/trips/page.tsx
@@ -19,12 +19,50 @@ import {
 import { apiFetch } from "@/lib/api/client";
 import { formatDistanceKm } from "@/lib/formatters";
 import { API_URL } from "@/lib/constants";
+import { Badge } from "@/components/ui/badge";
 import type { components } from "@/lib/api/schema";
 
-type TripListItem = components["schemas"]["Trip.TripListItem.jsonld"];
+type TripListItem = components["schemas"]["Trip.TripListItem.jsonld"] & {
+  status?: string;
+};
 type TripCollection = components["schemas"]["HydraCollectionBaseSchema"] & {
   member: TripListItem[];
 };
+
+function TripStatusBadge({ status }: { status?: string }) {
+  const t = useTranslations("tripList");
+
+  if (status === "analyzing") {
+    return (
+      <Badge
+        variant="secondary"
+        className="bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300 border-amber-200 dark:border-amber-700"
+        data-testid="status-analyzing"
+      >
+        {t("status_analyzing")}
+      </Badge>
+    );
+  }
+
+  if (status === "analyzed") {
+    return (
+      <Badge
+        variant="secondary"
+        className="bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300 border-green-200 dark:border-green-700"
+        data-testid="status-analyzed"
+      >
+        {t("status_analyzed")}
+      </Badge>
+    );
+  }
+
+  // draft (default)
+  return (
+    <Badge variant="outline" data-testid="status-draft">
+      {t("status_draft")}
+    </Badge>
+  );
+}
 
 const ITEMS_PER_PAGE = 10;
 
@@ -121,17 +159,22 @@ export default function TripsPage() {
       {/* Header */}
       <div className="flex flex-wrap items-center justify-between gap-4 mb-8">
         <h1 className="text-2xl font-bold">{t("title")}</h1>
-        <Button
-          asChild
-          variant="ghost"
-          size="icon"
-          title={t("close")}
-          aria-label={t("close")}
-        >
-          <Link href="/">
-            <X className="h-4 w-4" />
-          </Link>
-        </Button>
+        <div className="flex items-center gap-2">
+          <Button asChild variant="default" size="sm" data-testid="new-trip-button">
+            <Link href="/trips/new">{t("newTrip")}</Link>
+          </Button>
+          <Button
+            asChild
+            variant="ghost"
+            size="icon"
+            title={t("close")}
+            aria-label={t("close")}
+          >
+            <Link href="/">
+              <X className="h-4 w-4" />
+            </Link>
+          </Button>
+        </div>
       </div>
 
       {/* Filters */}
@@ -237,11 +280,13 @@ export default function TripsPage() {
                     type="button"
                     className="flex-1 text-left min-w-0 cursor-pointer"
                     onClick={() => router.push(`/trips/${trip.id ?? ""}`)}
+                    data-testid={`trip-item-${trip.id ?? ""}`}
                   >
                     <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
                       <span className="font-semibold truncate">
                         {trip.title ?? t("untitled")}
                       </span>
+                      <TripStatusBadge status={trip.status} />
                       {(trip.stageCount ?? 0) > 0 && (
                         <span className="text-sm text-muted-foreground">
                           {t("stages", { count: trip.stageCount ?? 0 })}

--- a/pwa/src/app/trips/page.tsx
+++ b/pwa/src/app/trips/page.tsx
@@ -160,7 +160,12 @@ export default function TripsPage() {
       <div className="flex flex-wrap items-center justify-between gap-4 mb-8">
         <h1 className="text-2xl font-bold">{t("title")}</h1>
         <div className="flex items-center gap-2">
-          <Button asChild variant="default" size="sm" data-testid="new-trip-button">
+          <Button
+            asChild
+            variant="default"
+            size="sm"
+            data-testid="new-trip-button"
+          >
             <Link href="/trips/new">{t("newTrip")}</Link>
           </Button>
           <Button

--- a/pwa/src/components/recent-trips.tsx
+++ b/pwa/src/components/recent-trips.tsx
@@ -9,12 +9,50 @@ import { Loader2 } from "lucide-react";
 import { apiFetch } from "@/lib/api/client";
 import { formatDistanceKm } from "@/lib/formatters";
 import { API_URL } from "@/lib/constants";
+import { Badge } from "@/components/ui/badge";
 import type { components } from "@/lib/api/schema";
 
-type TripListItem = components["schemas"]["Trip.TripListItem.jsonld"];
+type TripListItem = components["schemas"]["Trip.TripListItem.jsonld"] & {
+  status?: string;
+};
 type TripCollection = components["schemas"]["HydraCollectionBaseSchema"] & {
   member: TripListItem[];
 };
+
+function TripStatusBadge({ status }: { status?: string }) {
+  const t = useTranslations("tripList");
+
+  if (status === "analyzing") {
+    return (
+      <Badge
+        variant="secondary"
+        className="text-xs bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300 border-amber-200 dark:border-amber-700"
+        data-testid="status-analyzing"
+      >
+        {t("status_analyzing")}
+      </Badge>
+    );
+  }
+
+  if (status === "analyzed") {
+    return (
+      <Badge
+        variant="secondary"
+        className="text-xs bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300 border-green-200 dark:border-green-700"
+        data-testid="status-analyzed"
+      >
+        {t("status_analyzed")}
+      </Badge>
+    );
+  }
+
+  // draft (default)
+  return (
+    <Badge variant="outline" className="text-xs" data-testid="status-draft">
+      {t("status_draft")}
+    </Badge>
+  );
+}
 
 export function RecentTrips() {
   const t = useTranslations();
@@ -88,6 +126,7 @@ export function RecentTrips() {
                 <span className="font-medium truncate">
                   {trip.title ?? t("tripList.untitled")}
                 </span>
+                <TripStatusBadge status={trip.status} />
                 {(trip.totalDistance ?? 0) > 0 && (
                   <span className="text-sm text-muted-foreground">
                     {formatDistanceKm(trip.totalDistance ?? 0)}

--- a/pwa/src/components/recent-trips.tsx
+++ b/pwa/src/components/recent-trips.tsx
@@ -9,50 +9,13 @@ import { Loader2 } from "lucide-react";
 import { apiFetch } from "@/lib/api/client";
 import { formatDistanceKm } from "@/lib/formatters";
 import { API_URL } from "@/lib/constants";
-import { Badge } from "@/components/ui/badge";
+import { TripStatusBadge } from "@/components/trip-status-badge";
 import type { components } from "@/lib/api/schema";
 
-type TripListItem = components["schemas"]["Trip.TripListItem.jsonld"] & {
-  status?: string;
-};
+type TripListItem = components["schemas"]["Trip.TripListItem.jsonld"];
 type TripCollection = components["schemas"]["HydraCollectionBaseSchema"] & {
   member: TripListItem[];
 };
-
-function TripStatusBadge({ status }: { status?: string }) {
-  const t = useTranslations("tripList");
-
-  if (status === "analyzing") {
-    return (
-      <Badge
-        variant="secondary"
-        className="text-xs bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300 border-amber-200 dark:border-amber-700"
-        data-testid="status-analyzing"
-      >
-        {t("status_analyzing")}
-      </Badge>
-    );
-  }
-
-  if (status === "analyzed") {
-    return (
-      <Badge
-        variant="secondary"
-        className="text-xs bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300 border-green-200 dark:border-green-700"
-        data-testid="status-analyzed"
-      >
-        {t("status_analyzed")}
-      </Badge>
-    );
-  }
-
-  // draft (default)
-  return (
-    <Badge variant="outline" className="text-xs" data-testid="status-draft">
-      {t("status_draft")}
-    </Badge>
-  );
-}
 
 export function RecentTrips() {
   const t = useTranslations();
@@ -126,7 +89,7 @@ export function RecentTrips() {
                 <span className="font-medium truncate">
                   {trip.title ?? t("tripList.untitled")}
                 </span>
-                <TripStatusBadge status={trip.status} />
+                <TripStatusBadge status={trip.status} className="text-xs" />
                 {(trip.totalDistance ?? 0) > 0 && (
                   <span className="text-sm text-muted-foreground">
                     {formatDistanceKm(trip.totalDistance ?? 0)}

--- a/pwa/src/components/trip-status-badge.tsx
+++ b/pwa/src/components/trip-status-badge.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+
+type TripStatus = "draft" | "analyzing" | "analyzed";
+
+export function TripStatusBadge({
+  status,
+  className,
+}: {
+  status?: string;
+  className?: string;
+}) {
+  const t = useTranslations("tripList");
+
+  if (status === ("analyzing" satisfies TripStatus)) {
+    return (
+      <Badge
+        variant="secondary"
+        className={cn(
+          "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300 border-amber-200 dark:border-amber-700",
+          className,
+        )}
+        data-testid="status-analyzing"
+      >
+        {t("status_analyzing")}
+      </Badge>
+    );
+  }
+
+  if (status === ("analyzed" satisfies TripStatus)) {
+    return (
+      <Badge
+        variant="secondary"
+        className={cn(
+          "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300 border-green-200 dark:border-green-700",
+          className,
+        )}
+        data-testid="status-analyzed"
+      >
+        {t("status_analyzed")}
+      </Badge>
+    );
+  }
+
+  return (
+    <Badge variant="outline" className={className} data-testid="status-draft">
+      {t("status_draft")}
+    </Badge>
+  );
+}

--- a/pwa/src/lib/api/schema.d.ts
+++ b/pwa/src/lib/api/schema.d.ts
@@ -963,8 +963,8 @@ export interface components {
             createdAt?: string;
             /** Format: date-time */
             updatedAt?: string;
-            /** @description Computed trip status: draft | analyzing | analyzed */
-            status?: string;
+            /** @enum {string} */
+            status?: "draft" | "analyzing" | "analyzed";
         };
         "Trip.TripRequest": {
             sourceUrl: string | null;

--- a/pwa/src/lib/api/schema.d.ts
+++ b/pwa/src/lib/api/schema.d.ts
@@ -963,6 +963,8 @@ export interface components {
             createdAt?: string;
             /** Format: date-time */
             updatedAt?: string;
+            /** @description Computed trip status: draft | analyzing | analyzed */
+            status?: string;
         };
         "Trip.TripRequest": {
             sourceUrl: string | null;

--- a/pwa/tests/mocked/trip-list-statuses.spec.ts
+++ b/pwa/tests/mocked/trip-list-statuses.spec.ts
@@ -82,7 +82,9 @@ test.describe("trip list statuses", () => {
     await expect(analyzingBadge).toBeVisible();
   });
 
-  test("displays analyzed status badge for completed trip", async ({ page }) => {
+  test("displays analyzed status badge for completed trip", async ({
+    page,
+  }) => {
     await expect(page.getByText("Voyage Pyrénées")).toBeVisible();
     const analyzedBadge = page.getByTestId("status-analyzed").first();
     await expect(analyzedBadge).toBeVisible();

--- a/pwa/tests/mocked/trip-list-statuses.spec.ts
+++ b/pwa/tests/mocked/trip-list-statuses.spec.ts
@@ -1,0 +1,224 @@
+import { test, expect } from "@playwright/test";
+import { FAKE_JWT_TOKEN } from "../fixtures/api-mocks";
+
+const MOCK_TRIPS_WITH_STATUSES = {
+  member: [
+    {
+      id: "01936f6e-0000-7000-8000-000000000201",
+      title: "Brouillon Alpes",
+      totalDistance: 0,
+      stageCount: 0,
+      startDate: null,
+      endDate: null,
+      createdAt: "2025-06-01T00:00:00+00:00",
+      updatedAt: "2025-06-01T00:00:00+00:00",
+      status: "draft",
+    },
+    {
+      id: "01936f6e-0000-7000-8000-000000000202",
+      title: "Analyse Bretagne",
+      totalDistance: 0,
+      stageCount: 0,
+      startDate: "2025-08-01T00:00:00+00:00",
+      endDate: "2025-08-05T00:00:00+00:00",
+      createdAt: "2025-06-15T00:00:00+00:00",
+      updatedAt: "2025-06-15T00:00:00+00:00",
+      status: "analyzing",
+    },
+    {
+      id: "01936f6e-0000-7000-8000-000000000203",
+      title: "Voyage Pyrénées",
+      totalDistance: 520.0,
+      stageCount: 8,
+      startDate: "2025-09-01T00:00:00+00:00",
+      endDate: "2025-09-08T00:00:00+00:00",
+      createdAt: "2025-07-01T00:00:00+00:00",
+      updatedAt: "2025-07-01T00:00:00+00:00",
+      status: "analyzed",
+    },
+  ],
+  totalItems: 3,
+};
+
+test.describe("trip list statuses", () => {
+  test.beforeEach(async ({ page }) => {
+    // Mock auth refresh so AuthGuard passes
+    await page.route("**/auth/refresh", (route) =>
+      route.fulfill({
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token: FAKE_JWT_TOKEN }),
+      }),
+    );
+
+    // Mock the trips collection API
+    await page.route("**/trips*", (route, request) => {
+      const accept = request.headers()["accept"] ?? "";
+      if (!accept.includes("application/ld+json")) return route.fallback();
+      if (request.method() !== "GET") return route.fallback();
+
+      return route.fulfill({
+        status: 200,
+        headers: { "Content-Type": "application/ld+json; charset=utf-8" },
+        body: JSON.stringify(MOCK_TRIPS_WITH_STATUSES),
+      });
+    });
+
+    await page.goto("/trips");
+    await page.waitForLoadState("networkidle");
+  });
+
+  test("displays draft status badge for unanalysed trip", async ({ page }) => {
+    await expect(page.getByText("Brouillon Alpes")).toBeVisible();
+    const draftBadge = page.getByTestId("status-draft").first();
+    await expect(draftBadge).toBeVisible();
+  });
+
+  test("displays analyzing status badge for trip in progress", async ({
+    page,
+  }) => {
+    await expect(page.getByText("Analyse Bretagne")).toBeVisible();
+    const analyzingBadge = page.getByTestId("status-analyzing").first();
+    await expect(analyzingBadge).toBeVisible();
+  });
+
+  test("displays analyzed status badge for completed trip", async ({ page }) => {
+    await expect(page.getByText("Voyage Pyrénées")).toBeVisible();
+    const analyzedBadge = page.getByTestId("status-analyzed").first();
+    await expect(analyzedBadge).toBeVisible();
+  });
+
+  test("all three status badges are visible simultaneously", async ({
+    page,
+  }) => {
+    await expect(page.getByTestId("status-draft").first()).toBeVisible();
+    await expect(page.getByTestId("status-analyzing").first()).toBeVisible();
+    await expect(page.getByTestId("status-analyzed").first()).toBeVisible();
+  });
+
+  test("clicking draft trip navigates to trip detail", async ({ page }) => {
+    // Mock the trip detail endpoint so navigation doesn't fail
+    await page.route(
+      "**/trips/01936f6e-0000-7000-8000-000000000201/detail",
+      (route) =>
+        route.fulfill({
+          status: 200,
+          headers: { "Content-Type": "application/ld+json; charset=utf-8" },
+          body: JSON.stringify({
+            id: "01936f6e-0000-7000-8000-000000000201",
+            title: "Brouillon Alpes",
+            stages: [],
+            isLocked: false,
+            fatigueFactor: 0.9,
+            elevationPenalty: 50,
+            maxDistancePerDay: 80,
+            averageSpeed: 15,
+            ebikeMode: false,
+            departureHour: 8,
+            enabledAccommodationTypes: [],
+          }),
+        }),
+    );
+
+    await page
+      .getByTestId("trip-item-01936f6e-0000-7000-8000-000000000201")
+      .click();
+    await expect(page).toHaveURL(
+      /\/trips\/01936f6e-0000-7000-8000-000000000201/,
+      { timeout: 5000 },
+    );
+  });
+
+  test("clicking analyzed trip navigates to trip detail", async ({ page }) => {
+    await page.route(
+      "**/trips/01936f6e-0000-7000-8000-000000000203/detail",
+      (route) =>
+        route.fulfill({
+          status: 200,
+          headers: { "Content-Type": "application/ld+json; charset=utf-8" },
+          body: JSON.stringify({
+            id: "01936f6e-0000-7000-8000-000000000203",
+            title: "Voyage Pyrénées",
+            stages: [],
+            isLocked: false,
+            fatigueFactor: 0.9,
+            elevationPenalty: 50,
+            maxDistancePerDay: 80,
+            averageSpeed: 15,
+            ebikeMode: false,
+            departureHour: 8,
+            enabledAccommodationTypes: [],
+          }),
+        }),
+    );
+
+    await page
+      .getByTestId("trip-item-01936f6e-0000-7000-8000-000000000203")
+      .click();
+    await expect(page).toHaveURL(
+      /\/trips\/01936f6e-0000-7000-8000-000000000203/,
+      { timeout: 5000 },
+    );
+  });
+
+  test("new trip button is visible and links to trip creation", async ({
+    page,
+  }) => {
+    const newTripButton = page.getByTestId("new-trip-button");
+    await expect(newTripButton).toBeVisible();
+    await newTripButton.click();
+    await expect(page).toHaveURL(/\/trips\/new/, { timeout: 5000 });
+  });
+});
+
+test.describe("mes voyages header link", () => {
+  test("my trips link is visible when authenticated", async ({ page }) => {
+    // Mock auth so the user is logged in
+    await page.route("**/auth/refresh", (route) =>
+      route.fulfill({
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token: FAKE_JWT_TOKEN }),
+      }),
+    );
+
+    // Mock trips endpoint (no trips needed)
+    await page.route("**/trips*", (route, request) => {
+      const accept = request.headers()["accept"] ?? "";
+      if (!accept.includes("application/ld+json")) return route.fallback();
+      if (request.method() !== "GET") return route.fallback();
+      return route.fulfill({
+        status: 200,
+        headers: { "Content-Type": "application/ld+json; charset=utf-8" },
+        body: JSON.stringify({ member: [], totalItems: 0 }),
+      });
+    });
+
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    // The "Mes voyages" link is shown in the TripPlanner header when authenticated and no trip open
+    const myTripsLink = page.getByTestId("my-trips-link");
+    await expect(myTripsLink).toBeVisible({ timeout: 5000 });
+  });
+
+  test("my trips link is not visible when unauthenticated", async ({
+    page,
+  }) => {
+    // Mock auth to fail (unauthenticated)
+    await page.route("**/auth/refresh", (route) =>
+      route.fulfill({
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ message: "Unauthorized" }),
+      }),
+    );
+
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    // Unauthenticated users see the landing page — no "Mes voyages" link
+    const myTripsLink = page.getByTestId("my-trips-link");
+    await expect(myTripsLink).not.toBeVisible({ timeout: 3000 });
+  });
+});


### PR DESCRIPTION
## Summary

- Add computed `status` field (`draft` | `analyzing` | `analyzed`) to `TripListItem` DTO via `TripCollectionProvider` using `ComputationTrackerInterface`
- Display status badges on trip list (`pwa/src/app/trips/page.tsx`) and recent trips (`pwa/src/components/recent-trips.tsx`) with 3 visual variants
- Add "Mes voyages" link in header (visible when authenticated, icon-only on mobile)
- Add i18n keys for the 3 status labels in `fr.json` / `en.json`
- Add Playwright mocked tests covering all 3 statuses, navigation on click, and header visibility

Closes #318

## Test plan

- [ ] Trip list shows "Brouillon" badge for draft trips
- [ ] Trip list shows "En cours d'analyse" badge for trips being analyzed
- [ ] Trip list shows "Analysé" badge for fully analyzed trips
- [ ] "Mes voyages" link visible in header when authenticated
- [ ] "Mes voyages" link hidden when not authenticated
- [ ] "Nouveau voyage" CTA button visible on trips list page
- [ ] Clicking a trip navigates to the correct page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

**Reviewed commit:** `8a2cf226cb7dcd6d1d5bc4938ea9c8e03d2d7197`

All findings from previous review rounds have been fully addressed. The TTL-expiry correctness bug (analyzed trips reverting to "draft" after 30-minute cache expiry) is fixed in the final commit. The implementation is clean, the test suite is comprehensive, and the architecture is sound.

**Resolved threads:** All 8 previously open bot-authored threads are resolved (no new resolutions this pass — all were addressed by the latest pushes).

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Findings summary

No findings. ✓

**No inline comments.**

---
Generated with [Claude Code](https://claude.com/claude-code)
<!-- claude-review-end -->