### PR TITLE
feat(llm): wire chat actions to inline recomputation

### DIFF
--- a/api/src/ApiResource/TripChatResponse.php
+++ b/api/src/ApiResource/TripChatResponse.php
@@ -18,6 +18,8 @@ final readonly class TripChatResponse
 {
     /**
      * @param array<string, mixed> $params
+     * @param list<int>            $impactedStageNumbers Day numbers (1-indexed) whose recomputation has been dispatched.
+     *                                                   Empty when the action is informational or requires full analysis.
      */
     public function __construct(
         #[ApiProperty(description: 'Trip identifier (UUID v7) the chat exchange belongs to.', required: true)]
@@ -30,6 +32,10 @@ final readonly class TripChatResponse
         public string $response,
         #[ApiProperty(description: 'True when this action will trigger a backend recomputation (Messenger dispatch wired in #311).', required: true)]
         public bool $dispatched = false,
+        #[ApiProperty(description: 'Day numbers (1-indexed) whose recomputation has been dispatched.')]
+        public array $impactedStageNumbers = [],
+        #[ApiProperty(description: 'True when the action requires a full trip re-analysis (Acte 2).')]
+        public bool $requiresFullAnalysis = false,
     ) {
     }
 }

--- a/api/src/Llm/ChatActionInterpreter.php
+++ b/api/src/Llm/ChatActionInterpreter.php
@@ -140,6 +140,7 @@ final readonly class ChatActionInterpreter
             ChatAction::ACTION_ADD_WAYPOINT => $this->normaliseAddWaypoint($params),
             ChatAction::ACTION_CHANGE_ACCOMMODATION => $this->normaliseChangeAccommodation($params),
             ChatAction::ACTION_ADJUST_DISTANCE => $this->normaliseAdjustDistance($params),
+            ChatAction::ACTION_CHANGE_ROUTE => [],
             ChatAction::ACTION_INFO => [],
             default => null,
         };

--- a/api/src/Llm/Dto/ChatAction.php
+++ b/api/src/Llm/Dto/ChatAction.php
@@ -24,6 +24,8 @@ final readonly class ChatAction
 
     public const string ACTION_ADJUST_DISTANCE = 'adjust_distance';
 
+    public const string ACTION_CHANGE_ROUTE = 'change_route';
+
     public const string ACTION_INFO = 'info';
 
     /**
@@ -35,6 +37,7 @@ final readonly class ChatAction
         self::ACTION_ADD_WAYPOINT,
         self::ACTION_CHANGE_ACCOMMODATION,
         self::ACTION_ADJUST_DISTANCE,
+        self::ACTION_CHANGE_ROUTE,
         self::ACTION_INFO,
     ];
 

--- a/api/src/Llm/LlmAnalysisTracker.php
+++ b/api/src/Llm/LlmAnalysisTracker.php
@@ -92,6 +92,28 @@ final readonly class LlmAnalysisTracker implements LlmAnalysisTrackerInterface
         return $this->claim($this->readyClaimKey($tripId));
     }
 
+    public function markSkipAiAnalysis(string $tripId): void
+    {
+        $item = $this->tripStateCache->getItem($this->skipAiAnalysisKey($tripId));
+        $item->set(true);
+        $item->expiresAfter(self::TTL);
+
+        $this->tripStateCache->save($item);
+    }
+
+    public function consumeSkipAiAnalysis(string $tripId): bool
+    {
+        $key = $this->skipAiAnalysisKey($tripId);
+        $item = $this->tripStateCache->getItem($key);
+        if (!$item->isHit()) {
+            return false;
+        }
+
+        $this->tripStateCache->deleteItem($key);
+
+        return true === $item->get();
+    }
+
     /**
      * Atomic NX-claim via Symfony Lock with autoRelease disabled — the lock survives
      * the request and acts as a single-use slot for the TTL lifetime.
@@ -126,5 +148,10 @@ final readonly class LlmAnalysisTracker implements LlmAnalysisTrackerInterface
     private function readyClaimKey(string $tripId): string
     {
         return \sprintf('trip.%s.llm_ready_claimed', $tripId);
+    }
+
+    private function skipAiAnalysisKey(string $tripId): string
+    {
+        return \sprintf('trip.%s.llm_skip_analysis', $tripId);
     }
 }

--- a/api/src/Llm/LlmAnalysisTrackerInterface.php
+++ b/api/src/Llm/LlmAnalysisTrackerInterface.php
@@ -56,4 +56,21 @@ interface LlmAnalysisTrackerInterface
      * retried by the messenger.
      */
     public function claimTripReadyPublication(string $tripId): bool;
+
+    /**
+     * Marks the next pending enrichment cycle as "skip LLaMA 8B re-analysis".
+     *
+     * Used by chat-driven inline edits (issue #311): when the rider acts on the
+     * trip via the AI bubble, the recomputation pipeline reruns the geographic
+     * scans but the AI overview should NOT be invalidated by default. The flag
+     * is consumed by the gate handler so it only impacts the very next cycle.
+     */
+    public function markSkipAiAnalysis(string $tripId): void;
+
+    /**
+     * Atomically reads and clears the "skip LLaMA 8B re-analysis" marker.
+     *
+     * Returns true when the marker was set (and is now consumed), false otherwise.
+     */
+    public function consumeSkipAiAnalysis(string $tripId): bool;
 }

--- a/api/src/Llm/SystemPrompt/dialogue.txt
+++ b/api/src/Llm/SystemPrompt/dialogue.txt
@@ -52,6 +52,7 @@ texte avant ni après. Schéma :
 | `add_waypoint`        | `{ "name": <string>, "stage": <int|null> }`    | Ajoute un point d'intérêt (détour) à l'itinéraire. |
 | `change_accommodation`| `{ "stage": <int>, "type": <string> }`         | Change le type d'hébergement (valeurs autorisées : `camp_site`, `hostel`, `alpine_hut`, `chalet`, `guest_house`, `motel`, `hotel`, `wilderness_hut`, `shelter`). |
 | `adjust_distance`     | `{ "stage": <int>, "km": <number> }`           | Modifie la distance cible d'une étape.              |
+| `change_route`        | `{}`                                           | Modification du tracé global (nécessite Acte 2).    |
 | `info`                | `{}`                                           | Question d'information : pas de modification.       |
 
 Si la demande ne correspond à aucune action, utilise `info` et explique simplement
@@ -103,6 +104,13 @@ Utilisateur : « Allonge l'étape 5 à 95 km »
   "action": "adjust_distance",
   "params": { "stage": 5, "km": 95 },
   "response": "Je porte l'étape 5 à 95 km. Je revérifie le profil et le timing d'arrivée pour confirmer que ça reste tenable."
+}
+
+Utilisateur : « Change l'itinéraire pour passer par la côte »
+{
+  "action": "change_route",
+  "params": {},
+  "response": "Cette modification touche l'ensemble du tracé : il faut relancer une analyse complète pour recalculer toutes les étapes et les enrichissements."
 }
 
 Utilisateur : « Quelle est la différence entre gravel et bikepacking ? »

--- a/api/src/Message/RecalculateStages.php
+++ b/api/src/Message/RecalculateStages.php
@@ -12,6 +12,9 @@ final readonly class RecalculateStages
      * @param bool      $skipGeographicScans   Skip ALL geographic scans (POIs, accommodations, bike shops, terrain).
      *                                         Takes precedence over $skipAccommodationScan: when true,
      *                                         $skipAccommodationScan is irrelevant.
+     * @param bool      $skipAiAnalysis        Skip the LLaMA 8B pass-1 / pass-2 re-analysis at the end of the
+     *                                         enrichment chain. Used by chat-driven inline edits so the rider can
+     *                                         iterate quickly without re-paying the LLM cost on every tweak.
      */
     public function __construct(
         public string $tripId,
@@ -19,6 +22,7 @@ final readonly class RecalculateStages
         public bool $skipAccommodationScan = false,
         public bool $skipGeographicScans = false,
         public ?int $generation = null,
+        public bool $skipAiAnalysis = false,
     ) {
     }
 }

--- a/api/src/MessageHandler/AllEnrichmentsCompletedHandler.php
+++ b/api/src/MessageHandler/AllEnrichmentsCompletedHandler.php
@@ -81,9 +81,17 @@ final readonly class AllEnrichmentsCompletedHandler
 
         $analysableStages = $this->countAnalysableStages($stages);
 
