### PR TITLE
docs(adr): ADR-039 right-sizing Free Tier + correction budget ADR-019

### DIFF
--- a/docs/LLaMA.md
+++ b/docs/LLaMA.md
@@ -5,6 +5,8 @@
 
 > **Statut :** l'analyse IA (par étape + vue d'ensemble, LLaMA 8B) et l'assistant conversationnel (LLaMA 3B, dont le mode in-ride POI) sont livrés — voir [ADR-028](adr/adr-028-ollama-llama-integration.md) et [ADR-030](adr/adr-030-symfony-ai-adoption.md). La génération d'itinéraire à partir d'un prompt texte (le flux « Brief de Mission » ci-dessous) est une cible non encore implémentée (#67). Ce document décrit l'architecture visée et son raisonnement.
 
+> **Profil beta (3B unique) — [ADR-039](adr/adr-039-beta-right-sizing-free-tier.md).** Sur le free tier Oracle, le facteur limitant est le **CPU** (inférence CPU-only sur 4 cœurs), pas la RAM. En beta (<10 users), seul **`llama3.2:3b`** est chargé, **à la demande** (pas de pinning des deux modèles). Le 8B (analyse) n'est pas résident : l'analyse d'étape utilise le 3B ou est différée. Le travail LLM est sérialisé sur un worker Messenger dédié (`llm`, 1 réplique), séparé des workers `async` I/O-bound. Le 8B résident et l'inférence GPU sont réintroduits lors de la migration GCP (cf. ADR-039). L'architecture multi-modèles décrite ci-dessous reste la cible post-beta.
+
 ---
 
 ## 1. Optimisations de l'Infrastructure

--- a/docs/adr/adr-019-deployment-infrastructure-strategy.md
+++ b/docs/adr/adr-019-deployment-infrastructure-strategy.md
@@ -3,6 +3,9 @@
 - **Status:** Proposed
 - **Date:** 2026-03-04
 - **Depends on:** ADR-016 (performance optimization), ADR-017 (Valhalla + Overpass), ADR-018 (Garmin export)
+- **Amended by:** [ADR-039](adr-039-beta-right-sizing-free-tier.md) (beta right-sizing + corrected budget)
+
+> **Budget correction (2026-06-01).** The RAM budget below was wrong: it counts a local Overpass server that was since removed (ADR-025, public API instead), and it omits the host OS + Docker daemon, the self-hosted observability/analytics stacks (GlitchTip ADR-031, Plausible/ClickHouse ADR-034) and Uptime Kuma, while under-counting Coolify. The "~9.5 GB margin" was illusory: a full self-hosted stack with both LLaMA models resident lands around **17-18 GB**, not 14.5 GB. More importantly, the binding constraint is **CPU** (CPU-only LLaMA inference on 4 cores), not RAM. The corrected RAM/CPU/disk budget and the deployed beta profile (single 3B on demand, split `async`/`llm` workers, SaaS observability, deferred analytics, France-only OSM) are formalised in [ADR-039](adr-039-beta-right-sizing-free-tier.md).
 
 ## Context and Problem Statement
 
@@ -27,11 +30,11 @@ Le projet est aujourd'hui exclusivement développé en local via Docker Compose.
 | Workers (×5) | Traitement async | ~1.5 GB |
 | PostgreSQL | Persistance (planifié) | ~200 MB |
 | Valhalla (ADR-017) | Routing engine | ~1-2 GB |
-| Overpass (ADR-017) | POI discovery | ~2-3 GB |
+| ~~Overpass (ADR-017)~~ | ~~POI discovery~~ — retiré (ADR-025), API publique | ~~2-3 GB~~ |
 | **Ollama (ADR-028)** | **Inférence LLaMA 8B + 3B** | **~6-8 GB** |
-| **Total** | | **~12-17 GB RAM** |
+| **Total** | | voir budget corrigé (ADR-039) |
 
-Stockage disque : ~6 GB (PBF Geofabrik + tiles Valhalla + base Overpass) + ~10 GB (modèles Ollama llama3.1:8b + llama3.2:3b).
+Stockage disque : ~6 GB (PBF Geofabrik France + tiles Valhalla) + ~10 GB (modèles Ollama llama3.1:8b + llama3.2:3b). Le budget RAM/CPU/disque corrigé est dans [ADR-039](adr-039-beta-right-sizing-free-tier.md) ; cette table conserve l'estimation initiale (avant retrait d'Overpass) pour mémoire.
 
 ### Contraintes
 
