### PR TITLE
feat(llm): wire pipeline gate to LLaMA passes and TRIP_READY (#303)

### DIFF
--- a/api/src/Enum/ComputationName.php
+++ b/api/src/Enum/ComputationName.php
@@ -23,10 +23,25 @@ enum ComputationName: string
     case HEALTH_SERVICES = 'health_services';
     case BORDER_CROSSING = 'border_crossing';
     case EVENTS = 'events';
+    /**
+     * LLaMA 8B pass-1 — per-stage AI analysis (issue #303).
+     *
+     * Dispatched once for every non-rest stage after the enrichment gate fires.
+     * Tracked separately from the main pipeline so it does not influence the
+     * `AllEnrichmentsCompleted` gate; it only feeds the AI progress category.
+     */
+    case STAGE_AI_ANALYSIS = 'stage_ai_analysis';
+    /**
+     * LLaMA 8B pass-2 — trip-level overview synthesis (issue #303).
+     *
+     * Dispatched once every pass-1 has settled. Used solely for progress reporting.
+     */
+    case TRIP_AI_OVERVIEW = 'trip_ai_overview';
 
     /**
      * Computations initialized at trip creation (the main pipeline).
-     * On-demand computations like ROUTE_SEGMENT are excluded.
+     * On-demand computations (ROUTE_SEGMENT) and post-pipeline LLM analyses
+     * (STAGE_AI_ANALYSIS, TRIP_AI_OVERVIEW) are excluded.
      *
      * @return list<self>
      */
@@ -34,7 +49,11 @@ enum ComputationName: string
     {
         return array_values(array_filter(
             self::cases(),
-            static fn (self $c): bool => self::ROUTE_SEGMENT !== $c,
+            static fn (self $c): bool => !\in_array($c, [
+                self::ROUTE_SEGMENT,
+                self::STAGE_AI_ANALYSIS,
+                self::TRIP_AI_OVERVIEW,
+            ], true),
         ));
     }
 
@@ -55,6 +74,7 @@ enum ComputationName: string
             self::HEALTH_SERVICES, self::RAILWAY_STATIONS, self::BORDER_CROSSING => 'terrain_security',
             self::WEATHER, self::WIND => 'weather',
             self::CALENDAR, self::EVENTS, self::CULTURAL_POIS => 'context',
+            self::STAGE_AI_ANALYSIS, self::TRIP_AI_OVERVIEW => 'ai_analysis',
         };
     }
 }

--- a/api/src/Llm/LlmAnalysisTracker.php
+++ b/api/src/Llm/LlmAnalysisTracker.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Llm;
+
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * PSR-6 backed implementation of {@see LlmAnalysisTrackerInterface}.
+ *
+ * Stores three keys per trip in the `cache.trip_state` (Redis) pool:
+ *  - `trip.{id}.llm_progress` → `{completed, failed, total}`
+ *  - `trip.{id}.llm_overview_claimed` → boolean
+ *  - `trip.{id}.llm_ready_claimed` → boolean
+ *
+ * The TOCTOU window of the read-modify-write counter is sub-millisecond and
+ * acceptable for a non-business-critical progress signal: if two workers
+ * settle simultaneously and one increment is lost, the only consequence is a
+ * progress-bar tick missing from the wire — pass-2 still runs (claim is NX)
+ * and TRIP_READY still fires.
+ */
+final readonly class LlmAnalysisTracker implements LlmAnalysisTrackerInterface
+{
+    private const int TTL = 1800; // 30 minutes — same horizon as ComputationTracker
+
+    public function __construct(
+        #[Autowire(service: 'cache.trip_state')]
+        private CacheItemPoolInterface $tripStateCache,
+    ) {
+    }
+
+    public function initializeStageAnalyses(string $tripId, int $expectedStages): void
+    {
+        $this->set($this->progressKey($tripId), [
+            'completed' => 0,
+            'failed' => 0,
+            'total' => max(0, $expectedStages),
+        ]);
+    }
+
+    public function markStageAnalysisSettled(string $tripId, bool $success): array
+    {
+        $progress = $this->getStageAnalysisProgress($tripId) ?? [
+            'completed' => 0,
+            'failed' => 0,
+            'total' => 0,
+        ];
+
+        if ($success) {
+            ++$progress['completed'];
+        } else {
+            ++$progress['failed'];
+        }
+
+        $this->set($this->progressKey($tripId), $progress);
+
+        return $progress;
+    }
+
+    public function getStageAnalysisProgress(string $tripId): ?array
+    {
+        $item = $this->tripStateCache->getItem($this->progressKey($tripId));
+        if (!$item->isHit()) {
+            return null;
+        }
+
+        /** @var array{completed: int, failed: int, total: int}|null $value */
+        $value = $item->get();
+
+        return $value;
+    }
+
+    public function claimOverviewDispatch(string $tripId): bool
+    {
+        return $this->claim($this->overviewClaimKey($tripId));
+    }
+
+    public function claimTripReadyPublication(string $tripId): bool
+    {
+        return $this->claim($this->readyClaimKey($tripId));
+    }
+
+    private function claim(string $key): bool
+    {
+        $item = $this->tripStateCache->getItem($key);
+        if ($item->isHit()) {
+            return false;
+        }
+
+        $item->set(true);
+        $item->expiresAfter(self::TTL);
+
+        $this->tripStateCache->save($item);
+
+        return true;
+    }
+
+    /** @param array{completed: int, failed: int, total: int} $value */
+    private function set(string $key, array $value): void
+    {
+        $item = $this->tripStateCache->getItem($key);
+        $item->set($value);
+        $item->expiresAfter(self::TTL);
+
+        $this->tripStateCache->save($item);
+    }
+
+    private function progressKey(string $tripId): string
+    {
+        return \sprintf('trip.%s.llm_progress', $tripId);
+    }
+
+    private function overviewClaimKey(string $tripId): string
+    {
+        return \sprintf('trip.%s.llm_overview_claimed', $tripId);
+    }
+
+    private function readyClaimKey(string $tripId): string
+    {
+        return \sprintf('trip.%s.llm_ready_claimed', $tripId);
+    }
+}

--- a/api/src/Llm/LlmAnalysisTracker.php
+++ b/api/src/Llm/LlmAnalysisTracker.php
@@ -6,6 +6,7 @@ namespace App\Llm;
 
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Lock\LockFactory;
 
 /**
  * PSR-6 backed implementation of {@see LlmAnalysisTrackerInterface}.
@@ -15,11 +16,12 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
  *  - `trip.{id}.llm_overview_claimed` → boolean
  *  - `trip.{id}.llm_ready_claimed` → boolean
  *
- * The TOCTOU window of the read-modify-write counter is sub-millisecond and
- * acceptable for a non-business-critical progress signal: if two workers
- * settle simultaneously and one increment is lost, the only consequence is a
- * progress-bar tick missing from the wire — pass-2 still runs (claim is NX)
- * and TRIP_READY still fires.
+ * Concurrency guarantees:
+ *  - The progress counter read-modify-write is serialized through a Symfony Lock
+ *    so two parallel workers settling at the same instant cannot lose updates
+ *    (which would freeze the pipeline if the counter never reaches `total`).
+ *  - The two claim slots use Symfony Lock with `autoRelease: false` so the slot
+ *    stays held for the lifetime of the TTL — true NX semantics, no double-claim.
  */
 final readonly class LlmAnalysisTracker implements LlmAnalysisTrackerInterface
 {
@@ -28,6 +30,7 @@ final readonly class LlmAnalysisTracker implements LlmAnalysisTrackerInterface
     public function __construct(
         #[Autowire(service: 'cache.trip_state')]
         private CacheItemPoolInterface $tripStateCache,
+        private LockFactory $lockFactory,
     ) {
     }
 
@@ -42,21 +45,28 @@ final readonly class LlmAnalysisTracker implements LlmAnalysisTrackerInterface
 
     public function markStageAnalysisSettled(string $tripId, bool $success): array
     {
-        $progress = $this->getStageAnalysisProgress($tripId) ?? [
-            'completed' => 0,
-            'failed' => 0,
-            'total' => 0,
-        ];
+        $lock = $this->lockFactory->createLock(\sprintf('trip.%s.llm_progress.update', $tripId), ttl: 5);
+        $lock->acquire(blocking: true);
 
-        if ($success) {
-            ++$progress['completed'];
-        } else {
-            ++$progress['failed'];
+        try {
+            $progress = $this->getStageAnalysisProgress($tripId) ?? [
+                'completed' => 0,
+                'failed' => 0,
+                'total' => 0,
+            ];
+
+            if ($success) {
+                ++$progress['completed'];
+            } else {
+                ++$progress['failed'];
+            }
+
+            $this->set($this->progressKey($tripId), $progress);
+
+            return $progress;
+        } finally {
+            $lock->release();
         }
-
-        $this->set($this->progressKey($tripId), $progress);
-
-        return $progress;
     }
 
     public function getStageAnalysisProgress(string $tripId): ?array
@@ -82,19 +92,15 @@ final readonly class LlmAnalysisTracker implements LlmAnalysisTrackerInterface
         return $this->claim($this->readyClaimKey($tripId));
     }
 
+    /**
+     * Atomic NX-claim via Symfony Lock with autoRelease disabled — the lock survives
+     * the request and acts as a single-use slot for the TTL lifetime.
+     */
     private function claim(string $key): bool
     {
-        $item = $this->tripStateCache->getItem($key);
-        if ($item->isHit()) {
-            return false;
-        }
+        $lock = $this->lockFactory->createLock($key, ttl: self::TTL, autoRelease: false);
 
-        $item->set(true);
-        $item->expiresAfter(self::TTL);
-
-        $this->tripStateCache->save($item);
-
-        return true;
+        return $lock->acquire(blocking: false);
     }
 
     /** @param array{completed: int, failed: int, total: int} $value */

--- a/api/src/Llm/LlmAnalysisTrackerInterface.php
+++ b/api/src/Llm/LlmAnalysisTrackerInterface.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Llm;
+
+/**
+ * Tracks the progress of the LLaMA 8B analysis pipeline (issue #303).
+ *
+ * Distinct from {@see \App\ComputationTracker\ComputationTrackerInterface} because:
+ *  - it is initialised AFTER the main enrichment gate has fired,
+ *  - settling its counter must NOT re-trigger the gate (otherwise TRIP_READY
+ *    would be published twice — once before, once after pass-2),
+ *  - pass-1 and pass-2 are sequential phases with their own readiness gates.
+ */
+interface LlmAnalysisTrackerInterface
+{
+    /**
+     * Initialises the tracker for a trip with the expected number of pass-1
+     * stage analyses. A value of 0 short-circuits the pipeline — the caller
+     * should treat that case as "no AI analysis to run".
+     */
+    public function initializeStageAnalyses(string $tripId, int $expectedStages): void;
+
+    /**
+     * Marks one pass-1 stage analysis as settled (succeeded or failed).
+     *
+     * Returns the snapshot of the counter AFTER incrementing so the caller
+     * can decide whether to dispatch pass-2.
+     *
+     * @return array{completed: int, failed: int, total: int}
+     */
+    public function markStageAnalysisSettled(string $tripId, bool $success): array;
+
+    /**
+     * Returns the current snapshot of the pass-1 counter, or null if the
+     * tracker has not been initialised for this trip (e.g. LLM disabled).
+     *
+     * @return array{completed: int, failed: int, total: int}|null
+     */
+    public function getStageAnalysisProgress(string $tripId): ?array;
+
+    /**
+     * Atomic NX-style claim of the "pass-2 dispatched" slot.
+     *
+     * Returns true on the first successful call — the caller owns the dispatch.
+     * Subsequent calls return false to guard against duplicate triggers when
+     * several pass-1 workers settle concurrently.
+     */
+    public function claimOverviewDispatch(string $tripId): bool;
+
+    /**
+     * Atomic NX-style claim of the "TRIP_READY published" slot for the LLM
+     * pipeline. Mirrors {@see \App\ComputationTracker\ComputationTrackerInterface::claimReadyPublication}
+     * so the trip-overview handler can publish exactly once even if it is
+     * retried by the messenger.
+     */
+    public function claimTripReadyPublication(string $tripId): bool;
+}

--- a/api/src/Mercure/NullTripUpdatePublisher.php
+++ b/api/src/Mercure/NullTripUpdatePublisher.php
@@ -40,8 +40,8 @@ final readonly class NullTripUpdatePublisher implements TripUpdatePublisherInter
     }
 
     /**
-     * @param list<Stage>                                                $stages
-     * @param array{status: array<string, string>, aiOverview?: ?string} $summary
+     * @param list<Stage>                                                                                                                                                                                                                     $stages
+     * @param array{status: array<string, string>, aiOverview?: array{narrative: string, patterns: list<string>, recommendations: list<string>, crossStageAlerts: list<string>, model: string, promptVersion: int, generatedAt: string}|null} $summary
      */
     public function publishTripReady(string $tripId, array $stages, array $summary): void
     {

--- a/api/src/Mercure/StagePayloadMapper.php
+++ b/api/src/Mercure/StagePayloadMapper.php
@@ -62,6 +62,9 @@ final readonly class StagePayloadMapper
                 $this->eventToPayload(...),
                 $stage->events,
             ),
