### PR TITLE
feat(monitoring): add Uptime Kuma self-hosted + external UptimeRobot

### DIFF
--- a/.docker/php/Dockerfile
+++ b/.docker/php/Dockerfile
@@ -79,7 +79,9 @@ CMD [ "frankenphp", "run", "--config", "/etc/frankenphp/Caddyfile", "--watch" ]
 # Prod FrankenPHP image
 FROM frankenphp_base AS frankenphp_prod
 
+ARG COMMIT_SHA=unknown
 ENV APP_ENV=prod
+ENV APP_COMMIT=${COMMIT_SHA}
 
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 

--- a/.docker/uptime-kuma/README.md
+++ b/.docker/uptime-kuma/README.md
@@ -1,0 +1,130 @@
+# Uptime Kuma — self-hosted monitoring
+
+Uptime Kuma is the **primary** uptime monitor for Bike Trip Planner. It runs on
+the same Coolify host as the application (Oracle Cloud Always Free VM, see
+[ADR-019](../../docs/adr/0019-hosting-coolify-oracle-cloud.md)) and provides
+sub-minute detection for backend and frontend outages.
+
+Because it shares the VM with the app, a host-level outage will take Uptime Kuma
+down too. The **external** UptimeRobot monitor documented in
+[`docs/runbooks/uptime-monitoring.md`](../../docs/runbooks/uptime-monitoring.md)
+acts as the off-host safety net.
+
+## 1. Coolify installation
+
+1. Log into the Coolify dashboard.
+2. **+ New resource → Docker Compose**.
+3. Name the resource `uptime-kuma`. Paste the content of
+   [`docker-compose.yml`](./docker-compose.yml) (or point the resource at this
+   path in the repository).
+4. Set the **domain** to `https://status.biketrip.mooo.com`. Coolify will
+   provision the Let's Encrypt certificate via Traefik automatically (FreeDNS
+   `mooo.com` A record must already point at the VM public IP).
+5. Click **Deploy**. Wait for the healthcheck to turn green
+   (`curl -f http://localhost:3001` succeeds).
+6. Open `https://status.biketrip.mooo.com` and create the **admin** account
+   (only the first visitor can register; subsequent visitors land on the login
+   page).
+
+> Storage: the named volume `uptime-kuma-data` persists the SQLite database
+> (`/app/data/kuma.db`) and all monitor configuration. Back it up with the
+> Coolify volume backup feature; restoring the volume is enough to recover all
+> monitors and history.
+
+## 2. Monitors to create
+
+All monitors are created manually via the Uptime Kuma UI
+(**+ Add New Monitor**). The table below is the source of truth — keep it in
+sync with the deployed configuration.
+
+| # | Type     | Target                                                              | Interval | Retries | Severity | Notes                                                       |
+| - | -------- | ------------------------------------------------------------------- | -------- | ------- | -------- | ----------------------------------------------------------- |
+| 1 | HTTP(s)  | `https://biketrip.mooo.com/api/healthz`                             | 60 s     | 2       | **P1**   | Liveness probe. Must answer `200` with body `ok`.           |
+| 2 | HTTP(s)  | `https://biketrip.mooo.com/api/health`                              | 300 s    | 2       | **P2**   | Readiness probe (DB + Redis + Mercure). `503` = degraded.   |
+| 3 | Keyword  | `https://biketrip.mooo.com/`, keyword `Bike Trip Planner`           | 300 s    | 2       | **P1**   | Detects PWA shell regressions (blank page, SSR crash).      |
+| 4 | DNS      | `biketrip.mooo.com`, resolver `1.1.1.1`, record type `A`            | 300 s    | 2       | **P2**   | Detects FreeDNS / DynDNS expiration.                        |
+| 5 | HTTP(s)  | `https://biketrip.mooo.com/.well-known/mercure?topic=test`          | 300 s    | 2       | **P2**   | Accept HTTP status `200,401`. Anything `5xx` = down.        |
+
+### Per-monitor configuration tips
+
+- **Monitor 1 (`/api/healthz`)** — `Accepted Status Codes: 200`. Add the
+  notification channel **immediately**: this is the only sub-minute alarm.
+- **Monitor 2 (`/api/health`)** — `Accepted Status Codes: 200`. A `503` here
+  means at least one dependency (PostgreSQL / Redis / Mercure) is degraded.
+- **Monitor 3 (keyword)** — `Keyword: Bike Trip Planner`,
+  `Case Sensitive: yes`. Validates the PWA actually renders the app shell.
+- **Monitor 4 (DNS)** — `DNS Resolver Server: 1.1.1.1`,
+  `Resource Record Type: A`. Compare with the expected IP of the Oracle VM.
+- **Monitor 5 (Mercure)** — `Accepted Status Codes: 200-299, 401`. Mercure
+  returns `401` for unauthenticated subscribers, which is the healthy answer
+  here. Any `502/503/504` indicates the hub is unreachable.
+
+## 3. Notification webhook (prepares P1.3)
+
+Uptime Kuma must push DOWN / UP events to GitHub's `repository_dispatch` API
+so the incident workflow (#P1.3) can react automatically.
+
+**Settings → Notifications → Setup Notification**:
+
+- **Notification Type**: `Webhook`
+- **Friendly Name**: `github-incident-dispatch`
+- **Post URL**: `https://api.github.com/repos/vincentchalamon/bike-trip-planner/dispatches`
+- **Request Body**: `Custom Body`
+- **Body**:
+
+  ```json
+  {
+    "event_type": "uptime_alert",
+    "client_payload": {
+      "source": "uptime-kuma",
+      "monitor": "{{ monitorJSON.name }}",
+      "status": "{{ status }}",
+      "msg": "{{ msg }}"
+    }
+  }
+  ```
+
+- **Additional Headers**:
+
+  ```json
+  {
+    "Accept": "application/vnd.github+json",
+    "Authorization": "Bearer <INCIDENT_DISPATCH_TOKEN>",
+    "X-GitHub-Api-Version": "2022-11-28"
+  }
+  ```
+
+  Replace `<INCIDENT_DISPATCH_TOKEN>` with a fine-grained GitHub PAT scoped to
+  the repository with the **Contents: Read & write** permission (required for
+  `repository_dispatch`). Store the token in the Coolify secret store, never in
+  the Uptime Kuma database backup.
+
+- **Apply on all existing monitors**: enable.
+- Test with **Test** — GitHub answers `204 No Content` on success.
+
+## 4. Public status page
+
+**Settings → Status Pages → New Status Page**:
+
+- **Slug**: `public` (final URL: `https://status.biketrip.mooo.com/status/public`)
+- **Title**: `Bike Trip Planner — Status`
+- **Theme**: Auto
+- **Published**: yes
+- **Monitors**: include all five above, grouped as:
+  - **Public services**: keyword (#3), DNS (#4)
+  - **API**: healthz (#1), health (#2), Mercure (#5)
+- **Show Tags**: no
+- **Show Powered By**: optional
+- **Domain Names**: leave empty (served on the default Uptime Kuma host)
+
+No authentication is required to view `/status/public`; the page surfaces only
+monitor names and uptime percentages, never internal URLs.
+
+## 5. Maintenance
+
+- **Backups**: schedule a weekly snapshot of the `uptime-kuma-data` volume in
+  Coolify. The SQLite DB is < 50 MB even with one year of history.
+- **Upgrades**: bump the image tag in
+  [`docker-compose.yml`](./docker-compose.yml) after reading the release notes,
+  then redeploy from Coolify. Never use `latest`.
+- **Resource budget**: ~80 MB RAM, < 1% CPU on the Always Free VM.

--- a/.docker/uptime-kuma/docker-compose.yml
+++ b/.docker/uptime-kuma/docker-compose.yml
@@ -1,0 +1,49 @@
+# Uptime Kuma — self-hosted monitoring
+#
+# Deployed separately from compose.prod.yaml via Coolify (one-click app or
+# custom service). This file documents the canonical configuration and can
+# be imported as a "Docker Compose" resource in the Coolify UI.
+#
+# See .docker/uptime-kuma/README.md for the full installation procedure
+# and the list of monitors to configure manually.
+
+services:
+  uptime-kuma:
+    # Pinned to a specific minor version. Bump intentionally after reading
+    # https://github.com/louislam/uptime-kuma/releases (no `latest` tag).
+    image: louislam/uptime-kuma:1.23.16
+    container_name: uptime-kuma
+    restart: unless-stopped
+    volumes:
+      # Persistent SQLite database + monitor configuration.
+      - uptime-kuma-data:/app/data
+    healthcheck:
+      # Uptime Kuma ships an extra-extra script; fall back to curl on the
+      # internal listener so the healthcheck survives image updates that
+      # might drop the bundled script.
+      test: ["CMD-SHELL", "curl -fsS http://localhost:3001 || exit 1"]
+      interval: 60s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    labels:
+      # Coolify / Traefik exposure. Coolify generates the `traefik` network
+      # automatically; these labels mirror the convention used by other
+      # Coolify-managed services for the project.
+      - "traefik.enable=true"
+      - "traefik.http.routers.uptime-kuma.rule=Host(`status.biketrip.mooo.com`)"
+      - "traefik.http.routers.uptime-kuma.entrypoints=websecure"
+      - "traefik.http.routers.uptime-kuma.tls=true"
+      - "traefik.http.routers.uptime-kuma.tls.certresolver=letsencrypt"
+      - "traefik.http.services.uptime-kuma.loadbalancer.server.port=3001"
+      # Optional: HTTP -> HTTPS redirect (Coolify usually handles this
+      # globally, kept here for environments where it isn't enabled).
+      - "traefik.http.routers.uptime-kuma-http.rule=Host(`status.biketrip.mooo.com`)"
+      - "traefik.http.routers.uptime-kuma-http.entrypoints=web"
+      - "traefik.http.routers.uptime-kuma-http.middlewares=uptime-kuma-redirect"
+      - "traefik.http.middlewares.uptime-kuma-redirect.redirectscheme.scheme=https"
+      - "traefik.http.middlewares.uptime-kuma-redirect.redirectscheme.permanent=true"
+
+volumes:
+  uptime-kuma-data:
+    name: uptime-kuma-data

--- a/api/composer.lock
+++ b/api/composer.lock
@@ -6916,16 +6916,16 @@
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.37.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
-                "reference": "9614ac4d8061dc257ecc64cba1b140873dce8ad3"
+                "reference": "dc21118016c039a66235cf93d96b435ffb282412"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/9614ac4d8061dc257ecc64cba1b140873dce8ad3",
-                "reference": "9614ac4d8061dc257ecc64cba1b140873dce8ad3",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/dc21118016c039a66235cf93d96b435ffb282412",
+                "reference": "dc21118016c039a66235cf93d96b435ffb282412",
                 "shasum": ""
             },
             "require": {
@@ -6979,7 +6979,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -6999,7 +6999,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-10T14:38:51+00:00"
+            "time": "2026-05-25T15:22:23+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",

--- a/api/config/packages/framework.php
+++ b/api/config/packages/framework.php
@@ -109,6 +109,11 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                         'Content-Type' => 'application/json',
                     ],
                 ],
+                'mercure.health.client' => [
+                    'base_uri' => '%env(MERCURE_URL)%',
+                    'max_redirects' => 0,
+                    'timeout' => 2,
+                ],
             ],
         ],
     ]);

