### PR TITLE
feat(deploy): add osm-cron service for nightly OSM refresh + Valhalla restart

### DIFF
--- a/.docker/osm-cron/Dockerfile
+++ b/.docker/osm-cron/Dockerfile
@@ -1,0 +1,28 @@
+# OSM cron scheduler: runs the provisioner in update mode every night and
+# restarts the Valhalla container so it rebuilds its tiles from the new PBF.
+#
+# Uses supercronic (cron designed for containers, logs to stdout) and the
+# official Docker CLI binary to orchestrate sibling containers via the
+# host's Docker socket (bind-mounted by compose).
+FROM docker:28-cli-alpine3.21
+
+ARG SUPERCRONIC_VERSION=v0.2.46
+ARG SUPERCRONIC_SHA1SUM=5bcefed628e32adc08e32634db2d10e9230dbca0
+
+# hadolint ignore=DL3018
+RUN apk add --no-cache curl tini \
+    && curl -fsSLO "https://github.com/aptible/supercronic/releases/download/${SUPERCRONIC_VERSION}/supercronic-linux-amd64" \
+    && echo "${SUPERCRONIC_SHA1SUM}  supercronic-linux-amd64" | sha1sum -c - \
+    && chmod +x supercronic-linux-amd64 \
+    && mv supercronic-linux-amd64 /usr/local/bin/supercronic \
+    && apk del curl
+
+COPY .docker/osm-cron/crontab /etc/supercronic/crontab
+COPY .docker/osm-cron/run-update.sh /usr/local/bin/run-update.sh
+RUN chmod +x /usr/local/bin/run-update.sh
+
+# OSM_CRON_SCHEDULE is read at container start and written into the crontab.
+ENV OSM_CRON_SCHEDULE="0 3 * * *"
+
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["sh", "-c", "echo \"${OSM_CRON_SCHEDULE} /usr/local/bin/run-update.sh\" > /etc/supercronic/crontab && exec supercronic /etc/supercronic/crontab"]

--- a/.docker/osm-cron/Dockerfile
+++ b/.docker/osm-cron/Dockerfile
@@ -7,14 +7,14 @@
 FROM docker:28-cli
 
 ARG SUPERCRONIC_VERSION=v0.2.46
-ARG SUPERCRONIC_SHA1SUM=5bcefed628e32adc08e32634db2d10e9230dbca0
+ARG SUPERCRONIC_SHA256SUM=5adff01c5a797663948e656d2b61d10932369ee437eb5cb54fa872b2960f222b
 
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache curl tini flock \
     && curl -fsSLO "https://github.com/aptible/supercronic/releases/download/${SUPERCRONIC_VERSION}/supercronic-linux-amd64" \
-    && echo "${SUPERCRONIC_SHA1SUM}  supercronic-linux-amd64" | sha1sum -c - \
+    && echo "${SUPERCRONIC_SHA256SUM}  supercronic-linux-amd64" | sha256sum -c - \
     && chmod +x supercronic-linux-amd64 \
     && mv supercronic-linux-amd64 /usr/local/bin/supercronic \
     && apk del curl

--- a/.docker/osm-cron/Dockerfile
+++ b/.docker/osm-cron/Dockerfile
@@ -27,4 +27,7 @@ RUN chmod +x /usr/local/bin/run-update.sh
 ENV OSM_CRON_SCHEDULE="0 3 * * *"
 
 ENTRYPOINT ["/sbin/tini", "--"]
-CMD ["sh", "-c", "echo \"${OSM_CRON_SCHEDULE} /usr/local/bin/run-update.sh\" > /etc/supercronic/crontab && exec supercronic /etc/supercronic/crontab"]
+# Strip any newline / carriage return from OSM_CRON_SCHEDULE before writing it
+# to the crontab, otherwise a malicious value could inject an additional cron
+# entry. Use printf '%s' to treat the env var as literal data.
+CMD ["sh", "-c", "printf '%s /usr/local/bin/run-update.sh\\n' \"$(printf '%s' \"${OSM_CRON_SCHEDULE}\" | tr -d '\\n\\r')\" > /etc/supercronic/crontab && exec supercronic /etc/supercronic/crontab"]