+            // LLaMA 8B pass-1 narrative briefing (issues #301/#303). Forwarded as-is so
+            // the frontend can render it next to the per-stage data atomically.
+            'aiAnalysis' => $stage->aiAnalysis,
         ];
     }
 

--- a/api/src/Mercure/TripUpdatePublisher.php
+++ b/api/src/Mercure/TripUpdatePublisher.php
@@ -71,8 +71,8 @@ final readonly class TripUpdatePublisher implements TripUpdatePublisherInterface
     }
 
     /**
-     * @param list<Stage>                                                $stages
-     * @param array{status: array<string, string>, aiOverview?: ?string} $summary
+     * @param list<Stage>                                                                                                                                                                                                                     $stages
+     * @param array{status: array<string, string>, aiOverview?: array{narrative: string, patterns: list<string>, recommendations: list<string>, crossStageAlerts: list<string>, model: string, promptVersion: int, generatedAt: string}|null} $summary
      */
     public function publishTripReady(string $tripId, array $stages, array $summary): void
     {

--- a/api/src/Mercure/TripUpdatePublisherInterface.php
+++ b/api/src/Mercure/TripUpdatePublisherInterface.php
@@ -49,8 +49,13 @@ interface TripUpdatePublisherInterface
     /**
      * Publishes the single terminal event of Mode 1 with the fully enriched trip payload.
      *
-     * @param list<Stage>                                                $stages
-     * @param array{status: array<string, string>, aiOverview?: ?string} $summary additional aggregate metadata
+     * The summary may carry the optional pass-2 AI overview (issue #303). When
+     * present, it is forwarded as a structured array under the `aiOverview` key
+     * so the frontend can render the trip-level briefing alongside the per-stage
+     * `aiAnalysis` already embedded in each stage payload.
+     *
+     * @param list<Stage>                                                                                                                                                                                                                     $stages
+     * @param array{status: array<string, string>, aiOverview?: array{narrative: string, patterns: list<string>, recommendations: list<string>, crossStageAlerts: list<string>, model: string, promptVersion: int, generatedAt: string}|null} $summary additional aggregate metadata
      */
     public function publishTripReady(string $tripId, array $stages, array $summary): void;
 

--- a/api/src/MessageHandler/AllEnrichmentsCompletedHandler.php
+++ b/api/src/MessageHandler/AllEnrichmentsCompletedHandler.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace App\MessageHandler;
 
+use App\ApiResource\Stage;
 use App\ComputationTracker\ComputationTrackerInterface;
+use App\Enum\ComputationName;
+use App\Llm\LlmAnalysisTrackerInterface;
 use App\Llm\LlmClientInterface;
 use App\Mercure\TripUpdatePublisherInterface;
 use App\Message\AllEnrichmentsCompleted;
@@ -15,19 +18,28 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 /**
- * Terminal handler of the enrichment pipeline.
+ * Terminal handler of the enrichment pipeline (gate side).
  *
- * This handler is fired by {@see AbstractTripMessageHandler} when the enrichment gate
- * (progress arithmetic) detects that every computation has settled.
+ * Fired by {@see AbstractTripMessageHandler} once the enrichment gate
+ * (issue #299) detects that every initialised computation has settled
+ * (`done` or `failed`).
  *
- * The full design (issues #301-#303) is to chain this handler into the LLaMA 8B
- * narrative analysis. Until that pipeline exists, the handler implements a minimal
- * fallback: it publishes the `TRIP_READY` Mercure event directly so the frontend
- * receives the terminal signal and can render the fully enriched trip atomically.
+ * From this point, two strategies coexist (issue #303 wires them):
  *
- * Once LLaMA is wired in, this handler can dispatch the `RunLlamaAnalysis` message
- * and let *that* downstream handler publish `TRIP_READY` after the AI overview
- * has been computed — without breaking any consumer of `TRIP_READY`.
+ *  - **Ollama disabled** (or no non-rest stage to analyse) — the handler is
+ *    self-terminating: it publishes the `TRIP_READY` Mercure event directly
+ *    so the frontend swaps state atomically with the enriched payload.
+ *  - **Ollama enabled** — the handler initialises the dedicated LLM tracker
+ *    ({@see LlmAnalysisTrackerInterface}) with the number of expected pass-1
+ *    analyses, then dispatches one {@see AnalyzeStageWithLlmMessage} per
+ *    non-rest stage. TRIP_READY is published later, by
+ *    {@see AnalyzeTripOverviewWithLlmHandler}, once pass-2 has settled (or
+ *    been skipped) — guaranteeing a single terminal event carrying both
+ *    per-stage `aiAnalysis` and the trip-level `aiOverview`.
+ *
+ * The dual responsibility (publish-or-delegate) is deliberate: keeping it in
+ * one place lets the frontend rely on a single TRIP_READY contract regardless
+ * of the AI feature flag.
  */
 #[AsMessageHandler]
 final readonly class AllEnrichmentsCompletedHandler
@@ -39,6 +51,7 @@ final readonly class AllEnrichmentsCompletedHandler
         private LoggerInterface $logger,
         private MessageBusInterface $messageBus,
         private LlmClientInterface $llmClient,
+        private LlmAnalysisTrackerInterface $llmTracker,
     ) {
     }
 
@@ -66,23 +79,61 @@ final readonly class AllEnrichmentsCompletedHandler
 
         $stages = $this->tripRequestRepository->getStages($tripId) ?? [];
 
-        // Issue #301 — LLaMA 8B pass 1: dispatch one AnalyzeStageWithLlmMessage per non-rest
-        // stage. Messages are independent and parallelisable across the worker pool. The
-        // handler is no-op when Ollama is disabled, so dispatching costs nothing in that case.
-        // TRIP_READY is still published synchronously here: the AI analysis is best-effort
-        // enrichment that lands later via a dedicated Mercure event (issues #302-#303).
-        if ($this->llmClient->isEnabled()) {
-            foreach ($stages as $stage) {
-                if ($stage->isRestDay) {
-                    continue;
-                }
+        $analysableStages = $this->countAnalysableStages($stages);
 
-                $this->messageBus->dispatch(new AnalyzeStageWithLlmMessage($tripId, $stage->dayNumber));
+        // Short-circuit: when the LLM is disabled OR there is no stage to analyse
+        // (e.g. all rest days), publish TRIP_READY directly — no AI overview to await.
+        if (!$this->llmClient->isEnabled() || 0 === $analysableStages) {
+            $this->publisher->publishTripReady($tripId, $stages, [
+                'status' => $statuses,
+            ]);
+
+            return;
+        }
+
+        // LLaMA 8B pass-1 dispatch: initialise the LLM tracker BEFORE dispatching
+        // so concurrent pass-1 workers can reliably increment the counter.
+        $this->llmTracker->initializeStageAnalyses($tripId, $analysableStages);
+
+        // Surface the AI category in the progress bar (issue #303): emit a
+        // single COMPUTATION_STEP_COMPLETED with completed=0 so the frontend
+        // can register the new "Analyse IA" tracker before any pass-1 settles.
+        $this->publisher->publishComputationStepCompleted(
+            $tripId,
+            ComputationName::STAGE_AI_ANALYSIS,
+            completed: 0,
+            total: $analysableStages + 1, // pass-1 stages + 1 pass-2 overview
+            failed: 0,
+        );
+
+        foreach ($stages as $stage) {
+            if ($stage->isRestDay) {
+                continue;
+            }
+
+            $this->messageBus->dispatch(new AnalyzeStageWithLlmMessage($tripId, $stage->dayNumber));
+        }
+
+        // Defensive corner case: when there is exactly one non-rest stage and that
+        // stage's pass-1 hits an empty repository or LLM error, the tracker will
+        // still settle from the worker side. We therefore do NOT short-circuit
+        // pass-2 here — the LlmAnalysisTracker handles the all-failed path.
+    }
+
+    /**
+     * Counts the stages that are eligible for pass-1 LLaMA analysis (non-rest).
+     *
+     * @param list<Stage> $stages
+     */
+    private function countAnalysableStages(array $stages): int
+    {
+        $count = 0;
+        foreach ($stages as $stage) {
+            if (!$stage->isRestDay) {
+                ++$count;
             }
         }
 
-        $this->publisher->publishTripReady($tripId, $stages, [
-            'status' => $statuses,
-        ]);
+        return $count;
     }
 }

