### PR TITLE
fix(security): add security headers in Caddyfile + drop x-powered-by

### DIFF
--- a/.docker/php/Caddyfile
+++ b/.docker/php/Caddyfile
@@ -95,7 +95,10 @@
         # nonce middleware); blob: by MapLibre web workers. External origins:
         # Carto/Esri/OSM map tiles + Wikimedia POI images. Plausible/Sentry are
         # env-gated off here; add their origins to script-src/connect-src when enabled.
-        header @pwa Content-Security-Policy-Report-Only "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self' 'unsafe-inline' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://basemaps.cartocdn.com https://server.arcgisonline.com https://tile.openstreetmap.org https://commons.wikimedia.org; connect-src 'self' https://basemaps.cartocdn.com https://server.arcgisonline.com https://tile.openstreetmap.org; worker-src 'self' blob:; font-src 'self' data:; manifest-src 'self'"
+        # `report-uri {$CSP_REPORT_URI:}` is a no-op when the env var is unset
+        # (dev/CI) and collects violations in prod when set to a GlitchTip/Sentry
+        # CSP endpoint, turning the Report-Only phase into a real safety net.
+        header @pwa Content-Security-Policy-Report-Only "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self' 'unsafe-inline' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://basemaps.cartocdn.com https://server.arcgisonline.com https://tile.openstreetmap.org https://commons.wikimedia.org; connect-src 'self' https://basemaps.cartocdn.com https://server.arcgisonline.com https://tile.openstreetmap.org; worker-src 'self' blob:; font-src 'self' data:; manifest-src 'self'; report-uri {$CSP_REPORT_URI:}"
 
         # Comment the following line if you don't want Next.js to catch requests for HTML documents.
         # In this case, they will be handled by the PHP app.

--- a/.docker/php/Caddyfile
+++ b/.docker/php/Caddyfile
@@ -66,6 +66,14 @@
     # Disable Topics tracking if not enabled explicitly: https://github.com/jkarlin/topics
     header ?Permissions-Policy "browsing-topics=()"
 
+    # Security headers (audit 35.2 SEC-002..004). Set site-wide; safe for both the
+    # PWA documents and the API responses. CSP (SEC-001) is scoped to the PWA in
+    # the route block below so it never touches the API docs UI.
+    header ?Strict-Transport-Security "max-age=31536000; includeSubDomains"
+    header ?X-Frame-Options "DENY"
+    header ?X-Content-Type-Options "nosniff"
+    header ?Referrer-Policy "strict-origin-when-cross-origin"
+
     route {
         # Matches requests for HTML documents, for static files and for Next.js files,
         # except for known API paths and paths with extensions handled by API Platform
@@ -78,6 +86,16 @@
             )
             || path('/favicon.ico', '/manifest.json', '/robots.txt', '/sitemap*', '/_next*', '/__next*')
             || query({'_rsc': '*'})`
+
+        # Content-Security-Policy (audit 35.2 SEC-001), scoped to the PWA so the
+        # API docs UI is untouched. Shipped as Report-Only first: it never blocks,
+        # so it carries zero regression risk while the manual recette observes any
+        # violation in the console — then it is promoted to enforce (35.4).
+        # 'unsafe-inline' (script/style) is required by Next.js hydration (no
+        # nonce middleware); blob: by MapLibre web workers. External origins:
+        # Carto/Esri/OSM map tiles + Wikimedia POI images. Plausible/Sentry are
+        # env-gated off here; add their origins to script-src/connect-src when enabled.
+        header @pwa Content-Security-Policy-Report-Only "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self' 'unsafe-inline' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://basemaps.cartocdn.com https://server.arcgisonline.com https://tile.openstreetmap.org https://commons.wikimedia.org; connect-src 'self' https://basemaps.cartocdn.com https://server.arcgisonline.com https://tile.openstreetmap.org; worker-src 'self' blob:; font-src 'self' data:; manifest-src 'self'"
 
         # Comment the following line if you don't want Next.js to catch requests for HTML documents.
         # In this case, they will be handled by the PHP app.

--- a/pwa/next.config.ts
+++ b/pwa/next.config.ts
@@ -6,6 +6,8 @@ const isMobile = process.env.BUILD_TARGET === "mobile";
 
 const nextConfig: NextConfig = {
   output: isMobile ? "export" : "standalone",
+  // Don't advertise the framework (audit 35.2 SEC-005: drop `x-powered-by`).
+  poweredByHeader: false,
   env: {
     NEXT_PUBLIC_IS_MOBILE_BUILD: isMobile ? "1" : "",
   },


### PR DESCRIPTION
## Durcissement pré-recette — audit 35.2 SEC-001..005

En-têtes de sécurité dans le **Caddyfile** (socle FrankenPHP pérenne, conforme à la décision
projet — pas à l'edge Coolify remplaçable) + `next.config.ts`.

### Changements
- **Site-wide** (sûrs pour PWA + API) : `Strict-Transport-Security: max-age=31536000;
  includeSubDomains` (**sans `preload`**, réversible) — SEC-002 ; `X-Frame-Options: DENY` — SEC-003 ;
  `X-Content-Type-Options: nosniff` — SEC-003 ; `Referrer-Policy: strict-origin-when-cross-origin`
  — SEC-004.
- **CSP (SEC-001)** scopée au matcher `@pwa` (l'UI `/docs` Swagger n'est pas touchée), **en
  Report-Only d'abord** : elle ne bloque jamais → **zéro risque de régression**, la recette
  manuelle observe les violations en console, puis promotion en enforce (35.4). Autorise ce dont la
  PWA a besoin : `'unsafe-inline'` (hydratation Next.js, pas de middleware nonce) + `blob:`
  (workers MapLibre), et les origines de tuiles Carto/Esri/OSM + images Wikimedia.
- **SEC-005** : `poweredByHeader: false` retire `x-powered-by: Next.js`.

### Vérification
- `caddy validate --adapter caddyfile` → **"Valid configuration"**.
- `prettier --check` + `eslint` sur `next.config.ts` → clean.
- Empirique (curl des en-têtes) : couvert par la CI (la stack boote avec ce Caddyfile pour les
  jobs Playwright/recette ; un Caddyfile invalide ferait échouer le boot) + recette manuelle.

### Auto-critique
- **CSP en Report-Only**, pas enforce : choix délibéré (exigence "ne pas régresser" — je ne peux
  pas valider empiriquement une CSP enforce en worktree sans la stack). La recette devient l'étape
  de validation avant l'enforce. SEC-001 donc **partiellement** clos (header présent, observabilité)
  ; enforce tracé pour 35.4.
- **Plausible/Sentry** : env-gatés OFF en iso-prod ; leurs origines sont à ajouter à
  `script-src`/`connect-src` si activés en prod (noté en commentaire).
- HSTS sans `preload` (irréversible évité).

<!-- claude-review-start -->
## Claude Review

Well-scoped, correct security hardening. All header choices are sound, the CSP is correctly scoped to `@pwa` to keep the Swagger UI untouched, and shipping Report-Only first is the right conservative default. The previous `report-uri` suggestion was addressed in the follow-up commit, turning the observation phase into a genuine safety net.

Reviewed commit: `71ef1c619eb62d7dc0bb311e63dfead8ee066ef8`

### Resolved threads
Resolved 1 previously open thread (report-uri suggestion — addressed in second commit).

### Review checklist
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases *(config-only change; `caddy validate` + CI boot smoke)*
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Findings
No new findings.

### Inline comments
No inline comments.
<!-- claude-review-end -->