### PR TITLE
fix(recompute): re-run full pipeline when recomputing during analysis (#649 bug 3)

### DIFF
--- a/api/src/State/TripBatchRecomputeProcessor.php
+++ b/api/src/State/TripBatchRecomputeProcessor.php
@@ -10,9 +10,11 @@ use ApiPlatform\State\ProcessorInterface;
 use App\ApiResource\Trip;
 use App\ApiResource\TripBatchRecomputeRequest;
 use App\ApiResource\TripRequest;
+use App\ComputationTracker\ComputationTrackerInterface;
 use App\ComputationTracker\TripGenerationTrackerInterface;
 use App\Repository\TripRequestRepositoryInterface;
 use App\Service\ComputationDependencyResolver;
+use App\Service\TripAnalysisDispatcher;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -20,6 +22,10 @@ use Symfony\Component\Messenger\MessageBusInterface;
 /**
  * Processes the batch recompute endpoint: applies N pending modifications in a
  * single request, dispatching only the minimal set of handlers needed.
+ *
+ * When the initial analysis is still in flight, falls back to the full enrichment
+ * pipeline (via {@see TripAnalysisDispatcher}) instead of the minimal resolver to
+ * prevent computations from being stranded by the generation bump — see #649.
  *
  * This avoids N sequential recomputations when the user accumulates several
  * modifications before confirming them. The dependency resolution is delegated
@@ -34,6 +40,8 @@ final readonly class TripBatchRecomputeProcessor implements ProcessorInterface
         private TripGenerationTrackerInterface $generationTracker,
         private ComputationDependencyResolver $dependencyResolver,
         private MessageBusInterface $messageBus,
+        private ComputationTrackerInterface $computationTracker,
+        private TripAnalysisDispatcher $analysisDispatcher,
     ) {
     }
 
@@ -67,6 +75,21 @@ final readonly class TripBatchRecomputeProcessor implements ProcessorInterface
 
         // Increment generation to invalidate in-flight workers
         $generation = $this->generationTracker->increment($tripId);
+
+        // If the initial analysis has not fully settled yet, a minimal,
+        // dependency-resolved recompute only re-dispatches a subset while the
+        // generation bump discards every in-flight computation it does NOT cover.
+        // Those stay "pending" forever: the enrichment gate never settles (no
+        // terminal trip_ready/trip_complete, so the frontend loader spins) and
+        // their results are lost — recette #649, adjusting the rider profile
+        // mid-analysis. Re-run the full enrichment pipeline for the new
+        // generation instead so nothing is stranded and the gate can settle.
+        $progress = $this->computationTracker->getProgress($tripId);
+        if ($progress['total'] > 0 && $progress['completed'] + $progress['failed'] < $progress['total']) {
+            $this->analysisDispatcher->dispatch($tripId, $request, $generation);
+
+            return new Trip(id: $tripId);
+        }
 
         $allStageIndices = array_keys($stages);
         $hasDates = $request->startDate instanceof \DateTimeImmutable;

--- a/api/tests/Unit/State/TripBatchRecomputeProcessorTest.php
+++ b/api/tests/Unit/State/TripBatchRecomputeProcessorTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\State;
+
+use ApiPlatform\Metadata\Post;
+use App\ApiResource\Model\Coordinate;
+use App\ApiResource\Stage;
+use App\ApiResource\TripBatchRecomputeRequest;
+use App\ApiResource\TripModification;
+use App\ApiResource\TripRequest;
+use App\ComputationTracker\ComputationTrackerInterface;
+use App\ComputationTracker\TripGenerationTrackerInterface;
+use App\Message\RecalculateStages;
+use App\Message\ScanAllOsmData;
+use App\Repository\TripRequestRepositoryInterface;
+use App\Service\ComputationDependencyResolver;
+use App\Service\TripAnalysisDispatcher;
+use App\State\TripBatchRecomputeProcessor;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final class TripBatchRecomputeProcessorTest extends TestCase
+{
+    /**
+     * Runs a `pacing` recompute with the given tracker progress and returns the
+     * dispatched message class names.
+     *
+     * @param array{completed: int, failed: int, total: int} $progress
+     *
+     * @return list<class-string>
+     */
+    private function recomputeWithProgress(array $progress): array
+    {
+        $coord = new Coordinate(lat: 45.0, lon: 5.0);
+        $stages = [
+            new Stage(tripId: 't', dayNumber: 1, distance: 80.0, elevation: 500.0, startPoint: $coord, endPoint: $coord),
+            new Stage(tripId: 't', dayNumber: 2, distance: 90.0, elevation: 600.0, startPoint: $coord, endPoint: $coord),
+        ];
+
+        $dispatched = [];
+        $messageBus = $this->createStub(MessageBusInterface::class);
+        $messageBus->method('dispatch')->willReturnCallback(
+            static function (object $message) use (&$dispatched): Envelope {
+                $dispatched[] = $message::class;
+
+                return new Envelope($message);
+            },
+        );
+
+        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
+        $tripStateManager->method('getStages')->willReturn($stages);
+        $tripStateManager->method('getRequest')->willReturn(new TripRequest());
+
+        $generationTracker = $this->createStub(TripGenerationTrackerInterface::class);
+        $generationTracker->method('increment')->willReturn(2);
+
+        $computationTracker = $this->createStub(ComputationTrackerInterface::class);
+        $computationTracker->method('getProgress')->willReturn($progress);
+
+        $processor = new TripBatchRecomputeProcessor(
+            $tripStateManager,
+            $generationTracker,
+            new ComputationDependencyResolver(),
+            $messageBus,
+            $computationTracker,
+            new TripAnalysisDispatcher($messageBus),
+        );
+
+        $request = new TripBatchRecomputeRequest([
+            new TripModification(stageIndex: null, type: 'pacing'),
+        ]);
+
+        $processor->process($request, new Post(), ['id' => 't']);
+
+        return $dispatched;
+    }
+
+    #[Test]
+    public function inFlightAnalysisReRunsTheFullPipeline(): void
+    {
+        // Some computations are still pending: a minimal recompute would strand
+        // the in-flight ones (the generation bump discards them), so the full
+        // enrichment pipeline must be re-dispatched instead (recette #649).
+        $dispatched = $this->recomputeWithProgress(['completed' => 7, 'failed' => 0, 'total' => 16]);
+
+        self::assertContains(ScanAllOsmData::class, $dispatched, 'Full pipeline must run while the analysis is in flight.');
+        self::assertNotContains(RecalculateStages::class, $dispatched, 'Minimal resolver path must be skipped while in flight.');
+    }
+
+    #[Test]
+    public function settledAnalysisUsesTheMinimalResolver(): void
+    {
+        // Every computation has settled: the minimal, dependency-resolved
+        // recompute is enough (and avoids re-running the whole pipeline).
+        $dispatched = $this->recomputeWithProgress(['completed' => 16, 'failed' => 0, 'total' => 16]);
+
+        self::assertContains(RecalculateStages::class, $dispatched, 'Settled trip uses the minimal resolver (RecalculateStages for pacing).');
+        self::assertNotContains(ScanAllOsmData::class, $dispatched, 'Full pipeline must not run for a settled trip.');
+    }
+
+    #[Test]
+    public function uninitializedTrackerFallsBackToMinimalResolver(): void
+    {
+        // getProgress() returns total=0 before initializeComputations() is called —
+        // the guard must treat this the same as "settled" and fall through to the
+        // minimal resolver, not the full pipeline.
+        $dispatched = $this->recomputeWithProgress(['completed' => 0, 'failed' => 0, 'total' => 0]);
+
+        self::assertContains(RecalculateStages::class, $dispatched, 'Uninitialized tracker must use the minimal resolver.');
+        self::assertNotContains(ScanAllOsmData::class, $dispatched, 'Full pipeline must not run when total=0.');
+    }
+}

