### PR TITLE
feat(health-services): lecture des services de santé depuis l'index PostGIS local (ADR-040)

### DIFF
--- a/api/migrations/Version20260615130000.php
+++ b/api/migrations/Version20260615130000.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Adds osm.health_services to the local-first Tier-1 reference schema (ADR-040):
+ * a PostGIS point table (pharmacies, hospitals, clinics) read by the API via
+ * ST_DWithin corridor queries, replacing the runtime Overpass health-service scan.
+ *
+ * Mirrors the osm2pgsql flex output (provisioner/osm2pgsql/tier1.lua): the
+ * provisioner imports into a staging schema and atomically swaps it onto `osm`.
+ * This migration bootstraps the table so it exists before the first provisioning
+ * run and so functional tests have it to seed and query.
+ */
+final class Version20260615130000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add the osm.health_services reference table for local-first health-service reads';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE SCHEMA IF NOT EXISTS osm');
+
+        $this->addSql(<<<'SQL'
+            CREATE TABLE IF NOT EXISTS osm.health_services (
+                osm_type character(1) NOT NULL,
+                osm_id bigint NOT NULL,
+                name text,
+                category text NOT NULL,
+                tags jsonb,
+                geom geometry(Point, 4326) NOT NULL,
+                PRIMARY KEY (osm_type, osm_id)
+            )
+            SQL);
+
+        $this->addSql('CREATE INDEX IF NOT EXISTS health_services_geom_idx ON osm.health_services USING gist (geom)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE IF EXISTS osm.health_services');
+    }
+}

--- a/api/src/MessageHandler/CheckHealthServicesHandler.php
+++ b/api/src/MessageHandler/CheckHealthServicesHandler.php
@@ -14,9 +14,8 @@ use App\Geo\GeoDistanceInterface;
 use App\Mercure\MercureEventType;
 use App\Mercure\TripUpdatePublisherInterface;
 use App\Message\CheckHealthServices;
+use App\Osm\HealthServiceRepositoryInterface;
 use App\Repository\TripRequestRepositoryInterface;
