### PR TITLE
feat(border): resolve countries from the local PostGIS index (ADR-040)

### DIFF
--- a/api/migrations/Version20260615180000.php
+++ b/api/migrations/Version20260615180000.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Adds osm.admin_boundaries to the local-first Tier-1 reference schema (ADR-040):
+ * country-level (admin_level=2) administrative boundaries stored as PostGIS
+ * MultiPolygons. The API resolves the country at a point via ST_Covers, replacing
+ * the runtime Overpass `is_in` query used for border-crossing detection; their
+ * union also forms the coverage polygon.
+ *
+ * Mirrors the osm2pgsql flex output (provisioner/osm2pgsql/tier1.lua): the
+ * provisioner imports into a staging schema and atomically swaps it onto `osm`.
+ * This migration bootstraps the table so it exists before the first provisioning
+ * run and so functional tests have it to seed and query.
+ */
+final class Version20260615180000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add the osm.admin_boundaries reference table (country multipolygons) for local-first border-crossing reads';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE SCHEMA IF NOT EXISTS osm');
+
+        $this->addSql(<<<'SQL'
+            CREATE TABLE IF NOT EXISTS osm.admin_boundaries (
+                osm_id bigint NOT NULL,
+                name text,
+                admin_level int,
+                tags jsonb,
+                geom geometry(MultiPolygon, 4326) NOT NULL,
+                PRIMARY KEY (osm_id)
+            )
+            SQL);
+
+        $this->addSql('CREATE INDEX IF NOT EXISTS admin_boundaries_geom_idx ON osm.admin_boundaries USING gist (geom)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE IF EXISTS osm.admin_boundaries');
+    }
+}

--- a/api/src/MessageHandler/CheckBorderCrossingHandler.php
+++ b/api/src/MessageHandler/CheckBorderCrossingHandler.php
@@ -13,9 +13,8 @@ use App\Enum\ComputationName;
 use App\Mercure\MercureEventType;
 use App\Mercure\TripUpdatePublisherInterface;
 use App\Message\CheckBorderCrossing;
+use App\Osm\AdminBoundaryRepositoryInterface;
 use App\Repository\TripRequestRepositoryInterface;
-use App\Scanner\QueryBuilderInterface;
-use App\Scanner\ScannerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -24,10 +23,10 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * Detects international border crossings along the route.
  *
- * For each stage, queries the country at start and end points via Overpass `is_in`.
- * When consecutive points belong to different countries, a nudge is emitted
- * indicating the border crossing. Deduplicates: each unique country pair
- * (A→B) produces at most one nudge.
+ * For each stage, resolves the country at start and end points via a ST_Covers
+ * lookup against the local admin_level=2 boundaries (ADR-040). When consecutive
+ * points belong to different countries, a nudge is emitted indicating the border
+ * crossing. Deduplicates: each unique country pair (A→B) produces at most one nudge.
  */
 #[AsMessageHandler]
 final readonly class CheckBorderCrossingHandler extends AbstractTripMessageHandler
@@ -38,8 +37,7 @@ final readonly class CheckBorderCrossingHandler extends AbstractTripMessageHandl
         TripGenerationTrackerInterface $generationTracker,
         LoggerInterface $logger,
         private TripRequestRepositoryInterface $tripStateManager,
-        private ScannerInterface $scanner,
-        private QueryBuilderInterface $queryBuilder,
+        private AdminBoundaryRepositoryInterface $adminBoundaryRepository,
         private TranslatorInterface $translator,
         MessageBusInterface $messageBus,
     ) {
@@ -70,7 +68,7 @@ final readonly class CheckBorderCrossingHandler extends AbstractTripMessageHandl
                 return;
             }
 
-            // Resolve country for each checkpoint via Overpass is_in
+            // Resolve country for each checkpoint via ST_Covers against the local boundaries
             $countries = $this->resolveCountries($checkPoints, $locale);
 
             // Detect border crossings: when consecutive countries differ
