### PR TITLE
feat(export): add whole-trip FIT export (roadbook + shared view)

### DIFF
--- a/api/src/ApiResource/Trip.php
+++ b/api/src/ApiResource/Trip.php
@@ -149,8 +149,9 @@ use App\State\TripUpdateProcessor;
             uriTemplate: '/trips/{id}{._format}',
             outputFormats: [
                 'gpx' => ['application/gpx+xml'],
+                'fit' => ['application/vnd.ant.fit'],
             ],
-            openapi: new Operation(summary: 'Download the full trip as a single GPX file containing all stages.'),
+            openapi: new Operation(summary: 'Download the full trip as a single GPX or FIT file containing all stages.'),
             security: "is_granted('TRIP_VIEW', object)",
             provider: TripGpxProvider::class,
         ),

--- a/api/src/Entity/TripShare.php
+++ b/api/src/Entity/TripShare.php
@@ -83,6 +83,15 @@ use Symfony\Component\Uid\Uuid;
             provider: TripShareGpxProvider::class,
         ),
         new Get(
+            uriTemplate: '/s/{shortCode}.fit',
+            outputFormats: ['fit' => ['application/vnd.ant.fit']],
+            uriVariables: ['shortCode' => new Link(fromClass: TripShare::class, identifiers: ['shortCode'])],
+            openapi: new Operation(summary: 'Download shared trip as FIT via short code.'),
+            security: 'is_granted("PUBLIC_ACCESS")',
+            output: Trip::class,
+            provider: TripShareGpxProvider::class,
+        ),
+        new Get(
             uriTemplate: '/s/{shortCode}/stages/{index}{._format}',
             outputFormats: [
                 'gpx' => ['application/gpx+xml'],

--- a/api/src/Entity/TripShare.php
+++ b/api/src/Entity/TripShare.php
@@ -89,7 +89,7 @@ use Symfony\Component\Uid\Uuid;
             openapi: new Operation(summary: 'Download shared trip as FIT via short code.'),
             security: 'is_granted("PUBLIC_ACCESS")',
             output: Trip::class,
-            provider: TripShareGpxProvider::class,
+            provider: TripShareGpxProvider::class, // format-agnostic: also serves .fit
         ),
         new Get(
             uriTemplate: '/s/{shortCode}/stages/{index}{._format}',

--- a/api/src/Serializer/TripFitNormalizer.php
+++ b/api/src/Serializer/TripFitNormalizer.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Serializer;
+
+use App\ApiResource\Model\Coordinate;
+use App\ApiResource\Stage;
+use App\ApiResource\Trip;
+use App\Repository\TripRequestRepositoryInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * Normalizes a {@see Trip} resource into a single FIT course structure.
+ *
+ * All stage geometries are merged into one continuous point list so that GPS
+ * devices display the whole trip as a single course. POIs and accommodations
+ * from every stage are merged into the course-point/waypoint list. Mirrors
+ * {@see TripGpxNormalizer} for the FIT format (the {@see FitEncoder} consumes
+ * the same `courseName`/`points`/`waypoints` shape as the per-stage FIT export).
+ */
+final readonly class TripFitNormalizer implements NormalizerInterface
+{
+    public function __construct(
+        private TripRequestRepositoryInterface $tripStateManager,
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array
+    {
+        if (!$data instanceof Trip) {
+            throw new \InvalidArgumentException(\sprintf('Expected instance of %s, got %s.', Trip::class, get_debug_type($data)));
+        }
+
+        /** @var list<Stage> $stages */
+        $stages = $context['trip_stages'] ?? $this->tripStateManager->getStages($data->id) ?? [];
+
+        $points = [];
+        $waypoints = [];
+
+        foreach ($stages as $stage) {
+            $stagePoints = array_map(
+                static fn (Coordinate $c): array => ['lat' => $c->lat, 'lon' => $c->lon, 'ele' => $c->ele],
+                $stage->geometry ?: [$stage->startPoint, $stage->endPoint],
+            );
+            array_push($points, ...$stagePoints);
+
+            foreach ($stage->pois as $poi) {
+                $waypoints[] = [
+                    'lat' => $poi->lat,
+                    'lon' => $poi->lon,
+                    'name' => $poi->name,
+                    'type' => $poi->category,
+                ];
+            }
+
+            foreach ($stage->accommodations as $accommodation) {
+                $waypoints[] = [
+                    'lat' => $accommodation->lat,
+                    'lon' => $accommodation->lon,
+                    'name' => $accommodation->name,
+                    'type' => $accommodation->type,
+                ];
+            }
+        }
+
+        return [
+            'courseName' => $this->tripStateManager->getTitle($data->id) ?? $data->id,
+            'points' => $points,
+            'waypoints' => $waypoints,
+        ];
+    }
+
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Trip && 'fit' === $format;
+    }
+
+    /**
+     * @return array<class-string, bool>
+     */
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Trip::class => 'fit' === $format];
+    }
+}