-use App\Scanner\QueryBuilderInterface;
-use App\Scanner\ScannerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -30,8 +29,10 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 #[AsMessageHandler]
 final readonly class CheckHealthServicesHandler extends AbstractTripMessageHandler
 {
-    /** Must be ≤ OsmOverpassQueryBuilder::HEALTH_SERVICE_RADIUS_METERS to avoid false alerts. */
     private const float HEALTH_SERVICE_PROXIMITY_METERS = 15000.0;
+
+    /** Corridor half-width (m) for the local-first health-service reads (ADR-040); kept equal to HEALTH_SERVICE_PROXIMITY_METERS so the DB pre-filter always covers the per-stage proximity threshold. */
+    private const int CORRIDOR_RADIUS_METERS = (int) self::HEALTH_SERVICE_PROXIMITY_METERS;
 
     public function __construct(
         ComputationTrackerInterface $computationTracker,
@@ -39,8 +40,7 @@ final readonly class CheckHealthServicesHandler extends AbstractTripMessageHandl
         TripGenerationTrackerInterface $generationTracker,
         LoggerInterface $logger,
         private TripRequestRepositoryInterface $tripStateManager,
-        private ScannerInterface $scanner,
-        private QueryBuilderInterface $queryBuilder,
+        private HealthServiceRepositoryInterface $healthServiceRepository,
         private GeoDistanceInterface $haversine,
         private TranslatorInterface $translator,
         MessageBusInterface $messageBus,
@@ -61,6 +61,7 @@ final readonly class CheckHealthServicesHandler extends AbstractTripMessageHandl
         $locale = $this->tripStateManager->getLocale($tripId) ?? 'en';
 
         $this->executeWithTracking($tripId, ComputationName::HEALTH_SERVICES, function () use ($tripId, $stages, $locale): void {
+            // Read health services from the local-first index along the route corridor (ADR-040).
             $decimatedData = $this->tripStateManager->getDecimatedPoints($tripId);
             $points = null !== $decimatedData
                 ? array_map(static fn (array $p): Coordinate => new Coordinate($p['lat'], $p['lon'], $p['ele']), $decimatedData)
@@ -69,24 +70,12 @@ final readonly class CheckHealthServicesHandler extends AbstractTripMessageHandl
                     $stages,
                 ));
 
-            $query = $this->queryBuilder->buildHealthServiceQuery($points);
-            $result = $this->scanner->query($query);
+            $route = array_map(static fn (Coordinate $point): array => ['lat' => $point->lat, 'lon' => $point->lon], $points);
 
-            /** @var list<array{lat?: float, lon?: float, center?: array{lat: float, lon: float}, tags?: array<string, string>}> $elements */
-            $elements = \is_array($result['elements'] ?? null) ? $result['elements'] : [];
-
-            // Parse health service locations
             /** @var list<array{lat: float, lon: float}> $healthServiceLocations */
             $healthServiceLocations = [];
-            foreach ($elements as $element) {
-                $lat = $element['lat'] ?? ($element['center']['lat'] ?? null);
-                $lon = $element['lon'] ?? ($element['center']['lon'] ?? null);
-
-                if (null === $lat || null === $lon) {
-                    continue;
-                }
-
-                $healthServiceLocations[] = ['lat' => (float) $lat, 'lon' => (float) $lon];
+            foreach ($this->healthServiceRepository->findInCorridor($route, self::CORRIDOR_RADIUS_METERS) as $service) {
+                $healthServiceLocations[] = ['lat' => $service['lat'], 'lon' => $service['lon']];
             }
 
             // Check each stage for nearby health services

--- a/api/src/Osm/HealthServiceRepository.php
+++ b/api/src/Osm/HealthServiceRepository.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Osm;
+
+use Doctrine\DBAL\Connection;
+
+/**
+ * Reads health services (pharmacies, hospitals, clinics) from the local-first
+ * Tier-1 index along the route corridor (ST_DWithin), replacing the runtime
+ * Overpass health-service scan (ADR-040).
+ */
+final readonly class HealthServiceRepository implements HealthServiceRepositoryInterface
+{
+    public function __construct(private Connection $connection)
+    {
+    }
+
+    /**
+     * Health services whose geometry is within $radiusMeters of the route corridor.
+     *
+     * @param list<array{lat: float, lon: float}> $route
+     *
+     * @return list<array{name: ?string, category: string, lat: float, lon: float}>
+     */
+    public function findInCorridor(array $route, int $radiusMeters): array
+    {
+        if ([] === $route) {
+            return [];
+        }
+
+        /** @var list<array<string, scalar|null>> $rows */
+        $rows = $this->connection->fetchAllAssociative(
+            <<<'SQL'
+                SELECT name, category, ST_Y(geom) AS lat, ST_X(geom) AS lon
+                FROM osm.health_services
+                WHERE ST_DWithin(
+                    geom::geography,
+                    ST_SetSRID(ST_GeomFromText(:wkt), 4326)::geography,
+                    :radius
+                )
+                SQL,
+            [
+                'wkt' => WktGeometry::lineStringOrPoint($route),
+                'radius' => $radiusMeters,
+            ],
+        );
+
+        $healthServices = [];
+        foreach ($rows as $row) {
+            $healthServices[] = [
+                'name' => null !== $row['name'] ? (string) $row['name'] : null,
+                'category' => (string) $row['category'],
+                'lat' => (float) $row['lat'],
+                'lon' => (float) $row['lon'],
+            ];
+        }
+
+        return $healthServices;
+    }
+}

--- a/api/src/Osm/HealthServiceRepositoryInterface.php
+++ b/api/src/Osm/HealthServiceRepositoryInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Osm;
+
+interface HealthServiceRepositoryInterface
+{
+    /**
+     * Health services (pharmacy, hospital, clinic) whose geometry is within
+     * $radiusMeters of the route corridor.
+     *
+     * @param list<array{lat: float, lon: float}> $route
+     *
+     * @return list<array{name: ?string, category: string, lat: float, lon: float}>
+     */
+    public function findInCorridor(array $route, int $radiusMeters): array;
+}

--- a/api/tests/Integration/Osm/OsmRepositoriesTest.php
+++ b/api/tests/Integration/Osm/OsmRepositoriesTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Integration\Osm;
 
 use App\Osm\AccommodationRepository;
 use App\Osm\BikeShopRepository;
+use App\Osm\HealthServiceRepository;
 use App\Osm\PoiRepository;
 use App\Osm\WaterPointRepository;
 use Doctrine\DBAL\Connection;
@@ -14,12 +15,9 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Foundry\Test\ResetDatabase;
 
 /**
- * Integration coverage for the local-first Tier-1 read layer (ADR-040, #56):
- * exercises the real PostGIS `osm` schema (created by Version20260614120000)
- * with seeded rows and asserts the ST_DWithin corridor / radius filtering.
- *
- * The repositories are instantiated directly on the real DBAL connection: they
- * have no consumer until the cut-over PR, so the container would prune them.
+ * Integration coverage for the local-first Tier-1 read layer (ADR-040): exercises
+ * the real PostGIS `osm` schema with seeded rows and asserts the ST_DWithin
+ * corridor / radius / category filtering for each repository.
  */
 final class OsmRepositoriesTest extends KernelTestCase
 {
@@ -38,7 +36,7 @@ final class OsmRepositoriesTest extends KernelTestCase
         $this->connection = $connection;
 
         // osm.* are not Doctrine entities, so the reset does not clear them.
-        $this->connection->executeStatement('TRUNCATE osm.pois, osm.accommodations, osm.water_points, osm.bike_shops');
+        $this->connection->executeStatement('TRUNCATE osm.pois, osm.accommodations, osm.water_points, osm.bike_shops, osm.health_services');
     }
 
     #[Test]
@@ -124,6 +122,26 @@ final class OsmRepositoriesTest extends KernelTestCase
     }
 
     #[Test]
+    public function healthServiceRepositoryReturnsServicesWithinTheCorridor(): void
+    {
+        $this->seedHealthService('pharmacy', 49.61, 6.14, 'On Route Pharmacy');
+        $this->seedHealthService('clinic', 49.615, 6.145, 'On Route Clinic');
+        $this->seedHealthService('hospital', 49.90, 6.80, 'Far Hospital');
+
+        $services = new HealthServiceRepository($this->connection)->findInCorridor([
+            ['lat' => 49.60, 'lon' => 6.13],
+            ['lat' => 49.62, 'lon' => 6.15],
+        ], 2000);
+
+        // Both in-corridor services are returned (no category filter); the far
+        // hospital is excluded by ST_DWithin.
+        $categories = array_map(static fn (array $service): string => $service['category'], $services);
+        self::assertCount(2, $services);
+        self::assertContains('pharmacy', $categories);
+        self::assertContains('clinic', $categories);
+    }
+
+    #[Test]
     public function emptyRouteOrCategoriesYieldNoQuery(): void
     {
         $this->seedPoi('restaurant', 49.61, 6.14);
@@ -131,6 +149,7 @@ final class OsmRepositoriesTest extends KernelTestCase
         self::assertSame([], new PoiRepository($this->connection)->findInCorridor([], 2000));
         self::assertSame([], new WaterPointRepository($this->connection)->findInCorridor([], 2000));
         self::assertSame([], new BikeShopRepository($this->connection)->findInCorridor([], 2000));
+        self::assertSame([], new HealthServiceRepository($this->connection)->findInCorridor([], 2000));
         self::assertSame([], new AccommodationRepository($this->connection)->findNear([['lat' => 49.61, 'lon' => 6.14]], 5000, []));
         self::assertSame([], new AccommodationRepository($this->connection)->findNear([], 5000, ['hotel']));
     }
@@ -176,6 +195,17 @@ final class OsmRepositoriesTest extends KernelTestCase
                 VALUES ('n', :id, :name, :category, CAST(:tags AS jsonb), ST_SetSRID(ST_MakePoint(:lon, :lat), 4326))
                 SQL,
             ['id' => ++$this->osmId, 'name' => $name, 'category' => $category, 'tags' => $tagsJson, 'lon' => $lon, 'lat' => $lat],
+        );
+    }
+
+    private function seedHealthService(string $category, float $lat, float $lon, ?string $name): void
+    {
+        $this->connection->executeStatement(
+            <<<'SQL'
+                INSERT INTO osm.health_services (osm_type, osm_id, name, category, tags, geom)
+                VALUES ('n', :id, :name, :category, '{}'::jsonb, ST_SetSRID(ST_MakePoint(:lon, :lat), 4326))
+                SQL,
+            ['id' => ++$this->osmId, 'name' => $name, 'category' => $category, 'lon' => $lon, 'lat' => $lat],
         );
     }
 }

