### PR TITLE
feat(error-pages): add 404 numeral + second CTA, enrich 500 with badge and request_id

### DIFF
--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -967,13 +967,15 @@
   "errorPages": {
     "notFound": {
       "title": "Off the trail",
-      "subtitle": "This page does not exist or has been moved.",
+      "subtitle": "This route does not exist — or the shared link has been revoked.",
       "illustrationAlt": "Lost cyclist in the mountains",
-      "backHome": "Back to home"
+      "backHome": "Back to home",
+      "myTrips": "My trips"
     },
     "error": {
       "title": "A pebble in the derailleur",
       "subtitle": "An unexpected error occurred. You can try again or return home.",
+      "badge": "Server error · 500",
       "retry": "Try again",
       "backHome": "Back to home"
     },

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -967,13 +967,15 @@
   "errorPages": {
     "notFound": {
       "title": "Hors-piste",
-      "subtitle": "Cette page n'existe pas ou a été déplacée.",
+      "subtitle": "Cette route n'existe pas — ou le lien de partage a été révoqué.",
       "illustrationAlt": "Cycliste perdu en montagne",
-      "backHome": "Retour à l'accueil"
+      "backHome": "Retour à l'accueil",
+      "myTrips": "Mes voyages"
     },
     "error": {
       "title": "Un caillou dans le dérailleur",
       "subtitle": "Une erreur inattendue est survenue. Vous pouvez réessayer ou revenir à l'accueil.",
+      "badge": "Erreur serveur · 500",
       "retry": "Réessayer",
       "backHome": "Retour à l'accueil"
     },

--- a/pwa/src/app/error.tsx
+++ b/pwa/src/app/error.tsx
@@ -22,6 +22,9 @@ export default function ErrorBoundary({ error, reset }: ErrorBoundaryProps) {
     });
   }, [error]);
 
