### PR TITLE
feat(chat): GET /trips/{id}/chat-history endpoint with pagination (#459)

### DIFF
--- a/api/src/ApiResource/TripChatMessageResource.php
+++ b/api/src/ApiResource/TripChatMessageResource.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ApiResource;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\OpenApi\Model\Operation;
+use ApiPlatform\OpenApi\Model\Parameter;
+use ApiPlatform\OpenApi\Model\Response;
+use App\State\TripChatHistoryProvider;
+
+/**
+ * Read-only DTO exposing a single persisted chat turn over the API.
+ *
+ * Backs the `GET /trips/{id}/chat-history` endpoint introduced in #459 so the
+ * PWA can rehydrate the chat drawer after a refresh or a return visit. The
+ * underlying Doctrine entity ({@see \App\Entity\TripChatMessage}) is kept
+ * private to the backend; only the publicly safe fields are exposed here.
+ *
+ * Messages are returned ordered by `createdAt` DESC (most recent first); the
+ * frontend reverses them for chronological rendering. Cursor pagination is
+ * available via the `before` query parameter (RFC 3339 datetime).
+ */
+#[ApiResource(
+    shortName: 'TripChatMessage',
+    operations: [
+        new GetCollection(
+            uriTemplate: '/trips/{id}/chat-history{._format}',
+            openapi: new Operation(
+                responses: [
+                    404 => new Response(description: 'Trip not found'),
+                ],
+                summary: 'List the persisted chat history for a trip (most-recent first, cursor pagination).',
+                parameters: [
+                    new Parameter(
+                        name: 'limit',
+                        in: 'query',
+                        description: 'Maximum number of messages to return (default 50, max 200).',
+                        required: false,
+                        schema: ['type' => 'integer', 'minimum' => 1, 'maximum' => 200, 'default' => 50],
+                    ),
+                    new Parameter(
+                        name: 'before',
+                        in: 'query',
+                        description: 'Only return messages strictly older than this RFC 3339 timestamp (used as a cursor for "load older").',
+                        required: false,
+                        schema: ['type' => 'string', 'format' => 'date-time'],
+                    ),
+                ],
+            ),
+            paginationEnabled: false,
+            security: "is_granted('TRIP_VIEW', request.attributes.get('id'))",
+            provider: TripChatHistoryProvider::class,
+        ),
+    ],
+)]
+final readonly class TripChatMessageResource
+{
+    /**
+     * @param non-empty-string $role one of `user` or `assistant`
+     */
+    public function __construct(
+        #[ApiProperty(description: 'Message identifier (UUID v7).', identifier: true)]
+        public string $id,
+        #[ApiProperty(description: 'Trip identifier (UUID v7) the message belongs to.')]
+        public string $tripId,
+        #[ApiProperty(description: 'Author role: `user` or `assistant`.')]
+        public string $role,
+        #[ApiProperty(description: 'Raw message content. For assistant turns this is the JSON envelope returned by the LLM.')]
+        public string $content,
+        #[ApiProperty(description: 'Structured action interpreted by the dialogue assistant (e.g. `split_stage`, `info`).')]
+        public ?string $action,
+        #[ApiProperty(description: 'Server-side creation timestamp (RFC 3339).')]
+        public \DateTimeImmutable $createdAt,
+    ) {
+    }
+}

--- a/api/src/Entity/TripChatMessage.php
+++ b/api/src/Entity/TripChatMessage.php
@@ -76,6 +76,9 @@ class TripChatMessage
         return $this->user;
     }
 
