### PR TITLE
ci(claude): drop AI attribution footers from PR and review templates

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "enableAllProjectMcpServers": true,
+  "includeCoAuthoredBy": false,
   "enabledMcpjsonServers": [
     "openapi-spec"
   ],

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -271,7 +271,6 @@ jobs:
                  - [ ] Documentation is up to date
                  - [ ] Dependent tickets accounted for
               5. **Inline comments** — "Posted N inline comments." (or "No inline comments." if none)
-              6. **Footer** — "Generated with [Claude Code](https://claude.ai/code)"
 
             **IMPORTANT: This step is NOT optional.** You must ALWAYS reach this step and submit the review.
             If you created a PENDING review, you MUST submit it — an unsubmitted pending review is invisible on GitHub.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -103,7 +103,6 @@ jobs:
               - `## Test plan` (bulleted checklist)
               - `## Auto-critique` (what was verified per CLAUDE.md)
               - `Closes #${{ github.event.issue.number }}`
-              - Footer: `🤖 Generated with [Claude Code](https://claude.ai/code)`
 
             ## Step 7 — Monitor CI
 


### PR DESCRIPTION
## Summary

- Retire le footer `🤖 Generated with [Claude Code]` du template de PR cree par `@claude pick` (`claude.yml`, Step 6)
- Retire l'item `Footer — "Generated with [Claude Code]"` du body de review du bot (`claude-code-review.yml`, section E)

## Contexte

Plus aucune mention d'attribution Claude/IA ne doit apparaitre dans les artefacts du projet (commits, PR, reviews). Le comportement local est couvert par le reglage `includeCoAuthoredBy: false` ; ces deux footers etaient codes en dur dans les prompts des workflows CI et ne sont pas regis par ce reglage, d'ou cette edition.

## Test plan

- [ ] `grep -rin "generated with\|🤖" .github/workflows/` ne retourne plus aucune occurrence
- [ ] Prochaine PR creee par `@claude pick` : absence du footer
- [ ] Prochaine review du bot : absence du footer

## Auto-critique

- Changement limite a deux lignes de texte de prompt, aucune logique de workflow modifiee
- Aucune entree non fiable introduite (pas de nouveau `${{ }}` ni de `run:`)
- Numerotation de la liste de review : l'item 6 etait le dernier, sa suppression ne casse pas la sequence 1-5
