### PR TITLE
chore(claude): incorporate Sprint 33 retrospective into skills

### DIFF
--- a/.claude/skills/close/SKILL.md
+++ b/.claude/skills/close/SKILL.md
@@ -25,8 +25,9 @@ List the **concrete** items that would be removed, with their PR/merge status:
 ## Step 3 — Clean up (plain git, only after confirmation)
 
 For each branch whose PR is **merged or closed**:
-- `git worktree remove <path>` then `git worktree prune`. If removal fails (dirty worktree), **flag it and skip** rather than force.
+- Worktrees created via `EnterWorktree` are locked. Run `git worktree unlock <path>` then `git worktree remove <path>` and finally `git worktree prune`. If the remove still fails because a sub-tree contains files written by Docker as root (typically `.phpunit.cache/`, `node_modules/.cache/`), **flag the paths to the user and stop** — do not try `sudo`, do not force. The user will clear them by hand.
 - `git branch -d feature/<n>` — use **`-d`, not `-D`**. If git refuses (unmerged), **flag it and skip** rather than force-delete.
+- Also clean the skeleton branches `worktree-agent-<id>` that `EnterWorktree` leaves behind: `git branch -d worktree-agent-<id>`.
 
 Worktrees live under the gitignored `.claude/worktrees/`, so these removals are purely local.
 

--- a/.claude/skills/pick/SKILL.md
+++ b/.claude/skills/pick/SKILL.md
@@ -2,7 +2,7 @@
 name: pick
 description: Implement a GitHub issue end-to-end (branch, code, test, PR, CI, review)
 argument-hint: <issue-number> [base-branch]
-allowed-tools: Bash(git *), Bash(gh *), Bash(make *), Read, Edit, Write, Glob, Grep
+allowed-tools: Bash(git *), Bash(gh *), Bash(make *), Bash(rsync *), Read, Edit, Write, Glob, Grep
 ---
 
 Implement GitHub issue `$ARGUMENTS` end-to-end. Parse the arguments: first token is the issue number, second token (optional) is the base branch (default `main`).
@@ -27,19 +27,38 @@ git fetch origin && git worktree add -b feature/<issue-number> .claude/worktrees
 
 > **All subsequent steps MUST be executed from the worktree directory (`.claude/worktrees/feature-<issue-number>`).**
 
-## Step 4 -- Read the issue
+## Step 4 -- Bootstrap deps
+
+The worktree starts with empty `vendor/` and `node_modules/`. Running `make install` per worktree is slow (≈30s composer + ≈25s npm) and Docker compose spins up a separate project per worktree path, so each tool invocation re-installs apk packages. Hard-link the existing deps from the main repo instead:
+
+```bash
+MAIN=/home/vincent/Sites/bike-trip-planner
+for p in api/vendor api/vendor-bin provisioner/vendor provisioner/vendor-bin pwa/node_modules; do
+  [ -d "$MAIN/$p" ] && rsync -a --link-dest="$MAIN/$p/" "$MAIN/$p/" "$p/"
+done
+```
+
+Only run `make install` if the issue actually touches `composer.json` or `package.json`.
+
+## Step 5 -- Read the issue
 
 Understand all requirements from the issue before writing any code.
 
-## Step 5 -- Implement
+## Step 6 -- Implement
 
 Implement the solution respecting CLAUDE.md rules (architecture, SOLID, patterns, tests). If backend DTOs change, run `make typegen`.
 
