### PR TITLE
feat(shortcuts): add T (theme) and M (map) keyboard shortcuts

### DIFF
--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -404,7 +404,9 @@
     "undo": "Undo last action",
     "redo": "Redo undone action",
     "toggleHelp": "Show / hide this help",
-    "closePanels": "Close open panel"
+    "closePanels": "Close open panel",
+    "toggleTheme": "Toggle light / dark theme",
+    "toggleMap": "Show / hide the map"
   },
   "tripLocked": {
     "banner": "This trip is underway or has passed — view only. Use \"Duplicate\" to plan a new variant."

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -404,7 +404,9 @@
     "undo": "Annuler la dernière action",
     "redo": "Rétablir l'action annulée",
     "toggleHelp": "Afficher / masquer cette aide",
-    "closePanels": "Fermer le panneau ouvert"
+    "closePanels": "Fermer le panneau ouvert",
+    "toggleTheme": "Basculer le thème clair / sombre",
+    "toggleMap": "Afficher / masquer la carte"
   },
   "tripLocked": {
     "banner": "Ce trip est en cours ou passé — consultation uniquement. Utilisez « Dupliquer » pour planifier une nouvelle variante."

--- a/pwa/src/components/help-modal.tsx
+++ b/pwa/src/components/help-modal.tsx
@@ -176,6 +176,8 @@ export function HelpModal() {
                 shortcuts={[
                   { keys: ["?"], label: tShortcuts("toggleHelp") },
                   { keys: ["Esc"], label: tShortcuts("closePanels") },
+                  { keys: ["T"], label: tShortcuts("toggleTheme") },
+                  { keys: ["M"], label: tShortcuts("toggleMap") },
                 ]}
               />
             </section>

--- a/pwa/src/hooks/use-keyboard-shortcuts.ts
+++ b/pwa/src/hooks/use-keyboard-shortcuts.ts
@@ -108,8 +108,16 @@ export function useKeyboardShortcuts(stageCount: number) {
         case "m":
         case "M":
           e.preventDefault();
-          // Toggle map visibility: timeline (no map) ↔ split (map shown).
-          setViewMode(viewMode === "timeline" ? "split" : "timeline");
+          // Toggle the map between the two desktop layouts: timeline (no map) ↔
+          // split (timeline + map). The map-only layout (a mobile default) is
+          // left unchanged so the round-trip is not lossy.
+          setViewMode(
+            viewMode === "split"
+              ? "timeline"
+              : viewMode === "timeline"
+                ? "split"
+                : viewMode,
+          );
           break;
       }
     }

--- a/pwa/src/hooks/use-keyboard-shortcuts.ts
+++ b/pwa/src/hooks/use-keyboard-shortcuts.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
+import { useTheme } from "next-themes";
 import { useUiStore } from "@/store/ui-store";
 
 /**
@@ -10,6 +11,8 @@ import { useUiStore } from "@/store/ui-store";
  * - `?`: toggle the keyboard shortcuts help modal
  * - `j`: navigate to the next stage (increment `focusedMapStageIndex`)
  * - `k`: navigate to the previous stage (decrement `focusedMapStageIndex`)
+ * - `t`: cycle the theme (light → dark → system), mirroring the ThemeToggle
+ * - `m`: toggle the map (timeline ↔ split view modes)
  *
  * Undo/redo shortcuts (Ctrl+Z / Ctrl+Y) are handled separately by
  * `useUndoRedo` to keep temporal concerns isolated.
@@ -22,6 +25,8 @@ import { useUiStore } from "@/store/ui-store";
  *   to the global map view (null). Pass `0` when no trip is loaded.
  */
 export function useKeyboardShortcuts(stageCount: number) {
+  const { theme, setTheme } = useTheme();
+
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
       // Ignore events when the user is typing
@@ -44,6 +49,8 @@ export function useKeyboardShortcuts(stageCount: number) {
         setHelpModalOpen,
         focusedMapStageIndex,
         setFocusedMapStageIndex,
+        viewMode,
+        setViewMode,
       } = useUiStore.getState();
 
       switch (e.key) {
@@ -88,10 +95,26 @@ export function useKeyboardShortcuts(stageCount: number) {
             setFocusedMapStageIndex(focusedMapStageIndex - 1);
           }
           break;
+
+        case "t":
+        case "T":
+          e.preventDefault();
+          // Cycle light → dark → system → light (mirrors ThemeToggle).
+          setTheme(
+            theme === "light" ? "dark" : theme === "dark" ? "system" : "light",
+          );
+          break;
+
+        case "m":
+        case "M":
+          e.preventDefault();
+          // Toggle map visibility: timeline (no map) ↔ split (map shown).
+          setViewMode(viewMode === "timeline" ? "split" : "timeline");
+          break;
       }
     }
 
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [stageCount]);
+  }, [stageCount, theme, setTheme]);
 }

