### PR TITLE
fix(auth): refresh-token grace window — keep session alive on rapid reload (#649)

### DIFF
--- a/api/migrations/Version20260610120000.php
+++ b/api/migrations/Version20260610120000.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Adds `replaced_by_token` to `refresh_token` for the rotation grace window (#649).
+ *
+ * On rotation the old token is no longer deleted: its lifetime is cut to a short
+ * grace window and it points at its successor. A rapid reload that re-sends the
+ * pre-rotation cookie then resolves to the successor (idempotent) instead of a
+ * 401 that would destroy the session.
+ */
+final class Version20260610120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add replaced_by_token to refresh_token for rotation grace window (#649)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            ALTER TABLE refresh_token ADD replaced_by_token VARCHAR(128) DEFAULT NULL
+            SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            ALTER TABLE refresh_token DROP replaced_by_token
+            SQL);
+    }
+}

--- a/api/src/Entity/RefreshToken.php
+++ b/api/src/Entity/RefreshToken.php
@@ -21,6 +21,14 @@ class RefreshToken
     #[ORM\Column]
     private \DateTimeImmutable $createdAt;
 
+    /**
+     * Successor token set when this one is rotated. Kept (rather than deleting
+     * the row) so a reload race that re-sends the pre-rotation token resolves to
+     * its successor within the grace window instead of being rejected (#649).
+     */
+    #[ORM\Column(length: 128, nullable: true)]
+    private ?string $replacedByToken = null;
+
     public function __construct(
         #[ORM\ManyToOne(targetEntity: User::class)]
         #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
@@ -53,6 +61,21 @@ class RefreshToken
     public function getExpiresAt(): \DateTimeImmutable
     {
         return $this->expiresAt;
+    }
+
+    public function getReplacedByToken(): ?string
+    {
+        return $this->replacedByToken;
+    }
+
+    /**
+     * Rotates this token: point it at its successor and cut its life to the grace
+     * window, so a reload race that re-sends it still resolves briefly (#649).
+     */
+    public function replaceWith(string $successorToken, \DateTimeImmutable $graceExpiresAt): void
+    {
+        $this->replacedByToken = $successorToken;
+        $this->expiresAt = $graceExpiresAt;
     }
 
     public function isValid(): bool

--- a/api/src/State/Auth/AuthRefreshProcessor.php
+++ b/api/src/State/Auth/AuthRefreshProcessor.php
@@ -9,6 +9,7 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use App\ApiResource\Auth\Auth;
 use App\Entity\RefreshToken;
+use App\Entity\User;
 use App\Repository\RefreshTokenRepository;
 use App\Security\AuthCookies;
 use Doctrine\ORM\EntityManagerInterface;
@@ -29,6 +30,13 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 final readonly class AuthRefreshProcessor implements ProcessorInterface
 {
     use AuthResponseHelper;
+
+    /**
+     * Seconds a just-rotated token stays usable so a reload race (the browser
+     * re-sends the pre-rotation cookie) resolves to its successor instead of a
+     * 401. Far longer than any reload round-trip, far shorter than the TTL.
+     */
+    private const int GRACE_SECONDS = 30;
 
     public function __construct(
         private RefreshTokenRepository $refreshTokenRepository,
@@ -67,13 +75,7 @@ final readonly class AuthRefreshProcessor implements ProcessorInterface
         if (!$existing instanceof RefreshToken) {
             $this->logger->debug('Auth refresh invalid token');
 
-            $response = new JsonResponse(
-                ['error' => $this->translator->trans('auth.error.refresh_invalid', [], 'auth')],
-                Response::HTTP_UNAUTHORIZED,
-            );
-            $response->headers->clearCookie(AuthCookies::REFRESH_TOKEN, '/', null, true, true, 'strict');
-
-            return $response;
+            return $this->unauthorized();
         }
 
         $user = $existing->getUser();
@@ -83,44 +85,25 @@ final readonly class AuthRefreshProcessor implements ProcessorInterface
         if ($user->isDeleted()) {
             $this->logger->warning('Auth refresh attempted on a deleted account', ['user' => $user->getId()->toRfc4122()]);
 
-            $response = new JsonResponse(
-                ['error' => $this->translator->trans('auth.error.refresh_invalid', [], 'auth')],
-                Response::HTTP_UNAUTHORIZED,
-            );
-            $response->headers->clearCookie(AuthCookies::REFRESH_TOKEN, '/', null, true, true, 'strict');
-
-            return $response;
+            return $this->unauthorized();
         }
 
-        // Atomic expire + rotate in a single transaction to prevent TOCTOU race
-        // and ensure no token is lost if the flush fails.
-        $expiredRows = 0;
-        $newRefreshToken = null;
+        // Resolve the live successor token. A refresh token is rotated on first
+        // use but kept valid for a short grace window: a rapid reload re-sends the
+        // pre-rotation cookie before the browser applied the Set-Cookie, and that
+        // request must resolve to the successor (idempotent) rather than a 401
+        // that clears the cookie and destroys the session (recette #649).
+        $replacedBy = $existing->getReplacedByToken();
+        $live = null !== $replacedBy
+            ? $this->refreshTokenRepository->findValidByToken($replacedBy)
+            : $this->rotate($existing, $user);
 
-        $this->entityManager->wrapInTransaction(function () use ($existing, $user, &$expiredRows, &$newRefreshToken): void {
-            $expiredRows = $this->entityManager->getConnection()->executeStatement(
-                "UPDATE refresh_token SET expires_at = '1970-01-01 00:00:00' WHERE id = :id AND expires_at > NOW()",
-                ['id' => $existing->getId()->toRfc4122()],
-            );
+        if (!$live instanceof RefreshToken) {
+            // The successor itself fell out of its grace window: genuinely stale.
+            $this->logger->debug('Auth refresh successor no longer valid');
 
-            if (0 === $expiredRows) {
-                return;
-            }
-
-            $this->entityManager->remove($existing);
-            $newRefreshToken = $this->refreshTokenRepository->createForUser($user);
-        });
-
-        if (0 === $expiredRows) {
-            $this->logger->debug('Auth refresh token already consumed (race)');
-
-            return new JsonResponse(
-                ['error' => $this->translator->trans('auth.error.refresh_invalid', [], 'auth')],
-                Response::HTTP_UNAUTHORIZED,
-            );
+            return $this->unauthorized();
         }
-
-        \assert($newRefreshToken instanceof RefreshToken);
 
         $jwt = $this->jwtManager->create($user);
 
@@ -128,11 +111,70 @@ final readonly class AuthRefreshProcessor implements ProcessorInterface
 
         $responseData = ['token' => $jwt];
         if ($isCapacitor) {
-            $responseData['refresh_token'] = $newRefreshToken->getToken();
+            $responseData['refresh_token'] = $live->getToken();
         }
 
         $response = new JsonResponse($responseData);
-        $this->setRefreshTokenCookie($response, $newRefreshToken->getToken(), $newRefreshToken->getExpiresAt());
+        $this->setRefreshTokenCookie($response, $live->getToken(), $live->getExpiresAt());
+
+        return $response;
+    }
+
+    /**
+     * Rotates the token but KEEPS the old one for a short grace window pointing
+     * at its successor, instead of deleting it. A reload race that re-sends the
+     * pre-rotation token then resolves to the successor (idempotent) rather than
+     * a 401 that clears the cookie and destroys the session (recette #649).
+     */
+    private function rotate(RefreshToken $existing, User $user): ?RefreshToken
+    {
+        // Successor created in-memory only (createForUser persists, never flushes).
+        $successor = $this->refreshTokenRepository->createForUser($user);
+        $grace = new \DateTimeImmutable(\sprintf('+%d seconds', self::GRACE_SECONDS));
+        $claimed = 0;
+
+        $this->entityManager->wrapInTransaction(function () use ($existing, $successor, $grace, &$claimed): void {
+            // Atomic CAS: only the first concurrent caller flips replaced_by_token
+            // from NULL — this fences a double-rotation that would otherwise orphan
+            // a live 30-day successor (and ensures the INSERT shares the txn).
+            $claimed = $this->entityManager->getConnection()->executeStatement(
+                'UPDATE refresh_token SET replaced_by_token = :new, expires_at = :grace WHERE id = :id AND replaced_by_token IS NULL AND expires_at > NOW()',
+                [
+                    'new' => $successor->getToken(),
+                    'grace' => $grace->format('Y-m-d H:i:s'),
+                    'id' => $existing->getId()->toRfc4122(),
+                ],
+            );
+
+            if (1 === $claimed) {
+                // Won: mirror the claim onto the managed entity so the successor is
+                // flushed and the mapped property is assigned in PHP (PHPStan can't
+                // see Doctrine's hydration of replaced_by_token).
+                $existing->replaceWith($successor->getToken(), $grace);
+            } else {
+                // Lost: drop the pending successor so the flush can't INSERT it.
+                $this->entityManager->detach($successor);
+            }
+        });
+
+        if (1 === $claimed) {
+            return $successor;
+        }
+
+        // Lost the race: a concurrent request rotated first. Follow its chain.
+        $this->entityManager->refresh($existing);
+        $replacedBy = $existing->getReplacedByToken();
+
+        return null !== $replacedBy ? $this->refreshTokenRepository->findValidByToken($replacedBy) : null;
+    }
+
+    private function unauthorized(): JsonResponse
+    {
+        $response = new JsonResponse(
+            ['error' => $this->translator->trans('auth.error.refresh_invalid', [], 'auth')],
+            Response::HTTP_UNAUTHORIZED,
+        );
+        $response->headers->clearCookie(AuthCookies::REFRESH_TOKEN, '/', null, true, true, 'strict');
 
         return $response;
     }

--- a/api/tests/Functional/Auth/AuthRefreshTest.php
+++ b/api/tests/Functional/Auth/AuthRefreshTest.php
@@ -123,17 +123,45 @@ final class AuthRefreshTest extends ApiTestCase
     }
 
     #[Test]
-    public function refreshTokenCannotBeReusedAfterRotation(): void
+    public function refreshWithinGraceWindowReturnsSameSuccessor(): void
     {
+        // A rapid reload re-sends the pre-rotation token. Within the grace window
+        // it must return the SAME successor (idempotent) and keep the session,
+        // instead of the 401 that previously logged the user out (recette #649).
         $this->createUserWithRefreshToken('reuse@example.com', 'single-use-token');
 
-        // First refresh should succeed
-        $this->sendRefreshRequest('single-use-token');
+        $first = $this->sendRefreshRequest('single-use-token');
+        $this->assertResponseStatusCodeSame(200);
+        $successor = $first->toArray(false)['refresh_token'];
+
+        $second = $this->sendRefreshRequest('single-use-token');
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertSame($successor, $second->toArray(false)['refresh_token']);
+    }
+
+    #[Test]
+    public function refreshCutsRotatedTokenToGraceWindow(): void
+    {
+        // The old token is kept (so a reload race resolves to its successor) but
+        // its lifetime is cut to the grace window — it must not survive the full
+        // 30-day TTL, which would widen the replay surface.
+        $this->createUserWithRefreshToken('grace@example.com', 'rotated-token');
+
+        $this->sendRefreshRequest('rotated-token');
         $this->assertResponseStatusCodeSame(200);
 
-        // Second refresh with the same token should fail (token was rotated)
-        $this->sendRefreshRequest('single-use-token');
-        $this->assertResponseStatusCodeSame(401);
+        $em = $this->getEntityManager();
+        $em->clear();
+
+        $old = $em->getRepository(RefreshToken::class)->findOneBy(['token' => 'rotated-token']);
+
+        $this->assertNotNull($old, 'Rotated token is kept for reload-race idempotency');
+        $this->assertNotNull($old->getReplacedByToken(), 'Rotated token points at its successor');
+        $this->assertLessThan(
+            new \DateTimeImmutable('+120 seconds'),
+            $old->getExpiresAt(),
+            'Rotated token lifetime is cut to the grace window, not the full TTL',
+        );
     }
 
     #[Test]


### PR DESCRIPTION
## Contexte

Recette #649 : un **reload rapide déconnecte l'utilisateur**. C'est PR A du plan auth (challengé en /effort max). Le flash de la landing est traité séparément (PR B, server-side web-only, en attente de validation de l'approche).

## Bug (vérifié dans le code)

La rotation one-time-use **supprimait** l'ancien token (`remove($existing)`) dans `AuthRefreshProcessor`. Sur un reload rapide, le navigateur ré-émet le cookie **pré-rotation** (avant d'avoir appliqué le `Set-Cookie`) :

1. Requête 1 → rotation OK, `Set-Cookie: S1`.
2. Requête 2 (cookie encore = ancien token) → `findValidByToken → null` → **401 qui efface le cookie** → session détruite des deux côtés.

Donc un double-reload ne 401ait pas seulement : il **détruisait la session**.

## Correctif

La rotation **ne supprime plus** l'ancien token : elle réduit sa durée de vie à une **fenêtre de grâce (30s)** et pose un pointeur `replaced_by_token` vers le successeur. Une race de reload se résout alors sur le successeur de façon **idempotente** (même token, 200) au lieu de déconnecter.

- `RefreshToken.replacedByToken` (colonne nullable `VARCHAR(128)`, + migration).
- `AuthRefreshProcessor::rotate()` : `UPDATE ... SET expires_at = :grace, replaced_by_token = :new WHERE id = :id AND replaced_by_token IS NULL AND expires_at > NOW()` — le **claim atomique** continue de fencer une double-rotation concurrente (TOCTOU-safe) ; le perdant relit le successeur du gagnant.
- `findValidByToken` inchangé ; les 401 (token invalide / expiré / hors-grâce / compte supprimé) effacent toujours le cookie.

## Sécurité

- Pas de détection de réutilisation / révocation de famille dans le code aujourd'hui : la rotation ne sert qu'à borner la durée de vie. La grâce ne sacrifie donc **aucune** propriété existante.
- Surface de rejeu bornée : l'ancien token meurt après 30s (≪ TTL 30j). Test dédié verrouille cette borne.
- Les tokens en grâce sont **fauchés par la commande purge-expired-tokens existante** une fois expirés (colonne string, pas de self-FK → aucune contrainte référentielle à la suppression).

## Tests

- `refreshWithinGraceWindowReturnsSameSuccessor` : 2 refresh rapides du même token → **200 + même successeur** (la non-régression du bug).
- `refreshCutsRotatedTokenToGraceWindow` : après rotation, l'ancien token est conservé, pointe vers son successeur, et sa durée de vie est ramenée à la grâce (pas 30j).
- Cas inchangés conservés : token invalide/expiré/manquant → 401, compte supprimé → 401 + clear, format JWT, successeur ≠ ancien.

Vérification PHP via CI (PHPUnit avec Postgres réel, PHPStan L9, Rector, CS-Fixer) — `vendor/` non installé dans le worktree. `php -l` OK localement sur les 5 fichiers.

Refs #649.

<!-- claude-review-start -->
## Claude Review

Both previously flagged issues have been fully addressed in this push. The raw-SQL CAS (`UPDATE … WHERE id = :id AND replaced_by_token IS NULL AND expires_at > NOW()`) is now correctly in place inside `wrapInTransaction`, providing genuine TOCTOU safety. The grace-bound assertion was tightened from `+1 hour` to `+120 seconds`, locking the 30 s security property against silent regressions. The implementation is correct and the logic holds under all relevant races.

**Resolved threads:** 2 (TOCTOU/CAS fix addressed; grace-bound test tightened — both now closed).

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Reviewed commit:** `acaaba0872da2acd28cee23090e0ebe64a637545`

**Inline comments:** None.
<!-- claude-review-end -->