### PR TITLE
feat(poi): lecture POI/eau depuis l'index PostGIS local (ADR-040)

### DIFF
--- a/api/src/MessageHandler/ScanPoisHandler.php
+++ b/api/src/MessageHandler/ScanPoisHandler.php
@@ -19,10 +19,10 @@ use App\Geo\GeometryDistributorInterface;
 use App\Mercure\MercureEventType;
 use App\Mercure\TripUpdatePublisherInterface;
 use App\Message\ScanPois;
+use App\Osm\PoiRepositoryInterface;
+use App\Osm\WaterPointRepositoryInterface;
 use App\Poi\SupplyTimelineBuilder;
 use App\Repository\TripRequestRepositoryInterface;
-use App\Scanner\QueryBuilderInterface;
-use App\Scanner\ScannerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -32,6 +32,9 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 final readonly class ScanPoisHandler extends AbstractTripMessageHandler
 {
     private const float LUNCH_NUDGE_DISTANCE_KM = 40.0;
+
+    /** Corridor half-width (m) for the local-first POI/water reads (ADR-040), matching the former Overpass "around" radius. */
+    private const int CORRIDOR_RADIUS_METERS = 2000;
 
     /** @var list<string> */
     private const array RESUPPLY_CATEGORIES = [
@@ -46,8 +49,8 @@ final readonly class ScanPoisHandler extends AbstractTripMessageHandler
         TripGenerationTrackerInterface $generationTracker,
         LoggerInterface $logger,
         private TripRequestRepositoryInterface $tripStateManager,
-        private ScannerInterface $scanner,
-        private QueryBuilderInterface $queryBuilder,
+        private PoiRepositoryInterface $poiRepository,
+        private WaterPointRepositoryInterface $waterPointRepository,
         private GeometryDistributorInterface $distributor,
         private SupplyTimelineBuilder $supplyTimelineBuilder,
         private RiderTimeEstimatorInterface $riderTimeEstimator,
@@ -73,7 +76,7 @@ final readonly class ScanPoisHandler extends AbstractTripMessageHandler
         $averageSpeed = $request instanceof TripRequest ? $request->averageSpeed : 15.0;
 
         $this->executeWithTracking($tripId, ComputationName::POIS, function () use ($tripId, $stages, $locale, $departureHour, $averageSpeed): void {
-            // Use decimated route points so the POI query matches the one warmed by ScanAllOsmDataHandler
+            // Decode the route corridor from the decimated points (fallback: stage geometry).
             $decimatedData = $this->tripStateManager->getDecimatedPoints($tripId);
             $allPoints = null !== $decimatedData
                 ? array_map(static fn (array $p): Coordinate => new Coordinate($p['lat'], $p['lon'], $p['ele']), $decimatedData)
@@ -82,67 +85,28 @@ final readonly class ScanPoisHandler extends AbstractTripMessageHandler
                     $stages,
                 ));
 
-            // Single POI query over all decimated points (cache-aligned with ScanAllOsmData)
-            // + one global cemetery query — both benefit from the warming cache
-            $results = $this->scanner->queryBatch([
-                'poi' => $this->queryBuilder->buildPoiQuery($allPoints),
-                'cemetery' => $this->queryBuilder->buildCemeteryQuery($allPoints),
-            ]);
+            $route = array_map(static fn (Coordinate $point): array => ['lat' => $point->lat, 'lon' => $point->lon], $allPoints);
 
-            // Parse all POIs from the single global query, then distribute to stages via geometry
-            $poiResult = $results['poi'] ?? [];
-            /** @var list<array{tags?: array<string, string>, lat?: float, lon?: float, center?: array{lat: float, lon: float}}> $elements */
-            $elements = \is_array($poiResult['elements'] ?? null) ? $poiResult['elements'] : [];
-
-            /** @var list<array{name: string, category: string, lat: float, lon: float}> $allPois */
+            // Read POIs and real drinking-water points from the local-first index along the
+            // route corridor (ADR-040), then distribute them to stages by geometry. The local
+            // index returns deterministic results, so a long stage with genuinely no resupply
+            // POI is no longer indistinguishable from an Overpass failure (lunch-nudge fix).
             $allPois = [];
-            foreach ($elements as $element) {
-                $tags = $element['tags'] ?? [];
-                $lat = $element['lat'] ?? ($element['center']['lat'] ?? null);
-                $lon = $element['lon'] ?? ($element['center']['lon'] ?? null);
-
-                if (null === $lat || null === $lon) {
-                    continue;
-                }
-
-                $category = $tags['amenity'] ?? $tags['shop'] ?? $tags['tourism'] ?? 'unknown';
-                $name = $tags['name'] ?? $category;
-
+            foreach ($this->poiRepository->findInCorridor($route, self::CORRIDOR_RADIUS_METERS) as $poi) {
                 $allPois[] = [
-                    'name' => $name,
-                    'category' => $category,
-                    'lat' => (float) $lat,
-                    'lon' => (float) $lon,
+                    'name' => $poi['name'] ?? $poi['category'],
+                    'category' => $poi['category'],
+                    'lat' => $poi['lat'],
+                    'lon' => $poi['lon'],
                 ];
             }
 
             /** @var array<int, list<array{name: string, category: string, lat: float, lon: float}>> $poisByStage */
             $poisByStage = $this->distributor->distributeByGeometry($allPois, $stages);
 
-            // Parse water points (cemeteries) for supply timeline
-            $cemeteryResult = $results['cemetery'] ?? [];
-            /** @var list<array{tags?: array<string, string>, lat?: float, lon?: float, center?: array{lat: float, lon: float}}> $cemeteryElements */
-            $cemeteryElements = \is_array($cemeteryResult['elements'] ?? null) ? $cemeteryResult['elements'] : [];
-            $allWaterPoints = [];
-            foreach ($cemeteryElements as $element) {
-                $lat = $element['lat'] ?? ($element['center']['lat'] ?? null);
-                $lon = $element['lon'] ?? ($element['center']['lon'] ?? null);
-                $tags = $element['tags'] ?? [];
-                $name = $tags['name'] ?? null;
+            $allWaterPoints = $this->waterPointRepository->findInCorridor($route, self::CORRIDOR_RADIUS_METERS);
 
-                if (null === $lat || null === $lon) {
-                    continue;
-                }
-
-                $allWaterPoints[] = [
-                    'name' => $name,
-                    'lat' => (float) $lat,
-                    'lon' => (float) $lon,
-                ];
-            }
-
-            // Distribute water points to their nearest stage by geometry
-            /** @var array<int, list<array{name: string|null, lat: float, lon: float}>> $waterByStage */
+            /** @var array<int, list<array{name: string|null, category: string, lat: float, lon: float}>> $waterByStage */
             $waterByStage = $this->distributor->distributeByGeometry($allWaterPoints, $stages);
 
             foreach ($stages as $i => $stage) {

--- a/api/src/Osm/PoiRepository.php
+++ b/api/src/Osm/PoiRepository.php
@@ -11,7 +11,7 @@ use Doctrine\DBAL\Connection;
  * Tier-1 index along the route corridor (ST_DWithin), replacing runtime Overpass
  * POI scans (ADR-040).
  */
-final readonly class PoiRepository
+final readonly class PoiRepository implements PoiRepositoryInterface
 {
     public function __construct(private Connection $connection)
     {

--- a/api/src/Osm/PoiRepositoryInterface.php
+++ b/api/src/Osm/PoiRepositoryInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Osm;
+
+interface PoiRepositoryInterface
+{
+    /**
+     * POIs whose geometry is within $radiusMeters of the route corridor.
+     *
+     * @param list<array{lat: float, lon: float}> $route
+     *
+     * @return list<array{name: ?string, category: string, lat: float, lon: float}>
+     */
+    public function findInCorridor(array $route, int $radiusMeters): array;
+}

--- a/api/src/Osm/WaterPointRepository.php
+++ b/api/src/Osm/WaterPointRepository.php
@@ -17,7 +17,7 @@ use Doctrine\DBAL\Connection;
  * query therefore returns all categories rather than filtering to a single one,
  * which would drop valid taps and springs.
  */
-final readonly class WaterPointRepository
+final readonly class WaterPointRepository implements WaterPointRepositoryInterface
 {
     public function __construct(private Connection $connection)
     {

--- a/api/src/Osm/WaterPointRepositoryInterface.php
+++ b/api/src/Osm/WaterPointRepositoryInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Osm;
+
+interface WaterPointRepositoryInterface
+{
+    /**
+     * Drinking-water points whose geometry is within $radiusMeters of the route corridor.
+     *
+     * @param list<array{lat: float, lon: float}> $route
+     *
+     * @return list<array{name: ?string, category: string, lat: float, lon: float}>
+     */
+    public function findInCorridor(array $route, int $radiusMeters): array;
+}

--- a/api/tests/Integration/Osm/ScanPoisCorridorTest.php
+++ b/api/tests/Integration/Osm/ScanPoisCorridorTest.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Osm;
+
+use App\ApiResource\Model\Alert;
+use App\ApiResource\Model\Coordinate;
+use App\ApiResource\Model\PointOfInterest;
+use App\ApiResource\Stage;
+use App\ApiResource\TripRequest;
+use App\ComputationTracker\ComputationTrackerInterface;
+use App\ComputationTracker\TripGenerationTrackerInterface;
+use App\Engine\RiderTimeEstimatorInterface;
+use App\Enum\AlertType;
+use App\Geo\GeometryBasedDistributor;
+use App\Geo\HaversineDistance;
+use App\Mercure\TripUpdatePublisherInterface;
+use App\Message\ScanPois;
+use App\MessageHandler\ScanPoisHandler;
+use App\Osm\PoiRepository;
+use App\Osm\WaterPointRepository;
+use App\Poi\SupplyTimelineBuilder;
+use App\Repository\TripRequestRepositoryInterface;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Log\NullLogger;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * End-to-end coverage of the local-first POI/water cut-over (ADR-040): runs the
+ * real ScanPoisHandler against real PoiRepository/WaterPointRepository on a
+ * PostGIS test DB seeded with committed osm fixtures, proving that POIs are
+ * detected from the index and that the lunch nudge fires from deterministic data
+ * (no more empty-on-error false positive) — only when no resupply POI is in range.
+ */
+final class ScanPoisCorridorTest extends KernelTestCase
+{
+    use ResetDatabase;
+
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get('doctrine.dbal.default_connection');
+        $this->connection = $connection;
+
+        $this->connection->executeStatement('TRUNCATE osm.pois, osm.accommodations, osm.water_points');
+
+        // Committed SQL fixtures (ADR-040 / #56). Corridor A (49.61, 6.14) carries a
+        // resupply POI + drinking water; corridor B (50.00, 7.00) carries only a
+        // non-resupply POI. The tests pick a corridor by routing a stage near A or B.
+        $this->connection->executeStatement(<<<'SQL'
+            INSERT INTO osm.pois (osm_type, osm_id, name, category, tags, geom) VALUES
+              ('n', 9001, 'Le Bistrot', 'restaurant', '{}'::jsonb, ST_SetSRID(ST_MakePoint(6.14, 49.61), 4326)),
+              ('n', 9002, 'Belvedere', 'viewpoint', '{}'::jsonb, ST_SetSRID(ST_MakePoint(7.00, 50.00), 4326))
+            SQL);
+        $this->connection->executeStatement(<<<'SQL'
+            INSERT INTO osm.water_points (osm_type, osm_id, name, category, tags, geom) VALUES
+              ('n', 9003, NULL, 'drinking_water', '{}'::jsonb, ST_SetSRID(ST_MakePoint(6.14, 49.61), 4326))
+            SQL);
+    }
+
+    #[Test]
+    public function resupplyPoiInCorridorSuppressesLunchNudge(): void
+    {
+        // Corridor A carries a restaurant → the 50 km stage must NOT get a lunch nudge.
+        $route = [
+            ['lat' => 49.60, 'lon' => 6.13],
+            ['lat' => 49.61, 'lon' => 6.14],
+            ['lat' => 49.62, 'lon' => 6.15],
+        ];
+        $stage = $this->stageOnRoute($route);
+        $this->runScan($route, $stage);
+
+        self::assertContains(
+            'restaurant',
+            array_map(static fn (PointOfInterest $poi): string => $poi->category, $stage->pois),
+            'The seeded restaurant in the corridor must be detected from the local index',
+        );
+        self::assertFalse(
+            array_any($stage->alerts, static fn (Alert $alert): bool => AlertType::NUDGE === $alert->type),
+            'A long stage with a resupply POI in the corridor must not raise the lunch nudge',
+        );
+    }
+
+    #[Test]
+    public function longStageWithoutResupplyPoiEmitsLunchNudge(): void
+    {
+        // Corridor B carries only a viewpoint (no resupply) → lunch nudge fires.
+        $route = [
+            ['lat' => 49.99, 'lon' => 6.99],
+            ['lat' => 50.00, 'lon' => 7.00],
+            ['lat' => 50.01, 'lon' => 7.01],
+        ];
+        $stage = $this->stageOnRoute($route);
+        $this->runScan($route, $stage);
+
+        self::assertContains(
+            'viewpoint',
+            array_map(static fn (PointOfInterest $poi): string => $poi->category, $stage->pois),
+        );
+        self::assertTrue(
+            array_any($stage->alerts, static fn (Alert $alert): bool => AlertType::NUDGE === $alert->type),
+            'A long stage with no resupply POI in the corridor must raise the lunch nudge',
+        );
+    }
+
+    /**
+     * @param list<array{lat: float, lon: float}> $route
+     */
+    private function stageOnRoute(array $route): Stage
+    {
+        $geometry = array_map(static fn (array $point): Coordinate => new Coordinate($point['lat'], $point['lon']), $route);
+
+        return new Stage(
+            tripId: 'trip-1',
+            dayNumber: 1,
+            distance: 50.0, // >= ScanPoisHandler::LUNCH_NUDGE_DISTANCE_KM
+            elevation: 300.0,
+            startPoint: $geometry[0],
+            endPoint: $geometry[\count($geometry) - 1],
+            geometry: $geometry,
+        );
+    }
+
+    /**
+     * @param list<array{lat: float, lon: float}> $route
+     */
+    private function runScan(array $route, Stage $stage): void
+    {
+        $decimated = array_map(
+            static fn (array $point): array => ['lat' => $point['lat'], 'lon' => $point['lon'], 'ele' => 0.0],
+            $route,
+        );
+
+        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
+        $tripStateManager->method('getStages')->willReturn([$stage]);
+        $tripStateManager->method('getLocale')->willReturn('en');
+        $tripStateManager->method('getRequest')->willReturn(new TripRequest());
+        $tripStateManager->method('getDecimatedPoints')->willReturn($decimated);
+
+        $computationTracker = $this->createStub(ComputationTrackerInterface::class);
+        $computationTracker->method('getProgress')->willReturn(['completed' => 0, 'failed' => 0, 'total' => 1]);
+
+        $translator = $this->createStub(TranslatorInterface::class);
+        $translator->method('trans')->willReturnCallback(static fn (string $id): string => $id);
+
+        $publisher = $this->createStub(TripUpdatePublisherInterface::class);
+
+        $haversine = new HaversineDistance();
+
+        $handler = new ScanPoisHandler(
+            $computationTracker,
+            $publisher,
+            $this->createStub(TripGenerationTrackerInterface::class),
+            new NullLogger(),
+            $tripStateManager,
+            new PoiRepository($this->connection),
+            new WaterPointRepository($this->connection),
+            new GeometryBasedDistributor($haversine),
+            new SupplyTimelineBuilder($haversine),
+            $this->createStub(RiderTimeEstimatorInterface::class),
+            $translator,
+            $this->createStub(MessageBusInterface::class),
+        );
+
+        $handler(new ScanPois('trip-1'));
+    }
+}

--- a/api/tests/Unit/MessageHandler/ScanPoisHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/ScanPoisHandlerTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\MessageHandler;
 
-use PHPUnit\Framework\MockObject\Stub;
 use App\ApiResource\Model\Coordinate;
 use App\ApiResource\Stage;
 use App\ApiResource\TripRequest;
@@ -17,11 +16,12 @@ use App\Mercure\MercureEventType;
 use App\Mercure\TripUpdatePublisherInterface;
 use App\Message\ScanPois;
 use App\MessageHandler\ScanPoisHandler;
+use App\Osm\PoiRepositoryInterface;
+use App\Osm\WaterPointRepositoryInterface;
 use App\Poi\SupplyTimelineBuilder;
 use App\Repository\TripRequestRepositoryInterface;
-use App\Scanner\QueryBuilderInterface;
-use App\Scanner\ScannerInterface;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -52,8 +52,8 @@ final class ScanPoisHandlerTest extends TestCase
     private function createHandler(
         TripRequestRepositoryInterface $tripStateManager,
         TripUpdatePublisherInterface $publisher,
-        ScannerInterface $scanner,
-        QueryBuilderInterface $queryBuilder,
+        PoiRepositoryInterface $poiRepository,
+        WaterPointRepositoryInterface $waterPointRepository,
         GeometryDistributorInterface $distributor,
         GeoDistanceInterface $haversine,
         RiderTimeEstimatorInterface $riderTimeEstimator,
@@ -74,8 +74,8 @@ final class ScanPoisHandlerTest extends TestCase
             $generationTracker,
             new NullLogger(),
             $tripStateManager,
-            $scanner,
-            $queryBuilder,
+            $poiRepository,
+            $waterPointRepository,
             $distributor,
             new SupplyTimelineBuilder($haversine),
             $riderTimeEstimator,
@@ -105,14 +105,32 @@ final class ScanPoisHandlerTest extends TestCase
     }
 
     /**
-     * @return array{QueryBuilderInterface&Stub, GeoDistanceInterface&Stub, RiderTimeEstimatorInterface&Stub}
+     * @param list<array{name: ?string, category: string, lat: float, lon: float}> $pois
+     */
+    private function poiRepository(array $pois): PoiRepositoryInterface
+    {
+        $repository = $this->createStub(PoiRepositoryInterface::class);
+        $repository->method('findInCorridor')->willReturn($pois);
+
+        return $repository;
+    }
+
+    /**
+     * @param list<array{name: ?string, category: string, lat: float, lon: float}> $waterPoints
+     */
+    private function waterPointRepository(array $waterPoints = []): WaterPointRepositoryInterface
+    {
+        $repository = $this->createStub(WaterPointRepositoryInterface::class);
+        $repository->method('findInCorridor')->willReturn($waterPoints);
+
+        return $repository;
+    }
+
+    /**
+     * @return array{GeoDistanceInterface&Stub, RiderTimeEstimatorInterface&Stub}
      */
     private function createDefaultStubs(): array
     {
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildPoiQuery')->willReturn('query');
-        $queryBuilder->method('buildCemeteryQuery')->willReturn('cemetery_query');
-
         $haversine = $this->createStub(GeoDistanceInterface::class);
         $haversine->method('inKilometers')->willReturn(10.0);
         $haversine->method('inMeters')->willReturnCallback(
@@ -121,26 +139,18 @@ final class ScanPoisHandlerTest extends TestCase
 
         $riderTimeEstimator = $this->createStub(RiderTimeEstimatorInterface::class);
 
-        return [$queryBuilder, $haversine, $riderTimeEstimator];
+        return [$haversine, $riderTimeEstimator];
     }
 
     #[Test]
     public function allResupplyPoisClosedAtEstimatedTimeEmitsWarning(): void
     {
         $stage = $this->createStage('trip-1', 1, 80.0);
-
-        // Pre-populate with two resupply POIs (restaurant category)
         $tripStateManager = $this->createTripStateManager([$stage]);
 
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('queryBatch')->willReturn([
-            'poi' => [
-                'elements' => [
-                    ['lat' => 48.2, 'lon' => 2.2, 'tags' => ['amenity' => 'restaurant', 'name' => 'Le Bistrot']],
-                    ['lat' => 48.3, 'lon' => 2.3, 'tags' => ['amenity' => 'restaurant', 'name' => 'Chez Paul']],
-                ],
-            ],
-            'cemetery' => ['elements' => []],
+        $poiRepository = $this->poiRepository([
+            ['name' => 'Le Bistrot', 'category' => 'restaurant', 'lat' => 48.2, 'lon' => 2.2],
+            ['name' => 'Chez Paul', 'category' => 'restaurant', 'lat' => 48.3, 'lon' => 2.3],
         ]);
 
         $distributor = $this->createStub(GeometryDistributorInterface::class);
@@ -152,10 +162,9 @@ final class ScanPoisHandlerTest extends TestCase
             [],
         );
 
-        [$queryBuilder, $haversine, $riderTimeEstimator] = $this->createDefaultStubs();
+        [$haversine, $riderTimeEstimator] = $this->createDefaultStubs();
 
-        // Return a time outside restaurant hours (restaurants: 12-14, 19-22)
-        // Return 16.0 (4 PM) → closed for both restaurants
+        // 16:00 → both restaurants closed (restaurants: 12-14, 19-22)
         $riderTimeEstimator->method('estimateTimeAtDistance')->willReturn(16.0);
 
         $publishedEvents = [];
@@ -165,7 +174,7 @@ final class ScanPoisHandlerTest extends TestCase
                 $publishedEvents[] = ['tripId' => $tripId, 'type' => $type, 'payload' => $payload];
             });
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $distributor, $haversine, $riderTimeEstimator);
+        $handler = $this->createHandler($tripStateManager, $publisher, $poiRepository, $this->waterPointRepository(), $distributor, $haversine, $riderTimeEstimator);
         $handler(new ScanPois('trip-1'));
 
         $poisScannedEvents = array_filter($publishedEvents, static fn (array $e): bool => MercureEventType::POIS_SCANNED === $e['type']);
@@ -182,18 +191,11 @@ final class ScanPoisHandlerTest extends TestCase
     public function atLeastOneOpenResupplyPoiEmitsNoTimingWarning(): void
     {
         $stage = $this->createStage('trip-1', 1, 80.0);
-
         $tripStateManager = $this->createTripStateManager([$stage]);
 
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('queryBatch')->willReturn([
-            'poi' => [
-                'elements' => [
-                    ['lat' => 48.2, 'lon' => 2.2, 'tags' => ['amenity' => 'restaurant', 'name' => 'Le Bistrot']],
-                    ['lat' => 48.3, 'lon' => 2.3, 'tags' => ['shop' => 'supermarket', 'name' => 'Carrefour']],
-                ],
-            ],
-            'cemetery' => ['elements' => []],
+        $poiRepository = $this->poiRepository([
+            ['name' => 'Le Bistrot', 'category' => 'restaurant', 'lat' => 48.2, 'lon' => 2.2],
+            ['name' => 'Carrefour', 'category' => 'supermarket', 'lat' => 48.3, 'lon' => 2.3],
         ]);
 
         $distributor = $this->createStub(GeometryDistributorInterface::class);
@@ -205,9 +207,9 @@ final class ScanPoisHandlerTest extends TestCase
             [],
         );
 
-        [$queryBuilder, $haversine, $riderTimeEstimator] = $this->createDefaultStubs();
+        [$haversine, $riderTimeEstimator] = $this->createDefaultStubs();
 
-        // Return 15.0 (3 PM) → restaurant closed, but supermarket open (9-20)
+        // 15:00 → restaurant closed, supermarket open (9-20)
         $riderTimeEstimator->method('estimateTimeAtDistance')->willReturn(15.0);
 
         $publishedEvents = [];
@@ -217,7 +219,7 @@ final class ScanPoisHandlerTest extends TestCase
                 $publishedEvents[] = ['tripId' => $tripId, 'type' => $type, 'payload' => $payload];
             });
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $distributor, $haversine, $riderTimeEstimator);
+        $handler = $this->createHandler($tripStateManager, $publisher, $poiRepository, $this->waterPointRepository(), $distributor, $haversine, $riderTimeEstimator);
         $handler(new ScanPois('trip-1'));
 
         $poisScannedEvents = array_filter($publishedEvents, static fn (array $e): bool => MercureEventType::POIS_SCANNED === $e['type']);
@@ -233,19 +235,11 @@ final class ScanPoisHandlerTest extends TestCase
     #[Test]
     public function noResupplyPoisEmitsNoTimingWarning(): void
     {
-        // Stage with only non-resupply POIs (tourism category)
         $stage = $this->createStage('trip-1', 1, 80.0);
-
         $tripStateManager = $this->createTripStateManager([$stage]);
 
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('queryBatch')->willReturn([
-            'poi' => [
-                'elements' => [
-                    ['lat' => 48.2, 'lon' => 2.2, 'tags' => ['tourism' => 'viewpoint', 'name' => 'Belvedere']],
-                ],
-            ],
-            'cemetery' => ['elements' => []],
+        $poiRepository = $this->poiRepository([
+            ['name' => 'Belvedere', 'category' => 'viewpoint', 'lat' => 48.2, 'lon' => 2.2],
         ]);
 
         $distributor = $this->createStub(GeometryDistributorInterface::class);
@@ -256,7 +250,7 @@ final class ScanPoisHandlerTest extends TestCase
             [],
         );
 
-        [$queryBuilder, $haversine, $riderTimeEstimator] = $this->createDefaultStubs();
+        [$haversine, $riderTimeEstimator] = $this->createDefaultStubs();
 
         $publishedEvents = [];
         $publisher = $this->createStub(TripUpdatePublisherInterface::class);
@@ -265,7 +259,7 @@ final class ScanPoisHandlerTest extends TestCase
                 $publishedEvents[] = ['tripId' => $tripId, 'type' => $type, 'payload' => $payload];
             });
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $distributor, $haversine, $riderTimeEstimator);
+        $handler = $this->createHandler($tripStateManager, $publisher, $poiRepository, $this->waterPointRepository(), $distributor, $haversine, $riderTimeEstimator);
         $handler(new ScanPois('trip-1'));
 
         $poisScannedEvents = array_filter($publishedEvents, static fn (array $e): bool => MercureEventType::POIS_SCANNED === $e['type']);
@@ -286,32 +280,24 @@ final class ScanPoisHandlerTest extends TestCase
         $publisher = $this->createMock(TripUpdatePublisherInterface::class);
         $publisher->expects($this->never())->method('publish');
 
-        $scanner = $this->createStub(ScannerInterface::class);
-        [$queryBuilder, $haversine, $riderTimeEstimator] = $this->createDefaultStubs();
+        [$haversine, $riderTimeEstimator] = $this->createDefaultStubs();
         $distributor = $this->createStub(GeometryDistributorInterface::class);
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $distributor, $haversine, $riderTimeEstimator);
+        $handler = $this->createHandler($tripStateManager, $publisher, $this->poiRepository([]), $this->waterPointRepository(), $distributor, $haversine, $riderTimeEstimator);
         $handler(new ScanPois('trip-1'));
     }
 
     #[Test]
     public function lunchNudgeEmittedForLongStageWithoutResupplyPois(): void
     {
-        // Stage >= 40km with no resupply POIs → lunch nudge
+        // Stage >= 40km with no resupply POIs in the local index → lunch nudge
         $stage = $this->createStage('trip-1', 1, 50.0);
-
         $tripStateManager = $this->createTripStateManager([$stage]);
-
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('queryBatch')->willReturn([
-            'poi' => ['elements' => []],
-            'cemetery' => ['elements' => []],
-        ]);
 
         $distributor = $this->createStub(GeometryDistributorInterface::class);
         $distributor->method('distributeByGeometry')->willReturn([]);
 
-        [$queryBuilder, $haversine, $riderTimeEstimator] = $this->createDefaultStubs();
+        [$haversine, $riderTimeEstimator] = $this->createDefaultStubs();
 
         $publishedEvents = [];
         $publisher = $this->createStub(TripUpdatePublisherInterface::class);
@@ -320,7 +306,7 @@ final class ScanPoisHandlerTest extends TestCase
                 $publishedEvents[] = ['tripId' => $tripId, 'type' => $type, 'payload' => $payload];
             });
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $distributor, $haversine, $riderTimeEstimator);
+        $handler = $this->createHandler($tripStateManager, $publisher, $this->poiRepository([]), $this->waterPointRepository(), $distributor, $haversine, $riderTimeEstimator);
         $handler(new ScanPois('trip-1'));
 
         $poisScannedEvents = array_filter($publishedEvents, static fn (array $e): bool => MercureEventType::POIS_SCANNED === $e['type']);
@@ -334,19 +320,11 @@ final class ScanPoisHandlerTest extends TestCase
     #[Test]
     public function resolveScheduleMapsBakeryCorrectly(): void
     {
-        // Bakery open 7-13 and 15-19; test at 10:00 → open, no warning
         $stage = $this->createStage('trip-1', 1, 80.0);
-
         $tripStateManager = $this->createTripStateManager([$stage]);
 
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('queryBatch')->willReturn([
-            'poi' => [
-                'elements' => [
-                    ['lat' => 48.2, 'lon' => 2.2, 'tags' => ['shop' => 'bakery', 'name' => 'Boulangerie']],
-                ],
-            ],
-            'cemetery' => ['elements' => []],
+        $poiRepository = $this->poiRepository([
+            ['name' => 'Boulangerie', 'category' => 'bakery', 'lat' => 48.2, 'lon' => 2.2],
         ]);
 
         $distributor = $this->createStub(GeometryDistributorInterface::class);
@@ -357,9 +335,9 @@ final class ScanPoisHandlerTest extends TestCase
             [],
         );
 
-        [$queryBuilder, $haversine, $riderTimeEstimator] = $this->createDefaultStubs();
+        [$haversine, $riderTimeEstimator] = $this->createDefaultStubs();
 
-        // 10:00 AM → bakery open (7-13 slot)
+        // 10:00 → bakery open (7-13 slot)
         $riderTimeEstimator->method('estimateTimeAtDistance')->willReturn(10.0);
 
         $publishedEvents = [];
@@ -369,7 +347,7 @@ final class ScanPoisHandlerTest extends TestCase
                 $publishedEvents[] = ['tripId' => $tripId, 'type' => $type, 'payload' => $payload];
             });
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $distributor, $haversine, $riderTimeEstimator);
+        $handler = $this->createHandler($tripStateManager, $publisher, $poiRepository, $this->waterPointRepository(), $distributor, $haversine, $riderTimeEstimator);
         $handler(new ScanPois('trip-1'));
 
         $poisScannedEvents = array_filter($publishedEvents, static fn (array $e): bool => MercureEventType::POIS_SCANNED === $e['type']);
