### PR TITLE
chore(claude): two-phase close skill + manual-settings reminder

### DIFF
--- a/.claude/skills/close/SKILL.md
+++ b/.claude/skills/close/SKILL.md
@@ -14,24 +14,38 @@ In priority order:
 2. Otherwise infer it: list local `feature/<n>` branches (`git branch`) and worktrees (`git worktree list`), then cross-reference those issue numbers against `TRACKING.md` to find which sprint they belong to.
 3. If still ambiguous (several active sprints, or none): propose the most likely sprint and **ask the user to confirm** before doing anything.
 
-## Step 2 — Show the cleanup plan (destructive guard)
+## Step 2 — Detect the cleanup phase
+
+Sprint cleanup happens in two waves and `/close` may be invoked at either point:
+
+- **Phase A — sprint cleanup**: feature branches and their worktrees still exist. The first `/close` of the sprint.
+- **Phase B — post-retro cleanup**: feature branches are gone, but a `chore/sprint-<n>-*` branch (the retrospective PR from a previous `/close` run) is still around because its PR merged after the first cleanup. A second `/close` to tidy that up.
+
+Detection:
+- If `git branch --list 'feature/*'` returns any branch belonging to this sprint → **Phase A**.
+- Else if `git branch --list 'chore/sprint-<n>-*'` returns any branch whose PR is merged → **Phase B**.
+- Else: nothing to do. Report "Sprint already fully closed" and exit.
+
+Report the detected phase to the user before proceeding.
+
+## Step 3 — Show the cleanup plan (destructive guard)
 
 List the **concrete** items that would be removed, with their PR/merge status:
-- Each worktree under `.claude/worktrees/` tied to a sprint issue (`git worktree list`).
-- Each local `feature/<n>` branch, with whether its PR is merged/closed/open (`gh pr view feature/<n> --json state,mergedAt`).
+- **Phase A**: each worktree under `.claude/worktrees/` tied to a sprint issue (`git worktree list`), plus each local `feature/<n>` branch (`gh pr view feature/<n> --json state,mergedAt`).
+- **Phase B**: each local `chore/sprint-<n>-*` branch (`gh pr view <branch> --json state,mergedAt`).
 
 **Require explicit user confirmation before any deletion**, regardless of confidence. Never delete a branch/worktree whose PR is still open.
 
-## Step 3 — Clean up (plain git, only after confirmation)
+## Step 4 — Clean up (plain git, only after confirmation)
 
 For each branch whose PR is **merged or closed**:
 - Worktrees created via `EnterWorktree` are locked. Run `git worktree unlock <path>` then `git worktree remove <path>` and finally `git worktree prune`. If the remove still fails because a sub-tree contains files written by Docker as root (typically `.phpunit.cache/`, `node_modules/.cache/`), **flag the paths to the user and stop** — do not try `sudo`, do not force. The user will clear them by hand.
-- `git branch -d feature/<n>` — use **`-d`, not `-D`**. If git refuses (unmerged), **flag it and skip** rather than force-delete.
+- `git branch -d <branch>` — use **`-d`, not `-D`**. If git refuses (unmerged), **flag it and skip** rather than force-delete.
 - Also clean the skeleton branches `worktree-agent-<id>` that `EnterWorktree` leaves behind: `git branch -d worktree-agent-<id>`.
 
 Worktrees live under the gitignored `.claude/worktrees/`, so these removals are purely local.
 
