### PR TITLE
feat(pwa): add AiBubble floating assistant component

### DIFF
--- a/api/config/packages/cache.php
+++ b/api/config/packages/cache.php
@@ -37,6 +37,10 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                     'adapter' => 'cache.adapter.redis',
                     'default_lifetime' => 604800, // 7 days
                 ],
+                'cache.trip_chat' => [
+                    'adapter' => 'cache.adapter.redis',
+                    'default_lifetime' => 1800, // 30 minutes — short-lived dialogue history
+                ],
             ],
         ],
     ]);
@@ -63,6 +67,9 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                         'adapter' => 'cache.adapter.array',
                     ],
                     'cache.wikidata' => [
+                        'adapter' => 'cache.adapter.array',
+                    ],
+                    'cache.trip_chat' => [
                         'adapter' => 'cache.adapter.array',
                     ],
                 ],

--- a/api/config/packages/rate_limiter.php
+++ b/api/config/packages/rate_limiter.php
@@ -43,6 +43,12 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 'interval' => '3600 seconds',
                 'cache_pool' => 'cache.rate_limiter',
             ],
+            'trip_chat' => [
+                'policy' => 'sliding_window',
+                'limit' => 20,
+                'interval' => '60 seconds',
+                'cache_pool' => 'cache.rate_limiter',
+            ],
         ],
         'cache' => [
             'pools' => [

--- a/api/src/ApiResource/Model/TripChatContext.php
+++ b/api/src/ApiResource/Model/TripChatContext.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ApiResource\Model;
+
+use ApiPlatform\Metadata\ApiProperty;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * Conversational context propagated with every chat request.
+ *
+ * Allows the dialogue assistant to resolve referential phrases such as « cette
+ * étape » against the stage the user is currently consulting in the UI.
+ */
+final class TripChatContext
+{
+    public function __construct(
+        #[Assert\Range(min: 1)]
+        #[ApiProperty(description: '1-indexed day number of the stage currently consulted, when applicable.')]
+        public ?int $currentStage = null,
+    ) {
+    }
+}

--- a/api/src/ApiResource/Trip.php
+++ b/api/src/ApiResource/Trip.php
@@ -15,6 +15,7 @@ use ApiPlatform\Metadata\Post;
 use ApiPlatform\OpenApi\Model\Operation;
 use App\State\AnalyzeTripProcessor;
 use App\State\TripBatchRecomputeProcessor;
+use App\State\TripChatProcessor;
 use App\State\TripCollectionProvider;
 use App\State\TripCreateProcessor;
 use App\State\TripDeleteProcessor;
@@ -101,6 +102,23 @@ use App\State\TripUpdateProcessor;
             mercure: true,
             provider: TripRequestProvider::class,
             processor: AnalyzeTripProcessor::class,
+        ),
+        new Post(
+            uriTemplate: '/trips/{id}/chat{._format}',
+            status: 200,
+            openapi: new Operation(
+                responses: [
+                    404 => new Response(description: 'Trip not found'),
+                    429 => new Response(description: 'Rate limit reached'),
+                    503 => new Response(description: 'AI assistant unavailable'),
+                ],
+                summary: 'Send a natural-language instruction to the LLaMA 3B dialogue assistant.',
+            ),
+            security: "is_granted('TRIP_EDIT', object)",
+            input: TripChatRequest::class,
+            output: TripChatResponse::class,
+            provider: TripRequestProvider::class,
+            processor: TripChatProcessor::class,
         ),
         new Post(
             uriTemplate: '/trips/{id}/recompute{._format}',

--- a/api/src/ApiResource/TripChatRequest.php
+++ b/api/src/ApiResource/TripChatRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ApiResource;
+
+use ApiPlatform\Metadata\ApiProperty;
+use App\ApiResource\Model\TripChatContext;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * Input DTO for the trip chat endpoint.
+ *
+ * Carries the user's natural-language message along with a small context object
+ * so the LLaMA 3B dialogue assistant can interpret stage-relative references.
+ */
+final class TripChatRequest
+{
+    public function __construct(
+        #[Assert\NotBlank]
+        #[Assert\Length(max: 2000)]
+        #[ApiProperty(description: 'Natural language instruction or question from the rider.')]
+        public string $message = '',
+        #[Assert\Valid]
+        #[ApiProperty(description: 'Conversational context (e.g. the stage currently consulted in the UI).')]
+        public ?TripChatContext $context = null,
+    ) {
+    }
+}

--- a/api/src/ApiResource/TripChatResponse.php
+++ b/api/src/ApiResource/TripChatResponse.php
@@ -20,18 +20,15 @@ final readonly class TripChatResponse
      * @param array<string, mixed> $params
      */
     public function __construct(
-        #[ApiProperty(description: 'Trip identifier (UUID v7) the chat exchange belongs to.')]
+        #[ApiProperty(description: 'Trip identifier (UUID v7) the chat exchange belongs to.', required: true)]
         public string $tripId,
-        #[ApiProperty(description: 'Action interpreted by the dialogue assistant (split_stage, info, ...).')]
+        #[ApiProperty(description: 'Action interpreted by the dialogue assistant (split_stage, info, ...).', required: true)]
         public string $action,
-        #[ApiProperty(
-            description: 'Parameters required to execute the action.',
-            schema: ['type' => 'object', 'additionalProperties' => true],
-        )]
+        #[ApiProperty(description: 'Parameters required to execute the action.', required: true, schema: ['type' => 'object', 'additionalProperties' => true])]
         public array $params,
-        #[ApiProperty(description: 'Conversational reply to display to the rider.')]
+        #[ApiProperty(description: 'Conversational reply to display to the rider.', required: true)]
         public string $response,
-        #[ApiProperty(description: 'True when the action triggered a backend recomputation.')]
+        #[ApiProperty(description: 'True when the action triggered a backend recomputation.', required: true)]
         public bool $dispatched = false,
     ) {
     }

--- a/api/src/ApiResource/TripChatResponse.php
+++ b/api/src/ApiResource/TripChatResponse.php
@@ -28,7 +28,7 @@ final readonly class TripChatResponse
         public array $params,
         #[ApiProperty(description: 'Conversational reply to display to the rider.', required: true)]
         public string $response,
-        #[ApiProperty(description: 'True when the action triggered a backend recomputation.', required: true)]
+        #[ApiProperty(description: 'True when this action will trigger a backend recomputation (Messenger dispatch wired in #311).', required: true)]
         public bool $dispatched = false,
     ) {
     }

--- a/api/src/ApiResource/TripChatResponse.php
+++ b/api/src/ApiResource/TripChatResponse.php
@@ -24,7 +24,10 @@ final readonly class TripChatResponse
         public string $tripId,
         #[ApiProperty(description: 'Action interpreted by the dialogue assistant (split_stage, info, ...).')]
         public string $action,
-        #[ApiProperty(description: 'Parameters required to execute the action.')]
+        #[ApiProperty(
+            description: 'Parameters required to execute the action.',
+            schema: ['type' => 'object', 'additionalProperties' => true],
+        )]
         public array $params,
         #[ApiProperty(description: 'Conversational reply to display to the rider.')]
         public string $response,

--- a/api/src/ApiResource/TripChatResponse.php
+++ b/api/src/ApiResource/TripChatResponse.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ApiResource;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+
+/**
+ * Output DTO for the trip chat endpoint.
+ *
+ * Contains the structured action interpreted by the dialogue assistant alongside
+ * the conversational response surfaced to the user in the chat panel.
+ */
+#[ApiResource(shortName: 'TripChat', operations: [])]
+final readonly class TripChatResponse
+{
+    /**
+     * @param array<string, mixed> $params
+     */
+    public function __construct(
+        #[ApiProperty(description: 'Trip identifier (UUID v7) the chat exchange belongs to.')]
+        public string $tripId,
+        #[ApiProperty(description: 'Action interpreted by the dialogue assistant (split_stage, info, ...).')]
+        public string $action,
+        #[ApiProperty(description: 'Parameters required to execute the action.')]
+        public array $params,
+        #[ApiProperty(description: 'Conversational reply to display to the rider.')]
+        public string $response,
+        #[ApiProperty(description: 'True when the action triggered a backend recomputation.')]
+        public bool $dispatched = false,
+    ) {
+    }
+}

--- a/api/src/Llm/ChatActionInterpreter.php
+++ b/api/src/Llm/ChatActionInterpreter.php
@@ -177,7 +177,11 @@ final readonly class ChatActionInterpreter
             return null;
         }
 
