### PR TITLE
refactor(llm): split ollama analysis/chat endpoints (OLLAMA_ANALYSIS_URL / OLLAMA_CHAT_URL)

### DIFF
--- a/api/.env
+++ b/api/.env
@@ -86,6 +86,11 @@ DATATOURISME_API_KEY=
 DATATOURISME_ENABLED=false
 WIKIDATA_USER_AGENT="BikeTripPlanner/1.0 (contact@example.org)"
 OLLAMA_BASE_URL=http://ollama:11434
+# Analysis and chat are split at the client level (issue #564); both default to the
+# same Ollama instance in beta. Override independently to point analysis at a
+# dedicated 8B service (or a managed endpoint) without touching the chat path.
+OLLAMA_ANALYSIS_URL=${OLLAMA_BASE_URL}
+OLLAMA_CHAT_URL=${OLLAMA_BASE_URL}
 OLLAMA_ENABLED=0
 # Beta profile (<10 users, Oracle ARM 24GB/4c): single 3B model for both
 # analysis passes (stage + overview); chat is already 3B. Reactivate 8B per

--- a/api/config/packages/ai_ollama_platform.php
+++ b/api/config/packages/ai_ollama_platform.php
@@ -5,10 +5,14 @@ declare(strict_types=1);
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
+    // The AI bundle builds a single `ai.platform.ollama` from this config; we bind it
+    // to the chat-scoped HTTP client. A second, analysis-scoped Platform + OllamaClient
+    // is wired manually in services.php (issue #564). Both clients default to the same
+    // Ollama instance in beta, so behaviour is unchanged.
     $containerConfigurator->extension('ai', [
         'platform' => [
             'ollama' => [
-                'http_client' => 'ollama.client',
+                'http_client' => 'ollama_chat.client',
             ],
         ],
     ]);

--- a/api/config/packages/framework.php
+++ b/api/config/packages/framework.php
@@ -100,8 +100,22 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                     'max_redirects' => 2,
                     'timeout' => 60,
                 ],