-## Step 6 -- Run tests
+## Step 7 -- QA loop (mandatory, in the worktree)
+
+Run `make qa` from the worktree **before pushing**. PHP-CS-Fixer, Rector and Prettier auto-apply fixes — re-stage and commit those changes (`style:` or amend the previous commit). Repeat until `make qa` exits 0 with no working-tree diff. PHPStan / TypeScript / ESLint errors must be fixed by hand, then re-run.
+
+Skipping this and pushing raw code wastes a CI round-trip per autofixable issue (observed in Sprint 33: PR #538 went red three times in a row on `php-cs-fixer` because the agent never ran QA locally).
+
+## Step 8 -- Run tests
 
 Run `make test`. Fix any failures until the suite passes.
 
-## Step 7 -- Self-review
+## Step 9 -- Self-review
 
 From the worktree directory, run `git diff <base-branch>...HEAD`. Look for:
 - Leftover `console.log`, `dump()`, `dd()`, or debug statements
@@ -48,14 +67,14 @@ From the worktree directory, run `git diff <base-branch>...HEAD`. Look for:
 
 Fix anything found, commit, and push.
 
-## Step 8 -- Create PR (Ready for review)
+## Step 10 -- Create PR (Ready for review)
 
 - From the worktree directory, stage and commit changes following Conventional Commits
 - Push the branch: `git push -u origin feature/<issue-number>`
 - Create the PR: `gh pr create --fill --base <base-branch>`
 - The PR body must include an **Auto-critique** section per CLAUDE.md
 
-## Step 9 -- Drive the PR to READY
+## Step 11 -- Drive the PR to READY
 
 Run the **bounded surveillance loop** (max 3 cycles) until the PR is READY. Never merge — the user merges.
 
@@ -63,11 +82,12 @@ Each cycle:
 1. **CI** — `gh pr checks`. If red: read the logs (`gh run view --log-failed`), fix, push.
 2. **Review comments** — fetch PR-level (`gh pr view --json comments`) and inline (`gh api repos/:owner/:repo/pulls/<pr>/comments`) comments. Address actionable points, push, resolve threads; list any left unactioned with the reason.
 3. **Conflicts** — `gh pr view --json mergeable,mergeStateStatus`. If `CONFLICTING`: rebase onto the base and resolve **conservatively**; if ambiguous or risky, stop and flag rather than force.
+4. **Parent moved (stacked PR)** — if the PR's base is `feature/<n>` and that branch has new commits on origin since the last sync, rebase: `git fetch origin && git rebase origin/feature/<n>`, then `git push --force-with-lease`. Resolve conflicts conservatively, flag if ambiguous.
 
 **READY** when: CI green AND mergeable AND not draft AND `claude-code-review.yml` has completed (`gh run view --workflow=claude-code-review.yml` shows `completed`) with no new blocking (Critical/High) comment. Wait for that workflow to finish before evaluating — it runs asynchronously after each push. After 3 cycles without convergence, report **NEEDS ATTENTION** with the blocker.
 
-## Step 10 -- Finalize
+## Step 12 -- Finalize
 
 - If TRACKING.md exists, update the row for this issue: change status to "En cours" and branch to `feature/<issue-number>`. Commit and push.
-- Remove the worktree: `git worktree remove .claude/worktrees/feature-<issue-number>`
+- Remove the worktree: `git worktree remove .claude/worktrees/feature-<issue-number>` (if it fails on root-owned files like `.phpunit.cache/`, flag to the user — Docker containers write as root).
 - Report the PR URL and its final status (READY / NEEDS ATTENTION + blocker) to the user.

--- a/.claude/skills/pick/SKILL.md
+++ b/.claude/skills/pick/SKILL.md
@@ -32,7 +32,7 @@ git fetch origin && git worktree add -b feature/<issue-number> .claude/worktrees
 The worktree starts with empty `vendor/` and `node_modules/`. Running `make install` per worktree is slow (≈30s composer + ≈25s npm) and Docker compose spins up a separate project per worktree path, so each tool invocation re-installs apk packages. Hard-link the existing deps from the main repo instead:
 
 ```bash
-MAIN=/home/vincent/Sites/bike-trip-planner
+MAIN=$(git worktree list | awk 'NR==1{print $1}')
 for p in api/vendor api/vendor-bin provisioner/vendor provisioner/vendor-bin pwa/node_modules; do
   [ -d "$MAIN/$p" ] && rsync -a --link-dest="$MAIN/$p/" "$MAIN/$p/" "$p/"
 done

--- a/.claude/skills/sprint/SKILL.md
+++ b/.claude/skills/sprint/SKILL.md
@@ -49,12 +49,19 @@ You are implementing GitHub issue #<number>: <title>
 1. Read CLAUDE.md to understand the project architecture and conventions
 2. Create branch `feature/<issue-number>` from `<base-branch>`
    - Base branch is `main` unless this issue depends on another, then use `feature/<dep-number>`
-3. Implement the solution following CLAUDE.md rules (architecture, SOLID, patterns)
-4. Commit your changes using Conventional Commits format
-5. **IMPORTANT: Do NOT run any `make` commands** — no `make qa`, `make test`, `make typegen`, `make phpunit`, `make phpstan`, etc. The main agent handles QA/tests later.
-6. If you modify backend DTOs (api/src/ApiResource/), include "DTO_CHANGED" in your final message
-7. If you add new dependencies to composer.json or package.json, include "DEPS_CHANGED" in your final message
-8. Focus only on writing correct, well-structured code and committing it
+3. Bootstrap deps in the worktree by hard-linking from the main repo (the worktree starts with empty vendor/ and node_modules/; reinstalling per worktree is expensive and Docker compose spins up a separate project per worktree path):
+   ```bash
+   MAIN=/home/vincent/Sites/bike-trip-planner
+   for p in api/vendor api/vendor-bin provisioner/vendor provisioner/vendor-bin pwa/node_modules; do
+     [ -d "$MAIN/$p" ] && rsync -a --link-dest="$MAIN/$p/" "$MAIN/$p/" "$p/"
+   done
+   ```
+4. Implement the solution following CLAUDE.md rules (architecture, SOLID, patterns)
+5. Run `make qa` and commit autofixes (PHP-CS-Fixer, Rector, Prettier auto-apply). Repeat until `make qa` exits 0 with no working-tree diff. PHPStan / TypeScript / ESLint errors must be fixed by hand. **Do NOT run `make test` / `make typegen` / `make install`** — the main agent handles those during Phase 2 (Docker container spin-up is shared there).
+6. Commit your changes using Conventional Commits format (final commit must include any QA autofixes — never leave a dirty worktree)
+7. If you modify backend DTOs (api/src/ApiResource/), include "DTO_CHANGED" in your final message
+8. If you add new dependencies to composer.json or package.json, include "DEPS_CHANGED" in your final message
+9. Focus only on writing correct, well-structured code and committing it
 ```
 
 Use `isolation: "worktree"` for each agent.
@@ -69,10 +76,10 @@ Track results: for each issue, record SUCCESS (with worktree branch), DTO_CHANGE
 
 For each successfully coded branch, **in dependency order**:
 
-1. `git checkout feature/<issue-number>`
+1. `cd` into the agent's worktree (or `git checkout feature/<issue-number>` if working from a shared one)
 2. If DEPS_CHANGED: `make install`
 3. If DTO_CHANGED: `make typegen`
-4. Run `make qa` — if it fails, read errors, fix, commit, retry (up to 3 attempts)
+4. Run `make qa` — Phase 1 already ran this in the agent, so this is the safety net. If it fails, read errors, fix, commit, retry (up to 3 attempts)
 5. Run `make test` — if it fails, read errors, fix, commit, retry (up to 3 attempts)
 6. If QA/tests still fail after 3 attempts, mark as **FAILED** and continue to the next branch
 
@@ -99,6 +106,7 @@ Each cycle:
 
    Address every **actionable** point, commit, push, then reply to / resolve the corresponding threads. List any comment you deliberately did not action, with the reason.
 3. **Conflicts** — `gh pr view <pr> --json mergeable,mergeStateStatus`. If `CONFLICTING`: rebase onto the base branch and resolve **conservatively**. If the resolution is ambiguous or risks discarding work, **stop and flag it** — do not force a resolution.
+4. **Parent moved (stacked PR)** — if the PR's base is `feature/<n>` and that branch advanced on origin since the last sync (compare local merge-base vs `origin/feature/<n>`), rebase onto it: `git fetch origin feature/<n> && git rebase origin/feature/<n>`, then `git push --force-with-lease`. **Whenever you push new commits to a parent branch (Phase 4 cycle on that PR), immediately re-rebase every child PR onto it** to keep the stack consistent — the GitHub UI does not do this for you and the stale child will hit a phantom conflict at merge time.
 
 **Termination (READY)** when all hold: CI green **AND** `mergeable` **AND** not draft **AND** `claude-code-review.yml` has completed (`gh run view --workflow=claude-code-review.yml` shows `completed`) with **no new blocking comment** (Critical/High). Wait for that workflow to finish before evaluating its output — after a push it is triggered asynchronously and may still be `pending`/`in_progress`.
 
@@ -112,7 +120,7 @@ For each issue, update the TRACKING.md row:
 - FAILED: set status to "Échoué"
 - BLOCKED: set status to "Bloqué"
 
-Commit and push the TRACKING.md update.
+Commit and push the TRACKING.md update **on a dedicated branch** (e.g. `chore/sprint-<n>-tracking`) — never on a worktree branch and never directly to main. From the main repo (not a worktree): `git switch main && git pull --ff-only && git switch -c chore/sprint-<n>-tracking`, edit, commit, push, open PR.
 
 ## Step 8 — Final report
 

--- a/.claude/skills/sprint/SKILL.md
+++ b/.claude/skills/sprint/SKILL.md
@@ -51,7 +51,7 @@ You are implementing GitHub issue #<number>: <title>
    - Base branch is `main` unless this issue depends on another, then use `feature/<dep-number>`
 3. Bootstrap deps in the worktree by hard-linking from the main repo (the worktree starts with empty vendor/ and node_modules/; reinstalling per worktree is expensive and Docker compose spins up a separate project per worktree path):
    ```bash
-   MAIN=/home/vincent/Sites/bike-trip-planner
+   MAIN=$(git worktree list | awk 'NR==1{print $1}')
    for p in api/vendor api/vendor-bin provisioner/vendor provisioner/vendor-bin pwa/node_modules; do
      [ -d "$MAIN/$p" ] && rsync -a --link-dest="$MAIN/$p/" "$MAIN/$p/" "$p/"
    done


### PR DESCRIPTION
## Summary

Three concrete improvements based on Sprint 33 pain points, applied to `pick` / `sprint` / `close` skills:

### 1. Agents must run `make qa` locally + commit autofixes
**Symptom**: PR #538 went red on `php-cs-fixer (provisioner)` three times because the agent committed without running QA. PHP-CS-Fixer / Rector / Prettier auto-applicable fixes only surfaced on CI.
**Fix**: `sprint` Step 3 prompt and `pick` new Step 7 mandate `make qa` in the worktree until exit 0 + clean working tree.

### 2. Bootstrap worktree deps via hardlinks
**Symptom**: Worktrees start with empty `vendor/` and `node_modules/`. Each Docker compose project is independent (project name = directory name), so `make install` reruns apk + composer + npm per worktree. Manually `rsync --link-dest` four times during the sprint cost ≈10 minutes.
**Fix**: New bootstrap step in both skills hard-links `api/vendor`, `api/vendor-bin`, `provisioner/vendor`, `provisioner/vendor-bin`, `pwa/node_modules` from the main repo. Cost: ~1s, no extra disk.

### 3. Auto-rebase stacked child PRs when parent moves
**Symptom**: PR #540 / #541 were stacked on #538. Every fix pushed to #538 left #540/#541 with stale parents — surfaced as conflicts only at merge time on #540.
**Fix**: `sprint` Step 6 cycle 4 and `pick` Step 11 cycle 4 explicitly require `git fetch origin feature/<n> && git rebase origin/feature/<n>` + `--force-with-lease` immediately after pushing to a parent.

### Bonus — `close` skill robustness
Worktrees created via `EnterWorktree` are locked; the close skill now unlocks them first. Docker-written root-owned files (`.phpunit.cache/`) are flagged for manual cleanup rather than forced (no `sudo`).

## Not included here — needs manual application

Proposal 5 (hook to auto-unlock worktrees before `git worktree remove`) is not in this PR: `.claude/settings.json` is protected by the existing `PreToolUse` hook against the `Edit` tool. If you want the hook, add this to `.claude/settings.json` under `hooks.PreToolUse`:

```json
{
  "matcher": "Bash",
  "hooks": [
    {
      "type": "command",
      "command": "bash -c 'CMD=$(jq -r \".tool_input.command\" <<< \"$(cat)\"); if [[ \"$CMD\" == *\"git worktree remove\"* ]]; then PATH_ARG=$(echo \"$CMD\" | grep -oP \"git worktree remove\\s+\\K\\S+\"); [ -n \\\"$PATH_ARG\\\" ] && git worktree unlock \\\"$PATH_ARG\\\" 2>/dev/null; fi; exit 0'"
    }
  ]
}
```

## Auto-critique

- Skill changes are documentation-only; they alter agent behaviour but require no code or tests.
- The hardlink trick relies on `rsync --link-dest` pointing at an absolute path matching the main repo. If you move the repo, the path in the skill needs updating — kept absolute on purpose so it's grep-able.
- The stacked-PR rebase guidance does not handle 3-way stacks (PR C depending on PR B depending on PR A): a child must be rebased after every parent change in the chain, which is mentioned but not enforced mechanically.

## Test plan

- [x] Skill files are valid frontmatter (manual diff review)
- [ ] Next `/sprint` or `/pick` invocation should pick up the new instructions automatically (skills are read at slash-command time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

Clean skill retrospective with clear symptom→fix framing. The correctness finding from the previous review (hardcoded repo path) was addressed in commit `4742b93a` by deriving the main repo path via `git worktree list`. No new blocking issues found.

**Resolved 2 previously open threads** (both were outdated; the hardcoded-path fix in `4742b93a` addressed both `pick/SKILL.md` and `sprint/SKILL.md`).

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [ ] Tests cover new/changed cases — skill files alter agent behaviour only; no automated tests applicable
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**No inline comments.**

Reviewed commit: `4742b93a98f50d43cfd15a947c7451b00fb7cf96`

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->