### PR TITLE
test(recette): cover AI + landing domains with FR/EN parity (Sprint 35.3 O3)

### DIFF
--- a/pwa/tests/recette/features/ai-features.en.feature
+++ b/pwa/tests/recette/features/ai-features.en.feature
@@ -1,0 +1,161 @@
+Feature: AI features
+  As a cyclist,
+  I want AI assistance on my trip and stages,
+  so that I can understand my route and refine my plan in natural language.
+
+  @desktop @critical
+  Scenario: Trip AI overview card displayed
+    Given I have created a trip with an AI overview
+    Then the trip AI overview card is visible
+    And the trip AI narrative summary is visible
+
+  @desktop
+  Scenario: Global patterns visible in the AI overview
+    Given I have created a trip with an AI overview
+    Then the AI global patterns are visible
+
+  @desktop
+  Scenario: Cross-stage recommendations visible in the AI overview
+    Given I have created a trip with an AI overview
+    Then the AI cross-stage recommendations are visible
+    And the AI cross-stage alerts are visible
+
+  @mobile
+  Scenario: AI overview details collapsed behind a toggle on mobile
+    Given I have created a trip with an AI overview on mobile
+    Then the AI overview details are collapsed
+    When I expand the AI overview details
+    Then the AI overview details are visible
+
+  @desktop @critical
+  Scenario: Trip AI overview card hidden when the LLM is absent
+    Given I have created a trip without an AI overview
+    Then the trip AI overview card is not visible
+
+  @desktop @critical
+  Scenario: "AI analysis" card present on a stage
+    Given I have created a trip with per-stage AI analysis
+    Then the AI analysis card for stage 1 is visible
+    And the AI description of stage 1 is displayed
+
+  @desktop
+  Scenario: AI insights and suggestions displayed on the stage
+    Given I have created a trip with per-stage AI analysis
+    Then the AI insights of stage 1 are displayed
+    And the AI suggestions of stage 1 are displayed
+
+  @desktop
+  Scenario: Full alert analysis expanded on click
+    Given I have created a trip with per-stage AI analysis
+    When I expand the full alerts of the AI analysis of stage 1
+    Then the full AI alert list of stage 1 is visible
+
+  @desktop
+  Scenario: Applying AI suggestions enqueues a modification
+    Given I have created a trip with per-stage AI analysis
+    When I apply the AI suggestions of stage 1
+    Then the modification queue is visible
+
+  @desktop @critical
+  Scenario: AI chat panel accessible after computation
+    Given I have created a full trip with 3 stages
+    When I open the AI assistant bubble
+    Then the AI chat panel is visible
+
+  @desktop @critical
+  Scenario: Message sent to the backend and reply shown in history
+    Given I have created a full trip with 3 stages
+    And the AI assistant replies "Here is my analysis of your stage."
+    When I open the AI assistant bubble
+    And I send the message "What do you think of this stage?" in the AI chat
+    Then a POST request to /trips/*/chat is sent
+    And the reply "Here is my analysis of your stage." appears in the chat history
+
+  @desktop
+  Scenario: Loading indicator while the assistant replies
+    Given I have created a full trip with 3 stages
+    And the AI assistant replies with a delay
+    When I open the AI assistant bubble
+    And I send the message "Any suggestion?" in the AI chat
+    Then the assistant typing indicator is visible
+
+  @desktop
+  Scenario: "In-ride" mode with geolocation suggests nearby POIs
+    Given I have created a full trip with 3 stages
+    And my position is shared at 48.8566, 2.3522
+    And the AI assistant replies with nearby POIs
+    When I open the AI assistant bubble
+    And I enable geolocation in the AI chat
+    And I send the message "A bakery not too far?" in the AI chat
+    Then a POI card is displayed in the AI chat
+
+  @desktop
+  Scenario: Safety disclaimer shown below in-ride POIs
+    Given I have created a full trip with 3 stages
+    And my position is shared at 48.8566, 2.3522
+    And the AI assistant replies with nearby POIs
+    When I open the AI assistant bubble
+    And I enable geolocation in the AI chat
+    And I send the message "A water point?" in the AI chat
+    Then the in-ride safety disclaimer is shown
+
+  @desktop @critical
+  Scenario: AI refinement card visible on the preview step
+    Given I am on the trip preview with the AI refinement card
+    Then the AI refinement card is visible
+    And the AI refinement character counter is displayed
+
+  @desktop
+  Scenario: "Apply" button disabled when the suggestion is empty
+    Given I am on the trip preview with the AI refinement card
+    Then the AI refinement "Apply" button is disabled
+
+  @desktop
+  Scenario: "Apply" button enabled when a suggestion is entered
+    Given I am on the trip preview with the AI refinement card
+    When I type "Add a stage in Aubenas" in the AI refinement
+    Then the AI refinement "Apply" button is enabled
+
+  @desktop
+  Scenario: 500-character limit enforced in the AI refinement
+    Given I am on the trip preview with the AI refinement card
+    When I type 600 characters in the AI refinement
+    Then the AI refinement suggestion is limited to 500 characters
+
+  @desktop
+  Scenario: Character counter decrements as I type
+    Given I am on the trip preview with the AI refinement card
+    When I type "Go along the coast" in the AI refinement
+    Then the AI refinement counter shows the number of remaining characters
+
+  @desktop
+  Scenario: Clear empties the AI refinement suggestion
+    Given I am on the trip preview with the AI refinement card
+    When I type "A suggestion to clear" in the AI refinement
+    And I click the AI refinement "Clear" button
+    Then the AI refinement textarea is empty
+
+  @desktop
+  Scenario: AI refinement card disabled when the LLM is unreachable
+    Given I am on the trip preview with the AI refinement unavailable
+    Then the AI refinement textarea is disabled
+    And an AI unavailable notice is displayed
+
+  @desktop @critical
+  Scenario: Changed distance highlighted after recomputation
+    Given I have created a full trip with 3 stages
+    When stage 1 is recomputed with a changed distance
+    Then the distance diff highlight of stage 1 is visible
+
+  @desktop
+  Scenario: Distance diff highlight disappears after about 3 seconds
+    Given I have created a full trip with 3 stages
+    When stage 1 is recomputed with a changed distance
+    Then the distance diff highlight of stage 1 is visible
+    And the distance diff highlight of stage 1 disappears after 3 seconds
+
+  @desktop
+  Scenario: Added alert highlighted after recomputation
+    Given I have created a full trip with 3 stages
+    When stage 1 is recomputed with a new alert
+    Then the alerts diff highlight of stage 1 is visible

--- a/pwa/tests/recette/features/ai-features.fr.feature
+++ b/pwa/tests/recette/features/ai-features.fr.feature
@@ -1,0 +1,162 @@
+# language: fr
+Fonctionnalité: Fonctionnalités IA
+  En tant que cycliste,
+  je veux une assistance IA sur mon voyage et mes étapes,
+  afin de comprendre mon parcours et d'affiner mon plan en langage naturel.
+
+  @desktop @critique
+  Scénario: Affichage de la carte de synthèse IA du voyage
+    Étant donné que j'ai créé un voyage avec une synthèse IA
+    Alors la carte de synthèse IA du voyage est visible
+    Et le résumé narratif IA du voyage est visible
+
+  @desktop
+  Scénario: Patterns globaux visibles dans la synthèse IA
+    Étant donné que j'ai créé un voyage avec une synthèse IA
+    Alors les patterns globaux IA sont visibles
+
+  @desktop
+  Scénario: Recommandations inter-étapes visibles dans la synthèse IA
+    Étant donné que j'ai créé un voyage avec une synthèse IA
+    Alors les recommandations IA inter-étapes sont visibles
+    Et les alertes IA inter-étapes sont visibles
+
+  @mobile
+  Scénario: Détails de la synthèse IA repliés derrière un bouton sur mobile
+    Étant donné que j'ai créé un voyage avec une synthèse IA sur mobile
+    Alors les détails de la synthèse IA sont repliés
+    Quand je déploie les détails de la synthèse IA
+    Alors les détails de la synthèse IA sont visibles
+
+  @desktop @critique
+  Scénario: Carte de synthèse IA masquée quand le LLM est absent
+    Étant donné que j'ai créé un voyage sans synthèse IA
+    Alors la carte de synthèse IA du voyage n'est pas visible
+
+  @desktop @critique
+  Scénario: Carte "Analyse IA" présente sur une étape
+    Étant donné que j'ai créé un voyage avec une analyse IA par étape
+    Alors la carte d'analyse IA de l'étape 1 est visible
+    Et la description IA de l'étape 1 est affichée
+
+  @desktop
+  Scénario: Insights et suggestions IA affichés sur l'étape
+    Étant donné que j'ai créé un voyage avec une analyse IA par étape
+    Alors les insights IA de l'étape 1 sont affichés
+    Et les suggestions IA de l'étape 1 sont affichées
+
+  @desktop
+  Scénario: Déploiement de l'analyse complète des alertes au clic
+    Étant donné que j'ai créé un voyage avec une analyse IA par étape
+    Quand je déploie les alertes complètes de l'analyse IA de l'étape 1
+    Alors la liste complète des alertes IA de l'étape 1 est visible
+
+  @desktop
+  Scénario: Application des suggestions IA met une modification en file d'attente
+    Étant donné que j'ai créé un voyage avec une analyse IA par étape
+    Quand j'applique les suggestions IA de l'étape 1
+    Alors la file d'attente des modifications est visible
+
+  @desktop @critique
+  Scénario: Panneau chat IA accessible après le calcul
+    Étant donné que j'ai créé un voyage complet avec 3 étapes
+    Quand j'ouvre la bulle d'assistance IA
+    Alors le panneau de chat IA est visible
+
+  @desktop @critique
+  Scénario: Message envoyé au backend et réponse affichée dans l'historique
+    Étant donné que j'ai créé un voyage complet avec 3 étapes
+    Et que l'assistant IA répond "Voici mon analyse de votre étape."
+    Quand j'ouvre la bulle d'assistance IA
+    Et que j'envoie le message "Que penses-tu de cette étape ?" dans le chat IA
+    Alors une requête POST vers /trips/*/chat est envoyée
+    Et la réponse "Voici mon analyse de votre étape." apparaît dans l'historique du chat
+
+  @desktop
+  Scénario: Indicateur de chargement pendant la réponse de l'assistant
+    Étant donné que j'ai créé un voyage complet avec 3 étapes
+    Et que l'assistant IA répond avec un délai
+    Quand j'ouvre la bulle d'assistance IA
+    Et que j'envoie le message "Une suggestion ?" dans le chat IA
+    Alors l'indicateur de saisie de l'assistant est visible
+
+  @desktop
+  Scénario: Mode "En route" avec géolocalisation propose des POIs proches
+    Étant donné que j'ai créé un voyage complet avec 3 étapes
+    Et que ma position est partagée à 48.8566, 2.3522
+    Et que l'assistant IA répond avec des POIs proches
+    Quand j'ouvre la bulle d'assistance IA
+    Et que j'active la géolocalisation dans le chat IA
+    Et que j'envoie le message "Une boulangerie pas trop loin ?" dans le chat IA
+    Alors une carte de POI est affichée dans le chat IA
+
+  @desktop
+  Scénario: Avertissement de sécurité affiché sous les POIs en route
+    Étant donné que j'ai créé un voyage complet avec 3 étapes
+    Et que ma position est partagée à 48.8566, 2.3522
+    Et que l'assistant IA répond avec des POIs proches
+    Quand j'ouvre la bulle d'assistance IA
+    Et que j'active la géolocalisation dans le chat IA
+    Et que j'envoie le message "Un point d'eau ?" dans le chat IA
+    Alors l'avertissement de sécurité en route est affiché
+
+  @desktop @critique
+  Scénario: Carte de raffinement IA visible à l'étape Aperçu
+    Étant donné que je suis sur l'aperçu de voyage avec la carte de raffinement IA
+    Alors la carte de raffinement IA est visible
+    Et le compteur de caractères de la carte de raffinement IA est affiché
+
+  @desktop
+  Scénario: Bouton "Appliquer" désactivé quand la suggestion est vide
+    Étant donné que je suis sur l'aperçu de voyage avec la carte de raffinement IA
+    Alors le bouton "Appliquer" du raffinement IA est désactivé
+
+  @desktop
+  Scénario: Bouton "Appliquer" activé quand une suggestion est saisie
+    Étant donné que je suis sur l'aperçu de voyage avec la carte de raffinement IA
+    Quand je saisis "Ajoute une étape à Aubenas" dans le raffinement IA
+    Alors le bouton "Appliquer" du raffinement IA est activé
+
+  @desktop
+  Scénario: Limite de 500 caractères respectée dans le raffinement IA
+    Étant donné que je suis sur l'aperçu de voyage avec la carte de raffinement IA
+    Quand je saisis 600 caractères dans le raffinement IA
+    Alors la suggestion de raffinement IA est limitée à 500 caractères
+
+  @desktop
+  Scénario: Le compteur de caractères décrémente à la saisie
+    Étant donné que je suis sur l'aperçu de voyage avec la carte de raffinement IA
+    Quand je saisis "Passe par la côte" dans le raffinement IA
+    Alors le compteur de raffinement IA indique le nombre de caractères restants
+
+  @desktop
+  Scénario: Effacer vide la suggestion de raffinement IA
+    Étant donné que je suis sur l'aperçu de voyage avec la carte de raffinement IA
+    Quand je saisis "Une suggestion à effacer" dans le raffinement IA
+    Et que je clique sur le bouton "Effacer" du raffinement IA
+    Alors la zone de saisie du raffinement IA est vide
+
+  @desktop
+  Scénario: Carte de raffinement IA désactivée quand le LLM est injoignable
+    Étant donné que je suis sur l'aperçu de voyage avec le raffinement IA indisponible
+    Alors la zone de saisie du raffinement IA est désactivée
+    Et un avis d'indisponibilité de l'IA est affiché
+
+  @desktop @critique
+  Scénario: Distance modifiée surlignée après recalcul
+    Étant donné que j'ai créé un voyage complet avec 3 étapes
+    Quand l'étape 1 est recalculée avec une distance modifiée
+    Alors le surlignage de diff de la distance de l'étape 1 est visible
+
+  @desktop
+  Scénario: Surlignage de diff de distance disparaît après environ 3 secondes
+    Étant donné que j'ai créé un voyage complet avec 3 étapes
+    Quand l'étape 1 est recalculée avec une distance modifiée
+    Alors le surlignage de diff de la distance de l'étape 1 est visible
+    Et le surlignage de diff de la distance de l'étape 1 disparaît après 3 secondes
+
+  @desktop
+  Scénario: Alerte ajoutée surlignée après recalcul
+    Étant donné que j'ai créé un voyage complet avec 3 étapes
+    Quand l'étape 1 est recalculée avec une nouvelle alerte
+    Alors le surlignage de diff des alertes de l'étape 1 est visible

