### PR TITLE
feat(railway-stations): read railway stations from the local PostGIS index (ADR-040)

### DIFF
--- a/api/migrations/Version20260615140000.php
+++ b/api/migrations/Version20260615140000.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Adds osm.railway_stations to the local-first Tier-1 reference schema (ADR-040):
+ * a PostGIS point table (mainline railway stations) read by the API via ST_DWithin
+ * queries, replacing the runtime Overpass railway-station scan.
+ *
+ * Mirrors the osm2pgsql flex output (provisioner/osm2pgsql/tier1.lua): the
+ * provisioner imports into a staging schema and atomically swaps it onto `osm`.
+ * This migration bootstraps the table so it exists before the first provisioning
+ * run and so functional tests have it to seed and query.
+ */
+final class Version20260615140000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add the osm.railway_stations reference table for local-first railway-station reads';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE SCHEMA IF NOT EXISTS osm');
+
+        $this->addSql(<<<'SQL'
+            CREATE TABLE IF NOT EXISTS osm.railway_stations (
+                osm_type character(1) NOT NULL,
+                osm_id bigint NOT NULL,
+                name text,
+                category text NOT NULL,
+                tags jsonb,
+                geom geometry(Point, 4326) NOT NULL,
+                PRIMARY KEY (osm_type, osm_id)
+            )
+            SQL);
+
+        $this->addSql('CREATE INDEX IF NOT EXISTS railway_stations_geom_idx ON osm.railway_stations USING gist (geom)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE IF EXISTS osm.railway_stations');
+    }
+}

--- a/api/src/MessageHandler/CheckRailwayStationsHandler.php
+++ b/api/src/MessageHandler/CheckRailwayStationsHandler.php
@@ -14,9 +14,8 @@ use App\Geo\GeoDistanceInterface;
 use App\Mercure\MercureEventType;
 use App\Mercure\TripUpdatePublisherInterface;
 use App\Message\CheckRailwayStations;
+use App\Osm\RailwayStationRepositoryInterface;
 use App\Repository\TripRequestRepositoryInterface;
-use App\Scanner\QueryBuilderInterface;
-use App\Scanner\ScannerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -41,8 +40,7 @@ final readonly class CheckRailwayStationsHandler extends AbstractTripMessageHand
         TripGenerationTrackerInterface $generationTracker,
         LoggerInterface $logger,
         private TripRequestRepositoryInterface $tripStateManager,
-        private ScannerInterface $scanner,
-        private QueryBuilderInterface $queryBuilder,
+        private RailwayStationRepositoryInterface $railwayStationRepository,
         private GeoDistanceInterface $haversine,
         private TranslatorInterface $translator,
         MessageBusInterface $messageBus,
@@ -72,23 +70,12 @@ final readonly class CheckRailwayStationsHandler extends AbstractTripMessageHand
                 return;
             }
 
-            $query = $this->queryBuilder->buildRailwayStationQuery($endPoints, self::STATION_PROXIMITY_METERS);
-            $result = $this->scanner->query($query);
+            // Read railway stations from the local-first index near the stage endpoints (ADR-040).
+            $route = array_map(static fn (Coordinate $point): array => ['lat' => $point->lat, 'lon' => $point->lon], $endPoints);
 
-            /** @var list<array{lat?: float, lon?: float, center?: array{lat: float, lon: float}, tags?: array<string, string>}> $elements */
-            $elements = \is_array($result['elements'] ?? null) ? $result['elements'] : [];
-
-            // Parse station locations
             $stationLocations = [];
