### PR TITLE
feat(terrain): read OSM ways from the local PostGIS index (ADR-040)

### DIFF
--- a/api/migrations/Version20260615170000.php
+++ b/api/migrations/Version20260615170000.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Adds osm.ways to the local-first Tier-1 reference schema (ADR-040): highway ways
+ * stored as PostGIS LineStrings, read by the API via ST_DWithin corridor queries
+ * (centroid + ST_Length computed at read time), replacing the runtime Overpass
+ * ways scan for terrain (surface + traffic) analysis.
+ *
+ * Mirrors the osm2pgsql flex output (provisioner/osm2pgsql/tier1.lua): the
+ * provisioner imports into a staging schema and atomically swaps it onto `osm`.
+ * This migration bootstraps the table so it exists before the first provisioning
+ * run and so functional tests have it to seed and query.
+ */
+final class Version20260615170000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add the osm.ways reference table (highway linestrings) for local-first terrain reads';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE SCHEMA IF NOT EXISTS osm');
+
+        $this->addSql(<<<'SQL'
+            CREATE TABLE IF NOT EXISTS osm.ways (
+                osm_id bigint NOT NULL,
+                tags jsonb,
+                geom geometry(LineString, 4326) NOT NULL,
+                PRIMARY KEY (osm_id)
+            )
+            SQL);
+
+        $this->addSql('CREATE INDEX IF NOT EXISTS ways_geom_idx ON osm.ways USING gist (geom)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE IF EXISTS osm.ways');
+    }
+}

--- a/api/src/MessageHandler/AnalyzeTerrainHandler.php
+++ b/api/src/MessageHandler/AnalyzeTerrainHandler.php
@@ -11,14 +11,12 @@ use App\ApiResource\Stage;
 use App\ComputationTracker\ComputationTrackerInterface;
 use App\ComputationTracker\TripGenerationTrackerInterface;
 use App\Enum\ComputationName;
-use App\Geo\GeoDistanceInterface;
 use App\Geo\GeometryDistributorInterface;
 use App\Mercure\MercureEventType;
 use App\Mercure\TripUpdatePublisherInterface;
 use App\Message\AnalyzeTerrain;
+use App\Osm\WaysRepositoryInterface;
 use App\Repository\TripRequestRepositoryInterface;
