### PR TITLE
feat(rgpd): add user account deletion and data export endpoints

### DIFF
--- a/api/migrations/Version20260529120000.php
+++ b/api/migrations/Version20260529120000.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Adds the `deleted_at` column to `user` for GDPR account anonymisation (#549).
+ *
+ * The right-to-erasure flow soft-deletes the account by stamping `deleted_at`
+ * and anonymising the email, while purging trips and revoking refresh tokens.
+ */
+final class Version20260529120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add deleted_at column to user for GDPR account anonymisation (#549)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            ALTER TABLE "user" ADD deleted_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL
+            SQL);
+        $this->addSql(<<<'SQL'
+            COMMENT ON COLUMN "user".deleted_at IS '(DC2Type:datetime_immutable)'
+            SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            ALTER TABLE "user" DROP deleted_at
+            SQL);
+    }
+}

--- a/api/src/ApiResource/Account/Account.php
+++ b/api/src/ApiResource/Account/Account.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ApiResource\Account;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Delete;
+use ApiPlatform\Metadata\Get;
+use App\State\Account\AccountDeleteProcessor;
+use App\State\Account\AccountExportProvider;
+
+/**
+ * GDPR self-service operations for the authenticated user (#549).
+ *
+ * - DELETE /users/me        right to erasure: anonymise the account, purge
+ *   trips and preferences, revoke refresh tokens
+ * - GET    /users/me/export right to portability: download a JSON archive of
+ *   the profile, trips and their preferences
+ *
+ * The current user is always resolved from the security token, never from a
+ * URL identifier, so there is no IDOR surface.
+ */
+#[ApiResource(
+    shortName: 'Account',
+    operations: [
+        new Delete(
+            uriTemplate: '/users/me',
+            status: 204,
+            security: "is_granted('ROLE_USER')",
+            output: false,
+            read: false,
+            processor: AccountDeleteProcessor::class,
+        ),
+        new Get(
+            uriTemplate: '/users/me/export',
+            security: "is_granted('ROLE_USER')",
+            provider: AccountExportProvider::class,
+        ),
+    ],
+)]
+final class Account
+{
+}

--- a/api/src/Entity/User.php
+++ b/api/src/Entity/User.php
@@ -27,6 +27,9 @@ class User implements UserInterface
     #[ORM\Column]
     private \DateTimeImmutable $createdAt;
 
+    #[ORM\Column(nullable: true)]
+    private ?\DateTimeImmutable $deletedAt = null;
+
     #[ORM\Column(length: 5, options: ['default' => 'fr'])]
     private string $locale = 'fr';
 
@@ -82,6 +85,29 @@ class User implements UserInterface
     public function getCreatedAt(): \DateTimeImmutable
     {
         return $this->createdAt;
+    }
+
+    public function getDeletedAt(): ?\DateTimeImmutable
+    {
+        return $this->deletedAt;
+    }
+
+    public function isDeleted(): bool
+    {
+        return $this->deletedAt instanceof \DateTimeImmutable;
+    }
+
+    /**
+     * Irreversibly anonymises the account: soft-deletes it and replaces the
+     * email PII with a non-resolvable placeholder. The roles are dropped so a
+     * lingering JWT no longer grants elevated access.
+     */
+    public function anonymize(): void
+    {
+        $this->deletedAt = new \DateTimeImmutable();
+        $this->email = \sprintf('deleted-%s@deleted.invalid', $this->id->toRfc4122());
+        $this->roles = [];
+        $this->locale = 'fr';
     }
 
     public function getLocale(): string

