### PR TITLE
feat(cultural-pois): read cultural POIs from the local PostGIS index (ADR-040)

### DIFF
--- a/api/migrations/Version20260615160000.php
+++ b/api/migrations/Version20260615160000.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Adds osm.cultural_pois to the local-first Tier-1 reference schema (ADR-040):
+ * a PostGIS point table (museums, monuments, historic sites) read by the API via
+ * ST_DWithin corridor queries, replacing the runtime Overpass cultural-POI scan.
+ * `wikidata` is kept as a first-class column for downstream enrichment.
+ *
+ * Mirrors the osm2pgsql flex output (provisioner/osm2pgsql/tier1.lua): the
+ * provisioner imports into a staging schema and atomically swaps it onto `osm`.
+ * This migration bootstraps the table so it exists before the first provisioning
+ * run and so functional tests have it to seed and query.
+ */
+final class Version20260615160000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add the osm.cultural_pois reference table for local-first cultural-POI reads';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE SCHEMA IF NOT EXISTS osm');
+
+        $this->addSql(<<<'SQL'
+            CREATE TABLE IF NOT EXISTS osm.cultural_pois (
+                osm_type character(1) NOT NULL,
+                osm_id bigint NOT NULL,
+                name text,
+                category text NOT NULL,
+                wikidata text,
+                tags jsonb,
+                geom geometry(Point, 4326) NOT NULL,
+                PRIMARY KEY (osm_type, osm_id)
+            )
+            SQL);
+
+        $this->addSql('CREATE INDEX IF NOT EXISTS cultural_pois_geom_idx ON osm.cultural_pois USING gist (geom)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE IF EXISTS osm.cultural_pois');
+    }
+}

--- a/api/src/CulturalPoiSource/OsmCulturalPoiSource.php
+++ b/api/src/CulturalPoiSource/OsmCulturalPoiSource.php
@@ -4,30 +4,12 @@ declare(strict_types=1);
 
 namespace App\CulturalPoiSource;
 
