### PR TITLE
test(recette): vérif liens & ancres Markdown + make link-check (Sprint 35.3 O5)

### DIFF
--- a/.docker/uptime-kuma/README.md
+++ b/.docker/uptime-kuma/README.md
@@ -9,7 +9,7 @@
 
 Uptime Kuma is the **primary** uptime monitor for Bike Trip Planner. It runs on
 the same Coolify host as the application (Oracle Cloud Always Free VM, see
-[ADR-019](../../docs/adr/0019-hosting-coolify-oracle-cloud.md)) and provides
+[ADR-019](../../docs/adr/adr-019-deployment-infrastructure-strategy.md)) and provides
 sub-minute detection for backend and frontend outages.
 
 Because it shares the VM with the app, a host-level outage will take Uptime Kuma

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,24 @@ jobs:
       - name: Run Markdownlint
         run: markdownlint-cli2 "**/*.md" "!.claude/**" "!**/vendor/**" "!**/vendor-bin/**" "!pwa/node_modules/**"
 
+  markdown-links:
+    name: Markdown Links
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "25"
+      # Internal links/anchors only (deterministic, no network). The script uses
+      # Node built-ins only, so no dependency install is needed. The external URL
+      # probe (--external) is network-dependent and flaky, so it is NOT gated in
+      # CI: run it manually via `make link-check -- --external` (the project
+      # favours manual execution over crons, cf. lighthouse.yml / #575).
+      - name: Check Markdown links & anchors (internal)
+        run: node scripts/check-md-links.mjs
+
   symfony-security-check:
     name: Security Check
     runs-on: ubuntu-latest

--- a/.github/workflows/link-check-external.yml
+++ b/.github/workflows/link-check-external.yml
@@ -1,0 +1,24 @@
+name: Markdown Links (external)
+
+# Network-dependent job: probes every external http(s) link in the Markdown docs
+# and fails on non-2xx/3xx. Kept out of the per-PR lane (and off any cron) because
+# external endpoints are flaky and frequently 403 bots — the project favours
+# manual execution over automatic crons (cf. lighthouse.yml / #575). Run it on
+# demand to audit rotted external references; the same check runs locally via
+# `make link-check -- --external`.
+on:
+  workflow_dispatch: ~
+
+jobs:
+  markdown-links-external:
+    name: Markdown Links (external)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "25"
+      - name: Check Markdown links & anchors (internal + external)
+        run: node scripts/check-md-links.mjs --external

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,15 @@
 # (The `ollama-init` model-pull job stays behind its profile, so dev never pulls.)
 export COMPOSE_FILE ?= compose.yaml:compose.ollama.yaml:compose.dev.yaml
 
+# Forward extra CLI words after the goal (e.g. `make link-check -- --external`,
+# `make phpunit -- --filter=Foo`) into $(ARGS) and stub them as no-op goals so
+# Make does not try to build them. Only triggers for targets that read $(ARGS).
+ARGS_TARGETS := link-check phpunit test-php phpstan rector test-e2e playwright test-recette visual-test visual-update screenshots
+ifneq (,$(filter $(ARGS_TARGETS),$(firstword $(MAKECMDGOALS))))
+  ARGS := $(filter-out --,$(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS)))
+  $(eval $(ARGS):;@:)
+endif
+
 help: ## Show this help message
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n\nTargets:\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
 
@@ -73,6 +82,9 @@ hadolint: ## Run Hadolint on Dockerfiles
 
 markdownlint: ## Run Markdownlint
 	@docker run --rm -v $$(pwd):/app -w /app davidanson/markdownlint-cli2 "**/*.md" "!.claude/**" "!api/vendor/**" "!api/vendor-bin/**" "!provisioner/vendor/**" "!provisioner/vendor-bin/**" "!pwa/node_modules/**"