--- a/api/config/packages/rate_limiter.php
+++ b/api/config/packages/rate_limiter.php
@@ -49,6 +49,18 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 'interval' => '60 seconds',
                 'cache_pool' => 'cache.rate_limiter',
             ],
+            'health_liveness' => [
+                'policy' => 'sliding_window',
+                'limit' => 60,
+                'interval' => '60 seconds',
+                'cache_pool' => 'cache.rate_limiter',
+            ],
+            'health_readiness' => [
+                'policy' => 'sliding_window',
+                'limit' => 20,
+                'interval' => '60 seconds',
+                'cache_pool' => 'cache.rate_limiter',
+            ],
         ],
         'cache' => [
             'pools' => [

--- a/api/config/packages/security.php
+++ b/api/config/packages/security.php
@@ -28,6 +28,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ],
         ],
         'access_control' => [
+            ['path' => '^/api/health(z)?$', 'roles' => 'PUBLIC_ACCESS'],
             ['path' => '^/docs', 'roles' => 'PUBLIC_ACCESS'],
             ['path' => '^/auth/(request-link|refresh|verify)$', 'roles' => 'PUBLIC_ACCESS'],
             ['path' => '^/access-requests(/verify)?$', 'roles' => 'PUBLIC_ACCESS'],

--- a/api/config/services.php
+++ b/api/config/services.php
@@ -10,6 +10,10 @@ use App\Repository\TripRequestRepositoryInterface;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->parameters()
+        ->set('app.commit_sha', '%env(default:default_commit_sha:APP_COMMIT)%')
+        ->set('default_commit_sha', 'unknown');
+
     $services = $containerConfigurator->services();
 
     $services->defaults()

--- a/api/src/Controller/HealthController.php
+++ b/api/src/Controller/HealthController.php
@@ -32,7 +32,8 @@ final readonly class HealthController
         private HttpClientInterface $valhallaClient,
         #[Autowire(service: 'ollama.client')]
         private HttpClientInterface $ollamaClient,
-        private HttpClientInterface $httpClient,
+        #[Autowire(service: 'mercure.health.client')]
+        private HttpClientInterface $mercureClient,
         #[Autowire(service: 'limiter.health_liveness')]
         private RateLimiterFactory $healthLivenessLimiter,
         #[Autowire(service: 'limiter.health_readiness')]
@@ -41,8 +42,6 @@ final readonly class HealthController
         private string $commitSha,
         #[Autowire(env: 'REDIS_URL')]
         private string $redisUrl,
-        #[Autowire(env: 'MERCURE_URL')]
-        private string $mercureUrl,
     ) {
     }
 
