### PR TITLE
fix(security): bump twig/twig to 3.27.0 (5 sandbox CVEs)

### DIFF
--- a/api/composer.lock
+++ b/api/composer.lock
@@ -10175,16 +10175,16 @@
         },
         {
             "name": "twig/twig",
-            "version": "v3.26.0",
+            "version": "v3.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "1fcae487b180d78e6351f4e0afa91f9eab96a2bc"
+                "reference": "04ae1bfe9463c816cf72ca0abe7eae2c77a9a9ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/1fcae487b180d78e6351f4e0afa91f9eab96a2bc",
-                "reference": "1fcae487b180d78e6351f4e0afa91f9eab96a2bc",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/04ae1bfe9463c816cf72ca0abe7eae2c77a9a9ed",
+                "reference": "04ae1bfe9463c816cf72ca0abe7eae2c77a9a9ed",
                 "shasum": ""
             },
             "require": {
@@ -10239,7 +10239,7 @@
             ],
             "support": {
                 "issues": "https://github.com/twigphp/Twig/issues",
-                "source": "https://github.com/twigphp/Twig/tree/v3.26.0"
+                "source": "https://github.com/twigphp/Twig/tree/v3.27.0"
             },
             "funding": [
                 {
@@ -10251,7 +10251,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-20T07:31:59+00:00"
+            "time": "2026-05-27T13:05:51+00:00"
         },
         {
             "name": "webmozart/assert",


### PR DESCRIPTION
## Summary
- Bump `twig/twig` 3.26.0 → 3.27.0 to remediate five sandbox security advisories surfaced by `composer audit`.
- Transitive dependency (via `symfony/twig-bundle`); only `api/composer.lock` changes, no other packages bumped.

## CVEs fixed (all sandbox bypasses, affected `<3.27.0`)
- CVE-2026-46636 — filter/tag/function allow-list bypass when sandbox state changes between renders
- CVE-2026-48805 — sandbox state regression in deprecated internal wrappers
- CVE-2026-48806 — `__toString()` policy bypass via dynamic mapping keys
- CVE-2026-48807 — `__toString()` policy bypass via `Traversable` in `join`/`replace` and `in`/`not in`
- CVE-2026-48808 — property allow-list bypass via the `column` filter under `SourcePolicyInterface`

## Test plan
- [x] `composer audit` → "No security vulnerability advisories found"
- [ ] CI green (Security Check, PHPStan, PHPUnit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

**Reviewed commit:** `069105502acb3e68c71aa91750022dc3e10ff314`

Clean, minimal security patch. The `composer.lock` update is correctly scoped to `twig/twig` only, with all five sandbox CVEs addressed in 3.27.0. No source code changes; no behavioral impact outside the Twig sandbox.

**Findings:** 0 critical · 0 warnings · 0 suggestions

### Review checklist
- [x] Code respects the project architecture — lock-file-only change is correct for a transitive dependency bump
- [x] SOLID principles and Law of Demeter followed — n/a
- [x] Design patterns used where appropriate — n/a
- [x] Tests cover new/changed cases — `composer audit` clean; no behavioral changes require unit/E2E tests
- [x] Documentation is up to date — CVEs documented in PR body; no code-level docs needed
- [x] Dependent tickets accounted for — n/a

No inline comments.

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->