### PR TITLE
docs(tracking): Sprint 35.3 terminé (O1-O5)

### DIFF
--- a/TRACKING.md
+++ b/TRACKING.md
@@ -734,15 +734,19 @@ Exécute l'outillage de 35 + revue ciblée, produit des **findings en issues** (
 
 Transforme le référentiel (35.1) en couverture automatisée + valide les baselines VR. Dépend de 35 + 35.1. Exécution : fan-out par domaine d'écran, findings -> issues (milestone `Sprint 35.4`). _(ex-ordres 20-31)_
 
-| Ordre | Titre | Effort |
-|---|---|---|
-| 1 | Tests Playwright : vérifier l'existant et réparer le périmé (refonte design S25-27, IA S30-32) | M |
-| 2 | Golden paths A/B/C + cas limites en Gherkin (checklists ci-dessous) | L |
-| 3 | Combler les domaines `.feature` absents (IA, design) | M |
-| 4 | Baselines VR (36 pages + set « états ») + comparaison app vs design (présence + position) | M |
-| 5 | Vérifier liens & ancres (docs, README, ADR, rapport recette) : aucun lien mort (404) ni ancre disparue | S |
+**✅ Livré** — 5 ordres, 4 PRs (O1 = no-op). Couverture Gherkin étendue (golden paths A/B/C + cas limites, IA, landing, parité FR/EN), baselines VR stabilisées et findings app-vs-design catalogués, liens/ancres vérifiés via outil reproductible.
+
+| Ordre | Titre | Effort | PRs |
+|---|---|---|---|
+| 1 | Tests Playwright : vérifier l'existant et réparer le périmé (refonte design S25-27, IA S30-32) | M | ✅ no-op — suite verte en CI (aucun test périmé ; échecs locaux dus à un build `pwa:ci` obsolète, levés après rebuild) |
+| 2 | Golden paths A/B/C + cas limites en Gherkin (checklists ci-dessous) | L | [#627](https://github.com/vincentchalamon/bike-trip-planner/pull/627) |
+| 3 | Combler les domaines `.feature` absents (IA, design) | M | [#623](https://github.com/vincentchalamon/bike-trip-planner/pull/623) |
+| 4 | Baselines VR (36 pages + set « états ») + comparaison app vs design (présence + position) | M | [#624](https://github.com/vincentchalamon/bike-trip-planner/pull/624) |
+| 5 | Vérifier liens & ancres (docs, README, ADR, rapport recette) : aucun lien mort (404) ni ancre disparue | S | [#622](https://github.com/vincentchalamon/bike-trip-planner/pull/622) |
 
 DoD : `make test-e2e` + `make test-recette` + `make visual-test` verts ; chaque écran du manifeste 35.1 a un verdict ; aucun lien/ancre cassé (ordre 5).
+
+**État DoD** : `test-recette` vert (golden paths + cas limites ; 2 scénarios `@fixme` documentés : multi-onglets, upload 30MB) ; `visual-test` vert (81 passed / 21 skipped — écrans à carte skippés sur Firefox sans WebGL + mobile 375px, raison documentée) ; verdict par écran consolidé dans [`docs/recette/app-vs-design-findings.md`](docs/recette/app-vs-design-findings.md) (divergences fonctionnelles/éléments/positionnement → hotlist Sprint 35.4) ; liens/ancres OK (`make link-check`). `manifest.spec.ts` (assertions de région) retiré au profit du document de findings (faux positifs : variante authentifiée + heuristique de viewport).
 
 ---
 


### PR DESCRIPTION
## Sprint 35.3 — Audit fonctionnel + couverture : clôture du suivi

Marque les 5 ordres du Sprint 35.3 comme livrés dans `TRACKING.md`, avec les PRs et l'état du DoD.

| Ordre | Livrable | PR |
|---|---|---|
| 1 | Tests Playwright périmés | ✅ no-op (suite verte en CI ; échecs locaux = build `pwa:ci` obsolète) |
| 2 | Golden paths A/B/C + cas limites | [#627](https://github.com/vincentchalamon/bike-trip-planner/pull/627) |
| 3 | Domaines `.feature` absents (IA, landing) + parité | [#623](https://github.com/vincentchalamon/bike-trip-planner/pull/623) |
| 4 | Baselines VR + comparaison app vs design | [#624](https://github.com/vincentchalamon/bike-trip-planner/pull/624) |
| 5 | Vérif liens & ancres | [#622](https://github.com/vincentchalamon/bike-trip-planner/pull/622) |

### État DoD
- `make test-recette` vert (2 `@fixme` documentés : multi-onglets, upload 30MB).
- `make visual-test` vert (81 passed / 21 skipped ; écrans à carte skippés sur Firefox sans WebGL + mobile 375px).
- Verdict par écran : [`docs/recette/app-vs-design-findings.md`](docs/recette/app-vs-design-findings.md) (livré par #624), divergences → hotlist Sprint 35.4.
- Liens/ancres OK (`make link-check`, #622).

À merger **après** les PRs d'ordre (#622, #623, #624, #627).

<!-- claude-review-start -->
## Claude Review

Pure documentation PR — marks Sprint 35.3 as delivered in `TRACKING.md` with PR links, effort, and DoD status. Clean change with no code concerns.

**Findings: 0 critical · 0 warning · 1 note**

**PR title note:** `docs(tracking): Sprint 35.3 terminé (O1-O5)` — "terminé" is a past participle, not imperative mood. Conventional Commits requires an imperative description (matching the commit message itself: `mark Sprint 35.3 complete (O1-O5, PRs #622-#627)`).

Reviewed commit: `269ac2bec54f94118efd554f8dd6e874e9a4ab3a`

### Review checklist
- [x] Code respects the project architecture _(N/A — docs only)_
- [x] SOLID principles and Law of Demeter followed _(N/A — docs only)_
- [x] Design patterns used where appropriate _(N/A — docs only)_
- [x] Tests cover new/changed cases _(N/A — docs only)_
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

No inline comments.
<!-- claude-review-end -->