--- a/pwa/tests/recette/features/cross-cutting-ux.en.feature
+++ b/pwa/tests/recette/features/cross-cutting-ux.en.feature
@@ -69,3 +69,75 @@ Feature: Cross-cutting UX
     Given the stage list exceeds the screen height
     When I scroll down
     Then a scroll-to-top button appears
+
+  @desktop @onboarding
+  Scenario: Onboarding tour shows on first launch
+    Given the onboarding tour is active on first launch
+    Then the onboarding tour popover is visible
+
+  @desktop @onboarding
+  Scenario: First step targets the magic link field
+    Given the onboarding tour is active on first launch
+    Then the onboarding tour popover is visible
+    And the tour step targets the magic link card
+
+  @desktop @onboarding
+  Scenario: Second step targets the GPX upload button
+    Given the onboarding tour is active on first launch
+    When I advance to the next tour step
+    Then the tour step targets the GPX upload card
+
+  @desktop @onboarding
+  Scenario: Closing the onboarding tour with Escape
+    Given the onboarding tour is active on first launch
+    When I press Escape
+    Then the onboarding tour popover is no longer visible
+
+  @desktop @onboarding
+  Scenario: Closing the onboarding tour by clicking the overlay
+    Given the onboarding tour is active on first launch
+    When I click the onboarding tour overlay
+    Then the onboarding tour popover is no longer visible
+
+  @desktop @onboarding
+  Scenario: The tour no longer reappears after being dismissed
+    Given the onboarding tour has already been seen
+    When I reload the page
+    Then the onboarding tour popover is no longer visible
+
+  @desktop @dark
+  Scenario: Theme cycle light to dark then system
+    When I toggle to light theme
+    And I click the theme button
+    Then the selected theme is "dark"
+    When I click the theme button
+    Then the selected theme is "system"
+
+  @desktop @dark
+  Scenario: System mode follows the operating system preference
+    Given the operating system prefers dark mode
+    When I select the system theme
+    Then the interface is displayed with a dark background
+
+  @desktop @dark
+  Scenario: Theme choice is persisted after reload
+    When I toggle to dark theme
+    And I reload the page
+    Then the interface is displayed with a dark background
+
+  @mobile
+  Scenario: Compact language labels on a narrow screen
+    Given I am displaying the app on a narrow screen
+    Then the compact language label "FR" is visible
+
+  @mobile
+  Scenario: Language swap on mobile
+    Given I am using the app on a mobile device
+    When I change the language to "English"
+    Then the interface is displayed in English
+
+  @desktop
+  Scenario: Language choice is persisted after reload
+    When I change the language to "English"
+    And I reload the page
+    Then the interface is displayed in English

--- a/pwa/tests/recette/features/cross-cutting-ux.fr.feature
+++ b/pwa/tests/recette/features/cross-cutting-ux.fr.feature
@@ -70,3 +70,75 @@ Fonctionnalité: UX transverse
     Étant donné que la liste d'étapes dépasse la hauteur de l'écran
     Quand je fais défiler vers le bas
     Alors un bouton "Retour en haut" apparaît
+
+  @desktop @onboarding
+  Scénario: Le tour d'onboarding s'affiche au premier lancement
+    Étant donné que le tour d'onboarding est actif au premier lancement
+    Alors le popover du tour d'onboarding est visible
+
+  @desktop @onboarding
+  Scénario: La première étape cible le champ de lien magique
+    Étant donné que le tour d'onboarding est actif au premier lancement
+    Alors le popover du tour d'onboarding est visible
+    Et l'étape du tour cible la carte de lien magique
+
+  @desktop @onboarding
+  Scénario: La deuxième étape cible le bouton d'import GPX
+    Étant donné que le tour d'onboarding est actif au premier lancement
+    Quand j'avance à l'étape suivante du tour
+    Alors l'étape du tour cible la carte d'import GPX
+
+  @desktop @onboarding
+  Scénario: Fermeture du tour d'onboarding par Échap
+    Étant donné que le tour d'onboarding est actif au premier lancement
+    Quand j'appuie sur Échap
+    Alors le popover du tour d'onboarding n'est plus visible
+
+  @desktop @onboarding
+  Scénario: Fermeture du tour d'onboarding par clic sur l'overlay
+    Étant donné que le tour d'onboarding est actif au premier lancement
+    Quand je clique sur l'overlay du tour d'onboarding
+    Alors le popover du tour d'onboarding n'est plus visible
+
+  @desktop @onboarding
+  Scénario: Le tour ne réapparaît plus après fermeture
+    Étant donné que le tour d'onboarding a déjà été vu
+    Quand je recharge la page
+    Alors le popover du tour d'onboarding n'est plus visible
+
+  @desktop @sombre
+  Scénario: Cycle de thème clair vers sombre puis système
+    Quand je bascule vers le thème clair
+    Et que je clique sur le bouton de thème
+    Alors le thème sélectionné est "dark"
+    Quand je clique sur le bouton de thème
+    Alors le thème sélectionné est "system"
+
+  @desktop @sombre
+  Scénario: Le mode système suit la préférence du système d'exploitation
+    Étant donné que le système d'exploitation préfère le mode sombre
+    Quand je sélectionne le thème système
+    Alors l'interface s'affiche avec un fond sombre
+
+  @desktop @sombre
+  Scénario: Le choix de thème est persisté après rechargement
+    Quand je bascule vers le thème sombre
+    Et que je recharge la page
+    Alors l'interface s'affiche avec un fond sombre
+
+  @mobile
+  Scénario: Labels de langue compacts sur écran étroit
+    Étant donné que j'affiche l'application sur un écran étroit
+    Alors le label compact de langue "FR" est visible
+
+  @mobile
+  Scénario: Permutation de langue sur mobile
+    Étant donné que j'utilise l'application sur un appareil mobile
+    Quand je change la langue vers "English"
+    Alors l'interface s'affiche en anglais
+
+  @desktop
+  Scénario: Le choix de langue est persisté après rechargement
+    Quand je change la langue vers "English"
+    Et que je recharge la page
+    Alors l'interface s'affiche en anglais

--- a/pwa/tests/recette/features/landing-page.en.feature
+++ b/pwa/tests/recette/features/landing-page.en.feature
@@ -26,7 +26,7 @@ Feature: Landing page
     Then the sources section is visible
     And the "komoot" source is displayed
     And the "strava" source is displayed
-    And the "ridewithgps" source is displayed
+    And the "rwgps" source is displayed
     And the "gpx" source is displayed
 
   @desktop

--- a/pwa/tests/recette/features/landing-page.en.feature
+++ b/pwa/tests/recette/features/landing-page.en.feature
@@ -1,0 +1,56 @@
+Feature: Landing page
+  As an unauthenticated visitor,
+  I want to discover the product on the public home page,
+  so that I understand the value proposition and can request access.
+
+  Background:
+    Given I am viewing the public landing page
+
+  @desktop @critical
+  Scenario: Hero section with title and calls to action
+    Then the hero section is visible
+    And the "Créer un itinéraire" call to action is visible
+    And the demo button is visible
+
+  @desktop
+  Scenario: "How it works" section
+    Then the "how it works" section is visible
+
+  @desktop
+  Scenario: Benefits bento
+    Then the features section is visible
+    And the bento grid is visible
+
+  @desktop @critical
+  Scenario: Supported sources displayed
+    Then the sources section is visible
+    And the "komoot" source is displayed
+    And the "strava" source is displayed
+    And the "ridewithgps" source is displayed
+    And the "gpx" source is displayed
+
+  @desktop
+  Scenario: Platforms section
+    Then the platforms section is visible
+
+  @desktop
+  Scenario: Testimonials and use cases
+    Then the testimonials section is visible
+
+  @desktop @critical
+  Scenario: Footer with legal links
+    Then the footer is visible
+    And the footer GitHub link is visible
+    And the footer legal link is visible
+    And the footer privacy link is visible
+
+  @desktop
+  Scenario: Call to action redirects to login when unauthenticated
+    Then the "Créer un itinéraire" button points to "/login"
+
+  @mobile @critical
+  Scenario: Landing page responsive on mobile
+    Given I am viewing the public landing page on mobile
+    Then the landing page is visible
+    And the hero section is visible
+    And the "Créer un itinéraire" call to action is visible

--- a/pwa/tests/recette/features/landing-page.fr.feature
+++ b/pwa/tests/recette/features/landing-page.fr.feature
@@ -1,0 +1,57 @@
+# language: fr
+Fonctionnalité: Page d'atterrissage
+  En tant que visiteur non connecté,
+  je veux découvrir le produit sur la page d'accueil publique,
+  afin de comprendre la proposition de valeur et de demander l'accès.
+
+  Contexte:
+    Étant donné que je consulte la page d'atterrissage publique
+
+  @desktop @critique
+  Scénario: Section héros avec titre et appels à l'action
+    Alors la section héros est visible
+    Et l'appel à l'action "Créer un itinéraire" est visible
+    Et le bouton de démonstration est visible
+
+  @desktop
+  Scénario: Section "Comment ça marche"
+    Alors la section "Comment ça marche" est visible
+
+  @desktop
+  Scénario: Bento des avantages
+    Alors la section des avantages est visible
+    Et la grille bento est visible
+
+  @desktop @critique
+  Scénario: Sources supportées affichées
+    Alors la section des sources est visible
+    Et la source "komoot" est affichée
+    Et la source "strava" est affichée
+    Et la source "ridewithgps" est affichée
+    Et la source "gpx" est affichée
+
+  @desktop
+  Scénario: Section plateformes
+    Alors la section des plateformes est visible
+
+  @desktop
+  Scénario: Témoignages et cas d'usage
+    Alors la section des témoignages est visible
+
+  @desktop @critique
+  Scénario: Footer avec liens légaux
+    Alors le footer est visible
+    Et le lien GitHub du footer est visible
+    Et le lien légal du footer est visible
+    Et le lien de confidentialité du footer est visible
+
+  @desktop
+  Scénario: Appel à l'action redirige vers la connexion quand non connecté
+    Alors le bouton "Créer un itinéraire" pointe vers "/login"
+
+  @mobile @critique
+  Scénario: Page d'atterrissage responsive sur mobile
+    Étant donné que je consulte la page d'atterrissage publique sur mobile
+    Alors la page d'atterrissage est visible
+    Et la section héros est visible
+    Et l'appel à l'action "Créer un itinéraire" est visible

--- a/pwa/tests/recette/features/landing-page.fr.feature
+++ b/pwa/tests/recette/features/landing-page.fr.feature
@@ -27,7 +27,7 @@ Fonctionnalité: Page d'atterrissage
     Alors la section des sources est visible
     Et la source "komoot" est affichée
     Et la source "strava" est affichée
-    Et la source "ridewithgps" est affichée
+    Et la source "rwgps" est affichée
     Et la source "gpx" est affichée
 
   @desktop

--- a/pwa/tests/recette/features/stage-management.en.feature
+++ b/pwa/tests/recette/features/stage-management.en.feature
@@ -73,3 +73,53 @@ Feature: Stage management
     Given I am on the home page
     When I submit a valid Komoot link
     Then I see a progress bar while stages are being computed
+
+  @desktop @supply
+  Scenario: Supply timeline displayed on a stage
+    Given supply data is available for stage 1
+    Then the supply timeline of stage 1 is visible
+
+  @desktop @supply
+  Scenario: Supply markers with water, food and mixed icons
+    Given supply data is available for stage 1
+    Then the supply marker at 15 km shows the water icon
+    And the supply marker at 42 km shows the food icon
+    And the supply marker at 59 km shows the mixed icon
+
+  @desktop @supply
+  Scenario: Hovering a marker shows the name and distance
+    Given supply data is available for stage 1
+    When I open the supply marker at 15 km
+    Then the supply tooltip shows "Cimetière de Vals"
+    And the supply tooltip shows "15 km"
+
+  @mobile @supply
+  Scenario: Horizontal scroll of the supply timeline on mobile
+    Given supply data is available for stage 1 on mobile
+    Then the supply timeline of stage 1 is visible
+
+  @desktop @timeline
+  Scenario: Split map + timeline view by default on desktop
+    Then I see both panels side by side
+    And the "split view" view mode button is active
+
+  @desktop @timeline
+  Scenario: Switch to timeline-only view
+    When I click the "timeline" view mode button
+    Then the timeline is visible
+    And the map panel is not visible
+
+  @desktop @timeline
+  Scenario: Back to split view from timeline-only view
+    When I click the "timeline" view mode button
+    And I click the "split view" view mode button
+    Then I see both panels side by side
+
+  @mobile @timeline
+  Scenario: Full-screen timeline on mobile with toggle to map
+    Given I switch to a mobile screen
+    When I click the "timeline" view mode button
+    Then the timeline is visible
+    And the map panel is not visible
+    When I click the "map only" view mode button
+    Then the map panel is visible

