### PR TITLE
feat(pwa): add account settings page with rgpd and danger zone

### DIFF
--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -936,8 +936,8 @@
       "deleteAccount": "Delete my account",
       "dialogTitle": "Delete your account?",
       "dialogDescription": "This action is permanent. All your trips and preferences will be deleted and cannot be recovered.",
-      "confirmLabel": "Type \"SUPPRIMER\" to confirm",
-      "keyword": "SUPPRIMER",
+      "confirmLabel": "Type \"DELETE\" to confirm",
+      "keyword": "DELETE",
       "deleteFailed": "Could not delete your account."
     },
     "logout": {

--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -943,7 +943,8 @@
     "logout": {
       "title": "Log out",
       "description": "You will be logged out of this device.",
-      "button": "Log out"
+      "button": "Log out",
+      "logoutFailed": "Logout failed. Please try again."
     }
   },
   "errorPages": {

--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -900,7 +900,51 @@
     "ctaCreateTrip": "Create a trip"
   },
   "navigation": {
-    "myTrips": "My trips"
+    "myTrips": "My trips",
+    "accountSettings": "My account"
+  },
+  "accountSettings": {
+    "title": "My account",
+    "subtitle": "Manage your account, preferences and data.",
+    "account": {
+      "title": "My account",
+      "description": "Email address linked to your account.",
+      "emailLabel": "Email address",
+      "changeEmail": "Change via magic link",
+      "changeEmailSent": "A change link has been sent to your email.",
+      "changeEmailFailed": "Could not send the change link."
+    },
+    "preferences": {
+      "title": "Preferences",
+      "description": "Customise the language and appearance of the app.",
+      "languageLabel": "Language",
+      "themeLabel": "Theme",
+      "themeLight": "Light",
+      "themeDark": "Dark",
+      "themeSystem": "Auto"
+    },
+    "data": {
+      "title": "My data",
+      "description": "Download an archive of your personal data (GDPR).",
+      "download": "Download my data (JSON)",
+      "downloading": "Downloading...",
+      "downloadFailed": "Could not download your data."
+    },
+    "danger": {
+      "title": "Danger zone",
+      "description": "Deleting your account is permanent and cannot be undone.",
+      "deleteAccount": "Delete my account",
+      "dialogTitle": "Delete your account?",
+      "dialogDescription": "This action is permanent. All your trips and preferences will be deleted and cannot be recovered.",
+      "confirmLabel": "Type \"SUPPRIMER\" to confirm",
+      "keyword": "SUPPRIMER",
+      "deleteFailed": "Could not delete your account."
+    },
+    "logout": {
+      "title": "Log out",
+      "description": "You will be logged out of this device.",
+      "button": "Log out"
+    }
   },
   "errorPages": {
     "notFound": {

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -943,7 +943,8 @@
     "logout": {
       "title": "Déconnexion",
       "description": "Vous serez déconnecté de cet appareil.",
-      "button": "Se déconnecter"
+      "button": "Se déconnecter",
+      "logoutFailed": "Échec de la déconnexion. Veuillez réessayer."
     }
   },
   "errorPages": {

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -900,7 +900,51 @@
     "ctaCreateTrip": "Créer un itinéraire"
   },
   "navigation": {
-    "myTrips": "Mes voyages"
+    "myTrips": "Mes voyages",
+    "accountSettings": "Mon compte"
+  },
+  "accountSettings": {
+    "title": "Mon compte",
+    "subtitle": "Gérez votre compte, vos préférences et vos données.",
+    "account": {
+      "title": "Mon compte",
+      "description": "Adresse e-mail associée à votre compte.",
+      "emailLabel": "Adresse e-mail",
+      "changeEmail": "Modifier via magic link",
+      "changeEmailSent": "Un lien de modification vous a été envoyé par e-mail.",
+      "changeEmailFailed": "Impossible d'envoyer le lien de modification."
+    },
+    "preferences": {
+      "title": "Préférences",
+      "description": "Personnalisez la langue et l'apparence de l'application.",
+      "languageLabel": "Langue",
+      "themeLabel": "Thème",
+      "themeLight": "Clair",
+      "themeDark": "Sombre",
+      "themeSystem": "Auto"
+    },
+    "data": {
+      "title": "Mes données",
+      "description": "Téléchargez une archive de vos données personnelles (RGPD).",
+      "download": "Télécharger mes données (JSON)",
+      "downloading": "Téléchargement...",
+      "downloadFailed": "Impossible de télécharger vos données."
+    },
+    "danger": {
+      "title": "Zone de danger",
+      "description": "La suppression de votre compte est définitive et irréversible.",
+      "deleteAccount": "Supprimer mon compte",
+      "dialogTitle": "Supprimer votre compte ?",
+      "dialogDescription": "Cette action est définitive. Tous vos voyages et préférences seront supprimés et ne pourront pas être récupérés.",
+      "confirmLabel": "Tapez « SUPPRIMER » pour confirmer",
+      "keyword": "SUPPRIMER",
+      "deleteFailed": "Impossible de supprimer votre compte."
+    },
+    "logout": {
+      "title": "Déconnexion",
+      "description": "Vous serez déconnecté de cet appareil.",
+      "button": "Se déconnecter"
+    }
   },
   "errorPages": {
     "notFound": {

--- a/pwa/src/app/account/settings/page.tsx
+++ b/pwa/src/app/account/settings/page.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import Link from "next/link";
+import { useTranslations } from "next-intl";
+import { Bike } from "lucide-react";
+import { AccountSection } from "@/components/account/account-section";
+import { PreferencesSection } from "@/components/account/preferences-section";
+import { DataSection } from "@/components/account/data-section";
+import { DangerZoneSection } from "@/components/account/danger-zone-section";
+import { LogoutSection } from "@/components/account/logout-section";
+
+/**
+ * Account settings page (#383).
+ *
+ * Reachable from the top-bar profile button. Protected by the global
+ * {@link AuthGuard}: `/account/settings` is not a public path, so an
+ * unauthenticated visitor is redirected to `/login`.
+ *
+ * Sections: account (email + magic-link change), preferences (language +
+ * theme), data export (GDPR), danger zone (account deletion) and logout.
+ */
+export default function AccountSettingsPage() {
+  const t = useTranslations("accountSettings");
+
+  return (
+    <div className="min-h-screen bg-background">
+      <header className="sticky top-0 z-30 w-full border-b border-border bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+        <div className="max-w-[800px] mx-auto flex items-center gap-2 px-4 md:px-6 h-14">
+          <Link
+            href="/"
+            className="flex items-center gap-2 font-bold text-base text-brand hover:opacity-80 transition-opacity"
+          >
+            <Bike className="h-5 w-5" aria-hidden="true" />
+            <span className="hidden sm:inline">Bike Trip Planner</span>
+          </Link>
+        </div>
+      </header>
+
+      <main
+        className="max-w-[800px] mx-auto px-4 md:px-6 py-8 md:py-12"
+        data-testid="account-settings-page"
+      >
+        <div className="mb-8">
+          <h1 className="font-serif text-2xl font-semibold tracking-tight">
+            {t("title")}
+          </h1>
+          <p className="text-muted-foreground text-sm mt-1">{t("subtitle")}</p>
+        </div>
+
+        <div className="flex flex-col gap-6">
+          <AccountSection />
+          <PreferencesSection />
+          <DataSection />
+          <DangerZoneSection />
+          <LogoutSection />
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/pwa/src/components/account/account-section.tsx
+++ b/pwa/src/components/account/account-section.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import { Loader2, Mail } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { toast } from "@/components/ui/sonner";
+import { useAuthStore } from "@/store/auth-store";
+
+/**
+ * "Mon compte" section: shows the current email and lets the user trigger an
+ * email change through the existing passwordless magic-link flow.
+ */
+export function AccountSection() {
+  const t = useTranslations("accountSettings.account");
+  const email = useAuthStore((s) => s.user?.email ?? "");
+  const requestMagicLink = useAuthStore((s) => s.requestMagicLink);
+  const [isSending, setIsSending] = useState(false);
+
+  async function handleChangeEmail() {
+    if (!email) return;
+    setIsSending(true);
+    try {
+      await requestMagicLink(email);
+      toast.success(t("changeEmailSent"));
+    } catch {
+      toast.error(t("changeEmailFailed"));
+    } finally {
+      setIsSending(false);
+    }
+  }
+
+  return (
+    <Card data-testid="account-section">
+      <CardHeader>
+        <CardTitle>{t("title")}</CardTitle>
+        <CardDescription>{t("description")}</CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+        <div className="flex flex-col gap-1">
+          <span className="text-sm font-medium text-muted-foreground">
+            {t("emailLabel")}
+          </span>
+          <span className="text-sm font-medium" data-testid="account-email">
+            {email}
+          </span>
+        </div>
+        <Button
+          variant="outline"
+          className="gap-2 cursor-pointer"
+          onClick={() => void handleChangeEmail()}
+          disabled={isSending || !email}
+          data-testid="change-email-button"
+        >
+          {isSending ? (
+            <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+          ) : (
+            <Mail className="h-4 w-4" aria-hidden="true" />
+          )}
+          {t("changeEmail")}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/pwa/src/components/account/danger-zone-section.tsx
+++ b/pwa/src/components/account/danger-zone-section.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import { useRouter } from "next/navigation";
+import { Trash2 } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { DestructiveDialog } from "@/components/destructive-dialog";
+import { toast } from "@/components/ui/sonner";
+import { deleteAccount } from "@/lib/api/client";
+import { useAuthStore } from "@/store/auth-store";
+
+/**
+ * "Zone de danger" section: account deletion behind a destructive dialog that
+ * requires typing the keyword `SUPPRIMER`. On success the user is logged out
+ * and redirected home.
+ */
+export function DangerZoneSection() {
+  const t = useTranslations("accountSettings.danger");
+  const router = useRouter();
+  const logout = useAuthStore((s) => s.logout);
+  const [open, setOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  async function handleDelete() {
+    setIsDeleting(true);
+    try {
+      const ok = await deleteAccount();
+      if (!ok) {
+        toast.error(t("deleteFailed"));
+        return;
+      }
+      await logout();
+      router.replace("/");
+    } catch {
+      toast.error(t("deleteFailed"));
+    } finally {
+      setIsDeleting(false);
+      setOpen(false);
+    }
+  }
+
+  return (
+    <Card className="border-destructive" data-testid="danger-zone-section">
+      <CardHeader>
+        <CardTitle className="text-destructive">{t("title")}</CardTitle>
+        <CardDescription>{t("description")}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Button
+          variant="destructive"
+          className="gap-2 cursor-pointer"
+          onClick={() => setOpen(true)}
+          data-testid="delete-account-button"
+        >
+          <Trash2 className="h-4 w-4" aria-hidden="true" />
+          {t("deleteAccount")}
+        </Button>
+
+        <DestructiveDialog
+          open={open}
+          onOpenChange={setOpen}
+          title={t("dialogTitle")}
+          description={t("dialogDescription")}
+          confirmationKeyword={t("keyword")}
+          confirmationLabel={t("confirmLabel")}
+          confirmLabel={t("deleteAccount")}
+          onConfirm={handleDelete}
+          isLoading={isDeleting}
+          data-testid="delete-account-dialog"
+        />
+      </CardContent>
+    </Card>
+  );
+}

--- a/pwa/src/components/account/danger-zone-section.tsx
+++ b/pwa/src/components/account/danger-zone-section.tsx
@@ -47,6 +47,8 @@ export function DangerZoneSection() {
     // API call succeeds, so a logout failure never masks a successful delete.
     try {
       await logout();
+    } catch {
+      // Account is already gone; a failed server logout must not block the redirect.
     } finally {
       setOpen(false);
       router.replace("/");

--- a/pwa/src/components/account/danger-zone-section.tsx
+++ b/pwa/src/components/account/danger-zone-section.tsx
@@ -38,12 +38,12 @@ export function DangerZoneSection() {
         return;
       }
       await logout();
+      setOpen(false);
       router.replace("/");
     } catch {
       toast.error(t("deleteFailed"));
     } finally {
       setIsDeleting(false);
-      setOpen(false);
     }
   }
 

--- a/pwa/src/components/account/danger-zone-section.tsx
+++ b/pwa/src/components/account/danger-zone-section.tsx
@@ -37,13 +37,19 @@ export function DangerZoneSection() {
         toast.error(t("deleteFailed"));
         return;
       }
-      await logout();
-      setOpen(false);
-      router.replace("/");
     } catch {
       toast.error(t("deleteFailed"));
+      return;
     } finally {
       setIsDeleting(false);
+    }
+    // Account deleted — log out and redirect regardless of whether the logout
+    // API call succeeds, so a logout failure never masks a successful delete.
+    try {
+      await logout();
+    } finally {
+      setOpen(false);
+      router.replace("/");
     }
   }
 

--- a/pwa/src/components/account/data-section.tsx
+++ b/pwa/src/components/account/data-section.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import { Download, Loader2 } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { toast } from "@/components/ui/sonner";
+import { downloadAccountExport } from "@/lib/api/client";
+
+/**
+ * "Mes données (RGPD)" section: downloads the user's full data archive as JSON
+ * via `GET /users/me/export`.
+ */
+export function DataSection() {
+  const t = useTranslations("accountSettings.data");
+  const [isDownloading, setIsDownloading] = useState(false);
+
+  async function handleDownload() {
+    setIsDownloading(true);
+    try {
+      await downloadAccountExport();
+    } catch {
+      toast.error(t("downloadFailed"));
+    } finally {
+      setIsDownloading(false);
+    }
+  }
+
+  return (
+    <Card data-testid="data-section">
+      <CardHeader>
+        <CardTitle>{t("title")}</CardTitle>
+        <CardDescription>{t("description")}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Button
+          variant="outline"
+          className="gap-2 cursor-pointer"
+          onClick={() => void handleDownload()}
+          disabled={isDownloading}
+          data-testid="export-data-button"
+        >
+          {isDownloading ? (
+            <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+          ) : (
+            <Download className="h-4 w-4" aria-hidden="true" />
+          )}
+          {isDownloading ? t("downloading") : t("download")}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/pwa/src/components/account/logout-section.tsx
+++ b/pwa/src/components/account/logout-section.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import { useRouter } from "next/navigation";
+import { Loader2, LogOut } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { useAuthStore } from "@/store/auth-store";
+
+/**
+ * "Déconnexion" section: logs the user out and redirects home.
+ */
+export function LogoutSection() {
+  const t = useTranslations("accountSettings.logout");
+  const router = useRouter();
+  const logout = useAuthStore((s) => s.logout);
+  const [isLoggingOut, setIsLoggingOut] = useState(false);
+
+  async function handleLogout() {
+    setIsLoggingOut(true);
+    try {
+      await logout();
+      router.replace("/");
+    } finally {
+      setIsLoggingOut(false);
+    }
+  }
+
+  return (
+    <Card data-testid="logout-section">
+      <CardHeader>
+        <CardTitle>{t("title")}</CardTitle>
+        <CardDescription>{t("description")}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Button
+          variant="outline"
+          className="gap-2 cursor-pointer"
+          onClick={() => void handleLogout()}
+          disabled={isLoggingOut}
+          data-testid="logout-button"
+        >
+          {isLoggingOut ? (
+            <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+          ) : (
+            <LogOut className="h-4 w-4" aria-hidden="true" />
+          )}
+          {t("button")}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/pwa/src/components/account/logout-section.tsx
+++ b/pwa/src/components/account/logout-section.tsx
@@ -12,6 +12,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { toast } from "@/components/ui/sonner";
 import { useAuthStore } from "@/store/auth-store";
 
 /**
@@ -28,6 +29,8 @@ export function LogoutSection() {
     try {
       await logout();
       router.replace("/");
+    } catch {
+      toast.error(t("logoutFailed"));
     } finally {
       setIsLoggingOut(false);
     }

--- a/pwa/src/components/account/preferences-section.tsx
+++ b/pwa/src/components/account/preferences-section.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useSyncExternalStore, useTransition } from "react";
+import { useLocale, useTranslations } from "next-intl";
+import { useRouter } from "next/navigation";
+import { useTheme } from "next-themes";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { SUPPORTED_LOCALES, type SupportedLocale } from "@/i18n/locale";
+import { setLocale } from "@/i18n/set-locale";
+
+const LOCALE_LABELS: Record<SupportedLocale, string> = {
+  fr: "Français",
+  en: "English",
+};
+
+const THEME_OPTIONS = ["light", "dark", "system"] as const;
+type ThemeOption = (typeof THEME_OPTIONS)[number];
+
+const emptySubscribe = () => () => {};
+const getTrue = () => true;
+const getFalse = () => false;
+
+/**
+ * "Préférences" section: language (synced with the top-bar locale switcher via
+ * the `locale` cookie + next-intl) and theme (Light/Dark/Auto synced with
+ * next-themes).
+ */
+export function PreferencesSection() {
+  const t = useTranslations("accountSettings.preferences");
+  const currentLocale = useLocale();
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const { theme, setTheme } = useTheme();
+  const mounted = useSyncExternalStore(emptySubscribe, getTrue, getFalse);
+
+  function handleLocaleChange(locale: SupportedLocale) {
+    if (locale === currentLocale) return;
+    startTransition(() => {
+      setLocale(locale);
+      router.refresh();
+    });
+  }
+
+  const themeLabels: Record<ThemeOption, string> = {
+    light: t("themeLight"),
+    dark: t("themeDark"),
+    system: t("themeSystem"),
+  };
+
+  return (
+    <Card data-testid="preferences-section">
+      <CardHeader>
+        <CardTitle>{t("title")}</CardTitle>
+        <CardDescription>{t("description")}</CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-6">
+        {/* Language */}
+        <div
+          className="flex flex-col gap-2"
+          role="group"
+          aria-label={t("languageLabel")}
+        >
+          <span className="text-sm font-medium">{t("languageLabel")}</span>
+          <div className="flex gap-2">
+            {SUPPORTED_LOCALES.map((locale) => {
+              const isActive = locale === currentLocale;
+              return (
+                <Button
+                  key={locale}
+                  variant={isActive ? "default" : "outline"}
+                  size="sm"
+                  className={cn(
+                    "cursor-pointer",
+                    isActive && "pointer-events-none",
+                  )}
+                  disabled={isPending}
+                  onClick={() => handleLocaleChange(locale)}
+                  aria-pressed={isActive}
+                  data-testid={`settings-locale-${locale}`}
+                >
+                  {LOCALE_LABELS[locale]}
+                </Button>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Theme */}
+        <div
+          className="flex flex-col gap-2"
+          role="group"
+          aria-label={t("themeLabel")}
+        >
+          <span className="text-sm font-medium">{t("themeLabel")}</span>
+          <div className="flex gap-2">
+            {THEME_OPTIONS.map((option) => {
+              const isActive = mounted && theme === option;
+              return (
+                <Button
+                  key={option}
+                  variant={isActive ? "default" : "outline"}
+                  size="sm"
+                  className={cn(
+                    "cursor-pointer",
+                    isActive && "pointer-events-none",
+                  )}
+                  disabled={!mounted}
+                  onClick={() => setTheme(option)}
+                  aria-pressed={isActive}
+                  data-testid={`settings-theme-${option}`}
+                >
+                  {themeLabels[option]}
+                </Button>
+              );
+            })}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/pwa/src/components/trip-planner.tsx
+++ b/pwa/src/components/trip-planner.tsx
@@ -11,7 +11,15 @@ import {
 import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { Settings, HelpCircle, Loader2, X, Share2, Map } from "lucide-react";
+import {
+  Settings,
+  HelpCircle,
+  Loader2,
+  X,
+  Share2,
+  Map,
+  User,
+} from "lucide-react";
 import { CardSelection } from "@/components/card-selection";
 import { GpxDropZone } from "@/components/gpx-drop-zone";
 import { TripLockedBanner } from "@/components/trip-locked-banner";
@@ -466,6 +474,19 @@ export function TripPlanner({
         data-testid="config-open-button"
       >
         <Settings className="h-4 w-4" />
+      </Button>
+      <Button
+        asChild
+        variant="ghost"
+        size="icon"
+        className="h-9 w-9 cursor-pointer"
+        title={tNav("accountSettings")}
+        aria-label={tNav("accountSettings")}
+        data-testid="account-settings-link"
+      >
+        <Link href="/account/settings">
+          <User className="h-4 w-4" />
+        </Link>
       </Button>
     </div>
   );

--- a/pwa/src/lib/api/client.ts
+++ b/pwa/src/lib/api/client.ts
@@ -737,6 +737,35 @@ export async function downloadStageFile(
 }
 
 /**
+ * GDPR right to portability (#549, #383): download the authenticated user's
+ * full data archive (`GET /users/me/export`) as a JSON file and trigger a
+ * browser save dialog.
+ *
+ * @throws {Error} When the server responds with a non-2xx status.
+ */
+export async function downloadAccountExport(): Promise<void> {
+  const res = await apiFetch(`${API_URL}/users/me/export`, {
+    headers: { Accept: "application/json" },
+  });
+  if (!res.ok) throw new Error(`Export failed with status ${res.status}`);
+  const blob = await res.blob();
+  const today = new Date().toISOString().slice(0, 10);
+  triggerBlobDownload(blob, `bike-trip-planner-export-${today}.json`);
+}
+
+/**
+ * GDPR right to erasure (#549, #383): permanently delete the authenticated
+ * user's account (`DELETE /users/me`). The backend anonymises the account,
+ * purges trips and preferences, and revokes refresh tokens.
+ *
+ * @returns true on HTTP 204, false otherwise.
+ */
+export async function deleteAccount(): Promise<boolean> {
+  const { response } = await apiClient.DELETE("/users/me");
+  return response.ok;
+}
+
+/**
  * Build the frontend share URL from a short code.
  */
 export function buildShareUrl(shortCode: string): string {

--- a/pwa/src/lib/api/client.ts
+++ b/pwa/src/lib/api/client.ts
@@ -745,7 +745,7 @@ export async function downloadStageFile(
  */
 export async function downloadAccountExport(): Promise<void> {
   const res = await apiFetch(`${API_URL}/users/me/export`, {
-    headers: { Accept: "application/json" },
+    headers: { Accept: "application/ld+json" },
   });
   if (!res.ok) throw new Error(`Export failed with status ${res.status}`);
   const blob = await res.blob();

--- a/pwa/src/lib/api/schema.d.ts
+++ b/pwa/src/lib/api/schema.d.ts
@@ -44,6 +44,46 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/users/me": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Removes the Account resource.
+         * @description Removes the Account resource.
+         */
+        delete: operations["api_usersme_delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/users/me/export": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Retrieves a Account resource.
+         * @description Retrieves a Account resource.
+         */
+        get: operations["api_usersmeexport_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/auth/logout": {
         parameters: {
             query?: never;
@@ -620,6 +660,18 @@ export interface components {
             };
             isLocked?: boolean;
         };
+        /**
+         * @description GDPR self-service operations for the authenticated user (#549).
+         *
+         *     - DELETE /users/me        right to erasure: anonymise the account, purge
+         *       trips and preferences, revoke refresh tokens
+         *     - GET    /users/me/export right to portability: download a JSON archive of
+         *       the profile, trips and their preferences
+         *
+         *     The current user is always resolved from the security token, never from a
+         *     URL identifier, so there is no IDOR surface.
+         */
+        "Account.jsonld": components["schemas"]["HydraItemBaseSchema"] & Record<string, never>;
         "Alert.fit": {
             /** @enum {string} */
             type?: "critical" | "warning" | "nudge";
@@ -1717,6 +1769,88 @@ export interface operations {
                     "application/ld+json": components["schemas"]["ConstraintViolation.jsonld"];
                     "application/problem+json": components["schemas"]["ConstraintViolation"];
                     "application/json": components["schemas"]["ConstraintViolation"];
+                };
+            };
+        };
+    };
+    api_usersme_delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Account resource deleted */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["Error.jsonld"];
+                    "application/problem+json": components["schemas"]["Error"];
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["Error.jsonld"];
+                    "application/problem+json": components["schemas"]["Error"];
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    api_usersmeexport_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Account resource */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["Account.jsonld"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["Error.jsonld"];
+                    "application/problem+json": components["schemas"]["Error"];
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["Error.jsonld"];
+                    "application/problem+json": components["schemas"]["Error"];
+                    "application/json": components["schemas"]["Error"];
                 };
             };
         };

--- a/pwa/src/store/auth-store.ts
+++ b/pwa/src/store/auth-store.ts
@@ -105,22 +105,30 @@ export const useAuthStore = create<AuthState>()(
 
     logout: async () => {
       const { accessToken } = get();
+      let serverLogoutFailed = false;
       try {
-        await fetch(`${API_URL}/auth/logout`, {
+        const res = await fetch(`${API_URL}/auth/logout`, {
           method: "POST",
           headers: {
             ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
           },
           credentials: "include",
         });
+        serverLogoutFailed = !res.ok;
       } catch {
-        // Ignore network errors during logout — clear local state regardless
+        serverLogoutFailed = true;
       }
+      // Clear local state regardless — the session is gone on this device.
       set((state) => {
         state.accessToken = null;
         state.user = null;
         state.isAuthenticated = false;
       });
+      // Surface a server-side failure so callers can warn the user the remote
+      // session may not have been revoked (e.g. keep them on the page).
+      if (serverLogoutFailed) {
+        throw new Error("Server-side logout failed");
+      }
     },
 
     silentRefresh: (): Promise<boolean> => {

--- a/pwa/tests/mocked/account-settings.spec.ts
+++ b/pwa/tests/mocked/account-settings.spec.ts
@@ -1,0 +1,152 @@
+import { test, expect } from "@playwright/test";
+import { FAKE_JWT_TOKEN } from "../fixtures/api-mocks";
+
+/**
+ * E2E coverage for the account settings page (#383).
+ *
+ * The page is auth-protected: AuthGuard runs a silent refresh on mount, so we
+ * mock POST /auth/refresh with a fake JWT to establish an authenticated
+ * session before navigating to /account/settings.
+ */
+async function mockAuthenticated(page: import("@playwright/test").Page) {
+  await page.route("**/auth/refresh", (route, request) => {
+    if (request.method() !== "POST") return route.fallback();
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ token: FAKE_JWT_TOKEN }),
+    });
+  });
+  await page.route("**/.well-known/mercure*", (route) => route.abort());
+}
+
+test.describe("Account settings", () => {
+  test("renders all sections for an authenticated user", async ({ page }) => {
+    await mockAuthenticated(page);
+
+    await page.goto("/account/settings");
+    await page.waitForLoadState("networkidle");
+
+    await expect(page.getByTestId("account-settings-page")).toBeVisible();
+    await expect(page.getByTestId("account-section")).toBeVisible();
+    await expect(page.getByTestId("preferences-section")).toBeVisible();
+    await expect(page.getByTestId("data-section")).toBeVisible();
+    await expect(page.getByTestId("danger-zone-section")).toBeVisible();
+    await expect(page.getByTestId("logout-section")).toBeVisible();
+    // Email from the fake JWT payload (username claim)
+    await expect(page.getByTestId("account-email")).toHaveText(
+      "test@example.com",
+    );
+  });
+
+  test("unauthenticated user is redirected to login", async ({ page }) => {
+    await page.route("**/auth/refresh", (route, request) => {
+      if (request.method() !== "POST") return route.fallback();
+      return route.fulfill({ status: 401, body: "" });
+    });
+
+    await page.goto("/account/settings");
+    await page.waitForURL(/\/login/, { timeout: 5000 });
+    await expect(page).toHaveURL(/\/login/);
+  });
+
+  test("export button calls GET /users/me/export", async ({ page }) => {
+    await mockAuthenticated(page);
+
+    let exportCalled = false;
+    await page.route("**/users/me/export", (route, request) => {
+      if (request.method() !== "GET") return route.fallback();
+      exportCalled = true;
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        headers: {
+          "Content-Disposition":
+            'attachment; filename="bike-trip-planner-export.json"',
+        },
+        body: JSON.stringify({ profile: {}, trips: [] }),
+      });
+    });
+
+    await page.goto("/account/settings");
+    await page.waitForLoadState("networkidle");
+
+    await page.getByTestId("export-data-button").click();
+    await expect.poll(() => exportCalled).toBe(true);
+  });
+
+  test("change email button triggers a magic link request", async ({
+    page,
+  }) => {
+    await mockAuthenticated(page);
+
+    let linkRequested = false;
+    await page.route("**/auth/request-link", (route, request) => {
+      if (request.method() !== "POST") return route.fallback();
+      linkRequested = true;
+      return route.fulfill({ status: 202, body: "" });
+    });
+
+    await page.goto("/account/settings");
+    await page.waitForLoadState("networkidle");
+
+    await page.getByTestId("change-email-button").click();
+    await expect.poll(() => linkRequested).toBe(true);
+  });
+
+  test("delete account requires typing SUPPRIMER then logs out", async ({
+    page,
+  }) => {
+    await mockAuthenticated(page);
+
+    let deleteCalled = false;
+    await page.route("**/users/me", (route, request) => {
+      if (request.method() !== "DELETE") return route.fallback();
+      deleteCalled = true;
+      return route.fulfill({ status: 204, body: "" });
+    });
+    await page.route("**/auth/logout", (route, request) => {
+      if (request.method() !== "POST") return route.fallback();
+      return route.fulfill({ status: 204, body: "" });
+    });
+
+    await page.goto("/account/settings");
+    await page.waitForLoadState("networkidle");
+
+    await page.getByTestId("delete-account-button").click();
+    const dialog = page.getByTestId("delete-account-dialog");
+    await expect(dialog).toBeVisible();
+
+    const confirm = page.getByTestId("delete-account-dialog-confirm");
+    // Disabled until the keyword is typed exactly
+    await expect(confirm).toBeDisabled();
+
+    await page
+      .getByTestId("delete-account-dialog-keyword-input")
+      .fill("SUPPRIMER");
+    await expect(confirm).toBeEnabled();
+
+    await confirm.click();
+    await expect.poll(() => deleteCalled).toBe(true);
+    // After deletion the user is logged out and redirected home
+    await page.waitForURL("/", { timeout: 5000 });
+  });
+
+  test("logout button logs out and redirects home", async ({ page }) => {
+    await mockAuthenticated(page);
+
+    let logoutCalled = false;
+    await page.route("**/auth/logout", (route, request) => {
+      if (request.method() !== "POST") return route.fallback();
+      logoutCalled = true;
+      return route.fulfill({ status: 204, body: "" });
+    });
+
+    await page.goto("/account/settings");
+    await page.waitForLoadState("networkidle");
+
+    await page.getByTestId("logout-button").click();
+    await expect.poll(() => logoutCalled).toBe(true);
+    await page.waitForURL("/", { timeout: 5000 });
+  });
+});

--- a/pwa/tests/mocked/account-settings.spec.ts
+++ b/pwa/tests/mocked/account-settings.spec.ts
@@ -132,6 +132,58 @@ test.describe("Account settings", () => {
     await page.waitForURL("/", { timeout: 5000 });
   });
 
+  test("delete account keeps dialog open and shows error toast on failure", async ({
+    page,
+  }) => {
+    await mockAuthenticated(page);
+
+    let deleteCalled = false;
+    await page.route("**/users/me", (route, request) => {
+      if (request.method() !== "DELETE") return route.fallback();
+      deleteCalled = true;
+      return route.fulfill({ status: 500, body: "" });
+    });
+
+    await page.goto("/account/settings");
+    await page.waitForLoadState("networkidle");
+
+    await page.getByTestId("delete-account-button").click();
+    const dialog = page.getByTestId("delete-account-dialog");
+    await expect(dialog).toBeVisible();
+
+    await page
+      .getByTestId("delete-account-dialog-keyword-input")
+      .fill("SUPPRIMER");
+    const confirm = page.getByTestId("delete-account-dialog-confirm");
+    await expect(confirm).toBeEnabled();
+    await confirm.click();
+
+    await expect.poll(() => deleteCalled).toBe(true);
+    // The fix: dialog must stay open so the user can retry without retyping.
+    await expect(dialog).toBeVisible();
+    await expect(page).toHaveURL(/\/account\/settings$/);
+  });
+
+  test("export button re-enables after a server error", async ({ page }) => {
+    await mockAuthenticated(page);
+
+    let exportCalled = false;
+    await page.route("**/users/me/export", (route, request) => {
+      if (request.method() !== "GET") return route.fallback();
+      exportCalled = true;
+      return route.fulfill({ status: 500, body: "" });
+    });
+
+    await page.goto("/account/settings");
+    await page.waitForLoadState("networkidle");
+
+    const button = page.getByTestId("export-data-button");
+    await button.click();
+    await expect.poll(() => exportCalled).toBe(true);
+    // The button must re-enable after the failure so the user can retry.
+    await expect(button).toBeEnabled();
+  });
+
   test("logout button logs out and redirects home", async ({ page }) => {
     await mockAuthenticated(page);
 

--- a/pwa/tests/mocked/account-settings.spec.ts
+++ b/pwa/tests/mocked/account-settings.spec.ts
@@ -201,4 +201,26 @@ test.describe("Account settings", () => {
     await expect.poll(() => logoutCalled).toBe(true);
     await page.waitForURL("/", { timeout: 5000 });
   });
+
+  test("logout button shows error toast and re-enables on failure", async ({
+    page,
+  }) => {
+    await mockAuthenticated(page);
+
+    await page.route("**/auth/logout", (route, request) => {
+      if (request.method() !== "POST") return route.fallback();
+      return route.fulfill({ status: 500, body: "" });
+    });
+
+    await page.goto("/account/settings");
+    await page.waitForLoadState("networkidle");
+
+    const button = page.getByTestId("logout-button");
+    await button.click();
+
+    // Button must re-enable after the failure so the user can retry.
+    await expect(button).toBeEnabled();
+    // URL must not change — user stays on the settings page.
+    await expect(page).toHaveURL(/\/account\/settings$/);
+  });
 });


### PR DESCRIPTION
## Contexte

Sprint 34 — page `/account/settings` accessible via le bouton profil de la top bar.

**PR empilée** sur #555 (`feature/549`, backend RGPD) dont elle consomme les endpoints `GET /users/me/export` et `DELETE /users/me`. À merger après #555.

Closes #383.

## Changements

- `pwa/src/app/account/settings/page.tsx` (protégée par AuthGuard) + 5 composants `pwa/src/components/account/` : Mon compte (magic link), Préférences (langue/thème), Mes données (export RGPD JSON), Zone de danger (`DestructiveDialog`, saisie `SUPPRIMER`), Déconnexion.
- Helpers API `downloadAccountExport()` / `deleteAccount()` (`pwa/src/lib/api/client.ts`).
- Bouton profil (initiale) dans la top bar → `/account/settings`.
- Types régénérés via `make typegen` (expose les endpoints #549).
- i18n FR + EN ; E2E `account-settings.spec.ts` (6 cas).

## Auto-critique

- `make qa` exit 0 ; E2E 6/6 (agent, port isolé).
- Régénération de types nécessaire car stackée sur un changement d'API (#549).

<!-- claude-review-start -->
## Claude Review

Clean, well-structured implementation. All previous findings (5 threads across three rounds) have been addressed. The `logout()` store change correctly propagates server-side failures to callers while always clearing local state; every error path in the UI now has a toast and a corresponding E2E test. No new issues found.

**Resolved 1 previously open thread** (logout failure E2E test — confirmed added in commit `558a2e98`).

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Commit reviewed

`558a2e987003ab2da79ea51578a3a99e621f5bf7`

### Inline comments

No inline comments.

---
Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->