### PR TITLE
feat(chat): wire TripChatProcessor to in-ride mode when GPS provided (#463)

### DIFF
--- a/api/config/reference.php
+++ b/api/config/reference.php
@@ -193,40 +193,40 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     workflows?: bool|array{
  *         enabled?: bool|Param, // Default: false
  *         workflows?: array<string, array{ // Default: []
- *             audit_trail?: bool|array{
- *                 enabled?: bool|Param, // Default: false
- *             },
- *             type?: "workflow"|"state_machine"|Param, // Default: "state_machine"
- *             marking_store?: array{
- *                 type?: "method"|Param,
- *                 property?: scalar|Param|null,
- *                 service?: scalar|Param|null,
- *             },
- *             supports?: string|list<scalar|Param|null>,
- *             definition_validators?: list<scalar|Param|null>,
- *             support_strategy?: scalar|Param|null,
- *             initial_marking?: \BackedEnum|string|list<scalar|Param|null>,
- *             events_to_dispatch?: null|list<string|Param>,
- *             places?: string|list<array{ // Default: []
- *                 name?: scalar|Param|null,
+ *                 audit_trail?: bool|array{
+ *                     enabled?: bool|Param, // Default: false
+ *                 },
+ *                 type?: "workflow"|"state_machine"|Param, // Default: "state_machine"
+ *                 marking_store?: array{
+ *                     type?: "method"|Param,
+ *                     property?: scalar|Param|null,
+ *                     service?: scalar|Param|null,
+ *                 },
+ *                 supports?: string|list<scalar|Param|null>,
+ *                 definition_validators?: list<scalar|Param|null>,
+ *                 support_strategy?: scalar|Param|null,
+ *                 initial_marking?: backed-enum|string|list<scalar|Param|null>,
+ *                 events_to_dispatch?: null|list<string|Param>,
+ *                 places?: string|list<array{ // Default: []
+ *                         name?: scalar|Param|null,
+ *                         metadata?: array<string, mixed>,
+ *                     }>,
+ *                 transitions?: list<array{ // Default: []
+ *                         name?: string|Param,
+ *                         guard?: string|Param, // An expression to block the transition.
+ *                         from?: backed-enum|string|list<array{ // Default: []
+ *                                 place?: string|Param,
+ *                                 weight?: int|Param, // Default: 1
+ *                             }>,
+ *                         to?: backed-enum|string|list<array{ // Default: []
+ *                                 place?: string|Param,
+ *                                 weight?: int|Param, // Default: 1
+ *                             }>,
+ *                         weight?: int|Param, // Default: 1
+ *                         metadata?: array<string, mixed>,
+ *                     }>,
  *                 metadata?: array<string, mixed>,
  *             }>,
- *             transitions?: list<array{ // Default: []
- *                 name?: string|Param,
- *                 guard?: string|Param, // An expression to block the transition.
- *                 from?: \BackedEnum|string|list<array{ // Default: []
- *                     place?: string|Param,
- *                     weight?: int|Param, // Default: 1
- *                 }>,
- *                 to?: \BackedEnum|string|list<array{ // Default: []
- *                     place?: string|Param,
- *                     weight?: int|Param, // Default: 1
- *                 }>,
- *                 weight?: int|Param, // Default: 1
- *                 metadata?: array<string, mixed>,
- *             }>,
- *             metadata?: array<string, mixed>,
- *         }>,
  *     },
  *     router?: bool|array{ // Router configuration
  *         enabled?: bool|Param, // Default: false
@@ -270,14 +270,14 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         base_path?: scalar|Param|null, // Default: ""
  *         base_urls?: string|list<scalar|Param|null>,
  *         packages?: array<string, array{ // Default: []
- *             strict_mode?: bool|Param, // Throw an exception if an entry is missing from the manifest.json. // Default: false
- *             version_strategy?: scalar|Param|null, // Default: null
- *             version?: scalar|Param|null,
- *             version_format?: scalar|Param|null, // Default: null
- *             json_manifest_path?: scalar|Param|null, // Default: null
- *             base_path?: scalar|Param|null, // Default: ""
- *             base_urls?: string|list<scalar|Param|null>,
- *         }>,
+ *                 strict_mode?: bool|Param, // Throw an exception if an entry is missing from the manifest.json. // Default: false
+ *                 version_strategy?: scalar|Param|null, // Default: null
+ *                 version?: scalar|Param|null,
+ *                 version_format?: scalar|Param|null, // Default: null
+ *                 json_manifest_path?: scalar|Param|null, // Default: null
+ *                 base_path?: scalar|Param|null, // Default: ""
+ *                 base_urls?: string|list<scalar|Param|null>,
+ *             }>,
  *     },
  *     asset_mapper?: bool|array{ // Asset Mapper configuration
  *         enabled?: bool|Param, // Default: false
@@ -315,16 +315,16 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             localizable_html_attributes?: list<scalar|Param|null>,
  *         },
  *         providers?: array<string, array{ // Default: []
- *             dsn?: scalar|Param|null,
- *             domains?: list<scalar|Param|null>,
- *             locales?: list<scalar|Param|null>,
- *         }>,
+ *                 dsn?: scalar|Param|null,
+ *                 domains?: list<scalar|Param|null>,
+ *                 locales?: list<scalar|Param|null>,
+ *             }>,
  *         globals?: array<string, string|array{ // Default: []
- *             value?: mixed,
- *             message?: string|Param,
- *             parameters?: array<string, scalar|Param|null>,
- *             domain?: string|Param,
- *         }>,
+ *                 value?: mixed,
+ *                 message?: string|Param,
+ *                 parameters?: array<string, scalar|Param|null>,
+ *                 domain?: string|Param,
+ *             }>,
  *     },
  *     validation?: bool|array{ // Validation configuration
  *         enabled?: bool|Param, // Default: true
@@ -341,8 +341,8 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         },
  *         disable_translation?: bool|Param, // Default: false
  *         auto_mapping?: array<string, array{ // Default: []
- *             services?: list<scalar|Param|null>,
- *         }>,
+ *                 services?: list<scalar|Param|null>,
+ *             }>,
  *     },
  *     serializer?: bool|array{ // Serializer configuration
  *         enabled?: bool|Param, // Default: true
@@ -355,11 +355,11 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         },
  *         default_context?: array<string, mixed>,
  *         named_serializers?: array<string, array{ // Default: []
- *             name_converter?: scalar|Param|null,
- *             default_context?: array<string, mixed>,
- *             include_built_in_normalizers?: bool|Param, // Whether to include the built-in normalizers // Default: true
- *             include_built_in_encoders?: bool|Param, // Whether to include the built-in encoders // Default: true
- *         }>,
+ *                 name_converter?: scalar|Param|null,
+ *                 default_context?: array<string, mixed>,
+ *                 include_built_in_normalizers?: bool|Param, // Whether to include the built-in normalizers // Default: true
+ *                 include_built_in_encoders?: bool|Param, // Whether to include the built-in encoders // Default: true
+ *             }>,
  *     },
  *     property_access?: bool|array{ // Property access configuration
  *         enabled?: bool|Param, // Default: true
@@ -389,24 +389,24 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         default_doctrine_dbal_provider?: scalar|Param|null, // Default: "database_connection"
  *         default_pdo_provider?: scalar|Param|null, // Default: null
  *         pools?: array<string, array{ // Default: []
- *             adapters?: string|list<scalar|Param|null>,
- *             tags?: scalar|Param|null, // Default: null
- *             public?: bool|Param, // Default: false
- *             default_lifetime?: scalar|Param|null, // Default lifetime of the pool.
- *             provider?: scalar|Param|null, // Overwrite the setting from the default provider for this adapter.
- *             early_expiration_message_bus?: scalar|Param|null,
- *             clearer?: scalar|Param|null,
- *         }>,
+ *                 adapters?: string|list<scalar|Param|null>,
+ *                 tags?: scalar|Param|null, // Default: null
+ *                 public?: bool|Param, // Default: false
+ *                 default_lifetime?: scalar|Param|null, // Default lifetime of the pool.
+ *                 provider?: scalar|Param|null, // Overwrite the setting from the default provider for this adapter.
+ *                 early_expiration_message_bus?: scalar|Param|null,
+ *                 clearer?: scalar|Param|null,
+ *             }>,
  *     },
  *     php_errors?: array{ // PHP errors handling configuration
  *         log?: mixed, // Use the application logger instead of the PHP logger for logging PHP errors. // Default: true
  *         throw?: bool|Param, // Throw PHP errors as \ErrorException instances. // Default: true
  *     },
  *     exceptions?: array<string, array{ // Default: []
- *         log_level?: scalar|Param|null, // The level of log message. Null to let Symfony decide. // Default: null
- *         status_code?: scalar|Param|null, // The status code of the response. Null or 0 to let Symfony decide. // Default: null
- *         log_channel?: scalar|Param|null, // The channel of log message. Null to let Symfony decide. // Default: null
- *     }>,
+ *             log_level?: scalar|Param|null, // The level of log message. Null to let Symfony decide. // Default: null
+ *             status_code?: scalar|Param|null, // The status code of the response. Null or 0 to let Symfony decide. // Default: null
+ *             log_channel?: scalar|Param|null, // The channel of log message. Null to let Symfony decide. // Default: null
+ *         }>,
  *     web_link?: bool|array{ // Web links configuration
  *         enabled?: bool|Param, // Default: true
  *     },
@@ -421,8 +421,8 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     messenger?: bool|array{ // Messenger configuration
  *         enabled?: bool|Param, // Default: true
  *         routing?: array<string, string|array{ // Default: []
- *             senders?: list<scalar|Param|null>,
- *         }>,
+ *                 senders?: list<scalar|Param|null>,
+ *             }>,
  *         serializer?: array{
  *             default_serializer?: scalar|Param|null, // Service id to use as the default serializer for the transports. // Default: "messenger.transport.native_php_serializer"
  *             symfony_serializer?: array{
@@ -431,34 +431,34 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             },
  *         },
  *         transports?: array<string, string|array{ // Default: []
- *             dsn?: scalar|Param|null,
- *             serializer?: scalar|Param|null, // Service id of a custom serializer to use. // Default: null
- *             options?: array<string, mixed>,
- *             failure_transport?: scalar|Param|null, // Transport name to send failed messages to (after all retries have failed). // Default: null
- *             retry_strategy?: string|array{
- *                 service?: scalar|Param|null, // Service id to override the retry strategy entirely. // Default: null
- *                 max_retries?: int|Param, // Default: 3
- *                 delay?: int|Param, // Time in ms to delay (or the initial value when multiplier is used). // Default: 1000
- *                 multiplier?: float|Param, // If greater than 1, delay will grow exponentially for each retry: this delay = (delay * (multiple ^ retries)). // Default: 2
- *                 max_delay?: int|Param, // Max time in ms that a retry should ever be delayed (0 = infinite). // Default: 0
- *                 jitter?: float|Param, // Randomness to apply to the delay (between 0 and 1). // Default: 0.1
- *             },
- *             rate_limiter?: scalar|Param|null, // Rate limiter name to use when processing messages. // Default: null
- *         }>,
+ *                 dsn?: scalar|Param|null,
+ *                 serializer?: scalar|Param|null, // Service id of a custom serializer to use. // Default: null
+ *                 options?: array<string, mixed>,
+ *                 failure_transport?: scalar|Param|null, // Transport name to send failed messages to (after all retries have failed). // Default: null
+ *                 retry_strategy?: string|array{
+ *                     service?: scalar|Param|null, // Service id to override the retry strategy entirely. // Default: null
+ *                     max_retries?: int|Param, // Default: 3
+ *                     delay?: int|Param, // Time in ms to delay (or the initial value when multiplier is used). // Default: 1000
+ *                     multiplier?: float|Param, // If greater than 1, delay will grow exponentially for each retry: this delay = (delay * (multiple ^ retries)). // Default: 2
+ *                     max_delay?: int|Param, // Max time in ms that a retry should ever be delayed (0 = infinite). // Default: 0
+ *                     jitter?: float|Param, // Randomness to apply to the delay (between 0 and 1). // Default: 0.1
+ *                 },
+ *                 rate_limiter?: scalar|Param|null, // Rate limiter name to use when processing messages. // Default: null
+ *             }>,
  *         failure_transport?: scalar|Param|null, // Transport name to send failed messages to (after all retries have failed). // Default: null
  *         stop_worker_on_signals?: int|string|list<scalar|Param|null>,
  *         default_bus?: scalar|Param|null, // Default: null
  *         buses?: array<string, array{ // Default: {"messenger.bus.default":{"default_middleware":{"enabled":true,"allow_no_handlers":false,"allow_no_senders":true},"middleware":[]}}
- *             default_middleware?: bool|string|array{
- *                 enabled?: bool|Param, // Default: true
- *                 allow_no_handlers?: bool|Param, // Default: false
- *                 allow_no_senders?: bool|Param, // Default: true
- *             },
- *             middleware?: string|list<string|array{ // Default: []
- *                 id?: scalar|Param|null,
- *                 arguments?: list<mixed>,
+ *                 default_middleware?: bool|string|array{
+ *                     enabled?: bool|Param, // Default: true
+ *                     allow_no_handlers?: bool|Param, // Default: false
+ *                     allow_no_senders?: bool|Param, // Default: true
+ *                 },
+ *                 middleware?: string|list<string|array{ // Default: []
+ *                         id?: scalar|Param|null,
+ *                         arguments?: list<mixed>,
+ *                     }>,
  *             }>,
- *         }>,
  *     },
  *     scheduler?: bool|array{ // Scheduler configuration
  *         enabled?: bool|Param, // Default: false
@@ -504,9 +504,9 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *                 enabled?: bool|Param, // Default: false
  *                 retry_strategy?: scalar|Param|null, // service id to override the retry strategy. // Default: null
  *                 http_codes?: int|string|array<string, array{ // Default: []
- *                     code?: int|Param,
- *                     methods?: string|list<string|Param>,
- *                 }>,
+ *                         code?: int|Param,
+ *                         methods?: string|list<string|Param>,
+ *                     }>,
  *                 max_retries?: int|Param, // Default: 3
  *                 delay?: int|Param, // Time in ms to delay (or the initial value when multiplier is used). // Default: 1000
  *                 multiplier?: float|Param, // If greater than 1, delay will grow exponentially for each retry: delay * (multiple ^ retries). // Default: 2