-use App\Scanner\QueryBuilderInterface;
-use App\Scanner\ScannerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -26,6 +24,9 @@ use Symfony\Component\Messenger\MessageBusInterface;
 #[AsMessageHandler]
 final readonly class AnalyzeTerrainHandler extends AbstractTripMessageHandler
 {
+    /** Corridor half-width (m) for the local-first ways reads (ADR-040). */
+    private const int WAYS_CORRIDOR_RADIUS_METERS = 100;
+
     public function __construct(
         ComputationTrackerInterface $computationTracker,
         TripUpdatePublisherInterface $publisher,
@@ -33,10 +34,8 @@ final readonly class AnalyzeTerrainHandler extends AbstractTripMessageHandler
         LoggerInterface $logger,
         private TripRequestRepositoryInterface $tripStateManager,
         private AnalyzerRegistryInterface $analyzerRegistry,
-        private ScannerInterface $scanner,
-        private QueryBuilderInterface $queryBuilder,
+        private WaysRepositoryInterface $waysRepository,
         private GeometryDistributorInterface $distributor,
-        private GeoDistanceInterface $geoDistance,
         MessageBusInterface $messageBus,
     ) {
         parent::__construct($computationTracker, $publisher, $generationTracker, $logger, $tripStateManager, $messageBus);
@@ -102,7 +101,9 @@ final readonly class AnalyzeTerrainHandler extends AbstractTripMessageHandler
     }
 
     /**
-     * Fetches OSM ways along the route and distributes them to stages.
+     * Reads OSM ways along the route from the local-first index and distributes
+     * them to stages (ADR-040). The index already reduces each way to its centroid,
+     * length (m) and surface/traffic tags, so no per-way geometry math is needed here.
      *
      * @param list<Stage> $stages
      *
@@ -118,80 +119,10 @@ final readonly class AnalyzeTerrainHandler extends AbstractTripMessageHandler
                 $stages,
             ));
 
-        $query = $this->queryBuilder->buildWaysQuery($points);
-        $result = $this->scanner->query($query);
+        $route = array_map(static fn (Coordinate $point): array => ['lat' => $point->lat, 'lon' => $point->lon], $points);
 
-        /** @var list<array{tags?: array<string, string>, geometry?: list<array{lat: float, lon: float}>}> $elements */
-        $elements = \is_array($result['elements'] ?? null) ? $result['elements'] : [];
+        $ways = $this->waysRepository->findInCorridor($route, self::WAYS_CORRIDOR_RADIUS_METERS);
 
-        $parsedWays = [];
-        foreach ($elements as $element) {
-            $tags = $element['tags'] ?? [];
-            $geometry = $element['geometry'] ?? [];
-            $length = $this->computeWayLength($geometry);
-            $center = $this->computeWayCenter($geometry);
-
-            if (null === $center) {
-                continue;
-            }
-
-            $way = [
-                'lat' => $center['lat'],
-                'lon' => $center['lon'],
-                'surface' => $tags['surface'] ?? '',
-                'highway' => $tags['highway'] ?? '',
-                'cycleway' => $tags['cycleway'] ?? '',
-                'cycleway:right' => $tags['cycleway:right'] ?? '',
-                'cycleway:left' => $tags['cycleway:left'] ?? '',
-                'cycleway:both' => $tags['cycleway:both'] ?? '',
-                'bicycle' => $tags['bicycle'] ?? '',
-                'maxspeed' => $tags['maxspeed'] ?? '',
-                'length' => $length,
-            ];
-
-            $parsedWays[] = $way;
-        }
-
-        return $this->distributor->distributeByGeometry($parsedWays, $stages);
-    }
-
-    /**
-     * Computes the length of a way in meters from its geometry nodes.
-     *
-     * @param list<array{lat: float, lon: float}> $geometry
-     */
-    private function computeWayLength(array $geometry): float
-    {
-        $length = 0.0;
-
-        for ($i = 1, $count = \count($geometry); $i < $count; ++$i) {
-            $length += $this->geoDistance->inMeters(
-                $geometry[$i - 1]['lat'],
-                $geometry[$i - 1]['lon'],
-                $geometry[$i]['lat'],
-                $geometry[$i]['lon'],
-            );
-        }
-
-        return $length;
-    }
-
-    /**
-     * Returns the geometric centroid of a way geometry.
-     *
-     * @param list<array{lat: float, lon: float}> $geometry
-     *
-     * @return array{lat: float, lon: float}|null
-     */
-    private function computeWayCenter(array $geometry): ?array
-    {
-        if ([] === $geometry) {
-            return null;
-        }
-
-        $lat = array_sum(array_column($geometry, 'lat')) / \count($geometry);
-        $lon = array_sum(array_column($geometry, 'lon')) / \count($geometry);
-
-        return ['lat' => $lat, 'lon' => $lon];
+        return $this->distributor->distributeByGeometry($ways, $stages);
     }
 }

