### PR TITLE
feat(batch): add ModificationQueue and batch recompute endpoint (#327)

### DIFF
--- a/api/src/ApiResource/Trip.php
+++ b/api/src/ApiResource/Trip.php
@@ -14,6 +14,7 @@ use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
 use ApiPlatform\OpenApi\Model\Operation;
 use App\State\AnalyzeTripProcessor;
+use App\State\TripBatchRecomputeProcessor;
 use App\State\TripCollectionProvider;
 use App\State\TripCreateProcessor;
 use App\State\TripDeleteProcessor;
@@ -100,6 +101,22 @@ use App\State\TripUpdateProcessor;
             mercure: true,
             provider: TripRequestProvider::class,
             processor: AnalyzeTripProcessor::class,
+        ),
+        new Post(
+            uriTemplate: '/trips/{id}/recompute{._format}',
+            status: 202,
+            openapi: new Operation(
+                responses: [
+                    404 => new Response(description: 'Trip not found'),
+                    422 => new Response(description: 'Trip has no stages to recompute'),
+                ],
+                summary: 'Apply a batch of pending modifications in a single recompute pass, dispatching only the minimal set of handlers needed.',
+            ),
+            security: "is_granted('TRIP_EDIT', object)",
+            input: TripBatchRecomputeRequest::class,
+            mercure: true,
+            provider: TripRequestProvider::class,
+            processor: TripBatchRecomputeProcessor::class,
         ),
         new Patch(
             uriTemplate: '/trips/{id}{._format}',

--- a/api/src/ApiResource/TripBatchRecomputeRequest.php
+++ b/api/src/ApiResource/TripBatchRecomputeRequest.php
@@ -18,6 +18,7 @@ final class TripBatchRecomputeRequest
      * @param list<TripModification> $modifications
      */
     public function __construct(
+        #[Assert\Valid]
         #[Assert\NotBlank]
         #[Assert\Count(min: 1)]
         public array $modifications = [],

--- a/api/src/ApiResource/TripBatchRecomputeRequest.php
+++ b/api/src/ApiResource/TripBatchRecomputeRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ApiResource;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * Input DTO for the batch recompute endpoint.
+ *
+ * Carries a list of pending modifications as described by the frontend batch queue.
+ * The backend resolves the minimal set of handlers to re-run and dispatches them.
+ */
+final class TripBatchRecomputeRequest
+{
+    /**
+     * @param list<TripModification> $modifications
+     */
+    public function __construct(
+        #[Assert\NotBlank]
+        #[Assert\Count(min: 1)]
+        public array $modifications = [],
+    ) {
+    }
+}

--- a/api/src/ApiResource/TripModification.php
+++ b/api/src/ApiResource/TripModification.php
@@ -21,6 +21,10 @@ final class TripModification
          * Null for trip-level modifications (dates, pacing settings, etc.).
          */
         #[Assert\PositiveOrZero]
+        #[Assert\When(
+            expression: "this.type in ['accommodation', 'distance']",
+            constraints: [new Assert\NotNull(message: 'stageIndex is required for accommodation and distance modifications.')],
+        )]
         public ?int $stageIndex = null,
 
         /**

--- a/api/src/ApiResource/TripModification.php
+++ b/api/src/ApiResource/TripModification.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ApiResource;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * Represents a single user modification in a batch recompute request.
+ *
+ * Each modification describes which stage is affected and what kind of change
+ * was made. The {@see \App\Service\ComputationDependencyResolver} uses this
+ * information to determine which computations need to be re-run.
+ */
+final class TripModification
+{
+    public function __construct(
+        /**
+         * Zero-based index of the affected stage.
+         * Null for trip-level modifications (dates, pacing settings, etc.).
+         */
+        #[Assert\PositiveOrZero]
+        public ?int $stageIndex = null,
+
+        /**
+         * Type of modification — determines which handlers are re-dispatched.
+         *
+         * Valid values: 'accommodation', 'distance', 'dates', 'pacing'.
+         */
+        #[Assert\NotBlank]
+        #[Assert\Choice(choices: ['accommodation', 'distance', 'dates', 'pacing'])]
+        public string $type = 'accommodation',
+
+        /**
+         * Human-readable description for display in the frontend queue panel.
+         */
+        #[Assert\Length(max: 255)]
+        public ?string $label = null,
+    ) {
+    }
+}

--- a/api/src/Service/ComputationDependencyResolver.php
+++ b/api/src/Service/ComputationDependencyResolver.php
@@ -30,7 +30,7 @@ use App\Message\ScanPois;
  * - 'distance':      RecalculateStages (affected + subsequent), ScanPois, ScanAccommodations,
  *                    AnalyzeTerrain, CheckBikeShops, CheckWaterPoints, CheckHealthServices,
  *                    CheckRailwayStations, FetchWeather (when dates set), CheckCalendar (when dates set)
- * - 'dates':         FetchWeather, CheckCalendar, ScanEvents
+ * - 'dates':         FetchWeather, CheckCalendar, ScanEvents, CheckCulturalPois
  * - 'pacing':        RecalculateStages (all stages)
  */
 final readonly class ComputationDependencyResolver

--- a/api/src/Service/ComputationDependencyResolver.php
+++ b/api/src/Service/ComputationDependencyResolver.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\ApiResource\TripModification;
+use App\Message\AnalyzeTerrain;
+use App\Message\CheckBikeShops;
+use App\Message\CheckCalendar;
+use App\Message\CheckCulturalPois;
+use App\Message\CheckHealthServices;
+use App\Message\CheckRailwayStations;
+use App\Message\CheckWaterPoints;
+use App\Message\FetchWeather;
+use App\Message\RecalculateStages;
+use App\Message\ScanAccommodations;
+use App\Message\ScanEvents;
+use App\Message\ScanPois;
+
+/**
+ * Resolves the minimal set of Messenger messages to dispatch for a batch of modifications.
+ *
+ * Instead of re-running the full enrichment pipeline (as {@see TripAnalysisDispatcher} does),
+ * this service fuses the dependencies of N modifications and dispatches only the handlers
+ * that are actually required.
+ *
+ * Dependency matrix:
+ * - 'accommodation': RecalculateStages (affected + next), ScanAccommodations (affected stages)
+ * - 'distance':      RecalculateStages (affected + subsequent), ScanPois, ScanAccommodations,
+ *                    AnalyzeTerrain, CheckBikeShops, CheckWaterPoints, CheckHealthServices,
+ *                    CheckRailwayStations, FetchWeather (when dates set), CheckCalendar (when dates set)
+ * - 'dates':         FetchWeather, CheckCalendar, ScanEvents
+ * - 'pacing':        RecalculateStages (all stages)
+ */
+final readonly class ComputationDependencyResolver
+{
+    /**
+     * @param list<TripModification> $modifications
+     * @param list<int>              $allStageIndices
+     * @param bool                   $hasDates
+     * @param list<string>           $enabledAccommodationTypes
+     *
+     * @return list<object> Messenger messages to dispatch
+     */
+    public function resolve(
+        string $tripId,
+        array $modifications,
+        array $allStageIndices,
+        bool $hasDates,
+        array $enabledAccommodationTypes,
+        ?int $generation,
+    ): array {
+        $messages = [];
+        $recalcIndices = [];
+        $accommodationScanIndices = [];
+        $needsPois = false;
+        $needsTerrain = false;
+        $needsBikeShops = false;
+        $needsWaterPoints = false;
+        $needsHealthServices = false;
+        $needsRailwayStations = false;
+        $needsWeather = false;
+        $needsCalendar = false;
+        $needsEvents = false;
+        $needsCulturalPois = false;
+
+        foreach ($modifications as $modification) {
+            switch ($modification->type) {
+                case 'accommodation':
+                    if (null !== $modification->stageIndex) {
+                        $recalcIndices[] = $modification->stageIndex;
+                        // Also recalculate the next stage (its startPoint may shift)
+                        if (isset($allStageIndices[$modification->stageIndex + 1])) {
+                            $recalcIndices[] = $modification->stageIndex + 1;
+                        }
+                        $accommodationScanIndices[] = $modification->stageIndex;
+                    }
+                    break;
+
+                case 'distance':
+                    if (null !== $modification->stageIndex) {
+                        // Distance change affects the modified stage and all subsequent
+                        $affected = array_filter(
+                            $allStageIndices,
+                            static fn (int $i): bool => $i >= $modification->stageIndex,
+                        );
+                        array_push($recalcIndices, ...array_values($affected));
+                        foreach ($affected as $idx) {
+                            $accommodationScanIndices[] = $idx;
+                        }
+                    }
+                    $needsPois = true;
+                    $needsTerrain = true;
+                    $needsBikeShops = true;
+                    $needsWaterPoints = true;
+                    $needsHealthServices = true;
+                    $needsRailwayStations = true;
+                    if ($hasDates) {
+                        $needsWeather = true;
+                        $needsCalendar = true;
+                    }
+                    break;
+
+                case 'dates':
+                    $needsWeather = true;
+                    $needsCalendar = true;
+                    $needsEvents = true;
+                    $needsCulturalPois = true;
+                    break;
+
+                case 'pacing':
+                    // Pacing changes affect all stages (fatigue factor, elevation penalty, etc.)
+                    array_push($recalcIndices, ...$allStageIndices);
+                    if ($hasDates) {
+                        $needsWeather = true;
+                        $needsCalendar = true;
+                    }
+                    break;
+            }
+        }
+
+        // Deduplicate and sort affected indices
+        $recalcIndices = array_values(array_unique($recalcIndices));
+        sort($recalcIndices);
+        $accommodationScanIndices = array_values(array_unique($accommodationScanIndices));
+
+        // Build RecalculateStages message (skip accommodation scan since we handle it separately)
+        if ([] !== $recalcIndices) {
+            $messages[] = new RecalculateStages(
+                $tripId,
+                $recalcIndices,
+                skipAccommodationScan: true,
+                generation: $generation,
+            );
+        }
+
+        // Build per-stage ScanAccommodations messages
+        foreach ($accommodationScanIndices as $idx) {
+            $messages[] = new ScanAccommodations(
+                $tripId,
+                stageIndex: $idx,
+                enabledAccommodationTypes: $enabledAccommodationTypes,
+                generation: $generation,
+            );
+        }
+
+        // Build optional enrichment messages
+        if ($needsPois) {
+            $messages[] = new ScanPois($tripId, $generation);
+        }
+        if ($needsTerrain) {
+            $messages[] = new AnalyzeTerrain($tripId, $generation);
+        }
+        if ($needsBikeShops) {
+            $messages[] = new CheckBikeShops($tripId, $generation);
+        }
+        if ($needsWaterPoints) {
+            $messages[] = new CheckWaterPoints($tripId, $generation);
+        }
+        if ($needsHealthServices) {
+            $messages[] = new CheckHealthServices($tripId, $generation);
+        }
+        if ($needsRailwayStations) {
+            $messages[] = new CheckRailwayStations($tripId, $generation);
+        }
+        if ($needsWeather) {
+            $messages[] = new FetchWeather($tripId, $generation);
+        }
+        if ($needsCalendar) {
+            $messages[] = new CheckCalendar($tripId, $generation);
+        }
+        if ($needsEvents) {
+            $messages[] = new ScanEvents($tripId, $generation);
+        }
+        if ($needsCulturalPois) {
+            $messages[] = new CheckCulturalPois($tripId, $generation);
+        }
+
+        return $messages;
+    }
+}

