### PR TITLE
fix(recette): close Sprint 35.2 criticals — IDOR, LOCK_DSN, Ollama degraded-mode wiring

### DIFF
--- a/TRACKING.md
+++ b/TRACKING.md
@@ -740,8 +740,9 @@ Transforme le référentiel (35.1) en couverture automatisée + valide les basel
 | 2 | Golden paths A/B/C + cas limites en Gherkin (checklists ci-dessous) | L |
 | 3 | Combler les domaines `.feature` absents (IA, design) | M |
 | 4 | Baselines VR (36 pages + set « états ») + comparaison app vs design (présence + position) | M |
+| 5 | Vérifier liens & ancres (docs, README, ADR, rapport recette) : aucun lien mort (404) ni ancre disparue | S |
 
-DoD : `make test-e2e` + `make test-recette` + `make visual-test` verts ; chaque écran du manifeste 35.1 a un verdict.
+DoD : `make test-e2e` + `make test-recette` + `make visual-test` verts ; chaque écran du manifeste 35.1 a un verdict ; aucun lien/ancre cassé (ordre 5).
 
 ---
 

--- a/api/src/ApiResource/TripDetail.php
+++ b/api/src/ApiResource/TripDetail.php
@@ -23,6 +23,9 @@ use App\State\TripDetailProvider;
         new Get(
             uriTemplate: '/trips/{id}/detail',
             openapi: new Operation(summary: 'Load trip configuration and persisted stages for frontend hydration.'),
+            // Object-level authz (finding IDOR-DETAIL): without this, any authenticated
+            // user could read another user's trip by UUID. Mirrors GET /trips/{id}/chat-history.
+            security: "is_granted('TRIP_VIEW', request.attributes.get('id'))",
             provider: TripDetailProvider::class,
         ),
     ],

--- a/api/src/Controller/HealthController.php
+++ b/api/src/Controller/HealthController.php
@@ -84,6 +84,10 @@ final readonly class HealthController
             $deps[$name] = $this->finishHttpCheck($pair);
         }
 
+        // Ollama is intentionally NOT required: the app runs in a degraded mode when
+        // the LLM tier is down (AI features disabled, not a 5xx) — see ADR-028
+        // "Degraded Mode" update. ollama_chat/ollama_analysis are still surfaced in
+        // `deps` (and logged) so operators can see/alert on the outage.
         $required = ['postgres', 'redis', 'mercure', 'valhalla'];
         $status = 'ok';
         foreach ($required as $dep) {

--- a/api/tests/Functional/TripDetailTest.php
+++ b/api/tests/Functional/TripDetailTest.php
@@ -87,13 +87,32 @@ final class TripDetailTest extends ApiTestCase
     }
 
     #[Test]
