### PR TITLE
feat(pwa): add TripAiOverview component for global AI summary (#305)

### DIFF
--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -584,6 +584,17 @@
     "analysisLaunched": "Analysis launched",
     "analysisLaunchFailed": "Failed to launch analysis. Please retry."
   },
+  "aiOverview": {
+    "title": "AI analysis",
+    "subtitle": "Assistant-generated summary covering the whole trip",
+    "patternsHeading": "Detected patterns",
+    "recommendationsHeading": "Recommendations",
+    "crossStageAlertsHeading": "Points to watch",
+    "expand": "Show more",
+    "expandAria": "Expand the AI summary",
+    "collapse": "Show less",
+    "collapseAria": "Collapse the AI summary"
+  },
   "aiRefinement": {
     "title": "Refine with the AI assistant",
     "helper": "Describe the change you want in one sentence — for example \"Add a stop in Ajaccio\" or \"Avoid main roads on day 3\".",

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -584,6 +584,17 @@
     "analysisLaunched": "Analyse lancée",
     "analysisLaunchFailed": "Impossible de lancer l'analyse. Réessayez."
   },
+  "aiOverview": {
+    "title": "Analyse IA",
+    "subtitle": "Synthèse générée par l'assistant à partir de l'ensemble du voyage",
+    "patternsHeading": "Tendances détectées",
+    "recommendationsHeading": "Recommandations",
+    "crossStageAlertsHeading": "Points d'attention",
+    "expand": "Voir plus",
+    "expandAria": "Déplier la synthèse IA",
+    "collapse": "Réduire",
+    "collapseAria": "Réduire la synthèse IA"
+  },
   "aiRefinement": {
     "title": "Affiner avec l'assistant IA",
     "helper": "Décrivez en une phrase la modification souhaitée — par exemple « Ajoute une étape à Ajaccio » ou « Évite les routes principales le jour 3 ».",

--- a/pwa/src/components/trip-ai-overview.tsx
+++ b/pwa/src/components/trip-ai-overview.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import { useId, useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
+import { Bot, ChevronDown, ChevronUp } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import { useTripAiOverview } from "@/store/trip-store";
+
+/**
+ * Acte 3 — Trip-level AI overview card (issue #305).
+ *
+ * Renders the narrative + patterns + recommendations + cross-stage alerts
+ * produced by the LLaMA pass 2 (`AnalyzeTripOverviewWithLlmHandler` →
+ * `aiOverview` field on the `trip_ready` Mercure event).
+ *
+ * Placement — top of the "Mon voyage" view (Acte 3), before the stage cards.
+ *
+ * Behavior:
+ * - Renders nothing when the store has no overview (LLM disabled / failed /
+ *   pending) — silent fallback as required by the issue spec.
+ * - On desktop (≥ md) the card is always fully expanded.
+ * - On mobile (< md) only the title + first narrative line are visible until
+ *   the user taps the disclosure button.
+ *
+ * The narrative is plain text (no full markdown parser is needed for the
+ * current backend output); paragraph breaks (`\n\n`) and line breaks (`\n`)
+ * are preserved by splitting on whitespace boundaries and emitting individual
+ * `<p>` elements. Bullet lists for patterns, recommendations and alerts are
+ * rendered explicitly so screen readers announce them as such.
+ */
+export function TripAiOverview() {
+  const t = useTranslations("aiOverview");
+  const overview = useTripAiOverview();
+  const [isMobileExpanded, setIsMobileExpanded] = useState(false);
+  const detailsId = useId();
+
+  const paragraphs = useMemo(() => {
+    if (!overview?.narrative) return [] as string[];
+    // Split on blank lines so the narrative renders as separate `<p>` blocks.
+    // Single newlines inside a paragraph are preserved via `whitespace-pre-line`.
+    return overview.narrative
+      .split(/\n\s*\n/)
+      .map((p) => p.trim())
+      .filter((p) => p.length > 0);
+  }, [overview?.narrative]);
+
+  // Silent fallback when no overview is available — the issue spec requires
+  // that the component does not render anything at all in that case.
+  if (!overview || paragraphs.length === 0) {
+    return null;
+  }
+
+  const firstParagraph = paragraphs[0] ?? "";
+  const hasMore =
+    paragraphs.length > 1 ||
+    overview.patterns.length > 0 ||
+    overview.recommendations.length > 0 ||
+    overview.crossStageAlerts.length > 0;
+
+  return (
+    <Card
+      data-testid="trip-ai-overview"
+      className={cn(
+        // Subtle border + muted background to distinguish from the rule-based
+        // stage cards rendered below.
+        "border-brand/30 bg-brand/5",
+      )}
+    >
+      <CardContent className="flex flex-col gap-4">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex items-start gap-3">
+            <span
+              aria-hidden="true"
+              className="mt-0.5 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-brand/15 text-brand"
+            >
+              <Bot className="h-4 w-4" />
+            </span>
+            <div>
+              <h2 className="text-base font-semibold leading-tight">
+                {t("title")}
+              </h2>
+              <p className="text-muted-foreground text-xs">{t("subtitle")}</p>
+            </div>
+          </div>
+
+          {/* Mobile-only disclosure button — desktop always shows the full
+              content thanks to the `md:block` overrides below. */}
+          {hasMore && (
+            <button
+              type="button"
+              onClick={() => setIsMobileExpanded((v) => !v)}
+              aria-expanded={isMobileExpanded}
+              aria-controls={detailsId}
+              aria-label={
+                isMobileExpanded ? t("collapseAria") : t("expandAria")
+              }
+              className={cn(
+                "md:hidden inline-flex items-center gap-1 rounded-md border border-border",
+                "px-2 py-1 text-xs text-muted-foreground hover:bg-accent",
+                "cursor-pointer",
+              )}
+              data-testid="trip-ai-overview-toggle"
+            >
+              {isMobileExpanded ? (
+                <>
+                  <span>{t("collapse")}</span>
+                  <ChevronUp className="h-3 w-3" />
+                </>
+              ) : (
+                <>
+                  <span>{t("expand")}</span>
+                  <ChevronDown className="h-3 w-3" />
+                </>
+              )}
+            </button>
+          )}
+        </div>
+
+        {/* Always-visible teaser: first paragraph (truncated to a single line
+            on mobile when collapsed, full text otherwise). */}
+        <p
+          className={cn(
+            "text-sm whitespace-pre-line",
+            // Collapsed mobile state: clamp to one line. On md+ screens we
+            // restore the full paragraph regardless of disclosure state.
+            !isMobileExpanded && "line-clamp-1 md:line-clamp-none",
+          )}
+          data-testid="trip-ai-overview-teaser"
+        >
+          {firstParagraph}
+        </p>
+
+        {/* Expanded content. Mobile: revealed by the disclosure toggle.
+            Desktop: always rendered (md:block) so the user sees everything
+            without interaction, per the issue spec. */}
+        {hasMore && (
+          <div
+            id={detailsId}
+            data-testid="trip-ai-overview-details"
+            className={cn(
+              "flex flex-col gap-4 text-sm",
+              isMobileExpanded ? "block" : "hidden md:flex",
+            )}
+          >
+            {/* Remaining narrative paragraphs (after the teaser). */}
+            {paragraphs.length > 1 && (
+              <div className="flex flex-col gap-2">
+                {paragraphs.slice(1).map((paragraph, idx) => (
+                  <p key={idx} className="whitespace-pre-line">
+                    {paragraph}
+                  </p>
+                ))}
+              </div>
+            )}
+
+            {overview.patterns.length > 0 && (
+              <section data-testid="trip-ai-overview-patterns">
+                <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  {t("patternsHeading")}
+                </h3>
+                <ul className="mt-1 list-disc space-y-1 pl-5">
+                  {overview.patterns.map((pattern, idx) => (
+                    <li key={idx}>{pattern}</li>
+                  ))}
+                </ul>
+              </section>
+            )}
+
+            {overview.recommendations.length > 0 && (
+              <section data-testid="trip-ai-overview-recommendations">
+                <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  {t("recommendationsHeading")}
+                </h3>
+                <ul className="mt-1 list-disc space-y-1 pl-5">
+                  {overview.recommendations.map((rec, idx) => (
+                    <li key={idx}>{rec}</li>
+                  ))}
+                </ul>
+              </section>
+            )}
+
+            {overview.crossStageAlerts.length > 0 && (
+              <section
+                data-testid="trip-ai-overview-cross-stage-alerts"
+                className="rounded-md border border-amber-500/40 bg-amber-500/5 p-3"
+              >
+                <h3 className="text-xs font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-300">
+                  {t("crossStageAlertsHeading")}
+                </h3>
+                <ul className="mt-1 list-disc space-y-1 pl-5">
+                  {overview.crossStageAlerts.map((alert, idx) => (
+                    <li key={idx}>{alert}</li>
+                  ))}
+                </ul>
+              </section>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/pwa/src/components/trip-ai-overview.tsx
+++ b/pwa/src/components/trip-ai-overview.tsx
@@ -82,7 +82,7 @@ export function TripAiOverview() {
           </div>
 
           {/* Mobile-only disclosure button — desktop always shows the full
-              content thanks to the `md:block` overrides below. */}
+              content thanks to the `md:flex` override below. */}
           {hasMore && (
             <button
               type="button"
@@ -129,7 +129,7 @@ export function TripAiOverview() {
         </p>
 
         {/* Expanded content. Mobile: revealed by the disclosure toggle.
-            Desktop: always rendered (md:block) so the user sees everything
+            Desktop: always rendered (md:flex) so the user sees everything
             without interaction, per the issue spec. */}
         {hasMore && (
           <div

--- a/pwa/src/components/trip-ai-overview.tsx
+++ b/pwa/src/components/trip-ai-overview.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useId, useMemo, useState } from "react";
+import { useId, useState } from "react";
 import { useTranslations } from "next-intl";
 import { Bot, ChevronDown, ChevronUp } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
@@ -35,15 +35,12 @@ export function TripAiOverview() {
   const [isMobileExpanded, setIsMobileExpanded] = useState(false);
   const detailsId = useId();
 
-  const paragraphs = useMemo(() => {
-    if (!overview?.narrative) return [] as string[];
-    // Split on blank lines so the narrative renders as separate `<p>` blocks.
-    // Single newlines inside a paragraph are preserved via `whitespace-pre-line`.
-    return overview.narrative
-      .split(/\n\s*\n/)
-      .map((p) => p.trim())
-      .filter((p) => p.length > 0);
-  }, [overview?.narrative]);
+  const paragraphs = overview?.narrative
+    ? overview.narrative
+        .split(/\n\s*\n/)
+        .map((p) => p.trim())
+        .filter((p) => p.length > 0)
+    : [];
 
   // Silent fallback when no overview is available — the issue spec requires
   // that the component does not render anything at all in that case.

--- a/pwa/src/components/trip-ai-overview.tsx
+++ b/pwa/src/components/trip-ai-overview.tsx
@@ -137,7 +137,7 @@ export function TripAiOverview() {
             data-testid="trip-ai-overview-details"
             className={cn(
               "flex flex-col gap-4 text-sm",
-              isMobileExpanded ? "block" : "hidden md:flex",
+              !isMobileExpanded && "hidden md:flex",
             )}
           >
             {/* Remaining narrative paragraphs (after the teaser). */}

--- a/pwa/src/components/trip-planner.tsx
+++ b/pwa/src/components/trip-planner.tsx
@@ -198,14 +198,19 @@ export function TripPlanner({
       useUiStore.getState().setAnalysisStarted(value);
       useUiStore.getState().setAnalysisPhaseActive(value);
     };
+    const onClearAiOverview = () => {
+      useTripStore.getState().setAiOverview(null);
+    };
     window.addEventListener("__test_set_processing", onProcessing);
     window.addEventListener("__test_set_analysis_started", onAnalysisStarted);
+    window.addEventListener("__test_clear_ai_overview", onClearAiOverview);
     return () => {
       window.removeEventListener("__test_set_processing", onProcessing);
       window.removeEventListener(
         "__test_set_analysis_started",
         onAnalysisStarted,
       );
+      window.removeEventListener("__test_clear_ai_overview", onClearAiOverview);
     };
   }, []);
 

--- a/pwa/src/components/trip-planner.tsx
+++ b/pwa/src/components/trip-planner.tsx
@@ -18,6 +18,7 @@ import { TripLockedBanner } from "@/components/trip-locked-banner";
 import { TripPreview } from "@/components/trip-preview";
 import { ProcessingProgress } from "@/components/processing-progress";
 import { TripSummary } from "@/components/trip-summary";
+import { TripAiOverview } from "@/components/trip-ai-overview";
 import { TripHeader } from "@/components/trip-header";
 import { TripDownloads } from "@/components/trip-downloads";
 import { StageProgressBar } from "@/components/stage-progress-bar";
@@ -657,6 +658,13 @@ export function TripPlanner({
                 maxDistancePerDay={maxDistancePerDay}
                 averageSpeed={averageSpeed}
               />
+
+              {/* Trip-level AI overview (issue #305) — narrative + patterns +
+                  recommendations produced by the LLaMA pass 2. Renders nothing
+                  silently when the LLM pipeline is disabled or did not produce
+                  an overview. Placed above the stage timeline so it gives the
+                  user a high-level view before they dive into per-stage data. */}
+              <TripAiOverview />
 
               {/* Sentinel — marks the natural position of the progress bar in the
                 flow. The sticky bar becomes visible once this exits the viewport. */}

--- a/pwa/src/globals.d.ts
+++ b/pwa/src/globals.d.ts
@@ -1,8 +1,11 @@
 import type { useUiStore } from "@/store/ui-store";
+import type { useTripStore } from "@/store/trip-store";
 
 declare global {
   interface Window {
     /** Exposed in non-production environments only (NODE_ENV !== 'production'). */
     __zustand_ui_store?: typeof useUiStore;
+    /** Exposed in non-production environments only (NODE_ENV !== 'production'). */
+    __zustand_trip_store?: typeof useTripStore;
   }
 }

--- a/pwa/src/hooks/use-mercure.ts
+++ b/pwa/src/hooks/use-mercure.ts
@@ -477,6 +477,10 @@ function dispatchEvent(event: MercureEvent): void {
       const incomingStages = event.data.stages.map(enrichedPayloadToStageData);
       store.applyTripReady(incomingStages);
       store.setComputationStatus(event.data.computationStatus);
+      // Trip-level AI overview (issue #305) — `aiOverview` is optional; when
+      // the LLM pipeline is disabled or failed it is absent or `null`, in
+      // which case the overview component renders nothing.
+      store.setAiOverview(event.data.aiOverview ?? null);
       useUiStore.getState().setAnalysisProgress(null);
       useUiStore.getState().setAnalysisStarted(true);
       useUiStore.getState().setAnalysisPhaseActive(false);

--- a/pwa/src/hooks/use-mercure.ts
+++ b/pwa/src/hooks/use-mercure.ts
@@ -3,6 +3,7 @@
 import { useEffect, useRef } from "react";
 import { MercureClient } from "@/lib/mercure/client";
 import type { EnrichedStagePayload, MercureEvent } from "@/lib/mercure/types";
+import { TripAiOverviewSchema } from "@/lib/validation/schemas";
 import { useTripStore } from "@/store/trip-store";
 import { useUiStore } from "@/store/ui-store";
 import { useOfflineStore } from "@/store/offline-store";
@@ -477,10 +478,15 @@ function dispatchEvent(event: MercureEvent): void {
       const incomingStages = event.data.stages.map(enrichedPayloadToStageData);
       store.applyTripReady(incomingStages);
       store.setComputationStatus(event.data.computationStatus);
-      // Trip-level AI overview (issue #305) — `aiOverview` is optional; when
-      // the LLM pipeline is disabled or failed it is absent or `null`, in
-      // which case the overview component renders nothing.
-      store.setAiOverview(event.data.aiOverview ?? null);
+      // Trip-level AI overview (issue #305) — `aiOverview` is optional and
+      // arrives from an LLM pipeline, so partial / malformed payloads must
+      // not crash the renderer. Zod parses + coerces missing array fields to
+      // `[]`; any parse failure collapses to `null` so the component falls
+      // back silently rather than rendering a half-populated card.
+      const parsedOverview = TripAiOverviewSchema.safeParse(
+        event.data.aiOverview,
+      );
+      store.setAiOverview(parsedOverview.success ? parsedOverview.data : null);
       useUiStore.getState().setAnalysisProgress(null);
       useUiStore.getState().setAnalysisStarted(true);
       useUiStore.getState().setAnalysisPhaseActive(false);

--- a/pwa/src/hooks/use-trip-planner.ts
+++ b/pwa/src/hooks/use-trip-planner.ts
@@ -676,6 +676,9 @@ export function useTripPlanner() {
         return false;
       }
       setProcessing(true);
+      // Clear stale AI overview so the card does not show outdated data
+      // while the new analysis is in flight.
+      useTripStore.getState().setAiOverview(null);
       setAccommodationScanning(true);
       useUiStore.getState().setAnalysisStarted(true);
       useUiStore.getState().setAnalysisPhaseActive(true);

--- a/pwa/src/lib/mercure/types.ts
+++ b/pwa/src/lib/mercure/types.ts
@@ -129,6 +129,33 @@ export interface SupplyMarker {
   food: SupplyFoodPoint[];
 }
 
+/**
+ * Trip-level AI overview produced by the LLaMA pass 2 (issue #302 backend).
+ *
+ * Carried by the terminal `trip_ready` Mercure event. Mirrors the backend
+ * `TripAiOverview` DTO (`api/src/Llm/Dto/TripAiOverview.php`) and the
+ * OpenAPI-generated `components["schemas"]["TripAiOverview"]`.
+ *
+ * Null/absent when the AI pipeline is disabled, has failed, or has not yet
+ * completed — consumers must treat the entire overview as optional.
+ */
+export interface TripAiOverviewPayload {
+  /** Narrative paragraph (≈120 words) summarising the trip as a whole. */
+  narrative: string;
+  /** Cross-stage patterns the rider should be aware of (fatigue, weather…). */
+  patterns: string[];
+  /** Trip-level actionable recommendations. */
+  recommendations: string[];
+  /** Trip-level alerts spanning multiple stages (warnings flagged from patterns). */
+  crossStageAlerts: string[];
+  /** LLM model identifier (e.g. `"llama3.1:8b"`). */
+  model: string;
+  /** System prompt revision — bumps trigger client-side staleness checks. */
+  promptVersion: number;
+  /** RFC3339 timestamp when the overview was generated. */
+  generatedAt: string;
+}
+
 export type MercureEvent =
   | {
       type: "route_parsed";
@@ -334,7 +361,7 @@ export type MercureEvent =
       data: {
         stages: EnrichedStagePayload[];
         computationStatus: Record<string, string>;
-        aiOverview?: string | null;
+        aiOverview?: TripAiOverviewPayload | null;
       };
     }
   | {

--- a/pwa/src/lib/validation/schemas.ts
+++ b/pwa/src/lib/validation/schemas.ts
@@ -179,6 +179,25 @@ export const StageDataSchema = z.object({
   surfaceBreakdown: z.array(SurfaceSegmentSchema).nullable().optional(),
 });
 
+/**
+ * Trip-level AI overview produced by the LLaMA pass 2 (issue #305).
+ *
+ * Mirrors the backend `TripAiOverview` DTO and the Mercure
+ * `TripAiOverviewPayload`. Array fields default to `[]` so partial LLM output
+ * (where the model omits a section) is coerced into safe empty lists rather
+ * than throwing at render time.
+ * TODO(#450): wire via typegen once backend Trip DTO exposes aiOverview in OpenAPI.
+ */
+export const TripAiOverviewSchema = z.object({
+  narrative: z.string(),
+  patterns: z.array(z.string()).default([]),
+  recommendations: z.array(z.string()).default([]),
+  crossStageAlerts: z.array(z.string()).default([]),
+  model: z.string().default(""),
+  promptVersion: z.number().int().default(1),
+  generatedAt: z.string().default(""),
+});
+
 export const TripStateSchema = z.object({
   trip: z
     .object({
@@ -212,3 +231,4 @@ export type EventData = z.infer<typeof EventSchema>;
 export type AccommodationData = z.infer<typeof AccommodationSchema>;
 export type SurfaceSegmentData = z.infer<typeof SurfaceSegmentSchema>;
 export type StageData = z.infer<typeof StageDataSchema>;
+export type TripAiOverviewData = z.infer<typeof TripAiOverviewSchema>;

--- a/pwa/src/store/trip-store.ts
+++ b/pwa/src/store/trip-store.ts
@@ -13,6 +13,7 @@ import type {
   SupplyMarkerData,
   EventData,
 } from "@/lib/validation/schemas";
+import type { TripAiOverviewPayload } from "@/lib/mercure/types";
 
 /**
  * A single user modification accumulated in the batch queue before being applied
@@ -82,6 +83,14 @@ interface TripState {
    * `POST /trips/{id}/recompute` instead of N sequential recomputations.
    */
   pendingModifications: Modification[];
+
+  /**
+   * Trip-level narrative produced by the LLaMA pass 2 (issue #302 backend).
+   * Populated on `trip_ready` and rendered at the top of "Mon voyage" by
+   * {@link TripAiOverview}. Stays `null` when the AI pipeline is disabled or
+   * has not completed, in which case the overview component is suppressed.
+   */
+  aiOverview: TripAiOverviewPayload | null;
 
   /**
    * Index of the stage currently displayed in the master/detail roadbook view
@@ -174,6 +183,13 @@ interface TripState {
    */
   applyTripReady: (stages: StageData[]) => void;
   /**
+   * Store (or clear) the trip-level AI overview produced by the LLaMA pass 2
+   * (issue #302). Called from {@link useMercure} when `trip_ready` lands. The
+   * payload is null when the LLM pipeline is disabled, failed, or has not yet
+   * produced a result.
+   */
+  setAiOverview: (overview: TripAiOverviewPayload | null) => void;
+  /**
    * Mode 2 — Per-stage replacement when `stage_updated` arrives.
    *
    * Same preservation semantics as {@link applyTripReady} but for a single
@@ -257,6 +273,7 @@ const initialState = {
   stageDiffs: new Map<number, Set<string>>(),
   pendingModifications: [] as Modification[],
   selectedStageIndex: 0,
+  aiOverview: null as TripAiOverviewPayload | null,
 };
 
 /**
@@ -642,6 +659,11 @@ export const useTripStore = create<TripState>()(
         });
       }),
 
+    setAiOverview: (overview) =>
+      set((state) => {
+        state.aiOverview = overview;
+      }),
+
     applyStageUpdate: (stageIndex, stage) =>
       set((state) => {
         const prev = state.stages[stageIndex];
@@ -814,3 +836,13 @@ export const useTripTemporalStore = createTemporalStore(
     );
   },
 );
+
+/**
+ * Selector for the trip-level AI overview narrative (issue #305).
+ *
+ * Returns `null` when the LLM pipeline is disabled, has not completed, or has
+ * failed — consumers should treat that case as "no overview to display" and
+ * fall back silently rather than rendering a placeholder.
+ */
+export const useTripAiOverview = (): TripAiOverviewPayload | null =>
+  useTripStore((state) => state.aiOverview);

--- a/pwa/src/store/trip-store.ts
+++ b/pwa/src/store/trip-store.ts
@@ -846,3 +846,11 @@ export const useTripTemporalStore = createTemporalStore(
  */
 export const useTripAiOverview = (): TripAiOverviewPayload | null =>
   useTripStore((state) => state.aiOverview);
+
+// Expose the store for E2E tests so Playwright can manipulate trip state directly
+// without relying on user interactions.
+if (typeof window !== "undefined" && process.env.NODE_ENV !== "production") {
+  (
+    window as Window & { __zustand_trip_store?: typeof useTripStore }
+  ).__zustand_trip_store = useTripStore;
+}

--- a/pwa/tests/fixtures/mock-data.ts
+++ b/pwa/tests/fixtures/mock-data.ts
@@ -549,6 +549,44 @@ export function tripReadyEvent(): MercureEvent {
   };
 }
 
+/**
+ * Variant of {@link tripReadyEvent} that carries a populated `aiOverview`
+ * payload, used by issue #305 tests to assert the {@link TripAiOverview}
+ * component renders the narrative, patterns, recommendations, and cross-stage
+ * alerts produced by the LLaMA pass 2.
+ */
+export function tripReadyEventWithAiOverview(): MercureEvent {
+  const base = tripReadyEvent();
+  if (base.type !== "trip_ready") {
+    throw new Error("tripReadyEvent() must return a trip_ready event");
+  }
+  return {
+    type: "trip_ready",
+    data: {
+      ...base.data,
+      aiOverview: {
+        narrative:
+          "Votre traversée de l'Ardèche s'étire sur deux jours bien rythmés.\n" +
+          "Le premier jour concentre le dénivelé positif, le second est plus roulant.",
+        patterns: [
+          "Dénivelé positif majoritairement sur le jour 1 (1180 m).",
+          "Vent dominant de secteur ouest sur les deux étapes.",
+        ],
+        recommendations: [
+          "Démarrer tôt le jour 1 pour profiter de la fraîcheur matinale.",
+          "Prévoir un ravitaillement complet avant Les Vans.",
+        ],
+        crossStageAlerts: [
+          "Charge cumulative supérieure à la moyenne — surveiller la fatigue J2.",
+        ],
+        model: "llama3.1:8b",
+        promptVersion: 1,
+        generatedAt: "2026-05-11T08:30:00Z",
+      },
+    },
+  };
+}
+
 export function stageUpdatedEvent(stageIndex: number): MercureEvent {
   return {
     type: "stage_updated",

--- a/pwa/tests/mocked/trip-ai-overview.spec.ts
+++ b/pwa/tests/mocked/trip-ai-overview.spec.ts
@@ -87,9 +87,10 @@ test.describe("TripAiOverview — re-analysis", () => {
     // Simulate the user triggering a fresh analysis from a downstream flow
     // (batch refinement, etc.): `handleLaunchAnalysis` must clear the stale
     // overview synchronously so the card does not show outdated data while
-    // the new pipeline is in flight.
+    // the new pipeline is in flight. The CustomEvent hook works in production
+    // builds (unlike `window.__zustand_trip_store` which is guarded by NODE_ENV).
     await mockedPage.evaluate(() => {
-      window.__zustand_trip_store?.getState().setAiOverview(null);
+      window.dispatchEvent(new CustomEvent("__test_clear_ai_overview"));
     });
 
     await expect(mockedPage.getByTestId("trip-ai-overview")).toHaveCount(0);

--- a/pwa/tests/mocked/trip-ai-overview.spec.ts
+++ b/pwa/tests/mocked/trip-ai-overview.spec.ts
@@ -1,0 +1,108 @@
+import { test, expect } from "../fixtures/base.fixture";
+import {
+  routeParsedEvent,
+  stagesComputedEvent,
+  tripReadyEvent,
+  tripReadyEventWithAiOverview,
+} from "../fixtures/mock-data";
+
+/**
+ * Issue #305 — Trip-level AI overview card.
+ *
+ * The {@link TripAiOverview} component renders the narrative, patterns,
+ * recommendations and cross-stage alerts produced by the LLaMA pass 2 at
+ * the top of "Mon voyage" (Acte 3). It must:
+ *   - render when `trip_ready` carries a populated `aiOverview` payload;
+ *   - render nothing at all when `aiOverview` is `null` (silent fallback);
+ *   - on mobile, hide the detailed sections behind a disclosure toggle.
+ */
+
+test.describe("TripAiOverview — display", () => {
+  test("renders the AI overview card when aiOverview is present", async ({
+    submitUrl,
+    injectEvent,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    await injectEvent(routeParsedEvent());
+    await injectEvent(stagesComputedEvent());
+    await injectEvent(tripReadyEventWithAiOverview());
+
+    const overview = mockedPage.getByTestId("trip-ai-overview");
+    await expect(overview).toBeVisible({ timeout: 10000 });
+
+    // Narrative teaser is always visible.
+    await expect(
+      mockedPage.getByTestId("trip-ai-overview-teaser"),
+    ).toContainText(/traversée de l'Ardèche/i);
+
+    // Patterns, recommendations, and cross-stage alerts are rendered as lists.
+    await expect(
+      mockedPage.getByTestId("trip-ai-overview-patterns"),
+    ).toContainText(/Dénivelé positif majoritairement/i);
+    await expect(
+      mockedPage.getByTestId("trip-ai-overview-recommendations"),
+    ).toContainText(/Démarrer tôt le jour 1/i);
+    await expect(
+      mockedPage.getByTestId("trip-ai-overview-cross-stage-alerts"),
+    ).toContainText(/Charge cumulative supérieure/i);
+  });
+
+  test("renders nothing when aiOverview is null (silent fallback)", async ({
+    submitUrl,
+    injectEvent,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    await injectEvent(routeParsedEvent());
+    await injectEvent(stagesComputedEvent());
+    // The canonical tripReadyEvent fixture has `aiOverview: null`.
+    await injectEvent(tripReadyEvent());
+
+    // Wait for the trip to render so we know the card SHOULD have appeared
+    // if the overview existed — then assert it does not.
+    await expect(mockedPage.getByTestId("stage-card-1")).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(mockedPage.getByTestId("trip-ai-overview")).toHaveCount(0);
+  });
+});
+
+test.describe("TripAiOverview — responsive", () => {
+  test("collapses detailed sections behind a disclosure toggle on mobile", async ({
+    submitUrl,
+    injectEvent,
+    mockedPage,
+  }) => {
+    // Switch to a mobile viewport so the `md:hidden` toggle becomes visible
+    // and the `hidden md:flex` details block is collapsed by default.
+    await mockedPage.setViewportSize({ width: 375, height: 800 });
+
+    await submitUrl();
+    await injectEvent(routeParsedEvent());
+    await injectEvent(stagesComputedEvent());
+    await injectEvent(tripReadyEventWithAiOverview());
+
+    const overview = mockedPage.getByTestId("trip-ai-overview");
+    await expect(overview).toBeVisible({ timeout: 10000 });
+
+    const toggle = mockedPage.getByTestId("trip-ai-overview-toggle");
+    await expect(toggle).toBeVisible();
+    await expect(toggle).toHaveAttribute("aria-expanded", "false");
+
+    // Details block is hidden in the collapsed state on mobile.
+    await expect(
+      mockedPage.getByTestId("trip-ai-overview-details"),
+    ).toBeHidden();
+
+    await toggle.click();
+
+    await expect(toggle).toHaveAttribute("aria-expanded", "true");
+    await expect(
+      mockedPage.getByTestId("trip-ai-overview-details"),
+    ).toBeVisible();
+    await expect(
+      mockedPage.getByTestId("trip-ai-overview-recommendations"),
+    ).toBeVisible();
+  });
+});

--- a/pwa/tests/mocked/trip-ai-overview.spec.ts
+++ b/pwa/tests/mocked/trip-ai-overview.spec.ts
@@ -68,6 +68,38 @@ test.describe("TripAiOverview — display", () => {
   });
 });
 
+test.describe("TripAiOverview — re-analysis", () => {
+  test("clears the stale overview when a new analysis is launched", async ({
+    submitUrl,
+    injectEvent,
+    mockedPage,
+  }) => {
+    // First analysis — overview appears.
+    await submitUrl();
+    await injectEvent(routeParsedEvent());
+    await injectEvent(stagesComputedEvent());
+    await injectEvent(tripReadyEventWithAiOverview());
+
+    await expect(mockedPage.getByTestId("trip-ai-overview")).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Simulate the user triggering a fresh analysis from a downstream flow
+    // (batch refinement, etc.): `handleLaunchAnalysis` must clear the stale
+    // overview synchronously so the card does not show outdated data while
+    // the new pipeline is in flight.
+    await mockedPage.evaluate(() => {
+      window.__zustand_trip_store?.getState().setAiOverview(null);
+    });
+
+    await expect(mockedPage.getByTestId("trip-ai-overview")).toHaveCount(0);
+
+    // A new `trip_ready` without an overview keeps the card absent.
+    await injectEvent(tripReadyEvent());
+    await expect(mockedPage.getByTestId("trip-ai-overview")).toHaveCount(0);
+  });
+});
+
 test.describe("TripAiOverview — responsive", () => {
   test("collapses detailed sections behind a disclosure toggle on mobile", async ({
     submitUrl,


### PR DESCRIPTION
## Summary

Closes #305.

Displays the LLaMA 8B pass-2 narrative summary at the top of "Mon voyage" (Acte 3): narrative paragraphs, patterns, recommendations and cross-stage alerts produced by `AnalyzeTripOverviewWithLlmHandler` and emitted via the `aiOverview` field of the `trip_ready` Mercure event.

- New `TripAiOverview` component (`pwa/src/components/trip-ai-overview.tsx`) — desktop: full card; mobile: collapsible with title + first narrative line until disclosure tap. Silent fallback (`null`) when overview is absent.
- Zustand store slot + `useTripAiOverview()` selector; `use-mercure.ts` forwards `aiOverview` from `trip_ready` payloads.
- Strongly typed Mercure payload (`TripAiOverviewPayload`) mirroring the backend DTO.
- French + English translations under the `aiOverview` namespace.

## Test plan

- [x] `make qa` — PHP-CS-Fixer, Rector, PHPStan L9, ESLint (incl. React Compiler), Prettier, TypeScript
- [x] `make test-php` — 1095 tests / 3247 assertions, 1 skipped
- [x] `make test-e2e` — 434 passed / 1 skipped, including 3 new tests in `pwa/tests/mocked/trip-ai-overview.spec.ts` (present, silent fallback, mobile collapse)

## Auto-critique

- Drops a `useMemo` to satisfy React Compiler lint — the cost is recomputing the paragraph split on every render, which is negligible for short narratives (under a few hundred chars). Acceptable trade-off given the compiler optimizes pure derivations automatically.
- The component uses a single disclosure toggle (mobile only); desktop is always expanded per spec. No keyboard shortcut beyond the focusable button.
- Cross-stage alerts use an inline amber-tinted block rather than a separate alert primitive — keeps the card cohesive but means screen readers won't pick up an "alert" role. Acceptable since these are summaries, not actionable alerts (those live in the per-stage alerts list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

The three commits pushed since the previous review close both open findings: Zod `safeParse` in `use-mercure.ts` guards against partial LLM payloads (resolving the array null-safety warning), and a Playwright re-analysis test was added. No critical or warning issues remain.

One open thread (PRRT_kwDORUitfM6BOCwm) is carried forward: the re-analysis test uses the `__test_clear_ai_overview` CustomEvent hook rather than calling `handleLaunchAnalysis()`, so a regression in `use-trip-planner.ts` (accidentally removing `setAiOverview(null)`) would not be caught by the test suite. This is a suggestion-level gap, not a blocker.

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [ ] Tests cover new/changed cases — re-analysis test exercises `setAiOverview(null)` via CustomEvent hook, bypassing the `handleLaunchAnalysis()` code path in `use-trip-planner.ts` (open thread PRRT_kwDORUitfM6BOCwm)
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Inline comments

No new inline comments.

---

Reviewed commit `51f23dfea82e6df3f0c54cd159f9e7eba400ece2`.

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->