### PR TITLE
feat(landing): add public header (brand, language, theme, sign-in, request access)

### DIFF
--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -911,7 +911,9 @@
     "primary": "Primary navigation",
     "newTrip": "New trip",
     "myTrips": "My trips",
-    "accountSettings": "My account"
+    "accountSettings": "My account",
+    "login": "Sign in",
+    "requestAccess": "Request access"
   },
   "help": {
     "title": "Help",

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -911,7 +911,9 @@
     "primary": "Navigation principale",
     "newTrip": "Nouveau voyage",
     "myTrips": "Mes voyages",
-    "accountSettings": "Mon compte"
+    "accountSettings": "Mon compte",
+    "login": "Se connecter",
+    "requestAccess": "Demander l'accès"
   },
   "help": {
     "title": "Aide",

--- a/pwa/src/components/landing/hero.tsx
+++ b/pwa/src/components/landing/hero.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { CtaButton } from "@/components/cta-button";
+import { PublicTopBar } from "@/components/public-top-bar";
 
 /**
  * Cinematic hero with a topographic / contour-line SVG background that evokes
@@ -17,6 +18,8 @@ export function LandingHero() {
       className="relative min-h-[100dvh] flex items-center justify-center overflow-hidden bg-surface"
       data-testid="section-hero"
     >
+      <PublicTopBar transparent />
+
       {/* ── Background: layered topographic map SVG ─────────────────── */}
       <div className="absolute inset-0 z-0" aria-hidden="true">
         {/* Warm paper base */}

--- a/pwa/src/components/public-top-bar.tsx
+++ b/pwa/src/components/public-top-bar.tsx
@@ -1,0 +1,67 @@
+import Link from "next/link";
+import { Bike } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { Button } from "@/components/ui/button";
+import { LocaleSwitcher } from "@/components/locale-switcher";
+import { ThemeToggle } from "@/components/theme-toggle";
+import { cn } from "@/lib/utils";
+
+/**
+ * Public (unauthenticated) site header for the landing and other public pages
+ * (FAQ, legal, privacy). Mirrors the design's landing header: brand + language
+ * pills + theme toggle + "sign in" / "request access" — so language, theme and
+ * auth are reachable from the top of the page, not only the footer (audit H1).
+ *
+ * `transparent` overlays it on the hero (absolute, no border/background) for the
+ * landing; the default solid variant suits standalone public pages.
+ */
+export function PublicTopBar({ transparent = false }: { transparent?: boolean }) {
+  const t = useTranslations("navigation");
+
+  return (
+    <header
+      data-testid="public-top-bar"
+      className={cn(
+        "z-20 w-full",
+        transparent
+          ? "absolute inset-x-0 top-0"
+          : "border-b border-border bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60",
+      )}
+    >
+      <div className="max-w-[1200px] mx-auto flex items-center gap-1 sm:gap-2 px-3 sm:px-4 md:px-6 h-16">
+        <Link
+          href="/"
+          className="flex items-center gap-2 font-bold text-base text-brand hover:opacity-80 transition-opacity shrink-0"
+          aria-label={t("brandHome")}
+          data-testid="public-top-bar-brand"
+        >
+          <Bike className="h-5 w-5" aria-hidden="true" />
+          <span className="hidden sm:inline">{t("brand")}</span>
+        </Link>
+
+        <div className="flex-1" />
+
+        <LocaleSwitcher />
+        <ThemeToggle />
+
+        <Button
+          asChild
+          variant="outline"
+          size="sm"
+          className="ml-1"
+          data-testid="public-top-bar-login"
+        >
+          <Link href="/login">{t("login")}</Link>
+        </Button>
+        <Button
+          asChild
+          size="sm"
+          className="hidden sm:inline-flex bg-brand hover:bg-brand-hover text-white"
+          data-testid="public-top-bar-request"
+        >
+          <Link href="/login">{t("requestAccess")}</Link>
+        </Button>
+      </div>
+    </header>
+  );
+}

