### PR TITLE
feat(pwa): add conditional plausible analytics script loading

### DIFF
--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -174,6 +174,12 @@ services:
         NEXT_PUBLIC_APP_RELEASE: "${APP_RELEASE:-}"
         NEXT_PUBLIC_APP_ENV: "${APP_ENV:-prod}"
         NEXT_PUBLIC_SENTRY_DSN: "${NEXT_PUBLIC_SENTRY_DSN:-}"
+        # Plausible analytics (self-hosted). Leave both empty to disable: the
+        # script is then never injected and no request hits the Plausible host.
+        # DOMAIN is the site id registered in Plausible; SRC is the full URL of
+        # the self-hosted tracker script (e.g. https://analytics.example/js/script.js).
+        NEXT_PUBLIC_PLAUSIBLE_DOMAIN: "${NEXT_PUBLIC_PLAUSIBLE_DOMAIN:-}"
+        NEXT_PUBLIC_PLAUSIBLE_SRC: "${NEXT_PUBLIC_PLAUSIBLE_SRC:-}"
       # SENTRY_AUTH_TOKEN (source-map upload) is a real secret: passed as a
       # BuildKit secret so it never lands in an image layer or the build cache.
       secrets:
@@ -193,6 +199,10 @@ services:
       NEXT_PUBLIC_SENTRY_DSN: "${NEXT_PUBLIC_SENTRY_DSN:-}"
       NEXT_PUBLIC_APP_RELEASE: "${APP_RELEASE:-}"
       NEXT_PUBLIC_APP_ENV: "${APP_ENV:-prod}"
+      # Plausible analytics (self-hosted). Leave empty to disable. Loaded only
+      # after the user grants analytics consent (cookie banner, #385).
+      NEXT_PUBLIC_PLAUSIBLE_DOMAIN: "${NEXT_PUBLIC_PLAUSIBLE_DOMAIN:-}"
+      NEXT_PUBLIC_PLAUSIBLE_SRC: "${NEXT_PUBLIC_PLAUSIBLE_SRC:-}"
       SENTRY_DSN: "${SENTRY_DSN:-}"
       APP_RELEASE: "${APP_RELEASE:-}"
     volumes:

--- a/pwa/src/app/layout.tsx
+++ b/pwa/src/app/layout.tsx
@@ -9,6 +9,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { Toaster } from "@/components/ui/sonner";
 import { OnboardingTour } from "@/components/onboarding-tour";
 import { AuthGuard } from "@/components/auth-guard";
