### PR TITLE
fix(ux): show shared-view map on mobile split + surface magic-link expiry delay

### DIFF
--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -694,7 +694,7 @@
     "checkYourInbox": "Check your inbox",
     "linkSentTo": "If <strong>{email}</strong> is registered, you'll receive a sign-in link shortly.",
     "checkSpamHint": "Don't forget to check your spam folder.",
-    "linkExpiryHint": "The sign-in link expires in 15 minutes.",
+    "linkExpiryHint": "The sign-in link expires in 30 minutes.",
     "resendLink": "Resend link",
     "resendLinkCountdown": "Resend link ({seconds}s)",
     "linkExpiredTitle": "Link expired or invalid",

--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -694,6 +694,7 @@
     "checkYourInbox": "Check your inbox",
     "linkSentTo": "If <strong>{email}</strong> is registered, you'll receive a sign-in link shortly.",
     "checkSpamHint": "Don't forget to check your spam folder.",
+    "linkExpiryHint": "The sign-in link expires in 15 minutes.",
     "resendLink": "Resend link",
     "resendLinkCountdown": "Resend link ({seconds}s)",
     "linkExpiredTitle": "Link expired or invalid",

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -694,6 +694,7 @@
     "checkYourInbox": "Vérifie ta boîte mail",
     "linkSentTo": "Si <strong>{email}</strong> est enregistrée, tu recevras un lien de connexion sous peu.",
     "checkSpamHint": "Pense à vérifier tes courriers indésirables.",
+    "linkExpiryHint": "Le lien de connexion expire dans 15 minutes.",
     "resendLink": "Renvoyer un lien",
     "resendLinkCountdown": "Renvoyer un lien ({seconds}s)",
     "linkExpiredTitle": "Lien expiré ou invalide",

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -694,7 +694,7 @@
     "checkYourInbox": "Vérifie ta boîte mail",
     "linkSentTo": "Si <strong>{email}</strong> est enregistrée, tu recevras un lien de connexion sous peu.",
     "checkSpamHint": "Pense à vérifier tes courriers indésirables.",
-    "linkExpiryHint": "Le lien de connexion expire dans 15 minutes.",
+    "linkExpiryHint": "Le lien de connexion expire dans 30 minutes.",
     "resendLink": "Renvoyer un lien",
     "resendLinkCountdown": "Renvoyer un lien ({seconds}s)",
     "linkExpiredTitle": "Lien expiré ou invalide",

--- a/pwa/src/app/s/[code]/shared-trip-page.tsx
+++ b/pwa/src/app/s/[code]/shared-trip-page.tsx
@@ -281,14 +281,14 @@ function SharedTripLoader({ code }: { code: string }) {
               <div
                 className={
                   viewMode === "split"
-                    ? "hidden lg:block lg:w-[520px] lg:shrink-0"
+                    ? "lg:w-[520px] lg:shrink-0"
                     : "w-full h-[calc(100vh-12rem)]"
                 }
               >
                 <div
                   className={
                     viewMode === "split"
-                      ? "lg:sticky lg:top-20 lg:h-[calc(100dvh-6rem)]"
+                      ? "h-[calc(100dvh-6rem)] lg:sticky lg:top-20"
                       : "w-full h-full"
                   }
                 >

--- a/pwa/src/components/auth/email-sent.tsx
+++ b/pwa/src/components/auth/email-sent.tsx
@@ -84,6 +84,12 @@ export function EmailSent({
           })}
         </p>
         <p className="text-muted-foreground text-xs">{t("checkSpamHint")}</p>
+        <p
+          className="text-muted-foreground text-xs"
+          data-testid="magic-link-expiry-hint"
+        >
+          {t("linkExpiryHint")}
+        </p>
       </div>
 
       <Button