@@ -516,57 +516,57 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         },
  *         mock_response_factory?: scalar|Param|null, // The id of the service that should generate mock responses. It should be either an invokable or an iterable.
  *         scoped_clients?: array<string, string|array{ // Default: []
- *             scope?: scalar|Param|null, // The regular expression that the request URL must match before adding the other options. When none is provided, the base URI is used instead.
- *             base_uri?: scalar|Param|null, // The URI to resolve relative URLs, following rules in RFC 3985, section 2.
- *             auth_basic?: scalar|Param|null, // An HTTP Basic authentication "username:password".
- *             auth_bearer?: scalar|Param|null, // A token enabling HTTP Bearer authorization.
- *             auth_ntlm?: scalar|Param|null, // A "username:password" pair to use Microsoft NTLM authentication (requires the cURL extension).
- *             query?: array<string, scalar|Param|null>,
- *             headers?: array<string, mixed>,
- *             max_redirects?: int|Param, // The maximum number of redirects to follow.
- *             http_version?: scalar|Param|null, // The default HTTP version, typically 1.1 or 2.0, leave to null for the best version.
- *             resolve?: array<string, scalar|Param|null>,
- *             proxy?: scalar|Param|null, // The URL of the proxy to pass requests through or null for automatic detection.
- *             no_proxy?: scalar|Param|null, // A comma separated list of hosts that do not require a proxy to be reached.
- *             timeout?: float|Param, // The idle timeout, defaults to the "default_socket_timeout" ini parameter.
- *             max_duration?: float|Param, // The maximum execution time for the request+response as a whole.
- *             bindto?: scalar|Param|null, // A network interface name, IP address, a host name or a UNIX socket to bind to.
- *             verify_peer?: bool|Param, // Indicates if the peer should be verified in a TLS context.
- *             verify_host?: bool|Param, // Indicates if the host should exist as a certificate common name.
- *             cafile?: scalar|Param|null, // A certificate authority file.
- *             capath?: scalar|Param|null, // A directory that contains multiple certificate authority files.
- *             local_cert?: scalar|Param|null, // A PEM formatted certificate file.
- *             local_pk?: scalar|Param|null, // A private key file.
- *             passphrase?: scalar|Param|null, // The passphrase used to encrypt the "local_pk" file.
- *             ciphers?: scalar|Param|null, // A list of TLS ciphers separated by colons, commas or spaces (e.g. "RC3-SHA:TLS13-AES-128-GCM-SHA256"...).
- *             peer_fingerprint?: array{ // Associative array: hashing algorithm => hash(es).
- *                 sha1?: mixed,
- *                 pin-sha256?: mixed,
- *                 md5?: mixed,
- *             },
- *             crypto_method?: scalar|Param|null, // The minimum version of TLS to accept; must be one of STREAM_CRYPTO_METHOD_TLSv*_CLIENT constants.
- *             extra?: array<string, mixed>,
- *             rate_limiter?: scalar|Param|null, // Rate limiter name to use for throttling requests. // Default: null
- *             caching?: bool|array{ // Caching configuration.
- *                 enabled?: bool|Param, // Default: false
- *                 cache_pool?: string|Param, // The taggable cache pool to use for storing the responses. // Default: "cache.http_client"
- *                 shared?: bool|Param, // Indicates whether the cache is shared (public) or private. // Default: true
- *                 max_ttl?: int|Param, // The maximum TTL (in seconds) allowed for cached responses. Null means no cap. // Default: null
- *             },
- *             retry_failed?: bool|array{
- *                 enabled?: bool|Param, // Default: false
- *                 retry_strategy?: scalar|Param|null, // service id to override the retry strategy. // Default: null
- *                 http_codes?: int|string|array<string, array{ // Default: []
- *                     code?: int|Param,
- *                     methods?: string|list<string|Param>,
- *                 }>,
- *                 max_retries?: int|Param, // Default: 3
- *                 delay?: int|Param, // Time in ms to delay (or the initial value when multiplier is used). // Default: 1000
- *                 multiplier?: float|Param, // If greater than 1, delay will grow exponentially for each retry: delay * (multiple ^ retries). // Default: 2
- *                 max_delay?: int|Param, // Max time in ms that a retry should ever be delayed (0 = infinite). // Default: 0
- *                 jitter?: float|Param, // Randomness in percent (between 0 and 1) to apply to the delay. // Default: 0.1
- *             },
- *         }>,
+ *                 scope?: scalar|Param|null, // The regular expression that the request URL must match before adding the other options. When none is provided, the base URI is used instead.
+ *                 base_uri?: scalar|Param|null, // The URI to resolve relative URLs, following rules in RFC 3985, section 2.
+ *                 auth_basic?: scalar|Param|null, // An HTTP Basic authentication "username:password".
+ *                 auth_bearer?: scalar|Param|null, // A token enabling HTTP Bearer authorization.
+ *                 auth_ntlm?: scalar|Param|null, // A "username:password" pair to use Microsoft NTLM authentication (requires the cURL extension).
+ *                 query?: array<string, scalar|Param|null>,
+ *                 headers?: array<string, mixed>,
+ *                 max_redirects?: int|Param, // The maximum number of redirects to follow.
+ *                 http_version?: scalar|Param|null, // The default HTTP version, typically 1.1 or 2.0, leave to null for the best version.
+ *                 resolve?: array<string, scalar|Param|null>,
+ *                 proxy?: scalar|Param|null, // The URL of the proxy to pass requests through or null for automatic detection.
+ *                 no_proxy?: scalar|Param|null, // A comma separated list of hosts that do not require a proxy to be reached.
+ *                 timeout?: float|Param, // The idle timeout, defaults to the "default_socket_timeout" ini parameter.
+ *                 max_duration?: float|Param, // The maximum execution time for the request+response as a whole.
+ *                 bindto?: scalar|Param|null, // A network interface name, IP address, a host name or a UNIX socket to bind to.
+ *                 verify_peer?: bool|Param, // Indicates if the peer should be verified in a TLS context.
+ *                 verify_host?: bool|Param, // Indicates if the host should exist as a certificate common name.
+ *                 cafile?: scalar|Param|null, // A certificate authority file.
+ *                 capath?: scalar|Param|null, // A directory that contains multiple certificate authority files.
+ *                 local_cert?: scalar|Param|null, // A PEM formatted certificate file.
+ *                 local_pk?: scalar|Param|null, // A private key file.
+ *                 passphrase?: scalar|Param|null, // The passphrase used to encrypt the "local_pk" file.
+ *                 ciphers?: scalar|Param|null, // A list of TLS ciphers separated by colons, commas or spaces (e.g. "RC3-SHA:TLS13-AES-128-GCM-SHA256"...).
+ *                 peer_fingerprint?: array{ // Associative array: hashing algorithm => hash(es).
+ *                     sha1?: mixed,
+ *                     pin-sha256?: mixed,
+ *                     md5?: mixed,
+ *                 },
+ *                 crypto_method?: scalar|Param|null, // The minimum version of TLS to accept; must be one of STREAM_CRYPTO_METHOD_TLSv*_CLIENT constants.
+ *                 extra?: array<string, mixed>,
+ *                 rate_limiter?: scalar|Param|null, // Rate limiter name to use for throttling requests. // Default: null
+ *                 caching?: bool|array{ // Caching configuration.
+ *                     enabled?: bool|Param, // Default: false
+ *                     cache_pool?: string|Param, // The taggable cache pool to use for storing the responses. // Default: "cache.http_client"
+ *                     shared?: bool|Param, // Indicates whether the cache is shared (public) or private. // Default: true
+ *                     max_ttl?: int|Param, // The maximum TTL (in seconds) allowed for cached responses. Null means no cap. // Default: null
+ *                 },
+ *                 retry_failed?: bool|array{
+ *                     enabled?: bool|Param, // Default: false
+ *                     retry_strategy?: scalar|Param|null, // service id to override the retry strategy. // Default: null
+ *                     http_codes?: int|string|array<string, array{ // Default: []
+ *                             code?: int|Param,
+ *                             methods?: string|list<string|Param>,
+ *                         }>,
+ *                     max_retries?: int|Param, // Default: 3
+ *                     delay?: int|Param, // Time in ms to delay (or the initial value when multiplier is used). // Default: 1000
+ *                     multiplier?: float|Param, // If greater than 1, delay will grow exponentially for each retry: delay * (multiple ^ retries). // Default: 2
+ *                     max_delay?: int|Param, // Max time in ms that a retry should ever be delayed (0 = infinite). // Default: 0
+ *                     jitter?: float|Param, // Randomness in percent (between 0 and 1) to apply to the delay. // Default: 0.1
+ *                 },
+ *             }>,
  *     },
  *     mailer?: bool|array{ // Mailer configuration
  *         enabled?: bool|Param, // Default: true
@@ -579,8 +579,8 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             allowed_recipients?: string|list<scalar|Param|null>,
  *         },
  *         headers?: array<string, string|array{ // Default: []
- *             value?: mixed,
- *         }>,
+ *                 value?: mixed,
+ *             }>,
  *         dkim_signer?: bool|array{ // DKIM signer configuration
  *             enabled?: bool|Param, // Default: false
  *             key?: scalar|Param|null, // Key content, or path to key (in PEM format with the `file://` prefix) // Default: ""
@@ -617,25 +617,25 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         notification_on_failed_messages?: bool|Param, // Default: false
  *         channel_policy?: array<string, string|list<scalar|Param|null>>,
  *         admin_recipients?: list<array{ // Default: []
- *             email?: scalar|Param|null,
- *             phone?: scalar|Param|null, // Default: ""
- *         }>,
+ *                 email?: scalar|Param|null,
+ *                 phone?: scalar|Param|null, // Default: ""
+ *             }>,
  *     },
  *     rate_limiter?: bool|array{ // Rate limiter configuration
  *         enabled?: bool|Param, // Default: true
  *         limiters?: array<string, array{ // Default: []
- *             lock_factory?: scalar|Param|null, // The service ID of the lock factory used by this limiter (or null to disable locking). // Default: "auto"
- *             cache_pool?: scalar|Param|null, // The cache pool to use for storing the current limiter state. // Default: "cache.rate_limiter"
- *             storage_service?: scalar|Param|null, // The service ID of a custom storage implementation, this precedes any configured "cache_pool". // Default: null
- *             policy?: "fixed_window"|"token_bucket"|"sliding_window"|"compound"|"no_limit"|Param, // The algorithm to be used by this limiter.
- *             limiters?: string|list<scalar|Param|null>,
- *             limit?: int|Param, // The maximum allowed hits in a fixed interval or burst.
- *             interval?: scalar|Param|null, // Configures the fixed interval if "policy" is set to "fixed_window" or "sliding_window". The value must be a number followed by "second", "minute", "hour", "day", "week" or "month" (or their plural equivalent).
- *             rate?: array{ // Configures the fill rate if "policy" is set to "token_bucket".
- *                 interval?: scalar|Param|null, // Configures the rate interval. The value must be a number followed by "second", "minute", "hour", "day", "week" or "month" (or their plural equivalent).
- *                 amount?: int|Param, // Amount of tokens to add each interval. // Default: 1
- *             },
- *         }>,
+ *                 lock_factory?: scalar|Param|null, // The service ID of the lock factory used by this limiter (or null to disable locking). // Default: "auto"
+ *                 cache_pool?: scalar|Param|null, // The cache pool to use for storing the current limiter state. // Default: "cache.rate_limiter"
+ *                 storage_service?: scalar|Param|null, // The service ID of a custom storage implementation, this precedes any configured "cache_pool". // Default: null
+ *                 policy?: "fixed_window"|"token_bucket"|"sliding_window"|"compound"|"no_limit"|Param, // The algorithm to be used by this limiter.
+ *                 limiters?: string|list<scalar|Param|null>,
+ *                 limit?: int|Param, // The maximum allowed hits in a fixed interval or burst.
+ *                 interval?: scalar|Param|null, // Configures the fixed interval if "policy" is set to "fixed_window" or "sliding_window". The value must be a number followed by "second", "minute", "hour", "day", "week" or "month" (or their plural equivalent).
+ *                 rate?: array{ // Configures the fill rate if "policy" is set to "token_bucket".
+ *                     interval?: scalar|Param|null, // Configures the rate interval. The value must be a number followed by "second", "minute", "hour", "day", "week" or "month" (or their plural equivalent).
+ *                     amount?: int|Param, // Amount of tokens to add each interval. // Default: 1
+ *                 },
+ *             }>,
  *     },
  *     uid?: bool|array{ // Uid configuration
  *         enabled?: bool|Param, // Default: true
@@ -648,33 +648,33 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     html_sanitizer?: bool|array{ // HtmlSanitizer configuration
  *         enabled?: bool|Param, // Default: false
  *         sanitizers?: array<string, array{ // Default: []
- *             allow_safe_elements?: bool|Param, // Allows "safe" elements and attributes. // Default: false
- *             allow_static_elements?: bool|Param, // Allows all static elements and attributes from the W3C Sanitizer API standard. // Default: false
- *             allow_elements?: array<string, mixed>,
- *             block_elements?: string|list<string|Param>,
- *             drop_elements?: string|list<string|Param>,
- *             allow_attributes?: array<string, mixed>,
- *             drop_attributes?: array<string, mixed>,
- *             force_attributes?: array<string, array<string, string|Param>>,
- *             force_https_urls?: bool|Param, // Transforms URLs using the HTTP scheme to use the HTTPS scheme instead. // Default: false
- *             allowed_link_schemes?: string|list<string|Param>,
- *             allowed_link_hosts?: null|string|list<string|Param>,
- *             allow_relative_links?: bool|Param, // Allows relative URLs to be used in links href attributes. // Default: false
- *             allowed_media_schemes?: string|list<string|Param>,
- *             allowed_media_hosts?: null|string|list<string|Param>,
- *             allow_relative_medias?: bool|Param, // Allows relative URLs to be used in media source attributes (img, audio, video, ...). // Default: false
- *             with_attribute_sanitizers?: string|list<string|Param>,
- *             without_attribute_sanitizers?: string|list<string|Param>,
- *             max_input_length?: int|Param, // The maximum length allowed for the sanitized input. // Default: 0
- *         }>,
+ *                 allow_safe_elements?: bool|Param, // Allows "safe" elements and attributes. // Default: false
+ *                 allow_static_elements?: bool|Param, // Allows all static elements and attributes from the W3C Sanitizer API standard. // Default: false
+ *                 allow_elements?: array<string, mixed>,
+ *                 block_elements?: string|list<string|Param>,
+ *                 drop_elements?: string|list<string|Param>,
+ *                 allow_attributes?: array<string, mixed>,
+ *                 drop_attributes?: array<string, mixed>,
+ *                 force_attributes?: array<string, array<string, string|Param>>,
+ *                 force_https_urls?: bool|Param, // Transforms URLs using the HTTP scheme to use the HTTPS scheme instead. // Default: false
+ *                 allowed_link_schemes?: string|list<string|Param>,
+ *                 allowed_link_hosts?: null|string|list<string|Param>,
+ *                 allow_relative_links?: bool|Param, // Allows relative URLs to be used in links href attributes. // Default: false
+ *                 allowed_media_schemes?: string|list<string|Param>,
+ *                 allowed_media_hosts?: null|string|list<string|Param>,
+ *                 allow_relative_medias?: bool|Param, // Allows relative URLs to be used in media source attributes (img, audio, video, ...). // Default: false
+ *                 with_attribute_sanitizers?: string|list<string|Param>,
+ *                 without_attribute_sanitizers?: string|list<string|Param>,
+ *                 max_input_length?: int|Param, // The maximum length allowed for the sanitized input. // Default: 0
+ *             }>,
  *     },
  *     webhook?: bool|array{ // Webhook configuration
  *         enabled?: bool|Param, // Default: false
  *         message_bus?: scalar|Param|null, // The message bus to use. // Default: "messenger.default_bus"
  *         routing?: array<string, array{ // Default: []
- *             service?: scalar|Param|null,
- *             secret?: scalar|Param|null, // Default: ""
- *         }>,
+ *                 service?: scalar|Param|null,
+ *                 secret?: scalar|Param|null, // Default: ""
+ *             }>,
  *     },
  *     remote-event?: bool|array{ // RemoteEvent configuration
  *         enabled?: bool|Param, // Default: false
@@ -686,10 +686,10 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  * @psalm-type TwigConfig = array{
  *     form_themes?: list<scalar|Param|null>,
  *     globals?: array<string, array{ // Default: []
- *         id?: scalar|Param|null,
- *         type?: scalar|Param|null,
- *         value?: mixed,
- *     }>,
+ *             id?: scalar|Param|null,
+ *             type?: scalar|Param|null,
+ *             value?: mixed,
+ *         }>,
  *     autoescape_service?: scalar|Param|null, // Default: null
  *     autoescape_service_method?: scalar|Param|null, // Default: null
  *     cache?: scalar|Param|null, // Default: true
@@ -730,18 +730,18 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         skip_same_as_origin?: bool|Param, // Default: true
  *     },
  *     paths?: array<string, array{ // Default: []
- *         allow_credentials?: bool|Param,
- *         allow_origin?: list<scalar|Param|null>,
- *         allow_headers?: list<scalar|Param|null>,
- *         allow_methods?: list<scalar|Param|null>,
- *         allow_private_network?: bool|Param,
- *         expose_headers?: list<scalar|Param|null>,
- *         max_age?: scalar|Param|null, // Default: 0
- *         hosts?: list<scalar|Param|null>,
- *         origin_regex?: bool|Param,
- *         forced_allow_origin_value?: scalar|Param|null, // Default: null
- *         skip_same_as_origin?: bool|Param,
- *     }>,
+ *             allow_credentials?: bool|Param,
+ *             allow_origin?: list<scalar|Param|null>,
+ *             allow_headers?: list<scalar|Param|null>,
+ *             allow_methods?: list<scalar|Param|null>,
+ *             allow_private_network?: bool|Param,
+ *             expose_headers?: list<scalar|Param|null>,
+ *             max_age?: scalar|Param|null, // Default: 0
+ *             hosts?: list<scalar|Param|null>,
+ *             origin_regex?: bool|Param,
+ *             forced_allow_origin_value?: scalar|Param|null, // Default: null
+ *             skip_same_as_origin?: bool|Param,
+ *         }>,
  * }
  * @psalm-type ApiPlatformConfig = array{
  *     title?: scalar|Param|null, // The title of the API. // Default: ""
@@ -841,13 +841,13 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         persist_authorization?: bool|Param, // Persist the SwaggerUI Authorization in the localStorage. // Default: false
  *         versions?: list<scalar|Param|null>,
  *         api_keys?: array<string, array{ // Default: []
- *             name?: scalar|Param|null, // The name of the header or query parameter containing the api key.
- *             type?: "query"|"header"|Param, // Whether the api key should be a query parameter or a header.
- *         }>,
+ *                 name?: scalar|Param|null, // The name of the header or query parameter containing the api key.
+ *                 type?: "query"|"header"|Param, // Whether the api key should be a query parameter or a header.
+ *             }>,
  *         http_auth?: array<string, array{ // Default: []
- *             scheme?: scalar|Param|null, // The OpenAPI HTTP auth scheme, for example "bearer"
- *             bearerFormat?: scalar|Param|null, // The OpenAPI HTTP bearer format
- *         }>,
+ *                 scheme?: scalar|Param|null, // The OpenAPI HTTP auth scheme, for example "bearer"
+ *                 bearerFormat?: scalar|Param|null, // The OpenAPI HTTP bearer format
+ *             }>,
  *         swagger_ui_extra_configuration?: mixed, // To pass extra configuration to Swagger UI, like docExpansion or filter. // Default: []
  *     },
  *     http_cache?: array{
@@ -888,9 +888,9 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         },
  *         termsOfService?: scalar|Param|null, // A URL to the Terms of Service for the API. MUST be in the format of a URL. // Default: null
  *         tags?: list<array{ // Default: []
- *             name?: scalar|Param|null,
- *             description?: scalar|Param|null, // Default: null
- *         }>,
+ *                 name?: scalar|Param|null,
+ *                 description?: scalar|Param|null, // Default: null
+ *             }>,
  *         license?: array{
  *             name?: scalar|Param|null, // The license name used for the API. // Default: null
  *             url?: scalar|Param|null, // URL to the license used for the API. MUST be in the format of a URL. // Default: null
@@ -912,17 +912,17 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     },
  *     exception_to_status?: array<string, int|Param>,
  *     formats?: array<string, array{ // Default: {"jsonld":{"mime_types":["application/ld+json"]}}
- *         mime_types?: list<scalar|Param|null>,
- *     }>,
+ *             mime_types?: list<scalar|Param|null>,
+ *         }>,
  *     patch_formats?: array<string, array{ // Default: {"json":{"mime_types":["application/merge-patch+json"]}}
- *         mime_types?: list<scalar|Param|null>,
- *     }>,
+ *             mime_types?: list<scalar|Param|null>,
+ *         }>,
  *     docs_formats?: array<string, array{ // Default: {"jsonld":{"mime_types":["application/ld+json"]},"jsonopenapi":{"mime_types":["application/vnd.openapi+json"]},"html":{"mime_types":["text/html"]},"yamlopenapi":{"mime_types":["application/vnd.openapi+yaml"]}}
- *         mime_types?: list<scalar|Param|null>,
- *     }>,
+ *             mime_types?: list<scalar|Param|null>,
+ *         }>,
  *     error_formats?: array<string, array{ // Default: {"jsonld":{"mime_types":["application/ld+json"]},"jsonproblem":{"mime_types":["application/problem+json"]},"json":{"mime_types":["application/problem+json","application/json"]}}
- *         mime_types?: list<scalar|Param|null>,
- *     }>,
+ *             mime_types?: list<scalar|Param|null>,
+ *         }>,
  *     jsonschema_formats?: list<scalar|Param|null>,
  *     defaults?: array{
  *         uri_template?: mixed,
@@ -994,30 +994,30 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         policy?: mixed,
  *         middleware?: mixed,
  *         parameters?: array<string, array{ // Default: []
- *             key?: mixed,
- *             schema?: mixed,
- *             open_api?: mixed,
- *             provider?: mixed,
- *             filter?: mixed,
- *             property?: mixed,
- *             description?: mixed,
- *             properties?: mixed,
- *             required?: mixed,
- *             priority?: mixed,
- *             hydra?: mixed,
- *             constraints?: mixed,
- *             security?: mixed,
- *             security_message?: mixed,
- *             extra_properties?: mixed,
- *             filter_context?: mixed,
- *             native_type?: mixed,
- *             cast_to_array?: mixed,
- *             cast_to_native_type?: mixed,
- *             cast_fn?: mixed,
- *             default?: mixed,
- *             filter_class?: mixed,
- *             ...<string, mixed>
- *         }>,
+ *                 key?: mixed,
+ *                 schema?: mixed,
+ *                 open_api?: mixed,
+ *                 provider?: mixed,
+ *                 filter?: mixed,
+ *                 property?: mixed,
+ *                 description?: mixed,
+ *                 properties?: mixed,
+ *                 required?: mixed,
+ *                 priority?: mixed,
+ *                 hydra?: mixed,
+ *                 constraints?: mixed,
+ *                 security?: mixed,
+ *                 security_message?: mixed,
+ *                 extra_properties?: mixed,
+ *                 filter_context?: mixed,
+ *                 native_type?: mixed,
+ *                 cast_to_array?: mixed,
+ *                 cast_to_native_type?: mixed,
+ *                 cast_fn?: mixed,
+ *                 default?: mixed,
+ *                 filter_class?: mixed,
+ *                 ...<string, mixed>
+ *             }>,
  *         strict_query_parameter_validation?: mixed,
  *         hide_hydra_operation?: mixed,
  *         json_stream?: mixed,