@@ -154,7 +152,8 @@ final readonly class CheckBorderCrossingHandler extends AbstractTripMessageHandl
     }
 
     /**
-     * Resolves the country name for each coordinate via Overpass is_in queries.
+     * Resolves the country name for each coordinate via a ST_Covers lookup against
+     * the local admin_level=2 boundaries.
      *
      * @param list<Coordinate> $points
      *
@@ -162,52 +161,11 @@ final readonly class CheckBorderCrossingHandler extends AbstractTripMessageHandl
      */
     private function resolveCountries(array $points, string $locale): array
     {
-        $queries = [];
-        foreach ($points as $i => $point) {
-            $queries['point_'.$i] = $this->queryBuilder->buildCountryQuery($point);
-        }
-
-        $results = $this->scanner->queryBatch($queries);
-
         $countries = [];
-        foreach (array_keys($points) as $i) {
-            $result = $results['point_'.$i] ?? [];
-            $countries[] = $this->extractCountryName($result, $locale);
+        foreach ($points as $point) {
+            $countries[] = $this->adminBoundaryRepository->findCountryAt($point->lat, $point->lon, $locale);
         }
 
         return $countries;
-    }
-
-    /**
-     * Extracts the country name from an Overpass is_in result.
-     *
-     * Tries locale-specific name first (e.g. name:fr → "Belgique"),
-     * then falls back to name:en, then the generic name tag.
-     *
-     * @param array<string, mixed> $result
-     */
-    private function extractCountryName(array $result, string $locale): ?string
-    {
-        /** @var list<array{tags?: array<string, string>}> $elements */
-        $elements = \is_array($result['elements'] ?? null) ? $result['elements'] : [];
-
-        foreach ($elements as $element) {
-            $tags = $element['tags'] ?? [];
-
-            $localeKey = 'name:'.$locale;
-            if (isset($tags[$localeKey])) {
-                return $tags[$localeKey];
-            }
-
-            if (isset($tags['name:en'])) {
-                return $tags['name:en'];
-            }
-
-            if (isset($tags['name'])) {
-                return $tags['name'];
-            }
-        }
-
-        return null;
     }
 }

--- a/api/src/Osm/AdminBoundaryRepository.php
+++ b/api/src/Osm/AdminBoundaryRepository.php
@@ -10,6 +10,10 @@ use Doctrine\DBAL\Connection;
  * Resolves the country at a point from the local-first Tier-1 index (ADR-040):
  * a ST_Covers lookup against the admin_level=2 boundaries in osm.admin_boundaries,
  * replacing the runtime Overpass `is_in` query for border-crossing detection.
+ *
+ * When several boundaries cover the same point (overlapping polygons for a
+ * disputed territory, or a checkpoint exactly on a shared border), the tie is
+ * resolved deterministically by osm_id so the trip snapshot stays reproducible.
  */
 final readonly class AdminBoundaryRepository implements AdminBoundaryRepositoryInterface
 {
@@ -25,6 +29,7 @@ final readonly class AdminBoundaryRepository implements AdminBoundaryRepositoryI
                 FROM osm.admin_boundaries
                 WHERE admin_level = 2
                   AND ST_Covers(geom, ST_SetSRID(ST_MakePoint(:lon, :lat), 4326))
+                ORDER BY osm_id
                 LIMIT 1
                 SQL,
             [

--- a/api/src/Osm/AdminBoundaryRepository.php
+++ b/api/src/Osm/AdminBoundaryRepository.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Osm;
+
+use Doctrine\DBAL\Connection;
+
+/**
+ * Resolves the country at a point from the local-first Tier-1 index (ADR-040):
+ * a ST_Covers lookup against the admin_level=2 boundaries in osm.admin_boundaries,
+ * replacing the runtime Overpass `is_in` query for border-crossing detection.
+ */
+final readonly class AdminBoundaryRepository implements AdminBoundaryRepositoryInterface
+{
+    public function __construct(private Connection $connection)
+    {
+    }
+
+    public function findCountryAt(float $lat, float $lon, string $locale): ?string
+    {
+        $country = $this->connection->fetchOne(
+            <<<'SQL'
+                SELECT COALESCE(tags->>('name:' || :locale), tags->>'name:en', name)
+                FROM osm.admin_boundaries
+                WHERE admin_level = 2
+                  AND ST_Covers(geom, ST_SetSRID(ST_MakePoint(:lon, :lat), 4326))
+                LIMIT 1
+                SQL,
+            [
+                'locale' => $locale,
+                'lon' => $lon,
+                'lat' => $lat,
+            ],
+        );
+
+        return \is_string($country) && '' !== $country ? $country : null;
+    }
+}

--- a/api/src/Osm/AdminBoundaryRepositoryInterface.php
+++ b/api/src/Osm/AdminBoundaryRepositoryInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Osm;
+
+interface AdminBoundaryRepositoryInterface
+{
+    /**
+     * Resolves the country (admin_level=2 boundary) containing the given point
+     * via ST_Covers, returning its name in $locale (falling back to name:en, then
+     * the default name), or null when the point lies outside every stored country.
+     */
+    public function findCountryAt(float $lat, float $lon, string $locale): ?string;
+}

--- a/api/src/Scanner/OsmOverpassQueryBuilder.php
+++ b/api/src/Scanner/OsmOverpassQueryBuilder.php
@@ -132,15 +132,6 @@ final readonly class OsmOverpassQueryBuilder implements QueryBuilderInterface
         );
     }
 
