### PR TITLE
feat(in-ride): read nearby POIs from the local PostGIS index, drop the Overpass scan (ADR-040)

### DIFF
--- a/api/config/packages/cache.php
+++ b/api/config/packages/cache.php
@@ -41,10 +41,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                     'adapter' => 'cache.adapter.redis',
                     'default_lifetime' => 1800, // 30 minutes — short-lived dialogue history
                 ],
-                'cache.in_ride_poi' => [
-                    'adapter' => 'cache.adapter.redis',
-                    'default_lifetime' => 300, // 5 minutes — short-lived in-ride POI scans
-                ],
             ],
         ],
     ]);
@@ -74,9 +70,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                         'adapter' => 'cache.adapter.array',
                     ],
                     'cache.trip_chat' => [
-                        'adapter' => 'cache.adapter.array',
-                    ],
-                    'cache.in_ride_poi' => [
                         'adapter' => 'cache.adapter.array',
                     ],
                 ],

--- a/api/src/InRide/InRideAssistant.php
+++ b/api/src/InRide/InRideAssistant.php
@@ -10,13 +10,8 @@ use App\Geo\GeoPoint;
 use App\Llm\Exception\OllamaUnavailableException;
 use App\Llm\LlmClientInterface;
 use App\Llm\SystemPromptLoader;
