### PR TITLE
chore(claude): add /check and /close skills, bounded PR surveillance

### DIFF
--- a/.claude/skills/check/SKILL.md
+++ b/.claude/skills/check/SKILL.md
@@ -21,11 +21,11 @@ Run the target. If it passes, go to Step 4.
 
 If it fails, read the **real error output**. Identify the failing tool (PHP-CS-Fixer, Rector, PHPStan, ESLint, Prettier, TS, PHPUnit, Playwright) and the precise cause.
 
-## Step 3 — Fix and retry (max 3 attempts)
+## Step 3 — Fix and retry (max 3 runs total)
 
 Apply the **smallest fix that makes the check pass** — lint/format/type errors, broken assertions, missing typegen. **Do not change feature behavior** to force a pass: if a test reveals a real regression, stop and report it instead of editing the test to match.
 
-Re-run the target. Repeat up to **3 attempts total**. After 3 failed attempts, stop and list the remaining errors verbatim — do not loop further.
+Re-run the target. Repeat up to **2 more times** (3 runs total including Step 2). After 3 failed runs, stop and list the remaining errors verbatim — do not loop further.
 
 ## Step 4 — Report with proof
 

--- a/.claude/skills/check/SKILL.md
+++ b/.claude/skills/check/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: check
+description: Goal-loop quality gate — run QA/tests and fix until green, with real output as proof
+argument-hint: "[qa|test|all]"
+allowed-tools: Bash(make *), Read, Edit, Grep, Glob
+---
+
+Drive the project to a verified-green state. Parse `$ARGUMENTS`: `qa`, `test`, or `all` (default `all`).
+
+This is a **goal-loop**: the completion condition is a passing run with its real output shown — not an assertion of success.
+
+## Step 1 — Pick the target
+
+- `qa` → `make qa`
+- `test` → `make test`
+- `all` (default) → `make qa`, then `make test`
+
+## Step 2 — Run and inspect
+
+Run the target. If it passes, go to Step 4.
+
+If it fails, read the **real error output**. Identify the failing tool (PHP-CS-Fixer, Rector, PHPStan, ESLint, Prettier, TS, PHPUnit, Playwright) and the precise cause.
+
+## Step 3 — Fix and retry (max 3 attempts)
+
+Apply the **smallest fix that makes the check pass** — lint/format/type errors, broken assertions, missing typegen. **Do not change feature behavior** to force a pass: if a test reveals a real regression, stop and report it instead of editing the test to match.
+
+Re-run the target. Repeat up to **3 attempts total**. After 3 failed attempts, stop and list the remaining errors verbatim — do not loop further.
+
+## Step 4 — Report with proof
+
+Declare green **only** with the real command output pasted as evidence. If `all` was requested, both `make qa` and `make test` must be green.
+
+If you stopped at the attempt cap or on a suspected real regression, say so explicitly and show the outstanding errors.

--- a/.claude/skills/close/SKILL.md
+++ b/.claude/skills/close/SKILL.md
@@ -25,7 +25,7 @@ List the **concrete** items that would be removed, with their PR/merge status:
 ## Step 3 — Clean up (plain git, only after confirmation)
 
 For each branch whose PR is **merged or closed**:
-- `git worktree remove <path>` then `git worktree prune`
+- `git worktree remove <path>` then `git worktree prune`. If removal fails (dirty worktree), **flag it and skip** rather than force.
 - `git branch -d feature/<n>` — use **`-d`, not `-D`**. If git refuses (unmerged), **flag it and skip** rather than force-delete.
 
 Worktrees live under the gitignored `.claude/worktrees/`, so these removals are purely local.

--- a/.claude/skills/close/SKILL.md
+++ b/.claude/skills/close/SKILL.md
@@ -2,7 +2,7 @@
 name: close
 description: Close a sprint — clean up local worktrees/branches, update main, and run a retrospective into the Claude config
 argument-hint: "[sprint-number]"
-allowed-tools: Bash(git *), Bash(gh *), Read, Edit, Grep, Glob
+allowed-tools: Bash(git *), Bash(gh *), Read, Write, Edit, Grep, Glob
 ---
 
 Close the current sprint: tidy local state and capture learnings. Parse `$ARGUMENTS`: an optional sprint number (override). If absent, **auto-detect** the current sprint.
@@ -45,4 +45,4 @@ Synthesize what went well / badly during this sprint, grounded in **actual event
 - a new/updated skill (`pick`, `sprint`, `check`, …)
 - a hook or permission in `.claude/settings.json`
 
