### PR TITLE
feat(messenger): add dedicated llm transport and worker-llm (split async/llm)

### DIFF
--- a/api/config/packages/messenger.php
+++ b/api/config/packages/messenger.php
@@ -50,6 +50,11 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 ],
                 'llm' => [
                     'dsn' => '%env(MESSENGER_TRANSPORT_DSN)%',
+                    // Own Redis stream so `messenger:consume llm` and `messenger:consume async`
+                    // don't compete in the same consumer group (which would let fast async jobs
+                    // land on the LLM worker and vice versa, defeating head-of-line isolation).
+                    // Shares the same Redis host/credentials — no new env var needed.
+                    'options' => ['stream' => 'messages-llm'],
                     'retry_strategy' => [
                         'max_retries' => 3,
                         'delay' => 1000,

--- a/api/config/packages/messenger.php
+++ b/api/config/packages/messenger.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Message\AllEnrichmentsCompleted;
 use App\Message\AnalyzeStageWithLlmMessage;
 use App\Message\AnalyzeTerrain;
+use App\Message\AnalyzeTripOverviewWithLlmMessage;
 use App\Message\AnalyzeWind;
 use App\Message\CheckBikeShops;
 use App\Message\CheckBorderCrossing;
@@ -47,6 +48,14 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                         'multiplier' => 2,
                     ],
                 ],
+                'llm' => [
+                    'dsn' => '%env(MESSENGER_TRANSPORT_DSN)%',
+                    'retry_strategy' => [
+                        'max_retries' => 3,
+                        'delay' => 1000,
+                        'multiplier' => 2,
+                    ],
+                ],
                 'failed' => '%env(MESSENGER_FAILED_DSN)%',
             ],
             'routing' => [
@@ -69,7 +78,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 RecalculateStages::class => 'async',
                 ScanEvents::class => 'async',
                 AllEnrichmentsCompleted::class => 'async',
-                AnalyzeStageWithLlmMessage::class => 'async',
+                AnalyzeStageWithLlmMessage::class => 'llm',
+                AnalyzeTripOverviewWithLlmMessage::class => 'llm',
             ],
         ],
     ]);

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -83,6 +83,34 @@ services:
       - ./api:/app
       - /app/var
 
+  worker-llm:
+    image: bike-trip-planner-php:dev
+    build:
+      target: frankenphp_dev
+    read_only: false
+    environment:
+      APP_ENV: dev
+      MAILER_DSN: smtp://mailcatcher:1025
+      WIKIDATA_USER_AGENT: "${WIKIDATA_USER_AGENT:-BikeTripPlanner/1.0 (contact@example.org)}"
+      OLLAMA_BASE_URL: "${OLLAMA_BASE_URL:-http://ollama:11434}"
+      OLLAMA_ENABLED: "${OLLAMA_ENABLED:-0}"
+      LOCK_DSN: redis://redis:6379
+      XDEBUG_MODE: "${XDEBUG_MODE:-off}"
+      JWT_SECRET_KEY: /app/config/jwt/private.pem
+      JWT_PUBLIC_KEY: /app/config/jwt/public.pem
+      JWT_PASSPHRASE: ""
+      FRONTEND_URL: "https://${SERVER_NAME:-localhost}"
+    secrets: !reset null
+    depends_on:
+      ollama:
+        condition: service_healthy
+        required: false
+    extra_hosts:
+      - host.docker.internal:host-gateway
+    volumes: !override
+      - ./api:/app
+      - /app/var
+
   pwa:
     image: bike-trip-planner-pwa:dev
     build:

--- a/compose.yaml
+++ b/compose.yaml
@@ -110,7 +110,7 @@ services:
     tmpfs:
       - /tmp
     deploy:
-      replicas: ${WORKER_REPLICAS:-5}
+      replicas: ${WORKER_REPLICAS:-2}
     depends_on:
       database:
         condition: service_healthy
@@ -154,7 +154,73 @@ services:
       - .docker/php/conf.d/10-app.ini:/usr/local/etc/php/conf.d/zz-app.ini:ro
       - .docker/php/conf.d/20-app.prod.ini:/usr/local/etc/php/conf.d/zz-app.prod.ini:ro
     healthcheck:
-      test: pgrep -f messenger:consume || exit 1
+      test: pgrep -f 'messenger:consume async' || exit 1
+      start_period: 30s
+      interval: 10s
+      timeout: 3s
+      retries: 3
+
+  # Dedicated worker for slow LLM inference jobs. A single replica caps
+  # concurrent inferences at one (4 ARM cores can't run several in parallel
+  # without thrashing) and keeps the `async` workers free of head-of-line
+  # blocking by fast enrichment jobs. See issue #565.
+  worker-llm:
+    image: ${PHP_IMAGE:-bike-trip-planner-php:ci}
+    build:
+      context: ./
+      dockerfile: .docker/php/Dockerfile
+      target: frankenphp_prod
+    command: bin/console messenger:consume llm --time-limit=3600 -vv
+    restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /tmp
+    deploy:
+      replicas: ${WORKER_LLM_REPLICAS:-1}
+    depends_on:
+      database:
+        condition: service_healthy
+      php:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      valhalla:
+        condition: service_healthy
+        required: false
+    environment:
+      APP_ENV: prod
+      TRUSTED_PROXIES: ${TRUSTED_PROXIES:-127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16}
+      TRUSTED_HOSTS: ${TRUSTED_HOSTS:-^${SERVER_NAME:-localhost}|php$$}
+      MERCURE_URL: ${MERCURE_URL:-http://php/.well-known/mercure}
+      MERCURE_PUBLIC_URL: ${MERCURE_PUBLIC_URL:-https://${SERVER_NAME:-localhost}/.well-known/mercure}
+      MERCURE_JWT_SECRET: "${MERCURE_JWT_KEY:-!ChangeThisMercureHubJWTSecretKey!}"
+      MESSENGER_TRANSPORT_DSN: redis://redis:6379/messages
+      MESSENGER_FAILED_DSN: redis://redis:6379/failed
+      REDIS_URL: redis://redis:6379
+      DATABASE_URL: "postgresql://${DATABASE_USERNAME:-app}:${DATABASE_PASSWORD:-!ChangeMe!}@database:5432/${DATABASE_NAME:-bike_trip_planner}?serverVersion=18&charset=utf8"
+      JWT_SECRET_KEY: /run/secrets/jwt_private_key
+      JWT_PUBLIC_KEY: /run/secrets/jwt_public_key
+      JWT_PASSPHRASE: "${JWT_PASSPHRASE}"
+      FRONTEND_URL: "${FRONTEND_URL}"
+      MAILER_DSN: "${MAILER_DSN}"
+      DATATOURISME_API_KEY: "${DATATOURISME_API_KEY:-}"
+      DATATOURISME_ENABLED: "${DATATOURISME_ENABLED:-false}"
+      # Error tracking (P1.1 / ADR-031). Leave SENTRY_DSN empty to disable.
+      SENTRY_DSN: "${SENTRY_DSN:-}"
+      APP_RELEASE: "${APP_RELEASE:-}"
+      # Workers must not run migrations — only the php service does (see ADR-032).
+      MIGRATIONS_ON_BOOT: "false"
+    secrets:
+      - jwt_private_key
+      - jwt_public_key
+    volumes:
+      - php_var:/app/var
+      # Mounted as zz-app.ini so it loads after docker.ini (which sets Europe/Brussels)
+      # and our date.timezone=UTC override takes effect.
+      - .docker/php/conf.d/10-app.ini:/usr/local/etc/php/conf.d/zz-app.ini:ro
+      - .docker/php/conf.d/20-app.prod.ini:/usr/local/etc/php/conf.d/zz-app.prod.ini:ro
+    healthcheck:
+      test: pgrep -f 'messenger:consume llm' || exit 1
       start_period: 30s
       interval: 10s
       timeout: 3s


### PR DESCRIPTION
Closes #565.

## Summary

Isole l'inférence LLM lente du flux d'enrichissement rapide pour éviter le head-of-line blocking sur 4 cœurs ARM.

- `messenger.php` : nouveau transport `llm` (même DSN Redis + retry que `async`) ; `AnalyzeStageWithLlmMessage` re-routé de `async` vers `llm`, `AnalyzeTripOverviewWithLlmMessage` (jusqu'ici non routé) routé vers `llm`.
- `compose.yaml` : `worker` async passe à `WORKER_REPLICAS:-2` (healthcheck `pgrep -f 'messenger:consume async'`) ; nouveau service `worker-llm` (`WORKER_LLM_REPLICAS:-1`, `messenger:consume llm`, healthcheck dédié) cloné du worker.
- `compose.dev.yaml` : override dev `worker-llm` (image frankenphp_dev, env `OLLAMA_*`, dépendance ollama, mount source).

→ au plus 1 inférence à la fois, jobs rapides non bloqués.

## Test plan

- [x] `docker compose config` OK (base + overlay dev)
- [x] `make qa` exit 0, working tree propre
- [ ] Recette : `pgrep` confirme la conso `llm` sur worker-llm / `async` sur workers ; import → preview rapide, analyses IA différées

## Auto-critique

- `compose.yaml` est aussi touché par #566 (limites mémoire, stackée sur cette branche) et #569 (start_period Valhalla) : conflit de merge probable entre #565 et #569, à résoudre conservativement à la fusion.
- Pas de DTO / dépendance modifiés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

The stream isolation concern from the previous review has been fully addressed — the `llm` transport now uses `options.stream: 'messages-llm'` to get its own Redis consumer group, separate from `async`'s `messages` stream. The `compose.dev.yaml` override correctly mirrors the established `worker` pattern. No new issues found.

Resolved 1 previously open thread (stream isolation on `messenger.php` — `options.stream: 'messages-llm'` fix applied in the second commit).

**PR title check:** The title description `transport llm dédié + worker-llm (split async/llm)` is in French/noun form rather than imperative English as required by Conventional Commits. The first commit's headline `feat(messenger): dedicated llm transport + worker-llm (split async/llm)` would be conformant.

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [ ] Tests cover new/changed cases — transport routing isolation is not covered by the automated suite (infrastructure config; `LlmPipelineTest` uses an in-memory bus and cannot catch transport-level misrouting — pre-existing acknowledged gap)
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

No inline comments.

Reviewed commit: `9799bd78882c00ec56d7bc2de2f8f1155b27d409`

---
Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->