-            foreach ($elements as $element) {
-                $lat = $element['lat'] ?? ($element['center']['lat'] ?? null);
-                $lon = $element['lon'] ?? ($element['center']['lon'] ?? null);
-
-                if (null === $lat || null === $lon) {
-                    continue;
-                }
-
-                $stationLocations[] = ['lat' => (float) $lat, 'lon' => (float) $lon];
+            foreach ($this->railwayStationRepository->findInCorridor($route, self::STATION_PROXIMITY_METERS) as $station) {
+                $stationLocations[] = ['lat' => $station['lat'], 'lon' => $station['lon']];
             }
 
             // Check each stage for nearby stations and build alerts

--- a/api/src/Osm/RailwayStationRepository.php
+++ b/api/src/Osm/RailwayStationRepository.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Osm;
+
+use Doctrine\DBAL\Connection;
+
+/**
+ * Reads mainline railway stations from the local-first Tier-1 index along the
+ * route corridor (ST_DWithin), replacing the runtime Overpass railway-station
+ * scan (ADR-040).
+ */
+final readonly class RailwayStationRepository implements RailwayStationRepositoryInterface
+{
+    public function __construct(private Connection $connection)
+    {
+    }
+
+    /**
+     * Railway stations whose geometry is within $radiusMeters of the route corridor.
+     *
+     * @param list<array{lat: float, lon: float}> $route
+     *
+     * @return list<array{name: ?string, category: string, lat: float, lon: float}>
+     */
+    public function findInCorridor(array $route, int $radiusMeters): array
+    {
+        if ([] === $route) {
+            return [];
+        }
+
+        /** @var list<array<string, scalar|null>> $rows */
+        $rows = $this->connection->fetchAllAssociative(
+            <<<'SQL'
+                SELECT name, category, ST_Y(geom) AS lat, ST_X(geom) AS lon
+                FROM osm.railway_stations
+                WHERE ST_DWithin(
+                    geom::geography,
+                    ST_SetSRID(ST_GeomFromText(:wkt), 4326)::geography,
+                    :radius
+                )
+                SQL,
+            [
+                'wkt' => WktGeometry::lineStringOrPoint($route),
+                'radius' => $radiusMeters,
+            ],
+        );
+
+        $stations = [];
+        foreach ($rows as $row) {
+            $stations[] = [
+                'name' => null !== $row['name'] ? (string) $row['name'] : null,
+                'category' => (string) $row['category'],
+                'lat' => (float) $row['lat'],
+                'lon' => (float) $row['lon'],
+            ];
+        }
+
+        return $stations;
+    }
+}

--- a/api/src/Osm/RailwayStationRepositoryInterface.php
+++ b/api/src/Osm/RailwayStationRepositoryInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Osm;
+
+interface RailwayStationRepositoryInterface
+{
+    /**
+     * Mainline railway stations whose geometry is within $radiusMeters of the
+     * route corridor.
+     *
+     * @param list<array{lat: float, lon: float}> $route
+     *
+     * @return list<array{name: ?string, category: string, lat: float, lon: float}>
+     */
+    public function findInCorridor(array $route, int $radiusMeters): array;
+}

--- a/api/src/Scanner/OsmOverpassQueryBuilder.php
+++ b/api/src/Scanner/OsmOverpassQueryBuilder.php
@@ -120,20 +120,6 @@ final readonly class OsmOverpassQueryBuilder implements QueryBuilderInterface
     }
 
     /**
-     * @param list<Coordinate> $endPoints
-     */
-    public function buildRailwayStationQuery(array $endPoints, int $radiusMeters = 10000): string
-    {
-        $polyline = $this->buildPolyline($endPoints);
-
-        return \sprintf(
-            '[out:json][timeout:15];nwr["railway"="station"]["usage"!="tourism"](around:%d,%s);out center tags 500;',
-            $radiusMeters,
-            $polyline,
-        );
-    }
-
-    /**
      * @param list<Coordinate> $decimatedPoints
      */
     public function buildHealthServiceQuery(array $decimatedPoints): string

