### PR TITLE
fix(security): bump symfony/polyfill-intl-idn (CVE-2026-46644)

### DIFF
--- a/api/composer.lock
+++ b/api/composer.lock
@@ -6916,16 +6916,16 @@
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.37.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
-                "reference": "9614ac4d8061dc257ecc64cba1b140873dce8ad3"
+                "reference": "dc21118016c039a66235cf93d96b435ffb282412"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/9614ac4d8061dc257ecc64cba1b140873dce8ad3",
-                "reference": "9614ac4d8061dc257ecc64cba1b140873dce8ad3",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/dc21118016c039a66235cf93d96b435ffb282412",
+                "reference": "dc21118016c039a66235cf93d96b435ffb282412",
                 "shasum": ""
             },
             "require": {
@@ -6979,7 +6979,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -6999,7 +6999,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-10T14:38:51+00:00"
+            "time": "2026-05-25T15:22:23+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",


### PR DESCRIPTION
## Contexte

Le job CI **Security Check (api)** plante sur `main` car `api/composer.lock` contient `symfony/polyfill-intl-idn` en version `v1.37.0`, vulnérable à la **CVE-2026-46644**.

Le bump vers `v1.38.1` est déjà appliqué dans les PRs #497 et #498, mais pas encore sur `main`. Conséquence : les PRs Wave 1 (#494, #495, #496), basées sur `main`, héritent du `composer.lock` vulnérable et leurs jobs Security Check sont rouges, ce qui bloque l'ensemble du flux.

Cette PR isole le fix sur `main` pour débloquer rapidement la chaîne CI sans attendre la fusion des PRs #497/#498.

## Changement

- `api/composer.lock` : `symfony/polyfill-intl-idn` `v1.37.0` -> `v1.38.1` (diff identique au commit `b9b8e0a6` de la PR #497).

## Impact

- Débloque le job **Security Check (api)** sur `main`.
- Débloque les PRs #494, #495, #496 (Wave 1) une fois rebasées / mergées sur ce `main` corrigé.

## Test plan

- [ ] La CI passe (Security Check (api) vert).
- [ ] `composer audit` ne signale plus CVE-2026-46644.

<!-- claude-review-start -->
## Claude Review

Minimal, targeted security patch. The diff is limited to the `composer.lock` entry for `symfony/polyfill-intl-idn`, replacing the vulnerable `v1.37.0` with `v1.38.1`. All changed fields (version string, git reference, dist URL, source URL, timestamp) are internally consistent with a legitimate upstream release bump. No code changes; no test coverage gap.

**Findings:** 0 critical · 0 warning · 0 info

**Review checklist**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**No inline comments.**

Reviewed commit: `e835d824cae9c8bba2098cf533a9a94704114ea5`

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->