### PR TITLE
chore(ci): pin third-party actions to immutable SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Run Hadolint
-        uses: hadolint/hadolint-action@v3.3.0
+        uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
         with:
           dockerfile: .docker/**/Dockerfile
 
@@ -152,7 +152,7 @@ jobs:
             ${{ runner.OS }}-phpcsfixer-
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v47
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
           files: ${{ matrix.project }}/**/*.php
       - name: Get Extra Arguments for PHP-CS-Fixer
@@ -297,7 +297,7 @@ jobs:
           echo "JWT_PRIVATE_KEY_PATH=${{ github.workspace }}/api/config/jwt/private.pem" >> "$GITHUB_ENV"
           echo "JWT_PUBLIC_KEY_PATH=${{ github.workspace }}/api/config/jwt/public.pem" >> "$GITHUB_ENV"
       - name: Build Docker images
-        uses: docker/bake-action@v7
+        uses: docker/bake-action@6614cfa25eff9a0b2b2697efb0b6159e7680d584 # v7.2.0
         with:
           load: true
           files: |
@@ -358,7 +358,7 @@ jobs:
           echo "JWT_PRIVATE_KEY_PATH=${{ github.workspace }}/api/config/jwt/private.pem" >> "$GITHUB_ENV"
           echo "JWT_PUBLIC_KEY_PATH=${{ github.workspace }}/api/config/jwt/public.pem" >> "$GITHUB_ENV"
       - name: Build Docker images
-        uses: docker/bake-action@v7
+        uses: docker/bake-action@6614cfa25eff9a0b2b2697efb0b6159e7680d584 # v7.2.0
         with:
           load: true
           files: |


### PR DESCRIPTION
## Contexte

Cette PR a été préparée dans le cadre du sprint **Gestion des bugs en prod** (#494 -> #502) avec l'hypothese initiale que certaines actions GitHub tierces utilisees dans `.github/workflows/ci.yml` etaient cassees (tags supprimes / repos suspendus).

## Diagnostic

Apres verification sur GitHub :

| Action | Statut reel | Derniere version | SHA |
|--------|-------------|------------------|-----|
| `tj-actions/changed-files@v47` | Tag valide (v47.0.6, publiee post-incident securite mars 2025) | v47.0.6 (18 avril 2025) | `9426d40962ed5378910ee2e21d5f8c6fcbf2dd96` |
| `docker/bake-action@v7` | Tag valide | v7.2.0 (21 mai) | `6614cfa25eff9a0b2b2697efb0b6159e7680d584` |
| `hadolint/hadolint-action@v3.3.0` | Tag valide | v3.3.0 (22 sept 2025) | `2332a7b74a6de0dda2e2221d575162eba76ba5e5` |

**Conclusion :** aucune des 3 actions n'est reellement cassee. Les CI failures observees sur #494 -> #502 ne sont **pas** liees aux actions tierces — par exemple sur #494, Hadolint, PHP CS Fixer et Playwright BDD Recette passent tous au vert. Les failures eparses sur d'autres PRs (#498, #500) concernent du code (Rector / PHPStan / Markdown Lint) et non l'infrastructure CI.

## Changement applique

Bien que les tags soient actuellement intacts, ils restent **mutables**. L'incident `tj-actions/changed-files` de mars 2025 a precisement consiste en la re-publication des tags v1 -> v45 vers un commit malveillant. La best practice GitHub Actions pour les actions tierces est donc de **pin les SHA complets** (40 caracteres), avec un commentaire mentionnant la version pour la tracabilite :

```yaml
uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
```

Cette PR remplace les 3 references de tag par leur SHA immuable.

## Actions encore en tag mutable (hors scope)

Pour information, d'autres actions tierces du workflow utilisent encore des tags mutables et meriteraient un pin SHA dans une PR future :

- `docker/setup-buildx-action@v4` (lignes 291, 352)
- `docker://oskarstark/php-cs-fixer-ga` (ligne 167, image Docker sans tag — utilise `latest`)

Les actions officielles `actions/*` (`checkout`, `cache`, `setup-node`, `setup-java`, `upload-artifact`) restent en tag mutable car publiees par GitHub directement (risque moindre).

## Test plan

- [ ] CI verte sur cette PR (Hadolint + PHP CS Fixer + Playwright)
- [ ] Aucune regression de comportement sur les jobs concernes

## Note

Le brief initial proposait que cette PR soit **mergee en premier pour debloquer #494 -> #502**. Le diagnostic montre que cela n'est pas necessaire : les CI failures sur ces PRs ne dependent pas des actions tierces. Cette PR reste neanmoins valuable comme amelioration de securite (best practice supply-chain).

<!-- claude-review-start -->
## Claude Review

Clean, well-scoped CI hardening change. All three SHA pins use full 40-character commit hashes with inline version comments for traceability — exactly the correct pattern. The existing Dependabot `github-actions` configuration (monthly schedule) supports SHA-pinned actions and will automatically open PRs when new versions are available, so maintenance burden is addressed.

**Resolved threads:** none (no prior review threads existed).

### Review checklist
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases (N/A — pure CI config, no behavioral change)
- [x] Documentation is up to date (inline `# vX.Y.Z` comments provide version traceability)
- [x] Dependent tickets accounted for

**No inline comments.**

> Reviewed commit `a9816af093c9ef0c8f7122d76d355459334a1d04`

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->