### PR TITLE
feat(trip-planner): add preview screen before analysis

### DIFF
--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -354,6 +354,25 @@
   "planner": {
     "closeTrip": "Close this trip"
   },
+  "tripPreview": {
+    "title": "Your route preview",
+    "subtitle": "Check the track, the stages and the settings before launching the full analysis.",
+    "stagesHeading": "Stage breakdown",
+    "stagesCount": "{count, plural, =0 {# stage} one {# stage} other {# stages}}",
+    "stageDay": "Day {day}",
+    "stageDistance": "{distance} km",
+    "stageElevation": "Elev+ {elevation} m",
+    "stageEndPoint": "Arrival: {lat}°N, {lon}°E",
+    "launchAnalysis": "Launch analysis",
+    "launchAnalysisAria": "Launch the full route analysis",
+    "launchingAnalysis": "Launching analysis...",
+    "modifyParameters": "Modify parameters",
+    "modifyParametersAria": "Open the configuration panel to modify parameters",
+    "changeRoute": "Change route",
+    "changeRouteAria": "Return to the preparation screen to change the route",
+    "analysisLaunched": "Analysis launched",
+    "analysisLaunchFailed": "Failed to launch analysis. Please retry."
+  },
   "errors": {
     "networkError": "Network error. Please check your connection.",
     "unexpectedError": "An unexpected error occurred.",

--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -362,7 +362,7 @@
     "stageDay": "Day {day}",
     "stageDistance": "{distance} km",
     "stageElevation": "Elev+ {elevation} m",
-    "stageEndPoint": "Arrival: {lat}°N, {lon}°E",
+    "stageEndPoint": "Arrival: {lat}°, {lon}°",
     "launchAnalysis": "Launch analysis",
     "launchAnalysisAria": "Launch the full route analysis",
     "launchingAnalysis": "Launching analysis...",

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -362,7 +362,7 @@
     "stageDay": "Jour {day}",
     "stageDistance": "{distance} km",
     "stageElevation": "D+ {elevation} m",
-    "stageEndPoint": "Arrivée : {lat}°N, {lon}°E",
+    "stageEndPoint": "Arrivée : {lat}°, {lon}°",
     "launchAnalysis": "Lancer l'analyse",
     "launchAnalysisAria": "Lancer l'analyse complète de l'itinéraire",
     "launchingAnalysis": "Lancement de l'analyse...",

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -354,6 +354,25 @@
   "planner": {
     "closeTrip": "Fermer ce trip"
   },
+  "tripPreview": {
+    "title": "Aperçu de votre itinéraire",
+    "subtitle": "Vérifiez le tracé, les étapes et les paramètres avant de lancer l'analyse complète.",
+    "stagesHeading": "Découpage en étapes",
+    "stagesCount": "{count, plural, =0 {# étape} one {# étape} other {# étapes}}",
+    "stageDay": "Jour {day}",
+    "stageDistance": "{distance} km",
+    "stageElevation": "D+ {elevation} m",
+    "stageEndPoint": "Arrivée : {lat}°N, {lon}°E",
+    "launchAnalysis": "Lancer l'analyse",
+    "launchAnalysisAria": "Lancer l'analyse complète de l'itinéraire",
+    "launchingAnalysis": "Lancement de l'analyse...",
+    "modifyParameters": "Modifier les paramètres",
+    "modifyParametersAria": "Ouvrir le panneau de configuration pour modifier les paramètres",
+    "changeRoute": "Changer d'itinéraire",
+    "changeRouteAria": "Retourner à l'écran de préparation pour changer d'itinéraire",
+    "analysisLaunched": "Analyse lancée",
+    "analysisLaunchFailed": "Impossible de lancer l'analyse. Réessayez."
+  },
   "errors": {
     "networkError": "Erreur réseau. Vérifiez votre connexion.",
     "unexpectedError": "Une erreur inattendue s'est produite.",

--- a/pwa/src/app/trips/[id]/trip-page.tsx
+++ b/pwa/src/app/trips/[id]/trip-page.tsx
@@ -142,6 +142,9 @@ function TripLoader({ tripId }: { tripId: string }) {
             sourceType: "persisted",
             title: data.title ?? null,
           });
+          // A persisted trip with stages has already gone through Phase 2,
+          // so bypass the Acte 1.5 preview gate and render the full view.
+          useUiStore.getState().setAnalysisStarted(true);
         }
 
         setIsLoaded(true);

--- a/pwa/src/components/card-selection.tsx
+++ b/pwa/src/components/card-selection.tsx
@@ -434,11 +434,12 @@ function GpxCard({ expanded, disabled, onSelect, onUpload }: GpxCardProps) {
               {t("gpxFileTooLarge")}
             </p>
           )}
-          {selectedFile && !selectedFile.name.toLowerCase().endsWith(".gpx") && (
-            <p className="text-sm text-destructive" role="alert">
-              {t("gpxInvalidType")}
-            </p>
-          )}
+          {selectedFile &&
+            !selectedFile.name.toLowerCase().endsWith(".gpx") && (
+              <p className="text-sm text-destructive" role="alert">
+                {t("gpxInvalidType")}
+              </p>
+            )}
         </div>
       )}
     </CardShell>

--- a/pwa/src/components/saved-trips-section.tsx
+++ b/pwa/src/components/saved-trips-section.tsx
@@ -7,6 +7,7 @@ import "dayjs/locale/fr";
 import { WifiOff } from "lucide-react";
 import { useOfflineStore } from "@/store/offline-store";
 import { useTripStore } from "@/store/trip-store";