@@ -1043,144 +1043,144 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     use_microseconds?: scalar|Param|null, // Default: true
  *     channels?: list<scalar|Param|null>,
  *     handlers?: array<string, array{ // Default: []
- *         type?: scalar|Param|null,
- *         id?: scalar|Param|null,
- *         enabled?: bool|Param, // Default: true
- *         priority?: scalar|Param|null, // Default: 0
- *         level?: scalar|Param|null, // Default: "DEBUG"
- *         bubble?: bool|Param, // Default: true
- *         interactive_only?: bool|Param, // Default: false
- *         app_name?: scalar|Param|null, // Default: null
- *         include_stacktraces?: bool|Param, // Default: false
- *         process_psr_3_messages?: array{
- *             enabled?: bool|Param|null, // Default: null
- *             date_format?: scalar|Param|null,
- *             remove_used_context_fields?: bool|Param,
- *         },
- *         path?: scalar|Param|null, // Default: "%kernel.logs_dir%/%kernel.environment%.log"
- *         file_permission?: scalar|Param|null, // Default: null
- *         use_locking?: bool|Param, // Default: false
- *         filename_format?: scalar|Param|null, // Default: "{filename}-{date}"
- *         date_format?: scalar|Param|null, // Default: "Y-m-d"
- *         ident?: scalar|Param|null, // Default: false
- *         logopts?: scalar|Param|null, // Default: 1
- *         facility?: scalar|Param|null, // Default: "user"
- *         max_files?: scalar|Param|null, // Default: 0
- *         action_level?: scalar|Param|null, // Default: "WARNING"
- *         activation_strategy?: scalar|Param|null, // Default: null
- *         stop_buffering?: bool|Param, // Default: true
- *         passthru_level?: scalar|Param|null, // Default: null
- *         excluded_http_codes?: list<array{ // Default: []
- *             code?: scalar|Param|null,
- *             urls?: list<scalar|Param|null>,
- *         }>,
- *         accepted_levels?: list<scalar|Param|null>,
- *         min_level?: scalar|Param|null, // Default: "DEBUG"
- *         max_level?: scalar|Param|null, // Default: "EMERGENCY"
- *         buffer_size?: scalar|Param|null, // Default: 0
- *         flush_on_overflow?: bool|Param, // Default: false
- *         handler?: scalar|Param|null,
- *         url?: scalar|Param|null,
- *         exchange?: scalar|Param|null,
- *         exchange_name?: scalar|Param|null, // Default: "log"
- *         channel?: scalar|Param|null, // Default: null
- *         bot_name?: scalar|Param|null, // Default: "Monolog"
- *         use_attachment?: scalar|Param|null, // Default: true
- *         use_short_attachment?: scalar|Param|null, // Default: false
- *         include_extra?: scalar|Param|null, // Default: false
- *         icon_emoji?: scalar|Param|null, // Default: null
- *         webhook_url?: scalar|Param|null,
- *         exclude_fields?: list<scalar|Param|null>,
- *         token?: scalar|Param|null,
- *         region?: scalar|Param|null,
- *         source?: scalar|Param|null,
- *         use_ssl?: bool|Param, // Default: true
- *         user?: mixed,
- *         title?: scalar|Param|null, // Default: null
- *         host?: scalar|Param|null, // Default: null
- *         port?: scalar|Param|null, // Default: 514
- *         config?: list<scalar|Param|null>,
- *         members?: list<scalar|Param|null>,
- *         connection_string?: scalar|Param|null,
- *         timeout?: scalar|Param|null,
- *         time?: scalar|Param|null, // Default: 60
- *         deduplication_level?: scalar|Param|null, // Default: 400
- *         store?: scalar|Param|null, // Default: null
- *         connection_timeout?: scalar|Param|null,
- *         persistent?: bool|Param,
- *         message_type?: scalar|Param|null, // Default: 0
- *         parse_mode?: scalar|Param|null, // Default: null
- *         disable_webpage_preview?: bool|Param|null, // Default: null
- *         disable_notification?: bool|Param|null, // Default: null
- *         split_long_messages?: bool|Param, // Default: false
- *         delay_between_messages?: bool|Param, // Default: false
- *         topic?: int|Param, // Default: null
- *         factor?: int|Param, // Default: 1
- *         tags?: string|list<scalar|Param|null>,
- *         console_formatter_options?: mixed, // Default: []
- *         formatter?: scalar|Param|null,
- *         nested?: bool|Param, // Default: false
- *         publisher?: string|array{
- *             id?: scalar|Param|null,
- *             hostname?: scalar|Param|null,
- *             port?: scalar|Param|null, // Default: 12201
- *             chunk_size?: scalar|Param|null, // Default: 1420
- *             encoder?: "json"|"compressed_json"|Param,
- *         },
- *         mongodb?: string|array{
- *             id?: scalar|Param|null, // ID of a MongoDB\Client service
- *             uri?: scalar|Param|null,
- *             username?: scalar|Param|null,
- *             password?: scalar|Param|null,
- *             database?: scalar|Param|null, // Default: "monolog"
- *             collection?: scalar|Param|null, // Default: "logs"
- *         },
- *         elasticsearch?: string|array{
- *             id?: scalar|Param|null,
- *             hosts?: list<scalar|Param|null>,
- *             host?: scalar|Param|null,
- *             port?: scalar|Param|null, // Default: 9200
- *             transport?: scalar|Param|null, // Default: "Http"
- *             user?: scalar|Param|null, // Default: null
- *             password?: scalar|Param|null, // Default: null
- *         },
- *         index?: scalar|Param|null, // Default: "monolog"
- *         document_type?: scalar|Param|null, // Default: "logs"
- *         ignore_error?: scalar|Param|null, // Default: false
- *         redis?: string|array{
- *             id?: scalar|Param|null,
- *             host?: scalar|Param|null,
- *             password?: scalar|Param|null, // Default: null
- *             port?: scalar|Param|null, // Default: 6379
- *             database?: scalar|Param|null, // Default: 0
- *             key_name?: scalar|Param|null, // Default: "monolog_redis"
- *         },
- *         predis?: string|array{
- *             id?: scalar|Param|null,
- *             host?: scalar|Param|null,
- *         },
- *         from_email?: scalar|Param|null,
- *         to_email?: string|list<scalar|Param|null>,
- *         subject?: scalar|Param|null,
- *         content_type?: scalar|Param|null, // Default: null
- *         headers?: list<scalar|Param|null>,
- *         mailer?: scalar|Param|null, // Default: null
- *         email_prototype?: string|array{
- *             id?: scalar|Param|null,
- *             method?: scalar|Param|null, // Default: null
- *         },
- *         verbosity_levels?: array{
- *             VERBOSITY_QUIET?: scalar|Param|null, // Default: "ERROR"
- *             VERBOSITY_NORMAL?: scalar|Param|null, // Default: "WARNING"
- *             VERBOSITY_VERBOSE?: scalar|Param|null, // Default: "NOTICE"
- *             VERBOSITY_VERY_VERBOSE?: scalar|Param|null, // Default: "INFO"
- *             VERBOSITY_DEBUG?: scalar|Param|null, // Default: "DEBUG"
- *         },
- *         channels?: string|array{
  *             type?: scalar|Param|null,
- *             elements?: list<scalar|Param|null>,
- *         },
- *     }>,
+ *             id?: scalar|Param|null,
+ *             enabled?: bool|Param, // Default: true
+ *             priority?: scalar|Param|null, // Default: 0
+ *             level?: scalar|Param|null, // Default: "DEBUG"
+ *             bubble?: bool|Param, // Default: true
+ *             interactive_only?: bool|Param, // Default: false
+ *             app_name?: scalar|Param|null, // Default: null
+ *             include_stacktraces?: bool|Param, // Default: false
+ *             process_psr_3_messages?: array{
+ *                 enabled?: bool|Param|null, // Default: null
+ *                 date_format?: scalar|Param|null,
+ *                 remove_used_context_fields?: bool|Param,
+ *             },
+ *             path?: scalar|Param|null, // Default: "%kernel.logs_dir%/%kernel.environment%.log"
+ *             file_permission?: scalar|Param|null, // Default: null
+ *             use_locking?: bool|Param, // Default: false
+ *             filename_format?: scalar|Param|null, // Default: "{filename}-{date}"
+ *             date_format?: scalar|Param|null, // Default: "Y-m-d"
+ *             ident?: scalar|Param|null, // Default: false
+ *             logopts?: scalar|Param|null, // Default: 1
+ *             facility?: scalar|Param|null, // Default: "user"
+ *             max_files?: scalar|Param|null, // Default: 0
+ *             action_level?: scalar|Param|null, // Default: "WARNING"
+ *             activation_strategy?: scalar|Param|null, // Default: null
+ *             stop_buffering?: bool|Param, // Default: true
+ *             passthru_level?: scalar|Param|null, // Default: null
+ *             excluded_http_codes?: list<array{ // Default: []
+ *                     code?: scalar|Param|null,
+ *                     urls?: list<scalar|Param|null>,
+ *                 }>,
+ *             accepted_levels?: list<scalar|Param|null>,
+ *             min_level?: scalar|Param|null, // Default: "DEBUG"
+ *             max_level?: scalar|Param|null, // Default: "EMERGENCY"
+ *             buffer_size?: scalar|Param|null, // Default: 0
+ *             flush_on_overflow?: bool|Param, // Default: false
+ *             handler?: scalar|Param|null,
+ *             url?: scalar|Param|null,
+ *             exchange?: scalar|Param|null,
+ *             exchange_name?: scalar|Param|null, // Default: "log"
+ *             channel?: scalar|Param|null, // Default: null
+ *             bot_name?: scalar|Param|null, // Default: "Monolog"
+ *             use_attachment?: scalar|Param|null, // Default: true
+ *             use_short_attachment?: scalar|Param|null, // Default: false
+ *             include_extra?: scalar|Param|null, // Default: false
+ *             icon_emoji?: scalar|Param|null, // Default: null
+ *             webhook_url?: scalar|Param|null,
+ *             exclude_fields?: list<scalar|Param|null>,
+ *             token?: scalar|Param|null,
+ *             region?: scalar|Param|null,
+ *             source?: scalar|Param|null,
+ *             use_ssl?: bool|Param, // Default: true
+ *             user?: mixed,
+ *             title?: scalar|Param|null, // Default: null
+ *             host?: scalar|Param|null, // Default: null
+ *             port?: scalar|Param|null, // Default: 514
+ *             config?: list<scalar|Param|null>,
+ *             members?: list<scalar|Param|null>,
+ *             connection_string?: scalar|Param|null,
+ *             timeout?: scalar|Param|null,
+ *             time?: scalar|Param|null, // Default: 60
+ *             deduplication_level?: scalar|Param|null, // Default: 400
+ *             store?: scalar|Param|null, // Default: null
+ *             connection_timeout?: scalar|Param|null,
+ *             persistent?: bool|Param,
+ *             message_type?: scalar|Param|null, // Default: 0
+ *             parse_mode?: scalar|Param|null, // Default: null
+ *             disable_webpage_preview?: bool|Param|null, // Default: null
+ *             disable_notification?: bool|Param|null, // Default: null
+ *             split_long_messages?: bool|Param, // Default: false
+ *             delay_between_messages?: bool|Param, // Default: false
+ *             topic?: int|Param, // Default: null
+ *             factor?: int|Param, // Default: 1
+ *             tags?: string|list<scalar|Param|null>,
+ *             console_formatter_options?: mixed, // Default: []
+ *             formatter?: scalar|Param|null,
+ *             nested?: bool|Param, // Default: false
+ *             publisher?: string|array{
+ *                 id?: scalar|Param|null,
+ *                 hostname?: scalar|Param|null,
+ *                 port?: scalar|Param|null, // Default: 12201
+ *                 chunk_size?: scalar|Param|null, // Default: 1420
+ *                 encoder?: "json"|"compressed_json"|Param,
+ *             },
+ *             mongodb?: string|array{
+ *                 id?: scalar|Param|null, // ID of a MongoDB\Client service
+ *                 uri?: scalar|Param|null,
+ *                 username?: scalar|Param|null,
+ *                 password?: scalar|Param|null,
+ *                 database?: scalar|Param|null, // Default: "monolog"
+ *                 collection?: scalar|Param|null, // Default: "logs"
+ *             },
+ *             elasticsearch?: string|array{
+ *                 id?: scalar|Param|null,
+ *                 hosts?: list<scalar|Param|null>,
+ *                 host?: scalar|Param|null,
+ *                 port?: scalar|Param|null, // Default: 9200
+ *                 transport?: scalar|Param|null, // Default: "Http"
+ *                 user?: scalar|Param|null, // Default: null
+ *                 password?: scalar|Param|null, // Default: null
+ *             },
+ *             index?: scalar|Param|null, // Default: "monolog"
+ *             document_type?: scalar|Param|null, // Default: "logs"
+ *             ignore_error?: scalar|Param|null, // Default: false
+ *             redis?: string|array{
+ *                 id?: scalar|Param|null,
+ *                 host?: scalar|Param|null,
+ *                 password?: scalar|Param|null, // Default: null
+ *                 port?: scalar|Param|null, // Default: 6379
+ *                 database?: scalar|Param|null, // Default: 0
+ *                 key_name?: scalar|Param|null, // Default: "monolog_redis"
+ *             },
+ *             predis?: string|array{
+ *                 id?: scalar|Param|null,
+ *                 host?: scalar|Param|null,
+ *             },
+ *             from_email?: scalar|Param|null,
+ *             to_email?: string|list<scalar|Param|null>,
+ *             subject?: scalar|Param|null,
+ *             content_type?: scalar|Param|null, // Default: null
+ *             headers?: list<scalar|Param|null>,
+ *             mailer?: scalar|Param|null, // Default: null
+ *             email_prototype?: string|array{
+ *                 id?: scalar|Param|null,
+ *                 method?: scalar|Param|null, // Default: null
+ *             },
+ *             verbosity_levels?: array{
+ *                 VERBOSITY_QUIET?: scalar|Param|null, // Default: "ERROR"
+ *                 VERBOSITY_NORMAL?: scalar|Param|null, // Default: "WARNING"
+ *                 VERBOSITY_VERBOSE?: scalar|Param|null, // Default: "NOTICE"
+ *                 VERBOSITY_VERY_VERBOSE?: scalar|Param|null, // Default: "INFO"
+ *                 VERBOSITY_DEBUG?: scalar|Param|null, // Default: "DEBUG"
+ *             },
+ *             channels?: string|array{
+ *                 type?: scalar|Param|null,
+ *                 elements?: list<scalar|Param|null>,
+ *             },
+ *         }>,
  * }
  * @psalm-type WebProfilerConfig = array{
  *     toolbar?: bool|array{ // Profiler toolbar configuration
@@ -1192,21 +1192,21 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  * }
  * @psalm-type MercureConfig = array{
  *     hubs?: array<string, array{ // Default: []
- *         url?: scalar|Param|null, // URL of the hub's publish endpoint
- *         public_url?: scalar|Param|null, // URL of the hub's public endpoint // Default: null
- *         jwt?: string|array{ // JSON Web Token configuration.
- *             value?: scalar|Param|null, // JSON Web Token to use to publish to this hub.
- *             provider?: scalar|Param|null, // The ID of a service to call to provide the JSON Web Token.
- *             factory?: scalar|Param|null, // The ID of a service to call to create the JSON Web Token.
- *             publish?: list<scalar|Param|null>,
- *             subscribe?: list<scalar|Param|null>,
- *             secret?: scalar|Param|null, // The JWT Secret to use.
- *             passphrase?: scalar|Param|null, // The JWT secret passphrase. // Default: ""
- *             algorithm?: scalar|Param|null, // The algorithm to use to sign the JWT // Default: "hmac.sha256"
- *         },
- *         jwt_provider?: scalar|Param|null, // Deprecated: The child node "jwt_provider" at path "mercure.hubs..jwt_provider" is deprecated, use "jwt.provider" instead. // The ID of a service to call to generate the JSON Web Token.
- *         bus?: scalar|Param|null, // Name of the Messenger bus where the handler for this hub must be registered. Default to the default bus if Messenger is enabled.
- *     }>,
+ *             url?: scalar|Param|null, // URL of the hub's publish endpoint
+ *             public_url?: scalar|Param|null, // URL of the hub's public endpoint // Default: null
+ *             jwt?: string|array{ // JSON Web Token configuration.
+ *                 value?: scalar|Param|null, // JSON Web Token to use to publish to this hub.
+ *                 provider?: scalar|Param|null, // The ID of a service to call to provide the JSON Web Token.
+ *                 factory?: scalar|Param|null, // The ID of a service to call to create the JSON Web Token.
+ *                 publish?: list<scalar|Param|null>,
+ *                 subscribe?: list<scalar|Param|null>,
+ *                 secret?: scalar|Param|null, // The JWT Secret to use.
+ *                 passphrase?: scalar|Param|null, // The JWT secret passphrase. // Default: ""
+ *                 algorithm?: scalar|Param|null, // The algorithm to use to sign the JWT // Default: "hmac.sha256"
+ *             },
+ *             jwt_provider?: scalar|Param|null, // Deprecated: The child node "jwt_provider" at path "mercure.hubs..jwt_provider" is deprecated, use "jwt.provider" instead. // The ID of a service to call to generate the JSON Web Token.
+ *             bus?: scalar|Param|null, // Name of the Messenger bus where the handler for this hub must be registered. Default to the default bus if Messenger is enabled.
+ *         }>,
  *     default_hub?: scalar|Param|null,
  *     default_cookie_lifetime?: int|Param, // Default lifetime of the cookie containing the JWT, in seconds. Defaults to the value of "framework.session.cookie_lifetime". // Default: null
  *     enable_profiler?: bool|Param, // Deprecated: The child node "enable_profiler" at path "mercure.enable_profiler" is deprecated. // Enable Symfony Web Profiler integration.
@@ -1215,56 +1215,10 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     dbal?: array{
  *         default_connection?: scalar|Param|null,
  *         types?: array<string, string|array{ // Default: []
- *             class?: scalar|Param|null,
- *         }>,
+ *                 class?: scalar|Param|null,
+ *             }>,
  *         driver_schemes?: array<string, scalar|Param|null>,
  *         connections?: array<string, array{ // Default: []
- *             url?: scalar|Param|null, // A URL with connection information; any parameter value parsed from this string will override explicitly set parameters
- *             dbname?: scalar|Param|null,
- *             host?: scalar|Param|null, // Defaults to "localhost" at runtime.
- *             port?: scalar|Param|null, // Defaults to null at runtime.
- *             user?: scalar|Param|null, // Defaults to "root" at runtime.
- *             password?: scalar|Param|null, // Defaults to null at runtime.
- *             dbname_suffix?: scalar|Param|null, // Adds the given suffix to the configured database name, this option has no effects for the SQLite platform
- *             application_name?: scalar|Param|null,
- *             charset?: scalar|Param|null,
- *             path?: scalar|Param|null,
- *             memory?: bool|Param,
- *             unix_socket?: scalar|Param|null, // The unix socket to use for MySQL
- *             persistent?: bool|Param, // True to use as persistent connection for the ibm_db2 driver
- *             protocol?: scalar|Param|null, // The protocol to use for the ibm_db2 driver (default to TCPIP if omitted)
- *             service?: bool|Param, // True to use SERVICE_NAME as connection parameter instead of SID for Oracle
- *             servicename?: scalar|Param|null, // Overrules dbname parameter if given and used as SERVICE_NAME or SID connection parameter for Oracle depending on the service parameter.
- *             sessionMode?: scalar|Param|null, // The session mode to use for the oci8 driver
- *             server?: scalar|Param|null, // The name of a running database server to connect to for SQL Anywhere.
- *             default_dbname?: scalar|Param|null, // Override the default database (postgres) to connect to for PostgreSQL connexion.
- *             sslmode?: scalar|Param|null, // Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL.
- *             sslrootcert?: scalar|Param|null, // The name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities.
- *             sslcert?: scalar|Param|null, // The path to the SSL client certificate file for PostgreSQL.
- *             sslkey?: scalar|Param|null, // The path to the SSL client key file for PostgreSQL.
- *             sslcrl?: scalar|Param|null, // The file name of the SSL certificate revocation list for PostgreSQL.
- *             pooled?: bool|Param, // True to use a pooled server with the oci8/pdo_oracle driver
- *             MultipleActiveResultSets?: bool|Param, // Configuring MultipleActiveResultSets for the pdo_sqlsrv driver
- *             instancename?: scalar|Param|null, // Optional parameter, complete whether to add the INSTANCE_NAME parameter in the connection. It is generally used to connect to an Oracle RAC server to select the name of a particular instance.
- *             connectstring?: scalar|Param|null, // Complete Easy Connect connection descriptor, see https://docs.oracle.com/database/121/NETAG/naming.htm.When using this option, you will still need to provide the user and password parameters, but the other parameters will no longer be used. Note that when using this parameter, the getHost and getPort methods from Doctrine\DBAL\Connection will no longer function as expected.
- *             driver?: scalar|Param|null, // Default: "pdo_mysql"
- *             auto_commit?: bool|Param,
- *             schema_filter?: scalar|Param|null,
- *             logging?: bool|Param, // Default: true
- *             profiling?: bool|Param, // Default: true
- *             profiling_collect_backtrace?: bool|Param, // Enables collecting backtraces when profiling is enabled // Default: false
- *             profiling_collect_schema_errors?: bool|Param, // Enables collecting schema errors when profiling is enabled // Default: true
- *             server_version?: scalar|Param|null,
- *             idle_connection_ttl?: int|Param, // Default: 600
- *             driver_class?: scalar|Param|null,
- *             wrapper_class?: scalar|Param|null,
- *             keep_replica?: bool|Param,
- *             options?: array<string, mixed>,
- *             mapping_types?: array<string, scalar|Param|null>,
- *             default_table_options?: array<string, scalar|Param|null>,
- *             schema_manager_factory?: scalar|Param|null, // Default: "doctrine.dbal.default_schema_manager_factory"
- *             result_cache?: scalar|Param|null,
- *             replicas?: array<string, array{ // Default: []
  *                 url?: scalar|Param|null, // A URL with connection information; any parameter value parsed from this string will override explicitly set parameters
  *                 dbname?: scalar|Param|null,
  *                 host?: scalar|Param|null, // Defaults to "localhost" at runtime.
@@ -1293,8 +1247,54 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *                 MultipleActiveResultSets?: bool|Param, // Configuring MultipleActiveResultSets for the pdo_sqlsrv driver
  *                 instancename?: scalar|Param|null, // Optional parameter, complete whether to add the INSTANCE_NAME parameter in the connection. It is generally used to connect to an Oracle RAC server to select the name of a particular instance.
  *                 connectstring?: scalar|Param|null, // Complete Easy Connect connection descriptor, see https://docs.oracle.com/database/121/NETAG/naming.htm.When using this option, you will still need to provide the user and password parameters, but the other parameters will no longer be used. Note that when using this parameter, the getHost and getPort methods from Doctrine\DBAL\Connection will no longer function as expected.
+ *                 driver?: scalar|Param|null, // Default: "pdo_mysql"
+ *                 auto_commit?: bool|Param,
+ *                 schema_filter?: scalar|Param|null,
+ *                 logging?: bool|Param, // Default: true
+ *                 profiling?: bool|Param, // Default: true
+ *                 profiling_collect_backtrace?: bool|Param, // Enables collecting backtraces when profiling is enabled // Default: false
+ *                 profiling_collect_schema_errors?: bool|Param, // Enables collecting schema errors when profiling is enabled // Default: true
+ *                 server_version?: scalar|Param|null,
+ *                 idle_connection_ttl?: int|Param, // Default: 600
+ *                 driver_class?: scalar|Param|null,
+ *                 wrapper_class?: scalar|Param|null,
+ *                 keep_replica?: bool|Param,
+ *                 options?: array<string, mixed>,
+ *                 mapping_types?: array<string, scalar|Param|null>,
+ *                 default_table_options?: array<string, scalar|Param|null>,
+ *                 schema_manager_factory?: scalar|Param|null, // Default: "doctrine.dbal.default_schema_manager_factory"
+ *                 result_cache?: scalar|Param|null,
+ *                 replicas?: array<string, array{ // Default: []
+ *                         url?: scalar|Param|null, // A URL with connection information; any parameter value parsed from this string will override explicitly set parameters
+ *                         dbname?: scalar|Param|null,
+ *                         host?: scalar|Param|null, // Defaults to "localhost" at runtime.
+ *                         port?: scalar|Param|null, // Defaults to null at runtime.
+ *                         user?: scalar|Param|null, // Defaults to "root" at runtime.
+ *                         password?: scalar|Param|null, // Defaults to null at runtime.
+ *                         dbname_suffix?: scalar|Param|null, // Adds the given suffix to the configured database name, this option has no effects for the SQLite platform
+ *                         application_name?: scalar|Param|null,
+ *                         charset?: scalar|Param|null,
+ *                         path?: scalar|Param|null,
+ *                         memory?: bool|Param,
+ *                         unix_socket?: scalar|Param|null, // The unix socket to use for MySQL
+ *                         persistent?: bool|Param, // True to use as persistent connection for the ibm_db2 driver
+ *                         protocol?: scalar|Param|null, // The protocol to use for the ibm_db2 driver (default to TCPIP if omitted)
+ *                         service?: bool|Param, // True to use SERVICE_NAME as connection parameter instead of SID for Oracle
+ *                         servicename?: scalar|Param|null, // Overrules dbname parameter if given and used as SERVICE_NAME or SID connection parameter for Oracle depending on the service parameter.
+ *                         sessionMode?: scalar|Param|null, // The session mode to use for the oci8 driver
+ *                         server?: scalar|Param|null, // The name of a running database server to connect to for SQL Anywhere.
+ *                         default_dbname?: scalar|Param|null, // Override the default database (postgres) to connect to for PostgreSQL connexion.
+ *                         sslmode?: scalar|Param|null, // Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL.
+ *                         sslrootcert?: scalar|Param|null, // The name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities.
+ *                         sslcert?: scalar|Param|null, // The path to the SSL client certificate file for PostgreSQL.
+ *                         sslkey?: scalar|Param|null, // The path to the SSL client key file for PostgreSQL.
+ *                         sslcrl?: scalar|Param|null, // The file name of the SSL certificate revocation list for PostgreSQL.
+ *                         pooled?: bool|Param, // True to use a pooled server with the oci8/pdo_oracle driver
+ *                         MultipleActiveResultSets?: bool|Param, // Configuring MultipleActiveResultSets for the pdo_sqlsrv driver
+ *                         instancename?: scalar|Param|null, // Optional parameter, complete whether to add the INSTANCE_NAME parameter in the connection. It is generally used to connect to an Oracle RAC server to select the name of a particular instance.
+ *                         connectstring?: scalar|Param|null, // Complete Easy Connect connection descriptor, see https://docs.oracle.com/database/121/NETAG/naming.htm.When using this option, you will still need to provide the user and password parameters, but the other parameters will no longer be used. Note that when using this parameter, the getHost and getPort methods from Doctrine\DBAL\Connection will no longer function as expected.
+ *                     }>,
  *             }>,
- *         }>,
  *     },
  *     orm?: array{
  *         default_entity_manager?: scalar|Param|null,
@@ -1305,93 +1305,93 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             evict_cache?: bool|Param, // Set to true to fetch the entity from the database instead of using the cache, if any // Default: false
  *         },
  *         entity_managers?: array<string, array{ // Default: []
- *             query_cache_driver?: string|array{
- *                 type?: scalar|Param|null, // Default: null
- *                 id?: scalar|Param|null,
- *                 pool?: scalar|Param|null,
- *             },
- *             metadata_cache_driver?: string|array{
- *                 type?: scalar|Param|null, // Default: null
- *                 id?: scalar|Param|null,
- *                 pool?: scalar|Param|null,
- *             },
- *             result_cache_driver?: string|array{
- *                 type?: scalar|Param|null, // Default: null
- *                 id?: scalar|Param|null,
- *                 pool?: scalar|Param|null,
- *             },
- *             entity_listeners?: array{
- *                 entities?: array<string, array{ // Default: []
- *                     listeners?: array<string, array{ // Default: []
- *                         events?: list<array{ // Default: []
- *                             type?: scalar|Param|null,
- *                             method?: scalar|Param|null, // Default: null
- *                         }>,
- *                     }>,
- *                 }>,
- *             },
- *             connection?: scalar|Param|null,
- *             class_metadata_factory_name?: scalar|Param|null, // Default: "Doctrine\\ORM\\Mapping\\ClassMetadataFactory"
- *             default_repository_class?: scalar|Param|null, // Default: "Doctrine\\ORM\\EntityRepository"
- *             auto_mapping?: scalar|Param|null, // Default: false
- *             naming_strategy?: scalar|Param|null, // Default: "doctrine.orm.naming_strategy.default"
- *             quote_strategy?: scalar|Param|null, // Default: "doctrine.orm.quote_strategy.default"
- *             typed_field_mapper?: scalar|Param|null, // Default: "doctrine.orm.typed_field_mapper.default"
- *             entity_listener_resolver?: scalar|Param|null, // Default: null
- *             fetch_mode_subselect_batch_size?: scalar|Param|null,
- *             repository_factory?: scalar|Param|null, // Default: "doctrine.orm.container_repository_factory"
- *             schema_ignore_classes?: list<scalar|Param|null>,
- *             validate_xml_mapping?: bool|Param, // Set to "true" to opt-in to the new mapping driver mode that was added in Doctrine ORM 2.14 and will be mandatory in ORM 3.0. See https://github.com/doctrine/orm/pull/6728. // Default: false
- *             second_level_cache?: array{
- *                 region_cache_driver?: string|array{
+ *                 query_cache_driver?: string|array{
  *                     type?: scalar|Param|null, // Default: null
  *                     id?: scalar|Param|null,
  *                     pool?: scalar|Param|null,
  *                 },
- *                 region_lock_lifetime?: scalar|Param|null, // Default: 60
- *                 log_enabled?: bool|Param, // Default: true
- *                 region_lifetime?: scalar|Param|null, // Default: 3600
- *                 enabled?: bool|Param, // Default: true
- *                 factory?: scalar|Param|null,
- *                 regions?: array<string, array{ // Default: []
- *                     cache_driver?: string|array{
+ *                 metadata_cache_driver?: string|array{
+ *                     type?: scalar|Param|null, // Default: null
+ *                     id?: scalar|Param|null,
+ *                     pool?: scalar|Param|null,
+ *                 },
+ *                 result_cache_driver?: string|array{
+ *                     type?: scalar|Param|null, // Default: null
+ *                     id?: scalar|Param|null,
+ *                     pool?: scalar|Param|null,
+ *                 },
+ *                 entity_listeners?: array{
+ *                     entities?: array<string, array{ // Default: []
+ *                             listeners?: array<string, array{ // Default: []
+ *                                     events?: list<array{ // Default: []
+ *                                             type?: scalar|Param|null,
+ *                                             method?: scalar|Param|null, // Default: null
+ *                                         }>,
+ *                                 }>,
+ *                         }>,
+ *                 },
+ *                 connection?: scalar|Param|null,
+ *                 class_metadata_factory_name?: scalar|Param|null, // Default: "Doctrine\\ORM\\Mapping\\ClassMetadataFactory"
+ *                 default_repository_class?: scalar|Param|null, // Default: "Doctrine\\ORM\\EntityRepository"
+ *                 auto_mapping?: scalar|Param|null, // Default: false
+ *                 naming_strategy?: scalar|Param|null, // Default: "doctrine.orm.naming_strategy.default"
+ *                 quote_strategy?: scalar|Param|null, // Default: "doctrine.orm.quote_strategy.default"
+ *                 typed_field_mapper?: scalar|Param|null, // Default: "doctrine.orm.typed_field_mapper.default"
+ *                 entity_listener_resolver?: scalar|Param|null, // Default: null
+ *                 fetch_mode_subselect_batch_size?: scalar|Param|null,
+ *                 repository_factory?: scalar|Param|null, // Default: "doctrine.orm.container_repository_factory"
+ *                 schema_ignore_classes?: list<scalar|Param|null>,
+ *                 validate_xml_mapping?: bool|Param, // Set to "true" to opt-in to the new mapping driver mode that was added in Doctrine ORM 2.14 and will be mandatory in ORM 3.0. See https://github.com/doctrine/orm/pull/6728. // Default: false
+ *                 second_level_cache?: array{
+ *                     region_cache_driver?: string|array{
  *                         type?: scalar|Param|null, // Default: null
  *                         id?: scalar|Param|null,
  *                         pool?: scalar|Param|null,
  *                     },
- *                     lock_path?: scalar|Param|null, // Default: "%kernel.cache_dir%/doctrine/orm/slc/filelock"
- *                     lock_lifetime?: scalar|Param|null, // Default: 60
- *                     type?: scalar|Param|null, // Default: "default"
- *                     lifetime?: scalar|Param|null, // Default: 0
- *                     service?: scalar|Param|null,
- *                     name?: scalar|Param|null,
- *                 }>,
- *                 loggers?: array<string, array{ // Default: []
- *                     name?: scalar|Param|null,
- *                     service?: scalar|Param|null,
- *                 }>,
- *             },
- *             hydrators?: array<string, scalar|Param|null>,
- *             mappings?: array<string, bool|string|array{ // Default: []
- *                 mapping?: scalar|Param|null, // Default: true
- *                 type?: scalar|Param|null,
- *                 dir?: scalar|Param|null,
- *                 alias?: scalar|Param|null,
- *                 prefix?: scalar|Param|null,
- *                 is_bundle?: bool|Param,
+ *                     region_lock_lifetime?: scalar|Param|null, // Default: 60
+ *                     log_enabled?: bool|Param, // Default: true
+ *                     region_lifetime?: scalar|Param|null, // Default: 3600
+ *                     enabled?: bool|Param, // Default: true
+ *                     factory?: scalar|Param|null,
+ *                     regions?: array<string, array{ // Default: []
+ *                             cache_driver?: string|array{
+ *                                 type?: scalar|Param|null, // Default: null
+ *                                 id?: scalar|Param|null,
+ *                                 pool?: scalar|Param|null,
+ *                             },
+ *                             lock_path?: scalar|Param|null, // Default: "%kernel.cache_dir%/doctrine/orm/slc/filelock"
+ *                             lock_lifetime?: scalar|Param|null, // Default: 60
+ *                             type?: scalar|Param|null, // Default: "default"
+ *                             lifetime?: scalar|Param|null, // Default: 0
+ *                             service?: scalar|Param|null,
+ *                             name?: scalar|Param|null,
+ *                         }>,
+ *                     loggers?: array<string, array{ // Default: []
+ *                             name?: scalar|Param|null,
+ *                             service?: scalar|Param|null,
+ *                         }>,
+ *                 },
+ *                 hydrators?: array<string, scalar|Param|null>,
+ *                 mappings?: array<string, bool|string|array{ // Default: []
+ *                         mapping?: scalar|Param|null, // Default: true
+ *                         type?: scalar|Param|null,
+ *                         dir?: scalar|Param|null,
+ *                         alias?: scalar|Param|null,
+ *                         prefix?: scalar|Param|null,
+ *                         is_bundle?: bool|Param,
+ *                     }>,
+ *                 dql?: array{
+ *                     string_functions?: array<string, scalar|Param|null>,
+ *                     numeric_functions?: array<string, scalar|Param|null>,
+ *                     datetime_functions?: array<string, scalar|Param|null>,
+ *                 },
+ *                 filters?: array<string, string|array{ // Default: []
+ *                         class?: scalar|Param|null,
+ *                         enabled?: bool|Param, // Default: false
+ *                         parameters?: array<string, mixed>,
+ *                     }>,
+ *                 identity_generation_preferences?: array<string, scalar|Param|null>,
  *             }>,
- *             dql?: array{
- *                 string_functions?: array<string, scalar|Param|null>,
- *                 numeric_functions?: array<string, scalar|Param|null>,
- *                 datetime_functions?: array<string, scalar|Param|null>,
- *             },
- *             filters?: array<string, string|array{ // Default: []
- *                 class?: scalar|Param|null,
- *                 enabled?: bool|Param, // Default: false
- *                 parameters?: array<string, mixed>,
- *             }>,
- *             identity_generation_preferences?: array<string, scalar|Param|null>,
- *         }>,
  *         resolve_target_entities?: array<string, scalar|Param|null>,
  *     },
  * }
