### PR TITLE
fix(security): make account deletion final + purge residual PII (RGPD)

### DIFF
--- a/api/config/packages/security.php
+++ b/api/config/packages/security.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Entity\User;
+use App\Security\DeletedUserChecker;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
@@ -24,6 +25,9 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 'pattern' => '^/',
                 'stateless' => true,
                 'provider' => 'app_user_provider',
+                // Reject soft-deleted (anonymised) accounts on every authentication,
+                // including the per-request JWT reload (see DeletedUserChecker).
+                'user_checker' => DeletedUserChecker::class,
                 'jwt' => [],
                 // Object-level authz denials (TRIP_*) are surfaced as 404, not 403, to
                 // avoid leaking trip existence by enumeration (ADR-038). Handled by

--- a/api/src/Repository/AccessRequestRepository.php
+++ b/api/src/Repository/AccessRequestRepository.php
@@ -25,6 +25,23 @@ final class AccessRequestRepository extends ServiceEntityRepository
     }
 
     /**
+     * Marks every access request for the given email for removal.
+     *
+     * Does NOT flush — the caller is responsible for flushing. Used by GDPR
+     * erasure: the table holds the email + IP as plain PII with no user FK, so
+     * it must be purged explicitly on account deletion.
+     */
+    public function removeAllForEmail(string $email): void
+    {
+        $this->getEntityManager()->createQueryBuilder()
+            ->delete(AccessRequest::class, 'ar')
+            ->where('ar.email = :email')
+            ->setParameter('email', $email)
+            ->getQuery()
+            ->execute();
+    }
+
+    /**
      * @return list<AccessRequest>
      */
     public function findVerified(

--- a/api/src/Repository/MagicLinkRepository.php
+++ b/api/src/Repository/MagicLinkRepository.php
@@ -84,6 +84,24 @@ final class MagicLinkRepository extends ServiceEntityRepository
         return $magicLink?->getUser();
     }
 