--- a/api/src/Osm/WaysRepository.php
+++ b/api/src/Osm/WaysRepository.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Osm;
+
+use Doctrine\DBAL\Connection;
+
+/**
+ * Reads highway ways from the local-first Tier-1 index along the route corridor
+ * (ST_DWithin), replacing the runtime Overpass ways scan (ADR-040). Each way is
+ * reduced in SQL to the shape the terrain analyzers consume: centroid + length
+ * (meters, via geography) + the surface/traffic tags. The full linestring stays
+ * in the table; only the derived fields cross the wire.
+ */
+final readonly class WaysRepository implements WaysRepositoryInterface
+{
+    public function __construct(private Connection $connection)
+    {
+    }
+
+    /**
+     * @param list<array{lat: float, lon: float}> $route
+     *
+     * @return list<array{lat: float, lon: float, surface: string, highway: string, cycleway: string, 'cycleway:right': string, 'cycleway:left': string, 'cycleway:both': string, bicycle: string, maxspeed: string, length: float}>
+     */
+    public function findInCorridor(array $route, int $radiusMeters): array
+    {
+        if ([] === $route) {
+            return [];
+        }
+
+        /** @var list<array<string, scalar|null>> $rows */
+        $rows = $this->connection->fetchAllAssociative(
+            <<<'SQL'
+                SELECT ST_Y(_c.centroid) AS lat,
+                       ST_X(_c.centroid) AS lon,
+                       ST_Length(geom::geography) AS length,
+                       tags->>'surface' AS surface,
+                       tags->>'highway' AS highway,
+                       tags->>'cycleway' AS cycleway,
+                       tags->>'cycleway:right' AS cycleway_right,
+                       tags->>'cycleway:left' AS cycleway_left,
+                       tags->>'cycleway:both' AS cycleway_both,
+                       tags->>'bicycle' AS bicycle,
+                       tags->>'maxspeed' AS maxspeed
+                FROM osm.ways,
+                LATERAL (SELECT ST_Centroid(geom) AS centroid) AS _c
+                WHERE ST_DWithin(
+                    geom::geography,
+                    ST_SetSRID(ST_GeomFromText(:wkt), 4326)::geography,
+                    :radius
+                )
+                SQL,
+            [
+                'wkt' => WktGeometry::lineStringOrPoint($route),
+                'radius' => $radiusMeters,
+            ],
+        );
+
+        $ways = [];
+        foreach ($rows as $row) {
+            $ways[] = [
+                'lat' => (float) $row['lat'],
+                'lon' => (float) $row['lon'],
+                'surface' => (string) ($row['surface'] ?? ''),
+                'highway' => (string) ($row['highway'] ?? ''),
+                'cycleway' => (string) ($row['cycleway'] ?? ''),
+                'cycleway:right' => (string) ($row['cycleway_right'] ?? ''),
+                'cycleway:left' => (string) ($row['cycleway_left'] ?? ''),
+                'cycleway:both' => (string) ($row['cycleway_both'] ?? ''),
+                'bicycle' => (string) ($row['bicycle'] ?? ''),
+                'maxspeed' => (string) ($row['maxspeed'] ?? ''),
+                'length' => (float) $row['length'],
+            ];
+        }
+
+        return $ways;
+    }
+}

--- a/api/src/Osm/WaysRepositoryInterface.php
+++ b/api/src/Osm/WaysRepositoryInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Osm;
+
+interface WaysRepositoryInterface
+{
+    /**
+     * Highway ways whose geometry is within $radiusMeters of the route corridor,
+     * each reduced to its centroid, length (m) and the tags the terrain analyzers
+     * read (surface, highway, cycleway*, bicycle, maxspeed).
+     *
+     * @param list<array{lat: float, lon: float}> $route
+     *
+     * @return list<array{lat: float, lon: float, surface: string, highway: string, cycleway: string, 'cycleway:right': string, 'cycleway:left': string, 'cycleway:both': string, bicycle: string, maxspeed: string, length: float}>
+     */
+    public function findInCorridor(array $route, int $radiusMeters): array;
+}

