### PR TITLE
chore(provisioning): add france-entière geofabrik entry and monthly osm refresh runbook

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -231,7 +231,12 @@ services:
       interval: 10s
       timeout: 5s
       retries: 3
-      start_period: 600s
+      # France-wide dataset: a cold tile build (no pre-populated valhalla-tiles
+      # volume) runs for hours. Pre-built monthly uploads make restarts fast
+      # (mmap of existing tiles), but the start_period must cover the worst case
+      # so the container is not flapped unhealthy mid-build.
+      # See docs/runbooks/osm-france-refresh.md and ADR-036.
+      start_period: 3600s
 
   database:
     image: postgres:18-alpine

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -22,6 +22,7 @@ Every runbook follows the same four sections:
 | [mercure-disconnected.md](mercure-disconnected.md) | SSE clients cannot reconnect |
 | [ollama-down.md](ollama-down.md) | LLM dependency unreachable (hard dep per ADR-028) |
 | [valhalla-overpass-rebuild.md](valhalla-overpass-rebuild.md) | Routing tiles or POI cache rebuild |
+| [osm-france-refresh.md](osm-france-refresh.md) | Monthly France-wide OSM build + tile upload |
 | [oracle-vm-reclaimed.md](oracle-vm-reclaimed.md) | Oracle Always Free instance reclaimed |
 | [incident-template.md](incident-template.md) | Post-mortem template |
 | [release-rollback.md](release-rollback.md) | Roll back a bad deploy via Coolify |

