### PR TITLE
feat(ux): add transverse UX states (empty/skeleton/dropzone/destructive-modal) (#402)

### DIFF
--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -4,6 +4,43 @@
     "description": "Plan your bikepacking trips with ease",
     "skipToTimeline": "Skip to timeline"
   },
+  "gpxDropZone": {
+    "ariaLabel": "GPX drop zone",
+    "ariaProgress": "Upload progress",
+    "idle": "Drag and drop your GPX file here",
+    "release": "Release to import",
+    "uploading": "Uploading…",
+    "browse": "Browse",
+    "retry": "Retry",
+    "sizeLimit": "Maximum {size} MB"
+  },
+  "sourceChip": {
+    "komoot": "Komoot detected",
+    "strava": "Strava detected",
+    "ridewithgps": "RideWithGPS detected",
+    "unsupported": "Unsupported URL"
+  },
+  "destructiveDialog": {
+    "cancel": "Cancel",
+    "confirm": "Delete",
+    "typeKeyword": "Type \"{keyword}\" to confirm"
+  },
+  "tripNotFound": {
+    "title": "Trip not found",
+    "subtitle": "This trip does not exist or has been deleted.",
+    "illustrationAlt": "Lost cyclist in the mountains",
+    "back": "Back to my trips"
+  },
+  "shareNotFound": {
+    "title": "Share revoked",
+    "subtitle": "This share link is invalid or has been revoked by its owner.",
+    "illustrationAlt": "Lost cyclist in the mountains",
+    "back": "Back to home"
+  },
+  "roadbookEmpty": {
+    "title": "Empty roadbook",
+    "subtitle": "No stages for this trip yet. Import a route or add your first stage to get started."
+  },
   "gpxUpload": {
     "ariaLabel": "Upload GPX file",
     "dropZone": "Drop your GPX file here"
@@ -18,7 +55,8 @@
     "datesLabel": "Trip dates",
     "noDates": "Dates not set",
     "profileLabel": "Rider profile",
-    "customProfile": "Custom"
+    "customProfile": "Custom",
+    "loadingAriaLabel": "Loading trip summary"
   },
   "tripTitle": {
     "fallback": "My Trip",
@@ -50,7 +88,8 @@
     "travelTimeTooltip": "Estimate based on average speed and elevation gain (Naismith rule adapted for cycling)",
     "diffDistanceChanged": "Distance changed",
     "diffAlertsAdded": "New alerts added",
-    "sunriseSunsetTooltip": "Sunrise and sunset times at stage end point (UTC)"
+    "sunriseSunsetTooltip": "Sunrise and sunset times at stage end point (UTC)",
+    "noAlerts": "No alerts for this stage"
   },
   "stageLocations": {
     "searchDeparture": "Search departure...",
@@ -478,6 +517,7 @@
     "gpxSizeLimit": "Max 30 MB",
     "gpxFileTooLarge": "File too large (max 30 MB).",
     "gpxInvalidType": "Only .gpx files are accepted.",
+    "gpxUploadGenericError": "Upload failed. Please try again.",
     "aiTitle": "AI Assistant",
     "aiDescription": "Build a custom route",
     "back": "Change method",

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -8,6 +8,43 @@
     "ariaLabel": "Importer un fichier GPX",
     "dropZone": "Déposez votre fichier GPX ici"
   },