--- a/.docker/osm-cron/Dockerfile
+++ b/.docker/osm-cron/Dockerfile
@@ -4,10 +4,12 @@
 # Uses supercronic (cron designed for containers, logs to stdout) and the
 # official Docker CLI binary to orchestrate sibling containers via the
 # host's Docker socket (bind-mounted by compose).
-FROM docker:28-cli-alpine3.21
+FROM docker:28-cli
 
 ARG SUPERCRONIC_VERSION=v0.2.46
 ARG SUPERCRONIC_SHA1SUM=5bcefed628e32adc08e32634db2d10e9230dbca0
+
+SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache curl tini \

--- a/.docker/osm-cron/Dockerfile
+++ b/.docker/osm-cron/Dockerfile
@@ -12,7 +12,7 @@ ARG SUPERCRONIC_SHA1SUM=5bcefed628e32adc08e32634db2d10e9230dbca0
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 
 # hadolint ignore=DL3018
-RUN apk add --no-cache curl tini \
+RUN apk add --no-cache curl tini flock \
     && curl -fsSLO "https://github.com/aptible/supercronic/releases/download/${SUPERCRONIC_VERSION}/supercronic-linux-amd64" \
     && echo "${SUPERCRONIC_SHA1SUM}  supercronic-linux-amd64" | sha1sum -c - \
     && chmod +x supercronic-linux-amd64 \

--- a/.docker/osm-cron/crontab
+++ b/.docker/osm-cron/crontab
@@ -1,0 +1,3 @@
+# Placeholder crontab. The actual schedule is written at container start
+# from the OSM_CRON_SCHEDULE env var (see Dockerfile CMD).
+0 3 * * * /usr/local/bin/run-update.sh

--- a/.docker/osm-cron/run-update.sh
+++ b/.docker/osm-cron/run-update.sh
@@ -16,6 +16,17 @@ log() {
     printf '[osm-cron] %s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"
 }
 
+# Concurrency guard — a long-running provisioner must not overlap with the
+# next scheduled fire, otherwise two sibling containers would write to the
+# same OSM data directory and corrupt the merged PBF. flock -n exits
+# immediately when the lock is already held; -E 0 turns that into a benign
+# skip (rc 0) so cron doesn't treat it as a failure.
+LOCK_FILE="${OSM_CRON_LOCK_FILE:-/tmp/osm-cron.lock}"
+if [ -z "${OSM_CRON_LOCKED:-}" ]; then
+    export OSM_CRON_LOCKED=1
+    exec flock -n -E 0 "${LOCK_FILE}" "$0" "$@"
+fi
+
 # Identify the current Compose project from our own labels so we target the
 # Valhalla instance belonging to *this* stack (multi-tenant safe). Falls back
 # to OSM_CRON_PROJECT if the label is unset.

--- a/.docker/osm-cron/run-update.sh
+++ b/.docker/osm-cron/run-update.sh
@@ -48,7 +48,7 @@ log "project=${PROJECT} provisioner_image=${PROVISIONER_IMAGE}"
 VALHALLA_CID="$(docker ps \
     --filter "label=com.docker.compose.project=${PROJECT}" \
     --filter "label=com.docker.compose.service=valhalla" \
-    --format '{{.ID}}')"
+    --format '{{.ID}}' | head -n 1)"
 
 if [ -z "${VALHALLA_CID}" ]; then
     log "ERROR: no running Valhalla container found for project ${PROJECT}"

