### PR TITLE
docs(tracking): restructure sprint 35 into an audit roadmap (35 + 35.1..35.4)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ hadolint: ## Run Hadolint on Dockerfiles
 	@find .docker -name Dockerfile -exec sh -c 'echo "=> {}"; docker run --rm -i hadolint/hadolint < "{}"' \;
 
 markdownlint: ## Run Markdownlint
-	@docker run --rm -v $$(pwd):/app -w /app davidanson/markdownlint-cli2 "**/*.md" "!.claude/**" "!api/vendor/**" "!api/vendor-bin/**" "!pwa/node_modules/**"
+	@docker run --rm -v $$(pwd):/app -w /app davidanson/markdownlint-cli2 "**/*.md" "!.claude/**" "!api/vendor/**" "!api/vendor-bin/**" "!provisioner/vendor/**" "!provisioner/vendor-bin/**" "!pwa/node_modules/**"
 
 tsc: typescript-check ## Alias for "typescript-check"
 

--- a/TRACKING.md
+++ b/TRACKING.md
@@ -370,8 +370,8 @@ Champ `action` sur le modèle Alert, actions contextuelles sur les analyseurs ex
 | 3     | [#283](https://github.com/vincentchalamon/bike-trip-planner/issues/283) | Nouvel analyseur : gare SNCF de secours (nudge)            | S      | [#330](https://github.com/vincentchalamon/bike-trip-planner/pull/330) | —         |
 | 4     | [#284](https://github.com/vincentchalamon/bike-trip-planner/issues/284) | Nouvel analyseur : pharmacie/hôpital à proximité (nudge)   | S      | [#331](https://github.com/vincentchalamon/bike-trip-planner/pull/331) | —         |
 | 5     | [#285](https://github.com/vincentchalamon/bike-trip-planner/issues/285) | Nouvel analyseur : passage frontière (nudge)               | M      | [#332](https://github.com/vincentchalamon/bike-trip-planner/pull/332) | —         |
-| 6     | [#313](https://github.com/vincentchalamon/bike-trip-planner/issues/313) | Nouvel analyseur : départ avant l'aube (warning)           | S      |     | —         |
-| 7     | [#314](https://github.com/vincentchalamon/bike-trip-planner/issues/314) | Nouvel analyseur : traversée cours d'eau sans pont (nudge) | M      |     | —         |
+| 6     | [#313](https://github.com/vincentchalamon/bike-trip-planner/issues/313) | ~~Nouvel analyseur : départ avant l'aube (warning)~~ — **abandonné** (non implémenté, fermé _not planned_) | S      |     | —         |
+| 7     | [#314](https://github.com/vincentchalamon/bike-trip-planner/issues/314) | ~~Nouvel analyseur : traversée cours d'eau sans pont (nudge)~~ — **abandonné** (non implémenté, fermé _not planned_) | M      |     | —         |
 | 8     | [#315](https://github.com/vincentchalamon/bike-trip-planner/issues/315) | ADR-TBD : alertes actionnables (action DTO, 4 types)       | S      |     | —         |
 
 ---
@@ -648,13 +648,13 @@ Ajustement de l'infrastructure pour démarrer une **beta restreinte (<10 users)*
 | Ordre | ID                                                                      | Titre                                                                              | Effort | PRs | Dépend de   |
 |-------|-------------------------------------------------------------------------|------------------------------------------------------------------------------------|--------|-----|-------------|
 | 1     | [#563](https://github.com/vincentchalamon/bike-trip-planner/issues/563) | Profil beta — modèle 3B unique (analyse + chat) + Ollama on-demand                 | S      | [#579](https://github.com/vincentchalamon/bike-trip-planner/pull/579) ✅ mergée | —           |
-| 2     | [#564](https://github.com/vincentchalamon/bike-trip-planner/issues/564) | Couture endpoint analyse/chat (`OLLAMA_ANALYSIS_URL` / `OLLAMA_CHAT_URL`)           | M      | [#580](https://github.com/vincentchalamon/bike-trip-planner/pull/580) 🚧 | —           |
-| 3     | [#565](https://github.com/vincentchalamon/bike-trip-planner/issues/565) | Transport `llm` dédié + `worker-llm` (split async/llm)                              | M      | [#581](https://github.com/vincentchalamon/bike-trip-planner/pull/581) 🚧 | —           |
-| 4     | [#566](https://github.com/vincentchalamon/bike-trip-planner/issues/566) | Limites mémoire conteneurs + Redis maxmemory (noeviction) + Postgres borné         | S      | [#582](https://github.com/vincentchalamon/bike-trip-planner/pull/582) 🚧 (base #581) | #565        |
-| 5     | [#567](https://github.com/vincentchalamon/bike-trip-planner/issues/567) | Beta sans analytics — gating env + différer le serveur + doc réactivation          | S      | [#583](https://github.com/vincentchalamon/bike-trip-planner/pull/583) 🚧 | #552, #553  |
-| 6     | [#568](https://github.com/vincentchalamon/bike-trip-planner/issues/568) | Observabilité beta SaaS — Sentry + UptimeRobot                                      | S      | [#584](https://github.com/vincentchalamon/bike-trip-planner/pull/584) 🚧 | —           |
-| 7     | [#569](https://github.com/vincentchalamon/bike-trip-planner/issues/569) | OSM France entière — build local mensuel + runbook + désactiver osm-cron nightly   | M      | [#575](https://github.com/vincentchalamon/bike-trip-planner/pull/575) (partiel) + [#585](https://github.com/vincentchalamon/bike-trip-planner/pull/585) 🚧 | —           |
-| 8     | [#570](https://github.com/vincentchalamon/bike-trip-planner/issues/570) | ADR-035 right-sizing Free Tier + correction budget ADR-019                         | S      | [#586](https://github.com/vincentchalamon/bike-trip-planner/pull/586) 🚧 (ADR-039) | —           |
+| 2     | [#564](https://github.com/vincentchalamon/bike-trip-planner/issues/564) | Couture endpoint analyse/chat (`OLLAMA_ANALYSIS_URL` / `OLLAMA_CHAT_URL`)           | M      | [#580](https://github.com/vincentchalamon/bike-trip-planner/pull/580) ✅ mergée | —           |
+| 3     | [#565](https://github.com/vincentchalamon/bike-trip-planner/issues/565) | Transport `llm` dédié + `worker-llm` (split async/llm)                              | M      | [#581](https://github.com/vincentchalamon/bike-trip-planner/pull/581) ✅ mergée | —           |
+| 4     | [#566](https://github.com/vincentchalamon/bike-trip-planner/issues/566) | Limites mémoire conteneurs + Redis maxmemory (noeviction) + Postgres borné         | S      | [#582](https://github.com/vincentchalamon/bike-trip-planner/pull/582) ✅ mergée (base #581) | #565        |
+| 5     | [#567](https://github.com/vincentchalamon/bike-trip-planner/issues/567) | Beta sans analytics — gating env + différer le serveur + doc réactivation          | S      | [#583](https://github.com/vincentchalamon/bike-trip-planner/pull/583) ✅ mergée | #552, #553  |
+| 6     | [#568](https://github.com/vincentchalamon/bike-trip-planner/issues/568) | Observabilité beta SaaS — Sentry + UptimeRobot                                      | S      | [#584](https://github.com/vincentchalamon/bike-trip-planner/pull/584) ✅ mergée | —           |
+| 7     | [#569](https://github.com/vincentchalamon/bike-trip-planner/issues/569) | OSM France entière — build local mensuel + runbook + désactiver osm-cron nightly   | M      | [#575](https://github.com/vincentchalamon/bike-trip-planner/pull/575) + [#585](https://github.com/vincentchalamon/bike-trip-planner/pull/585) ✅ mergée | —           |
+| 8     | [#570](https://github.com/vincentchalamon/bike-trip-planner/issues/570) | ADR-035 right-sizing Free Tier + correction budget ADR-019                         | S      | [#586](https://github.com/vincentchalamon/bike-trip-planner/pull/586) ✅ mergée (ADR-039) | —           |
 
 ### Recette Sprint 34.5
 
@@ -669,65 +669,74 @@ Ajustement de l'infrastructure pour démarrer une **beta restreinte (<10 users)*
 
 ---
 
-## Sprint 35 — Recette complète & Audit
+## Sprint 35 — Outillage d'audit
 
-Recette fonctionnelle end-to-end de l'ensemble de l'application (sprints 1 à 33, hors sprint 34 RGPD/parcours compte qui a sa propre recette) et audit complet : performance, sécurité, accessibilité, SEO, qualité de code, couverture de tests. Deux phases : **audit** (cartographier les problèmes) puis **corrections** (fixer par lots thématiques).
+> **Restructuration** : l'ancien « Sprint 35 — Recette complète & Audit » (36 ordres, 4 phases) était trop gros et hétérogène (outillage codable vs audits produisant des findings vs recette manuelle vs corrections). Il est découpé en 5 sous-sprints séquencés : **35** (outillage) et **35.1** (référentiel) en parallèle, puis **35.2** (audit non-fonctionnel) et **35.3** (audit fonctionnel + couverture) en parallèle, puis recette manuelle, puis **35.4** (corrections). Périmètre audité = features livrées sur `main` (sprints 1-33, design S25-27, IA S28-32, S34/34.5), **hors** S18 #313/#314 (abandonnés) et osm-cron nightly (#575 : refresh OSM désormais manuel). L'état des issues GitHub étant peu fiable, les findings d'audit se regroupent par **milestone `Sprint 35.4`**, pas par état d'issue.
 
-### Phase 1 — Outillage automatisé
+Outillage automatisé, prérequis à tout l'audit. 6 livrables regroupés en **4 PRs** (items 1+4 partagent les fixtures Playwright ; 2/3/5/6 touchent Makefile/CI/lockfile) ; séquence (A)+(B) en parallèle, puis (C), puis (D).
 
-| Ordre | Titre                                                          | Effort |
-|-------|----------------------------------------------------------------|--------|
-| 1     | Intégrer `@axe-core/playwright` dans les fixtures E2E          | S      |
-| 2     | Intégrer Lighthouse CI (`make lighthouse`)                     | M      |
-| 3     | Script de complétude i18n FR/EN (`make i18n-check`)            | S      |
-| 4     | Monitoring console errors + requêtes 500 dans les fixtures E2E | S      |
-| 5     | Ajouter `npm audit` au workflow CI                             | S      |
-| 6     | Visual regression screenshots Playwright (36 baselines)        | M      |
+| Ordre | Titre | Effort | PR |
+|---|---|---|---|
+| 1 | `@axe-core/playwright` dans les fixtures E2E (helper `expectNoCriticalA11yViolations`) | S | A |
+| 4 | Monitoring console errors + requêtes 500 dans les fixtures E2E | S | A |
+| 3 | Script de complétude i18n FR/EN (`make i18n-check`) | S | B |
+| 5 | `npm audit` au workflow CI (`--audit-level=high`) | S | B |
+| 2 | Lighthouse CI (`make lighthouse`, pages publiques) | M | C |
+| 6 | Visual regression Playwright (36 baselines = 6 combos x 6 pages) | M | D |
 
-### Phase 2 — Audit
+**Compléments** (manquaient dans les 6 d'origine) : gate de couverture PHPUnit >= 80 % (aucun fail-under aujourd'hui) ; `composer audit` (en plus de `symfony check:security`) ; next-intl `onError` pour les clés manquantes au runtime ; 2e set VR « états » (modales/toasts/empty/error) ; câbler le monitoring 500 sur un vrai backend. CI : léger per-PR (`i18n-check`, `npm audit`, smoke axe), lourd en nightly (`lighthouse`, `visual-test`).
 
-| Ordre | Titre                                                                     | Effort |
-|-------|---------------------------------------------------------------------------|--------|
-| 7     | Audit sécurité : headers HTTP (CSP, HSTS, X-Frame-Options) dans Caddy    | S      |
-| 8     | Audit sécurité : isolation Mercure entre utilisateurs                     | M      |
-| 9     | Audit sécurité : auth exhaustive sur tous les endpoints (401/403)         | M      |
-| 10    | Audit sécurité : rate limiting effectif (magic link, trip create, scrape) | S      |
-| 11    | Audit sécurité : XSS dans les champs éditables (titre, locations)        | S      |
-| 12    | Audit performance : Lighthouse CI sur toutes les pages                    | M      |
-| 13    | Audit performance : N+1 Doctrine (TripDetail, stages, accommodations)    | M      |
-| 14    | Audit performance : bundle size Next.js + code splitting                  | S      |
-| 15    | Audit performance : temps calcul async complet (upload → dernier SSE)    | M      |
-| 16    | Audit accessibilité : axe-core 0 violation critique                      | M      |
-| 17    | Audit accessibilité : navigation clavier complète (carte, sidebar, modales) | M   |
-| 18    | Audit SEO : meta tags, Open Graph sur les pages de partage               | S      |
-| 19    | Audit i18n : complétude FR/EN, formatage dates/nombres, clés visibles    | S      |
+---
 
-### Phase 3 — Recette manuelle
+## Sprint 35.1 — Référentiel de recette
 
-| Ordre | Titre                                                          | Effort |
-|-------|----------------------------------------------------------------|--------|
-| 20    | Golden path A : trip depuis lien Komoot (parcours complet)     | L      |
-| 21    | Golden path B : trip depuis upload GPX (drag & drop, ~25 MB)   | M      |
-| 22    | Golden path C : trip via URL (`/?link=...`)                    | S      |
-| 23    | Cas limites : inputs invalides (GPX malformé, > 30 MB, 0 pts) | M      |
-| 24    | Cas limites : auth (token expiré, double-clic, 2 onglets, inactivité 15 min) | M |
-| 25    | Cas limites : réseau (coupure pendant calcul, SSE déconnecté, worker crash) | M  |
-| 26    | Cas limites : undo/redo séquences complexes (repos + hébergement + distance) | S |
-| 27    | Cas limites : trip 20+ étapes, 0 hébergement, dénivelé > 3000m | S     |
-| 28    | Audit visuel : desktop Chrome clair FR + Firefox sombre EN     | M      |
-| 29    | Audit visuel : tablette 768×1024 + mobile 375×812 (clair/sombre) | M    |
-| 30    | Audit visuel : mode sombre complet (carte, elevation, modales, toasts) | M |
-| 31    | Audit visuel : états vides + états d'erreur sur toutes les pages | S     |
+Spec commune à l'audit fonctionnel automatisé (35.3) et à la recette manuelle. Ne dépend pas de l'outillage, donc parallélisable avec 35. Livrables sous `docs/recette/`.
 
-### Phase 4 — Corrections
+| Ordre | Titre | Effort |
+|---|---|---|
+| 1 | Inventaire des écrans (dérivé de `pwa/src/app/`) + variantes (auth/anon, états données) | S |
+| 2 | Checklist par écran : éléments, comportements, états (hover/focus/disabled/loading/empty/error), responsive, a11y clavier | M |
+| 3 | Manifeste d'éléments attendus par écran (présence + position approximative) dérivé de l'export Claude Design | M |
+| 4 | Audit de couverture Gherkin (30 `.feature` vs features réelles) + scénarios manquants à écrire (IA S30-32, design S25-27) | M |
 
-| Ordre | Titre                                                      | Effort |
-|-------|------------------------------------------------------------|--------|
-| 32    | Fix : headers de sécurité manquants dans Caddy             | S      |
-| 33    | Fix : bugs bloquants (P0) et fonctionnels dégradés (P1)    | L      |
-| 34    | Fix : régressions UX/UI (P2)                               | M      |
-| 35    | Fix : performance et polish (P3)                           | M      |
-| 36    | Re-test : golden path A final après corrections            | M      |
+Source design : export Claude Design vendoré sous `docs/recette/` (`tokens.jsx`, `pages-*.jsx`, `Toutes les pages.html`). **Comparaison app vs design = présence + position approximative** (auto, Playwright) ; couleur / typo / polish = **regard humain** (capture côte-à-côte).
+
+---
+
+## Sprint 35.2 — Audit non-fonctionnel & qualité
+
+Exécute l'outillage de 35 + revue ciblée, produit des **findings en issues** (milestone `Sprint 35.4`, labels `security`/`perf`/`a11y`/`seo`/`i18n` + sévérité `P0`-`P3`). Pas de fix. Dépend de 35. Exécution : fan-out d'agents par dimension, findings vérifiés avant ouverture, rapport `docs/recette/audit-report.md`. _(ex-ordres 7-19)_
+
+| Ordre | Titre | Effort |
+|---|---|---|
+| 1 | Sécurité : headers Caddy (constat), isolation Mercure, auth 401/403 exhaustive, rate limiting, XSS champs éditables, stack trace prod, `composer audit` | L |
+| 2 | Performance : Lighthouse toutes pages (y.c. auth, iso-prod seedé), N+1 Doctrine, bundle/code splitting, temps calcul async | L |
+| 3 | Accessibilité : axe 0 violation critique, navigation clavier (scriptée + manuelle) | M |
+| 4 | SEO : meta + Open Graph sur les pages de partage | S |
+| 5 | i18n : `make i18n-check` (parité) + clés visibles + formatage dates/nombres | S |
+| 6 | Qualité : couverture >= 80 %, `make qa` propre, dette de tracking | S |
+| 7 | Privacy/anonymisation : `/privacy`, gating par env Plausible, 0 cookie / 0 PII, purge user en DB (pas de consentement, #385 abandonné) | M |
+
+---
+
+## Sprint 35.3 — Audit fonctionnel + couverture
+
+Transforme le référentiel (35.1) en couverture automatisée + valide les baselines VR. Dépend de 35 + 35.1. Exécution : fan-out par domaine d'écran, findings -> issues (milestone `Sprint 35.4`). _(ex-ordres 20-31)_
+
+| Ordre | Titre | Effort |
+|---|---|---|
+| 1 | Tests Playwright : vérifier l'existant et réparer le périmé (refonte design S25-27, IA S30-32) | M |
+| 2 | Golden paths A/B/C + cas limites en Gherkin (checklists ci-dessous) | L |
+| 3 | Combler les domaines `.feature` absents (IA, design) | M |
+| 4 | Baselines VR (36 pages + set « états ») + comparaison app vs design (présence + position) | M |
+
+DoD : `make test-e2e` + `make test-recette` + `make visual-test` verts ; chaque écran du manifeste 35.1 a un verdict.
+
+---
+
+## Recette manuelle (utilisateur)
+
+Entre 35.3 et 35.4 : recette manuelle sur l'environnement iso-prod, guidée par le référentiel 35.1 + les baselines, produisant des findings (issues milestone `Sprint 35.4`). Checklists et seuils ci-dessous.
 
 ### Recette Sprint 35 — Golden Path A (Komoot)
 
@@ -808,9 +817,25 @@ Recette fonctionnelle end-to-end de l'ensemble de l'application (sprints 1 à 33
   - [ ] `make i18n-check` : 0 clé manquante
   - [ ] Headers sécurité présents : CSP, HSTS, X-Content-Type-Options, X-Frame-Options
   - [ ] Aucune stack trace exposée en `APP_ENV=prod`
-  - [ ] Audit privacy : page `/privacy` complète, mention Plausible (cloud / auto-hébergé), gating consentement effectif
+  - [ ] Audit privacy : page `/privacy` complète, mention Plausible (cloud / auto-hébergé), gating par env (`NEXT_PUBLIC_PLAUSIBLE_DOMAIN`), 0 cookie / 0 PII (pas de consentement, #385 abandonné)
   - [ ] Audit anonymisation : suppression user → trips et préférences purgés (vérifier via requête DB) ; events Plausible anonymes par construction (pas de lien à l'user)
   - [ ] Tous les bugs trouvés reportés en issues GitHub avec labels (`bug`, `ux`, `perf`, `security`, `a11y`)
+
+---
+
+## Sprint 35.4 — Corrections
+
+Fixe les findings de 35.2 + 35.3 + recette manuelle, requêtés par **milestone `Sprint 35.4`** (l'état des issues n'étant pas fiable). Modèle worktree-parallèle (`/sprint`). _(ex-ordres 32-36)_
+
+| Ordre | Titre | Effort |
+|---|---|---|
+| 1 | Headers de sécurité Caddy (CSP / HSTS / X-Frame-Options / X-Content-Type-Options) | S |
+| 2 | P0/P1 : bugs bloquants + fonctionnels dégradés | L |
+| 3 | P2 : régressions UX/UI | M |
+| 4 | P3 : performance et polish | M |
+| 5 | Re-test golden path A final (gate de clôture) | M |
+
+DoD : toutes les issues P0-P3 fermées ou explicitement reportées ; golden path A re-testé vert.
 
 ---
 

--- a/TRACKING.md
+++ b/TRACKING.md
@@ -616,7 +616,7 @@ Collecte de métriques d'usage **agrégées et anonymes** (sources, plateformes,
 | 1     | [#550](https://github.com/vincentchalamon/bike-trip-planner/issues/550) | Page `/privacy` + mentions légales `/legal` (sommaire sticky, footer global, mention Plausible)                  | M      | [#556](https://github.com/vincentchalamon/bike-trip-planner/pull/556) | sprint 25 |
 | 2     | [#549](https://github.com/vincentchalamon/bike-trip-planner/issues/549) | Anonymisation/suppression user (soft-delete trips + préférences) + export données JSON ; events Plausible non liés à l'user | M      | [#555](https://github.com/vincentchalamon/bike-trip-planner/pull/555) | —         |
 | 3     | [#548](https://github.com/vincentchalamon/bike-trip-planner/issues/548) | ADR-034 : décision Plausible auto-hébergé (justification RGPD, custom events)                                    | S      | [#554](https://github.com/vincentchalamon/bike-trip-planner/pull/554) | —         |
-| 4     | [#551](https://github.com/vincentchalamon/bike-trip-planner/issues/551) | Setup Plausible auto-hébergé Docker + domaine + DNS — **tâche manuelle (ops)**                                   | M      |     | #548      |
+| 4     | [#551](https://github.com/vincentchalamon/bike-trip-planner/issues/551) | Setup Plausible auto-hébergé Docker + domaine + DNS — **tâche manuelle (ops), différée post-beta** (ADR-034 / #567)  | M      |     | #548      |
 | 5     | [#552](https://github.com/vincentchalamon/bike-trip-planner/issues/552) | Intégration script Plausible dans `<head>` Next.js (data-domain, chargement conditionnel à la config env `NEXT_PUBLIC_PLAUSIBLE_DOMAIN` — pas de consentement, cf. ADR-034) | S      | [#557](https://github.com/vincentchalamon/bike-trip-planner/pull/557) | #551      |
 | 6     | [#553](https://github.com/vincentchalamon/bike-trip-planner/issues/553) | Custom events Plausible — sources & plateformes (`import_komoot`, `import_strava`, `import_rwgps`, `import_gpx`) | S      | [#561](https://github.com/vincentchalamon/bike-trip-planner/pull/561) | #552      |
 | 7     | [#553](https://github.com/vincentchalamon/bike-trip-planner/issues/553) | Custom events Plausible — valeur features & rétention/UX (`trip_created`, `trip_shared`, `accommodation_selected`, `alert_action_clicked`, `ai_chat_opened`…) — _fusionné dans #553_ | M      | [#561](https://github.com/vincentchalamon/bike-trip-planner/pull/561) | #552      |
@@ -685,6 +685,13 @@ Outillage automatisé, prérequis à tout l'audit. 6 livrables regroupés en **4
 | 6 | Visual regression Playwright (36 baselines = 6 combos x 6 pages) | M | D |
 
 **Compléments** (manquaient dans les 6 d'origine) : gate de couverture PHPUnit >= 80 % (aucun fail-under aujourd'hui) ; `composer audit` (en plus de `symfony check:security`) ; next-intl `onError` pour les clés manquantes au runtime ; 2e set VR « états » (modales/toasts/empty/error) ; câbler le monitoring 500 sur un vrai backend. CI : léger per-PR (`i18n-check`, `npm audit`, smoke axe), lourd en nightly (`lighthouse`, `visual-test`).
+
+**Dette pré-recette** (à solder avant l'audit fonctionnel 35.3, sinon il re-signale une dette connue) — 2 items frontend tech-debt, PR indépendante :
+
+| Issue | Titre | Effort |
+|---|---|---|
+| [#450](https://github.com/vincentchalamon/bike-trip-planner/issues/450) | Wire AI payloads (`aiOverview` / `aiAnalysis`) via typegen — remplacer les mirrors manuels (`mercure/types.ts`, `validation/schemas.ts`) | S |
+| [#451](https://github.com/vincentchalamon/bike-trip-planner/issues/451) | Scope `DiffHighlight` aux alertes seules dans `StageAiSummary` (aujourd'hui enveloppe tout le résumé) | S |
 
 ---
 
@@ -874,6 +881,7 @@ Mise en production basée sur [ADR-019](docs/adr/adr-019-deployment-infrastructu
 | 6     | Monitoring & healthchecks (incl. Ollama latence/disponibilité) | M      |
 | 7     | Migration données + smoke test production (incl. passe LLaMA 8B) | M      |
 | 8     | [#312](https://github.com/vincentchalamon/bike-trip-planner/issues/312) Feature-deploy : preview par PR (Étapes 1-7) | L |
+| 9     | [#270](https://github.com/vincentchalamon/bike-trip-planner/issues/270) Génération du keypair JWT sur le serveur (compose secrets + runbook `secrets-inventory.md`) | S |
 
 ### Recette Sprint 37
 


### PR DESCRIPTION
## Contexte

`/sprint 35` visait « Recette complète & Audit » : 36 ordres sur 4 phases, sans aucune issue GitHub, et de nature hétérogène (outillage codable vs audits produisant des findings vs recette manuelle vs corrections). Trop gros pour un seul sprint, et incompatible avec le modèle worktree-parallèle de `/sprint` sauf pour les phases outillage + corrections.

## Changements (doc + tooling)

- **Découpe de Sprint 35** en 5 sous-sprints séquencés, les 36 ordres tous redistribués (rien supprimé, checklists de recette préservées) :
  - **35** Outillage d'audit (6 livrables, 4 PRs groupées)
  - **35.1** Référentiel de recette (inventaire écrans + checklists + manifeste présence/position + couverture Gherkin)
  - **35.2** Audit non-fonctionnel & qualité (findings -> issues, milestone `Sprint 35.4`)
  - **35.3** Audit fonctionnel + couverture (tests Playwright + baselines VR + comparaison vs design)
  - **35.4** Corrections (worktree-parallèle)
- **Sprint 34.5** : statuts PR passés en ✅ mergé (marqueurs 🚧 périmés).
- **Sprint 18** : analyseurs #313 / #314 marqués abandonnés (non implémentés sur `main`).
- **Makefile** : la cible `markdownlint` exclut désormais `provisioner/vendor/**` (alignement sur `api/vendor`), pour que `make qa-doc` passe localement.

## Hygiène GitHub (déjà appliquée, hors PR)

L'état des issues était peu fiable (~14 features livrées encore ouvertes). Fermées :

- **completed** (livré sur `main`, vérifié) : #301 #302 #303 #309 #310 #311 #317 #327 #328 #345 #346 #347 #348 #349 #350 #351 #352
- **not planned** (abandonné) : #385 (bannière cookies, ADR-034), #313, #314

Laissées ouvertes pour arbitrage : #315 (ADR alertes), #450 / #451 (dette réelle), épics #370 / #375, tâches ops #270 / #551.

## Vérification

- `make qa-doc` : 0 erreur (78 fichiers).
- Diff limité à `TRACKING.md` + `Makefile`.

## Auto-critique

- Périmètre d'audit keyé sur `main` (code présent), pas sur l'état des issues. Exclusions explicites : S18 #313/#314, osm-cron nightly (#575, refresh OSM désormais manuel).
- 35.2 / 35.3 ne sont pas des sprints de features : ils produisent des findings (issues milestone `Sprint 35.4`), pas des PRs ; seul 35.4 réutilise le modèle worktree-parallèle.
- La comparaison app vs design se limite à présence + position approximative (auto) ; couleur / typo / polish = revue humaine.
- Le fix Makefile élargit légèrement le scope (build), mais corrige un oubli évident et conditionne un `make qa-doc` vert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

**0 findings** (0 critical, 0 warning, 0 suggestion).

Documentation-only PR (TRACKING.md + Makefile). The sprint restructuring is well-reasoned: all 36 original items are redistributed without loss across the 5 sub-sprints, the sequencing and parallelism rationale is sound, and the `provisioner/vendor` + `provisioner/vendor-bin` Makefile exclusions correctly mirror the existing `api/vendor` / `api/vendor-bin` pattern. Sprint 34.5 status updates (🚧 → ✅), Sprint 18 abandonment markers (#313/#314), the #551 post-beta deferral, and the #270 routing to Sprint 37 are all consistent with `main` state. The third commit's pre-recette debt additions (#450, #451) are correctly scoped to Sprint 35 as prerequisites to the functional audit.

No unresolved bot-authored threads. Previous bot review was already dismissed.

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases _(not applicable — doc + Makefile only)_
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

No inline comments.

---

_Reviewed commit: `6476895856ee527173dbf772eeb731705c402542`_

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->