--- a/pwa/tests/mocked/landing-header.spec.ts
+++ b/pwa/tests/mocked/landing-header.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Public landing header (audit H1) — the landing must expose brand, language,
+ * theme and auth entry points at the top of the page, not only in the footer.
+ */
+test.describe("landing public header", () => {
+  test.beforeEach(async ({ page }) => {
+    // 401 on refresh → unauthenticated → the landing (with its header) renders.
+    await page.route("**/auth/refresh", (route, request) => {
+      if (request.method() !== "POST") return route.fallback();
+      return route.fulfill({ status: 401, body: "" });
+    });
+
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+  });
+
+  test("renders the public top bar with brand, sign-in and request-access links", async ({
+    page,
+  }) => {
+    const header = page.getByTestId("public-top-bar");
+    await expect(header).toBeVisible();
+
+    const brand = page.getByTestId("public-top-bar-brand");
+    await expect(brand).toBeVisible();
+    await expect(brand).toHaveAttribute("href", "/");
+
+    const login = page.getByTestId("public-top-bar-login");
+    await expect(login).toBeVisible();
+    await expect(login).toHaveAttribute("href", "/login");
+
+    // Request-access CTA is desktop-only (hidden under the sm breakpoint).
+    const request = page.getByTestId("public-top-bar-request");
+    await expect(request).toHaveAttribute("href", "/login");
+  });
+});

--- a/pwa/tests/mocked/landing-header.spec.ts
+++ b/pwa/tests/mocked/landing-header.spec.ts
@@ -30,8 +30,10 @@ test.describe("landing public header", () => {
     await expect(login).toBeVisible();
     await expect(login).toHaveAttribute("href", "/login");
 
-    // Request-access CTA is desktop-only (hidden under the sm breakpoint).
+    // Request-access CTA is desktop-only (hidden under the sm breakpoint); at
+    // the default 1280px viewport it must be visible.
     const request = page.getByTestId("public-top-bar-request");
+    await expect(request).toBeVisible();
     await expect(request).toHaveAttribute("href", "/login");
   });
 });


### PR DESCRIPTION
## Contexte

Batch pré-recette, finding **H1** de l'audit app-vs-design v2 (#635) : la landing n'avait **aucun header** — langue, thème et connexion n'étaient atteignables qu'au footer. Le design `PageLandingDesktop` place un header sur le hero (logo + pills FR/EN + thème + « Se connecter » + « Demander l'accès »).

## Changements

- **Nouveau composant `PublicTopBar`** (`pwa/src/components/public-top-bar.tsx`) : header pour les pages publiques/anon — brand + `LocaleSwitcher` + `ThemeToggle` + « Se connecter » (→ `/login`) + « Demander l'accès » (→ `/login`, qui héberge le flux d'accès anticipé). Variante `transparent` pour l'overlay sur le hero ; variante solide (bordure + fond) pour de futures pages publiques (FAQ/legal/privacy).
- **Intégration dans le hero** (`landing/hero.tsx`) : `<PublicTopBar transparent />` en overlay haut, conforme au design (header sur le hero). Texte en couleur foreground (le hero de l'app a un fond topographique clair, pas le fond sombre du design → pas de texte blanc).
- **i18n** : `navigation.login` / `navigation.requestAccess` (FR + EN).

## Périmètre / suite

Ce PR couvre **H1 (header landing)** uniquement. La généralisation de la TopBar aux pages authentifiées (`/trips`, `/account`, wizard) et le header public sur `/faq` (H2) suivront dans des PR dédiées, ainsi que les rails + footer (account/faq).

## Tests

- `mocked/landing-header.spec.ts` (nouveau) : header visible, brand → `/`, login → `/login`, request-access → `/login`. Fichier séparé pour ne pas entrer en conflit avec #638 (qui modifie `landing-page.spec.ts`).
- Touche `hero.tsx` (pas `landing-page.tsx`) → pas de conflit avec #638.

Closes une partie de #635 (H1).

<!-- claude-review-start -->
## Claude Review

Reviewed commit `dfd546d4986e77487a9d5d4ea873261e3ab4075d`.

`PublicTopBar` is clean and well-scoped. The second commit addressed the previous finding by adding the missing `toBeVisible()` assertion for the request-access CTA. No new findings.

**Resolved 1 previously open thread** (missing `toBeVisible()` on request-access CTA — addressed in commit `dfd546d`).

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**No inline comments.**
<!-- claude-review-end -->