### PR TITLE
docs(recette): Sprint 35.2 — rapport d'audit consolidé (état courant)

### DIFF
--- a/docs/recette/audit-report.md
+++ b/docs/recette/audit-report.md
@@ -59,16 +59,18 @@ des passes.
 | QUAL-001 | Aucun seuil de couverture PHPUnit (`fail-under`) | P2 | quality | Confirmé |
 | QUAL-002 | Aucun seuil de couverture Vitest (frontend) | P2 | quality | Confirmé |
 | COV-API | Couverture PHPUnit API **71,8 %** statements (< 80 % DoD) | P2 | quality | Confirmé |
-| CI-UNIT | Tests unitaires front (Vitest) **non exécutés en CI** | P2 | quality | Confirmé |
+| COV-FRONT | Couverture front Vitest **16,85 %** statements (< 80 % DoD) | P2 | quality | Confirmé |
+| CI-UNIT | Tests unitaires front non gatés par la CI (suite cassée + 6 tests rot) | ~~P2~~ | quality | **Corrigé (PR #615)** |
 | QUAL-004 | `make lighthouse` non exécutable (Chrome introuvable dans l'image lhci) | ~~P2~~ | quality | **Corrigé (PR #612)** |
 | SEC-004 | Pas de Referrer-Policy | P3 | security | Confirmé |
 | SEC-005 | En-tête `x-powered-by: Next.js` exposé en prod | P3 | security | Confirmé |
 | PERF-001 | `maplibre-gl` importé statiquement dans `trip-planner.tsx` | P3 | perf | Confirmé |
 | I18N-001 | Pas de handler `onError` sur `NextIntlClientProvider` | P3 | i18n | Confirmé |
 | QUAL-003 | Dette de suppressions statiques (7 `@phpstan-ignore`, 5 front) | P3 | quality | Confirmé |
-| COV-PROV | Couverture provisioner non mesurable (xdebug absent du conteneur) | P3 | quality | Confirmé |
+| COV-PROV | Couverture provisioner (xdebug absent) -> mesurée 84,9 % | ~~P3~~ | quality | **Corrigé (PR #615)** |
 
-**Total : 1×P0, 3×P1 actifs (+1 corrigé), 15×P2 (+1 corrigé), 6×P3.** Le « aucun P0 » d'une première lecture
+**Total : 1×P0, 3×P1 actifs (+1 corrigé : F2), 15×P2 actifs (+2 corrigés : QUAL-004, CI-UNIT), 5×P3 actifs
+(+1 corrigé : COV-PROV).** Le « aucun P0 » d'une première lecture
 est **caduc** : F1 casse la création de trip en prod par défaut.
 
 ---
@@ -322,8 +324,9 @@ s'affiche en littéral sans signal.
 
 #### QUAL-001 / QUAL-002 — Pas de seuil de couverture (PHPUnit & Vitest) — P2
 
-`api/phpunit.dist.xml` : bloc `<coverage>` sans `<limit minimum="…">`. `pwa/vitest.config.ts` : aucune clé
-`coverage`/thresholds. La couverture n'est jamais un gate CI.
+`api/phpunit.dist.xml` : bloc `<coverage>` sans `<limit minimum="…">`. `pwa/vitest.config.ts` a une config
+`coverage` (provider v8, depuis #615) mais **aucun `thresholds`**. La couverture n'est donc jamais un gate CI
+(le job Vitest échoue sur un test rouge, pas sur un % insuffisant).
 **Reco :** seuil >= 80 % (cf. DoD) appliqué en CI, des deux côtés.
 
 #### COV-API — Couverture PHPUnit API 71,8 % statements (< 80 %) — P2
@@ -339,19 +342,28 @@ OK, but some tests were skipped! Tests: 1310, Assertions: 3819, Skipped: 1
 
 **Reco :** remonter la couverture API vers le seuil 80 % du DoD (couplé à QUAL-001).
 
-#### CI-UNIT — Tests unitaires front non exécutés en CI — P2
+#### CI-UNIT — Tests unitaires front non gatés par la CI — Corrigé (PR #615)
 
-`ci.yml` ne lance que `npm run test:ts` (TypeScript), **jamais `vitest`** : les tests unitaires front existent mais
-ne sont vérifiés par aucun pipeline. La mesure locale est en outre bloquée (conteneur `pwa` plafonné à 512 Mo
--> OOM-kill, provider `@vitest/coverage-v8` absent, volume `node_modules` désynchronisé -> `jsdom`
-`MODULE_NOT_FOUND`). Couverture front **non chiffrable en l'état**.
-**Reco :** ajouter un job `vitest run` en CI (+ provider de couverture pour QUAL-002).
+`ci.yml` ne lançait que `npm run test:ts` ; aucun job n'exécutait `vitest`. Le job `Unit Tests (Vitest)` ajouté
+(PR #615) a immédiatement révélé que la suite était **non-exécutable** : l'override `overrides.undici ^6.24.0`
+(plancher npm audit) forçait undici 6 dans `jsdom@29` qui exige `undici@^7.25.0` -> `Cannot find module
+'undici/lib/handler/wrap-handler.js'`, tous les tests échouaient au démarrage. De plus **6 tests étaient pourris**
+(test-rot jamais détecté faute de CI : assertions trop strictes, `TooltipProvider` manquant, timers chaînés).
+**PR #615** : override imbriqué `jsdom > undici ^7.25.0` (préserve le plancher ^6 ailleurs) + 6 corrections
+**test-only** (aucune modif appli) -> suite verte **234/234**, désormais gatée en CI.
 
-#### COV-PROV — Couverture provisioner non mesurable — P3
+#### COV-FRONT — Couverture front Vitest 16,85 % statements — P2
 
-Le conteneur `provisioner` n'embarque pas de driver xdebug -> `make coverage-ci` échoue sur cette jambe avec
-*« No code coverage driver available »*.
-**Reco :** aligner l'image provisioner sur l'API pour la couverture, ou exclure explicitement cette jambe.
+Désormais mesurable (provider `@vitest/coverage-v8` + config, PR #615) : `npx vitest run --coverage` ->
+statements **16,85 %** (1072/6359), lines 17,4 %, functions 12,7 %, branches 14,1 %. Très loin du seuil 80 %
+du DoD.
+**Reco :** remonter la couverture front (couplé à QUAL-002 pour le gate de seuil).
+
+#### COV-PROV — Couverture provisioner — Corrigé (PR #615)
+
+Le conteneur `provisioner` n'embarquait pas de driver xdebug -> `make coverage-ci` échouait sur cette jambe
+(*« No code coverage driver available »*). **PR #615** ajoute xdebug au stage dev du provisioner : couverture
+mesurée **84,9 %** statements (213/251, 32 tests OK).
 
 #### QUAL-004 — `make lighthouse` non exécutable — Corrigé (PR #612)
 
@@ -371,8 +383,8 @@ Volume faible et justifié, mais à tracer comme dette.
 
 #### Conformités qualité vérifiées
 
-+ **Suite QA/CI complète verte** (source de vérité = CI de cette PR, 21/21 checks) : PHP-CS-Fixer, Rector,
-  PHPStan **Level 9** + `banned_code`, ESLint strict (`no-explicit-any`, `no-console`), Prettier, TS,
++ **Suite QA/CI complète verte** (source de vérité = CI) : PHP-CS-Fixer, Rector, PHPStan **Level 9** +
+  `banned_code`, ESLint strict (`no-explicit-any`, `no-console`), Prettier, TS, **Vitest (depuis #615)**,
   Markdownlint, OpenAPI lint, Hadolint, i18n, PHPUnit (api + provisioner), Playwright, BDD recette, APK.
 + PHPUnit : `failOnWarning`/`failOnRisky`/`failOnDeprecation` = true.
 + `npm audit` : **8 modérées, 0 haute/critique** -> gate CI `--audit-level=high` vert.
@@ -415,6 +427,5 @@ d'audit : conteneur pwa cappé, OOM `tsc`/`vitest`) :
 | N+1 Doctrine profilé au runtime | profiler/logger sur endpoints seedés | iso-prod recette |
 | Analyse de bundle / code-splitting | `next build` (OOM local) | CI / machine dédiée |
 | axe runtime + nav clavier pages authentifiées | stack dev seedée + Playwright | dev seedé |
-| Couverture front Vitest chiffrée | provider absent + OOM + node_modules désync (cf. CI-UNIT) | CI à outiller |
 | Matrice multi-device (viewports × navigateurs × thèmes × langues) | Playwright lourd (OOM local) | CI / machine dédiée |
 | Chaos (kill/pause worker, coupure réseau -> retry/backoff, reconnexion SSE) | orchestration dédiée | machine dédiée |

--- a/docs/recette/audit-report.md
+++ b/docs/recette/audit-report.md
@@ -339,3 +339,19 @@ $ for p in / /login /privacy; do curl -skD - -o /dev/null -H 'Accept: text/html'
   scheme is missing »*, tous les appels renvoient un résultat vide ; **(2)** endpoint obsolète `/api/v1/places`
   → **404** alors que l'API v1 actuelle expose `/v1/catalog` et `/v1/placeOfInterest` (→ 200). **Fix 35.4** :
   ajouter `base_uri: https://api.datatourisme.fr` au scoped client + migrer endpoints/format vers l'API v1.
+
+### Lighthouse (pages publiques) — QUAL-004 corrigé, scores collectés
+
+`make lighthouse` (réparé) s'exécute désormais (Chrome trouvé via `CHROME_PATH`, 5 URLs × 3 runs) :
+
++ **Landing `/` sous les seuils** : Performance **0.65** (< 0.80) et Accessibility **0.84** (< 0.90)
+  → findings **`LH-PERF-HOME`** (P2) et **`LH-A11Y-HOME`** (P2, cohérent avec A11Y-001/002 : `<h1>`/`<main>`
+  absents du HTML SSR). SEO / Best-Practices OK sur `/`.
++ **`/login`, `/faq`, `/legal`, `/privacy` : conformes** (Perf ≥ 0.80, A11y ≥ 0.90, SEO ≥ 0.90, BP ≥ 0.90).
+
+### Isolation Mercure — confirmée empiriquement
+
+Un abonné **anonyme** au topic privé `/trips/{id}` ne reçoit **aucune donnée** (seulement le heartbeat SSE `:`).
+Les updates `private: true` ne sont délivrés qu'aux abonnés porteurs d'un JWT subscriber scopé (`subscriber_jwt`,
+Caddyfile) ; le `anonymous` du hub autorise la connexion mais pas la lecture des topics privés. Le finding v1
+« isolation Mercure à confirmer » est donc **levé**.

--- a/docs/recette/audit-report.md
+++ b/docs/recette/audit-report.md
@@ -41,10 +41,11 @@ des passes.
 | ID | Titre | Sévérité | Label | Statut |
 |---|---|---|---|---|
 | F1 | `LOCK_DSN` absent de `compose.yaml` -> fallback `redis://localhost` injoignable -> **création de trip 500 en prod** | **P0** | quality | Confirmé |
+| IDOR-DETAIL | `GET /trips/{id}/detail` sans autorisation objet -> **lecture du trip d'autrui** (IDOR authentifié) | **P1** | security | Confirmé (empirique) |
 | SEO-001 | Pages de partage `/s/[code]` sans `generateMetadata` (aperçu social cassé) | P1 | seo | Confirmé |
 | F3 | Intégration **Ollama prod absente de `compose.yaml`** + divergence ADR-028 (mode dégradé silencieux) | P1 | quality | Confirmé |
-| F4 | **Rate-limit `/auth/request-link` inopérant** : 6× même email -> `202`, aucun `429` | P1 | security | Confirmé |
 | F2 | `DataTourismeClient` `TypeError` si clé absente/vide -> `ScanAccommodations`/`ScanEvents` crashent | ~~P1~~ | quality | **Corrigé (PR #613)** |
+| F4 | Rate-limit `/auth/request-link` « sans 429 » : 6× -> `202` | ~~P1~~ | security | **Faux finding** (202 par design anti-énumération ; limiter actif, e-mails supprimés) |
 | SEC-001 | Pas de Content-Security-Policy sur les réponses HTML | P2 | security | Confirmé |
 | SEC-002 | Pas de Strict-Transport-Security (HSTS) | P2 | security | Confirmé |
 | SEC-003 | Pas de X-Frame-Options ni X-Content-Type-Options sur les pages PWA | P2 | security | Confirmé |
@@ -68,10 +69,12 @@ des passes.
 | I18N-001 | Pas de handler `onError` sur `NextIntlClientProvider` | P3 | i18n | Confirmé |
 | QUAL-003 | Dette de suppressions statiques (7 `@phpstan-ignore`, 5 front) | P3 | quality | Confirmé |
 | COV-PROV | Couverture provisioner (xdebug absent) -> mesurée 84,9 % | ~~P3~~ | quality | **Corrigé (PR #615)** |
+| RGPD-MAGIC | `magic_link` non purgés à la suppression de compte (7 rows, dont 2 valides) | P3 | privacy | Confirmé (empirique) |
 
-**Total : 1×P0, 3×P1 actifs (+1 corrigé : F2), 15×P2 actifs (+2 corrigés : QUAL-004, CI-UNIT), 5×P3 actifs
-(+1 corrigé : COV-PROV).** Le « aucun P0 » d'une première lecture
-est **caduc** : F1 casse la création de trip en prod par défaut.
+**Total : 1×P0, 3×P1 actifs (+1 corrigé : F2 ; F4 requalifié faux finding), 15×P2 actifs (+2 corrigés :
+QUAL-004, CI-UNIT), 6×P3 actifs (+1 corrigé : COV-PROV).** Le « aucun P0 » d'une première lecture
+est **caduc** : F1 casse la création de trip en prod par défaut. **IDOR-DETAIL** (P1) est le finding sécurité
+majeur de la passe empirique R4.
 
 ---
 
@@ -101,19 +104,21 @@ stack iso-prod. De plus `HealthController::$required` n'inclut pas Ollama -> hea
 **Reco (35.4) :** versionner Ollama en prod (`compose.ollama.yaml` livré PR #612 sert de base) ; aligner ADR-028
 (soit Ollama dans `$required`, soit acter le mode dégradé dans l'ADR).
 
-#### F4 — Rate-limit `/auth/request-link` inopérant — P1
+#### F4 — Rate-limit « sans 429 » — Faux finding (comportement par design)
 
-6 requêtes successives sur le même email renvoient toutes `202`, **aucun `429`** :
+6 requêtes successives renvoient toutes `202` (aucun `429`). **Ce n'est pas un bug** : `AuthRequestLinkProcessor`
+(l.30 *« Always returns the same neutral message to prevent user enumeration »*, l.62 *« Apply rate limiters --
+silently deny if exceeded »*) consomme bien les limiters (`isAccepted()`) puis renvoie **toujours** un `202` neutre,
+qu'il envoie l'e-mail ou non. L'absence de `429` est **anti-énumération volontaire**, pas un limiter cassé.
 
-```text
-$ for i in $(seq 1 6); do curl -sk -o /dev/null -w "%{http_code} " -X POST https://localhost/auth/request-link \
-    -H 'Content-Type: application/ld+json' -d '{"email":"flood@example.com"}'; done
-202 202 202 202 202 202
-```
+Preuve empirique du limiter actif : sur une rafale de `request-link` au-delà du quota IP (`magic_link_ip` 10/900s),
+**aucun e-mail n'arrive dans Mailcatcher** alors que tous renvoient `202` (l'e-mail d'invitation `app:create-user`,
+lui, est bien délivré -> le mailer fonctionne). Le limiter supprime donc silencieusement les envois.
 
-Les limiters sont pourtant configurés (`magic_link_email` 3/900s, cf. conformités Ordre 1). Piste : le storage du
-limiter en prod `read_only` (filesystem/cache) n'est pas writable, le limiter no-op silencieusement.
-**Reco (35.4) :** investiguer le storage du limiter sous `read_only` (Redis plutôt que cache filesystem).
+> Note : le pool `cache.rate_limiter` n'est pas défini dans `cache.php` (il retombe sur le cache applicatif
+> filesystem, écrit dans le volume `php_var` -> writable malgré `read_only`). L'hypothèse v1 « storage read-only »
+> est donc fausse. **Aucune action requise** ; éventuellement migrer le pool limiter sur Redis pour le partage
+> inter-réplicas (durcissement mineur, hors finding).
 
 #### DT-LIVE — DataTourisme mode live cassé — P2 (feature OFF par défaut)
 
@@ -196,17 +201,44 @@ x-powered-by: Next.js
 
 Fingerprinting du framework (facilite le ciblage de CVE). **Reco :** `poweredByHeader: false` dans `next.config`.
 
+#### IDOR-DETAIL — `GET /trips/{id}/detail` sans autorisation objet — P1
+
+`GET /trips/{id}/detail` n'applique **aucun contrôle d'ownership** : `TripDetailProvider::provide()`
+(`api/src/State/TripDetailProvider.php`) charge le trip par id et le renvoie tel quel — seul un `404` est levé s'il
+n'existe pas ; aucun `is_granted`, aucune comparaison au user courant. L'opération `Get` (`ApiResource/TripDetail.php`,
+`uriTemplate: /trips/{id}/detail`) ne déclare **pas de `security`**. Seul le firewall global impose l'authentification.
+
+Conséquence : **tout utilisateur authentifié lit le trip d'un autre** via son UUID (titre, `sourceUrl`, dates de
+voyage, étapes calculées : géométrie, météo, POI, hébergements). Preuve empirique (deux comptes distincts) :
+
+```text
+# A crée le trip 019e8dca-... ; B = autre compte
+GET /trips/019e8dca-.../detail  (B, non-proprio)  -> HTTP 200 + {"title":"Entre Sensée et Escaut","sourceUrl":...}
+GET /trips/019e8dca-.../detail  (anonyme)         -> HTTP 401
+PATCH/DELETE /trips/019e8dca-... (B)              -> HTTP 403   (TRIP_EDIT appliqué)
+GET /trips (collection, B)                        -> 0 item     (collection owner-scopée)
+```
+
+L'écriture et la collection sont donc bien protégées ; **seule la lecture `/detail` fuit**. Cela **réfute** la
+conformité v1 « IDOR couvert par TripVoter » : `TRIP_EDIT` l'est, `TRIP_VIEW` ne l'est pas sur `/detail`.
+**Reco (35.4) :** ajouter `security: "is_granted('TRIP_VIEW', object)"` sur l'opération `Get` `/detail` (ou enforcer
+l'ownership dans `TripDetailProvider`). Atténuations : pas d'IDOR en écriture, UUIDv7 non trivialement énumérable.
+
 #### Conformités sécurité vérifiées
 
-+ **Rate limiting (config)** : `magic_link_email` (3/900s), `magic_link_ip` (10/900s), `access_request_ip`
-  (3/3600s) — `rate_limiter.php` + appliqués dans `AuthRequestLinkProcessor` / `AccessRequestCreateProcessor`.
-  **Mais inopérant au runtime prod (cf. F4).**
++ **Rate limiting — actif (empirique)** : `magic_link_email` (3/900s), `magic_link_ip` (10/900s),
+  `access_request_ip` (3/3600s) — `rate_limiter.php`, consommés dans `AuthRequestLinkProcessor` /
+  `AccessRequestCreateProcessor`. La rafale ne renvoie pas de `429` (anti-énumération, cf. F4 requalifié) mais
+  **supprime bien les e-mails** au-delà du quota.
 + **XSS (statique)** : aucun `dangerouslySetInnerHTML` dans `pwa/src` (React échappe par défaut). Test payload
   sur champ éditable = à exécuter (cf. « Reste à exécuter »).
-+ **Auth 401 / IDOR** : `/trips` et endpoints protégés renvoient `401 JWT Token not found` non authentifié ;
-  IDOR couvert par `TripVoter` (`is_granted('TRIP_VIEW'/'TRIP_EDIT', object)`).
-+ **Stack-trace prod — confirmé empiriquement** : de vrais `500` (lock F1) et `415` (mauvais content-type)
-  renvoient un `problem+json` propre, **sans trace ni nom de classe** exposés ; `/_profiler` -> 404,
++ **Auth 401 + autorisation objet en écriture** : endpoints protégés -> `401` non authentifié (vérifié sur
+  `/trips/{id}/detail`) ; la **collection `/trips` est owner-scopée** (un autre user voit 0 trip) et
+  **`PATCH`/`DELETE` d'un trip d'autrui -> `403`** (`TripVoter` `TRIP_EDIT`). **Exception : IDOR-DETAIL** en
+  lecture (cf. ci-dessous) — `TRIP_VIEW` n'est PAS appliqué sur `/detail`.
++ **Stack-trace prod — confirmé empiriquement** : une **vraie `422`** (validation `startDate`), un `415`
+  (mauvais content-type), un `404` et un `500` (lock F1) renvoient un `problem+json` RFC7807 propre (titre
+  générique « An error occurred »), **sans trace, classe ni fichier** exposés ; `/_profiler` -> 404,
   `web_profiler` désactivé en prod.
 + **Isolation Mercure — confirmée empiriquement** : un abonné **anonyme** au topic privé `/trips/{id}` ne reçoit
   **aucune donnée** (seulement le heartbeat SSE `:`). Les updates `private: true` (`TripUpdatePublisher`) ne sont
@@ -393,7 +425,7 @@ Volume faible et justifié, mais à tracer comme dette.
 
 ### Privacy / anonymisation (Ordre 7)
 
-Aucune non-conformité. Conformités vérifiées :
+Une non-conformité mineure (RGPD-MAGIC, P3). Conformités vérifiées :
 
 + **Page `/privacy`** complète : responsable, base légale, finalités, données, rétention, droits, sous-traitants,
   analytics, contact. Plausible auto-hébergé, cookieless, sans PII vers tiers.
@@ -407,9 +439,23 @@ $ for p in / /login /privacy; do curl -skD - -o /dev/null -H 'Accept: text/html'
 /: none   /login: none   /privacy: none
 ```
 
-+ **Purge user (RGPD)** : `DELETE /users/me` -> `AccountDeleteProcessor` : transaction, cascade FK
-  (trips/stages/chat/shares), révocation des refresh tokens, anonymisation de l'email — irréversible, immédiat,
-  pas de cron (décision projet). Vérification DB/Redis après suppression = à exécuter (cf. ci-dessous).
++ **Purge user (RGPD) — confirmée empiriquement** : `DELETE /users/me` -> `204`. Sur un compte réel
+  (18 trips / 60 stages / 1 share / 7 refresh_token) :
+
+```text
+# avant: trips=18 stages=60 shares=1 refresh=7 ; email=recette@example.com
+DELETE /users/me -> 204
+# après: trips=0 stages=0 shares=0 refresh=0
+#        email=deleted-019e8c49-...@deleted.invalid  deleted_at=2026-06-03 13:57:10
+# Redis: 0 occurrence de l'email, 0 clé citant l'uid
+```
+
+  Cascade FK + révocation des refresh tokens + anonymisation irréversible de l'email confirmées ; pas de PII
+  résiduelle en base ni en Redis. Pas de cron (décision projet).
++ **RGPD-MAGIC (P3) — non-conformité** : la suppression **ne purge pas** la table `magic_link` (7 rows subsistent
+  pour le compte supprimé, dont **2 encore valides**). Le user ayant `deleted_at` posé, l'auth doit les rejeter
+  (hygiène plutôt qu'exploitation), mais c'est une purge incomplète. **Reco :** supprimer les `magic_link` du user
+  dans `AccountDeleteProcessor`.
 
 ---
 
@@ -418,14 +464,15 @@ $ for p in / /login /privacy; do curl -skD - -o /dev/null -H 'Accept: text/html'
 Items non bloquants pour la publication de ce rapport, à exercer sur stack seedée (certains bridés par la machine
 d'audit : conteneur pwa cappé, OOM `tsc`/`vitest`) :
 
+> Faits en R4 (passe empirique) : matrice 401/403 inter-utilisateurs (-> IDOR-DETAIL), purge RGPD DB/Redis
+> (-> RGPD-MAGIC), root-cause F4 (-> faux finding), stack-trace réelle (422/415/404/500). Restent :
+
 | Sujet | Pourquoi pas encore fait | Où |
 |---|---|---|
-| Matrice 403 inter-utilisateurs | second compte seedé requis | iso-prod recette |
-| XSS payload sur champ éditable d'un trip réel | nécessite trip seedé + inspection DOM rendu | iso-prod recette |
-| Purge RGPD vérifiée en DB/Redis/logs | requêtes SQL + `redis-cli KEYS` post-`DELETE /users/me` | iso-prod recette |
-| F4 rate-limit : root-cause du storage sous `read_only` | investigation infra | iso-prod recette |
+| XSS payload sur champ éditable (chat IA / note) | nécessite trip calculé + chat Ollama actif | iso-prod recette |
+| Lighthouse pages authentifiées (`make lighthouse-authed`) | nécessite un cookie `refresh_token` frais (limiter IP saturé en fin de passe) | iso-prod recette |
 | N+1 Doctrine profilé au runtime | profiler/logger sur endpoints seedés | iso-prod recette |
 | Analyse de bundle / code-splitting | `next build` (OOM local) | CI / machine dédiée |
 | axe runtime + nav clavier pages authentifiées | stack dev seedée + Playwright | dev seedé |
 | Matrice multi-device (viewports × navigateurs × thèmes × langues) | Playwright lourd (OOM local) | CI / machine dédiée |
-| Chaos (kill/pause worker, coupure réseau -> retry/backoff, reconnexion SSE) | orchestration dédiée | machine dédiée |
+| Chaos (kill/pause worker, coupure réseau -> retry/backoff, reconnexion SSE) | orchestration dédiée | machine dédiée (R5, en attente d'aval) |

--- a/docs/recette/audit-report.md
+++ b/docs/recette/audit-report.md
@@ -1,11 +1,13 @@
 # Rapport d'audit non-fonctionnel & qualité — Sprint 35.2
 
-> **Statut : rapport d'audit, AUCUN fix de code applicatif.** Les findings ci-dessous sont destinés à être
-> ouverts en issues GitHub (milestone `Sprint 35.4`, labels `security`/`perf`/`a11y`/`seo`/`i18n`/`quality`/`privacy`
-> et sévérité `P0`-`P3`). La création des issues est différée à validation utilisateur. Seuls l'**outillage de
-> recette** (PR #612) et la **dégradation gracieuse DataTourisme** (PR #613) ont été livrés pendant l'audit.
+> **Statut : rapport d'audit.** Les findings **non corrigés** ci-dessous sont destinés à être ouverts en issues
+> GitHub (milestone `Sprint 35.4`, labels `security`/`perf`/`a11y`/`seo`/`i18n`/`quality`/`privacy` et sévérité
+> `P0`-`P3`). La création des issues est différée à validation utilisateur. Ont été **corrigés pendant/après
+> l'audit** : l'outillage de recette (#612), la dégradation gracieuse DataTourisme (#613), la CI Vitest +
+> couverture (#615), puis les **correctifs critiques** — F1 (P0), IDOR-DETAIL et ENUM-404 (P1 sécurité) + le
+> wiring/réseau Ollama — via #616 et #618. Le reste est différé à Sprint 35.4.
 
-**Date :** 2026-06-03
+**Date :** 2026-06-03 (mis à jour 2026-06-04 : correctifs #616/#618)
 
 **Périmètre :** features livrées sur `main` (sprints 1-33, design S25-27, IA S28-32, S34/34.5),
 hors S18 #313/#314 (abandonnés) et osm-cron nightly (#575).
@@ -40,10 +42,11 @@ des passes.
 
 | ID | Titre | Sévérité | Label | Statut |
 |---|---|---|---|---|
-| F1 | `LOCK_DSN` absent de `compose.yaml` -> fallback `redis://localhost` injoignable -> **création de trip 500 en prod** | **P0** | quality | Confirmé |
-| IDOR-DETAIL | `GET /trips/{id}/detail` sans autorisation objet -> **lecture du trip d'autrui** (IDOR authentifié) | **P1** | security | Confirmé (empirique) |
+| F1 | `LOCK_DSN` absent de `compose.yaml` -> fallback `redis://localhost` injoignable -> **création de trip 500 en prod** | ~~P0~~ | quality | **Corrigé (#616)** |
+| IDOR-DETAIL | `GET /trips/{id}/detail` sans autorisation objet -> **lecture du trip d'autrui** (IDOR authentifié) | ~~P1~~ | security | **Corrigé (#616)** |
+| ENUM-404 | Refus d'autorisation objet -> `403` (vs `404` si inexistant) -> **fuite d'existence** par énumération | ~~P1~~ | security | **Corrigé (#618, ADR-038)** |
 | SEO-001 | Pages de partage `/s/[code]` sans `generateMetadata` (aperçu social cassé) | P1 | seo | Confirmé |
-| F3 | Ollama prod : wiring `OLLAMA_*` manquant dans `compose.yaml` + arbitrage hard-dep/dégradé (ADR-028) | P1 | quality | **En cours : #616 (wiring/ADR/réseau) + #304 (gating dégradé)** |
+| F3 | Ollama prod : wiring `OLLAMA_*` manquant dans `compose.yaml` + arbitrage hard-dep/dégradé (ADR-028) | P1 | quality | **Wiring/ADR/réseau corrigés (#616) ; reste #304 (gating dégradé)** |
 | F2 | `DataTourismeClient` `TypeError` si clé absente/vide -> `ScanAccommodations`/`ScanEvents` crashent | ~~P1~~ | quality | **Corrigé (PR #613)** |
 | F4 | Rate-limit `/auth/request-link` « sans 429 » : 6× -> `202` | ~~P1~~ | security | **Faux finding** (202 par design anti-énumération ; limiter actif, e-mails supprimés) |
 | SEC-001 | Pas de Content-Security-Policy sur les réponses HTML | P2 | security | Confirmé |
@@ -73,10 +76,12 @@ des passes.
 | COV-PROV | Couverture provisioner (xdebug absent) -> mesurée 84,9 % | ~~P3~~ | quality | **Corrigé (PR #615)** |
 | RGPD-MAGIC | `magic_link` non purgés à la suppression de compte (7 rows, dont 2 valides) | P3 | privacy | Confirmé (empirique) |
 
-**Total : 1×P0, 3×P1 actifs (+1 corrigé : F2 ; F4 requalifié faux finding), 16×P2 actifs (+2 corrigés :
-QUAL-004, CI-UNIT), 6×P3 actifs (+1 corrigé : COV-PROV) + 1×P3 à confirmer (CHAOS-RESTART).** Le « aucun P0 »
-d'une première lecture est **caduc** : F1 casse la création de trip en prod par défaut. **IDOR-DETAIL** (P1) est le
-finding sécurité majeur de la passe empirique R4.
+**Total actifs (différés Sprint 35.4) : 1×P1 (SEO-001), 16×P2, 6×P3 + 1×P3 à confirmer (CHAOS-RESTART).**
+**Corrigés pendant/après l'audit : F1 (P0, #616) ; IDOR-DETAIL et ENUM-404 (P1, #616/#618) ; F3 wiring/réseau
+(#616) ; F2 (P1, #613) ; QUAL-004 (#612) ; CI-UNIT + COV-PROV (#615) ; F4 requalifié faux finding.** Le « aucun
+P0 » d'une première lecture était **caduc** (F1 cassait la création de trip en prod) ; F1 et les deux findings
+sécurité majeurs de R4 (IDOR-DETAIL en lecture, ENUM-404 sur l'énumération) sont désormais **corrigés**. Reste le
+suivi #304 (mode dégradé Ollama) pour clore F3 côté produit.
 
 ---
 
@@ -95,8 +100,8 @@ LockAcquiringException: Failed to acquire the "..." lock — Redis connection re
 # POST /trips -> 500 ; OK après override LOCK_DSN=redis://redis:6379
 ```
 
-**Reco (35.4) :** ajouter `LOCK_DSN: redis://redis:6379` à `compose.yaml`. (Contourné en recette via
-`compose.recette.yaml` pour débloquer le golden path.)
+**Corrigé (#616) :** `LOCK_DSN: redis://redis:6379` ajouté à `compose.yaml` (le contournement temporaire de
+`compose.recette.yaml` a été retiré).
 
 #### F3 — Intégration Ollama prod : wiring manquant + arbitrage hard-dep/dégradé — P1
 
@@ -118,9 +123,11 @@ Sprint-29 (#375) ; l'objection « dégradé silencieux » est levée en rendant 
 + **PR #616** : wiring `OLLAMA_*` + `OLLAMA_ENABLED=1` dans `compose.yaml` (dev force 0, recette 1) ; Ollama
   reste **hors** du `$required` readiness ; **ADR-028** réécrit (« Decision Update - Degraded Mode », supersède
   le hard-dep) ; **ADR-027** annoté.
-+ **Topologie réseau (ADR-028)** : la stack Ollama **possède** le réseau `bike-trip-planner-llm` ; l'app le
-  **rejoint** en `external` (le consommateur rejoint le fournisseur ; seuls php/worker/worker-llm s'y attachent ;
-  DB/Redis hors de portée d'Ollama). À câbler au déploiement prod (overlay `external`).
++ **Topologie réseau (ADR-028)** : réseau partagé `bike-trip-planner-llm` **non-external, épinglé par `name`** —
+  la stack Ollama le **possède** et porte l'alias réseau `ollama` ; l'app le **rejoint** par ce nom (seuls
+  php/worker/worker-llm s'y attachent ; DB/Redis hors de portée d'Ollama). `attachable: true` est déclaré **des
+  deux côtés** pour éviter un « network exists with different configuration » selon l'ordre de démarrage. En prod
+  Coolify (projets séparés) le partage se fait par nom ; cf. ADR-028 « Deployment topology » + `docs/deployment.md`.
 + **#304 (rouvert)** : feature dédiée — dégradation gracieuse API (skip + logs `critical`) + gating front des
   features IA (génération depuis IA, chat, analyse) + signal capabilities. Couvre les **3 états** (IA activée /
   désactivée / activée-mais-indispo), à valider en recette + 35.3.
@@ -246,8 +253,23 @@ L'écriture, la collection **et le chat** sont bien protégés ; **seule la lect
 `TripChatMessageResource:56`) déclare `security: "is_granted('TRIP_VIEW', request.attributes.get('id'))"` (B -> 403
 vérifié). `/detail` est le **seul** endpoint de lecture trip à l'omettre. Cela **réfute** la conformité v1 « IDOR
 couvert par TripVoter » uniquement pour `/detail`.
-**Reco (35.4) :** copier l'expression `security` du chat-history sur l'opération `Get` `/detail`
-(`ApiResource/TripDetail.php`). Atténuations : pas d'IDOR en écriture, UUIDv7 non trivialement énumérable.
+**Corrigé (#616) :** l'expression `security: "is_granted('TRIP_VIEW', request.attributes.get('id'))"` du
+chat-history est appliquée à l'opération `Get` `/detail` (`ApiResource/TripDetail.php`). En complément,
+**ENUM-404 (#618, ADR-038)** uniformise tous les refus d'autorisation objet en `404` : le bloc de preuve
+ci-dessus, daté de l'audit, montrait `403` sur chat-history/`PATCH`/`DELETE` -> ces refus renvoient **désormais
+`404`** (un trip d'autrui devient indistinguable d'un trip inexistant).
+
+#### ENUM-404 — Refus d'autorisation objet en `403` -> fuite d'existence — P1 — Corrigé (#618)
+
+Constat (revue adverse de R4) : un refus d'autorisation objet renvoyait `403` alors qu'un trip inexistant renvoie
+`404`. Un attaquant authentifié distinguait donc « existe mais pas à moi » (`403`) de « n'existe pas » (`404`) en
+sondant des UUID — faiblesse d'énumération (OWASP API #1/#3 ; RFC 7231 §6.5.4 autorise explicitement le `404` pour
+masquer une ressource interdite).
+**Corrigé (#618, ADR-038) :** un listener `kernel.exception` (`HideForbiddenAsNotFoundListener`, priorité 2, gated
+sur l'authentification pleine) remplace l'`AccessDeniedException` objet par la même `TripNotFoundException`
+(message fixe, sans id échoé) que les providers lèvent pour un trip absent -> `404` **byte-identique** entre trip
+d'autrui et trip inexistant, sur tous les endpoints (item `GET`/`PATCH`/`DELETE`, `/detail`, chat-history,
+analyze). L'anonyme garde son `401` (entry point) ; un voyage verrouillé qu'on possède garde son `423`.
 
 #### Conformités sécurité vérifiées
 
@@ -260,10 +282,11 @@ couvert par TripVoter » uniquement pour `/detail`.
   `MapView.tsx:570` utilise `popup.setDOMContent(container)` où `container = document.createElement('div')` est
   **rempli par un portail React** -> noms échappés (pas de `setHTML`). Chat IA / texte = enfants React (échappés).
   React échappe donc l'intégralité des surfaces user/externe.
-+ **Auth 401 + autorisation objet en écriture** : endpoints protégés -> `401` non authentifié (vérifié sur
-  `/trips/{id}/detail`) ; la **collection `/trips` est owner-scopée** (un autre user voit 0 trip) et
-  **`PATCH`/`DELETE` d'un trip d'autrui -> `403`** (`TripVoter` `TRIP_EDIT`). **Exception : IDOR-DETAIL** en
-  lecture (cf. finding ci-dessus) — `TRIP_VIEW` n'est PAS appliqué sur `/detail`.
++ **Auth 401 + autorisation objet** : endpoints protégés -> `401` non authentifié ; la **collection `/trips` est
+  owner-scopée** (un autre user voit 0 trip). Au moment de l'audit, `PATCH`/`DELETE`/chat-history d'un trip
+  d'autrui renvoyaient `403` et `/detail` fuyait en `200` (IDOR-DETAIL). **Post-#616/#618 : `/detail` est protégé
+  par `TRIP_VIEW` et tous les refus d'autorisation objet renvoient `404`** (ENUM-404, ADR-038) — lecture comme
+  écriture d'un trip d'autrui indistinguables d'un trip inexistant.
 + **Stack-trace prod — confirmé empiriquement** : une **vraie `422`** (validation `startDate`), un `415`
   (mauvais content-type), un `404` et un `500` (lock F1) renvoient un `problem+json` RFC7807 propre (titre
   générique « An error occurred »), **sans trace, classe ni fichier** exposés ; `/_profiler` -> 404,

--- a/docs/recette/audit-report.md
+++ b/docs/recette/audit-report.md
@@ -43,7 +43,7 @@ des passes.
 | F1 | `LOCK_DSN` absent de `compose.yaml` -> fallback `redis://localhost` injoignable -> **création de trip 500 en prod** | **P0** | quality | Confirmé |
 | IDOR-DETAIL | `GET /trips/{id}/detail` sans autorisation objet -> **lecture du trip d'autrui** (IDOR authentifié) | **P1** | security | Confirmé (empirique) |
 | SEO-001 | Pages de partage `/s/[code]` sans `generateMetadata` (aperçu social cassé) | P1 | seo | Confirmé |
-| F3 | Intégration **Ollama prod absente de `compose.yaml`** + divergence ADR-028 (mode dégradé silencieux) | P1 | quality | Confirmé |
+| F3 | Ollama prod : wiring `OLLAMA_*` manquant dans `compose.yaml` + arbitrage hard-dep/dégradé (ADR-028) | P1 | quality | **En cours : #616 (wiring/ADR/réseau) + #304 (gating dégradé)** |
 | F2 | `DataTourismeClient` `TypeError` si clé absente/vide -> `ScanAccommodations`/`ScanEvents` crashent | ~~P1~~ | quality | **Corrigé (PR #613)** |
 | F4 | Rate-limit `/auth/request-link` « sans 429 » : 6× -> `202` | ~~P1~~ | security | **Faux finding** (202 par design anti-énumération ; limiter actif, e-mails supprimés) |
 | SEC-001 | Pas de Content-Security-Policy sur les réponses HTML | P2 | security | Confirmé |
@@ -98,13 +98,32 @@ LockAcquiringException: Failed to acquire the "..." lock — Redis connection re
 **Reco (35.4) :** ajouter `LOCK_DSN: redis://redis:6379` à `compose.yaml`. (Contourné en recette via
 `compose.recette.yaml` pour débloquer le golden path.)
 
-#### F3 — Intégration Ollama prod absente + divergence ADR-028 — P1
+#### F3 — Intégration Ollama prod : wiring manquant + arbitrage hard-dep/dégradé — P1
 
-`grep OLLAMA compose.yaml` = ∅ : le tier IA (analyse d'étapes, overview, chat) n'a aucune définition dans la
-stack iso-prod. De plus `HealthController::$required` n'inclut pas Ollama -> health vert même IA absente, un
-**mode dégradé silencieux** contraire à l'ADR-028 (« hard dependency »).
-**Reco (35.4) :** versionner Ollama en prod (`compose.ollama.yaml` livré PR #612 sert de base) ; aligner ADR-028
-(soit Ollama dans `$required`, soit acter le mode dégradé dans l'ADR).
+Deux constats distincts :
+
+1. **Wiring prod absent** : `grep OLLAMA compose.yaml` = ∅ -> les workers prod n'avaient **aucune** variable
+   `OLLAMA_*`, donc `OLLAMA_ENABLED` à `false` par défaut -> **IA OFF en prod**. (La présence d'Ollama lui-même
+   dans une stack séparée — `compose.ollama.yaml`, #612/#566 — est **voulue** : ressource lourde dimensionnée à
+   part. Ce n'était donc pas « Ollama absent » mais « l'app ne sait pas le joindre ».)
+2. **Divergence ADR-028** : `HealthController::$required` n'inclut pas Ollama (health vert même IA down) alors
+   qu'ADR-028 affirmait « hard dependency ». **Mais** 2 tests épinglent délibérément ce comportement
+   (`readinessReturns200WhenOllamaIsDown`) -> le **code + tests implémentent le mode dégradé**, pas le hard-dep.
+
+**Décision (audit 35.2) : mode dégradé-OK** — l'app doit fonctionner sans IA. Cela **réverse** le hard-dep
+Sprint-29 (#375) ; l'objection « dégradé silencieux » est levée en rendant la dégradation **explicite**.
+
+**Correctifs :**
+
++ **PR #616** : wiring `OLLAMA_*` + `OLLAMA_ENABLED=1` dans `compose.yaml` (dev force 0, recette 1) ; Ollama
+  reste **hors** du `$required` readiness ; **ADR-028** réécrit (« Decision Update - Degraded Mode », supersède
+  le hard-dep) ; **ADR-027** annoté.
++ **Topologie réseau (ADR-028)** : la stack Ollama **possède** le réseau `bike-trip-planner-llm` ; l'app le
+  **rejoint** en `external` (le consommateur rejoint le fournisseur ; seuls php/worker/worker-llm s'y attachent ;
+  DB/Redis hors de portée d'Ollama). À câbler au déploiement prod (overlay `external`).
++ **#304 (rouvert)** : feature dédiée — dégradation gracieuse API (skip + logs `critical`) + gating front des
+  features IA (génération depuis IA, chat, analyse) + signal capabilities. Couvre les **3 états** (IA activée /
+  désactivée / activée-mais-indispo), à valider en recette + 35.3.
 
 #### F4 — Rate-limit « sans 429 » — Faux finding (comportement par design)
 

--- a/docs/recette/audit-report.md
+++ b/docs/recette/audit-report.md
@@ -55,6 +55,7 @@ des passes.
 | A11Y-002 | Landing `/` sans `<h1>` dans le HTML rendu (SSR) | P2 | a11y | Confirmé |
 | LH-PERF-HOME | Landing `/` score Lighthouse Performance **0.65** (< 0.80) | P2 | perf | Confirmé |
 | LH-A11Y-HOME | Landing `/` score Lighthouse Accessibility **0.84** (< 0.90) | P2 | a11y | Confirmé |
+| LH-PERF-AUTH | Pages authentifiées sous seuil perf (`/trips` 0.73, `/trips/new` 0.52) | P2 | perf | Confirmé (empirique) |
 | DT-LIVE | DataTourisme mode live cassé : scoped client sans `base_uri` + endpoint obsolète | P2 | quality | Confirmé |
 | F5 | APIs externes flaky : **Overpass `429`/timeout** -> POI/alertes dégradés | P2 | perf | Confirmé |
 | QUAL-001 | Aucun seuil de couverture PHPUnit (`fail-under`) | P2 | quality | Confirmé |
@@ -230,8 +231,11 @@ l'ownership dans `TripDetailProvider`). Atténuations : pas d'IDOR en écriture,
   `access_request_ip` (3/3600s) — `rate_limiter.php`, consommés dans `AuthRequestLinkProcessor` /
   `AccessRequestCreateProcessor`. La rafale ne renvoie pas de `429` (anti-énumération, cf. F4 requalifié) mais
   **supprime bien les e-mails** au-delà du quota.
-+ **XSS (statique)** : aucun `dangerouslySetInnerHTML` dans `pwa/src` (React échappe par défaut). Test payload
-  sur champ éditable = à exécuter (cf. « Reste à exécuter »).
++ **XSS — aucun vecteur trouvé** : **0 sink HTML brut** dans tout `pwa/src` (`grep` `dangerouslySetInnerHTML` /
+  `.innerHTML` / `setHTML(` = ∅). Surface la plus à risque (popup carte, données POI/hébergements externes) :
+  `MapView.tsx:570` utilise `popup.setDOMContent(container)` où `container = document.createElement('div')` est
+  **rempli par un portail React** -> noms échappés (pas de `setHTML`). Chat IA / texte = enfants React (échappés).
+  React échappe donc l'intégralité des surfaces user/externe.
 + **Auth 401 + autorisation objet en écriture** : endpoints protégés -> `401` non authentifié (vérifié sur
   `/trips/{id}/detail`) ; la **collection `/trips` est owner-scopée** (un autre user voit 0 trip) et
   **`PATCH`/`DELETE` d'un trip d'autrui -> `403`** (`TripVoter` `TRIP_EDIT`). **Exception : IDOR-DETAIL** en
@@ -256,6 +260,20 @@ l'ownership dans `TripDetailProvider`). Atténuations : pas d'IDOR en écriture,
 maplibre-gl ~5.24`), sans `next/dynamic`. Atténué : `TripPlanner` n'est monté que sur les routes éditeur
 (`/trips/new`, `/trips/[id]`, `/s/[code]`), elles-mêmes en `dynamic()`.
 **Reco :** lazy-load `MapPanel` pour alléger le 1er chunk de la route éditeur.
+
+#### LH-PERF-AUTH — Lighthouse Performance pages authentifiées sous seuil — P2
+
+`make lighthouse-authed` (cookie `refresh_token` injecté via `extraHeaders`) sur la stack recette :
+
+```text
+/trips      (dashboard) : perf 0.73  a11y 1.00  best-practices 1.00  seo 1.00
+/trips/new  (éditeur)   : perf 0.52  a11y 1.00  best-practices 0.96  seo 1.00
+```
+
+**Performance < 0.80** sur les deux pages authentifiées ; l'éditeur tombe à **0.52** — cohérent avec PERF-001
+(`maplibre-gl` chargé statiquement sur la route éditeur). **A11y / Best-Practices / SEO conformes** (a11y = 1.0,
+contraste avec la landing publique A11Y-001/002). **Reco :** lazy-load `MapPanel` (PERF-001) + budget de perf sur
+les routes éditeur.
 
 #### Conformités performance vérifiées
 
@@ -464,12 +482,11 @@ Items non bloquants pour la publication de ce rapport, à exercer sur stack seed
 d'audit : conteneur pwa cappé, OOM `tsc`/`vitest`) :
 
 > Faits en R4 (passe empirique) : matrice 401/403 inter-utilisateurs (-> IDOR-DETAIL), purge RGPD DB/Redis
-> (-> RGPD-MAGIC), root-cause F4 (-> faux finding), stack-trace réelle (422/415/404/500). Restent :
+> (-> RGPD-MAGIC), root-cause F4 (-> faux finding), stack-trace réelle (422/415/404/500), **XSS** (0 sink, popup
+> portail React), **Lighthouse authentifié** (-> LH-PERF-AUTH). Restent (-> R5, en attente d'aval) :
 
 | Sujet | Pourquoi pas encore fait | Où |
 |---|---|---|
-| XSS payload sur champ éditable (chat IA / note) | nécessite trip calculé + chat Ollama actif | iso-prod recette |
-| Lighthouse pages authentifiées (`make lighthouse-authed`) | nécessite un cookie `refresh_token` frais (limiter IP saturé en fin de passe) | iso-prod recette |
 | N+1 Doctrine profilé au runtime | profiler/logger sur endpoints seedés | iso-prod recette |
 | Analyse de bundle / code-splitting | `next build` (OOM local) | CI / machine dédiée |
 | axe runtime + nav clavier pages authentifiées | stack dev seedée + Playwright | dev seedé |

--- a/docs/recette/audit-report.md
+++ b/docs/recette/audit-report.md
@@ -56,7 +56,7 @@ des passes.
 | LH-PERF-HOME | Landing `/` score Lighthouse Performance **0.65** (< 0.80) | P2 | perf | Confirmé |
 | LH-A11Y-HOME | Landing `/` score Lighthouse Accessibility **0.84** (< 0.90) | P2 | a11y | Confirmé |
 | LH-PERF-AUTH | Pages authentifiées sous seuil perf (`/trips` 0.73, `/trips/new` 0.52) | P2 | perf | Confirmé (empirique) |
-| CHAOS-RESTART | Worker `SIGKILL`/OOM ne redémarre pas malgré `restart: unless-stopped` (interaction `deploy.replicas`) | P2 | quality | Confirmé (empirique) |
+| CHAOS-RESTART | Worker `SIGKILL`/OOM lent/peu fiable à redémarrer (resté down > 2 min en test ; cause à confirmer) | P3 | quality | À confirmer |
 | DT-LIVE | DataTourisme mode live cassé : scoped client sans `base_uri` + endpoint obsolète | P2 | quality | Confirmé |
 | F5 | APIs externes flaky : **Overpass `429`/timeout** -> POI/alertes dégradés | P2 | perf | Confirmé |
 | QUAL-001 | Aucun seuil de couverture PHPUnit (`fail-under`) | P2 | quality | Confirmé |
@@ -73,10 +73,10 @@ des passes.
 | COV-PROV | Couverture provisioner (xdebug absent) -> mesurée 84,9 % | ~~P3~~ | quality | **Corrigé (PR #615)** |
 | RGPD-MAGIC | `magic_link` non purgés à la suppression de compte (7 rows, dont 2 valides) | P3 | privacy | Confirmé (empirique) |
 
-**Total : 1×P0, 3×P1 actifs (+1 corrigé : F2 ; F4 requalifié faux finding), 17×P2 actifs (+2 corrigés :
-QUAL-004, CI-UNIT), 6×P3 actifs (+1 corrigé : COV-PROV).** Le « aucun P0 » d'une première lecture
-est **caduc** : F1 casse la création de trip en prod par défaut. **IDOR-DETAIL** (P1) est le finding sécurité
-majeur de la passe empirique R4.
+**Total : 1×P0, 3×P1 actifs (+1 corrigé : F2 ; F4 requalifié faux finding), 16×P2 actifs (+2 corrigés :
+QUAL-004, CI-UNIT), 6×P3 actifs (+1 corrigé : COV-PROV) + 1×P3 à confirmer (CHAOS-RESTART).** Le « aucun P0 »
+d'une première lecture est **caduc** : F1 casse la création de trip en prod par défaut. **IDOR-DETAIL** (P1) est le
+finding sécurité majeur de la passe empirique R4.
 
 ---
 
@@ -215,16 +215,20 @@ voyage, étapes calculées : géométrie, météo, POI, hébergements). Preuve e
 
 ```text
 # A crée le trip 019e8dca-... ; B = autre compte
-GET /trips/019e8dca-.../detail  (B, non-proprio)  -> HTTP 200 + {"title":"Entre Sensée et Escaut","sourceUrl":...}
-GET /trips/019e8dca-.../detail  (anonyme)         -> HTTP 401
-PATCH/DELETE /trips/019e8dca-... (B)              -> HTTP 403   (TRIP_EDIT appliqué)
-GET /trips (collection, B)                        -> 0 item     (collection owner-scopée)
+GET /trips/019e8dca-.../detail        (B, non-proprio) -> HTTP 200 + {"title":"Entre Sensée et Escaut",...}
+GET /trips/019e8dca-.../detail        (anonyme)        -> HTTP 401
+GET /trips/019e8dca-.../chat-history  (B, non-proprio) -> HTTP 403   <- correctement protégé
+PATCH/DELETE /trips/019e8dca-...      (B)              -> HTTP 403   (TRIP_EDIT appliqué)
+GET /trips (collection, B)                             -> 0 item     (collection owner-scopée)
 ```
 
-L'écriture et la collection sont donc bien protégées ; **seule la lecture `/detail` fuit**. Cela **réfute** la
-conformité v1 « IDOR couvert par TripVoter » : `TRIP_EDIT` l'est, `TRIP_VIEW` ne l'est pas sur `/detail`.
-**Reco (35.4) :** ajouter `security: "is_granted('TRIP_VIEW', object)"` sur l'opération `Get` `/detail` (ou enforcer
-l'ownership dans `TripDetailProvider`). Atténuations : pas d'IDOR en écriture, UUIDv7 non trivialement énumérable.
+L'écriture, la collection **et le chat** sont bien protégés ; **seule la lecture `/detail` fuit**. Ce n'est donc
+**pas systémique** : le pattern correct existe déjà dans le code — `GET /trips/{id}/chat-history` (#459,
+`TripChatMessageResource:56`) déclare `security: "is_granted('TRIP_VIEW', request.attributes.get('id'))"` (B -> 403
+vérifié). `/detail` est le **seul** endpoint de lecture trip à l'omettre. Cela **réfute** la conformité v1 « IDOR
+couvert par TripVoter » uniquement pour `/detail`.
+**Reco (35.4) :** copier l'expression `security` du chat-history sur l'opération `Get` `/detail`
+(`ApiResource/TripDetail.php`). Atténuations : pas d'IDOR en écriture, UUIDv7 non trivialement énumérable.
 
 #### Conformités sécurité vérifiées
 
@@ -240,7 +244,7 @@ l'ownership dans `TripDetailProvider`). Atténuations : pas d'IDOR en écriture,
 + **Auth 401 + autorisation objet en écriture** : endpoints protégés -> `401` non authentifié (vérifié sur
   `/trips/{id}/detail`) ; la **collection `/trips` est owner-scopée** (un autre user voit 0 trip) et
   **`PATCH`/`DELETE` d'un trip d'autrui -> `403`** (`TripVoter` `TRIP_EDIT`). **Exception : IDOR-DETAIL** en
-  lecture (cf. ci-dessous) — `TRIP_VIEW` n'est PAS appliqué sur `/detail`.
+  lecture (cf. finding ci-dessus) — `TRIP_VIEW` n'est PAS appliqué sur `/detail`.
 + **Stack-trace prod — confirmé empiriquement** : une **vraie `422`** (validation `startDate`), un `415`
   (mauvais content-type), un `404` et un `500` (lock F1) renvoient un `problem+json` RFC7807 propre (titre
   générique « An error occurred »), **sans trace, classe ni fichier** exposés ; `/_profiler` -> 404,
@@ -502,8 +506,10 @@ GET /trips (collection) : 4 requêtes
   SELECT t0_.* ... (hydrate + join stages)    <- fetchJoinCollection
 ```
 
-Aucune requête par-ligne : le `/detail` est **plat** avec le nombre de stages, la collection **constante** avec le
-nombre de trips. Conformité N+1 confirmée.
+Aucune requête par-ligne : le `/detail` est **plat** avec le nombre de stages (1 SELECT pour les 3 stages). Pour la
+collection (mesurée ici avec 1 trip), le **nombre de requêtes est O(1) par construction** — le triptyque
+count + fenêtre d'ids + hydrate-join est la signature `fetchJoinCollection`, indépendante du nombre de trips.
+Conformité N+1 confirmée (un re-test à N trips le confirmerait quantitativement).
 
 ### Multi-device / responsive — aucun overflow
 
@@ -517,13 +523,15 @@ check responsive ciblé à part (cf. « Reste à exécuter »).
 + **Durabilité — confirmée** : workers stoppés -> trip créé -> **0 stage** + **9 messages en attente** dans le
   stream Redis `messages` (non perdus) -> redémarrage -> stages calculés, transport `failed` = **0**. Aucun message
   perdu malgré l'absence de consommateur.
-+ **CHAOS-RESTART (P2)** : un worker tué (`SIGKILL`, signal **137** = celui de l'OOM-killer) **ne redémarre pas**
-  malgré `restart: unless-stopped` (resté `Exited(137)` > 2 min sur 2 essais ; seul `docker start` manuel le
-  récupère). Cause probable : interaction `deploy.replicas: 2` + `restart` en Compose v2. Couplé au cap
-  **512 Mo/worker** (`deploy.resources.limits`), un worker OOM reste mort -> débit dégradé, voire pipeline en pause
-  si les deux tombent (les messages restent durables mais non traités). **Reco :** valider/forcer le redémarrage
-  sous réplicas (politique de restart effective ou superviseur basé healthcheck) + revoir le budget mémoire worker ;
-  à confirmer sur l'orchestrateur de prod (Coolify).
++ **CHAOS-RESTART (P3 — à confirmer)** : après `docker kill` (`SIGKILL`, signal **137** = celui de l'OOM-killer),
+  un worker est resté `Exited(137)` **> 2 min** (sur 2 essais) au lieu de redémarrer vite. **Mais** `docker inspect`
+  donne `RestartCount=1` (Policy `unless-stopped`) : la politique **a bien fini par s'appliquer** — ce n'est donc
+  pas un « jamais de redémarrage ». La mesure est **confondue** par mes kills répétés (backoff Docker croissant)
+  et l'environnement local. L'attribution à l'interaction `deploy.replicas` reste **non prouvée**. Le risque
+  théorique demeure : workers cappés à **512 Mo** (`deploy.resources.limits`), donc OOM plausible ; un redémarrage
+  lent/peu fiable dégraderait le débit (messages durables, non perdus, mais traités en retard).
+  **Reco :** retester proprement en isolé (un seul kill, backoff réinitialisé) **sur l'orchestrateur de prod
+  (Coolify)**, et vérifier que la politique de restart est effective sous réplicas avant de statuer.
 
 ---
 

--- a/docs/recette/audit-report.md
+++ b/docs/recette/audit-report.md
@@ -56,6 +56,7 @@ des passes.
 | LH-PERF-HOME | Landing `/` score Lighthouse Performance **0.65** (< 0.80) | P2 | perf | Confirmé |
 | LH-A11Y-HOME | Landing `/` score Lighthouse Accessibility **0.84** (< 0.90) | P2 | a11y | Confirmé |
 | LH-PERF-AUTH | Pages authentifiées sous seuil perf (`/trips` 0.73, `/trips/new` 0.52) | P2 | perf | Confirmé (empirique) |
+| CHAOS-RESTART | Worker `SIGKILL`/OOM ne redémarre pas malgré `restart: unless-stopped` (interaction `deploy.replicas`) | P2 | quality | Confirmé (empirique) |
 | DT-LIVE | DataTourisme mode live cassé : scoped client sans `base_uri` + endpoint obsolète | P2 | quality | Confirmé |
 | F5 | APIs externes flaky : **Overpass `429`/timeout** -> POI/alertes dégradés | P2 | perf | Confirmé |
 | QUAL-001 | Aucun seuil de couverture PHPUnit (`fail-under`) | P2 | quality | Confirmé |
@@ -72,7 +73,7 @@ des passes.
 | COV-PROV | Couverture provisioner (xdebug absent) -> mesurée 84,9 % | ~~P3~~ | quality | **Corrigé (PR #615)** |
 | RGPD-MAGIC | `magic_link` non purgés à la suppression de compte (7 rows, dont 2 valides) | P3 | privacy | Confirmé (empirique) |
 
-**Total : 1×P0, 3×P1 actifs (+1 corrigé : F2 ; F4 requalifié faux finding), 15×P2 actifs (+2 corrigés :
+**Total : 1×P0, 3×P1 actifs (+1 corrigé : F2 ; F4 requalifié faux finding), 17×P2 actifs (+2 corrigés :
 QUAL-004, CI-UNIT), 6×P3 actifs (+1 corrigé : COV-PROV).** Le « aucun P0 » d'une première lecture
 est **caduc** : F1 casse la création de trip en prod par défaut. **IDOR-DETAIL** (P1) est le finding sécurité
 majeur de la passe empirique R4.
@@ -277,9 +278,10 @@ les routes éditeur.
 
 #### Conformités performance vérifiées
 
-+ **N+1 Doctrine (statique)** : `TripCollectionProvider` (`leftJoin('t.stages')+addSelect` +
-  `Paginator(fetchJoinCollection: true)`) ; `DoctrineTripRequestRepository::storeStages` bulk DELETE + flush
-  unique ; updates JSONB par étape atomiques sans charger l'agrégat. Profiling runtime seedé = à exécuter.
++ **N+1 Doctrine — aucun, confirmé empiriquement** (cf. section R5) : `TripCollectionProvider`
+  (`leftJoin('t.stages')+addSelect` + `Paginator(fetchJoinCollection: true)`) ;
+  `DoctrineTripRequestRepository::storeStages` bulk DELETE + flush unique ; updates JSONB par étape atomiques.
+  Comptage SQL réel : `/detail` 3 requêtes (plat avec le nb de stages), `/trips` 4 requêtes (constant).
 + **Caches** : OSM 24h, météo 3h (ADR-022), points bruts/décimés 30 min.
 + **Async** : `FetchWeatherHandler` (cache->batch uncached->calcul), `OsmScanner::queryBatch` (Overpass
   concurrent), `ScanAccommodationsHandler` (multiplexage HTTP 2 vagues, SPARQL Wikidata batch).
@@ -476,19 +478,68 @@ $ for p in / /login /privacy; do curl -skD - -o /dev/null -H 'Accept: text/html'
 
 ---
 
+## R5 — perf runtime, responsive & résilience (empirique)
+
+### Analyse de bundle (`next build` prod)
+
+~6,5 Mo de chunks au total ; **maplibre-gl ~1,1 Mo** = dépendance dominante. Le chunk maplibre **n'est PAS dans
+`rootMainFiles`** (les 8 chunks chargés sur toutes les pages) et n'est référencé que par les routes carte
+(`/trips/new`...). Il est donc **route-splitté à l'éditeur**, absent de la landing/login/pages publiques ->
+**confirme l'atténuation de PERF-001** (maplibre hors du chemin critique public). Le lazy-load de `MapPanel`
+(reco PERF-001) allégerait encore le 1er paint de l'éditeur (LH-PERF-AUTH `/trips/new` = 0.52).
+
+### N+1 Doctrine — aucun (PostgreSQL `log_statement=all`, workers en pause)
+
+```text
+GET /trips/{id}/detail (3 stages) : 3 requêtes
+  SELECT ... FROM "user" WHERE ... (provider JWT)
+  SELECT ... FROM trip WHERE id = ?
+  SELECT ... FROM stage WHERE trip_id = ?     <- une seule, tous les stages
+GET /trips (collection) : 4 requêtes
+  SELECT ... FROM "user" ...
+  SELECT COUNT(DISTINCT t0_.id) FROM trip WHERE user_id = ?
+  SELECT DISTINCT id_0, MIN(...) ...          <- fenêtre d'ids (Paginator)
+  SELECT t0_.* ... (hydrate + join stages)    <- fetchJoinCollection
+```
+
+Aucune requête par-ligne : le `/detail` est **plat** avec le nombre de stages, la collection **constante** avec le
+nombre de trips. Conformité N+1 confirmée.
+
+### Multi-device / responsive — aucun overflow
+
+Matrice **90 checks** : 5 pages publiques (`/`, `/login`, `/faq`, `/legal`, `/privacy`) × 3 viewports
+(375 / 768 / 1440) × thèmes clair+sombre × **Chromium + Firefox + WebKit** -> **0 overflow horizontal, 0 erreur**
+(`document.scrollWidth <= clientWidth` partout). L'éditeur authentifié (`/trips/new`, panneaux + carte) reste un
+check responsive ciblé à part (cf. « Reste à exécuter »).
+
+### Chaos / résilience workers
+
++ **Durabilité — confirmée** : workers stoppés -> trip créé -> **0 stage** + **9 messages en attente** dans le
+  stream Redis `messages` (non perdus) -> redémarrage -> stages calculés, transport `failed` = **0**. Aucun message
+  perdu malgré l'absence de consommateur.
++ **CHAOS-RESTART (P2)** : un worker tué (`SIGKILL`, signal **137** = celui de l'OOM-killer) **ne redémarre pas**
+  malgré `restart: unless-stopped` (resté `Exited(137)` > 2 min sur 2 essais ; seul `docker start` manuel le
+  récupère). Cause probable : interaction `deploy.replicas: 2` + `restart` en Compose v2. Couplé au cap
+  **512 Mo/worker** (`deploy.resources.limits`), un worker OOM reste mort -> débit dégradé, voire pipeline en pause
+  si les deux tombent (les messages restent durables mais non traités). **Reco :** valider/forcer le redémarrage
+  sous réplicas (politique de restart effective ou superviseur basé healthcheck) + revoir le budget mémoire worker ;
+  à confirmer sur l'orchestrateur de prod (Coolify).
+
+---
+
 ## Reste à exécuter (empirique — recette ultérieure / Sprint 35.3+)
 
 Items non bloquants pour la publication de ce rapport, à exercer sur stack seedée (certains bridés par la machine
 d'audit : conteneur pwa cappé, OOM `tsc`/`vitest`) :
 
-> Faits en R4 (passe empirique) : matrice 401/403 inter-utilisateurs (-> IDOR-DETAIL), purge RGPD DB/Redis
-> (-> RGPD-MAGIC), root-cause F4 (-> faux finding), stack-trace réelle (422/415/404/500), **XSS** (0 sink, popup
-> portail React), **Lighthouse authentifié** (-> LH-PERF-AUTH). Restent (-> R5, en attente d'aval) :
+> Faits empiriquement : **R4** — matrice 401/403 (-> IDOR-DETAIL), purge RGPD DB/Redis (-> RGPD-MAGIC), F4
+> (-> faux finding), stack-trace (422/415/404/500), XSS (0 sink), Lighthouse authentifié (-> LH-PERF-AUTH) ;
+> **R5** — bundle (maplibre route-split), N+1 (aucun), multi-device 90 checks (0 overflow), chaos (durabilité OK
+> plus le finding CHAOS-RESTART). Restent (marginaux) :
 
 | Sujet | Pourquoi pas encore fait | Où |
 |---|---|---|
-| N+1 Doctrine profilé au runtime | profiler/logger sur endpoints seedés | iso-prod recette |
-| Analyse de bundle / code-splitting | `next build` (OOM local) | CI / machine dédiée |
+| Responsive éditeur authentifié (`/trips/new`, panneaux + carte) | overflow check authed | iso-prod recette |
 | axe runtime + nav clavier pages authentifiées | stack dev seedée + Playwright | dev seedé |
-| Matrice multi-device (viewports × navigateurs × thèmes × langues) | Playwright lourd (OOM local) | CI / machine dédiée |
-| Chaos (kill/pause worker, coupure réseau -> retry/backoff, reconnexion SSE) | orchestration dédiée | machine dédiée (R5, en attente d'aval) |
+| Reconnexion SSE Mercure sur coupure réseau (navigateur) | EventSource live + `tc netem`/disconnect | navigateur piloté |
+| XSS chat — payload runtime (complément au static 0-sink) | trip calculé + chat Ollama | iso-prod recette |

--- a/docs/recette/audit-report.md
+++ b/docs/recette/audit-report.md
@@ -1,10 +1,11 @@
 # Rapport d'audit non-fonctionnel & qualité — Sprint 35.2
 
-> **Statut : rapport d'audit, AUCUN fix.** Les findings ci-dessous sont destinés à être
+> **Statut : rapport d'audit, AUCUN fix de code applicatif.** Les findings ci-dessous sont destinés à être
 > ouverts en issues GitHub (milestone `Sprint 35.4`, labels `security`/`perf`/`a11y`/`seo`/`i18n`/`quality`/`privacy`
-> et sévérité `P0`-`P3`). La création des issues est différée à validation utilisateur.
+> et sévérité `P0`-`P3`). La création des issues est différée à validation utilisateur. Seuls l'**outillage de
+> recette** (PR #612) et la **dégradation gracieuse DataTourisme** (PR #613) ont été livrés pendant l'audit.
 
-**Date :** 2026-06-02
+**Date :** 2026-06-03
 
 **Périmètre :** features livrées sur `main` (sprints 1-33, design S25-27, IA S28-32, S34/34.5),
 hors S18 #313/#314 (abandonnés) et osm-cron nightly (#575).
@@ -13,61 +14,25 @@ hors S18 #313/#314 (abandonnés) et osm-cron nightly (#575).
 
 ## Méthodologie & environnement
 
-L'audit a été conduit sur deux boots locaux successifs de la stack (port 80/443 partagé, donc séquentiels) :
+L'audit a été conduit sur une stack **iso-prod fidèle, rebâtie depuis le code courant de `main`** (une première
+image `:ci` périmée masquait des régressions et a été écartée), complétée par une stack **dev** pour la seule
+couverture de tests (besoin de xdebug). Les verdicts ci-dessous reflètent l'**état courant**, pas l'historique
+des passes.
 
-| Phase | Stack | Usage |
+| Stack | Configuration | Ce qui y est vérifié |
 |---|---|---|
-| A | **iso-prod** (`compose.yaml`, `APP_ENV=prod`, image `:ci`) bootée avec une paire de clés JWT locales générées, `MAILER_DSN=null://` | Headers Caddy, suppression stack-trace, matrice auth 401/403, isolation Mercure, cookies, OG/SEO, HTML rendu (a11y/SEO) |
-| B | **dev** (`compose.yaml`+`compose.dev.yaml`, `APP_ENV=dev`, Mailcatcher + fixtures) | Outillage qualité : `i18n-check`, `npm audit`, tentative de couverture |
+| **iso-prod (recette)** | `compose.yaml` + `compose.recette.yaml` + `compose.ollama.yaml` (`make start-recette`) : `APP_ENV=prod`, `read_only`, clés JWT locales, **Mailcatcher** (capture magic-link) + **Ollama** (tier IA), images rebâties depuis `main` | Golden path authentifié réel, headers Caddy, suppression stack-trace, isolation Mercure, OG/SEO, HTML rendu (a11y/SEO), DataTourisme, Lighthouse, intégrations externes |
+| **dev** | `compose.yaml` + `compose.dev.yaml` (`make start-dev`), xdebug présent, clés régénérées via `make jwt-keypair-test` (`JWT_PASSPHRASE=test` forcé par `phpunit.dist.xml`) | Couverture PHPUnit chiffrée, `i18n-check`, audits de dépendances |
+
+**Golden path réel exercé :** compte créé via `app:create-user` -> magic-link capturé dans Mailcatcher ->
+`POST /auth/verify` (`application/ld+json`) -> JWT -> création de trips depuis des liens **Komoot réels** (dont
+« Entre Sensée et Escaut », zone Lille) -> calcul async -> partage.
+
+**Outillage livré pendant l'audit (PR #612) :** `make start-recette`, réparation `make lighthouse`
+(`CHROME_PATH` + workflow manuel `lighthouse.yml`), `make jwt-keypair-test`, `compose.recette.yaml`,
+`compose.ollama.yaml`, `scripts/recette-seed.sh`.
 
 **Sévérités :** P0 critique exploitable · P1 élevé · P2 moyen (durcissement impactant) · P3 faible (hygiène).
-
-**Limites locales (verdicts marqués « différé ») :**
-
-+ La stack iso-prod locale n'a **ni Mailcatcher ni fixtures** : les flux **authentifiés** (matrice 403 inter-utilisateurs, XSS sur champs éditables d'un trip réel, purge DB après suppression de compte, axe sur pages authentifiées) n'ont pas pu être exercés sous `APP_ENV=prod`. Ils sont vérifiés par **revue de code** et marqués « À confirmer iso-prod seedé ».
-+ Les **clés JWT d'environnement `test`** ne sont pas provisionnées localement → 151 erreurs `JWTEncodeFailureException` au lancement de la couverture. La **couverture PHPUnit chiffrée est donc déléguée au CI** (autorité). Le finding de configuration (absence de seuil `fail-under`) reste valide et confirmé par lecture de config.
-+ **Lighthouse n'a pas pu s'exécuter** (voir QUAL-004) : l'image `mcr.microsoft.com/playwright` utilisée par `lhci` ne contient pas l'installation Chrome attendue. Aucun score Performance/A11y/SEO/Best-Practices n'a donc été collecté.
-
----
-
-## Recette v2 — exécution sur iso-prod fidèle (mise à jour)
-
-> 2e passe sur une stack iso-prod **rebâtie depuis le code courant** (l'image `:ci` initiale
-> était périmée et masquait des régressions), avec **Mailcatcher + Ollama** (outillage PR #612)
-> et un **golden path authentifié réel** (compte via `app:create-user`, magic-link, liens Komoot
-> dont « Entre Sensée et Escaut » en zone Lille). Cette section corrige et complète la v1.
-
-### Nouveaux findings (prouvés empiriquement)
-
-| ID | Titre | Sévérité | Preuve | Suite |
-|---|---|---|---|---|
-| F1 | `LOCK_DSN` absent de `compose.yaml` → fallback `redis://localhost` injoignable → **création de trip 500 en prod** | **P0** | `LockAcquiringException: Redis connection refused` sur `POST /trips` (OK après override) | fix 35.4 : ajouter `LOCK_DSN` à `compose.yaml` |
-| F2 | `DataTourismeClient` `TypeError` si clé absente/vide (défaut prod) → **`ScanAccommodations`/`ScanEvents` crashent** | **P1** | log worker `Argument #5 ($apiKey) must be of type string, null given` | **corrigé : PR #613** |
-| F3 | Intégration **Ollama prod absente de `compose.yaml`** + divergence ADR-028 (health hors `$required` → mode dégradé silencieux contraire à l'ADR « hard dependency ») | P1 | `grep OLLAMA compose.yaml`=∅ ; `HealthController::$required` sans ollama | **outillé : `compose.ollama.yaml` (PR #612)** ; aligner ADR-028 |
-| F4 | **Rate-limit `/auth/request-link` inopérant** : 6× même email → `202`, aucun `429` | P1 | boucle curl | investiguer le storage du limiter (prod `read_only`) |
-| F5 | APIs externes flaky : **Overpass `429`/timeout** → POI/alertes dégradés | P2 | logs worker `429 Too Many Requests` | tiers ; cache + retry |
-
-### Corrections aux findings v1
-
-+ **SEO-001 (P1) — confirmé empiriquement** : la page de partage `/s/kETacKMK` rend `<title>Planificateur de voyage vélo</title>` (titre global) + meta description générique, **aucun `og:`/`twitter:`** → aperçu social cassé prouvé sur un trip réellement partagé.
-+ **QUAL-004 (Lighthouse) — corrigé (PR #612)** : cause = `chrome-launcher` ne trouve pas Chrome dans l'image Playwright **et** aucun job CI ne lançait lhci. Fix : `CHROME_PATH` + workflow manuel `lighthouse.yml`. Scores réels à collecter sur la stack recette.
-+ **Couverture — cause corrigée** : pas « clés JWT `test` non provisionnées » mais un **mismatch passphrase/clés** (le CI régénère + force `JWT_PASSPHRASE=test`). Fix : `JWT_PASSPHRASE` forcé dans `phpunit.dist.xml` + cible `make jwt-keypair-test` (PR #612).
-+ **SEC-003 — à nuancer** : `X-Frame-Options: deny` et `X-Content-Type-Options: nosniff` sont **présents sur les réponses API Platform** mais **absents des pages HTML PWA** (la surface clickjacking). Le finding ne vaut que pour la PWA.
-+ **Stack-trace prod — conformité confirmée empiriquement** : de vrais `500` (lock) et `415` (mauvais content-type) renvoient un `problem+json` propre, **sans trace ni nom de classe** exposés.
-+ **Faux positif écarté** : un crash `HealthController` (`RateLimiterFactory` injecté pour `$mercureClient`) au 1er boot venait d'un **cache prod périmé dans le volume `php_var`** réutilisé entre boots — **pas** un bug de `main` (résolu en recréant le volume). Ne PAS reporter.
-
-### Conformités confirmées
-
-+ **Golden path** : le trip « Entre Sensée et Escaut » (Komoot, zone Lille) est **calculé** (stages, distance 70,2 km, dénivelé) — fetch source + pacing OK.
-+ **Auth réelle** : magic-link via Mailcatcher → JWT (`/auth/verify` en `application/ld+json`) → création de trip authentifiée → partage.
-
-### Révision du verdict « aucun P0 »
-
-Caduc : **F1 (`LOCK_DSN`) est un P0** (création de trip cassée en prod par défaut).
-
-### Reste à exécuter (recette stable ultérieure, outillage prêt PR #612)
-
-Lighthouse (scores), axe runtime authed, **couverture chiffrée** (PHPUnit/Vitest via stack dev + `make jwt-keypair-test`), N+1 profilé, **isolation Mercure empirique**, **purge RGPD en DB**, XSS payload, analyse de bundle, multi-device, chaos (worker/réseau).
 
 ---
 
@@ -75,28 +40,116 @@ Lighthouse (scores), axe runtime authed, **couverture chiffrée** (PHPUnit/Vites
 
 | ID | Titre | Sévérité | Label | Statut |
 |---|---|---|---|---|
+| F1 | `LOCK_DSN` absent de `compose.yaml` -> fallback `redis://localhost` injoignable -> **création de trip 500 en prod** | **P0** | quality | Confirmé |
+| SEO-001 | Pages de partage `/s/[code]` sans `generateMetadata` (aperçu social cassé) | P1 | seo | Confirmé |
+| F3 | Intégration **Ollama prod absente de `compose.yaml`** + divergence ADR-028 (mode dégradé silencieux) | P1 | quality | Confirmé |
+| F4 | **Rate-limit `/auth/request-link` inopérant** : 6× même email -> `202`, aucun `429` | P1 | security | Confirmé |
+| F2 | `DataTourismeClient` `TypeError` si clé absente/vide -> `ScanAccommodations`/`ScanEvents` crashent | ~~P1~~ | quality | **Corrigé (PR #613)** |
 | SEC-001 | Pas de Content-Security-Policy sur les réponses HTML | P2 | security | Confirmé |
 | SEC-002 | Pas de Strict-Transport-Security (HSTS) | P2 | security | Confirmé |
 | SEC-003 | Pas de X-Frame-Options ni X-Content-Type-Options sur les pages PWA | P2 | security | Confirmé |
-| SEC-004 | Pas de Referrer-Policy | P3 | security | Confirmé |
-| SEC-005 | En-tête `x-powered-by: Next.js` exposé en prod | P3 | security | Confirmé |
-| SEO-001 | Pages de partage `/s/[code]` sans `generateMetadata` (aperçu social cassé) | P1 | seo | Confirmé |
 | SEO-002 | `robots.txt` et `sitemap.xml` absents (404) | P2 | seo | Confirmé |
 | SEO-003 | Aucune balise Open Graph / Twitter Card sur les pages publiques | P2 | seo | Confirmé |
 | A11Y-001 | Landing `/` sans landmark `<main>` dans le HTML rendu | P2 | a11y | Confirmé |
 | A11Y-002 | Landing `/` sans `<h1>` dans le HTML rendu (SSR) | P2 | a11y | Confirmé |
+| LH-PERF-HOME | Landing `/` score Lighthouse Performance **0.65** (< 0.80) | P2 | perf | Confirmé |
+| LH-A11Y-HOME | Landing `/` score Lighthouse Accessibility **0.84** (< 0.90) | P2 | a11y | Confirmé |
+| DT-LIVE | DataTourisme mode live cassé : scoped client sans `base_uri` + endpoint obsolète | P2 | quality | Confirmé |
+| F5 | APIs externes flaky : **Overpass `429`/timeout** -> POI/alertes dégradés | P2 | perf | Confirmé |
 | QUAL-001 | Aucun seuil de couverture PHPUnit (`fail-under`) | P2 | quality | Confirmé |
 | QUAL-002 | Aucun seuil de couverture Vitest (frontend) | P2 | quality | Confirmé |
-| QUAL-004 | `make lighthouse` non exécutable (Chrome introuvable dans l'image lhci) | P2 | quality | Confirmé |
+| COV-API | Couverture PHPUnit API **71,8 %** statements (< 80 % DoD) | P2 | quality | Confirmé |
+| CI-UNIT | Tests unitaires front (Vitest) **non exécutés en CI** | P2 | quality | Confirmé |
+| QUAL-004 | `make lighthouse` non exécutable (Chrome introuvable dans l'image lhci) | ~~P2~~ | quality | **Corrigé (PR #612)** |
+| SEC-004 | Pas de Referrer-Policy | P3 | security | Confirmé |
+| SEC-005 | En-tête `x-powered-by: Next.js` exposé en prod | P3 | security | Confirmé |
 | PERF-001 | `maplibre-gl` importé statiquement dans `trip-planner.tsx` | P3 | perf | Confirmé |
 | I18N-001 | Pas de handler `onError` sur `NextIntlClientProvider` | P3 | i18n | Confirmé |
 | QUAL-003 | Dette de suppressions statiques (7 `@phpstan-ignore`, 5 front) | P3 | quality | Confirmé |
+| COV-PROV | Couverture provisioner non mesurable (xdebug absent du conteneur) | P3 | quality | Confirmé |
 
-**16 findings v1 confirmés** : 1×P1, 8×P2, 7×P3. **À compléter par la Recette v2 ci-dessus** : **1×P0 (F1 `LOCK_DSN`)**, 3×P1 (F2–F4), 1×P2 (F5) + corrections. Le « aucun P0 » initial est **caduc**.
+**Total : 1×P0, 3×P1 actifs (+1 corrigé), 15×P2 (+1 corrigé), 6×P3.** Le « aucun P0 » d'une première lecture
+est **caduc** : F1 casse la création de trip en prod par défaut.
 
 ---
 
 ## Findings détaillés
+
+### Configuration de production & intégrations externes
+
+#### F1 — `LOCK_DSN` absent de `compose.yaml` -> création de trip 500 en prod — P0
+
+`compose.yaml` (iso-prod) n'expose pas `LOCK_DSN` ; le `framework.lock` retombe sur la valeur d'`api/.env`
+(`redis://localhost:6379`), injoignable depuis le conteneur (Redis est le service `redis`). À la création d'un
+trip, l'acquisition de lock échoue :
+
+```text
+LockAcquiringException: Failed to acquire the "..." lock — Redis connection refused (localhost:6379)
+# POST /trips -> 500 ; OK après override LOCK_DSN=redis://redis:6379
+```
+
+**Reco (35.4) :** ajouter `LOCK_DSN: redis://redis:6379` à `compose.yaml`. (Contourné en recette via
+`compose.recette.yaml` pour débloquer le golden path.)
+
+#### F3 — Intégration Ollama prod absente + divergence ADR-028 — P1
+
+`grep OLLAMA compose.yaml` = ∅ : le tier IA (analyse d'étapes, overview, chat) n'a aucune définition dans la
+stack iso-prod. De plus `HealthController::$required` n'inclut pas Ollama -> health vert même IA absente, un
+**mode dégradé silencieux** contraire à l'ADR-028 (« hard dependency »).
+**Reco (35.4) :** versionner Ollama en prod (`compose.ollama.yaml` livré PR #612 sert de base) ; aligner ADR-028
+(soit Ollama dans `$required`, soit acter le mode dégradé dans l'ADR).
+
+#### F4 — Rate-limit `/auth/request-link` inopérant — P1
+
+6 requêtes successives sur le même email renvoient toutes `202`, **aucun `429`** :
+
+```text
+$ for i in $(seq 1 6); do curl -sk -o /dev/null -w "%{http_code} " -X POST https://localhost/auth/request-link \
+    -H 'Content-Type: application/ld+json' -d '{"email":"flood@example.com"}'; done
+202 202 202 202 202 202
+```
+
+Les limiters sont pourtant configurés (`magic_link_email` 3/900s, cf. conformités Ordre 1). Piste : le storage du
+limiter en prod `read_only` (filesystem/cache) n'est pas writable, le limiter no-op silencieusement.
+**Reco (35.4) :** investiguer le storage du limiter sous `read_only` (Redis plutôt que cache filesystem).
+
+#### DT-LIVE — DataTourisme mode live cassé — P2 (feature OFF par défaut)
+
+La clé d'API est valide (`GET https://api.datatourisme.fr/v1/catalog` -> 200), mais en mode live
+(`DATATOURISME_ENABLED=true` + clé) **tous les appels échouent** :
+
+```text
+worker | WARNING [app] DataTourisme request failed, returning empty result.
+        ["error" => "Invalid URL: scheme is missing in "/api/v1/places?filters[0]...". Did you forget to add "http(s)://"?"]
+```
+
+Deux défauts : **(1)** le scoped client `datatourisme.client` (`api/config/packages/framework.php:81`) déclare un
+`scope` (regex SSRF) **sans `base_uri`** (contrairement à komoot/strava/overpass) -> `request('/api/v1/places')`
+(path relatif) n'a aucune base à préfixer ; **(2)** l'endpoint `/api/v1/places` est **obsolète** (l'API v1 actuelle
+expose `/v1/catalog` et `/v1/placeOfInterest`).
+**Reco (35.4) :** ajouter `base_uri: https://api.datatourisme.fr` au scoped client + migrer endpoints/format vers
+l'API v1. (Le mode **dégradé** — clé absente/vide — est OK depuis PR #613, cf. ci-dessous.)
+
+#### F5 — APIs externes flaky : Overpass `429`/timeout — P2
+
+```text
+worker | WARNING [app] Overpass query failed: 429 Too Many Requests
+```
+
+POI et alertes terrain dégradés quand Overpass throttle. Tiers, hors de notre contrôle direct.
+**Reco :** durcir cache + retry/backoff, documenter le comportement dégradé.
+
+#### Conformités intégrations vérifiées
+
++ **DataTourisme — dégradé OK (fix PR #613)** : avec `ENABLED=true` et clé **vide** (le cas du bug F2),
+  `ScanAccommodations` est « handled successfully », **aucun `TypeError`** (`?string $apiKey` + `isEnabled()`
+  null-safe -> source skippée par les registries). Avant le fix, ce cas crashait en boucle de retry.
++ **Golden path** : le trip « Entre Sensée et Escaut » (Komoot, zone Lille) est **calculé** (stages,
+  distance 70,2 km, dénivelé) — fetch source + pacing OK.
++ **Auth réelle** : magic-link via Mailcatcher -> JWT (`/auth/verify` en `application/ld+json`) -> création de
+  trip authentifiée -> partage.
+
+---
 
 ### Sécurité (Ordre 1)
 
@@ -113,17 +166,20 @@ $ curl -skD - -o /dev/null -H 'Accept: text/html' https://localhost/
 ```
 
 **Impact :** pas de défense en profondeur contre l'injection de scripts.
-**Reco :** CSP même restrictive au niveau edge (Caddy ou reverse-proxy Coolify).
+**Reco :** CSP même restrictive **dans le Caddyfile** (socle pérenne FrankenPHP, cf. décision projet — pas à
+l'edge Coolify remplaçable).
 
 #### SEC-002 — Pas de HSTS — P2
 
 Aucun `Strict-Transport-Security` sur les réponses (HTTP et HTTPS).
-**Reco :** `Strict-Transport-Security: max-age=31536000; includeSubDomains` à l'edge en prod.
+**Reco :** `Strict-Transport-Security: max-age=31536000; includeSubDomains` dans le Caddyfile.
 
 #### SEC-003 — Pas de X-Frame-Options / X-Content-Type-Options sur les pages PWA — P2
 
-Les pages HTML de la PWA (surface de clickjacking / MIME sniffing) ne portent ni `X-Frame-Options` ni `X-Content-Type-Options` (dump d'en-têtes SEC-001). API Platform pose ces en-têtes sur certaines réponses d'erreur, mais **pas** sur les documents HTML applicatifs.
-**Reco :** `X-Frame-Options: DENY` + `X-Content-Type-Options: nosniff` à l'edge.
+Les pages HTML de la PWA (surface de clickjacking / MIME sniffing) ne portent ni `X-Frame-Options` ni
+`X-Content-Type-Options` (dump d'en-têtes SEC-001). API Platform pose ces en-têtes sur certaines réponses
+d'erreur, mais **pas** sur les documents HTML applicatifs : le finding ne vaut que pour la PWA.
+**Reco :** `X-Frame-Options: DENY` + `X-Content-Type-Options: nosniff` dans le Caddyfile.
 
 #### SEC-004 — Pas de Referrer-Policy — P3
 
@@ -140,12 +196,21 @@ Fingerprinting du framework (facilite le ciblage de CVE). **Reco :** `poweredByH
 
 #### Conformités sécurité vérifiées
 
-+ **Rate limiting auth** : `magic_link_email` (3/900s), `magic_link_ip` (10/900s), `access_request_ip` (3/3600s) — `rate_limiter.php` + appliqués dans `AuthRequestLinkProcessor` / `AccessRequestCreateProcessor`.
-+ **XSS** : aucun `dangerouslySetInnerHTML` dans `pwa/src` (React échappe par défaut).
-+ **Auth 401** : `/trips` et endpoints protégés renvoient `401 JWT Token not found` non authentifié ; IDOR couvert par `TripVoter` (`is_granted('TRIP_VIEW'/'TRIP_EDIT', object)`).
-+ **Stack-trace prod** : 404/erreurs renvoient un `problem+json` propre, `/_profiler` → 404, `web_profiler` désactivé en prod.
++ **Rate limiting (config)** : `magic_link_email` (3/900s), `magic_link_ip` (10/900s), `access_request_ip`
+  (3/3600s) — `rate_limiter.php` + appliqués dans `AuthRequestLinkProcessor` / `AccessRequestCreateProcessor`.
+  **Mais inopérant au runtime prod (cf. F4).**
++ **XSS (statique)** : aucun `dangerouslySetInnerHTML` dans `pwa/src` (React échappe par défaut). Test payload
+  sur champ éditable = à exécuter (cf. « Reste à exécuter »).
++ **Auth 401 / IDOR** : `/trips` et endpoints protégés renvoient `401 JWT Token not found` non authentifié ;
+  IDOR couvert par `TripVoter` (`is_granted('TRIP_VIEW'/'TRIP_EDIT', object)`).
++ **Stack-trace prod — confirmé empiriquement** : de vrais `500` (lock F1) et `415` (mauvais content-type)
+  renvoient un `problem+json` propre, **sans trace ni nom de classe** exposés ; `/_profiler` -> 404,
+  `web_profiler` désactivé en prod.
++ **Isolation Mercure — confirmée empiriquement** : un abonné **anonyme** au topic privé `/trips/{id}` ne reçoit
+  **aucune donnée** (seulement le heartbeat SSE `:`). Les updates `private: true` (`TripUpdatePublisher`) ne sont
+  délivrés qu'aux porteurs d'un JWT subscriber scopé (`MercureTokenIssuer`, cookie `Secure`+`HttpOnly`+
+  `SameSite=strict`) ; le `anonymous` du hub autorise la connexion mais pas la lecture des topics privés.
 + **`composer audit`** : `No security vulnerability advisories found` (conteneur prod).
-+ **Isolation Mercure** : malgré `anonymous` dans le Caddyfile, les updates de trip sont publiés avec `private: true` (`TripUpdatePublisher`) et l'abonnement requiert un JWT subscriber scopé au topic (`MercureTokenIssuer`, cookie `Secure`+`HttpOnly`+`SameSite=strict`). Un abonné anonyme ouvre le hub (HTTP 200) mais **ne reçoit pas** les updates privés. Confirmation empirique différée iso-prod seedé.
 
 ---
 
@@ -153,21 +218,20 @@ Fingerprinting du framework (facilite le ciblage de CVE). **Reco :** `poweredByH
 
 #### PERF-001 — `maplibre-gl` importé statiquement — P3
 
-`pwa/src/components/trip-planner.tsx:30` importe `MapPanel` directement (chaîne `MapPanel → MapView → maplibre-gl ~5.24`), sans `next/dynamic`. Atténué : `TripPlanner` n'est monté que sur les routes éditeur (`/trips/new`, `/trips/[id]`, `/s/[code]`), elles-mêmes en `dynamic()`.
+`pwa/src/components/trip-planner.tsx:30` importe `MapPanel` directement (chaîne `MapPanel -> MapView ->
+maplibre-gl ~5.24`), sans `next/dynamic`. Atténué : `TripPlanner` n'est monté que sur les routes éditeur
+(`/trips/new`, `/trips/[id]`, `/s/[code]`), elles-mêmes en `dynamic()`.
 **Reco :** lazy-load `MapPanel` pour alléger le 1er chunk de la route éditeur.
 
 #### Conformités performance vérifiées
 
-+ **N+1 Doctrine** : `TripCollectionProvider` (`leftJoin('t.stages')+addSelect` + `Paginator(fetchJoinCollection: true)`) ; `DoctrineTripRequestRepository::storeStages` bulk DELETE + flush unique ; updates JSONB par étape atomiques sans charger l'agrégat.
++ **N+1 Doctrine (statique)** : `TripCollectionProvider` (`leftJoin('t.stages')+addSelect` +
+  `Paginator(fetchJoinCollection: true)`) ; `DoctrineTripRequestRepository::storeStages` bulk DELETE + flush
+  unique ; updates JSONB par étape atomiques sans charger l'agrégat. Profiling runtime seedé = à exécuter.
 + **Caches** : OSM 24h, météo 3h (ADR-022), points bruts/décimés 30 min.
-+ **Async** : `FetchWeatherHandler` (cache→batch uncached→calcul), `OsmScanner::queryBatch` (Overpass concurrent), `ScanAccommodationsHandler` (multiplexage HTTP 2 vagues, SPARQL Wikidata batch).
++ **Async** : `FetchWeatherHandler` (cache->batch uncached->calcul), `OsmScanner::queryBatch` (Overpass
+  concurrent), `ScanAccommodationsHandler` (multiplexage HTTP 2 vagues, SPARQL Wikidata batch).
 + **Profil altimétrique** : SVG custom O(n) + recherche binaire, sans lib de charting lourde.
-
-#### Différé performance
-
-+ Scores Lighthouse : **non collectés** (voir QUAL-004).
-+ Coût de sérialisation DTO `TripDetailProvider` : profiling runtime seedé requis.
-+ Latence chaîne de calcul async réelle : load-test iso-prod requis.
 
 ---
 
@@ -183,19 +247,24 @@ $ curl -sk -H 'Accept: text/html' https://localhost/login | grep -oE "<(h1|main)
 <main
 ```
 
-La landing rend son `<h1>` (`landing/hero.tsx`) et sa structure **côté client** après un contrôle d'auth ; le HTML initial n'expose donc ni `<h1>` ni landmark `<main>` — pénalise lecteurs d'écran et SEO. La page `/login` est conforme (preuve ci-dessus).
+La landing rend son `<h1>` (`landing/hero.tsx`) et sa structure **côté client** après un contrôle d'auth ; le
+HTML initial n'expose donc ni `<h1>` ni landmark `<main>` — pénalise lecteurs d'écran et SEO. La page `/login`
+est conforme (preuve ci-dessus).
 **Reco :** garantir un `<main>` + `<h1>` dans le rendu serveur de la landing.
+
+#### LH-A11Y-HOME — Lighthouse Accessibility `/` = 0.84 (< 0.90) — P2
+
+Score Lighthouse confirmant A11Y-001/002 (`<h1>`/`<main>` absents du HTML SSR). Mêmes corrections que
+A11Y-001/002.
 
 #### Conformités a11y vérifiées
 
-+ `lang="fr"` sur `<html>` ; `/faq`, `/legal`, `/privacy` ont hiérarchie h1→h2 correcte + landmarks.
++ `lang="fr"` sur `<html>` ; `/faq`, `/legal`, `/privacy` ont hiérarchie h1->h2 correcte + landmarks
+  (Lighthouse A11y >= 0.90 sur ces pages).
 + Formulaires (login, early-access) : `<label htmlFor>`, `aria-describedby`, `aria-invalid`.
 + Dialogs via Radix UI (a11y intégrée) ; images avec `alt` ; boutons carousel avec `aria-label`.
-+ Helper `expectNoCriticalA11yViolations` (@axe-core/playwright) câblé dans les fixtures (#601).
-
-#### Différé a11y
-
-+ Navigation clavier manuelle (focus trap modales, drag&drop timeline) et axe runtime sur pages **authentifiées** : stack dev seedée + Playwright requis.
++ Helper `expectNoCriticalA11yViolations` (@axe-core/playwright) câblé dans les fixtures (#601). axe runtime sur
+  pages **authentifiées** = à exécuter (cf. « Reste à exécuter »).
 
 ---
 
@@ -203,15 +272,18 @@ La landing rend son `<h1>` (`landing/hero.tsx`) et sa structure **côté client*
 
 #### SEO-001 — Pages de partage `/s/[code]` sans métadonnées dynamiques — P1
 
-`pwa/src/app/s/[code]/page.tsx` et `shared-trip-page.tsx` n'exportent ni `metadata` ni `generateMetadata`. Les liens de partage (raison d'être de la feature) n'ont donc ni `og:title`, ni `og:description`, ni `og:image` : l'aperçu social/messagerie est cassé. **C'est le cœur de l'Ordre 4.**
+`pwa/src/app/s/[code]/page.tsx` et `shared-trip-page.tsx` n'exportent ni `metadata` ni `generateMetadata`.
+Confirmé empiriquement sur un trip réellement partagé : `/s/kETacKMK` rend `<title>Planificateur de voyage
+vélo</title>` (titre global) + meta description générique, **aucun `og:`/`twitter:`** -> aperçu social/messagerie
+cassé. **C'est le cœur de l'Ordre 4.**
 **Reco :** `generateMetadata` par token de partage (titre du trip, distance/dénivelé, image de carte).
 
 #### SEO-002 — `robots.txt` / `sitemap.xml` absents — P2
 
 ```text
-curl -sk -o /dev/null -w "%{http_code}" https://localhost/robots.txt
+$ curl -sk -o /dev/null -w "%{http_code}" https://localhost/robots.txt
 404
-curl -sk -o /dev/null -w "%{http_code}" https://localhost/sitemap.xml
+$ curl -sk -o /dev/null -w "%{http_code}" https://localhost/sitemap.xml
 404
 ```
 
@@ -233,59 +305,77 @@ $ curl -sk -H 'Accept: text/html' https://localhost/ | grep -oiE "<meta[^>]*(og:
 
 #### I18N-001 — Pas de `onError` sur `NextIntlClientProvider` — P3
 
-`pwa/src/app/layout.tsx` instancie `NextIntlClientProvider` sans `onError` : une clé manquante au runtime s'affiche en littéral sans signal.
+`pwa/src/app/layout.tsx` instancie `NextIntlClientProvider` sans `onError` : une clé manquante au runtime
+s'affiche en littéral sans signal.
 **Reco :** `onError` qui loggue (et throw en dev).
 
 #### Conformités i18n vérifiées
 
 + **`make i18n-check` : PASS** — `i18n-check OK: 848 keys in sync across fr, en`.
-+ Formatage dates/nombres via `toLocaleDateString(undefined, …)` (délégué au locale) — `infographic.ts:632`, `StageDetailPanel.tsx:56`, `timeline.tsx:55`, `text-export.ts:24`.
++ Formatage dates/nombres via `toLocaleDateString(undefined, …)` (délégué au locale) — `infographic.ts:632`,
+  `StageDetailPanel.tsx:56`, `timeline.tsx:55`, `text-export.ts:24`.
 + ~119 composants via `useTranslations()`.
 
 ---
 
 ### Qualité (Ordre 6)
 
-#### QUAL-001 — Pas de seuil de couverture PHPUnit — P2
+#### QUAL-001 / QUAL-002 — Pas de seuil de couverture (PHPUnit & Vitest) — P2
 
-`api/phpunit.dist.xml` : bloc `<coverage>` sans `<limit minimum="…">`. La couverture n'est jamais un gate CI.
-**Reco :** ajouter un seuil (>= 80%, cf. DoD) et l'appliquer en CI.
+`api/phpunit.dist.xml` : bloc `<coverage>` sans `<limit minimum="…">`. `pwa/vitest.config.ts` : aucune clé
+`coverage`/thresholds. La couverture n'est jamais un gate CI.
+**Reco :** seuil >= 80 % (cf. DoD) appliqué en CI, des deux côtés.
 
-#### QUAL-002 — Pas de seuil de couverture Vitest — P2
+#### COV-API — Couverture PHPUnit API 71,8 % statements (< 80 %) — P2
 
-`pwa/vitest.config.ts` n'a aucune clé `coverage`/thresholds.
-**Reco :** configurer un seuil front (>= 80%).
-
-#### QUAL-004 — `make lighthouse` non exécutable — P2
+Mesurée sur la stack dev (xdebug, clés régénérées `make jwt-keypair-test` ; le mismatch passphrase/clés qui
+causait 151 `JWTEncodeFailureException` est corrigé via `JWT_PASSPHRASE` forcé dans `phpunit.dist.xml`).
 
 ```text
-$ make lighthouse
-…
-❌  Chrome installation not found
-Healthcheck failed!
-make: *** [Makefile:129 : lighthouse] Erreur 1
+$ make coverage-ci   # api
+OK, but some tests were skipped! Tests: 1310, Assertions: 3819, Skipped: 1
+# clover api/coverage/api/clover.xml : statements 6769/9432 = 71,8 % ; methods 561/959 = 58,5 %
 ```
 
-La cible lance `lhci autorun` dans `mcr.microsoft.com/playwright`, mais `lhci` ne trouve pas Chrome dans cette image. **Aucun score n'a pu être collecté** (perf/a11y/seo/best-practices).
-**Reco :** installer/pointer Chrome dans le job (`npx playwright install chrome` ou `CHROME_PATH`), sinon le gate Lighthouse est inopérant. Bloque la mesure des seuils Performance ≥ 80 / A11y ≥ 90 / SEO ≥ 90 du DoD recette.
+**Reco :** remonter la couverture API vers le seuil 80 % du DoD (couplé à QUAL-001).
+
+#### CI-UNIT — Tests unitaires front non exécutés en CI — P2
+
+`ci.yml` ne lance que `npm run test:ts` (TypeScript), **jamais `vitest`** : les tests unitaires front existent mais
+ne sont vérifiés par aucun pipeline. La mesure locale est en outre bloquée (conteneur `pwa` plafonné à 512 Mo
+-> OOM-kill, provider `@vitest/coverage-v8` absent, volume `node_modules` désynchronisé -> `jsdom`
+`MODULE_NOT_FOUND`). Couverture front **non chiffrable en l'état**.
+**Reco :** ajouter un job `vitest run` en CI (+ provider de couverture pour QUAL-002).
+
+#### COV-PROV — Couverture provisioner non mesurable — P3
+
+Le conteneur `provisioner` n'embarque pas de driver xdebug -> `make coverage-ci` échoue sur cette jambe avec
+*« No code coverage driver available »*.
+**Reco :** aligner l'image provisioner sur l'API pour la couverture, ou exclure explicitement cette jambe.
+
+#### QUAL-004 — `make lighthouse` non exécutable — Corrigé (PR #612)
+
+Cause : `lhci autorun` tournait dans `mcr.microsoft.com/playwright` où `chrome-launcher` ne trouvait pas Chrome,
+**et aucun job CI ne lançait lhci**. Fix livré : `CHROME_PATH` pointant le chromium Playwright + workflow manuel
+`lighthouse.yml`. La cible s'exécute désormais (5 URLs × 3 runs) et a permis de collecter LH-PERF-HOME /
+LH-A11Y-HOME (cf. Perf/A11y).
 
 #### QUAL-003 — Dette de suppressions statiques — P3
 
-+ 7 × `@phpstan-ignore` : `api/src/Story/AppStory.php` (×5, types Foundry), `AnalyzeTerrainHandler.php` (×2, nullsafe).
-+ 5 × suppressions front : 3 `react-hooks/exhaustive-deps`, 1 `@ts-expect-error` (test), 1 `@next/next/no-img-element` (images Wikimedia).
++ 7 × `@phpstan-ignore` : `api/src/Story/AppStory.php` (×5, types Foundry), `AnalyzeTerrainHandler.php`
+  (×2, nullsafe).
++ 5 × suppressions front : 3 `react-hooks/exhaustive-deps`, 1 `@ts-expect-error` (test),
+  1 `@next/next/no-img-element` (images Wikimedia).
 
 Volume faible et justifié, mais à tracer comme dette.
 
 #### Conformités qualité vérifiées
 
++ **Suite QA/CI complète verte** (source de vérité = CI de cette PR, 21/21 checks) : PHP-CS-Fixer, Rector,
+  PHPStan **Level 9** + `banned_code`, ESLint strict (`no-explicit-any`, `no-console`), Prettier, TS,
+  Markdownlint, OpenAPI lint, Hadolint, i18n, PHPUnit (api + provisioner), Playwright, BDD recette, APK.
 + PHPUnit : `failOnWarning`/`failOnRisky`/`failOnDeprecation` = true.
-+ PHPStan **Level 9** + `banned_code` (echo/dd/eval/exit/shell_exec…), Rector PHP 8.5, ESLint strict (`no-explicit-any`, `no-console`).
-+ `npm audit` : **8 modérées, 0 haute/critique** (relevé pendant `npm ci` du job lighthouse) → gate CI `--audit-level=high` vert.
-
-#### Différé qualité
-
-+ **Couverture chiffrée** : non mesurable localement (clés JWT `test` non provisionnées → 151 `JWTEncodeFailureException`). **Autorité = CI.**
-+ `make qa` complet : non rejoué ici (pré-commit + CI verts sur `main`).
++ `npm audit` : **8 modérées, 0 haute/critique** -> gate CI `--audit-level=high` vert.
 
 ---
 
@@ -293,8 +383,10 @@ Volume faible et justifié, mais à tracer comme dette.
 
 Aucune non-conformité. Conformités vérifiées :
 
-+ **Page `/privacy`** complète : sections responsable, base légale, finalités, données, rétention, droits, sous-traitants, **analytics**, contact. Mentionne Plausible auto-hébergé, cookieless, sans PII vers tiers.
-+ **Gating Plausible par env** : `pwa/src/components/plausible-script.tsx:39-41` retourne `null` si `NEXT_PUBLIC_PLAUSIBLE_DOMAIN`/`SRC` indéfinis → en iso-prod (vars vides), script absent, 0 requête analytics.
++ **Page `/privacy`** complète : responsable, base légale, finalités, données, rétention, droits, sous-traitants,
+  analytics, contact. Plausible auto-hébergé, cookieless, sans PII vers tiers.
++ **Gating Plausible par env** : `pwa/src/components/plausible-script.tsx:39-41` retourne `null` si
+  `NEXT_PUBLIC_PLAUSIBLE_DOMAIN`/`SRC` indéfinis -> en iso-prod (vars vides), script absent, 0 requête analytics.
 + **Pas de consentement** (ADR-034 : Plausible cookieless ; #385 bannière cookies abandonnée).
 + **0 cookie** sur pages publiques :
 
@@ -303,75 +395,26 @@ $ for p in / /login /privacy; do curl -skD - -o /dev/null -H 'Accept: text/html'
 /: none   /login: none   /privacy: none
 ```
 
-+ **Purge user (RGPD)** : `DELETE /users/me` → `AccountDeleteProcessor` : transaction, cascade FK (trips/stages/chat/shares), révocation des refresh tokens, anonymisation de l'email — irréversible, immédiat, pas de cron (décision projet). Vérification DB après suppression différée iso-prod seedé.
++ **Purge user (RGPD)** : `DELETE /users/me` -> `AccountDeleteProcessor` : transaction, cascade FK
+  (trips/stages/chat/shares), révocation des refresh tokens, anonymisation de l'email — irréversible, immédiat,
+  pas de cron (décision projet). Vérification DB/Redis après suppression = à exécuter (cf. ci-dessous).
 
 ---
 
-## Récapitulatif des différés (à exécuter en iso-prod seedé / CI)
+## Reste à exécuter (empirique — recette ultérieure / Sprint 35.3+)
 
-| Sujet | Raison | Où |
+Items non bloquants pour la publication de ce rapport, à exercer sur stack seedée (certains bridés par la machine
+d'audit : conteneur pwa cappé, OOM `tsc`/`vitest`) :
+
+| Sujet | Pourquoi pas encore fait | Où |
 |---|---|---|
-| Scores Lighthouse | `make lighthouse` cassé (QUAL-004) | corriger l'outillage puis iso-prod |
-| Couverture PHPUnit/Vitest chiffrée | clés JWT `test` absentes en local | CI |
-| Matrice 403 inter-utilisateurs, XSS sur trip réel | pas d'auth (mailer null) en prod local | iso-prod seedé |
-| Purge DB post-suppression compte | pas de user seedé | iso-prod seedé |
-| axe runtime + nav clavier pages authentifiées | stack dev + Playwright | dev seedé (Sprint 35.3) |
-| Confirmation empirique isolation Mercure | publish + subscribe anonyme | iso-prod seedé |
-
----
-
-## Recette v2 — résultats d'exécution (stack iso-prod rebâtie + golden path réel)
-
-> Exécution sur `make start-recette` (iso-prod `APP_ENV=prod` + Mailcatcher + Ollama), images rebâties
-> depuis `main` (fix DataTourisme #613 inclus). Golden path réel : compte via `app:create-user` →
-> magic-link Mailcatcher → JWT → trips Komoot (dont « Entre Sensée et Escaut », zone Lille).
-
-### DataTourisme — modes dégradé & live
-
-+ **Mode dégradé (clé absente ou `DATATOURISME_ENABLED=false`) : OK.** Avec `ENABLED=true` et clé **vide**
-  (le cas du bug F2), `ScanAccommodations` est « handled successfully », **aucun `TypeError`** : le fix #613
-  (`?string $apiKey` + `isEnabled()` null-safe) dégrade gracieusement (source skippée par les registries).
-  Avant le fix, ce cas crashait en boucle de retry.
-+ **Mode live (clé valide + `ENABLED=true`) : CASSÉ — finding `DT-LIVE` (P2, feature OFF par défaut).** La clé
-  est valide (`GET https://api.datatourisme.fr/v1/catalog` → 200), mais deux défauts : **(1)** le scoped client
-  `datatourisme.client` (`api/config/packages/framework.php:81`) a un `scope` (regex SSRF) **sans `base_uri`**
-  (contrairement à komoot/strava/overpass) → `request('/api/v1/places')` (path relatif) échoue *« Invalid URL:
-  scheme is missing »*, tous les appels renvoient un résultat vide ; **(2)** endpoint obsolète `/api/v1/places`
-  → **404** alors que l'API v1 actuelle expose `/v1/catalog` et `/v1/placeOfInterest` (→ 200). **Fix 35.4** :
-  ajouter `base_uri: https://api.datatourisme.fr` au scoped client + migrer endpoints/format vers l'API v1.
-
-### Lighthouse (pages publiques) — QUAL-004 corrigé, scores collectés
-
-`make lighthouse` (réparé) s'exécute désormais (Chrome trouvé via `CHROME_PATH`, 5 URLs × 3 runs) :
-
-+ **Landing `/` sous les seuils** : Performance **0.65** (< 0.80) et Accessibility **0.84** (< 0.90)
-  → findings **`LH-PERF-HOME`** (P2) et **`LH-A11Y-HOME`** (P2, cohérent avec A11Y-001/002 : `<h1>`/`<main>`
-  absents du HTML SSR). SEO / Best-Practices OK sur `/`.
-+ **`/login`, `/faq`, `/legal`, `/privacy` : conformes** (Perf ≥ 0.80, A11y ≥ 0.90, SEO ≥ 0.90, BP ≥ 0.90).
-
-### Isolation Mercure — confirmée empiriquement
-
-Un abonné **anonyme** au topic privé `/trips/{id}` ne reçoit **aucune donnée** (seulement le heartbeat SSE `:`).
-Les updates `private: true` ne sont délivrés qu'aux abonnés porteurs d'un JWT subscriber scopé (`subscriber_jwt`,
-Caddyfile) ; le `anonymous` du hub autorise la connexion mais pas la lecture des topics privés. Le finding v1
-« isolation Mercure à confirmer » est donc **levé**.
-
-### Couverture de tests — chiffrée
-
-Mesurée sur la stack **dev** (xdebug présent, clés JWT régénérées via `make jwt-keypair-test`,
-`JWT_PASSPHRASE=test` forcé par `phpunit.dist.xml` -> plus aucune `JWTEncodeFailureException`).
-
-+ **API PHPUnit : 1310 tests OK** (3819 assertions, 1 skip). Couverture **statements 71,8 %** (6769/9432),
-  méthodes 58,5 % (561/959) -> **sous le seuil 80 %** (clover `api/coverage/api/clover.xml`) -> finding
-  **`COV-API`** (P2). Le mismatch passphrase/clés du rapport v1 est corrigé : la couverture s'exécute désormais.
-+ **Provisioner** : couverture **non mesurable** (le conteneur `provisioner` n'embarque pas de driver xdebug ->
-  `make coverage-ci` échoue sur cette jambe avec *« No code coverage driver available »*). Finding **`COV-PROV`**
-  (P3) : aligner l'image provisioner sur l'API pour la couverture, ou exclure explicitement cette jambe.
-+ **Front Vitest : non exécuté en CI** (`ci.yml` ne lance que `npm run test:ts`, jamais `vitest`) -> finding
-  **`CI-UNIT`** (P2) : les tests unitaires front existent mais ne sont vérifiés par aucun pipeline. Localement la
-  mesure est bloquée (conteneur `pwa` plafonné à 512 Mo -> OOM-kill, provider `@vitest/coverage-v8` absent,
-  volume `node_modules` désynchronisé -> `jsdom` `MODULE_NOT_FOUND`). Couverture front **non chiffrable en l'état**.
-
-> Suite QA complète : source de vérité = la CI de #614 (**21/21 checks verts** : PHP-CS-Fixer, Rector, PHPStan L9,
-> ESLint, Prettier, TS, Markdownlint, OpenAPI lint, Hadolint, i18n, PHPUnit api+provisioner, Playwright, BDD recette,
-> APK). Non rejouée localement (OOM `tsc`/`rector` connus, cf. mémoire CI).
+| Matrice 403 inter-utilisateurs | second compte seedé requis | iso-prod recette |
+| XSS payload sur champ éditable d'un trip réel | nécessite trip seedé + inspection DOM rendu | iso-prod recette |
+| Purge RGPD vérifiée en DB/Redis/logs | requêtes SQL + `redis-cli KEYS` post-`DELETE /users/me` | iso-prod recette |
+| F4 rate-limit : root-cause du storage sous `read_only` | investigation infra | iso-prod recette |
+| N+1 Doctrine profilé au runtime | profiler/logger sur endpoints seedés | iso-prod recette |
+| Analyse de bundle / code-splitting | `next build` (OOM local) | CI / machine dédiée |
+| axe runtime + nav clavier pages authentifiées | stack dev seedée + Playwright | dev seedé |
+| Couverture front Vitest chiffrée | provider absent + OOM + node_modules désync (cf. CI-UNIT) | CI à outiller |
+| Matrice multi-device (viewports × navigateurs × thèmes × langues) | Playwright lourd (OOM local) | CI / machine dédiée |
+| Chaos (kill/pause worker, coupure réseau -> retry/backoff, reconnexion SSE) | orchestration dédiée | machine dédiée |

--- a/docs/recette/audit-report.md
+++ b/docs/recette/audit-report.md
@@ -440,18 +440,17 @@ $ for p in / /login /privacy; do curl -skD - -o /dev/null -H 'Accept: text/html'
 ```
 
 + **Purge user (RGPD) — confirmée empiriquement** : `DELETE /users/me` -> `204`. Sur un compte réel
-  (18 trips / 60 stages / 1 share / 7 refresh_token) :
+  (18 trips / 60 stages / 1 share / 7 refresh_token), cascade FK + révocation des refresh tokens +
+  anonymisation irréversible de l'email confirmées, sans PII résiduelle en base ni Redis (pas de cron) :
 
-```text
-# avant: trips=18 stages=60 shares=1 refresh=7 ; email=recette@example.com
-DELETE /users/me -> 204
-# après: trips=0 stages=0 shares=0 refresh=0
-#        email=deleted-019e8c49-...@deleted.invalid  deleted_at=2026-06-03 13:57:10
-# Redis: 0 occurrence de l'email, 0 clé citant l'uid
-```
+  ```text
+  # avant: trips=18 stages=60 shares=1 refresh=7 ; email=recette@example.com
+  DELETE /users/me -> 204
+  # après: trips=0 stages=0 shares=0 refresh=0 ; deleted_at posé
+  #        email = deleted-019e8c49-...@deleted.invalid
+  # Redis : 0 occurrence de l'email, 0 clé citant l'uid
+  ```
 
-  Cascade FK + révocation des refresh tokens + anonymisation irréversible de l'email confirmées ; pas de PII
-  résiduelle en base ni en Redis. Pas de cron (décision projet).
 + **RGPD-MAGIC (P3) — non-conformité** : la suppression **ne purge pas** la table `magic_link` (7 rows subsistent
   pour le compte supprimé, dont **2 encore valides**). Le user ayant `deleted_at` posé, l'auth doit les rejeter
   (hygiène plutôt qu'exploitation), mais c'est une purge incomplète. **Reco :** supprimer les `magic_link` du user

--- a/docs/recette/audit-report.md
+++ b/docs/recette/audit-report.md
@@ -355,3 +355,23 @@ Un abonné **anonyme** au topic privé `/trips/{id}` ne reçoit **aucune donnée
 Les updates `private: true` ne sont délivrés qu'aux abonnés porteurs d'un JWT subscriber scopé (`subscriber_jwt`,
 Caddyfile) ; le `anonymous` du hub autorise la connexion mais pas la lecture des topics privés. Le finding v1
 « isolation Mercure à confirmer » est donc **levé**.
+
+### Couverture de tests — chiffrée
+
+Mesurée sur la stack **dev** (xdebug présent, clés JWT régénérées via `make jwt-keypair-test`,
+`JWT_PASSPHRASE=test` forcé par `phpunit.dist.xml` -> plus aucune `JWTEncodeFailureException`).
+
++ **API PHPUnit : 1310 tests OK** (3819 assertions, 1 skip). Couverture **statements 71,8 %** (6769/9432),
+  méthodes 58,5 % (561/959) -> **sous le seuil 80 %** (clover `api/coverage/api/clover.xml`) -> finding
+  **`COV-API`** (P2). Le mismatch passphrase/clés du rapport v1 est corrigé : la couverture s'exécute désormais.
++ **Provisioner** : couverture **non mesurable** (le conteneur `provisioner` n'embarque pas de driver xdebug ->
+  `make coverage-ci` échoue sur cette jambe avec *« No code coverage driver available »*). Finding **`COV-PROV`**
+  (P3) : aligner l'image provisioner sur l'API pour la couverture, ou exclure explicitement cette jambe.
++ **Front Vitest : non exécuté en CI** (`ci.yml` ne lance que `npm run test:ts`, jamais `vitest`) -> finding
+  **`CI-UNIT`** (P2) : les tests unitaires front existent mais ne sont vérifiés par aucun pipeline. Localement la
+  mesure est bloquée (conteneur `pwa` plafonné à 512 Mo -> OOM-kill, provider `@vitest/coverage-v8` absent,
+  volume `node_modules` désynchronisé -> `jsdom` `MODULE_NOT_FOUND`). Couverture front **non chiffrable en l'état**.
+
+> Suite QA complète : source de vérité = la CI de #614 (**21/21 checks verts** : PHP-CS-Fixer, Rector, PHPStan L9,
+> ESLint, Prettier, TS, Markdownlint, OpenAPI lint, Hadolint, i18n, PHPUnit api+provisioner, Playwright, BDD recette,
+> APK). Non rejouée localement (OOM `tsc`/`rector` connus, cf. mémoire CI).

--- a/docs/recette/audit-report.md
+++ b/docs/recette/audit-report.md
@@ -317,3 +317,25 @@ $ for p in / /login /privacy; do curl -skD - -o /dev/null -H 'Accept: text/html'
 | Purge DB post-suppression compte | pas de user seedé | iso-prod seedé |
 | axe runtime + nav clavier pages authentifiées | stack dev + Playwright | dev seedé (Sprint 35.3) |
 | Confirmation empirique isolation Mercure | publish + subscribe anonyme | iso-prod seedé |
+
+---
+
+## Recette v2 — résultats d'exécution (stack iso-prod rebâtie + golden path réel)
+
+> Exécution sur `make start-recette` (iso-prod `APP_ENV=prod` + Mailcatcher + Ollama), images rebâties
+> depuis `main` (fix DataTourisme #613 inclus). Golden path réel : compte via `app:create-user` →
+> magic-link Mailcatcher → JWT → trips Komoot (dont « Entre Sensée et Escaut », zone Lille).
+
+### DataTourisme — modes dégradé & live
+
++ **Mode dégradé (clé absente ou `DATATOURISME_ENABLED=false`) : OK.** Avec `ENABLED=true` et clé **vide**
+  (le cas du bug F2), `ScanAccommodations` est « handled successfully », **aucun `TypeError`** : le fix #613
+  (`?string $apiKey` + `isEnabled()` null-safe) dégrade gracieusement (source skippée par les registries).
+  Avant le fix, ce cas crashait en boucle de retry.
++ **Mode live (clé valide + `ENABLED=true`) : CASSÉ — finding `DT-LIVE` (P2, feature OFF par défaut).** La clé
+  est valide (`GET https://api.datatourisme.fr/v1/catalog` → 200), mais deux défauts : **(1)** le scoped client
+  `datatourisme.client` (`api/config/packages/framework.php:81`) a un `scope` (regex SSRF) **sans `base_uri`**
+  (contrairement à komoot/strava/overpass) → `request('/api/v1/places')` (path relatif) échoue *« Invalid URL:
+  scheme is missing »*, tous les appels renvoient un résultat vide ; **(2)** endpoint obsolète `/api/v1/places`
+  → **404** alors que l'API v1 actuelle expose `/v1/catalog` et `/v1/placeOfInterest` (→ 200). **Fix 35.4** :
+  ajouter `base_uri: https://api.datatourisme.fr` au scoped client + migrer endpoints/format vers l'API v1.


### PR DESCRIPTION
## Rapport d'audit Sprint 35.2 — consolidé en un document unique

Exécution de la recette sur la stack iso-prod rebâtie (`make start-recette` : `APP_ENV=prod` + Mailcatcher + Ollama, images depuis `main` avec le fix DataTourisme #613), golden path authentifié réel (compte `app:create-user` -> magic-link -> JWT -> trips Komoot), + stack dev pour la couverture chiffrée.

**Cette PR fusionne** les deux passes interleavées (audit v1 + « Recette v2 ») en **un seul rapport d'état courant** : méthodologie unique, table de findings unique triée par sévérité (colonne *Statut* intégrant les fixes #612/#613), détails par Ordre avec les deltas v2 repliés inline, et une seule liste « Reste à exécuter ». Supprime les sections « Recette v2 » en double et les mentions « différé » devenues contradictoires.

### Findings (état courant)
- **F1 `LOCK_DSN` (P0)** : création de trip 500 en prod par défaut (`compose.yaml` sans `LOCK_DSN`).
- **P1** : IDOR-DETAIL (lecture du trip d'autrui, prouvé empiriquement), SEO-001 (aperçu social cassé, confirmé sur `/s/kETacKMK`), F3 (Ollama prod absent + divergence ADR-028). F2 **corrigé #613** ; F4 **faux finding** (202 anti-énumération par design).
- **P2** : SEC-001..003, SEO-002/003, A11Y-001/002, LH-PERF-HOME (0.65), LH-A11Y-HOME (0.84), LH-PERF-AUTH (0.73/0.52), DT-LIVE (live cassé : scoped client sans `base_uri` + endpoint obsolète), F5 (Overpass flaky), QUAL-001/002, COV-API (71,8 % < 80 %), COV-FRONT (16,85 % < 80 %). QUAL-004 **corrigé #612** ; CI-UNIT **corrigé #615**.
- **P3** : SEC-004/005, PERF-001, I18N-001, QUAL-003, CHAOS-RESTART (à confirmer), RGPD-MAGIC. COV-PROV **corrigé #615**.

### Conformités confirmées empiriquement
Isolation Mercure (abonné anonyme ne reçoit rien), stack-trace prod propre (422/415/404/500 -> `problem+json`), DataTourisme dégradé OK (#613), purge RGPD DB/Redis OK (cascade FK + anonymisation), 0 cookie pages publiques, `composer audit` clean, N+1 aucun (3 requêtes `/detail`, 4 requêtes `/trips`), multi-device 90 checks sans overflow.

### Reste à exécuter (Sprint 35.3+)
Responsive éditeur authed, axe runtime authed, reconnexion SSE Mercure, XSS chat payload runtime — listés en fin de rapport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

**Reviewed commit:** `50bd12998c6738ae3aa81381525d1f86b6c6242f`

**Summary:** Documentation-only PR consolidating two interleaved audit passes into a single current-state report. Content is well-structured and empirically grounded: findings are backed by real test runs (two-account IDOR proof, Lighthouse scores, SQL query logs for N+1, 90-check multi-device matrix, chaos durability tests), statuses accurately reflect fixes merged via #612/#613/#615/#616/#618, and editorial decisions (F3 degraded-mode arbitration, F4 false-finding requalification) are clearly reasoned. Finding counts are arithmetically consistent (1×P1 active, 16×P2, 6×P3 + 1 to confirm). No code changes.

**PR title check:** `Sprint 35.2 — rapport d'audit consolidé (état courant)` — description starts with uppercase and is a noun phrase rather than imperative mood; Conventional Commits requires lowercase imperative (e.g., `consolidate sprint 35.2 audit report into single current-state document`). Recurring non-conformance across this PR series; low impact for a docs-only PR.

### Review checklist

- [x] Code respects the project architecture *(documentation only — N/A)*
- [x] SOLID principles and Law of Demeter followed *(N/A)*
- [x] Design patterns used where appropriate *(N/A)*
- [x] Tests cover new/changed cases *(documentation only — N/A)*
- [x] Documentation is up to date ✓
- [x] Dependent tickets accounted for *(#612/#613/#615/#616/#618 fixes correctly reflected; F1/IDOR-DETAIL/ENUM-404 marked Corrigé; F3 tail tracked via #304; remaining findings deferred to Sprint 35.4 by design)*

No previously open bot review threads.

**Inline comments:** None.

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->