+    /**
+     * @return non-empty-string
+     */
     public function getRole(): string
     {
         return $this->role;

--- a/api/src/Repository/TripChatMessageRepository.php
+++ b/api/src/Repository/TripChatMessageRepository.php
@@ -9,20 +9,68 @@ use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
- * Persistence boundary for the long-term chat history.
- *
- * Read methods are intentionally kept out of this PR: the write path proves
- * the dual Redis + PostgreSQL persistence in isolation, and the read endpoint
- * (`GET /trips/{id}/chat-history`) is delivered by issue #459 / PR #471 where
- * the cursor pagination semantics live with the State Provider that consumes
- * them.
- *
  * @extends ServiceEntityRepository<TripChatMessage>
  */
 class TripChatMessageRepository extends ServiceEntityRepository
 {
+    public const int DEFAULT_LIMIT = 50;
+
+    public const int MAX_LIMIT = 200;
+
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, TripChatMessage::class);
+    }
+
+    /**
+     * Returns a page of chat turns for the given (trip, user) pair using a
+     * `created_at DESC` cursor pagination scheme. When `$before` is provided
+     * only messages strictly older than that timestamp are returned, so the
+     * PWA can implement "load older messages" by passing the createdAt of the
+     * oldest message already displayed.
+     *
+     * The composite index `(trip_id, user_id, created_at)` keeps the lookup
+     * O(log n) even after months of in-ride consultations (PostgreSQL scans
+     * B-tree indexes equally in either direction, so an ASC index serves the
+     * DESC query without a separate descending index).
+     *
+     * The `id` tie-breaker guarantees deterministic pagination when two turns
+     * land in the same TIMESTAMP(6) microsecond bucket (a single `flush()`
+     * persists the user + assistant turn in one round-trip, so collisions are
+     * realistic).
+     *
+     * The result is intentionally kept in DESC order (most-recent first) — the
+     * frontend reverses it for chronological rendering. See issue #459.
+     *
+     * @return list<TripChatMessage>
+     */
+    public function findHistory(
+        string $tripId,
+        string $userId,
+        int $limit = self::DEFAULT_LIMIT,
+        ?\DateTimeImmutable $before = null,
+    ): array {
+        if ($limit <= 0) {
+            return [];
+        }
+
+        $qb = $this->createQueryBuilder('m')
+            ->andWhere('IDENTITY(m.trip) = :tripId')
+            ->andWhere('IDENTITY(m.user) = :userId')
+            ->setParameter('tripId', $tripId)
+            ->setParameter('userId', $userId)
+            ->orderBy('m.createdAt', 'DESC')
+            ->addOrderBy('m.id', 'DESC')
+            ->setMaxResults(min($limit, self::MAX_LIMIT));
+
+        if ($before instanceof \DateTimeImmutable) {
+            $qb->andWhere('m.createdAt < :before')
+                ->setParameter('before', $before);
+        }
+
+        /** @var list<TripChatMessage> $rows */
+        $rows = $qb->getQuery()->getResult();
+
+        return $rows;
     }
 }

