### PR TITLE
feat(api): add POST /trips/{id}/analyze endpoint

### DIFF
--- a/api/config/packages/messenger.php
+++ b/api/config/packages/messenger.php
@@ -5,16 +5,20 @@ declare(strict_types=1);
 use App\Message\AnalyzeTerrain;
 use App\Message\AnalyzeWind;
 use App\Message\CheckBikeShops;
+use App\Message\CheckBorderCrossing;
 use App\Message\CheckCalendar;
 use App\Message\CheckCulturalPois;
+use App\Message\CheckHealthServices;
+use App\Message\CheckRailwayStations;
 use App\Message\CheckWaterPoints;
 use App\Message\FetchAndParseRoute;
 use App\Message\FetchWeather;
 use App\Message\GenerateStages;
-use App\Message\ScanAllOsmData;
 use App\Message\RecalculateRouteSegment;
 use App\Message\RecalculateStages;
 use App\Message\ScanAccommodations;
+use App\Message\ScanAllOsmData;
+use App\Message\ScanEvents;
 use App\Message\ScanPois;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
@@ -44,10 +48,14 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 CheckCalendar::class => 'async',
                 AnalyzeWind::class => 'async',
                 CheckBikeShops::class => 'async',
+                CheckBorderCrossing::class => 'async',
                 CheckCulturalPois::class => 'async',
+                CheckHealthServices::class => 'async',
+                CheckRailwayStations::class => 'async',
                 CheckWaterPoints::class => 'async',
                 RecalculateRouteSegment::class => 'async',
                 RecalculateStages::class => 'async',
+                ScanEvents::class => 'async',
             ],
         ],
     ]);

--- a/api/src/ApiResource/Trip.php
+++ b/api/src/ApiResource/Trip.php
@@ -13,6 +13,7 @@ use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
 use ApiPlatform\OpenApi\Model\Operation;
+use App\State\AnalyzeTripProcessor;
 use App\State\TripCollectionProvider;
 use App\State\TripCreateProcessor;
 use App\State\TripDeleteProcessor;
@@ -82,6 +83,23 @@ use App\State\TripUpdateProcessor;
             input: false,
             provider: TripRequestProvider::class,
             processor: TripDuplicateProcessor::class,
+        ),
+        new Post(
+            uriTemplate: '/trips/{id}/analyze{._format}',
+            status: 202,
+            openapi: new Operation(
+                responses: [
+                    404 => new Response(description: 'Trip not found'),
+                    409 => new Response(description: 'An analysis is already in progress'),
+                    422 => new Response(description: 'Trip has no stages to analyze'),
+                ],
+                summary: 'Trigger the full enrichment pipeline (POIs, weather, terrain, …) for a trip whose stages have been pre-computed.',
+            ),
+            security: "is_granted('TRIP_EDIT', object)",
+            input: false,
+            mercure: true,
+            provider: TripRequestProvider::class,
+            processor: AnalyzeTripProcessor::class,
         ),
         new Patch(
             uriTemplate: '/trips/{id}{._format}',

--- a/api/src/MessageHandler/GenerateStagesHandler.php
+++ b/api/src/MessageHandler/GenerateStagesHandler.php
@@ -17,23 +17,11 @@ use App\Enum\ComputationName;
 use App\Enum\SourceType;
 use App\Mercure\MercureEventType;
 use App\Mercure\TripUpdatePublisherInterface;
-use App\Message\AnalyzeTerrain;
-use App\Message\CheckBikeShops;
-use App\Message\CheckBorderCrossing;
-use App\Message\CheckCalendar;
-use App\Message\CheckCulturalPois;
-use App\Message\CheckHealthServices;
-use App\Message\CheckRailwayStations;
-use App\Message\CheckWaterPoints;
-use App\Message\FetchWeather;
 use App\Message\GenerateStages;
-use App\Message\ScanAccommodations;
-use App\Message\ScanEvents;
-use App\Message\ScanPois;
 use App\Repository\TripRequestRepositoryInterface;
+use App\Service\TripAnalysisDispatcher;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
-use Symfony\Component\Messenger\MessageBusInterface;
 
 #[AsMessageHandler]
 final readonly class GenerateStagesHandler extends AbstractTripMessageHandler
@@ -48,7 +36,7 @@ final readonly class GenerateStagesHandler extends AbstractTripMessageHandler
         private ElevationCalculatorInterface $elevationCalculator,
         private RouteSimplifierInterface $routeSimplifier,
         private PacingEngineInterface $pacingEngine,
-        private MessageBusInterface $messageBus,
+        private TripAnalysisDispatcher $analysisDispatcher,
     ) {
         parent::__construct($computationTracker, $publisher, $generationTracker, $logger);
     }
@@ -105,18 +93,7 @@ final readonly class GenerateStagesHandler extends AbstractTripMessageHandler
                 ),
             ]);
 
