### PR TITLE
fix(wizard): preview step during computation + reset on re-entering "Nouveau voyage" (#649)

### DIFF
--- a/pwa/src/app/trips/new/page.tsx
+++ b/pwa/src/app/trips/new/page.tsx
@@ -91,7 +91,16 @@ function WizardContent() {
   // app logic — e.g. analysis is reached only after the user clicks
   // "Lancer l'analyse"). We rely on the store's own guards (see `goToStep`).
   useEffect(() => {
-    if (requestedStep === null) return;
+    if (requestedStep === null) {
+      // Bare `/trips/new` (e.g. the header "Nouveau voyage" link) is an explicit
+      // fresh-start intent: reset a stale wizard instead of letting the
+      // store→URL effect re-pin a leftover `?step` and trap the user on the
+      // analysis/loading screen (recette #649).
+      if (currentStepRef.current !== "preparation") {
+        navigateToStep("preparation");
+      }
+      return;
+    }
     // Read the latest store step from a ref so this effect only re-runs when
     // the URL changes — not when the store advances asynchronously.
     const current = currentStepRef.current;

--- a/pwa/src/components/trip-planner.tsx
+++ b/pwa/src/components/trip-planner.tsx
@@ -296,11 +296,17 @@ export function TripPlanner({
   // - Stages computed, processing settled, analysis not launched → "preview"
   // - Stages computed, analysis complete → "my_trip"
   useEffect(() => {
-    if (isProcessing) {
-      // Computation in flight: advance past preparation/preview into analysis.
+    if (isProcessing && hasAnalysisStarted) {
+      // Acte 2 analysis in flight: advance past preparation/preview into analysis.
       completeStep("preparation");
       completeStep("preview");
       goToStep("analysis");
+    } else if (isProcessing) {
+      // Initial route computation (URL submit / GPX upload) in flight: park on
+      // "preview" (loading) instead of jumping to analysis, so the wizard passes
+      // through the preview step before the user launches the analysis (#649).
+      completeStep("preparation");
+      goToStep("preview");
     } else if (trip && stages.length > 0 && !hasAnalysisStarted) {
       // Phase 1 complete: pacing engine produced stages. Park on "preview"
       // and wait for the user to explicitly click "Lancer l'analyse".

--- a/pwa/tests/mocked/stepper-flow.spec.ts
+++ b/pwa/tests/mocked/stepper-flow.spec.ts
@@ -24,14 +24,15 @@ test.describe("Stepper — initial state", () => {
 });
 
 test.describe("Stepper — step transitions", () => {
-  test("advances to 'analysis' after URL submission", async ({
+  test("advances to 'preview' after URL submission", async ({
     submitUrl,
     mockedPage,
   }) => {
     await submitUrl();
-    // After URL submit + trip creation, isProcessing=true → analysis step
-    const analysisStep = mockedPage.getByTestId("stepper-step-analysis");
-    await expect(analysisStep).toHaveAttribute("aria-current", "step", {
+    // The initial route computation parks on "preview" (recette #649); analysis
+    // only follows the explicit "Lancer l'analyse" action.
+    const previewStep = mockedPage.getByTestId("stepper-step-preview");
+    await expect(previewStep).toHaveAttribute("aria-current", "step", {
       timeout: 5000,
     });
   });
@@ -52,9 +53,9 @@ test.describe("Stepper — step transitions", () => {
     mockedPage,
   }) => {
     await submitUrl();
-    // Wait until we move past preparation
+    // Wait until we move past preparation (now onto "preview")
     await expect(
-      mockedPage.getByTestId("stepper-step-analysis"),
+      mockedPage.getByTestId("stepper-step-preview"),
     ).toHaveAttribute("aria-current", "step", { timeout: 5000 });
     // preparation step should no longer be the active one
     await expect(
@@ -140,9 +141,9 @@ test.describe("Stepper — responsive mobile", () => {
     await mockedPage.setViewportSize({ width: 375, height: 812 });
     await submitUrl();
     const mobileLabel = mockedPage.getByTestId("stepper-mobile-label");
-    // After URL submit: moves to analysis (step 3)
-    await expect(mobileLabel).toContainText("3/4", { timeout: 5000 });
-    await expect(mobileLabel).toContainText("Analyse", { timeout: 5000 });
+    // After URL submit: moves to preview (step 2)
+    await expect(mobileLabel).toContainText("2/4", { timeout: 5000 });
+    await expect(mobileLabel).toContainText("Aperçu", { timeout: 5000 });
   });
 });
 
@@ -169,7 +170,7 @@ test.describe("Stepper — reset on clearTrip", () => {
     // Submitting a new URL must advance again instead of being stuck.
     await submitUrl();
     await expect(
-      mockedPage.getByTestId("stepper-step-analysis"),
+      mockedPage.getByTestId("stepper-step-preview"),
     ).toHaveAttribute("aria-current", "step", { timeout: 5000 });
   });
 });
@@ -182,13 +183,12 @@ test.describe("Stepper — backwards navigation", () => {
   }) => {
     await submitUrl();
     await injectEvent(routeParsedEvent());
-    // After route_parsed: preparation is complete, but we may still be in analysis
-    // Inject stages to reach preview
+    // Inject stages to reach the preview step
     await injectEvent(stagesComputedEvent());
 
-    // Wait until we're past preparation
+    // Wait until we're past preparation (now on "preview")
     await expect(
-      mockedPage.getByTestId("stepper-step-analysis"),
+      mockedPage.getByTestId("stepper-step-preview"),
     ).toHaveAttribute("aria-current", "step", { timeout: 5000 });
 
     // Inject a trip_complete event to move to my_trip is not done yet,

--- a/pwa/tests/mocked/wizard-stepper.spec.ts
+++ b/pwa/tests/mocked/wizard-stepper.spec.ts
@@ -21,9 +21,10 @@ interface WizardFixtures {
   wizardPage: Page;
   injectWizardEvent: (event: MercureEvent) => Promise<void>;
   /**
-   * Simulate `isProcessing=true` via the TripPlanner test hook. This triggers
-   * the same stepper transition that a real URL submit would (preparation +
-   * preview → analysis) without navigating away from /trips/new.
+   * Drive the stepper to the "analysis" step via the TripPlanner test hooks
+   * (analysis started + processing), without navigating away from /trips/new.
+   * A real URL submit now parks on "preview"; analysis follows "Lancer l'analyse"
+   * (recette #649).
    */
   simulateProcessing: () => Promise<void>;
 }
@@ -48,7 +49,13 @@ const test = base.extend<WizardFixtures>({
 
   simulateProcessing: async ({ wizardPage }, use) => {
     await use(async () => {
+      // Reaching "analysis" now requires the analysis phase to have started
+      // (the user clicked "Lancer l'analyse"); processing alone parks on
+      // "preview" (recette #649). Drive both hooks to reach the analysis state.
       await wizardPage.evaluate(() => {
+        window.dispatchEvent(
+          new CustomEvent("__test_set_analysis_started", { detail: true }),
+        );
         window.dispatchEvent(
           new CustomEvent("__test_set_processing", { detail: true }),
         );


### PR DESCRIPTION
Les deux bugs de machine à états du flux de création (recette #649), reproduits en runtime sur la recette.

## Repro (utilisateur connecté, sur la recette)
1. Clic "Nouveau voyage" → `/trips/new?step=1` ✅
2. Charge un lien Komoot / un GPX → `/trips/new?step=3` (saute l'étape 2) ❌
3. Re-clic "Nouveau voyage" → reste `/trips/new?step=3` au lieu de l'écran "Nouveau voyage" ❌

## Corrections
- **#1 — `trip-planner.tsx`** : le stepper passait directement à `analysis` (step 3) dès `isProcessing`, sautant `preview` (step 2). On n'entre dans `analysis` que si la phase d'analyse a réellement démarré (`hasAnalysisStarted`) ; le **calcul d'itinéraire initial** se pose désormais sur `preview` (loading). → étape 2 atteinte.
- **#3 — `new/page.tsx`** : ré-entrer sur `/trips/new` nu (lien header "Nouveau voyage") laissait le store sur une étape obsolète, et l'effet store→URL réépinglait le `?step` résiduel (`?step=3`), piégeant l'utilisateur sur l'écran d'analyse/loading. Un `/trips/new` nu (sans `?step`) est traité comme une intention de nouveau départ → rembobinage sur `preparation`.

## Vérification
- `tsc --noEmit` ✅, ESLint ✅ (local).
- Validé par la CI (Playwright wizard/stepper-flow/trip-creation contre le build prod de cette branche).

Refs #649.

<!-- claude-review-start -->
## Claude Review

> Reviewed commit `85fbfdb343a6609abef689e62e5967ec539e671c`

The previous review's finding (test suite asserting old buggy behavior) has been fully addressed by the third commit. Both logic fixes are correct and the test suite is now aligned.

- **`trip-planner.tsx`**: Gating the `analysis` step behind `hasAnalysisStarted` is the right invariant — `isProcessing` alone no longer skips `preview`.
- **`new/page.tsx`**: Treating bare `/trips/new` as a fresh-start intent and resetting to `preparation` is a clean fix for the URL-pinning trap; the `currentStepRef` guard prevents any re-entrancy loop.
- **Tests**: `simulateProcessing` now dispatches `__test_set_analysis_started` before `__test_set_processing`, matching the real-world event sequence. `stepper-flow.spec.ts` assertions have been updated to expect `preview` after URL submission. No security, performance, or architecture issues.

Resolved 0 previously open threads (none existed).

### Review checklist
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**No inline comments.**
<!-- claude-review-end -->