### PR TITLE
feat(poi): count fuel stations as a resupply option (ADR-040)

### DIFF
--- a/api/src/MessageHandler/ScanPoisHandler.php
+++ b/api/src/MessageHandler/ScanPoisHandler.php
@@ -40,7 +40,7 @@ final readonly class ScanPoisHandler extends AbstractTripMessageHandler
     private const array RESUPPLY_CATEGORIES = [
         'restaurant', 'cafe', 'bar', 'supermarket', 'convenience',
         'bakery', 'fast_food', 'marketplace', 'butcher', 'pastry',
-        'deli', 'greengrocer', 'general', 'farm',
+        'deli', 'greengrocer', 'general', 'farm', 'fuel',
     ];
 
     public function __construct(

--- a/api/tests/Integration/Osm/ScanPoisCorridorTest.php
+++ b/api/tests/Integration/Osm/ScanPoisCorridorTest.php
@@ -55,11 +55,14 @@ final class ScanPoisCorridorTest extends KernelTestCase
 
         // Committed SQL fixtures (ADR-040 / #56). Corridor A (49.61, 6.14) carries a
         // resupply POI + drinking water; corridor B (50.00, 7.00) carries only a
-        // non-resupply POI. The tests pick a corridor by routing a stage near A or B.
+        // non-resupply POI; corridor C (48.50, 5.00) carries only a fuel station
+        // (resupply via its convenience shop). The tests pick a corridor by routing
+        // a stage near A, B or C.
         $this->connection->executeStatement(<<<'SQL'
             INSERT INTO osm.pois (osm_type, osm_id, name, category, tags, geom) VALUES
               ('n', 9001, 'Le Bistrot', 'restaurant', '{}'::jsonb, ST_SetSRID(ST_MakePoint(6.14, 49.61), 4326)),
-              ('n', 9002, 'Belvedere', 'viewpoint', '{}'::jsonb, ST_SetSRID(ST_MakePoint(7.00, 50.00), 4326))
+              ('n', 9002, 'Belvedere', 'viewpoint', '{}'::jsonb, ST_SetSRID(ST_MakePoint(7.00, 50.00), 4326)),
+              ('n', 9004, 'Station Total', 'fuel', '{}'::jsonb, ST_SetSRID(ST_MakePoint(5.00, 48.50), 4326))
             SQL);
         $this->connection->executeStatement(<<<'SQL'
             INSERT INTO osm.water_points (osm_type, osm_id, name, category, tags, geom) VALUES
@@ -109,6 +112,30 @@ final class ScanPoisCorridorTest extends KernelTestCase
         self::assertTrue(
             array_any($stage->alerts, static fn (Alert $alert): bool => AlertType::NUDGE === $alert->type),
             'A long stage with no resupply POI in the corridor must raise the lunch nudge',
+        );
+    }
+
+    #[Test]
+    public function fuelStationInCorridorSuppressesLunchNudge(): void
+    {
+        // Corridor C carries only a fuel station → it counts as resupply (convenience
+        // shop), so the 50 km stage must NOT get a lunch nudge.
+        $route = [
+            ['lat' => 48.49, 'lon' => 4.99],
+            ['lat' => 48.50, 'lon' => 5.00],
+            ['lat' => 48.51, 'lon' => 5.01],
+        ];
+        $stage = $this->stageOnRoute($route);
+        $this->runScan($route, $stage);
+
+        self::assertContains(
+            'fuel',
+            array_map(static fn (PointOfInterest $poi): string => $poi->category, $stage->pois),
+            'The seeded fuel station in the corridor must be detected from the local index',
+        );
+        self::assertFalse(
+            array_any($stage->alerts, static fn (Alert $alert): bool => AlertType::NUDGE === $alert->type),
+            'A long stage with a fuel station in the corridor must not raise the lunch nudge',
         );
     }
 

--- a/provisioner/osm2pgsql/tier1.lua
+++ b/provisioner/osm2pgsql/tier1.lua
@@ -24,7 +24,7 @@ local ACCOMMODATION_TOURISM = {
 -- Resupply / point-of-interest categories (food, shops, services, sights).
 local POI_AMENITY = {
     restaurant = true, cafe = true, bar = true, pub = true, fast_food = true,
-    marketplace = true, pharmacy = true,
+    marketplace = true, pharmacy = true, fuel = true,
 }
 local POI_SHOP = {
     supermarket = true, convenience = true, bakery = true, butcher = true,


### PR DESCRIPTION
## Contexte

Enrichissement de la couche POI (local-first PostGIS, ADR-040) : les **stations-service** OSM (`amenity=fuel`) comptent désormais comme point de ravitaillement (boutique de proximité, souvent ouverte dimanche/tard) pour l'alerte resupply/lunch. Extension de la couche POI existante — **pas de nouvelle table, ni repo, ni handler**.

## Changements

- **`tier1.lua`** : `fuel = true` ajouté à `POI_AMENITY` → `amenity=fuel` importé dans `osm.pois` avec la catégorie `fuel`.
- **`ScanPoisHandler`** : `'fuel'` ajouté à la const `RESUPPLY_CATEGORIES` (source de vérité unique des décisions resupply : nudge lunch, timeline d'approvisionnement, timing-warning). Le `resolveSchedule()` gère `fuel` via son `default` (pas de filtre horaire — cohérent, stations souvent 24h).
- **`ScanPoisCorridorTest`** : nouveau cas (corridor C) — une étape de 50 km avec **uniquement** une station-service détectée ne déclenche **pas** le nudge lunch.

## Vérification

- `php -l` OK, `luac -p tier1.lua` OK, PHP-CS-Fixer 0/2.
- PHPStan 9 + PHPUnit (dont le nouveau test d'intégration) délégués à la CI.

_(Tranche produite en parallèle ; partage `tier1.lua` avec d'autres slices d'enrichissement — édition dans une région distincte, rebase trivial si besoin.)_

<!-- claude-review-start -->
## Claude Review

**Reviewed commit:** `652b67ae`

**Summary:** 0 findings — clean, minimal extension of an existing alert rule with appropriate test coverage.

| Severity | Count |
|----------|-------|
| 🔴 Critical | 0 |
| 🟡 Warning | 0 |
| 🔵 Info | 0 |

No previously open review threads (none existed). No previous bot reviews to dismiss.

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** None.
<!-- claude-review-end -->