-use App\Scanner\OsmOverpassQueryBuilder;
-use App\Scanner\ScannerInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
-use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Contracts\Cache\CacheInterface;
-use Symfony\Contracts\Cache\ItemInterface;
 
 /**
  * In-ride conversational assistant — the orchestrator that turns a free-text
@@ -26,11 +21,9 @@ use Symfony\Contracts\Cache\ItemInterface;
  * Pipeline:
  *  1. {@see PoiIntentDetector} classifies the user message into a structured
  *     intent (category + radius + optional opening-hours constraint).
- *  2. {@see OsmOverpassQueryBuilder} produces the matching Overpass QL query,
- *     which is fired through {@see ScannerInterface}. Results are cached for
- *     5 minutes in the `cache.in_ride_poi` Redis pool (key: rounded lat/lon,
- *     category, radius) so consecutive messages along the same area do not
- *     hammer Overpass.
+ *  2. {@see InRidePoiRepositoryInterface} reads the matching features from the
+ *     local-first Tier-1 PostGIS index (ADR-040) around the rider position — no
+ *     runtime Overpass call, so no cache is needed.
  *  3. Opening hours are validated via {@see OpeningHoursParser}. When the
  *     intent carries an `open_for_minutes` constraint, only POIs that remain
  *     open at least that long are kept.
@@ -44,19 +37,15 @@ use Symfony\Contracts\Cache\ItemInterface;
  *     `in-ride` system prompt) and returns a short markdown narrative shown in
  *     the chat bubble.
  *
- * The orchestrator is defensive: a missing/disabled LLM, an Overpass timeout
- * or an unparseable opening_hours tag never raise — they degrade to a sensible
- * narrative so the rider always gets a useful answer.
+ * The orchestrator is defensive: a missing/disabled LLM or an unparseable
+ * opening_hours tag never raise — they degrade to a sensible narrative so the
+ * rider always gets a useful answer.
  */
 final readonly class InRideAssistant
 {
     public const string NARRATIVE_MODEL = 'llama3.2:3b';
 
     private const int MAX_SUGGESTIONS = 3;
-
-    private const int CACHE_TTL_SECONDS = 300;
-
-    private const string CACHE_KEY_PREFIX = 'in_ride.poi.';
 
     /**
      * Detour weight in the ranking score. The score is
@@ -68,16 +57,13 @@ final readonly class InRideAssistant
 
     public function __construct(
         private PoiIntentDetector $intentDetector,
-        private ScannerInterface $scanner,
-        private OsmOverpassQueryBuilder $queryBuilder,
+        private InRidePoiRepositoryInterface $poiRepository,
         private OpeningHoursParser $openingHoursParser,
         private DetourCalculator $detourCalculator,
         private DeeplinkBuilder $deeplinkBuilder,
         private GeoDistanceInterface $distance,
         private LlmClientInterface $llmClient,
         private SystemPromptLoader $promptLoader,
-        #[Autowire(service: 'cache.in_ride_poi')]
-        private CacheInterface $cache,
         private LoggerInterface $logger = new NullLogger(),
     ) {
     }
@@ -131,60 +117,11 @@ final readonly class InRideAssistant
     }
 
     /**
-     * @return list<array<string, mixed>>
+     * @return list<array{lat: float, lon: float, tags: array<string, string>}>
      */
     private function fetchPois(GeoPoint $center, PoiIntent $intent): array
     {
-        $latRounded = round($center->lat, 3);
-        $lonRounded = round($center->lon, 3);
-        $cacheKey = self::CACHE_KEY_PREFIX.hash('xxh128', \sprintf(
-            '%s|%F|%F|%d',
-            $intent->category,
-            $latRounded,
-            $lonRounded,
-            $intent->maxDistanceMeters,
-        ));
-
-        try {
-            /** @var array<string, mixed> $payload */
-            $payload = $this->cache->get($cacheKey, function (ItemInterface $item) use ($center, $intent): array {
-                $item->expiresAfter(self::CACHE_TTL_SECONDS);
-
-                return $this->scanner->query($this->buildQuery($center, $intent));
-            });
-        } catch (\Throwable $throwable) {
-            $this->logger->warning('InRideAssistant: cache.get failed, falling back to direct query.', [
-                'error' => $throwable->getMessage(),
-            ]);
-
-            $payload = $this->scanner->query($this->buildQuery($center, $intent));
-        }
-
-        $elements = $payload['elements'] ?? [];
-        if (!\is_array($elements)) {
-            return [];
-        }
-
-        /** @var list<array<string, mixed>> $list */
-        $list = [];
-        foreach ($elements as $element) {
-            if (\is_array($element)) {
-                $list[] = $element;
-            }
-        }
-
-        return $list;
-    }
-
-    private function buildQuery(GeoPoint $center, PoiIntent $intent): string
-    {
-        return match ($intent->category) {
-            PoiSuggestion::CATEGORY_WATER => $this->queryBuilder->buildDrinkingWaterQuery($center, $intent->maxDistanceMeters),
-            PoiSuggestion::CATEGORY_SHELTER => $this->queryBuilder->buildShelterQuery($center, $intent->maxDistanceMeters),
-            PoiSuggestion::CATEGORY_FOOD => $this->queryBuilder->buildFoodQuery($center, $intent->maxDistanceMeters),
-            PoiSuggestion::CATEGORY_MECHANIC => $this->queryBuilder->buildMechanicQuery($center, $intent->maxDistanceMeters),
-            default => throw new \LogicException(\sprintf('Unsupported category "%s".', $intent->category)),
-        };
+        return $this->poiRepository->findNearby($center->lat, $center->lon, $intent->maxDistanceMeters, $intent->category);
     }
 
     /**

--- a/api/src/InRide/InRideAssistant.php
+++ b/api/src/InRide/InRideAssistant.php
@@ -244,14 +244,8 @@ final readonly class InRideAssistant
      */
     private function extractCoordinates(array $element): ?array
     {
-        // Overpass returns "lat"/"lon" for nodes and "center.lat"/"center.lon" for ways/relations.
         if (isset($element['lat'], $element['lon']) && \is_numeric($element['lat']) && \is_numeric($element['lon'])) {
             return [(float) $element['lat'], (float) $element['lon']];
-        }
-
-        $center = $element['center'] ?? null;
-        if (\is_array($center) && isset($center['lat'], $center['lon']) && \is_numeric($center['lat']) && \is_numeric($center['lon'])) {
-            return [(float) $center['lat'], (float) $center['lon']];
         }
 
         return null;

--- a/api/src/InRide/InRidePoiRepository.php
+++ b/api/src/InRide/InRidePoiRepository.php
@@ -19,24 +19,31 @@ final readonly class InRidePoiRepository implements InRidePoiRepositoryInterface
 
     public function findNearby(float $lat, float $lon, int $radiusMeters, string $category): array
     {
+        // `ORDER BY geom <-> point LIMIT 50` uses the GiST KNN operator to fetch
+        // the 50 nearest candidates only (restoring the old Overpass cap), so a
+        // dense city centre never floods buildSuggestions' per-row work.
         $sql = match ($category) {
             PoiSuggestion::CATEGORY_WATER => <<<'SQL'
                 SELECT ST_Y(geom) AS lat, ST_X(geom) AS lon, tags FROM osm.water_points
                 WHERE ST_DWithin(geom::geography, ST_SetSRID(ST_MakePoint(:lon, :lat), 4326)::geography, :radius)
+                ORDER BY geom <-> ST_SetSRID(ST_MakePoint(:lon, :lat), 4326) LIMIT 50
                 SQL,
             PoiSuggestion::CATEGORY_SHELTER => <<<'SQL'
                 SELECT ST_Y(geom) AS lat, ST_X(geom) AS lon, tags FROM osm.accommodations
                 WHERE category = 'shelter'
                   AND ST_DWithin(geom::geography, ST_SetSRID(ST_MakePoint(:lon, :lat), 4326)::geography, :radius)
+                ORDER BY geom <-> ST_SetSRID(ST_MakePoint(:lon, :lat), 4326) LIMIT 50
                 SQL,
             PoiSuggestion::CATEGORY_FOOD => <<<'SQL'
                 SELECT ST_Y(geom) AS lat, ST_X(geom) AS lon, tags FROM osm.pois
                 WHERE category IN ('restaurant', 'cafe', 'fast_food')
                   AND ST_DWithin(geom::geography, ST_SetSRID(ST_MakePoint(:lon, :lat), 4326)::geography, :radius)
+                ORDER BY geom <-> ST_SetSRID(ST_MakePoint(:lon, :lat), 4326) LIMIT 50
                 SQL,
             PoiSuggestion::CATEGORY_MECHANIC => <<<'SQL'
                 SELECT ST_Y(geom) AS lat, ST_X(geom) AS lon, tags FROM osm.bike_shops
                 WHERE ST_DWithin(geom::geography, ST_SetSRID(ST_MakePoint(:lon, :lat), 4326)::geography, :radius)
+                ORDER BY geom <-> ST_SetSRID(ST_MakePoint(:lon, :lat), 4326) LIMIT 50
                 SQL,
             default => null,
         };

--- a/api/src/InRide/InRidePoiRepository.php
+++ b/api/src/InRide/InRidePoiRepository.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\InRide;
+
+use Doctrine\DBAL\Connection;
+
+/**
+ * Reads nearby in-ride POIs from the local-first Tier-1 index (ADR-040), mapping
+ * each in-ride intent category to its osm.* table around the rider position —
+ * replacing the runtime Overpass in-ride scan and its 5-minute cache.
+ */
+final readonly class InRidePoiRepository implements InRidePoiRepositoryInterface
+{
+    public function __construct(private Connection $connection)
+    {
+    }
+
+    public function findNearby(float $lat, float $lon, int $radiusMeters, string $category): array
+    {
+        $sql = match ($category) {
+            PoiSuggestion::CATEGORY_WATER => <<<'SQL'
+                SELECT ST_Y(geom) AS lat, ST_X(geom) AS lon, tags FROM osm.water_points
+                WHERE ST_DWithin(geom::geography, ST_SetSRID(ST_MakePoint(:lon, :lat), 4326)::geography, :radius)
+                SQL,
+            PoiSuggestion::CATEGORY_SHELTER => <<<'SQL'
+                SELECT ST_Y(geom) AS lat, ST_X(geom) AS lon, tags FROM osm.accommodations
+                WHERE category = 'shelter'
+                  AND ST_DWithin(geom::geography, ST_SetSRID(ST_MakePoint(:lon, :lat), 4326)::geography, :radius)
+                SQL,
+            PoiSuggestion::CATEGORY_FOOD => <<<'SQL'
+                SELECT ST_Y(geom) AS lat, ST_X(geom) AS lon, tags FROM osm.pois
+                WHERE category IN ('restaurant', 'cafe', 'fast_food')
+                  AND ST_DWithin(geom::geography, ST_SetSRID(ST_MakePoint(:lon, :lat), 4326)::geography, :radius)
+                SQL,
+            PoiSuggestion::CATEGORY_MECHANIC => <<<'SQL'
+                SELECT ST_Y(geom) AS lat, ST_X(geom) AS lon, tags FROM osm.bike_shops
+                WHERE ST_DWithin(geom::geography, ST_SetSRID(ST_MakePoint(:lon, :lat), 4326)::geography, :radius)
+                SQL,
+            default => null,
+        };
+
+        if (null === $sql) {
+            return [];
+        }
+
+        /** @var list<array<string, scalar|null>> $rows */
+        $rows = $this->connection->fetchAllAssociative($sql, [
+            'lat' => $lat,
+            'lon' => $lon,
+            'radius' => $radiusMeters,
+        ]);
+
+        $features = [];
+        foreach ($rows as $row) {
+            $features[] = [
+                'lat' => (float) $row['lat'],
+                'lon' => (float) $row['lon'],
+                'tags' => $this->decodeTags($row['tags']),
+            ];
+        }
+
+        return $features;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function decodeTags(mixed $raw): array
+    {
+        if (!\is_string($raw)) {
+            return [];
+        }
+
+        $decoded = json_decode($raw, true);
+        if (!\is_array($decoded)) {
+            return [];
+        }
+
+        $tags = [];
+        foreach ($decoded as $key => $value) {
+            if (is_scalar($value)) {
+                $tags[(string) $key] = (string) $value;
+            }
+        }
+
+        return $tags;
+    }
+}

--- a/api/src/InRide/InRidePoiRepositoryInterface.php
+++ b/api/src/InRide/InRidePoiRepositoryInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\InRide;
+
+interface InRidePoiRepositoryInterface
+{
+    /**
+     * Nearby features of the given in-ride category within $radiusMeters of the
+     * rider position, with their raw OSM tags (name, opening_hours, phone...).
+     *
+     * @return list<array{lat: float, lon: float, tags: array<string, string>}>
+     */
+    public function findNearby(float $lat, float $lon, int $radiusMeters, string $category): array;
+}

--- a/api/src/Scanner/OsmOverpassQueryBuilder.php
+++ b/api/src/Scanner/OsmOverpassQueryBuilder.php
@@ -6,7 +6,6 @@ namespace App\Scanner;
 
 use App\ApiResource\TripRequest;
 use App\ApiResource\Model\Coordinate;
-use App\Geo\GeoPoint;
 
 final readonly class OsmOverpassQueryBuilder implements QueryBuilderInterface
 {
@@ -148,71 +147,6 @@ final readonly class OsmOverpassQueryBuilder implements QueryBuilderInterface
             '[out:json][timeout:15];(nwr["tourism"="museum"](around:%1$d,%2$s);nwr["tourism"="attraction"](around:%1$d,%2$s);nwr["tourism"="viewpoint"](around:%1$d,%2$s);nwr["historic"~"^(castle|monument|memorial|ruins|archaeological_site|church|cathedral|abbey|fort)$"](around:%1$d,%2$s););out center tags 100;',
             $radiusMeters,
             $polyline,
-        );
-    }
-
-    /**
-     * Builds an Overpass query for potable water sources (drinking_water amenities
-     * and public fountains) within a radius around a single geographic centre.
-     *
-     * Designed for in-ride POI scans: a tiny radius (≤ 5 km) keeps the response
-     * cheap and reactive.
-     */
-    public function buildDrinkingWaterQuery(GeoPoint $center, int $radiusM): string
-    {
-        return \sprintf(
-            '[out:json][timeout:15];(nwr["amenity"="drinking_water"](around:%1$d,%2$F,%3$F);nwr["amenity"="fountain"](around:%1$d,%2$F,%3$F););out center tags 50;',
-            $radiusM,
-            $center->lat,
-            $center->lon,
-        );
-    }
-
-    /**
-     * Builds an Overpass query for shelters (amenity=shelter) around a single
-     * geographic centre — useful for "I need to take refuge" in-ride intents.
-     */
-    public function buildShelterQuery(GeoPoint $center, int $radiusM): string
-    {
-        return \sprintf(
-            '[out:json][timeout:15];nwr["amenity"="shelter"](around:%d,%F,%F);out center tags 50;',
-            $radiusM,
-            $center->lat,
-            $center->lon,
-        );
-    }
-
-    /**
-     * Builds an Overpass query for food venues (fast_food, restaurant, cafe)
-     * around a single geographic centre.
-     *
-     * The original spec included an optional `cuisine` filter, but nothing in
-     * the in-ride pipeline currently extracts a cuisine hint from the rider
-     * prompt — adding the filter back will be a follow-up that wires the
-     * parameter end-to-end (PoiIntent → PoiIntentDetector → buildQuery).
-     */
-    public function buildFoodQuery(GeoPoint $center, int $radiusM): string
-    {
-        return \sprintf(
-            '[out:json][timeout:15];(nwr["amenity"="fast_food"](around:%1$d,%2$F,%3$F);nwr["amenity"="restaurant"](around:%1$d,%2$F,%3$F);nwr["amenity"="cafe"](around:%1$d,%2$F,%3$F););out center tags 50;',
-            $radiusM,
-            $center->lat,
-            $center->lon,
-        );
-    }
-
-    /**
-     * Builds an Overpass query for bicycle mechanic shops (shop=bicycle plus
-     * generic outlets advertising `service:bicycle:repair=yes`) around a single
-     * geographic centre.
-     */
-    public function buildMechanicQuery(GeoPoint $center, int $radiusM): string
-    {
-        return \sprintf(
-            '[out:json][timeout:15];(nwr["shop"="bicycle"](around:%1$d,%2$F,%3$F);nwr["service:bicycle:repair"="yes"](around:%1$d,%2$F,%3$F););out center tags 50;',
-            $radiusM,
-            $center->lat,
-            $center->lon,
         );
     }
 

--- a/api/tests/Integration/InRideAssistantTest.php
+++ b/api/tests/Integration/InRideAssistantTest.php
@@ -9,26 +9,24 @@ use App\Geo\HaversineDistance;
 use App\InRide\DeeplinkBuilder;
 use App\InRide\DetourCalculator;
 use App\InRide\InRideAssistant;
+use App\InRide\InRidePoiRepositoryInterface;
 use App\InRide\OpeningHoursParser;
 use App\InRide\PoiIntentDetector;
 use App\InRide\PoiSuggestion;
 use App\Llm\Exception\OllamaUnavailableException;
 use App\Llm\LlmClientInterface;
 use App\Llm\SystemPromptLoader;
-use App\Scanner\OsmOverpassQueryBuilder;
-use App\Scanner\ScannerInterface;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
-use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 /**
  * Integration tests for {@see InRideAssistant} — exercises the full pipeline
- * (intent detection → Overpass query → opening-hours filter → ranking →
- * narrative generation) with in-memory mocks for the LLM client and the OSM
- * scanner.
+ * (intent detection → local-first POI read → opening-hours filter → ranking →
+ * narrative generation) with in-memory mocks for the LLM client and the POI
+ * repository.
  */
 #[AllowMockObjectsWithoutExpectations]
 final class InRideAssistantTest extends TestCase
@@ -65,10 +63,10 @@ final class InRideAssistantTest extends TestCase
             'response' => '{"category":"unknown","max_distance_m":3000}',
         ]);
 
-        $scanner = $this->createMock(ScannerInterface::class);
-        $scanner->expects($this->never())->method('query');
+        $poiRepository = $this->createMock(InRidePoiRepositoryInterface::class);
+        $poiRepository->expects($this->never())->method('findNearby');
 
-        $assistant = $this->buildAssistant($llm, $scanner);
+        $assistant = $this->buildAssistant($llm, $poiRepository);
 
         $response = $assistant->assist(
             message: 'Quel temps fait-il ?',
@@ -81,7 +79,7 @@ final class InRideAssistantTest extends TestCase
     }
 
     #[Test]
-    public function waterIntentQueriesOverpassAndReturnsTopPois(): void
+    public function waterIntentReadsIndexAndReturnsTopPois(): void
     {
         // Intent classification call → water, 3 km radius. Narrative call → markdown.
         $llm = $this->createMock(LlmClientInterface::class);
@@ -97,43 +95,17 @@ final class InRideAssistantTest extends TestCase
             },
         );
 