+import { useUiStore } from "@/store/ui-store";
 
 export function SavedTripsSection() {
   const t = useTranslations();
@@ -15,6 +16,7 @@ export function SavedTripsSection() {
   const loadSavedTrips = useOfflineStore((s) => s.loadSavedTrips);
   const isOnline = useOfflineStore((s) => s.isOnline);
   const loadFromSavedTrip = useTripStore((s) => s.loadFromSavedTrip);
+  const setAnalysisStarted = useUiStore((s) => s.setAnalysisStarted);
 
   useEffect(() => {
     void loadSavedTrips();
@@ -41,7 +43,12 @@ export function SavedTripsSection() {
               <button
                 type="button"
                 className="w-full text-left rounded-lg border bg-card px-4 py-3 shadow-sm hover:bg-accent/50 transition-colors cursor-pointer"
-                onClick={() => loadFromSavedTrip(trip)}
+                onClick={() => {
+                  loadFromSavedTrip(trip);
+                  // Saved trips are always fully analysed (persisted on
+                  // trip_complete), so bypass the Acte 1.5 preview gate.
+                  setAnalysisStarted(true);
+                }}
                 data-testid={`saved-trip-card-${trip.id}`}
               >
                 <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5">

--- a/pwa/src/components/trip-planner.tsx
+++ b/pwa/src/components/trip-planner.tsx
@@ -8,6 +8,7 @@ import { Settings, HelpCircle, Loader2, X, Share2, Map } from "lucide-react";
 import { CardSelection } from "@/components/card-selection";
 import { GpxDropZone } from "@/components/gpx-drop-zone";
 import { TripLockedBanner } from "@/components/trip-locked-banner";
+import { TripPreview } from "@/components/trip-preview";
 import { TripSummary } from "@/components/trip-summary";
 import { TripHeader } from "@/components/trip-header";
 import { TripDownloads } from "@/components/trip-downloads";
@@ -85,6 +86,7 @@ export function TripPlanner({ onClose }: { onClose?: () => void } = {}) {
     handleInsertRestDay,
     handleAddPoiWaypoint,
     handleDuplicateTrip,
+    handleLaunchAnalysis,
     handleShareTrip,
     isShareModalOpen,
     setShareModalOpen,
@@ -103,6 +105,7 @@ export function TripPlanner({ onClose }: { onClose?: () => void } = {}) {
   const goToStep = useUiStore((s) => s.goToStep);
   const completeStep = useUiStore((s) => s.completeStep);
   const resetStepper = useUiStore((s) => s.resetStepper);
+  const hasAnalysisStarted = useUiStore((s) => s.hasAnalysisStarted);
   const activeStages = useMemo(
     () => stages.filter((s) => !s.isRestDay),
     [stages],
@@ -155,23 +158,28 @@ export function TripPlanner({ onClose }: { onClose?: () => void } = {}) {
   }, [setFocusedMapStageIndex]);
 
   // Drive stepper state transitions based on trip lifecycle:
-  // - URL submitted / GPX uploading → "analysis" (background computation)
-  // - Computation complete (trip + stages) → "my_trip"
-  // - Trip loaded but no stages (loading state) → "preview"
+  // - Processing (URL submit / GPX upload) → "analysis"
+  // - Stages computed, processing settled, analysis not launched → "preview"
+  // - Stages computed, analysis complete → "my_trip"
   useEffect(() => {
     if (isProcessing) {
-      // Computation is running: advance past preparation/preview into analysis
+      // Computation in flight: advance past preparation/preview into analysis.
       completeStep("preparation");
       completeStep("preview");
       goToStep("analysis");
-    } else if (trip && stages.length > 0) {
-      // Computation complete: all prior steps done, advance to my_trip
+    } else if (trip && stages.length > 0 && !hasAnalysisStarted) {
+      // Phase 1 complete: pacing engine produced stages. Park on "preview"
+      // and wait for the user to explicitly click "Lancer l'analyse".
+      completeStep("preparation");
+      goToStep("preview");
+    } else if (trip && stages.length > 0 && hasAnalysisStarted) {
+      // Phase 2 complete: every prior step done, advance to my_trip.
       completeStep("preparation");
       completeStep("preview");
       completeStep("analysis");
       goToStep("my_trip");
     } else if (trip && stages.length === 0) {
-      // Trip identity loaded but no stages yet: preview state
+      // Trip identity loaded but no stages yet: preview state (loading).
       completeStep("preparation");
       goToStep("preview");
     } else {
@@ -179,7 +187,15 @@ export function TripPlanner({ onClose }: { onClose?: () => void } = {}) {
       // past the "my_trip" lock and back to "preparation".
       resetStepper();
     }
-  }, [isProcessing, trip, stages.length, completeStep, goToStep, resetStepper]);
+  }, [
+    isProcessing,
+    trip,
+    stages.length,
+    hasAnalysisStarted,
+    completeStep,
+    goToStep,
+    resetStepper,
+  ]);
 
   // Mobile swipe: left → map, right → timeline (cycle: timeline ↔ map on mobile)
   const swipeHandlers = useSwipe({
@@ -268,9 +284,26 @@ export function TripPlanner({ onClose }: { onClose?: () => void } = {}) {
     return () => observer.disconnect();
   }, [hasMap, viewMode]);
 
-  // Derive the 3 UI states
+  // Derive the UI states (welcome / loading / preview / full trip view).
+  // The preview screen (Acte 1.5) sits between Phase 1 (pacing engine) and
+  // Phase 2 (enrichment) — it is active once the backend has produced
+  // stages AND the initial processing has settled AND the user has not yet
+  // clicked "Lancer l'analyse". The `trip_complete` event flips
+  // `hasAnalysisStarted` to `true`, which keeps the legacy single-phase
+  // flow (used in most mocked tests) rendering the full trip view.
   const isWelcome = !trip && !isProcessing;
   const isLoading = !trip && isProcessing;
+  const isPreview =
+    !!trip &&
+    !isProcessing &&
+    activeStages.length > 0 &&
+    !hasAnalysisStarted;
+  const clearTripAndReset = useCallback(() => {
+    clearTrip();
+    useUiStore.getState().setProcessing(false);
+    useUiStore.getState().setAccommodationScanning(false);
+    useUiStore.getState().setAnalysisStarted(false);
+  }, [clearTrip]);
 
   const tNav = useTranslations("navigation");
 
@@ -392,8 +425,58 @@ export function TripPlanner({ onClose }: { onClose?: () => void } = {}) {
           </div>
         )}
 
-        {/* === State 3: Trip loaded === */}
-        {trip && (
+        {/* === State 3a: Preview (Acte 1.5 — stages computed, analysis
+             not yet launched). Inserts a user-controlled gate between
+             Phase 1 (pacing engine) and Phase 2 (enrichment pipeline). */}
+        {isPreview && (
+          <>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="absolute top-2 right-4 md:right-6 h-8 w-8 z-10 text-muted-foreground hover:text-foreground"
+              onClick={() => {
+                if (onClose) {
+                  onClose();
+                } else {
+                  clearTripAndReset();
+                  router.push("/");
+                }
+              }}
+              title={t("planner.closeTrip")}
+              aria-label={t("planner.closeTrip")}
+              data-testid="close-trip-button-preview"
+            >
+              <X className="h-4 w-4" />
+            </Button>
+
+            <TripPreview
+              title={trip?.title ?? ""}
+              totalDistance={totalDistance}
+              totalElevation={totalElevation}
+              totalElevationLoss={totalElevationLoss}
+              stages={stages}
+              startDate={startDate}
+              endDate={endDate}
+              weather={firstWeather}
+              isWeatherLoading={isWeatherLoading}
+              fatigueFactor={fatigueFactor}
+              elevationPenalty={elevationPenalty}
+              maxDistancePerDay={maxDistancePerDay}
+              averageSpeed={averageSpeed}
+              onLaunchAnalysis={handleLaunchAnalysis}
+              onChangeRoute={() => {
+                clearTripAndReset();
+                router.push("/");
+              }}
+              onTitleChange={handleTitleChange}
+              showTitleSuggestion={totalDistance !== null}
+            />
+          </>
+        )}
+
+        {/* === State 3b: Trip loaded — full view (shown once the user
+             has launched the Phase 2 analysis via the preview CTA). === */}
+        {trip && !isPreview && (
           <>
             {/* Close button — top-right corner */}
             <Button
@@ -404,9 +487,7 @@ export function TripPlanner({ onClose }: { onClose?: () => void } = {}) {
                 if (onClose) {
                   onClose();
                 } else {
-                  clearTrip();
-                  useUiStore.getState().setProcessing(false);
-                  useUiStore.getState().setAccommodationScanning(false);
+                  clearTripAndReset();
                   router.push("/");
                 }
               }}

--- a/pwa/src/components/trip-planner.tsx
+++ b/pwa/src/components/trip-planner.tsx
@@ -157,6 +157,29 @@ export function TripPlanner({ onClose }: { onClose?: () => void } = {}) {
       window.removeEventListener("__test_set_focused_map_stage", handler);
   }, [setFocusedMapStageIndex]);
 
+  // E2E test hook: let Playwright simulate the Phase 1 → Phase 2 gate by
+  // forcing processing/analysisStarted flags. Needed because the prod build
+  // does not expose `window.__zustand_ui_store` (guarded by NODE_ENV).
+  useEffect(() => {
+    const onProcessing = (e: Event) => {
+      useUiStore.getState().setProcessing(!!(e as CustomEvent<boolean>).detail);
+    };
+    const onAnalysisStarted = (e: Event) => {
+      useUiStore
+        .getState()
+        .setAnalysisStarted(!!(e as CustomEvent<boolean>).detail);
+    };
+    window.addEventListener("__test_set_processing", onProcessing);
+    window.addEventListener("__test_set_analysis_started", onAnalysisStarted);
+    return () => {
+      window.removeEventListener("__test_set_processing", onProcessing);
+      window.removeEventListener(
+        "__test_set_analysis_started",
+        onAnalysisStarted,
+      );
+    };
+  }, []);
+
   // Drive stepper state transitions based on trip lifecycle:
   // - Processing (URL submit / GPX upload) → "analysis"
   // - Stages computed, processing settled, analysis not launched → "preview"

--- a/pwa/src/components/trip-planner.tsx
+++ b/pwa/src/components/trip-planner.tsx
@@ -294,10 +294,7 @@ export function TripPlanner({ onClose }: { onClose?: () => void } = {}) {
   const isWelcome = !trip && !isProcessing;
   const isLoading = !trip && isProcessing;
   const isPreview =
-    !!trip &&
-    !isProcessing &&
-    activeStages.length > 0 &&
-    !hasAnalysisStarted;
+    !!trip && !isProcessing && activeStages.length > 0 && !hasAnalysisStarted;
   const clearTripAndReset = useCallback(() => {
     clearTrip();
     useUiStore.getState().setProcessing(false);

--- a/pwa/src/components/trip-preview.tsx
+++ b/pwa/src/components/trip-preview.tsx
@@ -119,7 +119,10 @@ export function TripPreview({
           onTitleChange={onTitleChange}
           showTitleSuggestion={showTitleSuggestion}
         />
-        <p className="mt-2 text-sm text-muted-foreground" id="trip-preview-heading">
+        <p
+          className="mt-2 text-sm text-muted-foreground"
+          id="trip-preview-heading"
+        >
           {t("subtitle")}
         </p>
       </div>
@@ -181,10 +184,7 @@ export function TripPreview({
         <ul className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
           {activeStages.map((stage, i) => (
             <li key={`preview-stage-${i}`}>
-              <Card
-                className="h-full"
-                data-testid={`trip-preview-stage-${i}`}
-              >
+              <Card className="h-full" data-testid={`trip-preview-stage-${i}`}>
                 <CardContent className="p-4 space-y-2">
                   <div className="flex items-center justify-between">
                     <span className="font-medium">

--- a/pwa/src/components/trip-preview.tsx
+++ b/pwa/src/components/trip-preview.tsx
@@ -165,12 +165,12 @@ export function TripPreview({
         data-testid="trip-preview-stages"
       >
         <div className="flex items-baseline justify-between">
-          <h2
+          <h3
             id="trip-preview-stages-heading"
             className="text-lg font-semibold"
           >
             {t("stagesHeading")}
-          </h2>
+          </h3>
           <span
             className="text-sm text-muted-foreground"
             data-testid="trip-preview-stages-count"

--- a/pwa/src/components/trip-preview.tsx
+++ b/pwa/src/components/trip-preview.tsx
@@ -1,0 +1,288 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { useTranslations, useLocale } from "next-intl";
+import dayjs from "dayjs";
+import "dayjs/locale/fr";
+import "dayjs/locale/en";
+import {
+  Loader2,
+  Play,
+  Settings,
+  ArrowLeft,
+  ArrowUp,
+  Bike,
+  Flag,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { TripHeader } from "@/components/trip-header";
+import { TripSummary } from "@/components/trip-summary";
+import { MapPanel } from "@/components/Map";
+import { useUiStore } from "@/store/ui-store";
+import type { StageData, WeatherData } from "@/lib/validation/schemas";
+
+interface TripPreviewProps {
+  title: string;
+  totalDistance: number | null;
+  totalElevation: number | null;
+  totalElevationLoss: number | null;
+  stages: StageData[];
+  startDate: string | null;
+  endDate: string | null;
+  weather: WeatherData | null;
+  isWeatherLoading?: boolean;
+  fatigueFactor: number;
+  elevationPenalty: number;
+  maxDistancePerDay: number;
+  averageSpeed: number;
+  /** Called when the user clicks "Lancer l'analyse". Should launch the
+   *  Phase 2 enrichment pipeline and resolve to `true` on success. */
+  onLaunchAnalysis: () => Promise<boolean>;
+  /** Called when the user clicks "Changer d'itinéraire" — resets the trip
+   *  and returns to the Acte 1 "Préparation" screen. */
+  onChangeRoute: () => void;
+  onTitleChange: (title: string) => void;
+  /** When true, the trip header shows the feminist-name suggestion banner. */
+  showTitleSuggestion?: boolean;
+}
+
+/**
+ * Acte 1.5 — Preview screen. Sits between Acte 1 (Préparation) and Acte 2
+ * (Analyse). Shows the coarse route (map + elevation profile + per-stage
+ * breakdown) immediately after Phase 1 (`POST /trips` → pacing engine)
+ * completes, so the user can validate the track before committing to the
+ * expensive Phase 2 enrichments.
+ *
+ * Reuses {@link TripSummary}, {@link TripHeader}, and {@link MapPanel} so
+ * the preview stays visually consistent with the full trip view. The
+ * per-stage list is deliberately compact: distance + D+ + arrival label,
+ * no accommodations/weather/alerts (those arrive in Phase 2).
+ *
+ * The three CTAs implement the action contract from issue #321:
+ * - "Lancer l'analyse" → `POST /trips/{id}/analyze` (Acte 2)
+ * - "Modifier les paramètres" → opens the shared {@link ConfigPanel}
+ * - "Changer d'itinéraire" → `clearTrip()` and back to Acte 1
+ */
+export function TripPreview({
+  title,
+  totalDistance,
+  totalElevation,
+  totalElevationLoss,
+  stages,
+  startDate,
+  endDate,
+  weather,
+  isWeatherLoading,
+  fatigueFactor,
+  elevationPenalty,
+  maxDistancePerDay,
+  averageSpeed,
+  onLaunchAnalysis,
+  onChangeRoute,
+  onTitleChange,
+  showTitleSuggestion,
+}: TripPreviewProps) {
+  const t = useTranslations("tripPreview");
+  const locale = useLocale();
+  const setConfigPanelOpen = useUiStore((s) => s.setConfigPanelOpen);
+  const [isLaunching, setIsLaunching] = useState(false);
+
+  const activeStages = stages.filter((s) => !s.isRestDay);
+  const stagesCount = activeStages.length;
+
+  const handleLaunchClick = useCallback(async () => {
+    if (isLaunching) return;
+    setIsLaunching(true);
+    try {
+      await onLaunchAnalysis();
+    } finally {
+      setIsLaunching(false);
+    }
+  }, [isLaunching, onLaunchAnalysis]);
+
+  const handleOpenConfig = useCallback(() => {
+    setConfigPanelOpen(true);
+  }, [setConfigPanelOpen]);
+
+  return (
+    <section
+      className="space-y-6"
+      data-testid="trip-preview"
+      aria-labelledby="trip-preview-heading"
+    >
+      {/* Title row — reuses TripHeader so the feminist-name suggestion
+          banner behaves exactly like on the full trip view. */}
+      <div className="text-center md:text-left">
+        <TripHeader
+          title={title}
+          onTitleChange={onTitleChange}
+          showTitleSuggestion={showTitleSuggestion}
+        />
+        <p className="mt-2 text-sm text-muted-foreground" id="trip-preview-heading">
+          {t("subtitle")}
+        </p>
+      </div>
+
+      {/* Global stats (distance, elevation, weather, dates, profile). */}
+      <TripSummary
+        totalDistance={totalDistance}
+        totalElevation={totalElevation}
+        totalElevationLoss={totalElevationLoss}
+        weather={weather}
+        isWeatherLoading={isWeatherLoading}
+        isProcessing={false}
+        startDate={startDate}
+        endDate={endDate}
+        fatigueFactor={fatigueFactor}
+        elevationPenalty={elevationPenalty}
+        maxDistancePerDay={maxDistancePerDay}
+        averageSpeed={averageSpeed}
+      />
+
+      {/* Map + elevation profile — same component used on the full
+          trip view so the user sees the exact tracé they'll get. */}
+      <div
+        className="relative w-full h-[420px] md:h-[520px] rounded-lg overflow-hidden border border-border bg-muted/10"
+        data-testid="trip-preview-map"
+      >
+        <MapPanel
+          focusedStageIndex={null}
+          onStageClick={() => {
+            /* preview: map clicks are visual-only */
+          }}
+          onResetView={() => {
+            /* preview: nothing to reset */
+          }}
+        />
+      </div>
+
+      {/* Coarse stage breakdown */}
+      <section
+        className="space-y-3"
+        aria-labelledby="trip-preview-stages-heading"
+        data-testid="trip-preview-stages"
+      >
+        <div className="flex items-baseline justify-between">
+          <h2
+            id="trip-preview-stages-heading"
+            className="text-lg font-semibold"
+          >
+            {t("stagesHeading")}
+          </h2>
+          <span
+            className="text-sm text-muted-foreground"
+            data-testid="trip-preview-stages-count"
+          >
+            {t("stagesCount", { count: stagesCount })}
+          </span>
+        </div>
+
+        <ul className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {activeStages.map((stage, i) => (
+            <li key={`preview-stage-${i}`}>
+              <Card
+                className="h-full"
+                data-testid={`trip-preview-stage-${i}`}
+              >
+                <CardContent className="p-4 space-y-2">
+                  <div className="flex items-center justify-between">
+                    <span className="font-medium">
+                      {t("stageDay", { day: stage.dayNumber })}
+                    </span>
+                    {startDate && (
+                      <span className="text-xs text-muted-foreground">
+                        {dayjs(startDate)
+                          .add(stage.dayNumber - 1, "day")
+                          .locale(locale)
+                          .format("D MMM")}
+                      </span>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-3 text-sm text-muted-foreground">
+                    <span className="flex items-center gap-1">
+                      <Bike className="h-3.5 w-3.5 text-brand" />
+                      {t("stageDistance", {
+                        distance: Math.round(stage.distance),
+                      })}
+                    </span>
+                    <span className="flex items-center gap-1">
+                      <ArrowUp className="h-3.5 w-3.5 text-red-500" />
+                      {t("stageElevation", {
+                        elevation: Math.round(stage.elevation),
+                      })}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-1 text-xs text-muted-foreground">
+                    <Flag className="h-3 w-3 shrink-0" />
+                    <span className="truncate">
+                      {stage.endLabel
+                        ? stage.endLabel
+                        : t("stageEndPoint", {
+                            lat: stage.endPoint.lat.toFixed(3),
+                            lon: stage.endPoint.lon.toFixed(3),
+                          })}
+                    </span>
+                  </div>
+                </CardContent>
+              </Card>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      {/* Action bar — order matches the issue body:
+          1. Launch analysis (primary), 2. Modify parameters, 3. Change route. */}
+      <div
+        className="flex flex-col sm:flex-row gap-3 sm:justify-end pt-2"
+        data-testid="trip-preview-actions"
+      >
+        <Button
+          type="button"
+          variant="outline"
+          size="lg"
+          className="cursor-pointer sm:order-1 order-3"
+          onClick={onChangeRoute}
+          aria-label={t("changeRouteAria")}
+          data-testid="trip-preview-change-route"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          {t("changeRoute")}
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="lg"
+          className="cursor-pointer sm:order-2 order-2"
+          onClick={handleOpenConfig}
+          aria-label={t("modifyParametersAria")}
+          data-testid="trip-preview-modify-parameters"
+        >
+          <Settings className="h-4 w-4" />
+          {t("modifyParameters")}
+        </Button>
+        <Button
+          type="button"
+          size="lg"
+          className="cursor-pointer sm:order-3 order-1"
+          onClick={handleLaunchClick}
+          disabled={isLaunching || stagesCount === 0}
+          aria-label={t("launchAnalysisAria")}
+          data-testid="trip-preview-launch-analysis"
+        >
+          {isLaunching ? (
+            <>
+              <Loader2 className="h-4 w-4 animate-spin" />
+              {t("launchingAnalysis")}
+            </>
+          ) : (
+            <>
+              <Play className="h-4 w-4" />
+              {t("launchAnalysis")}
+            </>
+          )}
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/pwa/src/components/trip-preview.tsx
+++ b/pwa/src/components/trip-preview.tsx
@@ -119,15 +119,10 @@ export function TripPreview({
           onTitleChange={onTitleChange}
           showTitleSuggestion={showTitleSuggestion}
         />
-        <h2
-          id="trip-preview-heading"
-          className="text-lg font-semibold"
-        >
+        <h2 id="trip-preview-heading" className="text-lg font-semibold">
           {t("title")}
         </h2>
-        <p className="mt-2 text-sm text-muted-foreground">
-          {t("subtitle")}
-        </p>
+        <p className="mt-2 text-sm text-muted-foreground">{t("subtitle")}</p>
       </div>
 
       {/* Global stats (distance, elevation, weather, dates, profile). */}

--- a/pwa/src/components/trip-preview.tsx
+++ b/pwa/src/components/trip-preview.tsx
@@ -119,10 +119,13 @@ export function TripPreview({
           onTitleChange={onTitleChange}
           showTitleSuggestion={showTitleSuggestion}
         />
-        <p
-          className="mt-2 text-sm text-muted-foreground"
+        <h2
           id="trip-preview-heading"
+          className="text-lg font-semibold"
         >
+          {t("title")}
+        </h2>
+        <p className="mt-2 text-sm text-muted-foreground">
           {t("subtitle")}
         </p>
       </div>

--- a/pwa/src/hooks/use-mercure.ts
+++ b/pwa/src/hooks/use-mercure.ts
@@ -400,6 +400,12 @@ function dispatchEvent(event: MercureEvent): void {
       store.setComputationStatus(event.data.computationStatus);
       useUiStore.getState().setProcessing(false);
       useUiStore.getState().setAccommodationScanning(false);
+      // Phase 2 completion implies the analysis was running; mark it
+      // explicitly so the UI leaves the Acte 1.5 preview and renders the
+      // full trip view. This also covers legacy flows (tests, one-shot
+      // backends) where `trip_complete` is fired before #322's split
+      // lands and `POST /trips/{id}/analyze` ever gets called.
+      useUiStore.getState().setAnalysisStarted(true);
 
       // Persist the completed trip to IndexedDB for offline consultation
       if (store.trip) {

--- a/pwa/src/hooks/use-mercure.ts
+++ b/pwa/src/hooks/use-mercure.ts
@@ -398,14 +398,16 @@ function dispatchEvent(event: MercureEvent): void {
 
     case "trip_complete":
       store.setComputationStatus(event.data.computationStatus);
+      // Phase 2 completion implies the analysis was running; mark it
+      // explicitly BEFORE flipping isProcessing/accommodationScanning so
+      // any intermediate render observes { hasAnalysisStarted: true } and
+      // skips the "park on preview" branch of the stepper. Also covers
+      // legacy flows (tests, one-shot backends) where `trip_complete`
+      // fires before #322's split lands and `POST /trips/{id}/analyze`
+      // ever gets called.
+      useUiStore.getState().setAnalysisStarted(true);
       useUiStore.getState().setProcessing(false);
       useUiStore.getState().setAccommodationScanning(false);
-      // Phase 2 completion implies the analysis was running; mark it
-      // explicitly so the UI leaves the Acte 1.5 preview and renders the
-      // full trip view. This also covers legacy flows (tests, one-shot
-      // backends) where `trip_complete` is fired before #322's split
-      // lands and `POST /trips/{id}/analyze` ever gets called.
-      useUiStore.getState().setAnalysisStarted(true);
 
       // Persist the completed trip to IndexedDB for offline consultation
       if (store.trip) {

--- a/pwa/src/hooks/use-trip-planner.ts
+++ b/pwa/src/hooks/use-trip-planner.ts
@@ -665,9 +665,9 @@ export function useTripPlanner() {
         toast.error(t("tripPreview.analysisLaunchFailed"));
         return false;
       }
-      useUiStore.getState().setAnalysisStarted(true);
       setProcessing(true);
       setAccommodationScanning(true);
+      useUiStore.getState().setAnalysisStarted(true);
       return true;
     } catch (err) {
       if (isNetworkError(err)) {

--- a/pwa/src/hooks/use-trip-planner.ts
+++ b/pwa/src/hooks/use-trip-planner.ts
@@ -20,6 +20,7 @@ import {
   scanAccommodations,
   addPoiWaypointToRoute,
   duplicateTrip,
+  launchTripAnalysis,
 } from "@/lib/api/client";
 import { getRandomTripName } from "@/lib/trip-utils";
 import {
@@ -649,6 +650,35 @@ export function useTripPlanner() {
     }
   }
 
+  /**
+   * Fire the Phase 2 analysis pipeline for the currently-loaded trip and
+   * flip the UI store flag so the preview screen makes way for the full
+   * trip view. Errors surface as toasts but the user stays on the preview
+   * screen so they can retry.
+   */
+  async function handleLaunchAnalysis(): Promise<boolean> {
+    if (!tripId) return false;
+
+    try {
+      const ok = await launchTripAnalysis(tripId);
+      if (!ok) {
+        toast.error(t("tripPreview.analysisLaunchFailed"));
+        return false;
+      }
+      useUiStore.getState().setAnalysisStarted(true);
+      setProcessing(true);
+      setAccommodationScanning(true);
+      return true;
+    } catch (err) {
+      if (isNetworkError(err)) {
+        toast.error(t("errors.networkError"));
+      } else {
+        toast.error(t("tripPreview.analysisLaunchFailed"));
+      }
+      return false;
+    }
+  }
+
   async function handleDuplicateTrip(): Promise<string | null> {
     if (!tripId || !trip) return null;
 
@@ -836,6 +866,7 @@ export function useTripPlanner() {
     handleInsertRestDay,
     handleAddPoiWaypoint,
     handleDuplicateTrip,
+    handleLaunchAnalysis,
     handleShareTrip,
     isShareModalOpen,
     setShareModalOpen,

--- a/pwa/src/lib/api/client.ts
+++ b/pwa/src/lib/api/client.ts
@@ -333,6 +333,29 @@ export async function uploadGpxFile(
 }
 
 /**
+ * Trigger the full Phase 2 enrichment pipeline (POIs, weather, terrain, …)
+ * for a trip whose stages have been pre-computed during Phase 1.
+ *
+ * Returns `true` on HTTP 2xx; `false` otherwise.
+ *
+ * Note: until the OpenAPI schema is regenerated (after #322 lands on main),
+ * the `/trips/{id}/analyze` route is not yet exposed via `apiClient.POST`,
+ * so this function talks to the server through the lower-level {@link apiFetch}.
+ * Once the typegen catches up, this can be swapped for
+ * `apiClient.POST("/trips/{id}/analyze", { params: { path: { id } } })`.
+ */
+export async function launchTripAnalysis(tripId: string): Promise<boolean> {
+  const res = await apiFetch(`${API_URL}/trips/${tripId}/analyze`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/ld+json",
+      Accept: "application/ld+json",
+    },
+  });
+  return res.ok;
+}
+
+/**
  * Duplicate an existing trip (deep-clone with all stages and settings).
  * Returns the new trip id on success, null on failure.
  */

--- a/pwa/src/store/ui-store.ts
+++ b/pwa/src/store/ui-store.ts
@@ -56,6 +56,13 @@ interface UiState {
   currentStep: StepId;
   /** Set of steps the user has already completed (enables backwards navigation). */
   completedSteps: Set<StepId>;
+  /**
+   * Whether the user has explicitly launched the Phase 2 analysis via
+   * `POST /trips/{id}/analyze` (Acte 2). Until this is `true`, the UI stays
+   * on the "preview" screen (Acte 1.5) where the user can inspect the raw
+   * route and tweak parameters before committing to the full enrichment.
+   */
+  hasAnalysisStarted: boolean;
 
   setProcessing: (value: boolean) => void;
   setAccommodationScanning: (value: boolean) => void;
@@ -85,6 +92,9 @@ interface UiState {
   completeStep: (step: StepId) => void;
   /** Reset the stepper to "preparation" and clear completed steps (called on `clearTrip`). */
   resetStepper: () => void;
+  /** Flip {@link hasAnalysisStarted}. Called by the preview screen when the user
+   * confirms they want to launch the full enrichment pipeline. */
+  setAnalysisStarted: (value: boolean) => void;
 }
 
 /**
@@ -130,6 +140,7 @@ export const useUiStore = create<UiState>()(
     configPanelFocusSection: null,
     currentStep: "preparation",
     completedSteps: new Set<StepId>(),
+    hasAnalysisStarted: false,
 
     setProcessing: (value) =>
       set((state) => {
@@ -224,6 +235,12 @@ export const useUiStore = create<UiState>()(
       set((state) => {
         state.currentStep = "preparation";
         state.completedSteps = new Set<StepId>();
+        state.hasAnalysisStarted = false;
+      }),
+
+    setAnalysisStarted: (value) =>
+      set((state) => {
+        state.hasAnalysisStarted = value;
       }),
   })),
 );

--- a/pwa/tests/mocked/trip-preview.spec.ts
+++ b/pwa/tests/mocked/trip-preview.spec.ts
@@ -1,0 +1,183 @@
+import { test, expect } from "../fixtures/base.fixture";
+import { routeParsedEvent, stagesComputedEvent } from "../fixtures/mock-data";
+
+/**
+ * Acte 1.5 — Preview screen (issue #321).
+ *
+ * Simulates the two-phase pipeline (ADR-027): after Phase 1 (pacing engine)
+ * completes the frontend sits on the preview screen; the user then clicks
+ * "Lancer l'analyse" to trigger Phase 2 (`POST /trips/{id}/analyze`).
+ *
+ * In tests we simulate Phase 1 completion by injecting `route_parsed` +
+ * `stages_computed` SSE events and then flipping `isProcessing` off via the
+ * dev-only `window.__zustand_ui_store` handle — this is the same mechanism
+ * other mocked specs use to probe gated UI states.
+ */
+async function enterPreviewState(
+  submitUrl: () => Promise<void>,
+  injectEvent: (event: import("../../src/lib/mercure/types").MercureEvent) => Promise<void>,
+  mockedPage: import("@playwright/test").Page,
+): Promise<void> {
+  await submitUrl();
+  await injectEvent(routeParsedEvent());
+  await injectEvent(stagesComputedEvent());
+  // Simulate the Phase 1 → Phase 2 gate: computation has settled but the
+  // user has not yet launched the analysis.
+  await mockedPage.evaluate(() => {
+    const uiStore = (
+      window as Window & {
+        __zustand_ui_store?: {
+          getState: () => {
+            setProcessing: (v: boolean) => void;
+            setAnalysisStarted: (v: boolean) => void;
+          };
+        };
+      }
+    ).__zustand_ui_store;
+    uiStore?.getState().setProcessing(false);
+    uiStore?.getState().setAnalysisStarted(false);
+  });
+  await expect(mockedPage.getByTestId("trip-preview")).toBeVisible({
+    timeout: 5000,
+  });
+}
+
+test.describe("Trip preview — display", () => {
+  test("shows map, stats and stage breakdown after Phase 1 completes", async ({
+    submitUrl,
+    injectEvent,
+    mockedPage,
+  }) => {
+    await enterPreviewState(submitUrl, injectEvent, mockedPage);
+
+    // Map + elevation profile container
+    await expect(mockedPage.getByTestId("trip-preview-map")).toBeVisible();
+
+    // Global stats (reused TripSummary)
+    await expect(mockedPage.getByTestId("total-distance")).toBeVisible();
+    await expect(mockedPage.getByTestId("total-elevation")).toBeVisible();
+
+    // Stage breakdown — 3 stages in the mock fixture
+    await expect(
+      mockedPage.getByTestId("trip-preview-stages-count"),
+    ).toContainText("3");
+    await expect(mockedPage.getByTestId("trip-preview-stage-0")).toBeVisible();
+    await expect(mockedPage.getByTestId("trip-preview-stage-1")).toBeVisible();
+    await expect(mockedPage.getByTestId("trip-preview-stage-2")).toBeVisible();
+  });
+
+  test("stepper shows 'preview' as the active step", async ({
+    submitUrl,
+    injectEvent,
+    mockedPage,
+  }) => {
+    await enterPreviewState(submitUrl, injectEvent, mockedPage);
+    await expect(
+      mockedPage.getByTestId("stepper-step-preview"),
+    ).toHaveAttribute("aria-current", "step", { timeout: 5000 });
+  });
+});
+
+test.describe("Trip preview — actions", () => {
+  test("'Lancer l'analyse' calls POST /trips/{id}/analyze and moves to Acte 2", async ({
+    submitUrl,
+    injectEvent,
+    mockedPage,
+  }) => {
+    let analyzeRequested = false;
+    await mockedPage.route("**/trips/*/analyze", (route, request) => {
+      if (request.method() !== "POST") return route.fallback();
+      analyzeRequested = true;
+      return route.fulfill({
+        status: 202,
+        contentType: "application/ld+json",
+        body: JSON.stringify({ "@type": "Trip" }),
+      });
+    });
+
+    await enterPreviewState(submitUrl, injectEvent, mockedPage);
+    await mockedPage
+      .getByTestId("trip-preview-launch-analysis")
+      .click();
+
+    // Request was issued
+    await expect
+      .poll(() => analyzeRequested, { timeout: 5000 })
+      .toBe(true);
+
+    // Preview disappears and stepper advances to "analysis"
+    await expect(mockedPage.getByTestId("trip-preview")).toBeHidden({
+      timeout: 5000,
+    });
+    await expect(
+      mockedPage.getByTestId("stepper-step-analysis"),
+    ).toHaveAttribute("aria-current", "step", { timeout: 5000 });
+  });
+
+  test("'Modifier les paramètres' opens the ConfigPanel sidebar", async ({
+    submitUrl,
+    injectEvent,
+    mockedPage,
+  }) => {
+    await enterPreviewState(submitUrl, injectEvent, mockedPage);
+
+    await mockedPage
+      .getByTestId("trip-preview-modify-parameters")
+      .click();
+
+    // ConfigPanel is a dialog — its title appears when the panel slides in.
+    await expect(
+      mockedPage.getByRole("dialog", { name: /paramètres|settings/i }),
+    ).toBeVisible({ timeout: 5000 });
+  });
+
+  test("'Changer d'itinéraire' resets the trip and returns to Acte 1", async ({
+    submitUrl,
+    injectEvent,
+    mockedPage,
+  }) => {
+    await enterPreviewState(submitUrl, injectEvent, mockedPage);
+
+    await mockedPage.getByTestId("trip-preview-change-route").click();
+
+    // Back to the welcome screen (card selection is rendered)
+    await expect(mockedPage.getByTestId("card-selection")).toBeVisible({
+      timeout: 5000,
+    });
+    // And the stepper rewinds to "preparation"
+    await expect(
+      mockedPage.getByTestId("stepper-step-preparation"),
+    ).toHaveAttribute("aria-current", "step", { timeout: 5000 });
+  });
+
+  test("'Lancer l'analyse' surfaces a toast when the request fails", async ({
+    submitUrl,
+    injectEvent,
+    mockedPage,
+  }) => {
+    await mockedPage.route("**/trips/*/analyze", (route, request) => {
+      if (request.method() !== "POST") return route.fallback();
+      return route.fulfill({
+        status: 500,
+        contentType: "application/ld+json",
+        body: JSON.stringify({
+          "@type": "hydra:Error",
+          "hydra:title": "Server Error",
+        }),
+      });
+    });
+
+    await enterPreviewState(submitUrl, injectEvent, mockedPage);
+    await mockedPage
+      .getByTestId("trip-preview-launch-analysis")
+      .click();
+
+    // An error toast surfaces and the user stays on the preview screen
+    await expect(
+      mockedPage.getByText(
+        /impossible de lancer l'analyse|failed to launch analysis/i,
+      ),
+    ).toBeVisible({ timeout: 5000 });
+    await expect(mockedPage.getByTestId("trip-preview")).toBeVisible();
+  });
+});

--- a/pwa/tests/mocked/trip-preview.spec.ts
+++ b/pwa/tests/mocked/trip-preview.spec.ts
@@ -169,4 +169,21 @@ test.describe("Trip preview — actions", () => {
     ).toBeVisible({ timeout: 5000 });
     await expect(mockedPage.getByTestId("trip-preview")).toBeVisible();
   });
+
+  test("close button resets the trip and returns to Acte 1", async ({
+    submitUrl,
+    injectEvent,
+    mockedPage,
+  }) => {
+    await enterPreviewState(submitUrl, injectEvent, mockedPage);
+
+    await mockedPage.getByTestId("close-trip-button-preview").click();
+
+    await expect(mockedPage.getByTestId("card-selection")).toBeVisible({
+      timeout: 5000,
+    });
+    await expect(
+      mockedPage.getByTestId("stepper-step-preparation"),
+    ).toHaveAttribute("aria-current", "step", { timeout: 5000 });
+  });
 });

--- a/pwa/tests/mocked/trip-preview.spec.ts
+++ b/pwa/tests/mocked/trip-preview.spec.ts
@@ -8,10 +8,11 @@ import { routeParsedEvent, stagesComputedEvent } from "../fixtures/mock-data";
  * completes the frontend sits on the preview screen; the user then clicks
  * "Lancer l'analyse" to trigger Phase 2 (`POST /trips/{id}/analyze`).
  *
- * In tests we simulate Phase 1 completion by injecting `route_parsed` +
- * `stages_computed` SSE events and then flipping `isProcessing` off via the
- * dev-only `window.__zustand_ui_store` handle — this is the same mechanism
- * other mocked specs use to probe gated UI states.
+ * Phase 1 completion is simulated with `route_parsed` + `stages_computed`
+ * SSE events; the processing/analysisStarted flags are flipped via the
+ * `__test_set_processing` / `__test_set_analysis_started` CustomEvents
+ * wired into TripPlanner (these work in prod builds where the dev-only
+ * `window.__zustand_ui_store` handle is stripped by NODE_ENV).
  */
 async function enterPreviewState(
   submitUrl: () => Promise<void>,
@@ -26,18 +27,12 @@ async function enterPreviewState(
   // Simulate the Phase 1 → Phase 2 gate: computation has settled but the
   // user has not yet launched the analysis.
   await mockedPage.evaluate(() => {
-    const uiStore = (
-      window as Window & {
-        __zustand_ui_store?: {
-          getState: () => {
-            setProcessing: (v: boolean) => void;
-            setAnalysisStarted: (v: boolean) => void;
-          };
-        };
-      }
-    ).__zustand_ui_store;
-    uiStore?.getState().setProcessing(false);
-    uiStore?.getState().setAnalysisStarted(false);
+    window.dispatchEvent(
+      new CustomEvent("__test_set_processing", { detail: false }),
+    );
+    window.dispatchEvent(
+      new CustomEvent("__test_set_analysis_started", { detail: false }),
+    );
   });
   await expect(mockedPage.getByTestId("trip-preview")).toBeVisible({
     timeout: 5000,

--- a/pwa/tests/mocked/trip-preview.spec.ts
+++ b/pwa/tests/mocked/trip-preview.spec.ts
@@ -15,7 +15,9 @@ import { routeParsedEvent, stagesComputedEvent } from "../fixtures/mock-data";
  */
 async function enterPreviewState(
   submitUrl: () => Promise<void>,
-  injectEvent: (event: import("../../src/lib/mercure/types").MercureEvent) => Promise<void>,
+  injectEvent: (
+    event: import("../../src/lib/mercure/types").MercureEvent,
+  ) => Promise<void>,
   mockedPage: import("@playwright/test").Page,
 ): Promise<void> {
   await submitUrl();
@@ -96,14 +98,10 @@ test.describe("Trip preview — actions", () => {
     });
 
     await enterPreviewState(submitUrl, injectEvent, mockedPage);
-    await mockedPage
-      .getByTestId("trip-preview-launch-analysis")
-      .click();
+    await mockedPage.getByTestId("trip-preview-launch-analysis").click();
 
     // Request was issued
-    await expect
-      .poll(() => analyzeRequested, { timeout: 5000 })
-      .toBe(true);
+    await expect.poll(() => analyzeRequested, { timeout: 5000 }).toBe(true);
 
     // Preview disappears and stepper advances to "analysis"
     await expect(mockedPage.getByTestId("trip-preview")).toBeHidden({
@@ -121,9 +119,7 @@ test.describe("Trip preview — actions", () => {
   }) => {
     await enterPreviewState(submitUrl, injectEvent, mockedPage);
 
-    await mockedPage
-      .getByTestId("trip-preview-modify-parameters")
-      .click();
+    await mockedPage.getByTestId("trip-preview-modify-parameters").click();
 
     // ConfigPanel is a dialog — its title appears when the panel slides in.
     await expect(
@@ -168,9 +164,7 @@ test.describe("Trip preview — actions", () => {
     });
 
     await enterPreviewState(submitUrl, injectEvent, mockedPage);
-    await mockedPage
-      .getByTestId("trip-preview-launch-analysis")
-      .click();
+    await mockedPage.getByTestId("trip-preview-launch-analysis").click();
 
     // An error toast surfaces and the user stays on the preview screen
     await expect(


### PR DESCRIPTION
## Summary

- New `TripPreview` component (Acte 1.5) displayed after route import and before analysis
- Shows: zoomable map with stage markers, elevation profile, global stats (distance/D+/D-/stages), per-stage breakdown
- Three CTAs: "Lancer l'analyse" → `POST /trips/{id}/analyze`, "Modifier les paramètres" → side config panel, "Changer d'itinéraire" → back to Acte 1
- Reuses existing `MapView`, `ElevationProfile`, `ConfigPanel` — no duplication
- `hasAnalysisStarted` flag added to `ui-store` to gate the preview vs. processing view
- `launchTripAnalysis()` API helper in `client.ts` calling `/trips/{id}/analyze` (will use typed schema after #322 merges and typegen runs)
- i18n keys added to `fr.json` / `en.json` (`tripPreview` namespace)
- 6 Playwright mocked tests in `trip-preview.spec.ts`

## Auto-critique

- The `/analyze` call uses `apiFetch` directly (commented for swap to typed client after #322 typegen)
- `hasAnalysisStarted` flag reset when changing route to avoid stale state

> ⚠️ This PR is stacked on #367 (feature/320). Please merge #367 first.

Closes #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

All previous findings have been addressed. The last remaining open thread — `setAnalysisStarted(true)` ordering race in `use-mercure.ts` — is fixed by commit `fix(use-mercure): set hasAnalysisStarted before clearing processing`, which now calls `setAnalysisStarted(true)` before `setProcessing(false)`. No new issues found.

**Findings**: 0 · Resolved 1 previously open thread · Commit reviewed: `7d182c5a`

### PR title check

`feat(trip-planner): add preview screen before analysis` — conforms to Conventional Commits ✓

### Resolved threads

Resolved 1 previously open bot thread (`use-mercure.ts` `setAnalysisStarted`/`setProcessing` ordering race — now fixed).

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [ ] Dependent tickets accounted for (stacked on #367 — merge that first)

### Inline comments

No inline comments.

---
Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->