--- a/api/tests/Unit/MessageHandler/CheckHealthServicesHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/CheckHealthServicesHandlerTest.php
@@ -13,9 +13,8 @@ use App\Mercure\MercureEventType;
 use App\Mercure\TripUpdatePublisherInterface;
 use App\Message\CheckHealthServices;
 use App\MessageHandler\CheckHealthServicesHandler;
+use App\Osm\HealthServiceRepositoryInterface;
 use App\Repository\TripRequestRepositoryInterface;
-use App\Scanner\QueryBuilderInterface;
-use App\Scanner\ScannerInterface;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
@@ -44,11 +43,40 @@ final class CheckHealthServicesHandlerTest extends TestCase
         return $stages;
     }
 
+    /**
+     * @param list<array{name: ?string, category: string, lat: float, lon: float}> $services
+     */
+    private function healthServiceRepository(array $services): HealthServiceRepositoryInterface
+    {
+        $repository = $this->createStub(HealthServiceRepositoryInterface::class);
+        $repository->method('findInCorridor')->willReturnCallback(
+            static function (array $route, int $radiusMeters) use ($services): array {
+                self::assertSame(15000, $radiusMeters, 'findInCorridor must use the 15 km corridor radius');
+
+                return $services;
+            },
+        );
+
+        return $repository;
+    }
+
+    /**
+     * @param list<Stage>|null $stages
+     */
+    private function tripStateManager(?array $stages): TripRequestRepositoryInterface
+    {
+        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
+        $tripStateManager->method('getStages')->willReturn($stages);
+        $tripStateManager->method('getLocale')->willReturn('en');
+        $tripStateManager->method('getDecimatedPoints')->willReturn(null);
+
+        return $tripStateManager;
+    }
+
     private function createHandler(
         TripRequestRepositoryInterface $tripStateManager,
         TripUpdatePublisherInterface $publisher,
-        ScannerInterface $scanner,
-        QueryBuilderInterface $queryBuilder,
+        HealthServiceRepositoryInterface $healthServiceRepository,
         GeoDistanceInterface $haversine,
     ): CheckHealthServicesHandler {
         $computationTracker = $this->createStub(ComputationTrackerInterface::class);
@@ -70,8 +98,7 @@ final class CheckHealthServicesHandlerTest extends TestCase
             $generationTracker,
             new NullLogger(),
             $tripStateManager,
-            $scanner,
-            $queryBuilder,
+            $healthServiceRepository,
             $haversine,
             $translator,
             $this->createStub(MessageBusInterface::class),
@@ -79,30 +106,14 @@ final class CheckHealthServicesHandlerTest extends TestCase
     }
 
     #[Test]