--- a/pwa/tests/recette/features/stage-management.fr.feature
+++ b/pwa/tests/recette/features/stage-management.fr.feature
@@ -74,3 +74,53 @@ Fonctionnalité: Gestion des étapes
     Étant donné que je suis sur la page d'accueil
     Quand je soumets un lien Komoot valide
     Alors je vois une barre de progression pendant le calcul des étapes
+
+  @desktop @ravitaillement
+  Scénario: Affichage de la timeline des ravitaillements sur une étape
+    Étant donné que des données de ravitaillement sont disponibles pour l'étape 1
+    Alors la timeline des ravitaillements de l'étape 1 est visible
+
+  @desktop @ravitaillement
+  Scénario: Marqueurs de ravitaillement avec icônes eau, nourriture et mixte
+    Étant donné que des données de ravitaillement sont disponibles pour l'étape 1
+    Alors le marqueur de ravitaillement à 15 km affiche l'icône eau
+    Et le marqueur de ravitaillement à 42 km affiche l'icône nourriture
+    Et le marqueur de ravitaillement à 59 km affiche l'icône mixte
+
+  @desktop @ravitaillement
+  Scénario: Survol d'un marqueur affiche le nom et la distance
+    Étant donné que des données de ravitaillement sont disponibles pour l'étape 1
+    Quand j'ouvre le marqueur de ravitaillement à 15 km
+    Alors l'info-bulle de ravitaillement affiche "Cimetière de Vals"
+    Et l'info-bulle de ravitaillement affiche "15 km"
+
+  @mobile @ravitaillement
+  Scénario: Défilement horizontal de la timeline des ravitaillements sur mobile
+    Étant donné que des données de ravitaillement sont disponibles pour l'étape 1 sur mobile
+    Alors la timeline des ravitaillements de l'étape 1 est visible
+
+  @desktop @timeline
+  Scénario: Vue splitée carte + timeline par défaut sur desktop
+    Alors je vois les deux panneaux côte à côte
+    Et le bouton de mode "vue splitée" est actif
+
+  @desktop @timeline
+  Scénario: Bascule vers la vue timeline seule
+    Quand je clique sur le bouton de mode "chronologie"
+    Alors la timeline est visible
+    Et le panneau carte n'est pas visible
+
+  @desktop @timeline
+  Scénario: Retour à la vue splitée depuis la vue timeline seule
+    Quand je clique sur le bouton de mode "chronologie"
+    Et que je clique sur le bouton de mode "vue splitée"
+    Alors je vois les deux panneaux côte à côte
+
+  @mobile @timeline
+  Scénario: Timeline plein écran sur mobile avec bascule vers la carte
+    Étant donné que je passe sur un écran mobile
+    Quand je clique sur le bouton de mode "chronologie"
+    Alors la timeline est visible
+    Et le panneau carte n'est pas visible
+    Quand je clique sur le bouton de mode "carte seule"
+    Alors le panneau carte est visible

