### PR TITLE
docs(tracking): add PR links for sprint 23 issues (#324, #323, #325)

### DIFF
--- a/TRACKING.md
+++ b/TRACKING.md
@@ -437,9 +437,9 @@ Interface d'entrée de l'itinéraire (cartes Lien/GPX), écran de prévisualisat
 
 | Ordre | ID                                                                      | Titre                                                                           | Effort | PRs | Dépend de |
 |-------|-------------------------------------------------------------------------|---------------------------------------------------------------------------------|--------|-----|-----------|
-| 1     | [#324](https://github.com/vincentchalamon/bike-trip-planner/issues/324) | Events Mercure dual mode : computation_step_completed + TRIP_READY + STAGE_UPDATED | L   |     | #322      |
-| 2     | [#323](https://github.com/vincentchalamon/bike-trip-planner/issues/323) | Acte 2 — ProcessingProgress : écran de progression narrative par catégorie      | L      |     | #317 #324 |
-| 3     | [#325](https://github.com/vincentchalamon/bike-trip-planner/issues/325) | Acte 3 — Refonte résultats : alertes repliables + affichage structuré           | L      |     | #323 #324 |
+| 1     | [#324](https://github.com/vincentchalamon/bike-trip-planner/issues/324) | Events Mercure dual mode : computation_step_completed + TRIP_READY + STAGE_UPDATED | L   | [#376](https://github.com/vincentchalamon/bike-trip-planner/pull/376) `feature/324` | #322      |
+| 2     | [#323](https://github.com/vincentchalamon/bike-trip-planner/issues/323) | Acte 2 — ProcessingProgress : écran de progression narrative par catégorie      | L      | [#377](https://github.com/vincentchalamon/bike-trip-planner/pull/377) `feature/323` | #317 #324 |
+| 3     | [#325](https://github.com/vincentchalamon/bike-trip-planner/issues/325) | Acte 3 — Refonte résultats : alertes repliables + affichage structuré           | L      | [#378](https://github.com/vincentchalamon/bike-trip-planner/pull/378) `feature/325` | #323 #324 |
 
 ---
 


### PR DESCRIPTION
Mise à jour du suivi TRACKING.md avec les liens PR pour le sprint 23 :

- #324 → PR [#376](https://github.com/vincentchalamon/bike-trip-planner/pull/376) `feature/324`
- #323 → PR [#377](https://github.com/vincentchalamon/bike-trip-planner/pull/377) `feature/323`
- #325 → PR [#378](https://github.com/vincentchalamon/bike-trip-planner/pull/378) `feature/325`

<!-- claude-review-start -->
## Claude Review

**Summary:** Clean, minimal documentation update — adds PR links for all three sprint 23 issues in TRACKING.md. No code changes; nothing to flag.

**Findings:** 0 critical · 0 warnings · 0 suggestions

**Commit reviewed:** `32ad51ea64df61e97fd7f7da0c5d1442ccdc4a60`

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases *(N/A — docs only)*
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**No inline comments.**

---
Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->