### PR TITLE
fix(legal): make GDPR contact configurable + genericize host/region copy for self-hosting

### DIFF
--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -1063,14 +1063,14 @@
       "host": {
         "title": "Host",
         "paragraphs": [
-          "The application is hosted on cloud infrastructure located within the European Union.",
+          "The application is hosted by the operator of this instance.",
           "The exact details of the host can be provided on request at the contact address below."
         ]
       },
       "contact": {
         "title": "Contact",
         "paragraphs": [
-          "For any question about the site or to exercise your rights, contact us at: contact@bike-trip-planner.app.",
+          "For any question about the site or to exercise your rights, contact us at: __CONTACT_EMAIL__.",
           "You can also open an issue on the project's GitHub repository."
         ]
       },
@@ -1095,7 +1095,7 @@
         "title": "Data controller",
         "paragraphs": [
           "The data controller is the publisher of Bike Trip Planner (see the legal notice).",
-          "For any question about your personal data, contact us at: contact@bike-trip-planner.app."
+          "For any question about your personal data, contact us at: __CONTACT_EMAIL__."
         ]
       },
       "basis": {
@@ -1124,7 +1124,7 @@
       "retention": {
         "title": "Retention period",
         "paragraphs": [
-          "Your account and trips are kept for as long as your account is active. You may request their deletion at any time.",
+          "Your account and trips are kept for as long as your account is active. You may request their deletion at any time; deletion triggers an immediate and irreversible anonymisation of your account.",
           "Raw cached route data is kept for a maximum of 24 hours.",
           "Anonymous audience measurement data is aggregated and cannot be used to re-identify you."
         ]
@@ -1133,14 +1133,14 @@
         "title": "Your rights",
         "paragraphs": [
           "In accordance with the GDPR, you have the right of access, rectification, erasure, restriction, objection and portability of your data.",
-          "To exercise these rights, contact us at: contact@bike-trip-planner.app. We respond within one month.",
+          "To exercise these rights, contact us at: __CONTACT_EMAIL__. We respond within one month.",
           "You also have the right to lodge a complaint with your supervisory authority (in France, the CNIL — www.cnil.fr)."
         ]
       },
       "processors": {
         "title": "Processors",
         "paragraphs": [
-          "Infrastructure hosting: cloud provider located within the European Union.",
+          "Infrastructure hosting: a cloud provider chosen by the operator of this instance.",
           "Sending sign-in emails: a transactional email delivery provider.",
           "Open-data sources queried for analysis (OpenStreetMap, weather forecasts): no identifying personal data is transmitted to them."
         ]
@@ -1148,7 +1148,7 @@
       "analytics": {
         "title": "Audience measurement (Plausible)",
         "paragraphs": [
-          "We use Plausible Analytics, a privacy-friendly audience measurement solution, self-hosted on our own infrastructure within the European Union.",
+          "We use Plausible Analytics, a privacy-friendly audience measurement solution, self-hosted on the same infrastructure as the application.",
           "Plausible sets no cookies and uses no fingerprinting techniques. No data is shared with third parties for advertising purposes.",
           "IP addresses and user agents (browser) are anonymised and never stored; no data can be used to identify you or track you across sites.",
           "Purpose: to understand, in aggregate, which pages are visited and overall usage in order to improve the service. Retention: aggregated statistics only, no individual data.",
@@ -1158,7 +1158,7 @@
       "contact": {
         "title": "Contact",
         "paragraphs": [
-          "For any question about this privacy policy, write to us at: contact@bike-trip-planner.app.",
+          "For any question about this privacy policy, write to us at: __CONTACT_EMAIL__.",
           "This policy may be updated; the last-updated date is shown at the top of this page."
         ]
       }

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -1063,14 +1063,14 @@
       "host": {
         "title": "Hébergeur",
         "paragraphs": [
-          "L'application est hébergée sur une infrastructure cloud située dans l'Union européenne.",
+          "L'application est hébergée par l'opérateur de cette instance.",
           "Les coordonnées exactes de l'hébergeur peuvent être communiquées sur demande à l'adresse de contact ci-dessous."
         ]
       },
       "contact": {
         "title": "Contact",
         "paragraphs": [
-          "Pour toute question relative au site ou pour exercer vos droits, vous pouvez nous contacter à l'adresse : contact@bike-trip-planner.app.",
+          "Pour toute question relative au site ou pour exercer vos droits, vous pouvez nous contacter à l'adresse : __CONTACT_EMAIL__.",
           "Vous pouvez également ouvrir une issue sur le dépôt GitHub du projet."
         ]
       },
@@ -1095,7 +1095,7 @@
         "title": "Responsable du traitement",
         "paragraphs": [
           "Le responsable du traitement des données est l'éditeur de Bike Trip Planner (voir les mentions légales).",
-          "Pour toute question relative à vos données personnelles, contactez-nous à : contact@bike-trip-planner.app."
+          "Pour toute question relative à vos données personnelles, contactez-nous à : __CONTACT_EMAIL__."
         ]
       },
       "basis": {
@@ -1124,7 +1124,7 @@
       "retention": {
         "title": "Durée de conservation",
         "paragraphs": [
-          "Votre compte et vos voyages sont conservés tant que votre compte est actif. Vous pouvez demander leur suppression à tout moment.",
+          "Votre compte et vos voyages sont conservés tant que votre compte est actif. Vous pouvez demander leur suppression à tout moment ; la suppression entraîne une anonymisation immédiate et irréversible de votre compte.",
           "Les données de tracé brutes en cache sont conservées au maximum 24 heures.",
           "Les données de mesure d'audience anonyme sont agrégées et ne permettent pas de vous réidentifier."
         ]
@@ -1133,14 +1133,14 @@
         "title": "Vos droits",
         "paragraphs": [
           "Conformément au RGPD, vous disposez d'un droit d'accès, de rectification, d'effacement, de limitation, d'opposition et de portabilité de vos données.",
-          "Pour exercer ces droits, contactez-nous à : contact@bike-trip-planner.app. Nous répondons dans un délai d'un mois.",
+          "Pour exercer ces droits, contactez-nous à : __CONTACT_EMAIL__. Nous répondons dans un délai d'un mois.",
           "Vous avez également le droit d'introduire une réclamation auprès de la CNIL (www.cnil.fr)."
         ]
       },
       "processors": {
         "title": "Sous-traitants",
         "paragraphs": [
-          "Hébergement de l'infrastructure : prestataire cloud situé dans l'Union européenne.",
+          "Hébergement de l'infrastructure : prestataire cloud choisi par l'opérateur de cette instance.",
           "Envoi des emails de connexion : prestataire d'envoi d'emails transactionnels.",
           "Sources de données ouvertes interrogées pour l'analyse (OpenStreetMap, prévisions météo) : aucune donnée personnelle identifiante ne leur est transmise."
         ]
@@ -1148,7 +1148,7 @@
       "analytics": {
         "title": "Mesure d'audience (Plausible)",
         "paragraphs": [
-          "Nous utilisons Plausible Analytics, une solution de mesure d'audience respectueuse de la vie privée, auto-hébergée sur notre propre infrastructure dans l'Union européenne.",
+          "Nous utilisons Plausible Analytics, une solution de mesure d'audience respectueuse de la vie privée, auto-hébergée sur la même infrastructure que l'application.",
           "Plausible ne dépose aucun cookie et n'utilise aucune technique d'empreinte numérique (fingerprinting). Aucune donnée n'est partagée avec des tiers à des fins publicitaires.",
           "Les adresses IP et les agents utilisateur (navigateur) sont anonymisés et ne sont jamais stockés ; aucune donnée ne permet de vous identifier ou de vous suivre entre les sites.",
           "Finalité : comprendre de façon agrégée les pages consultées et l'usage global afin d'améliorer le service. Rétention : statistiques agrégées uniquement, aucune donnée individuelle.",
@@ -1158,7 +1158,7 @@
       "contact": {
         "title": "Contact",
         "paragraphs": [
-          "Pour toute question relative à cette politique de confidentialité, écrivez-nous à : contact@bike-trip-planner.app.",
+          "Pour toute question relative à cette politique de confidentialité, écrivez-nous à : __CONTACT_EMAIL__.",
           "Cette politique peut être mise à jour ; la date de dernière mise à jour figure en haut de cette page."
         ]
       }

--- a/pwa/src/app/legal/page.tsx
+++ b/pwa/src/app/legal/page.tsx
@@ -3,6 +3,7 @@ import {
   LegalPageLayout,
   type LegalSection,
   asParagraphs,
+  withContactEmail,
 } from "@/components/legal-page";
 import { LandingFooter } from "@/components/landing/footer";
 
@@ -13,8 +14,6 @@ const SECTION_IDS = [
   "intellectualProperty",
 ] as const;
 
-// TODO: the GDPR contact address (contact@bike-trip-planner.app in messages/*.json)
-// is a routable placeholder. Replace it with the real mailbox before going to production.
 export default async function LegalNoticePage() {
   const t = await getTranslations("legal");
 
@@ -23,7 +22,7 @@ export default async function LegalNoticePage() {
     return {
       id,
       title: t(`sections.${id}.title`),
-      paragraphs: asParagraphs(t.raw(key), `legal.${key}`),
+      paragraphs: withContactEmail(asParagraphs(t.raw(key), `legal.${key}`)),
     };
   });
 

--- a/pwa/src/app/privacy/page.tsx
+++ b/pwa/src/app/privacy/page.tsx
@@ -3,6 +3,7 @@ import {
   LegalPageLayout,
   type LegalSection,
   asParagraphs,
+  withContactEmail,
 } from "@/components/legal-page";
 import { LandingFooter } from "@/components/landing/footer";
 
@@ -18,8 +19,6 @@ const SECTION_IDS = [
   "contact",
 ] as const;
 
-// TODO: the GDPR contact address (contact@bike-trip-planner.app in messages/*.json)
-// is a routable placeholder. Replace it with the real mailbox before going to production.
 export default async function PrivacyPage() {
   const t = await getTranslations("privacy");
 
@@ -28,7 +27,7 @@ export default async function PrivacyPage() {
     return {
       id,
       title: t(`sections.${id}.title`),
-      paragraphs: asParagraphs(t.raw(key), `privacy.${key}`),
+      paragraphs: withContactEmail(asParagraphs(t.raw(key), `privacy.${key}`)),
     };
   });
 

--- a/pwa/src/components/legal-page.test.ts
+++ b/pwa/src/components/legal-page.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { withContactEmail } from "@/components/legal-page";
+import { CONTACT_EMAIL } from "@/lib/constants";
+
+describe("withContactEmail", () => {
+  it("substitutes the token with the configured contact address", () => {
+    const out = withContactEmail([
+      "Contactez-nous à : __CONTACT_EMAIL__.",
+      "No token here.",
+    ]);
+
+    expect(out[0]).toBe(`Contactez-nous à : ${CONTACT_EMAIL}.`);
+    expect(out[0]).not.toContain("__CONTACT_EMAIL__");
+    expect(out[1]).toBe("No token here.");
+  });
+
+  it("replaces every occurrence in a paragraph", () => {
+    const out = withContactEmail(["__CONTACT_EMAIL__ / __CONTACT_EMAIL__"]);
+
+    expect(out[0]).toBe(`${CONTACT_EMAIL} / ${CONTACT_EMAIL}`);
+  });
+});

--- a/pwa/src/components/legal-page.tsx
+++ b/pwa/src/components/legal-page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
+import { CONTACT_EMAIL } from "@/lib/constants";
 
 export interface LegalSection {
   id: string;
@@ -14,6 +15,11 @@ export function asParagraphs(raw: unknown, key: string): string[] {
     throw new Error(`Translation "${key}" must be an array of strings`);
   }
   return raw;
+}
+
+/** Substitutes the `__CONTACT_EMAIL__` token in legal copy with CONTACT_EMAIL. */
+export function withContactEmail(paragraphs: string[]): string[] {
+  return paragraphs.map((p) => p.replace(/__CONTACT_EMAIL__/g, CONTACT_EMAIL));
 }
 
 interface LegalPageProps {

--- a/pwa/src/lib/constants.ts
+++ b/pwa/src/lib/constants.ts
@@ -56,3 +56,12 @@ export const SITE_URL = process.env.NEXT_PUBLIC_API_URL || "https://localhost";
  * from `/api/health` (see `ai-availability.ts`).
  */
 export const AI_ENABLED = process.env.NEXT_PUBLIC_AI_ENABLED !== "0";
+
+/**
+ * GDPR/legal contact address shown on the legal & privacy pages. Each
+ * self-hosted instance sets its own mailbox via `NEXT_PUBLIC_CONTACT_EMAIL`
+ * (build-time inlined); the default is a generic RFC 2606 placeholder so the
+ * upstream build never ships a real address.
+ */
+export const CONTACT_EMAIL =
+  process.env.NEXT_PUBLIC_CONTACT_EMAIL || "contact@example.org";


### PR DESCRIPTION
## Contexte

Batch pré-recette, finding **H5** de l'audit app-vs-design v2 (#635). Le design nommait un domaine, un hébergeur (OVH), un DPO dédié et une conservation « 13 mois » ; l'app était déjà plus générique. Décision éditeur : **copie générique self-host** (domaine de déploiement inconnu, hébergeur provisoire/variable, projet open-source auto-hébergeable), contact **configurable**, anonymisation immédiate.

## Changements

- **Contact RGPD configurable** : `CONTACT_EMAIL` ajouté à `pwa/src/lib/constants.ts` (`NEXT_PUBLIC_CONTACT_EMAIL`, défaut placeholder RFC 2606 `contact@example.org`). Les catalogues `fr.json`/`en.json` utilisent désormais un token `__CONTACT_EMAIL__` (4 occurrences chacun) substitué au rendu par `withContactEmail()` ; suppression des `TODO` "replace before production" des pages legal/privacy.
- **Généricisation région/hébergeur** : suppression des assertions « Union européenne » (hébergeur, sous-traitants, Plausible) au profit de « opérateur de cette instance » / « même infrastructure que l'application » — non garantissables pour un déploiement self-host de région inconnue.
- **Anonymisation immédiate** : la section conservation mentionne désormais que la suppression entraîne une anonymisation immédiate et irréversible du compte (cohérent avec la réalité backend `AccountDeleteProcessor`).
- **Test** : `legal-page.test.ts` couvre la substitution du token (token remplacé, autres textes intacts, occurrences multiples).

Parité i18n FR/EN préservée (mêmes clés, même token). Aucune chaîne de test n'asserte l'ancien email/région.

## Vérification

- `node -e JSON.parse` : `fr.json` + `en.json` valides.
- Plus aucune occurrence de `bike-trip-planner.app` / « European Union » / « Union européenne » dans `pwa/messages` ni les pages legal/privacy.
- QA worktree non fiable (volume node_modules vide) → validation par la CI.

Closes une partie de #635 (H5).

<!-- claude-review-start -->
## Claude Review

**Reviewed commit:** `9f2b47b`

Clean, well-scoped fix. The build-time `NEXT_PUBLIC_CONTACT_EMAIL` → `CONTACT_EMAIL` constant follows the existing pattern in `constants.ts`, `withContactEmail` is a pure function that composes naturally after `asParagraphs`, and the unit tests cover substitution, no-op paragraphs, and multiple-occurrence replacement. TODO removal is warranted since the mechanism is now in place.

### Checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

No inline comments. No previous bot review threads to resolve.
<!-- claude-review-end -->