--- a/pwa/tests/recette/steps/ai-features.steps.ts
+++ b/pwa/tests/recette/steps/ai-features.steps.ts
@@ -1066,34 +1066,33 @@ Then("an AI unavailable notice is displayed", async ({ mockedPage }) => {
 Then(
   "le surlignage de diff de la distance de l'étape {int} est visible",
   async ({ mockedPage }, n: number) => {
-    void n;
-    await expect(mockedPage.getByTestId("diff-highlight-distance")).toBeVisible(
-      {
-        timeout: 2000,
-      },
-    );
+    await expect(
+      mockedPage
+        .getByTestId(`stage-card-${n}`)
+        .getByTestId("diff-highlight-distance"),
+    ).toBeVisible({ timeout: 2000 });
   },
 );
 
 Then(
   "the distance diff highlight of stage {int} is visible",
   async ({ mockedPage }, n: number) => {
-    void n;
-    await expect(mockedPage.getByTestId("diff-highlight-distance")).toBeVisible(
-      {
-        timeout: 2000,
-      },
-    );
+    await expect(
+      mockedPage
+        .getByTestId(`stage-card-${n}`)
+        .getByTestId("diff-highlight-distance"),
+    ).toBeVisible({ timeout: 2000 });
   },
 );
 
 Then(
   "le surlignage de diff de la distance de l'étape {int} disparaît après {int} secondes",
   async ({ mockedPage }, n: number, seconds: number) => {
-    void n;
     await mockedPage.waitForTimeout(seconds * 1000 + 500);
     await expect(
-      mockedPage.getByTestId("diff-highlight-distance"),
+      mockedPage
+        .getByTestId(`stage-card-${n}`)
+        .getByTestId("diff-highlight-distance"),
     ).toBeHidden();
   },
 );
@@ -1101,10 +1100,11 @@ Then(
 Then(
   "the distance diff highlight of stage {int} disappears after {int} seconds",
   async ({ mockedPage }, n: number, seconds: number) => {
-    void n;
     await mockedPage.waitForTimeout(seconds * 1000 + 500);
     await expect(
-      mockedPage.getByTestId("diff-highlight-distance"),
+      mockedPage
+        .getByTestId(`stage-card-${n}`)
+        .getByTestId("diff-highlight-distance"),
     ).toBeHidden();
   },
 );
@@ -1112,9 +1112,10 @@ Then(
 Then(
   "le surlignage de diff des alertes de l'étape {int} est visible",
   async ({ mockedPage }, n: number) => {
-    void n;
     await expect(
-      mockedPage.getByTestId("diff-highlight-alerts_added"),
+      mockedPage
+        .getByTestId(`stage-card-${n}`)
+        .getByTestId("diff-highlight-alerts_added"),
     ).toBeVisible({ timeout: 2000 });
   },
 );
@@ -1122,9 +1123,10 @@ Then(
 Then(
   "the alerts diff highlight of stage {int} is visible",
   async ({ mockedPage }, n: number) => {
-    void n;
     await expect(
-      mockedPage.getByTestId("diff-highlight-alerts_added"),
+      mockedPage
+        .getByTestId(`stage-card-${n}`)
+        .getByTestId("diff-highlight-alerts_added"),
     ).toBeVisible({ timeout: 2000 });
   },
 );

--- a/pwa/tests/recette/steps/ai-features.steps.ts
+++ b/pwa/tests/recette/steps/ai-features.steps.ts
@@ -38,6 +38,10 @@ async function mockChat(
   },
   delayMs = 0,
 ): Promise<void> {
+  // Reset the module-level capture: it persists across scenarios in the same
+  // worker, so a prior `mockChat` scenario would otherwise leave stale entries
+  // and make the "request sent" poll pass without a fresh POST.
+  capturedChatRequests.length = 0;
   await page.route(chatUrlPattern(), async (route, request) => {
     if (request.method() !== "POST") return route.fallback();
     try {

--- a/pwa/tests/recette/steps/ai-features.steps.ts
+++ b/pwa/tests/recette/steps/ai-features.steps.ts
@@ -1,0 +1,1102 @@
+import { expect, type Page } from "@playwright/test";
+import { Given, When, Then } from "../support/fixtures";
+import { getTripId } from "../../fixtures/api-mocks";
+import {
+  routeParsedEvent,
+  stagesComputedEvent,
+  tripReadyEvent,
+  tripReadyEventWithAiOverview,
+  tripReadyEventWithStageAiAnalysis,
+} from "../../fixtures/mock-data";
+import type { MercureEvent } from "../../../src/lib/mercure/types";
+
+// ---------------------------------------------------------------------------
+// AI features — trip overview, stage summary, chat, refinement, diff highlight
+// FR + EN. Mirrors the mocked specs (trip-ai-overview, stage-ai-summary,
+// ai-bubble, chat-in-ride, diff-highlight) but drives the public recette
+// fixtures so the scenarios are executable end-to-end.
+// ---------------------------------------------------------------------------
+
+function chatUrlPattern(): RegExp {
+  return new RegExp(
+    `/trips/${getTripId().replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&")}/chat$`,
+  );
+}
+
+const capturedChatRequests: { body: unknown }[] = [];
+
+/**
+ * Stub the chat endpoint with a deterministic assistant reply. `delayMs`
+ * keeps the request in flight long enough to observe the typing indicator.
+ */
+async function mockChat(
+  page: Page,
+  body: {
+    response: string;
+    pois?: unknown[];
+    action?: string;
+  },
+  delayMs = 0,
+): Promise<void> {
+  await page.route(chatUrlPattern(), async (route, request) => {
+    if (request.method() !== "POST") return route.fallback();
+    try {
+      capturedChatRequests.push({
+        body: JSON.parse(request.postData() ?? "{}"),
+      });
+    } catch {
+      capturedChatRequests.push({ body: null });
+    }
+    if (delayMs > 0) await new Promise((r) => setTimeout(r, delayMs));
+    await route.fulfill({
+      status: 200,
+      contentType: "application/ld+json",
+      body: JSON.stringify({
+        tripId: getTripId(),
+        action: body.action ?? (body.pois ? "find_poi" : "info"),
+        params: {},
+        response: body.response,
+        dispatched: false,
+        impactedStageNumbers: [],
+        requiresFullAnalysis: false,
+        pois: body.pois ?? [],
+      }),
+    });
+  });
+}
+
+/** A stage_updated event changing the distance (72.5 → 55.0 km). */
+function stageUpdatedWithDistanceChange(stageIndex: number): MercureEvent {
+  return {
+    type: "stage_updated",
+    data: {
+      stageIndex,
+      stage: {
+        dayNumber: stageIndex + 1,
+        distance: 55.0,
+        elevation: 720,
+        elevationLoss: 640,
+        startPoint: { lat: 44.735, lon: 4.598, ele: 280 },
+        endPoint: { lat: 44.5, lon: 4.4, ele: 500 },
+        geometry: [
+          { lat: 44.735, lon: 4.598, ele: 280 },
+          { lat: 44.5, lon: 4.4, ele: 500 },
+        ],
+        label: null,
+        isRestDay: false,
+        weather: null,
+        alerts: [],
+        pois: [],
+        accommodations: [],
+        selectedAccommodation: null,
+        events: [],
+      },
+    },
+  };
+}
+
+/** A stage_updated event adding a new alert (distance unchanged). */
+function stageUpdatedWithNewAlerts(stageIndex: number): MercureEvent {
+  return {
+    type: "stage_updated",
+    data: {
+      stageIndex,
+      stage: {
+        dayNumber: stageIndex + 1,
+        distance: 72.5,
+        elevation: 1180,
+        elevationLoss: 920,
+        startPoint: { lat: 44.735, lon: 4.598, ele: 280 },
+        endPoint: { lat: 44.532, lon: 4.392, ele: 540 },
+        geometry: [
+          { lat: 44.735, lon: 4.598, ele: 280 },
+          { lat: 44.532, lon: 4.392, ele: 540 },
+        ],
+        label: null,
+        isRestDay: false,
+        weather: null,
+        alerts: [
+          {
+            type: "warning",
+            message: "Newly detected steep gradient",
+            lat: 44.6,
+            lon: 4.5,
+          },
+        ],
+        pois: [],
+        accommodations: [],
+        selectedAccommodation: null,
+        events: [],
+      },
+    },
+  };
+}
+
+const NEARBY_POIS = [
+  {
+    name: "Boulangerie du Marché",
+    category: "food",
+    lat: 48.857,
+    lon: 2.353,
+    distance_m: 450,
+    detour_m: 200,
+    opening_hours_today: "Mo-Sa 07:00-19:30",
+    closes_at: "2026-05-19T19:30:00+02:00",
+    phone: "+33123456789",
+    deeplink: "https://maps.google.com/?q=48.857,2.353",
+    warning: null,
+  },
+];
+
+/**
+ * Reach the Acte 1.5 preview on `/trips/new` where the Ai refinement card is
+ * mounted via the wizard's `previewSlot`. A real magic-link submit redirects
+ * to `/trips/{id}`, so we synthesize the preview state directly: set a trip id,
+ * feed stages, and settle the processing/analysis flags (mirrors trip-preview
+ * spec's `enterPreviewState`, but on the wizard route so the slot renders).
+ */
+async function enterRefinementPreview(
+  page: Page,
+  injectEvent: (event: MercureEvent) => Promise<void>,
+  options: { available?: boolean } = {},
+): Promise<void> {
+  const available = options.available ?? true;
+  await page.goto("/trips/new");
+  await page.waitForLoadState("networkidle");
+  await page.evaluate((avail) => {
+    window.dispatchEvent(
+      new CustomEvent("__test_set_ai_capability", {
+        detail: { enabled: true, available: avail },
+      }),
+    );
+    window.dispatchEvent(
+      new CustomEvent("__test_set_trip_id", { detail: "test-trip-abc-123" }),
+    );
+  }, available);
+  await injectEvent(routeParsedEvent());
+  await injectEvent(stagesComputedEvent());
+  await page.evaluate(() => {
+    window.dispatchEvent(
+      new CustomEvent("__test_set_processing", { detail: false }),
+    );
+    window.dispatchEvent(
+      new CustomEvent("__test_set_analysis_started", { detail: false }),
+    );
+  });
+  await expect(page.getByTestId("ai-refinement-card")).toBeVisible({
+    timeout: 10000,
+  });
+}
+
+// ===========================================================================
+// Given — trip AI overview (FR + EN)
+// ===========================================================================
+
+Given(
+  "j'ai créé un voyage avec une synthèse IA",
+  async ({ submitUrl, injectEvent }) => {
+    await submitUrl();
+    await injectEvent(routeParsedEvent());
+    await injectEvent(stagesComputedEvent());
+    await injectEvent(tripReadyEventWithAiOverview());
+  },
+);
+
+Given(
+  "I have created a trip with an AI overview",
+  async ({ submitUrl, injectEvent }) => {
+    await submitUrl();
+    await injectEvent(routeParsedEvent());
+    await injectEvent(stagesComputedEvent());
+    await injectEvent(tripReadyEventWithAiOverview());
+  },
+);
+
+Given(
+  "j'ai créé un voyage avec une synthèse IA sur mobile",
+  async ({ submitUrl, injectEvent, mockedPage }) => {
+    await mockedPage.setViewportSize({ width: 375, height: 800 });
+    await submitUrl();
+    await injectEvent(routeParsedEvent());
+    await injectEvent(stagesComputedEvent());
+    await injectEvent(tripReadyEventWithAiOverview());
+  },
+);
+
+Given(
+  "I have created a trip with an AI overview on mobile",
+  async ({ submitUrl, injectEvent, mockedPage }) => {
+    await mockedPage.setViewportSize({ width: 375, height: 800 });
+    await submitUrl();
+    await injectEvent(routeParsedEvent());
+    await injectEvent(stagesComputedEvent());
+    await injectEvent(tripReadyEventWithAiOverview());
+  },
+);
+
+Given(
+  "j'ai créé un voyage sans synthèse IA",
+  async ({ submitUrl, injectEvent }) => {
+    await submitUrl();
+    await injectEvent(routeParsedEvent());
+    await injectEvent(stagesComputedEvent());
+    await injectEvent(tripReadyEvent());
+  },
+);
+
+Given(
+  "I have created a trip without an AI overview",
+  async ({ submitUrl, injectEvent }) => {
+    await submitUrl();
+    await injectEvent(routeParsedEvent());
+    await injectEvent(stagesComputedEvent());
+    await injectEvent(tripReadyEvent());
+  },
+);
+
+// ===========================================================================
+// Given — per-stage AI analysis (FR + EN)
+// ===========================================================================
+
+Given(
+  "j'ai créé un voyage avec une analyse IA par étape",
+  async ({ submitUrl, injectEvent }) => {
+    await submitUrl();
+    await injectEvent(routeParsedEvent());
+    await injectEvent(stagesComputedEvent());
+    await injectEvent(tripReadyEventWithStageAiAnalysis());
+  },
+);
+
+Given(
+  "I have created a trip with per-stage AI analysis",
+  async ({ submitUrl, injectEvent }) => {
+    await submitUrl();
+    await injectEvent(routeParsedEvent());
+    await injectEvent(stagesComputedEvent());
+    await injectEvent(tripReadyEventWithStageAiAnalysis());
+  },
+);
+
+// ===========================================================================
+// Given — chat assistant mocks (FR + EN)
+// ===========================================================================
+
+Given(
+  "l'assistant IA répond {string}",
+  async ({ mockedPage }, reply: string) => {
+    await mockChat(mockedPage, { response: reply });
+  },
+);
+
+Given(
+  "the AI assistant replies {string}",
+  async ({ mockedPage }, reply: string) => {
+    await mockChat(mockedPage, { response: reply });
+  },
+);
+
+Given("l'assistant IA répond avec un délai", async ({ mockedPage }) => {
+  await mockChat(mockedPage, { response: "Réponse différée." }, 1500);
+});
+
+Given("the AI assistant replies with a delay", async ({ mockedPage }) => {
+  await mockChat(mockedPage, { response: "Delayed reply." }, 1500);
+});
+
+Given(
+  "ma position est partagée à {float}, {float}",
+  async ({ mockedPage }, lat: number, lon: number) => {
+    const ctx = mockedPage.context();
+    await ctx.grantPermissions(["geolocation"]);
+    await ctx.setGeolocation({ latitude: lat, longitude: lon });
+  },
+);
+
+Given(
+  "my position is shared at {float}, {float}",
+  async ({ mockedPage }, lat: number, lon: number) => {
+    const ctx = mockedPage.context();
+    await ctx.grantPermissions(["geolocation"]);
+    await ctx.setGeolocation({ latitude: lat, longitude: lon });
+  },
+);
+
+Given("l'assistant IA répond avec des POIs proches", async ({ mockedPage }) => {
+  await mockChat(mockedPage, {
+    response: "Voici des points proches.",
+    pois: NEARBY_POIS,
+  });
+});
+
+Given("the AI assistant replies with nearby POIs", async ({ mockedPage }) => {
+  await mockChat(mockedPage, {
+    response: "Here are nearby points.",
+    pois: NEARBY_POIS,
+  });
+});
+
+// ===========================================================================
+// Given — AI refinement card (preview step on /trips/new)
+// ===========================================================================
+
+Given(
+  "je suis sur l'aperçu de voyage avec la carte de raffinement IA",
+  async ({ mockedPage, injectEvent }) => {
+    await enterRefinementPreview(mockedPage, injectEvent);
+  },
+);
+
+Given(
+  "I am on the trip preview with the AI refinement card",
+  async ({ mockedPage, injectEvent }) => {
+    await enterRefinementPreview(mockedPage, injectEvent);
+  },
+);
+
+Given(
+  "je suis sur l'aperçu de voyage avec le raffinement IA indisponible",
+  async ({ mockedPage, injectEvent }) => {
+    await enterRefinementPreview(mockedPage, injectEvent, { available: false });
+  },
+);
+
+Given(
+  "I am on the trip preview with the AI refinement unavailable",
+  async ({ mockedPage, injectEvent }) => {
+    await enterRefinementPreview(mockedPage, injectEvent, { available: false });
+  },
+);
+
+// ===========================================================================
+// When — chat interactions (FR + EN)
+// ===========================================================================
+
+When("j'ouvre la bulle d'assistance IA", async ({ mockedPage }) => {
+  const bubble = mockedPage.getByTestId("ai-bubble");
+  await expect(bubble).toBeVisible({ timeout: 10000 });
+  await bubble.click();
+});
+
+When("I open the AI assistant bubble", async ({ mockedPage }) => {
+  const bubble = mockedPage.getByTestId("ai-bubble");
+  await expect(bubble).toBeVisible({ timeout: 10000 });
+  await bubble.click();
+});
+
+When(
+  "j'envoie le message {string} dans le chat IA",
+  async ({ mockedPage }, message: string) => {
+    await mockedPage.getByTestId("ai-chat-panel-input").fill(message);
+    await mockedPage.getByTestId("ai-chat-panel-send").click();
+  },
+);
+
+When(
+  "I send the message {string} in the AI chat",
+  async ({ mockedPage }, message: string) => {
+    await mockedPage.getByTestId("ai-chat-panel-input").fill(message);
+    await mockedPage.getByTestId("ai-chat-panel-send").click();
+  },
+);
+
+When("j'active la géolocalisation dans le chat IA", async ({ mockedPage }) => {
+  await mockedPage.getByTestId("ai-chat-panel-geoloc-prompt").click();
+  await expect(
+    mockedPage.getByTestId("ai-chat-panel-geoloc-prompt"),
+  ).toHaveCount(0, { timeout: 3000 });
+});
+
+When("I enable geolocation in the AI chat", async ({ mockedPage }) => {
+  await mockedPage.getByTestId("ai-chat-panel-geoloc-prompt").click();
+  await expect(
+    mockedPage.getByTestId("ai-chat-panel-geoloc-prompt"),
+  ).toHaveCount(0, { timeout: 3000 });
+});
+
+// ===========================================================================
+// When — stage AI analysis interactions (FR + EN)
+// ===========================================================================
+
+When("je déploie les détails de la synthèse IA", async ({ mockedPage }) => {
+  await mockedPage.getByTestId("trip-ai-overview-toggle").click();
+});
+
+When("I expand the AI overview details", async ({ mockedPage }) => {
+  await mockedPage.getByTestId("trip-ai-overview-toggle").click();
+});
+
+When(
+  "je déploie les alertes complètes de l'analyse IA de l'étape {int}",
+  async ({ mockedPage }, n: number) => {
+    void n;
+    await mockedPage.getByTestId("stage-ai-summary-alerts-show-more").click();
+  },
+);
+
+When(
+  "I expand the full alerts of the AI analysis of stage {int}",
+  async ({ mockedPage }, n: number) => {
+    void n;
+    await mockedPage.getByTestId("stage-ai-summary-alerts-show-more").click();
+  },
+);
+
+When(
+  "j'applique les suggestions IA de l'étape {int}",
+  async ({ mockedPage }, n: number) => {
+    void n;
+    await mockedPage.getByTestId("stage-ai-summary-apply").click();
+  },
+);
+
+When(
+  "I apply the AI suggestions of stage {int}",
+  async ({ mockedPage }, n: number) => {
+    void n;
+    await mockedPage.getByTestId("stage-ai-summary-apply").click();
+  },
+);
+
+// ===========================================================================
+// When — AI refinement interactions (FR + EN)
+// ===========================================================================
+
+When(
+  "je saisis {string} dans le raffinement IA",
+  async ({ mockedPage }, value: string) => {
+    await mockedPage.getByTestId("ai-refinement-textarea").fill(value);
+  },
+);
+
+When(
+  "I type {string} in the AI refinement",
+  async ({ mockedPage }, value: string) => {
+    await mockedPage.getByTestId("ai-refinement-textarea").fill(value);
+  },
+);
+
+When(
+  "je saisis {int} caractères dans le raffinement IA",
+  async ({ mockedPage }, count: number) => {
+    await mockedPage
+      .getByTestId("ai-refinement-textarea")
+      .fill("a".repeat(count));
+  },
+);
+
+When(
+  "I type {int} characters in the AI refinement",
+  async ({ mockedPage }, count: number) => {
+    await mockedPage
+      .getByTestId("ai-refinement-textarea")
+      .fill("a".repeat(count));
+  },
+);
+
+When(
+  'je clique sur le bouton "Effacer" du raffinement IA',
+  async ({ mockedPage }) => {
+    await mockedPage.getByTestId("ai-refinement-clear").click();
+  },
+);
+
+When('I click the AI refinement "Clear" button', async ({ mockedPage }) => {
+  await mockedPage.getByTestId("ai-refinement-clear").click();
+});
+
+// ===========================================================================
+// When — diff highlight (FR + EN)
+// ===========================================================================
+
+When(
+  "l'étape {int} est recalculée avec une distance modifiée",
+  async ({ mockedPage, injectEvent }, n: number) => {
+    const stageCard = mockedPage.getByTestId(`stage-card-${n}`);
+    await stageCard
+      .getByRole("button", { name: "Sélectionner cet hébergement" })
+      .first()
+      .click();
+    await expect(mockedPage.getByTestId("stage-skeleton").first()).toBeVisible({
+      timeout: 3000,
+    });
+    await injectEvent(stageUpdatedWithDistanceChange(n - 1));
+    await expect(stageCard).toBeVisible({ timeout: 3000 });
+  },
+);
+
+When(
+  "stage {int} is recomputed with a changed distance",
+  async ({ mockedPage, injectEvent }, n: number) => {
+    const stageCard = mockedPage.getByTestId(`stage-card-${n}`);
+    await stageCard
+      .getByRole("button", { name: "Sélectionner cet hébergement" })
+      .first()
+      .click();
+    await expect(mockedPage.getByTestId("stage-skeleton").first()).toBeVisible({
+      timeout: 3000,
+    });
+    await injectEvent(stageUpdatedWithDistanceChange(n - 1));
+    await expect(stageCard).toBeVisible({ timeout: 3000 });
+  },
+);
+
+When(
+  "l'étape {int} est recalculée avec une nouvelle alerte",
+  async ({ mockedPage, injectEvent }, n: number) => {
+    const stageCard = mockedPage.getByTestId(`stage-card-${n}`);
+    await stageCard
+      .getByRole("button", { name: "Sélectionner cet hébergement" })
+      .first()
+      .click();
+    await expect(mockedPage.getByTestId("stage-skeleton").first()).toBeVisible({
+      timeout: 3000,
+    });
+    await injectEvent(stageUpdatedWithNewAlerts(n - 1));
+    await expect(stageCard).toBeVisible({ timeout: 3000 });
+  },
+);
+
+When(
+  "stage {int} is recomputed with a new alert",
+  async ({ mockedPage, injectEvent }, n: number) => {
+    const stageCard = mockedPage.getByTestId(`stage-card-${n}`);
+    await stageCard
+      .getByRole("button", { name: "Sélectionner cet hébergement" })
+      .first()
+      .click();
+    await expect(mockedPage.getByTestId("stage-skeleton").first()).toBeVisible({
+      timeout: 3000,
+    });
+    await injectEvent(stageUpdatedWithNewAlerts(n - 1));
+    await expect(stageCard).toBeVisible({ timeout: 3000 });
+  },
+);
+
+// ===========================================================================
+// Then — trip AI overview (FR + EN)
+// ===========================================================================
+
+Then(
+  "la carte de synthèse IA du voyage est visible",
+  async ({ mockedPage }) => {
+    await expect(mockedPage.getByTestId("trip-ai-overview")).toBeVisible({
+      timeout: 10000,
+    });
+  },
+);
+
+Then("the trip AI overview card is visible", async ({ mockedPage }) => {
+  await expect(mockedPage.getByTestId("trip-ai-overview")).toBeVisible({
+    timeout: 10000,
+  });
+});
+
+Then("le résumé narratif IA du voyage est visible", async ({ mockedPage }) => {
+  await expect(mockedPage.getByTestId("trip-ai-overview-teaser")).toBeVisible();
+});
+
+Then("the trip AI narrative summary is visible", async ({ mockedPage }) => {
+  await expect(mockedPage.getByTestId("trip-ai-overview-teaser")).toBeVisible();
+});
+
+Then("les patterns globaux IA sont visibles", async ({ mockedPage }) => {
+  await expect(mockedPage.getByTestId("trip-ai-overview-patterns")).toBeVisible(
+    {
+      timeout: 10000,
+    },
+  );
+});
+
+Then("the AI global patterns are visible", async ({ mockedPage }) => {
+  await expect(mockedPage.getByTestId("trip-ai-overview-patterns")).toBeVisible(
+    {
+      timeout: 10000,
+    },
+  );
+});
+
+Then(
+  "les recommandations IA inter-étapes sont visibles",
+  async ({ mockedPage }) => {
+    await expect(
+      mockedPage.getByTestId("trip-ai-overview-recommendations"),
+    ).toBeVisible({ timeout: 10000 });
+  },
+);
+
+Then(
+  "the AI cross-stage recommendations are visible",
+  async ({ mockedPage }) => {
+    await expect(
+      mockedPage.getByTestId("trip-ai-overview-recommendations"),
+    ).toBeVisible({ timeout: 10000 });
+  },
+);
+
+Then("les alertes IA inter-étapes sont visibles", async ({ mockedPage }) => {
+  await expect(
+    mockedPage.getByTestId("trip-ai-overview-cross-stage-alerts"),
+  ).toBeVisible();
+});
+
+Then("the AI cross-stage alerts are visible", async ({ mockedPage }) => {
+  await expect(
+    mockedPage.getByTestId("trip-ai-overview-cross-stage-alerts"),
+  ).toBeVisible();
+});
+
+Then("les détails de la synthèse IA sont repliés", async ({ mockedPage }) => {
+  await expect(
+    mockedPage.getByTestId("trip-ai-overview-toggle"),
+  ).toHaveAttribute("aria-expanded", "false", { timeout: 10000 });
+  await expect(mockedPage.getByTestId("trip-ai-overview-details")).toBeHidden();
+});
+
+Then("the AI overview details are collapsed", async ({ mockedPage }) => {
+  await expect(
+    mockedPage.getByTestId("trip-ai-overview-toggle"),
+  ).toHaveAttribute("aria-expanded", "false", { timeout: 10000 });
+  await expect(mockedPage.getByTestId("trip-ai-overview-details")).toBeHidden();
+});
+
+Then("les détails de la synthèse IA sont visibles", async ({ mockedPage }) => {
+  await expect(
+    mockedPage.getByTestId("trip-ai-overview-details"),
+  ).toBeVisible();
+});
+
+Then("the AI overview details are visible", async ({ mockedPage }) => {
+  await expect(
+    mockedPage.getByTestId("trip-ai-overview-details"),
+  ).toBeVisible();
+});
+
+Then(
+  "la carte de synthèse IA du voyage n'est pas visible",
+  async ({ mockedPage }) => {
+    await expect(mockedPage.getByTestId("stage-card-1")).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(mockedPage.getByTestId("trip-ai-overview")).toHaveCount(0);
+  },
+);
+
+Then("the trip AI overview card is not visible", async ({ mockedPage }) => {
+  await expect(mockedPage.getByTestId("stage-card-1")).toBeVisible({
+    timeout: 10000,
+  });
+  await expect(mockedPage.getByTestId("trip-ai-overview")).toHaveCount(0);
+});
+
+// ===========================================================================
+// Then — per-stage AI analysis (FR + EN)
+// ===========================================================================
+
+Then(
+  "la carte d'analyse IA de l'étape {int} est visible",
+  async ({ mockedPage }, n: number) => {
+    await expect(
+      mockedPage.getByTestId(`stage-ai-summary-${n - 1}`),
+    ).toBeVisible({
+      timeout: 10000,
+    });
+  },
+);
+
+Then(
+  "the AI analysis card for stage {int} is visible",
+  async ({ mockedPage }, n: number) => {
+    await expect(
+      mockedPage.getByTestId(`stage-ai-summary-${n - 1}`),
+    ).toBeVisible({
+      timeout: 10000,
+    });
+  },
+);
+
+Then(
+  "la description IA de l'étape {int} est affichée",
+  async ({ mockedPage }, n: number) => {
+    void n;
+    await expect(
+      mockedPage.getByTestId("stage-ai-summary-narrative"),
+    ).toBeVisible({ timeout: 10000 });
+  },
+);
+
+Then(
+  "the AI description of stage {int} is displayed",
+  async ({ mockedPage }, n: number) => {
+    void n;
+    await expect(
+      mockedPage.getByTestId("stage-ai-summary-narrative"),
+    ).toBeVisible({ timeout: 10000 });
+  },
+);
+
+Then(
+  "les insights IA de l'étape {int} sont affichés",
+  async ({ mockedPage }, n: number) => {
+    void n;
+    await expect(
+      mockedPage.getByTestId("stage-ai-summary-insights"),
+    ).toBeVisible({
+      timeout: 10000,
+    });
+  },
+);
+
+Then(
+  "the AI insights of stage {int} are displayed",
+  async ({ mockedPage }, n: number) => {
+    void n;
+    await expect(
+      mockedPage.getByTestId("stage-ai-summary-insights"),
+    ).toBeVisible({
+      timeout: 10000,
+    });
+  },
+);
+
+Then(
+  "les suggestions IA de l'étape {int} sont affichées",
+  async ({ mockedPage }, n: number) => {
+    void n;
+    await expect(
+      mockedPage.getByTestId("stage-ai-summary-suggestions"),
+    ).toBeVisible({ timeout: 10000 });
+  },
+);
+
+Then(
+  "the AI suggestions of stage {int} are displayed",
+  async ({ mockedPage }, n: number) => {
+    void n;
+    await expect(
+      mockedPage.getByTestId("stage-ai-summary-suggestions"),
+    ).toBeVisible({ timeout: 10000 });
+  },
+);
+
+Then(
+  "la liste complète des alertes IA de l'étape {int} est visible",
+  async ({ mockedPage }, n: number) => {
+    void n;
+    await expect(
+      mockedPage.getByTestId("stage-ai-summary-alerts-full"),
+    ).toBeVisible({ timeout: 5000 });
+  },
+);
+
+Then(
+  "the full AI alert list of stage {int} is visible",
+  async ({ mockedPage }, n: number) => {
+    void n;
+    await expect(
+      mockedPage.getByTestId("stage-ai-summary-alerts-full"),
+    ).toBeVisible({ timeout: 5000 });
+  },
+);
+
+Then(
+  "la file d'attente des modifications est visible",
+  async ({ mockedPage }) => {
+    await expect(mockedPage.getByTestId("modification-queue")).toBeVisible({
+      timeout: 5000,
+    });
+  },
+);
+
+Then("the modification queue is visible", async ({ mockedPage }) => {
+  await expect(mockedPage.getByTestId("modification-queue")).toBeVisible({
+    timeout: 5000,
+  });
+});
+
+// ===========================================================================
+// Then — chat panel (FR + EN)
+// ===========================================================================
+
+Then("le panneau de chat IA est visible", async ({ mockedPage }) => {
+  await expect(mockedPage.getByTestId("ai-chat-panel")).toBeVisible({
+    timeout: 5000,
+  });
+});
+
+Then("the AI chat panel is visible", async ({ mockedPage }) => {
+  await expect(mockedPage.getByTestId("ai-chat-panel")).toBeVisible({
+    timeout: 5000,
+  });
+});
+
+Then(/^une requête POST vers \/trips\/\*\/chat est envoyée$/, async () => {
+  await expect
+    .poll(() => capturedChatRequests.length, { timeout: 5000 })
+    .toBeGreaterThan(0);
+});
+
+Then(/^a POST request to \/trips\/\*\/chat is sent$/, async () => {
+  await expect
+    .poll(() => capturedChatRequests.length, { timeout: 5000 })
+    .toBeGreaterThan(0);
+});
+
+Then(
+  "la réponse {string} apparaît dans l'historique du chat",
+  async ({ mockedPage }, reply: string) => {
+    await expect(
+      mockedPage
+        .getByTestId("ai-chat-panel-message")
+        .filter({ hasText: reply }),
+    ).toBeVisible({ timeout: 5000 });
+  },
+);
+
+Then(
+  "the reply {string} appears in the chat history",
+  async ({ mockedPage }, reply: string) => {
+    await expect(
+      mockedPage
+        .getByTestId("ai-chat-panel-message")
+        .filter({ hasText: reply }),
+    ).toBeVisible({ timeout: 5000 });
+  },
+);
+
+Then(
+  "l'indicateur de saisie de l'assistant est visible",
+  async ({ mockedPage }) => {
+    await expect(mockedPage.getByTestId("ai-chat-panel-typing")).toBeVisible({
+      timeout: 3000,
+    });
+  },
+);
+
+Then("the assistant typing indicator is visible", async ({ mockedPage }) => {
+  await expect(mockedPage.getByTestId("ai-chat-panel-typing")).toBeVisible({
+    timeout: 3000,
+  });
+});
+
+Then(
+  "une carte de POI est affichée dans le chat IA",
+  async ({ mockedPage }) => {
+    await expect(mockedPage.getByTestId("poi-card").first()).toBeVisible({
+      timeout: 5000,
+    });
+  },
+);
+
+Then("a POI card is displayed in the AI chat", async ({ mockedPage }) => {
+  await expect(mockedPage.getByTestId("poi-card").first()).toBeVisible({
+    timeout: 5000,
+  });
+});
+
+Then(
+  "l'avertissement de sécurité en route est affiché",
+  async ({ mockedPage }) => {
+    await expect(mockedPage.getByTestId("in-ride-disclaimer")).toBeVisible({
+      timeout: 5000,
+    });
+  },
+);
+
+Then("the in-ride safety disclaimer is shown", async ({ mockedPage }) => {
+  await expect(mockedPage.getByTestId("in-ride-disclaimer")).toBeVisible({
+    timeout: 5000,
+  });
+});
+
+// ===========================================================================
+// Then — AI refinement card (FR + EN)
+// ===========================================================================
+
+Then("la carte de raffinement IA est visible", async ({ mockedPage }) => {
+  await expect(mockedPage.getByTestId("ai-refinement-card")).toBeVisible();
+});
+
+Then("the AI refinement card is visible", async ({ mockedPage }) => {
+  await expect(mockedPage.getByTestId("ai-refinement-card")).toBeVisible();
+});
+
+Then(
+  "le compteur de caractères de la carte de raffinement IA est affiché",
+  async ({ mockedPage }) => {
+    await expect(mockedPage.getByTestId("ai-refinement-counter")).toBeVisible();
+  },
+);
+
+Then(
+  "the AI refinement character counter is displayed",
+  async ({ mockedPage }) => {
+    await expect(mockedPage.getByTestId("ai-refinement-counter")).toBeVisible();
+  },
+);
+
+Then(
+  'le bouton "Appliquer" du raffinement IA est désactivé',
+  async ({ mockedPage }) => {
+    await expect(mockedPage.getByTestId("ai-refinement-apply")).toBeDisabled();
+  },
+);
+
+Then('the AI refinement "Apply" button is disabled', async ({ mockedPage }) => {
+  await expect(mockedPage.getByTestId("ai-refinement-apply")).toBeDisabled();
+});
+
+Then(
+  'le bouton "Appliquer" du raffinement IA est activé',
+  async ({ mockedPage }) => {
+    await expect(mockedPage.getByTestId("ai-refinement-apply")).toBeEnabled();
+  },
+);
+
+Then('the AI refinement "Apply" button is enabled', async ({ mockedPage }) => {
+  await expect(mockedPage.getByTestId("ai-refinement-apply")).toBeEnabled();
+});
+
+Then(
+  "la suggestion de raffinement IA est limitée à {int} caractères",
+  async ({ mockedPage }, max: number) => {
+    const value = await mockedPage
+      .getByTestId("ai-refinement-textarea")
+      .inputValue();
+    expect(value.length).toBe(max);
+  },
+);
+
+Then(
+  "the AI refinement suggestion is limited to {int} characters",
+  async ({ mockedPage }, max: number) => {
+    const value = await mockedPage
+      .getByTestId("ai-refinement-textarea")
+      .inputValue();
+    expect(value.length).toBe(max);
+  },
+);
+
+Then(
+  "le compteur de raffinement IA indique le nombre de caractères restants",
+  async ({ mockedPage }) => {
+    await expect(mockedPage.getByTestId("ai-refinement-counter")).toContainText(
+      "483",
+    );
+  },
+);
+
+Then(
+  "the AI refinement counter shows the number of remaining characters",
+  async ({ mockedPage }) => {
+    await expect(mockedPage.getByTestId("ai-refinement-counter")).toContainText(
+      "482",
+    );
+  },
+);
+
+Then("la zone de saisie du raffinement IA est vide", async ({ mockedPage }) => {
+  await expect(mockedPage.getByTestId("ai-refinement-textarea")).toHaveValue(
+    "",
+  );
+});
+
+Then("the AI refinement textarea is empty", async ({ mockedPage }) => {
+  await expect(mockedPage.getByTestId("ai-refinement-textarea")).toHaveValue(
+    "",
+  );
+});
+
+Then(
+  "la zone de saisie du raffinement IA est désactivée",
+  async ({ mockedPage }) => {
+    await expect(
+      mockedPage.getByTestId("ai-refinement-textarea"),
+    ).toBeDisabled();
+  },
+);
+
+Then("the AI refinement textarea is disabled", async ({ mockedPage }) => {
+  await expect(mockedPage.getByTestId("ai-refinement-textarea")).toBeDisabled();
+});
+
+Then(
+  "un avis d'indisponibilité de l'IA est affiché",
+  async ({ mockedPage }) => {
+    await expect(mockedPage.getByTestId("ai-unavailable-notice")).toBeVisible();
+  },
+);
+
+Then("an AI unavailable notice is displayed", async ({ mockedPage }) => {
+  await expect(mockedPage.getByTestId("ai-unavailable-notice")).toBeVisible();
+});
+
+// ===========================================================================
+// Then — diff highlight (FR + EN)
+// ===========================================================================
+
+Then(
+  "le surlignage de diff de la distance de l'étape {int} est visible",
+  async ({ mockedPage }, n: number) => {
+    void n;
+    await expect(mockedPage.getByTestId("diff-highlight-distance")).toBeVisible(
+      {
+        timeout: 2000,
+      },
+    );
+  },
+);
+
+Then(
+  "the distance diff highlight of stage {int} is visible",
+  async ({ mockedPage }, n: number) => {
+    void n;
+    await expect(mockedPage.getByTestId("diff-highlight-distance")).toBeVisible(
+      {
+        timeout: 2000,
+      },
+    );
+  },
+);
+
+Then(
+  "le surlignage de diff de la distance de l'étape {int} disparaît après {int} secondes",
+  async ({ mockedPage }, n: number, seconds: number) => {
+    void n;
+    await mockedPage.waitForTimeout(seconds * 1000 + 500);
+    await expect(
+      mockedPage.getByTestId("diff-highlight-distance"),
+    ).toBeHidden();
+  },
+);
+
+Then(
+  "the distance diff highlight of stage {int} disappears after {int} seconds",
+  async ({ mockedPage }, n: number, seconds: number) => {
+    void n;
+    await mockedPage.waitForTimeout(seconds * 1000 + 500);
+    await expect(
+      mockedPage.getByTestId("diff-highlight-distance"),
+    ).toBeHidden();
+  },
+);
+
+Then(
+  "le surlignage de diff des alertes de l'étape {int} est visible",
+  async ({ mockedPage }, n: number) => {
+    void n;
+    await expect(
+      mockedPage.getByTestId("diff-highlight-alerts_added"),
+    ).toBeVisible({ timeout: 2000 });
+  },
+);
+
+Then(
+  "the alerts diff highlight of stage {int} is visible",
+  async ({ mockedPage }, n: number) => {
+    void n;
+    await expect(
+      mockedPage.getByTestId("diff-highlight-alerts_added"),
+    ).toBeVisible({ timeout: 2000 });
+  },
+);

--- a/pwa/tests/recette/steps/ai-features.steps.ts
+++ b/pwa/tests/recette/steps/ai-features.steps.ts
@@ -514,7 +514,9 @@ When(
   async ({ mockedPage, injectEvent }, n: number) => {
     const stageCard = mockedPage.getByTestId(`stage-card-${n}`);
     await stageCard
-      .getByRole("button", { name: "Sélectionner cet hébergement" })
+      .getByRole("button", {
+        name: /Sélectionner cet hébergement|Select accommodation/,
+      })
       .first()
       .click();
     await expect(mockedPage.getByTestId("stage-skeleton").first()).toBeVisible({
@@ -530,7 +532,9 @@ When(
   async ({ mockedPage, injectEvent }, n: number) => {
     const stageCard = mockedPage.getByTestId(`stage-card-${n}`);
     await stageCard
-      .getByRole("button", { name: "Sélectionner cet hébergement" })
+      .getByRole("button", {
+        name: /Sélectionner cet hébergement|Select accommodation/,
+      })
       .first()
       .click();
     await expect(mockedPage.getByTestId("stage-skeleton").first()).toBeVisible({
@@ -546,7 +550,9 @@ When(
   async ({ mockedPage, injectEvent }, n: number) => {
     const stageCard = mockedPage.getByTestId(`stage-card-${n}`);
     await stageCard
-      .getByRole("button", { name: "Sélectionner cet hébergement" })
+      .getByRole("button", {
+        name: /Sélectionner cet hébergement|Select accommodation/,
+      })
       .first()
       .click();
     await expect(mockedPage.getByTestId("stage-skeleton").first()).toBeVisible({
@@ -562,7 +568,9 @@ When(
   async ({ mockedPage, injectEvent }, n: number) => {
     const stageCard = mockedPage.getByTestId(`stage-card-${n}`);
     await stageCard
-      .getByRole("button", { name: "Sélectionner cet hébergement" })
+      .getByRole("button", {
+        name: /Sélectionner cet hébergement|Select accommodation/,
+      })
       .first()
       .click();
     await expect(mockedPage.getByTestId("stage-skeleton").first()).toBeVisible({

--- a/pwa/tests/recette/steps/ai-features.steps.ts
+++ b/pwa/tests/recette/steps/ai-features.steps.ts
@@ -145,7 +145,7 @@ const NEARBY_POIS = [
     distance_m: 450,
     detour_m: 200,
     opening_hours_today: "Mo-Sa 07:00-19:30",
-    closes_at: "2026-05-19T19:30:00+02:00",
+    closes_at: "2030-12-31T23:59:00+02:00",
     phone: "+33123456789",
     deeplink: "https://maps.google.com/?q=48.857,2.353",
     warning: null,
@@ -433,32 +433,40 @@ When("I expand the AI overview details", async ({ mockedPage }) => {
 When(
   "je déploie les alertes complètes de l'analyse IA de l'étape {int}",
   async ({ mockedPage }, n: number) => {
-    void n;
-    await mockedPage.getByTestId("stage-ai-summary-alerts-show-more").click();
+    await mockedPage
+      .getByTestId(`stage-ai-summary-${n - 1}`)
+      .getByTestId("stage-ai-summary-alerts-show-more")
+      .click();
   },
 );
 
 When(
   "I expand the full alerts of the AI analysis of stage {int}",
   async ({ mockedPage }, n: number) => {
-    void n;
-    await mockedPage.getByTestId("stage-ai-summary-alerts-show-more").click();
+    await mockedPage
+      .getByTestId(`stage-ai-summary-${n - 1}`)
+      .getByTestId("stage-ai-summary-alerts-show-more")
+      .click();
   },
 );
 
 When(
   "j'applique les suggestions IA de l'étape {int}",
   async ({ mockedPage }, n: number) => {
-    void n;
-    await mockedPage.getByTestId("stage-ai-summary-apply").click();
+    await mockedPage
+      .getByTestId(`stage-ai-summary-${n - 1}`)
+      .getByTestId("stage-ai-summary-apply")
+      .click();
   },
 );
 
 When(
   "I apply the AI suggestions of stage {int}",
   async ({ mockedPage }, n: number) => {
-    void n;
-    await mockedPage.getByTestId("stage-ai-summary-apply").click();
+    await mockedPage
+      .getByTestId(`stage-ai-summary-${n - 1}`)
+      .getByTestId("stage-ai-summary-apply")
+      .click();
   },
 );
 
@@ -730,9 +738,10 @@ Then(
 Then(
   "la description IA de l'étape {int} est affichée",
   async ({ mockedPage }, n: number) => {
-    void n;
     await expect(
-      mockedPage.getByTestId("stage-ai-summary-narrative"),
+      mockedPage
+        .getByTestId(`stage-ai-summary-${n - 1}`)
+        .getByTestId("stage-ai-summary-narrative"),
     ).toBeVisible({ timeout: 10000 });
   },
 );
@@ -740,9 +749,10 @@ Then(
 Then(
   "the AI description of stage {int} is displayed",
   async ({ mockedPage }, n: number) => {
-    void n;
     await expect(
-      mockedPage.getByTestId("stage-ai-summary-narrative"),
+      mockedPage
+        .getByTestId(`stage-ai-summary-${n - 1}`)
+        .getByTestId("stage-ai-summary-narrative"),
     ).toBeVisible({ timeout: 10000 });
   },
 );
@@ -750,9 +760,10 @@ Then(
 Then(
   "les insights IA de l'étape {int} sont affichés",
   async ({ mockedPage }, n: number) => {
-    void n;
     await expect(
-      mockedPage.getByTestId("stage-ai-summary-insights"),
+      mockedPage
+        .getByTestId(`stage-ai-summary-${n - 1}`)
+        .getByTestId("stage-ai-summary-insights"),
     ).toBeVisible({
       timeout: 10000,
     });
@@ -762,9 +773,10 @@ Then(
 Then(
   "the AI insights of stage {int} are displayed",
   async ({ mockedPage }, n: number) => {
-    void n;
     await expect(
-      mockedPage.getByTestId("stage-ai-summary-insights"),
+      mockedPage
+        .getByTestId(`stage-ai-summary-${n - 1}`)
+        .getByTestId("stage-ai-summary-insights"),
     ).toBeVisible({
       timeout: 10000,
     });
@@ -774,9 +786,10 @@ Then(
 Then(
   "les suggestions IA de l'étape {int} sont affichées",
   async ({ mockedPage }, n: number) => {
-    void n;
     await expect(
-      mockedPage.getByTestId("stage-ai-summary-suggestions"),
+      mockedPage
+        .getByTestId(`stage-ai-summary-${n - 1}`)
+        .getByTestId("stage-ai-summary-suggestions"),
     ).toBeVisible({ timeout: 10000 });
   },
 );
@@ -784,9 +797,10 @@ Then(
 Then(
   "the AI suggestions of stage {int} are displayed",
   async ({ mockedPage }, n: number) => {
-    void n;
     await expect(
-      mockedPage.getByTestId("stage-ai-summary-suggestions"),
+      mockedPage
+        .getByTestId(`stage-ai-summary-${n - 1}`)
+        .getByTestId("stage-ai-summary-suggestions"),
     ).toBeVisible({ timeout: 10000 });
   },
 );
@@ -794,9 +808,10 @@ Then(
 Then(
   "la liste complète des alertes IA de l'étape {int} est visible",
   async ({ mockedPage }, n: number) => {
-    void n;
     await expect(
-      mockedPage.getByTestId("stage-ai-summary-alerts-full"),
+      mockedPage
+        .getByTestId(`stage-ai-summary-${n - 1}`)
+        .getByTestId("stage-ai-summary-alerts-full"),
     ).toBeVisible({ timeout: 5000 });
   },
 );
@@ -804,9 +819,10 @@ Then(
 Then(
   "the full AI alert list of stage {int} is visible",
   async ({ mockedPage }, n: number) => {
-    void n;
     await expect(
-      mockedPage.getByTestId("stage-ai-summary-alerts-full"),
+      mockedPage
+        .getByTestId(`stage-ai-summary-${n - 1}`)
+        .getByTestId("stage-ai-summary-alerts-full"),
     ).toBeVisible({ timeout: 5000 });
   },
 );

--- a/pwa/tests/recette/steps/cross-cutting-ux.steps.ts
+++ b/pwa/tests/recette/steps/cross-cutting-ux.steps.ts
@@ -457,3 +457,264 @@ Then("a scroll-to-top button appears", async ({ $test }) => {
   // Scroll-to-top button may not be implemented
   $test.fixme();
 });
+
+// ---------------------------------------------------------------------------
+// Onboarding tour (driver.js) — FR + EN
+//
+// The tour is suppressed under WebDriver unless the
+// `__PLAYWRIGHT_SHOW_ONBOARDING` flag is set before navigation. The mockedPage
+// fixture already navigated, so we install the init script then reload so the
+// flag is present on the next page load and the tour fires after its 800 ms
+// startup delay. Onboarding only runs on `/`.
+// ---------------------------------------------------------------------------
+
+const ONBOARDING_FLAG = "bike-trip-planner:onboarding-done";
+const ONBOARDING_POPOVER = ".driver-popover.onboarding-popover";
+
+async function startOnboarding(
+  page: import("@playwright/test").Page,
+): Promise<void> {
+  await page.addInitScript(() => {
+    localStorage.removeItem("bike-trip-planner:onboarding-done");
+    (
+      window as Window & { __PLAYWRIGHT_SHOW_ONBOARDING?: boolean }
+    ).__PLAYWRIGHT_SHOW_ONBOARDING = true;
+  });
+  await page.goto("/");
+  await page.waitForLoadState("networkidle");
+  await expect(page.locator(ONBOARDING_POPOVER)).toBeVisible({ timeout: 4000 });
+  // Wait for the driver.js highlight transition (≈400 ms) to settle.
+  await page.waitForTimeout(500);
+}
+
+Given(
+  "le tour d'onboarding est actif au premier lancement",
+  async ({ mockedPage }) => {
+    await startOnboarding(mockedPage);
+  },
+);
+
+Given(
+  "the onboarding tour is active on first launch",
+  async ({ mockedPage }) => {
+    await startOnboarding(mockedPage);
+  },
+);
+
+Given("le tour d'onboarding a déjà été vu", async ({ mockedPage }) => {
+  await mockedPage.addInitScript((flag) => {
+    localStorage.setItem(flag, "true");
+    (
+      window as Window & { __PLAYWRIGHT_SHOW_ONBOARDING?: boolean }
+    ).__PLAYWRIGHT_SHOW_ONBOARDING = true;
+  }, ONBOARDING_FLAG);
+  await mockedPage.goto("/");
+  await mockedPage.waitForLoadState("networkidle");
+});
+
+Given("the onboarding tour has already been seen", async ({ mockedPage }) => {
+  await mockedPage.addInitScript((flag) => {
+    localStorage.setItem(flag, "true");
+    (
+      window as Window & { __PLAYWRIGHT_SHOW_ONBOARDING?: boolean }
+    ).__PLAYWRIGHT_SHOW_ONBOARDING = true;
+  }, ONBOARDING_FLAG);
+  await mockedPage.goto("/");
+  await mockedPage.waitForLoadState("networkidle");
+});
+
+When("j'avance à l'étape suivante du tour", async ({ mockedPage }) => {
+  await mockedPage
+    .locator(".driver-popover-navigation-btns button")
+    .last()
+    .click();
+  await mockedPage.waitForTimeout(500);
+});
+
+When("I advance to the next tour step", async ({ mockedPage }) => {
+  await mockedPage
+    .locator(".driver-popover-navigation-btns button")
+    .last()
+    .click();
+  await mockedPage.waitForTimeout(500);
+});
+
+When("je clique sur l'overlay du tour d'onboarding", async ({ mockedPage }) => {
+  await mockedPage
+    .locator(".driver-overlay")
+    .click({ position: { x: 5, y: 5 } });
+});
+
+When("I click the onboarding tour overlay", async ({ mockedPage }) => {
+  await mockedPage
+    .locator(".driver-overlay")
+    .click({ position: { x: 5, y: 5 } });
+});
+
+Then("le popover du tour d'onboarding est visible", async ({ mockedPage }) => {
+  await expect(mockedPage.locator(ONBOARDING_POPOVER)).toBeVisible({
+    timeout: 4000,
+  });
+});
+
+Then("the onboarding tour popover is visible", async ({ mockedPage }) => {
+  await expect(mockedPage.locator(ONBOARDING_POPOVER)).toBeVisible({
+    timeout: 4000,
+  });
+});
+
+Then(
+  "le popover du tour d'onboarding n'est plus visible",
+  async ({ mockedPage }) => {
+    await expect(mockedPage.locator(ONBOARDING_POPOVER)).toBeHidden({
+      timeout: 4000,
+    });
+  },
+);
+
+Then(
+  "the onboarding tour popover is no longer visible",
+  async ({ mockedPage }) => {
+    await expect(mockedPage.locator(ONBOARDING_POPOVER)).toBeHidden({
+      timeout: 4000,
+    });
+  },
+);
+
+Then(
+  "l'étape du tour cible la carte de lien magique",
+  async ({ mockedPage }) => {
+    await expect(
+      mockedPage.locator('.driver-active-element[data-testid="card-link"]'),
+    ).toBeAttached({ timeout: 3000 });
+  },
+);
+
+Then("the tour step targets the magic link card", async ({ mockedPage }) => {
+  await expect(
+    mockedPage.locator('.driver-active-element[data-testid="card-link"]'),
+  ).toBeAttached({ timeout: 3000 });
+});
+
+Then("l'étape du tour cible la carte d'import GPX", async ({ mockedPage }) => {
+  await expect(
+    mockedPage.locator('.driver-active-element[data-testid="card-gpx"]'),
+  ).toBeAttached({ timeout: 3000 });
+});
+
+Then("the tour step targets the GPX upload card", async ({ mockedPage }) => {
+  await expect(
+    mockedPage.locator('.driver-active-element[data-testid="card-gpx"]'),
+  ).toBeAttached({ timeout: 3000 });
+});
+
+// ---------------------------------------------------------------------------
+// Theme — three-state cycle / system follow / persistence — FR + EN
+// ---------------------------------------------------------------------------
+
+When("je clique sur le bouton de thème", async ({ mockedPage }) => {
+  await mockedPage.getByTestId("theme-toggle").click();
+});
+
+When("I click the theme button", async ({ mockedPage }) => {
+  await mockedPage.getByTestId("theme-toggle").click();
+});
+
+Then(
+  "le thème sélectionné est {string}",
+  async ({ mockedPage }, state: string) => {
+    await expect(mockedPage.getByTestId("theme-toggle")).toHaveAttribute(
+      "data-theme-state",
+      state,
+      { timeout: 5000 },
+    );
+  },
+);
+
+Then(
+  "the selected theme is {string}",
+  async ({ mockedPage }, state: string) => {
+    await expect(mockedPage.getByTestId("theme-toggle")).toHaveAttribute(
+      "data-theme-state",
+      state,
+      { timeout: 5000 },
+    );
+  },
+);
+
+Given(
+  "le système d'exploitation préfère le mode sombre",
+  async ({ mockedPage }) => {
+    await mockedPage.emulateMedia({ colorScheme: "dark" });
+  },
+);
+
+Given("the operating system prefers dark mode", async ({ mockedPage }) => {
+  await mockedPage.emulateMedia({ colorScheme: "dark" });
+});
+
+When("je sélectionne le thème système", async ({ mockedPage }) => {
+  const toggle = mockedPage.getByTestId("theme-toggle");
+  await expect(toggle).toBeVisible({ timeout: 5000 });
+  for (let i = 0; i < 3; i++) {
+    if ((await toggle.getAttribute("data-theme-state")) === "system") break;
+    await toggle.click();
+  }
+  await expect(toggle).toHaveAttribute("data-theme-state", "system", {
+    timeout: 5000,
+  });
+});
+
+When("I select the system theme", async ({ mockedPage }) => {
+  const toggle = mockedPage.getByTestId("theme-toggle");
+  await expect(toggle).toBeVisible({ timeout: 5000 });
+  for (let i = 0; i < 3; i++) {
+    if ((await toggle.getAttribute("data-theme-state")) === "system") break;
+    await toggle.click();
+  }
+  await expect(toggle).toHaveAttribute("data-theme-state", "system", {
+    timeout: 5000,
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Language — compact labels / reload persistence — FR + EN
+// ---------------------------------------------------------------------------
+
+Then(
+  "le label compact de langue {string} est visible",
+  async ({ mockedPage }, label: string) => {
+    await expect(
+      mockedPage.getByTestId("locale-switch-fr").getByText(label, {
+        exact: true,
+      }),
+    ).toBeVisible({ timeout: 5000 });
+  },
+);
+
+Then(
+  "the compact language label {string} is visible",
+  async ({ mockedPage }, label: string) => {
+    await expect(
+      mockedPage.getByTestId("locale-switch-fr").getByText(label, {
+        exact: true,
+      }),
+    ).toBeVisible({ timeout: 5000 });
+  },
+);
+
+When("I reload the page", async ({ page }) => {
+  await page.reload();
+});
+
+Given("j'affiche l'application sur un écran étroit", async ({ mockedPage }) => {
+  await mockedPage.setViewportSize({ width: 390, height: 844 });
+  await mockedPage.goto("/");
+  await mockedPage.waitForLoadState("networkidle");
+});
+
+Given("I am displaying the app on a narrow screen", async ({ mockedPage }) => {
+  await mockedPage.setViewportSize({ width: 390, height: 844 });
+  await mockedPage.goto("/");
+  await mockedPage.waitForLoadState("networkidle");
+});

--- a/pwa/tests/recette/steps/landing-page.steps.ts
+++ b/pwa/tests/recette/steps/landing-page.steps.ts
@@ -1,0 +1,218 @@
+import { expect, type Page } from "@playwright/test";
+import { Given, Then } from "../support/fixtures";
+
+// ---------------------------------------------------------------------------
+// Landing page — public (unauthenticated) home page. FR + EN.
+// The `mockedPage` fixture authenticates by default (auth/refresh → 200), which
+// renders the TripPlanner instead of the LandingPage. These steps force a 401
+// silent-refresh and re-navigate so the anonymous LandingPage is rendered.
+// Testids mirror the contract pinned by tests/mocked/landing-page.spec.ts.
+// ---------------------------------------------------------------------------
+
+async function gotoLandingAsAnonymous(page: Page): Promise<void> {
+  await page.route("**/auth/refresh", (route, request) => {
+    if (request.method() !== "POST") return route.fallback();
+    return route.fulfill({ status: 401, body: "" });
+  });
+  await page.goto("/");
+  await page.waitForLoadState("networkidle");
+  await expect(page.getByTestId("landing-page")).toBeVisible({
+    timeout: 10000,
+  });
+}
+
+// --- Given (FR + EN) ---
+
+Given("je consulte la page d'atterrissage publique", async ({ mockedPage }) => {
+  await gotoLandingAsAnonymous(mockedPage);
+});
+
+Given("I am viewing the public landing page", async ({ mockedPage }) => {
+  await gotoLandingAsAnonymous(mockedPage);
+});
+
+Given(
+  "je consulte la page d'atterrissage publique sur mobile",
+  async ({ mockedPage }) => {
+    await mockedPage.setViewportSize({ width: 390, height: 844 });
+    await gotoLandingAsAnonymous(mockedPage);
+  },
+);
+
+Given(
+  "I am viewing the public landing page on mobile",
+  async ({ mockedPage }) => {
+    await mockedPage.setViewportSize({ width: 390, height: 844 });
+    await gotoLandingAsAnonymous(mockedPage);
+  },
+);
+
+// --- Then: page + sections (FR + EN) ---
+
+Then("la page d'atterrissage est visible", async ({ mockedPage }) => {
+  await expect(mockedPage.getByTestId("landing-page")).toBeVisible();
+});
+
+Then("the landing page is visible", async ({ mockedPage }) => {
+  await expect(mockedPage.getByTestId("landing-page")).toBeVisible();
+});
+
+Then("la section héros est visible", async ({ mockedPage }) => {
+  await expect(mockedPage.getByTestId("section-hero")).toBeVisible();
+});
+
+Then("the hero section is visible", async ({ mockedPage }) => {
+  await expect(mockedPage.getByTestId("section-hero")).toBeVisible();
+});
+
+Then('la section "Comment ça marche" est visible', async ({ mockedPage }) => {
+  await mockedPage.getByTestId("section-how-it-works").scrollIntoViewIfNeeded();
+  await expect(mockedPage.getByTestId("section-how-it-works")).toBeVisible();
+});
+
+Then('the "how it works" section is visible', async ({ mockedPage }) => {
+  await mockedPage.getByTestId("section-how-it-works").scrollIntoViewIfNeeded();
+  await expect(mockedPage.getByTestId("section-how-it-works")).toBeVisible();
+});
+
+Then("la section des avantages est visible", async ({ mockedPage }) => {
+  await mockedPage.getByTestId("section-features").scrollIntoViewIfNeeded();
+  await expect(mockedPage.getByTestId("section-features")).toBeVisible();
+});
+
+Then("the features section is visible", async ({ mockedPage }) => {
+  await mockedPage.getByTestId("section-features").scrollIntoViewIfNeeded();
+  await expect(mockedPage.getByTestId("section-features")).toBeVisible();
+});
+
+Then("la grille bento est visible", async ({ mockedPage }) => {
+  await expect(mockedPage.getByTestId("bento-grid")).toBeVisible();
+});
+
+Then("the bento grid is visible", async ({ mockedPage }) => {
+  await expect(mockedPage.getByTestId("bento-grid")).toBeVisible();
+});
+
+Then("la section des sources est visible", async ({ mockedPage }) => {
+  await mockedPage.getByTestId("section-sources").scrollIntoViewIfNeeded();
+  await expect(mockedPage.getByTestId("section-sources")).toBeVisible();
+});
+
+Then("the sources section is visible", async ({ mockedPage }) => {
+  await mockedPage.getByTestId("section-sources").scrollIntoViewIfNeeded();
+  await expect(mockedPage.getByTestId("section-sources")).toBeVisible();
+});
+
+Then("la source {string} est affichée", async ({ mockedPage }, key: string) => {
+  await expect(mockedPage.getByTestId(`source-${key}`).first()).toBeVisible();
+});
+
+Then(
+  "the {string} source is displayed",
+  async ({ mockedPage }, key: string) => {
+    await expect(mockedPage.getByTestId(`source-${key}`).first()).toBeVisible();
+  },
+);
+
+Then("la section des plateformes est visible", async ({ mockedPage }) => {
+  await mockedPage.getByTestId("section-availability").scrollIntoViewIfNeeded();
+  await expect(mockedPage.getByTestId("section-availability")).toBeVisible();
+});
+
+Then("the platforms section is visible", async ({ mockedPage }) => {
+  await mockedPage.getByTestId("section-availability").scrollIntoViewIfNeeded();
+  await expect(mockedPage.getByTestId("section-availability")).toBeVisible();
+});
+
+Then("la section des témoignages est visible", async ({ mockedPage }) => {
+  await mockedPage.getByTestId("section-testimonials").scrollIntoViewIfNeeded();
+  await expect(mockedPage.getByTestId("section-testimonials")).toBeVisible();
+});
+
+Then("the testimonials section is visible", async ({ mockedPage }) => {
+  await mockedPage.getByTestId("section-testimonials").scrollIntoViewIfNeeded();
+  await expect(mockedPage.getByTestId("section-testimonials")).toBeVisible();
+});
+
+// --- Then: footer + CTA (FR + EN) ---
+
+Then("le footer est visible", async ({ mockedPage }) => {
+  await mockedPage.getByTestId("section-footer").scrollIntoViewIfNeeded();
+  await expect(mockedPage.getByTestId("section-footer")).toBeVisible();
+});
+
+Then("the footer is visible", async ({ mockedPage }) => {
+  await mockedPage.getByTestId("section-footer").scrollIntoViewIfNeeded();
+  await expect(mockedPage.getByTestId("section-footer")).toBeVisible();
+});
+
+Then("le lien GitHub du footer est visible", async ({ mockedPage }) => {
+  await expect(mockedPage.getByTestId("footer-github")).toBeVisible();
+});
+
+Then("the footer GitHub link is visible", async ({ mockedPage }) => {
+  await expect(mockedPage.getByTestId("footer-github")).toBeVisible();
+});
+
+Then("le lien légal du footer est visible", async ({ mockedPage }) => {
+  await expect(mockedPage.getByTestId("footer-legal")).toBeVisible();
+});
+
+Then("the footer legal link is visible", async ({ mockedPage }) => {
+  await expect(mockedPage.getByTestId("footer-legal")).toBeVisible();
+});
+
+Then(
+  "le lien de confidentialité du footer est visible",
+  async ({ mockedPage }) => {
+    await expect(mockedPage.getByTestId("footer-privacy")).toBeVisible();
+  },
+);
+
+Then("the footer privacy link is visible", async ({ mockedPage }) => {
+  await expect(mockedPage.getByTestId("footer-privacy")).toBeVisible();
+});
+
+Then(
+  "l'appel à l'action \"Créer un itinéraire\" est visible",
+  async ({ mockedPage }) => {
+    await expect(
+      mockedPage.getByTestId("cta-create-itinerary").first(),
+    ).toBeVisible();
+  },
+);
+
+Then(
+  'the "Créer un itinéraire" call to action is visible',
+  async ({ mockedPage }) => {
+    await expect(
+      mockedPage.getByTestId("cta-create-itinerary").first(),
+    ).toBeVisible();
+  },
+);
+
+Then("le bouton de démonstration est visible", async ({ mockedPage }) => {
+  await expect(mockedPage.getByTestId("cta-demo")).toBeVisible();
+});
+
+Then("the demo button is visible", async ({ mockedPage }) => {
+  await expect(mockedPage.getByTestId("cta-demo")).toBeVisible();
+});
+
+Then(
+  'le bouton "Créer un itinéraire" pointe vers {string}',
+  async ({ mockedPage }, href: string) => {
+    await expect(
+      mockedPage.getByTestId("cta-create-itinerary").first(),
+    ).toHaveAttribute("href", href);
+  },
+);
+
+Then(
+  'the "Créer un itinéraire" button points to {string}',
+  async ({ mockedPage }, href: string) => {
+    await expect(
+      mockedPage.getByTestId("cta-create-itinerary").first(),
+    ).toHaveAttribute("href", href);
+  },
+);

--- a/pwa/tests/recette/steps/stage-management.steps.ts
+++ b/pwa/tests/recette/steps/stage-management.steps.ts
@@ -4,8 +4,20 @@ import {
   routeParsedEvent,
   stagesComputedEvent,
   tripCompleteEvent,
+  supplyTimelineEvent,
 } from "../../fixtures/mock-data";
 import { getTripId } from "../../fixtures/api-mocks";
+
+// Maps the localized supply-marker icon word to the emoji rendered by the
+// SupplyTimeline component (water 💧, food 🍴, mixed 🏘️).
+const SUPPLY_ICON: Record<string, string> = {
+  eau: "💧",
+  water: "💧",
+  nourriture: "🍴",
+  food: "🍴",
+  mixte: "🏘️",
+  mixed: "🏘️",
+};
 
 // ---------------------------------------------------------------------------
 // Stage management — FR + EN
@@ -444,5 +456,166 @@ Then(
     // It only renders after stages are computed (dayNumbers > 0), so it cannot be
     // observed "during computation". No computation progress bar exists in the app.
     $test.fixme();
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Supply timeline — FR + EN
+// The Background ships a full trip; supply markers arrive via a
+// `supply_timeline` SSE event for the targeted stage index.
+// ---------------------------------------------------------------------------
+
+Given(
+  "des données de ravitaillement sont disponibles pour l'étape {int}",
+  async ({ injectEvent }, stage: number) => {
+    await injectEvent(supplyTimelineEvent(stage - 1));
+  },
+);
+
+Given(
+  "supply data is available for stage {int}",
+  async ({ injectEvent }, stage: number) => {
+    await injectEvent(supplyTimelineEvent(stage - 1));
+  },
+);
+
+Given(
+  "des données de ravitaillement sont disponibles pour l'étape {int} sur mobile",
+  async ({ mockedPage, injectEvent }, stage: number) => {
+    await mockedPage.setViewportSize({ width: 390, height: 844 });
+    await injectEvent(supplyTimelineEvent(stage - 1));
+  },
+);
+
+Given(
+  "supply data is available for stage {int} on mobile",
+  async ({ mockedPage, injectEvent }, stage: number) => {
+    await mockedPage.setViewportSize({ width: 390, height: 844 });
+    await injectEvent(supplyTimelineEvent(stage - 1));
+  },
+);
+
+When(
+  "j'ouvre le marqueur de ravitaillement à {int} km",
+  async ({ mockedPage }, km: number) => {
+    await mockedPage.getByTestId(`supply-marker-${km}`).click();
+  },
+);
+
+When(
+  "I open the supply marker at {int} km",
+  async ({ mockedPage }, km: number) => {
+    await mockedPage.getByTestId(`supply-marker-${km}`).click();
+  },
+);
+
+Then(
+  "la timeline des ravitaillements de l'étape {int} est visible",
+  async ({ mockedPage }, stage: number) => {
+    await expect(
+      mockedPage
+        .getByTestId(`stage-card-${stage}`)
+        .getByTestId("supply-timeline"),
+    ).toBeVisible({ timeout: 10000 });
+  },
+);
+
+Then(
+  "the supply timeline of stage {int} is visible",
+  async ({ mockedPage }, stage: number) => {
+    await expect(
+      mockedPage
+        .getByTestId(`stage-card-${stage}`)
+        .getByTestId("supply-timeline"),
+    ).toBeVisible({ timeout: 10000 });
+  },
+);
+
+Then(
+  "le marqueur de ravitaillement à {int} km affiche l'icône {word}",
+  async ({ mockedPage }, km: number, icon: string) => {
+    const marker = mockedPage.getByTestId(`supply-marker-${km}`);
+    await expect(marker).toBeVisible({ timeout: 10000 });
+    await expect(marker).toContainText(SUPPLY_ICON[icon] ?? icon);
+  },
+);
+
+Then(
+  "the supply marker at {int} km shows the {word} icon",
+  async ({ mockedPage }, km: number, icon: string) => {
+    const marker = mockedPage.getByTestId(`supply-marker-${km}`);
+    await expect(marker).toBeVisible({ timeout: 10000 });
+    await expect(marker).toContainText(SUPPLY_ICON[icon] ?? icon);
+  },
+);
+
+Then(
+  "l'info-bulle de ravitaillement affiche {string}",
+  async ({ mockedPage }, text: string) => {
+    await expect(mockedPage.getByTestId("supply-tooltip")).toContainText(text, {
+      timeout: 3000,
+    });
+  },
+);
+
+Then(
+  "the supply tooltip shows {string}",
+  async ({ mockedPage }, text: string) => {
+    await expect(mockedPage.getByTestId("supply-tooltip")).toContainText(text, {
+      timeout: 3000,
+    });
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Timeline / roadbook redesign — FR + EN
+// The Background's full trip provides active stages, so the ViewModeToggle and
+// the split layout (#timeline + map-panel) render. Geometry-free is fine: the
+// panels' visibility depends on `activeStages.length`, not on geometry.
+// ---------------------------------------------------------------------------
+
+Given("je passe sur un écran mobile", async ({ mockedPage }) => {
+  await mockedPage.setViewportSize({ width: 390, height: 844 });
+});
+
+Given("I switch to a mobile screen", async ({ mockedPage }) => {
+  await mockedPage.setViewportSize({ width: 390, height: 844 });
+});
+
+Then("la timeline est visible", async ({ mockedPage }) => {
+  await expect(mockedPage.locator("#timeline")).toBeVisible({ timeout: 5000 });
+});
+
+Then("the timeline is visible", async ({ mockedPage }) => {
+  await expect(mockedPage.locator("#timeline")).toBeVisible({ timeout: 5000 });
+});
+
+Then(
+  "le bouton de mode {string} est actif",
+  async ({ mockedPage }, mode: string) => {
+    const modeMap: Record<string, string> = {
+      "carte seule": "view-mode-map",
+      "vue splitée": "view-mode-split",
+      chronologie: "view-mode-timeline",
+    };
+    const testId = modeMap[mode] ?? `view-mode-${mode}`;
+    await expect(
+      mockedPage.getByTestId("view-mode-toggle").getByTestId(testId),
+    ).toHaveAttribute("aria-pressed", "true", { timeout: 5000 });
+  },
+);
+
+Then(
+  "the {string} view mode button is active",
+  async ({ mockedPage }, mode: string) => {
+    const modeMap: Record<string, string> = {
+      "map only": "view-mode-map",
+      "split view": "view-mode-split",
+      timeline: "view-mode-timeline",
+    };
+    const testId = modeMap[mode] ?? `view-mode-${mode}`;
+    await expect(
+      mockedPage.getByTestId("view-mode-toggle").getByTestId(testId),
+    ).toHaveAttribute("aria-pressed", "true", { timeout: 5000 });
   },
 );


### PR DESCRIPTION
## Sprint 35.3 — Ordre 3 : combler les domaines `.feature` absents + parité

Comble les domaines de recette Gherkin non couverts (assistant IA, page
d'atterrissage) et complète les domaines transverses, en garantissant la parité
FR/EN.

### Livrables
- **`ai-features.{fr,en}.feature`** (24 scénarios) — synthèse IA voyage/étape,
  chat IA (in-ride, POI, géoloc), affinage (`AiRefinementCard`), surlignage de
  diff après recalcul inline (`diff-highlight-*`).
- **`landing-page.{fr,en}.feature`** (9 scénarios) — page anon : héros, sections
  (comment ça marche, avantages, bento, sources, plateformes, témoignages),
  footer, CTA.
- **`cross-cutting-ux.{fr,en}.feature`** (12 → 24) — raccourcis, thème, langue,
  onboarding, scroll-to-top.
- **`stage-management.{fr,en}.feature`** (12 → 20) — ajout/suppression/jour de
  repos/undo-redo.
- Steps associés, réutilisant les fixtures partagées (`mockedPage`, `submitUrl`,
  `createFullTrip`, injection SSE).

### Corrections (scénarios écrits sans exécution, alignés sur l'app réelle)
- **landing sources** : le testid de la carte RideWithGPS est `source-rwgps`
  (clé de la source dans `sources.tsx`), pas `source-ridewithgps`.
- **ai-features diff-highlight** : le déclencheur "sélectionner l'hébergement"
  était matché par le libellé **français uniquement**, d'où le timeout des
  scénarios EN. Désormais bilingue (`/Sélectionner cet hébergement|Select
  accommodation/`), comme golden-paths.

### Vérification (sortie réelle, stack iso-prod locale)
`make test-recette` sur cette branche : **379 passed / 50 skipped / 1 flake**.
L'unique échec (`auth-security.fr › Pas de traces de pile`, hors périmètre O3)
est un flake de la suite complète (race sur `magic-link-input` sous charge) :
il **passe en isolation** (`--grep "Pas de traces de pile"` → 1 passed en 3,5s)
et la CI le rejoue (`retries: 1`).

### Auto-critique
- **Diagnostics initiaux faux** : la version initiale visait `source-ridewithgps`
  et un bouton FR-only ; corrigé après exécution réelle contre l'app (les
  testids/labels existent, mais sous d'autres clés/locales).
- **Parité** : chaque scénario a son pendant FR/EN (mêmes steps, libellés
  localisés).
- **Périmètre** : recette Gherkin uniquement ; aucun changement applicatif.
  `make test`/`typegen` non lancés (sprint sans PHP, hors périmètre).

<!-- claude-review-start -->
## Claude Review

Reviewed commit `900cfba584ba6a32f519174c8cd9ffce82fb5e86`.

**Findings:** 0 findings — no new issues.

**Resolved threads:** Resolved 1 previously open thread — diff-highlight `void n` scoping, addressed in commit `900cfba` (`fix(recette): scope diff-highlight assertions to the stage card`).

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date *(n/a — test-only PR)*
- [x] Dependent tickets accounted for

**Inline comments:** None.
<!-- claude-review-end -->