@@ -1432,306 +1432,306 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         allow_if_equal_granted_denied?: bool|Param, // Default: true
  *     },
  *     password_hashers?: array<string, string|array{ // Default: []
- *         algorithm?: scalar|Param|null,
- *         migrate_from?: string|list<scalar|Param|null>,
- *         hash_algorithm?: scalar|Param|null, // Name of hashing algorithm for PBKDF2 (i.e. sha256, sha512, etc..) See hash_algos() for a list of supported algorithms. // Default: "sha512"
- *         key_length?: scalar|Param|null, // Default: 40
- *         ignore_case?: bool|Param, // Default: false
- *         encode_as_base64?: bool|Param, // Default: true
- *         iterations?: scalar|Param|null, // Default: 5000
- *         cost?: int|Param, // Default: null
- *         memory_cost?: scalar|Param|null, // Default: null
- *         time_cost?: scalar|Param|null, // Default: null
- *         id?: scalar|Param|null,
- *     }>,
+ *             algorithm?: scalar|Param|null,
+ *             migrate_from?: string|list<scalar|Param|null>,
+ *             hash_algorithm?: scalar|Param|null, // Name of hashing algorithm for PBKDF2 (i.e. sha256, sha512, etc..) See hash_algos() for a list of supported algorithms. // Default: "sha512"
+ *             key_length?: scalar|Param|null, // Default: 40
+ *             ignore_case?: bool|Param, // Default: false
+ *             encode_as_base64?: bool|Param, // Default: true
+ *             iterations?: scalar|Param|null, // Default: 5000
+ *             cost?: int|Param, // Default: null
+ *             memory_cost?: scalar|Param|null, // Default: null
+ *             time_cost?: scalar|Param|null, // Default: null
+ *             id?: scalar|Param|null,
+ *         }>,
  *     providers?: array<string, array{ // Default: []
- *         id?: scalar|Param|null,
- *         chain?: array{
- *             providers?: string|list<scalar|Param|null>,
- *         },
- *         entity?: array{
- *             class?: scalar|Param|null, // The full entity class name of your user class.
- *             property?: scalar|Param|null, // Default: null
- *             manager_name?: scalar|Param|null, // Default: null
- *         },
- *         memory?: array{
- *             users?: array<string, array{ // Default: []
- *                 password?: scalar|Param|null, // Default: null
- *                 roles?: string|list<scalar|Param|null>,
- *             }>,
- *         },
- *         ldap?: array{
- *             service?: scalar|Param|null,
- *             base_dn?: scalar|Param|null,
- *             search_dn?: scalar|Param|null, // Default: null
- *             search_password?: scalar|Param|null, // Default: null
- *             extra_fields?: list<scalar|Param|null>,
- *             default_roles?: string|list<scalar|Param|null>,
- *             role_fetcher?: scalar|Param|null, // Default: null
- *             uid_key?: scalar|Param|null, // Default: "sAMAccountName"
- *             filter?: scalar|Param|null, // Default: "({uid_key}={user_identifier})"
- *             password_attribute?: scalar|Param|null, // Default: null
- *         },
- *         lexik_jwt?: array{
- *             class?: scalar|Param|null, // Default: "Lexik\\Bundle\\JWTAuthenticationBundle\\Security\\User\\JWTUser"
- *         },
- *     }>,
+ *             id?: scalar|Param|null,
+ *             chain?: array{
+ *                 providers?: string|list<scalar|Param|null>,
+ *             },
+ *             entity?: array{
+ *                 class?: scalar|Param|null, // The full entity class name of your user class.
+ *                 property?: scalar|Param|null, // Default: null
+ *                 manager_name?: scalar|Param|null, // Default: null
+ *             },
+ *             memory?: array{
+ *                 users?: array<string, array{ // Default: []
+ *                         password?: scalar|Param|null, // Default: null
+ *                         roles?: string|list<scalar|Param|null>,
+ *                     }>,
+ *             },
+ *             ldap?: array{
+ *                 service?: scalar|Param|null,
+ *                 base_dn?: scalar|Param|null,
+ *                 search_dn?: scalar|Param|null, // Default: null
+ *                 search_password?: scalar|Param|null, // Default: null
+ *                 extra_fields?: list<scalar|Param|null>,
+ *                 default_roles?: string|list<scalar|Param|null>,
+ *                 role_fetcher?: scalar|Param|null, // Default: null
+ *                 uid_key?: scalar|Param|null, // Default: "sAMAccountName"
+ *                 filter?: scalar|Param|null, // Default: "({uid_key}={user_identifier})"
+ *                 password_attribute?: scalar|Param|null, // Default: null
+ *             },
+ *             lexik_jwt?: array{
+ *                 class?: scalar|Param|null, // Default: "Lexik\\Bundle\\JWTAuthenticationBundle\\Security\\User\\JWTUser"
+ *             },
+ *         }>,
  *     firewalls?: array<string, array{ // Default: []
- *         pattern?: scalar|Param|null,
- *         host?: scalar|Param|null,
- *         methods?: string|list<scalar|Param|null>,
- *         security?: bool|Param, // Default: true
- *         user_checker?: scalar|Param|null, // The UserChecker to use when authenticating users in this firewall. // Default: "security.user_checker"
- *         request_matcher?: scalar|Param|null,
- *         access_denied_url?: scalar|Param|null,
- *         access_denied_handler?: scalar|Param|null,
- *         entry_point?: scalar|Param|null, // An enabled authenticator name or a service id that implements "Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface".
- *         provider?: scalar|Param|null,
- *         stateless?: bool|Param, // Default: false
- *         lazy?: bool|Param, // Default: false
- *         context?: scalar|Param|null,
- *         logout?: array{
- *             enable_csrf?: bool|Param|null, // Default: null
- *             csrf_token_id?: scalar|Param|null, // Default: "logout"
- *             csrf_parameter?: scalar|Param|null, // Default: "_csrf_token"
- *             csrf_token_manager?: scalar|Param|null,
- *             path?: scalar|Param|null, // Default: "/logout"
- *             target?: scalar|Param|null, // Default: "/"
- *             invalidate_session?: bool|Param, // Default: true
- *             clear_site_data?: string|list<"*"|"cache"|"cookies"|"storage"|"executionContexts"|Param>,
- *             delete_cookies?: string|array<string, array{ // Default: []
- *                 path?: scalar|Param|null, // Default: null
- *                 domain?: scalar|Param|null, // Default: null
- *                 secure?: scalar|Param|null, // Default: false
- *                 samesite?: scalar|Param|null, // Default: null
- *                 partitioned?: scalar|Param|null, // Default: false
- *             }>,
- *         },
- *         switch_user?: array{
+ *             pattern?: scalar|Param|null,
+ *             host?: scalar|Param|null,
+ *             methods?: string|list<scalar|Param|null>,
+ *             security?: bool|Param, // Default: true
+ *             user_checker?: scalar|Param|null, // The UserChecker to use when authenticating users in this firewall. // Default: "security.user_checker"
+ *             request_matcher?: scalar|Param|null,
+ *             access_denied_url?: scalar|Param|null,
+ *             access_denied_handler?: scalar|Param|null,
+ *             entry_point?: scalar|Param|null, // An enabled authenticator name or a service id that implements "Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface".
  *             provider?: scalar|Param|null,
- *             parameter?: scalar|Param|null, // Default: "_switch_user"
- *             role?: scalar|Param|null, // Default: "ROLE_ALLOWED_TO_SWITCH"
- *             target_route?: scalar|Param|null, // Default: null
- *         },
- *         required_badges?: list<scalar|Param|null>,
- *         custom_authenticators?: list<scalar|Param|null>,
- *         login_throttling?: array{
- *             limiter?: scalar|Param|null, // A service id implementing "Symfony\Component\HttpFoundation\RateLimiter\RequestRateLimiterInterface".
- *             max_attempts?: int|Param, // Default: 5
- *             interval?: scalar|Param|null, // Default: "1 minute"
- *             lock_factory?: scalar|Param|null, // The service ID of the lock factory used by the login rate limiter (or null to disable locking). // Default: null
- *             cache_pool?: string|Param, // The cache pool to use for storing the limiter state // Default: "cache.rate_limiter"
- *             storage_service?: string|Param, // The service ID of a custom storage implementation, this precedes any configured "cache_pool" // Default: null
- *         },
- *         x509?: array{
- *             provider?: scalar|Param|null,
- *             user?: scalar|Param|null, // Default: "SSL_CLIENT_S_DN_Email"
- *             credentials?: scalar|Param|null, // Default: "SSL_CLIENT_S_DN"
- *             user_identifier?: scalar|Param|null, // Default: "emailAddress"
- *         },
- *         remote_user?: array{
- *             provider?: scalar|Param|null,
- *             user?: scalar|Param|null, // Default: "REMOTE_USER"
- *         },
- *         jwt?: array{
- *             provider?: scalar|Param|null, // Default: null
- *             authenticator?: scalar|Param|null, // Default: "lexik_jwt_authentication.security.jwt_authenticator"
- *         },
- *         login_link?: array{
- *             check_route?: scalar|Param|null, // Route that will validate the login link - e.g. "app_login_link_verify".
- *             check_post_only?: scalar|Param|null, // If true, only HTTP POST requests to "check_route" will be handled by the authenticator. // Default: false
- *             signature_properties?: list<scalar|Param|null>,
- *             lifetime?: int|Param, // The lifetime of the login link in seconds. // Default: 600
- *             max_uses?: int|Param, // Max number of times a login link can be used - null means unlimited within lifetime. // Default: null
- *             used_link_cache?: scalar|Param|null, // Cache service id used to expired links of max_uses is set.
- *             success_handler?: scalar|Param|null, // A service id that implements Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface.
- *             failure_handler?: scalar|Param|null, // A service id that implements Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface.
- *             provider?: scalar|Param|null, // The user provider to load users from.
- *             secret?: scalar|Param|null, // Default: "%kernel.secret%"
- *             always_use_default_target_path?: bool|Param, // Default: false
- *             default_target_path?: scalar|Param|null, // Default: "/"
- *             login_path?: scalar|Param|null, // Default: "/login"
- *             target_path_parameter?: scalar|Param|null, // Default: "_target_path"
- *             use_referer?: bool|Param, // Default: false
- *             failure_path?: scalar|Param|null, // Default: null
- *             failure_forward?: bool|Param, // Default: false
- *             failure_path_parameter?: scalar|Param|null, // Default: "_failure_path"
- *         },
- *         form_login?: array{
- *             provider?: scalar|Param|null,
- *             remember_me?: bool|Param, // Default: true
- *             success_handler?: scalar|Param|null,
- *             failure_handler?: scalar|Param|null,
- *             check_path?: scalar|Param|null, // Default: "/login_check"
- *             use_forward?: bool|Param, // Default: false
- *             login_path?: scalar|Param|null, // Default: "/login"
- *             username_parameter?: scalar|Param|null, // Default: "_username"
- *             password_parameter?: scalar|Param|null, // Default: "_password"
- *             csrf_parameter?: scalar|Param|null, // Default: "_csrf_token"
- *             csrf_token_id?: scalar|Param|null, // Default: "authenticate"
- *             enable_csrf?: bool|Param, // Default: false
- *             post_only?: bool|Param, // Default: true
- *             form_only?: bool|Param, // Default: false
- *             always_use_default_target_path?: bool|Param, // Default: false
- *             default_target_path?: scalar|Param|null, // Default: "/"
- *             target_path_parameter?: scalar|Param|null, // Default: "_target_path"
- *             use_referer?: bool|Param, // Default: false
- *             failure_path?: scalar|Param|null, // Default: null
- *             failure_forward?: bool|Param, // Default: false
- *             failure_path_parameter?: scalar|Param|null, // Default: "_failure_path"
- *         },
- *         form_login_ldap?: array{
- *             provider?: scalar|Param|null,
- *             remember_me?: bool|Param, // Default: true
- *             success_handler?: scalar|Param|null,
- *             failure_handler?: scalar|Param|null,
- *             check_path?: scalar|Param|null, // Default: "/login_check"
- *             use_forward?: bool|Param, // Default: false
- *             login_path?: scalar|Param|null, // Default: "/login"
- *             username_parameter?: scalar|Param|null, // Default: "_username"
- *             password_parameter?: scalar|Param|null, // Default: "_password"
- *             csrf_parameter?: scalar|Param|null, // Default: "_csrf_token"
- *             csrf_token_id?: scalar|Param|null, // Default: "authenticate"
- *             enable_csrf?: bool|Param, // Default: false
- *             post_only?: bool|Param, // Default: true
- *             form_only?: bool|Param, // Default: false
- *             always_use_default_target_path?: bool|Param, // Default: false
- *             default_target_path?: scalar|Param|null, // Default: "/"
- *             target_path_parameter?: scalar|Param|null, // Default: "_target_path"
- *             use_referer?: bool|Param, // Default: false
- *             failure_path?: scalar|Param|null, // Default: null
- *             failure_forward?: bool|Param, // Default: false
- *             failure_path_parameter?: scalar|Param|null, // Default: "_failure_path"
- *             service?: scalar|Param|null, // Default: "ldap"
- *             dn_string?: scalar|Param|null, // Default: "{user_identifier}"
- *             query_string?: scalar|Param|null,
- *             search_dn?: scalar|Param|null, // Default: ""
- *             search_password?: scalar|Param|null, // Default: ""
- *         },
- *         json_login?: array{
- *             provider?: scalar|Param|null,
- *             remember_me?: bool|Param, // Default: true
- *             success_handler?: scalar|Param|null,
- *             failure_handler?: scalar|Param|null,
- *             check_path?: scalar|Param|null, // Default: "/login_check"
- *             use_forward?: bool|Param, // Default: false
- *             login_path?: scalar|Param|null, // Default: "/login"
- *             username_path?: scalar|Param|null, // Default: "username"
- *             password_path?: scalar|Param|null, // Default: "password"
- *         },
- *         json_login_ldap?: array{
- *             provider?: scalar|Param|null,
- *             remember_me?: bool|Param, // Default: true
- *             success_handler?: scalar|Param|null,
- *             failure_handler?: scalar|Param|null,
- *             check_path?: scalar|Param|null, // Default: "/login_check"
- *             use_forward?: bool|Param, // Default: false
- *             login_path?: scalar|Param|null, // Default: "/login"
- *             username_path?: scalar|Param|null, // Default: "username"
- *             password_path?: scalar|Param|null, // Default: "password"
- *             service?: scalar|Param|null, // Default: "ldap"
- *             dn_string?: scalar|Param|null, // Default: "{user_identifier}"
- *             query_string?: scalar|Param|null,
- *             search_dn?: scalar|Param|null, // Default: ""
- *             search_password?: scalar|Param|null, // Default: ""
- *         },
- *         access_token?: array{
- *             provider?: scalar|Param|null,
- *             remember_me?: bool|Param, // Default: true
- *             success_handler?: scalar|Param|null,
- *             failure_handler?: scalar|Param|null,
- *             realm?: scalar|Param|null, // Default: null
- *             token_extractors?: string|list<scalar|Param|null>,
- *             token_handler?: string|array{
- *                 id?: scalar|Param|null,
- *                 oidc_user_info?: string|array{
- *                     base_uri?: scalar|Param|null, // Base URI of the userinfo endpoint on the OIDC server, or the OIDC server URI to use the discovery (require "discovery" to be configured).
- *                     discovery?: array{ // Enable the OIDC discovery.
- *                         cache?: array{
- *                             id?: scalar|Param|null, // Cache service id to use to cache the OIDC discovery configuration.
+ *             stateless?: bool|Param, // Default: false
+ *             lazy?: bool|Param, // Default: false
+ *             context?: scalar|Param|null,
+ *             logout?: array{
+ *                 enable_csrf?: bool|Param|null, // Default: null
+ *                 csrf_token_id?: scalar|Param|null, // Default: "logout"
+ *                 csrf_parameter?: scalar|Param|null, // Default: "_csrf_token"
+ *                 csrf_token_manager?: scalar|Param|null,
+ *                 path?: scalar|Param|null, // Default: "/logout"
+ *                 target?: scalar|Param|null, // Default: "/"
+ *                 invalidate_session?: bool|Param, // Default: true
+ *                 clear_site_data?: string|list<"*"|"cache"|"cookies"|"storage"|"executionContexts"|Param>,
+ *                 delete_cookies?: string|array<string, array{ // Default: []
+ *                         path?: scalar|Param|null, // Default: null
+ *                         domain?: scalar|Param|null, // Default: null
+ *                         secure?: scalar|Param|null, // Default: false
+ *                         samesite?: scalar|Param|null, // Default: null
+ *                         partitioned?: scalar|Param|null, // Default: false
+ *                     }>,
+ *             },
+ *             switch_user?: array{
+ *                 provider?: scalar|Param|null,
+ *                 parameter?: scalar|Param|null, // Default: "_switch_user"
+ *                 role?: scalar|Param|null, // Default: "ROLE_ALLOWED_TO_SWITCH"
+ *                 target_route?: scalar|Param|null, // Default: null
+ *             },
+ *             required_badges?: list<scalar|Param|null>,
+ *             custom_authenticators?: list<scalar|Param|null>,
+ *             login_throttling?: array{
+ *                 limiter?: scalar|Param|null, // A service id implementing "Symfony\Component\HttpFoundation\RateLimiter\RequestRateLimiterInterface".
+ *                 max_attempts?: int|Param, // Default: 5
+ *                 interval?: scalar|Param|null, // Default: "1 minute"
+ *                 lock_factory?: scalar|Param|null, // The service ID of the lock factory used by the login rate limiter (or null to disable locking). // Default: null
+ *                 cache_pool?: string|Param, // The cache pool to use for storing the limiter state // Default: "cache.rate_limiter"
+ *                 storage_service?: string|Param, // The service ID of a custom storage implementation, this precedes any configured "cache_pool" // Default: null
+ *             },
+ *             x509?: array{
+ *                 provider?: scalar|Param|null,
+ *                 user?: scalar|Param|null, // Default: "SSL_CLIENT_S_DN_Email"
+ *                 credentials?: scalar|Param|null, // Default: "SSL_CLIENT_S_DN"
+ *                 user_identifier?: scalar|Param|null, // Default: "emailAddress"
+ *             },
+ *             remote_user?: array{
+ *                 provider?: scalar|Param|null,
+ *                 user?: scalar|Param|null, // Default: "REMOTE_USER"
+ *             },
+ *             jwt?: array{
+ *                 provider?: scalar|Param|null, // Default: null
+ *                 authenticator?: scalar|Param|null, // Default: "lexik_jwt_authentication.security.jwt_authenticator"
+ *             },
+ *             login_link?: array{
+ *                 check_route?: scalar|Param|null, // Route that will validate the login link - e.g. "app_login_link_verify".
+ *                 check_post_only?: scalar|Param|null, // If true, only HTTP POST requests to "check_route" will be handled by the authenticator. // Default: false
+ *                 signature_properties?: list<scalar|Param|null>,
+ *                 lifetime?: int|Param, // The lifetime of the login link in seconds. // Default: 600
+ *                 max_uses?: int|Param, // Max number of times a login link can be used - null means unlimited within lifetime. // Default: null
+ *                 used_link_cache?: scalar|Param|null, // Cache service id used to expired links of max_uses is set.
+ *                 success_handler?: scalar|Param|null, // A service id that implements Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface.
+ *                 failure_handler?: scalar|Param|null, // A service id that implements Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface.
+ *                 provider?: scalar|Param|null, // The user provider to load users from.
+ *                 secret?: scalar|Param|null, // Default: "%kernel.secret%"
+ *                 always_use_default_target_path?: bool|Param, // Default: false
+ *                 default_target_path?: scalar|Param|null, // Default: "/"
+ *                 login_path?: scalar|Param|null, // Default: "/login"
+ *                 target_path_parameter?: scalar|Param|null, // Default: "_target_path"
+ *                 use_referer?: bool|Param, // Default: false
+ *                 failure_path?: scalar|Param|null, // Default: null
+ *                 failure_forward?: bool|Param, // Default: false
+ *                 failure_path_parameter?: scalar|Param|null, // Default: "_failure_path"
+ *             },
+ *             form_login?: array{
+ *                 provider?: scalar|Param|null,
+ *                 remember_me?: bool|Param, // Default: true
+ *                 success_handler?: scalar|Param|null,
+ *                 failure_handler?: scalar|Param|null,
+ *                 check_path?: scalar|Param|null, // Default: "/login_check"
+ *                 use_forward?: bool|Param, // Default: false
+ *                 login_path?: scalar|Param|null, // Default: "/login"
+ *                 username_parameter?: scalar|Param|null, // Default: "_username"
+ *                 password_parameter?: scalar|Param|null, // Default: "_password"
+ *                 csrf_parameter?: scalar|Param|null, // Default: "_csrf_token"
+ *                 csrf_token_id?: scalar|Param|null, // Default: "authenticate"
+ *                 enable_csrf?: bool|Param, // Default: false
+ *                 post_only?: bool|Param, // Default: true
+ *                 form_only?: bool|Param, // Default: false
+ *                 always_use_default_target_path?: bool|Param, // Default: false
+ *                 default_target_path?: scalar|Param|null, // Default: "/"
+ *                 target_path_parameter?: scalar|Param|null, // Default: "_target_path"
+ *                 use_referer?: bool|Param, // Default: false
+ *                 failure_path?: scalar|Param|null, // Default: null
+ *                 failure_forward?: bool|Param, // Default: false
+ *                 failure_path_parameter?: scalar|Param|null, // Default: "_failure_path"
+ *             },
+ *             form_login_ldap?: array{
+ *                 provider?: scalar|Param|null,
+ *                 remember_me?: bool|Param, // Default: true
+ *                 success_handler?: scalar|Param|null,
+ *                 failure_handler?: scalar|Param|null,
+ *                 check_path?: scalar|Param|null, // Default: "/login_check"
+ *                 use_forward?: bool|Param, // Default: false
+ *                 login_path?: scalar|Param|null, // Default: "/login"
+ *                 username_parameter?: scalar|Param|null, // Default: "_username"
+ *                 password_parameter?: scalar|Param|null, // Default: "_password"
+ *                 csrf_parameter?: scalar|Param|null, // Default: "_csrf_token"
+ *                 csrf_token_id?: scalar|Param|null, // Default: "authenticate"
+ *                 enable_csrf?: bool|Param, // Default: false
+ *                 post_only?: bool|Param, // Default: true
+ *                 form_only?: bool|Param, // Default: false
+ *                 always_use_default_target_path?: bool|Param, // Default: false
+ *                 default_target_path?: scalar|Param|null, // Default: "/"
+ *                 target_path_parameter?: scalar|Param|null, // Default: "_target_path"
+ *                 use_referer?: bool|Param, // Default: false
+ *                 failure_path?: scalar|Param|null, // Default: null
+ *                 failure_forward?: bool|Param, // Default: false
+ *                 failure_path_parameter?: scalar|Param|null, // Default: "_failure_path"
+ *                 service?: scalar|Param|null, // Default: "ldap"
+ *                 dn_string?: scalar|Param|null, // Default: "{user_identifier}"
+ *                 query_string?: scalar|Param|null,
+ *                 search_dn?: scalar|Param|null, // Default: ""
+ *                 search_password?: scalar|Param|null, // Default: ""
+ *             },
+ *             json_login?: array{
+ *                 provider?: scalar|Param|null,
+ *                 remember_me?: bool|Param, // Default: true
+ *                 success_handler?: scalar|Param|null,
+ *                 failure_handler?: scalar|Param|null,
+ *                 check_path?: scalar|Param|null, // Default: "/login_check"
+ *                 use_forward?: bool|Param, // Default: false
+ *                 login_path?: scalar|Param|null, // Default: "/login"
+ *                 username_path?: scalar|Param|null, // Default: "username"
+ *                 password_path?: scalar|Param|null, // Default: "password"
+ *             },
+ *             json_login_ldap?: array{
+ *                 provider?: scalar|Param|null,
+ *                 remember_me?: bool|Param, // Default: true
+ *                 success_handler?: scalar|Param|null,
+ *                 failure_handler?: scalar|Param|null,
+ *                 check_path?: scalar|Param|null, // Default: "/login_check"
+ *                 use_forward?: bool|Param, // Default: false
+ *                 login_path?: scalar|Param|null, // Default: "/login"
+ *                 username_path?: scalar|Param|null, // Default: "username"
+ *                 password_path?: scalar|Param|null, // Default: "password"
+ *                 service?: scalar|Param|null, // Default: "ldap"
+ *                 dn_string?: scalar|Param|null, // Default: "{user_identifier}"
+ *                 query_string?: scalar|Param|null,
+ *                 search_dn?: scalar|Param|null, // Default: ""
+ *                 search_password?: scalar|Param|null, // Default: ""
+ *             },
+ *             access_token?: array{
+ *                 provider?: scalar|Param|null,
+ *                 remember_me?: bool|Param, // Default: true
+ *                 success_handler?: scalar|Param|null,
+ *                 failure_handler?: scalar|Param|null,
+ *                 realm?: scalar|Param|null, // Default: null
+ *                 token_extractors?: string|list<scalar|Param|null>,
+ *                 token_handler?: string|array{
+ *                     id?: scalar|Param|null,
+ *                     oidc_user_info?: string|array{
+ *                         base_uri?: scalar|Param|null, // Base URI of the userinfo endpoint on the OIDC server, or the OIDC server URI to use the discovery (require "discovery" to be configured).
+ *                         discovery?: array{ // Enable the OIDC discovery.
+ *                             cache?: array{
+ *                                 id?: scalar|Param|null, // Cache service id to use to cache the OIDC discovery configuration.
+ *                             },
  *                         },
+ *                         claim?: scalar|Param|null, // Claim which contains the user identifier (e.g. sub, email, etc.). // Default: "sub"
+ *                         client?: scalar|Param|null, // HttpClient service id to use to call the OIDC server.
  *                     },
- *                     claim?: scalar|Param|null, // Claim which contains the user identifier (e.g. sub, email, etc.). // Default: "sub"
- *                     client?: scalar|Param|null, // HttpClient service id to use to call the OIDC server.
- *                 },
- *                 oidc?: array{
- *                     discovery?: array{ // Enable the OIDC discovery.
- *                         base_uri?: string|list<scalar|Param|null>,
- *                         cache?: array{
- *                             id?: scalar|Param|null, // Cache service id to use to cache the OIDC discovery configuration.
+ *                     oidc?: array{
+ *                         discovery?: array{ // Enable the OIDC discovery.
+ *                             base_uri?: string|list<scalar|Param|null>,
+ *                             cache?: array{
+ *                                 id?: scalar|Param|null, // Cache service id to use to cache the OIDC discovery configuration.
+ *                             },
  *                         },
- *                     },
- *                     claim?: scalar|Param|null, // Claim which contains the user identifier (e.g.: sub, email..). // Default: "sub"
- *                     audience?: scalar|Param|null, // Audience set in the token, for validation purpose.
- *                     issuers?: list<scalar|Param|null>,
- *                     algorithms?: list<scalar|Param|null>,
- *                     keyset?: scalar|Param|null, // JSON-encoded JWKSet used to sign the token (must contain a list of valid public keys).
- *                     encryption?: bool|array{
- *                         enabled?: bool|Param, // Default: false
- *                         enforce?: bool|Param, // When enabled, the token shall be encrypted. // Default: false
+ *                         claim?: scalar|Param|null, // Claim which contains the user identifier (e.g.: sub, email..). // Default: "sub"
+ *                         audience?: scalar|Param|null, // Audience set in the token, for validation purpose.
+ *                         issuers?: list<scalar|Param|null>,
  *                         algorithms?: list<scalar|Param|null>,
- *                         keyset?: scalar|Param|null, // JSON-encoded JWKSet used to decrypt the token (must contain a list of valid private keys).
+ *                         keyset?: scalar|Param|null, // JSON-encoded JWKSet used to sign the token (must contain a list of valid public keys).
+ *                         encryption?: bool|array{
+ *                             enabled?: bool|Param, // Default: false
+ *                             enforce?: bool|Param, // When enabled, the token shall be encrypted. // Default: false
+ *                             algorithms?: list<scalar|Param|null>,
+ *                             keyset?: scalar|Param|null, // JSON-encoded JWKSet used to decrypt the token (must contain a list of valid private keys).
+ *                         },
+ *                     },
+ *                     cas?: array{
+ *                         validation_url?: scalar|Param|null, // CAS server validation URL
+ *                         prefix?: scalar|Param|null, // CAS prefix // Default: "cas"
+ *                         http_client?: scalar|Param|null, // HTTP Client service // Default: null
+ *                     },
+ *                     oauth2?: scalar|Param|null,
+ *                 },
+ *             },
+ *             http_basic?: array{
+ *                 provider?: scalar|Param|null,
+ *                 realm?: scalar|Param|null, // Default: "Secured Area"
+ *             },
+ *             http_basic_ldap?: array{
+ *                 provider?: scalar|Param|null,
+ *                 realm?: scalar|Param|null, // Default: "Secured Area"
+ *                 service?: scalar|Param|null, // Default: "ldap"
+ *                 dn_string?: scalar|Param|null, // Default: "{user_identifier}"
+ *                 query_string?: scalar|Param|null,
+ *                 search_dn?: scalar|Param|null, // Default: ""
+ *                 search_password?: scalar|Param|null, // Default: ""
+ *             },
+ *             remember_me?: array{
+ *                 secret?: scalar|Param|null, // Default: "%kernel.secret%"
+ *                 service?: scalar|Param|null,
+ *                 user_providers?: string|list<scalar|Param|null>,
+ *                 catch_exceptions?: bool|Param, // Default: true
+ *                 signature_properties?: list<scalar|Param|null>,
+ *                 token_provider?: string|array{
+ *                     service?: scalar|Param|null, // The service ID of a custom remember-me token provider.
+ *                     doctrine?: bool|array{
+ *                         enabled?: bool|Param, // Default: false
+ *                         connection?: scalar|Param|null, // Default: null
  *                     },
  *                 },
- *                 cas?: array{
- *                     validation_url?: scalar|Param|null, // CAS server validation URL
- *                     prefix?: scalar|Param|null, // CAS prefix // Default: "cas"
- *                     http_client?: scalar|Param|null, // HTTP Client service // Default: null
- *                 },
- *                 oauth2?: scalar|Param|null,
+ *                 token_verifier?: scalar|Param|null, // The service ID of a custom rememberme token verifier.
+ *                 name?: scalar|Param|null, // Default: "REMEMBERME"
+ *                 lifetime?: int|Param, // Default: 31536000
+ *                 path?: scalar|Param|null, // Default: "/"
+ *                 domain?: scalar|Param|null, // Default: null
+ *                 secure?: true|false|"auto"|Param, // Default: false
+ *                 httponly?: bool|Param, // Default: true
+ *                 samesite?: null|"lax"|"strict"|"none"|Param, // Default: null
+ *                 always_remember_me?: bool|Param, // Default: false
+ *                 remember_me_parameter?: scalar|Param|null, // Default: "_remember_me"
  *             },
- *         },
- *         http_basic?: array{
- *             provider?: scalar|Param|null,
- *             realm?: scalar|Param|null, // Default: "Secured Area"
- *         },
- *         http_basic_ldap?: array{
- *             provider?: scalar|Param|null,
- *             realm?: scalar|Param|null, // Default: "Secured Area"
- *             service?: scalar|Param|null, // Default: "ldap"
- *             dn_string?: scalar|Param|null, // Default: "{user_identifier}"
- *             query_string?: scalar|Param|null,
- *             search_dn?: scalar|Param|null, // Default: ""
- *             search_password?: scalar|Param|null, // Default: ""
- *         },
- *         remember_me?: array{
- *             secret?: scalar|Param|null, // Default: "%kernel.secret%"
- *             service?: scalar|Param|null,
- *             user_providers?: string|list<scalar|Param|null>,
- *             catch_exceptions?: bool|Param, // Default: true
- *             signature_properties?: list<scalar|Param|null>,
- *             token_provider?: string|array{
- *                 service?: scalar|Param|null, // The service ID of a custom remember-me token provider.
- *                 doctrine?: bool|array{
- *                     enabled?: bool|Param, // Default: false
- *                     connection?: scalar|Param|null, // Default: null
- *                 },
- *             },
- *             token_verifier?: scalar|Param|null, // The service ID of a custom rememberme token verifier.
- *             name?: scalar|Param|null, // Default: "REMEMBERME"
- *             lifetime?: int|Param, // Default: 31536000
- *             path?: scalar|Param|null, // Default: "/"
- *             domain?: scalar|Param|null, // Default: null
- *             secure?: true|false|"auto"|Param, // Default: false
- *             httponly?: bool|Param, // Default: true
- *             samesite?: null|"lax"|"strict"|"none"|Param, // Default: null
- *             always_remember_me?: bool|Param, // Default: false
- *             remember_me_parameter?: scalar|Param|null, // Default: "_remember_me"
- *         },
- *     }>,
+ *         }>,
  *     access_control?: list<array{ // Default: []
- *         request_matcher?: scalar|Param|null, // Default: null
- *         requires_channel?: scalar|Param|null, // Default: null
- *         path?: scalar|Param|null, // Use the urldecoded format. // Default: null
- *         host?: scalar|Param|null, // Default: null
- *         port?: int|Param, // Default: null
- *         ips?: string|list<scalar|Param|null>,
- *         attributes?: array<string, scalar|Param|null>,
- *         route?: scalar|Param|null, // Default: null
- *         methods?: string|list<scalar|Param|null>,
- *         allow_if?: scalar|Param|null, // Default: null
- *         roles?: string|list<scalar|Param|null>,
- *     }>,
+ *             request_matcher?: scalar|Param|null, // Default: null
+ *             requires_channel?: scalar|Param|null, // Default: null
+ *             path?: scalar|Param|null, // Use the urldecoded format. // Default: null
+ *             host?: scalar|Param|null, // Default: null
+ *             port?: int|Param, // Default: null
+ *             ips?: string|list<scalar|Param|null>,
+ *             attributes?: array<string, scalar|Param|null>,
+ *             route?: scalar|Param|null, // Default: null
+ *             methods?: string|list<scalar|Param|null>,
+ *             allow_if?: scalar|Param|null, // Default: null
+ *             roles?: string|list<scalar|Param|null>,
+ *         }>,
  *     role_hierarchy?: array<string, string|list<scalar|Param|null>>,
  * }
  * @psalm-type LexikJwtAuthenticationConfig = array{
@@ -1768,15 +1768,15 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     },
  *     remove_token_from_body_when_cookies_used?: scalar|Param|null, // Default: true
  *     set_cookies?: array<string, array{ // Default: []
- *         lifetime?: scalar|Param|null, // The cookie lifetime. If null, the "token_ttl" option value will be used // Default: null
- *         samesite?: "none"|"lax"|"strict"|Param, // Default: "lax"
- *         path?: scalar|Param|null, // Default: "/"
- *         domain?: scalar|Param|null, // Default: null
- *         secure?: scalar|Param|null, // Default: true
- *         httpOnly?: scalar|Param|null, // Default: true
- *         partitioned?: scalar|Param|null, // Default: false
- *         split?: list<scalar|Param|null>,
- *     }>,
+ *             lifetime?: scalar|Param|null, // The cookie lifetime. If null, the "token_ttl" option value will be used // Default: null
+ *             samesite?: "none"|"lax"|"strict"|Param, // Default: "lax"
+ *             path?: scalar|Param|null, // Default: "/"
+ *             domain?: scalar|Param|null, // Default: null
+ *             secure?: scalar|Param|null, // Default: true
+ *             httpOnly?: scalar|Param|null, // Default: true
+ *             partitioned?: scalar|Param|null, // Default: false
+ *             split?: list<scalar|Param|null>,
+ *         }>,
  *     api_platform?: bool|array{ // API Platform compatibility: add check_path in OpenAPI documentation.
  *         enabled?: bool|Param, // Default: false
  *         check_path?: scalar|Param|null, // The login check path to add in OpenAPI. // Default: null

--- a/api/src/ApiResource/Model/PoiSuggestionDto.php
+++ b/api/src/ApiResource/Model/PoiSuggestionDto.php
@@ -31,7 +31,7 @@ final readonly class PoiSuggestionDto
         public float $lon,
         #[ApiProperty(description: 'Straight-line distance from the rider to the POI, in meters.', required: true)]
         public float $distance_m,
-        #[ApiProperty(description: 'Estimated additional kilometers if the rider detours to the POI (0 when no remaining route is known).', required: true)]
+        #[ApiProperty(description: 'Estimated additional meters if the rider detours to the POI (0 when no remaining route is known).', required: true)]
         public float $detour_m,
         #[ApiProperty(description: 'Raw OSM `opening_hours` tag for the current day, when available.')]
         public ?string $opening_hours_today,

--- a/api/src/ApiResource/Model/PoiSuggestionDto.php
+++ b/api/src/ApiResource/Model/PoiSuggestionDto.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ApiResource\Model;
+
+use ApiPlatform\Metadata\ApiProperty;
+
+/**
+ * Wire-shape mirror of {@see \App\InRide\PoiSuggestion::toArray()}.
+ *
+ * Exposing a typed DTO (rather than a raw `?array`) keeps the PHP → OpenAPI
+ * → TypeScript contract honest: every field is documented, the generated
+ * `schema.d.ts` carries the exact shape, and the PWA Zod schema can rely on
+ * the typegen output instead of duplicating the field list.
+ *
+ * Property names are intentionally snake_case to match the JSON the backend
+ * produces — `PoiSuggestion::toArray()` is the canonical serialiser and the
+ * PWA reads `distance_m`/`detour_m`/`opening_hours_today`/… directly.
+ */
+final readonly class PoiSuggestionDto
+{
+    public function __construct(
+        #[ApiProperty(description: 'Display name of the POI.', required: true)]
+        public string $name,
+        #[ApiProperty(description: 'POI category (food, water, shelter, mechanic).', required: true)]
+        public string $category,
+        #[ApiProperty(description: 'POI latitude (WGS84).', required: true)]
+        public float $lat,
+        #[ApiProperty(description: 'POI longitude (WGS84).', required: true)]
+        public float $lon,
+        #[ApiProperty(description: 'Straight-line distance from the rider to the POI, in meters.', required: true)]
+        public float $distance_m,
+        #[ApiProperty(description: 'Estimated additional kilometers if the rider detours to the POI (0 when no remaining route is known).', required: true)]
+        public float $detour_m,
+        #[ApiProperty(description: 'Raw OSM `opening_hours` tag for the current day, when available.')]
+        public ?string $opening_hours_today,
+        #[ApiProperty(description: 'RFC 3339 closing time of the currently-open interval, or null when the POI never closes / is closed.')]
+        public ?string $closes_at,
+        #[ApiProperty(description: 'Optional phone number extracted from the OSM tag.')]
+        public ?string $phone,
+        #[ApiProperty(description: 'Pre-built deeplink the rider can tap to open the POI in their map app.', required: true)]
+        public string $deeplink,
+        #[ApiProperty(description: 'Optional warning surfaced on the POI card (e.g. opening hours unreliable, POI far from route).')]
+        public ?string $warning,
+    ) {
+    }
+
+    /**
+     * @param array{
+     *     name: string,
+     *     category: string,
+     *     lat: float,
+     *     lon: float,
+     *     distance_m: float,
+     *     detour_m: float,
+     *     opening_hours_today: ?string,
+     *     closes_at: ?string,
+     *     phone: ?string,
+     *     deeplink: string,
+     *     warning: ?string,
+     * } $payload
+     */
+    public static function fromArray(array $payload): self
+    {
+        return new self(
+            name: $payload['name'],
+            category: $payload['category'],
+            lat: $payload['lat'],
+            lon: $payload['lon'],
+            distance_m: $payload['distance_m'],
+            detour_m: $payload['detour_m'],
+            opening_hours_today: $payload['opening_hours_today'],
+            closes_at: $payload['closes_at'],
+            phone: $payload['phone'],
+            deeplink: $payload['deeplink'],
+            warning: $payload['warning'],
+        );
+    }
+}

--- a/api/src/ApiResource/TripChatRequest.php
+++ b/api/src/ApiResource/TripChatRequest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\ApiResource;
 
 use ApiPlatform\Metadata\ApiProperty;
+use App\ApiResource\Model\GeoPosition;
 use App\ApiResource\Model\TripChatContext;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -13,6 +14,10 @@ use Symfony\Component\Validator\Constraints as Assert;
  *
  * Carries the user's natural-language message along with a small context object
  * so the LLaMA 3B dialogue assistant can interpret stage-relative references.
+ *
+ * When {@see $position} is provided (i.e. the rider is in-ride), the processor
+ * delegates to the {@see \App\InRide\InRideAssistant} and returns POI
+ * suggestions instead of planning actions.
  */
 final class TripChatRequest
 {
@@ -24,6 +29,9 @@ final class TripChatRequest
         #[Assert\Valid]
         #[ApiProperty(description: 'Conversational context (e.g. the stage currently consulted in the UI).')]
         public ?TripChatContext $context = null,
+        #[Assert\Valid]
+        #[ApiProperty(description: 'Optional rider GPS position. When provided, switches the assistant to in-ride POI search mode.')]
+        public ?GeoPosition $position = null,
     ) {
     }
 }

--- a/api/src/ApiResource/TripChatResponse.php
+++ b/api/src/ApiResource/TripChatResponse.php
@@ -6,20 +6,26 @@ namespace App\ApiResource;
 
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
+use App\ApiResource\Model\PoiSuggestionDto;
 
 /**
  * Output DTO for the trip chat endpoint.
  *
  * Contains the structured action interpreted by the dialogue assistant alongside
  * the conversational response surfaced to the user in the chat panel.
+ *
+ * When the request carries a GPS {@see TripChatRequest::$position}, the
+ * processor switches to in-ride mode and populates {@see $pois} with the
+ * top-3 POI suggestions returned by {@see \App\InRide\InRideAssistant}.
  */
 #[ApiResource(shortName: 'TripChat', operations: [])]
 final readonly class TripChatResponse
 {
     /**
-     * @param array<string, mixed> $params
-     * @param list<int>            $impactedStageNumbers Day numbers (1-indexed) whose recomputation has been dispatched.
-     *                                                   Empty when the action is informational or requires full analysis.
+     * @param array<string, mixed>        $params
+     * @param list<int>                   $impactedStageNumbers Day numbers (1-indexed) whose recomputation has been dispatched.
+     *                                                          Empty when the action is informational or requires full analysis.
+     * @param list<PoiSuggestionDto>|null $pois                 top POIs suggested in in-ride mode (null in planning mode)
      */
     public function __construct(
         #[ApiProperty(description: 'Trip identifier (UUID v7) the chat exchange belongs to.', required: true)]
@@ -36,6 +42,8 @@ final readonly class TripChatResponse
         public array $impactedStageNumbers = [],
         #[ApiProperty(description: 'True when the action requires a full trip re-analysis (Acte 2).')]
         public bool $requiresFullAnalysis = false,
+        #[ApiProperty(description: 'Top POI suggestions (only set in in-ride mode when GPS position is provided).')]
+        public ?array $pois = null,
     ) {
     }
 }

--- a/api/src/ApiResource/TripChatResponse.php
+++ b/api/src/ApiResource/TripChatResponse.php
@@ -22,10 +22,10 @@ use App\ApiResource\Model\PoiSuggestionDto;
 final readonly class TripChatResponse
 {
     /**
-     * @param array<string, mixed>        $params
-     * @param list<int>                   $impactedStageNumbers Day numbers (1-indexed) whose recomputation has been dispatched.
-     *                                                          Empty when the action is informational or requires full analysis.
-     * @param list<PoiSuggestionDto>|null $pois                 top POIs suggested in in-ride mode (null in planning mode)
+     * @param array<string, mixed>   $params
+     * @param list<int>              $impactedStageNumbers Day numbers (1-indexed) whose recomputation has been dispatched.
+     *                                                     Empty when the action is informational or requires full analysis.
+     * @param list<PoiSuggestionDto> $pois                 top POIs suggested in in-ride mode (empty in planning mode)
      */
     public function __construct(
         #[ApiProperty(description: 'Trip identifier (UUID v7) the chat exchange belongs to.', required: true)]
@@ -42,8 +42,8 @@ final readonly class TripChatResponse
         public array $impactedStageNumbers = [],
         #[ApiProperty(description: 'True when the action requires a full trip re-analysis (Acte 2).')]
         public bool $requiresFullAnalysis = false,
-        #[ApiProperty(description: 'Top POI suggestions (only set in in-ride mode when GPS position is provided).')]
-        public ?array $pois = null,
+        #[ApiProperty(description: 'Top POI suggestions (empty in planning mode, populated in in-ride mode when GPS position is provided).')]
+        public array $pois = [],
     ) {
     }
 }

--- a/api/src/InRide/InRideAssistant.php
+++ b/api/src/InRide/InRideAssistant.php
@@ -35,10 +35,9 @@ use Symfony\Contracts\Cache\ItemInterface;
  *     intent carries an `open_for_minutes` constraint, only POIs that remain
  *     open at least that long are kept.
  *  4. {@see DetourCalculator} approximates the detour required to visit each
- *     POI. The remaining route polyline is provided by the caller (the
- *     frontend store keeps it in memory) — when none is supplied, the rider
- *     position is used as a single-point polyline and detours collapse to the
- *     straight-line distance.
+ *     POI. The remaining-route polyline is provided by the caller (the
+ *     frontend store keeps it in memory); when none is supplied the detour
+ *     stays at 0 because there is no rejoin point to measure against.
  *  5. Top-3 POIs are picked using a score of "proximity × low-detour" and
  *     enriched with {@see DeeplinkBuilder} navigation URLs.
  *  6. The LLM is given a deterministic JSON view of the selected POIs (via the
@@ -107,9 +106,12 @@ final readonly class InRideAssistant
 
         $rawElements = $this->fetchPois($center, $intent);
 
-        $polyline = [] === $remainingRoute ? [$center] : $remainingRoute;
-
-        $suggestions = $this->buildSuggestions($rawElements, $center, $polyline, $intent, $now);
+        // When the rider hasn't shared a remaining-route polyline, we have no
+        // notion of "rejoining" the planned itinerary — a single-point
+        // polyline would yield a detour ≈ 2 × straight-line (out-and-back),
+        // which is misleading. Pass an empty polyline so buildSuggestions
+        // can record `detour_m = 0` for these rows.
+        $suggestions = $this->buildSuggestions($rawElements, $center, $remainingRoute, $intent, $now);
 
         // Rank by combined "distance + DETOUR_WEIGHT × detour" score.
         usort(
@@ -265,10 +267,17 @@ final readonly class InRideAssistant
                 }
             }
 
-            $detour = $this->detourCalculator->calculate($center, $poiPoint, $polyline);
-
-            if ($detour->poiFarFromRoute && null === $warning) {
-                $warning = 'Éloigné de l\'itinéraire';
+            if ([] === $polyline) {
+                // Without a planned itinerary we have no rejoin point to
+                // measure against, so the "detour" cost is unknown — surface
+                // it as 0 instead of fabricating a 2× round-trip estimate.
+                $detourMeters = 0.0;
+            } else {
+                $detour = $this->detourCalculator->calculate($center, $poiPoint, $polyline);
+                $detourMeters = $detour->detourMeters;
+                if ($detour->poiFarFromRoute && null === $warning) {
+                    $warning = 'Éloigné de l\'itinéraire';
+                }
             }
 
             $deeplink = $this->deeplinkBuilder->googleMapsBicycling($center, $poiPoint);
@@ -279,7 +288,7 @@ final readonly class InRideAssistant
                 lat: $poiPoint->lat,
                 lon: $poiPoint->lon,
                 distanceMeters: $straightLine,
-                detourMeters: $detour->detourMeters,
+                detourMeters: $detourMeters,
                 openingHoursToday: $openingHoursTag,
                 closesAt: $closesAt,
                 phone: \is_string($tags['phone'] ?? null) ? $tags['phone'] : (\is_string($tags['contact:phone'] ?? null) ? $tags['contact:phone'] : null),

--- a/api/src/Llm/ChatActionInterpreter.php
+++ b/api/src/Llm/ChatActionInterpreter.php
@@ -142,6 +142,9 @@ final readonly class ChatActionInterpreter
             ChatAction::ACTION_ADJUST_DISTANCE => $this->normaliseAdjustDistance($params),
             ChatAction::ACTION_CHANGE_ROUTE => [],
             ChatAction::ACTION_INFO => [],
+            // `find_poi` is intentionally absent from ChatAction::SUPPORTED_ACTIONS,
+            // so the action check upstream already collapses any planning-mode
+            // hallucination to `info` before reaching this normaliser.
             default => null,
         };
     }

--- a/api/src/Llm/Dto/ChatAction.php
+++ b/api/src/Llm/Dto/ChatAction.php
@@ -29,6 +29,16 @@ final readonly class ChatAction
     public const string ACTION_INFO = 'info';
 
     /**
+     * `find_poi` is exclusively driven by the in-ride pipeline
+     * ({@see \App\State\TripChatProcessor::processInRide()}), which constructs
+     * a `ChatAction` directly and bypasses {@see \App\Llm\ChatActionInterpreter}.
+     * It is intentionally NOT included in {@see self::SUPPORTED_ACTIONS} so the
+     * planning interpreter rejects any hallucinated `find_poi` emission and
+     * collapses it to `info`.
+     */
+    public const string ACTION_FIND_POI = 'find_poi';
+
+    /**
      * @var list<string>
      */
     public const array SUPPORTED_ACTIONS = [

--- a/api/src/State/TripChatProcessor.php
+++ b/api/src/State/TripChatProcessor.php
@@ -143,7 +143,7 @@ final readonly class TripChatProcessor implements ProcessorInterface
         // POI search mode. The planning pipeline (dialogue prompt, action
         // interpreter, Messenger dispatch) is bypassed entirely.
         if ($data->position instanceof GeoPosition) {
-            return $this->processInRide($tripId, $userId, $data);
+            return $this->processInRide($user, $tripId, $userId, $data);
         }
 
         $systemPrompt = $this->promptLoader->load(self::PROMPT_NAME);
@@ -356,7 +356,7 @@ final readonly class TripChatProcessor implements ProcessorInterface
      * a response carrying the `find_poi` action together with the structured
      * POI suggestions.
      */
-    private function processInRide(string $tripId, string $userId, TripChatRequest $data): TripChatResponse
+    private function processInRide(User $user, string $tripId, string $userId, TripChatRequest $data): TripChatResponse
     {
         \assert($data->position instanceof GeoPosition);
 
@@ -372,6 +372,21 @@ final readonly class TripChatProcessor implements ProcessorInterface
             ['role' => 'user', 'content' => $data->message],
             ['role' => 'assistant', 'content' => $response->narrative],
         ]);
+
+        // In-ride turns must also reach PostgreSQL so the rider's full chat
+        // history (planning + in-ride) survives a page reload. The geo/pois
+        // columns required to faithfully rehydrate POI cards land in #465.
+        $this->persistChatTurn(
+            $tripId,
+            $user,
+            $data->message,
+            $response->narrative,
+            new ChatAction(
+                action: ChatAction::ACTION_FIND_POI,
+                params: ['category' => $response->category],
+                response: $response->narrative,
+            ),
+        );
 
         return new TripChatResponse(
             tripId: $tripId,

--- a/api/src/State/TripChatProcessor.php
+++ b/api/src/State/TripChatProcessor.php
@@ -4,15 +4,17 @@ declare(strict_types=1);
 
 namespace App\State;
 
+use App\ApiResource\Model\GeoPosition;
+use App\ApiResource\Model\PoiSuggestionDto;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\Metadata\Post;
 use ApiPlatform\State\ProcessorInterface;
 use App\ApiResource\TripChatRequest;
 use App\ApiResource\TripChatResponse;
-use App\ApiResource\TripRequest;
-use App\Entity\TripChatMessage;
 use App\Entity\User;
 use App\ComputationTracker\TripGenerationTrackerInterface;
+use App\InRide\InRideAssistant;
+use App\InRide\PoiSuggestion;
 use App\Llm\ChatActionInterpreter;
 use App\Llm\ChatHistoryStore;
 use App\Llm\Dto\ChatAction;
@@ -21,7 +23,6 @@ use App\Llm\LlmClientInterface;
 use App\Llm\SystemPromptLoader;
 use App\Message\RecalculateStages;
 use App\Repository\TripRequestRepositoryInterface;
-use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
@@ -85,9 +86,9 @@ final readonly class TripChatProcessor implements ProcessorInterface
         private LoggerInterface $logger,
         private MessageBusInterface $messageBus,
         private TripGenerationTrackerInterface $generationTracker,
+        private InRideAssistant $inRideAssistant,
         #[Autowire(service: 'limiter.trip_chat')]
         private RateLimiterFactory $tripChatLimiter,
-        private ?EntityManagerInterface $entityManager = null,
         #[Autowire(env: 'default::OLLAMA_DIALOGUE_MODEL')]
         ?string $model = null,
     ) {
@@ -134,6 +135,13 @@ final readonly class TripChatProcessor implements ProcessorInterface
             throw new TooManyRequestsHttpException(retryAfter: $secondsUntilRetry, message: 'Chat rate limit reached. Please wait a moment before retrying.');
         }
 
+        // In-ride branch: the rider's GPS position switches the assistant into
+        // POI search mode. The planning pipeline (dialogue prompt, action
+        // interpreter, Messenger dispatch) is bypassed entirely.
+        if ($data->position instanceof GeoPosition) {
+            return $this->processInRide($tripId, $userId, $data);
+        }
+
         $systemPrompt = $this->promptLoader->load(self::PROMPT_NAME);
         $userMessage = $this->buildUserMessage($data);
         $history = $this->historyStore->get($tripId, $userId);
@@ -176,8 +184,6 @@ final readonly class TripChatProcessor implements ProcessorInterface
             ['role' => 'user', 'content' => $userMessage],
             ['role' => 'assistant', 'content' => $rawContent],
         ]);