--- a/api/src/MessageHandler/AnalyzeStageWithLlmHandler.php
+++ b/api/src/MessageHandler/AnalyzeStageWithLlmHandler.php
@@ -6,16 +6,21 @@ namespace App\MessageHandler;
 
 use App\ApiResource\Stage;
 use App\ApiResource\TripRequest;
+use App\Enum\ComputationName;
 use App\Llm\Dto\StageAiAnalysis;
 use App\Llm\Exception\OllamaUnavailableException;
+use App\Llm\LlmAnalysisTrackerInterface;
 use App\Llm\LlmClientInterface;
 use App\Llm\StageAnalysisSummaryBuilder;
 use App\Llm\SystemPromptLoader;
+use App\Mercure\TripUpdatePublisherInterface;
 use App\Message\AnalyzeStageWithLlmMessage;
+use App\Message\AnalyzeTripOverviewWithLlmMessage;
 use App\Repository\TripRequestRepositoryInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\MessageBusInterface;
 
 /**
  * LLaMA 8B pass-1: per-stage analysis (issue #301).
@@ -52,6 +57,9 @@ final readonly class AnalyzeStageWithLlmHandler
         private SystemPromptLoader $promptLoader,
         private StageAnalysisSummaryBuilder $summaryBuilder,
         private LoggerInterface $logger,
+        private LlmAnalysisTrackerInterface $llmTracker,
+        private MessageBusInterface $messageBus,
+        private TripUpdatePublisherInterface $publisher,
         #[Autowire(env: 'default::OLLAMA_STAGE_MODEL')]
         ?string $model = null,
     ) {
@@ -75,6 +83,7 @@ final readonly class AnalyzeStageWithLlmHandler
                 'tripId' => $message->tripId,
                 'dayNumber' => $message->dayNumber,
             ]);
+            $this->settle($message->tripId, success: false);
 
             return;
         }
@@ -85,6 +94,7 @@ final readonly class AnalyzeStageWithLlmHandler
                 'tripId' => $message->tripId,
                 'dayNumber' => $message->dayNumber,
             ]);
+            $this->settle($message->tripId, success: false);
 
             return;
         }
@@ -95,6 +105,8 @@ final readonly class AnalyzeStageWithLlmHandler
                 'dayNumber' => $message->dayNumber,
             ]);
 
+            // Rest days are not counted in the tracker total — do not settle here,
+            // the dispatcher already excluded them.
             return;
         }
 
@@ -112,6 +124,7 @@ final readonly class AnalyzeStageWithLlmHandler
                 'dayNumber' => $message->dayNumber,
                 'error' => $jsonException->getMessage(),
             ]);
+            $this->settle($message->tripId, success: false);
 
             return;
         }
@@ -133,11 +146,14 @@ final readonly class AnalyzeStageWithLlmHandler
                 'dayNumber' => $message->dayNumber,
                 'error' => $ollamaUnavailableException->getMessage(),
             ]);
+            $this->settle($message->tripId, success: false);
 
             return;
         }
 
         if (null === $response) {
+            $this->settle($message->tripId, success: false);
+
             return;
         }
 
@@ -147,6 +163,7 @@ final readonly class AnalyzeStageWithLlmHandler
                 'tripId' => $message->tripId,
                 'dayNumber' => $message->dayNumber,
             ]);
+            $this->settle($message->tripId, success: false);
 
             return;
         }
@@ -165,6 +182,57 @@ final readonly class AnalyzeStageWithLlmHandler
             'insights' => \count($analysis->insights),
             'suggestions' => \count($analysis->suggestions),
         ]);
+
+        $this->settle($message->tripId, success: true);
+    }
+
+    /**
+     * Settles one pass-1 slot on the LLM tracker, emits the AI progress event,
+     * and — when every pass-1 has settled — claims the pass-2 dispatch slot
+     * and queues the trip-overview message.
+     *
+     * Settling is intentionally idempotent at the dispatch level: if two
+     * concurrent workers race the final increment, only one will win the
+     * NX `claimOverviewDispatch()` call.
+     */
+    private function settle(string $tripId, bool $success): void
+    {
+        $progress = $this->llmTracker->markStageAnalysisSettled($tripId, $success);
+
+        // Total = pass-1 stages + 1 pass-2 overview. Progress published as steps
+        // so the AI category mirrors the regular pipeline progress bar.
+        $totalSteps = $progress['total'] + 1;
+        $this->publisher->publishComputationStepCompleted(
+            $tripId,
+            ComputationName::STAGE_AI_ANALYSIS,
+            completed: $progress['completed'],
+            total: $totalSteps,
+            failed: $progress['failed'],
+        );
+
+        $allSettled = $progress['total'] > 0
+            && $progress['completed'] + $progress['failed'] === $progress['total'];
+
+        if (!$allSettled) {
+            return;
+        }
+
+        if (!$this->llmTracker->claimOverviewDispatch($tripId)) {
+            $this->logger->debug('Trip overview already dispatched for trip {tripId} — skipping duplicate.', [
+                'tripId' => $tripId,
+            ]);
+
+            return;
+        }
+
+        $this->logger->info('All pass-1 LLM analyses settled for trip {tripId} — dispatching pass-2.', [
+            'tripId' => $tripId,
+            'completed' => $progress['completed'],
+            'failed' => $progress['failed'],
+            'total' => $progress['total'],
+        ]);
+
+        $this->messageBus->dispatch(new AnalyzeTripOverviewWithLlmMessage($tripId));
     }
 
     /**

--- a/api/src/MessageHandler/AnalyzeTripOverviewWithLlmHandler.php
+++ b/api/src/MessageHandler/AnalyzeTripOverviewWithLlmHandler.php
@@ -6,11 +6,15 @@ namespace App\MessageHandler;
 
 use App\ApiResource\Stage;
 use App\ApiResource\TripRequest;
+use App\ComputationTracker\ComputationTrackerInterface;
+use App\Enum\ComputationName;
 use App\Llm\Dto\StageAiAnalysis;
 use App\Llm\Dto\TripAiOverview;
 use App\Llm\Exception\OllamaUnavailableException;
+use App\Llm\LlmAnalysisTrackerInterface;
 use App\Llm\LlmClientInterface;
 use App\Llm\SystemPromptLoader;
+use App\Mercure\TripUpdatePublisherInterface;
 use App\Message\AnalyzeTripOverviewWithLlmMessage;
 use App\Repository\TripRequestRepositoryInterface;
 use Psr\Log\LoggerInterface;
@@ -62,6 +66,9 @@ final readonly class AnalyzeTripOverviewWithLlmHandler
         private LlmClientInterface $llmClient,
         private SystemPromptLoader $promptLoader,
         private LoggerInterface $logger,
+        private LlmAnalysisTrackerInterface $llmTracker,
+        private ComputationTrackerInterface $computationTracker,
+        private TripUpdatePublisherInterface $publisher,
         #[Autowire(env: 'default::OLLAMA_OVERVIEW_MODEL')]
         ?string $model = null,
     ) {
@@ -70,19 +77,26 @@ final readonly class AnalyzeTripOverviewWithLlmHandler
 
     public function __invoke(AnalyzeTripOverviewWithLlmMessage $message): void
     {
+        $tripId = $message->tripId;
+
         if (!$this->llmClient->isEnabled()) {
+            // The dispatcher (AllEnrichmentsCompletedHandler) already short-circuits
+            // and publishes TRIP_READY directly when the LLM is disabled. Reaching
+            // this handler with a disabled LLM means a stale / replayed message —
+            // skip silently to avoid a double publish.
             $this->logger->debug('LLM disabled — skipping trip overview synthesis.', [
-                'tripId' => $message->tripId,
+                'tripId' => $tripId,
             ]);
 
             return;
         }
 
-        $stages = $this->tripStateManager->getStages($message->tripId);
+        $stages = $this->tripStateManager->getStages($tripId);
         if (null === $stages || [] === $stages) {
             $this->logger->info('No stages found for trip — skipping LLM trip overview.', [
-                'tripId' => $message->tripId,
+                'tripId' => $tripId,
             ]);
+            $this->finalize($tripId, overview: null);
 
             return;
         }
@@ -90,13 +104,14 @@ final readonly class AnalyzeTripOverviewWithLlmHandler
         $stageInputs = $this->buildStageInputs($stages);
         if ([] === $stageInputs) {
             $this->logger->info('No pass-1 stage analyses available — skipping LLM trip overview.', [
-                'tripId' => $message->tripId,
+                'tripId' => $tripId,
             ]);
+            $this->finalize($tripId, overview: null);
 
             return;
         }
 
-        $request = $this->tripStateManager->getRequest($message->tripId);
+        $request = $this->tripStateManager->getRequest($tripId);
         $variables = $this->buildPromptVariables($request);
         $systemPrompt = $this->promptLoader->load(self::PROMPT_NAME, $variables);
 
@@ -109,9 +124,10 @@ final readonly class AnalyzeTripOverviewWithLlmHandler
             $userPrompt = json_encode($payload, \JSON_THROW_ON_ERROR | \JSON_UNESCAPED_UNICODE);
         } catch (\JsonException $jsonException) {
             $this->logger->warning('Failed to encode trip overview payload for LLM prompt.', [
-                'tripId' => $message->tripId,
+                'tripId' => $tripId,
                 'error' => $jsonException->getMessage(),
             ]);
+            $this->finalize($tripId, overview: null);
 
             return;
         }
@@ -130,22 +146,26 @@ final readonly class AnalyzeTripOverviewWithLlmHandler
             );
         } catch (OllamaUnavailableException $ollamaUnavailableException) {
             $this->logger->warning('Ollama unreachable — skipping trip overview synthesis.', [
-                'tripId' => $message->tripId,
+                'tripId' => $tripId,
                 'error' => $ollamaUnavailableException->getMessage(),
             ]);
+            $this->finalize($tripId, overview: null);
 
             return;
         }
 
         if (null === $response) {
+            $this->finalize($tripId, overview: null);
+
             return;
         }
 
         $rawText = $this->extractText($response);
         if (null === $rawText || '' === trim($rawText)) {
             $this->logger->warning('LLM returned an empty response for trip overview.', [
-                'tripId' => $message->tripId,
+                'tripId' => $tripId,
             ]);
+            $this->finalize($tripId, overview: null);
 
             return;
         }
@@ -153,15 +173,75 @@ final readonly class AnalyzeTripOverviewWithLlmHandler
         $overview = $this->parseMarkdownResponse($rawText);
 
         $this->tripStateManager->updateTripAiOverview(
-            $message->tripId,
+            $tripId,
             $overview->toArray(),
         );
 
         $this->logger->info('LLM trip overview persisted for trip {tripId}.', [
-            'tripId' => $message->tripId,
+            'tripId' => $tripId,
             'patterns' => \count($overview->patterns),
             'recommendations' => \count($overview->recommendations),
             'crossStageAlerts' => \count($overview->crossStageAlerts),
+        ]);
+
+        $this->finalize($tripId, $overview);
+    }
+
+    /**
+     * Terminal step of the LLM pipeline (issue #303).
+     *
+     * Whether pass-2 succeeds, fails or is skipped, the handler MUST publish
+     * the `TRIP_READY` Mercure event exactly once so the frontend renders the
+     * fully enriched trip atomically. The dual claim (`claimTripReadyPublication`)
+     * guards against retries when Messenger replays a soft-failed message.
+     *
+     * The published payload always includes:
+     *  - `stages` with their per-stage `aiAnalysis` (pass-1 result, may be null
+     *    for stages that failed),
+     *  - `computationStatus` from the gate tracker for diagnostic purposes,
+     *  - `aiOverview` whenever pass-2 produced one — omitted (key absent) when
+     *    pass-2 was skipped or failed, so the frontend can hide the section.
+     */
+    private function finalize(string $tripId, ?TripAiOverview $overview): void
+    {
+        // Emit the AI overview progress step regardless of outcome so the frontend
+        // can complete the "Analyse IA" category in the progress bar (issue #303).
+        $progress = $this->llmTracker->getStageAnalysisProgress($tripId);
+        if (null !== $progress) {
+            $totalSteps = $progress['total'] + 1;
+            $stageCompleted = $progress['completed'];
+            $stageFailed = $progress['failed'];
+
+            $this->publisher->publishComputationStepCompleted(
+                $tripId,
+                ComputationName::TRIP_AI_OVERVIEW,
+                completed: $stageCompleted + ($overview instanceof TripAiOverview ? 1 : 0),
+                total: $totalSteps,
+                failed: $stageFailed + ($overview instanceof TripAiOverview ? 0 : 1),
+            );
+        }
+
+        if (!$this->llmTracker->claimTripReadyPublication($tripId)) {
+            $this->logger->debug('TRIP_READY already published for trip {tripId} — skipping duplicate.', [
+                'tripId' => $tripId,
+            ]);
+
+            return;
+        }
+
+        $stages = $this->tripStateManager->getStages($tripId) ?? [];
+        $statuses = $this->computationTracker->getStatuses($tripId) ?? [];
+
+        $summary = ['status' => $statuses];
+        if ($overview instanceof TripAiOverview) {
+            $summary['aiOverview'] = $overview->toArray();
+        }
+
+        $this->publisher->publishTripReady($tripId, $stages, $summary);
+
+        $this->logger->info('TRIP_READY published for trip {tripId} with{withOverview} AI overview.', [
+            'tripId' => $tripId,
+            'withOverview' => $overview instanceof TripAiOverview ? '' : 'out',
         ]);
     }
 