@@ -73,7 +72,7 @@ final readonly class HealthController
 
         // Launch HTTP-based checks in parallel by issuing their requests up front.
         $pending = [
-            'mercure' => $this->startHttpCheck('HEAD', $this->mercureUrl.'?topic=health'),
+            'mercure' => $this->startHttpCheck('HEAD', '?topic=health', $this->mercureClient),
             'valhalla' => $this->startHttpCheck('GET', '/status', $this->valhallaClient),
             'ollama' => $this->startHttpCheck('GET', '/api/tags', $this->ollamaClient),
         ];
@@ -128,6 +127,10 @@ final readonly class HealthController
         $start = hrtime(true);
 
         try {
+            // Cap statement and any implicit reconnect to ~1s to avoid
+            // letting the probe block on the OS TCP timeout (~30s) when
+            // Postgres is unreachable.
+            $this->connection->executeStatement('SET statement_timeout = 1000');
             $this->connection->executeQuery('SELECT 1');
 
             return [
@@ -185,9 +188,8 @@ final readonly class HealthController
     /**
      * @return array{response: ?ResponseInterface, start: int, error: ?string}
      */
-    private function startHttpCheck(string $method, string $url, ?HttpClientInterface $client = null): array
+    private function startHttpCheck(string $method, string $url, HttpClientInterface $client): array
     {
-        $client ??= $this->httpClient;
         $start = hrtime(true);
 
         try {

--- a/api/src/Controller/HealthController.php
+++ b/api/src/Controller/HealthController.php
@@ -167,6 +167,14 @@ final readonly class HealthController
                 throw new \RuntimeException('connection failed');
             }
 
+            // Authenticate if the URL carries credentials (Coolify-managed
+            // Redis is typically password-protected). Without this PING
+            // returns NOAUTH and the probe falsely reports `down`.
+            if (isset($parsed['pass']) && '' !== $parsed['pass']) {
+                $user = $parsed['user'] ?? null;
+                $redis->auth(null !== $user && '' !== $user ? [$user, $parsed['pass']] : $parsed['pass']);
+            }
+
             $pong = $redis->ping();
             $redis->close();
 

--- a/api/src/Controller/HealthController.php
+++ b/api/src/Controller/HealthController.php
@@ -1,0 +1,240 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use Doctrine\DBAL\Connection;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * Liveness and readiness probes for orchestration (Coolify, Uptime Kuma, smoke tests).
+ *
+ * - GET /api/healthz: lightweight liveness, no dependencies, always 200.
+ * - GET /api/health:  readiness with parallel checks over critical dependencies.
+ *                     200 when every required dep is green, 503 otherwise.
+ */
+final readonly class HealthController
+{
+    private const float CHECK_TIMEOUT = 1.0;
+
+    public function __construct(
+        private Connection $connection,
+        #[Autowire(service: 'routing.client')]
+        private HttpClientInterface $valhallaClient,
+        #[Autowire(service: 'ollama.client')]
+        private HttpClientInterface $ollamaClient,
+        private HttpClientInterface $httpClient,
+        #[Autowire(service: 'limiter.health_liveness')]
+        private RateLimiterFactory $healthLivenessLimiter,
+        #[Autowire(service: 'limiter.health_readiness')]
+        private RateLimiterFactory $healthReadinessLimiter,
+        #[Autowire(param: 'app.commit_sha')]
+        private string $commitSha,
+        #[Autowire(env: 'REDIS_URL')]
+        private string $redisUrl,
+        #[Autowire(env: 'MERCURE_URL')]
+        private string $mercureUrl,
+    ) {
+    }
+
+    #[Route('/api/healthz', name: 'app_healthz', methods: ['GET'])]
+    public function liveness(Request $request): JsonResponse
+    {
+        $this->enforceRateLimit($this->healthLivenessLimiter, $request);
+
+        return new JsonResponse([
+            'status' => 'ok',
+            'commit' => $this->commitSha,
+        ]);
+    }
+
+    #[Route('/api/health', name: 'app_health', methods: ['GET'])]
+    public function readiness(Request $request): JsonResponse
+    {
+        $this->enforceRateLimit($this->healthReadinessLimiter, $request);
+
+        $deps = [];
+        $deps['postgres'] = $this->checkPostgres();
+        $deps['redis'] = $this->checkRedis();
+
+        // Launch HTTP-based checks in parallel by issuing their requests up front.
+        $pending = [
+            'mercure' => $this->startHttpCheck('HEAD', $this->mercureUrl.'?topic=health'),
+            'valhalla' => $this->startHttpCheck('GET', '/status', $this->valhallaClient),
+            'ollama' => $this->startHttpCheck('GET', '/api/tags', $this->ollamaClient),
+        ];
+
+        foreach ($pending as $name => $pair) {
+            $deps[$name] = $this->finishHttpCheck($pair);
+        }
+
+        $required = ['postgres', 'redis', 'mercure', 'valhalla'];
+        $status = 'ok';
+        foreach ($required as $dep) {
+            if ('ok' !== ($deps[$dep]['status'] ?? 'down')) {
+                $status = 'degraded';
+                break;
+            }
+        }
+
+        $httpStatus = 'ok' === $status ? Response::HTTP_OK : Response::HTTP_SERVICE_UNAVAILABLE;
+
+        return new JsonResponse([
+            'status' => $status,
+            'commit' => $this->commitSha,
+            'deps' => $deps,
+        ], $httpStatus);
+    }
+
+    private function enforceRateLimit(RateLimiterFactory $factory, Request $request): void
+    {
+        $limiter = $factory->create($request->getClientIp() ?? 'anonymous');
+
+        if (!$limiter->consume()->isAccepted()) {
+            throw new TooManyRequestsHttpException();
+        }
+    }
+
+    /**
+     * @return array{status: string, latency_ms: int, error?: string}
+     */
+    private function checkPostgres(): array
+    {
+        $start = hrtime(true);
+
+        try {
+            $this->connection->executeQuery('SELECT 1');
+
+            return [
+                'status' => 'ok',
+                'latency_ms' => $this->elapsedMs($start),
+            ];
+        } catch (\Throwable $e) {
+            return [
+                'status' => 'down',
+                'latency_ms' => $this->elapsedMs($start),
+                'error' => $this->sanitizeError($e),
+            ];
+        }
+    }
+
+    /**
+     * @return array{status: string, latency_ms: int, error?: string}
+     */
+    private function checkRedis(): array
+    {
+        $start = hrtime(true);
+
+        try {
+            $redis = new \Redis();
+            $parsed = parse_url($this->redisUrl);
+            if (false === $parsed || !isset($parsed['host'])) {
+                throw new \RuntimeException('invalid redis url');
+            }
+
+            $host = $parsed['host'];
+            $port = $parsed['port'] ?? 6379;
+            $connected = $redis->connect($host, $port, self::CHECK_TIMEOUT);
+            if (!$connected) {
+                throw new \RuntimeException('connection failed');
+            }
+
+            $pong = $redis->ping();
+            $redis->close();
+
+            $ok = '+PONG' === $pong || true === $pong || 'PONG' === $pong;
+
+            return [
+                'status' => $ok ? 'ok' : 'down',
+                'latency_ms' => $this->elapsedMs($start),
+            ];
+        } catch (\Throwable $throwable) {
+            return [
+                'status' => 'down',
+                'latency_ms' => $this->elapsedMs($start),
+                'error' => $this->sanitizeError($throwable),
+            ];
+        }
+    }
+
+    /**
+     * @return array{response: ?ResponseInterface, start: int, error: ?string}
+     */
+    private function startHttpCheck(string $method, string $url, ?HttpClientInterface $client = null): array
+    {
+        $client ??= $this->httpClient;
+        $start = hrtime(true);
+
+        try {
+            $response = $client->request($method, $url, [
+                'timeout' => self::CHECK_TIMEOUT,
+                'max_duration' => self::CHECK_TIMEOUT,
+            ]);
+
+            return ['response' => $response, 'start' => $start, 'error' => null];
+        } catch (\Throwable $throwable) {
+            return ['response' => null, 'start' => $start, 'error' => $this->sanitizeError($throwable)];
+        }
+    }
+
+    /**
+     * @param array{response: ?ResponseInterface, start: int, error: ?string} $pair
+     *
+     * @return array{status: string, latency_ms: int, error?: string}
+     */
+    private function finishHttpCheck(array $pair): array
+    {
+        $start = $pair['start'];
+
+        if (null !== $pair['error'] || null === $pair['response']) {
+            return [
+                'status' => 'down',
+                'latency_ms' => $this->elapsedMs($start),
+                'error' => $pair['error'] ?? 'no response',
+            ];
+        }
+
+        try {
+            $code = $pair['response']->getStatusCode();
+            // Drain the body so the response is fully consumed (releases the connection).
+            $pair['response']->getContent(false);
+
+            return [
+                'status' => $code < 500 ? 'ok' : 'down',
+                'latency_ms' => $this->elapsedMs($start),
+            ];
+        } catch (\Throwable $e) {
+            return [
+                'status' => 'down',
+                'latency_ms' => $this->elapsedMs($start),
+                'error' => $this->sanitizeError($e),
+            ];
+        }
+    }
+
+    private function elapsedMs(int $startNs): int
+    {
+        return (int) round((hrtime(true) - $startNs) / 1_000_000);
+    }
+
+    /**
+     * Surface only a short, non-sensitive class name to avoid leaking
+     * connection strings, hostnames, or stack traces in the public payload.
+     */
+    private function sanitizeError(\Throwable $e): string
+    {
+        $class = $e::class;
+        $short = substr((string) strrchr($class, '\\'), 1);
+
+        return '' !== $short ? $short : $class;
+    }
+}

--- a/api/src/Controller/HealthController.php
+++ b/api/src/Controller/HealthController.php
@@ -49,7 +49,10 @@ final readonly class HealthController
     #[Route('/api/healthz', name: 'app_healthz', methods: ['GET'])]
     public function liveness(Request $request): JsonResponse
     {
-        $this->enforceRateLimit($this->healthLivenessLimiter, $request);
+        // Liveness must remain dependency-free: rate limiting is best-effort and
+        // must never turn a healthy instance into a 5xx if Redis (or the cache
+        // pool backing the limiter) happens to be unreachable.
+        $this->enforceRateLimit($this->healthLivenessLimiter, $request, bestEffort: true);
 
         return new JsonResponse([
             'status' => 'ok',
@@ -60,7 +63,9 @@ final readonly class HealthController
     #[Route('/api/health', name: 'app_health', methods: ['GET'])]
     public function readiness(Request $request): JsonResponse
     {
-        $this->enforceRateLimit($this->healthReadinessLimiter, $request);
+        // Readiness reports degradation via the response body; do not let the
+        // rate limiter backend take down the probe itself.
+        $this->enforceRateLimit($this->healthReadinessLimiter, $request, bestEffort: true);
 
         $deps = [];
         $deps['postgres'] = $this->checkPostgres();
@@ -95,12 +100,23 @@ final readonly class HealthController
         ], $httpStatus);
     }
 
-    private function enforceRateLimit(RateLimiterFactory $factory, Request $request): void
+    private function enforceRateLimit(RateLimiterFactory $factory, Request $request, bool $bestEffort = false): void
     {
-        $limiter = $factory->create($request->getClientIp() ?? 'anonymous');
+        try {
+            $limiter = $factory->create($request->getClientIp() ?? 'anonymous');
 
-        if (!$limiter->consume()->isAccepted()) {
-            throw new TooManyRequestsHttpException();
+            if (!$limiter->consume()->isAccepted()) {
+                throw new TooManyRequestsHttpException();
+            }
+        } catch (TooManyRequestsHttpException $e) {
+            throw $e;
+        } catch (\Throwable $e) {
+            // The backing cache (e.g. Redis) is unavailable. Health probes must
+            // not fail on infrastructure issues unrelated to the probe itself —
+            // skip rate limiting rather than emit a 5xx.
+            if (!$bestEffort) {
+                throw $e;
+            }
         }
     }
 
@@ -118,11 +134,11 @@ final readonly class HealthController
                 'status' => 'ok',
                 'latency_ms' => $this->elapsedMs($start),
             ];
-        } catch (\Throwable $e) {
+        } catch (\Throwable $throwable) {
             return [
                 'status' => 'down',
                 'latency_ms' => $this->elapsedMs($start),
-                'error' => $this->sanitizeError($e),
+                'error' => $this->sanitizeError($throwable),
             ];
         }
     }
@@ -212,11 +228,11 @@ final readonly class HealthController
                 'status' => $code < 500 ? 'ok' : 'down',
                 'latency_ms' => $this->elapsedMs($start),
             ];
-        } catch (\Throwable $e) {
+        } catch (\Throwable $throwable) {
             return [
                 'status' => 'down',
                 'latency_ms' => $this->elapsedMs($start),
-                'error' => $this->sanitizeError($e),
+                'error' => $this->sanitizeError($throwable),
             ];
         }
     }