--- a/docs/runbooks/osm-france-refresh.md
+++ b/docs/runbooks/osm-france-refresh.md
@@ -1,0 +1,177 @@
+# OSM France Refresh — Monthly Local Build + Upload
+
+Production routing targets **France entière** (ADR-036, manual OSM refresh). The
+whole-France Geofabrik extract (~4.4 GB) produces a Valhalla tile set whose
+**build** is expensive: several hours on 4 ARM cores with a 4-8 GB RAM peak —
+well over the 6 h CI runner cap. `build_elevation` is kept.
+
+The build therefore runs **locally and on demand** (target cadence: monthly).
+The resulting tiles are packaged and uploaded to the production VM, the
+`valhalla-tiles` volume is repopulated, and Valhalla is restarted. At serving
+time Valhalla mmaps the tiles (~1.5-2.5 GB resident, ~15-25 GB disk) without
+rebuilding.
+
+`osm-cron` (the former nightly rebuild scheduler) was removed in ADR-036; this
+runbook is its replacement.
+
+## Symptômes
+
+- Scheduled monthly OSM refresh is due (data drifts over weeks, not hours).
+- New cycleways / road closures missing from routes for several weeks.
+- A fresh production VM needs its `valhalla-tiles` volume seeded (see also
+  [oracle-vm-reclaimed.md](oracle-vm-reclaimed.md)).
+
+This is **planned maintenance**, not an incident. For corrupted tiles or a hot
+rebuild, see [valhalla-overpass-rebuild.md](valhalla-overpass-rebuild.md).
+
+## Diagnostic
+
+Confirm what production is currently serving:
+
+```bash
+# On the production host (Coolify SSH), in the application directory:
+docker compose exec valhalla curl -sS http://localhost:8002/status | jq
+docker compose exec valhalla du -sh /custom_files
+docker compose exec valhalla ls -lh /custom_files
+```
+
+A healthy France tile set shows `valhalla_tiles.tar` plus `tiles/` under
+`/custom_files` and a `du -sh` in the 15-25 GB range.
+
+## Procédure
+
+All build steps run on a local workstation (>= 8 GB RAM free, ~30 GB disk).
+Production steps are marked **(prod)** and run on the Coolify host via SSH.
+
+### 1. Build the France tiles locally
+
+```bash
+# Configure the provisioner to target France entière (first run is interactive):
+make provision
+#   -> at the "Which region do you want to add?" prompt, choose:
+#        France (entiere) (4400 MB)
+#   -> confirm; the whole-France PBF is downloaded to
+#      .docker/osm/data/regions/ and merged into
+#      .docker/osm/data/default.osm.pbf
+
+# Subsequent monthly refreshes are non-interactive (re-downloads the saved
+# selection from .docker/osm/data/regions.json):
+make provision-update
+```
+
+Build the Valhalla tiles from that PBF by starting the local `routing` profile
+once. `build_elevation` is on by default in `compose.yaml`:
+
+```bash
+docker compose --profile routing up -d valhalla
+# Watch the build (hours for France entière); wait until /status answers:
+docker compose logs -f valhalla
+docker compose exec valhalla curl -sf http://localhost:8002/status >/dev/null \
+  && echo "tiles ready"
+```
+
+The gis-ops image writes the built graph to `/custom_files/` and packs it into
+`/custom_files/valhalla_tiles.tar`. With `serve_tiles: "True"` a boot that finds
+that tar serves it directly, without rebuilding.
+
+### 2. Package the tiles
+
+```bash
+VOL=$(docker volume ls -q | grep valhalla-tiles)   # e.g. <project>_valhalla-tiles
+docker run --rm -v "$VOL":/src -v "$PWD":/out alpine \
+  tar czf /out/valhalla-france-$(date +%Y%m).tar.gz -C /src valhalla_tiles.tar
+ls -lh valhalla-france-*.tar.gz
+```
+
+Packaging only `valhalla_tiles.tar` (not the unpacked `tiles/` dir) keeps the
+artifact small; the gis-ops entrypoint re-extracts it on boot.
+
+### 3. Upload to the production VM
+
+Pick whichever transport is available. Direct rsync to the host:
+
+```bash
+rsync -avP --partial valhalla-france-YYYYMM.tar.gz \
+  user@prod-host:/tmp/valhalla-france.tar.gz
+```
+
+Or stage in object storage (OCI / Backblaze B2) and pull on the host:
+
+```bash
+# local
+rclone copy valhalla-france-YYYYMM.tar.gz remote:bike-trip-planner/valhalla/
+# (prod)
+rclone copy remote:bike-trip-planner/valhalla/valhalla-france-YYYYMM.tar.gz /tmp/
+mv /tmp/valhalla-france-YYYYMM.tar.gz /tmp/valhalla-france.tar.gz
+```
+
+### 4. Repopulate the `valhalla-tiles` volume **(prod)**
+
+```bash
+# Stop the service so nothing reads the volume mid-write:
+docker compose stop valhalla
+
+VOL=$(docker volume ls -q | grep valhalla-tiles)
+# Wipe the old tiles, then unpack the new tar into the volume root:
+docker run --rm -v "$VOL":/dst alpine \
+  sh -c 'rm -rf /dst/valhalla_tiles /dst/valhalla_tiles.tar /dst/tiles'
+docker run --rm -v "$VOL":/dst -v /tmp:/in alpine \
+  tar xzf /in/valhalla-france.tar.gz -C /dst
+docker run --rm -v "$VOL":/dst alpine ls -lh /dst   # expect valhalla_tiles.tar
+```
+
+### 5. Restart Valhalla **(prod)**
+
+Coolify: redeploy the `valhalla` service from the dashboard, or on the host:
+
+```bash
+docker compose restart valhalla
+```
+
+### 6. Wait for the healthcheck **(prod)**
+
+Serving pre-built tiles is fast (mmap, no rebuild). The `start_period` in
+`compose.yaml` is sized for the worst case (cold build), so do not wait it out —
+poll `/status`:
+
+```bash
+docker compose ps valhalla            # STATUS should reach "healthy"
+docker compose exec valhalla curl -sS http://localhost:8002/status | jq
+```
+
+### 7. Smoke-test `/route` **(prod)**
+
+Lille -> Cassel (Hauts-de-France, ~40 km) must route on the France dataset:
+
+```bash
+docker compose exec php curl -sS -X POST http://valhalla:8002/route \
+  -H 'Content-Type: application/json' \
+  -d '{"locations":[{"lat":50.6292,"lon":3.0573},{"lat":50.8000,"lon":2.4869}],"costing":"bicycle"}' \
+  | jq '.trip.summary'
+```
+
+Expect a non-error response with a `length` of roughly 40-60 km. Confirm the
+application health endpoint too:
+
+```bash
+docker compose exec php curl -sS http://localhost/api/health | jq '.valhalla'
+```
+
+## Post-action
+
+- `docker compose ps valhalla` reports `healthy`; `/api/health` shows
+  `valhalla: ok`.
+- The Lille -> Cassel `/route` smoke test returns a valid trip.
+- Trigger one real trip computation through the app to confirm route + stage
+  generation succeed end to end.
+- Note the build runtime and the artifact name/date in `TRACKING.md` per project
+  conventions; delete the staged `/tmp/valhalla-france.tar.gz` on the host.
+
+## References
+
+- ADR-036 — Manual OSM Data Refresh (supersedes the nightly `osm-cron`)
+- ADR-017 — Valhalla routing engine
+- ADR-020 — Dynamic region provisioning (`provision` command)
+- [valhalla-overpass-rebuild.md](valhalla-overpass-rebuild.md) — corrupted-tile / hot rebuild
+- `Makefile` targets `provision`, `provision-update`, `ensure-default-pbf`
+- `compose.yaml` — `valhalla` service, `valhalla-tiles` volume, healthcheck `start_period`

