### PR TITLE
feat(bike-shops): lecture des magasins vélo depuis l'index PostGIS local (ADR-040)

### DIFF
--- a/api/migrations/Version20260615120000.php
+++ b/api/migrations/Version20260615120000.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Adds osm.bike_shops to the local-first Tier-1 reference schema (ADR-040): a
+ * PostGIS point table read by the API via ST_DWithin corridor queries, replacing
+ * the runtime Overpass bike-shop scan. Raw tags are kept so the read side can
+ * distinguish repair shops (service:bicycle:repair=yes) from sale-only outlets.
+ *
+ * Mirrors the osm2pgsql flex output (provisioner/osm2pgsql/tier1.lua): the
+ * provisioner imports into a staging schema and atomically swaps it onto `osm`.
+ * This migration bootstraps the table so it exists before the first provisioning
+ * run and so functional tests have it to seed and query.
+ */
+final class Version20260615120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add the osm.bike_shops reference table for local-first bike-shop reads';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE SCHEMA IF NOT EXISTS osm');
+
+        $this->addSql(<<<'SQL'
+            CREATE TABLE IF NOT EXISTS osm.bike_shops (
+                osm_type character(1) NOT NULL,
+                osm_id bigint NOT NULL,
+                name text,
+                category text NOT NULL,
+                tags jsonb,
+                geom geometry(Point, 4326) NOT NULL,
+                PRIMARY KEY (osm_type, osm_id)
+            )
+            SQL);
+
+        $this->addSql('CREATE INDEX IF NOT EXISTS bike_shops_geom_idx ON osm.bike_shops USING gist (geom)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE IF EXISTS osm.bike_shops');
+    }
+}

--- a/api/src/MessageHandler/CheckBikeShopsHandler.php
+++ b/api/src/MessageHandler/CheckBikeShopsHandler.php
@@ -29,8 +29,8 @@ final readonly class CheckBikeShopsHandler extends AbstractTripMessageHandler
 
     private const float BIKE_SHOP_PROXIMITY_METERS = 2000.0;
 