--- a/api/src/State/TripShareGpxProvider.php
+++ b/api/src/State/TripShareGpxProvider.php
@@ -14,7 +14,12 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
- * Downloads a shared trip as GPX via short code (anonymous access).
+ * Downloads a shared trip as GPX or FIT via short code (anonymous access).
+ *
+ * Format-agnostic: it resolves the share, delegates to {@see TripGpxProvider}
+ * to load the trip + stages, and lets the format-specific normalizer
+ * ({@see \App\Serializer\TripGpxNormalizer} / {@see \App\Serializer\TripFitNormalizer})
+ * render the response. The "Gpx" name is historical.
  *
  * @implements ProviderInterface<Trip>
  */

--- a/api/tests/Unit/Serializer/TripFitNormalizerTest.php
+++ b/api/tests/Unit/Serializer/TripFitNormalizerTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Serializer;
+
+use App\ApiResource\Model\Accommodation;
+use App\ApiResource\Model\Coordinate;
+use App\ApiResource\Model\PointOfInterest;
+use App\ApiResource\Stage;
+use App\ApiResource\Trip;
+use App\Repository\TripRequestRepositoryInterface;
+use App\Serializer\TripFitNormalizer;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class TripFitNormalizerTest extends TestCase
+{
+    #[Test]
+    public function normalizeReturnsTitleAsCourseNameWithFlatPoints(): void
+    {
+        $stage1 = new Stage(
+            tripId: 'trip-abc',
+            dayNumber: 1,
+            distance: 80.0,
+            elevation: 500.0,
+            startPoint: new Coordinate(50.629, 3.057),
+            endPoint: new Coordinate(50.700, 3.100),
+            geometry: [new Coordinate(50.629, 3.057, 42.0), new Coordinate(50.700, 3.100, 50.0)],
+        );
+
+        $stage2 = new Stage(
+            tripId: 'trip-abc',
+            dayNumber: 2,
+            distance: 60.0,
+            elevation: 300.0,
+            startPoint: new Coordinate(50.700, 3.100),
+            endPoint: new Coordinate(50.800, 3.200),
+            geometry: [new Coordinate(50.700, 3.100, 50.0), new Coordinate(50.800, 3.200, 60.0)],
+        );
+
+        $repository = $this->createStub(TripRequestRepositoryInterface::class);
+        $repository->method('getStages')->willReturn([$stage1, $stage2]);
+        $repository->method('getTitle')->willReturn('My Trip');
+
+        $normalizer = new TripFitNormalizer($repository);
+        $result = $normalizer->normalize(new Trip('trip-abc'), 'fit');
+
+        self::assertIsArray($result);
+        self::assertSame('My Trip', $result['courseName']);
+        self::assertArrayNotHasKey('trackName', $result);
+        /** @var list<array{lat: float, lon: float, ele: float|null}> $points */
+        $points = $result['points'];
+        self::assertCount(4, $points);
+        self::assertSame(50.629, $points[0]['lat']);
+        self::assertSame(50.800, $points[3]['lat']);
+    }
+
+    #[Test]
+    public function normalizeMergesWaypointsFromAllStagesWithType(): void
+    {
+        $stage1 = new Stage(
+            tripId: 'trip-abc',
+            dayNumber: 1,
+            distance: 80.0,
+            elevation: 500.0,
+            startPoint: new Coordinate(50.629, 3.057),
+            endPoint: new Coordinate(50.700, 3.100),
+        );
+        $stage1->addPoi(new PointOfInterest('Bakery', 'bakery', 50.650, 3.070));
+
+        $stage2 = new Stage(
+            tripId: 'trip-abc',
+            dayNumber: 2,
+            distance: 60.0,
+            elevation: 300.0,
+            startPoint: new Coordinate(50.700, 3.100),
+            endPoint: new Coordinate(50.800, 3.200),
+        );
+        $stage2->addAccommodation(new Accommodation('Hotel', 'hotel', 50.780, 3.190, 80.0, 120.0, false));
+
+        $repository = $this->createStub(TripRequestRepositoryInterface::class);
+        $repository->method('getStages')->willReturn([$stage1, $stage2]);
+
+        $normalizer = new TripFitNormalizer($repository);
+        $result = $normalizer->normalize(new Trip('trip-abc'), 'fit');
+
+        /** @var list<array{name: string, type: string, lat: float, lon: float}> $waypoints */
+        $waypoints = $result['waypoints'];
+        self::assertCount(2, $waypoints);
+        self::assertSame('Bakery', $waypoints[0]['name']);
+        self::assertSame('bakery', $waypoints[0]['type']);
+        self::assertSame('Hotel', $waypoints[1]['name']);
+        self::assertSame('hotel', $waypoints[1]['type']);
+    }
+
+    #[Test]
+    public function normalizeWithEmptyStagesReturnsEmptyPointsAndWaypoints(): void
+    {
+        $repository = $this->createStub(TripRequestRepositoryInterface::class);
+        $repository->method('getStages')->willReturn([]);
+
+        $normalizer = new TripFitNormalizer($repository);
+        $result = $normalizer->normalize(new Trip('trip-abc'), 'fit');
+
+        self::assertSame([], $result['points']);
+        self::assertSame([], $result['waypoints']);
+    }
+
+    #[Test]
+    public function supportsOnlyTripInFitFormat(): void
+    {
+        $repository = $this->createStub(TripRequestRepositoryInterface::class);
+        $normalizer = new TripFitNormalizer($repository);
+
+        $trip = new Trip('trip-abc');
+        $stage = new Stage('t', 1, 1.0, 0.0, new Coordinate(0, 0), new Coordinate(0, 0));
+
+        self::assertTrue($normalizer->supportsNormalization($trip, 'fit'));
+        self::assertFalse($normalizer->supportsNormalization($trip, 'gpx'));
+        self::assertFalse($normalizer->supportsNormalization($stage, 'fit'));
+    }
+
+    #[Test]
+    public function normalizeWithInvalidDataThrowsException(): void
+    {
+        $repository = $this->createStub(TripRequestRepositoryInterface::class);
+        $normalizer = new TripFitNormalizer($repository);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $normalizer->normalize('not a trip', 'fit');
+    }
+}

