### PR TITLE
feat(pwa): add diff highlight after inline recomputation (#328)

### DIFF
--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -48,6 +48,8 @@
     "saveDistance": "Save",
     "travelTime": "Dep ~{departure} → Arr ~{arrival}",
     "travelTimeTooltip": "Estimate based on average speed and elevation gain (Naismith rule adapted for cycling)",
+    "diffDistanceChanged": "Distance changed",
+    "diffAlertsAdded": "New alerts added",
     "sunriseSunsetTooltip": "Sunrise and sunset times at stage end point (UTC)"
   },
   "stageLocations": {

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -48,6 +48,8 @@
     "saveDistance": "Enregistrer",
     "travelTime": "Départ ~{departure} → Arrivée ~{arrival}",
     "travelTimeTooltip": "Estimation basée sur la vitesse moyenne et le dénivelé (règle de Naismith adaptée au vélo)",
+    "diffDistanceChanged": "Distance modifiée",
+    "diffAlertsAdded": "Nouvelles alertes ajoutées",
     "sunriseSunsetTooltip": "Heures de lever et coucher du soleil au point d'arrivée de l'étape (UTC)"
   },
   "stageLocations": {

--- a/pwa/src/app/globals.css
+++ b/pwa/src/app/globals.css
@@ -140,6 +140,27 @@
   }
 }
 