-    /** Corridor half-width (m) for the local-first bike-shop reads (ADR-040). */
-    private const int CORRIDOR_RADIUS_METERS = 2000;
+    /** Corridor half-width (m) for the local-first bike-shop reads (ADR-040); kept equal to BIKE_SHOP_PROXIMITY_METERS so the DB pre-filter always covers the per-stage proximity threshold. */
+    private const int CORRIDOR_RADIUS_METERS = (int) self::BIKE_SHOP_PROXIMITY_METERS;
 
     public function __construct(
         ComputationTrackerInterface $computationTracker,

--- a/api/src/MessageHandler/CheckBikeShopsHandler.php
+++ b/api/src/MessageHandler/CheckBikeShopsHandler.php
@@ -15,9 +15,8 @@ use App\Geo\GeoDistanceInterface;
 use App\Mercure\MercureEventType;
 use App\Mercure\TripUpdatePublisherInterface;
 use App\Message\CheckBikeShops;
+use App\Osm\BikeShopRepositoryInterface;
 use App\Repository\TripRequestRepositoryInterface;
-use App\Scanner\QueryBuilderInterface;
-use App\Scanner\ScannerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -30,14 +29,16 @@ final readonly class CheckBikeShopsHandler extends AbstractTripMessageHandler
 
     private const float BIKE_SHOP_PROXIMITY_METERS = 2000.0;
 
+    /** Corridor half-width (m) for the local-first bike-shop reads (ADR-040). */
+    private const int CORRIDOR_RADIUS_METERS = 2000;
+
     public function __construct(
         ComputationTrackerInterface $computationTracker,
         TripUpdatePublisherInterface $publisher,
         TripGenerationTrackerInterface $generationTracker,
         LoggerInterface $logger,
         private TripRequestRepositoryInterface $tripStateManager,
-        private ScannerInterface $scanner,
-        private QueryBuilderInterface $queryBuilder,
+        private BikeShopRepositoryInterface $bikeShopRepository,
         private GeoDistanceInterface $haversine,
         private TranslatorInterface $translator,
         MessageBusInterface $messageBus,
@@ -65,7 +66,7 @@ final readonly class CheckBikeShopsHandler extends AbstractTripMessageHandler
         $locale = $this->tripStateManager->getLocale($tripId) ?? 'en';
 
         $this->executeWithTracking($tripId, ComputationName::BIKE_SHOPS, function () use ($tripId, $stages, $locale): void {
-            // Single Overpass query using decimated route points (shared cache key with ScanAllOsmDataHandler)
+            // Read bike shops from the local-first index along the route corridor (ADR-040).
             $decimatedData = $this->tripStateManager->getDecimatedPoints($tripId);
             $points = null !== $decimatedData
                 ? array_map(static fn (array $p): Coordinate => new Coordinate($p['lat'], $p['lon'], $p['ele']), $decimatedData)
@@ -74,30 +75,16 @@ final readonly class CheckBikeShopsHandler extends AbstractTripMessageHandler
                     $stages,
                 ));
 
-            $query = $this->queryBuilder->buildBikeShopQuery($points);
-            $result = $this->scanner->query($query);
-
-            /** @var list<array{lat?: float, lon?: float, center?: array{lat: float, lon: float}, tags?: array<string, string>}> $elements */
-            $elements = \is_array($result['elements'] ?? null) ? $result['elements'] : [];
+            $route = array_map(static fn (Coordinate $point): array => ['lat' => $point->lat, 'lon' => $point->lon], $points);
 
             // Parse bike shop locations, distinguishing repair shops from sale-only shops
             $repairShopLocations = [];
             $saleOnlyShopLocations = [];
-            foreach ($elements as $element) {
-                $lat = $element['lat'] ?? ($element['center']['lat'] ?? null);
-                $lon = $element['lon'] ?? ($element['center']['lon'] ?? null);
-
-                if (null === $lat || null === $lon) {
-                    continue;
-                }
-
-                $tags = $element['tags'] ?? [];
-                $hasRepair = isset($tags['service:bicycle:repair']) && 'yes' === $tags['service:bicycle:repair'];
-
-                if ($hasRepair) {
-                    $repairShopLocations[] = ['lat' => (float) $lat, 'lon' => (float) $lon];
+            foreach ($this->bikeShopRepository->findInCorridor($route, self::CORRIDOR_RADIUS_METERS) as $shop) {
+                if ($shop['hasRepair']) {
+                    $repairShopLocations[] = ['lat' => $shop['lat'], 'lon' => $shop['lon']];
                 } else {
-                    $saleOnlyShopLocations[] = ['lat' => (float) $lat, 'lon' => (float) $lon];
+                    $saleOnlyShopLocations[] = ['lat' => $shop['lat'], 'lon' => $shop['lon']];
                 }
             }
 

--- a/api/src/Osm/BikeShopRepository.php
+++ b/api/src/Osm/BikeShopRepository.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Osm;
+
+use Doctrine\DBAL\Connection;
+
+/**
+ * Reads bike shops from the local-first Tier-1 index along the route corridor
+ * (ST_DWithin), replacing the runtime Overpass bike-shop scan (ADR-040). The
+ * repair flag is derived from the raw tags so the analyzer can tell repair shops
+ * apart from sale-only outlets.
+ */
+final readonly class BikeShopRepository implements BikeShopRepositoryInterface
+{
+    public function __construct(private Connection $connection)
+    {
+    }
+
+    /**
+     * Bike shops whose geometry is within $radiusMeters of the route corridor.
+     *
+     * @param list<array{lat: float, lon: float}> $route
+     *
+     * @return list<array{name: ?string, lat: float, lon: float, hasRepair: bool}>
+     */
+    public function findInCorridor(array $route, int $radiusMeters): array
+    {
+        if ([] === $route) {
+            return [];
+        }
+
+        /** @var list<array<string, scalar|null>> $rows */
+        $rows = $this->connection->fetchAllAssociative(
+            <<<'SQL'
+                SELECT name, ST_Y(geom) AS lat, ST_X(geom) AS lon,
+                       (COALESCE(tags->>'service:bicycle:repair', '') = 'yes')::int AS has_repair
+                FROM osm.bike_shops
+                WHERE ST_DWithin(
+                    geom::geography,
+                    ST_SetSRID(ST_GeomFromText(:wkt), 4326)::geography,
+                    :radius
+                )
+                SQL,
+            [
+                'wkt' => WktGeometry::lineStringOrPoint($route),
+                'radius' => $radiusMeters,
+            ],
+        );
+
+        $bikeShops = [];
+        foreach ($rows as $row) {
+            $bikeShops[] = [
+                'name' => null !== $row['name'] ? (string) $row['name'] : null,
+                'lat' => (float) $row['lat'],
+                'lon' => (float) $row['lon'],
+                'hasRepair' => 1 === (int) $row['has_repair'],
+            ];
+        }
+
+        return $bikeShops;
+    }
+}

--- a/api/src/Osm/BikeShopRepositoryInterface.php
+++ b/api/src/Osm/BikeShopRepositoryInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Osm;
+
+interface BikeShopRepositoryInterface
+{
+    /**
+     * Bike shops whose geometry is within $radiusMeters of the route corridor.
+     *
+     * @param list<array{lat: float, lon: float}> $route
+     *
+     * @return list<array{name: ?string, lat: float, lon: float, hasRepair: bool}>
+     */
+    public function findInCorridor(array $route, int $radiusMeters): array;
+}

--- a/api/tests/Integration/Osm/OsmRepositoriesTest.php
+++ b/api/tests/Integration/Osm/OsmRepositoriesTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Integration\Osm;
 
 use App\Osm\AccommodationRepository;
+use App\Osm\BikeShopRepository;
 use App\Osm\PoiRepository;
 use App\Osm\WaterPointRepository;
 use Doctrine\DBAL\Connection;
@@ -37,7 +38,7 @@ final class OsmRepositoriesTest extends KernelTestCase
         $this->connection = $connection;
 
         // osm.* are not Doctrine entities, so the reset does not clear them.
-        $this->connection->executeStatement('TRUNCATE osm.pois, osm.accommodations, osm.water_points');
+        $this->connection->executeStatement('TRUNCATE osm.pois, osm.accommodations, osm.water_points, osm.bike_shops');
     }
 
     #[Test]
@@ -97,12 +98,39 @@ final class OsmRepositoriesTest extends KernelTestCase
     }
 
     #[Test]
+    public function bikeShopRepositoryDerivesRepairFlagAndFiltersByCorridor(): void
+    {
+        $this->seedBikeShop('bicycle', 49.61, 6.14, 'Repair Shop', '{"shop":"bicycle","service:bicycle:repair":"yes"}');
+        $this->seedBikeShop('bicycle', 49.615, 6.145, 'Sale Only', '{"shop":"bicycle"}');
+        $this->seedBikeShop('repair_station', 49.612, 6.142, 'Workshop', '{"service:bicycle:repair":"yes"}');
+        $this->seedBikeShop('bicycle', 49.90, 6.80, 'Far Shop', '{"shop":"bicycle","service:bicycle:repair":"yes"}');
+
+        $shops = new BikeShopRepository($this->connection)->findInCorridor([
+            ['lat' => 49.60, 'lon' => 6.13],
+            ['lat' => 49.62, 'lon' => 6.15],
+        ], 2000);
+
+        // Three shops in the corridor; the far one is excluded by ST_DWithin.
+        $repairByName = [];
+        foreach ($shops as $shop) {
+            $repairByName[(string) $shop['name']] = $shop['hasRepair'];
+        }
+
+        self::assertCount(3, $shops);
+        self::assertTrue($repairByName['Repair Shop'], 'shop=bicycle with service:bicycle:repair=yes is a repair shop');
+        self::assertFalse($repairByName['Sale Only'], 'shop=bicycle without the repair tag is sale-only');
+        self::assertTrue($repairByName['Workshop'], 'a repair workshop without shop=bicycle still has repair');
+        self::assertArrayNotHasKey('Far Shop', $repairByName);
+    }
+
+    #[Test]
     public function emptyRouteOrCategoriesYieldNoQuery(): void
     {
         $this->seedPoi('restaurant', 49.61, 6.14);
 
         self::assertSame([], new PoiRepository($this->connection)->findInCorridor([], 2000));
         self::assertSame([], new WaterPointRepository($this->connection)->findInCorridor([], 2000));
+        self::assertSame([], new BikeShopRepository($this->connection)->findInCorridor([], 2000));
         self::assertSame([], new AccommodationRepository($this->connection)->findNear([['lat' => 49.61, 'lon' => 6.14]], 5000, []));
         self::assertSame([], new AccommodationRepository($this->connection)->findNear([], 5000, ['hotel']));
     }
@@ -137,6 +165,17 @@ final class OsmRepositoriesTest extends KernelTestCase
                 VALUES ('n', :id, :name, :category, :stars, '{}'::jsonb, ST_SetSRID(ST_MakePoint(:lon, :lat), 4326))
                 SQL,
             ['id' => ++$this->osmId, 'name' => $name, 'category' => $category, 'stars' => $stars, 'lon' => $lon, 'lat' => $lat],
+        );
+    }
+
+    private function seedBikeShop(string $category, float $lat, float $lon, ?string $name, string $tagsJson): void
+    {
+        $this->connection->executeStatement(
+            <<<'SQL'
+                INSERT INTO osm.bike_shops (osm_type, osm_id, name, category, tags, geom)
+                VALUES ('n', :id, :name, :category, CAST(:tags AS jsonb), ST_SetSRID(ST_MakePoint(:lon, :lat), 4326))
+                SQL,
+            ['id' => ++$this->osmId, 'name' => $name, 'category' => $category, 'tags' => $tagsJson, 'lon' => $lon, 'lat' => $lat],
         );
     }
 }

