### PR TITLE
feat(pwa): add plausible custom events for imports and key features

### DIFF
--- a/pwa/src/components/ai-bubble.tsx
+++ b/pwa/src/components/ai-bubble.tsx
@@ -9,6 +9,7 @@ import { useTripStore } from "@/store/trip-store";
 import { AiChatPanel } from "@/components/ai-chat-panel";
 import { ChatOfflineBadge } from "@/components/chat/ChatOfflineBadge";
 import { useOnlineStatus } from "@/hooks/use-online-status";
+import { trackEvent } from "@/lib/plausible";
 import { cn } from "@/lib/utils";
 
 /**
@@ -47,13 +48,19 @@ export function AiBubble() {
     setCurrentContext({ currentStage: activeDayNumber ?? null });
   }, [activeDayNumber, setCurrentContext]);
 
+  // Track only the open transition so closing the panel does not emit an event.
+  const handleToggle = () => {
+    if (!isBubbleOpen) trackEvent("ai_chat_opened");
+    toggleBubble();
+  };
+
   if (!trip || isAnalysisPhaseActive) return null;
 
   return (
     <>
       <button
         type="button"
-        onClick={isOnline ? toggleBubble : undefined}
+        onClick={isOnline ? handleToggle : undefined}
         aria-disabled={!isOnline}
         aria-label={isBubbleOpen ? t("closeAria") : t("openAria")}
         aria-expanded={isBubbleOpen}

--- a/pwa/src/components/alert-action-button.tsx
+++ b/pwa/src/components/alert-action-button.tsx
@@ -3,6 +3,7 @@
 import { Sparkles, Shuffle, Compass, X, type LucideIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { trackEvent } from "@/lib/plausible";
 import type { AlertActionData } from "@/lib/validation/schemas";
 
 /**
@@ -51,7 +52,10 @@ export function AlertActionButton({
       type="button"
       variant="outline"
       size="xs"
-      onClick={onClick}
+      onClick={() => {
+        trackEvent("alert_action_clicked", { kind: action.kind });
+        onClick();
+      }}
       disabled={disabled}
       aria-label={ariaLabel ?? action.label}
       data-testid="alert-action-button"

--- a/pwa/src/components/share-modal.tsx
+++ b/pwa/src/components/share-modal.tsx
@@ -45,6 +45,7 @@ import {
   createTripShare,
   revokeTripShare,
 } from "@/lib/api/client";
+import { trackEvent } from "@/lib/plausible";
 import type { StageData } from "@/lib/validation/schemas";
 
 interface ShareModalProps {
@@ -186,6 +187,7 @@ export function ShareModal({
       const result = await createTripShare(tripId);
       if (result) {
         setShareUrl(buildShareUrl(result.shortCode ?? ""));
+        trackEvent("trip_shared");
       } else {
         toast.error(t("linkCreateFailed"));
       }

--- a/pwa/src/globals.d.ts
+++ b/pwa/src/globals.d.ts
@@ -7,5 +7,13 @@ declare global {
     __zustand_ui_store?: typeof useUiStore;
     /** Exposed in non-production environments only (NODE_ENV !== 'production'). */
     __zustand_trip_store?: typeof useTripStore;
+    /**
+     * Plausible analytics event tracker, injected by {@link PlausibleScript}
+     * once analytics consent is granted. Absent otherwise.
+     */
+    plausible?: (
+      event: string,
+      options?: { props?: Record<string, string | number | boolean> },
+    ) => void;
   }
 }

--- a/pwa/src/hooks/use-trip-planner.test.ts
+++ b/pwa/src/hooks/use-trip-planner.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from "vitest";
+import { importEventForUrl } from "@/hooks/use-trip-planner";
+
+describe("importEventForUrl", () => {
+  it.each([
+    ["https://www.komoot.com/tour/123", "import_komoot"],
+    ["https://www.strava.com/routes/456", "import_strava"],
+    ["https://ridewithgps.com/routes/789", "import_rwgps"],
+    ["https://example.com/gpx", null],
+  ])("%s → %s", (url, expected) => {
+    expect(importEventForUrl(url)).toBe(expected);
+  });
+});

