### PR TITLE
feat(pwa): add privacy and legal pages content with sticky toc

### DIFF
--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -985,12 +985,121 @@
   },
   "legal": {
     "title": "Legal notice",
-    "comingSoon": "This page will be available soon.",
-    "backToHome": "Back to home"
+    "intro": "Legal information about the publisher and host of Bike Trip Planner.",
+    "lastUpdated": "Last updated: 29 May 2026",
+    "tocLabel": "Contents",
+    "backToHome": "Back to home",
+    "sections": {
+      "publisher": {
+        "title": "Publisher",
+        "paragraphs": [
+          "Bike Trip Planner is an open-source project published by Vincent Chalamon.",
+          "The source code is available on GitHub under an open-source license: https://github.com/vincentchalamon/bike-trip-planner",
+          "Publication director: Vincent Chalamon."
+        ]
+      },
+      "host": {
+        "title": "Host",
+        "paragraphs": [
+          "The application is hosted on cloud infrastructure located within the European Union.",
+          "The exact details of the host can be provided on request at the contact address below."
+        ]
+      },
+      "contact": {
+        "title": "Contact",
+        "paragraphs": [
+          "For any question about the site or to exercise your rights, contact us at: contact@bike-trip-planner.example.",
+          "You can also open an issue on the project's GitHub repository."
+        ]
+      },
+      "intellectualProperty": {
+        "title": "Intellectual property",
+        "paragraphs": [
+          "The Bike Trip Planner source code is distributed under an open-source license; the usage and redistribution terms are available in the GitHub repository.",
+          "Route and mapping data come from third-party sources (OpenStreetMap, DataTourisme, Wikidata, data.gouv.fr) and remain subject to their respective licenses, credited within the application.",
+          "Third-party trademarks, logos and content (Komoot, Strava, RideWithGPS, Garmin, Wahoo) remain the property of their respective owners."
+        ]
+      }
+    }
   },
   "privacy": {
     "title": "Privacy policy",
-    "comingSoon": "This page will be available soon.",
-    "backToHome": "Back to home"
+    "intro": "How Bike Trip Planner collects, uses and protects your personal data, in accordance with the GDPR.",
+    "lastUpdated": "Last updated: 29 May 2026",
+    "tocLabel": "Contents",
+    "backToHome": "Back to home",
+    "sections": {
+      "controller": {
+        "title": "Data controller",
+        "paragraphs": [
+          "The data controller is the publisher of Bike Trip Planner (see the legal notice).",
+          "For any question about your personal data, contact us at: contact@bike-trip-planner.example."
+        ]
+      },
+      "basis": {
+        "title": "Legal basis",
+        "paragraphs": [
+          "Processing of your email address is based on the performance of the service you request (magic-link sign-in and account management), under Article 6(1)(b) GDPR.",
+          "Anonymous audience measurement is based on our legitimate interest in improving the service, without prejudice to your rights and freedoms (Article 6(1)(f) GDPR)."
+        ]
+      },
+      "purposes": {
+        "title": "Purposes",
+        "paragraphs": [
+          "Your data is used to authenticate you, save and restore your trips, and compute route analyses (pacing, alerts, accommodation, weather).",
+          "Anonymous audience measurement is used solely to understand overall usage of the service and improve its usability."
+        ]
+      },
+      "data": {
+        "title": "Data collected",
+        "paragraphs": [
+          "Account: your email address, required for magic-link sign-in.",
+          "Trips: your trip configuration (title, dates, rider profile, stages, selected accommodation) is stored so you can access it from any device.",
+          "Route data: imported raw GPS points are cached temporarily (Redis) and then deleted automatically.",
+          "No sensitive data is collected, and no data is sold to third parties."
+        ]
+      },
+      "retention": {
+        "title": "Retention period",
+        "paragraphs": [
+          "Your account and trips are kept for as long as your account is active. You may request their deletion at any time.",
+          "Raw cached route data is kept for a maximum of 24 hours.",
+          "Anonymous audience measurement data is aggregated and cannot be used to re-identify you."
+        ]
+      },
+      "rights": {
+        "title": "Your rights",
+        "paragraphs": [
+          "In accordance with the GDPR, you have the right of access, rectification, erasure, restriction, objection and portability of your data.",
+          "To exercise these rights, contact us at: contact@bike-trip-planner.example. We respond within one month.",
+          "You also have the right to lodge a complaint with your supervisory authority (in France, the CNIL — www.cnil.fr)."
+        ]
+      },
+      "processors": {
+        "title": "Processors",
+        "paragraphs": [
+          "Infrastructure hosting: cloud provider located within the European Union.",
+          "Sending sign-in emails: a transactional email delivery provider.",
+          "Open-data sources queried for analysis (OpenStreetMap, weather forecasts): no identifying personal data is transmitted to them."
+        ]
+      },
+      "analytics": {
+        "title": "Audience measurement (Plausible)",
+        "paragraphs": [
+          "We use Plausible Analytics, a privacy-friendly audience measurement solution, self-hosted on our own infrastructure within the European Union.",
+          "Plausible sets no cookies and uses no fingerprinting techniques. No data is shared with third parties for advertising purposes.",
+          "IP addresses and user agents (browser) are anonymised and never stored; no data can be used to identify you or track you across sites.",
+          "Purpose: to understand, in aggregate, which pages are visited and overall usage in order to improve the service. Retention: aggregated statistics only, no individual data.",
+          "No consent banner is required because no personal data is collected; you nevertheless retain the objection rights described above."
+        ]
+      },
+      "contact": {
+        "title": "Contact",
+        "paragraphs": [
+          "For any question about this privacy policy, write to us at: contact@bike-trip-planner.example.",
+          "This policy may be updated; the last-updated date is shown at the top of this page."
+        ]
+      }
+    }
   }
 }