@@ -385,22 +363,13 @@ final class ScanPoisHandlerTest extends TestCase
     #[Test]
     public function poisWithin500mAreClusteredIntoSingleMarker(): void
     {
-        // Two restaurants very close (< 500m apart) → grouped into one marker
-        // One restaurant far away (> 500m from the others) → distinct marker
         $stage = $this->createStage('trip-1', 1, 80.0);
-
         $tripStateManager = $this->createTripStateManager([$stage]);
 
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('queryBatch')->willReturn([
-            'poi' => [
-                'elements' => [
-                    ['lat' => 48.2, 'lon' => 2.2, 'tags' => ['amenity' => 'restaurant', 'name' => 'Bistrot A']],
-                    ['lat' => 48.2, 'lon' => 2.2001, 'tags' => ['amenity' => 'restaurant', 'name' => 'Bistrot B']],
-                    ['lat' => 48.5, 'lon' => 2.5, 'tags' => ['amenity' => 'restaurant', 'name' => 'Remote Bistrot']],
-                ],
-            ],
-            'cemetery' => ['elements' => []],
+        $poiRepository = $this->poiRepository([
+            ['name' => 'Bistrot A', 'category' => 'restaurant', 'lat' => 48.2, 'lon' => 2.2],
+            ['name' => 'Bistrot B', 'category' => 'restaurant', 'lat' => 48.2, 'lon' => 2.2001],
+            ['name' => 'Remote Bistrot', 'category' => 'restaurant', 'lat' => 48.5, 'lon' => 2.5],
         ]);
 
         $distributor = $this->createStub(GeometryDistributorInterface::class);
@@ -413,25 +382,19 @@ final class ScanPoisHandlerTest extends TestCase
             [],
         );
 
-        [$queryBuilder, $riderTimeEstimator] = [$this->createStub(QueryBuilderInterface::class), $this->createStub(RiderTimeEstimatorInterface::class)];
-        $queryBuilder->method('buildPoiQuery')->willReturn('query');
-        $queryBuilder->method('buildCemeteryQuery')->willReturn('cemetery_query');
-
         $haversine = $this->createStub(GeoDistanceInterface::class);
-        // inKilometers used for cumulative distances along geometry
         $haversine->method('inKilometers')->willReturn(10.0);
-        // inMeters: return < 500 for nearby POIs, > 500 for distant ones
         $haversine->method('inMeters')->willReturnCallback(
             static function (float $lat1, float $lon1, float $lat2, float $lon2): float {
-                // Same coordinates or very close (Bistrot A & B)
                 if ($lat1 === $lat2 && abs($lon1 - $lon2) < 0.001) {
                     return 10.0; // within 500m
                 }
 
-                // Distance between close cluster and remote POI
-                return 40000.0; // far apart (> 500m)
+                return 40000.0; // far apart
             },
         );
+
+        $riderTimeEstimator = $this->createStub(RiderTimeEstimatorInterface::class);
 
         $publishedEvents = [];
         $publisher = $this->createStub(TripUpdatePublisherInterface::class);
@@ -440,15 +403,13 @@ final class ScanPoisHandlerTest extends TestCase
                 $publishedEvents[] = ['tripId' => $tripId, 'type' => $type, 'payload' => $payload];
             });
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $distributor, $haversine, $riderTimeEstimator);
+        $handler = $this->createHandler($tripStateManager, $publisher, $poiRepository, $this->waterPointRepository(), $distributor, $haversine, $riderTimeEstimator);
         $handler(new ScanPois('trip-1'));
 
         $timelineEvents = array_filter($publishedEvents, static fn (array $e): bool => MercureEventType::SUPPLY_TIMELINE === $e['type']);
         self::assertCount(1, $timelineEvents);
 
         $markers = array_first($timelineEvents)['payload']['markers'];
