### PR TITLE
chore(infra): bound container memory + redis maxmemory(volatile-lru) + postgres limits

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -25,6 +25,12 @@ services:
     read_only: true
     tmpfs:
       - /tmp
+    # Memory budget for the beta profile on a single 24 GB VM (#566). Ollama
+    # inference lives in a separate Coolify resource, so it is not counted here.
+    deploy:
+      resources:
+        limits:
+          memory: 768M
     depends_on:
       database:
         condition: service_healthy
@@ -109,8 +115,13 @@ services:
     read_only: true
     tmpfs:
       - /tmp
+    # Per-replica memory limit (#566). With 2 replicas the async workers cap at
+    # ~1 GB total, matching the ADR-019 RAM estimate for async processing.
     deploy:
       replicas: ${WORKER_REPLICAS:-2}
+      resources:
+        limits:
+          memory: 512M
     depends_on:
       database:
         condition: service_healthy
@@ -175,8 +186,14 @@ services:
     read_only: true
     tmpfs:
       - /tmp
+    # Highest worker limit (#566): the LLM worker buffers prompt/response
+    # payloads, but the heavy inference runs in the separate Ollama resource,
+    # so the worker itself stays modest.
     deploy:
       replicas: ${WORKER_LLM_REPLICAS:-1}
+      resources:
+        limits:
+          memory: 768M
     depends_on:
       database:
         condition: service_healthy
@@ -251,6 +268,11 @@ services:
       secrets:
         - sentry_auth_token
     restart: unless-stopped
+    # Next.js standalone server memory budget (#566).
+    deploy:
+      resources:
+        limits:
+          memory: 512M
     depends_on:
       - php # Mercure dependency
     tty: true
@@ -284,6 +306,11 @@ services:
     image: ghcr.io/gis-ops/docker-valhalla/valhalla:latest
     restart: unless-stopped
     profiles: ["routing"]
+    # Routing engine: tiles + elevation kept in memory (#566, ADR-019 ~1-2 GB).
+    deploy:
+      resources:
+        limits:
+          memory: 2G
     volumes:
       - .docker/osm/data/default.osm.pbf:/custom_files/default.osm.pbf
       - valhalla-tiles:/custom_files
@@ -307,6 +334,23 @@ services:
   database:
     image: postgres:18-alpine
     restart: unless-stopped
+    # Modest tuning for the beta profile (#566): max_connections covers php +
+    # 2 async workers + 1 llm worker + provisioner with headroom; shared_buffers
+    # stays well inside the 1 GB limit below. effective_cache_size tells the
+    # planner how much OS cache to assume (container_limit - shared_buffers -
+    # overhead), not an allocation — keeps cost estimates realistic at 1 GB.
+    command:
+      - postgres
+      - -c
+      - max_connections=50
+      - -c
+      - shared_buffers=256MB
+      - -c
+      - effective_cache_size=768MB
+    deploy:
+      resources:
+        limits:
+          memory: 1G
     environment:
       POSTGRES_DB: "${DATABASE_NAME:-bike_trip_planner}"
       POSTGRES_USER: "${DATABASE_USERNAME:-app}"
@@ -323,6 +367,22 @@ services:
   redis:
     image: redis:8-alpine
     restart: unless-stopped
+    # volatile-lru protects the Messenger queue (its list keys carry no TTL, so
+    # they are never evicted) while letting the TTL-bearing OSM/weather caches be
+    # evicted under pressure — so enqueue (LPUSH) writes keep succeeding instead of
+    # failing with OOM as they would under noeviction. maxmemory sits below the
+    # container limit to leave room for Redis overhead.
+    # See docs/runbooks/redis-out-of-memory.md and issue #566.
+    command:
+      - redis-server
+      - --maxmemory
+      - 384mb
+      - --maxmemory-policy
+      - volatile-lru
+    deploy:
+      resources:
+        limits:
+          memory: 512M
     healthcheck:
       test: [ "CMD", "redis-cli", "--raw", "incr", "ping" ]
       interval: 10s
@@ -339,6 +399,11 @@ services:
       - .docker/osm/data:/data
     restart: "no"
     profiles: ["provisioning"]
+    # One-shot OSM extract job; osmium needs headroom to parse the PBF (#566).
+    deploy:
+      resources:
+        limits:
+          memory: 1G
 
 volumes:
   caddy_data: ~


### PR DESCRIPTION
Closes #566.

> PR stackée sur #581 (feature/565). À rebaser sur `main` après le merge de #565.

## Summary

Filet anti-OOM sur la VM 24 GB partagée : bornes mémoire par conteneur + Redis/Postgres tunés pour le profil beta.

| Service | `deploy.resources.limits.memory` |
|---|---|
| php | 768M |
| worker (async, x2) | 512M chacun |
| worker-llm (x1) | 768M |
| pwa | 512M |
| valhalla | 2G |
| database | 1G |
| redis | 512M |
| provisioner | 1G |

- **Redis** : `command` `--maxmemory 384mb --maxmemory-policy volatile-lru` (protège la file Messenger ; les caches OSM/météo portent des TTLs et seront évincés en premier sous pression).
- **PostgreSQL** : `max_connections=50`, `shared_buffers=256MB` (couvre php + workers + provisioner).

Ollama tourne comme resource Coolify séparée (non comptée). Plafond ~7,5 G pour les services always-on → marge large pour OS/Docker/Coolify + Ollama.

## Test plan

- [x] `docker compose config` OK (base + overlay dev) : limites, redis maxmemory/volatile-lru, postgres bornés rendus
- [x] `php-cs-fixer` OK
- [ ] Recette : `docker stats` sous limites, test de charge léger sans OOM-kill (`dmesg`)

## Auto-critique

- `make qa` n'a pas terminé localement (rector OOM sous pression mémoire des agents parallèles) — changement YAML-only, aucun PHP touché ; CI le confirmera.
- Dimensionnement à valider en recette `docker stats` réelle.
- Pas de DTO / dépendance modifiés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

All previous findings are addressed: `volatile-lru` eviction policy is in place, `effective_cache_size=768MB` was added as suggested, and the PR title now correctly reflects the deployed policy. The implementation is sound and the inline comments throughout the YAML explain the reasoning well. The referenced runbook (`docs/runbooks/redis-out-of-memory.md`) exists. No new findings.

Resolved 0 previously open threads (both prior bot threads were already marked resolved).
Dismissed 1 previous `CHANGES_REQUESTED` review (issue addressed by this commit).

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases *(infra YAML — no unit tests required)*
- [x] Documentation is up to date *(runbook exists, PR summary accurate)*
- [x] Dependent tickets accounted for *(stacked on #581, closes #566)*

### Inline comments

No inline comments.

---

*Reviewed commit: `5126b4c8b83824676e6b0f10458ab363d9d2d0b0`*

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->