### PR TITLE
feat(stage): add surface breakdown and sunrise/sunset display (#403)

### DIFF
--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -218,7 +218,9 @@
     "cardAriaLabel": "Stage weather",
     "sunriseShort": "sunrise",
     "sunsetShort": "sunset",
-    "sunriseSunsetTooltip": "Sunrise and sunset times at stage end point (UTC)"
+    "sunriseSunsetTooltip": "Sunrise and sunset times at stage end point (UTC)",
+    "sunStateDay": "Daylight",
+    "sunStateNight": "Night"
   },
   "stageStats": {
     "distance": "Distance",
@@ -243,6 +245,15 @@
     "physicalDetail": "{distance} km covered",
     "technicalDetail": "{ratio} m of climbing per km — average slope proxy",
     "elevationDetail": "{elevation} m of total ascent"
+  },
+  "surfaceBreakdown": {
+    "ariaLabel": "Surface breakdown",
+    "title": "Surfaces",
+    "label_paved": "Paved",
+    "label_gravel": "Gravel",
+    "label_cobblestone": "Cobblestone",
+    "label_unpaved": "Unpaved",
+    "label_unknown": "Unknown"
   },
   "textExport": {
     "button": "Export",

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -218,7 +218,9 @@
     "cardAriaLabel": "Météo de l'étape",
     "sunriseShort": "lever",
     "sunsetShort": "coucher",
-    "sunriseSunsetTooltip": "Heures de lever et coucher du soleil au point d'arrivée de l'étape (UTC)"
+    "sunriseSunsetTooltip": "Heures de lever et coucher du soleil au point d'arrivée de l'étape (UTC)",
+    "sunStateDay": "Soleil levé",
+    "sunStateNight": "Nuit"
   },
   "stageStats": {
     "distance": "Distance",
@@ -243,6 +245,15 @@
     "physicalDetail": "{distance} km parcourus",
     "technicalDetail": "{ratio} m de D+ par km — proxy de pente moyenne",
     "elevationDetail": "{elevation} m de dénivelé positif"
+  },
+  "surfaceBreakdown": {
+    "ariaLabel": "Répartition des surfaces",
+    "title": "Surfaces",
+    "label_paved": "Revêtu",
+    "label_gravel": "Gravier",
+    "label_cobblestone": "Pavé",
+    "label_unpaved": "Non revêtu",
+    "label_unknown": "Inconnu"
   },
   "textExport": {
     "button": "Exporter",

--- a/pwa/src/components/StageDetail/StageSurfaceBreakdown.test.tsx
+++ b/pwa/src/components/StageDetail/StageSurfaceBreakdown.test.tsx
@@ -1,0 +1,98 @@
+import { render } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import {
+  StageSurfaceBreakdown,
+  aggregateBreakdown,
+} from "./StageSurfaceBreakdown";
+
+// Stub next-intl to keep the component decoupled from a NextIntlClientProvider
+// in unit tests. Returning the key suffix is enough to assert layout logic.
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+describe("aggregateBreakdown", () => {
+  it("groups raw OSM surfaces into display families and sums lengths", () => {
+    const { totals, totalMeters } = aggregateBreakdown([
+      { surface: "asphalt", lengthMeters: 6000 },
+      { surface: "concrete", lengthMeters: 1000 },
+      { surface: "gravel", lengthMeters: 2500 },
+      { surface: "fine_gravel", lengthMeters: 500 },
+      { surface: "sett", lengthMeters: 1000 },
+      { surface: "weird-osm-value", lengthMeters: 500 },
+    ]);
+
+    expect(totalMeters).toBe(11500);
+    const byFamily = Object.fromEntries(
+      totals.map((t) => [t.family, t.meters]),
+    );
+    expect(byFamily).toEqual({
+      paved: 7000,
+      gravel: 3000,
+      cobblestone: 1000,
+      unknown: 500,
+    });
+  });
+
+  it("ignores zero/negative segments and preserves ordering", () => {
+    const { totals } = aggregateBreakdown([
+      { surface: "asphalt", lengthMeters: 0 },
+      { surface: "gravel", lengthMeters: 1000 },
+    ]);
+    expect(totals).toHaveLength(1);
+    expect(totals[0]?.family).toBe("gravel");
+  });
+});
+
+describe("StageSurfaceBreakdown", () => {
+  it("returns null when total length is zero", () => {
+    const { container } = render(
+      <StageSurfaceBreakdown
+        breakdown={[{ surface: "asphalt", lengthMeters: 0 }]}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders one segment per family and percentages sum to 100", () => {
+    const { getByTestId, queryByTestId } = render(
+      <StageSurfaceBreakdown
+        breakdown={[
+          { surface: "asphalt", lengthMeters: 6000 },
+          { surface: "gravel", lengthMeters: 3000 },
+          { surface: "sett", lengthMeters: 1000 },
+        ]}
+      />,
+    );
+
+    const paved = getByTestId("stage-surface-segment-paved");
+    const gravel = getByTestId("stage-surface-segment-gravel");
+    const cobble = getByTestId("stage-surface-segment-cobblestone");
+    expect(queryByTestId("stage-surface-segment-unpaved")).toBeNull();
+
+    const sum =
+      Number(paved.getAttribute("data-percent")) +
+      Number(gravel.getAttribute("data-percent")) +
+      Number(cobble.getAttribute("data-percent"));
+    expect(sum).toBe(100);
+  });
+
+  it("absorbs rounding error so the bar always sums to 100%", () => {
+    // 33.33% / 33.33% / 33.33% — naive rounding gives 33+33+33=99 → dominant slice fixes it.
+    const { getByTestId } = render(
+      <StageSurfaceBreakdown
+        breakdown={[
+          { surface: "asphalt", lengthMeters: 1000 },
+          { surface: "gravel", lengthMeters: 1000 },
+          { surface: "sett", lengthMeters: 1000 },
+        ]}
+      />,
+    );
+    const sum =
+      Number(getByTestId("stage-surface-segment-paved").dataset.percent) +
+      Number(getByTestId("stage-surface-segment-gravel").dataset.percent) +
+      Number(getByTestId("stage-surface-segment-cobblestone").dataset.percent);
+    expect(sum).toBe(100);
+  });
+});

--- a/pwa/src/components/StageDetail/StageSurfaceBreakdown.tsx
+++ b/pwa/src/components/StageDetail/StageSurfaceBreakdown.tsx
@@ -13,12 +13,7 @@ import type { SurfaceSegmentData } from "@/lib/validation/schemas";
  * visual buckets. Keep this list aligned with `SURFACE_FAMILIES` and the
  * matching i18n keys in `messages/{fr,en}.json` (`surfaceBreakdown.label_*`).
  */
-type SurfaceFamily =
-  | "paved"
-  | "gravel"
-  | "cobblestone"
-  | "unpaved"
-  | "unknown";
+type SurfaceFamily = "paved" | "gravel" | "cobblestone" | "unpaved" | "unknown";
 
 /**
  * Maps OSM `surface=*` raw values to coarser display families. The list mirrors
@@ -85,9 +80,10 @@ interface AggregatedFamily {
 }
 
 /** Public for test purposes — pure aggregation step. */
-export function aggregateBreakdown(
-  segments: readonly SurfaceSegmentData[],
-): { totals: AggregatedFamily[]; totalMeters: number } {
+export function aggregateBreakdown(segments: readonly SurfaceSegmentData[]): {
+  totals: AggregatedFamily[];
+  totalMeters: number;
+} {
   const buckets = new Map<SurfaceFamily, AggregatedFamily>();
 
   for (const segment of segments) {
@@ -99,10 +95,7 @@ export function aggregateBreakdown(
       rawSurfaces: [],
     };
     bucket.meters += segment.lengthMeters;
-    if (
-      segment.surface &&
-      bucket.rawSurfaces.indexOf(segment.surface) === -1
-    ) {
+    if (segment.surface && bucket.rawSurfaces.indexOf(segment.surface) === -1) {
       bucket.rawSurfaces.push(segment.surface);
     }
     buckets.set(family, bucket);

--- a/pwa/src/components/StageDetail/StageSurfaceBreakdown.tsx
+++ b/pwa/src/components/StageDetail/StageSurfaceBreakdown.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import type { SurfaceSegmentData } from "@/lib/validation/schemas";
+
+/**
+ * Surface family used to group raw OSM `surface=*` values into a small set of
+ * visual buckets. Keep this list aligned with `SURFACE_FAMILIES` and the
+ * matching i18n keys in `messages/{fr,en}.json` (`surfaceBreakdown.label_*`).
+ */
+type SurfaceFamily =
+  | "paved"
+  | "gravel"
+  | "cobblestone"
+  | "unpaved"
+  | "unknown";
+
+/**
+ * Maps OSM `surface=*` raw values to coarser display families. The list mirrors
+ * the values handled by `SurfaceAlertAnalyzer` on the backend so the visual
+ * grouping stays consistent with the alert engine.
+ */
+const SURFACE_TO_FAMILY: Record<string, SurfaceFamily> = {
+  paved: "paved",
+  asphalt: "paved",
+  concrete: "paved",
+  concrete_lanes: "paved",
+  concrete_plates: "paved",
+  paving_stones: "cobblestone",
+  sett: "cobblestone",
+  cobblestone: "cobblestone",
+  unhewn_cobblestone: "cobblestone",
+  bricks: "cobblestone",
+  metal: "paved",
+  wood: "paved",
+  gravel: "gravel",
+  fine_gravel: "gravel",
+  pebblestone: "gravel",
+  compacted: "gravel",
+  unpaved: "unpaved",
+  dirt: "unpaved",
+  ground: "unpaved",
+  earth: "unpaved",
+  grass: "unpaved",
+  sand: "unpaved",
+  mud: "unpaved",
+};
+
+/**
+ * Tailwind classes used to colour each surface family in the stacked bar.
+ * Sprint 25 design tokens (semantic foreground/muted) used for the unknown
+ * fallback so the bar still has a calm background where the data is sparse.
+ */
+const FAMILY_BAR_CLASS: Record<SurfaceFamily, string> = {
+  paved: "bg-sky-500 dark:bg-sky-400",
+  gravel: "bg-amber-500 dark:bg-amber-400",
+  cobblestone: "bg-stone-500 dark:bg-stone-400",
+  unpaved: "bg-orange-600 dark:bg-orange-500",
+  unknown: "bg-muted-foreground/40",
+};
+
+/** Stable order — the bar always renders families in this sequence. */
+const FAMILY_ORDER: readonly SurfaceFamily[] = [
+  "paved",
+  "gravel",
+  "cobblestone",
+  "unpaved",
+  "unknown",
+] as const;
+
+function familyOf(surface: string): SurfaceFamily {
+  return SURFACE_TO_FAMILY[surface] ?? "unknown";
+}
+
+interface AggregatedFamily {
+  family: SurfaceFamily;
+  meters: number;
+  /** Underlying raw `surface=*` values that fed this family — used in tooltips. */
+  rawSurfaces: string[];
+}
+
+/** Public for test purposes — pure aggregation step. */
+export function aggregateBreakdown(
+  segments: readonly SurfaceSegmentData[],
+): { totals: AggregatedFamily[]; totalMeters: number } {
+  const buckets = new Map<SurfaceFamily, AggregatedFamily>();
+
+  for (const segment of segments) {
+    if (segment.lengthMeters <= 0) continue;
+    const family = familyOf(segment.surface);
+    const bucket = buckets.get(family) ?? {
+      family,
+      meters: 0,
+      rawSurfaces: [],
+    };
+    bucket.meters += segment.lengthMeters;
+    if (
+      segment.surface &&
+      bucket.rawSurfaces.indexOf(segment.surface) === -1
+    ) {
+      bucket.rawSurfaces.push(segment.surface);
+    }
+    buckets.set(family, bucket);
+  }
+
+  const totalMeters = Array.from(buckets.values()).reduce(
+    (sum, b) => sum + b.meters,
+    0,
+  );
+
+  const totals = FAMILY_ORDER.flatMap((family) => {
+    const bucket = buckets.get(family);
+    return bucket ? [bucket] : [];
+  });
+
+  return { totals, totalMeters };
+}
+
+interface StageSurfaceBreakdownProps {
+  breakdown: readonly SurfaceSegmentData[];
+}
+
+/**
+ * Stacked horizontal bar showing the proportion of each surface family along
+ * the stage (e.g. 60% paved / 30% gravel / 10% cobblestone).
+ *
+ * Conditional: returns `null` when the backend has not provided the field, or
+ * when every segment has zero length. The component is forward-compatible —
+ * see `StageDataSchema.surfaceBreakdown` for the wire-format contract.
+ *
+ * Reuses sprint-25 design tokens (border, card, muted-foreground) and the same
+ * `rounded-lg border bg-card/40` shell as the difficulty/weather cards so the
+ * three blocks line up visually in the right-hand stage detail panel.
+ */
+export function StageSurfaceBreakdown({
+  breakdown,
+}: StageSurfaceBreakdownProps) {
+  const t = useTranslations("surfaceBreakdown");
+
+  const { totals, totalMeters } = aggregateBreakdown(breakdown);
+  if (totalMeters <= 0 || totals.length === 0) {
+    return null;
+  }
+
+  // Round to whole percent and adjust the dominant slice so the rendered bar
+  // always sums to exactly 100% (avoids the classic 99% / 101% rounding gap).
+  const rawPercents = totals.map((bucket) => ({
+    bucket,
+    rounded: Math.round((bucket.meters / totalMeters) * 100),
+  }));
+  const roundedSum = rawPercents.reduce((sum, p) => sum + p.rounded, 0);
+  if (roundedSum !== 100 && rawPercents.length > 0) {
+    // Largest slice absorbs the rounding delta.
+    const largest = rawPercents.reduce((acc, p) =>
+      p.rounded > acc.rounded ? p : acc,
+    );
+    largest.rounded += 100 - roundedSum;
+  }
+
+  return (
+    <section
+      data-testid="stage-surface-breakdown"
+      aria-label={t("ariaLabel")}
+      className="rounded-lg border border-border bg-card/40 p-3"
+    >
+      <header className="mb-2 flex items-center justify-between gap-2">
+        <h3 className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+          {t("title")}
+        </h3>
+      </header>
+
+      <div
+        className="relative flex h-2.5 w-full overflow-hidden rounded-full bg-muted"
+        role="img"
+        aria-label={rawPercents
+          .map(
+            (p) =>
+              `${p.rounded}% ${t(`label_${p.bucket.family}` as `label_${SurfaceFamily}`)}`,
+          )
+          .join(", ")}
+      >
+        {rawPercents.map((p) => (
+          <Tooltip key={p.bucket.family}>
+            <TooltipTrigger asChild>
+              <div
+                className={`h-full ${FAMILY_BAR_CLASS[p.bucket.family]} cursor-default first:rounded-l-full last:rounded-r-full transition-[width] duration-300`}
+                style={{ width: `${p.rounded}%` }}
+                data-testid={`stage-surface-segment-${p.bucket.family}`}
+                data-percent={p.rounded}
+              />
+            </TooltipTrigger>
+            <TooltipContent side="top" className="text-xs">
+              <span className="font-medium">
+                {t(`label_${p.bucket.family}` as `label_${SurfaceFamily}`)}
+              </span>
+              {" — "}
+              {p.rounded}% ({(p.bucket.meters / 1000).toFixed(1)} km)
+              {p.bucket.rawSurfaces.length > 0 && (
+                <span className="block text-muted-foreground">
+                  {p.bucket.rawSurfaces.join(", ")}
+                </span>
+              )}
+            </TooltipContent>
+          </Tooltip>
+        ))}
+      </div>
+
+      <ul className="mt-2 flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground">
+        {rawPercents.map((p) => (
+          <li
+            key={p.bucket.family}
+            className="flex items-center gap-1.5"
+            data-testid={`stage-surface-legend-${p.bucket.family}`}
+          >
+            <span
+              aria-hidden="true"
+              className={`h-2 w-2 rounded-full ${FAMILY_BAR_CLASS[p.bucket.family]}`}
+            />
+            <span>
+              {t(`label_${p.bucket.family}` as `label_${SurfaceFamily}`)}
+            </span>
+            <span className="tabular-nums text-muted-foreground/80">
+              {p.rounded}%
+            </span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/pwa/src/components/StageDetail/StageSurfaceBreakdown.tsx
+++ b/pwa/src/components/StageDetail/StageSurfaceBreakdown.tsx
@@ -48,8 +48,8 @@ const SURFACE_TO_FAMILY: Record<string, SurfaceFamily> = {
 
 /**
  * Tailwind classes used to colour each surface family in the stacked bar.
- * Sprint 25 design tokens (semantic foreground/muted) used for the unknown
- * fallback so the bar still has a calm background where the data is sparse.
+ * Semantic foreground/muted design tokens are used for the unknown fallback
+ * so the bar still has a calm background where the data is sparse.
  */
 const FAMILY_BAR_CLASS: Record<SurfaceFamily, string> = {
   paved: "bg-sky-500 dark:bg-sky-400",
@@ -126,9 +126,9 @@ interface StageSurfaceBreakdownProps {
  * when every segment has zero length. The component is forward-compatible —
  * see `StageDataSchema.surfaceBreakdown` for the wire-format contract.
  *
- * Reuses sprint-25 design tokens (border, card, muted-foreground) and the same
- * `rounded-lg border bg-card/40` shell as the difficulty/weather cards so the
- * three blocks line up visually in the right-hand stage detail panel.
+ * Reuses the shared design tokens (border, card, muted-foreground) and the
+ * same `rounded-lg border bg-card/40` shell as the difficulty/weather cards
+ * so the three blocks line up visually in the right-hand stage detail panel.
  */
 export function StageSurfaceBreakdown({
   breakdown,

--- a/pwa/src/components/StageDetail/StageWeatherCard.test.tsx
+++ b/pwa/src/components/StageDetail/StageWeatherCard.test.tsx
@@ -1,5 +1,13 @@
-import { describe, it, expect } from "vitest";
-import { isSunUp } from "./StageWeatherCard";
+import { render } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { isSunUp, StageWeatherCard } from "./StageWeatherCard";
+
+// Stub next-intl to avoid wiring a NextIntlClientProvider in unit tests.
+// Returning the key suffix is enough to assert rendering logic.
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
 
 describe("isSunUp", () => {
   it("returns null when the stage is not today", () => {
@@ -31,5 +39,74 @@ describe("isSunUp", () => {
     const today = new Date(Date.UTC(2030, 5, 21));
     const now = new Date(Date.UTC(2030, 5, 21, 22, 0, 0));
     expect(isSunUp(today, 5.5, 20.5, now)).toBe(false);
+  });
+});
+
+describe("StageWeatherCard sun-state pill", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // Equatorial reference point keeps sunrise/sunset close to 06:00/18:00 UTC,
+  // which gives stable "is the sun up" expectations independent of the season.
+  const endPointLat = 0;
+  const endPointLon = 0;
+
+  it("hides the pill when isSunUp returns null (stage not today)", () => {
+    // Pin "now" to a date that is not the trip start date.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(Date.UTC(2030, 5, 22, 12, 0, 0)));
+
+    const { queryByTestId } = render(
+      <StageWeatherCard
+        weather={null}
+        startDate="2030-06-21"
+        stageIndex={0}
+        endPointLat={endPointLat}
+        endPointLon={endPointLon}
+      />,
+    );
+
+    // Sun-times footer is rendered (sunrise/sunset known) but the live pill is not.
+    expect(queryByTestId("stage-weather-sun-times")).not.toBeNull();
+    expect(queryByTestId("stage-weather-sun-state")).toBeNull();
+  });
+
+  it("shows the Sun pill during daylight (data-state=\"day\")", () => {
+    // Stage is today, noon UTC at the equator → sun is up.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(Date.UTC(2030, 5, 21, 12, 0, 0)));
+
+    const { getByTestId } = render(
+      <StageWeatherCard
+        weather={null}
+        startDate="2030-06-21"
+        stageIndex={0}
+        endPointLat={endPointLat}
+        endPointLon={endPointLon}
+      />,
+    );
+
+    const pill = getByTestId("stage-weather-sun-state");
+    expect(pill).toHaveAttribute("data-state", "day");
+  });
+
+  it("shows the Moon pill at night (data-state=\"night\")", () => {
+    // Stage is today, 23:00 UTC at the equator → sun is down.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(Date.UTC(2030, 5, 21, 23, 0, 0)));
+
+    const { getByTestId } = render(
+      <StageWeatherCard
+        weather={null}
+        startDate="2030-06-21"
+        stageIndex={0}
+        endPointLat={endPointLat}
+        endPointLon={endPointLon}
+      />,
+    );
+
+    const pill = getByTestId("stage-weather-sun-state");
+    expect(pill).toHaveAttribute("data-state", "night");
   });
 });

--- a/pwa/src/components/StageDetail/StageWeatherCard.test.tsx
+++ b/pwa/src/components/StageDetail/StageWeatherCard.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { isSunUp } from "./StageWeatherCard";
+
+describe("isSunUp", () => {
+  it("returns null when the stage is not today", () => {
+    const stageDate = new Date(Date.UTC(2030, 0, 15));
+    const now = new Date(Date.UTC(2030, 0, 14, 12, 0, 0));
+    // Sunrise 6h, sunset 20h — irrelevant since stage is tomorrow.
+    expect(isSunUp(stageDate, 6, 20, now)).toBeNull();
+  });
+
+  it("returns null when sunrise/sunset are unavailable (polar)", () => {
+    const today = new Date(Date.UTC(2030, 5, 21));
+    const now = new Date(Date.UTC(2030, 5, 21, 12, 0, 0));
+    expect(isSunUp(today, null, null, now)).toBeNull();
+  });
+
+  it("returns true when current UTC time is between sunrise and sunset", () => {
+    const today = new Date(Date.UTC(2030, 5, 21));
+    const now = new Date(Date.UTC(2030, 5, 21, 12, 0, 0));
+    expect(isSunUp(today, 5.5, 20.5, now)).toBe(true);
+  });
+
+  it("returns false before sunrise on the stage day", () => {
+    const today = new Date(Date.UTC(2030, 5, 21));
+    const now = new Date(Date.UTC(2030, 5, 21, 4, 0, 0));
+    expect(isSunUp(today, 5.5, 20.5, now)).toBe(false);
+  });
+
+  it("returns false after sunset on the stage day", () => {
+    const today = new Date(Date.UTC(2030, 5, 21));
+    const now = new Date(Date.UTC(2030, 5, 21, 22, 0, 0));
+    expect(isSunUp(today, 5.5, 20.5, now)).toBe(false);
+  });
+});

--- a/pwa/src/components/StageDetail/StageWeatherCard.tsx
+++ b/pwa/src/components/StageDetail/StageWeatherCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { Sunrise, Sunset, Droplets, Wind, Gauge } from "lucide-react";
+import { Sunrise, Sunset, Droplets, Wind, Gauge, Moon, Sun } from "lucide-react";
 import { weatherIconMap, DefaultWeatherIcon } from "@/lib/weather-icons";
 import {
   computeSunTimes,
@@ -14,6 +14,41 @@ function getComfortColor(index: number): string {
   if (index >= 70) return "text-emerald-500";
   if (index >= 40) return "text-amber-500";
   return "text-red-500";
+}
+
+/**
+ * Returns whether the sun is currently up at the stage's reference point, or
+ * `null` when the comparison is not meaningful (the stage is not today, or
+ * sunrise/sunset are unavailable for the location/date — polar day/night).
+ *
+ * `sunrise` / `sunset` are decimal UTC hours — same convention as
+ * `computeSunTimes`. `now` defaults to the current wall clock; injecting it is
+ * useful in unit tests.
+ */
+export function isSunUp(
+  stageDate: Date | null,
+  sunrise: number | null,
+  sunset: number | null,
+  now: Date = new Date(),
+): boolean | null {
+  if (!stageDate || sunrise === null || sunset === null) return null;
+  // Only show a "live" indicator when the stage date is today (UTC) — the
+  // ride is happening now, not in the future or past.
+  const today = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
+  );
+  const stageDay = new Date(
+    Date.UTC(
+      stageDate.getUTCFullYear(),
+      stageDate.getUTCMonth(),
+      stageDate.getUTCDate(),
+    ),
+  );
+  if (today.getTime() !== stageDay.getTime()) return null;
+
+  const nowDecimal =
+    now.getUTCHours() + now.getUTCMinutes() / 60 + now.getUTCSeconds() / 3600;
+  return nowDecimal >= sunrise && nowDecimal < sunset;
 }
 
 interface StageWeatherCardProps {
@@ -50,17 +85,22 @@ export function StageWeatherCard({
 }: StageWeatherCardProps) {
   const t = useTranslations("weather");
 
-  const sunTimes =
+  const stageDate =
     endPointLat !== undefined && endPointLon !== undefined
-      ? (() => {
-          const stageDate = computeStageDate(startDate ?? null, stageIndex);
-          if (!stageDate) return null;
-          return computeSunTimes(stageDate, endPointLat, endPointLon);
-        })()
+      ? computeStageDate(startDate ?? null, stageIndex)
+      : null;
+  const sunTimes =
+    stageDate && endPointLat !== undefined && endPointLon !== undefined
+      ? computeSunTimes(stageDate, endPointLat, endPointLon)
       : null;
 
   const showSunTimes =
     sunTimes && sunTimes.sunrise !== null && sunTimes.sunset !== null;
+
+  // `null` when the stage isn't today — only render the live badge then.
+  const sunIsUp = sunTimes
+    ? isSunUp(stageDate, sunTimes.sunrise, sunTimes.sunset)
+    : null;
 
   if (!weather && !showSunTimes) {
     return null;
@@ -149,7 +189,7 @@ export function StageWeatherCard({
 
       {showSunTimes && (
         <div
-          className={`flex items-center justify-between gap-3 text-xs text-muted-foreground${weather ? " mt-3 border-t border-border/60 pt-2" : ""}`}
+          className={`flex flex-wrap items-center justify-between gap-3 text-xs text-muted-foreground${weather ? " mt-3 border-t border-border/60 pt-2" : ""}`}
           data-testid="stage-weather-sun-times"
           title={t("sunriseSunsetTooltip")}
         >
@@ -162,6 +202,26 @@ export function StageWeatherCard({
               {t("sunriseShort")}
             </span>
           </div>
+
+          {sunIsUp !== null && (
+            <span
+              data-testid="stage-weather-sun-state"
+              data-state={sunIsUp ? "day" : "night"}
+              className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium ${
+                sunIsUp
+                  ? "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300"
+                  : "bg-slate-200 text-slate-700 dark:bg-slate-800 dark:text-slate-300"
+              }`}
+            >
+              {sunIsUp ? (
+                <Sun className="h-3 w-3" aria-hidden="true" />
+              ) : (
+                <Moon className="h-3 w-3" aria-hidden="true" />
+              )}
+              {sunIsUp ? t("sunStateDay") : t("sunStateNight")}
+            </span>
+          )}
+
           <div className="flex items-center gap-1.5">
             <span className="text-muted-foreground/70">{t("sunsetShort")}</span>
             <span className="tabular-nums">

--- a/pwa/src/components/StageDetail/StageWeatherCard.tsx
+++ b/pwa/src/components/StageDetail/StageWeatherCard.tsx
@@ -1,7 +1,15 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { Sunrise, Sunset, Droplets, Wind, Gauge, Moon, Sun } from "lucide-react";
+import {
+  Sunrise,
+  Sunset,
+  Droplets,
+  Wind,
+  Gauge,
+  Moon,
+  Sun,
+} from "lucide-react";
 import { weatherIconMap, DefaultWeatherIcon } from "@/lib/weather-icons";
 import {
   computeSunTimes,

--- a/pwa/src/components/StageDetail/index.ts
+++ b/pwa/src/components/StageDetail/index.ts
@@ -2,3 +2,4 @@ export { StageAiSummary } from "./StageAiSummary";
 export { StageStatsRow } from "./StageStatsRow";
 export { StageDifficultyComposed } from "./StageDifficultyComposed";
 export { StageWeatherCard } from "./StageWeatherCard";
+export { StageSurfaceBreakdown } from "./StageSurfaceBreakdown";

--- a/pwa/src/components/stage-card.tsx
+++ b/pwa/src/components/stage-card.tsx
@@ -17,6 +17,7 @@ import {
   StageStatsRow,
   StageDifficultyComposed,
   StageWeatherCard,
+  StageSurfaceBreakdown,
 } from "@/components/StageDetail";
 import type { StageData, AccommodationData } from "@/lib/validation/schemas";
 import { useTripStore } from "@/store/trip-store";
@@ -63,6 +64,7 @@ interface StageCardProps {
  *   2. AI summary (Fraunces italic, sparkle, collapsible if long)
  *   3. Stats 4-col (distance editable / D+ / duration / budget)
  *   4. Composed difficulty gauge (physical / technical / elevation)
+ *   4b. Surface breakdown (sprint 27 — issue #403, conditional on backend field)
  *   5. Enriched weather card (forecast + sunrise/sunset)
  *   6. Alerts — collapsible by severity
  *   7. Events — collapsible
@@ -177,6 +179,12 @@ export function StageCard({
             distance={stage.distance}
             elevation={stage.elevation ?? 0}
           />
+        )}
+
+        {/* 4b. Surface breakdown — only when the backend exposes the field
+            (forward-compatible: see StageDataSchema.surfaceBreakdown). */}
+        {stage.surfaceBreakdown && stage.surfaceBreakdown.length > 0 && (
+          <StageSurfaceBreakdown breakdown={stage.surfaceBreakdown} />
         )}
 
         {/* 5. Enriched weather card */}

--- a/pwa/src/components/stage-card.tsx
+++ b/pwa/src/components/stage-card.tsx
@@ -59,12 +59,12 @@ interface StageCardProps {
 /**
  * Right-hand stage detail card.
  *
- * Block order (sprint 26 — issue #395):
+ * Block order:
  *   1. Locations (departure → arrival)
  *   2. AI summary (Fraunces italic, sparkle, collapsible if long)
  *   3. Stats 4-col (distance editable / D+ / duration / budget)
  *   4. Composed difficulty gauge (physical / technical / elevation)
- *   4b. Surface breakdown (sprint 27 — issue #403, conditional on backend field)
+ *   4b. Surface breakdown (conditional — see StageDataSchema.surfaceBreakdown)
  *   5. Enriched weather card (forecast + sunrise/sunset)
  *   6. Alerts — collapsible by severity
  *   7. Events — collapsible

--- a/pwa/src/lib/validation/schemas.ts
+++ b/pwa/src/lib/validation/schemas.ts
@@ -118,6 +118,22 @@ export const AccommodationSchema = z.object({
   openingHours: z.string().nullable().optional(),
 });
 
+/**
+ * Single surface segment in a stage's surface breakdown — pairs an OSM-style
+ * `surface` tag (e.g. `paved`, `gravel`, `cobblestone`, `unknown`) with its
+ * cumulative length in metres along the route. The frontend converts the list
+ * to percentages on the fly.
+ *
+ * NOTE: backend (`StageResponse`) does not yet emit this field. The schema is
+ * forward-compatible so the SurfaceBreakdown component renders automatically
+ * when the field appears, without requiring a frontend release.
+ * TODO(#403 backend follow-up): wire via typegen once the OSM aggregation ships.
+ */
+export const SurfaceSegmentSchema = z.object({
+  surface: z.string(),
+  lengthMeters: z.number().nonnegative(),
+});
+
 export const StageDataSchema = z.object({
   dayNumber: z.number(),
   distance: z.number(),
@@ -151,6 +167,16 @@ export const StageDataSchema = z.object({
    * TODO(#395): wire via typegen once backend StageResponse DTO ships aiSummary
    */
   aiSummary: z.string().nullable().optional(),
+  /**
+   * Optional per-stage surface breakdown — list of `{ surface, lengthMeters }`
+   * pairs aggregated from OSM `surface` tags along the stage. Rendered as a
+   * stacked bar in the stage detail panel (sprint 27 — issue #403). Schema is
+   * forward-compatible: backend may emit this field when available without
+   * breaking existing clients.
+   * TODO(#403): wire via typegen once backend StageResponse DTO ships
+   * `surfaceBreakdown`.
+   */
+  surfaceBreakdown: z.array(SurfaceSegmentSchema).nullable().optional(),
 });
 
 export const TripStateSchema = z.object({
@@ -184,4 +210,5 @@ export type SupplyFoodPointData = z.infer<typeof SupplyFoodPointSchema>;
 export type SupplyMarkerData = z.infer<typeof SupplyMarkerSchema>;
 export type EventData = z.infer<typeof EventSchema>;
 export type AccommodationData = z.infer<typeof AccommodationSchema>;
+export type SurfaceSegmentData = z.infer<typeof SurfaceSegmentSchema>;
 export type StageData = z.infer<typeof StageDataSchema>;

--- a/pwa/src/lib/validation/schemas.ts
+++ b/pwa/src/lib/validation/schemas.ts
@@ -170,9 +170,9 @@ export const StageDataSchema = z.object({
   /**
    * Optional per-stage surface breakdown — list of `{ surface, lengthMeters }`
    * pairs aggregated from OSM `surface` tags along the stage. Rendered as a
-   * stacked bar in the stage detail panel (sprint 27 — issue #403). Schema is
-   * forward-compatible: backend may emit this field when available without
-   * breaking existing clients.
+   * stacked bar in the stage detail panel. Schema is forward-compatible:
+   * backend may emit this field when available without breaking existing
+   * clients.
    * TODO(#403): wire via typegen once backend StageResponse DTO ships
    * `surfaceBreakdown`.
    */


### PR DESCRIPTION
## Summary

Closes #403 — Sprint 27 (Reste du design, issue #375 §9).

**Surface breakdown :**
- `StageSurfaceBreakdown.tsx` (nouveau, conditionnel) : barre stackée + légende avec familles paved / gravel / cobblestone / unpaved / unknown. Logique d'agrégation testée (vitest), retourne `null` si le champ est absent.
- `StageDataSchema` : ajout du champ optionnel `surfaceBreakdown` (forward-compatible, mirror du pattern `aiSummary` introduit en #395).
- Wiring dans `stage-card.tsx` (block 4b entre difficulty et weather) : ne s'affiche que si `stage.surfaceBreakdown` est non vide.

**Sunrise/sunset :**
- `StageWeatherCard.tsx` : ajout d'un pill « Soleil levé / Nuit » avec icônes `Sun` / `Moon`, basé sur le helper `pwa/src/lib/sun-times.ts` (NOAA, déjà côté client). Ne s'affiche que si l'étape tombe aujourd'hui (UTC).
- Tests vitest pour `isSunUp` (jour/nuit/polaire/autre jour).

i18n FR/EN : `surfaceBreakdown.*` namespace + `weather.sunStateDay`/`sunStateNight`.

## Auto-critique

- **`surface_breakdown` n'est pas exposé par le backend.** `AnalyzeTerrainHandler` parse OSM `surface=*` pour `SurfaceAlertAnalyzer` mais aucune agrégation n'est sérialisée dans `StageResponse`. Conformément à l'issue, **pas de modif backend** — le frontend reste conditionnel et s'activera dès qu'un sprint ultérieur ajoutera `surfaceBreakdown` au DTO.
- Sunrise/sunset n'a pas demandé de DTO change : déjà calculé côté client via NOAA helper.

## Test plan

- [ ] Étape avec `surfaceBreakdown` non vide → barre stackée + légende
- [ ] Étape sans `surfaceBreakdown` → block masqué
- [ ] Pill « Soleil levé » visible le jour, « Nuit » la nuit (étapes du jour seulement)
- [ ] Vitest passe pour `StageSurfaceBreakdown.test.tsx` et `StageWeatherCard.test.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

**Findings:** 0 new issues · Commit reviewed: `ea10c90`

All previously flagged sprint-reference comments have been removed in the latest pushes. The surface-breakdown stacked bar and the sun-state pill are well-structured, architecturally consistent with existing patterns, correctly forward-compatible, and fully tested at both the unit and component levels. Ready to merge.

Resolved 2 previously open threads (sprint references in `schemas.ts` surfaceBreakdown JSDoc and in `StageSurfaceBreakdown.tsx` removed).

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Inline comments

No inline comments.

---
Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->