+    /**
+     * Marks all magic links for the given user for removal.
+     *
+     * Does NOT flush — the caller is responsible for flushing. Used by GDPR
+     * erasure: the soft-delete (anonymise) does not trigger the FK ON DELETE
+     * CASCADE, so lingering links would otherwise survive and could still be
+     * consumed.
+     */
+    public function removeAllForUser(User $user): void
+    {
+        $this->getEntityManager()->createQueryBuilder()
+            ->delete(MagicLink::class, 'ml')
+            ->where('ml.user = :user')
+            ->setParameter('user', $user)
+            ->getQuery()
+            ->execute();
+    }
+
     private function hasActiveLinkForUser(User $user): bool
     {
         $count = $this->createQueryBuilder('ml')

--- a/api/src/Security/DeletedUserChecker.php
+++ b/api/src/Security/DeletedUserChecker.php
@@ -26,7 +26,10 @@ final class DeletedUserChecker implements UserCheckerInterface
     public function checkPreAuth(UserInterface $user): void
     {
         if ($user instanceof User && $user->isDeleted()) {
-            throw new CustomUserMessageAccountStatusException('Account deleted.');
+            // Neutral message: Lexik surfaces it verbatim in the 401 body, so it
+            // must not reveal that the account ever existed (same rationale as the
+            // neutral key in AuthVerifyProcessor).
+            throw new CustomUserMessageAccountStatusException('Invalid credentials.');
         }
     }
 

--- a/api/src/Security/DeletedUserChecker.php
+++ b/api/src/Security/DeletedUserChecker.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Security;
+
+use App\Entity\User;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\CustomUserMessageAccountStatusException;
+use Symfony\Component\Security\Core\User\UserCheckerInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * Rejects authentication for soft-deleted (anonymised) accounts.
+ *
+ * GDPR erasure soft-deletes the account (stamps deletedAt, anonymises the email)
+ * rather than hard-deleting the row, so the FK ON DELETE CASCADE never fires and
+ * the user remains loadable by the JWT user provider. Without this guard a
+ * lingering credential (an un-purged magic link, or a JWT minted before the
+ * deletion) could still authenticate the deleted account. Wired as the firewall
+ * user_checker so it runs on every authentication, including the per-request JWT
+ * reload — a deleted account is rejected globally.
+ */
+final class DeletedUserChecker implements UserCheckerInterface
+{
+    public function checkPreAuth(UserInterface $user): void
+    {
+        if ($user instanceof User && $user->isDeleted()) {
+            throw new CustomUserMessageAccountStatusException('Account deleted.');
+        }
+    }
+
+    public function checkPostAuth(UserInterface $user, ?TokenInterface $token = null): void
+    {
+    }
+}

--- a/api/src/State/Account/AccountDeleteProcessor.php
+++ b/api/src/State/Account/AccountDeleteProcessor.php
@@ -9,6 +9,8 @@ use ApiPlatform\State\ProcessorInterface;
 use App\ApiResource\Account\Account;
 use App\ApiResource\TripRequest;
 use App\Entity\User;
+use App\Repository\AccessRequestRepository;
+use App\Repository\MagicLinkRepository;
 use App\Repository\RefreshTokenRepository;
 use App\Security\AuthCookies;
 use Doctrine\ORM\EntityManagerInterface;
@@ -33,6 +35,8 @@ final readonly class AccountDeleteProcessor implements ProcessorInterface
     public function __construct(
         private EntityManagerInterface $entityManager,
         private RefreshTokenRepository $refreshTokenRepository,
+        private MagicLinkRepository $magicLinkRepository,
+        private AccessRequestRepository $accessRequestRepository,
         private Security $security,
         private LoggerInterface $logger,
     ) {
@@ -47,7 +51,11 @@ final readonly class AccountDeleteProcessor implements ProcessorInterface
 
         \assert($user instanceof User);
 
-        $this->entityManager->wrapInTransaction(function () use ($user): void {
+        // Capture the email before anonymisation so we can purge the standalone
+        // access_request rows (email PII, no user FK) that hold it.
+        $email = $user->getEmail();
+
+        $this->entityManager->wrapInTransaction(function () use ($user, $email): void {
             // Purge trips (cascades to stages, chat messages and shares via FK
             // ON DELETE CASCADE) which also removes the per-trip preferences.
             $this->entityManager->createQueryBuilder()
@@ -59,6 +67,15 @@ final readonly class AccountDeleteProcessor implements ProcessorInterface
 
             // Revoke every refresh token so lingering sessions cannot be reused.
             $this->refreshTokenRepository->removeAllForUser($user);
+
+            // Purge magic links: the soft-delete below does not trigger the FK
+            // ON DELETE CASCADE, so a lingering valid link could otherwise still
+            // authenticate the (now anonymised) account.
+            $this->magicLinkRepository->removeAllForUser($user);
+
+            // Purge early-access requests holding the email/IP PII (standalone
+            // table, no user FK).
+            $this->accessRequestRepository->removeAllForEmail($email);
 
             // Soft-delete + irreversible PII anonymisation.
             $user->anonymize();

--- a/api/src/State/Auth/AuthRefreshProcessor.php
+++ b/api/src/State/Auth/AuthRefreshProcessor.php
@@ -76,9 +76,24 @@ final readonly class AuthRefreshProcessor implements ProcessorInterface
             return $response;
         }
 
+        $user = $existing->getUser();
+
+        // A deleted (anonymised) account must never be re-authenticated, even if
+        // a refresh token lingered (GDPR erasure is final). Reject + clear cookie.
+        if ($user->isDeleted()) {
+            $this->logger->warning('Auth refresh attempted on a deleted account', ['user' => $user->getId()->toRfc4122()]);
+
+            $response = new JsonResponse(
+                ['error' => $this->translator->trans('auth.error.refresh_invalid', [], 'auth')],
+                Response::HTTP_UNAUTHORIZED,
+            );
+            $response->headers->clearCookie(AuthCookies::REFRESH_TOKEN, '/', null, true, true, 'strict');
+
+            return $response;
+        }
+
         // Atomic expire + rotate in a single transaction to prevent TOCTOU race
         // and ensure no token is lost if the flush fails.
-        $user = $existing->getUser();
         $expiredRows = 0;
         $newRefreshToken = null;
 

--- a/api/src/State/Auth/AuthVerifyProcessor.php
+++ b/api/src/State/Auth/AuthVerifyProcessor.php
@@ -57,6 +57,18 @@ final readonly class AuthVerifyProcessor implements ProcessorInterface
             );
         }
 
+        // A deleted (anonymised) account must never be re-authenticated, even
+        // with an otherwise-valid magic link (GDPR erasure is final). Neutral
+        // 401 — do not leak that the account existed.
+        if ($user->isDeleted()) {
+            $this->logger->warning('Auth verify attempted on a deleted account', ['user' => $user->getId()->toRfc4122()]);
+
+            return new JsonResponse(
+                ['error' => $this->translator->trans('auth.error.invalid_link', [], 'auth')],
+                Response::HTTP_UNAUTHORIZED,
+            );
+        }
+
         $jwt = $this->jwtManager->create($user);
 
         // Wrap refresh token creation in a transaction: if flush fails, the

--- a/api/tests/Functional/Account/AccountDeleteTest.php
+++ b/api/tests/Functional/Account/AccountDeleteTest.php
@@ -6,8 +6,12 @@ namespace App\Tests\Functional\Account;
 
 use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
 use App\ApiResource\TripRequest;
+use App\Entity\AccessRequest;
+use App\Entity\MagicLink;
 use App\Entity\RefreshToken;
 use App\Entity\User;
+use App\Repository\AccessRequestRepository;
+use App\Repository\MagicLinkRepository;
 use App\Repository\RefreshTokenRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
@@ -161,6 +165,72 @@ final class AccountDeleteTest extends ApiTestCase
     {
         self::createClient()->request('DELETE', '/users/me');
 
+        $this->assertResponseStatusCodeSame(401);
+    }
+
+    #[Test]
+    public function deleteAccountPurgesMagicLinks(): void
+    {
+        $fixtures = $this->createUserWithTrip('magic-purge@example.com');
+        $user = $fixtures['user'];
+        $userId = $user->getId()->toRfc4122();
+
+        $em = $this->getEntityManager();
+        $em->persist(new MagicLink($user, 'lingering-link-token', new \DateTimeImmutable('+30 minutes')));
+        $em->flush();
+
+        self::createClient()->request('DELETE', '/users/me', [
+            'headers' => ['Authorization' => 'Bearer '.$fixtures['jwt']],
+        ]);
+        $this->assertResponseStatusCodeSame(204);
+
+        /** @var MagicLinkRepository $repo */
+        $repo = self::getContainer()->get(MagicLinkRepository::class);
+        $em->clear();
+        $reloaded = $em->find(User::class, Uuid::fromString($userId));
+        \assert($reloaded instanceof User);
+
+        $this->assertCount(0, $repo->findBy(['user' => $reloaded]), 'magic_link rows must be purged on erasure');
+    }
+
+    #[Test]
+    public function deleteAccountPurgesAccessRequest(): void
+    {
+        $email = 'access-purge@example.com';
+        $em = $this->getEntityManager();
+        $em->persist(new AccessRequest($email, '203.0.113.7'));
+        $em->flush();
+
+        $fixtures = $this->createUserWithTrip($email);
+
+        self::createClient()->request('DELETE', '/users/me', [
+            'headers' => ['Authorization' => 'Bearer '.$fixtures['jwt']],
+        ]);
+        $this->assertResponseStatusCodeSame(204);
+
+        /** @var AccessRequestRepository $repo */
+        $repo = self::getContainer()->get(AccessRequestRepository::class);
+        $em->clear();
+
+        $this->assertNull($repo->findByEmail($email), 'access_request PII must be purged on erasure');
+    }
+
+    #[Test]
+    public function deletedAccountJwtIsRejected(): void
+    {
+        // After erasure, a JWT minted for the account must no longer authenticate
+        // (DeletedUserChecker rejects the soft-deleted user on the per-request
+        // JWT reload).
+        $fixtures = $this->createUserWithTrip('ghost@example.com');
+
+        self::createClient()->request('DELETE', '/users/me', [
+            'headers' => ['Authorization' => 'Bearer '.$fixtures['jwt']],
+        ]);
+        $this->assertResponseStatusCodeSame(204);
+
+        self::createClient()->request('GET', '/trips', [
+            'headers' => ['Authorization' => 'Bearer '.$fixtures['jwt']],
+        ]);
         $this->assertResponseStatusCodeSame(401);
     }
 }

--- a/api/tests/Functional/Auth/AuthRefreshTest.php
+++ b/api/tests/Functional/Auth/AuthRefreshTest.php
@@ -149,4 +149,18 @@ final class AuthRefreshTest extends ApiTestCase
         $parts = explode('.', (string) $data['token']);
         $this->assertCount(3, $parts, 'JWT should have 3 dot-separated parts');
     }
+
+    #[Test]
+    public function refreshDeletedAccountReturns401(): void
+    {
+        // A lingering refresh token must not re-authenticate a deleted account.
+        $user = $this->createUserWithRefreshToken('deleted-refresh@example.com', 'deleted-refresh-token');
+        $em = $this->getEntityManager();
+        $user->anonymize();
+        $em->flush();
+
+        $this->sendRefreshRequest('deleted-refresh-token');
+
+        $this->assertResponseStatusCodeSame(401);
+    }
 }

