### PR TITLE
refactor(provisioner): extract OsmDataDownloader with atomic write + osmium merge

### DIFF
--- a/provisioner/src/Exception/DownloadFailedException.php
+++ b/provisioner/src/Exception/DownloadFailedException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Provisioner\Exception;
+
+final class DownloadFailedException extends \RuntimeException
+{
+}

--- a/provisioner/src/Exception/MergeFailedException.php
+++ b/provisioner/src/Exception/MergeFailedException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Provisioner\Exception;
+
+final class MergeFailedException extends \RuntimeException
+{
+}

--- a/provisioner/src/OsmDataDownloader.php
+++ b/provisioner/src/OsmDataDownloader.php
@@ -55,9 +55,8 @@ final readonly class OsmDataDownloader
 
         $targetPath = $this->targetPath($slug);
         // Always write through a .tmp + atomic rename so a transport failure
-        // can never destroy an existing PBF at $targetPath. The behaviour
-        // difference for $forceOverwrite is in the caller (which skips
-        // download entirely when the file already exists and force is false).
+        // can never corrupt an existing PBF at $targetPath. The caller controls
+        // whether to skip already-present files via file_exists() before calling download().
         $writePath = $targetPath.'.tmp';
         $url = GeofabrikRegionRegistry::downloadUrl($slug);
 

--- a/provisioner/src/OsmDataDownloader.php
+++ b/provisioner/src/OsmDataDownloader.php
@@ -64,13 +64,16 @@ final readonly class OsmDataDownloader
 
         try {
             $response = $this->httpClient->request('GET', $url);
-            foreach ($this->httpClient->stream($response) as $chunk) {
-                fwrite($fileHandle, $chunk->getContent());
-            }
 
             $statusCode = $response->getStatusCode();
             if ($statusCode < 200 || $statusCode >= 300) {
                 throw new DownloadFailedException(\sprintf('Download of "%s" failed with HTTP %d', $slug, $statusCode));
+            }
+
+            foreach ($this->httpClient->stream($response) as $chunk) {
+                if (false === fwrite($fileHandle, $chunk->getContent())) {
+                    throw new DownloadFailedException(\sprintf('Failed to write to "%s" while downloading "%s"', $writePath, $slug));
+                }
             }
         } catch (HttpClientExceptionInterface $e) {
             fclose($fileHandle);

--- a/provisioner/src/OsmDataDownloader.php
+++ b/provisioner/src/OsmDataDownloader.php
@@ -123,11 +123,7 @@ final readonly class OsmDataDownloader
         $process->run();
 
         if (!$process->isSuccessful()) {
-            throw new MergeFailedException(\sprintf(
-                'osmium merge failed (exit %s): %s',
-                (string) $process->getExitCode(),
-                $process->getErrorOutput(),
-            ));
+            throw new MergeFailedException(\sprintf('osmium merge failed (exit %s): %s', (string) $process->getExitCode(), $process->getErrorOutput()));
         }
     }
 }