-use App\ApiResource\Model\Coordinate;
-use App\Scanner\QueryBuilderInterface;
-use App\Scanner\ScannerInterface;
+use App\Osm\CulturalPoiRepositoryInterface;
 
 final readonly class OsmCulturalPoiSource implements CulturalPoiSourceInterface
 {
-    /**
-     * @var list<string>
-     */
-    private const array NOTABLE_HISTORIC_VALUES = [
-        'castle',
-        'monument',
-        'memorial',
-        'ruins',
-        'archaeological_site',
-        'church',
-        'cathedral',
-        'abbey',
-        'fort',
-    ];
-
     public function __construct(
-        private ScannerInterface $scanner,
-        private QueryBuilderInterface $queryBuilder,
+        private CulturalPoiRepositoryInterface $culturalPoiRepository,
     ) {
     }
 
@@ -38,45 +20,19 @@ final readonly class OsmCulturalPoiSource implements CulturalPoiSourceInterface
      */
     public function fetchForStages(array $stageGeometries, int $radiusMeters): array
     {
-        $coordinateGeometries = array_map(
-            static fn (array $geometry): array => array_map(
-                static fn (array $point): Coordinate => new Coordinate($point['lat'], $point['lon']),
-                $geometry,
-            ),
-            $stageGeometries,
-        );
-
-        $query = $this->queryBuilder->buildBatchCulturalPoiQuery($coordinateGeometries, $radiusMeters);
-        $result = $this->scanner->query($query);
-
-        /** @var list<array{tags?: array<string, string>, lat?: float, lon?: float, center?: array{lat: float, lon: float}}> $elements */
-        $elements = \is_array($result['elements'] ?? null) ? $result['elements'] : [];
+        $route = [] !== $stageGeometries ? array_merge(...$stageGeometries) : [];
 
         $pois = [];
-        foreach ($elements as $element) {
-            $lat = $element['lat'] ?? ($element['center']['lat'] ?? null);
-            $lon = $element['lon'] ?? ($element['center']['lon'] ?? null);
-
-            if (null === $lat || null === $lon) {
-                continue;
-            }
-
-            $tags = $element['tags'] ?? [];
-            $poiType = $this->resolveCulturalPoiType($tags);
-
-            if (null === $poiType) {
-                continue;
-            }
-
+        foreach ($this->culturalPoiRepository->findInCorridor($route, $radiusMeters) as $poi) {
             $pois[] = [
-                'name' => $tags['name'] ?? $poiType,
-                'type' => $poiType,
-                'lat' => (float) $lat,
-                'lon' => (float) $lon,
+                'name' => $poi['name'] ?? $poi['category'],
+                'type' => $poi['category'],
+                'lat' => $poi['lat'],
+                'lon' => $poi['lon'],
                 'openingHours' => null,
                 'estimatedPrice' => null,
                 'description' => null,
-                'wikidataId' => isset($tags['wikidata']) && '' !== $tags['wikidata'] ? $tags['wikidata'] : null,
+                'wikidataId' => $poi['wikidata'],
                 'source' => 'osm',
             ];
         }
@@ -92,26 +48,5 @@ final readonly class OsmCulturalPoiSource implements CulturalPoiSourceInterface
     public function getName(): string
     {
         return 'osm';
-    }
-
-    /**
-     * @param array<string, string> $tags
-     */
-    private function resolveCulturalPoiType(array $tags): ?string
-    {
-        if (isset($tags['tourism'])) {
-            return match ($tags['tourism']) {
-                'museum' => 'museum',
-                'attraction' => 'attraction',
-                'viewpoint' => 'viewpoint',
-                default => null,
-            };
-        }
-
-        if (isset($tags['historic']) && \in_array($tags['historic'], self::NOTABLE_HISTORIC_VALUES, true)) {
-            return $tags['historic'];
-        }
-
-        return null;
     }
 }

--- a/api/src/Osm/CulturalPoiRepository.php
+++ b/api/src/Osm/CulturalPoiRepository.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Osm;
+
+use Doctrine\DBAL\Connection;
+
+/**
+ * Reads cultural POIs from the local-first Tier-1 index along the route corridor
+ * (ST_DWithin), replacing the runtime Overpass cultural-POI scan (ADR-040). The
+ * stored category is the resolved type (tourism or historic value).
+ */
+final readonly class CulturalPoiRepository implements CulturalPoiRepositoryInterface
+{
+    public function __construct(private Connection $connection)
+    {
+    }
+
+    /**
+     * Cultural POIs within $radiusMeters of the route corridor, nearest first.
+     *
+     * @param list<array{lat: float, lon: float}> $route
+     *
+     * @return list<array{name: ?string, category: string, lat: float, lon: float, wikidata: ?string}>
+     */
+    public function findInCorridor(array $route, int $radiusMeters): array
+    {
+        if ([] === $route) {
+            return [];
+        }
+
+        $wkt = WktGeometry::lineStringOrPoint($route);
+
+        // `ORDER BY geom <-> route LIMIT 100` (GiST KNN) caps the result like the
+        // old Overpass `out center tags 100;`, fetching the nearest cultural POIs.
+        /** @var list<array<string, scalar|null>> $rows */
+        $rows = $this->connection->fetchAllAssociative(
+            <<<'SQL'
+                SELECT name, category, wikidata, ST_Y(geom) AS lat, ST_X(geom) AS lon
+                FROM osm.cultural_pois
+                WHERE ST_DWithin(
+                    geom::geography,
+                    ST_SetSRID(ST_GeomFromText(:wkt), 4326)::geography,
+                    :radius
+                )
+                ORDER BY geom <-> ST_SetSRID(ST_GeomFromText(:wkt), 4326)
+                LIMIT 100
+                SQL,
+            [
+                'wkt' => $wkt,
+                'radius' => $radiusMeters,
+            ],
+        );
+
+        $pois = [];
+        foreach ($rows as $row) {
+            $pois[] = [
+                'name' => null !== $row['name'] ? (string) $row['name'] : null,
+                'category' => (string) $row['category'],
+                'lat' => (float) $row['lat'],
+                'lon' => (float) $row['lon'],
+                'wikidata' => null !== $row['wikidata'] && '' !== $row['wikidata'] ? (string) $row['wikidata'] : null,
+            ];
+        }
+
+        return $pois;
+    }
+}

--- a/api/src/Osm/CulturalPoiRepositoryInterface.php
+++ b/api/src/Osm/CulturalPoiRepositoryInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Osm;
+
+interface CulturalPoiRepositoryInterface
+{
+    /**
+     * Cultural POIs (museums, monuments, historic sites) whose geometry is within
+     * $radiusMeters of the route corridor, nearest first (capped).
+     *
+     * @param list<array{lat: float, lon: float}> $route
+     *
+     * @return list<array{name: ?string, category: string, lat: float, lon: float, wikidata: ?string}>
+     */
+    public function findInCorridor(array $route, int $radiusMeters): array;
+}

--- a/api/src/Scanner/OsmOverpassQueryBuilder.php
+++ b/api/src/Scanner/OsmOverpassQueryBuilder.php
@@ -132,24 +132,6 @@ final readonly class OsmOverpassQueryBuilder implements QueryBuilderInterface
         );
     }
 