--- a/.docker/osm-cron/run-update.sh
+++ b/.docker/osm-cron/run-update.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+# OSM nightly refresh orchestrator.
+#
+# 1. Runs the provisioner image in non-interactive mode against the persisted
+#    region selection (see #477). The OSM data directory is shared with the
+#    Valhalla container and mounted into the sibling provisioner container we
+#    spawn via the host Docker socket.
+# 2. Restarts the Valhalla container (identified by Compose labels) so the
+#    GIS-Ops image rebuilds its tiles from the new PBF on startup.
+#
+# Designed to be invoked by supercronic in the osm-cron container.
+
+set -eu
+
+log() {
+    printf '[osm-cron] %s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"
+}
+
+# Identify the current Compose project from our own labels so we target the
+# Valhalla instance belonging to *this* stack (multi-tenant safe). Falls back
+# to OSM_CRON_PROJECT if the label is unset.
+PROJECT="${OSM_CRON_PROJECT:-$(docker inspect -f '{{ index .Config.Labels "com.docker.compose.project" }}' "$(hostname)" 2>/dev/null || true)}"
+
+if [ -z "${PROJECT}" ]; then
+    log "ERROR: unable to determine Compose project name (set OSM_CRON_PROJECT)"
+    exit 1
+fi
+
+PROVISIONER_IMAGE="${OSM_CRON_PROVISIONER_IMAGE:-${PROJECT}-provisioner}"
+
+log "project=${PROJECT} provisioner_image=${PROVISIONER_IMAGE}"
+
+# Discover the Valhalla container in this project so we can both reuse its
+# host-side mount for /custom_files (which contains the merged PBF and is the
+# same directory the provisioner writes to) and restart it once the refresh
+# completes.
+VALHALLA_CID="$(docker ps \
+    --filter "label=com.docker.compose.project=${PROJECT}" \
+    --filter "label=com.docker.compose.service=valhalla" \
+    --format '{{.ID}}')"
+
+if [ -z "${VALHALLA_CID}" ]; then
+    log "ERROR: no running Valhalla container found for project ${PROJECT}"
+    exit 1
+fi
+
+# Extract the host path bind-mounted at /custom_files/default.osm.pbf inside
+# the Valhalla container — that's the same default.osm.pbf the provisioner
+# writes to /data/default.osm.pbf. We mount its parent directory at /data in
+# the sibling provisioner container.
+OSM_DATA_HOST_PATH="${OSM_CRON_OSM_DATA_PATH:-$(docker inspect "${VALHALLA_CID}" \
+    --format '{{ range .Mounts }}{{ if eq .Destination "/custom_files/default.osm.pbf" }}{{ .Source }}{{ end }}{{ end }}' \
+    | sed 's|/default\.osm\.pbf$||')}"
+
+if [ -z "${OSM_DATA_HOST_PATH}" ]; then
+    log "ERROR: unable to resolve host path of OSM data directory (set OSM_CRON_OSM_DATA_PATH)"
+    exit 1
+fi
+
+log "osm_data_host_path=${OSM_DATA_HOST_PATH}"
+
+log "running provisioner update"
+docker run --rm \
+    --label "com.docker.compose.project=${PROJECT}" \
+    -v "${OSM_DATA_HOST_PATH}:/data" \
+    "${PROVISIONER_IMAGE}" \
+    --no-interaction
+
+log "provisioner update finished, restarting Valhalla container ${VALHALLA_CID}"
+docker restart "${VALHALLA_CID}"
+log "Valhalla restarted, tiles will rebuild from the new PBF on startup"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := help
-.PHONY: help start stop install qa test php-shell pwa-shell ensure-default-pbf provision coverage coverage-ci migration migrate db-create fixtures
+.PHONY: help start stop install qa test php-shell pwa-shell ensure-default-pbf provision provision-update coverage coverage-ci migration migrate db-create fixtures
 
 help: ## Show this help message
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n\nTargets:\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
@@ -122,6 +122,9 @@ test: qa test-php test-e2e openapi-lint security-check ## Run full test suite (R
 ## --- 🗺️ OSM Provisioning ---
 provision: ensure-default-pbf ## Provision OSM regions interactively
 	@docker compose --profile provisioning run --rm provisioner
+
+provision-update: ## Trigger a non-interactive provisioner update (manual osm-cron debug)
+	@docker compose --profile provisioning run --rm provisioner --no-interaction
 
 ## --- 🗄️ Database ---
 migration: ## Generate a Doctrine migration

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -262,6 +262,22 @@ services:
     restart: "no"
     profiles: ["provisioning"]
 