--- a/api/src/Scanner/QueryBuilderInterface.php
+++ b/api/src/Scanner/QueryBuilderInterface.php
@@ -58,16 +58,6 @@ interface QueryBuilderInterface
     public function buildCemeteryQuery(array $decimatedPoints): string;
 
     /**
-     * Queries railway stations (excluding tourist railways) around stage endpoints.
-     *
-     * Used to detect whether a cyclist can reach a train station in case of
-     * emergency (mechanical failure, injury, extreme weather).
-     *
-     * @param list<Coordinate> $endPoints stage start/end points
-     */
-    public function buildRailwayStationQuery(array $endPoints, int $radiusMeters = 10000): string;
-
-    /**
      * Queries pharmacies, hospitals and clinics along the route.
      *
      * Used by the health-services checker to detect stages with no

--- a/api/tests/Integration/Osm/OsmRepositoriesTest.php
+++ b/api/tests/Integration/Osm/OsmRepositoriesTest.php
@@ -8,6 +8,7 @@ use App\Osm\AccommodationRepository;
 use App\Osm\BikeShopRepository;
 use App\Osm\HealthServiceRepository;
 use App\Osm\PoiRepository;
+use App\Osm\RailwayStationRepository;
 use App\Osm\WaterPointRepository;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\Test;
@@ -36,7 +37,7 @@ final class OsmRepositoriesTest extends KernelTestCase
         $this->connection = $connection;
 
         // osm.* are not Doctrine entities, so the reset does not clear them.
-        $this->connection->executeStatement('TRUNCATE osm.pois, osm.accommodations, osm.water_points, osm.bike_shops, osm.health_services');
+        $this->connection->executeStatement('TRUNCATE osm.pois, osm.accommodations, osm.water_points, osm.bike_shops, osm.health_services, osm.railway_stations');
     }
 
     #[Test]
@@ -142,6 +143,23 @@ final class OsmRepositoriesTest extends KernelTestCase
     }
 
     #[Test]
+    public function railwayStationRepositoryReturnsStationsWithinTheCorridor(): void
+    {
+        $this->seedRailwayStation(49.61, 6.14, 'On Route Station');
+        $this->seedRailwayStation(49.90, 6.80, 'Far Station');
+
+        $stations = new RailwayStationRepository($this->connection)->findInCorridor([
+            ['lat' => 49.60, 'lon' => 6.13],
+            ['lat' => 49.62, 'lon' => 6.15],
+        ], 10000);
+
+        // The far station (~50 km) is excluded by ST_DWithin.
+        self::assertCount(1, $stations);
+        self::assertSame('On Route Station', $stations[0]['name']);
+        self::assertSame('station', $stations[0]['category']);
+    }
+
+    #[Test]
     public function emptyRouteOrCategoriesYieldNoQuery(): void
     {
         $this->seedPoi('restaurant', 49.61, 6.14);
@@ -150,6 +168,7 @@ final class OsmRepositoriesTest extends KernelTestCase
         self::assertSame([], new WaterPointRepository($this->connection)->findInCorridor([], 2000));
         self::assertSame([], new BikeShopRepository($this->connection)->findInCorridor([], 2000));
         self::assertSame([], new HealthServiceRepository($this->connection)->findInCorridor([], 2000));
+        self::assertSame([], new RailwayStationRepository($this->connection)->findInCorridor([], 10000));
         self::assertSame([], new AccommodationRepository($this->connection)->findNear([['lat' => 49.61, 'lon' => 6.14]], 5000, []));
         self::assertSame([], new AccommodationRepository($this->connection)->findNear([], 5000, ['hotel']));
     }
@@ -206,6 +225,17 @@ final class OsmRepositoriesTest extends KernelTestCase
                 VALUES ('n', :id, :name, :category, '{}'::jsonb, ST_SetSRID(ST_MakePoint(:lon, :lat), 4326))
                 SQL,
             ['id' => ++$this->osmId, 'name' => $name, 'category' => $category, 'lon' => $lon, 'lat' => $lat],
+        );
+    }
+
+    private function seedRailwayStation(float $lat, float $lon, ?string $name): void
+    {
+        $this->connection->executeStatement(
+            <<<'SQL'
+                INSERT INTO osm.railway_stations (osm_type, osm_id, name, category, tags, geom)
+                VALUES ('n', :id, :name, 'station', '{}'::jsonb, ST_SetSRID(ST_MakePoint(:lon, :lat), 4326))
+                SQL,
+            ['id' => ++$this->osmId, 'name' => $name, 'lon' => $lon, 'lat' => $lat],
         );
     }
 }

--- a/api/tests/Unit/MessageHandler/CheckRailwayStationsHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/CheckRailwayStationsHandlerTest.php
@@ -13,9 +13,8 @@ use App\Mercure\MercureEventType;
 use App\Mercure\TripUpdatePublisherInterface;
 use App\Message\CheckRailwayStations;
 use App\MessageHandler\CheckRailwayStationsHandler;
+use App\Osm\RailwayStationRepositoryInterface;
 use App\Repository\TripRequestRepositoryInterface;
-use App\Scanner\QueryBuilderInterface;
-use App\Scanner\ScannerInterface;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
@@ -44,11 +43,39 @@ final class CheckRailwayStationsHandlerTest extends TestCase
         return $stages;
     }
 
+    /**
+     * @param list<array{name: ?string, category: string, lat: float, lon: float}> $stations
+     */
+    private function railwayStationRepository(array $stations): RailwayStationRepositoryInterface
+    {
+        $repository = $this->createStub(RailwayStationRepositoryInterface::class);
+        $repository->method('findInCorridor')->willReturnCallback(
+            static function (array $route, int $radiusMeters) use ($stations): array {
+                self::assertSame(10000, $radiusMeters, 'findInCorridor must use the 10 km station radius');
+
+                return $stations;
+            },
+        );
+
+        return $repository;
+    }
+
+    /**
+     * @param list<Stage>|null $stages
+     */
+    private function tripStateManager(?array $stages): TripRequestRepositoryInterface
+    {
+        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
+        $tripStateManager->method('getStages')->willReturn($stages);
+        $tripStateManager->method('getLocale')->willReturn('en');
+
+        return $tripStateManager;
+    }
+
     private function createHandler(
         TripRequestRepositoryInterface $tripStateManager,
         TripUpdatePublisherInterface $publisher,
-        ScannerInterface $scanner,
-        QueryBuilderInterface $queryBuilder,
+        RailwayStationRepositoryInterface $railwayStationRepository,
         GeoDistanceInterface $haversine,
     ): CheckRailwayStationsHandler {
         $computationTracker = $this->createStub(ComputationTrackerInterface::class);
@@ -70,8 +97,7 @@ final class CheckRailwayStationsHandlerTest extends TestCase
             $generationTracker,
             new NullLogger(),
             $tripStateManager,
-            $scanner,
-            $queryBuilder,
+            $railwayStationRepository,
             $haversine,
             $translator,
             $this->createStub(MessageBusInterface::class),
@@ -81,24 +107,9 @@ final class CheckRailwayStationsHandlerTest extends TestCase
     #[Test]
     public function stationNearbyEmitsNoAlert(): void
     {
-        $stages = $this->createStages('trip-1');
-
-        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
-        $tripStateManager->method('getStages')->willReturn($stages);
-        $tripStateManager->method('getLocale')->willReturn('en');
-
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildRailwayStationQuery')->willReturn('query');
-
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('query')->willReturn([
-            'elements' => [
-                [
-                    'lat' => 48.5,
-                    'lon' => 2.5,
-                    'tags' => ['name' => 'Gare de Lyon'],
-                ],
-            ],
+        $tripStateManager = $this->tripStateManager($this->createStages('trip-1'));
+        $railwayStationRepository = $this->railwayStationRepository([
+            ['name' => 'Gare de Lyon', 'category' => 'station', 'lat' => 48.5, 'lon' => 2.5],
         ]);
 
         // Station is within 10 km of every stage endpoint
@@ -114,24 +125,15 @@ final class CheckRailwayStationsHandlerTest extends TestCase
                 $this->callback(static fn (array $data): bool => [] === $data['alerts']),
             );
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine);
+        $handler = $this->createHandler($tripStateManager, $publisher, $railwayStationRepository, $haversine);
         $handler(new CheckRailwayStations('trip-1'));
     }
 
     #[Test]
     public function noStationNearbyEmitsNudgeForEveryStage(): void
     {
-        $stages = $this->createStages('trip-1');
-
-        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
-        $tripStateManager->method('getStages')->willReturn($stages);
-        $tripStateManager->method('getLocale')->willReturn('en');
-
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildRailwayStationQuery')->willReturn('query');
-
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('query')->willReturn(['elements' => []]);
+        $tripStateManager = $this->tripStateManager($this->createStages('trip-1'));
+        $railwayStationRepository = $this->railwayStationRepository([]);
 
         $haversine = $this->createStub(GeoDistanceInterface::class);
 
@@ -151,7 +153,7 @@ final class CheckRailwayStationsHandlerTest extends TestCase
                 }),
             );
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine);
+        $handler = $this->createHandler($tripStateManager, $publisher, $railwayStationRepository, $haversine);
         $handler(new CheckRailwayStations('trip-1'));
     }
 