-
-        $this->persistChatTurn($tripId, $user, $userMessage, $rawContent, $action);
 
         $impactedStageNumbers = $this->resolveImpactedStageNumbers($tripId, $action);
         $requiresFullAnalysis = ChatAction::ACTION_CHANGE_ROUTE === $action->action;
@@ -340,65 +346,43 @@ final readonly class TripChatProcessor implements ProcessorInterface
     }
 
     /**
-     * Writes the user prompt + assistant reply to PostgreSQL alongside the Redis
-     * context window (cf. #458). Failures are logged but never bubble up so a
-     * transient DB hiccup cannot abort an otherwise successful chat turn — the
-     * Redis history remains authoritative for the next LLM call either way.
+     * In-ride mode: delegate POI search to {@see InRideAssistant} and return
+     * a response carrying the `find_poi` action together with the structured
+     * POI suggestions.
      */
-    private function persistChatTurn(
-        string $tripId,
-        User $user,
-        string $userMessage,
-        string $assistantContent,
-        ChatAction $action,
-    ): void {
-        if (!$this->entityManager instanceof EntityManagerInterface) {
-            return;
-        }
+    private function processInRide(string $tripId, string $userId, TripChatRequest $data): TripChatResponse
+    {
+        \assert($data->position instanceof GeoPosition);
 
-        try {
-            $trip = $this->entityManager->getReference(TripRequest::class, $tripId);
-            if (!$trip instanceof TripRequest) {
-                return;
-            }
+        // InRideAssistant::assist() already catches OllamaUnavailableException
+        // and produces a markdown fallback narrative, so we do not re-wrap it
+        // here.
+        $response = $this->inRideAssistant->assist(
+            message: $data->message,
+            position: $data->position,
+        );
 
-            $userTurn = new TripChatMessage(
-                trip: $trip,
-                user: $user,
-                role: TripChatMessage::ROLE_USER,
-                content: $userMessage,
-            );
-            $assistantTurn = new TripChatMessage(
-                trip: $trip,
-                user: $user,
-                role: TripChatMessage::ROLE_ASSISTANT,
-                content: $assistantContent,
-                action: $action->action,
-            );
+        $this->historyStore->appendMany($tripId, $userId, [
+            ['role' => 'user', 'content' => $data->message],
+            ['role' => 'assistant', 'content' => $response->narrative],
+        ]);
 
-            // `wrapInTransaction` gives us atomicity (both turns persisted or
-            // neither) — it does NOT scope the UoW, since Doctrine ORM 3
-            // dropped the optional `flush($entity)` argument. In our request
-            // lifecycle the chat processor is the last writer (API Platform
-            // processors run after input validation, no other entities are
-            // dirty by then), so a wider flush is acceptable in practice;
-            // the transaction keeps the rollback semantics if the persist or
-            // FK validation fails partway through.
-            $this->entityManager->wrapInTransaction(function () use ($userTurn, $assistantTurn): void {
-                $this->entityManager->persist($userTurn);
-                $this->entityManager->persist($assistantTurn);
-                $this->entityManager->flush();
-            });
-        } catch (\Throwable $throwable) {
-            // Proxy-load failures surface here at `flush()` time, not at `getReference()`;
-            // a missing trip yields a foreign-key violation that we log and swallow so the
-            // Redis sliding-window context (already updated) remains authoritative for the
-            // current request.
-            $this->logger->warning('Failed to persist trip chat history to PostgreSQL.', [
-                'tripId' => $tripId,
-                'error' => $throwable->getMessage(),
-            ]);
-        }
+        return new TripChatResponse(
+            tripId: $tripId,
+            action: ChatAction::ACTION_FIND_POI,
+            params: ['category' => $response->category],
+            response: $response->narrative,
+            dispatched: false,
+            impactedStageNumbers: [],
+            requiresFullAnalysis: false,
+            // API Platform serialises PoiSuggestionDto's public snake_case
+            // properties directly, so the wire JSON matches the snake_case
+            // contract the PWA Zod schema and PoiCard rendering expect.
+            pois: array_map(
+                static fn (PoiSuggestion $p): PoiSuggestionDto => PoiSuggestionDto::fromArray($p->toArray()),
+                $response->pois,
+            ),
+        );
     }
 
     private function buildUserMessage(TripChatRequest $request): string

--- a/api/src/State/TripChatProcessor.php
+++ b/api/src/State/TripChatProcessor.php
@@ -11,6 +11,8 @@ use ApiPlatform\Metadata\Post;
 use ApiPlatform\State\ProcessorInterface;
 use App\ApiResource\TripChatRequest;
 use App\ApiResource\TripChatResponse;
+use App\ApiResource\TripRequest;
+use App\Entity\TripChatMessage;
 use App\Entity\User;
 use App\ComputationTracker\TripGenerationTrackerInterface;
 use App\InRide\InRideAssistant;
@@ -23,6 +25,7 @@ use App\Llm\LlmClientInterface;
 use App\Llm\SystemPromptLoader;
 use App\Message\RecalculateStages;
 use App\Repository\TripRequestRepositoryInterface;
+use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
@@ -91,6 +94,7 @@ final readonly class TripChatProcessor implements ProcessorInterface
         private RateLimiterFactory $tripChatLimiter,
         #[Autowire(env: 'default::OLLAMA_DIALOGUE_MODEL')]
         ?string $model = null,
+        private ?EntityManagerInterface $entityManager = null,
     ) {
         $this->model = (null === $model || '' === $model) ? self::DEFAULT_MODEL : $model;
     }