--- a/api/tests/Functional/HealthControllerTest.php
+++ b/api/tests/Functional/HealthControllerTest.php
@@ -28,6 +28,18 @@ final class HealthControllerTest extends ApiTestCase
         $this->client = self::createClient();
     }
 
+    #[\Override]
+    protected function tearDown(): void
+    {
+        // Reset overridden services so that the broken-Postgres mock and the
+        // unreachable REDIS_URL injected by a given test do not leak into
+        // subsequent ones — the kernel is reused ($alwaysBootKernel = false).
+        $container = self::getContainer();
+        $container->reset();
+        putenv('REDIS_URL');
+        parent::tearDown();
+    }
+
     #[Test]
     public function livenessReturns200WithCommitSha(): void
     {
@@ -135,6 +147,31 @@ final class HealthControllerTest extends ApiTestCase
         $this->assertSame('RuntimeException', $data['deps']['postgres']['error']);
     }
 
+    #[Test]
+    public function readinessReturns503WhenRedisIsDown(): void
+    {
+        // Bind an unreachable Redis URL before the kernel is booted so the
+        // HealthController is built with it as its `$redisUrl` arg.
+        $_ENV['REDIS_URL'] = 'redis://127.0.0.1:19999';
+        $_SERVER['REDIS_URL'] = 'redis://127.0.0.1:19999';
+        self::ensureKernelShutdown();
+        $client = self::createClient();
+
+        // Now register the mocked HTTP clients on the freshly booted container.
+        $container = self::getContainer();
+        $container->set('routing.client', new MockHttpClient(new MockResponse('OK', ['http_code' => 200])));
+        $container->set('ollama.client', new MockHttpClient(new MockResponse('{"models":[]}', ['http_code' => 200])));
+        $container->set('mercure.health.client', new MockHttpClient(new MockResponse('', ['http_code' => 200])));
+
+        $response = $client->request('GET', '/api/health');
+
+        unset($_ENV['REDIS_URL'], $_SERVER['REDIS_URL']);
+
+        $this->assertResponseStatusCodeSame(503);
+        $data = $response->toArray(false);
+        $this->assertSame('down', $data['deps']['redis']['status']);
+    }
+
     private function mockHealthHttpClients(
         MockResponse $valhalla,
         MockResponse $ollama,
@@ -143,7 +180,6 @@ final class HealthControllerTest extends ApiTestCase
         $container = self::getContainer();
         $container->set('routing.client', new MockHttpClient($valhalla));
         $container->set('ollama.client', new MockHttpClient($ollama));
-        // Default HTTP client is used for the Mercure HEAD check.
-        $container->set('http_client', new MockHttpClient($mercure));
+        $container->set('mercure.health.client', new MockHttpClient($mercure));
     }
 }