-        // Short-circuit: when the LLM is disabled OR there is no stage to analyse
-        // (e.g. all rest days), publish TRIP_READY directly — no AI overview to await.
-        if (!$this->llmClient->isEnabled() || 0 === $analysableStages) {
+        // Issue #311 — chat-driven inline edits set a one-shot "skip AI" marker via
+        // the LlmAnalysisTracker. When present, consume it now so the gate behaves
+        // exactly like the "LLM disabled" branch: publish TRIP_READY directly and
+        // do not invalidate the existing AI overview / per-stage briefings.
+        $skipAiAnalysis = $this->llmTracker->consumeSkipAiAnalysis($tripId);
+
+        // Short-circuit: when the LLM is disabled, when the rider explicitly opted
+        // out of re-analysis via the chat bubble, or when there is no stage to
+        // analyse (e.g. all rest days), publish TRIP_READY directly — no AI
+        // overview to await.
+        if (!$this->llmClient->isEnabled() || $skipAiAnalysis || 0 === $analysableStages) {
             $this->publisher->publishTripReady($tripId, $stages, [
                 'status' => $statuses,
             ]);

--- a/api/src/MessageHandler/RecalculateStagesHandler.php
+++ b/api/src/MessageHandler/RecalculateStagesHandler.php
@@ -9,6 +9,7 @@ use App\ApiResource\Model\Coordinate;
 use App\ApiResource\Stage;
 use App\ComputationTracker\ComputationTrackerInterface;
 use App\ComputationTracker\TripGenerationTrackerInterface;
+use App\Llm\LlmAnalysisTrackerInterface;
 use App\Mercure\MercureEventType;
 use App\Mercure\TripUpdatePublisherInterface;
 use App\Message\AnalyzeTerrain;
@@ -32,6 +33,7 @@ final readonly class RecalculateStagesHandler extends AbstractTripMessageHandler
         LoggerInterface $logger,
         private TripRequestRepositoryInterface $tripStateManager,
         MessageBusInterface $messageBus,
+        private LlmAnalysisTrackerInterface $llmTracker,
     ) {
         parent::__construct($computationTracker, $publisher, $generationTracker, $logger, $tripStateManager, $messageBus);
     }
@@ -55,6 +57,15 @@ final readonly class RecalculateStagesHandler extends AbstractTripMessageHandler
 
         if (null === $stages) {
             return;
+        }
+
+        // Inline edits (issue #311): when the caller signals "skip AI re-analysis",
+        // mark the trip so the downstream gate handler skips dispatching the
+        // LLaMA 8B passes. The marker is consumed (one-shot) by the gate handler.
+        // Set after the stages guard so a dangling marker can't leak to an
+        // unrelated AllEnrichmentsCompleted cycle if stage data is missing.
+        if ($message->skipAiAnalysis) {
+            $this->llmTracker->markSkipAiAnalysis($tripId);
         }
 
         $affectedIndices = $message->affectedIndices;

--- a/api/src/State/TripChatProcessor.php
+++ b/api/src/State/TripChatProcessor.php
@@ -10,12 +10,15 @@ use ApiPlatform\State\ProcessorInterface;
 use App\ApiResource\TripChatRequest;
 use App\ApiResource\TripChatResponse;
 use App\Entity\User;
+use App\ComputationTracker\TripGenerationTrackerInterface;
 use App\Llm\ChatActionInterpreter;
 use App\Llm\ChatHistoryStore;
 use App\Llm\Dto\ChatAction;
 use App\Llm\Exception\OllamaUnavailableException;
 use App\Llm\LlmClientInterface;
 use App\Llm\SystemPromptLoader;
+use App\Message\RecalculateStages;
+use App\Repository\TripRequestRepositoryInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
@@ -23,6 +26,7 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
 use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\RateLimiter\RateLimiterFactory;
 
 /**
@@ -53,10 +57,8 @@ final readonly class TripChatProcessor implements ProcessorInterface
     /**
      * Actions that mutate the trip and therefore require backend recomputation.
      *
-     * The actual Messenger dispatch is intentionally deferred to a follow-up
-     * issue (#311): the chat endpoint signals the intent via `dispatched=true`
-     * so the frontend can show a "computing" state, while the message routing
-     * itself remains a single point to extend.
+     * Each non-info, non-change_route action is mapped to a {@see RecalculateStages}
+     * dispatch (with `skipAiAnalysis: true`) by {@see self::dispatchRecomputation()}.
      *
      * @var list<string>
      */
@@ -71,12 +73,15 @@ final readonly class TripChatProcessor implements ProcessorInterface
     private string $model;
 
     public function __construct(
+        private TripRequestRepositoryInterface $tripStateManager,
         private LlmClientInterface $llmClient,
         private SystemPromptLoader $promptLoader,
         private ChatActionInterpreter $interpreter,
         private ChatHistoryStore $historyStore,
         private Security $security,
         private LoggerInterface $logger,
+        private MessageBusInterface $messageBus,
+        private TripGenerationTrackerInterface $generationTracker,
         #[Autowire(service: 'limiter.trip_chat')]
         private RateLimiterFactory $tripChatLimiter,
         #[Autowire(env: 'default::OLLAMA_DIALOGUE_MODEL')]
@@ -168,14 +173,25 @@ final readonly class TripChatProcessor implements ProcessorInterface
             ['role' => 'assistant', 'content' => $rawContent],
         ]);
 
-        $dispatched = \in_array($action->action, self::RECOMPUTE_ACTIONS, true);
+        $impactedStageNumbers = $this->resolveImpactedStageNumbers($tripId, $action);
+        $requiresFullAnalysis = ChatAction::ACTION_CHANGE_ROUTE === $action->action;
+        $dispatched = false;
 
