### PR TITLE
feat(in-ride): DetourCalculator (orthogonal projection + Haversine) (#461)

### DIFF
--- a/api/src/Geo/GeoPoint.php
+++ b/api/src/Geo/GeoPoint.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Geo;
+
+/**
+ * Immutable geographic coordinate (WGS84) used by in-ride geometry helpers.
+ */
+final readonly class GeoPoint
+{
+    public function __construct(
+        public float $lat,
+        public float $lon,
+    ) {
+    }
+}

--- a/api/src/InRide/DetourCalculator.php
+++ b/api/src/InRide/DetourCalculator.php
@@ -19,7 +19,7 @@ use App\Geo\GeoPoint;
  *
  * Edge cases:
  *  - Empty polyline → throws {@see \InvalidArgumentException}.
- *  - POI "behind" the rider (negative detour) → detour clamped to 0 and flagged.
+ *  - POI "behind" the rider (raw `t < 0` on segment 0; raw detour is positive) → detour clamped to 0 and flagged.
  *  - POI further than {@see self::POI_FAR_THRESHOLD_METERS} from the route → flagged.
  */
 final readonly class DetourCalculator
@@ -112,8 +112,7 @@ final readonly class DetourCalculator
      *
      * The resulting parameter t is clamped to [0, 1] so the projection always lies on
      * the segment (extremities included), which is what we want for a "rejoin point".
-     */
-    /**
+     *
      * @return array{GeoPoint, float} the clamped projection point and the raw (unclamped) parameter t
      */
     private function projectOnSegment(GeoPoint $poi, GeoPoint $a, GeoPoint $b): array

--- a/api/src/InRide/DetourCalculator.php
+++ b/api/src/InRide/DetourCalculator.php
@@ -36,10 +36,10 @@ final readonly class DetourCalculator
     }
 
     /**
-     * @param list<GeoPoint> $remainingRoute Polyline of the rider's remaining itinerary,
-     *                                       ordered from current position towards the end.
+     * @param list<GeoPoint> $remainingRoute polyline of the rider's remaining itinerary,
+     *                                       ordered from current position towards the end
      *
-     * @throws \InvalidArgumentException When $remainingRoute is empty.
+     * @throws \InvalidArgumentException when $remainingRoute is empty
      */
     public function calculate(GeoPoint $from, GeoPoint $poi, array $remainingRoute): DetourResult
     {
@@ -49,19 +49,24 @@ final readonly class DetourCalculator
 
         $rejoinPoint = $remainingRoute[0];
         $segmentIndex = 0;
-        $minPerpendicular = $this->distance->inMeters(
-            $poi->lat,
-            $poi->lon,
-            $rejoinPoint->lat,
-            $rejoinPoint->lon,
-        );
+        $minPerpendicular = \PHP_FLOAT_MAX;
+        $bestRawT = 0.0;
 
         $segmentsCount = \count($remainingRoute) - 1;
+        if (0 === $segmentsCount) {
+            $minPerpendicular = $this->distance->inMeters(
+                $poi->lat,
+                $poi->lon,
+                $rejoinPoint->lat,
+                $rejoinPoint->lon,
+            );
+        }
+
         for ($i = 0; $i < $segmentsCount; ++$i) {
             $a = $remainingRoute[$i];
             $b = $remainingRoute[$i + 1];
 
-            $projection = $this->projectOnSegment($poi, $a, $b);
+            [$projection, $rawT] = $this->projectOnSegment($poi, $a, $b);
             $perpendicular = $this->distance->inMeters(
                 $poi->lat,
                 $poi->lon,
@@ -73,6 +78,7 @@ final readonly class DetourCalculator
                 $minPerpendicular = $perpendicular;
                 $rejoinPoint = $projection;
                 $segmentIndex = $i;
+                $bestRawT = $rawT;
             }
         }
 
@@ -81,7 +87,11 @@ final readonly class DetourCalculator
         $fromToRejoin = $this->distance->inMeters($from->lat, $from->lon, $rejoinPoint->lat, $rejoinPoint->lon);
 
         $rawDetour = $straightLineToPoi + $poiToRejoin - $fromToRejoin;
-        $clamped = $rawDetour < 0.0;
+        // POI is behind the rider when its projection on the first segment is before the segment start
+        // (rawT < 0 on segment 0) — the rejoin clamps to the rider's position so the detour would
+        // require backtracking. Surface that explicitly by clamping to zero and flagging.
+        $isBehind = 0 === $segmentIndex && $bestRawT < 0.0;
+        $clamped = $rawDetour < 0.0 || $isBehind;
         $detour = $clamped ? 0.0 : $rawDetour;
 
         return new DetourResult(
@@ -103,10 +113,13 @@ final readonly class DetourCalculator
      * The resulting parameter t is clamped to [0, 1] so the projection always lies on
      * the segment (extremities included), which is what we want for a "rejoin point".
      */
-    private function projectOnSegment(GeoPoint $poi, GeoPoint $a, GeoPoint $b): GeoPoint
+    /**
+     * @return array{GeoPoint, float} the clamped projection point and the raw (unclamped) parameter t
+     */
+    private function projectOnSegment(GeoPoint $poi, GeoPoint $a, GeoPoint $b): array
     {
         if ($a->lat === $b->lat && $a->lon === $b->lon) {
-            return $a;
+            return [$a, 0.0];
         }
 
         // Use a local equirectangular projection: x scaled by cos(latitude) so degrees
@@ -126,15 +139,18 @@ final readonly class DetourCalculator
         $denominator = $dx * $dx + $dy * $dy;
 
         if (0.0 === $denominator) {
-            return $a;
+            return [$a, 0.0];
         }
 
-        $t = (($px - $ax) * $dx + ($py - $ay) * $dy) / $denominator;
-        $t = max(0.0, min(1.0, $t));
+        $rawT = (($px - $ax) * $dx + ($py - $ay) * $dy) / $denominator;
+        $t = max(0.0, min(1.0, $rawT));
 
-        return new GeoPoint(
-            lat: $a->lat + $t * ($b->lat - $a->lat),
-            lon: $a->lon + $t * ($b->lon - $a->lon),
-        );
+        return [
+            new GeoPoint(
+                lat: $a->lat + $t * ($b->lat - $a->lat),
+                lon: $a->lon + $t * ($b->lon - $a->lon),
+            ),
+            $rawT,
+        ];
     }
 }

--- a/api/src/InRide/DetourCalculator.php
+++ b/api/src/InRide/DetourCalculator.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\InRide;
+
+use App\Geo\GeoDistanceInterface;
+use App\Geo\GeoPoint;
+
+/**
+ * Approximates the detour required to visit a point of interest from the current
+ * rider position, without recomputing the GPX route.
+ *
+ * The POI is projected orthogonally on every segment of the remaining polyline,
+ * the closest projection (smallest perpendicular distance) is chosen as the
+ * rejoin point, and the detour is estimated using Haversine distances:
+ *
+ *     detour = d(from → poi) + d(poi → rejoin) − d(from → rejoin)
+ *
+ * Edge cases:
+ *  - Empty polyline → throws {@see \InvalidArgumentException}.
+ *  - POI "behind" the rider (negative detour) → detour clamped to 0 and flagged.
+ *  - POI further than {@see self::POI_FAR_THRESHOLD_METERS} from the route → flagged.
+ */
+final readonly class DetourCalculator
+{
+    /**
+     * Perpendicular distance above which the POI is considered far from the route
+     * and a warning flag is raised on the result.
+     */
+    public const float POI_FAR_THRESHOLD_METERS = 5_000.0;
+
+    public function __construct(
+        private GeoDistanceInterface $distance,
+    ) {
+    }
+
+    /**
+     * @param list<GeoPoint> $remainingRoute Polyline of the rider's remaining itinerary,
+     *                                       ordered from current position towards the end.
+     *
+     * @throws \InvalidArgumentException When $remainingRoute is empty.
+     */
+    public function calculate(GeoPoint $from, GeoPoint $poi, array $remainingRoute): DetourResult
+    {
+        if ([] === $remainingRoute) {
+            throw new \InvalidArgumentException('Remaining route polyline must not be empty.');
+        }
+
+        $rejoinPoint = $remainingRoute[0];
+        $segmentIndex = 0;
+        $minPerpendicular = $this->distance->inMeters(
+            $poi->lat,
+            $poi->lon,
+            $rejoinPoint->lat,
+            $rejoinPoint->lon,
+        );
+
+        $segmentsCount = \count($remainingRoute) - 1;
+        for ($i = 0; $i < $segmentsCount; ++$i) {
+            $a = $remainingRoute[$i];
+            $b = $remainingRoute[$i + 1];
+
+            $projection = $this->projectOnSegment($poi, $a, $b);
+            $perpendicular = $this->distance->inMeters(
+                $poi->lat,
+                $poi->lon,
+                $projection->lat,
+                $projection->lon,
+            );
+
+            if ($perpendicular < $minPerpendicular) {
+                $minPerpendicular = $perpendicular;
+                $rejoinPoint = $projection;
+                $segmentIndex = $i;
+            }
+        }
+
+        $straightLineToPoi = $this->distance->inMeters($from->lat, $from->lon, $poi->lat, $poi->lon);
+        $poiToRejoin = $this->distance->inMeters($poi->lat, $poi->lon, $rejoinPoint->lat, $rejoinPoint->lon);
+        $fromToRejoin = $this->distance->inMeters($from->lat, $from->lon, $rejoinPoint->lat, $rejoinPoint->lon);
+
+        $rawDetour = $straightLineToPoi + $poiToRejoin - $fromToRejoin;
+        $clamped = $rawDetour < 0.0;
+        $detour = $clamped ? 0.0 : $rawDetour;
+
+        return new DetourResult(
+            rejoinPoint: $rejoinPoint,
+            segmentIndex: $segmentIndex,
+            detourMeters: $detour,
+            straightLineToPoiMeters: $straightLineToPoi,
+            poiFarFromRoute: $minPerpendicular > self::POI_FAR_THRESHOLD_METERS,
+            detourClampedToZero: $clamped,
+        );
+    }
+
+    /**
+     * Orthogonal projection of $poi onto the segment [$a, $b], performed in a local
+     * equirectangular tangent plane centered on the segment. The plane approximation
+     * is sufficient for typical bikepacking segment lengths (a few hundred meters to a
+     * few kilometers) and avoids the cost of a full geodesic projection.
+     *
+     * The resulting parameter t is clamped to [0, 1] so the projection always lies on
+     * the segment (extremities included), which is what we want for a "rejoin point".
+     */
+    private function projectOnSegment(GeoPoint $poi, GeoPoint $a, GeoPoint $b): GeoPoint
+    {
+        if ($a->lat === $b->lat && $a->lon === $b->lon) {
+            return $a;
+        }
+
+        // Use a local equirectangular projection: x scaled by cos(latitude) so degrees
+        // of longitude are weighted comparably to degrees of latitude in distance terms.
+        $latRefRad = deg2rad(($a->lat + $b->lat) / 2.0);
+        $cosLat = cos($latRefRad);
+
+        $ax = $a->lon * $cosLat;
+        $ay = $a->lat;
+        $bx = $b->lon * $cosLat;
+        $by = $b->lat;
+        $px = $poi->lon * $cosLat;
+        $py = $poi->lat;
+
+        $dx = $bx - $ax;
+        $dy = $by - $ay;
+        $denominator = $dx * $dx + $dy * $dy;
+
+        if (0.0 === $denominator) {
+            return $a;
+        }
+
+        $t = (($px - $ax) * $dx + ($py - $ay) * $dy) / $denominator;
+        $t = max(0.0, min(1.0, $t));
+
+        return new GeoPoint(
+            lat: $a->lat + $t * ($b->lat - $a->lat),
+            lon: $a->lon + $t * ($b->lon - $a->lon),
+        );
+    }
+}

--- a/api/src/InRide/DetourResult.php
+++ b/api/src/InRide/DetourResult.php
@@ -14,12 +14,15 @@ use App\Geo\GeoPoint;
  * - $segmentIndex: index of the segment of the polyline (i.e. between point $i and $i+1)
  *   on which $rejoinPoint lies.
  * - $detourMeters: estimated additional distance in meters compared to staying on the route.
- *   Clamped to 0 when the POI is behind the rider (negative raw value).
+ *   Clamped to 0 either when the raw Haversine sum is slightly negative (floating-point
+ *   noise on a POI essentially on the route) or when the POI is behind the rider (the
+ *   detour is positive but represents unavoidable backtracking).
  * - $straightLineToPoiMeters: Haversine distance between the rider position and the POI.
  * - $poiFarFromRoute: true when the perpendicular distance from the POI to the route
  *   exceeds the {@see DetourCalculator::POI_FAR_THRESHOLD_METERS} warning threshold.
- * - $detourClampedToZero: true when the raw detour value was negative (POI behind the rider)
- *   and has been clamped to 0.
+ * - $detourClampedToZero: true when `detourMeters` was clamped to 0, either because the
+ *   raw Haversine sum was slightly negative or because the POI is behind the rider
+ *   (raw `t < 0` on segment 0).
  */
 final readonly class DetourResult
 {

--- a/api/src/InRide/DetourResult.php
+++ b/api/src/InRide/DetourResult.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\InRide;
+
+use App\Geo\GeoPoint;
+
+/**
+ * Outcome of a detour approximation computed by {@see DetourCalculator}.
+ *
+ * - $rejoinPoint: orthogonal projection of the POI on the remaining route — where the rider
+ *   is expected to resume the original itinerary after visiting the POI.
+ * - $segmentIndex: index of the segment of the polyline (i.e. between point $i and $i+1)
+ *   on which $rejoinPoint lies.
+ * - $detourMeters: estimated additional distance in meters compared to staying on the route.
+ *   Clamped to 0 when the POI is behind the rider (negative raw value).
+ * - $straightLineToPoiMeters: Haversine distance between the rider position and the POI.
+ * - $poiFarFromRoute: true when the perpendicular distance from the POI to the route
+ *   exceeds the {@see DetourCalculator::POI_FAR_THRESHOLD_METERS} warning threshold.
+ * - $detourClampedToZero: true when the raw detour value was negative (POI behind the rider)
+ *   and has been clamped to 0.
+ */
+final readonly class DetourResult
+{
+    public function __construct(
+        public GeoPoint $rejoinPoint,
+        public int $segmentIndex,
+        public float $detourMeters,
+        public float $straightLineToPoiMeters,
+        public bool $poiFarFromRoute = false,
+        public bool $detourClampedToZero = false,
+    ) {
+    }
+}

--- a/api/tests/Unit/InRide/DetourCalculatorTest.php
+++ b/api/tests/Unit/InRide/DetourCalculatorTest.php
@@ -74,9 +74,11 @@ final class DetourCalculatorTest extends TestCase
         $this->assertEqualsWithDelta(5.010, $result->rejoinPoint->lon, 1e-4);
         $this->assertSame(0, $result->segmentIndex);
 
-        // Detour roughly equals 2 × perpendicular distance (~222 m).
-        $this->assertGreaterThan(150.0, $result->detourMeters);
-        $this->assertLessThan(260.0, $result->detourMeters);
+        // Going through the POI costs ~119 m extra vs. staying on the segment
+        // (the rider is at the segment start, so the detour is asymmetric and
+        // smaller than 2× the perpendicular distance).
+        $this->assertGreaterThan(50.0, $result->detourMeters);
+        $this->assertLessThan(200.0, $result->detourMeters);
         $this->assertFalse($result->poiFarFromRoute);
         $this->assertFalse($result->detourClampedToZero);
     }
@@ -163,7 +165,7 @@ final class DetourCalculatorTest extends TestCase
 
         $result = $this->calculator->calculate($from, $poi, $route);
 
-        $expected = (new HaversineDistance())->inMeters(45.0, 5.000, 45.001, 5.010);
+        $expected = new HaversineDistance()->inMeters(45.0, 5.000, 45.001, 5.010);
         $this->assertEqualsWithDelta($expected, $result->straightLineToPoiMeters, 0.001);
     }
 }