@@ -160,28 +162,12 @@ final class CheckRailwayStationsHandlerTest extends TestCase
     {
         // Stage 1: start(48.0,2.0) end(48.5,2.5) — station at start, within range
         // Stage 2: start(48.5,2.5) end(49.0,3.0) — both endpoints far from station
-        $stages = $this->createStages('trip-1', 2);
-
-        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
-        $tripStateManager->method('getStages')->willReturn($stages);
-        $tripStateManager->method('getLocale')->willReturn('en');
-
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildRailwayStationQuery')->willReturn('query');
-
-        // Station at Stage 1's start point — near Stage 1, far from Stage 2
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('query')->willReturn([
-            'elements' => [
-                [
-                    'lat' => 48.0,
-                    'lon' => 2.0,
-                    'tags' => ['name' => 'Gare de Lyon'],
-                ],
-            ],
+        $tripStateManager = $this->tripStateManager($this->createStages('trip-1', 2));
+        $railwayStationRepository = $this->railwayStationRepository([
+            ['name' => 'Gare de Lyon', 'category' => 'station', 'lat' => 48.0, 'lon' => 2.0],
         ]);
 
-        // lat1 is the stage endpoint lat; lat1 < 48.5 means Stage 1 endpoints (near), lat1 >= 48.5 means Stage 2 endpoints (far)
+        // lat1 is the stage endpoint lat; lat1 < 48.5 → Stage 1 endpoints (near), lat1 >= 48.5 → Stage 2 endpoints (far)
         $haversine = $this->createStub(GeoDistanceInterface::class);
         $haversine->method('inMeters')->willReturnCallback(
             static fn (float $lat1): float => $lat1 >= 48.5 ? 15000.0 : 5000.0,
@@ -205,7 +191,7 @@ final class CheckRailwayStationsHandlerTest extends TestCase
                 }),
             );
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine);
+        $handler = $this->createHandler($tripStateManager, $publisher, $railwayStationRepository, $haversine);
         $handler(new CheckRailwayStations('trip-1'));
     }
 