-    public function buildCountryQuery(Coordinate $point): string
-    {
-        return \sprintf(
-            '[out:json][timeout:10];is_in(%F,%F)->.a;area.a["admin_level"="2"]["boundary"="administrative"];out tags 1;',
-            $point->lat,
-            $point->lon,
-        );
-    }
-
     /** @param list<Coordinate> $points */
     private function buildPolyline(array $points): string
     {

--- a/api/src/Scanner/QueryBuilderInterface.php
+++ b/api/src/Scanner/QueryBuilderInterface.php
@@ -66,12 +66,4 @@ interface QueryBuilderInterface
      * @param list<Coordinate> $decimatedPoints
      */
     public function buildHealthServiceQuery(array $decimatedPoints): string;
-
-    /**
-     * Queries the country (admin_level=2) for a given coordinate using Overpass is_in.
-     *
-     * Returns relations with admin_level=2 and boundary=administrative that contain the point,
-     * allowing border crossing detection by comparing countries at different route positions.
-     */
-    public function buildCountryQuery(Coordinate $point): string;
 }

--- a/api/tests/Integration/Osm/AdminBoundaryIndexReadTest.php
+++ b/api/tests/Integration/Osm/AdminBoundaryIndexReadTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Osm;
+
+use App\Osm\AdminBoundaryRepository;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * Integration coverage for the local-first admin-boundary read layer (ADR-040):
+ * seeds real PostGIS country multipolygons in osm.admin_boundaries and asserts the
+ * ST_Covers point-in-country resolution plus the localized-name fallback chain
+ * (name:<locale> → name:en → name) that replaces the Overpass is_in extraction.
+ */
+final class AdminBoundaryIndexReadTest extends KernelTestCase
+{
+    use ResetDatabase;
+
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get('doctrine.dbal.default_connection');
+        $this->connection = $connection;
+
+        $this->connection->executeStatement('TRUNCATE osm.admin_boundaries');
+
+        // Three disjoint country squares: France (all names equal), Belgium (a
+        // distinct name:fr), Luxembourg (only the plain name tag).
+        $this->connection->executeStatement(<<<'SQL'
+            INSERT INTO osm.admin_boundaries (osm_id, name, admin_level, tags, geom) VALUES
+              (1, 'France', 2, '{"name":"France","name:en":"France","name:fr":"France"}'::jsonb,
+                  ST_SetSRID(ST_GeomFromText('MULTIPOLYGON(((2 48, 3 48, 3 49, 2 49, 2 48)))'), 4326)),
+              (2, 'Belgium', 2, '{"name":"Belgium","name:en":"Belgium","name:fr":"Belgique"}'::jsonb,
+                  ST_SetSRID(ST_GeomFromText('MULTIPOLYGON(((4 50, 5 50, 5 51, 4 51, 4 50)))'), 4326)),
+              (3, 'Luxembourg', 2, '{"name":"Luxembourg"}'::jsonb,
+                  ST_SetSRID(ST_GeomFromText('MULTIPOLYGON(((6 49.5, 6.5 49.5, 6.5 50, 6 50, 6 49.5)))'), 4326))
+            SQL);
+    }
+
+    #[Test]
+    public function findCountryAtResolvesCountryContainingPoint(): void
+    {
+        $repository = new AdminBoundaryRepository($this->connection);
+
+        self::assertSame('France', $repository->findCountryAt(48.5, 2.5, 'en'));
+        self::assertSame('Belgium', $repository->findCountryAt(50.5, 4.5, 'en'));
+    }
+
+    #[Test]
+    public function findCountryAtPrefersLocalizedName(): void
+    {
+        // name:fr is preferred over name:en when present.
+        self::assertSame('Belgique', new AdminBoundaryRepository($this->connection)->findCountryAt(50.5, 4.5, 'fr'));
+    }
+
+    #[Test]
+    public function findCountryAtFallsBackToNameEnThenName(): void
+    {
+        $repository = new AdminBoundaryRepository($this->connection);
+
+        // No name:de → falls back to name:en.
+        self::assertSame('Belgium', $repository->findCountryAt(50.5, 4.5, 'de'));
+        // Only the plain name tag → falls back to it.
+        self::assertSame('Luxembourg', $repository->findCountryAt(49.7, 6.2, 'fr'));
+    }
+
+    #[Test]
+    public function findCountryAtReturnsNullOutsideAllBoundaries(): void
+    {
+        self::assertNull(new AdminBoundaryRepository($this->connection)->findCountryAt(0.0, 0.0, 'en'));
+    }
+}