-        if ($dispatched) {
-            $this->logger->info('Chat action ready for recomputation.', [
+        if ($requiresFullAnalysis) {
+            $this->logger->info('Chat action requires full trip re-analysis (Acte 2).', [
                 'tripId' => $tripId,
                 'action' => $action->action,
-                'params' => $action->params,
             ]);
+        } elseif ([] !== $impactedStageNumbers) {
+            $dispatched = $this->dispatchRecomputation($tripId, $impactedStageNumbers);
+
+            if ($dispatched) {
+                $this->logger->info('Chat action triggered inline recomputation.', [
+                    'tripId' => $tripId,
+                    'action' => $action->action,
+                    'impactedStageNumbers' => $impactedStageNumbers,
+                ]);
+            }
         }
 
         return new TripChatResponse(
@@ -184,7 +200,137 @@ final readonly class TripChatProcessor implements ProcessorInterface
             params: $action->params,
             response: $action->response,
             dispatched: $dispatched,
+            impactedStageNumbers: $impactedStageNumbers,
+            requiresFullAnalysis: $requiresFullAnalysis,
         );
+    }
+
+    /**
+     * Maps a parsed action to the list of 1-indexed day numbers whose
+     * recomputation must be triggered.
+     *
+     * @return list<int>
+     */
+    private function resolveImpactedStageNumbers(string $tripId, ChatAction $action): array
+    {
+        if (!\in_array($action->action, self::RECOMPUTE_ACTIONS, true)) {
+            return [];
+        }
+
+        $stages = $this->tripStateManager->getStages($tripId) ?? [];
+        $totalStages = \count($stages);
+        if (0 === $totalStages) {
+            return [];
+        }
+
+        $params = $action->params;
+
+        switch ($action->action) {
+            case ChatAction::ACTION_SPLIT_STAGE:
+                $stage = $this->extractStageNumber($params['stage'] ?? null);
+                if (null === $stage || $stage < 1 || $stage > $totalStages) {
+                    return [];
+                }
+
+                // Split produces two halves: the original day and the new day immediately
+                // after it. When the rider asks to split the last stage, the second half
+                // becomes a brand-new day number.
+                $second = min($stage + 1, $totalStages + 1);
+
+                return [$stage, $second];
+
+            case ChatAction::ACTION_MERGE_STAGES:
+                $raw = $params['stages'] ?? null;
+                if (!\is_array($raw)) {
+                    return [];
+                }
+
+                $values = array_values($raw);
+                $first = $this->extractStageNumber($values[0] ?? null);
+                $second = $this->extractStageNumber($values[1] ?? null);
+                if (null === $first || null === $second) {
+                    return [];
+                }
+
+                if ($first < 1 || $first > $totalStages || $second < 1 || $second > $totalStages) {
+                    return [];
+                }
+
+                // The surviving stage after merging two consecutive days is the
+                // lower-numbered one. Normalise to min() so a reversed [3, 2]
+                // pair from the LLM still shimmers the correct card.
+                return [min($first, $second)];
+
+            case ChatAction::ACTION_ADD_WAYPOINT:
+
+            case ChatAction::ACTION_ADJUST_DISTANCE:
+                $stage = $this->extractStageNumber($params['stage'] ?? null);
+                if (null === $stage || $stage < 1 || $stage > $totalStages) {
+                    return [];
+                }
+
+                return [$stage];
+            case ChatAction::ACTION_CHANGE_ACCOMMODATION:
+                $stage = $this->extractStageNumber($params['stage'] ?? null);
+                if (null === $stage || $stage < 1 || $stage > $totalStages) {
+                    return [];
+                }
+
+                // Changing the accommodation moves the arrival point — the next stage
+                // departs from the new spot, so recompute it too when it exists.
+                $next = $stage + 1;
+
+                return $next <= $totalStages ? [$stage, $next] : [$stage];
+            default:
+                return [];
+        }
+    }
+
+    private function extractStageNumber(mixed $value): ?int
+    {
+        if (\is_int($value) && $value > 0) {
+            return $value;
+        }
+
+        if (\is_string($value) && ctype_digit($value)) {
+            $int = (int) $value;
+
+            return $int > 0 ? $int : null;
+        }
+
+        return null;
+    }
+
+    /**
+     * Dispatches a single {@see RecalculateStages} message covering the affected
+     * stage indices (0-indexed for the message contract). Returns `true` when a
+     * dispatch happened — `false` when the indices map to nothing recomputable.
+     *
+     * @param list<int> $stageNumbers 1-indexed day numbers
+     */
+    private function dispatchRecomputation(string $tripId, array $stageNumbers): bool
+    {
+        $indices = array_values(array_unique(array_map(
+            static fn (int $n): int => $n - 1,
+            $stageNumbers,
+        )));
+
+        if ([] === $indices) {
+            return false;
+        }
+
+        // Bump generation: chat-driven edits invalidate in-flight computations on
+        // the same trip so a stale ScanPois cannot land after the new STAGE_UPDATED.
+        $generation = $this->generationTracker->increment($tripId);
+
+        $this->messageBus->dispatch(new RecalculateStages(
+            tripId: $tripId,
+            affectedIndices: $indices,
+            generation: $generation,
+            skipAiAnalysis: true,
+        ));
+
+        return true;
     }
 
     private function buildUserMessage(TripChatRequest $request): string

--- a/api/tests/Functional/TripChatTest.php
+++ b/api/tests/Functional/TripChatTest.php
@@ -89,7 +89,12 @@ final class TripChatTest extends ApiTestCase
         $this->assertSame('split_stage', $data['action']);
         $this->assertSame(['stage' => 3], $data['params']);
         $this->assertStringContainsString('étape 3', $data['response']);
-        $this->assertTrue($data['dispatched']);
+        // The functional fixture has no stages, so the recompute guard short-circuits
+        // and no Messenger message is dispatched. The dispatch path itself is covered
+        // by TripChatProcessorTest with a seeded stage list.
+        $this->assertFalse($data['dispatched']);
+        $this->assertSame([], $data['impactedStageNumbers']);
+        $this->assertFalse($data['requiresFullAnalysis']);
     }
 
     #[Test]
@@ -122,6 +127,42 @@ final class TripChatTest extends ApiTestCase
         $data = $response->toArray(false);
         $this->assertSame('info', $data['action']);
         $this->assertFalse($data['dispatched']);
+        $this->assertSame([], $data['impactedStageNumbers']);
+        $this->assertFalse($data['requiresFullAnalysis']);
+    }
+
+    #[Test]
+    public function chatChangeRouteActionFlagsFullAnalysis(): void
+    {
+        $this->seedTrip(self::TRIP_ID);
+
+        $this->installFakeLlmClient(new FakeLlmClient([
+            'message' => [
+                'role' => 'assistant',
+                'content' => json_encode([
+                    'action' => 'change_route',
+                    'params' => [],
+                    'response' => 'Cette modification touche tout le tracé.',
+                ], \JSON_THROW_ON_ERROR),
+            ],
+        ]));
+
+        $response = $this->client->request(
+            'POST',
+            \sprintf('/trips/%s/chat', self::TRIP_ID),
+            [
+                'json' => ['message' => "Change l'itinéraire pour passer par la côte"],
+                'headers' => ['Content-Type' => 'application/ld+json', ...$this->authHeader($this->jwtToken)],
+            ],
+        );
+
+        $this->assertResponseStatusCodeSame(200);
+
+        $data = $response->toArray(false);
+        $this->assertSame('change_route', $data['action']);
+        $this->assertFalse($data['dispatched']);
+        $this->assertSame([], $data['impactedStageNumbers']);
+        $this->assertTrue($data['requiresFullAnalysis']);
     }
 
     #[Test]

--- a/api/tests/Integration/LlmPipelineTest.php
+++ b/api/tests/Integration/LlmPipelineTest.php
@@ -653,4 +653,23 @@ final class InMemoryLlmAnalysisTracker implements LlmAnalysisTrackerInterface
 
         return true;
     }
+
+    /** @var array<string, true> */
+    private array $skipFlags = [];
+
+    public function markSkipAiAnalysis(string $tripId): void
+    {
+        $this->skipFlags[$tripId] = true;
+    }
+
+    public function consumeSkipAiAnalysis(string $tripId): bool
+    {
+        if (!isset($this->skipFlags[$tripId])) {
+            return false;
+        }
+
+        unset($this->skipFlags[$tripId]);
+
+        return true;
+    }
 }

--- a/api/tests/Unit/Llm/ChatActionInterpreterTest.php
+++ b/api/tests/Unit/Llm/ChatActionInterpreterTest.php
@@ -216,6 +216,22 @@ final class ChatActionInterpreterTest extends TestCase
     }
 
     #[Test]
+    public function parsesChangeRouteAction(): void
+    {
+        $action = $this->interpreter->interpret(
+            json_encode([
+                'action' => 'change_route',
+                'params' => [],
+                'response' => 'Cette modification touche tout le tracé.',
+            ], \JSON_THROW_ON_ERROR),
+        );
+
+        $this->assertSame(ChatAction::ACTION_CHANGE_ROUTE, $action->action);
+        $this->assertSame([], $action->params);
+        $this->assertStringContainsString('tracé', $action->response);
+    }
+
+    #[Test]
     public function malformedJsonFallsBackToInfo(): void
     {
         $action = $this->interpreter->interpret('not a json payload');

--- a/api/tests/Unit/MessageHandler/AllEnrichmentsCompletedHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/AllEnrichmentsCompletedHandlerTest.php
@@ -245,6 +245,56 @@ final class AllEnrichmentsCompletedHandlerTest extends TestCase
         $handler(new AllEnrichmentsCompleted($tripId));
     }
 
