### PR TITLE
feat(trips): redesign trips list with 2-col grid + empty states (#399)

### DIFF
--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -381,7 +381,22 @@
     "close": "Back to home",
     "status_draft": "Draft",
     "status_analyzing": "Analyzing...",
-    "status_analyzed": "Analyzed"
+    "status_analyzed": "Analyzed",
+    "totalDistance": "Total distance",
+    "stageCount": "Stage count",
+    "openTrip": "Open trip \"{title}\"",
+    "emptyState": {
+      "createFirstTitle": "Create your first trip",
+      "createFirstDescription": "Import a GPX track, a Komoot, Strava or RideWithGPS route — and let yourself be guided onto the road.",
+      "newTrip": "Create a trip",
+      "noResultsTitle": "No trip matches your search",
+      "activeFilters": "Active filters:",
+      "filterTitle": "title \"{value}\"",
+      "filterDates": "dates {value}",
+      "filterFrom": "from {value}",
+      "filterUntil": "until {value}",
+      "resetFilters": "Reset filters"
+    }
   },
   "noDates": {
     "banner": "Dates not set — Displaying from today",

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -381,7 +381,22 @@
     "close": "Retour à l'accueil",
     "status_draft": "Brouillon",
     "status_analyzing": "En cours d'analyse",
-    "status_analyzed": "Analysé"
+    "status_analyzed": "Analysé",
+    "totalDistance": "Distance totale",
+    "stageCount": "Nombre d'étapes",
+    "openTrip": "Ouvrir le voyage « {title} »",
+    "emptyState": {
+      "createFirstTitle": "Crée ton premier voyage",
+      "createFirstDescription": "Importe une trace GPX, un itinéraire Komoot, Strava ou RideWithGPS — et laisse-toi guider sur les routes.",
+      "newTrip": "Créer un voyage",
+      "noResultsTitle": "Aucun voyage ne correspond à votre recherche",
+      "activeFilters": "Filtres actifs :",
+      "filterTitle": "titre « {value} »",
+      "filterDates": "dates {value}",
+      "filterFrom": "à partir du {value}",
+      "filterUntil": "jusqu'au {value}",
+      "resetFilters": "Réinitialiser les filtres"
+    }
   },
   "noDates": {
     "banner": "Dates non renseignées — Affichage depuis aujourd'hui",

--- a/pwa/src/app/trips/page.tsx
+++ b/pwa/src/app/trips/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
-import { useTranslations } from "next-intl";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useTranslations, useLocale } from "next-intl";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
-import { Trash2, ChevronLeft, ChevronRight, Loader2, X } from "lucide-react";
+import dayjs from "dayjs";
+import "dayjs/locale/fr";
+import { ChevronLeft, ChevronRight, Loader2, X } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -17,9 +18,9 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { apiFetch } from "@/lib/api/client";
-import { formatDistanceKm } from "@/lib/formatters";
 import { API_URL } from "@/lib/constants";
-import { TripStatusBadge } from "@/components/trip-status-badge";
+import { TripCard } from "@/components/trip-card";
+import { TripsEmptyState } from "@/components/trips-empty-state";
 import type { components } from "@/lib/api/schema";
 
 type TripListItem = components["schemas"]["Trip.TripListItem.jsonld"];
@@ -27,11 +28,12 @@ type TripCollection = components["schemas"]["HydraCollectionBaseSchema"] & {
   member: TripListItem[];
 };
 
-const ITEMS_PER_PAGE = 10;
+const ITEMS_PER_PAGE = 12;
 
 export default function TripsPage() {
   const t = useTranslations("tripList");
-  const router = useRouter();
+  const tFilters = useTranslations("tripList.emptyState");
+  const locale = useLocale();
 
   const [trips, setTrips] = useState<TripListItem[]>([]);
   const [totalItems, setTotalItems] = useState(0);
@@ -54,6 +56,18 @@ export default function TripsPage() {
     }, 350);
     return () => clearTimeout(timer);
   }, [titleFilter]);