--- a/api/tests/Integration/Osm/AdminBoundaryIndexReadTest.php
+++ b/api/tests/Integration/Osm/AdminBoundaryIndexReadTest.php
@@ -77,4 +77,21 @@ final class AdminBoundaryIndexReadTest extends KernelTestCase
     {
         self::assertNull(new AdminBoundaryRepository($this->connection)->findCountryAt(0.0, 0.0, 'en'));
     }
+
+    #[Test]
+    public function findCountryAtIsDeterministicWhenBoundariesOverlap(): void
+    {
+        // Two admin_level=2 polygons covering the exact same area (a disputed
+        // territory, or a point on a shared border where ST_Covers is true for
+        // both): the lower osm_id must win, stably across plan/vacuum changes.
+        $this->connection->executeStatement(<<<'SQL'
+            INSERT INTO osm.admin_boundaries (osm_id, name, admin_level, tags, geom) VALUES
+              (11, 'Beta', 2, '{"name":"Beta","name:en":"Beta"}'::jsonb,
+                  ST_SetSRID(ST_GeomFromText('MULTIPOLYGON(((10 10, 12 10, 12 12, 10 12, 10 10)))'), 4326)),
+              (10, 'Alpha', 2, '{"name":"Alpha","name:en":"Alpha"}'::jsonb,
+                  ST_SetSRID(ST_GeomFromText('MULTIPOLYGON(((10 10, 12 10, 12 12, 10 12, 10 10)))'), 4326))
+            SQL);
+
+        self::assertSame('Alpha', new AdminBoundaryRepository($this->connection)->findCountryAt(11.0, 11.0, 'en'));
+    }
 }

--- a/api/tests/Unit/MessageHandler/CheckBorderCrossingHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/CheckBorderCrossingHandlerTest.php
@@ -12,9 +12,8 @@ use App\Mercure\MercureEventType;
 use App\Mercure\TripUpdatePublisherInterface;
 use App\Message\CheckBorderCrossing;
 use App\MessageHandler\CheckBorderCrossingHandler;
+use App\Osm\AdminBoundaryRepositoryInterface;
 use App\Repository\TripRequestRepositoryInterface;
-use App\Scanner\QueryBuilderInterface;
-use App\Scanner\ScannerInterface;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
@@ -26,8 +25,7 @@ final class CheckBorderCrossingHandlerTest extends TestCase
     private function createHandler(
         TripRequestRepositoryInterface $tripStateManager,
         TripUpdatePublisherInterface $publisher,
-        ScannerInterface $scanner,
-        QueryBuilderInterface $queryBuilder,
+        AdminBoundaryRepositoryInterface $adminBoundaryRepository,
     ): CheckBorderCrossingHandler {
         $computationTracker = $this->createStub(ComputationTrackerInterface::class);
         $computationTracker->method('getProgress')->willReturn(['completed' => 0, 'failed' => 0, 'total' => 1]);
@@ -48,11 +46,29 @@ final class CheckBorderCrossingHandlerTest extends TestCase
             $generationTracker,
             new NullLogger(),
             $tripStateManager,
-            $scanner,
-            $queryBuilder,
+            $adminBoundaryRepository,
             $translator,
             $this->createStub(MessageBusInterface::class),
         );
+    }
+
+    /**
+     * Resolves the checkpoint countries in call order: start of stage 0, then the
+     * end of each stage. A null entry models a point outside every stored boundary.
+     *
+     * @param list<string|null> $countriesInOrder
+     */
+    private function adminBoundaryRepository(array $countriesInOrder): AdminBoundaryRepositoryInterface
+    {
+        $repository = $this->createStub(AdminBoundaryRepositoryInterface::class);
+        $index = 0;
+        $repository->method('findCountryAt')->willReturnCallback(
+            static function () use ($countriesInOrder, &$index): ?string {
+                return $countriesInOrder[$index++] ?? null;
+            },
+        );
+
+        return $repository;
     }
 
     /** @param list<Stage>|null $stages */