+  "gpxDropZone": {
+    "ariaLabel": "Zone de dépôt GPX",
+    "ariaProgress": "Progression de l'import",
+    "idle": "Glissez-déposez votre fichier GPX ici",
+    "release": "Relâchez pour importer",
+    "uploading": "Import en cours…",
+    "browse": "Parcourir",
+    "retry": "Réessayer",
+    "sizeLimit": "Maximum {size} Mo"
+  },
+  "sourceChip": {
+    "komoot": "Komoot détecté",
+    "strava": "Strava détecté",
+    "ridewithgps": "RideWithGPS détecté",
+    "unsupported": "URL non supportée"
+  },
+  "destructiveDialog": {
+    "cancel": "Annuler",
+    "confirm": "Supprimer",
+    "typeKeyword": "Tapez « {keyword} » pour confirmer"
+  },
+  "tripNotFound": {
+    "title": "Voyage introuvable",
+    "subtitle": "Ce voyage n'existe pas ou a été supprimé.",
+    "illustrationAlt": "Cycliste perdu en montagne",
+    "back": "Retour à mes voyages"
+  },
+  "shareNotFound": {
+    "title": "Partage révoqué",
+    "subtitle": "Ce lien de partage est invalide ou a été révoqué par son propriétaire.",
+    "illustrationAlt": "Cycliste perdu en montagne",
+    "back": "Retour à l'accueil"
+  },
+  "roadbookEmpty": {
+    "title": "Carnet de route vierge",
+    "subtitle": "Aucune étape pour ce voyage. Importez un itinéraire ou ajoutez votre première étape pour commencer."
+  },
   "tripSummary": {
     "totalDistance": "Distance totale :",
     "totalElevation": "Dénivelé total :",
@@ -18,7 +55,8 @@
     "datesLabel": "Dates du voyage",
     "noDates": "Dates non définies",
     "profileLabel": "Profil cyclo",
-    "customProfile": "Personnalisé"
+    "customProfile": "Personnalisé",
+    "loadingAriaLabel": "Chargement du résumé du voyage"
   },
   "tripTitle": {
     "fallback": "Mon voyage",
@@ -50,7 +88,8 @@
     "travelTimeTooltip": "Estimation basée sur la vitesse moyenne et le dénivelé (règle de Naismith adaptée au vélo)",
     "diffDistanceChanged": "Distance modifiée",
     "diffAlertsAdded": "Nouvelles alertes ajoutées",
-    "sunriseSunsetTooltip": "Heures de lever et coucher du soleil au point d'arrivée de l'étape (UTC)"
+    "sunriseSunsetTooltip": "Heures de lever et coucher du soleil au point d'arrivée de l'étape (UTC)",
+    "noAlerts": "Aucune alerte pour cette étape"
   },
   "stageLocations": {
     "searchDeparture": "Rechercher un départ...",
@@ -478,6 +517,7 @@
     "gpxSizeLimit": "Maximum 30 Mo",
     "gpxFileTooLarge": "Fichier trop volumineux (max 30 Mo).",
     "gpxInvalidType": "Seuls les fichiers .gpx sont acceptés.",
+    "gpxUploadGenericError": "L'import a échoué. Veuillez réessayer.",
     "aiTitle": "Assistant IA",
     "aiDescription": "Créez un itinéraire sur mesure",
     "back": "Changer de méthode",

--- a/pwa/src/app/s/[code]/shared-trip-page.tsx
+++ b/pwa/src/app/s/[code]/shared-trip-page.tsx
@@ -172,10 +172,12 @@ function SharedTripLoader({ code }: { code: string }) {
 
   if (!isLoaded) {
     return (
-      <div className="flex items-center justify-center min-h-[60vh] gap-3 text-muted-foreground">
-        <Loader2 className="h-5 w-5 animate-spin" />
-        <span>{t("loading")}</span>
-      </div>
+      <main className="max-w-[1200px] mx-auto px-4 md:px-6 py-8 md:py-12">
+        <div className="flex items-center justify-center min-h-[60vh] gap-3 text-muted-foreground">
+          <Loader2 className="h-5 w-5 animate-spin" />
+          <span>{t("loading")}</span>
+        </div>
+      </main>
     );
   }
 
@@ -184,7 +186,7 @@ function SharedTripLoader({ code }: { code: string }) {
 
   return (
     <ShareProvider value={{ shortCode: code, title: title ?? "" }}>
-      <div className="space-y-6">
+      <main className="max-w-[1200px] mx-auto px-4 md:px-6 py-8 md:py-12 space-y-6">
         {/* Read-only banner */}
         <div
           data-testid="read-only-banner"
@@ -274,7 +276,7 @@ function SharedTripLoader({ code }: { code: string }) {
             </div>
           )}
         </div>
-      </div>
+      </main>
     </ShareProvider>
   );
 }
@@ -284,11 +286,9 @@ export default function SharedTripPage() {
 
   return (
     <HydrationBoundary>
-      <main className="max-w-[1200px] mx-auto px-4 md:px-6 py-8 md:py-12">
-        <Suspense fallback={null}>
-          <SharedTripLoader code={code} />
-        </Suspense>
-      </main>
+      <Suspense fallback={null}>
+        <SharedTripLoader code={code} />
+      </Suspense>
     </HydrationBoundary>
   );
 }

--- a/pwa/src/app/s/[code]/shared-trip-page.tsx
+++ b/pwa/src/app/s/[code]/shared-trip-page.tsx
@@ -2,11 +2,10 @@
 
 import { useEffect, useMemo, useState, useCallback } from "react";
 import { useTranslations } from "next-intl";
-import Link from "next/link";
 import { useParams } from "next/navigation";
 import { Suspense } from "react";
-import { ArrowLeft, Info, Loader2 } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import { Info, Loader2 } from "lucide-react";
+import { TripNotFound } from "@/components/trip-not-found";
 import { Timeline } from "@/components/timeline";
 import { TripSummary } from "@/components/trip-summary";
 import { TripDownloads } from "@/components/trip-downloads";
@@ -165,16 +164,8 @@ function SharedTripLoader({ code }: { code: string }) {
 
   if (loadError) {
     return (
-      <div className="flex flex-col items-center justify-center min-h-[60vh] gap-4">
-        <p className="text-destructive" data-testid="share-error">
-          {t("error")}
-        </p>
-        <Button asChild variant="outline">
-          <Link href="/">
-            <ArrowLeft className="h-4 w-4 mr-2" />
-            {t("backToHome")}
-          </Link>
-        </Button>
+      <div data-testid="share-error">
+        <TripNotFound variant="share" />
       </div>
     );
   }

--- a/pwa/src/app/trips/[id]/trip-page.tsx
+++ b/pwa/src/app/trips/[id]/trip-page.tsx
@@ -2,14 +2,16 @@
 
 import { useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
-import Link from "next/link";
 import { useParams } from "next/navigation";
 import { useRouter } from "next/navigation";
 import { Suspense } from "react";
-import { ArrowLeft, Loader2 } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import { Loader2 } from "lucide-react";
 import { TripPlanner } from "@/components/trip-planner";
 import { TripPlannerErrorBoundary } from "@/components/trip-planner-error-boundary";
+import { TripNotFound } from "@/components/trip-not-found";
+import { TripSummarySkeleton } from "@/components/trip-summary-skeleton";
+import { TimelineSidebarSkeleton } from "@/components/timeline-sidebar-skeleton";
+import { StagePanelSkeleton } from "@/components/stage-panel-skeleton";
 import { HydrationBoundary } from "@/components/hydration-boundary";
 import { useTripStore } from "@/store/trip-store";
 import { useUiStore } from "@/store/ui-store";
@@ -173,25 +175,30 @@ function TripLoader({ tripId }: { tripId: string }) {
   ]);
 
   if (loadError) {
-    return (
-      <div className="flex flex-col items-center justify-center min-h-[60vh] gap-4">
-        <p className="text-destructive">{t("loadingError")}</p>
-        <Button asChild variant="outline">
-          <Link href="/trips">
-            <ArrowLeft className="h-4 w-4 mr-2" />
-            {t("backToList")}
-          </Link>
-        </Button>
-      </div>
-    );
+    return <TripNotFound />;
   }
 
   if (!isLoaded) {
     return (
-      <div className="flex items-center justify-center min-h-[60vh] gap-3 text-muted-foreground">
-        <Loader2 className="h-5 w-5 animate-spin" />
-        <span>{t("loading")}</span>
-      </div>
+      <main
+        className="max-w-[1200px] mx-auto px-4 md:px-6 py-8 md:py-12 space-y-6"
+        data-testid="trip-loading-skeleton"
+        aria-busy="true"
+      >
+        <TripSummarySkeleton />
+        <div className="flex items-center justify-center gap-3 text-muted-foreground text-sm">
+          <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+          <span>{t("loading")}</span>
+        </div>
+        <div className="flex flex-col gap-6 lg:flex-row lg:gap-8 lg:items-start">
+          <aside className="w-full lg:w-[260px] lg:shrink-0 rounded-xl border border-border bg-card/40 p-3 lg:p-4">
+            <TimelineSidebarSkeleton count={4} />
+          </aside>
+          <div className="flex-1 min-w-0">
+            <StagePanelSkeleton />
+          </div>
+        </div>
+      </main>
     );
   }
 

--- a/pwa/src/components/Timeline/StageDetailPanel.tsx
+++ b/pwa/src/components/Timeline/StageDetailPanel.tsx
@@ -3,9 +3,11 @@
 import { useCallback, useEffect, useRef } from "react";
 import { useTranslations } from "next-intl";
 import { StageCard } from "@/components/stage-card";
+import { StagePanelSkeleton } from "@/components/stage-panel-skeleton";
 import { StageSkeleton } from "@/components/stage-skeleton";
 import { RestDayCard } from "@/components/rest-day-card";
 import { NoDatesBanner } from "@/components/no-dates-banner";
+import { RoadbookEmptyState } from "@/components/roadbook-empty-state";
 import { AddStageButton } from "@/components/add-stage-button";
 import { AddRestDayButton } from "@/components/add-rest-day-button";
 import { useTripStore } from "@/store/trip-store";
@@ -88,7 +90,6 @@ export function StageDetailPanel({
   onClearNewAcc,
   onOpenConfig,
 }: StageDetailPanelProps) {
-  const t = useTranslations("timeline");
   const tStage = useTranslations("stage");
   const recomputingStages = useTripStore((s) => s.recomputingStages);
   const selectedRef = useRef<HTMLDivElement>(null);
@@ -111,12 +112,16 @@ export function StageDetailPanel({
   );
 
   if (stages.length === 0) {
+    if (isProcessing) {
+      return (
+        <div data-testid="stage-detail-loading">
+          <StagePanelSkeleton />
+        </div>
+      );
+    }
     return (
-      <div
-        className="rounded-xl border border-border bg-card p-6 text-sm text-muted-foreground"
-        data-testid="stage-detail-empty"
-      >
-        {t("noStageSelected")}
+      <div data-testid="stage-detail-empty">
+        <RoadbookEmptyState />
       </div>
     );
   }

--- a/pwa/src/components/Timeline/TimelineSidebar.tsx
+++ b/pwa/src/components/Timeline/TimelineSidebar.tsx
@@ -3,6 +3,7 @@
 import { useMemo } from "react";
 import { useTranslations } from "next-intl";
 import { BedDouble } from "lucide-react";
+import { TimelineSidebarSkeleton } from "@/components/timeline-sidebar-skeleton";
 import { cn } from "@/lib/utils";
 import type { StageData } from "@/lib/validation/schemas";
 
@@ -51,19 +52,7 @@ export function TimelineSidebar({
 
   if (stages.length === 0) {
     if (!isProcessing) return null;
-    return (
-      <nav
-        aria-label={t("loadingStages")}
-        className="relative flex flex-col gap-3 py-2"
-      >
-        {[0, 1, 2].map((i) => (
-          <div key={i} className="flex items-center gap-3 animate-pulse">
-            <div className="w-3 h-3 rounded-full bg-brand/40 shrink-0" />
-            <div className="h-3 w-32 rounded bg-muted" />
-          </div>
-        ))}
-      </nav>
-    );
+    return <TimelineSidebarSkeleton />;
   }
 
   return (

--- a/pwa/src/components/card-selection.tsx
+++ b/pwa/src/components/card-selection.tsx
@@ -8,8 +8,10 @@ import {
   type KeyboardEvent as ReactKeyboardEvent,
 } from "react";
 import { useTranslations } from "next-intl";
-import { Link2, FileUp, Sparkles, ArrowLeft, Upload } from "lucide-react";
+import { Link2, FileUp, Sparkles, ArrowLeft } from "lucide-react";
 import { AiChatCard, type AiChatMessage } from "@/components/ai-chat-card";
+import { GpxDropZoneCard } from "@/components/gpx-drop-zone-card";
+import { SourceUrlChip } from "@/components/source-url-chip";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -261,6 +263,9 @@ function LinkCard({ expanded, disabled, onSelect, onSubmit }: LinkCardProps) {
               {error}
             </p>
           )}
+          {!error && url.trim().length > 0 && (
+            <SourceUrlChip value={url} />
+          )}
         </div>
       )}
     </CardShell>
@@ -276,82 +281,41 @@ interface GpxCardProps {
 
 function GpxCard({ expanded, disabled, onSelect, onUpload }: GpxCardProps) {
   const t = useTranslations("cardSelection");
-  const [isDragOver, setIsDragOver] = useState(false);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
-  const fileInputRef = useRef<HTMLInputElement>(null);
-  const dropZoneRef = useRef<HTMLDivElement>(null);
-
-  // Auto-focus the drop zone when the card expands
-  useEffect(() => {
-    if (expanded) dropZoneRef.current?.focus();
-  }, [expanded]);
+  const [dropZoneState, setDropZoneState] = useState<
+    | { status: "idle" }
+    | { status: "uploading"; fileName: string; progress?: number | null }
+    | { status: "error"; message: string }
+  >({ status: "idle" });
 
   const handleFile = useCallback(
     async (file: File) => {
       setSelectedFile(file);
-      if (file.size > MAX_GPX_SIZE_BYTES) return;
-      await onUpload(file);
-    },
-    [onUpload],
-  );
-
-  const handleBrowse = useCallback(() => {
-    fileInputRef.current?.click();
-  }, []);
-
-  const handleInputChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      const file = e.target.files?.[0];
-      if (file && !file.name.toLowerCase().endsWith(".gpx")) {
-        setSelectedFile(file);
-      } else if (file) {
-        void handleFile(file);
-      }
-      if (fileInputRef.current) fileInputRef.current.value = "";
-    },
-    [handleFile],
-  );
-
-  const handleDragOver = useCallback(
-    (e: React.DragEvent<HTMLDivElement>) => {
-      e.preventDefault();
-      if (disabled) return;
-      if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
-      setIsDragOver(true);
-    },
-    [disabled],
-  );
-
-  const handleDragLeave = useCallback((e: React.DragEvent<HTMLDivElement>) => {
-    e.preventDefault();
-    if (e.currentTarget.contains(e.relatedTarget as Node | null)) return;
-    setIsDragOver(false);
-  }, []);
-
-  const handleDrop = useCallback(
-    (e: React.DragEvent<HTMLDivElement>) => {
-      e.preventDefault();
-      setIsDragOver(false);
-      if (disabled) return;
-      const file = e.dataTransfer?.files[0];
-      if (!file) return;
       if (!file.name.toLowerCase().endsWith(".gpx")) {
-        setSelectedFile(file);
+        setDropZoneState({ status: "error", message: t("gpxInvalidType") });
         return;
       }
-      void handleFile(file);
-    },
-    [disabled, handleFile],
-  );
-
-  const handleKeyDown = useCallback(
-    (e: ReactKeyboardEvent<HTMLDivElement>) => {
-      if (e.key === "Enter" || e.key === " ") {
-        e.preventDefault();
-        handleBrowse();
+      if (file.size > MAX_GPX_SIZE_BYTES) {
+        setDropZoneState({ status: "error", message: t("gpxFileTooLarge") });
+        return;
+      }
+      setDropZoneState({ status: "uploading", fileName: file.name });
+      try {
+        await onUpload(file);
+        // Caller is responsible for navigating away; if we're still mounted
+        // reset the state to idle so the user can retry if needed.
+        setDropZoneState({ status: "idle" });
+      } catch (e) {
+        setDropZoneState({
+          status: "error",
+          message:
+            e instanceof Error && e.message
+              ? e.message
+              : t("gpxUploadGenericError"),
+        });
       }
     },
-    [handleBrowse],
+    [onUpload, t],
   );
 
   const fileSizeMb = selectedFile
@@ -371,64 +335,16 @@ function GpxCard({ expanded, disabled, onSelect, onUpload }: GpxCardProps) {
     >
       {expanded && (
         <div className="flex flex-col gap-3 w-full">
-          <div
-            ref={dropZoneRef}
-            role="button"
-            tabIndex={0}
-            aria-label={t("gpxDescription")}
-            onClick={handleBrowse}
-            onKeyDown={handleKeyDown}
-            onDragOver={handleDragOver}
-            onDragLeave={handleDragLeave}
-            onDrop={handleDrop}
-            className={cn(
-              "flex flex-col items-center justify-center gap-2 rounded-lg border-2 border-dashed px-4 py-8 cursor-pointer transition-colors",
-              "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand",
-              isDragOver
-                ? "border-brand bg-brand/5"
-                : "border-muted-foreground/30 hover:border-brand/60 hover:bg-muted/20",
-              disabled && "cursor-not-allowed opacity-60",
-            )}
-            data-testid="card-gpx-dropzone"
-            data-drag-over={isDragOver}
-          >
-            <Upload
-              className="h-8 w-8 text-muted-foreground"
-              aria-hidden="true"
-            />
-            <p className="text-sm text-muted-foreground text-center">
-              {t("gpxDescription")}
-            </p>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={(e) => {
-                e.stopPropagation();
-                handleBrowse();
-              }}
-              disabled={disabled}
-              data-testid="card-gpx-browse"
-            >
-              {t("gpxBrowse")}
-            </Button>
-            <p className="text-xs text-muted-foreground/70">
-              {t("gpxSizeLimit")}
-            </p>
-          </div>
-
-          <input
-            ref={fileInputRef}
-            type="file"
-            accept=".gpx"
-            onChange={handleInputChange}
+          <GpxDropZoneCard
+            state={dropZoneState}
             disabled={disabled}
-            className="hidden"
-            data-testid="gpx-file-input"
-            aria-label={t("gpxTitle")}
+            maxBytes={MAX_GPX_SIZE_BYTES}
+            onFileSelected={(file) => void handleFile(file)}
+            dropZoneTestId="card-gpx-dropzone"
+            fileInputTestId="gpx-file-input"
           />
 
-          {selectedFile && (
+          {selectedFile && dropZoneState.status !== "uploading" && (
             <div
               className="flex items-center justify-between rounded-md border bg-muted/30 px-3 py-2 text-sm"
               data-testid="card-gpx-file-feedback"
@@ -447,18 +363,6 @@ function GpxCard({ expanded, disabled, onSelect, onUpload }: GpxCardProps) {
               </span>
             </div>
           )}
-
-          {selectedFile && selectedFile.size > MAX_GPX_SIZE_BYTES && (
-            <p className="text-sm text-destructive" role="alert">
-              {t("gpxFileTooLarge")}
-            </p>
-          )}
-          {selectedFile &&
-            !selectedFile.name.toLowerCase().endsWith(".gpx") && (
-              <p className="text-sm text-destructive" role="alert">
-                {t("gpxInvalidType")}
-              </p>
-            )}
         </div>
       )}
     </CardShell>

--- a/pwa/src/components/card-selection.tsx
+++ b/pwa/src/components/card-selection.tsx
@@ -263,9 +263,7 @@ function LinkCard({ expanded, disabled, onSelect, onSubmit }: LinkCardProps) {
               {error}
             </p>
           )}
-          {!error && url.trim().length > 0 && (
-            <SourceUrlChip value={url} />
-          )}
+          {!error && url.trim().length > 0 && <SourceUrlChip value={url} />}
         </div>
       )}
     </CardShell>

--- a/pwa/src/components/card-selection.tsx
+++ b/pwa/src/components/card-selection.tsx
@@ -285,6 +285,14 @@ function GpxCard({ expanded, disabled, onSelect, onUpload }: GpxCardProps) {
     | { status: "uploading"; fileName: string; progress?: number | null }
     | { status: "error"; message: string }
   >({ status: "idle" });
+  const dropZoneRef = useRef<HTMLDivElement>(null);
+
+  // Auto-focus the drop zone when the card expands so keyboard users
+  // don't have to tab again to reach it. Mirrors the LinkCard's
+  // auto-focus on its URL input.
+  useEffect(() => {
+    if (expanded) dropZoneRef.current?.focus();
+  }, [expanded]);
 
   const handleFile = useCallback(
     async (file: File) => {
@@ -334,6 +342,7 @@ function GpxCard({ expanded, disabled, onSelect, onUpload }: GpxCardProps) {
       {expanded && (
         <div className="flex flex-col gap-3 w-full">
           <GpxDropZoneCard
+            ref={dropZoneRef}
             state={dropZoneState}
             disabled={disabled}
             maxBytes={MAX_GPX_SIZE_BYTES}

--- a/pwa/src/components/destructive-dialog.test.tsx
+++ b/pwa/src/components/destructive-dialog.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { DestructiveDialog } from "./destructive-dialog";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string, params?: Record<string, string>) =>
+    params ? `${key}:${JSON.stringify(params)}` : key,
+}));
+
+describe("DestructiveDialog", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the title and description when open", () => {
+    render(
+      <DestructiveDialog
+        open
+        onOpenChange={() => {}}
+        title="Delete trip?"
+        description="This cannot be undone."
+        onConfirm={() => {}}
+      />,
+    );
+
+    expect(screen.getByText("Delete trip?")).toBeInTheDocument();
+    expect(screen.getByText("This cannot be undone.")).toBeInTheDocument();
+  });
+
+  it("invokes onConfirm when the destructive button is clicked (no keyword)", () => {
+    const onConfirm = vi.fn();
+    render(
+      <DestructiveDialog
+        open
+        onOpenChange={() => {}}
+        title="Delete?"
+        description="Gone forever."
+        onConfirm={onConfirm}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("destructive-dialog-confirm"));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables the destructive button until the keyword is typed", () => {
+    const onConfirm = vi.fn();
+    render(
+      <DestructiveDialog
+        open
+        onOpenChange={() => {}}
+        title="Delete account?"
+        description="All data will be lost."
+        confirmationKeyword="SUPPRIMER"
+        onConfirm={onConfirm}
+      />,
+    );
+
+    const button = screen.getByTestId(
+      "destructive-dialog-confirm",
+    ) as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+
+    const input = screen.getByTestId("destructive-dialog-keyword-input");
+    fireEvent.change(input, { target: { value: "wrong" } });
+    expect(button.disabled).toBe(true);
+
+    fireEvent.change(input, { target: { value: "SUPPRIMER" } });
+    expect(button.disabled).toBe(false);
+
+    fireEvent.click(button);
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("invokes onOpenChange(false) when the cancel button is clicked", () => {
+    const onOpenChange = vi.fn();
+    render(
+      <DestructiveDialog
+        open
+        onOpenChange={onOpenChange}
+        title="Delete?"
+        description="Gone forever."
+        onConfirm={() => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("destructive-dialog-cancel"));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/pwa/src/components/destructive-dialog.tsx
+++ b/pwa/src/components/destructive-dialog.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
+import { Loader2, AlertTriangle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+/**
+ * Reusable destructive confirmation dialog (sprint 27, issue #402).
+ *
+ * Used for high-risk actions that cannot be undone — such as deleting a trip
+ * or an account. When `confirmationKeyword` is provided, the user must type
+ * the keyword exactly into a text field before the destructive button is
+ * enabled (used for account deletion). Otherwise the destructive button is
+ * always active and the dialog is a simple "Cancel / Delete" confirmation.
+ */
+export interface DestructiveDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Title — must be explicit ("Delete this trip?"). */
+  title: string;
+  /** Description — explains the consequences of the action. */
+  description: React.ReactNode;
+  /**
+   * If provided, user must type this keyword (case-sensitive) before the
+   * destructive button activates. Used for highest-risk actions.
+   */
+  confirmationKeyword?: string;
+  /** Label for the confirmation input (only shown when keyword is set). */
+  confirmationLabel?: string;
+  /** Placeholder for the confirmation input. */
+  confirmationPlaceholder?: string;
+  /** Custom label for the cancel button. Defaults to translated "Cancel". */
+  cancelLabel?: string;
+  /** Custom label for the destructive button. Defaults to translated "Delete". */
+  confirmLabel?: string;
+  /** Called when the user confirms. May be async. */
+  onConfirm: () => void | Promise<void>;
+  /** When true, the destructive button shows a spinner and is disabled. */
+  isLoading?: boolean;
+  /** Optional test id to discriminate dialog instances. */
+  "data-testid"?: string;
+}
+
+export function DestructiveDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmationKeyword,
+  confirmationLabel,
+  confirmationPlaceholder,
+  cancelLabel,
+  confirmLabel,
+  onConfirm,
+  isLoading = false,
+  "data-testid": testId = "destructive-dialog",
+}: DestructiveDialogProps) {
+  const t = useTranslations("destructiveDialog");
+  const [typed, setTyped] = useState("");
+
+  // Reset the typed keyword whenever the dialog opens or closes so the
+  // confirmation can't be bypassed by reopening.
+  useEffect(() => {
+    if (!open) setTyped("");
+  }, [open]);
+
+  const requiresKeyword =
+    typeof confirmationKeyword === "string" && confirmationKeyword.length > 0;
+  const keywordSatisfied = !requiresKeyword || typed === confirmationKeyword;
+
+  const handleConfirm = useCallback(() => {
+    if (!keywordSatisfied || isLoading) return;
+    void onConfirm();
+  }, [keywordSatisfied, isLoading, onConfirm]);
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (isLoading) return;
+        onOpenChange(next);
+      }}
+    >
+      <DialogContent data-testid={testId}>
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <AlertTriangle
+              className="h-5 w-5 text-destructive shrink-0"
+              aria-hidden="true"
+            />
+            {title}
+          </DialogTitle>
+          <DialogDescription asChild>
+            <div className="space-y-2 text-muted-foreground text-sm">
+              {typeof description === "string" ? <p>{description}</p> : description}
+            </div>
+          </DialogDescription>
+        </DialogHeader>
+
+        {requiresKeyword && (
+          <div className="flex flex-col gap-2">
+            <label
+              htmlFor={`${testId}-keyword-input`}
+              className="text-sm font-medium text-foreground"
+            >
+              {confirmationLabel ??
+                t("typeKeyword", { keyword: confirmationKeyword })}
+            </label>
+            <Input
+              id={`${testId}-keyword-input`}
+              type="text"
+              autoComplete="off"
+              autoCorrect="off"
+              spellCheck={false}
+              value={typed}
+              onChange={(e) => setTyped(e.target.value)}
+              placeholder={
+                confirmationPlaceholder ?? confirmationKeyword
+              }
+              disabled={isLoading}
+              className={cn(
+                keywordSatisfied
+                  ? "ring-1 ring-destructive/30"
+                  : "ring-2 ring-destructive/20",
+              )}
+              data-testid={`${testId}-keyword-input`}
+              aria-invalid={!keywordSatisfied}
+            />
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isLoading}
+            data-testid={`${testId}-cancel`}
+          >
+            {cancelLabel ?? t("cancel")}
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={handleConfirm}
+            disabled={!keywordSatisfied || isLoading}
+            data-testid={`${testId}-confirm`}
+          >
+            {isLoading && (
+              <Loader2 className="h-4 w-4 mr-2 animate-spin" aria-hidden="true" />
+            )}
+            {confirmLabel ?? t("confirm")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/pwa/src/components/destructive-dialog.tsx
+++ b/pwa/src/components/destructive-dialog.tsx
@@ -137,7 +137,9 @@ export function DestructiveDialog({
                   : "ring-2 ring-destructive/20",
               )}
               data-testid={`${testId}-keyword-input`}
-              aria-invalid={!keywordSatisfied}
+              aria-invalid={
+                typed.length > 0 && !keywordSatisfied ? true : undefined
+              }
             />
           </div>
         )}

--- a/pwa/src/components/destructive-dialog.tsx
+++ b/pwa/src/components/destructive-dialog.tsx
@@ -103,7 +103,11 @@ export function DestructiveDialog({
           </DialogTitle>
           <DialogDescription asChild>
             <div className="space-y-2 text-muted-foreground text-sm">
-              {typeof description === "string" ? <p>{description}</p> : description}
+              {typeof description === "string" ? (
+                <p>{description}</p>
+              ) : (
+                description
+              )}
             </div>
           </DialogDescription>
         </DialogHeader>
@@ -125,9 +129,7 @@ export function DestructiveDialog({
               spellCheck={false}
               value={typed}
               onChange={(e) => setTyped(e.target.value)}
-              placeholder={
-                confirmationPlaceholder ?? confirmationKeyword
-              }
+              placeholder={confirmationPlaceholder ?? confirmationKeyword}
               disabled={isLoading}
               className={cn(
                 keywordSatisfied
@@ -156,7 +158,10 @@ export function DestructiveDialog({
             data-testid={`${testId}-confirm`}
           >
             {isLoading && (
-              <Loader2 className="h-4 w-4 mr-2 animate-spin" aria-hidden="true" />
+              <Loader2
+                className="h-4 w-4 mr-2 animate-spin"
+                aria-hidden="true"
+              />
             )}
             {confirmLabel ?? t("confirm")}
           </Button>

--- a/pwa/src/components/destructive-dialog.tsx
+++ b/pwa/src/components/destructive-dialog.tsx
@@ -133,8 +133,8 @@ export function DestructiveDialog({
               disabled={isLoading}
               className={cn(
                 keywordSatisfied
-                  ? "ring-1 ring-destructive/30"
-                  : "ring-2 ring-destructive/20",
+                  ? "ring-1 ring-green-500/60 dark:ring-green-400/50"
+                  : "ring-2 ring-destructive/40",
               )}
               data-testid={`${testId}-keyword-input`}
               aria-invalid={

--- a/pwa/src/components/gpx-drop-zone-card.test.tsx
+++ b/pwa/src/components/gpx-drop-zone-card.test.tsx
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { GpxDropZoneCard } from "./gpx-drop-zone-card";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string, params?: Record<string, string>) =>
+    params ? `${key}:${JSON.stringify(params)}` : key,
+}));
+
+/**
+ * Helper: locate the inner role="button" drop zone div within a render.
+ * The outer wrapper exposes the `data-testid` from `dropZoneTestId`; the
+ * actual interactive zone is the first descendant with role="button".
+ */
+function getDropZone(): HTMLElement {
+  return screen.getByRole("button", { name: "ariaLabel" });
+}
+
+function getHiddenFileInput(): HTMLInputElement {
+  return screen.getByTestId("gpx-drop-zone-input") as HTMLInputElement;
+}
+
+function makeGpxFile(name = "trip.gpx"): File {
+  return new File(["<gpx/>"], name, { type: "application/gpx+xml" });
+}
+
+describe("GpxDropZoneCard", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the idle state by default with the upload icon and idle copy", () => {
+    render(<GpxDropZoneCard onFileSelected={() => {}} />);
+    const wrapper = screen.getByTestId("gpx-drop-zone-card");
+    expect(wrapper).toHaveAttribute("data-status", "idle");
+    expect(screen.getByText("idle")).toBeInTheDocument();
+    expect(screen.getByTestId("gpx-drop-zone-browse")).toBeInTheDocument();
+  });
+
+  it("switches to the hovering state on dragover and clears it on dragleave", () => {
+    render(<GpxDropZoneCard onFileSelected={() => {}} />);
+    const wrapper = screen.getByTestId("gpx-drop-zone-card");
+    const zone = getDropZone();
+
+    fireEvent.dragOver(zone);
+    expect(wrapper).toHaveAttribute("data-status", "hovering");
+    expect(wrapper).toHaveAttribute("data-drag-over", "true");
+
+    fireEvent.dragLeave(zone);
+    expect(wrapper).toHaveAttribute("data-status", "idle");
+    expect(wrapper).not.toHaveAttribute("data-drag-over");
+  });
+
+  it("calls onFileSelected with the dropped file", () => {
+    const onFileSelected = vi.fn();
+    render(<GpxDropZoneCard onFileSelected={onFileSelected} />);
+    const file = makeGpxFile();
+    const zone = getDropZone();
+
+    fireEvent.drop(zone, { dataTransfer: { files: [file] } });
+    expect(onFileSelected).toHaveBeenCalledTimes(1);
+    expect(onFileSelected).toHaveBeenCalledWith(file);
+  });
+
+  it("calls onFileSelected when the hidden file input changes", () => {
+    const onFileSelected = vi.fn();
+    render(<GpxDropZoneCard onFileSelected={onFileSelected} />);
+    const file = makeGpxFile("from-input.gpx");
+    const input = getHiddenFileInput();
+
+    fireEvent.change(input, { target: { files: [file] } });
+    expect(onFileSelected).toHaveBeenCalledWith(file);
+  });
+
+  it("renders the uploading state non-interactively with file name and progress", () => {
+    render(
+      <GpxDropZoneCard
+        onFileSelected={() => {}}
+        state={{ status: "uploading", fileName: "trip.gpx", progress: 42 }}
+      />,
+    );
+    const wrapper = screen.getByTestId("gpx-drop-zone-card");
+    expect(wrapper).toHaveAttribute("data-status", "uploading");
+
+    const zone = getDropZone();
+    expect(zone).toHaveAttribute("tabIndex", "-1");
+    expect(zone).toHaveAttribute("aria-busy", "true");
+
+    expect(
+      screen.getByTestId("gpx-drop-zone-uploading-name"),
+    ).toHaveTextContent("trip.gpx");
+    const progressBar = screen.getByRole("progressbar");
+    expect(progressBar).toHaveAttribute("aria-valuenow", "42");
+  });
+
+  it("ignores drops while uploading", () => {
+    const onFileSelected = vi.fn();
+    render(
+      <GpxDropZoneCard
+        onFileSelected={onFileSelected}
+        state={{ status: "uploading", fileName: "busy.gpx" }}
+      />,
+    );
+    const zone = getDropZone();
+    fireEvent.drop(zone, { dataTransfer: { files: [makeGpxFile()] } });
+    expect(onFileSelected).not.toHaveBeenCalled();
+  });
+
+  it("renders the error state with a retry button that triggers the file picker", () => {
+    const onFileSelected = vi.fn();
+    render(
+      <GpxDropZoneCard
+        onFileSelected={onFileSelected}
+        state={{ status: "error", message: "Format invalide" }}
+      />,
+    );
+    const wrapper = screen.getByTestId("gpx-drop-zone-card");
+    expect(wrapper).toHaveAttribute("data-status", "error");
+
+    expect(screen.getByTestId("gpx-drop-zone-error")).toHaveTextContent(
+      "Format invalide",
+    );
+
+    const retry = screen.getByTestId("gpx-drop-zone-retry");
+    const input = getHiddenFileInput();
+    const clickSpy = vi.spyOn(input, "click");
+
+    fireEvent.click(retry);
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("triggers the hidden file input on Enter and Space when focused on the drop zone", () => {
+    render(<GpxDropZoneCard onFileSelected={() => {}} />);
+    const zone = getDropZone();
+    const input = getHiddenFileInput();
+    const clickSpy = vi.spyOn(input, "click");
+
+    fireEvent.keyDown(zone, { key: "Enter" });
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+
+    fireEvent.keyDown(zone, { key: " " });
+    expect(clickSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("forwards the ref to the inner drop zone element", () => {
+    const ref = { current: null as HTMLDivElement | null };
+    render(<GpxDropZoneCard ref={ref} onFileSelected={() => {}} />);
+    expect(ref.current).not.toBeNull();
+    expect(ref.current).toHaveAttribute("role", "button");
+  });
+});

--- a/pwa/src/components/gpx-drop-zone-card.tsx
+++ b/pwa/src/components/gpx-drop-zone-card.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  forwardRef,
   useCallback,
   useEffect,
   useRef,
@@ -48,244 +49,257 @@ interface GpxDropZoneCardProps {
  * UI that used to live inline in {@link CardSelection}'s GPX card. The
  * component is purely presentational for the upload/error states — the
  * parent decides when to switch into them via the `state` prop.
+ *
+ * The forwarded ref targets the inner role="button" drop zone div so
+ * callers can programmatically focus it (e.g. when the parent card
+ * expands).
  */
-export function GpxDropZoneCard({
-  state = { status: "idle" },
-  disabled = false,
-  onFileSelected,
-  maxBytes,
-  className,
-  dropZoneTestId = "gpx-drop-zone-card",
-  fileInputTestId = "gpx-drop-zone-input",
-}: GpxDropZoneCardProps) {
-  const t = useTranslations("gpxDropZone");
-  const fileInputRef = useRef<HTMLInputElement>(null);
-  const [isDragOver, setIsDragOver] = useState(false);
-
-  // Effective visual state: a local "hovering" overrides the parent-driven
-  // "idle" state so we can show the hover styling without round-tripping.
-  const effectiveStatus =
-    state.status === "idle" && isDragOver ? "hovering" : state.status;
-
-  const handleBrowse = useCallback(() => {
-    if (disabled || state.status === "uploading") return;
-    fileInputRef.current?.click();
-  }, [disabled, state.status]);
-
-  const handleInputChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      const file = e.target.files?.[0];
-      if (file) onFileSelected(file);
-      if (fileInputRef.current) fileInputRef.current.value = "";
+export const GpxDropZoneCard = forwardRef<HTMLDivElement, GpxDropZoneCardProps>(
+  function GpxDropZoneCard(
+    {
+      state = { status: "idle" },
+      disabled = false,
+      onFileSelected,
+      maxBytes,
+      className,
+      dropZoneTestId = "gpx-drop-zone-card",
+      fileInputTestId = "gpx-drop-zone-input",
     },
-    [onFileSelected],
-  );
+    ref,
+  ) {
+    const t = useTranslations("gpxDropZone");
+    const fileInputRef = useRef<HTMLInputElement>(null);
+    const [isDragOver, setIsDragOver] = useState(false);
 
-  const handleDragOver = useCallback(
-    (e: React.DragEvent<HTMLDivElement>) => {
-      e.preventDefault();
+    // Effective visual state: a local "hovering" overrides the parent-driven
+    // "idle" state so we can show the hover styling without round-tripping.
+    const effectiveStatus =
+      state.status === "idle" && isDragOver ? "hovering" : state.status;
+
+    const handleBrowse = useCallback(() => {
       if (disabled || state.status === "uploading") return;
-      if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
-      setIsDragOver(true);
-    },
-    [disabled, state.status],
-  );
+      fileInputRef.current?.click();
+    }, [disabled, state.status]);
 
-  const handleDragLeave = useCallback((e: React.DragEvent<HTMLDivElement>) => {
-    e.preventDefault();
-    if (e.currentTarget.contains(e.relatedTarget as Node | null)) return;
-    setIsDragOver(false);
-  }, []);
+    const handleInputChange = useCallback(
+      (e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0];
+        if (file) onFileSelected(file);
+        if (fileInputRef.current) fileInputRef.current.value = "";
+      },
+      [onFileSelected],
+    );
 
-  const handleDrop = useCallback(
-    (e: React.DragEvent<HTMLDivElement>) => {
-      e.preventDefault();
-      setIsDragOver(false);
-      if (disabled || state.status === "uploading") return;
-      const file = e.dataTransfer?.files[0];
-      if (file) onFileSelected(file);
-    },
-    [disabled, state.status, onFileSelected],
-  );
-
-  const handleKeyDown = useCallback(
-    (e: ReactKeyboardEvent<HTMLDivElement>) => {
-      if (e.key === "Enter" || e.key === " ") {
+    const handleDragOver = useCallback(
+      (e: React.DragEvent<HTMLDivElement>) => {
         e.preventDefault();
-        handleBrowse();
-      }
-    },
-    [handleBrowse],
-  );
+        if (disabled || state.status === "uploading") return;
+        if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
+        setIsDragOver(true);
+      },
+      [disabled, state.status],
+    );
 
-  // Reset local hover state if the upload starts (e.g. via file picker)
-  useEffect(() => {
-    if (state.status === "uploading") setIsDragOver(false);
-  }, [state.status]);
+    const handleDragLeave = useCallback(
+      (e: React.DragEvent<HTMLDivElement>) => {
+        e.preventDefault();
+        if (e.currentTarget.contains(e.relatedTarget as Node | null)) return;
+        setIsDragOver(false);
+      },
+      [],
+    );
 
-  const sizeHintMb = maxBytes
-    ? Math.round(maxBytes / (1024 * 1024)).toString()
-    : null;
+    const handleDrop = useCallback(
+      (e: React.DragEvent<HTMLDivElement>) => {
+        e.preventDefault();
+        setIsDragOver(false);
+        if (disabled || state.status === "uploading") return;
+        const file = e.dataTransfer?.files[0];
+        if (file) onFileSelected(file);
+      },
+      [disabled, state.status, onFileSelected],
+    );
 
-  return (
-    <div
-      className={cn("flex flex-col gap-2", className)}
-      data-testid={dropZoneTestId}
-      data-status={effectiveStatus}
-      data-drag-over={effectiveStatus === "hovering" ? true : undefined}
-    >
+    const handleKeyDown = useCallback(
+      (e: ReactKeyboardEvent<HTMLDivElement>) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          handleBrowse();
+        }
+      },
+      [handleBrowse],
+    );
+
+    // Reset local hover state if the upload starts (e.g. via file picker)
+    useEffect(() => {
+      if (state.status === "uploading") setIsDragOver(false);
+    }, [state.status]);
+
+    const sizeHintMb = maxBytes
+      ? Math.round(maxBytes / (1024 * 1024)).toString()
+      : null;
+
+    return (
       <div
-        role="button"
-        tabIndex={effectiveStatus === "uploading" || disabled ? -1 : 0}
-        aria-label={t("ariaLabel")}
-        aria-disabled={disabled || undefined}
-        aria-busy={effectiveStatus === "uploading" || undefined}
-        aria-invalid={effectiveStatus === "error" || undefined}
-        onClick={handleBrowse}
-        onKeyDown={handleKeyDown}
-        onDragOver={handleDragOver}
-        onDragLeave={handleDragLeave}
-        onDrop={handleDrop}
-        className={cn(
-          "flex flex-col items-center justify-center gap-2 rounded-lg border-2 px-4 py-8 transition-colors text-center",
-          "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand",
-          // Idle: dashed muted border
-          effectiveStatus === "idle" &&
-            "border-dashed border-muted-foreground/30 bg-background hover:border-brand/60 hover:bg-muted/20 cursor-pointer",
-          // Hovering: solid brand border + soft accent fill
-          effectiveStatus === "hovering" &&
-            "border-solid border-brand bg-brand/5 cursor-copy",
-          // Uploading: solid muted border, busy cursor
-          effectiveStatus === "uploading" &&
-            "border-solid border-muted-foreground/40 bg-muted/30 cursor-progress",
-          // Error: solid red border + soft red fill
-          effectiveStatus === "error" &&
-            "border-solid border-destructive/70 bg-destructive/5 cursor-pointer",
-          disabled && "cursor-not-allowed opacity-60",
-        )}
+        className={cn("flex flex-col gap-2", className)}
+        data-testid={dropZoneTestId}
+        data-status={effectiveStatus}
+        data-drag-over={effectiveStatus === "hovering" ? true : undefined}
       >
-        {effectiveStatus === "uploading" ? (
-          <Loader2
-            className="h-8 w-8 text-brand animate-spin"
-            aria-hidden="true"
-          />
-        ) : effectiveStatus === "error" ? (
-          <AlertCircle
-            className="h-8 w-8 text-destructive"
-            aria-hidden="true"
-          />
-        ) : (
-          <Upload
-            className={cn(
-              "h-8 w-8",
-              effectiveStatus === "hovering"
-                ? "text-brand"
-                : "text-muted-foreground",
-            )}
-            aria-hidden="true"
-          />
-        )}
+        <div
+          ref={ref}
+          role="button"
+          tabIndex={effectiveStatus === "uploading" || disabled ? -1 : 0}
+          aria-label={t("ariaLabel")}
+          aria-disabled={disabled || undefined}
+          aria-busy={effectiveStatus === "uploading" || undefined}
+          aria-invalid={effectiveStatus === "error" || undefined}
+          onClick={handleBrowse}
+          onKeyDown={handleKeyDown}
+          onDragOver={handleDragOver}
+          onDragLeave={handleDragLeave}
+          onDrop={handleDrop}
+          className={cn(
+            "flex flex-col items-center justify-center gap-2 rounded-lg border-2 px-4 py-8 transition-colors text-center",
+            "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand",
+            // Idle: dashed muted border
+            effectiveStatus === "idle" &&
+              "border-dashed border-muted-foreground/30 bg-background hover:border-brand/60 hover:bg-muted/20 cursor-pointer",
+            // Hovering: solid brand border + soft accent fill
+            effectiveStatus === "hovering" &&
+              "border-solid border-brand bg-brand/5 cursor-copy",
+            // Uploading: solid muted border, busy cursor
+            effectiveStatus === "uploading" &&
+              "border-solid border-muted-foreground/40 bg-muted/30 cursor-progress",
+            // Error: solid red border + soft red fill
+            effectiveStatus === "error" &&
+              "border-solid border-destructive/70 bg-destructive/5 cursor-pointer",
+            disabled && "cursor-not-allowed opacity-60",
+          )}
+        >
+          {effectiveStatus === "uploading" ? (
+            <Loader2
+              className="h-8 w-8 text-brand animate-spin"
+              aria-hidden="true"
+            />
+          ) : effectiveStatus === "error" ? (
+            <AlertCircle
+              className="h-8 w-8 text-destructive"
+              aria-hidden="true"
+            />
+          ) : (
+            <Upload
+              className={cn(
+                "h-8 w-8",
+                effectiveStatus === "hovering"
+                  ? "text-brand"
+                  : "text-muted-foreground",
+              )}
+              aria-hidden="true"
+            />
+          )}
 
-        {effectiveStatus === "uploading" && state.status === "uploading" ? (
-          <div className="w-full max-w-xs flex flex-col gap-1.5 items-center">
-            <div className="flex items-center gap-2 text-sm text-foreground max-w-full">
-              <FileText className="h-4 w-4 shrink-0" aria-hidden="true" />
-              <span
-                className="truncate font-medium"
-                data-testid="gpx-drop-zone-uploading-name"
-              >
-                {state.fileName}
-              </span>
-            </div>
-            <div
-              className="w-full h-1.5 rounded-full bg-muted overflow-hidden"
-              role="progressbar"
-              aria-valuemin={0}
-              aria-valuemax={100}
-              aria-valuenow={
-                typeof state.progress === "number"
-                  ? Math.round(state.progress)
-                  : undefined
-              }
-              aria-label={t("ariaProgress")}
-            >
+          {effectiveStatus === "uploading" && state.status === "uploading" ? (
+            <div className="w-full max-w-xs flex flex-col gap-1.5 items-center">
+              <div className="flex items-center gap-2 text-sm text-foreground max-w-full">
+                <FileText className="h-4 w-4 shrink-0" aria-hidden="true" />
+                <span
+                  className="truncate font-medium"
+                  data-testid="gpx-drop-zone-uploading-name"
+                >
+                  {state.fileName}
+                </span>
+              </div>
               <div
-                className={cn(
-                  "h-full bg-brand transition-[width] duration-200",
-                  typeof state.progress !== "number" &&
-                    "animate-[indeterminate_1.5s_ease-in-out_infinite]",
-                )}
-                style={
+                className="w-full h-1.5 rounded-full bg-muted overflow-hidden"
+                role="progressbar"
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-valuenow={
                   typeof state.progress === "number"
-                    ? {
-                        width: `${Math.min(100, Math.max(0, state.progress))}%`,
-                      }
-                    : { width: "40%" }
+                    ? Math.round(state.progress)
+                    : undefined
                 }
-              />
+                aria-label={t("ariaProgress")}
+              >
+                <div
+                  className={cn(
+                    "h-full bg-brand transition-[width] duration-200",
+                    typeof state.progress !== "number" &&
+                      "animate-[indeterminate_1.5s_ease-in-out_infinite]",
+                  )}
+                  style={
+                    typeof state.progress === "number"
+                      ? {
+                          width: `${Math.min(100, Math.max(0, state.progress))}%`,
+                        }
+                      : { width: "40%" }
+                  }
+                />
+              </div>
+              <p className="text-xs text-muted-foreground">{t("uploading")}</p>
             </div>
-            <p className="text-xs text-muted-foreground">{t("uploading")}</p>
-          </div>
-        ) : effectiveStatus === "error" && state.status === "error" ? (
-          <>
-            <p
-              className="text-sm font-medium text-destructive"
-              data-testid="gpx-drop-zone-error"
-              role="alert"
-            >
-              {state.message}
-            </p>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={(e) => {
-                e.stopPropagation();
-                handleBrowse();
-              }}
-              disabled={disabled}
-              data-testid="gpx-drop-zone-retry"
-            >
-              {t("retry")}
-            </Button>
-          </>
-        ) : (
-          <>
-            <p className="text-sm text-muted-foreground">
-              {t(effectiveStatus === "hovering" ? "release" : "idle")}
-            </p>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={(e) => {
-                e.stopPropagation();
-                handleBrowse();
-              }}
-              disabled={disabled}
-              data-testid="gpx-drop-zone-browse"
-            >
-              {t("browse")}
-            </Button>
-            {sizeHintMb && (
-              <p className="text-xs text-muted-foreground/70">
-                {t("sizeLimit", { size: sizeHintMb })}
+          ) : effectiveStatus === "error" && state.status === "error" ? (
+            <>
+              <p
+                className="text-sm font-medium text-destructive"
+                data-testid="gpx-drop-zone-error"
+                role="alert"
+              >
+                {state.message}
               </p>
-            )}
-          </>
-        )}
-      </div>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleBrowse();
+                }}
+                disabled={disabled}
+                data-testid="gpx-drop-zone-retry"
+              >
+                {t("retry")}
+              </Button>
+            </>
+          ) : (
+            <>
+              <p className="text-sm text-muted-foreground">
+                {t(effectiveStatus === "hovering" ? "release" : "idle")}
+              </p>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleBrowse();
+                }}
+                disabled={disabled}
+                data-testid="gpx-drop-zone-browse"
+              >
+                {t("browse")}
+              </Button>
+              {sizeHintMb && (
+                <p className="text-xs text-muted-foreground/70">
+                  {t("sizeLimit", { size: sizeHintMb })}
+                </p>
+              )}
+            </>
+          )}
+        </div>
 
-      <input
-        ref={fileInputRef}
-        type="file"
-        accept=".gpx"
-        onChange={handleInputChange}
-        disabled={disabled || effectiveStatus === "uploading"}
-        className="hidden"
-        data-testid={fileInputTestId}
-        aria-label={t("ariaLabel")}
-      />
-    </div>
-  );
-}
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept=".gpx"
+          onChange={handleInputChange}
+          disabled={disabled || effectiveStatus === "uploading"}
+          className="hidden"
+          data-testid={fileInputTestId}
+          aria-label={t("ariaLabel")}
+        />
+      </div>
+    );
+  },
+);

--- a/pwa/src/components/gpx-drop-zone-card.tsx
+++ b/pwa/src/components/gpx-drop-zone-card.tsx
@@ -217,7 +217,9 @@ export function GpxDropZoneCard({
                 )}
                 style={
                   typeof state.progress === "number"
-                    ? { width: `${Math.min(100, Math.max(0, state.progress))}%` }
+                    ? {
+                        width: `${Math.min(100, Math.max(0, state.progress))}%`,
+                      }
                     : { width: "40%" }
                 }
               />

--- a/pwa/src/components/gpx-drop-zone-card.tsx
+++ b/pwa/src/components/gpx-drop-zone-card.tsx
@@ -17,12 +17,22 @@ import { cn } from "@/lib/utils";
  * Discrete states the drop zone can be in. Drives both visual styling and
  * accessibility annotations (aria-busy / aria-invalid). Using a discriminated
  * union avoids juggling several boolean flags ("isUploading", "hasError"…).
+ *
+ * The `"hovering"` visual state is intentionally NOT part of this public
+ * union: it is purely a local, drag-event-driven display value (see
+ * `EffectiveStatus` below). Exposing it would let callers force the UI into
+ * a stuck "hovering" look that would never react to actual drag events.
  */
 export type GpxDropZoneState =
   | { status: "idle" }
-  | { status: "hovering" }
   | { status: "uploading"; fileName: string; progress?: number | null }
   | { status: "error"; message: string };
+
+/**
+ * Internal display value: the public statuses plus the locally-derived
+ * `"hovering"` state. Kept private to this module on purpose.
+ */
+type EffectiveStatus = GpxDropZoneState["status"] | "hovering";
 
 interface GpxDropZoneCardProps {
   /** External state if the parent wants to drive uploading/error UI. */
@@ -73,7 +83,7 @@ export const GpxDropZoneCard = forwardRef<HTMLDivElement, GpxDropZoneCardProps>(
 
     // Effective visual state: a local "hovering" overrides the parent-driven
     // "idle" state so we can show the hover styling without round-tripping.
-    const effectiveStatus =
+    const effectiveStatus: EffectiveStatus =
       state.status === "idle" && isDragOver ? "hovering" : state.status;
 
     const handleBrowse = useCallback(() => {

--- a/pwa/src/components/gpx-drop-zone-card.tsx
+++ b/pwa/src/components/gpx-drop-zone-card.tsx
@@ -38,7 +38,7 @@ interface GpxDropZoneCardProps {
   /** External state if the parent wants to drive uploading/error UI. */
   state?: GpxDropZoneState;
   disabled?: boolean;
-  /** Called with a valid GPX File once the user picks or drops one. */
+  /** Called with the selected or dropped file. Caller is responsible for type and size validation. */
   onFileSelected: (file: File) => void;
   /** Maximum file size in bytes — used only for the visual hint text. */
   maxBytes?: number;

--- a/pwa/src/components/gpx-drop-zone-card.tsx
+++ b/pwa/src/components/gpx-drop-zone-card.tsx
@@ -1,0 +1,289 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from "react";
+import { useTranslations } from "next-intl";
+import { Upload, FileText, AlertCircle, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+/**
+ * Discrete states the drop zone can be in. Drives both visual styling and
+ * accessibility annotations (aria-busy / aria-invalid). Using a discriminated
+ * union avoids juggling several boolean flags ("isUploading", "hasError"…).
+ */
+export type GpxDropZoneState =
+  | { status: "idle" }
+  | { status: "hovering" }
+  | { status: "uploading"; fileName: string; progress?: number | null }
+  | { status: "error"; message: string };
+
+interface GpxDropZoneCardProps {
+  /** External state if the parent wants to drive uploading/error UI. */
+  state?: GpxDropZoneState;
+  disabled?: boolean;
+  /** Called with a valid GPX File once the user picks or drops one. */
+  onFileSelected: (file: File) => void;
+  /** Maximum file size in bytes — used only for the visual hint text. */
+  maxBytes?: number;
+  className?: string;
+  /**
+   * Optional override for the drop-zone test id. Defaults to
+   * "gpx-drop-zone-card" but legacy callers may pin this to
+   * "card-gpx-dropzone" to keep existing E2E selectors working.
+   */
+  dropZoneTestId?: string;
+  /** Optional override for the hidden file input test id. */
+  fileInputTestId?: string;
+}
+
+/**
+ * Inline GPX drop zone with four explicit visual states (sprint 27, #402):
+ * `idle`, `hovering`, `uploading`, `error`. Replaces the ad-hoc drop zone
+ * UI that used to live inline in {@link CardSelection}'s GPX card. The
+ * component is purely presentational for the upload/error states — the
+ * parent decides when to switch into them via the `state` prop.
+ */
+export function GpxDropZoneCard({
+  state = { status: "idle" },
+  disabled = false,
+  onFileSelected,
+  maxBytes,
+  className,
+  dropZoneTestId = "gpx-drop-zone-card",
+  fileInputTestId = "gpx-drop-zone-input",
+}: GpxDropZoneCardProps) {
+  const t = useTranslations("gpxDropZone");
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [isDragOver, setIsDragOver] = useState(false);
+
+  // Effective visual state: a local "hovering" overrides the parent-driven
+  // "idle" state so we can show the hover styling without round-tripping.
+  const effectiveStatus =
+    state.status === "idle" && isDragOver ? "hovering" : state.status;
+
+  const handleBrowse = useCallback(() => {
+    if (disabled || state.status === "uploading") return;
+    fileInputRef.current?.click();
+  }, [disabled, state.status]);
+
+  const handleInputChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (file) onFileSelected(file);
+      if (fileInputRef.current) fileInputRef.current.value = "";
+    },
+    [onFileSelected],
+  );
+
+  const handleDragOver = useCallback(
+    (e: React.DragEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      if (disabled || state.status === "uploading") return;
+      if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
+      setIsDragOver(true);
+    },
+    [disabled, state.status],
+  );
+
+  const handleDragLeave = useCallback((e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    if (e.currentTarget.contains(e.relatedTarget as Node | null)) return;
+    setIsDragOver(false);
+  }, []);
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      setIsDragOver(false);
+      if (disabled || state.status === "uploading") return;
+      const file = e.dataTransfer?.files[0];
+      if (file) onFileSelected(file);
+    },
+    [disabled, state.status, onFileSelected],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: ReactKeyboardEvent<HTMLDivElement>) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        handleBrowse();
+      }
+    },
+    [handleBrowse],
+  );
+
+  // Reset local hover state if the upload starts (e.g. via file picker)
+  useEffect(() => {
+    if (state.status === "uploading") setIsDragOver(false);
+  }, [state.status]);
+
+  const sizeHintMb = maxBytes
+    ? Math.round(maxBytes / (1024 * 1024)).toString()
+    : null;
+
+  return (
+    <div
+      className={cn("flex flex-col gap-2", className)}
+      data-testid={dropZoneTestId}
+      data-status={effectiveStatus}
+      data-drag-over={effectiveStatus === "hovering" ? true : undefined}
+    >
+      <div
+        role="button"
+        tabIndex={effectiveStatus === "uploading" || disabled ? -1 : 0}
+        aria-label={t("ariaLabel")}
+        aria-disabled={disabled || undefined}
+        aria-busy={effectiveStatus === "uploading" || undefined}
+        aria-invalid={effectiveStatus === "error" || undefined}
+        onClick={handleBrowse}
+        onKeyDown={handleKeyDown}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+        className={cn(
+          "flex flex-col items-center justify-center gap-2 rounded-lg border-2 px-4 py-8 transition-colors text-center",
+          "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand",
+          // Idle: dashed muted border
+          effectiveStatus === "idle" &&
+            "border-dashed border-muted-foreground/30 bg-background hover:border-brand/60 hover:bg-muted/20 cursor-pointer",
+          // Hovering: solid brand border + soft accent fill
+          effectiveStatus === "hovering" &&
+            "border-solid border-brand bg-brand/5 cursor-copy",
+          // Uploading: solid muted border, busy cursor
+          effectiveStatus === "uploading" &&
+            "border-solid border-muted-foreground/40 bg-muted/30 cursor-progress",
+          // Error: solid red border + soft red fill
+          effectiveStatus === "error" &&
+            "border-solid border-destructive/70 bg-destructive/5 cursor-pointer",
+          disabled && "cursor-not-allowed opacity-60",
+        )}
+      >
+        {effectiveStatus === "uploading" ? (
+          <Loader2
+            className="h-8 w-8 text-brand animate-spin"
+            aria-hidden="true"
+          />
+        ) : effectiveStatus === "error" ? (
+          <AlertCircle
+            className="h-8 w-8 text-destructive"
+            aria-hidden="true"
+          />
+        ) : (
+          <Upload
+            className={cn(
+              "h-8 w-8",
+              effectiveStatus === "hovering"
+                ? "text-brand"
+                : "text-muted-foreground",
+            )}
+            aria-hidden="true"
+          />
+        )}
+
+        {effectiveStatus === "uploading" && state.status === "uploading" ? (
+          <div className="w-full max-w-xs flex flex-col gap-1.5 items-center">
+            <div className="flex items-center gap-2 text-sm text-foreground max-w-full">
+              <FileText className="h-4 w-4 shrink-0" aria-hidden="true" />
+              <span
+                className="truncate font-medium"
+                data-testid="gpx-drop-zone-uploading-name"
+              >
+                {state.fileName}
+              </span>
+            </div>
+            <div
+              className="w-full h-1.5 rounded-full bg-muted overflow-hidden"
+              role="progressbar"
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-valuenow={
+                typeof state.progress === "number"
+                  ? Math.round(state.progress)
+                  : undefined
+              }
+              aria-label={t("ariaProgress")}
+            >
+              <div
+                className={cn(
+                  "h-full bg-brand transition-[width] duration-200",
+                  typeof state.progress !== "number" &&
+                    "animate-[indeterminate_1.5s_ease-in-out_infinite]",
+                )}
+                style={
+                  typeof state.progress === "number"
+                    ? { width: `${Math.min(100, Math.max(0, state.progress))}%` }
+                    : { width: "40%" }
+                }
+              />
+            </div>
+            <p className="text-xs text-muted-foreground">{t("uploading")}</p>
+          </div>
+        ) : effectiveStatus === "error" && state.status === "error" ? (
+          <>
+            <p
+              className="text-sm font-medium text-destructive"
+              data-testid="gpx-drop-zone-error"
+              role="alert"
+            >
+              {state.message}
+            </p>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={(e) => {
+                e.stopPropagation();
+                handleBrowse();
+              }}
+              disabled={disabled}
+              data-testid="gpx-drop-zone-retry"
+            >
+              {t("retry")}
+            </Button>
+          </>
+        ) : (
+          <>
+            <p className="text-sm text-muted-foreground">
+              {t(effectiveStatus === "hovering" ? "release" : "idle")}
+            </p>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={(e) => {
+                e.stopPropagation();
+                handleBrowse();
+              }}
+              disabled={disabled}
+              data-testid="gpx-drop-zone-browse"
+            >
+              {t("browse")}
+            </Button>
+            {sizeHintMb && (
+              <p className="text-xs text-muted-foreground/70">
+                {t("sizeLimit", { size: sizeHintMb })}
+              </p>
+            )}
+          </>
+        )}
+      </div>
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".gpx"
+        onChange={handleInputChange}
+        disabled={disabled || effectiveStatus === "uploading"}
+        className="hidden"
+        data-testid={fileInputTestId}
+        aria-label={t("ariaLabel")}
+      />
+    </div>
+  );
+}

--- a/pwa/src/components/roadbook-empty-state.tsx
+++ b/pwa/src/components/roadbook-empty-state.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+
+/**
+ * Empty-state placeholder for an empty roadbook (sprint 27, #402).
+ *
+ * Rendered when a trip has been loaded but contains no stages — usually
+ * because the import pipeline hasn't materialised stages yet, or the user
+ * navigated to a freshly-created draft. Mirrors the "off the trail" tone of
+ * the not-found page: warm illustration plus a short, encouraging message.
+ */
+export function RoadbookEmptyState({
+  className,
+}: {
+  className?: string;
+}) {
+  const t = useTranslations("roadbookEmpty");
+
+  return (
+    <div
+      className={[
+        "flex flex-col items-center justify-center gap-5 rounded-xl border border-dashed border-border bg-card/40 px-6 py-12 text-center",
+        className ?? "",
+      ].join(" ")}
+      role="status"
+      aria-live="polite"
+      data-testid="roadbook-empty-state"
+    >
+      {/* Minimalist roadbook illustration: open notebook with a road */}
+      <svg
+        aria-hidden="true"
+        viewBox="0 0 200 120"
+        className="h-24 w-auto text-[var(--color-accent-brand)]"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        data-testid="roadbook-empty-state-illustration"
+      >
+        {/* Notebook spine */}
+        <line x1="100" y1="20" x2="100" y2="105" />
+        {/* Notebook covers */}
+        <path d="M30 20 L100 20 L100 105 L30 105 Z" />
+        <path d="M100 20 L170 20 L170 105 L100 105 Z" />
+        {/* Winding road */}
+        <path d="M45 95 Q60 75 75 80 T 95 50" />
+        <path d="M105 50 Q120 30 140 45 T 160 30" />
+        {/* Compass rose */}
+        <circle cx="155" cy="90" r="8" />
+        <line x1="155" y1="82" x2="155" y2="98" />
+        <line x1="147" y1="90" x2="163" y2="90" />
+      </svg>
+
+      <div className="space-y-1.5 max-w-sm">
+        <h2
+          className="font-serif text-xl md:text-2xl font-semibold tracking-tight text-foreground"
+          data-testid="roadbook-empty-state-title"
+        >
+          {t("title")}
+        </h2>
+        <p className="text-sm text-muted-foreground">{t("subtitle")}</p>
+      </div>
+    </div>
+  );
+}

--- a/pwa/src/components/roadbook-empty-state.tsx
+++ b/pwa/src/components/roadbook-empty-state.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useTranslations } from "next-intl";
+import { cn } from "@/lib/utils";
 
 /**
  * Empty-state placeholder for an empty roadbook (sprint 27, #402).
@@ -15,10 +16,10 @@ export function RoadbookEmptyState({ className }: { className?: string }) {
 
   return (
     <div
-      className={[
+      className={cn(
         "flex flex-col items-center justify-center gap-5 rounded-xl border border-dashed border-border bg-card/40 px-6 py-12 text-center",
-        className ?? "",
-      ].join(" ")}
+        className,
+      )}
       role="status"
       aria-live="polite"
       data-testid="roadbook-empty-state"

--- a/pwa/src/components/roadbook-empty-state.tsx
+++ b/pwa/src/components/roadbook-empty-state.tsx
@@ -10,11 +10,7 @@ import { useTranslations } from "next-intl";
  * navigated to a freshly-created draft. Mirrors the "off the trail" tone of
  * the not-found page: warm illustration plus a short, encouraging message.
  */
-export function RoadbookEmptyState({
-  className,
-}: {
-  className?: string;
-}) {
+export function RoadbookEmptyState({ className }: { className?: string }) {
   const t = useTranslations("roadbookEmpty");
 
   return (

--- a/pwa/src/components/source-url-chip.test.tsx
+++ b/pwa/src/components/source-url-chip.test.tsx
@@ -14,11 +14,20 @@ describe("detectSourceProvider", () => {
     ["https://www.komoot.com/collection/12345", "komoot"],
     ["https://www.komoot.com/en-us/collection/678", "komoot"],
     ["https://www.strava.com/routes/9876", "strava"],
-    ["https://strava.com/routes/9876", "strava"],
     ["https://ridewithgps.com/routes/42", "ridewithgps"],
-    ["https://www.ridewithgps.com/routes/42", "ridewithgps"],
   ])("detects %s as %s", (url, expected) => {
     expect(detectSourceProvider(url)).toBe(expected);
+  });
+
+  it.each([
+    // Backend RouteFetcherRegistry requires strict host (no http://, www only
+    // for komoot/strava). Permissive client-side regexes would create
+    // false-positive chips.
+    ["https://strava.com/routes/9876"],
+    ["https://www.ridewithgps.com/routes/42"],
+    ["http://www.komoot.com/tour/12345"],
+  ])("treats %s as unsupported (mirrors backend strictness)", (url) => {
+    expect(detectSourceProvider(url)).toBe("unsupported");
   });
 
   it("returns 'unsupported' for valid URLs that don't match any provider", () => {

--- a/pwa/src/components/source-url-chip.test.tsx
+++ b/pwa/src/components/source-url-chip.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { SourceUrlChip, detectSourceProvider } from "./source-url-chip";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+describe("detectSourceProvider", () => {
+  it.each([
+    ["https://www.komoot.com/tour/12345", "komoot"],
+    ["https://www.komoot.com/fr-fr/tour/12345", "komoot"],
+    ["https://www.komoot.com/collection/12345", "komoot"],
+    ["https://www.komoot.com/en-us/collection/678", "komoot"],
+    ["https://www.strava.com/routes/9876", "strava"],
+    ["https://strava.com/routes/9876", "strava"],
+    ["https://ridewithgps.com/routes/42", "ridewithgps"],
+    ["https://www.ridewithgps.com/routes/42", "ridewithgps"],
+  ])("detects %s as %s", (url, expected) => {
+    expect(detectSourceProvider(url)).toBe(expected);
+  });
+
+  it("returns 'unsupported' for valid URLs that don't match any provider", () => {
+    expect(detectSourceProvider("https://example.com/route/1")).toBe(
+      "unsupported",
+    );
+  });
+
+  it("returns null for empty values", () => {
+    expect(detectSourceProvider("")).toBeNull();
+    expect(detectSourceProvider("   ")).toBeNull();
+  });
+
+  it("returns null for invalid URLs", () => {
+    expect(detectSourceProvider("not-a-url")).toBeNull();
+    expect(detectSourceProvider("foo bar")).toBeNull();
+  });
+});
+
+describe("SourceUrlChip", () => {
+  it("renders nothing for empty input", () => {
+    const { container } = render(<SourceUrlChip value="" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing for invalid URLs", () => {
+    const { container } = render(<SourceUrlChip value="not-a-url" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders Komoot chip for a Komoot tour URL", () => {
+    render(<SourceUrlChip value="https://www.komoot.com/tour/12345" />);
+    const chip = screen.getByTestId("source-url-chip");
+    expect(chip).toHaveAttribute("data-provider", "komoot");
+    expect(chip).toHaveTextContent("komoot");
+  });
+
+  it("renders Strava chip for a Strava route URL", () => {
+    render(<SourceUrlChip value="https://www.strava.com/routes/9876" />);
+    expect(screen.getByTestId("source-url-chip")).toHaveAttribute(
+      "data-provider",
+      "strava",
+    );
+  });
+
+  it("renders RideWithGPS chip for a RWGPS URL", () => {
+    render(<SourceUrlChip value="https://ridewithgps.com/routes/42" />);
+    expect(screen.getByTestId("source-url-chip")).toHaveAttribute(
+      "data-provider",
+      "ridewithgps",
+    );
+  });
+
+  it("renders unsupported chip for an unrecognised valid URL", () => {
+    render(<SourceUrlChip value="https://example.com/foo" />);
+    expect(screen.getByTestId("source-url-chip")).toHaveAttribute(
+      "data-provider",
+      "unsupported",
+    );
+  });
+});

--- a/pwa/src/components/source-url-chip.tsx
+++ b/pwa/src/components/source-url-chip.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { CheckCircle2, AlertCircle } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { isValidUrl } from "@/lib/validation/url";
+
+/**
+ * Detected route source provider, derived from a free-form URL.
+ *
+ * Mirrors the backend `RouteFetcherRegistry` strategies. The detection runs
+ * client-side after the URL field is validated to give the user immediate
+ * feedback as a coloured chip beneath the input.
+ */
+export type SourceProvider =
+  | "komoot"
+  | "strava"
+  | "ridewithgps"
+  | "unsupported";
+
+const PROVIDER_PATTERNS: Record<
+  Exclude<SourceProvider, "unsupported">,
+  readonly RegExp[]
+> = {
+  komoot: [
+    /^https?:\/\/(www\.)?komoot\.com\/([a-z]{2}-[a-z]{2}\/)?(tour|collection)\/\d+/i,
+  ],
+  strava: [/^https?:\/\/(www\.)?strava\.com\/routes\/\d+/i],
+  ridewithgps: [/^https?:\/\/(www\.)?ridewithgps\.com\/routes\/\d+/i],
+};
+
+/**
+ * Detect the route source from a URL. Returns null when the value is empty
+ * or not a valid URL (no chip should be displayed yet — wait for further
+ * input). Returns "unsupported" for valid URLs that don't match any known
+ * source.
+ */
+export function detectSourceProvider(value: string): SourceProvider | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  if (!isValidUrl(trimmed)) return null;
+
+  for (const [provider, patterns] of Object.entries(PROVIDER_PATTERNS) as Array<
+    [Exclude<SourceProvider, "unsupported">, readonly RegExp[]]
+  >) {
+    if (patterns.some((p) => p.test(trimmed))) return provider;
+  }
+  return "unsupported";
+}
+
+interface SourceUrlChipProps {
+  /** URL value being entered. Detection runs on each render. */
+  value: string;
+  className?: string;
+}
+
+/**
+ * Small inline chip displayed under the URL input on the trip-creation page.
+ *
+ * Communicates the detected route source (Komoot / Strava / RideWithGPS) or
+ * flags an unsupported URL. Renders nothing while the value is empty or not
+ * a parseable URL — to avoid scolding users mid-typing.
+ */
+export function SourceUrlChip({ value, className }: SourceUrlChipProps) {
+  const t = useTranslations("sourceChip");
+  const provider = detectSourceProvider(value);
+  if (provider === null) return null;
+
+  const config: Record<
+    SourceProvider,
+    { label: string; classes: string; icon: React.ReactNode }
+  > = {
+    komoot: {
+      label: t("komoot"),
+      // Brand-ish green chip for Komoot
+      classes:
+        "bg-green-50 text-green-800 border-green-200 dark:bg-green-950/40 dark:text-green-300 dark:border-green-800",
+      icon: <CheckCircle2 className="h-3.5 w-3.5" aria-hidden="true" />,
+    },
+    strava: {
+      label: t("strava"),
+      // Strava signature orange
+      classes:
+        "bg-orange-50 text-orange-800 border-orange-200 dark:bg-orange-950/40 dark:text-orange-300 dark:border-orange-800",
+      icon: <CheckCircle2 className="h-3.5 w-3.5" aria-hidden="true" />,
+    },
+    ridewithgps: {
+      label: t("ridewithgps"),
+      // RideWithGPS signature blue
+      classes:
+        "bg-blue-50 text-blue-800 border-blue-200 dark:bg-blue-950/40 dark:text-blue-300 dark:border-blue-800",
+      icon: <CheckCircle2 className="h-3.5 w-3.5" aria-hidden="true" />,
+    },
+    unsupported: {
+      label: t("unsupported"),
+      classes:
+        "bg-red-50 text-red-800 border-red-200 dark:bg-red-950/40 dark:text-red-300 dark:border-red-800",
+      icon: <AlertCircle className="h-3.5 w-3.5" aria-hidden="true" />,
+    },
+  };
+
+  const c = config[provider];
+  return (
+    <span
+      role="status"
+      aria-live="polite"
+      data-testid="source-url-chip"
+      data-provider={provider}
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs font-medium",
+        c.classes,
+        className,
+      )}
+    >
+      {c.icon}
+      {c.label}
+    </span>
+  );
+}

--- a/pwa/src/components/source-url-chip.tsx
+++ b/pwa/src/components/source-url-chip.tsx
@@ -23,10 +23,10 @@ const PROVIDER_PATTERNS: Record<
   readonly RegExp[]
 > = {
   komoot: [
-    /^https?:\/\/(www\.)?komoot\.com\/([a-z]{2}-[a-z]{2}\/)?(tour|collection)\/\d+/i,
+    /^https:\/\/www\.komoot\.com\/([a-z]{2}-[a-z]{2}\/)?(tour|collection)\/\d+/i,
   ],
-  strava: [/^https?:\/\/(www\.)?strava\.com\/routes\/\d+/i],
-  ridewithgps: [/^https?:\/\/(www\.)?ridewithgps\.com\/routes\/\d+/i],
+  strava: [/^https:\/\/www\.strava\.com\/routes\/\d+/i],
+  ridewithgps: [/^https:\/\/ridewithgps\.com\/routes\/\d+/i],
 };
 
 /**

--- a/pwa/src/components/stage-card.tsx
+++ b/pwa/src/components/stage-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { X, Loader2 } from "lucide-react";
+import { X, Loader2, CheckCircle2 } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
@@ -205,6 +205,18 @@ export function StageCard({
           <div className="flex items-center gap-2 text-xs text-muted-foreground">
             <Loader2 className="h-3.5 w-3.5 animate-spin" />
             <span>{t("loadingAlerts")}</span>
+          </div>
+        )}
+        {!hasAlerts && !isProcessing && !stage.isRestDay && (
+          <div
+            className="flex items-center gap-2 text-xs text-muted-foreground"
+            data-testid="stage-no-alerts"
+          >
+            <CheckCircle2
+              className="h-3.5 w-3.5 text-green-600 dark:text-green-400 shrink-0"
+              aria-hidden="true"
+            />
+            <span>{t("noAlerts")}</span>
           </div>
         )}
 

--- a/pwa/src/components/stage-panel-skeleton.tsx
+++ b/pwa/src/components/stage-panel-skeleton.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { Card, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+/**
+ * Loading skeleton for the right-hand stage detail panel (sprint 27, #402).
+ *
+ * Mimics the visible structure of {@link StageCard}: stats row, weather card,
+ * alerts block. Used by `StageDetailPanel` while the trip is still loading
+ * so the layout stays stable. Reuses the shared shimmer animation from
+ * `Skeleton` (Tailwind `animate-pulse`) to match `StageSkeleton` (sprint 24).
+ */
+export function StagePanelSkeleton() {
+  const t = useTranslations("stage");
+
+  return (
+    <Card
+      className="border-border shadow-sm rounded-xl w-full relative"
+      data-testid="stage-panel-skeleton"
+      aria-busy="true"
+      aria-label={t("loadingAlerts")}
+    >
+      <CardContent className="p-4 md:p-6 space-y-4">
+        {/* Header — locations / day chip */}
+        <div className="flex flex-col gap-2">
+          <Skeleton className="h-5 w-2/3" />
+          <Skeleton className="h-4 w-1/2" />
+        </div>
+
+        {/* Stats grid — distance / elevation / duration / budget */}
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-3 pt-2">
+          {[0, 1, 2, 3].map((i) => (
+            <div key={i} className="flex flex-col gap-1.5">
+              <Skeleton className="h-3 w-12" />
+              <Skeleton className="h-5 w-16" />
+            </div>
+          ))}
+        </div>
+
+        {/* Weather block */}
+        <div className="rounded-lg border border-border p-4 space-y-2">
+          <Skeleton className="h-4 w-1/3" />
+          <div className="flex items-center gap-3">
+            <Skeleton className="h-10 w-10 rounded-full" />
+            <div className="flex-1 space-y-1.5">
+              <Skeleton className="h-3 w-2/5" />
+              <Skeleton className="h-3 w-3/5" />
+            </div>
+          </div>
+        </div>
+
+        {/* Alerts block — title + 2 alert rows */}
+        <div className="space-y-2 pt-2">
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="h-12 w-full rounded-md" />
+          <Skeleton className="h-12 w-3/4 rounded-md" />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/pwa/src/components/timeline-sidebar-skeleton.tsx
+++ b/pwa/src/components/timeline-sidebar-skeleton.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { Skeleton } from "@/components/ui/skeleton";
+
+/**
+ * Loading skeleton for {@link TimelineSidebar} (sprint 27, #402).
+ *
+ * Renders 4 dot markers with shimmer lines, mirroring the production sidebar
+ * layout. The connecting brand-tinted line is preserved so the skeleton holds
+ * the same vertical footprint as the real sidebar — no layout shift.
+ */
+export function TimelineSidebarSkeleton({
+  count = 4,
+  className,
+}: {
+  /** Number of placeholder rows to render (default 4). */
+  count?: number;
+  className?: string;
+}) {
+  const t = useTranslations("timeline");
+
+  return (
+    <nav
+      aria-label={t("loadingStages")}
+      aria-busy="true"
+      data-testid="timeline-sidebar-skeleton"
+      className={["relative", className ?? ""].join(" ")}
+    >
+      {/* Vertical connecting line — same offset as TimelineSidebar */}
+      <div
+        aria-hidden="true"
+        className="absolute left-[15px] top-3 bottom-3 w-px bg-brand/30"
+      />
+
+      <ul className="flex flex-col">
+        {Array.from({ length: count }).map((_, i) => (
+          <li key={i} className="flex items-start gap-3 px-2 py-2">
+            <span
+              aria-hidden="true"
+              className="relative z-10 mt-1 shrink-0 w-3 h-3 rounded-full border-[3px] border-brand/60 bg-background"
+            />
+            <span className="flex-1 min-w-0 flex flex-col gap-1">
+              <Skeleton className="h-3.5 w-32" />
+              <Skeleton className="h-3 w-20" />
+            </span>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}

--- a/pwa/src/components/timeline-sidebar-skeleton.tsx
+++ b/pwa/src/components/timeline-sidebar-skeleton.tsx
@@ -2,6 +2,7 @@
 
 import { useTranslations } from "next-intl";
 import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
 
 /**
  * Loading skeleton for {@link TimelineSidebar} (sprint 27, #402).
@@ -25,7 +26,7 @@ export function TimelineSidebarSkeleton({
       aria-label={t("loadingStages")}
       aria-busy="true"
       data-testid="timeline-sidebar-skeleton"
-      className={["relative", className ?? ""].join(" ")}
+      className={cn("relative", className)}
     >
       {/* Vertical connecting line — same offset as TimelineSidebar */}
       <div

--- a/pwa/src/components/trip-not-found.tsx
+++ b/pwa/src/components/trip-not-found.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import Link from "next/link";
+import { useTranslations } from "next-intl";
+import { Button } from "@/components/ui/button";
+
+interface TripNotFoundProps {
+  /**
+   * Variant — selects the message tone.
+   * - `trip`: "trip not found" (used by /trips/[id])
+   * - `share`: "shared link revoked or invalid" (used by /s/[code])
+   */
+  variant?: "trip" | "share";
+  /** Optional override for the back-link target (defaults per-variant). */
+  backHref?: string;
+  backLabel?: string;
+}
+
+/**
+ * Stylised "trip not found" page (sprint 27, #402).
+ *
+ * Used by both `/trips/[id]` (trip 404) and `/s/[code]` (revoked share). The
+ * variant prop swaps the title/subtitle copy while keeping the same warm
+ * illustration and amber-accented button. The illustration mirrors the
+ * sprint 25 visual language used by `/not-found`.
+ */
+export function TripNotFound({
+  variant = "trip",
+  backHref,
+  backLabel,
+}: TripNotFoundProps) {
+  const t = useTranslations(
+    variant === "share" ? "shareNotFound" : "tripNotFound",
+  );
+
+  const defaultHref = variant === "share" ? "/" : "/trips";
+
+  return (
+    <main
+      className="flex min-h-[60vh] items-center justify-center px-4 py-12 bg-[var(--color-surface)] text-[var(--color-ink)]"
+      data-testid={`${variant}-not-found-page`}
+    >
+      <div className="text-center space-y-6 max-w-md">
+        {/* Reuse the cyclist-on-mountain motif of /not-found */}
+        <svg
+          aria-label={t("illustrationAlt")}
+          role="img"
+          viewBox="0 0 200 120"
+          className="mx-auto h-32 w-auto text-[var(--color-accent-brand)]"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          data-testid={`${variant}-not-found-illustration`}
+        >
+          <path d="M0 90 L40 50 L70 75 L110 30 L150 70 L200 45 L200 120 L0 120 Z" />
+          <circle cx="160" cy="25" r="8" />
+          <circle cx="55" cy="100" r="9" />
+          <circle cx="85" cy="100" r="9" />
+          <path d="M55 100 L70 80 L85 100 M70 80 L78 80 L85 100 M70 80 L65 70" />
+          <path d="M70 60 q2 -8 6 -8 q4 0 4 4 q0 4 -4 6 q-2 1 -2 4" />
+          <circle cx="74" cy="70" r="0.5" fill="currentColor" />
+        </svg>
+
+        <div className="space-y-3">
+          <h1
+            className="font-serif text-3xl md:text-4xl font-semibold tracking-tight"
+            data-testid={`${variant}-not-found-title`}
+          >
+            {t("title")}
+          </h1>
+          <p
+            className="font-sans text-base md:text-lg text-[var(--color-ink)]/70"
+            data-testid={`${variant}-not-found-subtitle`}
+          >
+            {t("subtitle")}
+          </p>
+        </div>
+
+        <Button asChild size="lg" data-testid={`${variant}-not-found-back`}>
+          <Link href={backHref ?? defaultHref}>{backLabel ?? t("back")}</Link>
+        </Button>
+      </div>
+    </main>
+  );
+}

--- a/pwa/src/components/trip-summary-skeleton.tsx
+++ b/pwa/src/components/trip-summary-skeleton.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { Skeleton } from "@/components/ui/skeleton";
+
+/**
+ * Loading skeleton for {@link TripSummary} (sprint 27, #402).
+ *
+ * Shimmer card with three short lines (distance / elevation / dates) plus a
+ * wider rectangle (weather / budget). Used when the trip data is still being
+ * fetched but the page chrome must remain stable. Mirrors the inline pulses
+ * already rendered when `TripSummary` has partial data, but provides a
+ * standalone block that can be slotted in front of the real summary.
+ */
+export function TripSummarySkeleton() {
+  const t = useTranslations("tripSummary");
+
+  return (
+    <div
+      className="space-y-2"
+      role="status"
+      aria-busy="true"
+      aria-label={t("loadingAriaLabel")}
+      data-testid="trip-summary-skeleton"
+    >
+      <div className="flex flex-wrap items-center justify-center gap-x-6 gap-y-1">
+        <Skeleton className="h-4 w-20" />
+        <Skeleton className="h-4 w-28" />
+        <Skeleton className="h-4 w-32" />
+      </div>
+      <div className="flex flex-wrap items-center justify-center gap-x-6 gap-y-1">
+        <Skeleton className="h-5 w-44 rounded-md" />
+        <Skeleton className="h-4 w-24" />
+      </div>
+    </div>
+  );
+}

--- a/pwa/tests/mocked/trip-detail.spec.ts
+++ b/pwa/tests/mocked/trip-detail.spec.ts
@@ -129,12 +129,10 @@ test.describe("/trips/[id] detail page", () => {
     await page.goto(`/trips/${TRIP_ID}`);
     await page.waitForLoadState("networkidle");
 
-    await expect(page.getByText(/impossible de charger/i)).toBeVisible({
+    await expect(page.getByTestId("trip-not-found-page")).toBeVisible({
       timeout: 5000,
     });
-    await expect(
-      page.getByRole("link", { name: /retour aux voyages/i }),
-    ).toBeVisible();
+    await expect(page.getByTestId("trip-not-found-back")).toBeVisible();
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #402 — Sprint 27 (Reste du design, issue #375 §8). Harmonise les états UX transverses.

**Nouveaux composants :**
- `destructive-dialog.tsx` : modale de confirmation réutilisable avec optional keyword challenge (ex : SUPPRIMER pour suppression de compte) + tests vitest.
- `source-url-chip.tsx` : chip détection Komoot/Strava/RideWithGPS/non-supportée + tests vitest.
- `gpx-drop-zone-card.tsx` : drop zone 4 états (`idle`/`hovering`/`uploading`/`error`) avec progress bar inline et retry.
- `trip-not-found.tsx` : page 404 stylisée avec variantes `trip` et `share`.
- `roadbook-empty-state.tsx` : illustration + message roadbook vierge.
- Skeletons : `trip-summary-skeleton.tsx`, `timeline-sidebar-skeleton.tsx` (4 dots + lignes), `stage-panel-skeleton.tsx` (stats + weather + alertes).

**Modifié :**
- `card-selection.tsx` : `LinkCard` affiche le `SourceUrlChip` après saisie ; `GpxCard` délègue à `GpxDropZoneCard` (selectors `card-gpx-dropzone` et `gpx-file-input` préservés).
- `stage-card.tsx` : empty alerts → « Aucune alerte pour cette étape ✓ »
- `Timeline/TimelineSidebar.tsx` + `Timeline/StageDetailPanel.tsx` : skeletons + roadbook empty state.
- `app/trips/[id]/trip-page.tsx` : erreur → `TripNotFound` ; loading → skeleton layout complet.
- `app/s/[code]/shared-trip-page.tsx` : partage révoqué → `TripNotFound variant="share"`.
- i18n FR/EN : `gpxDropZone`, `sourceChip`, `destructiveDialog`, `tripNotFound`, `shareNotFound`, `roadbookEmpty`, `stage.noAlerts`, `cardSelection.gpxUploadGenericError`.

## Auto-critique

- Le `DestructiveDialog` est volontairement réutilisable pour adoption ultérieure (suppression voyage dans #399, suppression compte dans le sprint 32).
- Pas touché à `/trips/page.tsx` (#399) ni aux composants auth (#401).
- Selectors E2E préservés (`card-gpx-dropzone`, `gpx-file-input`).

## Test plan

- [ ] GPX drop zone passe par `idle` → `hovering` (drag over) → `uploading` (avec progression) → `error` (en cas d'échec)
- [ ] Chip de détection apparaît sous l'input URL après saisie d'une URL Komoot/Strava/RWGPS/inconnue
- [ ] Modale destructive fonctionne avec et sans keyword challenge
- [ ] `/trips/[id]` invalide → `TripNotFound` avec bouton retour
- [ ] Skeletons visibles pendant le loading des écrans concernés
- [ ] E2E mockés non régressés

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

Reviewed commit `6d4e24d`.

All prior review findings have been addressed. The six new components are clean, properly tested, and correctly accessible. The nested `<main>` landmark issue, the ring-inversion on `DestructiveDialog`, the `GpxDropZoneState` API exposure, the `onFileSelected` JSDoc, and the missing `GpxDropZoneCard` test suite are all resolved in the latest commits. One minor test-precision item remains.

**Resolved threads:** Resolved 2 previously open bot threads — ring styling inversion (fixed with green confirmation ring) and `onFileSelected` JSDoc accuracy (caller now correctly documented as responsible for validation).

**Review checklist**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Findings by severity**
- 💡 suggestion × 1 — `share-page.spec.ts` error test still uses `page.getByRole("link").first()` instead of `data-testid="share-not-found-back"` (unlike the parallel fix in `trip-detail.spec.ts`)

**Posted 1 inline comment.**

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->