--- a/api/src/Service/ComputationDependencyResolver.php
+++ b/api/src/Service/ComputationDependencyResolver.php
@@ -38,7 +38,6 @@ final readonly class ComputationDependencyResolver
     /**
      * @param list<TripModification> $modifications
      * @param list<int>              $allStageIndices
-     * @param bool                   $hasDates
      * @param list<string>           $enabledAccommodationTypes
      *
      * @return list<object> Messenger messages to dispatch
@@ -74,8 +73,10 @@ final readonly class ComputationDependencyResolver
                         if (isset($allStageIndices[$modification->stageIndex + 1])) {
                             $recalcIndices[] = $modification->stageIndex + 1;
                         }
+
                         $accommodationScanIndices[] = $modification->stageIndex;
                     }
+
                     break;
 
                 case 'distance':
@@ -90,6 +91,7 @@ final readonly class ComputationDependencyResolver
                             $accommodationScanIndices[] = $idx;
                         }
                     }
+
                     $needsPois = true;
                     $needsTerrain = true;
                     $needsBikeShops = true;
@@ -100,6 +102,7 @@ final readonly class ComputationDependencyResolver
                         $needsWeather = true;
                         $needsCalendar = true;
                     }
+
                     break;
 
                 case 'dates':
@@ -116,6 +119,7 @@ final readonly class ComputationDependencyResolver
                         $needsWeather = true;
                         $needsCalendar = true;
                     }
+
                     break;
             }
         }
@@ -149,30 +153,39 @@ final readonly class ComputationDependencyResolver
         if ($needsPois) {
             $messages[] = new ScanPois($tripId, $generation);
         }
+
         if ($needsTerrain) {
             $messages[] = new AnalyzeTerrain($tripId, $generation);
         }
+
         if ($needsBikeShops) {
             $messages[] = new CheckBikeShops($tripId, $generation);
         }
+
         if ($needsWaterPoints) {
             $messages[] = new CheckWaterPoints($tripId, $generation);
         }
+
         if ($needsHealthServices) {
             $messages[] = new CheckHealthServices($tripId, $generation);
         }
+
         if ($needsRailwayStations) {
             $messages[] = new CheckRailwayStations($tripId, $generation);
         }
+
         if ($needsWeather) {
             $messages[] = new FetchWeather($tripId, $generation);
         }
+
         if ($needsCalendar) {
             $messages[] = new CheckCalendar($tripId, $generation);
         }
+
         if ($needsEvents) {
             $messages[] = new ScanEvents($tripId, $generation);
         }
+
         if ($needsCulturalPois) {
             $messages[] = new CheckCulturalPois($tripId, $generation);
         }

--- a/api/src/State/TripBatchRecomputeProcessor.php
+++ b/api/src/State/TripBatchRecomputeProcessor.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\State\ProcessorInterface;
+use App\ApiResource\Trip;
+use App\ApiResource\TripBatchRecomputeRequest;
+use App\ApiResource\TripRequest;
+use App\ComputationTracker\TripGenerationTrackerInterface;
+use App\Repository\TripRequestRepositoryInterface;
+use App\Service\ComputationDependencyResolver;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+/**
+ * Processes the batch recompute endpoint: applies N pending modifications in a
+ * single request, dispatching only the minimal set of handlers needed.
+ *
+ * This avoids N sequential recomputations when the user accumulates several
+ * modifications before confirming them. The dependency resolution is delegated
+ * to {@see ComputationDependencyResolver}.
+ *
+ * @implements ProcessorInterface<TripBatchRecomputeRequest, Trip>
+ */
+final readonly class TripBatchRecomputeProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private TripRequestRepositoryInterface $tripStateManager,
+        private TripGenerationTrackerInterface $generationTracker,
+        private ComputationDependencyResolver $dependencyResolver,
+        private MessageBusInterface $messageBus,
+    ) {
+    }
+
+    /**
+     * @param TripBatchRecomputeRequest $data
+     * @param Post                      $operation
+     * @param array{id?: string}        $uriVariables
+     */
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): Trip
+    {
+        \assert($data instanceof TripBatchRecomputeRequest);
+        $tripId = $uriVariables['id'] ?? '';
+
+        if ('' === $tripId) {
+            throw new NotFoundHttpException('Trip not found.');
+        }
+
+        $stages = $this->tripStateManager->getStages($tripId);
+        if (null === $stages || [] === $stages) {
+            throw new UnprocessableEntityHttpException('Trip has no stages to recompute.');
+        }
+
+        $request = $this->tripStateManager->getRequest($tripId);
+        if (!$request instanceof TripRequest) {
+            throw new NotFoundHttpException('Trip not found.');
+        }
+
+        // Increment generation to invalidate in-flight workers
+        $generation = $this->generationTracker->increment($tripId);
+
+        $allStageIndices = array_keys($stages);
+        $hasDates = $request->startDate instanceof \DateTimeImmutable;
+
+        $messages = $this->dependencyResolver->resolve(
+            $tripId,
+            $data->modifications,
+            $allStageIndices,
+            $hasDates,
+            $request->enabledAccommodationTypes,
+            $generation,
+        );
+
+        foreach ($messages as $message) {
+            $this->messageBus->dispatch($message);
+        }
+
+        return new Trip(id: $tripId);
+    }
+}

--- a/api/src/State/TripBatchRecomputeProcessor.php
+++ b/api/src/State/TripBatchRecomputeProcessor.php
@@ -52,7 +52,11 @@ final readonly class TripBatchRecomputeProcessor implements ProcessorInterface
         }
 
         $stages = $this->tripStateManager->getStages($tripId);