--- a/api/tests/Integration/LlmPipelineTest.php
+++ b/api/tests/Integration/LlmPipelineTest.php
@@ -126,8 +126,20 @@ final class LlmPipelineTest extends TestCase
             publisher: $publisher,
         );
 
-        $bus->register(AnalyzeStageWithLlmMessage::class, $stageHandler);
-        $bus->register(AnalyzeTripOverviewWithLlmMessage::class, $overviewHandler);
+        $bus->register(
+            AnalyzeStageWithLlmMessage::class,
+            static function (object $message) use ($stageHandler): void {
+                \assert($message instanceof AnalyzeStageWithLlmMessage);
+                $stageHandler($message);
+            },
+        );
+        $bus->register(
+            AnalyzeTripOverviewWithLlmMessage::class,
+            static function (object $message) use ($overviewHandler): void {
+                \assert($message instanceof AnalyzeTripOverviewWithLlmMessage);
+                $overviewHandler($message);
+            },
+        );
 
         // The terminal handler shares the LLM tracker with both downstream handlers
         // so the gate→pass1→pass2→TRIP_READY flow is observable in-memory.
@@ -157,11 +169,16 @@ final class LlmPipelineTest extends TestCase
         self::assertCount(1, $tripReadyEvents, 'TRIP_READY must be published exactly once.');
 
         // The payload must contain stages with ai_analysis and the ai_overview.
-        [$tripReady] = array_values($tripReadyEvents);
+        $tripReady = $tripReadyEvents[0];
         self::assertSame(self::TRIP_ID, $tripReady['tripId']);
+        self::assertArrayHasKey('stages', $tripReady['data']);
+        self::assertIsArray($tripReady['data']['stages']);
         self::assertCount(3, $tripReady['data']['stages']);
+        self::assertIsArray($tripReady['data']['stages'][0]);
         self::assertNotNull($tripReady['data']['stages'][0]['aiAnalysis']);
+        self::assertIsArray($tripReady['data']['stages'][2]);
         self::assertNotNull($tripReady['data']['stages'][2]['aiAnalysis']);
+        self::assertIsArray($tripReady['data']['stages'][1]);
         self::assertNull($tripReady['data']['stages'][1]['aiAnalysis'], 'Rest stage payload carries no ai_analysis.');
         self::assertArrayHasKey('aiOverview', $tripReady['data']);
         self::assertIsArray($tripReady['data']['aiOverview']);
@@ -212,8 +229,10 @@ final class LlmPipelineTest extends TestCase
         $tripReadyEvents = $publisher->byType(MercureEventType::TRIP_READY);
         self::assertCount(1, $tripReadyEvents);
 
-        [$tripReady] = array_values($tripReadyEvents);
+        $tripReady = $tripReadyEvents[0];
         self::assertSame(self::TRIP_ID, $tripReady['tripId']);
+        self::assertArrayHasKey('stages', $tripReady['data']);
+        self::assertIsArray($tripReady['data']['stages']);
         self::assertCount(1, $tripReady['data']['stages']);
         self::assertArrayNotHasKey('aiOverview', $tripReady['data'], 'Disabled LLM means no aiOverview key.');
 
@@ -367,11 +386,17 @@ final class InMemoryTripRequestRepository implements TripRequestRepositoryInterf
         $this->aiOverview = $aiOverview;
     }
 
+    /**
+     * @return array<string, mixed>|null
+     */
     public function stageAiAnalysisFor(int $dayNumber): ?array
     {
         return $this->stageAiAnalysis[$dayNumber] ?? null;
     }
 