-
-        // Bistrot A and B are within 500m → one marker; Remote Bistrot is far → another marker
         self::assertCount(2, $markers, 'Expected 2 markers: one cluster for close POIs, one for the remote POI');
         self::assertSame('food', $markers[0]['type']);
         self::assertCount(2, $markers[0]['food'], 'Expected 2 food items in the clustered marker');
@@ -457,52 +418,32 @@ final class ScanPoisHandlerTest extends TestCase
     }
 
     #[Test]
-    public function poiQueryUsesDecimatedPointsForCacheAlignment(): void
+    public function poiRepositoryQueriedWithDecimatedRouteCorridor(): void
     {
         $stage1 = $this->createStage('trip-1', 1, 50.0);
         $stage2 = $this->createStage('trip-1', 2, 50.0);
-
         $tripStateManager = $this->createTripStateManager([$stage1, $stage2]);
 
-        $queryBuilder = $this->createMock(QueryBuilderInterface::class);
-        // buildPoiQuery should be called once with all decimated points (cache-aligned with ScanAllOsmData)
-        $queryBuilder->expects($this->once())
-            ->method('buildPoiQuery')
-            ->with($this->callback(static fn (array $points): bool => 2 === \count($points)
-                && $points[0] instanceof Coordinate
-                && 48.0 === $points[0]->lat
-                && 2.0 === $points[0]->lon
-                && $points[1] instanceof Coordinate
-                && 48.5 === $points[1]->lat
-                && 2.5 === $points[1]->lon))
-            ->willReturn('global_poi_query');
-        $queryBuilder->method('buildCemeteryQuery')->willReturn('cemetery_query');
-
-        $scanner = $this->createMock(ScannerInterface::class);
-        $scanner->expects($this->once())
-            ->method('queryBatch')
-            ->with($this->callback(
-                // Must have a single 'poi' key and 'cemetery' key (not per-stage keys)
-                static fn (array $queries): bool => isset($queries['poi'], $queries['cemetery'])
-                && 2 === \count($queries)
-            ))
-            ->willReturn([
-                'poi' => ['elements' => []],
-                'cemetery' => ['elements' => []],
-            ]);
+        // The corridor read uses the decimated points as a {lat, lon} route.
+        $poiRepository = $this->createMock(PoiRepositoryInterface::class);
+        $poiRepository->expects($this->once())
+            ->method('findInCorridor')
+            ->with(
+                $this->callback(static fn (array $route): bool => [
+                    ['lat' => 48.0, 'lon' => 2.0],
+                    ['lat' => 48.5, 'lon' => 2.5],
+                ] === $route),
+                $this->greaterThan(0),
+            )
+            ->willReturn([]);
 
         $distributor = $this->createStub(GeometryDistributorInterface::class);
         $distributor->method('distributeByGeometry')->willReturn([]);
 
-        $haversine = $this->createStub(GeoDistanceInterface::class);
-        $haversine->method('inKilometers')->willReturn(10.0);
-        $haversine->method('inMeters')->willReturn(10000.0);
-
-        $riderTimeEstimator = $this->createStub(RiderTimeEstimatorInterface::class);
-
+        [$haversine, $riderTimeEstimator] = $this->createDefaultStubs();
         $publisher = $this->createStub(TripUpdatePublisherInterface::class);
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $distributor, $haversine, $riderTimeEstimator);
+        $handler = $this->createHandler($tripStateManager, $publisher, $poiRepository, $this->waterPointRepository(), $distributor, $haversine, $riderTimeEstimator);
         $handler(new ScanPois('trip-1'));
     }
 