+
+  const hasActiveFilters = Boolean(
+    debouncedTitle || startDateFilter || endDateFilter,
+  );
+
+  const resetFilters = useCallback(() => {
+    setTitleFilter("");
+    setDebouncedTitle("");
+    setStartDateFilter("");
+    setEndDateFilter("");
+    setPage(1);
+  }, []);
 
   const fetchTrips = useCallback(async () => {
     setIsLoading(true);
@@ -117,11 +131,40 @@ export default function TripsPage() {
 
   const totalPages = Math.max(1, Math.ceil(totalItems / ITEMS_PER_PAGE));
 
+  // Human-readable summary of active filters (used in no-results empty state).
+  const activeFiltersLabel = useMemo(() => {
+    if (!hasActiveFilters) return undefined;
+    const fragments: string[] = [];
+    if (debouncedTitle) {
+      fragments.push(tFilters("filterTitle", { value: debouncedTitle }));
+    }
+    if (startDateFilter || endDateFilter) {
+      const fmt = (d: string) => dayjs(d).locale(locale).format("D MMM YYYY");
+      const range =
+        startDateFilter && endDateFilter
+          ? `${fmt(startDateFilter)} — ${fmt(endDateFilter)}`
+          : startDateFilter
+            ? tFilters("filterFrom", { value: fmt(startDateFilter) })
+            : tFilters("filterUntil", { value: fmt(endDateFilter) });
+      fragments.push(tFilters("filterDates", { value: range }));
+    }
+    return fragments.join(" · ");
+  }, [
+    hasActiveFilters,
+    debouncedTitle,
+    startDateFilter,
+    endDateFilter,
+    locale,
+    tFilters,
+  ]);
+
   return (
     <main className="max-w-[1200px] mx-auto px-4 md:px-6 py-8 md:py-12">
       {/* Header */}
       <div className="flex flex-wrap items-center justify-between gap-4 mb-8">
-        <h1 className="text-2xl font-bold">{t("title")}</h1>
+        <h1 className="font-serif text-3xl md:text-4xl font-semibold tracking-tight">
+          {t("title")}
+        </h1>
         <div className="flex items-center gap-2">
           <Button
             asChild
@@ -185,17 +228,11 @@ export default function TripsPage() {
             aria-label={t("filterUntil")}
           />
         </div>
-        {(titleFilter || startDateFilter || endDateFilter) && (
+        {hasActiveFilters && (
           <Button
             variant="ghost"
             size="sm"
-            onClick={() => {
-              setTitleFilter("");
-              setDebouncedTitle("");
-              setStartDateFilter("");
-              setEndDateFilter("");
-              setPage(1);
-            }}
+            onClick={resetFilters}
             data-testid="clear-filters-button"
           >
             <X className="h-4 w-4 mr-1" />
@@ -226,77 +263,29 @@ export default function TripsPage() {
         </div>
       )}
 
-      {/* Empty state */}
+      {/* Empty states (mutually exclusive: filters active vs no trips at all) */}
       {!isLoading && !loadError && trips.length === 0 && (
-        <div className="text-center py-16 text-muted-foreground">
-          <p>{t("noTrips")}</p>
-        </div>
+        <TripsEmptyState
+          variant={hasActiveFilters ? "no-results" : "empty"}
+          activeFiltersLabel={activeFiltersLabel}
+          onResetFilters={hasActiveFilters ? resetFilters : undefined}
+        />
       )}
 
-      {/* Trip list */}
+      {/* Trip grid */}
       {!isLoading && !loadError && trips.length > 0 && (
         <>
-          <p className="text-sm text-muted-foreground mb-3" aria-live="polite">
+          <p className="text-sm text-muted-foreground mb-4" aria-live="polite">
             {t("totalItems", { count: totalItems })}
           </p>
-          <ul className="space-y-3" role="list">
+          <ul
+            className="grid grid-cols-1 gap-4 md:grid-cols-2 md:gap-6"
+            role="list"
+            data-testid="trips-grid"
+          >
             {trips.map((trip) => (
               <li key={trip.id}>
-                <div className="flex items-center gap-3 rounded-lg border bg-card px-4 py-4 shadow-sm hover:bg-accent/50 transition-colors">
-                  {/* Clickable trip info */}
-                  <button
-                    type="button"
-                    className="flex-1 text-left min-w-0 cursor-pointer"
-                    onClick={() => router.push(`/trips/${trip.id ?? ""}`)}
-                    data-testid={`trip-item-${trip.id ?? ""}`}
-                  >
-                    <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
-                      <span className="font-semibold truncate">
-                        {trip.title ?? t("untitled")}
-                      </span>
-                      <TripStatusBadge status={trip.status} />
-                      {(trip.stageCount ?? 0) > 0 && (
-                        <span className="text-sm text-muted-foreground">
-                          {t("stages", { count: trip.stageCount ?? 0 })}
-                        </span>
-                      )}
-                      {(trip.totalDistance ?? 0) > 0 && (
-                        <span className="text-sm text-muted-foreground">
-                          {formatDistanceKm(trip.totalDistance ?? 0)}
-                        </span>
-                      )}
-                    </div>
-                    <div className="mt-1 text-sm text-muted-foreground">
-                      {trip.startDate || trip.endDate ? (
-                        <span>
-                          {trip.startDate
-                            ? new Date(trip.startDate).toLocaleDateString()
-                            : "?"}
-                          {" — "}
-                          {trip.endDate
-                            ? new Date(trip.endDate).toLocaleDateString()
-                            : "?"}
-                        </span>
-                      ) : (
-                        <span>{t("noDates")}</span>
-                      )}
-                    </div>
-                  </button>
-
-                  {/* Actions */}
-                  <div className="flex items-center gap-1 shrink-0">
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="h-8 w-8 text-destructive hover:text-destructive hover:bg-destructive/10"
-                      onClick={() => setDeleteTarget(trip)}
-                      title={t("deleteTrip")}
-                      aria-label={t("deleteTrip")}
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
-                  </div>
-                </div>
+                <TripCard trip={trip} onDelete={setDeleteTarget} />
               </li>
             ))}
           </ul>

--- a/pwa/src/components/trip-card.tsx
+++ b/pwa/src/components/trip-card.tsx
@@ -191,9 +191,9 @@ function TripMiniMap({ path }: { path: string }) {
 
 function PolylineEndpoints({ path }: { path: string }) {
   const points = useMemo(() => parsePathPoints(path), [path]);
-  if (points.length < 2) return null;
   const first = points[0];
   const last = points[points.length - 1];
+  if (!first || !last) return null;
   return (
     <>
       <circle cx={first.x} cy={first.y} r="2.5" className="fill-emerald-500" />

--- a/pwa/src/components/trip-card.tsx
+++ b/pwa/src/components/trip-card.tsx
@@ -50,19 +50,13 @@ export function TripCard({ trip, onDelete }: TripCardProps) {
       )}
       data-testid={`trip-card-${tripId}`}
     >
-      {/* Mini-map preview */}
-      <button
-        type="button"
-        onClick={() => router.push(`/trips/${tripId}`)}
-        className="relative block w-full text-left cursor-pointer focus:outline-none"
-        aria-label={t("openTrip", { title: trip.title ?? t("untitled") })}
-        data-testid={`trip-item-${tripId}`}
-      >
+      {/* Mini-map preview (decorative, click handled by stretched link below) */}
+      <div className="relative block w-full" aria-hidden="true">
         <TripMiniMap path={polylinePath} tripId={tripId} />
         <div className="absolute top-3 right-3">
           <TripStatusBadge status={trip.status} />
         </div>
-      </button>
+      </div>
 
       {/* Content */}
       <div className="flex flex-1 flex-col gap-3 p-4">
@@ -70,7 +64,13 @@ export function TripCard({ trip, onDelete }: TripCardProps) {
           <button
             type="button"
             onClick={() => router.push(`/trips/${tripId}`)}
-            className="text-left flex-1 min-w-0 cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-sm"
+            className={cn(
+              "text-left flex-1 min-w-0 cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-sm",
+              // Stretched-link: extend click target to cover the entire card.
+              "after:absolute after:inset-0 after:z-0",
+            )}
+            aria-label={t("openTrip", { title: trip.title ?? t("untitled") })}
+            data-testid={`trip-item-${tripId}`}
           >
             <h3 className="font-serif text-lg font-semibold leading-tight tracking-tight truncate">
               {trip.title ?? t("untitled")}
@@ -85,7 +85,7 @@ export function TripCard({ trip, onDelete }: TripCardProps) {
             <Button
               variant="ghost"
               size="icon"
-              className="h-8 w-8 shrink-0 text-muted-foreground hover:text-destructive hover:bg-destructive/10"
+              className="relative z-10 h-8 w-8 shrink-0 text-muted-foreground hover:text-destructive hover:bg-destructive/10"
               onClick={(e) => {
                 e.stopPropagation();
                 onDelete(trip);

--- a/pwa/src/components/trip-card.tsx
+++ b/pwa/src/components/trip-card.tsx
@@ -1,0 +1,267 @@
+"use client";
+
+import { useMemo } from "react";
+import { useLocale, useTranslations } from "next-intl";
+import { useRouter } from "next/navigation";
+import dayjs from "dayjs";
+import "dayjs/locale/fr";
+import { Mountain, MapPin, Trash2, Calendar } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { TripStatusBadge } from "@/components/trip-status-badge";
+import { formatDistanceKm } from "@/lib/formatters";
+import { cn } from "@/lib/utils";
+import type { components } from "@/lib/api/schema";
+
+type TripListItem = components["schemas"]["Trip.TripListItem.jsonld"];
+
+interface TripCardProps {
+  trip: TripListItem;
+  onDelete?: (trip: TripListItem) => void;
+}
+
+/**
+ * Card displaying a trip summary with a decorative mini-map preview.
+ *
+ * The mini-map is rendered as a deterministic SVG polyline derived from
+ * the trip id. Until the backend exposes decimated geometry on the list DTO,
+ * this preserves a route-like visual without per-card detail fetches.
+ */
+export function TripCard({ trip, onDelete }: TripCardProps) {
+  const t = useTranslations("tripList");
+  const locale = useLocale();
+  const router = useRouter();
+
+  const tripId = trip.id ?? "";
+  const polylinePath = useMemo(() => buildPolylinePath(tripId), [tripId]);
+  const distance = formatDistanceKm(trip.totalDistance ?? 0);
+  const stageCount = trip.stageCount ?? 0;
+  const dateLabel = formatDateRange(
+    trip.startDate ?? null,
+    trip.endDate ?? null,
+    locale,
+    t("noDates"),
+  );
+
+  return (
+    <article
+      className={cn(
+        "group relative flex flex-col overflow-hidden rounded-xl border bg-card shadow-sm",
+        "transition-all hover:shadow-md hover:border-brand/40 focus-within:ring-2 focus-within:ring-ring",
+      )}
+      data-testid={`trip-card-${tripId}`}
+    >
+      {/* Mini-map preview */}
+      <button
+        type="button"
+        onClick={() => router.push(`/trips/${tripId}`)}
+        className="relative block w-full text-left cursor-pointer focus:outline-none"
+        aria-label={t("openTrip", { title: trip.title ?? t("untitled") })}
+        data-testid={`trip-item-${tripId}`}
+      >
+        <TripMiniMap path={polylinePath} />
+        <div className="absolute top-3 right-3">
+          <TripStatusBadge status={trip.status} />
+        </div>
+      </button>
+
+      {/* Content */}
+      <div className="flex flex-1 flex-col gap-3 p-4">
+        <header className="flex items-start justify-between gap-2">
+          <button
+            type="button"
+            onClick={() => router.push(`/trips/${tripId}`)}
+            className="text-left flex-1 min-w-0 cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-sm"
+          >
+            <h3 className="font-serif text-lg font-semibold leading-tight tracking-tight truncate">
+              {trip.title ?? t("untitled")}
+            </h3>
+            <p className="mt-1 flex items-center gap-1.5 text-sm text-muted-foreground">
+              <Calendar className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+              <span className="truncate">{dateLabel}</span>
+            </p>
+          </button>
+
+          {onDelete && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 shrink-0 text-muted-foreground hover:text-destructive hover:bg-destructive/10"
+              onClick={(e) => {
+                e.stopPropagation();
+                onDelete(trip);
+              }}
+              title={t("deleteTrip")}
+              aria-label={t("deleteTrip")}
+            >
+              <Trash2 className="h-4 w-4" />
+            </Button>
+          )}
+        </header>
+
+        {/* Stats */}
+        <dl className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm">
+          {distance && (
+            <div className="flex items-center gap-1.5 text-muted-foreground">
+              <MapPin className="h-3.5 w-3.5" aria-hidden="true" />
+              <dt className="sr-only">{t("totalDistance")}</dt>
+              <dd className="font-medium text-foreground">{distance}</dd>
+            </div>
+          )}
+          {stageCount > 0 && (
+            <div className="flex items-center gap-1.5 text-muted-foreground">
+              <Mountain className="h-3.5 w-3.5" aria-hidden="true" />
+              <dt className="sr-only">{t("stageCount")}</dt>
+              <dd className="font-medium text-foreground">
+                {t("stages", { count: stageCount })}
+              </dd>
+            </div>
+          )}
+        </dl>
+      </div>
+    </article>
+  );
+}
+
+/**
+ * Decorative mini-map: gradient terrain background with a stylised polyline.
+ */
+function TripMiniMap({ path }: { path: string }) {
+  return (
+    <div
+      className="relative h-32 w-full overflow-hidden bg-gradient-to-br from-emerald-50 via-sky-50 to-amber-50 dark:from-emerald-950/40 dark:via-sky-950/40 dark:to-amber-950/40"
+      aria-hidden="true"
+    >
+      <svg
+        viewBox="0 0 200 100"
+        preserveAspectRatio="none"
+        className="absolute inset-0 h-full w-full"
+      >
+        <defs>
+          <pattern
+            id="trip-card-grid"
+            width="20"
+            height="20"
+            patternUnits="userSpaceOnUse"
+          >
+            <path
+              d="M 20 0 L 0 0 0 20"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="0.3"
+              className="text-foreground/10"
+            />
+          </pattern>
+          <linearGradient
+            id="trip-card-route"
+            x1="0%"
+            y1="0%"
+            x2="100%"
+            y2="0%"
+          >
+            <stop offset="0%" stopColor="var(--brand)" />
+            <stop offset="100%" stopColor="var(--brand-hover)" />
+          </linearGradient>
+        </defs>
+        <rect width="200" height="100" fill="url(#trip-card-grid)" />
+
+        {/* Halo */}
+        <path
+          d={path}
+          fill="none"
+          stroke="white"
+          strokeOpacity="0.6"
+          strokeWidth="4"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        {/* Route */}
+        <path
+          d={path}
+          fill="none"
+          stroke="url(#trip-card-route)"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <PolylineEndpoints path={path} />
+      </svg>
+    </div>
+  );
+}
+
+function PolylineEndpoints({ path }: { path: string }) {
+  const points = useMemo(() => parsePathPoints(path), [path]);
+  if (points.length < 2) return null;
+  const first = points[0];
+  const last = points[points.length - 1];
+  return (
+    <>
+      <circle cx={first.x} cy={first.y} r="2.5" className="fill-emerald-500" />
+      <circle cx={last.x} cy={last.y} r="2.5" className="fill-rose-500" />
+    </>
+  );
+}
+
+function parsePathPoints(path: string): { x: number; y: number }[] {
+  const out: { x: number; y: number }[] = [];
+  const re = /[ML]\s*(-?\d+(?:\.\d+)?)\s+(-?\d+(?:\.\d+)?)/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(path)) !== null) {
+    out.push({ x: Number(match[1]), y: Number(match[2]) });
+  }
+  return out;
+}
+
+/** Deterministic seeded PRNG (mulberry32). */
+function mulberry32(seed: number): () => number {
+  let t = seed >>> 0;
+  return () => {
+    t = (t + 0x6d2b79f5) >>> 0;
+    let r = t;
+    r = Math.imul(r ^ (r >>> 15), r | 1);
+    r ^= r + Math.imul(r ^ (r >>> 7), r | 61);
+    return ((r ^ (r >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function hashString(s: string): number {
+  let h = 2166136261;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+}
+
+/** Build an SVG path for a meandering route stable per `seed`. */
+function buildPolylinePath(seed: string): string {
+  const rand = mulberry32(hashString(seed || "trip"));
+  const points = 7;
+  const padding = 12;
+  const stepX = (200 - padding * 2) / (points - 1);
+  const coords: { x: number; y: number }[] = [];
+  let prevY = padding + rand() * (100 - padding * 2);
+  for (let i = 0; i < points; i++) {
+    const x = padding + i * stepX + (rand() - 0.5) * 6;
+    const drift = (rand() - 0.5) * 40;
+    const y = Math.max(padding, Math.min(100 - padding, prevY + drift));
+    coords.push({ x, y });
+    prevY = y;
+  }
+  return coords
+    .map((p, i) => `${i === 0 ? "M" : "L"} ${p.x.toFixed(1)} ${p.y.toFixed(1)}`)
+    .join(" ");
+}
+
+function formatDateRange(
+  startDate: string | null,
+  endDate: string | null,
+  locale: string,
+  fallback: string,
+): string {
+  if (!startDate && !endDate) return fallback;
+  const fmt = (d: string | null) =>
+    d ? dayjs(d).locale(locale).format("D MMM YYYY") : "?";
+  if (startDate && endDate && startDate === endDate) return fmt(startDate);
+  return `${fmt(startDate)} — ${fmt(endDate)}`;
+}

--- a/pwa/src/components/trip-card.tsx
+++ b/pwa/src/components/trip-card.tsx
@@ -58,7 +58,7 @@ export function TripCard({ trip, onDelete }: TripCardProps) {
         aria-label={t("openTrip", { title: trip.title ?? t("untitled") })}
         data-testid={`trip-item-${tripId}`}
       >
-        <TripMiniMap path={polylinePath} />
+        <TripMiniMap path={polylinePath} tripId={tripId} />
         <div className="absolute top-3 right-3">
           <TripStatusBadge status={trip.status} />
         </div>
@@ -124,8 +124,14 @@ export function TripCard({ trip, onDelete }: TripCardProps) {
 
 /**
  * Decorative mini-map: gradient terrain background with a stylised polyline.
+ *
+ * SVG `<defs>` ids are suffixed with `tripId` to avoid duplicate-id collisions
+ * when many cards are rendered in a list.
  */
-function TripMiniMap({ path }: { path: string }) {
+function TripMiniMap({ path, tripId }: { path: string; tripId: string }) {
+  const idSuffix = sanitizeIdSuffix(tripId);
+  const gridId = `trip-card-grid-${idSuffix}`;
+  const routeId = `trip-card-route-${idSuffix}`;
   return (
     <div
       className="relative h-32 w-full overflow-hidden bg-gradient-to-br from-emerald-50 via-sky-50 to-amber-50 dark:from-emerald-950/40 dark:via-sky-950/40 dark:to-amber-950/40"
@@ -138,7 +144,7 @@ function TripMiniMap({ path }: { path: string }) {
       >
         <defs>
           <pattern
-            id="trip-card-grid"
+            id={gridId}
             width="20"
             height="20"
             patternUnits="userSpaceOnUse"
@@ -151,18 +157,12 @@ function TripMiniMap({ path }: { path: string }) {
               className="text-foreground/10"
             />
           </pattern>
-          <linearGradient
-            id="trip-card-route"
-            x1="0%"
-            y1="0%"
-            x2="100%"
-            y2="0%"
-          >
+          <linearGradient id={routeId} x1="0%" y1="0%" x2="100%" y2="0%">
             <stop offset="0%" stopColor="var(--brand)" />
             <stop offset="100%" stopColor="var(--brand-hover)" />
           </linearGradient>
         </defs>
-        <rect width="200" height="100" fill="url(#trip-card-grid)" />
+        <rect width="200" height="100" fill={`url(#${gridId})`} />
 
         {/* Halo */}
         <path
@@ -178,7 +178,7 @@ function TripMiniMap({ path }: { path: string }) {
         <path
           d={path}
           fill="none"
-          stroke="url(#trip-card-route)"
+          stroke={`url(#${routeId})`}
           strokeWidth="2"
           strokeLinecap="round"
           strokeLinejoin="round"
@@ -187,6 +187,12 @@ function TripMiniMap({ path }: { path: string }) {
       </svg>
     </div>
   );
+}
+
+/** Sanitize an arbitrary string into a safe SVG id fragment. */
+function sanitizeIdSuffix(value: string): string {
+  const cleaned = value.replace(/[^a-zA-Z0-9_-]/g, "");
+  return cleaned.length > 0 ? cleaned : "default";
 }
 
 function PolylineEndpoints({ path }: { path: string }) {

--- a/pwa/src/components/trip-card.tsx
+++ b/pwa/src/components/trip-card.tsx
@@ -5,6 +5,7 @@ import { useLocale, useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
 import dayjs from "dayjs";
 import "dayjs/locale/fr";
+import "dayjs/locale/en";
 import { Mountain, MapPin, Trash2, Calendar } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { TripStatusBadge } from "@/components/trip-status-badge";

--- a/pwa/src/components/trips-empty-state.tsx
+++ b/pwa/src/components/trips-empty-state.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import Link from "next/link";
+import { useTranslations } from "next-intl";
+import { Bike, SearchX } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export type TripsEmptyStateVariant = "empty" | "no-results";
+
+interface TripsEmptyStateProps {
+  variant: TripsEmptyStateVariant;
+  /** Human-readable summary of currently active filters (no-results only). */
+  activeFiltersLabel?: string;
+  /** Reset all filters (no-results only). */
+  onResetFilters?: () => void;
+}
+
+/**
+ * Two mutually-exclusive empty states for the /trips page:
+ *   - `empty`     : the user has no trips at all → encourage creating one.
+ *   - `no-results`: filters are active but yield zero results → reset/keep searching.
+ */
+export function TripsEmptyState({
+  variant,
+  activeFiltersLabel,
+  onResetFilters,
+}: TripsEmptyStateProps) {
+  const t = useTranslations("tripList.emptyState");
+
+  if (variant === "no-results") {
+    return (
+      <section
+        className="mx-auto flex max-w-md flex-col items-center text-center py-12 md:py-16"
+        data-testid="trips-empty-no-results"
+        aria-live="polite"
+      >
+        <div
+          className="mb-6 flex h-20 w-20 items-center justify-center rounded-full bg-muted"
+          aria-hidden="true"
+        >
+          <SearchX className="h-10 w-10 text-muted-foreground" />
+        </div>
+        <h2 className="font-serif text-2xl font-semibold tracking-tight">
+          {t("noResultsTitle")}
+        </h2>
+        {activeFiltersLabel && (
+          <p
+            className="mt-3 text-sm text-muted-foreground"
+            data-testid="trips-empty-active-filters"
+          >
+            {t("activeFilters")} {activeFiltersLabel}
+          </p>
+        )}
+        <div className="mt-6 flex flex-wrap items-center justify-center gap-3">
+          {onResetFilters && (
+            <Button
+              variant="default"
+              onClick={onResetFilters}
+              data-testid="trips-empty-reset-filters"
+            >
+              {t("resetFilters")}
+            </Button>
+          )}
+          <Button
+            asChild
+            variant="ghost"
+            data-testid="trips-empty-new-trip-secondary"
+          >
+            <Link href="/trips/new">{t("newTrip")}</Link>
+          </Button>
+        </div>
+      </section>
+    );
+  }
+
+  // variant === "empty"
+  return (
+    <section
+      className="mx-auto flex max-w-md flex-col items-center text-center py-12 md:py-16"
+      data-testid="trips-empty-no-trips"
+      aria-live="polite"
+    >
+      <div
+        className="relative mb-6 flex h-28 w-28 items-center justify-center rounded-full bg-brand-light"
+        aria-hidden="true"
+      >
+        <Bike className="h-14 w-14 text-brand" strokeWidth={1.5} />
+        <span className="absolute -right-1 -top-1 h-3 w-3 rounded-full bg-emerald-500 shadow-md" />
+        <span className="absolute -left-2 bottom-1 h-2 w-2 rounded-full bg-amber-400 shadow-sm" />
+      </div>
+      <h2 className="font-serif text-2xl md:text-3xl font-semibold tracking-tight">
+        {t("createFirstTitle")}
+      </h2>
+      <p className="mt-3 text-base text-muted-foreground">
+        {t("createFirstDescription")}
+      </p>
+      <Button
+        asChild
+        variant="default"
+        size="lg"
+        className="mt-6"
+        data-testid="trips-empty-new-trip-primary"
+      >
+        <Link href="/trips/new">{t("newTrip")}</Link>
+      </Button>
+    </section>
+  );
+}

--- a/pwa/tests/mocked/trips-list.spec.ts
+++ b/pwa/tests/mocked/trips-list.spec.ts
@@ -127,3 +127,88 @@ test.describe("/trips page", () => {
     ).not.toBeVisible();
   });
 });
+
+test.describe("/trips empty states", () => {
+  test.beforeEach(async ({ page }) => {
+    // Mock auth refresh so AuthGuard passes
+    await page.route("**/auth/refresh", (route) =>
+      route.fulfill({
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token: FAKE_JWT_TOKEN }),
+      }),
+    );
+  });
+
+  test("shows empty state when no trips exist", async ({ page }) => {
+    await page.route("**/trips*", (route, request) => {
+      const accept = request.headers()["accept"] ?? "";
+      if (!accept.includes("application/ld+json")) return route.fallback();
+      if (request.method() !== "GET") return route.fallback();
+
+      return route.fulfill({
+        status: 200,
+        headers: { "Content-Type": "application/ld+json; charset=utf-8" },
+        body: JSON.stringify({ member: [], totalItems: 0 }),
+      });
+    });
+
+    await page.goto("/trips");
+    await page.waitForLoadState("networkidle");
+
+    await expect(page.getByTestId("trips-empty-no-trips")).toBeVisible();
+    await expect(
+      page.getByTestId("trips-empty-new-trip-primary"),
+    ).toBeVisible();
+    // The no-results variant must NOT render in this case.
+    await expect(page.getByTestId("trips-empty-no-results")).not.toBeVisible();
+  });
+
+  test("shows no-results state when filter has no match", async ({ page }) => {
+    // Return populated trips when no title filter, empty otherwise.
+    await page.route("**/trips*", (route, request) => {
+      const accept = request.headers()["accept"] ?? "";
+      if (!accept.includes("application/ld+json")) return route.fallback();
+      if (request.method() !== "GET") return route.fallback();
+
+      const url = new URL(request.url());
+      const hasTitleFilter = url.searchParams.has("title");
+
+      const body = hasTitleFilter
+        ? { member: [], totalItems: 0 }
+        : MOCK_TRIPS;
+
+      return route.fulfill({
+        status: 200,
+        headers: { "Content-Type": "application/ld+json; charset=utf-8" },
+        body: JSON.stringify(body),
+      });
+    });
+
+    await page.goto("/trips");
+    await page.waitForLoadState("networkidle");
+
+    // Initial state: trips visible.
+    await expect(page.getByText("Tour des Alpes")).toBeVisible();
+    await expect(page.getByText("Bretagne coastal")).toBeVisible();
+
+    // Type a non-matching title in the search filter (350ms debounce).
+    const searchInput = page.getByRole("searchbox", {
+      name: /rechercher par titre/i,
+    });
+    await searchInput.fill("zzz-no-match");
+
+    // No-results empty state appears.
+    await expect(page.getByTestId("trips-empty-no-results")).toBeVisible();
+    await expect(
+      page.getByTestId("trips-empty-active-filters"),
+    ).toBeVisible();
+
+    // Click reset-filters → original trips reappear.
+    await page.getByTestId("trips-empty-reset-filters").click();
+
+    await expect(page.getByText("Tour des Alpes")).toBeVisible();
+    await expect(page.getByText("Bretagne coastal")).toBeVisible();
+    await expect(page.getByTestId("trips-empty-no-results")).not.toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #399 — Sprint 27 (Reste du design, issue #375 §4).

- Refonte visuelle de `/trips` : grille 2 colonnes responsive, titre Fraunces, badge statut conservé.
- Nouveau composant `trip-card.tsx` avec mini-map décorative SVG (polyline déterministe seedée par trip id, dégradé brand, marqueurs start/end). Préserve `data-testid="trip-item-${id}"` pour la compat E2E.
- Nouveau composant `trips-empty-state.tsx` avec prop `variant: 'empty' | 'no-results'` :
  - `empty` : illustration vélo + titre Fraunces « Crée ton premier voyage » + CTA ambre.
  - `no-results` : icône `SearchX` + récap des filtres actifs + bouton « Réinitialiser » + ghost « Nouveau voyage ».
- i18n FR/EN : nouvelles clés `tripList.emptyState.*`, `tripList.totalDistance`, `tripList.stageCount`, `tripList.openTrip`.

### Note mini-map

`Trip.TripListItem` ne sérialise pas la géométrie ; pour ne pas alourdir le DTO ni multiplier les fetchs, la mini-map est rendue en SVG décoratif déterministe (seed = trip id). Lorsqu'un sprint ultérieur exposera la polyline décimée sur l'endpoint liste, on remplacera la fonction de seed par les coordonnées réelles.

## Auto-critique

- Pourquoi un SVG décoratif au lieu d'une vraie mini-map Leaflet ? Trade-off vitesse/coût : importer Leaflet sur la page liste alourdirait fortement le bundle. Le SVG seedé par id reste stable visuellement par voyage et sera trivialement remplacé quand la donnée arrivera.
- Empty-state vs no-results basculé via `hasActiveFilters` (titre OU plage de dates) : couvre les filtres existants sans rajouter d'état applicatif.

## Test plan

- [ ] `/trips` vide → variante `empty` avec CTA « Créer un voyage »
- [ ] `/trips` avec filtre sans résultat → variante `no-results` + récap filtres + bouton reset
- [ ] Grille 2 colonnes en `md+`, 1 colonne en mobile
- [ ] Mini-map visible et déterministe par trip
- [ ] Suppression d'un voyage depuis la card fonctionne
- [ ] E2E mockés `tests/mocked/trip-list.spec.ts` passent (selectors `trip-item-${id}` préservés)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

All four previously flagged issues have been addressed across subsequent commits (SVG ID collision `0937a00`, stretched-link a11y `680b952`, dayjs `en` locale `985b8b7`, E2E coverage `342dc5d`). The implementation is clean and ready to merge.

**Findings: 0**

Resolved 1 previously open thread (E2E coverage for `TripsEmptyState` both variants — addressed in `342dc5d`).

### PR title check
`feat(trips): redesign trips list with 2-col grid + empty states (#399)` — the `(#399)` suffix is non-standard per Conventional Commits but not blocking.

### Review checklist
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases — E2E coverage added for both `empty` and `no-results` variants
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**No inline comments.**

**Reviewed commit:** `342dc5d`

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->