@@ -263,24 +266,30 @@ C'est la seule infrastructure gratuite offrant suffisamment de ressources (24 GB
                             └──────────┘  └──────────┘
 
                         ┌─────────────────────────────────────┐
-                        │         Estimation RAM totale         │
+                        │  Estimation RAM (CORRIGÉE — ADR-039) │
+                        │  Full self-hosted, both models hot   │
                         │                                       │
-                        │  Coolify + Traefik        ~550 MB    │
+                        │  OS + Docker daemon       ~800 MB    │
+                        │  Coolify + Traefik        ~700 MB    │
                         │  Next.js                  ~600 MB    │
-                        │  PHP (API)                ~500 MB    │
-                        │  Mercure                   ~50 MB    │
-                        │  Redis                    ~100 MB    │
-                        │  PostgreSQL               ~200 MB    │
-                        │  Workers (×5)            ~1500 MB    │
+                        │  PHP (FrankenPHP, API+SSE) ~600 MB   │
+                        │  Redis                    ~150 MB    │
+                        │  PostgreSQL               ~250 MB    │
+                        │  Workers async + llm     ~1000 MB    │
                         │  Valhalla                ~1500 MB    │
-                        │  Overpass                ~2500 MB    │
                         │  Ollama (LLaMA 8B+3B)    ~7000 MB    │
+                        │  GlitchTip (ADR-031)     ~1000 MB    │
+                        │  Plausible + ClickHouse  ~2000 MB    │
+                        │  Uptime Kuma              ~150 MB    │
                         │  ─────────────────────────────────   │
-                        │  Total                  ~14.5 GB     │
+                        │  Total full self-hosted ~17-18 GB    │
                         │  Disponible              24.0 GB     │
