### PR TITLE
chore(claude): sprint 34 retro — stacked-PR squash rebase + close docker teardown

### DIFF
--- a/.claude/skills/close/SKILL.md
+++ b/.claude/skills/close/SKILL.md
@@ -38,10 +38,24 @@ List the **concrete** items that would be removed, with their PR/merge status:
 
 ## Step 4 — Clean up (plain git, only after confirmation)
 
-For each branch whose PR is **merged or closed**:
-- Worktrees created via `EnterWorktree` are locked. Run `git worktree unlock <path>` then `git worktree remove <path>` and finally `git worktree prune`. If the remove still fails because a sub-tree contains files written by Docker as root (typically `.phpunit.cache/`, `node_modules/.cache/`), **flag the paths to the user and stop** — do not try `sudo`, do not force. The user will clear them by hand.
-- `git branch -d <branch>` — use **`-d`, not `-D`**. If git refuses (unmerged), **flag it and skip** rather than force-delete.
-- Also clean the skeleton branches `worktree-agent-<id>` that `EnterWorktree` leaves behind: `git branch -d worktree-agent-<id>`.
+For each branch whose PR is **merged or closed**, in this order:
+
+1. **Tear down the worktree's Docker stack.** Each worktree runs its own `docker compose up` under a project named after the worktree directory basename (e.g. `agent-a3008e9ca9369931a`), spinning up a full stack (caddy/php/pwa/database/redis/mercure/ollama/valhalla/…) with its own containers, **named volumes**, and network. These accumulate and overload the machine if left behind. Remove the project (no compose file needed — `-p` is enough):
+   ```bash
+   docker compose -p <worktree-basename> down --volumes --remove-orphans
+   ```
+   The project name is the worktree dir basename as Docker sanitizes it (lowercased, non-alphanumeric stripped); for `agent-<hex>` worktrees it is the basename verbatim. This only touches that worktree's project — never the main stack or other worktrees.
+
+2. **Remove the worktree.** Worktrees created via `EnterWorktree` are locked: `git worktree unlock <path>` then `git worktree remove <path>`, finally `git worktree prune`. If the remove fails with **Permission denied** because a sub-tree holds files written by Docker as root (typically `pwa/test-results/`, `recette-report/`, `.features-gen/`, `.phpunit.cache/`, `node_modules/.cache/`), do **not** use `sudo` and do **not** `chown`/`rm` on the host (the agent has neither permission). Delete them from inside a throwaway **root** container that bind-mounts the worktrees parent — a root container can remove root-owned files:
+   ```bash
+   docker run --rm -v <abs-path>/.claude/worktrees:/wt alpine rm -rf /wt/<worktree-basename>
+   git worktree prune
+   ```
+   If Docker itself is unavailable (e.g. the user is mid-cleanup), flag the path and skip — never `sudo`.
+
+3. **Delete the branch.** `git branch -d <branch>` — use **`-d`, not `-D`**. If git refuses (unmerged — common with squash-merged PRs whose tip is not an ancestor of `main`), confirm the PR is merged on GitHub (`gh pr view`), then it is safe; flag it and let the user `-D`, or skip. Never force-delete blindly.
+
+4. **Skeletons.** Also clean the `worktree-agent-<id>` branches that `EnterWorktree` leaves behind: `git branch -d worktree-agent-<id>`.
 
 Worktrees live under the gitignored `.claude/worktrees/`, so these removals are purely local.
 

--- a/.claude/skills/close/SKILL.md
+++ b/.claude/skills/close/SKILL.md
@@ -48,6 +48,10 @@ For each branch whose PR is **merged or closed**, in this order:
 
 2. **Remove the worktree.** Worktrees created via `EnterWorktree` are locked: `git worktree unlock <path>` then `git worktree remove <path>`, finally `git worktree prune`. If the remove fails with **Permission denied** because a sub-tree holds files written by Docker as root (typically `pwa/test-results/`, `recette-report/`, `.features-gen/`, `.phpunit.cache/`, `node_modules/.cache/`), do **not** use `sudo` and do **not** `chown`/`rm` on the host (the agent has neither permission). Delete them from inside a throwaway **root** container that bind-mounts the worktrees parent — a root container can remove root-owned files:
    ```bash
+   # Safety: assert <worktree-basename> is non-empty and contains no path
+   # separator before running — an empty value expands to `rm -rf /wt/` and
+   # wipes every worktree in the mount. For agent-<hex> names this is always
+   # safe; double-check if the worktree was created with a custom path.
    docker run --rm -v <abs-path>/.claude/worktrees:/wt alpine rm -rf /wt/<worktree-basename>
    git worktree prune
    ```

--- a/.claude/skills/sprint/SKILL.md
+++ b/.claude/skills/sprint/SKILL.md
@@ -107,6 +107,16 @@ Each cycle:
    Address every **actionable** point, commit, push, then reply to / resolve the corresponding threads. List any comment you deliberately did not action, with the reason.
 3. **Conflicts** — `gh pr view <pr> --json mergeable,mergeStateStatus`. If `CONFLICTING`: rebase onto the base branch and resolve **conservatively**. If the resolution is ambiguous or risks discarding work, **stop and flag it** — do not force a resolution.
 4. **Parent moved (stacked PR)** — if the PR's base is `feature/<n>` and that branch advanced on origin since the last sync (compare local merge-base vs `origin/feature/<n>`), rebase onto it: `git fetch origin feature/<n> && git rebase origin/feature/<n>`, then `git push --force-with-lease`. **Whenever you push new commits to a parent branch (Phase 4 cycle on that PR), immediately re-rebase every child PR onto it** to keep the stack consistent — the GitHub UI does not do this for you and the stale child will hit a phantom conflict at merge time.
