### PR TITLE
feat(bike-shops): count self-service repair stations as a repair option (ADR-040)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Rules are executed in priority order (lower = higher priority):
 | **Calendar** | -- | ![nudge](https://img.shields.io/badge/-nudge-0288d1) | Stage falls on a Sunday (businesses may be closed) |
 | **Wind** | -- | ![warning](https://img.shields.io/badge/-warning-ed6c02) | Headwind >= 25 km/h on >= 60 % of stages with weather data |
 | **Comfort** | -- | ![warning](https://img.shields.io/badge/-warning-ed6c02) | Poor comfort index (< 40/100) on at least one stage |
-| **Bike shops** | -- | ![nudge](https://img.shields.io/badge/-nudge-0288d1) | No repair shop within 2 km of stage midpoint (trips > 5 stages) |
+| **Bike shops** | -- | ![nudge](https://img.shields.io/badge/-nudge-0288d1) | No repair resource within 2 km of stage midpoint (trips > 5 stages) |
 | **Bike shops** | -- | ![nudge](https://img.shields.io/badge/-nudge-0288d1) | Nearby shop sells bikes but does not offer repair service |
 | **Resupply** | -- | ![nudge](https://img.shields.io/badge/-nudge-0288d1) | Stage >= 40 km with no food/resupply POI along the route |
 | **Resupply** | -- | ![warning](https://img.shields.io/badge/-warning-ed6c02) | All resupply POIs on the stage are closed at estimated passage time |

--- a/api/src/Osm/BikeShopRepository.php
+++ b/api/src/Osm/BikeShopRepository.php
@@ -9,8 +9,8 @@ use Doctrine\DBAL\Connection;
 /**
  * Reads bike shops from the local-first Tier-1 index along the route corridor
  * (ST_DWithin), replacing the runtime Overpass bike-shop scan (ADR-040). The
- * repair flag is derived from the raw tags so the analyzer can tell repair shops
- * apart from sale-only outlets.
+ * repair flag is derived from the raw tags (or a self-service repair-station
+ * category) so the analyzer can tell repair resources apart from sale-only outlets.
  */
 final readonly class BikeShopRepository implements BikeShopRepositoryInterface
 {
@@ -35,7 +35,7 @@ final readonly class BikeShopRepository implements BikeShopRepositoryInterface
         $rows = $this->connection->fetchAllAssociative(
             <<<'SQL'
                 SELECT name, ST_Y(geom) AS lat, ST_X(geom) AS lon,
-                       (COALESCE(tags->>'service:bicycle:repair', '') = 'yes')::int AS has_repair
+                       (category = 'repair_station' OR COALESCE(tags->>'service:bicycle:repair', '') = 'yes')::int AS has_repair
                 FROM osm.bike_shops
                 WHERE ST_DWithin(
                     geom::geography,

--- a/api/tests/Integration/Osm/OsmRepositoriesTest.php
+++ b/api/tests/Integration/Osm/OsmRepositoriesTest.php
@@ -102,6 +102,7 @@ final class OsmRepositoriesTest extends KernelTestCase
         $this->seedBikeShop('bicycle', 49.61, 6.14, 'Repair Shop', '{"shop":"bicycle","service:bicycle:repair":"yes"}');
         $this->seedBikeShop('bicycle', 49.615, 6.145, 'Sale Only', '{"shop":"bicycle"}');
         $this->seedBikeShop('repair_station', 49.612, 6.142, 'Workshop', '{"service:bicycle:repair":"yes"}');
+        $this->seedBikeShop('repair_station', 49.613, 6.143, 'Self-Service Stand', '{"amenity":"bicycle_repair_station"}');
         $this->seedBikeShop('bicycle', 49.90, 6.80, 'Far Shop', '{"shop":"bicycle","service:bicycle:repair":"yes"}');
 
         $shops = new BikeShopRepository($this->connection)->findInCorridor([
@@ -109,16 +110,17 @@ final class OsmRepositoriesTest extends KernelTestCase
             ['lat' => 49.62, 'lon' => 6.15],
         ], 2000);
 
-        // Three shops in the corridor; the far one is excluded by ST_DWithin.
+        // Four shops in the corridor; the far one is excluded by ST_DWithin.
         $repairByName = [];
         foreach ($shops as $shop) {
             $repairByName[(string) $shop['name']] = $shop['hasRepair'];
         }
 
-        self::assertCount(3, $shops);
+        self::assertCount(4, $shops);
         self::assertTrue($repairByName['Repair Shop'], 'shop=bicycle with service:bicycle:repair=yes is a repair shop');
         self::assertFalse($repairByName['Sale Only'], 'shop=bicycle without the repair tag is sale-only');
         self::assertTrue($repairByName['Workshop'], 'a repair workshop without shop=bicycle still has repair');
+        self::assertTrue($repairByName['Self-Service Stand'], 'a self-service repair station (amenity=bicycle_repair_station) counts as repair');
         self::assertArrayNotHasKey('Far Shop', $repairByName);
     }
 

--- a/provisioner/osm2pgsql/tier1.lua
+++ b/provisioner/osm2pgsql/tier1.lua
@@ -157,11 +157,13 @@ local function water_category(tags)
     return nil
 end
 
--- Bicycle shops and generic outlets advertising repair (service:bicycle:repair=yes);
--- the repair flag is preserved in the raw tags for the read side to distinguish them.
+-- Bicycle shops, generic outlets advertising repair (service:bicycle:repair=yes)
+-- and public self-service repair stations (amenity=bicycle_repair_station: pump +
+-- tools); the repair flag is preserved in the raw tags for the read side.
 local function bike_shop_category(tags)
     if tags.shop == 'bicycle' then return 'bicycle' end
     if tags['service:bicycle:repair'] == 'yes' then return 'repair_station' end
+    if tags.amenity == 'bicycle_repair_station' then return 'repair_station' end
     return nil
 end
 


### PR DESCRIPTION
## Contexte

Enrichissement de la couche `bike_shops` (local-first PostGIS, ADR-040) : les **stations de réparation libre-service** OSM (`amenity=bicycle_repair_station` — pompe + outils) comptent désormais comme une ressource de réparation pour l'alerte « pas d'atelier vélo » (pour ne pas rester en rade). Extension de la couche existante — **pas de nouvelle table, ni repo, ni handler**.

## Changements

- **`tier1.lua`** : `bike_shop_category` ajoute la branche `amenity=bicycle_repair_station → 'repair_station'` (importé dans `osm.bike_shops`).
- **`BikeShopRepository`** : `has_repair` vaut vrai aussi quand `category = 'repair_station'` (en plus de `service:bicycle:repair=yes`), couvrant les stations libre-service sans tag de service.
- **`OsmRepositoriesTest`** : fixture `repair_station` (`amenity=bicycle_repair_station`, sans tag `service:bicycle:repair`) → `hasRepair=true`.
- `CheckBikeShopsHandler` inchangé (consomme `hasRepair`).

## Vérification

- `php -l` OK, `luac -p tier1.lua` OK, PHP-CS-Fixer 0/2.
- Expression `has_repair` validée contre PostGIS réel : station libre-service → 1, vendeur seul → 0.
- PHPStan 9 + PHPUnit délégués à la CI.

_(Tranche produite en parallèle ; partage `tier1.lua` avec d'autres slices d'enrichissement — édition dans une région distincte, rebase trivial si besoin.)_

<!-- claude-review-start -->
## Claude Review

**Commit reviewed:** `6e20245759bb9980e7eb2415cc1ccc12e328d171`

**Findings:** 0 — approved.

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Resolved threads:** None (no prior open threads).

**Inline comments:** None posted.
<!-- claude-review-end -->