--- a/api/tests/Functional/HealthControllerTest.php
+++ b/api/tests/Functional/HealthControllerTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Symfony\Bundle\Test\Client;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+final class HealthControllerTest extends ApiTestCase
+{
+    private Client $client;
+
+    #[\Override]
+    public static function setUpBeforeClass(): void
+    {
+        self::$alwaysBootKernel = false;
+    }
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->client = self::createClient();
+    }
+
+    #[Test]
+    public function livenessReturns200WithCommitSha(): void
+    {
+        $response = $this->client->request('GET', '/api/healthz');
+
+        $this->assertResponseStatusCodeSame(200);
+
+        $data = $response->toArray();
+        $this->assertSame('ok', $data['status']);
+        $this->assertArrayHasKey('commit', $data);
+        $this->assertIsString($data['commit']);
+    }
+
+    #[Test]
+    public function livenessIsPubliclyAccessible(): void
+    {
+        // No Authorization header -> must still respond 200.
+        $this->client->request('GET', '/api/healthz');
+
+        $this->assertResponseStatusCodeSame(200);
+    }
+
+    #[Test]
+    public function readinessReturns200WhenAllDependenciesAreUp(): void
+    {
+        $this->mockHealthHttpClients(
+            valhalla: new MockResponse('OK', ['http_code' => 200]),
+            ollama: new MockResponse('{"models":[]}', ['http_code' => 200]),
+            mercure: new MockResponse('', ['http_code' => 200]),
+        );
+
+        $response = $this->client->request('GET', '/api/health');
+
+        $this->assertResponseStatusCodeSame(200);
+
+        $data = $response->toArray();
+        $this->assertSame('ok', $data['status']);
+        $this->assertArrayHasKey('deps', $data);
+        foreach (['postgres', 'redis', 'mercure', 'valhalla', 'ollama'] as $dep) {
+            $this->assertArrayHasKey($dep, $data['deps'], \sprintf('Missing dep %s', $dep));
+            $this->assertArrayHasKey('status', $data['deps'][$dep]);
+            $this->assertArrayHasKey('latency_ms', $data['deps'][$dep]);
+        }
+    }
+
+    #[Test]
+    public function readinessReturns503WhenValhallaIsDown(): void
+    {
+        $this->mockHealthHttpClients(
+            valhalla: new MockResponse('boom', ['http_code' => 500]),
+            ollama: new MockResponse('{"models":[]}', ['http_code' => 200]),
+            mercure: new MockResponse('', ['http_code' => 200]),
+        );
+
+        $response = $this->client->request('GET', '/api/health');
+
+        $this->assertResponseStatusCodeSame(503);
+
+        $data = $response->toArray(false);
+        $this->assertSame('degraded', $data['status']);
+        $this->assertSame('down', $data['deps']['valhalla']['status']);
+    }
+
+    #[Test]
+    public function readinessReturns503WhenMercureIsUnreachable(): void
+    {
+        $this->mockHealthHttpClients(
+            valhalla: new MockResponse('OK', ['http_code' => 200]),
+            ollama: new MockResponse('{"models":[]}', ['http_code' => 200]),
+            mercure: new MockResponse('', ['http_code' => 0, 'error' => 'connection refused']),
+        );
+
+        $response = $this->client->request('GET', '/api/health');
+
+        $this->assertResponseStatusCodeSame(503);
+
+        $data = $response->toArray(false);
+        $this->assertSame('down', $data['deps']['mercure']['status']);
+    }
+
+    #[Test]
+    #[AllowMockObjectsWithoutExpectations]
+    public function readinessReturns503WhenPostgresIsDown(): void
+    {
+        $this->mockHealthHttpClients(
+            valhalla: new MockResponse('OK', ['http_code' => 200]),
+            ollama: new MockResponse('{"models":[]}', ['http_code' => 200]),
+            mercure: new MockResponse('', ['http_code' => 200]),
+        );
+
+        $brokenConnection = $this->createMock(Connection::class);
+        $brokenConnection->method('executeQuery')->willThrowException(
+            new \RuntimeException('connection refused')
+        );
+        self::getContainer()->set('doctrine.dbal.default_connection', $brokenConnection);
+
+        $response = $this->client->request('GET', '/api/health');
+
+        $this->assertResponseStatusCodeSame(503);
+
+        $data = $response->toArray(false);
+        $this->assertSame('down', $data['deps']['postgres']['status']);
+        // Sanity: error string is sanitized (short class name, no stack trace).
+        $this->assertArrayHasKey('error', $data['deps']['postgres']);
+        $this->assertSame('RuntimeException', $data['deps']['postgres']['error']);
+    }
+
+    private function mockHealthHttpClients(
+        MockResponse $valhalla,
+        MockResponse $ollama,
+        MockResponse $mercure,
+    ): void {
+        $container = self::getContainer();
+        $container->set('routing.client', new MockHttpClient($valhalla));
+        $container->set('ollama.client', new MockHttpClient($ollama));
+        // Default HTTP client is used for the Mercure HEAD check.
+        $container->set('http_client', new MockHttpClient($mercure));
+    }
+}

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -11,6 +11,8 @@ services:
       context: ./
       dockerfile: .docker/php/Dockerfile
       target: frankenphp_prod