@@ -90,16 +106,8 @@ final class CheckBorderCrossingHandlerTest extends TestCase
 
         $tripStateManager = $this->createTripStateManager($stages);
 
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildCountryQuery')->willReturn('query');
-
-        // Overpass queryBatch returns: point_0 = France, point_1 = Belgium, point_2 = Belgium
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('queryBatch')->willReturn([
-            'point_0' => ['elements' => [['tags' => ['name:en' => 'France', 'admin_level' => '2']]]],
-            'point_1' => ['elements' => [['tags' => ['name:en' => 'Belgium', 'admin_level' => '2']]]],
-            'point_2' => ['elements' => [['tags' => ['name:en' => 'Belgium', 'admin_level' => '2']]]],
-        ]);
+        // Checkpoints: Lille (France), Courtrai (Belgium), Renaix (Belgium)
+        $adminBoundaryRepository = $this->adminBoundaryRepository(['France', 'Belgium', 'Belgium']);
 
         $publisher = $this->createMock(TripUpdatePublisherInterface::class);
         $publisher->expects($this->once())
@@ -118,7 +126,7 @@ final class CheckBorderCrossingHandlerTest extends TestCase
                 }),
             );
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder);
+        $handler = $this->createHandler($tripStateManager, $publisher, $adminBoundaryRepository);
         $handler(new CheckBorderCrossing('trip-1'));
     }
 
@@ -147,16 +155,8 @@ final class CheckBorderCrossingHandlerTest extends TestCase
 
         $tripStateManager = $this->createTripStateManager($stages);
 
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildCountryQuery')->willReturn('query');
-
-        // All points are in France
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('queryBatch')->willReturn([
-            'point_0' => ['elements' => [['tags' => ['name:en' => 'France', 'admin_level' => '2']]]],
-            'point_1' => ['elements' => [['tags' => ['name:en' => 'France', 'admin_level' => '2']]]],
-            'point_2' => ['elements' => [['tags' => ['name:en' => 'France', 'admin_level' => '2']]]],
-        ]);
+        // All checkpoints resolve to France
+        $adminBoundaryRepository = $this->adminBoundaryRepository(['France', 'France', 'France']);
 
         $publisher = $this->createMock(TripUpdatePublisherInterface::class);
         $publisher->expects($this->once())
@@ -167,7 +167,7 @@ final class CheckBorderCrossingHandlerTest extends TestCase
                 $this->callback(static fn (array $data): bool => [] === $data['alerts']),
             );
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder);
+        $handler = $this->createHandler($tripStateManager, $publisher, $adminBoundaryRepository);
         $handler(new CheckBorderCrossing('trip-1'));
     }
 
@@ -206,17 +206,8 @@ final class CheckBorderCrossingHandlerTest extends TestCase
 
         $tripStateManager = $this->createTripStateManager($stages);
 
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildCountryQuery')->willReturn('query');
-
-        // France → Belgium → France → Belgium
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('queryBatch')->willReturn([
-            'point_0' => ['elements' => [['tags' => ['name:en' => 'France']]]],
-            'point_1' => ['elements' => [['tags' => ['name:en' => 'Belgium']]]],
-            'point_2' => ['elements' => [['tags' => ['name:en' => 'France']]]],
-            'point_3' => ['elements' => [['tags' => ['name:en' => 'Belgium']]]],
-        ]);
+        // Checkpoints: France → Belgium → France → Belgium
+        $adminBoundaryRepository = $this->adminBoundaryRepository(['France', 'Belgium', 'France', 'Belgium']);
 
         $publisher = $this->createMock(TripUpdatePublisherInterface::class);
         $publisher->expects($this->once())
@@ -234,7 +225,7 @@ final class CheckBorderCrossingHandlerTest extends TestCase
                 }),
             );
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder);
+        $handler = $this->createHandler($tripStateManager, $publisher, $adminBoundaryRepository);
         $handler(new CheckBorderCrossing('trip-1'));
     }
 
@@ -246,15 +237,14 @@ final class CheckBorderCrossingHandlerTest extends TestCase
         $publisher = $this->createMock(TripUpdatePublisherInterface::class);
         $publisher->expects($this->never())->method('publish');
 
-        $scanner = $this->createStub(ScannerInterface::class);
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
+        $adminBoundaryRepository = $this->createStub(AdminBoundaryRepositoryInterface::class);
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder);
+        $handler = $this->createHandler($tripStateManager, $publisher, $adminBoundaryRepository);
         $handler(new CheckBorderCrossing('trip-1'));
     }
 
     #[Test]