-            $this->messageBus->dispatch(new ScanPois($tripId, $generation));
-            $this->messageBus->dispatch(new ScanAccommodations($tripId, enabledAccommodationTypes: $request->enabledAccommodationTypes, generation: $generation));
-            $this->messageBus->dispatch(new AnalyzeTerrain($tripId, $generation));
-            $this->messageBus->dispatch(new FetchWeather($tripId, $generation));
-            $this->messageBus->dispatch(new CheckCalendar($tripId, $generation));
-            $this->messageBus->dispatch(new CheckBikeShops($tripId, $generation));
-            $this->messageBus->dispatch(new CheckWaterPoints($tripId, $generation));
-            $this->messageBus->dispatch(new CheckHealthServices($tripId, $generation));
-            $this->messageBus->dispatch(new CheckCulturalPois($tripId, $generation));
-            $this->messageBus->dispatch(new CheckRailwayStations($tripId, $generation));
-            $this->messageBus->dispatch(new CheckBorderCrossing($tripId, $generation));
-            $this->messageBus->dispatch(new ScanEvents($tripId, $generation));
+            $this->analysisDispatcher->dispatch($tripId, $request, $generation);
         }, $generation);
     }
 

--- a/api/src/Service/TripAnalysisDispatcher.php
+++ b/api/src/Service/TripAnalysisDispatcher.php
@@ -15,6 +15,7 @@ use App\Message\CheckRailwayStations;
 use App\Message\CheckWaterPoints;
 use App\Message\FetchWeather;
 use App\Message\ScanAccommodations;
+use App\Message\ScanAllOsmData;
 use App\Message\ScanEvents;
 use App\Message\ScanPois;
 use Symfony\Component\Messenger\MessageBusInterface;