+      args:
+        COMMIT_SHA: ${COMMIT_SHA:-unknown}
     restart: unless-stopped
     read_only: true
     tmpfs:
@@ -48,6 +50,7 @@ services:
       MAILER_DSN: "${MAILER_DSN}"
       DATATOURISME_API_KEY: "${DATATOURISME_API_KEY:-}"
       DATATOURISME_ENABLED: "${DATATOURISME_ENABLED:-false}"
+      APP_COMMIT: "${COMMIT_SHA:-unknown}"
     secrets:
       - jwt_private_key
       - jwt_public_key
@@ -71,7 +74,7 @@ services:
       - .docker/php/conf.d/10-app.ini:/usr/local/etc/php/conf.d/zz-app.ini:ro
       - .docker/php/conf.d/20-app.prod.ini:/usr/local/etc/php/conf.d/zz-app.prod.ini:ro
     healthcheck:
-      test: curl --fail http://php/docs || exit 1
+      test: curl -fsS http://php/api/healthz || exit 1
       start_period: 30s
       interval: 10s
       timeout: 3s

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -1,3 +1,8 @@
+# Uptime monitoring (Uptime Kuma) is deployed as a separate Coolify resource,
+# not embedded in this stack. See .docker/uptime-kuma/README.md for the
+# installation procedure and the external UptimeRobot safety net is documented
+# in docs/runbooks/uptime-monitoring.md.
+
 secrets:
   jwt_private_key:
     file: ${JWT_PRIVATE_KEY_PATH:-/etc/bike-trip-planner/jwt/private.pem}
