### PR TITLE
fix(provisioner): sync osmium tags-filter with the Tier-1 table scope

### DIFF
--- a/provisioner/src/PostgisImporter.php
+++ b/provisioner/src/PostgisImporter.php
@@ -45,7 +45,7 @@ final readonly class PostgisImporter
      * @var list<string>
      */
     private const array TAGS_FILTER_EXPRESSIONS = [
-        'nwr/amenity=restaurant,cafe,bar,pub,fast_food,marketplace,pharmacy,hospital,clinic,drinking_water,water_point,fountain,shelter,bicycle_repair_station,charging_station',
+        'nwr/amenity=restaurant,cafe,bar,pub,fast_food,marketplace,pharmacy,hospital,clinic,fuel,drinking_water,water_point,fountain,shelter,bicycle_repair_station,charging_station',
         'nwr/shop=supermarket,convenience,bakery,butcher,greengrocer,deli,general,pastry,farm,bicycle',
         'nwr/tourism=hotel,hostel,guest_house,motel,chalet,camp_site,alpine_hut,wilderness_hut,apartment,viewpoint,attraction,museum',
         'nwr/historic=castle,monument,memorial,ruins,archaeological_site,church,cathedral,abbey,fort',

--- a/provisioner/src/PostgisImporter.php
+++ b/provisioner/src/PostgisImporter.php
@@ -37,15 +37,20 @@ final readonly class PostgisImporter
 
     /**
      * Tag expressions for `osmium tags-filter`; together they keep every feature
-     * the flex style maps. osmium keeps referenced nodes/members by default, so
-     * way geometries stay complete.
+     * osm2pgsql/tier1.lua maps (its `is_relevant`). This list MUST stay in sync
+     * with the flex style: a category mapped there but missing here is silently
+     * dropped from the PBF before import, leaving its table empty. osmium keeps
+     * referenced nodes/members by default, so way geometries stay complete.
      *
      * @var list<string>
      */
     private const array TAGS_FILTER_EXPRESSIONS = [
-        'nwr/amenity=restaurant,cafe,bar,pub,fast_food,marketplace,pharmacy,drinking_water,water_point,fountain,shelter',
-        'nwr/shop=supermarket,convenience,bakery,butcher,greengrocer,deli,general,pastry,farm',
-        'nwr/tourism=hotel,hostel,guest_house,motel,chalet,camp_site,alpine_hut,wilderness_hut,apartment,viewpoint,attraction',
+        'nwr/amenity=restaurant,cafe,bar,pub,fast_food,marketplace,pharmacy,hospital,clinic,drinking_water,water_point,fountain,shelter,bicycle_repair_station,charging_station',
+        'nwr/shop=supermarket,convenience,bakery,butcher,greengrocer,deli,general,pastry,farm,bicycle',
+        'nwr/tourism=hotel,hostel,guest_house,motel,chalet,camp_site,alpine_hut,wilderness_hut,apartment,viewpoint,attraction,museum',
+        'nwr/historic=castle,monument,memorial,ruins,archaeological_site,church,cathedral,abbey,fort',
+        'nwr/railway=station',
+        'nwr/service:bicycle:repair=yes',
         'nwr/man_made=water_tap',
         'nwr/natural=spring',
     ];

--- a/provisioner/tests/PostgisImporterTest.php
+++ b/provisioner/tests/PostgisImporterTest.php
@@ -49,6 +49,18 @@ final class PostgisImporterTest extends TestCase
         );
         self::assertContains('nwr/man_made=water_tap', $this->captured[0]);
         self::assertContains('nwr/natural=spring', $this->captured[0]);