--- a/api/src/State/TripChatHistoryProvider.php
+++ b/api/src/State/TripChatHistoryProvider.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\State;
+
+use Symfony\Component\HttpFoundation\Request;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProviderInterface;
+use App\ApiResource\TripChatMessageResource;
+use App\Entity\TripChatMessage;
+use App\Entity\User;
+use App\Repository\TripChatMessageRepository;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Loads the persisted chat history for a trip with cursor-based pagination.
+ *
+ * Companion provider for {@see TripChatMessageResource} backing
+ * `GET /trips/{id}/chat-history`. The Redis-backed Mercure history is volatile
+ * and capped to the most recent N turns; this endpoint reads the durable
+ * PostgreSQL store so the PWA can rehydrate the chat drawer days later.
+ *
+ * Security: API Platform's `is_granted('TRIP_VIEW', ...)` gate already enforces
+ * trip ownership upstream. This provider additionally scopes the query by the
+ * authenticated user's id so a future change that broadens the voter (e.g.
+ * shared trips) cannot leak another rider's private chat turns.
+ *
+ * @implements ProviderInterface<TripChatMessageResource>
+ */
+final readonly class TripChatHistoryProvider implements ProviderInterface
+{
+    public function __construct(
+        private TripChatMessageRepository $repository,
+        private Security $security,
+        private RequestStack $requestStack,
+    ) {
+    }
+
+    /**
+     * @param array{id?: string} $uriVariables
+     *
+     * @return list<TripChatMessageResource>
+     */
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): array
+    {
+        $tripId = $uriVariables['id'] ?? '';
+        if ('' === $tripId || !Uuid::isValid($tripId)) {
+            return [];
+        }
+
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new HttpException(401, 'Authentication required.');
+        }
+
+        $request = $this->requestStack->getCurrentRequest();
+        $limit = TripChatMessageRepository::DEFAULT_LIMIT;
+        $before = null;
+
+        if ($request instanceof Request) {
+            $rawLimit = $request->query->get('limit');
+            if (\is_string($rawLimit) && '' !== $rawLimit) {
+                if (!ctype_digit($rawLimit)) {
+                    throw new HttpException(400, \sprintf('Invalid "limit": "%s" is not a positive integer.', $rawLimit));
+                }
+
+                $candidate = (int) $rawLimit;
+                if ($candidate < 1) {
+                    throw new HttpException(400, 'Invalid "limit": must be >= 1.');
+                }
+
+                $limit = min($candidate, TripChatMessageRepository::MAX_LIMIT);
+            }
+
+            $rawBefore = $request->query->get('before');
+            if (\is_string($rawBefore) && '' !== $rawBefore) {
+                // Constrain to RFC 3339 so relative expressions like "next week" or
+                // "+1 year" — accepted by the permissive DateTimeImmutable parser —
+                // do not silently yield unexpected cursor windows.
+                $before = \DateTimeImmutable::createFromFormat(\DateTimeInterface::RFC3339, $rawBefore)
+                    ?: \DateTimeImmutable::createFromFormat(\DateTimeInterface::RFC3339_EXTENDED, $rawBefore);
+
+                if (!$before instanceof \DateTimeImmutable) {
+                    throw new HttpException(400, \sprintf('Invalid "before" cursor: "%s" is not a valid RFC 3339 datetime.', $rawBefore));
+                }
+
+                // `created_at` is persisted as UTC in a `TIMESTAMP(6) WITHOUT TIME ZONE`
+                // column; Doctrine binds DateTimeImmutable parameters in their own
+                // timezone, so a cursor with a non-UTC offset would produce a wrong
+                // SQL boundary. Normalise to UTC defensively.
+                $before = $before->setTimezone(new \DateTimeZone('UTC'));
+            }
+        }
+
+        $messages = $this->repository->findHistory(
+            tripId: $tripId,
+            userId: $user->getId()->toRfc4122(),
+            limit: $limit,
+            before: $before,
+        );
+
+        return array_map(
+            fn (TripChatMessage $entity): TripChatMessageResource => $this->toResource($entity, $tripId),
+            $messages,
+        );
+    }
+
+    private function toResource(TripChatMessage $entity, string $tripId): TripChatMessageResource
+    {
+        return new TripChatMessageResource(
+            id: $entity->getId()->toRfc4122(),
+            // $tripId comes from the URL — using it directly avoids a SELECT to
+            // initialise the lazy Doctrine proxy returned by $entity->getTrip().
+            tripId: $tripId,
+            role: $entity->getRole(),
+            content: $entity->getContent(),
+            action: $entity->getAction(),
+            createdAt: $entity->getCreatedAt(),
+        );
+    }
+}