+  # Nightly OSM refresh scheduler.
+  # Runs the provisioner in update mode on OSM_CRON_SCHEDULE (default 03:00 UTC)
+  # and restarts Valhalla so it rebuilds its tiles from the new PBF.
+  # The Docker socket is mounted RW: standard pattern for sibling-container
+  # orchestrators (Ofelia, Watchtower) — kept lean (only docker-cli + supercronic).
+  osm-cron:
+    build:
+      context: ./
+      dockerfile: .docker/osm-cron/Dockerfile
+    restart: unless-stopped
+    profiles: ["routing"]
+    environment:
+      OSM_CRON_SCHEDULE: "${OSM_CRON_SCHEDULE:-0 3 * * *}"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
 volumes:
   caddy_data: ~
   caddy_config: ~

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -277,6 +277,8 @@ services:
       OSM_CRON_SCHEDULE: "${OSM_CRON_SCHEDULE:-0 3 * * *}"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+    security_opt:
+      - no-new-privileges:true
 
 volumes:
   caddy_data: ~

--- a/compose.yaml
+++ b/compose.yaml
@@ -276,6 +276,20 @@ services:
     restart: "no"
     profiles: ["provisioning"]
 
+  # Nightly OSM refresh scheduler (mirrors compose.prod.yaml).
+  # Profile-gated to "routing" so it only runs when explicitly opted in
+  # locally — useful to exercise the full refresh + Valhalla restart cycle.
+  osm-cron:
+    build:
+      context: ./
+      dockerfile: .docker/osm-cron/Dockerfile
+    restart: unless-stopped
+    profiles: ["routing"]
+    environment:
+      OSM_CRON_SCHEDULE: "${OSM_CRON_SCHEDULE:-0 3 * * *}"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
 volumes:
   caddy_data: ~
   caddy_config: ~

--- a/compose.yaml
+++ b/compose.yaml
@@ -289,6 +289,8 @@ services:
       OSM_CRON_SCHEDULE: "${OSM_CRON_SCHEDULE:-0 3 * * *}"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+    security_opt:
+      - no-new-privileges:true
 
 volumes:
   caddy_data: ~


### PR DESCRIPTION
Closes #479. Stacked on top of #538 (feature/477) — needs the `--no-interaction` mode added there.

## Summary

- `.docker/osm-cron/Dockerfile` — alpine + `docker:cli` + `supercronic v0.2.46` (SHA1 verified) + `tini` as PID 1.
- `.docker/osm-cron/crontab` — placeholder; the real schedule line is rendered at container start from `OSM_CRON_SCHEDULE` (default `0 3 * * *`).
- `.docker/osm-cron/run-update.sh` (100755) — discovers the Compose project from its own container labels, locates the Valhalla container via `com.docker.compose.service=valhalla`, reuses Valhalla's OSM bind-mount for a sibling `docker run` of the `provisioner` image with `--no-interaction`, then `docker restart`s Valhalla so it rebuilds its tiles.
- `compose.yaml` + `compose.prod.yaml` — new `osm-cron` service under profile `routing`. Docker socket mounted RW. `OSM_CRON_SCHEDULE` env var. No exposed ports.
- `Makefile` — new `provision-update` target (`docker compose --profile provisioning run --rm provisioner --no-interaction`) for manual debugging.

## Auto-critique

- Docker socket mount is intentional and equivalent to host-root — the trade-off is acknowledged here and fully documented in ADR-033 (#539) + the README security caveat. Re-evaluating via `tecnativa/docker-socket-proxy` is captured as a follow-up.
- Locked to profile `routing` so the cron only runs when Valhalla runs.
- Image tags are pinned (no `:latest`) to make supply-chain upgrades intentional.

## Test plan

- [x] `make qa` — green
- [x] `make phpunit` (provisioner) — 18 tests, 197 assertions, OK (regression check)
- [ ] Manual : `docker compose --profile routing up -d osm-cron` with `OSM_CRON_SCHEDULE="* * * * *"` → `docker logs osm-cron` shows provisioner success + Valhalla restart
- [ ] Manual : after restart, Valhalla healthcheck `service_starting` → `service_healthy` (< 10 min on Île-de-France)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

**Findings:** None | Reviewed commit `1f58140`

**Resolved threads:** Resolved 4 previously open bot-authored threads — SHA256 upgrade (×2, including carry-over) and `head -n 1` guard (×2, including carry-over). All findings from prior cycles are now addressed in code.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [ ] Tests cover new/changed cases *(no automated tests for the osm-cron container; manual test plan provided)*
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** None.

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->