+
+        // Categories added by later cut-over slices must stay in the filter, else
+        // their tables import empty (tier1.lua maps them but osmium would drop them).
+        self::assertContains('nwr/railway=station', $this->captured[0]);
+        self::assertContains('nwr/service:bicycle:repair=yes', $this->captured[0]);
+        $joined = implode(' ', $this->captured[0]);
+        self::assertStringContainsString('hospital', $joined);
+        self::assertStringContainsString('bicycle_repair_station', $joined);
+        self::assertStringContainsString('charging_station', $joined);
+        self::assertStringContainsString('historic=', $joined);
+        self::assertStringContainsString('attraction,museum', $joined);
+        self::assertStringContainsString('farm,bicycle', $joined);
     }
 
     #[Test]

--- a/provisioner/tests/PostgisImporterTest.php
+++ b/provisioner/tests/PostgisImporterTest.php
@@ -58,6 +58,7 @@ final class PostgisImporterTest extends TestCase
         self::assertStringContainsString('hospital', $joined);
         self::assertStringContainsString('bicycle_repair_station', $joined);
         self::assertStringContainsString('charging_station', $joined);
+        self::assertStringContainsString(',fuel,', $joined);
         self::assertStringContainsString('historic=', $joined);
         self::assertStringContainsString('attraction,museum', $joined);
         self::assertStringContainsString('farm,bicycle', $joined);


### PR DESCRIPTION
## Bug

`PostgisImporter::TAGS_FILTER_EXPRESSIONS` (le filtre `osmium tags-filter` qui réduit le PBF avant `osm2pgsql`) **n'a pas été mis à jour** au fil des slices de cutover. Il ne gardait que les features Tier-1 d'origine (POI / hébergements / eau). Conséquence : en provisioning **réel**, les features ajoutées depuis sont **strippées du PBF avant l'import**, laissant leurs tables **vides** :

- `bike_shops` — `shop=bicycle`, `service:bicycle:repair`, `amenity=bicycle_repair_station` strippés
- `health_services` — `hospital`/`clinic` strippés (seul `pharmacy` passait)
- `railway_stations` — `railway=station` strippé
- `charging_stations` — `amenity=charging_station` strippé
- `cultural_pois` — `tourism=museum` + `historic=*` strippés (seuls viewpoint/attraction passaient)

Les tests d'intégration seedent `osm.*` directement → ils ne couvrent pas le pipeline provisioner, d'où le passage inaperçu sur 5 PR mergées (#670, #671, #672, #675, #677).

## Correctif

- **`TAGS_FILTER_EXPRESSIONS`** étendu pour couvrir tout le scope de `tier1.lua` (`is_relevant`) : amenity (+ hospital, clinic, bicycle_repair_station, charging_station), shop (+ bicycle), tourism (+ museum), `historic=…`, `railway=station`, `service:bicycle:repair=yes`. Le filtre reste un sur-ensemble grossier ; `tier1.lua` affine (ex. fountains potables uniquement).
- **Docblock** renforcé : la liste DOIT rester synchro avec `tier1.lua` (anti-régression — c'est précisément cette dérive qui a causé le bug).
- **Test** : `PostgisImporterTest` verrouille désormais les catégories (railway, service:bicycle:repair, hospital, bicycle_repair_station, charging_station, historic, museum, shop=bicycle).

Les highways (table `ways`) seront ajoutées avec la slice terrain à venir.

## Vérification

- `php -l` OK, PHP-CS-Fixer (config provisioner) 0/2.
- PHPStan/PHPUnit/Rector provisioner délégués à la CI.

<!-- claude-review-start -->
## Claude Review

The second commit correctly addresses the `amenity=fuel` gap flagged in the previous review. All osmium tag expressions now fully cover `tier1.lua`'s `is_relevant` function — every feature category that Lua maps to a table is preserved in the PBF before import. The strengthened docblock and regression test assertions make future sync drift visible at test time rather than at provisioning time.

Resolved 1 previously open bot thread (`amenity=fuel` gap addressed by commit 2).

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Inline comments

No inline comments.

---
*Reviewed commit: 44b06c19db3c511a05402832874b2203ca205a18*
<!-- claude-review-end -->