### PR TITLE
fix(test): use a relative future start date in RestDayInsertProcessorTest

### DIFF
--- a/api/tests/Unit/State/RestDayInsertProcessorTest.php
+++ b/api/tests/Unit/State/RestDayInsertProcessorTest.php
@@ -251,7 +251,9 @@ final class RestDayInsertProcessorTest extends TestCase
         $stage0 = new Stage(tripId: 'trip-1', dayNumber: 1, distance: 80.0, elevation: 500.0, startPoint: $coord, endPoint: $coord);
 
         $tripRequest = new TripRequest();
-        $tripRequest->startDate = new \DateTimeImmutable('2026-06-01');
+        // Relative future date so the trip is never locked (startDate <= today),
+        // otherwise this test becomes a time bomb once the hard-coded day passes.
+        $tripRequest->startDate = new \DateTimeImmutable('+1 month');
 
         $this->tripStateManager->method('getStages')->willReturn([$stage0]);
         $this->tripStateManager->method('getRequest')->willReturn($tripRequest);


### PR DESCRIPTION
## Problème

`PHPUnit (api)` échoue depuis le **2026-06-01** sur `main` et donc sur toute PR ouverte ce jour :

```
RestDayInsertProcessorTest::dispatchesFetchWeatherAndCheckCalendarWhenStartDateIsSet
HttpException: This trip is locked: its start date is today or in the past.
```

Le test codait `startDate = '2026-06-01'` pour garder le trip déverrouillé, mais `TripLocker::isLocked` verrouille tout trip dont `startDate <= today` (UTC). Le 2026-06-01, la date est devenue « aujourd'hui » → `HTTP 423` → erreur. Bug **calendaire**, sans rapport avec une feature.

## Correctif

`startDate` passe à une date relative `'+1 month'` (toujours future, jamais verrouillée). Le test `lockedTripThrowsHttpException` utilise déjà ce style relatif (`'yesterday'`).

## Vérification

```
$ docker compose run --rm --no-deps php vendor/bin/phpunit --filter RestDayInsertProcessorTest --no-coverage
OK (9 tests, 33 assertions)
```

## Suivi (hors scope ici)

Plusieurs suites codent encore `startDate = '2026-07-01'` (StageCreate/Delete/Move/Update, TripChat, TripAnalyze, …) — **même classe de bombe à retardement**, due le 2026-07-01. À traiter par un balayage dédié (dates relatives).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

Clean, minimal, and correct fix. The relative `'+1 month'` date eliminates the time-bomb without touching any production code, and is consistent with the `'yesterday'` pattern already used in the same test class.

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [N/A] Dependent tickets accounted for

No inline comments.

> Reviewed commit `5ee3dba9c44aae70d3bfbc463427767e169c4b88` · No previous bot review threads to resolve.

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->