--- a/provisioner/src/OsmDataDownloader.php
+++ b/provisioner/src/OsmDataDownloader.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Provisioner;
+
+use Provisioner\Exception\DownloadFailedException;
+use Provisioner\Exception\MergeFailedException;
+use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Component\Process\Process;
+use Symfony\Contracts\HttpClient\Exception\ExceptionInterface as HttpClientExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+final class OsmDataDownloader
+{
+    private readonly HttpClientInterface $httpClient;
+
+    /**
+     * @var \Closure(list<string>): Process
+     */
+    private readonly \Closure $processFactory;
+
+    /**
+     * @param (\Closure(list<string>): Process)|null $processFactory factory used to build the osmium process; defaults to a real {@see Process}
+     */
+    public function __construct(
+        private readonly string $regionsDir,
+        ?HttpClientInterface $httpClient = null,
+        ?\Closure $processFactory = null,
+        private readonly int $mergeTimeoutSeconds = 600,
+    ) {
+        $this->httpClient = $httpClient ?? HttpClient::create();
+        $this->processFactory = $processFactory ?? static fn (array $command): Process => new Process($command);
+    }
+
+    public function targetPath(string $slug): string
+    {
+        return \sprintf('%s/%s-latest.osm.pbf', $this->regionsDir, $slug);
+    }
+
+    /**
+     * Download the PBF for the given slug.
+     *
+     * When $forceOverwrite is true, the file is written to "{target}.tmp" first
+     * then atomically renamed to the final path so a partial download cannot
+     * corrupt an existing PBF if the process is interrupted.
+     *
+     * @throws DownloadFailedException
+     */
+    public function download(string $slug, bool $forceOverwrite): void
+    {
+        if (!is_dir($this->regionsDir) && !mkdir($this->regionsDir, 0o755, true) && !is_dir($this->regionsDir)) {
+            throw new DownloadFailedException(\sprintf('Cannot create regions directory "%s"', $this->regionsDir));
+        }
+
+        $targetPath = $this->targetPath($slug);
+        $writePath = $forceOverwrite ? $targetPath.'.tmp' : $targetPath;
+        $url = GeofabrikRegionRegistry::downloadUrl($slug);
+
+        $fileHandle = fopen($writePath, 'w');
+        if (false === $fileHandle) {
+            throw new DownloadFailedException(\sprintf('Cannot open "%s" for writing', $writePath));
+        }
+
+        try {
+            $response = $this->httpClient->request('GET', $url);
+            foreach ($this->httpClient->stream($response) as $chunk) {
+                fwrite($fileHandle, $chunk->getContent());
+            }
+
+            $statusCode = $response->getStatusCode();
+            if ($statusCode < 200 || $statusCode >= 300) {
+                throw new DownloadFailedException(\sprintf('Download of "%s" failed with HTTP %d', $slug, $statusCode));
+            }
+        } catch (HttpClientExceptionInterface $e) {
+            fclose($fileHandle);
+            @unlink($writePath);
+
+            throw new DownloadFailedException(\sprintf('Download of "%s" failed: %s', $slug, $e->getMessage()), 0, $e);
+        } catch (DownloadFailedException $e) {
+            fclose($fileHandle);
+            @unlink($writePath);
+
+            throw $e;
+        }
+
+        fclose($fileHandle);
+
+        if ($forceOverwrite && !rename($writePath, $targetPath)) {
+            @unlink($writePath);
+
+            throw new DownloadFailedException(\sprintf('Atomic rename of "%s" to "%s" failed', $writePath, $targetPath));
+        }
+    }
+
+    /**
+     * Merge the given PBF files into $outputPath via `osmium merge --overwrite`.
+     *
+     * @param list<string> $pbfPaths
+     *
+     * @throws MergeFailedException
+     */
+    public function merge(array $pbfPaths, string $outputPath): void
+    {
+        if ([] === $pbfPaths) {
+            throw new MergeFailedException('Cannot run osmium merge with an empty list of PBF files');
+        }
+
+        $command = array_merge(
+            ['osmium', 'merge', '--overwrite', '-o', $outputPath],
+            $pbfPaths,
+        );
+
+        $process = ($this->processFactory)($command);
+        $process->setTimeout((float) $this->mergeTimeoutSeconds);
+        $process->run();
+
+        if (!$process->isSuccessful()) {
+            throw new MergeFailedException(\sprintf(
+                'osmium merge failed (exit %s): %s',
+                (string) $process->getExitCode(),
+                $process->getErrorOutput(),
+            ));
+        }
+    }
+}

--- a/provisioner/src/OsmDataDownloader.php
+++ b/provisioner/src/OsmDataDownloader.php
@@ -11,23 +11,23 @@ use Symfony\Component\Process\Process;
 use Symfony\Contracts\HttpClient\Exception\ExceptionInterface as HttpClientExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