--- a/api/tests/Functional/TripChatHistoryTest.php
+++ b/api/tests/Functional/TripChatHistoryTest.php
@@ -1,0 +1,256 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Symfony\Bundle\Test\Client;
+use App\ApiResource\TripRequest;
+use App\Entity\TripChatMessage;
+use App\Entity\User;
+use App\Repository\TripRequestRepositoryInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Uid\Uuid;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+use Zenstruck\Foundry\Test\Factories;
+
+#[ResetDatabase]
+final class TripChatHistoryTest extends ApiTestCase
+{
+    use Factories;
+    use JwtAuthTestTrait;
+
+    private const string TRIP_ID = '01936f6e-0000-7000-8000-000000000301';
+
+    private const string OTHER_TRIP_ID = '01936f6e-0000-7000-8000-000000000302';
+
+    private Client $client;
+
+    private User $testUser;
+
+    private string $jwtToken;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->client = self::createClient();
+        ['user' => $this->testUser, 'token' => $this->jwtToken] = $this->createTestUserWithJwt('chat-history@example.com');
+    }
+
+    private function seedTrip(string $tripId, ?User $owner = null): void
+    {
+        /** @var TripRequestRepositoryInterface $repo */
+        $repo = self::getContainer()->get(TripRequestRepositoryInterface::class);
+
+        $request = new TripRequest(Uuid::fromString($tripId));
+        $request->sourceUrl = 'https://www.komoot.com/tour/123456789';
+        $request->startDate = new \DateTimeImmutable('2026-07-01');
+
+        $repo->initializeTrip($tripId, $request);
+
+        $this->associateTripWithUser($tripId, $owner ?? $this->testUser);
+    }
+
+    /**
+     * @param list<array{role: non-empty-string, content: string, action?: ?string, createdAt: string}> $turns
+     */
+    private function seedMessages(string $tripId, User $user, array $turns): void
+    {
+        /** @var EntityManagerInterface $em */
+        $em = self::getContainer()->get('doctrine.orm.entity_manager');
+        $trip = $em->getReference(TripRequest::class, Uuid::fromString($tripId));
+        \assert($trip instanceof TripRequest);
+        $managedUser = $em->find(User::class, $user->getId());
+        \assert($managedUser instanceof User);
+
+        foreach ($turns as $turn) {
+            $message = new TripChatMessage(
+                trip: $trip,
+                user: $managedUser,
+                role: $turn['role'],
+                content: $turn['content'],
+                action: $turn['action'] ?? null,
+                createdAt: new \DateTimeImmutable($turn['createdAt']),
+            );
+            $em->persist($message);
+        }
+
+        $em->flush();
+        $em->clear();
+    }
+
+    #[Test]
+    public function chatHistoryReturnsMessagesMostRecentFirst(): void
+    {
+        $this->seedTrip(self::TRIP_ID);
+        $this->seedMessages(self::TRIP_ID, $this->testUser, [
+            ['role' => TripChatMessage::ROLE_USER, 'content' => 'Bonjour', 'createdAt' => '2026-05-01 10:00:00'],
+            ['role' => TripChatMessage::ROLE_ASSISTANT, 'content' => '{"action":"info","params":{},"response":"Salut"}', 'action' => 'info', 'createdAt' => '2026-05-01 10:00:05'],
+            ['role' => TripChatMessage::ROLE_USER, 'content' => "Coupe l'étape 3", 'createdAt' => '2026-05-01 10:01:00'],
+        ]);
+
+        $response = $this->client->request(
+            'GET',
+            \sprintf('/trips/%s/chat-history', self::TRIP_ID),
+            ['headers' => ['Accept' => 'application/ld+json', ...$this->authHeader($this->jwtToken)]],
+        );
+
+        $this->assertResponseIsSuccessful();
+
+        $data = $response->toArray(false);
+        $this->assertArrayHasKey('member', $data);
+        $this->assertCount(3, $data['member']);
+        $this->assertSame("Coupe l'étape 3", $data['member'][0]['content']);
+        $this->assertSame(TripChatMessage::ROLE_USER, $data['member'][0]['role']);
+        $this->assertSame('Bonjour', $data['member'][2]['content']);
+        $this->assertSame(self::TRIP_ID, $data['member'][0]['tripId']);
+    }
+
+    #[Test]
+    public function chatHistoryHonoursLimitQueryParameter(): void
+    {
+        $this->seedTrip(self::TRIP_ID);
+        $this->seedMessages(self::TRIP_ID, $this->testUser, [
+            ['role' => TripChatMessage::ROLE_USER, 'content' => 'msg-1', 'createdAt' => '2026-05-01 09:00:00'],
+            ['role' => TripChatMessage::ROLE_USER, 'content' => 'msg-2', 'createdAt' => '2026-05-01 09:01:00'],
+            ['role' => TripChatMessage::ROLE_USER, 'content' => 'msg-3', 'createdAt' => '2026-05-01 09:02:00'],
+        ]);
+
+        $response = $this->client->request(
+            'GET',
+            \sprintf('/trips/%s/chat-history?limit=2', self::TRIP_ID),
+            ['headers' => ['Accept' => 'application/ld+json', ...$this->authHeader($this->jwtToken)]],
+        );
+
+        $this->assertResponseIsSuccessful();
+        $data = $response->toArray(false);
+        $this->assertCount(2, $data['member']);
+        $this->assertSame('msg-3', $data['member'][0]['content']);
+        $this->assertSame('msg-2', $data['member'][1]['content']);
+    }
+
+    #[Test]
+    public function chatHistoryRejectsLimitZero(): void
+    {
+        $this->seedTrip(self::TRIP_ID);
+
+        $this->client->request(
+            'GET',
+            \sprintf('/trips/%s/chat-history?limit=0', self::TRIP_ID),
+            ['headers' => ['Accept' => 'application/ld+json', ...$this->authHeader($this->jwtToken)]],
+        );
+
+        $this->assertResponseStatusCodeSame(400);
+    }
+
+    #[Test]
+    public function chatHistoryNormalisesNonUtcBeforeCursorToUtc(): void
+    {
+        $this->seedTrip(self::TRIP_ID);
+        $this->seedMessages(self::TRIP_ID, $this->testUser, [
+            // 09:00 UTC. A +02:00 cursor of 11:30 must compare to 09:30 UTC, so this row stays.
+            ['role' => TripChatMessage::ROLE_USER, 'content' => 'kept-utc-0900', 'createdAt' => '2026-05-01 09:00:00'],
+            ['role' => TripChatMessage::ROLE_USER, 'content' => 'dropped-utc-1000', 'createdAt' => '2026-05-01 10:00:00'],
+        ]);
+
+        $response = $this->client->request(
+            'GET',
+            \sprintf('/trips/%s/chat-history?before=%s', self::TRIP_ID, urlencode('2026-05-01T11:30:00+02:00')),
+            ['headers' => ['Accept' => 'application/ld+json', ...$this->authHeader($this->jwtToken)]],
+        );
+
+        $this->assertResponseIsSuccessful();
+        $data = $response->toArray(false);
+        $this->assertCount(1, $data['member']);
+        $this->assertSame('kept-utc-0900', $data['member'][0]['content']);
+    }
+
+    #[Test]
+    public function chatHistorySupportsBeforeCursorPagination(): void
+    {
+        $this->seedTrip(self::TRIP_ID);
+        $this->seedMessages(self::TRIP_ID, $this->testUser, [
+            ['role' => TripChatMessage::ROLE_USER, 'content' => 'oldest', 'createdAt' => '2026-05-01 08:00:00'],
+            ['role' => TripChatMessage::ROLE_USER, 'content' => 'middle', 'createdAt' => '2026-05-01 09:00:00'],
+            ['role' => TripChatMessage::ROLE_USER, 'content' => 'newest', 'createdAt' => '2026-05-01 10:00:00'],
+        ]);
+
+        $response = $this->client->request(
+            'GET',
+            \sprintf('/trips/%s/chat-history?before=%s', self::TRIP_ID, urlencode('2026-05-01T09:30:00+00:00')),
+            ['headers' => ['Accept' => 'application/ld+json', ...$this->authHeader($this->jwtToken)]],
+        );
+
+        $this->assertResponseIsSuccessful();
+        $data = $response->toArray(false);
+        $this->assertCount(2, $data['member']);
+        $this->assertSame('middle', $data['member'][0]['content']);
+        $this->assertSame('oldest', $data['member'][1]['content']);
+    }
+
+    #[Test]
+    public function chatHistoryReturns400OnInvalidBeforeCursor(): void
+    {
+        $this->seedTrip(self::TRIP_ID);
+
+        $this->client->request(
+            'GET',
+            \sprintf('/trips/%s/chat-history?before=not-a-date', self::TRIP_ID),
+            ['headers' => ['Accept' => 'application/ld+json', ...$this->authHeader($this->jwtToken)]],
+        );
+
+        $this->assertResponseStatusCodeSame(400);
+    }
+
+    #[Test]
+    public function chatHistoryRejectsUnauthenticatedRequests(): void
+    {
+        $this->seedTrip(self::TRIP_ID);
+
+        $this->client->request(
+            'GET',
+            \sprintf('/trips/%s/chat-history', self::TRIP_ID),
+            ['headers' => ['Accept' => 'application/ld+json']],
+        );
+
+        $this->assertResponseStatusCodeSame(401);
+    }
+
+    #[Test]
+    public function chatHistoryDeniesAccessToTripsOwnedByAnotherUser(): void
+    {
+        /** @var EntityManagerInterface $em */
+        $em = self::getContainer()->get('doctrine.orm.entity_manager');
+        $other = new User('stranger@example.com');
+        $em->persist($other);
+        $em->flush();
+
+        $this->seedTrip(self::OTHER_TRIP_ID, owner: $other);
+
+        $this->client->request(
+            'GET',
+            \sprintf('/trips/%s/chat-history', self::OTHER_TRIP_ID),
+            ['headers' => ['Accept' => 'application/ld+json', ...$this->authHeader($this->jwtToken)]],
+        );
+
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    #[Test]
+    public function chatHistoryReturnsEmptyCollectionWhenNoMessagesPersisted(): void
+    {
+        $this->seedTrip(self::TRIP_ID);
+
+        $response = $this->client->request(
+            'GET',
+            \sprintf('/trips/%s/chat-history', self::TRIP_ID),
+            ['headers' => ['Accept' => 'application/ld+json', ...$this->authHeader($this->jwtToken)]],
+        );
+
+        $this->assertResponseIsSuccessful();
+        $data = $response->toArray(false);
+        $this->assertSame([], $data['member']);
+    }
+}