@@ -11,8 +16,6 @@ services:
       context: ./
       dockerfile: .docker/php/Dockerfile
       target: frankenphp_prod
-      args:
-        COMMIT_SHA: ${COMMIT_SHA:-unknown}
     restart: unless-stopped
     read_only: true
     tmpfs:
@@ -50,7 +53,6 @@ services:
       MAILER_DSN: "${MAILER_DSN}"
       DATATOURISME_API_KEY: "${DATATOURISME_API_KEY:-}"
       DATATOURISME_ENABLED: "${DATATOURISME_ENABLED:-false}"
-      APP_COMMIT: "${COMMIT_SHA:-unknown}"
     secrets:
       - jwt_private_key
       - jwt_public_key
@@ -74,7 +76,7 @@ services:
       - .docker/php/conf.d/10-app.ini:/usr/local/etc/php/conf.d/zz-app.ini:ro
       - .docker/php/conf.d/20-app.prod.ini:/usr/local/etc/php/conf.d/zz-app.prod.ini:ro
     healthcheck:
-      test: curl -fsS http://php/api/healthz || exit 1
+      test: curl --fail http://php/docs || exit 1
       start_period: 30s
       interval: 10s
       timeout: 3s

--- a/docs/runbooks/uptime-monitoring.md
+++ b/docs/runbooks/uptime-monitoring.md
@@ -1,0 +1,129 @@
+# Runbook — Uptime monitoring
+
+Two-layer uptime monitoring for Bike Trip Planner production:
+
+1. **Self-hosted (Uptime Kuma)** on the Coolify VM — sub-minute detection,
+   rich monitor types, public status page. Configuration documented in
+   [`.docker/uptime-kuma/README.md`](../../.docker/uptime-kuma/README.md).
+2. **External (UptimeRobot)** — single off-host probe that survives a full VM
+   outage. This document covers (2).
+
+## Why two layers?
+
+Uptime Kuma runs on the same Oracle Cloud Always Free VM as the application
+(see [ADR-019](../adr/0019-hosting-coolify-oracle-cloud.md)). If the VM goes
+down — kernel panic, network ACL change, Oracle reclaims the instance — Uptime
+Kuma goes down with it and emits no alert. UptimeRobot's free tier runs from
+external probes; a single HTTP monitor is enough to detect a host-level outage
+and trigger the incident workflow.
+
+## UptimeRobot setup
+
+### Account
+
+1. Create a free account on <https://uptimerobot.com> with the team alias
+   `oncall@biketrip.mooo.com` (or any shared inbox). Free tier allows 50
+   monitors at 5-minute intervals; we use one.
+2. Enable **two-factor authentication** on the account.
+
+### Monitor
+
+**+ Add New Monitor**:
+
+- **Monitor Type**: `HTTP(s)`
+- **Friendly Name**: `biketrip-healthz`
+- **URL**: `https://biketrip.mooo.com/api/healthz`
+- **Monitoring Interval**: `5 minutes` (free tier minimum)
+- **Monitor Timeout**: `30 seconds`
+- **HTTP Method**: `GET`
+- **Accepted Status Codes**: `200`
+- **Alert Contacts**: see below
+
+### Alert contact — GitHub `repository_dispatch` webhook
+
+**My Settings → Alert Contacts → Add Alert Contact**:
+
+- **Alert Contact Type**: `Webhook`
+- **Friendly Name**: `github-incident-dispatch`
+- **URL to Notify**:
+  `https://api.github.com/repos/vincentchalamon/bike-trip-planner/dispatches`
+- **POST Value (JSON Format)**: enable
+- **POST Value**:
+
+  ```json
+  {
+    "event_type": "uptime_alert",
+    "client_payload": {
+      "source": "uptimerobot",
+      "monitor": "biketrip-healthz",
+      "status": "*alertTypeFriendlyName*",
+      "url": "*monitorURL*",
+      "details": "*alertDetails*"
+    }
+  }
+  ```
+
+- **Custom HTTP Headers** (UptimeRobot Pro feature; on free tier, encode the
+  token in the URL query string as a fallback — see workaround below):
+
+  ```json
+  {
+    "Authorization": "Bearer <INCIDENT_DISPATCH_TOKEN>",
+    "Accept": "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28"
+  }
+  ```
+
+  > **Free tier workaround**: UptimeRobot free does not allow custom headers.
+  > Route the webhook through a tiny relay (Cloudflare Worker or a
+  > GitHub-hosted `workflow_dispatch` proxy) that adds the `Authorization`
+  > header server-side. Document the relay URL in the Coolify secret store.
+  > Until the relay exists, the UptimeRobot alert still fires by email; the
+  > `repository_dispatch` automation is best-effort on free tier.
+
+- **Enable notifications for**: `Down` and `Up`.
+
+Attach the alert contact to the `biketrip-healthz` monitor.
+
+### Verification
+
+```bash
+# Simulate a down event from a workstation (requires the PAT):
+curl -fsS -X POST \
+  -H "Authorization: Bearer $INCIDENT_DISPATCH_TOKEN" \
+  -H "Accept: application/vnd.github+json" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  https://api.github.com/repos/vincentchalamon/bike-trip-planner/dispatches \
+  -d '{"event_type":"uptime_alert","client_payload":{"source":"uptimerobot","monitor":"biketrip-healthz","status":"down"}}'
+```
+
+GitHub answers `204 No Content` on success. The future incident workflow
+(#P1.3) listens on `repository_dispatch` events of type `uptime_alert`.
+
+## Severity & escalation
+
+| Monitor                                  | Source        | Severity | First responder         |
+| ---------------------------------------- | ------------- | -------- | ----------------------- |
+| `/api/healthz` (60 s)                    | Uptime Kuma   | P1       | On-call engineer        |
+| `/api/healthz` (5 min, external)         | UptimeRobot   | P1       | On-call engineer        |
+| `/api/health` (5 min)                    | Uptime Kuma   | P2       | On-call engineer        |
+| Keyword `/`                              | Uptime Kuma   | P1       | On-call engineer        |
+| DNS `A` record                           | Uptime Kuma   | P2       | Infra owner             |
+| Mercure hub                              | Uptime Kuma   | P2       | Backend owner           |
+
+UptimeRobot is intentionally redundant with Uptime Kuma #1. The duplicate alarm
+is the trade-off: if both fire, the issue is real; if only UptimeRobot fires,
+the VM (or Uptime Kuma) is the problem.
+
+## Token rotation
+
+`INCIDENT_DISPATCH_TOKEN` is a fine-grained GitHub PAT with
+**Contents: Read & write** on `vincentchalamon/bike-trip-planner` only.
+
+- Lifetime: 90 days (GitHub maximum for fine-grained PATs without SSO).
+- Storage: Coolify secret store (for Uptime Kuma) + UptimeRobot alert contact
+  (or relay env var).
+- Rotation runbook: generate a new PAT, update both stores, send a test
+  dispatch, then revoke the old PAT.
+
+Never commit the token to the repository.


### PR DESCRIPTION
## Summary

Implements P1.2 of the production bug-management plan: a two-layer uptime
monitoring stack so that production outages are detected in under a minute and
piped into the upcoming P1.3 incident automation.

- **Self-hosted (`.docker/uptime-kuma/`)** — Coolify-managed `louislam/uptime-kuma:1.23.16`
  on `status.biketrip.mooo.com`, with Traefik/Let's Encrypt labels, an internal
  `curl` healthcheck, and a persistent SQLite volume. The README documents the
  five monitors to create manually (`/api/healthz` P1 @ 60 s, `/api/health` P2,
  keyword on `/`, DNS A record, Mercure hub), the public status page at
  `/status/public`, and the GitHub `repository_dispatch` webhook (with
  `<INCIDENT_DISPATCH_TOKEN>` placeholder).
- **External (`docs/runbooks/uptime-monitoring.md`)** — UptimeRobot free-tier
  monitor on `/api/healthz` (5 min) acting as the off-host safety net for full
  VM outages, with the same `repository_dispatch` webhook contract and a
  free-tier workaround for the missing custom-header support.
- `compose.prod.yaml` — a comment now points operators at the dedicated
  Uptime Kuma stack instead of embedding it in the main compose file
  (Coolify pattern preserved).

> Note: this PR is temporarily based on top of #497 (P0.2 health endpoints,
> branch `feat/486-health-endpoints`). The blocker commits will disappear from
> the diff once #497 is merged into `main`.