-        if (null === $stages || [] === $stages) {
+        if (null === $stages) {
+            throw new NotFoundHttpException('Trip not found.');
+        }
+
+        if ([] === $stages) {
             throw new UnprocessableEntityHttpException('Trip has no stages to recompute.');
         }
 

--- a/api/tests/Unit/Service/ComputationDependencyResolverTest.php
+++ b/api/tests/Unit/Service/ComputationDependencyResolverTest.php
@@ -9,9 +9,6 @@ use App\Message\AnalyzeTerrain;
 use App\Message\CheckBikeShops;
 use App\Message\CheckCalendar;
 use App\Message\CheckCulturalPois;
-use App\Message\CheckHealthServices;
-use App\Message\CheckRailwayStations;
-use App\Message\CheckWaterPoints;
 use App\Message\FetchWeather;
 use App\Message\RecalculateStages;
 use App\Message\ScanAccommodations;
@@ -161,7 +158,7 @@ final class ComputationDependencyResolverTest extends TestCase
         $this->assertContains(ScanEvents::class, $classes);
 
         // Exactly one RecalculateStages message (deduplicated)
-        $this->assertSame(1, \count(array_filter($messages, static fn (object $m): bool => $m instanceof RecalculateStages)));
+        $this->assertCount(1, array_filter($messages, static fn (object $m): bool => $m instanceof RecalculateStages));
     }
 
     #[Test]
@@ -172,7 +169,7 @@ final class ComputationDependencyResolverTest extends TestCase
 
         foreach ($messages as $message) {
             if (property_exists($message, 'generation')) {
-                /** @var object{generation: ?int} $message */
+                /* @var object{generation: ?int} $message */
                 $this->assertSame(7, $message->generation, \sprintf('Expected generation 7 for %s', $message::class));
             }
         }
@@ -200,7 +197,7 @@ final class ComputationDependencyResolverTest extends TestCase
     /**
      * @template T of object
      *
-     * @param list<object>   $messages
+     * @param list<object>    $messages
      * @param class-string<T> $class
      */
     private function firstOf(array $messages, string $class): ?object

--- a/api/tests/Unit/Service/ComputationDependencyResolverTest.php
+++ b/api/tests/Unit/Service/ComputationDependencyResolverTest.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service;
+
+use App\ApiResource\TripModification;
+use App\Message\AnalyzeTerrain;
+use App\Message\CheckBikeShops;
+use App\Message\CheckCalendar;
+use App\Message\CheckCulturalPois;
+use App\Message\CheckHealthServices;
+use App\Message\CheckRailwayStations;
+use App\Message\CheckWaterPoints;
+use App\Message\FetchWeather;
+use App\Message\RecalculateStages;
+use App\Message\ScanAccommodations;
+use App\Message\ScanEvents;
+use App\Message\ScanPois;
+use App\Service\ComputationDependencyResolver;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class ComputationDependencyResolverTest extends TestCase
+{
+    private ComputationDependencyResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->resolver = new ComputationDependencyResolver();
+    }
+
+    #[Test]
+    public function accommodationModificationTriggersRecalculateAndScanForAffectedStages(): void
+    {
+        $modification = new TripModification(stageIndex: 1, type: 'accommodation', label: 'Hébergement étape 2');
+        $messages = $this->resolver->resolve(
+            'trip-1',
+            [$modification],
+            [0, 1, 2],
+            false,
+            ['hotel', 'camp_site'],
+            generation: 5,
+        );
+
+        $classes = $this->classesOf($messages);
+
+        $this->assertContains(RecalculateStages::class, $classes);
+        $this->assertContains(ScanAccommodations::class, $classes);
+
+        // Must NOT trigger the full enrichment pipeline
+        $this->assertNotContains(AnalyzeTerrain::class, $classes);
+        $this->assertNotContains(FetchWeather::class, $classes);
+        $this->assertNotContains(ScanPois::class, $classes);
+    }
+
+    #[Test]
+    public function accommodationModificationIncludesNextStageInRecalculate(): void
+    {
+        $modification = new TripModification(stageIndex: 0, type: 'accommodation', label: 'test');
+        $messages = $this->resolver->resolve('trip-1', [$modification], [0, 1, 2], false, [], generation: null);
+
+        $recalc = $this->firstOf($messages, RecalculateStages::class);
+        $this->assertInstanceOf(RecalculateStages::class, $recalc);
+        // Stage 0 + next stage 1
+        $this->assertContains(0, $recalc->affectedIndices);
+        $this->assertContains(1, $recalc->affectedIndices);
+    }
+
+    #[Test]
+    public function distanceModificationTriggersEnrichmentPipeline(): void
+    {
+        $modification = new TripModification(stageIndex: 1, type: 'distance', label: 'Distance étape 2');
+        $messages = $this->resolver->resolve(
+            'trip-1',
+            [$modification],
+            [0, 1, 2],
+            false,
+            ['hotel'],
+            generation: 3,
+        );
+
+        $classes = $this->classesOf($messages);
+
+        $this->assertContains(RecalculateStages::class, $classes);
+        $this->assertContains(ScanAccommodations::class, $classes);
+        $this->assertContains(ScanPois::class, $classes);
+        $this->assertContains(AnalyzeTerrain::class, $classes);
+        $this->assertContains(CheckBikeShops::class, $classes);
+    }
+
+    #[Test]
+    public function distanceModificationWithDatesTriggersWeatherAndCalendar(): void
+    {
+        $modification = new TripModification(stageIndex: 0, type: 'distance', label: 'test');
+        $messages = $this->resolver->resolve('trip-1', [$modification], [0, 1], true, [], generation: null);
+
+        $classes = $this->classesOf($messages);
+        $this->assertContains(FetchWeather::class, $classes);
+        $this->assertContains(CheckCalendar::class, $classes);
+    }
+
+    #[Test]
+    public function distanceModificationWithoutDatesDoesNotTriggerWeather(): void
+    {
+        $modification = new TripModification(stageIndex: 0, type: 'distance', label: 'test');
+        $messages = $this->resolver->resolve('trip-1', [$modification], [0, 1], false, [], generation: null);
+
+        $classes = $this->classesOf($messages);
+        $this->assertNotContains(FetchWeather::class, $classes);
+        $this->assertNotContains(CheckCalendar::class, $classes);
+    }
+
+    #[Test]
+    public function datesModificationTriggersWeatherCalendarAndEvents(): void
+    {
+        $modification = new TripModification(stageIndex: null, type: 'dates', label: 'Dates');
+        $messages = $this->resolver->resolve('trip-1', [$modification], [0, 1, 2], true, [], generation: null);
+
+        $classes = $this->classesOf($messages);
+        $this->assertContains(FetchWeather::class, $classes);
+        $this->assertContains(CheckCalendar::class, $classes);
+        $this->assertContains(ScanEvents::class, $classes);
+        $this->assertContains(CheckCulturalPois::class, $classes);
+
+        // Dates alone do NOT trigger route recalculation
+        $this->assertNotContains(RecalculateStages::class, $classes);
+    }
+
+    #[Test]
+    public function pacingModificationTriggersRecalculateForAllStages(): void
+    {
+        $modification = new TripModification(stageIndex: null, type: 'pacing', label: 'Pacing');
+        $messages = $this->resolver->resolve('trip-1', [$modification], [0, 1, 2], false, [], generation: null);
+
+        $recalc = $this->firstOf($messages, RecalculateStages::class);
+        $this->assertInstanceOf(RecalculateStages::class, $recalc);
+        $this->assertCount(3, $recalc->affectedIndices);
+    }
+
+    #[Test]
+    public function batchFusesDependenciesAcrossModifications(): void
+    {
+        $modifications = [
+            new TripModification(stageIndex: 0, type: 'accommodation', label: 'acc 0'),
+            new TripModification(stageIndex: 2, type: 'distance', label: 'dist 2'),
+            new TripModification(stageIndex: null, type: 'dates', label: 'dates'),
+        ];
+
+        $messages = $this->resolver->resolve('trip-1', $modifications, [0, 1, 2], true, ['hotel'], generation: 1);
+
+        $classes = $this->classesOf($messages);
+
+        // All three modification types contribute their required handlers
+        $this->assertContains(RecalculateStages::class, $classes);
+        $this->assertContains(ScanAccommodations::class, $classes);
+        $this->assertContains(ScanPois::class, $classes);
+        $this->assertContains(AnalyzeTerrain::class, $classes);
+        $this->assertContains(FetchWeather::class, $classes);
+        $this->assertContains(CheckCalendar::class, $classes);
+        $this->assertContains(ScanEvents::class, $classes);
+
+        // Exactly one RecalculateStages message (deduplicated)
+        $this->assertSame(1, \count(array_filter($messages, static fn (object $m): bool => $m instanceof RecalculateStages)));
+    }
+
+    #[Test]
+    public function generationIsPropagatedToAllMessages(): void
+    {
+        $modification = new TripModification(stageIndex: 0, type: 'distance', label: 'test');
+        $messages = $this->resolver->resolve('trip-1', [$modification], [0, 1], false, ['hotel'], generation: 7);
+
+        foreach ($messages as $message) {
+            if (property_exists($message, 'generation')) {
+                /** @var object{generation: ?int} $message */
+                $this->assertSame(7, $message->generation, \sprintf('Expected generation 7 for %s', $message::class));
+            }
+        }
+    }
+
+    #[Test]
+    public function emptyModificationsListReturnsNoMessages(): void
+    {
+        $messages = $this->resolver->resolve('trip-1', [], [0, 1, 2], false, [], generation: null);
+        $this->assertSame([], $messages);
+    }
+
+    // --- Helpers ---
+
+    /**
+     * @param list<object> $messages
+     *
+     * @return list<class-string>
+     */
+    private function classesOf(array $messages): array
+    {
+        return array_map(static fn (object $m): string => $m::class, $messages);
+    }
+
+    /**
+     * @template T of object
+     *
+     * @param list<object>   $messages
+     * @param class-string<T> $class
+     */
+    private function firstOf(array $messages, string $class): ?object
+    {
+        foreach ($messages as $message) {
+            if ($message instanceof $class) {
+                return $message;
+            }
+        }
+
+        return null;
+    }
+}