@@ -184,6 +188,8 @@ final readonly class TripChatProcessor implements ProcessorInterface
             ['role' => 'user', 'content' => $userMessage],
             ['role' => 'assistant', 'content' => $rawContent],
         ]);
+
+        $this->persistChatTurn($tripId, $user, $userMessage, $rawContent, $action);
 
         $impactedStageNumbers = $this->resolveImpactedStageNumbers($tripId, $action);
         $requiresFullAnalysis = ChatAction::ACTION_CHANGE_ROUTE === $action->action;
@@ -383,6 +389,72 @@ final readonly class TripChatProcessor implements ProcessorInterface
                 $response->pois,
             ),
         );
+    }
+
+    /**
+     * Writes the user prompt + assistant reply to PostgreSQL alongside the Redis
+     * context window (cf. #458). Failures are logged but never bubble up so a
+     * transient DB hiccup cannot abort an otherwise successful chat turn — the
+     * Redis history remains authoritative for the next LLM call either way.
+     */
+    private function persistChatTurn(
+        string $tripId,
+        User $user,
+        string $userMessage,
+        string $assistantContent,
+        ChatAction $action,
+    ): void {
+        // Pin the EntityManager to a local variable so PHPStan keeps the
+        // non-null narrowing inside the wrapInTransaction closure (Level 9
+        // does not carry property-type narrowing across closure boundaries).
+        $entityManager = $this->entityManager;
+        if (!$entityManager instanceof EntityManagerInterface) {
+            return;
+        }
+
+        try {
+            $trip = $entityManager->getReference(TripRequest::class, $tripId);
+            if (!$trip instanceof TripRequest) {
+                return;
+            }
+
+            $userTurn = new TripChatMessage(
+                trip: $trip,
+                user: $user,
+                role: TripChatMessage::ROLE_USER,
+                content: $userMessage,
+            );
+            $assistantTurn = new TripChatMessage(
+                trip: $trip,
+                user: $user,
+                role: TripChatMessage::ROLE_ASSISTANT,
+                content: $assistantContent,
+                action: $action->action,
+            );
+
+            // `wrapInTransaction` gives us atomicity (both turns persisted or
+            // neither) — it does NOT scope the UoW, since Doctrine ORM 3
+            // dropped the optional `flush($entity)` argument. In our request
+            // lifecycle the chat processor is the last writer (API Platform
+            // processors run after input validation, no other entities are
+            // dirty by then), so a wider flush is acceptable in practice;
+            // the transaction keeps the rollback semantics if the persist or
+            // FK validation fails partway through.
+            $entityManager->wrapInTransaction(static function () use ($entityManager, $userTurn, $assistantTurn): void {
+                $entityManager->persist($userTurn);
+                $entityManager->persist($assistantTurn);
+                $entityManager->flush();
+            });
+        } catch (\Throwable $throwable) {
+            // Proxy-load failures surface here at `flush()` time, not at `getReference()`;
+            // a missing trip yields a foreign-key violation that we log and swallow so the
+            // Redis sliding-window context (already updated) remains authoritative for the
+            // current request.
+            $this->logger->warning('Failed to persist trip chat history to PostgreSQL.', [
+                'tripId' => $tripId,
+                'error' => $throwable->getMessage(),
+            ]);
+        }
     }
 
     private function buildUserMessage(TripChatRequest $request): string