--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -51,6 +51,7 @@
     "estimatedBudget": "Estimated budget:",
     "disclaimer": "Automatically detected data may contain errors.",
     "downloadGpx": "Download full trip GPX",
+    "downloadFit": "Download full trip FIT",
     "downloadFailed": "Download failed. Please try again.",
     "datesLabel": "Trip dates",
     "noDates": "Dates not set",

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -51,6 +51,7 @@
     "estimatedBudget": "Budget estimé :",
     "disclaimer": "Les données détectées automatiquement peuvent contenir des erreurs.",
     "downloadGpx": "Télécharger le GPX complet",
+    "downloadFit": "Télécharger le FIT complet",
     "downloadFailed": "Le téléchargement a échoué. Veuillez réessayer.",
     "datesLabel": "Dates du voyage",
     "noDates": "Dates non définies",

--- a/pwa/src/components/shared-top-bar.tsx
+++ b/pwa/src/components/shared-top-bar.tsx
@@ -16,10 +16,10 @@ interface SharedTopBarProps {
  * Contrast with the owner top bar in {@link TripPlanner}: there is no
  * undo/redo, no Share button, no profile menu, no config gear, and no
  * insertion / deletion controls. Only the brand link (left) and the global
- * GPX download (right) are exposed.
+ * GPX / FIT download (right) are exposed.
  *
- * The Garmin FIT export from sprint 34 is intentionally omitted until that
- * feature ships — see issue #404.
+ * Garmin Connect sync (direct upload to the watch) remains out of scope — see
+ * issue #404.
  */
 export function SharedTopBar({ tripTitle }: SharedTopBarProps) {
   const t = useTranslations("sharedTopBar");
@@ -54,7 +54,7 @@ export function SharedTopBar({ tripTitle }: SharedTopBarProps) {
         {/* Spacer when no title to push the download button to the right */}
         {!tripTitle && <div className="flex-1" />}
 
-        {/* Global GPX download — only action available in read-only mode */}
+        {/* Global GPX / FIT download — only action available in read-only mode */}
         <div className="shrink-0">
           <TripDownloads tripId={undefined} tripTitle={tripTitle ?? ""} />
         </div>

--- a/pwa/src/components/trip-downloads.tsx
+++ b/pwa/src/components/trip-downloads.tsx
@@ -17,6 +17,10 @@ interface TripDownloadsProps {
  * Whole-trip download controls for the top bar: GPX and FIT, each merging all
  * stages into a single file. Mirrors the per-stage {@link StageDownloads} two-
  * button pattern. In the shared (read-only) view it downloads via short code.
+ *
+ * Mobile keeps the bar within the viewport (no mobile artboard yet, audit H11):
+ * the GPX button is icon-only and the FIT button is hidden under the `sm`
+ * breakpoint. Per-stage FIT export stays available everywhere.
  */
 export function TripDownloads({ tripId, tripTitle }: TripDownloadsProps) {
   const t = useTranslations("tripSummary");
@@ -58,12 +62,12 @@ export function TripDownloads({ tripId, tripTitle }: TripDownloadsProps) {
         ) : (
           <Download className="h-4 w-4" />
         )}
-        <span className="text-xs font-medium">GPX</span>
+        <span className="hidden text-xs font-medium sm:inline">GPX</span>
       </Button>
       <Button
         variant="ghost"
         size="sm"
-        className="h-9 gap-1 px-2 cursor-pointer"
+        className="hidden h-9 gap-1 px-2 cursor-pointer sm:inline-flex"
         disabled={disabled}
         onClick={() => void handleDownload("fit")}
         aria-label={t("downloadFit")}

--- a/pwa/src/components/trip-downloads.tsx
+++ b/pwa/src/components/trip-downloads.tsx
@@ -5,7 +5,7 @@ import { useTranslations } from "next-intl";
 import { toast } from "@/components/ui/sonner";
 import { Download, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { downloadTripGpx, downloadSharedTripGpx } from "@/lib/api/client";
+import { downloadTripFile, downloadSharedTripFile } from "@/lib/api/client";
 import { useShareContext } from "@/lib/share-context";
 
 interface TripDownloadsProps {
@@ -13,19 +13,24 @@ interface TripDownloadsProps {
   tripTitle: string;
 }
 
+/**
+ * Whole-trip download controls for the top bar: GPX and FIT, each merging all
+ * stages into a single file. Mirrors the per-stage {@link StageDownloads} two-
+ * button pattern. In the shared (read-only) view it downloads via short code.
+ */
 export function TripDownloads({ tripId, tripTitle }: TripDownloadsProps) {
   const t = useTranslations("tripSummary");
   const share = useShareContext();
-  const [downloading, setDownloading] = useState(false);
+  const [downloading, setDownloading] = useState<"gpx" | "fit" | false>(false);
 
-  async function handleDownload() {
+  async function handleDownload(format: "gpx" | "fit") {
     if (!tripId && !share) return;
-    setDownloading(true);
+    setDownloading(format);
     try {
       if (share) {
-        await downloadSharedTripGpx(share.shortCode, share.title);
+        await downloadSharedTripFile(share.shortCode, share.title, format);
       } else {
-        await downloadTripGpx(tripId!, tripTitle);
+        await downloadTripFile(tripId!, tripTitle, format);
       }
     } catch {
       toast.error(t("downloadFailed"));
@@ -34,21 +39,44 @@ export function TripDownloads({ tripId, tripTitle }: TripDownloadsProps) {
     }
   }
 
+  const disabled = (!tripId && !share) || !!downloading;
+
   return (
-    <Button
-      variant="ghost"
-      size="icon"
-      className="h-9 w-9 cursor-pointer"
-      disabled={(!tripId && !share) || downloading}
-      onClick={() => void handleDownload()}
-      aria-label={t("downloadGpx")}
-      title={t("downloadGpx")}
-    >
-      {downloading ? (
-        <Loader2 className="h-4 w-4 animate-spin" />
-      ) : (
-        <Download className="h-4 w-4" />
-      )}
-    </Button>
+    <>
+      <Button
+        variant="ghost"
+        size="sm"
+        className="h-9 gap-1 px-2 cursor-pointer"
+        disabled={disabled}
+        onClick={() => void handleDownload("gpx")}
+        aria-label={t("downloadGpx")}
+        title={t("downloadGpx")}
+        data-testid="trip-download-gpx"
+      >
+        {downloading === "gpx" ? (
+          <Loader2 className="h-4 w-4 animate-spin" />
+        ) : (
+          <Download className="h-4 w-4" />
+        )}
+        <span className="text-xs font-medium">GPX</span>
+      </Button>
+      <Button
+        variant="ghost"
+        size="sm"
+        className="h-9 gap-1 px-2 cursor-pointer"
+        disabled={disabled}
+        onClick={() => void handleDownload("fit")}
+        aria-label={t("downloadFit")}
+        title={t("downloadFit")}
+        data-testid="trip-download-fit"
+      >
+        {downloading === "fit" ? (
+          <Loader2 className="h-4 w-4 animate-spin" />
+        ) : (
+          <Download className="h-4 w-4" />
+        )}
+        <span className="text-xs font-medium">FIT</span>
+      </Button>
+    </>
   );
 }

--- a/pwa/src/lib/api/client.ts
+++ b/pwa/src/lib/api/client.ts
@@ -711,15 +711,16 @@ function triggerBlobDownload(blob: Blob, filename: string): void {
   URL.revokeObjectURL(url);
 }
 
-export async function downloadTripGpx(
+export async function downloadTripFile(
   tripId: string,
   tripTitle: string,
+  format: "gpx" | "fit",
 ): Promise<void> {
-  const res = await apiFetch(`${API_URL}/trips/${tripId}.gpx`);
+  const res = await apiFetch(`${API_URL}/trips/${tripId}.${format}`);
   if (!res.ok) throw new Error(`Download failed with status ${res.status}`);
   const blob = await res.blob();
   const safeName = tripTitle.trim().replace(/[^a-z0-9\-_]/gi, "-") || "trip";
-  triggerBlobDownload(blob, `${safeName}.gpx`);
+  triggerBlobDownload(blob, `${safeName}.${format}`);
 }
 
 export async function downloadStageFile(
@@ -844,17 +845,20 @@ export async function fetchSharedTrip(
 }
 
 /**
- * Download shared trip as GPX via short code (anonymous).
+ * Download a shared trip as GPX or FIT via short code (anonymous).
  */
-export async function downloadSharedTripGpx(
+export async function downloadSharedTripFile(
   shortCode: string,
   tripTitle: string,
+  format: "gpx" | "fit",
 ): Promise<void> {
-  const res = await fetch(`${API_URL}/s/${encodeURIComponent(shortCode)}.gpx`);
+  const res = await fetch(
+    `${API_URL}/s/${encodeURIComponent(shortCode)}.${format}`,
+  );
   if (!res.ok) throw new Error("Download failed");
   const blob = await res.blob();
   const safeName = tripTitle.trim().replace(/[^a-z0-9\-_]/gi, "-") || "trip";
-  triggerBlobDownload(blob, `${safeName}.gpx`);
+  triggerBlobDownload(blob, `${safeName}.${format}`);
 }
 
 /**

--- a/pwa/tests/mocked/fit-download.spec.ts
+++ b/pwa/tests/mocked/fit-download.spec.ts
@@ -59,4 +59,57 @@ test.describe("FIT download", () => {
       .toBeGreaterThan(0);
     expect(fitRequests[0]).toContain("/stages/0.fit");
   });
+
+  test("global FIT download button is visible after stages computed", async ({
+    submitUrl,
+    injectSequence,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    await injectSequence([
+      routeParsedEvent(),
+      stagesComputedEvent(),
+      tripCompleteEvent(),
+    ]);
+
+    const button = mockedPage.getByRole("button", {
+      name: /Télécharger le FIT complet/,
+    });
+    await expect(button).toBeVisible();
+    await expect(button).toBeEnabled();
+  });
+
+  test("global FIT download triggers API fetch on the trip endpoint", async ({
+    submitUrl,
+    injectSequence,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    await injectSequence([
+      routeParsedEvent(),
+      stagesComputedEvent(),
+      tripCompleteEvent(),
+    ]);
+
+    // Track whole-trip FIT API requests (not the per-stage `/stages/*.fit`).
+    const fitRequests: string[] = [];
+    await mockedPage.route("**/trips/*.fit", (route) => {
+      fitRequests.push(route.request().url());
+      return route.fulfill({
+        status: 200,
+        contentType: "application/vnd.ant.fit",
+        body: Buffer.from([0x0e, 0x20, 0x14, 0x08]), // minimal FIT header stub
+      });
+    });
+
+    const button = mockedPage.getByRole("button", {
+      name: /Télécharger le FIT complet/,
+    });
+    await button.click();
+
+    await expect
+      .poll(() => fitRequests.length, { timeout: 5000 })
+      .toBeGreaterThan(0);
+    expect(fitRequests[0]).toMatch(/\/trips\/[^/]+\.fit$/);
+  });
 });


### PR DESCRIPTION
## Contexte

Batch pré-recette, finding **H3** (🔴 export FIT global manquant). Le FIT n'existait qu'au niveau étape (`/trips/{id}/stages/{i}.fit`) ; le niveau voyage entier ne proposait que le GPX. Décision éditeur : **FIT global complet (roadbook + vue partagée)**.

## Backend

- **`TripFitNormalizer`** (nouveau) : mirror de `TripGpxNormalizer` pour le format `fit` — fusionne toutes les étapes en une seule course `{courseName, points[], waypoints[]}`, la forme déjà consommée par `FitEncoder` (export FIT par étape). Le provider existant `TripGpxProvider` est format-agnostique (réutilisé tel quel).
- **Trip** (`/trips/{id}`) : ajout du format `fit` aux `outputFormats` de l'opération d'export (à côté de `gpx`).
- **TripShare** (`/s/{shortCode}.fit`) : nouvelle opération Get (le partage utilise une extension codée en dur car `/s/{shortCode}` est prit par la vue) ; provider `TripShareGpxProvider` réutilisé.
- **Test** : `TripFitNormalizerTest` (mirror de `TripGpxNormalizerTest`) — `courseName`, points fusionnés, waypoints `{name,type}`, format support, données invalides.

## Frontend

- **API client** : `downloadTripGpx`/`downloadSharedTripGpx` généralisés en `downloadTripFile`/`downloadSharedTripFile` avec un param `format: "gpx" | "fit"` (même motif que `downloadStageFile`). Seul `trip-downloads.tsx` les consommait.
- **`TripDownloads`** : deux boutons directs **GPX** + **FIT** (motif `StageDownloads`), au lieu du GPX seul. Le bouton GPX **conserve son nom accessible** « Télécharger le GPX complet » → contrat recette préservé. i18n `tripSummary.downloadFit` (FR+EN).
- **Commentaires** : `top-bar.tsx` (« GPX/FIT download menu ») devient exact ; `shared-top-bar.tsx` corrigé (FIT fichier désormais exposé ; Garmin **Connect** sync reste hors périmètre #404).

## Choix : boutons directs plutôt que menu déroulant

Le design montre un « menu » GPX/FIT, mais les scénarios recette `@critical` (golden-paths + export) localisent le bouton voyage par son nom accessible « Télécharger le GPX complet » et le **cliquent directement**. Un popover (option masquée) les casserait. Deux boutons directs (motif déjà utilisé par étape) atteignent la parité fonctionnelle sans rompre le contrat recette.

## Tests / vérification

- `php -l` OK sur les nouveaux fichiers ; PHPStan/PHPUnit via CI.
- Parité i18n FR/EN préservée. Pas de référence résiduelle aux anciennes fonctions GPX.
- **Recette FIT voyage non ajoutée** : exigerait un tracker de requêtes trip-FIT + steps/features (FR+EN) sur des scénarios @critical, à l'aveugle (recette locale indisponible). Le `TripFitNormalizer` est couvert en unitaire, le bouton FIT est structurellement identique au GPX déjà couvert en recette. Parité recette = follow-up possible.

Closes une partie de #635 (H3).

<!-- claude-review-start -->
## Claude Review

**Commit reviewed:** `346bb3e`

Clean, well-executed follow-through. `TripFitNormalizer` is a faithful mirror of `TripGpxNormalizer` — same `getSupportedTypes`/`supportsNormalization` pattern, same point-merging logic, correct omission of `symbol`/`sourceUrl` (FIT doesn't use them). `TripGpxProvider` is confirmed format-agnostic. The frontend unification to `downloadTripFile`/`downloadSharedTripFile` is clean and consistent with the existing `downloadStageFile` pattern. Unit coverage is thorough; the two new E2E tests cover button visibility and API routing for the trip-level endpoint.

### Findings summary

| Severity | Count |
|----------|-------|
| critical | 0     |
| warning  | 0     |
| suggestion | 0  |

### Resolved threads

Resolved 1 previously open bot thread: `TripShareGpxProvider` docblock suggestion — both the class-level docblock and the inline comment in `TripShare.php` were updated in the latest push.

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Inline comments

No inline comments.
<!-- claude-review-end -->