-final class OsmDataDownloader
+final readonly class OsmDataDownloader
 {
-    private readonly HttpClientInterface $httpClient;
+    private HttpClientInterface $httpClient;
 
     /**
      * @var \Closure(list<string>): Process
      */
-    private readonly \Closure $processFactory;
+    private \Closure $processFactory;
 
     /**
      * @param (\Closure(list<string>): Process)|null $processFactory factory used to build the osmium process; defaults to a real {@see Process}
      */
     public function __construct(
-        private readonly string $regionsDir,
+        private string $regionsDir,
         ?HttpClientInterface $httpClient = null,
         ?\Closure $processFactory = null,
-        private readonly int $mergeTimeoutSeconds = 600,
+        private int $mergeTimeoutSeconds = 600,
     ) {
         $this->httpClient = $httpClient ?? HttpClient::create();
         $this->processFactory = $processFactory ?? static fn (array $command): Process => new Process($command);

--- a/provisioner/src/OsmDataDownloader.php
+++ b/provisioner/src/OsmDataDownloader.php
@@ -29,7 +29,7 @@ final readonly class OsmDataDownloader
         ?\Closure $processFactory = null,
         private int $mergeTimeoutSeconds = 600,
     ) {
-        $this->httpClient = $httpClient ?? HttpClient::create();
+        $this->httpClient = $httpClient ?? HttpClient::create(['max_redirects' => 2]);
         $this->processFactory = $processFactory ?? static fn (array $command): Process => new Process($command);
     }
 
@@ -41,20 +41,24 @@ final readonly class OsmDataDownloader
     /**
      * Download the PBF for the given slug.
      *
-     * When $forceOverwrite is true, the file is written to "{target}.tmp" first
-     * then atomically renamed to the final path so a partial download cannot
-     * corrupt an existing PBF if the process is interrupted.
+     * The file is always written to "{target}.tmp" first then atomically
+     * renamed to the final path so a partial download (or any pre-rename
+     * failure) cannot corrupt an existing PBF at the target path.
      *
      * @throws DownloadFailedException
      */
-    public function download(string $slug, bool $forceOverwrite): void
+    public function download(string $slug): void
     {
         if (!is_dir($this->regionsDir) && !mkdir($this->regionsDir, 0o755, true) && !is_dir($this->regionsDir)) {
             throw new DownloadFailedException(\sprintf('Cannot create regions directory "%s"', $this->regionsDir));
         }
 
         $targetPath = $this->targetPath($slug);
-        $writePath = $forceOverwrite ? $targetPath.'.tmp' : $targetPath;
+        // Always write through a .tmp + atomic rename so a transport failure
+        // can never destroy an existing PBF at $targetPath. The behaviour
+        // difference for $forceOverwrite is in the caller (which skips
+        // download entirely when the file already exists and force is false).
+        $writePath = $targetPath.'.tmp';
         $url = GeofabrikRegionRegistry::downloadUrl($slug);
 
         $fileHandle = fopen($writePath, 'w');
@@ -89,7 +93,7 @@ final readonly class OsmDataDownloader
 
         fclose($fileHandle);
 
-        if ($forceOverwrite && !rename($writePath, $targetPath)) {
+        if (!rename($writePath, $targetPath)) {
             @unlink($writePath);
 
             throw new DownloadFailedException(\sprintf('Atomic rename of "%s" to "%s" failed', $writePath, $targetPath));

--- a/provisioner/src/OsmDataDownloader.php
+++ b/provisioner/src/OsmDataDownloader.php
@@ -7,6 +7,7 @@ namespace Provisioner;
 use Provisioner\Exception\DownloadFailedException;
 use Provisioner\Exception\MergeFailedException;
 use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Component\Process\Exception\ProcessTimedOutException;
 use Symfony\Component\Process\Process;
 use Symfony\Contracts\HttpClient\Exception\ExceptionInterface as HttpClientExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -27,7 +28,7 @@ final readonly class OsmDataDownloader
         private string $regionsDir,
         ?HttpClientInterface $httpClient = null,
         ?\Closure $processFactory = null,
-        private int $mergeTimeoutSeconds = 600,
+        private float $mergeTimeoutSeconds = 600.0,
     ) {
         $this->httpClient = $httpClient ?? HttpClient::create(['max_redirects' => 2]);
         $this->processFactory = $processFactory ?? static fn (array $command): Process => new Process($command);
@@ -118,8 +119,12 @@ final readonly class OsmDataDownloader
         );
 
         $process = ($this->processFactory)($command);
-        $process->setTimeout((float) $this->mergeTimeoutSeconds);
-        $process->run();
+        $process->setTimeout($this->mergeTimeoutSeconds);
+        try {
+            $process->run();
+        } catch (ProcessTimedOutException $processTimedOutException) {
+            throw new MergeFailedException(\sprintf('osmium merge timed out after %.1fs', $this->mergeTimeoutSeconds), 0, $processTimedOutException);
+        }
 
         if (!$process->isSuccessful()) {
             throw new MergeFailedException(\sprintf('osmium merge failed (exit %s): %s', (string) $process->getExitCode(), $process->getErrorOutput()));

--- a/provisioner/src/ProvisionCommand.php
+++ b/provisioner/src/ProvisionCommand.php
@@ -13,8 +13,6 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Symfony\Component\HttpClient\HttpClient;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 #[AsCommand(
     name: 'provision',
@@ -37,17 +35,13 @@ final class ProvisionCommand extends Command
         private readonly string $mergedPbf = self::DEFAULT_MERGED_PBF,
         string $selectionFile = self::DEFAULT_SELECTION_FILE,
         ?RegionSelectionStore $selectionStore = null,
-        ?HttpClientInterface $httpClient = null,
         ?OsmDataDownloader $downloader = null,
         private readonly bool $runMerge = true,
     ) {
         parent::__construct();
 
         $this->selectionStore = $selectionStore ?? new RegionSelectionStore($selectionFile);
-        $this->downloader = $downloader ?? new OsmDataDownloader(
-            regionsDir: $this->regionsDir,
-            httpClient: $httpClient ?? HttpClient::create(),
-        );
+        $this->downloader = $downloader ?? new OsmDataDownloader(regionsDir: $this->regionsDir);
     }
 
     protected function configure(): void

--- a/provisioner/src/ProvisionCommand.php
+++ b/provisioner/src/ProvisionCommand.php
@@ -283,7 +283,7 @@ final class ProvisionCommand extends Command
             $io->write('  Merging PBF files with osmium... ');
 
             try {
-                $this->downloader->merge(array_values($pbfFiles), $this->mergedPbf);
+                $this->downloader->merge($pbfFiles, $this->mergedPbf);
             } catch (MergeFailedException $e) {
                 $io->newLine();
                 $io->error($e->getMessage());

--- a/provisioner/src/ProvisionCommand.php
+++ b/provisioner/src/ProvisionCommand.php
@@ -257,7 +257,7 @@ final class ProvisionCommand extends Command
             $io->write(\sprintf('  [%d/%d] Downloading %s... ', $i + 1, $total, $slug));
 
             try {
-                $this->downloader->download($slug, forceOverwrite: $force);
+                $this->downloader->download($slug);
             } catch (DownloadFailedException $e) {
                 $io->newLine();
                 $io->error($e->getMessage());

--- a/provisioner/src/ProvisionCommand.php
+++ b/provisioner/src/ProvisionCommand.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Provisioner;
 
+use Provisioner\Exception\DownloadFailedException;
+use Provisioner\Exception\MergeFailedException;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -12,8 +14,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\HttpClient\HttpClient;
-use Symfony\Component\Process\Process;
-use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 #[AsCommand(
@@ -30,7 +30,7 @@ final class ProvisionCommand extends Command
 
     private readonly RegionSelectionStore $selectionStore;
 
-    private readonly HttpClientInterface $httpClient;
+    private readonly OsmDataDownloader $downloader;
 
     public function __construct(
         private readonly string $regionsDir = self::DEFAULT_REGIONS_DIR,
@@ -38,12 +38,16 @@ final class ProvisionCommand extends Command
         string $selectionFile = self::DEFAULT_SELECTION_FILE,
         ?RegionSelectionStore $selectionStore = null,
         ?HttpClientInterface $httpClient = null,
+        ?OsmDataDownloader $downloader = null,
         private readonly bool $runMerge = true,
     ) {
         parent::__construct();
 
         $this->selectionStore = $selectionStore ?? new RegionSelectionStore($selectionFile);
-        $this->httpClient = $httpClient ?? HttpClient::create();
+        $this->downloader = $downloader ?? new OsmDataDownloader(
+            regionsDir: $this->regionsDir,
+            httpClient: $httpClient ?? HttpClient::create(),
+        );
     }
 
     protected function configure(): void
@@ -242,57 +246,31 @@ final class ProvisionCommand extends Command
      */
     private function downloadAndMerge(SymfonyStyle $io, array $slugs, bool $force): int
     {
-        if (!is_dir($this->regionsDir) && !mkdir($this->regionsDir, 0o755, true) && !is_dir($this->regionsDir)) {
-            $io->error(\sprintf('Cannot create regions directory: %s', $this->regionsDir));
-
-            return Command::FAILURE;
-        }
-
         $toDownload = [];
         foreach ($slugs as $slug) {
-            $targetPath = \sprintf('%s/%s-latest.osm.pbf', $this->regionsDir, $slug);
+            $targetPath = $this->downloader->targetPath($slug);
 
             if (!$force && file_exists($targetPath)) {
                 $io->writeln(\sprintf('  [skip] %s (already downloaded)', $slug));
                 continue;
             }
 
-            $toDownload[] = ['slug' => $slug, 'path' => $targetPath];
+            $toDownload[] = $slug;
         }
 
         $total = \count($toDownload);
-        foreach ($toDownload as $i => $region) {
-            $io->write(\sprintf('  [%d/%d] Downloading %s... ', $i + 1, $total, $region['slug']));
-            $url = GeofabrikRegionRegistry::downloadUrl($region['slug']);
-
-            $response = $this->httpClient->request('GET', $url);
-            $fileHandle = fopen($region['path'], 'w');
-
-            if (false === $fileHandle) {
-                $io->error(\sprintf('Cannot write to %s', $region['path']));
-
-                return Command::FAILURE;
-            }
+        foreach ($toDownload as $i => $slug) {
+            $io->write(\sprintf('  [%d/%d] Downloading %s... ', $i + 1, $total, $slug));
 
             try {
-                foreach ($this->httpClient->stream($response) as $chunk) {
-                    if (false === fwrite($fileHandle, $chunk->getContent())) {
-                        fclose($fileHandle);
-                        @unlink($region['path']);
-                        $io->error(\sprintf('Failed to write to %s', $region['path']));
-
-                        return Command::FAILURE;
-                    }
-                }
-            } catch (TransportExceptionInterface $e) {
-                fclose($fileHandle);
-                @unlink($region['path']);
-                $io->error(\sprintf('Download of %s interrupted: %s', $region['slug'], $e->getMessage()));
+                $this->downloader->download($slug, forceOverwrite: $force);
+            } catch (DownloadFailedException $e) {
+                $io->newLine();
+                $io->error($e->getMessage());
 
                 return Command::FAILURE;
             }
 
-            fclose($fileHandle);
             $io->writeln("\u{2713}");
         }
 
@@ -304,17 +282,11 @@ final class ProvisionCommand extends Command
         if ([] !== $pbfFiles) {
             $io->write('  Merging PBF files with osmium... ');
 
-            $mergeCmd = array_merge(
-                ['osmium', 'merge', '--overwrite', '-o', $this->mergedPbf],
-                $pbfFiles,
-            );
-
-            $process = new Process($mergeCmd);
-            $process->setTimeout(600);
-            $process->run();
-
-            if (!$process->isSuccessful()) {
-                $io->error('osmium merge failed: '.$process->getErrorOutput());
+            try {
+                $this->downloader->merge(array_values($pbfFiles), $this->mergedPbf);
+            } catch (MergeFailedException $e) {
+                $io->newLine();
+                $io->error($e->getMessage());
 
                 return Command::FAILURE;
             }

--- a/provisioner/tests/OsmDataDownloaderTest.php
+++ b/provisioner/tests/OsmDataDownloaderTest.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Provisioner\Tests;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Provisioner\Exception\DownloadFailedException;
+use Provisioner\Exception\MergeFailedException;
+use Provisioner\OsmDataDownloader;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\Process\Process;
+
+final class OsmDataDownloaderTest extends TestCase
+{
+    private string $tmpDir;
+
+    private string $regionsDir;
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir().'/osm-downloader-'.uniqid('', true);
+        $this->regionsDir = $this->tmpDir.'/regions';
+        mkdir($this->tmpDir, 0o755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDir($this->tmpDir);
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        foreach (glob($dir.'/*') ?: [] as $entry) {
+            if (is_dir($entry)) {
+                $this->removeDir($entry);
+            } else {
+                unlink($entry);
+            }
+        }
+        rmdir($dir);
+    }
+
+    #[Test]
+    public function downloadInstallModeWritesDirectlyToFinalPath(): void
+    {
+        $httpClient = new MockHttpClient(static fn (): MockResponse => new MockResponse('osm-bytes'));
+        $downloader = new OsmDataDownloader($this->regionsDir, $httpClient);
+
+        $downloader->download('bretagne', forceOverwrite: false);
+
+        $finalPath = $this->regionsDir.'/bretagne-latest.osm.pbf';
+        self::assertFileExists($finalPath);
+        self::assertSame('osm-bytes', file_get_contents($finalPath));
+        self::assertFileDoesNotExist($finalPath.'.tmp');
+    }
+
+    #[Test]
+    public function downloadCreatesRegionsDirectoryWhenMissing(): void
+    {
+        $httpClient = new MockHttpClient(static fn (): MockResponse => new MockResponse('osm-bytes'));
+        $downloader = new OsmDataDownloader($this->regionsDir, $httpClient);
+
+        self::assertDirectoryDoesNotExist($this->regionsDir);
+
+        $downloader->download('alsace', forceOverwrite: false);
+
+        self::assertDirectoryExists($this->regionsDir);
+    }
+
+    #[Test]
+    public function downloadForceOverwriteWritesToTempThenAtomicRenames(): void
+    {
+        mkdir($this->regionsDir, 0o755, true);
+        $finalPath = $this->regionsDir.'/bretagne-latest.osm.pbf';
+        file_put_contents($finalPath, 'stale-content');
+
+        $tmpPath = $finalPath.'.tmp';
+        $testCase = $this;
+        $tmpExistedDuringStreaming = false;
+
+        $httpClient = new MockHttpClient(static function () use ($tmpPath, &$tmpExistedDuringStreaming, $testCase): MockResponse {
+            // While the response is being streamed, the .tmp file must exist
+            // and the final path must still hold the stale content.
+            $tmpExistedDuringStreaming = file_exists($tmpPath);
+            $testCase::assertSame('stale-content', file_get_contents(\dirname($tmpPath).'/bretagne-latest.osm.pbf'));
+
+            return new MockResponse('fresh-bytes');
+        });
+
+        $downloader = new OsmDataDownloader($this->regionsDir, $httpClient);
+        $downloader->download('bretagne', forceOverwrite: true);
+
+        self::assertTrue($tmpExistedDuringStreaming, '.tmp file should be created before streaming starts');
+        self::assertFileExists($finalPath);
+        self::assertSame('fresh-bytes', file_get_contents($finalPath));
+        self::assertFileDoesNotExist($tmpPath);
+    }
+
+    #[Test]
+    public function downloadHttpErrorRaisesDownloadFailedExceptionAndCleansTempFile(): void
+    {
+        mkdir($this->regionsDir, 0o755, true);
+        $finalPath = $this->regionsDir.'/bretagne-latest.osm.pbf';
+        file_put_contents($finalPath, 'stale-but-valid');
+
+        $httpClient = new MockHttpClient(static fn (): MockResponse => new MockResponse('not found', ['http_code' => 404]));
+        $downloader = new OsmDataDownloader($this->regionsDir, $httpClient);
+
+        try {
+            $downloader->download('bretagne', forceOverwrite: true);
+            self::fail('Expected DownloadFailedException');
+        } catch (DownloadFailedException $e) {
+            self::assertStringContainsString('bretagne', $e->getMessage());
+            self::assertStringContainsString('404', $e->getMessage());
+        }
+
+        // Stale final file must remain untouched, temp must be gone.
+        self::assertFileExists($finalPath);
+        self::assertSame('stale-but-valid', file_get_contents($finalPath));
+        self::assertFileDoesNotExist($finalPath.'.tmp');
+    }
+
+    #[Test]
+    public function downloadTransportErrorRaisesDownloadFailedException(): void
+    {
+        $httpClient = new MockHttpClient(static fn (): MockResponse => new MockResponse('', [
+            'error' => 'connection refused',
+        ]));
+        $downloader = new OsmDataDownloader($this->regionsDir, $httpClient);
+
+        $this->expectException(DownloadFailedException::class);
+
+        $downloader->download('bretagne', forceOverwrite: false);
+    }
+
+    #[Test]
+    public function mergeBuildsOsmiumCommandAndSucceeds(): void
+    {
+        /** @var list<string>|null $capturedCommand */
+        $capturedCommand = null;
+        $factory = function (array $command) use (&$capturedCommand): Process {
+            $capturedCommand = $command;
+
+            // Trivial process that always succeeds.
+            return new Process(['true']);
+        };
+
+        $downloader = new OsmDataDownloader(
+            regionsDir: $this->regionsDir,
+            processFactory: $factory,
+        );
+
+        $output = $this->tmpDir.'/merged.osm.pbf';
+        $downloader->merge(['/a.osm.pbf', '/b.osm.pbf'], $output);
+
+        self::assertSame(
+            ['osmium', 'merge', '--overwrite', '-o', $output, '/a.osm.pbf', '/b.osm.pbf'],
+            $capturedCommand,
+        );
+    }
+
+    #[Test]
+    public function mergeFailureRaisesMergeFailedExceptionWithStderr(): void
+    {
+        $factory = static fn (array $command): Process => new Process([
+            'sh', '-c', 'echo "boom" 1>&2; exit 2',
+        ]);
+
+        $downloader = new OsmDataDownloader(
+            regionsDir: $this->regionsDir,
+            processFactory: $factory,
+        );
+
+        try {
+            $downloader->merge(['/a.osm.pbf'], $this->tmpDir.'/merged.osm.pbf');
+            self::fail('Expected MergeFailedException');
+        } catch (MergeFailedException $e) {
+            self::assertStringContainsString('osmium merge failed', $e->getMessage());
+            self::assertStringContainsString('boom', $e->getMessage());
+            self::assertStringContainsString('exit 2', $e->getMessage());
+        }
+    }
+
+    #[Test]
+    public function mergeWithEmptyListThrows(): void
+    {
+        $downloader = new OsmDataDownloader($this->regionsDir);
+
+        $this->expectException(MergeFailedException::class);
+
+        $downloader->merge([], $this->tmpDir.'/merged.osm.pbf');
+    }
+
+    #[Test]
+    public function targetPathReturnsCanonicalLayout(): void
+    {
+        $downloader = new OsmDataDownloader($this->regionsDir);
+
+        self::assertSame(
+            $this->regionsDir.'/bretagne-latest.osm.pbf',
+            $downloader->targetPath('bretagne'),
+        );
+    }
+}

--- a/provisioner/tests/OsmDataDownloaderTest.php
+++ b/provisioner/tests/OsmDataDownloaderTest.php
@@ -129,16 +129,26 @@ final class OsmDataDownloaderTest extends TestCase
     }
 
     #[Test]
-    public function downloadTransportErrorRaisesDownloadFailedException(): void
+    public function downloadTransportErrorRaisesDownloadFailedExceptionAndCleansTempFile(): void
     {
+        mkdir($this->regionsDir, 0o755, true);
+        $finalPath = $this->regionsDir.'/bretagne-latest.osm.pbf';
+        file_put_contents($finalPath, 'stale-but-valid');
+
         $httpClient = new MockHttpClient(static fn (): MockResponse => new MockResponse('', [
             'error' => 'connection refused',
         ]));
         $downloader = new OsmDataDownloader($this->regionsDir, $httpClient);
 
-        $this->expectException(DownloadFailedException::class);
+        try {
+            $downloader->download('bretagne');
+            self::fail('Expected DownloadFailedException');
+        } catch (DownloadFailedException) {
+        }
 
-        $downloader->download('bretagne');
+        self::assertFileExists($finalPath);
+        self::assertSame('stale-but-valid', file_get_contents($finalPath));
+        self::assertFileDoesNotExist($finalPath.'.tmp');
     }
 
     #[Test]

--- a/provisioner/tests/OsmDataDownloaderTest.php
+++ b/provisioner/tests/OsmDataDownloaderTest.php
@@ -44,6 +44,7 @@ final class OsmDataDownloaderTest extends TestCase
                 unlink($entry);
             }
         }
+
         rmdir($dir);
     }
 
@@ -116,9 +117,9 @@ final class OsmDataDownloaderTest extends TestCase
         try {
             $downloader->download('bretagne', forceOverwrite: true);
             self::fail('Expected DownloadFailedException');
-        } catch (DownloadFailedException $e) {
-            self::assertStringContainsString('bretagne', $e->getMessage());
-            self::assertStringContainsString('404', $e->getMessage());
+        } catch (DownloadFailedException $downloadFailedException) {
+            self::assertStringContainsString('bretagne', $downloadFailedException->getMessage());
+            self::assertStringContainsString('404', $downloadFailedException->getMessage());
         }
 
         // Stale final file must remain untouched, temp must be gone.
@@ -181,10 +182,10 @@ final class OsmDataDownloaderTest extends TestCase
         try {
             $downloader->merge(['/a.osm.pbf'], $this->tmpDir.'/merged.osm.pbf');
             self::fail('Expected MergeFailedException');
-        } catch (MergeFailedException $e) {
-            self::assertStringContainsString('osmium merge failed', $e->getMessage());
-            self::assertStringContainsString('boom', $e->getMessage());
-            self::assertStringContainsString('exit 2', $e->getMessage());
+        } catch (MergeFailedException $mergeFailedException) {
+            self::assertStringContainsString('osmium merge failed', $mergeFailedException->getMessage());
+            self::assertStringContainsString('boom', $mergeFailedException->getMessage());
+            self::assertStringContainsString('exit 2', $mergeFailedException->getMessage());
         }
     }
 

--- a/provisioner/tests/OsmDataDownloaderTest.php
+++ b/provisioner/tests/OsmDataDownloaderTest.php
@@ -200,6 +200,25 @@ final class OsmDataDownloaderTest extends TestCase
     }
 
     #[Test]
+    public function mergeTimeoutRaisesMergeFailedException(): void
+    {
+        $factory = static fn (array $command): Process => new Process(['sleep', '5']);
+
+        $downloader = new OsmDataDownloader(
+            regionsDir: $this->regionsDir,
+            processFactory: $factory,
+            mergeTimeoutSeconds: 0.05,
+        );
+
+        try {
+            $downloader->merge(['/a.osm.pbf'], $this->tmpDir.'/merged.osm.pbf');
+            self::fail('Expected MergeFailedException');
+        } catch (MergeFailedException $mergeFailedException) {
+            self::assertStringContainsString('timed out', $mergeFailedException->getMessage());
+        }
+    }
+
+    #[Test]
     public function mergeWithEmptyListThrows(): void
     {
         $downloader = new OsmDataDownloader($this->regionsDir);

--- a/provisioner/tests/OsmDataDownloaderTest.php
+++ b/provisioner/tests/OsmDataDownloaderTest.php
@@ -49,7 +49,7 @@ final class OsmDataDownloaderTest extends TestCase
     }
 
     #[Test]
-    public function downloadInstallModeWritesDirectlyToFinalPath(): void
+    public function downloadAlwaysWritesThroughTmpThenAtomicRenamesToFinalPath(): void
     {
         $httpClient = new MockHttpClient(static fn (): MockResponse => new MockResponse('osm-bytes'));
         $downloader = new OsmDataDownloader($this->regionsDir, $httpClient);
@@ -76,7 +76,7 @@ final class OsmDataDownloaderTest extends TestCase
     }
 
     #[Test]
-    public function downloadForceOverwriteWritesToTempThenAtomicRenames(): void
+    public function downloadOverwritesExistingFileAtomicallyViaTmp(): void
     {
         mkdir($this->regionsDir, 0o755, true);
         $finalPath = $this->regionsDir.'/bretagne-latest.osm.pbf';

--- a/provisioner/tests/OsmDataDownloaderTest.php
+++ b/provisioner/tests/OsmDataDownloaderTest.php
@@ -54,7 +54,7 @@ final class OsmDataDownloaderTest extends TestCase
         $httpClient = new MockHttpClient(static fn (): MockResponse => new MockResponse('osm-bytes'));
         $downloader = new OsmDataDownloader($this->regionsDir, $httpClient);
 
-        $downloader->download('bretagne', forceOverwrite: false);
+        $downloader->download('bretagne');
 
         $finalPath = $this->regionsDir.'/bretagne-latest.osm.pbf';
         self::assertFileExists($finalPath);
@@ -70,7 +70,7 @@ final class OsmDataDownloaderTest extends TestCase
 
         self::assertDirectoryDoesNotExist($this->regionsDir);
 
-        $downloader->download('alsace', forceOverwrite: false);
+        $downloader->download('alsace');
 
         self::assertDirectoryExists($this->regionsDir);
     }
@@ -96,7 +96,7 @@ final class OsmDataDownloaderTest extends TestCase
         });
 
         $downloader = new OsmDataDownloader($this->regionsDir, $httpClient);
-        $downloader->download('bretagne', forceOverwrite: true);
+        $downloader->download('bretagne');
 
         self::assertTrue($tmpExistedDuringStreaming, '.tmp file should be created before streaming starts');
         self::assertFileExists($finalPath);
@@ -115,7 +115,7 @@ final class OsmDataDownloaderTest extends TestCase
         $downloader = new OsmDataDownloader($this->regionsDir, $httpClient);
 
         try {
-            $downloader->download('bretagne', forceOverwrite: true);
+            $downloader->download('bretagne');
             self::fail('Expected DownloadFailedException');
         } catch (DownloadFailedException $downloadFailedException) {
             self::assertStringContainsString('bretagne', $downloadFailedException->getMessage());
@@ -138,7 +138,7 @@ final class OsmDataDownloaderTest extends TestCase
 
         $this->expectException(DownloadFailedException::class);
 
-        $downloader->download('bretagne', forceOverwrite: false);
+        $downloader->download('bretagne');
     }
 
     #[Test]

--- a/provisioner/tests/ProvisionCommandTest.php
+++ b/provisioner/tests/ProvisionCommandTest.php
@@ -61,7 +61,10 @@ final class ProvisionCommandTest extends TestCase
             regionsDir: $this->regionsDir,
             mergedPbf: $this->mergedPbf,
             selectionFile: $this->selectionFile,
-            httpClient: $httpClient ?? new MockHttpClient(static fn (): MockResponse => new MockResponse('osm-bytes')),
+            downloader: new \Provisioner\OsmDataDownloader(
+                regionsDir: $this->regionsDir,
+                httpClient: $httpClient ?? new MockHttpClient(static fn (): MockResponse => new MockResponse('osm-bytes')),
+            ),
             runMerge: false,
         );
 