+5. **Parent merged (squash) — child retargeted to `main`** — when a parent PR is **squash-merged** and its branch deleted, GitHub retargets the child PR onto `main`, but the child branch still carries the parent's pre-squash commits, so a plain `git rebase origin/main` conflicts and `mergeable` shows `CONFLICTING`. Do **not** rebase onto `main` directly. Instead replay only the child's own commits with `--onto`, dropping the now-merged parent commits:
+   ```bash
+   git fetch origin
+   # <last-parent-commit> = the child's branch point off the parent, i.e. the
+   # last commit in `git log origin/main..feature/<child>` that belongs to the
+   # parent (everything above it is the child's own work to keep).
+   git rebase --onto origin/main <last-parent-commit> feature/<child>
+   git push --force-with-lease
+   ```
+   Verify afterwards that `git log origin/main..HEAD` lists **only** the child's commits. For a 3-deep stack (A→B→C), do this bottom-up as each parent merges.
 
 **Termination (READY)** when all hold: CI green **AND** `mergeable` **AND** not draft **AND** `claude-code-review.yml` has completed (`gh run view --workflow=claude-code-review.yml` shows `completed`) with **no new blocking comment** (Critical/High). Wait for that workflow to finish before evaluating its output — after a push it is triggered asynchronously and may still be `pending`/`in_progress`.
 

--- a/.claude/skills/sprint/SKILL.md
+++ b/.claude/skills/sprint/SKILL.md
@@ -110,9 +110,10 @@ Each cycle:
 5. **Parent merged (squash) — child retargeted to `main`** — when a parent PR is **squash-merged** and its branch deleted, GitHub retargets the child PR onto `main`, but the child branch still carries the parent's pre-squash commits, so a plain `git rebase origin/main` conflicts and `mergeable` shows `CONFLICTING`. Do **not** rebase onto `main` directly. Instead replay only the child's own commits with `--onto`, dropping the now-merged parent commits:
    ```bash
    git fetch origin
-   # <last-parent-commit> = the child's branch point off the parent, i.e. the
-   # last commit in `git log origin/main..feature/<child>` that belongs to the
-   # parent (everything above it is the child's own work to keep).
+   # <last-parent-commit> = the tip of the former parent branch before squash,
+   # i.e. the most-recent (top-most) commit in
+   # `git log origin/main..feature/<child>` that belongs to the parent.
+   # Everything above it in the log is the child's own work to replay.
    git rebase --onto origin/main <last-parent-commit> feature/<child>
    git push --force-with-lease
    ```


### PR DESCRIPTION
Rétrospective Sprint 34 — corrections de process actées dans les skills (points #2, #5 et bonus validés).

## #2 — `sprint` skill : rebase d'une PR enfant après squash-merge du parent
Le skill couvrait déjà « le parent a avancé » (`git rebase origin/feature/<n>`). Ajout du cas réellement rencontré ce sprint (chaîne 549→383→384) : quand le parent est **squash-mergé** et sa branche supprimée, l'enfant retargeté sur `main` porte encore les commits pré-squash → `CONFLICTING`. Recette ajoutée :
```bash
git rebase --onto origin/main <last-parent-commit> feature/<child>
git push --force-with-lease
```

## #5 — `close` skill : suppression des fichiers root-owned sans sudo
`make test-e2e`/`test-recette` lancent Playwright en **root** (pas de `--user`) → `test-results/`, `recette-report/`, `.features-gen/` écrits en root dans le worktree → `git worktree remove` échoue, et l'agent ne peut ni `rm` ni `chown`. Remplacement du « flag and stop » par la suppression via **conteneur root jetable** :
```bash
docker run --rm -v <abs>/.claude/worktrees:/wt alpine rm -rf /wt/<basename>
git worktree prune
```

## Bonus — `close` skill : démontage de la stack Docker du worktree
Chaque worktree lance un `docker compose up` complet sous un projet par worktree. Ajout, avant suppression de chaque worktree :
```bash
docker compose -p <worktree-basename> down --volumes --remove-orphans
```

Step 4 du skill `close` réordonné : (1) down Docker → (2) worktree remove (+ fallback conteneur root) → (3) `git branch -d` → (4) skeletons.

## Hors périmètre (décidé)
- Préventif Makefile `--user` : écarté (risque npm/node_modules en non-root).
- TRACKING double-edit (#3) et cross-check ADR↔privacy (#4) : ignorés (cas particuliers).
- Aucun changement `settings.json` → pas d'application manuelle requise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

**0 findings.** Both warnings from the previous review were addressed in commit `27cd3a2`.

Reviewed commit `27cd3a2`.

**Resolved 2 previously open threads** (parent-tip ambiguity in sprint/SKILL.md; missing safety guard in close/SKILL.md — both fixes present in the current diff).

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases (N/A — skill instruction files only)
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**No inline comments.**

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->