### PR TITLE
feat(faq): add public header, sections rail and footer

### DIFF
--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -974,6 +974,7 @@
     "title": "Frequently Asked Questions",
     "description": "Everything you need to know about Bike Trip Planner.",
     "backToHome": "Back to home",
+    "sectionsLabel": "Sections",
     "categoryProject": "The project",
     "categoryHowItWorks": "How it works",
     "categoryAccess": "Access",

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -974,6 +974,7 @@
     "title": "Foire aux questions",
     "description": "Tout ce que vous devez savoir sur Bike Trip Planner.",
     "backToHome": "Retour à l'accueil",
+    "sectionsLabel": "Sections",
     "categoryProject": "Le projet",
     "categoryHowItWorks": "Fonctionnement",
     "categoryAccess": "Accès",

--- a/pwa/src/app/faq/page.tsx
+++ b/pwa/src/app/faq/page.tsx
@@ -2,6 +2,8 @@ import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import { getTranslations } from "next-intl/server";
 import { FaqAccordion, type FaqCategory } from "@/components/faq-accordion";
+import { PublicTopBar } from "@/components/public-top-bar";
+import { LandingFooter } from "@/components/landing/footer";
 
 export default async function FaqPage() {
   const t = await getTranslations("faq");
@@ -37,35 +39,64 @@ export default async function FaqPage() {
   ];
 
   return (
-    <main className="max-w-2xl mx-auto px-4 md:px-6 py-12">
-      {/* Back link */}
-      <Link
-        href="/"
-        className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground mb-8 transition-colors"
-        data-testid="faq-back-link"
+    <div className="min-h-screen bg-background flex flex-col">
+      <PublicTopBar />
+
+      <main
+        className="flex-1 w-full max-w-5xl mx-auto px-4 md:px-6 py-12"
+        data-testid="faq-page"
       >
-        <ArrowLeft className="h-4 w-4" aria-hidden="true" />
-        {t("backToHome")}
-      </Link>
-
-      {/* Header */}
-      <div className="mb-10">
-        <h1 className="text-3xl font-bold tracking-tight mb-2">{t("title")}</h1>
-        <p className="text-muted-foreground">{t("description")}</p>
-      </div>
-
-      {/* FAQ Categories */}
-      <FaqAccordion categories={categories} />
-
-      {/* Footer link back */}
-      <div className="mt-12 pt-6 border-t text-center">
+        {/* Back link */}
         <Link
           href="/"
-          className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+          className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground mb-8 transition-colors"
+          data-testid="faq-back-link"
         >
+          <ArrowLeft className="h-4 w-4" aria-hidden="true" />
           {t("backToHome")}
         </Link>
-      </div>
-    </main>
+
+        {/* Header */}
+        <div className="mb-10">
+          <h1 className="text-3xl font-bold tracking-tight mb-2">
+            {t("title")}
+          </h1>
+          <p className="text-muted-foreground">{t("description")}</p>
+        </div>
+
+        <div className="grid gap-10 md:grid-cols-[16rem_1fr]">
+          {/* Sections rail (sticky on desktop) */}
+          <nav
+            aria-label={t("sectionsLabel")}
+            className="md:sticky md:top-12 md:self-start"
+            data-testid="faq-sections-rail"
+          >
+            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-3">
+              {t("sectionsLabel")}
+            </p>
+            <ul className="space-y-2 text-sm border-l border-border">
+              {categories.map((category) => (
+                <li key={category.id}>
+                  <a
+                    href={`#faq-category-${category.id}`}
+                    className="block -ml-px border-l border-transparent pl-4 text-muted-foreground hover:text-foreground hover:border-brand transition-colors"
+                    data-testid={`faq-sections-link-${category.id}`}
+                  >
+                    {category.label}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </nav>
+
+          {/* Content */}
+          <div className="min-w-0">
+            <FaqAccordion categories={categories} />
+          </div>
+        </div>
+      </main>
+
+      <LandingFooter />
+    </div>
   );
 }

--- a/pwa/src/components/faq-accordion.tsx
+++ b/pwa/src/components/faq-accordion.tsx
@@ -80,7 +80,7 @@ export function FaqAccordion({ categories }: FaqAccordionProps) {
         >
           <h2
             id={`faq-category-${category.id}`}
-            className="text-lg font-semibold mb-4"
+            className="scroll-mt-24 text-lg font-semibold mb-4"
           >
             {category.label}
           </h2>

--- a/pwa/tests/mocked/faq.spec.ts
+++ b/pwa/tests/mocked/faq.spec.ts
@@ -10,6 +10,22 @@ test.describe("/faq page", () => {
     });
   });
 
+  test("renders the public chrome: top bar, sections rail and footer", async ({
+    page,
+  }) => {
+    await page.goto("/faq");
+    await page.waitForLoadState("networkidle");
+
+    await expect(page.getByTestId("public-top-bar")).toBeVisible();
+    await expect(page.getByTestId("faq-sections-rail")).toBeVisible();
+    // One rail link per category, anchored to its heading.
+    await expect(page.getByTestId("faq-sections-link-project")).toHaveAttribute(
+      "href",
+      "#faq-category-project",
+    );
+    await expect(page.getByTestId("section-footer")).toBeVisible();
+  });
+
   test("displays all three FAQ categories", async ({ page }) => {
     await page.goto("/faq");
     await page.waitForLoadState("networkidle");


### PR DESCRIPTION
## Contexte

Batch pré-recette, finding **#8** (FAQ = divergence de structure) + **H2** (chrome généralisé). Le design `/faq` a une TopBar, un rail « Sections » et un footer ; l'app n'avait qu'un lien retour + l'accordéon en `max-w-2xl`.

## Changements

- **`<PublicTopBar />`** (variante solide) en tête — réutilise le composant créé pour la landing (#639) : brand + langue + thème + connexion + demander l'accès.
- **Rail « Sections »** (gauche, sticky desktop) : un lien par catégorie, ancré sur le titre de catégorie (`#faq-category-<id>`). `scroll-mt-24` ajouté aux `<h2>` de `FaqAccordion` pour l'offset d'ancrage.
- **`LandingFooter`** en bas.
- **Layout** : grille `md:grid-cols-[16rem_1fr]` (rail + accordéon), empilé sous `md`.
- **Taxonomie 3 catégories conservée** (Projet / Fonctionnement / Accès, sans « Tarifs ») — choix produit acté.
- Lien retour `faq-back-link` **conservé** (testé + sélecteur "ready" VR) ; lien retour de bas de page redondant supprimé.

## Tests

- Tests existants préservés : 3 `<h2>` (catégories), 1 `<h1>`, accordéon `button[aria-expanded]`, `faq-back-link`. Vérifié que `PublicTopBar`/`LandingFooter` n'ajoutent **ni heading ni bouton `aria-expanded`** (ThemeToggle = cycle, LocaleSwitcher = `role=group`).
- Nouveau test : chrome (`public-top-bar` + `faq-sections-rail` + lien ancré `#faq-category-project` + `section-footer`).
- i18n `faq.sectionsLabel` (FR+EN), parité préservée.
- **VR** : baseline `faq.png` à régénérer (`make visual-update`, hors CI). QA worktree → CI ; prettier OK.

Closes une partie de #635 (#8, H2 faq).

<!-- claude-review-start -->
## Claude Review

Reviewed commit `3cf67e3114a3c7d02a538726e6309f27cfd18e03`.

**Summary:** Clean, focused PR that correctly ports the public chrome pattern from the landing page (#639) to the FAQ page. The layout refactor, i18n additions, and E2E test coverage are all well-executed with no significant issues found.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate (reuses `PublicTopBar` / `LandingFooter` from #639)
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for (#635 #8 and H2 faq)

**Findings by severity:** 0 critical · 0 warning · 0 info

No inline comments.
<!-- claude-review-end -->