--- a/api/tests/Unit/MessageHandler/CheckBikeShopsHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/CheckBikeShopsHandlerTest.php
@@ -68,8 +68,11 @@ final class CheckBikeShopsHandlerTest extends TestCase
         GeoDistanceInterface $haversine,
         ?ComputationTrackerInterface $computationTracker = null,
     ): CheckBikeShopsHandler {
-        $computationTracker ??= $this->createStub(ComputationTrackerInterface::class);
-        $computationTracker->method('getProgress')->willReturn(['completed' => 0, 'failed' => 0, 'total' => 1]);
+        if (null === $computationTracker) {
+            $stub = $this->createStub(ComputationTrackerInterface::class);
+            $stub->method('getProgress')->willReturn(['completed' => 0, 'failed' => 0, 'total' => 1]);
+            $computationTracker = $stub;
+        }
 
         $translator = $this->createStub(TranslatorInterface::class);
         $translator->method('trans')->willReturnCallback(

--- a/api/tests/Unit/MessageHandler/CheckBikeShopsHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/CheckBikeShopsHandlerTest.php
@@ -13,9 +13,8 @@ use App\Mercure\MercureEventType;
 use App\Mercure\TripUpdatePublisherInterface;
 use App\Message\CheckBikeShops;
 use App\MessageHandler\CheckBikeShopsHandler;
+use App\Osm\BikeShopRepositoryInterface;
 use App\Repository\TripRequestRepositoryInterface;
-use App\Scanner\QueryBuilderInterface;
-use App\Scanner\ScannerInterface;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
@@ -44,11 +43,27 @@ final class CheckBikeShopsHandlerTest extends TestCase
         return $stages;
     }
 
+    /**
+     * @param list<array{name: ?string, lat: float, lon: float, hasRepair: bool}> $shops
+     */
+    private function bikeShopRepository(array $shops): BikeShopRepositoryInterface
+    {
+        $repository = $this->createStub(BikeShopRepositoryInterface::class);
+        $repository->method('findInCorridor')->willReturnCallback(
+            static function (array $route, int $radiusMeters) use ($shops): array {
+                self::assertSame(2000, $radiusMeters, 'findInCorridor must use the 2 km corridor radius');
+
+                return $shops;
+            },
+        );
+
+        return $repository;
+    }
+
     private function createHandler(
         TripRequestRepositoryInterface $tripStateManager,
         TripUpdatePublisherInterface $publisher,
-        ScannerInterface $scanner,
-        QueryBuilderInterface $queryBuilder,
+        BikeShopRepositoryInterface $bikeShopRepository,
         GeoDistanceInterface $haversine,
     ): CheckBikeShopsHandler {
         $computationTracker = $this->createStub(ComputationTrackerInterface::class);
@@ -71,36 +86,29 @@ final class CheckBikeShopsHandlerTest extends TestCase
             $generationTracker,
             new NullLogger(),
             $tripStateManager,
-            $scanner,
-            $queryBuilder,
+            $bikeShopRepository,
             $haversine,
             $translator,
             $this->createStub(MessageBusInterface::class),
         );
     }
 
