### PR TITLE
feat(wizard): split /trips/new into 4 steps with WizardStepper and narrative analysis screen

### DIFF
--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -360,28 +360,53 @@
     "failureMessage": "Failed: {message}",
     "categories": {
       "terrain_security": {
-        "label": "Terrain & Safety",
-        "description": "Surface, traffic, slopes, continuity"
+        "label": "Terrain analysis",
+        "description": "Surface, traffic, slopes, continuity",
+        "running": "Querying OpenStreetMap…",
+        "done": "Terrain analysed",
+        "failed": "Terrain analysis unavailable"
       },
       "supply": {
-        "label": "Supply",
-        "description": "Water points, shops"
+        "label": "Points of interest",
+        "description": "Water points, shops, cultural sites",
+        "running": "Looking up points of interest…",
+        "done": "Points of interest collected",
+        "failed": "POI lookup unavailable"
       },
       "accommodations": {
         "label": "Accommodations",
-        "description": "Campings, lodges, hotels"
+        "description": "Campings, lodges, hotels",
+        "running": "Identifying accommodations…",
+        "done": "Accommodations identified",
+        "failed": "Accommodation lookup unavailable"
       },
       "weather": {
-        "label": "Weather & Conditions",
-        "description": "Forecasts, wind, sunset"
+        "label": "Weather",
+        "description": "Forecasts, wind, conditions",
+        "running": "Fetching weather forecasts…",
+        "done": "Forecasts ready",
+        "failed": "Weather unavailable"
       },
       "services": {
-        "label": "Services",
-        "description": "Bike shops, repair"
+        "label": "Safety & services",
+        "description": "Bike shops, rescue, stations, borders",
+        "running": "Mapping services along the route…",
+        "done": "Services mapped",
+        "failed": "Services unavailable"
+      },
+      "context": {
+        "label": "Local events",
+        "description": "Calendar, festivals, holidays",
+        "running": "Looking up local events…",
+        "done": "Local events ready",
+        "failed": "Local events unavailable"
       },
       "ai": {
-        "label": "AI Analysis",
-        "description": "Narrative trip summary"
+        "label": "AI summary",
+        "description": "Narrative trip summary",
+        "running": "Drafting the summary…",
+        "done": "Summary drafted",
+        "failed": "AI summary unavailable"
       }
     },
     "statusLabels": {

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -360,28 +360,53 @@
     "failureMessage": "Échec : {message}",
     "categories": {
       "terrain_security": {
-        "label": "Terrain & Sécurité",
-        "description": "Surface, trafic, pentes, continuité"
+        "label": "Analyse du terrain",
+        "description": "Surface, trafic, pentes, continuité",
+        "running": "Interrogation d'OpenStreetMap…",
+        "done": "Terrain analysé",
+        "failed": "Analyse du terrain indisponible"
       },
       "supply": {
-        "label": "Ravitaillement",
-        "description": "Points d'eau, commerces"
+        "label": "Points d'intérêt",
+        "description": "Points d'eau, commerces, sites culturels",
+        "running": "Recherche des points d'intérêt…",
+        "done": "Points d'intérêt collectés",
+        "failed": "Recherche des POI indisponible"
       },
       "accommodations": {
         "label": "Hébergements",
-        "description": "Campings, gîtes, hôtels"
+        "description": "Campings, gîtes, hôtels",
+        "running": "Identification des hébergements…",
+        "done": "Hébergements identifiés",
+        "failed": "Recherche d'hébergements indisponible"
       },
       "weather": {
-        "label": "Météo & Conditions",
-        "description": "Prévisions, vent, coucher de soleil"
+        "label": "Météo",
+        "description": "Prévisions, vent, conditions",
+        "running": "Récupération des prévisions météo…",
+        "done": "Prévisions récupérées",
+        "failed": "Météo indisponible"
       },
       "services": {
-        "label": "Services",
-        "description": "Magasins vélo, réparateurs"
+        "label": "Sécurité & services",
+        "description": "Magasins vélo, secours, gares, frontières",
+        "running": "Recensement des services le long du tracé…",
+        "done": "Services recensés",
+        "failed": "Services indisponibles"
+      },
+      "context": {
+        "label": "Événements locaux",
+        "description": "Calendrier, fêtes, jours fériés",
+        "running": "Recherche d'événements locaux…",
+        "done": "Événements locaux récupérés",
+        "failed": "Événements locaux indisponibles"
       },
       "ai": {
-        "label": "Analyse IA",
-        "description": "Synthèse narrative du voyage"
+        "label": "Synthèse IA",
+        "description": "Synthèse narrative du voyage",
+        "running": "Rédaction de la synthèse…",
+        "done": "Synthèse rédigée",
+        "failed": "Synthèse IA indisponible"
       }
     },
     "statusLabels": {

--- a/pwa/src/app/error.tsx
+++ b/pwa/src/app/error.tsx
@@ -59,11 +59,7 @@ export default function ErrorBoundary({ error, reset }: ErrorBoundaryProps) {
         </div>
 
         <div className="flex flex-col sm:flex-row gap-3 justify-center">
-          <Button
-            onClick={reset}
-            size="lg"
-            data-testid="error-retry-button"
-          >
+          <Button onClick={reset} size="lg" data-testid="error-retry-button">
             {t("retry")}
           </Button>
           <Button asChild variant="outline" size="lg">

--- a/pwa/src/app/global-error.tsx
+++ b/pwa/src/app/global-error.tsx
@@ -21,7 +21,8 @@ export default function GlobalError({ error, reset }: GlobalErrorProps) {
 
   // lang hardcoded: GlobalError replaces the root layout so next-intl context is unavailable
   const title = "Un caillou dans le dérailleur";
-  const subtitle = "Une erreur critique est survenue. Vous pouvez recharger la page.";
+  const subtitle =
+    "Une erreur critique est survenue. Vous pouvez recharger la page.";
   const requestIdLabel = "Identifiant pour le support :";
   const reloadLabel = "Recharger la page";
 
@@ -105,7 +106,9 @@ export default function GlobalError({ error, reset }: GlobalErrorProps) {
             </svg>
           </div>
 
-          <div style={{ display: "flex", flexDirection: "column", gap: "0.75rem" }}>
+          <div
+            style={{ display: "flex", flexDirection: "column", gap: "0.75rem" }}
+          >
             <h1
               data-testid="global-error-title"
               style={{

--- a/pwa/src/app/not-found.tsx
+++ b/pwa/src/app/not-found.tsx
@@ -27,7 +27,10 @@ export default async function NotFound() {
       backHome: t("backHome"),
     };
   } catch (e) {
-    console.error("[not-found] getTranslations failed, falling back to default copy:", e);
+    console.error(
+      "[not-found] getTranslations failed, falling back to default copy:",
+      e,
+    );
     copy = FALLBACK_COPY;
   }
 

--- a/pwa/src/app/trips/new/page.tsx
+++ b/pwa/src/app/trips/new/page.tsx
@@ -1,21 +1,172 @@
-import { Suspense } from "react";
+"use client";
+
+import { Suspense, useCallback, useEffect, useMemo } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useTranslations } from "next-intl";
 import { HydrationBoundary } from "@/components/hydration-boundary";
 import { TripPlanner } from "@/components/trip-planner";
 import { TripPlannerErrorBoundary } from "@/components/trip-planner-error-boundary";
+import {
+  WizardStepper,
+  WIZARD_STEPS,
+  wizardStepFromNumber,
+  wizardStepToNumber,
+  type WizardStepId,
+} from "@/components/wizard-stepper";
+import { useUiStore } from "@/store/ui-store";
+import type { StepId } from "@/store/ui-store";
+import { useTripStore } from "@/store/trip-store";
 
 /**
- * New trip creation page.
- * Renders the full trip planner so authenticated users can import a route
- * or upload a GPX file to start planning a new trip.
+ * `/trips/new` — 4-step wizard for trip creation (issue #391).
+ *
+ * Each act of the planner now sits behind an explicit URL-addressable step:
+ *
+ *   ?step=1 → preparation (Card Selection: Lien / GPX / Assistant IA)
+ *   ?step=2 → preview     (Map + stats + stages + sliders + "Lancer l'analyse")
+ *   ?step=3 → analysis    (Narrative SSE display)
+ *   ?step=4 → my_trip     (Redirect to `/trips/[id]`)
+ *
+ * The {@link WizardStepper} mirrors the URL: clicking a completed step rewrites
+ * `?step=` and rewinds the wizard. The query param is the source of truth so
+ * the workflow is shareable, refresh-safe, and bookmarkable.
+ *
+ * Implementation note: we reuse the battle-tested {@link TripPlanner} for the
+ * underlying state machine (URL submit, GPX upload, preview, analysis,
+ * my_trip), but suppress its internal `<Stepper />` — the new
+ * `<WizardStepper />` rendered at the top of this page replaces it for the
+ * `/trips/new` route only.
+ */
+function WizardContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const t = useTranslations("stepper");
+  const currentStep = useUiStore((s) => s.currentStep);
+  const completedSteps = useUiStore((s) => s.completedSteps);
+  const goToStep = useUiStore((s) => s.goToStep);
+  const tripId = useTripStore((s) => s.trip?.id ?? null);
+
+  const requestedStep = useMemo<WizardStepId | null>(() => {
+    const raw = searchParams.get("step");
+    if (raw === null) return null;
+    const parsed = Number.parseInt(raw, 10);
+    return Number.isFinite(parsed) ? wizardStepFromNumber(parsed) : null;
+  }, [searchParams]);
+
+  const clearTrip = useTripStore((s) => s.clearTrip);
+
+  // Resolve a backwards navigation request (from the stepper or the URL):
+  // when going back to "preparation" we must also clear the trip data, or
+  // the lifecycle effect in {@link TripPlanner} would immediately re-advance
+  // the stepper to "preview". Other backwards transitions are pure store
+  // mutations.
+  const navigateToStep = useCallback(
+    (step: WizardStepId) => {
+      if (step === "preparation") {
+        clearTrip();
+        const ui = useUiStore.getState();
+        ui.setProcessing(false);
+        ui.setAccommodationScanning(false);
+        ui.setAnalysisStarted(false);
+        ui.setAnalysisPhaseActive(false);
+        ui.resetStepper();
+        return;
+      }
+      goToStep(step as StepId);
+    },
+    [clearTrip, goToStep],
+  );
+
+  // URL → store: when the URL contains a `?step=` value, drive the store. Only
+  // apply it for backwards navigation (forward navigation is dictated by the
+  // app logic — e.g. analysis is reached only after the user clicks
+  // "Lancer l'analyse"). We rely on the store's own guards (see `goToStep`).
+  useEffect(() => {
+    if (requestedStep === null) return;
+    if (requestedStep === currentStep) return;
+    // The "analysis" step is system-driven and never reachable via URL.
+    if (requestedStep === "analysis") return;
+    // Forward navigation via URL is also blocked: the user must reach forward
+    // steps via in-app actions (submitting a URL, clicking "Lancer l'analyse").
+    const requestedIdx = WIZARD_STEPS.indexOf(requestedStep);
+    const currentIdx = WIZARD_STEPS.indexOf(currentStep);
+    if (requestedIdx > currentIdx) return;
+    navigateToStep(requestedStep);
+  }, [requestedStep, currentStep, navigateToStep]);
+
+  // Store → URL: keep `?step=` in sync whenever the store advances. Use
+  // `replace` so the back button doesn't pile up history entries for each
+  // intermediate state.
+  useEffect(() => {
+    const current = searchParams.get("step");
+    const desired = String(wizardStepToNumber(currentStep));
+    if (current === desired) return;
+    const next = new URLSearchParams(searchParams.toString());
+    next.set("step", desired);
+    router.replace(`/trips/new?${next.toString()}`, { scroll: false });
+  }, [currentStep, router, searchParams]);
+
+  // Step 4 "Mon voyage" → redirect to /trips/[id] once the trip identity is
+  // known. We intentionally wait for `tripId` to be set; in the unlikely
+  // event the wizard reaches `my_trip` without an identity (defensive), we
+  // simply stay on the wizard and let the user manage from there.
+  useEffect(() => {
+    if (currentStep !== "my_trip") return;
+    if (!tripId) return;
+    router.replace(`/trips/${encodeURIComponent(tripId)}`);
+  }, [currentStep, tripId, router]);
+
+  const handleStepperNavigate = useCallback(
+    (step: WizardStepId) => navigateToStep(step),
+    [navigateToStep],
+  );
+
+  // Render the WizardStepper outside TripPlanner's main layout because
+  // TripPlanner manages its own padded section. We mount everything inside
+  // a single page wrapper so `/trips/new` looks coherent.
+  return (
+    <div data-testid="wizard-trip-new" data-current-step={currentStep}>
+      <a
+        href="#wizard-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:bg-background focus:p-2 focus:rounded"
+      >
+        {t("ariaLabel")}
+      </a>
+
+      {/* Step indicator — desktop horizontal stepper, mobile compact label.
+          {@link WizardStepId} and {@link StepId} share the same string union,
+          so the cast is structurally safe — it only narrows the nominal type. */}
+      <div className="max-w-[1200px] mx-auto px-4 md:px-6 pt-6 pb-2">
+        <WizardStepper
+          currentStep={currentStep as WizardStepId}
+          completedSteps={completedSteps as Set<WizardStepId>}
+          onNavigate={handleStepperNavigate}
+        />
+      </div>
+
+      <div id="wizard-content">
+        <TripPlanner hideStepper />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * `/trips/new` page — wraps the wizard in the standard error/hydration
+ * boundaries used elsewhere in the app. The {@link Suspense} is required by
+ * `useSearchParams` for static export compatibility (see Next.js docs).
  */
 export default function NewTripPage() {
   return (
     <HydrationBoundary>
       <TripPlannerErrorBoundary>
         <Suspense fallback={null}>
-          <TripPlanner />
+          <WizardContent />
         </Suspense>
       </TripPlannerErrorBoundary>
     </HydrationBoundary>
   );
 }
+
+// Re-export the wizard step constants for tests / external consumers.
+export { WIZARD_STEPS };

--- a/pwa/src/app/trips/new/page.tsx
+++ b/pwa/src/app/trips/new/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useCallback, useEffect, useMemo } from "react";
+import { Suspense, useCallback, useEffect, useMemo, useRef } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { HydrationBoundary } from "@/components/hydration-boundary";
@@ -55,6 +55,15 @@ function WizardContent() {
 
   const clearTrip = useTripStore((s) => s.clearTrip);
 
+  // Mirror `currentStep` into a ref so the URL→store effect can read the
+  // latest value without re-running every time the store advances. This
+  // prevents a race where `setProcessing(true)` synchronously moves the
+  // store to "analysis" while the URL is still `?step=1` (router.replace is
+  // async): the effect would otherwise observe the stale URL and call
+  // `navigateToStep("preparation")`, wiping the trip and looping.
+  const currentStepRef = useRef<WizardStepId>(currentStep as WizardStepId);
+  currentStepRef.current = currentStep as WizardStepId;
+
   // Resolve a backwards navigation request (from the stepper or the URL):
   // when going back to "preparation" we must also clear the trip data, or
   // the lifecycle effect in {@link TripPlanner} would immediately re-advance
@@ -81,16 +90,19 @@ function WizardContent() {
   // "Lancer l'analyse"). We rely on the store's own guards (see `goToStep`).
   useEffect(() => {
     if (requestedStep === null) return;
-    if (requestedStep === currentStep) return;
+    // Read the latest store step from a ref so this effect only re-runs when
+    // the URL changes — not when the store advances asynchronously.
+    const current = currentStepRef.current;
+    if (requestedStep === current) return;
     // The "analysis" step is system-driven and never reachable via URL.
     if (requestedStep === "analysis") return;
     // Forward navigation via URL is also blocked: the user must reach forward
     // steps via in-app actions (submitting a URL, clicking "Lancer l'analyse").
     const requestedIdx = WIZARD_STEPS.indexOf(requestedStep);
-    const currentIdx = WIZARD_STEPS.indexOf(currentStep);
+    const currentIdx = WIZARD_STEPS.indexOf(current);
     if (requestedIdx > currentIdx) return;
     navigateToStep(requestedStep);
-  }, [requestedStep, currentStep, navigateToStep]);
+  }, [requestedStep, navigateToStep]);
 
   // Store → URL: keep `?step=` in sync whenever the store advances. Use
   // `replace` so the back button doesn't pile up history entries for each

--- a/pwa/src/app/trips/new/page.tsx
+++ b/pwa/src/app/trips/new/page.tsx
@@ -67,8 +67,6 @@ function WizardContent() {
         const ui = useUiStore.getState();
         ui.setProcessing(false);
         ui.setAccommodationScanning(false);
-        ui.setAnalysisStarted(false);
-        ui.setAnalysisPhaseActive(false);
         ui.resetStepper();
         return;
       }
@@ -167,6 +165,3 @@ export default function NewTripPage() {
     </HydrationBoundary>
   );
 }
-
-// Re-export the wizard step constants for tests / external consumers.
-export { WIZARD_STEPS };

--- a/pwa/src/components/alert-list.tsx
+++ b/pwa/src/components/alert-list.tsx
@@ -76,9 +76,7 @@ export function AlertList({ alerts, onAddPoiWaypoint }: AlertListProps) {
                   )}
                   aria-hidden
                   data-testid={`alert-category-icon-${category}`}
-                  data-enriched={
-                    isEnrichedCulturalPoi ? "true" : undefined
-                  }
+                  data-enriched={isEnrichedCulturalPoi ? "true" : undefined}
                 >
                   {isEnrichedCulturalPoi ? (
                     <CulturalPoiEnrichedIcon size={20} />

--- a/pwa/src/components/processing-progress.tsx
+++ b/pwa/src/components/processing-progress.tsx
@@ -2,50 +2,81 @@
 
 import { useMemo } from "react";
 import { useTranslations } from "next-intl";
-import { Check, Loader2, AlertTriangle } from "lucide-react";
+import {
+  Check,
+  Loader2,
+  AlertTriangle,
+  Mountain,
+  MapPin,
+  Tent,
+  CloudSun,
+  CalendarDays,
+  Shield,
+  Sparkles,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useUiStore } from "@/store/ui-store";
 import { TripHeader } from "@/components/trip-header";
 
-type CategoryKey =
+/**
+ * Narrative acts displayed during step 3 "Analyse" of the wizard. Each act
+ * groups one or more backend `ComputationName` values: when every backing
+ * step has been seen in a `computation_step_completed` event the act flips
+ * to "done"; otherwise the currently-running step (if it belongs to the act)
+ * marks it as "in progress".
+ *
+ * The keys double as translation slugs under
+ * `processingProgress.categories.<key>` (legacy keys are preserved to keep
+ * the existing translations / tests working) and as `data-testid` suffixes.
+ */
+type ActKey =
   | "terrain_security"
   | "supply"
   | "accommodations"
   | "weather"
   | "services"
+  | "context"
   | "ai";
 
-interface CategoryDefinition {
-  /** Translation key under `processingProgress.categories`. */
-  translationKey: CategoryKey;
-  icon: string;
+interface ActDefinition {
+  /** Translation slug under `processingProgress.categories.<key>`. */
+  translationKey: ActKey;
+  /** Lucide icon — keeps the visual identity consistent with the rest of the app. */
+  icon: LucideIcon;
   /**
-   * Backend `ComputationName::value` identifiers that drive this narrative
-   * category. A category is "done" once every listed step has been seen
-   * in a `computation_step_completed` event. See issue #323 for the
-   * handler → category mapping and `ComputationName` on the backend.
+   * Backend `ComputationName::value` identifiers that drive this act. An act
+   * is "done" once every listed step has been seen in a
+   * `computation_step_completed` event.
    */
   steps: string[];
   /**
-   * When true, the category is hidden from the UI until at least one of
-   * its steps has been reported. Used for the optional AI category: when
-   * Ollama is disabled no `ai_*` events arrive, and the row stays hidden.
+   * Optional acts are hidden until at least one of their steps has been
+   * reported (e.g. AI when Ollama is disabled).
    */
   optional?: boolean;
 }
 
 /**
- * Narrative categories displayed to the user during Acte 2. Each row is
- * backed by one or more backend computation steps. Order matches the
- * visual order on screen (per issue #323).
+ * Seven narrative acts mapped onto the backend `ComputationName` enum:
+ *   1. Analyse du terrain & sécurité — `osm_scan`, `terrain`
+ *   2. Points d'intérêt & ravitaillement — `pois`, `water_points`, `cultural_pois`
+ *   3. Hébergements — `accommodations`
+ *   4. Météo & conditions — `weather`, `wind`
+ *   5. Services & secours — `bike_shops`, `health_services`,
+ *      `railway_stations`, `border_crossing`
+ *   6. Contexte local — `calendar`, `events`
+ *   7. Synthèse IA (optional) — `ai_stage`, `ai_overview`
+ *
+ * Order matches the visual order on screen and the importance ranking from
+ * #391: terrain & security comes first, AI comes last.
  */
-const CATEGORIES: { key: CategoryKey; def: CategoryDefinition }[] = [
+const ACTS: { key: ActKey; def: ActDefinition }[] = [
   {
     key: "terrain_security",
     def: {
       translationKey: "terrain_security",
-      icon: "🛣️",
-      // ScanAllOsmData (osm_scan) + AnalyzeTerrain (terrain)
+      icon: Mountain,
       steps: ["osm_scan", "terrain"],
     },
   },
@@ -53,17 +84,15 @@ const CATEGORIES: { key: CategoryKey; def: CategoryDefinition }[] = [
     key: "supply",
     def: {
       translationKey: "supply",
-      icon: "💧",
-      // CheckWaterPoints (water_points) + ScanPois (pois)
-      steps: ["water_points", "pois"],
+      icon: MapPin,
+      steps: ["pois", "water_points", "cultural_pois"],
     },
   },
   {
     key: "accommodations",
     def: {
       translationKey: "accommodations",
-      icon: "🏕️",
-      // ScanAccommodations
+      icon: Tent,
       steps: ["accommodations"],
     },
   },
@@ -71,26 +100,36 @@ const CATEGORIES: { key: CategoryKey; def: CategoryDefinition }[] = [
     key: "weather",
     def: {
       translationKey: "weather",
-      icon: "🌤️",
-      // FetchWeather + AnalyzeWind + CheckCalendar
-      steps: ["weather", "wind", "calendar"],
+      icon: CloudSun,
+      steps: ["weather", "wind"],
     },
   },
   {
     key: "services",
     def: {
       translationKey: "services",
-      icon: "🔧",
-      // CheckBikeShops
-      steps: ["bike_shops"],
+      icon: Shield,
+      steps: [
+        "bike_shops",
+        "health_services",
+        "railway_stations",
+        "border_crossing",
+      ],
+    },
+  },
+  {
+    key: "context",
+    def: {
+      translationKey: "context",
+      icon: CalendarDays,
+      steps: ["calendar", "events"],
     },
   },
   {
     key: "ai",
     def: {
       translationKey: "ai",
-      icon: "🤖",
-      // AnalyzeStageWithLlm + AnalyzeTripOverviewWithLlm (Ollama-only)
+      icon: Sparkles,
       steps: ["ai_stage", "ai_overview"],
       optional: true,
     },
@@ -105,24 +144,27 @@ interface ProcessingProgressProps {
 }
 
 /**
- * Acte 2 — narrative progress screen.
+ * Step 3 "Analyse" — narrative SSE display.
  *
- * Shown during Phase 2 (initial enrichment). Displays a checklist of
- * user-facing categories (terrain, supply, accommodations, weather,
- * services, optional AI) each backed by one or more Messenger handlers
- * on the backend. Rows transition through
+ * Renders 5-8 acts (see {@link ACTS}), each backed by one or more backend
+ * `ComputationName` values (issue #391). Acts transition through
  *   pending ○ → in progress (spinner) → done ✓ | failed ⚠
  * as `computation_step_completed` (and `computation_error`) Mercure events
  * arrive. A global percentage bar sits at the bottom.
  *
+ * Each act exposes a **dynamic sub-description** computed from the latest
+ * SSE payload (e.g. "Interrogation d'OpenStreetMap…" while
+ * `osm_scan` runs, then "Terrain analysé" once both `osm_scan` and `terrain`
+ * are done).
+ *
  * Rules:
- * - The only interactive affordance is the trip title. Every other action
- *   is intentionally omitted to keep the user focused while the backend
- *   is crunching through the pipeline (issue #323).
- * - The optional AI row is only rendered once at least one `ai_*` step
- *   has been seen — so when Ollama is disabled, the row stays hidden.
+ * - The only interactive affordance is the trip title. Every other action is
+ *   intentionally omitted to keep the user focused while the backend is
+ *   crunching through the pipeline.
+ * - The optional AI act stays hidden until at least one `ai_*` step has been
+ *   seen — so when Ollama is disabled, the row never appears.
  * - `trip_ready` flips `isProcessing` to `false`, which is the trigger
- *   for the parent component to fade this screen out toward Acte 3.
+ *   for the parent component to advance to step 4.
  */
 export function ProcessingProgress({
   title,
@@ -133,15 +175,16 @@ export function ProcessingProgress({
   const stepStates = useUiStore((s) => s.analysisStepStates);
   const currentStep = analysisProgress?.step ?? null;
 
-  const rows = useMemo(
+  const acts = useMemo(
     () =>
-      CATEGORIES.map(({ key, def }) => {
+      ACTS.map(({ key, def }) => {
         const statuses = def.steps.map(
           (step) => stepStates[step]?.status ?? "pending",
         );
         const errors = def.steps
           .map((step) => stepStates[step]?.error)
           .filter((e): e is string => !!e);
+        const doneCount = statuses.filter((s) => s === "done").length;
 
         let status: AggregatedStatus;
         if (statuses.includes("failed")) {
@@ -152,8 +195,6 @@ export function ProcessingProgress({
           statuses.some((s) => s === "done") ||
           (currentStep !== null && def.steps.includes(currentStep))
         ) {
-          // Either we already collected some results for this category or
-          // the in-flight step belongs to it — highlight it as in progress.
           status = "in_progress";
         } else {
           status = "pending";
@@ -164,7 +205,15 @@ export function ProcessingProgress({
           statuses.every((s) => s === "pending") &&
           !(currentStep !== null && def.steps.includes(currentStep));
 
-        return { key, def, status, error: errors[0] ?? null, hidden };
+        return {
+          key,
+          def,
+          status,
+          error: errors[0] ?? null,
+          doneCount,
+          totalCount: def.steps.length,
+          hidden,
+        };
       }),
     [stepStates, currentStep],
   );
@@ -189,61 +238,89 @@ export function ProcessingProgress({
       aria-live="polite"
       aria-busy="true"
     >
-      <div className="w-full max-w-2xl space-y-6">
+      <div className="w-full max-w-3xl space-y-6">
         {/* Editable title — the only affordance the user retains during
-            the system step (see issue #323). */}
+            step 3 (per #391). */}
         <div className="text-center">
           <TripHeader title={title} onTitleChange={onTitleChange} />
           <p className="mt-2 text-sm text-muted-foreground">{t("subtitle")}</p>
         </div>
 
-        {/* Category checklist (boxed, per the design spec) */}
+        {/* Narrative acts (boxed, per the design spec) */}
         <div
           className="rounded-xl border bg-card p-4 md:p-6 shadow-sm"
           data-testid="processing-progress-box"
         >
           <ul className="space-y-3">
-            {rows.map(({ key, def, status, error, hidden }) => {
-              if (hidden) return null;
-              return (
-                <li
-                  key={key}
-                  data-testid={`processing-category-${key}`}
-                  data-status={status}
-                  className={cn(
-                    "flex items-start gap-3 rounded-lg px-3 py-2 transition-colors",
-                    status === "in_progress" && "bg-brand/5",
-                    status === "failed" && "bg-destructive/5",
-                  )}
-                >
-                  <span
-                    aria-hidden="true"
-                    className="text-2xl leading-none shrink-0"
-                  >
-                    {def.icon}
-                  </span>
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center justify-between gap-2">
-                      <span className="font-semibold text-sm md:text-base">
-                        {t(`categories.${def.translationKey}.label`)}
-                      </span>
-                      <StatusIndicator status={status} />
-                    </div>
-                    <p className="text-xs md:text-sm text-muted-foreground">
-                      {t(`categories.${def.translationKey}.description`)}
-                    </p>
-                    {status === "failed" && error && (
-                      <p
-                        className="mt-1 text-xs text-destructive"
-                        data-testid={`processing-category-${key}-error`}
-                      >
-                        {t("failureMessage", { message: error })}
-                      </p>
+            {acts.map(
+              ({
+                key,
+                def,
+                status,
+                error,
+                doneCount,
+                totalCount,
+                hidden,
+              }) => {
+                if (hidden) return null;
+                const Icon = def.icon;
+                return (
+                  <li
+                    key={key}
+                    data-testid={`processing-category-${key}`}
+                    data-status={status}
+                    className={cn(
+                      "flex items-start gap-3 rounded-lg px-3 py-3 transition-colors",
+                      status === "in_progress" && "bg-brand/5",
+                      status === "failed" && "bg-destructive/5",
                     )}
-                  </div>
-                </li>
-              );
-            })}
+                  >
+                    <span
+                      aria-hidden="true"
+                      className={cn(
+                        "flex items-center justify-center w-10 h-10 rounded-full shrink-0",
+                        status === "done"
+                          ? "bg-brand/10 text-brand"
+                          : status === "in_progress"
+                            ? "bg-brand/15 text-brand"
+                            : status === "failed"
+                              ? "bg-destructive/10 text-destructive"
+                              : "bg-muted text-muted-foreground/60",
+                      )}
+                    >
+                      <Icon className="h-5 w-5" aria-hidden="true" />
+                    </span>
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center justify-between gap-2">
+                        <span className="font-semibold text-sm md:text-base">
+                          {t(`categories.${def.translationKey}.label`)}
+                        </span>
+                        <StatusIndicator status={status} />
+                      </div>
+                      <p
+                        className="text-xs md:text-sm text-muted-foreground"
+                        data-testid={`processing-category-${key}-description`}
+                      >
+                        <ActDescription
+                          actKey={def.translationKey}
+                          status={status}
+                          doneCount={doneCount}
+                          totalCount={totalCount}
+                        />
+                      </p>
+                      {status === "failed" && error && (
+                        <p
+                          className="mt-1 text-xs text-destructive"
+                          data-testid={`processing-category-${key}-error`}
+                        >
+                          {t("failureMessage", { message: error })}
+                        </p>
+                      )}
+                    </div>
+                  </li>
+                );
+              },
+            )}
           </ul>
 
           {/* Global progress bar */}
@@ -272,6 +349,46 @@ export function ProcessingProgress({
         </div>
       </div>
     </section>
+  );
+}
+
+interface ActDescriptionProps {
+  actKey: ActKey;
+  status: AggregatedStatus;
+  doneCount: number;
+  totalCount: number;
+}
+
+/**
+ * Resolve the user-facing sub-description for an act, depending on its
+ * lifecycle state. Each state maps to a distinct translation key under
+ * `processingProgress.categories.<key>` so the UI text can be tuned per
+ * locale without touching this component:
+ *
+ *   - `pending`     → `description` (default static)
+ *   - `in_progress` → `running`     (e.g. "Interrogation d'OpenStreetMap…")
+ *   - `done`        → `done`        (e.g. "Terrain analysé")
+ *   - `failed`      → `failed`      (short "ne pas pu" message)
+ *
+ * `done`/`total` counts are passed as ICU variables so translations can use
+ * them when relevant (e.g. "{done} / {total} services analysés").
+ */
+function ActDescription({
+  actKey,
+  status,
+  doneCount,
+  totalCount,
+}: ActDescriptionProps) {
+  const t = useTranslations("processingProgress.categories");
+  const variants: Record<AggregatedStatus, string> = {
+    pending: "description",
+    in_progress: "running",
+    done: "done",
+    failed: "failed",
+  };
+  const variant = variants[status];
+  return (
+    <>{t(`${actKey}.${variant}`, { done: doneCount, total: totalCount })}</>
   );
 }
 

--- a/pwa/src/components/processing-progress.tsx
+++ b/pwa/src/components/processing-progress.tsx
@@ -253,15 +253,7 @@ export function ProcessingProgress({
         >
           <ul className="space-y-3">
             {acts.map(
-              ({
-                key,
-                def,
-                status,
-                error,
-                doneCount,
-                totalCount,
-                hidden,
-              }) => {
+              ({ key, def, status, error, doneCount, totalCount, hidden }) => {
                 if (hidden) return null;
                 const Icon = def.icon;
                 return (

--- a/pwa/src/components/trip-planner.tsx
+++ b/pwa/src/components/trip-planner.tsx
@@ -42,7 +42,10 @@ import {
   mealsForStage,
 } from "@/lib/budget-constants";
 
-export function TripPlanner({ onClose }: { onClose?: () => void } = {}) {
+export function TripPlanner({
+  onClose,
+  hideStepper = false,
+}: { onClose?: () => void; hideStepper?: boolean } = {}) {
   const t = useTranslations();
   const router = useRouter();
   const clearTrip = useTripStore((s) => s.clearTrip);
@@ -438,10 +441,14 @@ export function TripPlanner({ onClose }: { onClose?: () => void } = {}) {
 
         {/* Stepper — visible in all planning states (welcome, loading, trip loaded).
             Hidden on landing page, FAQ and trips list since those pages don't
-            render TripPlanner at all. */}
-        <div className="mb-8 pb-6" data-testid="stepper-wrapper">
-          <Stepper />
-        </div>
+            render TripPlanner at all. The wizard at `/trips/new` renders its
+            own {@link WizardStepper} synced with the URL and passes
+            `hideStepper` to suppress this internal one. */}
+        {!hideStepper && (
+          <div className="mb-8 pb-6" data-testid="stepper-wrapper">
+            <Stepper />
+          </div>
+        )}
 
         {/* === State 1: Welcome (no trip, not processing) === */}
         {isWelcome && (

--- a/pwa/src/components/wizard-stepper.tsx
+++ b/pwa/src/components/wizard-stepper.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { useCallback } from "react";
+import { Check } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { cn } from "@/lib/utils";
+
+/**
+ * Wizard step identifiers — the four acts of the `/trips/new` flow.
+ *
+ * - `preparation` (1) — user picks an input method (link, GPX, AI assistant)
+ * - `preview`     (2) — coarse route preview, pacing sliders, "Lancer l'analyse"
+ * - `analysis`    (3) — narrative SSE display (system step, never clickable)
+ * - `my_trip`     (4) — redirect to `/trips/[id]` (visual end-state only)
+ */
+export type WizardStepId = "preparation" | "preview" | "analysis" | "my_trip";
+
+export const WIZARD_STEPS: WizardStepId[] = [
+  "preparation",
+  "preview",
+  "analysis",
+  "my_trip",
+];
+
+/**
+ * Map a 1-based wizard step number from the URL (`?step=1..4`) to its
+ * canonical {@link WizardStepId}. Returns `preparation` for any out-of-range
+ * input so the user always lands on a valid screen.
+ */
+export function wizardStepFromNumber(step: number | null): WizardStepId {
+  if (step === null || step < 1 || step > WIZARD_STEPS.length) {
+    return "preparation";
+  }
+  return WIZARD_STEPS[step - 1] ?? "preparation";
+}
+
+/** Inverse of {@link wizardStepFromNumber}. */
+export function wizardStepToNumber(step: WizardStepId): number {
+  return WIZARD_STEPS.indexOf(step) + 1;
+}
+
+interface WizardStepperProps {
+  /** Currently active step. */
+  currentStep: WizardStepId;
+  /** Set of steps the user has completed (drives back-navigation affordances). */
+  completedSteps: Set<WizardStepId>;
+  /**
+   * Optional callback fired when the user clicks a previously completed step.
+   * `analysis` is never reported (system step). When omitted, the stepper
+   * renders as a read-only progress indicator.
+   */
+  onNavigate?: (step: WizardStepId) => void;
+}
+
+/**
+ * Desktop-first 4-step horizontal wizard indicator for `/trips/new`.
+ *
+ * ```
+ *   ●━━━━━━━━━━●━━━━━━━━━━○━━━━━━━━━━○
+ *   1            2            3            4
+ *   Préparation  Aperçu       Analyse      Mon voyage
+ * ```
+ *
+ * Behaviour:
+ * - Completed steps render as a checkmark and are clickable (when `onNavigate`
+ *   is provided) — the parent decides whether to consume the click and rewind
+ *   the wizard. The current step is highlighted; future steps are dimmed.
+ * - "Analyse" (step 3) is **never** clickable. It is a system step driven by
+ *   the SSE pipeline, not a user-controlled screen.
+ * - On `my_trip` the entire stepper becomes read-only — the user has reached
+ *   the trip dashboard.
+ * - On mobile the stepper collapses to a compact "Étape N/4 — Nom" label
+ *   (per the issue spec).
+ */
+export function WizardStepper({
+  currentStep,
+  completedSteps,
+  onNavigate,
+}: WizardStepperProps) {
+  const t = useTranslations("stepper");
+  const currentIndex = WIZARD_STEPS.indexOf(currentStep);
+  const isMyTrip = currentStep === "my_trip";
+
+  const stepLabels: Record<WizardStepId, string> = {
+    preparation: t("preparation"),
+    preview: t("preview"),
+    analysis: t("analysis"),
+    my_trip: t("myTrip"),
+  };
+
+  const isClickable = useCallback(
+    (step: WizardStepId): boolean => {
+      if (!onNavigate) return false;
+      // Lock once the user has reached the final step.
+      if (isMyTrip) return false;
+      // System step — never user-navigable.
+      if (step === "analysis") return false;
+      // Cannot click the active step.
+      if (step === currentStep) return false;
+      // Only completed (past) steps are reachable backwards.
+      const stepIdx = WIZARD_STEPS.indexOf(step);
+      if (stepIdx < currentIndex) return completedSteps.has(step);
+      return false;
+    },
+    [completedSteps, currentIndex, currentStep, isMyTrip, onNavigate],
+  );
+
+  const handleClick = useCallback(
+    (step: WizardStepId) => {
+      if (!onNavigate) return;
+      onNavigate(step);
+    },
+    [onNavigate],
+  );
+
+  return (
+    <nav
+      role="navigation"
+      aria-label={t("ariaLabel")}
+      data-testid="wizard-stepper"
+      data-current-step={currentStep}
+      className="w-full"
+    >
+      {/* Mobile compact label — "Étape 2/4 — Aperçu" */}
+      <div
+        className="sm:hidden text-sm text-muted-foreground text-center py-2"
+        data-testid="wizard-stepper-mobile-label"
+        aria-hidden="true"
+      >
+        {t("mobileLabel", {
+          current: currentIndex + 1,
+          total: WIZARD_STEPS.length,
+          stepName: stepLabels[currentStep],
+        })}
+      </div>
+
+      {/* Desktop horizontal stepper */}
+      <ol className="hidden sm:flex items-start w-full">
+        {WIZARD_STEPS.map((step, index) => {
+          const isActive = step === currentStep;
+          const isCompleted = completedSteps.has(step);
+          const isPast = index < currentIndex;
+          const isFuture = index > currentIndex;
+          const clickable = isClickable(step);
+          const number = index + 1;
+
+          return (
+            <li
+              key={step}
+              className={cn(
+                "flex items-start",
+                index < WIZARD_STEPS.length - 1 ? "flex-1" : "",
+              )}
+            >
+              {/* Step indicator (button when clickable, div otherwise) */}
+              <div className="flex flex-col items-center gap-2 relative">
+                {clickable ? (
+                  <button
+                    type="button"
+                    onClick={() => handleClick(step)}
+                    aria-current={isActive ? "step" : undefined}
+                    aria-label={stepLabels[step]}
+                    data-testid={`wizard-stepper-step-${step}`}
+                    data-step-number={number}
+                    className={cn(
+                      "flex items-center justify-center w-9 h-9 rounded-full border-2 transition-colors duration-200 cursor-pointer",
+                      "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand",
+                      "border-brand bg-brand text-white hover:bg-brand/80",
+                    )}
+                  >
+                    {isCompleted ? (
+                      <Check className="w-4 h-4" aria-hidden="true" />
+                    ) : (
+                      <span className="text-sm font-semibold">{number}</span>
+                    )}
+                  </button>
+                ) : (
+                  <div
+                    aria-current={isActive ? "step" : undefined}
+                    aria-label={stepLabels[step]}
+                    data-testid={`wizard-stepper-step-${step}`}
+                    data-step-number={number}
+                    className={cn(
+                      "flex items-center justify-center w-9 h-9 rounded-full border-2 transition-colors duration-200",
+                      isActive
+                        ? "border-brand bg-brand text-white shadow-sm"
+                        : isCompleted || isPast
+                          ? "border-brand bg-brand text-white"
+                          : isFuture
+                            ? "border-muted-foreground/30 bg-background text-muted-foreground/50"
+                            : "border-brand bg-background text-brand",
+                    )}
+                  >
+                    {isCompleted || (isPast && !isActive) ? (
+                      <Check className="w-4 h-4" aria-hidden="true" />
+                    ) : (
+                      <span className="text-sm font-semibold">{number}</span>
+                    )}
+                  </div>
+                )}
+
+                {/* Step label */}
+                <span
+                  className={cn(
+                    "text-xs whitespace-nowrap font-medium",
+                    isActive
+                      ? "text-foreground font-semibold"
+                      : isCompleted || isPast
+                        ? "text-muted-foreground"
+                        : "text-muted-foreground/50",
+                  )}
+                >
+                  {stepLabels[step]}
+                </span>
+              </div>
+
+              {/* Connector line between steps */}
+              {index < WIZARD_STEPS.length - 1 && (
+                <div
+                  className={cn(
+                    "flex-1 h-0.5 mt-[18px] mx-2 transition-colors duration-200",
+                    index < currentIndex
+                      ? "bg-brand"
+                      : "bg-muted-foreground/20",
+                  )}
+                  aria-hidden="true"
+                />
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}

--- a/pwa/src/store/trip-store.ts
+++ b/pwa/src/store/trip-store.ts
@@ -384,9 +384,9 @@ export const useTripStore = create<TripState>()(
             ...a,
             _group: source,
           }));
-          const kept = (
-            state.stages[stageIndex].alerts as StageAlert[]
-          ).filter((a) => a._group !== source);
+          const kept = (state.stages[stageIndex].alerts as StageAlert[]).filter(
+            (a) => a._group !== source,
+          );
           state.stages[stageIndex].alerts = [...kept, ...taggedAlerts];
         }
       }),

--- a/pwa/tests/mocked/processing-progress.spec.ts
+++ b/pwa/tests/mocked/processing-progress.spec.ts
@@ -64,6 +64,9 @@ test.describe("ProcessingProgress — display", () => {
     await expect(
       mockedPage.getByTestId("processing-category-services"),
     ).toBeVisible();
+    await expect(
+      mockedPage.getByTestId("processing-category-context"),
+    ).toBeVisible();
   });
 
   test("AI category is hidden when Ollama is disabled (no ai_* events)", async ({
@@ -138,6 +141,112 @@ test.describe("ProcessingProgress — category progression", () => {
     await expect(
       mockedPage.getByTestId("processing-category-accommodations"),
     ).toHaveAttribute("data-status", "done");
+  });
+
+  test("marks context as done once calendar and events both complete", async ({
+    submitUrl,
+    injectEvent,
+    mockedPage,
+  }) => {
+    await enterAnalysingState(submitUrl, injectEvent, mockedPage);
+    await injectEvent(
+      computationStepCompletedEvent("calendar", "context", 1, 16),
+    );
+    await injectEvent(
+      computationStepCompletedEvent("events", "context", 2, 16),
+    );
+    await expect(
+      mockedPage.getByTestId("processing-category-context"),
+    ).toHaveAttribute("data-status", "done");
+  });
+});
+
+test.describe("ProcessingProgress — ActDescription sub-descriptions", () => {
+  test("shows static description while act is pending", async ({
+    submitUrl,
+    injectEvent,
+    mockedPage,
+  }) => {
+    await enterAnalysingState(submitUrl, injectEvent, mockedPage);
+    // No step events for terrain_security yet — the act stays pending and
+    // displays its default static description from
+    // `processingProgress.categories.terrain_security.description`.
+    await expect(
+      mockedPage.getByTestId("processing-category-terrain_security"),
+    ).toHaveAttribute("data-status", "pending");
+    await expect(
+      mockedPage.getByTestId(
+        "processing-category-terrain_security-description",
+      ),
+    ).toHaveText("Surface, trafic, pentes, continuité");
+  });
+
+  test("shows running text while act is in_progress", async ({
+    submitUrl,
+    injectEvent,
+    mockedPage,
+  }) => {
+    await enterAnalysingState(submitUrl, injectEvent, mockedPage);
+    // Reporting `osm_scan` as the current step (without completing `terrain`)
+    // flips terrain_security to in_progress and surfaces the `running` copy.
+    await injectEvent(
+      computationStepCompletedEvent("osm_scan", "terrain_security", 1, 16),
+    );
+    await expect(
+      mockedPage.getByTestId("processing-category-terrain_security"),
+    ).toHaveAttribute("data-status", "in_progress");
+    await expect(
+      mockedPage.getByTestId(
+        "processing-category-terrain_security-description",
+      ),
+    ).toHaveText("Interrogation d'OpenStreetMap…");
+  });
+
+  test("shows done text once all act steps complete", async ({
+    submitUrl,
+    injectEvent,
+    mockedPage,
+  }) => {
+    await enterAnalysingState(submitUrl, injectEvent, mockedPage);
+    // Both backing steps completed → terrain_security is done.
+    await injectEvent(
+      computationStepCompletedEvent("osm_scan", "terrain_security", 1, 16),
+    );
+    await injectEvent(
+      computationStepCompletedEvent("terrain", "terrain_security", 2, 16),
+    );
+    await expect(
+      mockedPage.getByTestId("processing-category-terrain_security"),
+    ).toHaveAttribute("data-status", "done");
+    await expect(
+      mockedPage.getByTestId(
+        "processing-category-terrain_security-description",
+      ),
+    ).toHaveText("Terrain analysé");
+  });
+
+  test("shows failed text on computation_error", async ({
+    submitUrl,
+    injectEvent,
+    mockedPage,
+  }) => {
+    await enterAnalysingState(submitUrl, injectEvent, mockedPage);
+    await injectEvent({
+      type: "computation_error",
+      data: {
+        computation: "osm_scan",
+        message: "Overpass timed out",
+        retryable: true,
+      },
+    });
+    await expect(
+      mockedPage.getByTestId("processing-category-terrain_security"),
+    ).toHaveAttribute("data-status", "failed");
+    await expect(
+      mockedPage.getByTestId(
+        "processing-category-terrain_security-description",
+      ),
+    ).toHaveText("Analyse du terrain indisponible");
   });
 });
 

--- a/pwa/tests/mocked/wizard-stepper.spec.ts
+++ b/pwa/tests/mocked/wizard-stepper.spec.ts
@@ -225,7 +225,9 @@ test.describe("WizardStepper — URL forward-jump blocked", () => {
 
     // The URL should be rewritten to step=1 (preparation) since the wizard
     // cannot forward-jump to a step the user hasn't reached yet.
-    await expect(page).toHaveURL(/step=1/, { timeout: 5000 });
+    // waitForURL is more reliable than expect(page).toHaveURL() here because
+    // the redirect is driven by a React useEffect (async after hydration).
+    await page.waitForURL(/step=1/, { timeout: 5000 });
 
     // Preparation step should be the active one
     await expect(page.getByTestId("wizard-stepper")).toHaveAttribute(
@@ -242,7 +244,7 @@ test.describe("WizardStepper — URL forward-jump blocked", () => {
     await page.waitForLoadState("networkidle");
 
     // Forward jump to analysis (system step) is also blocked
-    await expect(page).toHaveURL(/step=1/, { timeout: 5000 });
+    await page.waitForURL(/step=1/, { timeout: 5000 });
     await expect(page.getByTestId("wizard-stepper")).toHaveAttribute(
       "data-current-step",
       "preparation",
@@ -257,7 +259,7 @@ test.describe("WizardStepper — URL forward-jump blocked", () => {
     await page.waitForLoadState("networkidle");
 
     // Forward jump to preview is blocked (user hasn't submitted a route yet)
-    await expect(page).toHaveURL(/step=1/, { timeout: 5000 });
+    await page.waitForURL(/step=1/, { timeout: 5000 });
     await expect(page.getByTestId("wizard-stepper")).toHaveAttribute(
       "data-current-step",
       "preparation",

--- a/pwa/tests/mocked/wizard-stepper.spec.ts
+++ b/pwa/tests/mocked/wizard-stepper.spec.ts
@@ -120,9 +120,7 @@ test.describe("WizardStepper — 'analysis' is never a button", () => {
   }) => {
     const analysisEl = wizardPage.getByTestId("wizard-stepper-step-analysis");
     await expect(analysisEl).toBeVisible();
-    const tagName = await analysisEl.evaluate((el) =>
-      el.tagName.toLowerCase(),
-    );
+    const tagName = await analysisEl.evaluate((el) => el.tagName.toLowerCase());
     expect(tagName).toBe("div");
   });
 
@@ -134,9 +132,7 @@ test.describe("WizardStepper — 'analysis' is never a button", () => {
     // analysis is now the active step — it must never become a button
     const analysisEl = wizardPage.getByTestId("wizard-stepper-step-analysis");
     await expect(analysisEl).toHaveAttribute("aria-current", "step");
-    const tagName = await analysisEl.evaluate((el) =>
-      el.tagName.toLowerCase(),
-    );
+    const tagName = await analysisEl.evaluate((el) => el.tagName.toLowerCase());
     expect(tagName).toBe("div");
   });
 });
@@ -300,9 +296,7 @@ test.describe("WizardStepper — back navigation clears the trip", () => {
     await simulateProcessing();
 
     // Navigate back to preparation via the stepper button
-    await wizardPage
-      .getByTestId("wizard-stepper-step-preparation")
-      .click();
+    await wizardPage.getByTestId("wizard-stepper-step-preparation").click();
 
     // The card selection should be visible again (trip was cleared)
     await expect(wizardPage.getByTestId("wizard-stepper")).toHaveAttribute(

--- a/pwa/tests/mocked/wizard-stepper.spec.ts
+++ b/pwa/tests/mocked/wizard-stepper.spec.ts
@@ -1,0 +1,430 @@
+import { test as base, expect, type Page } from "@playwright/test";
+import { mockAllApis } from "../fixtures/api-mocks";
+import { injectSseEvent } from "../fixtures/sse-helpers";
+import { routeParsedEvent, stagesComputedEvent } from "../fixtures/mock-data";
+import type { MercureEvent } from "../../src/lib/mercure/types";
+
+/**
+ * Fixtures for the WizardStepper tests.
+ *
+ * The WizardStepper (`data-testid="wizard-stepper"`) is only rendered on the
+ * `/trips/new` route. The internal `<Stepper />` (test IDs `stepper-step-*`)
+ * is a separate component covered by `stepper-flow.spec.ts`.
+ *
+ * Because `handleMagicLink` calls `router.push('/trips/{id}')` after POST, a
+ * real URL submission navigates away from `/trips/new` before the WizardStepper
+ * can show the analysis state. Tests for advanced states therefore drive the
+ * Zustand store directly via the `__test_set_processing` and
+ * `__test_set_analysis_started` event hooks exposed by TripPlanner for E2E use.
+ */
+interface WizardFixtures {
+  wizardPage: Page;
+  injectWizardEvent: (event: MercureEvent) => Promise<void>;
+  /**
+   * Simulate `isProcessing=true` via the TripPlanner test hook. This triggers
+   * the same stepper transition that a real URL submit would (preparation +
+   * preview → analysis) without navigating away from /trips/new.
+   */
+  simulateProcessing: () => Promise<void>;
+}
+
+const test = base.extend<WizardFixtures>({
+  wizardPage: async ({ page }, use) => {
+    await mockAllApis(page);
+    await page.goto("/trips/new");
+    await page.waitForLoadState("networkidle");
+    // Expand the Link card so the magic-link-input is immediately available.
+    const linkCard = page.getByTestId("card-link");
+    if (await linkCard.isVisible().catch(() => false)) {
+      const expanded = await linkCard.getAttribute("data-expanded");
+      if (expanded !== "true") await linkCard.click();
+    }
+    await use(page);
+  },
+
+  injectWizardEvent: async ({ wizardPage }, use) => {
+    await use((event: MercureEvent) => injectSseEvent(wizardPage, event));
+  },
+
+  simulateProcessing: async ({ wizardPage }, use) => {
+    await use(async () => {
+      await wizardPage.evaluate(() => {
+        window.dispatchEvent(
+          new CustomEvent("__test_set_processing", { detail: true }),
+        );
+      });
+      // Wait for the stepper to reflect the analysis step
+      await expect(wizardPage.getByTestId("wizard-stepper")).toHaveAttribute(
+        "data-current-step",
+        "analysis",
+        { timeout: 5000 },
+      );
+    });
+  },
+});
+
+test.describe("WizardStepper — initial state", () => {
+  test("wizard stepper is visible on /trips/new", async ({ wizardPage }) => {
+    await expect(wizardPage.getByTestId("wizard-stepper")).toBeVisible();
+  });
+
+  test("all 4 steps are rendered initially", async ({ wizardPage }) => {
+    await expect(
+      wizardPage.getByTestId("wizard-stepper-step-preparation"),
+    ).toBeVisible();
+    await expect(
+      wizardPage.getByTestId("wizard-stepper-step-preview"),
+    ).toBeVisible();
+    await expect(
+      wizardPage.getByTestId("wizard-stepper-step-analysis"),
+    ).toBeVisible();
+    await expect(
+      wizardPage.getByTestId("wizard-stepper-step-my_trip"),
+    ).toBeVisible();
+  });
+
+  test("first step 'preparation' is active initially", async ({
+    wizardPage,
+  }) => {
+    const stepEl = wizardPage.getByTestId("wizard-stepper-step-preparation");
+    await expect(stepEl).toHaveAttribute("aria-current", "step");
+  });
+
+  test("initial step is reflected in data-current-step attribute", async ({
+    wizardPage,
+  }) => {
+    await expect(wizardPage.getByTestId("wizard-stepper")).toHaveAttribute(
+      "data-current-step",
+      "preparation",
+    );
+  });
+
+  test("inactive steps do not have aria-current initially", async ({
+    wizardPage,
+  }) => {
+    await expect(
+      wizardPage.getByTestId("wizard-stepper-step-preview"),
+    ).not.toHaveAttribute("aria-current");
+    await expect(
+      wizardPage.getByTestId("wizard-stepper-step-analysis"),
+    ).not.toHaveAttribute("aria-current");
+    await expect(
+      wizardPage.getByTestId("wizard-stepper-step-my_trip"),
+    ).not.toHaveAttribute("aria-current");
+  });
+});
+
+test.describe("WizardStepper — 'analysis' is never a button", () => {
+  test("analysis step is a div (not a button) on initial load", async ({
+    wizardPage,
+  }) => {
+    const analysisEl = wizardPage.getByTestId("wizard-stepper-step-analysis");
+    await expect(analysisEl).toBeVisible();
+    const tagName = await analysisEl.evaluate((el) =>
+      el.tagName.toLowerCase(),
+    );
+    expect(tagName).toBe("div");
+  });
+
+  test("analysis step is a div (not a button) when it is the active step", async ({
+    wizardPage,
+    simulateProcessing,
+  }) => {
+    await simulateProcessing();
+    // analysis is now the active step — it must never become a button
+    const analysisEl = wizardPage.getByTestId("wizard-stepper-step-analysis");
+    await expect(analysisEl).toHaveAttribute("aria-current", "step");
+    const tagName = await analysisEl.evaluate((el) =>
+      el.tagName.toLowerCase(),
+    );
+    expect(tagName).toBe("div");
+  });
+});
+
+test.describe("WizardStepper — completed steps become buttons (before my_trip)", () => {
+  test("preparation step becomes a button once completed while on analysis", async ({
+    wizardPage,
+    simulateProcessing,
+  }) => {
+    await simulateProcessing();
+    // isProcessing=true → preparation is completed, analysis is active, not my_trip
+    // → preparation should be rendered as a <button> (clickable back-navigation)
+    const preparationEl = wizardPage.getByTestId(
+      "wizard-stepper-step-preparation",
+    );
+    await expect(preparationEl).toBeVisible();
+    const tagName = await preparationEl.evaluate((el) =>
+      el.tagName.toLowerCase(),
+    );
+    expect(tagName).toBe("button");
+  });
+
+  test("preview step becomes a button once completed while on analysis", async ({
+    wizardPage,
+    simulateProcessing,
+  }) => {
+    await simulateProcessing();
+    // isProcessing=true also completes "preview" per TripPlanner useEffect
+    const previewEl = wizardPage.getByTestId("wizard-stepper-step-preview");
+    await expect(previewEl).toBeVisible();
+    const tagName = await previewEl.evaluate((el) => el.tagName.toLowerCase());
+    expect(tagName).toBe("button");
+  });
+});
+
+test.describe("WizardStepper — non-clickable steps remain divs", () => {
+  test("future steps are never buttons", async ({ wizardPage }) => {
+    // On initial load (preparation active), preview/analysis/my_trip are future
+    // steps and must never be rendered as buttons.
+    for (const stepId of ["preview", "analysis", "my_trip"] as const) {
+      const el = wizardPage.getByTestId(`wizard-stepper-step-${stepId}`);
+      await expect(el).toBeVisible();
+      const tagName = await el.evaluate((e) => e.tagName.toLowerCase());
+      expect(tagName, `future step '${stepId}' should be a div`).toBe("div");
+    }
+  });
+
+  test("the active step is never a button", async ({ wizardPage }) => {
+    // Active step is never clickable (cannot navigate to the step you are on)
+    const preparationEl = wizardPage.getByTestId(
+      "wizard-stepper-step-preparation",
+    );
+    await expect(preparationEl).toHaveAttribute("aria-current", "step");
+    const tagName = await preparationEl.evaluate((el) =>
+      el.tagName.toLowerCase(),
+    );
+    expect(tagName).toBe("div");
+  });
+
+  test("analysis and my_trip are always divs (never buttons) during analysis", async ({
+    wizardPage,
+    simulateProcessing,
+  }) => {
+    await simulateProcessing();
+    // analysis: active step → always div
+    const analysisEl = wizardPage.getByTestId("wizard-stepper-step-analysis");
+    const analysisTag = await analysisEl.evaluate((el) =>
+      el.tagName.toLowerCase(),
+    );
+    expect(analysisTag).toBe("div");
+
+    // my_trip: future step → always div
+    const myTripEl = wizardPage.getByTestId("wizard-stepper-step-my_trip");
+    const myTripTag = await myTripEl.evaluate((el) => el.tagName.toLowerCase());
+    expect(myTripTag).toBe("div");
+  });
+});
+
+test.describe("WizardStepper — URL forward-jump blocked", () => {
+  test("navigating to ?step=4 when on step 1 stays on step 1", async ({
+    page,
+  }) => {
+    await mockAllApis(page);
+    await page.goto("/trips/new?step=4");
+    await page.waitForLoadState("networkidle");
+
+    // The URL should be rewritten to step=1 (preparation) since the wizard
+    // cannot forward-jump to a step the user hasn't reached yet.
+    await expect(page).toHaveURL(/step=1/, { timeout: 5000 });
+
+    // Preparation step should be the active one
+    await expect(page.getByTestId("wizard-stepper")).toHaveAttribute(
+      "data-current-step",
+      "preparation",
+    );
+  });
+
+  test("navigating to ?step=3 (analysis) when on step 1 stays on step 1", async ({
+    page,
+  }) => {
+    await mockAllApis(page);
+    await page.goto("/trips/new?step=3");
+    await page.waitForLoadState("networkidle");
+
+    // Forward jump to analysis (system step) is also blocked
+    await expect(page).toHaveURL(/step=1/, { timeout: 5000 });
+    await expect(page.getByTestId("wizard-stepper")).toHaveAttribute(
+      "data-current-step",
+      "preparation",
+    );
+  });
+
+  test("navigating to ?step=2 when on step 1 stays on step 1", async ({
+    page,
+  }) => {
+    await mockAllApis(page);
+    await page.goto("/trips/new?step=2");
+    await page.waitForLoadState("networkidle");
+
+    // Forward jump to preview is blocked (user hasn't submitted a route yet)
+    await expect(page).toHaveURL(/step=1/, { timeout: 5000 });
+    await expect(page.getByTestId("wizard-stepper")).toHaveAttribute(
+      "data-current-step",
+      "preparation",
+    );
+  });
+});
+
+test.describe("WizardStepper — back navigation clears the trip", () => {
+  test("clicking preparation button from analysis rewinds to preparation", async ({
+    wizardPage,
+    simulateProcessing,
+  }) => {
+    await simulateProcessing();
+
+    // preparation is now a button (completed, before analysis, not my_trip)
+    const preparationBtn = wizardPage.getByTestId(
+      "wizard-stepper-step-preparation",
+    );
+    const tagName = await preparationBtn.evaluate((el) =>
+      el.tagName.toLowerCase(),
+    );
+    expect(tagName).toBe("button");
+
+    await preparationBtn.click();
+
+    // The wizard should rewind back to preparation
+    await expect(wizardPage.getByTestId("wizard-stepper")).toHaveAttribute(
+      "data-current-step",
+      "preparation",
+      { timeout: 5000 },
+    );
+  });
+
+  test("back navigation to preparation restores initial UI (card selection visible)", async ({
+    wizardPage,
+    simulateProcessing,
+  }) => {
+    await simulateProcessing();
+
+    // Navigate back to preparation via the stepper button
+    await wizardPage
+      .getByTestId("wizard-stepper-step-preparation")
+      .click();
+
+    // The card selection should be visible again (trip was cleared)
+    await expect(wizardPage.getByTestId("wizard-stepper")).toHaveAttribute(
+      "data-current-step",
+      "preparation",
+      { timeout: 5000 },
+    );
+  });
+});
+
+test.describe("WizardStepper — step transitions", () => {
+  test("stepper advances to analysis when processing starts", async ({
+    wizardPage,
+    simulateProcessing,
+  }) => {
+    await simulateProcessing();
+    await expect(wizardPage.getByTestId("wizard-stepper")).toHaveAttribute(
+      "data-current-step",
+      "analysis",
+    );
+    const analysisEl = wizardPage.getByTestId("wizard-stepper-step-analysis");
+    await expect(analysisEl).toHaveAttribute("aria-current", "step");
+  });
+
+  test("preparation step is no longer active during analysis", async ({
+    wizardPage,
+    simulateProcessing,
+  }) => {
+    await simulateProcessing();
+    await expect(
+      wizardPage.getByTestId("wizard-stepper-step-preparation"),
+    ).not.toHaveAttribute("aria-current");
+  });
+});
+
+test.describe("WizardStepper — accessibility", () => {
+  test("wizard stepper has role=navigation", async ({ wizardPage }) => {
+    const stepper = wizardPage.getByTestId("wizard-stepper");
+    await expect(stepper).toHaveAttribute("role", "navigation");
+  });
+
+  test("active step has aria-current=step", async ({ wizardPage }) => {
+    const preparationStep = wizardPage.getByTestId(
+      "wizard-stepper-step-preparation",
+    );
+    await expect(preparationStep).toHaveAttribute("aria-current", "step");
+  });
+
+  test("each step has data-step-number attribute", async ({ wizardPage }) => {
+    await expect(
+      wizardPage.getByTestId("wizard-stepper-step-preparation"),
+    ).toHaveAttribute("data-step-number", "1");
+    await expect(
+      wizardPage.getByTestId("wizard-stepper-step-preview"),
+    ).toHaveAttribute("data-step-number", "2");
+    await expect(
+      wizardPage.getByTestId("wizard-stepper-step-analysis"),
+    ).toHaveAttribute("data-step-number", "3");
+    await expect(
+      wizardPage.getByTestId("wizard-stepper-step-my_trip"),
+    ).toHaveAttribute("data-step-number", "4");
+  });
+});
+
+test.describe("WizardStepper — responsive mobile", () => {
+  test("mobile compact label is visible on small viewport", async ({
+    wizardPage,
+  }) => {
+    await wizardPage.setViewportSize({ width: 375, height: 812 });
+    const mobileLabel = wizardPage.getByTestId("wizard-stepper-mobile-label");
+    await expect(mobileLabel).toBeVisible();
+  });
+
+  test("mobile label shows correct step info for preparation", async ({
+    wizardPage,
+  }) => {
+    await wizardPage.setViewportSize({ width: 375, height: 812 });
+    const mobileLabel = wizardPage.getByTestId("wizard-stepper-mobile-label");
+    // At preparation step: label should mention "1/4"
+    await expect(mobileLabel).toContainText("1/4");
+  });
+
+  test("mobile label updates when step advances to analysis", async ({
+    wizardPage,
+    simulateProcessing,
+  }) => {
+    await wizardPage.setViewportSize({ width: 375, height: 812 });
+    await simulateProcessing();
+    const mobileLabel = wizardPage.getByTestId("wizard-stepper-mobile-label");
+    // After moving to analysis: "3/4"
+    await expect(mobileLabel).toContainText("3/4", { timeout: 5000 });
+  });
+});
+
+test.describe("WizardStepper — WizardStepper vs internal Stepper", () => {
+  test("wizard-stepper test IDs are distinct from internal stepper test IDs", async ({
+    wizardPage,
+  }) => {
+    // WizardStepper uses wizard-stepper-step-* test IDs
+    await expect(
+      wizardPage.getByTestId("wizard-stepper-step-preparation"),
+    ).toBeVisible();
+
+    // The internal Stepper (stepper-step-*) is suppressed via hideStepper=true
+    // on /trips/new, so those test IDs should NOT be present.
+    await expect(
+      wizardPage.getByTestId("stepper-step-preparation"),
+    ).not.toBeAttached();
+  });
+
+  test("SSE events are injectable on /trips/new (WizardStepper route)", async ({
+    wizardPage,
+    injectWizardEvent,
+    simulateProcessing,
+  }) => {
+    await simulateProcessing();
+    // Injecting SSE events should not cause errors on /trips/new
+    await injectWizardEvent(routeParsedEvent());
+    await injectWizardEvent(stagesComputedEvent());
+
+    // Stepper remains on analysis (isProcessing=true, not cleared by these events)
+    await expect(wizardPage.getByTestId("wizard-stepper")).toHaveAttribute(
+      "data-current-step",
+      "analysis",
+    );
+  });
+});


### PR DESCRIPTION
Closes #391

## Summary

Refactors `/trips/new` into a 4-step wizard with desktop `WizardStepper` and narrative SSE analysis screen.

- `WizardStepper` (desktop horizontal stepper with numbered steps + connecting line; compact mobile fallback "Étape N/4")
- 4 steps wired through `?step=1..4` query param synchronized bidirectionally with `useUiStore.currentStep`
  - **Préparation** — Card Selection (Lien / GPX), step 1
  - **Aperçu** — Map + stats + stages + sliders + CTA "Lancer l'analyse", step 2
  - **Analyse** — Narrative SSE screen, step 3
  - **Mon voyage** — Redirect to `/trips/[id]`, step 4
- `processing-progress.tsx` refactored: 7 narrative acts mapped on `ComputationName` (terrain, points of interest, accommodations, weather, services, local context, AI summary) with dynamic running/done/failed sub-descriptions
- `TripPlanner` accepts `hideStepper` prop so the wizard replaces the inline stepper without affecting `/`
- AI cards (chat #392 / refinement #393) are out of scope for this PR

## Test plan

- [ ] Wizard navigation forward via in-app actions and backward via stepper
- [ ] URL `?step=1..4` updates state; manual forward jumps blocked (data-driven)
- [ ] Narrative analysis screen renders with SSE events
- [ ] Existing `/` flow unchanged

## Auto-critique

- Pre-existing prettier issues on 5 files unrelated to this PR (`error.tsx`, `global-error.tsx`, `not-found.tsx`, `alert-list.tsx`, `trip-store.ts`) were also formatted to unblock CI
- Forward URL navigation is intentionally blocked to keep state machine consistent — users must reach forward steps via in-app actions
- The legacy inline `Stepper` is preserved (still used by `/`) — wizard composes on top of it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

**Reviewed commit:** `52ae558ea2fa1da97d3f4482c67f139457a1222f`

All previously flagged issues are resolved. The `context` act visibility assertion, context done-state progression test, and the full `ActDescription` state-machine test suite (pending → in_progress → done → failed) are present and structurally correct. Translation keys (`running`/`done`/`failed`) are complete for all 7 acts in both `en.json` and `fr.json`. The render-synced ref pattern from the regression fix remains sound. No new issues found.

### Resolved threads

Resolved 2 previously open bot-authored threads that were addressed by the latest commit.

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Inline comments

No inline comments.

---

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->