### PR TITLE
feat(llm): add cycling system prompts and SystemPromptLoader (#300)

### DIFF
--- a/api/src/Llm/SystemPrompt/stage-analysis.txt
+++ b/api/src/Llm/SystemPrompt/stage-analysis.txt
@@ -1,0 +1,118 @@
+You are an expert bikepacking and cycle-touring analyst. Your task is to analyze a single
+day stage of a self-supported bike trip and provide a concise, actionable briefing for
+the rider.
+
+# Audience and tone
+
+- Audience: an autonomous cyclotourist or bikepacker, riding in {{region}} (typical
+  regions: France, Belgium, Netherlands, EuroVelo network, voies vertes, RAVeL).
+- Rider profile: {{rider_profile}} (e.g. randonneur, gravel/bikepacker, e-bike/VAE,
+  family). Adapt advice to the profile (an e-bike rider needs charging info, a family
+  needs lower daily targets, a gravel rider tolerates rougher surfaces).
+- Tone: factual, friendly, practical. Avoid marketing language. Use the metric system.
+- Output language: {{language}} (default: French if unspecified).
+- Date of the ride: {{date}}.
+
+# Cycling terminology you must use correctly
+
+- Surface types: asphalte/asphalt, gravel/gravier, chemin/path, pavé/cobblestone,
+  single-track, voie verte (greenway), piste cyclable (cycle path).
+- Gradients: faux-plat, côte, raidillon, col.
+- Profiles: randonneur, gravel, bikepacker, VAE/e-bike, vélo de route, VTC.
+- Logistics: ravitaillement (resupply), point d'eau (water point), bivouac, gîte,
+  refuge, camping, autonomie (range), dénivelé (elevation gain/D+).
+
+# Input format
+
+You will receive a single JSON object describing the stage. Expected fields (some may
+be absent — handle gracefully):
+
+```json
+{
+  "stage_number": 3,
+  "distance_km": 78.4,
+  "elevation_gain_m": 920,
+  "elevation_loss_m": 880,
+  "surface_breakdown": {"asphalt": 62, "gravel": 28, "path": 10},
+  "weather": {"temp_min_c": 8, "temp_max_c": 19, "precip_mm": 4, "wind_kmh": 22, "wind_dir": "NW"},
+  "alerts": ["steep_descent_km42", "no_water_50km_segment"],
+  "water_points": 3,
+  "resupply": [{"name": "Boulangerie Dupont", "km": 34}],
+  "accommodations": [{"type": "camping", "name": "Camping du Lac", "km": 78}],
+  "arrival_time": "18:42",
+  "sunset": "20:15",
+  "start_location": "Cluny",
+  "end_location": "Mâcon"
+}
+```
+
+# Output format
+
+Produce a Markdown briefing with EXACTLY these three sections, in this order:
+
+## Synthèse
+A short narrative paragraph (3-5 sentences, ~80 words max) summarising the stage:
+distance, profile, dominant surface, weather context, and overall difficulty
+assessment for the rider profile.
+
+## Insights
+3 to 5 bullet points highlighting non-obvious facts the rider should know: surface
+transitions, weather/wind interaction with the route direction, exposure to sun,
+sparse resupply zones, late arrival vs. sunset margin, climbing concentration.
+
+## Recommandations
+2 to 4 actionable suggestions, each one short and concrete. Examples: "Faire le
+plein d'eau à Cluny avant le segment de 50 km sans point d'eau", "Partir avant 8h
+pour éviter la chaleur sur le plateau exposé".
+
+# Hard constraints
+
+- Output MUST be under 500 tokens total.
+- Do NOT invent data not present in the input. If a field is missing, do not mention
+  it instead of guessing.
+- Do NOT repeat the raw JSON in your output.
+- Do NOT add extra sections, disclaimers, or apologies.
+
+# Few-shot example
+
+Input:
+```json
+{
+  "stage_number": 2,
+  "distance_km": 92.1,
+  "elevation_gain_m": 1240,
+  "elevation_loss_m": 1180,
+  "surface_breakdown": {"asphalt": 45, "gravel": 50, "path": 5},
+  "weather": {"temp_min_c": 12, "temp_max_c": 28, "precip_mm": 0, "wind_kmh": 18, "wind_dir": "S"},
+  "alerts": ["no_water_45km_segment", "steep_climb_km60"],
+  "water_points": 2,
+  "resupply": [{"name": "Épicerie du Village", "km": 28}],
+  "accommodations": [{"type": "gite", "name": "Gîte des Cévennes", "km": 92}],
+  "arrival_time": "19:20",
+  "sunset": "21:05",
+  "start_location": "Florac",
+  "end_location": "Le Pont-de-Montvert"
+}
+```
+
+Expected output:
+
+## Synthèse
+Étape exigeante de 92 km avec 1240 m de D+, dominée par le gravel (50 %) sur les
+crêtes cévenoles. Météo chaude (jusqu'à 28 °C) et sèche, avec un vent de sud
+modéré qui sera de face sur la deuxième moitié. Profil cassant, ravitaillements
+rares : prévoir une vraie autonomie en eau.
+
+## Insights
+- Long segment sans point d'eau de 45 km après Florac : à anticiper avant le départ.
+- Raidillon marqué au km 60 sous la chaleur de l'après-midi — combinaison
+  potentiellement éprouvante.
+- Le vent de sud freinera la progression après le col, allongeant l'effort vers
+  Le Pont-de-Montvert.
+- Arrivée prévue à 19h20 avec une marge confortable de 1h45 avant le coucher du
+  soleil.
+
+## Recommandations
+- Faire le plein d'eau (3 L minimum) à Florac et recharger à l'épicerie km 28.
+- Partir avant 7h30 pour boucler le raidillon avant le pic de chaleur.
+- Confirmer la disponibilité du gîte des Cévennes la veille au soir.

--- a/api/src/Llm/SystemPrompt/trip-overview.txt
+++ b/api/src/Llm/SystemPrompt/trip-overview.txt
@@ -1,0 +1,119 @@
+You are an expert bikepacking and cycle-touring coach. Your task is to take the
+per-stage briefings already produced for a multi-day self-supported trip and
+synthesise a global overview of the journey for the rider.
+
+# Audience and tone
+
+- Audience: an autonomous cyclotourist or bikepacker, riding in {{region}} (typical
+  regions: France, Belgium, Netherlands, EuroVelo network).
+- Rider profile: {{rider_profile}}.
+- Tone: factual, supportive coach. No marketing fluff. Metric system.
+- Output language: {{language}} (default: French if unspecified).
+- Trip start date: {{date}}.
+
+# Cycling terminology you must use correctly
+
+- Effort/recovery: charge, fatigue cumulative, jour de récupération, intensité.
+- Surface mix, dénivelé total (total elevation gain), kilométrage moyen.
+- Logistics: étape de ravitaillement, étape engagée (committed), point d'étape clé.
+
+# Input format
+
+You will receive an array of per-stage summaries (one per day) plus a rider profile
+block. Each stage summary already contains "Synthèse / Insights / Recommandations".
+The total input size is ~2000-3000 tokens.
+
+```json
+{
+  "rider_profile": {
+    "type": "gravel",
+    "fitness": "intermediate",
+    "constraints": ["solo", "self-supported"]
+  },
+  "stages": [
+    {"stage_number": 1, "distance_km": 65, "elevation_gain_m": 600, "summary": "..."},
+    {"stage_number": 2, "distance_km": 92, "elevation_gain_m": 1240, "summary": "..."},
+    {"stage_number": 3, "distance_km": 78, "elevation_gain_m": 920, "summary": "..."}
+  ]
+}
+```
+
+# Output format
+
+Produce a Markdown briefing with EXACTLY these four sections, in this order:
+
+## Vue d'ensemble
+2-4 sentences describing the trip as a whole: total distance, total D+, number of
+days, dominant surface mix, geographic logic of the route.
+
+## Charge et fatigue cumulative
+Analyse how effort accumulates across stages. Identify the toughest day, any
+back-to-back hard days, and whether the pacing leaves recovery margin. Reference
+specific stage numbers.
+
+## Patterns transversaux
+3 to 5 bullets covering recurring themes: weather windows, sparse resupply zones
+that span multiple days, surface transitions between regions, exposure patterns,
+gear/autonomy considerations valid across the whole trip.
+
+## Recommandations globales
+3 to 5 actionable, trip-level suggestions. Examples: re-order stages, plan a rest
+day, schedule resupply on a specific stage, anticipate gear/clothing needs for a
+weather shift mid-trip.
+
+# Hard constraints
+
+- Output MUST be under 800 tokens total.
+- Do NOT repeat the per-stage briefings verbatim. Synthesise.
+- Do NOT invent data not present in the input.
+- Do NOT add extra sections, disclaimers, or apologies.
+
+# Few-shot example
+
+Input (abridged):
+```json
+{
+  "rider_profile": {"type": "gravel", "fitness": "intermediate", "constraints": ["solo"]},
+  "stages": [
+    {"stage_number": 1, "distance_km": 65, "elevation_gain_m": 600,
+     "summary": "Étape d'approche roulante, asphalte 80%, météo douce, ravitaillement abondant."},
+    {"stage_number": 2, "distance_km": 92, "elevation_gain_m": 1240,
+     "summary": "Étape exigeante, gravel 50%, chaleur 28°C, segment 45km sans eau, raidillon km60."},
+    {"stage_number": 3, "distance_km": 78, "elevation_gain_m": 920,
+     "summary": "Crêtes cévenoles, gravel dominant, vent de face, arrivée 18h42 (sunset 20h15)."}
+  ]
+}
+```
+
+Expected output:
+
+## Vue d'ensemble
+Trip de 3 jours sur 235 km cumulés et 2760 m de D+, traversant le Massif Central
+avec une montée progressive en engagement. Profil mixte asphalte/gravel cohérent
+avec une pratique gravel intermédiaire en autonomie.
+
+## Charge et fatigue cumulative
+L'étape 1 sert d'échauffement (faible D+, ravitaillement facile), puis les étapes
+2 et 3 enchaînent deux journées exigeantes en gravel et en dénivelé sans jour de
+récupération intercalé. La J2 est clairement la plus dure (1240 m de D+ et chaleur),
+la J3 ajoute du vent de face — la fatigue cumulative culmine en fin de J3.
+
+## Patterns transversaux
+- Les zones sans point d'eau apparaissent dès J2 et persistent en J3 : autonomie
+  hydrique de 3 L à prévoir systématiquement à partir de J2.
+- Le mix surface bascule progressivement de l'asphalte (J1) vers le gravel
+  dominant (J2-J3) : pneumatiques gravel > 40 mm fortement conseillés.
+- Les arrivées se font tard l'après-midi (18h-19h) avec marge décroissante avant
+  le coucher du soleil : importance de partir tôt à partir de J2.
+- Pas de précipitations annoncées sur les 3 jours — fenêtre météo stable mais
+  chaude.
+
+## Recommandations globales
+- Insérer une vraie pause/récup à mi-J2 (siesta + ravitaillement à l'épicerie km 28)
+  pour absorber la double charge J2+J3.
+- Charger 3 L d'eau au départ de J2 et J3, identifier les points d'eau de
+  remplissage avant le départ chaque matin.
+- Préparer un plan B d'hébergement pour la fin J3 si la fatigue impose un arrêt
+  anticipé avant Le Pont-de-Montvert.
+- Partir avant 8h sur J2 et J3 pour éviter chaleur de l'après-midi et garder une
+  marge confortable avant le coucher du soleil.

--- a/api/src/Llm/SystemPromptLoader.php
+++ b/api/src/Llm/SystemPromptLoader.php
@@ -49,8 +49,8 @@ final readonly class SystemPromptLoader
             throw new \InvalidArgumentException('Prompt name must not be empty.');
         }
 
-        if (str_contains($promptName, '/') || str_contains($promptName, '\\') || str_contains($promptName, "\0")) {
-            throw new \InvalidArgumentException(\sprintf('Prompt name "%s" must not contain path separators.', $promptName));
+        if (str_contains($promptName, '/') || str_contains($promptName, '\\') || str_contains($promptName, "\0") || '.' === $promptName || '..' === $promptName) {
+            throw new \InvalidArgumentException(\sprintf('Prompt name "%s" must not contain path separators, null bytes, or be a relative-path reference.', $promptName));
         }
 
         $path = $this->promptDir.\DIRECTORY_SEPARATOR.$promptName.self::EXTENSION;

--- a/api/src/Llm/SystemPromptLoader.php
+++ b/api/src/Llm/SystemPromptLoader.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Llm;
+
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * Loads versioned LLM system prompts from disk and substitutes placeholder variables.
+ *
+ * Prompt files live next to the source code (under `api/src/Llm/SystemPrompt/`) so they
+ * are versioned with the codebase and reviewed alongside the prompt-engineering changes.
+ *
+ * Placeholders use the `{{variable_name}}` syntax and are replaced via simple
+ * string substitution — no Twig dependency, no expression evaluation, no surprises.
+ */
+final readonly class SystemPromptLoader
+{
+    private const string EXTENSION = '.txt';
+
+    private string $promptDir;
+
+    public function __construct(
+        #[Autowire('%kernel.project_dir%/src/Llm/SystemPrompt')]
+        string $promptDir,
+    ) {
+        $this->promptDir = rtrim($promptDir, \DIRECTORY_SEPARATOR);
+    }
+
+    /**
+     * Loads a prompt by name (without the `.txt` extension) and substitutes
+     * the provided placeholder values.
+     *
+     * Any placeholder left in the template after substitution is left as-is
+     * (no exception thrown) so that callers may layer multiple substitution
+     * passes if needed.
+     *
+     * @param non-empty-string     $promptName Filename without extension, e.g. `stage-analysis`.
+     *                                         Must not contain path separators.
+     * @param array<string,scalar> $variables  Map of placeholder name → replacement value.
+     *
+     * @throws \InvalidArgumentException if the prompt name is empty or contains separators.
+     * @throws \RuntimeException         if the prompt file cannot be found or read.
+     */
+    public function load(string $promptName, array $variables = []): string
+    {
+        if ('' === $promptName) {
+            throw new \InvalidArgumentException('Prompt name must not be empty.');
+        }
+
+        if (str_contains($promptName, '/') || str_contains($promptName, '\\') || str_contains($promptName, "\0")) {
+            throw new \InvalidArgumentException(\sprintf('Prompt name "%s" must not contain path separators.', $promptName));
+        }
+
+        $path = $this->promptDir.\DIRECTORY_SEPARATOR.$promptName.self::EXTENSION;
+
+        if (!is_file($path)) {
+            throw new \RuntimeException(\sprintf('System prompt "%s" not found at "%s".', $promptName, $path));
+        }
+
+        $template = @file_get_contents($path);
+
+        if (false === $template) {
+            throw new \RuntimeException(\sprintf('Failed to read system prompt "%s" at "%s".', $promptName, $path));
+        }
+
+        if ([] === $variables) {
+            return $template;
+        }
+
+        $search = [];
+        $replace = [];
+
+        foreach ($variables as $name => $value) {
+            $search[] = '{{'.$name.'}}';
+            $replace[] = (string) $value;
+        }
+
+        return str_replace($search, $replace, $template);
+    }
+}

--- a/api/src/Llm/SystemPromptLoader.php
+++ b/api/src/Llm/SystemPromptLoader.php
@@ -38,10 +38,10 @@ final readonly class SystemPromptLoader
      *
      * @param non-empty-string     $promptName Filename without extension, e.g. `stage-analysis`.
      *                                         Must not contain path separators.
-     * @param array<string,scalar> $variables  Map of placeholder name → replacement value.
+     * @param array<string,scalar> $variables  map of placeholder name → replacement value
      *
-     * @throws \InvalidArgumentException if the prompt name is empty or contains separators.
-     * @throws \RuntimeException         if the prompt file cannot be found or read.
+     * @throws \InvalidArgumentException if the prompt name is empty or contains separators
+     * @throws \RuntimeException         if the prompt file cannot be found or read
      */
     public function load(string $promptName, array $variables = []): string
     {

--- a/api/src/Llm/SystemPromptLoader.php
+++ b/api/src/Llm/SystemPromptLoader.php
@@ -77,6 +77,8 @@ final readonly class SystemPromptLoader
             $replace[] = (string) $value;
         }
 
+        // str_replace with arrays is sequential: each replacement is applied on the already-
+        // substituted string. Variable values must not contain the {{…}} delimiter themselves.
         return str_replace($search, $replace, $template);
     }
 }

--- a/api/tests/Unit/Llm/SystemPromptLoaderTest.php
+++ b/api/tests/Unit/Llm/SystemPromptLoaderTest.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Llm;
+
+use App\Llm\SystemPromptLoader;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class SystemPromptLoaderTest extends TestCase
+{
+    private string $tmpDir;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'system-prompt-loader-'.bin2hex(random_bytes(4));
+
+        if (!mkdir($this->tmpDir, 0o755, true) && !is_dir($this->tmpDir)) {
+            throw new \RuntimeException(\sprintf('Failed to create tmp dir "%s".', $this->tmpDir));
+        }
+    }
+
+    #[\Override]
+    protected function tearDown(): void
+    {
+        if (!is_dir($this->tmpDir)) {
+            return;
+        }
+
+        foreach (glob($this->tmpDir.\DIRECTORY_SEPARATOR.'*') ?: [] as $file) {
+            unlink($file);
+        }
+        rmdir($this->tmpDir);
+    }
+
+    #[Test]
+    public function loadReturnsRawTemplateWhenNoVariablesProvided(): void
+    {
+        $this->writePrompt('greeting', "Hello {{name}}, welcome to {{place}}.\n");
+
+        $loader = new SystemPromptLoader($this->tmpDir);
+
+        self::assertSame("Hello {{name}}, welcome to {{place}}.\n", $loader->load('greeting'));
+    }
+
+    #[Test]
+    public function loadSubstitutesProvidedPlaceholders(): void
+    {
+        $this->writePrompt('greeting', 'Hello {{name}}, welcome to {{place}}.');
+
+        $loader = new SystemPromptLoader($this->tmpDir);
+
+        $output = $loader->load('greeting', ['name' => 'Alice', 'place' => 'Cluny']);
+
+        self::assertSame('Hello Alice, welcome to Cluny.', $output);
+    }
+
+    #[Test]
+    public function loadLeavesUnknownPlaceholdersUntouched(): void
+    {
+        $this->writePrompt('partial', 'Hello {{name}} on {{date}}.');
+
+        $loader = new SystemPromptLoader($this->tmpDir);
+
+        $output = $loader->load('partial', ['name' => 'Bob']);
+
+        self::assertSame('Hello Bob on {{date}}.', $output);
+    }
+
+    #[Test]
+    public function loadAcceptsScalarVariables(): void
+    {
+        $this->writePrompt('scalars', 'Stage {{n}} of {{total}} — distance: {{km}} km, sunny: {{sunny}}.');
+
+        $loader = new SystemPromptLoader($this->tmpDir);
+
+        $output = $loader->load('scalars', [
+            'n' => 1,
+            'total' => 3,
+            'km' => 78.4,
+            'sunny' => true,
+        ]);
+
+        self::assertSame('Stage 1 of 3 — distance: 78.4 km, sunny: 1.', $output);
+    }
+
+    #[Test]
+    public function loadTrimsTrailingDirectorySeparatorOnConstruction(): void
+    {
+        $this->writePrompt('trimmed', 'ok');
+
+        $loader = new SystemPromptLoader($this->tmpDir.\DIRECTORY_SEPARATOR);
+
+        self::assertSame('ok', $loader->load('trimmed'));
+    }
+
+    #[Test]
+    public function loadThrowsWhenPromptFileIsMissing(): void
+    {
+        $loader = new SystemPromptLoader($this->tmpDir);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('System prompt "missing" not found');
+
+        $loader->load('missing');
+    }
+
+    #[Test]
+    public function loadThrowsOnEmptyPromptName(): void
+    {
+        $loader = new SystemPromptLoader($this->tmpDir);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Prompt name must not be empty.');
+
+        $loader->load('');
+    }
+
+    #[Test]
+    public function loadRejectsForwardSlashInPromptName(): void
+    {
+        $loader = new SystemPromptLoader($this->tmpDir);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('must not contain path separators');
+
+        $loader->load('../escape');
+    }
+
+    #[Test]
+    public function loadRejectsBackslashInPromptName(): void
+    {
+        $loader = new SystemPromptLoader($this->tmpDir);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('must not contain path separators');
+
+        $loader->load('escape\\windows');
+    }
+
+    #[Test]
+    public function loadRejectsNullByteInPromptName(): void
+    {
+        $loader = new SystemPromptLoader($this->tmpDir);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('must not contain path separators');
+
+        $loader->load("nul\0byte");
+    }
+
+    #[Test]
+    public function shippedStageAnalysisPromptIsLoadable(): void
+    {
+        $loader = new SystemPromptLoader(__DIR__.'/../../../src/Llm/SystemPrompt');
+
+        $output = $loader->load('stage-analysis', [
+            'region' => 'France',
+            'rider_profile' => 'gravel',
+            'language' => 'fr',
+            'date' => '2026-05-06',
+        ]);
+
+        self::assertStringNotContainsString('{{region}}', $output);
+        self::assertStringNotContainsString('{{rider_profile}}', $output);
+        self::assertStringContainsString('France', $output);
+        self::assertStringContainsString('gravel', $output);
+    }
+
+    #[Test]
+    public function shippedTripOverviewPromptIsLoadable(): void
+    {
+        $loader = new SystemPromptLoader(__DIR__.'/../../../src/Llm/SystemPrompt');
+
+        $output = $loader->load('trip-overview', [
+            'region' => 'EuroVelo',
+            'rider_profile' => 'randonneur',
+            'language' => 'fr',
+            'date' => '2026-05-06',
+        ]);
+
+        self::assertStringNotContainsString('{{region}}', $output);
+        self::assertStringNotContainsString('{{rider_profile}}', $output);
+        self::assertStringContainsString('EuroVelo', $output);
+        self::assertStringContainsString('randonneur', $output);
+    }
+
+    #[Test]
+    public function shippedPromptsRespectTokenBudgets(): void
+    {
+        // Approximation: 1 token ~ 4 characters for English/French mixed text.
+        // We allow generous headroom so the few-shot example keeps the prompts well under
+        // the model's context window. The runtime <500/<800 token *output* budgets are
+        // enforced by the model, not by the prompt length itself.
+        $stage = file_get_contents(__DIR__.'/../../../src/Llm/SystemPrompt/stage-analysis.txt');
+        $trip = file_get_contents(__DIR__.'/../../../src/Llm/SystemPrompt/trip-overview.txt');
+
+        self::assertNotFalse($stage);
+        self::assertNotFalse($trip);
+
+        // Sanity bounds: must be long enough to be useful, short enough to fit comfortably
+        // alongside user input in an 8B model's context window (~8k tokens).
+        self::assertGreaterThan(500, mb_strlen($stage));
+        self::assertGreaterThan(500, mb_strlen($trip));
+        self::assertLessThan(8000, mb_strlen($stage));
+        self::assertLessThan(8000, mb_strlen($trip));
+    }
+
+    private function writePrompt(string $name, string $contents): void
+    {
+        $path = $this->tmpDir.\DIRECTORY_SEPARATOR.$name.'.txt';
+
+        if (false === file_put_contents($path, $contents)) {
+            throw new \RuntimeException(\sprintf('Failed to write prompt "%s".', $path));
+        }
+    }
+}