+    /**
+     * @return array<string, mixed>|null
+     */
     public function tripAiOverview(): ?array
     {
         return $this->aiOverview;
@@ -453,12 +478,15 @@ final class InMemoryTripRequestRepository implements TripRequestRepositoryInterf
  */
 final class InMemoryBus implements MessageBusInterface
 {
-    /** @var array<class-string, callable(object): void> */
+    /** @var array<string, callable(object): void> */
     private array $handlers = [];
 
     private int $dispatchCount = 0;
 
-    /** @param callable(object): void $handler */
+    /**
+     * @param class-string           $messageClass
+     * @param callable(object): void $handler
+     */
     public function register(string $messageClass, callable $handler): void
     {
         $this->handlers[$messageClass] = $handler;

--- a/api/tests/Integration/LlmPipelineTest.php
+++ b/api/tests/Integration/LlmPipelineTest.php
@@ -1,0 +1,626 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration;
+
+use App\ApiResource\Model\Coordinate;
+use App\ApiResource\Stage;
+use App\ApiResource\TripRequest;
+use App\ComputationTracker\ComputationTrackerInterface;
+use App\Enum\ComputationName;
+use App\Llm\LlmAnalysisTrackerInterface;
+use App\Llm\LlmClientInterface;
+use App\Llm\StageAnalysisSummaryBuilder;
+use App\Llm\SystemPromptLoader;
+use App\Mercure\MercureEventType;
+use App\Mercure\StagePayloadMapper;
+use App\Mercure\TripUpdatePublisherInterface;
+use App\Message\AllEnrichmentsCompleted;
+use App\Message\AnalyzeStageWithLlmMessage;
+use App\Message\AnalyzeTripOverviewWithLlmMessage;
+use App\MessageHandler\AllEnrichmentsCompletedHandler;
+use App\MessageHandler\AnalyzeStageWithLlmHandler;
+use App\MessageHandler\AnalyzeTripOverviewWithLlmHandler;
+use App\Repository\TripRequestRepositoryInterface;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+/**
+ * End-to-end pipeline test for the LLaMA 8B analysis chain (issue #303).
+ *
+ * Exercises the three handlers in sequence:
+ *
+ *   AllEnrichmentsCompletedHandler
+ *   → N × AnalyzeStageWithLlmHandler (pass 1, parallel)
+ *   → AnalyzeTripOverviewWithLlmHandler (pass 2)
+ *   → TRIP_READY published once with the fully enriched payload
+ *
+ * The Messenger bus is replaced with an in-memory dispatcher that immediately
+ * invokes the matching handler so the test can run synchronously and assert
+ * end-to-end side effects: pass-1 analyses, pass-2 overview, single TRIP_READY
+ * publication, and progress events.
+ *
+ * Both Ollama-enabled (full pipeline) and Ollama-disabled (short-circuit) flows
+ * are covered.
+ */
+final class LlmPipelineTest extends TestCase
+{
+    private const string TRIP_ID = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
+
+    private string $tmpPromptDir = '';
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->tmpPromptDir = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'llm-pipeline-prompts-'.bin2hex(random_bytes(4));
+
+        if (!mkdir($this->tmpPromptDir, 0o755, true) && !is_dir($this->tmpPromptDir)) {
+            throw new \RuntimeException('Failed to create tmp prompt dir.');
+        }
+
+        $placeholders = "Region: {{region}}\nProfile: {{rider_profile}}\nLanguage: {{language}}\nDate: {{date}}\n";
+        file_put_contents(
+            $this->tmpPromptDir.\DIRECTORY_SEPARATOR.AnalyzeStageWithLlmHandler::PROMPT_NAME.'.txt',
+            $placeholders,
+        );
+        file_put_contents(
+            $this->tmpPromptDir.\DIRECTORY_SEPARATOR.AnalyzeTripOverviewWithLlmHandler::PROMPT_NAME.'.txt',
+            $placeholders,
+        );
+    }
+
+    #[\Override]
+    protected function tearDown(): void
+    {
+        if (!is_dir($this->tmpPromptDir)) {
+            return;
+        }
+
+        foreach (glob($this->tmpPromptDir.\DIRECTORY_SEPARATOR.'*') ?: [] as $file) {
+            unlink($file);
+        }
+
+        rmdir($this->tmpPromptDir);
+    }
+
+    #[Test]
+    public function fullPipelineEnrichmentsToLlmToTripReady(): void
+    {
+        $stages = [
+            $this->makeStage(dayNumber: 1, distance: 80.0),
+            $this->makeStage(dayNumber: 2, distance: 0.0, isRestDay: true),
+            $this->makeStage(dayNumber: 3, distance: 95.0),
+        ];
+
+        $repository = new InMemoryTripRequestRepository(
+            stages: $stages,
+            request: $this->makeTripRequest(),
+        );
+
+        $publisher = new RecordingTripUpdatePublisher();
+        $llmTracker = new InMemoryLlmAnalysisTracker();
+        $bus = new InMemoryBus();
+
+        $stageHandler = new AnalyzeStageWithLlmHandler(
+            tripStateManager: $repository,
+            llmClient: $this->stageLlmClient(),
+            promptLoader: new SystemPromptLoader($this->tmpPromptDir),
+            summaryBuilder: new StageAnalysisSummaryBuilder(),
+            logger: new NullLogger(),
+            llmTracker: $llmTracker,
+            messageBus: $bus,
+            publisher: $publisher,
+        );
+
+        $overviewHandler = new AnalyzeTripOverviewWithLlmHandler(
+            tripStateManager: $repository,
+            llmClient: $this->overviewLlmClient(),
+            promptLoader: new SystemPromptLoader($this->tmpPromptDir),
+            logger: new NullLogger(),
+            llmTracker: $llmTracker,
+            computationTracker: $this->stubComputationTracker(['route' => 'done', 'weather' => 'failed']),
+            publisher: $publisher,
+        );
+
+        $bus->register(AnalyzeStageWithLlmMessage::class, $stageHandler);
+        $bus->register(AnalyzeTripOverviewWithLlmMessage::class, $overviewHandler);
+
+        // The terminal handler shares the LLM tracker with both downstream handlers
+        // so the gate→pass1→pass2→TRIP_READY flow is observable in-memory.
+        $terminalHandler = new AllEnrichmentsCompletedHandler(
+            computationTracker: $this->stubComputationTracker(['route' => 'done']),
+            publisher: $publisher,
+            tripRequestRepository: $repository,
+            logger: new NullLogger(),
+            messageBus: $bus,
+            llmClient: $this->stageLlmClient(),
+            llmTracker: $llmTracker,
+        );
+
+        // Trigger the pipeline.
+        $terminalHandler(new AllEnrichmentsCompleted(self::TRIP_ID));
+
+        // Pass-1: each non-rest stage received an aiAnalysis.
+        self::assertNotNull($repository->stageAiAnalysisFor(1), 'Stage 1 should have a pass-1 analysis.');
+        self::assertNotNull($repository->stageAiAnalysisFor(3), 'Stage 3 should have a pass-1 analysis.');
+        self::assertNull($repository->stageAiAnalysisFor(2), 'Rest stage 2 must not be analysed.');
+
+        // Pass-2: trip-level overview was persisted.
+        self::assertNotNull($repository->tripAiOverview(), 'Pass-2 trip overview should be persisted.');
+
+        // Exactly one TRIP_READY was published — the terminal one from the overview handler.
+        $tripReadyEvents = $publisher->byType(MercureEventType::TRIP_READY);
+        self::assertCount(1, $tripReadyEvents, 'TRIP_READY must be published exactly once.');
+
+        // The payload must contain stages with ai_analysis and the ai_overview.
+        [$tripReady] = array_values($tripReadyEvents);
+        self::assertSame(self::TRIP_ID, $tripReady['tripId']);
+        self::assertCount(3, $tripReady['data']['stages']);
+        self::assertNotNull($tripReady['data']['stages'][0]['aiAnalysis']);
+        self::assertNotNull($tripReady['data']['stages'][2]['aiAnalysis']);
+        self::assertNull($tripReady['data']['stages'][1]['aiAnalysis'], 'Rest stage payload carries no ai_analysis.');
+        self::assertArrayHasKey('aiOverview', $tripReady['data']);
+        self::assertIsArray($tripReady['data']['aiOverview']);
+        self::assertNotSame('', $tripReady['data']['aiOverview']['narrative']);
+
+        // AI progress events fired (initial + per-stage + final overview).
+        $progressEvents = $publisher->byType(MercureEventType::COMPUTATION_STEP_COMPLETED);
+        $aiProgressEvents = array_values(array_filter(
+            $progressEvents,
+            static fn (array $event): bool => 'ai_analysis' === ($event['data']['category'] ?? null),
+        ));
+        self::assertGreaterThanOrEqual(2, \count($aiProgressEvents), 'At least the kick-off and overview AI progress events must fire.');
+    }
+
+    #[Test]
+    public function pipelineWithoutOllamaShortCircuitsToTripReady(): void
+    {
+        $stages = [$this->makeStage(dayNumber: 1, distance: 80.0)];
+
+        $repository = new InMemoryTripRequestRepository(
+            stages: $stages,
+            request: $this->makeTripRequest(),
+        );
+
+        $publisher = new RecordingTripUpdatePublisher();
+
+        $bus = new InMemoryBus();
+
+        $disabledLlm = $this->createStub(LlmClientInterface::class);
+        $disabledLlm->method('isEnabled')->willReturn(false);
+
+        $terminalHandler = new AllEnrichmentsCompletedHandler(
+            computationTracker: $this->stubComputationTracker(['route' => 'done']),
+            publisher: $publisher,
+            tripRequestRepository: $repository,
+            logger: new NullLogger(),
+            messageBus: $bus,
+            llmClient: $disabledLlm,
+            llmTracker: new InMemoryLlmAnalysisTracker(),
+        );
+
+        $terminalHandler(new AllEnrichmentsCompleted(self::TRIP_ID));
+
+        // No LLM message dispatched.
+        self::assertSame(0, $bus->dispatchCount(), 'No LLM message must be dispatched when Ollama is disabled.');
+
+        // Exactly one TRIP_READY published, no ai_overview.
+        $tripReadyEvents = $publisher->byType(MercureEventType::TRIP_READY);
+        self::assertCount(1, $tripReadyEvents);
+
+        [$tripReady] = array_values($tripReadyEvents);
+        self::assertSame(self::TRIP_ID, $tripReady['tripId']);
+        self::assertCount(1, $tripReady['data']['stages']);
+        self::assertArrayNotHasKey('aiOverview', $tripReady['data'], 'Disabled LLM means no aiOverview key.');
+
+        // No AI progress events.
+        $aiProgress = array_filter(
+            $publisher->byType(MercureEventType::COMPUTATION_STEP_COMPLETED),
+            static fn (array $event): bool => 'ai_analysis' === ($event['data']['category'] ?? null),
+        );
+        self::assertCount(0, $aiProgress, 'AI category must NOT appear when LLM is disabled.');
+    }
+
+    #[Test]
+    public function pipelineWithOnlyRestDaysShortCircuitsToTripReady(): void
+    {
+        $stages = [$this->makeStage(dayNumber: 1, distance: 0.0, isRestDay: true)];
+
+        $repository = new InMemoryTripRequestRepository(
+            stages: $stages,
+            request: $this->makeTripRequest(),
+        );
+
+        $publisher = new RecordingTripUpdatePublisher();
+
+        $bus = new InMemoryBus();
+
+        $enabledLlm = $this->createStub(LlmClientInterface::class);
+        $enabledLlm->method('isEnabled')->willReturn(true);
+
+        $terminalHandler = new AllEnrichmentsCompletedHandler(
+            computationTracker: $this->stubComputationTracker(['route' => 'done']),
+            publisher: $publisher,
+            tripRequestRepository: $repository,
+            logger: new NullLogger(),
+            messageBus: $bus,
+            llmClient: $enabledLlm,
+            llmTracker: new InMemoryLlmAnalysisTracker(),
+        );
+
+        $terminalHandler(new AllEnrichmentsCompleted(self::TRIP_ID));
+
+        // Even with LLM enabled, no analysable stage means short-circuit.
+        self::assertSame(0, $bus->dispatchCount());
+        self::assertCount(1, $publisher->byType(MercureEventType::TRIP_READY));
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers / factories
+    // -------------------------------------------------------------------------
+
+    private function makeStage(int $dayNumber, float $distance, bool $isRestDay = false): Stage
+    {
+        return new Stage(
+            tripId: self::TRIP_ID,
+            dayNumber: $dayNumber,
+            distance: $distance,
+            elevation: 500.0,
+            startPoint: new Coordinate(48.0, 2.0),
+            endPoint: new Coordinate(48.5, 2.5),
+            isRestDay: $isRestDay,
+        );
+    }
+
+    private function makeTripRequest(): TripRequest
+    {
+        $request = new TripRequest();
+        $request->locale = 'fr';
+        $request->ebikeMode = false;
+        $request->startDate = new \DateTimeImmutable('2026-06-01');
+
+        return $request;
+    }
+
+    private function stageLlmClient(): LlmClientInterface
+    {
+        $client = $this->createStub(LlmClientInterface::class);
+        $client->method('isEnabled')->willReturn(true);
+        $client->method('generate')->willReturn([
+            'response' => "## Synthèse\nÉtape exigeante.\n\n## Insights\n- Long sans eau\n\n## Recommandations\n- Faire le plein.\n",
+            'done' => true,
+        ]);
+
+        return $client;
+    }
+
+    private function overviewLlmClient(): LlmClientInterface
+    {
+        $client = $this->createStub(LlmClientInterface::class);
+        $client->method('isEnabled')->willReturn(true);
+        $client->method('generate')->willReturn([
+            'response' => "## Vue d'ensemble\nTrip exigeant.\n\n## Charge et fatigue cumulative\nJ2 plus dure.\n\n## Patterns transversaux\n- Zones sans eau\n\n## Recommandations globales\n- Pause à mi-parcours.\n",
+            'done' => true,
+        ]);
+
+        return $client;
+    }
+
+    /** @param array<string, string> $statuses */
+    private function stubComputationTracker(array $statuses): ComputationTrackerInterface
+    {
+        $tracker = $this->createStub(ComputationTrackerInterface::class);
+        $tracker->method('claimReadyPublication')->willReturn(true);
+        $tracker->method('getStatuses')->willReturn($statuses);
+
+        return $tracker;
+    }
+}
+
+/**
+ * Minimal in-memory repository covering only the slice of
+ * {@see TripRequestRepositoryInterface} exercised by the LLM pipeline.
+ */
+final class InMemoryTripRequestRepository implements TripRequestRepositoryInterface
+{
+    /** @var array<int, array{narrative: string, insights: list<string>, suggestions: list<string>, model: string, promptVersion: int, generatedAt: string}|null> */
+    private array $stageAiAnalysis = [];
+
+    /** @var array{narrative: string, patterns: list<string>, recommendations: list<string>, crossStageAlerts: list<string>, model: string, promptVersion: int, generatedAt: string}|null */
+    private ?array $aiOverview = null;
+
+    /** @param list<Stage> $stages */
+    public function __construct(
+        private readonly array $stages,
+        private readonly TripRequest $request,
+    ) {
+    }
+
+    public function getStages(string $tripId): array
+    {
+        return array_map(
+            function (Stage $stage): Stage {
+                $stage->aiAnalysis = $this->stageAiAnalysis[$stage->dayNumber] ?? null;
+
+                return $stage;
+            },
+            $this->stages,
+        );
+    }
+
+    public function getRequest(string $tripId): TripRequest
+    {
+        return $this->request;
+    }
+
+    public function updateStageAiAnalysis(string $tripId, int $dayNumber, ?array $aiAnalysis): void
+    {
+        $this->stageAiAnalysis[$dayNumber] = $aiAnalysis;
+    }
+
+    public function updateTripAiOverview(string $tripId, ?array $aiOverview): void
+    {
+        $this->aiOverview = $aiOverview;
+    }
+
+    public function stageAiAnalysisFor(int $dayNumber): ?array
+    {
+        return $this->stageAiAnalysis[$dayNumber] ?? null;
+    }
+
+    public function tripAiOverview(): ?array
+    {
+        return $this->aiOverview;
+    }
+
+    // ---- unused interface members ----
+
+    public function initializeTrip(string $tripId, TripRequest $request): void
+    {
+    }
+
+    public function storeRequest(string $tripId, TripRequest $request): void
+    {
+    }
+
+    public function getTitle(string $tripId): ?string
+    {
+        return null;
+    }
+
+    public function storeTitle(string $tripId, ?string $title): void
+    {
+    }
+
+    public function storeRawPoints(string $tripId, array $rawPoints): void
+    {
+    }
+
+    public function getRawPoints(string $tripId): ?array
+    {
+        return null;
+    }
+
+    public function storeDecimatedPoints(string $tripId, array $decimatedPoints): void
+    {
+    }
+
+    public function getDecimatedPoints(string $tripId): ?array
+    {
+        return null;
+    }
+
+    public function storeStages(string $tripId, array $stages): void
+    {
+    }
+
+    public function storeTracksData(string $tripId, array $tracksData): void
+    {
+    }
+
+    public function getTracksData(string $tripId): ?array
+    {
+        return null;
+    }
+
+    public function storeSourceType(string $tripId, string $sourceType): void
+    {
+    }
+
+    public function getSourceType(string $tripId): ?string
+    {
+        return null;
+    }
+
+    public function storeLocale(string $tripId, string $locale): void
+    {
+    }
+
+    public function getLocale(string $tripId): ?string
+    {
+        return null;
+    }
+}
+
+/**
+ * In-memory bus that immediately routes the dispatched message to the
+ * registered handler. Mirrors Symfony Messenger's sync transport behaviour
+ * closely enough for orchestration testing.
+ */
+final class InMemoryBus implements MessageBusInterface
+{
+    /** @var array<class-string, callable(object): void> */
+    private array $handlers = [];
+
+    private int $dispatchCount = 0;
+
+    /** @param callable(object): void $handler */
+    public function register(string $messageClass, callable $handler): void
+    {
+        $this->handlers[$messageClass] = $handler;
+    }
+
+    public function dispatch(object $message, array $stamps = []): Envelope
+    {
+        ++$this->dispatchCount;
+        $class = $message::class;
+
+        if (isset($this->handlers[$class])) {
+            ($this->handlers[$class])($message);
+        }
+
+        return new Envelope($message, $stamps);
+    }
+
+    public function dispatchCount(): int
+    {
+        return $this->dispatchCount;
+    }
+}
+
+/**
+ * Captures every Mercure event the pipeline publishes so the test can assert
+ * exactly one TRIP_READY and a coherent sequence of progress events.
+ */
+final class RecordingTripUpdatePublisher implements TripUpdatePublisherInterface
+{
+    /** @var list<array{tripId: string, type: MercureEventType, data: array<string, mixed>}> */
+    private array $events = [];
+
+    private readonly StagePayloadMapper $mapper;
+
+    public function __construct()
+    {
+        $this->mapper = new StagePayloadMapper();
+    }
+
+    /** @param array<string, mixed> $data */
+    public function publish(string $tripId, MercureEventType $type, array $data = []): void
+    {
+        $this->events[] = ['tripId' => $tripId, 'type' => $type, 'data' => $data];
+    }
+
+    public function publishValidationError(string $tripId, string $code, string $message): void
+    {
+    }
+
+    public function publishComputationError(string $tripId, string $computation, string $message, bool $retryable = true): void
+    {
+    }
+
+    public function publishTripComplete(string $tripId, array $computationStatus): void
+    {
+    }
+
+    public function publishComputationStepCompleted(
+        string $tripId,
+        ComputationName $step,
+        int $completed,
+        int $total,
+        int $failed = 0,
+    ): void {
+        $this->publish($tripId, MercureEventType::COMPUTATION_STEP_COMPLETED, [
+            'step' => $step->value,
+            'category' => $step->category(),
+            'completed' => $completed,
+            'failed' => $failed,
+            'total' => $total,
+        ]);
+    }
+
+    public function publishTripReady(string $tripId, array $stages, array $summary): void
+    {
+        $data = [
+            'stages' => $this->mapper->toPayloadList($stages),
+            'computationStatus' => $summary['status'] ?? [],
+        ];
+
+        if (\array_key_exists('aiOverview', $summary)) {
+            $data['aiOverview'] = $summary['aiOverview'];
+        }
+
+        $this->publish($tripId, MercureEventType::TRIP_READY, $data);
+    }
+
+    public function publishStageUpdated(string $tripId, Stage $stage): void
+    {
+    }
+
+    /**
+     * @return list<array{tripId: string, type: MercureEventType, data: array<string, mixed>}>
+     */
+    public function byType(MercureEventType $type): array
+    {
+        return array_values(array_filter(
+            $this->events,
+            static fn (array $event): bool => $event['type'] === $type,
+        ));
+    }
+}
+
+/**
+ * In-memory implementation of {@see LlmAnalysisTrackerInterface} for the
+ * pipeline test — same semantics as the Redis-backed version, no I/O.
+ */
+final class InMemoryLlmAnalysisTracker implements LlmAnalysisTrackerInterface
+{
+    /** @var array<string, array{completed: int, failed: int, total: int}> */
+    private array $progress = [];
+
+    /** @var array<string, true> */
+    private array $overviewClaims = [];
+
+    /** @var array<string, true> */
+    private array $readyClaims = [];
+
+    public function initializeStageAnalyses(string $tripId, int $expectedStages): void
+    {
+        $this->progress[$tripId] = ['completed' => 0, 'failed' => 0, 'total' => max(0, $expectedStages)];
+    }
+
+    public function markStageAnalysisSettled(string $tripId, bool $success): array
+    {
+        $progress = $this->progress[$tripId] ?? ['completed' => 0, 'failed' => 0, 'total' => 0];
+
+        if ($success) {
+            ++$progress['completed'];
+        } else {
+            ++$progress['failed'];
+        }
+
+        $this->progress[$tripId] = $progress;
+
+        return $progress;
+    }
+
+    public function getStageAnalysisProgress(string $tripId): ?array
+    {
+        return $this->progress[$tripId] ?? null;
+    }
+
+    public function claimOverviewDispatch(string $tripId): bool
+    {
+        if (isset($this->overviewClaims[$tripId])) {
+            return false;
+        }
+
+        $this->overviewClaims[$tripId] = true;
+
+        return true;
+    }
+
+    public function claimTripReadyPublication(string $tripId): bool
+    {
+        if (isset($this->readyClaims[$tripId])) {
+            return false;
+        }
+
+        $this->readyClaims[$tripId] = true;
+
+        return true;
+    }
+}

--- a/api/tests/Integration/LlmPipelineTest.php
+++ b/api/tests/Integration/LlmPipelineTest.php
@@ -9,6 +9,7 @@ use App\ApiResource\Stage;
 use App\ApiResource\TripRequest;
 use App\ComputationTracker\ComputationTrackerInterface;
 use App\Enum\ComputationName;
+use App\Llm\Dto\StageAiAnalysis;
 use App\Llm\LlmAnalysisTrackerInterface;
 use App\Llm\LlmClientInterface;
 use App\Llm\StageAnalysisSummaryBuilder;
@@ -363,7 +364,8 @@ final class InMemoryTripRequestRepository implements TripRequestRepositoryInterf
     {
         return array_map(
             function (Stage $stage): Stage {
-                $stage->aiAnalysis = $this->stageAiAnalysis[$stage->dayNumber] ?? null;
+                $analysisData = $this->stageAiAnalysis[$stage->dayNumber] ?? null;
+                $stage->aiAnalysis = null === $analysisData ? null : StageAiAnalysis::fromArray($analysisData);
 
                 return $stage;
             },

--- a/api/tests/Unit/Llm/AnalyzeStageWithLlmHandlerTest.php
+++ b/api/tests/Unit/Llm/AnalyzeStageWithLlmHandlerTest.php
@@ -8,9 +8,11 @@ use App\ApiResource\Model\Coordinate;
 use App\ApiResource\Stage;
 use App\ApiResource\TripRequest;
 use App\Llm\Exception\OllamaUnavailableException;
+use App\Llm\LlmAnalysisTrackerInterface;
 use App\Llm\LlmClientInterface;
 use App\Llm\StageAnalysisSummaryBuilder;
 use App\Llm\SystemPromptLoader;
+use App\Mercure\NullTripUpdatePublisher;
 use App\Message\AnalyzeStageWithLlmMessage;
 use App\MessageHandler\AnalyzeStageWithLlmHandler;
 use App\Repository\TripRequestRepositoryInterface;
@@ -19,6 +21,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
+use Symfony\Component\Messenger\MessageBusInterface;
 
 #[AllowMockObjectsWithoutExpectations]
 final class AnalyzeStageWithLlmHandlerTest extends TestCase
@@ -352,12 +355,19 @@ final class AnalyzeStageWithLlmHandlerTest extends TestCase
         TripRequestRepositoryInterface $repo,
         LlmClientInterface $llmClient,
     ): AnalyzeStageWithLlmHandler {
+        $tracker = $this->createStub(LlmAnalysisTrackerInterface::class);
+        $tracker->method('markStageAnalysisSettled')->willReturn(['completed' => 0, 'failed' => 1, 'total' => 1]);
+        $tracker->method('claimOverviewDispatch')->willReturn(false);
+
         return new AnalyzeStageWithLlmHandler(
             tripStateManager: $repo,
             llmClient: $llmClient,
             promptLoader: new SystemPromptLoader($this->tmpPromptDir),
             summaryBuilder: new StageAnalysisSummaryBuilder(),
             logger: new NullLogger(),
+            llmTracker: $tracker,
+            messageBus: $this->createStub(MessageBusInterface::class),
+            publisher: new NullTripUpdatePublisher(),
         );
     }
 

--- a/api/tests/Unit/Llm/AnalyzeStageWithLlmHandlerTest.php
+++ b/api/tests/Unit/Llm/AnalyzeStageWithLlmHandlerTest.php
@@ -14,6 +14,7 @@ use App\Llm\StageAnalysisSummaryBuilder;
 use App\Llm\SystemPromptLoader;
 use App\Mercure\NullTripUpdatePublisher;
 use App\Message\AnalyzeStageWithLlmMessage;
+use App\Message\AnalyzeTripOverviewWithLlmMessage;
 use App\MessageHandler\AnalyzeStageWithLlmHandler;
 use App\Repository\TripRequestRepositoryInterface;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
@@ -21,6 +22,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
+use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 #[AllowMockObjectsWithoutExpectations]
@@ -343,6 +345,38 @@ final class AnalyzeStageWithLlmHandlerTest extends TestCase
         self::assertSame(['B'], $captured['suggestions']);
     }
 
+    #[Test]
+    public function dispatchesPass2WhenClaimingOverviewDispatch(): void
+    {
+        $stage = $this->makeStage(dayNumber: 1);
+
+        $repo = $this->createMock(TripRequestRepositoryInterface::class);
+        $repo->method('getStages')->willReturn([$stage]);
+        $repo->method('getRequest')->willReturn($this->makeTripRequest());
+        $repo->method('updateStageAiAnalysis');
+
+        $llmClient = $this->createMock(LlmClientInterface::class);
+        $llmClient->method('isEnabled')->willReturn(true);
+        $llmClient->method('generate')->willReturn([
+            'response' => "## Synthèse\nOK.",
+            'done' => true,
+        ]);
+
+        $messageBus = $this->createMock(MessageBusInterface::class);
+        $messageBus->expects(self::once())
+            ->method('dispatch')
+            ->with(self::isInstanceOf(AnalyzeTripOverviewWithLlmMessage::class))
+            ->willReturnCallback(static fn (object $message): Envelope => new Envelope($message));
+
+        $handler = $this->makeHandler(
+            repo: $repo,
+            llmClient: $llmClient,
+            claimsOverviewDispatch: true,
+            messageBus: $messageBus,
+        );
+        $handler(new AnalyzeStageWithLlmMessage(self::TRIP_ID, 1));
+    }
+
     // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
@@ -350,14 +384,17 @@ final class AnalyzeStageWithLlmHandlerTest extends TestCase
     /**
      * @param TripRequestRepositoryInterface&MockObject $repo
      * @param LlmClientInterface&MockObject             $llmClient
+     * @param (MessageBusInterface&MockObject)|null     $messageBus override the bus when the test asserts pass-2 dispatch
      */
     private function makeHandler(
         TripRequestRepositoryInterface $repo,
         LlmClientInterface $llmClient,
+        bool $claimsOverviewDispatch = false,
+        ?MessageBusInterface $messageBus = null,
     ): AnalyzeStageWithLlmHandler {
         $tracker = $this->createStub(LlmAnalysisTrackerInterface::class);
-        $tracker->method('markStageAnalysisSettled')->willReturn(['completed' => 0, 'failed' => 1, 'total' => 1]);
-        $tracker->method('claimOverviewDispatch')->willReturn(false);
+        $tracker->method('markStageAnalysisSettled')->willReturn(['completed' => 1, 'failed' => 0, 'total' => 1]);
+        $tracker->method('claimOverviewDispatch')->willReturn($claimsOverviewDispatch);
 
         return new AnalyzeStageWithLlmHandler(
             tripStateManager: $repo,
@@ -366,7 +403,7 @@ final class AnalyzeStageWithLlmHandlerTest extends TestCase
             summaryBuilder: new StageAnalysisSummaryBuilder(),
             logger: new NullLogger(),
             llmTracker: $tracker,
-            messageBus: $this->createStub(MessageBusInterface::class),
+            messageBus: $messageBus ?? $this->createStub(MessageBusInterface::class),
             publisher: new NullTripUpdatePublisher(),
         );
     }

--- a/api/tests/Unit/Llm/AnalyzeTripOverviewWithLlmHandlerTest.php
+++ b/api/tests/Unit/Llm/AnalyzeTripOverviewWithLlmHandlerTest.php
@@ -7,10 +7,13 @@ namespace App\Tests\Unit\Llm;
 use App\ApiResource\Model\Coordinate;
 use App\ApiResource\Stage;
 use App\ApiResource\TripRequest;
+use App\ComputationTracker\ComputationTrackerInterface;
 use App\Llm\Dto\StageAiAnalysis;
 use App\Llm\Exception\OllamaUnavailableException;
+use App\Llm\LlmAnalysisTrackerInterface;
 use App\Llm\LlmClientInterface;
 use App\Llm\SystemPromptLoader;
+use App\Mercure\NullTripUpdatePublisher;
 use App\Message\AnalyzeTripOverviewWithLlmMessage;
 use App\MessageHandler\AnalyzeTripOverviewWithLlmHandler;
 use App\Repository\TripRequestRepositoryInterface;
@@ -468,11 +471,21 @@ final class AnalyzeTripOverviewWithLlmHandlerTest extends TestCase
         TripRequestRepositoryInterface $repo,
         LlmClientInterface $llmClient,
     ): AnalyzeTripOverviewWithLlmHandler {
+        $llmTracker = $this->createStub(LlmAnalysisTrackerInterface::class);
+        $llmTracker->method('getStageAnalysisProgress')->willReturn(['completed' => 1, 'failed' => 0, 'total' => 1]);
+        $llmTracker->method('claimTripReadyPublication')->willReturn(true);
+
+        $computationTracker = $this->createStub(ComputationTrackerInterface::class);
+        $computationTracker->method('getStatuses')->willReturn([]);
+
         return new AnalyzeTripOverviewWithLlmHandler(
             tripStateManager: $repo,
             llmClient: $llmClient,
             promptLoader: new SystemPromptLoader($this->tmpPromptDir),
             logger: new NullLogger(),
+            llmTracker: $llmTracker,
+            computationTracker: $computationTracker,
+            publisher: new NullTripUpdatePublisher(),
         );
     }
 

--- a/api/tests/Unit/Llm/AnalyzeTripOverviewWithLlmHandlerTest.php
+++ b/api/tests/Unit/Llm/AnalyzeTripOverviewWithLlmHandlerTest.php
@@ -14,6 +14,7 @@ use App\Llm\LlmAnalysisTrackerInterface;
 use App\Llm\LlmClientInterface;
 use App\Llm\SystemPromptLoader;
 use App\Mercure\NullTripUpdatePublisher;
+use App\Mercure\TripUpdatePublisherInterface;
 use App\Message\AnalyzeTripOverviewWithLlmMessage;
 use App\MessageHandler\AnalyzeTripOverviewWithLlmHandler;
 use App\Repository\TripRequestRepositoryInterface;
@@ -459,6 +460,36 @@ final class AnalyzeTripOverviewWithLlmHandlerTest extends TestCase
         self::assertSame(2, $payload['stages'][0]['stage_number']);
     }
 
+    #[Test]
+    public function doesNotPublishTripReadyWhenClaimAlreadyTaken(): void
+    {
+        $stage = $this->makeStage(dayNumber: 1);
+        $stage->aiAnalysis = $this->makeAiAnalysis('Étape 1');
+
+        $repo = $this->createMock(TripRequestRepositoryInterface::class);
+        $repo->method('getStages')->willReturn([$stage]);
+        $repo->method('getRequest')->willReturn($this->makeTripRequest());
+        $repo->method('updateTripAiOverview');
+
+        $llmClient = $this->createMock(LlmClientInterface::class);
+        $llmClient->method('isEnabled')->willReturn(true);
+        $llmClient->method('generate')->willReturn([
+            'response' => "## Vue d'ensemble\nOK.",
+            'done' => true,
+        ]);
+
+        $publisher = $this->createMock(TripUpdatePublisherInterface::class);
+        $publisher->expects(self::never())->method('publishTripReady');
+
+        $handler = $this->makeHandler(
+            repo: $repo,
+            llmClient: $llmClient,
+            claimsTripReadyPublication: false,
+            publisher: $publisher,
+        );
+        $handler(new AnalyzeTripOverviewWithLlmMessage(self::TRIP_ID));
+    }
+
     // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
@@ -470,10 +501,12 @@ final class AnalyzeTripOverviewWithLlmHandlerTest extends TestCase
     private function makeHandler(
         TripRequestRepositoryInterface $repo,
         LlmClientInterface $llmClient,
+        bool $claimsTripReadyPublication = true,
+        ?TripUpdatePublisherInterface $publisher = null,
     ): AnalyzeTripOverviewWithLlmHandler {
         $llmTracker = $this->createStub(LlmAnalysisTrackerInterface::class);
         $llmTracker->method('getStageAnalysisProgress')->willReturn(['completed' => 1, 'failed' => 0, 'total' => 1]);
-        $llmTracker->method('claimTripReadyPublication')->willReturn(true);
+        $llmTracker->method('claimTripReadyPublication')->willReturn($claimsTripReadyPublication);
 
         $computationTracker = $this->createStub(ComputationTrackerInterface::class);
         $computationTracker->method('getStatuses')->willReturn([]);
@@ -485,7 +518,7 @@ final class AnalyzeTripOverviewWithLlmHandlerTest extends TestCase
             logger: new NullLogger(),
             llmTracker: $llmTracker,
             computationTracker: $computationTracker,
-            publisher: new NullTripUpdatePublisher(),
+            publisher: $publisher ?? new NullTripUpdatePublisher(),
         );
     }
 

