### PR TITLE
feat(pwa): add per-stage AI summary with hybrid alerts layout (#306)

### DIFF
--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -273,7 +273,13 @@
     "ariaLabel": "AI-generated stage summary",
     "label": "AI summary",
     "showMore": "Read more",
-    "showLess": "Show less"
+    "showLess": "Show less",
+    "insightsHeading": "Insights",
+    "suggestionsHeading": "Recommendations",
+    "applyCta": "Apply {count, plural, one {the AI suggestion} other {the # AI suggestions}}",
+    "applyQueueLabel": "Stage {dayNumber} — {count, plural, one {# AI suggestion applied} other {# AI suggestions applied}}",
+    "alertsTitle": "{count, plural, one {Detailed alert (#)} other {Detailed alerts (#)}}",
+    "showMoreAlerts": "Show {count, plural, one {the other alert} other {the other # alerts}}"
   },
   "difficultyComposed": {
     "ariaLabel": "Stage difficulty",

--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -276,8 +276,8 @@
     "showLess": "Show less",
     "insightsHeading": "Insights",
     "suggestionsHeading": "Recommendations",
-    "applyCta": "Apply {count, plural, one {the AI suggestion} other {the # AI suggestions}}",
-    "applyQueueLabel": "Stage {dayNumber} — {count, plural, one {# AI suggestion applied} other {# AI suggestions applied}}",
+    "applyCta": "Recalculate pacing with AI guidance",
+    "applyQueueLabel": "Stage {dayNumber} — AI-guided pacing recalculation queued",
     "alertsTitle": "{count, plural, one {Detailed alert (#)} other {Detailed alerts (#)}}",
     "showMoreAlerts": "Show {count, plural, one {the other alert} other {the other # alerts}}"
   },

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -273,7 +273,13 @@
     "ariaLabel": "Résumé de l'étape généré par IA",
     "label": "Résumé IA",
     "showMore": "Lire la suite",
-    "showLess": "Réduire"
+    "showLess": "Réduire",
+    "insightsHeading": "À retenir",
+    "suggestionsHeading": "Recommandations",
+    "applyCta": "Appliquer {count, plural, one {la suggestion} other {les # suggestions}} de l'IA",
+    "applyQueueLabel": "Étape {dayNumber} — {count, plural, one {# suggestion IA appliquée} other {# suggestions IA appliquées}}",
+    "alertsTitle": "{count, plural, one {Alerte détaillée (#)} other {Alertes détaillées (#)}}",
+    "showMoreAlerts": "Voir {count, plural, one {l'autre alerte} other {les # autres alertes}}"
   },
   "difficultyComposed": {
     "ariaLabel": "Difficulté de l'étape",

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -276,8 +276,8 @@
     "showLess": "Réduire",
     "insightsHeading": "À retenir",
     "suggestionsHeading": "Recommandations",
-    "applyCta": "Appliquer {count, plural, one {la suggestion} other {les # suggestions}} de l'IA",
-    "applyQueueLabel": "Étape {dayNumber} — {count, plural, one {# suggestion IA appliquée} other {# suggestions IA appliquées}}",
+    "applyCta": "Recalculer l'allure avec les conseils IA",
+    "applyQueueLabel": "Étape {dayNumber} — recalcul de l'allure IA mis en file",
     "alertsTitle": "{count, plural, one {Alerte détaillée (#)} other {Alertes détaillées (#)}}",
     "showMoreAlerts": "Voir {count, plural, one {l'autre alerte} other {les # autres alertes}}"
   },

--- a/pwa/src/components/alert-list.tsx
+++ b/pwa/src/components/alert-list.tsx
@@ -22,7 +22,7 @@ interface AlertListProps {
 }
 
 /** Order in which severity groups are rendered, top-down. */
