### PR TITLE
feat(db): socle PostGIS pour l'index de référence local-first (ADR-040)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,11 @@ jobs:
       options: --user root
     services:
       database:
-        image: postgres:18-alpine
+        # PostGIS image: Foundry resets the test DB in "migrate" mode, so the
+        # CREATE EXTENSION postgis migration (ADR-040) runs here too — the test
+        # DB engine must match the app's PostGIS-enabled Postgres. The init
+        # script also enables postgis on POSTGRES_DB and template1.
+        image: postgis/postgis:18-3.6-alpine
         env:
           POSTGRES_USER: app
           POSTGRES_PASSWORD: "!ChangeMe!"

--- a/api/config/packages/doctrine.php
+++ b/api/config/packages/doctrine.php
@@ -18,6 +18,11 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 'default' => [
                     'url' => '%env(resolve:DATABASE_URL)%',
                     'profiling_collect_backtrace' => '%kernel.debug%',
+                    // PostGIS creates the spatial_ref_sys table in the public schema.
+                    // Exclude it from the schema tool so doctrine:migrations:diff and
+                    // schema:validate don't emit a DROP for it. The Tier-1 osm2pgsql
+                    // tables live in their own schema, also outside Doctrine (ADR-040).
+                    'schema_filter' => '~^(?!spatial_ref_sys)~',
                     'mapping_types' => [
                         'jsonb' => 'jsonb',
                         '_text' => 'text[]',

--- a/api/migrations/Version20260611090000.php
+++ b/api/migrations/Version20260611090000.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Enables the PostGIS extension for the local-first Tier-1 reference index (ADR-040).
+ *
+ * The reference dataset (POI, accommodations, water points, admin boundaries,
+ * cycle routes) is imported into PostgreSQL/PostGIS by the provisioner and read
+ * by the API via spatial corridor queries (ST_DWithin), replacing the runtime
+ * Overpass dependency. This migration only enables the extension; the spatial
+ * tables themselves are created by the osm2pgsql flex import in a dedicated
+ * schema, outside Doctrine's managed metadata.
+ */
+final class Version20260611090000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Enable the PostGIS extension for the local-first spatial reference index';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE EXTENSION IF NOT EXISTS postgis');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // The postgis Docker image enables postgis_topology on a fresh volume; it
+        // depends on postgis, so drop it first to avoid a dependency error.
+        $this->addSql('DROP EXTENSION IF EXISTS postgis_topology');
+        $this->addSql('DROP EXTENSION IF EXISTS postgis');
+    }
+}

--- a/compose.yaml
+++ b/compose.yaml
@@ -388,7 +388,12 @@ services:
       start_period: 3600s
 
   database:
-    image: postgres:18-alpine
+    # PostGIS-enabled Postgres. The local-first Tier-1 reference index
+    # (POI/accommodations/water/admin/cycle) is imported by the provisioner and
+    # read via spatial corridor queries (ST_DWithin), replacing the runtime
+    # Overpass dependency. The Alpine variant keeps the small footprint of the
+    # former postgres:18-alpine base (same PG18 binaries + data layout). ADR-040.
+    image: postgis/postgis:18-3.6-alpine
     restart: unless-stopped
     # Modest tuning for the beta profile (#566): max_connections covers php +
     # 2 async workers + 1 llm worker + provisioner with headroom; shared_buffers

