### PR TITLE
docs(adr): add adr-034 plausible self-hosted analytics decision

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Type safety is enforced end-to-end: PHP DTOs define the schema -> API Platform e
 | [Getting Started](docs/getting-started.md) | Requirements, installation, and local setup |
 | [Contributing](docs/contributing.md) | Development workflow, standards, and tooling |
 | [Deployment](docs/deployment.md) | CI/CD pipeline, required secrets, rollback procedure |
-| [Architecture Decisions](docs/adr/) | 33 ADRs explaining every major technical choice |
+| [Architecture Decisions](docs/adr/) | 34 ADRs explaining every major technical choice |
 | [Runbooks](docs/runbooks/) | On-call playbooks: workers, DB, Redis, Mercure, Ollama, releases |
 | [Claude Code Tooling](docs/claude-code-tooling.md) | MCP servers, hooks, and skills for AI-assisted development |
 

--- a/TRACKING.md
+++ b/TRACKING.md
@@ -617,12 +617,12 @@ Collecte de métriques d'usage **agrégées et anonymes** (sources, plateformes,
 | 2     | [#549](https://github.com/vincentchalamon/bike-trip-planner/issues/549) | Anonymisation/suppression user (soft-delete trips + préférences) + export données JSON ; events Plausible non liés à l'user | M      | [#555](https://github.com/vincentchalamon/bike-trip-planner/pull/555) | —         |
 | 3     | [#548](https://github.com/vincentchalamon/bike-trip-planner/issues/548) | ADR-034 : décision Plausible auto-hébergé (justification RGPD, custom events)                                    | S      | [#554](https://github.com/vincentchalamon/bike-trip-planner/pull/554) | —         |
 | 4     | [#551](https://github.com/vincentchalamon/bike-trip-planner/issues/551) | Setup Plausible auto-hébergé Docker + domaine + DNS — **tâche manuelle (ops)**                                   | M      |     | #548      |
-| 5     | [#552](https://github.com/vincentchalamon/bike-trip-planner/issues/552) | Intégration script Plausible dans `<head>` Next.js (data-domain, chargement conditionnel après consentement)     | S      | [#557](https://github.com/vincentchalamon/bike-trip-planner/pull/557) | #551      |
+| 5     | [#552](https://github.com/vincentchalamon/bike-trip-planner/issues/552) | Intégration script Plausible dans `<head>` Next.js (data-domain, chargement conditionnel à la config env `NEXT_PUBLIC_PLAUSIBLE_DOMAIN` — pas de consentement, cf. ADR-034) | S      | [#557](https://github.com/vincentchalamon/bike-trip-planner/pull/557) | #551      |
 | 6     | [#553](https://github.com/vincentchalamon/bike-trip-planner/issues/553) | Custom events Plausible — sources & plateformes (`import_komoot`, `import_strava`, `import_rwgps`, `import_gpx`) | S      | [#561](https://github.com/vincentchalamon/bike-trip-planner/pull/561) | #552      |
 | 7     | [#553](https://github.com/vincentchalamon/bike-trip-planner/issues/553) | Custom events Plausible — valeur features & rétention/UX (`trip_created`, `trip_shared`, `accommodation_selected`, `alert_action_clicked`, `ai_chat_opened`…) — _fusionné dans #553_ | M      | [#561](https://github.com/vincentchalamon/bike-trip-planner/pull/561) | #552      |
 | 8     | [#383](https://github.com/vincentchalamon/bike-trip-planner/issues/383) | Page `/account/settings` (Mon compte / Préférences / RGPD download / Zone de danger / Déconnexion)               | L      | [#558](https://github.com/vincentchalamon/bike-trip-planner/pull/558) | #550, #549 |
 | 9     | [#384](https://github.com/vincentchalamon/bike-trip-planner/issues/384) | Refonte top bar desktop (logo + tabs + undo/redo + Partager + ? aide unifiée + pills FR\|EN + thème + profil)    | L      | [#559](https://github.com/vincentchalamon/bike-trip-planner/pull/559) | #383       |
-| 10    | [#385](https://github.com/vincentchalamon/bike-trip-planner/issues/385) | Bannière cookies bas d'écran + modale granularité (Tout accepter / refuser / Personnaliser) — gating Plausible    | M      | [#560](https://github.com/vincentchalamon/bike-trip-planner/pull/560) | #550, #552 |
+| 10    | [#385](https://github.com/vincentchalamon/bike-trip-planner/issues/385) | ~~Bannière cookies + modale granularité~~ — **abandonné** : Plausible cookieless/sans PII, aucun consentement requis (cf. ADR-034) ; gating par env uniquement | M      | [#560](https://github.com/vincentchalamon/bike-trip-planner/pull/560) (fermée) | #550, #552 |
 
 ### Recette Sprint 34
 
@@ -630,14 +630,13 @@ Collecte de métriques d'usage **agrégées et anonymes** (sources, plateformes,
   - [ ] Page `/privacy` accessible et complète (base légale, conservation, droits utilisateurs, mention Plausible)
   - [ ] Mentions légales `/legal` accessibles
   - [ ] Page `/account/settings` accessible via le bouton profil de la top bar
-  - [ ] Bannière cookies bas d'écran fonctionnelle (Tout accepter / refuser / Personnaliser)
-  - [ ] **« Tout refuser »** → script Plausible **non chargé** (vérifier DevTools `Network` : aucune requête vers `plausible.io` / domaine auto-hébergé)
-  - [ ] **« Tout accepter »** → script Plausible chargé, page view trackée dans le dashboard Plausible
+  - [ ] Aucune bannière de consentement (Plausible cookieless/sans PII — aucun consentement requis, cf. ADR-034)
+  - [ ] Script Plausible chargé **uniquement si `NEXT_PUBLIC_PLAUSIBLE_DOMAIN` est défini** ; dormant sinon (beta sans analytics) — vérifier DevTools `Network`
+  - [ ] Lorsque configuré : page view trackée dans le dashboard Plausible
   - [ ] Custom events visibles dans le dashboard Plausible (sources d'import, trip_created, trip_shared, etc.)
   - [ ] Aucun cookie posé par Plausible (vérifier `document.cookie`)
   - [ ] Aucune IP, User-Agent brut ou coordonnées GPS dans les events Plausible (Plausible anonymise nativement)
   - [ ] Suppression de compte → trips et préférences purgés ; events Plausible historiques restent (anonymes par construction)
-  - [ ] Dismiss persistant de la bannière cookies (stocké localement, pas re-affiché à la session suivante)
   - [ ] Documentation Plausible dans `/privacy` mentionne : cloud/auto-hébergé, finalités, rétention, droits
 
 ---

--- a/docs/adr/adr-034-usage-analytics-plausible.md
+++ b/docs/adr/adr-034-usage-analytics-plausible.md
@@ -15,14 +15,14 @@ The replacement must:
 
 1. Collect page views and custom interaction events.
 2. Never store PII or use browser fingerprinting (RGPD / GDPR constraints are strict).
-3. Load only after explicit analytics consent (privacy-by-default), gated by the cookie banner, even though Plausible is cookieless and would not legally require it.
+3. Require no consent banner: Plausible is cookieless and stores no PII, so loading is gated solely on environment configuration (lawful basis: legitimate interest, RGPD art. 6(1)(f)).
 4. Integrate with the existing Docker Compose self-hosted deployment on Oracle Cloud + Coolify (ADR-019).
 5. Have zero recurring licence cost.
 
 ## Decision Drivers
 
 - **Data sovereignty:** user interaction data must not leave the self-hosted infrastructure.
-- **RGPD compliance by design:** no cookies, no browser fingerprint, anonymised IP and User-Agent. A consent banner is not legally required under RGPD recital 47 / ePrivacy Directive, but the project gates loading on explicit consent anyway (privacy-by-default, single consent UX).
+- **RGPD compliance by design:** no cookies, no browser fingerprint, anonymised IP and User-Agent. A consent banner is not legally required: ePrivacy art. 5(3) / art. 82 LIL is not triggered (nothing is stored on or read from the device), and the processing rests on legitimate interest (RGPD art. 6(1)(f)). Loading is therefore gated solely on environment configuration; no cookie banner is shown.
 - **Cost:** cloud SaaS plans add a recurring invoice to a project with a zero-budget ops model.
 - **Operational fit:** the deployment already runs Docker Compose on a single Oracle VM; a new Compose service is the natural unit of integration.
 - **Licence:** must be open source with a permissive enough licence for self-hosting (AGPL-3.0 is acceptable; it only requires source disclosure if the software itself is distributed, which self-hosting is not).
@@ -54,7 +54,7 @@ New Coolify service stack under `.docker/plausible/docker-compose.yml`:
 All three containers live on an isolated Docker network; only `plausible` is published.
 TLS terminated by the Coolify-managed Traefik (Let's Encrypt).
 
-The PWA injects the `plausible/analytics` script via a `<Script>` tag in the root layout, conditionally — only after the visitor has granted analytics consent (see Consent Gating Strategy below). The script is served from the same subdomain (`stats.biketrip.mooo.com/js/script.js`) to avoid ad-blocker false positives on common public Plausible CDN hostnames.
+The PWA injects the `plausible/analytics` script via a `<Script>` tag in the root layout, conditionally — only when the Plausible env vars are configured (see Loading Strategy below). The script is served from the same subdomain (`stats.biketrip.mooo.com/js/script.js`) to avoid ad-blocker false positives on common public Plausible CDN hostnames.
 
 ### RGPD / Privacy Posture
 
@@ -64,7 +64,7 @@ Plausible CE does not set any cookie and does not use browser fingerprinting. Th
 - **User-Agent:** parsed to `{browser}/{version}` and `{os}/{version}`; the full string is discarded.
 - Events carry no `userId`, no session ID, and no cross-visit identifier.
 
-Consequence: under RGPD, no cookie consent banner is legally required — Plausible's privacy model is explicitly designed for compliance without a consent mechanism ([their compliance page](https://plausible.io/data-policy)). The project nonetheless gates loading on explicit consent (see below) as a privacy-by-default posture and to expose a single, unified consent UX for any future trackers.
+Consequence: under RGPD, no cookie consent banner is legally required — Plausible's privacy model is explicitly designed for compliance without a consent mechanism ([their compliance page](https://plausible.io/data-policy)), and this aligns with the CNIL audience-measurement framework (anonymous statistics only, no cross-site tracking, EU self-hosted, disclosure in the privacy policy). Loading is therefore gated solely on environment configuration (see Loading Strategy below); a consent banner would contradict this posture and add needless friction. Users retain a documented right to object on the `/privacy` page.
 
 ### Custom Events
 
@@ -91,15 +91,17 @@ Beyond automatic pageview tracking, the following custom events are instrumented
 
 Events are fired via `plausible()` from the frontend using the Plausible custom event API. No backend instrumentation is needed; all events are browser-side.
 
-### Consent Gating Strategy
+### Loading Strategy
 
-Although Plausible requires no consent under RGPD, the project adopts a **privacy-by-default** posture: the script is **loaded conditionally, only after the visitor grants analytics consent**. This is implemented across the sprint as follows:
+Because Plausible requires no consent (cookieless, no PII — see above), the script is **loaded solely on environment configuration**, with no consent banner:
 
-- A bottom cookie banner + granularity modal (issue #385) records the decision in the `cookie-consent` localStorage key (`{ analytics: boolean }`); technical cookies are always-on, analytics is opt-in.
-- The `<Script>` tag (issue #552) reads that consent and only injects when `analytics === true` and the `NEXT_PUBLIC_PLAUSIBLE_DOMAIN` / `NEXT_PUBLIC_PLAUSIBLE_SRC` env vars are set. Before consent — or on "reject all" — no request is ever made to the Plausible host, and a previously injected script is unloaded on revocation.
+- The `<Script>` tag (issue #552) injects only when both `NEXT_PUBLIC_PLAUSIBLE_DOMAIN` and `NEXT_PUBLIC_PLAUSIBLE_SRC` are set. When they are unset, nothing is rendered and no request is ever made to the Plausible host.
 - Custom events (issue #553) are fired through a `trackEvent` helper that is a no-op when the script is absent, so they inherit the same gate.
+- Browser-level Do Not Track (DNT) is honoured natively client-side by Plausible.
 
-This also honours browser-level Do Not Track (DNT), which Plausible suppresses client-side natively. The single consent UX generalises to any future tracker should one be added.
+A cookie consent banner was initially scoped (issue #385) but dropped: it would gate a tool that legally needs no consent, contradict the privacy policy, and reduce data accuracy for no compliance benefit.
+
+**Beta posture (Sprint 34.5, issue #567):** the env-only gate also serves as the analytics kill-switch. During the restricted beta the env vars are left unset, so the analytics code ships but stays dormant (no requests). Reactivation is a deploy-time concern: set the two env vars once the Plausible service is provisioned.
 
 ## Alternatives Considered
 
@@ -149,7 +151,7 @@ Widely used, free SaaS, with powerful funnel and retention analysis.
 ### Positive
 
 - Zero recurring licence cost.
-- RGPD compliance by design: no cookies, no fingerprinting; a banner is not legally required, yet loading is gated on explicit consent for a privacy-by-default posture.
+- RGPD compliance by design: no cookies, no fingerprinting; no consent banner is required (legitimate interest), so loading is gated solely on environment configuration — no friction, no consent-decline data loss.
 - Data stays on our infrastructure; no third-party data processor in the chain.
 - Out-of-the-box dashboard with pageviews, referrers, countries, devices, custom events, funnels.
 - Custom event API is simple: one `plausible('event_name')` call per interaction.

--- a/docs/adr/adr-034-usage-analytics-plausible.md
+++ b/docs/adr/adr-034-usage-analytics-plausible.md
@@ -1,0 +1,173 @@
+# ADR-034: Usage Analytics — Plausible Community Edition Self-Hosted
+
+- **Status:** Accepted
+- **Date:** 2026-05-29
+- **Depends on:** ADR-019 (Production Hosting on Oracle Cloud + Coolify), ADR-022 (Persistent Storage Strategy)
+- **Related:** Sprint 34, Epic #370, Arbitrage #375 v3
+
+## Context and Problem Statement
+
+Bike Trip Planner needs aggregated, anonymous usage metrics to guide product decisions: which import sources are actually used, which features drive retention, and which entry points lead to trip creation. Without this data, prioritisation is driven by assumption rather than evidence.
+
+An earlier implementation plan (replaced by this ADR) considered a native `UsageEvent` partitioned PostgreSQL table with a custom aggregation layer. That approach was abandoned: it required significant bespoke development (schema, aggregation queries, retention, a read interface), duplicated problems that dedicated analytics tools already solve, and added ongoing maintenance surface to the API and Doctrine ORM layer.
+
+The replacement must:
+
+1. Collect page views and custom interaction events.
+2. Never store PII or use browser fingerprinting (RGPD / GDPR constraints are strict).
+3. Require no cookie consent banner (no cookies, no cross-site tracking).
+4. Integrate with the existing Docker Compose self-hosted deployment on Oracle Cloud + Coolify (ADR-019).
+5. Have zero recurring licence cost.
+
+## Decision Drivers
+
+- **Data sovereignty:** user interaction data must not leave the self-hosted infrastructure.
+- **RGPD compliance by design:** no cookies, no browser fingerprint, anonymised IP and User-Agent — no consent banner required under RGPD recital 47 / ePrivacy Directive.
+- **Cost:** cloud SaaS plans add a recurring invoice to a project with a zero-budget ops model.
+- **Operational fit:** the deployment already runs Docker Compose on a single Oracle VM; a new Compose service is the natural unit of integration.
+- **Licence:** must be open source with a permissive enough licence for self-hosting (AGPL-3.0 is acceptable; it only requires source disclosure if the software itself is distributed, which self-hosting is not).
+
+## Decision
+
+Adopt **Plausible Analytics Community Edition (CE)** running as a self-hosted Docker Compose service, deployed alongside the existing stack on the Coolify-managed Oracle VM.
+
+### Why Self-Hosted Instead of `plausible.io` Cloud
+
+| Dimension | Plausible Cloud | Plausible CE Self-Hosted |
+|---|---|---|
+| Data location | Plausible EU servers | Our own VM, our own PostgreSQL + ClickHouse |
+| Monthly cost | $9/mo (100k pageviews) | $0 (licence) + marginal VM resources |
+| RGPD data-processor agreement | Required (DPA with Plausible) | Not required (single-controller) |
+| Control over retention | Via dashboard setting | Full — `clickhouse` TTL configurable |
+| Upgrade cadence | Automatic | Manual (pinned image digest) |
+
+Self-hosting is the correct choice: data sovereignty, zero recurring cost, and no third-party data processor in the RGPD chain.
+
+### Topology
+
+New Coolify service stack under `.docker/plausible/docker-compose.yml`:
+
+- `plausible` — Elixir/Phoenix HTTP application (Traefik-exposed at `stats.biketrip.mooo.com`).
+- `plausible-db` — dedicated PostgreSQL instance (metadata, accounts, site config).
+- `plausible-events-db` — ClickHouse for event storage and aggregation.
+
+All three containers live on an isolated Docker network; only `plausible` is published.
+TLS terminated by the Coolify-managed Traefik (Let's Encrypt).
+
+The PWA injects the `plausible/analytics` script via a `<Script>` tag in the root layout. The script is served from the same subdomain (`stats.biketrip.mooo.com/js/script.js`) to avoid ad-blocker false positives on common public Plausible CDN hostnames.
+
+### RGPD / Privacy Posture
+
+Plausible CE does not set any cookie and does not use browser fingerprinting. The following anonymisations apply natively before any event is stored:
+
+- **IP address:** hashed with a daily rotating salt; the original IP is never persisted.
+- **User-Agent:** parsed to `{browser}/{version}` and `{os}/{version}`; the full string is discarded.
+- Events carry no `userId`, no session ID, and no cross-visit identifier.
+
+Consequence: no cookie consent banner is required. Plausible's privacy model is explicitly designed for RGPD compliance without a consent mechanism; this is documented in [their compliance page](https://plausible.io/data-policy).
+
+### Custom Events
+
+Beyond automatic pageview tracking, the following custom events are instrumented:
+
+**Import source events** (sent when a user successfully imports a route):
+
+| Event name | Description |
+|---|---|
+| `import_komoot` | Komoot tour or collection imported |
+| `import_strava` | Strava route imported |
+| `import_rwgps` | RideWithGPS route imported |
+| `import_gpx` | GPX file uploaded |
+
+**Feature and retention events** (sent on meaningful interactions):
+
+| Event name | Description |
+|---|---|
+| `trip_created` | A new trip is saved for the first time |
+| `trip_shared` | A trip share link is generated |
+| `accommodation_selected` | User saves an accommodation suggestion |
+| `alert_action_clicked` | User acts on an alert nudge (dismiss / resolve) |
+| `ai_chat_opened` | AI assistant chat panel is opened |
+
+Events are fired via `plausible()` from the frontend using the Plausible custom event API. No backend instrumentation is needed; all events are browser-side.
+
+### Consent Gating Strategy
+
+Because Plausible requires no consent under RGPD by design, the script is loaded unconditionally for all visitors. No consent banner or opt-in gate is displayed. If a visitor uses a browser-level Do Not Track (DNT) header, the Plausible script honours it natively (tracking is suppressed client-side).
+
+Should the project expand to jurisdictions with stricter requirements (e.g. Quebec Law 25, CCPA opt-out), a thin wrapper around `plausible()` can be introduced that checks a localStorage preference before firing events. This is a future concern; the current implementation is unconditional.
+
+## Alternatives Considered
+
+### Plausible Cloud (`plausible.io`)
+
+The simplest path: sign up, paste one script tag, and data appears in the dashboard within minutes. No ops burden.
+
+**Rejected because:**
+
+- Recurring cost ($9/mo minimum) contradicts the zero-budget ops model.
+- Data leaves our infrastructure; a RGPD data-processor agreement (DPA) is required.
+- At scale (100k+ pageviews), cost tiers up significantly.
+
+### Native `UsageEvent` Implementation (Abandoned)
+
+A custom Doctrine entity `UsageEvent` backed by a partitioned PostgreSQL table (partition by month), with a custom aggregation layer and an admin read interface.
+
+**Rejected (and previously abandoned) because:**
+
+- Significant bespoke development effort: schema, indexes, aggregation queries, a retention/pruning job, and a read interface (API endpoint or dashboard).
+- Duplicates problems Plausible already solves — deduplication, session window, funnel analysis, time-series charts.
+- Adds ongoing maintenance to the API and ORM layer for a concern orthogonal to trip planning.
+- PostgreSQL is a poor fit for high-cardinality append-only event streams (ClickHouse, which Plausible uses, is columnar and purpose-built for this workload).
+
+### Matomo (Self-Hosted)
+
+Open source (GPL-3.0), well-established, feature-rich analytics platform with an extensive plugin ecosystem.
+
+**Rejected because:**
+
+- Cookie-based by default; requires consent configuration and explicit RGPD plugin setup to reach cookie-free mode.
+- Heavier resource footprint than Plausible (PHP + MariaDB + a separate cron container).
+- Feature scope far exceeds what Bike Trip Planner needs; the complexity overhead is not justified.
+
+### Google Analytics 4 (GA4)
+
+Widely used, free SaaS, with powerful funnel and retention analysis.
+
+**Rejected because:**
+
+- Sends data to Google's servers; fundamentally incompatible with data sovereignty and RGPD compliance without a consent banner.
+- Cookie-based by default; a consent banner is legally required in EU.
+- Introduces a third-party dependency that ad-blockers routinely block, degrading data quality.
+
+## Consequences
+
+### Positive
+
+- Zero recurring licence cost.
+- RGPD compliance by design: no cookies, no fingerprinting, no consent banner needed.
+- Data stays on our infrastructure; no third-party data processor in the chain.
+- Out-of-the-box dashboard with pageviews, referrers, countries, devices, custom events, funnels.
+- Custom event API is simple: one `plausible('event_name')` call per interaction.
+
+### Negative
+
+- **Resource overhead:** Plausible CE requires PostgreSQL (metadata) + ClickHouse (events). ClickHouse is the dominant cost: ~1 GB RAM at idle, ~10 GB disk for the first year of data at moderate traffic. This adds to the Oracle VM's already-loaded memory budget (GlitchTip, Valhalla, Ollama, app stack).
+- **ClickHouse backup:** an additional backup target beyond the existing PostgreSQL dumps. ClickHouse supports `BACKUP TO S3` or filesystem snapshots; this must be added to the ops runbook.
+- **DNS / TLS:** a new subdomain (`stats.biketrip.mooo.com`) must be provisioned and pointed to the Oracle VM. Let's Encrypt certificate managed by Traefik as with other services.
+- **Upgrade cadence:** Plausible CE releases must be tracked manually (no automatic updates); pinned image tags should be updated via Dependabot or a periodic review.
+- **Native `UsageEvent` implementation abandoned:** any future need for server-side event correlation (e.g. linking an analytics event to a specific trip computation) requires a separate mechanism, as Plausible events carry no application-level IDs.
+
+### Neutral
+
+- The Plausible CE licence (AGPL-3.0) applies to the Plausible source code itself; self-hosting does not trigger the AGPL copyleft clause (the software is not distributed). No impact on Bike Trip Planner's own MIT licence.
+- The `plausible/analytics` JavaScript snippet is ~1 kB (gzipped); negligible impact on PWA bundle size and Lighthouse performance score.
+
+## References
+
+- [Plausible CE self-hosting documentation](https://plausible.io/docs/self-hosting)
+- [Plausible RGPD compliance](https://plausible.io/data-policy)
+- [Plausible custom events API](https://plausible.io/docs/custom-event-goals)
+- [ADR-019: Deployment Infrastructure Strategy](adr-019-deployment-infrastructure-strategy.md)
+- [ADR-022: Persistent Storage Strategy](adr-022-persistent-storage-strategy.md)
+- [ADR-031: Error Tracking Strategy (GlitchTip)](adr-031-error-tracking-strategy.md)

--- a/docs/adr/adr-034-usage-analytics-plausible.md
+++ b/docs/adr/adr-034-usage-analytics-plausible.md
@@ -15,14 +15,14 @@ The replacement must:
 
 1. Collect page views and custom interaction events.
 2. Never store PII or use browser fingerprinting (RGPD / GDPR constraints are strict).
-3. Require no cookie consent banner (no cookies, no cross-site tracking).
+3. Load only after explicit analytics consent (privacy-by-default), gated by the cookie banner, even though Plausible is cookieless and would not legally require it.
 4. Integrate with the existing Docker Compose self-hosted deployment on Oracle Cloud + Coolify (ADR-019).
 5. Have zero recurring licence cost.
 
 ## Decision Drivers
 
 - **Data sovereignty:** user interaction data must not leave the self-hosted infrastructure.
-- **RGPD compliance by design:** no cookies, no browser fingerprint, anonymised IP and User-Agent — no consent banner required under RGPD recital 47 / ePrivacy Directive.
+- **RGPD compliance by design:** no cookies, no browser fingerprint, anonymised IP and User-Agent. A consent banner is not legally required under RGPD recital 47 / ePrivacy Directive, but the project gates loading on explicit consent anyway (privacy-by-default, single consent UX).
 - **Cost:** cloud SaaS plans add a recurring invoice to a project with a zero-budget ops model.
 - **Operational fit:** the deployment already runs Docker Compose on a single Oracle VM; a new Compose service is the natural unit of integration.
 - **Licence:** must be open source with a permissive enough licence for self-hosting (AGPL-3.0 is acceptable; it only requires source disclosure if the software itself is distributed, which self-hosting is not).
@@ -54,7 +54,7 @@ New Coolify service stack under `.docker/plausible/docker-compose.yml`:
 All three containers live on an isolated Docker network; only `plausible` is published.
 TLS terminated by the Coolify-managed Traefik (Let's Encrypt).
 
-The PWA injects the `plausible/analytics` script via a `<Script>` tag in the root layout. The script is served from the same subdomain (`stats.biketrip.mooo.com/js/script.js`) to avoid ad-blocker false positives on common public Plausible CDN hostnames.
+The PWA injects the `plausible/analytics` script via a `<Script>` tag in the root layout, conditionally — only after the visitor has granted analytics consent (see Consent Gating Strategy below). The script is served from the same subdomain (`stats.biketrip.mooo.com/js/script.js`) to avoid ad-blocker false positives on common public Plausible CDN hostnames.
 
 ### RGPD / Privacy Posture
 
@@ -64,7 +64,7 @@ Plausible CE does not set any cookie and does not use browser fingerprinting. Th
 - **User-Agent:** parsed to `{browser}/{version}` and `{os}/{version}`; the full string is discarded.
 - Events carry no `userId`, no session ID, and no cross-visit identifier.
 
-Consequence: no cookie consent banner is required. Plausible's privacy model is explicitly designed for RGPD compliance without a consent mechanism; this is documented in [their compliance page](https://plausible.io/data-policy).
+Consequence: under RGPD, no cookie consent banner is legally required — Plausible's privacy model is explicitly designed for compliance without a consent mechanism ([their compliance page](https://plausible.io/data-policy)). The project nonetheless gates loading on explicit consent (see below) as a privacy-by-default posture and to expose a single, unified consent UX for any future trackers.
 
 ### Custom Events
 
@@ -93,9 +93,13 @@ Events are fired via `plausible()` from the frontend using the Plausible custom 
 
 ### Consent Gating Strategy
 
-Because Plausible requires no consent under RGPD by design, the script is loaded unconditionally for all visitors. No consent banner or opt-in gate is displayed. If a visitor uses a browser-level Do Not Track (DNT) header, the Plausible script honours it natively (tracking is suppressed client-side).
+Although Plausible requires no consent under RGPD, the project adopts a **privacy-by-default** posture: the script is **loaded conditionally, only after the visitor grants analytics consent**. This is implemented across the sprint as follows:
 
-Should the project expand to jurisdictions with stricter requirements (e.g. Quebec Law 25, CCPA opt-out), a thin wrapper around `plausible()` can be introduced that checks a localStorage preference before firing events. This is a future concern; the current implementation is unconditional.
+- A bottom cookie banner + granularity modal (issue #385) records the decision in the `cookie-consent` localStorage key (`{ analytics: boolean }`); technical cookies are always-on, analytics is opt-in.
+- The `<Script>` tag (issue #552) reads that consent and only injects when `analytics === true` and the `NEXT_PUBLIC_PLAUSIBLE_DOMAIN` / `NEXT_PUBLIC_PLAUSIBLE_SRC` env vars are set. Before consent — or on "reject all" — no request is ever made to the Plausible host, and a previously injected script is unloaded on revocation.
+- Custom events (issue #553) are fired through a `trackEvent` helper that is a no-op when the script is absent, so they inherit the same gate.
+
+This also honours browser-level Do Not Track (DNT), which Plausible suppresses client-side natively. The single consent UX generalises to any future tracker should one be added.
 
 ## Alternatives Considered
 
@@ -145,7 +149,7 @@ Widely used, free SaaS, with powerful funnel and retention analysis.
 ### Positive
 
 - Zero recurring licence cost.
-- RGPD compliance by design: no cookies, no fingerprinting, no consent banner needed.
+- RGPD compliance by design: no cookies, no fingerprinting; a banner is not legally required, yet loading is gated on explicit consent for a privacy-by-default posture.
 - Data stays on our infrastructure; no third-party data processor in the chain.
 - Out-of-the-box dashboard with pageviews, referrers, countries, devices, custom events, funnels.
 - Custom event API is simple: one `plausible('event_name')` call per interaction.


### PR DESCRIPTION
## Contexte

Sprint 34. Documente la décision d'adopter **Plausible Analytics auto-hébergé** (Community Edition, AGPL-3.0) pour la collecte de métriques d'usage agrégées et anonymes, en remplacement de l'implémentation native (UsageEvent) abandonnée (#375 v3).

Closes #548.

## Changements

- `docs/adr/adr-034-usage-analytics-plausible.md` : décision (self-hosted vs cloud), justification RGPD (no cookie, IP/UA anonymisés, events non liés à l'user), custom events prévus, topologie Docker (Postgres + ClickHouse), conséquences, alternatives écartées (cloud, native, Matomo, GA4).
- `README.md` : "33 ADRs" → "34 ADRs".

## Auto-critique

- ADR numéroté **034** (et non "029 mise à jour" comme indiqué par erreur dans TRACKING : 029 = early-access).
- Doc uniquement, aucun impact runtime. `make qa-doc` / markdownlint verts.

<!-- claude-review-start -->
## Claude Review

**0 findings** — Commit `2b7fae9`

The ADR is thorough and well-structured. The legal reasoning (RGPD art. 6(1)(f), ePrivacy art. 5(3), CNIL anonymous-statistics framework) is sound. The env-only loading strategy and the dropped consent banner are clearly justified. `TRACKING.md` now fully aligns with the ADR's final posture (items 5 and 10 updated, DoD replaced with env-based checks).

**Resolved threads:** Resolved 1 previously open thread that was addressed by commit 4 (`2b7fae9` — TRACKING.md realigned to env-only, no consent banner).

### Review Checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases *(N/A — documentation only)*
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Inline Comments

No inline comments.

---
*Generated with [Claude Code](https://claude.ai/code)*
<!-- claude-review-end -->