### PR TITLE
chore(observability): beta sur SaaS — Sentry + UptimeRobot

### DIFF
--- a/.docker/glitchtip/README.md
+++ b/.docker/glitchtip/README.md
@@ -2,6 +2,8 @@
 
 Production-grade error tracker for Bike Trip Planner. See [ADR-031](../../docs/adr/adr-031-error-tracking-strategy.md) for the rationale.
 
+> **Beta posture (Sprint 34.5, issue #568):** this stack is **not deployed** during the restricted beta. The Sentry SDKs point at **Sentry SaaS free tier** instead (set `SENTRY_DSN` / `NEXT_PUBLIC_SENTRY_DSN` to the SaaS DSN). These files are kept for reversibility: deploy the stack below and switch the DSN/`SENTRY_URL` back to `errors.biketrip.mooo.com` to restore self-hosting. See the "Beta posture" section in ADR-031.
+
 ## Architecture
 
 Four containers on an isolated Docker network:

--- a/.docker/uptime-kuma/README.md
+++ b/.docker/uptime-kuma/README.md
@@ -1,5 +1,12 @@
 # Uptime Kuma — self-hosted monitoring
 
+> **Beta posture (Sprint 34.5, issue #568):** this stack is **not deployed**
+> during the restricted beta. Availability is monitored solely by the external
+> **UptimeRobot** probe on `/api/healthz` (see
+> [`docs/runbooks/uptime-monitoring.md`](../../docs/runbooks/uptime-monitoring.md)).
+> These files are kept for reversibility: deploy the stack below to restore the
+> self-hosted primary layer post-beta.
+
 Uptime Kuma is the **primary** uptime monitor for Bike Trip Planner. It runs on
 the same Coolify host as the application (Oracle Cloud Always Free VM, see
 [ADR-019](../../docs/adr/0019-hosting-coolify-oracle-cloud.md)) and provides

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -400,7 +400,7 @@ Caches : OSM 24h, Wikidata 7j, DataTourisme (par ressource), Open-Meteo 3h.
 | ✅ | Events d'usage | `import_komoot/strava/rwgps/gpx`, `trip_created`, `trip_shared`, `accommodation_selected`, `alert_action_clicked`, `ai_chat_opened`. Sprint 34 #561 |
 | 📅 | Service Plausible CE (Docker) | PostgreSQL + ClickHouse auto-hébergés, sous-domaine dédié. ADR-034 |
 
-> Pas de Google Analytics ni Posthog. Analytics produit : **Plausible Community Edition** auto-hébergé, sans cookie ni PII (IP et User-Agent anonymisés) — voir [ADR-034](docs/adr/adr-034-usage-analytics-plausible.md). Suivi des erreurs : **GlitchTip** auto-hébergé, compatible Sentry — voir [ADR-031](docs/adr/adr-031-error-tracking-strategy.md). L'implémentation native `UsageEvent` initialement envisagée a été abandonnée au profit de Plausible.
+> Pas de Google Analytics ni Posthog. Analytics produit : **Plausible Community Edition** auto-hébergé, sans cookie ni PII (IP et User-Agent anonymisés) — voir [ADR-034](docs/adr/adr-034-usage-analytics-plausible.md). Suivi des erreurs : SDK **Sentry** (backend + PWA), compatible GlitchTip — en beta (Sprint 34.5) pointé sur **Sentry SaaS free**, GlitchTip auto-hébergé conservé mais non déployé (réversible) — voir [ADR-031](docs/adr/adr-031-error-tracking-strategy.md). L'implémentation native `UsageEvent` initialement envisagée a été abandonnée au profit de Plausible.
 
 ---
 
@@ -475,8 +475,8 @@ Caches : OSM 24h, Wikidata 7j, DataTourisme (par ressource), Open-Meteo 3h.
 | ✅ | Coolify | Orchestration des déploiements via webhook. ADR-019 |
 | ✅ | Docker prod | `compose.yaml` (FrankenPHP edge : Caddy + Mercure embarqués, PostgreSQL, Redis, Valhalla) ; dev iso-prod via `compose.dev.yaml`. ADR-037 |
 | ✅ | Healthchecks | `GET /api/healthz` (liveness) + `GET /api/health` (readiness). Sprint 30 #497 |
-| ✅ | Suivi des erreurs GlitchTip | Auto-hébergé, SDK Sentry (backend + PWA). ADR-031. Sprint 30 #500 #495 |
-| ✅ | Monitoring uptime | Uptime Kuma auto-hébergé + UptimeRobot externe, alertes → incidents GitHub. Sprint 30 #499 #502 |
+| ✅ | Suivi des erreurs | SDK Sentry (backend + PWA). **Beta (Sprint 34.5 #568) : Sentry SaaS free**, GlitchTip auto-hébergé conservé mais non déployé — réversible. ADR-031. Sprint 30 #500 #495 |
+| ✅ | Monitoring uptime | **Beta (Sprint 34.5 #568) : UptimeRobot externe seul** sur `/api/healthz` ; Uptime Kuma auto-hébergé conservé mais non déployé. Alertes → incidents GitHub. Sprint 30 #499 #502 |
 | ✅ | Refresh OSM manuel | `make provision-update` + `docker compose restart valhalla`. ADR-036 (supersède ADR-033) |
 | ✅ | Migrations & rollback | Stratégie documentée. ADR-032 |
 | 📅 | Feature-deploy (preview par PR) | Sprint 32 #312 |

--- a/docs/adr/adr-031-error-tracking-strategy.md
+++ b/docs/adr/adr-031-error-tracking-strategy.md
@@ -96,6 +96,20 @@ GlitchTip default retention is 30 days for events; we keep it as is. Aggregated 
 
 - Sentry SDKs are widely used; both LLMs and human developers recognize the patterns. Lock-in is low because GlitchTip implements the public Sentry wire protocol — migrating to another compatible backend is a DSN change.
 
+## Beta posture (Sprint 34.5, issue #568)
+
+For the restricted beta we **do not deploy** the self-hosted GlitchTip stack. Standing up four extra containers (~500 MB RAM, dedicated PostgreSQL + Redis) on the Oracle VM is not justified while traffic is low and the stack is still being stabilised.
+
+Instead, the SDKs (already wired — `sentry/sentry-symfony`, `@sentry/nextjs`) point at **Sentry SaaS free tier** (`sentry.io`, < 5k events/month):
+
+- Set `SENTRY_DSN` (backend, used by `php` + `worker`) and `NEXT_PUBLIC_SENTRY_DSN` (PWA, build arg + SSR) to the Sentry-issued project DSN.
+- The free tier event cap (5k/month) is ample for beta volume; the `before_send` / `beforeSend` filters (404/405/validation, offline, chunk-load, Mercure reconnect) keep noise well under the cap.
+- Source-map upload still works: point `SENTRY_URL`/`SENTRY_ORG`/`SENTRY_PROJECT`/`SENTRY_AUTH_TOKEN` at the Sentry SaaS org instead of the GlitchTip instance.
+
+This intentionally relaxes decision driver #1 (self-hosting) and reverses considered-alternative #1 (Sentry SaaS was originally rejected on principle). The trade-off is explicit and **fully reversible**: GlitchTip is the standing target architecture; the wire protocol is identical, so switching back is a DSN/`SENTRY_URL` change once the GlitchTip stack is deployed. `.docker/glitchtip/` is kept in the repository (not deleted) precisely so the self-hosted topology can be restored without rework.
+
+PII posture is unchanged: `sendDefaultPii: false`, only whitelisted tags and `user.id` (UUID v7) leave the SDK, so no user data is exfiltrated to the SaaS beyond stack traces and those tags.
+
 ## Implementation Notes
 
 - The SentryBundle is registered only in the `prod` environment (see `api/config/bundles.php`) so dev and test never make outbound calls.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -73,8 +73,10 @@ gracefully when Ollama is unreachable. See
 ## Deployment & operations
 
 Production runs as Docker Compose on an Oracle Cloud VM, orchestrated by Coolify and shipped by
-the `deploy.yml` workflow. Errors flow to self-hosted GlitchTip; uptime is watched by Uptime Kuma
-and UptimeRobot. See [Deployment](deployment.md) and the [runbooks](runbooks/).
+the `deploy.yml` workflow. Errors flow through the Sentry SDKs and uptime is probed externally; in
+beta (Sprint 34.5) these point at Sentry SaaS and UptimeRobot, with the self-hosted GlitchTip and
+Uptime Kuma stacks kept in-repo but not deployed (reversible — see ADR-031). See
+[Deployment](deployment.md) and the [runbooks](runbooks/).
 
 ## ADR index by theme
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -30,8 +30,8 @@ When the Sentry/GlitchTip secrets are missing, the `upload-sourcemaps` job is sk
 ## Monitoring & observability
 
 - **Health endpoints** — `GET /api/healthz` (liveness) and `GET /api/health` (readiness); the smoke-test job and the uptime monitors probe these.
-- **Error tracking** — self-hosted GlitchTip (Sentry-compatible) receives backend and PWA errors. See [ADR-031](adr/adr-031-error-tracking-strategy.md) and [.docker/glitchtip](../.docker/glitchtip/README.md).
-- **Uptime** — self-hosted Uptime Kuma plus external UptimeRobot watch the public endpoints. See [runbooks/uptime-monitoring.md](runbooks/uptime-monitoring.md) and [.docker/uptime-kuma](../.docker/uptime-kuma/README.md).
+- **Error tracking** — Sentry SDKs (`sentry/sentry-symfony`, `@sentry/nextjs`) capture backend and PWA errors. **Beta (Sprint 34.5):** the DSNs point at **Sentry SaaS free tier**; the self-hosted GlitchTip stack (`.docker/glitchtip/`) is kept in-repo but not deployed. Reversible by switching `SENTRY_DSN` / `NEXT_PUBLIC_SENTRY_DSN` / `SENTRY_URL` back to the GlitchTip instance. See [ADR-031](adr/adr-031-error-tracking-strategy.md) and [.docker/glitchtip](../.docker/glitchtip/README.md).
+- **Uptime** — **Beta (Sprint 34.5):** only the external **UptimeRobot** probe on `/api/healthz` is active; self-hosted Uptime Kuma (`.docker/uptime-kuma/`) is kept in-repo but not deployed. See [runbooks/uptime-monitoring.md](runbooks/uptime-monitoring.md) and [.docker/uptime-kuma](../.docker/uptime-kuma/README.md).
 - **Incidents** — uptime/error alerts raise a `repository_dispatch` consumed by `.github/workflows/incident-create.yml`, which opens a triaged incident issue. On-call playbooks live in [runbooks/](runbooks/).
 - **OSM data** — routing extracts are refreshed manually (`make provision-update` then restart Valhalla); there is no scheduled job. See [ADR-036](adr/adr-036-manual-osm-data-refresh.md).
 

--- a/docs/runbooks/uptime-monitoring.md
+++ b/docs/runbooks/uptime-monitoring.md
@@ -1,12 +1,23 @@
 # Runbook — Uptime monitoring
 
-Two-layer uptime monitoring for Bike Trip Planner production:
+> **Beta posture (Sprint 34.5, issue #568):** during the restricted beta we run
+> **only the external UptimeRobot monitor** on `/api/healthz`. The self-hosted
+> Uptime Kuma stack (`.docker/uptime-kuma/`) is **not deployed** — its files
+> stay in the repository for reversibility but no container runs on the VM. The
+> single off-host probe on `/api/healthz` (which transitively pings Ollama via
+> the readiness chain) is enough to detect a host-level outage and raise an
+> incident. Re-enable Uptime Kuma later by deploying the stack and restoring the
+> "Self-hosted" layer below. See [ADR-031](../adr/adr-031-error-tracking-strategy.md)
+> for the parallel Sentry-SaaS beta posture.
+
+Target (post-beta) two-layer uptime monitoring for Bike Trip Planner production:
 
 1. **Self-hosted (Uptime Kuma)** on the Coolify VM — sub-minute detection,
    rich monitor types, public status page. Configuration documented in
    [`.docker/uptime-kuma/README.md`](../../.docker/uptime-kuma/README.md).
+   **Not deployed in beta** (see banner above).
 2. **External (UptimeRobot)** — single off-host probe that survives a full VM
-   outage. This document covers (2).
+   outage. **This is the only active layer in beta.** This document covers (2).
 
 ## Why two layers?
 


### PR DESCRIPTION
Closes #568.

## Summary

Documente le choix d'observabilité beta sur services SaaS free (réversible), sans héberger GlitchTip (~1 GB / 4 conteneurs) ni Uptime Kuma sur la VM.

- `docs/adr/adr-031-error-tracking-strategy.md` : section « Beta posture (Sprint 34.5) » → SDK Sentry pointent sur Sentry SaaS free (<5k events/mois) au lieu du GlitchTip auto-hébergé ; réversible (protocole identique, `.docker/glitchtip/` conservé).
- `docs/runbooks/uptime-monitoring.md` : bannière beta → seule la sonde UptimeRobot externe sur `/api/healthz` est active ; Uptime Kuma non déployé mais conservé.
- `docs/deployment.md`, `docs/architecture.md`, `FEATURES.md` : sections observabilité alignées sur la posture beta.
- `.docker/glitchtip/README.md`, `.docker/uptime-kuma/README.md` : notes « non déployé en beta, conservé pour réversibilité » (répertoires non supprimés).

`SENTRY_DSN` / `NEXT_PUBLIC_SENTRY_DSN` déjà câblés dans `compose.yaml` (valeur via env Coolify) → aucune modif compose.

## Test plan

- [x] `make qa` : PHP CS-Fixer / Rector / PHPStan « No errors »
- [x] `markdownlint` 0 erreur sur les 7 fichiers touchés
- [ ] Recette : erreur backend/front remonte dans Sentry SaaS ; monitor UptimeRobot vert

## Auto-critique

- Doc-only ; aucune garantie automatisée que les DSN SaaS sont bien posés en prod (config Coolify hors repo).
- Pas de DTO / dépendance modifiés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

Documentation-only PR — coherent and internally consistent across all 7 files. The PII posture note and the reversibility rationale are clearly articulated in ADR-031; no security or architecture concerns.

**Findings: 0 critical · 0 warning · 1 suggestion (PR title only)**

**PR title check** — `chore(observability): beta sur SaaS — Sentry + UptimeRobot` has two convention issues: (1) all changes are documentation files only, so `docs` is the correct type rather than `chore`; (2) the description is a noun phrase rather than imperative mood — e.g. `docs(observability): document beta SaaS posture — Sentry + UptimeRobot`.

## Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases *(docs-only — no tests required)*
- [x] Documentation is up to date
- [x] Dependent tickets accounted for (#568)

No inline comments. Reviewed commit `4c808629d4db030cb38ca808dcc646da6a5d228d`.

---
Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->