--- a/api/tests/Unit/InRide/DetourCalculatorTest.php
+++ b/api/tests/Unit/InRide/DetourCalculatorTest.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\InRide;
+
+use App\Geo\GeoPoint;
+use App\Geo\HaversineDistance;
+use App\InRide\DetourCalculator;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class DetourCalculatorTest extends TestCase
+{
+    private DetourCalculator $calculator;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->calculator = new DetourCalculator(new HaversineDistance());
+    }
+
+    #[Test]
+    public function emptyPolylineThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->calculator->calculate(
+            new GeoPoint(45.0, 5.0),
+            new GeoPoint(45.001, 5.001),
+            [],
+        );
+    }
+
+    #[Test]
+    public function poiOnRouteYieldsZeroDetour(): void
+    {
+        // West-east straight route along latitude 45.
+        $route = [
+            new GeoPoint(45.0, 5.000),
+            new GeoPoint(45.0, 5.010),
+            new GeoPoint(45.0, 5.020),
+        ];
+        $from = new GeoPoint(45.0, 5.000);
+        $poi = new GeoPoint(45.0, 5.005); // directly on the first segment
+
+        $result = $this->calculator->calculate($from, $poi, $route);
+
+        // Detour must be (near) zero — going through the POI does not add length.
+        $this->assertEqualsWithDelta(0.0, $result->detourMeters, 1.0);
+        $this->assertEqualsWithDelta(45.0, $result->rejoinPoint->lat, 1e-6);
+        $this->assertEqualsWithDelta(5.005, $result->rejoinPoint->lon, 1e-6);
+        $this->assertSame(0, $result->segmentIndex);
+        $this->assertFalse($result->poiFarFromRoute);
+        $this->assertFalse($result->detourClampedToZero);
+    }
+
+    #[Test]
+    public function poiToTheRightOfRouteProducesPositiveDetour(): void
+    {
+        // West-east straight route along latitude 45, POI offset to the north.
+        $route = [
+            new GeoPoint(45.0, 5.000),
+            new GeoPoint(45.0, 5.020),
+        ];
+        $from = new GeoPoint(45.0, 5.000);
+        // ~111m north of (45.0, 5.010): 0.001 deg lat ≈ 111 m.
+        $poi = new GeoPoint(45.001, 5.010);
+
+        $result = $this->calculator->calculate($from, $poi, $route);
+
+        // Rejoin point should be the orthogonal projection on the segment ≈ (45.0, 5.010).
+        $this->assertEqualsWithDelta(45.0, $result->rejoinPoint->lat, 1e-4);
+        $this->assertEqualsWithDelta(5.010, $result->rejoinPoint->lon, 1e-4);
+        $this->assertSame(0, $result->segmentIndex);
+
+        // Detour roughly equals 2 × perpendicular distance (~222 m).
+        $this->assertGreaterThan(150.0, $result->detourMeters);
+        $this->assertLessThan(260.0, $result->detourMeters);
+        $this->assertFalse($result->poiFarFromRoute);
+        $this->assertFalse($result->detourClampedToZero);
+    }
+
+    #[Test]
+    public function poiBehindPositionClampsDetourToZero(): void
+    {
+        // West-east route, rider already past the POI.
+        $route = [
+            new GeoPoint(45.0, 5.010),
+            new GeoPoint(45.0, 5.020),
+        ];
+        $from = new GeoPoint(45.0, 5.010);
+        $poi = new GeoPoint(45.0, 5.000); // behind the rider
+
+        $result = $this->calculator->calculate($from, $poi, $route);
+
+        $this->assertSame(0.0, $result->detourMeters);
+        $this->assertTrue($result->detourClampedToZero);
+        // Best rejoin point is the segment start (closest projection).
+        $this->assertEqualsWithDelta(5.010, $result->rejoinPoint->lon, 1e-6);
+    }
+
+    #[Test]
+    public function poiFarFromRouteRaisesWarningFlag(): void
+    {
+        // Route around (45.0, 5.0); POI ~10km north → far above 5km threshold.
+        $route = [
+            new GeoPoint(45.0, 5.000),
+            new GeoPoint(45.0, 5.020),
+        ];
+        $from = new GeoPoint(45.0, 5.000);
+        $poi = new GeoPoint(45.10, 5.010); // 0.10 deg lat ≈ 11 km north
+
+        $result = $this->calculator->calculate($from, $poi, $route);
+
+        $this->assertTrue($result->poiFarFromRoute);
+        $this->assertGreaterThan(0.0, $result->detourMeters);
+    }
+
+    #[Test]
+    public function picksClosestSegmentAcrossMultipleSegments(): void
+    {
+        // L-shaped polyline: first goes east, then turns north.
+        $route = [
+            new GeoPoint(45.000, 5.000),
+            new GeoPoint(45.000, 5.020),
+            new GeoPoint(45.020, 5.020),
+        ];
+        $from = new GeoPoint(45.000, 5.000);
+        // POI sits just east of the vertical segment → should rejoin on segment index 1.
+        $poi = new GeoPoint(45.010, 5.021);
+
+        $result = $this->calculator->calculate($from, $poi, $route);
+
+        $this->assertSame(1, $result->segmentIndex);
+        $this->assertEqualsWithDelta(5.020, $result->rejoinPoint->lon, 1e-4);
+        $this->assertEqualsWithDelta(45.010, $result->rejoinPoint->lat, 1e-4);
+    }
+
+    #[Test]
+    public function singlePointPolylineUsesItAsRejoin(): void
+    {
+        $route = [new GeoPoint(45.0, 5.0)];
+        $from = new GeoPoint(45.0, 5.0);
+        $poi = new GeoPoint(45.001, 5.0);
+
+        $result = $this->calculator->calculate($from, $poi, $route);
+
+        $this->assertSame(0, $result->segmentIndex);
+        $this->assertSame(45.0, $result->rejoinPoint->lat);
+        $this->assertSame(5.0, $result->rejoinPoint->lon);
+    }
+
+    #[Test]
+    public function straightLineToPoiMatchesHaversine(): void
+    {
+        $route = [
+            new GeoPoint(45.0, 5.000),
+            new GeoPoint(45.0, 5.020),
+        ];
+        $from = new GeoPoint(45.0, 5.000);
+        $poi = new GeoPoint(45.001, 5.010);
+
+        $result = $this->calculator->calculate($from, $poi, $route);
+
+        $expected = (new HaversineDistance())->inMeters(45.0, 5.000, 45.001, 5.010);
+        $this->assertEqualsWithDelta($expected, $result->straightLineToPoiMeters, 0.001);
+    }
+}


