### PR TITLE
feat(seo): add public metadata (OG/Twitter, robots, sitemap, shared trips) + i18n onError

### DIFF
--- a/pwa/src/app/layout.tsx
+++ b/pwa/src/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { Fraunces, Inter_Tight, JetBrains_Mono } from "next/font/google";
 import { getLocale, getMessages, getTranslations } from "next-intl/server";
 import { DEFAULT_LOCALE } from "@/i18n/locale";
-import { API_URL } from "@/lib/constants";
+import { SITE_URL } from "@/lib/constants";
 import "./globals.css";
 import { IntlProvider } from "@/components/intl-provider";
 import { ThemeProvider } from "@/components/theme-provider";
@@ -44,7 +44,7 @@ export async function generateMetadata(): Promise<Metadata> {
   // iso-prod, so API_URL is the site URL. Per-page metadata (e.g. shared trips)
   // overrides these.
   return {
-    metadataBase: new URL(API_URL),
+    metadataBase: new URL(SITE_URL),
     title,
     description,
     openGraph: {

--- a/pwa/src/app/layout.tsx
+++ b/pwa/src/app/layout.tsx
@@ -1,9 +1,10 @@
 import type { Metadata } from "next";
 import { Fraunces, Inter_Tight, JetBrains_Mono } from "next/font/google";
-import { NextIntlClientProvider } from "next-intl";
 import { getLocale, getMessages, getTranslations } from "next-intl/server";
 import { DEFAULT_LOCALE } from "@/i18n/locale";
+import { API_URL } from "@/lib/constants";
 import "./globals.css";
+import { IntlProvider } from "@/components/intl-provider";
 import { ThemeProvider } from "@/components/theme-provider";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Toaster } from "@/components/ui/sonner";
@@ -27,18 +28,38 @@ const jetbrainsMono = JetBrains_Mono({
 });
 
 export async function generateMetadata(): Promise<Metadata> {
+  let title = "Bike Trip Planner";
+  let description = "Plan your bikepacking trips";
   try {
     const t = await getTranslations("layout");
-    return {
-      title: t("title"),
-      description: t("description"),
-    };
+    title = t("title");
+    description = t("description");
   } catch {
-    return {
-      title: "Bike Trip Planner",
-      description: "Plan your bikepacking trips",
-    };
+    // Static export prerendering: next-intl server context unavailable — keep
+    // the English defaults above.
   }
+
+  // Open Graph / Twitter Card on every page (audit 35.2 SEO-003). `metadataBase`
+  // makes relative OG URLs absolute; the PWA and API share the origin in
+  // iso-prod, so API_URL is the site URL. Per-page metadata (e.g. shared trips)
+  // overrides these.
+  return {
+    metadataBase: new URL(API_URL),
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      url: "/",
+      siteName: "Bike Trip Planner",
+      type: "website",
+    },
+    twitter: {
+      card: "summary",
+      title,
+      description,
+    },
+  };
 }
 
 export default async function RootLayout({
@@ -65,7 +86,7 @@ export default async function RootLayout({
       className={`${fraunces.variable} ${interTight.variable} ${jetbrainsMono.variable}`}
     >
       <body className="antialiased overflow-x-hidden">
-        <NextIntlClientProvider locale={locale} messages={messages}>
+        <IntlProvider locale={locale} messages={messages}>
           <ThemeProvider
             attribute="class"
             defaultTheme="system"
@@ -78,7 +99,7 @@ export default async function RootLayout({
             </AuthGuard>
             <Toaster richColors position="top-right" />
           </ThemeProvider>
-        </NextIntlClientProvider>
+        </IntlProvider>
         <PlausibleScript />
       </body>
     </html>

--- a/pwa/src/app/robots.ts
+++ b/pwa/src/app/robots.ts
@@ -1,6 +1,10 @@
 import type { MetadataRoute } from "next";
 import { SITE_URL } from "@/lib/constants";
 
+// Required for `output: export` (mobile/Capacitor build): metadata route
+// handlers must be statically generated at build time.
+export const dynamic = "force-static";
+
 /**
  * robots.txt (audit 35.2 SEO-002). Crawlers may index the public pages; the
  * authenticated app (`/trips`, `/account`) and the unguessable share links

--- a/pwa/src/app/robots.ts
+++ b/pwa/src/app/robots.ts
@@ -1,5 +1,5 @@
 import type { MetadataRoute } from "next";
-import { API_URL } from "@/lib/constants";
+import { SITE_URL } from "@/lib/constants";
 
 /**
  * robots.txt (audit 35.2 SEO-002). Crawlers may index the public pages; the
@@ -13,6 +13,6 @@ export default function robots(): MetadataRoute.Robots {
       allow: "/",
       disallow: ["/trips", "/account", "/s/"],
     },
-    sitemap: new URL("/sitemap.xml", API_URL).toString(),
+    sitemap: new URL("/sitemap.xml", SITE_URL).toString(),
   };
 }

--- a/pwa/src/app/robots.ts
+++ b/pwa/src/app/robots.ts
@@ -1,0 +1,18 @@
+import type { MetadataRoute } from "next";
+import { API_URL } from "@/lib/constants";
+
+/**
+ * robots.txt (audit 35.2 SEO-002). Crawlers may index the public pages; the
+ * authenticated app (`/trips`, `/account`) and the unguessable share links
+ * (`/s/`) are disallowed so they are neither crawled nor indexed.
+ */
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: ["/trips", "/account", "/s/"],
+    },
+    sitemap: new URL("/sitemap.xml", API_URL).toString(),
+  };
+}

--- a/pwa/src/app/s/[code]/page.tsx
+++ b/pwa/src/app/s/[code]/page.tsx
@@ -12,8 +12,6 @@ export function generateStaticParams() {
 /** Minimal shape of the public shared-trip payload used for metadata. */
 interface SharedTripMeta {
   title?: string | null;
-  startDate?: string | null;
-  endDate?: string | null;
   stages?: { distance?: number | null; elevation?: number | null }[] | null;
 }
 

--- a/pwa/src/app/s/[code]/page.tsx
+++ b/pwa/src/app/s/[code]/page.tsx
@@ -41,6 +41,9 @@ export async function generateMetadata({
     const res = await fetch(`${backend}/s/${encodeURIComponent(code)}`, {
       headers: { Accept: "application/ld+json" },
       cache: "no-store",
+      // Bound SSR on a slow/hanging backend (project HTTP convention: 10s). An
+      // AbortError is caught below and falls back to the generic metadata.
+      signal: AbortSignal.timeout(10_000),
     });
     if (!res.ok) {
       return fallback;

--- a/pwa/src/app/s/[code]/page.tsx
+++ b/pwa/src/app/s/[code]/page.tsx
@@ -30,7 +30,7 @@ export async function generateMetadata({
   params: Promise<{ code: string }>;
 }): Promise<Metadata> {
   const { code } = await params;
-  const fallback: Metadata = { title: "Voyage partagé — Bike Trip Planner" };
+  const fallback: Metadata = { title: "Shared trip — Bike Trip Planner" };
 
   if ("__placeholder" === code) {
     return fallback;
@@ -50,16 +50,18 @@ export async function generateMetadata({
     }
 
     const trip = (await res.json()) as SharedTripMeta;
-    const title = `${trip.title?.trim() || "Voyage à vélo"} — Bike Trip Planner`;
+    const title = `${trip.title?.trim() || "Bike trip"} — Bike Trip Planner`;
     const stages = trip.stages ?? [];
-    const km = Math.round(stages.reduce((sum, s) => sum + (s.distance ?? 0), 0));
+    const km = Math.round(
+      stages.reduce((sum, s) => sum + (s.distance ?? 0), 0),
+    );
     const dPlus = Math.round(
       stages.reduce((sum, s) => sum + (s.elevation ?? 0), 0),
     );
     const description =
       km > 0
-        ? `Itinéraire vélo partagé : ${km} km, ${dPlus} m D+.`
-        : "Itinéraire vélo partagé.";
+        ? `Shared bike route: ${km} km, ${dPlus} m D+.`
+        : "Shared bike route.";
 
     return {
       title,

--- a/pwa/src/app/s/[code]/page.tsx
+++ b/pwa/src/app/s/[code]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import dynamic from "next/dynamic";
 
 const SharedTripPage = dynamic(() => import("./shared-trip-page"), {
@@ -6,6 +7,72 @@ const SharedTripPage = dynamic(() => import("./shared-trip-page"), {
 
 export function generateStaticParams() {
   return [{ code: "__placeholder" }];
+}
+
+/** Minimal shape of the public shared-trip payload used for metadata. */
+interface SharedTripMeta {
+  title?: string | null;
+  startDate?: string | null;
+  endDate?: string | null;
+  stages?: { distance?: number | null; elevation?: number | null }[] | null;
+}
+
+/**
+ * Per-share Open Graph / Twitter metadata (audit 35.2 SEO-001). Fetched
+ * server-side from the public `GET /s/{code}` endpoint via the INTERNAL backend
+ * URL (not the public https origin: avoids the self-signed cert + server-side
+ * routing). Defensive: a revoked/unknown code (or any error) falls back to a
+ * generic title so the page still renders.
+ */
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ code: string }>;
+}): Promise<Metadata> {
+  const { code } = await params;
+  const fallback: Metadata = { title: "Voyage partagé — Bike Trip Planner" };
+
+  if ("__placeholder" === code) {
+    return fallback;
+  }
+
+  try {
+    const backend = process.env.API_BACKEND_URL ?? "http://php";
+    const res = await fetch(`${backend}/s/${encodeURIComponent(code)}`, {
+      headers: { Accept: "application/ld+json" },
+      cache: "no-store",
+    });
+    if (!res.ok) {
+      return fallback;
+    }
+
+    const trip = (await res.json()) as SharedTripMeta;
+    const title = `${trip.title?.trim() || "Voyage à vélo"} — Bike Trip Planner`;
+    const stages = trip.stages ?? [];
+    const km = Math.round(stages.reduce((sum, s) => sum + (s.distance ?? 0), 0));
+    const dPlus = Math.round(
+      stages.reduce((sum, s) => sum + (s.elevation ?? 0), 0),
+    );
+    const description =
+      km > 0
+        ? `Itinéraire vélo partagé : ${km} km, ${dPlus} m D+.`
+        : "Itinéraire vélo partagé.";
+
+    return {
+      title,
+      description,
+      openGraph: {
+        title,
+        description,
+        url: `/s/${code}`,
+        siteName: "Bike Trip Planner",
+        type: "article",
+      },
+      twitter: { card: "summary", title, description },
+    };
+  } catch {
+    return fallback;
+  }
 }
 
 export default function Page() {

--- a/pwa/src/app/s/shared-trip-metadata.test.ts
+++ b/pwa/src/app/s/shared-trip-metadata.test.ts
@@ -8,8 +8,8 @@ import { generateMetadata } from "@/app/s/[code]/page";
 
 const params = (code: string) => ({ params: Promise.resolve({ code }) });
 
-const mockFetch = (impl: () => unknown) => {
-  const fn = vi.fn(impl as never);
+const mockFetch = (impl: (...args: unknown[]) => unknown) => {
+  const fn = vi.fn(impl);
   vi.stubGlobal("fetch", fn);
   return fn;
 };
@@ -36,7 +36,7 @@ describe("generateMetadata (shared trip)", () => {
 
     expect(meta).toEqual({ title: "Shared trip — Bike Trip Planner" });
     expect(fetchSpy).toHaveBeenCalledOnce();
-    expect(fetchSpy.mock.calls[0][0]).toContain("/s/missing");
+    expect(fetchSpy.mock.calls[0]?.[0]).toContain("/s/missing");
   });
 
   it("falls back to the generic title when the fetch throws (timeout/network)", async () => {

--- a/pwa/src/app/s/shared-trip-metadata.test.ts
+++ b/pwa/src/app/s/shared-trip-metadata.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Neutralize the lazy client component so importing the route module only
+// exercises generateMetadata (next/dynamic is not available outside Next).
+vi.mock("next/dynamic", () => ({ default: () => () => null }));
+
+import { generateMetadata } from "@/app/s/[code]/page";
+
+const params = (code: string) => ({ params: Promise.resolve({ code }) });
+
+const mockFetch = (impl: () => unknown) => {
+  const fn = vi.fn(impl as never);
+  vi.stubGlobal("fetch", fn);
+  return fn;
+};
+
+describe("generateMetadata (shared trip)", () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("returns the generic fallback for the static-export placeholder without fetching", async () => {
+    const fetchSpy = mockFetch(() => {
+      throw new Error("should not be called");
+    });
+
+    const meta = await generateMetadata(params("__placeholder"));
+
+    expect(meta).toEqual({ title: "Shared trip — Bike Trip Planner" });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the generic title when the backend responds non-OK (revoked/unknown code)", async () => {
+    const fetchSpy = mockFetch(() => Promise.resolve({ ok: false }));
+
+    const meta = await generateMetadata(params("missing"));
+
+    expect(meta).toEqual({ title: "Shared trip — Bike Trip Planner" });
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    expect(fetchSpy.mock.calls[0][0]).toContain("/s/missing");
+  });
+
+  it("falls back to the generic title when the fetch throws (timeout/network)", async () => {
+    mockFetch(() => Promise.reject(new Error("aborted")));
+
+    const meta = await generateMetadata(params("slow"));
+
+    expect(meta).toEqual({ title: "Shared trip — Bike Trip Planner" });
+  });
+
+  it("builds title/description/OG from the trip when the fetch succeeds", async () => {
+    mockFetch(() =>
+      Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            title: "Tour des Flandres",
+            stages: [
+              { distance: 50, elevation: 600 },
+              { distance: 30, elevation: 400 },
+            ],
+          }),
+      }),
+    );
+
+    const meta = await generateMetadata(params("abc123"));
+
+    expect(meta.title).toBe("Tour des Flandres — Bike Trip Planner");
+    expect(meta.description).toBe("Shared bike route: 80 km, 1000 m D+.");
+    expect(meta.openGraph).toMatchObject({
+      url: "/s/abc123",
+      siteName: "Bike Trip Planner",
+      type: "article",
+    });
+    expect(meta.twitter).toMatchObject({ card: "summary" });
+  });
+
+  it("uses the default title and a stage-less description when the trip has no stages", async () => {
+    mockFetch(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ title: "", stages: [] }),
+      }),
+    );
+
+    const meta = await generateMetadata(params("xyz"));
+
+    expect(meta.title).toBe("Bike trip — Bike Trip Planner");
+    expect(meta.description).toBe("Shared bike route.");
+  });
+});

--- a/pwa/src/app/sitemap.ts
+++ b/pwa/src/app/sitemap.ts
@@ -1,0 +1,16 @@
+import type { MetadataRoute } from "next";
+import { API_URL } from "@/lib/constants";
+
+/**
+ * sitemap.xml (audit 35.2 SEO-002). Lists the public, indexable pages only —
+ * never the authenticated app or the private share links.
+ */
+export default function sitemap(): MetadataRoute.Sitemap {
+  const publicPaths = ["/", "/login", "/faq", "/legal", "/privacy"];
+
+  return publicPaths.map((path) => ({
+    url: new URL(path, API_URL).toString(),
+    changeFrequency: "monthly",
+    priority: "/" === path ? 1 : 0.7,
+  }));
+}

--- a/pwa/src/app/sitemap.ts
+++ b/pwa/src/app/sitemap.ts
@@ -1,6 +1,10 @@
 import type { MetadataRoute } from "next";
 import { SITE_URL } from "@/lib/constants";
 
+// Required for `output: export` (mobile/Capacitor build): metadata route
+// handlers must be statically generated at build time.
+export const dynamic = "force-static";
+
 /**
  * sitemap.xml (audit 35.2 SEO-002). Lists the public, indexable pages only —
  * never the authenticated app or the private share links.

--- a/pwa/src/app/sitemap.ts
+++ b/pwa/src/app/sitemap.ts
@@ -1,5 +1,5 @@
 import type { MetadataRoute } from "next";
-import { API_URL } from "@/lib/constants";
+import { SITE_URL } from "@/lib/constants";
 
 /**
  * sitemap.xml (audit 35.2 SEO-002). Lists the public, indexable pages only —
@@ -9,7 +9,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
   const publicPaths = ["/", "/login", "/faq", "/legal", "/privacy"];
 
   return publicPaths.map((path) => ({
-    url: new URL(path, API_URL).toString(),
+    url: new URL(path, SITE_URL).toString(),
     changeFrequency: "monthly",
     priority: "/" === path ? 1 : 0.7,
   }));

--- a/pwa/src/components/intl-provider.tsx
+++ b/pwa/src/components/intl-provider.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import type { ReactNode } from "react";
+import {
+  NextIntlClientProvider,
+  type AbstractIntlMessages,
+  type IntlError,
+} from "next-intl";
+import { logger } from "@/lib/logger";
+
+/**
+ * Client wrapper around `NextIntlClientProvider` that wires an `onError` handler
+ * (audit 35.2 I18N-001). A missing/invalid translation key previously rendered
+ * as a silent literal with no signal; now it throws in development (so drift is
+ * caught immediately) and is reported via the structured logger in production.
+ *
+ * It lives in its own client component because `onError` is a function, which a
+ * Server Component (the root layout) cannot pass as a prop to a client one.
+ */
+function handleIntlError(error: IntlError): void {
+  if (process.env.NODE_ENV === "development") {
+    throw error;
+  }
+  logger.warn("next-intl error", { error });
+}
+
+export function IntlProvider({
+  locale,
+  messages,
+  children,
+}: {
+  locale: string;
+  messages: AbstractIntlMessages;
+  children: ReactNode;
+}) {
+  return (
+    <NextIntlClientProvider
+      locale={locale}
+      messages={messages}
+      onError={handleIntlError}
+    >
+      {children}
+    </NextIntlClientProvider>
+  );
+}

--- a/pwa/src/lib/constants.ts
+++ b/pwa/src/lib/constants.ts
@@ -40,6 +40,15 @@ export const SCRAPE_DEBOUNCE_MS = 500;
 export const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "https://localhost";
 
 /**
+ * Absolute site origin for building canonical/OG/sitemap URLs. Unlike API_URL,
+ * this falls back on an EMPTY string too (`||`, not `??`): the mobile/export
+ * build injects `NEXT_PUBLIC_API_URL=""` when the var is unset, and
+ * `new URL(path, "")` throws — which would break the static sitemap/robots
+ * generation. The PWA and API share the origin in iso-prod/prod.
+ */
+export const SITE_URL = process.env.NEXT_PUBLIC_API_URL || "https://localhost";
+
+/**
  * Whether the AI tier is enabled for this build (mirrors backend `OLLAMA_ENABLED`).
  * Build-time only — `NEXT_PUBLIC_*` is inlined, so flipping it requires a front
  * rebuild. Defaults to enabled; set `NEXT_PUBLIC_AI_ENABLED=0` to hide the AI


### PR DESCRIPTION
## Durcissement pré-recette — audit 35.2 SEO-001/002/003 + I18N-001

### Changements
- **SEO-003** : `layout.tsx` ajoute `metadataBase` + `openGraph` + `twitter` sur toutes les pages
  (métadonnées par défaut, surchargées par page).
- **SEO-002** : `robots.ts` + `sitemap.ts` (App Router). Sitemap = pages **publiques** indexables
  uniquement (`/`, `/login`, `/faq`, `/legal`, `/privacy`) ; robots `Disallow` l'app authentifiée
  (`/trips`, `/account`) et les liens de partage privés (`/s/`).
- **SEO-001** : `s/[code]/page.tsx` expose un `generateMetadata` par partage, fetché côté serveur
  depuis l'endpoint public `GET /s/{code}` via l'**URL interne** `API_BACKEND_URL`/`http://php`
  (évite le cert auto-signé + le routage serveur), avec repli défensif sur code révoqué/inconnu.
- **I18N-001** : nouveau wrapper client `intl-provider.tsx` qui câble `onError` sur
  `NextIntlClientProvider` — **throw en dev** (drift i18n attrapé), report via le logger structuré
  en prod. Un prop fonction ne peut pas traverser la frontière server→client, d'où le wrapper.

### Vérification
- prettier + eslint : clean ; tsc : aucune erreur dans les fichiers modifiés (erreurs résiduelles
  `@sentry`/`@axe` = faux positifs deps-périmées, verts en CI).
- Empirique (`/robots.txt`, `/sitemap.xml`, balises `og:`, métadonnées `/s/{code}`) : CI + recette.

### Auto-critique
- **Image OG** : aucune image dédiée dans `public/` → OG textuel (valide) ; une image (carte) serait
  un plus, différable.
- **metadataBase = API_URL** : URL du site (même origine que l'API en iso-prod) ; à pointer sur un
  `NEXT_PUBLIC_SITE_URL` dédié si les origines divergent.
- `generateMetadata` `/s` en `cache: "no-store"` (partage révocable) ; coût négligeable.

<!-- claude-review-start -->
## Claude Review

Reviewed commit `629f4ac00c4a7c04f82741c1c3aa085be9503c5d`.

Clean implementation — no new findings. All prior bot-opened threads are fully addressed: fetch timeout (commit 3), English OG strings (commit 5), test coverage across 5 paths (commits 6–7), and the dead `startDate`/`endDate` fields in `SharedTripMeta` (latest commit).

Resolved 1 previously open thread (dead fields suggestion — addressed in the latest commit).

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Inline comments

No inline comments.
<!-- claude-review-end -->