### PR TITLE
docs(recette): add Sprint 35.1 recette reference

### DIFF
--- a/docs/recette/01-inventaire-ecrans.md
+++ b/docs/recette/01-inventaire-ecrans.md
@@ -151,9 +151,22 @@ Au-delà des états par écran, ces variantes s'appliquent largement et doivent 
 - **Onboarding :** `onboarding-tour.tsx` au premier lancement.
 - **Responsive :** mobile 390px vs desktop 1280px.
 
-## États non routés (écrans système)
+## Écrans système
 
-Pas de route App Router dédiée mais présents dans le design et le code :
+Fichiers spéciaux App Router (`pwa/src/app/`), testables en recette.
 
-- **404** : `not-found` (design `PageNotFoundDesktop`).
-- **500** : error boundary (design `PageErrorDesktop`, `TripPlannerErrorBoundary`).
+### 13. Page non trouvée — `not-found.tsx`
+
+- **Fichier :** `pwa/src/app/not-found.tsx`
+- **Objectif :** rendu sur toute URL non matchée (404).
+- **Auth :** public.
+- **Déclenchement recette :** naviguer vers une URL inexistante.
+- **Design :** `PageNotFoundDesktop`.
+
+### 14. Erreur applicative — `error.tsx` / `global-error.tsx`
+
+- **Fichiers :** `pwa/src/app/error.tsx`, `pwa/src/app/global-error.tsx`
+- **Objectif :** error boundary App Router (erreur de rendu) ; `global-error` couvre le layout racine.
+- **Auth :** public.
+- **Déclenchement recette :** provoquer une erreur de rendu (mock API en échec). Complété au niveau planner par `TripPlannerErrorBoundary`.
+- **Design :** `PageErrorDesktop`.

--- a/docs/recette/01-inventaire-ecrans.md
+++ b/docs/recette/01-inventaire-ecrans.md
@@ -1,0 +1,159 @@
+# Ordre 1 — Inventaire des écrans
+
+Inventaire dérivé de `pwa/src/app/` (App Router Next.js 16). Pour chaque route : objectif, exigence d'authentification, états de données et composants principaux.
+
+## Classes d'authentification
+
+Source : `pwa/src/components/auth-guard.tsx`.
+
+- **public** : rendu immédiat, aucune session requise.
+- **requires-auth** : redirige vers `/login` si non authentifié ; rend `null` pendant le contrôle pour éviter le flash de contenu.
+- **anon-only** : redirige vers `/` si déjà authentifié.
+
+| Classe | Routes |
+|---|---|
+| public (exact) | `/`, `/faq`, `/legal`, `/privacy`, `/access-requests/verify` |
+| public (préfixe) | `/auth/verify/*`, `/s/*` |
+| anon-only | `/login` |
+| requires-auth | `/trips`, `/trips/new`, `/trips/[id]`, `/account/settings` |
+
+`/` est public mais **dual-state** : page d'atterrissage pour les anonymes, tableau de bord planner pour les authentifiés (silent refresh au montage).
+
+## Écrans
+
+### 1. Accueil — `/`
+
+- **Fichier :** `pwa/src/app/page.tsx`
+- **Objectif :** atterrissage (anon) ou tableau de bord planner (auth).
+- **Auth :** public, dual-state.
+- **États :**
+  - `loading` : rendu `null` pendant le silent refresh (anti-flash).
+  - anon : `LandingPage`.
+  - auth : `TripPlanner` (dans `HydrationBoundary` + `TripPlannerErrorBoundary`).
+- **Composants clés :** `LandingPage`, `TripPlanner`, `TripPlannerErrorBoundary`, `HydrationBoundary`.
+
+### 2. Connexion — `/login`
+
+- **Fichier :** `pwa/src/app/login/page.tsx`
+- **Objectif :** authentification par lien magique.
+- **Auth :** anon-only (redirige vers `/` si authentifié).
+- **États :** formulaire prêt ; bannière early access. Sous-états (envoi, lien envoyé, cooldown 60s) gérés par `MagicLinkForm`.
+- **Composants clés :** `MagicLinkForm`, `AttributionFooter`.
+
+### 3. Mes voyages — `/trips`
+
+- **Fichier :** `pwa/src/app/trips/page.tsx`
+- **Objectif :** lister, filtrer, paginer et supprimer les voyages.
+- **Auth :** requires-auth.
+- **États :**
+  - `loading` : spinner + texte (`aria-live=polite`, `aria-busy`).
+  - `error` : message + bouton réessayer.
+  - `empty` : `TripsEmptyState` variant `empty`.
+  - `no-results` (filtres actifs) : `TripsEmptyState` variant `no-results` + reset.
+  - `populated` : grille `TripCard` (1 col mobile / 2 col desktop), pagination si `totalPages > 1`, dialog de confirmation de suppression.
+- **Composants clés :** `TripCard`, `TripsEmptyState`, `Dialog`.
+
+### 4. Nouveau voyage (wizard) — `/trips/new`
+
+- **Fichier :** `pwa/src/app/trips/new/page.tsx`
+- **Objectif :** wizard 4 étapes (préparation -> aperçu -> analyse -> redirection vers le voyage).
+- **Auth :** requires-auth.
+- **États (param `?step=` = source de vérité, synchro bidirectionnelle avec le store) :**
+  - step 1 préparation : `CardSelection` (URL / GPX / Assistant IA).
+  - step 2 aperçu : carte + stats + étapes + sliders + CTA "Lancer l'analyse" + `AiRefinementCard`.
+  - step 3 analyse : flux narratif SSE.
+  - step 4 : redirige vers `/trips/[id]` quand `tripId` connu.
+- **Composants clés :** `WizardStepper`, `TripPlanner` (`hideStepper`, `previewSlot`), `AiRefinementCard`.
+
+### 5. Détail voyage — `/trips/[id]`
+
+- **Fichiers :** `pwa/src/app/trips/[id]/page.tsx` (wrapper) -> `trip-page.tsx`.
+- **Objectif :** consulter et éditer un voyage persisté (éditeur principal).
+- **Auth :** requires-auth.
+- **États :**
+  - `loading` : skeletons (`TripSummarySkeleton`, `TimelineSidebarSkeleton`, `StagePanelSkeleton`, `aria-busy`).
+  - `error` (non trouvé) : `TripNotFound`.
+  - `populated` : `TripPlanner` hydraté ; états internes `computing`, météo en chargement, scan hébergements.
+- **Composants clés :** `TripLoader` (fetch `/trips/{id}/detail`), `TripPlanner`, skeletons.
+
+### 6. Vue partagée — `/s/[code]`
+
+- **Fichiers :** `pwa/src/app/s/[code]/page.tsx` (wrapper) -> `shared-trip-page.tsx`.
+- **Objectif :** vue publique **lecture seule** d'un voyage partagé (roadbook + carte, sans édition).
+- **Auth :** public (préfixe `/s/`).
+- **États :**
+  - `loading` : spinner centré (min-height 60vh).
+  - `error` (non trouvé / lien révoqué) : `TripNotFound` variant `share` + `SharedTopBar`.
+  - `populated` : `TripSummary` (read-only), `ViewModeToggle` (timeline / map / split), `RoadbookMasterDetail` (`readOnly`), `MapPanel`.
+- **Composants clés :** `SharedTripLoader`, `SharedTopBar`, `SharedViewBanner`, `TripSummary`, `ViewModeToggle`, `RoadbookMasterDetail`, `MapPanel`.
+
+### 7. Paramètres du compte — `/account/settings`
+
+- **Fichier :** `pwa/src/app/account/settings/page.tsx`
+- **Objectif :** gestion du compte (email, langue/thème, export RGPD, suppression, déconnexion).
+- **Auth :** requires-auth.
+- **États :** sections empilées ; sous-états gérés par chaque section.
+- **Composants clés :** `AccountSection`, `PreferencesSection`, `DataSection`, `DangerZoneSection`, `LogoutSection`.
+
+### 8. Vérification demande d'accès — `/access-requests/verify`
+
+- **Fichier :** `pwa/src/app/access-requests/verify/page.tsx`
+- **Objectif :** vérifier une demande d'early access via lien email (params signés HMAC transmis au backend).
+- **Auth :** public.
+- **États :**
+  - `loading` : spinner + "Verifying…" (`role=status`, `aria-live`).
+  - succès : `window.location.replace()` vers le backend, qui redirige vers `/?access=confirmed`.
+  - erreur (params manquants) : redirection auto vers `/`.
+- **Composants clés :** aucun (spinner/texte).
+
+### 9. Vérification lien magique — `/auth/verify/[token]`
+
+- **Fichiers :** `pwa/src/app/auth/verify/[token]/page.tsx` (wrapper) -> `verify-page.tsx`.
+- **Objectif :** consommer le token à usage unique, recevoir JWT + cookie refresh.
+- **Auth :** public (préfixe `/auth/verify`).
+- **États :**
+  - `loading` : spinner + "Verifying…".
+  - succès : `setAuth` + redirection vers `/`.
+  - erreur (token invalide/expiré) : `LinkExpired` (option redemander un lien -> `/login`).
+- **Composants clés :** `LinkExpired`.
+
+### 10. FAQ — `/faq`
+
+- **Fichier :** `pwa/src/app/faq/page.tsx`
+- **Objectif :** FAQ publique, 3 catégories repliables (projet, fonctionnement, accès).
+- **Auth :** public.
+- **États :** contenu statique SSR.
+- **Composants clés :** `FaqAccordion`.
+
+### 11. Mentions légales — `/legal`
+
+- **Fichier :** `pwa/src/app/legal/page.tsx`
+- **Objectif :** éditeur, hébergeur, contact, propriété intellectuelle.
+- **Auth :** public.
+- **États :** contenu statique SSR.
+- **Composants clés :** `LegalPageLayout`, `LandingFooter`.
+
+### 12. Confidentialité — `/privacy`
+
+- **Fichier :** `pwa/src/app/privacy/page.tsx`
+- **Objectif :** politique RGPD (responsable, base légale, finalités, conservation, droits, sous-traitants, analytics, contact).
+- **Auth :** public.
+- **États :** contenu statique SSR.
+- **Composants clés :** `LegalPageLayout`, `LandingFooter`.
+
+## Variantes transverses
+
+Au-delà des états par écran, ces variantes s'appliquent largement et doivent être vérifiées :
+
+- **Thème :** clair / sombre / système (`theme-toggle.tsx`).
+- **Langue :** FR / EN (`locale-switcher.tsx`).
+- **Hors-ligne :** `offline-banner.tsx` (voir `mobile-offline.feature`).
+- **Onboarding :** `onboarding-tour.tsx` au premier lancement.
+- **Responsive :** mobile 390px vs desktop 1280px.
+
+## États non routés (écrans système)
+
+Pas de route App Router dédiée mais présents dans le design et le code :
+
+- **404** : `not-found` (design `PageNotFoundDesktop`).
+- **500** : error boundary (design `PageErrorDesktop`, `TripPlannerErrorBoundary`).

--- a/docs/recette/02-checklists-ecrans.md
+++ b/docs/recette/02-checklists-ecrans.md
@@ -29,6 +29,7 @@ Appliquée à tout composant interactif, sauf mention contraire :
 ## 1. Accueil — `/`
 
 **Anon (landing) :**
+
 - [ ] Barre de nav : logo, sélecteur de langue, toggle thème, "Se connecter", "Demander l'accès".
 - [ ] Hero : titre, sous-titre, CTA "Créer mon itinéraire" + "Voir la démo".
 - [ ] Sections : "Comment ça marche" (4 étapes), bento avantages, sources supportées, aperçu écrans, CTA early access, footer (liens légaux).
@@ -36,6 +37,7 @@ Appliquée à tout composant interactif, sauf mention contraire :
 - [ ] Responsive 390px : sections empilées, lisibles.
 
 **Auth (planner) :**
+
 - [ ] Bascule vers `TripPlanner` sans flash anon (state `loading` -> `null`).
 - [ ] error boundary capture une erreur de rendu sans page blanche.
 
@@ -140,7 +142,15 @@ Appliquée à tout composant interactif, sauf mention contraire :
 - [ ] Liens d'ancrage fonctionnels.
 - [ ] Footer présent.
 
-## États système (404 / 500)
+## Écrans système (404 / 500)
 
-- [ ] 404 : message "Hors-piste", CTA "Retour à l'accueil" + "Mes voyages".
-- [ ] 500 : icône d'alerte, badge "Erreur serveur · 500", `request_id` + timestamp, CTA "Réessayer" + "Signaler".
+**404 (`not-found.tsx`)** — déclenchement : URL inexistante :
+
+- [ ] message "Hors-piste", CTA "Retour à l'accueil" + "Mes voyages".
+- [ ] CTA : hover, focus clavier.
+
+**500 (`error.tsx` / `global-error.tsx`)** — déclenchement : erreur de rendu :
+
+- [ ] icône d'alerte, badge "Erreur serveur · 500", `request_id` + timestamp.
+- [ ] CTA "Réessayer" (relance le rendu) + "Signaler".
+- [ ] `global-error` : la page reste affichable même si le layout racine échoue.

--- a/docs/recette/02-checklists-ecrans.md
+++ b/docs/recette/02-checklists-ecrans.md
@@ -1,0 +1,146 @@
+# Ordre 2 — Checklists par écran
+
+Checklist de recette par écran : éléments attendus, comportements, états interactifs (hover / focus / disabled / loading / empty / error), responsive et accessibilité clavier.
+
+Les écrans suivent l'[inventaire](01-inventaire-ecrans.md). Légende des cases : `[ ]` à vérifier en recette.
+
+## Grille d'états standard
+
+Appliquée à tout composant interactif, sauf mention contraire :
+
+- **hover** : retour visuel au survol (curseur, couleur, élévation).
+- **focus** : anneau de focus visible au clavier (`:focus-visible`), jamais supprimé sans remplacement.
+- **disabled** : état grisé, non focusable ou `aria-disabled`, pas d'action.
+- **loading** : indicateur (spinner / skeleton), `aria-busy`, action bloquée pendant le traitement.
+- **empty** : message explicite + action de sortie quand une liste est vide.
+- **error** : message lisible + action de récupération (réessayer / corriger).
+
+## A11y clavier (transverse)
+
+- [ ] Tab parcourt tous les éléments interactifs dans un ordre logique.
+- [ ] Focus visible partout, jamais piégé hors d'une modale.
+- [ ] Modales : focus trap, `Esc` ferme, focus restauré au déclencheur à la fermeture.
+- [ ] Raccourcis documentés (modale d'aide) : `J`/`K` étape suiv./préc., `Ctrl+Z`/`Ctrl+Y` undo/redo, `?` aide, `Esc` fermer, `T` thème, `M` carte.
+- [ ] Régions live (`aria-live`) annoncent loading / succès / erreur.
+- [ ] axe : 0 violation critique (helper `expectNoCriticalA11yViolations`).
+
+---
+
+## 1. Accueil — `/`
+
+**Anon (landing) :**
+- [ ] Barre de nav : logo, sélecteur de langue, toggle thème, "Se connecter", "Demander l'accès".
+- [ ] Hero : titre, sous-titre, CTA "Créer mon itinéraire" + "Voir la démo".
+- [ ] Sections : "Comment ça marche" (4 étapes), bento avantages, sources supportées, aperçu écrans, CTA early access, footer (liens légaux).
+- [ ] CTA et champs : hover, focus, disabled (early access en cours d'envoi).
+- [ ] Responsive 390px : sections empilées, lisibles.
+
+**Auth (planner) :**
+- [ ] Bascule vers `TripPlanner` sans flash anon (state `loading` -> `null`).
+- [ ] error boundary capture une erreur de rendu sans page blanche.
+
+## 2. Connexion — `/login`
+
+- [ ] Champ email, bouton "Envoyer le lien magique", lien "Demander l'accès".
+- [ ] Validation email : format invalide -> message inline, bouton disabled.
+- [ ] loading : envoi en cours, bouton disabled.
+- [ ] Sous-état "email envoyé" : confirmation + cooldown 60s (bouton renvoyer disabled puis actif).
+- [ ] Redirection vers `/` si déjà authentifié (anon-only).
+- [ ] Clavier : Entrée soumet, focus initial sur le champ email.
+
+## 3. Mes voyages — `/trips`
+
+- [ ] Header : titre, recherche, filtre par date, "Nouveau voyage".
+- [ ] loading : spinner + texte (`aria-busy`, `aria-live=polite`).
+- [ ] empty : `TripsEmptyState` (incite à créer).
+- [ ] no-results (filtres actifs) : message + résumé filtres + reset.
+- [ ] error : message + bouton réessayer.
+- [ ] populated : grille `TripCard` (hover sur carte), pagination si `> 1` page.
+- [ ] Suppression : dialog de confirmation, focus trap, `Esc` annule.
+- [ ] Responsive : 1 colonne mobile / 2 colonnes desktop ; date inputs max 10rem.
+
+## 4. Nouveau voyage — `/trips/new`
+
+- [ ] `WizardStepper` reflète l'étape courante ; `?step=` synchro avec l'UI.
+- [ ] step 1 : onglets "Lien URL" / "Fichier GPX" / "Assistant IA".
+  - [ ] URL : détection auto (badge "Komoot détecté" etc.), URL non supportée -> message.
+  - [ ] GPX : drop zone (états idle / uploading + barre / success / error fichier invalide).
+  - [ ] Assistant IA : chat (saisie, envoi, bulles user/assistant, "Valider et continuer").
+- [ ] step 2 : carte, profil altimétrique, stats, sliders pacing, dates, hébergements, `AiRefinementCard`, CTA "Lancer l'analyse" + "Retour".
+- [ ] step 3 : barre de progression globale + actes de calcul (done/running/pending) + aperçu temps réel.
+- [ ] step 4 : redirection vers `/trips/[id]`.
+- [ ] disabled : "Continuer" tant que la source n'est pas valide.
+- [ ] Clavier : navigation entre onglets, sliders au clavier (flèches).
+
+## 5. Détail voyage — `/trips/[id]`
+
+- [ ] loading : skeletons (résumé, sidebar timeline, panneau étape).
+- [ ] error : `TripNotFound`.
+- [ ] populated : header voyage (titre éditable, dates, km, D+, difficulté), synthèse IA globale.
+- [ ] Layout 3 colonnes desktop : timeline étapes | carte + profils | détail étape.
+- [ ] Détail étape : métriques (km éditable, D+, départ, ETA), météo, alertes groupées par sévérité, événements (repliable), hébergements (sélection + alternatives), téléchargements GPX/FIT.
+- [ ] Édition : champ distance éditable (focus, validation, recalcul), `inline-recomputation-bar` pendant le recalcul.
+- [ ] Diff IA : surlignage transitoire des champs modifiés (~3s) + annonce lecteur d'écran.
+- [ ] Undo/redo : boutons + raccourcis.
+- [ ] computing : barre de recalcul, `aria-busy`.
+- [ ] no-dates : `no-dates-banner` quand les dates manquent.
+- [ ] locked : `trip-locked-banner` si verrouillé.
+- [ ] Responsive : colonnes empilées sur mobile, `ViewModeToggle`.
+
+## 6. Vue partagée — `/s/[code]`
+
+- [ ] Bannière "lecture seule" (`SharedViewBanner`) visible en haut.
+- [ ] Top bar simplifiée : logo, "Télécharger GPX" / "Télécharger FIT".
+- [ ] loading : spinner centré.
+- [ ] error (lien révoqué / non trouvé) : `TripNotFound` variant share.
+- [ ] populated : `TripSummary` read-only, `ViewModeToggle` (timeline/map/split), `RoadbookMasterDetail` read-only.
+- [ ] Aucun contrôle d'édition visible (pas de champ éditable, pas d'undo/redo).
+- [ ] Responsive : split flex-col mobile / flex-row desktop ; carte masquée sur mobile en split.
+
+## 7. Paramètres du compte — `/account/settings`
+
+- [ ] Header sticky : logo (masqué mobile), retour.
+- [ ] Section Email : affichage + "Modifier via magic link".
+- [ ] Section Préférences : langue FR/EN, thème clair/sombre/auto.
+- [ ] Section RGPD : "Télécharger mes données (JSON)" (loading pendant l'export).
+- [ ] Section Danger Zone : "Supprimer mon compte…" -> dialog destructif (confirmation explicite).
+- [ ] Section Déconnexion : logout.
+- [ ] error : échec d'une action -> message + récupération.
+- [ ] Responsive : max-width 800px, padding adaptatif.
+
+## 8. Vérification demande d'accès — `/access-requests/verify`
+
+- [ ] loading : spinner + "Verifying…" (`role=status`).
+- [ ] succès : redirection backend puis `/?access=confirmed`.
+- [ ] error (params manquants) : redirection auto vers `/`.
+
+## 9. Vérification lien magique — `/auth/verify/[token]`
+
+- [ ] loading : spinner + "Verifying…".
+- [ ] succès : session ouverte, redirection vers `/`.
+- [ ] error (token expiré/invalide) : `LinkExpired` + "Renvoyer un lien" -> `/login`.
+
+## 10. FAQ — `/faq`
+
+- [ ] Accordéon 3 catégories ; items repliables (hover, focus, expand/collapse au clavier `Entrée`/`Espace`).
+- [ ] `aria-expanded` cohérent.
+- [ ] Liens retour fonctionnels.
+- [ ] Responsive : max-width 2xl.
+
+## 11. Mentions légales — `/legal`
+
+- [ ] Sommaire latéral + sections (éditeur, hébergeur, contact, propriété intellectuelle, licence).
+- [ ] Liens d'ancrage du sommaire fonctionnels (focus déplacé).
+- [ ] Footer présent.
+
+## 12. Confidentialité — `/privacy`
+
+- [ ] Sommaire latéral + 9 sections (responsable -> contact).
+- [ ] Mention base légale RGPD + date de mise à jour.
+- [ ] Liens d'ancrage fonctionnels.
+- [ ] Footer présent.
+
+## États système (404 / 500)
+
+- [ ] 404 : message "Hors-piste", CTA "Retour à l'accueil" + "Mes voyages".
+- [ ] 500 : icône d'alerte, badge "Erreur serveur · 500", `request_id` + timestamp, CTA "Réessayer" + "Signaler".

--- a/docs/recette/03-manifeste-elements.md
+++ b/docs/recette/03-manifeste-elements.md
@@ -1,0 +1,200 @@
+# Ordre 3 — Manifeste d'éléments attendus
+
+Manifeste **présence + position approximative** des éléments par écran, dérivé de l'export Claude Design vendoré sous [`design/`](design/). Destiné à une comparaison automatisée (Playwright) app vs design.
+
+**Rappel de convention :** seules la **présence** et la **position approximative** (région : header / sidebar / main / footer ; ordre vertical) sont vérifiables automatiquement. Couleur, typo, espacement exact, polish => **regard humain** (capture côte-à-côte en recette manuelle).
+
+L'export design est en **1280px** (desktop, hauteur ~860px par page). Les libellés ci-dessous sont **verbatim** depuis le design (français) ; l'app réelle peut différer selon la locale active.
+
+## Design tokens (`design/tokens.jsx`)
+
+- **Polices :** serif `Fraunces`, sans `Inter Tight`, mono `JetBrains Mono`.
+- **Palette clair (accent ambre) :** fond `#faf7f0`, surface `#ffffff`, surface alt `#f3ece0`, ligne `#e4dbc9`, encre `#2a2418`, encre douce `#5a4e3a`, accent `#c2671e`.
+- **Sévérités :** rouge `#b84420` (critique), vert `#4a7a3e` (ok), bleu `#3d6b91` (info).
+- Mode sombre supporté via toggle thème.
+
+## Notation des positions
+
+- **header** : barre supérieure pleine largeur.
+- **sidebar-L / sidebar-R** : colonne latérale gauche / droite.
+- **main** : zone centrale principale.
+- **footer** : bas de page.
+- **overlay** : modale / popover centré au-dessus du contenu.
+- Ordre indiqué top-to-bottom dans chaque région.
+
+---
+
+## Landing — `/` anon (`design/pages-auth.jsx` `PageLandingDesktop`)
+
+| Région | Éléments attendus (ordre vertical) |
+|---|---|
+| header | logo + "Bike Trip Planner" ; sélecteur langue FR/EN ; toggle thème ; bouton "Se connecter" ; bouton "Demander l'accès" (accent) |
+| main (hero) | pill "Beta privée · accès sur demande" ; H1 ; sous-titre sources ; CTA "Créer mon itinéraire" + "Voir la démo" ; indicateur de scroll |
+| main | section "De l'import au roadbook, en quatre étapes." (4 cartes numérotées) |
+| main | bento "Tout ce qu'il faut pour rouler serein." (terrain, météo, ravitaillement, IA, hébergements, alertes, exports) |
+| main | section sources "Importez depuis ce que vous avez." (Komoot, RideWithGPS, Strava, GPX, IA) |
+| main | aperçu écrans "Sur tous vos écrans." (mockup desktop + mobile) |
+| main | CTA "Rejoignez la beta privée." (champ email + "Demander l'accès") |
+| footer | copyright + liens FAQ / Confidentialité / Mentions légales / GitHub |
+
+## Login — `/login` (`PageLoginDesktop`)
+
+| Région | Éléments attendus |
+|---|---|
+| overlay (carte 440px centrée) | logo + titre ; H2 "Bon retour." ; champ email ; bouton "Envoyer le lien magique" ; lien "Pas encore de compte ? Demander l'accès" |
+| overlay (état envoyé) | icône check ; H2 "Email envoyé, vérifie ta boîte." ; texte expiration 15 min ; bouton "Renvoyer un lien (Ns)" (disabled pendant cooldown) |
+
+## Auth verify — `/auth/verify/[token]` (`PageAuthVerifyDesktop`)
+
+| Région | Éléments attendus |
+|---|---|
+| overlay (480px) état verifying | loader ; H2 "Vérification du lien…" ; texte |
+| overlay état expiré | icône alerte (rouge) ; H2 "Lien expiré ou invalide." ; boutons "Renvoyer un lien" + "Retour" |
+
+## Access request verify — `/access-requests/verify` (`PageAccessRequestDesktop`)
+
+| Région | Éléments attendus |
+|---|---|
+| overlay (480px) | icône check (accent) ; H2 "Demande prise en compte." ; texte ; bouton "Retour à l'accueil" |
+
+## FAQ — `/faq` (`PageFaqDesktop`)
+
+| Région | Éléments attendus |
+|---|---|
+| header | TopBar |
+| sidebar-L (240px) | label "Sections" ; liens (Prise en main, Import & formats, Calculs & météo, Partage, Hors-ligne, Tarifs) ; carte lien GitHub |
+| main | H1 "Foire aux questions" ; texte ; accordéon FAQ |
+| footer | footer |
+
+## Account settings — `/account/settings` (`PageAccountSettingsDesktop`)
+
+| Région | Éléments attendus |
+|---|---|
+| header | TopBar |
+| sidebar-L (240px) | avatar + nom + email ; bouton "Mon compte" (actif) ; bouton déconnexion (rouge) |
+| main | H1 "Mon compte" ; carte Email + "Modifier via magic link" ; carte Préférences (langue FR/EN + thème Clair/Sombre/Auto) ; carte RGPD + "Télécharger mes données (JSON)" ; Danger Zone + "Supprimer mon compte…" (rouge) |
+| footer | footer |
+
+## Privacy — `/privacy` (`design/pages-extra.jsx` `PagePrivacyDesktop`)
+
+| Région | Éléments attendus |
+|---|---|
+| sidebar-L (220px) | "Sommaire" + liens (Introduction, Base légale, Données collectées, Conservation, Vos droits, Cookies & analytics, Contact DPO) |
+| main | pill "Politique de confidentialité" ; H1 "Confidentialité" ; sous-titre date + base légale RGPD ; sections de contenu |
+| footer | footer |
+
+## Legal — `/legal` (`PageLegalDesktop`)
+
+| Région | Éléments attendus |
+|---|---|
+| sidebar-L (220px) | menu (Éditeur, Hébergeur, Contact, Propriété intellectuelle, Licence code source) |
+| main | pill "Mentions légales" ; H1 "Mentions légales" ; sous-titre ; sections |
+| footer | footer |
+
+## Trips list — `/trips` (`design/pages-trips.jsx` `PageTripsListDesktop`)
+
+| Région | Éléments attendus |
+|---|---|
+| header | TopBar |
+| main (header) | H1 "Mes voyages" ; recherche ; bouton "Filtrer par date" ; bouton "Nouveau voyage" (accent) |
+| main (grille) | cartes voyage (2 col) : vignette carte ~190px ; pill statut (En cours / Terminé / Brouillon / Archivé) ; H3 titre ; route + date ; stats distance + durée |
+| footer | footer |
+
+## Roadbook (détail) — `/trips/[id]` (`design/pages-roadbook.jsx` `PageRoadbookDesktop`)
+
+| Région | Éléments attendus |
+|---|---|
+| header | barre de progression recalcul (au-dessus) ; TopBar avec undo + share |
+| main (header voyage) | breadcrumb "Mes voyages › [titre]" ; H1 titre + dates + km + D+ + pill difficulté ; **carte synthèse IA globale** (droite) |
+| sidebar-L (280px) | header "Étapes" ; timeline verticale (cercle jour + nom + km + D+ + points d'alerte) ; boutons "ajouter étape / jour de repos" |
+| main (centre) | carte OSM (étape active) + overlay POI ; contrôles carte (coordonnées + zoom) ; toggle "Carte" / "Satellite" ; profil altimétrique "Profil altimétrique — [étape]" ; `SupplyTimeline` |
+| sidebar-R (360px) | pill "JOUR N · [date]" + boutons "GPX" / "FIT" ; H2 nom étape ; **synthèse IA d'étape** ; métriques (KM éditable, D+, DEP, ETA) ; jauge difficulté ; carte météo ; alertes groupées (critique/attention/info) ; événements (repliable) ; hébergements (sélection + alternatives + "Élargir la zone (5 km)" + "Ajouter manuellement") |
+| overlay | **bulle de chat IA** |
+| footer | footer |
+
+## Vue partagée — `/s/[code]` (`PagePublicSharedDesktop`)
+
+| Région | Éléments attendus |
+|---|---|
+| header | bannière "Vue partagée en lecture seule — vous consultez un itinéraire partagé par [nom]." (bleu) ; top bar simplifiée (logo + "Télécharger GPX" + "Télécharger FIT") |
+| main (hero) | carte OSM pleine largeur + overlay titre/route (bas gauche) + stats (bas droite) |
+| main (grille) | cartes étapes (barre de couleur + cercle jour + date + H3 route + profil + stats km/D+) |
+| footer | footer |
+
+## Wizard step 1 — préparation (`design/pages-wizard.jsx` `PageTripsNewDesktop`)
+
+| Région | Éléments attendus |
+|---|---|
+| header | TopBar (page new) |
+| sidebar-L | `WizardStepper` |
+| main | H1 "D'où vient votre tracé ?" ; sélecteur onglets "Lien URL" / "Fichier GPX" / "Assistant IA" |
+| main (onglet URL) | champ URL ; badge détection ("Komoot Tour détecté") ; carte aperçu route ; bouton "Continuer — Aperçu" |
+| main (onglet GPX) | drop zone (icône + label selon état + barre upload) ; bouton "Continuer — Aperçu" (succès) |
+| main (onglet IA) | conteneur chat (header accent "Assistant IA · Génération d'itinéraire" ; messages ; champ + "Envoyer" ; "Valider et continuer") |
+| footer | footer |
+
+## Wizard step 2 — aperçu & config (`PageTripsNewDesktopStep2`)
+
+| Région | Éléments attendus |
+|---|---|
+| sidebar-L | `WizardStepper` |
+| main-L | titre voyage éditable + icône edit ; carte OSM ; profil altimétrique ; stats (Distance, Dénivelé +, Dénivelé −, Durée est.) |
+| main-R (panneau config) | sélecteur profil (Débutant/Intermédiaire/Expert) ; 5 sliders pacing (distance max, vitesse, départ, fatigue, pénalité dénivelé) ; toggle e-bike ; dates + types hébergement (pills) ; section "Affiner avec l'IA" (textarea + "Effacer"/"Appliquer" + changements proposés) ; CTA "Lancer l'analyse" (accent) + "Retour" |
+| footer | footer |
+
+## Wizard step 3 — analyse (`PageProcessingDesktop`)
+
+| Région | Éléments attendus |
+|---|---|
+| sidebar-L | `WizardStepper` |
+| main-L | H1 titre voyage ; texte "Traitement en parallèle…" ; carte progression globale (label + % + barre) ; liste des actes de calcul (7 items : done/running/pending + label + badges + barre running) |
+| main-R | label "Aperçu temps réel" ; carte OSM ; carte profil altimétrique ; stats (Distance, Dénivelé +, POI trouvés) |
+| footer | footer |
+
+## Modales (`design/modals.jsx`)
+
+### Modale Partage (`ModalShareDesktop`, 600px)
+
+| Section | Éléments |
+|---|---|
+| header | H3 "Partager ce voyage" + sous-titre + bouton fermer |
+| Lien partageable | URL (mono, accent) ; boutons "Copier" + "Révoquer" (rouge) ; info accès lecture seule |
+| Infographie PNG | label + badge "1080×1080" ; aperçu canvas ; bouton "Télécharger PNG (1080×1080)" |
+| Résumé texte | bloc texte mono (titre, distance, D+, dates, étapes) ; bouton "Copier le texte" |
+| Garmin Connect | état non connecté : "Connecter Garmin" (vert) ; état connecté : email + "Envoyer ce voyage vers Garmin Connect" |
+
+### Modale Config (`ModalConfigPanel`, 360px)
+
+| Section | Éléments |
+|---|---|
+| header | H3 "Paramètres" |
+| Dates | inputs "Départ" / "Retour" |
+| Profil cycliste | 3 boutons profil + 5 sliders + toggle e-bike |
+| Hébergements | 9 toggles type (Gîte, Hôtel, Camping, …) |
+| Thème + Langue | sélecteur thème (Clair/Sombre/Auto) + langue (FR/EN) |
+| Actions | "Dupliquer ce voyage" + "Partager" |
+
+### Modale Aide (`ModalHelp`, 520px)
+
+| Onglet | Éléments |
+|---|---|
+| Raccourcis | liste : `J`/`K`, `Ctrl+Z`, `Ctrl+Y`, `?`, `Esc`, `T`, `M` |
+| FAQ rapide | 4 cartes Q/R |
+
+### Modale FAQ (`ModalFaq`, 640px)
+
+- accordéon 7 items (premier ouvert par défaut).
+
+## Écrans système (design, non routés)
+
+- **404** (`PageNotFoundDesktop`) : "404" serif ; H2 "Hors-piste." ; CTA "Retour à l'accueil" + "Mes voyages".
+- **500** (`PageErrorDesktop`) : icône alerte ; badge "Erreur serveur · 500" ; bloc `request_id` + timestamp ; CTA "Réessayer" + "Signaler le problème".
+
+## Références design utiles (non routées)
+
+Présentes dans l'export comme planches de référence, à utiliser pour la recette visuelle manuelle :
+
+- **États UI** (`PageStatesDesktop`) : empty / skeleton / error / form states.
+- **Légende pictos** (`PagePictoLegendDesktop`) : fins d'étape, hébergements (9), eau & ravitaillement, services vélo, POI culturels.
+- **POI popover** (`design/pages-poi.jsx`) : variante enrichie (Wikidata/DataTourisme) vs minimale (OSM).
+- **Infographie** (`PageInfographicDesktop`) : format 1080×1080 du partage PNG.

--- a/docs/recette/03-manifeste-elements.md
+++ b/docs/recette/03-manifeste-elements.md
@@ -185,7 +185,7 @@ L'export design est en **1280px** (desktop, hauteur ~860px par page). Les libell
 
 - accordéon 7 items (premier ouvert par défaut).
 
-## Écrans système (design, non routés)
+## Écrans système (`not-found.tsx`, `error.tsx`)
 
 - **404** (`PageNotFoundDesktop`) : "404" serif ; H2 "Hors-piste." ; CTA "Retour à l'accueil" + "Mes voyages".
 - **500** (`PageErrorDesktop`) : icône alerte ; badge "Erreur serveur · 500" ; bloc `request_id` + timestamp ; CTA "Réessayer" + "Signaler le problème".

--- a/docs/recette/04-couverture-gherkin.md
+++ b/docs/recette/04-couverture-gherkin.md
@@ -1,0 +1,144 @@
+# Ordre 4 — Audit de couverture Gherkin
+
+Audit des 30 fichiers `.feature` (15 sujets x FR/EN) sous `pwa/tests/recette/features/` face aux features réellement livrées, et liste des scénarios manquants à écrire (priorité IA S30-32 et design S25-27).
+
+## Inventaire et parité FR/EN
+
+154 scénarios côté FR. Parité globalement bonne, **3 écarts** (l'EN a un `Scenario Outline` absent du FR) :
+
+| Sujet | FR | EN | Parité |
+|---|---|---|---|
+| accommodations | 11 | 11 | OK |
+| alerts-analysis | 9 | 10 | **écart** : EN a "Difficulty thresholds by alert type" |
+| auth-security | 10 | 10 | OK |
+| configuration | 10 | 10 | OK |
+| cross-cutting-ux | 12 | 12 | OK |
+| dates-calendar | 8 | 8 | OK |
+| edge-cases | 12 | 12 | OK |
+| export | 8 | 9 | **écart** : EN a "Export by file format" |
+| map-visualization | 12 | 12 | OK |
+| mobile-offline | 12 | 12 | OK |
+| sharing | 8 | 8 | OK |
+| stage-management | 12 | 12 | OK |
+| trip-creation | 11 | 12 | **écart** : EN a "Trip creation from different sources" |
+| trip-management | 9 | 9 | OK |
+| weather-time | 10 | 10 | OK |
+
+**À corriger (parité) :** ajouter les 3 `Scenario Outline` manquants côté FR :
+- `alerts-analysis.fr.feature` : "Seuils de difficulté par type d'alerte"
+- `export.fr.feature` : "Export par format de fichier"
+- `trip-creation.fr.feature` : "Création de voyage depuis différentes sources"
+
+## Matrice de couverture vs features réelles
+
+Les 15 sujets couvrent bien les **workflows cœur** (sprints 1-24). Les **trous portent précisément sur les sprints récents** : IA S28-32 et refonte design S25-27.
+
+| Domaine réel | Composant(s) | Couverture | Statut |
+|---|---|---|---|
+| Workflows cœur (création, étapes, météo, hébergements, alertes, export, partage, dates, carte, offline) | — | 13 sujets | **COUVERT** |
+| Synthèse IA voyage | `trip-ai-overview.tsx` | aucune | **MANQUANT** |
+| Synthèse IA étape | `stage-ai-summary.tsx` | aucune | **MANQUANT** |
+| Chat IA conversationnel | `ai-chat-panel.tsx` | aucune | **MANQUANT** |
+| Raffinement IA (génération conversationnelle) | `ai-refinement-card.tsx` | aucune | **MANQUANT** |
+| Surlignage des diffs IA | `diff-highlight.tsx` | aucune | **MANQUANT** |
+| Page d'atterrissage | `landing-page.tsx`, `landing/` | aucune | **MANQUANT** |
+| Tour d'onboarding | `onboarding-tour.tsx` | `cross-cutting-ux` (1 scénario) | **PARTIEL** |
+| Toggle thème (clair/sombre/système) | `theme-toggle.tsx` | `cross-cutting-ux` (2 scénarios) | **PARTIEL** |
+| Sélecteur de langue | `locale-switcher.tsx` | `cross-cutting-ux` (2 scénarios) | **PARTIEL** |
+| Supply timeline | `SupplyTimeline/` | aucune | **MANQUANT** |
+| Timeline/roadbook redesignée | `timeline.tsx`, `timeline-marker.tsx` | `stage-management` (partiel) | **PARTIEL** |
+
+## Scénarios manquants à écrire
+
+Estimation ~53 scénarios : 2 nouveaux fichiers + extensions de 2 fichiers existants. À écrire en FR **et** EN (parité).
+
+### IA S28-32 — nouveau fichier `ai-features.{fr,en}.feature` (priorité HAUTE)
+
+**Synthèse IA voyage (`trip-ai-overview`)** — 5 scénarios :
+- Affichage de la carte de synthèse IA en haut de "Mon voyage".
+- Contenu narratif visible.
+- Patterns globaux visibles (dénivelé cumulé, difficultés saisonnières).
+- Recommandations inter-étapes visibles.
+- Carte masquée quand le LLM est absent/désactivé.
+
+**Synthèse IA étape (`stage-ai-summary`)** — 4 scénarios :
+- Carte "Analyse IA" présente sur chaque étape.
+- Description IA de l'étape affichée.
+- Alertes cross-stage intégrées dans la carte.
+- Déploiement de l'analyse complète au clic.
+
+**Chat IA (`ai-chat-panel`)** — 6 scénarios :
+- Panneau chat visible après calcul.
+- Message envoyé au backend (`POST /trips/*/chat`).
+- Réponse affichée dans l'historique.
+- Indicateur de chargement pendant la réponse.
+- Mode "En route" + géolocalisation -> POIs proches.
+- Carte POI (`PoiCard`) affichée depuis une réponse.
+
+**Raffinement IA (`ai-refinement-card`)** — 7 scénarios :
+- Carte "Suggestion de modification" visible.
+- Limite 500 caractères respectée.
+- Compteur de caractères affiché.
+- Bouton "Appliquer" disabled si vide.
+- Appel API de raffinement déclenché.
+- Étapes régénérées après raffinement.
+- Textarea vidée après succès.
+
+**Surlignage diff IA (`diff-highlight`)** — 3 scénarios :
+- Distance modifiée surlignée (animation ~3s).
+- Alerte ajoutée surlignée.
+- Annonce lecteur d'écran du champ modifié.
+
+### Design S25-27 (priorité HAUTE / MOYENNE)
+
+**Page d'atterrissage** — nouveau fichier `landing-page.{fr,en}.feature` — 8 scénarios :
+- Hero (titre, description, CTA).
+- "Comment ça marche" (3-4 étapes).
+- Bento avantages.
+- Sources supportées (Komoot, Strava, RideWithGPS, GPX).
+- Section plateformes.
+- Témoignages / cas d'usage.
+- Footer + liens légaux.
+- Responsive 390px (sections empilées).
+
+**Onboarding** — étendre `cross-cutting-ux` — 7 scénarios :
+- Fermeture par `Esc`.
+- Fermeture par clic overlay.
+- Étape 1 cible le champ lien magique.
+- Étape 2 cible le bouton upload GPX.
+- Étapes 3-4 modales centrées (profil rider, lecture timeline).
+- Tour ne réapparaît plus après fermeture (flag persistant).
+
+**Thème** — étendre `cross-cutting-ux` — 3 scénarios :
+- Cycle clair -> sombre -> système.
+- Mode système suit l'OS.
+- Choix persisté (localStorage) après refresh.
+
+**Langue** — étendre `cross-cutting-ux` — 3 scénarios :
+- Labels compacts (FR/EN) sur écran étroit.
+- Permutation sur mobile.
+- Persistance après refresh.
+
+**Supply timeline** — étendre `stage-management` — 4 scénarios :
+- Affichage de la timeline des ravitaillements.
+- Marqueurs avec icônes (eau, nourriture, mécanique).
+- Hover -> nom + distance.
+- Défilement horizontal sur mobile.
+
+**Timeline/roadbook redesignée** — étendre `stage-management` — 4 scénarios :
+- Vue splitée carte + timeline.
+- Toggle "Carte seule" / "Splitée".
+- Réajustement responsive.
+- Timeline plein écran sur mobile + bascule carte.
+
+## Synthèse
+
+| Catégorie | Fichiers | Scénarios à écrire | Priorité |
+|---|---|---|---|
+| Parité FR/EN | 3 existants | 3 outlines | BASSE |
+| IA S28-32 | 1 nouveau (`ai-features`) | ~25 | HAUTE |
+| Landing | 1 nouveau (`landing-page`) | 8 | HAUTE |
+| Onboarding / thème / langue | extension `cross-cutting-ux` | 13 | MOYENNE |
+| Supply / timeline | extension `stage-management` | 8 | MOYENNE |
+
+> Note : l'écriture effective de ces scénarios + leur automatisation relève du **Sprint 35.3** (audit fonctionnel + couverture). Ce document en est le référentiel d'entrée.

--- a/docs/recette/04-couverture-gherkin.md
+++ b/docs/recette/04-couverture-gherkin.md
@@ -25,6 +25,7 @@ Audit des 30 fichiers `.feature` (15 sujets x FR/EN) sous `pwa/tests/recette/fea
 | weather-time | 10 | 10 | OK |
 
 **À corriger (parité) :** ajouter les 3 `Scenario Outline` manquants côté FR :
+
 - `alerts-analysis.fr.feature` : "Seuils de difficulté par type d'alerte"
 - `export.fr.feature` : "Export par format de fichier"
 - `trip-creation.fr.feature` : "Création de voyage depuis différentes sources"
@@ -55,6 +56,7 @@ Estimation ~53 scénarios : 2 nouveaux fichiers + extensions de 2 fichiers exist
 ### IA S28-32 — nouveau fichier `ai-features.{fr,en}.feature` (priorité HAUTE)
 
 **Synthèse IA voyage (`trip-ai-overview`)** — 5 scénarios :
+
 - Affichage de la carte de synthèse IA en haut de "Mon voyage".
 - Contenu narratif visible.
 - Patterns globaux visibles (dénivelé cumulé, difficultés saisonnières).
@@ -62,12 +64,14 @@ Estimation ~53 scénarios : 2 nouveaux fichiers + extensions de 2 fichiers exist
 - Carte masquée quand le LLM est absent/désactivé.
 
 **Synthèse IA étape (`stage-ai-summary`)** — 4 scénarios :
+
 - Carte "Analyse IA" présente sur chaque étape.
 - Description IA de l'étape affichée.
 - Alertes cross-stage intégrées dans la carte.
 - Déploiement de l'analyse complète au clic.
 
 **Chat IA (`ai-chat-panel`)** — 6 scénarios :
+
 - Panneau chat visible après calcul.
 - Message envoyé au backend (`POST /trips/*/chat`).
 - Réponse affichée dans l'historique.
@@ -76,6 +80,7 @@ Estimation ~53 scénarios : 2 nouveaux fichiers + extensions de 2 fichiers exist
 - Carte POI (`PoiCard`) affichée depuis une réponse.
 
 **Raffinement IA (`ai-refinement-card`)** — 7 scénarios :
+
 - Carte "Suggestion de modification" visible.
 - Limite 500 caractères respectée.
 - Compteur de caractères affiché.
@@ -85,6 +90,7 @@ Estimation ~53 scénarios : 2 nouveaux fichiers + extensions de 2 fichiers exist
 - Textarea vidée après succès.
 
 **Surlignage diff IA (`diff-highlight`)** — 3 scénarios :
+
 - Distance modifiée surlignée (animation ~3s).
 - Alerte ajoutée surlignée.
 - Annonce lecteur d'écran du champ modifié.
@@ -92,6 +98,7 @@ Estimation ~53 scénarios : 2 nouveaux fichiers + extensions de 2 fichiers exist
 ### Design S25-27 (priorité HAUTE / MOYENNE)
 
 **Page d'atterrissage** — nouveau fichier `landing-page.{fr,en}.feature` — 8 scénarios :
+
 - Hero (titre, description, CTA).
 - "Comment ça marche" (3-4 étapes).
 - Bento avantages.
@@ -102,6 +109,7 @@ Estimation ~53 scénarios : 2 nouveaux fichiers + extensions de 2 fichiers exist
 - Responsive 390px (sections empilées).
 
 **Onboarding** — étendre `cross-cutting-ux` — 7 scénarios :
+
 - Fermeture par `Esc`.
 - Fermeture par clic overlay.
 - Étape 1 cible le champ lien magique.
@@ -110,22 +118,26 @@ Estimation ~53 scénarios : 2 nouveaux fichiers + extensions de 2 fichiers exist
 - Tour ne réapparaît plus après fermeture (flag persistant).
 
 **Thème** — étendre `cross-cutting-ux` — 3 scénarios :
+
 - Cycle clair -> sombre -> système.
 - Mode système suit l'OS.
 - Choix persisté (localStorage) après refresh.
 
 **Langue** — étendre `cross-cutting-ux` — 3 scénarios :
+
 - Labels compacts (FR/EN) sur écran étroit.
 - Permutation sur mobile.
 - Persistance après refresh.
 
 **Supply timeline** — étendre `stage-management` — 4 scénarios :
+
 - Affichage de la timeline des ravitaillements.
 - Marqueurs avec icônes (eau, nourriture, mécanique).
 - Hover -> nom + distance.
 - Défilement horizontal sur mobile.
 
 **Timeline/roadbook redesignée** — étendre `stage-management` — 4 scénarios :
+
 - Vue splitée carte + timeline.
 - Toggle "Carte seule" / "Splitée".
 - Réajustement responsive.

--- a/docs/recette/README.md
+++ b/docs/recette/README.md
@@ -27,3 +27,40 @@ L'export Claude Design (claude.ai/design) est vendoré sous [`design/`](design/)
 - Routes auth : voir `pwa/src/components/auth-guard.tsx`. Trois classes : **public**, **requires-auth**, **anon-only**.
 - États de données normalisés : `loading`, `empty`, `populated`, `error`, plus états métier (`computing`, `locked`, `no-dates`, `offline`).
 - Breakpoints de référence : mobile **390px**, desktop **1280px** (base de l'export design).
+
+## Traçabilité
+
+Une ligne par écran de l'[inventaire](01-inventaire-ecrans.md), reliant les 4 livrables et le(s) sujet(s) `.feature` couvrant (Gherkin sous `pwa/tests/recette/features/`). `—` = trou de couverture identifié à l'[ordre 4](04-couverture-gherkin.md).
+
+| Écran | Checklist | Manifeste | Sujet(s) `.feature` |
+|---|---|---|---|
+| `/` (landing anon) | 02 §1 | 03 Landing | — (landing à écrire) |
+| `/` (planner auth) | 02 §1 | 03 Roadbook | trip-management, trip-creation |
+| `/login` | 02 §2 | 03 Login | auth-security |
+| `/trips` | 02 §3 | 03 Trips list | trip-management |
+| `/trips/new` | 02 §4 | 03 Wizard 1/2/3 | trip-creation, configuration |
+| `/trips/[id]` | 02 §5 | 03 Roadbook | stage-management, alerts-analysis, weather-time, accommodations, map-visualization, dates-calendar, export ; **IA à écrire** |
+| `/s/[code]` | 02 §6 | 03 Vue partagée | sharing |
+| `/account/settings` | 02 §7 | 03 Account settings | auth-security ; privacy (partiel) |
+| `/access-requests/verify` | 02 §8 | 03 Access request | auth-security |
+| `/auth/verify/[token]` | 02 §9 | 03 Auth verify | auth-security |
+| `/faq` | 02 §10 | 03 FAQ | cross-cutting-ux (partiel) |
+| `/legal` | 02 §11 | 03 Legal | — |
+| `/privacy` | 02 §12 | 03 Privacy | — |
+| 404 / 500 | 02 Écrans système | 03 Écrans système | edge-cases |
+| Transverse (thème, langue, onboarding, offline) | 02 A11y + grilles | 03 modales / tokens | cross-cutting-ux, mobile-offline |
+
+## Utilisation et critères de recette
+
+Comment ce référentiel est consommé en aval :
+
+- **Sprint 35.3 (automatisé)** : chaque écran de l'inventaire doit avoir un verdict. Le manifeste (ordre 3) alimente un test Playwright de présence + position ; les trous Gherkin (ordre 4) deviennent des `.feature` à écrire puis automatiser.
+- **Recette manuelle** : la checklist (ordre 2) sert de script pas-à-pas ; la comparaison visuelle app vs design (couleur/typo/polish) se fait à l'oeil, capture côte-à-côte avec `design/`.
+
+**Critère de passage par écran :** tous les éléments du manifeste présents et bien positionnés (auto) **ET** checklist sans point bloquant **ET** 0 violation a11y critique (`expectNoCriticalA11yViolations`). Un écart de polish visuel est un finding (issue milestone `Sprint 35.4`), pas un échec bloquant de recette.
+
+## Niveau de confiance
+
+- **Ordres 1-2 (inventaire, checklists)** : dérivés du code (`pwa/src/app/`, composants) — haute confiance.
+- **Ordre 3 (manifeste)** : dérivé de l'export design (desktop 1280px). Libellés **verbatim FR** ; l'app réelle varie selon la locale, et les positions sont **approximatives par conception**.
+- **Ordre 4 (couverture)** : compteurs de scénarios et parité FR/EN vérifiés ; la liste des manquants est une estimation de cadrage pour 35.3.

--- a/docs/recette/README.md
+++ b/docs/recette/README.md
@@ -1,0 +1,29 @@
+# Référentiel de recette
+
+Spec commune à l'audit fonctionnel automatisé (Sprint 35.3) et à la recette manuelle. Décrit **ce que l'application doit faire** (écrans, éléments, comportements, états) indépendamment de la façon dont c'est testé.
+
+Périmètre : features livrées sur `main` (sprints 1-33, design S25-27, IA S28-32, S34/34.5), **hors** S18 #313/#314 (abandonnés) et osm-cron nightly (#575).
+
+## Livrables
+
+| Doc | Ordre 35.1 | Contenu |
+|---|---|---|
+| [`01-inventaire-ecrans.md`](01-inventaire-ecrans.md) | 1 | Inventaire des écrans dérivé de `pwa/src/app/` + variantes auth/anon et états de données. |
+| [`02-checklists-ecrans.md`](02-checklists-ecrans.md) | 2 | Checklist par écran : éléments, comportements, états (hover/focus/disabled/loading/empty/error), responsive, a11y clavier. |
+| [`03-manifeste-elements.md`](03-manifeste-elements.md) | 3 | Manifeste d'éléments attendus par écran (présence + position approximative) dérivé de l'export Claude Design. |
+| [`04-couverture-gherkin.md`](04-couverture-gherkin.md) | 4 | Audit de couverture Gherkin (`.feature` vs features réelles) + scénarios manquants à écrire. |
+
+## Source design
+
+L'export Claude Design (claude.ai/design) est vendoré sous [`design/`](design/) : `tokens.jsx`, `pages-*.jsx`, `modals.jsx`, `ui.jsx`, `ui2.jsx`, `toutes-les-pages.html`. Ce sont des prototypes HTML/CSS/JS, pas du code de production.
+
+**Convention de comparaison app vs design :**
+
+- **Présence + position approximative** des éléments => vérifiable automatiquement (Playwright, voir [`03-manifeste-elements.md`](03-manifeste-elements.md)).
+- **Couleur, typo, polish** => regard humain (capture côte-à-côte pendant la recette manuelle).
+
+## Conventions
+
+- Routes auth : voir `pwa/src/components/auth-guard.tsx`. Trois classes : **public**, **requires-auth**, **anon-only**.
+- États de données normalisés : `loading`, `empty`, `populated`, `error`, plus états métier (`computing`, `locked`, `no-dates`, `offline`).
+- Breakpoints de référence : mobile **390px**, desktop **1280px** (base de l'export design).

--- a/docs/recette/design/EXPORT-README.md
+++ b/docs/recette/design/EXPORT-README.md
@@ -1,0 +1,22 @@
+# CODING AGENTS: READ THIS FIRST
+
+This is a **handoff bundle** from Claude Design (claude.ai/design).
+
+A user mocked up designs in HTML/CSS/JS using an AI design tool, then exported this bundle so a coding agent can implement the designs for real.
+
+## What you should do — IMPORTANT
+
+**Read `bike-trip-planner/project/Bike Trip Planner - Toutes les pages.html` in full.** The user had this file open when they triggered the handoff, so it's almost certainly the primary design they want built. Read it top to bottom — don't skim. Then **follow its imports**: open every file it pulls in (shared components, CSS, scripts) so you understand how the pieces fit together before you start implementing.
+
+**If anything is ambiguous, ask the user to confirm before you start implementing.** It's much cheaper to clarify scope up front than to build the wrong thing.
+
+## About the design files
+
+The design medium is **HTML/CSS/JS** — these are prototypes, not production code. Your job is to **recreate them pixel-perfectly** in whatever technology makes sense for the target codebase (React, Vue, native, whatever fits). Match the visual output; don't copy the prototype's internal structure unless it happens to fit.
+
+**Don't render these files in a browser or take screenshots unless the user asks you to.** Everything you need — dimensions, colors, layout rules — is spelled out in the source. Read the HTML and CSS directly; a screenshot won't tell you anything they don't.
+
+## Bundle contents
+
+- `bike-trip-planner/README.md` — this file
+- `bike-trip-planner/project/` — the `Bike Trip Planner` project files (HTML prototypes, assets, components)

--- a/docs/recette/design/EXPORT-README.md
+++ b/docs/recette/design/EXPORT-README.md
@@ -1,3 +1,11 @@
+# ARCHIVED — Design export reference (do not act on this file)
+
+> **Note for coding agents:** this file is committed as a static reference artifact for Sprint 35.1 acceptance testing (recette). It is NOT an active design handoff. Do NOT read or implement anything described below. The authoritative implementation source is `pwa/src/app/`; the design is already built. The paths referenced below (e.g. `bike-trip-planner/project/...`) do not exist in this repo.
+
+---
+
+<!-- Original Claude Design export README preserved verbatim below, for traceability only. -->
+
 # CODING AGENTS: READ THIS FIRST
 
 This is a **handoff bundle** from Claude Design (claude.ai/design).

--- a/docs/recette/design/EXPORT-README.md
+++ b/docs/recette/design/EXPORT-README.md
@@ -4,9 +4,9 @@
 
 ---
 
-<!-- Original Claude Design export README preserved verbatim below, for traceability only. -->
+<!-- Original Claude Design export README preserved below, for traceability only. -->
 
-# CODING AGENTS: READ THIS FIRST
+## CODING AGENTS: READ THIS FIRST
 
 This is a **handoff bundle** from Claude Design (claude.ai/design).
 

--- a/docs/recette/design/app.jsx
+++ b/docs/recette/design/app.jsx
@@ -1,0 +1,107 @@
+// app.jsx — Full canvas: desktop-only, light + dark, all screens
+
+function DarkToggle({ dark, setDark }) {
+  return (
+    <div style={{ position:'fixed', top:16, right:16, zIndex:100, background:'#1a1814', color:'#f5ede0', padding:'7px 13px', borderRadius:999, display:'flex', gap:9, alignItems:'center', fontSize:12, fontWeight:500, fontFamily:'"Inter Tight", system-ui, sans-serif', boxShadow:'0 4px 16px rgba(0,0,0,.3)', border:'1px solid rgba(255,255,255,.1)', cursor:'pointer', userSelect:'none' }} onClick={()=>setDark(!dark)}>
+      <span>{dark?'☾':'☀'}</span>
+      <span>{dark?'Dark':'Light'}</span>
+      <div style={{ width:28,height:14,borderRadius:7,background:dark?'#c2671e':'#555',position:'relative' }}>
+        <div style={{ position:'absolute',top:2,left:dark?14:2,width:10,height:10,borderRadius:'50%',background:'#fff',transition:'left 0.15s' }}/>
+      </div>
+    </div>
+  );
+}
+
+function App() {
+  const [dark, setDark] = React.useState(false);
+  const theme = React.useMemo(() => makeTheme('amber', dark), [dark]);
+
+  return (
+    <ThemeCtx.Provider value={theme}>
+      <DarkToggle dark={dark} setDark={setDark}/>
+      <DesignCanvas>
+
+        {/* ── Canvas header ── */}
+        <div style={{ padding:'0 60px 52px', maxWidth:1020 }}>
+          <div style={{ fontSize:11, fontWeight:700, letterSpacing:2, textTransform:'uppercase', color:'#8b7e66', marginBottom:12 }}>Design complet · Desktop 1280×860 · Light + Dark</div>
+          <h1 style={{ fontFamily:'"Fraunces", Georgia, serif', fontSize:56, letterSpacing:-1.3, fontWeight:500, margin:0, marginBottom:12, color:'#2a2418', lineHeight:1.05 }}>
+            Bike Trip Planner<br/><span style={{ fontStyle:'italic', color:'#c2671e' }}>tous les écrans</span>.
+          </h1>
+          <p style={{ fontSize:15, color:'#5a4e3a', maxWidth:780, lineHeight:1.55, margin:0 }}>
+            Toutes les pages du produit — wizard 4 étapes, roadbook complet, authentification, gestion des voyages, paramètres, légal, états UI, légende pictos, infographie 1080×1080 — avec features futures (IA, Garmin, batch mode) dessinées comme pleinement fonctionnelles. Basculez light/dark (coin haut-droit).
+          </p>
+        </div>
+
+        {/* ══════ ① PARCOURS PRINCIPAL ══════ */}
+        <DCSection title="① Parcours principal — Wizard 4 étapes" subtitle="Landing → Préparation (chat IA multi-tours) → Aperçu & config → Analyse narrative → Mon voyage" gap={60}>
+          <DCArtboard label="/ · Landing — full page (desktop 1280 × 5400)" width={1280} height={5400}><PageLandingDesktop/></DCArtboard>
+          <DCArtboard label="/trips/new · Étape 1 — Préparation (Lien · GPX · Chat IA)" width={1280} height={860}><PageTripsNewDesktop/></DCArtboard>
+          <DCArtboard label="/trips/new · Étape 2 — Aperçu & configuration" width={1280} height={860}><PageTripsNewDesktopStep2/></DCArtboard>
+          <DCArtboard label="/trips/new · Étape 3 — Analyse narrative" width={1280} height={860}><PageProcessingDesktop/></DCArtboard>
+          <DCArtboard label="/trips/[id] · Étape 4 — Mon voyage (roadbook complet)" width={1280} height={860}><PageRoadbookDesktop/></DCArtboard>
+        </DCSection>
+
+        {/* ══════ ② GESTION DES VOYAGES ══════ */}
+        <DCSection title="② Gestion des voyages" subtitle="Liste · vue partagée lecture seule" gap={60}>
+          <DCArtboard label="/trips · Liste des voyages" width={1280} height={860}><PageTripsListDesktop/></DCArtboard>
+          <DCArtboard label="/s/[code] · Vue partagée (read-only + bandeau)" width={1280} height={860}><PagePublicSharedDesktop/></DCArtboard>
+        </DCSection>
+
+        {/* ══════ ③ AUTHENTIFICATION ══════ */}
+        <DCSection title="③ Authentification" subtitle="Magic link · 3 états · vérification · demande d'accès" gap={60}>
+          <DCArtboard label="/login · État 1 — Formulaire magic link" width={1280} height={860}><PageLoginDesktop state="form"/></DCArtboard>
+          <DCArtboard label="/login · État 2 — Email envoyé (timer 60s)" width={1280} height={860}><PageLoginDesktop state="sent"/></DCArtboard>
+          <DCArtboard label="/login · État 2b — Renvoyer actif (après 60s)" width={1280} height={860}><PageLoginDesktop state="sent-ready"/></DCArtboard>
+          <DCArtboard label="/auth/verify · En cours" width={1280} height={860}><PageAuthVerifyDesktop state="verifying"/></DCArtboard>
+          <DCArtboard label="/auth/verify · État 3 — Lien expiré / invalide" width={1280} height={860}><PageAuthVerifyDesktop state="expired"/></DCArtboard>
+          <DCArtboard label="/access-requests/verify · Confirmation" width={1280} height={860}><PageAccessRequestDesktop/></DCArtboard>
+        </DCSection>
+
+        {/* ══════ ④ COMPTE & LÉGAL ══════ */}
+        <DCSection title="④ Compte utilisateur & légal" subtitle="Paramètres RGPD · confidentialité · mentions légales" gap={60}>
+          <DCArtboard label="/account/settings · Paramètres compte" width={1280} height={860}><PageAccountSettingsDesktop/></DCArtboard>
+          <DCArtboard label="/privacy · Politique de confidentialité" width={1280} height={860}><PagePrivacyDesktop/></DCArtboard>
+          <DCArtboard label="/legal · Mentions légales" width={1280} height={860}><PageLegalDesktop/></DCArtboard>
+        </DCSection>
+
+        {/* ══════ ⑤ SUPPORT & ERREURS ══════ */}
+        <DCSection title="⑤ Support & états d'erreur" subtitle="FAQ (modal) · 404 · 500" gap={60}>
+          <DCArtboard label="/faq · FAQ (modale)" width={1280} height={860}><ModalFaq/></DCArtboard>
+          <DCArtboard label="/not-found · 404 Hors-piste" width={1280} height={860}><PageNotFoundDesktop/></DCArtboard>
+          <DCArtboard label="/error · 500 Erreur serveur" width={1280} height={860}><PageErrorDesktop/></DCArtboard>
+        </DCSection>
+
+        {/* ══════ ⑥ MODALS ══════ */}
+        <DCSection title="⑥ Modals" subtitle="Partage (lien + infographie + texte + Garmin Connect) · Config panel · Aide (raccourcis + FAQ)" gap={60}>
+          <DCArtboard label="Modal · Partager (avec Garmin Connect — Sprint 31)" width={1280} height={860}><ModalShareDesktop/></DCArtboard>
+          <DCArtboard label="Modal · Paramètres du voyage" width={1280} height={860}><ModalConfigPanel/></DCArtboard>
+          <DCArtboard label="Modal · Aide unifiée (raccourcis + FAQ)" width={1280} height={860}><ModalHelp/></DCArtboard>
+        </DCSection>
+
+        {/* ══════ ⑦ ÉTATS & COMPOSANTS ══════ */}
+        <DCSection title="⑦ États UI & validations" subtitle="Empty states · skeleton/loading · erreurs · magic link 3 états · validations inline (email, URL, GPX)" gap={60}>
+          <DCArtboard label="États UI — empty / skeleton / errors / magic link / validations" width={1280} height={860}><PageStatesDesktop/></DCArtboard>
+        </DCSection>
+
+        {/* ══════ ⑧ POI CULTURELS ══════ */}
+        <DCSection title="⑧ Popover POI culturel" subtitle="Marqueurs pulsants · Variante A enrichie (Wikidata) · Variante B minimale (OSM)" gap={60}>
+          <DCArtboard label="POI Popover — pulsation + variantes A/B" width={1280} height={860}><PagePOIPopoverDesktop/></DCArtboard>
+        </DCSection>
+
+        {/* ══════ ⑨ LÉGENDE PICTOS ══════ */}
+        <DCSection title="⑨ Système de pictogrammes" subtitle="Légende complète · 9 hébergements · POI · alertes · services" gap={60}>
+          <DCArtboard label="Légende pictos — tous les marqueurs carte" width={1280} height={860}><PagePictoLegendDesktop/></DCArtboard>
+        </DCSection>
+
+        {/* ══════ ⑩ INFOGRAPHIE ══════ */}
+        <DCSection title="⑩ Infographie PNG exportable" subtitle="Format 1:1 · 1080×1080 px · Instagram / WhatsApp / Telegram" gap={60}>
+          <DCArtboard label="Infographie — 1080×1080 (format carré)" width={1080} height={1080}><PageInfographicDesktop/></DCArtboard>
+        </DCSection>
+
+        <div style={{ height:80 }}/>
+      </DesignCanvas>
+    </ThemeCtx.Provider>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('app')).render(<App/>);

--- a/docs/recette/design/design-canvas.jsx
+++ b/docs/recette/design/design-canvas.jsx
@@ -1,0 +1,253 @@
+
+// DesignCanvas.jsx — Figma-ish design canvas wrapper
+// Warm gray grid bg + Sections + Artboards + PostIt notes.
+// No assets, no deps.
+
+const DC = {
+  bg: '#f0eee9',
+  grid: 'rgba(0,0,0,0.06)',
+  label: 'rgba(60,50,40,0.7)',
+  title: 'rgba(40,30,20,0.85)',
+  subtitle: 'rgba(60,50,40,0.6)',
+  postitBg: '#fef4a8',
+  postitText: '#5a4a2a',
+  font: '-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif',
+};
+
+// ─────────────────────────────────────────────────────────────
+// Main canvas — transform-based pan/zoom viewport
+//
+// Input mapping (Figma-style):
+//   • trackpad pinch  → zoom   (ctrlKey wheel; Safari gesture* events)
+//   • trackpad scroll → pan    (two-finger)
+//   • mouse wheel     → zoom   (notched; distinguished from trackpad scroll)
+//   • middle-drag / primary-drag-on-bg → pan
+//
+// Transform state lives in a ref and is written straight to the DOM
+// (translate3d + will-change) so wheel ticks don't go through React —
+// keeps pans at 60fps on dense canvases.
+// ─────────────────────────────────────────────────────────────
+function DesignCanvas({ children, minScale = 0.1, maxScale = 8, style = {} }) {
+  const vpRef = React.useRef(null);
+  const worldRef = React.useRef(null);
+  const tf = React.useRef({ x: 0, y: 0, scale: 1 });
+
+  const apply = React.useCallback(() => {
+    const { x, y, scale } = tf.current;
+    const el = worldRef.current;
+    if (el) el.style.transform = `translate3d(${x}px, ${y}px, 0) scale(${scale})`;
+  }, []);
+
+  React.useEffect(() => {
+    const vp = vpRef.current;
+    if (!vp) return;
+
+    const zoomAt = (cx, cy, factor) => {
+      const r = vp.getBoundingClientRect();
+      const px = cx - r.left, py = cy - r.top;
+      const t = tf.current;
+      const next = Math.min(maxScale, Math.max(minScale, t.scale * factor));
+      const k = next / t.scale;
+      // keep the world point under the cursor fixed
+      t.x = px - (px - t.x) * k;
+      t.y = py - (py - t.y) * k;
+      t.scale = next;
+      apply();
+    };
+
+    // Mouse-wheel vs trackpad-scroll heuristic. A physical wheel sends
+    // line-mode deltas (Firefox) or large integer pixel deltas with no X
+    // component (Chrome/Safari, typically multiples of 100/120). Trackpad
+    // two-finger scroll sends small/fractional pixel deltas, often with
+    // non-zero deltaX. ctrlKey is set by the browser for trackpad pinch.
+    const isMouseWheel = (e) =>
+      e.deltaMode !== 0 ||
+      (e.deltaX === 0 && Number.isInteger(e.deltaY) && Math.abs(e.deltaY) >= 40);
+
+    const onWheel = (e) => {
+      e.preventDefault();
+      if (isGesturing) return; // Safari: gesture* owns the pinch — discard concurrent wheels
+      if (e.ctrlKey) {
+        // trackpad pinch (or explicit ctrl+wheel)
+        zoomAt(e.clientX, e.clientY, Math.exp(-e.deltaY * 0.01));
+      } else if (isMouseWheel(e)) {
+        // notched mouse wheel — fixed-ratio step per click
+        zoomAt(e.clientX, e.clientY, Math.exp(-Math.sign(e.deltaY) * 0.18));
+      } else {
+        // trackpad two-finger scroll — pan
+        tf.current.x -= e.deltaX;
+        tf.current.y -= e.deltaY;
+        apply();
+      }
+    };
+
+    // Safari sends native gesture* events for trackpad pinch with a smooth
+    // e.scale; preferring these over the ctrl+wheel fallback gives a much
+    // better feel there. No-ops on other browsers. Safari also fires
+    // ctrlKey wheel events during the same pinch — isGesturing makes
+    // onWheel drop those entirely so they neither zoom nor pan.
+    let gsBase = 1;
+    let isGesturing = false;
+    const onGestureStart = (e) => { e.preventDefault(); isGesturing = true; gsBase = tf.current.scale; };
+    const onGestureChange = (e) => {
+      e.preventDefault();
+      zoomAt(e.clientX, e.clientY, (gsBase * e.scale) / tf.current.scale);
+    };
+    const onGestureEnd = (e) => { e.preventDefault(); isGesturing = false; };
+
+    // Drag-pan: middle button anywhere, or primary button starting on the
+    // canvas background (not inside an artboard).
+    let drag = null;
+    const onPointerDown = (e) => {
+      const onBg = e.target === vp || e.target === worldRef.current;
+      if (!(e.button === 1 || (e.button === 0 && onBg))) return;
+      e.preventDefault();
+      vp.setPointerCapture(e.pointerId);
+      drag = { id: e.pointerId, lx: e.clientX, ly: e.clientY };
+      vp.style.cursor = 'grabbing';
+    };
+    const onPointerMove = (e) => {
+      if (!drag || e.pointerId !== drag.id) return;
+      tf.current.x += e.clientX - drag.lx;
+      tf.current.y += e.clientY - drag.ly;
+      drag.lx = e.clientX; drag.ly = e.clientY;
+      apply();
+    };
+    const onPointerUp = (e) => {
+      if (!drag || e.pointerId !== drag.id) return;
+      vp.releasePointerCapture(e.pointerId);
+      drag = null;
+      vp.style.cursor = '';
+    };
+
+    vp.addEventListener('wheel', onWheel, { passive: false });
+    vp.addEventListener('gesturestart', onGestureStart, { passive: false });
+    vp.addEventListener('gesturechange', onGestureChange, { passive: false });
+    vp.addEventListener('gestureend', onGestureEnd, { passive: false });
+    vp.addEventListener('pointerdown', onPointerDown);
+    vp.addEventListener('pointermove', onPointerMove);
+    vp.addEventListener('pointerup', onPointerUp);
+    vp.addEventListener('pointercancel', onPointerUp);
+    return () => {
+      vp.removeEventListener('wheel', onWheel);
+      vp.removeEventListener('gesturestart', onGestureStart);
+      vp.removeEventListener('gesturechange', onGestureChange);
+      vp.removeEventListener('gestureend', onGestureEnd);
+      vp.removeEventListener('pointerdown', onPointerDown);
+      vp.removeEventListener('pointermove', onPointerMove);
+      vp.removeEventListener('pointerup', onPointerUp);
+      vp.removeEventListener('pointercancel', onPointerUp);
+    };
+  }, [apply, minScale, maxScale]);
+
+  const gridSvg = `url("data:image/svg+xml,%3Csvg width='120' height='120' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M120 0H0v120' fill='none' stroke='${encodeURIComponent(DC.grid)}' stroke-width='1'/%3E%3C/svg%3E")`;
+  return (
+    <div
+      ref={vpRef}
+      className="design-canvas"
+      style={{
+        height: '100vh', width: '100vw',
+        background: DC.bg,
+        overflow: 'hidden',
+        overscrollBehavior: 'none',
+        touchAction: 'none',
+        position: 'relative',
+        fontFamily: DC.font,
+        boxSizing: 'border-box',
+        ...style,
+      }}
+    >
+      <div
+        ref={worldRef}
+        style={{
+          position: 'absolute', top: 0, left: 0,
+          transformOrigin: '0 0',
+          willChange: 'transform',
+          width: 'max-content', minWidth: '100%',
+          minHeight: '100%',
+          padding: '60px 0 80px',
+          backgroundImage: gridSvg,
+          backgroundSize: '120px 120px',
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Section — title + subtitle + h-stack of artboards (no wrap)
+// ─────────────────────────────────────────────────────────────
+function DCSection({ title, subtitle, children, gap = 48 }) {
+  return (
+    <div style={{ marginBottom: 80, position: 'relative' }}>
+      <div style={{ padding: '0 60px 36px' }}>
+        <div style={{
+          fontSize: 22, fontWeight: 600, color: DC.title,
+          letterSpacing: -0.3, marginBottom: 4,
+        }}>{title}</div>
+        {subtitle && (
+          <div style={{
+            fontSize: 14, fontWeight: 400, color: DC.subtitle,
+          }}>{subtitle}</div>
+        )}
+      </div>
+      {/* h-stack — clips offscreen, never wraps */}
+      <div style={{
+        display: 'flex', gap, padding: '0 60px',
+        alignItems: 'flex-start', width: 'max-content',
+      }}>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Artboard — labeled card
+// ─────────────────────────────────────────────────────────────
+function DCArtboard({ label, children, width, height, style = {} }) {
+  return (
+    <div style={{ position: 'relative', flexShrink: 0 }}>
+      {label && (
+        <div style={{
+          position: 'absolute', bottom: '100%', left: 0,
+          paddingBottom: 8,
+          fontSize: 12, fontWeight: 500, color: DC.label,
+          whiteSpace: 'nowrap',
+        }}>{label}</div>
+      )}
+      <div style={{
+        borderRadius: 2,
+        boxShadow: '0 1px 3px rgba(0,0,0,0.08), 0 4px 16px rgba(0,0,0,0.06)',
+        overflow: 'hidden',
+        width, height,
+        background: '#fff',
+        ...style,
+      }}>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Post-it — absolute-positioned sticky note
+// ─────────────────────────────────────────────────────────────
+function DCPostIt({ children, top, left, right, bottom, rotate = -2, width = 180 }) {
+  return (
+    <div style={{
+      position: 'absolute', top, left, right, bottom, width,
+      background: DC.postitBg, padding: '14px 16px',
+      fontFamily: '"Comic Sans MS", "Marker Felt", "Segoe Print", cursive',
+      fontSize: 14, lineHeight: 1.4, color: DC.postitText,
+      boxShadow: '0 2px 8px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.08)',
+      transform: `rotate(${rotate}deg)`,
+      zIndex: 5,
+    }}>{children}</div>
+  );
+}
+
+Object.assign(window, { DesignCanvas, DCSection, DCArtboard, DCPostIt });
+

--- a/docs/recette/design/modals.jsx
+++ b/docs/recette/design/modals.jsx
@@ -1,0 +1,327 @@
+// modals.jsx — Share modal (with Garmin Connect) + Config panel
+
+function ModalShell({ children, width = 560, title, sub }) {
+  const t = useTheme();
+  return (
+    <div style={{ width:1280, height:860, background:t.name==='dark'?'rgba(15,13,10,.72)':'rgba(40,30,20,.35)', display:'flex', alignItems:'center', justifyContent:'center', fontFamily:t.sans, position:'relative' }}>
+      <div style={{ position:'absolute', inset:0, opacity:.3, filter:'blur(2px)', overflow:'hidden' }}><PageRoadbookDesktop/></div>
+      <div style={{ position:'absolute', inset:0, background:t.name==='dark'?'rgba(15,13,10,.55)':'rgba(40,30,20,.3)' }}/>
+      <div style={{ position:'relative', width, background:t.surface, borderRadius:16, boxShadow:'0 20px 80px rgba(0,0,0,.25)', border:`1px solid ${t.line}`, overflow:'hidden', color:t.ink, maxHeight:820 }}>
+        <div style={{ padding:'18px 22px', borderBottom:`1px solid ${t.line}`, display:'flex', justifyContent:'space-between', alignItems:'start' }}>
+          <div>
+            <div style={{ fontFamily:t.serif, fontSize:22, fontWeight:500, letterSpacing:-0.3 }}>{title}</div>
+            {sub && <div style={{ fontSize:12, color:t.inkSoft, marginTop:3 }}>{sub}</div>}
+          </div>
+          <div style={{ width:28,height:28,borderRadius:8,background:t.surfaceAlt,color:t.inkSoft,display:'flex',alignItems:'center',justifyContent:'center',cursor:'pointer' }}>{I.close}</div>
+        </div>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+// ─── SHARE MODAL ─────────────────────────────────────────────────────────────
+// Source: share-modal.tsx — 4 sections: link, infographic, text, Garmin Connect
+function ModalShareDesktop() {
+  const t = useTheme();
+  const shareUrl = 'https://biketripplanner.app/s/7kR4mN';
+  return (
+    <ModalShell width={600} title="Partager ce voyage" sub="Lien lecture seule · infographie PNG · texte · Garmin Connect">
+      <div style={{ overflowY:'auto', maxHeight:680 }}>
+        <div style={{ padding:'20px 22px', display:'flex', flexDirection:'column', gap:0 }}>
+
+          {/* Section 1: Lien partageable */}
+          <div style={{ marginBottom:20 }}>
+            <div style={{ display:'flex', alignItems:'center', gap:8, marginBottom:10 }}>
+              {React.cloneElement(I.link,{width:14,height:14,color:t.inkSoft})}
+              <span style={{ fontSize:13, fontWeight:600 }}>Lien partageable</span>
+            </div>
+            <div style={{ display:'flex', gap:8, alignItems:'center', background:t.surfaceAlt, padding:'9px 12px', borderRadius:10, marginBottom:6 }}>
+              <span style={{ flex:1, fontSize:12.5, color:t.accent, fontFamily:t.mono, overflow:'hidden', textOverflow:'ellipsis', whiteSpace:'nowrap' }}>{shareUrl}</span>
+              <Btn variant="ghost" size="xs" icon={React.cloneElement(I.copy,{width:12,height:12})}>Copier</Btn>
+              <Btn variant="ghost" size="xs" icon={React.cloneElement(I.alert,{width:12,height:12})} style={{ color:t.red, borderColor:`${t.red}40` }}>Révoquer</Btn>
+            </div>
+            <div style={{ fontSize:11, color:t.inkSoft }}>Accès en lecture seule · sans compte requis.</div>
+          </div>
+
+          <div style={{ height:1, background:t.line, marginBottom:20 }}/>
+
+          {/* Section 2: Infographie */}
+          <div style={{ marginBottom:20 }}>
+            <div style={{ display:'flex', alignItems:'center', gap:8, marginBottom:10 }}>
+              {React.cloneElement(I.camera,{width:14,height:14,color:t.inkSoft})}
+              <span style={{ fontSize:13, fontWeight:600 }}>Infographie PNG</span>
+              <Pill sm bg={t.accentSoft} color={t.accentInk} bold>1080×1080</Pill>
+            </div>
+            {/* Canvas preview */}
+            <div style={{ borderRadius:12, overflow:'hidden', marginBottom:10, position:'relative', height:200, border:`1px solid ${t.line}` }}>
+              {/* Simulated infographic preview */}
+              <div style={{ width:'100%', height:'100%', background:`linear-gradient(135deg, #2a2418, #3d3428)`, display:'flex', flexDirection:'column', padding:20 }}>
+                <div style={{ fontSize:14, fontWeight:600, color:'#f1c999', fontFamily:'"Fraunces", serif', marginBottom:4 }}>{TRIP.title}</div>
+                <div style={{ fontSize:11, color:'rgba(255,255,255,.55)', marginBottom:10 }}>Lille → Gand · {TRIP.totalKm} km · {TRIP.days} jours</div>
+                <div style={{ flex:1, borderRadius:8, overflow:'hidden', opacity:.8 }}>
+                  <OsmMap w={556} h={110} simplified/>
+                </div>
+                <div style={{ display:'flex', gap:10, marginTop:10 }}>
+                  {[{v:`${TRIP.totalKm} km`},{v:`+${TRIP.totalUp}m`},{v:`${TRIP.days} j`}].map((s,i)=>(
+                    <div key={i} style={{ background:'rgba(255,255,255,.08)', borderRadius:6, padding:'5px 10px' }}>
+                      <div style={{ fontSize:12, fontWeight:600, color:'#fff' }}>{s.v}</div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+            <Btn variant="ghost" size="sm" icon={I.download}>Télécharger PNG (1080×1080)</Btn>
+          </div>
+
+          <div style={{ height:1, background:t.line, marginBottom:20 }}/>
+
+          {/* Section 3: Texte résumé */}
+          <div style={{ marginBottom:20 }}>
+            <div style={{ display:'flex', alignItems:'center', gap:8, marginBottom:10 }}>
+              {React.cloneElement(I.list,{width:14,height:14,color:t.inkSoft})}
+              <span style={{ fontSize:13, fontWeight:600 }}>Résumé texte</span>
+            </div>
+            <div style={{ background:t.surfaceAlt, borderRadius:10, padding:'12px 14px', fontSize:11.5, fontFamily:t.mono, color:t.ink, lineHeight:1.7, marginBottom:10, maxHeight:140, overflowY:'auto' }}>
+              <div><strong>L'Odyssée des Eaux Royales</strong></div>
+              <div>Distance : 143 km · Dénivelé + : 1 430 m</div>
+              <div>Dates : 14 — 17 mai 2026</div>
+              <div>—</div>
+              {STAGES.map((s,i)=>(
+                <div key={i}>J{s.day} · {s.from} → {s.to} · {s.km} km · +{s.up} m</div>
+              ))}
+              <div>—</div>
+              <div>Voir en ligne : {shareUrl}</div>
+            </div>
+            <Btn variant="ghost" size="sm" icon={React.cloneElement(I.copy,{width:12,height:12})}>Copier le texte</Btn>
+          </div>
+
+          <div style={{ height:1, background:t.line, marginBottom:20 }}/>
+
+          {/* Section 4: Garmin Connect (Sprint 31) */}
+          <div>
+            <div style={{ display:'flex', alignItems:'center', gap:8, marginBottom:10 }}>
+              <div style={{ width:22,height:22,borderRadius:5,background:'#1a6632',display:'flex',alignItems:'center',justifyContent:'center',flexShrink:0 }}>
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="white"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm-1-13h2v6h-2zm0 8h2v2h-2z"/></svg>
+              </div>
+              <span style={{ fontSize:13, fontWeight:600 }}>Garmin Connect</span>
+              <Pill sm bg="#e8f5e9" color="#1a6632" bold>Sprint 31</Pill>
+            </div>
+
+            {/* State A: not connected */}
+            <div style={{ background:t.surfaceAlt, border:`1px solid ${t.line}`, borderRadius:12, padding:16, marginBottom:8 }}>
+              <div style={{ display:'flex', gap:12, alignItems:'center' }}>
+                <div style={{ width:44,height:44,borderRadius:12,background:'#1a6632',display:'flex',alignItems:'center',justifyContent:'center',flexShrink:0 }}>
+                  <svg width="24" height="24" viewBox="0 0 24 24" fill="white"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 14.5v-9l6 4.5-6 4.5z"/></svg>
+                </div>
+                <div style={{ flex:1 }}>
+                  <div style={{ fontSize:13, fontWeight:600, marginBottom:2 }}>Non connecté à Garmin Connect</div>
+                  <div style={{ fontSize:11.5, color:t.inkSoft }}>Envoyez vos étapes directement vers votre montre Garmin.</div>
+                </div>
+                <Btn variant="primary" size="sm" style={{ background:'#1a6632', flexShrink:0 }}>Connecter Garmin</Btn>
+              </div>
+            </div>
+
+            {/* State B: connected */}
+            <div style={{ background:t.greenSoft, border:`1px solid ${t.green}30`, borderRadius:12, padding:16 }}>
+              <div style={{ display:'flex', gap:12, alignItems:'center', marginBottom:10 }}>
+                <div style={{ width:44,height:44,borderRadius:'50%',background:'#1a6632',color:'#fff',display:'flex',alignItems:'center',justifyContent:'center',fontWeight:700,fontSize:16,flexShrink:0 }}>G</div>
+                <div style={{ flex:1 }}>
+                  <div style={{ fontSize:12, color:t.green, fontWeight:600, marginBottom:1 }}>Connecté</div>
+                  <div style={{ fontSize:13, fontWeight:600 }}>noe@les-tilleuls.coop</div>
+                </div>
+                <span style={{ fontSize:11.5, color:t.inkSoft, cursor:'pointer' }}>Déconnecter</span>
+              </div>
+              <Btn variant="primary" size="md" full style={{ background:'#1a6632', marginBottom:6 }} icon={I.share}>Envoyer ce voyage vers Garmin Connect</Btn>
+              <div style={{ fontSize:11, color:t.inkSoft, textAlign:'center' }}>4 fichiers FIT seront envoyés (une par étape)</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </ModalShell>
+  );
+}
+
+// ─── CONFIG PANEL MODAL ──────────────────────────────────────────────────────
+function ModalConfigPanel() {
+  const t = useTheme();
+  return (
+    <ModalShell width={360} title="Paramètres" sub="Voyage · compte · thème · langue">
+      <div style={{ padding:'16px 20px', maxHeight:640, overflowY:'auto', display:'flex', flexDirection:'column', gap:18 }}>
+        {/* Dates */}
+        <div>
+          <div style={{ fontSize:12.5, fontWeight:600, marginBottom:8 }}>Dates</div>
+          <div style={{ display:'grid', gridTemplateColumns:'1fr 1fr', gap:6 }}>
+            <div>
+              <div style={{ fontSize:10.5, color:t.inkSoft, marginBottom:3 }}>Départ</div>
+              <div style={{ padding:'7px 10px', background:t.surface, border:`1.5px solid ${t.accent}`, borderRadius:8, fontSize:12.5, fontFamily:t.mono, fontWeight:600 }}>14 mai</div>
+            </div>
+            <div>
+              <div style={{ fontSize:10.5, color:t.inkSoft, marginBottom:3 }}>Retour</div>
+              <div style={{ padding:'7px 10px', background:t.surface, border:`1px solid ${t.line}`, borderRadius:8, fontSize:12.5, fontFamily:t.mono, fontWeight:600, color:t.inkSoft }}>17 mai</div>
+            </div>
+          </div>
+        </div>
+        <div style={{ height:1, background:t.line }}/>
+        {/* Pacing */}
+        <div>
+          <div style={{ fontSize:12.5, fontWeight:600, marginBottom:8 }}>Profil cycliste</div>
+          <div style={{ display:'flex', gap:4, marginBottom:10 }}>
+            {['Débutant','Intermédiaire','Expert'].map((p,i) => (
+              <div key={i} style={{ flex:1, padding:'6px 4px', borderRadius:7, border:`1px solid ${i===1?t.accent:t.line}`, background:i===1?t.accent:'transparent', textAlign:'center', fontSize:11.5, fontWeight:600, color:i===1?'#fff':t.inkSoft, cursor:'pointer' }}>{p}</div>
+            ))}
+          </div>
+          {[
+            { l:'Distance max / jour', v:'80 km', pct:28 },
+            { l:'Vitesse moyenne', v:'15 km/h', pct:22 },
+            { l:'Heure de départ', v:'08h00', pct:33 },
+            { l:'Fatigue', v:'10 %', pct:20 },
+            { l:'Pénalité dénivelé', v:'25 %', pct:25 },
+          ].map((s,i)=>(
+            <div key={i} style={{ display:'flex', alignItems:'center', gap:7, marginBottom:7 }}>
+              <span style={{ fontSize:11, color:t.inkSoft, width:115, flexShrink:0 }}>{s.l}</span>
+              <div style={{ flex:1, height:4, background:t.surfaceAlt, borderRadius:2, position:'relative' }}>
+                <div style={{ width:`${s.pct}%`, height:'100%', background:t.accent, borderRadius:2 }}/>
+                <div style={{ position:'absolute', left:`calc(${s.pct}% - 6px)`, top:-4, width:12, height:12, borderRadius:'50%', background:'#fff', border:`2px solid ${t.accent}` }}/>
+              </div>
+              <span style={{ fontSize:10.5, fontFamily:t.mono, fontWeight:600, width:46, textAlign:'right', flexShrink:0 }}>{s.v}</span>
+            </div>
+          ))}
+          <div style={{ display:'flex', alignItems:'center', gap:7, marginTop:2 }}>
+            <span style={{ fontSize:11, color:t.inkSoft, flex:1 }}>Mode e-bike</span>
+            <div style={{ width:30, height:16, borderRadius:8, background:t.surfaceAlt, position:'relative' }}>
+              <div style={{ position:'absolute', top:2, left:2, width:12, height:12, borderRadius:'50%', background:'#fff' }}/>
+            </div>
+          </div>
+        </div>
+        <div style={{ height:1, background:t.line }}/>
+        {/* Accommodation types */}
+        <div>
+          <div style={{ fontSize:12.5, fontWeight:600, marginBottom:8 }}>Hébergements</div>
+          <div style={{ display:'flex', flexDirection:'column', gap:5 }}>
+            {Object.entries(ACC_TYPES).map(([k,v],i) => (
+              <div key={k} style={{ display:'flex', alignItems:'center', gap:8 }}>
+                <div style={{ width:26, height:14, borderRadius:7, background:i<3?t.accent:t.surfaceAlt, position:'relative', flexShrink:0 }}>
+                  <div style={{ position:'absolute', top:1, left:i<3?14:1, width:12, height:12, borderRadius:'50%', background:'#fff' }}/>
+                </div>
+                <span style={{ fontSize:12 }}>{v.icon}</span>
+                <span style={{ fontSize:12, color:i<3?t.ink:t.inkSoft }}>{v.label}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+        <div style={{ height:1, background:t.line }}/>
+        {/* Theme + Language */}
+        <div style={{ display:'flex', justifyContent:'space-between', alignItems:'center' }}>
+          <span style={{ fontSize:12.5, fontWeight:600 }}>Thème</span>
+          <div style={{ display:'flex', background:t.surfaceAlt, borderRadius:6, padding:2, gap:1 }}>
+            {['Clair','Sombre','Auto'].map((x,i)=>(
+              <div key={x} style={{ padding:'4px 9px', borderRadius:5, fontSize:11.5, fontWeight:600, background:i===0?t.accent:'transparent', color:i===0?'#fff':t.inkSoft, cursor:'pointer' }}>{x}</div>
+            ))}
+          </div>
+        </div>
+        <div style={{ display:'flex', justifyContent:'space-between', alignItems:'center' }}>
+          <span style={{ fontSize:12.5, fontWeight:600 }}>Langue</span>
+          <div style={{ display:'flex', background:t.surfaceAlt, borderRadius:6, padding:2, gap:1 }}>
+            {['FR','EN'].map((l,i)=>(
+              <div key={l} style={{ padding:'4px 10px', borderRadius:5, fontSize:11.5, fontWeight:600, background:i===0?t.accent:'transparent', color:i===0?'#fff':t.inkSoft, cursor:'pointer' }}>{l}</div>
+            ))}
+          </div>
+        </div>
+        <div style={{ height:1, background:t.line }}/>
+        {/* Trip actions */}
+        <div>
+          <div style={{ fontSize:12.5, fontWeight:600, marginBottom:8 }}>Actions voyage</div>
+          <div style={{ display:'flex', flexDirection:'column', gap:5 }}>
+            <Btn variant="ghost" size="sm" full icon={React.cloneElement(I.copy,{width:12,height:12})}>Dupliquer ce voyage</Btn>
+            <Btn variant="ghost" size="sm" full icon={I.share}>Partager</Btn>
+          </div>
+        </div>
+      </div>
+    </ModalShell>
+  );
+}
+
+// ─── HELP MODAL (P1) — Raccourcis + FAQ en onglets ──────────────────────────
+function ModalHelp() {
+  const t = useTheme();
+  const [tab, setTab] = React.useState('shortcuts');
+  const shortcuts = [
+    { key:'J / K', action:'Étape suivante / précédente' },
+    { key:'Ctrl+Z', action:'Annuler la dernière action' },
+    { key:'Ctrl+Y', action:'Rétablir' },
+    { key:'?', action:'Afficher cette aide' },
+    { key:'Esc', action:'Fermer les panneaux' },
+    { key:'T', action:'Basculer le thème clair/sombre' },
+    { key:'M', action:'Afficher / masquer la carte' },
+  ];
+  return (
+    <ModalShell width={520} title="Aide">
+      <div style={{ padding:'0 22px 22px' }}>
+        <div style={{ display:'flex', gap:2, background:t.surfaceAlt, padding:3, borderRadius:9, margin:'14px 0 18px' }}>
+          {[{k:'shortcuts',l:'Raccourcis clavier'},{k:'faq',l:'FAQ rapide'}].map(x => (
+            <div key={x.k} onClick={()=>setTab(x.k)} style={{ flex:1, padding:'8px 12px', borderRadius:7, fontSize:13, fontWeight:500, background:x.k===tab?t.surface:'transparent', color:x.k===tab?t.ink:t.inkSoft, textAlign:'center', cursor:'pointer', boxShadow:x.k===tab?t.shadowSoft:'none' }}>{x.l}</div>
+          ))}
+        </div>
+        {tab === 'shortcuts' && (
+          <div style={{ display:'flex', flexDirection:'column', gap:4 }}>
+            {shortcuts.map((s,i)=>(
+              <div key={i} style={{ display:'flex', alignItems:'center', gap:12, padding:'9px 12px', borderRadius:9, background:t.surfaceAlt }}>
+                <kbd style={{ padding:'3px 8px', background:t.surface, border:`1px solid ${t.line}`, borderRadius:5, fontFamily:t.mono, fontSize:12, fontWeight:700, color:t.ink, flexShrink:0, boxShadow:`0 1px 2px rgba(0,0,0,.1)` }}>{s.key}</kbd>
+                <span style={{ fontSize:13, color:t.inkSoft }}>{s.action}</span>
+              </div>
+            ))}
+          </div>
+        )}
+        {tab === 'faq' && (
+          <div style={{ display:'flex', flexDirection:'column', gap:8 }}>
+            {[
+              { q:'Quelles sources d\'import ?', a:'Komoot, RideWithGPS, Strava, GPX, IA.' },
+              { q:'Comment fonctionne le mode hors-ligne ?', a:'Les voyages consultés sont mis en cache localement sur Android via la PWA.' },
+              { q:'Puis-je exporter vers Garmin ?', a:'Oui — exports FIT par étape, et envoi direct vers Garmin Connect (requiert connexion OAuth).' },
+              { q:'Mes données sont-elles partagées ?', a:'Non. Vos voyages sont privés. Un lien de partage génère une URL anonyme révocable à tout moment.' },
+            ].map((f,i)=>(
+              <div key={i} style={{ border:`1px solid ${t.line}`, borderRadius:10, background:t.surface, padding:'12px 14px' }}>
+                <div style={{ fontSize:13, fontWeight:600, marginBottom:4 }}>{f.q}</div>
+                <div style={{ fontSize:12.5, color:t.inkSoft, lineHeight:1.5 }}>{f.a}</div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </ModalShell>
+  );
+}
+
+// ─── FAQ MODAL ─────────────────────────────────────────────────────────────
+function ModalFaq() {
+  const t = useTheme();
+  const faqs = [
+    { q:'Quelles sources d\'import ?', a:'Komoot (Tours et Collections), RideWithGPS, Strava, fichiers GPX standards, et un générateur IA multi-tours.', open:true },
+    { q:'Comment est calculé le dénivelé ?', a:'Modèle DEM SRTM 30m avec pénalité configurable. Tient compte de la fatigue cumulative et de la vitesse de montée.' },
+    { q:'Les données météo sont fiables au-delà de 7 jours ?', a:'Jusqu\'à 10 jours : prévisions horaires Open-Meteo. Au-delà : normales saisonnières avec indicateur d\'incertitude.' },
+    { q:'Comment fonctionne le mode hors-ligne ?', a:'Les voyages consultés sont mis en cache localement via la PWA Android.' },
+    { q:'Puis-je exporter vers Garmin ?', a:'Oui — exports FIT par étape et envoi direct vers Garmin Connect (OAuth 2.0 PKCE).' },
+    { q:'Mes données sont-elles partagées ?', a:'Non. Vos voyages sont privés. Un lien de partage génère une URL anonyme révocable.' },
+    { q:'Combien coûte l\'outil ?', a:'Gratuit pendant la beta. Les premiers utilisateurs conserveront un accès gratuit à vie aux fonctionnalités de base.' },
+  ];
+  return (
+    <ModalShell width={640} title="Foire aux questions">
+      <div style={{ overflowY:'auto', maxHeight:660, padding:'12px 22px 22px' }}>
+        <div style={{ display:'flex', flexDirection:'column', gap:8 }}>
+          {faqs.map((f,i)=>(
+            <div key={i} style={{ border:`1px solid ${t.line}`, borderRadius:11, background:t.surface, overflow:'hidden' }}>
+              <div style={{ padding:'13px 16px', display:'flex', alignItems:'center', justifyContent:'space-between', background:f.open?t.surfaceAlt:'transparent', cursor:'pointer' }}>
+                <span style={{ fontSize:13.5, fontWeight:600 }}>{f.q}</span>
+                <span style={{ color:t.inkMute, display:'flex', transform:f.open?'rotate(90deg)':'none' }}>{I.chevron}</span>
+              </div>
+              {f.open && <div style={{ padding:'0 16px 14px', fontSize:13, color:t.inkSoft, lineHeight:1.6 }}>{f.a}</div>}
+            </div>
+          ))}
+        </div>
+      </div>
+    </ModalShell>
+  );
+}
+
+Object.assign(window, { ModalShareDesktop, ModalConfigPanel, ModalHelp, ModalFaq });

--- a/docs/recette/design/pages-auth.jsx
+++ b/docs/recette/design/pages-auth.jsx
@@ -1,0 +1,635 @@
+// pages-auth.jsx — Auth pages + account settings + legal
+// Landing page kept here for simplicity
+
+// ─── LANDING ─────────────────────────────────────────────────────────────────
+function PageLandingDesktop({ w = 1280, h = 5400 }) {
+  const t = useTheme();
+  const Section = ({ bg, children, pad = '80px 64px' }) => (
+    <section style={{ background: bg || t.bg, padding: pad }}>
+      <div style={{ maxWidth: 1080, margin: '0 auto' }}>{children}</div>
+    </section>
+  );
+  const H2 = ({ title, sub }) => (
+    <div style={{ textAlign:'center', marginBottom:48 }}>
+      <h2 style={{ fontFamily:t.serif, fontSize:44, fontWeight:500, letterSpacing:-1, lineHeight:1.05, margin:0, color:t.ink }}>{title}</h2>
+      {sub && <p style={{ fontSize:16, color:t.inkSoft, margin:'14px auto 0', maxWidth:580, lineHeight:1.55 }}>{sub}</p>}
+    </div>
+  );
+  return (
+    <div style={{ width:w, minHeight:h, background:t.bg, color:t.ink, fontFamily:t.sans, overflow:'hidden' }}>
+      {/* HERO */}
+      <div style={{ position:'relative', height:760, overflow:'hidden' }}>
+        <div style={{ position:'absolute', inset:0 }}>
+          <OsmMap w={w} h={760}/>
+          <div style={{ position:'absolute', inset:0, background:'linear-gradient(180deg,rgba(26,20,10,.62)0%,rgba(26,20,10,.48)40%,rgba(26,20,10,.85)100%)' }}/>
+        </div>
+        <div style={{ position:'relative', display:'flex', alignItems:'center', justifyContent:'space-between', padding:'22px 48px', zIndex:2 }}>
+          <div style={{ display:'flex', alignItems:'center', gap:10 }}>
+            <Logo size={32}/><span style={{ fontSize:16, fontWeight:600, letterSpacing:-0.2, color:'#fff' }}>Bike Trip Planner</span>
+          </div>
+          <div style={{ display:'flex', alignItems:'center', gap:16 }}>
+            <div style={{ display:'flex', background:'rgba(255,255,255,.12)', borderRadius:6, padding:2, gap:1 }}>
+              {['FR','EN'].map((l,i) => (
+                <div key={l} style={{ padding:'3px 8px', borderRadius:5, fontSize:12, fontWeight:600, background:i===0?'rgba(255,255,255,.2)':'transparent', color:'#fff', cursor:'pointer' }}>{l}</div>
+              ))}
+            </div>
+            <div style={{ display:'flex', background:'rgba(255,255,255,.12)', borderRadius:6, padding:2, gap:1 }}>
+              {['☀','☾'].map((ic,i) => (
+                <div key={i} style={{ padding:'3px 9px', borderRadius:5, fontSize:13, background:i===0?'rgba(255,255,255,.2)':'transparent', color:'#fff', cursor:'pointer', lineHeight:1 }}>{ic}</div>
+              ))}
+            </div>
+            <div style={{ padding:'7px 14px', border:'1px solid rgba(255,255,255,.3)', borderRadius:8, fontSize:13, color:'#fff', background:'rgba(255,255,255,.08)' }}>Se connecter</div>
+            <div style={{ padding:'7px 14px', background:t.accent, borderRadius:8, fontSize:13, color:'#fff', fontWeight:600 }}>Demander l'accès</div>
+          </div>
+        </div>
+        <div style={{ position:'relative', zIndex:2, textAlign:'center', padding:'80px 48px 0', maxWidth:860, margin:'0 auto' }}>
+          <Pill bg="rgba(255,255,255,.14)" color="#fff" style={{ marginBottom:24, border:'1px solid rgba(255,255,255,.22)' }}>
+            <span style={{ width:6,height:6,borderRadius:'50%',background:t.accent }}/> Beta privée · accès sur demande
+          </Pill>
+          <h1 style={{ fontFamily:t.serif, fontSize:72, lineHeight:1.02, fontWeight:500, letterSpacing:-2, margin:0, color:'#fff', textShadow:'0 4px 24px rgba(0,0,0,.4)' }}>
+            Votre prochain voyage à vélo,<br/><span style={{ fontStyle:'italic', color:'#f1c999' }}>planifié dans les moindres détails</span>.
+          </h1>
+          <p style={{ fontSize:18, lineHeight:1.55, color:'rgba(255,255,255,.88)', margin:'24px auto 0', maxWidth:640, textShadow:'0 2px 12px rgba(0,0,0,.3)' }}>
+            Komoot, RideWithGPS, Strava, GPX. Dénivelé, météo, hébergements, alertes. Consultable hors-ligne, partageable en un lien.
+          </p>
+          <div style={{ display:'flex', gap:14, justifyContent:'center', marginTop:32 }}>
+            <div style={{ padding:'14px 28px', background:t.accent, borderRadius:10, fontSize:15, color:'#fff', fontWeight:600, display:'flex', alignItems:'center', gap:8, boxShadow:`0 8px 24px ${t.accent}55` }}>
+              {React.cloneElement(I.bike,{width:18,height:18})} Créer mon itinéraire
+            </div>
+            <div style={{ padding:'14px 28px', border:'1px solid rgba(255,255,255,.35)', borderRadius:10, fontSize:15, color:'#fff', background:'rgba(255,255,255,.1)' }}>
+              Voir la démo
+            </div>
+          </div>
+        </div>
+        {/* Scroll indicator */}
+        <div style={{ position:'absolute', bottom:30, left:'50%', transform:'translateX(-50%)', zIndex:2 }}>
+          <div style={{ width:24,height:40,borderRadius:999,border:'2px solid rgba(255,255,255,.35)',display:'flex',justifyContent:'center',paddingTop:8 }}>
+            <div style={{ width:4,height:8,borderRadius:2,background:'rgba(255,255,255,.6)' }}/>
+          </div>
+        </div>
+      </div>
+
+      {/* HOW IT WORKS — 4 steps */}
+      <Section bg={t.bg}>
+        <H2 title="De l'import au roadbook, en quatre étapes."/>
+        <div style={{ display:'grid', gridTemplateColumns:'repeat(4,1fr)', gap:10 }}>
+          {[
+            { n:1, i:I.link, t:'Import', d:'Lien Komoot, RWGPS, Strava ou fichier GPX.' },
+            { n:2, i:I.map, t:'Aperçu & config', d:'Visualisez l\'itinéraire, réglez profil et préférences.' },
+            { n:3, i:I.bolt, t:'Analyse', d:'Dénivelé, surfaces, météo, hébergements, alertes — tout calculé.' },
+            { n:4, i:I.sparkle, t:'Personnalisation', d:'Affinez les étapes, sélectionnez vos hébergements, exportez.' },
+          ].map((s,idx,arr) => (
+            <div key={idx} style={{ textAlign:'center', padding:'22px 10px', background:t.surface, borderRadius:14, border:`1px solid ${t.line}`, boxShadow:t.shadowSoft }}>
+              <div style={{ position:'relative', width:52,height:52,margin:'0 auto 16px' }}>
+                <div style={{ width:52,height:52,borderRadius:'50%',background:idx===arr.length-1?t.accent:t.accentSoft,border:`2px solid ${t.accent}40`,display:'flex',alignItems:'center',justifyContent:'center',color:idx===arr.length-1?'#fff':t.accent }}>
+                  {React.cloneElement(s.i,{width:20,height:20})}
+                </div>
+                <div style={{ position:'absolute',top:-4,right:-4,width:20,height:20,borderRadius:'50%',background:t.ink,color:t.bg,fontSize:10,fontWeight:700,display:'flex',alignItems:'center',justifyContent:'center' }}>{s.n}</div>
+              </div>
+              <h3 style={{ fontSize:14,fontWeight:600,margin:0,marginBottom:6,color:t.ink }}>{s.t}</h3>
+              <p style={{ fontSize:12,color:t.inkSoft,lineHeight:1.5,margin:0 }}>{s.d}</p>
+            </div>
+          ))}
+        </div>
+      </Section>
+
+      {/* FEATURES BENTO */}
+      <Section bg={t.surfaceAlt}>
+        <H2 title="Tout ce qu'il faut pour rouler serein."/>
+        <div style={{ display:'grid', gridTemplateColumns:'repeat(12,1fr)', gridAutoRows:170, gap:12 }}>
+          {/* Terrain — tall */}
+          <div style={{ gridColumn:'span 5', gridRow:'span 2', background:t.surface, border:`1px solid ${t.line}`, borderRadius:18, padding:24, display:'flex', flexDirection:'column' }}>
+            <div style={{ display:'flex', gap:8, alignItems:'center', marginBottom:12 }}>
+              <div style={{ width:34,height:34,borderRadius:9,background:t.accentSoft,color:t.accent,display:'flex',alignItems:'center',justifyContent:'center' }}>{React.cloneElement(I.mountain,{width:16,height:16})}</div>
+              <Pill sm bg={t.accentSoft} color={t.accentInk} bold>Données terrain</Pill>
+            </div>
+            <h3 style={{ fontFamily:t.serif, fontSize:24, fontWeight:500, letterSpacing:-0.5, margin:0, marginBottom:8, lineHeight:1.15 }}>Chaque mètre de dénivelé, anticipé.</h3>
+            <p style={{ fontSize:13, color:t.inkSoft, lineHeight:1.6, margin:0, marginBottom:14 }}>Surfaces (asphalte, gravier, chemins), pentes abruptes, ruptures de rythme. Repérez les 9 % avant qu'ils ne vous surprennent.</p>
+            <div style={{ marginTop:'auto', background:t.surfaceAlt, borderRadius:10, padding:12, border:`1px solid ${t.line}` }}>
+              <ElevProfile w={340} h={50} up={412} down={378} distance={42.5}/>
+              <div style={{ display:'flex', gap:5, marginTop:8 }}>
+                <Pill sm bg={t.redSoft} color={t.red}>Pente 9,2 % · km 28</Pill>
+                <Pill sm bg={t.accentSoft} color={t.accentInk}>Gravier · 3 km</Pill>
+              </div>
+            </div>
+          </div>
+          {/* Weather */}
+          <div style={{ gridColumn:'span 4', background:t.accent, color:'#fff', borderRadius:18, padding:20, position:'relative', overflow:'hidden' }}>
+            <div style={{ position:'absolute', top:-16, right:-16, width:100, height:100, borderRadius:'50%', background:'rgba(255,255,255,.1)' }}/>
+            <div style={{ position:'absolute', top:16, right:16, color:'rgba(255,255,255,.6)' }}>{React.cloneElement(I.wind,{width:32,height:32})}</div>
+            <div style={{ fontSize:11, fontWeight:700, letterSpacing:1.5, textTransform:'uppercase', opacity:.8, marginBottom:8 }}>Météo 14 j.</div>
+            <h3 style={{ fontFamily:t.serif, fontSize:20, fontWeight:500, letterSpacing:-0.4, margin:0, marginBottom:6, lineHeight:1.15 }}>Vent, humidité, pluie, confort — sur vos dates exactes.</h3>
+            <div style={{ display:'flex', gap:3, marginTop:12 }}>
+              {[17,19,22,24,21,18,20].map((d,i) => (
+                <div key={i} style={{ flex:1, textAlign:'center' }}>
+                  <div style={{ fontSize:9, opacity:.7 }}>J+{i}</div>
+                  <div style={{ fontSize:11, fontWeight:600 }}>{d}°</div>
+                </div>
+              ))}
+            </div>
+          </div>
+          {/* Supply */}
+          <div style={{ gridColumn:'span 3', background:t.surface, border:`1px solid ${t.line}`, borderRadius:18, padding:20 }}>
+            <div style={{ width:34,height:34,borderRadius:9,background:t.accentSoft,color:t.accent,display:'flex',alignItems:'center',justifyContent:'center',marginBottom:10 }}>{React.cloneElement(I.coffee,{width:16,height:16})}</div>
+            <h3 style={{ fontSize:14,fontWeight:600,margin:0,marginBottom:6 }}>Ravitaillement</h3>
+            <p style={{ fontSize:12,color:t.inkSoft,lineHeight:1.5,margin:0 }}>Supérettes, fontaines, cafés — filtrés par horaires.</p>
+          </div>
+          {/* AI — wide */}
+          <div style={{ gridColumn:'span 7', gridRow:'span 2', background:'linear-gradient(135deg, #1f1d1a 0%, #3d3428 100%)', color:'#fff', borderRadius:18, padding:28, position:'relative', overflow:'hidden' }}>
+            <div style={{ position:'absolute', top:24, right:24, color:t.accent, opacity:.25 }}>{React.cloneElement(I.sparkle,{width:70,height:70})}</div>
+            <Pill sm bg="rgba(194,103,30,.2)" color="#f1c999" bold style={{ marginBottom:14 }}>✦ Assistant IA</Pill>
+            <h3 style={{ fontFamily:t.serif, fontSize:30, fontWeight:500, letterSpacing:-0.7, margin:0, marginBottom:10, lineHeight:1.05 }}>Décrivez. L'IA compose.</h3>
+            <p style={{ fontSize:13.5, color:'rgba(255,255,255,.72)', lineHeight:1.6, margin:0, maxWidth:440 }}>Donnez vos contraintes — distance, dénivelé, dates, région, hébergements — l'IA assemble des étapes cohérentes depuis votre point de départ. Dialogue multi-tours.</p>
+            <div style={{ marginTop:18, background:'rgba(255,255,255,.06)', border:'1px solid rgba(255,255,255,.1)', borderRadius:10, padding:12, fontFamily:t.mono, fontSize:11.5, color:'rgba(255,255,255,.85)' }}>
+              « 3 jours, 250 km, collines modérées, départ Lille, gîtes »
+            </div>
+            <div style={{ display:'flex', gap:7, marginTop:10 }}>
+              {[{d:'J1',t:'Lille → Tournai',km:'78 km'},{d:'J2',t:'Tournai → Mons',km:'92 km'},{d:'J3',t:'Mons → Dinant',km:'80 km'}].map((s,i)=>(
+                <div key={i} style={{ flex:1, background:'rgba(255,255,255,.08)', borderRadius:8, padding:8 }}>
+                  <div style={{ fontSize:9.5, color:t.accent, fontWeight:700 }}>{s.d}</div>
+                  <div style={{ fontSize:11.5, fontWeight:600, marginTop:2 }}>{s.t}</div>
+                  <div style={{ fontSize:10.5, color:'rgba(255,255,255,.5)' }}>{s.km}</div>
+                </div>
+              ))}
+            </div>
+          </div>
+          {/* Accommodations */}
+          <div style={{ gridColumn:'span 5', background:t.surface, border:`1px solid ${t.line}`, borderRadius:18, padding:0, overflow:'hidden', display:'flex' }}>
+            <div style={{ flex:1, padding:18 }}>
+              <div style={{ width:34,height:34,borderRadius:9,background:t.accentSoft,color:t.accent,display:'flex',alignItems:'center',justifyContent:'center',marginBottom:10 }}>{React.cloneElement(I.bed,{width:16,height:16})}</div>
+              <h3 style={{ fontSize:14,fontWeight:600,margin:0,marginBottom:6 }}>9 types d'hébergements</h3>
+              <div style={{ display:'flex', gap:4, flexWrap:'wrap' }}>
+                {Object.values(ACC_TYPES).map((a,i) => <span key={i} style={{ fontSize:14 }} title={a.label}>{a.icon}</span>)}
+              </div>
+            </div>
+            <div style={{ width:150, position:'relative' }}><OsmMap w={150} h={170} simplified/></div>
+          </div>
+          {/* Alerts */}
+          <div style={{ gridColumn:'span 4', background:'#1f1d1a', color:'#fff', borderRadius:18, padding:20 }}>
+            <div style={{ display:'flex', gap:8, marginBottom:8 }}>
+              <div style={{ width:30,height:30,borderRadius:8,background:'rgba(255,255,255,.1)',color:t.accent,display:'flex',alignItems:'center',justifyContent:'center' }}>{React.cloneElement(I.alert,{width:14,height:14})}</div>
+              <h3 style={{ fontSize:14,fontWeight:600,margin:0,alignSelf:'center' }}>20+ alertes sécurité</h3>
+            </div>
+            <p style={{ fontSize:12,color:'rgba(255,255,255,.65)',lineHeight:1.5,margin:0,marginBottom:10 }}>Trafic dense, pentes, pavés, coucher de soleil, frontières — avec actions contextuelles.</p>
+            <div style={{ display:'flex', gap:5, flexWrap:'wrap' }}>
+              <Pill sm bg="rgba(184,68,32,.2)" color="#ffa88a" bold>Critique</Pill>
+              <Pill sm bg="rgba(194,103,30,.2)" color="#f1c999" bold>Attention</Pill>
+              <Pill sm bg="rgba(61,107,145,.2)" color="#9cc3e0" bold>Info</Pill>
+            </div>
+          </div>
+          {/* Exports */}
+          <div style={{ gridColumn:'span 3', background:t.surface, border:`1px solid ${t.line}`, borderRadius:18, padding:20 }}>
+            <div style={{ width:34,height:34,borderRadius:9,background:t.accentSoft,color:t.accent,display:'flex',alignItems:'center',justifyContent:'center',marginBottom:10 }}>{React.cloneElement(I.download,{width:16,height:16})}</div>
+            <h3 style={{ fontSize:14,fontWeight:600,margin:0,marginBottom:6 }}>Exports GPX / FIT</h3>
+            <p style={{ fontSize:12,color:t.inkSoft,lineHeight:1.5,margin:0 }}>Garmin Connect, FIT par étape, GPX enrichi avec waypoints POI.</p>
+          </div>
+        </div>
+      </Section>
+
+      {/* SOURCES (3 real + IA) */}
+      <Section bg={t.bg} pad="70px 64px">
+        <H2 title="Importez depuis ce que vous avez."/>
+        <div style={{ display:'flex', justifyContent:'center', gap:28, flexWrap:'wrap' }}>
+          {[
+            { n:'Komoot', d:'Tour & Collection', c:'#6AA127', wordmark:'komoot' },
+            { n:'RideWithGPS', d:'Route', c:'#ED1C24', wordmark:'RWGPS' },
+            { n:'Strava', d:'Activité', c:'#FC4C02', wordmark:'strava' },
+            { n:'GPX', d:'Fichier', c:'#5a4e3a', wordmark:'GPX' },
+            { n:'IA', d:'Génération IA', c:t.accent, wordmark:'✦ IA' },
+          ].map((s,i)=>(
+            <div key={i} style={{ display:'flex', flexDirection:'column', alignItems:'center', gap:10, width:110 }}>
+              <div style={{ width:72,height:72,borderRadius:17,background:t.surface,border:`1px solid ${t.line}`,display:'flex',alignItems:'center',justifyContent:'center',boxShadow:t.shadowSoft }}>
+                <span style={{ fontSize: s.wordmark.length > 5 ? 11 : 18, fontWeight:800, color:s.c, letterSpacing: s.wordmark.length > 5 ? 0.5 : -0.5, textTransform: s.n === 'Strava' || s.n === 'Komoot' ? 'lowercase' : 'none', fontStyle: s.n === 'Komoot' ? 'italic' : 'normal' }}>{s.wordmark}</span>
+              </div>
+              <div style={{ textAlign:'center' }}>
+                <div style={{ fontSize:12.5,fontWeight:600,color:t.ink }}>{s.n}</div>
+                <div style={{ fontSize:10.5,color:t.inkMute }}>{s.d}</div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </Section>
+
+      {/* SCREENS PREVIEW */}
+      <Section bg={t.surfaceAlt} pad="80px 64px">
+        <H2 title="Sur tous vos écrans." sub="Le même roadbook — desktop pour planifier, mobile pour rouler."/>
+        <div style={{ display:'flex', gap:28, justifyContent:'center', alignItems:'flex-start', maxWidth:1000, margin:'0 auto' }}>
+          {/* Desktop mockup */}
+          <div style={{ flex:'0 0 680px' }}>
+            <div style={{ fontSize:11.5, fontWeight:600, color:t.inkSoft, letterSpacing:1, textTransform:'uppercase', marginBottom:10 }}>Desktop</div>
+            <div style={{ background:t.ink, borderRadius:12, padding:'4px 4px 0', boxShadow:t.shadow }}>
+              {/* Browser chrome */}
+              <div style={{ display:'flex', alignItems:'center', gap:6, padding:'6px 12px', marginBottom:4 }}>
+                <div style={{ display:'flex', gap:4 }}>
+                  {['#ed6a5e','#f5bf4f','#61c554'].map((c,i)=><div key={i} style={{width:8,height:8,borderRadius:'50%',background:c}}/>)}
+                </div>
+                <div style={{ flex:1, background:'rgba(255,255,255,.1)', borderRadius:4, padding:'2px 10px', fontSize:10, color:'rgba(255,255,255,.5)', fontFamily:'"JetBrains Mono", monospace' }}>biketripplanner.app/trips/1</div>
+              </div>
+              {/* Screen content */}
+              <div style={{ background:t.surface, borderRadius:'0 0 8px 8px', overflow:'hidden', display:'grid', gridTemplateColumns:'200px 1fr 220px', height:280 }}>
+                {/* Left: stage list */}
+                <div style={{ borderRight:`1px solid ${t.line}`, padding:10, overflow:'hidden' }}>
+                  <div style={{ fontSize:9, fontWeight:600, color:t.inkSoft, textTransform:'uppercase', letterSpacing:0.5, marginBottom:8 }}>Étapes</div>
+                  {STAGES.slice(0,3).map((s,i) => {
+                    const c = [t.forest,t.accent,t.blue][i];
+                    return (
+                      <div key={i} style={{ display:'flex', gap:6, padding:'6px 4px', borderRadius:6, background:i===1?t.surfaceAlt:'transparent', marginBottom:3 }}>
+                        <div style={{ width:18,height:18,borderRadius:'50%',background:c,color:'#fff',display:'flex',alignItems:'center',justifyContent:'center',fontSize:9,fontWeight:700,flexShrink:0 }}>{s.day}</div>
+                        <div>
+                          <div style={{ fontSize:9.5, fontWeight:600, color:t.ink }}>{s.from} → {s.to}</div>
+                          <div style={{ fontSize:8.5, color:t.inkMute }}>{s.km} km</div>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+                {/* Center: map */}
+                <div style={{ overflow:'hidden' }}><OsmMap w={260} h={280} active={1}/></div>
+                {/* Right: stage detail */}
+                <div style={{ borderLeft:`1px solid ${t.line}`, padding:10, overflow:'hidden' }}>
+                  <div style={{ display:'inline-flex', padding:'2px 6px', borderRadius:4, background:t.accent, color:'#fff', fontSize:8.5, fontWeight:700, marginBottom:6 }}>JOUR 2</div>
+                  <div style={{ fontFamily:t.serif, fontSize:11, fontWeight:500, marginBottom:6 }}>Roubaix → Tournai</div>
+                  <ElevProfile w={200} h={28} up={412} down={378} distance={42.5}/>
+                  <div style={{ display:'grid', gridTemplateColumns:'1fr 1fr', gap:4, marginTop:6 }}>
+                    <div style={{ padding:4, background:t.surfaceAlt, borderRadius:4 }}>
+                      <div style={{ fontSize:7.5, color:t.inkMute }}>KM</div>
+                      <div style={{ fontSize:10, fontWeight:600 }}>42.5</div>
+                    </div>
+                    <div style={{ padding:4, background:t.surfaceAlt, borderRadius:4 }}>
+                      <div style={{ fontSize:7.5, color:t.inkMute }}>D+</div>
+                      <div style={{ fontSize:10, fontWeight:600 }}>+412m</div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          {/* Mobile mockup */}
+          <div style={{ flex:'0 0 190px' }}>
+            <div style={{ fontSize:11.5, fontWeight:600, color:t.inkSoft, letterSpacing:1, textTransform:'uppercase', marginBottom:10 }}>Mobile</div>
+            <div style={{ background:t.ink, borderRadius:24, padding:'14px 6px 6px', boxShadow:t.shadow }}>
+              {/* Notch */}
+              <div style={{ width:60, height:16, background:t.ink, borderRadius:8, margin:'-8px auto 6px' }}/>
+              <div style={{ background:t.surface, borderRadius:18, overflow:'hidden' }}>
+                {/* Status bar */}
+                <div style={{ padding:'4px 14px', display:'flex', justifyContent:'space-between', fontSize:9, fontWeight:600 }}>
+                  <span>9:41</span><span>● ●</span>
+                </div>
+                {/* Map */}
+                <OsmMap w={178} h={120} active={1}/>
+                {/* Stage info */}
+                <div style={{ padding:'8px 12px' }}>
+                  <div style={{ display:'inline-flex', padding:'1px 5px', borderRadius:3, background:t.accent, color:'#fff', fontSize:7.5, fontWeight:700, marginBottom:4 }}>JOUR 2</div>
+                  <div style={{ fontFamily:t.serif, fontSize:11, fontWeight:500, marginBottom:3 }}>Roubaix → Tournai</div>
+                  <div style={{ fontSize:9, color:t.inkSoft, marginBottom:4 }}>42,5 km · +412 m · 4h40</div>
+                  <ElevProfile w={154} h={22} up={412} down={378} distance={42.5}/>
+                </div>
+                {/* Tab bar hint */}
+                <div style={{ height:20, borderTop:`1px solid ${t.line}`, display:'flex', alignItems:'center', justifyContent:'center', gap:20 }}>
+                  {[t.accent, t.inkMute, t.inkMute].map((c,i) => <div key={i} style={{ width:16, height:3, borderRadius:2, background:c }}/>)}
+                </div>
+              </div>
+            </div>
+            <div style={{ marginTop:10, display:'flex', alignItems:'center', gap:5, justifyContent:'center' }}>
+              {React.cloneElement(I.wifiOff,{width:12,height:12,color:t.inkMute})}
+              <span style={{ fontSize:11, color:t.inkSoft }}>Hors-ligne disponible</span>
+            </div>
+          </div>
+        </div>
+      </Section>
+
+      {/* EARLY ACCESS */}
+      <Section bg={t.name==='dark'?'#2a2620':'#2a2418'} pad="80px 64px">
+        <div style={{ textAlign:'center' }}>
+          <h2 style={{ fontFamily:t.serif, fontSize:44, fontWeight:500, letterSpacing:-1, margin:0, marginBottom:16, color:'#fff' }}>Rejoignez la beta privée.</h2>
+          <p style={{ fontSize:15, color:'rgba(255,255,255,.72)', maxWidth:500, margin:'0 auto 28px', lineHeight:1.6 }}>Gratuit pendant la phase beta. Invitation par email dès qu'une place se libère.</p>
+          <div style={{ display:'flex', gap:8, maxWidth:440, margin:'0 auto', background:'rgba(255,255,255,.08)', borderRadius:11, padding:5, border:'1px solid rgba(255,255,255,.18)' }}>
+            <div style={{ flex:1, display:'flex', alignItems:'center', gap:8, padding:'0 12px', fontSize:13.5, color:'rgba(255,255,255,.55)' }}>
+              {React.cloneElement(I.mail,{width:14,height:14})} vous@exemple.com
+            </div>
+            <div style={{ padding:'11px 20px', background:t.accent, borderRadius:7, fontSize:13.5, color:'#fff', fontWeight:600 }}>Demander l'accès</div>
+          </div>
+        </div>
+      </Section>
+
+      {/* FOOTER */}
+      <div style={{ padding:'28px 64px', borderTop:`1px solid ${t.line}`, background:t.surfaceAlt }}>
+        <div style={{ maxWidth:1080, margin:'0 auto', display:'flex', justifyContent:'space-between', alignItems:'center' }}>
+          <div style={{ fontSize:12, color:t.inkMute }}>© 2026 Bike Trip Planner</div>
+          <div style={{ display:'flex', gap:18, fontSize:12, color:t.inkSoft }}>
+            {['FAQ','Confidentialité','/privacy','Mentions légales','/legal'].filter((x,i)=>i%2===0).map((l,i)=>(
+              <span key={i} style={{ cursor:'pointer' }}>{['FAQ','Confidentialité','Mentions légales','GitHub'][i]}</span>
+            ))}
+            <span style={{ display:'flex', alignItems:'center', gap:4, cursor:'pointer' }}>{React.cloneElement(I.github,{width:12,height:12})} GitHub</span>
+          </div>
+        </div>
+      </div>
+
+      {/* Cookie banner */}
+      <div style={{ background:t.surface, borderTop:`1px solid ${t.line}`, padding:'12px 24px', display:'flex', alignItems:'center', justifyContent:'space-between', gap:16, boxShadow:`0 -2px 12px rgba(0,0,0,.08)` }}>
+        <div style={{ flex:1, fontSize:12.5, color:t.inkSoft, lineHeight:1.5 }}>
+          Cookies techniques essentiels et analytics anonymes (sans IP, sans empreinte de navigateur, sans cross-site tracking).{' '}
+          <span style={{ color:t.accent, fontWeight:600, cursor:'pointer' }}>Personnaliser</span>
+        </div>
+        <div style={{ display:'flex', gap:8, flexShrink:0 }}>
+          <Btn variant="ghost" size="sm">Tout refuser</Btn>
+          <Btn variant="accent" size="sm">Tout accepter</Btn>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── LOGIN ────────────────────────────────────────────────────────────────────
+function PageLoginDesktop({ w = 1280, h = 860, state = 'form' }) {
+  const t = useTheme();
+  return (
+    <div style={{ width:w, height:h, background:t.paper||t.bg, color:t.ink, fontFamily:t.sans, display:'flex', alignItems:'center', justifyContent:'center', position:'relative', overflow:'hidden' }}>
+      <div style={{ position:'absolute', inset:0, opacity:.3 }}><OsmMap w={w} h={h}/></div>
+      <div style={{ position:'absolute', inset:0, background:t.name==='dark'?'rgba(26,24,20,.75)':'rgba(250,247,240,.8)' }}/>
+      <div style={{ position:'relative', width:440, background:t.surface, border:`1px solid ${t.line}`, borderRadius:18, padding:36, boxShadow:t.shadow }}>
+        <div style={{ display:'flex', alignItems:'center', gap:10, marginBottom:24 }}>
+          <Logo size={34}/><span style={{ fontSize:16, fontWeight:600 }}>Bike Trip Planner</span>
+        </div>
+        {state === 'form' && (
+          <>
+            <h2 style={{ fontFamily:t.serif, fontSize:30, letterSpacing:-0.6, fontWeight:500, margin:0, marginBottom:8 }}>Bon retour.</h2>
+            <p style={{ fontSize:13.5, color:t.inkSoft, margin:0, marginBottom:22, lineHeight:1.5 }}>Entrez votre email — nous vous enverrons un lien magique. Pas de mot de passe.</p>
+            <div style={{ fontSize:11.5, fontWeight:600, color:t.inkSoft, marginBottom:5, textTransform:'uppercase', letterSpacing:0.4 }}>Email</div>
+            <div style={{ display:'flex', alignItems:'center', gap:8, padding:'11px 14px', background:t.bg, border:`1.5px solid ${t.accent}`, borderRadius:10, marginBottom:16 }}>
+              {React.cloneElement(I.mail,{width:14,height:14,color:t.accent})}
+              <span style={{ fontSize:13.5, color:t.ink, fontFamily:t.mono }}>noe@les-tilleuls.coop</span>
+            </div>
+            <Btn variant="accent" size="lg" full>Envoyer le lien magique</Btn>
+            <div style={{ fontSize:12, color:t.inkSoft, textAlign:'center', marginTop:20 }}>
+              Pas encore de compte ? <span style={{ color:t.accent, fontWeight:600, cursor:'pointer' }}>Demander l'accès</span>
+            </div>
+          </>
+        )}
+        {state === 'sent' && (
+          <>
+            <div style={{ width:64,height:64,borderRadius:16,background:t.greenSoft,color:t.green,display:'flex',alignItems:'center',justifyContent:'center',margin:'0 auto 20px' }}>
+              {React.cloneElement(I.check,{width:28,height:28})}
+            </div>
+            <h2 style={{ fontFamily:t.serif, fontSize:26, fontWeight:500, textAlign:'center', margin:'0 0 10px' }}>Email envoyé, vérifie ta boîte.</h2>
+            <p style={{ fontSize:13, color:t.inkSoft, textAlign:'center', lineHeight:1.55, margin:'0 0 22px' }}>Lien envoyé à <strong>noe@les-tilleuls.coop</strong>. Il expire dans 15 minutes.</p>
+            {/* Resend disabled (timer) */}
+            <Btn variant="ghost" size="lg" full style={{ opacity:0.5, cursor:'not-allowed' }}>Renvoyer un lien (42s)</Btn>
+            <div style={{ fontSize:11.5, color:t.inkMute, textAlign:'center', marginTop:10 }}>Le bouton sera actif dans 42 secondes.</div>
+          </>
+        )}
+        {state === 'sent-ready' && (
+          <>
+            <div style={{ width:64,height:64,borderRadius:16,background:t.greenSoft,color:t.green,display:'flex',alignItems:'center',justifyContent:'center',margin:'0 auto 20px' }}>
+              {React.cloneElement(I.check,{width:28,height:28})}
+            </div>
+            <h2 style={{ fontFamily:t.serif, fontSize:26, fontWeight:500, textAlign:'center', margin:'0 0 10px' }}>Email envoyé, vérifie ta boîte.</h2>
+            <p style={{ fontSize:13, color:t.inkSoft, textAlign:'center', lineHeight:1.55, margin:'0 0 22px' }}>Lien envoyé à <strong>noe@les-tilleuls.coop</strong>. Il expire dans 15 minutes.</p>
+            <Btn variant="accent" size="lg" full icon={React.cloneElement(I.mail,{width:14,height:14})}>Renvoyer un lien</Btn>
+            <div style={{ fontSize:11.5, color:t.inkSoft, textAlign:'center', marginTop:10 }}>Pas reçu ? Vérifiez vos spams.</div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── AUTH VERIFY ─────────────────────────────────────────────────────────────
+function PageAuthVerifyDesktop({ w = 1280, h = 860, state = 'verifying' }) {
+  const t = useTheme();
+  return (
+    <div style={{ width:w, height:h, background:t.bg, display:'flex', alignItems:'center', justifyContent:'center', fontFamily:t.sans, position:'relative', overflow:'hidden' }}>
+      <div style={{ position:'absolute', inset:0, opacity:.3 }}><OsmMap w={w} h={h}/></div>
+      <div style={{ position:'absolute', inset:0, background:t.name==='dark'?'rgba(26,24,20,.75)':'rgba(250,247,240,.8)' }}/>
+      <div style={{ position:'relative', width:480, background:t.surface, border:`1px solid ${t.line}`, borderRadius:18, padding:44, boxShadow:t.shadow, textAlign:'center', color:t.ink }}>
+        {state === 'verifying' && (
+          <>
+            <div style={{ width:64,height:64,borderRadius:'50%',border:`3px solid ${t.line}`,borderTopColor:t.accent,margin:'0 auto 20px',animation:'spin 1s linear infinite' }}/>
+            <h2 style={{ fontFamily:t.serif, fontSize:26, margin:0, marginBottom:10, fontWeight:500 }}>Vérification du lien…</h2>
+            <p style={{ fontSize:13.5, color:t.inkSoft, lineHeight:1.55 }}>Ouverture de votre session dans un instant.</p>
+          </>
+        )}
+        {state === 'expired' && (
+          <>
+            <div style={{ width:64,height:64,borderRadius:'50%',background:t.redSoft,color:t.red,display:'flex',alignItems:'center',justifyContent:'center',margin:'0 auto 20px' }}>{React.cloneElement(I.alert,{width:28,height:28})}</div>
+            <h2 style={{ fontFamily:t.serif, fontSize:24, margin:0, marginBottom:10, fontWeight:500 }}>Lien expiré ou invalide.</h2>
+            <p style={{ fontSize:13, color:t.inkSoft, margin:'0 0 22px', lineHeight:1.55 }}>Les liens magiques expirent après 15 minutes.</p>
+            <div style={{ display:'flex', gap:8, justifyContent:'center' }}>
+              <Btn variant="accent">Renvoyer un lien</Btn>
+              <Btn variant="ghost">Retour</Btn>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── ACCESS REQUEST ───────────────────────────────────────────────────────────
+function PageAccessRequestDesktop({ w = 1280, h = 860 }) {
+  const t = useTheme();
+  return (
+    <div style={{ width:w, height:h, background:t.bg, display:'flex', alignItems:'center', justifyContent:'center', fontFamily:t.sans, position:'relative', overflow:'hidden' }}>
+      <div style={{ position:'absolute', inset:0, opacity:.3 }}><OsmMap w={w} h={h}/></div>
+      <div style={{ position:'absolute', inset:0, background:t.name==='dark'?'rgba(26,24,20,.75)':'rgba(250,247,240,.8)' }}/>
+      <div style={{ position:'relative', width:480, background:t.surface, border:`1px solid ${t.line}`, borderRadius:18, padding:44, boxShadow:t.shadow, textAlign:'center', color:t.ink }}>
+        <div style={{ width:64,height:64,borderRadius:16,background:t.accentSoft,color:t.accent,display:'flex',alignItems:'center',justifyContent:'center',margin:'0 auto 20px' }}>
+          {React.cloneElement(I.check,{width:28,height:28})}
+        </div>
+        <h2 style={{ fontFamily:t.serif, fontSize:30, fontWeight:500, letterSpacing:-0.5, margin:0, marginBottom:12 }}>Demande prise en compte.</h2>
+        <p style={{ fontSize:14, color:t.inkSoft, marginBottom:26, lineHeight:1.6 }}>Merci pour votre intérêt ! Votre demande d'accès anticipé a bien été enregistrée. Vous recevrez une invitation par email dès que votre dossier sera analysé.</p>
+        <Btn variant="ghost" size="lg" full>Retour à l'accueil</Btn>
+      </div>
+    </div>
+  );
+}
+
+// ─── FAQ ──────────────────────────────────────────────────────────────────────
+function PageFaqDesktop({ w = 1280, h = 860 }) {
+  const t = useTheme(); // Not used as standalone page anymore (FAQ is a modal), but kept for reference
+  const faqs = [
+    { q:'Quelles sources d\'import sont supportées ?', a:'Komoot (Tours et Collections), RideWithGPS, Strava, fichiers GPX standards, et un générateur IA multi-tours.', open:true },
+    { q:'Comment est calculé le dénivelé ?' },
+    { q:'Les données météo sont-elles fiables au-delà de 7 jours ?' },
+    { q:'Puis-je éditer mes étapes ?' },
+    { q:'Comment fonctionne le mode hors-ligne ?' },
+    { q:'Mes données sont-elles partagées ?' },
+    { q:'Combien coûte l\'outil ?' },
+  ];
+  return (
+    <div style={{ width:w, height:h, background:t.bg, color:t.ink, fontFamily:t.sans, display:'flex', flexDirection:'column', overflow:'hidden' }}>
+      <TopBarDesktop/>
+      <div style={{ display:'grid', gridTemplateColumns:'240px 1fr', flex:1, minHeight:0 }}>
+        <div style={{ padding:'28px 20px', borderRight:`1px solid ${t.line}`, overflowY:'auto', background:t.surface }}>
+          <div style={{ fontSize:11.5, fontWeight:600, color:t.inkSoft, letterSpacing:0.5, textTransform:'uppercase', marginBottom:10 }}>Sections</div>
+          {['Prise en main','Import & formats','Calculs & météo','Partage','Hors-ligne','Tarifs'].map((s,i)=>(
+            <div key={i} style={{ padding:'8px 12px', borderRadius:8, fontSize:13, color:i===0?t.ink:t.inkSoft, background:i===0?t.surfaceAlt:'transparent', fontWeight:i===0?600:500, marginBottom:2, cursor:'pointer' }}>{s}</div>
+          ))}
+          <div style={{ marginTop:24, padding:14, background:t.surfaceAlt, borderRadius:10, border:`1px solid ${t.line}` }}>
+            <div style={{ fontSize:12, color:t.inkSoft }}>Documentation complète sur <span style={{ color:t.accent, fontWeight:600, cursor:'pointer' }}>GitHub →</span></div>
+          </div>
+        </div>
+        <div style={{ padding:'36px 56px', overflowY:'auto' }}>
+          <h1 style={{ fontFamily:t.serif, fontSize:40, letterSpacing:-0.7, fontWeight:500, margin:0, marginBottom:8 }}>Foire aux questions</h1>
+          <p style={{ fontSize:14, color:t.inkSoft, marginBottom:24, lineHeight:1.5 }}>Tout ce qu'il faut savoir avant votre premier voyage.</p>
+          <div style={{ maxWidth:700, display:'flex', flexDirection:'column', gap:8 }}>
+            {faqs.map((f,i)=>(
+              <div key={i} style={{ border:`1px solid ${t.line}`, borderRadius:12, background:t.surface, overflow:'hidden' }}>
+                <div style={{ padding:'16px 20px', display:'flex', alignItems:'center', justifyContent:'space-between', background:f.open?t.surfaceAlt:'transparent', cursor:'pointer' }}>
+                  <span style={{ fontSize:14, fontWeight:600 }}>{f.q}</span>
+                  <span style={{ color:t.inkMute, display:'flex', transform:f.open?'rotate(90deg)':'none' }}>{I.chevron}</span>
+                </div>
+                {f.open && <div style={{ padding:'0 20px 16px', fontSize:13, color:t.inkSoft, lineHeight:1.6 }}>{f.a}</div>}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+      <DesktopFooter/>
+    </div>
+  );
+}
+
+// ─── ACCOUNT SETTINGS (new P1) ───────────────────────────────────────────────
+function PageAccountSettingsDesktop({ w = 1280, h = 860 }) {
+  const t = useTheme();
+  return (
+    <div style={{ width:w, height:h, color:t.ink, fontFamily:t.sans, display:'flex', flexDirection:'column', overflow:'hidden', position:'relative' }}>
+      <div style={{ position:'absolute', inset:0, opacity:.3 }}><OsmMap w={w} h={h}/></div>
+      <div style={{ position:'absolute', inset:0, background:t.name==='dark'?'rgba(26,24,20,.75)':'rgba(250,247,240,.8)' }}/>
+      <div style={{ position:'relative', zIndex:1, display:'flex', flexDirection:'column', height:'100%' }}>
+      <TopBarDesktop/>
+      <div style={{ display:'grid', gridTemplateColumns:'240px 1fr', flex:1, minHeight:0 }}>
+        {/* Sidebar */}
+        <div style={{ padding:'28px 20px', borderRight:`1px solid ${t.line}`, background:t.surface }}>
+          <div style={{ display:'flex', alignItems:'center', gap:10, marginBottom:24 }}>
+            <div style={{ width:42,height:42,borderRadius:'50%',background:t.accent,color:'#fff',display:'flex',alignItems:'center',justifyContent:'center',fontWeight:700,fontSize:17 }}>N</div>
+            <div>
+              <div style={{ fontSize:13.5, fontWeight:600 }}>Noé Fritz</div>
+              <div style={{ fontSize:11.5, color:t.inkSoft }}>noe@les-tilleuls.coop</div>
+            </div>
+          </div>
+          <div style={{ padding:'9px 12px', borderRadius:8, fontSize:13, color:t.ink, background:t.surfaceAlt, fontWeight:600, marginBottom:2 }}>Mon compte</div>
+          <div style={{ marginTop:'auto', paddingTop:24, borderTop:`1px solid ${t.line}`, marginTop:24 }}>
+            <div style={{ padding:'9px 12px', borderRadius:8, fontSize:13, color:t.red, cursor:'pointer', display:'flex', alignItems:'center', gap:7 }}>
+              {React.cloneElement(I.logout,{width:14,height:14})} Se déconnecter
+            </div>
+          </div>
+        </div>
+        {/* Main */}
+        <div style={{ padding:'36px 56px', overflowY:'auto' }}>
+          <h1 style={{ fontFamily:t.serif, fontSize:36, letterSpacing:-0.6, fontWeight:500, margin:0, marginBottom:28 }}>Mon compte</h1>
+
+          {/* Email */}
+          <div style={{ background:t.surface, border:`1px solid ${t.line}`, borderRadius:14, padding:22, marginBottom:16 }}>
+            <div style={{ fontSize:12.5, fontWeight:600, color:t.inkSoft, marginBottom:10, textTransform:'uppercase', letterSpacing:0.4 }}>Email</div>
+            <div style={{ display:'flex', alignItems:'center', gap:12 }}>
+              <div style={{ flex:1, padding:'10px 14px', background:t.surfaceAlt, borderRadius:9, fontSize:13.5, fontFamily:t.mono, color:t.ink }}>noe@les-tilleuls.coop</div>
+              <Btn variant="ghost" size="sm" icon={I.edit}>Modifier via magic link</Btn>
+            </div>
+          </div>
+
+          {/* Preferences */}
+          <div style={{ background:t.surface, border:`1px solid ${t.line}`, borderRadius:14, padding:22, marginBottom:16 }}>
+            <div style={{ fontSize:12.5, fontWeight:600, color:t.inkSoft, marginBottom:14, textTransform:'uppercase', letterSpacing:0.4 }}>Préférences</div>
+            <div style={{ display:'flex', alignItems:'center', justifyContent:'space-between', marginBottom:12 }}>
+              <span style={{ fontSize:13.5 }}>Langue préférée</span>
+              <div style={{ display:'flex', background:t.surfaceAlt, borderRadius:7, padding:2, gap:1 }}>
+                {['FR','EN'].map((l,i)=>(
+                  <div key={l} style={{ padding:'5px 12px', borderRadius:5, fontSize:12, fontWeight:600, background:i===0?t.accent:'transparent', color:i===0?'#fff':t.inkSoft, cursor:'pointer' }}>{l}</div>
+                ))}
+              </div>
+            </div>
+            <div style={{ display:'flex', alignItems:'center', justifyContent:'space-between' }}>
+              <span style={{ fontSize:13.5 }}>Thème</span>
+              <div style={{ display:'flex', background:t.surfaceAlt, borderRadius:7, padding:2, gap:1 }}>
+                {['Clair','Sombre','Auto'].map((l,i)=>(
+                  <div key={l} style={{ padding:'5px 10px', borderRadius:5, fontSize:12, fontWeight:600, background:i===0?t.surface:'transparent', color:i===0?t.ink:t.inkSoft, cursor:'pointer', boxShadow:i===0?t.shadowSoft:'none' }}>{l}</div>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          {/* RGPD */}
+          <div style={{ background:t.surface, border:`1px solid ${t.line}`, borderRadius:14, padding:22, marginBottom:16 }}>
+            <div style={{ fontSize:12.5, fontWeight:600, color:t.inkSoft, marginBottom:12, textTransform:'uppercase', letterSpacing:0.4 }}>Mes données (RGPD)</div>
+            <p style={{ fontSize:13, color:t.inkSoft, lineHeight:1.55, margin:'0 0 14px' }}>Téléchargez l'intégralité de vos données (voyages, paramètres, historique) au format JSON.</p>
+            <Btn variant="ghost" size="sm" icon={I.download}>Télécharger mes données (JSON)</Btn>
+          </div>
+
+          {/* Danger zone */}
+          <div style={{ background:t.surface, border:`2px solid ${t.red}30`, borderRadius:14, padding:22 }}>
+            <div style={{ fontSize:12.5, fontWeight:600, color:t.red, marginBottom:10, textTransform:'uppercase', letterSpacing:0.4 }}>Zone de danger</div>
+            <p style={{ fontSize:13, color:t.inkSoft, lineHeight:1.55, margin:'0 0 14px' }}>La suppression du compte est irréversible. Tous vos voyages seront définitivement effacés.</p>
+            <Btn variant="danger" size="sm" icon={I.alert}>Supprimer mon compte…</Btn>
+          </div>
+        </div>
+      </div>
+      <DesktopFooter/>
+      </div>
+    </div>
+  );
+}
+
+// ─── 404 / 500 ────────────────────────────────────────────────────────────────
+function PageNotFoundDesktop({ w = 1280, h = 860 }) {
+  const t = useTheme();
+  return (
+    <div style={{ width:w, height:h, color:t.ink, fontFamily:t.sans, display:'flex', flexDirection:'column', position:'relative', overflow:'hidden' }}>
+      <div style={{ position:'absolute', inset:0, opacity:.3 }}><OsmMap w={w} h={h}/></div>
+      <div style={{ position:'absolute', inset:0, background:t.name==='dark'?'rgba(26,24,20,.75)':'rgba(250,247,240,.8)' }}/>
+      <div style={{ position:'relative', zIndex:1, display:'flex', flexDirection:'column', height:'100%' }}>
+      <TopBarDesktop/>
+      <div style={{ flex:1, display:'flex', alignItems:'center', justifyContent:'center', padding:40, textAlign:'center' }}>
+        <div style={{ maxWidth:520 }}>
+          <div style={{ fontFamily:t.serif, fontSize:160, fontWeight:500, letterSpacing:-6, color:t.accent, lineHeight:1, fontStyle:'italic' }}>404</div>
+          <h2 style={{ fontFamily:t.serif, fontSize:34, letterSpacing:-0.6, fontWeight:500, margin:'-10px 0 14px' }}>Hors-piste.</h2>
+          <p style={{ fontSize:15, color:t.inkSoft, marginBottom:26, lineHeight:1.55 }}>Cette route n'existe pas — ou le lien de partage a été révoqué.</p>
+          <div style={{ display:'flex', gap:10, justifyContent:'center' }}>
+            <Btn variant="accent" size="lg" icon={I.home}>Retour à l'accueil</Btn>
+            <Btn variant="ghost" size="lg" icon={I.trips}>Mes voyages</Btn>
+          </div>
+        </div>
+      </div>
+      <DesktopFooter/>
+      </div>
+    </div>
+  );
+}
+
+function PageErrorDesktop({ w = 1280, h = 860 }) {
+  const t = useTheme();
+  return (
+    <div style={{ width:w, height:h, color:t.ink, fontFamily:t.sans, display:'flex', flexDirection:'column', position:'relative', overflow:'hidden' }}>
+      <div style={{ position:'absolute', inset:0, opacity:.3 }}><OsmMap w={w} h={h}/></div>
+      <div style={{ position:'absolute', inset:0, background:t.name==='dark'?'rgba(26,24,20,.75)':'rgba(250,247,240,.8)' }}/>
+      <div style={{ position:'relative', zIndex:1, display:'flex', flexDirection:'column', height:'100%' }}>
+      <TopBarDesktop/>
+      <div style={{ flex:1, display:'flex', alignItems:'center', justifyContent:'center', padding:40, textAlign:'center' }}>
+        <div style={{ maxWidth:520 }}>
+          <div style={{ width:100,height:100,borderRadius:24,background:t.redSoft,color:t.red,display:'flex',alignItems:'center',justifyContent:'center',margin:'0 auto 24px' }}>
+            {React.cloneElement(I.alert,{width:44,height:44})}
+          </div>
+          <div style={{ fontSize:11.5,fontWeight:600,color:t.red,letterSpacing:1.5,textTransform:'uppercase',marginBottom:12 }}>Erreur serveur · 500</div>
+          <h2 style={{ fontFamily:t.serif, fontSize:36, letterSpacing:-0.6, fontWeight:500, margin:'0 0 14px' }}>Un caillou dans le dérailleur.</h2>
+          <p style={{ fontSize:14.5, color:t.inkSoft, marginBottom:20, lineHeight:1.6 }}>Nos mécanos sont sur le coup — ça devrait être corrigé dans quelques minutes.</p>
+          <div style={{ background:t.surface, border:`1px solid ${t.line}`, borderRadius:10, padding:13, fontSize:11.5, color:t.inkMute, fontFamily:t.mono, textAlign:'left', marginBottom:22 }}>
+            request_id: req_9f4a2b1c8e3d<br/>timestamp: 2026-04-24T14:32:18Z
+          </div>
+          <div style={{ display:'flex', gap:10, justifyContent:'center' }}>
+            <Btn variant="accent" size="lg">Réessayer</Btn>
+            <Btn variant="ghost" size="lg">Signaler le problème</Btn>
+          </div>
+        </div>
+      </div>
+      <DesktopFooter/>
+      </div>
+    </div>
+  );
+}
+
+Object.assign(window, {
+  PageLandingDesktop, PageLoginDesktop, PageAuthVerifyDesktop,
+  PageAccessRequestDesktop, PageFaqDesktop,
+  PageAccountSettingsDesktop, PageNotFoundDesktop, PageErrorDesktop,
+});

--- a/docs/recette/design/pages-extra.jsx
+++ b/docs/recette/design/pages-extra.jsx
@@ -1,0 +1,513 @@
+// pages-extra.jsx — Legal, empty/loading/error states, picto legend, infographic
+
+// ─── Privacy / Legal pages ──────────────────────────────────────────────────
+function PagePrivacyDesktop({ w = 1280, h = 860 }) {
+  const t = useTheme();
+  const MapBg = () => (<><div style={{position:'absolute',inset:0,opacity:.3,zIndex:0}}><OsmMap w={w} h={h}/></div><div style={{position:'absolute',inset:0,zIndex:0,background:t.name==='dark'?'rgba(26,24,20,.75)':'rgba(250,247,240,.8)'}}/></>);
+  const sections = [
+    { id:'intro', title:'Introduction', content:'Bike Trip Planner collecte uniquement les données strictement nécessaires au fonctionnement du service. Nous n\'utilisons pas de cookies tiers à des fins publicitaires.' },
+    { id:'base', title:'Base légale', content:'Le traitement est fondé sur le contrat (CGU) pour la gestion des voyages, et sur l\'intérêt légitime pour l\'amélioration du service via des analytics anonymes.' },
+    { id:'data', title:'Données collectées', content:'Email (auth), voyages créés (tracés, étapes, hébergements), préférences (langue, thème). Les tracés GPS restent sur vos appareils entre sessions — nous traitons uniquement les métadonnées de voyage côté serveur.' },
+    { id:'retention', title:'Conservation', content:'Les données sont conservées 13 mois après la dernière activité. Vous pouvez demander la suppression à tout moment depuis Paramètres → Mes données.' },
+    { id:'rights', title:'Vos droits', content:'Accès, rectification, suppression, portabilité, opposition. Contactez dpo@biketripplanner.app. Délai de réponse : 30 jours maximum.' },
+    { id:'analytics', title:'Cookies & analytics', content:'Cookies techniques essentiels uniquement (session JWT). Analytics agrégées et anonymes en interne (sans IP, sans empreinte de navigateur, sans tracking cross-site, suppression à 13 mois).' },
+    { id:'contact', title:'Contact DPO', content:'Data Protection Officer : dpo@biketripplanner.app — pour toute demande relative à vos données personnelles.' },
+  ];
+  return (
+    <div style={{ width:w, height:h, color:t.ink, fontFamily:t.sans, display:'flex', flexDirection:'column', overflow:'hidden', position:'relative' }}>
+      <MapBg/>
+      <div style={{ position:'relative', zIndex:1, display:'flex', flexDirection:'column', flex:1, minHeight:0 }}>
+      <TopBarDesktop/>
+      <div style={{ display:'grid', gridTemplateColumns:'220px 1fr', flex:1, minHeight:0 }}>
+        <div style={{ padding:'28px 16px', borderRight:`1px solid ${t.line}`, overflowY:'auto', background:t.surface, position:'sticky', top:0 }}>
+          <div style={{ fontSize:11, fontWeight:600, color:t.inkSoft, textTransform:'uppercase', letterSpacing:0.5, marginBottom:10 }}>Sommaire</div>
+          {sections.map((s,i)=>(
+            <div key={i} style={{ padding:'7px 10px', borderRadius:7, fontSize:12.5, color:i===0?t.ink:t.inkSoft, fontWeight:i===0?600:400, cursor:'pointer', marginBottom:2 }}>{s.title}</div>
+          ))}
+        </div>
+        <div style={{ padding:'40px 60px', overflowY:'auto' }}>
+          <Pill bg={t.blueSoft} color={t.blue} bold style={{ marginBottom:16 }}>Politique de confidentialité</Pill>
+          <h1 style={{ fontFamily:t.serif, fontSize:40, letterSpacing:-0.7, fontWeight:500, margin:0, marginBottom:6 }}>Confidentialité</h1>
+          <p style={{ fontSize:13.5, color:t.inkSoft, marginBottom:36, lineHeight:1.5 }}>Dernière mise à jour : 24 avril 2026 · Base légale : RGPD (UE 2016/679)</p>
+          <div style={{ maxWidth:680, display:'flex', flexDirection:'column', gap:28 }}>
+            {sections.map((s,i)=>(
+              <div key={i}>
+                <h2 style={{ fontFamily:t.serif, fontSize:22, fontWeight:500, letterSpacing:-0.3, margin:0, marginBottom:10 }}>{s.title}</h2>
+                <p style={{ fontSize:14, color:t.inkSoft, lineHeight:1.7, margin:0 }}>{s.content}</p>
+                {i < sections.length-1 && <div style={{ height:1, background:t.lineSoft, marginTop:28 }}/>}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+      <DesktopFooter/>
+      </div>
+    </div>
+  );
+}
+
+function PageLegalDesktop({ w = 1280, h = 860 }) {
+  const t = useTheme();
+  return (
+    <div style={{ width:w, height:h, color:t.ink, fontFamily:t.sans, display:'flex', flexDirection:'column', overflow:'hidden', position:'relative' }}>
+      <div style={{position:'absolute',inset:0,opacity:.3,zIndex:0}}><OsmMap w={w} h={h}/></div>
+      <div style={{position:'absolute',inset:0,zIndex:0,background:t.name==='dark'?'rgba(26,24,20,.75)':'rgba(250,247,240,.8)'}}/>
+      <div style={{ position:'relative', zIndex:1, display:'flex', flexDirection:'column', flex:1, minHeight:0 }}>
+      <TopBarDesktop/>
+      <div style={{ display:'grid', gridTemplateColumns:'220px 1fr', flex:1, minHeight:0 }}>
+        <div style={{ padding:'28px 16px', borderRight:`1px solid ${t.line}`, background:t.surface }}>
+          <div style={{ fontSize:11, fontWeight:600, color:t.inkSoft, textTransform:'uppercase', letterSpacing:0.5, marginBottom:10 }}>Sommaire</div>
+          {['Éditeur','Hébergeur','Contact','Propriété intellectuelle','Licence code source'].map((s,i)=>(
+            <div key={i} style={{ padding:'7px 10px', borderRadius:7, fontSize:12.5, color:i===0?t.ink:t.inkSoft, fontWeight:i===0?600:400, cursor:'pointer', marginBottom:2 }}>{s}</div>
+          ))}
+        </div>
+        <div style={{ padding:'40px 60px', overflowY:'auto' }}>
+          <Pill bg={t.surfaceAlt} color={t.inkSoft} bold style={{ marginBottom:16 }}>Mentions légales</Pill>
+          <h1 style={{ fontFamily:t.serif, fontSize:40, letterSpacing:-0.7, fontWeight:500, margin:0, marginBottom:6 }}>Mentions légales</h1>
+          <p style={{ fontSize:13.5, color:t.inkSoft, marginBottom:36 }}>Conformément à la loi pour la confiance dans l'économie numérique (LCEN).</p>
+          <div style={{ maxWidth:680, display:'flex', flexDirection:'column', gap:24 }}>
+            {[
+              { t:'Éditeur', c:'Vincent Chalamon — vincent@chalamon.fr' },
+              { t:'Hébergeur', c:'OVHcloud SAS — 2 rue Kellermann, 59100 Roubaix · support.ovhcloud.com' },
+              { t:'Contact', c:'contact@biketripplanner.app' },
+              { t:'Propriété intellectuelle', c:'Le code source est publié sous licence AGPL v3.0 (github.com/vincentchalamon/bike-trip-planner). Les données cartographiques sont © OpenStreetMap contributors (ODbL 1.0).' },
+              { t:'Licence code source', c:'GNU Affero General Public License v3.0 — usage commercial autorisé sous conditions, avec partage des modifications.' },
+            ].map((s,i)=>(
+              <div key={i}>
+                <h2 style={{ fontFamily:t.serif, fontSize:20, fontWeight:500, margin:0, marginBottom:8 }}>{s.t}</h2>
+                <p style={{ fontSize:13.5, color:t.inkSoft, lineHeight:1.65, margin:0 }}>{s.c}</p>
+                {i < 4 && <div style={{ height:1, background:t.lineSoft, marginTop:24 }}/>}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+      <DesktopFooter/>
+      </div>
+    </div>
+  );
+}
+
+// ─── STATES panel ─────────────────────────────────────────────────────────────
+function PageStatesDesktop({ w = 1280, h = 860 }) {
+  const t = useTheme();
+  const MapBg2 = () => (<><div style={{position:'absolute',inset:0,opacity:.3,zIndex:0}}><OsmMap w={w} h={h}/></div><div style={{position:'absolute',inset:0,zIndex:0,background:t.name==='dark'?'rgba(26,24,20,.75)':'rgba(250,247,240,.8)'}}/></>);
+  const Skel = ({ w: sw = '100%', h: sh = 14, r = 6 }) => (
+    <div className={t.name==='dark'?'dark-shimmer-bg':'shimmer-bg'} style={{ width:sw, height:sh, borderRadius:r }}/>
+  );
+
+  return (
+    <div style={{ width:w, height:h, color:t.ink, fontFamily:t.sans, display:'flex', flexDirection:'column', overflow:'hidden', position:'relative' }}>
+      <MapBg2/>
+      <div style={{ position:'relative', zIndex:1, display:'flex', flexDirection:'column', flex:1, minHeight:0 }}>
+      <TopBarDesktop/>
+      <div style={{ flex:1, overflowY:'auto', padding:'32px 48px' }}>
+        <h1 style={{ fontFamily:t.serif, fontSize:36, letterSpacing:-0.6, fontWeight:500, margin:'0 0 32px' }}>États UI</h1>
+        <div style={{ display:'grid', gridTemplateColumns:'repeat(3,1fr)', gap:28 }}>
+
+          {/* Empty states */}
+          <div>
+            <div style={{ fontSize:11.5, fontWeight:700, color:t.accent, letterSpacing:1, textTransform:'uppercase', marginBottom:14 }}>Empty states</div>
+            {/* No trips */}
+            <div style={{ background:t.surface, border:`2px dashed ${t.line}`, borderRadius:14, padding:32, textAlign:'center', marginBottom:12 }}>
+              <div style={{ width:56,height:56,borderRadius:16,background:t.surfaceAlt,color:t.inkMute,display:'flex',alignItems:'center',justifyContent:'center',margin:'0 auto 14px' }}>{React.cloneElement(I.trips,{width:24,height:24})}</div>
+              <div style={{ fontSize:14,fontWeight:600,marginBottom:6 }}>Aucun voyage encore</div>
+              <p style={{ fontSize:12.5,color:t.inkSoft,margin:'0 0 16px',lineHeight:1.5 }}>Créez votre premier itinéraire en quelques secondes.</p>
+              <Btn variant="accent" size="sm" icon={I.plus}>Créer un voyage</Btn>
+            </div>
+            {/* No search results (filter active, 0 matches) — mutually exclusive with "Aucun voyage encore" on /trips */}
+            <div style={{ background:t.surface, border:`2px dashed ${t.line}`, borderRadius:14, padding:32, textAlign:'center', marginBottom:12 }}>
+              <div style={{ width:56,height:56,borderRadius:16,background:t.surfaceAlt,color:t.inkMute,display:'flex',alignItems:'center',justifyContent:'center',margin:'0 auto 14px' }}>
+                <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/>
+                  <line x1="8" y1="8" x2="14" y2="14" stroke={t.red} strokeWidth="2.2"/><line x1="14" y1="8" x2="8" y2="14" stroke={t.red} strokeWidth="2.2"/>
+                </svg>
+              </div>
+              <div style={{ fontSize:14,fontWeight:600,marginBottom:6 }}>Aucun voyage ne correspond à votre recherche</div>
+              <p style={{ fontSize:12,color:t.inkSoft,margin:'0 0 16px',lineHeight:1.5 }}>Filtres actifs : titre « Pyrénées » · dates 14–17 mai 2026</p>
+              <div style={{ display:'flex', gap:8, justifyContent:'center' }}>
+                <Btn variant="accent" size="sm">Réinitialiser les filtres</Btn>
+                <Btn variant="ghost" size="sm" icon={I.plus}>Nouveau voyage</Btn>
+              </div>
+            </div>
+            {/* No alerts */}
+            <div style={{ background:t.surface, border:`1px solid ${t.line}`, borderRadius:12, padding:20, textAlign:'center', marginBottom:12 }}>
+              <div style={{ fontSize:22, marginBottom:6 }}>🎉</div>
+              <div style={{ fontSize:13,fontWeight:600,marginBottom:4 }}>Aucune alerte sur cette étape</div>
+              <div style={{ fontSize:11.5,color:t.inkSoft }}>L'étape est dégagée.</div>
+            </div>
+            {/* No accommodations */}
+            <div style={{ background:t.surface, border:`1px solid ${t.line}`, borderRadius:12, padding:20 }}>
+              <div style={{ display:'flex', alignItems:'center', gap:8, marginBottom:8 }}>
+                {React.cloneElement(I.info,{width:14,height:14,color:t.inkMute})}
+                <span style={{ fontSize:12.5, color:t.inkSoft }}>Aucun hébergement dans un rayon de 5 km.</span>
+              </div>
+              <span style={{ fontSize:11.5, color:t.accent, fontWeight:600, cursor:'pointer' }}>› Élargir la zone de recherche</span>
+            </div>
+          </div>
+
+          {/* Skeleton / loading states */}
+          <div>
+            <div style={{ fontSize:11.5, fontWeight:700, color:t.accent, letterSpacing:1, textTransform:'uppercase', marginBottom:14 }}>Skeleton / Loading</div>
+            {/* Trip card skeleton */}
+            <div style={{ background:t.surface, border:`1px solid ${t.line}`, borderRadius:14, overflow:'hidden', marginBottom:12, display:'flex' }}>
+              <div className={t.name==='dark'?'dark-shimmer-bg':'shimmer-bg'} style={{ width:160,height:140 }}/>
+              <div style={{ flex:1, padding:16, display:'flex', flexDirection:'column', gap:8 }}>
+                <Skel w="40%" h={12}/>
+                <Skel w="90%" h={18}/>
+                <Skel w="60%" h={12}/>
+                <div style={{ marginTop:'auto', display:'flex', gap:8 }}>
+                  <Skel w={50} h={12}/>
+                  <Skel w={50} h={12}/>
+                </div>
+              </div>
+            </div>
+            {/* Stage detail skeleton */}
+            <div style={{ background:t.surface, border:`1px solid ${t.line}`, borderRadius:14, padding:16, marginBottom:12, display:'flex', flexDirection:'column', gap:8 }}>
+              <div style={{ display:'flex', gap:8 }}><Skel w={64} h={20} r={10}/><Skel w={80} h={20} r={10}/></div>
+              <Skel w="75%" h={22}/>
+              <Skel h={60} r={10}/>
+              <div style={{ display:'grid', gridTemplateColumns:'repeat(4,1fr)', gap:6 }}>
+                {[0,1,2,3].map(i=><Skel key={i} h={44} r={10}/>)}
+              </div>
+            </div>
+            {/* Processing spinner */}
+            <div style={{ background:t.surface, border:`1px solid ${t.line}`, borderRadius:12, padding:'16px 20px', display:'flex', alignItems:'center', gap:12 }}>
+              <div style={{ width:32,height:32,borderRadius:'50%',border:`3px solid ${t.line}`,borderTopColor:t.accent,animation:'spin 1s linear infinite',flexShrink:0 }}/>
+              <div>
+                <div style={{ fontSize:13.5,fontWeight:600,marginBottom:2 }}>Recalcul en cours…</div>
+                <div style={{ fontSize:11.5,color:t.inkSoft }}>Mise à jour des étapes après modification</div>
+              </div>
+            </div>
+          </div>
+
+          {/* Error states */}
+          <div>
+            <div style={{ fontSize:11.5, fontWeight:700, color:t.accent, letterSpacing:1, textTransform:'uppercase', marginBottom:14 }}>Erreurs</div>
+            {/* GPX parse error */}
+            <div style={{ background:t.redSoft, border:`1px solid ${t.red}30`, borderRadius:12, padding:16, marginBottom:12 }}>
+              <div style={{ display:'flex', gap:8, alignItems:'flex-start' }}>
+                {React.cloneElement(I.alert,{width:16,height:16,color:t.red})}
+                <div>
+                  <div style={{ fontSize:13,fontWeight:600,color:t.red,marginBottom:3 }}>Fichier GPX invalide</div>
+                  <div style={{ fontSize:12,color:t.inkSoft,lineHeight:1.5 }}>Le fichier ne contient aucun waypoint. Vérifiez qu'il s'agit bien d'un tracé GPX.</div>
+                  <Btn variant="ghost" size="sm" style={{ marginTop:8, borderColor:t.red, color:t.red }}>Réessayer</Btn>
+                </div>
+              </div>
+            </div>
+            {/* URL not supported */}
+            <div style={{ background:t.redSoft, border:`1px solid ${t.red}30`, borderRadius:12, padding:16, marginBottom:12 }}>
+              <div style={{ display:'flex', gap:8, alignItems:'flex-start' }}>
+                {React.cloneElement(I.alert,{width:16,height:16,color:t.red})}
+                <div>
+                  <div style={{ fontSize:13,fontWeight:600,color:t.red,marginBottom:3 }}>URL non supportée</div>
+                  <div style={{ fontSize:12,color:t.inkSoft }}>Formats supportés : Komoot, RideWithGPS, Strava, GPX.</div>
+                </div>
+              </div>
+            </div>
+            {/* Offline */}
+            <div style={{ background:t.name==='dark'?'#1a1a22':'#f0f0fa', border:`1px solid ${t.blue}30`, borderRadius:12, padding:'10px 16px', marginBottom:12, display:'flex', alignItems:'center', gap:10 }}>
+              {React.cloneElement(I.wifiOff,{width:14,height:14,color:t.blue})}
+              <div style={{ flex:1, fontSize:12.5, color:t.blue }}>Hors ligne — données en cache affichées.</div>
+              <Btn variant="ghost" size="sm" style={{ borderColor:t.blue, color:t.blue, fontSize:11 }}>Réessayer</Btn>
+            </div>
+            {/* Share link revoked */}
+            <div style={{ background:t.surface, border:`1px solid ${t.line}`, borderRadius:12, padding:20, textAlign:'center' }}>
+              <div style={{ fontSize:24, marginBottom:8 }}>🔗</div>
+              <div style={{ fontSize:13.5,fontWeight:600,marginBottom:6 }}>Lien de partage révoqué</div>
+              <p style={{ fontSize:12.5,color:t.inkSoft,margin:'0 0 14px',lineHeight:1.5 }}>Le propriétaire a désactivé ce lien de partage.</p>
+              <Btn variant="ghost" size="sm">Retour à l'accueil</Btn>
+            </div>
+          </div>
+
+          {/* Form states */}
+          <div style={{ gridColumn:'span 3' }}>
+            <div style={{ fontSize:11.5, fontWeight:700, color:t.accent, letterSpacing:1, textTransform:'uppercase', marginBottom:14 }}>États de formulaires</div>
+            <div style={{ display:'grid', gridTemplateColumns:'repeat(4,1fr)', gap:14 }}>
+              {/* URL detection states */}
+              {[
+                { label:'URL — en cours d\'analyse', badge:'Analyse…', badgeColor:t.inkMute, badgeBg:t.surfaceAlt, inputBorder:t.line },
+                { label:'Komoot détecté', badge:'Komoot Tour ✓', badgeColor:t.green, badgeBg:t.greenSoft, inputBorder:t.green },
+                { label:'Strava détecté', badge:'Strava Route ✓', badgeColor:'#FC4C02', badgeBg:'#fff1e8', inputBorder:'#FC4C02' },
+                { label:'URL non supportée', badge:'Non reconnu ✗', badgeColor:t.red, badgeBg:t.redSoft, inputBorder:t.red },
+              ].map((s,i)=>(
+                <div key={i}>
+                  <div style={{ fontSize:11, color:t.inkSoft, marginBottom:5 }}>{s.label}</div>
+                  <div style={{ padding:'9px 12px', background:t.surface, border:`1.5px solid ${s.inputBorder}`, borderRadius:9, fontFamily:t.mono, fontSize:12, color:t.ink, marginBottom:5, overflow:'hidden', textOverflow:'ellipsis', whiteSpace:'nowrap' }}>
+                    {i===0?'https://...(analyse)':i===1?'komoot.com/tour/284…':i===2?'strava.com/routes/…':'https://maps.google.com/…'}
+                  </div>
+                  <div style={{ display:'inline-flex', alignItems:'center', gap:5, padding:'3px 9px', background:s.badgeBg, borderRadius:5, fontSize:11, color:s.badgeColor, fontWeight:600 }}>
+                    {s.badge}
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <div style={{ display:'grid', gridTemplateColumns:'repeat(4,1fr)', gap:14, marginTop:16 }}>
+              {/* Magic link states */}
+              {[
+                { label:'État 1 — Formulaire saisie', content: (
+                  <div>
+                    <div style={{ padding:'10px 14px', background:t.surface, border:`1px solid ${t.line}`, borderRadius:9, fontSize:13.5, color:t.inkMute, marginBottom:8, display:'flex', alignItems:'center', gap:8 }}>
+                      {React.cloneElement(I.mail,{width:14,height:14})} votre@email.com
+                    </div>
+                    <Btn variant="accent" size="sm" full>Recevoir le lien</Btn>
+                  </div>
+                )},
+                { label:'État 2 — Email envoyé (timer 60s)', content: (
+                  <div style={{ padding:'14px 16px', background:t.greenSoft, border:`1px solid ${t.green}30`, borderRadius:10, textAlign:'center' }}>
+                    <div style={{ width:36,height:36,borderRadius:10,background:t.green,color:'#fff',display:'flex',alignItems:'center',justifyContent:'center',margin:'0 auto 8px' }}>{React.cloneElement(I.check,{width:16,height:16})}</div>
+                    <div style={{ fontSize:13,fontWeight:600,color:t.green,marginBottom:2 }}>Email envoyé ✓</div>
+                    <div style={{ fontSize:11.5,color:t.inkSoft,marginBottom:10 }}>Vérifie ta boîte · noe@…coop</div>
+                    <div style={{ padding:'6px 12px', background:t.surface, border:`1px solid ${t.line}`, borderRadius:7, fontSize:12, color:t.inkMute, opacity:0.5 }}>Renvoyer (42s)</div>
+                  </div>
+                )},
+                { label:'État 3 — Lien expiré / invalide', content: (
+                  <div style={{ padding:'14px 16px', background:t.redSoft, border:`1px solid ${t.red}30`, borderRadius:10, textAlign:'center' }}>
+                    <div style={{ width:36,height:36,borderRadius:10,background:t.red,color:'#fff',display:'flex',alignItems:'center',justifyContent:'center',margin:'0 auto 8px' }}>{React.cloneElement(I.alert,{width:16,height:16})}</div>
+                    <div style={{ fontSize:13,fontWeight:600,color:t.red,marginBottom:2 }}>Lien expiré ou invalide</div>
+                    <div style={{ fontSize:11.5,color:t.inkSoft,marginBottom:10 }}>Les liens expirent après 15 min.</div>
+                    <Btn variant="accent" size="sm" style={{ width:'100%' }}>Redemander un lien</Btn>
+                  </div>
+                )},
+                { label:'Email invalide (inline)', content: (
+                  <div>
+                    <div style={{ padding:'10px 14px', background:t.surface, border:`1.5px solid ${t.red}`, borderRadius:9, fontSize:13.5, color:t.ink, marginBottom:4, display:'flex', alignItems:'center', gap:8 }}>
+                      {React.cloneElement(I.mail,{width:14,height:14,color:t.red})} pas-un-email
+                    </div>
+                    <div style={{ fontSize:11.5, color:t.red, display:'flex', alignItems:'center', gap:4 }}>
+                      {React.cloneElement(I.alert,{width:11,height:11})} Format d'email invalide.
+                    </div>
+                  </div>
+                )},
+              ].map((s,i)=>(
+                <div key={i}>
+                  <div style={{ fontSize:11, color:t.inkSoft, marginBottom:5 }}>{s.label}</div>
+                  {s.content}
+                </div>
+              ))}
+            </div>
+
+            {/* Validation inline — URL + GPX */}
+            <div style={{ fontSize:11.5, fontWeight:700, color:t.accent, letterSpacing:1, textTransform:'uppercase', marginTop:20, marginBottom:14 }}>Validations inline (URL + GPX)</div>
+            <div style={{ display:'grid', gridTemplateColumns:'repeat(4,1fr)', gap:14 }}>
+              {[
+                { label:'URL non supportée', content: (
+                  <div>
+                    <div style={{ padding:'10px 14px', background:t.surface, border:`1.5px solid ${t.red}`, borderRadius:9, fontSize:12, fontFamily:t.mono, color:t.ink, marginBottom:4, overflow:'hidden', textOverflow:'ellipsis', whiteSpace:'nowrap' }}>
+                      https://instagram.com/p/xyz
+                    </div>
+                    <div style={{ fontSize:11.5, color:t.red, display:'flex', alignItems:'center', gap:4 }}>
+                      {React.cloneElement(I.alert,{width:11,height:11})} URL non supportée.
+                    </div>
+                    <div style={{ fontSize:10.5, color:t.inkMute, marginTop:3 }}>Formats : Komoot, RWGPS, Strava, GPX.</div>
+                  </div>
+                )},
+                { label:'URL YouTube (non supportée)', content: (
+                  <div>
+                    <div style={{ padding:'10px 14px', background:t.surface, border:`1.5px solid ${t.red}`, borderRadius:9, fontSize:12, fontFamily:t.mono, color:t.ink, marginBottom:4, overflow:'hidden', textOverflow:'ellipsis', whiteSpace:'nowrap' }}>
+                      https://youtube.com/watch?v=…
+                    </div>
+                    <div style={{ fontSize:11.5, color:t.red, display:'flex', alignItems:'center', gap:4 }}>
+                      {React.cloneElement(I.alert,{width:11,height:11})} Lien vidéo détecté — non supporté.
+                    </div>
+                  </div>
+                )},
+                { label:'GPX trop lourd (>30 Mo)', content: (
+                  <div style={{ border:`2px solid ${t.red}`, borderRadius:14, padding:'20px 16px', textAlign:'center', background:t.redSoft }}>
+                    <div style={{ width:40,height:40,borderRadius:12,background:t.surface,color:t.red,display:'flex',alignItems:'center',justifyContent:'center',margin:'0 auto 10px' }}>
+                      {React.cloneElement(I.alert,{width:20,height:20})}
+                    </div>
+                    <div style={{ fontSize:13,fontWeight:600,color:t.red,marginBottom:3 }}>Fichier trop volumineux</div>
+                    <div style={{ fontSize:11.5,color:t.inkSoft }}>Le fichier dépasse 30 Mo.</div>
+                    <div style={{ fontSize:10.5,color:t.inkMute,marginTop:4,fontFamily:t.mono }}>route-europe.gpx · 48,2 Mo</div>
+                  </div>
+                )},
+                { label:'GPX corrompu / illisible', content: (
+                  <div style={{ border:`2px solid ${t.red}`, borderRadius:14, padding:'20px 16px', textAlign:'center', background:t.redSoft }}>
+                    <div style={{ width:40,height:40,borderRadius:12,background:t.surface,color:t.red,display:'flex',alignItems:'center',justifyContent:'center',margin:'0 auto 10px' }}>
+                      {React.cloneElement(I.alert,{width:20,height:20})}
+                    </div>
+                    <div style={{ fontSize:13,fontWeight:600,color:t.red,marginBottom:3 }}>Impossible de lire ce fichier GPX</div>
+                    <div style={{ fontSize:11.5,color:t.inkSoft }}>Le fichier semble corrompu ou n'est pas au format GPX.</div>
+                    <Btn variant="ghost" size="sm" style={{ marginTop:8, borderColor:t.red, color:t.red }}>Réessayer</Btn>
+                  </div>
+                )},
+              ].map((s,i)=>(
+                <div key={i}>
+                  <div style={{ fontSize:11, color:t.inkSoft, marginBottom:5 }}>{s.label}</div>
+                  {s.content}
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+      <DesktopFooter/>
+      </div>
+    </div>
+  );
+}
+
+// ─── PICTO LEGEND ─────────────────────────────────────────────────────────────
+function PagePictoLegendDesktop({ w = 1280, h = 860 }) {
+  const t = useTheme();
+  const MapBg3 = () => (<><div style={{position:'absolute',inset:0,opacity:.3,zIndex:0}}><OsmMap w={w} h={h}/></div><div style={{position:'absolute',inset:0,zIndex:0,background:t.name==='dark'?'rgba(26,24,20,.75)':'rgba(250,247,240,.8)'}}/></>);
+  const groups = [
+    {
+      title:'Fin d\'étape', items:[
+        { icon:'●', color:'#4a7a3e', label:'Fin étape 1', desc:'Pastille numérotée' },
+        { icon:'●', color:'#c2671e', label:'Fin étape 2', desc:'' },
+        { icon:'●', color:'#3d6b91', label:'Fin étape 3', desc:'' },
+        { icon:'●', color:'#b86a3e', label:'Fin étape 4', desc:'' },
+      ]
+    },
+    {
+      title:'Hébergements (9 types)', items:Object.entries(ACC_TYPES).map(([k,v])=>({ icon:v.icon, color:v.color, label:v.label, desc:`OSM: tourism=${k}` }))
+    },
+    {
+      title:'Points d\'eau & ravitaillement', items:[
+        { icon:'💧', color:'#3d6b91', label:'Point d\'eau', desc:'Fontaine potable' },
+        { icon:'🛒', color:'#4a7a3e', label:'Ravitaillement', desc:'Supérette, boulangerie…' },
+        { icon:'☕', color:'#8a5a2e', label:'Café / pause', desc:'Suggestion de pause' },
+      ]
+    },
+    {
+      title:'Services vélo & sécurité', items:[
+        { icon:'🔧', color:'#c2671e', label:'Atelier vélo', desc:'Réparation à proximité' },
+        { icon:'🚉', color:'#3d6b91', label:'Gare SNCF/SNCB', desc:'Évacuation d\'urgence' },
+        { icon:'💊', color:'#b83a3a', label:'Pharmacie / hôpital', desc:'Services de santé' },
+        { icon:'🌍', color:'#6b3e7a', label:'Passage frontière', desc:'Changement de pays' },
+        { icon:'🌊', color:'#3d6b91', label:'Cours d\'eau sans pont', desc:'Traversée difficile' },
+        { icon:'🌅', color:'#c2671e', label:'Départ avant l\'aube', desc:'Risque nuit' },
+      ]
+    },
+    {
+      title:'POI culturels & événements', items:[
+        { icon:'🏛️', color:'#6b5a3e', label:'Musée / monument', desc:'Avec horaires + prix' },
+        { icon:'🏰', color:'#5a3e6b', label:'Château', desc:'Wikidata enrichi' },
+        { icon:'🔭', color:'#3e6b5a', label:'Point de vue', desc:'Panorama' },
+        { icon:'🎪', color:'#8a3a6b', label:'Événement daté', desc:'Festival, marché…' },
+        { icon:'🛍️', color:'#6b5a3e', label:'Marché forain', desc:'data.gouv.fr' },
+        { icon:'📍', color:'#c2671e', label:'Waypoint utilisateur', desc:'Ajout manuel' },
+      ]
+    },
+  ];
+  return (
+    <div style={{ width:w, height:h, color:t.ink, fontFamily:t.sans, display:'flex', flexDirection:'column', overflow:'hidden', position:'relative' }}>
+      <MapBg3/>
+      <div style={{ position:'relative', zIndex:1, display:'flex', flexDirection:'column', flex:1, minHeight:0 }}>
+      <TopBarDesktop/>
+      <div style={{ flex:1, overflowY:'auto', padding:'32px 48px' }}>
+        <h1 style={{ fontFamily:t.serif, fontSize:36, letterSpacing:-0.6, fontWeight:500, margin:'0 0 8px' }}>Système de pictogrammes</h1>
+        <p style={{ fontSize:14, color:t.inkSoft, marginBottom:32, lineHeight:1.5 }}>Référence visuelle — light & dark mode. Utilisé sur la carte MapLibre et dans les panneaux d'étape.</p>
+        <div style={{ display:'flex', flexDirection:'column', gap:24 }}>
+          {groups.map((g,gi)=>(
+            <div key={gi}>
+              <div style={{ fontSize:12, fontWeight:700, color:t.accent, letterSpacing:1.2, textTransform:'uppercase', marginBottom:10 }}>{g.title}</div>
+              <div style={{ display:'flex', flexWrap:'wrap', gap:10 }}>
+                {g.items.map((item,i)=>(
+                  <div key={i} style={{ display:'flex', alignItems:'center', gap:10, padding:'10px 14px', background:t.surface, border:`1px solid ${t.line}`, borderRadius:12, minWidth:180, boxShadow:t.shadowSoft }}>
+                    <div style={{ width:38,height:38,borderRadius:10,background:`${item.color}18`,border:`1.5px solid ${item.color}40`,display:'flex',alignItems:'center',justifyContent:'center',fontSize:18,flexShrink:0 }}>
+                      {item.icon}
+                    </div>
+                    <div>
+                      <div style={{ fontSize:12.5, fontWeight:600, color:t.ink }}>{item.label}</div>
+                      {item.desc && <div style={{ fontSize:11, color:t.inkMute, marginTop:1 }}>{item.desc}</div>}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+      <DesktopFooter/>
+      </div>
+    </div>
+  );
+}
+
+// ─── INFOGRAPHIC 1:1 1080×1080 ────────────────────────────────────────────────
+function PageInfographicDesktop({ w = 1080, h = 1080 }) {
+  const t = makeTheme('amber', false); // Always light for infographic
+
+  return (
+    <ThemeCtx.Provider value={t}>
+      <div style={{ width:w, height:h, background:`linear-gradient(135deg, #2a2418 0%, #3d3428 100%)`, color:'#fff', fontFamily:'"Inter Tight", system-ui, sans-serif', overflow:'hidden', position:'relative', display:'flex', flexDirection:'column' }}>
+        {/* Background map (faint) */}
+        <div style={{ position:'absolute', inset:0, opacity:0.12 }}>
+          <OsmMap w={w} h={h}/>
+        </div>
+
+        {/* Colored accent band top */}
+        <div style={{ height:6, background:`linear-gradient(90deg, ${t.accent}, #b86a3e, #4a7a3e, #3d6b91)`, flexShrink:0 }}/>
+
+        <div style={{ position:'relative', flex:1, display:'flex', flexDirection:'column', padding:64 }}>
+          {/* Header */}
+          <div style={{ display:'flex', alignItems:'center', gap:12, marginBottom:32 }}>
+            <Logo size={36}/>
+            <span style={{ fontSize:14, fontWeight:600, color:'rgba(255,255,255,.7)', letterSpacing:0.5 }}>Bike Trip Planner</span>
+          </div>
+
+          {/* Title */}
+          <h1 style={{ fontFamily:'"Fraunces", Georgia, serif', fontSize:58, fontWeight:500, letterSpacing:-1.5, lineHeight:1.05, margin:'0 0 12px', color:'#fff' }}>
+            L'Odyssée des<br/><span style={{ fontStyle:'italic', color:'#f1c999' }}>Eaux Royales</span>
+          </h1>
+          <div style={{ fontSize:16, color:'rgba(255,255,255,.65)', marginBottom:40 }}>Lille → Gand · 14 – 17 mai 2026</div>
+
+          {/* Map */}
+          <div style={{ borderRadius:20, overflow:'hidden', marginBottom:36, flex:'0 0 320px', border:'3px solid rgba(255,255,255,.1)' }}>
+            <OsmMap w={952} h={320}/>
+          </div>
+
+          {/* Stats grid */}
+          <div style={{ display:'grid', gridTemplateColumns:'repeat(4,1fr)', gap:14, marginBottom:32 }}>
+            {[
+              { l:'Distance', v:'143 km' },
+              { l:'Dénivelé', v:'+1 430 m' },
+              { l:'Durée', v:'4 jours' },
+              { l:'Budget', v:'~€270' },
+            ].map((s,i)=>(
+              <div key={i} style={{ background:'rgba(255,255,255,.08)', border:'1px solid rgba(255,255,255,.12)', borderRadius:14, padding:'16px 18px', backdropFilter:'blur(10px)' }}>
+                <div style={{ fontSize:11, color:'rgba(255,255,255,.5)', fontWeight:600, letterSpacing:0.5, textTransform:'uppercase', marginBottom:6 }}>{s.l}</div>
+                <div style={{ fontFamily:'"Fraunces", Georgia, serif', fontSize:26, fontWeight:500, letterSpacing:-0.5 }}>{s.v}</div>
+              </div>
+            ))}
+          </div>
+
+          {/* Stages */}
+          <div style={{ display:'grid', gridTemplateColumns:'repeat(4,1fr)', gap:10 }}>
+            {STAGES.map((s,i)=>{
+              const c = [t.forest,t.accent,t.blue,t.rose][i];
+              return (
+                <div key={i} style={{ background:'rgba(255,255,255,.06)', border:`1.5px solid ${c}50`, borderRadius:12, padding:'12px 14px' }}>
+                  <div style={{ display:'flex', alignItems:'center', gap:6, marginBottom:6 }}>
+                    <div style={{ width:20,height:20,borderRadius:5,background:c,color:'#fff',fontSize:10,fontWeight:700,display:'flex',alignItems:'center',justifyContent:'center' }}>{s.day}</div>
+                    <span style={{ fontSize:10, color:'rgba(255,255,255,.5)' }}>{s.date}</span>
+                  </div>
+                  <div style={{ fontSize:12.5, fontWeight:600, lineHeight:1.2, marginBottom:4 }}>{s.from} → {s.to}</div>
+                  <div style={{ fontSize:11, color:'rgba(255,255,255,.55)' }}>{s.km} km · +{s.up} m</div>
+                </div>
+              );
+            })}
+          </div>
+
+          {/* Footer */}
+          <div style={{ marginTop:'auto', paddingTop:20, borderTop:'1px solid rgba(255,255,255,.1)', display:'flex', justifyContent:'space-between', alignItems:'center' }}>
+            <div style={{ fontSize:11, color:'rgba(255,255,255,.35)' }}>biketripplanner.app</div>
+            <div style={{ fontSize:11, color:'rgba(255,255,255,.35)' }}>© OpenStreetMap contributors</div>
+          </div>
+        </div>
+
+        {/* Colored accent band bottom */}
+        <div style={{ height:6, background:`linear-gradient(90deg, #3d6b91, #4a7a3e, #b86a3e, ${t.accent})`, flexShrink:0 }}/>
+      </div>
+    </ThemeCtx.Provider>
+  );
+}
+
+Object.assign(window, {
+  PagePrivacyDesktop, PageLegalDesktop, PageStatesDesktop,
+  PagePictoLegendDesktop, PageInfographicDesktop,
+});

--- a/docs/recette/design/pages-poi.jsx
+++ b/docs/recette/design/pages-poi.jsx
@@ -1,0 +1,102 @@
+// pages-poi.jsx — POI Popover showcase (Variante A enrichie + B minimale, light + dark)
+
+function PagePOIPopoverDesktop({ w = 1280, h = 860 }) {
+  const t = useTheme();
+  return (
+    <div style={{ width:w, height:h, color:t.ink, fontFamily:t.sans, display:'flex', flexDirection:'column', overflow:'hidden', position:'relative' }}>
+      <div style={{ position:'absolute', inset:0, opacity:.3, zIndex:0 }}><OsmMap w={w} h={h}/></div>
+      <div style={{ position:'absolute', inset:0, zIndex:0, background:t.name==='dark'?'rgba(26,24,20,.75)':'rgba(250,247,240,.8)' }}/>
+      <div style={{ position:'relative', zIndex:1, display:'flex', flexDirection:'column', flex:1, minHeight:0 }}>
+        <TopBarDesktop/>
+        <div style={{ flex:1, overflowY:'auto', padding:'32px 48px' }}>
+          <h1 style={{ fontFamily:t.serif, fontSize:36, letterSpacing:-0.6, fontWeight:500, margin:'0 0 8px' }}>Popover POI culturel</h1>
+          <p style={{ fontSize:14, color:t.inkSoft, marginBottom:32, lineHeight:1.5 }}>Les POI culturels pulsent sur la carte pour inviter au clic. Deux variantes de popover selon la richesse des données.</p>
+
+          {/* Map demo with pulsating markers */}
+          <div style={{ marginBottom:32 }}>
+            <div style={{ fontSize:11.5, fontWeight:700, color:t.accent, letterSpacing:1, textTransform:'uppercase', marginBottom:10 }}>Carte — marqueurs pulsants (culturels) vs statiques (services)</div>
+            <div style={{ borderRadius:16, overflow:'hidden', border:`1px solid ${t.line}`, position:'relative', height:260 }}>
+              <OsmMap w={w-96} h={260} showPOI/>
+              {/* Legend overlay */}
+              <div style={{ position:'absolute', bottom:12, left:12, background:t.surface, border:`1px solid ${t.line}`, borderRadius:10, padding:'8px 12px', display:'flex', gap:14, fontSize:11, boxShadow:t.shadowSoft }}>
+                <div style={{ display:'flex', alignItems:'center', gap:5 }}>
+                  <div style={{ width:12, height:12, borderRadius:'50%', border:`2px solid ${t.accent}`, position:'relative' }}>
+                    <div style={{ position:'absolute', inset:-4, borderRadius:'50%', border:`1px solid ${t.accent}`, opacity:0.3 }}/>
+                  </div>
+                  <span style={{ color:t.inkSoft }}>POI culturel (pulsant)</span>
+                </div>
+                <div style={{ display:'flex', alignItems:'center', gap:5 }}>
+                  <div style={{ width:8, height:8, borderRadius:'50%', background:'#3d6b91' }}/>
+                  <span style={{ color:t.inkSoft }}>Service (statique)</span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Popover variants */}
+          <div style={{ display:'grid', gridTemplateColumns:'repeat(2,1fr)', gap:28 }}>
+            {/* Variante A */}
+            <div>
+              <div style={{ fontSize:11.5, fontWeight:700, color:t.accent, letterSpacing:1, textTransform:'uppercase', marginBottom:14 }}>Variante A — enrichie (Wikidata + DataTourisme)</div>
+              <div style={{ display:'flex', flexDirection:'column', gap:16 }}>
+                <div>
+                  <div style={{ fontSize:11, color:t.inkSoft, marginBottom:6 }}>État : ouvert</div>
+                  <POIPopoverRich/>
+                </div>
+                <div>
+                  <div style={{ fontSize:11, color:t.inkSoft, marginBottom:6 }}>État : fermé</div>
+                  <POIPopoverRichClosed/>
+                </div>
+              </div>
+            </div>
+
+            {/* Variante B */}
+            <div>
+              <div style={{ fontSize:11.5, fontWeight:700, color:t.accent, letterSpacing:1, textTransform:'uppercase', marginBottom:14 }}>Variante B — minimale (OSM seul)</div>
+              <div style={{ display:'flex', flexDirection:'column', gap:16 }}>
+                <div>
+                  <div style={{ fontSize:11, color:t.inkSoft, marginBottom:6 }}>Lieu de culte (pas de photo, pas d'horaires)</div>
+                  <POIPopoverMinimal/>
+                </div>
+                <div>
+                  <div style={{ fontSize:11, color:t.inkSoft, marginBottom:6 }}>Point de vue gratuit</div>
+                  <POIPopoverMinimalFree/>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Spec table */}
+          <div style={{ marginTop:32, background:t.surface, border:`1px solid ${t.line}`, borderRadius:14, padding:20 }}>
+            <div style={{ fontSize:12, fontWeight:700, color:t.accent, letterSpacing:1, textTransform:'uppercase', marginBottom:12 }}>Logique d'affichage</div>
+            <div style={{ display:'grid', gridTemplateColumns:'160px 1fr 1fr', gap:1, fontSize:12 }}>
+              {/* Header */}
+              <div style={{ padding:'8px 10px', fontWeight:700, background:t.surfaceAlt, borderRadius:'8px 0 0 0' }}>Donnée</div>
+              <div style={{ padding:'8px 10px', fontWeight:700, background:t.surfaceAlt }}>Variante A</div>
+              <div style={{ padding:'8px 10px', fontWeight:700, background:t.surfaceAlt, borderRadius:'0 8px 0 0' }}>Variante B</div>
+              {[
+                ['Photo (P18)', 'Wikimedia Commons', '—'],
+                ['Nom', 'Wikidata label', 'OSM name tag'],
+                ['Catégorie', 'Enrichie (château, musée…)', 'Tag OSM brut'],
+                ['Description', '2-3 lignes multilingues', '—'],
+                ['Horaires', 'Structurés + état actuel', '—'],
+                ['Prix', 'Estimé ou "Gratuit"', '—'],
+                ['Lien Wikipedia', '✓', '—'],
+                ['Bouton Naviguer', '✓', '✓'],
+              ].map(([label, a, b], i) => (
+                <React.Fragment key={i}>
+                  <div style={{ padding:'6px 10px', color:t.inkSoft, borderTop:`1px solid ${t.lineSoft}` }}>{label}</div>
+                  <div style={{ padding:'6px 10px', borderTop:`1px solid ${t.lineSoft}` }}>{a}</div>
+                  <div style={{ padding:'6px 10px', color: b === '—' ? t.inkMute : t.ink, borderTop:`1px solid ${t.lineSoft}` }}>{b}</div>
+                </React.Fragment>
+              ))}
+            </div>
+          </div>
+        </div>
+        <DesktopFooter/>
+      </div>
+    </div>
+  );
+}
+
+Object.assign(window, { PagePOIPopoverDesktop });

--- a/docs/recette/design/pages-roadbook.jsx
+++ b/docs/recette/design/pages-roadbook.jsx
@@ -1,0 +1,315 @@
+// pages-roadbook.jsx — Step 4 "Mon Voyage" roadbook with all P2 features
+// Sprint 24, 27, 28 features drawn as fully functional
+
+function PageRoadbookDesktop({ w = 1280, h = 860 }) {
+  const t = useTheme();
+  const [activeStage, setActiveStage] = React.useState(1);
+  const [aiChatOpen, setAiChatOpen] = React.useState(false);
+  const [showEvents, setShowEvents] = React.useState(false);
+  const stage = STAGES[activeStage];
+  const alerts = RICH_ALERTS[activeStage] || [];
+  const dayColors = [t.forest, t.accent, t.blue, t.rose];
+  const stageColor = dayColors[activeStage];
+
+  return (
+    <div style={{ width:w, height:h, background:t.bg, color:t.ink, fontFamily:t.sans, display:'flex', flexDirection:'column', overflow:'hidden', position:'relative' }}>
+      {/* Recomputation progress bar (Sprint 24) */}
+      <RecomputeBar progress={0}/>
+
+      <TopBarDesktop page="trips" showUndo showShare/>
+
+      {/* Trip header */}
+      <div style={{ padding:'14px 28px 12px', borderBottom:`1px solid ${t.line}`, display:'flex', justifyContent:'space-between', alignItems:'flex-start', flexShrink:0 }}>
+        <div>
+          <div style={{ display:'flex', alignItems:'center', gap:8, fontSize:12, color:t.inkSoft, marginBottom:4 }}>
+            <span>Mes voyages</span><span>›</span>
+            <span style={{ color:t.ink, fontWeight:500 }}>L'Odyssée des Eaux Royales</span>
+          </div>
+          <h1 style={{ fontFamily:t.serif, fontSize:28, letterSpacing:-0.6, fontWeight:500, margin:0, marginBottom:4 }}>{TRIP.title}</h1>
+          <div style={{ display:'flex', gap:12, fontSize:12.5, color:t.inkSoft, alignItems:'center', flexWrap:'wrap' }}>
+            <span>{TRIP.dateRange}</span>
+            <span>·</span><span>{TRIP.totalKm} km · +{TRIP.totalUp} m · {TRIP.days} étapes</span>
+            <span>·</span><Pill sm bg={t.accentSoft} color={t.accentInk}>{TRIP.level}</Pill>
+          </div>
+        </div>
+        {/* AI global summary (Sprint 27) */}
+        <div style={{ maxWidth:380, background:t.surfaceAlt, border:`1px solid ${t.line}`, borderRadius:12, padding:'10px 14px', display:'flex', gap:8, alignItems:'flex-start' }}>
+          <div style={{ width:24, height:24, borderRadius:6, background:t.accent, display:'flex', alignItems:'center', justifyContent:'center', flexShrink:0, marginTop:1 }}>
+            {React.cloneElement(I.sparkle,{width:11,height:11,color:'#fff'})}
+          </div>
+          <p style={{ fontFamily:t.serif, fontSize:12.5, fontStyle:'italic', lineHeight:1.55, color:t.ink, margin:0 }}>
+            Un parcours varié entre polders flamands et collines de l'Escaut, idéal pour 4 jours de bikepacking paisibles avec hébergements de charme.
+          </p>
+        </div>
+      </div>
+
+      <div style={{ display:'grid', gridTemplateColumns:'280px 1fr 360px', flex:1, minHeight:0 }}>
+        {/* LEFT — vertical timeline */}
+        <div style={{ borderRight:`1px solid ${t.line}`, overflowY:'auto', padding:'14px 12px', background:t.surface }}>
+          <div style={{ fontSize:10.5, fontWeight:600, color:t.inkSoft, textTransform:'uppercase', letterSpacing:0.5, padding:'4px 8px 10px' }}>Étapes</div>
+          {STAGES.map((s, i) => {
+            const a = i === activeStage;
+            const c = dayColors[i];
+            const isLast = i === STAGES.length - 1;
+            return (
+              <div key={i}>
+                <div onClick={() => setActiveStage(i)} style={{ display:'flex', gap:10, paddingBottom:isLast?0:2, cursor:'pointer' }}>
+                  {/* Timeline */}
+                  <div style={{ display:'flex', flexDirection:'column', alignItems:'center', flexShrink:0 }}>
+                    <div style={{ width:30, height:30, borderRadius:'50%', background:c, color:'#fff', display:'flex', alignItems:'center', justifyContent:'center', fontWeight:700, fontSize:13, zIndex:1, boxShadow:a?`0 0 0 3px ${c}40`:'none', transition:'box-shadow 0.15s' }}>{s.day}</div>
+                    {!isLast && <div style={{ width:2, flex:1, background:t.line, minHeight:20, margin:'3px 0' }}/>}
+                  </div>
+                  {/* Stage info */}
+                  <div style={{ flex:1, padding:'4px 8px 14px', borderRadius:9, background:a?t.surfaceAlt:'transparent', border:a?`1px solid ${t.line}`:'1px solid transparent' }}>
+                    <div style={{ fontSize:11.5, fontWeight:600, color:a?t.ink:t.inkSoft, lineHeight:1.2, marginBottom:2 }}>{s.from} → {s.to}</div>
+                    <div style={{ fontSize:10.5, color:t.inkMute }}>{s.date} · {s.km} km · +{s.up} m</div>
+                    <div style={{ display:'flex', gap:4, marginTop:5 }}>
+                      {(RICH_ALERTS[i]||[]).slice(0,3).map((al,j) => {
+                        const cm = {critical:t.red,warning:t.accent,nudge:t.blue}[al.sev];
+                        return <span key={j} style={{ width:5,height:5,borderRadius:'50%',background:cm }}/>;
+                      })}
+                    </div>
+                  </div>
+                </div>
+                {/* "+ Ajouter étape / repos" between stages */}
+                {!isLast && (
+                  <div style={{ display:'flex', gap:4, marginLeft:40, marginBottom:4, opacity:0.4 }}>
+                    <span style={{ fontSize:10, color:t.accent, cursor:'pointer', padding:'1px 6px', border:`1px dashed ${t.accent}`, borderRadius:4 }}>+ étape</span>
+                    <span style={{ fontSize:10, color:t.inkSoft, cursor:'pointer', padding:'1px 6px', border:`1px dashed ${t.line}`, borderRadius:4 }}>🛏 repos</span>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        {/* CENTER — OSM map with elev under */}
+        <div style={{ display:'flex', flexDirection:'column', overflow:'hidden' }}>
+          <div style={{ flex:1, position:'relative', overflow:'hidden' }}>
+            <OsmMap w={640} h={h-310} active={activeStage} showPOI/>
+            {/* Map controls */}
+            <div style={{ position:'absolute', top:12, right:12, display:'flex', flexDirection:'column', gap:4 }}>
+              <div style={{ background:t.surface, border:`1px solid ${t.line}`, borderRadius:7, padding:6, fontSize:12, fontFamily:t.mono, color:t.inkSoft, boxShadow:t.shadowSoft, fontSize:10.5 }}>50.742°N 3.602°E</div>
+              {['+','−'].map((x,i)=>(
+                <div key={i} style={{ width:30,height:30,background:t.surface,border:`1px solid ${t.line}`,borderRadius:7,display:'flex',alignItems:'center',justifyContent:'center',fontSize:16,fontWeight:500,color:t.ink,cursor:'pointer',boxShadow:t.shadowSoft }}>{x}</div>
+              ))}
+            </div>
+            {/* Map view toggle */}
+            <div style={{ position:'absolute', top:12, left:12, display:'flex', gap:3, background:t.surface, border:`1px solid ${t.line}`, borderRadius:8, padding:3, boxShadow:t.shadowSoft }}>
+              {['Carte','Satellite'].map((x,i)=>(
+                <div key={x} style={{ padding:'4px 10px', borderRadius:5, fontSize:11, fontWeight:600, background:i===0?t.ink:'transparent', color:i===0?t.bg:t.inkSoft, cursor:'pointer' }}>{x}</div>
+              ))}
+            </div>
+          </div>
+          {/* Elevation profile */}
+          <div style={{ borderTop:`1px solid ${t.line}`, padding:'10px 16px', background:t.surface, flexShrink:0 }}>
+            <div style={{ display:'flex', justifyContent:'space-between', marginBottom:5 }}>
+              <span style={{ fontSize:12, fontWeight:600 }}>Profil altimétrique — {stage.from} → {stage.to}</span>
+              <span style={{ fontSize:10.5, color:t.inkMute, fontFamily:t.mono }}>alt. max 142 m</span>
+            </div>
+            <ElevProfile w={608} h={64} up={stage.up} down={stage.down} distance={stage.km} showMarkers/>
+            <div style={{ display:'flex', justifyContent:'space-between', fontSize:9.5, color:t.inkMute, fontFamily:t.mono, marginTop:3 }}>
+              <span>0 km</span><span>10</span><span>20</span><span>30</span><span>{stage.km} km</span>
+            </div>
+          </div>
+          {/* Supply timeline */}
+          <div style={{ padding:'10px 16px', borderTop:`1px solid ${t.line}`, background:t.surfaceAlt, flexShrink:0 }}>
+            <SupplyTimeline stageKm={stage.km}/>
+          </div>
+        </div>
+
+        {/* RIGHT — stage detail */}
+        <div style={{ overflowY:'auto', borderLeft:`1px solid ${t.line}`, background:t.surfaceAlt, display:'flex', flexDirection:'column', gap:10, padding:'16px 16px' }}>
+          {/* Stage header */}
+          <div style={{ display:'flex', gap:8, alignItems:'center', marginBottom:4 }}>
+            <Pill bg={stageColor} color="#fff" bold>JOUR {stage.day}</Pill>
+            <span style={{ fontSize:12, color:t.inkSoft }}>{stage.date}</span>
+            {/* Downloads dropdown */}
+            <div style={{ marginLeft:'auto', display:'flex', gap:4 }}>
+              {['GPX','FIT'].map((x,i)=>(
+                <div key={i} style={{ padding:'3px 7px', background:t.surface, border:`1px solid ${t.line}`, borderRadius:5, fontSize:10, fontWeight:600, color:t.inkSoft, cursor:'pointer', display:'flex', alignItems:'center', gap:3 }}>
+                  <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M12 3v13M6 11l6 6 6-6"/><path d="M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-2"/></svg>
+                  {x}
+                </div>
+              ))}
+            </div>
+          </div>
+          <div style={{ fontFamily:t.serif, fontSize:20, fontWeight:500, letterSpacing:-0.3 }}>{stage.from} → {stage.to}</div>
+
+          {/* AI stage summary (Sprint 27) */}
+          <AISummaryCard text="Étape facile à travers le bassin minier rénové, avec une belle remontée vers les Flandres belges sur les derniers 10 km. Surface 64 % asphalte, 36 % gravier — chaussures renforcées recommandées."/>
+
+          {/* Key metrics + editable distance */}
+          <div style={{ display:'grid', gridTemplateColumns:'repeat(4,1fr)', gap:6 }}>
+            {[
+              { l:'KM', v:stage.km, accent:true, editable:true },
+              { l:'D+', v:`+${stage.up}m` },
+              { l:'DEP', v:stage.dep },
+              { l:'ETA', v:stage.arr },
+            ].map((m,i)=>(
+              <div key={i} style={{ padding:'9px 10px', background:t.surface, borderRadius:10, border:`1px solid ${m.accent?t.accent:t.line}` }}>
+                <div style={{ fontSize:9, color:t.inkSoft, fontWeight:600, letterSpacing:0.4, textTransform:'uppercase' }}>{m.l}</div>
+                <div style={{ fontFamily:t.serif, fontSize:18, fontWeight:500, letterSpacing:-0.3, marginTop:2, display:'flex', alignItems:'center', gap:4 }}>
+                  {m.v}
+                  {m.editable && React.cloneElement(I.edit,{width:11,height:11,color:t.inkMute})}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* Difficulty gauge */}
+          <DifficultyGauge score={activeStage===2?78:activeStage===1?52:30}/>
+
+          {/* Enhanced weather */}
+          <WeatherCard weather={stage.weather} stageKm={stage.km}/>
+
+          {/* Alerts grouped by severity */}
+          <div>
+            <div style={{ fontSize:11, fontWeight:600, color:t.inkSoft, letterSpacing:0.4, textTransform:'uppercase', marginBottom:6 }}>Alertes ({alerts.length})</div>
+            <AlertGroup alerts={alerts}/>
+          </div>
+
+          {/* Events panel (collapsible) */}
+          <div>
+            <div onClick={()=>setShowEvents(!showEvents)} style={{ display:'flex', alignItems:'center', gap:6, cursor:'pointer', padding:'8px 10px', background:t.surface, border:`1px solid ${t.line}`, borderRadius:9 }}>
+              <span style={{ fontSize:12.5, fontWeight:600, flex:1 }}>Événements locaux</span>
+              <Pill sm bg={t.blueSoft} color={t.blue} bold>2</Pill>
+              <span style={{ color:t.inkMute, transform:showEvents?'rotate(90deg)':'none', display:'flex', transition:'transform 0.15s' }}>{I.chevron}</span>
+            </div>
+            {showEvents && (
+              <div style={{ background:t.surface, border:`1px solid ${t.line}`, borderTop:'none', borderRadius:'0 0 9px 9px', padding:'8px 12px' }}>
+                <div style={{ fontSize:12, color:t.ink, marginBottom:4 }}>🎪 Marché de Tournai — sam. 15 mai · 08h–13h</div>
+                <div style={{ fontSize:12, color:t.ink }}>🎵 Festival Banlieues Bleues — 14-17 mai</div>
+              </div>
+            )}
+          </div>
+
+          {/* Accommodations inline (9 types) */}
+          <div>
+            <div style={{ fontSize:11, fontWeight:600, color:t.inkSoft, letterSpacing:0.4, textTransform:'uppercase', marginBottom:6 }}>Hébergements</div>
+            {/* Selected */}
+            {stage.lodging && (
+              <div style={{ display:'flex', gap:10, padding:'10px 12px', border:`1.5px solid ${t.accent}`, borderRadius:10, background:t.accentSofter, marginBottom:6 }}>
+                <div style={{ width:34, height:34, borderRadius:9, background:t.accent, color:'#fff', display:'flex', alignItems:'center', justifyContent:'center', flexShrink:0, fontSize:16 }}>
+                  {ACC_TYPES.guest_house.icon}
+                </div>
+                <div style={{ flex:1 }}>
+                  <div style={{ fontSize:13, fontWeight:600 }}>{stage.lodging.name}</div>
+                  <div style={{ fontSize:11, color:t.inkSoft, marginTop:1 }}>{stage.lodging.type} · {stage.lodging.dist} · ⭐ {stage.lodging.rating}</div>
+                </div>
+                <div style={{ textAlign:'right' }}>
+                  <div style={{ fontSize:13, fontWeight:700, color:t.accent }}>{stage.lodging.price}</div>
+                </div>
+              </div>
+            )}
+            {/* Other suggestions */}
+            {[
+              { n:'Ibis Budget', type:'hotel', price:'€55', dist:'1,4 km' },
+              { n:'Camping Municipal', type:'camp_site', price:'€12', dist:'2,1 km' },
+              { n:'Refuge du Chemin', type:'wilderness_hut', price:'€0-10', dist:'3,8 km' },
+            ].map((o,i)=>(
+              <div key={i} style={{ display:'flex', gap:8, padding:'7px 10px', border:`1px solid ${t.lineSoft}`, borderRadius:8, background:t.surface, marginBottom:3, opacity:0.6 }}>
+                <span style={{ fontSize:14, flexShrink:0 }}>{ACC_TYPES[o.type]?.icon}</span>
+                <div style={{ flex:1 }}>
+                  <div style={{ fontSize:11.5, fontWeight:500 }}>{o.n}</div>
+                  <div style={{ fontSize:10, color:t.inkMute }}>{ACC_TYPES[o.type]?.label} · {o.dist}</div>
+                </div>
+                <span style={{ fontSize:11.5, color:t.inkMute, flexShrink:0 }}>{o.price}</span>
+              </div>
+            ))}
+            <div style={{ display:'flex', gap:6, marginTop:6 }}>
+              <span style={{ fontSize:11, color:t.accent, fontWeight:600, cursor:'pointer' }}>› Élargir la zone (5 km)</span>
+              <span style={{ fontSize:11, color:t.inkMute }}>·</span>
+              <span style={{ fontSize:11, color:t.accent, fontWeight:600, cursor:'pointer' }}>+ Ajouter manuellement</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* AI chat bubble (Sprint 28) */}
+      <AIChatBubble/>
+
+      <DesktopFooter/>
+    </div>
+  );
+}
+
+// ─── Public shared view (read-only) ──────────────────────────────────────────
+function PagePublicSharedDesktop({ w = 1280, h = 860 }) {
+  const t = useTheme();
+  return (
+    <div style={{ width:w, height:h, color:t.ink, fontFamily:t.sans, display:'flex', flexDirection:'column', overflow:'hidden', position:'relative' }}>
+      <div style={{ position:'absolute', inset:0, opacity:.3, zIndex:0 }}><OsmMap w={w} h={h}/></div>
+      <div style={{ position:'absolute', inset:0, zIndex:0, background:t.name==='dark'?'rgba(26,24,20,.75)':'rgba(250,247,240,.8)' }}/>
+      <div style={{ position:'relative', zIndex:1, display:'flex', flexDirection:'column', flex:1, minHeight:0 }}>
+      {/* Read-only banner */}
+      <div style={{ background:t.name==='dark'?'#1d2a3d':'#dde8f0', borderBottom:`1px solid ${t.blue}30`, padding:'7px 24px', display:'flex', alignItems:'center', gap:8, fontSize:12.5, color:t.blue, flexShrink:0 }}>
+        {React.cloneElement(I.share,{width:13,height:13})}
+        <span><strong>Vue partagée en lecture seule</strong> — vous consultez un itinéraire partagé par Noé Fritz.</span>
+      </div>
+
+      {/* Simplified top bar */}
+      <div style={{ display:'flex', alignItems:'center', justifyContent:'space-between', padding:'12px 24px', borderBottom:`1px solid ${t.line}`, background:t.bg }}>
+        <div style={{ display:'flex', alignItems:'center', gap:10 }}>
+          <Logo size={26}/>
+          <span style={{ fontSize:14, fontWeight:600, color:t.ink }}>Bike Trip Planner</span>
+        </div>
+        <div style={{ display:'flex', gap:8 }}>
+          <Btn variant="ghost" size="sm" icon={I.download}>Télécharger GPX</Btn>
+          <Btn variant="ghost" size="sm" icon={I.download}>Télécharger FIT</Btn>
+        </div>
+      </div>
+
+      {/* Hero map */}
+      <div style={{ position:'relative', height:280, overflow:'hidden', flexShrink:0 }}>
+        <OsmMap w={w} h={280}/>
+        <div style={{ position:'absolute', inset:0, background:t.name==='dark'?'linear-gradient(180deg,rgba(10,8,5,0)40%,rgba(10,8,5,0.9))':'linear-gradient(180deg,rgba(250,247,240,0)40%,rgba(250,247,240,0.92))' }}/>
+        <div style={{ position:'absolute', bottom:20, left:48, right:48, display:'flex', justifyContent:'space-between', alignItems:'flex-end' }}>
+          <div>
+            <h1 style={{ fontFamily:t.serif, fontSize:38, fontWeight:500, letterSpacing:-0.7, margin:0 }}>{TRIP.title}</h1>
+            <div style={{ fontSize:14, color:t.inkSoft, marginTop:6 }}>Lille → Gand · {TRIP.totalKm} km · {TRIP.days} jours · {TRIP.dateRange}</div>
+          </div>
+          <div style={{ display:'flex', gap:20 }}>
+            {[{v:TRIP.totalKm,u:'km'},{v:`+${TRIP.totalUp}`,u:'m D+'},{v:TRIP.days,u:'étapes'}].map((m,i)=>(
+              <div key={i} style={{ textAlign:'center' }}>
+                <div style={{ fontFamily:t.serif, fontSize:26, fontWeight:500, letterSpacing:-0.5 }}>{m.v}</div>
+                <div style={{ fontSize:10, color:t.inkSoft, textTransform:'uppercase', letterSpacing:0.5, marginTop:3 }}>{m.u}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Stages */}
+      <div style={{ flex:1, overflowY:'auto', padding:'24px 48px' }}>
+        <div style={{ fontSize:11.5, fontWeight:600, color:t.accent, letterSpacing:1, textTransform:'uppercase', marginBottom:14 }}>Itinéraire</div>
+        <div style={{ display:'grid', gridTemplateColumns:'repeat(4,1fr)', gap:14 }}>
+          {STAGES.map((s,i) => {
+            const c = [t.forest,t.accent,t.blue,t.rose][i];
+            return (
+              <div key={i} style={{ background:t.surface, border:`1px solid ${t.line}`, borderRadius:14, overflow:'hidden' }}>
+                <div style={{ height:4, background:c }}/>
+                <div style={{ padding:'14px 14px 12px' }}>
+                  <div style={{ display:'flex', gap:6, alignItems:'center', marginBottom:8 }}>
+                    <div style={{ width:24,height:24,borderRadius:7,background:c,color:'#fff',fontSize:12,fontWeight:700,display:'flex',alignItems:'center',justifyContent:'center' }}>{s.day}</div>
+                    <span style={{ fontSize:11, color:t.inkSoft }}>{s.date}</span>
+                  </div>
+                  <div style={{ fontFamily:t.serif, fontSize:16, fontWeight:500, letterSpacing:-0.2, lineHeight:1.2, marginBottom:6 }}>{s.from} → {s.to}</div>
+                  <ElevProfile w={200} h={38} up={s.up} down={s.down} distance={s.km} color={c}/>
+                  <div style={{ display:'grid', gridTemplateColumns:'1fr 1fr', gap:4, marginTop:8, fontSize:11 }}>
+                    <div><b style={{ fontSize:14, fontFamily:t.serif }}>{s.km}</b> <span style={{ color:t.inkMute }}>km</span></div>
+                    <div><b style={{ fontSize:14, fontFamily:t.serif }}>+{s.up}</b> <span style={{ color:t.inkMute }}>m</span></div>
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+      <DesktopFooter/>
+      </div>
+    </div>
+  );
+}
+
+Object.assign(window, { PageRoadbookDesktop, PagePublicSharedDesktop });

--- a/docs/recette/design/pages-trips.jsx
+++ b/docs/recette/design/pages-trips.jsx
@@ -1,0 +1,64 @@
+// pages-trips.jsx — Trips list + (PageRoadbookDesktop now in pages-roadbook.jsx)
+
+// ─── Trips list ──────────────────────────────────────────────────────────────
+function PageTripsListDesktop({ w = 1280, h = 860 }) {
+  const t = useTheme();
+  const trips = [
+    { title:"L'Odyssée des Eaux Royales", from:'Lille', to:'Gand', km:143, days:4, when:'14 – 17 mai 2026', status:'active' },
+    { title:"Côte d'Opale — escapade", from:'Boulogne', to:'Bray-Dunes', km:86, days:2, when:'5 – 6 avril 2026', status:'done' },
+    { title:"Loire à Vélo — segment 3", from:'Blois', to:'Saumur', km:214, days:5, when:'12 – 16 juin 2026', status:'draft' },
+    { title:"Tour des Flandres amateur", from:'Gand', to:'Bruges', km:98, days:2, when:'22 – 23 juillet', status:'archived' },
+  ];
+  const badge = { active:{l:'En cours',c:t.green,bg:t.greenSoft}, done:{l:'Terminé',c:t.inkSoft,bg:t.surfaceAlt}, draft:{l:'Brouillon',c:t.accent,bg:t.accentSoft}, archived:{l:'Archivé',c:t.inkMute,bg:t.surfaceAlt} };
+
+  const MapBg = () => (
+    <>
+      <div style={{ position:'absolute', inset:0, opacity:.3, zIndex:0 }}><OsmMap w={w} h={h}/></div>
+      <div style={{ position:'absolute', inset:0, zIndex:0, background:t.name==='dark'?'rgba(26,24,20,.75)':'rgba(250,247,240,.8)' }}/>
+    </>
+  );
+
+  return (
+    <div style={{ width:w, height:h, color:t.ink, fontFamily:t.sans, display:'flex', flexDirection:'column', overflow:'hidden', position:'relative' }}>
+      <MapBg/>
+      <div style={{ position:'relative', zIndex:1, display:'flex', flexDirection:'column', flex:1, minHeight:0 }}>
+        <TopBarDesktop page="trips"/>
+        <div style={{ padding:'28px 48px 14px', display:'flex', alignItems:'flex-end', justifyContent:'space-between' }}>
+          <h1 style={{ fontFamily:t.serif, fontSize:40, letterSpacing:-0.7, fontWeight:500, margin:0 }}>Mes voyages</h1>
+          <div style={{ display:'flex', gap:8 }}>
+            <div style={{ display:'flex', alignItems:'center', gap:6, padding:'9px 14px', background:t.surface, border:`1px solid ${t.line}`, borderRadius:9, fontSize:13, color:t.inkMute }}>
+              {I.search}<span>Rechercher un voyage…</span>
+            </div>
+            <Btn variant="ghost" icon={I.filter}>Filtrer par date</Btn>
+            <Btn variant="accent" icon={I.plus}>Nouveau voyage</Btn>
+          </div>
+        </div>
+        <div style={{ padding:'6px 48px 16px', display:'grid', gridTemplateColumns:'repeat(2,1fr)', gap:16, flex:1, minHeight:0, overflowY:'auto', alignContent:'start' }}>
+          {trips.map((tr,i) => {
+            const b = badge[tr.status];
+            return (
+              <div key={i} style={{ background:t.surface, border:`1px solid ${t.line}`, borderRadius:16, overflow:'hidden', display:'flex', boxShadow:t.shadowSoft }}>
+                <div style={{ width:190, flexShrink:0 }}><OsmMap w={190} h={200}/></div>
+                <div style={{ flex:1, padding:'16px 18px', display:'flex', flexDirection:'column' }}>
+                  <div style={{ display:'flex', justifyContent:'space-between', alignItems:'start', marginBottom:6 }}>
+                    <Pill sm bg={b.bg} color={b.c} bold>{b.l}</Pill>
+                    <div style={{ color:t.inkMute, display:'flex' }}>{I.moreH}</div>
+                  </div>
+                  <div style={{ fontFamily:t.serif, fontSize:18, letterSpacing:-0.3, fontWeight:500, lineHeight:1.15, marginBottom:5 }}>{tr.title}</div>
+                  <div style={{ fontSize:12, color:t.inkSoft, marginBottom:12 }}>{tr.from} → {tr.to} · {tr.when}</div>
+                  <div style={{ display:'flex', gap:16, fontSize:11, color:t.inkSoft, marginTop:'auto', paddingTop:10, borderTop:`1px solid ${t.lineSoft}` }}>
+                    <span><b style={{ color:t.ink, fontSize:13 }}>{tr.km}</b> km</span>
+                    <span><b style={{ color:t.ink, fontSize:13 }}>{tr.days}</b> jours</span>
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+        <DesktopFooter/>
+      </div>
+    </div>
+  );
+}
+
+Object.assign(window, { PageTripsListDesktop });

--- a/docs/recette/design/pages-wizard.jsx
+++ b/docs/recette/design/pages-wizard.jsx
@@ -1,0 +1,435 @@
+// pages-wizard.jsx — 4 Wizard steps: Préparation · Aperçu · Analyse · Mon Voyage
+// P0 fixes: AI chat multi-turn, narrative progression, 3 presets, Leaflet map
+
+// ──────────────────────────────────────────────────────────────────────────────
+// STEP 1 — PRÉPARATION : Lien · GPX · AI Chat multi-tours
+// ──────────────────────────────────────────────────────────────────────────────
+function PageTripsNewDesktop({ w = 1280, h = 860 }) {
+  const t = useTheme();
+  const [mode, setMode] = React.useState('link'); // 'link' | 'gpx' | 'ai'
+  const [urlVal, setUrlVal] = React.useState('https://www.komoot.com/tour/2847193');
+  const [gpxState, setGpxState] = React.useState('idle'); // idle | hover | uploading | success | error
+  const [aiMessages, setAiMessages] = React.useState([
+    { role:'assistant', text:'Bonjour ! Décrivez votre envie et je composerai un itinéraire sur mesure. Longueur, région, niveau, nombre de jours, préférences hébergement…' },
+    { role:'user', text:'3 jours à vélo depuis Lille, ~50 km/j, collines flamandes, je veux dormir en gîtes.' },
+    { role:'assistant', text:'Voici ce que je propose :\n\n**J1 · Lille → Tournai** · 48 km · +340 m · Gîte du Moulin à Eau\n**J2 · Tournai → Oudenaarde** · 52 km · +680 m · Chambre d\'hôtes Au Fil de l\'Escaut\n**J3 · Oudenaarde → Gand** · 38 km · +210 m · Arrivée en centre-ville\n\nTotal : 138 km · +1 230 m D+. Souhaitez-vous ajuster une étape ?' },
+    { role:'user', text:'Peux-tu rallonger le J1 jusqu\'à 55 km ?' },
+    { role:'assistant', text:'J1 mis à jour : **Lille → Tournai via Roubaix** · 56 km · +412 m — la variante passe par le Parc de la Ferme Dupire et longe la Marque sur 8 km. Gîte conservé. Voulez-vous valider cet itinéraire ?' },
+  ]);
+
+  const tabStyle = (k) => ({
+    flex:1, padding:'10px 16px', borderRadius:9, fontSize:13, fontWeight:600,
+    background: mode===k ? t.surface : 'transparent',
+    color: mode===k ? t.ink : t.inkSoft,
+    textAlign:'center', cursor:'pointer',
+    boxShadow: mode===k ? t.shadowSoft : 'none',
+    display:'flex', alignItems:'center', justifyContent:'center', gap:6,
+    transition:'all 0.15s',
+  });
+
+  const gpxStateUI = {
+    idle:      { border: `2px dashed ${t.line}`,   bg: t.surfaceAlt, icon: I.upload,    label:'Glissez un fichier .gpx',    sub:'ou cliquez pour parcourir · 30 Mo max' },
+    hover:     { border: `2px dashed ${t.accent}`, bg: t.accentSofter, icon: I.upload,  label:'Déposez votre fichier',        sub:'GPX détecté' },
+    uploading: { border: `2px dashed ${t.line}`,   bg: t.surfaceAlt, icon: I.loader,    label:'Import en cours…',            sub:'2,3 Mo · 142 points GPS' },
+    success:   { border: `2px solid ${t.green}`,   bg: t.greenSoft,  icon: I.check,     label:'sortie-lombardie.gpx importé', sub:'182 km · +1 280 m D+' },
+    error:     { border: `2px solid ${t.red}`,     bg: t.redSoft,    icon: I.alert,     label:'Fichier non reconnu',          sub:'Format GPX requis · taille max 30 Mo' },
+  };
+  const gpxUI = gpxStateUI[gpxState];
+
+  return (
+    <div style={{ width:w, height:h, background:t.bg, color:t.ink, fontFamily:t.sans, display:'flex', flexDirection:'column', overflow:'hidden' }}>
+      <TopBarDesktop page="new"/>
+      <div style={{ display:'flex', flex:1, minHeight:0 }}>
+        <WizardStepper active={1} t={t}/>
+        <div style={{ flex:1, display:'flex', flexDirection:'column', minHeight:0 }}>
+          <div style={{ flex:1, overflowY:'auto', padding:'36px 56px' }}>
+            <div style={{ maxWidth:640 }}>
+              <h1 style={{ fontFamily:t.serif, fontSize:38, letterSpacing:-0.7, fontWeight:500, margin:0, marginBottom:8, lineHeight:1.1 }}>D'où vient votre tracé ?</h1>
+              <p style={{ fontSize:14, color:t.inkSoft, marginBottom:28, lineHeight:1.55 }}>Collez un lien, importez un GPX, ou laissez l'IA générer votre itinéraire en dialogue.</p>
+
+              {/* Source selector */}
+              <div style={{ display:'flex', gap:3, background:t.surfaceAlt, padding:4, borderRadius:12, marginBottom:28 }}>
+                <div onClick={()=>setMode('link')} style={tabStyle('link')}>{I.link} Lien URL</div>
+                <div onClick={()=>setMode('gpx')} style={tabStyle('gpx')}>{I.upload} Fichier GPX</div>
+                <div onClick={()=>setMode('ai')} style={{ ...tabStyle('ai'), color: mode==='ai' ? t.accent : t.inkSoft, borderBottom: mode==='ai' ? `2px solid ${t.accent}` : 'none' }}>
+                  {React.cloneElement(I.sparkle,{width:14,height:14,color:mode==='ai'?t.accent:t.inkSoft})} Assistant IA
+                </div>
+              </div>
+
+              {/* --- LINK MODE --- */}
+              {mode === 'link' && (
+                <div>
+                  <div style={{ fontSize:11, color:t.inkSoft, fontWeight:600, marginBottom:6 }}>URL Komoot · RideWithGPS · Strava — détection automatique</div>
+                  <div style={{ display:'flex', alignItems:'center', gap:8, padding:'11px 14px', background:t.surface, border:`1.5px solid ${t.accent}`, borderRadius:10, marginBottom:10 }}>
+                    <span style={{ color:t.accent, display:'flex' }}>{I.link}</span>
+                    <span style={{ fontSize:13.5, fontFamily:t.mono, flex:1, color:t.ink, overflow:'hidden', textOverflow:'ellipsis', whiteSpace:'nowrap' }}>{urlVal}</span>
+                  </div>
+                  {/* Detection badge */}
+                  <div style={{ display:'inline-flex', alignItems:'center', gap:6, padding:'4px 10px', background:t.greenSoft, borderRadius:6, marginBottom:16 }}>
+                    {React.cloneElement(I.check,{width:12,height:12,color:t.green})}
+                    <span style={{ fontSize:11.5, color:t.green, fontWeight:600 }}>Komoot Tour détecté</span>
+                  </div>
+                  {/* Route preview */}
+                  <div style={{ background:t.surface, border:`1px solid ${t.line}`, borderRadius:12, overflow:'hidden', marginBottom:24, display:'flex' }}>
+                    <div style={{ width:180, flexShrink:0 }}><OsmMap w={180} h={130} simplified/></div>
+                    <div style={{ flex:1, padding:'14px 16px' }}>
+                      <div style={{ fontFamily:t.serif, fontSize:18, fontWeight:500, letterSpacing:-0.3, marginBottom:4 }}>Flandres côtières</div>
+                      <div style={{ fontSize:12, color:t.inkSoft, marginBottom:8 }}>182 km · +1 280 m · 4 étapes suggérées</div>
+                      <div style={{ display:'flex', gap:6 }}>
+                        <Pill sm bg={t.accentSoft} color={t.accentInk}>Bitume 74 %</Pill>
+                        <Pill sm bg={t.surfaceAlt} color={t.inkSoft}>Gravier 22 %</Pill>
+                        <Pill sm bg={t.accentSoft} color={t.accentInk}>Intermédiaire</Pill>
+                      </div>
+                    </div>
+                  </div>
+                  <Btn variant="accent" size="lg" full icon={React.cloneElement(I.chevron,{width:14,height:14})}>Continuer — Aperçu</Btn>
+                </div>
+              )}
+
+              {/* --- GPX MODE --- */}
+              {mode === 'gpx' && (
+                <div>
+                  <div onClick={()=>setGpxState(gpxState==='idle'?'hover':gpxState==='hover'?'uploading':gpxState==='uploading'?'success':gpxState==='success'?'error':'idle')}
+                    style={{ border:gpxUI.border, borderRadius:14, padding:'36px 24px', textAlign:'center', background:gpxUI.bg, cursor:'pointer', transition:'all 0.2s', marginBottom:16 }}>
+                    <div style={{ width:52, height:52, borderRadius:14, background:t.surface, color: gpxState==='success'?t.green:gpxState==='error'?t.red:t.inkSoft, display:'flex', alignItems:'center', justifyContent:'center', margin:'0 auto 14px', boxShadow:t.shadowSoft }}>
+                      {React.cloneElement(gpxState==='uploading'?I.loader:gpxUI.icon, { width:24, height:24, className: gpxState==='uploading'?'spin':'' })}
+                    </div>
+                    <div style={{ fontSize:14, fontWeight:600, color:t.ink, marginBottom:4 }}>{gpxUI.label}</div>
+                    <div style={{ fontSize:12, color:t.inkSoft }}>{gpxUI.sub}</div>
+                    {gpxState==='uploading' && (
+                      <div style={{ marginTop:12, height:4, background:t.surfaceAlt, borderRadius:2, overflow:'hidden', width:200, margin:'12px auto 0' }}>
+                        <div style={{ width:'60%', height:'100%', background:t.accent, borderRadius:2, animation:'pulse 1s infinite' }}/>
+                      </div>
+                    )}
+                  </div>
+                  <div style={{ fontSize:11, color:t.inkMute, textAlign:'center', marginBottom:24 }}>Cliquez sur la zone pour simuler les états (idle → hover → uploading → succès → erreur)</div>
+                  {gpxState === 'success' && (
+                    <Btn variant="accent" size="lg" full>Continuer — Aperçu</Btn>
+                  )}
+                </div>
+              )}
+
+              {/* --- AI CHAT MODE (multi-turn) --- */}
+              {mode === 'ai' && (
+                <div style={{ background:t.surface, border:`1.5px solid ${t.accent}`, borderRadius:16, overflow:'hidden' }}>
+                  {/* Chat header */}
+                  <div style={{ padding:'12px 16px', background:t.accentSofter, borderBottom:`1px solid ${t.accent}30`, display:'flex', alignItems:'center', gap:8 }}>
+                    <div style={{ width:28, height:28, borderRadius:8, background:t.accent, display:'flex', alignItems:'center', justifyContent:'center' }}>
+                      {React.cloneElement(I.sparkle,{width:14,height:14,color:'#fff'})}
+                    </div>
+                    <div>
+                      <div style={{ fontSize:13, fontWeight:600, color:t.accentInk }}>Assistant IA · Génération d'itinéraire</div>
+                      <div style={{ fontSize:10.5, color:t.accentInk, opacity:0.75 }}>Dialogue multi-tours · LLaMA 8B · contextualisé</div>
+                    </div>
+                  </div>
+
+                  {/* Messages history */}
+                  <div style={{ maxHeight:280, overflowY:'auto', padding:'14px 16px', display:'flex', flexDirection:'column', gap:10 }}>
+                    {aiMessages.map((m, i) => (
+                      <div key={i} style={{ display:'flex', gap:8, alignItems:'flex-start', flexDirection: m.role==='user'?'row-reverse':'row' }}>
+                        {m.role==='assistant' && (
+                          <div style={{ width:24, height:24, borderRadius:'50%', background:t.accent, flexShrink:0, display:'flex', alignItems:'center', justifyContent:'center', marginTop:2 }}>
+                            {React.cloneElement(I.sparkle,{width:10,height:10,color:'#fff'})}
+                          </div>
+                        )}
+                        <div style={{
+                          maxWidth:'80%', padding:'9px 12px', borderRadius:11,
+                          background: m.role==='user' ? t.ink : t.surfaceAlt,
+                          color: m.role==='user' ? t.bg : t.ink,
+                          fontSize:12.5, lineHeight:1.55,
+                          borderBottomRightRadius: m.role==='user'?2:11,
+                          borderBottomLeftRadius: m.role==='assistant'?2:11,
+                        }}>
+                          {m.text.split('\n').map((line,j) => (
+                            <div key={j} style={{ minHeight: line===''?8:undefined }}>
+                              {line.startsWith('**') ? <strong>{line.replace(/\*\*/g,'')}</strong> : line}
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+
+                  {/* Input area */}
+                  <div style={{ padding:'10px 12px', borderTop:`1px solid ${t.line}`, background:t.bg, display:'flex', gap:8 }}>
+                    <div style={{ flex:1, padding:'8px 12px', background:t.surface, border:`1px solid ${t.line}`, borderRadius:9, fontSize:12.5, color:t.inkSoft }}>
+                      Affinez ou demandez une modification…
+                    </div>
+                    <button style={{ padding:'8px 14px', background:t.accent, border:'none', borderRadius:9, color:'#fff', fontSize:12, fontWeight:600, cursor:'pointer', flexShrink:0 }}>Envoyer</button>
+                  </div>
+
+                  {/* Validate CTA */}
+                  <div style={{ padding:'10px 12px', borderTop:`1px solid ${t.line}`, display:'flex', justifyContent:'flex-end' }}>
+                    <Btn variant="primary" size="md" icon={React.cloneElement(I.check,{width:13,height:13})}>Valider et continuer</Btn>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+      <DesktopFooter/>
+    </div>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// STEP 2 — APERÇU : Map + stats + config + single-shot AI + CTA
+// ──────────────────────────────────────────────────────────────────────────────
+function PageTripsNewDesktopStep2({ w = 1280, h = 860 }) {
+  const t = useTheme();
+  return (
+    <div style={{ width:w, height:h, background:t.bg, color:t.ink, fontFamily:t.sans, display:'flex', flexDirection:'column', overflow:'hidden' }}>
+      <TopBarDesktop page="new"/>
+      <div style={{ display:'flex', flex:1, minHeight:0 }}>
+        <WizardStepper active={2} t={t}/>
+        <div style={{ flex:1, display:'grid', gridTemplateColumns:'1fr 380px', minHeight:0 }}>
+          {/* Left: map + elev + stats */}
+          <div style={{ display:'flex', flexDirection:'column', overflow:'hidden', borderRight:`1px solid ${t.line}` }}>
+            {/* Editable trip title */}
+            <div style={{ padding:'12px 16px', borderBottom:`1px solid ${t.line}`, background:t.surface, display:'flex', alignItems:'center', gap:8 }}>
+              <span style={{ fontFamily:t.serif, fontSize:18, fontWeight:500, letterSpacing:-0.3, color:t.ink }}>{TRIP.title}</span>
+              <div style={{ width:22, height:22, borderRadius:6, background:t.surfaceAlt, color:t.inkSoft, display:'flex', alignItems:'center', justifyContent:'center', cursor:'pointer', flexShrink:0 }}>
+                {React.cloneElement(I.edit,{width:11,height:11})}
+              </div>
+              
+            </div>
+            <div style={{ flex:1, overflow:'hidden', position:'relative' }}>
+              <OsmMap w={900} h={h-310} active={null}/>
+            </div>
+            {/* Elev */}
+            <div style={{ borderTop:`1px solid ${t.line}`, padding:'12px 20px', background:t.surface, flexShrink:0 }}>
+              <div style={{ fontSize:11.5, fontWeight:600, marginBottom:6 }}>Profil altimétrique</div>
+              <div style={{ display:'flex', justifyContent:'center' }}>
+                <ElevProfile w={820} h={60} up={TRIP.totalUp} down={1380} distance={TRIP.totalKm} showMarkers/>
+              </div>
+            </div>
+            {/* Stats */}
+            <div style={{ display:'flex', gap:10, padding:'12px 20px', background:t.surfaceAlt, borderTop:`1px solid ${t.line}`, flexShrink:0 }}>
+              {[{l:'Distance',v:TRIP.totalKm,u:'km'},{l:'Dénivelé +',v:'+'+TRIP.totalUp,u:'m'},{l:'Dénivelé −',v:'−1 380',u:'m'},{l:'Durée est.',v:`${TRIP.days} j`,u:''}].map((m,i)=>(
+                <div key={i} style={{ flex:1, padding:12, background:t.surface, borderRadius:10, border:`1px solid ${t.line}` }}>
+                  <div style={{ fontSize:10, color:t.inkSoft, fontWeight:600, letterSpacing:0.4, textTransform:'uppercase' }}>{m.l}</div>
+                  <div style={{ fontFamily:t.serif, fontSize:20, fontWeight:500, letterSpacing:-0.3, marginTop:3 }}>{m.v} <span style={{ fontSize:11, color:t.inkSoft, fontFamily:t.sans }}>{m.u}</span></div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Right: config + AI single-shot */}
+          <div style={{ display:'flex', flexDirection:'column', overflowY:'auto', padding:'20px 20px' }}>
+            {/* Presets — 3 only */}
+            <div style={{ marginBottom:14 }}>
+              <div style={{ fontSize:11, color:t.inkSoft, fontWeight:600, letterSpacing:0.4, marginBottom:8, textTransform:'uppercase' }}>Profil cycliste</div>
+              <div style={{ display:'flex', gap:5 }}>
+                {['Débutant','Intermédiaire','Expert'].map((p,i) => (
+                  <div key={i} style={{ flex:1, padding:'8px 6px', borderRadius:8, border:`1.5px solid ${i===1?t.accent:t.line}`, background:i===1?t.accentSofter:'transparent', textAlign:'center', fontSize:11.5, fontWeight:600, color:i===1?t.accentInk:t.inkSoft, cursor:'pointer' }}>{p}</div>
+                ))}
+              </div>
+            </div>
+            {/* Pacing sliders */}
+            {[
+              { l:'Distance max / jour', v:'80 km', pct:28 },
+              { l:'Vitesse moyenne',     v:'15 km/h', pct:22 },
+              { l:'Heure de départ',     v:'08h00', pct:33 },
+              { l:'Fatigue',             v:'10 %', pct:20 },
+              { l:'Pénalité dénivelé',  v:'25 %', pct:25 },
+            ].map((s,i)=>(
+              <div key={i} style={{ display:'flex', alignItems:'center', gap:8, marginBottom:8 }}>
+                <span style={{ fontSize:11, color:t.inkSoft, width:110, flexShrink:0 }}>{s.l}</span>
+                <div style={{ flex:1, height:4, background:t.surfaceAlt, borderRadius:2, position:'relative' }}>
+                  <div style={{ width:`${s.pct}%`, height:'100%', background:t.accent, borderRadius:2 }}/>
+                  <div style={{ position:'absolute', left:`calc(${s.pct}% - 6px)`, top:-4, width:12, height:12, borderRadius:'50%', background:'#fff', border:`2px solid ${t.accent}` }}/>
+                </div>
+                <span style={{ fontSize:11, fontFamily:t.mono, fontWeight:600, color:t.ink, width:46, textAlign:'right', flexShrink:0 }}>{s.v}</span>
+              </div>
+            ))}
+            {/* E-bike */}
+            <div style={{ display:'flex', alignItems:'center', gap:8, marginBottom:14, paddingTop:6, borderTop:`1px solid ${t.line}` }}>
+              <span style={{ fontSize:11.5, color:t.inkSoft, flex:1 }}>Mode e-bike</span>
+              <div style={{ width:34, height:18, borderRadius:9, background:t.surfaceAlt, position:'relative' }}>
+                <div style={{ position:'absolute', top:2, left:2, width:14, height:14, borderRadius:'50%', background:'#fff' }}/>
+              </div>
+            </div>
+            {/* Dates + accommodation */}
+            <div style={{ display:'grid', gridTemplateColumns:'1fr 1fr', gap:8, marginBottom:14 }}>
+              <div style={{ padding:'8px 10px', background:t.surface, border:`1.5px solid ${t.accent}`, borderRadius:8, fontSize:12.5, fontFamily:t.mono, fontWeight:600 }}>14 — 17 mai 2026</div>
+              <div style={{ padding:'8px 10px', background:t.surface, border:`1px solid ${t.line}`, borderRadius:8 }}>
+                <div style={{ fontSize:9.5, color:t.inkMute, marginBottom:2 }}>Hébergements</div>
+                <div style={{ display:'flex', gap:3, flexWrap:'wrap' }}>
+                  {['Gîte','Hôtel','Camping'].map((x,i) => <Pill key={i} sm bg={i<2?t.accentSofter:t.surfaceAlt} color={i<2?t.accentInk:t.inkSoft} bold>{x}</Pill>)}
+                </div>
+              </div>
+            </div>
+            {/* AI single-shot refinement */}
+            <div style={{ borderTop:`1px solid ${t.line}`, paddingTop:14, marginBottom:14 }}>
+              <div style={{ display:'flex', alignItems:'center', gap:6, marginBottom:8 }}>
+                {React.cloneElement(I.sparkle,{width:13,height:13,color:t.accent})}
+                <span style={{ fontSize:12.5, fontWeight:600 }}>Affiner avec l'IA</span>
+                <span style={{ fontSize:10.5, color:t.inkMute }}>(ajustement ponctuel)</span>
+              </div>
+              <div style={{ background:t.surface, border:`1.5px solid ${t.accent}`, borderRadius:10, padding:12, marginBottom:8 }}>
+                <div style={{ fontSize:12.5, color:t.ink, lineHeight:1.6, minHeight:54 }}>Rallonge l'étape 2, ajoute un café dans les Flandres…</div>
+                <div style={{ display:'flex', gap:5, justifyContent:'flex-end', marginTop:6 }}>
+                  <div style={{ padding:'4px 10px', background:t.surfaceAlt, borderRadius:6, fontSize:10.5, color:t.inkSoft }}>Effacer</div>
+                  <div style={{ padding:'4px 10px', background:t.accent, borderRadius:6, fontSize:10.5, color:'#fff', fontWeight:600 }}>Appliquer</div>
+                </div>
+              </div>
+              {/* Proposed changes */}
+              {[{t:'J2 rallongée',d:'38 → 44 km via Menin',c:t.accent},{t:'Café ajouté',d:'Kafé Kasteel, Courtrai · km 24',c:t.green}].map((c,i) => (
+                <div key={i} style={{ display:'flex', gap:8, padding:'7px 10px', background:t.surface, border:`1px solid ${t.line}`, borderRadius:8, borderLeft:`3px solid ${c.c}`, marginBottom:4 }}>
+                  <div style={{ flex:1 }}>
+                    <div style={{ fontSize:12, fontWeight:600 }}>{c.t}</div>
+                    <div style={{ fontSize:10.5, color:t.inkSoft }}>{c.d}</div>
+                  </div>
+                  {React.cloneElement(I.check,{width:13,height:13,color:t.green})}
+                </div>
+              ))}
+            </div>
+            <div style={{ marginTop:'auto', display:'flex', flexDirection:'column', gap:8 }}>
+              <Btn variant="accent" size="lg" full icon={React.cloneElement(I.chevron,{width:14,height:14})}>Lancer l'analyse</Btn>
+              <Btn variant="ghost" size="md" full icon={I.back}>Retour</Btn>
+            </div>
+          </div>
+        </div>
+      </div>
+      <DesktopFooter/>
+    </div>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// STEP 3 — ANALYSE : Narrative progression (P0.2)
+// ──────────────────────────────────────────────────────────────────────────────
+const COMPUTE_ACTS = [
+  {
+    id:'route', label:'Analyse du tracé', color:'#4a7a3e', done:true,
+    sub:'2 847 points GPS · 143 km parsés · 4 étapes découpées',
+    tasks:['ROUTE','STAGES'],
+  },
+  {
+    id:'terrain', label:'Analyse du terrain', color:'#6b5a3e', done:true,
+    sub:'Dénivelé +1 430 m · gravier 22% · 3 sections pavées détectées',
+    tasks:['TERRAIN','OSM_SCAN'],
+  },
+  {
+    id:'pois', label:'Points d\'intérêt', color:'#3d6b91', running:true, progress:72,
+    sub:'Interrogation OpenStreetMap… 142 POI trouvés · 3 POI culturels enrichis via Wikidata',
+    tasks:['POIS','CULTURAL_POIS','WATER_POINTS','BIKE_SHOPS'],
+  },
+  {
+    id:'lodging', label:'Hébergements', color:'#8a5a2e', pending:true,
+    sub:'',
+    tasks:['LODGING'],
+  },
+  {
+    id:'weather', label:'Météo & confort', color:'#3d6b91', pending:true,
+    sub:'',
+    tasks:['WEATHER','WIND'],
+  },
+  {
+    id:'events', label:'Événements locaux', color:'#6b3a6e', pending:true,
+    sub:'',
+    tasks:['CALENDAR'],
+  },
+  {
+    id:'safety', label:'Sécurité & évacuation', color:'#8a3a2e', pending:true,
+    sub:'',
+    tasks:['RAILWAY_STATIONS','BORDER_CROSSINGS','HEALTH_SERVICES'],
+  },
+];
+
+function PageProcessingDesktop({ w = 1280, h = 860 }) {
+  const t = useTheme();
+  return (
+    <div style={{ width:w, height:h, background:t.bg, color:t.ink, fontFamily:t.sans, display:'flex', flexDirection:'column', overflow:'hidden' }}>
+      <TopBarDesktop page="new"/>
+      <div style={{ display:'flex', flex:1, minHeight:0 }}>
+        <WizardStepper active={3} t={t}/>
+        <div style={{ display:'grid', gridTemplateColumns:'1.1fr 1fr', flex:1, minHeight:0 }}>
+          {/* Left: progression narrative */}
+          <div style={{ padding:'40px 52px', overflowY:'auto', borderRight:`1px solid ${t.line}` }}>
+            <h1 style={{ fontFamily:t.serif, fontSize:34, letterSpacing:-0.7, fontWeight:500, margin:0, marginBottom:8, lineHeight:1.1 }}>
+              <span style={{ fontStyle:'italic', color:t.accent }}>L'Odyssée des Eaux Royales</span>
+            </h1>
+            <p style={{ fontSize:14, color:t.inkSoft, marginBottom:28, lineHeight:1.55 }}>Traitement en parallèle — environ 30 secondes. Vous pouvez basculer d'onglet.</p>
+
+            {/* Global progress */}
+            <div style={{ background:t.surface, border:`1px solid ${t.line}`, borderRadius:12, padding:16, marginBottom:24 }}>
+              <div style={{ display:'flex', justifyContent:'space-between', marginBottom:8, fontSize:12, fontWeight:600 }}>
+                <span style={{ display:'flex', alignItems:'center', gap:6, color:t.ink, fontWeight:600 }}><span style={{width:8,height:8,borderRadius:'50%',background:t.accent,animation:'pulse 1.4s infinite',flexShrink:0}}/> Analyse en cours</span>
+                <span style={{ color:t.accent, fontFamily:t.mono }}>47 %</span>
+              </div>
+              <div style={{ height:6, background:t.surfaceAlt, borderRadius:3, overflow:'hidden' }}>
+                <div style={{ height:'100%', width:'47%', background:`linear-gradient(90deg,${t.accent},${t.accent}cc)`, borderRadius:3 }}/>
+              </div>
+            </div>
+
+            {/* Acts */}
+            <div style={{ display:'flex', flexDirection:'column', gap:3 }}>
+              {COMPUTE_ACTS.map((act, i) => (
+                <div key={act.id} style={{ padding:'12px 14px', borderRadius:10, background: act.running ? t.accentSofter : 'transparent', border: act.running ? `1px solid ${t.accent}30` : '1px solid transparent' }}>
+                  <div style={{ display:'flex', gap:12, alignItems:'flex-start' }}>
+                    {/* Status dot */}
+                    <div style={{ width:24, height:24, borderRadius:'50%', flexShrink:0, marginTop:1,
+                      background: act.done ? t.green : act.running ? t.surface : t.surfaceAlt,
+                      color: act.done ? '#fff' : t.inkMute,
+                      display:'flex', alignItems:'center', justifyContent:'center',
+                      border: act.running ? `2px solid ${t.accent}` : 'none',
+                    }}>
+                      {act.done && React.cloneElement(I.check,{width:11,height:11})}
+                      {act.running && <div style={{ width:8,height:8,borderRadius:'50%',background:t.accent,animation:'pulse 1s infinite' }}/>}
+                      {act.pending && <span style={{ fontSize:10, fontWeight:700 }}>{i+1}</span>}
+                    </div>
+                    <div style={{ flex:1 }}>
+                      <div style={{ display:'flex', justifyContent:'space-between', alignItems:'baseline' }}>
+                        <div style={{ fontSize:13.5, fontWeight: act.running?700:500, color: act.pending?t.inkMute:t.ink }}>{act.label}</div>
+                        {act.running && <span style={{ fontSize:11, color:t.accent, fontFamily:t.mono, fontWeight:600 }}>{act.progress}%</span>}
+                      </div>
+                      {/* Task badges */}
+                      <div style={{ display:'flex', gap:4, flexWrap:'wrap', marginTop:4, marginBottom: act.sub?4:0 }}>
+                        {act.tasks.map(tk => (
+                          <span key={tk} style={{ fontSize:9.5, padding:'1px 6px', borderRadius:4, background: act.done?t.greenSoft:act.running?t.accentSofter:t.surfaceAlt, color: act.done?t.green:act.running?t.accentInk:t.inkMute, fontFamily:t.mono, fontWeight:600 }}>{tk}</span>
+                        ))}
+                      </div>
+                      {act.sub && <div style={{ fontSize:11.5, color:t.inkSoft, lineHeight:1.45 }}>{act.sub}</div>}
+                      {act.running && (
+                        <div style={{ height:3, background:t.surfaceAlt, borderRadius:2, marginTop:8, overflow:'hidden' }}>
+                          <div style={{ height:'100%', width:`${act.progress}%`, background:t.accent, borderRadius:2 }}/>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Right: live preview */}
+          <div style={{ background:t.surfaceAlt, padding:28, display:'flex', flexDirection:'column', gap:14, overflow:'hidden' }}>
+            <div style={{ fontSize:11.5, fontWeight:600, color:t.inkSoft, textTransform:'uppercase', letterSpacing:0.5 }}>Aperçu temps réel</div>
+            <div style={{ background:t.surface, borderRadius:12, overflow:'hidden', border:`1px solid ${t.line}` }}>
+              <OsmMap w={460} h={220}/>
+            </div>
+            <div style={{ background:t.surface, borderRadius:12, padding:14, border:`1px solid ${t.line}` }}>
+              <div style={{ fontSize:12, fontWeight:600, marginBottom:8 }}>Profil altimétrique</div>
+              <div style={{ display:'flex', justifyContent:'center' }}>
+                <ElevProfile w={430} h={70} up={TRIP.totalUp} down={1380} distance={TRIP.totalKm} showMarkers/>
+              </div>
+            </div>
+            <div style={{ display:'grid', gridTemplateColumns:'repeat(3,1fr)', gap:8 }}>
+              {[{l:'Distance',v:'143',u:'km'},{l:'Dénivelé +',v:'1 430',u:'m'},{l:'POI trouvés',v:'142',u:''}].map((m,i)=>(
+                <div key={i} style={{ background:t.surface, border:`1px solid ${t.line}`, borderRadius:10, padding:12 }}>
+                  <div style={{ fontSize:10, color:t.inkSoft, fontWeight:600, textTransform:'uppercase', letterSpacing:0.3 }}>{m.l}</div>
+                  <div style={{ fontFamily:t.serif, fontSize:22, fontWeight:500, letterSpacing:-0.5, marginTop:3 }}>{m.v} <span style={{ fontSize:11, color:t.inkSoft, fontFamily:t.sans }}>{m.u}</span></div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+      <DesktopFooter/>
+    </div>
+  );
+}
+
+Object.assign(window, { PageTripsNewDesktop, PageTripsNewDesktopStep2, PageProcessingDesktop, COMPUTE_ACTS });

--- a/docs/recette/design/shared-data.jsx
+++ b/docs/recette/design/shared-data.jsx
@@ -1,0 +1,137 @@
+// Shared trip data for all 3 design variants.
+// Same route as the README screenshot: "L'Odyssée des Eaux Royales", Lille -> Tournai.
+
+const TRIP = {
+  title: "L'Odyssée des Eaux Royales",
+  source: "komoot.com/tour/2847193",
+  totalKm: 143,
+  totalUp: 1430,
+  totalDown: 1380,
+  budgetMin: 48,
+  budgetMax: 80,
+  dateRange: "14 — 17 mai",
+  level: "Intermédiaire",
+  days: 4,
+  avgSpeed: 15,
+  departure: "08:00",
+};
+
+const STAGES = [
+  {
+    day: 1,
+    date: "Jeu. 14 mai",
+    from: "Lille",
+    fromCoord: "50.638°N, 3.050°E",
+    to: "Roubaix",
+    toCoord: "50.742°N, 3.602°E",
+    km: 38.2,
+    up: 187,
+    down: 142,
+    dep: "08:00",
+    arr: "11:45",
+    diff: "Facile",
+    diffScore: 0.25,
+    sunrise: "06:12",
+    sunset: "21:28",
+    weather: { t: 17, icon: "sun", wind: 12, windDir: "SW" },
+    surface: { paved: 82, gravel: 18 },
+    alerts: [
+      { sev: "nudge",   icon: "info",     title: "Pause café possible à Lambersart", body: "Arrêt café/pâtisserie recommandé au km 14.2" },
+      { sev: "nudge",   icon: "sparkles", title: "POI culturel — Villa Cavrois",     body: "Monument historique · ouverture 10h–18h · 9 €" },
+    ],
+    lodging: { name: "Le Gîte des Trois Écluses", type: "Gîte", price: "€62 / nuit", dist: "0.4 km", rating: 4.6 },
+  },
+  {
+    day: 2,
+    date: "Ven. 15 mai",
+    from: "Roubaix",
+    fromCoord: "50.742°N, 3.602°E",
+    to: "Tournai",
+    toCoord: "50.608°N, 3.389°E",
+    km: 42.5,
+    up: 412,
+    down: 378,
+    dep: "08:00",
+    arr: "12:40",
+    diff: "Moyen",
+    diffScore: 0.55,
+    sunrise: "06:10",
+    sunset: "21:30",
+    weather: { t: 19, icon: "partly", wind: 22, windDir: "W" },
+    surface: { paved: 64, gravel: 36 },
+    alerts: [
+      { sev: "warning",  icon: "wind",    title: "Vent de face modéré",          body: "Headwind 22 km/h (O) sur 60% du tronçon" },
+      { sev: "warning",  icon: "steep",   title: "Pente soutenue km 28–31",      body: "Gradient moyen 9,2% sur 2,8 km" },
+      { sev: "nudge",    icon: "cross",   title: "Traversée de frontière",       body: "France → Belgique · pensez à votre CNI" },
+    ],
+    lodging: { name: "Auberge de la Grand'Place", type: "Auberge", price: "€75 / nuit", dist: "0.2 km", rating: 4.8 },
+  },
+  {
+    day: 3,
+    date: "Sam. 16 mai",
+    from: "Tournai",
+    fromCoord: "50.608°N, 3.389°E",
+    to: "Oudenaarde",
+    toCoord: "50.845°N, 3.605°E",
+    km: 34.1,
+    up: 486,
+    down: 512,
+    dep: "08:00",
+    arr: "11:50",
+    diff: "Moyen",
+    diffScore: 0.62,
+    sunrise: "06:08",
+    sunset: "21:32",
+    weather: { t: 21, icon: "sun", wind: 8, windDir: "S" },
+    surface: { paved: 58, gravel: 38, pave: 4 },
+    alerts: [
+      { sev: "critical", icon: "traffic", title: "Route primaire N60 km 18–19",  body: "1,3 km sans piste cyclable — détour +2,8 km suggéré" },
+      { sev: "warning",  icon: "cobble",  title: "Secteur pavé — Koppenberg",    body: "700 m de pavés irréguliers · km 24,5" },
+      { sev: "nudge",    icon: "water",   title: "Point d'eau · km 12,8",        body: "Fontaine publique · qualité potable vérifiée" },
+    ],
+    lodging: { name: "Chambres d'hôtes Au Fil de l'Escaut", type: "Chambre d'hôtes", price: "€68 / nuit", dist: "0.6 km", rating: 4.9 },
+  },
+  {
+    day: 4,
+    date: "Dim. 17 mai",
+    from: "Oudenaarde",
+    fromCoord: "50.845°N, 3.605°E",
+    to: "Gand",
+    toCoord: "51.054°N, 3.717°E",
+    km: 28.2,
+    up: 198,
+    down: 204,
+    dep: "09:00",
+    arr: "12:15",
+    diff: "Facile",
+    diffScore: 0.28,
+    sunrise: "06:06",
+    sunset: "21:34",
+    weather: { t: 22, icon: "sun", wind: 6, windDir: "SE" },
+    surface: { paved: 92, gravel: 8 },
+    alerts: [
+      { sev: "nudge",   icon: "calendar", title: "Jour férié / dimanche",        body: "Commerces possiblement fermés après 13h" },
+      { sev: "nudge",   icon: "train",    title: "Gare SNCB à 1,2 km de l'arrivée", body: "Retour direct Gand → Lille (1h45)" },
+    ],
+    lodging: null,
+  },
+];
+
+// A hand-drawn-ish route polyline for the map mockups (lat/lon coords normalised 0..1).
+// Points roughly approximate the Lille → Tournai → Oudenaarde → Gand corridor.
+const ROUTE = [
+  [0.10, 0.72], [0.14, 0.70], [0.18, 0.66], [0.22, 0.63], [0.26, 0.60], // day 1
+  [0.30, 0.58], [0.33, 0.56], [0.36, 0.58], [0.40, 0.62], [0.44, 0.64], // day 2
+  [0.48, 0.60], [0.52, 0.54], [0.56, 0.48], [0.60, 0.44], [0.64, 0.40], // day 3
+  [0.70, 0.34], [0.76, 0.28], [0.82, 0.22], [0.88, 0.18], [0.94, 0.14], // day 4
+];
+
+// Split into day segments for color-coded rendering.
+const ROUTE_DAYS = [
+  ROUTE.slice(0, 5),
+  ROUTE.slice(4, 10),
+  ROUTE.slice(9, 15),
+  ROUTE.slice(14, 20),
+];
+
+Object.assign(window, { TRIP, STAGES, ROUTE, ROUTE_DAYS });

--- a/docs/recette/design/tokens.jsx
+++ b/docs/recette/design/tokens.jsx
@@ -1,0 +1,71 @@
+// Design tokens & theme for all Bike Trip Planner screens
+// Outdoor, warm, map-inspired palette. Dark mode via `dark` flag.
+
+const TOKENS = {
+  // Font stacks — pin real fonts (Google Fonts loaded in HTML)
+  serif: '"Fraunces", "Cormorant Garamond", Georgia, serif',
+  sans:  '"Inter Tight", "Inter", system-ui, -apple-system, sans-serif',
+  mono:  '"JetBrains Mono", ui-monospace, monospace',
+};
+
+function makeTheme(accent, dark) {
+  // Accent families
+  const accents = {
+    amber:  { solid: '#c2671e', soft: '#fbe6cc', softer: '#fdf2e0', ink: '#6b3a14' },
+    forest: { solid: '#4a6b3a', soft: '#d9e3cc', softer: '#eaf0de', ink: '#2a3e1f' },
+    indigo: { solid: '#3b5998', soft: '#d3dbef', softer: '#e8ecf7', ink: '#1f2e52' },
+    brick:  { solid: '#a8412a', soft: '#f0d0c6', softer: '#f8e5dd', ink: '#5c1f12' },
+  };
+  const a = accents[accent] || accents.amber;
+
+  if (dark) return {
+    ...TOKENS,
+    name: 'dark',
+    bg:         '#1a1814',
+    surface:    '#24211c',
+    surfaceAlt: '#2c2822',
+    line:       '#3a352d',
+    lineSoft:   '#2f2a23',
+    ink:        '#f5ede0',
+    inkSoft:    '#c9bfad',
+    inkMute:    '#8a8173',
+    accent:     a.solid,
+    accentSoft: '#3a2d1d',
+    accentInk:  '#f1c999',
+    red:        '#e57a5a',    redSoft: '#3a241d',
+    blue:       '#7ba3c9',    blueSoft: '#1d2b3a',
+    green:      '#8fb170',    greenSoft: '#1f2a1a',
+    forest:     '#a8c07e',
+    rose:       '#d8967a',
+    shadow:     '0 1px 2px rgba(0,0,0,0.4), 0 4px 12px rgba(0,0,0,0.25)',
+    shadowSoft: '0 1px 2px rgba(0,0,0,0.3)',
+    paper:      'radial-gradient(ellipse at top, #2a2620 0%, #1a1814 80%)',
+  };
+
+  return {
+    ...TOKENS,
+    name: 'light',
+    bg:         '#faf7f0',       // warm paper
+    surface:    '#ffffff',
+    surfaceAlt: '#f3ece0',
+    line:       '#e4dbc9',
+    lineSoft:   '#efe7d5',
+    ink:        '#2a2418',
+    inkSoft:    '#5a4e3a',
+    inkMute:    '#8b7e66',
+    accent:     a.solid,
+    accentSoft: a.soft,
+    accentSofter: a.softer,
+    accentInk:  a.ink,
+    red:        '#b84420',   redSoft:   '#f5ddd0',
+    blue:       '#3d6b91',   blueSoft:  '#d8e4ef',
+    green:      '#4a7a3a',   greenSoft: '#dbe8ce',
+    forest:     '#4a6b3a',
+    rose:       '#b86a3e',
+    shadow:     '0 1px 2px rgba(80,60,30,0.06), 0 8px 24px rgba(80,60,30,0.08)',
+    shadowSoft: '0 1px 2px rgba(80,60,30,0.04)',
+    paper:      'radial-gradient(ellipse at top, #fdf9ef 0%, #f5ecda 100%)',
+  };
+}
+
+Object.assign(window, { TOKENS, makeTheme });

--- a/docs/recette/design/toutes-les-pages.html
+++ b/docs/recette/design/toutes-les-pages.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="fr">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Bike Trip Planner — Design complet</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;1,9..144,400;1,9..144,500&family=Inter+Tight:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet"/>
+<style>
+  html, body { margin: 0; padding: 0; background: #f0eee9; font-family: "Inter Tight", system-ui, sans-serif; }
+  * { box-sizing: border-box; }
+  @keyframes pulse { 0%, 100% { opacity: 1 } 50% { opacity: 0.4 } }
+  @keyframes spin { to { transform: rotate(360deg) } }
+  @keyframes shimmer { 0% { background-position: -600px 0 } 100% { background-position: 600px 0 } }
+  .spin { animation: spin 1s linear infinite }
+  .pulse { animation: pulse 1.4s ease-in-out infinite }
+  .shimmer-bg {
+    background: linear-gradient(90deg, #f0eee9 25%, #e8e2d4 50%, #f0eee9 75%);
+    background-size: 600px 100%;
+    animation: shimmer 1.5s ease-in-out infinite;
+  }
+  .dark-shimmer-bg {
+    background: linear-gradient(90deg, #24211c 25%, #2e2a24 50%, #24211c 75%);
+    background-size: 600px 100%;
+    animation: shimmer 1.5s ease-in-out infinite;
+  }
+</style>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+</head>
+<body>
+<div id="app"></div>
+<script type="text/babel" src="design-canvas.jsx"></script>
+<script type="text/babel" src="designs/shared-data.jsx"></script>
+<script type="text/babel" src="src/tokens.jsx"></script>
+<script type="text/babel" src="src/ui.jsx"></script>
+<script type="text/babel" src="src/ui2.jsx"></script>
+<script type="text/babel" src="src/pages-auth.jsx"></script>
+<script type="text/babel" src="src/pages-wizard.jsx"></script>
+<script type="text/babel" src="src/pages-roadbook.jsx"></script>
+<script type="text/babel" src="src/pages-trips.jsx"></script>
+<script type="text/babel" src="src/pages-extra.jsx"></script>
+<script type="text/babel" src="src/pages-poi.jsx"></script>
+<script type="text/babel" src="src/modals.jsx"></script>
+<script type="text/babel" src="src/app.jsx"></script>
+</body>
+</html>

--- a/docs/recette/design/toutes-les-pages.html
+++ b/docs/recette/design/toutes-les-pages.html
@@ -32,18 +32,18 @@
 </head>
 <body>
 <div id="app"></div>
+<script type="text/babel" src="shared-data.jsx"></script>
+<script type="text/babel" src="tokens.jsx"></script>
+<script type="text/babel" src="ui.jsx"></script>
+<script type="text/babel" src="ui2.jsx"></script>
+<script type="text/babel" src="pages-auth.jsx"></script>
+<script type="text/babel" src="pages-wizard.jsx"></script>
+<script type="text/babel" src="pages-roadbook.jsx"></script>
+<script type="text/babel" src="pages-trips.jsx"></script>
+<script type="text/babel" src="pages-extra.jsx"></script>
+<script type="text/babel" src="pages-poi.jsx"></script>
+<script type="text/babel" src="modals.jsx"></script>
 <script type="text/babel" src="design-canvas.jsx"></script>
-<script type="text/babel" src="designs/shared-data.jsx"></script>
-<script type="text/babel" src="src/tokens.jsx"></script>
-<script type="text/babel" src="src/ui.jsx"></script>
-<script type="text/babel" src="src/ui2.jsx"></script>
-<script type="text/babel" src="src/pages-auth.jsx"></script>
-<script type="text/babel" src="src/pages-wizard.jsx"></script>
-<script type="text/babel" src="src/pages-roadbook.jsx"></script>
-<script type="text/babel" src="src/pages-trips.jsx"></script>
-<script type="text/babel" src="src/pages-extra.jsx"></script>
-<script type="text/babel" src="src/pages-poi.jsx"></script>
-<script type="text/babel" src="src/modals.jsx"></script>
-<script type="text/babel" src="src/app.jsx"></script>
+<script type="text/babel" src="app.jsx"></script>
 </body>
 </html>

--- a/docs/recette/design/ui.jsx
+++ b/docs/recette/design/ui.jsx
@@ -1,0 +1,372 @@
+// UI primitives + icons + map/elevation SVG helpers shared across all page designs.
+// Relies on: TOKENS, makeTheme (tokens.jsx) ; TRIP, STAGES, ROUTE, ROUTE_DAYS (shared-data.jsx).
+
+const ThemeCtx = React.createContext(null);
+const useTheme = () => React.useContext(ThemeCtx);
+
+// ── Primitives ──────────────────────────────────────────────
+function Pill({ children, bg, color, sm, bold, style = {} }) {
+  return (
+    <span style={{
+      display: 'inline-flex', alignItems: 'center', gap: 5,
+      padding: sm ? '2px 8px' : '4px 10px', borderRadius: 999,
+      background: bg, color,
+      fontSize: sm ? 10.5 : 11.5, fontWeight: bold ? 600 : 500,
+      whiteSpace: 'nowrap', letterSpacing: 0.1,
+      ...style,
+    }}>{children}</span>
+  );
+}
+
+function Card({ children, style = {}, pad = 18, tint }) {
+  const t = useTheme();
+  return (
+    <div style={{
+      background: tint || t.surface,
+      border: `1px solid ${t.line}`,
+      borderRadius: 14,
+      padding: pad,
+      ...style,
+    }}>{children}</div>
+  );
+}
+
+function Btn({ children, variant = 'primary', size = 'md', icon, style = {}, onClick, full }) {
+  const t = useTheme();
+  const sz = {
+    xs: { p: '5px 10px', fs: 11.5, r: 7 },
+    sm: { p: '7px 12px', fs: 12.5, r: 8 },
+    md: { p: '9px 16px', fs: 13,   r: 9 },
+    lg: { p: '12px 22px', fs: 14,   r: 10 },
+  }[size];
+  const v = {
+    primary: { bg: t.ink,     c: t.bg,   b: 'none' },
+    accent:  { bg: t.accent,  c: '#fff', b: 'none' },
+    ghost:   { bg: 'transparent', c: t.inkSoft, b: `1px solid ${t.line}` },
+    soft:    { bg: t.surfaceAlt,  c: t.ink,     b: 'none' },
+    danger:  { bg: t.red, c: '#fff', b: 'none' },
+  }[variant];
+  return (
+    <button onClick={onClick} style={{
+      padding: sz.p, fontSize: sz.fs, fontWeight: 500,
+      background: v.bg, color: v.c, border: v.b, borderRadius: sz.r,
+      cursor: 'pointer', display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+      gap: 6, fontFamily: 'inherit',
+      width: full ? '100%' : 'auto',
+      ...style,
+    }}>{icon}{children}</button>
+  );
+}
+
+function Field({ label, hint, children, style = {} }) {
+  const t = useTheme();
+  return (
+    <label style={{ display: 'block', ...style }}>
+      {label && <div style={{ fontSize: 11.5, fontWeight: 600, color: t.inkSoft, marginBottom: 6, textTransform: 'uppercase', letterSpacing: 0.4 }}>{label}</div>}
+      {children}
+      {hint && <div style={{ fontSize: 11, color: t.inkMute, marginTop: 4 }}>{hint}</div>}
+    </label>
+  );
+}
+
+function Input({ value, placeholder, icon, style = {}, mono }) {
+  const t = useTheme();
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '10px 12px', background: t.bg, border: `1px solid ${t.line}`, borderRadius: 9, ...style }}>
+      {icon && <span style={{ color: t.inkMute, display: 'flex' }}>{icon}</span>}
+      <span style={{ fontSize: 13, color: value ? t.ink : t.inkMute, fontFamily: mono ? t.mono : 'inherit', flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+        {value || placeholder}
+      </span>
+    </div>
+  );
+}
+
+// ── Icons ──────────────────────────────────────────────────
+const Ic = ({ d, size = 16, sw = 1.7, fill = 'none' }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill={fill} stroke="currentColor" strokeWidth={sw} strokeLinecap="round" strokeLinejoin="round" style={{ flexShrink: 0 }}>
+    {typeof d === 'string' ? <path d={d} /> : d}
+  </svg>
+);
+const I = {
+  bike:     <Ic d="M5 17a3 3 0 1 0 0-6 3 3 0 0 0 0 6Zm14 0a3 3 0 1 0 0-6 3 3 0 0 0 0 6Zm-7-3 3-6h-3l-3 6h3Zm0 0 3 2m-8-8h3" />,
+  map:     <Ic d={<><path d="M9 4 3 6v14l6-2 6 2 6-2V4l-6 2-6-2Z"/><path d="M9 4v14M15 6v14"/></>} />,
+  clock:   <Ic d={<><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></>} />,
+  upload:  <Ic d={<><path d="M12 3v13M6 9l6-6 6 6"/><path d="M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-2"/></>} />,
+  link:    <Ic d={<><path d="M10 14a5 5 0 0 1 0-7l3-3a5 5 0 0 1 7 7l-2 2"/><path d="M14 10a5 5 0 0 1 0 7l-3 3a5 5 0 0 1-7-7l2-2"/></>} />,
+  download:<Ic d={<><path d="M12 3v13M6 11l6 6 6-6"/><path d="M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-2"/></>} />,
+  share:   <Ic d={<><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><path d="m8.5 10.5 7-4m-7 7 7 4"/></>} />,
+  edit:    <Ic d={<><path d="M12 20h9"/><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4Z"/></>} />,
+  plus:    <Ic d="M12 5v14M5 12h14" />,
+  check:   <Ic d="m5 12 5 5L20 7" />,
+  alert:   <Ic d={<><path d="M12 9v4M12 17h.01"/><path d="M10.3 3.9 2.1 18.1A2 2 0 0 0 3.8 21h16.4a2 2 0 0 0 1.7-2.9L13.7 3.9a2 2 0 0 0-3.4 0Z"/></>} />,
+  info:    <Ic d={<><circle cx="12" cy="12" r="9"/><path d="M12 16v-4M12 8h.01"/></>} />,
+  wind:    <Ic d={<><path d="M3 8h13a3 3 0 1 0-3-3M3 16h17a3 3 0 1 1-3 3M3 12h9"/></>} />,
+  mountain:<Ic d="m3 19 7-12 4 7 2-3 5 8Z" />,
+  sun:     <Ic d={<><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></>} />,
+  droplet: <Ic d="M12 3s7 7.5 7 13a7 7 0 1 1-14 0c0-5.5 7-13 7-13Z" />,
+  wrench:  <Ic d="M15 4a5 5 0 0 0-6 7l-6 6a1.4 1.4 0 1 0 2 2l6-6a5 5 0 0 0 7-6l-3 3-2-2 2-3Z" />,
+  coffee:  <Ic d={<><path d="M4 8h12v6a4 4 0 0 1-4 4H8a4 4 0 0 1-4-4V8Z"/><path d="M16 10h2a2 2 0 0 1 0 4h-2M8 2v3M12 2v3"/></>} />,
+  camera:  <Ic d={<><path d="M3 8h3l2-3h8l2 3h3a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V9a1 1 0 0 1 1-1Z"/><circle cx="12" cy="13" r="4"/></>} />,
+  close:   <Ic d="M6 6l12 12M18 6l-12 12" />,
+  chevron: <Ic d="m9 6 6 6-6 6" />,
+  chevUp:  <Ic d="m6 15 6-6 6 6" />,
+  chevDn:  <Ic d="m6 9 6 6 6-6" />,
+  back:    <Ic d="m15 6-6 6 6 6" />,
+  train:   <Ic d={<><rect x="5" y="3" width="14" height="15" rx="2"/><path d="M5 13h14M9 21l-2-3M15 21l2-3M9 8h.01M15 8h.01"/></>} />,
+  flag:    <Ic d="M4 21V4m0 0h11l-2 4 2 4H4" />,
+  home:    <Ic d="m3 11 9-8 9 8v9a1 1 0 0 1-1 1h-5v-6h-6v6H4a1 1 0 0 1-1-1v-9Z" />,
+  list:    <Ic d={<><path d="M8 6h12M8 12h12M8 18h12"/><circle cx="4" cy="6" r="1"/><circle cx="4" cy="12" r="1"/><circle cx="4" cy="18" r="1"/></>} />,
+  search:  <Ic d={<><circle cx="11" cy="11" r="7"/><path d="m21 21-4.5-4.5"/></>} />,
+  settings:<Ic d={<><circle cx="12" cy="12" r="3"/><path d="M12 1v4M12 19v4M4.2 4.2l2.8 2.8M17 17l2.8 2.8M1 12h4M19 12h4M4.2 19.8 7 17M17 7l2.8-2.8"/></>} />,
+  bed:     <Ic d={<><path d="M3 18V7m0 0h12a4 4 0 0 1 4 4v7M3 13h18"/><circle cx="7" cy="10" r="1.5"/></>} />,
+  traffic: <Ic d={<><circle cx="12" cy="12" r="9"/><path d="M4 10h16M10 4v16"/></>} />,
+  cobble:  <Ic d={<><rect x="3" y="4" width="7" height="7" rx="1"/><rect x="14" y="4" width="7" height="7" rx="1"/><rect x="3" y="13" width="7" height="7" rx="1"/><rect x="14" y="13" width="7" height="7" rx="1"/></>} />,
+  sparkle: <Ic d="M12 3v5M12 16v5M3 12h5M16 12h5M5.6 5.6l3.5 3.5M14.9 14.9l3.5 3.5M5.6 18.4l3.5-3.5M14.9 9.1l3.5-3.5" />,
+  compass: <Ic d={<><circle cx="12" cy="12" r="9"/><path d="m14.5 9.5-2 5-5 2 2-5 5-2Z"/></>} />,
+  mail:    <Ic d={<><rect x="3" y="5" width="18" height="14" rx="2"/><path d="m3 7 9 7 9-7"/></>} />,
+  lock:    <Ic d={<><rect x="5" y="11" width="14" height="10" rx="2"/><path d="M8 11V7a4 4 0 0 1 8 0v4"/></>} />,
+  logout:  <Ic d={<><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4M16 17l5-5-5-5M21 12H9"/></>} />,
+  trips:   <Ic d={<><path d="M2 17 9 5l6 4 7-7"/><path d="m22 2-5 1 1 5"/></>} />,
+  dumbbell:<Ic d={<><path d="M3 8v8M7 6v12M21 8v8M17 6v12M7 12h10"/></>} />,
+  thermometer: <Ic d={<><path d="M14 4a2 2 0 1 0-4 0v10a4 4 0 1 0 4 0V4Z"/></>} />,
+  arrowUp: <Ic d="M5 12l7-7 7 7M12 5v14" />,
+  arrowDn: <Ic d="M5 12l7 7 7-7M12 5v14" />,
+  help:    <Ic d={<><circle cx="12" cy="12" r="9"/><path d="M9.5 9a2.5 2.5 0 0 1 5 0c0 1.7-2.5 2-2.5 4M12 17h.01"/></>} />,
+  ghostFace:<Ic d={<><path d="M4 19V8a8 8 0 1 1 16 0v11l-2.5-2-2.5 2-2.5-2-2.5 2-2.5-2L4 19Z"/><path d="M9 10h.01M15 10h.01"/></>} />,
+  loader:  <Ic d="M12 3a9 9 0 0 1 9 9" />,
+  bolt:    <Ic d="m13 2-9 11h8l-1 9 9-11h-8l1-9Z" />,
+  calendar:<Ic d={<><rect x="3" y="5" width="18" height="16" rx="2"/><path d="M3 10h18M8 3v4M16 3v4"/></>} />,
+  euro:    <Ic d="M18 7a5 5 0 0 0-8.2 2M18 17a5 5 0 0 1-8.2-2M4 10h9M4 14h8" />,
+  filter:  <Ic d="M3 4h18l-7 9v6l-4 2v-8L3 4Z" />,
+  star:    <Ic d="m12 3 2.9 6 6.5.9-4.7 4.6 1.1 6.5L12 18l-5.8 3 1.1-6.5L2.6 9.9 9.1 9 12 3Z" fill="currentColor" />,
+  globe:   <Ic d={<><circle cx="12" cy="12" r="9"/><path d="M3 12h18M12 3a14 14 0 0 1 0 18M12 3a14 14 0 0 0 0 18"/></>} />,
+  moreH:   <Ic d={<><circle cx="5" cy="12" r="1"/><circle cx="12" cy="12" r="1"/><circle cx="19" cy="12" r="1"/></>} />,
+  pdf:     <Ic d={<><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8l-6-6Z"/><path d="M14 2v6h6M8 13h8M8 17h5"/></>} />,
+  copy:    <Ic d={<><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></>} />,
+  navigation: <Ic d="M3 11 22 2 13 21 11 13 3 11Z" />,
+  lock:    <Ic d={<><rect x="5" y="11" width="14" height="10" rx="2"/><path d="M8 11V7a4 4 0 0 1 8 0v4"/></>} />,
+  logout:  <Ic d={<><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4M16 17l5-5-5-5M21 12H9"/></>} />,
+  qrcode:  <Ic d={<><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><path d="M14 14h3v3h-3zM20 14v3M14 20h3M20 20h1"/></>} />,
+  monitor: <Ic d={<><rect x="2" y="4" width="20" height="13" rx="2"/><path d="M8 21h8M12 17v4"/></>} />,
+  smartphone: <Ic d={<><rect x="7" y="2" width="10" height="20" rx="2"/><path d="M11 18h2"/></>} />,
+  wifiOff: <Ic d={<><path d="M2 2l20 20M8.5 15.5a5 5 0 0 1 7 0M5 12a10 10 0 0 1 3-2M19 12a10 10 0 0 0-5-2.7"/><circle cx="12" cy="19" r="1" fill="currentColor"/></>} />,
+  github:  <Ic d="M12 2A10 10 0 0 0 9 21.8c.5.1.7-.2.7-.5v-2c-2.8.6-3.4-1.2-3.4-1.2-.4-1.2-1-1.5-1-1.5-.9-.6.1-.6.1-.6 1 .1 1.5 1 1.5 1 .9 1.6 2.4 1.1 3 .9.1-.7.4-1.1.6-1.4-2.2-.3-4.6-1.1-4.6-5 0-1.1.4-2 1-2.7-.1-.3-.4-1.3.1-2.7 0 0 .8-.3 2.7 1a9.4 9.4 0 0 1 5 0c1.9-1.3 2.7-1 2.7-1 .5 1.4.2 2.4.1 2.7.6.7 1 1.6 1 2.7 0 3.9-2.4 4.7-4.6 5 .4.3.7 1 .7 2v2.9c0 .3.2.6.7.5A10 10 0 0 0 12 2Z" />,
+  trips:   <Ic d={<><path d="M2 17 9 5l6 4 7-7"/><path d="m22 2-5 1 1 5"/></>} />,
+  loader:  <Ic d="M12 3a9 9 0 0 1 9 9" />,
+  bolt:    <Ic d="m13 2-9 11h8l-1 9 9-11h-8l1-9Z" />,
+  moreH:   <Ic d={<><circle cx="5" cy="12" r="1"/><circle cx="12" cy="12" r="1"/><circle cx="19" cy="12" r="1"/></>} />,
+  play:    <Ic d="M6 4v16l14-8L6 4Z" fill="currentColor" />,
+};
+
+// ── Map ────────────────────────────────────────────────────
+function MapCanvas({ w, h, active = null, showLabels = true, simplified = false }) {
+  const t = useTheme();
+  const toXY = ([nx, ny]) => [nx * w, ny * h];
+  const pathFor = (pts) => pts.map(([nx, ny], i) => `${i === 0 ? 'M' : 'L'} ${(nx * w).toFixed(1)} ${(ny * h).toFixed(1)}`).join(' ');
+  const dayColors = [t.forest, t.accent, t.blue, t.rose];
+  const mapBg    = t.name === 'dark' ? '#2d2920' : '#ece3d0';
+  const mapBg2   = t.name === 'dark' ? '#332e24' : '#e0d5bd';
+  const hill1    = t.name === 'dark' ? '#352f25' : '#e0d5b9';
+  const hill2    = t.name === 'dark' ? '#2e3329' : '#d0dcbc';
+  const hill3    = t.name === 'dark' ? '#2a3329' : '#c0cfa8';
+  const water    = t.name === 'dark' ? '#3d5560' : '#9ab5bb';
+  const road     = t.name === 'dark' ? '#453e32' : '#d4c9b2';
+  const labelC   = t.name === 'dark' ? '#a89c85' : '#8a7f6a';
+  const gid = `mapbg-${Math.round(w)}-${t.name}`;
+  return (
+    <svg width={w} height={h} style={{ display: 'block' }}>
+      <defs>
+        <linearGradient id={gid} x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0" stopColor={mapBg} />
+          <stop offset="1" stopColor={mapBg2} />
+        </linearGradient>
+      </defs>
+      <rect width={w} height={h} fill={`url(#${gid})`} />
+      {!simplified && <>
+        <path d={`M 0 ${h*0.3} Q ${w*0.3} ${h*0.2}, ${w*0.6} ${h*0.35} T ${w} ${h*0.3} L ${w} 0 L 0 0 Z`} fill={hill1} opacity={0.6} />
+        <path d={`M 0 ${h*0.6} Q ${w*0.2} ${h*0.5}, ${w*0.4} ${h*0.65} T ${w*0.8} ${h*0.55} L ${w} ${h*0.65} L ${w} ${h} L 0 ${h} Z`} fill={hill2} opacity={0.6} />
+        <path d={`M 0 ${h*0.75} Q ${w*0.3} ${h*0.7}, ${w*0.6} ${h*0.8} T ${w} ${h*0.78} L ${w} ${h} L 0 ${h} Z`} fill={hill3} opacity={0.55} />
+        <path d={`M 0 ${h*0.85} Q ${w*0.4} ${h*0.75}, ${w*0.7} ${h*0.9} T ${w} ${h*0.72}`} fill="none" stroke={water} strokeWidth={Math.max(2, w/260)} opacity={0.7} />
+        <path d={`M ${w*0.2} 0 Q ${w*0.3} ${h*0.2}, ${w*0.25} ${h*0.4}`} fill="none" stroke={water} strokeWidth={Math.max(1.5, w/320)} opacity={0.6} />
+        <path d={`M 0 ${h*0.5} Q ${w*0.5} ${h*0.45}, ${w} ${h*0.55}`} fill="none" stroke={road} strokeWidth={1} />
+        <path d={`M ${w*0.35} 0 Q ${w*0.4} ${h*0.4}, ${w*0.3} ${h}`} fill="none" stroke={road} strokeWidth={1} />
+      </>}
+      {showLabels && (
+        <g fontFamily={t.sans} fontSize={Math.max(9, w/70)} fill={labelC} fontWeight={500}>
+          <text x={w*0.08} y={h*0.78}>LILLE</text>
+          <text x={w*0.42} y={h*0.66}>TOURNAI</text>
+          <text x={w*0.64} y={h*0.40}>OUDENAARDE</text>
+          <text x={w*0.84} y={h*0.17}>GAND</text>
+        </g>
+      )}
+      {ROUTE_DAYS.map((pts, i) => (
+        <path key={`s${i}`} d={pathFor(pts)} fill="none" stroke="#000" strokeWidth={Math.max(4, w/90)} opacity={0.12} strokeLinecap="round" strokeLinejoin="round" transform="translate(0 2)" />
+      ))}
+      {ROUTE_DAYS.map((pts, i) => (
+        <path key={i} d={pathFor(pts)} fill="none"
+          stroke={dayColors[i]}
+          strokeWidth={active === null || active === i ? Math.max(3, w/110) : Math.max(2, w/160)}
+          opacity={active === null || active === i ? 1 : 0.35}
+          strokeLinecap="round" strokeLinejoin="round" />
+      ))}
+      {ROUTE_DAYS.map((pts, i) => {
+        const [ex, ey] = toXY(pts[pts.length - 1]);
+        const R = Math.max(10, w/55);
+        return (
+          <g key={`m${i}`}>
+            <circle cx={ex} cy={ey+6} r={R-4} fill="#000" opacity={0.15} />
+            <circle cx={ex} cy={ey} r={R} fill={t.surface} stroke={dayColors[i]} strokeWidth={2.5} />
+            <text x={ex} y={ey+R/3} textAnchor="middle" fontFamily={t.sans} fontSize={R*0.85} fontWeight={700} fill={dayColors[i]}>{i+1}</text>
+          </g>
+        );
+      })}
+      {(() => {
+        const [sx, sy] = toXY(ROUTE[0]);
+        const R = Math.max(7, w/80);
+        return (
+          <g>
+            <circle cx={sx} cy={sy+6} r={R-2} fill="#000" opacity={0.15} />
+            <circle cx={sx} cy={sy} r={R} fill={t.ink} />
+            <circle cx={sx} cy={sy} r={R/2.5} fill={t.surface} />
+          </g>
+        );
+      })()}
+    </svg>
+  );
+}
+
+// ── Elevation profile ──────────────────────────────────────
+function ElevProfile({ w, h, up, down, distance, color, filled = true, showMarkers = false }) {
+  const t = useTheme();
+  const c = color || t.accent;
+  const N = 80;
+  const seed = up + down + distance;
+  const pts = [];
+  for (let i = 0; i < N; i++) {
+    const x = i / (N - 1);
+    const base = Math.sin(x * Math.PI * 1.1) * 0.6 + Math.sin(seed * 0.02 + i * 0.5) * 0.1 + Math.cos(seed * 0.03 + i * 0.2) * 0.07;
+    pts.push([x, Math.max(0.05, Math.min(1, base + 0.15))]);
+  }
+  const path = pts.map(([x, y], i) => `${i === 0 ? 'M' : 'L'} ${(x * w).toFixed(1)} ${((1 - y) * (h - 4) + 2).toFixed(1)}`).join(' ');
+  const filledPath = `${path} L ${w} ${h} L 0 ${h} Z`;
+  const gid = `elev-${Math.round(seed)}-${w}-${t.name}`;
+  return (
+    <svg width={w} height={h} style={{ display: 'block' }}>
+      <defs>
+        <linearGradient id={gid} x1="0" x2="0" y1="0" y2="1">
+          <stop offset="0" stopColor={c} stopOpacity="0.35" />
+          <stop offset="1" stopColor={c} stopOpacity="0" />
+        </linearGradient>
+      </defs>
+      {filled && <path d={filledPath} fill={`url(#${gid})`} />}
+      <path d={path} fill="none" stroke={c} strokeWidth={2} strokeLinejoin="round" />
+      {showMarkers && [0.25, 0.55, 0.78].map((x, i) => {
+        const p = pts[Math.floor(x * (N-1))];
+        const py = (1 - p[1]) * (h - 4) + 2;
+        return <circle key={i} cx={x * w} cy={py} r={3} fill={t.surface} stroke={c} strokeWidth={1.5} />;
+      })}
+    </svg>
+  );
+}
+
+// ── Alert row ──────────────────────────────────────────────
+function sevMap(t) {
+  return {
+    critical: { c: t.red,    bg: t.redSoft,    label: 'Critique',  ic: I.alert },
+    warning:  { c: t.accent, bg: t.accentSoft, label: 'Attention', ic: I.alert },
+    nudge:    { c: t.blue,   bg: t.blueSoft,   label: 'Info',      ic: I.info  },
+  };
+}
+function iconFor(key) {
+  return ({ info: I.info, sparkles: I.sparkle, wind: I.wind, steep: I.mountain, cross: I.flag, traffic: I.traffic, cobble: I.cobble, water: I.droplet, calendar: I.calendar, train: I.train })[key] || I.info;
+}
+
+function AlertRow({ alert, compact }) {
+  const t = useTheme();
+  const m = sevMap(t)[alert.sev];
+  return (
+    <div style={{ display: 'flex', gap: 11, padding: compact ? 10 : 13, background: t.surface, border: `1px solid ${t.line}`, borderRadius: 11 }}>
+      <div style={{ width: 32, height: 32, borderRadius: 9, background: m.bg, color: m.c, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+        {iconFor(alert.icon)}
+      </div>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ display: 'flex', gap: 6, alignItems: 'center', marginBottom: 2 }}>
+          <span style={{ fontSize: 12.5, fontWeight: 600, color: t.ink }}>{alert.title}</span>
+          <Pill sm color={m.c} bg={m.bg}>{m.label}</Pill>
+        </div>
+        <div style={{ fontSize: 11.5, color: t.inkSoft, lineHeight: 1.45 }}>{alert.body}</div>
+      </div>
+    </div>
+  );
+}
+
+// ── Desktop top nav ────────────────────────────────────────
+function TopNav({ active }) {
+  const t = useTheme();
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '14px 28px', borderBottom: `1px solid ${t.line}`, background: t.bg }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 30 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <Logo />
+          <span style={{ fontSize: 15, fontWeight: 600, color: t.ink, letterSpacing: -0.2 }}>Bike Trip Planner</span>
+        </div>
+        <div style={{ display: 'flex', gap: 2, background: t.surfaceAlt, padding: 3, borderRadius: 9 }}>
+          {[{k:'new',l:'Nouveau voyage'},{k:'trips',l:'Mes voyages'}].map(x => (
+            <div key={x.k} style={{ padding: '6px 13px', borderRadius: 7, fontSize: 12.5, fontWeight: 500, background: x.k === active ? t.surface : 'transparent', color: x.k === active ? t.ink : t.inkSoft, boxShadow: x.k === active ? t.shadowSoft : 'none' }}>{x.l}</div>
+          ))}
+        </div>
+      </div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <button style={{ padding: 8, border: `1px solid ${t.line}`, background: t.surface, borderRadius: 9, color: t.inkSoft, display: 'flex' }}>{I.help}</button>
+      </div>
+    </div>
+  );
+}
+
+function Logo({ size = 30 }) {
+  const t = useTheme();
+  return (
+    <div style={{ width: size, height: size, borderRadius: Math.round(size*0.28), background: t.ink, color: t.bg, display: 'flex', alignItems: 'center', justifyContent: 'center', fontWeight: 700, fontSize: size*0.5, letterSpacing: -1, position: 'relative' }}>
+      <svg width={size*0.6} height={size*0.6} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <circle cx="6" cy="15" r="4" /><circle cx="18" cy="15" r="4" /><path d="m12 15-3-6h5l-2 6 3-6" />
+      </svg>
+    </div>
+  );
+}
+
+// Mobile status bar + tab bar
+function StatusBar({ dark }) {
+  return (
+    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '6px 22px 4px', fontSize: 13, fontWeight: 600, color: dark ? '#f5ede0' : '#1a1814', fontFamily: 'SF Pro Display, -apple-system, sans-serif' }}>
+      <span>9:41</span>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
+        <svg width="17" height="10" viewBox="0 0 17 11" fill="none"><path d="M8.4 2.9A6 6 0 0 1 12 4.3l1-1a7.5 7.5 0 0 0-9.2 0l1 1a6 6 0 0 1 3.6-1.4Zm0 2.2c1 0 1.9.3 2.5 1l1-1a5.3 5.3 0 0 0-7 0l1 1c.6-.7 1.5-1 2.5-1Zm1.5 2.5-1.5 1.5L7 7.6a2 2 0 0 1 3 0Z" fill="currentColor"/></svg>
+        <svg width="14" height="10" viewBox="0 0 16 11" fill="none"><rect x="0.5" y="0.5" width="13" height="9" rx="2.5" stroke="currentColor" fill="none" opacity="0.5"/><rect x="2" y="2" width="10" height="6" rx="1" fill="currentColor"/><path d="M14.5 3.5V6.5" stroke="currentColor" strokeLinecap="round"/></svg>
+      </div>
+    </div>
+  );
+}
+
+function TabBar({ active }) {
+  const t = useTheme();
+  const items = [
+    { k: 'home', l: 'Planifier', i: I.plus },
+    { k: 'trips', l: 'Voyages', i: I.trips },
+    { k: 'faq', l: 'Aide', i: I.help },
+    { k: 'me', l: 'Moi', i: I.settings },
+  ];
+  return (
+    <div style={{ display: 'flex', borderTop: `1px solid ${t.line}`, background: t.surface, padding: '8px 0 22px' }}>
+      {items.map(x => {
+        const a = x.k === active;
+        return (
+          <div key={x.k} style={{ flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 2, color: a ? t.accent : t.inkMute }}>
+            {x.i}<span style={{ fontSize: 10, fontWeight: 500 }}>{x.l}</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+Object.assign(window, { ThemeCtx, useTheme, Pill, Card, Btn, Field, Input, I, Ic, MapCanvas, ElevProfile, sevMap, iconFor, AlertRow, TopNav, Logo, StatusBar, TabBar });

--- a/docs/recette/design/ui2.jsx
+++ b/docs/recette/design/ui2.jsx
@@ -1,0 +1,719 @@
+// ui2.jsx — New shared components for the full redesign
+// Depends on: ui.jsx (ThemeCtx, useTheme, I, Pill, Btn, Card, etc.)
+
+// ─── OSM Map container (realistic Leaflet-style, no SVG drawings) ────────────
+function OsmMap({ w, h, active = null, showMarkers = true, showPOI = false, dark: forceDark }) {
+  const t = useTheme();
+  const dark = forceDark !== undefined ? forceDark : (t.name === 'dark');
+
+  // OSM tile style colors
+  const bg      = dark ? '#1a1f2e' : '#f8f4ec';
+  const water   = dark ? '#1a2a3d' : '#a8d8ea';
+  const park    = dark ? '#1e2d1e' : '#d4e9c4';
+  const road1   = dark ? '#2a2420' : '#ffffff';
+  const road2   = dark ? '#252018' : '#f0ece0';
+  const build   = dark ? '#1e1c18' : '#e8e0d4';
+  const text    = dark ? '#9a9a8a' : '#666050';
+  const dayColors = ['#4a7a3e','#c2671e','#3d6b91','#b86a3e'];
+
+  const toXY = ([nx, ny]) => [nx * w, ny * h];
+
+  return (
+    <svg width={w} height={h} style={{ display: 'block' }}>
+      {/* Base */}
+      <rect width={w} height={h} fill={bg}/>
+      {/* Parks */}
+      <path d={`M 0 ${h*.6} Q ${w*.2} ${h*.5}, ${w*.4} ${h*.65} T ${w*.8} ${h*.55} L ${w} ${h*.65} L ${w} ${h} L 0 ${h} Z`} fill={park} opacity={0.7}/>
+      {/* Water */}
+      <path d={`M 0 ${h*.85} Q ${w*.4} ${h*.75}, ${w*.7} ${h*.9} T ${w} ${h*.72}`} fill="none" stroke={water} strokeWidth={Math.max(3, w/120)} opacity={0.9}/>
+      <path d={`M ${w*.2} 0 Q ${w*.3} ${h*.2}, ${w*.25} ${h*.4}`} fill="none" stroke={water} strokeWidth={Math.max(2, w/180)} opacity={0.8}/>
+      {/* Buildings */}
+      {Array.from({length: 18}).map((_, i) => {
+        const x = (i * 73 + 15) % (w - 30); const y = (i * 57 + 20) % (h - 20);
+        return <rect key={i} x={x} y={y} width={18+i%12} height={14+i%8} rx={1} fill={build} opacity={0.6}/>;
+      })}
+      {/* Primary roads */}
+      <path d={`M 0 ${h*.5} Q ${w*.5} ${h*.45}, ${w} ${h*.55}`} fill="none" stroke={road1} strokeWidth={3} opacity={0.8}/>
+      <path d={`M ${w*.35} 0 Q ${w*.4} ${h*.4}, ${w*.3} ${h}`} fill="none" stroke={road1} strokeWidth={3} opacity={0.7}/>
+      {/* Secondary roads */}
+      <path d={`M 0 ${h*.3} Q ${w*.3} ${h*.28}, ${w*.6} ${h*.35}`} fill="none" stroke={road2} strokeWidth={1.5}/>
+      <path d={`M ${w*.6} 0 Q ${w*.65} ${h*.3}, ${w*.7} ${h*.6}`} fill="none" stroke={road2} strokeWidth={1.5}/>
+      {/* City names */}
+      <g fontFamily={t.sans} fontSize={Math.max(9, w/80)} fill={text} fontWeight={500}>
+        <text x={w*.06} y={h*.78}>Lille</text>
+        <text x={w*.4} y={h*.67}>Tournai</text>
+        <text x={w*.63} y={h*.42}>Oudenaarde</text>
+        <text x={w*.84} y={h*.18}>Gand</text>
+      </g>
+      {/* Route polylines */}
+      {ROUTE_DAYS.map((pts, i) => {
+        const pathD = pts.map(([nx, ny], j) => `${j===0?'M':'L'} ${(nx*w).toFixed(1)} ${(ny*h).toFixed(1)}`).join(' ');
+        const c = dayColors[i];
+        return (
+          <g key={i}>
+            <path d={pathD} fill="none" stroke="#000" strokeWidth={6} opacity={0.12} strokeLinecap="round" strokeLinejoin="round" transform="translate(0 2)"/>
+            <path d={pathD} fill="none" stroke={c} strokeWidth={active===null||active===i?4:2.5}
+              opacity={active===null||active===i?1:0.3} strokeLinecap="round" strokeLinejoin="round"/>
+          </g>
+        );
+      })}
+      {/* Stage end markers */}
+      {showMarkers && ROUTE_DAYS.map((pts, i) => {
+        const [ex, ey] = toXY(pts[pts.length-1]);
+        const c = dayColors[i];
+        const R = Math.max(11, w/60);
+        return (
+          <g key={`m${i}`}>
+            <circle cx={ex} cy={ey+5} r={R-2} fill="#000" opacity={0.2}/>
+            <circle cx={ex} cy={ey} r={R} fill="#fff" stroke={c} strokeWidth={2.5}/>
+            <text x={ex} y={ey+R*.35} textAnchor="middle" fontFamily={t.sans} fontSize={R*.85} fontWeight={700} fill={c}>{i+1}</text>
+          </g>
+        );
+      })}
+      {/* Start marker */}
+      {(() => {
+        const [sx, sy] = toXY(ROUTE[0]);
+        return (
+          <g>
+            <circle cx={sx} cy={sy+5} r={6} fill="#000" opacity={0.2}/>
+            <circle cx={sx} cy={sy} r={8} fill={t.name==='dark'?'#f0ebe0':'#1f1d1a'}/>
+            <circle cx={sx} cy={sy} r={3} fill="#fff"/>
+          </g>
+        );
+      })()}
+      {/* POI icons — see pulsating cultural POIs below */}
+      {/* Pulsating cultural POI markers */}
+      {showPOI && (
+        <g>
+          {/* Cultural POIs with pulse halo */}
+          {[
+            { cx: w*.25, cy: h*.62, icon: '🏛️', label: 'Villa Cavrois' },
+            { cx: w*.52, cy: h*.44, icon: '🏰', label: 'Château de Tournai' },
+            { cx: w*.72, cy: h*.32, icon: '⛪', label: 'Église St-Walburge' },
+          ].map((poi, pi) => (
+            <g key={`cpoi-${pi}`}>
+              {/* Animated pulse halo */}
+              <circle cx={poi.cx} cy={poi.cy} r={14} fill="none" stroke={dark?'#f1c999':'#c2671e'} strokeWidth={1.5} opacity={0.6}>
+                <animate attributeName="r" values="8;18;8" dur="2s" repeatCount="indefinite"/>
+                <animate attributeName="opacity" values="0.7;0.1;0.7" dur="2s" repeatCount="indefinite"/>
+              </circle>
+              <circle cx={poi.cx} cy={poi.cy} r={10} fill="none" stroke={dark?'#f1c999':'#c2671e'} strokeWidth={1} opacity={0.35}>
+                <animate attributeName="r" values="10;22;10" dur="2s" repeatCount="indefinite" begin="0.3s"/>
+                <animate attributeName="opacity" values="0.5;0;0.5" dur="2s" repeatCount="indefinite" begin="0.3s"/>
+              </circle>
+              {/* POI dot */}
+              <circle cx={poi.cx} cy={poi.cy} r={8} fill={dark?'#2a2418':'#fff'} stroke={dark?'#f1c999':'#c2671e'} strokeWidth={2}/>
+              <text x={poi.cx} y={poi.cy+3.5} textAnchor="middle" fontSize={9}>{poi.icon}</text>
+            </g>
+          ))}
+          {/* Non-cultural POIs (static, no pulse) */}
+          <circle cx={w*.38} cy={h*.7} r={6} fill="#3d6b91" stroke="#fff" strokeWidth={1.5}/>
+          <circle cx={w*.15} cy={h*.55} r={5} fill="#4a7a3e" stroke="#fff" strokeWidth={1.5}/>
+          <circle cx={w*.60} cy={h*.58} r={5} fill="#8a5a2e" stroke="#fff" strokeWidth={1.5}/>
+        </g>
+      )}
+      {/* OSM attribution */}
+      <text x={w-8} y={h-5} textAnchor="end" fontFamily={t.sans} fontSize={9} fill={dark?'rgba(255,255,255,0.4)':'rgba(0,0,0,0.4)'}>© OpenStreetMap contributors</text>
+    </svg>
+  );
+}
+
+// ─── Elevation profile ────────────────────────────────────────────────────────
+function ElevProfile({ w, h, up, down, distance, color, filled = true, showMarkers = false }) {
+  const t = useTheme();
+  const c = color || t.accent;
+  const N = 80;
+  const seed = up + down + distance;
+  const pts = [];
+  for (let i = 0; i < N; i++) {
+    const x = i / (N-1);
+    const base = Math.sin(x*Math.PI*1.1)*0.6 + Math.sin(seed*0.02+i*0.5)*0.1 + Math.cos(seed*0.03+i*0.2)*0.07;
+    pts.push([x, Math.max(0.05, Math.min(1, base+0.15))]);
+  }
+  const path = pts.map(([x,y],i) => `${i===0?'M':'L'} ${(x*w).toFixed(1)} ${((1-y)*(h-4)+2).toFixed(1)}`).join(' ');
+  const gid = `elev-${Math.round(seed)}-${Math.round(w)}-${t.name}`;
+  return (
+    <svg width={w} height={h} style={{display:'block'}}>
+      <defs>
+        <linearGradient id={gid} x1="0" x2="0" y1="0" y2="1">
+          <stop offset="0" stopColor={c} stopOpacity="0.35"/>
+          <stop offset="1" stopColor={c} stopOpacity="0"/>
+        </linearGradient>
+      </defs>
+      {filled && <path d={`${path} L ${w} ${h} L 0 ${h} Z`} fill={`url(#${gid})`}/>}
+      <path d={path} fill="none" stroke={c} strokeWidth={2} strokeLinejoin="round"/>
+      {showMarkers && [0.25,0.55,0.78].map((x,i) => {
+        const p = pts[Math.floor(x*(N-1))];
+        const py = (1-p[1])*(h-4)+2;
+        return <circle key={i} cx={x*w} cy={py} r={3} fill={t.surface} stroke={c} strokeWidth={1.5}/>;
+      })}
+    </svg>
+  );
+}
+
+// ─── Top bar desktop (full version) ──────────────────────────────────────────
+function TopBarDesktop({ page = 'none', showUndo = false, showShare = false, onShare, lang = 'FR', dark: isDark, onToggleDark }) {
+  const t = useTheme();
+  return (
+    <div style={{ display:'flex', alignItems:'center', justifyContent:'space-between', padding:'0 24px', borderBottom:`1px solid ${t.line}`, background:t.bg, height:52, flexShrink:0, gap:8 }}>
+      {/* Left: logo + nav */}
+      <div style={{ display:'flex', alignItems:'center', gap:20 }}>
+        <div style={{ display:'flex', alignItems:'center', gap:8 }}>
+          <Logo size={28}/>
+          <span style={{ fontSize:14, fontWeight:600, color:t.ink, letterSpacing:-0.2 }}>Bike Trip Planner</span>
+        </div>
+        <div style={{ display:'flex', gap:2, background:t.surfaceAlt, padding:3, borderRadius:8 }}>
+          {[{k:'new',l:'Nouveau voyage'},{k:'trips',l:'Mes voyages'}].map(x => (
+            <div key={x.k} style={{ padding:'5px 12px', borderRadius:6, fontSize:12.5, fontWeight:500, background:x.k===page?t.surface:'transparent', color:x.k===page?t.ink:t.inkSoft, boxShadow:x.k===page?t.shadowSoft:'none', cursor:'pointer' }}>{x.l}</div>
+          ))}
+        </div>
+      </div>
+
+      {/* Right */}
+      <div style={{ display:'flex', alignItems:'center', gap:6 }}>
+        {/* Undo/Redo — only on roadbook */}
+        {showUndo && (
+          <div style={{ display:'flex', gap:2, marginRight:4 }}>
+            <div style={{ width:30, height:30, borderRadius:7, border:`1px solid ${t.line}`, background:t.surface, display:'flex', alignItems:'center', justifyContent:'center', color:t.inkSoft, cursor:'pointer' }}>
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M3 7v6h6"/><path d="M21 17a9 9 0 0 0-9-9 9 9 0 0 0-6 2.3L3 13"/></svg>
+            </div>
+            <div style={{ width:30, height:30, borderRadius:7, border:`1px solid ${t.line}`, background:t.surface, display:'flex', alignItems:'center', justifyContent:'center', color:t.inkSoft, cursor:'pointer', opacity:0.45 }}>
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 7v6h-6"/><path d="M3 17a9 9 0 0 1 9-9 9 9 0 0 1 6 2.3L21 13"/></svg>
+            </div>
+          </div>
+        )}
+        {/* Share button */}
+        {showShare && (
+          <Btn variant="accent" size="sm" icon={I.share} style={{ marginRight:4 }}>Partager</Btn>
+        )}
+        {/* Help */}
+        <div style={{ width:30, height:30, borderRadius:7, border:`1px solid ${t.line}`, background:t.surface, display:'flex', alignItems:'center', justifyContent:'center', color:t.inkSoft, cursor:'pointer', fontSize:13, fontWeight:700 }}>?</div>
+        {/* Language pills */}
+        <div style={{ display:'flex', background:t.surfaceAlt, borderRadius:6, padding:'2px', gap:1 }}>
+          {['FR','EN'].map(l => (
+            <div key={l} style={{ padding:'3px 8px', borderRadius:5, fontSize:11, fontWeight:600, background:l===lang?t.surface:'transparent', color:l===lang?t.ink:t.inkSoft, cursor:'pointer', boxShadow:l===lang?t.shadowSoft:'none' }}>{l}</div>
+          ))}
+        </div>
+
+        {/* Theme toggle */}
+        <div style={{ display:'flex', background:t.surfaceAlt, borderRadius:6, padding:'2px', gap:1 }}>
+          {[{icon:'☀',dark:false},{icon:'☾',dark:true}].map((l,i) => (
+            <div key={i} style={{ padding:'3px 9px', borderRadius:5, fontSize:13, background:(t.name==='dark'===l.dark)?t.surface:'transparent', color:(t.name==='dark'===l.dark)?t.ink:t.inkSoft, cursor:'pointer', boxShadow:(t.name==='dark'===l.dark)?t.shadowSoft:'none', lineHeight:1 }}>{l.icon}</div>
+          ))}
+        </div>
+        {/* Profile button */}
+        <div style={{ width:30, height:30, borderRadius:'50%', background:t.accent, color:'#fff', display:'flex', alignItems:'center', justifyContent:'center', fontWeight:600, fontSize:13, cursor:'pointer', flexShrink:0 }}>N</div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Desktop footer ────────────────────────────────────────────────────────────
+function DesktopFooter() {
+  const t = useTheme();
+  return (
+    <div style={{ padding:'12px 28px', borderTop:`1px solid ${t.line}`, background:t.surfaceAlt, display:'flex', justifyContent:'space-between', alignItems:'center', flexShrink:0 }}>
+      <div style={{ fontSize:11, color:t.inkMute }}>© 2026 Bike Trip Planner</div>
+      <div style={{ display:'flex', gap:18, fontSize:11.5, color:t.inkSoft }}>
+        {['FAQ','Confidentialité','Mentions légales','GitHub'].map((l,i) => (
+          <span key={i} style={{ cursor:'pointer', display:'flex', alignItems:'center', gap:4 }}>{i===3?<>{React.cloneElement(I.github,{width:12,height:12})}{l}</>:l}</span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ─── Cookie banner ─────────────────────────────────────────────────────────────
+function CookieBanner() {
+  const t = useTheme();
+  return (
+    <div style={{ position:'absolute', bottom:0, left:0, right:0, background:t.surface, borderTop:`1px solid ${t.line}`, padding:'12px 24px', display:'flex', alignItems:'center', justifyContent:'space-between', gap:16, zIndex:20, boxShadow:`0 -2px 12px rgba(0,0,0,0.08)` }}>
+      <div style={{ flex:1, fontSize:12.5, color:t.inkSoft, lineHeight:1.5 }}>
+        Cookies techniques essentiels et analytics anonymes (sans IP, sans empreinte de navigateur, sans cross-site tracking). <span style={{ color:t.accent, fontWeight:600, cursor:'pointer' }}>Personnaliser</span>
+      </div>
+      <div style={{ display:'flex', gap:8, flexShrink:0 }}>
+        <Btn variant="ghost" size="sm">Tout refuser</Btn>
+        <Btn variant="accent" size="sm">Tout accepter</Btn>
+      </div>
+    </div>
+  );
+}
+
+// ─── Alert with actions (P0.8) ─────────────────────────────────────────────────
+const ACTION_META = {
+  AUTO_FIX: { label:'Corriger', icon:'wrench' },
+  DETOUR:   { label:'Itinéraire alternatif', icon:'map' },
+  NAVIGATE: { label:'Naviguer', icon:'navigation' },
+  DISMISS:  { label:'Écarter', icon:'check' },
+};
+const ICON_FOR_ACTION = {
+  wrench: <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg>,
+  map: <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polygon points="3 6 9 3 15 6 21 3 21 18 15 21 9 18 3 21"/><line x1="9" y1="3" x2="9" y2="18"/><line x1="15" y1="6" x2="15" y2="21"/></svg>,
+  navigation: <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polygon points="3 11 22 2 13 21 11 13 3 11"/></svg>,
+  check: <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><polyline points="20 6 9 17 4 12"/></svg>,
+};
+
+function AlertGroup({ alerts, compact = false }) {
+  const t = useTheme();
+  const [collapsed, setCollapsed] = React.useState({});
+
+  const grouped = { critical: [], warning: [], nudge: [] };
+  (alerts || []).forEach(a => (grouped[a.sev] || grouped.nudge).push(a));
+
+  const sevStyle = {
+    critical: { c: t.red,    bg: t.redSoft,    label: 'Critique' },
+    warning:  { c: t.accent, bg: t.accentSoft, label: 'Attention' },
+    nudge:    { c: t.blue,   bg: t.blueSoft,   label: 'Info' },
+  };
+
+  return (
+    <div style={{ display:'flex', flexDirection:'column', gap:6 }}>
+      {['critical','warning','nudge'].map(sev => {
+        const items = grouped[sev];
+        if (!items.length) return null;
+        const s = sevStyle[sev];
+        const isCollapsed = collapsed[sev];
+        return (
+          <div key={sev} style={{ border:`1px solid ${s.c}30`, borderRadius:11, overflow:'hidden' }}>
+            {/* Header */}
+            <div onClick={() => setCollapsed(p=>({...p,[sev]:!p[sev]}))} style={{ display:'flex', alignItems:'center', gap:8, padding:'8px 12px', background:s.bg, cursor:'pointer', userSelect:'none' }}>
+              <Pill sm color={s.c} bg={`${s.c}20`} bold>{s.label}</Pill>
+              <span style={{ fontSize:11.5, fontWeight:600, color:s.c }}>{items.length}</span>
+              <span style={{ marginLeft:'auto', color:s.c, display:'flex', transform:isCollapsed?'none':'rotate(90deg)', transition:'transform 0.15s' }}>
+                {I.chevron}
+              </span>
+            </div>
+            {/* Items */}
+            {!isCollapsed && (
+              <div style={{ display:'flex', flexDirection:'column', gap:1, background:t.surface }}>
+                {items.map((a,i) => (
+                  <div key={i} style={{ padding:compact?'8px 12px':'10px 12px', borderTop:i>0?`1px solid ${t.lineSoft}`:undefined }}>
+                    <div style={{ fontSize:compact?12:13, fontWeight:600, color:t.ink, marginBottom:2 }}>{a.title}</div>
+                    <div style={{ fontSize:11, color:t.inkSoft, lineHeight:1.45, marginBottom:a.action?6:0 }}>{a.body}</div>
+                    {a.action && (
+                      <button style={{ display:'inline-flex', alignItems:'center', gap:4, padding:'3px 8px', borderRadius:5, border:`1px solid ${s.c}`, background:'transparent', color:s.c, fontSize:10.5, fontWeight:600, cursor:'pointer' }}>
+                        {ICON_FOR_ACTION[ACTION_META[a.action]?.icon]}
+                        {ACTION_META[a.action]?.label}
+                      </button>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// Augment STAGES.alerts with action field for demo
+const RICH_ALERTS = {
+  0: [
+    { sev:'nudge', icon:'info', title:'Pause café — Lambersart', body:'Pâtisserie Aux Deux Mondes · km 14,2 · ouvert 07h-19h', action:'NAVIGATE' },
+    { sev:'nudge', icon:'sparkles', title:'POI culturel — Villa Cavrois', body:'Monument historique · ouv. 10h-18h · 9 €', action:'NAVIGATE' },
+  ],
+  1: [
+    { sev:'warning', icon:'wind', title:'Vent de face modéré (Headwind)', body:'22 km/h face route sur 60% du tronçon', action:'DISMISS' },
+    { sev:'warning', icon:'steep', title:'Pente soutenue km 28–31', body:'Gradient moyen 9,2% sur 2,8 km · sustained ≥ 8%', action:'DETOUR' },
+    { sev:'nudge', icon:'cross', title:'Traversée de frontière', body:'France → Belgique · pensez à votre CNI', action:'NAVIGATE' },
+  ],
+  2: [
+    { sev:'critical', icon:'traffic', title:'Route N60 sans piste cyclable', body:'1,3 km route primaire · détour +2,8 km suggéré', action:'DETOUR' },
+    { sev:'warning', icon:'cobble', title:'Secteur pavé — Koppenberg', body:'700 m pavés irréguliers · km 24,5', action:'AUTO_FIX' },
+    { sev:'nudge', icon:'water', title:'Point d\'eau · km 12,8', body:'Fontaine publique · qualité potable vérifiée', action:'NAVIGATE' },
+  ],
+  3: [
+    { sev:'nudge', icon:'calendar', title:'Dimanche — commerces fermés', body:'Possiblement après 13h', action:'DISMISS' },
+    { sev:'nudge', icon:'train', title:'Gare SNCB à 1,2 km', body:'Retour direct Gand → Lille (1h45)', action:'NAVIGATE' },
+  ],
+};
+
+// ─── 9 Accommodation types ───────────────────────────────────────────────────
+const ACC_TYPES = {
+  hotel:         { label:'Hôtel',           icon:'🏨', color:'#3d6b91' },
+  motel:         { label:'Motel',           icon:'🛣️', color:'#5a6b7a' },
+  guest_house:   { label:'Chambre d\'hôtes',icon:'🏡', color:'#6b5a3e' },
+  chalet:        { label:'Chalet',          icon:'🏔️', color:'#3e6b4a' },
+  hostel:        { label:'Auberge',         icon:'🏠', color:'#8a5a2e' },
+  alpine_hut:    { label:'Refuge alpin',    icon:'⛺', color:'#5a3e7a' },
+  camp_site:     { label:'Camping',         icon:'🏕️', color:'#4a7a3e' },
+  wilderness_hut:{ label:'Abri',            icon:'🛖', color:'#6b4a2e' },
+  shelter:       { label:'Bivouac',         icon:'🌿', color:'#3e6b3e' },
+};
+
+// ─── Enhanced weather card ────────────────────────────────────────────────────
+function WeatherCard({ weather, stageKm = 0 }) {
+  const t = useTheme();
+  if (!weather) return null;
+
+  // Simulate enhanced data
+  const comfort = weather.wind > 20 ? 42 : weather.wind > 10 ? 68 : 82;
+  const humidity = 55 + Math.round(weather.wind * 1.2);
+  const rainProb = weather.wind > 20 ? 35 : 12;
+  const windType = weather.windDir === 'W' || weather.windDir === 'SW' ? 'headwind' :
+                   weather.windDir === 'E' || weather.windDir === 'NE' ? 'tailwind' : 'crosswind';
+  const windLabel = { headwind:'Vent de face', tailwind:'Vent dans le dos', crosswind:'Vent latéral' }[windType];
+  const windColor = windType === 'headwind' ? t.red : windType === 'tailwind' ? t.green : t.accent;
+  const comfortColor = comfort > 70 ? t.green : comfort > 40 ? t.accent : t.red;
+
+  return (
+    <div style={{ background:t.surface, border:`1px solid ${t.line}`, borderRadius:12, padding:14 }}>
+      <div style={{ display:'flex', justifyContent:'space-between', alignItems:'flex-start', marginBottom:12 }}>
+        <div>
+          <div style={{ fontSize:10.5, color:t.inkSoft, fontWeight:600, letterSpacing:0.4, textTransform:'uppercase', marginBottom:4 }}>Météo</div>
+          <div style={{ fontSize:26, fontWeight:600, lineHeight:1 }}>{weather.t}°C</div>
+        </div>
+        <div style={{ textAlign:'right' }}>
+          <div style={{ fontSize:12, fontWeight:600, color:comfortColor, marginBottom:2 }}>Confort {comfort}/100</div>
+          <div style={{ width:80, height:6, background:t.surfaceAlt, borderRadius:3, overflow:'hidden' }}>
+            <div style={{ width:`${comfort}%`, height:'100%', background:comfortColor, borderRadius:3 }}/>
+          </div>
+        </div>
+      </div>
+      <div style={{ display:'grid', gridTemplateColumns:'1fr 1fr', gap:8 }}>
+        <div style={{ padding:'8px 10px', background:t.surfaceAlt, borderRadius:8 }}>
+          <div style={{ fontSize:9.5, color:t.inkMute, fontWeight:600, letterSpacing:0.4, textTransform:'uppercase', marginBottom:3 }}>Vent</div>
+          <div style={{ fontSize:13.5, fontWeight:600, color:windColor }}>{weather.wind} km/h</div>
+          <div style={{ fontSize:10.5, color:windColor, fontWeight:600 }}>{windLabel}</div>
+        </div>
+        <div style={{ padding:'8px 10px', background:t.surfaceAlt, borderRadius:8 }}>
+          <div style={{ fontSize:9.5, color:t.inkMute, fontWeight:600, letterSpacing:0.4, textTransform:'uppercase', marginBottom:3 }}>Humidité</div>
+          <div style={{ fontSize:13.5, fontWeight:600 }}>{humidity}%</div>
+          <div style={{ fontSize:10.5, color:t.inkSoft }}>Pluie {rainProb}%</div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Supply timeline ──────────────────────────────────────────────────────────
+function SupplyTimeline({ stageKm = 42.5 }) {
+  const t = useTheme();
+  const markers = [
+    { km: 8.2, type: 'water', label: 'Fontaine' },
+    { km: 14.5, type: 'food', label: 'Boulangerie' },
+    { km: 22.1, type: 'water', label: 'Aire de repos' },
+    { km: 28.8, type: 'bike', label: 'Atelier vélo' },
+    { km: 36.4, type: 'food', label: 'Supermarché' },
+  ];
+  const typeColor = { water:'#3d6b91', food:'#4a7a3e', bike:'#c2671e' };
+  const typeIcon = { water:'💧', food:'🛒', bike:'🔧' };
+
+  return (
+    <div style={{ background:t.surface, border:`1px solid ${t.line}`, borderRadius:12, padding:14 }}>
+      <div style={{ fontSize:11, fontWeight:600, color:t.inkSoft, letterSpacing:0.4, textTransform:'uppercase', marginBottom:10 }}>Timeline ravitaillement</div>
+      <div style={{ position:'relative', height:40 }}>
+        {/* Track */}
+        <div style={{ position:'absolute', left:0, right:0, top:'50%', height:3, background:t.surfaceAlt, borderRadius:2, transform:'translateY(-50%)' }}/>
+        {/* Start/end labels */}
+        <div style={{ position:'absolute', left:0, bottom:-18, fontSize:10, color:t.inkMute, fontFamily:t.mono }}>0 km</div>
+        <div style={{ position:'absolute', right:0, bottom:-18, fontSize:10, color:t.inkMute, fontFamily:t.mono }}>{stageKm} km</div>
+        {/* Markers */}
+        {markers.map((m, i) => {
+          const pct = (m.km / stageKm) * 100;
+          const c = typeColor[m.type];
+          return (
+            <div key={i} title={`${m.label} · km ${m.km}`} style={{ position:'absolute', left:`${pct}%`, top:'50%', transform:'translate(-50%, -50%)', width:20, height:20, borderRadius:'50%', background:c, border:`2px solid ${t.surface}`, display:'flex', alignItems:'center', justifyContent:'center', fontSize:9, cursor:'pointer', boxShadow:'0 1px 4px rgba(0,0,0,0.2)' }}>
+              {typeIcon[m.type]}
+            </div>
+          );
+        })}
+      </div>
+      {/* Legend */}
+      <div style={{ display:'flex', gap:12, marginTop:22 }}>
+        {Object.entries(typeColor).map(([k,c]) => (
+          <div key={k} style={{ display:'flex', alignItems:'center', gap:4, fontSize:10.5, color:t.inkSoft }}>
+            <div style={{ width:10, height:10, borderRadius:'50%', background:c }}/>{typeIcon[k]} {k==='water'?'Eau':k==='food'?'Ravitaillement':'Atelier'}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ─── Difficulty gauge ─────────────────────────────────────────────────────────
+function DifficultyGauge({ score = 55 }) {
+  const t = useTheme();
+  const color = score >= 70 ? t.red : score >= 40 ? t.accent : t.green;
+  const label = score >= 70 ? 'Difficile' : score >= 40 ? 'Intermédiaire' : 'Facile';
+  const segments = [
+    { label:'Facile', color:t.green, w:40 },
+    { label:'Intermédiaire', color:t.accent, w:35 },
+    { label:'Difficile', color:t.red, w:25 },
+  ];
+  return (
+    <div style={{ background:t.surface, border:`1px solid ${t.line}`, borderRadius:12, padding:14 }}>
+      <div style={{ display:'flex', justifyContent:'space-between', alignItems:'center', marginBottom:8 }}>
+        <div style={{ fontSize:11, fontWeight:600, color:t.inkSoft, letterSpacing:0.4, textTransform:'uppercase' }}>Difficulté</div>
+        <div style={{ fontSize:13, fontWeight:700, color }}>{label} · {score}/100</div>
+      </div>
+      <div style={{ display:'flex', height:8, borderRadius:4, overflow:'hidden', gap:1 }}>
+        {segments.map((s,i) => (
+          <div key={i} style={{ flex:s.w, background:s.color, opacity:0.3+0.7*(
+            s.label==='Facile'?1:
+            s.label==='Intermédiaire'&&score>=40?1:
+            s.label==='Difficile'&&score>=70?1:0.15
+          ) }}/>
+        ))}
+      </div>
+      {/* Marker */}
+      <div style={{ position:'relative', height:14, marginTop:2 }}>
+        <div style={{ position:'absolute', left:`${score}%`, transform:'translateX(-50%)', width:0, height:0, borderLeft:'5px solid transparent', borderRight:'5px solid transparent', borderBottom:`7px solid ${color}` }}/>
+      </div>
+    </div>
+  );
+}
+
+// ─── AI Summary card (Sprint 27) ──────────────────────────────────────────────
+function AISummaryCard({ text, global = false }) {
+  const t = useTheme();
+  return (
+    <div style={{ background:t.name==='dark'?`linear-gradient(135deg, #1e1a14, #2a2418)`:t.surfaceAlt, border:`1px solid ${t.line}`, borderRadius:12, padding:14, position:'relative' }}>
+      <div style={{ position:'absolute', top:10, right:10, opacity:0.12 }}>{React.cloneElement(I.sparkle,{width:32,height:32})}</div>
+      <div style={{ display:'flex', alignItems:'center', gap:6, marginBottom:8 }}>
+        <div style={{ width:22, height:22, borderRadius:6, background:t.accent, display:'flex', alignItems:'center', justifyContent:'center' }}>{React.cloneElement(I.sparkle,{width:11,height:11,color:'#fff'})}</div>
+        <span style={{ fontSize:11, fontWeight:700, color:t.accent, letterSpacing:0.5, textTransform:'uppercase' }}>{global?'Résumé IA du voyage':'Résumé IA de l\'étape'}</span>
+      </div>
+      <p style={{ fontFamily:t.serif, fontSize:global?15:13, fontStyle:'italic', lineHeight:1.6, color:t.ink, margin:0 }}>{text}</p>
+    </div>
+  );
+}
+
+// ─── Batch mode floating button (Sprint 24) ──────────────────────────────────
+function BatchModeButton({ count = 3 }) {
+  const t = useTheme();
+  return (
+    <div style={{ position:'absolute', bottom:24, right:24, display:'flex', gap:8, alignItems:'center', zIndex:10 }}>
+      <button style={{ padding:'8px 14px', background:t.surface, border:`1px solid ${t.line}`, borderRadius:10, fontSize:12.5, fontWeight:500, color:t.inkSoft, cursor:'pointer', boxShadow:t.shadow }}>Annuler toutes</button>
+      <button style={{ padding:'8px 16px', background:t.accent, border:'none', borderRadius:10, fontSize:13, fontWeight:600, color:'#fff', cursor:'pointer', boxShadow:`0 4px 16px ${t.accent}55` }}>
+        Appliquer ({count} modifications)
+      </button>
+    </div>
+  );
+}
+
+// ─── Progress bar recomputation (Sprint 24) ─────────────────────────────────
+function RecomputeBar({ progress = 65 }) {
+  const t = useTheme();
+  return (
+    <div style={{ position:'absolute', top:0, left:0, right:0, height:2, background:t.line, zIndex:10 }}>
+      <div style={{ height:'100%', width:`${progress}%`, background:t.accent, borderRadius:1, transition:'width 0.3s' }}/>
+    </div>
+  );
+}
+
+// ─── Locked banner ────────────────────────────────────────────────────────────
+function LockedBanner() {
+  const t = useTheme();
+  return (
+    <div style={{ background:t.accentSoft, borderBottom:`1px solid ${t.accent}30`, padding:'7px 24px', display:'flex', alignItems:'center', gap:8, fontSize:12.5, color:t.accentInk, flexShrink:0 }}>
+      {React.cloneElement(I.lock,{width:13,height:13})}
+      <span><strong>Voyage verrouillé</strong> — lecture seule pendant le calcul ou après expiration.</span>
+    </div>
+  );
+}
+
+// ─── Shimmer skeleton ────────────────────────────────────────────────────────
+function Shimmer({ w = '100%', h = 16, r = 8, dark: isDark }) {
+  const t = useTheme();
+  const cls = t.name === 'dark' ? 'dark-shimmer-bg' : 'shimmer-bg';
+  return <div className={cls} style={{ width: w, height: h, borderRadius: r }}/>;
+}
+
+// ─── AI Chat bubble (Sprint 28) ──────────────────────────────────────────────
+function AIChatBubble() {
+  const t = useTheme();
+  return (
+    <div style={{ position:'absolute', bottom:24, right:24, zIndex:10 }}>
+      <div style={{ width:48, height:48, borderRadius:'50%', background:t.accent, color:'#fff', display:'flex', alignItems:'center', justifyContent:'center', cursor:'pointer', boxShadow:`0 4px 20px ${t.accent}66, 0 0 0 4px ${t.accentSoft}` }}>
+        {React.cloneElement(I.sparkle,{width:20,height:20})}
+      </div>
+    </div>
+  );
+}
+
+// ─── POI Popover — Variante A (enrichie) ─────────────────────────────────────
+function POIPopoverRich({ dark: forceDark }) {
+  const t = useTheme();
+  return (
+    <div style={{ width:320, background:t.surface, border:`1px solid ${t.line}`, borderRadius:14, boxShadow:t.shadow, overflow:'hidden', fontFamily:t.sans, color:t.ink }}>
+      {/* Photo header */}
+      <div style={{ height:140, position:'relative', overflow:'hidden' }}>
+        <div style={{ width:'100%', height:'100%', background:`linear-gradient(135deg, ${t.name==='dark'?'#2a3020':'#d4dcc0'} 0%, ${t.name==='dark'?'#1e2818':'#c0d0a0'} 100%)`, display:'flex', alignItems:'center', justifyContent:'center' }}>
+          <div style={{ textAlign:'center', color:t.inkMute }}>
+            <div style={{ fontSize:36, marginBottom:4 }}>🏰</div>
+            <div style={{ fontSize:10, fontFamily:t.mono, opacity:0.6 }}>photo Wikimedia P18</div>
+          </div>
+        </div>
+        {/* Category pill overlay */}
+        <div style={{ position:'absolute', top:10, left:10 }}>
+          <Pill sm bg="rgba(0,0,0,.55)" color="#fff" bold>Château</Pill>
+        </div>
+        {/* Distance pill */}
+        <div style={{ position:'absolute', top:10, right:10 }}>
+          <Pill sm bg="rgba(0,0,0,.55)" color="#fff">1,2 km du tracé</Pill>
+        </div>
+      </div>
+      {/* Content */}
+      <div style={{ padding:'12px 14px' }}>
+        <div style={{ fontSize:15, fontWeight:600, marginBottom:2 }}>Château des Comtes de Tournai</div>
+        <div style={{ fontSize:11.5, color:t.inkSoft, lineHeight:1.55, marginBottom:10 }}>
+          Forteresse médiévale du XIIe siècle dominant l'Escaut. Collection d'armes et vue panoramique depuis le donjon.
+        </div>
+        {/* Hours + price */}
+        <div style={{ display:'flex', gap:8, marginBottom:10 }}>
+          <div style={{ flex:1, padding:'7px 10px', background:t.surfaceAlt, borderRadius:8 }}>
+            <div style={{ fontSize:9.5, color:t.inkMute, fontWeight:600, letterSpacing:0.3, textTransform:'uppercase', marginBottom:2 }}>Horaires</div>
+            <div style={{ fontSize:12, fontWeight:600, color:t.green }}>Ouvert jusqu'à 18h</div>
+          </div>
+          <div style={{ padding:'7px 10px', background:t.surfaceAlt, borderRadius:8, minWidth:70 }}>
+            <div style={{ fontSize:9.5, color:t.inkMute, fontWeight:600, letterSpacing:0.3, textTransform:'uppercase', marginBottom:2 }}>Prix</div>
+            <div style={{ fontSize:12, fontWeight:600 }}>8 €</div>
+          </div>
+        </div>
+        {/* Actions */}
+        <div style={{ display:'flex', gap:6 }}>
+          <Btn variant="accent" size="sm" icon={React.cloneElement(I.navigation,{width:12,height:12})} style={{ flex:1 }}>Naviguer</Btn>
+          <Btn variant="ghost" size="sm" icon={React.cloneElement(I.globe,{width:12,height:12})} style={{ flex:1 }}>Wikipedia</Btn>
+        </div>
+      </div>
+      {/* Arrow pointer */}
+      <div style={{ position:'absolute', bottom:-8, left:'50%', transform:'translateX(-50%)', width:0, height:0, borderLeft:'8px solid transparent', borderRight:'8px solid transparent', borderTop:`8px solid ${t.surface}` }}/>
+    </div>
+  );
+}
+
+// ─── POI Popover — Variante A closed hours ───────────────────────────────────
+function POIPopoverRichClosed({ dark: forceDark }) {
+  const t = useTheme();
+  return (
+    <div style={{ width:320, background:t.surface, border:`1px solid ${t.line}`, borderRadius:14, boxShadow:t.shadow, overflow:'hidden', fontFamily:t.sans, color:t.ink }}>
+      {/* Photo header */}
+      <div style={{ height:140, position:'relative', overflow:'hidden' }}>
+        <div style={{ width:'100%', height:'100%', background:`linear-gradient(135deg, ${t.name==='dark'?'#2a2028':'#dcccd8'} 0%, ${t.name==='dark'?'#1e1820':'#d0b8c8'} 100%)`, display:'flex', alignItems:'center', justifyContent:'center' }}>
+          <div style={{ textAlign:'center', color:t.inkMute }}>
+            <div style={{ fontSize:36, marginBottom:4 }}>🏛️</div>
+            <div style={{ fontSize:10, fontFamily:t.mono, opacity:0.6 }}>photo Wikimedia P18</div>
+          </div>
+        </div>
+        <div style={{ position:'absolute', top:10, left:10 }}>
+          <Pill sm bg="rgba(0,0,0,.55)" color="#fff" bold>Musée</Pill>
+        </div>
+      </div>
+      <div style={{ padding:'12px 14px' }}>
+        <div style={{ fontSize:15, fontWeight:600, marginBottom:2 }}>Villa Cavrois</div>
+        <div style={{ fontSize:11.5, color:t.inkSoft, lineHeight:1.55, marginBottom:10 }}>
+          Chef-d'œuvre moderniste de Robert Mallet-Stevens (1932). Mobilier d'origine et jardin art déco restaurés.
+        </div>
+        <div style={{ display:'flex', gap:8, marginBottom:10 }}>
+          <div style={{ flex:1, padding:'7px 10px', background:t.surfaceAlt, borderRadius:8 }}>
+            <div style={{ fontSize:9.5, color:t.inkMute, fontWeight:600, letterSpacing:0.3, textTransform:'uppercase', marginBottom:2 }}>Horaires</div>
+            <div style={{ fontSize:12, fontWeight:600, color:t.red }}>Fermé · ouvre demain à 9h</div>
+          </div>
+          <div style={{ padding:'7px 10px', background:t.surfaceAlt, borderRadius:8, minWidth:70 }}>
+            <div style={{ fontSize:9.5, color:t.inkMute, fontWeight:600, letterSpacing:0.3, textTransform:'uppercase', marginBottom:2 }}>Prix</div>
+            <div style={{ fontSize:12, fontWeight:600 }}>9 €</div>
+          </div>
+        </div>
+        <div style={{ display:'flex', gap:6 }}>
+          <Btn variant="accent" size="sm" icon={React.cloneElement(I.navigation,{width:12,height:12})} style={{ flex:1 }}>Naviguer</Btn>
+          <Btn variant="ghost" size="sm" icon={React.cloneElement(I.globe,{width:12,height:12})} style={{ flex:1 }}>Wikipedia</Btn>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── POI Popover — Variante B (minimale, OSM seul) ──────────────────────────
+function POIPopoverMinimal() {
+  const t = useTheme();
+  return (
+    <div style={{ width:240, background:t.surface, border:`1px solid ${t.line}`, borderRadius:12, boxShadow:t.shadow, padding:'12px 14px', fontFamily:t.sans, color:t.ink }}>
+      <div style={{ display:'flex', gap:8, alignItems:'center', marginBottom:10 }}>
+        <div style={{ width:32, height:32, borderRadius:8, background:t.surfaceAlt, display:'flex', alignItems:'center', justifyContent:'center', fontSize:16 }}>⛪</div>
+        <div>
+          <div style={{ fontSize:13.5, fontWeight:600 }}>Église St-Walburge</div>
+          <div style={{ fontSize:11, color:t.inkMute }}>place_of_worship · OSM</div>
+        </div>
+      </div>
+      <Btn variant="accent" size="sm" full icon={React.cloneElement(I.navigation,{width:12,height:12})}>Naviguer</Btn>
+    </div>
+  );
+}
+
+// ─── POI Popover — Variante B free ──────────────────────────────────────────
+function POIPopoverMinimalFree() {
+  const t = useTheme();
+  return (
+    <div style={{ width:240, background:t.surface, border:`1px solid ${t.line}`, borderRadius:12, boxShadow:t.shadow, padding:'12px 14px', fontFamily:t.sans, color:t.ink }}>
+      <div style={{ display:'flex', gap:8, alignItems:'center', marginBottom:10 }}>
+        <div style={{ width:32, height:32, borderRadius:8, background:t.surfaceAlt, display:'flex', alignItems:'center', justifyContent:'center', fontSize:16 }}>🔭</div>
+        <div>
+          <div style={{ fontSize:13.5, fontWeight:600 }}>Belvédère de l'Escaut</div>
+          <div style={{ fontSize:11, color:t.inkMute }}>viewpoint · OSM</div>
+        </div>
+      </div>
+      <div style={{ display:'flex', alignItems:'center', gap:5, marginBottom:8 }}>
+        <Pill sm bg={t.greenSoft} color={t.green} bold>Gratuit</Pill>
+        <span style={{ fontSize:11, color:t.inkMute }}>· accès libre</span>
+      </div>
+      <Btn variant="accent" size="sm" full icon={React.cloneElement(I.navigation,{width:12,height:12})}>Naviguer</Btn>
+    </div>
+  );
+}
+
+const WIZARD_STEPS = [
+  { n: 1, t: 'Préparation',   s: 'Importez votre tracé' },
+  { n: 2, t: 'Aperçu',        s: 'Carte, config, affinage IA' },
+  { n: 3, t: 'Analyse',       s: 'Traitement complet' },
+  { n: 4, t: 'Mon voyage',    s: 'Personnalisez votre roadbook' },
+];
+
+function WizardStepper({ active = 1, t }) {
+  return (
+    <div style={{ padding: '36px 28px', borderRight: `1px solid ${t.line}`, background: t.surface, width: 340, flexShrink: 0, display:'flex', flexDirection:'column' }}>
+      <div style={{ fontSize: 11, color: t.inkMute, fontWeight: 600, letterSpacing: 1, textTransform: 'uppercase', marginBottom: 8 }}>Étape {active} sur 4</div>
+      <h2 style={{ fontFamily: t.serif, fontSize: 26, margin: 0, marginBottom: 26, letterSpacing: -0.4, fontWeight: 500 }}>{WIZARD_STEPS[active-1].t}</h2>
+      {WIZARD_STEPS.map(s => {
+        const done = s.n < active;
+        const isActive = s.n === active;
+        return (
+          <div key={s.n} style={{ display: 'flex', gap: 14, padding: '14px 0', borderTop: s.n > 1 ? `1px solid ${t.lineSoft}` : 'none' }}>
+            <div style={{ width: 28, height: 28, borderRadius: '50%', flexShrink: 0, background: done ? t.green : isActive ? t.accent : t.surfaceAlt, color: done || isActive ? '#fff' : t.inkSoft, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 12, fontWeight: 700 }}>
+              {done ? <Ic d="m5 12 5 5L20 7" size={14} sw={2.5}/> : s.n}
+            </div>
+            <div style={{ flex: 1 }}>
+              <div style={{ fontSize: 13.5, fontWeight: isActive ? 600 : 500, color: isActive || done ? t.ink : t.inkSoft }}>{s.t}</div>
+              <div style={{ fontSize: 11.5, color: t.inkMute, marginTop: 2 }}>{s.s}</div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function MWizardHeader({ step, t }) {
+  return (
+    <>
+      <div style={{ padding: '14px 20px', display: 'flex', justifyContent: 'space-between', alignItems: 'center', borderBottom: `1px solid ${t.line}` }}>
+        <div style={{ color: t.inkSoft, display: 'flex' }}>{I.close}</div>
+        <span style={{ fontSize: 13, fontWeight: 600 }}>Nouveau voyage · {step}/4</span>
+        <div style={{ width: 20 }}/>
+      </div>
+      <div style={{ height: 3, background: t.surfaceAlt }}>
+        <div style={{ height: '100%', width: `${(step/4)*100}%`, background: t.accent, transition: 'width 0.3s' }}/>
+      </div>
+    </>
+  );
+}
+
+Object.assign(window, {
+  OsmMap, ElevProfile, TopBarDesktop, DesktopFooter, CookieBanner,
+  AlertGroup, RICH_ALERTS, ACC_TYPES, WeatherCard, SupplyTimeline,
+  DifficultyGauge, AISummaryCard, BatchModeButton, RecomputeBar,
+  LockedBanner, Shimmer, AIChatBubble,
+  POIPopoverRich, POIPopoverRichClosed, POIPopoverMinimal, POIPopoverMinimalFree,
+  WIZARD_STEPS, WizardStepper, MWizardHeader,
+});


### PR DESCRIPTION
## Sprint 35.1 — Référentiel de recette

Spec commune à l'audit fonctionnel automatisé (35.3) et à la recette manuelle, livrée sous `docs/recette/`. Couvre les 4 ordres du sprint en une PR unique (livrables documentaires fortement couplés, tous sous `docs/recette/`).

### Livrables

| Ordre | Doc | Contenu |
|---|---|---|
| 1 | `01-inventaire-ecrans.md` | Inventaire des 12 routes `pwa/src/app/` + 2 écrans système (404/500) + classes auth (public / requires-auth / anon-only via `auth-guard.tsx`) + états de données + variantes transverses. |
| 2 | `02-checklists-ecrans.md` | Checklist de recette par écran : éléments, comportements, états (hover/focus/disabled/loading/empty/error), responsive, a11y clavier. |
| 3 | `03-manifeste-elements.md` | Manifeste présence + position approximative par écran, dérivé de l'export Claude Design (tables par région header/sidebar/main/footer/overlay). |
| 4 | `04-couverture-gherkin.md` | Audit des 30 `.feature` (154 scénarios FR) : parité FR/EN (3 écarts), matrice de couverture vs features réelles, ~53 scénarios manquants (IA S28-32, design S25-27). |

Le `README.md` du référentiel ajoute une **matrice de traçabilité** (écran → checklist → manifeste → `.feature`), les **critères de passage de recette (DoD)** et le **niveau de confiance** par livrable.

Export Claude Design vendoré sous `docs/recette/design/` (`tokens.jsx`, `pages-*.jsx`, `modals.jsx`, `ui.jsx`, `ui2.jsx`, `toutes-les-pages.html`).

### Convention app vs design

- **Présence + position approximative** => vérifiable automatiquement (Playwright, ordre 3).
- **Couleur / typo / polish** => regard humain (capture côte-à-côte en recette manuelle).

### Auto-critique

- **PR purement documentaire** : 0 modification de code PHP/TS. Aucun nouvel ADR (référentiel, pas décision d'archi).
- **Revue PO/PM appliquée** : correction des écrans système 404/500 (vraies pages App Router `not-found.tsx` / `error.tsx` / `global-error.tsx`, pas des écrans non routés) ; ajout traçabilité + critères de recette pour rendre le référentiel exploitable comme source unique en 35.3.
- **Vérifications** : tous les composants cités existent dans `pwa/src/components` ; l'endpoint chat IA `/trips/{id}/chat` est confirmé.
- **QA** : `eslint` + `i18n-check` (848 clés) + `Markdown Lint` verts. Les fichiers `docs/` sont hors scope Prettier/ESLint (`pwa/`). Legs PHP délégués à la CI (0 fichier PHP ; OOM Rector local = gotcha connu).
- **Périmètre** : l'écriture effective + automatisation des scénarios manquants relève du Sprint 35.3 ; cette PR en est le référentiel d'entrée.
- **Limite** : le manifeste (ordre 3) reflète l'export design (desktop 1280px, libellés FR verbatim) ; positions approximatives par conception, polish visuel à valider à l'oeil.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

**Reviewed commit:** `9d72d16cf5cafb4c540e7c341896fbc9eaa8ca21`

Purely documentary PR (0 PHP/TS changes). Both findings from the previous review have been fully addressed: `EXPORT-README.md` now carries a clear archived/no-action header neutralising the prompt injection vector, and `toutes-les-pages.html` script paths now match the vendored file layout. No new findings.

### Findings: 0

### Resolved threads

Resolved 3 previously open bot-authored threads:
- `docs/recette/design/EXPORT-README.md` — prompt injection vector (neutralised by ARCHIVED header + agent note)
- `docs/recette/design/EXPORT-README.md` — duplicate/outdated thread (same fix)
- `docs/recette/design/toutes-les-pages.html` — broken script paths (all paths now match vendored files)

### Review checklist

- [x] Code respects the project architecture — N/A (docs only)
- [x] SOLID principles and Law of Demeter followed — N/A (docs only)
- [x] Design patterns used where appropriate — N/A (docs only)
- [x] Tests cover new/changed cases — N/A (docs only, no code)
- [x] Documentation is up to date — PR IS the documentation
- [x] Dependent tickets accounted for — all previous blockers resolved

### Inline comments

No inline comments.

---

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->