### PR TITLE
feat(pwa): add cookie consent banner gating plausible analytics

### DIFF
--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -1101,5 +1101,28 @@
         ]
       }
     }
+  },
+  "cookies": {
+    "acceptAll": "Accept all",
+    "rejectAll": "Reject all",
+    "privacyLink": "Learn more about our privacy policy",
+    "banner": {
+      "ariaLabel": "Cookie consent",
+      "message": "We use cookies to measure site traffic. You can accept, reject or customize your choices.",
+      "customize": "Customize"
+    },
+    "modal": {
+      "title": "Cookie preferences",
+      "description": "Choose which cookie categories you allow. You can change these choices at any time.",
+      "save": "Save my preferences",
+      "technical": {
+        "title": "Technical cookies",
+        "description": "Required for the site to work. Always enabled."
+      },
+      "analytics": {
+        "title": "Analytics",
+        "description": "Anonymous traffic statistics via Plausible."
+      }
+    }
   }
 }

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -1101,5 +1101,28 @@
         ]
       }
     }
+  },
+  "cookies": {
+    "acceptAll": "Tout accepter",
+    "rejectAll": "Tout refuser",
+    "privacyLink": "En savoir plus sur notre politique de confidentialité",
+    "banner": {
+      "ariaLabel": "Consentement aux cookies",
+      "message": "Nous utilisons des cookies pour mesurer l'audience du site. Vous pouvez accepter, refuser ou personnaliser vos choix.",
+      "customize": "Personnaliser"
+    },
+    "modal": {
+      "title": "Préférences de cookies",
+      "description": "Choisissez les catégories de cookies que vous autorisez. Vous pouvez modifier ces choix à tout moment.",
+      "save": "Enregistrer mes préférences",
+      "technical": {
+        "title": "Cookies techniques",
+        "description": "Nécessaires au fonctionnement du site. Toujours activés."
+      },
+      "analytics": {
+        "title": "Mesure d'audience",
+        "description": "Statistiques de fréquentation anonymes via Plausible."
+      }
+    }
   }
 }