--- a/api/src/Service/TripAnalysisDispatcher.php
+++ b/api/src/Service/TripAnalysisDispatcher.php
@@ -42,6 +42,7 @@ final readonly class TripAnalysisDispatcher
      */
     public function dispatch(string $tripId, TripRequest $request, ?int $generation = null): void
     {
+        $this->messageBus->dispatch(new ScanAllOsmData($tripId, $generation));
         $this->messageBus->dispatch(new ScanPois($tripId, $generation));
         $this->messageBus->dispatch(new ScanAccommodations(
             $tripId,

--- a/api/src/Service/TripAnalysisDispatcher.php
+++ b/api/src/Service/TripAnalysisDispatcher.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\ApiResource\TripRequest;
+use App\Message\AnalyzeTerrain;
+use App\Message\CheckBikeShops;
+use App\Message\CheckBorderCrossing;
+use App\Message\CheckCalendar;
+use App\Message\CheckCulturalPois;
+use App\Message\CheckHealthServices;
+use App\Message\CheckRailwayStations;
+use App\Message\CheckWaterPoints;
+use App\Message\FetchWeather;
+use App\Message\ScanAccommodations;
+use App\Message\ScanEvents;
+use App\Message\ScanPois;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+/**
+ * Dispatches all enrichment messages for a trip once its stages have been generated.
+ *
+ * Centralises the fan-out previously inlined in {@see \App\MessageHandler\GenerateStagesHandler}
+ * so that the same pipeline can be triggered from:
+ *  - the stage-generation handler (automatic flow, Act 1),
+ *  - the dedicated `POST /trips/{id}/analyze` endpoint (explicit flow, Act 2).
+ */
+final readonly class TripAnalysisDispatcher
+{
+    public function __construct(
+        private MessageBusInterface $messageBus,
+    ) {
+    }
+
+    /**
+     * Dispatches every enrichment message for the given trip.
+     *
+     * @param int|null $generation Current trip generation. When provided, stale workers can discard
+     *                             outdated messages. Pass null for fire-and-forget pipelines.
+     */
+    public function dispatch(string $tripId, TripRequest $request, ?int $generation = null): void
+    {
+        $this->messageBus->dispatch(new ScanPois($tripId, $generation));
+        $this->messageBus->dispatch(new ScanAccommodations(
+            $tripId,
+            enabledAccommodationTypes: $request->enabledAccommodationTypes,
+            generation: $generation,
+        ));
+        $this->messageBus->dispatch(new AnalyzeTerrain($tripId, $generation));
+        $this->messageBus->dispatch(new FetchWeather($tripId, $generation));
+        $this->messageBus->dispatch(new CheckCalendar($tripId, $generation));
+        $this->messageBus->dispatch(new CheckBikeShops($tripId, $generation));
+        $this->messageBus->dispatch(new CheckWaterPoints($tripId, $generation));
+        $this->messageBus->dispatch(new CheckHealthServices($tripId, $generation));
+        $this->messageBus->dispatch(new CheckCulturalPois($tripId, $generation));
+        $this->messageBus->dispatch(new CheckRailwayStations($tripId, $generation));
+        $this->messageBus->dispatch(new CheckBorderCrossing($tripId, $generation));
+        $this->messageBus->dispatch(new ScanEvents($tripId, $generation));
+    }
+}

--- a/api/src/State/AnalyzeTripProcessor.php
+++ b/api/src/State/AnalyzeTripProcessor.php
@@ -111,12 +111,6 @@ final readonly class AnalyzeTripProcessor implements ProcessorInterface
      */
     private function isAnalysisRunning(array $statuses): bool
     {
-        foreach (self::ANALYSIS_COMPUTATIONS as $computation) {
-            if (($statuses[$computation->value] ?? null) === 'running') {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(self::ANALYSIS_COMPUTATIONS, fn ($computation): bool => ($statuses[$computation->value] ?? null) === 'running');
     }
 }

--- a/api/src/State/AnalyzeTripProcessor.php
+++ b/api/src/State/AnalyzeTripProcessor.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\State\ProcessorInterface;
+use App\ApiResource\Trip;
+use App\ApiResource\TripRequest;
+use App\ComputationTracker\ComputationTrackerInterface;
+use App\ComputationTracker\TripGenerationTrackerInterface;
+use App\Enum\ComputationName;
+use App\Repository\TripRequestRepositoryInterface;
+use App\Service\TripAnalysisDispatcher;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+
+/**
+ * Triggers the full enrichment pipeline for a trip whose stages have been pre-computed.
+ *
+ * Decouples preview (stage generation) from analysis (enrichment): the preview step stops
+ * after stages are generated; the user explicitly requests analysis via this endpoint.
+ *
+ * @implements ProcessorInterface<TripRequest, Trip>
+ */
+final readonly class AnalyzeTripProcessor implements ProcessorInterface
+{
+    /**
+     * Computations considered part of the enrichment pipeline (i.e. triggered by this endpoint).
+     *
+     * ROUTE and STAGES belong to the preview phase and are therefore excluded from both
+     * the "already running" check and the reset/re-dispatch cycle.
+     *
+     * @var list<ComputationName>
+     */
+    private const array ANALYSIS_COMPUTATIONS = [
+        ComputationName::OSM_SCAN,
+        ComputationName::POIS,
+        ComputationName::ACCOMMODATIONS,
+        ComputationName::TERRAIN,
+        ComputationName::WEATHER,
+        ComputationName::CALENDAR,
+        ComputationName::WIND,
+        ComputationName::BIKE_SHOPS,
+        ComputationName::WATER_POINTS,
+        ComputationName::CULTURAL_POIS,
+        ComputationName::RAILWAY_STATIONS,
+        ComputationName::HEALTH_SERVICES,
+        ComputationName::BORDER_CROSSING,
+        ComputationName::EVENTS,
+    ];
+
+    public function __construct(
+        private TripRequestRepositoryInterface $tripStateManager,
+        private ComputationTrackerInterface $computationTracker,
+        private TripGenerationTrackerInterface $generationTracker,
+        private TripAnalysisDispatcher $analysisDispatcher,
+    ) {
+    }
+
+    /**
+     * @param TripRequest        $data         The TripRequest resolved by {@see TripRequestProvider}
+     * @param Post               $operation
+     * @param array{id?: string} $uriVariables
+     */
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): Trip
+    {
+        \assert($data instanceof TripRequest);
+        $tripId = $uriVariables['id'] ?? '';
+
+        if ('' === $tripId) {
+            throw new NotFoundHttpException('Trip not found.');
+        }
+
+        // 422: the trip must have pre-computed stages before analysis can be requested.
+        $stages = $this->tripStateManager->getStages($tripId);
+        if (null === $stages || [] === $stages) {
+            throw new UnprocessableEntityHttpException('Trip has no stages to analyze.');
+        }
+
+        $statuses = $this->computationTracker->getStatuses($tripId) ?? [];
+
+        // 409: an analysis is already in flight; the client should wait for it to complete.
+        if ($this->isAnalysisRunning($statuses)) {
+            throw new ConflictHttpException('An analysis is already in progress for this trip.');
+        }
+
+        // Re-arm every enrichment computation so the tracker reflects the new pipeline
+        // without discarding the preview-phase statuses (ROUTE, STAGES).
+        foreach (self::ANALYSIS_COMPUTATIONS as $computation) {
+            $this->computationTracker->resetComputation($tripId, $computation);
+        }
+
+        $generation = $this->generationTracker->current($tripId);
+
+        $this->analysisDispatcher->dispatch($tripId, $data, $generation);
+
+        $statuses = $this->computationTracker->getStatuses($tripId) ?? [];
+
+        return new Trip(
+            id: $tripId,
+            computationStatus: $statuses,
+        );
+    }
+
+    /**
+     * @param array<string, string> $statuses
+     */
+    private function isAnalysisRunning(array $statuses): bool
+    {
+        foreach (self::ANALYSIS_COMPUTATIONS as $computation) {
+            if (($statuses[$computation->value] ?? null) === 'running') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/api/tests/Functional/TripAnalyzeTest.php
+++ b/api/tests/Functional/TripAnalyzeTest.php
@@ -24,6 +24,7 @@ use App\Message\CheckRailwayStations;
 use App\Message\CheckWaterPoints;
 use App\Message\FetchWeather;
 use App\Message\ScanAccommodations;
+use App\Message\ScanAllOsmData;
 use App\Message\ScanEvents;
 use App\Message\ScanPois;
 use App\Repository\TripRequestRepositoryInterface;
@@ -168,6 +169,7 @@ final class TripAnalyzeTest extends ApiTestCase
         );
 
         $expected = [
+            ScanAllOsmData::class,
             ScanPois::class,
             ScanAccommodations::class,
             AnalyzeTerrain::class,

--- a/api/tests/Functional/TripAnalyzeTest.php
+++ b/api/tests/Functional/TripAnalyzeTest.php
@@ -87,6 +87,7 @@ final class TripAnalyzeTest extends ApiTestCase
                 ],
             );
         }
+
         $repo->storeStages($tripId, $stages);
 
         /** @var ComputationTrackerInterface $tracker */

--- a/api/tests/Functional/TripAnalyzeTest.php
+++ b/api/tests/Functional/TripAnalyzeTest.php
@@ -1,0 +1,287 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Symfony\Bundle\Test\Client;
+use App\ApiResource\Model\Coordinate;
+use App\ApiResource\Stage;
+use App\ApiResource\TripRequest;
+use App\ComputationTracker\ComputationTrackerInterface;
+use App\ComputationTracker\TripGenerationTrackerInterface;
+use App\Entity\User;
+use App\Enum\ComputationName;
+use App\Enum\SourceType;
+use App\Message\AnalyzeTerrain;
+use App\Message\CheckBikeShops;
+use App\Message\CheckBorderCrossing;
+use App\Message\CheckCalendar;
+use App\Message\CheckCulturalPois;
+use App\Message\CheckHealthServices;
+use App\Message\CheckRailwayStations;
+use App\Message\CheckWaterPoints;
+use App\Message\FetchWeather;
+use App\Message\ScanAccommodations;
+use App\Message\ScanEvents;
+use App\Message\ScanPois;
+use App\Repository\TripRequestRepositoryInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport;
+use Symfony\Component\Uid\Uuid;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+use Zenstruck\Foundry\Test\Factories;
+
+#[ResetDatabase]
+final class TripAnalyzeTest extends ApiTestCase
+{
+    use Factories;
+    use JwtAuthTestTrait;
+
+    private const string TRIP_ID = '01936f6e-0000-7000-8000-000000000042';
+
+    private Client $client;
+
+    private User $testUser;
+
+    private string $jwtToken;
+
+    protected function setUp(): void
+    {
+        $this->client = self::createClient();
+        ['user' => $this->testUser, 'token' => $this->jwtToken] = $this->createTestUserWithJwt('test@example.com');
+    }
+
+    /**
+     * Seeds a trip with pre-computed stages and a fresh computation tracker
+     * where ROUTE and STAGES are already done (preview phase complete).
+     */
+    private function seedTripReadyForAnalysis(string $tripId, int $stageCount = 3): void
+    {
+        $container = self::getContainer();
+
+        /** @var TripRequestRepositoryInterface $repo */
+        $repo = $container->get(TripRequestRepositoryInterface::class);
+
+        $request = new TripRequest(Uuid::fromString($tripId));
+        $request->sourceUrl = 'https://www.komoot.com/tour/123456789';
+        $request->startDate = new \DateTimeImmutable('2026-07-01');
+
+        $repo->initializeTrip($tripId, $request);
+        $repo->storeSourceType($tripId, SourceType::KOMOOT_TOUR->value);
+
+        $stages = [];
+        for ($i = 0; $i < $stageCount; ++$i) {
+            $stages[] = new Stage(
+                tripId: $tripId,
+                dayNumber: $i + 1,
+                distance: 80.0,
+                elevation: 500.0,
+                startPoint: new Coordinate(45.0 + $i * 0.5, 5.0 + $i * 0.5),
+                endPoint: new Coordinate(45.0 + ($i + 1) * 0.5, 5.0 + ($i + 1) * 0.5),
+                geometry: [
+                    new Coordinate(45.0 + $i * 0.5, 5.0 + $i * 0.5),
+                    new Coordinate(45.0 + ($i + 1) * 0.5, 5.0 + ($i + 1) * 0.5),
+                ],
+            );
+        }
+        $repo->storeStages($tripId, $stages);
+
+        /** @var ComputationTrackerInterface $tracker */
+        $tracker = $container->get(ComputationTrackerInterface::class);
+        $tracker->initializeComputations($tripId, ComputationName::pipeline());
+        $tracker->markDone($tripId, ComputationName::ROUTE);
+        $tracker->markDone($tripId, ComputationName::STAGES);
+
+        /** @var TripGenerationTrackerInterface $generationTracker */
+        $generationTracker = $container->get(TripGenerationTrackerInterface::class);
+        $generationTracker->initialize($tripId);
+
+        $this->associateTripWithUser($tripId, $this->testUser);
+    }
+
+    private function seedTripWithoutStages(string $tripId): void
+    {
+        $container = self::getContainer();
+
+        /** @var TripRequestRepositoryInterface $repo */
+        $repo = $container->get(TripRequestRepositoryInterface::class);
+
+        $request = new TripRequest(Uuid::fromString($tripId));
+        $request->sourceUrl = 'https://www.komoot.com/tour/123456789';
+
+        $repo->initializeTrip($tripId, $request);
+        $repo->storeSourceType($tripId, SourceType::KOMOOT_TOUR->value);
+
+        /** @var ComputationTrackerInterface $tracker */
+        $tracker = $container->get(ComputationTrackerInterface::class);
+        $tracker->initializeComputations($tripId, ComputationName::pipeline());
+
+        /** @var TripGenerationTrackerInterface $generationTracker */
+        $generationTracker = $container->get(TripGenerationTrackerInterface::class);
+        $generationTracker->initialize($tripId);
+
+        $this->associateTripWithUser($tripId, $this->testUser);
+    }
+
+    #[Test]
+    public function analyzeTripReturns202(): void
+    {
+        $this->seedTripReadyForAnalysis(self::TRIP_ID);
+
+        $response = $this->client->request(
+            'POST',
+            \sprintf('/trips/%s/analyze', self::TRIP_ID),
+            ['headers' => [...['Content-Type' => 'application/ld+json'], ...$this->authHeader($this->jwtToken)]],
+        );
+
+        $this->assertResponseStatusCodeSame(202);
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+
+        $data = $response->toArray(false);
+        $this->assertSame(self::TRIP_ID, $data['id']);
+        $this->assertSame('Trip', $data['@type']);
+        $this->assertArrayHasKey('computationStatus', $data);
+    }
+
+    #[Test]
+    public function analyzeDispatchesEveryEnrichmentMessage(): void
+    {
+        $this->seedTripReadyForAnalysis(self::TRIP_ID);
+
+        $this->client->request(
+            'POST',
+            \sprintf('/trips/%s/analyze', self::TRIP_ID),
+            ['headers' => [...['Content-Type' => 'application/ld+json'], ...$this->authHeader($this->jwtToken)]],
+        );
+
+        $this->assertResponseStatusCodeSame(202);
+
+        /** @var InMemoryTransport $transport */
+        $transport = self::getContainer()->get('messenger.transport.async');
+        $dispatched = array_map(
+            static fn (Envelope $envelope): string => $envelope->getMessage()::class,
+            $transport->getSent(),
+        );
+
+        $expected = [
+            ScanPois::class,
+            ScanAccommodations::class,
+            AnalyzeTerrain::class,
+            FetchWeather::class,
+            CheckCalendar::class,
+            CheckBikeShops::class,
+            CheckWaterPoints::class,
+            CheckHealthServices::class,
+            CheckCulturalPois::class,
+            CheckRailwayStations::class,
+            CheckBorderCrossing::class,
+            ScanEvents::class,
+        ];
+
+        foreach ($expected as $message) {
+            $this->assertContains($message, $dispatched, \sprintf('%s should have been dispatched.', $message));
+        }
+    }
+
+    #[Test]
+    public function analyzeResetsEnrichmentComputationsToPending(): void
+    {
+        $this->seedTripReadyForAnalysis(self::TRIP_ID);
+
+        $response = $this->client->request(
+            'POST',
+            \sprintf('/trips/%s/analyze', self::TRIP_ID),
+            ['headers' => [...['Content-Type' => 'application/ld+json'], ...$this->authHeader($this->jwtToken)]],
+        );
+
+        $this->assertResponseStatusCodeSame(202);
+
+        $data = $response->toArray(false);
+        // Preview-phase computations stay done
+        $this->assertSame('done', $data['computationStatus']['route']);
+        $this->assertSame('done', $data['computationStatus']['stages']);
+        // Enrichment computations are re-armed
+        $this->assertSame('pending', $data['computationStatus']['osm_scan']);
+        $this->assertSame('pending', $data['computationStatus']['pois']);
+        $this->assertSame('pending', $data['computationStatus']['weather']);
+        $this->assertSame('pending', $data['computationStatus']['terrain']);
+    }
+
+    #[Test]
+    public function analyzeWithoutStagesReturns422(): void
+    {
+        $this->seedTripWithoutStages(self::TRIP_ID);
+
+        $this->client->request(
+            'POST',
+            \sprintf('/trips/%s/analyze', self::TRIP_ID),
+            ['headers' => [...['Content-Type' => 'application/ld+json'], ...$this->authHeader($this->jwtToken)]],
+        );
+
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    #[Test]
+    public function analyzeWhileAnalysisInProgressReturns409(): void
+    {
+        $this->seedTripReadyForAnalysis(self::TRIP_ID);
+
+        // Simulate an in-flight analysis by marking an enrichment computation as running.
+        /** @var ComputationTrackerInterface $tracker */
+        $tracker = self::getContainer()->get(ComputationTrackerInterface::class);
+        $tracker->markRunning(self::TRIP_ID, ComputationName::WEATHER);
+
+        $this->client->request(
+            'POST',
+            \sprintf('/trips/%s/analyze', self::TRIP_ID),
+            ['headers' => [...['Content-Type' => 'application/ld+json'], ...$this->authHeader($this->jwtToken)]],
+        );
+
+        $this->assertResponseStatusCodeSame(409);
+    }
+
+    #[Test]
+    public function analyzeNonExistentTripReturns404(): void
+    {
+        $this->client->request(
+            'POST',
+            '/trips/00000000-0000-0000-0000-000000000000/analyze',
+            ['headers' => [...['Content-Type' => 'application/ld+json'], ...$this->authHeader($this->jwtToken)]],
+        );
+
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    #[Test]
+    public function analyzeRequiresAuthentication(): void
+    {
+        $this->seedTripReadyForAnalysis(self::TRIP_ID);
+
+        $this->client->request(
+            'POST',
+            \sprintf('/trips/%s/analyze', self::TRIP_ID),
+            ['headers' => ['Content-Type' => 'application/ld+json']],
+        );
+
+        $this->assertResponseStatusCodeSame(401);
+    }
+
+    #[Test]
+    public function analyzeRejectsTripOwnedByAnotherUser(): void
+    {
+        $this->seedTripReadyForAnalysis(self::TRIP_ID);
+
+        ['token' => $otherToken] = $this->createTestUserWithJwt('other@example.com');
+
+        $this->client->request(
+            'POST',
+            \sprintf('/trips/%s/analyze', self::TRIP_ID),
+            ['headers' => [...['Content-Type' => 'application/ld+json'], ...$this->authHeader($otherToken)]],
+        );
+
+        $this->assertResponseStatusCodeSame(403);
+    }
+}

--- a/api/tests/Functional/TripAnalyzeTest.php
+++ b/api/tests/Functional/TripAnalyzeTest.php
@@ -182,9 +182,7 @@ final class TripAnalyzeTest extends ApiTestCase
             ScanEvents::class,
         ];
 
-        foreach ($expected as $message) {
-            $this->assertContains($message, $dispatched, \sprintf('%s should have been dispatched.', $message));
-        }
+        $this->assertSame($expected, $dispatched, 'Exactly one message per enrichment step must be dispatched, in order.');
     }
 
     #[Test]

--- a/api/tests/Unit/MessageHandler/GenerateStagesHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/GenerateStagesHandlerTest.php
@@ -19,6 +19,7 @@ use App\Mercure\TripUpdatePublisherInterface;
 use App\Message\GenerateStages;
 use App\MessageHandler\GenerateStagesHandler;
 use App\Repository\TripRequestRepositoryInterface;
+use App\Service\TripAnalysisDispatcher;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
@@ -48,7 +49,7 @@ final class GenerateStagesHandlerTest extends TestCase
             $this->createStub(ElevationCalculatorInterface::class),
             $this->createStub(RouteSimplifierInterface::class),
             $pacingEngine,
-            $messageBus,
+            new TripAnalysisDispatcher($messageBus),
         );
     }
 
@@ -120,7 +121,7 @@ final class GenerateStagesHandlerTest extends TestCase
             $this->createStub(ElevationCalculatorInterface::class),
             $this->createStub(RouteSimplifierInterface::class),
             $pacingEngine,
-            $messageBus,
+            new TripAnalysisDispatcher($messageBus),
         );
 
         $handler(new GenerateStages('trip-1'));