-**Propose, do not apply.** If the user approves a change, implement it via a **feature branch + PR** — never commit config directly to `main` (and TRACKING.md changes also go through a PR).
+**Propose, do not apply.** If the user approves a change, implement it via a **feature branch + PR** — never commit config directly to `main`.

--- a/.claude/skills/close/SKILL.md
+++ b/.claude/skills/close/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: close
+description: Close a sprint — clean up local worktrees/branches, update main, and run a retrospective into the Claude config
+argument-hint: "[sprint-number]"
+allowed-tools: Bash(git *), Bash(gh *), Read, Edit, Grep, Glob
+---
+
+Close the current sprint: tidy local state and capture learnings. Parse `$ARGUMENTS`: an optional sprint number (override). If absent, **auto-detect** the current sprint.
+
+## Step 1 — Detect the sprint
+
+In priority order:
+1. The sprint number already discussed in this conversation.
+2. Otherwise infer it: list local `feature/<n>` branches (`git branch`) and worktrees (`git worktree list`), then cross-reference those issue numbers against `TRACKING.md` to find which sprint they belong to.
+3. If still ambiguous (several active sprints, or none): propose the most likely sprint and **ask the user to confirm** before doing anything.
+
+## Step 2 — Show the cleanup plan (destructive guard)
+
+List the **concrete** items that would be removed, with their PR/merge status:
+- Each worktree under `.claude/worktrees/` tied to a sprint issue (`git worktree list`).
+- Each local `feature/<n>` branch, with whether its PR is merged/closed/open (`gh pr view feature/<n> --json state,mergedAt`).
+
+**Require explicit user confirmation before any deletion**, regardless of confidence. Never delete a branch/worktree whose PR is still open.
+
+## Step 3 — Clean up (plain git, only after confirmation)
+
+For each branch whose PR is **merged or closed**:
+- `git worktree remove <path>` then `git worktree prune`
+- `git branch -d feature/<n>` — use **`-d`, not `-D`**. If git refuses (unmerged), **flag it and skip** rather than force-delete.
+
+Worktrees live under the gitignored `.claude/worktrees/`, so these removals are purely local.
+
+## Step 4 — Update main
+
+```bash
+git checkout main && git pull --ff-only origin main
+```
+
+If `--ff-only` fails (local main diverged), report it and stop — do not reset or force.
+
+## Step 5 — Retrospective into the config
+
+Synthesize what went well / badly during this sprint, grounded in **actual events** (recurring CI failures, review back-and-forths, blocking hooks, conventions repeatedly missed). For each recurring pain point, propose a **concrete** config change:
+- `CLAUDE.md` rule or gotcha
+- a new/updated skill (`pick`, `sprint`, `check`, …)
+- a hook or permission in `.claude/settings.json`
+
+**Propose, do not apply.** If the user approves a change, implement it via a **feature branch + PR** — never commit config directly to `main` (and TRACKING.md changes also go through a PR).

--- a/.claude/skills/pick/SKILL.md
+++ b/.claude/skills/pick/SKILL.md
@@ -64,7 +64,7 @@ Each cycle:
 2. **Review comments** — fetch PR-level (`gh pr view --json comments`) and inline (`gh api repos/:owner/:repo/pulls/<pr>/comments`) comments. Address actionable points, push, resolve threads; list any left unactioned with the reason.
 3. **Conflicts** — `gh pr view --json mergeable,mergeStateStatus`. If `CONFLICTING`: rebase onto the base and resolve **conservatively**; if ambiguous or risky, stop and flag rather than force.
 
-**READY** when: CI green AND mergeable AND not draft AND a fresh `claude-code-review.yml` cycle adds no new blocking (Critical/High) comment. After 3 cycles without convergence, report **NEEDS ATTENTION** with the blocker.
+**READY** when: CI green AND mergeable AND not draft AND `claude-code-review.yml` has completed (`gh run view --workflow=claude-code-review.yml` shows `completed`) with no new blocking (Critical/High) comment. Wait for that workflow to finish before evaluating — it runs asynchronously after each push. After 3 cycles without convergence, report **NEEDS ATTENTION** with the blocker.
 
 ## Step 10 -- Finalize
 

--- a/.claude/skills/pick/SKILL.md
+++ b/.claude/skills/pick/SKILL.md
@@ -55,12 +55,19 @@ Fix anything found, commit, and push.
 - Create the PR: `gh pr create --fill --base <base-branch>`
 - The PR body must include an **Auto-critique** section per CLAUDE.md
 
