### PR TITLE
chore(tracking): record sprint 28 PRs (#435-#438)

### DIFF
--- a/TRACKING.md
+++ b/TRACKING.md
@@ -508,10 +508,10 @@ Service OllamaClient PHP, configuration Docker Ollama, gate mechanism dans Compu
 
 | Ordre | ID                                                                      | Titre                                                              | Effort | PRs | Dépend de |
 |-------|-------------------------------------------------------------------------|--------------------------------------------------------------------|--------|-----|-----------|
-| 1     | [#297](https://github.com/vincentchalamon/bike-trip-planner/issues/297) | ADR-027 : architecture Ollama/LLaMA (2 passes, context)            | S      |     | —         |
-| 2     | [#298](https://github.com/vincentchalamon/bike-trip-planner/issues/298) | Service OllamaClient PHP + configuration Docker Ollama             | M      |     | —         |
-| 3     | [#299](https://github.com/vincentchalamon/bike-trip-planner/issues/299) | Gate mechanism dans ComputationTracker                             | M      |     | —         |
-| 4     | [#300](https://github.com/vincentchalamon/bike-trip-planner/issues/300) | System prompts cyclotourisme versionnés (LLaMA 8B)                 | S      |     | —         |
+| 1     | [#297](https://github.com/vincentchalamon/bike-trip-planner/issues/297) | ADR-027 : architecture Ollama/LLaMA (2 passes, context)            | S      | [#435](https://github.com/vincentchalamon/bike-trip-planner/pull/435) `feature/297` | —         |
+| 2     | [#298](https://github.com/vincentchalamon/bike-trip-planner/issues/298) | Service OllamaClient PHP + configuration Docker Ollama             | M      | [#437](https://github.com/vincentchalamon/bike-trip-planner/pull/437) `feature/298` | —         |
+| 3     | [#299](https://github.com/vincentchalamon/bike-trip-planner/issues/299) | Gate mechanism dans ComputationTracker                             | M      | [#438](https://github.com/vincentchalamon/bike-trip-planner/pull/438) `feature/299` | —         |
+| 4     | [#300](https://github.com/vincentchalamon/bike-trip-planner/issues/300) | System prompts cyclotourisme versionnés (LLaMA 8B)                 | S      | [#436](https://github.com/vincentchalamon/bike-trip-planner/pull/436) `feature/300` | —         |
 
 ---
 

--- a/TRACKING.md
+++ b/TRACKING.md
@@ -504,11 +504,11 @@ Refonte des écrans restants : `/trips`, landing, auth, états UX transverses, v
 
 ## Sprint 28 — Intégration Ollama : fondations backend
 
-Service OllamaClient PHP, configuration Docker Ollama, gate mechanism dans ComputationTracker, system prompts cyclotourisme versionnés. ADR-027.
+Service OllamaClient PHP, configuration Docker Ollama, gate mechanism dans ComputationTracker, system prompts cyclotourisme versionnés. ADR-028.
 
 | Ordre | ID                                                                      | Titre                                                              | Effort | PRs | Dépend de |
 |-------|-------------------------------------------------------------------------|--------------------------------------------------------------------|--------|-----|-----------|
-| 1     | [#297](https://github.com/vincentchalamon/bike-trip-planner/issues/297) | ADR-027 : architecture Ollama/LLaMA (2 passes, context)            | S      | [#435](https://github.com/vincentchalamon/bike-trip-planner/pull/435) `feature/297` | —         |
+| 1     | [#297](https://github.com/vincentchalamon/bike-trip-planner/issues/297) | ADR-028 : architecture Ollama/LLaMA (2 passes, context)            | S      | [#435](https://github.com/vincentchalamon/bike-trip-planner/pull/435) `feature/297` | —         |
 | 2     | [#298](https://github.com/vincentchalamon/bike-trip-planner/issues/298) | Service OllamaClient PHP + configuration Docker Ollama             | M      | [#437](https://github.com/vincentchalamon/bike-trip-planner/pull/437) `feature/298` | —         |
 | 3     | [#299](https://github.com/vincentchalamon/bike-trip-planner/issues/299) | Gate mechanism dans ComputationTracker                             | M      | [#438](https://github.com/vincentchalamon/bike-trip-planner/pull/438) `feature/299` | —         |
 | 4     | [#300](https://github.com/vincentchalamon/bike-trip-planner/issues/300) | System prompts cyclotourisme versionnés (LLaMA 8B)                 | S      | [#436](https://github.com/vincentchalamon/bike-trip-planner/pull/436) `feature/300` | —         |


### PR DESCRIPTION
## Summary

- Records the four sprint-28 PRs in `TRACKING.md`:
  - #297 → #435 (ADR-028 Ollama/LLaMA — renumbered from 027)
  - #298 → #437 (OllamaClient + Docker)
  - #299 → #438 (gate mechanism)
  - #300 → #436 (system prompts)

## Test plan

- [ ] CI green (docs-only, no code changes).

<!-- claude-review-start -->
## Claude Review

All previously flagged issues have been addressed. The second commit (`fix(tracking): update ADR-027 references to ADR-028 in sprint 28 entries`) correctly fixes both the sprint-section header (line 507) and the task-row title (line 511) to reference ADR-028.

**Findings: 0**

Commit reviewed: `6ad133cc05efcfead4082a22f8fc072192a60be7`

**Resolved threads:** Resolved 1 previously open thread (ADR-027 → ADR-028 fix confirmed).

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**No inline comments.**

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->