-                'ollama.client' => [
-                    'base_uri' => '%env(OLLAMA_BASE_URL)%',
+                // Analysis and chat are split at the client level (issue #564) so the
+                // async per-stage/overview analysis can later point to a dedicated 8B
+                // service (or a managed endpoint) without touching the chat path —
+                // config-only. Both default to OLLAMA_BASE_URL, so in beta they target
+                // the same Ollama instance and behaviour is unchanged.
+                'ollama_analysis.client' => [
+                    'base_uri' => '%env(OLLAMA_ANALYSIS_URL)%',
+                    'max_redirects' => 0,
+                    'timeout' => 30,
+                    'headers' => [
+                        'Accept' => 'application/json',
+                        'Content-Type' => 'application/json',
+                    ],
+                ],
+                'ollama_chat.client' => [
+                    'base_uri' => '%env(OLLAMA_CHAT_URL)%',
                     'max_redirects' => 0,
                     'timeout' => 30,
                     'headers' => [

--- a/api/config/services.php
+++ b/api/config/services.php
@@ -2,12 +2,20 @@
 
 declare(strict_types=1);
 
+use App\Llm\LlmClientInterface;
+use App\Llm\OllamaClient;
 use App\Mercure\NullTripUpdatePublisher;
 use App\Mercure\TripUpdatePublisher;
 use App\Mercure\TripUpdatePublisherInterface;
+use App\MessageHandler\AnalyzeStageWithLlmHandler;
+use App\MessageHandler\AnalyzeTripOverviewWithLlmHandler;
 use App\Repository\RedisTripRequestRepository;
 use App\Repository\TripRequestRepositoryInterface;
+use Symfony\AI\Platform\Bridge\Ollama\Factory as OllamaPlatformFactory;
+use Symfony\AI\Platform\PlatformInterface;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $containerConfigurator->parameters()
@@ -21,6 +29,45 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->autoconfigure();
 
     $services->load('App\\', __DIR__.'/../src/');
+
+    // Split Ollama analysis vs chat at the client level (issue #564). The chat
+    // OllamaClient reuses the bundle-built `ai.platform.ollama` platform (bound to
+    // `ollama_chat.client` in ai_ollama_platform.php); the analysis OllamaClient gets
+    // its own Platform built on the `ollama_analysis.client` scoped HTTP client. Both
+    // clients default to the same Ollama instance in beta, so behaviour is unchanged.
+    $services->set('app.llm.ollama_platform.analysis', PlatformInterface::class)
+        ->factory([OllamaPlatformFactory::class, 'createPlatform'])
+        ->lazy()
+        ->args([
+            null,
+            null,
+            service('ollama_analysis.client'),
+            service('ai.platform.contract.ollama'),
+            service('event_dispatcher'),
+        ]);
+
+    // Chat client: default LlmClientInterface (in-ride assistant, POI intent, chat).
+    $services->set(OllamaClient::class)
+        ->args([
+            service(PlatformInterface::class),
+            service('logger'),
+            '%env(bool:default::OLLAMA_ENABLED)%',
+        ]);
+
+    $services->set('app.llm.ollama_client.analysis', OllamaClient::class)
+        ->args([
+            service('app.llm.ollama_platform.analysis'),
+            service('logger'),
+            '%env(bool:default::OLLAMA_ENABLED)%',
+        ]);
+
+    $services->alias(LlmClientInterface::class, OllamaClient::class);
+
+    // Async analysis handlers (pass-1 per stage, pass-2 overview) use the analysis client.
+    $services->get(AnalyzeStageWithLlmHandler::class)
+        ->arg('$llmClient', service('app.llm.ollama_client.analysis'));
+    $services->get(AnalyzeTripOverviewWithLlmHandler::class)
+        ->arg('$llmClient', service('app.llm.ollama_client.analysis'));
 
     if ('test' === $containerConfigurator->env()) {
         $services->alias(TripUpdatePublisherInterface::class, NullTripUpdatePublisher::class);

--- a/api/src/Controller/HealthController.php
+++ b/api/src/Controller/HealthController.php
@@ -31,7 +31,7 @@ final readonly class HealthController
         private Connection $connection,
         #[Autowire(service: 'routing.client')]
         private HttpClientInterface $valhallaClient,
-        #[Autowire(service: 'ollama.client')]
+        #[Autowire(service: 'ollama_chat.client')]
         private HttpClientInterface $ollamaClient,
         #[Autowire(service: 'mercure.health.client')]
         private HttpClientInterface $mercureClient,

--- a/api/src/Controller/HealthController.php
+++ b/api/src/Controller/HealthController.php
@@ -32,7 +32,9 @@ final readonly class HealthController
         #[Autowire(service: 'routing.client')]
         private HttpClientInterface $valhallaClient,
         #[Autowire(service: 'ollama_chat.client')]
-        private HttpClientInterface $ollamaClient,
+        private HttpClientInterface $ollamaChatClient,
+        #[Autowire(service: 'ollama_analysis.client')]
+        private HttpClientInterface $ollamaAnalysisClient,
         #[Autowire(service: 'mercure.health.client')]
         private HttpClientInterface $mercureClient,
         #[Autowire(service: 'limiter.health_liveness')]
@@ -74,7 +76,8 @@ final readonly class HealthController
         $pending = [
             'mercure' => $this->startHttpCheck('HEAD', '?topic=health', $this->mercureClient),
             'valhalla' => $this->startHttpCheck('GET', '/status', $this->valhallaClient),
-            'ollama' => $this->startHttpCheck('GET', '/api/tags', $this->ollamaClient),
+            'ollama_chat' => $this->startHttpCheck('GET', '/api/tags', $this->ollamaChatClient),
+            'ollama_analysis' => $this->startHttpCheck('GET', '/api/tags', $this->ollamaAnalysisClient),
         ];
 
         foreach ($pending as $name => $pair) {

--- a/api/tests/Functional/HealthControllerTest.php
+++ b/api/tests/Functional/HealthControllerTest.php
@@ -208,7 +208,7 @@ final class HealthControllerTest extends ApiTestCase
     ): void {
         $container = self::getContainer();
         $container->set('routing.client', new MockHttpClient($valhalla));
-        $container->set('ollama.client', new MockHttpClient($ollama));
+        $container->set('ollama_chat.client', new MockHttpClient($ollama));
         $container->set('mercure.health.client', new MockHttpClient($mercure));
     }
 }

--- a/api/tests/Functional/HealthControllerTest.php
+++ b/api/tests/Functional/HealthControllerTest.php
@@ -78,7 +78,7 @@ final class HealthControllerTest extends ApiTestCase
         $data = $response->toArray();
         $this->assertSame('ok', $data['status']);
         $this->assertArrayHasKey('deps', $data);
-        foreach (['postgres', 'redis', 'mercure', 'valhalla', 'ollama'] as $dep) {
+        foreach (['postgres', 'redis', 'mercure', 'valhalla', 'ollama_chat', 'ollama_analysis'] as $dep) {
             $this->assertArrayHasKey($dep, $data['deps'], \sprintf('Missing dep %s', $dep));
             $this->assertArrayHasKey('status', $data['deps'][$dep]);
             $this->assertArrayHasKey('latency_ms', $data['deps'][$dep]);
@@ -198,17 +198,39 @@ final class HealthControllerTest extends ApiTestCase
         $this->assertResponseStatusCodeSame(200);
         $data = $response->toArray();
         $this->assertSame('ok', $data['status']);
-        $this->assertSame('down', $data['deps']['ollama']['status']);
+        $this->assertSame('down', $data['deps']['ollama_chat']['status']);
+    }
+
+    #[Test]
+    public function readinessReturns200WhenOllamaAnalysisIsDown(): void
+    {
+        // The analysis client is also excluded from $required; an analysis-only
+        // outage surfaces in deps.ollama_analysis but must not flip the aggregate.
+        $this->mockHealthHttpClients(
+            valhalla: new MockResponse('OK', ['http_code' => 200]),
+            ollama: new MockResponse('{"models":[]}', ['http_code' => 200]),
+            mercure: new MockResponse('', ['http_code' => 200]),
+            ollamaAnalysis: new MockResponse('error', ['http_code' => 503]),
+        );
+
+        $response = $this->client->request('GET', '/api/health');
+
+        $this->assertResponseStatusCodeSame(200);
+        $data = $response->toArray();
+        $this->assertSame('ok', $data['status']);
+        $this->assertSame('down', $data['deps']['ollama_analysis']['status']);
     }
 
     private function mockHealthHttpClients(
         MockResponse $valhalla,
         MockResponse $ollama,
         MockResponse $mercure,
+        ?MockResponse $ollamaAnalysis = null,
     ): void {
         $container = self::getContainer();
         $container->set('routing.client', new MockHttpClient($valhalla));
         $container->set('ollama_chat.client', new MockHttpClient($ollama));
+        $container->set('ollama_analysis.client', new MockHttpClient($ollamaAnalysis ?? new MockResponse('{"models":[]}', ['http_code' => 200])));
         $container->set('mercure.health.client', new MockHttpClient($mercure));
     }
 }

--- a/api/tests/Functional/LlmClientWiringTest.php
+++ b/api/tests/Functional/LlmClientWiringTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Llm\LlmClientInterface;
+use App\Llm\OllamaClient;
+use App\MessageHandler\AnalyzeStageWithLlmHandler;
+use App\MessageHandler\AnalyzeTripOverviewWithLlmHandler;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Guards the DI override that wires the analysis-scoped Ollama client into the
+ * async analysis handlers (#564). Without this, renaming the `$llmClient`
+ * constructor arg would silently fall back to the default chat-aliased client
+ * and analysis would hit the chat endpoint once OLLAMA_ANALYSIS_URL diverges —
+ * no compile error, no other test failure.
+ */
+final class LlmClientWiringTest extends ApiTestCase
+{
+    #[Test]
+    public function analyzeHandlersReceiveTheAnalysisScopedClient(): void
+    {
+        self::bootKernel();
+        $container = self::getContainer();
+
+        $analysisClient = $container->get('app.llm.ollama_client.analysis');
+        $chatClient = $container->get(LlmClientInterface::class);
+
+        self::assertInstanceOf(OllamaClient::class, $analysisClient);
+        self::assertNotSame($chatClient, $analysisClient, 'Analysis and chat clients must be distinct instances.');
+
+        foreach ([AnalyzeStageWithLlmHandler::class, AnalyzeTripOverviewWithLlmHandler::class] as $handlerId) {
+            $handler = $container->get($handlerId);
+            $injected = new \ReflectionProperty($handler, 'llmClient')->getValue($handler);
+            self::assertSame($analysisClient, $injected, \sprintf('%s must receive the analysis-scoped client.', $handlerId));
+        }
+    }
+}

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -25,6 +25,9 @@ services:
       MAILER_DSN: smtp://mailcatcher:1025
       WIKIDATA_USER_AGENT: "${WIKIDATA_USER_AGENT:-BikeTripPlanner/1.0 (contact@example.org)}"
       OLLAMA_BASE_URL: "${OLLAMA_BASE_URL:-http://ollama:11434}"
+      # Split analysis vs chat endpoints (issue #564); both default to OLLAMA_BASE_URL.
+      OLLAMA_ANALYSIS_URL: "${OLLAMA_ANALYSIS_URL:-${OLLAMA_BASE_URL:-http://ollama:11434}}"
+      OLLAMA_CHAT_URL: "${OLLAMA_CHAT_URL:-${OLLAMA_BASE_URL:-http://ollama:11434}}"
       OLLAMA_ENABLED: "${OLLAMA_ENABLED:-0}"
       LOCK_DSN: redis://redis:6379
       # See https://xdebug.org/docs/all_settings#mode
@@ -65,6 +68,9 @@ services:
       MAILER_DSN: smtp://mailcatcher:1025
       WIKIDATA_USER_AGENT: "${WIKIDATA_USER_AGENT:-BikeTripPlanner/1.0 (contact@example.org)}"
       OLLAMA_BASE_URL: "${OLLAMA_BASE_URL:-http://ollama:11434}"
+      # Split analysis vs chat endpoints (issue #564); both default to OLLAMA_BASE_URL.
+      OLLAMA_ANALYSIS_URL: "${OLLAMA_ANALYSIS_URL:-${OLLAMA_BASE_URL:-http://ollama:11434}}"
+      OLLAMA_CHAT_URL: "${OLLAMA_CHAT_URL:-${OLLAMA_BASE_URL:-http://ollama:11434}}"
       OLLAMA_ENABLED: "${OLLAMA_ENABLED:-0}"
       LOCK_DSN: redis://redis:6379
       XDEBUG_MODE: "${XDEBUG_MODE:-off}"

--- a/docs/runbooks/ollama-down.md
+++ b/docs/runbooks/ollama-down.md
@@ -6,7 +6,7 @@ Ollama is a **hard runtime dependency** per ADR-028 — there is no graceful fal
 
 - Trip creation blocks on the brief intake step (PWA wizard hangs on "Analyzing your brief…")
 - PHP logs: `OllamaClient`: timeout, `ConnectException`, or schema validation rejection followed by dead-letter
-- `/api/health` returns HTTP **200** with `deps.ollama.status: "down"` in the body — Ollama is probed but excluded from the required set (`HealthController::$required`), so it does **not** flip the aggregate HTTP status to 503
+- `/api/health` returns HTTP **200** with `deps.ollama_chat.status: "down"` (and `deps.ollama_analysis.status` for the analysis endpoint — same service in beta, distinct once `OLLAMA_ANALYSIS_URL` diverges) in the body — Ollama is probed but excluded from the required set (`HealthController::$required`), so it does **not** flip the aggregate HTTP status to 503
 - Messenger `failed` transport grows with `AnalyzeStageMessage` / brief-intake messages
 
 ## Diagnostic
@@ -62,12 +62,12 @@ docker stats --no-stream ollama
 
 4. **If the OS killed Ollama for OOM**, free RAM before restarting (see `redis-out-of-memory.md` for Redis pressure) and consider lowering Valhalla or worker count temporarily.
 
-5. **As a deployment-level mitigation**, note that `/api/health` stays HTTP 200 on an Ollama-only outage, so Coolify's probe will **not** trip. To gate routing on the LLM tier (maintenance page rather than a half-broken flow), watch `deps.ollama.status` explicitly via Uptime Kuma rather than the aggregate HTTP status.
+5. **As a deployment-level mitigation**, note that `/api/health` stays HTTP 200 on an Ollama-only outage, so Coolify's probe will **not** trip. To gate routing on the LLM tier (maintenance page rather than a half-broken flow), watch `deps.ollama_chat.status` explicitly via Uptime Kuma rather than the aggregate HTTP status.
 
 ## Post-action
 
 - `curl http://ollama:11434/api/tags` lists `llama3.2:3b` (it appears once probed/loaded on demand).
-- `/api/health` shows `deps.ollama.status: "ok"` for two consecutive probes.
+- `/api/health` shows `deps.ollama_chat.status: "ok"` for two consecutive probes.
 - Replay successful — `failed` transport empty.
 - If a model was re-pulled, note the size and time in the incident issue (network bandwidth cost on Oracle).
 - If this is the second occurrence in 7 d, open an issue to investigate persistent memory growth in Ollama.


### PR DESCRIPTION
Closes #564.

## Summary

Scinde le client Ollama unique en deux clients scopés (analyse vs chat) pour pouvoir plus tard pointer l'analyse vers un endpoint dédié 8B / managé GCP en config-only. En beta les deux URLs pointent le même service → comportement inchangé.

- `framework.php` : `ollama.client` → deux clients `ollama_analysis.client` (`OLLAMA_ANALYSIS_URL`) et `ollama_chat.client` (`OLLAMA_CHAT_URL`).
- `ai_ollama_platform.php` : plateforme `ai.platform.ollama` liée à `ollama_chat.client`.
- `services.php` : seconde plateforme analyse + 2e `OllamaClient` (`app.llm.ollama_client.analysis`) ; `LlmClientInterface` aliasé sur le client chat. Call sites analyse (`AnalyzeStageWithLlmHandler`, `AnalyzeTripOverviewWithLlmHandler`) → client analyse ; chat (`InRideAssistant`, `PoiIntentDetector`, `TripChatProcessor`) → client chat.
- `HealthController` + test : sonde repointée sur `ollama_chat.client`.
- `api/.env` : `OLLAMA_ANALYSIS_URL` / `OLLAMA_CHAT_URL` défaut `${OLLAMA_BASE_URL}` (rétro-compat).
- `compose.dev.yaml` : les 2 vars passées à php + worker.

`LlmClientInterface` et le constructeur `OllamaClient` inchangés (modèle par appel).

## Test plan

- [x] `make qa` : PHPStan L9 « No errors » (api + provisioner), CS-Fixer/Rector 0 fix
- [x] Tests LLM/InRide/chat : 186 tests, 501 assertions OK
- [ ] Recette : les 2 URLs sur le même service, comportement inchangé

## Auto-critique

- Le volet pwa de `make qa` n'a pas pu tourner localement (node_modules monté en volume vide) ; aucun fichier frontend touché, CI fera l'install propre.
- Pas de DTO / dépendance modifiés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

All three previous suggestions fully addressed: health-key rename, `LlmClientWiringTest` for DI wiring guard, and the symmetrical `readinessReturns200WhenOllamaAnalysisIsDown` test. The split is clean, security posture is unchanged (scoped clients, `max_redirects: 0`, `timeout: 30`), and documentation is complete (`.env`, `compose.dev.yaml`, runbook).

**Resolved threads:** Resolved 1 previously open thread (`PRRT_kwDORUitfM6GKA9q` — `readinessReturns200WhenOllamaAnalysisIsDown` test, now added).

**PR title:** `couture` in the subject is a French noun — the squash commit message uses `split` which is the correct imperative English form. Consider aligning: `refactor(llm): split ollama analysis/chat endpoints (OLLAMA_ANALYSIS_URL / OLLAMA_CHAT_URL)`.

**Review checklist**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases (`LlmClientWiringTest` guards DI wiring; health tests cover both probes and both down-states)
- [x] Documentation is up to date (runbook, `.env`, `compose.dev.yaml` all updated)
- [x] Dependent tickets accounted for (closes #564)

**Inline comments:** No inline comments.

Reviewed commit `86955585634f95d651b1c77c16814b34ec6e152d`.

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->