### PR TITLE
build(recette): outillage pour une recette Sprint 35.2 complète et reproductible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,8 @@ jobs:
           XDEBUG_MODE: coverage
           DATABASE_URL: "postgresql://app:!ChangeMe!@database:5432/app?serverVersion=18&charset=utf8"
           REDIS_URL: "redis://redis:6379"
-          JWT_PASSPHRASE: "test"
+          # JWT_PASSPHRASE is forced to "test" in api/phpunit.dist.xml (matches the
+          # keypair generated above with `-pass pass:test`), so no env override here.
           FRONTEND_URL: "https://localhost"
         run: vendor/bin/phpunit --coverage-clover coverage/clover.xml
       - name: Upload coverage report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,8 +81,6 @@ jobs:
           XDEBUG_MODE: coverage
           DATABASE_URL: "postgresql://app:!ChangeMe!@database:5432/app?serverVersion=18&charset=utf8"
           REDIS_URL: "redis://redis:6379"
-          # JWT_PASSPHRASE is forced to "test" in api/phpunit.dist.xml (matches the
-          # keypair generated above with `-pass pass:test`), so no env override here.
           FRONTEND_URL: "https://localhost"
         run: vendor/bin/phpunit --coverage-clover coverage/clover.xml
       - name: Upload coverage report

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,58 @@
+name: Lighthouse
+
+# Heavy job: boots the iso-prod stack and runs Lighthouse CI on the public pages.
+# Manual trigger only (workflow_dispatch) — the project favours manual execution
+# over automatic crons (cf. osm-cron dropped for manual refresh, #575).
+on:
+  workflow_dispatch: ~
+
+jobs:
+  lighthouse:
+    name: Lighthouse
+    runs-on: ubuntu-latest
+    env:
+      COMPOSE_FILE: compose.yaml
+      WORKER_REPLICAS: 1
+      JWT_PASSPHRASE: "ci-test-passphrase"
+      FRONTEND_URL: "https://localhost"
+      MAILER_DSN: "null://null"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+      - name: Generate JWT keys
+        run: |
+          mkdir -p api/config/jwt
+          openssl genpkey -algorithm RSA -out api/config/jwt/private.pem -pkeyopt rsa_keygen_bits:4096 -pass pass:ci-test-passphrase
+          openssl rsa -pubout -in api/config/jwt/private.pem -out api/config/jwt/public.pem -passin pass:ci-test-passphrase
+          echo "JWT_PRIVATE_KEY_PATH=${{ github.workspace }}/api/config/jwt/private.pem" >> "$GITHUB_ENV"
+          echo "JWT_PUBLIC_KEY_PATH=${{ github.workspace }}/api/config/jwt/public.pem" >> "$GITHUB_ENV"
+      - name: Build Docker images
+        uses: docker/bake-action@6614cfa25eff9a0b2b2697efb0b6159e7680d584 # v7.2.0
+        with:
+          load: true
+          files: |
+            compose.yaml
+          set: |
+            *.platform=linux/amd64
+            php.cache-from=type=gha,scope=php
+            php.cache-from=type=gha,scope=php-main
+            pwa.cache-from=type=gha,scope=pwa
+            pwa.cache-from=type=gha,scope=pwa-main
+      - name: Start services
+        run: docker compose up -d database php pwa worker redis --no-build --wait
+      - name: Run Lighthouse
+        run: make lighthouse
+      - name: Upload Lighthouse report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: lighthouse-report
+          path: pwa/.lighthouseci/
+          retention-days: 14
+      - name: Debug services on failure
+        if: failure()
+        run: |
+          docker compose ps
+          docker compose logs

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ compose.override.yml
 
 .docker/osm/data/*
 !.docker/osm/data/.gitkeep
+.docker/jwt-recette/
 
 coverage/
 .lighthouseci/

--- a/Makefile
+++ b/Makefile
@@ -31,11 +31,10 @@ start: start-prod ## Alias for start-prod
 start-prod: ensure-default-pbf ## Start the Docker environment (Detached) in production mode
 	@docker compose -f compose.yaml up --wait
 
-start-recette: ensure-default-pbf ## Boot iso-prod + Mailcatcher + Ollama for the recette (manual audit). Re-routing needs `make provision` + `--profile routing`.
+start-recette: ensure-default-pbf ## Boot iso-prod + Mailcatcher + Ollama (compose.ollama.yaml) for the recette. Re-routing needs `make provision` + `--profile routing`.
 	@mkdir -p .docker/jwt-recette
 	@test -f .docker/jwt-recette/private.pem || { openssl genpkey -algorithm RSA -out .docker/jwt-recette/private.pem -pkeyopt rsa_keygen_bits:4096 -pass pass:recette && openssl rsa -pubout -in .docker/jwt-recette/private.pem -out .docker/jwt-recette/public.pem -passin pass:recette; }
-	@JWT_PRIVATE_KEY_PATH=$(CURDIR)/.docker/jwt-recette/private.pem JWT_PUBLIC_KEY_PATH=$(CURDIR)/.docker/jwt-recette/public.pem JWT_PASSPHRASE=recette docker compose -f compose.yaml -f compose.recette.yaml up --wait
-	@docker compose -f compose.yaml -f compose.recette.yaml exec -T ollama ollama pull $${RECETTE_OLLAMA_MODEL:-llama3.2:3b}
+	@JWT_PRIVATE_KEY_PATH=$(CURDIR)/.docker/jwt-recette/private.pem JWT_PUBLIC_KEY_PATH=$(CURDIR)/.docker/jwt-recette/public.pem JWT_PASSPHRASE=recette OLLAMA_PULL_MODELS="$${OLLAMA_PULL_MODELS:-llama3.2:3b}" docker compose -f compose.yaml -f compose.recette.yaml -f compose.ollama.yaml up --wait
 
 stop: ## Stop the Docker environment
 	@docker compose stop

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
 .DEFAULT_GOAL := help
 .PHONY: help start stop install qa test php-shell pwa-shell ensure-default-pbf provision provision-update coverage coverage-ci migration migrate db-create fixtures
 
-# Dev loads the iso-prod base + dev overrides automatically. Prod targets pass an
-# explicit `-f compose.yaml`, which takes precedence over COMPOSE_FILE, so the dev
-# overrides never leak into a production invocation.
-export COMPOSE_FILE ?= compose.yaml:compose.dev.yaml
+# Dev loads the iso-prod base + the shared Ollama service + dev overrides
+# automatically. Prod targets pass an explicit `-f compose.yaml`, which takes
+# precedence over COMPOSE_FILE, so the dev/ollama layers never leak into prod.
+# (The `ollama-init` model-pull job stays behind its profile, so dev never pulls.)
+export COMPOSE_FILE ?= compose.yaml:compose.ollama.yaml:compose.dev.yaml
 
 help: ## Show this help message
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n\nTargets:\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
@@ -34,7 +35,7 @@ start-prod: ensure-default-pbf ## Start the Docker environment (Detached) in pro
 start-recette: ensure-default-pbf ## Boot iso-prod + Mailcatcher + Ollama (compose.ollama.yaml) for the recette. Re-routing needs `make provision` + `--profile routing`.
 	@mkdir -p .docker/jwt-recette
 	@(test -f .docker/jwt-recette/private.pem && test -f .docker/jwt-recette/public.pem) || { openssl genpkey -algorithm RSA -out .docker/jwt-recette/private.pem -pkeyopt rsa_keygen_bits:4096 -pass pass:recette && openssl rsa -pubout -in .docker/jwt-recette/private.pem -out .docker/jwt-recette/public.pem -passin pass:recette; }
-	@JWT_PRIVATE_KEY_PATH=$(CURDIR)/.docker/jwt-recette/private.pem JWT_PUBLIC_KEY_PATH=$(CURDIR)/.docker/jwt-recette/public.pem JWT_PASSPHRASE=recette OLLAMA_PULL_MODELS="$${OLLAMA_PULL_MODELS:-llama3.2:3b}" docker compose -f compose.yaml -f compose.recette.yaml -f compose.ollama.yaml up --wait
+	@JWT_PRIVATE_KEY_PATH=$(CURDIR)/.docker/jwt-recette/private.pem JWT_PUBLIC_KEY_PATH=$(CURDIR)/.docker/jwt-recette/public.pem JWT_PASSPHRASE=recette OLLAMA_PULL_MODELS="$${OLLAMA_PULL_MODELS:-llama3.2:3b}" docker compose -f compose.yaml -f compose.recette.yaml -f compose.ollama.yaml --profile ollama-init up --wait
 
 stop: ## Stop the Docker environment
 	@docker compose stop

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ start-prod: ensure-default-pbf ## Start the Docker environment (Detached) in pro
 
 start-recette: ensure-default-pbf ## Boot iso-prod + Mailcatcher + Ollama (compose.ollama.yaml) for the recette. Re-routing needs `make provision` + `--profile routing`.
 	@mkdir -p .docker/jwt-recette
-	@test -f .docker/jwt-recette/private.pem || { openssl genpkey -algorithm RSA -out .docker/jwt-recette/private.pem -pkeyopt rsa_keygen_bits:4096 -pass pass:recette && openssl rsa -pubout -in .docker/jwt-recette/private.pem -out .docker/jwt-recette/public.pem -passin pass:recette; }
+	@(test -f .docker/jwt-recette/private.pem && test -f .docker/jwt-recette/public.pem) || { openssl genpkey -algorithm RSA -out .docker/jwt-recette/private.pem -pkeyopt rsa_keygen_bits:4096 -pass pass:recette && openssl rsa -pubout -in .docker/jwt-recette/private.pem -out .docker/jwt-recette/public.pem -passin pass:recette; }
 	@JWT_PRIVATE_KEY_PATH=$(CURDIR)/.docker/jwt-recette/private.pem JWT_PUBLIC_KEY_PATH=$(CURDIR)/.docker/jwt-recette/public.pem JWT_PASSPHRASE=recette OLLAMA_PULL_MODELS="$${OLLAMA_PULL_MODELS:-llama3.2:3b}" docker compose -f compose.yaml -f compose.recette.yaml -f compose.ollama.yaml up --wait
 
 stop: ## Stop the Docker environment

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,12 @@ start: start-prod ## Alias for start-prod
 start-prod: ensure-default-pbf ## Start the Docker environment (Detached) in production mode
 	@docker compose -f compose.yaml up --wait
 
+start-recette: ensure-default-pbf ## Boot iso-prod + Mailcatcher + Ollama for the recette (manual audit). Re-routing needs `make provision` + `--profile routing`.
+	@mkdir -p .docker/jwt-recette
+	@test -f .docker/jwt-recette/private.pem || { openssl genpkey -algorithm RSA -out .docker/jwt-recette/private.pem -pkeyopt rsa_keygen_bits:4096 -pass pass:recette && openssl rsa -pubout -in .docker/jwt-recette/private.pem -out .docker/jwt-recette/public.pem -passin pass:recette; }
+	@JWT_PRIVATE_KEY_PATH=$(CURDIR)/.docker/jwt-recette/private.pem JWT_PUBLIC_KEY_PATH=$(CURDIR)/.docker/jwt-recette/public.pem JWT_PASSPHRASE=recette docker compose -f compose.yaml -f compose.recette.yaml up --wait
+	@docker compose -f compose.yaml -f compose.recette.yaml exec -T ollama ollama pull $${RECETTE_OLLAMA_MODEL:-llama3.2:3b}
+
 stop: ## Stop the Docker environment
 	@docker compose stop
 
@@ -131,7 +137,7 @@ lighthouse: ## Run Lighthouse CI on public pages (requires the prod stack up: ma
 		--mount type=volume,src=playwright_node_modules,dst=/app/node_modules \
 		--rm --ipc=host \
 		mcr.microsoft.com/playwright:v1.60.0-noble \
-		/bin/sh -c 'npm ci; npx lhci autorun --config=lighthouserc.json'
+		/bin/sh -c 'npm ci; CHROME_PATH=$$(node -e "process.stdout.write(require(\"playwright\").chromium.executablePath())") npx lhci autorun --config=lighthouserc.json'
 
 visual-test: ## Run visual-regression assertions (requires prod stack + committed baselines)
 	@docker run --network host \
@@ -148,6 +154,9 @@ visual-update: ## (Re)generate visual-regression baselines in the container (req
 		--rm --ipc=host \
 		mcr.microsoft.com/playwright:v1.60.0-noble \
 		/bin/sh -c 'npm ci; npx playwright test --config playwright.visual.config.ts --update-snapshots'
+
+jwt-keypair-test: ## (Re)generate JWT keys matching the test passphrase (run before coverage/test-php locally)
+	@docker compose exec php sh -c 'openssl genpkey -algorithm RSA -out config/jwt/private.pem -pkeyopt rsa_keygen_bits:4096 -pass pass:test && openssl rsa -pubout -in config/jwt/private.pem -out config/jwt/public.pem -passin pass:test'
 
 coverage: ## Run PHPUnit with coverage (HTML report)
 	@docker compose exec -e XDEBUG_MODE=coverage php vendor/bin/phpunit --coverage-html coverage/api

--- a/api/phpunit.dist.xml
+++ b/api/phpunit.dist.xml
@@ -31,6 +31,9 @@
 
         <env name="MAILER_DSN" value="null://null"/>
         <env name="ACCESS_REQUEST_HMAC_SECRET" value="test-hmac-secret-for-phpunit" force="true"/>
+        <!-- Match the test JWT keypair passphrase (CI generates keys with `-pass pass:test`;
+             neutralises the empty JWT_PASSPHRASE injected by compose.dev.yaml). -->
+        <env name="JWT_PASSPHRASE" value="test" force="true"/>
 
         <!-- ###+ symfony/lock ### -->
         <!-- Choose one of the stores below -->

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -8,7 +8,8 @@
 # Dev keeps the prod topology (FrankenPHP edge: reverse proxy + embedded Mercure
 # + PHP app); it only swaps the build target to frankenphp_dev (Xdebug, file
 # watcher), bind-mounts the source, relaxes read_only/secrets, and adds the
-# dev-only mailcatcher and ollama services.
+# dev-only mailcatcher service. The `ollama` service lives in compose.ollama.yaml
+# (single source of truth) and is layered in via COMPOSE_FILE for dev too.
 
 services:
   php:
@@ -148,30 +149,6 @@ services:
       retries: 3
       start_period: 10s
 
-  ollama:
-    # Pinned by digest (same as compose.recette.yaml) for reproducibility.
-    image: ollama/ollama@sha256:a6149234667efc71d37766d61c1a16f24c33e4cd7a0bf4125c44a7e47e2419c4
-    restart: unless-stopped
-    expose:
-      - 11434
-    environment:
-      # Beta profile (issue #563): right-size for Oracle ARM (24GB/4c, <10 users).
-      # One resident model at a time, two parallel slots for chat <-> analysis
-      # coexistence, 5m keep_alive so models unload at rest (~0GB idle, ~2.3GB
-      # during a 3B analysis). Cold-start (~3-8s) is invisible behind async phase 2.
-      OLLAMA_MAX_LOADED_MODELS: "1"
-      OLLAMA_NUM_PARALLEL: "2"
-      OLLAMA_KEEP_ALIVE: "5m"
-    volumes:
-      - ollama-data:/root/.ollama
-    healthcheck:
-      # /api/tags is the lightest endpoint exposed by Ollama (lists local models).
-      test: ["CMD-SHELL", "ollama list >/dev/null 2>&1 || exit 1"]
-      interval: 10s
-      timeout: 5s
-      retries: 3
-      start_period: 30s
-
   # Dev provisioner: build the `dev` target with the working tree mounted, so
   # `make provision` and the provisioner QA targets run against live code
   # (the prod base bakes the sources into the image instead).
@@ -183,7 +160,6 @@ services:
       - ./provisioner:/app
 
 volumes:
-  ollama-data: ~
   # Dev-only: the pwa source mounts live in this file's pwa override.
   pwa_node_modules: ~
   pwa_next: ~

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -134,7 +134,8 @@ services:
       start_period: 120s
 
   mailcatcher:
-    image: schickling/mailcatcher
+    # Pinned by digest (same as compose.recette.yaml): no versioned tags upstream.
+    image: schickling/mailcatcher@sha256:55ed289525a565f7587b138a423705267eb34eda1ec8d35acd6dc7966a933e84
     restart: unless-stopped
     ports:
       - target: 1080
@@ -148,7 +149,8 @@ services:
       start_period: 10s
 
   ollama:
-    image: ollama/ollama:latest
+    # Pinned by digest (same as compose.recette.yaml) for reproducibility.
+    image: ollama/ollama@sha256:a6149234667efc71d37766d61c1a16f24c33e4cd7a0bf4125c44a7e47e2419c4
     restart: unless-stopped
     expose:
       - 11434

--- a/compose.ollama.yaml
+++ b/compose.ollama.yaml
@@ -1,0 +1,55 @@
+# Ollama inference — deployed as a SEPARATE resource (ADR-028 + #566), NOT part of
+# the main iso-prod stack (compose.yaml). Versioned here so the production LLM tier is
+# reproducible and validated by the recette, instead of living only in Coolify env vars.
+#
+# Prod (Coolify): deploy this file as its own resource on the shared network; the app
+#   workers reach it via OLLAMA_BASE_URL=http://ollama:11434. Models are pulled at deploy
+#   time by the one-shot `ollama-init` job (ADR-028). Size OLLAMA_PULL_MODELS to the tier
+#   (default: dialogue 3b + analysis 8b; resource-constrained operators use 1b/8b-q4_K_M).
+# Recette (local): docker compose -f compose.yaml -f compose.recette.yaml -f compose.ollama.yaml up --wait
+#   (see `make start-recette`); OLLAMA_PULL_MODELS is narrowed to llama3.2:3b to stay light.
+
+services:
+  ollama:
+    # Pinned by digest (matches compose.dev.yaml / compose.recette.yaml).
+    image: ollama/ollama@sha256:a6149234667efc71d37766d61c1a16f24c33e4cd7a0bf4125c44a7e47e2419c4
+    restart: unless-stopped
+    expose:
+      - 11434
+    # Beta profile sizing (#566 / ADR-019): one resident model, two parallel slots,
+    # 5m keep-alive. ~2.3 GB during a 3B analysis; 8B-q4 needs more headroom.
+    deploy:
+      resources:
+        limits:
+          memory: ${OLLAMA_MEMORY_LIMIT:-6G}
+    environment:
+      OLLAMA_MAX_LOADED_MODELS: "1"
+      OLLAMA_NUM_PARALLEL: "2"
+      OLLAMA_KEEP_ALIVE: "5m"
+    volumes:
+      - ollama-data:/root/.ollama
+    healthcheck:
+      test: ["CMD-SHELL", "ollama list >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+
+  # One-shot model pull at deploy time (ADR-028: "models pulled at deploy via a one-shot
+  # init job; the volume persists the blobs across restarts"). Exits 0 once models are present.
+  ollama-init:
+    image: ollama/ollama@sha256:a6149234667efc71d37766d61c1a16f24c33e4cd7a0bf4125c44a7e47e2419c4
+    restart: "no"
+    depends_on:
+      ollama:
+        condition: service_healthy
+    environment:
+      OLLAMA_HOST: http://ollama:11434
+      OLLAMA_PULL_MODELS: "${OLLAMA_PULL_MODELS:-llama3.2:3b llama3.1:8b}"
+    entrypoint:
+      - /bin/sh
+      - -c
+      - 'for m in $$OLLAMA_PULL_MODELS; do echo "pulling $$m"; ollama pull "$$m"; done'
+
+volumes:
+  ollama-data: ~

--- a/compose.ollama.yaml
+++ b/compose.ollama.yaml
@@ -40,6 +40,9 @@ services:
   ollama-init:
     image: ollama/ollama@sha256:a6149234667efc71d37766d61c1a16f24c33e4cd7a0bf4125c44a7e47e2419c4
     restart: "no"
+    # Behind a profile so it only runs on demand (recette: `--profile ollama-init`),
+    # never on a plain `make start-dev` where OLLAMA_ENABLED=0 and pulling models is wasteful.
+    profiles: ["ollama-init"]
     depends_on:
       ollama:
         condition: service_healthy

--- a/compose.recette.yaml
+++ b/compose.recette.yaml
@@ -1,0 +1,99 @@
+# Recette overlay on top of compose.yaml (iso-prod).
+#
+# Keeps the prod topology untouched (APP_ENV=prod, read_only, JWT secrets) and ONLY:
+#   - adds a Mailcatcher service (capture magic-link emails for the real auth flow),
+#   - adds an Ollama service + OLLAMA_ENABLED=1 (exercise the AI chat/enrichment and
+#     its XSS surface, absent from the iso-prod compose where inference is external).
+#
+# Load EXPLICITLY (never auto-loaded): docker compose -f compose.yaml -f compose.recette.yaml ...
+# Named compose.recette.yaml (not compose.override.yaml) to avoid implicit auto-load.
+# Provide JWT keys via JWT_PRIVATE_KEY_PATH / JWT_PUBLIC_KEY_PATH + JWT_PASSPHRASE
+# (see `make start-recette`), same pattern as the CI playwright job. Valhalla (re-routing)
+# stays opt-in via `--profile routing` + a regional OSM extract (`make provision`).
+
+services:
+  php:
+    environment:
+      MAILER_DSN: smtp://mailcatcher:1025
+      OLLAMA_BASE_URL: "${OLLAMA_BASE_URL:-http://ollama:11434}"
+      OLLAMA_ANALYSIS_URL: "${OLLAMA_ANALYSIS_URL:-${OLLAMA_BASE_URL:-http://ollama:11434}}"
+      OLLAMA_CHAT_URL: "${OLLAMA_CHAT_URL:-${OLLAMA_BASE_URL:-http://ollama:11434}}"
+      OLLAMA_ENABLED: "1"
+      # Single small model for all LLM roles to keep the local recette light
+      # (chat default is 3b, analysis/overview default to 8b — overridden here).
+      OLLAMA_DIALOGUE_MODEL: "${OLLAMA_DIALOGUE_MODEL:-llama3.2:3b}"
+      OLLAMA_STAGE_MODEL: "${OLLAMA_STAGE_MODEL:-llama3.2:3b}"
+      OLLAMA_OVERVIEW_MODEL: "${OLLAMA_OVERVIEW_MODEL:-llama3.2:3b}"
+    depends_on:
+      ollama:
+        condition: service_healthy
+        required: false
+
+  worker:
+    environment:
+      MAILER_DSN: smtp://mailcatcher:1025
+      OLLAMA_BASE_URL: "${OLLAMA_BASE_URL:-http://ollama:11434}"
+      OLLAMA_ANALYSIS_URL: "${OLLAMA_ANALYSIS_URL:-${OLLAMA_BASE_URL:-http://ollama:11434}}"
+      OLLAMA_CHAT_URL: "${OLLAMA_CHAT_URL:-${OLLAMA_BASE_URL:-http://ollama:11434}}"
+      OLLAMA_ENABLED: "1"
+      # Single small model for all LLM roles to keep the local recette light
+      # (chat default is 3b, analysis/overview default to 8b — overridden here).
+      OLLAMA_DIALOGUE_MODEL: "${OLLAMA_DIALOGUE_MODEL:-llama3.2:3b}"
+      OLLAMA_STAGE_MODEL: "${OLLAMA_STAGE_MODEL:-llama3.2:3b}"
+      OLLAMA_OVERVIEW_MODEL: "${OLLAMA_OVERVIEW_MODEL:-llama3.2:3b}"
+    depends_on:
+      ollama:
+        condition: service_healthy
+        required: false
+
+  worker-llm:
+    environment:
+      MAILER_DSN: smtp://mailcatcher:1025
+      OLLAMA_BASE_URL: "${OLLAMA_BASE_URL:-http://ollama:11434}"
+      OLLAMA_ANALYSIS_URL: "${OLLAMA_ANALYSIS_URL:-${OLLAMA_BASE_URL:-http://ollama:11434}}"
+      OLLAMA_CHAT_URL: "${OLLAMA_CHAT_URL:-${OLLAMA_BASE_URL:-http://ollama:11434}}"
+      OLLAMA_ENABLED: "1"
+      # Single small model for all LLM roles to keep the local recette light
+      # (chat default is 3b, analysis/overview default to 8b — overridden here).
+      OLLAMA_DIALOGUE_MODEL: "${OLLAMA_DIALOGUE_MODEL:-llama3.2:3b}"
+      OLLAMA_STAGE_MODEL: "${OLLAMA_STAGE_MODEL:-llama3.2:3b}"
+      OLLAMA_OVERVIEW_MODEL: "${OLLAMA_OVERVIEW_MODEL:-llama3.2:3b}"
+    depends_on:
+      ollama:
+        condition: service_healthy
+        required: false
+
+  mailcatcher:
+    image: schickling/mailcatcher
+    restart: unless-stopped
+    ports:
+      - target: 1080
+        published: ${MAILCATCHER_PORT:-1080}
+        protocol: tcp
+    healthcheck:
+      test: ["CMD-SHELL", "ruby -e \"require 'net/http'; Net::HTTP.get(URI('http://localhost:1080'))\" || exit 1"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 10s
+
+  ollama:
+    image: ollama/ollama:latest
+    restart: unless-stopped
+    expose:
+      - 11434
+    environment:
+      OLLAMA_MAX_LOADED_MODELS: "1"
+      OLLAMA_NUM_PARALLEL: "2"
+      OLLAMA_KEEP_ALIVE: "5m"
+    volumes:
+      - ollama-data:/root/.ollama
+    healthcheck:
+      test: ["CMD-SHELL", "ollama list >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+
+volumes:
+  ollama-data: ~

--- a/compose.recette.yaml
+++ b/compose.recette.yaml
@@ -15,6 +15,10 @@ services:
   php:
     environment:
       MAILER_DSN: smtp://mailcatcher:1025
+      # Workaround for a recette finding: compose.yaml (prod) omits LOCK_DSN, so it
+      # falls back to api/.env's redis://localhost:6379 (unreachable from the container,
+      # redis is the `redis` service) -> trip creation 500s. Fix belongs in compose.yaml (35.4).
+      LOCK_DSN: redis://redis:6379
       OLLAMA_BASE_URL: "${OLLAMA_BASE_URL:-http://ollama:11434}"
       OLLAMA_ANALYSIS_URL: "${OLLAMA_ANALYSIS_URL:-${OLLAMA_BASE_URL:-http://ollama:11434}}"
       OLLAMA_CHAT_URL: "${OLLAMA_CHAT_URL:-${OLLAMA_BASE_URL:-http://ollama:11434}}"
@@ -32,6 +36,10 @@ services:
   worker:
     environment:
       MAILER_DSN: smtp://mailcatcher:1025
+      # Workaround for a recette finding: compose.yaml (prod) omits LOCK_DSN, so it
+      # falls back to api/.env's redis://localhost:6379 (unreachable from the container,
+      # redis is the `redis` service) -> trip creation 500s. Fix belongs in compose.yaml (35.4).
+      LOCK_DSN: redis://redis:6379
       OLLAMA_BASE_URL: "${OLLAMA_BASE_URL:-http://ollama:11434}"
       OLLAMA_ANALYSIS_URL: "${OLLAMA_ANALYSIS_URL:-${OLLAMA_BASE_URL:-http://ollama:11434}}"
       OLLAMA_CHAT_URL: "${OLLAMA_CHAT_URL:-${OLLAMA_BASE_URL:-http://ollama:11434}}"
@@ -49,6 +57,10 @@ services:
   worker-llm:
     environment:
       MAILER_DSN: smtp://mailcatcher:1025
+      # Workaround for a recette finding: compose.yaml (prod) omits LOCK_DSN, so it
+      # falls back to api/.env's redis://localhost:6379 (unreachable from the container,
+      # redis is the `redis` service) -> trip creation 500s. Fix belongs in compose.yaml (35.4).
+      LOCK_DSN: redis://redis:6379
       OLLAMA_BASE_URL: "${OLLAMA_BASE_URL:-http://ollama:11434}"
       OLLAMA_ANALYSIS_URL: "${OLLAMA_ANALYSIS_URL:-${OLLAMA_BASE_URL:-http://ollama:11434}}"
       OLLAMA_CHAT_URL: "${OLLAMA_CHAT_URL:-${OLLAMA_BASE_URL:-http://ollama:11434}}"
@@ -64,7 +76,9 @@ services:
         required: false
 
   mailcatcher:
-    image: schickling/mailcatcher
+    # Pinned by digest: schickling/mailcatcher has no versioned tags, and the
+    # mutable tag would let an upstream rebuild change the HTTP API recette-seed.sh relies on.
+    image: schickling/mailcatcher@sha256:55ed289525a565f7587b138a423705267eb34eda1ec8d35acd6dc7966a933e84
     restart: unless-stopped
     ports:
       - target: 1080
@@ -78,7 +92,8 @@ services:
       start_period: 10s
 
   ollama:
-    image: ollama/ollama:latest
+    # Pinned by digest for reproducibility (Ollama ships frequent inference-API changes).
+    image: ollama/ollama@sha256:a6149234667efc71d37766d61c1a16f24c33e4cd7a0bf4125c44a7e47e2419c4
     restart: unless-stopped
     expose:
       - 11434

--- a/compose.recette.yaml
+++ b/compose.recette.yaml
@@ -2,8 +2,8 @@
 #
 # Keeps the prod topology untouched (APP_ENV=prod, read_only, JWT secrets) and ONLY:
 #   - adds a Mailcatcher service (capture magic-link emails for the real auth flow),
-#   - adds an Ollama service + OLLAMA_ENABLED=1 (exercise the AI chat/enrichment and
-#     its XSS surface, absent from the iso-prod compose where inference is external).
+#   - sets OLLAMA_ENABLED=1 + OLLAMA_* URLs so the workers use the Ollama service from
+#     compose.ollama.yaml (load it too) to exercise the AI tier, absent from iso-prod.
 #
 # Load EXPLICITLY (never auto-loaded): docker compose -f compose.yaml -f compose.recette.yaml ...
 # Named compose.recette.yaml (not compose.override.yaml) to avoid implicit auto-load.
@@ -91,24 +91,6 @@ services:
       retries: 3
       start_period: 10s
 
-  ollama:
-    # Pinned by digest for reproducibility (Ollama ships frequent inference-API changes).
-    image: ollama/ollama@sha256:a6149234667efc71d37766d61c1a16f24c33e4cd7a0bf4125c44a7e47e2419c4
-    restart: unless-stopped
-    expose:
-      - 11434
-    environment:
-      OLLAMA_MAX_LOADED_MODELS: "1"
-      OLLAMA_NUM_PARALLEL: "2"
-      OLLAMA_KEEP_ALIVE: "5m"
-    volumes:
-      - ollama-data:/root/.ollama
-    healthcheck:
-      test: ["CMD-SHELL", "ollama list >/dev/null 2>&1 || exit 1"]
-      interval: 10s
-      timeout: 5s
-      retries: 3
-      start_period: 30s
-
-volumes:
-  ollama-data: ~
+# The `ollama` service (+ ollama-data volume) lives in compose.ollama.yaml so the prod
+# LLM tier is versioned and validated by the recette. Load all three:
+#   docker compose -f compose.yaml -f compose.recette.yaml -f compose.ollama.yaml up --wait

--- a/compose.recette.yaml
+++ b/compose.recette.yaml
@@ -11,23 +11,28 @@
 # (see `make start-recette`), same pattern as the CI playwright job. Valhalla (re-routing)
 # stays opt-in via `--profile routing` + a regional OSM extract (`make provision`).
 
+# Shared env for php/worker/worker-llm — extension field + YAML merge key to avoid
+# duplicating the block across the three services (review #612).
+x-recette-env: &recette-env
+  MAILER_DSN: smtp://mailcatcher:1025
+  # Workaround for a recette finding: compose.yaml (prod) omits LOCK_DSN, so it
+  # falls back to api/.env's redis://localhost:6379 (unreachable from the container,
+  # redis is the `redis` service) -> trip creation 500s. Fix belongs in compose.yaml (35.4).
+  LOCK_DSN: redis://redis:6379
+  OLLAMA_BASE_URL: "${OLLAMA_BASE_URL:-http://ollama:11434}"
+  OLLAMA_ANALYSIS_URL: "${OLLAMA_ANALYSIS_URL:-${OLLAMA_BASE_URL:-http://ollama:11434}}"
+  OLLAMA_CHAT_URL: "${OLLAMA_CHAT_URL:-${OLLAMA_BASE_URL:-http://ollama:11434}}"
+  OLLAMA_ENABLED: "1"
+  # Single small model for all LLM roles to keep the local recette light
+  # (chat default is 3b, analysis/overview default to 8b — overridden here).
+  OLLAMA_DIALOGUE_MODEL: "${OLLAMA_DIALOGUE_MODEL:-llama3.2:3b}"
+  OLLAMA_STAGE_MODEL: "${OLLAMA_STAGE_MODEL:-llama3.2:3b}"
+  OLLAMA_OVERVIEW_MODEL: "${OLLAMA_OVERVIEW_MODEL:-llama3.2:3b}"
+
 services:
   php:
     environment:
-      MAILER_DSN: smtp://mailcatcher:1025
-      # Workaround for a recette finding: compose.yaml (prod) omits LOCK_DSN, so it
-      # falls back to api/.env's redis://localhost:6379 (unreachable from the container,
-      # redis is the `redis` service) -> trip creation 500s. Fix belongs in compose.yaml (35.4).
-      LOCK_DSN: redis://redis:6379
-      OLLAMA_BASE_URL: "${OLLAMA_BASE_URL:-http://ollama:11434}"
-      OLLAMA_ANALYSIS_URL: "${OLLAMA_ANALYSIS_URL:-${OLLAMA_BASE_URL:-http://ollama:11434}}"
-      OLLAMA_CHAT_URL: "${OLLAMA_CHAT_URL:-${OLLAMA_BASE_URL:-http://ollama:11434}}"
-      OLLAMA_ENABLED: "1"
-      # Single small model for all LLM roles to keep the local recette light
-      # (chat default is 3b, analysis/overview default to 8b — overridden here).
-      OLLAMA_DIALOGUE_MODEL: "${OLLAMA_DIALOGUE_MODEL:-llama3.2:3b}"
-      OLLAMA_STAGE_MODEL: "${OLLAMA_STAGE_MODEL:-llama3.2:3b}"
-      OLLAMA_OVERVIEW_MODEL: "${OLLAMA_OVERVIEW_MODEL:-llama3.2:3b}"
+      <<: *recette-env
     depends_on:
       ollama:
         condition: service_healthy
@@ -35,20 +40,7 @@ services:
 
   worker:
     environment:
-      MAILER_DSN: smtp://mailcatcher:1025
-      # Workaround for a recette finding: compose.yaml (prod) omits LOCK_DSN, so it
-      # falls back to api/.env's redis://localhost:6379 (unreachable from the container,
-      # redis is the `redis` service) -> trip creation 500s. Fix belongs in compose.yaml (35.4).
-      LOCK_DSN: redis://redis:6379
-      OLLAMA_BASE_URL: "${OLLAMA_BASE_URL:-http://ollama:11434}"
-      OLLAMA_ANALYSIS_URL: "${OLLAMA_ANALYSIS_URL:-${OLLAMA_BASE_URL:-http://ollama:11434}}"
-      OLLAMA_CHAT_URL: "${OLLAMA_CHAT_URL:-${OLLAMA_BASE_URL:-http://ollama:11434}}"
-      OLLAMA_ENABLED: "1"
-      # Single small model for all LLM roles to keep the local recette light
-      # (chat default is 3b, analysis/overview default to 8b — overridden here).
-      OLLAMA_DIALOGUE_MODEL: "${OLLAMA_DIALOGUE_MODEL:-llama3.2:3b}"
-      OLLAMA_STAGE_MODEL: "${OLLAMA_STAGE_MODEL:-llama3.2:3b}"
-      OLLAMA_OVERVIEW_MODEL: "${OLLAMA_OVERVIEW_MODEL:-llama3.2:3b}"
+      <<: *recette-env
     depends_on:
       ollama:
         condition: service_healthy
@@ -56,20 +48,7 @@ services:
 
   worker-llm:
     environment:
-      MAILER_DSN: smtp://mailcatcher:1025
-      # Workaround for a recette finding: compose.yaml (prod) omits LOCK_DSN, so it
-      # falls back to api/.env's redis://localhost:6379 (unreachable from the container,
-      # redis is the `redis` service) -> trip creation 500s. Fix belongs in compose.yaml (35.4).
-      LOCK_DSN: redis://redis:6379
-      OLLAMA_BASE_URL: "${OLLAMA_BASE_URL:-http://ollama:11434}"
-      OLLAMA_ANALYSIS_URL: "${OLLAMA_ANALYSIS_URL:-${OLLAMA_BASE_URL:-http://ollama:11434}}"
-      OLLAMA_CHAT_URL: "${OLLAMA_CHAT_URL:-${OLLAMA_BASE_URL:-http://ollama:11434}}"
-      OLLAMA_ENABLED: "1"
-      # Single small model for all LLM roles to keep the local recette light
-      # (chat default is 3b, analysis/overview default to 8b — overridden here).
-      OLLAMA_DIALOGUE_MODEL: "${OLLAMA_DIALOGUE_MODEL:-llama3.2:3b}"
-      OLLAMA_STAGE_MODEL: "${OLLAMA_STAGE_MODEL:-llama3.2:3b}"
-      OLLAMA_OVERVIEW_MODEL: "${OLLAMA_OVERVIEW_MODEL:-llama3.2:3b}"
+      <<: *recette-env
     depends_on:
       ollama:
         condition: service_healthy

--- a/compose.recette.yaml
+++ b/compose.recette.yaml
@@ -20,8 +20,10 @@ x-recette-env: &recette-env
   # redis is the `redis` service) -> trip creation 500s. Fix belongs in compose.yaml (35.4).
   LOCK_DSN: redis://redis:6379
   OLLAMA_BASE_URL: "${OLLAMA_BASE_URL:-http://ollama:11434}"
-  OLLAMA_ANALYSIS_URL: "${OLLAMA_ANALYSIS_URL:-${OLLAMA_BASE_URL:-http://ollama:11434}}"
-  OLLAMA_CHAT_URL: "${OLLAMA_CHAT_URL:-${OLLAMA_BASE_URL:-http://ollama:11434}}"
+  # Flat defaults (no nested interpolation): robust across Compose versions and
+  # unambiguous. Recette never overrides OLLAMA_BASE_URL alone, so no fallback is lost.
+  OLLAMA_ANALYSIS_URL: "${OLLAMA_ANALYSIS_URL:-http://ollama:11434}"
+  OLLAMA_CHAT_URL: "${OLLAMA_CHAT_URL:-http://ollama:11434}"
   OLLAMA_ENABLED: "1"
   # Single small model for all LLM roles to keep the local recette light
   # (chat default is 3b, analysis/overview default to 8b — overridden here).

--- a/pwa/lighthouserc.json
+++ b/pwa/lighthouserc.json
@@ -10,7 +10,7 @@
       ],
       "numberOfRuns": 3,
       "settings": {
-        "chromeFlags": "--ignore-certificate-errors --no-sandbox"
+        "chromeFlags": "--ignore-certificate-errors --allow-insecure-localhost --no-sandbox"
       }
     },
     "assert": {

--- a/scripts/recette-seed.sh
+++ b/scripts/recette-seed.sh
@@ -45,10 +45,13 @@ RECETTE_JWT=$($CURL -X POST "$BASE_URL/auth/verify" -H 'Content-Type: applicatio
 [ -n "$RECETTE_JWT" ] || { echo "ERROR: /auth/verify did not return a JWT" >&2; exit 1; }
 
 create_trip() { # url start end maxDistancePerDay [ebike]
-  $CURL -X POST "$BASE_URL/trips" \
+  local id
+  id=$($CURL -f -X POST "$BASE_URL/trips" \
     -H "Authorization: Bearer $RECETTE_JWT" -H 'Content-Type: application/ld+json' \
     -d "{\"sourceUrl\":\"$1\",\"startDate\":\"$2\",\"endDate\":\"$3\",\"maxDistancePerDay\":$4,\"ebikeMode\":${5:-false}}" \
-    | json 'd=json.load(sys.stdin);print(d.get("id",""))'
+    | json 'd=json.load(sys.stdin);print(d.get("id",""))')
+  [ -n "$id" ] || { echo "ERROR: /trips returned no id for $1" >&2; exit 1; }
+  echo "$id"
 }
 
 echo "==> Creating trips from the provided Komoot links"

--- a/scripts/recette-seed.sh
+++ b/scripts/recette-seed.sh
@@ -26,7 +26,7 @@ echo "==> Ensuring user $RECETTE_EMAIL (app:create-user, idempotent)"
 $COMPOSE exec -T php bin/console app:create-user "$RECETTE_EMAIL" --locale="$LOCALE" || true
 
 echo "==> Requesting a fresh magic link"
-$CURL -X POST "$BASE_URL/auth/request-link" -H 'Content-Type: application/json' \
+$CURL -X POST "$BASE_URL/auth/request-link" -H 'Content-Type: application/ld+json' \
   -d "{\"email\":\"$RECETTE_EMAIL\"}" >/dev/null
 
 echo "==> Reading magic link from Mailcatcher"
@@ -37,13 +37,13 @@ TOKEN=$($CURL "$MAILCATCHER_URL/messages/$MSG_ID.html" | grep -oE 'auth/verify/[
 [ -n "$TOKEN" ] || { echo "ERROR: no /auth/verify token in mail $MSG_ID" >&2; exit 1; }
 
 echo "==> Verifying token -> JWT"
-RECETTE_JWT=$($CURL -X POST "$BASE_URL/auth/verify" -H 'Content-Type: application/json' \
+RECETTE_JWT=$($CURL -X POST "$BASE_URL/auth/verify" -H 'Content-Type: application/ld+json' \
   -d "{\"token\":\"$TOKEN\"}" | json 'print(json.load(sys.stdin)["token"])')
 [ -n "$RECETTE_JWT" ] || { echo "ERROR: /auth/verify did not return a JWT" >&2; exit 1; }
 
 create_trip() { # url start end maxDistancePerDay [ebike]
-  $CURL -X POST "$BASE_URL/trips.json" \
-    -H "Authorization: Bearer $RECETTE_JWT" -H 'Content-Type: application/json' \
+  $CURL -X POST "$BASE_URL/trips" \
+    -H "Authorization: Bearer $RECETTE_JWT" -H 'Content-Type: application/ld+json' \
     -d "{\"sourceUrl\":\"$1\",\"startDate\":\"$2\",\"endDate\":\"$3\",\"maxDistancePerDay\":$4,\"ebikeMode\":${5:-false}}" \
     | json 'd=json.load(sys.stdin);print(d.get("id",""))'
 }

--- a/scripts/recette-seed.sh
+++ b/scripts/recette-seed.sh
@@ -33,7 +33,7 @@ echo "==> Reading magic link from Mailcatcher"
 sleep 2
 MSG_ID=$($CURL "$MAILCATCHER_URL/messages" | json 'm=json.load(sys.stdin);print(m[-1]["id"] if m else "")')
 [ -n "$MSG_ID" ] || { echo "ERROR: no mail captured in Mailcatcher" >&2; exit 1; }
-TOKEN=$($CURL "$MAILCATCHER_URL/messages/$MSG_ID.html" | grep -oE 'auth/verify/[A-Za-z0-9]+' | head -1 | sed 's#auth/verify/##')
+TOKEN=$($CURL "$MAILCATCHER_URL/messages/$MSG_ID.html" | grep -oE 'auth/verify/[A-Za-z0-9_-]+' | head -1 | sed 's#auth/verify/##')
 [ -n "$TOKEN" ] || { echo "ERROR: no /auth/verify token in mail $MSG_ID" >&2; exit 1; }
 
 echo "==> Verifying token -> JWT"

--- a/scripts/recette-seed.sh
+++ b/scripts/recette-seed.sh
@@ -30,9 +30,12 @@ $CURL -X POST "$BASE_URL/auth/request-link" -H 'Content-Type: application/ld+jso
   -d "{\"email\":\"$RECETTE_EMAIL\"}" >/dev/null
 
 echo "==> Reading magic link from Mailcatcher"
-sleep 2
-MSG_ID=$($CURL "$MAILCATCHER_URL/messages" | json 'm=json.load(sys.stdin);print(m[-1]["id"] if m else "")')
-[ -n "$MSG_ID" ] || { echo "ERROR: no mail captured in Mailcatcher" >&2; exit 1; }
+for _i in $(seq 1 15); do
+  sleep 2
+  MSG_ID=$($CURL "$MAILCATCHER_URL/messages" | json 'm=json.load(sys.stdin);print(m[-1]["id"] if m else "")')
+  [ -n "$MSG_ID" ] && break
+done
+[ -n "$MSG_ID" ] || { echo "ERROR: no mail captured in Mailcatcher after 30s" >&2; exit 1; }
 TOKEN=$($CURL "$MAILCATCHER_URL/messages/$MSG_ID.html" | grep -oE 'auth/verify/[A-Za-z0-9_-]+' | head -1 | sed 's#auth/verify/##')
 [ -n "$TOKEN" ] || { echo "ERROR: no /auth/verify token in mail $MSG_ID" >&2; exit 1; }
 

--- a/scripts/recette-seed.sh
+++ b/scripts/recette-seed.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# Recette seed (Sprint 35.2 v2) — iso-prod-faithful, option 2.
+#
+# Boots an authenticated session on the running recette stack (see `make start-recette`)
+# via the REAL passwordless flow (app:create-user -> Mailcatcher -> /auth/verify), then
+# creates the trips from the user-provided Komoot links. Prints RECETTE_JWT and the
+# trip ids for the audit steps to reuse.
+#
+# Run from the repo root, AFTER `make start-recette`. Requires python3 + curl.
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-https://localhost}"
+MAILCATCHER_URL="${MAILCATCHER_URL:-http://localhost:1080}"
+RECETTE_EMAIL="${RECETTE_EMAIL:-recette@example.com}"
+LOCALE="${RECETTE_LOCALE:-fr}"
+COMPOSE="docker compose -f compose.yaml -f compose.recette.yaml"
+CURL="curl -sk"
+
+json() { python3 -c "import sys,json;$1"; }
+
+echo "==> Purging Mailcatcher inbox"
+$CURL -X DELETE "$MAILCATCHER_URL/messages" >/dev/null 2>&1 || true
+
+echo "==> Ensuring user $RECETTE_EMAIL (app:create-user, idempotent)"
+$COMPOSE exec -T php bin/console app:create-user "$RECETTE_EMAIL" --locale="$LOCALE" || true
+
+echo "==> Requesting a fresh magic link"
+$CURL -X POST "$BASE_URL/auth/request-link" -H 'Content-Type: application/json' \
+  -d "{\"email\":\"$RECETTE_EMAIL\"}" >/dev/null
+
+echo "==> Reading magic link from Mailcatcher"
+sleep 2
+MSG_ID=$($CURL "$MAILCATCHER_URL/messages" | json 'm=json.load(sys.stdin);print(m[-1]["id"] if m else "")')
+[ -n "$MSG_ID" ] || { echo "ERROR: no mail captured in Mailcatcher" >&2; exit 1; }
+TOKEN=$($CURL "$MAILCATCHER_URL/messages/$MSG_ID.html" | grep -oE 'auth/verify/[A-Za-z0-9]+' | head -1 | sed 's#auth/verify/##')
+[ -n "$TOKEN" ] || { echo "ERROR: no /auth/verify token in mail $MSG_ID" >&2; exit 1; }
+
+echo "==> Verifying token -> JWT"
+RECETTE_JWT=$($CURL -X POST "$BASE_URL/auth/verify" -H 'Content-Type: application/json' \
+  -d "{\"token\":\"$TOKEN\"}" | json 'print(json.load(sys.stdin)["token"])')
+[ -n "$RECETTE_JWT" ] || { echo "ERROR: /auth/verify did not return a JWT" >&2; exit 1; }
+
+create_trip() { # url start end maxDistancePerDay [ebike]
+  $CURL -X POST "$BASE_URL/trips.json" \
+    -H "Authorization: Bearer $RECETTE_JWT" -H 'Content-Type: application/json' \
+    -d "{\"sourceUrl\":\"$1\",\"startDate\":\"$2\",\"endDate\":\"$3\",\"maxDistancePerDay\":$4,\"ebikeMode\":${5:-false}}" \
+    | json 'd=json.load(sys.stdin);print(d.get("id",""))'
+}
+
+echo "==> Creating trips from the provided Komoot links"
+# Entre Sensée et Escaut (zone Lille -> also re-routing test); intermediate, camping
+T1=$(create_trip "https://www.komoot.com/fr-fr/tour/2795080048" 2026-05-01 2026-05-03 70)
+# Beginner, ~40 km/day, lodging
+T2=$(create_trip "https://www.komoot.com/fr-fr/tour/2888900113" 2026-05-14 2026-05-17 40)
+# Collection, intermediate, camping
+T3=$(create_trip "https://www.komoot.com/fr-fr/collection/4226094/-cap-sur-la-cote-weekend-baroudeurs" 2026-05-08 2026-05-10 60)
+
+echo
+echo "RECETTE_JWT=$RECETTE_JWT"
+echo "RECETTE_TRIP_IDS=$T1 $T2 $T3"
+echo
+echo "Note: trip computation is async (Komoot fetch + pacing + OSM/weather). Poll"
+echo "  $CURL -H \"Authorization: Bearer \$RECETTE_JWT\" $BASE_URL/trips/<id>/detail"
+echo "until stages appear. Re-routing (POI/accommodation) needs \`make provision\` +"
+echo "the routing profile. GPX fallback: POST $BASE_URL/trips/gpx-upload (multipart gpxFile)."


### PR DESCRIPTION
## Contexte

La recette Sprint 35.2 (#610) a buté sur 4 limitations d'environnement qui ont laissé ~7/13 items non mesurés ou vérifiés par simple revue de code. Cette PR livre l'**outillage** pour rendre la recette **exécutable et reproductible**, avant de re-jouer l'audit complet et de corriger #610.

## Changements

- **`make lighthouse` réparé (QUAL-004)** : `CHROME_PATH` pointe vers le chromium Playwright (l'image n'expose pas Chrome sur les chemins standards → `chrome-launcher` échouait) + `--allow-insecure-localhost` pour le cert auto-signé. Validé localement : Chrome se lance désormais (l'erreur « Chrome installation not found » a disparu).
- **`.github/workflows/lighthouse.yml`** (nouveau) : workflow Lighthouse déclenché **manuellement** (`workflow_dispatch`) — pas de cron, cohérent avec l'exécution manuelle du projet (osm-cron #575).
- **Couverture PHPUnit débloquée** : `JWT_PASSPHRASE=test` forcé dans `api/phpunit.dist.xml` (même pattern que les overrides Docker existants) → neutralise le `JWT_PASSPHRASE=""` injecté par `compose.dev.yaml`, cause des 151 `JWTEncodeFailureException`. Le `JWT_PASSPHRASE` redondant du step CI est retiré. Nouvelle cible `make jwt-keypair-test` pour (re)générer des clés concordantes avant `make coverage`/`make test-php` en local.
- **`compose.recette.yaml`** (nouveau) + **`make start-recette`** : overlay iso-prod qui ajoute **Mailcatcher** (capture des magic-links → flux d'auth réel) et **Ollama** (`OLLAMA_ENABLED=1`, modèle unique léger `llama3.2:3b` → chat/enrichissement IA testables, dont leur surface XSS), sans relâcher l'iso-prod (`APP_ENV=prod`, `read_only`, secrets conservés).
- **`scripts/recette-seed.sh`** (nouveau) : seed iso-prod fidèle (option 2) — `app:create-user` → lecture Mailcatcher → `/auth/verify` → JWT → création des trips depuis les liens Komoot réels (fallback upload GPX documenté). Débloque aussi le smoke auth #77.

## Auto-critique

- **`make lighthouse`** validé jusqu'au lancement de Chrome ; les **scores réels** seront collectés sur la stack `start-recette` (PWA prod), pas en dev (la stack dev renvoie 502 pendant la recompilation Turbopack).
- Le workflow Lighthouse est **manuel** : il ne tournera pas tant qu'on ne le déclenche pas (choix assumé vs cron).
- `compose.recette.yaml` partage le volume `ollama-data` avec la stack dev (réutilise un modèle déjà pull).
- **Re-routing Valhalla** non couvert par défaut : le stub OSM fait 18 Ko → nécessite `make provision` (extract Hauts-de-France) + `--profile routing` (étape dédiée de la phase d'exécution).
- Pré-commit `make qa` non exécuté localement (pas de hook installé) → je m'appuie sur la CI ; mes changements sont surtout Makefile/compose/shell/workflow, le seul impact testé étant le job PHPUnit (clés `pass:test` + passphrase forcée).

Partie d'un plan en 3 temps : (1) cet outillage, (2) exécution de la recette v2, (3) mise à jour du rapport #610.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

All findings from the previous review have been addressed. The final outstanding correctness issue — flat `OLLAMA_*_URL` defaults in `compose.recette.yaml` to avoid non-recursive Docker Compose interpolation — is confirmed fixed in the latest commit (`77b3aa9`). No new findings.

| Severity | Count |
|---|---|
| — | 0 |

**PR title:** `build(recette): outillage pour une recette Sprint 35.2 complète et reproductible` — French description rather than imperative English. Suggested: `build(recette): add tooling for a complete, reproducible Sprint 35.2 recette`. Not blocking.

**Dismissed reviews:** 2 previously `CHANGES_REQUESTED` bot reviews dismissed (superseded by this review).

### Review checklist
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases *(tooling-only PR — no new application logic)*
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Commit reviewed:** `77b3aa9a94ef0977bbedabdb272d4c887b87463d`

**Inline comments:** No inline comments.

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->