+    #[Test]
+    public function skipsLlmDispatchWhenSkipAiAnalysisMarkerIsConsumed(): void
+    {
+        $tripId = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
+
+        $stage = new Stage(
+            tripId: $tripId,
+            dayNumber: 1,
+            distance: 80.0,
+            elevation: 500.0,
+            startPoint: new Coordinate(48.0, 2.0),
+            endPoint: new Coordinate(48.5, 2.5),
+        );
+
+        $tracker = $this->createStub(ComputationTrackerInterface::class);
+        $tracker->method('claimReadyPublication')->willReturn(true);
+        $tracker->method('getStatuses')->willReturn([]);
+
+        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
+        $tripStateManager->method('getStages')->willReturn([$stage]);
+
+        $llmClient = $this->createStub(LlmClientInterface::class);
+        $llmClient->method('isEnabled')->willReturn(true);
+
+        $llmAnalysisTracker = $this->createMock(LlmAnalysisTrackerInterface::class);
+        $llmAnalysisTracker->expects(self::once())
+            ->method('consumeSkipAiAnalysis')
+            ->with($tripId)
+            ->willReturn(true);
+        $llmAnalysisTracker->expects(self::never())->method('initializeStageAnalyses');
+
+        $publisher = $this->createMock(TripUpdatePublisherInterface::class);
+        $publisher->expects(self::once())->method('publishTripReady');
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects(self::never())->method('dispatch');
+
+        $handler = new AllEnrichmentsCompletedHandler(
+            $tracker,
+            $publisher,
+            $tripStateManager,
+            new NullLogger(),
+            $bus,
+            $llmClient,
+            $llmAnalysisTracker,
+        );
+
+        $handler(new AllEnrichmentsCompleted($tripId));
+    }
+
     private function disabledLlmClient(): LlmClientInterface
     {
         $llmClient = $this->createStub(LlmClientInterface::class);

--- a/api/tests/Unit/MessageHandler/RecalculateStagesHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/RecalculateStagesHandlerTest.php
@@ -9,6 +9,7 @@ use App\ApiResource\Stage;
 use App\ApiResource\TripRequest;
 use App\ComputationTracker\ComputationTrackerInterface;
 use App\ComputationTracker\TripGenerationTrackerInterface;
+use App\Llm\LlmAnalysisTrackerInterface;
 use App\Mercure\MercureEventType;
 use App\Mercure\TripUpdatePublisherInterface;
 use App\Message\RecalculateStages;
@@ -28,6 +29,7 @@ final class RecalculateStagesHandlerTest extends TestCase
         TripUpdatePublisherInterface $publisher,
         MessageBusInterface $messageBus,
         ?TripGenerationTrackerInterface $generationTracker = null,
+        ?LlmAnalysisTrackerInterface $llmTracker = null,
     ): RecalculateStagesHandler {
         $computationTracker = $this->createStub(ComputationTrackerInterface::class);
         $computationTracker->method('getProgress')->willReturn(['completed' => 0, 'failed' => 0, 'total' => 1]);
@@ -39,6 +41,7 @@ final class RecalculateStagesHandlerTest extends TestCase
             new NullLogger(),
             $tripStateManager,
             $messageBus,
+            $llmTracker ?? $this->createStub(LlmAnalysisTrackerInterface::class),
         );
     }
 
@@ -174,5 +177,82 @@ final class RecalculateStagesHandlerTest extends TestCase
         $second = $scanMessages[1];
         $this->assertSame(2, $second->stageIndex);
         $this->assertFalse($second->isExpandScan);
+    }
+
+    #[Test]
+    public function skipAiAnalysisFlagMarksTrackerOnce(): void
+    {
+        $stage = new Stage(
+            tripId: 'trip-1',
+            dayNumber: 1,
+            distance: 80.0,
+            elevation: 500.0,
+            startPoint: new Coordinate(48.0, 2.0),
+            endPoint: new Coordinate(48.5, 2.5),
+        );
+
+        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
+        $tripStateManager->method('getStages')->willReturn([$stage]);
+
+        $publisher = $this->createStub(TripUpdatePublisherInterface::class);
+
+        $messageBus = $this->createStub(MessageBusInterface::class);
+        $messageBus->method('dispatch')->willReturn(new Envelope(new \stdClass()));
+
+        $llmTracker = $this->createMock(LlmAnalysisTrackerInterface::class);
+        $llmTracker->expects($this->once())->method('markSkipAiAnalysis')->with('trip-1');
+
+        $handler = $this->createHandler(
+            $tripStateManager,
+            $publisher,
+            $messageBus,
+            null,
+            $llmTracker,
+        );
+
+        $handler(new RecalculateStages(
+            tripId: 'trip-1',
+            affectedIndices: [0],
+            skipGeographicScans: true,
+            skipAiAnalysis: true,
+        ));
+    }
+
+    #[Test]
+    public function skipAiAnalysisDefaultsToFalseAndDoesNotMarkTracker(): void
+    {
+        $stage = new Stage(
+            tripId: 'trip-1',
+            dayNumber: 1,
+            distance: 80.0,
+            elevation: 500.0,
+            startPoint: new Coordinate(48.0, 2.0),
+            endPoint: new Coordinate(48.5, 2.5),
+        );
+
+        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
+        $tripStateManager->method('getStages')->willReturn([$stage]);
+
+        $publisher = $this->createStub(TripUpdatePublisherInterface::class);
+
+        $messageBus = $this->createStub(MessageBusInterface::class);
+        $messageBus->method('dispatch')->willReturn(new Envelope(new \stdClass()));
+
+        $llmTracker = $this->createMock(LlmAnalysisTrackerInterface::class);
+        $llmTracker->expects($this->never())->method('markSkipAiAnalysis');
+
+        $handler = $this->createHandler(
+            $tripStateManager,
+            $publisher,
+            $messageBus,
+            null,
+            $llmTracker,
+        );
+
+        $handler(new RecalculateStages(
+            tripId: 'trip-1',
+            affectedIndices: [0],
+            skipGeographicScans: true,
+        ));
     }
 }

--- a/api/tests/Unit/State/TripChatProcessorTest.php
+++ b/api/tests/Unit/State/TripChatProcessorTest.php
@@ -5,12 +5,19 @@ declare(strict_types=1);
 namespace App\Tests\Unit\State;
 
 use ApiPlatform\Metadata\Post;
+use App\ApiResource\Model\Coordinate;
+use App\ApiResource\Model\TripChatContext;
+use App\ApiResource\Stage;
 use App\ApiResource\TripChatRequest;
+use App\ApiResource\TripRequest;
+use App\ComputationTracker\TripGenerationTrackerInterface;
 use App\Entity\User;
 use App\Llm\ChatActionInterpreter;
 use App\Llm\ChatHistoryStore;
 use App\Llm\LlmClientInterface;
 use App\Llm\SystemPromptLoader;
+use App\Message\RecalculateStages;
+use App\Repository\TripRequestRepositoryInterface;
 use App\State\TripChatProcessor;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\Test;
@@ -19,17 +26,29 @@ use Psr\Log\NullLogger;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
 use Symfony\Component\Uid\Uuid;
 
 /**
- * Unit coverage for the rate-limit branch of {@see TripChatProcessor}.
+ * Verifies that the chat processor maps each parsed action to the right
+ * inline recomputation dispatch (issue #311):
+ *  - `split_stage` → RecalculateStages on 2 halves
+ *  - `merge_stages` → RecalculateStages on the merged stage
+ *  - `add_waypoint` → RecalculateStages on 1 stage
+ *  - `change_accommodation` → RecalculateStages on arrival + next stage
+ *  - `adjust_distance` → RecalculateStages on 1 stage
+ *  - `info` → no dispatch
+ *  - `change_route` → no dispatch, requiresFullAnalysis=true.
  *
- * The functional layer cannot exercise the cross-request limiter state because
- * the test cache pool (array adapter) is reset between kernel requests. This
- * test wires the processor against an in-memory rate limiter sized so the
- * second `process()` call exhausts the quota and triggers the 429 branch.
+ * Also covers the 429 rate-limit branch — exercised here because the test
+ * cache pool resets between kernel requests at the functional layer so
+ * a multi-request HTTP test cannot accumulate limiter state.
+ *
+ * All recomputation dispatches must carry `skipAiAnalysis: true` so the
+ * LLaMA 8B re-analysis is skipped by default during inline edits.
  */
 #[AllowMockObjectsWithoutExpectations]
 final class TripChatProcessorTest extends TestCase
@@ -48,52 +67,411 @@ final class TripChatProcessorTest extends TestCase
     }
 
     #[Test]