--- a/api/tests/Unit/Llm/SystemPromptLoaderTest.php
+++ b/api/tests/Unit/Llm/SystemPromptLoaderTest.php
@@ -32,6 +32,7 @@ final class SystemPromptLoaderTest extends TestCase
         foreach (glob($this->tmpDir.\DIRECTORY_SEPARATOR.'*') ?: [] as $file) {
             unlink($file);
         }
+
         rmdir($this->tmpDir);
     }
 
@@ -115,6 +116,7 @@ final class SystemPromptLoaderTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Prompt name must not be empty.');
 
+        // @phpstan-ignore argument.type (intentional: this test verifies the runtime guard against empty input)
         $loader->load('');
     }
 

--- a/api/tests/Unit/Llm/SystemPromptLoaderTest.php
+++ b/api/tests/Unit/Llm/SystemPromptLoaderTest.php
@@ -177,6 +177,28 @@ final class SystemPromptLoaderTest extends TestCase
     }
 
     #[Test]
+    public function loadRejectsSingleDotPromptName(): void
+    {
+        $loader = new SystemPromptLoader($this->tmpDir);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('must not contain path separators');
+
+        $loader->load('.');
+    }
+
+    #[Test]
+    public function loadRejectsDoubleDotPromptName(): void
+    {
+        $loader = new SystemPromptLoader($this->tmpDir);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('must not contain path separators');
+
+        $loader->load('..');
+    }
+
+    #[Test]
     public function shippedStageAnalysisPromptIsLoadable(): void
     {
         $loader = new SystemPromptLoader(__DIR__.'/../../../src/Llm/SystemPrompt');

--- a/api/tests/Unit/Llm/SystemPromptLoaderTest.php
+++ b/api/tests/Unit/Llm/SystemPromptLoaderTest.php
@@ -109,6 +109,29 @@ final class SystemPromptLoaderTest extends TestCase
     }
 
     #[Test]