--- a/api/tests/Integration/TripChatInRideTest.php
+++ b/api/tests/Integration/TripChatInRideTest.php
@@ -1,0 +1,297 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration;
+
+use ApiPlatform\Metadata\Post;
+use App\ApiResource\Model\Coordinate;
+use App\ApiResource\Model\GeoPosition;
+use App\ApiResource\Stage;
+use App\ApiResource\TripChatRequest;
+use App\ApiResource\TripRequest;
+use App\ComputationTracker\TripGenerationTrackerInterface;
+use App\Entity\User;
+use App\Geo\HaversineDistance;
+use App\InRide\DeeplinkBuilder;
+use App\InRide\DetourCalculator;
+use App\InRide\InRideAssistant;
+use App\InRide\OpeningHoursParser;
+use App\InRide\PoiIntentDetector;
+use App\InRide\PoiSuggestion;
+use App\Llm\ChatActionInterpreter;
+use App\Llm\ChatHistoryStore;
+use App\Llm\Dto\ChatAction;
+use App\Llm\LlmClientInterface;
+use App\Llm\SystemPromptLoader;
+use App\Message\RecalculateStages;
+use App\Repository\TripRequestRepositoryInterface;
+use App\Scanner\OsmOverpassQueryBuilder;
+use App\Scanner\ScannerInterface;
+use App\State\TripChatProcessor;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Integration: verifies that {@see TripChatProcessor} switches to in-ride
+ * mode when a GPS position is present in the payload, delegating to the
+ * {@see InRideAssistant} and surfacing the top-3 POI suggestions in the
+ * response (issue #463).
+ */
+#[AllowMockObjectsWithoutExpectations]
+final class TripChatInRideTest extends TestCase
+{
+    private const string TRIP_ID = '01936f6e-0000-7000-8000-000000000200';
+
+    private string $promptFixtureDir = '';
+
+    #[\Override]
+    protected function tearDown(): void
+    {
+        if ('' === $this->promptFixtureDir || !is_dir($this->promptFixtureDir)) {
+            return;
+        }
+
+        foreach (glob($this->promptFixtureDir.'/*') ?: [] as $file) {
+            @unlink($file);
+        }
+
+        @rmdir($this->promptFixtureDir);
+    }
+
+    #[Test]
+    public function positionInPayloadDelegatesToInRideAssistantAndReturnsTopPois(): void
+    {
+        $bus = $this->newMessageBus();
+        $scanner = $this->createMock(ScannerInterface::class);
+        $scanner->expects($this->once())->method('query')->willReturn([
+            'elements' => [
+                [
+                    'type' => 'node',
+                    'lat' => 50.8504,
+                    'lon' => 4.3520,
+                    'tags' => ['name' => 'Fontaine du Sablon'],
+                ],
+                [
+                    'type' => 'node',
+                    'lat' => 50.8550,
+                    'lon' => 4.3600,
+                    'tags' => ['name' => 'Fontaine Royale'],
+                ],
+                [
+                    'type' => 'node',
+                    'lat' => 50.8600,
+                    'lon' => 4.3650,
+                    'tags' => ['name' => 'Fontaine de la Place'],
+                ],
+                [
+                    'type' => 'node',
+                    'lat' => 50.8700,
+                    'lon' => 4.3700,
+                    'tags' => ['name' => 'Fontaine du Parc'],
+                ],
+            ],
+        ]);
+
+        $llm = $this->createMock(LlmClientInterface::class);
+        $llm->method('isEnabled')->willReturn(true);
+        $llm->method('generate')->willReturnCallback(
+            static function (string $model, string $prompt, ?string $systemPrompt = null, array $options = []): array {
+                // The intent detector sends the raw user message; the narrative
+                // generator sends a JSON payload.
+                if (str_starts_with(trim($prompt), '{')) {
+                    return ['response' => "Voici l'eau la plus proche."];
+                }
+
+                return ['response' => '{"category":"water","max_distance_m":3000}'];
+            },
+        );
+
+        $processor = $this->newProcessor($llm, $scanner, $bus);
+
+        $response = $processor->process(
+            new TripChatRequest(
+                message: "Je cherche un point d'eau",
+                context: null,
+                position: new GeoPosition(50.8503, 4.3517),
+            ),
+            new Post(),
+            ['id' => self::TRIP_ID],
+        );
+
+        self::assertSame(ChatAction::ACTION_FIND_POI, $response->action);
+        self::assertSame(['category' => PoiSuggestion::CATEGORY_WATER], $response->params);
+        self::assertFalse($response->dispatched);
+        self::assertSame([], $response->impactedStageNumbers);
+        self::assertFalse($response->requiresFullAnalysis);
+        self::assertSame("Voici l'eau la plus proche.", $response->response);
+
+        self::assertIsArray($response->pois);
+        // Top-3 capped, in proximity order.
+        self::assertCount(3, $response->pois);
+        self::assertSame('Fontaine du Sablon', $response->pois[0]->name);
+        self::assertSame(PoiSuggestion::CATEGORY_WATER, $response->pois[0]->category);
+
+        // No planning action dispatched in in-ride mode.
+        self::assertSame([], $this->collectDispatched($bus, RecalculateStages::class));
+    }
+
+    #[Test]
+    public function unknownIntentInInRideModeReturnsEmptyPoisAndExplanatoryResponse(): void
+    {
+        $scanner = $this->createMock(ScannerInterface::class);
+        $scanner->expects($this->never())->method('query');
+
+        $llm = $this->createMock(LlmClientInterface::class);
+        $llm->method('isEnabled')->willReturn(true);
+        $llm->method('generate')->willReturn([
+            'response' => '{"category":"unknown","max_distance_m":3000}',
+        ]);
+
+        $processor = $this->newProcessor($llm, $scanner, $this->newMessageBus());
+
+        $response = $processor->process(
+            new TripChatRequest(
+                message: 'Quelle est la météo ?',
+                context: null,
+                position: new GeoPosition(50.8503, 4.3517),
+            ),
+            new Post(),
+            ['id' => self::TRIP_ID],
+        );
+
+        self::assertSame(ChatAction::ACTION_FIND_POI, $response->action);
+        self::assertSame(['category' => PoiSuggestion::CATEGORY_UNKNOWN], $response->params);
+        self::assertIsArray($response->pois);
+        self::assertSame([], $response->pois);
+        self::assertStringContainsString("point d'intérêt", $response->response);
+    }
+
+    private function newProcessor(
+        LlmClientInterface $llm,
+        ScannerInterface $scanner,
+        MessageBusInterface $messageBus,
+    ): TripChatProcessor {
+        $tripRequest = new TripRequest();
+        $stages = [
+            new Stage(
+                tripId: self::TRIP_ID,
+                dayNumber: 1,
+                distance: 50.0,
+                elevation: 200.0,
+                startPoint: new Coordinate(48.0, 2.0, 0.0),
+                endPoint: new Coordinate(48.1, 2.1, 0.0),
+            ),
+        ];
+
+        $repository = $this->createStub(TripRequestRepositoryInterface::class);
+        $repository->method('getRequest')->willReturn($tripRequest);
+        $repository->method('getStages')->willReturn($stages);
+
+        $promptLoader = new SystemPromptLoader($this->createPromptFixtureDir());
+        $historyStore = new ChatHistoryStore(new ArrayAdapter());
+
+        $generationTracker = $this->createStub(TripGenerationTrackerInterface::class);
+        $generationTracker->method('increment')->willReturn(1);
+
+        $user = new User('chat@example.com', Uuid::v7());
+
+        $security = $this->createStub(Security::class);
+        $security->method('getUser')->willReturn($user);
+
+        $distance = new HaversineDistance();
+        $inRideAssistant = new InRideAssistant(
+            intentDetector: new PoiIntentDetector($llm),
+            scanner: $scanner,
+            queryBuilder: new OsmOverpassQueryBuilder(),
+            openingHoursParser: new OpeningHoursParser(),
+            detourCalculator: new DetourCalculator($distance),
+            deeplinkBuilder: new DeeplinkBuilder(),
+            distance: $distance,
+            llmClient: $llm,
+            promptLoader: $promptLoader,
+            cache: new ArrayAdapter(),
+        );
+
+        return new TripChatProcessor(
+            tripStateManager: $repository,
+            llmClient: $llm,
+            promptLoader: $promptLoader,
+            interpreter: new ChatActionInterpreter(new NullLogger()),
+            historyStore: $historyStore,
+            security: $security,
+            logger: new NullLogger(),
+            messageBus: $messageBus,
+            generationTracker: $generationTracker,
+            inRideAssistant: $inRideAssistant,
+            tripChatLimiter: $this->newNoLimiterFactory(),
+        );
+    }
+
+    private function createPromptFixtureDir(): string
+    {
+        $dir = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'trip-chat-in-ride-prompts-'.bin2hex(random_bytes(4));
+        mkdir($dir, 0o775, true);
+        file_put_contents($dir.\DIRECTORY_SEPARATOR.'dialogue.txt', 'SYSTEM PROMPT');
+        file_put_contents($dir.\DIRECTORY_SEPARATOR.'in-ride.txt', 'Respond with markdown narrative.');
+        $this->promptFixtureDir = $dir;
+
+        return $dir;
+    }
+
+    private function newMessageBus(): MessageBusInterface
+    {
+        return new class () implements MessageBusInterface {
+            /** @var list<Envelope> */
+            public array $dispatched = [];
+
+            public function dispatch(object $message, array $stamps = []): Envelope
+            {
+                $envelope = $message instanceof Envelope ? $message : new Envelope($message, $stamps);
+                $this->dispatched[] = $envelope;
+
+                return $envelope;
+            }
+        };
+    }
+
+    /**
+     * @template T of object
+     *
+     * @param class-string<T> $messageClass
+     *
+     * @return list<T>
+     */
+    private function collectDispatched(MessageBusInterface $bus, string $messageClass): array
+    {
+        \assert(property_exists($bus, 'dispatched'));
+
+        $collected = [];
+        /** @var Envelope $envelope */
+        foreach ($bus->dispatched as $envelope) {
+            $message = $envelope->getMessage();
+            if ($message instanceof $messageClass) {
+                $collected[] = $message;
+            }
+        }
+
+        return $collected;
+    }
+
+    private function newNoLimiterFactory(): RateLimiterFactory
+    {
+        return new RateLimiterFactory(
+            ['id' => 'trip_chat_in_ride_test', 'policy' => 'no_limit'],
+            new InMemoryStorage(),
+        );
+    }
+}

--- a/api/tests/Integration/TripChatInRideTest.php
+++ b/api/tests/Integration/TripChatInRideTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Integration;
 
+use Doctrine\ORM\EntityManagerInterface;
 use ApiPlatform\Metadata\Post;
 use App\ApiResource\Model\Coordinate;
 use App\ApiResource\Model\GeoPosition;
@@ -176,10 +177,58 @@ final class TripChatInRideTest extends TestCase
         self::assertStringContainsString("point d'intérêt", $response->response);
     }
 
+    /**
+     * Ensures the in-ride branch reaches the EntityManager so PostgreSQL
+     * captures both turns of the consultation (Redis sliding-window context
+     * alone disappears after MAX_MESSAGES).
+     */
+    #[AllowMockObjectsWithoutExpectations]
+    #[Test]
+    public function inRideTurnsArePersistedToPostgres(): void
+    {
+        $persisted = [];
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->method('getReference')
+            ->willReturnCallback(static fn (string $class, string $id): TripRequest => new TripRequest(Uuid::fromString($id)));
+        $entityManager->method('wrapInTransaction')
+            ->willReturnCallback(static fn (callable $callback) => $callback($entityManager));
+        $entityManager->expects(self::exactly(2))
+            ->method('persist')
+            ->willReturnCallback(static function (object $entity) use (&$persisted): void {
+                $persisted[] = $entity;
+            });
+        $entityManager->expects(self::once())->method('flush');
+
+        $scanner = $this->createMock(ScannerInterface::class);
+        $scanner->method('query')->willReturn(['elements' => []]);
+
+        $llm = $this->createMock(LlmClientInterface::class);
+        $llm->method('isEnabled')->willReturn(true);
+        $llm->method('generate')->willReturn([
+            'response' => '{"category":"unknown","max_distance_m":3000}',
+        ]);
+
+        $processor = $this->newProcessor($llm, $scanner, $this->newMessageBus(), $entityManager);
+
+        $processor->process(
+            new TripChatRequest(
+                message: 'Point eau ?',
+                context: null,
+                position: new GeoPosition(50.8503, 4.3517),
+            ),
+            new Post(),
+            ['id' => self::TRIP_ID],
+        );
+
+        self::assertCount(2, $persisted, 'In-ride turns must persist both user prompt and assistant reply.');
+    }
+
     private function newProcessor(
         LlmClientInterface $llm,
         ScannerInterface $scanner,
         MessageBusInterface $messageBus,
+        ?EntityManagerInterface $entityManager = null,
     ): TripChatProcessor {
         $tripRequest = new TripRequest();
         $stages = [
@@ -234,6 +283,7 @@ final class TripChatInRideTest extends TestCase
             generationTracker: $generationTracker,
             inRideAssistant: $inRideAssistant,
             tripChatLimiter: $this->newNoLimiterFactory(),
+            entityManager: $entityManager,
         );
     }
 

--- a/api/tests/Integration/TripChatPlanningRegressionTest.php
+++ b/api/tests/Integration/TripChatPlanningRegressionTest.php
@@ -123,7 +123,7 @@ final class TripChatPlanningRegressionTest extends TestCase
         self::assertSame($expectedDispatched, $response->dispatched);
         self::assertSame($expectedRequiresFullAnalysis, $response->requiresFullAnalysis);
         self::assertSame($expectedImpactedStageNumbers, $response->impactedStageNumbers);