-    #[Test]
-    public function shopWithRepairServiceEmitsNoAlert(): void
+    private function tripStateManager(string $tripId, int $stageCount = 6): TripRequestRepositoryInterface
     {
-        $stages = $this->createStages('trip-1');
-
         $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
-        $tripStateManager->method('getStages')->willReturn($stages);
+        $tripStateManager->method('getStages')->willReturn($this->createStages($tripId, $stageCount));
         $tripStateManager->method('getLocale')->willReturn('en');
         $tripStateManager->method('getDecimatedPoints')->willReturn(null);
 
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildBikeShopQuery')->willReturn('query');
+        return $tripStateManager;
+    }
 
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('query')->willReturn([
-            'elements' => [
-                [
-                    'lat' => 48.5,
-                    'lon' => 2.5,
-                    'tags' => ['shop' => 'bicycle', 'service:bicycle:repair' => 'yes'],
-                ],
-            ],
+    #[Test]
+    public function repairShopNearbyEmitsNoAlert(): void
+    {
+        $tripStateManager = $this->tripStateManager('trip-1');
+        $bikeShopRepository = $this->bikeShopRepository([
+            ['name' => 'Cycles Repair', 'lat' => 48.5, 'lon' => 2.5, 'hasRepair' => true],
         ]);
 
         // Shop is close to every stage's midpoint (endPoint: 48.5, 2.5)
@@ -116,32 +124,16 @@ final class CheckBikeShopsHandlerTest extends TestCase
                 $this->callback(static fn (array $data): bool => [] === $data['alerts']),
             );
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine);
+        $handler = $this->createHandler($tripStateManager, $publisher, $bikeShopRepository, $haversine);
         $handler(new CheckBikeShops('trip-1'));
     }
 
     #[Test]
