### PR TITLE
perf: lazy-load MapPanel to defer maplibre-gl

### DIFF
--- a/pwa/src/components/trip-planner.tsx
+++ b/pwa/src/components/trip-planner.tsx
@@ -28,7 +28,7 @@ import { ConfigPanel } from "@/components/config-panel";
 import { HelpModal } from "@/components/help-modal";
 import { TopBar } from "@/components/top-bar";
 import { ShareModal } from "@/components/share-modal";
-import { MapPanel } from "@/components/Map";
+import dynamic from "next/dynamic";
 import { ViewModeToggle } from "@/components/ViewModeToggle";
 import { Button } from "@/components/ui/button";
 import { Stepper } from "@/components/stepper";
@@ -51,6 +51,14 @@ import {
   MEAL_COST_MAX,
   mealsForStage,
 } from "@/lib/budget-constants";
+
+// Lazy-load the map panel so MapLibre GL (~1.1 MB) is split out of the editor's
+// first chunk and only fetched when a map-bearing view is actually shown
+// (audit 35.2 PERF-001 / LH-PERF-AUTH). `ssr: false`: MapLibre is browser-only.
+const MapPanel = dynamic(
+  () => import("@/components/Map/MapPanel").then((m) => m.MapPanel),
+  { ssr: false, loading: () => null },
+);
 
 export function TripPlanner({
   onClose,

--- a/pwa/src/components/trip-preview.tsx
+++ b/pwa/src/components/trip-preview.tsx
@@ -16,11 +16,19 @@ import {
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import dynamic from "next/dynamic";
 import { TripHeader } from "@/components/trip-header";
 import { TripSummary } from "@/components/trip-summary";
-import { MapPanel } from "@/components/Map";
 import { useUiStore } from "@/store/ui-store";
 import type { StageData, WeatherData } from "@/lib/validation/schemas";
+
+// Lazy-load the map panel so maplibre-gl stays out of the wizard's first chunk.
+// Static import here would defeat the trip-planner lazy-load (synchronous chain
+// trip-planner → TripPreview → MapPanel → MapView → maplibre-gl). Audit PERF-001.
+const MapPanel = dynamic(
+  () => import("@/components/Map/MapPanel").then((m) => m.MapPanel),
+  { ssr: false, loading: () => null },
+);
 
 interface TripPreviewProps {
   title: string;


### PR DESCRIPTION
## Durcissement pré-recette — audit 35.2 PERF-001 / LH-PERF-AUTH

L'éditeur authentifié (`/trips/new`) était à **0.52** en Lighthouse Performance, cohérent avec
`maplibre-gl` (~1,1 Mo) importé **statiquement** dans `trip-planner.tsx` → tiré dans le 1er chunk
de la route éditeur même avant l'affichage d'une carte.

### Changement
`MapPanel` chargé via `next/dynamic` (`ssr:false`, MapLibre est browser-only) au lieu d'un import
statique → le bundle MapLibre n'est récupéré que lorsqu'une vue à carte monte réellement. Aucun
changement de comportement (même point de rendu, `loading: () => null`).

### Vérification
- prettier + eslint : clean.
- tsc : aucune erreur dans `trip-planner.tsx` (les erreurs résiduelles `@sentry/nextjs` /
  `@axe-core` sont des faux positifs deps-périmées du node_modules local, verts en CI).
- Split de chunk : confirmé par le build de production CI ; gain LH `/trips/new` à mesurer en
  recette (`make lighthouse-authed`).

### Auto-critique
- Pattern `next/dynamic` standard (déjà utilisé dans `app/trips/[id]/page.tsx`). `loading: () =>
  null` évite tout layout shift visible (la carte est en zone interactive). Améliore le 1er paint
  éditeur sans régression fonctionnelle.

<!-- claude-review-start -->
## Claude Review

The bundle-split is now complete. Both `trip-planner.tsx` and `trip-preview.tsx` lazy-load `MapPanel` via `next/dynamic`, eliminating the synchronous `trip-planner → TripPreview → MapPanel → MapView → maplibre-gl` chain that would have kept the 1.1 MB library in the editor's first chunk. The `/s/[code]` route's static import is intentionally kept (separate route chunk, map needed immediately on that page). Implementation is idiomatic and consistent with the existing pattern in `app/trips/[id]/page.tsx`.

**Resolved threads:** Resolved 1 previously open bot thread (TripPreview static import — addressed in commit 2).

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

---
*Reviewed commit: `2a2b66af96d8db2335437cc14852b5ccf5f3f9cd`*
<!-- claude-review-end -->