@@ -517,32 +458,21 @@ final class ScanPoisHandlerTest extends TestCase
         $tripStateManager->method('getRequest')->willReturn(new TripRequest());
         $tripStateManager->method('getDecimatedPoints')->willReturn(null);
 
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('queryBatch')->willReturn([
-            'poi' => ['elements' => []],
-            'cemetery' => ['elements' => []],
-        ]);
+        // No decimated points → corridor falls back to the 6-point stage geometry.
+        $poiRepository = $this->createMock(PoiRepositoryInterface::class);
+        $poiRepository->expects($this->once())
+            ->method('findInCorridor')
+            ->with(
+                $this->callback(static fn (array $route): bool => 6 === \count($route)
+                    && ['lat' => 48.0, 'lon' => 2.0] === $route[0]),
+                $this->greaterThan(0),
+            )
+            ->willReturn([]);
 
         $distributor = $this->createStub(GeometryDistributorInterface::class);
         $distributor->method('distributeByGeometry')->willReturn([]);
 
-        $queryBuilder = $this->createMock(QueryBuilderInterface::class);
-        $queryBuilder->expects($this->once())
-            ->method('buildPoiQuery')
-            ->with($this->callback(static fn (array $points): bool => 6 === \count($points)
-                && $points[0] instanceof Coordinate
-                && 48.0 === $points[0]->lat
-                && 2.0 === $points[0]->lon))
-            ->willReturn('fallback_query');
-        $queryBuilder->method('buildCemeteryQuery')->willReturn('cemetery_query');
-
-        $haversine = $this->createStub(GeoDistanceInterface::class);
-        $haversine->method('inKilometers')->willReturn(10.0);
-        $haversine->method('inMeters')->willReturnCallback(
-            static fn (float $lat1, float $lon1, float $lat2, float $lon2): float => ($lat1 === $lat2 && $lon1 === $lon2) ? 0.0 : 10000.0,
-        );
-
-        $riderTimeEstimator = $this->createStub(RiderTimeEstimatorInterface::class);
+        [$haversine, $riderTimeEstimator] = $this->createDefaultStubs();
 
         $publishedEvents = [];
         $publisher = $this->createStub(TripUpdatePublisherInterface::class);