--- a/api/tests/Unit/Mercure/TripUpdatePublisherTest.php
+++ b/api/tests/Unit/Mercure/TripUpdatePublisherTest.php
@@ -75,14 +75,24 @@ final class TripUpdatePublisherTest extends TestCase
     #[Test]
     public function publishesTripReadyWithOptionalAiOverview(): void
     {
+        $aiOverview = [
+            'narrative' => 'Sunny ride with moderate climbs.',
+            'patterns' => [],
+            'recommendations' => [],
+            'crossStageAlerts' => [],
+            'model' => 'llama3.1:8b',
+            'promptVersion' => 1,
+            'generatedAt' => '2026-05-07T18:00:00+00:00',
+        ];
+
         $hub = $this->createMock(HubInterface::class);
         $hub->expects(self::once())
             ->method('publish')
-            ->willReturnCallback(function (Update $update): string {
-                /** @var array{type: string, data: array{aiOverview?: ?string}} $decoded */
+            ->willReturnCallback(function (Update $update) use ($aiOverview): string {
+                /** @var array{type: string, data: array{aiOverview?: array<string, mixed>|null}} $decoded */
                 $decoded = json_decode($update->getData(), true, flags: \JSON_THROW_ON_ERROR);
                 self::assertArrayHasKey('aiOverview', $decoded['data']);
-                self::assertSame('Sunny ride with moderate climbs.', $decoded['data']['aiOverview']);
+                self::assertSame($aiOverview, $decoded['data']['aiOverview']);
 
                 return 'id';
             });
@@ -90,7 +100,7 @@ final class TripUpdatePublisherTest extends TestCase
         $publisher = new TripUpdatePublisher($hub, new StagePayloadMapper());
         $publisher->publishTripReady(self::TRIP_ID, [], [
             'status' => [],
-            'aiOverview' => 'Sunny ride with moderate climbs.',
+            'aiOverview' => $aiOverview,
         ]);
     }
 

--- a/api/tests/Unit/MessageHandler/AllEnrichmentsCompletedHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/AllEnrichmentsCompletedHandlerTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\MessageHandler;
 use App\ApiResource\Model\Coordinate;
 use App\ApiResource\Stage;
 use App\ComputationTracker\ComputationTrackerInterface;
+use App\Llm\LlmAnalysisTrackerInterface;
 use App\Llm\LlmClientInterface;
 use App\Mercure\TripUpdatePublisherInterface;
 use App\Message\AllEnrichmentsCompleted;
@@ -20,12 +21,13 @@ use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 /**
- * Validates the minimal fallback behaviour of the gate's terminal handler.
+ * Validates the dual-strategy behaviour of the gate's terminal handler (issue #303).
  *
- * The full LLaMA pipeline (issues #301-#303) is not wired yet; until then,
- * this handler must publish the `TRIP_READY` Mercure event directly so the
- * frontend receives the terminal signal. When the AI pipeline lands, the
- * downstream LLaMA handler will own that publication instead.
+ *  - When the LLM is disabled (or no analysable stage exists), this handler is
+ *    self-terminating and publishes `TRIP_READY` directly.
+ *  - When the LLM is enabled, it initialises the LLM analysis tracker, dispatches
+ *    one pass-1 message per non-rest stage, and defers `TRIP_READY` publication
+ *    to {@see \App\MessageHandler\AnalyzeTripOverviewWithLlmHandler}.
  */
 final class AllEnrichmentsCompletedHandlerTest extends TestCase
 {
@@ -68,6 +70,7 @@ final class AllEnrichmentsCompletedHandlerTest extends TestCase
             new NullLogger(),
             $this->createStub(MessageBusInterface::class),
             $this->disabledLlmClient(),
+            $this->createStub(LlmAnalysisTrackerInterface::class),
         );
 
         $handler(new AllEnrichmentsCompleted($tripId));
@@ -93,6 +96,7 @@ final class AllEnrichmentsCompletedHandlerTest extends TestCase
             new NullLogger(),
             $this->createStub(MessageBusInterface::class),
             $this->disabledLlmClient(),
+            $this->createStub(LlmAnalysisTrackerInterface::class),
         );
 
         $handler(new AllEnrichmentsCompleted($tripId));
@@ -126,6 +130,7 @@ final class AllEnrichmentsCompletedHandlerTest extends TestCase
             new NullLogger(),
             $this->createStub(MessageBusInterface::class),
             $this->disabledLlmClient(),
+            $this->createStub(LlmAnalysisTrackerInterface::class),
         );
 
         $handler(new AllEnrichmentsCompleted($tripId));
