### PR TITLE
feat(provisioner): import OSM Tier-1 dans PostGIS (ADR-040)

### DIFF
--- a/.docker/provisioner/Dockerfile
+++ b/.docker/provisioner/Dockerfile
@@ -20,10 +20,13 @@ RUN composer dump-autoload --classmap-authoritative --no-dev
 # Stage 2: Dev (sources bind-mounted via compose.yaml)
 FROM php:8.5-cli-bookworm AS dev
 
+# osm2pgsql + postgresql-client (psql) drive the Tier-1 PostGIS import (ADR-040).
 # hadolint ignore=DL3008
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
     	osmium-tool \
+    	osm2pgsql \
+    	postgresql-client \
     && rm -rf /var/lib/apt/lists/*
 
 # xdebug enables `make coverage`/`coverage-ci` on the provisioner leg (same driver as
@@ -43,10 +46,13 @@ ENTRYPOINT ["php", "bin/provision"]
 # Stage 3: Production
 FROM php:8.5-cli-bookworm AS prod
 
+# osm2pgsql + postgresql-client (psql) drive the Tier-1 PostGIS import (ADR-040).
 # hadolint ignore=DL3008
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
     	osmium-tool \
+    	osm2pgsql \
+    	postgresql-client \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/Makefile
+++ b/Makefile
@@ -191,11 +191,11 @@ coverage-ci: ## Run PHPUnit with coverage (Clover XML for CI)
 test: qa test-php test-e2e openapi-lint security-check ## Run full test suite (Requires QA to pass first)
 
 ## --- 🗺️ OSM Provisioning ---
-provision: ensure-default-pbf ## Provision OSM regions interactively
-	@docker compose --profile provisioning run --rm provisioner
+provision: ensure-default-pbf ## Provision OSM regions + import the Tier-1 PostGIS index
+	@docker compose --profile provisioning run --rm provisioner --with-postgis
 
-provision-update: ## Trigger a non-interactive provisioner update (re-download OSM regions)
-	@docker compose --profile provisioning run --rm provisioner --no-interaction
+provision-update: ## Trigger a non-interactive provisioner update (re-download OSM + re-import PostGIS)
+	@docker compose --profile provisioning run --rm provisioner --no-interaction --with-postgis
 
 ## --- 🗄️ Database ---
 migration: ## Generate a Doctrine migration

--- a/README.md
+++ b/README.md
@@ -223,6 +223,8 @@ make provision
 
 This runs the unified `provision` command inside the `provisioner` container (Compose profile `provisioning`). It downloads the configured Geofabrik regions, writes them atomically to the shared `/data` volume, and updates `/data/regions.json`. Re-running the same command later updates existing regions instead of re-installing them — the install vs update mode is detected from the presence of `/data/regions.json` and the `--no-interaction` flag.
 
+The Makefile targets also pass `--with-postgis`, which imports the bikepacking-relevant OSM features (POI, accommodations, water points) into the PostGIS `osm` schema via `osm2pgsql` (flex style `provisioner/osm2pgsql/tier1.lua`). The import builds a staging schema and swaps it onto the live `osm` schema in one transaction, so the previous dataset keeps serving until the new one is complete. This local-first reference index is what the API reads via `ST_DWithin` corridor queries — see [ADR-040](docs/adr/adr-040-local-first-reference-data-postgis.md).
+
 **Refresh (manual):**
 
 OSM data is refreshed manually — there is no scheduled job. Re-download the configured Geofabrik extracts and reload them into Valhalla on whatever cadence suits the deployment:

--- a/compose.yaml
+++ b/compose.yaml
@@ -460,11 +460,23 @@ services:
       - .docker/osm/data:/data
     restart: "no"
     profiles: ["provisioning"]
-    # One-shot OSM extract job; osmium needs headroom to parse the PBF (#566).
+    depends_on:
+      database:
+        condition: service_healthy
+    environment:
+      # Tier-1 PostGIS import target (ADR-040). Standard libpq env, consumed by
+      # osm2pgsql and psql when the provisioner runs with --with-postgis.
+      PGHOST: "${DATABASE_HOST:-database}"
+      PGPORT: "5432"
+      PGUSER: "${DATABASE_USERNAME:-app}"
+      PGPASSWORD: "${DATABASE_PASSWORD:-!ChangeMe!}"
+      PGDATABASE: "${DATABASE_NAME:-bike_trip_planner}"
+    # One-shot OSM extract + PostGIS import; osm2pgsql needs more headroom than
+    # the osmium merge (in-RAM node cache bounded via --cache). See ADR-040.
     deploy:
       resources:
         limits:
-          memory: 1G
+          memory: 2G
 
 volumes:
   caddy_data: ~

--- a/provisioner/osm2pgsql/tier1.lua
+++ b/provisioner/osm2pgsql/tier1.lua
@@ -1,0 +1,192 @@
+-- osm2pgsql flex style for the local-first Tier-1 reference index (ADR-040).
+--
+-- Imports the bikepacking-relevant OSM features into a dedicated staging schema
+-- as PostGIS point geometries (SRID 4326), which the importer then swaps onto
+-- the live `osm` schema atomically. The API reads these tables via ST_DWithin
+-- corridor queries, replacing the runtime Overpass dependency.
+--
+-- Scope of this style (PR2a-2): pois, accommodations, water_points. The
+-- admin_boundaries (coverage polygon) and cycle_routes tables land later.
+
+-- MUST match PostgisImporter::STAGING_SCHEMA: osm2pgsql writes the output tables
+-- here, and the importer creates/swaps this exact schema onto the live `osm`.
+local SCHEMA = 'osm_staging'
+local SRID = 4326
+
+-- Accommodation tourism values the app supports (TripRequest::ALL_ACCOMMODATION_TYPES);
+-- `shelter` is amenity=shelter and handled separately below.
+local ACCOMMODATION_TOURISM = {
+    hotel = true, hostel = true, guest_house = true, motel = true,
+    chalet = true, camp_site = true, alpine_hut = true, wilderness_hut = true,
+    apartment = true,
+}
+
+-- Resupply / point-of-interest categories (food, shops, services, sights).
+local POI_AMENITY = {
+    restaurant = true, cafe = true, bar = true, pub = true, fast_food = true,
+    marketplace = true, pharmacy = true,
+}
+local POI_SHOP = {
+    supermarket = true, convenience = true, bakery = true, butcher = true,
+    greengrocer = true, deli = true, general = true, pastry = true, farm = true,
+}
+local POI_TOURISM = {
+    viewpoint = true, attraction = true,
+}
+
+local pois = osm2pgsql.define_table({
+    name = 'pois',
+    schema = SCHEMA,
+    ids = { type = 'any', id_column = 'osm_id', type_column = 'osm_type' },
+    columns = {
+        { column = 'name', type = 'text' },
+        { column = 'category', type = 'text', not_null = true },
+        { column = 'opening_hours', type = 'text' },
+        { column = 'website', type = 'text' },
+        { column = 'tags', type = 'jsonb' },
+        { column = 'geom', type = 'point', projection = SRID, not_null = true },
+    },
+    indexes = {
+        { column = 'geom', method = 'gist' },
+        { column = 'category', method = 'btree' },
+    },
+})
+
+local accommodations = osm2pgsql.define_table({
+    name = 'accommodations',
+    schema = SCHEMA,
+    ids = { type = 'any', id_column = 'osm_id', type_column = 'osm_type' },
+    columns = {
+        { column = 'name', type = 'text' },
+        { column = 'category', type = 'text', not_null = true },
+        { column = 'stars', type = 'int' },
+        { column = 'capacity', type = 'int' },
+        { column = 'fee', type = 'text' },
+        { column = 'website', type = 'text' },
+        { column = 'wikidata', type = 'text' },
+        { column = 'opening_hours', type = 'text' },
+        { column = 'tags', type = 'jsonb' },
+        { column = 'geom', type = 'point', projection = SRID, not_null = true },
+    },
+    indexes = {
+        { column = 'geom', method = 'gist' },
+        { column = 'category', method = 'btree' },
+    },
+})
+
+local water_points = osm2pgsql.define_table({
+    name = 'water_points',
+    schema = SCHEMA,
+    ids = { type = 'any', id_column = 'osm_id', type_column = 'osm_type' },
+    columns = {
+        { column = 'name', type = 'text' },
+        { column = 'category', type = 'text', not_null = true },
+        { column = 'tags', type = 'jsonb' },
+        { column = 'geom', type = 'point', projection = SRID, not_null = true },
+    },
+    indexes = {
+        { column = 'geom', method = 'gist' },
+    },
+})
+
+local function poi_category(tags)
+    if tags.amenity and POI_AMENITY[tags.amenity] then return tags.amenity end
+    if tags.shop and POI_SHOP[tags.shop] then return tags.shop end
+    if tags.tourism and POI_TOURISM[tags.tourism] then return tags.tourism end
+    return nil
+end
+
+local function accommodation_category(tags)
+    if tags.tourism and ACCOMMODATION_TOURISM[tags.tourism] then return tags.tourism end
+    if tags.amenity == 'shelter' then return 'shelter' end
+    return nil
+end
+
+-- Real drinking water (replaces the cemetery proxy).
+local function water_category(tags)
+    if tags.amenity == 'drinking_water' then return 'drinking_water' end
+    if tags.amenity == 'water_point' then return 'water_point' end
+    if tags.man_made == 'water_tap' then return 'water_tap' end
+    if tags.amenity == 'fountain' and tags.drinking_water == 'yes' then return 'fountain' end
+    if tags.natural == 'spring' and tags.drinking_water == 'yes' then return 'spring' end
+    return nil
+end
+
+local function is_relevant(tags)
+    return poi_category(tags) ~= nil
+        or accommodation_category(tags) ~= nil
+        or water_category(tags) ~= nil
+end
+
+-- Safe integer coercion (works on both Lua 5.x and LuaJIT builds of osm2pgsql).
+local function to_int(v)
+    local n = tonumber(v)
+    if n == nil then return nil end
+    return math.floor(n)
+end
+
+local function insert_features(tags, geom)
+    local cat = poi_category(tags)
+    if cat then
+        pois:insert({
+            name = tags.name,
+            category = cat,
+            opening_hours = tags.opening_hours,
+            website = tags.website,
+            tags = tags,
+            geom = geom,
+        })
+    end
+
+    local acc = accommodation_category(tags)
+    if acc then
+        accommodations:insert({
+            name = tags.name,
+            category = acc,
+            stars = to_int(tags.stars),
+            capacity = to_int(tags.capacity),
+            fee = tags.fee or tags.charge,
+            website = tags.website,
+            wikidata = tags.wikidata,
+            opening_hours = tags.opening_hours,
+            tags = tags,
+            geom = geom,
+        })
+    end
+
+    local wcat = water_category(tags)
+    if wcat then
+        water_points:insert({
+            name = tags.name,
+            category = wcat,
+            tags = tags,
+            geom = geom,
+        })
+    end
+end
+
+-- Centroid point of a way (closed -> polygon centroid, otherwise line centroid).
+-- Guarded: a degenerate/invalid geometry yields nil and the feature is skipped.
+local function way_centroid(object)
+    local ok, geom = pcall(function()
+        if object.is_closed then
+            return object:as_polygon():centroid()
+        end
+        return object:as_linestring():centroid()
+    end)
+    if ok then return geom end
+    return nil
+end
+
+function osm2pgsql.process_node(object)
+    -- tags-filter keeps untagged nodes referenced by ways; skip them here.
+    if not is_relevant(object.tags) then return end
+    insert_features(object.tags, object:as_point())
+end
+
+function osm2pgsql.process_way(object)
+    if not is_relevant(object.tags) then return end
+    local geom = way_centroid(object)
+    if geom == nil then return end
+    insert_features(object.tags, geom)
+end

--- a/provisioner/src/Exception/ImportFailedException.php
+++ b/provisioner/src/Exception/ImportFailedException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Provisioner\Exception;
+
+final class ImportFailedException extends \RuntimeException
+{
+}

--- a/provisioner/src/GeofabrikRegionRegistry.php
+++ b/provisioner/src/GeofabrikRegionRegistry.php
@@ -7,12 +7,21 @@ namespace Provisioner;
 final class GeofabrikRegionRegistry
 {
     /**
+     * Geofabrik slugs that live at the `europe/` level (whole countries) rather
+     * than under `europe/france/`. The Tier-1 beta perimeter is FR + Benelux.
+     */
+    private const array EUROPE_LEVEL_SLUGS = ['france', 'belgium', 'netherlands', 'luxembourg'];
+
+    /**
      * @return array<string, array{slug: string, size: string}>
      */
     public static function all(): array
     {
         return [
             'France (entiere)' => ['slug' => 'france', 'size' => '4400 MB'],
+            'Belgique' => ['slug' => 'belgium', 'size' => '500 MB'],
+            'Pays-Bas' => ['slug' => 'netherlands', 'size' => '1600 MB'],
+            'Luxembourg' => ['slug' => 'luxembourg', 'size' => '40 MB'],
             'Alsace' => ['slug' => 'alsace', 'size' => '122 MB'],
             'Aquitaine' => ['slug' => 'aquitaine', 'size' => '276 MB'],
             'Auvergne' => ['slug' => 'auvergne', 'size' => '141 MB'],
@@ -45,9 +54,10 @@ final class GeofabrikRegionRegistry
 
     public static function downloadUrl(string $slug): string
     {
-        // The whole-France extract lives one level above the per-region directory.
-        if ('france' === $slug) {
-            return 'https://download.geofabrik.de/europe/france-latest.osm.pbf';
+        // Whole countries (France + Benelux) live at the europe/ level; French
+        // regions live one level down under europe/france/.
+        if (\in_array($slug, self::EUROPE_LEVEL_SLUGS, true)) {
+            return \sprintf('https://download.geofabrik.de/europe/%s-latest.osm.pbf', $slug);
         }
 
         return \sprintf(

--- a/provisioner/src/PostgisImporter.php
+++ b/provisioner/src/PostgisImporter.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Provisioner;
+
+use Provisioner\Exception\ImportFailedException;
+use Symfony\Component\Process\Exception\ProcessTimedOutException;
+use Symfony\Component\Process\Process;
+
+/**
+ * Imports the Tier-1 reference features (POI, accommodations, water points) from
+ * the merged PBF into PostGIS, behind an atomic schema swap (ADR-040).
+ *
+ * Flow: tags-filter the merged PBF down to the relevant features, import them
+ * into a fresh staging schema via osm2pgsql (flex output, osm2pgsql/tier1.lua),
+ * then rename the staging schema onto the live schema in one transaction. The
+ * live schema keeps serving reads until the swap, so a failed import leaves the
+ * previous dataset intact.
+ *
+ * Database connection is taken from the standard libpq environment
+ * (PGHOST/PGPORT/PGUSER/PGPASSWORD/PGDATABASE), inherited by osm2pgsql and psql.
+ */
+final readonly class PostgisImporter
+{
+    /**
+     * Staging schema the flex tables are written into before the atomic swap.
+     *
+     * This MUST stay equal to the `SCHEMA` constant in osm2pgsql/tier1.lua:
+     * osm2pgsql creates the output tables in the schema the Lua style declares,
+     * while the DROP/CREATE and the swap here target this name. If the two ever
+     * diverge, osm2pgsql writes to one schema and the swap renames the other
+     * (empty) schema onto the live one — destroying the live data. Hence a fixed
+     * constant rather than a constructor parameter.
+     */
+    private const string STAGING_SCHEMA = 'osm_staging';
+
+    /**
+     * Tag expressions for `osmium tags-filter`; together they keep every feature
+     * the flex style maps. osmium keeps referenced nodes/members by default, so
+     * way geometries stay complete.
+     *
+     * @var list<string>
+     */
+    private const array TAGS_FILTER_EXPRESSIONS = [
+        'nwr/amenity=restaurant,cafe,bar,pub,fast_food,marketplace,pharmacy,drinking_water,water_point,fountain,shelter',
+        'nwr/shop=supermarket,convenience,bakery,butcher,greengrocer,deli,general,pastry,farm',
+        'nwr/tourism=hotel,hostel,guest_house,motel,chalet,camp_site,alpine_hut,wilderness_hut,apartment,viewpoint,attraction',
+        'nwr/man_made=water_tap',
+        'nwr/natural=spring',
+    ];
+
+    /**
+     * @var \Closure(list<string>): Process
+     */
+    private \Closure $processFactory;
+
+    /**
+     * @param (\Closure(list<string>): Process)|null $processFactory factory used to build the osmium/osm2pgsql/psql processes; defaults to a real {@see Process}
+     */
+    public function __construct(
+        private string $flexStylePath,
+        private string $liveSchema = 'osm',
+        private int $cacheMb = 800,
+        ?\Closure $processFactory = null,
+        private float $timeoutSeconds = 1800.0,
+    ) {
+        $this->processFactory = $processFactory ?? static fn (array $command): Process => new Process($command);
+    }
+
+    /**
+     * @throws ImportFailedException
+     */
+    public function run(string $mergedPbf, string $filteredPbf): void
+    {
+        $this->filter($mergedPbf, $filteredPbf);
+        $this->import($filteredPbf);
+        $this->swap();
+    }
+
+    /**
+     * @throws ImportFailedException
+     */
+    public function filter(string $mergedPbf, string $filteredPbf): void
+    {
+        $this->runProcess(
+            array_merge(['osmium', 'tags-filter', '--overwrite', '-o', $filteredPbf, $mergedPbf], self::TAGS_FILTER_EXPRESSIONS),
+            'osmium tags-filter',
+        );
+    }
+
+    /**
+     * @throws ImportFailedException
+     */
+    public function import(string $filteredPbf): void
+    {
+        // Fresh staging schema (drop any half-written leftover from a prior crash).
+        $this->runProcess([
+            'psql', '-v', 'ON_ERROR_STOP=1', '-c',
+            \sprintf('DROP SCHEMA IF EXISTS %1$s CASCADE; CREATE SCHEMA %1$s;', self::STAGING_SCHEMA),
+        ], 'psql create staging schema');
+
+        $this->runProcess([
+            'osm2pgsql',
+            '--create',
+            '--slim',
+            '--drop',
+            '--output=flex',
+            '--style', $this->flexStylePath,
+            '--cache', (string) $this->cacheMb,
+            '--middle-schema', self::STAGING_SCHEMA,
+            $filteredPbf,
+        ], 'osm2pgsql import');
+    }
+
+    /**
+     * @throws ImportFailedException
+     */
+    public function swap(): void
+    {
+        $this->runProcess([
+            'psql', '-v', 'ON_ERROR_STOP=1', '--single-transaction', '-c',
+            \sprintf('DROP SCHEMA IF EXISTS %s CASCADE; ALTER SCHEMA %s RENAME TO %s;', $this->liveSchema, self::STAGING_SCHEMA, $this->liveSchema),
+        ], 'psql schema swap');
+    }
+
+    /**
+     * @param list<string> $command
+     *
+     * @throws ImportFailedException
+     */
+    private function runProcess(array $command, string $label): void
+    {
+        $process = ($this->processFactory)($command);
+        $process->setTimeout($this->timeoutSeconds);
+
+        try {
+            $process->run();
+        } catch (ProcessTimedOutException $processTimedOutException) {
+            throw new ImportFailedException(\sprintf('%s timed out after %.1fs', $label, $this->timeoutSeconds), 0, $processTimedOutException);
+        }
+
+        if (!$process->isSuccessful()) {
+            throw new ImportFailedException(\sprintf('%s failed (exit %s): %s', $label, (string) $process->getExitCode(), $process->getErrorOutput()));
+        }
+    }
+}

--- a/provisioner/src/ProvisionCommand.php
+++ b/provisioner/src/ProvisionCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Provisioner;
 
 use Provisioner\Exception\DownloadFailedException;
+use Provisioner\Exception\ImportFailedException;
 use Provisioner\Exception\MergeFailedException;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -26,9 +27,13 @@ final class ProvisionCommand extends Command
 
     private const string DEFAULT_SELECTION_FILE = '/data/regions.json';
 
+    private const string DEFAULT_FILTERED_PBF = '/data/tier1-filtered.osm.pbf';
+
     private readonly RegionSelectionStore $selectionStore;
 
     private readonly OsmDataDownloader $downloader;
+
+    private readonly PostgisImporter $postgisImporter;
 
     public function __construct(
         private readonly string $regionsDir = self::DEFAULT_REGIONS_DIR,
@@ -37,16 +42,22 @@ final class ProvisionCommand extends Command
         ?RegionSelectionStore $selectionStore = null,
         ?OsmDataDownloader $downloader = null,
         private readonly bool $runMerge = true,
+        private readonly string $filteredPbf = self::DEFAULT_FILTERED_PBF,
+        ?PostgisImporter $postgisImporter = null,
     ) {
         parent::__construct();
 
         $this->selectionStore = $selectionStore ?? new RegionSelectionStore($selectionFile);
         $this->downloader = $downloader ?? new OsmDataDownloader(regionsDir: $this->regionsDir);
+        $this->postgisImporter = $postgisImporter ?? new PostgisImporter(
+            flexStylePath: \dirname(__DIR__).'/osm2pgsql/tier1.lua',
+        );
     }
 
     protected function configure(): void
     {
         $this->addOption('dry-run', null, InputOption::VALUE_NONE, 'Show what would be downloaded without executing');
+        $this->addOption('with-postgis', null, InputOption::VALUE_NONE, 'After merging, import the Tier-1 features into PostGIS (requires PG* env)');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -55,6 +66,7 @@ final class ProvisionCommand extends Command
         $io->title('OSM Region Provisioner');
 
         $dryRun = (bool) $input->getOption('dry-run');
+        $importPostgis = (bool) $input->getOption('with-postgis');
         $interactive = $input->isInteractive();
         $hasSelection = $this->selectionStore->exists();
 
@@ -65,13 +77,13 @@ final class ProvisionCommand extends Command
         }
 
         if ($hasSelection) {
-            return $this->runUpdateFlow($io, $dryRun, $interactive);
+            return $this->runUpdateFlow($io, $dryRun, $interactive, $importPostgis);
         }
 
-        return $this->runInstallFlow($io, $dryRun);
+        return $this->runInstallFlow($io, $dryRun, $importPostgis);
     }
 
-    private function runInstallFlow(SymfonyStyle $io, bool $dryRun): int
+    private function runInstallFlow(SymfonyStyle $io, bool $dryRun, bool $importPostgis): int
     {
         $allRegions = GeofabrikRegionRegistry::all();
         $regionNames = array_keys($allRegions);
@@ -154,7 +166,7 @@ final class ProvisionCommand extends Command
 
         $slugs = array_map(static fn (string $name): string => $allRegions[$name]['slug'], $selected);
 
-        $result = $this->downloadAndMerge($io, $slugs, force: false);
+        $result = $this->downloadAndMerge($io, $slugs, force: false, importPostgis: $importPostgis);
         if (Command::SUCCESS !== $result) {
             return $result;
         }
@@ -165,7 +177,7 @@ final class ProvisionCommand extends Command
         return Command::SUCCESS;
     }
 
-    private function runUpdateFlow(SymfonyStyle $io, bool $dryRun, bool $interactive): int
+    private function runUpdateFlow(SymfonyStyle $io, bool $dryRun, bool $interactive, bool $importPostgis): int
     {
         $slugs = $this->selectionStore->load();
         $knownSlugs = array_column(GeofabrikRegionRegistry::all(), 'slug');
@@ -189,11 +201,11 @@ final class ProvisionCommand extends Command
 
             $io->warning('Selection file exists but is empty or invalid. Falling back to install flow.');
 
-            return $this->runInstallFlow($io, $dryRun);
+            return $this->runInstallFlow($io, $dryRun, $importPostgis);
         }
 
         if (!$interactive) {
-            return $this->runSilentUpdate($io, $slugs, $dryRun);
+            return $this->runSilentUpdate($io, $slugs, $dryRun, $importPostgis);
         }
 
         $choice = $io->choice(
@@ -203,8 +215,8 @@ final class ProvisionCommand extends Command
         );
 
         return match ($choice) {
-            'update' => $this->runSilentUpdate($io, $slugs, $dryRun),
-            'reconfigure' => $this->runInstallFlow($io, $dryRun),
+            'update' => $this->runSilentUpdate($io, $slugs, $dryRun, $importPostgis),
+            'reconfigure' => $this->runInstallFlow($io, $dryRun, $importPostgis),
             default => Command::SUCCESS,
         };
     }
@@ -212,7 +224,7 @@ final class ProvisionCommand extends Command
     /**
      * @param list<string> $slugs
      */
-    private function runSilentUpdate(SymfonyStyle $io, array $slugs, bool $dryRun): int
+    private function runSilentUpdate(SymfonyStyle $io, array $slugs, bool $dryRun, bool $importPostgis): int
     {
         $io->section('Updating persisted regions');
         foreach ($slugs as $slug) {
@@ -225,7 +237,7 @@ final class ProvisionCommand extends Command
             return Command::SUCCESS;
         }
 
-        $result = $this->downloadAndMerge($io, $slugs, force: true);
+        $result = $this->downloadAndMerge($io, $slugs, force: true, importPostgis: $importPostgis);
         if (Command::SUCCESS !== $result) {
             return $result;
         }
@@ -238,7 +250,7 @@ final class ProvisionCommand extends Command
     /**
      * @param list<string> $slugs
      */
-    private function downloadAndMerge(SymfonyStyle $io, array $slugs, bool $force): int
+    private function downloadAndMerge(SymfonyStyle $io, array $slugs, bool $force, bool $importPostgis): int
     {
         $toDownload = [];
         foreach ($slugs as $slug) {
@@ -279,6 +291,21 @@ final class ProvisionCommand extends Command
             try {
                 $this->downloader->merge($pbfFiles, $this->mergedPbf);
             } catch (MergeFailedException $e) {
+                $io->newLine();
+                $io->error($e->getMessage());
+
+                return Command::FAILURE;
+            }
+
+            $io->writeln("\u{2713}");
+        }
+
+        if ($importPostgis) {
+            $io->write('  Importing Tier-1 features into PostGIS... ');
+
+            try {
+                $this->postgisImporter->run($this->mergedPbf, $this->filteredPbf);
+            } catch (ImportFailedException $e) {
                 $io->newLine();
                 $io->error($e->getMessage());
 

--- a/provisioner/tests/GeofabrikRegionRegistryTest.php
+++ b/provisioner/tests/GeofabrikRegionRegistryTest.php
@@ -11,9 +11,26 @@ use Provisioner\GeofabrikRegionRegistry;
 final class GeofabrikRegionRegistryTest extends TestCase
 {
     #[Test]
-    public function allReturns28Regions(): void
+    public function allReturns31Regions(): void
     {
-        self::assertCount(28, GeofabrikRegionRegistry::all());
+        self::assertCount(31, GeofabrikRegionRegistry::all());
+    }
+
+    #[Test]
+    public function allIncludesBeneluxCountries(): void
+    {
+        $regions = GeofabrikRegionRegistry::all();
+        self::assertArrayHasKey('Belgique', $regions);
+        self::assertArrayHasKey('Pays-Bas', $regions);
+        self::assertArrayHasKey('Luxembourg', $regions);
+    }
+
+    #[Test]
+    public function downloadUrlForBeneluxUsesEuropeLevelExtract(): void
+    {
+        self::assertSame('https://download.geofabrik.de/europe/belgium-latest.osm.pbf', GeofabrikRegionRegistry::downloadUrl('belgium'));
+        self::assertSame('https://download.geofabrik.de/europe/netherlands-latest.osm.pbf', GeofabrikRegionRegistry::downloadUrl('netherlands'));
+        self::assertSame('https://download.geofabrik.de/europe/luxembourg-latest.osm.pbf', GeofabrikRegionRegistry::downloadUrl('luxembourg'));
     }
 
     #[Test]
@@ -60,11 +77,17 @@ final class GeofabrikRegionRegistryTest extends TestCase
     #[Test]
     public function allSlugsProduceValidUrls(): void
     {
+        $europeLevel = ['france', 'belgium', 'netherlands', 'luxembourg'];
+
         foreach (GeofabrikRegionRegistry::all() as $name => $data) {
             $url = GeofabrikRegionRegistry::downloadUrl($data['slug']);
-            if ('france' === $data['slug']) {
-                // Whole-France extract lives one level up, not under /france/.
-                self::assertStringContainsString('/europe/france-latest.osm.pbf', $url, $name);
+            if (\in_array($data['slug'], $europeLevel, true)) {
+                // Whole countries live at the europe/ level, not under /france/.
+                self::assertSame(
+                    \sprintf('https://download.geofabrik.de/europe/%s-latest.osm.pbf', $data['slug']),
+                    $url,
+                    $name,
+                );
             } else {
                 self::assertStringStartsWith('https://download.geofabrik.de/europe/france/', $url, $name);
             }

--- a/provisioner/tests/PostgisImporterTest.php
+++ b/provisioner/tests/PostgisImporterTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Provisioner\Tests;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Provisioner\Exception\ImportFailedException;
+use Provisioner\PostgisImporter;
+use Symfony\Component\Process\Exception\ProcessTimedOutException;
+use Symfony\Component\Process\Process;
+
+final class PostgisImporterTest extends TestCase
+{
+    /**
+     * @var list<list<string>>
+     */
+    private array $captured = [];
+
+    /**
+     * Factory that records each built command and runs a trivial successful process.
+     */
+    private function capturingFactory(): \Closure
+    {
+        return function (array $command): Process {
+            /** @var list<string> $cmd */
+            $cmd = $command;
+            $this->captured[] = $cmd;
+
+            return new Process(['true']);
+        };
+    }
+
+    #[Test]
+    public function filterBuildsOsmiumTagsFilterCommand(): void
+    {
+        $importer = new PostgisImporter(
+            flexStylePath: '/app/osm2pgsql/tier1.lua',
+            processFactory: $this->capturingFactory(),
+        );
+
+        $importer->filter('/data/default.osm.pbf', '/data/tier1-filtered.osm.pbf');
+
+        self::assertCount(1, $this->captured);
+        self::assertSame(
+            ['osmium', 'tags-filter', '--overwrite', '-o', '/data/tier1-filtered.osm.pbf', '/data/default.osm.pbf'],
+            \array_slice($this->captured[0], 0, 6),
+        );
+        self::assertContains('nwr/man_made=water_tap', $this->captured[0]);
+        self::assertContains('nwr/natural=spring', $this->captured[0]);
+    }
+
+    #[Test]
+    public function importCreatesStagingSchemaThenRunsOsm2pgsqlFlex(): void
+    {
+        $importer = new PostgisImporter(
+            flexStylePath: '/app/osm2pgsql/tier1.lua',
+            cacheMb: 512,
+            processFactory: $this->capturingFactory(),
+        );
+
+        $importer->import('/data/tier1-filtered.osm.pbf');
+
+        self::assertCount(2, $this->captured);
+
+        self::assertSame('psql', $this->captured[0][0]);
+        self::assertStringContainsString('CREATE SCHEMA osm_staging', implode(' ', $this->captured[0]));
+
+        $osm2pgsql = $this->captured[1];
+        self::assertSame('osm2pgsql', $osm2pgsql[0]);
+        self::assertContains('--create', $osm2pgsql);
+        self::assertContains('--slim', $osm2pgsql);
+        self::assertContains('--drop', $osm2pgsql);
+        self::assertContains('--output=flex', $osm2pgsql);
+        self::assertContains('/app/osm2pgsql/tier1.lua', $osm2pgsql);
+        self::assertContains('512', $osm2pgsql);
+        $midIdx = array_search('--middle-schema', $osm2pgsql, true);
+        self::assertNotFalse($midIdx, '--middle-schema flag must be present');
+        self::assertArrayHasKey($midIdx + 1, $osm2pgsql, '--middle-schema must be followed by its value');
+        self::assertSame('osm_staging', $osm2pgsql[$midIdx + 1], '--middle-schema value must match STAGING_SCHEMA');
+        self::assertContains('/data/tier1-filtered.osm.pbf', $osm2pgsql);
+    }
+
+    #[Test]
+    public function swapRenamesStagingOntoLiveInOneTransaction(): void
+    {
+        $importer = new PostgisImporter(
+            flexStylePath: '/app/osm2pgsql/tier1.lua',
+            liveSchema: 'osm',
+            processFactory: $this->capturingFactory(),
+        );
+
+        $importer->swap();
+
+        self::assertCount(1, $this->captured);
+        $cmd = $this->captured[0];
+        self::assertSame('psql', $cmd[0]);
+        self::assertContains('--single-transaction', $cmd);
+
+        $sql = end($cmd);
+        self::assertStringContainsString('DROP SCHEMA IF EXISTS osm CASCADE', $sql);
+        self::assertStringContainsString('ALTER SCHEMA osm_staging RENAME TO osm', $sql);
+    }
+
+    #[Test]
+    public function failingProcessRaisesImportFailedExceptionWithStderr(): void
+    {
+        $factory = static fn (array $command): Process => new Process(['sh', '-c', 'echo "boom" 1>&2; exit 3']);
+
+        $importer = new PostgisImporter(
+            flexStylePath: '/app/osm2pgsql/tier1.lua',
+            processFactory: $factory,
+        );
+
+        try {
+            $importer->filter('/in.osm.pbf', '/out.osm.pbf');
+            self::fail('Expected ImportFailedException');
+        } catch (ImportFailedException $importFailedException) {
+            self::assertStringContainsString('osmium tags-filter failed', $importFailedException->getMessage());
+            self::assertStringContainsString('boom', $importFailedException->getMessage());
+            self::assertStringContainsString('exit 3', $importFailedException->getMessage());
+        }
+    }
+
+    #[Test]
+    public function timedOutProcessRaisesImportFailedException(): void
+    {
+        // A real process that outlives the (tiny) timeout, mirroring the
+        // merge-timeout test in OsmDataDownloaderTest. Process::run() is @final,
+        // so it cannot be overridden to fake the timeout.
+        $importer = new PostgisImporter(
+            flexStylePath: '/app/osm2pgsql/tier1.lua',
+            processFactory: static fn (array $command): Process => new Process(['sleep', '5']),
+            timeoutSeconds: 0.05,
+        );
+
+        try {
+            $importer->filter('/in.osm.pbf', '/out.osm.pbf');
+            self::fail('Expected ImportFailedException');
+        } catch (ImportFailedException $importFailedException) {
+            self::assertStringContainsString('osmium tags-filter timed out after', $importFailedException->getMessage());
+            self::assertInstanceOf(ProcessTimedOutException::class, $importFailedException->getPrevious());
+        }
+    }
+}

--- a/provisioner/tests/ProvisionCommandTest.php
+++ b/provisioner/tests/ProvisionCommandTest.php
@@ -6,12 +6,15 @@ namespace Provisioner\Tests;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Provisioner\OsmDataDownloader;
+use Provisioner\PostgisImporter;
 use Provisioner\ProvisionCommand;
 use Provisioner\RegionSelectionStore;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\Process\Process;
 
 final class ProvisionCommandTest extends TestCase
 {
@@ -55,17 +58,23 @@ final class ProvisionCommandTest extends TestCase
         rmdir($dir);
     }
 
-    private function buildTester(?MockHttpClient $httpClient = null): CommandTester
-    {
+    private function buildTester(
+        ?MockHttpClient $httpClient = null,
+        bool $runMerge = false,
+        ?\Closure $downloaderProcessFactory = null,
+        ?PostgisImporter $postgisImporter = null,
+    ): CommandTester {
         $command = new ProvisionCommand(
             regionsDir: $this->regionsDir,
             mergedPbf: $this->mergedPbf,
             selectionFile: $this->selectionFile,
-            downloader: new \Provisioner\OsmDataDownloader(
+            downloader: new OsmDataDownloader(
                 regionsDir: $this->regionsDir,
                 httpClient: $httpClient ?? new MockHttpClient(static fn (): MockResponse => new MockResponse('osm-bytes')),
+                processFactory: $downloaderProcessFactory,
             ),
-            runMerge: false,
+            runMerge: $runMerge,
+            postgisImporter: $postgisImporter,
         );
 
         $app = new Application();
@@ -220,5 +229,82 @@ final class ProvisionCommandTest extends TestCase
 
         self::assertSame(0, $exitCode);
         self::assertStringContainsString('No region selected', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function withPostgisFlagRunsTheImport(): void
+    {
+        new RegionSelectionStore($this->selectionFile)->save(['bretagne']);
+
+        $calls = 0;
+        $importer = new PostgisImporter(
+            flexStylePath: '/app/osm2pgsql/tier1.lua',
+            processFactory: function (array $command) use (&$calls): Process {
+                ++$calls;
+
+                return new Process(['true']);
+            },
+        );
+
+        $tester = $this->buildTester(
+            runMerge: true,
+            downloaderProcessFactory: static fn (array $command): Process => new Process(['true']),
+            postgisImporter: $importer,
+        );
+
+        $exitCode = $tester->execute(['--with-postgis' => true], ['interactive' => false]);
+
+        self::assertSame(0, $exitCode, $tester->getDisplay());
+        self::assertStringContainsString('Importing Tier-1 features into PostGIS', $tester->getDisplay());
+        self::assertGreaterThan(0, $calls, 'PostgisImporter::run() should have been invoked');
+    }
+
+    #[Test]
+    public function postgisImportFailureReturnsFailure(): void
+    {
+        new RegionSelectionStore($this->selectionFile)->save(['bretagne']);
+
+        $importer = new PostgisImporter(
+            flexStylePath: '/app/osm2pgsql/tier1.lua',
+            processFactory: static fn (array $command): Process => new Process(['sh', '-c', 'echo "boom" 1>&2; exit 1']),
+        );
+
+        $tester = $this->buildTester(
+            runMerge: true,
+            downloaderProcessFactory: static fn (array $command): Process => new Process(['true']),
+            postgisImporter: $importer,
+        );
+
+        $exitCode = $tester->execute(['--with-postgis' => true], ['interactive' => false]);
+
+        self::assertSame(1, $exitCode);
+        self::assertStringContainsString('tags-filter failed', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function withoutPostgisFlagSkipsImport(): void
+    {
+        new RegionSelectionStore($this->selectionFile)->save(['bretagne']);
+
+        $ran = false;
+        $importer = new PostgisImporter(
+            flexStylePath: '/app/osm2pgsql/tier1.lua',
+            processFactory: function (array $command) use (&$ran): Process {
+                $ran = true;
+
+                return new Process(['true']);
+            },
+        );
+
+        $tester = $this->buildTester(
+            runMerge: true,
+            downloaderProcessFactory: static fn (array $command): Process => new Process(['true']),
+            postgisImporter: $importer,
+        );
+
+        $exitCode = $tester->execute([], ['interactive' => false]);
+
+        self::assertSame(0, $exitCode, $tester->getDisplay());
+        self::assertFalse($ran, 'import must not run without --with-postgis');
     }
 }


### PR DESCRIPTION
## Contexte

2e tranche du chantier local-first (recette #649, Lot D / Tier-1, ADR-040). Étend le provisioner pour peupler l'index de référence PostGIS que l'API lira par requêtes corridor `ST_DWithin`, en remplacement de la dépendance Overpass au runtime.

## Changements

- **Registry Geofabrik** : ajout du Benelux (`belgium` / `netherlands` / `luxembourg`) au périmètre bêta ; les slugs niveau `europe/` sont résolus à côté de la France entière.
- **Image provisioner** : installation de `osm2pgsql` + `postgresql-client`.
- **Style flex Lua** (`provisioner/osm2pgsql/tier1.lua`) : tables `pois`, `accommodations`, `water_points` en géométrie point (SRID 4326) + index **GIST**, colonnes utiles en clair + tags bruts `JSONB` ; nœuds et centroïdes de ways ; **vraie eau potable** (fin du proxy cimetière).
- **`PostgisImporter`** : `osmium tags-filter` → `osm2pgsql` (flex, `--slim --drop`, `--cache` borné) dans un **schéma de staging** → **swap atomique en une transaction** sur le schéma live `osm` ; le dataset précédent sert les lectures jusqu'à la bascule.
- **`make provision[-update]`** passent `--with-postgis` ; le provisioner gagne une connexion DB (env libpq) + `depends_on: database`.
- **Tests** : construction des commandes `PostgisImporter` + registry/URLs Benelux.

## Périmètre

`pois` / `accommodations` / `water_points` (consommés par PR3). `admin_boundaries` (polygone de couverture) et `cycle_routes` arrivent en **PR2c**.

## Vérification

Import réel **Luxembourg** (périmètre bêta), DB sur l'image PostGIS de la PR précédente :

- filtre : `46,9 Mo` PBF → **`432 Ko`** (réduction ~100×) ;
- comptages : **pois 3720, accommodations 1931, water_points 220** ;
- `water_points` = `drinking_water` 142, `water_tap` 38, `water_point` 34, `spring` 6 ;
- **SRID 4326 / Point** + index **GIST** confirmés sur les 3 tables ;
- **`ST_DWithin`** : 299 POI à 600 m du centre de Luxembourg-ville ;
- **pic RSS osm2pgsql = 23 Mo** — `--cache` borne le pic indépendamment de la taille d'entrée, très confortable vs la limite provisioner (2 G).

`php -l`, markdownlint et liens internes OK localement ; suite PHPUnit complète déléguée à la CI (worktree sans `vendor`).

## Suite

- **PR2c** : `admin_boundaries` + polygone de couverture + `cycle_routes` + monitoring `/health`.
- **PR2b** : enrichissement Wikidata/DataTourisme + pricing 2 couches.
- **PR3** : API lecture locale (`PoiRepository`/`AccommodationRepository`, handlers corridor, retrait Overpass runtime, correction du faux nudge, hors-zone) + DB de test PostGIS (#56).

Refs #649

<!-- claude-review-start -->
## Claude Review

Reviewed commit `955ef70fb977bb52c9be50c2aae0081902ac04d4`.

All findings from the previous review have been addressed. The `STAGING_SCHEMA` constant correctly enforces the Lua/PHP schema coupling; `$importPostgis` is now a local variable (no mutable singleton state); the `--middle-schema` value assertion is present and guards the coupling at the test level; and the `ProcessTimedOutException` branch is now covered by `timedOutProcessRaisesImportFailedException` using a real `sleep 5` process with a 0.05 s timeout. The compose libpq env vars follow the same `${DATABASE_*}` pattern as the rest of the stack — no hardcoded secrets. No new findings.

**Resolved threads:** Resolved 1 previously open thread (`ProcessTimedOutException` branch is now covered by `timedOutProcessRaisesImportFailedException`).

**Review checklist**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.
<!-- claude-review-end -->