-        if ($second !== $first + 1) {
+        // Accept either order — the dialogue prompt asks for consecutive
+        // stages but does not constrain which one comes first. Downstream
+        // consumers normalise the surviving stage via min() before
+        // dispatching the recomputation.
+        if (1 !== abs($first - $second)) {
             return null;
         }
 

--- a/api/src/Llm/ChatActionInterpreter.php
+++ b/api/src/Llm/ChatActionInterpreter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Llm;
 
+use App\ApiResource\TripRequest;
 use App\Llm\Dto\ChatAction;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
@@ -216,11 +217,16 @@ final readonly class ChatActionInterpreter
         $stage = $this->toPositiveInt($params['stage'] ?? null);
         $type = $params['type'] ?? null;
 
-        if (null === $stage || !\is_string($type) || '' === trim($type)) {
+        if (null === $stage || !\is_string($type)) {
             return null;
         }
 
-        return ['stage' => $stage, 'type' => trim($type)];
+        $normalised = strtolower(trim($type));
+        if (!\in_array($normalised, TripRequest::ALL_ACCOMMODATION_TYPES, true)) {
+            return null;
+        }
+
+        return ['stage' => $stage, 'type' => $normalised];
     }
 
     /**

--- a/api/src/Llm/ChatActionInterpreter.php
+++ b/api/src/Llm/ChatActionInterpreter.php
@@ -1,0 +1,267 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Llm;
+
+use App\Llm\Dto\ChatAction;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+/**
+ * Parses the raw JSON emitted by LLaMA 3B (via the `dialogue` system prompt) into
+ * a typed {@see ChatAction} that the chat processor can dispatch.
+ *
+ * Robustness goals:
+ * - Tolerant to LLM noise: leading/trailing prose, Markdown code fences, smart quotes.
+ * - Never throws: invalid or unsupported payloads degrade to a safe `info` fallback
+ *   so the chat endpoint always returns a usable response.
+ * - Strict on action vocabulary: only the actions whitelisted in
+ *   {@see ChatAction::SUPPORTED_ACTIONS} are propagated; everything else collapses
+ *   to `info` with the model's `response` preserved.
+ */
+final readonly class ChatActionInterpreter
+{
+    public const string DEFAULT_FALLBACK_MESSAGE = "Je n'ai pas compris la demande. Pourriez-vous préciser ?";
+
+    public function __construct(
+        private LoggerInterface $logger = new NullLogger(),
+    ) {
+    }
+
+    /**
+     * Parses the raw assistant content (already extracted from the Ollama envelope).
+     *
+     * @param string $rawContent Raw text emitted by the model (expected to be a JSON object)
+     */
+    public function interpret(string $rawContent): ChatAction
+    {
+        $payload = $this->decodeJson($rawContent);
+
+        if (null === $payload) {
+            $this->logger->warning('Chat LLM response is not valid JSON.', [
+                'raw' => $this->truncate($rawContent),
+            ]);
+
+            return $this->fallback(self::DEFAULT_FALLBACK_MESSAGE);
+        }
+
+        $action = \is_string($payload['action'] ?? null) ? trim($payload['action']) : '';
+        $response = \is_string($payload['response'] ?? null) ? trim($payload['response']) : '';
+        $params = \is_array($payload['params'] ?? null) ? $payload['params'] : [];
+
+        if ('' === $response) {
+            $response = self::DEFAULT_FALLBACK_MESSAGE;
+        }
+
+        if (!\in_array($action, ChatAction::SUPPORTED_ACTIONS, true)) {
+            $this->logger->info('Chat LLM produced an unsupported action — falling back to info.', [
+                'action' => $action,
+            ]);
+
+            return new ChatAction(ChatAction::ACTION_INFO, [], $response);
+        }
+
+        $normalisedParams = $this->normaliseParams($action, $params);
+
+        if (null === $normalisedParams) {
+            $this->logger->info('Chat LLM produced invalid params for action — falling back to info.', [
+                'action' => $action,
+            ]);
+
+            return new ChatAction(ChatAction::ACTION_INFO, [], $response);
+        }
+
+        return new ChatAction($action, $normalisedParams, $response);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function decodeJson(string $rawContent): ?array
+    {
+        $candidate = trim($rawContent);
+
+        if ('' === $candidate) {
+            return null;
+        }
+
+        // Strip Markdown code fences (```json ... ```) when present.
+        if (str_starts_with($candidate, '```')) {
+            $candidate = preg_replace('/^```(?:json)?\s*/i', '', $candidate) ?? $candidate;
+            $candidate = preg_replace('/\s*```$/', '', $candidate) ?? $candidate;
+            $candidate = trim($candidate);
+        }
+
+        // Extract the first {...} block when the model wraps it in prose.
+        if (!str_starts_with($candidate, '{')) {
+            $start = strpos($candidate, '{');
+            $end = strrpos($candidate, '}');
+            if (false === $start || false === $end || $end <= $start) {
+                return null;
+            }
+            $candidate = substr($candidate, $start, $end - $start + 1);
+        }
+
+        try {
+            $decoded = json_decode($candidate, true, flags: \JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return null;
+        }
+
+        if (!\is_array($decoded)) {
+            return null;
+        }
+
+        /** @var array<string, mixed> $decoded */
+        return $decoded;
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     *
+     * @return array<string, mixed>|null Returns null when the params are invalid for the given action.
+     */
+    private function normaliseParams(string $action, array $params): ?array
+    {
+        return match ($action) {
+            ChatAction::ACTION_SPLIT_STAGE => $this->normaliseStageOnly($params),
+            ChatAction::ACTION_MERGE_STAGES => $this->normaliseMergeStages($params),
+            ChatAction::ACTION_ADD_WAYPOINT => $this->normaliseAddWaypoint($params),
+            ChatAction::ACTION_CHANGE_ACCOMMODATION => $this->normaliseChangeAccommodation($params),
+            ChatAction::ACTION_ADJUST_DISTANCE => $this->normaliseAdjustDistance($params),
+            ChatAction::ACTION_INFO => [],
+            default => null,
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     *
+     * @return array{stage: int}|null
+     */
+    private function normaliseStageOnly(array $params): ?array
+    {
+        $stage = $this->toPositiveInt($params['stage'] ?? null);
+
+        return null === $stage ? null : ['stage' => $stage];
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     *
+     * @return array{stages: array{int, int}}|null
+     */
+    private function normaliseMergeStages(array $params): ?array
+    {
+        $raw = $params['stages'] ?? null;
+        if (!\is_array($raw) || 2 !== \count($raw)) {
+            return null;
+        }
+
+        $values = array_values($raw);
+        $first = $this->toPositiveInt($values[0]);
+        $second = $this->toPositiveInt($values[1]);
+
+        if (null === $first || null === $second) {
+            return null;
+        }
+
+        if ($second !== $first + 1) {
+            return null;
+        }
+
+        return ['stages' => [$first, $second]];
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     *
+     * @return array{name: string, stage: int|null}|null
+     */
+    private function normaliseAddWaypoint(array $params): ?array
+    {
+        $name = $params['name'] ?? null;
+        if (!\is_string($name) || '' === trim($name)) {
+            return null;
+        }
+
+        $stage = null;
+        if (\array_key_exists('stage', $params) && null !== $params['stage']) {
+            $stage = $this->toPositiveInt($params['stage']);
+            if (null === $stage) {
+                return null;
+            }
+        }
+
+        return ['name' => trim($name), 'stage' => $stage];
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     *
+     * @return array{stage: int, type: string}|null
+     */
+    private function normaliseChangeAccommodation(array $params): ?array
+    {
+        $stage = $this->toPositiveInt($params['stage'] ?? null);
+        $type = $params['type'] ?? null;
+
+        if (null === $stage || !\is_string($type) || '' === trim($type)) {
+            return null;
+        }
+
+        return ['stage' => $stage, 'type' => trim($type)];
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     *
+     * @return array{stage: int, km: float}|null
+     */
+    private function normaliseAdjustDistance(array $params): ?array
+    {
+        $stage = $this->toPositiveInt($params['stage'] ?? null);
+        $km = $params['km'] ?? null;
+
+        if (null === $stage) {
+            return null;
+        }
+
+        if (!\is_int($km) && !\is_float($km)) {
+            return null;
+        }
+
+        $kmFloat = (float) $km;
+        if ($kmFloat <= 0.0) {
+            return null;
+        }
+
+        return ['stage' => $stage, 'km' => $kmFloat];
+    }
+
+    private function toPositiveInt(mixed $value): ?int
+    {
+        if (\is_int($value) && $value > 0) {
+            return $value;
+        }
+
+        if (\is_string($value) && ctype_digit($value)) {
+            $int = (int) $value;
+
+            return $int > 0 ? $int : null;
+        }
+
+        return null;
+    }
+
+    private function fallback(string $message): ChatAction
+    {
+        return new ChatAction(ChatAction::ACTION_INFO, [], $message);
+    }
+
+    private function truncate(string $value): string
+    {
+        return mb_strlen($value) > 500 ? mb_substr($value, 0, 500).'…' : $value;
+    }
+}

--- a/api/src/Llm/ChatActionInterpreter.php
+++ b/api/src/Llm/ChatActionInterpreter.php
@@ -100,6 +100,7 @@ final readonly class ChatActionInterpreter
             if (false === $start || false === $end || $end <= $start) {
                 return null;
             }
+
             $candidate = substr($candidate, $start, $end - $start + 1);
         }
 
@@ -113,14 +114,22 @@ final readonly class ChatActionInterpreter
             return null;
         }
 
-        /** @var array<string, mixed> $decoded */
-        return $decoded;
+        $result = [];
+        foreach ($decoded as $key => $value) {
+            if (!\is_string($key)) {
+                return null;
+            }
+
+            $result[$key] = $value;
+        }
+
+        return $result;
     }
 
     /**
      * @param array<string, mixed> $params
      *
-     * @return array<string, mixed>|null Returns null when the params are invalid for the given action.
+     * @return array<string, mixed>|null returns null when the params are invalid for the given action
      */
     private function normaliseParams(string $action, array $params): ?array
     {

--- a/api/src/Llm/ChatHistoryStore.php
+++ b/api/src/Llm/ChatHistoryStore.php
@@ -39,8 +39,20 @@ final readonly class ChatHistoryStore
             return [];
         }
 
-        /** @var list<array{role: string, content: string}> $value */
-        return $value;
+        $result = [];
+        foreach ($value as $entry) {
+            if (!\is_array($entry)
+                || !isset($entry['role'], $entry['content'])
+                || !\is_string($entry['role'])
+                || !\is_string($entry['content'])
+            ) {
+                continue;
+            }
+
+            $result[] = ['role' => $entry['role'], 'content' => $entry['content']];
+        }
+
+        return $result;
     }
 
     public function append(string $tripId, string $userId, string $role, string $content): void
@@ -50,11 +62,12 @@ final readonly class ChatHistoryStore
 
         if (\count($history) > self::MAX_MESSAGES) {
             $history = \array_slice($history, -self::MAX_MESSAGES);
-            /** @var list<array{role: string, content: string}> $history */
+            /* @var list<array{role: string, content: string}> $history */
         }
 
         $item = $this->cache->getItem($this->key($tripId, $userId));
         $item->set($history);
+
         $this->cache->save($item);
     }
 

--- a/api/src/Llm/ChatHistoryStore.php
+++ b/api/src/Llm/ChatHistoryStore.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Llm;
+
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * Short-lived per-(trip, user) dialogue history backed by Redis.
+ *
+ * Only the last {@see self::MAX_MESSAGES} turns are kept so the prompt window
+ * stays bounded for LLaMA 3B inference. Entries are stored as plain `{role,
+ * content}` arrays compatible with the Ollama chat API.
+ */
+final readonly class ChatHistoryStore
+{
+    public const int MAX_MESSAGES = 5;
+
+    public function __construct(
+        #[Autowire(service: 'cache.trip_chat')]
+        private CacheItemPoolInterface $cache,
+    ) {
+    }
+
+    /**
+     * @return list<array{role: string, content: string}>
+     */
+    public function get(string $tripId, string $userId): array
+    {
+        $item = $this->cache->getItem($this->key($tripId, $userId));
+        if (!$item->isHit()) {
+            return [];
+        }
+
+        $value = $item->get();
+        if (!\is_array($value)) {
+            return [];
+        }
+
+        /** @var list<array{role: string, content: string}> $value */
+        return $value;
+    }
+
+    public function append(string $tripId, string $userId, string $role, string $content): void
+    {
+        $history = $this->get($tripId, $userId);
+        $history[] = ['role' => $role, 'content' => $content];
+
+        if (\count($history) > self::MAX_MESSAGES) {
+            $history = \array_slice($history, -self::MAX_MESSAGES);
+            /** @var list<array{role: string, content: string}> $history */
+        }
+
+        $item = $this->cache->getItem($this->key($tripId, $userId));
+        $item->set($history);
+        $this->cache->save($item);
+    }
+
+    private function key(string $tripId, string $userId): string
+    {
+        return \sprintf('trip.%s.user.%s.chat', $tripId, $userId);
+    }
+}

--- a/api/src/Llm/ChatHistoryStore.php
+++ b/api/src/Llm/ChatHistoryStore.php
@@ -57,12 +57,25 @@ final readonly class ChatHistoryStore
 
     public function append(string $tripId, string $userId, string $role, string $content): void
     {
+        $this->appendMany($tripId, $userId, [['role' => $role, 'content' => $content]]);
+    }
+
+    /**
+     * @param list<array{role: string, content: string}> $messages
+     */
+    public function appendMany(string $tripId, string $userId, array $messages): void
+    {
+        if ([] === $messages) {
+            return;
+        }
+
         $history = $this->get($tripId, $userId);
-        $history[] = ['role' => $role, 'content' => $content];
+        foreach ($messages as $message) {
+            $history[] = $message;
+        }
 
         if (\count($history) > self::MAX_MESSAGES) {
             $history = \array_slice($history, -self::MAX_MESSAGES);
-            /* @var list<array{role: string, content: string}> $history */
         }
 
         $item = $this->cache->getItem($this->key($tripId, $userId));

--- a/api/src/Llm/ChatHistoryStore.php
+++ b/api/src/Llm/ChatHistoryStore.php
@@ -30,11 +30,44 @@ final readonly class ChatHistoryStore
     public function get(string $tripId, string $userId): array
     {
         $item = $this->cache->getItem($this->key($tripId, $userId));
-        if (!$item->isHit()) {
-            return [];
+
+        return $item->isHit() ? $this->sanitize($item->get()) : [];
+    }
+
+    public function append(string $tripId, string $userId, string $role, string $content): void
+    {
+        $this->appendMany($tripId, $userId, [['role' => $role, 'content' => $content]]);
+    }
+
+    /**
+     * @param list<array{role: string, content: string}> $messages
+     */
+    public function appendMany(string $tripId, string $userId, array $messages): void
+    {
+        if ([] === $messages) {
+            return;
         }
 
-        $value = $item->get();
+        $item = $this->cache->getItem($this->key($tripId, $userId));
+        $history = $item->isHit() ? $this->sanitize($item->get()) : [];
+
+        foreach ($messages as $message) {
+            $history[] = $message;
+        }
+
+        if (\count($history) > self::MAX_MESSAGES) {
+            $history = \array_slice($history, -self::MAX_MESSAGES);
+        }
+
+        $item->set($history);
+        $this->cache->save($item);
+    }
+
+    /**
+     * @return list<array{role: string, content: string}>
+     */
+    private function sanitize(mixed $value): array
+    {
         if (!\is_array($value)) {
             return [];
         }
@@ -53,35 +86,6 @@ final readonly class ChatHistoryStore
         }
 
         return $result;
-    }
-
-    public function append(string $tripId, string $userId, string $role, string $content): void
-    {
-        $this->appendMany($tripId, $userId, [['role' => $role, 'content' => $content]]);
-    }
-
-    /**
-     * @param list<array{role: string, content: string}> $messages
-     */
-    public function appendMany(string $tripId, string $userId, array $messages): void
-    {
-        if ([] === $messages) {
-            return;
-        }
-
-        $history = $this->get($tripId, $userId);
-        foreach ($messages as $message) {
-            $history[] = $message;
-        }
-
-        if (\count($history) > self::MAX_MESSAGES) {
-            $history = \array_slice($history, -self::MAX_MESSAGES);
-        }
-
-        $item = $this->cache->getItem($this->key($tripId, $userId));
-        $item->set($history);
-
-        $this->cache->save($item);
     }
 
     private function key(string $tripId, string $userId): string

--- a/api/src/Llm/Dto/ChatAction.php
+++ b/api/src/Llm/Dto/ChatAction.php
@@ -15,10 +15,15 @@ namespace App\Llm\Dto;
 final readonly class ChatAction
 {
     public const string ACTION_SPLIT_STAGE = 'split_stage';
+
     public const string ACTION_MERGE_STAGES = 'merge_stages';
+
     public const string ACTION_ADD_WAYPOINT = 'add_waypoint';
+
     public const string ACTION_CHANGE_ACCOMMODATION = 'change_accommodation';
+
     public const string ACTION_ADJUST_DISTANCE = 'adjust_distance';
+
     public const string ACTION_INFO = 'info';
 
     /**

--- a/api/src/Llm/Dto/ChatAction.php
+++ b/api/src/Llm/Dto/ChatAction.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Llm\Dto;
+
+/**
+ * Parsed LLaMA 3B chat brief.
+ *
+ * Produced by {@see \App\Llm\ChatActionInterpreter} from the JSON envelope emitted
+ * by the dialogue system prompt. The processor uses {@see self::$action} to decide
+ * whether to dispatch Messenger messages and forwards {@see self::$response} to
+ * the frontend as the conversational reply.
+ */
+final readonly class ChatAction
+{
+    public const string ACTION_SPLIT_STAGE = 'split_stage';
+    public const string ACTION_MERGE_STAGES = 'merge_stages';
+    public const string ACTION_ADD_WAYPOINT = 'add_waypoint';
+    public const string ACTION_CHANGE_ACCOMMODATION = 'change_accommodation';
+    public const string ACTION_ADJUST_DISTANCE = 'adjust_distance';
+    public const string ACTION_INFO = 'info';
+
+    /**
+     * @var list<string>
+     */
+    public const array SUPPORTED_ACTIONS = [
+        self::ACTION_SPLIT_STAGE,
+        self::ACTION_MERGE_STAGES,
+        self::ACTION_ADD_WAYPOINT,
+        self::ACTION_CHANGE_ACCOMMODATION,
+        self::ACTION_ADJUST_DISTANCE,
+        self::ACTION_INFO,
+    ];
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    public function __construct(
+        public string $action,
+        public array $params,
+        public string $response,
+    ) {
+    }
+}

--- a/api/src/Llm/SystemPrompt/dialogue.txt
+++ b/api/src/Llm/SystemPrompt/dialogue.txt
@@ -50,7 +50,7 @@ texte avant ni après. Schéma :
 | `split_stage`         | `{ "stage": <int> }`                           | Découpe l'étape indiquée en deux étapes.            |
 | `merge_stages`        | `{ "stages": [<int>, <int>] }`                 | Fusionne deux étapes consécutives.                  |
 | `add_waypoint`        | `{ "name": <string>, "stage": <int|null> }`    | Ajoute un point d'intérêt (détour) à l'itinéraire. |
-| `change_accommodation`| `{ "stage": <int>, "type": <string> }`         | Change le type d'hébergement de l'étape.            |
+| `change_accommodation`| `{ "stage": <int>, "type": <string> }`         | Change le type d'hébergement (valeurs autorisées : `camp_site`, `hostel`, `alpine_hut`, `chalet`, `guest_house`, `motel`, `hotel`, `wilderness_hut`, `shelter`). |
 | `adjust_distance`     | `{ "stage": <int>, "km": <number> }`           | Modifie la distance cible d'une étape.              |
 | `info`                | `{}`                                           | Question d'information : pas de modification.       |
 
@@ -94,7 +94,7 @@ Utilisateur : « Sur cette étape je préférerais dormir en gîte plutôt qu'en
 (contexte : currentStage = 2)
 {
   "action": "change_accommodation",
-  "params": { "stage": 2, "type": "gite" },
+  "params": { "stage": 2, "type": "guest_house" },
   "response": "Je remplace l'hébergement de l'étape 2 par un gîte. Je relance la recherche pour trouver les meilleures options sur place."
 }
 

--- a/api/src/Llm/SystemPrompt/dialogue.txt
+++ b/api/src/Llm/SystemPrompt/dialogue.txt
@@ -78,9 +78,9 @@ Utilisateur : « Coupe l'étape 3 en deux »
 
 Utilisateur : « Évite les routes à trafic sur l'étape 4 »
 {
-  "action": "avoid_traffic",
-  "params": { "stage": 4 },
-  "response": "Je recalcule l'étape 4 en privilégiant les voies vertes et les routes secondaires à faible trafic."
+  "action": "info",
+  "params": {},
+  "response": "Je ne peux pas encore recalculer l'itinéraire pour éviter le trafic. Vous pouvez me demander de découper ou fusionner une étape, d'ajouter un point de passage, de changer l'hébergement ou d'ajuster la distance cible."
 }
 
 Utilisateur : « Ajoute un détour par le Mont Cassel »

--- a/api/src/Llm/SystemPrompt/dialogue.txt
+++ b/api/src/Llm/SystemPrompt/dialogue.txt
@@ -1,0 +1,113 @@
+Tu es un assistant cyclotourisme bienveillant, concis et pragmatique, intégré à une
+application de planification de voyage à vélo (bikepacking, gravel, randonnée, VAE).
+Ton rôle est d'interpréter les demandes en langage naturel d'un cyclotouriste pour
+ajuster son itinéraire et de répondre clairement, en français, sans jargon inutile.
+
+# Domaine et terminologie
+
+- Utilise correctement le vocabulaire cyclo : étape, distance, dénivelé (D+/D-),
+  surface (asphalte, gravier, chemin, pavé, voie verte, piste cyclable), col,
+  raidillon, faux-plat, ravitaillement, point d'eau, bivouac, gîte, refuge,
+  camping, autonomie.
+- Profils cyclistes possibles : randonneur, gravel/bikepacker, VAE/e-bike, famille,
+  vélo de route, VTC.
+- Contexte géographique : France, Belgique, Pays-Bas (EuroVelo, voies vertes, RAVeL,
+  V-routes belges, LF-routes néerlandaises). Adapte les noms de lieux à ce contexte.
+- Système métrique uniquement (kilomètres, mètres). Pas de miles.
+
+# Contexte fourni par l'application
+
+À chaque message tu peux recevoir des informations contextuelles :
+- `currentStage` : numéro de l'étape actuellement consultée par l'utilisateur (ou
+  `null` si aucune étape n'est sélectionnée). Si l'utilisateur dit « cette étape »,
+  utilise `currentStage`.
+- Historique des derniers échanges (au plus 5 messages) pour maintenir une continuité
+  conversationnelle.
+
+# Format de sortie : JSON strict
+
+Tu DOIS répondre EXCLUSIVEMENT avec un objet JSON valide, sans bloc de code, sans
+texte avant ni après. Schéma :
+
+```json
+{
+  "action": "<nom_action>",
+  "params": { ... },
+  "response": "<réponse conversationnelle en français>"
+}
+```
+
+- `action` : nom court en snake_case parmi la liste des actions supportées.
+- `params` : objet contenant les paramètres requis par l'action (peut être vide).
+- `response` : 1 à 3 phrases en français, ton chaleureux et factuel, qui confirment
+  ce que tu vas faire ou répondent à la question. Cette chaîne est affichée à
+  l'utilisateur dans l'interface de chat.
+
+# Actions supportées
+
+| action                | params                                         | effet                                               |
+| --------------------- | ---------------------------------------------- | --------------------------------------------------- |
+| `split_stage`         | `{ "stage": <int> }`                           | Découpe l'étape indiquée en deux étapes.            |
+| `merge_stages`        | `{ "stages": [<int>, <int>] }`                 | Fusionne deux étapes consécutives.                  |
+| `add_waypoint`        | `{ "name": <string>, "stage": <int|null> }`    | Ajoute un point d'intérêt (détour) à l'itinéraire. |
+| `change_accommodation`| `{ "stage": <int>, "type": <string> }`         | Change le type d'hébergement de l'étape.            |
+| `adjust_distance`     | `{ "stage": <int>, "km": <number> }`           | Modifie la distance cible d'une étape.              |
+| `info`                | `{}`                                           | Question d'information : pas de modification.       |
+
+Si la demande ne correspond à aucune action, utilise `info` et explique simplement
+dans `response` (par exemple : terminologie, suggestion, encouragement).
+
+# Règles strictes
+
+- N'invente jamais de numéro d'étape : si l'utilisateur dit « cette étape » et que
+  `currentStage` vaut `null`, demande de préciser dans `response` avec l'action
+  `info`.
+- N'imagine pas d'actions ou de paramètres en dehors du tableau ci-dessus.
+- Pas d'emoji, pas de Markdown, pas de balises HTML dans `response`.
+- Pas de bloc de code dans la sortie. Pas de phrase d'introduction du type « Voici
+  la réponse JSON ».
+
+# Exemples
+
+Utilisateur : « Coupe l'étape 3 en deux »
+{
+  "action": "split_stage",
+  "params": { "stage": 3 },
+  "response": "Très bien, je découpe l'étape 3 en deux étapes plus courtes pour adoucir le rythme."
+}
+
+Utilisateur : « Évite les routes à trafic sur l'étape 4 »
+{
+  "action": "avoid_traffic",
+  "params": { "stage": 4 },
+  "response": "Je recalcule l'étape 4 en privilégiant les voies vertes et les routes secondaires à faible trafic."
+}
+
+Utilisateur : « Ajoute un détour par le Mont Cassel »
+{
+  "action": "add_waypoint",
+  "params": { "name": "Mont Cassel", "stage": null },
+  "response": "J'ajoute un crochet par le Mont Cassel : c'est un beau belvédère, le détour vaut le coup."
+}
+
+Utilisateur : « Sur cette étape je préférerais dormir en gîte plutôt qu'en camping »
+(contexte : currentStage = 2)
+{
+  "action": "change_accommodation",
+  "params": { "stage": 2, "type": "gite" },
+  "response": "Je remplace l'hébergement de l'étape 2 par un gîte. Je relance la recherche pour trouver les meilleures options sur place."
+}
+
+Utilisateur : « Allonge l'étape 5 à 95 km »
+{
+  "action": "adjust_distance",
+  "params": { "stage": 5, "km": 95 },
+  "response": "Je porte l'étape 5 à 95 km. Je revérifie le profil et le timing d'arrivée pour confirmer que ça reste tenable."
+}
+
+Utilisateur : « Quelle est la différence entre gravel et bikepacking ? »
+{
+  "action": "info",
+  "params": {},
+  "response": "Le gravel désigne le type de vélo et de surface (routes blanches, chemins roulants). Le bikepacking décrit le style de voyage : itinérant, autonome, avec un matériel léger fixé sur le vélo. On peut tout à fait faire du bikepacking en gravel."
+}

--- a/api/src/State/TripChatProcessor.php
+++ b/api/src/State/TripChatProcessor.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\State;
 
-use App\ApiResource\TripRequest;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\Metadata\Post;
 use ApiPlatform\State\ProcessorInterface;
@@ -17,7 +16,6 @@ use App\Llm\Dto\ChatAction;
 use App\Llm\Exception\OllamaUnavailableException;
 use App\Llm\LlmClientInterface;
 use App\Llm\SystemPromptLoader;
-use App\Repository\TripRequestRepositoryInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
@@ -73,7 +71,6 @@ final readonly class TripChatProcessor implements ProcessorInterface
     private string $model;
 
     public function __construct(
-        private TripRequestRepositoryInterface $tripStateManager,
         private LlmClientInterface $llmClient,
         private SystemPromptLoader $promptLoader,
         private ChatActionInterpreter $interpreter,
@@ -109,6 +106,16 @@ final readonly class TripChatProcessor implements ProcessorInterface
 
         $userId = $user->getId()->toRfc4122();
 
+        // Trip existence is guaranteed by TripRequestProvider — wired as the
+        // operation's provider, it throws NotFoundHttpException before this
+        // processor is entered. Don't re-read the cache here.
+
+        // Feature-flag guard before consuming a rate-limit token, so a user
+        // hitting a disabled endpoint doesn't burn their 20 req/min quota.
+        if (!$this->llmClient->isEnabled()) {
+            throw new ServiceUnavailableHttpException(retryAfter: null, message: 'AI assistant is currently disabled.');
+        }
+
         $limiter = $this->tripChatLimiter->create($userId);
         $rateLimit = $limiter->consume();
         if (!$rateLimit->isAccepted()) {
@@ -116,15 +123,6 @@ final readonly class TripChatProcessor implements ProcessorInterface
             $secondsUntilRetry = max(0, $retryAfter->getTimestamp() - new \DateTimeImmutable()->getTimestamp());
 
             throw new TooManyRequestsHttpException(retryAfter: $secondsUntilRetry, message: 'Chat rate limit reached. Please wait a moment before retrying.');
-        }
-
-        $request = $this->tripStateManager->getRequest($tripId);
-        if (!$request instanceof TripRequest) {
-            throw new NotFoundHttpException(\sprintf('Trip "%s" not found or has expired.', $tripId));
-        }
-
-        if (!$this->llmClient->isEnabled()) {
-            throw new ServiceUnavailableHttpException(retryAfter: null, message: 'AI assistant is currently disabled.');
         }
 
         $systemPrompt = $this->promptLoader->load(self::PROMPT_NAME);

--- a/api/src/State/TripChatProcessor.php
+++ b/api/src/State/TripChatProcessor.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\State;
 
+use App\ApiResource\TripRequest;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\Metadata\Post;
 use ApiPlatform\State\ProcessorInterface;
@@ -114,7 +115,7 @@ final readonly class TripChatProcessor implements ProcessorInterface
         }
 
         $request = $this->tripStateManager->getRequest($tripId);
-        if (null === $request) {
+        if (!$request instanceof TripRequest) {
             throw new NotFoundHttpException(\sprintf('Trip "%s" not found or has expired.', $tripId));
         }
 
@@ -144,7 +145,7 @@ final readonly class TripChatProcessor implements ProcessorInterface
                 'error' => $ollamaUnavailableException->getMessage(),
             ]);
 
-            throw new ServiceUnavailableHttpException(retryAfter: null, message: 'AI assistant is temporarily unavailable. Please retry shortly.');
+            throw new ServiceUnavailableHttpException(retryAfter: null, message: 'AI assistant is temporarily unavailable. Please retry shortly.', previous: $ollamaUnavailableException);
         }
 
         if (null === $response) {

--- a/api/src/State/TripChatProcessor.php
+++ b/api/src/State/TripChatProcessor.php
@@ -161,8 +161,10 @@ final readonly class TripChatProcessor implements ProcessorInterface
 
         $action = $this->interpreter->interpret($rawContent);
 
-        $this->historyStore->append($tripId, $userId, 'user', $userMessage);
-        $this->historyStore->append($tripId, $userId, 'assistant', $rawContent);
+        $this->historyStore->appendMany($tripId, $userId, [
+            ['role' => 'user', 'content' => $userMessage],
+            ['role' => 'assistant', 'content' => $rawContent],
+        ]);
 
         $dispatched = \in_array($action->action, self::RECOMPUTE_ACTIONS, true);
 

--- a/api/src/State/TripChatProcessor.php
+++ b/api/src/State/TripChatProcessor.php
@@ -110,8 +110,12 @@ final readonly class TripChatProcessor implements ProcessorInterface
         $userId = $user->getId()->toRfc4122();
 
         $limiter = $this->tripChatLimiter->create($userId);
-        if (!$limiter->consume()->isAccepted()) {
-            throw new TooManyRequestsHttpException(message: 'Chat rate limit reached. Please wait a moment before retrying.');
+        $rateLimit = $limiter->consume();
+        if (!$rateLimit->isAccepted()) {
+            $retryAfter = $rateLimit->getRetryAfter();
+            $secondsUntilRetry = max(0, $retryAfter->getTimestamp() - new \DateTimeImmutable()->getTimestamp());
+
+            throw new TooManyRequestsHttpException(retryAfter: $secondsUntilRetry, message: 'Chat rate limit reached. Please wait a moment before retrying.');
         }
 
         $request = $this->tripStateManager->getRequest($tripId);
@@ -149,7 +153,7 @@ final readonly class TripChatProcessor implements ProcessorInterface
         }
 
         if (null === $response) {
-            throw new ServiceUnavailableHttpException(retryAfter: null, message: 'AI assistant is currently disabled.');
+            throw new ServiceUnavailableHttpException(retryAfter: null, message: 'AI assistant returned an empty response. Please retry.');
         }
 
         $rawContent = $this->extractText($response);

--- a/api/src/State/TripChatProcessor.php
+++ b/api/src/State/TripChatProcessor.php
@@ -1,0 +1,214 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\State\ProcessorInterface;
+use App\ApiResource\TripChatRequest;
+use App\ApiResource\TripChatResponse;
+use App\Entity\User;
+use App\Llm\ChatActionInterpreter;
+use App\Llm\ChatHistoryStore;
+use App\Llm\Dto\ChatAction;
+use App\Llm\Exception\OllamaUnavailableException;
+use App\Llm\LlmClientInterface;
+use App\Llm\SystemPromptLoader;
+use App\Repository\TripRequestRepositoryInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+
+/**
+ * Handles `POST /trips/{id}/chat`: orchestrates the LLaMA 3B dialogue assistant.
+ *
+ * Pipeline:
+ * 1. Enforce a per-user rate limit (20 req/min) to protect the local LLM.
+ * 2. Verify the trip exists; load minimal context for the dialogue prompt.
+ * 3. Build the chat history (last {@see ChatHistoryStore::MAX_MESSAGES} turns)
+ *    plus the new user message, and call {@see LlmClientInterface::chat()}.
+ * 4. Parse the JSON envelope into a {@see ChatAction} via {@see ChatActionInterpreter}.
+ * 5. Flag the response as `dispatched` for actions that require recomputation
+ *    (the actual Messenger wiring is delivered by a follow-up issue).
+ *
+ * When the LLM is disabled or unreachable, the endpoint returns 503 so the
+ * frontend can show a clear error instead of a vague fallback message.
+ *
+ * @implements ProcessorInterface<TripChatRequest, TripChatResponse>
+ */
+final readonly class TripChatProcessor implements ProcessorInterface
+{
+    public const string PROMPT_NAME = 'dialogue';
+
+    public const string DEFAULT_MODEL = 'llama3.2:3b';
+
+    public const int MAX_RESPONSE_TOKENS = 600;
+
+    /**
+     * Actions that mutate the trip and therefore require backend recomputation.
+     *
+     * The actual Messenger dispatch is intentionally deferred to a follow-up
+     * issue (#311): the chat endpoint signals the intent via `dispatched=true`
+     * so the frontend can show a "computing" state, while the message routing
+     * itself remains a single point to extend.
+     *
+     * @var list<string>
+     */
+    private const array RECOMPUTE_ACTIONS = [
+        ChatAction::ACTION_SPLIT_STAGE,
+        ChatAction::ACTION_MERGE_STAGES,
+        ChatAction::ACTION_ADD_WAYPOINT,
+        ChatAction::ACTION_CHANGE_ACCOMMODATION,
+        ChatAction::ACTION_ADJUST_DISTANCE,
+    ];
+
+    private string $model;
+
+    public function __construct(
+        private TripRequestRepositoryInterface $tripStateManager,
+        private LlmClientInterface $llmClient,
+        private SystemPromptLoader $promptLoader,
+        private ChatActionInterpreter $interpreter,
+        private ChatHistoryStore $historyStore,
+        private Security $security,
+        private LoggerInterface $logger,
+        #[Autowire(service: 'limiter.trip_chat')]
+        private RateLimiterFactory $tripChatLimiter,
+        #[Autowire(env: 'default::OLLAMA_DIALOGUE_MODEL')]
+        ?string $model = null,
+    ) {
+        $this->model = (null === $model || '' === $model) ? self::DEFAULT_MODEL : $model;
+    }
+
+    /**
+     * @param TripChatRequest    $data
+     * @param Post               $operation
+     * @param array{id?: string} $uriVariables
+     */
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): TripChatResponse
+    {
+        \assert($data instanceof TripChatRequest);
+
+        $tripId = $uriVariables['id'] ?? '';
+        if ('' === $tripId) {
+            throw new NotFoundHttpException('Trip not found.');
+        }
+
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new HttpException(401, 'Authentication required.');
+        }
+
+        $userId = $user->getId()->toRfc4122();
+
+        $limiter = $this->tripChatLimiter->create($userId);
+        if (!$limiter->consume()->isAccepted()) {
+            throw new TooManyRequestsHttpException(message: 'Chat rate limit reached. Please wait a moment before retrying.');
+        }
+
+        $request = $this->tripStateManager->getRequest($tripId);
+        if (null === $request) {
+            throw new NotFoundHttpException(\sprintf('Trip "%s" not found or has expired.', $tripId));
+        }
+
+        if (!$this->llmClient->isEnabled()) {
+            throw new ServiceUnavailableHttpException(retryAfter: null, message: 'AI assistant is currently disabled.');
+        }
+
+        $systemPrompt = $this->promptLoader->load(self::PROMPT_NAME);
+        $userMessage = $this->buildUserMessage($data);
+        $history = $this->historyStore->get($tripId, $userId);
+
+        $messages = [...$history, ['role' => 'user', 'content' => $userMessage]];
+
+        try {
+            $response = $this->llmClient->chat(
+                model: $this->model,
+                messages: $messages,
+                systemPrompt: $systemPrompt,
+                options: [
+                    'format' => 'json',
+                    'num_predict' => self::MAX_RESPONSE_TOKENS,
+                ],
+            );
+        } catch (OllamaUnavailableException $ollamaUnavailableException) {
+            $this->logger->warning('Ollama unreachable — chat endpoint returning 503.', [
+                'tripId' => $tripId,
+                'error' => $ollamaUnavailableException->getMessage(),
+            ]);
+
+            throw new ServiceUnavailableHttpException(retryAfter: null, message: 'AI assistant is temporarily unavailable. Please retry shortly.');
+        }
+
+        if (null === $response) {
+            throw new ServiceUnavailableHttpException(retryAfter: null, message: 'AI assistant is currently disabled.');
+        }
+
+        $rawContent = $this->extractText($response);
+        if (null === $rawContent) {
+            $this->logger->warning('Ollama chat response missing message content.', ['tripId' => $tripId]);
+
+            throw new ServiceUnavailableHttpException(retryAfter: null, message: 'AI assistant returned an invalid response. Please retry.');
+        }
+
+        $action = $this->interpreter->interpret($rawContent);
+
+        $this->historyStore->append($tripId, $userId, 'user', $userMessage);
+        $this->historyStore->append($tripId, $userId, 'assistant', $rawContent);
+
+        $dispatched = \in_array($action->action, self::RECOMPUTE_ACTIONS, true);
+
+        if ($dispatched) {
+            $this->logger->info('Chat action ready for recomputation.', [
+                'tripId' => $tripId,
+                'action' => $action->action,
+                'params' => $action->params,
+            ]);
+        }
+
+        return new TripChatResponse(
+            tripId: $tripId,
+            action: $action->action,
+            params: $action->params,
+            response: $action->response,
+            dispatched: $dispatched,
+        );
+    }
+
+    private function buildUserMessage(TripChatRequest $request): string
+    {
+        $currentStage = $request->context?->currentStage;
+        $contextLine = \sprintf(
+            "[contexte] currentStage=%s\n",
+            null === $currentStage ? 'null' : (string) $currentStage,
+        );
+
+        return $contextLine.$request->message;
+    }
+
+    /**
+     * @param array<string, mixed> $response
+     */
+    private function extractText(array $response): ?string
+    {
+        if (isset($response['message']) && \is_array($response['message'])) {
+            $content = $response['message']['content'] ?? null;
+            if (\is_string($content)) {
+                return $content;
+            }
+        }
+
+        if (isset($response['response']) && \is_string($response['response'])) {
+            return $response['response'];
+        }
+
+        return null;
+    }
+}

--- a/api/tests/Functional/TripChatTest.php
+++ b/api/tests/Functional/TripChatTest.php
@@ -144,6 +144,27 @@ final class TripChatTest extends ApiTestCase
     }
 
     #[Test]
+    public function chatReturns503WhenLlmEnabledButReturnsNull(): void
+    {
+        $this->seedTrip(self::TRIP_ID);
+
+        // Edge case: client reports as enabled but chat() returns null. The
+        // dedicated 503 wording for this branch is otherwise untested.
+        $this->installFakeLlmClient(new FakeLlmClient(response: null, enabled: true));
+
+        $this->client->request(
+            'POST',
+            \sprintf('/trips/%s/chat', self::TRIP_ID),
+            [
+                'json' => ['message' => 'Bonjour'],
+                'headers' => ['Content-Type' => 'application/ld+json', ...$this->authHeader($this->jwtToken)],
+            ],
+        );
+
+        $this->assertResponseStatusCodeSame(503);
+    }
+
+    #[Test]
     public function chatReturns503WhenOllamaUnreachable(): void
     {
         $this->seedTrip(self::TRIP_ID);

--- a/api/tests/Functional/TripChatTest.php
+++ b/api/tests/Functional/TripChatTest.php
@@ -1,0 +1,304 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Symfony\Bundle\Test\Client;
+use App\ApiResource\TripRequest;
+use App\Entity\User;
+use App\Llm\Exception\OllamaUnavailableException;
+use App\Llm\LlmClientInterface;
+use App\Repository\TripRequestRepositoryInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Uid\Uuid;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+use Zenstruck\Foundry\Test\Factories;
+
+#[ResetDatabase]
+final class TripChatTest extends ApiTestCase
+{
+    use Factories;
+    use JwtAuthTestTrait;
+
+    private const string TRIP_ID = '01936f6e-0000-7000-8000-000000000099';
+
+    private Client $client;
+
+    private User $testUser;
+
+    private string $jwtToken;
+
+    protected function setUp(): void
+    {
+        $this->client = self::createClient();
+        ['user' => $this->testUser, 'token' => $this->jwtToken] = $this->createTestUserWithJwt('chat@example.com');
+    }
+
+    private function seedTrip(string $tripId): void
+    {
+        /** @var TripRequestRepositoryInterface $repo */
+        $repo = self::getContainer()->get(TripRequestRepositoryInterface::class);
+
+        $request = new TripRequest(Uuid::fromString($tripId));
+        $request->sourceUrl = 'https://www.komoot.com/tour/123456789';
+        $request->startDate = new \DateTimeImmutable('2026-07-01');
+
+        $repo->initializeTrip($tripId, $request);
+
+        $this->associateTripWithUser($tripId, $this->testUser);
+    }
+
+    private function installFakeLlmClient(LlmClientInterface $client): void
+    {
+        self::getContainer()->set(LlmClientInterface::class, $client);
+        self::getContainer()->set('App\\Llm\\OllamaClient', $client);
+    }
+
+    #[Test]
+    public function chatReturnsParsedActionAndResponse(): void
+    {
+        $this->seedTrip(self::TRIP_ID);
+
+        $this->installFakeLlmClient(new FakeLlmClient([
+            'message' => [
+                'role' => 'assistant',
+                'content' => json_encode([
+                    'action' => 'split_stage',
+                    'params' => ['stage' => 3],
+                    'response' => "Très bien, je découpe l'étape 3 en deux.",
+                ], \JSON_THROW_ON_ERROR),
+            ],
+        ]));
+
+        $response = $this->client->request(
+            'POST',
+            \sprintf('/trips/%s/chat', self::TRIP_ID),
+            [
+                'json' => [
+                    'message' => "Coupe l'étape 3 en deux",
+                    'context' => ['currentStage' => 3],
+                ],
+                'headers' => $this->authHeader($this->jwtToken),
+            ],
+        );
+
+        $this->assertResponseStatusCodeSame(200);
+
+        $data = $response->toArray(false);
+        $this->assertSame('split_stage', $data['action']);
+        $this->assertSame(['stage' => 3], $data['params']);
+        $this->assertStringContainsString('étape 3', $data['response']);
+        $this->assertTrue($data['dispatched']);
+    }
+
+    #[Test]
+    public function chatInfoActionDoesNotMarkAsDispatched(): void
+    {
+        $this->seedTrip(self::TRIP_ID);
+
+        $this->installFakeLlmClient(new FakeLlmClient([
+            'message' => [
+                'role' => 'assistant',
+                'content' => json_encode([
+                    'action' => 'info',
+                    'params' => [],
+                    'response' => 'Le gravel désigne un type de vélo.',
+                ], \JSON_THROW_ON_ERROR),
+            ],
+        ]));
+
+        $response = $this->client->request(
+            'POST',
+            \sprintf('/trips/%s/chat', self::TRIP_ID),
+            [
+                'json' => ['message' => "C'est quoi le gravel ?"],
+                'headers' => $this->authHeader($this->jwtToken),
+            ],
+        );
+
+        $this->assertResponseStatusCodeSame(200);
+
+        $data = $response->toArray(false);
+        $this->assertSame('info', $data['action']);
+        $this->assertFalse($data['dispatched']);
+    }
+
+    #[Test]
+    public function chatReturns503WhenLlmDisabled(): void
+    {
+        $this->seedTrip(self::TRIP_ID);
+
+        $this->installFakeLlmClient(new FakeLlmClient(response: null, enabled: false));
+
+        $this->client->request(
+            'POST',
+            \sprintf('/trips/%s/chat', self::TRIP_ID),
+            [
+                'json' => ['message' => 'Bonjour'],
+                'headers' => $this->authHeader($this->jwtToken),
+            ],
+        );
+
+        $this->assertResponseStatusCodeSame(503);
+    }
+
+    #[Test]
+    public function chatReturns503WhenOllamaUnreachable(): void
+    {
+        $this->seedTrip(self::TRIP_ID);
+
+        $this->installFakeLlmClient(new FakeLlmClient(throwUnavailable: true));
+
+        $this->client->request(
+            'POST',
+            \sprintf('/trips/%s/chat', self::TRIP_ID),
+            [
+                'json' => ['message' => 'Bonjour'],
+                'headers' => $this->authHeader($this->jwtToken),
+            ],
+        );
+
+        $this->assertResponseStatusCodeSame(503);
+    }
+
+    #[Test]
+    public function chatRateLimitsAfter20RequestsPerMinute(): void
+    {
+        $this->seedTrip(self::TRIP_ID);
+
+        $this->installFakeLlmClient(new FakeLlmClient([
+            'message' => [
+                'role' => 'assistant',
+                'content' => json_encode([
+                    'action' => 'info',
+                    'params' => [],
+                    'response' => 'OK',
+                ], \JSON_THROW_ON_ERROR),
+            ],
+        ]));
+
+        for ($i = 0; $i < 20; ++$i) {
+            $this->client->request(
+                'POST',
+                \sprintf('/trips/%s/chat', self::TRIP_ID),
+                [
+                    'json' => ['message' => 'ping '.$i],
+                    'headers' => $this->authHeader($this->jwtToken),
+                ],
+            );
+            $this->assertResponseStatusCodeSame(200, \sprintf('Request #%d should succeed.', $i + 1));
+        }
+
+        $this->client->request(
+            'POST',
+            \sprintf('/trips/%s/chat', self::TRIP_ID),
+            [
+                'json' => ['message' => 'over the limit'],
+                'headers' => $this->authHeader($this->jwtToken),
+            ],
+        );
+
+        $this->assertResponseStatusCodeSame(429);
+    }
+
+    #[Test]
+    public function chatRejectsUnauthenticatedRequests(): void
+    {
+        $this->seedTrip(self::TRIP_ID);
+
+        $this->client->request(
+            'POST',
+            \sprintf('/trips/%s/chat', self::TRIP_ID),
+            ['json' => ['message' => 'Bonjour']],
+        );
+
+        $this->assertResponseStatusCodeSame(401);
+    }
+
+    #[Test]
+    public function chatReturns404ForUnknownTrip(): void
+    {
+        $this->installFakeLlmClient(new FakeLlmClient(enabled: false));
+
+        $this->client->request(
+            'POST',
+            '/trips/00000000-0000-0000-0000-000000000000/chat',
+            [
+                'json' => ['message' => 'Bonjour'],
+                'headers' => $this->authHeader($this->jwtToken),
+            ],
+        );
+
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    #[Test]
+    public function chatRejectsBlankMessage(): void
+    {
+        $this->seedTrip(self::TRIP_ID);
+
+        $this->installFakeLlmClient(new FakeLlmClient([
+            'message' => ['role' => 'assistant', 'content' => '{}'],
+        ]));
+
+        $this->client->request(
+            'POST',
+            \sprintf('/trips/%s/chat', self::TRIP_ID),
+            [
+                'json' => ['message' => ''],
+                'headers' => $this->authHeader($this->jwtToken),
+            ],
+        );
+
+        $this->assertResponseStatusCodeSame(422);
+    }
+}
+
+/**
+ * Minimal in-memory LlmClient used by the chat functional test.
+ */
+final class FakeLlmClient implements LlmClientInterface
+{
+    /**
+     * @param array<string, mixed>|null $response
+     */
+    public function __construct(
+        private readonly ?array $response = null,
+        private readonly bool $enabled = true,
+        private readonly bool $throwUnavailable = false,
+    ) {
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->enabled;
+    }
+
+    public function generate(string $model, string $prompt, ?string $systemPrompt = null, array $options = []): ?array
+    {
+        return $this->respond();
+    }
+
+    public function chat(string $model, array $messages, ?string $systemPrompt = null, array $options = []): ?array
+    {
+        return $this->respond();
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function respond(): ?array
+    {
+        if ($this->throwUnavailable) {
+            throw new OllamaUnavailableException('Simulated outage.');
+        }
+
+        if (!$this->enabled) {
+            return null;
+        }
+
+        return $this->response;
+    }
+}

--- a/api/tests/Functional/TripChatTest.php
+++ b/api/tests/Functional/TripChatTest.php
@@ -53,7 +53,6 @@ final class TripChatTest extends ApiTestCase
     private function installFakeLlmClient(LlmClientInterface $client): void
     {
         self::getContainer()->set(LlmClientInterface::class, $client);
-        self::getContainer()->set('App\\Llm\\OllamaClient', $client);
     }
 
     #[Test]
@@ -80,7 +79,7 @@ final class TripChatTest extends ApiTestCase
                     'message' => "Coupe l'étape 3 en deux",
                     'context' => ['currentStage' => 3],
                 ],
-                'headers' => $this->authHeader($this->jwtToken),
+                'headers' => ['Content-Type' => 'application/ld+json', ...$this->authHeader($this->jwtToken)],
             ],
         );
 
@@ -114,7 +113,7 @@ final class TripChatTest extends ApiTestCase
             \sprintf('/trips/%s/chat', self::TRIP_ID),
             [
                 'json' => ['message' => "C'est quoi le gravel ?"],
-                'headers' => $this->authHeader($this->jwtToken),
+                'headers' => ['Content-Type' => 'application/ld+json', ...$this->authHeader($this->jwtToken)],
             ],
         );
 
@@ -137,7 +136,7 @@ final class TripChatTest extends ApiTestCase
             \sprintf('/trips/%s/chat', self::TRIP_ID),
             [
                 'json' => ['message' => 'Bonjour'],
-                'headers' => $this->authHeader($this->jwtToken),
+                'headers' => ['Content-Type' => 'application/ld+json', ...$this->authHeader($this->jwtToken)],
             ],
         );
 
@@ -156,51 +155,11 @@ final class TripChatTest extends ApiTestCase
             \sprintf('/trips/%s/chat', self::TRIP_ID),
             [
                 'json' => ['message' => 'Bonjour'],
-                'headers' => $this->authHeader($this->jwtToken),
+                'headers' => ['Content-Type' => 'application/ld+json', ...$this->authHeader($this->jwtToken)],
             ],
         );
 
         $this->assertResponseStatusCodeSame(503);
-    }
-
-    #[Test]
-    public function chatRateLimitsAfter20RequestsPerMinute(): void
-    {
-        $this->seedTrip(self::TRIP_ID);
-
-        $this->installFakeLlmClient(new FakeLlmClient([
-            'message' => [
-                'role' => 'assistant',
-                'content' => json_encode([
-                    'action' => 'info',
-                    'params' => [],
-                    'response' => 'OK',
-                ], \JSON_THROW_ON_ERROR),
-            ],
-        ]));
-
-        for ($i = 0; $i < 20; ++$i) {
-            $this->client->request(
-                'POST',
-                \sprintf('/trips/%s/chat', self::TRIP_ID),
-                [
-                    'json' => ['message' => 'ping '.$i],
-                    'headers' => $this->authHeader($this->jwtToken),
-                ],
-            );
-            $this->assertResponseStatusCodeSame(200, \sprintf('Request #%d should succeed.', $i + 1));
-        }
-
-        $this->client->request(
-            'POST',
-            \sprintf('/trips/%s/chat', self::TRIP_ID),
-            [
-                'json' => ['message' => 'over the limit'],
-                'headers' => $this->authHeader($this->jwtToken),
-            ],
-        );
-
-        $this->assertResponseStatusCodeSame(429);
     }
 
     #[Test]
