### PR TITLE
feat(legal): add /legal and /privacy stub pages accessible without auth

### DIFF
--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -924,5 +924,15 @@
     "wikidataCredit": "Data under",
     "datagouvCredit": "Weekly markets (data.gouv.fr) —",
     "licenceOuverte": "Licence Ouverte 2.0"
+  },
+  "legal": {
+    "title": "Legal notice",
+    "comingSoon": "This page will be available soon.",
+    "backToHome": "Back to home"
+  },
+  "privacy": {
+    "title": "Privacy policy",
+    "comingSoon": "This page will be available soon.",
+    "backToHome": "Back to home"
   }
 }

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -924,5 +924,15 @@
     "wikidataCredit": "Données sous",
     "datagouvCredit": "Marchés hebdomadaires (data.gouv.fr) —",
     "licenceOuverte": "Licence Ouverte 2.0"
+  },
+  "legal": {
+    "title": "Mentions légales",
+    "comingSoon": "Cette page sera disponible prochainement.",
+    "backToHome": "Retour à l'accueil"
+  },
+  "privacy": {
+    "title": "Politique de confidentialité",
+    "comingSoon": "Cette page sera disponible prochainement.",
+    "backToHome": "Retour à l'accueil"
   }
 }

--- a/pwa/src/app/legal/page.tsx
+++ b/pwa/src/app/legal/page.tsx
@@ -1,0 +1,25 @@
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { getTranslations } from "next-intl/server";
+
+export default async function LegalPage() {
+  const t = await getTranslations("legal");
+
+  return (
+    <main className="max-w-2xl mx-auto px-4 md:px-6 py-12">
+      <Link
+        href="/"
+        className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground mb-8 transition-colors"
+        data-testid="legal-back-link"
+      >
+        <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+        {t("backToHome")}
+      </Link>
+
+      <div className="mb-10">
+        <h1 className="text-3xl font-bold tracking-tight mb-2">{t("title")}</h1>
+        <p className="text-muted-foreground">{t("comingSoon")}</p>
+      </div>
+    </main>
+  );
+}

--- a/pwa/src/app/privacy/page.tsx
+++ b/pwa/src/app/privacy/page.tsx
@@ -1,0 +1,25 @@
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { getTranslations } from "next-intl/server";
+
+export default async function PrivacyPage() {
+  const t = await getTranslations("privacy");
+
+  return (
+    <main className="max-w-2xl mx-auto px-4 md:px-6 py-12">
+      <Link
+        href="/"
+        className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground mb-8 transition-colors"
+        data-testid="privacy-back-link"
+      >
+        <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+        {t("backToHome")}
+      </Link>
+
+      <div className="mb-10">
+        <h1 className="text-3xl font-bold tracking-tight mb-2">{t("title")}</h1>
+        <p className="text-muted-foreground">{t("comingSoon")}</p>
+      </div>
+    </main>
+  );
+}

--- a/pwa/src/components/StageDetail/StageWeatherCard.test.tsx
+++ b/pwa/src/components/StageDetail/StageWeatherCard.test.tsx
@@ -72,7 +72,7 @@ describe("StageWeatherCard sun-state pill", () => {
     expect(queryByTestId("stage-weather-sun-state")).toBeNull();
   });
 
