### PR TITLE
docs(runbooks): add secrets inventory and rotation policy

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,6 +23,7 @@
 ## Verification
 
 - [ ] Related runbook updated if applicable
+- [ ] If this PR introduces or removes a secret, `docs/runbooks/secrets-inventory.md` is updated
 
 ## Auto-critique
 

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -27,6 +27,8 @@ Every runbook follows the same four sections:
 | [release-rollback.md](release-rollback.md) | Roll back a bad deploy via Coolify |
 | [release-checklist.md](release-checklist.md) | Pre-release checklist |
 | [uptime-monitoring.md](uptime-monitoring.md) | Uptime Kuma + UptimeRobot configuration |
+| [secrets-inventory.md](secrets-inventory.md) | Source of truth for every production secret |
+| [secrets-rotation.md](secrets-rotation.md) | Rotation policy + per-class procedures |
 
 ## Conventions
 

--- a/docs/runbooks/secrets-inventory.md
+++ b/docs/runbooks/secrets-inventory.md
@@ -52,7 +52,7 @@ Pour la rotation : voir [secrets-rotation.md](secrets-rotation.md).
 
 En cas de bootstrap depuis zéro (VM perdue, Coolify réinstallé) :
 
-1. Récupérer la clé privée `age` depuis **Bitwarden vault** (item `bike-trip-planner / age private key`).
+1. Récupérer la clé privée `age` depuis **Bitwarden vault** : item canonique `bike-trip-planner / age private key` (la rotation conserve toujours ce nom pour la clé courante et renomme l'ancienne en `... legacy YYYYMMDD`, voir [secrets-rotation.md](secrets-rotation.md)).
 2. Restaurer le bundle envs depuis B2 via `disaster-recovery.md` (procédure générique §1).
 3. Réimporter les envs dans Coolify (UI ou `coolify` CLI).
 4. Pour les CI secrets : régénérer depuis le provider concerné (Backblaze, Resend, Anthropic…) ; ces secrets ne sont **pas** dans le backup bundle (ils vivent dans GitHub).

--- a/docs/runbooks/secrets-inventory.md
+++ b/docs/runbooks/secrets-inventory.md
@@ -1,0 +1,63 @@
+# Secrets Inventory
+
+Single source of truth for every secret used by the production stack. Updated as part of any PR that introduces or removes a secret (see PR template checklist).
+
+Centralisation **documentaire** uniquement : aucun SaaS de gestion de secrets (Bitwarden Secrets Manager, Doppler, Vault…) n'est utilisé. Coolify reste le runtime store ; le bundle envs + PEM est sauvegardé chiffré (`age`) vers B2 par le job de backup (ADR-033, hors scope ici).
+
+Pour la rotation : voir [secrets-rotation.md](secrets-rotation.md).
+
+## Conventions
+
+- **Localisation source** = système qui détient la valeur de référence. Si elle est perdue ailleurs, on la récupère ici.
+- **Bitwarden vault** désigne le Bitwarden Password Manager personnel (plan Free), pas Bitwarden Secrets Manager.
+- **Backup bundle** = inclus dans le tar chiffré `age` produit par le service `backup` (ADR-033, PR #4 de `mossy-castle`).
+
+## Runtime secrets (consommés par la stack en prod)
+
+| Nom | Type | Localisation source | Consommateur | Backup bundle | Rotation | Référence |
+|---|---|---|---|---|---|---|
+| `JWT_PRIVATE_KEY_PATH` (PEM) | PEM RSA | Fichier monté `/etc/bike-trip-planner/jwt/private.pem` (VM) | `php`, `worker` (LexikJWT) | Oui | On-compromise | ADR-023 |
+| `JWT_PUBLIC_KEY_PATH` (PEM) | PEM RSA | Fichier monté `/etc/bike-trip-planner/jwt/public.pem` (VM) | `php`, `worker` (LexikJWT) | Oui | On-compromise (avec la clé privée) | ADR-023 |
+| `JWT_PASSPHRASE` | Passphrase | Coolify env | `php`, `worker` | Oui | On-compromise (avec la clé privée) | ADR-023 |
+| `MERCURE_JWT_KEY` | Passphrase HS256 | Coolify env | `php` (publisher + subscriber + Mercure hub) | Oui | On-compromise | `compose.prod.yaml` |
+| `DATABASE_USERNAME` | Identifiant Postgres | Coolify env | `php`, `worker`, `database` | Oui | Statique | ADR-022 |
+| `DATABASE_PASSWORD` | Password Postgres | Coolify env | `php`, `worker`, `database` | Oui | Bi-annuel + on-compromise | ADR-022 |
+| `DATABASE_NAME` | Nom de base | Coolify env | `php`, `worker`, `database` | Oui | Statique | ADR-022 |
+| `MAILER_DSN` | DSN Resend (contient API key) | Coolify env | `php`, `worker` | Oui | On-compromise | ADR-029 |
+| `DATATOURISME_API_KEY` | API key | Coolify env | `worker` (multi-source) | Oui | On-compromise | ADR-026 |
+| `SENTRY_DSN` | DSN GlitchTip (public côté projet, technique côté ingestion) | Coolify env | `php`, `worker`, `pwa` (SSR) | Oui | On-compromise (projet GlitchTip recréé) | ADR-031 |
+| `NEXT_PUBLIC_SENTRY_DSN` | Idem, exposé au bundle client | Coolify env (build arg) | `pwa` (client) | Oui | Idem `SENTRY_DSN` | ADR-031 |
+| `AGE_RECIPIENT` | Clé publique `age` | Coolify env du service `backup` (clé publique committable) | `backup` (chiffrement dumps) | N/A (publique) | On-compromise — clé privée seule sensible | ADR-033 |
+| Clé privée `age` correspondante | Clé privée `age` | **Bitwarden vault** (hors VM) | Opérateur lors d'un restore | N/A (jamais en prod) | On-compromise | ADR-033 |
+| `B2_ACCOUNT_ID` / `B2_APPLICATION_KEY` | Application key Backblaze | Coolify env du service `backup` | `backup` (rclone) | Oui | **Annuelle** + on-compromise | ADR-033 |
+| `OCI_*` (S3 endpoint creds Object Storage) | Customer Secret Key | Coolify env du service `backup` | `backup` (rclone) | Oui | Annuelle + on-compromise | ADR-033 |
+
+> Les entrées `AGE_RECIPIENT`, `B2_*`, `OCI_*`, `backup` sont introduites par les PR de `mossy-castle` (Sprint 38). Elles sont listées ici par anticipation pour que l'inventaire soit complet dès le merge de ce runbook + d'`adr-033`.
+
+## CI/CD secrets (consommés par GitHub Actions)
+
+| Nom | Type | Localisation source | Consommateur (workflow) | Rotation | Référence |
+|---|---|---|---|---|---|
+| `COOLIFY_WEBHOOK_URL` | URL avec token intégré | GitHub repo secret | `deploy.yml` | On-compromise (régénération côté Coolify) | PR #501 |
+| `COOLIFY_DEPLOY_SECRET` | Bearer secret | GitHub repo secret | `deploy.yml` | On-compromise | PR #501 |
+| `SENTRY_AUTH_TOKEN` | Org token GlitchTip | GitHub repo secret | `deploy.yml` (source-map upload) | On-compromise | ADR-031 |
+| `SENTRY_URL` / `SENTRY_ORG` / `SENTRY_PROJECT` | Métadonnées (non sensibles) | GitHub repo secret | `deploy.yml` | Statiques | ADR-031 |
+| `NEXT_PUBLIC_SENTRY_DSN` | DSN client | GitHub repo secret | `deploy.yml` (build arg) | Idem runtime | ADR-031 |
+| `INCIDENT_DISPATCH_TOKEN` | Fine-grained PAT (issues:write) | GitHub repo secret | `incident-create.yml`, alertes externes | **90 jours** (déjà documenté) | PR #502 |
+| `DATABASE_URL` | DSN Postgres (dev/import) | GitHub repo secret | `import-markets.yml` | Statique (DSN dev) | — |
+| `CLAUDE_CODE_OAUTH_TOKEN` | OAuth token Anthropic | GitHub repo secret | `claude.yml`, `claude-code-review.yml` | Géré par Anthropic | CLAUDE.md |
+| `GITHUB_TOKEN` | Token natif GHA | Auto-injecté | Tous workflows | Géré par GitHub (par run) | — |
+
+## Bootstrap (perte totale)
+
+En cas de bootstrap depuis zéro (VM perdue, Coolify réinstallé) :
+
+1. Récupérer la clé privée `age` depuis **Bitwarden vault** (item `bike-trip-planner / age private key`).
+2. Restaurer le bundle envs depuis B2 via `disaster-recovery.md` (procédure générique §1).
+3. Réimporter les envs dans Coolify (UI ou `coolify` CLI).
+4. Pour les CI secrets : régénérer depuis le provider concerné (Backblaze, Resend, Anthropic…) ; ces secrets ne sont **pas** dans le backup bundle (ils vivent dans GitHub).
+
+## Hors scope
+
+- Secrets de développement (`.env.local`, `.env.test`) : non sensibles, regénérés par `make start-dev`.
+- Secrets applicatifs internes (CSRF, session cookies) : gérés par Symfony, scope local.

--- a/docs/runbooks/secrets-rotation.md
+++ b/docs/runbooks/secrets-rotation.md
@@ -69,7 +69,14 @@ Invalide toutes les sessions en cours (refresh tokens DB inclus, car la vérific
    docker compose exec php bin/console lexik:jwt:generate-keypair --overwrite
    ```
 
-   Cela écrit `config/jwt/private.pem` et `config/jwt/public.pem`. Les chemins runtime (`/etc/bike-trip-planner/jwt/*.pem`) sont **montés depuis l'hôte** : copier explicitement les nouveaux PEM vers `/etc/bike-trip-planner/jwt/` sur la VM.
+   Cela écrit les PEM dans `/app/config/jwt/` (espace de travail du container). Les chemins runtime (`/etc/bike-trip-planner/jwt/*.pem`) sont **montés depuis l'hôte** ; extraire les fichiers générés :
+
+   ```bash
+   docker cp php:/app/config/jwt/private.pem /etc/bike-trip-planner/jwt/private.pem
+   docker cp php:/app/config/jwt/public.pem  /etc/bike-trip-planner/jwt/public.pem
+   chmod 600 /etc/bike-trip-planner/jwt/private.pem
+   ```
+
 2. Mettre à jour `JWT_PASSPHRASE` dans Coolify (utiliser la passphrase saisie lors de la regen).
 3. Redéployer la stack pour que `php` et `worker` rechargent les secrets Docker.
 4. Communiquer aux testeurs : "reconnexion magic link nécessaire".

--- a/docs/runbooks/secrets-rotation.md
+++ b/docs/runbooks/secrets-rotation.md
@@ -7,7 +7,7 @@ L'inventaire complet des secrets est dans [secrets-inventory.md](secrets-invento
 ## Symptômes (déclencheurs de rotation)
 
 - Suspicion de fuite (commit accidentel, log exposé, screenshot partagé, poste compromis)
-- Alerte GitHub Secret Scanning (`mcp__plugin_github_github__run_secret_scanning` ou notification automatique)
+- Alerte GitHub Secret Scanning (notification automatique GitHub ou `gh api repos/vincentchalamon/bike-trip-planner/secret-scanning/alerts`)
 - Incident `severity:high` impliquant le service ou l'opérateur détenant la clé
 - Échéance calendaire (cf. matrice ci-dessous)
 
@@ -36,7 +36,7 @@ Pour tout secret sauf cas spécifiques (cf. section suivante) :
 2. **Générer une nouvelle valeur** côté provider, scope minimal (ex. B2 : limiter au bucket `btp-backups`).
 3. **Mettre à jour** la localisation source listée dans [secrets-inventory.md](secrets-inventory.md) :
    - Coolify env → UI ou `coolify env set`
-   - GitHub secret → MCP `mcp__plugin_github_github__*` ou UI repo settings
+   - GitHub secret → `gh secret set <NAME>` ou UI repo settings
 4. **Redéployer** si runtime secret : tag `vX.Y.Z+1-rotation` ou re-trigger `deploy.yml` manuellement.
 5. **Vérifier** : `curl https://<host>/api/healthz` + `curl https://<host>/api/health` verts ; pour CI secret, déclencher le workflow concerné.
 6. **Tracer** dans un commentaire de l'issue d'incident liée (`incident-template.md`) : qui, quand, quel secret, raison.
@@ -53,7 +53,7 @@ La rotation **ne re-chiffre pas** l'historique des backups : trop coûteux, et l
    age-keygen -o age-key-$(date +%Y%m%d).txt
    ```
 
-2. Stocker la **nouvelle clé privée** dans **Bitwarden vault** (nouvel item `bike-trip-planner / age private key YYYYMMDD`). **Conserver les anciennes clés** dans des items distincts marqués `legacy` — nécessaires pour restaurer les dumps antérieurs.
+2. Dans **Bitwarden vault** : **renommer l'item courant** `bike-trip-planner / age private key` en `bike-trip-planner / age private key legacy YYYYMMDD` (date de la dernière utilisation comme clé courante). **Créer un nouvel item** `bike-trip-planner / age private key` (nom canonique conservé) contenant la nouvelle clé privée. Le bootstrap DR cherche toujours le nom canonique ; les items `legacy *` ne servent qu'à restaurer les dumps antérieurs et doivent être conservés indéfiniment.
 3. Mettre à jour `AGE_RECIPIENT` dans Coolify (env du service `backup`) avec la nouvelle clé publique.
 4. Mettre à jour le repo si la clé publique y est référencée (`compose.prod.yaml` par défaut env, ADR-033).
 5. Forcer un backup : `make backup-now`. Confirmer via `rclone ls b2:btp-backups | tail -1` que le dernier dump est bien plus récent que la rotation.

--- a/docs/runbooks/secrets-rotation.md
+++ b/docs/runbooks/secrets-rotation.md
@@ -1,0 +1,111 @@
+# Secrets Rotation
+
+Politique de rotation des secrets de production. Volontairement courte : à l'échelle du projet (un environnement, un opérateur, ~15 secrets), la rotation calendaire systématique coûte plus qu'elle ne rapporte. Le mode par défaut est **on-compromise**, sauf cas listés ci-dessous.
+
+L'inventaire complet des secrets est dans [secrets-inventory.md](secrets-inventory.md).
+
+## Symptômes (déclencheurs de rotation)
+
+- Suspicion de fuite (commit accidentel, log exposé, screenshot partagé, poste compromis)
+- Alerte GitHub Secret Scanning (`mcp__plugin_github_github__run_secret_scanning` ou notification automatique)
+- Incident `severity:high` impliquant le service ou l'opérateur détenant la clé
+- Échéance calendaire (cf. matrice ci-dessous)
+
+## Matrice de rotation
+
+| Secret | Cadence par défaut | Justification |
+|---|---|---|
+| `JWT_*` (PEM + passphrase) | On-compromise | Auth passwordless, surface limitée. Rotation invalide toutes les sessions (15 min access / 7 j refresh — acceptable). |
+| `MERCURE_JWT_KEY` | On-compromise | Reconnexion SSE forcée des clients. |
+| `AGE_RECIPIENT` (et clé privée associée) | On-compromise | Re-chiffrer la rétention GFS est coûteux. Clé privée hors-ligne dans Bitwarden, exposition quasi nulle. |
+| `B2_APPLICATION_KEY` | **Annuelle** + on-compromise | Standard cloud. Coût rotation faible. |
+| `OCI_*` (Object Storage) | **Annuelle** + on-compromise | Idem. |
+| `DATABASE_PASSWORD` | **Bi-annuelle** + on-compromise | Compromise rare en pratique (réseau Docker isolé), mais hygiène utile. |
+| `MAILER_DSN` (Resend) | On-compromise | Pas de risque structurel à scheduler. |
+| `DATATOURISME_API_KEY` | On-compromise | Idem. |
+| `SENTRY_DSN` / `SENTRY_AUTH_TOKEN` | On-compromise | Projet GlitchTip recréable. |
+| `COOLIFY_WEBHOOK_URL`, `COOLIFY_DEPLOY_SECRET` | On-compromise | Webhook unique, exposition uniquement au job GHA `deploy.yml`. |
+| `INCIDENT_DISPATCH_TOKEN` | **90 jours** | Déjà appliqué (fine-grained PAT, contraintes GitHub). |
+| `CLAUDE_CODE_OAUTH_TOKEN` | Géré par Anthropic | Hors scope. |
+
+## Procédure générique (on-compromise)
+
+Pour tout secret sauf cas spécifiques (cf. section suivante) :
+
+1. **Révoquer immédiatement** côté provider (Backblaze, Resend, Anthropic, GitHub PAT…). Couper l'accès en premier, regénérer ensuite.
+2. **Générer une nouvelle valeur** côté provider, scope minimal (ex. B2 : limiter au bucket `btp-backups`).
+3. **Mettre à jour** la localisation source listée dans [secrets-inventory.md](secrets-inventory.md) :
+   - Coolify env → UI ou `coolify env set`
+   - GitHub secret → MCP `mcp__plugin_github_github__*` ou UI repo settings
+4. **Redéployer** si runtime secret : tag `vX.Y.Z+1-rotation` ou re-trigger `deploy.yml` manuellement.
+5. **Vérifier** : `curl https://<host>/api/healthz` + `curl https://<host>/api/health` verts ; pour CI secret, déclencher le workflow concerné.
+6. **Tracer** dans un commentaire de l'issue d'incident liée (`incident-template.md`) : qui, quand, quel secret, raison.
+
+## Procédures spécifiques
+
+### `age` recipient
+
+La rotation **ne re-chiffre pas** l'historique des backups : trop coûteux, et l'ancienne clé privée reste valide pour décrypter les anciens dumps tant qu'on la conserve.
+
+1. Sur un poste de confiance, hors-ligne si possible :
+
+   ```bash
+   age-keygen -o age-key-$(date +%Y%m%d).txt
+   ```
+
+2. Stocker la **nouvelle clé privée** dans **Bitwarden vault** (nouvel item `bike-trip-planner / age private key YYYYMMDD`). **Conserver les anciennes clés** dans des items distincts marqués `legacy` — nécessaires pour restaurer les dumps antérieurs.
+3. Mettre à jour `AGE_RECIPIENT` dans Coolify (env du service `backup`) avec la nouvelle clé publique.
+4. Mettre à jour le repo si la clé publique y est référencée (`compose.prod.yaml` par défaut env, ADR-033).
+5. Forcer un backup : `make backup-now`. Confirmer via `rclone ls b2:btp-backups | tail -1` que le dernier dump est bien plus récent que la rotation.
+6. **Ne pas supprimer** les anciens dumps avant leur expiration GFS naturelle.
+
+### LexikJWT (`JWT_*`)
+
+Invalide toutes les sessions en cours (refresh tokens DB inclus, car la vérification de signature échoue).
+
+1. Sur la VM, dans le container `php` éphémère :
+
+   ```bash
+   docker compose exec php bin/console lexik:jwt:generate-keypair --overwrite
+   ```
+
+   Cela écrit `config/jwt/private.pem` et `config/jwt/public.pem`. Les chemins runtime (`/etc/bike-trip-planner/jwt/*.pem`) sont **montés depuis l'hôte** : copier explicitement les nouveaux PEM vers `/etc/bike-trip-planner/jwt/` sur la VM.
+2. Mettre à jour `JWT_PASSPHRASE` dans Coolify (utiliser la passphrase saisie lors de la regen).
+3. Redéployer la stack pour que `php` et `worker` rechargent les secrets Docker.
+4. Communiquer aux testeurs : "reconnexion magic link nécessaire".
+5. Vérifier : `curl -X POST /api/auth/magic-link` → 202, login flow complet OK.
+
+### B2 application key
+
+1. Backblaze B2 console → Application Keys → **Add a New Application Key**, scope `btp-backups` only, capabilities `listFiles`, `readFiles`, `writeFiles`, `deleteFiles`.
+2. Récupérer `keyID` + `applicationKey` (affiché une seule fois).
+3. Mettre à jour `B2_ACCOUNT_ID` (= keyID) et `B2_APPLICATION_KEY` dans Coolify env du service `backup`.
+4. Restart `backup` service : `docker compose restart backup`.
+5. Valider : `make backup-now` → succès, `rclone ls b2:btp-backups` liste le nouveau dump.
+6. **Supprimer l'ancienne clé** dans la console Backblaze (rétention pendant 7 j non requise, vu que la nouvelle a fonctionné).
+
+### Database password
+
+Downtime ~30 s acceptable. Faire en heure creuse.
+
+1. Sur la VM :
+
+   ```bash
+   docker compose exec database psql -U "$DATABASE_USERNAME" -d "$DATABASE_NAME" -c \
+     "ALTER USER \"$DATABASE_USERNAME\" WITH PASSWORD '<NEW_PASSWORD>';"
+   ```
+
+2. Mettre à jour `DATABASE_PASSWORD` dans Coolify env.
+3. Redéployer (Coolify) — `php`, `worker`, `backup` reprennent la nouvelle valeur via le DSN.
+4. Vérifier : `curl /api/health` → `deps.postgres.status: "healthy"`.
+
+## Post-action
+
+- Mettre à jour la colonne "Rotation" de [secrets-inventory.md](secrets-inventory.md) si la cadence change ou si un secret est ajouté/retiré.
+- Si la rotation faisait suite à un incident : compléter le post-mortem (`incident-template.md`) en référençant cette procédure.
+- Pour les rotations calendaires : créer une note de rappel (calendrier perso ou issue GitHub `chore(security): rotate B2 key — due YYYY-MM`) lors de la rotation précédente.
+
+## Hors scope
+
+- Rotation programmatique (cron, scheduler) — non justifié à cette échelle.
+- Migration vers un secret manager (Bitwarden Secrets Manager, Doppler, Vault, Infisical) — décision documentée dans [secrets-inventory.md](secrets-inventory.md). À reconsidérer si > 3 environnements ou > 1 opérateur.


### PR DESCRIPTION
## Summary

Challenge et remplacement des deux éléments différés par le plan backup `mossy-castle` (Sprint 38) :

- **Bitwarden Secrets Manager rejeté** : payant, sur-dimensionné pour un projet à un seul environnement, un seul opérateur, ~15 secrets. La centralisation est résolue **documentairement** par `secrets-inventory.md` + **opérationnellement** par le bundle envs/PEM chiffré `age` du backup (ADR-033).
- **Runbook de rotation recadré** : un seul document court, matrice par classe de clé, mode par défaut **on-compromise**. Calendrier réservé à B2/OCI (annuel) et `DATABASE_PASSWORD` (bi-annuel). `INCIDENT_DISPATCH_TOKEN` (90 j) déjà documenté ailleurs, simplement référencé.

## Changes

- `docs/runbooks/secrets-inventory.md` — tableau unique de tous les secrets runtime + CI/CD, localisation source, consommateur, présence dans le backup bundle, cadence de rotation, ADR/PR de référence
- `docs/runbooks/secrets-rotation.md` — matrice de rotation + procédure générique on-compromise + procédures spécifiques (age, JWT Lexik, B2 application key, DB password)
- `docs/runbooks/README.md` — référence les deux nouveaux runbooks
- `.github/PULL_REQUEST_TEMPLATE.md` — coche "si un secret est introduit/retiré, l'inventaire est mis à jour"

Les entrées `AGE_RECIPIENT`, `B2_*`, `OCI_*`, service `backup` sont listées par anticipation : leur introduction effective est portée par `mossy-castle` (Sprint 38, ADR-033).

## Test plan

- [x] `make markdownlint` → 0 error
- [ ] Revue manuelle : passer chaque `${VAR}` de `compose.prod.yaml` et chaque `secrets.X` des workflows GHA → tous présents dans l'inventaire
- [ ] Exercice à blanc "où trouver `MERCURE_JWT_KEY` ?" → réponse en < 30 s via le runbook

## Verification

- [x] Related runbook updated if applicable
- [x] If this PR introduces or removes a secret, `docs/runbooks/secrets-inventory.md` is updated (N/A — aucun secret introduit ici)

## Hors scope

- Tooling de gestion de secrets (Bitwarden SM, Doppler, Vault, Infisical) — rejet documenté dans `secrets-inventory.md`
- Rotation programmatique automatique — non justifié à l'échelle actuelle

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

**Commit reviewed:** c033b20eb265ea1ce5d1e7769bd33668a3039c5b

### Summary

All three previous findings are resolved. The age key canonical-name approach keeps the DR bootstrap reliable, the MCP tool references were replaced with stable `gh` CLI equivalents, and the last commit added explicit `docker cp` + `chmod` commands so the LexikJWT rotation procedure is self-contained under incident conditions. No new findings.

Resolved 1 previously open bot thread (docker cp) addressed by the latest commit.

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases — N/A (documentation only)
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Findings by severity

No findings.

### Inline comments

No inline comments.

---

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->