-    public function nearbyPharmacyEmitsNoAlert(): void
+    public function nearbyHealthServiceEmitsNoAlert(): void
     {
-        $stages = $this->createStages('trip-1');
-
-        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
-        $tripStateManager->method('getStages')->willReturn($stages);
-        $tripStateManager->method('getLocale')->willReturn('en');
-        $tripStateManager->method('getDecimatedPoints')->willReturn(null);
-
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildHealthServiceQuery')->willReturn('query');
-
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('query')->willReturn([
-            'elements' => [
-                [
-                    'lat' => 48.25,
-                    'lon' => 2.25,
-                    'tags' => ['amenity' => 'pharmacy'],
-                ],
-            ],
+        $tripStateManager = $this->tripStateManager($this->createStages('trip-1'));
+        $healthServiceRepository = $this->healthServiceRepository([
+            ['name' => 'Pharmacie du Centre', 'category' => 'pharmacy', 'lat' => 48.25, 'lon' => 2.25],
         ]);
 
-        // Pharmacy is close to every stage's midpoint
+        // Service is close to every stage's midpoint
         $haversine = $this->createStub(GeoDistanceInterface::class);
         $haversine->method('inMeters')->willReturn(5000.0);
 
@@ -115,25 +126,15 @@ final class CheckHealthServicesHandlerTest extends TestCase
                 $this->callback(static fn (array $data): bool => [] === $data['alerts']),
             );
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine);
+        $handler = $this->createHandler($tripStateManager, $publisher, $healthServiceRepository, $haversine);
         $handler(new CheckHealthServices('trip-1'));
     }
 
     #[Test]
     public function noHealthServiceEmitsNudgeForEveryStage(): void
     {
-        $stages = $this->createStages('trip-1');
-
-        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
-        $tripStateManager->method('getStages')->willReturn($stages);
-        $tripStateManager->method('getLocale')->willReturn('en');
-        $tripStateManager->method('getDecimatedPoints')->willReturn(null);
-
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildHealthServiceQuery')->willReturn('query');
-
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('query')->willReturn(['elements' => []]);
+        $tripStateManager = $this->tripStateManager($this->createStages('trip-1'));
+        $healthServiceRepository = $this->healthServiceRepository([]);
 
         $haversine = $this->createStub(GeoDistanceInterface::class);
 
@@ -152,35 +153,19 @@ final class CheckHealthServicesHandlerTest extends TestCase
                 }),
             );
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine);
+        $handler = $this->createHandler($tripStateManager, $publisher, $healthServiceRepository, $haversine);
         $handler(new CheckHealthServices('trip-1'));
     }
 
     #[Test]
     public function distantHealthServiceEmitsNudge(): void
     {
-        $stages = $this->createStages('trip-1', 2);
-
-        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
-        $tripStateManager->method('getStages')->willReturn($stages);
-        $tripStateManager->method('getLocale')->willReturn('en');
-        $tripStateManager->method('getDecimatedPoints')->willReturn(null);
-
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildHealthServiceQuery')->willReturn('query');
-
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('query')->willReturn([
-            'elements' => [
-                [
-                    'lat' => 49.0,
-                    'lon' => 3.0,
-                    'tags' => ['amenity' => 'hospital'],
-                ],
-            ],
+        $tripStateManager = $this->tripStateManager($this->createStages('trip-1', 2));
+        $healthServiceRepository = $this->healthServiceRepository([
+            ['name' => 'Hôpital Lointain', 'category' => 'hospital', 'lat' => 49.0, 'lon' => 3.0],
         ]);
 
-        // Hospital is too far from all stages (> 15 km)
+        // Service is too far from all stages (> 15 km)
         $haversine = $this->createStub(GeoDistanceInterface::class);
         $haversine->method('inMeters')->willReturn(20000.0);
 
@@ -198,64 +183,24 @@ final class CheckHealthServicesHandlerTest extends TestCase
                 }),
             );
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine);
+        $handler = $this->createHandler($tripStateManager, $publisher, $healthServiceRepository, $haversine);
         $handler(new CheckHealthServices('trip-1'));
     }
 
     #[Test]
     public function nullStagesReturnsEarly(): void
     {
-        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
-        $tripStateManager->method('getStages')->willReturn(null);
+        $tripStateManager = $this->tripStateManager(null);
 
         $publisher = $this->createMock(TripUpdatePublisherInterface::class);
         $publisher->expects($this->never())->method('publish');
 
-        $scanner = $this->createStub(ScannerInterface::class);
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $haversine = $this->createStub(GeoDistanceInterface::class);
-
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine);
-        $handler(new CheckHealthServices('trip-1'));
-    }
-
-    #[Test]
-    public function clinicWithinRadiusEmitsNoAlert(): void
-    {
-        $stages = $this->createStages('trip-1', 1);
-
-        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
-        $tripStateManager->method('getStages')->willReturn($stages);
-        $tripStateManager->method('getLocale')->willReturn('en');
-        $tripStateManager->method('getDecimatedPoints')->willReturn(null);
-
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildHealthServiceQuery')->willReturn('query');
-
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('query')->willReturn([
-            'elements' => [
-                [
-                    'center' => ['lat' => 48.3, 'lon' => 2.3],
-                    'tags' => ['amenity' => 'clinic'],
-                ],
-            ],
-        ]);
-
-        // Clinic within radius
-        $haversine = $this->createStub(GeoDistanceInterface::class);
-        $haversine->method('inMeters')->willReturn(10000.0);
-
-        $publisher = $this->createMock(TripUpdatePublisherInterface::class);
-        $publisher->expects($this->once())
-            ->method('publish')
-            ->with(
-                'trip-1',
-                MercureEventType::HEALTH_SERVICE_ALERTS,
-                $this->callback(static fn (array $data): bool => [] === $data['alerts']),
-            );
-
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine);
+        $handler = $this->createHandler(
+            $tripStateManager,
+            $publisher,
+            $this->healthServiceRepository([]),
+            $this->createStub(GeoDistanceInterface::class),
+        );
         $handler(new CheckHealthServices('trip-1'));
     }
 }