### PR DESCRIPTION
## Summary

Sprint 32 #461 — Calcul de détour approximatif POI / itinéraire restant, sans recalcul GPX.

- `App\InRide\DetourCalculator` : projection orthogonale du POI sur chaque segment de la polyline restante, sélection du segment au plus proche
- `DetourResult` DTO : rejoinPoint, segmentIndex, detourMeters, straightLineToPoiMeters, poiFarFromRoute, detourClampedToZero
- Détection "POI derrière" via le paramètre raw `t < 0` sur le premier segment (clamp à 0)
- Flag `poiFarFromRoute` si distance perpendiculaire > 5 km
- Réutilise `App\Geo\HaversineDistance` (existant) + `App\Geo\GeoPoint` (nouveau)
- 8 tests unitaires (polyline vide, POI sur la route, à droite, derrière, hors stage, L-shape, etc.)

Closes #461

## Test plan

- [ ] CI verte
- [ ] Algorithme correct sur fixtures géométriques précises
- [ ] Gestion des cas limites

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

**0 new findings** — all previous issues resolved.

**Commit reviewed:** `41c2f5e19fb2cc0939b984915d189bb603e5af15`

### Resolved threads
Resolved 3 previously open bot-authored threads that were all addressed in the latest commits (`fix(in-ride)` + `docs(in-ride)`):
- Merged orphaned `projectOnSegment` docblocks into a single block.
- Corrected the "behind-rider" description in `DetourCalculator` class docblock (raw detour is positive, not negative).
- Corrected the `$detourMeters` / `$detourClampedToZero` descriptions in `DetourResult`.

### PR title
`feat(in-ride): DetourCalculator (orthogonal projection + Haversine) (#461)` still does not follow Conventional Commits — the description must be lowercase imperative and should not include class names or issue references. Suggested: `feat(in-ride): add detour calculator using orthogonal projection and haversine`.

### Review checklist
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Inline comments
No inline comments.

---
Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->