@@ -227,7 +186,7 @@ final class TripChatTest extends ApiTestCase
             '/trips/00000000-0000-0000-0000-000000000000/chat',
             [
                 'json' => ['message' => 'Bonjour'],
-                'headers' => $this->authHeader($this->jwtToken),
+                'headers' => ['Content-Type' => 'application/ld+json', ...$this->authHeader($this->jwtToken)],
             ],
         );
 
@@ -248,7 +207,7 @@ final class TripChatTest extends ApiTestCase
             \sprintf('/trips/%s/chat', self::TRIP_ID),
             [
                 'json' => ['message' => ''],
-                'headers' => $this->authHeader($this->jwtToken),
+                'headers' => ['Content-Type' => 'application/ld+json', ...$this->authHeader($this->jwtToken)],
             ],
         );
 
@@ -259,15 +218,15 @@ final class TripChatTest extends ApiTestCase
 /**
  * Minimal in-memory LlmClient used by the chat functional test.
  */
-final class FakeLlmClient implements LlmClientInterface
+final readonly class FakeLlmClient implements LlmClientInterface
 {
     /**
      * @param array<string, mixed>|null $response
      */
     public function __construct(
-        private readonly ?array $response = null,
-        private readonly bool $enabled = true,
-        private readonly bool $throwUnavailable = false,
+        private ?array $response = null,
+        private bool $enabled = true,
+        private bool $throwUnavailable = false,
     ) {
     }
 

--- a/api/tests/Unit/Llm/ChatActionInterpreterTest.php
+++ b/api/tests/Unit/Llm/ChatActionInterpreterTest.php
@@ -115,13 +115,28 @@ final class ChatActionInterpreterTest extends TestCase
         $action = $this->interpreter->interpret(
             json_encode([
                 'action' => 'change_accommodation',
-                'params' => ['stage' => 2, 'type' => 'gite'],
+                'params' => ['stage' => 2, 'type' => 'guest_house'],
                 'response' => "J'ajuste l'hébergement.",
             ], \JSON_THROW_ON_ERROR),
         );
 
         $this->assertSame(ChatAction::ACTION_CHANGE_ACCOMMODATION, $action->action);
-        $this->assertSame(['stage' => 2, 'type' => 'gite'], $action->params);
+        $this->assertSame(['stage' => 2, 'type' => 'guest_house'], $action->params);
+    }
+
+    #[Test]
+    public function changeAccommodationFallsBackToInfoWhenTypeIsNotInTheAllowlist(): void
+    {
+        $action = $this->interpreter->interpret(
+            json_encode([
+                'action' => 'change_accommodation',
+                'params' => ['stage' => 2, 'type' => 'palace'],
+                'response' => 'Bien noté.',
+            ], \JSON_THROW_ON_ERROR),
+        );
+
+        $this->assertSame(ChatAction::ACTION_INFO, $action->action);
+        $this->assertSame([], $action->params);
     }
 
     #[Test]