--- a/provisioner/osm2pgsql/tier1.lua
+++ b/provisioner/osm2pgsql/tier1.lua
@@ -5,7 +5,7 @@
 -- the live `osm` schema atomically. The API reads these tables via ST_DWithin
 -- corridor queries, replacing the runtime Overpass dependency.
 --
--- Scope of this style: pois, accommodations, water_points, bike_shops. The
+-- Scope of this style: pois, accommodations, water_points, bike_shops, health_services. The
 -- admin_boundaries (coverage polygon) and cycle_routes tables land later.
 
 -- MUST match PostgisImporter::STAGING_SCHEMA: osm2pgsql writes the output tables
@@ -104,6 +104,21 @@ local bike_shops = osm2pgsql.define_table({
     },
 })
 
+local health_services = osm2pgsql.define_table({
+    name = 'health_services',
+    schema = SCHEMA,
+    ids = { type = 'any', id_column = 'osm_id', type_column = 'osm_type' },
+    columns = {
+        { column = 'name', type = 'text' },
+        { column = 'category', type = 'text', not_null = true },
+        { column = 'tags', type = 'jsonb' },
+        { column = 'geom', type = 'point', projection = SRID, not_null = true },
+    },
+    indexes = {
+        { column = 'geom', method = 'gist' },
+    },
+})
+
 local function poi_category(tags)
     if tags.amenity and POI_AMENITY[tags.amenity] then return tags.amenity end
     if tags.shop and POI_SHOP[tags.shop] then return tags.shop end
