### PR TITLE
fix(database): update postgres volume mount path for PostgreSQL 18

### DIFF
--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -185,7 +185,7 @@ services:
       POSTGRES_USER: "${DATABASE_USERNAME:-app}"
       POSTGRES_PASSWORD: "${DATABASE_PASSWORD:-!ChangeMe!}"
     volumes:
-      - database_data:/var/lib/postgresql/data
+      - database_data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}"]
       interval: 10s

--- a/compose.yaml
+++ b/compose.yaml
@@ -188,7 +188,7 @@ services:
       POSTGRES_USER: "${DATABASE_USERNAME:-app}"
       POSTGRES_PASSWORD: "${DATABASE_PASSWORD:-!ChangeMe!}"
     volumes:
-      - database_data:/var/lib/postgresql/data
+      - database_data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}"]
       interval: 10s


### PR DESCRIPTION
## Summary

- PostgreSQL 18 changed `PGDATA` from `/var/lib/postgresql/data` to `/var/lib/postgresql/18/docker` (see [docker-library/postgres#1259](https://github.com/docker-library/postgres/pull/1259))
- The `VOLUME` declaration also moved from `/var/lib/postgresql/data` to `/var/lib/postgresql`
- Both `compose.yaml` and `compose.prod.yaml` were mounting the `database_data` named volume at the old path, causing the named volume to be unused and data to go into an anonymous volume — breaking CI

## Test plan

- [ ] CI passes (PHPUnit and Playwright jobs)
- [ ] Local: `docker compose up database` starts without errors and `pg_isready` returns healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

**Findings:** 0 critical · 0 warnings · 0 suggestions

**Commit reviewed:** `bf3ebb8b55f6c99dba0916a18c9db377ba3ed94a`

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

No inline comments.

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->