### PR TITLE
feat(llm): profil beta — modèle 3B unique + Ollama on-demand

### DIFF
--- a/api/.env
+++ b/api/.env
@@ -87,5 +87,10 @@ DATATOURISME_ENABLED=false
 WIKIDATA_USER_AGENT="BikeTripPlanner/1.0 (contact@example.org)"
 OLLAMA_BASE_URL=http://ollama:11434
 OLLAMA_ENABLED=0
+# Beta profile (<10 users, Oracle ARM 24GB/4c): single 3B model for both
+# analysis passes (stage + overview); chat is already 3B. Reactivate 8B per
+# pass by overriding these to llama3.1:8b. See issue #563.
+OLLAMA_STAGE_MODEL=llama3.2:3b
+OLLAMA_OVERVIEW_MODEL=llama3.2:3b
 ###< app ###
 

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -118,6 +118,14 @@ services:
     restart: unless-stopped
     expose:
       - 11434
+    environment:
+      # Beta profile (issue #563): right-size for Oracle ARM (24GB/4c, <10 users).
+      # One resident model at a time, two parallel slots for chat <-> analysis
+      # coexistence, 5m keep_alive so models unload at rest (~0GB idle, ~2.3GB
+      # during a 3B analysis). Cold-start (~3-8s) is invisible behind async phase 2.
+      OLLAMA_MAX_LOADED_MODELS: "1"
+      OLLAMA_NUM_PARALLEL: "2"
+      OLLAMA_KEEP_ALIVE: "5m"
     volumes:
       - ollama-data:/root/.ollama
     healthcheck:

--- a/docs/runbooks/ollama-down.md
+++ b/docs/runbooks/ollama-down.md
@@ -22,12 +22,13 @@ Probe the API directly:
 docker compose exec php curl -sS http://ollama:11434/api/tags | jq '.models[].name'
 ```
 
-Expected models per ADR-028:
+Expected models (beta profile, issue #563 — single 3B for analysis + chat):
 
-- `llama3.1:8b` (analysis pass, `num_ctx: 8192`, 60 s timeout)
-- `llama3.2:3b` (dialogue pass, 10 s timeout)
+- `llama3.2:3b` (analysis passes — stage + overview, `num_ctx: 8192`, 60 s timeout; and dialogue pass, 10 s timeout)
 
-Check RAM pressure on the VM (Ollama is the largest single consumer, ~6-8 GB):
+8B (`llama3.1:8b`) is reactivable per pass via `OLLAMA_STAGE_MODEL` / `OLLAMA_OVERVIEW_MODEL`.
+
+Check RAM pressure on the VM (Ollama loads on demand with `OLLAMA_KEEP_ALIVE=5m` — ~0 GB idle, ~2.3 GB during a 3B analysis):
 
 ```bash
 free -h
@@ -44,14 +45,13 @@ docker stats --no-stream ollama
 
    Wait for the healthcheck (`ollama list`) to go green before retrying any failed message.
 
-2. **Re-pull missing models** (if `/api/tags` returned an empty or partial list):
+2. **Re-pull the missing model** (if `/api/tags` returned an empty list):
 
    ```bash
-   docker compose exec ollama ollama pull llama3.1:8b
    docker compose exec ollama ollama pull llama3.2:3b
    ```
 
-   Operators on resource-constrained hardware may substitute `llama3.2:1b` / `llama3.1:8b-q4_K_M` per ADR-028 — never disable the LLM tier.
+   Operators on resource-constrained hardware may substitute `llama3.2:1b` per ADR-028 — never disable the LLM tier. Re-pull `llama3.1:8b` only if it was reactivated via `OLLAMA_STAGE_MODEL` / `OLLAMA_OVERVIEW_MODEL`.
 
 3. **Replay failed Messenger messages** once Ollama is healthy:
 
@@ -66,7 +66,7 @@ docker stats --no-stream ollama
 
 ## Post-action
 
-- `curl http://ollama:11434/api/tags` lists both expected models.
+- `curl http://ollama:11434/api/tags` lists `llama3.2:3b` (it appears once probed/loaded on demand).
 - `/api/health` shows `deps.ollama.status: "ok"` for two consecutive probes.
 - Replay successful — `failed` transport empty.
 - If a model was re-pulled, note the size and time in the incident issue (network bandwidth cost on Oracle).


### PR DESCRIPTION
Closes #563.

## Summary

Right-sizing du profil beta (<10 users, Oracle Free Tier) sur un seul modèle 3B avec Ollama chargé à la demande.

- `api/.env` : `OLLAMA_STAGE_MODEL=llama3.2:3b` + `OLLAMA_OVERVIEW_MODEL=llama3.2:3b` (chat déjà en 3B). Défaut code `llama3.1:8b` réactivable par env.
- `compose.dev.yaml` : service `ollama` reçoit `OLLAMA_MAX_LOADED_MODELS=1`, `OLLAMA_NUM_PARALLEL=2`, `OLLAMA_KEEP_ALIVE=5m` (chargement on-demand → ~0 GB repos, ~2,3 GB pendant analyse).
- `docs/runbooks/ollama-down.md` : pull uniquement `llama3.2:3b`, empreinte mémoire on-demand, 8B réactivable.

En prod le service Ollama est une stack Coolify séparée (hors repo) : les knobs serveur s'y posent via env.

## Test plan

- [x] `make qa` (PHP-CS-Fixer / Rector / PHPStan L9) vert, aucun autofix
- [ ] `docker stats` : Ollama ~0 au repos, ~2,3 GB pendant une analyse (recette manuelle)
- [ ] `/api/healthz` vert, analyse de bout en bout en 3B (recette manuelle)

## Auto-critique

- Aucun service `ollama` dans `compose.yaml` (iso-prod) : les knobs ne s'appliquent qu'en dev via `compose.dev.yaml` ; la prod dépend de la config Coolify, à documenter côté ADR-039 (#570).
- Pas de DTO / dépendance modifiés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

Config-only, well-scoped change. The env defaults, compose knobs, and runbook update are internally consistent. No correctness, security, or performance issues found.

**Findings:** 0 critical · 0 warning · 1 info (noted below, not blocking)

**Resolved threads:** none (no prior review threads existed).

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases — N/A (config/doc change only)
- [ ] Documentation is up to date — ADR-028 and ADR-019 still reference `llama3.1:8b` as the analysis model; disk storage figures in ADR-019 (`~10 GB`) are now overstated. Author acknowledged the gap in auto-critique (deferred to ADR-039 / #570).
- [x] Dependent tickets accounted for (#570 tracks the ADR update)

### Notes

**`DEFAULT_MODEL` / `.env` divergence (info, not blocking):** Both `AnalyzeStageWithLlmHandler` and `AnalyzeTripOverviewWithLlmHandler` hard-code `DEFAULT_MODEL = 'llama3.1:8b'` as the code-level fallback (`default::` env processor). The `.env` now defaults to `llama3.2:3b`. This is intentional (env overrides code fallback for the beta profile; 8B remains the code-level safe default for operators who do not propagate `.env` defaults). The relationship is correct but the class docstrings still say "LLaMA 8B pass-1" which will read as stale — worth updating in a follow-up.

**No inline comments.**

---
_Reviewed commit: `c0bed78` — Generated with [Claude Code](https://claude.ai/code)_
<!-- claude-review-end -->