+    public function splitStageActionDispatchesRecomputeForBothHalves(): void
+    {
+        $bus = $this->newMessageBus();
+        $processor = $this->newProcessor(
+            llmContent: $this->jsonEnvelope('split_stage', ['stage' => 3], 'OK'),
+            stagesCount: 5,
+            messageBus: $bus,
+        );
+
+        $response = $processor->process(
+            new TripChatRequest("Coupe l'étape 3 en deux", new TripChatContext(currentStage: 3)),
+            new Post(),
+            ['id' => self::TRIP_ID],
+        );
+
+        self::assertSame('split_stage', $response->action);
+        self::assertTrue($response->dispatched);
+        self::assertSame([3, 4], $response->impactedStageNumbers);
+        self::assertFalse($response->requiresFullAnalysis);
+
+        $messages = $this->collectDispatched($bus, RecalculateStages::class);
+        self::assertCount(1, $messages);
+        self::assertSame([2, 3], $messages[0]->affectedIndices);
+        self::assertTrue($messages[0]->skipAiAnalysis);
+    }
+
+    /**
+     * Splitting the last stage of the trip yields a brand-new day number beyond
+     * the current stage list. Both halves are still surfaced in
+     * {@see TripChatResponse::$impactedStageNumbers} so the frontend can shimmer
+     * the new slot once the recomputation lands.
+     */
+    #[Test]
+    public function splitLastStageActionDispatchesBothHalves(): void
+    {
+        $bus = $this->newMessageBus();
+        $processor = $this->newProcessor(
+            llmContent: $this->jsonEnvelope('split_stage', ['stage' => 5], 'OK'),
+            stagesCount: 5,
+            messageBus: $bus,
+        );
+
+        $response = $processor->process(
+            new TripChatRequest('Coupe la dernière étape en deux'),
+            new Post(),
+            ['id' => self::TRIP_ID],
+        );
+
+        self::assertSame([5, 6], $response->impactedStageNumbers);
+        self::assertTrue($response->dispatched);
+
+        $messages = $this->collectDispatched($bus, RecalculateStages::class);
+        self::assertCount(1, $messages);
+        self::assertSame([4, 5], $messages[0]->affectedIndices);
+        self::assertTrue($messages[0]->skipAiAnalysis);
+    }
+
+    #[Test]
+    public function mergeStagesActionDispatchesRecomputeForMergedStage(): void
+    {
+        $bus = $this->newMessageBus();
+        $processor = $this->newProcessor(
+            llmContent: $this->jsonEnvelope('merge_stages', ['stages' => [2, 3]], 'OK'),
+            stagesCount: 5,
+            messageBus: $bus,
+        );
+
+        $response = $processor->process(
+            new TripChatRequest('Fusionne les étapes 2 et 3'),
+            new Post(),
+            ['id' => self::TRIP_ID],
+        );
+
+        self::assertTrue($response->dispatched);
+        self::assertSame([2], $response->impactedStageNumbers);
+
+        $messages = $this->collectDispatched($bus, RecalculateStages::class);
+        self::assertCount(1, $messages);
+        self::assertSame([1], $messages[0]->affectedIndices);
+        self::assertTrue($messages[0]->skipAiAnalysis);
+    }
+
+    /**
+     * The system prompt does not constrain the order of the merge pair, so the
+     * LLM may emit `{"stages": [3, 2]}` for the same intent. The processor must
+     * normalise the surviving stage to the lower index so the right card
+     * shimmers in the UI.
+     */
+    #[Test]
+    public function mergeStagesReversedOrderDispatchesLowerStage(): void
+    {
+        $bus = $this->newMessageBus();
+        $processor = $this->newProcessor(
+            llmContent: $this->jsonEnvelope('merge_stages', ['stages' => [3, 2]], 'OK'),
+            stagesCount: 5,
+            messageBus: $bus,
+        );
+
+        $response = $processor->process(
+            new TripChatRequest('Fusionne les étapes 2 et 3'),
+            new Post(),
+            ['id' => self::TRIP_ID],
+        );
+
+        self::assertSame([2], $response->impactedStageNumbers);
+        $messages = $this->collectDispatched($bus, RecalculateStages::class);
+        self::assertCount(1, $messages);
+        self::assertSame([1], $messages[0]->affectedIndices);
+    }
+
+    #[Test]
+    public function addWaypointActionDispatchesRecomputeForTheStage(): void
+    {
+        $bus = $this->newMessageBus();
+        $processor = $this->newProcessor(
+            llmContent: $this->jsonEnvelope(
+                'add_waypoint',
+                ['name' => 'Mont Cassel', 'stage' => 4],
+                'Ajout',
+            ),
+            stagesCount: 5,
+            messageBus: $bus,
+        );
+
+        $response = $processor->process(
+            new TripChatRequest('Ajoute un détour par le Mont Cassel'),
+            new Post(),
+            ['id' => self::TRIP_ID],
+        );
+
+        self::assertTrue($response->dispatched);
+        self::assertSame([4], $response->impactedStageNumbers);
+
+        $messages = $this->collectDispatched($bus, RecalculateStages::class);
+        self::assertCount(1, $messages);
+        self::assertSame([3], $messages[0]->affectedIndices);
+        self::assertTrue($messages[0]->skipAiAnalysis);
+    }
+
+    /**
+     * The dialogue prompt allows `add_waypoint` with `stage: null` when the rider
+     * does not specify a day. In that case the processor returns a successful
+     * action but does not dispatch any recomputation — the frontend reads
+     * `dispatched=false` and surfaces the conversational reply only.
+     *
+     * Behaviour is documented here so callers don't mistake the no-op for a bug.
+     */
+    #[Test]
+    public function addWaypointWithNullStageIsAcceptedButDispatchesNothing(): void
+    {
+        $bus = $this->newMessageBus();
+        $processor = $this->newProcessor(
+            llmContent: $this->jsonEnvelope(
+                'add_waypoint',
+                ['name' => 'Mont Cassel', 'stage' => null],
+                'Ajout sans étape précise',
+            ),
+            stagesCount: 5,
+            messageBus: $bus,
+        );
+
+        $response = $processor->process(
+            new TripChatRequest("Ajoute un point d'eau quelque part"),
+            new Post(),
+            ['id' => self::TRIP_ID],
+        );
+
+        self::assertSame('add_waypoint', $response->action);
+        self::assertFalse($response->dispatched);
+        self::assertSame([], $response->impactedStageNumbers);
+        self::assertEmpty($this->collectDispatched($bus, RecalculateStages::class));
+    }
+
+    #[Test]
+    public function changeAccommodationActionRecomputesArrivalAndNextStage(): void
+    {
+        $bus = $this->newMessageBus();
+        $processor = $this->newProcessor(
+            llmContent: $this->jsonEnvelope(
+                'change_accommodation',
+                ['stage' => 2, 'type' => 'guest_house'],
+                'OK',
+            ),
+            stagesCount: 5,
+            messageBus: $bus,
+        );
+
+        $response = $processor->process(
+            new TripChatRequest('Sur cette étape je préfère dormir en gîte'),
+            new Post(),
+            ['id' => self::TRIP_ID],
+        );
+
+        self::assertTrue($response->dispatched);
+        self::assertSame([2, 3], $response->impactedStageNumbers);
+
+        $messages = $this->collectDispatched($bus, RecalculateStages::class);
+        self::assertCount(1, $messages);
+        self::assertSame([1, 2], $messages[0]->affectedIndices);
+        self::assertTrue($messages[0]->skipAiAnalysis);
+    }
+
+    #[Test]
+    public function changeAccommodationOnLastStageOnlyRecomputesTheStage(): void
+    {
+        $bus = $this->newMessageBus();
+        $processor = $this->newProcessor(
+            llmContent: $this->jsonEnvelope(
+                'change_accommodation',
+                ['stage' => 5, 'type' => 'camp_site'],
+                'OK',
+            ),
+            stagesCount: 5,
+            messageBus: $bus,
+        );
+
+        $response = $processor->process(
+            new TripChatRequest('Camping pour la dernière étape'),
+            new Post(),
+            ['id' => self::TRIP_ID],
+        );
+
+        self::assertSame([5], $response->impactedStageNumbers);
+
+        $messages = $this->collectDispatched($bus, RecalculateStages::class);
+        self::assertCount(1, $messages);
+        self::assertSame([4], $messages[0]->affectedIndices);
+    }
+
+    #[Test]
+    public function adjustDistanceActionDispatchesRecomputeForOneStage(): void
+    {
+        $bus = $this->newMessageBus();
+        $processor = $this->newProcessor(
+            llmContent: $this->jsonEnvelope(
+                'adjust_distance',
+                ['stage' => 5, 'km' => 95],
+                'OK',
+            ),
+            stagesCount: 5,
+            messageBus: $bus,
+        );
+
+        $response = $processor->process(
+            new TripChatRequest("Allonge l'étape 5 à 95 km"),
+            new Post(),
+            ['id' => self::TRIP_ID],
+        );
+
+        self::assertTrue($response->dispatched);
+        self::assertSame([5], $response->impactedStageNumbers);
+
+        $messages = $this->collectDispatched($bus, RecalculateStages::class);
+        self::assertCount(1, $messages);
+        self::assertSame([4], $messages[0]->affectedIndices);
+        self::assertTrue($messages[0]->skipAiAnalysis);
+    }
+
+    #[Test]
+    public function infoActionDispatchesNothing(): void
+    {
+        $bus = $this->newMessageBus();
+        $processor = $this->newProcessor(
+            llmContent: $this->jsonEnvelope('info', [], 'Le gravel désigne…'),
+            stagesCount: 5,
+            messageBus: $bus,
+        );
+
+        $response = $processor->process(
+            new TripChatRequest("C'est quoi le gravel ?"),
+            new Post(),
+            ['id' => self::TRIP_ID],
+        );
+
+        self::assertSame('info', $response->action);
+        self::assertFalse($response->dispatched);
+        self::assertSame([], $response->impactedStageNumbers);
+        self::assertFalse($response->requiresFullAnalysis);
+
+        self::assertCount(0, $this->collectDispatched($bus, RecalculateStages::class));
+    }
+
+    #[Test]
+    public function changeRouteActionFlagsFullAnalysisAndDispatchesNothing(): void
+    {
+        $bus = $this->newMessageBus();
+        $processor = $this->newProcessor(
+            llmContent: $this->jsonEnvelope(
+                'change_route',
+                [],
+                'Cette modification touche tout le tracé.',
+            ),
+            stagesCount: 5,
+            messageBus: $bus,
+        );
+
+        $response = $processor->process(
+            new TripChatRequest("Change l'itinéraire pour passer par la côte"),
+            new Post(),
+            ['id' => self::TRIP_ID],
+        );
+
+        self::assertSame('change_route', $response->action);
+        self::assertTrue($response->requiresFullAnalysis);
+        self::assertFalse($response->dispatched);
+        self::assertSame([], $response->impactedStageNumbers);
+
+        self::assertCount(0, $this->collectDispatched($bus, RecalculateStages::class));
+    }
+
+    #[Test]
+    public function dispatchesNothingWhenStageNumberIsOutOfRange(): void
+    {
+        $bus = $this->newMessageBus();
+        $processor = $this->newProcessor(
+            llmContent: $this->jsonEnvelope('split_stage', ['stage' => 99], 'OK'),
+            stagesCount: 5,
+            messageBus: $bus,
+        );
+
+        $response = $processor->process(
+            new TripChatRequest("Coupe l'étape 99"),
+            new Post(),
+            ['id' => self::TRIP_ID],
+        );
+
+        self::assertFalse($response->dispatched);
+        self::assertSame([], $response->impactedStageNumbers);
+        self::assertCount(0, $this->collectDispatched($bus, RecalculateStages::class));
+    }
+
+    #[Test]
     public function processThrows429WhenRateLimitExceeded(): void
     {
-        $processor = $this->newProcessor(limit: 1);
-        $request = new TripChatRequest('Bonjour');
-        $operation = new Post();
+        $factory = new RateLimiterFactory(
+            ['id' => 'trip_chat_test_429', 'policy' => 'fixed_window', 'limit' => 1, 'interval' => '1 hour'],
+            new InMemoryStorage(),
+        );
+        $processor = $this->newProcessor(
+            llmContent: $this->jsonEnvelope('info', [], 'OK'),
+            stagesCount: 1,
+            messageBus: $this->newMessageBus(),
+            limiterFactory: $factory,
+        );
 
         // First call consumes the only token.
-        $processor->process($request, $operation, ['id' => self::TRIP_ID]);
+        $processor->process(new TripChatRequest('Bonjour'), new Post(), ['id' => self::TRIP_ID]);
 
         // Second call must hit the limiter and trip the 429 branch.
         $this->expectException(TooManyRequestsHttpException::class);
-        $processor->process($request, $operation, ['id' => self::TRIP_ID]);
+        $processor->process(new TripChatRequest('Encore'), new Post(), ['id' => self::TRIP_ID]);
     }
 
