### PR TITLE
fix(datatourisme): degrade gracefully when no API key is configured

### DIFF
--- a/api/src/DataTourisme/DataTourismeClient.php
+++ b/api/src/DataTourisme/DataTourismeClient.php
@@ -23,8 +23,12 @@ final readonly class DataTourismeClient implements DataTourismeClientInterface
         #[Autowire(service: 'limiter.datatourisme')]
         private RateLimiterFactoryInterface $rateLimiter,
         private LoggerInterface $logger,
+        // Nullable: the `default::` env processor resolves an unset/empty
+        // DATATOURISME_API_KEY to null, which is the default in prod (key not
+        // configured). A non-nullable string here threw a TypeError at construction,
+        // taking down ScanAccommodations entirely instead of degrading gracefully.
         #[Autowire(env: 'default::DATATOURISME_API_KEY')]
-        private string $apiKey,
+        private ?string $apiKey,
         #[Autowire(env: 'bool:default::DATATOURISME_ENABLED')]
         private bool $enabled,
     ) {
@@ -32,7 +36,7 @@ final readonly class DataTourismeClient implements DataTourismeClientInterface
 
     public function isEnabled(): bool
     {
-        return $this->enabled && '' !== $this->apiKey;
+        return $this->enabled && null !== $this->apiKey && '' !== $this->apiKey;
     }
 
     /**

--- a/api/tests/Unit/DataTourisme/DataTourismeClientTest.php
+++ b/api/tests/Unit/DataTourisme/DataTourismeClientTest.php
@@ -54,6 +54,16 @@ final class DataTourismeClientTest extends TestCase
         $this->assertFalse($client->isEnabled());
     }
 
+    #[Test]
+    public function isEnabledReturnsFalseWhenKeyIsNull(): void
+    {
+        // The `default::DATATOURISME_API_KEY` env processor resolves an unset key
+        // to null (prod default); isEnabled() must stay false, not crash.
+        $client = $this->makeClient(apiKey: null, enabled: true);
+
+        $this->assertFalse($client->isEnabled());
+    }
+
     // -------------------------------------------------------------------------
     // request() — cache hit
     // -------------------------------------------------------------------------
@@ -241,7 +251,7 @@ final class DataTourismeClientTest extends TestCase
         ?HttpClientInterface $httpClient = null,
         ?RateLimiterFactoryInterface $rateLimiter = null,
         ?LoggerInterface $logger = null,
-        string $apiKey = 'test-api-key',
+        ?string $apiKey = 'test-api-key',
         bool $enabled = true,
     ): DataTourismeClient {
         return new DataTourismeClient(


### PR DESCRIPTION
## Contexte

Finding remonté par la **recette Sprint 35.2 v2** (golden path réel, stack iso-prod à jour) : la création d'un trip déclenche `ScanAccommodations`, qui **crashe en `TypeError`** :

```
App\DataTourisme\DataTourismeClient::__construct(): Argument #5 ($apiKey)
must be of type string, null given
```

## Cause

`DataTourismeClient::$apiKey` est typé `string` (non-nullable) et autowiré via `#[Autowire(env: 'default::DATATOURISME_API_KEY')]`. Le processeur `default::` résout une variable **absente ou vide** en `null` — ce qui est le **cas par défaut en production** (`DATATOURISME_ENABLED=false`, clé non fournie ; `compose.yaml` met `DATATOURISME_API_KEY: "${DATATOURISME_API_KEY:-}"`). Le `null` injecté dans un `string` lève une `TypeError` **au constructeur**, donc avant que la garde `isEnabled()` ne puisse désactiver la source. Résultat : `ScanAccommodations` (et `ScanEvents`) échouent en boucle de retry, l'enrichissement hébergements/POI est cassé en prod par défaut.

Non détecté en CI : les E2E sont mockés et le smoke réel (#77) est skippé — seul le golden path réel le déclenche.

## Fix

- `private ?string $apiKey` (nullable) → plus de `TypeError` à l'instanciation.
- `isEnabled()` rendu null-safe : `$this->enabled && null !== $this->apiKey && '' !== $this->apiKey`.

Le mode dégradé existait déjà : `AccommodationSourceRegistry` / `CulturalPoiSourceRegistry` skippent toute source dont `isEnabled()` est faux. Ce fix laisse simplement le client s'instancier pour que cette garde s'applique. Quand une vraie clé DataTourisme (réutilisateur, API Web) est fournie + `DATATOURISME_ENABLED=true`, le comportement est inchangé.

## Auto-critique

- Fix minimal et ciblé ; aucun changement de comportement quand la clé est présente.
- À compléter (hors PR) : fournir `DATATOURISME_API_KEY` en prod via Coolify (compte **réutilisateur** API Web, gratuit) + afficher l'attribution licence côté POI réutilisés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

> Reviewed commit `683da861deadc8ab45a61d7a0023455837c5402c`

The fix is correct and complete. The second commit addressed all findings from the previous review: `makeClient()` now accepts `?string` and the new `isEnabledReturnsFalseWhenKeyIsNull` test covers the null key path. The production `TypeError` is fixed with minimal blast radius — only two lines changed in the source file, and behavior is unchanged when a valid API key is configured.

**Findings:** 0

**Resolved threads:** Resolved 1 previously open thread (null API key test coverage — addressed by second commit).

**Review checklist**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->