--- a/pwa/tests/mocked/keyboard-shortcuts.spec.ts
+++ b/pwa/tests/mocked/keyboard-shortcuts.spec.ts
@@ -134,6 +134,36 @@ test.describe("Keyboard shortcuts", () => {
     await expect(mapContainer).toHaveAttribute("data-focused-stage", "2");
   });
 
+  test("T key cycles the theme", async ({ createFullTrip, mockedPage }) => {
+    await createFullTrip();
+    const toggle = mockedPage.getByTestId("theme-toggle");
+    await expect(toggle).toBeVisible();
+    const before = (await toggle.getAttribute("data-theme-state")) ?? "";
+
+    await mockedPage.locator("body").click();
+    await mockedPage.keyboard.press("t");
+
+    // The selected theme cycled (light → dark → system → light).
+    await expect(toggle).not.toHaveAttribute("data-theme-state", before);
+  });
+
+  test("M key toggles the map", async ({ createFullTrip, mockedPage }) => {
+    await createFullTrip();
+    const map = mockedPage.getByTestId("map-container");
+    // Default desktop view mode is "split" → the map is shown.
+    await expect(map).toBeVisible();
+
+    await mockedPage.locator("body").click();
+
+    // Hide the map (split → timeline).
+    await mockedPage.keyboard.press("m");
+    await expect(map).not.toBeVisible();
+
+    // Show it again (timeline → split).
+    await mockedPage.keyboard.press("m");
+    await expect(map).toBeVisible();
+  });
+
   test("shortcuts are suppressed when focus is inside an <input>", async ({
     mockedPage,
   }) => {


### PR DESCRIPTION
## Contexte

Batch pré-recette, finding **H9** : le design liste les raccourcis **T** (thème) et **M** (carte) dans la modale Aide, mais ni le hook `use-keyboard-shortcuts.ts` ni `help-modal.tsx` ne les géraient.

## Changements

- **`use-keyboard-shortcuts.ts`** :
  - **T** : cycle le thème (light → dark → system → light) via `useTheme()` (next-themes), en miroir de `ThemeToggle`. `theme`/`setTheme` ajoutés aux deps de l'effet.
  - **M** : bascule la carte via `viewMode` du ui-store (`timeline` ↔ `split`).
  - Mêmes garde-fous que J/K (supprimés en saisie input/textarea/select/contentEditable ; ignorés avec Ctrl/Alt).
- **`help-modal.tsx`** : T et M ajoutés à la section « Interface » de la liste des raccourcis.
- **i18n** : `keyboardHelp.toggleTheme` / `keyboardHelp.toggleMap` (FR+EN).

## Tests

- `keyboard-shortcuts.spec.ts` (mocked) : nouveau test **T** (le `data-theme-state` du `theme-toggle` change) + **M** (`map-container` masqué puis ré-affiché). Même fixture `createFullTrip` que les tests J/K.
- Recette inchangée (cross-cutting ne teste que Ctrl+Z/Y, pas de compte de raccourcis). Parité i18n préservée ; prettier OK.

Closes une partie de #635 (H9).

<!-- claude-review-start -->
## Claude Review

Reviewed commit `15af2b5f2d5c460ed24e47cf087eb45a5d0159c9`.

**Findings:** 0 critical, 0 warning.

Resolved 1 previously open thread.

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Inline comments

No inline comments.
<!-- claude-review-end -->