-    /**
-     * @param list<list<Coordinate>> $stageGeometries
-     *
-     * Note: 'out center tags 100' caps the result set globally across all stages.
-     * Acceptable for typical bikepacking trips (≤7 stages, sparse cultural POIs).
-     */
-    public function buildBatchCulturalPoiQuery(array $stageGeometries, int $radiusMeters = 500): string
-    {
-        $allPoints = array_merge(...$stageGeometries);
-        $polyline = $this->buildPolyline($allPoints);
-
-        return \sprintf(
-            '[out:json][timeout:15];(nwr["tourism"="museum"](around:%1$d,%2$s);nwr["tourism"="attraction"](around:%1$d,%2$s);nwr["tourism"="viewpoint"](around:%1$d,%2$s);nwr["historic"~"^(castle|monument|memorial|ruins|archaeological_site|church|cathedral|abbey|fort)$"](around:%1$d,%2$s););out center tags 100;',
-            $radiusMeters,
-            $polyline,
-        );
-    }
-
     public function buildCountryQuery(Coordinate $point): string
     {
         return \sprintf(

--- a/api/src/Scanner/QueryBuilderInterface.php
+++ b/api/src/Scanner/QueryBuilderInterface.php
@@ -68,13 +68,6 @@ interface QueryBuilderInterface
     public function buildHealthServiceQuery(array $decimatedPoints): string;
 
     /**
-     * Build a single Overpass query for cultural POIs along all stages.
-     *
-     * @param list<list<Coordinate>> $stageGeometries geometry points per stage
-     */
-    public function buildBatchCulturalPoiQuery(array $stageGeometries, int $radiusMeters = 500): string;
-
-    /**
      * Queries the country (admin_level=2) for a given coordinate using Overpass is_in.
      *
      * Returns relations with admin_level=2 and boundary=administrative that contain the point,

--- a/api/tests/Integration/Osm/CulturalPoiIndexReadTest.php
+++ b/api/tests/Integration/Osm/CulturalPoiIndexReadTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Osm;
+
+use App\Osm\CulturalPoiRepository;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * Integration coverage for the local-first cultural-POI read layer (ADR-040):
+ * exercises the real PostGIS osm.cultural_pois table with seeded rows and asserts
+ * the ST_DWithin corridor filtering plus the wikidata column mapping.
+ */
+final class CulturalPoiIndexReadTest extends KernelTestCase
+{
+    use ResetDatabase;
+
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get('doctrine.dbal.default_connection');
+        $this->connection = $connection;
+
+        $this->connection->executeStatement('TRUNCATE osm.cultural_pois');
+
+        // A museum (with wikidata) and a castle on the corridor; a far museum (~50 km).
+        $this->connection->executeStatement(<<<'SQL'
+            INSERT INTO osm.cultural_pois (osm_type, osm_id, name, category, wikidata, tags, geom) VALUES
+              ('n', 1, 'Louvre', 'museum', 'Q19675', '{}'::jsonb, ST_SetSRID(ST_MakePoint(6.14, 49.61), 4326)),
+              ('n', 2, 'Château', 'castle', NULL, '{}'::jsonb, ST_SetSRID(ST_MakePoint(6.145, 49.615), 4326)),
+              ('n', 3, 'Musée Lointain', 'museum', NULL, '{}'::jsonb, ST_SetSRID(ST_MakePoint(6.80, 49.90), 4326))
+            SQL);
+    }
+
+    #[Test]
+    public function findInCorridorReturnsCulturalPoisWithWikidata(): void
+    {
+        $pois = new CulturalPoiRepository($this->connection)->findInCorridor([
+            ['lat' => 49.60, 'lon' => 6.13],
+            ['lat' => 49.62, 'lon' => 6.15],
+        ], 2000);
+
+        $byName = [];
+        foreach ($pois as $poi) {
+            $byName[(string) $poi['name']] = $poi;
+        }
+
+        // The far museum is excluded by ST_DWithin.
+        self::assertCount(2, $pois);
+        self::assertSame('museum', $byName['Louvre']['category']);
+        self::assertSame('Q19675', $byName['Louvre']['wikidata']);
+        self::assertSame('castle', $byName['Château']['category']);
+        self::assertNull($byName['Château']['wikidata']);
+        self::assertArrayNotHasKey('Musée Lointain', $byName);
+    }
+
+    #[Test]
+    public function emptyRouteYieldsNoQuery(): void
+    {
+        self::assertSame([], new CulturalPoiRepository($this->connection)->findInCorridor([], 2000));
+    }
+}

--- a/api/tests/Unit/CulturalPoiSource/OsmCulturalPoiSourceTest.php
+++ b/api/tests/Unit/CulturalPoiSource/OsmCulturalPoiSourceTest.php
@@ -5,71 +5,38 @@ declare(strict_types=1);
 namespace App\Tests\Unit\CulturalPoiSource;
 
 use App\CulturalPoiSource\OsmCulturalPoiSource;
-use App\Scanner\QueryBuilderInterface;
-use App\Scanner\ScannerInterface;
+use App\Osm\CulturalPoiRepositoryInterface;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 final class OsmCulturalPoiSourceTest extends TestCase
 {
-    private function makeSource(
-        ScannerInterface $scanner,
-        QueryBuilderInterface $queryBuilder,
-    ): OsmCulturalPoiSource {
-        return new OsmCulturalPoiSource($scanner, $queryBuilder);
-    }
-
-    /**
-     * @return list<list<array{lat: float, lon: float}>>
-     */
-    private function stageGeometries(): array
-    {
-        return [
-            [['lat' => 48.0, 'lon' => 2.0], ['lat' => 48.5, 'lon' => 2.5]],
-        ];
-    }
-
     #[Test]
     public function isEnabledAlwaysReturnsTrue(): void
     {
-        $source = $this->makeSource(
-            $this->createStub(ScannerInterface::class),
-            $this->createStub(QueryBuilderInterface::class),
-        );
-
-        self::assertTrue($source->isEnabled());
+        self::assertTrue($this->makeSource()->isEnabled());
     }
 
     #[Test]
     public function getNameReturnsOsm(): void
     {
-        $source = $this->makeSource(
-            $this->createStub(ScannerInterface::class),
-            $this->createStub(QueryBuilderInterface::class),
-        );
-
-        self::assertSame('osm', $source->getName());
+        self::assertSame('osm', $this->makeSource()->getName());
     }
 
     #[Test]
-    public function museumIsMapped(): void
+    public function mapsRepositoryRowToCandidate(): void
     {
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('query')->willReturn([
-            'elements' => [
-                ['lat' => 48.2, 'lon' => 2.2, 'tags' => ['tourism' => 'museum', 'name' => 'Louvre']],
-            ],
-        ]);
+        $source = $this->makeSource($this->repository([
+            ['name' => 'Louvre', 'category' => 'museum', 'lat' => 48.2, 'lon' => 2.2, 'wikidata' => null],
+        ]));
 
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildBatchCulturalPoiQuery')->willReturn('query');
-
-        $source = $this->makeSource($scanner, $queryBuilder);
         $result = $source->fetchForStages($this->stageGeometries(), 500);
 
         self::assertCount(1, $result);
         self::assertSame('Louvre', $result[0]['name']);
         self::assertSame('museum', $result[0]['type']);
+        self::assertSame(48.2, $result[0]['lat']);
+        self::assertSame(2.2, $result[0]['lon']);
         self::assertSame('osm', $result[0]['source']);
         self::assertNull($result[0]['openingHours']);
         self::assertNull($result[0]['estimatedPrice']);
@@ -77,143 +44,89 @@ final class OsmCulturalPoiSourceTest extends TestCase
     }
 
     #[Test]
-    public function wikidataTagIsExtracted(): void
+    public function historicTypePassesThrough(): void
     {
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('query')->willReturn([
-            'elements' => [
-                ['lat' => 48.2, 'lon' => 2.2, 'tags' => ['tourism' => 'museum', 'name' => 'Louvre', 'wikidata' => 'Q19675']],
-            ],
-        ]);
+        $source = $this->makeSource($this->repository([
+            ['name' => 'Château', 'category' => 'castle', 'lat' => 48.2, 'lon' => 2.2, 'wikidata' => null],
+        ]));
 
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildBatchCulturalPoiQuery')->willReturn('query');
-
-        $source = $this->makeSource($scanner, $queryBuilder);
-        $result = $source->fetchForStages($this->stageGeometries(), 500);
-
-        self::assertCount(1, $result);
-        self::assertSame('Q19675', $result[0]['wikidataId']);
+        self::assertSame('castle', $source->fetchForStages($this->stageGeometries(), 500)[0]['type']);
     }
 
     #[Test]
-    public function elementWithMissingCoordinatesIsSkipped(): void
+    public function extractsWikidataId(): void
     {
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('query')->willReturn([
-            'elements' => [
-                ['tags' => ['tourism' => 'museum', 'name' => 'No Coords Museum']],
-            ],
-        ]);
+        $source = $this->makeSource($this->repository([
+            ['name' => 'Louvre', 'category' => 'museum', 'lat' => 48.2, 'lon' => 2.2, 'wikidata' => 'Q19675'],
+        ]));
 
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildBatchCulturalPoiQuery')->willReturn('query');
-
-        $source = $this->makeSource($scanner, $queryBuilder);
-        $result = $source->fetchForStages($this->stageGeometries(), 500);
-
-        self::assertCount(0, $result);
+        self::assertSame('Q19675', $source->fetchForStages($this->stageGeometries(), 500)[0]['wikidataId']);
     }
 
     #[Test]
-    public function nonNotableHistoricTagIsSkipped(): void
+    public function nullWikidataMapsToNull(): void
     {
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('query')->willReturn([
-            'elements' => [
-                ['lat' => 48.2, 'lon' => 2.2, 'tags' => ['historic' => 'milestone', 'name' => 'Old Stone']],
-            ],
-        ]);
+        $source = $this->makeSource($this->repository([
+            ['name' => 'Museum', 'category' => 'museum', 'lat' => 48.2, 'lon' => 2.2, 'wikidata' => null],
+        ]));
 
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildBatchCulturalPoiQuery')->willReturn('query');
-
-        $source = $this->makeSource($scanner, $queryBuilder);
-        $result = $source->fetchForStages($this->stageGeometries(), 500);
-
-        self::assertCount(0, $result);
+        self::assertNull($source->fetchForStages($this->stageGeometries(), 500)[0]['wikidataId']);
     }
 
     #[Test]
-    public function notableHistoricCastleIsMapped(): void
+    public function nameFallsBackToTypeWhenNull(): void
     {
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('query')->willReturn([
-            'elements' => [
-                ['lat' => 48.2, 'lon' => 2.2, 'tags' => ['historic' => 'castle', 'name' => 'Château Frontenac']],
-            ],
-        ]);
+        $source = $this->makeSource($this->repository([
+            ['name' => null, 'category' => 'viewpoint', 'lat' => 48.2, 'lon' => 2.2, 'wikidata' => null],
+        ]));
 
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildBatchCulturalPoiQuery')->willReturn('query');
-
-        $source = $this->makeSource($scanner, $queryBuilder);
-        $result = $source->fetchForStages($this->stageGeometries(), 500);
-
-        self::assertCount(1, $result);
-        self::assertSame('castle', $result[0]['type']);
+        self::assertSame('viewpoint', $source->fetchForStages($this->stageGeometries(), 500)[0]['name']);
     }
 
     #[Test]
-    public function unknownTourismTagIsSkipped(): void
+    public function flattensStageGeometriesIntoTheCorridorRoute(): void
     {
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('query')->willReturn([
-            'elements' => [
-                ['lat' => 48.2, 'lon' => 2.2, 'tags' => ['tourism' => 'hotel', 'name' => 'Grand Hotel']],
-            ],
-        ]);
+        $repository = $this->createStub(CulturalPoiRepositoryInterface::class);
+        $repository->method('findInCorridor')->willReturnCallback(
+            static function (array $route, int $radiusMeters): array {
+                self::assertSame([
+                    ['lat' => 48.0, 'lon' => 2.0],
+                    ['lat' => 48.5, 'lon' => 2.5],
+                    ['lat' => 49.0, 'lon' => 3.0],
+                ], $route);
+                self::assertSame(500, $radiusMeters);
 
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildBatchCulturalPoiQuery')->willReturn('query');
+                return [];
+            },
+        );
 
-        $source = $this->makeSource($scanner, $queryBuilder);
-        $result = $source->fetchForStages($this->stageGeometries(), 500);
-
-        self::assertCount(0, $result);
+        new OsmCulturalPoiSource($repository)->fetchForStages([
+            [['lat' => 48.0, 'lon' => 2.0], ['lat' => 48.5, 'lon' => 2.5]],
+            [['lat' => 49.0, 'lon' => 3.0]],
+        ], 500);
     }
 
-    #[Test]
-    public function centerCoordinatesAreUsedForWayElements(): void
+    /**
+     * @return list<list<array{lat: float, lon: float}>>
+     */
+    private function stageGeometries(): array
     {
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('query')->willReturn([
-            'elements' => [
-                [
-                    'center' => ['lat' => 48.3, 'lon' => 2.3],
-                    'tags' => ['tourism' => 'attraction', 'name' => 'Big Park'],
-                ],
-            ],
-        ]);
-
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildBatchCulturalPoiQuery')->willReturn('query');
-
-        $source = $this->makeSource($scanner, $queryBuilder);
-        $result = $source->fetchForStages($this->stageGeometries(), 500);
-
-        self::assertCount(1, $result);
-        self::assertSame(48.3, $result[0]['lat']);
-        self::assertSame(2.3, $result[0]['lon']);
+        return [[['lat' => 48.0, 'lon' => 2.0], ['lat' => 48.5, 'lon' => 2.5]]];
     }
 
-    #[Test]
-    public function emptyWikidataTagResultsInNullWikidataId(): void
+    /**
+     * @param list<array{name: ?string, category: string, lat: float, lon: float, wikidata: ?string}> $rows
+     */
+    private function repository(array $rows): CulturalPoiRepositoryInterface
     {
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('query')->willReturn([
-            'elements' => [
-                ['lat' => 48.2, 'lon' => 2.2, 'tags' => ['tourism' => 'museum', 'name' => 'Museum', 'wikidata' => '']],
-            ],
-        ]);
+        $repository = $this->createStub(CulturalPoiRepositoryInterface::class);
+        $repository->method('findInCorridor')->willReturn($rows);
 
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildBatchCulturalPoiQuery')->willReturn('query');
+        return $repository;
+    }
 
-        $source = $this->makeSource($scanner, $queryBuilder);
-        $result = $source->fetchForStages($this->stageGeometries(), 500);
-
-        self::assertCount(1, $result);
-        self::assertNull($result[0]['wikidataId']);
+    private function makeSource(?CulturalPoiRepositoryInterface $repository = null): OsmCulturalPoiSource
+    {
+        return new OsmCulturalPoiSource($repository ?? $this->createStub(CulturalPoiRepositoryInterface::class));
     }
 }

--- a/api/tests/Unit/Scanner/OsmOverpassQueryBuilderTest.php
+++ b/api/tests/Unit/Scanner/OsmOverpassQueryBuilderTest.php
@@ -230,31 +230,4 @@ final class OsmOverpassQueryBuilderTest extends TestCase
         $this->assertStringContainsString('45.000000,5.000000', $query);
         $this->assertStringContainsString('45.100000,5.100000', $query);
     }