-        self::assertNull($response->pois, 'pois must be null in planning mode');
+        self::assertSame([], $response->pois, 'pois must be empty in planning mode');
 
         $dispatched = $this->collectDispatched($bus, RecalculateStages::class);
         if ($expectedDispatched) {

--- a/api/tests/Integration/TripChatPlanningRegressionTest.php
+++ b/api/tests/Integration/TripChatPlanningRegressionTest.php
@@ -1,0 +1,256 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration;
+
+use ApiPlatform\Metadata\Post;
+use App\ApiResource\Model\Coordinate;
+use App\ApiResource\Stage;
+use App\ApiResource\TripChatRequest;
+use App\ApiResource\TripRequest;
+use App\ComputationTracker\TripGenerationTrackerInterface;
+use App\Entity\User;
+use App\Geo\HaversineDistance;
+use App\InRide\DeeplinkBuilder;
+use App\InRide\DetourCalculator;
+use App\InRide\InRideAssistant;
+use App\InRide\OpeningHoursParser;
+use App\InRide\PoiIntentDetector;
+use App\Llm\ChatActionInterpreter;
+use App\Llm\ChatHistoryStore;
+use App\Llm\LlmClientInterface;
+use App\Llm\SystemPromptLoader;
+use App\Message\RecalculateStages;
+use App\Repository\TripRequestRepositoryInterface;
+use App\Scanner\OsmOverpassQueryBuilder;
+use App\Scanner\ScannerInterface;
+use App\State\TripChatProcessor;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Regression: when {@see TripChatRequest::$position} is null, the planning
+ * pipeline introduced in sprint 31 must keep working unchanged — the seven
+ * planning actions are still dispatched (or flagged as full-analysis /
+ * info) and the in-ride assistant must NOT be invoked.
+ */
+final class TripChatPlanningRegressionTest extends TestCase
+{
+    private const string TRIP_ID = '01936f6e-0000-7000-8000-000000000300';
+
+    private string $promptFixtureDir = '';
+
+    #[\Override]
+    protected function tearDown(): void
+    {
+        if ('' === $this->promptFixtureDir || !is_dir($this->promptFixtureDir)) {
+            return;
+        }
+
+        foreach (glob($this->promptFixtureDir.'/*') ?: [] as $file) {
+            @unlink($file);
+        }
+
+        @rmdir($this->promptFixtureDir);
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1: array<string, mixed>, 2: bool, 3: bool, 4: list<int>}>
+     */
+    public static function planningActionsProvider(): iterable
+    {
+        yield 'split_stage' => ['split_stage', ['stage' => 3], true, false, [3, 4]];
+        yield 'merge_stages' => ['merge_stages', ['stages' => [2, 3]], true, false, [2]];
+        yield 'add_waypoint' => ['add_waypoint', ['name' => 'Mont Cassel', 'stage' => 4], true, false, [4]];
+        yield 'change_accommodation' => ['change_accommodation', ['stage' => 2, 'type' => 'guest_house'], true, false, [2, 3]];
+        yield 'adjust_distance' => ['adjust_distance', ['stage' => 5, 'km' => 95], true, false, [5]];
+        yield 'change_route' => ['change_route', [], false, true, []];
+        yield 'info' => ['info', [], false, false, []];
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     * @param list<int>            $expectedImpactedStageNumbers
+     */
+    #[Test]
+    #[DataProvider('planningActionsProvider')]
+    public function planningActionsStillWorkWithoutPosition(
+        string $action,
+        array $params,
+        bool $expectedDispatched,
+        bool $expectedRequiresFullAnalysis,
+        array $expectedImpactedStageNumbers,
+    ): void {
+        $bus = $this->newMessageBus();
+
+        $scanner = $this->createMock(ScannerInterface::class);
+        // In planning mode the in-ride scanner must never be queried.
+        $scanner->expects($this->never())->method('query');
+
+        $envelope = json_encode([
+            'action' => $action,
+            'params' => $params,
+            'response' => 'OK',
+        ], \JSON_THROW_ON_ERROR);
+
+        $llm = $this->createMock(LlmClientInterface::class);
+        $llm->method('isEnabled')->willReturn(true);
+        $llm->method('chat')->willReturn([
+            'message' => ['role' => 'assistant', 'content' => $envelope],
+        ]);
+        // generate() belongs to the in-ride pipeline — never expected here.
+        $llm->expects($this->never())->method('generate');
+
+        $processor = $this->newProcessor($llm, $scanner, $bus);
+
+        $response = $processor->process(
+            new TripChatRequest(message: 'message planning'),
+            new Post(),
+            ['id' => self::TRIP_ID],
+        );
+
+        self::assertSame($action, $response->action);
+        self::assertSame($expectedDispatched, $response->dispatched);
+        self::assertSame($expectedRequiresFullAnalysis, $response->requiresFullAnalysis);
+        self::assertSame($expectedImpactedStageNumbers, $response->impactedStageNumbers);
+        self::assertNull($response->pois, 'pois must be null in planning mode');
+
+        $dispatched = $this->collectDispatched($bus, RecalculateStages::class);
+        if ($expectedDispatched) {
+            self::assertCount(1, $dispatched);
+            self::assertTrue($dispatched[0]->skipAiAnalysis);
+        } else {
+            self::assertCount(0, $dispatched);
+        }
+    }
+
+    private function newProcessor(
+        LlmClientInterface $llm,
+        ScannerInterface $scanner,
+        MessageBusInterface $messageBus,
+    ): TripChatProcessor {
+        $tripRequest = new TripRequest();
+        $stages = [];
+        for ($i = 1; $i <= 5; ++$i) {
+            $stages[] = new Stage(
+                tripId: self::TRIP_ID,
+                dayNumber: $i,
+                distance: 50.0,
+                elevation: 200.0,
+                startPoint: new Coordinate(48.0, 2.0, 0.0),
+                endPoint: new Coordinate(48.1, 2.1, 0.0),
+            );
+        }
+
+        $repository = $this->createStub(TripRequestRepositoryInterface::class);
+        $repository->method('getRequest')->willReturn($tripRequest);
+        $repository->method('getStages')->willReturn($stages);
+
+        $promptLoader = new SystemPromptLoader($this->createPromptFixtureDir());
+        $historyStore = new ChatHistoryStore(new ArrayAdapter());
+
+        $generationTracker = $this->createStub(TripGenerationTrackerInterface::class);
+        $generationTracker->method('increment')->willReturn(1);
+
+        $user = new User('chat@example.com', Uuid::v7());
+
+        $security = $this->createStub(Security::class);
+        $security->method('getUser')->willReturn($user);
+
+        $distance = new HaversineDistance();
+        $inRideAssistant = new InRideAssistant(
+            intentDetector: new PoiIntentDetector($llm),
+            scanner: $scanner,
+            queryBuilder: new OsmOverpassQueryBuilder(),
+            openingHoursParser: new OpeningHoursParser(),
+            detourCalculator: new DetourCalculator($distance),
+            deeplinkBuilder: new DeeplinkBuilder(),
+            distance: $distance,
+            llmClient: $llm,
+            promptLoader: $promptLoader,
+            cache: new ArrayAdapter(),
+        );
+
+        return new TripChatProcessor(
+            tripStateManager: $repository,
+            llmClient: $llm,
+            promptLoader: $promptLoader,
+            interpreter: new ChatActionInterpreter(new NullLogger()),
+            historyStore: $historyStore,
+            security: $security,
+            logger: new NullLogger(),
+            messageBus: $messageBus,
+            generationTracker: $generationTracker,
+            inRideAssistant: $inRideAssistant,
+            tripChatLimiter: $this->newNoLimiterFactory(),
+        );
+    }
+
+    private function createPromptFixtureDir(): string
+    {
+        $dir = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'trip-chat-planning-prompts-'.bin2hex(random_bytes(4));
+        mkdir($dir, 0o775, true);
+        file_put_contents($dir.\DIRECTORY_SEPARATOR.'dialogue.txt', 'SYSTEM PROMPT');
+        file_put_contents($dir.\DIRECTORY_SEPARATOR.'in-ride.txt', 'Respond with markdown narrative.');
+        $this->promptFixtureDir = $dir;
+
+        return $dir;
+    }
+
+    private function newMessageBus(): MessageBusInterface
+    {
+        return new class () implements MessageBusInterface {
+            /** @var list<Envelope> */
+            public array $dispatched = [];
+
+            public function dispatch(object $message, array $stamps = []): Envelope
+            {
+                $envelope = $message instanceof Envelope ? $message : new Envelope($message, $stamps);
+                $this->dispatched[] = $envelope;
+
+                return $envelope;
+            }
+        };
+    }
+
+    /**
+     * @template T of object
+     *
+     * @param class-string<T> $messageClass
+     *
+     * @return list<T>
+     */
+    private function collectDispatched(MessageBusInterface $bus, string $messageClass): array
+    {
+        \assert(property_exists($bus, 'dispatched'));
+
+        $collected = [];
+        /** @var Envelope $envelope */
+        foreach ($bus->dispatched as $envelope) {
+            $message = $envelope->getMessage();
+            if ($message instanceof $messageClass) {
+                $collected[] = $message;
+            }
+        }
+
+        return $collected;
+    }
+
+    private function newNoLimiterFactory(): RateLimiterFactory
+    {
+        return new RateLimiterFactory(
+            ['id' => 'trip_chat_planning_test', 'policy' => 'no_limit'],
+            new InMemoryStorage(),
+        );
+    }
+}

--- a/api/tests/Unit/State/TripChatProcessorTest.php
+++ b/api/tests/Unit/State/TripChatProcessorTest.php
@@ -11,20 +11,25 @@ use App\ApiResource\Stage;
 use App\ApiResource\TripChatRequest;
 use App\ApiResource\TripRequest;
 use App\ComputationTracker\TripGenerationTrackerInterface;
-use App\Entity\TripChatMessage;
 use App\Entity\User;
+use App\Geo\HaversineDistance;
+use App\InRide\DeeplinkBuilder;
+use App\InRide\DetourCalculator;
+use App\InRide\InRideAssistant;
+use App\InRide\OpeningHoursParser;
+use App\InRide\PoiIntentDetector;
 use App\Llm\ChatActionInterpreter;
 use App\Llm\ChatHistoryStore;
 use App\Llm\LlmClientInterface;
 use App\Llm\SystemPromptLoader;
+use App\Scanner\OsmOverpassQueryBuilder;
+use App\Scanner\ScannerInterface;
 use App\Message\RecalculateStages;
 use App\Repository\TripRequestRepositoryInterface;
 use App\State\TripChatProcessor;
-use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
@@ -423,137 +428,11 @@ final class TripChatProcessorTest extends TestCase
         $processor->process(new TripChatRequest('Encore'), new Post(), ['id' => self::TRIP_ID]);
     }
 
-    /**
-     * Long-term persistence regression test (#458): every chat turn must be
-     * written to PostgreSQL *in addition* to the rolling Redis context window
-     * so the rider can recover their conversation from a cold reload.
-     */
-    #[Test]
-    public function chatTurnIsPersistedToPostgresInAdditionToRedis(): void
-    {
-        $persisted = [];
-        $flushed = 0;
-
-        $entityManager = $this->createMock(EntityManagerInterface::class);
-        $entityManager->method('getReference')
-            ->willReturnCallback(static fn (string $class, string $id): TripRequest => new TripRequest(Uuid::fromString($id)));
-        $entityManager->method('wrapInTransaction')
-            ->willReturnCallback(static fn (callable $callback) => $callback($entityManager));
-        $entityManager->expects(self::exactly(2))
-            ->method('persist')
-            ->willReturnCallback(static function (object $entity) use (&$persisted): void {
-                $persisted[] = $entity;
-            });
-        $entityManager->expects(self::once())
-            ->method('flush')
-            ->willReturnCallback(static function () use (&$flushed): void {
-                ++$flushed;
-            });
-
-        $processor = $this->newProcessor(
-            llmContent: $this->jsonEnvelope('info', [], 'Réponse persistée'),
-            stagesCount: 3,
-            messageBus: $this->newMessageBus(),
-            entityManager: $entityManager,
-        );
-
-        $processor->process(
-            new TripChatRequest('Quel est mon dénivelé total ?'),
-            new Post(),
-            ['id' => self::TRIP_ID],
-        );
-
-        self::assertCount(2, $persisted, 'Both the user turn and the assistant reply must be persisted.');
-        self::assertSame(1, $flushed, 'A single flush is expected per chat turn.');
-
-        /** @var TripChatMessage $userTurn */
-        $userTurn = $persisted[0];
-        /** @var TripChatMessage $assistantTurn */
-        $assistantTurn = $persisted[1];
-
-        self::assertInstanceOf(TripChatMessage::class, $userTurn);
-        self::assertInstanceOf(TripChatMessage::class, $assistantTurn);
-        self::assertSame(TripChatMessage::ROLE_USER, $userTurn->getRole());
-        self::assertSame(TripChatMessage::ROLE_ASSISTANT, $assistantTurn->getRole());
-        self::assertStringContainsString('Quel est mon dénivelé total ?', $userTurn->getContent());
-        self::assertSame('info', $assistantTurn->getAction());
-    }
-
-    /**
-     * Without the optional repository/entity manager (e.g. legacy wiring during
-     * the rollout), the processor must continue to function: the Redis history
-     * is the legacy single source of truth and a missing PG writer should not
-     * break the chat endpoint.
-     */
-    #[Test]
-    public function chatStillWorksWhenChatMessageRepositoryIsUnwired(): void
-    {
-        $processor = $this->newProcessor(
-            llmContent: $this->jsonEnvelope('info', [], 'OK'),
-            stagesCount: 3,
-            messageBus: $this->newMessageBus(),
-        );
-
-        $response = $processor->process(
-            new TripChatRequest('Bonjour'),
-            new Post(),
-            ['id' => self::TRIP_ID],
-        );
-
-        self::assertSame('info', $response->action);
-    }
-
-    /**
-     * When PostgreSQL is reachable but the persist or flush throws (FK
-     * violation, connection drop mid-transaction, …), the chat endpoint must
-     * still return a usable response — the Redis sliding-window context has
-     * already been updated and remains authoritative for the next LLM call.
-     */
-    #[Test]
-    public function chatStillReturnsResponseWhenPgPersistFails(): void
-    {
-        $entityManager = $this->createMock(EntityManagerInterface::class);
-        $entityManager->method('getReference')
-            ->willReturnCallback(static fn (string $class, string $id): TripRequest => new TripRequest(Uuid::fromString($id)));
-        $entityManager->method('wrapInTransaction')
-            ->willThrowException(new \RuntimeException('PG connection lost'));
-
-        // Capture the swallowed exception via the logger contract so a future
-        // refactor that silently drops the `logger->warning(...)` call cannot
-        // hide the failure from operators.
-        $logger = $this->createMock(LoggerInterface::class);
-        $logger->expects(self::atLeastOnce())
-            ->method('warning')
-            ->with(
-                self::stringContains('Failed to persist trip chat history'),
-                self::callback(static fn (array $ctx): bool => 'PG connection lost' === ($ctx['error'] ?? null)),
-            );
-
-        $processor = $this->newProcessor(
-            llmContent: $this->jsonEnvelope('info', [], 'OK même si PG est cassé'),
-            stagesCount: 3,
-            messageBus: $this->newMessageBus(),
-            entityManager: $entityManager,
-            logger: $logger,
-        );
-
-        $response = $processor->process(
-            new TripChatRequest('Bonjour'),
-            new Post(),
-            ['id' => self::TRIP_ID],
-        );
-
-        self::assertSame('info', $response->action);
-        self::assertSame('OK même si PG est cassé', $response->response);
-    }
-
     private function newProcessor(
         string $llmContent,
         int $stagesCount,
         MessageBusInterface $messageBus,
         ?RateLimiterFactory $limiterFactory = null,
-        ?EntityManagerInterface $entityManager = null,
-        ?LoggerInterface $logger = null,
     ): TripChatProcessor {
         $tripRequest = new TripRequest();
         $stages = [];
@@ -590,6 +469,22 @@ final class TripChatProcessorTest extends TestCase
         $security = $this->createStub(Security::class);
         $security->method('getUser')->willReturn($user);
 
+        $distance = new HaversineDistance();
+        $scanner = $this->createStub(ScannerInterface::class);
+        $scanner->method('query')->willReturn(['elements' => []]);
+        $inRideAssistant = new InRideAssistant(
+            intentDetector: new PoiIntentDetector($llmClient),
+            scanner: $scanner,
+            queryBuilder: new OsmOverpassQueryBuilder(),
+            openingHoursParser: new OpeningHoursParser(),
+            detourCalculator: new DetourCalculator($distance),
+            deeplinkBuilder: new DeeplinkBuilder(),
+            distance: $distance,
+            llmClient: $llmClient,
+            promptLoader: $promptLoader,
+            cache: new ArrayAdapter(),
+        );
+
         return new TripChatProcessor(
             tripStateManager: $repository,
             llmClient: $llmClient,
@@ -597,11 +492,11 @@ final class TripChatProcessorTest extends TestCase
             interpreter: new ChatActionInterpreter(new NullLogger()),
             historyStore: $historyStore,
             security: $security,
-            logger: $logger ?? new NullLogger(),
+            logger: new NullLogger(),
             messageBus: $messageBus,
             generationTracker: $generationTracker,
+            inRideAssistant: $inRideAssistant,
             tripChatLimiter: $limiterFactory ?? $this->newNoLimiterFactory(),
-            entityManager: $entityManager,
         );
     }
 

--- a/api/tests/Unit/State/TripChatProcessorTest.php
+++ b/api/tests/Unit/State/TripChatProcessorTest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\State;
 
+use Doctrine\ORM\EntityManagerInterface;
+use App\Entity\TripChatMessage;
+use Psr\Log\LoggerInterface;
 use ApiPlatform\Metadata\Post;
 use App\ApiResource\Model\Coordinate;
 use App\ApiResource\Model\TripChatContext;
@@ -428,11 +431,137 @@ final class TripChatProcessorTest extends TestCase
         $processor->process(new TripChatRequest('Encore'), new Post(), ['id' => self::TRIP_ID]);
     }
 
+    /**
+     * Guarantees the dual-write contract from #458: each chat turn persisted to
+     * Redis is also written to PostgreSQL via the EntityManager. Both the user
+     * prompt and the assistant reply must reach `persist()` and a single
+     * `flush()` must be issued per turn.
+     */
+    #[AllowMockObjectsWithoutExpectations]
+    #[Test]
+    public function chatTurnIsPersistedToPostgresInAdditionToRedis(): void
+    {
+        $persisted = [];
+        $flushed = 0;
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->method('getReference')
+            ->willReturnCallback(static fn (string $class, string $id): TripRequest => new TripRequest(Uuid::fromString($id)));
+        $entityManager->method('wrapInTransaction')
+            ->willReturnCallback(static fn (callable $callback) => $callback($entityManager));
+        $entityManager->expects(self::exactly(2))
+            ->method('persist')
+            ->willReturnCallback(static function (object $entity) use (&$persisted): void {
+                $persisted[] = $entity;
+            });
+        $entityManager->expects(self::once())
+            ->method('flush')
+            ->willReturnCallback(static function () use (&$flushed): void {
+                ++$flushed;
+            });
+
+        $processor = $this->newProcessor(
+            llmContent: $this->jsonEnvelope('info', [], 'Réponse persistée'),
+            stagesCount: 3,
+            messageBus: $this->newMessageBus(),
+            entityManager: $entityManager,
+        );
+
+        $processor->process(
+            new TripChatRequest('Quel est mon dénivelé total ?'),
+            new Post(),
+            ['id' => self::TRIP_ID],
+        );
+
+        self::assertCount(2, $persisted, 'Both the user turn and the assistant reply must be persisted.');
+        self::assertSame(1, $flushed, 'A single flush is expected per chat turn.');
+
+        /** @var TripChatMessage $userTurn */
+        $userTurn = $persisted[0];
+        /** @var TripChatMessage $assistantTurn */
+        $assistantTurn = $persisted[1];
+
+        self::assertInstanceOf(TripChatMessage::class, $userTurn);
+        self::assertInstanceOf(TripChatMessage::class, $assistantTurn);
+        self::assertSame(TripChatMessage::ROLE_USER, $userTurn->getRole());
+        self::assertSame(TripChatMessage::ROLE_ASSISTANT, $assistantTurn->getRole());
+        self::assertStringContainsString('Quel est mon dénivelé total ?', $userTurn->getContent());
+        self::assertSame('info', $assistantTurn->getAction());
+    }
+
+    /**
+     * Without the optional EntityManager (e.g. legacy wiring during the
+     * rollout), the processor must continue to function: the Redis history
+     * is the legacy single source of truth and a missing PG writer should
+     * not break the chat endpoint.
+     */
+    #[Test]
+    public function chatStillWorksWhenChatMessageRepositoryIsUnwired(): void
+    {
+        $processor = $this->newProcessor(
+            llmContent: $this->jsonEnvelope('info', [], 'OK'),
+            stagesCount: 3,
+            messageBus: $this->newMessageBus(),
+        );
+
+        $response = $processor->process(
+            new TripChatRequest('Bonjour'),
+            new Post(),
+            ['id' => self::TRIP_ID],
+        );
+
+        self::assertSame('info', $response->action);
+    }
+
+    /**
+     * When PostgreSQL is reachable but the persist or flush throws (FK
+     * violation, connection drop mid-transaction, …), the chat endpoint must
+     * still return a usable response — the Redis sliding-window context has
+     * already been updated and remains authoritative for the next LLM call.
+     */
+    #[AllowMockObjectsWithoutExpectations]
+    #[Test]
+    public function chatStillReturnsResponseWhenPgPersistFails(): void
+    {
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->method('getReference')
+            ->willReturnCallback(static fn (string $class, string $id): TripRequest => new TripRequest(Uuid::fromString($id)));
+        $entityManager->method('wrapInTransaction')
+            ->willThrowException(new \RuntimeException('PG connection lost'));
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::atLeastOnce())
+            ->method('warning')
+            ->with(
+                self::stringContains('Failed to persist trip chat history'),
+                self::callback(static fn (array $ctx): bool => 'PG connection lost' === ($ctx['error'] ?? null)),
+            );
+
+        $processor = $this->newProcessor(
+            llmContent: $this->jsonEnvelope('info', [], 'OK même si PG est cassé'),
+            stagesCount: 3,
+            messageBus: $this->newMessageBus(),
+            entityManager: $entityManager,
+            logger: $logger,
+        );
+
+        $response = $processor->process(
+            new TripChatRequest('Bonjour'),
+            new Post(),
+            ['id' => self::TRIP_ID],
+        );
+
+        self::assertSame('info', $response->action);
+        self::assertSame('OK même si PG est cassé', $response->response);
+    }
+
     private function newProcessor(
         string $llmContent,
         int $stagesCount,
         MessageBusInterface $messageBus,
         ?RateLimiterFactory $limiterFactory = null,
+        ?EntityManagerInterface $entityManager = null,
+        ?LoggerInterface $logger = null,
     ): TripChatProcessor {
         $tripRequest = new TripRequest();
         $stages = [];
@@ -492,11 +621,12 @@ final class TripChatProcessorTest extends TestCase
             interpreter: new ChatActionInterpreter(new NullLogger()),
             historyStore: $historyStore,
             security: $security,
-            logger: new NullLogger(),
+            logger: $logger ?? new NullLogger(),
             messageBus: $messageBus,
             generationTracker: $generationTracker,
             inRideAssistant: $inRideAssistant,
             tripChatLimiter: $limiterFactory ?? $this->newNoLimiterFactory(),
+            entityManager: $entityManager,
         );
     }
 

--- a/pwa/src/lib/api/schema.d.ts
+++ b/pwa/src/lib/api/schema.d.ts
@@ -404,6 +404,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/trips/{id}/chat-history": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List the persisted chat history for a trip (most-recent first, cursor pagination).
+         * @description List the persisted chat history for a trip (most-recent first, cursor pagination).
+         */
+        get: operations["api_trips_idchat-history_get_collection"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/trips/{id}/detail": {
         parameters: {
             query?: never;
@@ -834,6 +854,14 @@ export interface components {
             /** @description Opening hours (Wikidata P8989). */
             openingHours?: string | null;
         };
+        GeoPosition: {
+            /** @description Latitude in decimal degrees (WGS84). */
+            lat: number;
+            /** @description Longitude in decimal degrees (WGS84). */
+            lon: number;
+            /** @description Optional bearing (heading) in degrees clockwise from north. */
+            bearing?: number | null;
+        };
         HydraCollectionBaseSchema: components["schemas"]["HydraCollectionBaseSchemaNoPagination"] & {
             /**
              * @example {
@@ -883,6 +911,30 @@ export interface components {
             });
             "@id": string;
             "@type": string;
+        };
+        "PoiSuggestionDto.jsonld": {
+            /** @description Display name of the POI. */
+            name: string;
+            /** @description POI category (food, water, shelter, mechanic). */
+            category: string;
+            /** @description POI latitude (WGS84). */
+            lat: number;
+            /** @description POI longitude (WGS84). */
+            lon: number;
+            /** @description Straight-line distance from the rider to the POI, in meters. */
+            distance_m: number;
+            /** @description Estimated additional meters if the rider detours to the POI (0 when no remaining route is known). */
+            detour_m: number;
+            /** @description Raw OSM `opening_hours` tag for the current day, when available. */
+            opening_hours_today?: string | null;
+            /** @description RFC 3339 closing time of the currently-open interval, or null when the POI never closes / is closed. */
+            closes_at?: string | null;
+            /** @description Optional phone number extracted from the OSM tag. */
+            phone?: string | null;
+            /** @description Pre-built deeplink the rider can tap to open the POI in their map app. */
+            deeplink: string;
+            /** @description Optional warning surfaced on the POI card (e.g. opening hours unreliable, POI far from route). */
+            warning?: string | null;
         };
         "PointOfInterest.fit": {
             name?: string;
@@ -1062,6 +1114,7 @@ export interface components {
             /** @description Natural language instruction or question from the rider. */
             message: string;
             context?: components["schemas"]["TripChatContext"] | null;
+            position?: components["schemas"]["GeoPosition"] | null;
         };
         "Trip.TripChatResponse.jsonld": components["schemas"]["HydraItemBaseSchema"] & {
             /** @description Trip identifier (UUID v7) the chat exchange belongs to. */
@@ -1079,6 +1132,7 @@ export interface components {
             impactedStageNumbers?: number[];
             /** @description True when the action requires a full trip re-analysis (Acte 2). */
             requiresFullAnalysis?: boolean;
+            pois?: components["schemas"]["PoiSuggestionDto.jsonld"][];
         };
         "Trip.TripListItem.jsonld": components["schemas"]["HydraItemBaseSchema"] & {
             id?: string;
@@ -1222,6 +1276,35 @@ export interface components {
         TripChatContext: {
             /** @description 1-indexed day number of the stage currently consulted, when applicable. */
             currentStage?: number | null;
+        };
+        /**
+         * @description Read-only DTO exposing a single persisted chat turn over the API.
+         *
+         *     Backs the `GET /trips/{id}/chat-history` endpoint introduced in #459 so the
+         *     PWA can rehydrate the chat drawer after a refresh or a return visit. The
+         *     underlying Doctrine entity ({@see \App\Entity\TripChatMessage}) is kept
+         *     private to the backend; only the publicly safe fields are exposed here.
+         *
+         *     Messages are returned ordered by `createdAt` DESC (most recent first); the
+         *     frontend reverses them for chronological rendering. Cursor pagination is
+         *     available via the `before` query parameter (RFC 3339 datetime).
+         */
+        "TripChatMessage.jsonld": components["schemas"]["HydraItemBaseSchema"] & {
+            /** @description Message identifier (UUID v7). */
+            id?: string;
+            /** @description Trip identifier (UUID v7) the message belongs to. */
+            tripId?: string;
+            /** @description Author role: `user` or `assistant`. */
+            role?: string;
+            /** @description Raw message content. For assistant turns this is the JSON envelope returned by the LLM. */
+            content?: string;
+            /** @description Structured action interpreted by the dialogue assistant (e.g. `split_stage`, `info`). */
+            action?: string | null;
+            /**
+             * Format: date-time
+             * @description Server-side creation timestamp (RFC 3339).
+             */
+            createdAt?: string;
         };
         /**
          * @description Read-only trip detail resource for loading a persisted trip on the frontend.
@@ -2942,6 +3025,54 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ConstraintViolation"];
                     "application/json": components["schemas"]["ConstraintViolation"];
                 };
+            };
+        };
+    };
+    "api_trips_idchat-history_get_collection": {
+        parameters: {
+            query?: {
+                /** @description Maximum number of messages to return (default 50, max 200). */
+                limit?: number;
+                /** @description Only return messages strictly older than this RFC 3339 timestamp (used as a cursor for "load older"). */
+                before?: string;
+            };
+            header?: never;
+            path: {
+                /** @description TripChatMessage identifier */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description TripChatMessage collection */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["HydraCollectionBaseSchemaNoPagination"] & {
+                        member: components["schemas"]["TripChatMessage.jsonld"][];
+                    };
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["Error.jsonld"];
+                    "application/problem+json": components["schemas"]["Error"];
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Trip not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };


### PR DESCRIPTION
## Summary

Sprint 32 #463 — Branchement final backend : `TripChatProcessor` bascule en mode in-ride uniquement quand une position GPS est présente dans le payload.

- `TripChatRequest` : ajout `position: ?GeoPosition`
- `TripChatResponse` : ajout `pois: ?list<PoiSuggestion>`
- `ChatAction` : ajout constante `ACTION_FIND_POI`
- `ChatActionInterpreter` : `normaliseFindPoi()` (catégorie + max_distance + opening_filter)
- `TripChatProcessor` : branche conditionnelle → délégation à `InRideAssistant` si position fournie, sinon comportement actuel inchangé (rétrocompatible)
- `dialogue.txt` : mention brève de `find_poi`
- Tests : `TripChatInRideTest` (position → in-ride) + `TripChatPlanningRegressionTest` (sans position, les 7 actions planning marchent toujours)

Depends on #472 (#462).

Closes #463

## Test plan

- [ ] CI verte
- [ ] Rétrocompat : les 7 actions planning (split, merge, add_waypoint, change_accommodation, adjust_distance, change_route, info) marchent sans position
- [ ] Avec position : top 3 POI + dispatched=false

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

Reviewed commit `62c671f0c6d4cdc99b6dc999d19a140a291a9a5f`.

**0 findings. All previously open bot threads resolved.**

The 5th commit (`test(chat): cover in-ride PostgreSQL persistence`) addresses the last remaining warning: `TripChatInRideTest::newProcessor()` now accepts an optional `EntityManagerInterface`, and the new `inRideTurnsArePersistedToPostgres` test wires a spy that asserts `persist()` × 2 and `flush()` × 1 — matching the dual-write contract from `chatTurnIsPersistedToPostgresInAdditionToRedis` on the planning path. The in-ride PostgreSQL persistence path is now a first-class regression guard.

Resolved 1 previously open thread: `TripChatInRideTest::newProcessor()` omits `EntityManager` (now wired in `inRideTurnsArePersistedToPostgres` ✓).

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases — in-ride dual-write now guarded by `inRideTurnsArePersistedToPostgres`
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Inline comments

No inline comments.

---

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->