### PR DESCRIPTION
## Summary

Sprint 32 #459 — Endpoint API Platform pour recharger l'historique persisté en PG (#458).

- Endpoint `GET /trips/{id}/chat-history` (lecture seule)
- State Provider `TripChatHistoryProvider` + ressource `TripChatMessageResource`
- Sécurité : auth requise, voter `TRIP_VIEW` + filtre user-id (defence-in-depth)
- Pagination cursor : `?limit=50&before=<created_at>`
- Format `created_at DESC` (PWA reverse pour affichage chronologique)
- 7 tests fonctionnels (ordering, pagination, cursor invalide, auth, ownership)

Depends on #467 (#458).

Closes #459

## Test plan

- [ ] CI verte
- [ ] Pagination cursor fonctionne
- [ ] 401/403 sur user non authentifié / trip d'un autre user

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

**0 findings** · All previously raised threads are resolved.

**Commit reviewed:** `9009d6e97392de1cf8515c41987f6321ae8e4cc5`

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### PR title

`feat(chat): GET /trips/{id}/chat-history endpoint with pagination (#459)` — description starts with uppercase `GET` and is not in imperative mood. Suggested: `feat(chat): add GET /trips/{id}/chat-history endpoint with cursor pagination`.

### Resolved threads

All 9 previously opened bot threads are already resolved — no action required.

### Inline comments

No inline comments.

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->