@@ -135,11 +150,20 @@ local function bike_shop_category(tags)
     return nil
 end
 
+-- Health services: pharmacies, hospitals and clinics.
+local function health_category(tags)
+    if tags.amenity == 'pharmacy' or tags.amenity == 'hospital' or tags.amenity == 'clinic' then
+        return tags.amenity
+    end
+    return nil
+end
+
 local function is_relevant(tags)
     return poi_category(tags) ~= nil
         or accommodation_category(tags) ~= nil
         or water_category(tags) ~= nil
         or bike_shop_category(tags) ~= nil
+        or health_category(tags) ~= nil
 end
 
 -- Safe integer coercion (works on both Lua 5.x and LuaJIT builds of osm2pgsql).
@@ -193,6 +217,16 @@ local function insert_features(tags, geom)
         bike_shops:insert({
             name = tags.name,
             category = bcat,
+            tags = tags,
+            geom = geom,
+        })
+    end
+
+    local hcat = health_category(tags)
+    if hcat then
+        health_services:insert({
+            name = tags.name,
+            category = hcat,
             tags = tags,
             geom = geom,
         })


### PR DESCRIPTION
## Contexte

Slice #2 du retrait Overpass runtime (ADR-040), après les magasins vélo (#670). Bascule des **services de santé** (`CheckHealthServicesHandler` — pharmacies, hôpitaux, cliniques) sur l'index PostGIS local. Donnée statique OSM → import.