Closes #489

## Test plan

- [ ] `make qa` passes locally (markdown + YAML).
- [ ] Deploy `.docker/uptime-kuma/docker-compose.yml` via Coolify on staging
      and verify `https://status.biketrip.mooo.com` serves the Uptime Kuma UI
      with a valid Let's Encrypt certificate.
- [ ] Create the five monitors listed in `.docker/uptime-kuma/README.md` and
      confirm they all turn green against staging.
- [ ] Configure the GitHub webhook notification and confirm a forced DOWN
      event on staging triggers `repository_dispatch` (`204 No Content`).
- [ ] Create the UptimeRobot account + monitor described in
      `docs/runbooks/uptime-monitoring.md` and verify the email alert fires
      when staging `/api/healthz` is taken down.
- [ ] Stop Redis on staging → `/api/health` returns `503` → Uptime Kuma alerts
      within 60 s.

<!-- claude-review-start -->
## Claude Review

All previous findings have been addressed. The two-layer monitoring stack (Uptime Kuma + UptimeRobot), the scoped Mercure health client, the best-effort rate limiter, Redis credential authentication, and the Redis-down test are all well-implemented. The `symfony/polyfill-intl-idn` CVE bump is included. No new findings.

**Findings: 0 critical · 0 warnings · 0 info**

Reviewed commit: `04e846a1909feb97f873b43f8d294c1821cf05e8`

---

### Resolved threads

Resolved 2 previously open threads that were addressed:
- Mercure unscoped-client warning → fixed via `mercure.health.client` scoped service
- Missing Redis-down test → `readinessReturns503WhenRedisIsDown()` added

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Inline comments

No inline comments.

---

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->