-        $scanner = $this->createMock(ScannerInterface::class);
-        $scanner->expects($this->once())->method('query')->willReturn([
-            'elements' => [
-                [
-                    'type' => 'node',
-                    'lat' => 50.8504,
-                    'lon' => 4.3520,
-                    'tags' => ['name' => 'Fontaine du Sablon'],
-                ],
-                [
-                    'type' => 'node',
-                    'lat' => 50.8550,
-                    'lon' => 4.3600,
-                    'tags' => ['name' => 'Fontaine Royale'],
-                ],
-                // Anonymous water POIs are still surfaced under a generic label
-                // because the coordinates alone are actionable (deeplink only
-                // needs lat/lon) — only food/mechanic queries drop unnamed nodes.
-                [
-                    'type' => 'node',
-                    'lat' => 50.8505,
-                    'lon' => 4.3521,
-                    'tags' => [],
-                ],
-                // Way / relation Overpass elements expose coordinates via the
-                // `center` sub-object rather than top-level lat/lon. Cover the
-                // extraction branch so a regression that drops it (e.g. a
-                // building-mapped fountain) cannot silently disappear.
-                [
-                    'type' => 'way',
-                    'center' => ['lat' => 50.8509, 'lon' => 4.3527],
-                    'tags' => ['name' => 'Fontaine Centrale'],
-                ],
-            ],
+        $poiRepository = $this->poiRepository([
+            ['lat' => 50.8504, 'lon' => 4.3520, 'tags' => ['name' => 'Fontaine du Sablon']],
+            ['lat' => 50.8550, 'lon' => 4.3600, 'tags' => ['name' => 'Fontaine Royale']],
+            // Anonymous water POIs are still surfaced under a generic label
+            // because the coordinates alone are actionable (the deeplink only
+            // needs lat/lon) — only food/mechanic queries drop unnamed rows.
+            ['lat' => 50.8505, 'lon' => 4.3521, 'tags' => []],
+            ['lat' => 50.8509, 'lon' => 4.3527, 'tags' => ['name' => 'Fontaine Centrale']],
         ]);
 
-        $assistant = $this->buildAssistant($llm, $scanner);
+        $assistant = $this->buildAssistant($llm, $poiRepository);
 
         $response = $assistant->assist(
             message: "Je cherche un point d'eau",
@@ -164,31 +136,12 @@ final class InRideAssistantTest extends TestCase
             },
         );
 
-        $scanner = $this->createMock(ScannerInterface::class);
-        $scanner->method('query')->willReturn([
-            'elements' => [
-                [
-                    'type' => 'node',
-                    'lat' => 50.8504,
-                    'lon' => 4.3520,
-                    'tags' => [
-                        'name' => 'Restaurant Fermé',
-                        'opening_hours' => 'Mo-Fr 09:00-12:00',
-                    ],
-                ],
-                [
-                    'type' => 'node',
-                    'lat' => 50.8510,
-                    'lon' => 4.3525,
-                    'tags' => [
-                        'name' => 'Frites 24/7',
-                        'opening_hours' => '24/7',
-                    ],
-                ],
-            ],
+        $poiRepository = $this->poiRepository([
+            ['lat' => 50.8504, 'lon' => 4.3520, 'tags' => ['name' => 'Restaurant Fermé', 'opening_hours' => 'Mo-Fr 09:00-12:00']],
+            ['lat' => 50.8510, 'lon' => 4.3525, 'tags' => ['name' => 'Frites 24/7', 'opening_hours' => '24/7']],
         ]);
 
-        $assistant = $this->buildAssistant($llm, $scanner);
+        $assistant = $this->buildAssistant($llm, $poiRepository);
 
         // Sunday 14:00 UTC — outside the Mo-Fr 09:00-12:00 window of the first POI.
         $response = $assistant->assist(
@@ -215,22 +168,18 @@ final class InRideAssistantTest extends TestCase
             },
         );
 
-        $elements = [];
+        $features = [];
         // 5 POIs at increasing distances along latitude.
         $offsets = [0.0002, 0.0005, 0.0010, 0.0015, 0.0020];
         foreach ($offsets as $i => $offset) {
-            $elements[] = [
-                'type' => 'node',
+            $features[] = [
                 'lat' => 50.8503 + $offset,
                 'lon' => 4.3517,
                 'tags' => ['name' => 'POI '.($i + 1)],
             ];
         }
 
-        $scanner = $this->createMock(ScannerInterface::class);
-        $scanner->method('query')->willReturn(['elements' => $elements]);
-
-        $assistant = $this->buildAssistant($llm, $scanner);
+        $assistant = $this->buildAssistant($llm, $this->poiRepository($features));
 
         $response = $assistant->assist(
             message: 'Restaurant',
@@ -244,7 +193,7 @@ final class InRideAssistantTest extends TestCase
     }
 
     #[Test]
-    public function emptyOverpassResultsProduceFallbackNarrative(): void
+    public function emptyIndexResultsProduceFallbackNarrative(): void
     {
         $llm = $this->createMock(LlmClientInterface::class);
         $llm->method('generate')->willReturnCallback(
@@ -253,10 +202,7 @@ final class InRideAssistantTest extends TestCase
             ],
         );
 
-        $scanner = $this->createMock(ScannerInterface::class);
-        $scanner->method('query')->willReturn(['elements' => []]);
-
-        $assistant = $this->buildAssistant($llm, $scanner);
+        $assistant = $this->buildAssistant($llm, $this->poiRepository([]));
 
         $response = $assistant->assist(
             message: 'Un abri pour la pluie',
@@ -289,14 +235,11 @@ final class InRideAssistantTest extends TestCase
         $logger->expects(self::once())->method('critical')
             ->with(self::stringContains('LLM unavailable for narrative'));
 
-        $scanner = $this->createMock(ScannerInterface::class);
-        $scanner->method('query')->willReturn([
-            'elements' => [
-                ['type' => 'node', 'lat' => 50.8504, 'lon' => 4.3520, 'tags' => ['name' => 'Fontaine']],
-            ],
+        $poiRepository = $this->poiRepository([
+            ['lat' => 50.8504, 'lon' => 4.3520, 'tags' => ['name' => 'Fontaine']],
         ]);
 
-        $assistant = $this->buildAssistant($llm, $scanner, $logger);
+        $assistant = $this->buildAssistant($llm, $poiRepository, $logger);
 
         $response = $assistant->assist(
             message: "Je cherche un point d'eau",
@@ -308,24 +251,33 @@ final class InRideAssistantTest extends TestCase
         self::assertNotEmpty($response->pois);
     }
 
+    /**
+     * @param list<array{lat: float, lon: float, tags: array<string, string>}> $features
+     */
+    private function poiRepository(array $features): InRidePoiRepositoryInterface
+    {
+        $repository = $this->createStub(InRidePoiRepositoryInterface::class);
+        $repository->method('findNearby')->willReturn($features);
+
+        return $repository;
+    }
+
     private function buildAssistant(
         LlmClientInterface $llm,
-        ScannerInterface $scanner,
+        InRidePoiRepositoryInterface $poiRepository,
         ?LoggerInterface $logger = null,
     ): InRideAssistant {
         $distance = new HaversineDistance();
 
         return new InRideAssistant(
             intentDetector: new PoiIntentDetector($llm),
-            scanner: $scanner,
-            queryBuilder: new OsmOverpassQueryBuilder(),
+            poiRepository: $poiRepository,
             openingHoursParser: new OpeningHoursParser(),
             detourCalculator: new DetourCalculator($distance),
             deeplinkBuilder: new DeeplinkBuilder(),
             distance: $distance,
             llmClient: $llm,
             promptLoader: new SystemPromptLoader($this->promptDir),
-            cache: new ArrayAdapter(),
             logger: $logger ?? new NullLogger(),
         );
     }

--- a/api/tests/Integration/Osm/InRidePoiIndexReadTest.php
+++ b/api/tests/Integration/Osm/InRidePoiIndexReadTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Osm;
+
+use App\InRide\InRidePoiRepository;
+use App\InRide\PoiSuggestion;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * Integration coverage for the local-first in-ride read layer (ADR-040): each
+ * in-ride intent category maps to its osm.* table around the rider position,
+ * with raw tags decoded — replacing the runtime Overpass in-ride scan.
+ */
+final class InRidePoiIndexReadTest extends KernelTestCase
+{
+    use ResetDatabase;
+
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get('doctrine.dbal.default_connection');
+        $this->connection = $connection;
+
+        $this->connection->executeStatement('TRUNCATE osm.water_points, osm.accommodations, osm.pois, osm.bike_shops');
+
+        // One feature per category at (49.61, 6.14), plus decoys that the category
+        // mapping must exclude (a hotel for shelter, a viewpoint for food).
+        $this->connection->executeStatement(<<<'SQL'
+            INSERT INTO osm.water_points (osm_type, osm_id, name, category, tags, geom) VALUES
+              ('n', 1, 'Fontaine', 'drinking_water', '{"name":"Fontaine"}'::jsonb, ST_SetSRID(ST_MakePoint(6.14, 49.61), 4326));
+            INSERT INTO osm.accommodations (osm_type, osm_id, name, category, tags, geom) VALUES
+              ('n', 2, 'Abri', 'shelter', '{"name":"Abri"}'::jsonb, ST_SetSRID(ST_MakePoint(6.14, 49.61), 4326)),
+              ('n', 3, 'Hotel', 'hotel', '{"name":"Hotel"}'::jsonb, ST_SetSRID(ST_MakePoint(6.14, 49.61), 4326));
+            INSERT INTO osm.pois (osm_type, osm_id, name, category, tags, geom) VALUES
+              ('n', 4, 'Resto', 'restaurant', '{"name":"Resto","opening_hours":"24/7"}'::jsonb, ST_SetSRID(ST_MakePoint(6.14, 49.61), 4326)),
+              ('n', 5, 'Belvedere', 'viewpoint', '{"name":"Belvedere"}'::jsonb, ST_SetSRID(ST_MakePoint(6.14, 49.61), 4326));
+            INSERT INTO osm.bike_shops (osm_type, osm_id, name, category, tags, geom) VALUES
+              ('n', 6, 'Cycles', 'bicycle', '{"name":"Cycles"}'::jsonb, ST_SetSRID(ST_MakePoint(6.14, 49.61), 4326));
+            SQL);
+    }
+
+    #[Test]
+    public function findNearbyMapsEachCategoryToItsTableWithDecodedTags(): void
+    {
+        $repository = new InRidePoiRepository($this->connection);
+
+        $water = $repository->findNearby(49.61, 6.14, 2000, PoiSuggestion::CATEGORY_WATER);
+        self::assertCount(1, $water);
+        self::assertSame('Fontaine', $water[0]['tags']['name']);
+        self::assertEqualsWithDelta(49.61, $water[0]['lat'], 0.0001);
+
+        // Shelter reads osm.accommodations filtered to category 'shelter' — the hotel is excluded.
+        $shelter = $repository->findNearby(49.61, 6.14, 2000, PoiSuggestion::CATEGORY_SHELTER);
+        self::assertCount(1, $shelter);
+        self::assertSame('Abri', $shelter[0]['tags']['name']);
+
+        // Food reads osm.pois filtered to restaurant/cafe/fast_food — the viewpoint is excluded.
+        $food = $repository->findNearby(49.61, 6.14, 2000, PoiSuggestion::CATEGORY_FOOD);
+        self::assertCount(1, $food);
+        self::assertSame('24/7', $food[0]['tags']['opening_hours']);
+
+        $mechanic = $repository->findNearby(49.61, 6.14, 2000, PoiSuggestion::CATEGORY_MECHANIC);
+        self::assertCount(1, $mechanic);
+        self::assertSame('Cycles', $mechanic[0]['tags']['name']);
+    }
+
+    #[Test]
+    public function findNearbyExcludesFeaturesOutsideTheRadius(): void
+    {
+        $repository = new InRidePoiRepository($this->connection);
+
+        // ~130 km from the seeded features → nothing in a 2 km radius.
+        self::assertSame([], $repository->findNearby(48.0, 2.0, 2000, PoiSuggestion::CATEGORY_WATER));
+    }
+}

--- a/api/tests/Integration/TripChatInRideTest.php
+++ b/api/tests/Integration/TripChatInRideTest.php
@@ -17,6 +17,7 @@ use App\Geo\HaversineDistance;
 use App\InRide\DeeplinkBuilder;
 use App\InRide\DetourCalculator;
 use App\InRide\InRideAssistant;
+use App\InRide\InRidePoiRepositoryInterface;
 use App\InRide\OpeningHoursParser;
 use App\InRide\PoiIntentDetector;
 use App\InRide\PoiSuggestion;
@@ -27,8 +28,6 @@ use App\Llm\LlmClientInterface;
 use App\Llm\SystemPromptLoader;
 use App\Message\RecalculateStages;
 use App\Repository\TripRequestRepositoryInterface;
-use App\Scanner\OsmOverpassQueryBuilder;
-use App\Scanner\ScannerInterface;
 use App\State\TripChatProcessor;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\Test;
@@ -73,34 +72,12 @@ final class TripChatInRideTest extends TestCase
     public function positionInPayloadDelegatesToInRideAssistantAndReturnsTopPois(): void
     {
         $bus = $this->newMessageBus();
-        $scanner = $this->createMock(ScannerInterface::class);
-        $scanner->expects($this->once())->method('query')->willReturn([
-            'elements' => [
-                [
-                    'type' => 'node',
-                    'lat' => 50.8504,
-                    'lon' => 4.3520,
-                    'tags' => ['name' => 'Fontaine du Sablon'],
-                ],
-                [
-                    'type' => 'node',
-                    'lat' => 50.8550,
-                    'lon' => 4.3600,
-                    'tags' => ['name' => 'Fontaine Royale'],
-                ],
-                [
-                    'type' => 'node',
-                    'lat' => 50.8600,
-                    'lon' => 4.3650,
-                    'tags' => ['name' => 'Fontaine de la Place'],
-                ],
-                [
-                    'type' => 'node',
-                    'lat' => 50.8700,
-                    'lon' => 4.3700,
-                    'tags' => ['name' => 'Fontaine du Parc'],
-                ],
-            ],
+        $poiRepository = $this->createMock(InRidePoiRepositoryInterface::class);
+        $poiRepository->expects($this->once())->method('findNearby')->willReturn([
+            ['lat' => 50.8504, 'lon' => 4.3520, 'tags' => ['name' => 'Fontaine du Sablon']],
+            ['lat' => 50.8550, 'lon' => 4.3600, 'tags' => ['name' => 'Fontaine Royale']],
+            ['lat' => 50.8600, 'lon' => 4.3650, 'tags' => ['name' => 'Fontaine de la Place']],
+            ['lat' => 50.8700, 'lon' => 4.3700, 'tags' => ['name' => 'Fontaine du Parc']],
         ]);
 
         $llm = $this->createMock(LlmClientInterface::class);
@@ -117,7 +94,7 @@ final class TripChatInRideTest extends TestCase
             },
         );
 
-        $processor = $this->newProcessor($llm, $scanner, $bus);
+        $processor = $this->newProcessor($llm, $poiRepository, $bus);
 
         $response = $processor->process(
             new TripChatRequest(
@@ -149,8 +126,8 @@ final class TripChatInRideTest extends TestCase
     #[Test]
     public function unknownIntentInInRideModeReturnsEmptyPoisAndExplanatoryResponse(): void
     {
-        $scanner = $this->createMock(ScannerInterface::class);
-        $scanner->expects($this->never())->method('query');
+        $poiRepository = $this->createMock(InRidePoiRepositoryInterface::class);
+        $poiRepository->expects($this->never())->method('findNearby');
 
         $llm = $this->createMock(LlmClientInterface::class);
         $llm->method('isEnabled')->willReturn(true);
@@ -158,7 +135,7 @@ final class TripChatInRideTest extends TestCase
             'response' => '{"category":"unknown","max_distance_m":3000}',
         ]);
 
-        $processor = $this->newProcessor($llm, $scanner, $this->newMessageBus());
+        $processor = $this->newProcessor($llm, $poiRepository, $this->newMessageBus());
 
         $response = $processor->process(
             new TripChatRequest(
@@ -200,8 +177,8 @@ final class TripChatInRideTest extends TestCase
             });
         $entityManager->expects(self::once())->method('flush');
 
-        $scanner = $this->createMock(ScannerInterface::class);
-        $scanner->method('query')->willReturn(['elements' => []]);
+        $poiRepository = $this->createMock(InRidePoiRepositoryInterface::class);
+        $poiRepository->method('findNearby')->willReturn([]);
 
         $llm = $this->createMock(LlmClientInterface::class);
         $llm->method('isEnabled')->willReturn(true);
@@ -209,7 +186,7 @@ final class TripChatInRideTest extends TestCase
             'response' => '{"category":"unknown","max_distance_m":3000}',
         ]);
 
-        $processor = $this->newProcessor($llm, $scanner, $this->newMessageBus(), $entityManager);
+        $processor = $this->newProcessor($llm, $poiRepository, $this->newMessageBus(), $entityManager);
 
         $processor->process(
             new TripChatRequest(
@@ -226,7 +203,7 @@ final class TripChatInRideTest extends TestCase
 
     private function newProcessor(
         LlmClientInterface $llm,
-        ScannerInterface $scanner,
+        InRidePoiRepositoryInterface $poiRepository,
         MessageBusInterface $messageBus,
         ?EntityManagerInterface $entityManager = null,
     ): TripChatProcessor {
@@ -260,15 +237,13 @@ final class TripChatInRideTest extends TestCase
         $distance = new HaversineDistance();
         $inRideAssistant = new InRideAssistant(
             intentDetector: new PoiIntentDetector($llm),
-            scanner: $scanner,
-            queryBuilder: new OsmOverpassQueryBuilder(),
+            poiRepository: $poiRepository,
             openingHoursParser: new OpeningHoursParser(),
             detourCalculator: new DetourCalculator($distance),
             deeplinkBuilder: new DeeplinkBuilder(),
             distance: $distance,
             llmClient: $llm,
             promptLoader: $promptLoader,
-            cache: new ArrayAdapter(),
         );
 
         return new TripChatProcessor(

--- a/api/tests/Integration/TripChatPlanningRegressionTest.php
+++ b/api/tests/Integration/TripChatPlanningRegressionTest.php
@@ -15,6 +15,7 @@ use App\Geo\HaversineDistance;
 use App\InRide\DeeplinkBuilder;
 use App\InRide\DetourCalculator;
 use App\InRide\InRideAssistant;
+use App\InRide\InRidePoiRepositoryInterface;
 use App\InRide\OpeningHoursParser;
 use App\InRide\PoiIntentDetector;
 use App\Llm\ChatActionInterpreter;
@@ -23,8 +24,6 @@ use App\Llm\LlmClientInterface;
 use App\Llm\SystemPromptLoader;
 use App\Message\RecalculateStages;
 use App\Repository\TripRequestRepositoryInterface;
-use App\Scanner\OsmOverpassQueryBuilder;
-use App\Scanner\ScannerInterface;
 use App\State\TripChatProcessor;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
@@ -93,9 +92,9 @@ final class TripChatPlanningRegressionTest extends TestCase
     ): void {
         $bus = $this->newMessageBus();
 
-        $scanner = $this->createMock(ScannerInterface::class);
-        // In planning mode the in-ride scanner must never be queried.
-        $scanner->expects($this->never())->method('query');
+        $poiRepository = $this->createMock(InRidePoiRepositoryInterface::class);
+        // In planning mode the in-ride index must never be queried.
+        $poiRepository->expects($this->never())->method('findNearby');
 
         $envelope = json_encode([
             'action' => $action,
@@ -111,7 +110,7 @@ final class TripChatPlanningRegressionTest extends TestCase
         // generate() belongs to the in-ride pipeline — never expected here.
         $llm->expects($this->never())->method('generate');
 
-        $processor = $this->newProcessor($llm, $scanner, $bus);
+        $processor = $this->newProcessor($llm, $poiRepository, $bus);
 
         $response = $processor->process(
             new TripChatRequest(message: 'message planning'),
@@ -136,7 +135,7 @@ final class TripChatPlanningRegressionTest extends TestCase
 
     private function newProcessor(
         LlmClientInterface $llm,
-        ScannerInterface $scanner,
+        InRidePoiRepositoryInterface $poiRepository,
         MessageBusInterface $messageBus,
     ): TripChatProcessor {
         $tripRequest = new TripRequest();
@@ -170,15 +169,13 @@ final class TripChatPlanningRegressionTest extends TestCase
         $distance = new HaversineDistance();
         $inRideAssistant = new InRideAssistant(
             intentDetector: new PoiIntentDetector($llm),
-            scanner: $scanner,
-            queryBuilder: new OsmOverpassQueryBuilder(),
+            poiRepository: $poiRepository,
             openingHoursParser: new OpeningHoursParser(),
             detourCalculator: new DetourCalculator($distance),
             deeplinkBuilder: new DeeplinkBuilder(),
             distance: $distance,
             llmClient: $llm,
             promptLoader: $promptLoader,
-            cache: new ArrayAdapter(),
         );
 
         return new TripChatProcessor(

--- a/api/tests/Unit/State/TripChatProcessorTest.php
+++ b/api/tests/Unit/State/TripChatProcessorTest.php
@@ -18,6 +18,7 @@ use App\Geo\HaversineDistance;
 use App\InRide\DeeplinkBuilder;
 use App\InRide\DetourCalculator;
 use App\InRide\InRideAssistant;
+use App\InRide\InRidePoiRepositoryInterface;
 use App\InRide\OpeningHoursParser;
 use App\InRide\PoiIntentDetector;
 use App\Llm\ChatActionInterpreter;
@@ -25,8 +26,6 @@ use App\Llm\ChatHistoryStore;
 use App\Llm\Exception\OllamaUnavailableException;
 use App\Llm\LlmClientInterface;
 use App\Llm\SystemPromptLoader;
-use App\Scanner\OsmOverpassQueryBuilder;
-use App\Scanner\ScannerInterface;
 use App\Message\RecalculateStages;
 use App\Repository\TripRequestRepositoryInterface;
 use App\State\TripChatProcessor;
@@ -516,18 +515,11 @@ final class TripChatProcessorTest extends TestCase
             });
         $entityManager->method('flush');
 
-        // Scanner returns one named water POI close to the rider so the
+        // The index returns one named water POI close to the rider so the
         // in-ride pipeline produces a non-empty $poisPayload that
         // `persistChatTurn` stores on the assistant turn.
-        $scannerResponse = [
-            'elements' => [
-                [
-                    'type' => 'node',
-                    'lat' => 48.8570,
-                    'lon' => 2.3530,
-                    'tags' => ['name' => 'Fontaine Wallace'],
-                ],
-            ],
+        $inRidePois = [
+            ['lat' => 48.8570, 'lon' => 2.3530, 'tags' => ['name' => 'Fontaine Wallace']],
         ];
 
         $processor = $this->newProcessor(
@@ -540,7 +532,7 @@ final class TripChatProcessorTest extends TestCase
             stagesCount: 3,
             messageBus: $this->newMessageBus(),
             entityManager: $entityManager,
-            scannerResponse: $scannerResponse,
+            inRidePois: $inRidePois,
         );
 
         $processor->process(
@@ -674,7 +666,7 @@ final class TripChatProcessorTest extends TestCase
     }
 
     /**
-     * @param array<string, mixed>|null $scannerResponse optional Overpass payload returned by the in-ride scanner mock
+     * @param list<array{lat: float, lon: float, tags: array<string, string>}>|null $inRidePois optional features returned by the in-ride index mock
      */
     private function newProcessor(
         string $llmContent,
@@ -682,7 +674,7 @@ final class TripChatProcessorTest extends TestCase
         MessageBusInterface $messageBus,
         ?RateLimiterFactory $limiterFactory = null,
         ?EntityManagerInterface $entityManager = null,
-        ?array $scannerResponse = null,
+        ?array $inRidePois = null,
         ?LoggerInterface $logger = null,
         ?\Throwable $chatException = null,
     ): TripChatProcessor {
@@ -734,19 +726,17 @@ final class TripChatProcessorTest extends TestCase
         $security->method('getUser')->willReturn($user);
 
         $distance = new HaversineDistance();
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('query')->willReturn($scannerResponse ?? ['elements' => []]);
+        $poiRepository = $this->createStub(InRidePoiRepositoryInterface::class);
+        $poiRepository->method('findNearby')->willReturn($inRidePois ?? []);
         $inRideAssistant = new InRideAssistant(
             intentDetector: new PoiIntentDetector($llmClient),
-            scanner: $scanner,
-            queryBuilder: new OsmOverpassQueryBuilder(),
+            poiRepository: $poiRepository,
             openingHoursParser: new OpeningHoursParser(),
             detourCalculator: new DetourCalculator($distance),
             deeplinkBuilder: new DeeplinkBuilder(),
             distance: $distance,
             llmClient: $llmClient,
             promptLoader: $promptLoader,
-            cache: new ArrayAdapter(),
         );
 
         return new TripChatProcessor(


### PR DESCRIPTION
## Contexte

Cutover de l'**assistant in-ride** (le dernier gros consommateur Overpass on-demand) sur l'index local-first PostGIS (ADR-040). L'in-ride interroge autour de la position du cycliste par intent (eau/abri/food/mécano) — toutes ces catégories sont **déjà dans l'index** (`water_points` / `accommodations`-shelter / `pois`-food / `bike_shops`), donc aucune nouvelle table ni changement `tier1.lua`.

## Changements

- **`InRidePoiRepository`** (+ interface, dans `App\\InRide`) : `findNearby(lat, lon, radius, category)` mappe chaque catégorie d'intent vers sa table `osm.*` (`ST_DWithin` autour du point), renvoie `{lat, lon, tags}` (tags JSONB décodés — name/opening_hours/phone). Filtres : shelter → `accommodations` category='shelter' ; food → `pois` IN (restaurant, cafe, fast_food) ; eau/mécano → tables dédiées.
- **`InRideAssistant`** : injecte `InRidePoiRepositoryInterface` à la place de `ScannerInterface` + `OsmOverpassQueryBuilder` + le cache. `fetchPois` lit l'index local ; `buildQuery` supprimé. Le reste du pipeline (filtre horaires, détour, ranking, narration LLM, dégradation gracieuse) est **inchangé** — `buildSuggestions` consomme déjà `{lat, lon, tags}`.
- **Cache supprimé** : le pool `cache.in_ride_poi` (5 min, anti-hammering Overpass) devient inutile sur des lectures PostGIS indexées → retiré de `cache.php` (prod + test).
- **`OsmOverpassQueryBuilder`** : retrait des 4 builders in-ride orphelins (`buildDrinkingWaterQuery`/`buildShelterQuery`/`buildFoodQuery`/`buildMechanicQuery`) + de l'import `GeoPoint` devenu inutilisé (aucun appelant, aucun test).
- **Tests** : `InRideAssistantTest` réécrit (mock du repo au lieu du scanner ; tout le pipeline conservé) ; nouveau `InRidePoiIndexReadTest` (repo réel sur DB : mapping par catégorie + filtres + décodage tags).

`TripChatProcessor` (seul autre consommateur) est inchangé — `InRideAssistant` est autowiré.

## Vérification

- `php -l` OK (7 fichiers), PHP-CS-Fixer 0/7, aucun résidu (`cache.in_ride_poi`, 4 builders).
- Filtres catégorie validés contre PostGIS réel (shelter exclut hotel ; food exclut viewpoint).
- PHPStan 9 + PHPUnit délégués à la CI.

_(Indépendant de #675 et des slices `tier1.lua` — ne partage aucun fichier avec elles.)_

<!-- claude-review-start -->
## Claude Review

Clean, well-scoped cutover. The SQL is fully parameterized (no injection risk), the Overpass HTTP calls are gone (a direct security improvement), all four queries are bounded via the KNN `ORDER BY geom <-> … LIMIT 50`, and the integration test validates the critical category-mapping invariants (shelter excludes hotel, food excludes viewpoint). The third commit resolved the only finding from the prior review (dead `extractCoordinates` center-branch).

**Findings:** 0 critical, 0 warnings.

**Resolved 1 previously open thread** — the dead Overpass `center`-branch in `extractCoordinates` was dropped in commit `ddf9089`.

### Review checklist
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** None.

_Reviewed commit: ddf9089eb332f6b9ccb5e4d02a42befe322c6ce2_
<!-- claude-review-end -->