### PR TITLE
feat(share): redesign shared trip view as explicit read-only layout (#404)

### DIFF
--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -680,8 +680,12 @@
     "loading": "Loading shared trip...",
     "error": "This share link is invalid or has been revoked.",
     "backToHome": "Back to home",
-    "readOnlyBanner": "You are viewing a read-only shared trip.",
+    "readOnlyBanner": "Shared view — read only",
     "noStages": "This trip has no stages yet."
+  },
+  "sharedTopBar": {
+    "brand": "Bike Trip Planner",
+    "brandHome": "Bike Trip Planner — home"
   },
   "landing": {
     "hero": {

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -680,8 +680,12 @@
     "loading": "Chargement du voyage partagé...",
     "error": "Ce lien de partage est invalide ou a été révoqué.",
     "backToHome": "Retour à l'accueil",
-    "readOnlyBanner": "Vous consultez un voyage partagé en lecture seule.",
+    "readOnlyBanner": "Vue partagée — lecture seule",
     "noStages": "Ce voyage n'a pas encore d'étapes."
+  },
+  "sharedTopBar": {
+    "brand": "Bike Trip Planner",
+    "brandHome": "Bike Trip Planner — accueil"
   },
   "landing": {
     "hero": {

--- a/pwa/src/app/s/[code]/shared-trip-page.tsx
+++ b/pwa/src/app/s/[code]/shared-trip-page.tsx
@@ -4,17 +4,19 @@ import { useEffect, useMemo, useState, useCallback } from "react";
 import { useTranslations } from "next-intl";
 import { useParams } from "next/navigation";
 import { Suspense } from "react";
-import { Info, Loader2 } from "lucide-react";
+import { Loader2 } from "lucide-react";
 import { TripNotFound } from "@/components/trip-not-found";
-import { Timeline } from "@/components/timeline";
+import { RoadbookMasterDetail } from "@/components/Timeline";
 import { TripSummary } from "@/components/trip-summary";
-import { TripDownloads } from "@/components/trip-downloads";
 import { MapPanel } from "@/components/Map/MapPanel";
 import { ViewModeToggle } from "@/components/ViewModeToggle";
 import { HydrationBoundary } from "@/components/hydration-boundary";
+import { SharedTopBar } from "@/components/shared-top-bar";
+import { SharedViewBanner } from "@/components/shared-view-banner";
 import { fetchSharedTrip } from "@/lib/api/client";
 import { ShareProvider } from "@/lib/share-context";
 import { useUiStore } from "@/store/ui-store";
+import { useTripStore } from "@/store/trip-store";
 import {
   MEAL_COST_MIN,
   MEAL_COST_MAX,
@@ -22,9 +24,13 @@ import {
 } from "@/lib/budget-constants";
 import type { StageData } from "@/lib/validation/schemas";
 
+const noop = () => {};
+
 function SharedTripLoader({ code }: { code: string }) {
   const t = useTranslations("sharePage");
   const viewMode = useUiStore((s) => s.viewMode);
+  const setStagesInStore = useTripStore((s) => s.setStages);
+  const clearTrip = useTripStore((s) => s.clearTrip);
   const [loadError, setLoadError] = useState(false);
   const [isLoaded, setIsLoaded] = useState(false);
   const [title, setTitle] = useState<string | null>(null);
@@ -96,6 +102,11 @@ function SharedTripLoader({ code }: { code: string }) {
         }));
 
         setStages(parsedStages);
+        // Hydrate the trip store so that <RoadbookMasterDetail /> (which
+        // reads `selectedStageIndex` from the store) works correctly. The
+        // store stays local — no `setTrip()` call means no API/PATCH calls
+        // can be issued from this read-only view.
+        setStagesInStore(parsedStages);
 
         const activeStages = parsedStages.filter((s) => !s.isRestDay);
         setTotalDistance(activeStages.reduce((sum, s) => sum + s.distance, 0));
@@ -123,8 +134,11 @@ function SharedTripLoader({ code }: { code: string }) {
 
     return () => {
       cancelled = true;
+      // Reset the trip store so leaving the shared page does not leak
+      // stages into a fresh planner session.
+      clearTrip();
     };
-  }, [code]);
+  }, [code, setStagesInStore, clearTrip]);
 
   const estimatedBudget = useMemo(() => {
     const nonRestStages = stages.filter((s) => !s.isRestDay);
@@ -172,12 +186,15 @@ function SharedTripLoader({ code }: { code: string }) {
 
   if (!isLoaded) {
     return (
-      <main className="max-w-[1200px] mx-auto px-4 md:px-6 py-8 md:py-12">
-        <div className="flex items-center justify-center min-h-[60vh] gap-3 text-muted-foreground">
-          <Loader2 className="h-5 w-5 animate-spin" />
-          <span>{t("loading")}</span>
-        </div>
-      </main>
+      <>
+        <SharedTopBar />
+        <main className="max-w-[1200px] mx-auto px-4 md:px-6 py-8 md:py-12">
+          <div className="flex items-center justify-center min-h-[60vh] gap-3 text-muted-foreground">
+            <Loader2 className="h-5 w-5 animate-spin" />
+            <span>{t("loading")}</span>
+          </div>
+        </main>
+      </>
     );
   }
 
@@ -186,95 +203,102 @@ function SharedTripLoader({ code }: { code: string }) {
 
   return (
     <ShareProvider value={{ shortCode: code, title: title ?? "" }}>
-      <main className="max-w-[1200px] mx-auto px-4 md:px-6 py-8 md:py-12 space-y-6">
-        {/* Read-only banner */}
-        <div
-          data-testid="read-only-banner"
-          className="flex items-center gap-2 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-800 dark:border-blue-800 dark:bg-blue-950/30 dark:text-blue-300"
-        >
-          <Info className="h-4 w-4 shrink-0" />
-          {t("readOnlyBanner")}
-        </div>
+      <SharedTopBar tripTitle={title ?? undefined} />
 
-        {/* Title + downloads */}
-        <div className="flex items-center gap-3">
+      <main className="max-w-[1200px] mx-auto px-4 md:px-6 py-6 md:py-8">
+        <div className="space-y-6">
+          {/* Permanent read-only banner — sits under the top bar. */}
+          <SharedViewBanner />
+
+          {/* Trip title (hero) — separate from the compact title in the top
+              bar so the page still has a clear heading hierarchy. */}
           {title && (
-            <h1 className="text-2xl font-bold tracking-tight flex-1">
-              {title}
-            </h1>
-          )}
-          <TripDownloads tripId={undefined} tripTitle={title ?? ""} />
-        </div>
-
-        {/* Summary */}
-        <TripSummary
-          totalDistance={totalDistance}
-          totalElevation={totalElevation}
-          totalElevationLoss={totalElevationLoss}
-          weather={stages[0]?.weather ?? null}
-          isWeatherLoading={false}
-          isProcessing={false}
-          estimatedBudgetMin={estimatedBudget.min}
-          estimatedBudgetMax={estimatedBudget.max}
-          startDate={startDate}
-          endDate={endDate}
-          fatigueFactor={pacingConfig?.fatigueFactor ?? 0.9}
-          elevationPenalty={pacingConfig?.elevationPenalty ?? 50}
-          maxDistancePerDay={pacingConfig?.maxDistancePerDay ?? 80}
-          averageSpeed={pacingConfig?.averageSpeed ?? 15}
-        />
-
-        {/* View mode toggle */}
-        <div className="flex justify-end">
-          <ViewModeToggle />
-        </div>
-
-        {/* Timeline + Map */}
-        <div className="flex gap-8 relative">
-          {showTimeline && (
-            <div
-              className={
-                viewMode === "split"
-                  ? "flex-1 min-w-0"
-                  : "w-full max-w-[900px] mx-auto"
-              }
-            >
-              {stages.length > 0 ? (
-                <Timeline
-                  stages={stages}
-                  startDate={startDate}
-                  isProcessing={false}
-                  readOnly
-                  onDeleteStage={() => {}}
-                  onAddStage={() => {}}
-                  onAddAccommodation={() => {}}
-                  onUpdateAccommodation={() => {}}
-                  onRemoveAccommodation={() => {}}
-                />
-              ) : (
-                <p className="text-center text-muted-foreground">
-                  {t("noStages")}
-                </p>
-              )}
-            </div>
+            <h1 className="text-2xl font-bold tracking-tight">{title}</h1>
           )}
 
-          {showMap && (
-            <div
-              className={
-                viewMode === "split"
-                  ? "hidden lg:block lg:w-[520px] lg:sticky lg:top-4 lg:h-[calc(100vh-6rem)]"
-                  : "w-full h-[calc(100vh-12rem)]"
-              }
-            >
-              <MapPanel
-                focusedStageIndex={focusedStageIndex}
-                onStageClick={handleStageClick}
-                onResetView={handleResetView}
-                stages={stages}
-              />
-            </div>
-          )}
+          {/* Summary */}
+          <TripSummary
+            totalDistance={totalDistance}
+            totalElevation={totalElevation}
+            totalElevationLoss={totalElevationLoss}
+            weather={stages[0]?.weather ?? null}
+            isWeatherLoading={false}
+            isProcessing={false}
+            estimatedBudgetMin={estimatedBudget.min}
+            estimatedBudgetMax={estimatedBudget.max}
+            startDate={startDate}
+            endDate={endDate}
+            fatigueFactor={pacingConfig?.fatigueFactor ?? 0.9}
+            elevationPenalty={pacingConfig?.elevationPenalty ?? 50}
+            maxDistancePerDay={pacingConfig?.maxDistancePerDay ?? 80}
+            averageSpeed={pacingConfig?.averageSpeed ?? 15}
+          />
+
+          {/* View mode toggle */}
+          <div className="flex justify-end">
+            <ViewModeToggle />
+          </div>
+
+          {/* Master/detail roadbook + map (read-only). The configuration
+              panel, undo/redo, and "+" insertion controls are intentionally
+              omitted in the shared view. */}
+          <div
+            className={[
+              "flex gap-8",
+              viewMode === "split" ? "lg:flex-row flex-col" : "",
+            ].join(" ")}
+            data-testid="split-view-container"
+          >
+            {showTimeline && (
+              <div
+                className={
+                  viewMode === "split" ? "lg:flex-1 lg:min-w-0" : "w-full"
+                }
+              >
+                {stages.length > 0 ? (
+                  <RoadbookMasterDetail
+                    stages={stages}
+                    startDate={startDate}
+                    isProcessing={false}
+                    readOnly
+                    onDeleteStage={noop}
+                    onAddAccommodation={noop}
+                    onUpdateAccommodation={noop}
+                    onRemoveAccommodation={noop}
+                  />
+                ) : (
+                  <p className="text-center text-muted-foreground">
+                    {t("noStages")}
+                  </p>
+                )}
+              </div>
+            )}
+
+            {showMap && (
+              <div
+                className={
+                  viewMode === "split"
+                    ? "lg:w-[520px] lg:shrink-0"
+                    : "w-full h-[calc(100vh-12rem)]"
+                }
+              >
+                <div
+                  className={
+                    viewMode === "split"
+                      ? "lg:sticky lg:top-20 lg:h-[calc(100dvh-6rem)]"
+                      : "w-full h-full"
+                  }
+                >
+                  <MapPanel
+                    focusedStageIndex={focusedStageIndex}
+                    onStageClick={handleStageClick}
+                    onResetView={handleResetView}
+                    stages={stages}
+                  />
+                </div>
+              </div>
+            )}
+          </div>
         </div>
       </main>
     </ShareProvider>

--- a/pwa/src/app/s/[code]/shared-trip-page.tsx
+++ b/pwa/src/app/s/[code]/shared-trip-page.tsx
@@ -186,7 +186,7 @@ function SharedTripLoader({ code }: { code: string }) {
 
   if (!isLoaded) {
     return (
-      <>
+      <ShareProvider value={null}>
         <SharedTopBar />
         <main className="max-w-[1200px] mx-auto px-4 md:px-6 py-8 md:py-12">
           <div className="flex items-center justify-center min-h-[60vh] gap-3 text-muted-foreground">
@@ -194,7 +194,7 @@ function SharedTripLoader({ code }: { code: string }) {
             <span>{t("loading")}</span>
           </div>
         </main>
-      </>
+      </ShareProvider>
     );
   }
 

--- a/pwa/src/app/s/[code]/shared-trip-page.tsx
+++ b/pwa/src/app/s/[code]/shared-trip-page.tsx
@@ -278,7 +278,7 @@ function SharedTripLoader({ code }: { code: string }) {
               <div
                 className={
                   viewMode === "split"
-                    ? "lg:w-[520px] lg:shrink-0"
+                    ? "hidden lg:block lg:w-[520px] lg:shrink-0"
                     : "w-full h-[calc(100vh-12rem)]"
                 }
               >

--- a/pwa/src/app/s/[code]/shared-trip-page.tsx
+++ b/pwa/src/app/s/[code]/shared-trip-page.tsx
@@ -178,9 +178,12 @@ function SharedTripLoader({ code }: { code: string }) {
 
   if (loadError) {
     return (
-      <div data-testid="share-error">
-        <TripNotFound variant="share" />
-      </div>
+      <ShareProvider value={null}>
+        <SharedTopBar />
+        <div data-testid="share-error">
+          <TripNotFound variant="share" />
+        </div>
+      </ShareProvider>
     );
   }
 

--- a/pwa/src/components/shared-top-bar.tsx
+++ b/pwa/src/components/shared-top-bar.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import Link from "next/link";
+import { Bike } from "lucide-react";
+import { TripDownloads } from "@/components/trip-downloads";
+
+interface SharedTopBarProps {
+  /** Trip title rendered next to the brand. Omitted when not loaded yet. */
+  tripTitle?: string;
+}
+
+/**
+ * Simplified top bar for the shared trip view (`/s/[code]`).
+ *
+ * Contrast with the owner top bar in {@link TripPlanner}: there is no
+ * undo/redo, no Share button, no profile menu, no config gear, and no
+ * insertion / deletion controls. Only the brand link (left) and the global
+ * GPX download (right) are exposed.
+ *
+ * The Garmin FIT export from sprint 34 is intentionally omitted until that
+ * feature ships — see issue #404.
+ */
+export function SharedTopBar({ tripTitle }: SharedTopBarProps) {
+  const t = useTranslations("sharedTopBar");
+
+  return (
+    <header
+      data-testid="shared-top-bar"
+      className="sticky top-0 z-30 w-full border-b border-border bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60"
+    >
+      <div className="max-w-[1200px] mx-auto flex items-center gap-4 px-4 md:px-6 h-14">
+        {/* Brand — links back to home */}
+        <Link
+          href="/"
+          className="flex items-center gap-2 font-bold text-base text-brand hover:opacity-80 transition-opacity shrink-0"
+          aria-label={t("brandHome")}
+        >
+          <Bike className="h-5 w-5" aria-hidden="true" />
+          <span className="hidden sm:inline">{t("brand")}</span>
+        </Link>
+
+        {/* Trip title — hidden on small screens to keep the bar compact */}
+        {tripTitle && (
+          <span
+            className="hidden md:block flex-1 min-w-0 truncate text-sm text-muted-foreground"
+            data-testid="shared-top-bar-title"
+            title={tripTitle}
+          >
+            {tripTitle}
+          </span>
+        )}
+
+        {/* Spacer when no title to push the download button to the right */}
+        {!tripTitle && <div className="flex-1" />}
+
+        {/* Global GPX download — only action available in read-only mode */}
+        <div className="shrink-0">
+          <TripDownloads tripId={undefined} tripTitle={tripTitle ?? ""} />
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/pwa/src/components/shared-view-banner.tsx
+++ b/pwa/src/components/shared-view-banner.tsx
@@ -19,7 +19,6 @@ export function SharedViewBanner() {
   return (
     <div
       role="status"
-      aria-live="polite"
       data-testid="read-only-banner"
       className="flex items-center gap-2 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm font-medium text-blue-800 dark:border-blue-800 dark:bg-blue-950/30 dark:text-blue-300"
     >

--- a/pwa/src/components/shared-view-banner.tsx
+++ b/pwa/src/components/shared-view-banner.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { Eye } from "lucide-react";
+
+/**
+ * Permanent read-only banner displayed on the shared trip view (`/s/[code]`).
+ *
+ * Sits directly under the {@link SharedTopBar} to make the read-only nature of
+ * the page unambiguous, distinguishing it from the owner roadbook
+ * (`/trips/[id]`) that uses the same master/detail layout.
+ *
+ * Uses sprint 25 design tokens: rounded-lg, border, blue-toned semantic
+ * surface for an informational (not warning) tone.
+ */
+export function SharedViewBanner() {
+  const t = useTranslations("sharePage");
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      data-testid="read-only-banner"
+      className="flex items-center gap-2 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm font-medium text-blue-800 dark:border-blue-800 dark:bg-blue-950/30 dark:text-blue-300"
+    >
+      <Eye className="h-4 w-4 shrink-0" aria-hidden="true" />
+      <span>{t("readOnlyBanner")}</span>
+    </div>
+  );
+}

--- a/pwa/tests/mocked/share-page.spec.ts
+++ b/pwa/tests/mocked/share-page.spec.ts
@@ -107,6 +107,9 @@ test.describe("/s/[code] page", () => {
       timeout: 10000,
     });
 
+    // Top bar stays mounted in the error branch so the user has a home link
+    await expect(page.getByTestId("shared-top-bar")).toBeVisible();
+
     // Back to home link
     await expect(page.getByRole("link").first()).toBeVisible();
   });

--- a/pwa/tests/mocked/share-page.spec.ts
+++ b/pwa/tests/mocked/share-page.spec.ts
@@ -73,6 +73,16 @@ test.describe("/s/[code] page", () => {
       page.getByRole("heading", { name: "Tour de Bretagne" }),
     ).toBeVisible({ timeout: 10000 });
 
+    // Shared top bar with trip title and GPX download
+    const topBar = page.getByTestId("shared-top-bar");
+    await expect(topBar).toBeVisible();
+    const topBarTitle = page.getByTestId("shared-top-bar-title");
+    await expect(topBarTitle).toBeVisible();
+    await expect(topBarTitle).toHaveText("Tour de Bretagne");
+    await expect(
+      topBar.getByRole("button", { name: "Télécharger le GPX complet" }),
+    ).toBeVisible();
+
     // Trip summary stats
     await expect(page.getByTestId("total-distance")).toBeVisible();
 


### PR DESCRIPTION
## Summary

Closes #404 — Sprint 27 (Reste du design, issue #375 §11). Différencie explicitement la vue partagée `/s/[code]` du roadbook propriétaire `/trips/[id]`.

- `shared-view-banner.tsx` (nouveau) : bandeau permanent « Vue partagée — lecture seule » avec `data-testid="read-only-banner"` (compat E2E) en tokens informationnels sprint 25.
- `shared-top-bar.tsx` (nouveau) : top bar simplifiée — logo + « Bike Trip Planner » (lien `/`), titre voyage optionnel, bouton « Télécharger GPX » global via `<TripDownloads>`. Pas d'undo/redo, pas de bouton Partager, pas de profil.
- `app/s/[code]/shared-trip-page.tsx` (refonte) : remplace l'ancien header inline + `<Timeline>` par `<SharedTopBar>` + `<SharedViewBanner>` + `<RoadbookMasterDetail readOnly>` (master/detail du sprint 26). Hydrate `useTripStore.setStages` (sans `setTrip` pour bloquer les PATCHs) et nettoie le store au démontage.
- i18n FR/EN : update `sharePage.readOnlyBanner`, ajout `sharedTopBar.brand`/`brandHome`.

## Auto-critique

- Bouton « Télécharger FIT » volontairement omis (sprint 34 Garmin pas encore livré) — sera ajouté quand FIT export sera dispo.
- Réutilisation de `<RoadbookMasterDetail readOnly>` plutôt qu'un composant dupliqué : `readOnly` désactive déjà boutons d'insertion, distance editor, actions hébergements.
- Tous les selectors E2E (`read-only-banner`, `stage-card-1`, `stage-card-2`, `share-error`, `total-distance`, h1) préservés.

## Test plan

- [ ] `/s/<code>` affiche le bandeau lecture seule + top bar simplifiée
- [ ] Bouton « Télécharger GPX » fonctionne
- [ ] Pas de boutons d'édition / undo / partage / profil visibles
- [ ] Master/detail navigable (sélection d'étape)
- [ ] Partage révoqué → erreur dédiée
- [ ] E2E `tests/mocked/share-page.spec.ts` passe

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

**Commit reviewed:** `8848b0f5a29a7e8478b099fa935c37f5c2feb3b3`

**Findings:** 0 critical · 0 warning · 0 suggestions

All previously flagged issues have been addressed across the 7 commits. The `setStages`-without-`setTrip` hydration pattern correctly prevents PATCH calls from the read-only view. `TripDownloads` gracefully disables the download button when `!tripId && !share` (loading/error states), so no phantom downloads are possible. The a11y cleanup commit correctly removed the redundant `aria-live` attribute, leaving only the semantically appropriate `role="status"`.

Resolved 1 previously open bot thread (`aria-live` redundant with `role="status"` — addressed in commit `8848b0f`).

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Inline comments

No inline comments.

---
Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->