-    public function shopWithoutRepairServiceEmitsNoRepairNudge(): void
+    public function saleOnlyShopNearbyEmitsNoRepairNudge(): void
     {
-        $stages = $this->createStages('trip-1');
-
-        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
-        $tripStateManager->method('getStages')->willReturn($stages);
-        $tripStateManager->method('getLocale')->willReturn('en');
-        $tripStateManager->method('getDecimatedPoints')->willReturn(null);
-
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildBikeShopQuery')->willReturn('query');
-
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('query')->willReturn([
-            'elements' => [
-                [
-                    'lat' => 48.5,
-                    'lon' => 2.5,
-                    'tags' => ['shop' => 'bicycle'],
-                ],
-            ],
+        $tripStateManager = $this->tripStateManager('trip-1');
+        $bikeShopRepository = $this->bikeShopRepository([
+            ['name' => 'Cycles Sale', 'lat' => 48.5, 'lon' => 2.5, 'hasRepair' => false],
         ]);
 
         // Sale-only shop is close to every stage's midpoint
@@ -174,25 +166,15 @@ final class CheckBikeShopsHandlerTest extends TestCase
                 }),
             );
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine);
+        $handler = $this->createHandler($tripStateManager, $publisher, $bikeShopRepository, $haversine);
         $handler(new CheckBikeShops('trip-1'));
     }
 
     #[Test]
     public function noShopNearbyEmitsStandardNudge(): void
     {
-        $stages = $this->createStages('trip-1');
-
-        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
-        $tripStateManager->method('getStages')->willReturn($stages);
-        $tripStateManager->method('getLocale')->willReturn('en');
-        $tripStateManager->method('getDecimatedPoints')->willReturn(null);
-
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildBikeShopQuery')->willReturn('query');
-
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('query')->willReturn(['elements' => []]);
+        $tripStateManager = $this->tripStateManager('trip-1');
+        $bikeShopRepository = $this->bikeShopRepository([]);
 
         $haversine = $this->createStub(GeoDistanceInterface::class);
 
@@ -212,49 +194,25 @@ final class CheckBikeShopsHandlerTest extends TestCase
                 }),
             );
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine);
+        $handler = $this->createHandler($tripStateManager, $publisher, $bikeShopRepository, $haversine);
         $handler(new CheckBikeShops('trip-1'));
     }
 
     #[Test]