-    public function nullCountryFromOverpassIsIgnored(): void
+    public function nullCountryFromBoundaryLookupIsIgnored(): void
     {
         $stages = [
             new Stage(
@@ -269,15 +259,8 @@ final class CheckBorderCrossingHandlerTest extends TestCase
 
         $tripStateManager = $this->createTripStateManager($stages);
 
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildCountryQuery')->willReturn('query');
-
-        // One point resolves to France, the other has no country data
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('queryBatch')->willReturn([
-            'point_0' => ['elements' => [['tags' => ['name:en' => 'France']]]],
-            'point_1' => ['elements' => []],
-        ]);
+        // One point resolves to France, the other lies outside every stored boundary
+        $adminBoundaryRepository = $this->adminBoundaryRepository(['France', null]);
 
         $publisher = $this->createMock(TripUpdatePublisherInterface::class);
         $publisher->expects($this->once())
@@ -288,7 +271,7 @@ final class CheckBorderCrossingHandlerTest extends TestCase
                 $this->callback(static fn (array $data): bool => [] === $data['alerts']),
             );
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder);
+        $handler = $this->createHandler($tripStateManager, $publisher, $adminBoundaryRepository);
         $handler(new CheckBorderCrossing('trip-1'));
     }
 
@@ -308,14 +291,7 @@ final class CheckBorderCrossingHandlerTest extends TestCase
 
         $tripStateManager = $this->createTripStateManager($stages);
 
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildCountryQuery')->willReturn('query');
-
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('queryBatch')->willReturn([
-            'point_0' => ['elements' => [['tags' => ['name:en' => 'France']]]],
-            'point_1' => ['elements' => [['tags' => ['name:en' => 'Belgium']]]],
-        ]);
+        $adminBoundaryRepository = $this->adminBoundaryRepository(['France', 'Belgium']);
 
         $publisher = $this->createMock(TripUpdatePublisherInterface::class);
         $publisher->expects($this->once())
@@ -336,88 +312,7 @@ final class CheckBorderCrossingHandlerTest extends TestCase
                 }),
             );
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder);
-        $handler(new CheckBorderCrossing('trip-1'));
-    }
-
-    #[Test]
-    public function fallsBackToNameTagWhenNameEnNotAvailable(): void
-    {
-        $stages = [
-            new Stage(
-                tripId: 'trip-1',
-                dayNumber: 1,
-                distance: 80.0,
-                elevation: 200.0,
-                startPoint: new Coordinate(50.6292, 3.0573),
-                endPoint: new Coordinate(50.8279, 3.2646),
-            ),
-        ];
-
-        $tripStateManager = $this->createTripStateManager($stages);
-
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildCountryQuery')->willReturn('query');
-
-        // name:en missing, falls back to name tag
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('queryBatch')->willReturn([
-            'point_0' => ['elements' => [['tags' => ['name' => 'France']]]],
-            'point_1' => ['elements' => [['tags' => ['name' => 'Belgique / België']]]],
-        ]);
-
-        $publisher = $this->createMock(TripUpdatePublisherInterface::class);
-        $publisher->expects($this->once())
-            ->method('publish')
-            ->with(
-                'trip-1',
-                MercureEventType::BORDER_CROSSING_ALERTS,
-                $this->callback(static fn (array $data): bool => 1 === \count($data['alerts'])
-                    && str_contains((string) $data['alerts'][0]['message'], 'Belgique')),
-            );
-
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder);
-        $handler(new CheckBorderCrossing('trip-1'));
-    }
-
-    #[Test]
-    public function localeAwareCountryNameUsesLocalizedName(): void
-    {
-        $stages = [
-            new Stage(
-                tripId: 'trip-1',
-                dayNumber: 1,
-                distance: 80.0,
-                elevation: 200.0,
-                startPoint: new Coordinate(50.6292, 3.0573),
-                endPoint: new Coordinate(50.8279, 3.2646),
-            ),
-        ];
-
-        // French locale: should prefer name:fr over name:en
-        $tripStateManager = $this->createTripStateManager($stages, 'fr');
-
-        $queryBuilder = $this->createStub(QueryBuilderInterface::class);
-        $queryBuilder->method('buildCountryQuery')->willReturn('query');
-
-        // Both name:fr and name:en available — should pick name:fr
-        $scanner = $this->createStub(ScannerInterface::class);
-        $scanner->method('queryBatch')->willReturn([
-            'point_0' => ['elements' => [['tags' => ['name:fr' => 'France', 'name:en' => 'France']]]],
-            'point_1' => ['elements' => [['tags' => ['name:fr' => 'Belgique', 'name:en' => 'Belgium']]]],
-        ]);
-
-        $publisher = $this->createMock(TripUpdatePublisherInterface::class);
-        $publisher->expects($this->once())
-            ->method('publish')
-            ->with(
-                'trip-1',
-                MercureEventType::BORDER_CROSSING_ALERTS,
-                $this->callback(static fn (array $data): bool => 1 === \count($data['alerts'])
-                    && str_contains((string) $data['alerts'][0]['message'], 'Belgique')),
-            );
-
-        $handler = $this->createHandler($tripStateManager, $publisher, $scanner, $queryBuilder);
+        $handler = $this->createHandler($tripStateManager, $publisher, $adminBoundaryRepository);
         $handler(new CheckBorderCrossing('trip-1'));
     }
 }

