### PR TITLE
fix(ci): scan docker subdirectories for dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,8 @@ version: 2
 updates:
   # Maintain Docker base image digests
   - package-ecosystem: docker
-    directory: /.docker
+    directories:
+      - /.docker/*
     schedule:
       interval: weekly
     labels:


### PR DESCRIPTION
## Summary

Dependabot failed with `No Dockerfiles nor Kubernetes YAML found in /.docker` ([run](https://github.com/vincentchalamon/bike-trip-planner/actions/runs/26277632634/job/77345701368)) because the Dockerfiles live in subdirectories (`php`, `pwa`, `provisioner`), not at the root of `/.docker`.

Switched `directory: /.docker` to `directories: [/.docker/*]` so Dependabot scans each subdirectory.

## Test plan

- [ ] Next scheduled Dependabot docker run succeeds

<!-- claude-review-start -->
## Claude Review

**Reviewed commit:** f41eea0df9919ecb9ae915b7a6d93d04a7a5140a
**Findings:** 0 critical · 0 warning · 0 suggestion

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

No inline comments.

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->