### PR TITLE
fix(stages): serve the gpx/fit stage download on a dedicated /export sub-route (#649)

### DIFF
--- a/api/src/ApiResource/Stage.php
+++ b/api/src/ApiResource/Stage.php
@@ -32,7 +32,12 @@ use App\State\StageUpdateProcessor;
     shortName: 'Stage',
     operations: [
         new Get(
-            uriTemplate: '/trips/{tripId}/stages/{index}{._format}',
+            // Dedicated export sub-route: the canonical '/trips/{tripId}/stages/{index}'
+            // path is the StageResponse NotExposed IRI (json-ld). Sharing it made the
+            // NotExposedAction controller shadow this gpx/fit download, so the
+            // authenticated download 404'd with "This route does not aim to be called"
+            // (recette #649). A distinct path avoids the collision.
+            uriTemplate: '/trips/{tripId}/stages/{index}/export{._format}',
             outputFormats: [
                 'gpx' => ['application/gpx+xml'],
                 'fit' => ['application/vnd.ant.fit'],

--- a/pwa/src/lib/api/client.ts
+++ b/pwa/src/lib/api/client.ts
@@ -730,7 +730,7 @@ export async function downloadStageFile(
   dayNumber: number,
 ): Promise<void> {
   const res = await apiFetch(
-    `${API_URL}/trips/${tripId}/stages/${stageIndex}.${format}`,
+    `${API_URL}/trips/${tripId}/stages/${stageIndex}/export.${format}`,
   );
   if (!res.ok) throw new Error(`Download failed with status ${res.status}`);
   const blob = await res.blob();

--- a/pwa/tests/fixtures/api-mocks.ts
+++ b/pwa/tests/fixtures/api-mocks.ts
@@ -222,8 +222,8 @@ export async function mockAllApis(
     });
   });
 
-  // GET /trips/{id}/stages/{index}.gpx — serve mock GPX
-  await page.route("**/trips/*/stages/*.gpx", (route) =>
+  // GET /trips/{id}/stages/{index}/export.gpx — serve mock GPX
+  await page.route("**/trips/*/stages/*/export.gpx", (route) =>
     route.fulfill({
       status: 200,
       contentType: "application/gpx+xml",

--- a/pwa/tests/mocked/fit-download.spec.ts
+++ b/pwa/tests/mocked/fit-download.spec.ts
@@ -38,7 +38,7 @@ test.describe("FIT download", () => {
 
     // Track FIT API requests
     const fitRequests: string[] = [];
-    await mockedPage.route("**/trips/*/stages/*.fit", (route) => {
+    await mockedPage.route("**/trips/*/stages/*/export.fit", (route) => {
       fitRequests.push(route.request().url());
       return route.fulfill({
         status: 200,
@@ -57,7 +57,7 @@ test.describe("FIT download", () => {
     await expect
       .poll(() => fitRequests.length, { timeout: 5000 })
       .toBeGreaterThan(0);
-    expect(fitRequests[0]).toContain("/stages/0.fit");
+    expect(fitRequests[0]).toContain("/stages/0/export.fit");
   });
 
   test("global FIT download button is visible after stages computed", async ({
@@ -91,7 +91,7 @@ test.describe("FIT download", () => {
       tripCompleteEvent(),
     ]);
 
-    // Track whole-trip FIT API requests (not the per-stage `/stages/*.fit`).
+    // Track whole-trip FIT API requests (not the per-stage `/stages/*/export.fit`).
     const fitRequests: string[] = [];
     await mockedPage.route("**/trips/*.fit", (route) => {
       fitRequests.push(route.request().url());

--- a/pwa/tests/mocked/gpx-download.spec.ts
+++ b/pwa/tests/mocked/gpx-download.spec.ts
@@ -38,7 +38,7 @@ test.describe("GPX download", () => {
 
     // Track GPX API requests
     const gpxRequests: string[] = [];
-    await mockedPage.route("**/trips/*/stages/*.gpx", (route) => {
+    await mockedPage.route("**/trips/*/stages/*/export.gpx", (route) => {
       gpxRequests.push(route.request().url());
       return route.fulfill({
         status: 200,
@@ -57,7 +57,7 @@ test.describe("GPX download", () => {
     await expect
       .poll(() => gpxRequests.length, { timeout: 5000 })
       .toBeGreaterThan(0);
-    expect(gpxRequests[0]).toContain("/stages/0.gpx");
+    expect(gpxRequests[0]).toContain("/stages/0/export.gpx");
   });
 
   test("global GPX download button is visible after stages computed", async ({

--- a/pwa/tests/recette/features/export.en.feature
+++ b/pwa/tests/recette/features/export.en.feature
@@ -13,7 +13,7 @@ Feature: GPX and FIT export
   @desktop @critical
   Scenario: Stage GPX download triggers API call
     When I click "Download GPX" for stage 1
-    Then a GET request to /trips/*/stages/0.gpx is sent
+    Then a GET request to /trips/*/stages/0/export.gpx is sent
 
   @desktop @critical
   Scenario: Global GPX download button visible after stages computed
@@ -38,7 +38,7 @@ Feature: GPX and FIT export
   @desktop @critical
   Scenario: Stage FIT download
     When I click "Download FIT" for stage 1
-    Then a GET request to /trips/*/stages/0.fit is sent
+    Then a GET request to /trips/*/stages/0/export.fit is sent
 
   @desktop
   Scenario: FIT button disabled during computation

--- a/pwa/tests/recette/features/export.fr.feature
+++ b/pwa/tests/recette/features/export.fr.feature
@@ -14,7 +14,7 @@ Fonctionnalité: Export GPX et FIT
   @desktop @critique
   Scénario: Téléchargement GPX d'une étape déclenche l'appel API
     Quand je clique sur "Télécharger le GPX" de l'étape 1
-    Alors une requête GET vers /trips/*/stages/0.gpx est envoyée
+    Alors une requête GET vers /trips/*/stages/0/export.gpx est envoyée
 
   @desktop @critique
   Scénario: Bouton GPX global visible après le calcul des étapes
@@ -39,7 +39,7 @@ Fonctionnalité: Export GPX et FIT
   @desktop @critique
   Scénario: Téléchargement FIT d'une étape
     Quand je clique sur "Télécharger le FIT" de l'étape 1
-    Alors une requête GET vers /trips/*/stages/0.fit est envoyée
+    Alors une requête GET vers /trips/*/stages/0/export.fit est envoyée
 
   @desktop
   Scénario: Bouton FIT désactivé pendant le calcul

--- a/pwa/tests/recette/steps/export.steps.ts
+++ b/pwa/tests/recette/steps/export.steps.ts
@@ -158,13 +158,13 @@ Then(
 );
 
 Then(
-  /^une requête GET vers \/trips\/\*\/stages\/0\.gpx est envoyée$/,
+  /^une requête GET vers \/trips\/\*\/stages\/0\/export\.gpx est envoyée$/,
   async () => {
     const gpxRequests = getTrackedStageGpxRequests();
     await expect
       .poll(() => gpxRequests.length, { timeout: 5000 })
       .toBeGreaterThan(0);
-    expect(gpxRequests[0]).toContain("/stages/0.gpx");
+    expect(gpxRequests[0]).toContain("/stages/0/export.gpx");
   },
 );
 
@@ -200,13 +200,13 @@ Then("un message d'erreur s'affiche", async ({ mockedPage }) => {
 });
 
 Then(
-  /^une requête GET vers \/trips\/\*\/stages\/0\.fit est envoyée$/,
+  /^une requête GET vers \/trips\/\*\/stages\/0\/export\.fit est envoyée$/,
   async () => {
     const fitRequests = getTrackedStageFitRequests();
     await expect
       .poll(() => fitRequests.length, { timeout: 5000 })
       .toBeGreaterThan(0);
-    expect(fitRequests[0]).toContain("/stages/0.fit");
+    expect(fitRequests[0]).toContain("/stages/0/export.fit");
   },
 );
 
@@ -248,13 +248,16 @@ Then(
   },
 );
 
-Then(/^a GET request to \/trips\/\*\/stages\/0\.gpx is sent$/, async () => {
-  const gpxRequests = getTrackedStageGpxRequests();
-  await expect
-    .poll(() => gpxRequests.length, { timeout: 5000 })
-    .toBeGreaterThan(0);
-  expect(gpxRequests[0]).toContain("/stages/0.gpx");
-});
+Then(
+  /^a GET request to \/trips\/\*\/stages\/0\/export\.gpx is sent$/,
+  async () => {
+    const gpxRequests = getTrackedStageGpxRequests();
+    await expect
+      .poll(() => gpxRequests.length, { timeout: 5000 })
+      .toBeGreaterThan(0);
+    expect(gpxRequests[0]).toContain("/stages/0/export.gpx");
+  },
+);
 
 Then(
   'the "Télécharger le GPX complet" button is visible and enabled',
@@ -289,13 +292,16 @@ Then("an error message is displayed", async ({ mockedPage }) => {
   ).toBeVisible({ timeout: 5000 });
 });
 
-Then(/^a GET request to \/trips\/\*\/stages\/0\.fit is sent$/, async () => {
-  const fitRequests = getTrackedStageFitRequests();
-  await expect
-    .poll(() => fitRequests.length, { timeout: 5000 })
-    .toBeGreaterThan(0);
-  expect(fitRequests[0]).toContain("/stages/0.fit");
-});
+Then(
+  /^a GET request to \/trips\/\*\/stages\/0\/export\.fit is sent$/,
+  async () => {
+    const fitRequests = getTrackedStageFitRequests();
+    await expect
+      .poll(() => fitRequests.length, { timeout: 5000 })
+      .toBeGreaterThan(0);
+    expect(fitRequests[0]).toContain("/stages/0/export.fit");
+  },
+);
 
 Then(
   "the FIT button for stage {int} is disabled",

--- a/pwa/tests/recette/support/export-download-tracker.ts
+++ b/pwa/tests/recette/support/export-download-tracker.ts
@@ -3,9 +3,9 @@ import type { Page, Route } from "@playwright/test";
 const GPX_BODY =
   '<?xml version="1.0"?><gpx><trk><trkseg><trkpt lat="44.7" lon="4.5"><ele>280</ele></trkpt></trkseg></trk></gpx>';
 
-const STAGE_GPX_PATTERN = "**/trips/*/stages/*.gpx";
+const STAGE_GPX_PATTERN = "**/trips/*/stages/*/export.gpx";
 const TRIP_GPX_PATTERN = "**/trips/*.gpx";
-const STAGE_FIT_PATTERN = "**/trips/*/stages/*.fit";
+const STAGE_FIT_PATTERN = "**/trips/*/stages/*/export.fit";
 
 const capturedRequests = {
   stageGpx: [] as string[],
@@ -74,7 +74,7 @@ export async function trackStageExportDownload(
 ): Promise<void> {
   resetRequests("stageExport");
   await page.route(
-    `**/trips/*/stages/*.${extension}`,
+    `**/trips/*/stages/*/export.${extension}`,
     (route) => {
       capturedRequests.stageExport.push(route.request().url());
       return route.fulfill({


### PR DESCRIPTION
## Contexte

Recette #649 : le téléchargement GPX/FIT d'une étape **échoue quand l'utilisateur est connecté** (`This route does not aim to be called`), alors qu'il **fonctionne en vue partagée**.

## Cause racine (diagnostiquée sur iso-prod)

Le DTO de sortie `StageResponse` déclare un `#[NotExposed(shortName: 'Stage', uriTemplate: '/trips/{tripId}/stages/{index}{._format}')]` — il fournit le `@id`/`@context`/`@type` que les réponses des mutations doivent porter (`stage-schema.json` les **exige** : `@id` pattern `^/trips/.+/stages/\d+$`). Or c'est **exactement la même route** que le `Get` gpx/fit de `Stage`. Le contrôleur `NotExposedAction` (404) **shadowe** donc le vrai download. La vue partagée n'a pas la collision (préfixe distinct `/s/{shortCode}/...`).

## Fix

Déplacer le download gpx/fit vers `/trips/{tripId}/stages/{index}/export{._format}` :
- la route canonique reste l'IRI `StageResponse` (les mutations conservent `@id`/`@type`/`@context` → `stage-schema.json` passe, `StageCreateTest`/`StageUpdateTest` inchangés) ;
- le download n'entre plus en collision.

Front : `downloadStageFile` (fetch brut) + les specs `gpx-download`/`fit-download` ciblent la nouvelle URL. Le download partagé (`/s/{shortCode}/...`, sans collision) est inchangé.

## Vérification (stack iso-prod locale)

| Endpoint | Avant | Après |
|---|---|---|
| `GET .../stages/0/export.gpx` (auth) | — | **200** (24 KB GPX) |
| `GET .../stages/0/export.fit` (auth) | — | **200** (FIT) |
| `GET .../stages/0.gpx` (ancienne) | 404 (shadow) | 404 (route IRI NotExposed) |
| `POST .../stages` (mutation) | 202 | **202** + `@id`/`@type`/`@context` intacts |

Note : `downloadStageFile` utilise un fetch brut (pas openapi-fetch typé) → pas de dépendance typegen ; le `schema.d.ts` a un drift préexistant (hors scope de cette PR).

Refs #649.

<!-- claude-review-start -->
## Claude Review

**Reviewed commit:** 8fad05eed3b9022ba187177efb2c9cd4faf8b1e1  
**Findings:** 0 (no critical, no warnings)

### Summary

Surgical, well-contained fix. Moving the export endpoint to `/trips/{tripId}/stages/{index}/export{._format}` cleanly resolves the `NotExposedAction` shadow without touching the `StageResponse` canonical IRI. The frontend client, all mocked E2E specs, the BDD step definitions (EN + FR), and the download tracker patterns are updated atomically. A grep confirms no old `stages/*.gpx` or `stages/*.fit` URL patterns remain in the codebase.

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Inline comments

No inline comments.
<!-- claude-review-end -->