--- a/api/tests/Unit/Llm/ChatActionInterpreterTest.php
+++ b/api/tests/Unit/Llm/ChatActionInterpreterTest.php
@@ -1,0 +1,279 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Llm;
+
+use App\Llm\ChatActionInterpreter;
+use App\Llm\Dto\ChatAction;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class ChatActionInterpreterTest extends TestCase
+{
+    private ChatActionInterpreter $interpreter;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->interpreter = new ChatActionInterpreter();
+    }
+
+    #[Test]
+    public function parsesSplitStageAction(): void
+    {
+        $action = $this->interpreter->interpret(
+            json_encode([
+                'action' => 'split_stage',
+                'params' => ['stage' => 3],
+                'response' => "Très bien, je découpe l'étape 3 en deux.",
+            ], \JSON_THROW_ON_ERROR),
+        );
+
+        $this->assertSame(ChatAction::ACTION_SPLIT_STAGE, $action->action);
+        $this->assertSame(['stage' => 3], $action->params);
+        $this->assertStringContainsString('étape 3', $action->response);
+    }
+
+    #[Test]
+    public function parsesMergeStagesAction(): void
+    {
+        $action = $this->interpreter->interpret(
+            json_encode([
+                'action' => 'merge_stages',
+                'params' => ['stages' => [2, 3]],
+                'response' => 'Je fusionne les étapes 2 et 3.',
+            ], \JSON_THROW_ON_ERROR),
+        );
+
+        $this->assertSame(ChatAction::ACTION_MERGE_STAGES, $action->action);
+        $this->assertSame(['stages' => [2, 3]], $action->params);
+    }
+
+    #[Test]
+    public function rejectsNonConsecutiveMergeStages(): void
+    {
+        $action = $this->interpreter->interpret(
+            json_encode([
+                'action' => 'merge_stages',
+                'params' => ['stages' => [2, 5]],
+                'response' => 'On fusionne 2 et 5.',
+            ], \JSON_THROW_ON_ERROR),
+        );
+
+        $this->assertSame(ChatAction::ACTION_INFO, $action->action);
+        $this->assertSame([], $action->params);
+    }
+
+    #[Test]
+    public function parsesAddWaypointWithoutStage(): void
+    {
+        $action = $this->interpreter->interpret(
+            json_encode([
+                'action' => 'add_waypoint',
+                'params' => ['name' => 'Mont Cassel', 'stage' => null],
+                'response' => 'Détour ajouté par le Mont Cassel.',
+            ], \JSON_THROW_ON_ERROR),
+        );
+
+        $this->assertSame(ChatAction::ACTION_ADD_WAYPOINT, $action->action);
+        $this->assertSame(['name' => 'Mont Cassel', 'stage' => null], $action->params);
+    }
+
+    #[Test]
+    public function parsesAddWaypointWithStage(): void
+    {
+        $action = $this->interpreter->interpret(
+            json_encode([
+                'action' => 'add_waypoint',
+                'params' => ['name' => 'Mont Cassel', 'stage' => 2],
+                'response' => 'Détour ajouté.',
+            ], \JSON_THROW_ON_ERROR),
+        );
+
+        $this->assertSame(ChatAction::ACTION_ADD_WAYPOINT, $action->action);
+        $this->assertSame(['name' => 'Mont Cassel', 'stage' => 2], $action->params);
+    }
+
+    #[Test]
+    public function rejectsAddWaypointWithEmptyName(): void
+    {
+        $action = $this->interpreter->interpret(
+            json_encode([
+                'action' => 'add_waypoint',
+                'params' => ['name' => '   ', 'stage' => null],
+                'response' => 'OK',
+            ], \JSON_THROW_ON_ERROR),
+        );
+
+        $this->assertSame(ChatAction::ACTION_INFO, $action->action);
+    }
+
+    #[Test]
+    public function parsesChangeAccommodationAction(): void
+    {
+        $action = $this->interpreter->interpret(
+            json_encode([
+                'action' => 'change_accommodation',
+                'params' => ['stage' => 2, 'type' => 'gite'],
+                'response' => "J'ajuste l'hébergement.",
+            ], \JSON_THROW_ON_ERROR),
+        );
+
+        $this->assertSame(ChatAction::ACTION_CHANGE_ACCOMMODATION, $action->action);
+        $this->assertSame(['stage' => 2, 'type' => 'gite'], $action->params);
+    }
+
+    #[Test]
+    public function parsesAdjustDistanceAction(): void
+    {
+        $action = $this->interpreter->interpret(
+            json_encode([
+                'action' => 'adjust_distance',
+                'params' => ['stage' => 5, 'km' => 95],
+                'response' => 'OK.',
+            ], \JSON_THROW_ON_ERROR),
+        );
+
+        $this->assertSame(ChatAction::ACTION_ADJUST_DISTANCE, $action->action);
+        $this->assertSame(['stage' => 5, 'km' => 95.0], $action->params);
+    }
+
+    #[Test]
+    public function parsesAdjustDistanceWithFloat(): void
+    {
+        $action = $this->interpreter->interpret(
+            json_encode([
+                'action' => 'adjust_distance',
+                'params' => ['stage' => 5, 'km' => 87.5],
+                'response' => 'OK.',
+            ], \JSON_THROW_ON_ERROR),
+        );
+
+        $this->assertSame(['stage' => 5, 'km' => 87.5], $action->params);
+    }
+
+    #[Test]
+    public function parsesInfoAction(): void
+    {
+        $action = $this->interpreter->interpret(
+            json_encode([
+                'action' => 'info',
+                'params' => new \stdClass(),
+                'response' => 'Le gravel désigne un type de vélo.',
+            ], \JSON_THROW_ON_ERROR),
+        );
+
+        $this->assertSame(ChatAction::ACTION_INFO, $action->action);
+        $this->assertSame([], $action->params);
+        $this->assertSame('Le gravel désigne un type de vélo.', $action->response);
+    }
+
+    #[Test]
+    public function unknownActionDegradesToInfo(): void
+    {
+        $action = $this->interpreter->interpret(
+            json_encode([
+                'action' => 'avoid_traffic',
+                'params' => ['stage' => 4],
+                'response' => 'Je recalcule en évitant le trafic.',
+            ], \JSON_THROW_ON_ERROR),
+        );
+
+        $this->assertSame(ChatAction::ACTION_INFO, $action->action);
+        $this->assertSame([], $action->params);
+        $this->assertSame('Je recalcule en évitant le trafic.', $action->response);
+    }
+
+    #[Test]
+    public function malformedJsonFallsBackToInfo(): void
+    {
+        $action = $this->interpreter->interpret('not a json payload');
+
+        $this->assertSame(ChatAction::ACTION_INFO, $action->action);
+        $this->assertSame([], $action->params);
+        $this->assertSame(ChatActionInterpreter::DEFAULT_FALLBACK_MESSAGE, $action->response);
+    }
+
+    #[Test]
+    public function emptyResponseFallsBackToDefaultMessage(): void
+    {
+        $action = $this->interpreter->interpret('');
+
+        $this->assertSame(ChatAction::ACTION_INFO, $action->action);
+        $this->assertSame(ChatActionInterpreter::DEFAULT_FALLBACK_MESSAGE, $action->response);
+    }
+
+    #[Test]
+    public function jsonWrappedInCodeFenceIsTolerated(): void
+    {
+        $payload = "```json\n".json_encode([
+            'action' => 'split_stage',
+            'params' => ['stage' => 1],
+            'response' => 'OK.',
+        ], \JSON_THROW_ON_ERROR)."\n```";
+
+        $action = $this->interpreter->interpret($payload);
+
+        $this->assertSame(ChatAction::ACTION_SPLIT_STAGE, $action->action);
+        $this->assertSame(['stage' => 1], $action->params);
+    }
+
+    #[Test]
+    public function jsonEmbeddedInProseIsExtracted(): void
+    {
+        $payload = 'Voici la réponse : '.json_encode([
+            'action' => 'info',
+            'params' => [],
+            'response' => 'Bonjour.',
+        ], \JSON_THROW_ON_ERROR).' Fin.';
+
+        $action = $this->interpreter->interpret($payload);
+
+        $this->assertSame(ChatAction::ACTION_INFO, $action->action);
+        $this->assertSame('Bonjour.', $action->response);
+    }
+
+    #[Test]
+    public function missingStageParamFallsBackToInfo(): void
+    {
+        $action = $this->interpreter->interpret(
+            json_encode([
+                'action' => 'split_stage',
+                'params' => [],
+                'response' => 'OK.',
+            ], \JSON_THROW_ON_ERROR),
+        );
+
+        $this->assertSame(ChatAction::ACTION_INFO, $action->action);
+    }
+
+    #[Test]
+    public function negativeStageFallsBackToInfo(): void
+    {
+        $action = $this->interpreter->interpret(
+            json_encode([
+                'action' => 'split_stage',
+                'params' => ['stage' => -1],
+                'response' => 'OK.',
+            ], \JSON_THROW_ON_ERROR),
+        );
+
+        $this->assertSame(ChatAction::ACTION_INFO, $action->action);
+    }
+
+    #[Test]
+    public function stringStageIsCoerced(): void
+    {
+        $action = $this->interpreter->interpret(
+            json_encode([
+                'action' => 'split_stage',
+                'params' => ['stage' => '3'],
+                'response' => 'OK.',
+            ], \JSON_THROW_ON_ERROR),
+        );
+
+        $this->assertSame(ChatAction::ACTION_SPLIT_STAGE, $action->action);
+        $this->assertSame(['stage' => 3], $action->params);
+    }
+}

