### PR TITLE
fix(wizard): improve trip-page load UX and add an explicit route-link submit (#649)

### DIFF
--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -545,6 +545,7 @@
     "linkInputPlaceholder": "Enter your Komoot, Strava or RideWithGPS link here...",
     "linkInvalidUrl": "Please enter a valid URL.",
     "linkUnsupportedSource": "Unsupported source. Use Komoot, Strava or RideWithGPS.",
+    "linkSubmit": "Import",
     "gpxTitle": "GPX file",
     "gpxDescription": "Drag & drop your file",
     "gpxBrowse": "Browse",

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -545,6 +545,7 @@
     "linkInputPlaceholder": "Collez votre lien Komoot, Strava ou RideWithGPS ici...",
     "linkInvalidUrl": "Veuillez entrer une URL valide.",
     "linkUnsupportedSource": "Source non supportée. Utilisez Komoot, Strava ou RideWithGPS.",
+    "linkSubmit": "Importer",
     "gpxTitle": "Fichier GPX",
     "gpxDescription": "Glissez-déposez votre fichier",
     "gpxBrowse": "Parcourir",

--- a/pwa/src/components/Timeline/StageDetailPanel.tsx
+++ b/pwa/src/components/Timeline/StageDetailPanel.tsx
@@ -93,9 +93,16 @@ export function StageDetailPanel({
   const tStage = useTranslations("stage");
   const recomputingStages = useTripStore((s) => s.recomputingStages);
   const selectedRef = useRef<HTMLDivElement>(null);
+  const prevSelectedIndexRef = useRef(selectedIndex);
 
-  // Scroll the selected stage into view when selection changes.
+  // Scroll the selected stage into view on user selection changes — but skip the
+  // initial render so loading a trip keeps the scroll at the top instead of
+  // jumping down to the first stage (recette #649). Comparing against the
+  // previous index (rather than a "has-run" flag) stays correct under React
+  // Strict Mode's double-invoked mount effect.
   useEffect(() => {
+    if (prevSelectedIndexRef.current === selectedIndex) return;
+    prevSelectedIndexRef.current = selectedIndex;
     selectedRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
   }, [selectedIndex]);
 

--- a/pwa/src/components/card-selection.tsx
+++ b/pwa/src/components/card-selection.tsx
@@ -240,24 +240,35 @@ function LinkCard({ expanded, disabled, onSelect, onSubmit }: LinkCardProps) {
           >
             {t("linkInputLabel")}
           </label>
-          <Input
-            ref={inputRef}
-            id="card-link-url"
-            type="url"
-            value={url}
-            onChange={handleChange}
-            onKeyDown={handleKeyDown}
-            onPaste={handlePaste}
-            placeholder={t("linkInputPlaceholder")}
-            disabled={disabled}
-            className={cn(
-              "w-full text-base rounded-lg px-4 py-3 h-auto",
-              error && "ring-2 ring-destructive",
-            )}
-            data-testid="magic-link-input"
-            aria-invalid={!!error}
-            aria-describedby={error ? "card-link-error" : undefined}
-          />
+          <div className="flex gap-2">
+            <Input
+              ref={inputRef}
+              id="card-link-url"
+              type="url"
+              value={url}
+              onChange={handleChange}
+              onKeyDown={handleKeyDown}
+              onPaste={handlePaste}
+              placeholder={t("linkInputPlaceholder")}
+              disabled={disabled}
+              className={cn(
+                "w-full text-base rounded-lg px-4 py-3 h-auto",
+                error && "ring-2 ring-destructive",
+              )}
+              data-testid="magic-link-input"
+              aria-invalid={!!error}
+              aria-describedby={error ? "card-link-error" : undefined}
+            />
+            <Button
+              type="button"
+              onClick={() => void submit(url)}
+              disabled={disabled || url.trim().length === 0}
+              className="shrink-0 h-auto px-4 cursor-pointer bg-brand-fill text-white hover:bg-brand-fill-hover"
+              data-testid="magic-link-submit"
+            >
+              {t("linkSubmit")}
+            </Button>
+          </div>
           {error && (
             <p
               id="card-link-error"

--- a/pwa/src/components/card-selection.tsx
+++ b/pwa/src/components/card-selection.tsx
@@ -192,7 +192,7 @@ function LinkCard({ expanded, disabled, onSelect, onSubmit }: LinkCardProps) {
   const handleChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     setUrl(e.target.value);
     // Clear any previous error while the user is editing. Validation runs
-    // on submit (Enter or paste of a fully-formed URL).
+    // on submit (Enter or the Import button).
     setError(null);
   }, []);
 
@@ -212,13 +212,14 @@ function LinkCard({ expanded, disabled, onSelect, onSubmit }: LinkCardProps) {
       const trimmed = pasted.trim();
       if (!trimmed) return;
       if (isSupportedSourceUrl(trimmed)) {
+        // Fill the field for review — submission stays explicit (Enter or the
+        // Import button), so a paste never navigates away unprompted (#649).
         e.preventDefault();
         setUrl(trimmed);
         setError(null);
-        void submit(trimmed);
       }
     },
-    [submit],
+    [],
   );
 
   return (

--- a/pwa/src/components/trip-title.tsx
+++ b/pwa/src/components/trip-title.tsx
@@ -6,6 +6,7 @@ import { X } from "lucide-react";
 import { EditableField } from "@/components/editable-field";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
+import { useTripStore } from "@/store/trip-store";
 
 import { getSuggestionName } from "@/lib/trip-utils";
 
@@ -23,9 +24,33 @@ export function TripTitle({
   isLoading,
 }: TripTitleProps) {
   const t = useTranslations("tripTitle");
+  const tripId = useTripStore((s) => s.trip?.id ?? null);
   const [dismissed, setDismissed] = useState(false);
   const [suggestedName] = useState(() => getSuggestionName(title));
   const hasShown = useRef(false);
+
+  // Persist the accept/dismiss decision per trip so the suggestion is not
+  // re-proposed after a reload (recette #649).
+  const storageKey = tripId ? `btp.title-suggestion-dismissed.${tripId}` : null;
+
+  useEffect(() => {
+    if (!storageKey) return;
+    try {
+      if (window.localStorage.getItem(storageKey) === "1") setDismissed(true);
+    } catch {
+      /* localStorage unavailable (private mode, SSR) — keep showing once */
+    }
+  }, [storageKey]);
+
+  const dismiss = () => {
+    setDismissed(true);
+    if (!storageKey) return;
+    try {
+      window.localStorage.setItem(storageKey, "1");
+    } catch {
+      /* ignore storage write errors */
+    }
+  };
 
   const shouldShow = showSuggestion && !dismissed && !hasShown.current;
 
@@ -65,7 +90,7 @@ export function TripTitle({
             className="h-6 text-xs cursor-pointer"
             onClick={() => {
               onChange(suggestedName);
-              setDismissed(true);
+              dismiss();
             }}
           >
             {t("apply")}
@@ -74,7 +99,7 @@ export function TripTitle({
             variant="ghost"
             size="icon"
             className="h-6 w-6 cursor-pointer"
-            onClick={() => setDismissed(true)}
+            onClick={dismiss}
             aria-label={t("dismissSuggestion")}
           >
             <X className="h-3.5 w-3.5" />

--- a/pwa/src/components/trip-title.tsx
+++ b/pwa/src/components/trip-title.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useLayoutEffect, useRef } from "react";
 import { useTranslations } from "next-intl";
 import { X } from "lucide-react";
 import { EditableField } from "@/components/editable-field";
@@ -33,7 +33,9 @@ export function TripTitle({
   // re-proposed after a reload (recette #649).
   const storageKey = tripId ? `btp.title-suggestion-dismissed.${tripId}` : null;
 
-  useEffect(() => {
+  // Read the persisted decision before paint (not after) so a previously
+  // dismissed suggestion never flashes on reload (#649 review).
+  useLayoutEffect(() => {
     if (!storageKey) return;
     try {
       if (window.localStorage.getItem(storageKey) === "1") setDismissed(true);

--- a/pwa/tests/mocked/trip-creation.spec.ts
+++ b/pwa/tests/mocked/trip-creation.spec.ts
@@ -123,7 +123,7 @@ test.describe("Trip creation flow", () => {
     );
   });
 
-  test("auto-submits on paste of valid URL", async ({ mockedPage }) => {
+  test("paste fills the field without submitting", async ({ mockedPage }) => {
     const input = mockedPage.getByTestId("magic-link-input");
     await input.focus();
     // Dispatch a paste event with clipboardData
@@ -142,7 +142,16 @@ test.describe("Trip creation flow", () => {
       });
       el.dispatchEvent(event);
     });
-    // Should auto-submit — trip title skeleton or title should appear
+    // Paste populates the field for review — it must NOT auto-submit/navigate.
+    await expect(input).toHaveValue("https://www.komoot.com/fr-fr/tour/12345");
+    await expect(mockedPage).toHaveURL("/");
+  });
+
+  test("Import button submits the entered URL", async ({ mockedPage }) => {
+    const input = mockedPage.getByTestId("magic-link-input");
+    await input.fill("https://www.komoot.com/fr-fr/tour/12345");
+    await mockedPage.getByTestId("magic-link-submit").click();
+    await mockedPage.waitForURL(/\/trips\//, { timeout: 5000 });
     await expect(
       mockedPage
         .getByTestId("trip-title-skeleton")

--- a/pwa/tests/recette/features/trip-creation.en.feature
+++ b/pwa/tests/recette/features/trip-creation.en.feature
@@ -50,8 +50,15 @@ Feature: Trip creation
     And I see stage card 3
 
   @desktop
-  Scenario: Auto-submit when pasting a valid URL
+  Scenario: Pasting a valid URL fills the field without submitting
     When I paste "https://www.komoot.com/fr-fr/tour/12345" into the magic link field
+    Then the magic link field contains "https://www.komoot.com/fr-fr/tour/12345"
+    And I stay on the home page
+
+  @desktop
+  Scenario: Submitting a valid link via the Import button
+    When I type "https://www.komoot.com/fr-fr/tour/12345" in the magic link field
+    And I click the "Import" button
     Then I am redirected to the trip page
 
   @desktop

--- a/pwa/tests/recette/features/trip-creation.fr.feature
+++ b/pwa/tests/recette/features/trip-creation.fr.feature
@@ -51,8 +51,15 @@ Fonctionnalité: Création de voyage
     Et je vois la carte de l'étape 3
 
   @desktop
-  Scénario: Soumission automatique lors du collage d'une URL valide
+  Scénario: Le collage d'une URL valide remplit le champ sans soumettre
     Quand je colle l'URL "https://www.komoot.com/fr-fr/tour/12345" dans le champ de lien magique
+    Alors le champ de lien magique contient "https://www.komoot.com/fr-fr/tour/12345"
+    Et je reste sur la page d'accueil
+
+  @desktop
+  Scénario: Soumission d'un lien valide via le bouton Importer
+    Quand je saisis "https://www.komoot.com/fr-fr/tour/12345" dans le champ de lien magique
+    Et que je clique sur le bouton "Importer"
     Alors je suis redirigé vers la page du voyage
 
   @desktop

--- a/pwa/tests/recette/steps/common.steps.ts
+++ b/pwa/tests/recette/steps/common.steps.ts
@@ -429,6 +429,20 @@ When(
   },
 );
 
+Then(
+  "le champ de lien magique contient {string}",
+  async ({ mockedPage }, value: string) => {
+    await expect(mockedPage.getByTestId("magic-link-input")).toHaveValue(value);
+  },
+);
+
+Then(
+  "the magic link field contains {string}",
+  async ({ mockedPage }, value: string) => {
+    await expect(mockedPage.getByTestId("magic-link-input")).toHaveValue(value);
+  },
+);
+
 // ---------------------------------------------------------------------------
 // Error messages — FR + EN
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Lot « flux wizard » de la recette #649 — sous-ensemble **sûr et isolé** (3 correctifs).

## Corrections
- **fix(trip)** — *scroll au chargement* : `StageDetailPanel` faisait un `scrollIntoView` à chaque changement de `selectedIndex`, y compris au montage → la page sautait vers la 1re étape à l'ouverture. On ne scrolle que sur un vrai changement d'index (comparaison à la valeur précédente — **safe en React Strict Mode**, suite review bot).
- **fix(trip)** — *suggestion de titre persistée* : la décision accepter/refuser vivait en state local → réapparaissait au rechargement. Persistée en `localStorage` par tripId.
- **fix(wizard)** — *bouton de soumission du lien* : coller une URL supportée auto-soumettait instantanément (aucune revue possible). On retire l'auto-submit au paste et on ajoute un bouton « Importer » explicite à côté du champ (Entrée soumet toujours). Clé i18n `cardSelection.linkSubmit` (fr+en).

## Vérification
- `tsc --noEmit` ✅, ESLint ✅, i18n ✅ — en local. CI Playwright contre le build prod de la branche.

## Différé (suivi dédié)
- **Stepper de création masqué sur la page voyage** (recette #649) : retiré de cette PR car il masque le `<Stepper />` interne testé par `stepper-flow.spec.ts` (via `createFullTrip` → `/trips/[id]`). À refaire avec la mise à jour des tests mockés (et vérif BDD), dans une PR dédiée.

## Lié
- **#653** : les 2 bugs de machine à états du flux (skip étape 2, boucle `?step=3`).

Refs #649.

<!-- claude-review-start -->
## Claude Review

All three fixes are correct, well-scoped, and clean. The `prevSelectedIndexRef` scroll guard is Strict Mode safe. The `useLayoutEffect` localStorage read prevents the dismissal-banner flash on reload. The Import button correctly delegates submission from the paste handler to an explicit user action, and all previously flagged test coverage gaps have been closed by the final commit.

**Commit reviewed:** `c575e308c2f95f28270fad4d3e123f81f5815a63`

| Severity | Count |
|---|---|
| 🔴 Critical | 0 |
| 🟡 Warning | 0 |
| ℹ️ Info | 0 |

### Review checklist
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases — mocked spec + BDD features (EN + FR) updated; all new step definitions pre-exist
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Resolved threads:** Resolved 1 previously open bot thread (Import button test coverage — addressed by `c575e308`).

No inline comments.
<!-- claude-review-end -->