--- a/api/tests/Integration/Osm/WaysIndexReadTest.php
+++ b/api/tests/Integration/Osm/WaysIndexReadTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Osm;
+
+use App\Osm\WaysRepository;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * Integration coverage for the local-first ways read layer (ADR-040): seeds real
+ * PostGIS LineStrings in osm.ways and asserts the ST_DWithin corridor filtering
+ * plus the centroid / geography-length / tag projection the terrain analyzers consume.
+ */
+final class WaysIndexReadTest extends KernelTestCase
+{
+    use ResetDatabase;
+
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get('doctrine.dbal.default_connection');
+        $this->connection = $connection;
+
+        $this->connection->executeStatement('TRUNCATE osm.ways');
+
+        // A secondary road on the corridor and a primary road ~50 km away.
+        $this->connection->executeStatement(<<<'SQL'
+            INSERT INTO osm.ways (osm_id, tags, geom) VALUES
+              (1, '{"highway":"secondary","surface":"asphalt","maxspeed":"50"}'::jsonb,
+                  ST_SetSRID(ST_GeomFromText('LINESTRING(6.13 49.60, 6.15 49.62)'), 4326)),
+              (2, '{"highway":"primary"}'::jsonb,
+                  ST_SetSRID(ST_GeomFromText('LINESTRING(6.80 49.90, 6.81 49.91)'), 4326))
+            SQL);
+    }
+
+    #[Test]
+    public function findInCorridorProjectsCentroidLengthAndTags(): void
+    {
+        $ways = new WaysRepository($this->connection)->findInCorridor([
+            ['lat' => 49.60, 'lon' => 6.13],
+            ['lat' => 49.62, 'lon' => 6.15],
+        ], 100);
+
+        // The far primary road is excluded by ST_DWithin.
+        self::assertCount(1, $ways);
+
+        $way = $ways[0];
+        self::assertSame('secondary', $way['highway']);
+        self::assertSame('asphalt', $way['surface']);
+        self::assertSame('50', $way['maxspeed']);
+        // Tags absent from the row default to '' (the shape the analyzers expect).
+        self::assertSame('', $way['cycleway']);
+        self::assertSame('', $way['bicycle']);
+        // Centroid of the linestring + a real geography length in meters.
+        self::assertEqualsWithDelta(49.61, $way['lat'], 0.01);
+        self::assertEqualsWithDelta(6.14, $way['lon'], 0.01);
+        self::assertGreaterThan(1000.0, $way['length']);
+    }
+
+    #[Test]
+    public function emptyRouteYieldsNoQuery(): void
+    {
+        self::assertSame([], new WaysRepository($this->connection)->findInCorridor([], 100));
+    }
+}

--- a/api/tests/Unit/MessageHandler/AnalyzeTerrainHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/AnalyzeTerrainHandlerTest.php
@@ -12,15 +12,13 @@ use App\ApiResource\TripRequest;
 use App\ComputationTracker\ComputationTrackerInterface;
 use App\ComputationTracker\TripGenerationTrackerInterface;
 use App\Enum\AlertType;
-use App\Geo\GeoDistanceInterface;
 use App\Geo\GeometryDistributorInterface;
 use App\Mercure\MercureEventType;
 use App\Mercure\TripUpdatePublisherInterface;
 use App\Message\AnalyzeTerrain;
 use App\MessageHandler\AnalyzeTerrainHandler;
+use App\Osm\WaysRepositoryInterface;
 use App\Repository\TripRequestRepositoryInterface;
-use App\Scanner\QueryBuilderInterface;
-use App\Scanner\ScannerInterface;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
@@ -45,14 +43,29 @@ final class AnalyzeTerrainHandlerTest extends TestCase
         );
     }
 
+    /**
+     * @param list<array{lat: float, lon: float, surface: string, highway: string, cycleway: string, 'cycleway:right': string, 'cycleway:left': string, 'cycleway:both': string, bicycle: string, maxspeed: string, length: float}> $ways
+     */
+    private function waysRepository(array $ways): WaysRepositoryInterface
+    {
+        $repository = $this->createStub(WaysRepositoryInterface::class);
+        $repository->method('findInCorridor')->willReturnCallback(
+            static function (array $route, int $radiusMeters) use ($ways): array {
+                self::assertSame(100, $radiusMeters, 'findInCorridor must use the 100 m ways corridor');
+
+                return $ways;
+            },
+        );
+
+        return $repository;
+    }
+
     private function createHandler(
         TripRequestRepositoryInterface $tripStateManager,
         AnalyzerRegistryInterface $analyzerRegistry,
         TripUpdatePublisherInterface $publisher,
-        ScannerInterface $scanner,
-        QueryBuilderInterface $queryBuilder,
+        WaysRepositoryInterface $waysRepository,
         GeometryDistributorInterface $distributor,
-        GeoDistanceInterface $geoDistance,
     ): AnalyzeTerrainHandler {
         $computationTracker = $this->createStub(ComputationTrackerInterface::class);
         $computationTracker->method('getProgress')->willReturn(['completed' => 0, 'failed' => 0, 'total' => 1]);
@@ -66,10 +79,8 @@ final class AnalyzeTerrainHandlerTest extends TestCase
             new NullLogger(),
             $tripStateManager,
             $analyzerRegistry,
-            $scanner,
-            $queryBuilder,
+            $waysRepository,
             $distributor,
-            $geoDistance,
             $this->createStub(MessageBusInterface::class),
         );
     }