--- a/api/src/State/Account/AccountDeleteProcessor.php
+++ b/api/src/State/Account/AccountDeleteProcessor.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\State\Account;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\ApiResource\Account\Account;
+use App\ApiResource\TripRequest;
+use App\Entity\User;
+use App\Repository\RefreshTokenRepository;
+use App\Security\AuthCookies;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * GDPR right to erasure: anonymises the current user's account.
+ *
+ * Soft-deletes the account (stamps deletedAt), irreversibly anonymises the
+ * email to break the PII link, purges every trip (and, via cascade, their
+ * stages/preferences), and revokes all refresh tokens. The trips carry the
+ * per-trip preferences (pacing, accommodation types…), so removing them also
+ * erases those preferences.
+ *
+ * @implements ProcessorInterface<Account, Response>
+ */
+final readonly class AccountDeleteProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private RefreshTokenRepository $refreshTokenRepository,
+        private Security $security,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @param Account $data
+     */
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): JsonResponse
+    {
+        $user = $this->security->getUser();
+
+        \assert($user instanceof User);
+
+        $this->entityManager->wrapInTransaction(function () use ($user): void {
+            // Purge trips (cascades to stages, chat messages and shares via FK
+            // ON DELETE CASCADE) which also removes the per-trip preferences.
+            $this->entityManager->createQueryBuilder()
+                ->delete(TripRequest::class, 't')
+                ->where('t.user = :user')
+                ->setParameter('user', $user)
+                ->getQuery()
+                ->execute();
+
+            // Revoke every refresh token so lingering sessions cannot be reused.
+            $this->refreshTokenRepository->removeAllForUser($user);
+
+            // Soft-delete + irreversible PII anonymisation.
+            $user->anonymize();
+        });
+
+        $this->logger->info('Account deleted (GDPR erasure)', ['user' => $user->getId()->toRfc4122()]);
+
+        $response = new JsonResponse(null, Response::HTTP_NO_CONTENT);
+        $response->headers->clearCookie(AuthCookies::REFRESH_TOKEN, '/', null, true, true, 'strict');
+
+        return $response;
+    }
+}

--- a/api/src/State/Account/AccountExportProvider.php
+++ b/api/src/State/Account/AccountExportProvider.php
@@ -46,8 +46,10 @@ final readonly class AccountExportProvider implements ProviderInterface
             ->getQuery()
             ->getResult();
 