--- a/provisioner/src/GeofabrikRegionRegistry.php
+++ b/provisioner/src/GeofabrikRegionRegistry.php
@@ -12,6 +12,7 @@ final class GeofabrikRegionRegistry
     public static function all(): array
     {
         return [
+            'France (entiere)' => ['slug' => 'france', 'size' => '4400 MB'],
             'Alsace' => ['slug' => 'alsace', 'size' => '122 MB'],
             'Aquitaine' => ['slug' => 'aquitaine', 'size' => '276 MB'],
             'Auvergne' => ['slug' => 'auvergne', 'size' => '141 MB'],
@@ -44,6 +45,11 @@ final class GeofabrikRegionRegistry
 
     public static function downloadUrl(string $slug): string
     {
+        // The whole-France extract lives one level above the per-region directory.
+        if ('france' === $slug) {
+            return 'https://download.geofabrik.de/europe/france-latest.osm.pbf';
+        }
+
         return \sprintf(
             'https://download.geofabrik.de/europe/france/%s-latest.osm.pbf',
             $slug,

--- a/provisioner/tests/GeofabrikRegionRegistryTest.php
+++ b/provisioner/tests/GeofabrikRegionRegistryTest.php
@@ -62,7 +62,13 @@ final class GeofabrikRegionRegistryTest extends TestCase
     {
         foreach (GeofabrikRegionRegistry::all() as $name => $data) {
             $url = GeofabrikRegionRegistry::downloadUrl($data['slug']);
-            self::assertStringStartsWith('https://download.geofabrik.de/europe/france', $url, $name);
+            if ('france' === $data['slug']) {
+                // Whole-France extract lives one level up, not under /france/.
+                self::assertStringContainsString('/europe/france-latest.osm.pbf', $url, $name);
+            } else {
+                self::assertStringStartsWith('https://download.geofabrik.de/europe/france/', $url, $name);
+            }
+
             self::assertStringEndsWith('-latest.osm.pbf', $url, $name);
         }
     }

--- a/provisioner/tests/GeofabrikRegionRegistryTest.php
+++ b/provisioner/tests/GeofabrikRegionRegistryTest.php
@@ -11,9 +11,24 @@ use Provisioner\GeofabrikRegionRegistry;
 final class GeofabrikRegionRegistryTest extends TestCase
 {
     #[Test]
-    public function allReturns27Regions(): void
+    public function allReturns28Regions(): void
     {
-        self::assertCount(27, GeofabrikRegionRegistry::all());
+        self::assertCount(28, GeofabrikRegionRegistry::all());
+    }
+
+    #[Test]
+    public function allIncludesWholeFrance(): void
+    {
+        self::assertArrayHasKey('France (entiere)', GeofabrikRegionRegistry::all());
+    }
+
+    #[Test]
+    public function downloadUrlForWholeFranceUsesTopLevelExtract(): void
+    {
+        self::assertSame(
+            'https://download.geofabrik.de/europe/france-latest.osm.pbf',
+            GeofabrikRegionRegistry::downloadUrl('france'),
+        );
     }
 
     #[Test]
@@ -47,7 +62,7 @@ final class GeofabrikRegionRegistryTest extends TestCase
     {
         foreach (GeofabrikRegionRegistry::all() as $name => $data) {
             $url = GeofabrikRegionRegistry::downloadUrl($data['slug']);
-            self::assertStringStartsWith('https://download.geofabrik.de/europe/france/', $url, $name);
+            self::assertStringStartsWith('https://download.geofabrik.de/europe/france', $url, $name);
             self::assertStringEndsWith('-latest.osm.pbf', $url, $name);
         }
     }


### PR DESCRIPTION
Closes #569.

> osm-cron nightly déjà retiré par #575 (mergée) / ADR-036 ; vérifié absent de `compose*.yaml`. Cette PR couvre le reste.

## Summary

Cible OSM = **France entière**, buildée en local mensuel (pas de cap CI ni rebuild nightly sur la VM).

- `provisioner/src/GeofabrikRegionRegistry.php` : entrée `France (entiere)` (slug `france`, ~4400 MB). `downloadUrl()` gère le cas spécial (extract un niveau au-dessus : `europe/france-latest.osm.pbf`). Tests : 27→28 régions + 2 tests dédiés.
- `docs/runbooks/osm-france-refresh.md` (créé, indexé dans `docs/runbooks/README.md`) : build local (`make provision`, `build_elevation` conservé) → packaging `valhalla_tiles.tar` → upload (rsync/scp ou OCI/B2) → repeuplement volume `valhalla-tiles` → restart Valhalla (Coolify / `docker compose restart valhalla`) → healthcheck → smoke-test `/route` Lille→Cassel.
- `compose.yaml` : `start_period` Valhalla 600s → 3600s (build à froid France entière sans flap unhealthy ; restarts sur tuiles pré-construites restent rapides via mmap).

## Test plan

- [x] PHPStan api + provisioner « No errors »
- [x] PHPUnit provisioner : 32 tests / 235 assertions OK
- [x] `markdownlint` 0 erreur (runbook + README)
- [ ] Recette : tuiles France servies (`/route` OK), healthcheck vert, runbook rejouable

## Auto-critique

- `compose.yaml` aussi touché par #565/#566 (services workers) : conflit de merge probable avec #565 sur ce fichier, à résoudre conservativement.
- `build_elevation` conservé (consommé par `ValhallaRoutingProvider` + future génération LLaMA #67).
- Pas de DTO / dépendance modifiés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

Clean, well-scoped provisioning change. No new findings — the previous concern about test assertion precision was fully addressed in commit 2 (`test(provisioner): keep strict url prefix for regional slugs`), and the 1 prior bot thread is already resolved.

**PR title check:** `chore(provisioning): OSM France entière — build local mensuel + runbook` — description is not in imperative mood and is partially in French. Suggested fix: `chore(provisioning): add france-entière geofabrik entry and monthly osm refresh runbook`. (Flagged in prior reviews, unchanged.)

### Review checklist
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [ ] Dependent tickets accounted for — merge conflict risk with #565/#566 on `compose.yaml` noted in PR auto-critique

No inline comments.

---
_Reviewed commit `c16a8293f409948b67a44f641b8e5716345d3c57`. Generated with [Claude Code](https://claude.ai/code)_
<!-- claude-review-end -->