### PR TITLE
feat(pwa): add collapsible stage alerts for Acte 3 (#325)

### DIFF
--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -358,6 +358,12 @@
         "label": "AI Analysis",
         "description": "Narrative trip summary"
       }
+    },
+    "statusLabels": {
+      "done": "done",
+      "inProgress": "in progress",
+      "failed": "failed",
+      "pending": "pending"
     }
   },
   "cardSelection": {

--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -328,6 +328,38 @@
     "myTrip": "My Trip",
     "mobileLabel": "Step {current}/{total} — {stepName}"
   },
+  "processingProgress": {
+    "subtitle": "Analysis in progress… this may take a few minutes.",
+    "progressLabel": "Overall progress",
+    "progressPercent": "{percent}%",
+    "failureMessage": "Failed: {message}",
+    "categories": {
+      "terrain_security": {
+        "label": "Terrain & Safety",
+        "description": "Surface, traffic, slopes, continuity"
+      },
+      "supply": {
+        "label": "Supply",
+        "description": "Water points, shops"
+      },
+      "accommodations": {
+        "label": "Accommodations",
+        "description": "Campings, lodges, hotels"
+      },
+      "weather": {
+        "label": "Weather & Conditions",
+        "description": "Forecasts, wind, sunset"
+      },
+      "services": {
+        "label": "Services",
+        "description": "Bike shops, repair"
+      },
+      "ai": {
+        "label": "AI Analysis",
+        "description": "Narrative trip summary"
+      }
+    }
+  },
   "cardSelection": {
     "heading": "How would you like to start?",
     "linkTitle": "Link",

--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -244,6 +244,11 @@
     "navigateToCrossing": "Navigate to crossing",
     "free": "Free admission"
   },
+  "stageAlerts": {
+    "title": "{count, plural, one {# alert} other {# alerts}}",
+    "showMore": "Show {count} more {count, plural, one {alert} other {alerts}}",
+    "showLess": "Show fewer alerts"
+  },
   "onboarding": {
     "nextBtn": "Next",
     "prevBtn": "Back",

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -328,6 +328,38 @@
     "myTrip": "Mon voyage",
     "mobileLabel": "Étape {current}/{total} — {stepName}"
   },
+  "processingProgress": {
+    "subtitle": "Analyse en cours… cela peut prendre quelques minutes.",
+    "progressLabel": "Progression globale",
+    "progressPercent": "{percent}%",
+    "failureMessage": "Échec : {message}",
+    "categories": {
+      "terrain_security": {
+        "label": "Terrain & Sécurité",
+        "description": "Surface, trafic, pentes, continuité"
+      },
+      "supply": {
+        "label": "Ravitaillement",
+        "description": "Points d'eau, commerces"
+      },
+      "accommodations": {
+        "label": "Hébergements",
+        "description": "Campings, gîtes, hôtels"
+      },
+      "weather": {
+        "label": "Météo & Conditions",
+        "description": "Prévisions, vent, coucher de soleil"
+      },
+      "services": {
+        "label": "Services",
+        "description": "Magasins vélo, réparateurs"
+      },
+      "ai": {
+        "label": "Analyse IA",
+        "description": "Synthèse narrative du voyage"
+      }
+    }
+  },
   "cardSelection": {
     "heading": "Comment souhaitez-vous commencer ?",
     "linkTitle": "Lien",

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -358,6 +358,12 @@
         "label": "Analyse IA",
         "description": "Synthèse narrative du voyage"
       }
+    },
+    "statusLabels": {
+      "done": "terminé",
+      "inProgress": "en cours",
+      "failed": "échec",
+      "pending": "en attente"
     }
   },
   "cardSelection": {

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -244,6 +244,11 @@
     "navigateToCrossing": "Aller au passage frontière",
     "free": "Entrée gratuite"
   },
+  "stageAlerts": {
+    "title": "{count, plural, one {# alerte} other {# alertes}}",
+    "showMore": "Voir {count} {count, plural, one {autre alerte} other {autres alertes}}",
+    "showLess": "Voir moins d'alertes"
+  },
   "onboarding": {
     "nextBtn": "Suivant",
     "prevBtn": "Précédent",

--- a/pwa/src/components/alert-list.tsx
+++ b/pwa/src/components/alert-list.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback } from "react";
 import { AlertBadge } from "@/components/alert-badge";
 import type { AlertData } from "@/lib/validation/schemas";
 import { Button } from "@/components/ui/button";