@@ -87,10 +98,8 @@ final class AnalyzeTerrainHandlerTest extends TestCase
             $tripStateManager,
             $this->createStub(AnalyzerRegistryInterface::class),
             $publisher,
-            $this->createStub(ScannerInterface::class),
-            $this->createStub(QueryBuilderInterface::class),
+            $this->createStub(WaysRepositoryInterface::class),
             $this->createStub(GeometryDistributorInterface::class),
-            $this->createStub(GeoDistanceInterface::class),
         );
 
         $handler(new AnalyzeTerrain('trip-1'));
@@ -112,38 +121,14 @@ final class AnalyzeTerrainHandlerTest extends TestCase
             ['lat' => 48.5, 'lon' => 2.5, 'ele' => 0.0],
         ]);
 
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildWaysQuery')->willReturn('way-query');
-
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('query')->willReturn([
-            'elements' => [
-                [
-                    'tags' => ['highway' => 'primary', 'surface' => 'asphalt'],
-                    'geometry' => [
-                        ['lat' => 48.1, 'lon' => 2.1],
-                        ['lat' => 48.2, 'lon' => 2.2],
-                    ],
-                ],
-            ],
+        $waysRepository = $this->waysRepository([
+            ['lat' => 48.1, 'lon' => 2.1, 'surface' => 'asphalt', 'highway' => 'primary', 'cycleway' => '', 'cycleway:right' => '', 'cycleway:left' => '', 'cycleway:both' => '', 'bicycle' => '', 'maxspeed' => '', 'length' => 1000.0],
         ]);
-
-        $geoDistance = $this->createStub(GeoDistanceInterface::class);
-        $geoDistance->method('inMeters')->willReturn(1000.0);
 
         $distributor = $this->createStub(GeometryDistributorInterface::class);
         $distributor->method('distributeByGeometry')->willReturn([
             0 => [
-                [
-                    'lat' => 48.1,
-                    'lon' => 2.1,
-                    'surface' => 'asphalt',
-                    'highway' => 'primary',
-                    'cycleway' => '',
-                    'cycleway:right' => '',
-                    'cycleway:left' => '',
-                    'length' => 1000.0,
-                ],
+                ['lat' => 48.1, 'lon' => 2.1, 'surface' => 'asphalt', 'highway' => 'primary', 'length' => 1000.0],
             ],
         ]);
 
@@ -157,16 +142,12 @@ final class AnalyzeTerrainHandlerTest extends TestCase
                 return [];
             });
 
-        $publisher = $this->createStub(TripUpdatePublisherInterface::class);
-
         $handler = $this->createHandler(
             $tripStateManager,
             $analyzerRegistry,
-            $publisher,
-            $scanner,
-            $queryBuilder,
+            $this->createStub(TripUpdatePublisherInterface::class),
+            $waysRepository,
             $distributor,
-            $geoDistance,
         );
 
         $handler(new AnalyzeTerrain('trip-1'));
@@ -194,13 +175,6 @@ final class AnalyzeTerrainHandlerTest extends TestCase
             ['lat' => 48.0, 'lon' => 2.0, 'ele' => 0.0],
         ]);
 
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildWaysQuery')->willReturn('query');
-
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('query')->willReturn(['elements' => []]);
-
-        $geoDistance = $this->createStub(GeoDistanceInterface::class);
         $distributor = $this->createStub(GeometryDistributorInterface::class);
         $distributor->method('distributeByGeometry')->willReturn([]);
 
