### PR TITLE
feat(osm): couche de lecture locale PostGIS + schéma osm (ADR-040)

### DIFF
--- a/api/migrations/Version20260614120000.php
+++ b/api/migrations/Version20260614120000.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Creates the local-first Tier-1 reference schema `osm` (ADR-040): pois,
+ * accommodations and water_points as PostGIS point tables, read by the API via
+ * ST_DWithin corridor queries instead of the runtime Overpass API.
+ *
+ * The structure mirrors the osm2pgsql flex output (provisioner/osm2pgsql/tier1.lua):
+ * the provisioner imports into a staging schema and atomically swaps it onto `osm`,
+ * replacing what this migration bootstraps. This migration exists so the schema is
+ * present before the first provisioning run (the API returns empty results rather
+ * than erroring) and so functional tests have the tables to seed and query. The
+ * tables live in their own schema, outside Doctrine's managed (public) metadata.
+ */
+final class Version20260614120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create the osm reference schema (pois, accommodations, water_points) for local-first reads';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE SCHEMA IF NOT EXISTS osm');
+
+        $this->addSql(<<<'SQL'
+            CREATE TABLE IF NOT EXISTS osm.pois (
+                osm_type character(1) NOT NULL,
+                osm_id bigint NOT NULL,
+                name text,
+                category text NOT NULL,
+                opening_hours text,
+                website text,
+                tags jsonb,
+                geom geometry(Point, 4326) NOT NULL,
+                PRIMARY KEY (osm_type, osm_id)
+            )
+            SQL);
+
+        $this->addSql(<<<'SQL'
+            CREATE TABLE IF NOT EXISTS osm.accommodations (
+                osm_type character(1) NOT NULL,
+                osm_id bigint NOT NULL,
+                name text,
+                category text NOT NULL,
+                stars integer,
+                capacity integer,
+                fee text,
+                website text,
+                wikidata text,
+                opening_hours text,
+                tags jsonb,
+                geom geometry(Point, 4326) NOT NULL,
+                PRIMARY KEY (osm_type, osm_id)
+            )
+            SQL);
+
+        $this->addSql(<<<'SQL'
+            CREATE TABLE IF NOT EXISTS osm.water_points (
+                osm_type character(1) NOT NULL,
+                osm_id bigint NOT NULL,
+                name text,
+                category text NOT NULL,
+                tags jsonb,
+                geom geometry(Point, 4326) NOT NULL,
+                PRIMARY KEY (osm_type, osm_id)
+            )
+            SQL);
+
+        $this->addSql('CREATE INDEX IF NOT EXISTS pois_geom_idx ON osm.pois USING gist (geom)');
+        $this->addSql('CREATE INDEX IF NOT EXISTS pois_category_idx ON osm.pois USING btree (category)');
+        $this->addSql('CREATE INDEX IF NOT EXISTS accommodations_geom_idx ON osm.accommodations USING gist (geom)');
+        $this->addSql('CREATE INDEX IF NOT EXISTS accommodations_category_idx ON osm.accommodations USING btree (category)');
+        $this->addSql('CREATE INDEX IF NOT EXISTS water_points_geom_idx ON osm.water_points USING gist (geom)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP SCHEMA IF EXISTS osm CASCADE');
+    }
+}