+/**
+ * Transient highlight for diff fields after an inline recomputation.
+ * Starts with a yellow background and fades to transparent over 3 s,
+ * matching the store expiry timer in use-mercure.ts.
+ */
+@keyframes diff-highlight {
+  0% {
+    background-color: oklch(0.97 0.12 95);
+  }
+  30% {
+    background-color: oklch(0.97 0.12 95);
+  }
+  100% {
+    background-color: transparent;
+  }
+}
+
+.diff-highlight {
+  animation: diff-highlight 3s ease-out forwards;
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/pwa/src/app/globals.css
+++ b/pwa/src/app/globals.css
@@ -49,6 +49,7 @@
   --color-brand-light: var(--brand-light);
   --color-brand-hover: var(--brand-hover);
   --color-muted-icon: var(--muted-icon);
+  --color-diff-highlight: var(--diff-highlight);
 }
 
 :root {
@@ -57,6 +58,7 @@
   --brand-light: #ebf5f6;
   --brand-hover: #2e8a9a;
   --muted-icon: #9da5a7;
+  --diff-highlight: oklch(0.97 0.12 95);
   --background: oklch(1 0 0);
   --foreground: oklch(0.129 0.042 264.695);
   --card: oklch(1 0 0);
@@ -95,6 +97,7 @@
   --brand-light: #1a3a40;
   --brand-hover: #4bbdd1;
   --muted-icon: #6b7275;
+  --diff-highlight: oklch(0.35 0.08 95);
   --background: oklch(0.129 0.042 264.695);
   --foreground: oklch(0.984 0.003 247.858);
   --card: oklch(0.208 0.042 265.755);
@@ -147,10 +150,10 @@
  */
 @keyframes diff-highlight {
   0% {
-    background-color: oklch(0.97 0.12 95);
+    background-color: var(--color-diff-highlight);
   }
   30% {
-    background-color: oklch(0.97 0.12 95);
+    background-color: var(--color-diff-highlight);
   }
   100% {
     background-color: transparent;

--- a/pwa/src/components/diff-highlight.tsx
+++ b/pwa/src/components/diff-highlight.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useTripStore } from "@/store/trip-store";
+
+interface DiffHighlightProps {
+  /** Index of the stage this highlight belongs to. */
+  stageIndex: number;
+  /**
+   * Logical field name to watch. When this field appears in the stage's
+   * `stageDiffs` set, the children receive a transient highlight animation.
+   *
+   * Valid values: `"distance"`, `"elevation"`, `"arrivalTime"`,
+   * `"alerts_added"`, `"alerts_removed"`, `"selectedAccommodation"`.
+   */
+  field: string;
+  /** Content to wrap. Receives the highlight class when the field changed. */
+  children: React.ReactNode;
+  /**
+   * Optional accessible label suffix appended to a visually-hidden span so
+   * screen-reader users are informed of the change without relying on colour
+   * alone. Defaults to the empty string (no announcement).
+   */
+  changeLabel?: string;
+}
+
+/**
+ * Wraps its children in a `<span>` that temporarily receives a yellow-to-
+ * transparent background animation whenever the specified `field` appears in
+ * the `stageDiffs` map for the given `stageIndex`.
+ *
+ * The highlight is self-resetting: the store entry is cleared after ~3 s by
+ * the timer set in `use-mercure.ts`, which automatically removes the CSS class
+ * because the component re-renders when the store changes.
+ *
+ * Accessibility: a visually-hidden `<span aria-live="polite">` announces the
+ * change to assistive technologies when `changeLabel` is provided, satisfying
+ * WCAG 1.4.1 (not solely colour-based).
+ *
+ * Usage:
+ * ```tsx
+ * <DiffHighlight stageIndex={i} field="distance" changeLabel="Distance modifiée">
+ *   <span>{stage.distance} km</span>
+ * </DiffHighlight>
+ * ```
+ */
+export function DiffHighlight({
+  stageIndex,
+  field,
+  children,
+  changeLabel = "",
+}: DiffHighlightProps) {
+  const isChanged = useTripStore(
+    (s) => s.stageDiffs.get(stageIndex)?.has(field) ?? false,
+  );
+
+  return (
+    <span
+      className={isChanged ? "diff-highlight rounded px-0.5" : undefined}
+      data-testid={isChanged ? `diff-highlight-${field}` : undefined}
+    >
+      {children}
+      {isChanged && changeLabel && (
+        <span
+          className="sr-only"
+          aria-live="polite"
+          aria-atomic="true"
+        >
+          {changeLabel}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/pwa/src/components/diff-highlight.tsx
+++ b/pwa/src/components/diff-highlight.tsx
@@ -9,8 +9,7 @@ interface DiffHighlightProps {
    * Logical field name to watch. When this field appears in the stage's
    * `stageDiffs` set, the children receive a transient highlight animation.
    *
-   * Valid values: `"distance"`, `"elevation"`, `"arrivalTime"`,
-   * `"alerts_added"`, `"alerts_removed"`, `"selectedAccommodation"`.
+   * Valid values: `"distance"`, `"alerts_added"`.
    */
   field: string;
   /** Content to wrap. Receives the highlight class when the field changed. */
@@ -59,9 +58,9 @@ export function DiffHighlight({
       data-testid={isChanged ? `diff-highlight-${field}` : undefined}
     >
       {children}
-      {isChanged && changeLabel && (
+      {changeLabel && (
         <span className="sr-only" aria-live="polite" aria-atomic="true">
-          {changeLabel}
+          {isChanged ? changeLabel : ""}
         </span>
       )}
     </span>

--- a/pwa/src/components/diff-highlight.tsx
+++ b/pwa/src/components/diff-highlight.tsx
@@ -60,11 +60,7 @@ export function DiffHighlight({
     >
       {children}
       {isChanged && changeLabel && (
-        <span
-          className="sr-only"
-          aria-live="polite"
-          aria-atomic="true"
-        >
+        <span className="sr-only" aria-live="polite" aria-atomic="true">
           {changeLabel}
         </span>
       )}

--- a/pwa/src/components/stage-card.tsx
+++ b/pwa/src/components/stage-card.tsx
@@ -166,12 +166,8 @@ export function StageCard({
                   isProcessing={isProcessing}
                   departureHour={stage.isRestDay ? undefined : departureHour}
                   averageSpeedKmh={stage.isRestDay ? undefined : averageSpeed}
-                  endPointLat={
-                    stage.isRestDay ? undefined : stage.endPoint.lat
-                  }
-                  endPointLon={
-                    stage.isRestDay ? undefined : stage.endPoint.lon
-                  }
+                  endPointLat={stage.isRestDay ? undefined : stage.endPoint.lat}
+                  endPointLon={stage.isRestDay ? undefined : stage.endPoint.lon}
                   startDate={stage.isRestDay ? undefined : startDate}
                   stageIndex={stage.isRestDay ? undefined : stageIndex}
                 />

--- a/pwa/src/components/stage-card.tsx
+++ b/pwa/src/components/stage-card.tsx
@@ -14,6 +14,7 @@ import { EventsPanel } from "@/components/events-panel";
 import { StageDownloads } from "@/components/stage-downloads";
 import { StageDistanceEditor } from "@/components/stage-distance-editor";
 import { DifficultyGauge } from "@/components/difficulty-gauge";
+import { DiffHighlight } from "@/components/diff-highlight";
 import { SupplyTimeline } from "@/components/SupplyTimeline/SupplyTimeline";
 import type { StageData, AccommodationData } from "@/lib/validation/schemas";
 import { useTripStore } from "@/store/trip-store";
@@ -152,19 +153,29 @@ export function StageCard({
             />
           ) : (
             <>
-              <StageMetadata
-                distance={stage.distance}
-                elevation={stage.elevation}
-                elevationLoss={stage.elevationLoss ?? 0}
-                weather={stage.weather}
-                isProcessing={isProcessing}
-                departureHour={stage.isRestDay ? undefined : departureHour}
-                averageSpeedKmh={stage.isRestDay ? undefined : averageSpeed}
-                endPointLat={stage.isRestDay ? undefined : stage.endPoint.lat}
-                endPointLon={stage.isRestDay ? undefined : stage.endPoint.lon}
-                startDate={stage.isRestDay ? undefined : startDate}
-                stageIndex={stage.isRestDay ? undefined : stageIndex}
-              />
+              <DiffHighlight
+                stageIndex={stageIndex}
+                field="distance"
+                changeLabel={t("diffDistanceChanged")}
+              >
+                <StageMetadata
+                  distance={stage.distance}
+                  elevation={stage.elevation}
+                  elevationLoss={stage.elevationLoss ?? 0}
+                  weather={stage.weather}
+                  isProcessing={isProcessing}
+                  departureHour={stage.isRestDay ? undefined : departureHour}
+                  averageSpeedKmh={stage.isRestDay ? undefined : averageSpeed}
+                  endPointLat={
+                    stage.isRestDay ? undefined : stage.endPoint.lat
+                  }
+                  endPointLon={
+                    stage.isRestDay ? undefined : stage.endPoint.lon
+                  }
+                  startDate={stage.isRestDay ? undefined : startDate}
+                  stageIndex={stage.isRestDay ? undefined : stageIndex}
+                />
+              </DiffHighlight>
               {stage.distance !== null && (
                 <DifficultyGauge
                   difficulty={difficulty}
@@ -189,10 +200,16 @@ export function StageCard({
         {/* Alerts */}
         {stage.alerts.length > 0 && (
           <div className="mt-3">
-            <StageAlerts
-              alerts={stage.alerts}
-              onAddPoiWaypoint={onAddPoiWaypoint}
-            />
+            <DiffHighlight
+              stageIndex={stageIndex}
+              field="alerts_added"
+              changeLabel={t("diffAlertsAdded")}
+            >
+              <StageAlerts
+                alerts={stage.alerts}
+                onAddPoiWaypoint={onAddPoiWaypoint}
+              />
+            </DiffHighlight>
           </div>
         )}
         {isProcessing && stage.alerts.length === 0 && (

--- a/pwa/src/hooks/use-mercure.ts
+++ b/pwa/src/hooks/use-mercure.ts
@@ -16,6 +16,8 @@ const MERCURE_URL =
   process.env.NEXT_PUBLIC_MERCURE_URL ??
   "https://localhost/.well-known/mercure";
 
+const stageDiffTimers = new Map<number, ReturnType<typeof setTimeout>>();
+
 /**
  * Dispatches a Mercure SSE event to the appropriate Zustand store action.
  *
@@ -524,11 +526,14 @@ function dispatchEvent(event: MercureEvent): void {
       if (prevStage) {
         const changed = computeStageDiff(prevStage, incoming);
         if (changed.size > 0) {
+          const existingTimer = stageDiffTimers.get(event.data.stageIndex);
+          if (existingTimer !== undefined) clearTimeout(existingTimer);
           store.setStageDiff(event.data.stageIndex, changed);
-          // Auto-clear after 3 seconds so the highlight fades out naturally.
-          setTimeout(() => {
+          const timer = setTimeout(() => {
             useTripStore.getState().clearStageDiff(event.data.stageIndex);
+            stageDiffTimers.delete(event.data.stageIndex);
           }, 3000);
+          stageDiffTimers.set(event.data.stageIndex, timer);
         }
       }
 
@@ -576,21 +581,14 @@ function dispatchEvent(event: MercureEvent): void {
  * the store so that `DiffHighlight` can transiently highlight each changed
  * piece of data.
  *
- * Compared fields: `distance`, `elevation`, `alerts`, `selectedAccommodation`,
- * `arrivalTime` (derived from distance + speed, approximated by distance).
+ * Compared fields: `distance`, `alerts_added`.
  */
 function computeStageDiff(prev: StageData, next: StageData): Set<string> {
   const changed = new Set<string>();
 
   if (prev.distance !== next.distance) changed.add("distance");
-  if (
-    prev.elevation !== next.elevation ||
-    prev.elevationLoss !== next.elevationLoss
-  ) {
-    changed.add("elevation");
-  }
 
-  // Alert changes: detect new alerts (added) and removed ones
+  // Alert changes: detect newly added alerts only
   const prevMessages = new Set(
     prev.alerts.map((a) => `${a.type}:${a.message}`),
   );
@@ -598,17 +596,7 @@ function computeStageDiff(prev: StageData, next: StageData): Set<string> {
     next.alerts.map((a) => `${a.type}:${a.message}`),
   );
   const hasNewAlerts = [...nextMessages].some((m) => !prevMessages.has(m));
-  const hasRemovedAlerts = [...prevMessages].some((m) => !nextMessages.has(m));
   if (hasNewAlerts) changed.add("alerts_added");
-  if (hasRemovedAlerts) changed.add("alerts_removed");
-
-  // Accommodation change: compare selected accommodation identity
-  const prevAccName = prev.selectedAccommodation?.name ?? null;
-  const nextAccName = next.selectedAccommodation?.name ?? null;
-  if (prevAccName !== nextAccName) changed.add("selectedAccommodation");
-
-  // Arrival time is derived from distance; flag it when distance changes.
-  if (prev.distance !== next.distance) changed.add("arrivalTime");
 
   return changed;
 }

--- a/pwa/src/hooks/use-mercure.ts
+++ b/pwa/src/hooks/use-mercure.ts
@@ -579,10 +579,7 @@ function dispatchEvent(event: MercureEvent): void {
  * Compared fields: `distance`, `elevation`, `alerts`, `selectedAccommodation`,
  * `arrivalTime` (derived from distance + speed, approximated by distance).
  */
-function computeStageDiff(
-  prev: StageData,
-  next: StageData,
-): Set<string> {
+function computeStageDiff(prev: StageData, next: StageData): Set<string> {
   const changed = new Set<string>();
 
   if (prev.distance !== next.distance) changed.add("distance");
@@ -594,8 +591,12 @@ function computeStageDiff(
   }
 
   // Alert changes: detect new alerts (added) and removed ones
-  const prevMessages = new Set(prev.alerts.map((a) => `${a.type}:${a.message}`));
-  const nextMessages = new Set(next.alerts.map((a) => `${a.type}:${a.message}`));
+  const prevMessages = new Set(
+    prev.alerts.map((a) => `${a.type}:${a.message}`),
+  );
+  const nextMessages = new Set(
+    next.alerts.map((a) => `${a.type}:${a.message}`),
+  );
   const hasNewAlerts = [...nextMessages].some((m) => !prevMessages.has(m));
   const hasRemovedAlerts = [...prevMessages].some((m) => !nextMessages.has(m));
   if (hasNewAlerts) changed.add("alerts_added");

--- a/pwa/src/hooks/use-mercure.ts
+++ b/pwa/src/hooks/use-mercure.ts
@@ -515,7 +515,23 @@ function dispatchEvent(event: MercureEvent): void {
       // Mode 2 — per-stage update. Replace the single slice; preserved
       // fields (labels, search radius) are handled by the store.
       const incoming = enrichedPayloadToStageData(event.data.stage);
+
+      // Capture previous state before applying the update to compute the diff.
+      const prevStage = store.stages[event.data.stageIndex];
       store.applyStageUpdate(event.data.stageIndex, incoming);
+
+      // Compute the set of changed fields for transient diff highlighting.
+      if (prevStage) {
+        const changed = computeStageDiff(prevStage, incoming);
+        if (changed.size > 0) {
+          store.setStageDiff(event.data.stageIndex, changed);
+          // Auto-clear after 3 seconds so the highlight fades out naturally.
+          setTimeout(() => {
+            useTripStore.getState().clearStageDiff(event.data.stageIndex);
+          }, 3000);
+        }
+      }
+
       // Remove this stage from the recomputing set — the shimmer skeleton
       // can now be replaced by the real card.
       store.finishStageRecomputation(event.data.stageIndex);
@@ -552,6 +568,48 @@ function dispatchEvent(event: MercureEvent): void {
       }
       break;
   }
+}
+
+/**
+ * Compares a previous and incoming stage snapshot and returns the set of
+ * logical field names that have changed. Used to populate `stageDiffs` in
+ * the store so that `DiffHighlight` can transiently highlight each changed
+ * piece of data.
+ *
+ * Compared fields: `distance`, `elevation`, `alerts`, `selectedAccommodation`,
+ * `arrivalTime` (derived from distance + speed, approximated by distance).
+ */
+function computeStageDiff(
+  prev: StageData,
+  next: StageData,
+): Set<string> {
+  const changed = new Set<string>();
+
+  if (prev.distance !== next.distance) changed.add("distance");
+  if (
+    prev.elevation !== next.elevation ||
+    prev.elevationLoss !== next.elevationLoss
+  ) {
+    changed.add("elevation");
+  }
+
+  // Alert changes: detect new alerts (added) and removed ones
+  const prevMessages = new Set(prev.alerts.map((a) => `${a.type}:${a.message}`));
+  const nextMessages = new Set(next.alerts.map((a) => `${a.type}:${a.message}`));
+  const hasNewAlerts = [...nextMessages].some((m) => !prevMessages.has(m));
+  const hasRemovedAlerts = [...prevMessages].some((m) => !nextMessages.has(m));
+  if (hasNewAlerts) changed.add("alerts_added");
+  if (hasRemovedAlerts) changed.add("alerts_removed");
+
+  // Accommodation change: compare selected accommodation identity
+  const prevAccName = prev.selectedAccommodation?.name ?? null;
+  const nextAccName = next.selectedAccommodation?.name ?? null;
+  if (prevAccName !== nextAccName) changed.add("selectedAccommodation");
+
+  // Arrival time is derived from distance; flag it when distance changes.
+  if (prev.distance !== next.distance) changed.add("arrivalTime");
+
+  return changed;
 }
 
 /**

--- a/pwa/src/store/trip-store.ts
+++ b/pwa/src/store/trip-store.ts
@@ -52,6 +52,13 @@ interface TripState {
    * triggered and each index is removed when its `stage_updated` event lands.
    */
   recomputingStages: Set<number>;
+  /**
+   * Map of stage index → set of changed field names, populated after a
+   * `stage_updated` event lands. Each entry expires after ~3 seconds via a
+   * client-side timer. Used by `DiffHighlight` to transiently highlight the
+   * fields that changed during an inline recomputation.
+   */
+  stageDiffs: Map<number, Set<string>>;
 
   setTrip: (trip: TripIdentity) => void;
   updateRouteData: (data: {
@@ -155,6 +162,16 @@ interface TripState {
   finishStageRecomputation: (index: number) => void;
   /** Clear all recomputing stages — safety net for lost `stage_updated` events. */
   clearRecomputingStages: () => void;
+  /**
+   * Record which fields changed for a stage after a `stage_updated` event.
+   * Replaces any previously recorded diff for the same index.
+   */
+  setStageDiff: (stageIndex: number, changedFields: Set<string>) => void;
+  /**
+   * Clear the diff highlight for a stage (called by the auto-expiry timer
+   * in `use-mercure.ts` after ~3 seconds).
+   */
+  clearStageDiff: (stageIndex: number) => void;
   clearTrip: () => void;
   /** Hydrate the trip store from a {@link SavedTrip} snapshot (offline consultation). */
   loadFromSavedTrip: (trip: SavedTrip) => void;
@@ -181,6 +198,7 @@ const initialState = {
   stages: [],
   computationStatus: {},
   recomputingStages: new Set<number>(),
+  stageDiffs: new Map<number, Set<string>>(),
 };
 
 /**
@@ -598,6 +616,16 @@ export const useTripStore = create<TripState>()(
     clearRecomputingStages: () =>
       set((state) => {
         state.recomputingStages.clear();
+      }),
+
+    setStageDiff: (stageIndex, changedFields) =>
+      set((state) => {
+        state.stageDiffs.set(stageIndex, changedFields);
+      }),
+
+    clearStageDiff: (stageIndex) =>
+      set((state) => {
+        state.stageDiffs.delete(stageIndex);
       }),
 
     loadFromSavedTrip: (trip) => {

--- a/pwa/tests/mocked/diff-highlight.spec.ts
+++ b/pwa/tests/mocked/diff-highlight.spec.ts
@@ -1,0 +1,217 @@
+import { test, expect } from "../fixtures/base.fixture";
+import type { MercureEvent } from "../../src/lib/mercure/types";
+import {
+  routeParsedEvent,
+  stagesComputedEvent,
+  tripCompleteEvent,
+  accommodationsFoundEvent,
+} from "../fixtures/mock-data";
+
+/**
+ * Issue #328 — Diff highlight after inline recomputation.
+ *
+ * After a `stage_updated` event lands, fields that changed on the stage card
+ * are briefly highlighted in yellow (3 s fade-out animation). The highlight
+ * disappears after the timer expires, and screen-reader users receive an
+ * accessible announcement.
+ */
+
+/** A stage_updated event that changes the distance (72.5 → 55.0 km). */
+function stageUpdatedWithDistanceChange(stageIndex: number): MercureEvent {
+  return {
+    type: "stage_updated",
+    data: {
+      stageIndex,
+      stage: {
+        dayNumber: stageIndex + 1,
+        distance: 55.0, // was 72.5 km in stagesComputedEvent
+        elevation: 720,
+        elevationLoss: 640,
+        startPoint: { lat: 44.735, lon: 4.598, ele: 280 },
+        endPoint: { lat: 44.5, lon: 4.4, ele: 500 },
+        geometry: [
+          { lat: 44.735, lon: 4.598, ele: 280 },
+          { lat: 44.5, lon: 4.4, ele: 500 },
+        ],
+        label: null,
+        isRestDay: false,
+        weather: null,
+        alerts: [],
+        pois: [],
+        accommodations: [],
+        selectedAccommodation: null,
+        events: [],
+      },
+    },
+  };
+}
+
+/** A stage_updated event that adds a new alert on the stage. */
+function stageUpdatedWithNewAlerts(stageIndex: number): MercureEvent {
+  return {
+    type: "stage_updated",
+    data: {
+      stageIndex,
+      stage: {
+        dayNumber: stageIndex + 1,
+        distance: 72.5, // same distance — no distance diff
+        elevation: 1180,
+        elevationLoss: 920,
+        startPoint: { lat: 44.735, lon: 4.598, ele: 280 },
+        endPoint: { lat: 44.532, lon: 4.392, ele: 540 },
+        geometry: [
+          { lat: 44.735, lon: 4.598, ele: 280 },
+          { lat: 44.532, lon: 4.392, ele: 540 },
+        ],
+        label: null,
+        isRestDay: false,
+        weather: null,
+        alerts: [
+          {
+            type: "warning",
+            message: "Newly detected steep gradient",
+            lat: 44.6,
+            lon: 4.5,
+          },
+        ],
+        pois: [],
+        accommodations: [],
+        selectedAccommodation: null,
+        events: [],
+      },
+    },
+  };
+}
+
+test.describe("Diff highlight after inline recomputation", () => {
+  test("distance field is highlighted after stage_updated with changed distance", async ({
+    submitUrl,
+    injectEvent,
+    injectSequence,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    await injectSequence([
+      routeParsedEvent(),
+      stagesComputedEvent(),
+      accommodationsFoundEvent(0),
+      tripCompleteEvent(),
+    ]);
+    await expect(mockedPage.getByTestId("stage-card-1")).toBeVisible({
+      timeout: 10000,
+    });
+
+    // Trigger inline recomputation via accommodation selection
+    const stageCard = mockedPage.getByTestId("stage-card-1");
+    const selectButtons = stageCard.getByRole("button", {
+      name: "Sélectionner cet hébergement",
+    });
+    await selectButtons.first().click();
+
+    // Wait for skeleton to appear (recomputation in progress)
+    await expect(mockedPage.getByTestId("stage-skeleton").first()).toBeVisible({
+      timeout: 3000,
+    });
+
+    // Inject stage_updated with distance change
+    await injectEvent(stageUpdatedWithDistanceChange(0));
+
+    // Stage card should be back
+    await expect(mockedPage.getByTestId("stage-card-1")).toBeVisible({
+      timeout: 3000,
+    });
+
+    // Distance diff highlight should be present
+    await expect(
+      mockedPage.getByTestId("diff-highlight-distance"),
+    ).toBeVisible({ timeout: 1000 });
+  });
+
+  test("diff highlight disappears after ~3s", async ({
+    submitUrl,
+    injectEvent,
+    injectSequence,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    await injectSequence([
+      routeParsedEvent(),
+      stagesComputedEvent(),
+      accommodationsFoundEvent(0),
+      tripCompleteEvent(),
+    ]);
+    await expect(mockedPage.getByTestId("stage-card-1")).toBeVisible({
+      timeout: 10000,
+    });
+
+    // Trigger recomputation
+    const stageCard = mockedPage.getByTestId("stage-card-1");
+    const selectButtons = stageCard.getByRole("button", {
+      name: "Sélectionner cet hébergement",
+    });
+    await selectButtons.first().click();
+    await expect(mockedPage.getByTestId("stage-skeleton").first()).toBeVisible({
+      timeout: 3000,
+    });
+
+    // Inject the update
+    await injectEvent(stageUpdatedWithDistanceChange(0));
+    await expect(mockedPage.getByTestId("stage-card-1")).toBeVisible({
+      timeout: 3000,
+    });
+
+    // Highlight should be visible immediately after the update
+    await expect(
+      mockedPage.getByTestId("diff-highlight-distance"),
+    ).toBeVisible({ timeout: 1000 });
+
+    // After ~3.5 seconds the store timer should have fired and removed the
+    // highlight (data-testid is only set when isChanged is true).
+    await mockedPage.waitForTimeout(3500);
+    await expect(
+      mockedPage.getByTestId("diff-highlight-distance"),
+    ).toBeHidden();
+  });
+
+  test("new alerts are highlighted after stage_updated adds alerts", async ({
+    submitUrl,
+    injectEvent,
+    injectSequence,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    await injectSequence([
+      routeParsedEvent(),
+      stagesComputedEvent(),
+      accommodationsFoundEvent(0),
+      tripCompleteEvent(),
+    ]);
+    await expect(mockedPage.getByTestId("stage-card-1")).toBeVisible({
+      timeout: 10000,
+    });
+
+    // Trigger inline recomputation via accommodation selection
+    const stageCard = mockedPage.getByTestId("stage-card-1");
+    const selectButtons = stageCard.getByRole("button", {
+      name: "Sélectionner cet hébergement",
+    });
+    await selectButtons.first().click();
+
+    await expect(mockedPage.getByTestId("stage-skeleton").first()).toBeVisible({
+      timeout: 3000,
+    });
+
+    // Inject stage_updated that adds a new alert
+    await injectEvent(stageUpdatedWithNewAlerts(0));
+
+    // Stage card should be back
+    await expect(mockedPage.getByTestId("stage-card-1")).toBeVisible({
+      timeout: 3000,
+    });
+
+    // Alerts-added diff highlight should be present
+    await expect(
+      mockedPage.getByTestId("diff-highlight-alerts_added"),
+    ).toBeVisible({ timeout: 1000 });
+  });
+});

--- a/pwa/tests/mocked/diff-highlight.spec.ts
+++ b/pwa/tests/mocked/diff-highlight.spec.ts
@@ -122,9 +122,9 @@ test.describe("Diff highlight after inline recomputation", () => {
     });
 
     // Distance diff highlight should be present
-    await expect(
-      mockedPage.getByTestId("diff-highlight-distance"),
-    ).toBeVisible({ timeout: 1000 });
+    await expect(mockedPage.getByTestId("diff-highlight-distance")).toBeVisible(
+      { timeout: 1000 },
+    );
   });
 
   test("diff highlight disappears after ~3s", async ({
@@ -161,9 +161,9 @@ test.describe("Diff highlight after inline recomputation", () => {
     });
 
     // Highlight should be visible immediately after the update
-    await expect(
-      mockedPage.getByTestId("diff-highlight-distance"),
-    ).toBeVisible({ timeout: 1000 });
+    await expect(mockedPage.getByTestId("diff-highlight-distance")).toBeVisible(
+      { timeout: 1000 },
+    );
 
     // After ~3.5 seconds the store timer should have fired and removed the
     // highlight (data-testid is only set when isChanged is true).


### PR DESCRIPTION
## Summary

- Adds a `DiffHighlight` component that wraps stage card fields and applies a transient yellow→transparent CSS animation whenever the corresponding field appears in the store's `stageDiffs` map
- Extends `trip-store.ts` with `stageDiffs: Map<number, Set<string>>`, `setStageDiff()`, and `clearStageDiff()` actions
- `use-mercure.ts` captures the previous stage state before `applyStageUpdate`, computes changed fields (`distance`, `elevation`, `alerts_added`, `alerts_removed`, `selectedAccommodation`) via `computeStageDiff()`, populates the store, and schedules auto-clear after 3 s via `setTimeout`
- CSS `@keyframes diff-highlight` added to `globals.css` — yellow background fades to transparent over 3 s, matching the store timer
- Accessible: visually-hidden `aria-live="polite"` span announces the change to screen readers (WCAG 1.4.1 — not colour-only)
- `data-testid="diff-highlight-{field}"` attribute present only when the field is actively highlighted (used by Playwright tests)

## Test plan

- [ ] Mocked Playwright: distance field is highlighted after `stage_updated` with changed distance
- [ ] Mocked Playwright: highlight disappears after ~3 s (store timer fires, `data-testid` removed)
- [ ] Mocked Playwright: new alerts section is highlighted after `stage_updated` adds alerts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

All prior review findings are addressed in the latest push. The implementation is clean and correct: `aria-live` is always in the DOM when `changeLabel` is provided, `stageDiffTimers` correctly cancels stale timers before scheduling new ones, and `computeStageDiff` is scoped to exactly the two fields (`distance`, `alerts_added`) that have corresponding `DiffHighlight` wrappers.

**Findings: 1 suggestion (non-blocking)**

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

Posted 1 inline comment.

---
Reviewed commit: `ffe90efa18e2d267b5551c21219254145060eba9`

Generated with [Claude Code](https://claude.com/claude-code)
<!-- claude-review-end -->