-
-    #[Test]
-    public function buildBatchCulturalPoiQueryMergesAllStages(): void
-    {
-        $stage1 = [new Coordinate(45.0, 5.0), new Coordinate(45.1, 5.1)];
-        $stage2 = [new Coordinate(46.0, 6.0), new Coordinate(46.1, 6.1)];
-
-        $query = $this->builder->buildBatchCulturalPoiQuery([$stage1, $stage2]);
-
-        // All points from both stages should be in the polyline
-        $this->assertStringContainsString('45.000000,5.000000', $query);
-        $this->assertStringContainsString('46.000000,6.000000', $query);
-        $this->assertStringContainsString('"tourism"="museum"', $query);
-        $this->assertStringContainsString('"historic"~"^(castle|monument|memorial|ruins|archaeological_site|church|cathedral|abbey|fort)$"', $query);
-        $this->assertStringContainsString('out center tags 100', $query);
-    }
-
-    #[Test]
-    public function buildBatchCulturalPoiQueryUsesCustomRadius(): void
-    {
-        $stage1 = [new Coordinate(45.0, 5.0)];
-
-        $query = $this->builder->buildBatchCulturalPoiQuery([$stage1], 1000);
-
-        $this->assertStringContainsString('around:1000', $query);
-        $this->assertStringNotContainsString('around:500', $query);
-    }
 }