+import { sortBySeverity } from "@/lib/alert-utils";
 import {
   MapPin,
   Wrench,
@@ -10,8 +11,6 @@ import {
   Check,
 } from "lucide-react";
 import { useTranslations } from "next-intl";
-
-const severityOrder = { critical: 0, warning: 1, nudge: 2 } as const;
 
 const actionIcons = {
   auto_fix: Wrench,
@@ -43,9 +42,7 @@ export function AlertList({ alerts, onAddPoiWaypoint }: AlertListProps) {
 
   if (alerts.length === 0) return null;
 
-  const sorted = [...alerts].sort(
-    (a, b) => (severityOrder[a.type] ?? 2) - (severityOrder[b.type] ?? 2),
-  );
+  const sorted = sortBySeverity(alerts);
 
   return (
     <div className="flex flex-col gap-2">

--- a/pwa/src/components/processing-progress.tsx
+++ b/pwa/src/components/processing-progress.tsx
@@ -276,11 +276,12 @@ export function ProcessingProgress({
 }
 
 function StatusIndicator({ status }: { status: AggregatedStatus }) {
+  const t = useTranslations("processingProgress");
   switch (status) {
     case "done":
       return (
         <span
-          aria-label="done"
+          aria-label={t("statusLabels.done")}
           data-testid="status-done"
           className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-brand text-white"
         >
@@ -290,7 +291,7 @@ function StatusIndicator({ status }: { status: AggregatedStatus }) {
     case "in_progress":
       return (
         <span
-          aria-label="in progress"
+          aria-label={t("statusLabels.inProgress")}
           data-testid="status-in-progress"
           className="inline-flex h-5 w-5 items-center justify-center text-brand"
         >
@@ -300,7 +301,7 @@ function StatusIndicator({ status }: { status: AggregatedStatus }) {
     case "failed":
       return (
         <span
-          aria-label="failed"
+          aria-label={t("statusLabels.failed")}
           data-testid="status-failed"
           className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-destructive/10 text-destructive"
         >
@@ -311,7 +312,7 @@ function StatusIndicator({ status }: { status: AggregatedStatus }) {
     default:
       return (
         <span
-          aria-label="pending"
+          aria-label={t("statusLabels.pending")}
           data-testid="status-pending"
           className="inline-flex h-5 w-5 items-center justify-center rounded-full border border-muted-foreground/30 text-muted-foreground/50"
         >

--- a/pwa/src/components/processing-progress.tsx
+++ b/pwa/src/components/processing-progress.tsx
@@ -1,0 +1,322 @@
+"use client";
+
+import { useMemo } from "react";
+import { useTranslations } from "next-intl";
+import { Check, Loader2, AlertTriangle } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useUiStore } from "@/store/ui-store";
+import { TripHeader } from "@/components/trip-header";
+
+type CategoryKey =
+  | "terrain_security"
+  | "supply"
+  | "accommodations"
+  | "weather"
+  | "services"
+  | "ai";
+
+interface CategoryDefinition {
+  /** Translation key under `processingProgress.categories`. */
+  translationKey: CategoryKey;
+  icon: string;
+  /**
+   * Backend `ComputationName::value` identifiers that drive this narrative
+   * category. A category is "done" once every listed step has been seen
+   * in a `computation_step_completed` event. See issue #323 for the
+   * handler → category mapping and `ComputationName` on the backend.
+   */
+  steps: string[];
+  /**
+   * When true, the category is hidden from the UI until at least one of
+   * its steps has been reported. Used for the optional AI category: when
+   * Ollama is disabled no `ai_*` events arrive, and the row stays hidden.
+   */
+  optional?: boolean;
+}
+
+/**
+ * Narrative categories displayed to the user during Acte 2. Each row is
+ * backed by one or more backend computation steps. Order matches the
+ * visual order on screen (per issue #323).
+ */
+const CATEGORIES: { key: CategoryKey; def: CategoryDefinition }[] = [
+  {
+    key: "terrain_security",
+    def: {
+      translationKey: "terrain_security",
+      icon: "🛣️",
+      // ScanAllOsmData (osm_scan) + AnalyzeTerrain (terrain)
+      steps: ["osm_scan", "terrain"],
+    },
+  },
+  {
+    key: "supply",
+    def: {
+      translationKey: "supply",
+      icon: "💧",
+      // CheckWaterPoints (water_points) + ScanPois (pois)
+      steps: ["water_points", "pois"],
+    },
+  },
+  {
+    key: "accommodations",
+    def: {
+      translationKey: "accommodations",
+      icon: "🏕️",
+      // ScanAccommodations
+      steps: ["accommodations"],
+    },
+  },
+  {
+    key: "weather",
+    def: {
+      translationKey: "weather",
+      icon: "🌤️",
+      // FetchWeather + AnalyzeWind + CheckCalendar
+      steps: ["weather", "wind", "calendar"],
+    },
+  },
+  {
+    key: "services",
+    def: {
+      translationKey: "services",
+      icon: "🔧",
+      // CheckBikeShops
+      steps: ["bike_shops"],
+    },
+  },
+  {
+    key: "ai",
+    def: {
+      translationKey: "ai",
+      icon: "🤖",
+      // AnalyzeStageWithLlm + AnalyzeTripOverviewWithLlm (Ollama-only)
+      steps: ["ai_stage", "ai_overview"],
+      optional: true,
+    },
+  },
+];
+
+type AggregatedStatus = "pending" | "in_progress" | "done" | "failed";
+
+interface ProcessingProgressProps {
+  title: string;
+  onTitleChange: (title: string) => void;
+}
+
+/**
+ * Acte 2 — narrative progress screen.
+ *
+ * Shown during Phase 2 (initial enrichment). Displays a checklist of
+ * user-facing categories (terrain, supply, accommodations, weather,
+ * services, optional AI) each backed by one or more Messenger handlers
+ * on the backend. Rows transition through
+ *   pending ○ → in progress (spinner) → done ✓ | failed ⚠
+ * as `computation_step_completed` (and `computation_error`) Mercure events
+ * arrive. A global percentage bar sits at the bottom.
+ *
+ * Rules:
+ * - The only interactive affordance is the trip title. Every other action
+ *   is intentionally omitted to keep the user focused while the backend
+ *   is crunching through the pipeline (issue #323).
+ * - The optional AI row is only rendered once at least one `ai_*` step
+ *   has been seen — so when Ollama is disabled, the row stays hidden.
+ * - `trip_ready` flips `isProcessing` to `false`, which is the trigger
+ *   for the parent component to fade this screen out toward Acte 3.
+ */
+export function ProcessingProgress({
+  title,
+  onTitleChange,
+}: ProcessingProgressProps) {
+  const t = useTranslations("processingProgress");
+  const analysisProgress = useUiStore((s) => s.analysisProgress);
+  const stepStates = useUiStore((s) => s.analysisStepStates);
+  const currentStep = analysisProgress?.step ?? null;
+
+  const rows = useMemo(
+    () =>
+      CATEGORIES.map(({ key, def }) => {
+        const statuses = def.steps.map(
+          (step) => stepStates[step]?.status ?? "pending",
+        );
+        const errors = def.steps
+          .map((step) => stepStates[step]?.error)
+          .filter((e): e is string => !!e);
+
+        let status: AggregatedStatus;
+        if (statuses.includes("failed")) {
+          status = "failed";
+        } else if (statuses.every((s) => s === "done")) {
+          status = "done";
+        } else if (
+          statuses.some((s) => s === "done") ||
+          (currentStep !== null && def.steps.includes(currentStep))
+        ) {
+          // Either we already collected some results for this category or
+          // the in-flight step belongs to it — highlight it as in progress.
+          status = "in_progress";
+        } else {
+          status = "pending";
+        }
+
+        const hidden =
+          def.optional &&
+          statuses.every((s) => s === "pending") &&
+          !(currentStep !== null && def.steps.includes(currentStep));
+
+        return { key, def, status, error: errors[0] ?? null, hidden };
+      }),
+    [stepStates, currentStep],
+  );
+
+  const percent = analysisProgress
+    ? Math.min(
+        100,
+        Math.max(
+          0,
+          Math.round(
+            (analysisProgress.completed / Math.max(1, analysisProgress.total)) *
+              100,
+          ),
+        ),
+      )
+    : 0;
+
+  return (
+    <section
+      className="min-h-[60vh] flex flex-col items-center justify-center py-8 animate-in fade-in duration-300"
+      data-testid="processing-progress"
+      aria-live="polite"
+      aria-busy="true"
+    >
+      <div className="w-full max-w-2xl space-y-6">
+        {/* Editable title — the only affordance the user retains during
+            the system step (see issue #323). */}
+        <div className="text-center">
+          <TripHeader title={title} onTitleChange={onTitleChange} />
+          <p className="mt-2 text-sm text-muted-foreground">{t("subtitle")}</p>
+        </div>
+
+        {/* Category checklist (boxed, per the design spec) */}
+        <div
+          className="rounded-xl border bg-card p-4 md:p-6 shadow-sm"
+          data-testid="processing-progress-box"
+        >
+          <ul className="space-y-3">
+            {rows.map(({ key, def, status, error, hidden }) => {
+              if (hidden) return null;
+              return (
+                <li
+                  key={key}
+                  data-testid={`processing-category-${key}`}
+                  data-status={status}
+                  className={cn(
+                    "flex items-start gap-3 rounded-lg px-3 py-2 transition-colors",
+                    status === "in_progress" && "bg-brand/5",
+                    status === "failed" && "bg-destructive/5",
+                  )}
+                >
+                  <span
+                    aria-hidden="true"
+                    className="text-2xl leading-none shrink-0"
+                  >
+                    {def.icon}
+                  </span>
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="font-semibold text-sm md:text-base">
+                        {t(`categories.${def.translationKey}.label`)}
+                      </span>
+                      <StatusIndicator status={status} />
+                    </div>
+                    <p className="text-xs md:text-sm text-muted-foreground">
+                      {t(`categories.${def.translationKey}.description`)}
+                    </p>
+                    {status === "failed" && error && (
+                      <p
+                        className="mt-1 text-xs text-destructive"
+                        data-testid={`processing-category-${key}-error`}
+                      >
+                        {t("failureMessage", { message: error })}
+                      </p>
+                    )}
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+
+          {/* Global progress bar */}
+          <div className="mt-6">
+            <div
+              className="h-2 w-full rounded-full bg-muted overflow-hidden"
+              role="progressbar"
+              aria-valuenow={percent}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-label={t("progressLabel")}
+            >
+              <div
+                data-testid="processing-progress-bar"
+                className="h-full bg-brand transition-all duration-300"
+                style={{ width: `${percent}%` }}
+              />
+            </div>
+            <p
+              className="mt-2 text-xs text-muted-foreground text-right"
+              data-testid="processing-progress-percent"
+            >
+              {t("progressPercent", { percent })}
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function StatusIndicator({ status }: { status: AggregatedStatus }) {
+  switch (status) {
+    case "done":
+      return (
+        <span
+          aria-label="done"
+          data-testid="status-done"
+          className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-brand text-white"
+        >
+          <Check className="h-3 w-3" aria-hidden="true" />
+        </span>
+      );
+    case "in_progress":
+      return (
+        <span
+          aria-label="in progress"
+          data-testid="status-in-progress"
+          className="inline-flex h-5 w-5 items-center justify-center text-brand"
+        >
+          <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+        </span>
+      );
+    case "failed":
+      return (
+        <span
+          aria-label="failed"
+          data-testid="status-failed"
+          className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-destructive/10 text-destructive"
+        >
+          <AlertTriangle className="h-3 w-3" aria-hidden="true" />
+        </span>
+      );
+    case "pending":
+    default:
+      return (
+        <span
+          aria-label="pending"
+          data-testid="status-pending"
+          className="inline-flex h-5 w-5 items-center justify-center rounded-full border border-muted-foreground/30 text-muted-foreground/50"
+        >
+          <span className="h-2 w-2 rounded-full bg-muted-foreground/30" />
+        </span>
+      );
+  }
+}

--- a/pwa/src/components/stage-alerts.tsx
+++ b/pwa/src/components/stage-alerts.tsx
@@ -38,11 +38,11 @@ export function StageAlerts({ alerts, onAddPoiWaypoint }: StageAlertsProps) {
   const toggleExpanded = useCallback(() => setExpanded((prev) => !prev), []);
   const toggleShowAll = useCallback(() => setShowAll((prev) => !prev), []);
 
-  if (alerts.length === 0) return null;
-
   const sorted = useMemo(() => sortBySeverity(alerts), [alerts]);
   const visible = showAll ? sorted : sorted.slice(0, INITIAL_VISIBLE_COUNT);
   const hiddenCount = sorted.length - INITIAL_VISIBLE_COUNT;
+
+  if (alerts.length === 0) return null;
 
   return (
     <div data-testid="stage-alerts">

--- a/pwa/src/components/stage-alerts.tsx
+++ b/pwa/src/components/stage-alerts.tsx
@@ -5,17 +5,10 @@ import { ChevronDown, ChevronUp } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { AlertList } from "@/components/alert-list";
 import { Button } from "@/components/ui/button";
+import { sortBySeverity } from "@/lib/alert-utils";
 import type { AlertData } from "@/lib/validation/schemas";
 
 const INITIAL_VISIBLE_COUNT = 3;
-
-const severityOrder = { critical: 0, warning: 1, nudge: 2 } as const;
-
-function sortBySeverity(alerts: AlertData[]): AlertData[] {
-  return [...alerts].sort(
-    (a, b) => (severityOrder[a.type] ?? 2) - (severityOrder[b.type] ?? 2),
-  );
-}
 
 interface StageAlertsProps {
   alerts: AlertData[];

--- a/pwa/src/components/stage-alerts.tsx
+++ b/pwa/src/components/stage-alerts.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { ChevronDown, ChevronUp } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { AlertList } from "@/components/alert-list";
+import { Button } from "@/components/ui/button";
+import type { AlertData } from "@/lib/validation/schemas";
+
+const INITIAL_VISIBLE_COUNT = 3;
+
+const severityOrder = { critical: 0, warning: 1, nudge: 2 } as const;
+
+function sortBySeverity(alerts: AlertData[]): AlertData[] {
+  return [...alerts].sort(
+    (a, b) => (severityOrder[a.type] ?? 2) - (severityOrder[b.type] ?? 2),
+  );
+}
+
+interface StageAlertsProps {
+  alerts: AlertData[];
+  onAddPoiWaypoint?: (poiLat: number, poiLon: number) => void;
+}
+
+/**
+ * Collapsible, severity-sorted, paginated alert section for a stage.
+ *
+ * - Sorted by severity: critical → warning → nudge.
+ * - First 3 alerts visible by default; a "Show N more" button reveals the rest.
+ * - The entire section is collapsible via a header toggle (▼/▲).
+ * - Starts expanded (no AI summary at this stage to justify collapsing).
+ */
+export function StageAlerts({ alerts, onAddPoiWaypoint }: StageAlertsProps) {
+  const t = useTranslations("stageAlerts");
+  const [expanded, setExpanded] = useState(true);
+  const [showAll, setShowAll] = useState(false);
+
+  const toggleExpanded = useCallback(
+    () => setExpanded((prev) => !prev),
+    [],
+  );
+  const toggleShowAll = useCallback(() => setShowAll((prev) => !prev), []);
+
+  if (alerts.length === 0) return null;
+
+  const sorted = sortBySeverity(alerts);
+  const visible = showAll ? sorted : sorted.slice(0, INITIAL_VISIBLE_COUNT);
+  const hiddenCount = sorted.length - INITIAL_VISIBLE_COUNT;
+
+  return (
+    <div data-testid="stage-alerts">
+      {/* Section header */}
+      <button
+        type="button"
+        className="flex w-full items-center justify-between gap-2 py-1 text-sm font-medium text-foreground hover:text-foreground/80 transition-colors"
+        onClick={toggleExpanded}
+        aria-expanded={expanded}
+        data-testid="stage-alerts-toggle"
+      >
+        <span data-testid="stage-alerts-count">
+          {t("title", { count: alerts.length })}
+        </span>
+        {expanded ? (
+          <ChevronUp className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+        ) : (
+          <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+        )}
+      </button>
+
+      {/* Collapsible body */}
+      {expanded && (
+        <div className="mt-2 space-y-1" data-testid="stage-alerts-body">
+          <AlertList alerts={visible} onAddPoiWaypoint={onAddPoiWaypoint} />
+
+          {/* "Show N more" / "Show less" pagination */}
+          {hiddenCount > 0 && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="mt-1 h-7 px-2 text-xs text-muted-foreground hover:text-foreground"
+              onClick={toggleShowAll}
+              data-testid="stage-alerts-show-more"
+            >
+              {showAll
+                ? t("showLess")
+                : t("showMore", { count: hiddenCount })}
+            </Button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/pwa/src/components/stage-alerts.tsx
+++ b/pwa/src/components/stage-alerts.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useMemo } from "react";
 import { ChevronDown, ChevronUp } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { AlertList } from "@/components/alert-list";
@@ -40,7 +40,7 @@ export function StageAlerts({ alerts, onAddPoiWaypoint }: StageAlertsProps) {
 
   if (alerts.length === 0) return null;
 
-  const sorted = sortBySeverity(alerts);
+  const sorted = useMemo(() => sortBySeverity(alerts), [alerts]);
   const visible = showAll ? sorted : sorted.slice(0, INITIAL_VISIBLE_COUNT);
   const hiddenCount = sorted.length - INITIAL_VISIBLE_COUNT;
 

--- a/pwa/src/components/stage-alerts.tsx
+++ b/pwa/src/components/stage-alerts.tsx
@@ -35,10 +35,7 @@ export function StageAlerts({ alerts, onAddPoiWaypoint }: StageAlertsProps) {
   const [expanded, setExpanded] = useState(true);
   const [showAll, setShowAll] = useState(false);
 
-  const toggleExpanded = useCallback(
-    () => setExpanded((prev) => !prev),
-    [],
-  );
+  const toggleExpanded = useCallback(() => setExpanded((prev) => !prev), []);
   const toggleShowAll = useCallback(() => setShowAll((prev) => !prev), []);
 
   if (alerts.length === 0) return null;
@@ -61,9 +58,15 @@ export function StageAlerts({ alerts, onAddPoiWaypoint }: StageAlertsProps) {
           {t("title", { count: alerts.length })}
         </span>
         {expanded ? (
-          <ChevronUp className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+          <ChevronUp
+            className="h-4 w-4 shrink-0 text-muted-foreground"
+            aria-hidden="true"
+          />
         ) : (
-          <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+          <ChevronDown
+            className="h-4 w-4 shrink-0 text-muted-foreground"
+            aria-hidden="true"
+          />
         )}
       </button>
 
@@ -81,9 +84,7 @@ export function StageAlerts({ alerts, onAddPoiWaypoint }: StageAlertsProps) {
               onClick={toggleShowAll}
               data-testid="stage-alerts-show-more"
             >
-              {showAll
-                ? t("showLess")
-                : t("showMore", { count: hiddenCount })}
+              {showAll ? t("showLess") : t("showMore", { count: hiddenCount })}
             </Button>
           )}
         </div>

--- a/pwa/src/components/stage-card.tsx
+++ b/pwa/src/components/stage-card.tsx
@@ -8,7 +8,7 @@ import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { StageLocations } from "@/components/stage-locations";
 import { StageMetadata } from "@/components/stage-metadata";
-import { AlertList } from "@/components/alert-list";
+import { StageAlerts } from "@/components/stage-alerts";
 import { AccommodationPanel } from "@/components/accommodation-panel";
 import { EventsPanel } from "@/components/events-panel";
 import { StageDownloads } from "@/components/stage-downloads";
@@ -189,7 +189,7 @@ export function StageCard({
         {/* Alerts */}
         {stage.alerts.length > 0 && (
           <div className="mt-3">
-            <AlertList
+            <StageAlerts
               alerts={stage.alerts}
               onAddPoiWaypoint={onAddPoiWaypoint}
             />

--- a/pwa/src/components/trip-planner.tsx
+++ b/pwa/src/components/trip-planner.tsx
@@ -107,6 +107,7 @@ export function TripPlanner({ onClose }: { onClose?: () => void } = {}) {
   const completeStep = useUiStore((s) => s.completeStep);
   const resetStepper = useUiStore((s) => s.resetStepper);
   const hasAnalysisStarted = useUiStore((s) => s.hasAnalysisStarted);
+  const isAnalysisPhaseActive = useUiStore((s) => s.isAnalysisPhaseActive);
   const activeStages = useMemo(
     () => stages.filter((s) => !s.isRestDay),
     [stages],
@@ -166,9 +167,9 @@ export function TripPlanner({ onClose }: { onClose?: () => void } = {}) {
       useUiStore.getState().setProcessing(!!(e as CustomEvent<boolean>).detail);
     };
     const onAnalysisStarted = (e: Event) => {
-      useUiStore
-        .getState()
-        .setAnalysisStarted(!!(e as CustomEvent<boolean>).detail);
+      const value = !!(e as CustomEvent<boolean>).detail;
+      useUiStore.getState().setAnalysisStarted(value);
+      useUiStore.getState().setAnalysisPhaseActive(value);
     };
     window.addEventListener("__test_set_processing", onProcessing);
     window.addEventListener("__test_set_analysis_started", onAnalysisStarted);
@@ -319,17 +320,18 @@ export function TripPlanner({ onClose }: { onClose?: () => void } = {}) {
   const isLoading = !trip && isProcessing;
   const isPreview =
     !!trip && !isProcessing && activeStages.length > 0 && !hasAnalysisStarted;
-  // Acte 2 — narrative progress screen. Active once the user has explicitly
-  // launched the Phase 2 enrichment (`hasAnalysisStarted`) and the backend
-  // is still crunching (`isProcessing`). `trip_ready` flips both flags and
-  // transitions us out into Acte 3.
+  // Acte 2 — narrative progress screen. Active only while the Acte 2 pipeline
+  // is in flight (`isAnalysisPhaseActive`). Uses a dedicated flag rather than
+  // `hasAnalysisStarted` so that Acte 3 inline-edit backend calls (PATCH
+  // distance, pacing, etc.) don't re-trigger the progress screen.
   const isAnalysing =
-    !!trip && isProcessing && hasAnalysisStarted && activeStages.length > 0;
+    !!trip && isProcessing && isAnalysisPhaseActive && activeStages.length > 0;
   const clearTripAndReset = useCallback(() => {
     clearTrip();
     useUiStore.getState().setProcessing(false);
     useUiStore.getState().setAccommodationScanning(false);
     useUiStore.getState().setAnalysisStarted(false);
+    useUiStore.getState().setAnalysisPhaseActive(false);
   }, [clearTrip]);
 
   const tNav = useTranslations("navigation");

--- a/pwa/src/components/trip-planner.tsx
+++ b/pwa/src/components/trip-planner.tsx
@@ -9,6 +9,7 @@ import { CardSelection } from "@/components/card-selection";
 import { GpxDropZone } from "@/components/gpx-drop-zone";
 import { TripLockedBanner } from "@/components/trip-locked-banner";
 import { TripPreview } from "@/components/trip-preview";
+import { ProcessingProgress } from "@/components/processing-progress";
 import { TripSummary } from "@/components/trip-summary";
 import { TripHeader } from "@/components/trip-header";
 import { TripDownloads } from "@/components/trip-downloads";
@@ -318,6 +319,12 @@ export function TripPlanner({ onClose }: { onClose?: () => void } = {}) {
   const isLoading = !trip && isProcessing;
   const isPreview =
     !!trip && !isProcessing && activeStages.length > 0 && !hasAnalysisStarted;
+  // Acte 2 — narrative progress screen. Active once the user has explicitly
+  // launched the Phase 2 enrichment (`hasAnalysisStarted`) and the backend
+  // is still crunching (`isProcessing`). `trip_ready` flips both flags and
+  // transitions us out into Acte 3.
+  const isAnalysing =
+    !!trip && isProcessing && hasAnalysisStarted && activeStages.length > 0;
   const clearTripAndReset = useCallback(() => {
     clearTrip();
     useUiStore.getState().setProcessing(false);
@@ -494,9 +501,39 @@ export function TripPlanner({ onClose }: { onClose?: () => void } = {}) {
           </>
         )}
 
+        {/* === State 3a-bis: Acte 2 — narrative progress screen
+             (processing + analysis launched, before trip_ready). === */}
+        {isAnalysing && (
+          <>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="absolute top-2 right-4 md:right-6 h-8 w-8 z-10 text-muted-foreground hover:text-foreground"
+              onClick={() => {
+                if (onClose) {
+                  onClose();
+                } else {
+                  clearTripAndReset();
+                  router.push("/");
+                }
+              }}
+              title={t("planner.closeTrip")}
+              aria-label={t("planner.closeTrip")}
+              data-testid="close-trip-button-analysing"
+            >
+              <X className="h-4 w-4" />
+            </Button>
+
+            <ProcessingProgress
+              title={trip?.title ?? ""}
+              onTitleChange={handleTitleChange}
+            />
+          </>
+        )}
+
         {/* === State 3b: Trip loaded — full view (shown once the user
              has launched the Phase 2 analysis via the preview CTA). === */}
-        {trip && !isPreview && (
+        {trip && !isPreview && !isAnalysing && (
           <>
             {/* Close button — top-right corner */}
             <Button

--- a/pwa/src/hooks/use-mercure.ts
+++ b/pwa/src/hooks/use-mercure.ts
@@ -410,6 +410,7 @@ function dispatchEvent(event: MercureEvent): void {
       // fires before #322's split lands and `POST /trips/{id}/analyze`
       // ever gets called.
       useUiStore.getState().setAnalysisStarted(true);
+      useUiStore.getState().setAnalysisPhaseActive(false);
       useUiStore.getState().setProcessing(false);
       useUiStore.getState().setAccommodationScanning(false);
 
@@ -462,6 +463,7 @@ function dispatchEvent(event: MercureEvent): void {
       store.setComputationStatus(event.data.computationStatus);
       useUiStore.getState().setAnalysisProgress(null);
       useUiStore.getState().setAnalysisStarted(true);
+      useUiStore.getState().setAnalysisPhaseActive(false);
       useUiStore.getState().setProcessing(false);
       useUiStore.getState().setAccommodationScanning(false);
 

--- a/pwa/src/hooks/use-mercure.ts
+++ b/pwa/src/hooks/use-mercure.ts
@@ -540,6 +540,7 @@ function dispatchEvent(event: MercureEvent): void {
       if (!event.data.retryable) {
         useUiStore.getState().setProcessing(false);
         useUiStore.getState().setAccommodationScanning(false);
+        useUiStore.getState().setAnalysisPhaseActive(false);
       }
       break;
   }

--- a/pwa/src/hooks/use-mercure.ts
+++ b/pwa/src/hooks/use-mercure.ts
@@ -448,6 +448,9 @@ function dispatchEvent(event: MercureEvent): void {
         completed: event.data.completed,
         total: event.data.total,
       });
+      // Record the step as completed so the Acte 2 narrative screen can
+      // aggregate per-category status (see ProcessingProgress).
+      useUiStore.getState().recordAnalysisStep(event.data.step);
       break;
 
     case "trip_ready": {
@@ -527,6 +530,11 @@ function dispatchEvent(event: MercureEvent): void {
 
     case "computation_error":
       toast.error(`Computation failed: ${event.data.message}`);
+      // Surface the failure on the Acte 2 narrative screen so the user
+      // sees which step went wrong.
+      useUiStore
+        .getState()
+        .failAnalysisStep(event.data.computation, event.data.message);
       if (!event.data.retryable) {
         useUiStore.getState().setProcessing(false);
         useUiStore.getState().setAccommodationScanning(false);

--- a/pwa/src/hooks/use-trip-planner.ts
+++ b/pwa/src/hooks/use-trip-planner.ts
@@ -668,6 +668,7 @@ export function useTripPlanner() {
       setProcessing(true);
       setAccommodationScanning(true);
       useUiStore.getState().setAnalysisStarted(true);
+      useUiStore.getState().setAnalysisPhaseActive(true);
       return true;
     } catch (err) {
       if (isNetworkError(err)) {

--- a/pwa/src/lib/alert-utils.ts
+++ b/pwa/src/lib/alert-utils.ts
@@ -1,0 +1,9 @@
+import type { AlertData } from "@/lib/validation/schemas";
+
+export const severityOrder = { critical: 0, warning: 1, nudge: 2 } as const;
+
+export function sortBySeverity(alerts: AlertData[]): AlertData[] {
+  return [...alerts].sort(
+    (a, b) => (severityOrder[a.type] ?? 2) - (severityOrder[b.type] ?? 2),
+  );
+}

--- a/pwa/src/store/ui-store.ts
+++ b/pwa/src/store/ui-store.ts
@@ -61,8 +61,18 @@ interface UiState {
    * `POST /trips/{id}/analyze` (Acte 2). Until this is `true`, the UI stays
    * on the "preview" screen (Acte 1.5) where the user can inspect the raw
    * route and tweak parameters before committing to the full enrichment.
+   * Stays `true` for the lifetime of the trip so Acte 3 inline edits don't
+   * revert to the preview screen.
    */
   hasAnalysisStarted: boolean;
+  /**
+   * Whether the Acte 2 enrichment pipeline is currently running. `true` from
+   * the moment the user clicks "Lancer l'analyse" until `trip_ready` (or
+   * `trip_complete`) arrives. Distinct from {@link hasAnalysisStarted} which
+   * stays `true` permanently — this flag gates the `ProcessingProgress` screen
+   * so that Acte 3 inline-edit backend calls don't re-trigger it.
+   */
+  isAnalysisPhaseActive: boolean;
   /**
    * Latest snapshot from the `computation_step_completed` Mercure event.
    * Drives the progress bar during Phase 2. `null` when no analysis is in
@@ -130,6 +140,9 @@ interface UiState {
   /** Flip {@link hasAnalysisStarted}. Called by the preview screen when the user
    * confirms they want to launch the full enrichment pipeline. */
   setAnalysisStarted: (value: boolean) => void;
+  /** Flip {@link isAnalysisPhaseActive}. Set `true` when Acte 2 starts, `false`
+   * when `trip_ready` / `trip_complete` lands. */
+  setAnalysisPhaseActive: (value: boolean) => void;
   /** Store a `computation_step_completed` snapshot (Mode 1 progress tick). */
   setAnalysisProgress: (
     progress: {
@@ -189,6 +202,7 @@ export const useUiStore = create<UiState>()(
     currentStep: "preparation",
     completedSteps: new Set<StepId>(),
     hasAnalysisStarted: false,
+    isAnalysisPhaseActive: false,
     analysisProgress: null,
     analysisStepStates: {},
 
@@ -286,6 +300,7 @@ export const useUiStore = create<UiState>()(
         state.currentStep = "preparation";
         state.completedSteps = new Set<StepId>();
         state.hasAnalysisStarted = false;
+        state.isAnalysisPhaseActive = false;
         state.analysisProgress = null;
         state.analysisStepStates = {};
       }),
@@ -293,6 +308,11 @@ export const useUiStore = create<UiState>()(
     setAnalysisStarted: (value) =>
       set((state) => {
         state.hasAnalysisStarted = value;
+      }),
+
+    setAnalysisPhaseActive: (value) =>
+      set((state) => {
+        state.isAnalysisPhaseActive = value;
       }),
 
     setAnalysisProgress: (progress) =>

--- a/pwa/src/store/ui-store.ts
+++ b/pwa/src/store/ui-store.ts
@@ -143,8 +143,6 @@ interface UiState {
   recordAnalysisStep: (step: string) => void;
   /** Mark a step as failed with a human-readable error message. */
   failAnalysisStep: (step: string, message: string) => void;
-  /** Reset all step statuses (called on trip clear). */
-  resetAnalysisSteps: () => void;
 }
 
 /**
@@ -319,10 +317,6 @@ export const useUiStore = create<UiState>()(
         };
       }),
 
-    resetAnalysisSteps: () =>
-      set((state) => {
-        state.analysisStepStates = {};
-      }),
   })),
 );
 

--- a/pwa/src/store/ui-store.ts
+++ b/pwa/src/store/ui-store.ts
@@ -74,6 +74,30 @@ interface UiState {
     completed: number;
     total: number;
   } | null;
+  /**
+   * Per-step progress state for Acte 2 (narrative progress screen).
+   *
+   * Keyed by the backend `ComputationName::value` emitted in
+   * `computation_step_completed` events (e.g. "terrain", "water_points",
+   * "bike_shops", "accommodations", …). Statuses:
+   *   pending → in_progress → done | failed
+   *
+   * The narrative screen groups these steps into user-facing categories
+   * (Terrain, Ravitaillement, Hébergements, Météo, Services, AI). See
+   * `components/processing-progress.tsx` for the mapping.
+   *
+   * `in_progress` is a transient state: the backend only emits a single
+   * event *when a step completes*, so we track "seen" steps as done and
+   * use the latest `analysisProgress.step` to highlight the currently
+   * running step.
+   */
+  analysisStepStates: Record<
+    string,
+    {
+      status: "done" | "failed";
+      error: string | null;
+    }
+  >;
 
   setProcessing: (value: boolean) => void;
   setAccommodationScanning: (value: boolean) => void;
@@ -115,6 +139,12 @@ interface UiState {
       total: number;
     } | null,
   ) => void;
+  /** Mark a step as completed (from a `computation_step_completed` event). */
+  recordAnalysisStep: (step: string) => void;
+  /** Mark a step as failed with a human-readable error message. */
+  failAnalysisStep: (step: string, message: string) => void;
+  /** Reset all step statuses (called on trip clear). */
+  resetAnalysisSteps: () => void;
 }
 
 /**
@@ -162,6 +192,7 @@ export const useUiStore = create<UiState>()(
     completedSteps: new Set<StepId>(),
     hasAnalysisStarted: false,
     analysisProgress: null,
+    analysisStepStates: {},
 
     setProcessing: (value) =>
       set((state) => {
@@ -258,6 +289,7 @@ export const useUiStore = create<UiState>()(
         state.completedSteps = new Set<StepId>();
         state.hasAnalysisStarted = false;
         state.analysisProgress = null;
+        state.analysisStepStates = {};
       }),
 
     setAnalysisStarted: (value) =>
@@ -268,6 +300,28 @@ export const useUiStore = create<UiState>()(
     setAnalysisProgress: (progress) =>
       set((state) => {
         state.analysisProgress = progress;
+      }),
+
+    recordAnalysisStep: (step) =>
+      set((state) => {
+        const current = state.analysisStepStates[step];
+        // Once a step has failed, a subsequent completion tick should not
+        // silently flip it back to done — keep the error surface visible.
+        if (current?.status === "failed") return;
+        state.analysisStepStates[step] = { status: "done", error: null };
+      }),
+
+    failAnalysisStep: (step, message) =>
+      set((state) => {
+        state.analysisStepStates[step] = {
+          status: "failed",
+          error: message,
+        };
+      }),
+
+    resetAnalysisSteps: () =>
+      set((state) => {
+        state.analysisStepStates = {};
       }),
   })),
 );

--- a/pwa/src/store/ui-store.ts
+++ b/pwa/src/store/ui-store.ts
@@ -322,10 +322,6 @@ export const useUiStore = create<UiState>()(
 
     recordAnalysisStep: (step) =>
       set((state) => {
-        const current = state.analysisStepStates[step];
-        // Once a step has failed, a subsequent completion tick should not
-        // silently flip it back to done — keep the error surface visible.
-        if (current?.status === "failed") return;
         state.analysisStepStates[step] = { status: "done", error: null };
       }),
 

--- a/pwa/tests/mocked/actionable-alerts.spec.ts
+++ b/pwa/tests/mocked/actionable-alerts.spec.ts
@@ -165,25 +165,6 @@ function tripReadyWithThreeAlertsEvent(): MercureEvent {
   };
 }
 
-/**
- * Drive the app into Acte 3 via the analysis-started gate → trip_ready flow.
- */
-async function enterActe3ViaAnalysis(
-  submitUrl: () => Promise<void>,
-  injectEvent: (event: MercureEvent) => Promise<void>,
-  tripReadyFn: () => MercureEvent,
-): Promise<void> {
-  await submitUrl();
-  await injectEvent(routeParsedEvent());
-  await injectEvent(stagesComputedEvent());
-  // Simulate user clicking "Lancer l'analyse"
-  await injectEvent({
-    type: "trip_complete" as const,
-    data: { computationStatus: { route: "done", stages: "done" } },
-  });
-  await injectEvent(tripReadyFn());
-}
-
 // ---------------------------------------------------------------------------
 // Severity sorting
 // ---------------------------------------------------------------------------

--- a/pwa/tests/mocked/actionable-alerts.spec.ts
+++ b/pwa/tests/mocked/actionable-alerts.spec.ts
@@ -471,6 +471,9 @@ test.describe("StageAlerts — alert actions", () => {
       timeout: 5000,
     });
 
+    // "Warning alert D" (detour) is 4th after severity sort — expand pagination first
+    await stageCard.getByTestId("stage-alerts-show-more").click();
+
     // "Take detour" is the detour action on "Warning alert D"
     await expect(stageCard.getByText("Take detour")).toBeVisible();
     await expect(stageCard.getByText("Take detour")).toBeDisabled();

--- a/pwa/tests/mocked/actionable-alerts.spec.ts
+++ b/pwa/tests/mocked/actionable-alerts.spec.ts
@@ -42,11 +42,15 @@ function tripReadyWithManyAlertsEvent(): MercureEvent {
             {
               type: "nudge",
               message: "Nudge alert A",
+              lat: null,
+              lon: null,
               action: { kind: "dismiss", label: "OK", payload: {} },
             },
             {
               type: "warning",
               message: "Warning alert B",
+              lat: 44.6,
+              lon: 4.5,
               action: {
                 kind: "navigate",
                 label: "Zoom to location",
@@ -56,6 +60,8 @@ function tripReadyWithManyAlertsEvent(): MercureEvent {
             {
               type: "critical",
               message: "Critical alert C",
+              lat: null,
+              lon: null,
               action: {
                 kind: "auto_fix",
                 label: "Split stage",
@@ -65,19 +71,27 @@ function tripReadyWithManyAlertsEvent(): MercureEvent {
             {
               type: "warning",
               message: "Warning alert D",
+              lat: null,
+              lon: null,
               action: { kind: "detour", label: "Take detour", payload: {} },
             },
             {
               type: "nudge",
               message: "Nudge alert E",
+              lat: null,
+              lon: null,
             },
             {
               type: "critical",
               message: "Critical alert F",
+              lat: null,
+              lon: null,
             },
             {
               type: "warning",
               message: "Warning alert G",
+              lat: null,
+              lon: null,
             },
           ],
           pois: [],
@@ -119,11 +133,23 @@ function tripReadyWithThreeAlertsEvent(): MercureEvent {
           isRestDay: false,
           weather: null,
           alerts: [
-            { type: "critical", message: "Critical alert 1" },
-            { type: "warning", message: "Warning alert 2" },
+            {
+              type: "critical",
+              message: "Critical alert 1",
+              lat: null,
+              lon: null,
+            },
+            {
+              type: "warning",
+              message: "Warning alert 2",
+              lat: null,
+              lon: null,
+            },
             {
               type: "nudge",
               message: "Nudge alert 3",
+              lat: null,
+              lon: null,
               action: { kind: "dismiss", label: "Got it", payload: {} },
             },
           ],
@@ -181,7 +207,9 @@ test.describe("StageAlerts — severity sorting", () => {
     });
 
     // The first badge rendered inside the list should belong to the critical group.
-    const badges = stageCard.locator('[data-testid="stage-alerts-body"] .rounded-md');
+    const badges = stageCard.locator(
+      '[data-testid="stage-alerts-body"] .rounded-md',
+    );
     const firstBadgeText = await badges.first().textContent();
     // Critical alert C comes before Warning / Nudge
     expect(firstBadgeText).toContain("Critical alert C");
@@ -201,9 +229,9 @@ test.describe("StageAlerts — severity sorting", () => {
 
     const stageCard = mockedPage.getByTestId("stage-card-1");
     // 7 alerts total
-    await expect(
-      stageCard.getByTestId("stage-alerts-count"),
-    ).toContainText("7");
+    await expect(stageCard.getByTestId("stage-alerts-count")).toContainText(
+      "7",
+    );
   });
 });
 
@@ -230,12 +258,10 @@ test.describe("StageAlerts — pagination", () => {
     });
 
     // The "show more" button should be present (7 alerts − 3 visible = 4 hidden)
-    await expect(
-      stageCard.getByTestId("stage-alerts-show-more"),
-    ).toBeVisible();
-    await expect(
-      stageCard.getByTestId("stage-alerts-show-more"),
-    ).toContainText("4");
+    await expect(stageCard.getByTestId("stage-alerts-show-more")).toBeVisible();
+    await expect(stageCard.getByTestId("stage-alerts-show-more")).toContainText(
+      "4",
+    );
   });
 
   test("reveals all alerts after clicking 'Show more'", async ({
@@ -313,9 +339,10 @@ test.describe("StageAlerts — collapse/expand", () => {
     await expect(stageCard.getByTestId("stage-alerts-body")).toBeVisible({
       timeout: 5000,
     });
-    await expect(
-      stageCard.getByTestId("stage-alerts-toggle"),
-    ).toHaveAttribute("aria-expanded", "true");
+    await expect(stageCard.getByTestId("stage-alerts-toggle")).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
   });
 
   test("clicking the toggle hides the alert body", async ({
@@ -338,12 +365,11 @@ test.describe("StageAlerts — collapse/expand", () => {
     // Collapse
     await stageCard.getByTestId("stage-alerts-toggle").click();
 
-    await expect(
-      stageCard.getByTestId("stage-alerts-body"),
-    ).not.toBeVisible();
-    await expect(
-      stageCard.getByTestId("stage-alerts-toggle"),
-    ).toHaveAttribute("aria-expanded", "false");
+    await expect(stageCard.getByTestId("stage-alerts-body")).not.toBeVisible();
+    await expect(stageCard.getByTestId("stage-alerts-toggle")).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
   });
 
   test("clicking the toggle again re-expands the section", async ({
@@ -400,9 +426,7 @@ test.describe("StageAlerts — alert actions", () => {
     await stageCard.getByText("OK").first().click();
 
     // Dismissed alert should show reduced opacity marker
-    await expect(
-      stageCard.getByTestId("alert-dismissed"),
-    ).toBeVisible();
+    await expect(stageCard.getByTestId("alert-dismissed")).toBeVisible();
   });
 
   test("navigate action button is enabled and visible", async ({

--- a/pwa/tests/mocked/actionable-alerts.spec.ts
+++ b/pwa/tests/mocked/actionable-alerts.spec.ts
@@ -187,13 +187,14 @@ test.describe("StageAlerts — severity sorting", () => {
       timeout: 5000,
     });
 
-    // The first badge rendered inside the list should belong to the critical group.
-    const badges = stageCard.locator(
-      '[data-testid="stage-alerts-body"] .rounded-md',
-    );
-    const firstBadgeText = await badges.first().textContent();
-    // Critical alert C comes before Warning / Nudge
-    expect(firstBadgeText).toContain("Critical alert C");
+    // After sorting: criticals fill the first visible slots (only 3 shown by default).
+    // Both criticals should be visible; nudges should be hidden behind "Show more".
+    const alertsBody = stageCard.getByTestId("stage-alerts-body");
+    await expect(alertsBody.getByText("Critical alert C")).toBeVisible();
+    await expect(alertsBody.getByText("Critical alert F")).toBeVisible();
+    // Nudge alerts sit below the fold — not visible until "Show more" is clicked.
+    await expect(alertsBody.getByText("Nudge alert A")).not.toBeVisible();
+    await expect(alertsBody.getByText("Nudge alert E")).not.toBeVisible();
   });
 
   test("shows correct total count in the section header", async ({

--- a/pwa/tests/mocked/actionable-alerts.spec.ts
+++ b/pwa/tests/mocked/actionable-alerts.spec.ts
@@ -1,0 +1,553 @@
+/**
+ * Issue #325 — Acte 3 : collapsible stage alerts with severity sorting and pagination.
+ *
+ * Tests:
+ * - Alerts are sorted by severity (critical → warning → nudge).
+ * - First 3 alerts shown, "Show N more" reveals the rest.
+ * - Section collapses and expands via the header toggle.
+ * - Individual alert actions (auto_fix, navigate, dismiss) work as expected.
+ * - Transition from Acte 2 ProcessingProgress (trip_ready) to Acte 3.
+ */
+
+import { test, expect } from "../fixtures/base.fixture";
+import type { MercureEvent } from "../../src/lib/mercure/types";
+import {
+  routeParsedEvent,
+  stagesComputedEvent,
+  tripReadyEvent,
+} from "../fixtures/mock-data";
+
+/** A trip_ready event with many alerts on stage 0 (7 alerts, mixed severity). */
+function tripReadyWithManyAlertsEvent(): MercureEvent {
+  return {
+    type: "trip_ready",
+    data: {
+      stages: [
+        {
+          dayNumber: 1,
+          distance: 72.5,
+          elevation: 1180,
+          elevationLoss: 920,
+          startPoint: { lat: 44.735, lon: 4.598, ele: 280 },
+          endPoint: { lat: 44.532, lon: 4.392, ele: 540 },
+          geometry: [
+            { lat: 44.735, lon: 4.598, ele: 280 },
+            { lat: 44.532, lon: 4.392, ele: 540 },
+          ],
+          label: null,
+          isRestDay: false,
+          weather: null,
+          alerts: [
+            // nudge first in list — should appear last after sorting
+            {
+              type: "nudge",
+              message: "Nudge alert A",
+              action: { kind: "dismiss", label: "OK", payload: {} },
+            },
+            {
+              type: "warning",
+              message: "Warning alert B",
+              action: {
+                kind: "navigate",
+                label: "Zoom to location",
+                payload: { lat: 44.6, lon: 4.5 },
+              },
+            },
+            {
+              type: "critical",
+              message: "Critical alert C",
+              action: {
+                kind: "auto_fix",
+                label: "Split stage",
+                payload: { splitAt: 45.0 },
+              },
+            },
+            {
+              type: "warning",
+              message: "Warning alert D",
+              action: { kind: "detour", label: "Take detour", payload: {} },
+            },
+            {
+              type: "nudge",
+              message: "Nudge alert E",
+            },
+            {
+              type: "critical",
+              message: "Critical alert F",
+            },
+            {
+              type: "warning",
+              message: "Warning alert G",
+            },
+          ],
+          pois: [],
+          accommodations: [],
+          selectedAccommodation: null,
+          events: [],
+        },
+      ],
+      computationStatus: {
+        route: "done",
+        stages: "done",
+        weather: "done",
+        terrain: "done",
+        accommodations: "done",
+      },
+      aiOverview: null,
+    },
+  };
+}
+
+/** A trip_ready event with exactly 3 alerts on stage 0 (no "Show more" needed). */
+function tripReadyWithThreeAlertsEvent(): MercureEvent {
+  return {
+    type: "trip_ready",
+    data: {
+      stages: [
+        {
+          dayNumber: 1,
+          distance: 72.5,
+          elevation: 1180,
+          elevationLoss: 920,
+          startPoint: { lat: 44.735, lon: 4.598, ele: 280 },
+          endPoint: { lat: 44.532, lon: 4.392, ele: 540 },
+          geometry: [
+            { lat: 44.735, lon: 4.598, ele: 280 },
+            { lat: 44.532, lon: 4.392, ele: 540 },
+          ],
+          label: null,
+          isRestDay: false,
+          weather: null,
+          alerts: [
+            { type: "critical", message: "Critical alert 1" },
+            { type: "warning", message: "Warning alert 2" },
+            {
+              type: "nudge",
+              message: "Nudge alert 3",
+              action: { kind: "dismiss", label: "Got it", payload: {} },
+            },
+          ],
+          pois: [],
+          accommodations: [],
+          selectedAccommodation: null,
+          events: [],
+        },
+      ],
+      computationStatus: { route: "done", stages: "done" },
+      aiOverview: null,
+    },
+  };
+}
+
+/**
+ * Drive the app into Acte 3 via the analysis-started gate → trip_ready flow.
+ */
+async function enterActe3ViaAnalysis(
+  submitUrl: () => Promise<void>,
+  injectEvent: (event: MercureEvent) => Promise<void>,
+  tripReadyFn: () => MercureEvent,
+): Promise<void> {
+  await submitUrl();
+  await injectEvent(routeParsedEvent());
+  await injectEvent(stagesComputedEvent());
+  // Simulate user clicking "Lancer l'analyse"
+  await injectEvent({
+    type: "trip_complete" as const,
+    data: { computationStatus: { route: "done", stages: "done" } },
+  });
+  await injectEvent(tripReadyFn());
+}
+
+// ---------------------------------------------------------------------------
+// Severity sorting
+// ---------------------------------------------------------------------------
+
+test.describe("StageAlerts — severity sorting", () => {
+  test("alerts are displayed in severity order: critical → warning → nudge", async ({
+    submitUrl,
+    injectSequence,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    await injectSequence([
+      routeParsedEvent(),
+      stagesComputedEvent(),
+      tripReadyWithManyAlertsEvent(),
+    ]);
+
+    const stageCard = mockedPage.getByTestId("stage-card-1");
+    await expect(stageCard.getByTestId("stage-alerts")).toBeVisible({
+      timeout: 5000,
+    });
+
+    // The first badge rendered inside the list should belong to the critical group.
+    const badges = stageCard.locator('[data-testid="stage-alerts-body"] .rounded-md');
+    const firstBadgeText = await badges.first().textContent();
+    // Critical alert C comes before Warning / Nudge
+    expect(firstBadgeText).toContain("Critical alert C");
+  });
+
+  test("shows correct total count in the section header", async ({
+    submitUrl,
+    injectSequence,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    await injectSequence([
+      routeParsedEvent(),
+      stagesComputedEvent(),
+      tripReadyWithManyAlertsEvent(),
+    ]);
+
+    const stageCard = mockedPage.getByTestId("stage-card-1");
+    // 7 alerts total
+    await expect(
+      stageCard.getByTestId("stage-alerts-count"),
+    ).toContainText("7");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pagination — "Show N more" / "Show less"
+// ---------------------------------------------------------------------------
+
+test.describe("StageAlerts — pagination", () => {
+  test("shows only the first 3 alerts by default when there are more than 3", async ({
+    submitUrl,
+    injectSequence,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    await injectSequence([
+      routeParsedEvent(),
+      stagesComputedEvent(),
+      tripReadyWithManyAlertsEvent(),
+    ]);
+
+    const stageCard = mockedPage.getByTestId("stage-card-1");
+    await expect(stageCard.getByTestId("stage-alerts")).toBeVisible({
+      timeout: 5000,
+    });
+
+    // The "show more" button should be present (7 alerts − 3 visible = 4 hidden)
+    await expect(
+      stageCard.getByTestId("stage-alerts-show-more"),
+    ).toBeVisible();
+    await expect(
+      stageCard.getByTestId("stage-alerts-show-more"),
+    ).toContainText("4");
+  });
+
+  test("reveals all alerts after clicking 'Show more'", async ({
+    submitUrl,
+    injectSequence,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    await injectSequence([
+      routeParsedEvent(),
+      stagesComputedEvent(),
+      tripReadyWithManyAlertsEvent(),
+    ]);
+
+    const stageCard = mockedPage.getByTestId("stage-card-1");
+    await expect(stageCard.getByTestId("stage-alerts")).toBeVisible({
+      timeout: 5000,
+    });
+
+    // Click "Show more"
+    await stageCard.getByTestId("stage-alerts-show-more").click();
+
+    // All 7 alerts should be visible now — the "Nudge alert A" message (which was
+    // below the initial 3) should now be present in the DOM.
+    await expect(stageCard).toContainText("Nudge alert A");
+    await expect(stageCard).toContainText("Nudge alert E");
+
+    // The toggle label should change to "Show less"
+    await expect(
+      stageCard.getByTestId("stage-alerts-show-more"),
+    ).not.toContainText("4");
+  });
+
+  test("does not show 'Show more' when alerts count is at most 3", async ({
+    submitUrl,
+    injectSequence,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    await injectSequence([
+      routeParsedEvent(),
+      stagesComputedEvent(),
+      tripReadyWithThreeAlertsEvent(),
+    ]);
+
+    const stageCard = mockedPage.getByTestId("stage-card-1");
+    await expect(stageCard.getByTestId("stage-alerts")).toBeVisible({
+      timeout: 5000,
+    });
+
+    await expect(
+      stageCard.getByTestId("stage-alerts-show-more"),
+    ).not.toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Collapse / expand
+// ---------------------------------------------------------------------------
+
+test.describe("StageAlerts — collapse/expand", () => {
+  test("section is expanded by default", async ({
+    submitUrl,
+    injectSequence,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    await injectSequence([
+      routeParsedEvent(),
+      stagesComputedEvent(),
+      tripReadyWithThreeAlertsEvent(),
+    ]);
+
+    const stageCard = mockedPage.getByTestId("stage-card-1");
+    await expect(stageCard.getByTestId("stage-alerts-body")).toBeVisible({
+      timeout: 5000,
+    });
+    await expect(
+      stageCard.getByTestId("stage-alerts-toggle"),
+    ).toHaveAttribute("aria-expanded", "true");
+  });
+
+  test("clicking the toggle hides the alert body", async ({
+    submitUrl,
+    injectSequence,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    await injectSequence([
+      routeParsedEvent(),
+      stagesComputedEvent(),
+      tripReadyWithThreeAlertsEvent(),
+    ]);
+
+    const stageCard = mockedPage.getByTestId("stage-card-1");
+    await expect(stageCard.getByTestId("stage-alerts-body")).toBeVisible({
+      timeout: 5000,
+    });
+
+    // Collapse
+    await stageCard.getByTestId("stage-alerts-toggle").click();
+
+    await expect(
+      stageCard.getByTestId("stage-alerts-body"),
+    ).not.toBeVisible();
+    await expect(
+      stageCard.getByTestId("stage-alerts-toggle"),
+    ).toHaveAttribute("aria-expanded", "false");
+  });
+
+  test("clicking the toggle again re-expands the section", async ({
+    submitUrl,
+    injectSequence,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    await injectSequence([
+      routeParsedEvent(),
+      stagesComputedEvent(),
+      tripReadyWithThreeAlertsEvent(),
+    ]);
+
+    const stageCard = mockedPage.getByTestId("stage-card-1");
+    await expect(stageCard.getByTestId("stage-alerts-body")).toBeVisible({
+      timeout: 5000,
+    });
+
+    // Collapse then expand
+    await stageCard.getByTestId("stage-alerts-toggle").click();
+    await stageCard.getByTestId("stage-alerts-toggle").click();
+
+    await expect(stageCard.getByTestId("stage-alerts-body")).toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Alert actions (auto_fix, navigate, dismiss) — inherited from AlertList
+// ---------------------------------------------------------------------------
+
+test.describe("StageAlerts — alert actions", () => {
+  test("dismiss action marks the alert as dismissed", async ({
+    submitUrl,
+    injectSequence,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    await injectSequence([
+      routeParsedEvent(),
+      stagesComputedEvent(),
+      tripReadyWithManyAlertsEvent(),
+    ]);
+
+    const stageCard = mockedPage.getByTestId("stage-card-1");
+    await expect(stageCard.getByTestId("stage-alerts")).toBeVisible({
+      timeout: 5000,
+    });
+
+    // "OK" is the dismiss action on "Nudge alert A" — expand all first
+    await stageCard.getByTestId("stage-alerts-show-more").click();
+
+    // Click the dismiss button on "Nudge alert A"
+    await stageCard.getByText("OK").first().click();
+
+    // Dismissed alert should show reduced opacity marker
+    await expect(
+      stageCard.getByTestId("alert-dismissed"),
+    ).toBeVisible();
+  });
+
+  test("navigate action button is enabled and visible", async ({
+    submitUrl,
+    injectSequence,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    await injectSequence([
+      routeParsedEvent(),
+      stagesComputedEvent(),
+      tripReadyWithManyAlertsEvent(),
+    ]);
+
+    const stageCard = mockedPage.getByTestId("stage-card-1");
+    await expect(stageCard.getByTestId("stage-alerts")).toBeVisible({
+      timeout: 5000,
+    });
+
+    // "Zoom to location" is the navigate action on "Warning alert B"
+    await expect(stageCard.getByText("Zoom to location")).toBeVisible();
+    await expect(stageCard.getByText("Zoom to location")).not.toBeDisabled();
+  });
+
+  test("auto_fix action button is disabled (not yet implemented)", async ({
+    submitUrl,
+    injectSequence,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    await injectSequence([
+      routeParsedEvent(),
+      stagesComputedEvent(),
+      tripReadyWithManyAlertsEvent(),
+    ]);
+
+    const stageCard = mockedPage.getByTestId("stage-card-1");
+    await expect(stageCard.getByTestId("stage-alerts")).toBeVisible({
+      timeout: 5000,
+    });
+
+    // "Split stage" is the auto_fix action on "Critical alert C"
+    await expect(stageCard.getByText("Split stage")).toBeVisible();
+    await expect(stageCard.getByText("Split stage")).toBeDisabled();
+  });
+
+  test("detour action button is disabled (not yet implemented)", async ({
+    submitUrl,
+    injectSequence,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    await injectSequence([
+      routeParsedEvent(),
+      stagesComputedEvent(),
+      tripReadyWithManyAlertsEvent(),
+    ]);
+
+    const stageCard = mockedPage.getByTestId("stage-card-1");
+    await expect(stageCard.getByTestId("stage-alerts")).toBeVisible({
+      timeout: 5000,
+    });
+
+    // "Take detour" is the detour action on "Warning alert D"
+    await expect(stageCard.getByText("Take detour")).toBeVisible();
+    await expect(stageCard.getByText("Take detour")).toBeDisabled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Transition from Acte 2 → Acte 3
+// ---------------------------------------------------------------------------
+
+test.describe("StageAlerts — transition from Acte 2", () => {
+  test("stage alerts are visible after transitioning from ProcessingProgress via trip_ready", async ({
+    submitUrl,
+    injectEvent,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    await injectEvent(routeParsedEvent());
+    await injectEvent(stagesComputedEvent());
+
+    // Trigger Acte 2 (analysis started + processing)
+    await mockedPage.evaluate(() => {
+      window.dispatchEvent(
+        new CustomEvent("__test_set_processing", { detail: true }),
+      );
+      window.dispatchEvent(
+        new CustomEvent("__test_set_analysis_started", { detail: true }),
+      );
+    });
+
+    await expect(mockedPage.getByTestId("processing-progress")).toBeVisible({
+      timeout: 5000,
+    });
+
+    // Send trip_ready — transitions to Acte 3
+    await injectEvent(tripReadyWithThreeAlertsEvent());
+
+    await expect(mockedPage.getByTestId("processing-progress")).toBeHidden({
+      timeout: 5000,
+    });
+    await expect(mockedPage.getByTestId("stage-card-1")).toBeVisible({
+      timeout: 5000,
+    });
+    await expect(
+      mockedPage.getByTestId("stage-card-1").getByTestId("stage-alerts"),
+    ).toBeVisible();
+  });
+
+  test("original trip_ready transition still works when stages have no alerts", async ({
+    submitUrl,
+    injectEvent,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    await injectEvent(routeParsedEvent());
+    await injectEvent(stagesComputedEvent());
+
+    await mockedPage.evaluate(() => {
+      window.dispatchEvent(
+        new CustomEvent("__test_set_processing", { detail: true }),
+      );
+      window.dispatchEvent(
+        new CustomEvent("__test_set_analysis_started", { detail: true }),
+      );
+    });
+
+    await expect(mockedPage.getByTestId("processing-progress")).toBeVisible({
+      timeout: 5000,
+    });
+
+    // trip_ready with empty alerts
+    await injectEvent(tripReadyEvent());
+
+    await expect(mockedPage.getByTestId("processing-progress")).toBeHidden({
+      timeout: 5000,
+    });
+    await expect(mockedPage.getByTestId("stage-card-1")).toBeVisible({
+      timeout: 5000,
+    });
+    // No alert section when there are no alerts
+    await expect(
+      mockedPage.getByTestId("stage-card-1").getByTestId("stage-alerts"),
+    ).not.toBeVisible();
+  });
+});

--- a/pwa/tests/mocked/mercure-dual-mode.spec.ts
+++ b/pwa/tests/mocked/mercure-dual-mode.spec.ts
@@ -42,6 +42,9 @@ test.describe("Mercure dual mode — Mode 1 (initial analysis)", () => {
     await expect(mockedPage.getByTestId("stage-card-1")).toBeVisible({
       timeout: 10000,
     });
+
+    // analysisProgress is cleared on trip_ready — progress screen must be gone.
+    await expect(mockedPage.getByTestId("processing-progress")).toBeHidden();
   });
 
   test("trip_ready performs an atomic swap of trip state", async ({

--- a/pwa/tests/mocked/processing-progress.spec.ts
+++ b/pwa/tests/mocked/processing-progress.spec.ts
@@ -1,0 +1,199 @@
+import { test, expect } from "../fixtures/base.fixture";
+import type { Page } from "@playwright/test";
+import {
+  computationStepCompletedEvent,
+  routeParsedEvent,
+  stagesComputedEvent,
+  tripReadyEvent,
+} from "../fixtures/mock-data";
+import type { MercureEvent } from "../../src/lib/mercure/types";
+
+/**
+ * Issue #323 — Acte 2 ProcessingProgress screen.
+ *
+ * The progress screen activates when the user has launched the Phase 2
+ * analysis (`hasAnalysisStarted`) and the backend is still crunching
+ * (`isProcessing`). Categories transition between pending, in_progress,
+ * done and failed states as `computation_step_completed` /
+ * `computation_error` events arrive. A `trip_ready` event flips
+ * `isProcessing` off and hands over to Acte 3 (the full trip view).
+ */
+async function enterAnalysingState(
+  submitUrl: () => Promise<void>,
+  injectEvent: (event: MercureEvent) => Promise<void>,
+  mockedPage: Page,
+): Promise<void> {
+  await submitUrl();
+  await injectEvent(routeParsedEvent());
+  await injectEvent(stagesComputedEvent());
+  // Simulate the "user clicked Launch analysis" gate: processing remains
+  // true and analysis has been started explicitly.
+  await mockedPage.evaluate(() => {
+    window.dispatchEvent(
+      new CustomEvent("__test_set_processing", { detail: true }),
+    );
+    window.dispatchEvent(
+      new CustomEvent("__test_set_analysis_started", { detail: true }),
+    );
+  });
+  await expect(mockedPage.getByTestId("processing-progress")).toBeVisible({
+    timeout: 5000,
+  });
+}
+
+test.describe("ProcessingProgress — display", () => {
+  test("renders the six narrative categories during analysis", async ({
+    submitUrl,
+    injectEvent,
+    mockedPage,
+  }) => {
+    await enterAnalysingState(submitUrl, injectEvent, mockedPage);
+
+    await expect(
+      mockedPage.getByTestId("processing-category-terrain_security"),
+    ).toBeVisible();
+    await expect(mockedPage.getByTestId("processing-category-supply")).toBeVisible();
+    await expect(
+      mockedPage.getByTestId("processing-category-accommodations"),
+    ).toBeVisible();
+    await expect(mockedPage.getByTestId("processing-category-weather")).toBeVisible();
+    await expect(
+      mockedPage.getByTestId("processing-category-services"),
+    ).toBeVisible();
+  });
+
+  test("AI category is hidden when Ollama is disabled (no ai_* events)", async ({
+    submitUrl,
+    injectEvent,
+    mockedPage,
+  }) => {
+    await enterAnalysingState(submitUrl, injectEvent, mockedPage);
+    await expect(
+      mockedPage.getByTestId("processing-category-ai"),
+    ).toBeHidden();
+  });
+
+  test("AI category becomes visible when an ai_* step is reported", async ({
+    submitUrl,
+    injectEvent,
+    mockedPage,
+  }) => {
+    await enterAnalysingState(submitUrl, injectEvent, mockedPage);
+    // The AI category is hidden until at least one ai_* step fires.
+    await injectEvent(computationStepCompletedEvent("ai_stage", "route", 1, 16));
+    await expect(
+      mockedPage.getByTestId("processing-category-ai"),
+    ).toBeVisible();
+  });
+});
+
+test.describe("ProcessingProgress — category progression", () => {
+  test("starts every category as pending", async ({
+    submitUrl,
+    injectEvent,
+    mockedPage,
+  }) => {
+    await enterAnalysingState(submitUrl, injectEvent, mockedPage);
+
+    await expect(
+      mockedPage.getByTestId("processing-category-terrain_security"),
+    ).toHaveAttribute("data-status", "pending");
+    await expect(
+      mockedPage.getByTestId("processing-category-accommodations"),
+    ).toHaveAttribute("data-status", "pending");
+  });
+
+  test("moves a category to in_progress while its steps are running", async ({
+    submitUrl,
+    injectEvent,
+    mockedPage,
+  }) => {
+    await enterAnalysingState(submitUrl, injectEvent, mockedPage);
+    // Accommodations has a single step — an in-flight computation_step_completed
+    // for "accommodations" would actually flip it to done, so we simulate the
+    // currently-running step via the "terrain_security" row (osm_scan + terrain):
+    // sending only osm_scan leaves terrain undone → the row is in_progress.
+    await injectEvent(
+      computationStepCompletedEvent("osm_scan", "points_of_interest", 1, 16),
+    );
+    await expect(
+      mockedPage.getByTestId("processing-category-terrain_security"),
+    ).toHaveAttribute("data-status", "in_progress");
+  });
+
+  test("marks a category as done once all its steps have completed", async ({
+    submitUrl,
+    injectEvent,
+    mockedPage,
+  }) => {
+    await enterAnalysingState(submitUrl, injectEvent, mockedPage);
+    // Accommodations has a single backing step.
+    await injectEvent(
+      computationStepCompletedEvent("accommodations", "accommodations", 1, 16),
+    );
+    await expect(
+      mockedPage.getByTestId("processing-category-accommodations"),
+    ).toHaveAttribute("data-status", "done");
+  });
+});
+
+test.describe("ProcessingProgress — failure handling", () => {
+  test("renders the warning icon and explanatory message on computation_error", async ({
+    submitUrl,
+    injectEvent,
+    mockedPage,
+  }) => {
+    await enterAnalysingState(submitUrl, injectEvent, mockedPage);
+
+    await injectEvent({
+      type: "computation_error",
+      data: {
+        computation: "accommodations",
+        message: "Overpass timed out",
+        retryable: true,
+      },
+    });
+
+    await expect(
+      mockedPage.getByTestId("processing-category-accommodations"),
+    ).toHaveAttribute("data-status", "failed");
+    await expect(
+      mockedPage.getByTestId("processing-category-accommodations-error"),
+    ).toContainText(/Overpass timed out/);
+  });
+});
+
+test.describe("ProcessingProgress — global progress bar", () => {
+  test("reflects the completed/total ratio from computation_step_completed", async ({
+    submitUrl,
+    injectEvent,
+    mockedPage,
+  }) => {
+    await enterAnalysingState(submitUrl, injectEvent, mockedPage);
+    await injectEvent(
+      computationStepCompletedEvent("terrain", "terrain_security", 4, 16),
+    );
+    await expect(
+      mockedPage.getByTestId("processing-progress-percent"),
+    ).toContainText("25%");
+  });
+});
+
+test.describe("ProcessingProgress — transition to Acte 3", () => {
+  test("trip_ready hands over to the full trip view (Acte 3)", async ({
+    submitUrl,
+    injectEvent,
+    mockedPage,
+  }) => {
+    await enterAnalysingState(submitUrl, injectEvent, mockedPage);
+    await injectEvent(tripReadyEvent());
+    // The progress screen is gone…
+    await expect(mockedPage.getByTestId("processing-progress")).toBeHidden({
+      timeout: 5000,
+    });
+    // …and the regular trip view (stage cards) is now on screen.
+    await expect(mockedPage.getByTestId("stage-card-1")).toBeVisible({
+      timeout: 5000,
+    });
+  });
+});

--- a/pwa/tests/mocked/processing-progress.spec.ts
+++ b/pwa/tests/mocked/processing-progress.spec.ts
@@ -52,11 +52,15 @@ test.describe("ProcessingProgress — display", () => {
     await expect(
       mockedPage.getByTestId("processing-category-terrain_security"),
     ).toBeVisible();
-    await expect(mockedPage.getByTestId("processing-category-supply")).toBeVisible();
+    await expect(
+      mockedPage.getByTestId("processing-category-supply"),
+    ).toBeVisible();
     await expect(
       mockedPage.getByTestId("processing-category-accommodations"),
     ).toBeVisible();
-    await expect(mockedPage.getByTestId("processing-category-weather")).toBeVisible();
+    await expect(
+      mockedPage.getByTestId("processing-category-weather"),
+    ).toBeVisible();
     await expect(
       mockedPage.getByTestId("processing-category-services"),
     ).toBeVisible();
@@ -68,9 +72,7 @@ test.describe("ProcessingProgress — display", () => {
     mockedPage,
   }) => {
     await enterAnalysingState(submitUrl, injectEvent, mockedPage);
-    await expect(
-      mockedPage.getByTestId("processing-category-ai"),
-    ).toBeHidden();
+    await expect(mockedPage.getByTestId("processing-category-ai")).toBeHidden();
   });
 
   test("AI category becomes visible when an ai_* step is reported", async ({
@@ -80,7 +82,9 @@ test.describe("ProcessingProgress — display", () => {
   }) => {
     await enterAnalysingState(submitUrl, injectEvent, mockedPage);
     // The AI category is hidden until at least one ai_* step fires.
-    await injectEvent(computationStepCompletedEvent("ai_stage", "route", 1, 16));
+    await injectEvent(
+      computationStepCompletedEvent("ai_stage", "route", 1, 16),
+    );
     await expect(
       mockedPage.getByTestId("processing-category-ai"),
     ).toBeVisible();

--- a/pwa/tests/mocked/processing-progress.spec.ts
+++ b/pwa/tests/mocked/processing-progress.spec.ts
@@ -200,4 +200,24 @@ test.describe("ProcessingProgress — transition to Acte 3", () => {
       timeout: 5000,
     });
   });
+
+  test("does not re-appear during Acte 3 inline-edit processing", async ({
+    submitUrl,
+    injectEvent,
+    mockedPage,
+  }) => {
+    await enterAnalysingState(submitUrl, injectEvent, mockedPage);
+    await injectEvent(tripReadyEvent());
+    await expect(mockedPage.getByTestId("processing-progress")).toBeHidden({
+      timeout: 5000,
+    });
+    // Simulate a background PATCH (e.g. pacing update) re-setting isProcessing=true.
+    // isAnalysisPhaseActive is now false, so the screen must not re-appear.
+    await mockedPage.evaluate(() => {
+      window.dispatchEvent(
+        new CustomEvent("__test_set_processing", { detail: true }),
+      );
+    });
+    await expect(mockedPage.getByTestId("processing-progress")).toBeHidden();
+  });
 });


### PR DESCRIPTION
## Résumé

- Ajoute le composant `StageAlerts` — section repliable par étape avec tri par sévérité (critical → warning → nudge), pagination 3+N, et boutons d'action contextuels (auto_fix, detour, navigate, dismiss)
- Remplace l'ancien usage de `AlertList` dans `stage-card.tsx` par `StageAlerts`
- Transition depuis Acte 2 : sur réception de `trip_ready`, le store passe en mode "résultats" et le stepper marque "Mon voyage" comme étape active
- Tests Playwright mocked : tri par sévérité, pagination, collapse/expand, actions (auto_fix, navigate, dismiss, detour), transition Acte 2 → Acte 3

## Auto-critique

- Les actions `auto_fix` et `detour` sont rendues désactivées (not yet implemented) — placeholder intentionnel pour les sprints suivants
- Le clic sur une alerte `navigate` dispatche un event custom `__map_zoom` — suppose que la carte écoute cet event ; à vérifier lors de l'intégration carte complète
- Le tri par sévérité est recalculé à chaque render — acceptable pour < 20 alertes par étape, à mémoïser si besoin

Dépend de #323 (feature/323) et #324 (feature/324)
Closes #325

<!-- claude-review-start -->
## Claude Review

**Reviewed commit:** `972e1f606a24201306ced149bc4dcbf6a939e175`
**Findings:** 0 critical · 0 warnings · 0 suggestions

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Resolved threads

All 6 previously open bot-authored threads are resolved in this revision.

### Inline comments

No inline comments.

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->