--- a/api/tests/Functional/Auth/AuthRefreshTest.php
+++ b/api/tests/Functional/Auth/AuthRefreshTest.php
@@ -159,8 +159,17 @@ final class AuthRefreshTest extends ApiTestCase
         $user->anonymize();
         $em->flush();
 
-        $this->sendRefreshRequest('deleted-refresh-token');
+        $response = $this->sendRefreshRequest('deleted-refresh-token');
 
         $this->assertResponseStatusCodeSame(401);
+
+        // The deleted-account branch clears the refresh cookie: a refresh_token
+        // Set-Cookie must be present and expired (Max-Age=0 / 1970), not absent.
+        $setCookie = $response->getHeaders(false)['set-cookie'][0] ?? '';
+        $this->assertStringContainsString('refresh_token=', $setCookie);
+        $this->assertMatchesRegularExpression(
+            '/Max-Age=0|expires=Thu, 01-Jan-1970/i',
+            $setCookie,
+        );
     }
 }

--- a/api/tests/Functional/Auth/AuthVerifyTest.php
+++ b/api/tests/Functional/Auth/AuthVerifyTest.php
@@ -184,4 +184,30 @@ final class AuthVerifyTest extends ApiTestCase
         $parts = explode('.', (string) $data['token']);
         $this->assertCount(3, $parts, 'JWT should have 3 dot-separated parts');
     }
