### PR TITLE
feat(ai): explicit degraded mode when the AI tier is unavailable (#304)

### DIFF
--- a/TRACKING.md
+++ b/TRACKING.md
@@ -517,7 +517,7 @@ Service OllamaClient PHP, configuration Docker Ollama, gate mechanism dans Compu
 
 ## Sprint 29 — LLaMA 8B : analyse 2 passes
 
-Pipeline d'analyse IA : passe 1 par étape (parallélisable via Messenger), passe 2 vue d'ensemble, orchestration gate → LLaMA → TRIP_READY. **Décision : Ollama est une dépendance dure** — pas de fallback gracieux (cf. issue #375 arbitrage v2 « IA toujours active »). Issue #304 fermée.
+Pipeline d'analyse IA : passe 1 par étape (parallélisable via Messenger), passe 2 vue d'ensemble, orchestration gate → LLaMA → TRIP_READY. **Décision (Sprint 29) : Ollama est une dépendance dure** — pas de fallback gracieux (cf. issue #375 arbitrage v2 « IA toujours active »). Issue #304 fermée, puis **rouverte par l'audit Sprint 35.2** : la décision est ré-inversée en **mode dégradé explicite** (cf. ADR-028 « Decision Update — Degraded Mode » + #616) ; implémentée sur `feature/304`.
 
 | Ordre | ID                                                                      | Titre                                                     | Effort | PRs                                                                                | Dépend de      |
 |-------|-------------------------------------------------------------------------|-----------------------------------------------------------|--------|------------------------------------------------------------------------------------|----------------|
@@ -1007,7 +1007,7 @@ Sprint dédié à la résilience de la donnée en production. ADR-032 (Migration
 
 | ID                                                                      | Titre                                                  | Raison                                                                       |
 |-------------------------------------------------------------------------|--------------------------------------------------------|------------------------------------------------------------------------------|
-| [#304](https://github.com/vincentchalamon/bike-trip-planner/issues/304) | Fallback gracieux sans Ollama                          | Ollama = dépendance dure (issue #375 arbitrage v2 « IA toujours active »)    |
+| [#304](https://github.com/vincentchalamon/bike-trip-planner/issues/304) | Fallback gracieux sans Ollama                          | **Rouvert** (audit Sprint 35.2) — mode dégradé explicite, en cours sur `feature/304` (ADR-028 « Degraded Mode ») |
 | [#307](https://github.com/vincentchalamon/bike-trip-planner/issues/307) | Bandeau « Actualiser l'analyse IA »                    | IA toujours active — pas de bandeau (issue #375 §16 Sprint 27)               |
 | [#308](https://github.com/vincentchalamon/bike-trip-planner/issues/308) | Fallback frontend sans LLaMA                           | Ollama = dépendance dure — impossible (issue #375 arbitrage v2)              |
 

--- a/api/src/Controller/HealthController.php
+++ b/api/src/Controller/HealthController.php
@@ -35,6 +35,8 @@ final readonly class HealthController
         private HttpClientInterface $ollamaChatClient,
         #[Autowire(service: 'ollama_analysis.client')]
         private HttpClientInterface $ollamaAnalysisClient,
+        #[Autowire(env: 'bool:default::OLLAMA_ENABLED')]
+        private bool $aiEnabled,
         #[Autowire(service: 'mercure.health.client')]
         private HttpClientInterface $mercureClient,
         #[Autowire(service: 'limiter.health_liveness')]
@@ -76,18 +78,25 @@ final readonly class HealthController
         $pending = [
             'mercure' => $this->startHttpCheck('HEAD', '?topic=health', $this->mercureClient),
             'valhalla' => $this->startHttpCheck('GET', '/status', $this->valhallaClient),
-            'ollama_chat' => $this->startHttpCheck('GET', '/api/tags', $this->ollamaChatClient),
-            'ollama_analysis' => $this->startHttpCheck('GET', '/api/tags', $this->ollamaAnalysisClient),
         ];
+
+        // The LLM tier is probed/surfaced only when enabled (OLLAMA_ENABLED=1). When off,
+        // the absence of `deps.ollama_*` is itself the "AI disabled" signal, and we skip
+        // two pointless probes against an unwired tier. The PWA gates AI features on
+        // NEXT_PUBLIC_AI_ENABLED + deps.ollama_chat (ADR-028 "Degraded Mode").
+        if ($this->aiEnabled) {
+            $pending['ollama_chat'] = $this->startHttpCheck('GET', '/api/tags', $this->ollamaChatClient);
+            $pending['ollama_analysis'] = $this->startHttpCheck('GET', '/api/tags', $this->ollamaAnalysisClient);
+        }
 
         foreach ($pending as $name => $pair) {
             $deps[$name] = $this->finishHttpCheck($pair);
         }
 
-        // Ollama is intentionally NOT required: the app runs in a degraded mode when
-        // the LLM tier is down (AI features disabled, not a 5xx) — see ADR-028
-        // "Degraded Mode" update. ollama_chat/ollama_analysis are still surfaced in
-        // `deps` (and logged) so operators can see/alert on the outage.
+        // Ollama is intentionally NOT required: the app runs in a degraded mode when the
+        // LLM tier is down (AI features disabled, not a 5xx) — see ADR-028 "Degraded Mode"
+        // update. When enabled, ollama_chat/ollama_analysis are surfaced in `deps` (and
+        // logged `critical`) so operators can see/alert on the outage.
         $required = ['postgres', 'redis', 'mercure', 'valhalla'];
         $status = 'ok';
         foreach ($required as $dep) {

--- a/api/src/InRide/InRideAssistant.php
+++ b/api/src/InRide/InRideAssistant.php
@@ -375,7 +375,7 @@ final readonly class InRideAssistant
                 ],
             );
         } catch (OllamaUnavailableException $ollamaUnavailableException) {
-            $this->logger->info('InRideAssistant: LLM unavailable for narrative, using fallback.', [
+            $this->logger->critical('InRideAssistant: LLM unavailable for narrative, using fallback.', [
                 'error' => $ollamaUnavailableException->getMessage(),
             ]);
 

--- a/api/src/InRide/PoiIntentDetector.php
+++ b/api/src/InRide/PoiIntentDetector.php
@@ -88,7 +88,7 @@ PROMPT;
                 ],
             );
         } catch (OllamaUnavailableException $ollamaUnavailableException) {
-            $this->logger->info('PoiIntentDetector: LLM unavailable, defaulting to unknown intent.', [
+            $this->logger->critical('PoiIntentDetector: LLM unavailable, defaulting to unknown intent.', [
                 'error' => $ollamaUnavailableException->getMessage(),
             ]);
 

--- a/api/src/MessageHandler/AnalyzeStageWithLlmHandler.php
+++ b/api/src/MessageHandler/AnalyzeStageWithLlmHandler.php
@@ -141,7 +141,7 @@ final readonly class AnalyzeStageWithLlmHandler
                 ],
             );
         } catch (OllamaUnavailableException $ollamaUnavailableException) {
-            $this->logger->warning('Ollama unreachable — skipping stage analysis.', [
+            $this->logger->critical('Ollama unreachable — skipping stage analysis.', [
                 'tripId' => $message->tripId,
                 'dayNumber' => $message->dayNumber,
                 'error' => $ollamaUnavailableException->getMessage(),

--- a/api/src/MessageHandler/AnalyzeTripOverviewWithLlmHandler.php
+++ b/api/src/MessageHandler/AnalyzeTripOverviewWithLlmHandler.php
@@ -145,7 +145,7 @@ final readonly class AnalyzeTripOverviewWithLlmHandler
                 ],
             );
         } catch (OllamaUnavailableException $ollamaUnavailableException) {
-            $this->logger->warning('Ollama unreachable — skipping trip overview synthesis.', [
+            $this->logger->critical('Ollama unreachable — skipping trip overview synthesis.', [
                 'tripId' => $tripId,
                 'error' => $ollamaUnavailableException->getMessage(),
             ]);

--- a/api/src/State/TripChatProcessor.php
+++ b/api/src/State/TripChatProcessor.php
@@ -163,7 +163,7 @@ final readonly class TripChatProcessor implements ProcessorInterface
                 ],
             );
         } catch (OllamaUnavailableException $ollamaUnavailableException) {
-            $this->logger->warning('Ollama unreachable — chat endpoint returning 503.', [
+            $this->logger->critical('Ollama unreachable — chat endpoint returning 503.', [
                 'tripId' => $tripId,
                 'error' => $ollamaUnavailableException->getMessage(),
             ]);

--- a/api/tests/Functional/HealthControllerTest.php
+++ b/api/tests/Functional/HealthControllerTest.php
@@ -32,11 +32,12 @@ final class HealthControllerTest extends ApiTestCase
     #[\Override]
     protected function tearDown(): void
     {
-        // Reset overridden services so that the broken-Postgres / broken-Redis
-        // mock injected by a given test does not leak into subsequent ones —
-        // the kernel is reused ($alwaysBootKernel = false).
-        $container = self::getContainer();
-        $container->reset();
+        // A test may flip OLLAMA_ENABLED and reboot the kernel (see
+        // bootWithOllamaEnabled): restore the default (0) and drop the kernel so the
+        // next test boots fresh with a clean env and no leaked service overrides
+        // (broken Postgres/Redis, mocked HTTP clients).
+        $_SERVER['OLLAMA_ENABLED'] = $_ENV['OLLAMA_ENABLED'] = '0';
+        self::ensureKernelShutdown();
         parent::tearDown();
     }
 
@@ -65,6 +66,7 @@ final class HealthControllerTest extends ApiTestCase
     #[Test]
     public function readinessReturns200WhenAllDependenciesAreUp(): void
     {
+        $this->bootWithOllamaEnabled();
         $this->mockHealthHttpClients(
             valhalla: new MockResponse('OK', ['http_code' => 200]),
             ollama: new MockResponse('{"models":[]}', ['http_code' => 200]),
@@ -187,6 +189,7 @@ final class HealthControllerTest extends ApiTestCase
     {
         // Ollama is intentionally excluded from $required, so its outage must
         // not flip the aggregate status — pin that contract here.
+        $this->bootWithOllamaEnabled();
         $this->mockHealthHttpClients(
             valhalla: new MockResponse('OK', ['http_code' => 200]),
             ollama: new MockResponse('error', ['http_code' => 500]),
@@ -206,6 +209,7 @@ final class HealthControllerTest extends ApiTestCase
     {
         // The analysis client is also excluded from $required; an analysis-only
         // outage surfaces in deps.ollama_analysis but must not flip the aggregate.
+        $this->bootWithOllamaEnabled();
         $this->mockHealthHttpClients(
             valhalla: new MockResponse('OK', ['http_code' => 200]),
             ollama: new MockResponse('{"models":[]}', ['http_code' => 200]),
@@ -219,6 +223,38 @@ final class HealthControllerTest extends ApiTestCase
         $data = $response->toArray();
         $this->assertSame('ok', $data['status']);
         $this->assertSame('down', $data['deps']['ollama_analysis']['status']);
+    }
+
+    #[Test]
+    public function readinessOmitsOllamaWhenAiDisabled(): void
+    {
+        // OLLAMA_ENABLED=0 (the test-suite default): the LLM tier is neither probed
+        // nor surfaced — its very absence from `deps` is the "AI disabled" signal.
+        $this->mockHealthHttpClients(
+            valhalla: new MockResponse('OK', ['http_code' => 200]),
+            ollama: new MockResponse('{"models":[]}', ['http_code' => 200]),
+            mercure: new MockResponse('', ['http_code' => 200]),
+        );
+
+        $response = $this->client->request('GET', '/api/health');
+
+        $this->assertResponseStatusCodeSame(200);
+        $data = $response->toArray();
+        $this->assertSame('ok', $data['status']);
+        $this->assertArrayNotHasKey('ollama_chat', $data['deps']);
+        $this->assertArrayNotHasKey('ollama_analysis', $data['deps']);
+    }
+
+    /**
+     * Reboot the kernel with OLLAMA_ENABLED=1 so the readiness probe surfaces the LLM
+     * tier. Must be called before mocking the HTTP clients (the reboot rebuilds the
+     * container). tearDown restores the default (0) and drops the kernel.
+     */
+    private function bootWithOllamaEnabled(): void
+    {
+        $_SERVER['OLLAMA_ENABLED'] = $_ENV['OLLAMA_ENABLED'] = '1';
+        self::ensureKernelShutdown();
+        $this->client = self::createClient();
     }
 
     private function mockHealthHttpClients(

--- a/api/tests/Integration/InRideAssistantTest.php
+++ b/api/tests/Integration/InRideAssistantTest.php
@@ -12,6 +12,7 @@ use App\InRide\InRideAssistant;
 use App\InRide\OpeningHoursParser;
 use App\InRide\PoiIntentDetector;
 use App\InRide\PoiSuggestion;
+use App\Llm\Exception\OllamaUnavailableException;
 use App\Llm\LlmClientInterface;
 use App\Llm\SystemPromptLoader;
 use App\Scanner\OsmOverpassQueryBuilder;
@@ -19,6 +20,8 @@ use App\Scanner\ScannerInterface;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 /**
@@ -265,8 +268,51 @@ final class InRideAssistantTest extends TestCase
         $this->assertStringContainsString('rien trouvé', $response->narrative);
     }
 
-    private function buildAssistant(LlmClientInterface $llm, ScannerInterface $scanner): InRideAssistant
+    #[Test]
+    public function logsAtCriticalWhenOllamaUnreachableForNarrative(): void
     {
+        // Intent classification succeeds (user message) but the narrative call
+        // (JSON payload) hits an unreachable tier — it must log `critical` and
+        // still serve the fallback narrative (#304).
+        $llm = $this->createMock(LlmClientInterface::class);
+        $llm->method('generate')->willReturnCallback(
+            static function (string $model, string $prompt): array {
+                if (str_starts_with(trim($prompt), '{')) {
+                    throw new OllamaUnavailableException('boom');
+                }
+
+                return ['response' => '{"category":"water","max_distance_m":3000}'];
+            },
+        );
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())->method('critical')
+            ->with(self::stringContains('LLM unavailable for narrative'));
+
+        $scanner = $this->createMock(ScannerInterface::class);
+        $scanner->method('query')->willReturn([
+            'elements' => [
+                ['type' => 'node', 'lat' => 50.8504, 'lon' => 4.3520, 'tags' => ['name' => 'Fontaine']],
+            ],
+        ]);
+
+        $assistant = $this->buildAssistant($llm, $scanner, $logger);
+
+        $response = $assistant->assist(
+            message: "Je cherche un point d'eau",
+            position: new GeoPosition(50.8503, 4.3517),
+        );
+
+        // Graceful degradation: POIs are still returned with a fallback narrative.
+        self::assertSame(PoiSuggestion::CATEGORY_WATER, $response->category);
+        self::assertNotEmpty($response->pois);
+    }
+
+    private function buildAssistant(
+        LlmClientInterface $llm,
+        ScannerInterface $scanner,
+        ?LoggerInterface $logger = null,
+    ): InRideAssistant {
         $distance = new HaversineDistance();
 
         return new InRideAssistant(
@@ -280,6 +326,7 @@ final class InRideAssistantTest extends TestCase
             llmClient: $llm,
             promptLoader: new SystemPromptLoader($this->promptDir),
             cache: new ArrayAdapter(),
+            logger: $logger ?? new NullLogger(),
         );
     }
 }

--- a/api/tests/Unit/InRide/PoiIntentDetectorTest.php
+++ b/api/tests/Unit/InRide/PoiIntentDetectorTest.php
@@ -6,12 +6,14 @@ namespace App\Tests\Unit\InRide;
 
 use App\InRide\PoiIntentDetector;
 use App\InRide\PoiSuggestion;
+use App\Llm\Exception\OllamaUnavailableException;
 use App\Llm\LlmClientInterface;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
 /**
@@ -33,6 +35,21 @@ final class PoiIntentDetectorTest extends TestCase
         $detector = new PoiIntentDetector($llm, new NullLogger());
 
         $intent = $detector->detect('   ');
+
+        self::assertTrue($intent->isUnknown());
+    }
+
+    #[Test]
+    public function logsAtCriticalWhenOllamaUnreachable(): void
+    {
+        $llm = $this->createMock(LlmClientInterface::class);
+        $llm->method('generate')->willThrowException(new OllamaUnavailableException('boom'));
+
+        // AI enabled but unreachable must be logged at `critical` for ops alerting (#304).
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())->method('critical')->with(self::stringContains('LLM unavailable'));
+
+        $intent = new PoiIntentDetector($llm, $logger)->detect('Un café ?');
 
         self::assertTrue($intent->isUnknown());
     }

--- a/api/tests/Unit/Llm/AnalyzeStageWithLlmHandlerTest.php
+++ b/api/tests/Unit/Llm/AnalyzeStageWithLlmHandlerTest.php
@@ -21,6 +21,7 @@ use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -142,7 +143,11 @@ final class AnalyzeStageWithLlmHandlerTest extends TestCase
         $llmClient->method('isEnabled')->willReturn(true);
         $llmClient->method('generate')->willThrowException(new OllamaUnavailableException('boom'));
 
-        $handler = $this->makeHandler(repo: $repo, llmClient: $llmClient);
+        // AI enabled but Ollama unreachable must be logged at `critical` for ops alerting (#304).
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())->method('critical')->with(self::stringContains('Ollama unreachable'));
+
+        $handler = $this->makeHandler(repo: $repo, llmClient: $llmClient, logger: $logger);
         $handler(new AnalyzeStageWithLlmMessage(self::TRIP_ID, 1));
     }
 
@@ -385,12 +390,14 @@ final class AnalyzeStageWithLlmHandlerTest extends TestCase
      * @param TripRequestRepositoryInterface&MockObject $repo
      * @param LlmClientInterface&MockObject             $llmClient
      * @param (MessageBusInterface&MockObject)|null     $messageBus override the bus when the test asserts pass-2 dispatch
+     * @param (LoggerInterface&MockObject)|null         $logger     override the logger when the test asserts a log level
      */
     private function makeHandler(
         TripRequestRepositoryInterface $repo,
         LlmClientInterface $llmClient,
         bool $claimsOverviewDispatch = false,
         ?MessageBusInterface $messageBus = null,
+        ?LoggerInterface $logger = null,
     ): AnalyzeStageWithLlmHandler {
         $tracker = $this->createStub(LlmAnalysisTrackerInterface::class);
         $tracker->method('markStageAnalysisSettled')->willReturn(['completed' => 1, 'failed' => 0, 'total' => 1]);
@@ -401,7 +408,7 @@ final class AnalyzeStageWithLlmHandlerTest extends TestCase
             llmClient: $llmClient,
             promptLoader: new SystemPromptLoader($this->tmpPromptDir),
             summaryBuilder: new StageAnalysisSummaryBuilder(),
-            logger: new NullLogger(),
+            logger: $logger ?? new NullLogger(),
             llmTracker: $tracker,
             messageBus: $messageBus ?? $this->createStub(MessageBusInterface::class),
             publisher: new NullTripUpdatePublisher(),

--- a/api/tests/Unit/Llm/AnalyzeTripOverviewWithLlmHandlerTest.php
+++ b/api/tests/Unit/Llm/AnalyzeTripOverviewWithLlmHandlerTest.php
@@ -22,6 +22,7 @@ use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
 #[AllowMockObjectsWithoutExpectations]
@@ -189,7 +190,11 @@ final class AnalyzeTripOverviewWithLlmHandlerTest extends TestCase
         $llmClient->method('isEnabled')->willReturn(true);
         $llmClient->method('generate')->willThrowException(new OllamaUnavailableException('boom'));
 
-        $handler = $this->makeHandler(repo: $repo, llmClient: $llmClient);
+        // AI enabled but Ollama unreachable must be logged at `critical` for ops alerting (#304).
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())->method('critical')->with(self::stringContains('Ollama unreachable'));
+
+        $handler = $this->makeHandler(repo: $repo, llmClient: $llmClient, logger: $logger);
         $handler(new AnalyzeTripOverviewWithLlmMessage(self::TRIP_ID));
     }
 
@@ -497,12 +502,14 @@ final class AnalyzeTripOverviewWithLlmHandlerTest extends TestCase
     /**
      * @param TripRequestRepositoryInterface&MockObject $repo
      * @param LlmClientInterface&MockObject             $llmClient
+     * @param (LoggerInterface&MockObject)|null         $logger    override the logger when the test asserts a log level
      */
     private function makeHandler(
         TripRequestRepositoryInterface $repo,
         LlmClientInterface $llmClient,
         bool $claimsTripReadyPublication = true,
         ?TripUpdatePublisherInterface $publisher = null,
+        ?LoggerInterface $logger = null,
     ): AnalyzeTripOverviewWithLlmHandler {
         $llmTracker = $this->createStub(LlmAnalysisTrackerInterface::class);
         $llmTracker->method('getStageAnalysisProgress')->willReturn(['completed' => 1, 'failed' => 0, 'total' => 1]);
@@ -515,7 +522,7 @@ final class AnalyzeTripOverviewWithLlmHandlerTest extends TestCase
             tripStateManager: $repo,
             llmClient: $llmClient,
             promptLoader: new SystemPromptLoader($this->tmpPromptDir),
-            logger: new NullLogger(),
+            logger: $logger ?? new NullLogger(),
             llmTracker: $llmTracker,
             computationTracker: $computationTracker,
             publisher: $publisher ?? new NullTripUpdatePublisher(),

--- a/api/tests/Unit/State/TripChatProcessorTest.php
+++ b/api/tests/Unit/State/TripChatProcessorTest.php
@@ -22,6 +22,7 @@ use App\InRide\OpeningHoursParser;
 use App\InRide\PoiIntentDetector;
 use App\Llm\ChatActionInterpreter;
 use App\Llm\ChatHistoryStore;
+use App\Llm\Exception\OllamaUnavailableException;
 use App\Llm\LlmClientInterface;
 use App\Llm\SystemPromptLoader;
 use App\Scanner\OsmOverpassQueryBuilder;
@@ -37,6 +38,7 @@ use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
 use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -646,6 +648,31 @@ final class TripChatProcessorTest extends TestCase
         self::assertSame('OK même si PG est cassé', $response->response);
     }
 
+    #[Test]
+    public function returnsServiceUnavailableAndLogsCriticalWhenOllamaUnreachable(): void
+    {
+        // AI enabled but the chat call hits an unreachable tier: 503 + `critical` log (#304).
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())->method('critical')
+            ->with(self::stringContains('Ollama unreachable'));
+
+        $processor = $this->newProcessor(
+            llmContent: '',
+            stagesCount: 1,
+            messageBus: $this->newMessageBus(),
+            logger: $logger,
+            chatException: new OllamaUnavailableException('boom'),
+        );
+
+        $this->expectException(ServiceUnavailableHttpException::class);
+
+        $processor->process(
+            new TripChatRequest('Bonjour'),
+            new Post(),
+            ['id' => self::TRIP_ID],
+        );
+    }
+
     /**
      * @param array<string, mixed>|null $scannerResponse optional Overpass payload returned by the in-ride scanner mock
      */
@@ -657,6 +684,7 @@ final class TripChatProcessorTest extends TestCase
         ?EntityManagerInterface $entityManager = null,
         ?array $scannerResponse = null,
         ?LoggerInterface $logger = null,
+        ?\Throwable $chatException = null,
     ): TripChatProcessor {
         $tripRequest = new TripRequest();
         $stages = [];
@@ -678,9 +706,14 @@ final class TripChatProcessorTest extends TestCase
 
         $llmClient = $this->createStub(LlmClientInterface::class);
         $llmClient->method('isEnabled')->willReturn(true);
-        $llmClient->method('chat')->willReturn([
-            'message' => ['role' => 'assistant', 'content' => $llmContent],
-        ]);
+        if ($chatException instanceof \Throwable) {
+            $llmClient->method('chat')->willThrowException($chatException);
+        } else {
+            $llmClient->method('chat')->willReturn([
+                'message' => ['role' => 'assistant', 'content' => $llmContent],
+            ]);
+        }
+
         // PoiIntentDetector + InRideAssistant narrative both call generate().
         // We return the same `$llmContent` envelope so in-ride tests can drive
         // the intent classifier with the same fixture as planning tests; the

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -126,6 +126,12 @@ services:
       NODE_ENV: development
       # Development usage only
       NODE_TLS_REJECT_UNAUTHORIZED: "0"
+      # Derived from OLLAMA_ENABLED (single flag for both tiers), defaulting to
+      # enabled so the assistant UI is exercised (and E2E specs see it). Ollama
+      # itself is off in dev, so /api/health omits the tier and the PWA shows the
+      # explicit degraded-mode gating (#304). `next dev` reads NEXT_PUBLIC_* at
+      # runtime — no rebuild needed.
+      NEXT_PUBLIC_AI_ENABLED: "${OLLAMA_ENABLED:-1}"
     volumes: !override
       - ./pwa:/srv/app
       - pwa_node_modules:/srv/app/node_modules

--- a/compose.yaml
+++ b/compose.yaml
@@ -314,6 +314,11 @@ services:
         # the self-hosted tracker script (e.g. https://analytics.example/js/script.js).
         NEXT_PUBLIC_PLAUSIBLE_DOMAIN: "${NEXT_PUBLIC_PLAUSIBLE_DOMAIN:-}"
         NEXT_PUBLIC_PLAUSIBLE_SRC: "${NEXT_PUBLIC_PLAUSIBLE_SRC:-}"
+        # AI feature gating (#304): inlined into the client bundle so AI features
+        # are hidden outright when off. Derived from OLLAMA_ENABLED so a single
+        # flag drives both tiers (front + API), with no divergence; changing it
+        # requires a front rebuild (NEXT_PUBLIC_* is build-time).
+        NEXT_PUBLIC_AI_ENABLED: "${OLLAMA_ENABLED:-1}"
       # SENTRY_AUTH_TOKEN (source-map upload) is a real secret: passed as a
       # BuildKit secret so it never lands in an image layer or the build cache.
       secrets:

--- a/docs/adr/adr-028-ollama-llama-integration.md
+++ b/docs/adr/adr-028-ollama-llama-integration.md
@@ -140,8 +140,9 @@ update below, which supersedes the earlier hard-dependency stance.
   `external: true` + a one-time `docker network create bike-trip-planner-llm` (validate when the prod target exists).
 - **Health.** Ollama is deliberately **excluded from the readiness `$required` set** (`GET /api/health` stays `ok`
   when the LLM tier is down) and from liveness — an Ollama outage must neither return traffic-blocking 503s nor
-  restart-loop the app. Its status is still **surfaced in `deps.ollama_chat`/`deps.ollama_analysis`** and logged
-  `critical` so operators can alert. This realises the degraded-mode contract below.
+  restart-loop the app. When `OLLAMA_ENABLED=1` its status is **surfaced in `deps.ollama_chat`/`deps.ollama_analysis`**
+  (the keys are omitted entirely when AI is off by config, so their absence is itself the "disabled" signal), and an
+  unreachable enabled tier is logged `critical` so operators can alert. This realises the degraded-mode contract below.
 
 ---
 
@@ -179,10 +180,13 @@ uptime). That objection is **resolved by making degradation explicit**, not by f
   AI passes (stage analysis, overview, chat) are **skipped** rather than retried-to-failure, and the event is
   logged at **`critical`** for alerting. The app does not return a traffic-blocking 503 for an AI outage; Ollama
   stays **out of the readiness `$required` set** (see Deployment topology → Health).
-- **Front — explicit feature-gating.** The PWA reads AI availability (capabilities signal / health `deps.ollama`)
-  and **disables the AI-driven features** when the tier is down: AI trip generation, the in-editor AI chat, and
-  AI trip analysis. The user sees *why* they are unavailable rather than silently receiving a degraded report —
-  this is the determinism guarantee the Sprint-29 update was protecting, kept intact.
+- **Front — explicit feature-gating.** The PWA derives AI availability from two signals: the build-time
+  `NEXT_PUBLIC_AI_ENABLED` flag (mirrors `OLLAMA_ENABLED` — when off, AI features are hidden outright with no probe)
+  and, when enabled, a runtime `GET /api/health` → `deps.ollama_chat.status` probe at planner mount. It **disables
+  the AI-driven features** when the tier is unreachable: AI trip generation (refinement card), the in-editor AI chat,
+  and AI trip analysis (an explicit "AI unavailable" notice). The user sees *why* they are unavailable rather than
+  silently receiving a degraded report — the determinism guarantee the Sprint-29 update was protecting, kept intact.
+  No dedicated `/capabilities` endpoint is introduced: `/api/health` already carries the runtime signal.
 - **Three supported states.** `OLLAMA_ENABLED=0` (AI off by config — features hidden), `OLLAMA_ENABLED=1` +
   reachable (full AI), and `OLLAMA_ENABLED=1` + unreachable (degraded — features disabled, `critical` logs).
 - **Issues.** #304 (graceful fallback without Ollama) is **re-opened** to carry the front gating + API

--- a/docs/runbooks/ollama-down.md
+++ b/docs/runbooks/ollama-down.md
@@ -1,13 +1,14 @@
 # Ollama Down
 
-Ollama is a **hard runtime dependency** per ADR-028 — there is no graceful fallback. If the LLM tier is unreachable, the gate pipeline (brief intake, narrative analysis) fails and the deployment is considered unhealthy.
+Ollama is an **optional LLM tier** running in **explicit degraded mode** (ADR-028, "Decision Update — Degraded Mode Re-instated"). When it is unreachable the app **stays up**: AI passes are skipped (not retried to failure), the events are logged `critical` for alerting, `/api/health` stays HTTP **200** (Ollama is excluded from the readiness `$required` set), and the PWA **disables the AI features with an explicit "unavailable" notice** rather than silently dropping them. Trip computation, rule-based alerts, and `TRIP_READY` are unaffected.
 
 ## Symptômes
 
-- Trip creation blocks on the brief intake step (PWA wizard hangs on "Analyzing your brief…")
-- PHP logs: `OllamaClient`: timeout, `ConnectException`, or schema validation rejection followed by dead-letter
-- `/api/health` returns HTTP **200** with `deps.ollama_chat.status: "down"` (and `deps.ollama_analysis.status` for the analysis endpoint — same service in beta, distinct once `OLLAMA_ANALYSIS_URL` diverges) in the body — Ollama is probed but excluded from the required set (`HealthController::$required`), so it does **not** flip the aggregate HTTP status to 503
-- Messenger `failed` transport grows with `AnalyzeStageMessage` / brief-intake messages
+- PHP/worker logs at **`critical`**: `Ollama unreachable — skipping stage analysis.` / `… skipping trip overview synthesis.` / `Ollama unreachable — chat endpoint returning 503.` (plus the in-ride detector/assistant). One per affected message — Sentry groups them by the fixed template.
+- `GET /api/health` returns HTTP **200** with `deps.ollama_chat.status: "down"` (and `deps.ollama_analysis.status`) — surfaced **only when `OLLAMA_ENABLED=1`**; the keys are absent entirely when AI is off by config. Ollama is probed but excluded from `$required`, so it does **not** flip the aggregate HTTP status to 503.
+- PWA: the floating AI bubble is disabled (title "Assistant IA indisponible"), the Acte 3 "AI unavailable" notice shows, and the refinement card on `/trips/new` is disabled.
+- The in-editor chat endpoint (`POST /trips/{id}/chat`) returns **503** while the tier is down.
+- Trips still complete: stages, weather, and rule-based alerts render; only the AI narrative is absent.
 
 ## Diagnostic
 
@@ -20,6 +21,12 @@ Probe the API directly:
 
 ```bash
 docker compose exec php curl -sS http://ollama:11434/api/tags | jq '.models[].name'
+```
+
+Check what the app sees (the keys appear only when `OLLAMA_ENABLED=1`):
+
+```bash
+curl -s localhost/api/health | jq '.deps.ollama_chat, .deps.ollama_analysis'
 ```
 
 Expected models (beta profile, issue #563 — single 3B for analysis + chat):
@@ -37,13 +44,15 @@ docker stats --no-stream ollama
 
 ## Procédure
 
+The app is **not** down — this is a service-restoration runbook, not an incident-mitigation one.
+
 1. **Restart the container**:
 
    ```bash
    docker compose restart ollama
    ```
 
-   Wait for the healthcheck (`ollama list`) to go green before retrying any failed message.
+   Wait for the healthcheck (`ollama list`) to go green.
 
 2. **Re-pull the missing model** (if `/api/tags` returned an empty list):
 
@@ -51,9 +60,9 @@ docker stats --no-stream ollama
    docker compose exec ollama ollama pull llama3.2:3b
    ```
 
-   Operators on resource-constrained hardware may substitute `llama3.2:1b` per ADR-028 — never disable the LLM tier. Re-pull `llama3.1:8b` only if it was reactivated via `OLLAMA_STAGE_MODEL` / `OLLAMA_OVERVIEW_MODEL`.
+   Operators on resource-constrained hardware may substitute `llama3.2:1b`. Re-pull `llama3.1:8b` only if it was reactivated via `OLLAMA_STAGE_MODEL` / `OLLAMA_OVERVIEW_MODEL`.
 
-3. **Replay failed Messenger messages** once Ollama is healthy:
+3. **Replay failed Messenger messages**, if any. Most AI passes are skipped gracefully and never reach the failed transport, but a transient error mid-call can:
 
    ```bash
    docker compose exec php bin/console messenger:failed:show
@@ -62,17 +71,19 @@ docker stats --no-stream ollama
 
 4. **If the OS killed Ollama for OOM**, free RAM before restarting (see `redis-out-of-memory.md` for Redis pressure) and consider lowering Valhalla or worker count temporarily.
 
-5. **As a deployment-level mitigation**, note that `/api/health` stays HTTP 200 on an Ollama-only outage, so Coolify's probe will **not** trip. To gate routing on the LLM tier (maintenance page rather than a half-broken flow), watch `deps.ollama_chat.status` explicitly via Uptime Kuma rather than the aggregate HTTP status.
+5. **Intentionally running without AI?** Set `OLLAMA_ENABLED=0` on the API workers **and** `NEXT_PUBLIC_AI_ENABLED=0` on the PWA build — the two must mirror each other. The health probe then omits the Ollama keys and the PWA hides AI features outright (no "unavailable" notice). Flipping the front flag requires a **front rebuild** (`NEXT_PUBLIC_*` is build-time).
 
 ## Post-action
 
 - `curl http://ollama:11434/api/tags` lists `llama3.2:3b` (it appears once probed/loaded on demand).
 - `/api/health` shows `deps.ollama_chat.status: "ok"` for two consecutive probes.
+- The PWA AI bubble is active again and the Acte 3 "AI unavailable" notice is gone.
 - Replay successful — `failed` transport empty.
 - If a model was re-pulled, note the size and time in the incident issue (network bandwidth cost on Oracle).
 - If this is the second occurrence in 7 d, open an issue to investigate persistent memory growth in Ollama.
 
 ## References
 
-- ADR-028 — Ollama/LLaMA integration (hard dependency, no graceful fallback)
+- ADR-028 — Ollama/LLaMA integration ("Decision Update — Degraded Mode Re-instated", Sprint 35.4)
 - ADR-027 — Gate mechanism and two-phase pipeline
+- Issue #304 — explicit degraded mode (front gating + API `critical` logging)

--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -610,7 +610,8 @@
     "errorUnavailable": "The AI assistant is temporarily unavailable. Try again later.",
     "errorGeneric": "Something went wrong. Please try again later.",
     "fullAnalysisHint": "This change requires a brand-new full analysis.",
-    "relaunchAnalysis": "Relaunch analysis"
+    "relaunchAnalysis": "Relaunch analysis",
+    "unavailableTitle": "AI assistant unavailable"
   },
   "chat": {
     "offline": {
@@ -655,6 +656,11 @@
     "applying": "Applying…",
     "unavailable": "AI assistant coming soon.",
     "applyFailed": "Failed to apply the suggestion. Please retry."
+  },
+  "aiUnavailable": {
+    "analysis": "AI analysis unavailable: the AI service is currently offline.",
+    "refinement": "AI assistant unavailable, try again later.",
+    "chat": "AI assistant unavailable."
   },
   "errors": {
     "networkError": "Network error. Please check your connection.",

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -610,7 +610,8 @@
     "errorUnavailable": "L'assistant IA est temporairement indisponible. Réessayez plus tard.",
     "errorGeneric": "Une erreur est survenue. Réessayez plus tard.",
     "fullAnalysisHint": "Cette modification nécessite une nouvelle analyse complète.",
-    "relaunchAnalysis": "Relancer l'analyse"
+    "relaunchAnalysis": "Relancer l'analyse",
+    "unavailableTitle": "Assistant IA indisponible"
   },
   "chat": {
     "offline": {
@@ -655,6 +656,11 @@
     "applying": "Application…",
     "unavailable": "Assistant IA bientôt disponible.",
     "applyFailed": "Impossible d'appliquer la suggestion. Réessayez."
+  },
+  "aiUnavailable": {
+    "analysis": "Analyse IA indisponible : le service IA est actuellement hors ligne.",
+    "refinement": "Assistant IA indisponible, réessayez plus tard.",
+    "chat": "Assistant IA indisponible."
   },
   "errors": {
     "networkError": "Erreur réseau. Vérifiez votre connexion.",

--- a/pwa/src/app/trips/new/page.tsx
+++ b/pwa/src/app/trips/new/page.tsx
@@ -45,6 +45,7 @@ function WizardContent() {
   const currentStep = useUiStore((s) => s.currentStep);
   const completedSteps = useUiStore((s) => s.completedSteps);
   const goToStep = useUiStore((s) => s.goToStep);
+  const aiCapability = useUiStore((s) => s.aiCapability);
   const tripId = useTripStore((s) => s.trip?.id ?? null);
 
   const requestedStep = useMemo<WizardStepId | null>(() => {
@@ -158,12 +159,19 @@ function WizardContent() {
       <div id="wizard-content">
         {/* Step 2 ("Aperçu") embeds the single-shot AI refinement card
             (issue #393). The slot is forwarded to {@link TripPreview} so the
-            card sits between the stages list and the launch CTA. The card is
-            rendered unconditionally — TripPlanner only mounts the preview
-            UI when the wizard is on step 2, so the slot is naturally scoped.
+            card sits between the stages list and the launch CTA. Gated on AI
+            availability (#304): hidden when AI is off by config, disabled with
+            an explicit notice when the tier is enabled but unreachable.
             TODO(#309): wire the `onApply` handler to the chat-IA endpoint
             (sprint 31) once it ships. */}
-        <TripPlanner hideStepper previewSlot={<AiRefinementCard />} />
+        <TripPlanner
+          hideStepper
+          previewSlot={
+            aiCapability.enabled ? (
+              <AiRefinementCard unavailable={!aiCapability.available} />
+            ) : undefined
+          }
+        />
       </div>
     </div>
   );

--- a/pwa/src/components/ai-bubble.tsx
+++ b/pwa/src/components/ai-bubble.tsx
@@ -43,6 +43,7 @@ export function AiBubble() {
   const setCurrentContext = useUiStore((s) => s.setCurrentContext);
 
   const trip = useTripStore((s) => s.trip);
+  const aiCapability = useUiStore((s) => s.aiCapability);
 
   useEffect(() => {
     setCurrentContext({ currentStage: activeDayNumber ?? null });
@@ -55,32 +56,46 @@ export function AiBubble() {
   };
 
   if (!trip || isAnalysisPhaseActive) return null;
+  // AI disabled by config (NEXT_PUBLIC_AI_ENABLED=0) — hide the assistant entirely.
+  if (!aiCapability.enabled) return null;
+
+  // Disabled affordance when the network is down OR the (enabled) AI tier is
+  // unreachable: same visual treatment, distinct title + data attribute (#304).
+  const isAiDown = !aiCapability.available;
+  const isUnavailable = !isOnline || isAiDown;
 
   return (
     <>
       <button
         type="button"
-        onClick={isOnline ? handleToggle : undefined}
-        aria-disabled={!isOnline}
+        onClick={isUnavailable ? undefined : handleToggle}
+        aria-disabled={isUnavailable}
         aria-label={isBubbleOpen ? t("closeAria") : t("openAria")}
         aria-expanded={isBubbleOpen}
         aria-controls="ai-chat-panel"
         data-testid="ai-bubble"
         data-open={isBubbleOpen || undefined}
         data-offline={!isOnline || undefined}
-        title={!isOnline ? tOffline("label") : undefined}
+        data-ai-down={(isOnline && isAiDown) || undefined}
+        title={
+          !isOnline
+            ? tOffline("label")
+            : isAiDown
+              ? t("unavailableTitle")
+              : undefined
+        }
         className={cn(
           "fixed bottom-6 right-6 z-30 inline-flex items-center justify-center",
           "h-14 w-14 rounded-full bg-brand text-white shadow-lg",
           "hover:bg-brand-hover transition-transform hover:scale-105",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-hover focus-visible:ring-offset-2",
-          !isOnline &&
+          isUnavailable &&
             "cursor-not-allowed opacity-60 hover:scale-100 hover:bg-brand",
         )}
       >
         <Sparkles className="h-6 w-6" aria-hidden="true" />
         {!isOnline && <ChatOfflineBadge />}
-        {isOnline && !hasSeenBubble && (
+        {isOnline && !isAiDown && !hasSeenBubble && (
           <span
             data-testid="ai-bubble-badge"
             className={cn(

--- a/pwa/src/components/ai-refinement-card.tsx
+++ b/pwa/src/components/ai-refinement-card.tsx
@@ -6,6 +6,7 @@ import { toast } from "@/components/ui/sonner";
 import { Sparkles, Loader2, Eraser, Send } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { AiUnavailableNotice } from "@/components/ai-unavailable-notice";
 import { cn } from "@/lib/utils";
 
 /**
@@ -34,6 +35,11 @@ interface AiRefinementCardProps {
    * recomputation or when the trip is locked / offline).
    */
   disabled?: boolean;
+  /**
+   * When `true`, the AI tier is enabled but unreachable (#304): the card is
+   * disabled and an explicit "unavailable" notice is shown inline.
+   */
+  unavailable?: boolean;
   className?: string;
 }
 
@@ -57,6 +63,7 @@ interface AiRefinementCardProps {
 export function AiRefinementCard({
   onApply,
   disabled = false,
+  unavailable = false,
   className,
 }: AiRefinementCardProps) {
   const t = useTranslations("aiRefinement");
@@ -65,10 +72,11 @@ export function AiRefinementCard({
   const [suggestion, setSuggestion] = useState("");
   const [isApplying, setIsApplying] = useState(false);
 
+  const isDisabled = disabled || unavailable;
   const trimmed = suggestion.trim();
   const remaining = MAX_SUGGESTION_LENGTH - suggestion.length;
-  const canApply = trimmed.length > 0 && !isApplying && !disabled;
-  const canClear = suggestion.length > 0 && !isApplying && !disabled;
+  const canApply = trimmed.length > 0 && !isApplying && !isDisabled;
+  const canClear = suggestion.length > 0 && !isApplying && !isDisabled;
 
   const handleClear = useCallback(() => {
     setSuggestion("");
@@ -123,6 +131,7 @@ export function AiRefinementCard({
         </p>
       </CardHeader>
       <CardContent className="space-y-3">
+        {unavailable && <AiUnavailableNotice context="refinement" />}
         <label htmlFor={textareaId} className="sr-only">
           {t("textareaLabel")}
         </label>
@@ -136,7 +145,7 @@ export function AiRefinementCard({
           maxLength={MAX_SUGGESTION_LENGTH}
           placeholder={t("placeholder")}
           aria-describedby={`${helperId} ${helperId}-counter`}
-          disabled={disabled || isApplying}
+          disabled={isDisabled || isApplying}
           data-testid="ai-refinement-textarea"
           className={cn(
             "w-full resize-y rounded-md border border-input bg-background px-3 py-2 text-sm shadow-xs",

--- a/pwa/src/components/ai-unavailable-notice.tsx
+++ b/pwa/src/components/ai-unavailable-notice.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { CloudOff } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Discreet inline notice shown when the AI tier is enabled but unreachable
+ * (explicit degraded mode, #304). Surfaces the outage instead of silently
+ * dropping the AI-driven feature. Used by the Acte 3 analysis zone and the
+ * refinement card; the chat bubble conveys the same state via its disabled
+ * affordance + title.
+ */
+export function AiUnavailableNotice({
+  context = "analysis",
+  className,
+}: {
+  context?: "analysis" | "refinement" | "chat";
+  className?: string;
+}) {
+  const t = useTranslations("aiUnavailable");
+
+  return (
+    <div
+      role="alert"
+      data-testid="ai-unavailable-notice"
+      className={cn(
+        "flex items-center gap-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800",
+        "dark:border-amber-900 dark:bg-amber-950 dark:text-amber-200",
+        className,
+      )}
+    >
+      <CloudOff className="h-4 w-4 shrink-0" aria-hidden="true" />
+      <span>{t(context)}</span>
+    </div>
+  );
+}

--- a/pwa/src/components/trip-planner.tsx
+++ b/pwa/src/components/trip-planner.tsx
@@ -19,6 +19,7 @@ import { TripPreview } from "@/components/trip-preview";
 import { ProcessingProgress } from "@/components/processing-progress";
 import { TripSummary } from "@/components/trip-summary";
 import { TripAiOverview } from "@/components/trip-ai-overview";
+import { AiUnavailableNotice } from "@/components/ai-unavailable-notice";
 import { TripHeader } from "@/components/trip-header";
 import { AiBubble } from "@/components/ai-bubble";
 import { StageProgressBar } from "@/components/stage-progress-bar";
@@ -44,6 +45,7 @@ import { useTripStore } from "@/store/trip-store";
 import { useUiStore } from "@/store/ui-store";
 import { useOfflineStore } from "@/store/offline-store";
 import { useSwipe } from "@/hooks/use-swipe";
+import { fetchAiAvailability } from "@/lib/ai-availability";
 import {
   MEAL_COST_MIN,
   MEAL_COST_MAX,
@@ -134,6 +136,23 @@ export function TripPlanner({
   const resetStepper = useUiStore((s) => s.resetStepper);
   const hasAnalysisStarted = useUiStore((s) => s.hasAnalysisStarted);
   const isAnalysisPhaseActive = useUiStore((s) => s.isAnalysisPhaseActive);
+  const aiEnabled = useUiStore((s) => s.aiCapability.enabled);
+  const aiAvailable = useUiStore((s) => s.aiCapability.available);
+  const setAiAvailable = useUiStore((s) => s.setAiAvailable);
+
+  // Probe the LLM tier once on mount so AI features can be gated explicitly when it
+  // is enabled but unreachable (#304); no network call at all when AI is off.
+  useEffect(() => {
+    if (!aiEnabled) return;
+    let cancelled = false;
+    void fetchAiAvailability().then((available) => {
+      if (!cancelled) setAiAvailable(available);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [aiEnabled, setAiAvailable]);
+
   const activeStages = useMemo(
     () => stages.filter((s) => !s.isRestDay),
     [stages],
@@ -214,6 +233,13 @@ export function TripPlanner({
         useTripStore.getState().clearTrip();
       }
     };
+    const onSetAiCapability = (e: Event) => {
+      const detail = (
+        e as CustomEvent<{ enabled: boolean; available: boolean }>
+      ).detail;
+      if (detail) useUiStore.getState().setAiCapability(detail);
+    };
+    window.addEventListener("__test_set_ai_capability", onSetAiCapability);
     window.addEventListener("__test_set_processing", onProcessing);
     window.addEventListener("__test_set_analysis_started", onAnalysisStarted);
     window.addEventListener("__test_clear_ai_overview", onClearAiOverview);
@@ -234,6 +260,7 @@ export function TripPlanner({
         onSetActiveDayNumber,
       );
       window.removeEventListener("__test_set_trip_id", onSetTripId);
+      window.removeEventListener("__test_set_ai_capability", onSetAiCapability);
     };
   }, []);
 
@@ -636,6 +663,9 @@ export function TripPlanner({
                   silently when the LLM pipeline is disabled or did not produce
                   an overview. Placed above the stage timeline so it gives the
                   user a high-level view before they dive into per-stage data. */}
+              {aiEnabled && !aiAvailable && (
+                <AiUnavailableNotice context="analysis" />
+              )}
               <TripAiOverview />
 
               {/* Sentinel — marks the natural position of the progress bar in the

--- a/pwa/src/hooks/use-mercure.ts
+++ b/pwa/src/hooks/use-mercure.ts
@@ -9,6 +9,7 @@ import { useUiStore } from "@/store/ui-store";
 import { useOfflineStore } from "@/store/offline-store";
 import type { SavedTrip } from "@/store/offline-store";
 import { reverseGeocode } from "@/lib/geocode/client";
+import { fetchAiAvailability } from "@/lib/ai-availability";
 import { toast } from "@/components/ui/sonner";
 import { DEFAULT_ACCOMMODATION_RADIUS_KM } from "@/lib/accommodation-constants";
 import type { StageData } from "@/lib/validation/schemas";
@@ -487,6 +488,19 @@ function dispatchEvent(event: MercureEvent): void {
         event.data.aiOverview,
       );
       store.setAiOverview(parsedOverview.success ? parsedOverview.data : null);
+      // If AI is enabled and looked reachable at mount but no overview arrived, the
+      // tier may have gone down mid-Phase 2. Re-probe so the UI can explicitly flag
+      // the outage instead of silently showing no analysis (#304).
+      const ui = useUiStore.getState();
+      if (
+        ui.aiCapability.enabled &&
+        ui.aiCapability.available &&
+        !parsedOverview.success
+      ) {
+        void fetchAiAvailability().then((available) =>
+          ui.setAiAvailable(available),
+        );
+      }
       useUiStore.getState().setAnalysisProgress(null);
       useUiStore.getState().setAnalysisStarted(true);
       useUiStore.getState().setAnalysisPhaseActive(false);

--- a/pwa/src/lib/ai-availability.ts
+++ b/pwa/src/lib/ai-availability.ts
@@ -1,0 +1,43 @@
+/**
+ * Minimal shape of the `/api/health` readiness payload this module relies on.
+ * The endpoint is a plain controller (not an API Platform resource), so it is
+ * absent from the generated OpenAPI schema — hence this local type rather than
+ * `components["schemas"][...]`.
+ */
+interface HealthResponse {
+  deps?: {
+    ollama_chat?: { status?: string };
+  };
+}
+
+/**
+ * Runtime AI-tier availability probe (#304).
+ *
+ * Orthogonal to the build-time {@link AI_ENABLED} flag (which decides whether AI
+ * features should exist at all): this answers "is the LLM tier reachable right
+ * now?" by reading `/api/health` → `deps.ollama_chat.status`. When the backend
+ * runs with `OLLAMA_ENABLED=0` it omits the key entirely, which resolves to
+ * unavailable (covers a front-enabled / API-disabled misconfiguration).
+ *
+ * Failure-open: a network/parse error — or a 429 from the per-IP readiness rate
+ * limiter — resolves to `true`, so a transient health hiccup never hides a
+ * working feature. A genuine outage still surfaces reactively via the 503 the
+ * chat endpoint returns.
+ */
+export async function fetchAiAvailability(): Promise<boolean> {
+  try {
+    const res = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL ?? ""}/api/health`,
+      { headers: { Accept: "application/json" } },
+    );
+
+    // The readiness probe is rate-limited per IP; a 429 is not a real outage.
+    if (res.status === 429) return true;
+
+    const body = (await res.json()) as HealthResponse;
+
+    return body.deps?.ollama_chat?.status === "ok";
+  } catch {
+    return true;
+  }
+}

--- a/pwa/src/lib/constants.ts
+++ b/pwa/src/lib/constants.ts
@@ -38,3 +38,12 @@ export const SCRAPE_DEBOUNCE_MS = 500;
 
 /** Backend API base URL */
 export const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "https://localhost";
+
+/**
+ * Whether the AI tier is enabled for this build (mirrors backend `OLLAMA_ENABLED`).
+ * Build-time only — `NEXT_PUBLIC_*` is inlined, so flipping it requires a front
+ * rebuild. Defaults to enabled; set `NEXT_PUBLIC_AI_ENABLED=0` to hide the AI
+ * features outright (no network call). When enabled, runtime availability is read
+ * from `/api/health` (see `ai-availability.ts`).
+ */
+export const AI_ENABLED = process.env.NEXT_PUBLIC_AI_ENABLED !== "0";

--- a/pwa/src/store/ui-store.ts
+++ b/pwa/src/store/ui-store.ts
@@ -3,6 +3,7 @@
 import { create } from "zustand";
 import { immer } from "zustand/middleware/immer";
 import { enableMapSet } from "immer";
+import { AI_ENABLED } from "@/lib/constants";
 
 // Required for Immer to allow mutating Set/Map drafts (used by completedSteps).
 enableMapSet();
@@ -173,6 +174,14 @@ interface UiState {
    * Persisted by {@link toggleBubble} the first time the panel opens.
    */
   hasSeenBubble: boolean;
+  /**
+   * AI tier availability driving the explicit degraded-mode gating (#304).
+   * - `enabled`: build-time config (`AI_ENABLED`); when false, AI features are hidden.
+   * - `available`: runtime reachability of the LLM tier, read from `/api/health`
+   *   (`deps.ollama_chat`). Starts optimistic (`true`) to avoid a disabled→enabled
+   *   flash; flipped to `false` only once an outage is confirmed.
+   */
+  aiCapability: { enabled: boolean; available: boolean };
 
   setProcessing: (value: boolean) => void;
   setAccommodationScanning: (value: boolean) => void;
@@ -233,6 +242,13 @@ interface UiState {
   clearHistory: () => void;
   /** Flip the in-flight indicator that drives the typing dots. */
   setChatSending: (value: boolean) => void;
+  /** Update the runtime AI availability (from the `/api/health` probe, #304). */
+  setAiAvailable: (value: boolean) => void;
+  /** Replace the whole AI capability — E2E override hook for the 3 states (#304). */
+  setAiCapability: (capability: {
+    enabled: boolean;
+    available: boolean;
+  }) => void;
 }
 
 const BUBBLE_SEEN_STORAGE_KEY = "btp.ai-bubble.seen";
@@ -307,6 +323,7 @@ export const useUiStore = create<UiState>()(
     currentContext: { currentStage: null },
     isChatSending: false,
     hasSeenBubble: readBubbleSeenFromStorage(),
+    aiCapability: { enabled: AI_ENABLED, available: true },
 
     setProcessing: (value) =>
       set((state) => {
@@ -469,6 +486,16 @@ export const useUiStore = create<UiState>()(
     setChatSending: (value) =>
       set((state) => {
         state.isChatSending = value;
+      }),
+
+    setAiAvailable: (value) =>
+      set((state) => {
+        state.aiCapability.available = value;
+      }),
+
+    setAiCapability: (capability) =>
+      set((state) => {
+        state.aiCapability = capability;
       }),
   })),
 );

--- a/pwa/tests/fixtures/api-mocks.ts
+++ b/pwa/tests/fixtures/api-mocks.ts
@@ -11,6 +11,12 @@ export interface MockApiOptions {
    * existing specs are not retroactively failed.
    */
   assertNoRuntimeErrors?: boolean;
+  /**
+   * Runtime AI-tier availability surfaced by the mocked `/api/health`
+   * (`deps.ollama_chat.status`). Defaults to reachable so existing AI specs
+   * (bubble, chat) keep passing; set `false` to exercise the degraded mode (#304).
+   */
+  aiAvailable?: boolean;
 }
 
 const TRIP_ID = "test-trip-abc-123";
@@ -45,6 +51,7 @@ export async function mockAllApis(
     postTripBody,
     deleteStageFail = false,
     addStageFail = false,
+    aiAvailable = true,
   } = options;
 
   // POST /auth/refresh — return fake JWT so AuthGuard's silentRefresh succeeds
@@ -54,6 +61,29 @@ export async function mockAllApis(
       status: 200,
       contentType: "application/json",
       body: JSON.stringify({ token: FAKE_JWT_TOKEN }),
+    });
+  });
+
+  // GET /api/health — readiness probe the PWA reads to gate AI features (#304).
+  // `aiAvailable` toggles deps.ollama_chat between "ok"/"down"; the aggregate
+  // status stays "ok" either way (Ollama is excluded from the required set).
+  await page.route("**/api/health", (route, request) => {
+    if (request.method() !== "GET") return route.fallback();
+    const ollamaStatus = aiAvailable ? "ok" : "down";
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        status: "ok",
+        deps: {
+          postgres: { status: "ok" },
+          redis: { status: "ok" },
+          mercure: { status: "ok" },
+          valhalla: { status: "ok" },
+          ollama_chat: { status: ollamaStatus },
+          ollama_analysis: { status: ollamaStatus },
+        },
+      }),
     });
   });
 

--- a/pwa/tests/mocked/ai-capabilities.spec.ts
+++ b/pwa/tests/mocked/ai-capabilities.spec.ts
@@ -1,0 +1,77 @@
+import { test, expect } from "../fixtures/base.fixture";
+
+/**
+ * Issue #304 — explicit degraded-mode gating of the AI features.
+ *
+ * `NEXT_PUBLIC_AI_ENABLED` defaults to enabled and runtime availability comes
+ * from `/api/health`. To pin all three states deterministically — and prod-safely,
+ * since the E2E build hides `window.__zustand_ui_store` — the tests drive the
+ * capability via the `__test_set_ai_capability` CustomEvent:
+ *  - enabled + reachable   → AI features active
+ *  - enabled + unreachable → features disabled with an explicit notice
+ *  - disabled by config    → features hidden (no notice)
+ */
+
+function setAiCapability(
+  page: import("@playwright/test").Page,
+  capability: { enabled: boolean; available: boolean },
+): Promise<void> {
+  return page.evaluate((detail) => {
+    window.dispatchEvent(
+      new CustomEvent("__test_set_ai_capability", { detail }),
+    );
+  }, capability);
+}
+
+test.describe("AI capabilities gating (#304)", () => {
+  test("tier reachable: the assistant is active and no unavailable notice shows", async ({
+    createFullTrip,
+    mockedPage,
+  }) => {
+    await createFullTrip();
+    await setAiCapability(mockedPage, { enabled: true, available: true });
+
+    const bubble = mockedPage.getByTestId("ai-bubble");
+    await expect(bubble).toBeVisible();
+    await expect(mockedPage.getByTestId("ai-unavailable-notice")).toHaveCount(
+      0,
+    );
+
+    // Active → clicking opens the chat panel.
+    await bubble.click();
+    await expect(mockedPage.getByTestId("ai-chat-panel")).toBeVisible();
+  });
+
+  test("tier enabled but unreachable: the assistant is disabled and the notice shows", async ({
+    createFullTrip,
+    mockedPage,
+  }) => {
+    await createFullTrip();
+    await setAiCapability(mockedPage, { enabled: true, available: false });
+
+    const bubble = mockedPage.getByTestId("ai-bubble");
+    await expect(bubble).toBeVisible();
+    await expect(bubble).toHaveAttribute("aria-disabled", "true");
+    await expect(bubble).toHaveAttribute("data-ai-down", "true");
+
+    // Disabled → a forced click must not open the panel.
+    await bubble.click({ force: true });
+    await expect(mockedPage.getByTestId("ai-chat-panel")).toHaveCount(0);
+
+    // Explicit degraded-mode notice in Acte 3 (Mon voyage).
+    await expect(mockedPage.getByTestId("ai-unavailable-notice")).toBeVisible();
+  });
+
+  test("disabled by config: AI features are hidden with no notice", async ({
+    createFullTrip,
+    mockedPage,
+  }) => {
+    await createFullTrip();
+    await setAiCapability(mockedPage, { enabled: false, available: false });
+
+    await expect(mockedPage.getByTestId("ai-bubble")).toHaveCount(0);
+    await expect(mockedPage.getByTestId("ai-unavailable-notice")).toHaveCount(
+      0,
+    );
+  });
+});


### PR DESCRIPTION
## What & why

Closes the loop on **#304** (re-opened by the Sprint 35.2 audit): the app must run **without the AI tier**, in an **explicit** degraded mode (lifting the "silent fallback" objection of #375). Implements the ADR-028 "Decision Update — Degraded Mode" contract — three states: AI off by config, AI on + reachable, AI on + unreachable.

## Changes

### Backend
- **Critical logging.** The Ollama-unreachable path now logs `critical` (was `warning`/`info`) at the five caller catch-sites (stage/overview analysis handlers, chat processor, in-ride detector + assistant) for ops alerting. `OllamaClient` keeps its low-level transport `warning`, so a single failure yields one `critical`, not two.
- **Health.** `GET /api/health` probes and surfaces `ollama_chat` / `ollama_analysis` **only when `OLLAMA_ENABLED=1`**; their absence is the "AI disabled" signal. Ollama stays out of the readiness `$required` set (unchanged) — an outage never returns a 503.

### Front
- **Signal.** `NEXT_PUBLIC_AI_ENABLED` (build-time, **defaults to enabled**; set `0` to hide AI outright with no network call). When enabled, a `GET /api/health` probe at planner mount (re-probed on `trip_ready`, so an outage mid-Phase-2 is caught) drives runtime availability via the `ui-store`.
- **Gating (3 features).** Chat bubble, refinement card (`/trips/new`), and trip analysis are **disabled with an explicit "AI unavailable" notice** when the tier is enabled-but-unreachable; hidden entirely when off. New `AiUnavailableNotice` (`role="alert"`); the bubble reuses the offline-disabled affordance with a distinct `data-ai-down` + title. Failure-open: a health hiccup never hides a working feature (the chat 503 stays the reactive net).
- No dedicated `/capabilities` endpoint — `/api/health` already carries the runtime signal (see ADR-028).

### Docs / config
- `NEXT_PUBLIC_AI_ENABLED` build-arg wired in `compose.yaml`, dev and recette.
- Rewrote the obsolete `ollama-down` runbook; annotated ADR-028; updated TRACKING.

## Tests
- **PHP (green):** `HealthControllerTest` (10) — the 3 AI states incl. the `OLLAMA_ENABLED=1` kernel-reboot path + `readinessOmitsOllamaWhenAiDisabled`; LLM unit handlers (51) asserting the new `critical` logs. `OllamaClientTest` unchanged.
- **QA (green):** PHPStan L9, php-cs-fixer, rector, tsc, ESLint, Prettier, i18n:check, markdownlint.
- **E2E:** new `ai-capabilities.spec.ts` (off / down / full), driven prod-safely by a `__test_set_ai_capability` CustomEvent (the prod E2E build hides `window.__zustand_ui_store`), plus a mocked `/api/health` in the shared fixture.

## Auto-critique
- **`NEXT_PUBLIC_AI_ENABLED` is build-time:** flipping AI on/off needs a front rebuild. Accepted as an infra decision (mirrors `OLLAMA_ENABLED`); defaults to enabled so a missing build-arg never silently hides AI, and a front/API mismatch degrades safely (features disabled, not broken).
- **`/api/health` is per-IP rate-limited (20/min, readiness):** the PWA probe shares that budget. No restart-loop risk (the Coolify probe uses its own IP), but many clients behind one NAT could 429 → failure-open (signal lost, not a false disable). Fine for the beta (<10 users, ADR-039); bump the limit or add a dedicated endpoint if usage grows.
- **In-ride `critical`:** `PoiIntentDetector` + `InRideAssistant` were `info` (they still serve a fallback narrative). Bumped for a uniform "tier down" alert as agreed; an in-ride message during an outage can emit 2 `critical` (template-fixed → Sentry-groupable).

Closes #304.

<!-- claude-review-start -->
## Claude Review

The three-state degraded-mode model (AI off by config / on+reachable / on+unreachable) is correctly implemented end-to-end. All five `critical`-log contracts are pinned by dedicated unit tests, failure-open semantics are sound throughout (`fetchAiAvailability` returns `true` on 429 or any network error), and the E2E suite covers all three states deterministically via the `__test_set_ai_capability` CustomEvent. No findings.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**No inline comments.**

---
_Reviewed commit `28b67375` — Generated with [Claude Code](https://claude.ai/code)_
<!-- claude-review-end -->