### PR TITLE
feat(accommodation): lecture des hébergements depuis l'index PostGIS local (ADR-040)

### DIFF
--- a/api/src/AccommodationSource/OsmAccommodationSource.php
+++ b/api/src/AccommodationSource/OsmAccommodationSource.php
@@ -26,7 +26,7 @@ final readonly class OsmAccommodationSource implements AccommodationSourceInterf
     public function fetch(array $endPoints, int $radiusMeters, array $enabledTypes = TripRequest::ALL_ACCOMMODATION_TYPES): array
     {
         // Read accommodations from the local-first index within the radius of the
-        // stage end points (where the rider sleeps), no longer around Overpass (ADR-040).
+        // stage end points, where the rider sleeps (ADR-040).
         $points = array_map(
             static fn (Coordinate $point): array => ['lat' => $point->lat, 'lon' => $point->lon],
             array_values($endPoints),

--- a/api/src/AccommodationSource/OsmAccommodationSource.php
+++ b/api/src/AccommodationSource/OsmAccommodationSource.php
@@ -7,14 +7,12 @@ namespace App\AccommodationSource;
 use App\ApiResource\Model\Coordinate;
 use App\ApiResource\TripRequest;
 use App\Engine\PricingHeuristicEngine;
-use App\Scanner\QueryBuilderInterface;
-use App\Scanner\ScannerInterface;
+use App\Osm\AccommodationRepositoryInterface;
 
 final readonly class OsmAccommodationSource implements AccommodationSourceInterface
 {
     public function __construct(
-        private ScannerInterface $scanner,
-        private QueryBuilderInterface $queryBuilder,
+        private AccommodationRepositoryInterface $accommodationRepository,
         private PricingHeuristicEngine $pricingEngine,
     ) {
     }
@@ -27,13 +25,36 @@ final readonly class OsmAccommodationSource implements AccommodationSourceInterf
      */
     public function fetch(array $endPoints, int $radiusMeters, array $enabledTypes = TripRequest::ALL_ACCOMMODATION_TYPES): array
     {
-        $query = $this->queryBuilder->buildAccommodationQuery($endPoints, $radiusMeters, $enabledTypes);
-        $result = $this->scanner->query($query);
+        // Read accommodations from the local-first index within the radius of the
+        // stage end points (where the rider sleeps), no longer around Overpass (ADR-040).
+        $points = array_map(
+            static fn (Coordinate $point): array => ['lat' => $point->lat, 'lon' => $point->lon],
+            array_values($endPoints),
+        );
 
-        /** @var list<array{id?: int, type?: string, tags?: array<string, string>, lat?: float, lon?: float, center?: array{lat: float, lon: float}}> $elements */
-        $elements = \is_array($result['elements'] ?? null) ? $result['elements'] : [];
+        $candidates = [];
+        foreach ($this->accommodationRepository->findNear($points, $radiusMeters, $enabledTypes) as $accommodation) {
+            $tags = $accommodation['tags'];
+            $pricing = $this->pricingEngine->estimatePrice($accommodation['category'], $tags);
 
-        return $this->parseElements($elements);
+            $candidates[] = [
+                'name' => $accommodation['name'] ?? $accommodation['category'],
+                'type' => $accommodation['category'],
+                'lat' => $accommodation['lat'],
+                'lon' => $accommodation['lon'],
+                'priceMin' => $pricing['min'],
+                'priceMax' => $pricing['max'],
+                'isExact' => $pricing['isExact'],
+                'url' => $accommodation['website'] ?? ($tags['contact:website'] ?? null),
+                'tagCount' => \count($tags),
+                'hasWebsite' => null !== $accommodation['website'] || isset($tags['contact:website']),
+                'tags' => $tags,
+                'source' => 'osm',
+                'wikidataId' => $accommodation['wikidata'],
+            ];
+        }
+
+        return $candidates;
     }
 
     public function isEnabled(): bool
@@ -44,54 +65,5 @@ final readonly class OsmAccommodationSource implements AccommodationSourceInterf
     public function getName(): string
     {
         return 'osm';
-    }
-
-    /**
-     * @param list<array{id?: int, type?: string, tags?: array<string, string>, lat?: float, lon?: float, center?: array{lat: float, lon: float}}> $elements
-     *
-     * @return list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, source: string, wikidataId: ?string}>
-     */
-    private function parseElements(array $elements): array
-    {
-        $candidates = [];
-
-        foreach ($elements as $element) {
-            $tags = $element['tags'] ?? [];
-            $lat = $element['lat'] ?? ($element['center']['lat'] ?? null);
-            $lon = $element['lon'] ?? ($element['center']['lon'] ?? null);
-
-            if (null === $lat || null === $lon) {
-                continue;
-            }
-
-            $url = $tags['website']
-                ?? $tags['contact:website']
-                ?? (isset($element['id'], $element['type'])
-                    ? \sprintf('https://www.openstreetmap.org/%s/%d', $element['type'], $element['id'])
-                    : null);
-
-            $type = $tags['tourism'] ?? ('shelter' === ($tags['amenity'] ?? null) ? 'shelter' : 'hotel');
-            $name = $tags['name'] ?? $type;
-            $tagCount = \count($tags);
-            $pricing = $this->pricingEngine->estimatePrice($type, $tags);
-
-            $candidates[] = [
-                'name' => $name,
-                'type' => $type,
-                'lat' => (float) $lat,
-                'lon' => (float) $lon,
-                'priceMin' => $pricing['min'],
-                'priceMax' => $pricing['max'],
-                'isExact' => $pricing['isExact'],
-                'url' => $url,
-                'tagCount' => $tagCount,
-                'hasWebsite' => isset($tags['website']) || isset($tags['contact:website']),
-                'tags' => $tags,
-                'source' => 'osm',
-                'wikidataId' => $tags['wikidata'] ?? null,
-            ];
-        }
-
-        return $candidates;
     }
 }

--- a/api/src/Osm/AccommodationRepository.php
+++ b/api/src/Osm/AccommodationRepository.php
@@ -12,7 +12,7 @@ use Doctrine\DBAL\Connection;
  * stage end points (ST_DWithin), replacing the runtime Overpass accommodation
  * source (ADR-040). DataTourisme/Wikidata enrichment stays in their own sources.
  */
-final readonly class AccommodationRepository
+final readonly class AccommodationRepository implements AccommodationRepositoryInterface
 {
     public function __construct(private Connection $connection)
     {

--- a/api/src/Osm/AccommodationRepositoryInterface.php
+++ b/api/src/Osm/AccommodationRepositoryInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Osm;
+
+interface AccommodationRepositoryInterface
+{
+    /**
+     * Accommodations of the given categories within $radiusMeters of any point.
+     *
+     * @param list<array{lat: float, lon: float}> $points
+     * @param list<string>                        $categories
+     *
+     * @return list<array{name: ?string, category: string, lat: float, lon: float, stars: ?int, capacity: ?int, fee: ?string, website: ?string, wikidata: ?string, openingHours: ?string, tags: array<string, string>}>
+     */
+    public function findNear(array $points, int $radiusMeters, array $categories): array;
+}

--- a/api/tests/Integration/Osm/AccommodationIndexReadTest.php
+++ b/api/tests/Integration/Osm/AccommodationIndexReadTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Osm;
+
+use App\AccommodationSource\OsmAccommodationSource;
+use App\ApiResource\Model\Coordinate;
+use App\Engine\PricingHeuristicEngine;
+use App\Osm\AccommodationRepository;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * End-to-end coverage of the local-first accommodation cut-over (ADR-040): runs
+ * the real OsmAccommodationSource against the real AccommodationRepository on a
+ * PostGIS test DB seeded with committed osm fixtures, proving that accommodations
+ * are detected from the index (no more empty-on-Overpass-error) with radius and
+ * category filtering, and that columns/tags map onto the candidate shape (charge
+ * to exact price, website to url, wikidata to wikidataId).
+ */
+final class AccommodationIndexReadTest extends KernelTestCase
+{
+    use ResetDatabase;
+
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get('doctrine.dbal.default_connection');
+        $this->connection = $connection;
+
+        // osm.* are not Doctrine entities, so the Foundry reset does not clear them.
+        $this->connection->executeStatement('TRUNCATE osm.accommodations');
+
+        // Committed SQL fixtures (ADR-040 / #56). Two accommodations within 5 km of
+        // the stage end point (48.5, 2.5): a hotel (website + wikidata) and a camp
+        // site (charge tag). A far hotel (~130 km) and a near hostel exercise the
+        // radius and category filters respectively.
+        $this->connection->executeStatement(<<<'SQL'
+            INSERT INTO osm.accommodations (osm_type, osm_id, name, category, website, wikidata, tags, geom) VALUES
+              ('n', 8001, 'Hotel du Centre', 'hotel', 'https://hotel.example', 'Q42', '{}'::jsonb, ST_SetSRID(ST_MakePoint(2.5, 48.5), 4326)),
+              ('n', 8002, 'Camping du Lac', 'camp_site', NULL, NULL, '{"charge": "18 EUR"}'::jsonb, ST_SetSRID(ST_MakePoint(2.51, 48.51), 4326)),
+              ('n', 8003, 'Auberge Lointaine', 'hotel', NULL, NULL, '{}'::jsonb, ST_SetSRID(ST_MakePoint(3.5, 49.5), 4326)),
+              ('n', 8004, 'Auberge de Jeunesse', 'hostel', NULL, NULL, '{}'::jsonb, ST_SetSRID(ST_MakePoint(2.5, 48.5), 4326))
+            SQL);
+    }
+
+    #[Test]
+    public function fetchDetectsAccommodationsFromTheIndexWithinRadiusAndCategory(): void
+    {
+        $results = $this->source()->fetch([new Coordinate(48.5, 2.5)], 5000, ['hotel', 'camp_site']);
+
+        $types = array_map(static fn (array $candidate): string => $candidate['type'], $results);
+        sort($types);
+
+        // The near hotel and camp site are detected; the far hotel (out of radius)
+        // and the near hostel (category not requested) are excluded.
+        self::assertSame(['camp_site', 'hotel'], $types);
+    }
+
+    #[Test]
+    public function fetchMapsColumnsAndTagsOntoTheCandidateShape(): void
+    {
+        $results = $this->source()->fetch([new Coordinate(48.5, 2.5)], 5000, ['hotel', 'camp_site']);
+
+        $byType = [];
+        foreach ($results as $candidate) {
+            $byType[$candidate['type']] = $candidate;
+        }
+
+        self::assertArrayHasKey('hotel', $byType);
+        self::assertSame('Hotel du Centre', $byType['hotel']['name']);
+        self::assertSame('https://hotel.example', $byType['hotel']['url']);
+        self::assertTrue($byType['hotel']['hasWebsite']);
+        self::assertSame('Q42', $byType['hotel']['wikidataId']);
+        self::assertSame('osm', $byType['hotel']['source']);
+
+        self::assertArrayHasKey('camp_site', $byType);
+        self::assertSame(18.0, $byType['camp_site']['priceMin']);
+        self::assertSame(18.0, $byType['camp_site']['priceMax']);
+        self::assertTrue($byType['camp_site']['isExact']);
+        self::assertNull($byType['camp_site']['url']);
+        self::assertFalse($byType['camp_site']['hasWebsite']);
+    }
+
+    private function source(): OsmAccommodationSource
+    {
+        return new OsmAccommodationSource(
+            new AccommodationRepository($this->connection),
+            new PricingHeuristicEngine(),
+        );
+    }
+}

--- a/api/tests/Integration/Osm/AccommodationIndexReadTest.php
+++ b/api/tests/Integration/Osm/AccommodationIndexReadTest.php
@@ -38,7 +38,7 @@ final class AccommodationIndexReadTest extends KernelTestCase
         // osm.* are not Doctrine entities, so the Foundry reset does not clear them.
         $this->connection->executeStatement('TRUNCATE osm.accommodations');
 
-        // Committed SQL fixtures (ADR-040 / #56). Two accommodations within 5 km of
+        // Committed SQL fixtures (ADR-040). Two accommodations within 5 km of
         // the stage end point (48.5, 2.5): a hotel (website + wikidata) and a camp
         // site (charge tag). A far hotel (~130 km) and a near hostel exercise the
         // radius and category filters respectively.
@@ -62,6 +62,24 @@ final class AccommodationIndexReadTest extends KernelTestCase
         // The near hotel and camp site are detected; the far hotel (out of radius)
         // and the near hostel (category not requested) are excluded.
         self::assertSame(['camp_site', 'hotel'], $types);
+    }
+
+    #[Test]
+    public function fetchMatchesAccommodationsAcrossMultipleEndpoints(): void
+    {
+        // A real trip passes one end point per stage: fetch() builds a MULTIPOINT of
+        // N vertices. Two end points, each near a different hotel, must both match —
+        // the far hotel (~130 km) is out of range of the first end point alone.
+        $results = $this->source()->fetch(
+            [new Coordinate(48.5, 2.5), new Coordinate(49.5, 3.5)],
+            5000,
+            ['hotel'],
+        );
+
+        $names = array_map(static fn (array $candidate): string => $candidate['name'], $results);
+        sort($names);
+
+        self::assertSame(['Auberge Lointaine', 'Hotel du Centre'], $names);
     }
 
     #[Test]

--- a/api/tests/Unit/AccommodationSource/OsmAccommodationSourceTest.php
+++ b/api/tests/Unit/AccommodationSource/OsmAccommodationSourceTest.php
@@ -7,8 +7,7 @@ namespace App\Tests\Unit\AccommodationSource;
 use App\AccommodationSource\OsmAccommodationSource;
 use App\ApiResource\Model\Coordinate;
 use App\Engine\PricingHeuristicEngine;
-use App\Scanner\QueryBuilderInterface;
-use App\Scanner\ScannerInterface;
+use App\Osm\AccommodationRepositoryInterface;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -17,39 +16,20 @@ final class OsmAccommodationSourceTest extends TestCase
     #[Test]
     public function getNameReturnsOsm(): void
     {
-        $source = $this->createSource();
-
-        $this->assertSame('osm', $source->getName());
+        $this->assertSame('osm', $this->createSource()->getName());
     }
 
     #[Test]
     public function isEnabledAlwaysReturnsTrue(): void
     {
-        $source = $this->createSource();
-
-        $this->assertTrue($source->isEnabled());
+        $this->assertTrue($this->createSource()->isEnabled());
     }
 
     #[Test]
-    public function fetchParsesNodeElementWithTourismTag(): void
+    public function fetchMapsRepositoryRowToCandidate(): void
     {
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('query')->willReturn([
-            'elements' => [
-                [
-                    'id' => 123,
-                    'type' => 'node',
-                    'lat' => 48.6,
-                    'lon' => 2.6,
-                    'tags' => ['tourism' => 'hotel', 'name' => 'Hotel du Nord'],
-                ],
-            ],
-        ]);
+        $source = $this->createSource($this->repository([$this->row(category: 'hotel', name: 'Hotel du Nord')]));
 
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildAccommodationQuery')->willReturn('query');
-
-        $source = $this->createSource($scanner, $queryBuilder);
         $results = $source->fetch([new Coordinate(48.5, 2.5)], 5000, ['hotel']);
 
         $this->assertCount(1, $results);
@@ -58,159 +38,165 @@ final class OsmAccommodationSourceTest extends TestCase
         $this->assertSame(48.6, $results[0]['lat']);
         $this->assertSame(2.6, $results[0]['lon']);
         $this->assertSame('osm', $results[0]['source']);
+        $this->assertSame(0, $results[0]['tagCount']);
     }
 
     #[Test]
-    public function fetchExtractsWikidataIdFromTags(): void
+    public function fetchFallsBackToCategoryWhenNameIsNull(): void
     {
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('query')->willReturn([
-            'elements' => [
-                [
-                    'id' => 456,
-                    'type' => 'node',
-                    'lat' => 48.6,
-                    'lon' => 2.6,
-                    'tags' => ['tourism' => 'hotel', 'name' => 'Hotel Wikidata', 'wikidata' => 'Q12345'],
-                ],
-            ],
-        ]);
+        $source = $this->createSource($this->repository([$this->row(category: 'shelter', name: null)]));
 
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildAccommodationQuery')->willReturn('query');
+        $results = $source->fetch([new Coordinate(48.5, 2.5)], 5000, ['shelter']);
 
-        $source = $this->createSource($scanner, $queryBuilder);
+        $this->assertSame('shelter', $results[0]['name']);
+    }
+
+    #[Test]
+    public function fetchUsesWikidataFromRepositoryRow(): void
+    {
+        $source = $this->createSource($this->repository([$this->row(wikidata: 'Q12345')]));
+
         $results = $source->fetch([new Coordinate(48.5, 2.5)], 5000, ['hotel']);
 
-        $this->assertCount(1, $results);
         $this->assertSame('Q12345', $results[0]['wikidataId']);
     }
 
     #[Test]
-    public function fetchSetsNullWikidataIdWhenTagAbsent(): void
+    public function fetchSetsNullWikidataIdWhenAbsent(): void
     {
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('query')->willReturn([
-            'elements' => [
-                [
-                    'id' => 789,
-                    'type' => 'node',
-                    'lat' => 48.6,
-                    'lon' => 2.6,
-                    'tags' => ['tourism' => 'hostel', 'name' => 'Hostel Central'],
-                ],
-            ],
-        ]);
+        $source = $this->createSource($this->repository([$this->row(wikidata: null)]));
 
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildAccommodationQuery')->willReturn('query');
+        $results = $source->fetch([new Coordinate(48.5, 2.5)], 5000, ['hotel']);
 
-        $source = $this->createSource($scanner, $queryBuilder);
-        $results = $source->fetch([new Coordinate(48.5, 2.5)], 5000, ['hostel']);
-
-        $this->assertCount(1, $results);
         $this->assertNull($results[0]['wikidataId']);
     }
 
     #[Test]
-    public function fetchUsesWayCenterCoordinatesWhenLatLonAbsent(): void
+    public function fetchPricesShelterAtZero(): void
     {
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('query')->willReturn([
-            'elements' => [
-                [
-                    'id' => 101,
-                    'type' => 'way',
-                    'center' => ['lat' => 47.1, 'lon' => 3.2],
-                    'tags' => ['tourism' => 'camp_site', 'name' => 'Camping du Lac'],
-                ],
-            ],
-        ]);
+        $source = $this->createSource($this->repository([$this->row(category: 'shelter')]));
 
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildAccommodationQuery')->willReturn('query');
-
-        $source = $this->createSource($scanner, $queryBuilder);
-        $results = $source->fetch([new Coordinate(47.0, 3.0)], 5000, ['camp_site']);
-
-        $this->assertCount(1, $results);
-        $this->assertSame(47.1, $results[0]['lat']);
-        $this->assertSame(3.2, $results[0]['lon']);
-    }
-
-    #[Test]
-    public function fetchSkipsElementsWithoutCoordinates(): void
-    {
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('query')->willReturn([
-            'elements' => [
-                [
-                    'id' => 999,
-                    'type' => 'way',
-                    'tags' => ['tourism' => 'hotel', 'name' => 'No Coords Hotel'],
-                ],
-            ],
-        ]);
-
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildAccommodationQuery')->willReturn('query');
-
-        $source = $this->createSource($scanner, $queryBuilder);
-        $results = $source->fetch([new Coordinate(48.5, 2.5)], 5000, ['hotel']);
-
-        $this->assertCount(0, $results);
-    }
-
-    #[Test]
-    public function fetchMapsAmenityShelterToShelterType(): void
-    {
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('query')->willReturn([
-            'elements' => [
-                [
-                    'id' => 200,
-                    'type' => 'node',
-                    'lat' => 46.0,
-                    'lon' => 1.0,
-                    'tags' => ['amenity' => 'shelter', 'shelter_type' => 'lean_to', 'name' => 'Lean-To'],
-                ],
-            ],
-        ]);
-
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildAccommodationQuery')->willReturn('query');
-
-        $source = $this->createSource($scanner, $queryBuilder);
         $results = $source->fetch([new Coordinate(46.0, 1.0)], 5000, ['shelter']);
 
-        $this->assertCount(1, $results);
         $this->assertSame('shelter', $results[0]['type']);
         $this->assertSame(0.0, $results[0]['priceMin']);
         $this->assertSame(0.0, $results[0]['priceMax']);
+        $this->assertFalse($results[0]['isExact']);
     }
 
     #[Test]
-    public function fetchReturnsEmptyArrayWhenNoElements(): void
+    public function fetchUsesExactPriceFromChargeTag(): void
     {
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('query')->willReturn(['elements' => []]);
+        $source = $this->createSource($this->repository([$this->row(category: 'camp_site', tags: ['charge' => '15 EUR'])]));
 
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildAccommodationQuery')->willReturn('query');
+        $results = $source->fetch([new Coordinate(48.5, 2.5)], 5000, ['camp_site']);
 
-        $source = $this->createSource($scanner, $queryBuilder);
+        $this->assertSame(15.0, $results[0]['priceMin']);
+        $this->assertSame(15.0, $results[0]['priceMax']);
+        $this->assertTrue($results[0]['isExact']);
+        $this->assertSame(1, $results[0]['tagCount']);
+    }
+
+    #[Test]
+    public function fetchDerivesUrlAndHasWebsiteFromWebsiteColumn(): void
+    {
+        $source = $this->createSource($this->repository([$this->row(website: 'https://hotel.example')]));
+
         $results = $source->fetch([new Coordinate(48.5, 2.5)], 5000, ['hotel']);
+
+        $this->assertSame('https://hotel.example', $results[0]['url']);
+        $this->assertTrue($results[0]['hasWebsite']);
+    }
+
+    #[Test]
+    public function fetchFallsBackToContactWebsiteTagForUrl(): void
+    {
+        $source = $this->createSource($this->repository([$this->row(website: null, tags: ['contact:website' => 'https://contact.example'])]));
+
+        $results = $source->fetch([new Coordinate(48.5, 2.5)], 5000, ['hotel']);
+
+        $this->assertSame('https://contact.example', $results[0]['url']);
+        $this->assertTrue($results[0]['hasWebsite']);
+    }
+
+    #[Test]
+    public function fetchSetsNoUrlWhenNeitherWebsiteNorContactPresent(): void
+    {
+        $source = $this->createSource($this->repository([$this->row(website: null)]));
+
+        $results = $source->fetch([new Coordinate(48.5, 2.5)], 5000, ['hotel']);
+
+        $this->assertNull($results[0]['url']);
+        $this->assertFalse($results[0]['hasWebsite']);
+    }
+
+    #[Test]
+    public function fetchPassesPointsRadiusAndEnabledTypesToRepository(): void
+    {
+        $repository = $this->createStub(AccommodationRepositoryInterface::class);
+        $repository->method('findNear')->willReturnCallback(
+            static function (array $points, int $radiusMeters, array $categories): array {
+                self::assertSame([['lat' => 48.5, 'lon' => 2.5]], $points);
+                self::assertSame(5000, $radiusMeters);
+                self::assertSame(['hotel', 'hostel'], $categories);
+
+                return [];
+            },
+        );
+
+        $this->createSource($repository)->fetch([new Coordinate(48.5, 2.5)], 5000, ['hotel', 'hostel']);
+    }
+
+    #[Test]
+    public function fetchReturnsEmptyArrayWhenRepositoryReturnsNothing(): void
+    {
+        $results = $this->createSource($this->repository([]))->fetch([new Coordinate(48.5, 2.5)], 5000, ['hotel']);
 
         $this->assertSame([], $results);
     }
 
-    private function createSource(
-        ?ScannerInterface $scanner = null,
-        ?QueryBuilderInterface $queryBuilder = null,
-    ): OsmAccommodationSource {
+    /**
+     * @param array<string, string> $tags
+     *
+     * @return array{name: ?string, category: string, lat: float, lon: float, stars: ?int, capacity: ?int, fee: ?string, website: ?string, wikidata: ?string, openingHours: ?string, tags: array<string, string>}
+     */
+    private function row(
+        string $category = 'hotel',
+        ?string $name = 'Hotel du Nord',
+        ?string $website = null,
+        ?string $wikidata = null,
+        array $tags = [],
+    ): array {
+        return [
+            'name' => $name,
+            'category' => $category,
+            'lat' => 48.6,
+            'lon' => 2.6,
+            'stars' => null,
+            'capacity' => null,
+            'fee' => null,
+            'website' => $website,
+            'wikidata' => $wikidata,
+            'openingHours' => null,
+            'tags' => $tags,
+        ];
+    }
+
+    /**
+     * @param list<array{name: ?string, category: string, lat: float, lon: float, stars: ?int, capacity: ?int, fee: ?string, website: ?string, wikidata: ?string, openingHours: ?string, tags: array<string, string>}> $rows
+     */
+    private function repository(array $rows): AccommodationRepositoryInterface
+    {
+        $repository = $this->createStub(AccommodationRepositoryInterface::class);
+        $repository->method('findNear')->willReturn($rows);
+
+        return $repository;
+    }
+
+    private function createSource(?AccommodationRepositoryInterface $repository = null): OsmAccommodationSource
+    {
         return new OsmAccommodationSource(
-            scanner: $scanner ?? $this->createStub(ScannerInterface::class),
-            queryBuilder: $queryBuilder ?? $this->createStub(QueryBuilderInterface::class),
+            accommodationRepository: $repository ?? $this->createStub(AccommodationRepositoryInterface::class),
             pricingEngine: new PricingHeuristicEngine(),
         );
     }


### PR DESCRIPTION
## Contexte

Dernier bug de données de la recette #649 : les hébergements n'étaient pas détectés de façon fiable (dépendance Overpass runtime, vide-sur-erreur). Cette PR bascule la source OSM des hébergements sur l'index local-first PostGIS (ADR-040), dans la continuité de #666 (POI), #667 (POI/eau) et #668 (eau, fin du proxy cimetière).

C'est la dernière bascule de lecture des **données** : DataTourisme, Wikidata et le scraping de prix restent dans leurs propres sources ; le `ScanAccommodationsHandler` et le registre multi-source sont intacts.

## Changements

- **`AccommodationRepositoryInterface`** (nouveau) : couture derrière `AccommodationRepository` (signature `findNear(points, radius, categories)`), pour autoriser le mock en test unitaire et l'auto-alias Symfony.
- **`OsmAccommodationSource`** : n'injecte plus `ScannerInterface` + `QueryBuilderInterface` mais `AccommodationRepositoryInterface` + `PricingHeuristicEngine`. `fetch()` lit l'index via `findNear` (rayon autour des points d'arrivée d'étape, là où l'on dort) et mappe chaque ligne sur la forme candidate :
  - `type` = `category`, `name` = `name ?? category` ;
  - prix via `PricingHeuristicEngine::estimatePrice(category, tags)` (le tag `charge` donne un prix exact) ;
  - `url` = colonne `website` ?? tag `contact:website` (le permalink OSM, non scrapable, est abandonné — le repo n'expose pas `osm_id`) ;
  - `wikidataId` = colonne `wikidata`, `tags`/`tagCount`/`hasWebsite` dérivés.
- **Tests** : test unitaire réécrit (mock de l'interface, couverture du mapping : fallback nom→catégorie, prix exact depuis `charge`, url/hasWebsite, wikidata, passage rayon/catégories au repo) ; nouveau test d'intégration `AccommodationIndexReadTest` (source + repo réels sur DB PostGIS de test, fixtures SQL committées) prouvant la détection déterministe avec filtrage rayon + catégorie.

Aucune dépendance Overpass runtime ne subsiste côté hébergements → plus de détection vide en cas d'échec tiers.

## Vérification

- `php -l` : OK sur les 5 fichiers.
- PHP-CS-Fixer (dry-run) : 0/5 à corriger.
- SQL `findNear` validé contre la base PostGIS bootée (transaction annulée) : retourne exactement l'hôtel + le camping proches, exclut le lointain (rayon) et le hostel (catégorie) ; colonnes `website`/`wikidata` présentes.
- PHPStan niveau 9 + PHPUnit (unitaire + intégration) délégués à la CI (worktree sans `vendor`).

<!-- claude-review-start -->
## Claude Review

Reviewed commit `7307c2b380b73a025409df36940e5de1fc24cc11`.

**0 findings.** No inline comments.

Resolved 1 previously open bot-authored thread (Overpass-migration reference removed from `OsmAccommodationSource::fetch()` comment — ADR-040 anchor retained).

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for
<!-- claude-review-end -->