### PR TITLE
test(visual): add visual-regression harness (config + matrix + targets)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,22 @@ lighthouse: ## Run Lighthouse CI on public pages (requires the prod stack up: ma
 		mcr.microsoft.com/playwright:v1.60.0-noble \
 		/bin/sh -c 'npm ci; npx lhci autorun --config=lighthouserc.json'
 
+visual-test: ## Run visual-regression assertions (requires prod stack + committed baselines)
+	@docker run --network host \
+		-w /app -v $(CURDIR)/pwa:/app \
+		--mount type=volume,src=playwright_node_modules,dst=/app/node_modules \
+		--rm --ipc=host \
+		mcr.microsoft.com/playwright:v1.60.0-noble \
+		/bin/sh -c 'npm ci; npx playwright test --config playwright.visual.config.ts $(ARGS)'
+
+visual-update: ## (Re)generate visual-regression baselines in the container (requires prod stack: make start)
+	@docker run --network host \
+		-w /app -v $(CURDIR)/pwa:/app \
+		--mount type=volume,src=playwright_node_modules,dst=/app/node_modules \
+		--rm --ipc=host \
+		mcr.microsoft.com/playwright:v1.60.0-noble \
+		/bin/sh -c 'npm ci; npx playwright test --config playwright.visual.config.ts --update-snapshots'
+
 coverage: ## Run PHPUnit with coverage (HTML report)
 	@docker compose exec -e XDEBUG_MODE=coverage php vendor/bin/phpunit --coverage-html coverage/api
 	@docker compose --profile provisioning run -e XDEBUG_MODE=coverage --entrypoint "" provisioner vendor/bin/phpunit --coverage-html coverage/provisioner

--- a/pwa/package-lock.json
+++ b/pwa/package-lock.json
@@ -38,7 +38,7 @@
         "@capacitor/cli": "^7.6.2",
         "@eslint/eslintrc": "^3.3.5",
         "@lhci/cli": "^0.15.1",
-        "@playwright/test": "^1.59.1",
+        "@playwright/test": "^1.60.0",
         "@tailwindcss/postcss": "^4.2.4",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",

--- a/pwa/package.json
+++ b/pwa/package.json
@@ -45,7 +45,7 @@
     "@capacitor/cli": "^7.6.2",
     "@eslint/eslintrc": "^3.3.5",
     "@lhci/cli": "^0.15.1",
-    "@playwright/test": "^1.59.1",
+    "@playwright/test": "^1.60.0",
     "@tailwindcss/postcss": "^4.2.4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/pwa/playwright.config.ts
+++ b/pwa/playwright.config.ts
@@ -6,7 +6,9 @@ export default defineConfig({
   testDir: "./tests",
   // The documentation screenshot capture (tests/screenshots/) writes image files
   // and is not an assertion suite; it is run on demand via `make screenshots`.
-  testIgnore: ["**/screenshots/**"],
+  // The visual-regression suite (tests/visual/) has its own multi-project config
+  // and is run on demand via `make visual-test`.
+  testIgnore: ["**/screenshots/**", "**/visual/**"],
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,

--- a/pwa/playwright.visual.config.ts
+++ b/pwa/playwright.visual.config.ts
@@ -1,0 +1,92 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Visual-regression suite (`tests/visual/`), run via `make visual-test` and
+ * regenerated via `make visual-update`. Kept in a dedicated config (and ignored
+ * by the main `playwright.config.ts`) so it never runs during `make test-e2e`.
+ *
+ * The 6 projects mirror the Sprint 35 audit-visuel matrix
+ * (device x browser engine x theme x language). Baselines are OS/rendering
+ * specific and MUST be generated inside the `mcr.microsoft.com/playwright`
+ * container (`make visual-update`), never on a host, or CI will diff against
+ * different font/AA rendering.
+ */
+const COMBOS = [
+  {
+    name: "desktop-1920-chromium-light-fr",
+    device: "Desktop Chrome",
+    viewport: { width: 1920, height: 1080 },
+    colorScheme: "light" as const,
+    theme: "light",
+    locale: "fr",
+  },
+  {
+    name: "desktop-1920-firefox-dark-en",
+    device: "Desktop Firefox",
+    viewport: { width: 1920, height: 1080 },
+    colorScheme: "dark" as const,
+    theme: "dark",
+    locale: "en",
+  },
+  {
+    name: "desktop-1440-chromium-dark-fr",
+    device: "Desktop Chrome",
+    viewport: { width: 1440, height: 900 },
+    colorScheme: "dark" as const,
+    theme: "dark",
+    locale: "fr",
+  },
+  {
+    name: "tablet-768-chromium-light-en",
+    device: "Desktop Chrome",
+    viewport: { width: 768, height: 1024 },
+    colorScheme: "light" as const,
+    theme: "light",
+    locale: "en",
+  },
+  {
+    name: "mobile-375-chromium-light-fr",
+    device: "Desktop Chrome",
+    viewport: { width: 375, height: 812 },
+    colorScheme: "light" as const,
+    theme: "light",
+    locale: "fr",
+  },
+  {
+    name: "mobile-375-webkit-dark-en",
+    device: "Desktop Safari",
+    viewport: { width: 375, height: 812 },
+    colorScheme: "dark" as const,
+    theme: "dark",
+    locale: "en",
+  },
+];
+
+export default defineConfig({
+  testDir: "./tests/visual",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  reporter: "line",
+  snapshotPathTemplate: "{testDir}/__screenshots__/{projectName}/{arg}{ext}",
+  expect: {
+    toHaveScreenshot: {
+      maxDiffPixelRatio: 0.02,
+      animations: "disabled",
+      caret: "hide",
+    },
+  },
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL ?? "https://localhost",
+    ignoreHTTPSErrors: true,
+  },
+  projects: COMBOS.map((c) => ({
+    name: c.name,
+    use: {
+      ...devices[c.device],
+      viewport: c.viewport,
+      colorScheme: c.colorScheme,
+      locale: c.locale === "fr" ? "fr-FR" : "en-US",
+    },
+    metadata: { theme: c.theme, appLocale: c.locale },
+  })),
+});

--- a/pwa/playwright.visual.config.ts
+++ b/pwa/playwright.visual.config.ts
@@ -6,17 +6,28 @@ import { defineConfig, devices } from "@playwright/test";
  * by the main `playwright.config.ts`) so it never runs during `make test-e2e`.
  *
  * The 6 projects mirror the Sprint 35 audit-visuel matrix