-## Step 9 -- Wait for CI
+## Step 9 -- Drive the PR to READY
 
-Run `gh pr checks --watch`. If CI fails, read the logs, fix the issues, push, and watch again.
+Run the **bounded surveillance loop** (max 3 cycles) until the PR is READY. Never merge — the user merges.
+
+Each cycle:
+1. **CI** — `gh pr checks`. If red: read the logs (`gh run view --log-failed`), fix, push.
+2. **Review comments** — fetch PR-level (`gh pr view --json comments`) and inline (`gh api repos/:owner/:repo/pulls/<pr>/comments`) comments. Address actionable points, push, resolve threads; list any left unactioned with the reason.
+3. **Conflicts** — `gh pr view --json mergeable,mergeStateStatus`. If `CONFLICTING`: rebase onto the base and resolve **conservatively**; if ambiguous or risky, stop and flag rather than force.
+
+**READY** when: CI green AND mergeable AND not draft AND a fresh `claude-code-review.yml` cycle adds no new blocking (Critical/High) comment. After 3 cycles without convergence, report **NEEDS ATTENTION** with the blocker.
 
 ## Step 10 -- Finalize
 
 - If TRACKING.md exists, update the row for this issue: change status to "En cours" and branch to `feature/<issue-number>`. Commit and push.
 - Remove the worktree: `git worktree remove .claude/worktrees/feature-<issue-number>`
-- Report the PR URL to the user.
+- Report the PR URL and its final status (READY / NEEDS ATTENTION + blocker) to the user.

--- a/.claude/skills/sprint/SKILL.md
+++ b/.claude/skills/sprint/SKILL.md
@@ -85,29 +85,46 @@ For each branch that passed Phase 2, create a PR:
    - Title: Conventional Commit format matching the issue type
    - Body: summary + Auto-critique section per CLAUDE.md
    - Base branch: `main` (or `feature/<dep-number>` for dependent issues)
-3. Run `gh pr checks --watch` to wait for CI (run multiple watches in parallel if possible)
 
-If CI fails, read logs, fix, push, and re-check (up to 2 attempts).
+## Step 6 — Phase 4: Drive each PR to READY
 
-## Step 6 — Update TRACKING.md
+For each open PR, run the **bounded surveillance loop** until it converges. **Maximum K=3 cycles per PR.** Never merge — the user merges (a PR is only ever brought to READY).
+
+Each cycle:
+
+1. **CI** — `gh pr checks <pr>`. If red: read the failing logs (`gh run view --log-failed`), apply the smallest fix, commit, push.
+2. **Review comments** — fetch both:
+   - PR-level comments: `gh pr view <pr> --json comments`
+   - Inline review comments: `gh api repos/:owner/:repo/pulls/<pr>/comments`
+
+   Address every **actionable** point, commit, push, then reply to / resolve the corresponding threads. List any comment you deliberately did not action, with the reason.
+3. **Conflicts** — `gh pr view <pr> --json mergeable,mergeStateStatus`. If `CONFLICTING`: rebase onto the base branch and resolve **conservatively**. If the resolution is ambiguous or risks discarding work, **stop and flag it** — do not force a resolution.
+
+**Termination (READY)** when all hold: CI green **AND** `mergeable` **AND** not draft **AND** a fresh `claude-code-review.yml` cycle adds **no new blocking comment** (Critical/High).
+
+**Loop note:** each push triggers `synchronize` → the review bot re-runs and auto-resolves its own fixed threads. Treat that auto-resolution as progress; stop as soon as a cycle produces no new blocking comment. After K cycles without convergence, mark the PR **NEEDS ATTENTION** with the blocking reason and move on.
+
+## Step 7 — Update TRACKING.md
 
 For each issue, update the TRACKING.md row:
-- SUCCESS with PR: set status to "En cours", add PR link and branch name
+- READY PR: set status to "En cours", add PR link and branch name
+- NEEDS ATTENTION: set status to "En cours", add PR link, note the blocker
 - FAILED: set status to "Échoué"
 - BLOCKED: set status to "Bloqué"
 
 Commit and push the TRACKING.md update.
 