+import { PlausibleScript } from "@/components/plausible-script";
 
 const fraunces = Fraunces({
   subsets: ["latin"],
@@ -78,6 +79,7 @@ export default async function RootLayout({
             <Toaster richColors position="top-right" />
           </ThemeProvider>
         </NextIntlClientProvider>
+        <PlausibleScript />
       </body>
     </html>
   );

--- a/pwa/src/components/plausible-script.tsx
+++ b/pwa/src/components/plausible-script.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import Script from "next/script";
+import { useAnalyticsConsent } from "@/hooks/use-analytics-consent";
+
+/**
+ * Plausible analytics (self-hosted) loader.
+ *
+ * Injects the Plausible script only when BOTH conditions hold:
+ *  1. `NEXT_PUBLIC_PLAUSIBLE_DOMAIN` and `NEXT_PUBLIC_PLAUSIBLE_SRC` are set;
+ *  2. the user has granted analytics consent (see {@link useAnalyticsConsent}).
+ *
+ * Until consent is granted, nothing is rendered and no request is made to the
+ * Plausible domain. The real cookie-banner gating wiring lands in #385; this
+ * component already reads the shared consent source.
+ */
+type PlausibleTestOverride = Window & {
+  __PLAYWRIGHT_PLAUSIBLE_DOMAIN?: string;
+  __PLAYWRIGHT_PLAUSIBLE_SRC?: string;
+};
+
+export function PlausibleScript() {
+  const hasConsent = useAnalyticsConsent();
+
+  // `NEXT_PUBLIC_*` are inlined at build time, so E2E running against an
+  // env-less dev server cannot exercise the "configured" branch. Mirror the
+  // `__PLAYWRIGHT_*` window-override convention already used by the onboarding
+  // tour to let tests supply the config at runtime.
+  const override =
+    typeof window !== "undefined"
+      ? (window as PlausibleTestOverride)
+      : undefined;
+  const domain =
+    process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN ??
+    override?.__PLAYWRIGHT_PLAUSIBLE_DOMAIN;
+  const src =
+    process.env.NEXT_PUBLIC_PLAUSIBLE_SRC ??
+    override?.__PLAYWRIGHT_PLAUSIBLE_SRC;
+
+  if (!domain || !src || !hasConsent) {
+    return null;
+  }
+
+  return (
+    <Script
+      id="plausible-analytics"
+      data-testid="plausible-script"
+      data-domain={domain}
+      src={src}
+      strategy="afterInteractive"
+    />
+  );
+}

--- a/pwa/src/components/plausible-script.tsx
+++ b/pwa/src/components/plausible-script.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Script from "next/script";
+import { useEffect, useRef } from "react";
 import { useAnalyticsConsent } from "@/hooks/use-analytics-consent";
 
 /**
@@ -26,8 +27,13 @@ export function PlausibleScript() {
   // env-less dev server cannot exercise the "configured" branch. Mirror the
   // `__PLAYWRIGHT_*` window-override convention already used by the onboarding
   // tour to let tests supply the config at runtime.
+  // Only honoured outside production builds: the override controls an
+  // executable `<script src>`, so leaving it reachable in production would let
+  // any `window` writer point analytics at an arbitrary URL. The
+  // `process.env.NODE_ENV` check lets the dead-code eliminator strip it from
+  // production bundles.
   const override =
-    typeof window !== "undefined"
+    typeof window !== "undefined" && process.env.NODE_ENV !== "production"
       ? (window as PlausibleTestOverride)
       : undefined;
   const domain =
@@ -36,6 +42,23 @@ export function PlausibleScript() {
   const src =
     process.env.NEXT_PUBLIC_PLAUSIBLE_SRC ??
     override?.__PLAYWRIGHT_PLAUSIBLE_SRC;
+
+  // `<Script>` injects a real `<script>` into the document head; unmounting it
+  // (e.g. when consent is revoked via the cookie banner in #385) leaves both the
+  // DOM node and Plausible's runtime state in place, so tracking would continue
+  // until the next reload. Tear both down explicitly when consent drops.
+  const wasInjected = useRef(false);
+  useEffect(() => {
+    const shouldInject = Boolean(domain && src && hasConsent);
+    if (shouldInject) {
+      wasInjected.current = true;
+      return;
+    }
+    if (!wasInjected.current) return;
+    wasInjected.current = false;
+    document.getElementById("plausible-analytics")?.remove();
+    delete (window as Window & { plausible?: unknown }).plausible;
+  }, [domain, src, hasConsent]);
 
   if (!domain || !src || !hasConsent) {
     return null;

--- a/pwa/src/components/plausible-script.tsx
+++ b/pwa/src/components/plausible-script.tsx
@@ -23,17 +23,15 @@ type PlausibleTestOverride = Window & {
 export function PlausibleScript() {
   const hasConsent = useAnalyticsConsent();
 
-  // `NEXT_PUBLIC_*` are inlined at build time, so E2E running against an
-  // env-less dev server cannot exercise the "configured" branch. Mirror the
-  // `__PLAYWRIGHT_*` window-override convention already used by the onboarding
-  // tour to let tests supply the config at runtime.
-  // Only honoured outside production builds: the override controls an
-  // executable `<script src>`, so leaving it reachable in production would let
-  // any `window` writer point analytics at an arbitrary URL. The
-  // `process.env.NODE_ENV` check lets the dead-code eliminator strip it from
-  // production bundles.
+  // `NEXT_PUBLIC_*` are inlined at build time, so E2E (which runs a production
+  // build in CI) cannot exercise the "configured" branch via env vars. Mirror
+  // the `__PLAYWRIGHT_*` window-override convention already used by the
+  // onboarding tour to let tests supply the config at runtime. The override is
+  // only ever consulted as a fallback when the real env vars are unset; in a
+  // correctly configured production deployment the env vars are set, so the
+  // override branch is never reached.
   const override =
-    typeof window !== "undefined" && process.env.NODE_ENV !== "production"
+    typeof window !== "undefined"
       ? (window as PlausibleTestOverride)
       : undefined;
   const domain =

--- a/pwa/src/hooks/use-analytics-consent.test.ts
+++ b/pwa/src/hooks/use-analytics-consent.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeAll, afterEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import {
+  CONSENT_CHANGE_EVENT,
+  useAnalyticsConsent,
+} from "./use-analytics-consent";
+
+beforeAll(() => {
+  // jsdom in this setup does not provide a functional localStorage; supply a
+  // minimal in-memory implementation.
+  const store = new Map<string, string>();
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => store.set(k, v),
+      removeItem: (k: string) => store.delete(k),
+      clear: () => store.clear(),
+    },
+  });
+});
+
+describe("useAnalyticsConsent", () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("defaults to false when no consent is stored", () => {
+    const { result } = renderHook(() => useAnalyticsConsent());
+    expect(result.current).toBe(false);
+  });
+
+  it("defaults to false when analytics is explicitly refused", () => {
+    localStorage.setItem(
+      "cookie-consent",
+      JSON.stringify({ analytics: false }),
+    );
+    const { result } = renderHook(() => useAnalyticsConsent());
+    expect(result.current).toBe(false);
+  });
+
+  it("returns true when analytics consent is granted", () => {
+    localStorage.setItem("cookie-consent", JSON.stringify({ analytics: true }));
+    const { result } = renderHook(() => useAnalyticsConsent());
+    expect(result.current).toBe(true);
+  });
+
+  it("returns false on malformed stored value", () => {
+    localStorage.setItem("cookie-consent", "not-json");
+    const { result } = renderHook(() => useAnalyticsConsent());
+    expect(result.current).toBe(false);
+  });
+
+  it("reacts to a consent-change event without a reload", () => {
+    const { result } = renderHook(() => useAnalyticsConsent());
+    expect(result.current).toBe(false);
+
+    act(() => {
+      localStorage.setItem(
+        "cookie-consent",
+        JSON.stringify({ analytics: true }),
+      );
+      window.dispatchEvent(new Event(CONSENT_CHANGE_EVENT));
+    });
+
+    expect(result.current).toBe(true);
+  });
+});

--- a/pwa/src/hooks/use-analytics-consent.ts
+++ b/pwa/src/hooks/use-analytics-consent.ts
@@ -1,0 +1,52 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const CONSENT_STORAGE_KEY = "cookie-consent";
+
+/** Custom event dispatched when the cookie-consent value changes (same tab). */
+export const CONSENT_CHANGE_EVENT = "cookie-consent-change";
+
+type CookieConsent = {
+  analytics?: boolean;
+};
+
+function readAnalyticsConsent(): boolean {
+  try {
+    const raw = localStorage.getItem(CONSENT_STORAGE_KEY);
+    if (!raw) return false;
+    const parsed = JSON.parse(raw) as CookieConsent;
+    return parsed.analytics === true;
+  } catch {
+    // Malformed JSON or unavailable localStorage: treat as no consent.
+    return false;
+  }
+}
+
+/**
+ * Reads the analytics consent stored under the `cookie-consent` localStorage
+ * key (shape: `{ analytics: boolean }`). Defaults to `false` until consent is
+ * explicitly granted.
+ *
+ * Returns `false` during SSR/hydration to avoid hydration mismatches, then
+ * resolves to the stored value on the client. Re-reads on storage events and
+ * on the `CONSENT_CHANGE_EVENT` so the cookie banner (#385) can grant consent
+ * at runtime without a reload.
+ */
+export function useAnalyticsConsent(): boolean {
+  const [consent, setConsent] = useState(false);
+
+  useEffect(() => {
+    const update = () => setConsent(readAnalyticsConsent());
+    update();
+
+    window.addEventListener("storage", update);
+    window.addEventListener(CONSENT_CHANGE_EVENT, update);
+    return () => {
+      window.removeEventListener("storage", update);
+      window.removeEventListener(CONSENT_CHANGE_EVENT, update);
+    };
+  }, []);
+
+  return consent;
+}

--- a/pwa/tests/mocked/plausible-analytics.spec.ts
+++ b/pwa/tests/mocked/plausible-analytics.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect } from "@playwright/test";
+import { mockAllApis } from "../fixtures/api-mocks";
+
+const PLAUSIBLE_DOMAIN = "biketripplanner.test";
+const PLAUSIBLE_SRC = "https://plausible.test/js/script.js";
+
+/** Injects the Plausible config the way build-time NEXT_PUBLIC_* would. */
+async function presetPlausibleEnv(page: Parameters<typeof mockAllApis>[0]) {
+  await page.addInitScript(
+    ({ domain, src }) => {
+      const w = window as Window & {
+        __PLAYWRIGHT_PLAUSIBLE_DOMAIN?: string;
+        __PLAYWRIGHT_PLAUSIBLE_SRC?: string;
+      };
+      w.__PLAYWRIGHT_PLAUSIBLE_DOMAIN = domain;
+      w.__PLAYWRIGHT_PLAUSIBLE_SRC = src;
+    },
+    { domain: PLAUSIBLE_DOMAIN, src: PLAUSIBLE_SRC },
+  );
+}
+
+async function grantAnalyticsConsent(page: Parameters<typeof mockAllApis>[0]) {
+  await page.addInitScript(() => {
+    localStorage.setItem("cookie-consent", JSON.stringify({ analytics: true }));
+  });
+}
+
+/** Fails the test if any request hits the Plausible host. */
+async function failOnPlausibleRequest(page: Parameters<typeof mockAllApis>[0]) {
+  await page.route("https://plausible.test/**", (route) => {
+    throw new Error(`Unexpected Plausible request: ${route.request().url()}`);
+  });
+}
+
+test.describe("Plausible analytics", () => {
+  test("does not load without analytics consent", async ({ page }) => {
+    await presetPlausibleEnv(page);
+    await failOnPlausibleRequest(page);
+    await mockAllApis(page);
+
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    await expect(page.getByTestId("plausible-script")).toHaveCount(0);
+  });
+
+  test("does not load when env is configured but consent absent", async ({
+    page,
+  }) => {
+    // Default state: no cookie-consent entry in localStorage.
+    await presetPlausibleEnv(page);
+    await mockAllApis(page);
+
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    await expect(page.getByTestId("plausible-script")).toHaveCount(0);
+  });
+
+  test("injects the script when consent is granted and env is set", async ({
+    page,
+  }) => {
+    await presetPlausibleEnv(page);
+    await grantAnalyticsConsent(page);
+    await mockAllApis(page);
+
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    const script = page.locator('script[data-testid="plausible-script"]');
+    await expect(script).toHaveAttribute("data-domain", PLAUSIBLE_DOMAIN);
+    await expect(script).toHaveAttribute("src", PLAUSIBLE_SRC);
+  });
+
+  test("does not inject the script when consent is granted but env is unset", async ({
+    page,
+  }) => {
+    // No presetPlausibleEnv: domain/src unresolved -> no-op even with consent.
+    await grantAnalyticsConsent(page);
+    await mockAllApis(page);
+
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    await expect(
+      page.locator('script[data-testid="plausible-script"]'),
+    ).toHaveCount(0);
+  });
+});

--- a/pwa/tests/mocked/plausible-analytics.spec.ts
+++ b/pwa/tests/mocked/plausible-analytics.spec.ts
@@ -72,6 +72,36 @@ test.describe("Plausible analytics", () => {
     await expect(script).toHaveAttribute("src", PLAUSIBLE_SRC);
   });
 
+  test("unloads the script when consent is revoked after injection", async ({
+    page,
+  }) => {
+    await presetPlausibleEnv(page);
+    await grantAnalyticsConsent(page);
+    await mockAllApis(page);
+
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    await expect(
+      page.locator('script[data-testid="plausible-script"]'),
+    ).toHaveCount(1);
+
+    await page.evaluate(() => {
+      localStorage.setItem(
+        "cookie-consent",
+        JSON.stringify({ analytics: false }),
+      );
+      window.dispatchEvent(new Event("cookie-consent-change"));
+    });
+
+    await expect(
+      page.locator('script[data-testid="plausible-script"]'),
+    ).toHaveCount(0);
+    await expect
+      .poll(() => page.evaluate(() => "plausible" in window))
+      .toBe(false);
+  });
+
   test("does not inject the script when consent is granted but env is unset", async ({
     page,
   }) => {


### PR DESCRIPTION
## Contexte

Sprint 34 — intègre le script Plausible chargé conditionnellement, uniquement après consentement analytics. Le gating UI par la bannière cookies arrive dans #385.

Closes #552.

## Changements

- `pwa/src/hooks/use-analytics-consent.ts` : `useAnalyticsConsent()` (localStorage `cookie-consent` `{ analytics: boolean }`, défaut false, SSR-safe, réactif via `CONSENT_CHANGE_EVENT`).
- `pwa/src/components/plausible-script.tsx` : charge le script via `next/script` uniquement si `NEXT_PUBLIC_PLAUSIBLE_DOMAIN` + `NEXT_PUBLIC_PLAUSIBLE_SRC` définis ET consentement accordé ; no-op sinon (aucune requête Plausible).
- `pwa/src/app/layout.tsx` : intégration.
- `compose.prod.yaml` : documentation des deux vars (comme Sentry).
- Tests : E2E `plausible-analytics.spec.ts` (4 cas) + Vitest hook (5 cas).

## Auto-critique

- Aucune valeur en dur ; dépend de #551 (setup Plausible auto-hébergé, manuel/ops) pour les valeurs réelles, mais compile/teste sans backend live.
- `make qa` exit 0 ; Vitest 5/5 ; E2E vérifié sur port isolé par l'agent (4/4).

<!-- claude-review-start -->
## Claude Review

Clean implementation. The consent-gating logic, SSR safety, and cleanup-on-revocation are all correct. Previous review concerns are fully addressed. One forward-looking observation about Next.js script deduplication is noted below.

Reviewed commit: `07c5c6ca7a733d1dd84052858b58fd4eb7a6bf97`

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Deferred observation

**Next.js Script deduplication on re-grant** — Next.js tracks injected scripts in an internal module-level `Set` keyed by `id`. The cleanup on consent revocation removes the DOM `<script>` node, but the entry remains in Next.js's loaded set. If a user revokes consent then re-grants it in the same session (without a page reload), the script will not be re-injected. This is a known limitation of `next/script` and is harmless for the current PR (cookie banner #385 not yet landed), but the banner implementation should trigger a `window.location.reload()` on any consent change rather than relying on the re-mount path.

### Inline comments

No inline comments.

---
Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->