--- a/provisioner/osm2pgsql/tier1.lua
+++ b/provisioner/osm2pgsql/tier1.lua
@@ -5,8 +5,8 @@
 -- the live `osm` schema atomically. The API reads these tables via ST_DWithin
 -- corridor queries, replacing the runtime Overpass dependency.
 --
--- Scope of this style: pois, accommodations, water_points, bike_shops, health_services, railway_stations, charging_stations, cultural_pois, ways. The
--- admin_boundaries (coverage polygon) and cycle_routes tables land later.
+-- Scope of this style: pois, accommodations, water_points, bike_shops, health_services, railway_stations, charging_stations, cultural_pois, ways, admin_boundaries. The
+-- cycle_routes table lands later.
 
 -- MUST match PostgisImporter::STAGING_SCHEMA: osm2pgsql writes the output tables
 -- here, and the importer creates/swaps this exact schema onto the live `osm`.
@@ -195,6 +195,24 @@ local ways = osm2pgsql.define_table({
     },
 })
 
+-- Country boundaries (admin_level=2), stored as multipolygons. The API resolves
+-- the country at a point via ST_Covers, replacing the runtime Overpass is_in
+-- query; their union also forms the coverage polygon.
+local admin_boundaries = osm2pgsql.define_table({
+    name = 'admin_boundaries',
+    schema = SCHEMA,
+    ids = { type = 'relation', id_column = 'osm_id' },
+    columns = {
+        { column = 'name', type = 'text' },
+        { column = 'admin_level', type = 'int' },
+        { column = 'tags', type = 'jsonb' },
+        { column = 'geom', type = 'multipolygon', projection = SRID, not_null = true },
+    },
+    indexes = {
+        { column = 'geom', method = 'gist' },
+    },
+})
+
 local function poi_category(tags)
     if tags.amenity and POI_AMENITY[tags.amenity] then return tags.amenity end
     if tags.shop and POI_SHOP[tags.shop] then return tags.shop end
@@ -261,6 +279,11 @@ end
 -- True for the highway ways imported into the ways table (linestrings).
 local function way_highway(tags)
     return tags.highway ~= nil and WAY_HIGHWAY[tags.highway] == true
+end
+
+-- True for country-level administrative boundary relations.
+local function is_country_boundary(tags)
+    return tags.boundary == 'administrative' and tags.admin_level == '2'
 end
 
 local function is_relevant(tags)
@@ -410,4 +433,20 @@ function osm2pgsql.process_way(object)
     local geom = way_centroid(object)
     if geom == nil then return end
     insert_features(object.tags, geom)
+end
+
+function osm2pgsql.process_relation(object)
+    if not is_country_boundary(object.tags) then return end
+
+    -- as_multipolygon() builds the area from the boundary's member ways; a
+    -- broken/incomplete relation yields nil and is skipped.
+    local ok, geom = pcall(function() return object:as_multipolygon() end)
+    if not ok or geom == nil then return end
+
+    admin_boundaries:insert({
+        name = object.tags.name,
+        admin_level = to_int(object.tags.admin_level),
+        tags = object.tags,
+        geom = geom,
+    })
 end

--- a/provisioner/src/PostgisImporter.php
+++ b/provisioner/src/PostgisImporter.php
@@ -54,6 +54,7 @@ final readonly class PostgisImporter
         'nwr/man_made=water_tap',
         'nwr/natural=spring',
         'w/highway=primary,secondary,tertiary,unclassified,residential,living_street,service,track,path,cycleway,footway,bridleway',