+  // Shown alongside the request_id so a user can quote when the error occurred.
+  const timestamp = new Date().toISOString();
+
   return (
     <main
       className="flex min-h-screen items-center justify-center px-4 py-12 bg-[var(--color-surface)] text-[var(--color-ink)]"
@@ -29,7 +32,7 @@ export default function ErrorBoundary({ error, reset }: ErrorBoundaryProps) {
     >
       <div className="text-center space-y-6 max-w-md">
         <div
-          className="mx-auto flex h-20 w-20 items-center justify-center rounded-full bg-[var(--color-accent-soft)] text-[var(--color-accent-ink)]"
+          className="mx-auto flex h-20 w-20 items-center justify-center rounded-full bg-red-100 text-red-600 dark:bg-red-900/30 dark:text-red-400"
           aria-hidden="true"
         >
           <svg
@@ -48,6 +51,12 @@ export default function ErrorBoundary({ error, reset }: ErrorBoundaryProps) {
         </div>
 
         <div className="space-y-3">
+          <p
+            className="text-xs font-semibold uppercase tracking-[0.15em] text-red-600 dark:text-red-400"
+            data-testid="error-badge"
+          >
+            {t("badge")}
+          </p>
           <h1
             className="font-serif text-3xl md:text-4xl font-semibold tracking-tight"
             data-testid="error-title"
@@ -61,6 +70,17 @@ export default function ErrorBoundary({ error, reset }: ErrorBoundaryProps) {
             {t("subtitle")}
           </p>
         </div>
+
+        {error.digest && (
+          <div
+            className="rounded-lg border border-border bg-[var(--color-surface)] p-3 text-left font-mono text-xs text-[var(--color-ink)]/60"
+            data-testid="error-request-id"
+          >
+            request_id: {error.digest}
+            <br />
+            timestamp: {timestamp}
+          </div>
+        )}
 
         <div className="flex flex-col sm:flex-row gap-3 justify-center">
           <Button onClick={reset} size="lg" data-testid="error-retry-button">

--- a/pwa/src/app/error.tsx
+++ b/pwa/src/app/error.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
@@ -22,8 +22,9 @@ export default function ErrorBoundary({ error, reset }: ErrorBoundaryProps) {
     });
   }, [error]);
 
-  // Shown alongside the request_id so a user can quote when the error occurred.
-  const timestamp = new Date().toISOString();
+  // Captured once at mount so it stays stable across re-renders: shown alongside
+  // the request_id so a user can quote when the error occurred.
+  const [timestamp] = useState(() => new Date().toISOString());
 
   return (
     <main

--- a/pwa/src/app/not-found.tsx
+++ b/pwa/src/app/not-found.tsx
@@ -8,13 +8,15 @@ interface Copy {
   subtitle: string;
   illustrationAlt: string;
   backHome: string;
+  myTrips: string;
 }
 
 const FALLBACK_COPY: Copy = {
   title: "Hors-piste",
-  subtitle: "Cette page n'existe pas ou a été déplacée.",
+  subtitle: "Cette route n'existe pas — ou le lien de partage a été révoqué.",
   illustrationAlt: "Cycliste perdu en montagne",
   backHome: "Retour à l'accueil",
+  myTrips: "Mes voyages",
 };
 
 export default async function NotFound() {
@@ -26,6 +28,7 @@ export default async function NotFound() {
       subtitle: t("subtitle"),
       illustrationAlt: t("illustrationAlt"),
       backHome: t("backHome"),
+      myTrips: t("myTrips"),
     };
   } catch (e) {
     logger.error(
@@ -68,6 +71,14 @@ export default async function NotFound() {
           <circle cx="74" cy="70" r="0.5" fill="currentColor" />
         </svg>
 
+        <div
+          className="font-serif text-7xl md:text-8xl font-medium italic leading-none tracking-tight text-[var(--color-accent-brand)]"
+          data-testid="not-found-code"
+          aria-hidden="true"
+        >
+          404
+        </div>
+
         <div className="space-y-3">
           <h1
             className="font-serif text-4xl md:text-5xl font-semibold tracking-tight"
@@ -83,9 +94,19 @@ export default async function NotFound() {
           </p>
         </div>
 
-        <Button asChild size="lg" data-testid="not-found-home-link">
-          <Link href="/">{copy.backHome}</Link>
-        </Button>
+        <div className="flex flex-col sm:flex-row gap-3 justify-center">
+          <Button asChild size="lg" data-testid="not-found-home-link">
+            <Link href="/">{copy.backHome}</Link>
+          </Button>
+          <Button
+            asChild
+            variant="outline"
+            size="lg"
+            data-testid="not-found-trips-link"
+          >
+            <Link href="/trips">{copy.myTrips}</Link>
+          </Button>
+        </div>
       </div>
     </main>
   );

--- a/pwa/tests/mocked/error-pages.spec.ts
+++ b/pwa/tests/mocked/error-pages.spec.ts
@@ -39,8 +39,11 @@ test.describe("404 / not-found page", () => {
 
     // Subtitle in French.
     await expect(page.getByTestId("not-found-subtitle")).toHaveText(
-      "Cette page n'existe pas ou a été déplacée.",
+      "Cette route n'existe pas — ou le lien de partage a été révoqué.",
     );
+
+    // Large decorative "404" numeral.
+    await expect(page.getByTestId("not-found-code")).toHaveText("404");
 
     // SVG illustration is present and has an accessible label.
     const illustration = page.getByTestId("not-found-illustration");
@@ -55,6 +58,12 @@ test.describe("404 / not-found page", () => {
     await expect(homeLink).toBeVisible();
     await expect(homeLink).toHaveText("Retour à l'accueil");
     await expect(homeLink).toHaveAttribute("href", "/");
+
+    // Second CTA links to the trips list.
+    const tripsLink = page.getByTestId("not-found-trips-link");
+    await expect(tripsLink).toBeVisible();
+    await expect(tripsLink).toHaveText("Mes voyages");
+    await expect(tripsLink).toHaveAttribute("href", "/trips");
   });
 
   test("uses the warm paper surface token as background", async ({ page }) => {


### PR DESCRIPTION
## Contexte

Batch pré-recette, findings **H7** (404) et **H6** (500) de l'audit app-vs-design v2 (#635). Le doc curé v1 jugeait ces pages « conformes » à tort : le design `PageNotFoundDesktop`/`PageErrorDesktop` montre des éléments absents de l'app.

## Changements

### 404 (`not-found.tsx`)
- Ajout du grand **numéral « 404 »** (serif italic accent, `not-found-code`, décoratif `aria-hidden`).
- Ajout du **2e CTA « Mes voyages »** (outline → `/trips`, `not-found-trips-link`).
- Sous-titre aligné sur le design (mentionne le lien de partage révoqué, plus exact pour les 404 de `/s/`).
- Illustration SVG cycliste conservée (identité app).

### 500 (`error.tsx`)
- **Icône rouge sémantique** (red-100/red-600 + variantes dark) au lieu de l'accent.
- Ajout du **badge « Erreur serveur · 500 »** (`error-badge`).
- Ajout du bloc mono **`request_id` (= `error.digest`) + `timestamp`** rendu quand un digest est disponible (`error-request-id`) — le digest était loggé mais jamais affiché.
- Pas de bouton « Signaler le problème » : aucun canal de report n'existe (décision éditeur).

## i18n

Nouvelles clés FR/EN : `errorPages.notFound.myTrips`, `errorPages.error.badge` ; sous-titre 404 mis à jour. Parité préservée.

## Tests

- `error-pages.spec.ts` (mocked) mis à jour : nouveau sous-titre, assertions du numéral `404` et du 2e CTA `/trips`.
- 500 non couvert en E2E (déclencher `error.tsx` en navigation réelle exige une route de test embarquée, intentionnellement évitée) → validé visuellement en recette.
- VR : la baseline `not-found.png` devra être régénérée (`make visual-update`, hors CI) suite au changement de layout.

Closes une partie de #635 (H6, H7).

<!-- claude-review-start -->
## Claude Review

Reviewed commit `d85d29e6`. Clean, focused UI changes — well-scoped and correctly implemented. The previous correctness finding (timestamp drift) was addressed in the follow-up commit; no new findings.

**Resolved 1 previously open thread** — `timestamp` stabilized via `useState` lazy initializer ✅

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases — `not-found.tsx` fully covered; `error.tsx` E2E gap acknowledged and accepted
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

No inline comments.
<!-- claude-review-end -->