-    public function detailNonExistentTripReturns404(): void
+    public function detailNonExistentTripReturns403(): void
     {
+        // The TRIP_VIEW voter runs before the provider (security expression on the
+        // id), so an unknown trip is denied (403) without revealing existence —
+        // same contract as GET /trips/{id}/chat-history.
         $this->client->request('GET', '/trips/00000000-0000-0000-0000-000000000000/detail', [
             'headers' => $this->authHeader($this->jwtToken),
         ]);
 
-        $this->assertResponseStatusCodeSame(404);
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    #[Test]
+    public function detailOfAnotherUsersTripReturns403(): void
+    {
+        // IDOR-DETAIL regression: a trip owned by someone else must not be readable.
+        $repo = $this->seedTrip(self::TRIP_ID);
+        $repo->storeStages(self::TRIP_ID, []);
+
+        ['token' => $otherToken] = $this->createTestUserWithJwt('intruder@example.com');
+
+        $this->client->request('GET', \sprintf('/trips/%s/detail', self::TRIP_ID), [
+            'headers' => array_merge(['Accept' => 'application/ld+json'], $this->authHeader($otherToken)),
+        ]);
+
+        $this->assertResponseStatusCodeSame(403);
     }
 
     #[Test]

--- a/compose.ollama.yaml
+++ b/compose.ollama.yaml
@@ -14,6 +14,12 @@ services:
     # Pinned by digest (matches compose.dev.yaml / compose.recette.yaml).
     image: ollama/ollama@sha256:a6149234667efc71d37766d61c1a16f24c33e4cd7a0bf4125c44a7e47e2419c4
     restart: unless-stopped
+    # `default` keeps ollama reachable inside a single merged compose project
+    # (dev/recette/CI). `bike-trip-planner-llm` is the shared network the app
+    # stack joins in a separate-stack prod deployment (see ADR-028 + networks below).
+    networks:
+      - default
+      - bike-trip-planner-llm
     expose:
       - 11434
     # Beta profile sizing (#566 / ADR-019): one resident model, two parallel slots,
@@ -53,6 +59,17 @@ services:
       - /bin/sh
       - -c
       - 'for m in $$OLLAMA_PULL_MODELS; do echo "pulling $$m"; ollama pull "$$m"; done'
+
+networks:
+  # This (Ollama) stack OWNS the shared LLM network; the application stack joins
+  # it as `external` in a separate-stack production deployment, so php/worker/
+  # worker-llm can reach `http://ollama:11434` (consumer joins provider — see
+  # ADR-028 "Deployment topology"). `attachable` lets a separately-deployed app
+  # project attach to it. In dev/recette/CI the two compose files load as one
+  # project, so this network is simply created by that project.
+  bike-trip-planner-llm:
+    name: bike-trip-planner-llm
+    attachable: true
 
 volumes:
   ollama-data: ~

--- a/compose.ollama.yaml
+++ b/compose.ollama.yaml
@@ -18,8 +18,12 @@ services:
     # (dev/recette/CI). `bike-trip-planner-llm` is the shared network the app
     # stack joins in a separate-stack prod deployment (see ADR-028 + networks below).
     networks:
-      - default
-      - bike-trip-planner-llm
+      default: {}
+      # Explicit alias so the app stack always resolves `ollama` on this shared
+      # network, independent of the Ollama stack's project/service name.
+      bike-trip-planner-llm:
+        aliases:
+          - ollama
     expose:
       - 11434
     # Beta profile sizing (#566 / ADR-019): one resident model, two parallel slots,

--- a/compose.ollama.yaml
+++ b/compose.ollama.yaml
@@ -65,12 +65,12 @@ services:
       - 'for m in $$OLLAMA_PULL_MODELS; do echo "pulling $$m"; ollama pull "$$m"; done'
 
 networks:
-  # This (Ollama) stack OWNS the shared LLM network; the application stack joins
-  # it as `external` in a separate-stack production deployment, so php/worker/
-  # worker-llm can reach `http://ollama:11434` (consumer joins provider — see
-  # ADR-028 "Deployment topology"). `attachable` lets a separately-deployed app
-  # project attach to it. In dev/recette/CI the two compose files load as one
-  # project, so this network is simply created by that project.
+  # Shared LLM network. This (Ollama) stack attaches `ollama` to it and owns the
+  # `ollama` alias; `attachable: true` lets a separately-deployed app project join
+  # it by name. The application stack (compose.yaml) declares the same fixed name
+  # as non-external too: each context creates the network if absent (CI, standalone
+  # `make start-prod`, single merged dev/recette project) or reuses the existing one
+  # in a two-stack prod deployment. See ADR-028 "Deployment topology".
   bike-trip-planner-llm:
     name: bike-trip-planner-llm
     attachable: true

--- a/compose.recette.yaml
+++ b/compose.recette.yaml
@@ -15,10 +15,6 @@
 # duplicating the block across the three services (review #612).
 x-recette-env: &recette-env
   MAILER_DSN: smtp://mailcatcher:1025
-  # Workaround for a recette finding: compose.yaml (prod) omits LOCK_DSN, so it
-  # falls back to api/.env's redis://localhost:6379 (unreachable from the container,
-  # redis is the `redis` service) -> trip creation 500s. Fix belongs in compose.yaml (35.4).
-  LOCK_DSN: redis://redis:6379
   OLLAMA_BASE_URL: "${OLLAMA_BASE_URL:-http://ollama:11434}"
   # Flat defaults (no nested interpolation): robust across Compose versions and
   # unambiguous. Recette never overrides OLLAMA_BASE_URL alone, so no fallback is lost.

--- a/compose.yaml
+++ b/compose.yaml
@@ -36,6 +36,9 @@ services:
         condition: service_healthy
       redis:
         condition: service_started
+    networks:
+      - default
+      - bike-trip-planner-llm
     environment:
       APP_ENV: prod
       CADDY_GLOBAL_OPTIONS: ${CADDY_GLOBAL_OPTIONS:-}
@@ -125,6 +128,9 @@ services:
       dockerfile: .docker/php/Dockerfile
       target: frankenphp_prod
     command: bin/console messenger:consume async --time-limit=3600 -vv
+    networks:
+      - default
+      - bike-trip-planner-llm
     restart: unless-stopped
     read_only: true
     tmpfs:
@@ -210,6 +216,9 @@ services:
       dockerfile: .docker/php/Dockerfile
       target: frankenphp_prod
     command: bin/console messenger:consume llm --time-limit=3600 -vv
+    networks:
+      - default
+      - bike-trip-planner-llm
     restart: unless-stopped
     read_only: true
     tmpfs:
@@ -453,3 +462,13 @@ volumes:
   php_var: ~
   database_data: ~
   valhalla-tiles: ~
+
+networks:
+  # Shared with the separate Ollama stack (compose.ollama.yaml) so php/worker/
+  # worker-llm reach http://ollama:11434. Declared by a fixed `name` (non-external):
+  # in a single merged project (dev/recette/CI) it is created once; a standalone app
+  # project creates it too. The Ollama stack declares the same name and owns the
+  # `ollama` network alias. For fully separate Coolify projects the network is shared
+  # by name; see ADR-028 "Deployment topology".
+  bike-trip-planner-llm:
+    name: bike-trip-planner-llm

--- a/compose.yaml
+++ b/compose.yaml
@@ -56,6 +56,10 @@ services:
       MESSENGER_TRANSPORT_DSN: redis://redis:6379/messages
       MESSENGER_FAILED_DSN: redis://redis:6379/failed
       REDIS_URL: redis://redis:6379
+      # Symfony Lock store. Without this, framework.lock falls back to api/.env's
+      # redis://localhost:6379 (unreachable from the container) -> trip creation
+      # 500s in prod (finding F1). Redis is the `redis` service. See ADR-022.
+      LOCK_DSN: redis://redis:6379
       DATABASE_URL: "postgresql://${DATABASE_USERNAME:-app}:${DATABASE_PASSWORD:-!ChangeMe!}@database:5432/${DATABASE_NAME:-bike_trip_planner}?serverVersion=18&charset=utf8"
       JWT_SECRET_KEY: /run/secrets/jwt_private_key
       JWT_PUBLIC_KEY: /run/secrets/jwt_public_key
@@ -142,6 +146,10 @@ services:
       MESSENGER_TRANSPORT_DSN: redis://redis:6379/messages
       MESSENGER_FAILED_DSN: redis://redis:6379/failed
       REDIS_URL: redis://redis:6379
+      # Symfony Lock store. Without this, framework.lock falls back to api/.env's
+      # redis://localhost:6379 (unreachable from the container) -> trip creation
+      # 500s in prod (finding F1). Redis is the `redis` service. See ADR-022.
+      LOCK_DSN: redis://redis:6379
       DATABASE_URL: "postgresql://${DATABASE_USERNAME:-app}:${DATABASE_PASSWORD:-!ChangeMe!}@database:5432/${DATABASE_NAME:-bike_trip_planner}?serverVersion=18&charset=utf8"
       JWT_SECRET_KEY: /run/secrets/jwt_private_key
       JWT_PUBLIC_KEY: /run/secrets/jwt_public_key
@@ -214,6 +222,10 @@ services:
       MESSENGER_TRANSPORT_DSN: redis://redis:6379/messages
       MESSENGER_FAILED_DSN: redis://redis:6379/failed
       REDIS_URL: redis://redis:6379
+      # Symfony Lock store. Without this, framework.lock falls back to api/.env's
+      # redis://localhost:6379 (unreachable from the container) -> trip creation
+      # 500s in prod (finding F1). Redis is the `redis` service. See ADR-022.
+      LOCK_DSN: redis://redis:6379
       DATABASE_URL: "postgresql://${DATABASE_USERNAME:-app}:${DATABASE_PASSWORD:-!ChangeMe!}@database:5432/${DATABASE_NAME:-bike_trip_planner}?serverVersion=18&charset=utf8"
       JWT_SECRET_KEY: /run/secrets/jwt_private_key
       JWT_PUBLIC_KEY: /run/secrets/jwt_public_key

--- a/compose.yaml
+++ b/compose.yaml
@@ -472,3 +472,7 @@ networks:
   # by name; see ADR-028 "Deployment topology".
   bike-trip-planner-llm:
     name: bike-trip-planner-llm
+    # Must match compose.ollama.yaml exactly: whichever stack comes up first
+    # creates the network, so identical attributes avoid a "network exists with
+    # different configuration" mismatch when the other stack joins it by name.
+    attachable: true

--- a/compose.yaml
+++ b/compose.yaml
@@ -61,6 +61,14 @@ services:
       # 500s in prod (finding F1). Redis is the `redis` service. See ADR-022.
       LOCK_DSN: redis://redis:6379
       DATABASE_URL: "postgresql://${DATABASE_USERNAME:-app}:${DATABASE_PASSWORD:-!ChangeMe!}@database:5432/${DATABASE_NAME:-bike_trip_planner}?serverVersion=18&charset=utf8"
+      # Ollama is a hard runtime dependency in prod (ADR-028, finding F3): the LLM
+      # tier is a SEPARATE resource (compose.ollama.yaml) reached over the shared
+      # `bike-trip-planner-llm` network. Enabled by default here; compose.dev.yaml
+      # forces 0, compose.recette.yaml forces 1.
+      OLLAMA_BASE_URL: "${OLLAMA_BASE_URL:-http://ollama:11434}"
+      OLLAMA_ANALYSIS_URL: "${OLLAMA_ANALYSIS_URL:-${OLLAMA_BASE_URL:-http://ollama:11434}}"
+      OLLAMA_CHAT_URL: "${OLLAMA_CHAT_URL:-${OLLAMA_BASE_URL:-http://ollama:11434}}"
+      OLLAMA_ENABLED: "${OLLAMA_ENABLED:-1}"
       JWT_SECRET_KEY: /run/secrets/jwt_private_key
       JWT_PUBLIC_KEY: /run/secrets/jwt_public_key
       JWT_PASSPHRASE: "${JWT_PASSPHRASE}"
@@ -151,6 +159,14 @@ services:
       # 500s in prod (finding F1). Redis is the `redis` service. See ADR-022.
       LOCK_DSN: redis://redis:6379
       DATABASE_URL: "postgresql://${DATABASE_USERNAME:-app}:${DATABASE_PASSWORD:-!ChangeMe!}@database:5432/${DATABASE_NAME:-bike_trip_planner}?serverVersion=18&charset=utf8"
+      # Ollama is a hard runtime dependency in prod (ADR-028, finding F3): the LLM
+      # tier is a SEPARATE resource (compose.ollama.yaml) reached over the shared
+      # `bike-trip-planner-llm` network. Enabled by default here; compose.dev.yaml
+      # forces 0, compose.recette.yaml forces 1.
+      OLLAMA_BASE_URL: "${OLLAMA_BASE_URL:-http://ollama:11434}"
+      OLLAMA_ANALYSIS_URL: "${OLLAMA_ANALYSIS_URL:-${OLLAMA_BASE_URL:-http://ollama:11434}}"
+      OLLAMA_CHAT_URL: "${OLLAMA_CHAT_URL:-${OLLAMA_BASE_URL:-http://ollama:11434}}"
+      OLLAMA_ENABLED: "${OLLAMA_ENABLED:-1}"
       JWT_SECRET_KEY: /run/secrets/jwt_private_key
       JWT_PUBLIC_KEY: /run/secrets/jwt_public_key
       JWT_PASSPHRASE: "${JWT_PASSPHRASE}"
@@ -227,6 +243,14 @@ services:
       # 500s in prod (finding F1). Redis is the `redis` service. See ADR-022.
       LOCK_DSN: redis://redis:6379
       DATABASE_URL: "postgresql://${DATABASE_USERNAME:-app}:${DATABASE_PASSWORD:-!ChangeMe!}@database:5432/${DATABASE_NAME:-bike_trip_planner}?serverVersion=18&charset=utf8"
+      # Ollama is a hard runtime dependency in prod (ADR-028, finding F3): the LLM
+      # tier is a SEPARATE resource (compose.ollama.yaml) reached over the shared
+      # `bike-trip-planner-llm` network. Enabled by default here; compose.dev.yaml
+      # forces 0, compose.recette.yaml forces 1.
+      OLLAMA_BASE_URL: "${OLLAMA_BASE_URL:-http://ollama:11434}"
+      OLLAMA_ANALYSIS_URL: "${OLLAMA_ANALYSIS_URL:-${OLLAMA_BASE_URL:-http://ollama:11434}}"
+      OLLAMA_CHAT_URL: "${OLLAMA_CHAT_URL:-${OLLAMA_BASE_URL:-http://ollama:11434}}"
+      OLLAMA_ENABLED: "${OLLAMA_ENABLED:-1}"
       JWT_SECRET_KEY: /run/secrets/jwt_private_key
       JWT_PUBLIC_KEY: /run/secrets/jwt_public_key
       JWT_PASSPHRASE: "${JWT_PASSPHRASE}"

--- a/compose.yaml
+++ b/compose.yaml
@@ -61,10 +61,12 @@ services:
       # 500s in prod (finding F1). Redis is the `redis` service. See ADR-022.
       LOCK_DSN: redis://redis:6379
       DATABASE_URL: "postgresql://${DATABASE_USERNAME:-app}:${DATABASE_PASSWORD:-!ChangeMe!}@database:5432/${DATABASE_NAME:-bike_trip_planner}?serverVersion=18&charset=utf8"
-      # Ollama is a hard runtime dependency in prod (ADR-028, finding F3): the LLM
-      # tier is a SEPARATE resource (compose.ollama.yaml) reached over the shared
-      # `bike-trip-planner-llm` network. Enabled by default here; compose.dev.yaml
-      # forces 0, compose.recette.yaml forces 1.
+      # Ollama (LLM tier) runs as a SEPARATE resource (compose.ollama.yaml, ADR-028).
+      # These vars tell the app where to reach it. dev/recette load both files as one
+      # compose project, so `ollama` resolves directly. A separate-stack prod joins
+      # Ollama's `bike-trip-planner-llm` network (ADR-028 topology, via a deploy
+      # overlay) or sets OLLAMA_BASE_URL to a routable address; unreachable -> degraded
+      # mode (#304), not a 5xx. OLLAMA_ENABLED: dev forces 0, recette/prod 1.
       OLLAMA_BASE_URL: "${OLLAMA_BASE_URL:-http://ollama:11434}"
       OLLAMA_ANALYSIS_URL: "${OLLAMA_ANALYSIS_URL:-${OLLAMA_BASE_URL:-http://ollama:11434}}"
       OLLAMA_CHAT_URL: "${OLLAMA_CHAT_URL:-${OLLAMA_BASE_URL:-http://ollama:11434}}"
@@ -159,10 +161,12 @@ services:
       # 500s in prod (finding F1). Redis is the `redis` service. See ADR-022.
       LOCK_DSN: redis://redis:6379
       DATABASE_URL: "postgresql://${DATABASE_USERNAME:-app}:${DATABASE_PASSWORD:-!ChangeMe!}@database:5432/${DATABASE_NAME:-bike_trip_planner}?serverVersion=18&charset=utf8"
-      # Ollama is a hard runtime dependency in prod (ADR-028, finding F3): the LLM
-      # tier is a SEPARATE resource (compose.ollama.yaml) reached over the shared
-      # `bike-trip-planner-llm` network. Enabled by default here; compose.dev.yaml
-      # forces 0, compose.recette.yaml forces 1.
+      # Ollama (LLM tier) runs as a SEPARATE resource (compose.ollama.yaml, ADR-028).
+      # These vars tell the app where to reach it. dev/recette load both files as one
+      # compose project, so `ollama` resolves directly. A separate-stack prod joins
+      # Ollama's `bike-trip-planner-llm` network (ADR-028 topology, via a deploy
+      # overlay) or sets OLLAMA_BASE_URL to a routable address; unreachable -> degraded
+      # mode (#304), not a 5xx. OLLAMA_ENABLED: dev forces 0, recette/prod 1.
       OLLAMA_BASE_URL: "${OLLAMA_BASE_URL:-http://ollama:11434}"
       OLLAMA_ANALYSIS_URL: "${OLLAMA_ANALYSIS_URL:-${OLLAMA_BASE_URL:-http://ollama:11434}}"
       OLLAMA_CHAT_URL: "${OLLAMA_CHAT_URL:-${OLLAMA_BASE_URL:-http://ollama:11434}}"
@@ -243,10 +247,12 @@ services:
       # 500s in prod (finding F1). Redis is the `redis` service. See ADR-022.
       LOCK_DSN: redis://redis:6379
       DATABASE_URL: "postgresql://${DATABASE_USERNAME:-app}:${DATABASE_PASSWORD:-!ChangeMe!}@database:5432/${DATABASE_NAME:-bike_trip_planner}?serverVersion=18&charset=utf8"
-      # Ollama is a hard runtime dependency in prod (ADR-028, finding F3): the LLM
-      # tier is a SEPARATE resource (compose.ollama.yaml) reached over the shared
-      # `bike-trip-planner-llm` network. Enabled by default here; compose.dev.yaml
-      # forces 0, compose.recette.yaml forces 1.
+      # Ollama (LLM tier) runs as a SEPARATE resource (compose.ollama.yaml, ADR-028).
+      # These vars tell the app where to reach it. dev/recette load both files as one
+      # compose project, so `ollama` resolves directly. A separate-stack prod joins
+      # Ollama's `bike-trip-planner-llm` network (ADR-028 topology, via a deploy
+      # overlay) or sets OLLAMA_BASE_URL to a routable address; unreachable -> degraded
+      # mode (#304), not a 5xx. OLLAMA_ENABLED: dev forces 0, recette/prod 1.
       OLLAMA_BASE_URL: "${OLLAMA_BASE_URL:-http://ollama:11434}"
       OLLAMA_ANALYSIS_URL: "${OLLAMA_ANALYSIS_URL:-${OLLAMA_BASE_URL:-http://ollama:11434}}"
       OLLAMA_CHAT_URL: "${OLLAMA_CHAT_URL:-${OLLAMA_BASE_URL:-http://ollama:11434}}"

--- a/docs/adr/adr-027-gate-mechanism-two-phase-pipeline.md
+++ b/docs/adr/adr-027-gate-mechanism-two-phase-pipeline.md
@@ -159,6 +159,12 @@ This is the only concurrency primitive outside the PSR-6 cache path, and it is c
 
 ### Ollama as a Hard Dependency
 
+> **Superseded (Sprint 35.4).** This "hard dependency" stance was reversed — see
+> [ADR-028 → "Decision Update — Degraded Mode Re-instated"](adr-028-ollama-llama-integration.md). The app now stays
+> up when Ollama is unavailable: Phase 2 AI passes are skipped (with `critical` logs) instead of failing the trip,
+> and the PWA disables the AI features. #304 is re-opened to carry that work. The paragraph below is kept for
+> historical context.
+
 LLaMA inference (`RunLlamaInferenceHandler`) is a **non-skippable step** of Phase 2. There is no fallback path: if Ollama is unavailable or returns an error, Phase 2 fails and `trip_ready` is not emitted (instead `trip_error` is published via Mercure). Ollama must be running and healthy for the analysis pipeline to complete.
 
 This decision was solidified as part of issue [#375](https://github.com/vincentchalamon/bike-trip-planner/issues/375) (design v2 arbitrage: "IA toujours active"). Issues #304 (graceful fallback), #307 (stale AI banner), and #308 (frontend LLaMA fallback) were closed accordingly. Deployment configurations (see ADR-019) must include Ollama with a healthcheck gate before the application is considered operational.

--- a/docs/adr/adr-028-ollama-llama-integration.md
+++ b/docs/adr/adr-028-ollama-llama-integration.md
@@ -1,4 +1,4 @@
-# ADR-028: Ollama/LLaMA Integration Architecture (2-Pass Pipeline, Context Window, Hard Dependency)
+# ADR-028: Ollama/LLaMA Integration Architecture (2-Pass Pipeline, Context Window, Graceful Degradation)
 
 - **Status:** Accepted
 - **Date:** 2026-05-06
@@ -110,6 +110,37 @@ Every prompt invokes Ollama with `format: "json"` and a JSON Schema embedded in 
 - Models are pulled at deploy time via a one-shot init job; the container's volume persists the model blobs across restarts.
 - The PHP `OllamaClient` is a scoped HTTP client (per ADR-001 SSRF policy) bound to the Ollama base URI, with a 60 s timeout for the analysis pass and a 10 s timeout for the dialogue pass.
 
+### Deployment topology — separate resource + shared network (refined Sprint 35.4)
+
+The original "Ollama runs on the project's Docker network" wording is superseded. Following #566/#612 and
+audit finding F3, in production Ollama is deployed as a **separate resource** (`compose.ollama.yaml`), not part
+of the main application stack (`compose.yaml`). Rationale: resource sizing (~2-6 GB resident, GPU-optional,
+model blobs on a persistent volume — radically different from the 512 MB app workers) and an independent
+lifecycle (slow model pulls via the one-shot `ollama-init`; restarts/upgrades decoupled from the stateless app).
+This separation is for **deployment decoupling**; at runtime the LLM tier is **optional** — see the "Degraded Mode"
+update below, which supersedes the earlier hard-dependency stance.
+
+- **Network — the consumer joins the provider.** The Ollama stack **owns** a dedicated, stably-named Docker
+  network (`bike-trip-planner-llm`) and attaches `ollama` to it. The application stack **joins** that network as
+  `external` (consumer reaching into the provider's network, matching the dependency direction Project -> Ollama).
+  Only the services that call Ollama (`php`, `worker`, `worker-llm`) attach; `database`, `redis`, `mercure`,
+  `valhalla` stay on the app's internal network (least connectivity — the third-party inference container has no
+  route to the datastore). Preferred over a third pre-created shared network: clear ownership, no out-of-band
+  `docker network create`.
+- **dev / recette.** `compose.yaml` + `compose.ollama.yaml` load as a **single** Compose project, so the network
+  is created by that project (non-external) and `http://ollama:11434` resolves directly; only the production app
+  stack declares the network `external: true`. `OLLAMA_ENABLED` defaults to `1` in `compose.yaml` (AI on whenever
+  the tier is reachable), is overridden to `0` in `compose.dev.yaml`, and `1` in `compose.recette.yaml`.
+- **Ordering.** Bring the Ollama stack up first so its network exists before the app stack joins (an `external`
+  network must pre-exist). The network persists across `ollama` service restarts; only `docker compose down` on the
+  Ollama stack removes it, so tear the app stack down first. There is **no service-health startup ordering**: an app
+  worker boots even if Ollama is not yet reachable, and in-flight LLM messages retry on the durable Redis transport
+  until it is.
+- **Health.** Ollama is deliberately **excluded from the readiness `$required` set** (`GET /api/health` stays `ok`
+  when the LLM tier is down) and from liveness — an Ollama outage must neither return traffic-blocking 503s nor
+  restart-loop the app. Its status is still **surfaced in `deps.ollama_chat`/`deps.ollama_analysis`** and logged
+  `critical` so operators can alert. This realises the degraded-mode contract below.
+
 ---
 
 ## Decision Update — Hard Dependency (Sprint 29)
@@ -131,6 +162,36 @@ This update supersedes the "graceful fallback" wording from the original draft. 
 
 ---
 
+## Decision Update — Degraded Mode Re-instated (Sprint 35.4)
+
+The Sprint-29 "hard dependency" stance above is **reversed**: the application must remain usable when the LLM tier
+is unavailable. This re-arbitration came out of the Sprint 35.2 audit (finding F3): the operational reality of issue
+[#566](https://github.com/vincentchalamon/bike-trip-planner/issues/566) (Ollama deployed as a separate,
+resource-heavy resource that can legitimately be down or unprovisioned) collided with the "health 503 if Ollama
+down" rule, which would take the whole app offline for an AI outage.
+
+The original objection to a fallback was that it was **silent** (non-deterministic output depending on Ollama
+uptime). That objection is **resolved by making degradation explicit**, not by forbidding it:
+
+- **API — graceful degradation, not 5xx.** When Ollama is configured (`OLLAMA_ENABLED=1`) but unreachable, the
+  AI passes (stage analysis, overview, chat) are **skipped** rather than retried-to-failure, and the event is
+  logged at **`critical`** for alerting. The app does not return a traffic-blocking 503 for an AI outage; Ollama
+  stays **out of the readiness `$required` set** (see Deployment topology → Health).
+- **Front — explicit feature-gating.** The PWA reads AI availability (capabilities signal / health `deps.ollama`)
+  and **disables the AI-driven features** when the tier is down: AI trip generation, the in-editor AI chat, and
+  AI trip analysis. The user sees *why* they are unavailable rather than silently receiving a degraded report —
+  this is the determinism guarantee the Sprint-29 update was protecting, kept intact.
+- **Three supported states.** `OLLAMA_ENABLED=0` (AI off by config — features hidden), `OLLAMA_ENABLED=1` +
+  reachable (full AI), and `OLLAMA_ENABLED=1` + unreachable (degraded — features disabled, `critical` logs).
+- **Issues.** #304 (graceful fallback without Ollama) is **re-opened** to carry the front gating + API
+  degradation + critical-logging work. #307 (rule-based-only toggle) and #308 (form-based brief fallback) remain
+  separate and are not implied by this update.
+
+This update supersedes "Decision Update — Hard Dependency (Sprint 29)" for the availability/health contract. The
+two-pass pipeline, JSON-mode contract, and model roles above are unchanged.
+
+---
+
 ## Consequences
 
 ### Positive
@@ -138,13 +199,13 @@ This update supersedes the "graceful fallback" wording from the original draft. 
 - **Privacy preserved end-to-end.** No user payload leaves the operator's perimeter. Trip briefs, even those containing personal information, are processed locally.
 - **Zero per-inference cost.** Adding an extra stage or running a regression suite has no marginal cost beyond local compute time.
 - **Reviewable prompts.** All prompt logic lives in versioned text files. Behaviour changes are visible in `git diff`, reviewable in PRs, and testable against fixtures.
-- **Deterministic production output.** Because Ollama is a hard dependency, every deployed instance produces output of the same shape; no silent feature degradation.
+- **Deterministic, non-silent degradation.** When Ollama is up, every instance produces the same shape of output. When it is down, the AI features are *explicitly* disabled (front gating + `critical` logs) rather than silently dropped, so a user never unknowingly receives a degraded report — the determinism guarantee is kept without forcing a hard dependency (see "Decision Update — Degraded Mode").
 - **Latency contained to Phase 2.** Per ADR-027, the analysis pass runs after the preview is already on screen, so the 8B model's per-stage cost (~10–30 s) does not impact the time-to-first-render.
 - **Composable with the rule-based engine.** The rule-based alerts (ADR-012) remain the deterministic source of truth; the LLM only ranks, narrates, and contextualises them. A regression in LLM output does not silently invent alerts.
 
 ### Negative
 
-- **Hard runtime dependency on Ollama.** Operators must run Ollama on the same network as the workers. The backend health check refuses to mark the deployment ready otherwise. This is an explicit trade-off (see "Decision update").
+- **Optional LLM tier with an explicit degradation surface.** Ollama runs as a separate resource on a shared network (see "Deployment topology"). When it is unavailable the app stays up in **degraded mode** — AI features disabled in the PWA, AI passes skipped in the API with `critical` logs; readiness is unaffected. The trade-off is the added gating/degradation surface across front + API, tracked in #304 (see "Decision Update — Degraded Mode").
 - **Memory footprint.** The 8B model in Q4 quantisation occupies ~5 GB resident; the 3B model adds ~2 GB. Operators below 8 GB RAM must use smaller variants and accept reduced quality.
 - **Cold-start latency.** First inference after container boot incurs a model-load delay (5–15 s depending on disk speed). Mitigated by a warm-up call in the worker bootstrap.
 - **Prompt drift on model upgrades.** Upgrading the base model (e.g. LLaMA 3.x → 3.y) may shift output format adherence. Each model upgrade must run the regression fixture suite before promotion.

--- a/docs/adr/adr-028-ollama-llama-integration.md
+++ b/docs/adr/adr-028-ollama-llama-integration.md
@@ -120,22 +120,24 @@ lifecycle (slow model pulls via the one-shot `ollama-init`; restarts/upgrades de
 This separation is for **deployment decoupling**; at runtime the LLM tier is **optional** — see the "Degraded Mode"
 update below, which supersedes the earlier hard-dependency stance.
 
-- **Network — the consumer joins the provider.** The Ollama stack **owns** a dedicated, stably-named Docker
-  network (`bike-trip-planner-llm`) and attaches `ollama` to it. The application stack **joins** that network as
-  `external` (consumer reaching into the provider's network, matching the dependency direction Project -> Ollama).
-  Only the services that call Ollama (`php`, `worker`, `worker-llm`) attach; `database`, `redis`, `mercure`,
-  `valhalla` stay on the app's internal network (least connectivity — the third-party inference container has no
-  route to the datastore). Preferred over a third pre-created shared network: clear ownership, no out-of-band
-  `docker network create`.
-- **dev / recette.** `compose.yaml` + `compose.ollama.yaml` load as a **single** Compose project, so the network
-  is created by that project (non-external) and `http://ollama:11434` resolves directly; only the production app
-  stack declares the network `external: true`. `OLLAMA_ENABLED` defaults to `1` in `compose.yaml` (AI on whenever
-  the tier is reachable), is overridden to `0` in `compose.dev.yaml`, and `1` in `compose.recette.yaml`.
-- **Ordering.** Bring the Ollama stack up first so its network exists before the app stack joins (an `external`
-  network must pre-exist). The network persists across `ollama` service restarts; only `docker compose down` on the
-  Ollama stack removes it, so tear the app stack down first. There is **no service-health startup ordering**: an app
-  worker boots even if Ollama is not yet reachable, and in-flight LLM messages retry on the durable Redis transport
-  until it is.
+- **Network — a shared, name-pinned bridge.** Both stacks declare `bike-trip-planner-llm` by a fixed `name`
+  (non-`external`). `compose.ollama.yaml` attaches `ollama` to it and **owns the `ollama` network alias**, so the
+  app resolves `http://ollama:11434` regardless of the Ollama stack's project/service name. `compose.yaml` attaches
+  only the services that call Ollama (`php`, `worker`, `worker-llm`); `database`, `redis`, `mercure`, `valhalla`
+  stay on the app's default network (least connectivity — the third-party inference container has no route to the
+  datastore). Non-`external` (rather than `external` + a pre-created network) is chosen deliberately: CI boots a
+  subset (`docker compose up -d database php pwa worker redis`, no Ollama) and `make start-prod` runs `compose.yaml`
+  alone — an `external` network would force a `docker network create` in CI, every Makefile target, and Coolify
+  ops. With a name-pinned non-`external` network each context simply creates it if absent.
+- **Resolution per context.** Single merged project (dev/recette/CI): one network, created by the project, every
+  service resolves `ollama`. Standalone app project (`make start-prod`, no Ollama): the app creates the network and
+  runs degraded (no `ollama` to resolve). Two separate Coolify projects (app + Ollama): the network is **shared by
+  name** — the first stack up creates it, the second attaches by name. `OLLAMA_ENABLED` defaults to `1` in
+  `compose.yaml` (AI on whenever the tier is reachable), `0` in `compose.dev.yaml`, `1` in `compose.recette.yaml`.
+- **Ordering.** No service-health startup ordering: an app worker boots even if Ollama is not yet reachable, and
+  in-flight LLM messages retry on the durable Redis transport until it is. In the two-project Coolify case, if a
+  Compose version flags a project-label conflict on the shared name-pinned network, switch both stacks to
+  `external: true` + a one-time `docker network create bike-trip-planner-llm` (validate when the prod target exists).
 - **Health.** Ollama is deliberately **excluded from the readiness `$required` set** (`GET /api/health` stays `ok`
   when the LLM tier is down) and from liveness — an Ollama outage must neither return traffic-blocking 503s nor
   restart-loop the app. Its status is still **surfaced in `deps.ollama_chat`/`deps.ollama_analysis`** and logged

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -11,6 +11,32 @@ Bike Trip Planner is deployed on Oracle Cloud Always Free (ARM A1) via Coolify (
 
 Migrations are executed at container boot (see [ADR-032](adr/adr-032-migrations-and-rollback-strategy.md)). Coolify keeps the N most recent images, enabling 1-click rollback to any previous SHA; the `build-images` job also prunes GHCR to the 10 most recent versions per image.
 
+## LLM tier (Ollama) and the shared network
+
+The Ollama inference tier is **not** part of the application stack (`compose.yaml`). It lives in `compose.ollama.yaml` and is deployed as a **separate Coolify resource** (ADR-028 + #566): it has very different resource needs (a resident model is ~2-6 GB RAM, GPU-optional, model blobs on a persistent volume) and an independent lifecycle (slow model pulls, restarts decoupled from the stateless app).
+
+The two stacks talk over a shared Docker network, `bike-trip-planner-llm`:
+
+- Declared by a fixed `name` (non-`external`) in **both** `compose.yaml` and `compose.ollama.yaml`. The first stack to come up creates it; the other attaches by name.
+- `compose.ollama.yaml` attaches `ollama` to it and owns the network alias `ollama`, so the app reaches `http://ollama:11434` regardless of the Ollama project/service name.
+- Only the LLM-calling services join it (`php`, `worker`, `worker-llm`). `database`, `redis`, `mercure` and `valhalla` stay on the app's default network (least connectivity: the third-party inference container has no route to the datastore).
+- Models are pulled once at deploy time by the `ollama-init` one-shot (`docker compose -f compose.ollama.yaml --profile ollama-init up`), persisted in the `ollama-data` volume.
+
+### Startup ordering
+
+**Order-independent.** Because the network is name-pinned and non-`external`, neither stack has to start first: the first `up` creates the network, the second attaches to it by name. Functionally too, the app boots even if Ollama is not yet up; it runs in **degraded mode** (AI features hidden in the PWA, AI passes skipped in the API with `critical` logs, `/api/health` stays `ok`) and in-flight LLM messages retry on the durable Redis transport until Ollama answers (see ADR-028 "Degraded Mode" and [runbooks/ollama-down.md](runbooks/ollama-down.md)). Bringing Ollama up first is optional, only so the very first AI request succeeds immediately.
+
+Two ways to run it:
+
+| Model | Command | When |
+| --- | --- | --- |
+| **Separate resources** (recommended) | App resource: `docker compose -f compose.yaml up -d` · Ollama resource: `docker compose -f compose.ollama.yaml up -d` (two Coolify resources / projects) | Prod: lets Ollama be sized/placed independently (RAM/GPU/host). |
+| **Co-located** (single host) | `docker compose -f compose.yaml -f compose.ollama.yaml up -d` (one project) | Simplest; only if one host has the RAM for Ollama. Loses the resource separation. |
+
+> **Caveat (two-project model):** sharing a name-pinned non-`external` network across two separate Compose projects works on current Compose, but some versions warn on the network's project-ownership label. If that surfaces in your Coolify setup, switch the network to `external: true` in both files and pre-create it once with `docker network create bike-trip-planner-llm` (then bring up either stack in any order). Tear down the app stack before the Ollama stack so the shared network is not removed from under a running consumer.
+
+> **Local dev/recette** boot everything as a **single** Compose project (`make start-dev`, `make start-recette`), so the network is created once and there is no ordering to worry about. `OLLAMA_ENABLED` is `0` in dev (AI off, no models pulled) and `1` in recette. See [getting-started.md](getting-started.md).
+
 ## Required GitHub Actions secrets
 
 | Secret | Required for | Purpose |

--- a/docs/getting-started.fr.md
+++ b/docs/getting-started.fr.md
@@ -80,12 +80,16 @@ Vous devriez recevoir un document JSON OpenAPI.
 ## Tâches courantes
 
 ```bash
-make start     # Démarrer tous les conteneurs
-make stop      # Arrêter tous les conteneurs (conserve les données)
-make clean     # Arrêter tous les conteneurs et effacer toutes les données (à utiliser avec précaution)
+make start         # Démarrer tous les conteneurs (mode iso-prod)
+make start-dev     # Démarrer en mode développement (hot reload ; tier IA désactivé par défaut)
+make start-recette # Iso-prod + Mailcatcher + Ollama (IA activée) pour la recette
+make stop          # Arrêter tous les conteneurs (conserve les données)
+make clean         # Arrêter tous les conteneurs et effacer toutes les données (à utiliser avec précaution)
 ```
 
 Consultez `make help` pour la liste complète des cibles disponibles.
+
+> **Un seul projet, aucun ordre.** En local, chaque cible `make start*` démarre l'app et le tier IA Ollama dans un **seul** projet Compose : le réseau partagé `bike-trip-planner-llm` est créé une fois et tu n'as jamais à démarrer l'un avant l'autre. En production, le tier IA est une ressource *séparée* avec son propre modèle de démarrage — voir [deployment.md](deployment.md#llm-tier-ollama-and-the-shared-network).
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -80,12 +80,16 @@ You should receive an OpenAPI JSON document.
 ## Common tasks
 
 ```bash
-make start     # Start all containers
-make stop      # Stop all containers (preserves data)
-make clean     # Stop all containers and erase all data (use with caution)
+make start         # Start all containers (production-iso mode)
+make start-dev     # Start in development mode (hot reload; AI tier off by default)
+make start-recette # Production-iso + Mailcatcher + Ollama (AI on) for the recette
+make stop          # Stop all containers (preserves data)
+make clean         # Stop all containers and erase all data (use with caution)
 ```
 
 See `make help` for the full list of available targets.
+
+> **One project, no ordering.** Locally, every `make start*` target boots the app and the Ollama LLM tier as a **single** Compose project, so the shared `bike-trip-planner-llm` network is created once and you never have to start one before the other. In production the LLM tier is a *separate* resource with its own startup model — see [deployment.md](deployment.md#llm-tier-ollama-and-the-shared-network).
 
 ---
 


### PR DESCRIPTION
Corrige les findings critiques de l'audit Sprint 35.2, avant 35.3.

## IDOR-DETAIL (P1, sécurité)
`GET /trips/{id}/detail` n'avait aucun contrôle d'autorisation objet -> tout utilisateur authentifié lisait le trip d'un autre. Fix : `security: "is_granted('TRIP_VIEW', request.attributes.get('id'))"` (copie du pattern de `chat-history`). Trip inexistant/étranger -> 403. Test mis à jour + test de non-régression IDOR ajouté.

## F1 (P0, prod cassée)
`compose.yaml` omettait `LOCK_DSN` -> fallback `redis://localhost` injoignable -> création de trip 500 en prod. Fix : `LOCK_DSN: redis://redis:6379` sur php/worker/worker-llm.

## F3 + arbitrage mode dégradé (ADR-028)
Décision : **le projet doit fonctionner sans IA** (dégradé-OK), ce qui **réverse** le hard-dep Sprint-29 (#375). Le dégradé est rendu **explicite** (pas silencieux), ce qui lève l'objection d'origine.

- **compose.yaml** : wiring `OLLAMA_BASE_URL`/`ANALYSIS_URL`/`CHAT_URL` + `OLLAMA_ENABLED=1` sur php/worker/worker-llm (l'app sait joindre la ressource Ollama séparée). dev force `0`, recette force `1`.
- **HealthController** : Ollama reste **hors** du `$required` de readiness (dégradé-OK ; épingle le contrat des tests existants).
- **ADR-028** : nouvelle « Decision Update - Degraded Mode Re-instated » (supersède le hard-dep) + **topologie de déploiement** : Ollama possède le réseau `bike-trip-planner-llm`, l'app le rejoint en `external` (le consommateur rejoint le fournisseur ; moindre connectivité ; DB/Redis hors du réseau Ollama).
- **ADR-027** : section « hard dependency » annotée comme superseded.
- **TRACKING** : 35.3 ordre 5 (liens/ancres : pas de 404 ni ancre disparue).

Le **gating front + dégradation gracieuse API + logs `critical`** sont portés par **#304 (rouvert)** — feature dédiée, pas ce hotfix. Les 3 états IA (activée/désactivée/indispo) seront couverts par la recette + 35.3.

## Vérifications
- `php -l` (TripDetail, HealthController) OK ; `docker compose -f compose.yaml config` OK ; markdownlint (ADR-028/027, TRACKING) 0 erreur.
- PHPUnit (dont test IDOR + les 2 tests health ollama-down qui restent verts) : délégué à la CI de cette PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-review-start -->
## Claude Review

**0 critical · 0 warning** · reviewed commit `14a864d`

All three critical fixes are correct and fully implemented. The IDOR fix mirrors the established `chat-history` security pattern with proper `TripVoter` wiring; the voter correctly accepts raw UUID strings so the security expression `is_granted('TRIP_VIEW', request.attributes.get('id'))` works without further plumbing. The 403-for-non-existent contract (no existence leak) matches the sibling endpoint. `LOCK_DSN` is correctly added to all three PHP services in `compose.yaml` with the stale `compose.recette.yaml` workaround removed. The degraded-mode architectural decision is thoroughly documented across ADR-027/028; the `bike-trip-planner-llm` network is declared identically (`name`-pinned, `attachable: true`) in both stacks and correctly joined only by the LLM-calling services — keeping `database`/`redis`/`mercure`/`valhalla` off the shared network (least-connectivity principle). Deployment/getting-started docs cover both run modes.

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases — IDOR regression test + 403 contract for non-existent/foreign trips
- [x] Documentation is up to date — ADR-027/028 updated; deployment.md + getting-started docs updated; TRACKING.md updated
- [x] Dependent tickets accounted for — #304 re-opened to carry front-gating + graceful degradation

### Inline comments

No inline comments.

---

Generated with [Claude Code](https://claude.ai/code)
<!-- claude-review-end -->