-    private function newProcessor(int $limit): TripChatProcessor
-    {
+    private function newProcessor(
+        string $llmContent,
+        int $stagesCount,
+        MessageBusInterface $messageBus,
+        ?RateLimiterFactory $limiterFactory = null,
+    ): TripChatProcessor {
+        $tripRequest = new TripRequest();
+        $stages = [];
+        for ($i = 1; $i <= $stagesCount; ++$i) {
+            $stages[] = new Stage(
+                tripId: self::TRIP_ID,
+                dayNumber: $i,
+                distance: 50.0,
+                elevation: 200.0,
+                startPoint: new Coordinate(48.0, 2.0, 0.0),
+                endPoint: new Coordinate(48.1, 2.1, 0.0),
+            );
+        }
+
+        $repository = $this->createStub(TripRequestRepositoryInterface::class);
+        $repository->method('getRequest')->willReturn($tripRequest);
+        $repository->method('getStages')->willReturn($stages);
+
+
         $llmClient = $this->createStub(LlmClientInterface::class);
         $llmClient->method('isEnabled')->willReturn(true);
         $llmClient->method('chat')->willReturn([
-            'message' => [
-                'role' => 'assistant',
-                'content' => json_encode([
-                    'action' => 'info',
-                    'params' => [],
-                    'response' => 'OK',
-                ], \JSON_THROW_ON_ERROR),
-            ],
+            'message' => ['role' => 'assistant', 'content' => $llmContent],
         ]);
 
+        $promptLoader = new SystemPromptLoader($this->createPromptFixtureDir());
+        $historyStore = new ChatHistoryStore(new ArrayAdapter());
+
+        $generationTracker = $this->createStub(TripGenerationTrackerInterface::class);
+        $generationTracker->method('increment')->willReturn(42);
+
         $user = new User('chat@example.com', Uuid::v7());
+
         $security = $this->createStub(Security::class);
         $security->method('getUser')->willReturn($user);
 
-        $factory = new RateLimiterFactory(
-            ['id' => 'trip_chat', 'policy' => 'fixed_window', 'limit' => $limit, 'interval' => '1 hour'],
-            new InMemoryStorage(),
-        );
-
         return new TripChatProcessor(
+            tripStateManager: $repository,
             llmClient: $llmClient,
-            promptLoader: new SystemPromptLoader($this->createPromptFixtureDir()),
+            promptLoader: $promptLoader,
             interpreter: new ChatActionInterpreter(new NullLogger()),
-            historyStore: new ChatHistoryStore(new ArrayAdapter()),
+            historyStore: $historyStore,
             security: $security,
             logger: new NullLogger(),
-            tripChatLimiter: $factory,
+            messageBus: $messageBus,
+            generationTracker: $generationTracker,
+            tripChatLimiter: $limiterFactory ?? $this->newNoLimiterFactory(),
         );
     }
 
@@ -105,5 +483,64 @@ final class TripChatProcessorTest extends TestCase
         $this->promptFixtureDir = $dir;
 
         return $dir;
+    }
+
+    private function newMessageBus(): MessageBusInterface
+    {
+        return new class () implements MessageBusInterface {
+            /** @var list<Envelope> */
+            public array $dispatched = [];
+
+            public function dispatch(object $message, array $stamps = []): Envelope
+            {
+                $envelope = $message instanceof Envelope ? $message : new Envelope($message, $stamps);
+                $this->dispatched[] = $envelope;
+
+                return $envelope;
+            }
+        };
+    }
+
+    /**
+     * @template T of object
+     *
+     * @param class-string<T> $messageClass
+     *
+     * @return list<T>
+     */
+    private function collectDispatched(MessageBusInterface $bus, string $messageClass): array
+    {
+        \assert(property_exists($bus, 'dispatched'));
+
+        $collected = [];
+        /** @var Envelope $envelope */
+        foreach ($bus->dispatched as $envelope) {
+            $message = $envelope->getMessage();
+            if ($message instanceof $messageClass) {
+                $collected[] = $message;
+            }
+        }
+
+        return $collected;
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    private function jsonEnvelope(string $action, array $params, string $response): string
+    {
+        return json_encode([
+            'action' => $action,
+            'params' => $params,
+            'response' => $response,
+        ], \JSON_THROW_ON_ERROR);
+    }
+
+    private function newNoLimiterFactory(): RateLimiterFactory
+    {
+        return new RateLimiterFactory(
+            ['id' => 'trip_chat_test', 'policy' => 'no_limit'],
+            new InMemoryStorage(),
+        );
     }
 }

--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -608,7 +608,9 @@
     "errorNetwork": "Network error. Check your connection then try again.",
     "errorRateLimit": "You have reached the message rate limit. Please try again shortly.",
     "errorUnavailable": "The AI assistant is temporarily unavailable. Try again later.",