- * (device x browser engine x theme x language). Baselines are OS/rendering
- * specific and MUST be generated inside the `mcr.microsoft.com/playwright`
- * container (`make visual-update`), never on a host, or CI will diff against
- * different font/AA rendering.
+ * (device x browser engine x theme x language). Mobile/tablet combos use real
+ * mobile presets (or explicit touch/DPR) so the baselines exercise touch styles
+ * and HiDPI rendering, not narrow-desktop. Baselines are OS/rendering specific
+ * and MUST be generated inside the `mcr.microsoft.com/playwright` container
+ * (`make visual-update`), never on a host.
  */
-const COMBOS = [
+const COMBOS: Array<{
+  name: string;
+  device: keyof typeof devices;
+  viewport: { width: number; height: number };
+  colorScheme: "light" | "dark";
+  theme: string;
+  locale: string;
+  isMobile?: boolean;
+  hasTouch?: boolean;
+  deviceScaleFactor?: number;
+}> = [
   {
     name: "desktop-1920-chromium-light-fr",
     device: "Desktop Chrome",
     viewport: { width: 1920, height: 1080 },
-    colorScheme: "light" as const,
+    colorScheme: "light",
     theme: "light",
     locale: "fr",
   },
@@ -24,7 +35,7 @@ const COMBOS = [
     name: "desktop-1920-firefox-dark-en",
     device: "Desktop Firefox",
     viewport: { width: 1920, height: 1080 },
-    colorScheme: "dark" as const,
+    colorScheme: "dark",
     theme: "dark",
     locale: "en",
   },
@@ -32,31 +43,36 @@ const COMBOS = [
     name: "desktop-1440-chromium-dark-fr",
     device: "Desktop Chrome",
     viewport: { width: 1440, height: 900 },
-    colorScheme: "dark" as const,
+    colorScheme: "dark",
     theme: "dark",
     locale: "fr",
   },
   {
+    // No Chromium tablet preset exists; keep the Desktop Chrome engine but opt
+    // into touch + HiDPI so the baseline reflects tablet rendering.
     name: "tablet-768-chromium-light-en",
     device: "Desktop Chrome",
     viewport: { width: 768, height: 1024 },
-    colorScheme: "light" as const,
+    colorScheme: "light",
     theme: "light",
     locale: "en",
+    isMobile: true,
+    hasTouch: true,
+    deviceScaleFactor: 2,
   },
   {
     name: "mobile-375-chromium-light-fr",
-    device: "Desktop Chrome",
+    device: "Pixel 5",
     viewport: { width: 375, height: 812 },
-    colorScheme: "light" as const,
+    colorScheme: "light",
     theme: "light",
     locale: "fr",
   },
   {
     name: "mobile-375-webkit-dark-en",
-    device: "Desktop Safari",
+    device: "iPhone 12",
     viewport: { width: 375, height: 812 },
-    colorScheme: "dark" as const,
+    colorScheme: "dark",
     theme: "dark",
     locale: "en",
   },
@@ -83,9 +99,17 @@ export default defineConfig({
     name: c.name,
     use: {
       ...devices[c.device],
+      // Explicit viewport from the audit matrix takes precedence over the preset.
       viewport: c.viewport,
       colorScheme: c.colorScheme,
       locale: c.locale === "fr" ? "fr-FR" : "en-US",
+      ...(c.isMobile !== undefined
+        ? {
+            isMobile: c.isMobile,
+            hasTouch: c.hasTouch,
+            deviceScaleFactor: c.deviceScaleFactor,
+          }
+        : {}),
     },
     metadata: { theme: c.theme, appLocale: c.locale },
   })),

--- a/pwa/tests/visual/pages.spec.ts
+++ b/pwa/tests/visual/pages.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Visual-regression baselines for the public pages, across the 6 projects
+ * defined in `playwright.visual.config.ts` (device x browser x theme x lang).
+ *
+ * Run / regenerate with `make visual-test` / `make visual-update` against a
+ * running prod stack (`make start`). The authenticated "loaded trip" baseline
+ * needs the mocked fixture chain (createFullTrip) and is added when the
+ * baselines are first generated in Sprint 35.3.
+ */
+const PAGES = [
+  { name: "landing", path: "/" },
+  { name: "login", path: "/login" },
+  { name: "faq", path: "/faq" },
+  { name: "legal", path: "/legal" },
+  { name: "privacy", path: "/privacy" },
+];
+
+test.describe("visual baselines (public pages)", () => {
+  for (const { name, path } of PAGES) {
+    test(name, async ({ page, baseURL }, testInfo) => {
+      const { theme, appLocale } = testInfo.project.metadata as {
+        theme: string;
+        appLocale: string;
+      };
+      await page.context().addCookies([
+        { name: "locale", value: appLocale, url: baseURL ?? "https://localhost" },
+      ]);
+      // next-themes reads the persisted theme before first paint.
+      await page.addInitScript((value) => {
+        try {
+          window.localStorage.setItem("theme", value);
+        } catch {
+          /* storage unavailable — colorScheme still drives prefers-color-scheme */
+        }
+      }, theme);
+
+      await page.goto(path);
+      await page.waitForLoadState("networkidle");
+
+      await expect(page).toHaveScreenshot(`${name}.png`, {
+        fullPage: true,
+        // Map tiles load from the network and are non-deterministic.
+        mask: [page.locator(".maplibregl-map, [data-testid='map'], canvas")],
+      });
+    });
+  }
+});


### PR DESCRIPTION
## Sprint 35 — Outillage d'audit (PR D) — empilée sur #604

Closes #600.

- `pwa/playwright.visual.config.ts` : matrice **6 projects** (device × moteur × thème × langue) de l'audit-visuel S35, `toHaveScreenshot` { maxDiffPixelRatio 0.02, animations disabled, caret hide }.
- `pwa/tests/visual/pages.spec.ts` : **5 pages publiques** (`/`, `/login`, `/faq`, `/legal`, `/privacy`) = **30 baselines**, cookie `locale` + thème posés avant `goto`, **carte masquée**.
- `make visual-test` / `make visual-update` ; suite **exclue de `make test-e2e`** (testIgnore `**/visual/**`).

## Baselines

Non générées dans cette PR : elles sont OS/rendu-spécifiques et doivent être produites **dans le conteneur Playwright** contre la stack lancée (`make start` + `make visual-update`). Générées + committées en **Sprint 35.3** (avec la 6e baseline « trip chargé », qui nécessite les fixtures mock `createFullTrip`). Aucun job CI ne lance la suite (nightly, cf. plan) → CI verte sans baselines.

## Vérification

- ESLint : 0 erreur. tsc (`--noEmit`) : 0 erreur.

## Auto-critique

- 30 baselines (5 pages publiques) au lieu de 36 : la 6e page (trip chargé) dépend du harnais de mock ; ajoutée lors de la génération en 35.3.
- PR **empilée** sur #604 (base `feature/599`) pour éviter un conflit d'insertion dans le Makefile (cibles `lighthouse` puis `visual-*`). À retarget sur `main` si #604 est squash-mergée avant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

The visual-regression harness is complete and correct. The version alignment warning from the previous review has been addressed: `@playwright/test` is now `^1.60.0`, matching the `mcr.microsoft.com/playwright:v1.60.0-noble` container image used by both `make visual-test` and `make visual-update`. All previously open threads are resolved.

**Findings:** 0 critical, 0 warnings, 0 suggestions.

**Resolved 1 previously open thread** (Makefile:148 — `@playwright/test` version alignment, fixed in commit `2c368f9`).

### Review checklist
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**No inline comments.**

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->