@@ -183,6 +188,11 @@ final class AllEnrichmentsCompletedHandlerTest extends TestCase
         $llmClient = $this->createStub(LlmClientInterface::class);
         $llmClient->method('isEnabled')->willReturn(true);
 
+        $llmAnalysisTracker = $this->createMock(LlmAnalysisTrackerInterface::class);
+        $llmAnalysisTracker->expects(self::once())
+            ->method('initializeStageAnalyses')
+            ->with($tripId, 2);
+
         $handler = new AllEnrichmentsCompletedHandler(
             $tracker,
             $publisher,
@@ -190,6 +200,7 @@ final class AllEnrichmentsCompletedHandlerTest extends TestCase
             new NullLogger(),
             $bus,
             $llmClient,
+            $llmAnalysisTracker,
         );
 
         $handler(new AllEnrichmentsCompleted($tripId));
@@ -228,6 +239,7 @@ final class AllEnrichmentsCompletedHandlerTest extends TestCase
             new NullLogger(),
             $bus,
             $this->disabledLlmClient(),
+            $this->createStub(LlmAnalysisTrackerInterface::class),
         );
 
         $handler(new AllEnrichmentsCompleted($tripId));


### PR DESCRIPTION
## Summary

Connects the gate mechanism (#299) to the 2-pass LLaMA pipeline (#301, #302) and centralises TRIP_READY emission. Closes the orchestration story introduced in ADR-028.

### Flow

```
Enrichments terminate → AllEnrichmentsCompletedHandler:
  ├─ LLM disabled / no analysable stage → publish TRIP_READY directly
  └─ LLM enabled:
       ├─ Init LLM tracker, dispatch N × AnalyzeStageWithLlmMessage (parallel)
       ├─ Each pass-1 settles → tracker counter increments
       ├─ Last pass-1 → NX-claim dispatches AnalyzeTripOverviewWithLlmMessage
       └─ Pass-2 finalize() → NX-claim publishes TRIP_READY (with ai_overview)
```

- **`LlmAnalysisTracker`** (Redis-backed, PSR-6 cache.trip_state, 30 min TTL) — distinct from `ComputationTracker`. Provides `markStageAnalysisSettled`, `claimOverviewDispatch` (NX), `claimTripReadyPublication` (NX).
- **`StagePayloadMapper`** now exposes `aiAnalysis` on the wire format.
- **`TripUpdatePublisher::publishTripReady`** signature widened to accept structured `aiOverview` summary.
- **AI progress events** (`computation_step_completed` with `category: ai_analysis`) fire at kick-off, after each pass-1, and on overview completion — feeding the Acte 2 progress bar.
- New `ComputationName::STAGE_AI_ANALYSIS` / `TRIP_AI_OVERVIEW` cases (excluded from regular `pipeline()`).
- Integration test `LlmPipelineTest` covers: full pipeline / Ollama-off short-circuit / only-rest-days short-circuit.

> Depends on #301 + #302.

## Test plan

- [x] `make qa`
- [x] `make test-php` (1086 tests, 1 skipped)
- [ ] CI

## Auto-critique

- NX-claim semantics on both `dispatchOverview` and `publishTripReady` guarantee exactly-once even under Messenger retries / parallel pass-1 settle races.
- TRIP_READY is still published when pass-2 fails (best-effort): the rider sees the data, just without `aiOverview`.
- The frontend will receive a single TRIP_READY event with the full payload (stages enriched + ai_analysis + ai_overview), replacing the progressive rendering — `computation_step_completed` events are now purely for the progress bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

The PR is in excellent shape. All issues raised in previous rounds have been addressed: Symfony Lock serialises the progress counter (eliminating the lost-update race), `claimOverviewDispatch` returns `true` in the new `dispatchesPass2WhenClaimingOverviewDispatch` unit test, `claimTripReadyPublication = false` is exercised by `doesNotPublishTripReadyWhenClaimAlreadyTaken`, and `TripAiOverview` retains its `#[NotBlank]` constraints. No new critical or warning findings.

**Findings: 0 critical, 0 warnings, 0 suggestions.**

**Resolved 2 previously open threads** that were addressed by the latest commits.

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases — integration test covers all three pipeline branches; unit tests cover NX-claim guards and pass-2 dispatch
- [x] Documentation is up to date
- [x] Dependent tickets accounted for (#299, #301, #302)

### Inline comments

No inline comments.

---
_Reviewed at commit `b62dd90`. Generated with [Claude Code](https://claude.com/claude-code)_
<!-- claude-review-end -->