### PR TITLE
chore(tracking): link sprint 31 PRs

### DIFF
--- a/TRACKING.md
+++ b/TRACKING.md
@@ -544,9 +544,9 @@ Assistant conversationnel via bulle flottante, LLaMA 3B pour interpréter les in
 
 | Ordre | ID                                                                      | Titre                                                                            | Effort | PRs | Dépend de |
 |-------|-------------------------------------------------------------------------|----------------------------------------------------------------------------------|--------|-----|-----------|
-| 1     | [#309](https://github.com/vincentchalamon/bike-trip-planner/issues/309) | System prompt dialogue LLaMA 3B + endpoint backend chat IA                       | M      |     | #298      |
-| 2     | [#310](https://github.com/vincentchalamon/bike-trip-planner/issues/310) | Composant AiBubble : bulle flottante + panneau chat                              | L      |     | #309 sprint 25 |
-| 3     | [#311](https://github.com/vincentchalamon/bike-trip-planner/issues/311) | Intégration bulle IA ↔ recomputation inline + skipAiAnalysis + toggle batch     | M      |     | #309 #310 |
+| 1     | [#309](https://github.com/vincentchalamon/bike-trip-planner/issues/309) | System prompt dialogue LLaMA 3B + endpoint backend chat IA                       | M      | [#453](https://github.com/vincentchalamon/bike-trip-planner/pull/453) `feature/309` | #298      |
+| 2     | [#310](https://github.com/vincentchalamon/bike-trip-planner/issues/310) | Composant AiBubble : bulle flottante + panneau chat                              | L      | [#454](https://github.com/vincentchalamon/bike-trip-planner/pull/454) `feature/310` | #309 sprint 25 |
+| 3     | [#311](https://github.com/vincentchalamon/bike-trip-planner/issues/311) | Intégration bulle IA ↔ recomputation inline + skipAiAnalysis + toggle batch     | M      | [#455](https://github.com/vincentchalamon/bike-trip-planner/pull/455) `feature/311` | #309 #310 |
 
 ---
 


### PR DESCRIPTION
Updates `TRACKING.md` with the three PRs landed for sprint 31 (Bulle IA / LLaMA 3B chat).

- #453 → #309 backend chat endpoint
- #454 → #310 `AiBubble` component
- #455 → #311 chat ↔ recomputation wiring

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

Clean tracking update — three PR links added to the sprint 31 table in `TRACKING.md`, no code changes. Nothing to flag.

**Review summary:** 0 findings (0 critical, 0 warnings).

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

No inline comments.

_Reviewed commit: e4b103f093bb1229bd09d38be863aab305afee14_

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->