+    public function loadThrowsWhenPromptFileIsUnreadable(): void
+    {
+        if (0 === \posix_getuid()) {
+            self::markTestSkipped('Cannot test file-permission denial when running as root.');
+        }
+
+        $path = $this->tmpDir.\DIRECTORY_SEPARATOR.'unreadable.txt';
+        file_put_contents($path, 'content');
+        chmod($path, 0o000);
+
+        $loader = new SystemPromptLoader($this->tmpDir);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Failed to read system prompt "unreadable"');
+
+        try {
+            $loader->load('unreadable');
+        } finally {
+            chmod($path, 0o644);
+        }
+    }
+
+    #[Test]
     public function loadThrowsOnEmptyPromptName(): void
     {
         $loader = new SystemPromptLoader($this->tmpDir);


### PR DESCRIPTION
Closes #300.

## Summary

- Adds two versioned LLaMA 8B system prompts under `api/src/Llm/SystemPrompt/` :
  - `stage-analysis.txt` — pass 1, per-stage analysis, role: cycling-tour analyst, output Markdown 3 sections (Synthèse / Insights / Recommandations), 1 few-shot example (Florac → Le Pont-de-Montvert), &lt;500 tokens.
  - `trip-overview.txt` — pass 2, trip overview, role: cycling-tour coach, output 4 sections (Vue d'ensemble / Charge / Patterns / Recommandations globales), few-shot 3 stages, &lt;800 tokens.
- Adds `App\Llm\SystemPromptLoader` (`final readonly`) with placeholder substitution (`{{var}}` via `str_replace`), path-traversal guards (slash/backslash/null byte), and an explicit `RuntimeException` for missing files.
- Adds 12 unit tests in `api/tests/Unit/Llm/SystemPromptLoaderTest.php` covering substitution, scalar coercion, missing files, traversal rejection, and a real load of both shipped prompts.

## Auto-critique

- The loader has **no dependency on `OllamaClient` (#298)** — it is a pure file-loading utility, so it can be tested and used independently. The actual prompt → LLM wiring lands in #301-#303.
- The two prompt files are **deliberately verbose** (few-shot included) to anchor the model to cycling-tour terminology. They are versioned with the code so reviews catch prompt drift.
- One PHPStan suppression (`@phpstan-ignore argument.type`) was added on the empty-string test, because the public type contract (`non-empty-string`) is what guards normal callers — the runtime check exists for defense-in-depth and the test verifies it.
- E2E tests show 16 pre-existing failures on `main` unrelated to this PR (backend-only change, no UI surface touched).

## Test plan

- [ ] CI green on the PR.
- [ ] Reviewer reads the two prompts and confirms the cycling-tour framing/terminology.

<!-- claude-review-start -->
## Claude Review

**Reviewed commit:** `eb32cc5`

### Summary

The PR is in excellent shape. All three previously flagged bot-review threads have been resolved by follow-up commits: the `str_replace` sequential-substitution caveat is documented with an inline comment, `loadThrowsWhenPromptFileIsUnreadable` is implemented with a root-skip guard, and the bare `.` / `..` path-traversal gap is now closed. The `SystemPromptLoader` is a clean, well-tested, security-conscious file-loader with comprehensive edge-case coverage across 16 unit tests.

### Resolved threads
Resolved 1 previously open thread addressed by commit `eb32cc5` (bare `.` / `..` guard now added to the traversal deny-list).

### Review checklist
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for (#298, #301–#303 referenced)

### Inline comments
No inline comments.

---
Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->