### PR TITLE
feat(llm): add trip overview pass 2 handler (#302)

### DIFF
--- a/api/migrations/Version20260506100000.php
+++ b/api/migrations/Version20260506100000.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260506100000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add ai_overview JSONB column to trip table for LLaMA 8B pass-2 trip overview (#302)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE trip ADD ai_overview JSONB DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE trip DROP ai_overview');
+    }
+}

--- a/api/src/ApiResource/TripRequest.php
+++ b/api/src/ApiResource/TripRequest.php
@@ -139,6 +139,22 @@ final class TripRequest
     #[ApiProperty(readable: false, writable: false)]
     public Collection $stages;
 
+    /**
+     * LLaMA 8B pass-2 trip overview (issue #302).
+     *
+     * Synthesises the per-stage briefings into a global narrative (cumulative
+     * fatigue, cross-stage patterns, trip-level recommendations). Persisted as
+     * JSONB so the schema can evolve without a migration on every prompt revision.
+     *
+     * Exposed as readable on the API to let the frontend render the overview
+     * once the pipeline finalises (Mercure TRIP_READY event — wired in #303).
+     *
+     * @var array{narrative: string, patterns: list<string>, recommendations: list<string>, crossStageAlerts: list<string>, model: string, promptVersion: int, generatedAt: string}|null
+     */
+    #[ORM\Column(name: 'ai_overview', type: 'jsonb', nullable: true)]
+    #[ApiProperty(writable: false)]
+    public ?array $aiOverview = null;
+
     public function __construct(?Uuid $id = null)
     {
         $this->id = $id ?? Uuid::v7();

--- a/api/src/ApiResource/TripRequest.php
+++ b/api/src/ApiResource/TripRequest.php
@@ -7,6 +7,7 @@ namespace App\ApiResource;
 use ApiPlatform\Metadata\ApiProperty;
 use App\Entity\Stage;
 use App\Entity\User;
+use App\Llm\Dto\TripAiOverview;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
@@ -146,14 +147,21 @@ final class TripRequest
      * fatigue, cross-stage patterns, trip-level recommendations). Persisted as
      * JSONB so the schema can evolve without a migration on every prompt revision.
      *