## Changements

- **Provisioner** (`tier1.lua`) : table flex `health_services` (point + GIST) ; catégorie = `amenity` ∈ {pharmacy, hospital, clinic}.
- **Migration** `Version20260615130000` : table `osm.health_services` (mirror du flex) + index GIST.
- **`HealthServiceRepository`** (+ interface) : `findInCorridor(route, radius)` via `ST_DWithin`, retourne `{name, category, lat, lon}` (même forme que `PoiRepository`).
- **`CheckHealthServicesHandler`** : injecte `HealthServiceRepositoryInterface` (plus de `ScannerInterface`/`QueryBuilderInterface`), lit le corridor (rayon 15 km, identique à l'ancien `around`). Const `CORRIDOR_RADIUS_METERS = (int) self::HEALTH_SERVICE_PROXIMITY_METERS` (le pré-filtre DB couvre toujours le seuil de proximité). Logique d'alerte inchangée (NUDGE si aucun service à 15 km du milieu d'étape).
- **Tests** : test unitaire réécrit (mock de l'interface : service proche → pas d'alerte, aucun → nudge par étape, service lointain → nudge, stages null → retour anticipé, rayon 15 km épinglé) ; `OsmRepositoriesTest` étendu (corridor santé : pharmacie + clinique retournées, hôpital lointain exclu) + docblock nettoyé (réf. ticket obsolète, rationale « no consumer » devenu faux).

## Vérification

- `php -l` OK (6 fichiers), `luac -p tier1.lua` OK, PHP-CS-Fixer 0/6.
- DDL + requête corridor validées contre la base PostGIS bootée (transaction annulée) : pharmacie + clinique dans le corridor retournées, hôpital à ~50 km exclu par `ST_DWithin`.
- PHPStan 9 + PHPUnit (unitaire + intégration) délégués à la CI.

<!-- claude-review-start -->
## Claude Review

Clean, consistent implementation. `HealthServiceRepository` follows the established DBAL/PostGIS pattern from `BikeShopRepository`/`PoiRepository` exactly: raw `Connection`, named-parameter query, scalar cast on return. The 15 km corridor radius equals `HEALTH_SERVICE_PROXIMITY_METERS`, so the DB pre-filter is guaranteed to cover every per-stage Haversine check — no false negatives possible. The Lua flex table definition is symmetric with the migration DDL (same column set, same GIST index, same PK shape). `AlertDocumentationTest::ALERT_RULE_MAP` already carries the `health_service` entry; no documentation update needed.

**PR title check:** The description uses a French noun phrase ("lecture des services de santé…") rather than the imperative mood required by Conventional Commits. The commit headline uses the correct form. Suggested fix: `feat(health-services): read health services from the local PostGIS index (ADR-040)`.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

No inline comments.

_Reviewed commit: 8b500b535ec9a0e46eda010fddaef8b9eab4ef9e_
<!-- claude-review-end -->