--- a/pwa/src/hooks/use-mercure.ts
+++ b/pwa/src/hooks/use-mercure.ts
@@ -576,6 +576,18 @@ function dispatchEvent(event: MercureEvent): void {
       // Remove this stage from the recomputing set — the shimmer skeleton
       // can now be replaced by the real card.
       store.finishStageRecomputation(event.data.stageIndex);
+
+      // A batch/inline recompute (Mode 2) re-publishes per-stage `stage_updated`
+      // events but never the terminal `trip_complete`/`trip_ready`: the enrichment
+      // gate only fires once EVERY initialised computation has settled, and the
+      // computations a trip never runs (e.g. weather/calendar without dates) stay
+      // "pending" forever. So once the last recomputing stage settles, clear the
+      // global processing overlay here — otherwise it spins forever (recette #649,
+      // "profil expert"). Tied to `recomputingStages` so the initial full analysis
+      // (which never populates that set) keeps relying on `trip_ready`.
+      if (useTripStore.getState().recomputingStages.size === 0) {
+        useUiStore.getState().setProcessing(false);
+      }
       // Labels may have been wiped if endpoints moved — refresh if needed.
       const updated = useTripStore.getState().stages[event.data.stageIndex];
       if (


### PR DESCRIPTION
## Contexte

Recette #649, bug 3 : ajuster le profil rider (ou toute modification) **pendant que l'analyse initiale tourne encore** laisse le loader figé indéfiniment.

## Cause racine (diagnostiquée sur iso-prod, pas spéculée)

Le recompute incrémente la génération du trip pour invalider les workers en vol. Mais le recompute minimal (résolu par dépendances) ne re-dispatche qu'un **sous-ensemble** → toute computation encore en vol qu'il ne couvre pas est **discardée par le garde de staleness (`isStale`) et reste `pending`**. Le gate terminal (`AbstractTripMessageHandler`) n'émet `trip_complete`/`trip_ready` que lorsque **toutes** les computations initialisées sont settled (`completed + failed === total`) → il ne fire jamais → l'overlay de chargement (vidé uniquement par cet event terminal) reste affiché, et les enrichissements stranded sont **perdus**.

**Preuve (stack iso-prod locale) :**

| Scénario | `computation_status` final | event terminal |
|---|---|---|
| recompute APRÈS analyse settled | 16 done | ✅ trip_complete |
| recompute PENDANT l'analyse (avant fix) | 7 done / **9 pending** | ❌ jamais |
| recompute PENDANT l'analyse (après fix) | **16 done** | **✅** |

## Fix (complet : backend + frontend)

**Backend** — `TripBatchRecomputeProcessor` : si le tracker montre que l'analyse n'est pas entièrement settled, le recompute relance le **pipeline d'enrichissement complet** (`TripAnalysisDispatcher`) pour la nouvelle génération au lieu du set minimal → rien n'est stranded et le gate peut atteindre `allSettled`. Les trips settled conservent le recompute minimal (optimisation préservée).

**Frontend** — `use-mercure.ts` : vide l'overlay global dès que la dernière étape en recompute se settle (`recomputingStages` vidé via les events `stage_updated`) au lieu d'attendre l'event terminal → un recompute par-étape léger ne bloque plus l'UI pendant l'enrichissement lent. L'analyse initiale (qui ne peuple jamais `recomputingStages`) continue de s'appuyer sur `trip_ready`.

## Tests
- `TripBatchRecomputeProcessorTest` : in-flight → pipeline complet (`ScanAllOsmData`, pas de `RecalculateStages`) ; settled → resolver minimal (`RecalculateStages`, pas de pipeline complet).
- Vérifié sur iso-prod : recompute mid-analyse → **202 + 16 done + terminal fired** (était : loader figé + 9 pending stranded).

Refs #649.

<!-- claude-review-start -->
## Claude Review

**Commit reviewed:** `86bf25a440a00e0b68a7ae9e412323564a3cd6f9`

### Summary

All three findings from the previous review have been addressed. The implementation is correct: the backend guard handles all edge cases (in-flight, settled, `total=0`, all-failed), the frontend overlay clearing is tied to `recomputingStages` so the initial analysis is unaffected, and `setAccommodationScanning` is correctly omitted from the new block. One informational note: the `stage_updated` path that clears the overlay when `recomputingStages` empties has no dedicated Playwright assertion — the existing `batch-mode.spec.ts` tests shimmer/card visibility but does not assert that the global processing overlay is cleared by this path. Not a blocker given the complexity of simulating the race condition in E2E.

### Resolved threads

Resolved 3 previously open bot-authored threads that were addressed:
- Docblock updated to reflect the in-flight fallback behaviour
- `setAccommodationScanning(false)` correctly absent from the new `recomputingStages === 0` block
- `uninitializedTrackerFallsBackToMinimalResolver` test added for `total=0` edge case

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Inline comments

No inline comments.
<!-- claude-review-end -->