### PR TITLE
feat(pwa): useGeolocation + useOnlineStatus hooks + ChatOfflineBadge (#464)

### DIFF
--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -615,12 +615,6 @@
   "chat": {
     "offline": {
       "label": "You are offline. The assistant is unavailable."
-    },
-    "geoloc": {
-      "requesting": "Requesting your location…",
-      "denied": "Location permission denied. Update your browser settings to share it.",
-      "unavailable": "Your device cannot determine your location right now.",
-      "timeout": "Locating you took too long. Please try again."
     }
   },
   "aiOverview": {

--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -612,6 +612,17 @@
     "fullAnalysisHint": "This change requires a brand-new full analysis.",
     "relaunchAnalysis": "Relaunch analysis"
   },
+  "chat": {
+    "offline": {
+      "label": "You are offline. The assistant is unavailable."
+    },
+    "geoloc": {
+      "requesting": "Requesting your location…",
+      "denied": "Location permission denied. Update your browser settings to share it.",
+      "unavailable": "Your device cannot determine your location right now.",
+      "timeout": "Locating you took too long. Please try again."
+    }
+  },
   "aiOverview": {
     "title": "AI analysis",
     "subtitle": "Assistant-generated summary covering the whole trip",

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -615,12 +615,6 @@
   "chat": {
     "offline": {
       "label": "Vous êtes hors ligne. L'assistant est indisponible."
-    },
-    "geoloc": {
-      "requesting": "Récupération de votre position…",
-      "denied": "Permission de localisation refusée. Modifiez les réglages du navigateur pour la partager.",
-      "unavailable": "Votre appareil ne parvient pas à déterminer votre position pour le moment.",
-      "timeout": "La localisation a pris trop de temps. Réessayez."
     }
   },
   "aiOverview": {

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -612,6 +612,17 @@
     "fullAnalysisHint": "Cette modification nécessite une nouvelle analyse complète.",
     "relaunchAnalysis": "Relancer l'analyse"
   },
+  "chat": {
+    "offline": {
+      "label": "Vous êtes hors ligne. L'assistant est indisponible."
+    },
+    "geoloc": {
+      "requesting": "Récupération de votre position…",
+      "denied": "Permission de localisation refusée. Modifiez les réglages du navigateur pour la partager.",
+      "unavailable": "Votre appareil ne parvient pas à déterminer votre position pour le moment.",
+      "timeout": "La localisation a pris trop de temps. Réessayez."
+    }
+  },
   "aiOverview": {
     "title": "Analyse IA",
     "subtitle": "Synthèse générée par l'assistant à partir de l'ensemble du voyage",

--- a/pwa/src/components/ai-bubble.tsx
+++ b/pwa/src/components/ai-bubble.tsx
@@ -53,8 +53,7 @@ export function AiBubble() {
     <>
       <button
         type="button"
-        onClick={toggleBubble}
-        disabled={!isOnline}
+        onClick={isOnline ? toggleBubble : undefined}
         aria-disabled={!isOnline}
         aria-label={isBubbleOpen ? t("closeAria") : t("openAria")}
         aria-expanded={isBubbleOpen}

--- a/pwa/src/components/ai-bubble.tsx
+++ b/pwa/src/components/ai-bubble.tsx
@@ -7,6 +7,8 @@ import { useShallow } from "zustand/react/shallow";
 import { useUiStore } from "@/store/ui-store";
 import { useTripStore } from "@/store/trip-store";
 import { AiChatPanel } from "@/components/ai-chat-panel";
+import { ChatOfflineBadge } from "@/components/chat/ChatOfflineBadge";
+import { useOnlineStatus } from "@/hooks/use-online-status";
 import { cn } from "@/lib/utils";
 
 /**
@@ -23,6 +25,8 @@ import { cn } from "@/lib/utils";
  */
 export function AiBubble() {
   const t = useTranslations("aiBubble");
+  const tOffline = useTranslations("chat.offline");
+  const isOnline = useOnlineStatus();
 
   const { isBubbleOpen, hasSeenBubble, toggleBubble, closeBubble } = useUiStore(
     useShallow((s) => ({
@@ -50,20 +54,27 @@ export function AiBubble() {
       <button
         type="button"
         onClick={toggleBubble}
+        disabled={!isOnline}
+        aria-disabled={!isOnline}
         aria-label={isBubbleOpen ? t("closeAria") : t("openAria")}
         aria-expanded={isBubbleOpen}
         aria-controls="ai-chat-panel"
         data-testid="ai-bubble"
         data-open={isBubbleOpen || undefined}
+        data-offline={!isOnline || undefined}
+        title={!isOnline ? tOffline("label") : undefined}
         className={cn(
           "fixed bottom-6 right-6 z-30 inline-flex items-center justify-center",
           "h-14 w-14 rounded-full bg-brand text-white shadow-lg",
           "hover:bg-brand-hover transition-transform hover:scale-105",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-hover focus-visible:ring-offset-2",
+          !isOnline &&
+            "cursor-not-allowed opacity-60 hover:scale-100 hover:bg-brand",
         )}
       >
         <Sparkles className="h-6 w-6" aria-hidden="true" />
-        {!hasSeenBubble && (
+        {!isOnline && <ChatOfflineBadge />}
+        {isOnline && !hasSeenBubble && (
           <span
             data-testid="ai-bubble-badge"
             className={cn(

--- a/pwa/src/components/chat/ChatOfflineBadge.tsx
+++ b/pwa/src/components/chat/ChatOfflineBadge.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { WifiOff } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface ChatOfflineBadgeProps {
+  className?: string;
+}
+
+/**
+ * Small visual indicator overlaid on the floating chat button when the user
+ * has lost network connectivity. The badge is purely decorative for sighted
+ * users; the parent button is responsible for the matching `aria-disabled`
+ * state and tooltip wording.
+ */
+export function ChatOfflineBadge({ className }: ChatOfflineBadgeProps) {
+  const t = useTranslations("chat.offline");
+
+  return (
+    <span
+      data-testid="chat-offline-badge"
+      role="img"
+      aria-label={t("label")}
+      title={t("label")}
+      className={cn(
+        "absolute -top-1 -right-1 inline-flex items-center justify-center",
+        "h-5 w-5 rounded-full bg-neutral-700 text-white shadow-sm",
+        "ring-2 ring-white",
+        className,
+      )}
+    >
+      <WifiOff className="h-3 w-3" aria-hidden="true" />
+    </span>
+  );
+}

--- a/pwa/src/components/chat/ChatOfflineBadge.tsx
+++ b/pwa/src/components/chat/ChatOfflineBadge.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useTranslations } from "next-intl";
 import { WifiOff } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -10,19 +9,16 @@ interface ChatOfflineBadgeProps {
 
 /**
  * Small visual indicator overlaid on the floating chat button when the user
- * has lost network connectivity. The badge is purely decorative for sighted
- * users; the parent button is responsible for the matching `aria-disabled`
- * state and tooltip wording.
+ * has lost network connectivity. The badge is purely decorative — the parent
+ * button already owns the accessible name, the `aria-disabled` state, and the
+ * tooltip wording — so we hide it from assistive technologies to avoid a
+ * duplicate "offline" announcement in NVDA / JAWS browse mode.
  */
 export function ChatOfflineBadge({ className }: ChatOfflineBadgeProps) {
-  const t = useTranslations("chat.offline");
-
   return (
     <span
       data-testid="chat-offline-badge"
-      role="img"
-      aria-label={t("label")}
-      title={t("label")}
+      aria-hidden="true"
       className={cn(
         "absolute -top-1 -right-1 inline-flex items-center justify-center",
         "h-5 w-5 rounded-full bg-neutral-700 text-white shadow-sm",

--- a/pwa/src/hooks/use-geolocation.test.ts
+++ b/pwa/src/hooks/use-geolocation.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useGeolocation } from "./use-geolocation";
+
+interface MockGeolocation {
+  getCurrentPosition: ReturnType<typeof vi.fn>;
+}
+
+const originalGeolocation = Object.getOwnPropertyDescriptor(
+  globalThis.navigator,
+  "geolocation",
+);
+
+function setGeolocation(value: MockGeolocation | undefined): void {
+  Object.defineProperty(globalThis.navigator, "geolocation", {
+    configurable: true,
+    writable: true,
+    value,
+  });
+}
+
+describe("useGeolocation", () => {
+  let mockGeolocation: MockGeolocation;
+
+  beforeEach(() => {
+    mockGeolocation = { getCurrentPosition: vi.fn() };
+    setGeolocation(mockGeolocation);
+  });
+
+  afterEach(() => {
+    if (originalGeolocation) {
+      Object.defineProperty(
+        globalThis.navigator,
+        "geolocation",
+        originalGeolocation,
+      );
+    } else {
+      // @ts-expect-error - cleaning up
+      delete (globalThis.navigator as { geolocation?: unknown }).geolocation;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it("starts with no position, no error and isRequesting=false", () => {
+    const { result } = renderHook(() => useGeolocation());
+    expect(result.current.position).toBeNull();
+    expect(result.current.error).toBeNull();
+    expect(result.current.isRequesting).toBe(false);
+  });
+
+  it("resolves a position when getCurrentPosition succeeds", () => {
+    mockGeolocation.getCurrentPosition.mockImplementation((success) => {
+      success({
+        coords: { latitude: 48.85, longitude: 2.35, accuracy: 12 },
+        timestamp: 1700000000000,
+      });
+    });
+
+    const { result } = renderHook(() => useGeolocation());
+    act(() => {
+      result.current.request();
+    });
+
+    expect(result.current.position).toEqual({
+      latitude: 48.85,
+      longitude: 2.35,
+      accuracy: 12,
+      timestamp: 1700000000000,
+    });
+    expect(result.current.error).toBeNull();
+    expect(result.current.isRequesting).toBe(false);
+  });
+
+  it("calls getCurrentPosition with battery-friendly options (no watchPosition)", () => {
+    mockGeolocation.getCurrentPosition.mockImplementation(() => {});
+    const { result } = renderHook(() => useGeolocation());
+    act(() => {
+      result.current.request();
+    });
+
+    expect(mockGeolocation.getCurrentPosition).toHaveBeenCalledTimes(1);
+    const options = mockGeolocation.getCurrentPosition.mock.calls[0]?.[2];
+    expect(options).toEqual({
+      enableHighAccuracy: false,
+      timeout: 10_000,
+      maximumAge: 60_000,
+    });
+  });
+
+  it.each([
+    [1, "denied"],
+    [2, "unavailable"],
+    [3, "timeout"],
+  ])("maps PositionError code %i to %s", (code, expected) => {
+    mockGeolocation.getCurrentPosition.mockImplementation((_, errorCb) => {
+      errorCb({ code, message: `mock ${expected}` });
+    });
+
+    const { result } = renderHook(() => useGeolocation());
+    act(() => {
+      result.current.request();
+    });
+
+    expect(result.current.error).toEqual({
+      code: expected,
+      message: `mock ${expected}`,
+    });
+    expect(result.current.isRequesting).toBe(false);
+  });
+
+  it("reports unsupported when navigator.geolocation is missing", () => {
+    setGeolocation(undefined);
+    const { result } = renderHook(() => useGeolocation());
+
+    act(() => {
+      result.current.request();
+    });
+
+    expect(result.current.error?.code).toBe("unsupported");
+  });
+});

--- a/pwa/src/hooks/use-geolocation.test.ts
+++ b/pwa/src/hooks/use-geolocation.test.ts
@@ -117,4 +117,45 @@ describe("useGeolocation", () => {
 
     expect(result.current.error?.code).toBe("unsupported");
   });
+
+  it("re-entrancy guard: a double-tap fires getCurrentPosition only once", () => {
+    // The first call captures the success callback without invoking it, so the
+    // hook is left in flight (isRequesting=true) — the second call must short
+    // out via the ref-based guard.
+    let capturedSuccess: PositionCallback | undefined;
+    mockGeolocation.getCurrentPosition.mockImplementation((successCb) => {
+      capturedSuccess = successCb;
+    });
+
+    const { result } = renderHook(() => useGeolocation());
+
+    act(() => {
+      result.current.request();
+      result.current.request();
+    });
+
+    expect(mockGeolocation.getCurrentPosition).toHaveBeenCalledTimes(1);
+
+    // Resolve the first request so the guard releases for a follow-up call.
+    act(() => {
+      capturedSuccess?.({
+        coords: {
+          latitude: 48.8566,
+          longitude: 2.3522,
+          accuracy: 12,
+          altitude: null,
+          altitudeAccuracy: null,
+          heading: null,
+          speed: null,
+        },
+        timestamp: Date.now(),
+      } as GeolocationPosition);
+    });
+
+    act(() => {
+      result.current.request();
+    });
+
+    expect(mockGeolocation.getCurrentPosition).toHaveBeenCalledTimes(2);
+  });
 });

--- a/pwa/src/hooks/use-geolocation.test.ts
+++ b/pwa/src/hooks/use-geolocation.test.ts
@@ -35,7 +35,6 @@ describe("useGeolocation", () => {
         originalGeolocation,
       );
     } else {
-      // @ts-expect-error - cleaning up
       delete (globalThis.navigator as { geolocation?: unknown }).geolocation;
     }
     vi.restoreAllMocks();

--- a/pwa/src/hooks/use-geolocation.ts
+++ b/pwa/src/hooks/use-geolocation.ts
@@ -1,0 +1,97 @@
+"use client";
+
+import { useCallback, useState } from "react";
+
+/**
+ * Reason codes for a geolocation failure.
+ *
+ * - `denied`: the user (or browser policy) refused permission.
+ * - `unavailable`: the device cannot determine a position.
+ * - `timeout`: the request did not complete within the timeout.
+ * - `unsupported`: the `navigator.geolocation` API is not available.
+ */
+export type GeolocationErrorCode =
+  | "denied"
+  | "unavailable"
+  | "timeout"
+  | "unsupported";
+
+export interface GeolocationCoords {
+  latitude: number;
+  longitude: number;
+  accuracy: number;
+  timestamp: number;
+}
+
+export interface GeolocationErrorInfo {
+  code: GeolocationErrorCode;
+  message: string;
+}
+
+export interface UseGeolocationResult {
+  position: GeolocationCoords | null;
+  error: GeolocationErrorInfo | null;
+  isRequesting: boolean;
+  request: () => void;
+}
+
+const DEFAULT_OPTIONS: PositionOptions = {
+  enableHighAccuracy: false,
+  timeout: 10_000,
+  maximumAge: 60_000,
+};
+
+/**
+ * One-shot geolocation hook.
+ *
+ * Intentionally avoids `watchPosition` to preserve battery on mobile devices.
+ * Each call to `request()` triggers a single `getCurrentPosition()` lookup
+ * with battery-friendly options (low accuracy, 60s cache, 10s timeout).
+ */
+export function useGeolocation(): UseGeolocationResult {
+  const [position, setPosition] = useState<GeolocationCoords | null>(null);
+  const [error, setError] = useState<GeolocationErrorInfo | null>(null);
+  const [isRequesting, setIsRequesting] = useState(false);
+
+  const request = useCallback(() => {
+    if (
+      typeof navigator === "undefined" ||
+      !("geolocation" in navigator) ||
+      !navigator.geolocation
+    ) {
+      setError({
+        code: "unsupported",
+        message: "Geolocation API is not available in this environment.",
+      });
+      return;
+    }
+
+    setIsRequesting(true);
+    setError(null);
+
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        setPosition({
+          latitude: pos.coords.latitude,
+          longitude: pos.coords.longitude,
+          accuracy: pos.coords.accuracy,
+          timestamp: pos.timestamp,
+        });
+        setIsRequesting(false);
+      },
+      (err) => {
+        const code: GeolocationErrorCode =
+          err.code === 1
+            ? "denied"
+            : err.code === 3
+              ? "timeout"
+              : "unavailable";
+        setError({ code, message: err.message });
+        setIsRequesting(false);
+      },
+      DEFAULT_OPTIONS,
+    );
+  }, []);
+
+  return { position, error, isRequesting, request };
+}

--- a/pwa/src/hooks/use-geolocation.ts
+++ b/pwa/src/hooks/use-geolocation.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 
 /**
  * Reason codes for a geolocation failure.
@@ -52,8 +52,15 @@ export function useGeolocation(): UseGeolocationResult {
   const [position, setPosition] = useState<GeolocationCoords | null>(null);
   const [error, setError] = useState<GeolocationErrorInfo | null>(null);
   const [isRequesting, setIsRequesting] = useState(false);
+  // Re-entrancy guard: the useCallback closure captures the *initial* value of
+  // isRequesting, so a state-based guard would never fire. A ref stays current
+  // across renders and prevents racing getCurrentPosition() calls from a
+  // double-tap or retry-on-error pattern.
+  const isRequestingRef = useRef(false);
 
   const request = useCallback(() => {
+    if (isRequestingRef.current) return;
+
     if (
       typeof navigator === "undefined" ||
       !("geolocation" in navigator) ||
@@ -66,6 +73,7 @@ export function useGeolocation(): UseGeolocationResult {
       return;
     }
 
+    isRequestingRef.current = true;
     setIsRequesting(true);
     setError(null);
 
@@ -77,6 +85,7 @@ export function useGeolocation(): UseGeolocationResult {
           accuracy: pos.coords.accuracy,
           timestamp: pos.timestamp,
         });
+        isRequestingRef.current = false;
         setIsRequesting(false);
       },
       (err) => {
@@ -87,6 +96,7 @@ export function useGeolocation(): UseGeolocationResult {
               ? "timeout"
               : "unavailable";
         setError({ code, message: err.message });
+        isRequestingRef.current = false;
         setIsRequesting(false);
       },
       DEFAULT_OPTIONS,

--- a/pwa/src/hooks/use-online-status.test.ts
+++ b/pwa/src/hooks/use-online-status.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useOnlineStatus } from "./use-online-status";
+
+const originalOnLine = Object.getOwnPropertyDescriptor(
+  window.navigator,
+  "onLine",
+);
+
+function setOnLine(value: boolean): void {
+  Object.defineProperty(window.navigator, "onLine", {
+    configurable: true,
+    get: () => value,
+  });
+}
+
+describe("useOnlineStatus", () => {
+  afterEach(() => {
+    if (originalOnLine) {
+      Object.defineProperty(window.navigator, "onLine", originalOnLine);
+    }
+  });
+
+  it("returns the current navigator.onLine value", () => {
+    setOnLine(true);
+    const { result } = renderHook(() => useOnlineStatus());
+    expect(result.current).toBe(true);
+  });
+
+  it("returns false when navigator.onLine is false", () => {
+    setOnLine(false);
+    const { result } = renderHook(() => useOnlineStatus());
+    expect(result.current).toBe(false);
+  });
+
+  it("reacts to the offline event", () => {
+    setOnLine(true);
+    const { result } = renderHook(() => useOnlineStatus());
+    expect(result.current).toBe(true);
+
+    act(() => {
+      setOnLine(false);
+      window.dispatchEvent(new Event("offline"));
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it("reacts to the online event", () => {
+    setOnLine(false);
+    const { result } = renderHook(() => useOnlineStatus());
+    expect(result.current).toBe(false);
+
+    act(() => {
+      setOnLine(true);
+      window.dispatchEvent(new Event("online"));
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it("removes listeners on unmount", () => {
+    setOnLine(true);
+    const { result, unmount } = renderHook(() => useOnlineStatus());
+    unmount();
+
+    // Dispatching after unmount must not throw and must not affect state.
+    act(() => {
+      setOnLine(false);
+      window.dispatchEvent(new Event("offline"));
+    });
+    expect(result.current).toBe(true);
+  });
+});

--- a/pwa/src/hooks/use-online-status.ts
+++ b/pwa/src/hooks/use-online-status.ts
@@ -1,0 +1,38 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Reactive wrapper around `navigator.onLine`.
+ *
+ * Subscribes to the `online` / `offline` window events so consumers re-render
+ * whenever connectivity changes. Defaults to `true` during SSR and before the
+ * browser-side effect runs, so the UI is optimistic by default.
+ */
+export function useOnlineStatus(): boolean {
+  const [isOnline, setIsOnline] = useState<boolean>(() => {
+    if (typeof navigator === "undefined") return true;
+    return navigator.onLine !== false;
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const handleOnline = () => setIsOnline(true);
+    const handleOffline = () => setIsOnline(false);
+
+    // Sync with the current value in case it changed between the initial
+    // render and the effect (e.g. hydration after a navigation while offline).
+    setIsOnline(navigator.onLine !== false);
+
+    window.addEventListener("online", handleOnline);
+    window.addEventListener("offline", handleOffline);
+
+    return () => {
+      window.removeEventListener("online", handleOnline);
+      window.removeEventListener("offline", handleOffline);
+    };
+  }, []);
+
+  return isOnline;
+}


### PR DESCRIPTION
## Summary

Sprint 32 #464 — Hooks PWA pour la géoloc one-shot et l'état réseau, badge offline sur le bouton flottant chat.

- `useGeolocation` : one-shot uniquement (économie batterie), `enableHighAccuracy: false`, timeout 10s, maximumAge 60s
- `useOnlineStatus` : wrapper `navigator.onLine` + listeners
- `ChatOfflineBadge` : indicateur visuel + état désactivé du bouton chat quand offline
- Intégration dans `ai-bubble.tsx`
- i18n FR/EN (`chat.offline.*`, `chat.geoloc.*`)
- Tests Vitest mockant `navigator.geolocation` et `navigator.onLine`

Closes #464

## Test plan

- [ ] CI verte
- [ ] Hooks couvrent succès + erreurs (denied, unavailable, timeout, unsupported)
- [ ] Bouton chat se désactive quand offline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

All prior issues are fully resolved by the latest two commits. The `aria-hidden="true"` fix on `ChatOfflineBadge` closes the last open thread. No new findings — the hooks, tests, and integration are clean.

**Commit reviewed:** `dab8ddc7743bc90237654bdee78101e6094cee15`

### Resolved threads

Resolved 1 previously open bot-authored thread (`PRRT_kwDORUitfM6Da3th` — `aria-hidden="true"` correctly applied to `ChatOfflineBadge`, matching the docstring intent and eliminating the duplicate AT announcement).

### PR title

`feat(pwa): useGeolocation + useOnlineStatus hooks + ChatOfflineBadge (#464)` — description is a noun phrase, not imperative mood. Suggested: `feat(pwa): add useGeolocation and useOnlineStatus hooks with ChatOfflineBadge`.

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [ ] Tests cover new/changed cases — offline behavior in `ai-bubble.tsx` (badge visibility, `aria-disabled`, blocked click) has no Playwright E2E test
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Notes

`useGeolocation` has no consumer in this PR (hook + tests added, but nothing calls `request()`). Per the previous review, this is acceptable if integration is planned in a follow-up sprint PR — confirm via the issue tracker before merge.

### Inline comments

No inline comments.

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->