@@ -227,17 +201,15 @@ final class AnalyzeTerrainHandlerTest extends TestCase
             $tripStateManager,
             $analyzerRegistry,
             $publisher,
-            $scanner,
-            $queryBuilder,
+            $this->waysRepository([]),
             $distributor,
-            $geoDistance,
         );
 
         $handler(new AnalyzeTerrain('trip-1'));
     }
 
     #[Test]
-    public function fallsBackToStageGeometryWhenNoDecimatedPoints(): void
+    public function usesStageGeometryRouteWhenNoDecimatedPoints(): void
     {
         $stage = $this->createStage();
         $tripRequest = new TripRequest();
@@ -249,84 +221,33 @@ final class AnalyzeTerrainHandlerTest extends TestCase
         $tripStateManager->method('getRequest')->willReturn($tripRequest);
         $tripStateManager->method('getDecimatedPoints')->willReturn(null);
 
-        $queryBuilder = $this->createMock(QueryBuilderInterface::class);
-        $queryBuilder->expects($this->once())
-            ->method('buildWaysQuery')
-            ->with($this->callback(static fn (array $points): bool => 3 === \count($points) && $points[0] instanceof Coordinate))
-            ->willReturn('query');
+        // No decimated points → the corridor route is built from the stage geometry.
+        $waysRepository = $this->createStub(WaysRepositoryInterface::class);
+        $waysRepository->method('findInCorridor')->willReturnCallback(
+            static function (array $route, int $radiusMeters): array {
+                self::assertSame(100, $radiusMeters);
+                self::assertSame([
+                    ['lat' => 48.0, 'lon' => 2.0],
+                    ['lat' => 48.25, 'lon' => 2.25],
+                    ['lat' => 48.5, 'lon' => 2.5],
+                ], $route);
 
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('query')->willReturn(['elements' => []]);
+                return [];
+            },
+        );
 
-        $geoDistance = $this->createStub(GeoDistanceInterface::class);
         $distributor = $this->createStub(GeometryDistributorInterface::class);
         $distributor->method('distributeByGeometry')->willReturn([]);
 
         $analyzerRegistry = $this->createStub(AnalyzerRegistryInterface::class);
         $analyzerRegistry->method('analyze')->willReturn([]);
 
-        $publisher = $this->createStub(TripUpdatePublisherInterface::class);
-
         $handler = $this->createHandler(
             $tripStateManager,
             $analyzerRegistry,
-            $publisher,
-            $scanner,
-            $queryBuilder,
+            $this->createStub(TripUpdatePublisherInterface::class),
+            $waysRepository,
             $distributor,
-            $geoDistance,
-        );
-
-        $handler(new AnalyzeTerrain('trip-1'));
-    }
-
-    #[Test]
-    public function skipsWayElementsWithEmptyGeometry(): void
-    {
-        $stage = $this->createStage();
-        $tripRequest = new TripRequest();
-        $tripRequest->ebikeMode = false;
-
-        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
-        $tripStateManager->method('getStages')->willReturn([$stage]);
-        $tripStateManager->method('getLocale')->willReturn('en');
-        $tripStateManager->method('getRequest')->willReturn($tripRequest);
-        $tripStateManager->method('getDecimatedPoints')->willReturn([
-            ['lat' => 48.0, 'lon' => 2.0, 'ele' => 0.0],
-        ]);
-
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildWaysQuery')->willReturn('query');
-
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('query')->willReturn([
-            'elements' => [
-                ['tags' => ['highway' => 'track'], 'geometry' => []],
-                ['tags' => ['highway' => 'primary']],
-            ],
-        ]);
-
-        $geoDistance = $this->createStub(GeoDistanceInterface::class);
-
-        $distributor = $this->createMock(GeometryDistributorInterface::class);
-        $distributor->expects($this->once())
-            ->method('distributeByGeometry')
-            ->with($this->callback(static fn (array $ways): bool => [] === $ways))
-            ->willReturn([]);
-
-        $analyzerRegistry = $this->createStub(AnalyzerRegistryInterface::class);
-        $analyzerRegistry->method('analyze')->willReturn([]);
-
-        $publisher = $this->createStub(TripUpdatePublisherInterface::class);
-
-        $handler = $this->createHandler(
-            $tripStateManager,
-            $analyzerRegistry,
-            $publisher,
-            $scanner,
-            $queryBuilder,
-            $distributor,
-            $geoDistance,
         );
 
         $handler(new AnalyzeTerrain('trip-1'));

--- a/provisioner/osm2pgsql/tier1.lua
+++ b/provisioner/osm2pgsql/tier1.lua
@@ -5,7 +5,7 @@
 -- the live `osm` schema atomically. The API reads these tables via ST_DWithin
 -- corridor queries, replacing the runtime Overpass dependency.
 --
--- Scope of this style: pois, accommodations, water_points, bike_shops, health_services, railway_stations, charging_stations, cultural_pois. The
+-- Scope of this style: pois, accommodations, water_points, bike_shops, health_services, railway_stations, charging_stations, cultural_pois, ways. The
 -- admin_boundaries (coverage polygon) and cycle_routes tables land later.
 
 -- MUST match PostgisImporter::STAGING_SCHEMA: osm2pgsql writes the output tables
@@ -42,6 +42,13 @@ local CULTURAL_TOURISM = {
 local CULTURAL_HISTORIC = {
     castle = true, monument = true, memorial = true, ruins = true,
     archaeological_site = true, church = true, cathedral = true, abbey = true, fort = true,
+}
+
+-- Road/path highway values analysed for surface + traffic (stored as linestrings).
+local WAY_HIGHWAY = {
+    primary = true, secondary = true, tertiary = true, unclassified = true,
+    residential = true, living_street = true, service = true, track = true,
+    path = true, cycleway = true, footway = true, bridleway = true,
 }
 
 local pois = osm2pgsql.define_table({
@@ -175,6 +182,19 @@ local cultural_pois = osm2pgsql.define_table({
     },
 })
 
+local ways = osm2pgsql.define_table({
+    name = 'ways',
+    schema = SCHEMA,
+    ids = { type = 'way', id_column = 'osm_id' },
+    columns = {
+        { column = 'tags', type = 'jsonb' },
+        { column = 'geom', type = 'linestring', projection = SRID, not_null = true },
+    },
+    indexes = {
+        { column = 'geom', method = 'gist' },
+    },
+})
+
 local function poi_category(tags)
     if tags.amenity and POI_AMENITY[tags.amenity] then return tags.amenity end
     if tags.shop and POI_SHOP[tags.shop] then return tags.shop end
@@ -238,6 +258,11 @@ local function cultural_category(tags)
     return nil
 end
 
+-- True for the highway ways imported into the ways table (linestrings).
+local function way_highway(tags)
+    return tags.highway ~= nil and WAY_HIGHWAY[tags.highway] == true
+end
+
 local function is_relevant(tags)
     return poi_category(tags) ~= nil
         or accommodation_category(tags) ~= nil
@@ -247,6 +272,7 @@ local function is_relevant(tags)
         or railway_category(tags) ~= nil
         or charging_category(tags) ~= nil
         or cultural_category(tags) ~= nil
+        or way_highway(tags)
 end
 
 -- Safe integer coercion (works on both Lua 5.x and LuaJIT builds of osm2pgsql).
@@ -368,6 +394,19 @@ end
 
 function osm2pgsql.process_way(object)
     if not is_relevant(object.tags) then return end
+
+    -- The ways table keeps the full linestring for surface/traffic analysis.
+    -- Highway ways are never a mapped POI category, so skip the centroid +
+    -- insert_features work (a no-op for them) on country-sized extracts.
+    if way_highway(object.tags) then
+        local ok, line = pcall(function() return object:as_linestring() end)
+        if ok and line ~= nil then
+            ways:insert({ tags = object.tags, geom = line })
+        end
+        return
+    end
+
+    -- Point features (POI/accommodation/...) use the way centroid.
     local geom = way_centroid(object)
     if geom == nil then return end
     insert_features(object.tags, geom)

--- a/provisioner/src/PostgisImporter.php
+++ b/provisioner/src/PostgisImporter.php
@@ -53,6 +53,7 @@ final readonly class PostgisImporter
         'nwr/service:bicycle:repair=yes',
         'nwr/man_made=water_tap',
         'nwr/natural=spring',
+        'w/highway=primary,secondary,tertiary,unclassified,residential,living_street,service,track,path,cycleway,footway,bridleway',
     ];
 
     /**

--- a/provisioner/tests/PostgisImporterTest.php
+++ b/provisioner/tests/PostgisImporterTest.php
@@ -62,6 +62,7 @@ final class PostgisImporterTest extends TestCase
         self::assertStringContainsString('historic=', $joined);
         self::assertStringContainsString('attraction,museum', $joined);
         self::assertStringContainsString('farm,bicycle', $joined);
+        self::assertStringContainsString('w/highway=', $joined);
     }
 
     #[Test]


### PR DESCRIPTION
## Contexte

Cutover de l'analyse **terrain** (`AnalyzeTerrainHandler` — surface + trafic) sur l'index PostGIS local (ADR-040). Première couche **lignes** (pas des points).

> **PR stackée sur #678** (base = `feature/provisioner-tags-filter-sync`, car terrain ajoute `highway` au même filtre). GitHub re-ciblera `main` au merge de #678 ; le diff ci-dessus est terrain seul.

## Insight clé

`AnalyzeTerrainHandler` n'utilise la géométrie des ways que pour calculer **longueur + centroïde**, puis sort une liste de `{lat, lon, surface, highway, cycleway*, bicycle, maxspeed, length}` (points + tags). Donc je **stocke la LINESTRING** et calcule **`ST_Centroid` + `ST_Length(geom::geography)` (mètres) à la lecture** — la forme `$way` est **identique**, donc les analyzers `Surface`/`Traffic` et leurs tests ne bougent pas.

## Changements

- **Provisioner** (`tier1.lua`) : table flex `ways` (**LINESTRING** + GIST) ; `WAY_HIGHWAY` (primary…bridleway) ; `process_way` insère la linestring (en plus du centroïde pour les features points). Filtre `osmium` += `w/highway=…`.
- **Migration** `Version20260615170000` : `osm.ways` (geom LineString, tags) + GIST.
- **`WaysRepository`** (+ interface) : `findInCorridor(route, radius)` → projette en SQL centroïde + longueur géographie + tags (`surface`, `highway`, `cycleway[:right|left|both]`, `bicycle`, `maxspeed`) vers la forme `$way`. Seuls les champs dérivés transitent (pas la ligne).
- **`AnalyzeTerrainHandler`** : injecte `WaysRepositoryInterface` (plus de `Scanner`/`QueryBuilder`/`GeoDistance`) ; `computeWayLength`/`computeWayCenter` supprimés (SQL). Rayon corridor 100 m (= ancien `buildWaysQuery`).
- **Tests** : test handler réécrit (mock du repo ; le test skip-empty-geometry devient caduc — l'index ne renvoie que des lignes valides) ; nouveau `WaysIndexReadTest` (LINESTRING réelle → centroïde + longueur + tags + corridor).

`buildWaysQuery` **reste** (encore appelé par `ScanAllOsmDataHandler`, retiré au nettoyage final). Distribution par étape (`GeometryBasedDistributor`) inchangée.

## Vérification

- `php -l` OK, `luac -p tier1.lua` OK, PHP-CS-Fixer 0 (configs api + provisioner).
- Requête validée contre PostGIS réel : centroïde (49.610, 6.140), longueur 2653 m (géographie), `highway`/`surface` extraits, route lointaine exclue.
- PHPStan 9 + PHPUnit délégués à la CI.

<!-- claude-review-start -->
## Claude Review

**Commit reviewed:** `66bfaabf5295d12338c18bf475cf2a18debd0dd2`

**Findings:** 0 — both previous findings addressed; no new issues.

**Resolved threads:** Resolved 2 previously open threads that were addressed.

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**No inline comments.**
<!-- claude-review-end -->