-## Step 7 — Final report
+## Step 8 — Final report
 
 Display a summary table:
 
 ```
 | Issue | Title | Status | PR | Notes |
 |-------|-------|--------|----|-------|
-| #42   | Add X | ✅ PR  | #50 | CI passing |
-| #43   | Fix Y | ❌ FAILED | — | QA: PHPStan error in Foo.php |
-| #44   | Add Z | 🚫 BLOCKED | — | Depends on #43 |
+| #42   | Add X | ✅ READY | #50 | CI green, no blocking review |
+| #43   | Fix Y | ⚠️ NEEDS ATTENTION | #51 | Conflict on Foo.php, flagged |
+| #44   | Add Z | ❌ FAILED | — | QA: PHPStan error in Bar.php |
+| #45   | Add W | 🚫 BLOCKED | — | Depends on #44 |
 ```
 
 Include timing information if available (total duration, per-phase breakdown).

--- a/.claude/skills/sprint/SKILL.md
+++ b/.claude/skills/sprint/SKILL.md
@@ -100,7 +100,7 @@ Each cycle:
    Address every **actionable** point, commit, push, then reply to / resolve the corresponding threads. List any comment you deliberately did not action, with the reason.
 3. **Conflicts** — `gh pr view <pr> --json mergeable,mergeStateStatus`. If `CONFLICTING`: rebase onto the base branch and resolve **conservatively**. If the resolution is ambiguous or risks discarding work, **stop and flag it** — do not force a resolution.
 
-**Termination (READY)** when all hold: CI green **AND** `mergeable` **AND** not draft **AND** a fresh `claude-code-review.yml` cycle adds **no new blocking comment** (Critical/High).
+**Termination (READY)** when all hold: CI green **AND** `mergeable` **AND** not draft **AND** `claude-code-review.yml` has completed (`gh run view --workflow=claude-code-review.yml` shows `completed`) with **no new blocking comment** (Critical/High). Wait for that workflow to finish before evaluating its output — after a push it is triggered asynchronously and may still be `pending`/`in_progress`.
 
 **Loop note:** each push triggers `synchronize` → the review bot re-runs and auto-resolves its own fixed threads. Treat that auto-resolution as progress; stop as soon as a cycle produces no new blocking comment. After K cycles without convergence, mark the PR **NEEDS ATTENTION** with the blocking reason and move on.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,5 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
-
 ## Project Overview
 
 Bike Trip Planner — a bikepacking trip planner. Decoupled architecture: PHP backend (API Platform on Symfony 8) provides stateless computation via async workers, Next.js 16 frontend manages presentation and state. PostgreSQL persists trip data (via Doctrine ORM); Redis handles transient computation state, Messenger transport, and external API caches.
@@ -41,11 +39,17 @@ make typegen                # Regenerate TS types from backend OpenAPI spec
 
 Pre-commit hook runs `make qa` automatically; commit aborts on failure.
 
+## Verification
+
+Never declare a task done without proof of execution. Paste the real output of `make qa` / `make test` (or run `/check`); never claim success from assumption. A green claim without evidence is not acceptable.
+
 ### Claude Code Skills
 
 ```bash
 /pick <issue-number> [base-branch]  # Implement a GitHub issue end-to-end
 /sprint <sprint-number>             # Implement all sprint issues in parallel via worktree agents
+/check [qa|test|all]                # Goal-loop: run QA/tests, fix until green, report real output
+/close [sprint-number]              # Close a sprint: clean worktrees/branches, update main, retrospective
 ```
 
 ### GitHub Automation

--- a/docs/claude-code-tooling.fr.md
+++ b/docs/claude-code-tooling.fr.md
@@ -164,6 +164,26 @@ Les skills sont des fichiers `.claude/skills/<nom>/SKILL.md` dans le projet. Ils
 - **Emplacement :** `.claude/skills/sprint/SKILL.md`
 - **Utilisation :** `/sprint <numéro-sprint>`
 
+Le sprint conduit chaque PR via une boucle de surveillance bornée (CI, commentaires de revue y compris inline, résolution prudente des conflits) jusqu'à l'état **READY** ou **NEEDS ATTENTION** — sans jamais merger.
+
+---
+
+### 3.3 Skill `/check` (DÉJÀ INSTALLÉ)
+
+**Objectif :** Goal-loop qualité — lance `make qa` / `make test`, corrige les échecs jusqu'au vert (max 3 runs), et rapporte la sortie réelle comme preuve. Ne déclare jamais un succès par supposition.
+
+- **Emplacement :** `.claude/skills/check/SKILL.md`
+- **Utilisation :** `/check [qa|test|all]` (défaut `all`)
+
+---
+
+### 3.4 Skill `/close` (DÉJÀ INSTALLÉ)
+
+**Objectif :** Clôture un sprint — auto-détecte le sprint courant, nettoie les worktrees/branches locaux (avec confirmation explicite avant toute suppression), met à jour `main` en `--ff-only`, et lance une rétrospective qui propose des améliorations de config sans les appliquer.
+
+- **Emplacement :** `.claude/skills/close/SKILL.md`
+- **Utilisation :** `/close [numéro-sprint]` (sprint auto-détecté si omis)
+
 ---
 
 ## 4. Workflows GitHub (automatisation CI)