-    public function repairServiceWithoutBicycleShopTagEmitsNoAlert(): void
+    public function tripWithFewStagesIsSkipped(): void
     {
-        $stages = $this->createStages('trip-1');
-
-        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
-        $tripStateManager->method('getStages')->willReturn($stages);
-        $tripStateManager->method('getLocale')->willReturn('en');
-        $tripStateManager->method('getDecimatedPoints')->willReturn(null);
-
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildBikeShopQuery')->willReturn('query');
-
-        // Associative workshop: has repair tag but no shop=bicycle
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('query')->willReturn([
-            'elements' => [
-                [
-                    'lat' => 48.5,
-                    'lon' => 2.5,
-                    'tags' => ['service:bicycle:repair' => 'yes'],
-                ],
-            ],
-        ]);
-
-        // Repair workshop is close to every stage's midpoint
-        $haversine = $this->createStub(GeoDistanceInterface::class);
-        $haversine->method('inMeters')->willReturn(100.0);
+        // BR-06: trips of 5 days or fewer skip the bike-shop check entirely.
+        $tripStateManager = $this->tripStateManager('trip-1', 5);
 
         $publisher = $this->createMock(TripUpdatePublisherInterface::class);
-        $publisher->expects($this->once())
-            ->method('publish')
-            ->with(
-                'trip-1',
-                MercureEventType::BIKE_SHOP_ALERTS,
-                $this->callback(static fn (array $data): bool => [] === $data['alerts']),
-            );
+        $publisher->expects($this->never())->method('publish');
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine);
+        $handler = $this->createHandler(
+            $tripStateManager,
+            $publisher,
+            $this->bikeShopRepository([['name' => 'Cycles Repair', 'lat' => 48.5, 'lon' => 2.5, 'hasRepair' => true]]),
+            $this->createStub(GeoDistanceInterface::class),
+        );
         $handler(new CheckBikeShops('trip-1'));
     }
 }