--- a/pwa/tests/mocked/auth-flow.spec.ts
+++ b/pwa/tests/mocked/auth-flow.spec.ts
@@ -45,7 +45,7 @@ test.describe("Auth flow", () => {
     // disabled resend button counting down from 60s.
     await expect(page.getByTestId("magic-link-sent")).toBeVisible();
     await expect(page.getByText("test@example.com")).toBeVisible();
-    // The link-expiry hint ("expires in 15 minutes") is shown.
+    // The link-expiry hint ("expires in 30 minutes") is shown.
     await expect(page.getByTestId("magic-link-expiry-hint")).toBeVisible();
   });
 

--- a/pwa/tests/mocked/auth-flow.spec.ts
+++ b/pwa/tests/mocked/auth-flow.spec.ts
@@ -45,6 +45,8 @@ test.describe("Auth flow", () => {
     // disabled resend button counting down from 60s.
     await expect(page.getByTestId("magic-link-sent")).toBeVisible();
     await expect(page.getByText("test@example.com")).toBeVisible();
+    // The link-expiry hint ("expires in 15 minutes") is shown.
+    await expect(page.getByTestId("magic-link-expiry-hint")).toBeVisible();
   });
 
   test("unauthenticated user sees landing page at /", async ({ page }) => {


### PR DESCRIPTION
## Contexte

Batch pré-recette, derniers items de polish : findings **H10** (carte split partagée masquée sous `lg`) et ton login (délai magic-link).

## Changements

### H10 — carte de la vue partagée (`shared-trip-page.tsx`)
En mode `split`, la carte avait `hidden lg:block` → elle **disparaissait** silencieusement sous le breakpoint `lg`, alors que l'éditeur (`trip-planner.tsx`) l'empile en pleine largeur. Aligné sur l'éditeur :
- Wrapper : `hidden lg:block lg:w-[520px] lg:shrink-0` → `lg:w-[520px] lg:shrink-0` (la carte s'empile sous la timeline sous `lg` au lieu de disparaître).
- Conteneur interne : hauteur appliquée à toutes les tailles (`h-[calc(100dvh-6rem)] lg:sticky lg:top-20`) pour que la carte ait une hauteur quand elle est empilée (sinon 0px = invisible).

### Ton login — délai d'expiration (`email-sent.tsx`)
Recommandation de l'audit : garder la formulation **anti-énumération** (« Si {email} est enregistrée… » — inchangée) et ajouter le délai d'expiration. **Le design indiquait « 15 minutes » mais c'était faux** : le TTL réel est **30 minutes** (`MagicLinkRepository::TTL_MINUTES = 30`, `AuthRequestLinkProcessor` → `expiresInMinutes: 30`, et l'email lui-même annonce 30). On affiche donc la vraie valeur. Nouvelle clé i18n `auth.linkExpiryHint` (FR+EN) rendue sous l'indice spam.

## Tests

- `auth-flow.spec.ts` (mocked) : assertion ajoutée — `magic-link-expiry-hint` visible après l'envoi.
- Conteneur `magic-link-sent` inchangé → tests recette/mocked existants préservés.
- Parité i18n FR/EN ; prettier OK ; QA worktree → CI.
- **VR** : la baseline de la vue partagée (split mobile) peut changer → régénérer si besoin (`make visual-update`, hors CI).

Closes une partie de #635 (H10 + ton login). **Dernier item du batch de corrections design** — tout l'audit v2 actionnable est désormais couvert (chrome, FIT, légal, landing, 404/500, raccourcis, polish).

<!-- claude-review-start -->
## Claude Review

Clean PR — all previously flagged issues have been addressed. The 30-minute expiry value is now correct in both locales, the stale test comment has been fixed, and the mobile map layout aligns with the editor's behaviour.

**Resolved 1 previously open thread** (stale "15 minutes" comment in the test file, corrected in `cdab512`).

**Findings: 0 critical, 0 warnings**

Reviewed commit: `cdab512eeed8eed32f3f6004df2f451acb71c5e2`

### Review checklist
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**No inline comments.**
<!-- claude-review-end -->