-     * Exposed as readable on the API to let the frontend render the overview
-     * once the pipeline finalises (Mercure TRIP_READY event — wired in #303).
+     * Internal storage — exposed on the API via {@see self::getAiOverview()} which returns
+     * a typed {@see TripAiOverview} DTO so the OpenAPI schema is precise and the frontend gets
+     * compile-time access to `narrative`, `patterns`, `recommendations`, etc.
      *
      * @var array{narrative: string, patterns: list<string>, recommendations: list<string>, crossStageAlerts: list<string>, model: string, promptVersion: int, generatedAt: string}|null
      */
     #[ORM\Column(name: 'ai_overview', type: 'jsonb', nullable: true)]
-    #[ApiProperty(writable: false)]
-    public ?array $aiOverview = null;
+    #[ApiProperty(readable: false, writable: false)]
+    public ?array $aiOverviewData = null;
+
+    #[ApiProperty(description: 'LLaMA 8B pass-2 trip overview (issue #302).', writable: false, identifier: false)]
+    public function getAiOverview(): ?TripAiOverview
+    {
+        return null === $this->aiOverviewData ? null : TripAiOverview::fromArray($this->aiOverviewData);
+    }
 
     public function __construct(?Uuid $id = null)
     {

--- a/api/src/Llm/Dto/TripAiOverview.php
+++ b/api/src/Llm/Dto/TripAiOverview.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Llm\Dto;
+
+/**
+ * Result of the LLaMA 8B pass-2 trip overview synthesis (issue #302).
+ *
+ * The LLM returns a Markdown briefing with four sections (Vue d'ensemble, Charge
+ * et fatigue cumulative, Patterns transversaux, Recommandations globales). The
+ * handler extracts each section into this immutable DTO and serialises it as
+ * JSONB on the trip table (`trip.ai_overview`).
+ *
+ * Shape mirrors {@see StageAiAnalysis} for symmetry, with two extra collections:
+ * `patterns` (cross-stage observations) and `crossStageAlerts` (trip-level
+ * warnings spanning multiple days).
+ */
+final readonly class TripAiOverview
+{
+    /**
+     * @param string       $narrative        global narrative paragraph (Vue d'ensemble + Charge et fatigue cumulative, ~120 words)
+     * @param list<string> $patterns         cross-stage patterns the rider should be aware of
+     * @param list<string> $recommendations  trip-level actionable recommendations
+     * @param list<string> $crossStageAlerts trip-level alerts spanning multiple stages (subset of patterns flagged as warnings)
+     * @param string       $model            LLM model identifier used to produce the overview (e.g. "llama3.1:8b")
+     * @param int          $promptVersion    identifies the system prompt revision (so consumers can detect staleness)
+     * @param string       $generatedAt      RFC3339 timestamp when the overview was generated
+     */
+    public function __construct(
+        public string $narrative,
+        public array $patterns,
+        public array $recommendations,
+        public array $crossStageAlerts,
+        public string $model,
+        public int $promptVersion,
+        public string $generatedAt,
+    ) {
+    }
+
+    /**
+     * Serialises the DTO to a JSONB-compatible array.
+     *
+     * @return array{narrative: string, patterns: list<string>, recommendations: list<string>, crossStageAlerts: list<string>, model: string, promptVersion: int, generatedAt: string}
+     */
+    public function toArray(): array
+    {
+        return [
+            'narrative' => $this->narrative,
+            'patterns' => $this->patterns,
+            'recommendations' => $this->recommendations,
+            'crossStageAlerts' => $this->crossStageAlerts,
+            'model' => $this->model,
+            'promptVersion' => $this->promptVersion,
+            'generatedAt' => $this->generatedAt,
+        ];
+    }
+
+    /**
+     * @param array{narrative?: string, patterns?: list<string>, recommendations?: list<string>, crossStageAlerts?: list<string>, model?: string, promptVersion?: int, generatedAt?: string} $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            narrative: $data['narrative'] ?? '',
+            patterns: $data['patterns'] ?? [],
+            recommendations: $data['recommendations'] ?? [],
+            crossStageAlerts: $data['crossStageAlerts'] ?? [],
+            model: $data['model'] ?? '',
+            promptVersion: $data['promptVersion'] ?? 1,
+            generatedAt: $data['generatedAt'] ?? '',
+        );
+    }
+}

--- a/api/src/Llm/Dto/TripAiOverview.php
+++ b/api/src/Llm/Dto/TripAiOverview.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace App\Llm\Dto;
 
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\NotNull;
+
 /**
  * Result of the LLaMA 8B pass-2 trip overview synthesis (issue #302).
  *
@@ -28,12 +31,19 @@ final readonly class TripAiOverview
      * @param string       $generatedAt      RFC3339 timestamp when the overview was generated
      */
     public function __construct(
+        #[NotBlank]
         public string $narrative,
+        #[NotNull]
         public array $patterns,
+        #[NotNull]
         public array $recommendations,
+        #[NotNull]
         public array $crossStageAlerts,
+        #[NotBlank]
         public string $model,
+        #[NotNull]
         public int $promptVersion,
+        #[NotBlank]
         public string $generatedAt,
     ) {
     }

--- a/api/src/Message/AnalyzeTripOverviewWithLlmMessage.php
+++ b/api/src/Message/AnalyzeTripOverviewWithLlmMessage.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Message;
+
+/**
+ * Dispatched once every per-stage LLaMA 8B pass-1 analysis has settled, to trigger
+ * the LLaMA 8B pass-2 trip overview synthesis (issue #302).
+ *
+ * Pass 2 takes the per-stage briefings produced by {@see AnalyzeStageWithLlmMessage}
+ * plus the rider profile and synthesises a global narrative covering cumulative
+ * fatigue, cross-stage patterns and trip-level recommendations. The handler runs
+ * once per trip — there is no parallel decomposition.
+ *
+ * The orchestration of the dispatch (gate detection, automatic chaining
+ * post-pass-1) is the responsibility of issue #303; this message remains a plain
+ * envelope carrying only the trip identifier.
+ */
+final readonly class AnalyzeTripOverviewWithLlmMessage
+{
+    public function __construct(
+        public string $tripId,
+    ) {
+    }
+}

--- a/api/src/MessageHandler/AnalyzeTripOverviewWithLlmHandler.php
+++ b/api/src/MessageHandler/AnalyzeTripOverviewWithLlmHandler.php
@@ -237,13 +237,20 @@ final readonly class AnalyzeTripOverviewWithLlmHandler
      */
     private function buildRiderProfile(?TripRequest $request): array
     {
-        $ebike = (bool) $request?->ebikeMode;
+        if (!$request instanceof TripRequest) {
+            return [
+                'type' => 'gravel',
+                'fitness' => 'intermediate',
+                'ebike' => false,
+                'locale' => 'fr',
+            ];
+        }
 
         return [
-            'type' => $ebike ? 'e-bike' : 'gravel',
+            'type' => $request->ebikeMode ? 'e-bike' : 'gravel',
             'fitness' => 'intermediate',
-            'ebike' => $ebike,
-            'locale' => $request?->locale ?? 'fr',
+            'ebike' => $request->ebikeMode,
+            'locale' => $request->locale,
         ];
     }
 
@@ -254,17 +261,22 @@ final readonly class AnalyzeTripOverviewWithLlmHandler
      */
     private function buildPromptVariables(?TripRequest $request): array
     {
-        $language = $request?->locale ?? 'fr';
-        $ebike = (bool) $request?->ebikeMode;
-        $riderProfile = $ebike ? 'e-bike/VAE' : 'randonneur/bikepacker';
+        if (!$request instanceof TripRequest) {
+            return [
+                'region' => 'Europe',
+                'rider_profile' => 'randonneur/bikepacker',
+                'language' => 'fr',
+                'date' => '',
+            ];
+        }
 
-        $startDate = $request?->startDate;
-        $date = $startDate instanceof \DateTimeImmutable ? $startDate->format('Y-m-d') : '';
+        $riderProfile = $request->ebikeMode ? 'e-bike/VAE' : 'randonneur/bikepacker';
+        $date = $request->startDate instanceof \DateTimeImmutable ? $request->startDate->format('Y-m-d') : '';
 
         return [
             'region' => 'Europe',
             'rider_profile' => $riderProfile,
-            'language' => $language,
+            'language' => $request->locale,
             'date' => $date,
         ];
     }
@@ -352,7 +364,7 @@ final readonly class AnalyzeTripOverviewWithLlmHandler
             }
         }
 
-        return array_values($alerts);
+        return $alerts;
     }
 
     /**

--- a/api/src/MessageHandler/AnalyzeTripOverviewWithLlmHandler.php
+++ b/api/src/MessageHandler/AnalyzeTripOverviewWithLlmHandler.php
@@ -106,10 +106,10 @@ final readonly class AnalyzeTripOverviewWithLlmHandler
 
         try {
             $userPrompt = json_encode($payload, \JSON_THROW_ON_ERROR | \JSON_UNESCAPED_UNICODE);
-        } catch (\JsonException $exception) {
+        } catch (\JsonException $jsonException) {
             $this->logger->warning('Failed to encode trip overview payload for LLM prompt.', [
                 'tripId' => $message->tripId,
-                'error' => $exception->getMessage(),
+                'error' => $jsonException->getMessage(),
             ]);
 
             return;
@@ -127,10 +127,10 @@ final readonly class AnalyzeTripOverviewWithLlmHandler
                     'num_predict' => self::MAX_RESPONSE_TOKENS,
                 ],
             );
-        } catch (OllamaUnavailableException $exception) {
+        } catch (OllamaUnavailableException $ollamaUnavailableException) {
             $this->logger->warning('Ollama unreachable — skipping trip overview synthesis.', [
                 'tripId' => $message->tripId,
-                'error' => $exception->getMessage(),
+                'error' => $ollamaUnavailableException->getMessage(),
             ]);
 
             return;
@@ -327,7 +327,7 @@ final readonly class AnalyzeTripOverviewWithLlmHandler
             crossStageAlerts: $crossStageAlerts,
             model: $this->model,
             promptVersion: self::PROMPT_VERSION,
-            generatedAt: (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format(\DATE_ATOM),
+            generatedAt: new \DateTimeImmutable('now', new \DateTimeZone('UTC'))->format(\DATE_ATOM),
         );
     }
 
@@ -372,6 +372,7 @@ final readonly class AnalyzeTripOverviewWithLlmHandler
                 if (null !== $currentKey) {
                     $sections[$currentKey] = implode("\n", $buffer);
                 }
+
                 $currentKey = $this->normaliseHeading($matches[1]);
                 $buffer = [];
 
@@ -420,6 +421,7 @@ final readonly class AnalyzeTripOverviewWithLlmHandler
                 if (null !== $current) {
                     $bullets[] = trim($current);
                 }
+
                 $current = $matches[1];
 
                 continue;

--- a/api/src/MessageHandler/AnalyzeTripOverviewWithLlmHandler.php
+++ b/api/src/MessageHandler/AnalyzeTripOverviewWithLlmHandler.php
@@ -1,0 +1,450 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MessageHandler;
+
+use App\ApiResource\Stage;
+use App\ApiResource\TripRequest;
+use App\Llm\Dto\TripAiOverview;
+use App\Llm\Exception\OllamaUnavailableException;
+use App\Llm\LlmClientInterface;
+use App\Llm\SystemPromptLoader;
+use App\Message\AnalyzeTripOverviewWithLlmMessage;
+use App\Repository\TripRequestRepositoryInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+/**
+ * LLaMA 8B pass-2: trip-level overview synthesis (issue #302).
+ *
+ * Consumes the per-stage briefings produced by {@see AnalyzeStageWithLlmHandler}
+ * and asks the LLM to synthesise a global narrative covering cumulative fatigue,
+ * cross-stage patterns and trip-level recommendations.
+ *
+ * Behaviour:
+ * - When Ollama is disabled (feature flag off): the handler returns silently.
+ * - When the LLM is unreachable: the {@see OllamaUnavailableException} is logged
+ *   and swallowed. AI overview is best-effort enrichment, never blocking.
+ * - When the response cannot be parsed: the handler logs and skips persistence.
+ * - When NO stage has a pass-1 analysis yet (e.g. every per-stage handler failed
+ *   or LLM was disabled): the handler skips, since there is nothing to summarise.
+ * - Stages WITHOUT a pass-1 analysis are simply omitted from the input array;
+ *   the LLM works with whatever subset is available.
+ *
+ * The orchestration of this handler (gate detection post-pass-1, automatic
+ * dispatch, TRIP_READY emission) is the responsibility of issue #303 — this
+ * class merely produces and persists the analysis.
+ */
+#[AsMessageHandler]
+final readonly class AnalyzeTripOverviewWithLlmHandler
+{
+    public const string PROMPT_NAME = 'trip-overview';
+
+    public const int PROMPT_VERSION = 1;
+
+    public const int MAX_RESPONSE_TOKENS = 800;
+
+    public const string DEFAULT_MODEL = 'llama3.1:8b';
+
+    /**
+     * Pass 2 takes ~2000-3000 tokens of input plus ~800 tokens of output, so a
+     * 8K window leaves comfortable headroom for the system prompt.
+     */
+    public const int OVERVIEW_NUM_CTX = 8192;
+
+    private string $model;
+
+    public function __construct(
+        private TripRequestRepositoryInterface $tripStateManager,
+        private LlmClientInterface $llmClient,
+        private SystemPromptLoader $promptLoader,
+        private LoggerInterface $logger,
+        #[Autowire(env: 'default::OLLAMA_OVERVIEW_MODEL')]
+        ?string $model = null,
+    ) {
+        $this->model = (null === $model || '' === $model) ? self::DEFAULT_MODEL : $model;
+    }
+
+    public function __invoke(AnalyzeTripOverviewWithLlmMessage $message): void
+    {
+        if (!$this->llmClient->isEnabled()) {
+            $this->logger->debug('LLM disabled — skipping trip overview synthesis.', [
+                'tripId' => $message->tripId,
+            ]);
+
+            return;
+        }
+
+        $stages = $this->tripStateManager->getStages($message->tripId);
+        if (null === $stages || [] === $stages) {
+            $this->logger->info('No stages found for trip — skipping LLM trip overview.', [
+                'tripId' => $message->tripId,
+            ]);
+
+            return;
+        }
+
+        $stageInputs = $this->buildStageInputs($stages);
+        if ([] === $stageInputs) {
+            $this->logger->info('No pass-1 stage analyses available — skipping LLM trip overview.', [
+                'tripId' => $message->tripId,
+            ]);
+
+            return;
+        }
+
+        $request = $this->tripStateManager->getRequest($message->tripId);
+        $variables = $this->buildPromptVariables($request);
+        $systemPrompt = $this->promptLoader->load(self::PROMPT_NAME, $variables);
+
+        $payload = [
+            'rider_profile' => $this->buildRiderProfile($request),
+            'stages' => $stageInputs,
+        ];
+
+        try {
+            $userPrompt = json_encode($payload, \JSON_THROW_ON_ERROR | \JSON_UNESCAPED_UNICODE);
+        } catch (\JsonException $exception) {
+            $this->logger->warning('Failed to encode trip overview payload for LLM prompt.', [
+                'tripId' => $message->tripId,
+                'error' => $exception->getMessage(),
+            ]);
+
+            return;
+        }
+
+        try {
+            $response = $this->llmClient->generate(
+                model: $this->model,
+                prompt: $userPrompt,
+                systemPrompt: $systemPrompt,
+                options: [
+                    // The system prompt asks for a Markdown briefing — disable Ollama's JSON mode.
+                    'format' => '',
+                    'num_ctx' => self::OVERVIEW_NUM_CTX,
+                    'num_predict' => self::MAX_RESPONSE_TOKENS,
+                ],
+            );
+        } catch (OllamaUnavailableException $exception) {
+            $this->logger->warning('Ollama unreachable — skipping trip overview synthesis.', [
+                'tripId' => $message->tripId,
+                'error' => $exception->getMessage(),
+            ]);
+
+            return;
+        }
+
+        if (null === $response) {
+            return;
+        }
+
+        $rawText = $this->extractText($response);
+        if (null === $rawText || '' === trim($rawText)) {
+            $this->logger->warning('LLM returned an empty response for trip overview.', [
+                'tripId' => $message->tripId,
+            ]);
+
+            return;
+        }
+
+        $overview = $this->parseMarkdownResponse($rawText);
+
+        $this->tripStateManager->updateTripAiOverview(
+            $message->tripId,
+            $overview->toArray(),
+        );
+
+        $this->logger->info('LLM trip overview persisted for trip {tripId}.', [
+            'tripId' => $message->tripId,
+            'patterns' => \count($overview->patterns),
+            'recommendations' => \count($overview->recommendations),
+            'crossStageAlerts' => \count($overview->crossStageAlerts),
+        ]);
+    }
+
+    /**
+     * Builds the compact summary fed to the LLM: one entry per stage with the
+     * key metrics + the pass-1 narrative (truncated). Rest days and stages
+     * without a pass-1 analysis are skipped — pass 2 should not invent data.
+     *
+     * @param list<Stage> $stages
+     *
+     * @return list<array{stage_number: int, distance_km: float, elevation_gain_m: int, summary: string}>
+     */
+    private function buildStageInputs(array $stages): array
+    {
+        $inputs = [];
+
+        foreach ($stages as $stage) {
+            if ($stage->isRestDay) {
+                continue;
+            }
+
+            $analysis = $stage->aiAnalysis;
+            if (null === $analysis) {
+                continue;
+            }
+
+            $summary = $this->composeStageSummary($analysis);
+            if ('' === $summary) {
+                continue;
+            }
+
+            $inputs[] = [
+                'stage_number' => $stage->dayNumber,
+                'distance_km' => round($stage->distance, 1),
+                'elevation_gain_m' => (int) round($stage->elevation),
+                'summary' => $summary,
+            ];
+        }
+
+        return $inputs;
+    }
+
+    /**
+     * Concatenates the pass-1 narrative + the most relevant insights/suggestions
+     * into a single synthetic sentence-level summary. Mirrors the few-shot
+     * example shape from the trip-overview system prompt.
+     *
+     * @param array{narrative?: string, insights?: list<string>, suggestions?: list<string>, model?: string, promptVersion?: int, generatedAt?: string} $analysis
+     */
+    private function composeStageSummary(array $analysis): string
+    {
+        $parts = [];
+
+        $narrative = trim($analysis['narrative'] ?? '');
+        if ('' !== $narrative) {
+            $parts[] = $narrative;
+        }
+
+        $insights = $analysis['insights'] ?? [];
+        if ([] !== $insights) {
+            $parts[] = 'Insights: '.implode(' | ', $insights);
+        }
+
+        $suggestions = $analysis['suggestions'] ?? [];
+        if ([] !== $suggestions) {
+            $parts[] = 'Recommandations: '.implode(' | ', $suggestions);
+        }
+
+        return trim(implode(' ', $parts));
+    }
+
+    /**
+     * @return array{type: string, fitness: string, ebike: bool, locale: string}
+     */
+    private function buildRiderProfile(?TripRequest $request): array
+    {
+        $ebike = (bool) $request?->ebikeMode;
+
+        return [
+            'type' => $ebike ? 'e-bike' : 'gravel',
+            'fitness' => 'intermediate',
+            'ebike' => $ebike,
+            'locale' => $request?->locale ?? 'fr',
+        ];
+    }
+
+    /**
+     * Builds the placeholders for {@see SystemPromptLoader::load()}.
+     *
+     * @return array<string, scalar>
+     */
+    private function buildPromptVariables(?TripRequest $request): array
+    {
+        $language = $request?->locale ?? 'fr';
+        $ebike = (bool) $request?->ebikeMode;
+        $riderProfile = $ebike ? 'e-bike/VAE' : 'randonneur/bikepacker';
+
+        $startDate = $request?->startDate;
+        $date = $startDate instanceof \DateTimeImmutable ? $startDate->format('Y-m-d') : '';
+
+        return [
+            'region' => 'Europe',
+            'rider_profile' => $riderProfile,
+            'language' => $language,
+            'date' => $date,
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $response Ollama API response (either /api/generate or /api/chat)
+     */
+    private function extractText(array $response): ?string
+    {
+        // /api/generate returns {"response": "...", "done": true, ...}
+        if (isset($response['response']) && \is_string($response['response'])) {
+            return $response['response'];
+        }
+
+        // /api/chat returns {"message": {"role": "assistant", "content": "..."}, ...}
+        if (isset($response['message']) && \is_array($response['message'])) {
+            $content = $response['message']['content'] ?? null;
+            if (\is_string($content)) {
+                return $content;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Parses a Markdown briefing with the four expected sections.
+     *
+     * Tolerant: when a section is missing or malformed, falls back to empty
+     * arrays so the persisted DTO stays well-typed. Bullets ("- ...", "* ...")
+     * are normalised into a list.
+     *
+     * Cross-stage alerts are derived from the patterns section: any bullet
+     * containing keywords ("attention", "warning", "danger", "risque") is
+     * additionally surfaced under crossStageAlerts.
+     */
+    private function parseMarkdownResponse(string $markdown): TripAiOverview
+    {
+        $sections = $this->splitMarkdownSections($markdown);
+
+        $overview = trim($sections['vue densemble'] ?? $sections['vue d ensemble'] ?? $sections['vue ensemble'] ?? '');
+        $fatigue = trim($sections['charge et fatigue cumulative'] ?? $sections['charge et fatigue'] ?? '');
+        $patterns = $this->extractBullets($sections['patterns transversaux'] ?? '');
+        $recommendations = $this->extractBullets($sections['recommandations globales'] ?? $sections['recommandations'] ?? '');
+        $crossStageAlerts = $this->extractCrossStageAlerts($patterns);
+
+        $narrativeParts = array_values(array_filter([$overview, $fatigue], static fn (string $part): bool => '' !== $part));
+        $narrative = implode("\n\n", $narrativeParts);
+
+        // Fallback: when both overview and fatigue sections are empty, use whatever
+        // text the model emitted so the rider still gets something.
+        if ('' === $narrative && [] === $patterns && [] === $recommendations) {
+            $narrative = trim($markdown);
+        }
+
+        return new TripAiOverview(
+            narrative: $narrative,
+            patterns: $patterns,
+            recommendations: $recommendations,
+            crossStageAlerts: $crossStageAlerts,
+            model: $this->model,
+            promptVersion: self::PROMPT_VERSION,
+            generatedAt: (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format(\DATE_ATOM),
+        );
+    }
+
+    /**
+     * @param list<string> $patterns
+     *
+     * @return list<string>
+     */
+    private function extractCrossStageAlerts(array $patterns): array
+    {
+        $alerts = [];
+        foreach ($patterns as $pattern) {
+            $lower = mb_strtolower($pattern);
+            if (
+                str_contains($lower, 'attention')
+                || str_contains($lower, 'warning')
+                || str_contains($lower, 'danger')
+                || str_contains($lower, 'risque')
+                || str_contains($lower, 'alerte')
+            ) {
+                $alerts[] = $pattern;
+            }
+        }
+
+        return array_values($alerts);
+    }
+
+    /**
+     * Splits a Markdown response into normalised section keys. Any heading
+     * level is accepted (#, ##, ###).
+     *
+     * @return array<string, string>
+     */
+    private function splitMarkdownSections(string $markdown): array
+    {
+        $sections = [];
+        $currentKey = null;
+        $buffer = [];
+
+        foreach (preg_split('/\R/', $markdown) ?: [] as $line) {
+            if (preg_match('/^\s*#+\s*(.+?)\s*$/u', $line, $matches)) {
+                if (null !== $currentKey) {
+                    $sections[$currentKey] = implode("\n", $buffer);
+                }
+                $currentKey = $this->normaliseHeading($matches[1]);
+                $buffer = [];
+
+                continue;
+            }
+
+            if (null !== $currentKey) {
+                $buffer[] = $line;
+            }
+        }
+
+        if (null !== $currentKey) {
+            $sections[$currentKey] = implode("\n", $buffer);
+        }
+
+        return $sections;
+    }
+
+    private function normaliseHeading(string $heading): string
+    {
+        $lower = mb_strtolower(trim($heading));
+        // Drop common French diacritics and apostrophes so "Vue d'ensemble" → "vue densemble"
+        // and "Recommandations globales" stays "recommandations globales".
+        $stripped = strtr($lower, [
+            'à' => 'a', 'á' => 'a', 'â' => 'a', 'ä' => 'a', 'ã' => 'a', 'å' => 'a',
+            'è' => 'e', 'é' => 'e', 'ê' => 'e', 'ë' => 'e',
+            'ì' => 'i', 'í' => 'i', 'î' => 'i', 'ï' => 'i',
+            'ò' => 'o', 'ó' => 'o', 'ô' => 'o', 'ö' => 'o', 'õ' => 'o',
+            'ù' => 'u', 'ú' => 'u', 'û' => 'u', 'ü' => 'u',
+            'ç' => 'c', 'ñ' => 'n', 'ÿ' => 'y',
+        ]);
+
+        return str_replace(["'", '’'], '', $stripped);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function extractBullets(string $section): array
+    {
+        $bullets = [];
+        $current = null;
+
+        foreach (preg_split('/\R/', $section) ?: [] as $line) {
+            if (preg_match('/^\s*[-*•]\s+(.*)$/u', $line, $matches)) {
+                if (null !== $current) {
+                    $bullets[] = trim($current);
+                }
+                $current = $matches[1];
+
+                continue;
+            }
+
+            if (null === $current) {
+                continue;
+            }
+
+            $trimmed = trim($line);
+            if ('' === $trimmed) {
+                $bullets[] = trim($current);
+                $current = null;
+
+                continue;
+            }
+
+            // Continuation line of the previous bullet.
+            $current .= ' '.$trimmed;
+        }
+
+        if (null !== $current) {
+            $bullets[] = trim($current);
+        }
+
+        return array_values(array_filter($bullets, static fn (string $b): bool => '' !== $b));
+    }
+}

--- a/api/src/MessageHandler/AnalyzeTripOverviewWithLlmHandler.php
+++ b/api/src/MessageHandler/AnalyzeTripOverviewWithLlmHandler.php
@@ -6,6 +6,7 @@ namespace App\MessageHandler;
 
 use App\ApiResource\Stage;
 use App\ApiResource\TripRequest;
+use App\Llm\Dto\StageAiAnalysis;
 use App\Llm\Dto\TripAiOverview;
 use App\Llm\Exception\OllamaUnavailableException;
 use App\Llm\LlmClientInterface;
@@ -207,40 +208,37 @@ final readonly class AnalyzeTripOverviewWithLlmHandler
      * Concatenates the pass-1 narrative + the most relevant insights/suggestions
      * into a single synthetic sentence-level summary. Mirrors the few-shot
      * example shape from the trip-overview system prompt.
-     *
-     * @param array{narrative?: string, insights?: list<string>, suggestions?: list<string>, model?: string, promptVersion?: int, generatedAt?: string} $analysis
      */
-    private function composeStageSummary(array $analysis): string
+    private function composeStageSummary(StageAiAnalysis $analysis): string
     {
         $parts = [];
 
-        $narrative = trim($analysis['narrative'] ?? '');
+        $narrative = trim($analysis->narrative);
         if ('' !== $narrative) {
             $parts[] = $narrative;
         }
 
-        $insights = $analysis['insights'] ?? [];
-        if ([] !== $insights) {
-            $parts[] = 'Insights: '.implode(' | ', $insights);
+        if ([] !== $analysis->insights) {
+            $parts[] = 'Insights: '.implode(' | ', $analysis->insights);
         }
 
-        $suggestions = $analysis['suggestions'] ?? [];
-        if ([] !== $suggestions) {
-            $parts[] = 'Recommandations: '.implode(' | ', $suggestions);
+        if ([] !== $analysis->suggestions) {
+            $parts[] = 'Recommandations: '.implode(' | ', $analysis->suggestions);
         }
 
         return trim(implode(' ', $parts));
     }
 
     /**
-     * @return array{type: string, fitness: string, ebike: bool, locale: string}
+     * @return array{type: string, ebike: bool, locale: string}
      */
     private function buildRiderProfile(?TripRequest $request): array
     {
+        // Note: a rider-fitness field will be added to TripRequest in a follow-up.
+        // Until then we omit the key entirely so the LLM uses its own default rather than a system-invented one.
         if (!$request instanceof TripRequest) {
             return [
                 'type' => 'gravel',
-                'fitness' => 'intermediate',
                 'ebike' => false,
                 'locale' => 'fr',
             ];
@@ -248,7 +246,6 @@ final readonly class AnalyzeTripOverviewWithLlmHandler
 
         return [
             'type' => $request->ebikeMode ? 'e-bike' : 'gravel',
-            'fitness' => 'intermediate',
             'ebike' => $request->ebikeMode,
             'locale' => $request->locale,
         ];
@@ -261,9 +258,13 @@ final readonly class AnalyzeTripOverviewWithLlmHandler
      */
     private function buildPromptVariables(?TripRequest $request): array
     {
+        // Note: `region` is left as an empty placeholder for now. The system prompt
+        // template tolerates an empty `{{region}}` placeholder, so the LLM degrades
+        // gracefully to its built-in regional knowledge until we wire a route-bbox-derived
+        // region or a TripRequest.region field.
         if (!$request instanceof TripRequest) {
             return [
-                'region' => 'Europe',
+                'region' => '',
                 'rider_profile' => 'randonneur/bikepacker',
                 'language' => 'fr',
                 'date' => '',
@@ -274,7 +275,7 @@ final readonly class AnalyzeTripOverviewWithLlmHandler
         $date = $request->startDate instanceof \DateTimeImmutable ? $request->startDate->format('Y-m-d') : '';
 
         return [
-            'region' => 'Europe',
+            'region' => '',
             'rider_profile' => $riderProfile,
             'language' => $request->locale,
             'date' => $date,

--- a/api/src/Repository/DoctrineTripRequestRepository.php
+++ b/api/src/Repository/DoctrineTripRequestRepository.php
@@ -224,6 +224,20 @@ final class DoctrineTripRequestRepository extends ServiceEntityRepository implem
             ->execute();
     }
 
+    /**
+     * @param array{narrative: string, patterns: list<string>, recommendations: list<string>, crossStageAlerts: list<string>, model: string, promptVersion: int, generatedAt: string}|null $aiOverview
+     */
+    public function updateTripAiOverview(string $tripId, ?array $aiOverview): void
+    {
+        $trip = $this->findTripRequest($tripId);
+        if (!$trip instanceof TripRequest) {
+            return;
+        }
+
+        $trip->aiOverview = $aiOverview;
+        $this->getEntityManager()->flush();
+    }
+
     // --- Private helpers ---
 
     private function findTripRequest(string $tripId): ?TripRequest

--- a/api/src/Repository/DoctrineTripRequestRepository.php
+++ b/api/src/Repository/DoctrineTripRequestRepository.php
@@ -225,17 +225,22 @@ final class DoctrineTripRequestRepository extends ServiceEntityRepository implem
     }
 
     /**
+     * Atomic UPDATE on the JSONB column to avoid loading the full TripRequest aggregate.
+     *
      * @param array{narrative: string, patterns: list<string>, recommendations: list<string>, crossStageAlerts: list<string>, model: string, promptVersion: int, generatedAt: string}|null $aiOverview
      */
     public function updateTripAiOverview(string $tripId, ?array $aiOverview): void
     {
-        $trip = $this->findTripRequest($tripId);
-        if (!$trip instanceof TripRequest) {
+        if (!Uuid::isValid($tripId)) {
             return;
         }
 
-        $trip->aiOverview = $aiOverview;
-        $this->getEntityManager()->flush();
+        $this->getEntityManager()->createQuery(
+            'UPDATE App\ApiResource\TripRequest t SET t.aiOverviewData = :aiOverview WHERE t.id = :tripId',
+        )
+            ->setParameter('tripId', Uuid::fromString($tripId))
+            ->setParameter('aiOverview', $aiOverview)
+            ->execute();
     }
 
     // --- Private helpers ---

--- a/api/src/Repository/RedisTripRequestRepository.php
+++ b/api/src/Repository/RedisTripRequestRepository.php
@@ -134,6 +134,20 @@ final readonly class RedisTripRequestRepository implements TripRequestRepository
     }
 
     /**
+     * @param array{narrative: string, patterns: list<string>, recommendations: list<string>, crossStageAlerts: list<string>, model: string, promptVersion: int, generatedAt: string}|null $aiOverview
+     */
+    public function updateTripAiOverview(string $tripId, ?array $aiOverview): void
+    {
+        $request = $this->getRequest($tripId);
+        if (!$request instanceof TripRequest) {
+            return;
+        }
+
+        $request->aiOverview = $aiOverview;
+        $this->set($this->requestKey($tripId), $request);
+    }
+
+    /**
      * Stores multi-track data for Komoot Collection source type.
      *
      * @param list<list<array{lat: float, lon: float, ele: float}>> $tracksData

--- a/api/src/Repository/RedisTripRequestRepository.php
+++ b/api/src/Repository/RedisTripRequestRepository.php
@@ -143,7 +143,7 @@ final readonly class RedisTripRequestRepository implements TripRequestRepository
             return;
         }
 
-        $request->aiOverview = $aiOverview;
+        $request->aiOverviewData = $aiOverview;
         $this->set($this->requestKey($tripId), $request);
     }
 

--- a/api/src/Repository/TripRequestRepositoryInterface.php
+++ b/api/src/Repository/TripRequestRepositoryInterface.php
@@ -60,6 +60,16 @@ interface TripRequestRepositoryInterface
     public function updateStageAiAnalysis(string $tripId, int $dayNumber, ?array $aiAnalysis): void;
 
     /**
+     * Persists the LLaMA 8B pass-2 trip overview atomically (issue #302).
+     *
+     * Returns silently if the trip does not exist anymore (e.g. the trip was
+     * deleted between dispatch and consumption).
+     *
+     * @param array{narrative: string, patterns: list<string>, recommendations: list<string>, crossStageAlerts: list<string>, model: string, promptVersion: int, generatedAt: string}|null $aiOverview
+     */
+    public function updateTripAiOverview(string $tripId, ?array $aiOverview): void;
+
+    /**
      * Stores multi-track data for Komoot Collection source type.
      *
      * @param list<list<array{lat: float, lon: float, ele: float}>> $tracksData

--- a/api/tests/Unit/Llm/AnalyzeTripOverviewWithLlmHandlerTest.php
+++ b/api/tests/Unit/Llm/AnalyzeTripOverviewWithLlmHandlerTest.php
@@ -13,11 +13,13 @@ use App\Llm\SystemPromptLoader;
 use App\Message\AnalyzeTripOverviewWithLlmMessage;
 use App\MessageHandler\AnalyzeTripOverviewWithLlmHandler;
 use App\Repository\TripRequestRepositoryInterface;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 
+#[AllowMockObjectsWithoutExpectations]
 final class AnalyzeTripOverviewWithLlmHandlerTest extends TestCase
 {
     private const string TRIP_ID = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
@@ -61,7 +63,7 @@ final class AnalyzeTripOverviewWithLlmHandlerTest extends TestCase
     #[Test]
     public function skipsSilentlyWhenLlmIsDisabled(): void
     {
-        $llmClient = $this->createStub(LlmClientInterface::class);
+        $llmClient = $this->createMock(LlmClientInterface::class);
         $llmClient->method('isEnabled')->willReturn(false);
 
         $repo = $this->createMock(TripRequestRepositoryInterface::class);
@@ -155,10 +157,15 @@ final class AnalyzeTripOverviewWithLlmHandlerTest extends TestCase
         $handler = $this->makeHandler(repo: $repo, llmClient: $llmClient);
         $handler(new AnalyzeTripOverviewWithLlmMessage(self::TRIP_ID));
 
+        self::assertIsString($captured['prompt']);
         $payload = json_decode($captured['prompt'], true, flags: \JSON_THROW_ON_ERROR);
         self::assertIsArray($payload);
+        self::assertArrayHasKey('stages', $payload);
+        self::assertIsArray($payload['stages']);
         self::assertCount(2, $payload['stages']);
+        self::assertIsArray($payload['stages'][0]);
         self::assertSame(1, $payload['stages'][0]['stage_number']);
+        self::assertIsArray($payload['stages'][1]);
         self::assertSame(3, $payload['stages'][1]['stage_number']);
     }
 
@@ -265,9 +272,11 @@ final class AnalyzeTripOverviewWithLlmHandlerTest extends TestCase
         self::assertIsArray($decoded);
         self::assertArrayHasKey('rider_profile', $decoded);
         self::assertArrayHasKey('stages', $decoded);
+        self::assertIsArray($decoded['stages']);
         self::assertCount(2, $decoded['stages']);
+        self::assertIsArray($decoded['stages'][0]);
         self::assertSame(1, $decoded['stages'][0]['stage_number']);
-        self::assertSame(65.0, $decoded['stages'][0]['distance_km']);
+        self::assertEqualsWithDelta(65.0, $decoded['stages'][0]['distance_km'], 0.01);
         self::assertSame(600, $decoded['stages'][0]['elevation_gain_m']);
         self::assertStringContainsString('Étape d\'approche', $decoded['stages'][0]['summary']);
 
@@ -276,6 +285,7 @@ final class AnalyzeTripOverviewWithLlmHandlerTest extends TestCase
         self::assertStringNotContainsString('{{', $captured['systemPrompt']);
 
         // Format must be disabled (markdown response, not JSON-mode).
+        self::assertIsArray($captured['options']);
         self::assertSame('', $captured['options']['format']);
         self::assertSame(AnalyzeTripOverviewWithLlmHandler::OVERVIEW_NUM_CTX, $captured['options']['num_ctx']);
     }
@@ -434,9 +444,13 @@ final class AnalyzeTripOverviewWithLlmHandlerTest extends TestCase
         $handler = $this->makeHandler(repo: $repo, llmClient: $llmClient);
         $handler(new AnalyzeTripOverviewWithLlmMessage(self::TRIP_ID));
 
+        self::assertIsString($captured['prompt']);
         $payload = json_decode($captured['prompt'], true, flags: \JSON_THROW_ON_ERROR);
         self::assertIsArray($payload);
+        self::assertArrayHasKey('stages', $payload);
+        self::assertIsArray($payload['stages']);
         self::assertCount(1, $payload['stages']);
+        self::assertIsArray($payload['stages'][0]);
         self::assertSame(2, $payload['stages'][0]['stage_number']);
     }
 

--- a/api/tests/Unit/Llm/AnalyzeTripOverviewWithLlmHandlerTest.php
+++ b/api/tests/Unit/Llm/AnalyzeTripOverviewWithLlmHandlerTest.php
@@ -228,6 +228,7 @@ final class AnalyzeTripOverviewWithLlmHandlerTest extends TestCase
     {
         $stage1 = $this->makeStage(dayNumber: 1, distance: 65.0, elevation: 600.0);
         $stage1->aiAnalysis = $this->makeAiAnalysis('Étape d\'approche roulante.');
+
         $stage2 = $this->makeStage(dayNumber: 2, distance: 92.0, elevation: 1240.0);
         $stage2->aiAnalysis = $this->makeAiAnalysis('Étape exigeante.');
 
@@ -412,6 +413,7 @@ final class AnalyzeTripOverviewWithLlmHandlerTest extends TestCase
         $stage1 = $this->makeStage(dayNumber: 1);
         $stage2 = $this->makeStage(dayNumber: 2);
         $stage2->aiAnalysis = $this->makeAiAnalysis('Étape exigeante.');
+
         $stage3 = $this->makeStage(dayNumber: 3);
 
         $repo = $this->createMock(TripRequestRepositoryInterface::class);
@@ -455,7 +457,6 @@ final class AnalyzeTripOverviewWithLlmHandlerTest extends TestCase
             llmClient: $llmClient,
             promptLoader: new SystemPromptLoader($this->tmpPromptDir),
             logger: new NullLogger(),
-            model: null,
         );
     }
 

--- a/api/tests/Unit/Llm/AnalyzeTripOverviewWithLlmHandlerTest.php
+++ b/api/tests/Unit/Llm/AnalyzeTripOverviewWithLlmHandlerTest.php
@@ -1,0 +1,499 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Llm;
+
+use App\ApiResource\Model\Coordinate;
+use App\ApiResource\Stage;
+use App\ApiResource\TripRequest;
+use App\Llm\Exception\OllamaUnavailableException;
+use App\Llm\LlmClientInterface;
+use App\Llm\SystemPromptLoader;
+use App\Message\AnalyzeTripOverviewWithLlmMessage;
+use App\MessageHandler\AnalyzeTripOverviewWithLlmHandler;
+use App\Repository\TripRequestRepositoryInterface;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+final class AnalyzeTripOverviewWithLlmHandlerTest extends TestCase
+{
+    private const string TRIP_ID = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
+
+    private string $tmpPromptDir = '';
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->tmpPromptDir = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'trip-overview-prompt-'.bin2hex(random_bytes(4));
+
+        if (!mkdir($this->tmpPromptDir, 0o755, true) && !is_dir($this->tmpPromptDir)) {
+            throw new \RuntimeException('Failed to create tmp prompt dir.');
+        }
+
+        // Minimal trip-overview prompt with placeholders the handler always provides.
+        file_put_contents(
+            $this->tmpPromptDir.\DIRECTORY_SEPARATOR.AnalyzeTripOverviewWithLlmHandler::PROMPT_NAME.'.txt',
+            "Region: {{region}}\nProfile: {{rider_profile}}\nLanguage: {{language}}\nDate: {{date}}\n",
+        );
+    }
+
+    #[\Override]
+    protected function tearDown(): void
+    {
+        if (!is_dir($this->tmpPromptDir)) {
+            return;
+        }
+
+        foreach (glob($this->tmpPromptDir.\DIRECTORY_SEPARATOR.'*') ?: [] as $file) {
+            unlink($file);
+        }
+
+        rmdir($this->tmpPromptDir);
+    }
+
+    // -------------------------------------------------------------------------
+    // Skip-paths
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function skipsSilentlyWhenLlmIsDisabled(): void
+    {
+        $llmClient = $this->createStub(LlmClientInterface::class);
+        $llmClient->method('isEnabled')->willReturn(false);
+
+        $repo = $this->createMock(TripRequestRepositoryInterface::class);
+        $repo->expects(self::never())->method('getStages');
+        $repo->expects(self::never())->method('updateTripAiOverview');
+
+        $handler = $this->makeHandler(repo: $repo, llmClient: $llmClient);
+        $handler(new AnalyzeTripOverviewWithLlmMessage(self::TRIP_ID));
+    }
+
+    #[Test]
+    public function skipsWhenStagesAreMissing(): void
+    {
+        $repo = $this->createMock(TripRequestRepositoryInterface::class);
+        $repo->method('getStages')->willReturn(null);
+        $repo->expects(self::never())->method('updateTripAiOverview');
+
+        $llmClient = $this->createMock(LlmClientInterface::class);
+        $llmClient->method('isEnabled')->willReturn(true);
+        $llmClient->expects(self::never())->method('generate');
+
+        $handler = $this->makeHandler(repo: $repo, llmClient: $llmClient);
+        $handler(new AnalyzeTripOverviewWithLlmMessage(self::TRIP_ID));
+    }
+
+    #[Test]
+    public function skipsWhenStagesArrayIsEmpty(): void
+    {
+        $repo = $this->createMock(TripRequestRepositoryInterface::class);
+        $repo->method('getStages')->willReturn([]);
+        $repo->expects(self::never())->method('updateTripAiOverview');
+
+        $llmClient = $this->createMock(LlmClientInterface::class);
+        $llmClient->method('isEnabled')->willReturn(true);
+        $llmClient->expects(self::never())->method('generate');
+
+        $handler = $this->makeHandler(repo: $repo, llmClient: $llmClient);
+        $handler(new AnalyzeTripOverviewWithLlmMessage(self::TRIP_ID));
+    }
+
+    #[Test]
+    public function skipsWhenNoStageHasPass1Analysis(): void
+    {
+        // 3 stages but none has aiAnalysis populated.
+        $stages = [
+            $this->makeStage(dayNumber: 1),
+            $this->makeStage(dayNumber: 2),
+            $this->makeStage(dayNumber: 3),
+        ];
+
+        $repo = $this->createMock(TripRequestRepositoryInterface::class);
+        $repo->method('getStages')->willReturn($stages);
+        $repo->expects(self::never())->method('updateTripAiOverview');
+
+        $llmClient = $this->createMock(LlmClientInterface::class);
+        $llmClient->method('isEnabled')->willReturn(true);
+        $llmClient->expects(self::never())->method('generate');
+
+        $handler = $this->makeHandler(repo: $repo, llmClient: $llmClient);
+        $handler(new AnalyzeTripOverviewWithLlmMessage(self::TRIP_ID));
+    }
+
+    #[Test]
+    public function skipsRestDaysWhenBuildingInputs(): void
+    {
+        $stage1 = $this->makeStage(dayNumber: 1);
+        $stage1->aiAnalysis = $this->makeAiAnalysis('Étape 1');
+
+        $restDay = $this->makeStage(dayNumber: 2, isRestDay: true);
+        // Even if a rest day has aiAnalysis (it shouldn't), it must be ignored.
+        $restDay->aiAnalysis = $this->makeAiAnalysis('Should not be used');
+
+        $stage3 = $this->makeStage(dayNumber: 3);
+        $stage3->aiAnalysis = $this->makeAiAnalysis('Étape 3');
+
+        $repo = $this->createMock(TripRequestRepositoryInterface::class);
+        $repo->method('getStages')->willReturn([$stage1, $restDay, $stage3]);
+        $repo->method('getRequest')->willReturn($this->makeTripRequest());
+        $repo->expects(self::once())->method('updateTripAiOverview');
+
+        $captured = [];
+        $llmClient = $this->createMock(LlmClientInterface::class);
+        $llmClient->method('isEnabled')->willReturn(true);
+        $llmClient->method('generate')
+            ->willReturnCallback(static function (string $model, string $prompt, ?string $systemPrompt, array $options) use (&$captured): array {
+                $captured['prompt'] = $prompt;
+
+                return ['response' => "## Vue d'ensemble\nOK\n", 'done' => true];
+            });
+
+        $handler = $this->makeHandler(repo: $repo, llmClient: $llmClient);
+        $handler(new AnalyzeTripOverviewWithLlmMessage(self::TRIP_ID));
+
+        $payload = json_decode($captured['prompt'], true, flags: \JSON_THROW_ON_ERROR);
+        self::assertIsArray($payload);
+        self::assertCount(2, $payload['stages']);
+        self::assertSame(1, $payload['stages'][0]['stage_number']);
+        self::assertSame(3, $payload['stages'][1]['stage_number']);
+    }
+
+    #[Test]
+    public function skipsAnalysisWhenOllamaUnreachable(): void
+    {
+        $stage = $this->makeStage(dayNumber: 1);
+        $stage->aiAnalysis = $this->makeAiAnalysis('A');
+
+        $repo = $this->createMock(TripRequestRepositoryInterface::class);
+        $repo->method('getStages')->willReturn([$stage]);
+        $repo->method('getRequest')->willReturn($this->makeTripRequest());
+        $repo->expects(self::never())->method('updateTripAiOverview');
+
+        $llmClient = $this->createMock(LlmClientInterface::class);
+        $llmClient->method('isEnabled')->willReturn(true);
+        $llmClient->method('generate')->willThrowException(new OllamaUnavailableException('boom'));
+
+        $handler = $this->makeHandler(repo: $repo, llmClient: $llmClient);
+        $handler(new AnalyzeTripOverviewWithLlmMessage(self::TRIP_ID));
+    }
+
+    #[Test]
+    public function skipsPersistenceWhenLlmReturnsNull(): void
+    {
+        $stage = $this->makeStage(dayNumber: 1);
+        $stage->aiAnalysis = $this->makeAiAnalysis('A');
+
+        $repo = $this->createMock(TripRequestRepositoryInterface::class);
+        $repo->method('getStages')->willReturn([$stage]);
+        $repo->method('getRequest')->willReturn($this->makeTripRequest());
+        $repo->expects(self::never())->method('updateTripAiOverview');
+
+        $llmClient = $this->createMock(LlmClientInterface::class);
+        $llmClient->method('isEnabled')->willReturn(true);
+        $llmClient->method('generate')->willReturn(null);
+
+        $handler = $this->makeHandler(repo: $repo, llmClient: $llmClient);
+        $handler(new AnalyzeTripOverviewWithLlmMessage(self::TRIP_ID));
+    }
+
+    #[Test]
+    public function skipsPersistenceWhenLlmReturnsEmptyText(): void
+    {
+        $stage = $this->makeStage(dayNumber: 1);
+        $stage->aiAnalysis = $this->makeAiAnalysis('A');
+
+        $repo = $this->createMock(TripRequestRepositoryInterface::class);
+        $repo->method('getStages')->willReturn([$stage]);
+        $repo->method('getRequest')->willReturn($this->makeTripRequest());
+        $repo->expects(self::never())->method('updateTripAiOverview');
+
+        $llmClient = $this->createMock(LlmClientInterface::class);
+        $llmClient->method('isEnabled')->willReturn(true);
+        $llmClient->method('generate')->willReturn(['response' => '   ', 'done' => true]);
+
+        $handler = $this->makeHandler(repo: $repo, llmClient: $llmClient);
+        $handler(new AnalyzeTripOverviewWithLlmMessage(self::TRIP_ID));
+    }
+
+    // -------------------------------------------------------------------------
+    // Happy paths
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function buildsPayloadAndCallsOllamaWithSystemPrompt(): void
+    {
+        $stage1 = $this->makeStage(dayNumber: 1, distance: 65.0, elevation: 600.0);
+        $stage1->aiAnalysis = $this->makeAiAnalysis('Étape d\'approche roulante.');
+        $stage2 = $this->makeStage(dayNumber: 2, distance: 92.0, elevation: 1240.0);
+        $stage2->aiAnalysis = $this->makeAiAnalysis('Étape exigeante.');
+
+        $repo = $this->createMock(TripRequestRepositoryInterface::class);
+        $repo->method('getStages')->willReturn([$stage1, $stage2]);
+        $repo->method('getRequest')->willReturn($this->makeTripRequest());
+        $repo->expects(self::once())->method('updateTripAiOverview');
+
+        $captured = [];
+        $llmClient = $this->createMock(LlmClientInterface::class);
+        $llmClient->method('isEnabled')->willReturn(true);
+        $llmClient->expects(self::once())
+            ->method('generate')
+            ->willReturnCallback(static function (string $model, string $prompt, ?string $systemPrompt, array $options) use (&$captured): array {
+                $captured['model'] = $model;
+                $captured['prompt'] = $prompt;
+                $captured['systemPrompt'] = $systemPrompt;
+                $captured['options'] = $options;
+
+                return [
+                    'response' => "## Vue d'ensemble\nGlobal narrative.\n\n## Charge et fatigue cumulative\nOK.\n\n## Patterns transversaux\n- Pattern A\n\n## Recommandations globales\n- Reco 1\n",
+                    'done' => true,
+                ];
+            });
+
+        $handler = $this->makeHandler(repo: $repo, llmClient: $llmClient);
+        $handler(new AnalyzeTripOverviewWithLlmMessage(self::TRIP_ID));
+
+        self::assertSame(AnalyzeTripOverviewWithLlmHandler::DEFAULT_MODEL, $captured['model']);
+
+        // The user prompt MUST be a valid JSON dump of {rider_profile, stages}.
+        self::assertIsString($captured['prompt']);
+        $decoded = json_decode($captured['prompt'], true, flags: \JSON_THROW_ON_ERROR);
+        self::assertIsArray($decoded);
+        self::assertArrayHasKey('rider_profile', $decoded);
+        self::assertArrayHasKey('stages', $decoded);
+        self::assertCount(2, $decoded['stages']);
+        self::assertSame(1, $decoded['stages'][0]['stage_number']);
+        self::assertSame(65.0, $decoded['stages'][0]['distance_km']);
+        self::assertSame(600, $decoded['stages'][0]['elevation_gain_m']);
+        self::assertStringContainsString('Étape d\'approche', $decoded['stages'][0]['summary']);
+
+        // System prompt must have placeholders substituted (no remaining {{...}}).
+        self::assertIsString($captured['systemPrompt']);
+        self::assertStringNotContainsString('{{', $captured['systemPrompt']);
+
+        // Format must be disabled (markdown response, not JSON-mode).
+        self::assertSame('', $captured['options']['format']);
+        self::assertSame(AnalyzeTripOverviewWithLlmHandler::OVERVIEW_NUM_CTX, $captured['options']['num_ctx']);
+    }
+
+    #[Test]
+    public function persistsParsedSectionsAsTripOverview(): void
+    {
+        $stage = $this->makeStage(dayNumber: 1);
+        $stage->aiAnalysis = $this->makeAiAnalysis('A');
+
+        $captured = [];
+        $repo = $this->createMock(TripRequestRepositoryInterface::class);
+        $repo->method('getStages')->willReturn([$stage]);
+        $repo->method('getRequest')->willReturn($this->makeTripRequest());
+        $repo->expects(self::once())
+            ->method('updateTripAiOverview')
+            ->willReturnCallback(static function (string $tripId, ?array $overview) use (&$captured): void {
+                $captured = ['tripId' => $tripId, 'overview' => $overview];
+            });
+
+        $markdown = <<<'MD'
+            ## Vue d'ensemble
+            Trip de 3 jours sur 235 km cumulés.
+
+            ## Charge et fatigue cumulative
+            La J2 est clairement la plus dure.
+
+            ## Patterns transversaux
+            - Zones sans eau dès J2 et persistant en J3.
+            - Surface bascule progressivement vers le gravel.
+            - Attention: arrivées tardives en J3 — risque de couchant.
+
+            ## Recommandations globales
+            - Insérer une pause à mi-J2.
+            - Charger 3 L d'eau au départ de J2 et J3.
+            MD;
+
+        $llmClient = $this->createMock(LlmClientInterface::class);
+        $llmClient->method('isEnabled')->willReturn(true);
+        $llmClient->method('generate')->willReturn(['response' => $markdown, 'done' => true]);
+
+        $handler = $this->makeHandler(repo: $repo, llmClient: $llmClient);
+        $handler(new AnalyzeTripOverviewWithLlmMessage(self::TRIP_ID));
+
+        self::assertSame(self::TRIP_ID, $captured['tripId']);
+
+        $overview = $captured['overview'];
+        self::assertIsArray($overview);
+        self::assertStringContainsString('Trip de 3 jours', $overview['narrative']);
+        self::assertStringContainsString('La J2 est clairement la plus dure', $overview['narrative']);
+        self::assertCount(3, $overview['patterns']);
+        self::assertSame('Zones sans eau dès J2 et persistant en J3.', $overview['patterns'][0]);
+        self::assertCount(2, $overview['recommendations']);
+        self::assertSame('Insérer une pause à mi-J2.', $overview['recommendations'][0]);
+        // The third pattern triggers cross-stage alert via "Attention" + "risque" keyword.
+        self::assertCount(1, $overview['crossStageAlerts']);
+        self::assertStringContainsString('Attention', $overview['crossStageAlerts'][0]);
+        self::assertSame(AnalyzeTripOverviewWithLlmHandler::DEFAULT_MODEL, $overview['model']);
+        self::assertSame(AnalyzeTripOverviewWithLlmHandler::PROMPT_VERSION, $overview['promptVersion']);
+        self::assertNotSame('', $overview['generatedAt']);
+    }
+
+    #[Test]
+    public function fallsBackToFullTextWhenSectionsAreMissing(): void
+    {
+        $stage = $this->makeStage(dayNumber: 1);
+        $stage->aiAnalysis = $this->makeAiAnalysis('A');
+
+        $captured = null;
+        $repo = $this->createMock(TripRequestRepositoryInterface::class);
+        $repo->method('getStages')->willReturn([$stage]);
+        $repo->method('getRequest')->willReturn($this->makeTripRequest());
+        $repo->expects(self::once())
+            ->method('updateTripAiOverview')
+            ->willReturnCallback(static function (string $tripId, ?array $overview) use (&$captured): void {
+                $captured = $overview;
+            });
+
+        $llmClient = $this->createMock(LlmClientInterface::class);
+        $llmClient->method('isEnabled')->willReturn(true);
+        $llmClient->method('generate')->willReturn([
+            'response' => 'Just a plain text answer with no markdown headings at all.',
+            'done' => true,
+        ]);
+
+        $handler = $this->makeHandler(repo: $repo, llmClient: $llmClient);
+        $handler(new AnalyzeTripOverviewWithLlmMessage(self::TRIP_ID));
+
+        self::assertIsArray($captured);
+        self::assertSame('Just a plain text answer with no markdown headings at all.', $captured['narrative']);
+        self::assertSame([], $captured['patterns']);
+        self::assertSame([], $captured['recommendations']);
+        self::assertSame([], $captured['crossStageAlerts']);
+    }
+
+    #[Test]
+    public function readsTextFromChatStyleResponse(): void
+    {
+        $stage = $this->makeStage(dayNumber: 1);
+        $stage->aiAnalysis = $this->makeAiAnalysis('A');
+
+        $captured = null;
+        $repo = $this->createMock(TripRequestRepositoryInterface::class);
+        $repo->method('getStages')->willReturn([$stage]);
+        $repo->method('getRequest')->willReturn($this->makeTripRequest());
+        $repo->expects(self::once())
+            ->method('updateTripAiOverview')
+            ->willReturnCallback(static function (string $tripId, ?array $overview) use (&$captured): void {
+                $captured = $overview;
+            });
+
+        $llmClient = $this->createMock(LlmClientInterface::class);
+        $llmClient->method('isEnabled')->willReturn(true);
+        $llmClient->method('generate')->willReturn([
+            'message' => [
+                'role' => 'assistant',
+                'content' => "## Vue d'ensemble\nText.\n\n## Patterns transversaux\n- A\n\n## Recommandations globales\n- B",
+            ],
+            'done' => true,
+        ]);
+
+        $handler = $this->makeHandler(repo: $repo, llmClient: $llmClient);
+        $handler(new AnalyzeTripOverviewWithLlmMessage(self::TRIP_ID));
+
+        self::assertIsArray($captured);
+        self::assertSame('Text.', $captured['narrative']);
+        self::assertSame(['A'], $captured['patterns']);
+        self::assertSame(['B'], $captured['recommendations']);
+    }
+
+    #[Test]
+    public function operatesWithSubsetOfStagesWhenSomePass1Failed(): void
+    {
+        // Three stages, only the middle one has a pass-1 analysis (others failed).
+        $stage1 = $this->makeStage(dayNumber: 1);
+        $stage2 = $this->makeStage(dayNumber: 2);
+        $stage2->aiAnalysis = $this->makeAiAnalysis('Étape exigeante.');
+        $stage3 = $this->makeStage(dayNumber: 3);
+
+        $repo = $this->createMock(TripRequestRepositoryInterface::class);
+        $repo->method('getStages')->willReturn([$stage1, $stage2, $stage3]);
+        $repo->method('getRequest')->willReturn($this->makeTripRequest());
+        $repo->expects(self::once())->method('updateTripAiOverview');
+
+        $captured = [];
+        $llmClient = $this->createMock(LlmClientInterface::class);
+        $llmClient->method('isEnabled')->willReturn(true);
+        $llmClient->method('generate')
+            ->willReturnCallback(static function (string $model, string $prompt, ?string $systemPrompt, array $options) use (&$captured): array {
+                $captured['prompt'] = $prompt;
+
+                return ['response' => "## Vue d'ensemble\nOK\n", 'done' => true];
+            });
+
+        $handler = $this->makeHandler(repo: $repo, llmClient: $llmClient);
+        $handler(new AnalyzeTripOverviewWithLlmMessage(self::TRIP_ID));
+
+        $payload = json_decode($captured['prompt'], true, flags: \JSON_THROW_ON_ERROR);
+        self::assertIsArray($payload);
+        self::assertCount(1, $payload['stages']);
+        self::assertSame(2, $payload['stages'][0]['stage_number']);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * @param TripRequestRepositoryInterface&MockObject $repo
+     * @param LlmClientInterface&MockObject             $llmClient
+     */
+    private function makeHandler(
+        TripRequestRepositoryInterface $repo,
+        LlmClientInterface $llmClient,
+    ): AnalyzeTripOverviewWithLlmHandler {
+        return new AnalyzeTripOverviewWithLlmHandler(
+            tripStateManager: $repo,
+            llmClient: $llmClient,
+            promptLoader: new SystemPromptLoader($this->tmpPromptDir),
+            logger: new NullLogger(),
+            model: null,
+        );
+    }
+
+    private function makeStage(int $dayNumber, bool $isRestDay = false, float $distance = 60.0, float $elevation = 500.0): Stage
+    {
+        return new Stage(
+            tripId: self::TRIP_ID,
+            dayNumber: $dayNumber,
+            distance: $distance,
+            elevation: $elevation,
+            startPoint: new Coordinate(48.0, 2.0),
+            endPoint: new Coordinate(48.5, 2.5),
+            isRestDay: $isRestDay,
+        );
+    }
+
+    /**
+     * @return array{narrative: string, insights: list<string>, suggestions: list<string>, model: string, promptVersion: int, generatedAt: string}
+     */
+    private function makeAiAnalysis(string $narrative): array
+    {
+        return [
+            'narrative' => $narrative,
+            'insights' => ['Some insight'],
+            'suggestions' => ['Some suggestion'],
+            'model' => 'llama3.1:8b',
+            'promptVersion' => 1,
+            'generatedAt' => '2026-05-06T10:00:00+00:00',
+        ];
+    }
+
+    private function makeTripRequest(): TripRequest
+    {
+        $request = new TripRequest();
+        $request->locale = 'fr';
+        $request->ebikeMode = false;
+        $request->startDate = new \DateTimeImmutable('2026-06-01');
+
+        return $request;
+    }
+}

--- a/api/tests/Unit/Llm/AnalyzeTripOverviewWithLlmHandlerTest.php
+++ b/api/tests/Unit/Llm/AnalyzeTripOverviewWithLlmHandlerTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\Llm;
 use App\ApiResource\Model\Coordinate;
 use App\ApiResource\Stage;
 use App\ApiResource\TripRequest;
+use App\Llm\Dto\StageAiAnalysis;
 use App\Llm\Exception\OllamaUnavailableException;
 use App\Llm\LlmClientInterface;
 use App\Llm\SystemPromptLoader;
@@ -278,6 +279,7 @@ final class AnalyzeTripOverviewWithLlmHandlerTest extends TestCase
         self::assertSame(1, $decoded['stages'][0]['stage_number']);
         self::assertEqualsWithDelta(65.0, $decoded['stages'][0]['distance_km'], 0.01);
         self::assertSame(600, $decoded['stages'][0]['elevation_gain_m']);
+        self::assertIsString($decoded['stages'][0]['summary']);
         self::assertStringContainsString('Étape d\'approche', $decoded['stages'][0]['summary']);
 
         // System prompt must have placeholders substituted (no remaining {{...}}).
@@ -487,19 +489,16 @@ final class AnalyzeTripOverviewWithLlmHandlerTest extends TestCase
         );
     }
 
-    /**
-     * @return array{narrative: string, insights: list<string>, suggestions: list<string>, model: string, promptVersion: int, generatedAt: string}
-     */
-    private function makeAiAnalysis(string $narrative): array
+    private function makeAiAnalysis(string $narrative): StageAiAnalysis
     {
-        return [
-            'narrative' => $narrative,
-            'insights' => ['Some insight'],
-            'suggestions' => ['Some suggestion'],
-            'model' => 'llama3.1:8b',
-            'promptVersion' => 1,
-            'generatedAt' => '2026-05-06T10:00:00+00:00',
-        ];
+        return new StageAiAnalysis(
+            narrative: $narrative,
+            insights: ['Some insight'],
+            suggestions: ['Some suggestion'],
+            model: 'llama3.1:8b',
+            promptVersion: 1,
+            generatedAt: '2026-05-06T10:00:00+00:00',
+        );
     }
 
     private function makeTripRequest(): TripRequest

--- a/api/tests/Unit/Llm/TripAiOverviewTest.php
+++ b/api/tests/Unit/Llm/TripAiOverviewTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Llm;
+
+use App\Llm\Dto\TripAiOverview;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class TripAiOverviewTest extends TestCase
+{
+    #[Test]
+    public function constructorAssignsAllFields(): void
+    {
+        $overview = new TripAiOverview(
+            narrative: 'Trip narrative.',
+            patterns: ['Pattern A', 'Pattern B'],
+            recommendations: ['Rec 1', 'Rec 2'],
+            crossStageAlerts: ['Attention: zone aride J2-J3'],
+            model: 'llama3.1:8b',
+            promptVersion: 1,
+            generatedAt: '2026-05-06T10:00:00+00:00',
+        );
+
+        self::assertSame('Trip narrative.', $overview->narrative);
+        self::assertSame(['Pattern A', 'Pattern B'], $overview->patterns);
+        self::assertSame(['Rec 1', 'Rec 2'], $overview->recommendations);
+        self::assertSame(['Attention: zone aride J2-J3'], $overview->crossStageAlerts);
+        self::assertSame('llama3.1:8b', $overview->model);
+        self::assertSame(1, $overview->promptVersion);
+        self::assertSame('2026-05-06T10:00:00+00:00', $overview->generatedAt);
+    }
+
+    #[Test]
+    public function toArrayPreservesEveryField(): void
+    {
+        $overview = new TripAiOverview(
+            narrative: 'N',
+            patterns: ['P'],
+            recommendations: ['R'],
+            crossStageAlerts: ['A'],
+            model: 'm',
+            promptVersion: 3,
+            generatedAt: 'g',
+        );
+
+        self::assertSame(
+            [
+                'narrative' => 'N',
+                'patterns' => ['P'],
+                'recommendations' => ['R'],
+                'crossStageAlerts' => ['A'],
+                'model' => 'm',
+                'promptVersion' => 3,
+                'generatedAt' => 'g',
+            ],
+            $overview->toArray(),
+        );
+    }
+
+    #[Test]
+    public function fromArrayRebuildsTheDto(): void
+    {
+        $overview = TripAiOverview::fromArray([
+            'narrative' => 'N',
+            'patterns' => ['P'],
+            'recommendations' => ['R'],
+            'crossStageAlerts' => ['A'],
+            'model' => 'm',
+            'promptVersion' => 2,
+            'generatedAt' => '2026-05-06T10:00:00+00:00',
+        ]);
+
+        self::assertSame('N', $overview->narrative);
+        self::assertSame(['P'], $overview->patterns);
+        self::assertSame(['R'], $overview->recommendations);
+        self::assertSame(['A'], $overview->crossStageAlerts);
+        self::assertSame('m', $overview->model);
+        self::assertSame(2, $overview->promptVersion);
+        self::assertSame('2026-05-06T10:00:00+00:00', $overview->generatedAt);
+    }
+
+    #[Test]
+    public function fromArrayUsesDefaultsForMissingFields(): void
+    {
+        $overview = TripAiOverview::fromArray([]);
+
+        self::assertSame('', $overview->narrative);
+        self::assertSame([], $overview->patterns);
+        self::assertSame([], $overview->recommendations);
+        self::assertSame([], $overview->crossStageAlerts);
+        self::assertSame('', $overview->model);
+        self::assertSame(1, $overview->promptVersion);
+        self::assertSame('', $overview->generatedAt);
+    }
+
+    #[Test]
+    public function fromArrayRoundTripsThroughToArray(): void
+    {
+        $original = new TripAiOverview(
+            narrative: 'Trip de 3 jours.',
+            patterns: ['Zones sans eau dès J2', 'Surface bascule vers le gravel'],
+            recommendations: ['Insérer une pause à mi-J2'],
+            crossStageAlerts: ['Attention: chaleur 28°C en J2'],
+            model: 'llama3.1:8b',
+            promptVersion: 1,
+            generatedAt: '2026-05-06T12:00:00+00:00',
+        );
+
+        $rebuilt = TripAiOverview::fromArray($original->toArray());
+
+        self::assertEquals($original, $rebuilt);
+    }
+}

--- a/api/tests/Unit/Repository/DoctrineTripRequestRepositoryTest.php
+++ b/api/tests/Unit/Repository/DoctrineTripRequestRepositoryTest.php
@@ -626,4 +626,75 @@ final class DoctrineTripRequestRepositoryTest extends TestCase
 
         $this->repository->storeStages($tripId, [$stageDto]);
     }
+
+    #[Test]
+    public function updateStageAiAnalysisRunsBulkUpdateWithoutLoadingTrip(): void
+    {
+        $tripId = Uuid::v7()->toRfc4122();
+        $payload = [
+            'narrative' => 'OK',
+            'insights' => ['i1'],
+            'suggestions' => ['s1'],
+            'model' => 'llama3.1:8b',
+            'promptVersion' => 1,
+            'generatedAt' => '2026-05-08T10:00:00+00:00',
+        ];
+
+        $this->entityManager->expects(self::never())->method('find');
+
+        $query = $this->createMock(Query::class);
+        $query->expects(self::exactly(3))->method('setParameter')->willReturnSelf();
+        $query->expects(self::once())->method('execute');
+
+        $this->entityManager->expects(self::once())
+            ->method('createQuery')
+            ->with(self::stringContains('UPDATE App\Entity\Stage'))
+            ->willReturn($query);
+
+        $this->repository->updateStageAiAnalysis($tripId, 3, $payload);
+    }
+
+    #[Test]
+    public function updateStageAiAnalysisIgnoresInvalidTripId(): void
+    {
+        $this->entityManager->expects(self::never())->method('createQuery');
+
+        $this->repository->updateStageAiAnalysis('not-a-uuid', 1, null);
+    }
+
+    #[Test]
+    public function updateTripAiOverviewRunsBulkUpdateWithoutLoadingTrip(): void
+    {
+        $tripId = Uuid::v7()->toRfc4122();
+        $payload = [
+            'narrative' => 'global',
+            'patterns' => ['p1'],
+            'recommendations' => ['r1'],
+            'crossStageAlerts' => [],
+            'model' => 'llama3.1:8b',
+            'promptVersion' => 1,
+            'generatedAt' => '2026-05-08T10:00:00+00:00',
+        ];
+
+        $this->entityManager->expects(self::never())->method('find');
+
+        $query = $this->createMock(Query::class);
+        $query->expects(self::exactly(2))->method('setParameter')->willReturnSelf();
+        $query->expects(self::once())->method('execute');
+
+        $this->entityManager->expects(self::once())
+            ->method('createQuery')
+            ->with(self::stringContains('UPDATE App\ApiResource\TripRequest'))
+            ->willReturn($query);
+
+        $this->repository->updateTripAiOverview($tripId, $payload);
+    }
+
+    #[Test]
+    public function updateTripAiOverviewIgnoresInvalidTripId(): void
+    {
+        $this->entityManager->expects(self::never())->method('createQuery');
+
+        $this->repository->updateTripAiOverview('not-a-uuid', null);
+    }
 }

--- a/api/tests/Unit/Repository/RedisTripRequestRepositoryTest.php
+++ b/api/tests/Unit/Repository/RedisTripRequestRepositoryTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Repository;
+
+use App\ApiResource\Model\Coordinate;
+use App\ApiResource\Stage;
+use App\ApiResource\TripRequest;
+use App\Llm\Dto\StageAiAnalysis;
+use App\Repository\RedisTripRequestRepository;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\SharedLockInterface;
+use Symfony\Component\Uid\Uuid;
+
+#[CoversClass(RedisTripRequestRepository::class)]
+#[AllowMockObjectsWithoutExpectations]
+final class RedisTripRequestRepositoryTest extends TestCase
+{
+    private CacheItemPoolInterface&MockObject $cache;
+
+    private LockFactory&MockObject $lockFactory;
+
+    private RedisTripRequestRepository $repository;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->cache = $this->createMock(CacheItemPoolInterface::class);
+        $this->lockFactory = $this->createMock(LockFactory::class);
+        $this->repository = new RedisTripRequestRepository($this->cache, $this->lockFactory);
+    }
+
+    #[Test]
+    public function updateTripAiOverviewPersistsToRedisWhenRequestExists(): void
+    {
+        $tripId = Uuid::v7()->toRfc4122();
+        $request = new TripRequest(Uuid::fromString($tripId));
+        $overview = [
+            'narrative' => 'global',
+            'patterns' => ['p1'],
+            'recommendations' => ['r1'],
+            'crossStageAlerts' => [],
+            'model' => 'llama3.1:8b',
+            'promptVersion' => 1,
+            'generatedAt' => '2026-05-11T10:00:00+00:00',
+        ];
+
+        $readItem = $this->createMock(CacheItemInterface::class);
+        $readItem->method('isHit')->willReturn(true);
+        $readItem->method('get')->willReturn($request);
+        $readItem->method('expiresAfter')->willReturnSelf();
+
+        $writeItem = $this->createMock(CacheItemInterface::class);
+        $writeItem->expects(self::once())
+            ->method('set')
+            ->with(self::callback(static fn (TripRequest $stored): bool => $overview === $stored->aiOverviewData));
+        $writeItem->method('expiresAfter')->willReturnSelf();
+
+        // getItem is called twice: once in getRequest (read), once in set() (write)
+        $this->cache->expects(self::exactly(2))
+            ->method('getItem')
+            ->with(\sprintf('trip.%s.request', $tripId))
+            ->willReturnOnConsecutiveCalls($readItem, $writeItem);
+
+        $this->cache->expects(self::atLeastOnce())->method('save');
+
+        $this->repository->updateTripAiOverview($tripId, $overview);
+    }
+
+    #[Test]
+    public function updateTripAiOverviewIsNoopWhenRequestMissing(): void
+    {
+        $tripId = Uuid::v7()->toRfc4122();
+
+        $missing = $this->createMock(CacheItemInterface::class);
+        $missing->method('isHit')->willReturn(false);
+
+        $this->cache->method('getItem')->willReturn($missing);
+
+        $this->cache->expects(self::never())->method('save');
+
+        $this->repository->updateTripAiOverview($tripId, null);
+    }
+
+    #[Test]
+    public function updateStageAiAnalysisAssignsDtoUnderLock(): void
+    {
+        $tripId = Uuid::v7()->toRfc4122();
+
+        $stage = new Stage(
+            tripId: $tripId,
+            dayNumber: 2,
+            distance: 50.0,
+            elevation: 200.0,
+            startPoint: new Coordinate(48.0, 2.0),
+            endPoint: new Coordinate(48.1, 2.1),
+        );
+
+        $analysis = [
+            'narrative' => 'OK',
+            'insights' => ['i1'],
+            'suggestions' => ['s1'],
+            'model' => 'llama3.1:8b',
+            'promptVersion' => 1,
+            'generatedAt' => '2026-05-11T10:00:00+00:00',
+        ];
+
+        $lock = $this->createMock(SharedLockInterface::class);
+        $lock->expects(self::once())->method('acquire')->with(true)->willReturn(true);
+        $lock->expects(self::once())->method('release');
+
+        $this->lockFactory->expects(self::once())
+            ->method('createLock')
+            ->with(self::stringContains($tripId), 5)
+            ->willReturn($lock);
+
+        $readItem = $this->createMock(CacheItemInterface::class);
+        $readItem->method('isHit')->willReturn(true);
+        $readItem->method('get')->willReturn([$stage]);
+        $readItem->method('expiresAfter')->willReturnSelf();
+
+        $writeItem = $this->createMock(CacheItemInterface::class);
+        $writeItem->expects(self::once())
+            ->method('set')
+            ->with(self::callback(static fn (array $stages): bool => 1 === \count($stages)
+                && $stages[0]->aiAnalysis instanceof StageAiAnalysis
+                && $analysis['narrative'] === $stages[0]->aiAnalysis->narrative));
+        $writeItem->method('expiresAfter')->willReturnSelf();
+
+        // getItem is called twice: once in getStages (read), once in storeStages->set (write)
+        $this->cache->method('getItem')
+            ->willReturnOnConsecutiveCalls($readItem, $writeItem);
+        $this->cache->expects(self::atLeastOnce())->method('save');
+
+        $this->repository->updateStageAiAnalysis($tripId, 2, $analysis);
+    }
+}

--- a/pwa/src/lib/api/schema.d.ts
+++ b/pwa/src/lib/api/schema.d.ts
@@ -1097,6 +1097,10 @@ export interface components {
              */
             enabledAccommodationTypes: string[];
             title?: string | null;
+            /** @description LLaMA 8B pass-2 trip overview (issue #302). */
+            readonly aiOverview?: {
+                [key: string]: number | string[] | string;
+            } | null;
         };
         "Trip.TripRequest.jsonMergePatch": {
             /** Format: uri */
@@ -1142,6 +1146,10 @@ export interface components {
              */
             enabledAccommodationTypes: string[];
             title?: string | null;
+            /** @description LLaMA 8B pass-2 trip overview (issue #302). */
+            readonly aiOverview?: {
+                [key: string]: number | string[] | string;
+            } | null;
         };
         "Trip.gpx": {
             id?: string;

--- a/pwa/src/lib/api/schema.d.ts
+++ b/pwa/src/lib/api/schema.d.ts
@@ -1097,10 +1097,7 @@ export interface components {
              */
             enabledAccommodationTypes: string[];
             title?: string | null;
-            /** @description LLaMA 8B pass-2 trip overview (issue #302). */
-            readonly aiOverview?: {
-                [key: string]: number | string[] | string;
-            } | null;
+            readonly aiOverview?: components["schemas"]["TripAiOverview"] | null;
         };
         "Trip.TripRequest.jsonMergePatch": {
             /** Format: uri */
@@ -1146,10 +1143,7 @@ export interface components {
              */
             enabledAccommodationTypes: string[];
             title?: string | null;
-            /** @description LLaMA 8B pass-2 trip overview (issue #302). */
-            readonly aiOverview?: {
-                [key: string]: number | string[] | string;
-            } | null;
+            readonly aiOverview?: components["schemas"]["TripAiOverview"] | null;
         };
         "Trip.gpx": {
             id?: string;
@@ -1166,6 +1160,22 @@ export interface components {
                 [key: string]: string;
             };
             isLocked?: boolean;
+        };
+        TripAiOverview: {
+            /** @description global narrative paragraph (Vue d'ensemble + Charge et fatigue cumulative, ~120 words) */
+            narrative: string;
+            /** @description cross-stage patterns the rider should be aware of */
+            patterns: string[];
+            /** @description trip-level actionable recommendations */
+            recommendations: string[];
+            /** @description trip-level alerts spanning multiple stages (subset of patterns flagged as warnings) */
+            crossStageAlerts: string[];
+            /** @description LLM model identifier used to produce the overview (e.g. "llama3.1:8b") */
+            model: string;
+            /** @description identifies the system prompt revision (so consumers can detect staleness) */
+            promptVersion: number;
+            /** @description RFC3339 timestamp when the overview was generated */
+            generatedAt: string;
         };
         /**
          * @description Read-only trip detail resource for loading a persisted trip on the frontend.


### PR DESCRIPTION
## Summary

Implements LLaMA 8B pass-2 trip overview synthesis (issue #302) — consumes the per-stage briefings from #301 and asks the LLM to produce a global narrative covering cumulative fatigue, cross-stage patterns and trip-level recommendations.

- **`AnalyzeTripOverviewWithLlmMessage(tripId)`** — dispatched once all pass-1 analyses settle (orchestration in #303).
- **`AnalyzeTripOverviewWithLlmHandler`** collects every populated `StageAiAnalysis`, builds a JSON payload (rider profile + stage briefings, ~2-3K tokens), calls Ollama with the `trip-overview` system prompt and parses the four expected sections (Vue d'ensemble, Charge et fatigue cumulative, Patterns transversaux, Recommandations globales).
- **`TripAiOverview` DTO** (immutable readonly) persisted on `TripRequest.ai_overview` (new JSONB column, migration `Version20260506100000`).
- `crossStageAlerts` are auto-derived from patterns matching severity keywords.
- Tolerant to partial pass-1 coverage (works with whatever subset is available).
- Does **not** publish TRIP_READY (deferred to #303).

> Depends on #301 — merge 301 first, this PR auto-retargets to `main`.

## Test plan

- [x] `make qa`
- [x] `make test-php` (1083 tests, 1 skipped)
- [ ] CI

## Auto-critique

- 8K context window (`OVERVIEW_NUM_CTX`) accommodates 10-stage trips with system prompt + completion.
- Pass-1 errors don't propagate: stages without `aiAnalysis` are simply omitted, rest days always excluded.
- Markdown parser uses diacritic-stripped heading normalisation for tolerance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

Clean pass — both previously open findings are now resolved. All `TripAiOverview` TypeScript fields are non-optional in `schema.d.ts`, and `updateTripAiOverview` is fully covered by unit tests in both `DoctrineTripRequestRepositoryTest` and the new `RedisTripRequestRepositoryTest`.

Reviewed commit: `7ea387cd2fd8219c2388cec187b9003fe392b9b6`

### Resolved threads

Resolved 2 previously open threads:
- **`PRRT_kwDORUitfM6Ahx5j`** — All `TripAiOverview` fields are now non-optional in `schema.d.ts` (`narrative: string`, `patterns: string[]`, etc.). The `#[NotBlank]`/`#[NotNull]` Validator constraints on constructor-promoted properties correctly triggered API Platform 4's `required` generation for the nested DTO.
- **`PRRT_kwDORUitfM6Ahx-q`** — `DoctrineTripRequestRepository::updateTripAiOverview` covered in `DoctrineTripRequestRepositoryTest` (bulk UPDATE verified, invalid UUID guarded). `RedisTripRequestRepository::updateTripAiOverview` covered in the new `RedisTripRequestRepositoryTest` (write-through verified, missing-request no-op verified).

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Inline comments

No inline comments.

---
Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->