### PR TITLE
feat(pwa): add inline recomputation shimmer skeleton and progress bar (#326)

### DIFF
--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -42,6 +42,7 @@
     "downloadFit": "Download FIT stage {dayNumber}",
     "downloadFailed": "Download failed. Please try again.",
     "loadingAlerts": "Analyzing stage...",
+    "recomputing": "Updating...",
     "editDistance": "Edit distance",
     "distanceLabel": "Distance (km)",
     "saveDistance": "Save",

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -42,6 +42,7 @@
     "downloadFit": "Télécharger le FIT étape {dayNumber}",
     "downloadFailed": "Le téléchargement a échoué. Veuillez réessayer.",
     "loadingAlerts": "Analyse de l'étape...",
+    "recomputing": "Mise à jour en cours...",
     "editDistance": "Modifier la distance",
     "distanceLabel": "Distance (km)",
     "saveDistance": "Enregistrer",

--- a/pwa/src/app/globals.css
+++ b/pwa/src/app/globals.css
@@ -128,6 +128,18 @@
   --sidebar-ring: oklch(0.551 0.027 264.364);
 }
 
+@keyframes indeterminate {
+  0% {
+    transform: translateX(-100%) scaleX(0.3);
+  }
+  50% {
+    transform: translateX(0%) scaleX(0.6);
+  }
+  100% {
+    transform: translateX(100%) scaleX(0.3);
+  }
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/pwa/src/components/inline-recomputation-bar.tsx
+++ b/pwa/src/components/inline-recomputation-bar.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useTripStore } from "@/store/trip-store";
+
+/**
+ * Thin horizontal progress bar that appears at the very top of the page
+ * during an Acte 3 inline recomputation. Visible only while at least one
+ * stage is in the `recomputingStages` set; disappears automatically once
+ * all pending `stage_updated` events have landed.
+ *
+ * The bar uses an indeterminate animation because the total number of
+ * `stage_updated` events may not be known upfront (backend can batch them).
+ */
+export function InlineRecomputationBar() {
+  const recomputingStages = useTripStore((s) => s.recomputingStages);
+
+  if (recomputingStages.size === 0) return null;
+
+  return (
+    <div
+      role="progressbar"
+      aria-label="Recalcul en cours"
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuetext="Recalcul en cours…"
+      data-testid="inline-recomputation-bar"
+      className="fixed top-0 left-0 right-0 z-50 h-0.5 overflow-hidden"
+    >
+      <div className="h-full w-full bg-brand/20">
+        <div className="h-full bg-brand animate-[indeterminate_1.5s_ease-in-out_infinite]" />
+      </div>
+    </div>
+  );
+}

--- a/pwa/src/components/inline-recomputation-bar.tsx
+++ b/pwa/src/components/inline-recomputation-bar.tsx
@@ -1,28 +1,21 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { useTripStore } from "@/store/trip-store";
 