@@ -199,6 +219,8 @@ Se déclenche automatiquement sur chaque PR (ouverture, synchronisation, réouve
 | Installé | Protection de fichiers (hook) | Hook PreToolUse | Configuré |
 | Installé | Skill `/pick` | Skill personnalisé | Installé |
 | Installé | Skill `/sprint` | Skill personnalisé | Installé |
+| Installé | Skill `/check` | Skill personnalisé | Installé |
+| Installé | Skill `/close` | Skill personnalisé | Installé |
 | Installé | Workflow `@claude pick` | GitHub Actions | Configuré |
 | Installé | Revue de code automatisée | GitHub Actions | Configuré |
 | Optionnel | Rappel post-compaction | Hook SessionStart | Optionnel |

--- a/docs/claude-code-tooling.md
+++ b/docs/claude-code-tooling.md
@@ -164,6 +164,26 @@ Skills are `.claude/skills/<name>/SKILL.md` files in the project. They add `/nam
 - **Location:** `.claude/skills/sprint/SKILL.md`
 - **Usage:** `/sprint <sprint-number>`
 
+The sprint drives each PR through a bounded surveillance loop (CI, review comments including inline, conservative conflict handling) until it reaches **READY** or **NEEDS ATTENTION** — it never merges.
+
+---
+
+### 3.3 Skill `/check` (ALREADY INSTALLED)
+
+**Purpose:** Quality goal-loop — runs `make qa` / `make test`, fixes failures until green (max 3 runs), and reports the real output as proof. Never declares success from assumption.
+
+- **Location:** `.claude/skills/check/SKILL.md`
+- **Usage:** `/check [qa|test|all]` (default `all`)
+
+---
+
+### 3.4 Skill `/close` (ALREADY INSTALLED)
+
+**Purpose:** Closes a sprint — auto-detects the current sprint, cleans up local worktrees/branches (with explicit confirmation before any deletion), updates `main` via `--ff-only`, and runs a retrospective proposing config improvements without applying them.
+
+- **Location:** `.claude/skills/close/SKILL.md`
+- **Usage:** `/close [sprint-number]` (sprint auto-detected if omitted)
+
 ---
 
 ## 4. GitHub Workflows (CI Automation)
@@ -199,6 +219,8 @@ Triggers automatically on every PR (open, sync, reopen, ready for review). Perfo
 | ✅        | File protection (hook)          | Hook PreToolUse   | Configured        |
 | ✅        | Skill `/pick`                   | Skill custom      | Installed         |
 | ✅        | Skill `/sprint`                 | Skill custom      | Installed         |
+| ✅        | Skill `/check`                  | Skill custom      | Installed         |
+| ✅        | Skill `/close`                  | Skill custom      | Installed         |
 | ✅        | `@claude pick` workflow         | GitHub Actions    | Configured        |
 | ✅        | Automated code review           | GitHub Actions    | Configured        |
 | 💡       | Post-compaction reminder        | Hook SessionStart | Optional          |

--- a/docs/contributing.fr.md
+++ b/docs/contributing.fr.md
@@ -207,12 +207,14 @@ Ces hooks sont scopés au projet et s'appliquent à tous les contributeurs qui u
 
 ### Skills (commandes slash)
 
-Deux skills personnalisés sont disponibles dans Claude Code :
+Quatre skills personnalisés sont disponibles dans Claude Code :
 
 | Commande | Description |
 |----------|-------------|
 | `/pick <numero-issue> [branche-base]` | Implémente une issue GitHub de bout en bout (branche, code, test, PR, monitoring CI) |
 | `/sprint <numero-sprint>` | Implémente toutes les issues du sprint en parallèle via des agents worktree |
+| `/check [qa\|test\|all]` | Goal-loop qualité : lance QA/tests et corrige jusqu'au vert, avec la sortie réelle |
+| `/close [numero-sprint]` | Clôture un sprint : nettoie worktrees/branches, met à jour main, rétrospective |
 
 ### Automatisation GitHub
 
@@ -302,7 +304,7 @@ bike-trip-planner/
 |       +-- claude-code-review.yml  # Revue de code automatisée des PR
 +-- .claude/
 |   +-- settings.json             # Hooks (auto-formatting, protection de fichiers)
-|   +-- skills/                   # Commandes slash personnalisées (pick, sprint)
+|   +-- skills/                   # Commandes slash personnalisées (pick, sprint, check, close)
 ```
 
 ---

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -207,12 +207,14 @@ These hooks are project-scoped and apply to all contributors who use Claude Code
 
 ### Skills (slash commands)
 
-Two custom skills are available in Claude Code:
+Four custom skills are available in Claude Code:
 
 | Command                              | Description                                                                  |
 |--------------------------------------|------------------------------------------------------------------------------|
 | `/pick <issue-number> [base-branch]` | Implements a GitHub issue end-to-end (branch, code, test, PR, CI monitoring) |
 | `/sprint <sprint-number>`            | Implements all sprint issues in parallel via worktree agents                 |
+| `/check [qa\|test\|all]`             | Quality goal-loop: runs QA/tests and fixes until green, with real output     |
+| `/close [sprint-number]`             | Closes a sprint: cleans worktrees/branches, updates main, retrospective      |
 
 ### GitHub automation
 
@@ -297,7 +299,7 @@ bike-trip-planner/
 │       └── claude-code-review.yml  # Automated PR code review
 ├── .claude/
 │   ├── settings.json             # Hooks (auto-formatting, file protection)
-│   └── skills/                   # Custom slash commands (pick, sprint)
+│   └── skills/                   # Custom slash commands (pick, sprint, check, close)
 ```
 
 ---


### PR DESCRIPTION
## Summary

Amélioration de la configuration Claude Code du projet, inspirée de l'article *Claude Code Mastery* et adaptée à l'existant (skills `/pick` + `/sprint`, workflows GitHub, système de mémoire). Les idées redondantes de l'article ont été écartées après challenge : découpage `api/`/`pwa/` de CLAUDE.md, agent reviewer local (recoupe `claude-code-review.yml`), `CLAUDE.local.md` (doublonne avec la mémoire).

## Changements

- **`/check`** (nouveau) — goal-loop qualité : lance `make qa`/`make test`, corrige jusqu'au vert (cap 3 tentatives), déclare succès uniquement avec la sortie réelle à l'appui.
- **`/close`** (nouveau) — clôture de sprint : auto-détection du sprint, confirmation avant toute suppression, nettoyage `git` (`worktree remove`/`prune`, `branch -d`), maj `main` en `--ff-only`, rétrospective qui **propose** des améliorations de config sans les appliquer.
- **`/sprint`** — Step 5 scindé : nouvelle Phase 4 de surveillance bornée des PRs (K=3) qui conduit chaque PR jusqu'à **READY** (CI, commentaires inline, conflits traités prudemment), **sans jamais merger**.
- **`/pick`** — Step 9 aligné sur le même contrat de terminaison READY / NEEDS ATTENTION.
- **`CLAUDE.md`** — élagué + règle « pas de terminé sans preuve d'exécution » + mention des nouveaux skills.

> Note : `~/.gitignore` global ignore `.claude/`, donc les nouveaux skills ont été ajoutés via `git add -f` (cohérent avec `pick`/`sprint` déjà versionnés).

## Test plan

- [ ] `/check` sur arbre propre → rapport vert avec sortie réelle ; erreur de lint triviale → boucle corrige ou s'arrête au cap 3 en listant les erreurs.
- [ ] `/sprint` sur un petit sprint → traite CI + commentaires inline, signale un conflit ambigu sans forcer, termine en READY/NEEDS ATTENTION, ne merge jamais.
- [ ] `/pick` → conduit la PR jusqu'à READY.
- [ ] `/close` (sans argument) → auto-détecte le sprint, confirme la liste avant suppression, maj `main`, rétro propose sans appliquer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

**Reviewed commit:** 10a8d620f6202914decf6fbcb9d907b75dbb1c35

### Summary

Clean, well-structured addition of two new skills (`/check`, `/close`) and an improved PR surveillance loop for `/sprint` and `/pick`. All 5 previously flagged issues were addressed in prior commits; no new findings.

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [ ] Tests cover new/changed cases *(skill files — not applicable)*
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Inline comments

No inline comments.

---
Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->