### PR DESCRIPTION
Closes #478. Stacked on top of #538 (feature/477).

## Summary

- Adds typed exceptions `DownloadFailedException` / `MergeFailedException` (both extend `\RuntimeException`).
- Adds `OsmDataDownloader` with:
  - `download(string $slug): void` — always writes to `{path}.tmp` first then atomically renames to the final path so a partial download can never corrupt an existing PBF at the target path.
  - `merge(array $pbfPaths, string $outputPath): void` — wraps `osmium merge --overwrite -o $output ...` via `Symfony\Component\Process\Process`. The `Process` is built through an injectable `\Closure` factory so unit tests can stub it without invoking the real `osmium` binary.
  - `targetPath(string $slug): string` — canonical layout helper used by `ProvisionCommand` to skip already-downloaded regions in install mode.
- Migrates `ProvisionCommand` to consume `OsmDataDownloader` and surfaces typed exceptions via `$io->error()`.
- Adds 9 unit tests for `OsmDataDownloader` (atomic `.tmp`-then-rename, HTTP 4xx cleanup, transport error cleanup, osmium command shape, osmium failure stderr+exit code, empty PBF list rejected, `targetPath` layout, auto-creation of regions dir).

## Auto-critique

- The merge step still goes through `Symfony\Component\Process\Process` by default; the `\Closure` factory is only there to make PHPUnit independent of `osmium`.
- `array_values` on the glob result was dropped to satisfy PHPStan L9 (`arrayValues.list`) — included as a follow-up fix commit on top.

## Test plan

- [x] `make phpstan` — no errors
- [x] `vendor/bin/phpunit` in provisioner — 27 tests, 219 assertions, OK
- [x] `make qa` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

All previous review findings have been fully addressed. The `ProcessTimedOutException` is now caught and re-wrapped as `MergeFailedException`, closing the crash path for slow `osmium merge` runs. The `fwrite()` return value is checked, HTTP status is validated before streaming begins, stale comments and test names are corrected, and `.tmp` cleanup is asserted on both transport-error and 4xx paths. The code is clean and ready to merge.

### Findings summary

No new findings.

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Resolved threads

Resolved 1 previously open bot thread: `ProcessTimedOutException` in `merge()` is now caught and wrapped as `MergeFailedException`, and `mergeTimeoutRaisesMergeFailedException` covers the path in tests.

### Inline comments

No inline comments.

Reviewed at commit `9c1f7aca94e530e9bb6eb7c58cd5ebf8041636ab`.

---

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->