### PR TITLE
docs(tracking): add PR links for sprint 24 issues (#326, #327, #328)

### DIFF
--- a/TRACKING.md
+++ b/TRACKING.md
@@ -447,11 +447,11 @@ Interface d'entrée de l'itinéraire (cartes Lien/GPX), écran de prévisualisat
 
 Shimmer/skeleton sur les étapes en recalcul, batch mode (ModificationQueue), diff post-recalcul.
 
-| Ordre | ID                                                                      | Titre                                                                     | Effort | PRs | Dépend de |
-|-------|-------------------------------------------------------------------------|---------------------------------------------------------------------------|--------|-----|-----------|
-| 1     | [#326](https://github.com/vincentchalamon/bike-trip-planner/issues/326) | Recomputation inline : shimmer/skeleton + barre de progression discrète   | L      |     | #324 #325 |
-| 2     | [#327](https://github.com/vincentchalamon/bike-trip-planner/issues/327) | Batch mode : ModificationQueue (accumulation + recalcul unique)           | L      |     | #326      |
-| 3     | [#328](https://github.com/vincentchalamon/bike-trip-planner/issues/328) | Diff post-recalcul : surbrillance des changements après recomputation     | M      |     | #326      |
+| Ordre | ID                                                                      | Titre                                                                     | Effort | PRs                                                                                | Dépend de |
+|-------|-------------------------------------------------------------------------|---------------------------------------------------------------------------|--------|------------------------------------------------------------------------------------|-----------|
+| 1     | [#326](https://github.com/vincentchalamon/bike-trip-planner/issues/326) | Recomputation inline : shimmer/skeleton + barre de progression discrète   | L      | [#380](https://github.com/vincentchalamon/bike-trip-planner/pull/380) `feature/326` | #324 #325 |
+| 2     | [#327](https://github.com/vincentchalamon/bike-trip-planner/issues/327) | Batch mode : ModificationQueue (accumulation + recalcul unique)           | L      | [#382](https://github.com/vincentchalamon/bike-trip-planner/pull/382) `feature/327` | #326      |
+| 3     | [#328](https://github.com/vincentchalamon/bike-trip-planner/issues/328) | Diff post-recalcul : surbrillance des changements après recomputation     | M      | [#381](https://github.com/vincentchalamon/bike-trip-planner/pull/381) `feature/328` | #326      |
 
 ---
 


### PR DESCRIPTION
## Summary

- Mise à jour du TRACKING.md sprint 24 avec les liens vers les PRs créées
- #326 → PR #380 `feature/326`
- #327 → PR #382 `feature/327`
- #328 → PR #381 `feature/328`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

**Summary:** Clean documentation-only PR that adds PR links to the sprint 24 tracking table. No code changes, no risk.

**Review summary:** 0 findings (0 critical, 0 warnings).

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases *(N/A — documentation only)*
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Commit reviewed:** `97d9ccb4cadc9cb51099a81ee06bf487e72197d9`

No inline comments.

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->