@@ -187,7 +188,7 @@ final class GenerateStagesHandlerTest extends TestCase
             $this->createStub(ElevationCalculatorInterface::class),
             $this->createStub(RouteSimplifierInterface::class),
             $pacingEngine,
-            $messageBus,
+            new TripAnalysisDispatcher($messageBus),
         );
 
         $handler(new GenerateStages('trip-1'));

--- a/api/tests/Unit/Service/TripAnalysisDispatcherTest.php
+++ b/api/tests/Unit/Service/TripAnalysisDispatcherTest.php
@@ -83,7 +83,7 @@ final class TripAnalysisDispatcherTest extends TestCase
 
         $scanAccommodations = null;
 
-        $messageBus = $this->createMock(MessageBusInterface::class);
+        $messageBus = $this->createStub(MessageBusInterface::class);
         $messageBus
             ->method('dispatch')
             ->willReturnCallback(static function (object $message) use (&$scanAccommodations): Envelope {
@@ -109,7 +109,7 @@ final class TripAnalysisDispatcherTest extends TestCase
 
         $generations = [];
 
-        $messageBus = $this->createMock(MessageBusInterface::class);
+        $messageBus = $this->createStub(MessageBusInterface::class);
         $messageBus
             ->method('dispatch')
             ->willReturnCallback(static function (object $message) use (&$generations): Envelope {

--- a/api/tests/Unit/Service/TripAnalysisDispatcherTest.php
+++ b/api/tests/Unit/Service/TripAnalysisDispatcherTest.php
@@ -15,6 +15,7 @@ use App\Message\CheckRailwayStations;
 use App\Message\CheckWaterPoints;
 use App\Message\FetchWeather;
 use App\Message\ScanAccommodations;
+use App\Message\ScanAllOsmData;
 use App\Message\ScanEvents;
 use App\Message\ScanPois;
 use App\Service\TripAnalysisDispatcher;
@@ -34,6 +35,7 @@ final class TripAnalysisDispatcherTest extends TestCase
         $request->enabledAccommodationTypes = ['hotel', 'camp_site'];
 
         $expectedMessages = [
+            ScanAllOsmData::class,
             ScanPois::class,
             ScanAccommodations::class,
             AnalyzeTerrain::class,

--- a/api/tests/Unit/Service/TripAnalysisDispatcherTest.php
+++ b/api/tests/Unit/Service/TripAnalysisDispatcherTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service;
+
+use App\ApiResource\TripRequest;
+use App\Message\AnalyzeTerrain;
+use App\Message\CheckBikeShops;
+use App\Message\CheckBorderCrossing;
+use App\Message\CheckCalendar;
+use App\Message\CheckCulturalPois;
+use App\Message\CheckHealthServices;
+use App\Message\CheckRailwayStations;
+use App\Message\CheckWaterPoints;
+use App\Message\FetchWeather;
+use App\Message\ScanAccommodations;
+use App\Message\ScanEvents;
+use App\Message\ScanPois;
+use App\Service\TripAnalysisDispatcher;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final class TripAnalysisDispatcherTest extends TestCase
+{
+    #[Test]
+    public function dispatchSendsEveryEnrichmentMessageOnce(): void
+    {
+        $tripId = 'trip-1';
+        $generation = 3;
+        $request = new TripRequest();
+        $request->enabledAccommodationTypes = ['hotel', 'camp_site'];
+
+        $expectedMessages = [
+            ScanPois::class,
+            ScanAccommodations::class,
+            AnalyzeTerrain::class,
+            FetchWeather::class,
+            CheckCalendar::class,
+            CheckBikeShops::class,
+            CheckWaterPoints::class,
+            CheckHealthServices::class,
+            CheckCulturalPois::class,
+            CheckRailwayStations::class,
+            CheckBorderCrossing::class,
+            ScanEvents::class,
+        ];
+
+        $dispatched = [];
+
+        $messageBus = $this->createMock(MessageBusInterface::class);
+        $messageBus
+            ->expects($this->exactly(\count($expectedMessages)))
+            ->method('dispatch')
+            ->willReturnCallback(static function (object $message) use (&$dispatched): Envelope {
+                $dispatched[] = $message;
+
+                return new Envelope($message);
+            });
+
+        $dispatcher = new TripAnalysisDispatcher($messageBus);
+        $dispatcher->dispatch($tripId, $request, $generation);
+
+        $dispatchedClasses = array_map(static fn (object $m): string => $m::class, $dispatched);
+        $this->assertSame($expectedMessages, $dispatchedClasses);
+
+        foreach ($dispatched as $message) {
+            $this->assertObjectHasProperty('tripId', $message);
+            /** @var object{tripId: string, generation: ?int} $message */
+            $this->assertSame($tripId, $message->tripId);
+            $this->assertSame($generation, $message->generation);
+        }
+    }
+
+    #[Test]
+    public function dispatchPropagatesEnabledAccommodationTypes(): void
+    {
+        $request = new TripRequest();
+        $request->enabledAccommodationTypes = ['hotel', 'hostel'];
+
+        $scanAccommodations = null;
+
+        $messageBus = $this->createMock(MessageBusInterface::class);
+        $messageBus
+            ->method('dispatch')
+            ->willReturnCallback(static function (object $message) use (&$scanAccommodations): Envelope {
+                if ($message instanceof ScanAccommodations) {
+                    $scanAccommodations = $message;
+                }
+
+                return new Envelope($message);
+            });
+
+        $dispatcher = new TripAnalysisDispatcher($messageBus);
+        $dispatcher->dispatch('trip-1', $request, null);
+
+        $this->assertInstanceOf(ScanAccommodations::class, $scanAccommodations);
+        $this->assertSame(['hotel', 'hostel'], $scanAccommodations->enabledAccommodationTypes);
+        $this->assertNull($scanAccommodations->generation);
+    }
+
+    #[Test]
+    public function dispatchAcceptsNullGeneration(): void
+    {
+        $request = new TripRequest();
+
+        $generations = [];
+
+        $messageBus = $this->createMock(MessageBusInterface::class);
+        $messageBus
+            ->method('dispatch')
+            ->willReturnCallback(static function (object $message) use (&$generations): Envelope {
+                if (property_exists($message, 'generation')) {
+                    /** @var object{generation: ?int} $message */
+                    $generations[] = $message->generation;
+                }
+
+                return new Envelope($message);
+            });
+
+        $dispatcher = new TripAnalysisDispatcher($messageBus);
+        $dispatcher->dispatch('trip-1', $request, null);
+
+        $this->assertNotEmpty($generations);
+        foreach ($generations as $value) {
+            $this->assertNull($value);
+        }
+    }
+}

--- a/api/tests/Unit/Service/TripAnalysisDispatcherTest.php
+++ b/api/tests/Unit/Service/TripAnalysisDispatcherTest.php
@@ -68,7 +68,8 @@ final class TripAnalysisDispatcherTest extends TestCase
 
         foreach ($dispatched as $message) {
             $this->assertObjectHasProperty('tripId', $message);
-            /** @var object{tripId: string, generation: ?int} $message */
+            $this->assertObjectHasProperty('generation', $message);
+            /* @var object{tripId: string, generation: ?int} $message */
             $this->assertSame($tripId, $message->tripId);
             $this->assertSame($generation, $message->generation);
         }
@@ -94,7 +95,7 @@ final class TripAnalysisDispatcherTest extends TestCase
             });
 
         $dispatcher = new TripAnalysisDispatcher($messageBus);
-        $dispatcher->dispatch('trip-1', $request, null);
+        $dispatcher->dispatch('trip-1', $request);
 
         $this->assertInstanceOf(ScanAccommodations::class, $scanAccommodations);
         $this->assertSame(['hotel', 'hostel'], $scanAccommodations->enabledAccommodationTypes);
@@ -113,7 +114,7 @@ final class TripAnalysisDispatcherTest extends TestCase
             ->method('dispatch')
             ->willReturnCallback(static function (object $message) use (&$generations): Envelope {
                 if (property_exists($message, 'generation')) {
-                    /** @var object{generation: ?int} $message */
+                    /* @var object{generation: ?int} $message */
                     $generations[] = $message->generation;
                 }
 
@@ -121,7 +122,7 @@ final class TripAnalysisDispatcherTest extends TestCase
             });
 
         $dispatcher = new TripAnalysisDispatcher($messageBus);
-        $dispatcher->dispatch('trip-1', $request, null);
+        $dispatcher->dispatch('trip-1', $request);
 
         $this->assertNotEmpty($generations);
         foreach ($generations as $value) {

--- a/pwa/src/lib/api/schema.d.ts
+++ b/pwa/src/lib/api/schema.d.ts
@@ -324,6 +324,26 @@ export interface paths {
         patch: operations["api_trips_id_patch"];
         trace?: never;
     };
+    "/trips/{id}/analyze": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Trigger the full enrichment pipeline (POIs, weather, terrain, …) for a trip whose stages have been pre-computed.
+         * @description Creates a Trip resource.
+         */
+        post: operations["api_trips_idanalyze_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/trips/{id}/duplicate": {
         parameters: {
             query?: never;
@@ -2485,6 +2505,76 @@ export interface operations {
                 };
             };
             /** @description An error occurred */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["ConstraintViolation.jsonld"];
+                    "application/problem+json": components["schemas"]["ConstraintViolation"];
+                    "application/json": components["schemas"]["ConstraintViolation"];
+                };
+            };
+        };
+    };
+    api_trips_idanalyze_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Trip identifier */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Trip resource created */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["Trip.jsonld"];
+                };
+            };
+            /** @description Invalid input */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["Error.jsonld"];
+                    "application/problem+json": components["schemas"]["Error"];
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["Error.jsonld"];
+                    "application/problem+json": components["schemas"]["Error"];
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Trip not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description An analysis is already in progress */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Trip has no stages to analyze */
             422: {
                 headers: {
                     [name: string]: unknown;


### PR DESCRIPTION
## Summary

- Adds `POST /api/trips/{id}/analyze` endpoint (202 Accepted) to decouple preview from full analysis
- Extracts `TripAnalysisDispatcher` service from `GenerateStagesHandler` (dispatches all 12 enrichment messages)
- `AnalyzeTripProcessor` validates trip state: 422 if no stages, 409 if analysis already running, 404/403 via provider/voter
- `GenerateStagesHandler` refactored to delegate to `TripAnalysisDispatcher` (backward-compatible)
- Regenerated OpenAPI TypeScript schema after DTO change

## Auto-critique

- The `resetComputation()` call per enrichment before re-dispatch preserves ROUTE/STAGES statuses — intentional to allow re-analysis without full re-import
- PHPStan `assertObjectHasProperty` added to satisfy type narrowing for dispatched message assertions

Closes #322

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

No blocking findings. The previously-reported critical issue (missing `ScanAllOsmData` import in `TripAnalysisDispatcher.php`) is fixed in the latest commit. The `WIND` entry in `ANALYSIS_COMPUTATIONS` without a direct dispatch is intentional — `AnalyzeWind` is chained downstream from `FetchWeatherHandler`, consistent with pre-existing pipeline behaviour.

### Resolved threads
Resolved 1 previously open thread: `ScanAllOsmData` import is now present in `TripAnalysisDispatcher.php`.

### Review checklist
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Commit reviewed
`f6b232d18d7dd2a29548aa6791a0c147696fea2a`

### Inline comments
No inline comments.

---
Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->