--- a/docs/adr/adr-040-local-first-reference-data-postgis.md
+++ b/docs/adr/adr-040-local-first-reference-data-postgis.md
@@ -1,0 +1,99 @@
+# ADR-040: Local-First Reference Data — Single PostgreSQL/PostGIS Source
+
+- **Status:** Proposed — flips to Accepted as the implementing PRs land (socle PostGIS first; provisioner import, enrichment, coverage/monitoring, and the API local-read cut-over follow)
+- **Date:** 2026-06-11
+- **Depends on:** ADR-022 (Persistent storage), ADR-033 (OSM data refresh), ADR-036 (Manual OSM refresh), ADR-039 (Beta right-sizing)
+- **Reformulates:** ADR-005 (external-API caching), ADR-013 (accommodation discovery), ADR-025 (removal of self-hosted Overpass), ADR-026 (multi-source integration)
+- **Does not affect:** ADR-004 (GPX parsing/decimation) — see "Relationship to ADR-004" below
+
+## Context and Problem Statement
+
+The closed-beta acceptance test ([#649](https://github.com/vincentchalamon/bike-trip-planner/issues/649)) showed that the product pillars that depend on map data are not reliable: POI discovery (food, water, shops), accommodation recommendation, and the alert engine that reads them. The root cause is structural, not a set of isolated bugs: the API depends on **fragile third-party services at request time**.
+
+- **Public Overpass (`overpass-api.de`)** has no retry/failover and is rate-limited. `OsmScanner` catches every failure and returns an **empty result** (`api/src/Scanner/OsmScanner.php`). That "empty-on-error" behaviour makes "the area genuinely has no data" indistinguishable from "the query failed", which directly produces:
+  - the **`alert.lunch.nudge` false positive** (`ScanPoisHandler`): an Overpass hiccup yields zero POIs, so `hasResupplyPoi()` is false and the nudge fires on a stage that actually has plenty of food;
+  - **missing accommodations / POIs**, because a transient failure silently drops a whole scan.
+- **Water detection** is a proxy: it queries cemeteries (legally required to have a water tap in France) instead of real drinking-water points, so the data is both approximate and tied to the same fragile Overpass path.
+- The accommodation path additionally stacks **runtime scraping** for prices, **DataTourisme** (rate-limited), and **Wikidata** (slow) — each a request-time third-party dependency that can degrade or block enrichment.
+
+ADR-025 removed the self-hosted Overpass to save RAM and accepted the public API plus a 24 h Redis cache as mitigation. The recette shows that mitigation is insufficient for a product whose core value is "where can I eat, sleep and refill water on this route".
+
+The application is **not yet launched**. That makes this the right moment to fix the foundation rather than patch symptoms.
+
+## Decision
+
+Adopt a **local-first architecture with a single PostgreSQL/PostGIS source of truth** for reference geodata. An asynchronous **provisioner aggregates** reference data into PostgreSQL/PostGIS; the **API reads only the local database**, autonomously. Third-party fragility is concentrated in the provisioner (best-effort) and never blocks a user request — at worst the data is dated, never absent-because-of-an-error.
+
+### Three-tier data model
+
+| Tier | Nature | Sources | Location | Runtime third-party dependency |
+|------|--------|---------|----------|--------------------------------|
+| **1. Reference** | Static, geo-bounded | OSM (POI, accommodations, water, cycle networks, admin boundaries), DataTourisme, Wikidata | **PostgreSQL/PostGIS** (provisioner = async aggregator) | None |
+| **2. Local compute** | Computation | Valhalla (routing), Ollama (LLM) | Local services | None |
+| **3. Live resilient** | Date/user input | Weather (open-meteo), route fetch (Komoot/Strava/RWGPS/GPX) | On-demand + cache | Yes, by nature |
+
+Beta perimeter for Tier 1: **France + Belgium + Netherlands + Luxembourg**. Adding a zone later is "add a PBF + re-provision", with no application code change.
+
+### Tier 1 — provisioner aggregator → PostGIS
+
+The existing `provisioner/` (already a Geofabrik PBF downloader/merger for Valhalla) is extended to also populate PostGIS:
+
+- **Download** Geofabrik PBF: `france` (already), plus `belgium`, `netherlands`, `luxembourg`.
+- **Extract** with `osmium tags-filter` (multi-GB PBF → tens of MB of relevant features).
+- **Import** with `osm2pgsql` (flex/Lua style) into spatial tables — `pois`, `accommodations`, `water_points`, `admin_boundaries`, `cycle_routes` — with useful columns in clear (`name`, `category`, `opening_hours`, `fee`/`charge`, `website`, `stars`, `capacity`, `wikidata`, …) plus the raw tags as `JSONB`. **GIST** indexes; centroids for ways/relations.
+- **Enrich** (in the provisioner only): **Wikidata** (batched SPARQL over the bounded set of Q-IDs) and **DataTourisme** via its dump/feed (not the runtime API).
+- **Accommodation pricing (beta, no scraping):** `price = structured open data (DataTourisme priceSpecification, OSM charge/fee) ?? heuristic (type/region/stars)`. A one-shot price scraper is deferred beyond the beta.
+- **Atomic versioned swap:** import into a staging schema, then switch in a single transaction; the previous dataset is kept until the new one is complete. Idempotent, never a partial state.
+- **Coverage polygon:** union of the provisioned countries' `admin_boundaries` (admin_level = 2).
+- **Monitoring:** "last successful refresh" + per-source counters surfaced in `/health`; cron cadence (OSM weekly, DataTourisme daily, Wikidata monthly).
+
+### API — local read only
+
+- New `PoiRepository` / `AccommodationRepository` (Doctrine DBAL + PostGIS) behind the existing `OsmScanner` / `OsmOverpassQueryBuilder` seams.
+- `ScanPoisHandler` / `ScanAccommodationsHandler` query **`ST_DWithin` along the decoded route corridor**, not only around the stage endpoint — this fixes the "radius too short / endpoint-only" gaps. Distribution stays via `GeometryBasedDistributor`.
+- **Snapshot preserved:** POI/accommodations remain frozen in `Stage` (JSONB) at analysis/recompute time (trips stay shareable and stable), but **sourced from the local index** instead of Overpass. The index is the source; the `Stage` is the per-trip frozen result.
+- The **in-ride assistant** is repointed onto the PostGIS repository (it was a 5-minute Overpass cache).
+- **Runtime Overpass dependency removed.** No more "empty-on-error", so `alert.lunch.nudge` can no longer be a false positive. Water uses the **real** `water_points` (end of the cemetery proxy).
+- **Out of zone:** `ST_Covers(coverage, trip)`. Outside the coverage polygon → a **non-blocking notice** in the preview **and** the edit actions that need Valhalla (split/merge/reroute) are **disabled** (no routing tiles out of zone) → display-only trip.
+
+### Relationship to ADR-004
+
+[ADR-004](adr-004-spatial-engineering-gpx-parsing-and-data-decimation.md) rejected PostGIS for **GPX parsing and decimation** — a per-request, transient workload where spinning up spatial SQL added no value over streaming `XMLReader` + in-PHP Douglas-Peucker. **That decision stands:** GPX ingestion keeps its in-process pipeline. This ADR introduces PostGIS for a *different* concern — a persistent, geo-bounded **reference index** queried with spatial predicates (`ST_DWithin`, `ST_Covers`). The two are not in tension.
+
+Concretely, the database image becomes `postgis/postgis:18-3.6-alpine` (same PG18 binaries and data layout as the former `postgres:18-alpine`, plus the extension). The extension is enabled by a Doctrine migration so it applies on existing volumes too. `spatial_ref_sys` is excluded from Doctrine's schema tool (`schema_filter`); the Tier-1 tables live in their own schema, managed by `osm2pgsql`, outside Doctrine's metadata.
+
+## Consequences
+
+### Positive
+
+- **Deterministic discovery:** the same route always yields the same POIs/accommodations/water — no rate-limit or timeout variance, no HTTP latency at request time.
+- **The `alert.lunch.nudge` false positive disappears:** "no data" now means the local index truly has none, not that a query failed.
+- **Real drinking water** replaces the cemetery proxy.
+- **Corridor queries** (`ST_DWithin` along the track) replace fixed "around the endpoint" radii, closing detection gaps.
+- **Third-party fragility is isolated** in the best-effort provisioner; a Wikidata/DataTourisme/Overpass-mirror outage degrades the *next refresh*, never a user request.
+
+### Negative
+
+- **PostGIS is an engine change** across dev, prod, CI and the test DB (not just a migration). Foundry resets the test DB in `migrate` mode, so the CI PHPUnit database service must also run the PostGIS image.
+- **Provisioning peak RAM:** `osm2pgsql` is the new memory consumer; its peak (bounded via `--slim` + a capped cache) must fit the provisioner's budget on the 24 GB beta VM (ADR-039). Measured when the import lands.
+- **Test DB PostGIS is a prerequisite** for the API local-read cut-over (the deferred real-DB integration coverage, issue #56).
+- **Stale drinking water is a safety risk**, not just "dated data", on an isolated stage → a sane refresh cadence and a neutral UI label are required.
+- **Larger database disk footprint** for the reference index (bounded by `osmium tags-filter` pre-extraction).
+
+### Neutral
+
+- ADR-004 is unaffected (GPX stays in-process).
+- ADR-005/013/025/026 are reformulated, not reversed: caching, accommodation discovery, the public-Overpass posture and multi-source integration are folded into the provisioner instead of the request path.
+- The beta perimeter (FR + Benelux) is intentionally bounded; widening it is data, not code.
+
+## Sources
+
+- [ADR-004](adr-004-spatial-engineering-gpx-parsing-and-data-decimation.md) — GPX parsing/decimation (PostGIS rejected there for a different, transient workload)
+- [ADR-005](adr-005-orchestration-optimization-and-caching-of-external-apis.md) — External-API orchestration and caching (reformulated)
+- [ADR-013](adr-013-accomodation-discovery-and-heuristic-pricing-strategy.md) — Accommodation discovery and heuristic pricing (reformulated)
+- [ADR-022](adr-022-persistent-storage-strategy.md) — Persistent storage strategy (PostgreSQL + JSONB)
+- [ADR-025](adr-025-removal-of-self-hosted-overpass.md) — Removal of self-hosted Overpass (runtime posture reformulated)
+- [ADR-026](adr-026-multi-source-data-integration.md) — Multi-source data integration (moved into the provisioner)
+- [ADR-033](adr-033-osm-data-refresh-strategy.md) — OSM data refresh strategy
+- [ADR-036](adr-036-manual-osm-data-refresh.md) — Manual OSM data refresh
+- [ADR-039](adr-039-beta-right-sizing-free-tier.md) — Beta right-sizing and RAM/CPU budget


### PR DESCRIPTION
## Contexte

1re tranche du chantier **local-first** (recette #649, Lot D / Tier-1, ADR-040). La dépendance Overpass au runtime rend la détection POI / hébergements / eau non déterministe : le « vide-sur-erreur » de `OsmScanner` transforme un échec de requête en « aucune donnée », ce qui déclenche le faux positif `alert.lunch.nudge` et fait silencieusement échouer des scans.

L'architecture cible importe le jeu de référence dans PostgreSQL/PostGIS via le provisioner et le lit en local par requêtes corridor (`ST_DWithin`). **Cette PR ne pose que le socle moteur** ; l'import, l'enrichissement et la bascule de l'API suivront.

## Changements

- Image `database` → `postgis/postgis:18-3.6-alpine` (même layout PG18 que `postgres:18-alpine`, empreinte Alpine conservée).
- Migration `CREATE EXTENSION IF NOT EXISTS postgis` (s'applique aussi sur volume existant ; `down` retire d'abord `postgis_topology`, auto-activé par l'image sur volume neuf).
- Doctrine `schema_filter` exclut `spatial_ref_sys`, sinon `migrations:diff` / `schema:validate` génèrent un `DROP` de cette table système PostGIS.
- CI : le service `database` du job PHPUnit passe aussi sur l'image PostGIS (Foundry reset en mode `migrate` → la migration s'exécute là aussi ; l'image active l'extension sur `POSTGRES_DB` + `template1`).
- ADR-040 : local-first / source unique PostgreSQL-PostGIS (reformule ADR-005/013/025/026 ; le pipeline GPX d'ADR-004 est inchangé).

## Vérification

- Local sur `postgis/postgis:18-3.6-alpine` : `POSTGIS 3.6.3 / PGSQL 180`, `CREATE EXTENSION` idempotent, `ST_DWithin` + `ST_Covers` = `t`.
- `markdownlint` + check des liens internes : OK.
- Suite PHPUnit complète : déléguée à la CI (worktree sans `vendor`).

## Suite (Lot D / Tier-1)

- **PR2a-2** : import OSM provisioner (`osm2pgsql` flex Lua, Benelux, tables + GIST, swap atomique) + mesure RAM du pic `osm2pgsql`.
- **PR2b** : enrichissement Wikidata/DataTourisme + pricing 2 couches (sans scraping).
- **PR2c** : polygone de couverture + monitoring `/health`.
- **PR3** : API lecture locale (`ST_DWithin` corridor, retrait Overpass runtime, correction du faux nudge + eau réelle, hors-zone) + DB de test PostGIS (#56).

Refs #649

<!-- claude-review-start -->
## Claude Review

Clean, focused infrastructure PR. The migration, schema filter, and Docker image changes are all correct and well-reasoned. No security, performance, or architecture issues found.

**PR title check:** `feat(db): socle PostGIS pour l'index de référence local-first (ADR-040)` — the description is a French noun phrase rather than an English imperative verb. The squash commit headline already has the right form: "enable PostGIS for the local-first Tier-1 reference index (ADR-040)". Suggest aligning the PR title to match.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases (infrastructure-only change; existing PHPUnit suite covers the DB layer end-to-end)
- [x] Documentation is up to date (ADR-040 added)
- [x] Dependent tickets accounted for (#649, follow-up PRs listed)

No inline comments.

_Reviewed commit: eec1769cbc5acba46b2d2c052950dcff9818ea35_
<!-- claude-review-end -->