### PR TITLE
fix(recette): #649 quick wins — GPX/FIT download auth, FRONTEND_URL, early-access anchor

### DIFF
--- a/api/src/ApiResource/Trip.php
+++ b/api/src/ApiResource/Trip.php
@@ -152,7 +152,7 @@ use App\State\TripUpdateProcessor;
                 'fit' => ['application/vnd.ant.fit'],
             ],
             openapi: new Operation(summary: 'Download the full trip as a single GPX or FIT file containing all stages.'),
-            security: "is_granted('TRIP_VIEW', object)",
+            security: "is_granted('TRIP_VIEW', request.attributes.get('id'))",
             provider: TripGpxProvider::class,
         ),
         new Delete(

--- a/api/tests/Functional/TripDownloadTest.php
+++ b/api/tests/Functional/TripDownloadTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Symfony\Bundle\Test\Client;
+use App\ApiResource\Model\Coordinate;
+use App\ApiResource\Stage as StageDto;
+use App\ApiResource\TripRequest;
+use App\Entity\User;
+use App\Repository\TripRequestRepositoryInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Uid\Uuid;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+use Zenstruck\Foundry\Test\Factories;
+
+#[ResetDatabase]
+final class TripDownloadTest extends ApiTestCase
+{
+    use Factories;
+    use JwtAuthTestTrait;
+
+    private const string TRIP_ID = '01936f6e-0000-7000-8000-000000000401';
+
+    private Client $client;
+
+    private User $testUser;
+
+    private string $jwtToken;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->client = self::createClient();
+        ['user' => $this->testUser, 'token' => $this->jwtToken] = $this->createTestUserWithJwt('test@example.com');
+    }
+
+    private function seedTripWithStages(string $tripId): void
+    {
+        /** @var TripRequestRepositoryInterface $repo */
+        $repo = self::getContainer()->get(TripRequestRepositoryInterface::class);
+
+        $request = new TripRequest(Uuid::fromString($tripId));
+        $request->sourceUrl = 'https://www.komoot.com/tour/123456789';
+
+        $repo->initializeTrip($tripId, $request);
+        $repo->storeTitle($tripId, 'Download test trip');
+        $this->associateTripWithUser($tripId, $this->testUser);
+
+        $stage = new StageDto(
+            tripId: $tripId,
+            dayNumber: 1,
+            distance: 85.5,
+            elevation: 1200.0,
+            startPoint: new Coordinate(45.0, 6.0, 1000.0),
+            endPoint: new Coordinate(45.5, 6.5, 800.0),
+            geometry: [new Coordinate(45.0, 6.0, 1000.0), new Coordinate(45.5, 6.5, 800.0)],
+        );
+        $repo->storeStages($tripId, [$stage]);
+    }
+
+    #[Test]
+    public function ownerDownloadsGpx(): void
+    {
+        $this->seedTripWithStages(self::TRIP_ID);
+
+        $response = $this->client->request('GET', \sprintf('/trips/%s.gpx', self::TRIP_ID), [
+            'headers' => array_merge(['Accept' => 'application/gpx+xml'], $this->authHeader($this->jwtToken)),
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertStringContainsString('<gpx', $response->getContent(false));
+    }
+
+    #[Test]
+    public function ownerDownloadsFit(): void
+    {
+        $this->seedTripWithStages(self::TRIP_ID);
+
+        $this->client->request('GET', \sprintf('/trips/%s.fit', self::TRIP_ID), [
+            'headers' => array_merge(['Accept' => 'application/vnd.ant.fit'], $this->authHeader($this->jwtToken)),
+        ]);
+
+        $this->assertResponseIsSuccessful();
+    }
+
+    #[Test]
+    public function foreignUserDownloadReturns404(): void
+    {
+        // Object-level authz denial is surfaced as 404 (ADR-038), not 403.
+        $this->seedTripWithStages(self::TRIP_ID);
+
+        ['token' => $otherToken] = $this->createTestUserWithJwt('intruder@example.com');
+
+        $this->client->request('GET', \sprintf('/trips/%s.gpx', self::TRIP_ID), [
+            'headers' => array_merge(['Accept' => 'application/gpx+xml'], $this->authHeader($otherToken)),
+        ]);
+
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    #[Test]
+    public function unauthenticatedDownloadReturns401(): void
+    {
+        $this->client->request('GET', \sprintf('/trips/%s.gpx', self::TRIP_ID), [
+            'headers' => ['Accept' => 'application/gpx+xml'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(401);
+    }
+}

--- a/compose.yaml
+++ b/compose.yaml
@@ -77,7 +77,7 @@ services:
       JWT_SECRET_KEY: /run/secrets/jwt_private_key
       JWT_PUBLIC_KEY: /run/secrets/jwt_public_key
       JWT_PASSPHRASE: "${JWT_PASSPHRASE}"
-      FRONTEND_URL: "${FRONTEND_URL}"
+      FRONTEND_URL: "${FRONTEND_URL:-https://localhost}"
       MAILER_DSN: "${MAILER_DSN}"
       DATATOURISME_API_KEY: "${DATATOURISME_API_KEY:-}"
       DATATOURISME_ENABLED: "${DATATOURISME_ENABLED:-false}"
@@ -180,7 +180,7 @@ services:
       JWT_SECRET_KEY: /run/secrets/jwt_private_key
       JWT_PUBLIC_KEY: /run/secrets/jwt_public_key
       JWT_PASSPHRASE: "${JWT_PASSPHRASE}"
-      FRONTEND_URL: "${FRONTEND_URL}"
+      FRONTEND_URL: "${FRONTEND_URL:-https://localhost}"
       MAILER_DSN: "${MAILER_DSN}"
       DATATOURISME_API_KEY: "${DATATOURISME_API_KEY:-}"
       DATATOURISME_ENABLED: "${DATATOURISME_ENABLED:-false}"
@@ -269,7 +269,7 @@ services:
       JWT_SECRET_KEY: /run/secrets/jwt_private_key
       JWT_PUBLIC_KEY: /run/secrets/jwt_public_key
       JWT_PASSPHRASE: "${JWT_PASSPHRASE}"
-      FRONTEND_URL: "${FRONTEND_URL}"
+      FRONTEND_URL: "${FRONTEND_URL:-https://localhost}"
       MAILER_DSN: "${MAILER_DSN}"
       DATATOURISME_API_KEY: "${DATATOURISME_API_KEY:-}"
       DATATOURISME_ENABLED: "${DATATOURISME_ENABLED:-false}"

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -826,7 +826,7 @@
     },
     "availability": {
       "title": "Disponible partout",
-      "subtitle": "Sur le web, sur votre poche et même sans réseau.",
+      "subtitle": "Sur le web, dans votre poche et même sans réseau.",
       "webTitle": "Web",
       "webDescription": "Optimisé pour tous les écrans, du smartphone au desktop.",
       "pwaTitle": "PWA",

--- a/pwa/src/components/attribution-footer.tsx
+++ b/pwa/src/components/attribution-footer.tsx
@@ -18,7 +18,7 @@ export function AttributionFooter() {
     <>
       <button
         onClick={() => setOpen(true)}
-        className="text-xs text-muted-foreground hover:text-foreground transition-colors underline underline-offset-2"
+        className="text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
         data-testid="attribution-footer-link"
       >
         {t("link")}

--- a/pwa/src/components/early-access-section.tsx
+++ b/pwa/src/components/early-access-section.tsx
@@ -31,6 +31,7 @@ export function EarlyAccessSection() {
 
   return (
     <section
+      id="early-access"
       className="py-24 md:py-32 bg-foreground text-background"
       data-testid="section-early-access"
     >

--- a/pwa/src/components/public-top-bar.tsx
+++ b/pwa/src/components/public-top-bar.tsx
@@ -59,7 +59,7 @@ export function PublicTopBar({ transparent = false }: { transparent?: boolean })
           className="hidden sm:inline-flex bg-brand-fill hover:bg-brand-fill-hover text-white"
           data-testid="public-top-bar-request"
         >
-          <Link href="/login">{t("requestAccess")}</Link>
+          <Link href="/#early-access">{t("requestAccess")}</Link>
         </Button>
       </div>
     </header>

--- a/pwa/tests/mocked/landing-header.spec.ts
+++ b/pwa/tests/mocked/landing-header.spec.ts
@@ -34,6 +34,6 @@ test.describe("landing public header", () => {
     // the default 1280px viewport it must be visible.
     const request = page.getByTestId("public-top-bar-request");
     await expect(request).toBeVisible();
-    await expect(request).toHaveAttribute("href", "/login");
+    await expect(request).toHaveAttribute("href", "/#early-access");
   });
 });


### PR DESCRIPTION
Premier lot de la recette #649 (quick wins, débloque la recette).

## Corrections
- **fix(api)** : le téléchargement GPX/FIT échouait quand l'utilisateur est connecté (403) alors qu'il marchait en vue partagée. `TripGpxProvider` renvoie un objet `Trip` nu que `TripVoter::supports()` rejette (il n'accepte que `TripRequest|string`) → le voter s'abstenait → accès refusé. L'opération passe désormais `request.attributes.get('id')` (string), supporté par le voter. Test de régression `TripDownloadTest` ajouté.
- **fix(docker)** : `FRONTEND_URL` était injecté sans défaut dans `compose.yaml` → vide en iso-prod, le lien d'activation devenait relatif `/auth/...` et se résolvait contre le domaine du mailer (mailcatcher). Défaut `https://localhost` (comme la directive Mercure).
- **fix(landing)** : ancre `id="early-access"` manquante ajoutée ; le CTA « Demander l'accès » pointe vers `/#early-access` (le lien de la page login l'utilisait déjà) ; typo « sur votre poche » → « dans votre poche » ; lien footer « À propos des données » en `cursor-pointer` sans soulignement.

## Vérification locale
- `TripDownloadTest` : 4 tests verts (owner GPX/FIT = 200, tiers = 404, anonyme = 401).
- PHP-CS-Fixer : 0 fichier à corriger. ESLint : 0 erreur. `tsc --noEmit` : clean. i18n : 850 clés en phase.
- PHPStan (OOM en local) et Prettier (non épinglé) : laissés à la CI ; les changements de ce lot sont neutres pour les deux.

Refs #649. Lot suivant : gating IA front (#304) en PR dédiée.

<!-- claude-review-start -->
## Claude Review

Three targeted, well-scoped fixes with clean regression coverage. The voter-abstention root cause is correctly diagnosed — `request.attributes.get('id')` aligns the download operation with the string type accepted by `TripVoter::supports()`. No critical or warning findings.

**Findings:** 0 critical, 0 warning, 1 note

**Resolved threads:** Resolved 1 previously open thread (outdated docblock note on `TripDownloadTest.php` — the docblock was not included in the final file).

**PR title check:** `fix(recette): #649 quick wins — …` — "quick wins" is a noun phrase rather than imperative mood, and embedding `#649` in the description is non-standard. Consider: `fix(recette): authorize GPX/FIT download, default FRONTEND_URL, add early-access anchor`.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

Reviewed commit: `4a485b54c6c594c9ebcd8a64118407255d2f3b25`
<!-- claude-review-end -->