--- a/provisioner/osm2pgsql/tier1.lua
+++ b/provisioner/osm2pgsql/tier1.lua
@@ -5,7 +5,7 @@
 -- the live `osm` schema atomically. The API reads these tables via ST_DWithin
 -- corridor queries, replacing the runtime Overpass dependency.
 --
--- Scope of this style: pois, accommodations, water_points, bike_shops, health_services, railway_stations, charging_stations. The
+-- Scope of this style: pois, accommodations, water_points, bike_shops, health_services, railway_stations, charging_stations, cultural_pois. The
 -- admin_boundaries (coverage polygon) and cycle_routes tables land later.
 
 -- MUST match PostgisImporter::STAGING_SCHEMA: osm2pgsql writes the output tables
@@ -32,6 +32,16 @@ local POI_SHOP = {
 }
 local POI_TOURISM = {
     viewpoint = true, attraction = true,
+}
+
+-- Cultural points of interest (museums, monuments, historic sites) for the
+-- cultural-POI suggestion alert.
+local CULTURAL_TOURISM = {
+    museum = true, attraction = true, viewpoint = true,
+}
+local CULTURAL_HISTORIC = {
+    castle = true, monument = true, memorial = true, ruins = true,
+    archaeological_site = true, church = true, cathedral = true, abbey = true, fort = true,
 }
 
 local pois = osm2pgsql.define_table({
@@ -149,6 +159,22 @@ local charging_stations = osm2pgsql.define_table({
     },
 })
 
+local cultural_pois = osm2pgsql.define_table({
+    name = 'cultural_pois',
+    schema = SCHEMA,
+    ids = { type = 'any', id_column = 'osm_id', type_column = 'osm_type' },
+    columns = {
+        { column = 'name', type = 'text' },
+        { column = 'category', type = 'text', not_null = true },
+        { column = 'wikidata', type = 'text' },
+        { column = 'tags', type = 'jsonb' },
+        { column = 'geom', type = 'point', projection = SRID, not_null = true },
+    },
+    indexes = {
+        { column = 'geom', method = 'gist' },
+    },
+})
+
 local function poi_category(tags)
     if tags.amenity and POI_AMENITY[tags.amenity] then return tags.amenity end
     if tags.shop and POI_SHOP[tags.shop] then return tags.shop end
@@ -204,6 +230,14 @@ local function charging_category(tags)
     return nil
 end
 
+-- Cultural POIs: the stored category is the resolved type (tourism or historic
+-- value), matching OsmCulturalPoiSource's expectations.
+local function cultural_category(tags)
+    if tags.tourism and CULTURAL_TOURISM[tags.tourism] then return tags.tourism end
+    if tags.historic and CULTURAL_HISTORIC[tags.historic] then return tags.historic end
+    return nil
+end
+
 local function is_relevant(tags)
     return poi_category(tags) ~= nil
         or accommodation_category(tags) ~= nil
@@ -212,6 +246,7 @@ local function is_relevant(tags)
         or health_category(tags) ~= nil
         or railway_category(tags) ~= nil
         or charging_category(tags) ~= nil
+        or cultural_category(tags) ~= nil
 end
 
 -- Safe integer coercion (works on both Lua 5.x and LuaJIT builds of osm2pgsql).
@@ -295,6 +330,17 @@ local function insert_features(tags, geom)
         charging_stations:insert({
             name = tags.name,
             category = ccat,
+            tags = tags,
+            geom = geom,
+        })
+    end
+
+    local cultcat = cultural_category(tags)
+    if cultcat then
+        cultural_pois:insert({
+            name = tags.name,
+            category = cultcat,
+            wikidata = tags.wikidata,
             tags = tags,
             geom = geom,
         })


### PR DESCRIPTION
## Contexte

Cutover de la source OSM des **POI culturels** (`OsmCulturalPoiSource`) sur l'index local-first PostGIS (ADR-040). La source DataTourisme (`DataTourismeCulturalPoiSource`) du registre multi-source reste intacte — elle rejoindra l'import DataTourisme (enrichissement). Donnée statique OSM → import.

## Changements

- **Provisioner** (`tier1.lua`) : table flex `cultural_pois` (point + GIST, colonne `wikidata`) ; `cultural_category` = valeur `tourism` (museum/attraction/viewpoint) **ou** `historic` (castle/monument/.../fort). La résolution du type passe de l'analyse à l'import (la catégorie stockée **est** le type). Note : viewpoint/attraction sont aussi dans `pois` (double-insert assumé — consommateurs distincts).
- **Migration** `Version20260615160000` : table `osm.cultural_pois` + index GIST.
- **`CulturalPoiRepository`** (+ interface, `App\Osm`) : `findInCorridor(route, radius)` via `ST_DWithin`, **`ORDER BY geom <-> route LIMIT 100`** (KNN GiST — restaure le cap de l'ancien `out center tags 100;`). Retourne `{name, category, lat, lon, wikidata}`.
- **`OsmCulturalPoiSource`** : injecte `CulturalPoiRepositoryInterface` (plus de `Scanner`/`QueryBuilder`), aplatit les géométries d'étapes en route, mappe vers la forme candidate (`type=category`, `wikidataId=wikidata`, `openingHours/estimatedPrice/description=null`, `source=osm`). `resolveCulturalPoiType` supprimé (filtrage à l'import).
- **`OsmOverpassQueryBuilder` + `QueryBuilderInterface`** : `buildBatchCulturalPoiQuery` retiré (orphelin après cutover) + ses 2 tests.
- **Tests** : test source réécrit (mock de l'interface : mapping, type historic, wikidata, fallback nom→type, aplatissement des étapes) ; nouveau `CulturalPoiIndexReadTest` (corridor + wikidata sur DB réelle). `CheckCulturalPoisHandler`/`CulturalPoiSourceRegistry` inchangés (autowirés).

## Vérification

- `php -l` OK (9), `luac -p tier1.lua` OK, PHP-CS-Fixer 0/9, aucun résidu `buildBatchCulturalPoiQuery`.
- DDL + corridor + KNN + `wikidata` validés contre PostGIS réel (musée + château retournés, lointain exclu).
- PHPStan 9 + PHPUnit délégués à la CI.

<!-- claude-review-start -->
## Claude Review

**1 finding (info only), 0 blocking issues.** Clean, well-scoped cutover that faithfully mirrors the existing `App\Osm` repository pattern. The Lua provisioner, migration, repository, and source all stay in sync. No security, correctness, or architecture issues found.

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Notes

- **KNN ordering metric**: `ORDER BY geom <-> …` is planar (degree-based), while `ST_DWithin` filters in geographic space (meters). The approximation is intentional and documented in the PR description, and it is the established pattern used in `ChargingStationRepository`. Within a bikepacking corridor the error is negligible.
- No `buildBatchCulturalPoiQuery` residues anywhere in the codebase — removal is clean.
- Migration follows the established `CREATE SCHEMA IF NOT EXISTS osm` / `DROP TABLE IF EXISTS` pattern; idempotent and rollback-safe.

Reviewed commit: `cbb5884869681cf841fb6553d5b8c1b2310849ff`

**No inline comments.**
<!-- claude-review-end -->