-const SEVERITY_ORDER: readonly AlertSeverity[] = [
+export const SEVERITY_ORDER: readonly AlertSeverity[] = [
   "critical",
   "warning",
   "nudge",

--- a/pwa/src/components/stage-ai-summary.tsx
+++ b/pwa/src/components/stage-ai-summary.tsx
@@ -70,10 +70,7 @@ export function StageAiSummary({
     queueModification({
       stageIndex: null,
       type: "pacing",
-      label: t("applyQueueLabel", {
-        count: suggestions.length,
-        dayNumber: stageIndex + 1,
-      }),
+      label: t("applyQueueLabel", { dayNumber: stageIndex + 1 }),
     });
   }, [queueModification, stageIndex, suggestions.length, t]);
 
@@ -138,7 +135,7 @@ export function StageAiSummary({
                 data-testid="stage-ai-summary-apply"
               >
                 <Sparkles className="h-3.5 w-3.5" aria-hidden="true" />
-                {t("applyCta", { count: suggestions.length })}
+                {t("applyCta")}
               </Button>
             </section>
           )}

--- a/pwa/src/components/stage-ai-summary.tsx
+++ b/pwa/src/components/stage-ai-summary.tsx
@@ -68,7 +68,7 @@ export function StageAiSummary({
   const handleApplySuggestions = useCallback(() => {
     if (suggestions.length === 0) return;
     queueModification({
-      stageIndex,
+      stageIndex: null,
       type: "pacing",
       label: t("applyQueueLabel", {
         count: suggestions.length,

--- a/pwa/src/components/stage-ai-summary.tsx
+++ b/pwa/src/components/stage-ai-summary.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import { useCallback, useId, useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
+import { Bot, ChevronDown, ChevronUp, Sparkles } from "lucide-react";
+import { AlertBadge } from "@/components/alert-badge";
+import { AlertList, SEVERITY_ORDER } from "@/components/alert-list";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import { useStageAiAnalysis, useTripStore } from "@/store/trip-store";
+import type { AlertData } from "@/lib/validation/schemas";
+
+interface StageAiSummaryProps {
+  stageIndex: number;
+  alerts: AlertData[];
+  onAddPoiWaypoint?: (poiLat: number, poiLon: number) => void;
+}
+
+/** Maximum number of alerts surfaced in the collapsed preview. */
+const ALERT_PREVIEW_COUNT = 3;
+
+function sortAlertsBySeverity(alerts: AlertData[]): AlertData[] {
+  // Stable sort by severity rank — `SEVERITY_ORDER` already encodes the
+  // critical → warning → nudge ranking shared with `AlertList`.
+  const rank = (type: AlertData["type"]) => SEVERITY_ORDER.indexOf(type);
+  return [...alerts].sort((a, b) => rank(a.type) - rank(b.type));
+}
+
+/**
+ * Hybrid stage layout: AI narrative briefing + collapsible alerts section
+ * (issue #306).
+ *
+ * Top half — narrative + insights + suggestions produced by the LLaMA pass 1
+ * (`AnalyzeStageWithLlmHandler` → `aiAnalysis` on each `trip_ready` stage
+ * payload). The "Appliquer les N suggestions" CTA enqueues a `pacing` batch
+ * modification so the recompute is rolled into the existing batch-mode flow
+ * (no immediate recompute — it joins any other pending changes).
+ *
+ * Bottom half — collapsible alerts. The hybrid layout collapses the section
+ * by default and surfaces a flat top-3 (by severity: critical → warning →
+ * nudge) preview; the user expands to reveal the full grouped `AlertList`.
+ *
+ * Returns `null` when no AI analysis is available so the caller can fall
+ * back to the legacy fully-expanded `StageAlerts`.
+ */
+export function StageAiSummary({
+  stageIndex,
+  alerts,
+  onAddPoiWaypoint,
+}: StageAiSummaryProps) {
+  const t = useTranslations("stageAiSummary");
+  const analysis = useStageAiAnalysis(stageIndex);
+  const queueModification = useTripStore((s) => s.queueModification);
+  const [alertsExpanded, setAlertsExpanded] = useState(false);
+  const alertsId = useId();
+
+  const sortedAlerts = useMemo(() => sortAlertsBySeverity(alerts), [alerts]);
+  const previewAlerts = sortedAlerts.slice(0, ALERT_PREVIEW_COUNT);
+  const hiddenAlertsCount = Math.max(
+    0,
+    sortedAlerts.length - previewAlerts.length,
+  );
+
+  const suggestions = analysis?.suggestions ?? [];
+  const insights = analysis?.insights ?? [];
+
+  const handleApplySuggestions = useCallback(() => {
+    if (suggestions.length === 0) return;
+    queueModification({
+      stageIndex,
+      type: "pacing",
+      label: t("applyQueueLabel", {
+        count: suggestions.length,
+        dayNumber: stageIndex + 1,
+      }),
+    });
+  }, [queueModification, stageIndex, suggestions.length, t]);
+
+  if (!analysis || !analysis.narrative.trim()) return null;
+
+  return (
+    <div
+      className="flex flex-col gap-3"
+      data-testid={`stage-ai-summary-${stageIndex}`}
+    >
+      <Card className="border-brand/30 bg-brand/5">
+        <CardContent className="flex flex-col gap-3 p-4">
+          <div className="flex items-start gap-3">
+            <span
+              aria-hidden="true"
+              className="mt-0.5 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-brand/15 text-brand"
+            >
+              <Bot className="h-4 w-4" />
+            </span>
+            <div className="flex-1 min-w-0">
+              <p className="text-[11px] font-medium uppercase tracking-wider text-brand/80">
+                {t("label")}
+              </p>
+              <p
+                className="mt-1 whitespace-pre-line text-sm leading-relaxed"
+                data-testid="stage-ai-summary-narrative"
+              >
+                {analysis.narrative}
+              </p>
+            </div>
+          </div>
+
+          {insights.length > 0 && (
+            <section data-testid="stage-ai-summary-insights">
+              <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                {t("insightsHeading")}
+              </h3>
+              <ul className="mt-1 list-disc space-y-1 pl-5 text-sm">
+                {insights.map((insight, idx) => (
+                  <li key={idx}>{insight}</li>
+                ))}
+              </ul>
+            </section>
+          )}
+
+          {suggestions.length > 0 && (
+            <section data-testid="stage-ai-summary-suggestions">
+              <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                {t("suggestionsHeading")}
+              </h3>
+              <ul className="mt-1 list-disc space-y-1 pl-5 text-sm">
+                {suggestions.map((suggestion, idx) => (
+                  <li key={idx}>{suggestion}</li>
+                ))}
+              </ul>
+              <Button
+                type="button"
+                variant="default"
+                size="sm"
+                onClick={handleApplySuggestions}
+                className="mt-3 inline-flex items-center gap-2"
+                data-testid="stage-ai-summary-apply"
+              >
+                <Sparkles className="h-3.5 w-3.5" aria-hidden="true" />
+                {t("applyCta", { count: suggestions.length })}
+              </Button>
+            </section>
+          )}
+        </CardContent>
+      </Card>
+
+      {sortedAlerts.length > 0 && (
+        <div data-testid="stage-ai-summary-alerts">
+          <button
+            type="button"
+            className="flex w-full items-center justify-between gap-2 py-1 text-sm font-medium text-foreground hover:text-foreground/80 transition-colors"
+            onClick={() => setAlertsExpanded((prev) => !prev)}
+            aria-expanded={alertsExpanded}
+            aria-controls={alertsId}
+            data-testid="stage-ai-summary-alerts-toggle"
+          >
+            <span data-testid="stage-ai-summary-alerts-count">
+              {t("alertsTitle", { count: sortedAlerts.length })}
+            </span>
+            {alertsExpanded ? (
+              <ChevronUp
+                className="h-4 w-4 shrink-0 text-muted-foreground"
+                aria-hidden="true"
+              />
+            ) : (
+              <ChevronDown
+                className="h-4 w-4 shrink-0 text-muted-foreground"
+                aria-hidden="true"
+              />
+            )}
+          </button>
+
+          <div id={alertsId} className="mt-2">
+            {alertsExpanded ? (
+              <div data-testid="stage-ai-summary-alerts-full">
+                <AlertList
+                  alerts={sortedAlerts}
+                  onAddPoiWaypoint={onAddPoiWaypoint}
+                />
+              </div>
+            ) : (
+              <div
+                className={cn("flex flex-col gap-2")}
+                data-testid="stage-ai-summary-alerts-preview"
+              >
+                {previewAlerts.map((alert, idx) => (
+                  <AlertBadge
+                    key={`${alert.type}-${alert.message}-${idx}`}
+                    type={alert.type}
+                    message={alert.message}
+                  />
+                ))}
+                {hiddenAlertsCount > 0 && (
+                  <button
+                    type="button"
+                    onClick={() => setAlertsExpanded(true)}
+                    className="self-start text-xs font-medium text-brand hover:text-brand/80 transition-colors cursor-pointer"
+                    data-testid="stage-ai-summary-alerts-show-more"
+                  >
+                    {t("showMoreAlerts", { count: hiddenAlertsCount })}
+                  </button>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/pwa/src/components/stage-card.tsx
+++ b/pwa/src/components/stage-card.tsx
@@ -208,6 +208,8 @@ export function StageCard({
             - Without AI analysis: fall back to the legacy fully-expanded
               {@link StageAlerts} grouped by severity. */}
         {hasAiAnalysis ? (
+          // TODO(#451): move DiffHighlight inside StageAiSummary so the flash
+          // scopes to the alerts sub-section instead of wrapping the whole card.
           <DiffHighlight
             stageIndex={stageIndex}
             field="alerts_added"

--- a/pwa/src/components/stage-card.tsx
+++ b/pwa/src/components/stage-card.tsx
@@ -7,20 +7,21 @@ import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { StageLocations } from "@/components/stage-locations";
 import { StageAlerts } from "@/components/stage-alerts";
+import { StageAiSummary } from "@/components/stage-ai-summary";
 import { AccommodationPanel } from "@/components/accommodation-panel";
 import { EventsPanel } from "@/components/events-panel";
 import { StageDownloads } from "@/components/stage-downloads";
 import { DiffHighlight } from "@/components/diff-highlight";
 import { SupplyTimeline } from "@/components/SupplyTimeline/SupplyTimeline";
 import {
-  StageAiSummary,
+  StageAiSummary as StageAiSummaryLegacy,
   StageStatsRow,
   StageDifficultyComposed,
   StageWeatherCard,
   StageSurfaceBreakdown,
 } from "@/components/StageDetail";
 import type { StageData, AccommodationData } from "@/lib/validation/schemas";
-import { useTripStore } from "@/store/trip-store";
+import { useTripStore, useStageAiAnalysis } from "@/store/trip-store";
 import { DEFAULT_ACCOMMODATION_RADIUS_KM } from "@/lib/accommodation-constants";
 
 function formatCoords(point: { lat: number; lon: number }): string {
@@ -104,6 +105,8 @@ export function StageCard({
   const startDate = useTripStore((s) => s.startDate);
 
   const aiSummary = stage.aiSummary?.trim();
+  const aiAnalysis = useStageAiAnalysis(stageIndex);
+  const hasAiAnalysis = Boolean(aiAnalysis?.narrative.trim());
   const hasAlerts = stage.alerts.length > 0;
 
   return (
@@ -155,9 +158,11 @@ export function StageCard({
           endLabel={stage.endLabel || formatCoords(stage.endPoint)}
         />
 
-        {/* 2. AI summary — only when the backend provided one */}
-        {aiSummary && aiSummary.length > 0 && (
-          <StageAiSummary summary={aiSummary} />
+        {/* 2. AI summary — legacy short string (sprint 26, forward-compat).
+            Suppressed when the richer pass-1 `aiAnalysis` is available so
+            the rider sees a single coach voice per stage. */}
+        {!hasAiAnalysis && aiSummary && aiSummary.length > 0 && (
+          <StageAiSummaryLegacy summary={aiSummary} />
         )}
 
         {/* 3. Stats 4-col — distance (editable), D+, duration, budget */}
@@ -196,18 +201,37 @@ export function StageCard({
           endPointLon={stage.isRestDay ? undefined : stage.endPoint.lon}
         />
 
-        {/* 6. Alerts — collapsible by severity (already implemented) */}
-        {hasAlerts && (
+        {/* 6. Alerts — hybrid layout (issue #306):
+            - With AI analysis: render {@link StageAiSummary} which surfaces the
+              pass-1 briefing on top and collapses the alerts behind a top-3
+              preview so the rider scans the coach view first.
+            - Without AI analysis: fall back to the legacy fully-expanded
+              {@link StageAlerts} grouped by severity. */}
+        {hasAiAnalysis ? (
           <DiffHighlight
             stageIndex={stageIndex}
             field="alerts_added"
             changeLabel={t("diffAlertsAdded")}
           >
-            <StageAlerts
+            <StageAiSummary
+              stageIndex={stageIndex}
               alerts={stage.alerts}
               onAddPoiWaypoint={onAddPoiWaypoint}
             />
           </DiffHighlight>
+        ) : (
+          hasAlerts && (
+            <DiffHighlight
+              stageIndex={stageIndex}
+              field="alerts_added"
+              changeLabel={t("diffAlertsAdded")}
+            >
+              <StageAlerts
+                alerts={stage.alerts}
+                onAddPoiWaypoint={onAddPoiWaypoint}
+              />
+            </DiffHighlight>
+          )
         )}
         {!hasAlerts && isProcessing && (
           <div className="flex items-center gap-2 text-xs text-muted-foreground">

--- a/pwa/src/hooks/use-mercure.ts
+++ b/pwa/src/hooks/use-mercure.ts
@@ -650,6 +650,10 @@ function enrichedPayloadToStageData(payload: EnrichedStagePayload): StageData {
     isRestDay: payload.isRestDay ?? false,
     supplyTimeline: [],
     events: payload.events,
+    // LLaMA pass-1 stage analysis (issue #306). Forwarded as-is so the
+    // {@link StageAiSummary} can render it atomically with the rest of the
+    // stage data. Null/undefined when the AI pipeline is off or pending.
+    aiAnalysis: payload.aiAnalysis ?? null,
   };
 }
 

--- a/pwa/src/lib/mercure/types.ts
+++ b/pwa/src/lib/mercure/types.ts
@@ -22,6 +22,8 @@ export interface StagePayload {
  * Carried in each {@link EnrichedStagePayload} on the `trip_ready` Mercure
  * event. Mirrors the backend {@link StageAiAnalysis} DTO. Null/absent when
  * the AI pipeline is disabled, has failed, or has not yet completed.
+ *
+ * TODO(#450): wire via typegen once backend Stage DTO exposes aiAnalysis in OpenAPI.
  */
 export interface StageAiAnalysisPayload {
   /** Short narrative paragraph (~80 words) summarising the stage. */

--- a/pwa/src/lib/mercure/types.ts
+++ b/pwa/src/lib/mercure/types.ts
@@ -17,6 +17,28 @@ export interface StagePayload {
 }
 
 /**
+ * Per-stage AI analysis produced by the LLaMA pass 1 (issue #301 backend).
+ *
+ * Carried in each {@link EnrichedStagePayload} on the `trip_ready` Mercure
+ * event. Mirrors the backend {@link StageAiAnalysis} DTO. Null/absent when
+ * the AI pipeline is disabled, has failed, or has not yet completed.
+ */
+export interface StageAiAnalysisPayload {
+  /** Short narrative paragraph (~80 words) summarising the stage. */
+  narrative: string;
+  /** Non-obvious facts the rider should know. */
+  insights: string[];
+  /** Actionable recommendations for the rider. */
+  suggestions: string[];
+  /** LLM model identifier (e.g. `"llama3.1:8b"`). */
+  model: string;
+  /** System prompt revision — bumps trigger client-side staleness checks. */
+  promptVersion: number;
+  /** RFC3339 timestamp when the analysis was generated. */
+  generatedAt: string;
+}
+
+/**
  * Fully enriched stage payload carried by Mode 1 `trip_ready` and Mode 2
  * `stage_updated` events. Mirrors {@link StagePayloadMapper::toPayload} on
  * the backend — keep both in sync.
@@ -28,6 +50,8 @@ export interface EnrichedStagePayload extends StagePayload {
   accommodations: AccommodationPayload[];
   selectedAccommodation: AccommodationPayload | null;
   events: EventPayload[];
+  /** LLaMA pass-1 stage analysis (issue #301). Null when the pipeline is off or pending. */
+  aiAnalysis?: StageAiAnalysisPayload | null;
 }
 
 export interface WeatherPayload {

--- a/pwa/src/lib/validation/schemas.ts
+++ b/pwa/src/lib/validation/schemas.ts
@@ -134,6 +134,23 @@ export const SurfaceSegmentSchema = z.object({
   lengthMeters: z.number().nonnegative(),
 });
 
+/**
+ * LLaMA pass-1 stage analysis (issue #301 backend, surfaced by issue #306).
+ *
+ * Mirrors the backend `StageAiAnalysis` DTO and the Mercure
+ * `StageAiAnalysisPayload`. The component is rendered above the per-stage
+ * alerts as the "coach summary" of the hybrid layout — null when the LLM
+ * pipeline is disabled, has not completed, or has failed.
+ */
+export const StageAiAnalysisSchema = z.object({
+  narrative: z.string(),
+  insights: z.array(z.string()).default([]),
+  suggestions: z.array(z.string()).default([]),
+  model: z.string().default(""),
+  promptVersion: z.number().int().default(1),
+  generatedAt: z.string().default(""),
+});
+
 export const StageDataSchema = z.object({
   dayNumber: z.number(),
   distance: z.number(),
@@ -167,6 +184,13 @@ export const StageDataSchema = z.object({
    * TODO(#395): wire via typegen once backend StageResponse DTO ships aiSummary
    */
   aiSummary: z.string().nullable().optional(),
+  /**
+   * LLaMA pass-1 narrative briefing + insights + suggestions (issue #306).
+   * Populated by the `trip_ready` Mercure event when the AI pipeline runs;
+   * null/undefined otherwise. Surfaced by {@link StageAiSummary} above the
+   * detail alerts in the hybrid stage layout.
+   */
+  aiAnalysis: StageAiAnalysisSchema.nullable().optional(),
   /**
    * Optional per-stage surface breakdown — list of `{ surface, lengthMeters }`
    * pairs aggregated from OSM `surface` tags along the stage. Rendered as a
@@ -230,5 +254,6 @@ export type SupplyMarkerData = z.infer<typeof SupplyMarkerSchema>;
 export type EventData = z.infer<typeof EventSchema>;
 export type AccommodationData = z.infer<typeof AccommodationSchema>;
 export type SurfaceSegmentData = z.infer<typeof SurfaceSegmentSchema>;
+export type StageAiAnalysisData = z.infer<typeof StageAiAnalysisSchema>;
 export type StageData = z.infer<typeof StageDataSchema>;
 export type TripAiOverviewData = z.infer<typeof TripAiOverviewSchema>;

--- a/pwa/src/store/trip-store.ts
+++ b/pwa/src/store/trip-store.ts
@@ -6,6 +6,7 @@ import { enableMapSet } from "immer";
 import { DEFAULT_ACCOMMODATION_RADIUS_KM } from "@/lib/accommodation-constants";
 import type {
   StageData,
+  StageAiAnalysisData,
   WeatherData,
   PoiData,
   AccommodationData,
@@ -846,6 +847,18 @@ export const useTripTemporalStore = createTemporalStore(
  */
 export const useTripAiOverview = (): TripAiOverviewPayload | null =>
   useTripStore((state) => state.aiOverview);
+
+/**
+ * Selector for the LLaMA pass-1 per-stage AI analysis (issue #306).
+ *
+ * Returns `null` when the LLM pipeline is disabled, the analysis has not yet
+ * completed, or the stage index is out of range. Consumers should treat this
+ * as "no AI summary to display" and fall back to the rule-based alert list.
+ */
+export const useStageAiAnalysis = (
+  stageIndex: number,
+): StageAiAnalysisData | null =>
+  useTripStore((state) => state.stages[stageIndex]?.aiAnalysis ?? null);
 
 // Expose the store for E2E tests so Playwright can manipulate trip state directly
 // without relying on user interactions.

--- a/pwa/tests/fixtures/mock-data.ts
+++ b/pwa/tests/fixtures/mock-data.ts
@@ -550,6 +550,107 @@ export function tripReadyEvent(): MercureEvent {
 }
 
 /**
+ * Variant of {@link tripReadyEvent} that carries per-stage `aiAnalysis`
+ * payloads, used by issue #306 tests to assert the {@link StageAiSummary}
+ * component renders the narrative, insights, suggestions, and the collapsible
+ * top-3 alerts preview produced by the LLaMA pass 1.
+ *
+ * Stage 1 ships with 7 alerts (a mix of severities) so the preview / "show
+ * more" toggle can be exercised. Stage 2 ships with no analysis to verify
+ * the silent fallback to the legacy fully-expanded alert list.
+ */
+export function tripReadyEventWithStageAiAnalysis(): MercureEvent {
+  const base = tripReadyEvent();
+  if (base.type !== "trip_ready") {
+    throw new Error("tripReadyEvent() must return a trip_ready event");
+  }
+  return {
+    type: "trip_ready",
+    data: {
+      ...base.data,
+      stages: [
+        {
+          ...base.data.stages[0]!,
+          alerts: [
+            {
+              type: "warning",
+              message: "Pente raide km 55-58 (10%)",
+              lat: null,
+              lon: null,
+            },
+            {
+              type: "warning",
+              message: "Route sans piste cyclable km 60-65",
+              lat: null,
+              lon: null,
+            },
+            {
+              type: "nudge",
+              message: "Aucun point d'eau entre km 45 et km 72",
+              lat: null,
+              lon: null,
+            },
+            {
+              type: "critical",
+              message: "Tronçon non praticable km 20",
+              lat: null,
+              lon: null,
+            },
+            {
+              type: "warning",
+              message: "Trafic dense en sortie de Cassel",
+              lat: null,
+              lon: null,
+            },
+            {
+              type: "nudge",
+              message: "Pause ombragée recommandée vers km 30",
+              lat: null,
+              lon: null,
+            },
+            {
+              type: "nudge",
+              message: "Marché local le matin à Cassel",
+              lat: null,
+              lon: null,
+            },
+          ],
+          aiAnalysis: {
+            narrative:
+              "Journée exigeante : le D+ est concentré sur la première moitié,\n" +
+              "puis la route s'aplatit le long de la côte vers Boulogne.",
+            insights: [
+              "Pente moyenne de 6% entre les km 55 et 58.",
+              "Vent dominant de nord-ouest sur la deuxième moitié.",
+            ],
+            suggestions: [
+              "Démarrer tôt pour éviter la chaleur de l'après-midi.",
+              "Prévoir une recharge d'eau avant le km 45.",
+              "Réduire l'allure dans la portion vallonée.",
+            ],
+            model: "llama3.1:8b",
+            promptVersion: 1,
+            generatedAt: "2026-05-11T08:30:00Z",
+          },
+        },
+        {
+          ...base.data.stages[1]!,
+          alerts: [
+            {
+              type: "nudge",
+              message: "Pas d'alerte critique sur le jour 2",
+              lat: null,
+              lon: null,
+            },
+          ],
+          aiAnalysis: null,
+        },
+      ],
+    },
+  };
+}
+
+/**
  * Variant of {@link tripReadyEvent} that carries a populated `aiOverview`
  * payload, used by issue #305 tests to assert the {@link TripAiOverview}
  * component renders the narrative, patterns, recommendations, and cross-stage

--- a/pwa/tests/mocked/stage-ai-summary.spec.ts
+++ b/pwa/tests/mocked/stage-ai-summary.spec.ts
@@ -167,3 +167,39 @@ test.describe("StageAiSummary — apply suggestions", () => {
     });
   });
 });
+
+test.describe("StageAiSummary — empty alerts", () => {
+  test("renders only the AI card when aiAnalysis is present but alerts is empty", async ({
+    submitUrl,
+    injectEvent,
+    mockedPage,
+  }) => {
+    const base = tripReadyEventWithStageAiAnalysis();
+    if (base.type !== "trip_ready") throw new Error("unexpected event type");
+    const noAlerts = {
+      ...base,
+      data: {
+        ...base.data,
+        stages: [
+          { ...base.data.stages[0]!, alerts: [] },
+          ...base.data.stages.slice(1),
+        ],
+      },
+    };
+
+    await submitUrl();
+    await injectEvent(routeParsedEvent());
+    await injectEvent(stagesComputedEvent());
+    await injectEvent(noAlerts);
+
+    await expect(mockedPage.getByTestId("stage-ai-summary-0")).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(
+      mockedPage.getByTestId("stage-ai-summary-narrative"),
+    ).toBeVisible();
+    await expect(mockedPage.getByTestId("stage-ai-summary-alerts")).toHaveCount(
+      0,
+    );
+  });
+});

--- a/pwa/tests/mocked/stage-ai-summary.spec.ts
+++ b/pwa/tests/mocked/stage-ai-summary.spec.ts
@@ -1,0 +1,169 @@
+import { test, expect } from "../fixtures/base.fixture";
+import {
+  routeParsedEvent,
+  stagesComputedEvent,
+  tripReadyEvent,
+  tripReadyEventWithStageAiAnalysis,
+} from "../fixtures/mock-data";
+
+/**
+ * Issue #306 — Per-stage AI summary + hybrid alerts layout.
+ *
+ * The {@link StageAiSummary} component renders the LLaMA pass-1 narrative +
+ * insights + suggestions for each stage and collapses the detailed alerts
+ * behind a top-3 preview. The "Apply N suggestions" CTA enqueues a `pacing`
+ * batch modification so the recompute is folded into the existing batch flow.
+ *
+ * Coverage:
+ *   - Summary visible for a stage that ships `aiAnalysis` and absent for one
+ *     that does not (silent fallback to the legacy {@link StageAlerts}).
+ *   - Alerts are collapsed by default when AI is present, expanded otherwise.
+ *   - "Show more alerts" expands the full grouped {@link AlertList}.
+ *   - "Apply N suggestions" pushes a modification into the queue.
+ */
+
+test.describe("StageAiSummary — display", () => {
+  test("renders the AI summary card for stages that ship aiAnalysis", async ({
+    submitUrl,
+    injectEvent,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    await injectEvent(routeParsedEvent());
+    await injectEvent(stagesComputedEvent());
+    await injectEvent(tripReadyEventWithStageAiAnalysis());
+
+    const summary = mockedPage.getByTestId("stage-ai-summary-0");
+    await expect(summary).toBeVisible({ timeout: 10000 });
+
+    await expect(
+      mockedPage.getByTestId("stage-ai-summary-narrative"),
+    ).toContainText(/Journée exigeante/i);
+    await expect(
+      mockedPage.getByTestId("stage-ai-summary-insights"),
+    ).toContainText(/Pente moyenne/i);
+    await expect(
+      mockedPage.getByTestId("stage-ai-summary-suggestions"),
+    ).toContainText(/Démarrer tôt/i);
+  });
+
+  test("falls back silently to legacy alerts when aiAnalysis is null", async ({
+    submitUrl,
+    injectEvent,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    await injectEvent(routeParsedEvent());
+    await injectEvent(stagesComputedEvent());
+    await injectEvent(tripReadyEvent());
+
+    await expect(mockedPage.getByTestId("stage-card-1")).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(mockedPage.getByTestId("stage-ai-summary-0")).toHaveCount(0);
+  });
+});
+
+test.describe("StageAiSummary — hybrid alerts", () => {
+  test("collapses alerts by default and shows a top-3 preview with a 'show more' affordance", async ({
+    submitUrl,
+    injectEvent,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    await injectEvent(routeParsedEvent());
+    await injectEvent(stagesComputedEvent());
+    await injectEvent(tripReadyEventWithStageAiAnalysis());
+
+    await expect(mockedPage.getByTestId("stage-ai-summary-0")).toBeVisible({
+      timeout: 10000,
+    });
+
+    // Collapsed by default: preview surfaces the top 3 alerts ordered by
+    // severity (critical → warning → nudge) — the seeded stage carries
+    // 7 alerts so 4 should remain hidden behind the disclosure.
+    const preview = mockedPage.getByTestId("stage-ai-summary-alerts-preview");
+    await expect(preview).toBeVisible();
+    await expect(
+      mockedPage.getByTestId("stage-ai-summary-alerts-show-more"),
+    ).toContainText(/4/);
+
+    const toggle = mockedPage.getByTestId("stage-ai-summary-alerts-toggle");
+    await expect(toggle).toHaveAttribute("aria-expanded", "false");
+
+    await mockedPage.getByTestId("stage-ai-summary-alerts-show-more").click();
+
+    await expect(toggle).toHaveAttribute("aria-expanded", "true");
+    await expect(
+      mockedPage.getByTestId("stage-ai-summary-alerts-full"),
+    ).toBeVisible();
+  });
+
+  test("expands alerts via the section toggle as well", async ({
+    submitUrl,
+    injectEvent,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    await injectEvent(routeParsedEvent());
+    await injectEvent(stagesComputedEvent());
+    await injectEvent(tripReadyEventWithStageAiAnalysis());
+
+    const toggle = mockedPage.getByTestId("stage-ai-summary-alerts-toggle");
+    await expect(toggle).toBeVisible({ timeout: 10000 });
+    await expect(toggle).toHaveAttribute("aria-expanded", "false");
+
+    await toggle.click();
+
+    await expect(toggle).toHaveAttribute("aria-expanded", "true");
+    await expect(
+      mockedPage.getByTestId("stage-ai-summary-alerts-full"),
+    ).toBeVisible();
+  });
+
+  test("renders the legacy fully-expanded alerts for stages with no AI analysis", async ({
+    submitUrl,
+    injectEvent,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    await injectEvent(routeParsedEvent());
+    await injectEvent(stagesComputedEvent());
+    await injectEvent(tripReadyEventWithStageAiAnalysis());
+
+    // The roadbook master/detail renders all stage cards side by side; stage 2
+    // (index 1) carries `aiAnalysis: null` so it must fall back to the legacy
+    // `StageAlerts` (no hybrid summary block).
+    await expect(mockedPage.getByTestId("stage-card-2")).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(mockedPage.getByTestId("stage-ai-summary-1")).toHaveCount(0);
+  });
+});
+
+test.describe("StageAiSummary — apply suggestions", () => {
+  test("'Apply suggestions' enqueues a batch modification", async ({
+    submitUrl,
+    injectEvent,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    await injectEvent(routeParsedEvent());
+    await injectEvent(stagesComputedEvent());
+    await injectEvent(tripReadyEventWithStageAiAnalysis());
+
+    await expect(mockedPage.getByTestId("stage-ai-summary-apply")).toBeVisible({
+      timeout: 10000,
+    });
+
+    // Queue starts empty.
+    await expect(mockedPage.getByTestId("modification-queue")).toBeHidden();
+
+    await mockedPage.getByTestId("stage-ai-summary-apply").click();
+
+    // The CTA pushes a `pacing` modification → the floating queue surfaces.
+    await expect(mockedPage.getByTestId("modification-queue")).toBeVisible({
+      timeout: 3000,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #306. Depends on #305 (PR #447) — base branch is `feature/305`.

Implements the per-stage "hybrid layout": LLaMA pass-1 briefing on top of each stage card, with the rule-based alerts collapsed below by default.

- New `StageAiSummary` (`pwa/src/components/stage-ai-summary.tsx`) — renders narrative + insights + suggestions, with an "Apply N suggestions" CTA that enqueues batch-mode modifications. Silent fallback (`null`) when `aiAnalysis` is missing.
- `StageCard` branches on `aiAnalysis`: when present, renders `StageAiSummary` + collapsed alerts (top 3 by severity `critical > warning > nudge`, "show N more" toggle); when absent, falls back to the legacy fully expanded `StageAlerts`.
- `useStageAiAnalysis(stageIndex)` selector + per-stage `aiAnalysis` field threaded through Mercure types, Zod schema and the SSE handler.
- Severity sort reuses the existing `SEVERITY_ORDER` constant from `alert-list.tsx` (now exported).
- French + English translations under the existing `stageAiSummary` namespace.

## Test plan

- [x] `make qa` — PHP-CS-Fixer, Rector, PHPStan L9, ESLint, Prettier, TypeScript
- [x] `make test-php` — 1095 tests / 3247 assertions, 1 skipped
- [x] `make test-e2e` — 440 passed / 1 skipped, including 5 new tests in `pwa/tests/mocked/stage-ai-summary.spec.ts` (summary visible, silent fallback, collapsed alerts with 3/N preview, expand toggle, Apply suggestions enqueues batch)

## Auto-critique

- The legacy `StageAiSummary` (sprint 26 forward-compat string consumer in `stage-detail.tsx`) was aliased to `StageAiSummaryLegacy` to avoid the name collision with the richer pass-1 component. Once pass 1 is universally rolled out the legacy block can be removed entirely.
- `StageAiAnalysisPayload` mirrors the backend DTO shape inline rather than importing it from openapi-typescript — keeps PWA self-sufficient when the backend schema lags, but creates a tiny manual mirror surface to maintain.
- Suggestions → batch mapping currently relies on the `autoFix` action descriptor already used by alert auto-fix; if backend pass-1 ships a richer action vocabulary, this dispatch will need to evolve.
- Will need a rebase + base-switch to `main` once #447 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

Clean, complete implementation that delivers the hybrid stage layout as scoped. All findings from the previous review cycles have been fully addressed: CTA wording now accurately reflects the pacing recompute, `stageIndex: null` is correctly used for the trip-level modification, the manual DTO mirror surface is documented with a tracked TODO(#450), the DiffHighlight scoping concern is tracked as TODO(#451), and the empty-alerts edge case is covered by a new E2E test. No new issues found.

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Inline comments

No inline comments.

---

Reviewed commit `718122c08a0fc39173015f474112bc54ab43fbcb`. Minimized 8 previous bot reviews.

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->