--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -1008,7 +1008,7 @@
       "contact": {
         "title": "Contact",
         "paragraphs": [
-          "For any question about the site or to exercise your rights, contact us at: contact@bike-trip-planner.example.",
+          "For any question about the site or to exercise your rights, contact us at: contact@bike-trip-planner.app.",
           "You can also open an issue on the project's GitHub repository."
         ]
       },
@@ -1033,7 +1033,7 @@
         "title": "Data controller",
         "paragraphs": [
           "The data controller is the publisher of Bike Trip Planner (see the legal notice).",
-          "For any question about your personal data, contact us at: contact@bike-trip-planner.example."
+          "For any question about your personal data, contact us at: contact@bike-trip-planner.app."
         ]
       },
       "basis": {
@@ -1071,7 +1071,7 @@
         "title": "Your rights",
         "paragraphs": [
           "In accordance with the GDPR, you have the right of access, rectification, erasure, restriction, objection and portability of your data.",
-          "To exercise these rights, contact us at: contact@bike-trip-planner.example. We respond within one month.",
+          "To exercise these rights, contact us at: contact@bike-trip-planner.app. We respond within one month.",
           "You also have the right to lodge a complaint with your supervisory authority (in France, the CNIL — www.cnil.fr)."
         ]
       },
@@ -1096,7 +1096,7 @@
       "contact": {
         "title": "Contact",
         "paragraphs": [
-          "For any question about this privacy policy, write to us at: contact@bike-trip-planner.example.",
+          "For any question about this privacy policy, write to us at: contact@bike-trip-planner.app.",
           "This policy may be updated; the last-updated date is shown at the top of this page."
         ]
       }

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -1008,7 +1008,7 @@
       "contact": {
         "title": "Contact",
         "paragraphs": [
-          "Pour toute question relative au site ou pour exercer vos droits, vous pouvez nous contacter à l'adresse : contact@bike-trip-planner.example.",
+          "Pour toute question relative au site ou pour exercer vos droits, vous pouvez nous contacter à l'adresse : contact@bike-trip-planner.app.",
           "Vous pouvez également ouvrir une issue sur le dépôt GitHub du projet."
         ]
       },
@@ -1033,7 +1033,7 @@
         "title": "Responsable du traitement",
         "paragraphs": [
           "Le responsable du traitement des données est l'éditeur de Bike Trip Planner (voir les mentions légales).",
-          "Pour toute question relative à vos données personnelles, contactez-nous à : contact@bike-trip-planner.example."
+          "Pour toute question relative à vos données personnelles, contactez-nous à : contact@bike-trip-planner.app."
         ]
       },
       "basis": {
@@ -1071,7 +1071,7 @@
         "title": "Vos droits",
         "paragraphs": [
           "Conformément au RGPD, vous disposez d'un droit d'accès, de rectification, d'effacement, de limitation, d'opposition et de portabilité de vos données.",
-          "Pour exercer ces droits, contactez-nous à : contact@bike-trip-planner.example. Nous répondons dans un délai d'un mois.",
+          "Pour exercer ces droits, contactez-nous à : contact@bike-trip-planner.app. Nous répondons dans un délai d'un mois.",
           "Vous avez également le droit d'introduire une réclamation auprès de la CNIL (www.cnil.fr)."
         ]
       },
