### PR TITLE
feat(design): load Fraunces, Inter Tight and JetBrains Mono via next/font

### DIFF
--- a/pwa/src/app/globals.css
+++ b/pwa/src/app/globals.css
@@ -7,8 +7,9 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-serif: var(--font-fraunces);
+  --font-sans: var(--font-inter-tight);
+  --font-mono: var(--font-jetbrains-mono);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -182,7 +183,7 @@
   color: var(--popover-foreground);
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  font-family: var(--font-geist-sans), system-ui, sans-serif;
+  font-family: var(--font-sans), system-ui, sans-serif;
   box-shadow:
     0 10px 25px -5px oklch(0 0 0 / 20%),
     0 4px 10px -2px oklch(0 0 0 / 10%);

--- a/pwa/src/app/layout.tsx
+++ b/pwa/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Fraunces, Inter_Tight, JetBrains_Mono } from "next/font/google";
 import { NextIntlClientProvider } from "next-intl";
 import { getLocale, getMessages, getTranslations } from "next-intl/server";
 import { DEFAULT_LOCALE } from "@/i18n/locale";
@@ -10,14 +10,19 @@ import { Toaster } from "@/components/ui/sonner";
 import { OnboardingTour } from "@/components/onboarding-tour";
 import { AuthGuard } from "@/components/auth-guard";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const fraunces = Fraunces({
   subsets: ["latin"],
+  variable: "--font-fraunces",
 });
 
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
+const interTight = Inter_Tight({
   subsets: ["latin"],
+  variable: "--font-inter-tight",
+});
+
+const jetbrainsMono = JetBrains_Mono({
+  subsets: ["latin"],
+  variable: "--font-jetbrains-mono",
 });
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -53,10 +58,12 @@ export default async function RootLayout({
   }
 
   return (
-    <html lang={locale} suppressHydrationWarning>
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased overflow-x-hidden`}
-      >
+    <html
+      lang={locale}
+      suppressHydrationWarning
+      className={`${fraunces.variable} ${interTight.variable} ${jetbrainsMono.variable}`}
+    >
+      <body className="antialiased overflow-x-hidden">
         <NextIntlClientProvider locale={locale} messages={messages}>
           <ThemeProvider
             attribute="class"


### PR DESCRIPTION
## Summary

Charge les 3 familles de fontes du nouveau design system via `next/font/google` et remplace les variables `--font-geist-*` (issue #387, sprint 25 — Design Foundations).

- **Fraunces** (`--font-serif`) — titres H1/H2, résumés IA, hero landing
- **Inter Tight** (`--font-sans`) — body, labels, boutons, navigation
- **JetBrains Mono** (`--font-mono`) — données numériques, code

## Changes

- `pwa/src/app/layout.tsx` : import des 3 fontes via `next/font/google`, classes de variables sur `<html>`
- `pwa/src/app/globals.css` :
  - `@theme inline` : `--font-geist-sans` → `--font-inter-tight`, `--font-geist-mono` → `--font-jetbrains-mono`, ajout de `--font-serif: var(--font-fraunces)`
  - Driver.js popover : `var(--font-geist-sans)` → `var(--font-sans)`

## Auto-critique

- Pas de modification de `package.json` — les fontes Google sont gérées directement par `next/font/google`
- Aucun composant existant ne référence directement `--font-geist-*` hors layout/globals (vérifié par grep)
- Le FOUT devrait être minimisé par la stratégie de chargement automatique de `next/font`

## Test plan

- [ ] `make qa` passe (CI)
- [ ] Visuellement : pas de FOUT au chargement initial
- [ ] Variables CSS `--font-serif`, `--font-sans`, `--font-mono` accessibles dans le DOM

Closes #387

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

**Findings:** 0 critical · 0 warnings · 0 suggestions

Reviewed commit `57e104abf6f2424396947603006c3de39b98e18e`.

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

No inline comments. No previously open threads to resolve.

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->