-                        │  Marge                    ~9.5 GB    │
+                        │  Marge réelle            ~6-7 GB     │
+                        │  Facteur limitant = CPU (4 cœurs)    │
                         └─────────────────────────────────────┘
 ```
+
+Overpass local est retiré (ADR-025) : POI via l'API publique. La marge "~9.5 GB" du premier brouillon était fausse (cf. note de correction en tête). Le profil réellement déployé en beta (<10 users, modèle 3B unique à la demande, workers `async`/`llm` séparés, observabilité SaaS, analytics différée) tient autour de ~9-9.5 GB et est détaillé dans [ADR-039](adr-039-beta-right-sizing-free-tier.md).
 
 ### Stratégie de déploiement progressive
 
@@ -306,7 +315,7 @@ C'est la seule infrastructure gratuite offrant suffisamment de ressources (24 GB
 - **Fiabilité Oracle** : Oracle peut réclamer les instances inactives. Le free tier peut évoluer sans préavis
 - **Pas de sous-domaine natif** : nécessite un domaine externe (achat ou FreeDNS)
 - **Authentification obligatoire** : le déploiement public impose d'implémenter une couche d'authentification complète (inscription, connexion, sessions, isolation des données) avant la mise en ligne — effort significatif non encore planifié
-- **Ollama = dépendance dure** : l'inférence LLaMA est non-skippable (cf. ADR-028 et issue #375 arbitrage v2 « IA toujours active »). Ollama doit être opérationnel avec les deux modèles (`llama3.1:8b`, `llama3.2:3b`) chargés avant que l'application soit considérée disponible. La marge RAM restante (~9.5 GB) reste confortable sur une VM 24 GB. Le healthcheck Coolify doit inclure un ping Ollama (`GET /api/health`) en plus des healthchecks applicatifs existants.
+- **Ollama = dépendance dure** : l'inférence LLaMA est non-skippable (cf. ADR-028 et issue #375 arbitrage v2 « IA toujours active »). Ollama doit être opérationnel avant que l'application soit considérée disponible. En beta, seul `llama3.2:3b` est chargé à la demande (ADR-039) ; le profil full self-hosted avec les deux modèles résidents (`llama3.1:8b`, `llama3.2:3b`) tient en RAM (~6-7 GB de marge sur 24 GB) mais sature les 4 cœurs CPU — c'est le facteur limitant réel, pas la RAM. Le healthcheck Coolify doit inclure un ping Ollama (`GET /api/health`) en plus des healthchecks applicatifs existants.
 
 ### Neutral
 

--- a/docs/adr/adr-039-beta-right-sizing-free-tier.md
+++ b/docs/adr/adr-039-beta-right-sizing-free-tier.md
@@ -1,6 +1,6 @@
 # ADR-039: Beta Right-Sizing on the Oracle Free Tier + Corrected RAM/CPU/Disk Budget
 
-- **Status:** Accepted
+- **Status:** Proposed — flips to Accepted once the implementing PRs land (#563 merged; #564-#569 open in Sprint 34.5)
 - **Date:** 2026-06-01
 - **Depends on:** ADR-019 (Deployment Infrastructure), ADR-028 (Ollama/LLaMA integration), ADR-031 (Error tracking), ADR-034 (Usage analytics), ADR-037 (Dev/Prod Docker convergence)
 - **Amends:** ADR-019 (RAM budget correction)

--- a/docs/adr/adr-039-beta-right-sizing-free-tier.md
+++ b/docs/adr/adr-039-beta-right-sizing-free-tier.md
@@ -1,0 +1,148 @@
+# ADR-039: Beta Right-Sizing on the Oracle Free Tier + Corrected RAM/CPU/Disk Budget
+
+- **Status:** Accepted
+- **Date:** 2026-06-01
+- **Depends on:** ADR-019 (Deployment Infrastructure), ADR-028 (Ollama/LLaMA integration), ADR-031 (Error tracking), ADR-034 (Usage analytics), ADR-037 (Dev/Prod Docker convergence)
+- **Amends:** ADR-019 (RAM budget correction)
+
+> **Note on numbering.** The source GitHub issue (#570) titled this ADR "ADR-035". ADR-035 was already allocated to RGPD account erasure (sprint 34), and 036 (manual OSM refresh) / 037 (dev/prod convergence) were taken on disk. The next free number, 038, is already claimed by an open PR (#578, backup/DR for #527). To avoid a collision the number slid to **ADR-039**. The technical scope is unchanged.
+
+## Context and Problem Statement
+
+ADR-019 retained the Oracle Cloud Always Free ARM VM (4 OCPUs / 24 GB RAM / 200 GB disk) as the production target, on the basis that it was the only free tier able to run the *complete* self-hosted stack including a local Overpass server. Two things have since changed, and the ADR-019 budget no longer reflects reality:
+
+1. **Overpass local was removed (ADR-025).** POI discovery now uses the public `overpass-api.de` API via the search-corridor strategy. The ~2.5 GB line in the ADR-019 budget for a local Overpass server is dead weight: that service is not deployed.
+
+2. **The ADR-019 budget under-counted everything else.** It omitted the host OS + Docker daemon, the self-hosted observability stack (GlitchTip, ADR-031), uptime monitoring (Uptime Kuma, runbook `uptime-monitoring.md`), and the analytics stack (Plausible CE + ClickHouse, ADR-034). It also under-counted Coolify. The headline "~9.5 GB margin" on a 24 GB VM was therefore illusory: a fully self-hosted stack with both LLaMA models resident, GlitchTip, Plausible/ClickHouse and Uptime Kuma lands around **17-18 GB**, not 14.5 GB.
+
+3. **The real limiting factor is CPU, not RAM.** Inference runs CPU-only on the Ampere A1 (4 cores, no GPU). A single LLaMA generation saturates several cores for seconds; the 8B analysis pass (ADR-028) takes up to ~30 s per stage. With 5 async workers able to fire LLM analyses in parallel, the VM thrashes on CPU long before RAM is exhausted. Sizing the deployment around RAM headroom misses the actual bottleneck.
+
+The project is entering a **closed beta with fewer than 10 users**. We need a deployment profile sized for that reality, not for the theoretical "everyone self-hosted, both models hot, full observability" maximum. This ADR formalises that profile and corrects the ADR-019 budget.
+
+## Decision
+
+Adopt a **beta right-sizing profile** for the Oracle Free Tier deployment, optimised for the CPU bottleneck and a <10-user load, while keeping a clean migration path to GCP when the beta outgrows the free tier.
+
+### 1. Single 3B model, on-demand (no resident 8B)
+
+Run **only `llama3.2:3b`**, loaded on demand rather than kept hot for both models. The 8B analysis model (ADR-028) is not resident in the beta profile: keeping two models pinned in memory is what pushed the budget over, and the 8B pass is the heaviest CPU consumer. The 3B model covers the conversational brief intake and the in-ride POI assistant. Stage analysis narrative either uses the 3B model or is deferred; this is an explicit beta trade-off documented in `docs/LLaMA.md`. Ollama `keep_alive` is tuned so the single model unloads under memory pressure instead of co-resident pinning.
+
+### 2. Split Messenger workers: `async` vs `llm`
+
+Today all messages, including `AnalyzeStageWithLlmMessage`, route to the single `async` transport consumed by `replicas: 5` (see `api/config/packages/messenger.php` and `compose.yaml`). In the beta profile, LLM work is isolated onto its own `llm` transport with a **single** dedicated consumer (`worker-llm`, 1 replica), while the non-LLM enrichments keep the `async` transport with a reduced replica count. This caps concurrent CPU-only inference to one at a time and stops a burst of trip computations from saturating all 4 cores with parallel LLaMA runs. The async (I/O-bound) work stays parallel; the LLM (CPU-bound) work is serialised.
+
+### 3. LLM endpoint seam
+
+Keep the LLM call behind a single endpoint seam (`OLLAMA_BASE_URL`, already an env var in `compose.dev.yaml`) so the inference backend is swappable without code changes. This is what makes the GCP migration path (below) a config change rather than a refactor: point the seam at a GPU-backed or managed inference endpoint and the application is unchanged.
+
+### 4. SaaS observability, deferred analytics
+
+For the beta, **do not self-host the observability and analytics stacks** on the Oracle VM:
+
+- **Error tracking:** use **Sentry SaaS** (free tier) instead of self-hosted GlitchTip (ADR-031). The Sentry SDKs are already wired (`sentry/sentry-symfony`, `@sentry/nextjs`); only the DSN changes. This removes GlitchTip-web/worker/postgres/redis (~500 MB+) from the VM.
+- **Uptime:** use **UptimeRobot** (free external tier) as the primary monitor instead of co-hosted Uptime Kuma. An external monitor is strictly better for the "VM is down" case anyway (a co-hosted monitor dies with the VM).
+- **Analytics:** **defer** the Plausible CE + ClickHouse stack (ADR-034) entirely. ClickHouse is a heavy resident process for <10 users of analytics signal. Analytics is revisited post-beta.
+
+ADR-031 and ADR-034 remain the accepted *target* architecture for a self-hosted, post-beta deployment; this ADR records the beta deviation, not a reversal.
+
+### 5. Memory limits
+
+Apply explicit Docker `mem_limit` / `deploy.resources.limits.memory` to the app services (php, worker, worker-llm, pwa, redis, valhalla) so a single misbehaving service cannot OOM-kill the VM. Without limits, the FrankenPHP workers and Next.js can grow unbounded under load; with the CPU bottleneck this manifests as memory creep during queue backlogs.
+
+### 6. OSM France build local
+
+The Valhalla tiles and the OSM extract are built from the **France** Geofabrik PBF locally on the VM (ADR-017, ADR-033, manual refresh per ADR-036), not pulled as a pre-built artifact. France-only keeps the tile build and disk footprint within the free-tier budget; a wider extract is a post-beta concern tied to the GCP migration.
+
+### Corrected budget
+
+The corrected budget reflects the actual beta profile (single 3B on demand, public Overpass, SaaS observability, deferred analytics) and, separately, the realistic *full self-hosted* maximum that ADR-019 should have shown.
+
+#### Beta profile (deployed)
+
+| Service | Rôle | RAM |
+|---------|------|-----|
+| OS + Docker daemon | Host | ~800 MB |
+| Coolify + Traefik | PaaS + reverse proxy | ~700 MB |
+| PHP (FrankenPHP, API + Mercure embedded) | Backend stateless + SSE | ~600 MB |
+| Next.js | Frontend SSR | ~600 MB |
+| Redis | Cache + queue | ~150 MB |
+| Worker `async` (×2) | Enrichments I/O-bound | ~600 MB |
+| Worker `llm` (×1) | LLM inference, serialised | ~350 MB |
+| PostgreSQL | Persistance | ~250 MB |
+| Valhalla (France) | Routing | ~1.5 GB |
+| Ollama (`llama3.2:3b`, on demand) | Inférence LLM | ~3-4 GB |
+| **Total beta** | | **~9-9.5 GB RAM** |
+
+Observability (Sentry) and uptime (UptimeRobot) are **off-VM SaaS**; analytics is **deferred**. Overpass is the public API (off-VM). Disk: ~5 GB (France PBF + Valhalla tiles) + ~2.5 GB (single 3B model).
+
+#### Full self-hosted maximum (corrected ADR-019 reference)
+
+For completeness, the realistic cost of the *fully self-hosted* target (both models hot, GlitchTip, Plausible/ClickHouse, Uptime Kuma) is:
+
+| Bloc | RAM |
+|------|-----|
+| OS + Docker | ~800 MB |
+| Coolify + Traefik | ~700 MB |
+| App core (php + pwa + redis + postgres + workers) | ~2.5 GB |
+| Valhalla | ~1.5 GB |
+| Ollama (3B + 8B résidents) | ~7 GB |
+| GlitchTip (web + worker + pg + redis) | ~1 GB |
+| Plausible + ClickHouse | ~2 GB |
+| Uptime Kuma | ~150 MB |
+| **Total full self-hosted** | **~17-18 GB RAM** |
+
+This leaves ~6-7 GB headroom on 24 GB, not 9.5 GB — and, more importantly, **RAM is not the binding constraint**. The 4 CPU cores are.
+
+### Limiting factor: CPU
+
+The Ampere A1 has **4 cores and no GPU**. LLaMA inference is CPU-only. A single 3B generation already pins multiple cores for seconds; an 8B analysis pass runs up to ~30 s. The deployment is therefore sized around **inference concurrency**, not RAM:
+
+- One `llm` worker means at most one inference at a time.
+- Async (I/O-bound) work stays parallel and does not contend for the same bottleneck.
+- The reclaim policy (ADR-019: p95 CPU < 20 % over 7 days) is comfortably avoided because even modest beta traffic keeps inference cores busy.
+
+### Migration path to GCP
+
+When the beta outgrows the free tier (more users, resident 8B, faster inference, self-hosted observability), migrate off Oracle to GCP:
+
+1. **Inference:** point `OLLAMA_BASE_URL` at a GPU-backed Compute Engine instance (or a managed endpoint). The endpoint seam (decision 3) makes this a config change. GPU inference removes the CPU bottleneck and unblocks the resident 8B analysis pass.
+2. **Compute:** move the app stack to a GCP VM (Compute Engine) or GKE, sized on the corrected full-stack budget (~18 GB) plus inference.
+3. **Observability/analytics:** re-enable self-hosted GlitchTip (ADR-031) and Plausible CE (ADR-034), or keep SaaS — decided at migration time on cost vs. control.
+4. **Region:** `europe-west1` (Belgium) / `europe-west9` (Paris) for latency + RGPD.
+
+The Docker Compose topology (ADR-037) is portable as-is; the migration is an infrastructure swap, not an application rewrite.
+
+## Consequences
+
+### Positive
+
+- The deployment is sized around the real bottleneck (CPU), so the VM stays responsive under beta load.
+- Serialising LLM work on a dedicated `llm` worker prevents a trip-computation burst from saturating all 4 cores.
+- Dropping GlitchTip, ClickHouse and Uptime Kuma from the VM frees several GB and a lot of CPU for inference.
+- SaaS uptime (UptimeRobot) survives a full VM outage, which a co-hosted monitor cannot.
+- Memory limits prevent a single service from OOM-killing the whole VM.
+- The endpoint seam keeps the GCP migration a config change.
+
+### Negative
+
+- **Beta uses Sentry SaaS:** error data leaves the perimeter (free-tier cap, third party), a deliberate deviation from the ADR-031 self-hosted stance for the beta only.
+- **No analytics during beta:** product usage signal is lost until the Plausible stack is re-enabled post-beta.
+- **No resident 8B:** stage-analysis narrative is degraded (3B or deferred) until the GCP migration provides GPU inference.
+- **Single `llm` worker is a throughput ceiling:** LLM analyses queue behind each other; acceptable at <10 users, a known scaling limit beyond.
+
+### Neutral
+
+- ADR-031 and ADR-034 remain the accepted post-beta target; this ADR records the beta deviation, not a reversal.
+- France-only OSM extract is unchanged from the existing manual-refresh posture (ADR-036).
+
+## Sources
+
+- [ADR-019](adr-019-deployment-infrastructure-strategy.md) — Deployment infrastructure (Oracle Always Free), budget amended by this ADR
+- [ADR-025](adr-025-removal-of-self-hosted-overpass.md) — Removal of self-hosted Overpass (public API)
+- [ADR-028](adr-028-ollama-llama-integration.md) — Ollama/LLaMA integration (2-pass, hard dependency, context window)
+- [ADR-031](adr-031-error-tracking-strategy.md) — Error tracking (GlitchTip self-hosted target)
+- [ADR-034](adr-034-usage-analytics-plausible.md) — Usage analytics (Plausible CE target)
+- [ADR-037](adr-037-docker-dev-prod-convergence.md) — Dev/Prod Docker convergence on FrankenPHP
+- [docs/LLaMA.md](../LLaMA.md) — LLM architecture and beta 3B profile
+- [docs/runbooks/uptime-monitoring.md](../runbooks/uptime-monitoring.md) — Uptime Kuma + UptimeRobot
+- [Oracle Cloud Always Free Resources](https://docs.oracle.com/en-us/iaas/Content/FreeTier/freetier_topic-Always_Free_Resources.htm)


### PR DESCRIPTION
Closes #570.

> L'issue disait « ADR-035 » mais 035 (RGPD), 036, 037 sont pris et 038 est réclamé par #578 (backup/DR) → numéro glissé à **ADR-039**.

## Summary

Formalise le right-sizing beta et corrige le budget RAM erroné d'ADR-019.

- `docs/adr/adr-039-beta-right-sizing-free-tier.md` (créé) : profil beta <10 users (3B unique on-demand, split workers `async`/`llm`, couture endpoint LLM, observabilité SaaS, analytics différée, `mem_limit`, OSM France build local), budget corrigé (beta déployé ~9-9,5 GB ; full self-hosted réaliste ~17-18 GB), **facteur limitant = CPU** (LLaMA CPU-only sur 4 cœurs Ampere A1), chemin de migration GCP.
- `docs/adr/adr-019-deployment-infrastructure-strategy.md` (amendé) : `Amended by: ADR-039`, budget RAM corrigé (OS/Docker, GlitchTip, Plausible/ClickHouse, Uptime Kuma ajoutés ; Overpass barré ADR-025), facteur limitant CPU.
- `docs/LLaMA.md` : encart profil beta 3B (chargement on-demand, worker `llm` dédié, 8B+GPU repoussés à GCP).

## Test plan

- [x] `markdownlint` 0 erreur sur les 3 docs
- [x] `make qa` : PHPStan / CS-Fixer / Rector « No errors »

## Auto-critique

- ADR documentant des décisions implémentées dans #563-#569 : si la numérotation 038/039 bouge (selon merge de #578), un resync de réf sera nécessaire.
- Doc-only ; pas de DTO / dépendance modifiés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

**No blocking findings.** The previous review concern (ADR-039 status "Accepted" while implementation was missing) was correctly addressed in the second commit — the status is now "Proposed — flips to Accepted once implementing PRs land (#563 merged; #564-#569 open in Sprint 34.5)". The ADR is well-structured, the budget correction is accurate, and the CPU-as-limiting-factor rationale is sound. One minor PR title convention issue remains.

### PR title

`docs(adr): ADR-039 right-sizing Free Tier + correction budget ADR-019` — the description is a noun phrase, not imperative mood. The commit messages inside the PR already use the correct form. Suggested title: `docs(adr): add ADR-039 beta right-sizing + correct ADR-019 budget`.

### Resolved threads

1 thread resolved (claude[bot] warning about ADR status — addressed in commit 2).

### Review checklist

- [ ] Code respects the project architecture — **N/A** (doc-only)
- [ ] SOLID principles and Law of Demeter followed — **N/A** (doc-only)
- [ ] Design patterns used where appropriate — **N/A** (doc-only)
- [ ] Tests cover new/changed cases — **N/A** (doc-only)
- [x] Documentation is up to date — ADR-039 correctly marked "Proposed"; ADR-019 amended with cross-reference; `docs/LLaMA.md` updated with beta 3B profile
- [x] Dependent tickets accounted for — numbering dependency on #578 noted in auto-critique; implementation dependency on #563-#569 stated in ADR status

### Inline comments

0 inline comments (no code-level issues to flag in a doc-only PR).

---

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->