+
+    #[Test]
+    public function verifyDeletedAccountReturns401(): void
+    {
+        // A still-valid magic link must not re-authenticate a deleted account
+        // (GDPR erasure is final). Guards against the auth-bypass where the link
+        // outlived the account (magic links are now purged on deletion, but the
+        // auth path must reject deleted users regardless).
+        $user = $this->createUserWithMagicLink('deleted@example.com', 'deleted-account-token');
+        $em = $this->getEntityManager();
+        $user->anonymize();
+        $em->flush();
+
+        $response = self::createClient()->request('POST', '/auth/verify', [
+            'headers' => ['Content-Type' => 'application/ld+json'],
+            'json' => ['token' => 'deleted-account-token'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(401);
+
+        // No session must be established for a deleted account.
+        $cookies = $response->getHeaders(false)['set-cookie'] ?? [];
+        foreach ($cookies as $cookie) {
+            $this->assertStringStartsNotWith('refresh_token=', (string) $cookie, 'No refresh cookie for a deleted account');
+        }
+    }
 }


### PR DESCRIPTION
## Durcissement pré-recette (findings audit 35.2 + bug surfacé au challenge)

Premier d'une série de PRs de durcissement avant la recette manuelle. Celle-ci traite le
point **sécurité + RGPD** le plus important — **non listé dans le rapport d'audit**, confirmé par
lecture du code lors du challenge du plan.

### Bug : un compte supprimé pouvait se ré-authentifier
- `AuthVerifyProcessor`/`AuthRefreshProcessor` créaient un JWT **sans contrôle `isDeleted()`**.
- Aucun `user_checker` sur le firewall `api` ; `User::anonymize()` vide les rôles mais
  `getRoles()` réinjecte `ROLE_USER` → le compte supprimé restait `IS_AUTHENTICATED_FULLY`.
- `magic_link` **n'était pas purgé** à la suppression (le soft-delete ne déclenche pas la FK
  `ON DELETE CASCADE`) → un lien valide ressuscitait un compte fantôme.
- `access_request` (email + IP en clair, table standalone sans FK user) **survivait** à la
  suppression = PII résiduelle.

Impact : données déjà purgées (pas de fuite), mais la suppression **n'était pas finale** → viole
la garantie RGPD de `/privacy`. Sévérité P2 (intégrité RGPD / correction auth).

### Correctifs
- **`DeletedUserChecker`** (nouveau) câblé `user_checker` du firewall `api` : rejette un compte
  soft-deleted à **chaque** authentification (y compris le rechargement JWT par requête) → un JWT
  résiduel devient inutilisable.
- **Refus explicite (401 neutre)** dans `AuthVerifyProcessor` et `AuthRefreshProcessor` avant
  d'émettre un jeton (pas de JWT, pas de cookie).
- **Purge dans `AccountDeleteProcessor`** (transaction d'effacement existante) : `magic_link`
  (`MagicLinkRepository::removeAllForUser`) + `access_request`
  (`AccessRequestRepository::removeAllForEmail`, email capturé avant `anonymize()`).

### Tests (5, demandés)
- `AuthVerifyTest::verifyDeletedAccountReturns401` (+ aucun cookie refresh) — couvre le bypass.
- `AuthRefreshTest::refreshDeletedAccountReturns401`.
- `AccountDeleteTest::deletedAccountJwtIsRejected` (garde-fou UserChecker, GET /trips → 401).
- `AccountDeleteTest::deleteAccountPurgesMagicLinks`.
- `AccountDeleteTest::deleteAccountPurgesAccessRequest`.

### Vérification
- Local : **PHPStan Level 9 [OK] No errors**, PHP-CS-Fixer (0 fichier), Rector (clean) sur l'api
  du worktree. Les tests fonctionnels (postgres + clés JWT) sont exécutés par la CI.

### Auto-critique
- Le `UserChecker` couvre toutes les voies d'auth ; les gardes explicites dans les processors
  évitent d'émettre un jeton (401 propre) — ceinture + bretelles assumées.
- Purge `access_request` par email capturé avant anonymisation (table sans FK). Choix RGPD par
  défaut = purge ; à acter produit si une base légale de conservation existait.
- Hors périmètre (différé 35.4) : couverture (COV-API/FRONT, QUAL gates), tiers/prod
  (F5/DT-LIVE/CHAOS).

<!-- claude-review-start -->
## Claude Review

All previously raised issues were addressed in the second commit: `DeletedUserChecker` now uses a neutral `"Invalid credentials."` message, and `AuthRefreshTest::refreshDeletedAccountReturns401` correctly asserts that the refresh cookie is present but expired (`Max-Age=0`). The implementation is complete, the five functional tests cover all critical bypass paths, and no new issues were found.

**Resolved threads:** Resolved 2 previously open threads that were addressed.

## Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Reviewed commit:** `a7e1f4d9b90b298cad0886dd41b9d8eabbf6e340`

**Inline comments:** No inline comments.
<!-- claude-review-end -->