@@ -551,10 +481,9 @@ final class ScanPoisHandlerTest extends TestCase
                 $publishedEvents[] = ['tripId' => $tripId, 'type' => $type, 'payload' => $payload];
             });
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $distributor, $haversine, $riderTimeEstimator);
+        $handler = $this->createHandler($tripStateManager, $publisher, $poiRepository, $this->waterPointRepository(), $distributor, $haversine, $riderTimeEstimator);
         $handler(new ScanPois('trip-1'));
 
-        // Handler should complete normally using stage geometry as fallback
         $poisScannedEvents = array_filter($publishedEvents, static fn (array $e): bool => MercureEventType::POIS_SCANNED === $e['type']);
         self::assertCount(1, $poisScannedEvents);
     }
@@ -562,22 +491,14 @@ final class ScanPoisHandlerTest extends TestCase
     #[Test]
     public function chainedPoisBeyondAnchorRadiusAreNotMerged(): void
     {
-        // Scenario: A (anchor, 0 km) → B (490m from A, within cluster) → C (490m from B but 980m from A)
-        // Anchor-based: C must NOT join A's cluster (980m > 500m from anchor).
-        // A pairwise/chain algorithm would incorrectly merge C because it is within 500m of B.
+        // A (anchor) → B (490m, within cluster) → C (980m from A, beyond anchor radius).
         $stage = $this->createStage('trip-1', 1, 80.0);
         $tripStateManager = $this->createTripStateManager([$stage]);
 
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('queryBatch')->willReturn([
-            'poi' => [
-                'elements' => [
-                    ['lat' => 48.0, 'lon' => 2.0, 'tags' => ['amenity' => 'restaurant', 'name' => 'POI A']],
-                    ['lat' => 48.0, 'lon' => 2.005, 'tags' => ['amenity' => 'restaurant', 'name' => 'POI B']],
-                    ['lat' => 48.0, 'lon' => 2.010, 'tags' => ['amenity' => 'restaurant', 'name' => 'POI C']],
-                ],
-            ],
-            'cemetery' => ['elements' => []],
+        $poiRepository = $this->poiRepository([
+            ['name' => 'POI A', 'category' => 'restaurant', 'lat' => 48.0, 'lon' => 2.0],
+            ['name' => 'POI B', 'category' => 'restaurant', 'lat' => 48.0, 'lon' => 2.005],
+            ['name' => 'POI C', 'category' => 'restaurant', 'lat' => 48.0, 'lon' => 2.010],
         ]);
 
         $distributor = $this->createStub(GeometryDistributorInterface::class);
@@ -590,26 +511,20 @@ final class ScanPoisHandlerTest extends TestCase
             [],
         );
 
-        [$queryBuilder, $riderTimeEstimator] = [
-            $this->createStub(QueryBuilderInterface::class),
-            $this->createStub(RiderTimeEstimatorInterface::class),
-        ];
-        $queryBuilder->method('buildPoiQuery')->willReturn('query');
-        $queryBuilder->method('buildCemeteryQuery')->willReturn('cemetery_query');
-
         $haversine = $this->createStub(GeoDistanceInterface::class);
         $haversine->method('inKilometers')->willReturn(10.0);
         $haversine->method('inMeters')->willReturnCallback(
             static function (float $lat1, float $lon1, float $lat2, float $lon2): float {
                 $lonDiff = abs($lon1 - $lon2);
-                // A→B ≈ 490m (within 500m radius), A→C ≈ 980m (exceeds anchor radius)
                 if ($lonDiff < 0.006) {
-                    return 490.0;
+                    return 490.0; // A→B within radius
                 }
 
-                return 980.0;
+                return 980.0; // A→C beyond anchor radius
             },
         );
+
+        $riderTimeEstimator = $this->createStub(RiderTimeEstimatorInterface::class);
 
         $publishedEvents = [];
         $publisher = $this->createStub(TripUpdatePublisherInterface::class);
@@ -618,16 +533,14 @@ final class ScanPoisHandlerTest extends TestCase
                 $publishedEvents[] = ['tripId' => $tripId, 'type' => $type, 'payload' => $payload];
             });
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $distributor, $haversine, $riderTimeEstimator);
+        $handler = $this->createHandler($tripStateManager, $publisher, $poiRepository, $this->waterPointRepository(), $distributor, $haversine, $riderTimeEstimator);
         $handler(new ScanPois('trip-1'));
 
         $timelineEvents = array_filter($publishedEvents, static fn (array $e): bool => MercureEventType::SUPPLY_TIMELINE === $e['type']);
         self::assertCount(1, $timelineEvents);
 
         $markers = array_first($timelineEvents)['payload']['markers'];