--- a/api/tests/Unit/Llm/ChatActionInterpreterTest.php
+++ b/api/tests/Unit/Llm/ChatActionInterpreterTest.php
@@ -51,6 +51,21 @@ final class ChatActionInterpreterTest extends TestCase
     }
 
     #[Test]
+    public function acceptsMergeStagesInReversedOrder(): void
+    {
+        $action = $this->interpreter->interpret(
+            json_encode([
+                'action' => 'merge_stages',
+                'params' => ['stages' => [3, 2]],
+                'response' => 'Je fusionne les étapes 2 et 3.',
+            ], \JSON_THROW_ON_ERROR),
+        );
+
+        $this->assertSame(ChatAction::ACTION_MERGE_STAGES, $action->action);
+        $this->assertSame(['stages' => [3, 2]], $action->params);
+    }
+
+    #[Test]
     public function rejectsNonConsecutiveMergeStages(): void
     {
         $action = $this->interpreter->interpret(

--- a/api/tests/Unit/Llm/ChatHistoryStoreTest.php
+++ b/api/tests/Unit/Llm/ChatHistoryStoreTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Llm;
+
+use App\Llm\ChatHistoryStore;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+final class ChatHistoryStoreTest extends TestCase
+{
+    private const string TRIP_ID = '01936f6e-0000-7000-8000-000000000099';
+
+    private const string USER_ID = '0193c000-0000-7000-8000-000000000001';
+
+    #[Test]
+    public function getReturnsEmptyArrayWhenNoHistoryIsStored(): void
+    {
+        $store = new ChatHistoryStore(new ArrayAdapter());
+
+        self::assertSame([], $store->get(self::TRIP_ID, self::USER_ID));
+    }
+
+    #[Test]
+    public function appendAndGetRoundTripASingleMessage(): void
+    {
+        $store = new ChatHistoryStore(new ArrayAdapter());
+
+        $store->append(self::TRIP_ID, self::USER_ID, 'user', 'Bonjour');
+
+        self::assertSame(
+            [['role' => 'user', 'content' => 'Bonjour']],
+            $store->get(self::TRIP_ID, self::USER_ID),
+        );
+    }
+
+    #[Test]
+    public function appendManyPersistsAllMessagesInOrder(): void
+    {
+        $store = new ChatHistoryStore(new ArrayAdapter());
+
+        $store->appendMany(self::TRIP_ID, self::USER_ID, [
+            ['role' => 'user', 'content' => 'Bonjour'],
+            ['role' => 'assistant', 'content' => 'Salut !'],
+        ]);
+
+        self::assertSame(
+            [
+                ['role' => 'user', 'content' => 'Bonjour'],
+                ['role' => 'assistant', 'content' => 'Salut !'],
+            ],
+            $store->get(self::TRIP_ID, self::USER_ID),
+        );
+    }
+
+    #[Test]
+    public function appendManyWithAnEmptyListDoesNothing(): void
+    {
+        $store = new ChatHistoryStore(new ArrayAdapter());
+        $store->append(self::TRIP_ID, self::USER_ID, 'user', 'Bonjour');
+
+        $store->appendMany(self::TRIP_ID, self::USER_ID, []);
+
+        self::assertSame(
+            [['role' => 'user', 'content' => 'Bonjour']],
+            $store->get(self::TRIP_ID, self::USER_ID),
+        );
+    }
+
+    #[Test]
+    public function historyIsTrimmedToTheLastMaxMessagesWhenItExceedsTheBound(): void
+    {
+        $store = new ChatHistoryStore(new ArrayAdapter());
+
+        for ($i = 1; $i <= ChatHistoryStore::MAX_MESSAGES + 2; ++$i) {
+            $store->append(self::TRIP_ID, self::USER_ID, 'user', 'msg '.$i);
+        }
+
+        $history = $store->get(self::TRIP_ID, self::USER_ID);
+
+        self::assertCount(ChatHistoryStore::MAX_MESSAGES, $history);
+        self::assertSame('msg 3', $history[0]['content']);
+        self::assertSame('msg '.(ChatHistoryStore::MAX_MESSAGES + 2), $history[ChatHistoryStore::MAX_MESSAGES - 1]['content']);
+    }
+
+    #[Test]
+    public function getDiscardsMalformedEntriesAndKeepsValidOnes(): void
+    {
+        $cache = new ArrayAdapter();
+        $item = $cache->getItem('trip.'.self::TRIP_ID.'.user.'.self::USER_ID.'.chat');
+        $item->set([
+            ['role' => 'user', 'content' => 'ok'],
+            'not-an-array',
+            ['role' => 'assistant'], // missing content
+            ['role' => 123, 'content' => 'bad-role-type'],
+            ['role' => 'user', 'content' => 'still ok'],
+        ]);
+        $cache->save($item);
+
+        $store = new ChatHistoryStore($cache);
+
+        self::assertSame(
+            [
+                ['role' => 'user', 'content' => 'ok'],
+                ['role' => 'user', 'content' => 'still ok'],
+            ],
+            $store->get(self::TRIP_ID, self::USER_ID),
+        );
+    }
+
+    #[Test]
+    public function historyIsScopedPerTripAndUser(): void
+    {
+        $store = new ChatHistoryStore(new ArrayAdapter());
+
+        $store->append('trip-a', 'user-1', 'user', 'A1');
+        $store->append('trip-b', 'user-1', 'user', 'B1');
+        $store->append('trip-a', 'user-2', 'user', 'A2');
+
+        self::assertSame([['role' => 'user', 'content' => 'A1']], $store->get('trip-a', 'user-1'));
+        self::assertSame([['role' => 'user', 'content' => 'B1']], $store->get('trip-b', 'user-1'));
+        self::assertSame([['role' => 'user', 'content' => 'A2']], $store->get('trip-a', 'user-2'));
+    }
+}

--- a/api/tests/Unit/State/TripChatProcessorTest.php
+++ b/api/tests/Unit/State/TripChatProcessorTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\State;
+
+use ApiPlatform\Metadata\Post;
+use App\ApiResource\TripChatRequest;
+use App\ApiResource\TripRequest;
+use App\Entity\User;
+use App\Llm\ChatActionInterpreter;
+use App\Llm\ChatHistoryStore;
+use App\Llm\LlmClientInterface;
+use App\Llm\SystemPromptLoader;
+use App\Repository\TripRequestRepositoryInterface;
+use App\State\TripChatProcessor;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Unit coverage for the rate-limit branch of {@see TripChatProcessor}.
+ *
+ * The functional layer cannot exercise the cross-request limiter state because
+ * the test cache pool (array adapter) is reset between kernel requests. This
+ * test wires the processor against an in-memory rate limiter sized so the
+ * second `process()` call exhausts the quota and triggers the 429 branch.
+ */
+#[AllowMockObjectsWithoutExpectations]
+final class TripChatProcessorTest extends TestCase
+{
+    private const string TRIP_ID = '01936f6e-0000-7000-8000-000000000099';
+
+    #[Test]
+    public function processThrows429WhenRateLimitExceeded(): void
+    {
+        $processor = $this->newProcessor(limit: 1);
+        $request = new TripChatRequest('Bonjour');
+        $operation = new Post();
+
+        // First call consumes the only token.
+        $processor->process($request, $operation, ['id' => self::TRIP_ID]);
+
+        // Second call must hit the limiter and trip the 429 branch.
+        $this->expectException(TooManyRequestsHttpException::class);
+        $processor->process($request, $operation, ['id' => self::TRIP_ID]);
+    }
+
+    private function newProcessor(int $limit): TripChatProcessor
+    {
+        $repository = $this->createStub(TripRequestRepositoryInterface::class);
+        $repository->method('getRequest')->willReturn(new TripRequest(Uuid::fromString(self::TRIP_ID)));
+
+        $llmClient = $this->createStub(LlmClientInterface::class);
+        $llmClient->method('isEnabled')->willReturn(true);
+        $llmClient->method('chat')->willReturn([
+            'message' => [
+                'role' => 'assistant',
+                'content' => json_encode([
+                    'action' => 'info',
+                    'params' => [],
+                    'response' => 'OK',
+                ], \JSON_THROW_ON_ERROR),
+            ],
+        ]);
+
+        $user = new User('chat@example.com', Uuid::v7());
+        $security = $this->createStub(Security::class);
+        $security->method('getUser')->willReturn($user);
+
+        $factory = new RateLimiterFactory(
+            ['id' => 'trip_chat', 'policy' => 'fixed_window', 'limit' => $limit, 'interval' => '1 hour'],
+            new InMemoryStorage(),
+        );
+
+        return new TripChatProcessor(
+            tripStateManager: $repository,
+            llmClient: $llmClient,
+            promptLoader: new SystemPromptLoader($this->createPromptFixtureDir()),
+            interpreter: new ChatActionInterpreter(new NullLogger()),
+            historyStore: new ChatHistoryStore(new ArrayAdapter()),
+            security: $security,
+            logger: new NullLogger(),
+            tripChatLimiter: $factory,
+        );
+    }
+
+    private function createPromptFixtureDir(): string
+    {
+        $dir = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'trip-chat-prompts-'.bin2hex(random_bytes(4));
+        mkdir($dir, 0o775, true);
+        file_put_contents($dir.\DIRECTORY_SEPARATOR.'dialogue.txt', 'SYSTEM PROMPT');
+
+        return $dir;
+    }
+}

--- a/api/tests/Unit/State/TripChatProcessorTest.php
+++ b/api/tests/Unit/State/TripChatProcessorTest.php
@@ -6,13 +6,11 @@ namespace App\Tests\Unit\State;
 
 use ApiPlatform\Metadata\Post;
 use App\ApiResource\TripChatRequest;
-use App\ApiResource\TripRequest;
 use App\Entity\User;
 use App\Llm\ChatActionInterpreter;
 use App\Llm\ChatHistoryStore;
 use App\Llm\LlmClientInterface;
 use App\Llm\SystemPromptLoader;
-use App\Repository\TripRequestRepositoryInterface;
 use App\State\TripChatProcessor;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\Test;
@@ -66,9 +64,6 @@ final class TripChatProcessorTest extends TestCase
 
     private function newProcessor(int $limit): TripChatProcessor
     {
-        $repository = $this->createStub(TripRequestRepositoryInterface::class);
-        $repository->method('getRequest')->willReturn(new TripRequest(Uuid::fromString(self::TRIP_ID)));
-
         $llmClient = $this->createStub(LlmClientInterface::class);
         $llmClient->method('isEnabled')->willReturn(true);
         $llmClient->method('chat')->willReturn([
@@ -92,7 +87,6 @@ final class TripChatProcessorTest extends TestCase
         );
 
         return new TripChatProcessor(
-            tripStateManager: $repository,
             llmClient: $llmClient,
             promptLoader: new SystemPromptLoader($this->createPromptFixtureDir()),
             interpreter: new ChatActionInterpreter(new NullLogger()),

--- a/api/tests/Unit/State/TripChatProcessorTest.php
+++ b/api/tests/Unit/State/TripChatProcessorTest.php
@@ -38,6 +38,17 @@ final class TripChatProcessorTest extends TestCase
 {
     private const string TRIP_ID = '01936f6e-0000-7000-8000-000000000099';
 
+    private string $promptFixtureDir = '';
+
+    #[\Override]
+    protected function tearDown(): void
+    {
+        if ('' !== $this->promptFixtureDir && is_dir($this->promptFixtureDir)) {
+            @unlink($this->promptFixtureDir.\DIRECTORY_SEPARATOR.'dialogue.txt');
+            @rmdir($this->promptFixtureDir);
+        }
+    }
+
     #[Test]
     public function processThrows429WhenRateLimitExceeded(): void
     {
@@ -97,6 +108,7 @@ final class TripChatProcessorTest extends TestCase
         $dir = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'trip-chat-prompts-'.bin2hex(random_bytes(4));
         mkdir($dir, 0o775, true);
         file_put_contents($dir.\DIRECTORY_SEPARATOR.'dialogue.txt', 'SYSTEM PROMPT');
+        $this->promptFixtureDir = $dir;
 
         return $dir;
     }

--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -590,6 +590,26 @@
     "analysisLaunched": "Analysis launched",
     "analysisLaunchFailed": "Failed to launch analysis. Please retry."
   },
+  "aiBubble": {
+    "label": "AI assistant",
+    "openAria": "Open the AI assistant",
+    "closeAria": "Close the AI assistant",
+    "newBadge": "New",
+    "title": "AI assistant",
+    "subtitle": "Ask a question or request a change.",
+    "greeting": "Hi! I'm your AI assistant. How can I help?",
+    "stageHint": "You are viewing stage {stage}. Ask me anything!",
+    "inputPlaceholder": "Ask for a change, e.g. \"split stage 3\"",
+    "inputAriaLabel": "Message for the AI assistant",
+    "send": "Send",
+    "sendAria": "Send the message",
+    "typing": "The assistant is replying…",
+    "historyAriaLabel": "Conversation with the AI assistant",
+    "errorNetwork": "Network error. Check your connection then try again.",
+    "errorRateLimit": "You have reached the message rate limit. Please try again shortly.",
+    "errorUnavailable": "The AI assistant is temporarily unavailable. Try again later.",
+    "errorGeneric": "Something went wrong. Please try again later."
+  },
   "aiOverview": {
     "title": "AI analysis",
     "subtitle": "Assistant-generated summary covering the whole trip",

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -590,6 +590,26 @@
     "analysisLaunched": "Analyse lancée",
     "analysisLaunchFailed": "Impossible de lancer l'analyse. Réessayez."
   },
+  "aiBubble": {
+    "label": "Assistant IA",
+    "openAria": "Ouvrir l'assistant IA",
+    "closeAria": "Fermer l'assistant IA",
+    "newBadge": "Nouveau",
+    "title": "Assistant IA",
+    "subtitle": "Posez une question ou demandez une modification.",
+    "greeting": "Bonjour ! Je suis votre assistant IA. Que puis-je faire pour vous ?",
+    "stageHint": "Vous consultez l'étape {stage}. Posez-moi une question !",
+    "inputPlaceholder": "Demandez une modification, par exemple « divise l'étape 3 »",
+    "inputAriaLabel": "Message pour l'assistant IA",
+    "send": "Envoyer",
+    "sendAria": "Envoyer le message",
+    "typing": "L'assistant rédige une réponse…",
+    "historyAriaLabel": "Conversation avec l'assistant IA",
+    "errorNetwork": "Erreur réseau. Vérifiez votre connexion puis réessayez.",
+    "errorRateLimit": "Vous avez atteint la limite de messages. Réessayez dans un instant.",
+    "errorUnavailable": "L'assistant IA est temporairement indisponible. Réessayez plus tard.",
+    "errorGeneric": "Une erreur est survenue. Réessayez plus tard."
+  },
   "aiOverview": {
     "title": "Analyse IA",
     "subtitle": "Synthèse générée par l'assistant à partir de l'ensemble du voyage",

--- a/pwa/src/components/ai-bubble.tsx
+++ b/pwa/src/components/ai-bubble.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useEffect } from "react";
+import { useTranslations } from "next-intl";
+import { Sparkles } from "lucide-react";
+import { useShallow } from "zustand/react/shallow";
+import { useUiStore } from "@/store/ui-store";
+import { useTripStore } from "@/store/trip-store";
+import { AiChatPanel } from "@/components/ai-chat-panel";
+import { cn } from "@/lib/utils";
+
+/**
+ * Floating AI assistant bubble + chat panel.
+ *
+ * - Bubble: bottom-right floating action button with a "Nouveau" badge on the
+ *   first visit (persisted via `localStorage`). Hidden during Acte 2 (the
+ *   narrative analysis screen) so it does not compete with the progress UI.
+ * - Panel: anchored 400 × 500 chat on desktop, full-screen sheet on mobile.
+ *
+ * The bubble also keeps {@link useUiStore.currentContext} in sync with the
+ * currently consulted stage (derived from {@link useUiStore.activeDayNumber})
+ * so every chat message carries the right `context.currentStage` payload.
+ */
+export function AiBubble() {
+  const t = useTranslations("aiBubble");
+
+  const { isBubbleOpen, hasSeenBubble, toggleBubble, closeBubble } = useUiStore(
+    useShallow((s) => ({
+      isBubbleOpen: s.isBubbleOpen,
+      hasSeenBubble: s.hasSeenBubble,
+      toggleBubble: s.toggleBubble,
+      closeBubble: s.closeBubble,
+    })),
+  );
+
+  const isAnalysisPhaseActive = useUiStore((s) => s.isAnalysisPhaseActive);
+  const activeDayNumber = useUiStore((s) => s.activeDayNumber);
+  const setCurrentContext = useUiStore((s) => s.setCurrentContext);
+
+  const trip = useTripStore((s) => s.trip);
+
+  useEffect(() => {
+    setCurrentContext({ currentStage: activeDayNumber ?? null });
+  }, [activeDayNumber, setCurrentContext]);
+
+  if (!trip || isAnalysisPhaseActive) return null;
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={toggleBubble}
+        aria-label={isBubbleOpen ? t("closeAria") : t("openAria")}
+        aria-expanded={isBubbleOpen}
+        aria-controls="ai-chat-panel"
+        data-testid="ai-bubble"
+        data-open={isBubbleOpen || undefined}
+        className={cn(
+          "fixed bottom-6 right-6 z-30 inline-flex items-center justify-center",
+          "h-14 w-14 rounded-full bg-brand text-white shadow-lg",
+          "hover:bg-brand-hover transition-transform hover:scale-105",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-hover focus-visible:ring-offset-2",
+        )}
+      >
+        <Sparkles className="h-6 w-6" aria-hidden="true" />
+        {!hasSeenBubble && (
+          <span
+            data-testid="ai-bubble-badge"
+            className={cn(
+              "absolute -top-1 -right-1 inline-flex items-center justify-center",
+              "rounded-full bg-red-500 text-white text-[10px] font-semibold",
+              "px-1.5 py-0.5 shadow-sm",
+            )}
+          >
+            {t("newBadge")}
+          </span>
+        )}
+        <span className="sr-only">{t("label")}</span>
+      </button>
+
+      {isBubbleOpen && <AiChatPanel onClose={closeBubble} />}
+    </>
+  );
+}

--- a/pwa/src/components/ai-chat-panel.tsx
+++ b/pwa/src/components/ai-chat-panel.tsx
@@ -1,0 +1,285 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from "react";
+import { useTranslations } from "next-intl";
+import { Send, Sparkles, X } from "lucide-react";
+import { useShallow } from "zustand/react/shallow";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { useUiStore, type AiChatMessage } from "@/store/ui-store";
+import { useTripPlanner } from "@/hooks/use-trip-planner";
+
+const CHAT_ACTION_INFO = "info";
+
+/**
+ * Fired on `document` whenever the chat endpoint returns an actionable
+ * response (anything but `info`). Issue #311 wires the matching recomputation
+ * flow on top of this signal so the bubble stays decoupled from the store.
+ */
+export const AI_CHAT_ACTION_EVENT = "ai-chat-action";
+
+/** Detail shape of {@link AI_CHAT_ACTION_EVENT}. */
+export interface AiChatActionEventDetail {
+  action: string;
+  params: Record<string, unknown>;
+  response: string;
+  tripId: string;
+  dispatched: boolean;
+}
+
+interface AiChatPanelProps {
+  /**
+   * Called when the panel is dismissed (close button, Escape key, backdrop
+   * click on mobile). Parent components remain in charge of the global open
+   * flag so the bubble and the panel stay in sync.
+   */
+  onClose: () => void;
+}
+
+/**
+ * Floating AI assistant chat panel.
+ *
+ * Renders a 400 × 500 anchored panel on desktop (≥ md) and a full-screen
+ * sheet on mobile. The header carries the title and close button, the body
+ * shows alternating user/assistant bubbles (auto-scrolled), and the footer
+ * holds the composer (Enter to send, Shift+Enter for newline).
+ *
+ * The panel reads/writes {@link useUiStore} for the chat history, the
+ * conversational context (currentStage), and the in-flight typing indicator.
+ * It calls {@link useTripPlanner.sendChatMessage} to round-trip the message
+ * to `POST /trips/{id}/chat` and, on receiving an actionable response,
+ * dispatches an {@link AI_CHAT_ACTION_EVENT} so issue #311 can plug the
+ * recomputation wiring without coupling to this component.
+ */
+export function AiChatPanel({ onClose }: AiChatPanelProps) {
+  const t = useTranslations("aiBubble");
+
+  const { chatHistory, isChatSending, currentContext } = useUiStore(
+    useShallow((s) => ({
+      chatHistory: s.chatHistory,
+      isChatSending: s.isChatSending,
+      currentContext: s.currentContext,
+    })),
+  );
+
+  const { sendChatMessage } = useTripPlanner();
+
+  const [draft, setDraft] = useState("");
+  const historyRef = useRef<HTMLDivElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const greeting: AiChatMessage = useMemo(
+    () => ({ role: "assistant", content: t("greeting"), ts: 0 }),
+    [t],
+  );
+
+  const transcript: ReadonlyArray<AiChatMessage> = useMemo(
+    () => (chatHistory.length === 0 ? [greeting] : [greeting, ...chatHistory]),
+    [chatHistory, greeting],
+  );
+
+  useEffect(() => {
+    const el = historyRef.current;
+    if (!el) return;
+    el.scrollTop = el.scrollHeight;
+  }, [transcript.length, isChatSending]);
+
+  useEffect(() => {
+    textareaRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    function handleKey(event: KeyboardEvent) {
+      if (event.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [onClose]);
+
+  const handleSubmit = useCallback(async () => {
+    const trimmed = draft.trim();
+    if (!trimmed || isChatSending) return;
+    setDraft("");
+    const response = await sendChatMessage(trimmed);
+    if (response && response.action !== CHAT_ACTION_INFO) {
+      const detail: AiChatActionEventDetail = {
+        action: response.action,
+        params: response.params,
+        response: response.response,
+        tripId: response.tripId,
+        dispatched: response.dispatched,
+      };
+      document.dispatchEvent(
+        new CustomEvent<AiChatActionEventDetail>(AI_CHAT_ACTION_EVENT, {
+          detail,
+        }),
+      );
+    }
+  }, [draft, isChatSending, sendChatMessage]);
+
+  const handleKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
+      if (event.key === "Enter" && !event.shiftKey) {
+        event.preventDefault();
+        void handleSubmit();
+      }
+    },
+    [handleSubmit],
+  );
+
+  const hint =
+    currentContext.currentStage !== null
+      ? t("stageHint", { stage: currentContext.currentStage })
+      : null;
+
+  const canSend = draft.trim().length > 0 && !isChatSending;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="false"
+      aria-label={t("title")}
+      data-testid="ai-chat-panel"
+      className={cn(
+        "fixed z-40 flex flex-col bg-background shadow-2xl",
+        "inset-0 md:inset-auto md:bottom-24 md:right-6",
+        "md:w-[400px] md:h-[500px] md:rounded-2xl border md:border-border",
+      )}
+    >
+      <header className="flex items-center gap-2 border-b border-border px-4 py-3">
+        <Sparkles className="h-4 w-4 text-brand" aria-hidden="true" />
+        <div className="flex-1 min-w-0">
+          <h2 className="text-sm font-semibold text-foreground">{t("title")}</h2>
+          <p className="text-xs text-muted-foreground truncate">
+            {t("subtitle")}
+          </p>
+        </div>
+        <Button
+          type="button"
+          size="icon"
+          variant="ghost"
+          onClick={onClose}
+          aria-label={t("closeAria")}
+          data-testid="ai-chat-panel-close"
+          className="h-8 w-8 shrink-0"
+        >
+          <X className="h-4 w-4" aria-hidden="true" />
+        </Button>
+      </header>
+
+      {hint && (
+        <p
+          className="px-4 py-2 text-xs text-muted-foreground bg-muted/40 border-b border-border"
+          data-testid="ai-chat-panel-hint"
+        >
+          {hint}
+        </p>
+      )}
+
+      <div
+        ref={historyRef}
+        role="log"
+        aria-live="polite"
+        aria-label={t("historyAriaLabel")}
+        data-testid="ai-chat-panel-history"
+        className="flex-1 overflow-y-auto px-4 py-3 flex flex-col gap-3 bg-muted/20"
+      >
+        {transcript.map((message, index) => (
+          <ChatBubble
+            key={`${message.role}-${message.ts}-${index}`}
+            message={message}
+          />
+        ))}
+        {isChatSending && <TypingDots />}
+      </div>
+
+      <div className="border-t border-border p-3 flex items-end gap-2">
+        <label htmlFor="ai-chat-panel-textarea" className="sr-only">
+          {t("inputAriaLabel")}
+        </label>
+        <textarea
+          ref={textareaRef}
+          id="ai-chat-panel-textarea"
+          value={draft}
+          onChange={(event) => setDraft(event.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder={t("inputPlaceholder")}
+          aria-label={t("inputAriaLabel")}
+          rows={2}
+          disabled={isChatSending}
+          data-testid="ai-chat-panel-input"
+          className={cn(
+            "flex-1 resize-none rounded-md border border-input bg-transparent px-3 py-2 text-sm",
+            "placeholder:text-muted-foreground",
+            "focus-visible:outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+            "disabled:cursor-not-allowed disabled:opacity-60",
+          )}
+        />
+        <Button
+          type="button"
+          size="icon"
+          onClick={() => void handleSubmit()}
+          disabled={!canSend}
+          aria-label={t("sendAria")}
+          data-testid="ai-chat-panel-send"
+          className="shrink-0 bg-brand text-white hover:bg-brand-hover disabled:bg-brand/40"
+        >
+          <Send className="h-4 w-4" aria-hidden="true" />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+interface ChatBubbleProps {
+  message: AiChatMessage;
+}
+
+function ChatBubble({ message }: ChatBubbleProps) {
+  const isUser = message.role === "user";
+  return (
+    <div
+      data-testid="ai-chat-panel-message"
+      data-role={message.role}
+      className={cn("flex w-full", isUser ? "justify-end" : "justify-start")}
+    >
+      <div
+        className={cn(
+          "max-w-[85%] rounded-2xl px-3 py-2 text-sm leading-relaxed shadow-sm whitespace-pre-wrap",
+          isUser
+            ? "bg-brand text-white rounded-br-sm"
+            : "bg-background border border-border text-foreground rounded-bl-sm",
+        )}
+      >
+        {message.content}
+      </div>
+    </div>
+  );
+}
+
+function TypingDots() {
+  const t = useTranslations("aiBubble");
+  return (
+    <div
+      data-testid="ai-chat-panel-typing"
+      role="status"
+      aria-live="polite"
+      className="flex w-full justify-start"
+    >
+      <div className="flex items-center gap-1 rounded-2xl rounded-bl-sm border border-border bg-background px-3 py-2 shadow-sm">
+        <span className="sr-only">{t("typing")}</span>
+        <span className="h-1.5 w-1.5 rounded-full bg-muted-foreground/70 animate-bounce [animation-delay:-0.3s]" />
+        <span className="h-1.5 w-1.5 rounded-full bg-muted-foreground/70 animate-bounce [animation-delay:-0.15s]" />
+        <span className="h-1.5 w-1.5 rounded-full bg-muted-foreground/70 animate-bounce" />
+      </div>
+    </div>
+  );
+}
+

--- a/pwa/src/components/ai-chat-panel.tsx
+++ b/pwa/src/components/ai-chat-panel.tsx
@@ -156,7 +156,9 @@ export function AiChatPanel({ onClose }: AiChatPanelProps) {
       <header className="flex items-center gap-2 border-b border-border px-4 py-3">
         <Sparkles className="h-4 w-4 text-brand" aria-hidden="true" />
         <div className="flex-1 min-w-0">
-          <h2 className="text-sm font-semibold text-foreground">{t("title")}</h2>
+          <h2 className="text-sm font-semibold text-foreground">
+            {t("title")}
+          </h2>
           <p className="text-xs text-muted-foreground truncate">
             {t("subtitle")}
           </p>
@@ -282,4 +284,3 @@ function TypingDots() {
     </div>
   );
 }
-

--- a/pwa/src/components/ai-chat-panel.tsx
+++ b/pwa/src/components/ai-chat-panel.tsx
@@ -215,6 +215,7 @@ export function AiChatPanel({ onClose }: AiChatPanelProps) {
           placeholder={t("inputPlaceholder")}
           aria-label={t("inputAriaLabel")}
           rows={2}
+          maxLength={2000}
           disabled={isChatSending}
           data-testid="ai-chat-panel-input"
           className={cn(

--- a/pwa/src/components/trip-planner.tsx
+++ b/pwa/src/components/trip-planner.tsx
@@ -208,6 +208,14 @@ export function TripPlanner({
         .getState()
         .setActiveDayNumber(typeof value === "number" ? value : null);
     };
+    const onSetTripId = (e: Event) => {
+      const id = (e as CustomEvent<string | null>).detail;
+      if (id) {
+        useTripStore.getState().setTrip({ id, title: "Test", sourceUrl: "" });
+      } else {
+        useTripStore.getState().clearTrip();
+      }
+    };
     window.addEventListener("__test_set_processing", onProcessing);
     window.addEventListener("__test_set_analysis_started", onAnalysisStarted);
     window.addEventListener("__test_clear_ai_overview", onClearAiOverview);
@@ -215,6 +223,7 @@ export function TripPlanner({
       "__test_set_active_day_number",
       onSetActiveDayNumber,
     );
+    window.addEventListener("__test_set_trip_id", onSetTripId);
     return () => {
       window.removeEventListener("__test_set_processing", onProcessing);
       window.removeEventListener(
@@ -226,6 +235,7 @@ export function TripPlanner({
         "__test_set_active_day_number",
         onSetActiveDayNumber,
       );
+      window.removeEventListener("__test_set_trip_id", onSetTripId);
     };
   }, []);
 

--- a/pwa/src/components/trip-planner.tsx
+++ b/pwa/src/components/trip-planner.tsx
@@ -21,6 +21,7 @@ import { TripSummary } from "@/components/trip-summary";
 import { TripAiOverview } from "@/components/trip-ai-overview";
 import { TripHeader } from "@/components/trip-header";
 import { TripDownloads } from "@/components/trip-downloads";
+import { AiBubble } from "@/components/ai-bubble";
 import { StageProgressBar } from "@/components/stage-progress-bar";
 import { RoadbookMasterDetail } from "@/components/Timeline";
 import { ConfigPanel } from "@/components/config-panel";
@@ -838,6 +839,11 @@ export function TripPlanner({
 
         {/* Keyboard shortcuts help modal */}
         <KeyboardHelpModal />
+
+        {/* Floating AI assistant — visible on Acte 1.5 (Aperçu) and Acte 3
+            (Mon voyage), hidden during Acte 2 thanks to the internal
+            `isAnalysisPhaseActive` guard. */}
+        <AiBubble />
       </main>
     </GpxDropZone>
   );

--- a/pwa/src/components/trip-planner.tsx
+++ b/pwa/src/components/trip-planner.tsx
@@ -202,9 +202,19 @@ export function TripPlanner({
     const onClearAiOverview = () => {
       useTripStore.getState().setAiOverview(null);
     };
+    const onSetActiveDayNumber = (e: Event) => {
+      const value = (e as CustomEvent<number | null>).detail;
+      useUiStore
+        .getState()
+        .setActiveDayNumber(typeof value === "number" ? value : null);
+    };
     window.addEventListener("__test_set_processing", onProcessing);
     window.addEventListener("__test_set_analysis_started", onAnalysisStarted);
     window.addEventListener("__test_clear_ai_overview", onClearAiOverview);
+    window.addEventListener(
+      "__test_set_active_day_number",
+      onSetActiveDayNumber,
+    );
     return () => {
       window.removeEventListener("__test_set_processing", onProcessing);
       window.removeEventListener(
@@ -212,6 +222,10 @@ export function TripPlanner({
         onAnalysisStarted,
       );
       window.removeEventListener("__test_clear_ai_overview", onClearAiOverview);
+      window.removeEventListener(
+        "__test_set_active_day_number",
+        onSetActiveDayNumber,
+      );
     };
   }, []);
 

--- a/pwa/src/hooks/use-trip-planner.ts
+++ b/pwa/src/hooks/use-trip-planner.ts
@@ -733,6 +733,7 @@ export function useTripPlanner() {
   ): Promise<TripChatResponseBody | null> {
     const trimmed = text.trim();
     if (!trimmed) return null;
+    if (trimmed.length > 2000) return null;
     if (!tripId) return null;
 
     const uiStore = useUiStore.getState();

--- a/pwa/src/hooks/use-trip-planner.ts
+++ b/pwa/src/hooks/use-trip-planner.ts
@@ -140,15 +140,19 @@ export function useTripPlanner() {
   const preDragPacingSnapshot = useRef<ReturnType<
     typeof getUndoableSlice
   > | null>(null);
+  const chatAbortRef = useRef<AbortController | null>(null);
 
   const tripId = trip?.id ?? null;
   useMercure(tripId, mercureToken);
 
   // Chat history is scoped to a single trip session. Wipe it whenever the
   // user switches trip so messages from trip A don't bleed into trip B's
-  // panel after navigation.
+  // panel after navigation. Also abort any chat request still in flight so
+  // the LLM server doesn't keep generating tokens for a panel that's gone.
   useEffect(() => {
     if (!tripId) return;
+    chatAbortRef.current?.abort();
+    chatAbortRef.current = null;
     useUiStore.getState().clearHistory();
   }, [tripId]);
 
@@ -752,11 +756,21 @@ export function useTripPlanner() {
     });
     uiStore.setChatSending(true);
 
+    // Track the in-flight request so the tripId useEffect can abort it on a
+    // trip switch. Any previous controller belongs to a settled request — we
+    // overwrite it without aborting (the request already completed).
+    const controller = new AbortController();
+    chatAbortRef.current = controller;
+
     try {
-      const { data, error, status } = await sendTripChat(tripId, {
-        message: trimmed,
-        context: { currentStage: uiStore.currentContext.currentStage },
-      });
+      const { data, error, status } = await sendTripChat(
+        tripId,
+        {
+          message: trimmed,
+          context: { currentStage: uiStore.currentContext.currentStage },
+        },
+        controller.signal,
+      );
 
       // Drop the response if the user switched trips while it was in-flight —
       // appending it would interleave trip A's reply into trip B's panel.

--- a/pwa/src/hooks/use-trip-planner.ts
+++ b/pwa/src/hooks/use-trip-planner.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
@@ -143,6 +143,14 @@ export function useTripPlanner() {
 
   const tripId = trip?.id ?? null;
   useMercure(tripId, mercureToken);
+
+  // Chat history is scoped to a single trip session. Wipe it whenever the
+  // user switches trip so messages from trip A don't bleed into trip B's
+  // panel after navigation.
+  useEffect(() => {
+    if (!tripId) return;
+    useUiStore.getState().clearHistory();
+  }, [tripId]);
 
   async function handleMagicLink(sourceUrl: string) {
     actions.clearTrip();

--- a/pwa/src/hooks/use-trip-planner.ts
+++ b/pwa/src/hooks/use-trip-planner.ts
@@ -797,7 +797,11 @@ export function useTripPlanner() {
       });
       return null;
     } finally {
-      useUiStore.getState().setChatSending(false);
+      // Only flip our own in-flight indicator off — a trip switch may have
+      // already started a fresh request whose flag we must not clobber.
+      if (useTripStore.getState().trip?.id === tripId) {
+        useUiStore.getState().setChatSending(false);
+      }
     }
   }
 

--- a/pwa/src/hooks/use-trip-planner.ts
+++ b/pwa/src/hooks/use-trip-planner.ts
@@ -758,6 +758,12 @@ export function useTripPlanner() {
         context: { currentStage: uiStore.currentContext.currentStage },
       });
 
+      // Drop the response if the user switched trips while it was in-flight —
+      // appending it would interleave trip A's reply into trip B's panel.
+      if (useTripStore.getState().trip?.id !== tripId) {
+        return null;
+      }
+
       if (error || !data) {
         const message =
           status === 429

--- a/pwa/src/hooks/use-trip-planner.ts
+++ b/pwa/src/hooks/use-trip-planner.ts
@@ -22,6 +22,8 @@ import {
   duplicateTrip,
   launchTripAnalysis,
   applyBatchRecompute,
+  sendTripChat,
+  type TripChatResponseBody,
 } from "@/lib/api/client";
 import { getRandomTripName } from "@/lib/trip-utils";
 import {
@@ -716,6 +718,74 @@ export function useTripPlanner() {
     }
   }
 
+  /**
+   * Dispatch a chat turn to `POST /trips/{id}/chat`, append both the user
+   * message and the assistant reply to {@link useUiStore.chatHistory}, and
+   * surface any actionable response (`split_stage`, `adjust_distance`, …) so
+   * downstream wiring can trigger the matching store action.
+   *
+   * The actual recomputation hook-up is delivered by issue #311 — this hook
+   * focuses on the round-trip, history bookkeeping, and exposing the parsed
+   * action via the returned value (and the assistant message in the store).
+   */
+  async function sendChatMessage(
+    text: string,
+  ): Promise<TripChatResponseBody | null> {
+    const trimmed = text.trim();
+    if (!trimmed) return null;
+    if (!tripId) return null;
+
+    const uiStore = useUiStore.getState();
+    uiStore.appendMessage({
+      role: "user",
+      content: trimmed,
+      ts: Date.now(),
+    });
+    uiStore.setChatSending(true);
+
+    try {
+      const { data, error, status } = await sendTripChat(tripId, {
+        message: trimmed,
+        context: { currentStage: uiStore.currentContext.currentStage },
+      });
+
+      if (error || !data) {
+        const message =
+          status === 429
+            ? t("aiBubble.errorRateLimit")
+            : status === 503
+              ? t("aiBubble.errorUnavailable")
+              : t("aiBubble.errorGeneric");
+        useUiStore.getState().appendMessage({
+          role: "assistant",
+          content: message,
+          ts: Date.now(),
+        });
+        return null;
+      }
+
+      useUiStore.getState().appendMessage({
+        role: "assistant",
+        content: data.response,
+        ts: Date.now(),
+      });
+
+      return data;
+    } catch (err) {
+      const message = isNetworkError(err)
+        ? t("aiBubble.errorNetwork")
+        : t("aiBubble.errorGeneric");
+      useUiStore.getState().appendMessage({
+        role: "assistant",
+        content: message,
+        ts: Date.now(),
+      });
+      return null;
+    } finally {
+      useUiStore.getState().setChatSending(false);
+    }
+  }
+
   const [isShareModalOpen, setShareModalOpen] = useState(false);
 
   function handleShareTrip(): void {
@@ -954,5 +1024,6 @@ export function useTripPlanner() {
     handleApplyBatch,
     handleCancelBatch,
     queueModification: actions.queueModification,
+    sendChatMessage,
   };
 }

--- a/pwa/src/hooks/use-trip-planner.ts
+++ b/pwa/src/hooks/use-trip-planner.ts
@@ -787,6 +787,13 @@ export function useTripPlanner() {
 
       return data;
     } catch (err) {
+      // Drop the error message if the user switched trips while the request
+      // was in flight — appending it would surface the previous trip's
+      // failure inside the new trip's panel.
+      if (useTripStore.getState().trip?.id !== tripId) {
+        return null;
+      }
+
       const message = isNetworkError(err)
         ? t("aiBubble.errorNetwork")
         : t("aiBubble.errorGeneric");

--- a/pwa/src/lib/api/client.ts
+++ b/pwa/src/lib/api/client.ts
@@ -376,6 +376,63 @@ export async function launchTripAnalysis(tripId: string): Promise<boolean> {
 }
 
 /**
+ * Body of `POST /trips/{id}/chat`. Mirrors `App\ApiResource\TripChatRequest`
+ * on the backend; declared locally until `make typegen` ingests the schema
+ * change introduced by issue #309.
+ */
+export interface TripChatRequestBody {
+  message: string;
+  context?: {
+    currentStage: number | null;
+  } | null;
+}
+
+/**
+ * Response of `POST /trips/{id}/chat`. Mirrors `App\ApiResource\TripChatResponse`
+ * on the backend (`tripId`, `action`, `params`, `response`, `dispatched`).
+ */
+export interface TripChatResponseBody {
+  tripId: string;
+  action: string;
+  params: Record<string, unknown>;
+  response: string;
+  dispatched: boolean;
+}
+
+/**
+ * Send a natural-language instruction to the LLaMA 3B dialogue assistant.
+ *
+ * Until the OpenAPI schema is regenerated (after #309 lands on main), the
+ * `/trips/{id}/chat` route is not yet exposed via `apiClient.POST`, so this
+ * function talks to the server through {@link apiFetch}. Once the typegen
+ * catches up, this can be swapped for a typed call.
+ */
+export async function sendTripChat(
+  tripId: string,
+  body: TripChatRequestBody,
+): Promise<{
+  data: TripChatResponseBody | null;
+  error: string | null;
+  status: number;
+}> {
+  const res = await apiFetch(`${API_URL}/trips/${tripId}/chat`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/ld+json",
+      Accept: "application/ld+json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    return { data: null, error: `HTTP ${res.status}`, status: res.status };
+  }
+
+  const data = (await res.json()) as TripChatResponseBody;
+  return { data, error: null, status: res.status };
+}
+
+/**
  * Duplicate an existing trip (deep-clone with all stages and settings).
  * Returns the new trip id on success, null on failure.
  */

--- a/pwa/src/lib/api/client.ts
+++ b/pwa/src/lib/api/client.ts
@@ -411,6 +411,7 @@ export interface TripChatResponseBody {
 export async function sendTripChat(
   tripId: string,
   body: TripChatRequestBody,
+  signal?: AbortSignal,
 ): Promise<{
   data: TripChatResponseBody | null;
   error: string | null;
@@ -423,6 +424,7 @@ export async function sendTripChat(
       Accept: "application/ld+json",
     },
     body: JSON.stringify(body),
+    signal,
   });
 
   if (!res.ok) {

--- a/pwa/src/lib/api/client.ts
+++ b/pwa/src/lib/api/client.ts
@@ -1,4 +1,5 @@
 import createClient, { type Middleware } from "openapi-fetch";
+import { z } from "zod";
 import type { components, operations, paths } from "./schema";
 import { API_URL } from "@/lib/constants";
 import { useAuthStore } from "@/store/auth-store";
@@ -428,9 +429,26 @@ export async function sendTripChat(
     return { data: null, error: `HTTP ${res.status}`, status: res.status };
   }
 
-  const data = (await res.json()) as TripChatResponseBody;
-  return { data, error: null, status: res.status };
+  const raw: unknown = await res.json();
+  const parsed = tripChatResponseSchema.safeParse(raw);
+  if (!parsed.success) {
+    return {
+      data: null,
+      error: "Invalid response shape",
+      status: res.status,
+    };
+  }
+
+  return { data: parsed.data, error: null, status: res.status };
 }
+
+const tripChatResponseSchema = z.object({
+  tripId: z.string(),
+  action: z.string(),
+  params: z.record(z.string(), z.unknown()),
+  response: z.string(),
+  dispatched: z.boolean(),
+});
 
 /**
  * Duplicate an existing trip (deep-clone with all stages and settings).

--- a/pwa/src/lib/api/schema.d.ts
+++ b/pwa/src/lib/api/schema.d.ts
@@ -1068,9 +1068,8 @@ export interface components {
             tripId?: string;
             /** @description Action interpreted by the dialogue assistant (split_stage, info, ...). */
             action?: string;
-            /** @description Parameters required to execute the action. */
             params?: {
-                [key: string]: string | null;
+                [key: string]: unknown;
             };
             /** @description Conversational reply to display to the rider. */
             response?: string;

--- a/pwa/src/lib/api/schema.d.ts
+++ b/pwa/src/lib/api/schema.d.ts
@@ -1073,7 +1073,7 @@ export interface components {
             };
             /** @description Conversational reply to display to the rider. */
             response: string;
-            /** @description True when the action triggered a backend recomputation. */
+            /** @description True when this action will trigger a backend recomputation (Messenger dispatch wired in #311). */
             dispatched: boolean;
         };
         "Trip.TripListItem.jsonld": components["schemas"]["HydraItemBaseSchema"] & {

--- a/pwa/src/lib/api/schema.d.ts
+++ b/pwa/src/lib/api/schema.d.ts
@@ -344,6 +344,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/trips/{id}/chat": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Send a natural-language instruction to the LLaMA 3B dialogue assistant.
+         * @description Send a natural-language instruction to the LLaMA 3B dialogue assistant.
+         */
+        post: operations["api_trips_idchat_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/trips/{id}/duplicate": {
         parameters: {
             query?: never;
@@ -1038,6 +1058,25 @@ export interface components {
         "Trip.TripBatchRecomputeRequest": {
             modifications: components["schemas"]["TripModification"][];
         };
+        "Trip.TripChatRequest": {
+            /** @description Natural language instruction or question from the rider. */
+            message: string;
+            context?: components["schemas"]["TripChatContext"] | null;
+        };
+        "Trip.TripChatResponse.jsonld": components["schemas"]["HydraItemBaseSchema"] & {
+            /** @description Trip identifier (UUID v7) the chat exchange belongs to. */
+            tripId?: string;
+            /** @description Action interpreted by the dialogue assistant (split_stage, info, ...). */
+            action?: string;
+            /** @description Parameters required to execute the action. */
+            params?: {
+                [key: string]: string | null;
+            };
+            /** @description Conversational reply to display to the rider. */
+            response?: string;
+            /** @description True when the action triggered a backend recomputation. */
+            dispatched?: boolean;
+        };
         "Trip.TripListItem.jsonld": components["schemas"]["HydraItemBaseSchema"] & {
             id?: string;
             title?: string | null;
@@ -1176,6 +1215,10 @@ export interface components {
             promptVersion: number;
             /** @description RFC3339 timestamp when the overview was generated */
             generatedAt: string;
+        };
+        TripChatContext: {
+            /** @description 1-indexed day number of the stage currently consulted, when applicable. */
+            currentStage?: number | null;
         };
         /**
          * @description Read-only trip detail resource for loading a persisted trip on the frontend.
@@ -2683,6 +2726,88 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ConstraintViolation"];
                     "application/json": components["schemas"]["ConstraintViolation"];
                 };
+            };
+        };
+    };
+    api_trips_idchat_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Trip identifier */
+                id: string;
+            };
+            cookie?: never;
+        };
+        /** @description The new Trip resource */
+        requestBody: {
+            content: {
+                "application/ld+json": components["schemas"]["Trip.TripChatRequest"];
+            };
+        };
+        responses: {
+            /** @description Trip resource created */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["Trip.TripChatResponse.jsonld"];
+                };
+            };
+            /** @description Invalid input */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["Error.jsonld"];
+                    "application/problem+json": components["schemas"]["Error"];
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["Error.jsonld"];
+                    "application/problem+json": components["schemas"]["Error"];
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Trip not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description An error occurred */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["ConstraintViolation.jsonld"];
+                    "application/problem+json": components["schemas"]["ConstraintViolation"];
+                    "application/json": components["schemas"]["ConstraintViolation"];
+                };
+            };
+            /** @description Rate limit reached */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description AI assistant unavailable */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };

--- a/pwa/src/lib/api/schema.d.ts
+++ b/pwa/src/lib/api/schema.d.ts
@@ -1065,16 +1065,16 @@ export interface components {
         };
         "Trip.TripChatResponse.jsonld": components["schemas"]["HydraItemBaseSchema"] & {
             /** @description Trip identifier (UUID v7) the chat exchange belongs to. */
-            tripId?: string;
+            tripId: string;
             /** @description Action interpreted by the dialogue assistant (split_stage, info, ...). */
-            action?: string;
-            params?: {
+            action: string;
+            params: {
                 [key: string]: unknown;
             };
             /** @description Conversational reply to display to the rider. */
-            response?: string;
+            response: string;
             /** @description True when the action triggered a backend recomputation. */
-            dispatched?: boolean;
+            dispatched: boolean;
         };
         "Trip.TripListItem.jsonld": components["schemas"]["HydraItemBaseSchema"] & {
             id?: string;

--- a/pwa/src/store/ui-store.ts
+++ b/pwa/src/store/ui-store.ts
@@ -460,6 +460,7 @@ export const useUiStore = create<UiState>()(
     clearHistory: () =>
       set((state) => {
         state.chatHistory = [];
+        state.isChatSending = false;
       }),
 
     setChatSending: (value) =>

--- a/pwa/src/store/ui-store.ts
+++ b/pwa/src/store/ui-store.ts
@@ -132,7 +132,7 @@ interface UiState {
   >;
   /**
    * Whether the floating AI assistant chat panel is currently open.
-   * Toggled by {@link toggleBubble}, {@link openBubble}, {@link closeBubble}.
+   * Toggled by {@link toggleBubble} / {@link closeBubble}.
    */
   isBubbleOpen: boolean;
   /**
@@ -154,7 +154,7 @@ interface UiState {
   /**
    * Whether the user has ever opened the AI bubble. Stored in
    * `localStorage` so the "Nouveau" badge only shows on the first visit.
-   * Hydrated from storage on mount via {@link markBubbleSeen}.
+   * Persisted by {@link toggleBubble} the first time the panel opens.
    */
   hasSeenBubble: boolean;
 
@@ -205,10 +205,8 @@ interface UiState {
   recordAnalysisStep: (step: string) => void;
   /** Mark a step as failed with a human-readable error message. */
   failAnalysisStep: (step: string, message: string) => void;
-  /** Flip {@link isBubbleOpen}. Also marks the bubble as seen. */
+  /** Flip {@link isBubbleOpen}. Also marks the bubble as seen on first open. */
   toggleBubble: () => void;
-  /** Force the chat panel open and mark the bubble as seen. */
-  openBubble: () => void;
   /** Force the chat panel closed. */
   closeBubble: () => void;
   /** Append a turn to {@link chatHistory}. */
@@ -219,8 +217,6 @@ interface UiState {
   clearHistory: () => void;
   /** Flip the in-flight indicator that drives the typing dots. */
   setChatSending: (value: boolean) => void;
-  /** Persist that the user has seen the bubble (suppresses the badge). */
-  markBubbleSeen: () => void;
 }
 
 const BUBBLE_SEEN_STORAGE_KEY = "btp.ai-bubble.seen";
@@ -433,15 +429,6 @@ export const useUiStore = create<UiState>()(
         }
       }),
 
-    openBubble: () =>
-      set((state) => {
-        state.isBubbleOpen = true;
-        if (!state.hasSeenBubble) {
-          state.hasSeenBubble = true;
-          writeBubbleSeenToStorage();
-        }
-      }),
-
     closeBubble: () =>
       set((state) => {
         state.isBubbleOpen = false;
@@ -466,13 +453,6 @@ export const useUiStore = create<UiState>()(
     setChatSending: (value) =>
       set((state) => {
         state.isChatSending = value;
-      }),
-
-    markBubbleSeen: () =>
-      set((state) => {
-        if (state.hasSeenBubble) return;
-        state.hasSeenBubble = true;
-        writeBubbleSeenToStorage();
       }),
   })),
 );

--- a/pwa/src/store/ui-store.ts
+++ b/pwa/src/store/ui-store.ts
@@ -26,6 +26,28 @@ export const STEPS: StepId[] = [
   "my_trip",
 ];
 
+/**
+ * One turn of the floating AI assistant conversation.
+ *
+ * Stored in-memory only — the dialogue history is intentionally not persisted
+ * across page reloads to mirror the backend-side {@link ChatHistoryStore} which
+ * uses a short-TTL Redis store per (trip, user) pair.
+ */
+export interface AiChatMessage {
+  role: "user" | "assistant";
+  content: string;
+  ts: number;
+}
+
+/**
+ * Conversational context propagated with every chat request so the dialogue
+ * assistant can resolve referential phrases such as « cette étape » against
+ * the stage the user is currently consulting.
+ */
+export interface AiChatContext {
+  currentStage: number | null;
+}
+
 interface UiState {
   isProcessing: boolean;
   isAccommodationScanning: boolean;
@@ -108,6 +130,33 @@ interface UiState {
       error: string | null;
     }
   >;
+  /**
+   * Whether the floating AI assistant chat panel is currently open.
+   * Toggled by {@link toggleBubble}, {@link openBubble}, {@link closeBubble}.
+   */
+  isBubbleOpen: boolean;
+  /**
+   * Conversation history of the floating AI assistant, oldest first. Cleared
+   * when the user starts a new trip or invokes {@link clearHistory}. Not
+   * persisted across reloads — the backend keeps the canonical history.
+   */
+  chatHistory: AiChatMessage[];
+  /**
+   * Conversational context the chat panel sends along with every message.
+   * Mirrors `TripChatContext` on the backend.
+   */
+  currentContext: AiChatContext;
+  /**
+   * `true` while a chat message is in flight — drives the typing indicator
+   * inside the chat panel and disables the send button.
+   */
+  isChatSending: boolean;
+  /**
+   * Whether the user has ever opened the AI bubble. Stored in
+   * `localStorage` so the "Nouveau" badge only shows on the first visit.
+   * Hydrated from storage on mount via {@link markBubbleSeen}.
+   */
+  hasSeenBubble: boolean;
 
   setProcessing: (value: boolean) => void;
   setAccommodationScanning: (value: boolean) => void;
@@ -156,6 +205,42 @@ interface UiState {
   recordAnalysisStep: (step: string) => void;
   /** Mark a step as failed with a human-readable error message. */
   failAnalysisStep: (step: string, message: string) => void;
+  /** Flip {@link isBubbleOpen}. Also marks the bubble as seen. */
+  toggleBubble: () => void;
+  /** Force the chat panel open and mark the bubble as seen. */
+  openBubble: () => void;
+  /** Force the chat panel closed. */
+  closeBubble: () => void;
+  /** Append a turn to {@link chatHistory}. */
+  appendMessage: (message: AiChatMessage) => void;
+  /** Update the conversational context broadcast to the chat endpoint. */
+  setCurrentContext: (context: AiChatContext) => void;
+  /** Reset the chat history (Acte 1.5 → Acte 3 transition, manual clear). */
+  clearHistory: () => void;
+  /** Flip the in-flight indicator that drives the typing dots. */
+  setChatSending: (value: boolean) => void;
+  /** Persist that the user has seen the bubble (suppresses the badge). */
+  markBubbleSeen: () => void;
+}
+
+const BUBBLE_SEEN_STORAGE_KEY = "btp.ai-bubble.seen";
+
+function readBubbleSeenFromStorage(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(BUBBLE_SEEN_STORAGE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function writeBubbleSeenToStorage(): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(BUBBLE_SEEN_STORAGE_KEY, "1");
+  } catch {
+    // localStorage may be unavailable (private mode, quota) — degrade silently.
+  }
 }
 
 /**
@@ -205,6 +290,11 @@ export const useUiStore = create<UiState>()(
     isAnalysisPhaseActive: false,
     analysisProgress: null,
     analysisStepStates: {},
+    isBubbleOpen: false,
+    chatHistory: [],
+    currentContext: { currentStage: null },
+    isChatSending: false,
+    hasSeenBubble: readBubbleSeenFromStorage(),
 
     setProcessing: (value) =>
       set((state) => {
@@ -331,6 +421,57 @@ export const useUiStore = create<UiState>()(
           status: "failed",
           error: message,
         };
+      }),
+
+    toggleBubble: () =>
+      set((state) => {
+        const next = !state.isBubbleOpen;
+        state.isBubbleOpen = next;
+        if (next && !state.hasSeenBubble) {
+          state.hasSeenBubble = true;
+          writeBubbleSeenToStorage();
+        }
+      }),
+
+    openBubble: () =>
+      set((state) => {
+        state.isBubbleOpen = true;
+        if (!state.hasSeenBubble) {
+          state.hasSeenBubble = true;
+          writeBubbleSeenToStorage();
+        }
+      }),
+
+    closeBubble: () =>
+      set((state) => {
+        state.isBubbleOpen = false;
+      }),
+
+    appendMessage: (message) =>
+      set((state) => {
+        state.chatHistory.push(message);
+      }),
+
+    setCurrentContext: (context) =>
+      set((state) => {
+        state.currentContext = context;
+      }),
+
+    clearHistory: () =>
+      set((state) => {
+        state.chatHistory = [];
+      }),
+
+    setChatSending: (value) =>
+      set((state) => {
+        state.isChatSending = value;
+      }),
+
+    markBubbleSeen: () =>
+      set((state) => {
+        if (state.hasSeenBubble) return;
+        state.hasSeenBubble = true;
+        writeBubbleSeenToStorage();
       }),
   })),
 );

--- a/pwa/tests/mocked/ai-bubble.spec.ts
+++ b/pwa/tests/mocked/ai-bubble.spec.ts
@@ -281,3 +281,51 @@ test.describe("AiBubble — error handling", () => {
     ).toContainText(/erreur réseau/i, { timeout: 5_000 });
   });
 });
+
+test.describe("AiBubble — cross-trip isolation", () => {
+  test("clears chat history when the active trip changes", async ({
+    createFullTrip,
+    mockedPage,
+  }) => {
+    await createFullTrip();
+
+    const captured: { body: unknown }[] = [];
+    await mockChat(
+      mockedPage,
+      { action: "info", params: {}, response: "Reply from trip A." },
+      captured,
+    );
+
+    // Send one message so chatHistory is non-empty (the panel also renders a
+    // static greeting bubble, so the transcript holds 3 messages here).
+    await mockedPage.getByTestId("ai-bubble").click();
+    await mockedPage.getByTestId("ai-chat-panel-input").fill("Hello trip A");
+    await mockedPage.getByTestId("ai-chat-panel-send").click();
+    await expect(
+      mockedPage
+        .getByTestId("ai-chat-panel-message")
+        .filter({ hasText: /Reply from trip A/i }),
+    ).toBeVisible({ timeout: 5_000 });
+    await expect(mockedPage.getByTestId("ai-chat-panel-message")).toHaveCount(
+      3,
+    );
+    await mockedPage.getByTestId("ai-chat-panel-close").click();
+
+    // Switch the active trip identifier in the store — the trip-planner
+    // useEffect keyed on tripId should fire and call clearHistory().
+    await mockedPage.evaluate(() => {
+      window.dispatchEvent(
+        new CustomEvent("__test_set_trip_id", {
+          detail: "01999999-0000-7000-8000-000000000099",
+        }),
+      );
+    });
+
+    // Reopening the bubble must only render the static greeting, not the
+    // user/assistant turns from the previous trip.
+    await mockedPage.getByTestId("ai-bubble").click();
+    await expect(mockedPage.getByTestId("ai-chat-panel-message")).toHaveCount(
+      1,
+    );
+  });
+});

--- a/pwa/tests/mocked/ai-bubble.spec.ts
+++ b/pwa/tests/mocked/ai-bubble.spec.ts
@@ -98,14 +98,9 @@ test.describe("AiBubble — chat round-trip", () => {
 
     // Select stage 3 so `activeDayNumber` propagates into `currentContext`.
     await mockedPage.evaluate(() => {
-      const store = (
-        window as Window & {
-          __zustand_ui_store?: {
-            setState: (s: Record<string, unknown>) => void;
-          };
-        }
-      ).__zustand_ui_store;
-      store?.setState({ activeDayNumber: 3 });
+      window.dispatchEvent(
+        new CustomEvent("__test_set_active_day_number", { detail: 3 }),
+      );
     });
 
     await mockedPage.getByTestId("ai-bubble").click();
@@ -197,14 +192,9 @@ test.describe("AiBubble — visibility gating", () => {
     await expect(mockedPage.getByTestId("ai-bubble")).toBeVisible();
 
     await mockedPage.evaluate(() => {
-      const store = (
-        window as Window & {
-          __zustand_ui_store?: {
-            setState: (s: Record<string, unknown>) => void;
-          };
-        }
-      ).__zustand_ui_store;
-      store?.setState({ isAnalysisPhaseActive: true });
+      window.dispatchEvent(
+        new CustomEvent("__test_set_analysis_started", { detail: true }),
+      );
     });
 
     await expect(mockedPage.getByTestId("ai-bubble")).toHaveCount(0);

--- a/pwa/tests/mocked/ai-bubble.spec.ts
+++ b/pwa/tests/mocked/ai-bubble.spec.ts
@@ -1,0 +1,231 @@
+import { test, expect } from "../fixtures/base.fixture";
+import { fullTripEventSequence } from "../fixtures/mock-data";
+import { getTripId } from "../fixtures/api-mocks";
+
+/**
+ * Issue #310 — AiBubble floating assistant.
+ *
+ * Coverage:
+ *  - The bubble opens/closes a 400×500 chat panel from the bottom right.
+ *  - Submitting a message round-trips through `POST /trips/{id}/chat` and
+ *    appends the assistant reply to the conversation.
+ *  - Context-aware: the body sent to the backend carries
+ *    `context.currentStage` matching the active day number.
+ *  - Actionable replies (action != "info") trigger an
+ *    `ai-chat-action` CustomEvent so the recomputation wiring (#311) can
+ *    plug in without coupling to the panel.
+ *  - The bubble is hidden during Acte 2 (`isAnalysisPhaseActive=true`).
+ *  - On mobile viewports the panel covers the full screen.
+ */
+
+function chatUrlPattern(): RegExp {
+  return new RegExp(
+    `/trips/${getTripId().replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&")}/chat$`,
+  );
+}
+
+async function mockChat(
+  page: import("@playwright/test").Page,
+  responseBody: {
+    action: string;
+    params: Record<string, unknown>;
+    response: string;
+    dispatched?: boolean;
+  },
+  capturedRequests: { body: unknown }[],
+): Promise<void> {
+  await page.route(chatUrlPattern(), async (route, request) => {
+    if (request.method() !== "POST") return route.fallback();
+    try {
+      capturedRequests.push({ body: JSON.parse(request.postData() ?? "{}") });
+    } catch {
+      capturedRequests.push({ body: null });
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/ld+json",
+      body: JSON.stringify({
+        tripId: getTripId(),
+        action: responseBody.action,
+        params: responseBody.params,
+        response: responseBody.response,
+        dispatched: responseBody.dispatched ?? false,
+      }),
+    });
+  });
+}
+
+test.describe("AiBubble — open/close", () => {
+  test("opens the chat panel when clicked and closes it via the close button", async ({
+    createFullTrip,
+    mockedPage,
+  }) => {
+    await createFullTrip();
+
+    const bubble = mockedPage.getByTestId("ai-bubble");
+    await expect(bubble).toBeVisible({ timeout: 10_000 });
+
+    await expect(mockedPage.getByTestId("ai-chat-panel")).toHaveCount(0);
+
+    await bubble.click();
+    await expect(mockedPage.getByTestId("ai-chat-panel")).toBeVisible();
+
+    // The "Nouveau" badge disappears on first open and stays gone across toggles.
+    await expect(mockedPage.getByTestId("ai-bubble-badge")).toHaveCount(0);
+
+    await mockedPage.getByTestId("ai-chat-panel-close").click();
+    await expect(mockedPage.getByTestId("ai-chat-panel")).toHaveCount(0);
+  });
+});
+
+test.describe("AiBubble — chat round-trip", () => {
+  test("sends a message, appends the assistant reply, and propagates currentStage in the context", async ({
+    createFullTrip,
+    mockedPage,
+  }) => {
+    await createFullTrip();
+
+    const captured: { body: unknown }[] = [];
+    await mockChat(
+      mockedPage,
+      {
+        action: "info",
+        params: {},
+        response: "Compris, voici ce que je peux vous dire…",
+      },
+      captured,
+    );
+
+    // Select stage 3 so `activeDayNumber` propagates into `currentContext`.
+    await mockedPage.evaluate(() => {
+      const store = (
+        window as Window & {
+          __zustand_ui_store?: {
+            setState: (s: Record<string, unknown>) => void;
+          };
+        }
+      ).__zustand_ui_store;
+      store?.setState({ activeDayNumber: 3 });
+    });
+
+    await mockedPage.getByTestId("ai-bubble").click();
+    await expect(mockedPage.getByTestId("ai-chat-panel-hint")).toContainText(
+      /étape 3/i,
+    );
+
+    const input = mockedPage.getByTestId("ai-chat-panel-input");
+    await input.fill("Que penses-tu de cette étape ?");
+    await mockedPage.getByTestId("ai-chat-panel-send").click();
+
+    // The assistant bubble appears in the history.
+    await expect(
+      mockedPage
+        .getByTestId("ai-chat-panel-message")
+        .filter({ hasText: /Compris, voici ce que je peux vous dire/i }),
+    ).toBeVisible({ timeout: 5_000 });
+
+    expect(captured).toHaveLength(1);
+    const body = captured[0]?.body as {
+      message?: string;
+      context?: { currentStage?: number | null };
+    };
+    expect(body.message).toBe("Que penses-tu de cette étape ?");
+    expect(body.context?.currentStage).toBe(3);
+  });
+
+  test("dispatches an ai-chat-action event for actionable replies", async ({
+    createFullTrip,
+    mockedPage,
+  }) => {
+    await createFullTrip();
+
+    await mockChat(
+      mockedPage,
+      {
+        action: "split_stage",
+        params: { stage: 3 },
+        response: "Bien sûr, je divise l'étape 3.",
+        dispatched: true,
+      },
+      [],
+    );
+
+    // Subscribe before triggering the round-trip so we capture the event.
+    await mockedPage.evaluate(() => {
+      const w = window as Window & { __aiChatActionDetail?: unknown };
+      document.addEventListener(
+        "ai-chat-action",
+        (event) => {
+          w.__aiChatActionDetail = (event as CustomEvent<unknown>).detail;
+        },
+        { once: true },
+      );
+    });
+
+    await mockedPage.getByTestId("ai-bubble").click();
+    await mockedPage
+      .getByTestId("ai-chat-panel-input")
+      .fill("Divise l'étape 3");
+    await mockedPage.getByTestId("ai-chat-panel-send").click();
+
+    await expect(
+      mockedPage
+        .getByTestId("ai-chat-panel-message")
+        .filter({ hasText: /je divise l'étape 3/i }),
+    ).toBeVisible({ timeout: 5_000 });
+
+    const detail = await mockedPage.evaluate(
+      () =>
+        (window as Window & { __aiChatActionDetail?: unknown })
+          .__aiChatActionDetail,
+    );
+    expect(detail).toMatchObject({
+      action: "split_stage",
+      params: { stage: 3 },
+      dispatched: true,
+    });
+  });
+});
+
+test.describe("AiBubble — visibility gating", () => {
+  test("is hidden while Acte 2 (analysis phase) is active", async ({
+    createFullTrip,
+    mockedPage,
+  }) => {
+    await createFullTrip();
+
+    await expect(mockedPage.getByTestId("ai-bubble")).toBeVisible();
+
+    await mockedPage.evaluate(() => {
+      const store = (
+        window as Window & {
+          __zustand_ui_store?: {
+            setState: (s: Record<string, unknown>) => void;
+          };
+        }
+      ).__zustand_ui_store;
+      store?.setState({ isAnalysisPhaseActive: true });
+    });
+
+    await expect(mockedPage.getByTestId("ai-bubble")).toHaveCount(0);
+  });
+});
+
+test.describe("AiBubble — responsive", () => {
+  test("renders the panel as a full-screen sheet on mobile", async ({
+    createFullTrip,
+    mockedPage,
+  }) => {
+    await mockedPage.setViewportSize({ width: 375, height: 800 });
+
+    await createFullTrip();
+
+    await mockedPage.getByTestId("ai-bubble").click();
+    const panel = mockedPage.getByTestId("ai-chat-panel");
+    await expect(panel).toBeVisible();
+
+    const box = await panel.boundingBox();
+    expect(box?.width).toBeGreaterThanOrEqual(350);
+    expect(box?.height).toBeGreaterThanOrEqual(700);
+  });
+});

--- a/pwa/tests/mocked/ai-bubble.spec.ts
+++ b/pwa/tests/mocked/ai-bubble.spec.ts
@@ -219,3 +219,65 @@ test.describe("AiBubble — responsive", () => {
     expect(box?.height).toBeGreaterThanOrEqual(700);
   });
 });
+
+test.describe("AiBubble — error handling", () => {
+  test("surfaces the rate-limit message on HTTP 429", async ({
+    createFullTrip,
+    mockedPage,
+  }) => {
+    await createFullTrip();
+    await mockedPage.route(chatUrlPattern(), (route) =>
+      route.fulfill({
+        status: 429,
+        contentType: "application/problem+json",
+        body: "{}",
+      }),
+    );
+
+    await mockedPage.getByTestId("ai-bubble").click();
+    await mockedPage.getByTestId("ai-chat-panel-input").fill("test");
+    await mockedPage.getByTestId("ai-chat-panel-send").click();
+
+    await expect(
+      mockedPage.getByTestId("ai-chat-panel-message").last(),
+    ).toContainText(/limite de messages/i, { timeout: 5_000 });
+  });
+
+  test("surfaces the unavailable message on HTTP 503", async ({
+    createFullTrip,
+    mockedPage,
+  }) => {
+    await createFullTrip();
+    await mockedPage.route(chatUrlPattern(), (route) =>
+      route.fulfill({
+        status: 503,
+        contentType: "application/problem+json",
+        body: "{}",
+      }),
+    );
+
+    await mockedPage.getByTestId("ai-bubble").click();
+    await mockedPage.getByTestId("ai-chat-panel-input").fill("test");
+    await mockedPage.getByTestId("ai-chat-panel-send").click();
+
+    await expect(
+      mockedPage.getByTestId("ai-chat-panel-message").last(),
+    ).toContainText(/temporairement indisponible/i, { timeout: 5_000 });
+  });
+
+  test("surfaces the network message on connection failure", async ({
+    createFullTrip,
+    mockedPage,
+  }) => {
+    await createFullTrip();
+    await mockedPage.route(chatUrlPattern(), (route) => route.abort("failed"));
+
+    await mockedPage.getByTestId("ai-bubble").click();
+    await mockedPage.getByTestId("ai-chat-panel-input").fill("test");
+    await mockedPage.getByTestId("ai-chat-panel-send").click();
+
+    await expect(
+      mockedPage.getByTestId("ai-chat-panel-message").last(),
+    ).toContainText(/erreur réseau/i, { timeout: 5_000 });
+  });
+});

--- a/pwa/tests/mocked/ai-bubble.spec.ts
+++ b/pwa/tests/mocked/ai-bubble.spec.ts
@@ -328,4 +328,44 @@ test.describe("AiBubble — cross-trip isolation", () => {
       1,
     );
   });
+
+  test("discards a stale network error after a trip switch", async ({
+    createFullTrip,
+    mockedPage,
+  }) => {
+    await createFullTrip();
+
+    // Hold the chat request so we can switch trips before it settles.
+    let releaseRoute!: () => void;
+    await mockedPage.route(chatUrlPattern(), async (route) => {
+      await new Promise<void>((res) => {
+        releaseRoute = res;
+      });
+      await route.abort("failed");
+    });
+
+    await mockedPage.getByTestId("ai-bubble").click();
+    await mockedPage.getByTestId("ai-chat-panel-input").fill("Hello trip A");
+    await mockedPage.getByTestId("ai-chat-panel-send").click();
+    await mockedPage.getByTestId("ai-chat-panel-close").click();
+
+    // Switch trips while the request is still in-flight.
+    await mockedPage.evaluate(() => {
+      window.dispatchEvent(
+        new CustomEvent("__test_set_trip_id", {
+          detail: "01999999-0000-7000-8000-000000000099",
+        }),
+      );
+    });
+
+    // Re-open the bubble on the new trip, then let the stale request fail.
+    await mockedPage.getByTestId("ai-bubble").click();
+    releaseRoute();
+
+    // Only the static greeting should remain — no error bubble from trip A.
+    await expect(mockedPage.getByTestId("ai-chat-panel-message")).toHaveCount(
+      1,
+      { timeout: 5_000 },
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Implements [#310](https://github.com/vincentchalamon/bike-trip-planner/issues/310) — bottom-right floating bubble + chat panel for conversational trip edits.

- `AiBubble` with sparkles icon, "Nouveau" badge persisted in `localStorage`, hidden during Acte 2 (analysis phase), syncs `currentContext.currentStage` from `activeDayNumber`.
- `AiChatPanel` slides up 400×500 desktop, fullscreen mobile; close button, user/AI bubbles, typing dots, Enter-to-send / Shift+Enter for newline, Escape closes.
- `sendChatMessage(text)` in `useTripPlanner` hits `POST /trips/{id}/chat`, appends turns to history, handles 429/503/network errors with i18n fallbacks.
- New `aiBubble.*` translations (fr/en).
- Emits an `ai-chat-action` `CustomEvent` for non-`info` replies — full recomputation wiring lands in #311.
- Playwright mocked spec covers open/close, message round-trip with `currentStage` propagation, action event dispatch, Acte 2 visibility gating, mobile fullscreen layout.

## Auto-critique

- `TripChatRequestBody` / `TripChatResponseBody` types live locally in `pwa/src/lib/api/client.ts` mirroring the backend DTOs; `make typegen` (run in #309) regenerates the OpenAPI schema, but the local types are kept for clarity until the typed client is rewired.

## Test plan

- [x] `make qa`
- [x] `make test-e2e ARGS="tests/mocked/ai-bubble.spec.ts"`
- [ ] CI green

Base branch: `feature/309` (stacked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

**Commit reviewed:** `993a0cd875175764f42805ee30be8abc42372e2b`

This is a clean, thoroughly iterated implementation. Across twelve commits the entire correctness surface has been covered: Zod validates the wire response, the 2 000-char cap is enforced at both DOM and function level, all three error branches (success, HTTP error, catch) carry stale-trip guards pinned by dedicated Playwright regressions, and — as of the final commit — in-flight LLM requests are aborted via `AbortController` when the user navigates away from a trip.

**Resolved threads:** Resolved 1 previously open bot-authored thread (`PRRT_kwDORUitfM6DGf1G` — AbortController suggestion, now implemented). Dismissed and minimized 13 previous bot reviews.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

---
Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->