@@ -1096,7 +1096,7 @@
       "contact": {
         "title": "Contact",
         "paragraphs": [
-          "Pour toute question relative à cette politique de confidentialité, écrivez-nous à : contact@bike-trip-planner.example.",
+          "Pour toute question relative à cette politique de confidentialité, écrivez-nous à : contact@bike-trip-planner.app.",
           "Cette politique peut être mise à jour ; la date de dernière mise à jour figure en haut de cette page."
         ]
       }

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -985,12 +985,121 @@
   },
   "legal": {
     "title": "Mentions légales",
-    "comingSoon": "Cette page sera disponible prochainement.",
-    "backToHome": "Retour à l'accueil"
+    "intro": "Informations légales relatives à l'éditeur et à l'hébergeur de Bike Trip Planner.",
+    "lastUpdated": "Dernière mise à jour : 29 mai 2026",
+    "tocLabel": "Sommaire",
+    "backToHome": "Retour à l'accueil",
+    "sections": {
+      "publisher": {
+        "title": "Éditeur",
+        "paragraphs": [
+          "Bike Trip Planner est un projet open-source édité par Vincent Chalamon.",
+          "Le code source est publié sur GitHub sous licence libre : https://github.com/vincentchalamon/bike-trip-planner",
+          "Directeur de la publication : Vincent Chalamon."
+        ]
+      },
+      "host": {
+        "title": "Hébergeur",
+        "paragraphs": [
+          "L'application est hébergée sur une infrastructure cloud située dans l'Union européenne.",
+          "Les coordonnées exactes de l'hébergeur peuvent être communiquées sur demande à l'adresse de contact ci-dessous."
+        ]
+      },
+      "contact": {
+        "title": "Contact",
+        "paragraphs": [
+          "Pour toute question relative au site ou pour exercer vos droits, vous pouvez nous contacter à l'adresse : contact@bike-trip-planner.example.",
+          "Vous pouvez également ouvrir une issue sur le dépôt GitHub du projet."
+        ]
+      },
+      "intellectualProperty": {
+        "title": "Propriété intellectuelle",
+        "paragraphs": [
+          "Le code source de Bike Trip Planner est distribué sous licence open-source ; les conditions d'utilisation et de redistribution figurent dans le dépôt GitHub.",
+          "Les données d'itinéraire et cartographiques proviennent de sources tierces (OpenStreetMap, DataTourisme, Wikidata, data.gouv.fr) et restent soumises à leurs licences respectives, créditées sur l'application.",
+          "Les marques, logos et contenus appartenant à des tiers (Komoot, Strava, RideWithGPS, Garmin, Wahoo) demeurent la propriété de leurs détenteurs respectifs."
+        ]
+      }
+    }
   },
   "privacy": {
     "title": "Politique de confidentialité",
-    "comingSoon": "Cette page sera disponible prochainement.",
-    "backToHome": "Retour à l'accueil"
+    "intro": "Comment Bike Trip Planner collecte, utilise et protège vos données personnelles, conformément au RGPD.",
+    "lastUpdated": "Dernière mise à jour : 29 mai 2026",
+    "tocLabel": "Sommaire",
+    "backToHome": "Retour à l'accueil",
+    "sections": {
+      "controller": {
+        "title": "Responsable du traitement",
+        "paragraphs": [
+          "Le responsable du traitement des données est l'éditeur de Bike Trip Planner (voir les mentions légales).",
+          "Pour toute question relative à vos données personnelles, contactez-nous à : contact@bike-trip-planner.example."
+        ]
+      },
+      "basis": {
+        "title": "Base légale",
+        "paragraphs": [
+          "Le traitement de votre adresse email repose sur l'exécution du service que vous demandez (connexion par lien magique et gestion de votre compte), au sens de l'article 6.1.b du RGPD.",
+          "La mesure d'audience anonyme repose sur notre intérêt légitime à améliorer le service, sans préjudice pour vos droits et libertés (article 6.1.f du RGPD)."
+        ]
+      },
+      "purposes": {
+        "title": "Finalités",
+        "paragraphs": [
+          "Vos données sont utilisées pour vous authentifier, sauvegarder et restituer vos voyages, et calculer les analyses d'itinéraire (pacing, alertes, hébergements, météo).",
+          "La mesure d'audience anonyme sert uniquement à comprendre l'usage global du service et à en améliorer l'ergonomie."
+        ]
+      },
+      "data": {
+        "title": "Données collectées",
+        "paragraphs": [
+          "Compte : votre adresse email, nécessaire à la connexion par lien magique.",
+          "Voyages : la configuration de vos voyages (titre, dates, profil cycliste, étapes, hébergements sélectionnés) est conservée pour vous permettre d'y accéder depuis n'importe quel appareil.",
+          "Données de tracé : les points GPS bruts importés sont conservés temporairement en cache (Redis) puis supprimés automatiquement.",
+          "Aucune donnée sensible n'est collectée, et aucune donnée n'est revendue à des tiers."
+        ]
+      },
+      "retention": {
+        "title": "Durée de conservation",
+        "paragraphs": [
+          "Votre compte et vos voyages sont conservés tant que votre compte est actif. Vous pouvez demander leur suppression à tout moment.",
+          "Les données de tracé brutes en cache sont conservées au maximum 24 heures.",
+          "Les données de mesure d'audience anonyme sont agrégées et ne permettent pas de vous réidentifier."
+        ]
+      },
+      "rights": {
+        "title": "Vos droits",
+        "paragraphs": [
+          "Conformément au RGPD, vous disposez d'un droit d'accès, de rectification, d'effacement, de limitation, d'opposition et de portabilité de vos données.",
+          "Pour exercer ces droits, contactez-nous à : contact@bike-trip-planner.example. Nous répondons dans un délai d'un mois.",
+          "Vous avez également le droit d'introduire une réclamation auprès de la CNIL (www.cnil.fr)."
+        ]
+      },
+      "processors": {
+        "title": "Sous-traitants",
+        "paragraphs": [
+          "Hébergement de l'infrastructure : prestataire cloud situé dans l'Union européenne.",
+          "Envoi des emails de connexion : prestataire d'envoi d'emails transactionnels.",
+          "Sources de données ouvertes interrogées pour l'analyse (OpenStreetMap, prévisions météo) : aucune donnée personnelle identifiante ne leur est transmise."
+        ]
+      },
+      "analytics": {
+        "title": "Mesure d'audience (Plausible)",
+        "paragraphs": [
+          "Nous utilisons Plausible Analytics, une solution de mesure d'audience respectueuse de la vie privée, auto-hébergée sur notre propre infrastructure dans l'Union européenne.",
+          "Plausible ne dépose aucun cookie et n'utilise aucune technique d'empreinte numérique (fingerprinting). Aucune donnée n'est partagée avec des tiers à des fins publicitaires.",
+          "Les adresses IP et les agents utilisateur (navigateur) sont anonymisés et ne sont jamais stockés ; aucune donnée ne permet de vous identifier ou de vous suivre entre les sites.",
+          "Finalité : comprendre de façon agrégée les pages consultées et l'usage global afin d'améliorer le service. Rétention : statistiques agrégées uniquement, aucune donnée individuelle.",
+          "Aucune bannière de consentement n'est requise car aucune donnée personnelle n'est collectée ; vous conservez néanmoins vos droits d'opposition décrits ci-dessus."
+        ]
+      },
+      "contact": {
+        "title": "Contact",
+        "paragraphs": [
+          "Pour toute question relative à cette politique de confidentialité, écrivez-nous à : contact@bike-trip-planner.example.",
+          "Cette politique peut être mise à jour ; la date de dernière mise à jour figure en haut de cette page."
+        ]
+      }
+    }
   }
 }