-  it("shows the Sun pill during daylight (data-state=\"day\")", () => {
+  it('shows the Sun pill during daylight (data-state="day")', () => {
     // Stage is today, noon UTC at the equator → sun is up.
     vi.useFakeTimers();
     vi.setSystemTime(new Date(Date.UTC(2030, 5, 21, 12, 0, 0)));
@@ -91,7 +91,7 @@ describe("StageWeatherCard sun-state pill", () => {
     expect(pill).toHaveAttribute("data-state", "day");
   });
 
-  it("shows the Moon pill at night (data-state=\"night\")", () => {
+  it('shows the Moon pill at night (data-state="night")', () => {
     // Stage is today, 23:00 UTC at the equator → sun is down.
     vi.useFakeTimers();
     vi.setSystemTime(new Date(Date.UTC(2030, 5, 21, 23, 0, 0)));

--- a/pwa/src/components/auth-guard.tsx
+++ b/pwa/src/components/auth-guard.tsx
@@ -8,7 +8,13 @@ import { useAuthStore } from "@/store/auth-store";
  * Paths that do not require authentication.
  * "/" is matched exactly; other entries use startsWith so nested routes are also public.
  */
-const PUBLIC_EXACT_PATHS = ["/", "/faq", "/access-requests/verify"];
+const PUBLIC_EXACT_PATHS = [
+  "/",
+  "/faq",
+  "/legal",
+  "/privacy",
+  "/access-requests/verify",
+];
 const PUBLIC_PREFIX_PATHS = ["/login", "/auth/verify", "/s/"];
 
 function isPublicPath(pathname: string): boolean {
@@ -26,8 +32,8 @@ function isPublicPath(pathname: string): boolean {
  *    from the httpOnly refresh_token cookie.
  * 2. If the user is not authenticated and the current path is protected,
  *    redirects to `/login`.
- * 3. Public pages (`/`, `/faq`, `/access-requests/verify`, `/login`, `/auth/verify/*`, `/s/*`)
- *    are always accessible without authentication.
+ * 3. Public pages (`/`, `/faq`, `/legal`, `/privacy`, `/access-requests/verify`,
+ *    `/login`, `/auth/verify/*`, `/s/*`) are always accessible without authentication.
  *
  * Renders a blank screen during the initial auth check to prevent
  * flashing protected content before the redirect.

--- a/pwa/src/lib/infographic-square.test.ts
+++ b/pwa/src/lib/infographic-square.test.ts
@@ -184,7 +184,11 @@ describe("infographic-square", () => {
     });
     const ctx = (
       canvas.getContext as unknown as {
-        mock: { results: Array<{ value: { fillText: { mock: { calls: unknown[][] } } } }> };
+        mock: {
+          results: Array<{
+            value: { fillText: { mock: { calls: unknown[][] } } };
+          }>;
+        };
       }
     ).mock.results[0]!.value;
     const fillTextCalls = ctx.fillText.mock.calls.map(

--- a/pwa/tests/mocked/legal-privacy.spec.ts
+++ b/pwa/tests/mocked/legal-privacy.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from "@playwright/test";
+import { FAKE_JWT_TOKEN } from "../fixtures/api-mocks";
+
+const PAGES = [
+  { path: "/legal", testid: "legal-back-link", title: "Mentions légales" },
+  {
+    path: "/privacy",
+    testid: "privacy-back-link",
+    title: "Politique de confidentialité",
+  },
+] as const;
+
+for (const { path, testid, title } of PAGES) {
+  test.describe(`${path} page`, () => {
+    test("is publicly accessible without authentication", async ({ page }) => {
+      await page.route("**/auth/refresh", (route, request) => {
+        if (request.method() !== "POST") return route.fallback();
+        return route.fulfill({ status: 401, body: "" });
+      });
+
+      await page.goto(path);
+      await page.waitForLoadState("networkidle");
+
+      // Should NOT redirect to /login
+      await expect(page).toHaveURL(path);
+      await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+    });
+
+    test("renders the localized title in French by default", async ({
+      page,
+    }) => {
+      await page.goto(path);
+      await page.waitForLoadState("networkidle");
+
+      await expect(page.getByRole("heading", { name: title })).toBeVisible({
+        timeout: 5000,
+      });
+    });
+
+    test("back-to-home link navigates to /", async ({ page }) => {
+      await page.route("**/auth/refresh", (route, request) => {
+        if (request.method() !== "POST") return route.fallback();
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ token: FAKE_JWT_TOKEN }),
+        });
+      });
+
+      await page.goto(path);
+      await page.waitForLoadState("networkidle");
+
+      const backLink = page.getByTestId(testid);
+      await expect(backLink).toBeVisible();
+      await backLink.click();
+      await expect(page).toHaveURL("/");
+    });
+  });
+}

--- a/pwa/tests/mocked/trips-list.spec.ts
+++ b/pwa/tests/mocked/trips-list.spec.ts
@@ -174,9 +174,7 @@ test.describe("/trips empty states", () => {
       const url = new URL(request.url());
       const hasTitleFilter = url.searchParams.has("title");
 
-      const body = hasTitleFilter
-        ? { member: [], totalItems: 0 }
-        : MOCK_TRIPS;
+      const body = hasTitleFilter ? { member: [], totalItems: 0 } : MOCK_TRIPS;
 
       return route.fulfill({
         status: 200,
@@ -200,9 +198,7 @@ test.describe("/trips empty states", () => {
 
     // No-results empty state appears.
     await expect(page.getByTestId("trips-empty-no-results")).toBeVisible();
-    await expect(
-      page.getByTestId("trips-empty-active-filters"),
-    ).toBeVisible();
+    await expect(page.getByTestId("trips-empty-active-filters")).toBeVisible();
 
     // Click reset-filters → original trips reappear.
     await page.getByTestId("trips-empty-reset-filters").click();


### PR DESCRIPTION
## Summary

Le footer du landing redesign (#400) ajoute des liens « Mentions légales » → `/legal` et « Confidentialité » → `/privacy`. Sans utilisateur authentifié, ces liens redirigeaient vers `/login` (AuthGuard ne les listait pas comme publics) puis, après ajout aux chemins publics, donnaient un 404 puisque les pages n'existent pas.

Cette PR comble le gap en attendant le sprint 32 :
- Ajoute `/legal` et `/privacy` à `PUBLIC_EXACT_PATHS` dans `auth-guard.tsx`.
- Crée des pages stub minimales (titre + message « bientôt disponible » + lien retour à l'accueil), dans le ton FAQ existant.
- i18n FR/EN : namespaces `legal` et `privacy`.

Le contenu complet (mentions légales structurées, politique RGPD, sommaire sticky, mention Plausible) est livré en sprint 32 (issue #375 §13–14, item 1 du sprint 32).

## Auto-critique

- Choix de pages stub plutôt qu'un retrait des liens du footer : les liens étaient pertinents et déjà testés en place ; un placeholder "À venir" est moins surprenant pour un visiteur qu'un 404 ou la disparition du lien entre deux releases.
- Inclusion de fixes prettier sur 3 fichiers de tests modifiés en sprint 27 (qui faisaient échouer `make qa` sur main) — sinon cette PR n'aurait pas pu passer la CI.

## Test plan

- [ ] Visiter `/legal` sans être connecté → page « Mentions légales » s'affiche, pas de redirection vers `/login`
- [ ] Visiter `/privacy` sans être connecté → page « Politique de confidentialité » s'affiche
- [ ] Liens du footer landing (`/legal` et `/privacy`) atteignent les pages
- [ ] Lien retour à l'accueil fonctionne sur les deux pages
- [ ] CI verte

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

**0 findings.** The PR is clean and ready to merge. The auth-guard update, stub pages, i18n keys, and E2E coverage all follow the existing `/faq` pattern exactly. The previously flagged missing test file (`legal-privacy.spec.ts`) has been added in the follow-up commit.

Resolved 1 previously open thread (E2E coverage was added).

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Inline comments

No inline comments.

---

Reviewed at commit `9d7a94de0f55ea2e1b9a1148f9eb36b01d7481f3`.

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->