-
-        // Anchor-based: A+B cluster together (490m from anchor A), C is 980m from anchor A → separate cluster
-        self::assertCount(2, $markers, "C must not chain into A's cluster: anchor-based check only, not pairwise");
+        self::assertCount(2, $markers, "C must not chain into A's cluster: anchor-based check only");
         self::assertCount(2, $markers[0]['food'], 'A and B should be in the same cluster');
         self::assertCount(1, $markers[1]['food'], 'C must be isolated in its own cluster');
     }


### PR DESCRIPTION
## Contexte

Bascule du scan POI d'Overpass (runtime) vers l'index local-first Tier-1 (recette #649, Lot D / Tier-1, **PR3b**). `ScanPoisHandler` lit désormais les POI et les **vrais points d'eau potable** le long du corridor (`ST_DWithin`) via les repos locaux au lieu d'interroger Overpass → données **déterministes** : une longue étape réellement sans POI de ravitaillement n'est plus indistinguable d'un échec Overpass → **le faux positif `alert.lunch.nudge` disparaît**, et les marqueurs d'eau viennent des vrais `water_points` (fin du proxy cimetière).

## Changements

- `PoiRepositoryInterface` / `WaterPointRepositoryInterface` (les concrets de PR3a les implémentent ; auto-wiring single-impl) → handler testable unitairement.
- `ScanPoisHandler` : `scanner.queryBatch(poi+cemetery)` (Overpass) → `PoiRepository` + `WaterPointRepository` (corridor 2 km), suppression du parsing d'éléments Overpass. Distributor + lunch nudge + supply timeline inchangés.
- **Test unitaire** : mocke les repos au lieu du scanner.
- **Test d'intégration** (vraie DB PostGIS, #56) + **fixtures SQL committées** : prouve que les POI sont détectés depuis l'index et que le lunch nudge ne se déclenche **que** sans POI de ravitaillement dans le corridor.

## Vérification

- `php -l` + `php-cs-fixer` verts.
- Sélectivité corridor `ST_DWithin` validée sur **DB PostGIS réelle** avec les fixtures : corridor A → restaurant (+ eau), corridor B → viewpoint uniquement.
- Suite PHPUnit complète (unitaire + intégration) : CI.

## Périmètre & suite

ScanPoisHandler uniquement. La **recette BDD est mockée** (`page.route` + Mercure injecté) → non impactée par le cutover.
- **PR3b-2** : `CheckWaterPointsHandler` (alerte gap d'eau) + rename `alert.cemetery` → `alert.water` (traductions + README + ALERT_RULE_MAP).
- **PR3b-3** : hébergements (`OsmAccommodationSource` → `AccommodationRepository`).
- **PR3c** : in-ride + `ScanAllOsmData` + retrait complet `OsmScanner`/Overpass + reformulation ADR-005/013/025/026.

Refs #649

<!-- claude-review-start -->
## Claude Review

Clean, well-scoped cut-over. The interface extraction (`PoiRepositoryInterface` / `WaterPointRepositoryInterface`) correctly enables unit testing, the SQL path is safe (WKT built from floats, used as a named bound parameter — no injection vector), and the PostGIS `ST_DWithin` corridor query has no N+1 pattern. Two minor test-coverage suggestions posted as inline comments.

**Resolved threads:** none (no prior bot threads existed).

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [ ] Documentation is up to date *(water point detection from the new repository is seeded in the integration test fixture but not asserted — see inline comment)*
- [x] Dependent tickets accounted for

### Inline comments

Posted 2 inline comments.

**Commit reviewed:** `31fd55e2a6a3ac0e22fd079f927c93ee0ed89d52`
<!-- claude-review-end -->