-    "errorGeneric": "Something went wrong. Please try again later."
+    "errorGeneric": "Something went wrong. Please try again later.",
+    "fullAnalysisHint": "This change requires a brand-new full analysis.",
+    "relaunchAnalysis": "Relaunch analysis"
   },
   "aiOverview": {
     "title": "AI analysis",

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -608,7 +608,9 @@
     "errorNetwork": "Erreur réseau. Vérifiez votre connexion puis réessayez.",
     "errorRateLimit": "Vous avez atteint la limite de messages. Réessayez dans un instant.",
     "errorUnavailable": "L'assistant IA est temporairement indisponible. Réessayez plus tard.",
-    "errorGeneric": "Une erreur est survenue. Réessayez plus tard."
+    "errorGeneric": "Une erreur est survenue. Réessayez plus tard.",
+    "fullAnalysisHint": "Cette modification nécessite une nouvelle analyse complète.",
+    "relaunchAnalysis": "Relancer l'analyse"
   },
   "aiOverview": {
     "title": "Analyse IA",

--- a/pwa/src/components/ai-chat-panel.tsx
+++ b/pwa/src/components/ai-chat-panel.tsx
@@ -32,6 +32,10 @@ export interface AiChatActionEventDetail {
   response: string;
   tripId: string;
   dispatched: boolean;
+  /** 1-indexed day numbers whose recomputation has been dispatched. */
+  impactedStageNumbers?: number[];
+  /** True when the action requires a full trip re-analysis (Acte 2). */
+  requiresFullAnalysis?: boolean;
 }
 
 interface AiChatPanelProps {
@@ -69,9 +73,10 @@ export function AiChatPanel({ onClose }: AiChatPanelProps) {
     })),
   );
 
-  const { sendChatMessage } = useTripPlanner();
+  const { sendChatMessage, relaunchFullAnalysis } = useTripPlanner();
 
   const [draft, setDraft] = useState("");
+  const [pendingFullAnalysis, setPendingFullAnalysis] = useState(false);
   const historyRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -115,14 +120,28 @@ export function AiChatPanel({ onClose }: AiChatPanelProps) {
         response: response.response,
         tripId: response.tripId,
         dispatched: response.dispatched,
+        impactedStageNumbers: response.impactedStageNumbers,
+        requiresFullAnalysis: response.requiresFullAnalysis,
       };
       document.dispatchEvent(
         new CustomEvent<AiChatActionEventDetail>(AI_CHAT_ACTION_EVENT, {
           detail,
         }),
       );
+      setPendingFullAnalysis(response.requiresFullAnalysis === true);
     }
   }, [draft, isChatSending, sendChatMessage]);
+
+  const handleRelaunchAnalysis = useCallback(async () => {
+    // Only clear the banner + close the panel once the analysis dispatch has
+    // succeeded — otherwise the "Relancer l'analyse" CTA would vanish on
+    // failure and the rider would have to ask the AI again to get it back.
+    const ok = await relaunchFullAnalysis();
+    if (ok) {
+      setPendingFullAnalysis(false);
+      onClose();
+    }
+  }, [relaunchFullAnalysis, onClose]);
 
   const handleKeyDown = useCallback(
     (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
@@ -201,6 +220,26 @@ export function AiChatPanel({ onClose }: AiChatPanelProps) {
         ))}
         {isChatSending && <TypingDots />}
       </div>
+
+      {pendingFullAnalysis && (
+        <div
+          data-testid="ai-chat-panel-full-analysis"
+          className="border-t border-border bg-muted/30 px-4 py-3 flex flex-col gap-2"
+        >
+          <p className="text-xs text-muted-foreground">
+            {t("fullAnalysisHint")}
+          </p>
+          <Button
+            type="button"
+            size="sm"
+            onClick={() => void handleRelaunchAnalysis()}
+            data-testid="ai-chat-panel-relaunch"
+            className="bg-brand text-white hover:bg-brand-hover"
+          >
+            {t("relaunchAnalysis")}
+          </Button>
+        </div>
+      )}
 
       <div className="border-t border-border p-3 flex items-end gap-2">
         <label htmlFor="ai-chat-panel-textarea" className="sr-only">

--- a/pwa/src/hooks/use-trip-planner.ts
+++ b/pwa/src/hooks/use-trip-planner.ts
@@ -733,12 +733,13 @@ export function useTripPlanner() {
   /**
    * Dispatch a chat turn to `POST /trips/{id}/chat`, append both the user
    * message and the assistant reply to {@link useUiStore.chatHistory}, and
-   * surface any actionable response (`split_stage`, `adjust_distance`, …) so
-   * downstream wiring can trigger the matching store action.
+   * — when the backend dispatched an inline recomputation — flag the impacted
+   * stages as `recomputing` so the timeline shows the shimmer skeleton until
+   * the matching `stage_updated` Mercure events land.
    *
-   * The actual recomputation hook-up is delivered by issue #311 — this hook
-   * focuses on the round-trip, history bookkeeping, and exposing the parsed
-   * action via the returned value (and the assistant message in the store).
+   * Issue #311: actionable replies carry `impactedStageNumbers` (1-indexed)
+   * and a `requiresFullAnalysis` flag. The latter triggers a bounce back to
+   * Acte 2 because the rider asked for a tracé-wide modification.
    */
   async function sendChatMessage(
     text: string,
@@ -799,6 +800,19 @@ export function useTripPlanner() {
         ts: Date.now(),
       });
 
+      // Inline recomputation: surface the shimmer skeleton on the impacted
+      // stage cards until the matching `stage_updated` SSE event clears it.
+      const impactedStages = data.impactedStageNumbers ?? [];
+      if (data.dispatched && impactedStages.length > 0) {
+        const indices = impactedStages
+          .filter((n): n is number => Number.isInteger(n) && n > 0)
+          .map((n) => n - 1);
+        if (indices.length > 0) {
+          actions.startStageRecomputation(indices);
+          setProcessing(true);
+        }
+      }
+
       return data;
     } catch (err) {
       // Drop the error message if the user switched trips while the request
@@ -824,6 +838,15 @@ export function useTripPlanner() {
         useUiStore.getState().setChatSending(false);
       }
     }
+  }
+
+  /**
+   * Bounce the rider back to Acte 2 (full re-analysis) on a `change_route`
+   * chat action. Mirrors {@link handleLaunchAnalysis} but is invoked from the
+   * chat panel "Relancer l'analyse" button.
+   */
+  async function relaunchFullAnalysis(): Promise<boolean> {
+    return handleLaunchAnalysis();
   }
 
   const [isShareModalOpen, setShareModalOpen] = useState(false);
@@ -1065,5 +1088,6 @@ export function useTripPlanner() {
     handleCancelBatch,
     queueModification: actions.queueModification,
     sendChatMessage,
+    relaunchFullAnalysis,
   };
 }