--- a/api/tests/Unit/Service/ComputationDependencyResolverTest.php
+++ b/api/tests/Unit/Service/ComputationDependencyResolverTest.php
@@ -136,6 +136,18 @@ final class ComputationDependencyResolverTest extends TestCase
     }
 
     #[Test]
+    public function pacingModificationWithDatesTriggersWeatherAndCalendar(): void
+    {
+        $modification = new TripModification(stageIndex: null, type: 'pacing', label: 'Pacing');
+        $messages = $this->resolver->resolve('trip-1', [$modification], [0, 1, 2], true, [], generation: null);
+
+        $classes = $this->classesOf($messages);
+        $this->assertContains(RecalculateStages::class, $classes);
+        $this->assertContains(FetchWeather::class, $classes);
+        $this->assertContains(CheckCalendar::class, $classes);
+    }
+
+    #[Test]
     public function batchFusesDependenciesAcrossModifications(): void
     {
         $modifications = [

--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -661,6 +661,16 @@
     "see_website": "Visit website",
     "see_website_label": "Visit {name}'s website"
   },
+  "modificationQueue": {
+    "panelLabel": "Pending modifications",
+    "title": "{count, plural, one {1 pending modification} other {# pending modifications}}",
+    "estimatedTimeSeconds": "Estimated time: ~{seconds} s",
+    "estimatedTimeMinute": "Estimated time: ~1 min",
+    "applyAll": "Apply all",
+    "cancel": "Cancel",
+    "applying": "Applying…",
+    "failedApply": "Failed to apply modifications. Please try again."
+  },
   "footer": {
     "faq": "FAQ"
   },

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -661,6 +661,16 @@
     "see_website": "Voir le site",
     "see_website_label": "Voir le site de {name}"
   },
+  "modificationQueue": {
+    "panelLabel": "Modifications en attente",
+    "title": "{count, plural, one {1 modification en attente} other {# modifications en attente}}",
+    "estimatedTimeSeconds": "Temps estimé : ~{seconds} s",
+    "estimatedTimeMinute": "Temps estimé : ~1 min",
+    "applyAll": "Appliquer tout",
+    "cancel": "Annuler",
+    "applying": "Application…",
+    "failedApply": "Impossible d'appliquer les modifications. Veuillez réessayer."
+  },
   "footer": {
     "faq": "FAQ"
   },

--- a/pwa/src/components/modification-queue.tsx
+++ b/pwa/src/components/modification-queue.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { ClipboardList, Clock, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useTripStore } from "@/store/trip-store";
+
+/**
+ * Seconds of backend recompute time estimated per modification.
+ *
+ * This is a rough heuristic shown to the user so they understand why
+ * batching several changes saves time. Values derived from observed p50
+ * durations across the handler pipeline:
+ * - accommodation: triggers RecalculateStages + ScanAccommodations (~5 s)
+ * - distance:      triggers RecalculateStages + POIs + terrain + … (~15 s)
+ * - dates:         triggers FetchWeather + CheckCalendar + ScanEvents (~8 s)
+ * - pacing:        triggers RecalculateStages for all stages (~10 s)
+ */
+const SECONDS_PER_MODIFICATION: Record<string, number> = {
+  accommodation: 5,
+  distance: 15,
+  dates: 8,
+  pacing: 10,
+};
+
+/**
+ * Maximum estimated seconds to display in the queue panel.
+ * Beyond this threshold we show "~1 min" instead of an exact count.
+ */
+const MAX_DISPLAY_SECONDS = 59;
+
+interface ModificationQueueProps {
+  onApply: () => void;
+  onCancel: () => void;
+  isApplying?: boolean;
+}
+
+/**
+ * Floating panel displayed at the bottom of the page when the user has
+ * accumulated one or more modifications in the batch queue.
+ *
+ * Shows the list of pending modifications, an estimated recompute time and
+ * two actions: "Apply all" (sends a single POST /recompute) and "Cancel"
+ * (clears the queue and restores the previous state).
+ */
+export function ModificationQueue({
+  onApply,
+  onCancel,
+  isApplying = false,
+}: ModificationQueueProps) {
+  const t = useTranslations("modificationQueue");
+  const pendingModifications = useTripStore((s) => s.pendingModifications);
+
+  if (pendingModifications.length === 0) return null;
+
+  const totalSeconds = pendingModifications.reduce((sum, mod) => {
+    return sum + (SECONDS_PER_MODIFICATION[mod.type] ?? 5);
+  }, 0);
+
+  const estimatedLabel =
+    totalSeconds > MAX_DISPLAY_SECONDS
+      ? t("estimatedTimeMinute")
+      : t("estimatedTimeSeconds", { seconds: totalSeconds });
+
+  return (
+    <div
+      role="region"
+      aria-label={t("panelLabel")}
+      data-testid="modification-queue"
+      className="fixed bottom-6 left-1/2 -translate-x-1/2 z-40 w-full max-w-md mx-auto px-4"
+    >
+      <div className="bg-background border border-border rounded-xl shadow-lg p-4 flex flex-col gap-3">
+        {/* Header */}
+        <div className="flex items-center gap-2">
+          <ClipboardList className="h-4 w-4 text-brand flex-shrink-0" />
+          <span className="font-semibold text-sm" data-testid="modification-queue-count">
+            {t("title", { count: pendingModifications.length })}
+          </span>
+        </div>
+
+        {/* Modification list */}
+        <ul className="space-y-1" data-testid="modification-queue-list">
+          {pendingModifications.map((mod, i) => (
+            <li
+              key={`${mod.type}-${mod.stageIndex ?? "trip"}-${i}`}
+              className="text-sm text-muted-foreground flex items-start gap-1.5"
+            >
+              <span className="mt-0.5 h-1.5 w-1.5 rounded-full bg-brand flex-shrink-0" />
+              <span data-testid={`modification-item-${i}`}>{mod.label}</span>
+            </li>
+          ))}
+        </ul>
+
+        {/* Estimated time */}
+        <div
+          className="flex items-center gap-1.5 text-xs text-muted-foreground"
+          data-testid="modification-queue-estimate"
+        >
+          <Clock className="h-3.5 w-3.5 flex-shrink-0" />
+          <span>{estimatedLabel}</span>
+        </div>
+
+        {/* Actions */}
+        <div className="flex gap-2 justify-end pt-1">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onCancel}
+            disabled={isApplying}
+            data-testid="modification-queue-cancel"
+          >
+            <X className="h-3.5 w-3.5 mr-1.5" />
+            {t("cancel")}
+          </Button>
+          <Button
+            size="sm"
+            onClick={onApply}
+            disabled={isApplying}
+            data-testid="modification-queue-apply"
+          >
+            {isApplying ? t("applying") : t("applyAll")}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/pwa/src/components/modification-queue.tsx
+++ b/pwa/src/components/modification-queue.tsx
@@ -73,7 +73,10 @@ export function ModificationQueue({
         {/* Header */}
         <div className="flex items-center gap-2">
           <ClipboardList className="h-4 w-4 text-brand flex-shrink-0" />
-          <span className="font-semibold text-sm" data-testid="modification-queue-count">
+          <span
+            className="font-semibold text-sm"
+            data-testid="modification-queue-count"
+          >
             {t("title", { count: pendingModifications.length })}
           </span>
         </div>

--- a/pwa/src/components/trip-planner.tsx
+++ b/pwa/src/components/trip-planner.tsx
@@ -24,6 +24,7 @@ import { Button } from "@/components/ui/button";
 import { UndoRedoButtons } from "@/components/undo-redo-buttons";
 import { Stepper } from "@/components/stepper";
 import { InlineRecomputationBar } from "@/components/inline-recomputation-bar";
+import { ModificationQueue } from "@/components/modification-queue";
 import { RecentTrips } from "@/components/recent-trips";
 import { SavedTripsSection } from "@/components/saved-trips-section";
 import { OfflineBanner } from "@/components/offline-banner";
@@ -93,6 +94,10 @@ export function TripPlanner({ onClose }: { onClose?: () => void } = {}) {
     isShareModalOpen,
     setShareModalOpen,
     clearNewAccKey,
+    pendingModifications,
+    isBatchApplying,
+    handleApplyBatch,
+    handleCancelBatch,
   } = useTripPlanner();
 
   // Auto-submit when ?link= query param is present
@@ -181,6 +186,25 @@ export function TripPlanner({ onClose }: { onClose?: () => void } = {}) {
         onAnalysisStarted,
       );
     };
+  }, []);
+
+  // E2E test hook: allow Playwright to enqueue modifications directly without
+  // going through real UI interactions (accommodation click, distance edit, etc.).
+  // This keeps batch-mode tests lean and deterministic.
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const mod = (
+        e as CustomEvent<{
+          stageIndex: number | null;
+          type: "accommodation" | "distance" | "dates" | "pacing";
+          label: string;
+        }>
+      ).detail;
+      useTripStore.getState().queueModification(mod);
+    };
+    window.addEventListener("__test_queue_modification", handler);
+    return () =>
+      window.removeEventListener("__test_queue_modification", handler);
   }, []);
 
   // Drive stepper state transitions based on trip lifecycle:
@@ -540,6 +564,15 @@ export function TripPlanner({ onClose }: { onClose?: () => void } = {}) {
           <>
             {/* Inline recomputation progress bar — thin bar at top of page */}
             <InlineRecomputationBar />
+
+            {/* Batch modification queue — floating panel at bottom of page */}
+            {pendingModifications.length > 0 && (
+              <ModificationQueue
+                onApply={handleApplyBatch}
+                onCancel={handleCancelBatch}
+                isApplying={isBatchApplying}
+              />
+            )}
 
             {/* Close button — top-right corner */}
             <Button

--- a/pwa/src/hooks/use-trip-planner.ts
+++ b/pwa/src/hooks/use-trip-planner.ts
@@ -859,10 +859,18 @@ export function useTripPlanner() {
         const affectedIndices = new Set<number>();
         for (const mod of pendingModifications) {
           if (mod.stageIndex !== null) {
-            affectedIndices.add(mod.stageIndex);
-            const nextIdx = mod.stageIndex + 1;
-            if (nextIdx < stages.length) {
-              affectedIndices.add(nextIdx);
+            if (mod.type === "distance") {
+              // Distance recomputes the modified stage and every subsequent one
+              // (mirrors ComputationDependencyResolver.resolve on the backend).
+              for (let i = mod.stageIndex; i < stages.length; i++) {
+                affectedIndices.add(i);
+              }
+            } else {
+              affectedIndices.add(mod.stageIndex);
+              const nextIdx = mod.stageIndex + 1;
+              if (nextIdx < stages.length) {
+                affectedIndices.add(nextIdx);
+              }
             }
           } else {
             // Trip-level modifications (dates, pacing) affect all stages

--- a/pwa/src/hooks/use-trip-planner.ts
+++ b/pwa/src/hooks/use-trip-planner.ts
@@ -21,6 +21,7 @@ import {
   addPoiWaypointToRoute,
   duplicateTrip,
   launchTripAnalysis,
+  applyBatchRecompute,
 } from "@/lib/api/client";
 import { getRandomTripName } from "@/lib/trip-utils";
 import {
@@ -116,8 +117,14 @@ export function useTripPlanner() {
       setIsLocked: s.setIsLocked,
       setDepartureHour: s.setDepartureHour,
       startStageRecomputation: s.startStageRecomputation,
+      queueModification: s.queueModification,
+      cancelAllModifications: s.cancelAllModifications,
+      clearPendingModifications: s.clearPendingModifications,
     })),
   );
+
+  const pendingModifications = useTripStore((s) => s.pendingModifications);
+  const [isBatchApplying, setIsBatchApplying] = useState(false);
 
   // UI store
   const isProcessing = useUiStore((s) => s.isProcessing);
@@ -838,6 +845,49 @@ export function useTripPlanner() {
     }
   }
 
+  async function handleApplyBatch() {
+    if (!tripId || pendingModifications.length === 0) return;
+
+    setIsBatchApplying(true);
+    try {
+      const ok = await applyBatchRecompute(tripId, pendingModifications);
+      if (ok) {
+        actions.clearPendingModifications();
+        setProcessing(true);
+        setAccommodationScanning(true);
+        // Mark all stages affected by pending modifications as recomputing
+        const affectedIndices = new Set<number>();
+        for (const mod of pendingModifications) {
+          if (mod.stageIndex !== null) {
+            affectedIndices.add(mod.stageIndex);
+            const nextIdx = mod.stageIndex + 1;
+            if (nextIdx < stages.length) {
+              affectedIndices.add(nextIdx);
+            }
+          } else {
+            // Trip-level modifications (dates, pacing) affect all stages
+            for (let i = 0; i < stages.length; i++) {
+              affectedIndices.add(i);
+            }
+          }
+        }
+        if (affectedIndices.size > 0) {
+          actions.startStageRecomputation(Array.from(affectedIndices));
+        }
+      } else {
+        toast.error(t("modificationQueue.failedApply"));
+      }
+    } catch {
+      toast.error(t("modificationQueue.failedApply"));
+    } finally {
+      setIsBatchApplying(false);
+    }
+  }
+
+  function handleCancelBatch() {
+    actions.cancelAllModifications();
+  }
+
   const firstStage = stages[0];
   const firstWeather = firstStage?.weather ?? null;
   const isWeatherLoading = isProcessing && stages.length > 0 && !firstWeather;
@@ -888,5 +938,10 @@ export function useTripPlanner() {
     isShareModalOpen,
     setShareModalOpen,
     clearNewAccKey: () => setNewAccKey(null),
+    pendingModifications,
+    isBatchApplying,
+    handleApplyBatch,
+    handleCancelBatch,
+    queueModification: actions.queueModification,
   };
 }

--- a/pwa/src/lib/api/client.ts
+++ b/pwa/src/lib/api/client.ts
@@ -343,11 +343,7 @@ export async function uploadGpxFile(
  */
 export async function applyBatchRecompute(
   tripId: string,
-  modifications: Array<{
-    stageIndex: number | null;
-    type: "accommodation" | "distance" | "dates" | "pacing";
-    label: string;
-  }>,
+  modifications: import("@/lib/api/schema").components["schemas"]["TripModification"][],
 ): Promise<boolean> {
   const res = await apiFetch(
     `${API_URL}/trips/${encodeURIComponent(tripId)}/recompute`,

--- a/pwa/src/lib/api/client.ts
+++ b/pwa/src/lib/api/client.ts
@@ -343,20 +343,13 @@ export async function uploadGpxFile(
  */
 export async function applyBatchRecompute(
   tripId: string,
-  modifications: import("@/lib/api/schema").components["schemas"]["TripModification"][],
+  modifications: components["schemas"]["TripModification"][],
 ): Promise<boolean> {
-  const res = await apiFetch(
-    `${API_URL}/trips/${encodeURIComponent(tripId)}/recompute`,
-    {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/ld+json",
-        Accept: "application/ld+json",
-      },
-      body: JSON.stringify({ modifications }),
-    },
-  );
-  return res.ok;
+  const { response } = await apiClient.POST("/trips/{id}/recompute", {
+    params: { path: { id: tripId } },
+    body: { modifications },
+  });
+  return response.ok;
 }
 
 /**

--- a/pwa/src/lib/api/client.ts
+++ b/pwa/src/lib/api/client.ts
@@ -333,6 +333,37 @@ export async function uploadGpxFile(
 }
 
 /**
+ * Apply a batch of pending modifications in a single recompute pass.
+ *
+ * Sends `POST /trips/{id}/recompute` with all queued modifications so the backend
+ * dispatches only the minimal set of handlers required — avoiding N sequential
+ * recomputations for N changes.
+ *
+ * Returns `true` on HTTP 2xx; `false` otherwise.
+ */
+export async function applyBatchRecompute(
+  tripId: string,
+  modifications: Array<{
+    stageIndex: number | null;
+    type: "accommodation" | "distance" | "dates" | "pacing";
+    label: string;
+  }>,
+): Promise<boolean> {
+  const res = await apiFetch(
+    `${API_URL}/trips/${encodeURIComponent(tripId)}/recompute`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/ld+json",
+        Accept: "application/ld+json",
+      },
+      body: JSON.stringify({ modifications }),
+    },
+  );
+  return res.ok;
+}
+
+/**
  * Trigger the full Phase 2 enrichment pipeline (POIs, weather, terrain, …)
  * for a trip whose stages have been pre-computed during Phase 1.
  *

--- a/pwa/src/lib/api/schema.d.ts
+++ b/pwa/src/lib/api/schema.d.ts
@@ -364,6 +364,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/trips/{id}/recompute": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Apply a batch of pending modifications in a single recompute pass, dispatching only the minimal set of handlers needed.
+         * @description Creates a Trip resource.
+         */
+        post: operations["api_trips_idrecompute_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/trips/{id}/detail": {
         parameters: {
             query?: never;
@@ -970,6 +990,9 @@ export interface components {
             elevationLoss?: number;
             isRestDay?: boolean;
         };
+        "Trip.TripBatchRecomputeRequest": {
+            modifications: components["schemas"]["TripModification"][];
+        };
         "Trip.TripListItem.jsonld": components["schemas"]["HydraItemBaseSchema"] & {
             id?: string;
             title?: string | null;
@@ -1191,6 +1214,17 @@ export interface components {
                     distanceToEndPoint?: number;
                 } | null;
             }[];
+        };
+        TripModification: {
+            /** @description Zero-based index of the affected stage. */
+            stageIndex?: number | null;
+            /**
+             * @description Type of modification — determines which handlers are re-dispatched.
+             * @enum {string}
+             */
+            type: "accommodation" | "distance" | "dates" | "pacing";
+            /** @description Human-readable description for display in the frontend queue panel. */
+            label?: string | null;
         };
         TripShare: {
             /** Format: uuid */
@@ -2638,6 +2672,74 @@ export interface operations {
                 content?: never;
             };
             /** @description An error occurred */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["ConstraintViolation.jsonld"];
+                    "application/problem+json": components["schemas"]["ConstraintViolation"];
+                    "application/json": components["schemas"]["ConstraintViolation"];
+                };
+            };
+        };
+    };
+    api_trips_idrecompute_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Trip identifier */
+                id: string;
+            };
+            cookie?: never;
+        };
+        /** @description The new Trip resource */
+        requestBody: {
+            content: {
+                "application/ld+json": components["schemas"]["Trip.TripBatchRecomputeRequest"];
+            };
+        };
+        responses: {
+            /** @description Trip resource created */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["Trip.jsonld"];
+                };
+            };
+            /** @description Invalid input */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["Error.jsonld"];
+                    "application/problem+json": components["schemas"]["Error"];
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["Error.jsonld"];
+                    "application/problem+json": components["schemas"]["Error"];
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Trip not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Trip has no stages to recompute */
             422: {
                 headers: {
                     [name: string]: unknown;

--- a/pwa/src/store/trip-store.ts
+++ b/pwa/src/store/trip-store.ts
@@ -690,6 +690,8 @@ export const useTripStore = create<TripState>()(
         state.pendingModifications = [];
       }),
 
+    // Intentionally identical to cancelAllModifications; kept separate so
+    // post-apply cleanup can diverge from user-initiated cancel in the future.
     clearPendingModifications: () =>
       set((state) => {
         state.pendingModifications = [];

--- a/pwa/src/store/trip-store.ts
+++ b/pwa/src/store/trip-store.ts
@@ -13,6 +13,22 @@ import type {
   SupplyMarkerData,
   EventData,
 } from "@/lib/validation/schemas";
+
+/**
+ * A single user modification accumulated in the batch queue before being applied
+ * in one recompute pass via `POST /trips/{id}/recompute`.
+ */
+export interface Modification {
+  /** Zero-based stage index. Null for trip-level changes (dates, pacing). */
+  stageIndex: number | null;
+  /**
+   * Modification type — maps directly to the backend TripModification.type:
+   * 'accommodation' | 'distance' | 'dates' | 'pacing'
+   */
+  type: "accommodation" | "distance" | "dates" | "pacing";
+  /** Human-readable description shown in the ModificationQueue panel. */
+  label: string;
+}
 import type { AccommodationType } from "@/lib/accommodation-types";
 import { FILTERABLE_ACCOMMODATION_TYPES } from "@/lib/accommodation-types";
 import { createTemporalStore } from "@/store/temporal-middleware";
@@ -59,6 +75,13 @@ interface TripState {
    * fields that changed during an inline recomputation.
    */
   stageDiffs: Map<number, Set<string>>;
+
+  /**
+   * Accumulated modifications that have not yet been sent to the backend.
+   * The user can accumulate N changes then click "Apply all" to send a single
+   * `POST /trips/{id}/recompute` instead of N sequential recomputations.
+   */
+  pendingModifications: Modification[];
 
   setTrip: (trip: TripIdentity) => void;
   updateRouteData: (data: {
@@ -172,6 +195,24 @@ interface TripState {
    * in `use-mercure.ts` after ~3 seconds).
    */
   clearStageDiff: (stageIndex: number) => void;
+
+  /**
+   * Enqueue a modification in the pending batch. Duplicate entries (same type
+   * + stageIndex) are replaced rather than appended.
+   */
+  queueModification: (modification: Modification) => void;
+
+  /**
+   * Remove all pending modifications, restoring the UI to its pre-queue state.
+   * Does NOT trigger a backend call — the caller is responsible for any rollback.
+   */
+  cancelAllModifications: () => void;
+
+  /**
+   * Internal: clears the pending modifications list after a successful batch apply.
+   * Called by the hook after the backend responds with 2xx.
+   */
+  clearPendingModifications: () => void;
   clearTrip: () => void;
   /** Hydrate the trip store from a {@link SavedTrip} snapshot (offline consultation). */
   loadFromSavedTrip: (trip: SavedTrip) => void;
@@ -199,6 +240,7 @@ const initialState = {
   computationStatus: {},
   recomputingStages: new Set<number>(),
   stageDiffs: new Map<number, Set<string>>(),
+  pendingModifications: [] as Modification[],
 };
 
 /**
@@ -626,6 +668,31 @@ export const useTripStore = create<TripState>()(
     clearStageDiff: (stageIndex) =>
       set((state) => {
         state.stageDiffs.delete(stageIndex);
+      }),
+
+    queueModification: (modification) =>
+      set((state) => {
+        // Replace duplicate: same type + stageIndex (null considered equal to null)
+        const existingIndex = state.pendingModifications.findIndex(
+          (m) =>
+            m.type === modification.type &&
+            m.stageIndex === modification.stageIndex,
+        );
+        if (existingIndex !== -1) {
+          state.pendingModifications[existingIndex] = modification;
+        } else {
+          state.pendingModifications.push(modification);
+        }
+      }),
+
+    cancelAllModifications: () =>
+      set((state) => {
+        state.pendingModifications = [];
+      }),
+
+    clearPendingModifications: () =>
+      set((state) => {
+        state.pendingModifications = [];
       }),
 
     loadFromSavedTrip: (trip) => {

--- a/pwa/tests/mocked/batch-mode.spec.ts
+++ b/pwa/tests/mocked/batch-mode.spec.ts
@@ -1,0 +1,358 @@
+import { test, expect } from "../fixtures/base.fixture";
+import {
+  routeParsedEvent,
+  stagesComputedEvent,
+  tripCompleteEvent,
+  stageUpdatedEvent,
+  accommodationsFoundEvent,
+} from "../fixtures/mock-data";
+
+/**
+ * Issue #327 — Batch mode: ModificationQueue (accumulation + single recompute).
+ *
+ * The user can accumulate several modifications before applying them in a single
+ * `POST /trips/{id}/recompute` call. The ModificationQueue floating panel shows:
+ * - The list of pending modifications
+ * - An estimated recompute time
+ * - "Apply all" and "Cancel" actions
+ *
+ * "Apply all" → sends one request → shows shimmer skeleton(s)
+ * "Cancel"    → clears the queue, restores previous state
+ */
+
+/**
+ * Helper: inject a `__test_queue_modification` custom event so the test can
+ * populate the pending modifications queue without wiring through real UI
+ * actions. The `trip-planner.tsx` E2E test hook (similar pattern to
+ * `__test_set_focused_map_stage`) dispatches this to the store directly.
+ */
+async function queueModification(
+  page: import("@playwright/test").Page,
+  modification: {
+    stageIndex: number | null;
+    type: "accommodation" | "distance" | "dates" | "pacing";
+    label: string;
+  },
+) {
+  await page.evaluate((mod) => {
+    window.dispatchEvent(
+      new CustomEvent("__test_queue_modification", { detail: mod }),
+    );
+  }, modification);
+}
+
+test.describe("ModificationQueue — display", () => {
+  test("modification queue panel is hidden when no modifications are pending", async ({
+    createFullTrip,
+    mockedPage,
+  }) => {
+    await createFullTrip();
+    await expect(mockedPage.getByTestId("modification-queue")).toBeHidden();
+  });
+
+  test("modification queue panel appears after queueing a modification", async ({
+    createFullTrip,
+    mockedPage,
+  }) => {
+    await createFullTrip();
+
+    await queueModification(mockedPage, {
+      stageIndex: 0,
+      type: "accommodation",
+      label: "Hébergement étape 1 : Camping Les Oliviers",
+    });
+
+    await expect(mockedPage.getByTestId("modification-queue")).toBeVisible({
+      timeout: 3000,
+    });
+  });
+
+  test("counter reflects the number of pending modifications", async ({
+    createFullTrip,
+    mockedPage,
+  }) => {
+    await createFullTrip();
+
+    await queueModification(mockedPage, {
+      stageIndex: 0,
+      type: "accommodation",
+      label: "Hébergement étape 1 : Camping Les Oliviers",
+    });
+    await queueModification(mockedPage, {
+      stageIndex: 1,
+      type: "distance",
+      label: "Distance étape 2 : 55 km → 65 km",
+    });
+    await queueModification(mockedPage, {
+      stageIndex: null,
+      type: "dates",
+      label: "Dates : 15 juin → 18 juin",
+    });
+
+    const countEl = mockedPage.getByTestId("modification-queue-count");
+    await expect(countEl).toBeVisible({ timeout: 3000 });
+    await expect(countEl).toContainText("3");
+  });
+
+  test("modification labels are listed in the queue panel", async ({
+    createFullTrip,
+    mockedPage,
+  }) => {
+    await createFullTrip();
+
+    await queueModification(mockedPage, {
+      stageIndex: 0,
+      type: "accommodation",
+      label: "Hébergement étape 1 : Camping Les Oliviers",
+    });
+    await queueModification(mockedPage, {
+      stageIndex: 1,
+      type: "distance",
+      label: "Distance étape 2 : 55 km → 65 km",
+    });
+
+    const list = mockedPage.getByTestId("modification-queue-list");
+    await expect(list).toBeVisible({ timeout: 3000 });
+    await expect(list).toContainText("Hébergement étape 1");
+    await expect(list).toContainText("Distance étape 2");
+  });
+
+  test("estimated recompute time is displayed", async ({
+    createFullTrip,
+    mockedPage,
+  }) => {
+    await createFullTrip();
+
+    await queueModification(mockedPage, {
+      stageIndex: 0,
+      type: "accommodation",
+      label: "Hébergement étape 1",
+    });
+
+    const estimate = mockedPage.getByTestId("modification-queue-estimate");
+    await expect(estimate).toBeVisible({ timeout: 3000 });
+    // Should show some time estimate (contains "~" and either "s" or "min")
+    await expect(estimate).toContainText("~");
+  });
+
+  test("duplicate modification type+stageIndex replaces existing entry", async ({
+    createFullTrip,
+    mockedPage,
+  }) => {
+    await createFullTrip();
+
+    await queueModification(mockedPage, {
+      stageIndex: 0,
+      type: "accommodation",
+      label: "Hébergement étape 1 : Gîte du Moulin",
+    });
+    // Queue the same type + stageIndex again — should replace, not append
+    await queueModification(mockedPage, {
+      stageIndex: 0,
+      type: "accommodation",
+      label: "Hébergement étape 1 : Camping Les Oliviers",
+    });
+
+    const countEl = mockedPage.getByTestId("modification-queue-count");
+    // Still only 1 entry (replacement, not addition)
+    await expect(countEl).toContainText("1");
+    await expect(
+      mockedPage.getByTestId("modification-queue-list"),
+    ).toContainText("Camping Les Oliviers");
+    await expect(
+      mockedPage.getByTestId("modification-queue-list"),
+    ).not.toContainText("Gîte du Moulin");
+  });
+});
+
+test.describe("ModificationQueue — apply all", () => {
+  test("'Apply all' sends a recompute request and shows shimmer skeleton", async ({
+    createFullTrip,
+    mockedPage,
+  }) => {
+    // Intercept the recompute request so we can control the response timing
+    let recomputeResolve: (() => void) | undefined;
+    await mockedPage.route("**/trips/*/recompute", (route, request) => {
+      if (request.method() !== "POST") return route.fallback();
+      // Hold the response until the test resolves it
+      return new Promise<void>((resolve) => {
+        recomputeResolve = () => {
+          resolve();
+          void route.fulfill({
+            status: 202,
+            contentType: "application/ld+json",
+            body: JSON.stringify({ "@type": "Trip", id: "test-trip-abc-123" }),
+          });
+        };
+      });
+    });
+
+    await createFullTrip();
+
+    await queueModification(mockedPage, {
+      stageIndex: 0,
+      type: "accommodation",
+      label: "Hébergement étape 1",
+    });
+
+    await expect(mockedPage.getByTestId("modification-queue")).toBeVisible({
+      timeout: 3000,
+    });
+
+    await mockedPage.getByTestId("modification-queue-apply").click();
+
+    // The "Applying…" state should be visible while the request is in-flight
+    await expect(mockedPage.getByTestId("modification-queue-apply")).toContainText(/appli/i, {
+      timeout: 3000,
+    });
+
+    // Resolve the request
+    recomputeResolve?.();
+
+    // After success the queue panel should disappear
+    await expect(mockedPage.getByTestId("modification-queue")).toBeHidden({
+      timeout: 5000,
+    });
+  });
+
+  test("'Apply all' sends a single request for multiple modifications", async ({
+    createFullTrip,
+    mockedPage,
+  }) => {
+    const recomputeRequests: unknown[] = [];
+    await mockedPage.route("**/trips/*/recompute", (route, request) => {
+      if (request.method() !== "POST") return route.fallback();
+      recomputeRequests.push(JSON.parse(request.postData() ?? "{}") as unknown);
+      return route.fulfill({
+        status: 202,
+        contentType: "application/ld+json",
+        body: JSON.stringify({ "@type": "Trip", id: "test-trip-abc-123" }),
+      });
+    });
+
+    await createFullTrip();
+
+    await queueModification(mockedPage, {
+      stageIndex: 0,
+      type: "accommodation",
+      label: "Hébergement étape 1",
+    });
+    await queueModification(mockedPage, {
+      stageIndex: 1,
+      type: "distance",
+      label: "Distance étape 2",
+    });
+    await queueModification(mockedPage, {
+      stageIndex: null,
+      type: "dates",
+      label: "Dates du voyage",
+    });
+
+    await mockedPage.getByTestId("modification-queue-apply").click();
+
+    // Wait for the request to be captured
+    await mockedPage.waitForTimeout(500);
+
+    // Exactly one recompute request was sent (batch mode)
+    expect(recomputeRequests).toHaveLength(1);
+
+    // The body should contain all 3 modifications
+    const body = recomputeRequests[0] as {
+      modifications: Array<{ type: string }>;
+    };
+    expect(body.modifications).toHaveLength(3);
+  });
+
+  test("shimmer skeleton appears for affected stage after apply", async ({
+    createFullTrip,
+    injectEvent,
+    mockedPage,
+  }) => {
+    await mockedPage.route("**/trips/*/recompute", (route, request) => {
+      if (request.method() !== "POST") return route.fallback();
+      return route.fulfill({
+        status: 202,
+        contentType: "application/ld+json",
+        body: JSON.stringify({ "@type": "Trip", id: "test-trip-abc-123" }),
+      });
+    });
+
+    await createFullTrip();
+
+    await queueModification(mockedPage, {
+      stageIndex: 0,
+      type: "accommodation",
+      label: "Hébergement étape 1",
+    });
+
+    await mockedPage.getByTestId("modification-queue-apply").click();
+
+    // Shimmer should appear for the affected stage
+    await expect(
+      mockedPage.getByTestId("stage-skeleton").first(),
+    ).toBeVisible({ timeout: 5000 });
+
+    // Original stage card should be hidden
+    await expect(mockedPage.getByTestId("stage-card-1")).toBeHidden();
+
+    // Inject stage_updated to resolve the recomputation
+    await injectEvent(stageUpdatedEvent(0));
+    await injectEvent(stageUpdatedEvent(1));
+
+    // Stage card should be restored
+    await expect(mockedPage.getByTestId("stage-card-1")).toBeVisible({
+      timeout: 3000,
+    });
+  });
+});
+
+test.describe("ModificationQueue — cancel", () => {
+  test("'Cancel' clears the queue and hides the panel", async ({
+    createFullTrip,
+    mockedPage,
+  }) => {
+    await createFullTrip();
+
+    await queueModification(mockedPage, {
+      stageIndex: 0,
+      type: "accommodation",
+      label: "Hébergement étape 1",
+    });
+
+    await expect(mockedPage.getByTestId("modification-queue")).toBeVisible({
+      timeout: 3000,
+    });
+
+    await mockedPage.getByTestId("modification-queue-cancel").click();
+
+    // Panel should be gone after cancellation
+    await expect(mockedPage.getByTestId("modification-queue")).toBeHidden({
+      timeout: 3000,
+    });
+  });
+
+  test("'Cancel' restores original stage cards (no shimmer)", async ({
+    createFullTrip,
+    mockedPage,
+  }) => {
+    await createFullTrip();
+
+    await queueModification(mockedPage, {
+      stageIndex: 0,
+      type: "distance",
+      label: "Distance étape 1",
+    });
+
+    await mockedPage.getByTestId("modification-queue-cancel").click();
+
+    // All stage cards should still be visible (no recomputation triggered)
+    await expect(mockedPage.getByTestId("stage-card-1")).toBeVisible({
+      timeout: 3000,
+    });
+    await expect(mockedPage.getByTestId("stage-card-2")).toBeVisible();
+    await expect(mockedPage.getByTestId("stage-card-3")).toBeVisible();
+
+    // No shimmer should appear
+    await expect(mockedPage.getByTestId("stage-skeleton")).toBeHidden();
+  });
+});

--- a/pwa/tests/mocked/batch-mode.spec.ts
+++ b/pwa/tests/mocked/batch-mode.spec.ts
@@ -202,7 +202,9 @@ test.describe("ModificationQueue — apply all", () => {
     await mockedPage.getByTestId("modification-queue-apply").click();
 
     // The "Applying…" state should be visible while the request is in-flight
-    await expect(mockedPage.getByTestId("modification-queue-apply")).toContainText(/appli/i, {
+    await expect(
+      mockedPage.getByTestId("modification-queue-apply"),
+    ).toContainText(/appli/i, {
       timeout: 3000,
     });
 
@@ -250,11 +252,10 @@ test.describe("ModificationQueue — apply all", () => {
 
     await mockedPage.getByTestId("modification-queue-apply").click();
 
-    // Wait for the request to be captured
-    await mockedPage.waitForTimeout(500);
-
     // Exactly one recompute request was sent (batch mode)
-    expect(recomputeRequests).toHaveLength(1);
+    await expect
+      .poll(() => recomputeRequests.length, { timeout: 3_000 })
+      .toBe(1);
 
     // The body should contain all 3 modifications
     const body = recomputeRequests[0] as {
@@ -288,9 +289,9 @@ test.describe("ModificationQueue — apply all", () => {
     await mockedPage.getByTestId("modification-queue-apply").click();
 
     // Shimmer should appear for the affected stage
-    await expect(
-      mockedPage.getByTestId("stage-skeleton").first(),
-    ).toBeVisible({ timeout: 5000 });
+    await expect(mockedPage.getByTestId("stage-skeleton").first()).toBeVisible({
+      timeout: 5000,
+    });
 
     // Original stage card should be hidden
     await expect(mockedPage.getByTestId("stage-card-1")).toBeHidden();

--- a/pwa/tests/mocked/batch-mode.spec.ts
+++ b/pwa/tests/mocked/batch-mode.spec.ts
@@ -305,6 +305,48 @@ test.describe("ModificationQueue — apply all", () => {
       timeout: 3000,
     });
   });
+
+  test("distance modification shows shimmer on all subsequent stages", async ({
+    createFullTrip,
+    injectEvent,
+    mockedPage,
+  }) => {
+    await mockedPage.route("**/trips/*/recompute", (route, request) => {
+      if (request.method() !== "POST") return route.fallback();
+      return route.fulfill({
+        status: 202,
+        contentType: "application/ld+json",
+        body: JSON.stringify({ "@type": "Trip", id: "test-trip-abc-123" }),
+      });
+    });
+
+    await createFullTrip();
+
+    // Queue a distance modification on stage 0 — backend will recompute all subsequent stages
+    await queueModification(mockedPage, {
+      stageIndex: 0,
+      type: "distance",
+      label: "Distance étape 1",
+    });
+
+    await mockedPage.getByTestId("modification-queue-apply").click();
+
+    // All stages from stageIndex=0 onwards (stages 0, 1, 2) must show shimmer
+    await expect(mockedPage.getByTestId("stage-card-1")).toBeHidden({
+      timeout: 5000,
+    });
+    await expect(mockedPage.getByTestId("stage-card-2")).toBeHidden();
+    await expect(mockedPage.getByTestId("stage-card-3")).toBeHidden();
+
+    // Resolve all three stages via SSE
+    await injectEvent(stageUpdatedEvent(0));
+    await injectEvent(stageUpdatedEvent(1));
+    await injectEvent(stageUpdatedEvent(2));
+
+    await expect(mockedPage.getByTestId("stage-card-1")).toBeVisible({
+      timeout: 3000,
+    });
+  });
 });
 
 test.describe("ModificationQueue — cancel", () => {


### PR DESCRIPTION
## Summary

- **Backend**: nouvel endpoint `POST /trips/{id}/recompute` avec `TripBatchRecomputeRequest` (liste de `TripModification`) et `TripBatchRecomputeProcessor`; service `ComputationDependencyResolver` qui fusionne les dépendances de N modifications et dispatche uniquement les handlers nécessaires
- **Frontend**: `Modification` type + `pendingModifications` / `queueModification` / `cancelAllModifications` / `clearPendingModifications` ajoutés au store Zustand; composant flottant `ModificationQueue` affiché en bas de page; hook `useTripPlanner` étendu avec `handleApplyBatch` / `handleCancelBatch`; `applyBatchRecompute()` dans `client.ts`
- **Tests**: `ComputationDependencyResolverTest.php` (8 cas unitaires PHPUnit) + `batch-mode.spec.ts` (10 cas Playwright mocked)

## Test plan

- [ ] Accumuler 3 modifications via `__test_queue_modification` → compteur "3 modifications en attente" visible
- [ ] "Appliquer tout" → un seul `POST /trips/{id}/recompute` envoyé (vérifié par `recomputeRequests.length === 1`)
- [ ] Shimmer skeleton apparaît sur les étapes affectées pendant le recalcul
- [ ] "Annuler" → panel disparaît, les stage cards restent visibles, aucun skeleton
- [ ] Estimation du temps affichée (contient "~")
- [ ] Modification dupliquée (même type + stageIndex) remplace l'entrée existante au lieu d'en créer une nouvelle
- [ ] `ComputationDependencyResolver` unit tests : accommodation → RecalculateStages + ScanAccommodations seulement; distance → pipeline enrichissement complet; dates → weather/calendar/events; pacing → RecalculateStages toutes étapes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

**Summary:** Round-8 review on commit `dc08c48756d5e4f4188871ae900acff883b5af21`. All 11 previously open bot threads are resolved; the `pacing + hasDates` test coverage added in the last commit closes the last flagged gap. One new `suggestion` raised: confirm whether `ScanEvents` / `CheckCulturalPois` should also fire for `pacing + hasDates` (by the same logic that drives `FetchWeather` + `CheckCalendar`).

**Findings:** 1 suggestion

**Commit reviewed:** `dc08c48756d5e4f4188871ae900acff883b5af21`

**Resolved threads:** All 11 previous bot-authored threads are already resolved — nothing to re-resolve this round.

**Dismissed:** Dismissed 1 remaining `CHANGES_REQUESTED` bot review (superseded by this review).

**PR title check:** ✅ Conforms to Conventional Commits.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** Posted 1 inline comment.

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->