@@ -224,16 +210,10 @@ final class CheckRailwayStationsHandlerTest extends TestCase
             isRestDay: true,
         );
 
-        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
-        $tripStateManager->method('getStages')->willReturn($stages);
-        $tripStateManager->method('getLocale')->willReturn('en');
-
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildRailwayStationQuery')->willReturn('query');
+        $tripStateManager = $this->tripStateManager($stages);
 
         // No stations found — without the rest-day guard, both stages would produce alerts
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('query')->willReturn(['elements' => []]);
+        $railwayStationRepository = $this->railwayStationRepository([]);
 
         $haversine = $this->createStub(GeoDistanceInterface::class);
 
@@ -247,64 +227,24 @@ final class CheckRailwayStationsHandlerTest extends TestCase
                 $this->callback(static fn (array $data): bool => 1 === \count($data['alerts'])),
             );
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine);
+        $handler = $this->createHandler($tripStateManager, $publisher, $railwayStationRepository, $haversine);
         $handler(new CheckRailwayStations('trip-1'));
     }
 
     #[Test]
     public function nullStagesReturnsEarly(): void
     {
-        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
-        $tripStateManager->method('getStages')->willReturn(null);
+        $tripStateManager = $this->tripStateManager(null);
 
         $publisher = $this->createMock(TripUpdatePublisherInterface::class);
         $publisher->expects($this->never())->method('publish');
 
-        $scanner = $this->createStub(ScannerInterface::class);
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $haversine = $this->createStub(GeoDistanceInterface::class);
-
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine);
-        $handler(new CheckRailwayStations('trip-1'));
-    }
-
-    #[Test]
-    public function stationWithCenterCoordinatesIsParsedCorrectly(): void
-    {
-        $stages = $this->createStages('trip-1', 1);
-
-        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
-        $tripStateManager->method('getStages')->willReturn($stages);
-        $tripStateManager->method('getLocale')->willReturn('en');
-
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildRailwayStationQuery')->willReturn('query');
-
-        // Station returned with center coordinates (way/relation)
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('query')->willReturn([
-            'elements' => [
-                [
-                    'center' => ['lat' => 48.5, 'lon' => 2.5],
-                    'tags' => ['name' => 'Gare du Nord'],
-                ],
-            ],
-        ]);
-
-        // Station within range
-        $haversine = $this->createStub(GeoDistanceInterface::class);
-        $haversine->method('inMeters')->willReturn(3000.0);
-
-        $publisher = $this->createMock(TripUpdatePublisherInterface::class);
-        $publisher->expects($this->once())
-            ->method('publish')
-            ->with(
-                'trip-1',
-                MercureEventType::RAILWAY_STATION_ALERTS,
-                $this->callback(static fn (array $data): bool => [] === $data['alerts']),
-            );
-
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder, $haversine);
+        $handler = $this->createHandler(
+            $tripStateManager,
+            $publisher,
+            $this->railwayStationRepository([]),
+            $this->createStub(GeoDistanceInterface::class),
+        );
         $handler(new CheckRailwayStations('trip-1'));
     }
 }