--- a/pwa/src/lib/api/client.ts
+++ b/pwa/src/lib/api/client.ts
@@ -390,7 +390,8 @@ export interface TripChatRequestBody {
 
 /**
  * Response of `POST /trips/{id}/chat`. Mirrors `App\ApiResource\TripChatResponse`
- * on the backend (`tripId`, `action`, `params`, `response`, `dispatched`).
+ * on the backend (`tripId`, `action`, `params`, `response`, `dispatched`,
+ * `impactedStageNumbers`, `requiresFullAnalysis`).
  */
 export interface TripChatResponseBody {
   tripId: string;
@@ -398,6 +399,17 @@ export interface TripChatResponseBody {
   params: Record<string, unknown>;
   response: string;
   dispatched: boolean;
+  /**
+   * 1-indexed day numbers whose recomputation was dispatched (chat-driven
+   * inline edits). Empty for `info` and `change_route` actions.
+   */
+  impactedStageNumbers?: number[];
+  /**
+   * True when the action requires a full trip re-analysis (Acte 2). The
+   * frontend should bounce the rider back to the analysis screen and offer
+   * a "Relancer l'analyse" button.
+   */
+  requiresFullAnalysis?: boolean;
 }
 
 /**
@@ -450,6 +462,8 @@ const tripChatResponseSchema = z.object({
   params: z.record(z.string(), z.unknown()),
   response: z.string(),
   dispatched: z.boolean(),
+  impactedStageNumbers: z.array(z.number()).optional(),
+  requiresFullAnalysis: z.boolean().optional(),
 });
 
 /**

--- a/pwa/src/lib/api/schema.d.ts
+++ b/pwa/src/lib/api/schema.d.ts
@@ -1075,6 +1075,10 @@ export interface components {
             response: string;
             /** @description True when this action will trigger a backend recomputation (Messenger dispatch wired in #311). */
             dispatched: boolean;
+            /** @description Day numbers (1-indexed) whose recomputation has been dispatched. */
+            impactedStageNumbers?: number[];
+            /** @description True when the action requires a full trip re-analysis (Acte 2). */
+            requiresFullAnalysis?: boolean;
         };
         "Trip.TripListItem.jsonld": components["schemas"]["HydraItemBaseSchema"] & {
             id?: string;

--- a/pwa/tests/mocked/ai-bubble.spec.ts
+++ b/pwa/tests/mocked/ai-bubble.spec.ts
@@ -1,5 +1,8 @@
 import { test, expect } from "../fixtures/base.fixture";
-import { fullTripEventSequence } from "../fixtures/mock-data";
+import {
+  fullTripEventSequence,
+  stageUpdatedEvent,
+} from "../fixtures/mock-data";
 import { getTripId } from "../fixtures/api-mocks";
 
 /**
@@ -31,6 +34,8 @@ async function mockChat(
     params: Record<string, unknown>;
     response: string;
     dispatched?: boolean;
+    impactedStageNumbers?: number[];
+    requiresFullAnalysis?: boolean;
   },
   capturedRequests: { body: unknown }[],
 ): Promise<void> {
@@ -50,6 +55,8 @@ async function mockChat(
         params: responseBody.params,
         response: responseBody.response,
         dispatched: responseBody.dispatched ?? false,
+        impactedStageNumbers: responseBody.impactedStageNumbers ?? [],
+        requiresFullAnalysis: responseBody.requiresFullAnalysis ?? false,
       }),
     });
   });
@@ -198,6 +205,115 @@ test.describe("AiBubble — visibility gating", () => {
     });
 
     await expect(mockedPage.getByTestId("ai-bubble")).toHaveCount(0);
+  });
+});
+
+test.describe("AiBubble — inline recomputation (#311)", () => {
+  test("split_stage action triggers shimmer on the two impacted stages and clears it when stage_updated lands", async ({
+    createFullTrip,
+    mockedPage,
+    injectSequence,
+  }) => {
+    await createFullTrip();
+
+    await mockChat(
+      mockedPage,
+      {
+        action: "split_stage",
+        params: { stage: 1 },
+        response: "Je découpe l'étape 1 en deux.",
+        dispatched: true,
+        impactedStageNumbers: [1, 2],
+      },
+      [],
+    );
+
+    await mockedPage.getByTestId("ai-bubble").click();
+    await mockedPage
+      .getByTestId("ai-chat-panel-input")
+      .fill("Coupe l'étape 1 en deux");
+    await mockedPage.getByTestId("ai-chat-panel-send").click();
+
+    // Wait for the assistant reply to confirm the response landed.
+    await expect(
+      mockedPage
+        .getByTestId("ai-chat-panel-message")
+        .filter({ hasText: /je découpe l'étape 1/i }),
+    ).toBeVisible({ timeout: 5_000 });
+
+    // The two impacted stage cards now render as shimmer skeletons.
+    await expect
+      .poll(async () => mockedPage.getByTestId("stage-skeleton").count())
+      .toBe(2);
+
+    // Inject a stage_updated event for stage 0 — one shimmer clears.
+    await injectSequence([stageUpdatedEvent(0)]);
+
+    await expect
+      .poll(async () => mockedPage.getByTestId("stage-skeleton").count())
+      .toBe(1);
+  });
+
+  test("info action does not mark any stage as recomputing", async ({
+    createFullTrip,
+    mockedPage,
+  }) => {
+    await createFullTrip();
+
+    await mockChat(
+      mockedPage,
+      {
+        action: "info",
+        params: {},
+        response: "Le gravel désigne…",
+      },
+      [],
+    );
+
+    await mockedPage.getByTestId("ai-bubble").click();
+    await mockedPage
+      .getByTestId("ai-chat-panel-input")
+      .fill("C'est quoi le gravel ?");
+    await mockedPage.getByTestId("ai-chat-panel-send").click();
+
+    await expect(
+      mockedPage
+        .getByTestId("ai-chat-panel-message")
+        .filter({ hasText: /Le gravel désigne/i }),
+    ).toBeVisible({ timeout: 5_000 });
+
+    await expect(mockedPage.getByTestId("stage-skeleton")).toHaveCount(0);
+  });
+
+  test("change_route action surfaces the relaunch full-analysis button", async ({
+    createFullTrip,
+    mockedPage,
+  }) => {
+    await createFullTrip();
+
+    await mockChat(
+      mockedPage,
+      {
+        action: "change_route",
+        params: {},
+        response: "Cette modification touche tout le tracé.",
+        requiresFullAnalysis: true,
+      },
+      [],
+    );
+
+    await mockedPage.getByTestId("ai-bubble").click();
+    await mockedPage
+      .getByTestId("ai-chat-panel-input")
+      .fill("Change l'itinéraire pour passer par la côte");
+    await mockedPage.getByTestId("ai-chat-panel-send").click();
+
+    await expect(
+      mockedPage.getByTestId("ai-chat-panel-full-analysis"),
+    ).toBeVisible({ timeout: 5_000 });
+    await expect(
+      mockedPage.getByTestId("ai-chat-panel-relaunch"),
+    ).toBeVisible();
   });
 });
 


### PR DESCRIPTION
## Summary

Implements [#311](https://github.com/vincentchalamon/bike-trip-planner/issues/311) — connects the chat actions to the recomputation pipeline and adds the `change_route` (full re-analysis) escape hatch.

**Backend**

- `TripChatProcessor` now maps each non-`info` action to the right `RecalculateStages` dispatch with `skipAiAnalysis: true` so LLaMA 8B is not re-run on inline edits.
- `RecalculateStages` carries `skipAiAnalysis`; `RecalculateStagesHandler` marks the trip via a new one-shot marker on `LlmAnalysisTrackerInterface` (Redis-backed, 30 min TTL); `AllEnrichmentsCompletedHandler` consumes the marker and short-circuits the LLaMA 8B dispatch.
- New `change_route` action: no stage dispatch, response carries `requiresFullAnalysis=true` so the frontend can return to Acte 2.
- `TripChatResponse` gains `impactedStageNumbers` and `requiresFullAnalysis` fields (schema regenerated).

**Frontend**

- `sendChatMessage` now starts the shimmer state on impacted stages via `startStageRecomputation` (0-indexed).
- `AiChatPanel` shows a "modification nécessite une analyse complète" banner with a "Relancer l'analyse" button for `change_route`.
- Playwright spec extended with `split_stage` shimmer flow, `info` no-shimmer assertion, and `change_route` relaunch button.

**Tests**

- `TripChatProcessorTest` — per-action dispatch shape, `skipAiAnalysis` flag, range guards, `change_route` flagging.
- `RecalculateStagesHandlerTest` — `markSkipAiAnalysis` triggered when flagged, default false.
- `AllEnrichmentsCompletedHandlerTest` — `consumeSkipAiAnalysis` → no LLaMA dispatch.

## Auto-critique

- The `skipAiAnalysis` propagation uses a one-shot Redis marker on `LlmAnalysisTrackerInterface` rather than threading the flag through every stage-scan message — trades a little coupling for a minimal blast radius. Documented in the handler.
- Switch in `resolveImpactedStageNumbers` has an explicit `default => []` after the case list; the guard `in_array(action, RECOMPUTE_ACTIONS)` upstream makes the default logically unreachable, but it keeps PHP happy without PHPStan noise.

## Test plan

- [x] `make qa`
- [x] `make phpunit`
- [ ] `make test-e2e ARGS="tests/mocked/ai-bubble.spec.ts"`
- [ ] CI green

Base branch: `feature/310` (stacked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

Reviewed commit `e203f94407cde8da642ddc251496ff2e98f86a63`.

Clean, production-ready implementation. The full `skipAiAnalysis` propagation chain — `TripChatProcessor` dispatch → `RecalculateStages` message → `RecalculateStagesHandler` marker (correctly placed after the null-stages guard) → `AllEnrichmentsCompletedHandler` short-circuit — is correctly wired end-to-end. All issues from previous rounds have been addressed: bounds checks on `merge_stages`, `min()` normalisation for reversed stage pairs, marker placement after the null-stages guard, relaunch-banner persistence on failure, and optional-field alignment between `schema.d.ts` and `client.ts`. No new findings.

**0 findings.**

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Inline comments

No inline comments.

---

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->