--- a/api/tests/Unit/MessageHandler/CheckBikeShopsHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/CheckBikeShopsHandlerTest.php
@@ -68,7 +68,7 @@ final class CheckBikeShopsHandlerTest extends TestCase
         GeoDistanceInterface $haversine,
         ?ComputationTrackerInterface $computationTracker = null,
     ): CheckBikeShopsHandler {
-        if (null === $computationTracker) {
+        if (!$computationTracker instanceof ComputationTrackerInterface) {
             $stub = $this->createStub(ComputationTrackerInterface::class);
             $stub->method('getProgress')->willReturn(['completed' => 0, 'failed' => 0, 'total' => 1]);
             $computationTracker = $stub;

--- a/api/tests/Unit/MessageHandler/CheckBikeShopsHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/CheckBikeShopsHandlerTest.php
@@ -8,6 +8,7 @@ use App\ApiResource\Model\Coordinate;
 use App\ApiResource\Stage;
 use App\ComputationTracker\ComputationTrackerInterface;
 use App\ComputationTracker\TripGenerationTrackerInterface;
+use App\Enum\ComputationName;
 use App\Geo\GeoDistanceInterface;
 use App\Mercure\MercureEventType;
 use App\Mercure\TripUpdatePublisherInterface;
@@ -65,8 +66,9 @@ final class CheckBikeShopsHandlerTest extends TestCase
         TripUpdatePublisherInterface $publisher,
         BikeShopRepositoryInterface $bikeShopRepository,
         GeoDistanceInterface $haversine,
+        ?ComputationTrackerInterface $computationTracker = null,
     ): CheckBikeShopsHandler {
-        $computationTracker = $this->createStub(ComputationTrackerInterface::class);
+        $computationTracker ??= $this->createStub(ComputationTrackerInterface::class);
         $computationTracker->method('getProgress')->willReturn(['completed' => 0, 'failed' => 0, 'total' => 1]);
 
         $translator = $this->createStub(TranslatorInterface::class);
@@ -201,17 +203,24 @@ final class CheckBikeShopsHandlerTest extends TestCase
     #[Test]
     public function tripWithFewStagesIsSkipped(): void
     {
-        // BR-06: trips of 5 days or fewer skip the bike-shop check entirely.
+        // BR-06: trips of 5 days or fewer skip the check entirely, but must still mark
+        // the computation done so trip generation does not hang waiting for a result.
         $tripStateManager = $this->tripStateManager('trip-1', 5);
 
         $publisher = $this->createMock(TripUpdatePublisherInterface::class);
         $publisher->expects($this->never())->method('publish');
+
+        $computationTracker = $this->createMock(ComputationTrackerInterface::class);
+        $computationTracker->expects($this->once())
+            ->method('markDone')
+            ->with('trip-1', ComputationName::BIKE_SHOPS);
 
         $handler = $this->createHandler(
             $tripStateManager,
             $publisher,
             $this->bikeShopRepository([['name' => 'Cycles Repair', 'lat' => 48.5, 'lon' => 2.5, 'hasRepair' => true]]),
             $this->createStub(GeoDistanceInterface::class),
+            $computationTracker,
         );
         $handler(new CheckBikeShops('trip-1'));
     }

--- a/provisioner/osm2pgsql/tier1.lua
+++ b/provisioner/osm2pgsql/tier1.lua
@@ -5,7 +5,7 @@
 -- the live `osm` schema atomically. The API reads these tables via ST_DWithin
 -- corridor queries, replacing the runtime Overpass dependency.
 --
--- Scope of this style (PR2a-2): pois, accommodations, water_points. The
+-- Scope of this style: pois, accommodations, water_points, bike_shops. The
 -- admin_boundaries (coverage polygon) and cycle_routes tables land later.
 
 -- MUST match PostgisImporter::STAGING_SCHEMA: osm2pgsql writes the output tables
@@ -89,6 +89,21 @@ local water_points = osm2pgsql.define_table({
     },
 })
 
+local bike_shops = osm2pgsql.define_table({
+    name = 'bike_shops',
+    schema = SCHEMA,
+    ids = { type = 'any', id_column = 'osm_id', type_column = 'osm_type' },
+    columns = {
+        { column = 'name', type = 'text' },
+        { column = 'category', type = 'text', not_null = true },
+        { column = 'tags', type = 'jsonb' },
+        { column = 'geom', type = 'point', projection = SRID, not_null = true },
+    },
+    indexes = {
+        { column = 'geom', method = 'gist' },
+    },
+})
+
 local function poi_category(tags)
     if tags.amenity and POI_AMENITY[tags.amenity] then return tags.amenity end
     if tags.shop and POI_SHOP[tags.shop] then return tags.shop end
@@ -112,10 +127,19 @@ local function water_category(tags)
     return nil
 end
 
+-- Bicycle shops and generic outlets advertising repair (service:bicycle:repair=yes);
+-- the repair flag is preserved in the raw tags for the read side to distinguish them.
+local function bike_shop_category(tags)
+    if tags.shop == 'bicycle' then return 'bicycle' end
+    if tags['service:bicycle:repair'] == 'yes' then return 'repair_station' end
+    return nil
+end
+
 local function is_relevant(tags)
     return poi_category(tags) ~= nil
         or accommodation_category(tags) ~= nil
         or water_category(tags) ~= nil
+        or bike_shop_category(tags) ~= nil
 end
 
 -- Safe integer coercion (works on both Lua 5.x and LuaJIT builds of osm2pgsql).
@@ -159,6 +183,16 @@ local function insert_features(tags, geom)
         water_points:insert({
             name = tags.name,
             category = wcat,
+            tags = tags,
+            geom = geom,
+        })
+    end
+
+    local bcat = bike_shop_category(tags)
+    if bcat then
+        bike_shops:insert({
+            name = tags.name,
+            category = bcat,
             tags = tags,
             geom = geom,
         })


### PR DESCRIPTION
## Contexte

Suite du retrait de la dépendance Overpass runtime (ADR-040), après POI (#667), eau (#668) et hébergements (#669). Objectif : **toutes** les données statiques issues d'OSM migrées vers PostGIS pour éliminer l'instabilité des services tiers en runtime. Les données réellement variables (météo, fetch d'itinéraire) restent live (Tier 3) — elles ne sont pas concernées.

Cette slice bascule les **magasins vélo** (`CheckBikeShopsHandler`).

## Changements

- **Provisioner** (`tier1.lua`) : nouvelle table flex `bike_shops` (point + GIST) ; catégorie `bicycle` (shop=bicycle) ou `repair_station` (outlet avec `service:bicycle:repair=yes`). Les tags bruts sont conservés pour distinguer réparateurs et vendeurs côté lecture.
- **Migration** `Version20260615120000` : table `osm.bike_shops` (mirror du flex) + index GIST, pour le bootstrap avant provisioning et le seeding des tests.
- **`BikeShopRepository`** (+ interface) : `findInCorridor(route, radius)` via `ST_DWithin`, avec le flag `hasRepair` dérivé en SQL (`COALESCE(tags->>'service:bicycle:repair','') = 'yes'` → `0/1` franc, robuste aux tags absents/NULL).
- **`CheckBikeShopsHandler`** : injecte `BikeShopRepositoryInterface` (plus de `ScannerInterface`/`QueryBuilderInterface`), lit le corridor (rayon 2 km, identique à l'ancien `around`), construit les listes réparateur/vente-seule depuis `hasRepair`. Logique d'alerte et seuils inchangés (BR-06 ≤ 5 étapes, proximité 2 km).
- **Tests** : test unitaire réécrit (mock de l'interface : réparateur → pas d'alerte, vente-seule → `no_repair_nudge`, aucun → nudge standard, trip court ignoré, rayon épinglé) ; `OsmRepositoriesTest` étendu (corridor + dérivation `hasRepair` : shop=bicycle+repair, vente seule, atelier-réparation sans shop=bicycle, hors corridor).

La distinction réparateur/vendeur passe de l'analyse (tags Overpass) à l'import/repo (tags persistés) — couverte par le test d'intégration sur DB réelle.

## Vérification

- `php -l` OK (6 fichiers), `luac -p tier1.lua` OK, PHP-CS-Fixer 0/6.
- DDL + requête corridor + dérivation `has_repair` validées contre la base PostGIS bootée (transaction annulée) : réparateur=1, vente-seule=0, atelier=1, tags NULL=0, magasin lointain exclu par `ST_DWithin`.
- PHPStan 9 + PHPUnit (unitaire + intégration) délégués à la CI.

<!-- claude-review-start -->
## Claude Review

Reviewed commit `eefd2fbf98c6dada886da42ebd8279aa8151ee7e`.

Clean fourth slice of the ADR-040 migration series. Both findings from the previous review were addressed before this run (both threads were pre-resolved). No new findings.

**PR title:** `feat(bike-shops): lecture des magasins vélo depuis l'index PostGIS local (ADR-040)` — description in French while commit messages use English. Not a Conventional Commits violation per se, but inconsistent with the rest of the history.

**Review checklist**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.
<!-- claude-review-end -->