--- a/pwa/src/hooks/use-trip-planner.ts
+++ b/pwa/src/hooks/use-trip-planner.ts
@@ -36,7 +36,7 @@ import type { AccommodationData, StageData } from "@/lib/validation/schemas";
 import type { AccommodationType } from "@/lib/accommodation-types";
 
 /** Map a source URL to its Plausible import event (null if unrecognised). */
-function importEventForUrl(url: string): PlausibleEvent | null {
+export function importEventForUrl(url: string): PlausibleEvent | null {
   if (/komoot\.com\//.test(url)) return "import_komoot";
   if (/strava\.com\//.test(url)) return "import_strava";
   if (/ridewithgps\.com\//.test(url)) return "import_rwgps";

--- a/pwa/src/hooks/use-trip-planner.ts
+++ b/pwa/src/hooks/use-trip-planner.ts
@@ -26,6 +26,7 @@ import {
   type TripChatResponseBody,
 } from "@/lib/api/client";
 import { getRandomTripName } from "@/lib/trip-utils";
+import { trackEvent, type PlausibleEvent } from "@/lib/plausible";
 import {
   MAX_ACCOMMODATION_RADIUS_KM,
   ACCOMMODATION_RADIUS_STEP_KM,
@@ -33,6 +34,14 @@ import {
 } from "@/lib/accommodation-constants";
 import type { AccommodationData, StageData } from "@/lib/validation/schemas";
 import type { AccommodationType } from "@/lib/accommodation-types";
+
+/** Map a source URL to its Plausible import event (null if unrecognised). */
+function importEventForUrl(url: string): PlausibleEvent | null {
+  if (/komoot\.com\//.test(url)) return "import_komoot";
+  if (/strava\.com\//.test(url)) return "import_strava";
+  if (/ridewithgps\.com\//.test(url)) return "import_rwgps";
+  return null;
+}
 
 /** Read current pacing + config state from the store without subscribing. */
 function getPacingState() {
@@ -188,6 +197,9 @@ export function useTripPlanner() {
         title: getRandomTripName(),
         sourceUrl,
       });
+      const importEvent = importEventForUrl(sourceUrl);
+      if (importEvent) trackEvent(importEvent);
+      trackEvent("trip_created", { source: importEvent ?? "url" });
       router.push(`/trips/${data.id ?? ""}`);
     } catch (err) {
       if (isNetworkError(err)) {
@@ -235,6 +247,8 @@ export function useTripPlanner() {
         sourceType: "gpx_upload",
         title: data.title ?? null,
       });
+      trackEvent("import_gpx");
+      trackEvent("trip_created", { source: "gpx" });
     } catch (err) {
       if (isNetworkError(err)) {
         toast.error(t("errors.networkError"));
@@ -936,6 +950,7 @@ export function useTripPlanner() {
         const affectedIndices = [stageIndex];
         if (nextStageIndex !== null) affectedIndices.push(nextStageIndex);
         actions.startStageRecomputation(affectedIndices);
+        trackEvent("accommodation_selected", { type: acc.type });
       }
     } catch {
       toast.error(t("errors.failedSelectAccommodation"));

--- a/pwa/src/lib/plausible.test.ts
+++ b/pwa/src/lib/plausible.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { trackEvent } from "./plausible";
+
+describe("trackEvent", () => {
+  afterEach(() => {
+    delete window.plausible;
+    vi.restoreAllMocks();
+  });
+
+  it("calls window.plausible with the event name and no options when no props", () => {
+    const spy = vi.fn();
+    window.plausible = spy;
+
+    trackEvent("trip_created");
+
+    expect(spy).toHaveBeenCalledWith("trip_created", undefined);
+  });
+
+  it("wraps props under the `props` key", () => {
+    const spy = vi.fn();
+    window.plausible = spy;
+
+    trackEvent("import_komoot", { source: "import_komoot" });
+
+    expect(spy).toHaveBeenCalledWith("import_komoot", {
+      props: { source: "import_komoot" },
+    });
+  });
+
+  it("is a no-op when window.plausible is undefined (no consent / not loaded)", () => {
+    expect(window.plausible).toBeUndefined();
+    expect(() => trackEvent("ai_chat_opened")).not.toThrow();
+  });
+});

--- a/pwa/src/lib/plausible.ts
+++ b/pwa/src/lib/plausible.ts
@@ -1,0 +1,34 @@
+/**
+ * Plausible custom-event helper.
+ *
+ * Emits goal-conversion events to the self-hosted Plausible instance loaded by
+ * {@link PlausibleScript}. The script only injects `window.plausible` once both
+ * the env config and analytics consent are present, so {@link trackEvent} is a
+ * no-op whenever the script is absent (consent refused or not configured).
+ */
+
+/** Custom events emitted across the app. Union-typed to catch typos. */
+export type PlausibleEvent =
+  // Import sources & platforms
+  | "import_komoot"
+  | "import_strava"
+  | "import_rwgps"
+  | "import_gpx"
+  // Feature value & retention/UX
+  | "trip_created"
+  | "trip_shared"
+  | "accommodation_selected"
+  | "alert_action_clicked"
+  | "ai_chat_opened";
+
+/**
+ * Send a custom event to Plausible. No-op when `window.plausible` is undefined
+ * (script not loaded: consent refused or analytics not configured).
+ */
+export function trackEvent(
+  name: PlausibleEvent,
+  props?: Record<string, string | number | boolean>,
+): void {
+  if (typeof window === "undefined") return;
+  window.plausible?.(name, props ? { props } : undefined);
+}


### PR DESCRIPTION
## Contexte

Sprint 34 — instrumentation des custom events Plausible (sources d'import + valeur features/rétention). Fusionne les items 6 et 7 du TRACKING.

**PR empilée** sur #557 (`feature/552`, script Plausible). À merger après #557.

Closes #553.

## Changements

- `pwa/src/lib/plausible.ts` : `trackEvent(name, props?)` (no-op si `window.plausible` absent / consentement refusé), noms typés (`PlausibleEvent`).
- `pwa/src/globals.d.ts` : type global `window.plausible`.
- Points d'appel instrumentés : `import_komoot/strava/rwgps/gpx` + `trip_created` (`use-trip-planner.ts`), `trip_shared` (`share-modal.tsx`), `accommodation_selected` (`use-trip-planner.ts`), `alert_action_clicked` (`alert-action-button.tsx`), `ai_chat_opened` (`ai-bubble.tsx`).
- Tests Vitest `plausible.test.ts` (3 cas).

## Auto-critique

- `make qa` exit 0 ; Vitest 3/3. Vérif dashboard Plausible = manuelle (nécessite #551 live), non bloquante CI.
- Modifications ciblées (un appel par action, pas de refactor).

<!-- claude-review-start -->
## Claude Review

Clean, well-typed analytics instrumentation. All `trackEvent` call sites fire on the success path only, the `PlausibleEvent` union prevents typos at compile time, and the SSR guard + optional-chaining pattern is correct. The second commit fully addressed the previous open thread by exporting `importEventForUrl` and adding a dedicated `use-trip-planner.test.ts` covering all four branches. No new correctness, security, or performance issues found.

**Findings: 0 new**

Resolved 1 previously open thread (bot-authored): `importEventForUrl` export + unit tests — addressed by commit `b053cbd`.

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Inline comments

No inline comments.

---

Reviewed commit: `b053cbd9264a6ef4b3243c274d98e315370e4c57`

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->