--- a/api/src/Osm/AccommodationRepository.php
+++ b/api/src/Osm/AccommodationRepository.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Osm;
+
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+
+/**
+ * Reads accommodations from the local-first Tier-1 index within a radius of the
+ * stage end points (ST_DWithin), replacing the runtime Overpass accommodation
+ * source (ADR-040). DataTourisme/Wikidata enrichment stays in their own sources.
+ */
+final readonly class AccommodationRepository
+{
+    public function __construct(private Connection $connection)
+    {
+    }
+
+    /**
+     * Accommodations of the given categories within $radiusMeters of any point.
+     *
+     * @param list<array{lat: float, lon: float}> $points
+     * @param list<string>                        $categories
+     *
+     * @return list<array{name: ?string, category: string, lat: float, lon: float, stars: ?int, capacity: ?int, fee: ?string, website: ?string, wikidata: ?string, openingHours: ?string, tags: array<string, string>}>
+     */
+    public function findNear(array $points, int $radiusMeters, array $categories): array
+    {
+        if ([] === $points || [] === $categories) {
+            return [];
+        }
+
+        /** @var list<array<string, scalar|null>> $rows */
+        $rows = $this->connection->fetchAllAssociative(
+            <<<'SQL'
+                SELECT name, category, stars, capacity, fee, website, wikidata, opening_hours,
+                       ST_Y(geom) AS lat, ST_X(geom) AS lon, tags
+                FROM osm.accommodations
+                WHERE category IN (:categories)
+                  AND ST_DWithin(
+                      geom::geography,
+                      ST_SetSRID(ST_GeomFromText(:wkt), 4326)::geography,
+                      :radius
+                  )
+                SQL,
+            [
+                'wkt' => WktGeometry::multiPoint($points),
+                'radius' => $radiusMeters,
+                'categories' => $categories,
+            ],
+            [
+                'categories' => ArrayParameterType::STRING,
+            ],
+        );
+
+        $accommodations = [];
+        foreach ($rows as $row) {
+            $accommodations[] = [
+                'name' => null !== $row['name'] ? (string) $row['name'] : null,
+                'category' => (string) $row['category'],
+                'lat' => (float) $row['lat'],
+                'lon' => (float) $row['lon'],
+                'stars' => null !== $row['stars'] ? (int) $row['stars'] : null,
+                'capacity' => null !== $row['capacity'] ? (int) $row['capacity'] : null,
+                'fee' => null !== $row['fee'] ? (string) $row['fee'] : null,
+                'website' => null !== $row['website'] ? (string) $row['website'] : null,
+                'wikidata' => null !== $row['wikidata'] ? (string) $row['wikidata'] : null,
+                'openingHours' => null !== $row['opening_hours'] ? (string) $row['opening_hours'] : null,
+                'tags' => $this->decodeTags($row['tags']),
+            ];
+        }
+
+        return $accommodations;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function decodeTags(mixed $raw): array
+    {
+        if (!\is_string($raw)) {
+            return [];
+        }
+
+        $decoded = json_decode($raw, true);
+        if (!\is_array($decoded)) {
+            return [];
+        }
+
+        $tags = [];
+        foreach ($decoded as $key => $value) {
+            if (is_scalar($value)) {
+                $tags[(string) $key] = (string) $value;
+            }
+        }
+
+        return $tags;
+    }
+}

--- a/api/src/Osm/PoiRepository.php
+++ b/api/src/Osm/PoiRepository.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Osm;
+
+use Doctrine\DBAL\Connection;
+
+/**
+ * Reads points of interest (food, shops, services, sights) from the local-first
+ * Tier-1 index along the route corridor (ST_DWithin), replacing runtime Overpass
+ * POI scans (ADR-040).
+ */
+final readonly class PoiRepository
+{
+    public function __construct(private Connection $connection)
+    {
+    }
+
+    /**
+     * POIs whose geometry is within $radiusMeters of the route corridor.
+     *
+     * @param list<array{lat: float, lon: float}> $route
+     *
+     * @return list<array{name: ?string, category: string, lat: float, lon: float}>
+     */
+    public function findInCorridor(array $route, int $radiusMeters): array
+    {
+        if ([] === $route) {
+            return [];
+        }
+
+        /** @var list<array<string, scalar|null>> $rows */
+        $rows = $this->connection->fetchAllAssociative(
+            <<<'SQL'
+                SELECT name, category, ST_Y(geom) AS lat, ST_X(geom) AS lon
+                FROM osm.pois
+                WHERE ST_DWithin(
+                    geom::geography,
+                    ST_SetSRID(ST_GeomFromText(:wkt), 4326)::geography,
+                    :radius
+                )
+                SQL,
+            [
+                'wkt' => WktGeometry::lineStringOrPoint($route),
+                'radius' => $radiusMeters,
+            ],
+        );
+
+        $pois = [];
+        foreach ($rows as $row) {
+            $pois[] = [
+                'name' => null !== $row['name'] ? (string) $row['name'] : null,
+                'category' => (string) $row['category'],
+                'lat' => (float) $row['lat'],
+                'lon' => (float) $row['lon'],
+            ];
+        }
+
+        return $pois;
+    }
+}

--- a/api/src/Osm/WaterPointRepository.php
+++ b/api/src/Osm/WaterPointRepository.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Osm;
+
+use Doctrine\DBAL\Connection;
+
+/**
+ * Reads real drinking-water points from the local-first Tier-1 index along the
+ * route corridor (ST_DWithin), replacing the runtime Overpass "cemetery proxy"
+ * (ADR-040).
+ *
+ * Every row in osm.water_points is a potable source by construction: the
+ * provisioner flex style (provisioner/osm2pgsql/tier1.lua) only imports
+ * drinking_water, water_point, water_tap and potable fountains/springs. The
+ * query therefore returns all categories rather than filtering to a single one,
+ * which would drop valid taps and springs.
+ */
+final readonly class WaterPointRepository
+{
+    public function __construct(private Connection $connection)
+    {
+    }
+
+    /**
+     * Drinking-water points whose geometry is within $radiusMeters of the route corridor.
+     *
+     * @param list<array{lat: float, lon: float}> $route
+     *
+     * @return list<array{name: ?string, category: string, lat: float, lon: float}>
+     */
+    public function findInCorridor(array $route, int $radiusMeters): array
+    {
+        if ([] === $route) {
+            return [];
+        }
+
+        /** @var list<array<string, scalar|null>> $rows */
+        $rows = $this->connection->fetchAllAssociative(
+            <<<'SQL'
+                SELECT name, category, ST_Y(geom) AS lat, ST_X(geom) AS lon
+                FROM osm.water_points
+                WHERE ST_DWithin(
+                    geom::geography,
+                    ST_SetSRID(ST_GeomFromText(:wkt), 4326)::geography,
+                    :radius
+                )
+                SQL,
+            [
+                'wkt' => WktGeometry::lineStringOrPoint($route),
+                'radius' => $radiusMeters,
+            ],
+        );
+
+        $waterPoints = [];
+        foreach ($rows as $row) {
+            $waterPoints[] = [
+                'name' => null !== $row['name'] ? (string) $row['name'] : null,
+                'category' => (string) $row['category'],
+                'lat' => (float) $row['lat'],
+                'lon' => (float) $row['lon'],
+            ];
+        }
+
+        return $waterPoints;
+    }
+}

--- a/api/src/Osm/WktGeometry.php
+++ b/api/src/Osm/WktGeometry.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Osm;
+
+/**
+ * Builds WKT geometries (lon-lat order) for the local-first PostGIS corridor
+ * queries (ADR-040). WKT uses X Y = longitude latitude.
+ */
+final class WktGeometry
+{
+    /**
+     * The decoded route as a LINESTRING, or a POINT when fewer than two distinct
+     * points are available (ST_GeomFromText rejects a single-vertex LINESTRING).
+     *
+     * @param list<array{lat: float, lon: float}> $points non-empty
+     *
+     * @throws \InvalidArgumentException when $points is empty
+     */
+    public static function lineStringOrPoint(array $points): string
+    {
+        $coords = array_values(array_unique(array_map(
+            static fn (array $p): string => \sprintf('%F %F', $p['lon'], $p['lat']),
+            $points,
+        )));
+
+        if ([] === $coords) {
+            throw new \InvalidArgumentException('lineStringOrPoint() requires at least one point.');
+        }
+
+        if (\count($coords) < 2) {
+            return \sprintf('POINT(%s)', $coords[0]);
+        }
+
+        return \sprintf('LINESTRING(%s)', implode(',', $coords));
+    }
+
+    /**
+     * @param list<array{lat: float, lon: float}> $points non-empty
+     *
+     * @throws \InvalidArgumentException when $points is empty
+     */
+    public static function multiPoint(array $points): string
+    {
+        $coords = array_values(array_unique(array_map(
+            static fn (array $p): string => \sprintf('(%F %F)', $p['lon'], $p['lat']),
+            $points,
+        )));
+
+        if ([] === $coords) {
+            throw new \InvalidArgumentException('multiPoint() requires at least one point.');
+        }
+
+        return \sprintf('MULTIPOINT(%s)', implode(',', $coords));
+    }
+}

--- a/api/tests/Integration/Osm/OsmRepositoriesTest.php
+++ b/api/tests/Integration/Osm/OsmRepositoriesTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Osm;
+
+use App\Osm\AccommodationRepository;
+use App\Osm\PoiRepository;
+use App\Osm\WaterPointRepository;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * Integration coverage for the local-first Tier-1 read layer (ADR-040, #56):
+ * exercises the real PostGIS `osm` schema (created by Version20260614120000)
+ * with seeded rows and asserts the ST_DWithin corridor / radius filtering.
+ *
+ * The repositories are instantiated directly on the real DBAL connection: they
+ * have no consumer until the cut-over PR, so the container would prune them.
+ */
+final class OsmRepositoriesTest extends KernelTestCase
+{
+    use ResetDatabase;
+
+    private Connection $connection;
+
+    private int $osmId = 0;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get('doctrine.dbal.default_connection');
+        $this->connection = $connection;
+
+        // osm.* are not Doctrine entities, so the reset does not clear them.
+        $this->connection->executeStatement('TRUNCATE osm.pois, osm.accommodations, osm.water_points');
+    }
+
+    #[Test]
+    public function poiRepositoryReturnsOnlyPoisWithinTheCorridor(): void
+    {
+        $this->seedPoi('restaurant', 49.61, 6.14, 'On Route');
+        $this->seedPoi('bakery', 49.80, 6.50, 'Far Away');
+
+        $pois = new PoiRepository($this->connection)->findInCorridor([
+            ['lat' => 49.60, 'lon' => 6.13],
+            ['lat' => 49.62, 'lon' => 6.15],
+        ], 2000);
+
+        self::assertCount(1, $pois);
+        self::assertSame('On Route', $pois[0]['name']);
+        self::assertSame('restaurant', $pois[0]['category']);
+        self::assertEqualsWithDelta(49.61, $pois[0]['lat'], 0.0001);
+        self::assertEqualsWithDelta(6.14, $pois[0]['lon'], 0.0001);
+    }
+
+    #[Test]
+    public function waterPointRepositoryReturnsPotablePointsWithinTheCorridor(): void
+    {
+        $this->seedWaterPoint('drinking_water', 49.61, 6.14);
+        $this->seedWaterPoint('water_tap', 49.615, 6.145);  // potable, different category, in corridor
+        $this->seedWaterPoint('spring', 49.80, 6.50);       // out of corridor
+
+        $waterPoints = new WaterPointRepository($this->connection)->findInCorridor([
+            ['lat' => 49.60, 'lon' => 6.13],
+            ['lat' => 49.62, 'lon' => 6.15],
+        ], 2000);
+
+        // Both potable categories in the corridor are returned (no category filter);
+        // the out-of-corridor spring is excluded by ST_DWithin.
+        $categories = array_map(static fn (array $point): string => $point['category'], $waterPoints);
+        self::assertCount(2, $waterPoints);
+        self::assertContains('drinking_water', $categories);
+        self::assertContains('water_tap', $categories);
+    }
+
+    #[Test]
+    public function accommodationRepositoryFiltersByRadiusAndCategory(): void
+    {
+        $this->seedAccommodation('hotel', 49.611, 6.141, 'Near Hotel', 3);
+        $this->seedAccommodation('camp_site', 49.611, 6.141, 'Near Campsite');
+        $this->seedAccommodation('hotel', 49.90, 6.80, 'Far Hotel');
+
+        $accommodations = new AccommodationRepository($this->connection)->findNear([
+            ['lat' => 49.61, 'lon' => 6.14],
+        ], 5000, ['hotel']);
+
+        // Only the near hotel: the far one is out of radius, the campsite is filtered out.
+        self::assertCount(1, $accommodations);
+        self::assertSame('Near Hotel', $accommodations[0]['name']);
+        self::assertSame('hotel', $accommodations[0]['category']);
+        self::assertSame(3, $accommodations[0]['stars']);
+    }
+
+    #[Test]
+    public function emptyRouteOrCategoriesYieldNoQuery(): void
+    {
+        $this->seedPoi('restaurant', 49.61, 6.14);
+
+        self::assertSame([], new PoiRepository($this->connection)->findInCorridor([], 2000));
+        self::assertSame([], new WaterPointRepository($this->connection)->findInCorridor([], 2000));
+        self::assertSame([], new AccommodationRepository($this->connection)->findNear([['lat' => 49.61, 'lon' => 6.14]], 5000, []));
+        self::assertSame([], new AccommodationRepository($this->connection)->findNear([], 5000, ['hotel']));
+    }
+
+    private function seedPoi(string $category, float $lat, float $lon, ?string $name = null): void
+    {
+        $this->connection->executeStatement(
+            <<<'SQL'
+                INSERT INTO osm.pois (osm_type, osm_id, name, category, tags, geom)
+                VALUES ('n', :id, :name, :category, '{}'::jsonb, ST_SetSRID(ST_MakePoint(:lon, :lat), 4326))
+                SQL,
+            ['id' => ++$this->osmId, 'name' => $name, 'category' => $category, 'lon' => $lon, 'lat' => $lat],
+        );
+    }
+
+    private function seedWaterPoint(string $category, float $lat, float $lon): void
+    {
+        $this->connection->executeStatement(
+            <<<'SQL'
+                INSERT INTO osm.water_points (osm_type, osm_id, name, category, tags, geom)
+                VALUES ('n', :id, NULL, :category, '{}'::jsonb, ST_SetSRID(ST_MakePoint(:lon, :lat), 4326))
+                SQL,
+            ['id' => ++$this->osmId, 'category' => $category, 'lon' => $lon, 'lat' => $lat],
+        );
+    }
+
+    private function seedAccommodation(string $category, float $lat, float $lon, ?string $name = null, ?int $stars = null): void
+    {
+        $this->connection->executeStatement(
+            <<<'SQL'
+                INSERT INTO osm.accommodations (osm_type, osm_id, name, category, stars, tags, geom)
+                VALUES ('n', :id, :name, :category, :stars, '{}'::jsonb, ST_SetSRID(ST_MakePoint(:lon, :lat), 4326))
+                SQL,
+            ['id' => ++$this->osmId, 'name' => $name, 'category' => $category, 'stars' => $stars, 'lon' => $lon, 'lat' => $lat],
+        );
+    }
+}

--- a/api/tests/Unit/Osm/WktGeometryTest.php
+++ b/api/tests/Unit/Osm/WktGeometryTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Osm;
+
+use App\Osm\WktGeometry;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class WktGeometryTest extends TestCase
+{
+    #[Test]
+    public function lineStringForTwoOrMoreDistinctPoints(): void
+    {
+        self::assertSame(
+            'LINESTRING(6.130000 49.600000,6.150000 49.620000)',
+            WktGeometry::lineStringOrPoint([
+                ['lat' => 49.60, 'lon' => 6.13],
+                ['lat' => 49.62, 'lon' => 6.15],
+            ]),
+        );
+    }
+
+    #[Test]
+    public function pointWhenAllVerticesCollapseToOne(): void
+    {
+        self::assertSame(
+            'POINT(6.130000 49.600000)',
+            WktGeometry::lineStringOrPoint([
+                ['lat' => 49.60, 'lon' => 6.13],
+                ['lat' => 49.60, 'lon' => 6.13],
+            ]),
+        );
+    }
+
+    #[Test]
+    public function multiPointWrapsEachVertex(): void
+    {
+        self::assertSame(
+            'MULTIPOINT((6.130000 49.600000),(6.150000 49.620000))',
+            WktGeometry::multiPoint([
+                ['lat' => 49.60, 'lon' => 6.13],
+                ['lat' => 49.62, 'lon' => 6.15],
+            ]),
+        );
+    }
+
+    #[Test]
+    public function lineStringOrPointRejectsEmptyInput(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        WktGeometry::lineStringOrPoint([]);
+    }
+
+    #[Test]
+    public function multiPointRejectsEmptyInput(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        WktGeometry::multiPoint([]);
+    }
+}


### PR DESCRIPTION
## Contexte

Fondation de la bascule hors-Overpass (recette #649, Lot D / Tier-1, **PR3a**). Ajoute la **couche de lecture** que les handlers consommeront ; la bascule elle-même (repointage des scan handlers + in-ride, retrait Overpass, correction du faux positif lunch-nudge, eau réelle) est **PR3b**.

## Changements

- **Migration** : crée le schéma `osm` (`pois`, `accommodations`, `water_points`) calqué sur la sortie flex osm2pgsql (`provisioner/osm2pgsql/tier1.lua`), avec index GIST. Elle **bootstrap** le schéma avant le 1er provisioning (l'API renvoie vide au lieu d'erreur) et donne à la DB de test les tables à seeder ; le **swap atomique** du provisioner remplace ensuite par les vraies données en prod.
- `App\Osm\PoiRepository` / `WaterPointRepository` : lecture corridor `ST_DWithin` le long du tracé décodé (LINESTRING).
- `App\Osm\AccommodationRepository` : `ST_DWithin` dans un rayon autour des points d'étape, filtré par catégorie activée.
- `App\Osm\WktGeometry` : constructeur WKT lon-lat (LINESTRING / POINT / MULTIPOINT).
- **Test d'intégration** contre la **vraie DB PostGIS** (#56) : seed `osm.*` + assertions du filtrage corridor / rayon / catégorie.

## Vérification

- Patterns SQL validés contre l'**import réel Luxembourg** : corridor `ST_DWithin` (553 POI), `MULTIPOINT`-rayon + catégorie `IN` (75 hébergements), eau `drinking_water`, décodage `ST_X/ST_Y` + `tags->>`.
- DDL de migration appliquée de façon idempotente.
- `php -l` + `php-cs-fixer` (config api) verts localement.
- Suite PHPUnit complète (dont le test d'intégration PostGIS) : CI.

## Suite (PR3b — cutover)

Repointer `ScanPoisHandler` / `ScanAccommodationsHandler` (via `OsmAccommodationSource`) / `CheckWaterPointsHandler` / `ScanAllOsmDataHandler` + in-ride sur ces repos ; retirer `OsmScanner` + le client Overpass ; **corriger le faux nudge lunch** (plus de vide-sur-erreur) + **eau réelle** (fin du proxy cimetière) ; maj ADR-013/025/026 + README + `ALERT_RULE_MAP`. (DataTourisme/Wikidata/scraping restent intacts. Hors-zone `ST_Covers` après PR2c.)

Refs #649

<!-- claude-review-start -->
## Claude Review

**Commit reviewed:** `bf29ead85756add8f6d2264602566827050804c2`
**Findings:** 0 critical, 0 warnings

**Resolved 1 previously open thread:** `AccommodationRepository::findNear([], …, ['hotel'])` — the empty-points early-return branch is now exercised in `emptyRouteOrCategoriesYieldNoQuery`.

### PR title

`feat(osm): couche de lecture locale PostGIS + schéma osm (ADR-040)` — the description is a French noun phrase rather than English imperative mood. Conventional Commits requires an imperative English description (e.g. `feat(osm): add local PostGIS read layer and osm schema (ADR-040)`). The commit message itself is correctly worded.

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [ ] Dependent tickets accounted for *(ADR-040 update intentionally deferred to PR3b per PR description)*

### Summary

All previous `REQUEST_CHANGES` findings have been resolved: composite PKs are present on every table, `WktGeometry::multiPoint` throws on empty input (with a matching unit test), the `WaterPointRepository` class docblock clarifies the provisioner-level potability guarantee, and both halves of the `AccommodationRepository::findNear` guard (`[] === $points` and `[] === $categories`) are now independently exercised. The read layer is correct, secure (parameterised queries, no SSRF surface), and well-tested against real PostGIS. Ready to merge.

No inline comments.
<!-- claude-review-end -->