+        $now = new \DateTimeImmutable();
+
         $data = [
-            'exportedAt' => new \DateTimeImmutable()->format(\DateTimeInterface::ATOM),
+            'exportedAt' => $now->format(\DateTimeInterface::ATOM),
             'profile' => [
                 'id' => $user->getId()->toRfc4122(),
                 'email' => $user->getEmail(),
@@ -63,7 +65,7 @@ final readonly class AccountExportProvider implements ProviderInterface
             'Content-Disposition',
             $response->headers->makeDisposition(
                 ResponseHeaderBag::DISPOSITION_ATTACHMENT,
-                \sprintf('bike-trip-planner-export-%s.json', new \DateTimeImmutable()->format('Y-m-d')),
+                \sprintf('bike-trip-planner-export-%s.json', $now->format('Y-m-d')),
             ),
         );
 

--- a/api/src/State/Account/AccountExportProvider.php
+++ b/api/src/State/Account/AccountExportProvider.php
@@ -37,8 +37,9 @@ final readonly class AccountExportProvider implements ProviderInterface
 
         /** @var list<TripRequest> $trips */
         $trips = $this->entityManager->createQueryBuilder()
-            ->select('t')
+            ->select('t', 's')
             ->from(TripRequest::class, 't')
+            ->leftJoin('t.stages', 's')
             ->where('t.user = :user')
             ->setParameter('user', $user)
             ->orderBy('t.createdAt', 'ASC')

--- a/api/src/State/Account/AccountExportProvider.php
+++ b/api/src/State/Account/AccountExportProvider.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\State\Account;
+
+use Symfony\Component\Uid\Uuid;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProviderInterface;
+use App\ApiResource\TripRequest;
+use App\Entity\Stage;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+
+/**
+ * GDPR right to portability: exports the current user's data as a downloadable
+ * JSON archive (profile + trips + their preferences).
+ *
+ * @implements ProviderInterface<JsonResponse>
+ */
+final readonly class AccountExportProvider implements ProviderInterface
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private Security $security,
+    ) {
+    }
+
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): JsonResponse
+    {
+        $user = $this->security->getUser();
+
+        \assert($user instanceof User);
+
+        /** @var list<TripRequest> $trips */
+        $trips = $this->entityManager->createQueryBuilder()
+            ->select('t')
+            ->from(TripRequest::class, 't')
+            ->where('t.user = :user')
+            ->setParameter('user', $user)
+            ->orderBy('t.createdAt', 'ASC')
+            ->getQuery()
+            ->getResult();
+
+        $data = [
+            'exportedAt' => new \DateTimeImmutable()->format(\DateTimeInterface::ATOM),
+            'profile' => [
+                'id' => $user->getId()->toRfc4122(),
+                'email' => $user->getEmail(),
+                'locale' => $user->getLocale(),
+                'roles' => $user->getRoles(),
+                'createdAt' => $user->getCreatedAt()->format(\DateTimeInterface::ATOM),
+            ],
+            'trips' => array_map($this->exportTrip(...), $trips),
+        ];
+
+        $response = new JsonResponse($data);
+        $response->headers->set(
+            'Content-Disposition',
+            $response->headers->makeDisposition(
+                ResponseHeaderBag::DISPOSITION_ATTACHMENT,
+                \sprintf('bike-trip-planner-export-%s.json', new \DateTimeImmutable()->format('Y-m-d')),
+            ),
+        );
+
+        return $response;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function exportTrip(TripRequest $trip): array
+    {
+        \assert($trip->id instanceof Uuid);
+
+        return [
+            'id' => $trip->id->toRfc4122(),
+            'title' => $trip->title,
+            'sourceUrl' => $trip->sourceUrl,
+            'sourceType' => $trip->sourceType,
+            'startDate' => $trip->startDate?->format('Y-m-d'),
+            'endDate' => $trip->endDate?->format('Y-m-d'),
+            'locale' => $trip->locale,
+            'createdAt' => $trip->createdAt->format(\DateTimeInterface::ATOM),
+            'updatedAt' => $trip->updatedAt->format(\DateTimeInterface::ATOM),
+            'preferences' => [
+                'fatigueFactor' => $trip->fatigueFactor,
+                'elevationPenalty' => $trip->elevationPenalty,
+                'ebikeMode' => $trip->ebikeMode,
+                'departureHour' => $trip->departureHour,
+                'maxDistancePerDay' => $trip->maxDistancePerDay,
+                'averageSpeed' => $trip->averageSpeed,
+                'enabledAccommodationTypes' => $trip->enabledAccommodationTypes,
+            ],
+            'stages' => array_map($this->exportStage(...), $trip->stages->toArray()),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function exportStage(Stage $stage): array
+    {
+        return [
+            'dayNumber' => $stage->getDayNumber(),
+            'label' => $stage->getLabel(),
+            'distance' => $stage->getDistance(),
+            'elevation' => $stage->getElevation(),
+        ];
+    }
+}

--- a/api/tests/Functional/Account/AccountDeleteTest.php
+++ b/api/tests/Functional/Account/AccountDeleteTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Account;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\ApiResource\TripRequest;
+use App\Entity\RefreshToken;
+use App\Entity\User;
+use App\Repository\RefreshTokenRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Uid\Uuid;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+use Zenstruck\Foundry\Test\Factories;
+
+#[ResetDatabase]
+final class AccountDeleteTest extends ApiTestCase
+{
+    use Factories;
+
+    #[\Override]
+    public static function setUpBeforeClass(): void
+    {
+        self::$alwaysBootKernel = false;
+    }
+
+    private function getEntityManager(): EntityManagerInterface
+    {
+        return self::getContainer()->get('doctrine.orm.entity_manager');
+    }
+
+    /**
+     * @param non-empty-string $email
+     *
+     * @return array{user: User, jwt: string, refreshToken: RefreshToken, tripId: string}
+     */
+    private function createUserWithTrip(string $email): array
+    {
+        $em = $this->getEntityManager();
+
+        $user = new User($email);
+        $em->persist($user);
+
+        $refreshToken = new RefreshToken(
+            $user,
+            bin2hex(random_bytes(32)),
+            new \DateTimeImmutable('+30 days'),
+        );
+        $em->persist($refreshToken);
+
+        $tripId = Uuid::v7();
+        $trip = new TripRequest($tripId);
+        $trip->user = $user;
+        $trip->fatigueFactor = 0.8;
+
+        $em->persist($trip);
+
+        $em->flush();
+
+        /** @var JWTTokenManagerInterface $jwtManager */
+        $jwtManager = self::getContainer()->get('lexik_jwt_authentication.jwt_manager');
+        $jwt = $jwtManager->create($user);
+
+        return ['user' => $user, 'jwt' => $jwt, 'refreshToken' => $refreshToken, 'tripId' => $tripId->toRfc4122()];
+    }
+
+    #[Test]
+    public function deleteAccountReturns204(): void
+    {
+        $fixtures = $this->createUserWithTrip('erase@example.com');
+
+        self::createClient()->request('DELETE', '/users/me', [
+            'headers' => ['Authorization' => 'Bearer '.$fixtures['jwt']],
+        ]);
+
+        $this->assertResponseStatusCodeSame(204);
+    }
+
+    #[Test]
+    public function deleteAccountAnonymizesEmailAndSoftDeletes(): void
+    {
+        $fixtures = $this->createUserWithTrip('anonymize@example.com');
+        $userId = $fixtures['user']->getId()->toRfc4122();
+
+        self::createClient()->request('DELETE', '/users/me', [
+            'headers' => ['Authorization' => 'Bearer '.$fixtures['jwt']],
+        ]);
+        $this->assertResponseStatusCodeSame(204);
+
+        $em = $this->getEntityManager();
+        $em->clear();
+
+        $user = $em->find(User::class, Uuid::fromString($userId));
+
+        $this->assertInstanceOf(User::class, $user);
+        $this->assertTrue($user->isDeleted());
+        $this->assertNotSame('anonymize@example.com', $user->getEmail());
+        $this->assertStringEndsWith('@deleted.invalid', $user->getEmail());
+    }
+
+    #[Test]
+    public function deleteAccountPurgesTripsAndPreferences(): void
+    {
+        $fixtures = $this->createUserWithTrip('purge@example.com');
+        $tripId = $fixtures['tripId'];
+
+        self::createClient()->request('DELETE', '/users/me', [
+            'headers' => ['Authorization' => 'Bearer '.$fixtures['jwt']],
+        ]);
+        $this->assertResponseStatusCodeSame(204);
+
+        $em = $this->getEntityManager();
+        $em->clear();
+
+        $this->assertNull($em->find(TripRequest::class, Uuid::fromString($tripId)));
+    }
+
+    #[Test]
+    public function deleteAccountRevokesRefreshTokens(): void
+    {
+        $fixtures = $this->createUserWithTrip('revoke@example.com');
+        $userId = $fixtures['user']->getId()->toRfc4122();
+
+        self::createClient()->request('DELETE', '/users/me', [
+            'headers' => ['Authorization' => 'Bearer '.$fixtures['jwt']],
+        ]);
+        $this->assertResponseStatusCodeSame(204);
+
+        /** @var RefreshTokenRepository $repo */
+        $repo = self::getContainer()->get(RefreshTokenRepository::class);
+        $em = $this->getEntityManager();
+        $em->clear();
+
+        $user = $em->find(User::class, Uuid::fromString($userId));
+        \assert($user instanceof User);
+
+        $this->assertCount(0, $repo->findBy(['user' => $user]));
+    }
+
+    #[Test]
+    public function deleteAccountWithoutAuthenticationReturns401(): void
+    {
+        self::createClient()->request('DELETE', '/users/me');
+
+        $this->assertResponseStatusCodeSame(401);
+    }
+}

--- a/api/tests/Functional/Account/AccountDeleteTest.php
+++ b/api/tests/Functional/Account/AccountDeleteTest.php
@@ -141,6 +141,22 @@ final class AccountDeleteTest extends ApiTestCase
     }
 
     #[Test]
+    public function deleteAccountClearsRefreshTokenCookie(): void
+    {
+        $fixtures = $this->createUserWithTrip('cookie@example.com');
+
+        $response = self::createClient()->request('DELETE', '/users/me', [
+            'headers' => ['Authorization' => 'Bearer '.$fixtures['jwt']],
+        ]);
+        $this->assertResponseStatusCodeSame(204);
+
+        $setCookie = $response->getHeaders(false)['set-cookie'][0] ?? '';
+        $this->assertStringContainsString('refresh_token=', $setCookie);
+        // Cookie must be cleared: Symfony stamps a past expiry and Max-Age=0.
+        $this->assertMatchesRegularExpression('/Max-Age=0|expires=Thu, 01-Jan-1970/i', $setCookie);
+    }
+
+    #[Test]
     public function deleteAccountWithoutAuthenticationReturns401(): void
     {
         self::createClient()->request('DELETE', '/users/me');

--- a/api/tests/Functional/Account/AccountExportTest.php
+++ b/api/tests/Functional/Account/AccountExportTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Functional\Account;
 
 use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
 use App\ApiResource\TripRequest;
+use App\Entity\Stage;
 use App\Entity\User;
 use Doctrine\ORM\EntityManagerInterface;
 use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
@@ -53,6 +54,21 @@ final class AccountExportTest extends ApiTestCase
 
         $em->persist($trip);
 
+        $stage = new Stage($trip);
+        $stage->setPosition(0);
+        $stage->setDayNumber(1);
+        $stage->setLabel('Day 1');
+        $stage->setDistance(65.0);
+        $stage->setElevation(800.0);
+        $stage->setStartLat(48.8566);
+        $stage->setStartLon(2.3522);
+        $stage->setEndLat(48.85);
+        $stage->setEndLon(2.36);
+
+        $trip->addStage($stage);
+
+        $em->persist($stage);
+
         $em->flush();
 
         /** @var JWTTokenManagerInterface $jwtManager */
@@ -86,6 +102,13 @@ final class AccountExportTest extends ApiTestCase
         $this->assertSame(0.85, $trip['preferences']['fatigueFactor']);
         $this->assertEqualsWithDelta(70.0, $trip['preferences']['maxDistancePerDay'], 0.001);
         $this->assertArrayHasKey('enabledAccommodationTypes', $trip['preferences']);
+
+        $this->assertCount(1, $trip['stages']);
+        $stage = $trip['stages'][0];
+        $this->assertSame(1, $stage['dayNumber']);
+        $this->assertSame('Day 1', $stage['label']);
+        $this->assertEqualsWithDelta(65.0, $stage['distance'], 0.001);
+        $this->assertEqualsWithDelta(800.0, $stage['elevation'], 0.001);
     }
 
     #[Test]

--- a/api/tests/Functional/Account/AccountExportTest.php
+++ b/api/tests/Functional/Account/AccountExportTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Account;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\ApiResource\TripRequest;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Uid\Uuid;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+use Zenstruck\Foundry\Test\Factories;
+
+#[ResetDatabase]
+final class AccountExportTest extends ApiTestCase
+{
+    use Factories;
+
+    #[\Override]
+    public static function setUpBeforeClass(): void
+    {
+        self::$alwaysBootKernel = false;
+    }
+
+    private function getEntityManager(): EntityManagerInterface
+    {
+        return self::getContainer()->get('doctrine.orm.entity_manager');
+    }
+
+    /**
+     * @param non-empty-string $email
+     *
+     * @return array{user: User, jwt: string}
+     */
+    private function createUserWithTrip(string $email): array
+    {
+        $em = $this->getEntityManager();
+
+        $user = new User($email);
+        $user->setLocale('en');
+
+        $em->persist($user);
+
+        $trip = new TripRequest(Uuid::v7());
+        $trip->user = $user;
+        $trip->title = 'My Bikepacking Trip';
+        $trip->sourceUrl = 'https://www.komoot.com/tour/123456789';
+        $trip->fatigueFactor = 0.85;
+        $trip->maxDistancePerDay = 70.0;
+
+        $em->persist($trip);
+
+        $em->flush();
+
+        /** @var JWTTokenManagerInterface $jwtManager */
+        $jwtManager = self::getContainer()->get('lexik_jwt_authentication.jwt_manager');
+        $jwt = $jwtManager->create($user);
+
+        return ['user' => $user, 'jwt' => $jwt];
+    }
+
+    #[Test]
+    public function exportReturnsProfileTripsAndPreferences(): void
+    {
+        $fixtures = $this->createUserWithTrip('export@example.com');
+
+        $response = self::createClient()->request('GET', '/users/me/export', [
+            'headers' => ['Authorization' => 'Bearer '.$fixtures['jwt']],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+
+        $data = $response->toArray();
+
+        $this->assertSame('export@example.com', $data['profile']['email']);
+        $this->assertSame('en', $data['profile']['locale']);
+        $this->assertArrayHasKey('createdAt', $data['profile']);
+
+        $this->assertCount(1, $data['trips']);
+        $trip = $data['trips'][0];
+        $this->assertSame('My Bikepacking Trip', $trip['title']);
+        $this->assertSame('https://www.komoot.com/tour/123456789', $trip['sourceUrl']);
+        $this->assertSame(0.85, $trip['preferences']['fatigueFactor']);
+        $this->assertEqualsWithDelta(70.0, $trip['preferences']['maxDistancePerDay'], 0.001);
+        $this->assertArrayHasKey('enabledAccommodationTypes', $trip['preferences']);
+    }
+
+    #[Test]
+    public function exportIsADownloadableAttachment(): void
+    {
+        $fixtures = $this->createUserWithTrip('download@example.com');
+
+        $response = self::createClient()->request('GET', '/users/me/export', [
+            'headers' => ['Authorization' => 'Bearer '.$fixtures['jwt']],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $disposition = $response->getHeaders()['content-disposition'][0] ?? '';
+        $this->assertStringContainsString('attachment', $disposition);
+        $this->assertStringContainsString('.json', $disposition);
+    }
+
+    #[Test]
+    public function exportWithoutAuthenticationReturns401(): void
+    {
+        self::createClient()->request('GET', '/users/me/export');
+
+        $this->assertResponseStatusCodeSame(401);
+    }
+}


### PR DESCRIPTION
## Contexte

Sprint 34 — prérequis RGPD du parcours compte. Implémente le droit à l'effacement et le droit à la portabilité côté backend.

Closes #549.

## Changements

- `User` : champ `deletedAt` + `anonymize()` (soft-delete + anonymisation irréversible de l'email) + migration `Version20260529120000`.
- Nouvelle ApiResource `Account` (sécurisée `ROLE_USER`, utilisateur courant via `Security`, pas d'IDOR) :
  - `DELETE /users/me` → `AccountDeleteProcessor` : purge trips (cascade FK), révoque les refresh tokens (réutilise `RefreshTokenRepository::removeAllForUser`), anonymise, transaction, efface le cookie refresh.
  - `GET /users/me/export` → `AccountExportProvider` : JSON téléchargeable (profil + trips + préférences + résumé étapes).
- Tests fonctionnels `api/tests/Functional/Account/` (8 tests, 25 assertions).

## Auto-critique

- Export et suppression regroupés dans une feature RGPD unique (même périmètre de données).
- Anonymisation **irréversible** de l'email (`deleted-<uuid>@deleted.invalid`) pour casser le PII ; events Plausible non concernés (anonymes par construction).
- `make qa` (PHPStan L9) + PHPUnit Account verts localement.

<!-- claude-review-start -->
## Claude Review

All previously flagged findings have been resolved across commits `bd528580` and `e4577149`: the N+1 eager-join, the missing `Stage` fixture, the double `DateTimeImmutable` (confirmed fixed in current code), and the missing cookie-clearing test. No new findings on the final commit.

**Findings: 0**

### Resolved threads

Resolved 2 previously open threads addressed by commit `e4577149`.

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Inline comments

No inline comments.

---

_Generated with [Claude Code](https://claude.ai/code) · Reviewed commit `e457714907652dca4fa26bba52a722a5ac0303e2`_
<!-- claude-review-end -->