+
+link-check: ## Check Markdown links & anchors (internal fatal; use `make link-check -- --external` to gate on external URLs)
+	@docker run --rm -v $(CURDIR):/app -w /app node:22-slim node scripts/check-md-links.mjs $(ARGS)
 
 tsc: typescript-check ## Alias for "typescript-check"
 

--- a/docs/runbooks/uptime-monitoring.md
+++ b/docs/runbooks/uptime-monitoring.md
@@ -22,7 +22,7 @@ Target (post-beta) two-layer uptime monitoring for Bike Trip Planner production:
 ## Why two layers?
 
 Uptime Kuma runs on the same Oracle Cloud Always Free VM as the application
-(see [ADR-019](../adr/0019-hosting-coolify-oracle-cloud.md)). If the VM goes
+(see [ADR-019](../adr/adr-019-deployment-infrastructure-strategy.md)). If the VM goes
 down — kernel panic, network ACL change, Oracle reclaims the instance — Uptime
 Kuma goes down with it and emits no alert. UptimeRobot's free tier runs from
 external probes; a single HTTP monitor is enough to detect a host-level outage

--- a/scripts/check-md-links.mjs
+++ b/scripts/check-md-links.mjs
@@ -1,0 +1,285 @@
+#!/usr/bin/env node
+// Markdown link & anchor checker (Node built-ins only: fs, path, fetch).
+//
+// - Internal relative links (`](./x.md)`, `](../adr/y.md)`, `](path#anchor)`,
+//   `](#anchor)`): the target file must exist; if a `#anchor` is present, the
+//   target file must contain a heading whose GitHub slug matches. These
+//   breakages are FATAL (exit 1).
+// - External `http(s)://` links: best-effort `fetch` (GET, ~8s timeout,
+//   following redirects). Non-2xx/3xx are reported but NON-FATAL by default
+//   (network flakiness); pass `--external` to include them in the exit code.
+//
+// Usage:
+//   node scripts/check-md-links.mjs [--external] [root]
+//
+// Scope: every `*.md` in the repo EXCEPT node_modules, vendor*, .claude,
+// .features-gen and *-report directories.
+
+import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { join, dirname, resolve, relative, extname } from 'node:path';
+
+const ROOT = resolve(process.argv.find((a, i) => i >= 2 && !a.startsWith('--')) ?? '.');
+const CHECK_EXTERNAL = process.argv.includes('--external');
+const EXTERNAL_TIMEOUT_MS = 8000;
+
+const SKIP_DIRS = new Set(['node_modules', '.git', '.claude', '.features-gen']);
+const SKIP_DIR_RE = /(^|\/)(vendor|vendor-bin)$|-report$/;
+
+/** Recursively collect in-scope Markdown files. */
+function collectMarkdown(dir, acc = []) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    const rel = relative(ROOT, full);
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name) || SKIP_DIR_RE.test(rel)) continue;
+      collectMarkdown(full, acc);
+    } else if (entry.isFile() && entry.name.toLowerCase().endsWith('.md')) {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+/**
+ * GitHub heading -> anchor slug.
+ * Lowercase, strip punctuation (keep letters/digits/space/hyphen, Unicode-aware),
+ * spaces -> hyphens. Duplicates are de-duplicated with -1, -2, ... by the caller.
+ */
+function slugify(heading) {
+  return heading
+    .trim()
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\s-]/gu, '')
+    .replace(/\s/g, '-');
+}
+
+/** Extract heading anchors (with GitHub de-duplication) from Markdown content. */
+function extractAnchors(content) {
+  const anchors = new Set();
+  const counts = new Map();
+  let inFence = false;
+  let fenceMarker = '';
+  for (const rawLine of content.split('\n')) {
+    const line = rawLine.replace(/\r$/, '');
+    const fence = line.match(/^\s*(```+|~~~+)/);
+    if (fence) {
+      if (!inFence) {
+        inFence = true;
+        fenceMarker = fence[1][0];
+      } else if (fence[1][0] === fenceMarker) {
+        inFence = false;
+      }
+      continue;
+    }
+    if (inFence) continue;
+    const m = line.match(/^#{1,6}\s+(.*?)\s*#*\s*$/);
+    if (!m) continue;
+    // Strip inline markdown (links, emphasis, code) the way GitHub does for slugs.
+    const text = m[1]
+      .replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1')
+      .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+      .replace(/\[([^\]]*)\]\[[^\]]*\]/g, '$1')
+      .replace(/`([^`]*)`/g, '$1')
+      .replace(/[*_~]/g, '');
+    let slug = slugify(text);
+    if (counts.has(slug)) {
+      const n = counts.get(slug) + 1;
+      counts.set(slug, n);
+      slug = `${slug}-${n}`;
+    } else {
+      counts.set(slug, 0);
+    }
+    anchors.add(slug);
+  }
+  return anchors;
+}
+
+/** Parse Markdown links, skipping fenced/inline code. Returns {url,line}. */
+function extractLinks(content) {
+  const links = [];
+  const lines = content.split('\n');
+  let inFence = false;
+  let fenceMarker = '';
+  // Matches [text](target) and [text](target "title"); ignores images via leading-! check.
+  const linkRe = /(!?)\[(?:[^\]]*)\]\(\s*(<[^>]*>|[^()\s]+(?:\([^()]*\)[^()\s]*)*)\s*(?:"[^"]*"|'[^']*')?\s*\)/g;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].replace(/\r$/, '');
+    const fence = line.match(/^\s*(```+|~~~+)/);
+    if (fence) {
+      if (!inFence) {
+        inFence = true;
+        fenceMarker = fence[1][0];
+      } else if (fence[1][0] === fenceMarker) {
+        inFence = false;
+      }
+      continue;
+    }
+    if (inFence) continue;
+    // Drop inline-code spans so links inside backticks are ignored.
+    const scrubbed = line.replace(/`[^`]*`/g, (s) => ' '.repeat(s.length));
+    let m;
+    linkRe.lastIndex = 0;
+    while ((m = linkRe.exec(scrubbed)) !== null) {
+      if (m[1] === '!') continue; // image, not a link
+      let url = m[2].trim();
+      if (url.startsWith('<') && url.endsWith('>')) url = url.slice(1, -1).trim();
+      if (url) links.push({ url, line: i + 1 });
+    }
+  }
+  return links;
+}
+
+/** Best-effort external HEAD/GET probe. Returns {ok, status, error}. */
+async function probeExternal(url) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), EXTERNAL_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, {
+      method: 'GET',
+      redirect: 'follow',
+      signal: controller.signal,
+      headers: { 'user-agent': 'bike-trip-planner-link-check/1.0' },
+    });
+    return { ok: res.status >= 200 && res.status < 400, status: res.status };
+  } catch (err) {
+    return { ok: false, status: 0, error: err.name === 'AbortError' ? 'timeout' : err.message };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+const anchorCache = new Map();
+function anchorsFor(filePath) {
+  if (!anchorCache.has(filePath)) {
+    anchorCache.set(filePath, extractAnchors(readFileSync(filePath, 'utf8')));
+  }
+  return anchorCache.get(filePath);
+}
+
+async function main() {
+  const files = collectMarkdown(ROOT).sort();
+  const internalFailures = []; // {file, line, url, reason}
+  const externalFailures = []; // {file, line, url, status, error}
+  const externalQueue = []; // {file, line, url}
+
+  for (const file of files) {
+    const content = readFileSync(file, 'utf8');
+    const selfAnchors = extractAnchors(content);
+    for (const { url, line } of extractLinks(content)) {
+      if (/^(https?:)?\/\//i.test(url)) {
+        if (url.startsWith('http://') || url.startsWith('https://')) {
+          externalQueue.push({ file, line, url });
+        }
+        continue; // protocol-relative or other schemes: skip
+      }
+      if (/^(mailto:|tel:|#!)/i.test(url)) continue;
+
+      // Pure in-document anchor.
+      if (url.startsWith('#')) {
+        const anchor = decodeURIComponent(url.slice(1));
+        if (anchor && !selfAnchors.has(anchor)) {
+          internalFailures.push({ file, line, url, reason: `ancre absente dans le fichier (#${anchor})` });
+        }
+        continue;
+      }
+
+      // Relative link, possibly with #anchor.
+      const hashIdx = url.indexOf('#');
+      const rawPath = hashIdx === -1 ? url : url.slice(0, hashIdx);
+      const anchor = hashIdx === -1 ? '' : decodeURIComponent(url.slice(hashIdx + 1));
+      const decodedPath = decodeURIComponent(rawPath);
+      const target = resolve(dirname(file), decodedPath);
+
+      if (!existsSync(target)) {
+        internalFailures.push({ file, line, url, reason: `cible introuvable (${decodedPath})` });
+        continue;
+      }
+      if (anchor) {
+        let stat;
+        try {
+          stat = statSync(target);
+        } catch {
+          stat = null;
+        }
+        if (!stat || stat.isDirectory()) {
+          internalFailures.push({ file, line, url, reason: `ancre sur une cible non-fichier (${decodedPath})` });
+          continue;
+        }
+        if (extname(target).toLowerCase() === '.md') {
+          if (!anchorsFor(target).has(anchor)) {
+            internalFailures.push({ file, line, url, reason: `ancre absente dans ${decodedPath} (#${anchor})` });
+          }
+        }
+        // Non-markdown target with anchor: existence is enough.
+      }
+    }
+  }
+
+  // External probes (best-effort, concurrency-limited). Skipped unless --external
+  // so the default run — and the per-PR CI job — stays deterministic and offline.
+  if (CHECK_EXTERNAL && externalQueue.length) {
+    const seen = new Map();
+    const CONCURRENCY = 8;
+    let idx = 0;
+    async function worker() {
+      while (idx < externalQueue.length) {
+        const item = externalQueue[idx++];
+        let result = seen.get(item.url);
+        if (!result) {
+          result = await probeExternal(item.url);
+          seen.set(item.url, result);
+        }
+        if (!result.ok) {
+          externalFailures.push({ ...item, status: result.status, error: result.error });
+        }
+      }
+    }
+    await Promise.all(Array.from({ length: Math.min(CONCURRENCY, externalQueue.length) }, worker));
+  }
+
+  // Report.
+  const byFile = new Map();
+  for (const f of internalFailures) {
+    if (!byFile.has(f.file)) byFile.set(f.file, []);
+    byFile.get(f.file).push(f);
+  }
+  if (internalFailures.length) {
+    console.log('\nLiens/ancres internes cassés:\n');
+    for (const [file, items] of [...byFile].sort()) {
+      console.log(`  ${relative(ROOT, file)}`);
+      for (const it of items.sort((a, b) => a.line - b.line)) {
+        console.log(`    L${it.line}: ${it.url} -> ${it.reason}`);
+      }
+    }
+  } else {
+    console.log('\nLiens/ancres internes: OK');
+  }
+
+  if (externalFailures.length) {
+    console.log('\nLiens externes non-2xx/3xx (best-effort):\n');
+    for (const it of externalFailures.sort((a, b) => `${a.file}${a.line}`.localeCompare(`${b.file}${b.line}`))) {
+      const detail = it.error ? it.error : `HTTP ${it.status}`;
+      console.log(`  ${relative(ROOT, it.file)} L${it.line}: ${it.url} -> ${detail}`);
+    }
+  } else if (CHECK_EXTERNAL && externalQueue.length) {
+    console.log('\nLiens externes: OK');
+  }
+
+  console.log('\nRésumé:');
+  console.log(`  fichiers scannés       : ${files.length}`);
+  console.log(
+    `  liens externes         : ${externalQueue.length}${CHECK_EXTERNAL ? " (probés)" : " (trouvés, probe ignoré — --external pour vérifier)"}`,
+  );
+  console.log(`  cassures internes      : ${internalFailures.length}`);
+  if (CHECK_EXTERNAL) {
+    console.log(`  externes non-2xx/3xx   : ${externalFailures.length}`);
+  }
+
+  const failed = internalFailures.length > 0 || (CHECK_EXTERNAL && externalFailures.length > 0);
+  process.exit(failed ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(2);
+});


### PR DESCRIPTION
## Sprint 35.3 — Ordre 5 : vérif liens & ancres (docs/README/ADR/rapport recette)

Aucun lien mort (404) ni ancre disparue dans la doc Markdown, vérifiable via un outil reproductible.

### Livrables
- **`scripts/check-md-links.mjs`** — Node pur (built-ins `fs`/`path`/`fetch`, **0 dépendance**). Slug GitHub Unicode-aware (minuscule, ponctuation supprimée, espaces→tirets, dédup `-1/-2`), URL-decode des ancres (`%C3%A9`), ignore fences/inline-code/images. **Liens internes + ancres = fatal** (exit 1) ; **liens externes = probe best-effort, opt-in `--external`** (gate le code de sortie).
- **`make link-check`** — exécute le script via `node:22-slim` jetable (aucune dépendance hôte). `make link-check -- --external` pour l'audit externe complet (propagation `$(ARGS)` ajoutée).
- **CI** — job `markdown-links` (`ci.yml`, per-PR, **interne déterministe + offline**) ; vérif externe sortie en workflow manuel `link-check-external.yml` (`workflow_dispatch`) car flaky (403 anti-bot, 404 historiques).

### Cassures internes corrigées (2)
ADR renommé `0019-hosting-coolify-oracle-cloud.md` → `adr-019-deployment-infrastructure-strategy.md` :
- `.docker/uptime-kuma/README.md:12`
- `docs/runbooks/uptime-monitoring.md:25`

### Vérifications (sorties réelles)
- `node scripts/check-md-links.mjs` (défaut, `--network none`) → **86 fichiers, 0 cassure interne, exit 0, offline en ~1,4s**.
- `--external` → exit 1 (gate sur les 404 réels).
- `make markdownlint` → 0 erreur (86 fichiers). `node --check` → OK.

### Externes non-2xx connus (laissés, hors périmètre fatal)
4 vrais 404 (citations historiques d'ADR vers repos/docs tiers déplacés : `docs.pmnd.rs/zustand/...persisting`, `docker-overpass-api`, `doctrine-orm/3.4/index`, `ollama/...modelfile#parameter`) + 5 faux positifs 403 anti-bot (medium.com, support.strava.com, claude.ai/code).

### Auto-critique
- **Probe externe gaté derrière `--external`** : le job CI per-PR reste offline et rapide (le 1er jet probait 604 URLs à chaque PR malgré un commentaire "no network" — corrigé).
- **404 historiques non corrigés** : volontaire (citations d'archive dans des ADR). Surfacés par `--external`/le workflow manuel, pas bloquants.
- **Périmètre** : Markdown uniquement (pas les liens dans le code/JSX). Suffisant pour la doc/ADR/recette visée par l'Ordre.
- Pas de nouvelle dépendance ; `make test`/`typegen`/`install` non lancés (sprint sans PHP, hors périmètre).

<!-- claude-review-start -->
## Claude Review

Clean implementation. The zero-dependency Node.js script is well-structured: fence tracking, GitHub-compatible slug generation (Unicode-aware, with de-duplication), anchor caching, and a URL-deduplicating external probe with bounded concurrency are all correct. The CI split (deterministic internal check per-PR, flaky external probe behind `workflow_dispatch`) is the right call. The two broken ADR references are fixed correctly. No findings.

**Reviewed commit:** `16b1473bc6459263cb6a09eaff94151b466f7fdd`

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**No inline comments.**
<!-- claude-review-end -->