+        'r/admin_level=2',
     ];
 
     /**

--- a/provisioner/tests/PostgisImporterTest.php
+++ b/provisioner/tests/PostgisImporterTest.php
@@ -63,6 +63,8 @@ final class PostgisImporterTest extends TestCase
         self::assertStringContainsString('attraction,museum', $joined);
         self::assertStringContainsString('farm,bicycle', $joined);
         self::assertStringContainsString('w/highway=', $joined);
+        // Country boundaries (relations) for the admin_boundaries table.
+        self::assertContains('r/admin_level=2', $this->captured[0]);
     }
 
     #[Test]


### PR DESCRIPTION
## Contexte

Cutover **border crossing → PostGIS** (ADR-040, local-first Tier-1). C'est le **dernier consommateur de la dépendance Overpass runtime** pour les données OSM : la détection de franchissement de frontière interrogeait Overpass `is_in` à chaque checkpoint pour résoudre le pays. Désormais elle lit l'index local.

## Changements

**Provisioner**
- `tier1.lua` : nouvelle table `admin_boundaries` + `process_relation` qui importe les polygones pays (`admin_level=2`, `boundary=administrative`) via `object:as_multipolygon()`.
- `PostgisImporter` : le `osmium tags-filter` garde `r/admin_level=2` (les ways/nœuds membres sont conservés par défaut → géométrie complète pour reconstruire la frontière).

**API**
- Migration `osm.admin_boundaries (osm_id, name, admin_level, tags, geom geometry(MultiPolygon,4326))` + index GIST. Bootstrap la table avant le 1er provisioning et pour les tests.
- `AdminBoundaryRepository::findCountryAt(lat, lon, locale)` : `ST_Covers` point-dans-pays + résolution de nom localisée `COALESCE(name:<locale>, name:en, name)`, remplaçant l'extraction de tags Overpass.
- `CheckBorderCrossingHandler` injecte le repository (drop `ScannerInterface` + `QueryBuilderInterface`). La logique de détection/dédup des crossings est inchangée.
- `buildCountryQuery` (orphelin) retiré de `OsmOverpassQueryBuilder` + `QueryBuilderInterface`.

**Tests**
- Test unitaire du handler réécrit sur un mock du repository (logique de crossing conservée).
- Les cas de résolution de nom (préférence locale, fallback `name:en`→`name`) migrent vers un **test d'intégration PostGIS réel** (`AdminBoundaryIndexReadTest`) qui seed 3 polygones pays.
- `PostgisImporterTest` : assertion `r/admin_level=2` dans le filtre.

## Vérification locale

- `php -l` OK sur tous les fichiers ; `luac -p tier1.lua` OK
- PHP-CS-Fixer : 0/8 (api) + 0/2 (provisioner)
- SQL validé contre PostGIS réel (BEGIN/ROLLBACK) — les 6 cas `ST_Covers`/COALESCE matchent le test d'intégration :

  | point | locale | pays |
  |---|---|---|
  | France | en | France |
  | Belgium | en | Belgium |
  | Belgium | fr | Belgique |
  | Belgium | de | Belgium (fallback `name:en`) |
  | Luxembourg | fr | Luxembourg (fallback `name`) |
  | hors zone | en | _(null)_ |

PHPStan L9 / Rector / PHPUnit : délégués à la CI (vendor absent du worktree).

## Note

`ScanAllOsmData` (umbrella) et les classes Overpass restantes (`OsmScanner`, `OsmOverpassQueryBuilder`, …) seront retirés dans la PR de **nettoyage final**, une fois aussi le cutover DataTourisme fait.

<!-- claude-review-start -->
## Claude Review

Clean cutover with all previous findings addressed. The second commit adds `ORDER BY osm_id` to `AdminBoundaryRepository` for deterministic country resolution on overlapping boundaries and backs it with a new `findCountryAtIsDeterministicWhenBoundariesOverlap` integration test. Architecture, security, and test coverage are solid throughout.

**Resolved 1 previously open thread.** (LIMIT 1 non-determinism — fixed with `ORDER BY osm_id`)

**Review checklist**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date (ADR-040 exists)
- [x] Dependent tickets accounted for

**Findings:** 0

Reviewed commit: `6b91ff4b87dc813d4fa13d2c09767d66c9fe95a4`

No inline comments.
<!-- claude-review-end -->