-/**
- * Thin horizontal progress bar that appears at the very top of the page
- * during an Acte 3 inline recomputation. Visible only while at least one
- * stage is in the `recomputingStages` set; disappears automatically once
- * all pending `stage_updated` events have landed.
- *
- * The bar uses an indeterminate animation because the total number of
- * `stage_updated` events may not be known upfront (backend can batch them).
- */
 export function InlineRecomputationBar() {
   const recomputingStages = useTripStore((s) => s.recomputingStages);
+  const t = useTranslations("stage");
 
   if (recomputingStages.size === 0) return null;
 
   return (
     <div
       role="progressbar"
-      aria-label="Recalcul en cours"
+      aria-label={t("recomputing")}
       aria-valuemin={0}
       aria-valuemax={100}
-      aria-valuetext="Recalcul en cours…"
+      aria-valuetext={t("recomputing")}
       data-testid="inline-recomputation-bar"
       className="fixed top-0 left-0 right-0 z-50 h-0.5 overflow-hidden"
     >

--- a/pwa/src/components/stage-skeleton.tsx
+++ b/pwa/src/components/stage-skeleton.tsx
@@ -14,7 +14,7 @@ export function StageSkeleton() {
 
   return (
     <Card
-      className="border-border shadow-sm rounded-xl w-full relative"
+      className="border-border shadow-sm rounded-xl w-full md:max-w-[80%] relative"
       data-testid="stage-skeleton"
       aria-busy="true"
       aria-label={t("recomputing")}

--- a/pwa/src/components/stage-skeleton.tsx
+++ b/pwa/src/components/stage-skeleton.tsx
@@ -14,7 +14,7 @@ export function StageSkeleton() {
 
   return (
     <Card
-      className="border-border shadow-sm rounded-xl w-full md:max-w-[80%] relative"
+      className="border-border shadow-sm rounded-xl w-full relative"
       data-testid="stage-skeleton"
       aria-busy="true"
       aria-label={t("recomputing")}
@@ -31,9 +31,9 @@ export function StageSkeleton() {
 
         {/* Metadata row */}
         <div className="flex items-center gap-3 flex-wrap mt-3">
-          <Skeleton className="h-5 w-20" />
-          <Skeleton className="h-5 w-24" />
-          <Skeleton className="h-5 w-16" />
+          <Skeleton className="h-5 w-1/4" />
+          <Skeleton className="h-5 w-1/3" />
+          <Skeleton className="h-5 w-1/5" />
         </div>
 
         {/* Bottom area — mirrors accommodations section height */}

--- a/pwa/src/components/stage-skeleton.tsx
+++ b/pwa/src/components/stage-skeleton.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { Card, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+/**
+ * Shimmer skeleton that replaces a {@link StageCard} during an inline
+ * recomputation (Acte 3). Matches the minimum dimensions of the real card
+ * to avoid layout shift while the backend re-processes the stage.
+ */
+export function StageSkeleton() {
+  const t = useTranslations("stage");
+
+  return (
+    <Card
+      className="border-border shadow-sm rounded-xl w-full md:max-w-[80%] relative"
+      data-testid="stage-skeleton"
+      aria-busy="true"
+      aria-label={t("recomputing")}
+    >
+      <CardContent className="p-4 md:p-6">
+        {/* Status label */}
+        <p className="text-xs text-muted-foreground mb-3">{t("recomputing")}</p>
+
+        {/* Locations row */}
+        <div className="flex flex-col gap-1.5 mb-3">
+          <Skeleton className="h-4 w-2/3" />
+          <Skeleton className="h-4 w-1/2" />
+        </div>
+
+        {/* Metadata row */}
+        <div className="flex items-center gap-3 flex-wrap mt-3">
+          <Skeleton className="h-5 w-20" />
+          <Skeleton className="h-5 w-24" />
+          <Skeleton className="h-5 w-16" />
+        </div>
+
+        {/* Bottom area — mirrors accommodations section height */}
+        <div className="mt-6">
+          <Skeleton className="h-px w-full mb-4" />
+          <Skeleton className="h-10 w-full" />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/pwa/src/components/timeline.tsx
+++ b/pwa/src/components/timeline.tsx
@@ -5,11 +5,13 @@ import { useTranslations } from "next-intl";
 import { NoDatesBanner } from "@/components/no-dates-banner";
 import { TimelineMarker } from "@/components/timeline-marker";
 import { StageCard } from "@/components/stage-card";
+import { StageSkeleton } from "@/components/stage-skeleton";
 import { AddStageButton } from "@/components/add-stage-button";
 import { AddRestDayButton } from "@/components/add-rest-day-button";
 import { RestDayCard } from "@/components/rest-day-card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useUiStore } from "@/store/ui-store";
+import { useTripStore } from "@/store/trip-store";
 import type { StageData, AccommodationData } from "@/lib/validation/schemas";
 
 interface TimelineProps {
@@ -87,6 +89,7 @@ export function Timeline({
   const MIN_KM = 5;
   const tTimeline = useTranslations("timeline");
   const setActiveDayNumber = useUiStore((s) => s.setActiveDayNumber);
+  const recomputingStages = useTripStore((s) => s.recomputingStages);
 
   const canInsertStage = useCallback(
     (afterIndex: number): boolean => {
@@ -239,6 +242,8 @@ export function Timeline({
                         canDelete={!readOnly && stages.length > 2}
                         onDelete={() => onDeleteStage(originalIndex)}
                       />
+                    ) : recomputingStages.has(originalIndex) ? (
+                      <StageSkeleton />
                     ) : (
                       <StageCard
                         stage={stage}

--- a/pwa/src/components/trip-planner.tsx
+++ b/pwa/src/components/trip-planner.tsx
@@ -23,6 +23,7 @@ import { ViewModeToggle } from "@/components/ViewModeToggle";
 import { Button } from "@/components/ui/button";
 import { UndoRedoButtons } from "@/components/undo-redo-buttons";
 import { Stepper } from "@/components/stepper";
+import { InlineRecomputationBar } from "@/components/inline-recomputation-bar";
 import { RecentTrips } from "@/components/recent-trips";
 import { SavedTripsSection } from "@/components/saved-trips-section";
 import { OfflineBanner } from "@/components/offline-banner";
@@ -537,6 +538,9 @@ export function TripPlanner({ onClose }: { onClose?: () => void } = {}) {
              has launched the Phase 2 analysis via the preview CTA). === */}
         {trip && !isPreview && !isAnalysing && (
           <>
+            {/* Inline recomputation progress bar — thin bar at top of page */}
+            <InlineRecomputationBar />
+
             {/* Close button — top-right corner */}
             <Button
               variant="ghost"

--- a/pwa/src/hooks/use-mercure.ts
+++ b/pwa/src/hooks/use-mercure.ts
@@ -513,6 +513,9 @@ function dispatchEvent(event: MercureEvent): void {
       // fields (labels, search radius) are handled by the store.
       const incoming = enrichedPayloadToStageData(event.data.stage);
       store.applyStageUpdate(event.data.stageIndex, incoming);
+      // Remove this stage from the recomputing set — the shimmer skeleton
+      // can now be replaced by the real card.
+      store.finishStageRecomputation(event.data.stageIndex);
       // Labels may have been wiped if endpoints moved — refresh if needed.
       const updated = useTripStore.getState().stages[event.data.stageIndex];
       if (

--- a/pwa/src/hooks/use-mercure.ts
+++ b/pwa/src/hooks/use-mercure.ts
@@ -396,6 +396,7 @@ function dispatchEvent(event: MercureEvent): void {
         coordinates: event.data.coordinates,
       });
       store.updateStageAlerts(event.data.stageIndex, [], "cultural_poi");
+      store.clearRecomputingStages();
       useUiStore.getState().setProcessing(false);
       break;
     }
@@ -411,6 +412,7 @@ function dispatchEvent(event: MercureEvent): void {
       // ever gets called.
       useUiStore.getState().setAnalysisStarted(true);
       useUiStore.getState().setAnalysisPhaseActive(false);
+      store.clearRecomputingStages();
       useUiStore.getState().setProcessing(false);
       useUiStore.getState().setAccommodationScanning(false);
 
@@ -464,6 +466,7 @@ function dispatchEvent(event: MercureEvent): void {
       useUiStore.getState().setAnalysisProgress(null);
       useUiStore.getState().setAnalysisStarted(true);
       useUiStore.getState().setAnalysisPhaseActive(false);
+      store.clearRecomputingStages();
       useUiStore.getState().setProcessing(false);
       useUiStore.getState().setAccommodationScanning(false);
 
@@ -529,6 +532,7 @@ function dispatchEvent(event: MercureEvent): void {
 
     case "validation_error":
       toast.error(event.data.message);
+      store.clearRecomputingStages();
       useUiStore.getState().setProcessing(false);
       useUiStore.getState().setAccommodationScanning(false);
       break;
@@ -541,6 +545,7 @@ function dispatchEvent(event: MercureEvent): void {
         .getState()
         .failAnalysisStep(event.data.computation, event.data.message);
       if (!event.data.retryable) {
+        store.clearRecomputingStages();
         useUiStore.getState().setProcessing(false);
         useUiStore.getState().setAccommodationScanning(false);
         useUiStore.getState().setAnalysisPhaseActive(false);

--- a/pwa/src/hooks/use-trip-planner.ts
+++ b/pwa/src/hooks/use-trip-planner.ts
@@ -115,6 +115,7 @@ export function useTripPlanner() {
       updateStageAlerts: s.updateStageAlerts,
       setIsLocked: s.setIsLocked,
       setDepartureHour: s.setDepartureHour,
+      startStageRecomputation: s.startStageRecomputation,
     })),
   );
 
@@ -428,6 +429,8 @@ export function useTripPlanner() {
         useTripTemporalStore.getState()._push(snapshot);
         setProcessing(true);
         setAccommodationScanning(true);
+        // Mark this stage as recomputing so the shimmer skeleton appears.
+        actions.startStageRecomputation([index]);
       }
     } catch {
       toast.error(t("errors.failedUpdateLocation"));
@@ -782,6 +785,11 @@ export function useTripPlanner() {
       } else {
         setProcessing(true);
         setAccommodationScanning(true);
+        // Mark affected stages as recomputing: the selected stage and the
+        // next one (its startPoint may have shifted to the accommodation).
+        const affectedIndices = [stageIndex];
+        if (nextStageIndex !== null) affectedIndices.push(nextStageIndex);
+        actions.startStageRecomputation(affectedIndices);
       }
     } catch {
       toast.error(t("errors.failedSelectAccommodation"));
@@ -815,6 +823,14 @@ export function useTripPlanner() {
       } else {
         setProcessing(true);
         setAccommodationScanning(true);
+        // Mark affected stages as recomputing: the deselected stage and the
+        // next one (its startPoint reverts to original after deselection).
+        const affectedIndices: number[] = [stageIndex];
+        const nextIdx = stageIndex + 1;
+        if (nextIdx < useTripStore.getState().stages.length) {
+          affectedIndices.push(nextIdx);
+        }
+        actions.startStageRecomputation(affectedIndices);
       }
     } catch {
       toast.error(t("errors.failedDeselectAccommodation"));

--- a/pwa/src/store/trip-store.ts
+++ b/pwa/src/store/trip-store.ts
@@ -153,6 +153,8 @@ interface TripState {
    * lands for that index). When the set becomes empty the progress bar hides.
    */
   finishStageRecomputation: (index: number) => void;
+  /** Clear all recomputing stages — safety net for lost `stage_updated` events. */
+  clearRecomputingStages: () => void;
   clearTrip: () => void;
   /** Hydrate the trip store from a {@link SavedTrip} snapshot (offline consultation). */
   loadFromSavedTrip: (trip: SavedTrip) => void;
@@ -591,6 +593,11 @@ export const useTripStore = create<TripState>()(
     finishStageRecomputation: (index) =>
       set((state) => {
         state.recomputingStages.delete(index);
+      }),
+
+    clearRecomputingStages: () =>
+      set((state) => {
+        state.recomputingStages.clear();
       }),
 
     loadFromSavedTrip: (trip) => {

--- a/pwa/src/store/trip-store.ts
+++ b/pwa/src/store/trip-store.ts
@@ -2,6 +2,7 @@
 
 import { create } from "zustand";
 import { immer } from "zustand/middleware/immer";
+import { enableMapSet } from "immer";
 import { DEFAULT_ACCOMMODATION_RADIUS_KM } from "@/lib/accommodation-constants";
 import type {
   StageData,
@@ -16,6 +17,9 @@ import type { AccommodationType } from "@/lib/accommodation-types";
 import { FILTERABLE_ACCOMMODATION_TYPES } from "@/lib/accommodation-types";
 import { createTemporalStore } from "@/store/temporal-middleware";
 import type { SavedTrip } from "@/store/offline-store";
+
+// Required for Immer to allow mutating Set/Map drafts (used by recomputingStages).
+enableMapSet();
 
 interface TripIdentity {
   id: string;
@@ -41,6 +45,13 @@ interface TripState {
   enabledAccommodationTypes: AccommodationType[];
   stages: StageData[];
   computationStatus: Record<string, string>;
+  /**
+   * Set of stage indices currently being recomputed inline (Acte 3).
+   * While an index is in this set, the corresponding stage card is replaced
+   * by a shimmer skeleton. The set is populated when a recomputation is
+   * triggered and each index is removed when its `stage_updated` event lands.
+   */
+  recomputingStages: Set<number>;
 
   setTrip: (trip: TripIdentity) => void;
   updateRouteData: (data: {
@@ -132,6 +143,16 @@ interface TripState {
    * slice. No-op if the index is out of bounds (stale message).
    */
   applyStageUpdate: (stageIndex: number, stage: StageData) => void;
+  /**
+   * Mark a set of stage indices as "recomputing" — their cards show a shimmer
+   * skeleton until the corresponding `stage_updated` events arrive.
+   */
+  startStageRecomputation: (indices: number[]) => void;
+  /**
+   * Remove a stage index from the recomputing set (called when `stage_updated`
+   * lands for that index). When the set becomes empty the progress bar hides.
+   */
+  finishStageRecomputation: (index: number) => void;
   clearTrip: () => void;
   /** Hydrate the trip store from a {@link SavedTrip} snapshot (offline consultation). */
   loadFromSavedTrip: (trip: SavedTrip) => void;
@@ -157,6 +178,7 @@ const initialState = {
   ] as AccommodationType[],
   stages: [],
   computationStatus: {},
+  recomputingStages: new Set<number>(),
 };
 
 /**
@@ -557,6 +579,18 @@ export const useTripStore = create<TripState>()(
           // handler delivers fresh data via a supply_timeline event.
           supplyTimeline: prev.supplyTimeline,
         };
+      }),
+
+    startStageRecomputation: (indices) =>
+      set((state) => {
+        for (const index of indices) {
+          state.recomputingStages.add(index);
+        }
+      }),
+
+    finishStageRecomputation: (index) =>
+      set((state) => {
+        state.recomputingStages.delete(index);
       }),
 
     loadFromSavedTrip: (trip) => {

--- a/pwa/src/store/ui-store.ts
+++ b/pwa/src/store/ui-store.ts
@@ -332,7 +332,6 @@ export const useUiStore = create<UiState>()(
           error: message,
         };
       }),
-
   })),
 );
 

--- a/pwa/tests/fixtures/mock-data.ts
+++ b/pwa/tests/fixtures/mock-data.ts
@@ -577,3 +577,46 @@ export function stageUpdatedEvent(stageIndex: number): MercureEvent {
     },
   };
 }
+
+export function stageUpdatedEventWithSelectedAccommodation(
+  stageIndex: number,
+): MercureEvent {
+  const hotelDuPont = {
+    name: "Hotel du Pont",
+    type: "hotel",
+    lat: 44.51,
+    lon: 4.39,
+    estimatedPriceMin: 65,
+    estimatedPriceMax: 85,
+    isExactPrice: false,
+    possibleClosed: false,
+    distanceToEndPoint: 0.5,
+    source: "osm" as const,
+  };
+  return {
+    type: "stage_updated",
+    data: {
+      stageIndex,
+      stage: {
+        dayNumber: stageIndex + 1,
+        distance: 55.0,
+        elevation: 720,
+        elevationLoss: 640,
+        startPoint: { lat: 44.735, lon: 4.598, ele: 280 },
+        endPoint: { lat: hotelDuPont.lat, lon: hotelDuPont.lon, ele: 0 },
+        geometry: [
+          { lat: 44.735, lon: 4.598, ele: 280 },
+          { lat: hotelDuPont.lat, lon: hotelDuPont.lon, ele: 0 },
+        ],
+        label: null,
+        isRestDay: false,
+        weather: null,
+        alerts: [],
+        pois: [],
+        accommodations: [hotelDuPont],
+        selectedAccommodation: hotelDuPont,
+        events: [],
+      },
+    },
+  };
+}

--- a/pwa/tests/mocked/accommodation-selection.spec.ts
+++ b/pwa/tests/mocked/accommodation-selection.spec.ts
@@ -53,8 +53,11 @@ test.describe("Accommodation selection", () => {
     });
     await selectButtons.first().click();
 
-    // Skeleton shows while stage recomputes — resolve it
+    // Wait for skeleton to appear (PATCH has returned and startStageRecomputation fired)
+    await expect(stageCard).toBeHidden({ timeout: 3000 });
+    // Resolve both affected stages (accommodation change recomputes stage 0 and 1)
     await injectEvent(stageUpdatedEventWithSelectedAccommodation(0));
+    await injectEvent(stageUpdatedEvent(1));
 
     // The accommodation should now be marked as selected
     await expect(stageCard).toContainText("Sélectionné");
@@ -94,8 +97,11 @@ test.describe("Accommodation selection", () => {
     });
     await selectButtons.first().click();
 
-    // Skeleton shows while stage recomputes — resolve it
+    // Wait for skeleton to appear (PATCH has returned and startStageRecomputation fired)
+    await expect(stageCard).toBeHidden({ timeout: 3000 });
+    // Resolve both affected stages (accommodation change recomputes stage 0 and 1)
     await injectEvent(stageUpdatedEventWithSelectedAccommodation(0));
+    await injectEvent(stageUpdatedEvent(1));
 
     // Only the selected accommodation should remain (Hotel du Pont; Camping removed)
     await expect(stageCard).toContainText("Hotel du Pont");
@@ -122,16 +128,22 @@ test.describe("Accommodation selection", () => {
       name: "Sélectionner cet hébergement",
     });
     await selectButtons.first().click();
-    // Skeleton shows while stage recomputes — resolve it with selected accommodation
+    // Wait for skeleton to appear (PATCH has returned and startStageRecomputation fired)
+    await expect(stageCard).toBeHidden({ timeout: 3000 });
+    // Resolve both affected stages (accommodation change recomputes stage 0 and 1)
     await injectEvent(stageUpdatedEventWithSelectedAccommodation(0));
+    await injectEvent(stageUpdatedEvent(1));
     await expect(stageCard).toContainText("Sélectionné");
 
     // Deselect
     await stageCard
       .getByRole("button", { name: "Désélectionner l'hébergement" })
       .click();
-    // Skeleton shows again during deselect recomputation — resolve it
+    // Wait for skeleton to appear before injecting the resolve event
+    await expect(stageCard).toBeHidden({ timeout: 3000 });
+    // Skeleton shows again during deselect recomputation — resolve both stages
     await injectEvent(stageUpdatedEvent(0));
+    await injectEvent(stageUpdatedEvent(1));
 
     // "Sélectionné" badge should be gone
     await expect(stageCard).not.toContainText("Sélectionné");

--- a/pwa/tests/mocked/accommodation-selection.spec.ts
+++ b/pwa/tests/mocked/accommodation-selection.spec.ts
@@ -4,6 +4,8 @@ import {
   stagesComputedEvent,
   accommodationsFoundEvent,
   tripCompleteEvent,
+  stageUpdatedEvent,
+  stageUpdatedEventWithSelectedAccommodation,
 } from "../fixtures/mock-data";
 
 test.describe("Accommodation selection", () => {
@@ -31,6 +33,7 @@ test.describe("Accommodation selection", () => {
 
   test("selecting an accommodation marks it as selected", async ({
     submitUrl,
+    injectEvent,
     injectSequence,
     mockedPage,
   }) => {
@@ -50,6 +53,9 @@ test.describe("Accommodation selection", () => {
     });
     await selectButtons.first().click();
 
+    // Skeleton shows while stage recomputes — resolve it
+    await injectEvent(stageUpdatedEventWithSelectedAccommodation(0));
+
     // The accommodation should now be marked as selected
     await expect(stageCard).toContainText("Sélectionné");
 
@@ -67,6 +73,7 @@ test.describe("Accommodation selection", () => {
 
   test("selecting an accommodation keeps only that accommodation", async ({
     submitUrl,
+    injectEvent,
     injectSequence,
     mockedPage,
   }) => {
@@ -87,6 +94,9 @@ test.describe("Accommodation selection", () => {
     });
     await selectButtons.first().click();
 
+    // Skeleton shows while stage recomputes — resolve it
+    await injectEvent(stageUpdatedEventWithSelectedAccommodation(0));
+
     // Only the selected accommodation should remain (Hotel du Pont; Camping removed)
     await expect(stageCard).toContainText("Hotel du Pont");
     await expect(stageCard).not.toContainText("Camping Les Oliviers");
@@ -94,6 +104,7 @@ test.describe("Accommodation selection", () => {
 
   test("deselecting an accommodation restores deselect state", async ({
     submitUrl,
+    injectEvent,
     injectSequence,
     mockedPage,
   }) => {
@@ -111,12 +122,16 @@ test.describe("Accommodation selection", () => {
       name: "Sélectionner cet hébergement",
     });
     await selectButtons.first().click();
+    // Skeleton shows while stage recomputes — resolve it with selected accommodation
+    await injectEvent(stageUpdatedEventWithSelectedAccommodation(0));
     await expect(stageCard).toContainText("Sélectionné");
 
     // Deselect
     await stageCard
       .getByRole("button", { name: "Désélectionner l'hébergement" })
       .click();
+    // Skeleton shows again during deselect recomputation — resolve it
+    await injectEvent(stageUpdatedEvent(0));
 
     // "Sélectionné" badge should be gone
     await expect(stageCard).not.toContainText("Sélectionné");

--- a/pwa/tests/mocked/inline-recomputation.spec.ts
+++ b/pwa/tests/mocked/inline-recomputation.spec.ts
@@ -202,9 +202,9 @@ test.describe("Inline recomputation — progress bar", () => {
     await injectEvent(stageUpdatedEvent(1));
 
     // Bar should disappear once recomputingStages is empty
-    await expect(
-      mockedPage.getByTestId("inline-recomputation-bar"),
-    ).toBeHidden({ timeout: 3000 });
+    await expect(mockedPage.getByTestId("inline-recomputation-bar")).toBeHidden(
+      { timeout: 3000 },
+    );
   });
 
   test("progress bar is not visible outside Acte 3 (no trip loaded)", async ({

--- a/pwa/tests/mocked/inline-recomputation.spec.ts
+++ b/pwa/tests/mocked/inline-recomputation.spec.ts
@@ -1,0 +1,218 @@
+import { test, expect } from "../fixtures/base.fixture";
+import {
+  routeParsedEvent,
+  stagesComputedEvent,
+  tripCompleteEvent,
+  stageUpdatedEvent,
+  accommodationsFoundEvent,
+} from "../fixtures/mock-data";
+
+/**
+ * Issue #326 — Acte 3 inline recomputation: shimmer skeleton + discrete progress bar.
+ *
+ * When the user modifies something in "Mon voyage" (Acte 3) — such as
+ * selecting/deselecting an accommodation — affected stage cards are replaced
+ * by a shimmer skeleton while the backend recomputes. A thin progress bar
+ * appears at the top of the page during the recomputation and disappears once
+ * all `stage_updated` events have landed.
+ */
+
+test.describe("Inline recomputation — skeleton", () => {
+  test("shimmer skeleton replaces stage card while stage_updated is pending", async ({
+    submitUrl,
+    injectEvent,
+    injectSequence,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    await injectSequence([
+      routeParsedEvent(),
+      stagesComputedEvent(),
+      accommodationsFoundEvent(0),
+      tripCompleteEvent(),
+    ]);
+    await expect(mockedPage.getByTestId("stage-card-1")).toBeVisible({
+      timeout: 10000,
+    });
+
+    // Trigger inline recomputation by selecting an accommodation
+    const stageCard = mockedPage.getByTestId("stage-card-1");
+    const selectButtons = stageCard.getByRole("button", {
+      name: "Sélectionner cet hébergement",
+    });
+    await selectButtons.first().click();
+
+    // The skeleton should appear on the affected stage
+    await expect(mockedPage.getByTestId("stage-skeleton").first()).toBeVisible({
+      timeout: 3000,
+    });
+
+    // The original stage card should be gone while recomputing
+    await expect(mockedPage.getByTestId("stage-card-1")).toBeHidden();
+  });
+
+  test("stage card is restored after stage_updated arrives", async ({
+    submitUrl,
+    injectEvent,
+    injectSequence,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    await injectSequence([
+      routeParsedEvent(),
+      stagesComputedEvent(),
+      accommodationsFoundEvent(0),
+      tripCompleteEvent(),
+    ]);
+    await expect(mockedPage.getByTestId("stage-card-1")).toBeVisible({
+      timeout: 10000,
+    });
+
+    // Trigger inline recomputation
+    const selectButtons = mockedPage
+      .getByTestId("stage-card-1")
+      .getByRole("button", { name: "Sélectionner cet hébergement" });
+    await selectButtons.first().click();
+
+    // Wait for skeleton to appear
+    await expect(mockedPage.getByTestId("stage-skeleton").first()).toBeVisible({
+      timeout: 3000,
+    });
+
+    // Inject stage_updated for index 0 to resolve the recomputation
+    await injectEvent(stageUpdatedEvent(0));
+
+    // The real stage card should be back
+    await expect(mockedPage.getByTestId("stage-card-1")).toBeVisible({
+      timeout: 3000,
+    });
+
+    // The skeleton should be gone
+    await expect(mockedPage.getByTestId("stage-skeleton")).toBeHidden();
+  });
+
+  test("skeleton preserves approximate card dimensions (no layout shift)", async ({
+    submitUrl,
+    injectEvent,
+    injectSequence,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    await injectSequence([
+      routeParsedEvent(),
+      stagesComputedEvent(),
+      accommodationsFoundEvent(0),
+      tripCompleteEvent(),
+    ]);
+    await expect(mockedPage.getByTestId("stage-card-1")).toBeVisible({
+      timeout: 10000,
+    });
+
+    // Measure the card before recomputation
+    const cardBefore = await mockedPage
+      .getByTestId("stage-card-1")
+      .boundingBox();
+    expect(cardBefore).not.toBeNull();
+
+    // Trigger recomputation
+    const selectButtons = mockedPage
+      .getByTestId("stage-card-1")
+      .getByRole("button", { name: "Sélectionner cet hébergement" });
+    await selectButtons.first().click();
+
+    // Measure the skeleton
+    await expect(mockedPage.getByTestId("stage-skeleton").first()).toBeVisible({
+      timeout: 3000,
+    });
+    const skeletonBox = await mockedPage
+      .getByTestId("stage-skeleton")
+      .first()
+      .boundingBox();
+    expect(skeletonBox).not.toBeNull();
+
+    // Width should be the same (same max-width constraints apply to both)
+    expect(skeletonBox!.width).toBeCloseTo(cardBefore!.width, -1);
+  });
+});
+
+test.describe("Inline recomputation — progress bar", () => {
+  test("progress bar appears when a recomputation starts", async ({
+    submitUrl,
+    injectEvent,
+    injectSequence,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    await injectSequence([
+      routeParsedEvent(),
+      stagesComputedEvent(),
+      accommodationsFoundEvent(0),
+      tripCompleteEvent(),
+    ]);
+    await expect(mockedPage.getByTestId("stage-card-1")).toBeVisible({
+      timeout: 10000,
+    });
+
+    // Bar should not be visible before any recomputation
+    await expect(
+      mockedPage.getByTestId("inline-recomputation-bar"),
+    ).toBeHidden();
+
+    // Trigger recomputation via accommodation selection
+    const selectButtons = mockedPage
+      .getByTestId("stage-card-1")
+      .getByRole("button", { name: "Sélectionner cet hébergement" });
+    await selectButtons.first().click();
+
+    // Bar should appear
+    await expect(
+      mockedPage.getByTestId("inline-recomputation-bar"),
+    ).toBeVisible({ timeout: 3000 });
+  });
+
+  test("progress bar disappears after all stage_updated events land", async ({
+    submitUrl,
+    injectEvent,
+    injectSequence,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    await injectSequence([
+      routeParsedEvent(),
+      stagesComputedEvent(),
+      accommodationsFoundEvent(0),
+      tripCompleteEvent(),
+    ]);
+    await expect(mockedPage.getByTestId("stage-card-1")).toBeVisible({
+      timeout: 10000,
+    });
+
+    // Trigger recomputation
+    const selectButtons = mockedPage
+      .getByTestId("stage-card-1")
+      .getByRole("button", { name: "Sélectionner cet hébergement" });
+    await selectButtons.first().click();
+
+    await expect(
+      mockedPage.getByTestId("inline-recomputation-bar"),
+    ).toBeVisible({ timeout: 3000 });
+
+    // Inject stage_updated for both affected stages (0 and 1)
+    await injectEvent(stageUpdatedEvent(0));
+    await injectEvent(stageUpdatedEvent(1));
+
+    // Bar should disappear once recomputingStages is empty
+    await expect(
+      mockedPage.getByTestId("inline-recomputation-bar"),
+    ).toBeHidden({ timeout: 3000 });
+  });
+
+  test("progress bar is not visible outside Acte 3 (no trip loaded)", async ({
+    mockedPage,
+  }) => {
+    // On the welcome screen there is no inline recomputation bar
+    await expect(
+      mockedPage.getByTestId("inline-recomputation-bar"),
+    ).toBeHidden();
+  });
+});

--- a/pwa/tests/mocked/inline-recomputation.spec.ts
+++ b/pwa/tests/mocked/inline-recomputation.spec.ts
@@ -110,8 +110,10 @@ test.describe("Inline recomputation — skeleton", () => {
       timeout: 3000,
     });
 
-    // Inject stage_updated for index 0 to resolve the recomputation
+    // Inject stage_updated for both affected stages: selecting an accommodation
+    // on stage 0 also triggers recomputation of stage 1 (its start shifts).
     await injectEvent(stageUpdatedEvent(0));
+    await injectEvent(stageUpdatedEvent(1));
 
     // The real stage card should be back
     await expect(mockedPage.getByTestId("stage-card-1")).toBeVisible({

--- a/pwa/tests/mocked/inline-recomputation.spec.ts
+++ b/pwa/tests/mocked/inline-recomputation.spec.ts
@@ -18,6 +18,37 @@ import {
  */
 
 test.describe("Inline recomputation — skeleton", () => {
+  test("shimmer skeleton appears after a distance change", async ({
+    submitUrl,
+    injectSequence,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    await injectSequence([
+      routeParsedEvent(),
+      stagesComputedEvent(),
+      accommodationsFoundEvent(0),
+      tripCompleteEvent(),
+    ]);
+    await expect(mockedPage.getByTestId("stage-card-1")).toBeVisible({
+      timeout: 10000,
+    });
+
+    // Trigger distance change
+    const stageCard = mockedPage.getByTestId("stage-card-1");
+    await stageCard
+      .getByRole("button", { name: "Modifier la distance" })
+      .click();
+    const input = stageCard.getByRole("spinbutton", { name: "Distance (km)" });
+    await input.fill("80");
+    await input.press("Enter");
+
+    // Skeleton should appear immediately after the PATCH succeeds
+    await expect(mockedPage.getByTestId("stage-skeleton").first()).toBeVisible({
+      timeout: 3000,
+    });
+  });
+
   test("shimmer skeleton replaces stage card while stage_updated is pending", async ({
     submitUrl,
     injectEvent,

--- a/pwa/tests/mocked/undo-redo.spec.ts
+++ b/pwa/tests/mocked/undo-redo.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "../fixtures/base.fixture";
+import { stageUpdatedEvent } from "../fixtures/mock-data";
 
 test.describe("Undo/Redo", () => {
   test("undo and redo buttons are disabled on fresh page load", async ({
@@ -58,6 +59,7 @@ test.describe("Undo/Redo", () => {
 
   test("Ctrl+Z is suppressed when an input is focused", async ({
     createFullTrip,
+    injectEvent,
     mockedPage,
   }) => {
     await createFullTrip();
@@ -74,6 +76,10 @@ test.describe("Undo/Redo", () => {
     await expect(mockedPage.getByTestId("undo-button")).toBeEnabled({
       timeout: 5000,
     });
+    // The distance change puts stage 0 in recomputing state (skeleton visible).
+    // Resolve it so the real card is accessible again.
+    await injectEvent(stageUpdatedEvent(0));
+    await expect(stageCard).toBeVisible({ timeout: 3000 });
     // Open the distance editor again — input is auto-focused
     await stageCard
       .getByRole("button", { name: "Modifier la distance" })


### PR DESCRIPTION
## Summary

- Adds a `recomputingStages: Set<number>` state to `trip-store.ts` tracking which stage indices are currently being recomputed inline (Acte 3)
- Introduces a new `StageSkeleton` component (animated shimmer) that replaces the real `StageCard` while a stage is recomputing — same dimensions to avoid layout shift
- Introduces a new `InlineRecomputationBar` component — a thin indeterminate progress bar fixed at the top of the page, visible only during an Acte 3 recomputation
- `use-mercure.ts` calls `finishStageRecomputation(index)` when a `stage_updated` event lands, removing the stage from the recomputing set
- `use-trip-planner.ts` calls `startStageRecomputation(indices)` on accommodation select/deselect and distance changes to trigger the shimmer

## Test plan

- [ ] Playwright mocked test `inline-recomputation.spec.ts`:
  - Selecting an accommodation → shimmer skeleton replaces the stage card
  - `stage_updated` SSE event → real card is restored, skeleton gone
  - Skeleton has approximately the same width as the original card (no layout shift)
  - Progress bar appears on recomputation start and disappears once all `stage_updated` events have landed
  - Progress bar is not visible outside Acte 3

Closes #326

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- claude-review-start -->
## Claude Review

Clean, complete implementation reviewed on commit `da25467`. All issues from prior rounds are fully addressed: i18n ARIA labels in `InlineRecomputationBar`, the `clearRecomputingStages` safety net at every terminal Mercure event (`route_segment_recalculated`, `trip_complete`, `trip_ready`, `validation_error`, non-retryable `computation_failed`), and E2E coverage for the `handleDistanceChange` trigger path. No new findings.

**Resolved threads:** All 3 previously open bot-authored threads are already resolved.

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Inline comments

No inline comments.

---
Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->