-## Step 4 — Update main
+## Step 5 — Update main
 
 ```bash
 git checkout main && git pull --ff-only origin main
@@ -39,7 +53,9 @@ git checkout main && git pull --ff-only origin main
 
 If `--ff-only` fails (local main diverged), report it and stop — do not reset or force.
 
-## Step 5 — Retrospective into the config
+## Step 6 — Retrospective into the config (Phase A only)
+
+Skip this step in Phase B — the retrospective was already done in the prior Phase A run.
 
 Synthesize what went well / badly during this sprint, grounded in **actual events** (recurring CI failures, review back-and-forths, blocking hooks, conventions repeatedly missed). For each recurring pain point, propose a **concrete** config change:
 - `CLAUDE.md` rule or gotcha
@@ -47,3 +63,16 @@ Synthesize what went well / badly during this sprint, grounded in **actual event
 - a hook or permission in `.claude/settings.json`
 
 **Propose, do not apply.** If the user approves a change, implement it via a **feature branch + PR** — never commit config directly to `main`.
+
+## Step 7 — Surface manually-applicable config (Phase A only)
+
+`.claude/settings.json` and `.claude/settings.local.json` are protected by a `PreToolUse` hook against `Write`/`Edit`. Any retrospective proposal that touches them cannot be applied by the agent — it must be applied by the user.
+
+When the retrospective produces such a proposal:
+1. Include the exact JSON diff in the retro PR description under a clearly-marked "Manual application required" section.
+2. After the retro PR is opened, remind the user explicitly that the hook/permission change requires their hand. Do not let it disappear into the PR body.
+3. Note that this reminder will not re-surface in Phase B — Phase B does not re-run the retrospective.
+
+## Step 8 — Final report
+
+Print a concise summary: which phase ran, what was removed, what is left for the user (root-owned dirs, manual settings.json changes), and the URL of the retro PR if one was created.


### PR DESCRIPTION
## Summary

Two follow-up improvements based on running `/close` twice during Sprint 33.

### 1. Phase A vs Phase B detection

**Symptom (observed in Sprint 33):**
- First `/close` cleaned worktrees + `feature/<n>` branches, opened retro PR #543.
- After #543 merged, the local `chore/sprint-33-retro-improvements` branch was orphaned.
- Running `/close` a second time silently re-ran the destructive cleanup and asked the retrospective question all over again — even though there was nothing left to retro.

**Fix:** new Step 2 explicitly detects:
- **Phase A** — feature branches still exist (first `/close` of the sprint).
- **Phase B** — only the `chore/sprint-<n>-*` retro branch remains (second `/close`, post-merge).
- **Nothing to do** — neither set exists, exit cleanly.

Phase B skips the retrospective step (Step 6) because it was already done in Phase A.

### 2. Manual-settings reminder

**Symptom:** during the Sprint 33 retro I proposed a `PreToolUse:Bash` hook for `.claude/settings.json`. That file is protected by the existing project hook against `Write`/`Edit`, so the agent cannot apply the change. I documented the diff in the PR body and merged the PR — but there is no mechanism that resurfaces the proposal after merge. The hook is now silently un-applied.

**Fix:** new Step 7 mandates:
1. A dedicated "Manual application required" section in the retro PR body.
2. An explicit reminder to the user **after opening the PR** (not buried in the description).
3. A note that Phase B does **not** re-surface this reminder.

## Auto-critique

- Detection in Step 2 is based on branch naming convention (`chore/sprint-<n>-*`). If a future retro uses a different prefix, the detection won't fire — kept the prefix grep-able on purpose so it's obvious to update both producer (sprint/pick skills creating the branch) and consumer (close skill detecting it).
- The "manual reminder" is a behavioural requirement, not a mechanical one. A future improvement could parse the retro PR body for `.claude/settings.json` snippets and emit a structured task — left out here as overkill for the current cadence (≈one retro per sprint).
- Phase detection still relies on the user invoking `/close` a second time. Could be auto-triggered by a hook after PR merge, but that's outside this PR's scope.

## Test plan

- [x] `git diff` review of the SKILL.md changes
- [ ] Next sprint close: confirm Phase A → Phase B transition works without re-prompting the retro

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

Reviewed commit `fdf758589ce737254198cd0afd04585fdeac6b90`.

The phase-detection split cleanly resolves the double-invocation problem observed in Sprint 33. The two-wave model (Phase A → Phase B → nothing to do) is the right abstraction, and the instruction prose is unambiguous enough for an LLM agent to execute correctly. Step 7's manual-settings reminder fills a real gap — previously those proposals disappeared silently into merged PR bodies.

**PR title check** — `chore(claude): two-phase close skill + manual-settings reminder`: the description is a noun phrase rather than imperative mood (Conventional Commits requires imperative). Consider e.g. `chore(claude): add two-phase detection to close skill and surface manual-settings reminder`.

**Review checklist**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [ ] Tests cover new/changed cases — live test deferred to next sprint close (appropriate for a behavioral skill file)
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

No inline comments. No previously open threads to resolve.

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->