--- a/provisioner/osm2pgsql/tier1.lua
+++ b/provisioner/osm2pgsql/tier1.lua
@@ -5,7 +5,7 @@
 -- the live `osm` schema atomically. The API reads these tables via ST_DWithin
 -- corridor queries, replacing the runtime Overpass dependency.
 --
--- Scope of this style: pois, accommodations, water_points, bike_shops, health_services. The
+-- Scope of this style: pois, accommodations, water_points, bike_shops, health_services, railway_stations. The
 -- admin_boundaries (coverage polygon) and cycle_routes tables land later.
 
 -- MUST match PostgisImporter::STAGING_SCHEMA: osm2pgsql writes the output tables
@@ -119,6 +119,21 @@ local health_services = osm2pgsql.define_table({
     },
 })
 
+local railway_stations = osm2pgsql.define_table({
+    name = 'railway_stations',
+    schema = SCHEMA,
+    ids = { type = 'any', id_column = 'osm_id', type_column = 'osm_type' },
+    columns = {
+        { column = 'name', type = 'text' },
+        { column = 'category', type = 'text', not_null = true },
+        { column = 'tags', type = 'jsonb' },
+        { column = 'geom', type = 'point', projection = SRID, not_null = true },
+    },
+    indexes = {
+        { column = 'geom', method = 'gist' },
+    },
+})
+
 local function poi_category(tags)
     if tags.amenity and POI_AMENITY[tags.amenity] then return tags.amenity end
     if tags.shop and POI_SHOP[tags.shop] then return tags.shop end