--- a/pwa/playwright.bdd.config.ts
+++ b/pwa/playwright.bdd.config.ts
@@ -42,6 +42,9 @@ export default defineConfig({
     locale: "fr-FR",
     trace: "on-first-retry",
     screenshot: "only-on-failure",
+    // Seed a recorded cookie-consent decision so the bottom consent banner
+    // does not overlay the viewport and intercept clicks during the recette.
+    storageState: "tests/fixtures/consent-storage-state.json",
   },
   projects: process.env.CI
     ? [

--- a/pwa/playwright.config.ts
+++ b/pwa/playwright.config.ts
@@ -17,6 +17,10 @@ export default defineConfig({
     locale: "fr-FR",
     trace: "on-first-retry",
     screenshot: "only-on-failure",
+    // Seed a recorded cookie-consent decision so the bottom consent banner
+    // does not overlay the viewport and intercept clicks across the suite.
+    // Specs that test the banner itself opt out via `test.use({ storageState: ... })`.
+    storageState: "tests/fixtures/consent-storage-state.json",
   },
   projects: process.env.CI
     ? [

--- a/pwa/src/app/layout.tsx
+++ b/pwa/src/app/layout.tsx
@@ -10,6 +10,7 @@ import { Toaster } from "@/components/ui/sonner";
 import { OnboardingTour } from "@/components/onboarding-tour";
 import { AuthGuard } from "@/components/auth-guard";
 import { PlausibleScript } from "@/components/plausible-script";
+import { CookieBanner } from "@/components/cookie-banner";
 
 const fraunces = Fraunces({
   subsets: ["latin"],
@@ -77,6 +78,7 @@ export default async function RootLayout({
               <OnboardingTour />
             </AuthGuard>
             <Toaster richColors position="top-right" />
+            <CookieBanner />
           </ThemeProvider>
         </NextIntlClientProvider>
         <PlausibleScript />

--- a/pwa/src/components/cookie-banner.tsx
+++ b/pwa/src/components/cookie-banner.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import { Button } from "@/components/ui/button";
+import { useCookieConsent } from "@/hooks/use-cookie-consent";
+import { CookieModal } from "@/components/cookie-modal";
+
+/**
+ * GDPR consent banner pinned to the bottom of the screen. Shown on first visit
+ * (no recorded decision). Accepting/refusing/saving persists the choice to the
+ * shared `cookie-consent` localStorage key, which gates Plausible loading.
+ */
+export function CookieBanner() {
+  const t = useTranslations("cookies");
+  const { consent, shouldShowBanner, acceptAll, rejectAll, save } =
+    useCookieConsent();
+  const [modalOpen, setModalOpen] = useState(false);
+
+  const handleSave = (analytics: boolean) => {
+    save(analytics);
+    setModalOpen(false);
+  };
+
+  const handleAcceptAll = () => {
+    acceptAll();
+    setModalOpen(false);
+  };
+
+  const handleRejectAll = () => {
+    rejectAll();
+    setModalOpen(false);
+  };
+
+  // The modal can still be reopened from /privacy in the future, but the banner
+  // itself only renders until a decision is recorded.
+  if (!shouldShowBanner) {
+    return modalOpen ? (
+      <CookieModal
+        open={modalOpen}
+        onOpenChange={setModalOpen}
+        initialAnalytics={consent?.analytics ?? false}
+        onSave={handleSave}
+        onAcceptAll={handleAcceptAll}
+        onRejectAll={handleRejectAll}
+      />
+    ) : null;
+  }
+
+  return (
+    <>
+      <div
+        role="dialog"
+        aria-label={t("banner.ariaLabel")}
+        data-testid="cookie-banner"
+        className="bg-background fixed inset-x-0 bottom-0 z-50 border-t p-4 shadow-lg sm:p-6"
+      >
+        <div className="mx-auto flex max-w-4xl flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <p className="text-muted-foreground text-sm">{t("banner.message")}</p>
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setModalOpen(true)}
+              data-testid="cookie-customize"
+            >
+              {t("banner.customize")}
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleRejectAll}
+              data-testid="cookie-reject-all"
+            >
+              {t("rejectAll")}
+            </Button>
+            <Button
+              size="sm"
+              onClick={handleAcceptAll}
+              data-testid="cookie-accept-all"
+            >
+              {t("acceptAll")}
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <CookieModal
+        open={modalOpen}
+        onOpenChange={setModalOpen}
+        initialAnalytics={consent?.analytics ?? false}
+        onSave={handleSave}
+        onAcceptAll={handleAcceptAll}
+        onRejectAll={handleRejectAll}
+      />
+    </>
+  );
+}

--- a/pwa/src/components/cookie-banner.tsx
+++ b/pwa/src/components/cookie-banner.tsx
@@ -32,19 +32,8 @@ export function CookieBanner() {
     setModalOpen(false);
   };
 
-  // The modal can still be reopened from /privacy in the future, but the banner
-  // itself only renders until a decision is recorded.
   if (!shouldShowBanner) {
-    return modalOpen ? (
-      <CookieModal
-        open={modalOpen}
-        onOpenChange={setModalOpen}
-        initialAnalytics={consent?.analytics ?? false}
-        onSave={handleSave}
-        onAcceptAll={handleAcceptAll}
-        onRejectAll={handleRejectAll}
-      />
-    ) : null;
+    return null;
   }
 
   return (

--- a/pwa/src/components/cookie-modal.tsx
+++ b/pwa/src/components/cookie-modal.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useTranslations } from "next-intl";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Switch } from "@/components/ui/switch";
+
+type CookieModalProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Current analytics opt-in, used to initialise the switch. */
+  initialAnalytics: boolean;
+  onSave: (analytics: boolean) => void;
+  onAcceptAll: () => void;
+  onRejectAll: () => void;
+};
+
+/**
+ * Granularity modal letting the user toggle the analytics category and save
+ * fine-grained preferences. Technical cookies are always on and not toggleable.
+ */
+export function CookieModal({
+  open,
+  onOpenChange,
+  initialAnalytics,
+  onSave,
+  onAcceptAll,
+  onRejectAll,
+}: CookieModalProps) {
+  const t = useTranslations("cookies");
+  const [analytics, setAnalytics] = useState(initialAnalytics);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent data-testid="cookie-modal" className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{t("modal.title")}</DialogTitle>
+          <DialogDescription>{t("modal.description")}</DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4 py-2">
+          <div
+            className="flex items-start justify-between gap-4 rounded-lg border p-4"
+            data-testid="cookie-category-technical"
+          >
+            <div className="flex flex-col gap-1">
+              <span className="text-sm font-medium">
+                {t("modal.technical.title")}
+              </span>
+              <span className="text-muted-foreground text-sm">
+                {t("modal.technical.description")}
+              </span>
+            </div>
+            <Switch
+              checked
+              disabled
+              aria-label={t("modal.technical.title")}
+              data-testid="cookie-toggle-technical"
+            />
+          </div>
+
+          <div
+            className="flex items-start justify-between gap-4 rounded-lg border p-4"
+            data-testid="cookie-category-analytics"
+          >
+            <div className="flex flex-col gap-1">
+              <span className="text-sm font-medium">
+                {t("modal.analytics.title")}
+              </span>
+              <span className="text-muted-foreground text-sm">
+                {t("modal.analytics.description")}
+              </span>
+            </div>
+            <Switch
+              checked={analytics}
+              onCheckedChange={setAnalytics}
+              aria-label={t("modal.analytics.title")}
+              data-testid="cookie-toggle-analytics"
+            />
+          </div>
+        </div>
+
+        <Link
+          href="/privacy"
+          className="text-muted-foreground hover:text-foreground text-sm underline underline-offset-4 transition-colors"
+          data-testid="cookie-modal-privacy-link"
+        >
+          {t("privacyLink")}
+        </Link>
+
+        <DialogFooter className="gap-2">
+          <Button
+            variant="ghost"
+            onClick={onRejectAll}
+            data-testid="cookie-modal-reject"
+          >
+            {t("rejectAll")}
+          </Button>
+          <Button
+            variant="outline"
+            onClick={onAcceptAll}
+            data-testid="cookie-modal-accept"
+          >
+            {t("acceptAll")}
+          </Button>
+          <Button
+            onClick={() => onSave(analytics)}
+            data-testid="cookie-modal-save"
+          >
+            {t("modal.save")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/pwa/src/components/cookie-modal.tsx
+++ b/pwa/src/components/cookie-modal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
@@ -38,6 +38,13 @@ export function CookieModal({
 }: CookieModalProps) {
   const t = useTranslations("cookies");
   const [analytics, setAnalytics] = useState(initialAnalytics);
+
+  // The modal stays mounted across open/close cycles, so reset the switch to
+  // the recorded consent whenever it reopens — otherwise an unsaved toggle
+  // dismissed via "×" would leak into the next open.
+  useEffect(() => {
+    if (open) setAnalytics(initialAnalytics);
+  }, [open, initialAnalytics]);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/pwa/src/hooks/use-analytics-consent.ts
+++ b/pwa/src/hooks/use-analytics-consent.ts
@@ -2,7 +2,8 @@
 
 import { useEffect, useState } from "react";
 
-const CONSENT_STORAGE_KEY = "cookie-consent";
+/** localStorage key holding the cookie-consent decision (`{ analytics: boolean }`). */
+export const CONSENT_STORAGE_KEY = "cookie-consent";
 
 /** Custom event dispatched when the cookie-consent value changes (same tab). */
 export const CONSENT_CHANGE_EVENT = "cookie-consent-change";

--- a/pwa/src/hooks/use-cookie-consent.ts
+++ b/pwa/src/hooks/use-cookie-consent.ts
@@ -1,0 +1,90 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  CONSENT_CHANGE_EVENT,
+  CONSENT_STORAGE_KEY,
+} from "@/hooks/use-analytics-consent";
+
+/**
+ * Persisted consent shape. Technical cookies are always on and are not stored
+ * (they have no opt-out), so only the analytics opt-in is persisted. The
+ * presence of the key marks the banner as dismissed.
+ */
+export type CookieConsent = {
+  analytics: boolean;
+};
+
+/**
+ * `null` = no decision recorded yet (banner must be shown).
+ */
+type StoredConsent = CookieConsent | null;
+
+function readConsent(): StoredConsent {
+  try {
+    const raw = localStorage.getItem(CONSENT_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<CookieConsent>;
+    return { analytics: parsed.analytics === true };
+  } catch {
+    return null;
+  }
+}
+
+function writeConsent(consent: CookieConsent): void {
+  try {
+    localStorage.setItem(CONSENT_STORAGE_KEY, JSON.stringify(consent));
+  } catch {
+    // localStorage may be unavailable (private browsing); ignore write errors.
+  }
+  // Notify same-tab listeners (e.g. PlausibleScript) so analytics can load
+  // without a reload. The native `storage` event only fires in other tabs.
+  window.dispatchEvent(new Event(CONSENT_CHANGE_EVENT));
+}
+
+/**
+ * Manages cookie consent: reading the stored decision, deciding whether the
+ * banner should be shown, and persisting choices to the shared `cookie-consent`
+ * localStorage key consumed by {@link useAnalyticsConsent}.
+ *
+ * `consent` is `null` during SSR/hydration and until localStorage is read, then
+ * resolves to the stored value (or `null` if no decision was made yet).
+ */
+export function useCookieConsent() {
+  const [consent, setConsent] = useState<StoredConsent>(null);
+  const [resolved, setResolved] = useState(false);
+
+  useEffect(() => {
+    setConsent(readConsent());
+    setResolved(true);
+
+    const update = () => setConsent(readConsent());
+    window.addEventListener("storage", update);
+    window.addEventListener(CONSENT_CHANGE_EVENT, update);
+    return () => {
+      window.removeEventListener("storage", update);
+      window.removeEventListener(CONSENT_CHANGE_EVENT, update);
+    };
+  }, []);
+
+  const save = useCallback((analytics: boolean) => {
+    const next = { analytics };
+    writeConsent(next);
+    setConsent(next);
+  }, []);
+
+  const acceptAll = useCallback(() => save(true), [save]);
+  const rejectAll = useCallback(() => save(false), [save]);
+
+  // Show the banner only once we know there is no recorded decision.
+  const shouldShowBanner = resolved && consent === null;
+
+  return {
+    consent,
+    resolved,
+    shouldShowBanner,
+    acceptAll,
+    rejectAll,
+    save,
+  };
+}

--- a/pwa/tests/fixtures/consent-storage-state.json
+++ b/pwa/tests/fixtures/consent-storage-state.json
@@ -1,0 +1,14 @@
+{
+  "cookies": [],
+  "origins": [
+    {
+      "origin": "https://localhost",
+      "localStorage": [
+        {
+          "name": "cookie-consent",
+          "value": "{\"analytics\":false}"
+        }
+      ]
+    }
+  ]
+}

--- a/pwa/tests/mocked/cookie-consent.spec.ts
+++ b/pwa/tests/mocked/cookie-consent.spec.ts
@@ -172,4 +172,27 @@ test.describe("Cookie granularity modal", () => {
     await page.getByTestId("cookie-modal-privacy-link").click();
     await expect(page).toHaveURL("/privacy");
   });
+
+  test("unsaved toggle is discarded when modal is dismissed and reopened", async ({
+    page,
+  }) => {
+    await mockAllApis(page);
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    // Open modal and toggle analytics ON without saving.
+    await page.getByTestId("cookie-customize").click();
+    await expect(page.getByTestId("cookie-toggle-analytics")).not.toBeChecked();
+    await page.getByTestId("cookie-toggle-analytics").click();
+    await expect(page.getByTestId("cookie-toggle-analytics")).toBeChecked();
+
+    // Dismiss without recording any consent.
+    await page.keyboard.press("Escape");
+    await expect(page.getByTestId("cookie-modal")).toHaveCount(0);
+    expect(await readStoredConsent(page)).toBeNull();
+
+    // Reopen — switch must be back to its initial (false) state.
+    await page.getByTestId("cookie-customize").click();
+    await expect(page.getByTestId("cookie-toggle-analytics")).not.toBeChecked();
+  });
 });

--- a/pwa/tests/mocked/cookie-consent.spec.ts
+++ b/pwa/tests/mocked/cookie-consent.spec.ts
@@ -1,0 +1,171 @@
+import { test, expect, type Page } from "@playwright/test";
+import { mockAllApis } from "../fixtures/api-mocks";
+
+const PLAUSIBLE_DOMAIN = "biketripplanner.test";
+const PLAUSIBLE_SRC = "https://plausible.test/js/script.js";
+
+/** Injects the Plausible config the way build-time NEXT_PUBLIC_* would. */
+async function presetPlausibleEnv(page: Page) {
+  await page.addInitScript(
+    ({ domain, src }) => {
+      const w = window as Window & {
+        __PLAYWRIGHT_PLAUSIBLE_DOMAIN?: string;
+        __PLAYWRIGHT_PLAUSIBLE_SRC?: string;
+      };
+      w.__PLAYWRIGHT_PLAUSIBLE_DOMAIN = domain;
+      w.__PLAYWRIGHT_PLAUSIBLE_SRC = src;
+    },
+    { domain: PLAUSIBLE_DOMAIN, src: PLAUSIBLE_SRC },
+  );
+}
+
+/** Fails the test if any request hits the Plausible host. */
+async function failOnPlausibleRequest(page: Page) {
+  await page.route("https://plausible.test/**", (route) => {
+    throw new Error(`Unexpected Plausible request: ${route.request().url()}`);
+  });
+}
+
+async function readStoredConsent(page: Page) {
+  return page.evaluate(() => {
+    const raw = localStorage.getItem("cookie-consent");
+    return raw ? (JSON.parse(raw) as { analytics?: boolean }) : null;
+  });
+}
+
+test.describe("Cookie consent banner", () => {
+  test("is visible on first visit", async ({ page }) => {
+    await mockAllApis(page);
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    await expect(page.getByTestId("cookie-banner")).toBeVisible();
+    await expect(page.getByTestId("cookie-accept-all")).toBeVisible();
+    await expect(page.getByTestId("cookie-reject-all")).toBeVisible();
+    await expect(page.getByTestId("cookie-customize")).toBeVisible();
+  });
+
+  test("is not shown again after a decision was recorded", async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        "cookie-consent",
+        JSON.stringify({ analytics: false }),
+      );
+    });
+    await mockAllApis(page);
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    await expect(page.getByTestId("cookie-banner")).toHaveCount(0);
+  });
+
+  test("'Reject all' records analytics:false, no Plausible request, banner dismissed persistently", async ({
+    page,
+  }) => {
+    await presetPlausibleEnv(page);
+    await failOnPlausibleRequest(page);
+    await mockAllApis(page);
+
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    await page.getByTestId("cookie-reject-all").click();
+
+    await expect(page.getByTestId("cookie-banner")).toHaveCount(0);
+    expect(await readStoredConsent(page)).toEqual({ analytics: false });
+    await expect(page.getByTestId("plausible-script")).toHaveCount(0);
+
+    // Persistent: reload keeps the banner dismissed.
+    await page.reload();
+    await page.waitForLoadState("networkidle");
+    await expect(page.getByTestId("cookie-banner")).toHaveCount(0);
+  });
+
+  test("'Accept all' records analytics:true and loads Plausible without reload", async ({
+    page,
+  }) => {
+    await presetPlausibleEnv(page);
+    await mockAllApis(page);
+
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    await page.getByTestId("cookie-accept-all").click();
+
+    await expect(page.getByTestId("cookie-banner")).toHaveCount(0);
+    expect(await readStoredConsent(page)).toEqual({ analytics: true });
+
+    const script = page.locator('script[data-testid="plausible-script"]');
+    await expect(script).toHaveAttribute("data-domain", PLAUSIBLE_DOMAIN);
+    await expect(script).toHaveAttribute("src", PLAUSIBLE_SRC);
+  });
+});
+
+test.describe("Cookie granularity modal", () => {
+  test("'Customize' opens the modal with both categories and a privacy link", async ({
+    page,
+  }) => {
+    await mockAllApis(page);
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    await page.getByTestId("cookie-customize").click();
+
+    await expect(page.getByTestId("cookie-modal")).toBeVisible();
+    await expect(page.getByTestId("cookie-category-technical")).toBeVisible();
+    await expect(page.getByTestId("cookie-category-analytics")).toBeVisible();
+    // Technical toggle is on and not changeable.
+    await expect(page.getByTestId("cookie-toggle-technical")).toBeDisabled();
+    await expect(page.getByTestId("cookie-modal-privacy-link")).toHaveAttribute(
+      "href",
+      "/privacy",
+    );
+  });
+
+  test("saving with analytics toggled on records analytics:true", async ({
+    page,
+  }) => {
+    await presetPlausibleEnv(page);
+    await mockAllApis(page);
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    await page.getByTestId("cookie-customize").click();
+    await page.getByTestId("cookie-toggle-analytics").click();
+    await page.getByTestId("cookie-modal-save").click();
+
+    await expect(page.getByTestId("cookie-modal")).toHaveCount(0);
+    await expect(page.getByTestId("cookie-banner")).toHaveCount(0);
+    expect(await readStoredConsent(page)).toEqual({ analytics: true });
+
+    const script = page.locator('script[data-testid="plausible-script"]');
+    await expect(script).toHaveAttribute("data-domain", PLAUSIBLE_DOMAIN);
+  });
+
+  test("saving with analytics left off records analytics:false and no Plausible", async ({
+    page,
+  }) => {
+    await presetPlausibleEnv(page);
+    await failOnPlausibleRequest(page);
+    await mockAllApis(page);
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    await page.getByTestId("cookie-customize").click();
+    await page.getByTestId("cookie-modal-save").click();
+
+    await expect(page.getByTestId("cookie-modal")).toHaveCount(0);
+    expect(await readStoredConsent(page)).toEqual({ analytics: false });
+    await expect(page.getByTestId("plausible-script")).toHaveCount(0);
+  });
+
+  test("privacy link navigates to /privacy", async ({ page }) => {
+    await mockAllApis(page);
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    await page.getByTestId("cookie-customize").click();
+    await page.getByTestId("cookie-modal-privacy-link").click();
+    await expect(page).toHaveURL("/privacy");
+  });
+});

--- a/pwa/tests/mocked/cookie-consent.spec.ts
+++ b/pwa/tests/mocked/cookie-consent.spec.ts
@@ -1,6 +1,10 @@
 import { test, expect, type Page } from "@playwright/test";
 import { mockAllApis } from "../fixtures/api-mocks";
 
+// This suite asserts the banner's own behaviour, so it must start with no
+// recorded consent — opt out of the global seeded storageState.
+test.use({ storageState: { cookies: [], origins: [] } });
+
 const PLAUSIBLE_DOMAIN = "biketripplanner.test";
 const PLAUSIBLE_SRC = "https://plausible.test/js/script.js";
 

--- a/pwa/tests/mocked/plausible-analytics.spec.ts
+++ b/pwa/tests/mocked/plausible-analytics.spec.ts
@@ -1,6 +1,10 @@
 import { test, expect } from "@playwright/test";
 import { mockAllApis } from "../fixtures/api-mocks";
 
+// Each case controls analytics consent explicitly via addInitScript, so start
+// from a clean slate — opt out of the global seeded storageState.
+test.use({ storageState: { cookies: [], origins: [] } });
+
 const PLAUSIBLE_DOMAIN = "biketripplanner.test";
 const PLAUSIBLE_SRC = "https://plausible.test/js/script.js";
 


### PR DESCRIPTION
## Contexte

Sprint 34 — bannière de consentement cookies RGPD + modale de granularité, qui gate le chargement de Plausible (#375 §15).

**PR empilée** sur #557 (`feature/552`, script Plausible) dont elle réutilise `use-analytics-consent.ts` / `CONSENT_CHANGE_EVENT`. À merger après #557.

Closes #385.

## Changements

- `pwa/src/components/cookie-banner.tsx` (bas d'écran, Tout accepter / refuser / Personnaliser) + `cookie-modal.tsx` (catégories techniques always-on / analytics opt-in, lien `/privacy`).
- `pwa/src/hooks/use-cookie-consent.ts` : écrit la clé `cookie-consent` partagée + dispatch `CONSENT_CHANGE_EVENT` (charge Plausible sans reload). Réutilise la clé exportée par `use-analytics-consent.ts`, pas de duplication.
- `pwa/src/app/layout.tsx` : bannière globale ; dismiss persistant (localStorage).
- i18n FR + EN ; E2E `cookie-consent.spec.ts`.

## Auto-critique

- `make qa` exit 0. Suite E2E non lancée localement (port 443) → CI.
- Refuser → `{analytics:false}` → aucune requête Plausible (vérifié dans la spec).

<!-- claude-review-start -->
## Claude Review

**Commit reviewed:** `2e3325ef036da2d7ca3b7f867e701a3a32d1788b`

**Summary:** Clean, complete implementation with no outstanding issues. All five previously raised threads have been resolved in prior pushes: the unreachable `CookieModal` branch was removed, the stale-switch `useEffect` reset is in place, and the regression test covering the "toggle → dismiss → reopen must reset" path was added. Security, performance, and architecture are all sound.

**Resolved threads:** All 5 previously opened bot threads are resolved; no new threads to open.

### Review checklist
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Inline comments
No inline comments.

---
Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->