--- a/pwa/src/app/legal/page.tsx
+++ b/pwa/src/app/legal/page.tsx
@@ -1,6 +1,13 @@
 import { getTranslations } from "next-intl/server";
-import { LegalPage, type LegalSection } from "@/components/legal-page";
+import { LegalPageLayout, type LegalSection } from "@/components/legal-page";
 import { LandingFooter } from "@/components/landing/footer";
+
+function asParagraphs(raw: unknown, key: string): string[] {
+  if (!Array.isArray(raw) || !raw.every((item) => typeof item === "string")) {
+    throw new Error(`Translation "${key}" must be an array of strings`);
+  }
+  return raw;
+}
 
 const SECTION_IDS = [
   "publisher",
@@ -9,18 +16,23 @@ const SECTION_IDS = [
   "intellectualProperty",
 ] as const;
 
-export default async function LegalPage_() {
+// TODO: the GDPR contact address (contact@bike-trip-planner.app in messages/*.json)
+// is a routable placeholder. Replace it with the real mailbox before going to production.
+export default async function LegalNoticePage() {
   const t = await getTranslations("legal");
 
-  const sections: LegalSection[] = SECTION_IDS.map((id) => ({
-    id,
-    title: t(`sections.${id}.title`),
-    paragraphs: t.raw(`sections.${id}.paragraphs`) as string[],
-  }));
+  const sections: LegalSection[] = SECTION_IDS.map((id) => {
+    const key = `sections.${id}.paragraphs`;
+    return {
+      id,
+      title: t(`sections.${id}.title`),
+      paragraphs: asParagraphs(t.raw(key), `legal.${key}`),
+    };
+  });
 
   return (
     <>
-      <LegalPage
+      <LegalPageLayout
         title={t("title")}
         intro={t("intro")}
         lastUpdated={t("lastUpdated")}

--- a/pwa/src/app/legal/page.tsx
+++ b/pwa/src/app/legal/page.tsx
@@ -1,13 +1,10 @@
 import { getTranslations } from "next-intl/server";
-import { LegalPageLayout, type LegalSection } from "@/components/legal-page";
+import {
+  LegalPageLayout,
+  type LegalSection,
+  asParagraphs,
+} from "@/components/legal-page";
 import { LandingFooter } from "@/components/landing/footer";
-
-function asParagraphs(raw: unknown, key: string): string[] {
-  if (!Array.isArray(raw) || !raw.every((item) => typeof item === "string")) {
-    throw new Error(`Translation "${key}" must be an array of strings`);
-  }
-  return raw;
-}
 
 const SECTION_IDS = [
   "publisher",

--- a/pwa/src/app/legal/page.tsx
+++ b/pwa/src/app/legal/page.tsx
@@ -1,25 +1,35 @@
-import Link from "next/link";
-import { ArrowLeft } from "lucide-react";
 import { getTranslations } from "next-intl/server";
+import { LegalPage, type LegalSection } from "@/components/legal-page";
+import { LandingFooter } from "@/components/landing/footer";
 
-export default async function LegalPage() {
+const SECTION_IDS = [
+  "publisher",
+  "host",
+  "contact",
+  "intellectualProperty",
+] as const;
+
+export default async function LegalPage_() {
   const t = await getTranslations("legal");
 
-  return (
-    <main className="max-w-2xl mx-auto px-4 md:px-6 py-12">
-      <Link
-        href="/"
-        className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground mb-8 transition-colors"
-        data-testid="legal-back-link"
-      >
-        <ArrowLeft className="h-4 w-4" aria-hidden="true" />
-        {t("backToHome")}
-      </Link>
+  const sections: LegalSection[] = SECTION_IDS.map((id) => ({
+    id,
+    title: t(`sections.${id}.title`),
+    paragraphs: t.raw(`sections.${id}.paragraphs`) as string[],
+  }));
 
-      <div className="mb-10">
-        <h1 className="text-3xl font-bold tracking-tight mb-2">{t("title")}</h1>
-        <p className="text-muted-foreground">{t("comingSoon")}</p>
-      </div>
-    </main>
+  return (
+    <>
+      <LegalPage
+        title={t("title")}
+        intro={t("intro")}
+        lastUpdated={t("lastUpdated")}
+        tocLabel={t("tocLabel")}
+        backToHome={t("backToHome")}
+        sections={sections}
+        testIdPrefix="legal"
+      />
+      <LandingFooter />
+    </>
   );
 }

--- a/pwa/src/app/privacy/page.tsx
+++ b/pwa/src/app/privacy/page.tsx
@@ -1,6 +1,13 @@
 import { getTranslations } from "next-intl/server";
-import { LegalPage, type LegalSection } from "@/components/legal-page";
+import { LegalPageLayout, type LegalSection } from "@/components/legal-page";
 import { LandingFooter } from "@/components/landing/footer";
+
+function asParagraphs(raw: unknown, key: string): string[] {
+  if (!Array.isArray(raw) || !raw.every((item) => typeof item === "string")) {
+    throw new Error(`Translation "${key}" must be an array of strings`);
+  }
+  return raw;
+}
 
 const SECTION_IDS = [
   "controller",
@@ -14,18 +21,23 @@ const SECTION_IDS = [
   "contact",
 ] as const;
 
+// TODO: the GDPR contact address (contact@bike-trip-planner.app in messages/*.json)
+// is a routable placeholder. Replace it with the real mailbox before going to production.
 export default async function PrivacyPage() {
   const t = await getTranslations("privacy");
 
-  const sections: LegalSection[] = SECTION_IDS.map((id) => ({
-    id,
-    title: t(`sections.${id}.title`),
-    paragraphs: t.raw(`sections.${id}.paragraphs`) as string[],
-  }));
+  const sections: LegalSection[] = SECTION_IDS.map((id) => {
+    const key = `sections.${id}.paragraphs`;
+    return {
+      id,
+      title: t(`sections.${id}.title`),
+      paragraphs: asParagraphs(t.raw(key), `privacy.${key}`),
+    };
+  });
 
   return (
     <>
-      <LegalPage
+      <LegalPageLayout
         title={t("title")}
         intro={t("intro")}
         lastUpdated={t("lastUpdated")}

--- a/pwa/src/app/privacy/page.tsx
+++ b/pwa/src/app/privacy/page.tsx
@@ -1,13 +1,10 @@
 import { getTranslations } from "next-intl/server";
-import { LegalPageLayout, type LegalSection } from "@/components/legal-page";
+import {
+  LegalPageLayout,
+  type LegalSection,
+  asParagraphs,
+} from "@/components/legal-page";
 import { LandingFooter } from "@/components/landing/footer";
-
-function asParagraphs(raw: unknown, key: string): string[] {
-  if (!Array.isArray(raw) || !raw.every((item) => typeof item === "string")) {
-    throw new Error(`Translation "${key}" must be an array of strings`);
-  }
-  return raw;
-}
 
 const SECTION_IDS = [
   "controller",

--- a/pwa/src/app/privacy/page.tsx
+++ b/pwa/src/app/privacy/page.tsx
@@ -1,25 +1,40 @@
-import Link from "next/link";
-import { ArrowLeft } from "lucide-react";
 import { getTranslations } from "next-intl/server";
+import { LegalPage, type LegalSection } from "@/components/legal-page";
+import { LandingFooter } from "@/components/landing/footer";
+
+const SECTION_IDS = [
+  "controller",
+  "basis",
+  "purposes",
+  "data",
+  "retention",
+  "rights",
+  "processors",
+  "analytics",
+  "contact",
+] as const;
 
 export default async function PrivacyPage() {
   const t = await getTranslations("privacy");
 
-  return (
-    <main className="max-w-2xl mx-auto px-4 md:px-6 py-12">
-      <Link
-        href="/"
-        className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground mb-8 transition-colors"
-        data-testid="privacy-back-link"
-      >
-        <ArrowLeft className="h-4 w-4" aria-hidden="true" />
-        {t("backToHome")}
-      </Link>
+  const sections: LegalSection[] = SECTION_IDS.map((id) => ({
+    id,
+    title: t(`sections.${id}.title`),
+    paragraphs: t.raw(`sections.${id}.paragraphs`) as string[],
+  }));
 
-      <div className="mb-10">
-        <h1 className="text-3xl font-bold tracking-tight mb-2">{t("title")}</h1>
-        <p className="text-muted-foreground">{t("comingSoon")}</p>
-      </div>
-    </main>
+  return (
+    <>
+      <LegalPage
+        title={t("title")}
+        intro={t("intro")}
+        lastUpdated={t("lastUpdated")}
+        tocLabel={t("tocLabel")}
+        backToHome={t("backToHome")}
+        sections={sections}
+        testIdPrefix="privacy"
+      />
+      <LandingFooter />
+    </>
   );
 }

--- a/pwa/src/components/legal-page.tsx
+++ b/pwa/src/components/legal-page.tsx
@@ -25,7 +25,47 @@ interface LegalPageProps {
   testIdPrefix: string;
 }
 
-export function LegalPage({
+/** Splits text on http(s) URLs and email addresses, rendering each as an anchor. */
+function linkify(text: string) {
+  const pattern = /(https?:\/\/[^\s]+|[\w.+-]+@[\w-]+\.[\w.-]+)/g;
+  return text.split(pattern).map((part, index) => {
+    if (/^https?:\/\//.test(part)) {
+      const href = part.replace(/[.,;:)]+$/, "");
+      const trailing = part.slice(href.length);
+      return (
+        <span key={index}>
+          <a
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-brand underline underline-offset-2 hover:no-underline"
+          >
+            {href}
+          </a>
+          {trailing}
+        </span>
+      );
+    }
+    if (/^[\w.+-]+@[\w-]+\.[\w.-]+$/.test(part)) {
+      const address = part.replace(/[.,;:]+$/, "");
+      const trailing = part.slice(address.length);
+      return (
+        <span key={index}>
+          <a
+            href={`mailto:${address}`}
+            className="text-brand underline underline-offset-2 hover:no-underline"
+          >
+            {address}
+          </a>
+          {trailing}
+        </span>
+      );
+    }
+    return part;
+  });
+}
+
+export function LegalPageLayout({
   title,
   intro,
   sections,
@@ -94,7 +134,7 @@ export function LegalPage({
                     key={index}
                     className="text-sm text-muted-foreground leading-relaxed"
                   >
-                    {paragraph}
+                    {linkify(paragraph)}
                   </p>
                 ))}
               </div>

--- a/pwa/src/components/legal-page.tsx
+++ b/pwa/src/components/legal-page.tsx
@@ -1,0 +1,107 @@
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+
+export interface LegalSection {
+  id: string;
+  title: string;
+  /** Paragraphs of body text. Each entry renders as its own <p>. */
+  paragraphs: string[];
+}
+
+interface LegalPageProps {
+  /** Main page heading. */
+  title: string;
+  /** Short intro paragraph below the heading. */
+  intro: string;
+  /** Sections rendered as anchored blocks with a sticky table of contents. */
+  sections: LegalSection[];
+  /** Localized "table of contents" heading. */
+  tocLabel: string;
+  /** Localized "back to home" link label. */
+  backToHome: string;
+  /** Localized "last updated" label, e.g. "Dernière mise à jour : 29 mai 2026". */
+  lastUpdated: string;
+  /** data-testid prefix, e.g. "privacy" or "legal". */
+  testIdPrefix: string;
+}
+
+export function LegalPage({
+  title,
+  intro,
+  sections,
+  tocLabel,
+  backToHome,
+  lastUpdated,
+  testIdPrefix,
+}: LegalPageProps) {
+  return (
+    <main className="max-w-5xl mx-auto px-4 md:px-6 py-12">
+      <Link
+        href="/"
+        className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground mb-8 transition-colors"
+        data-testid={`${testIdPrefix}-back-link`}
+      >
+        <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+        {backToHome}
+      </Link>
+
+      <div className="mb-10">
+        <h1 className="text-3xl font-bold tracking-tight mb-2">{title}</h1>
+        <p className="text-muted-foreground">{intro}</p>
+        <p className="text-xs text-muted-foreground mt-2">{lastUpdated}</p>
+      </div>
+
+      <div className="grid gap-10 md:grid-cols-[16rem_1fr]">
+        {/* Sticky table of contents (desktop) */}
+        <nav
+          aria-label={tocLabel}
+          className="md:sticky md:top-12 md:self-start"
+          data-testid={`${testIdPrefix}-toc`}
+        >
+          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-3">
+            {tocLabel}
+          </p>
+          <ul className="space-y-2 text-sm border-l border-border">
+            {sections.map((section) => (
+              <li key={section.id}>
+                <a
+                  href={`#${section.id}`}
+                  className="block -ml-px border-l border-transparent pl-4 text-muted-foreground hover:text-foreground hover:border-brand transition-colors"
+                  data-testid={`${testIdPrefix}-toc-${section.id}`}
+                >
+                  {section.title}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </nav>
+
+        {/* Content */}
+        <div className="space-y-10 min-w-0">
+          {sections.map((section) => (
+            <section
+              key={section.id}
+              id={section.id}
+              className="scroll-mt-12"
+              data-testid={`${testIdPrefix}-section-${section.id}`}
+            >
+              <h2 className="text-xl font-semibold tracking-tight mb-3">
+                {section.title}
+              </h2>
+              <div className="space-y-3">
+                {section.paragraphs.map((paragraph, index) => (
+                  <p
+                    key={index}
+                    className="text-sm text-muted-foreground leading-relaxed"
+                  >
+                    {paragraph}
+                  </p>
+                ))}
+              </div>
+            </section>
+          ))}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/pwa/src/components/legal-page.tsx
+++ b/pwa/src/components/legal-page.tsx
@@ -8,6 +8,14 @@ export interface LegalSection {
   paragraphs: string[];
 }
 
+/** Validates a `t.raw()` value as an array of strings, throwing on mismatch. */
+export function asParagraphs(raw: unknown, key: string): string[] {
+  if (!Array.isArray(raw) || !raw.every((item) => typeof item === "string")) {
+    throw new Error(`Translation "${key}" must be an array of strings`);
+  }
+  return raw;
+}
+
 interface LegalPageProps {
   /** Main page heading. */
   title: string;

--- a/pwa/tests/mocked/legal-privacy.spec.ts
+++ b/pwa/tests/mocked/legal-privacy.spec.ts
@@ -2,15 +2,40 @@ import { test, expect } from "@playwright/test";
 import { FAKE_JWT_TOKEN } from "../fixtures/api-mocks";
 
 const PAGES = [
-  { path: "/legal", testid: "legal-back-link", title: "Mentions légales" },
+  {
+    path: "/legal",
+    testid: "legal-back-link",
+    title: "Mentions légales",
+    toc: "legal-toc",
+    sectionCount: 4,
+    sampleSection: "legal-section-publisher",
+    sampleTocLink: "legal-toc-host",
+    sampleTarget: "#host",
+  },
   {
     path: "/privacy",
     testid: "privacy-back-link",
     title: "Politique de confidentialité",
+    toc: "privacy-toc",
+    sectionCount: 9,
+    sampleSection: "privacy-section-analytics",
+    sampleTocLink: "privacy-toc-rights",
+    sampleTarget: "#rights",
   },
 ] as const;
 
-for (const { path, testid, title } of PAGES) {
+for (const page_ of PAGES) {
+  const {
+    path,
+    testid,
+    title,
+    toc,
+    sectionCount,
+    sampleSection,
+    sampleTocLink,
+    sampleTarget,
+  } = page_;
+
   test.describe(`${path} page`, () => {
     test("is publicly accessible without authentication", async ({ page }) => {
       await page.route("**/auth/refresh", (route, request) => {
@@ -37,6 +62,45 @@ for (const { path, testid, title } of PAGES) {
       });
     });
 
+    test("renders all sections with level-2 headings", async ({ page }) => {
+      await page.goto(path);
+      await page.waitForLoadState("networkidle");
+
+      await expect(page.getByRole("heading", { level: 2 })).toHaveCount(
+        sectionCount,
+      );
+      await expect(page.getByTestId(sampleSection)).toBeVisible();
+    });
+
+    test("shows a table of contents whose links jump to sections", async ({
+      page,
+    }) => {
+      await page.goto(path);
+      await page.waitForLoadState("networkidle");
+
+      const tocNav = page.getByTestId(toc);
+      await expect(tocNav).toBeVisible();
+
+      const tocLink = page.getByTestId(sampleTocLink);
+      await expect(tocLink).toHaveAttribute("href", sampleTarget);
+      await tocLink.click();
+      await expect(page).toHaveURL(`${path}${sampleTarget}`);
+    });
+
+    test("renders the global footer with legal and privacy links", async ({
+      page,
+    }) => {
+      await page.goto(path);
+      await page.waitForLoadState("networkidle");
+
+      await expect(page.getByTestId("section-footer")).toBeVisible();
+
+      const legalLink = page.getByTestId("footer-legal");
+      const privacyLink = page.getByTestId("footer-privacy");
+      await expect(legalLink).toHaveAttribute("href", "/legal");
+      await expect(privacyLink).toHaveAttribute("href", "/privacy");
+    });
+
     test("back-to-home link navigates to /", async ({ page }) => {
       await page.route("**/auth/refresh", (route, request) => {
         if (request.method() !== "POST") return route.fallback();
@@ -57,3 +121,11 @@ for (const { path, testid, title } of PAGES) {
     });
   });
 }
+
+test("privacy page mentions Plausible analytics", async ({ page }) => {
+  await page.goto("/privacy");
+  await page.waitForLoadState("networkidle");
+
+  const section = page.getByTestId("privacy-section-analytics");
+  await expect(section).toContainText("Plausible");
+});


### PR DESCRIPTION
## Contexte

Sprint 34 — prérequis RGPD. Remplit le contenu des pages `/privacy` et `/legal` (auparavant stubs « Coming soon »).

Closes #550.

## Changements

- `/privacy` : politique de confidentialité complète (9 sections ancrées) — base légale, finalités, données, conservation, droits, sous-traitants, **mention Plausible** (auto-hébergé, sans cookie, IP/UA anonymisés), contact.
- `/legal` : mentions légales (éditeur, hébergeur, contact, PI).
- `pwa/src/components/legal-page.tsx` : layout réutilisable avec **sommaire sticky** (ancres), tokens design uniquement.
- Footer global (`LandingFooter` réutilisé) sur les deux pages, liens `/privacy` + `/legal`.
- i18n FR + EN (parité de clés vérifiée).
- E2E `pwa/tests/mocked/legal-privacy.spec.ts` étendu.

## Auto-critique

- `make qa` exit 0 (tsc strict, ESLint, Prettier).
- E2E non exécuté localement (port 443 partagé par l'env Docker) → validé par la CI.

<!-- claude-review-start -->
## Claude Review

**Findings:** 0 critical · 0 warning · 0 blocking

The third commit fully addresses the only remaining warning from the previous cycle: `asParagraphs` is now exported from `legal-page.tsx` and imported in both page files — no duplication. The implementation is clean, the `linkify` helper, `asParagraphs` guard, and server-component structure are all correct.

Reviewed commit: `779e18feb6550df057c300183efac221fcf35979`

### Resolved threads

Resolved 1 previously open thread that was addressed (asParagraphs DRY issue).

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Inline comments

No inline comments.

---

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->