@@ -158,12 +173,21 @@ local function health_category(tags)
     return nil
 end
 
+-- Mainline railway stations (excludes heritage/tourist railways via usage).
+local function railway_category(tags)
+    if tags.railway == 'station' and tags.usage ~= 'tourism' then
+        return 'station'
+    end
+    return nil
+end
+
 local function is_relevant(tags)
     return poi_category(tags) ~= nil
         or accommodation_category(tags) ~= nil
         or water_category(tags) ~= nil
         or bike_shop_category(tags) ~= nil
         or health_category(tags) ~= nil
+        or railway_category(tags) ~= nil
 end
 
 -- Safe integer coercion (works on both Lua 5.x and LuaJIT builds of osm2pgsql).
@@ -227,6 +251,16 @@ local function insert_features(tags, geom)
         health_services:insert({
             name = tags.name,
             category = hcat,
+            tags = tags,
+            geom = geom,
+        })
+    end
+
+    local rcat = railway_category(tags)
+    if rcat then
+        railway_stations:insert({
+            name = tags.name,
+            category = rcat,
             tags = tags,
             geom = geom,
         })


### PR DESCRIPTION
## Contexte

Slice #3 du retrait Overpass runtime (ADR-040), après vélo (#670) et santé (#671). Bascule des **gares ferroviaires** (`CheckRailwayStationsHandler` — option d'évacuation d'urgence) sur l'index PostGIS local. Donnée statique OSM → import.

## Changements

- **Provisioner** (`tier1.lua`) : table flex `railway_stations` (point + GIST) ; catégorie `station` pour `railway=station` **hors** `usage=tourism` (exclut les lignes touristiques/patrimoniales).
- **Migration** `Version20260615140000` : table `osm.railway_stations` (mirror du flex) + index GIST.
- **`RailwayStationRepository`** (+ interface) : `findInCorridor(route, radius)` via `ST_DWithin`, retourne `{name, category, lat, lon}`.
- **`CheckRailwayStationsHandler`** : injecte `RailwayStationRepositoryInterface` (plus de `ScannerInterface`/`QueryBuilderInterface`), lit le corridor autour des **endpoints d'étape** (start+end, hors jours de repos) via `STATION_PROXIMITY_METERS` (10 km) — même constante pour le pré-filtre DB et le contrôle de proximité par étape. Logique inchangée (nudge + action `navigate` vers la gare la plus proche).
- **Tests** : test unitaire réécrit (mock de l'interface : gare proche → pas d'alerte, aucune → nudge par étape, gare loin d'une étape → nudge + navigate, jour de repos ignoré, stages null → retour anticipé, rayon 10 km épinglé) ; `OsmRepositoriesTest` étendu (corridor gares : gare proche retournée, gare lointaine exclue).

## Vérification

- `php -l` OK (6 fichiers), `luac -p tier1.lua` OK, PHP-CS-Fixer 0/6.
- DDL + requête corridor validées contre la base PostGIS bootée (transaction annulée) : gare sur le tracé retournée, gare à ~50 km exclue par `ST_DWithin`.
- PHPStan 9 + PHPUnit (unitaire + intégration) délégués à la CI.

<!-- claude-review-start -->
## Claude Review

**No findings.** The migration, repository, provisioner, and tests are all correct and consistent with the ADR-040 slice pattern established by #670 and #671. The previously flagged orphaned `buildRailwayStationQuery` method has been removed from both `QueryBuilderInterface` and `OsmOverpassQueryBuilder` in the second commit.

**Resolved threads:** The previous `CHANGES_REQUESTED` review has been superseded — the reported issue is fixed.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

> **Commit reviewed:** ece90a93395a58c896287cc958468a20ac8e3231
<!-- claude-review-end -->