### PR TITLE
feat(datatourisme): import the flux into the local-first tourism schema (ADR-040)

### DIFF
--- a/.docker/provisioner/Dockerfile
+++ b/.docker/provisioner/Dockerfile
@@ -29,12 +29,13 @@ RUN apt-get update \
     	postgresql-client \
     && rm -rf /var/lib/apt/lists/*
 
-# xdebug enables `make coverage`/`coverage-ci` on the provisioner leg (same driver as
-# the php dev image). Off by default so normal `make test-php` is unaffected; the
-# coverage targets set XDEBUG_MODE=coverage per run.
+# zip drives the DataTourisme flux import (ext-zip → ZipArchive). xdebug enables
+# `make coverage`/`coverage-ci` on the provisioner leg (same driver as the php dev
+# image), off by default so normal `make test-php` is unaffected; the coverage
+# targets set XDEBUG_MODE=coverage per run.
 ADD --checksum=sha256:ca45e43f4299997f3cc78459eb7cc29c125281db8779f99209dc3fe3298fd117 \
     --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/download/2.11.1/install-php-extensions /usr/local/bin/
-RUN install-php-extensions xdebug
+RUN install-php-extensions xdebug zip
 ENV XDEBUG_MODE=off
 
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
@@ -54,6 +55,11 @@ RUN apt-get update \
     	osm2pgsql \
     	postgresql-client \
     && rm -rf /var/lib/apt/lists/*
+
+# zip drives the DataTourisme flux import (ext-zip → ZipArchive).
+ADD --checksum=sha256:ca45e43f4299997f3cc78459eb7cc29c125281db8779f99209dc3fe3298fd117 \
+    --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/download/2.11.1/install-php-extensions /usr/local/bin/
+RUN install-php-extensions zip
 
 WORKDIR /app
 COPY --from=deps /app/ ./

--- a/api/migrations/Version20260616120000.php
+++ b/api/migrations/Version20260616120000.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Adds the `tourism` reference schema (ADR-040): DataTourisme places imported by
+ * the provisioner into PostGIS, read by the API instead of the runtime
+ * DataTourisme REST API. DataTourisme is FR-only and lives in its OWN schema
+ * (not `osm`) so the OSM osm2pgsql swap — which does DROP SCHEMA osm CASCADE —
+ * never destroys it; the DataTourisme importer runs its own atomic swap.
+ *
+ * Three heads matching the existing consumers: cultural POIs
+ * (CulturalPoiSourceRegistry), accommodations (AccommodationSourceRegistry) and
+ * dated events (ScanEventsHandler). The primary key is the DataTourisme `@id`
+ * URI so daily refreshes upsert in place. This migration bootstraps the tables
+ * so they exist before the first provisioning run and for the functional tests.
+ */
+final class Version20260616120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add the tourism schema (cultural_pois, accommodations, events) for local-first DataTourisme reads';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE SCHEMA IF NOT EXISTS tourism');
+
+        $this->addSql(<<<'SQL'
+            CREATE TABLE IF NOT EXISTS tourism.cultural_pois (
+                id text NOT NULL,
+                name text,
+                category text NOT NULL,
+                opening_hours text,
+                description text,
+                wikidata text,
+                tags jsonb,
+                geom geometry(Point, 4326) NOT NULL,
+                PRIMARY KEY (id)
+            )
+            SQL);
+        $this->addSql('CREATE INDEX IF NOT EXISTS cultural_pois_geom_idx ON tourism.cultural_pois USING gist (geom)');
+
+        $this->addSql(<<<'SQL'
+            CREATE TABLE IF NOT EXISTS tourism.accommodations (
+                id text NOT NULL,
+                name text,
+                category text NOT NULL,
+                capacity int,
+                price numeric(10, 2),
+                description text,
+                tags jsonb,
+                geom geometry(Point, 4326) NOT NULL,
+                PRIMARY KEY (id)
+            )
+            SQL);
+        $this->addSql('CREATE INDEX IF NOT EXISTS accommodations_geom_idx ON tourism.accommodations USING gist (geom)');
+
+        $this->addSql(<<<'SQL'
+            CREATE TABLE IF NOT EXISTS tourism.events (
+                id text NOT NULL,
+                name text,
+                category text NOT NULL,
+                start_date date,
+                end_date date,
+                url text,
+                description text,
+                price_min numeric(10, 2),
+                tags jsonb,
+                geom geometry(Point, 4326) NOT NULL,
+                PRIMARY KEY (id)
+            )
+            SQL);
+        $this->addSql('CREATE INDEX IF NOT EXISTS events_geom_idx ON tourism.events USING gist (geom)');
+        $this->addSql('CREATE INDEX IF NOT EXISTS events_dates_idx ON tourism.events (start_date, end_date)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP SCHEMA IF EXISTS tourism CASCADE');
+    }
+}

--- a/compose.yaml
+++ b/compose.yaml
@@ -471,6 +471,10 @@ services:
       PGUSER: "${DATABASE_USERNAME:-app}"
       PGPASSWORD: "${DATABASE_PASSWORD:-!ChangeMe!}"
       PGDATABASE: "${DATABASE_NAME:-bike_trip_planner}"
+      # DataTourisme flux credentials, consumed when the provisioner runs with
+      # --with-datatourisme to download the flux ZIP into the tourism schema.
+      DATATOURISME_FLUX_ID: "${DATATOURISME_FLUX_ID:-}"
+      DATATOURISME_APP_KEY: "${DATATOURISME_APP_KEY:-}"
     # One-shot OSM extract + PostGIS import; osm2pgsql needs more headroom than
     # the osmium merge (in-RAM node cache bounded via --cache). See ADR-040.
     deploy:

--- a/provisioner/src/DataTourismeImporter.php
+++ b/provisioner/src/DataTourismeImporter.php
@@ -245,6 +245,13 @@ final readonly class DataTourismeImporter
                 \sprintf('CREATE INDEX ON %s.%s USING gist (geom);', self::STAGING_SCHEMA, $table),
             ], \sprintf('psql index %s', $table));
         }
+
+        // Date-range index for the events read path (matches Version20260616120000);
+        // recreated in staging so the atomic swap doesn't drop it.
+        $this->runProcess([
+            'psql', '-v', 'ON_ERROR_STOP=1', '-c',
+            \sprintf('CREATE INDEX ON %s.events (start_date, end_date);', self::STAGING_SCHEMA),
+        ], 'psql index events dates');
     }
 
     /**
@@ -270,8 +277,8 @@ final readonly class DataTourismeImporter
 
         try {
             $process->run();
-        } catch (ProcessTimedOutException $e) {
-            throw new ImportFailedException(\sprintf('%s timed out after %.1fs', $label, $this->timeoutSeconds), 0, $e);
+        } catch (ProcessTimedOutException $processTimedOutException) {
+            throw new ImportFailedException(\sprintf('%s timed out after %.1fs', $label, $this->timeoutSeconds), 0, $processTimedOutException);
         }
 
         if (!$process->isSuccessful()) {

--- a/provisioner/src/DataTourismeImporter.php
+++ b/provisioner/src/DataTourismeImporter.php
@@ -1,0 +1,279 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Provisioner;
+
+use Provisioner\Exception\ImportFailedException;
+use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Component\Process\Exception\ProcessTimedOutException;
+use Symfony\Component\Process\Process;
+use Symfony\Contracts\HttpClient\Exception\ExceptionInterface as HttpClientExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Imports the DataTourisme flux into the local-first `tourism` PostGIS schema
+ * (ADR-040), replacing the runtime DataTourisme REST API.
+ *
+ * Flow, behind an atomic schema swap (same shape as {@see PostgisImporter}):
+ * download the flux ZIP, stream its `objects/` JSON-LD files one by one,
+ * {@see DataTourismeMapper map} each to a cultural-POI / accommodation / event
+ * row, write the rows to per-table COPY files (constant memory regardless of the
+ * ~390k objects), bulk-load them into a fresh `tourism_staging` schema via psql
+ * COPY, then rename the staging schema onto the live `tourism` in one
+ * transaction. A failed import leaves the previous dataset intact.
+ *
+ * Rows are emitted in PostgreSQL text COPY format (`\N` = NULL, tab-separated,
+ * backslash-escaped); the geometry column receives EWKT (`SRID=4326;POINT(lon
+ * lat)`) which PostGIS parses on input. The DB connection comes from the libpq
+ * environment (PG*), inherited by psql.
+ */
+final readonly class DataTourismeImporter
+{
+    private const string STAGING_SCHEMA = 'tourism_staging';
+
+    private const string LIVE_SCHEMA = 'tourism';
+
+    /**
+     * Target tables and their COPY column order. `geom` always comes last and is
+     * fed EWKT. Must match Version20260616120000 (the live-schema bootstrap).
+     *
+     * @var array<string, list<string>>
+     */
+    private const array TABLE_COLUMNS = [
+        'cultural_pois' => ['id', 'name', 'category', 'opening_hours', 'description', 'wikidata', 'tags', 'geom'],
+        'accommodations' => ['id', 'name', 'category', 'capacity', 'price', 'description', 'tags', 'geom'],
+        'events' => ['id', 'name', 'category', 'start_date', 'end_date', 'url', 'description', 'price_min', 'tags', 'geom'],
+    ];
+
+    private const array STAGING_DDL = [
+        'cultural_pois' => 'id text, name text, category text NOT NULL, opening_hours text, description text, wikidata text, tags jsonb, geom geometry(Point, 4326) NOT NULL',
+        'accommodations' => 'id text, name text, category text NOT NULL, capacity int, price numeric(10, 2), description text, tags jsonb, geom geometry(Point, 4326) NOT NULL',
+        'events' => 'id text, name text, category text NOT NULL, start_date date, end_date date, url text, description text, price_min numeric(10, 2), tags jsonb, geom geometry(Point, 4326) NOT NULL',
+    ];
+
+    private HttpClientInterface $httpClient;
+
+    /**
+     * @var \Closure(list<string>): Process
+     */
+    private \Closure $processFactory;
+
+    /**
+     * @param (\Closure(list<string>): Process)|null $processFactory factory used to build the psql processes; defaults to a real {@see Process}
+     */
+    public function __construct(
+        private string $fluxUrl,
+        private DataTourismeMapper $mapper = new DataTourismeMapper(),
+        ?HttpClientInterface $httpClient = null,
+        ?\Closure $processFactory = null,
+        private float $timeoutSeconds = 1800.0,
+    ) {
+        $this->httpClient = $httpClient ?? HttpClient::create(['max_redirects' => 2]);
+        $this->processFactory = $processFactory ?? static fn (array $command): Process => new Process($command);
+    }
+
+    /**
+     * @throws ImportFailedException
+     */
+    public function run(string $workDir): void
+    {
+        $zipPath = $workDir.'/datatourisme-flux.zip';
+        $this->download($zipPath);
+        $copyFiles = $this->extract($zipPath, $workDir);
+        $this->load($copyFiles);
+        $this->swap();
+    }
+
+    /**
+     * @throws ImportFailedException
+     */
+    public function download(string $zipPath): void
+    {
+        $handle = fopen($zipPath, 'w');
+        if (false === $handle) {
+            throw new ImportFailedException(\sprintf('Cannot open "%s" for writing', $zipPath));
+        }
+
+        try {
+            $response = $this->httpClient->request('GET', $this->fluxUrl);
+            $status = $response->getStatusCode();
+            if ($status < 200 || $status >= 300) {
+                throw new ImportFailedException(\sprintf('DataTourisme flux download failed with HTTP %d', $status));
+            }
+
+            foreach ($this->httpClient->stream($response) as $chunk) {
+                if (false === fwrite($handle, $chunk->getContent())) {
+                    throw new ImportFailedException(\sprintf('Failed to write the flux to "%s"', $zipPath));
+                }
+            }
+        } catch (HttpClientExceptionInterface $e) {
+            fclose($handle);
+
+            throw new ImportFailedException(\sprintf('DataTourisme flux download failed: %s', $e->getMessage()), 0, $e);
+        } finally {
+            if (\is_resource($handle)) {
+                fclose($handle);
+            }
+        }
+    }
+
+    /**
+     * Streams the flux ZIP and writes one text-format COPY file per table.
+     *
+     * @return array<string, string> table name => COPY file path
+     *
+     * @throws ImportFailedException
+     */
+    private function extract(string $zipPath, string $workDir): array
+    {
+        $zip = new \ZipArchive();
+        if (true !== $zip->open($zipPath)) {
+            throw new ImportFailedException(\sprintf('Cannot open the flux ZIP "%s"', $zipPath));
+        }
+
+        $handles = [];
+        $files = [];
+        foreach (array_keys(self::TABLE_COLUMNS) as $table) {
+            $path = \sprintf('%s/tourism-%s.copy', $workDir, $table);
+            $handle = fopen($path, 'w');
+            if (false === $handle) {
+                throw new ImportFailedException(\sprintf('Cannot open COPY file "%s"', $path));
+            }
+
+            $handles[$table] = $handle;
+            $files[$table] = $path;
+        }
+
+        $heads = ['cultural' => 'cultural_pois', 'accommodation' => 'accommodations', 'event' => 'events'];
+
+        for ($i = 0, $n = $zip->numFiles; $i < $n; ++$i) {
+            $name = $zip->getNameIndex($i);
+            if (false === $name || !str_starts_with($name, 'objects/') || !str_ends_with($name, '.json')) {
+                continue;
+            }
+
+            $stream = $zip->getStream($name);
+            if (false === $stream) {
+                continue;
+            }
+
+            $contents = stream_get_contents($stream);
+            fclose($stream);
+            if (false === $contents) {
+                continue;
+            }
+
+            $object = json_decode($contents, true);
+            if (!\is_array($object)) {
+                continue;
+            }
+
+            /** @var array<string, mixed> $object */
+            $row = $this->mapper->map($object);
+            if (null === $row) {
+                continue;
+            }
+
+            $table = $heads[$row['head']];
+            fwrite($handles[$table], $this->copyLine($table, $row));
+        }
+
+        foreach ($handles as $handle) {
+            fclose($handle);
+        }
+
+        $zip->close();
+
+        return $files;
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function copyLine(string $table, array $row): string
+    {
+        $geom = \sprintf('SRID=4326;POINT(%.7F %.7F)', $row['lon'], $row['lat']);
+        $tags = json_encode(['type' => $row['type']], \JSON_UNESCAPED_UNICODE | \JSON_UNESCAPED_SLASHES);
+
+        $values = match ($table) {
+            'cultural_pois' => [$row['id'], $row['name'], $row['category'], $row['openingHours'], $row['description'], $row['wikidata'], $tags, $geom],
+            'accommodations' => [$row['id'], $row['name'], $row['category'], $row['capacity'], $row['price'], $row['description'], $tags, $geom],
+            'events' => [$row['id'], $row['name'], $row['category'], $row['startDate'], $row['endDate'], null, $row['description'], $row['price'], $tags, $geom],
+            default => [],
+        };
+
+        return implode("\t", array_map($this->copyValue(...), $values))."\n";
+    }
+
+    private function copyValue(mixed $value): string
+    {
+        if (null === $value || false === $value) {
+            return '\N';
+        }
+
+        $string = \is_bool($value) ? '1' : (string) $value;
+
+        return str_replace(['\\', "\t", "\n", "\r"], ['\\\\', '\\t', '\\n', '\\r'], $string);
+    }
+
+    /**
+     * @param array<string, string> $copyFiles
+     *
+     * @throws ImportFailedException
+     */
+    private function load(array $copyFiles): void
+    {
+        $ddl = \sprintf('DROP SCHEMA IF EXISTS %1$s CASCADE; CREATE SCHEMA %1$s;', self::STAGING_SCHEMA);
+        foreach (self::STAGING_DDL as $table => $columns) {
+            $ddl .= \sprintf(' CREATE TABLE %s.%s (%s);', self::STAGING_SCHEMA, $table, $columns);
+        }
+
+        $this->runProcess(['psql', '-v', 'ON_ERROR_STOP=1', '-c', $ddl], 'psql create tourism staging');
+
+        foreach ($copyFiles as $table => $path) {
+            $columns = implode(', ', self::TABLE_COLUMNS[$table]);
+            $copy = \sprintf("\\copy %s.%s (%s) FROM '%s'", self::STAGING_SCHEMA, $table, $columns, $path);
+            $this->runProcess(['psql', '-v', 'ON_ERROR_STOP=1', '-c', $copy], \sprintf('psql copy %s', $table));
+        }
+
+        foreach (array_keys(self::TABLE_COLUMNS) as $table) {
+            $this->runProcess([
+                'psql', '-v', 'ON_ERROR_STOP=1', '-c',
+                \sprintf('CREATE INDEX ON %s.%s USING gist (geom);', self::STAGING_SCHEMA, $table),
+            ], \sprintf('psql index %s', $table));
+        }
+    }
+
+    /**
+     * @throws ImportFailedException
+     */
+    private function swap(): void
+    {
+        $this->runProcess([
+            'psql', '-v', 'ON_ERROR_STOP=1', '--single-transaction', '-c',
+            \sprintf('DROP SCHEMA IF EXISTS %1$s CASCADE; ALTER SCHEMA %2$s RENAME TO %1$s;', self::LIVE_SCHEMA, self::STAGING_SCHEMA),
+        ], 'psql tourism swap');
+    }
+
+    /**
+     * @param list<string> $command
+     *
+     * @throws ImportFailedException
+     */
+    private function runProcess(array $command, string $label): void
+    {
+        $process = ($this->processFactory)($command);
+        $process->setTimeout($this->timeoutSeconds);
+
+        try {
+            $process->run();
+        } catch (ProcessTimedOutException $e) {
+            throw new ImportFailedException(\sprintf('%s timed out after %.1fs', $label, $this->timeoutSeconds), 0, $e);
+        }
+
+        if (!$process->isSuccessful()) {
+            throw new ImportFailedException(\sprintf('%s failed (exit %s): %s', $label, (string) $process->getExitCode(), $process->getErrorOutput()));
+        }
+    }
+}

--- a/provisioner/src/DataTourismeImporter.php
+++ b/provisioner/src/DataTourismeImporter.php
@@ -49,9 +49,9 @@ final readonly class DataTourismeImporter
     ];
 
     private const array STAGING_DDL = [
-        'cultural_pois' => 'id text, name text, category text NOT NULL, opening_hours text, description text, wikidata text, tags jsonb, geom geometry(Point, 4326) NOT NULL',
-        'accommodations' => 'id text, name text, category text NOT NULL, capacity int, price numeric(10, 2), description text, tags jsonb, geom geometry(Point, 4326) NOT NULL',
-        'events' => 'id text, name text, category text NOT NULL, start_date date, end_date date, url text, description text, price_min numeric(10, 2), tags jsonb, geom geometry(Point, 4326) NOT NULL',
+        'cultural_pois' => 'id text NOT NULL PRIMARY KEY, name text, category text NOT NULL, opening_hours text, description text, wikidata text, tags jsonb, geom geometry(Point, 4326) NOT NULL',
+        'accommodations' => 'id text NOT NULL PRIMARY KEY, name text, category text NOT NULL, capacity int, price numeric(10, 2), description text, tags jsonb, geom geometry(Point, 4326) NOT NULL',
+        'events' => 'id text NOT NULL PRIMARY KEY, name text, category text NOT NULL, start_date date, end_date date, url text, description text, price_min numeric(10, 2), tags jsonb, geom geometry(Point, 4326) NOT NULL',
     ];
 
     private HttpClientInterface $httpClient;
@@ -71,7 +71,7 @@ final readonly class DataTourismeImporter
         ?\Closure $processFactory = null,
         private float $timeoutSeconds = 1800.0,
     ) {
-        $this->httpClient = $httpClient ?? HttpClient::create(['max_redirects' => 2]);
+        $this->httpClient = $httpClient ?? HttpClient::create(['max_redirects' => 2, 'timeout' => $this->timeoutSeconds]);
         $this->processFactory = $processFactory ?? static fn (array $command): Process => new Process($command);
     }
 
@@ -109,10 +109,10 @@ final readonly class DataTourismeImporter
                     throw new ImportFailedException(\sprintf('Failed to write the flux to "%s"', $zipPath));
                 }
             }
-        } catch (HttpClientExceptionInterface $e) {
+        } catch (HttpClientExceptionInterface $httpClientException) {
             fclose($handle);
 
-            throw new ImportFailedException(\sprintf('DataTourisme flux download failed: %s', $e->getMessage()), 0, $e);
+            throw new ImportFailedException(\sprintf('DataTourisme flux download failed: %s', $httpClientException->getMessage()), 0, $httpClientException);
         } finally {
             if (\is_resource($handle)) {
                 fclose($handle);
@@ -196,7 +196,7 @@ final readonly class DataTourismeImporter
     private function copyLine(string $table, array $row): string
     {
         $geom = \sprintf('SRID=4326;POINT(%.7F %.7F)', $row['lon'], $row['lat']);
-        $tags = json_encode(['type' => $row['type']], \JSON_UNESCAPED_UNICODE | \JSON_UNESCAPED_SLASHES);
+        $tags = json_encode(['type' => $row['type']], \JSON_UNESCAPED_UNICODE | \JSON_UNESCAPED_SLASHES) ?: '{}';
 
         $values = match ($table) {
             'cultural_pois' => [$row['id'], $row['name'], $row['category'], $row['openingHours'], $row['description'], $row['wikidata'], $tags, $geom],

--- a/provisioner/src/DataTourismeImporter.php
+++ b/provisioner/src/DataTourismeImporter.php
@@ -27,6 +27,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  * backslash-escaped); the geometry column receives EWKT (`SRID=4326;POINT(lon
  * lat)`) which PostGIS parses on input. The DB connection comes from the libpq
  * environment (PG*), inherited by psql.
+ *
+ * @phpstan-import-type Row from DataTourismeMapper
  */
 final readonly class DataTourismeImporter
 {
@@ -189,7 +191,7 @@ final readonly class DataTourismeImporter
     }
 
     /**
-     * @param array<string, mixed> $row
+     * @phpstan-param Row $row
      */
     private function copyLine(string $table, array $row): string
     {
@@ -206,13 +208,13 @@ final readonly class DataTourismeImporter
         return implode("\t", array_map($this->copyValue(...), $values))."\n";
     }
 
-    private function copyValue(mixed $value): string
+    private function copyValue(string|int|float|null $value): string
     {
-        if (null === $value || false === $value) {
+        if (null === $value) {
             return '\N';
         }
 
-        $string = \is_bool($value) ? '1' : (string) $value;
+        $string = \is_string($value) ? $value : (string) $value;
 
         return str_replace(['\\', "\t", "\n", "\r"], ['\\\\', '\\t', '\\n', '\\r'], $string);
     }

--- a/provisioner/src/DataTourismeImporter.php
+++ b/provisioner/src/DataTourismeImporter.php
@@ -6,6 +6,7 @@ namespace Provisioner;
 
 use Provisioner\Exception\ImportFailedException;
 use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Component\HttpClient\ScopingHttpClient;
 use Symfony\Component\Process\Exception\ProcessTimedOutException;
 use Symfony\Component\Process\Process;
 use Symfony\Contracts\HttpClient\Exception\ExceptionInterface as HttpClientExceptionInterface;
@@ -71,7 +72,11 @@ final readonly class DataTourismeImporter
         ?\Closure $processFactory = null,
         private float $timeoutSeconds = 1800.0,
     ) {
-        $this->httpClient = $httpClient ?? HttpClient::create(['max_redirects' => 2, 'timeout' => $this->timeoutSeconds]);
+        // Scoped to the DataTourisme origin (SSRF policy, see CLAUDE.md).
+        $this->httpClient = $httpClient ?? ScopingHttpClient::forBaseUri(
+            HttpClient::create(['max_redirects' => 2, 'timeout' => $this->timeoutSeconds]),
+            'https://diffuseur.datatourisme.fr/',
+        );
         $this->processFactory = $processFactory ?? static fn (array $command): Process => new Process($command);
     }
 

--- a/provisioner/src/DataTourismeMapper.php
+++ b/provisioner/src/DataTourismeMapper.php
@@ -151,7 +151,7 @@ final class DataTourismeMapper
             return [];
         }
 
-        return array_values(array_filter($raw, 'is_string'));
+        return array_values(array_filter($raw, is_string(...)));
     }
 
     /**

--- a/provisioner/src/DataTourismeMapper.php
+++ b/provisioner/src/DataTourismeMapper.php
@@ -1,0 +1,297 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Provisioner;
+
+/**
+ * Maps one DataTourisme flux JSON-LD object to a normalised row for a tourism.*
+ * table, or null when it is not a category we import.
+ *
+ * The flux serialises the DataTourisme ontology with UNPREFIXED type terms in
+ * the JSON-LD type array (e.g. "CulturalSite", "Accommodation",
+ * "EntertainmentAndEvent"), labels as language-maps ({"fr":["…"]}), and the
+ * location under isLocatedAt[0]["schema:geo"] — none of which match the old
+ * runtime REST API shape, so this is a flux-specific mapper. The raw type list
+ * is preserved in the row's tags so nothing is lost.
+ *
+ * @phpstan-type Row array{head: string, id: string, name: string|null, category: string, lat: float, lon: float, description: string|null, openingHours: string|null, wikidata: string|null, capacity: int|null, price: float|null, startDate: string|null, endDate: string|null, type: list<string>}
+ */
+final class DataTourismeMapper
+{
+    /** Accommodation subtype (unprefixed ontology type) → app accommodation category. */
+    private const array ACCOMMODATION_CATEGORY = [
+        'Hotel' => 'hotel', 'HotelTrade' => 'hotel', 'HotelRestaurant' => 'hotel',
+        'Guesthouse' => 'guest_house', 'TableHoteGuesthouse' => 'guest_house', 'BedAndBreakfast' => 'guest_house',
+        'Camping' => 'camp_site', 'CampingAndCaravanning' => 'camp_site', 'NaturalCampingArea' => 'camp_site',
+        'FarmCamping' => 'camp_site', 'CamperVanArea' => 'camp_site', 'CampingCar' => 'camp_site',
+        'Chalet' => 'chalet', 'Hut' => 'wilderness_hut', 'TreeHouse' => 'chalet',
+        'CollectiveAccommodation' => 'hostel', 'GroupLodging' => 'hostel', 'StopOverOrGroupLodge' => 'hostel',
+        'ClubOrHolidayVillage' => 'hostel', 'HolidayResort' => 'hostel',
+    ];
+
+    /** Cultural/natural subtype (unprefixed ontology type) → app cultural-POI category. */
+    private const array CULTURAL_CATEGORY = [
+        'Museum' => 'museum', 'InterpretationCentre' => 'museum', 'ArtGalleryOrExhibitionGallery' => 'museum',
+        'Castle' => 'monument', 'FortifiedCastle' => 'monument', 'Fort' => 'monument', 'DefenceSite' => 'monument',
+        'ReligiousSite' => 'monument', 'Church' => 'monument', 'Cathedral' => 'monument', 'Chapel' => 'monument',
+        'Abbey' => 'monument', 'Basilica' => 'monument', 'Cloister' => 'monument', 'Calvary' => 'monument',
+        'RemembranceSite' => 'monument', 'Commemoration' => 'monument', 'ArcheologicalSite' => 'monument',
+        'RemarkableBuilding' => 'monument', 'CityHeritage' => 'monument', 'TechnicalHeritage' => 'monument',
+        'IndustrialSite' => 'monument', 'Mill' => 'monument', 'Aqueduct' => 'monument', 'Bridge' => 'monument',
+        'PointOfView' => 'viewpoint', 'NaturalHeritage' => 'viewpoint', 'NaturalCuriosity' => 'viewpoint',
+        'ParkAndGarden' => 'viewpoint', 'Forest' => 'viewpoint', 'Beach' => 'viewpoint', 'Lake' => 'viewpoint',
+        'Dune' => 'viewpoint', 'Glacier' => 'viewpoint', 'CaveSinkholeOrAven' => 'viewpoint', 'Source' => 'viewpoint',
+    ];
+
+    /** Event subtype (unprefixed ontology type) → app event category. */
+    private const array EVENT_CATEGORY = [
+        'Festival' => 'festival', 'TraditionalCelebration' => 'festival', 'Carnival' => 'festival', 'Parade' => 'festival',
+        'Concert' => 'concert', 'Recital' => 'concert', 'Opera' => 'concert',
+        'Exhibition' => 'exhibition', 'VisualArtsEvent' => 'exhibition',
+        'SportsEvent' => 'sports', 'SportsCompetition' => 'sports', 'SportsDemonstration' => 'sports',
+        'FairOrShow' => 'fair', 'SaleEvent' => 'fair', 'BusinessEvent' => 'fair', 'OpenDay' => 'fair',
+        'TheaterEvent' => 'show', 'ShowEvent' => 'show', 'ScreeningEvent' => 'show', 'Cinema' => 'show',
+    ];
+
+    /**
+     * @param array<string, mixed> $object
+     *
+     * @phpstan-return Row|null
+     */
+    public function map(array $object): ?array
+    {
+        $types = $this->types($object);
+        if ([] === $types) {
+            return null;
+        }
+
+        $id = \is_string($object['@id'] ?? null) ? $object['@id'] : null;
+        if (null === $id) {
+            return null;
+        }
+
+        $coords = $this->coordinates($object);
+        if (null === $coords) {
+            return null;
+        }
+
+        [$head, $category] = $this->classify($types);
+        if (null === $head) {
+            return null;
+        }
+
+        [$startDate, $endDate] = 'event' === $head ? $this->dates($object) : [null, null];
+
+        return [
+            'head' => $head,
+            'id' => $id,
+            'name' => $this->label($object['rdfs:label'] ?? null),
+            'category' => $category,
+            'lat' => $coords['lat'],
+            'lon' => $coords['lon'],
+            'description' => $this->description($object),
+            'openingHours' => null,
+            'wikidata' => $this->wikidata($object),
+            'capacity' => 'accommodation' === $head ? $this->intOrNull($object['allowedPersons'] ?? null) : null,
+            'price' => 'accommodation' === $head || 'event' === $head ? $this->price($object['offers'] ?? null) : null,
+            'startDate' => $startDate,
+            'endDate' => $endDate,
+            'type' => $types,
+        ];
+    }
+
+    /**
+     * @param list<string> $types
+     *
+     * @return array{string|null, string}
+     */
+    private function classify(array $types): array
+    {
+        // Events first: an event venue can also carry place types.
+        if (\in_array('EntertainmentAndEvent', $types, true)) {
+            return ['event', $this->resolve($types, self::EVENT_CATEGORY, 'event')];
+        }
+
+        if (\in_array('Accommodation', $types, true)) {
+            return ['accommodation', $this->resolve($types, self::ACCOMMODATION_CATEGORY, 'apartment')];
+        }
+
+        if (\in_array('CulturalSite', $types, true) || \in_array('NaturalHeritage', $types, true)) {
+            return ['cultural', $this->resolve($types, self::CULTURAL_CATEGORY, 'attraction')];
+        }
+
+        return [null, ''];
+    }
+
+    /**
+     * @param list<string>          $types
+     * @param array<string, string> $map
+     */
+    private function resolve(array $types, array $map, string $default): string
+    {
+        foreach ($types as $type) {
+            if (isset($map[$type])) {
+                return $map[$type];
+            }
+        }
+
+        return $default;
+    }
+
+    /**
+     * @param array<string, mixed> $object
+     *
+     * @return list<string>
+     */
+    private function types(array $object): array
+    {
+        $raw = $object['@type'] ?? null;
+        if (!\is_array($raw)) {
+            return [];
+        }
+
+        return array_values(array_filter($raw, 'is_string'));
+    }
+
+    /**
+     * @param array<string, mixed> $object
+     *
+     * @return array{lat: float, lon: float}|null
+     */
+    private function coordinates(array $object): ?array
+    {
+        $located = $object['isLocatedAt'] ?? null;
+        $first = \is_array($located) ? ($located[0] ?? null) : null;
+        $geo = \is_array($first) ? ($first['schema:geo'] ?? null) : null;
+        if (!\is_array($geo)) {
+            return null;
+        }
+
+        $lat = $geo['schema:latitude'] ?? null;
+        $lon = $geo['schema:longitude'] ?? null;
+        if (!is_numeric($lat) || !is_numeric($lon)) {
+            return null;
+        }
+
+        return ['lat' => (float) $lat, 'lon' => (float) $lon];
+    }
+
+    /**
+     * First value of a DataTourisme language-map ({"fr":["…"],"en":[…]}),
+     * preferring fr then en then any language.
+     */
+    private function label(mixed $langMap): ?string
+    {
+        if (!\is_array($langMap)) {
+            return null;
+        }
+
+        foreach (['fr', 'en'] as $lang) {
+            $value = $this->firstString($langMap[$lang] ?? null);
+            if (null !== $value) {
+                return $value;
+            }
+        }
+
+        foreach ($langMap as $values) {
+            $value = $this->firstString($values);
+            if (null !== $value) {
+                return $value;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, mixed> $object
+     */
+    private function description(array $object): ?string
+    {
+        $hasDescription = $object['hasDescription'] ?? null;
+        $first = \is_array($hasDescription) ? ($hasDescription[0] ?? null) : null;
+        if (\is_array($first)) {
+            $short = $this->label($first['shortDescription'] ?? null);
+            if (null !== $short) {
+                return $short;
+            }
+        }
+
+        return $this->label($object['rdfs:comment'] ?? null);
+    }
+
+    /**
+     * @param array<string, mixed> $object
+     */
+    private function wikidata(array $object): ?string
+    {
+        $sameAs = $object['owl:sameAs'] ?? null;
+        $uris = \is_array($sameAs) ? $sameAs : (\is_string($sameAs) ? [$sameAs] : []);
+        foreach ($uris as $uri) {
+            if (\is_string($uri) && str_contains($uri, 'wikidata.org/entity/')) {
+                $id = substr($uri, strrpos($uri, '/') + 1);
+                if (1 === preg_match('/^Q\d+$/', $id)) {
+                    return $id;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, mixed> $object
+     *
+     * @return array{string|null, string|null}
+     */
+    private function dates(array $object): array
+    {
+        return [
+            $this->firstString($object['schema:startDate'] ?? null),
+            $this->firstString($object['schema:endDate'] ?? null),
+        ];
+    }
+
+    private function price(mixed $offers): ?float
+    {
+        if (!\is_array($offers)) {
+            return null;
+        }
+
+        foreach ($offers as $offer) {
+            if (!\is_array($offer)) {
+                continue;
+            }
+
+            $specs = $offer['schema:priceSpecification'] ?? $offer['priceSpecification'] ?? null;
+            $specs = \is_array($specs) ? $specs : [];
+            foreach ($specs as $spec) {
+                $price = \is_array($spec) ? ($spec['schema:price'] ?? $spec['price'] ?? null) : null;
+                if (is_numeric($price)) {
+                    return (float) $price;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private function firstString(mixed $value): ?string
+    {
+        if (\is_string($value)) {
+            return '' === $value ? null : $value;
+        }
+
+        if (\is_array($value) && \is_string($value[0] ?? null) && '' !== $value[0]) {
+            return $value[0];
+        }
+
+        return null;
+    }
+
+    private function intOrNull(mixed $value): ?int
+    {
+        return is_numeric($value) ? (int) $value : null;
+    }
+}

--- a/provisioner/src/DataTourismeMapper.php
+++ b/provisioner/src/DataTourismeMapper.php
@@ -15,7 +15,7 @@ namespace Provisioner;
  * runtime REST API shape, so this is a flux-specific mapper. The raw type list
  * is preserved in the row's tags so nothing is lost.
  *
- * @phpstan-type Row array{head: string, id: string, name: string|null, category: string, lat: float, lon: float, description: string|null, openingHours: string|null, wikidata: string|null, capacity: int|null, price: float|null, startDate: string|null, endDate: string|null, type: list<string>}
+ * @phpstan-type Row array{head: 'cultural'|'accommodation'|'event', id: string, name: string|null, category: string, lat: float, lon: float, description: string|null, openingHours: string|null, wikidata: string|null, capacity: int|null, price: float|null, startDate: string|null, endDate: string|null, type: list<string>}
  */
 final class DataTourismeMapper
 {
@@ -104,7 +104,7 @@ final class DataTourismeMapper
     /**
      * @param list<string> $types
      *
-     * @return array{string|null, string}
+     * @return array{'cultural'|'accommodation'|'event'|null, string}
      */
     private function classify(array $types): array
     {

--- a/provisioner/src/ProvisionCommand.php
+++ b/provisioner/src/ProvisionCommand.php
@@ -37,8 +37,6 @@ final class ProvisionCommand extends Command
 
     private readonly PostgisImporter $postgisImporter;
 
-    private readonly ?DataTourismeImporter $dataTourismeImporter;
-
     public function __construct(
         private readonly string $regionsDir = self::DEFAULT_REGIONS_DIR,
         private readonly string $mergedPbf = self::DEFAULT_MERGED_PBF,
@@ -49,7 +47,8 @@ final class ProvisionCommand extends Command
         private readonly string $filteredPbf = self::DEFAULT_FILTERED_PBF,
         ?PostgisImporter $postgisImporter = null,
         private readonly string $dataTourismeDir = self::DEFAULT_DATATOURISME_DIR,
-        ?DataTourismeImporter $dataTourismeImporter = null,
+        // Built lazily in runDataTourisme() from DATATOURISME_* env when not injected.
+        private readonly ?DataTourismeImporter $dataTourismeImporter = null,
     ) {
         parent::__construct();
 
@@ -58,8 +57,6 @@ final class ProvisionCommand extends Command
         $this->postgisImporter = $postgisImporter ?? new PostgisImporter(
             flexStylePath: \dirname(__DIR__).'/osm2pgsql/tier1.lua',
         );
-        // Built lazily in runDataTourisme() from DATATOURISME_* env when not injected.
-        $this->dataTourismeImporter = $dataTourismeImporter;
     }
 
     protected function configure(): void
@@ -102,7 +99,7 @@ final class ProvisionCommand extends Command
     private function runDataTourisme(SymfonyStyle $io): int
     {
         $importer = $this->dataTourismeImporter;
-        if (null === $importer) {
+        if (!$importer instanceof DataTourismeImporter) {
             $fluxId = getenv('DATATOURISME_FLUX_ID') ?: '';
             $appKey = getenv('DATATOURISME_APP_KEY') ?: '';
             if ('' === $fluxId || '' === $appKey) {

--- a/provisioner/src/ProvisionCommand.php
+++ b/provisioner/src/ProvisionCommand.php
@@ -29,11 +29,15 @@ final class ProvisionCommand extends Command
 
     private const string DEFAULT_FILTERED_PBF = '/data/tier1-filtered.osm.pbf';
 
+    private const string DEFAULT_DATATOURISME_DIR = '/data/datatourisme';
+
     private readonly RegionSelectionStore $selectionStore;
 
     private readonly OsmDataDownloader $downloader;
 
     private readonly PostgisImporter $postgisImporter;
+
+    private readonly ?DataTourismeImporter $dataTourismeImporter;
 
     public function __construct(
         private readonly string $regionsDir = self::DEFAULT_REGIONS_DIR,
@@ -44,6 +48,8 @@ final class ProvisionCommand extends Command
         private readonly bool $runMerge = true,
         private readonly string $filteredPbf = self::DEFAULT_FILTERED_PBF,
         ?PostgisImporter $postgisImporter = null,
+        private readonly string $dataTourismeDir = self::DEFAULT_DATATOURISME_DIR,
+        ?DataTourismeImporter $dataTourismeImporter = null,
     ) {
         parent::__construct();
 
@@ -52,12 +58,15 @@ final class ProvisionCommand extends Command
         $this->postgisImporter = $postgisImporter ?? new PostgisImporter(
             flexStylePath: \dirname(__DIR__).'/osm2pgsql/tier1.lua',
         );
+        // Built lazily in runDataTourisme() from DATATOURISME_* env when not injected.
+        $this->dataTourismeImporter = $dataTourismeImporter;
     }
 
     protected function configure(): void
     {
         $this->addOption('dry-run', null, InputOption::VALUE_NONE, 'Show what would be downloaded without executing');
         $this->addOption('with-postgis', null, InputOption::VALUE_NONE, 'After merging, import the Tier-1 features into PostGIS (requires PG* env)');
+        $this->addOption('with-datatourisme', null, InputOption::VALUE_NONE, 'Download the DataTourisme flux and import it into the tourism schema (requires DATATOURISME_FLUX_ID + DATATOURISME_APP_KEY + PG* env)');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -67,6 +76,7 @@ final class ProvisionCommand extends Command
 
         $dryRun = (bool) $input->getOption('dry-run');
         $importPostgis = (bool) $input->getOption('with-postgis');
+        $importDataTourisme = (bool) $input->getOption('with-datatourisme');
         $interactive = $input->isInteractive();
         $hasSelection = $this->selectionStore->exists();
 
@@ -76,11 +86,55 @@ final class ProvisionCommand extends Command
             return Command::FAILURE;
         }
 
-        if ($hasSelection) {
-            return $this->runUpdateFlow($io, $dryRun, $interactive, $importPostgis);
+        $result = $hasSelection
+            ? $this->runUpdateFlow($io, $dryRun, $interactive, $importPostgis)
+            : $this->runInstallFlow($io, $dryRun, $importPostgis);
+
+        // DataTourisme is FR-only and independent of the OSM region selection,
+        // so it runs as its own step (its own download, schema and atomic swap).
+        if (Command::SUCCESS === $result && $importDataTourisme && !$dryRun) {
+            $result = $this->runDataTourisme($io);
         }
 
-        return $this->runInstallFlow($io, $dryRun, $importPostgis);
+        return $result;
+    }
+
+    private function runDataTourisme(SymfonyStyle $io): int
+    {
+        $importer = $this->dataTourismeImporter;
+        if (null === $importer) {
+            $fluxId = getenv('DATATOURISME_FLUX_ID') ?: '';
+            $appKey = getenv('DATATOURISME_APP_KEY') ?: '';
+            if ('' === $fluxId || '' === $appKey) {
+                $io->error('DataTourisme import requires DATATOURISME_FLUX_ID and DATATOURISME_APP_KEY.');
+
+                return Command::FAILURE;
+            }
+
+            $importer = new DataTourismeImporter(
+                \sprintf('https://diffuseur.datatourisme.fr/webservice/%s/%s', $fluxId, $appKey),
+            );
+        }
+
+        if (!is_dir($this->dataTourismeDir) && !mkdir($this->dataTourismeDir, 0o755, true) && !is_dir($this->dataTourismeDir)) {
+            $io->error(\sprintf('Cannot create DataTourisme work directory "%s"', $this->dataTourismeDir));
+
+            return Command::FAILURE;
+        }
+
+        $io->section('Importing DataTourisme into PostGIS');
+
+        try {
+            $importer->run($this->dataTourismeDir);
+        } catch (ImportFailedException $e) {
+            $io->error($e->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        $io->success('DataTourisme import complete.');
+
+        return Command::SUCCESS;
     }
 
     private function runInstallFlow(SymfonyStyle $io, bool $dryRun, bool $importPostgis): int

--- a/provisioner/src/ProvisionCommand.php
+++ b/provisioner/src/ProvisionCommand.php
@@ -123,8 +123,8 @@ final class ProvisionCommand extends Command
 
         try {
             $importer->run($this->dataTourismeDir);
-        } catch (ImportFailedException $e) {
-            $io->error($e->getMessage());
+        } catch (ImportFailedException $importFailedException) {
+            $io->error($importFailedException->getMessage());
 
             return Command::FAILURE;
         }

--- a/provisioner/tests/DataTourismeImporterTest.php
+++ b/provisioner/tests/DataTourismeImporterTest.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Provisioner\Tests;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Provisioner\DataTourismeImporter;
+use Provisioner\Exception\ImportFailedException;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\Process\Process;
+
+final class DataTourismeImporterTest extends TestCase
+{
+    private string $workDir;
+
+    /**
+     * @var list<list<string>>
+     */
+    private array $captured = [];
+
+    protected function setUp(): void
+    {
+        $this->workDir = sys_get_temp_dir().'/dt-importer-'.uniqid('', true);
+        mkdir($this->workDir, 0o755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->workDir.'/*') ?: [] as $file) {
+            unlink($file);
+        }
+
+        if (is_dir($this->workDir)) {
+            rmdir($this->workDir);
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $object
+     *
+     * @return array{0: string, 1: string}
+     */
+    private function place(string $relativePath, array $object): array
+    {
+        return [$relativePath, (string) json_encode($object)];
+    }
+
+    /**
+     * Builds a tiny flux ZIP (index + objects/) and returns its raw bytes.
+     */
+    private function fluxZipBytes(): string
+    {
+        $zipPath = $this->workDir.'/fixture.zip';
+        $zip = new \ZipArchive();
+        $zip->open($zipPath, \ZipArchive::CREATE | \ZipArchive::OVERWRITE);
+        $zip->addFromString('index.json', '[]');
+        $zip->addFromString('context.jsonld', '{}');
+
+        $entries = [
+            $this->place('objects/0/00/cultural.json', [
+                '@id' => 'https://data.datatourisme.fr/10/cultural',
+                '@type' => ['CulturalSite', 'Museum', 'PointOfInterest'],
+                'rdfs:label' => ['fr' => ['Musée test']],
+                'isLocatedAt' => [['schema:geo' => ['schema:latitude' => '48.5', 'schema:longitude' => '2.3']]],
+            ]),
+            $this->place('objects/0/00/event.json', [
+                '@id' => 'https://data.datatourisme.fr/10/event',
+                '@type' => ['EntertainmentAndEvent', 'Festival'],
+                'rdfs:label' => ['fr' => ['Festival test']],
+                'schema:startDate' => ['2026-07-01'],
+                'schema:endDate' => ['2026-07-03'],
+                'isLocatedAt' => [['schema:geo' => ['schema:latitude' => '45.0', 'schema:longitude' => '5.0']]],
+            ]),
+            // Out of scope (food) → must be skipped, not written to any COPY file.
+            $this->place('objects/0/00/food.json', [
+                '@id' => 'https://data.datatourisme.fr/10/food',
+                '@type' => ['FoodEstablishment', 'Restaurant'],
+                'rdfs:label' => ['fr' => ['Resto test']],
+                'isLocatedAt' => [['schema:geo' => ['schema:latitude' => '44.0', 'schema:longitude' => '4.0']]],
+            ]),
+        ];
+        foreach ($entries as [$name, $contents]) {
+            $zip->addFromString($name, $contents);
+        }
+
+        $zip->close();
+        $bytes = (string) file_get_contents($zipPath);
+        unlink($zipPath);
+
+        return $bytes;
+    }
+
+    private function capturingFactory(): \Closure
+    {
+        return function (array $command): Process {
+            /** @var list<string> $cmd */
+            $cmd = $command;
+            $this->captured[] = $cmd;
+
+            return new Process(['true']);
+        };
+    }
+
+    #[Test]
+    public function runStreamsTheFluxIntoStagingCopyFilesThenSwaps(): void
+    {
+        $httpClient = new MockHttpClient(new MockResponse($this->fluxZipBytes()));
+
+        $importer = new DataTourismeImporter(
+            fluxUrl: 'https://diffuseur.datatourisme.fr/webservice/flux/key',
+            httpClient: $httpClient,
+            processFactory: $this->capturingFactory(),
+        );
+
+        $importer->run($this->workDir);
+
+        // 1 staging DDL + 3 \copy + 3 index + 1 swap.
+        self::assertCount(8, $this->captured);
+
+        $ddl = implode(' ', $this->captured[0]);
+        self::assertStringContainsString('CREATE SCHEMA tourism_staging', $ddl);
+        self::assertStringContainsString('CREATE TABLE tourism_staging.cultural_pois', $ddl);
+        self::assertStringContainsString('CREATE TABLE tourism_staging.events', $ddl);
+
+        $joined = array_map(static fn (array $c): string => implode(' ', $c), $this->captured);
+        self::assertTrue(
+            (bool) array_filter($joined, static fn (string $c): bool => str_contains($c, '\copy tourism_staging.cultural_pois')),
+            'a COPY command targets tourism_staging.cultural_pois',
+        );
+
+        $last = end($this->captured);
+        self::assertNotFalse($last);
+        $swap = implode(' ', $last);
+        self::assertStringContainsString('DROP SCHEMA IF EXISTS tourism CASCADE', $swap);
+        self::assertStringContainsString('ALTER SCHEMA tourism_staging RENAME TO tourism', $swap);
+    }
+
+    #[Test]
+    public function copyFilesContainOnlyTheInScopeMappedRows(): void
+    {
+        $httpClient = new MockHttpClient(new MockResponse($this->fluxZipBytes()));
+
+        $importer = new DataTourismeImporter(
+            fluxUrl: 'https://example.test/flux',
+            httpClient: $httpClient,
+            processFactory: $this->capturingFactory(),
+        );
+
+        $importer->run($this->workDir);
+
+        $cultural = (string) file_get_contents($this->workDir.'/tourism-cultural_pois.copy');
+        $events = (string) file_get_contents($this->workDir.'/tourism-events.copy');
+        $accommodations = (string) file_get_contents($this->workDir.'/tourism-accommodations.copy');
+
+        self::assertSame(1, substr_count($cultural, "\n"), 'one cultural row');
+        self::assertSame(1, substr_count($events, "\n"), 'one event row');
+        self::assertSame('', $accommodations, 'no accommodation in the fixture');
+
+        // The geometry column carries EWKT and the food POI was skipped.
+        self::assertStringContainsString('SRID=4326;POINT(', $cultural);
+        self::assertStringContainsString('https://data.datatourisme.fr/10/cultural', $cultural);
+        self::assertStringContainsString('2026-07-01', $events);
+        self::assertStringNotContainsString('food', $cultural.$events);
+    }
+
+    #[Test]
+    public function downloadFailureRaisesImportFailedException(): void
+    {
+        $httpClient = new MockHttpClient(new MockResponse('not found', ['http_code' => 404]));
+
+        $importer = new DataTourismeImporter(
+            fluxUrl: 'https://example.test/flux',
+            httpClient: $httpClient,
+            processFactory: $this->capturingFactory(),
+        );
+
+        $this->expectException(ImportFailedException::class);
+        $importer->run($this->workDir);
+    }
+}

--- a/provisioner/tests/DataTourismeImporterTest.php
+++ b/provisioner/tests/DataTourismeImporterTest.php
@@ -181,6 +181,7 @@ final class DataTourismeImporterTest extends TestCase
             'isLocatedAt' => [['schema:geo' => ['schema:latitude' => '48.0', 'schema:longitude' => '2.0']]],
         ]));
         $zip->close();
+
         $bytes = (string) file_get_contents($zipPath);
         unlink($zipPath);
 

--- a/provisioner/tests/DataTourismeImporterTest.php
+++ b/provisioner/tests/DataTourismeImporterTest.php
@@ -167,6 +167,38 @@ final class DataTourismeImporterTest extends TestCase
     }
 
     #[Test]
+    public function escapesSpecialCharactersInCopyFields(): void
+    {
+        // The real flux has labels with tabs/newlines; unescaped they would split
+        // or break COPY rows and abort the whole load under ON_ERROR_STOP=1.
+        $zipPath = $this->workDir.'/special.zip';
+        $zip = new \ZipArchive();
+        $zip->open($zipPath, \ZipArchive::CREATE | \ZipArchive::OVERWRITE);
+        $zip->addFromString('objects/0/00/special.json', (string) json_encode([
+            '@id' => 'https://data.datatourisme.fr/10/special',
+            '@type' => ['CulturalSite', 'Museum', 'PointOfInterest'],
+            'rdfs:label' => ['fr' => ["Name\twith\ttabs\nand newline\\backslash"]],
+            'isLocatedAt' => [['schema:geo' => ['schema:latitude' => '48.0', 'schema:longitude' => '2.0']]],
+        ]));
+        $zip->close();
+        $bytes = (string) file_get_contents($zipPath);
+        unlink($zipPath);
+
+        $importer = new DataTourismeImporter(
+            fluxUrl: 'https://example.test/flux',
+            httpClient: new MockHttpClient(new MockResponse($bytes)),
+            processFactory: $this->capturingFactory(),
+        );
+        $importer->run($this->workDir);
+
+        $cultural = (string) file_get_contents($this->workDir.'/tourism-cultural_pois.copy');
+        self::assertStringNotContainsString("\t\t", $cultural, 'a literal tab in the name would split into extra columns');
+        self::assertStringContainsString('\t', $cultural, 'tab escaped as backslash-t');
+        self::assertStringContainsString('\n', $cultural, 'newline escaped as backslash-n');
+        self::assertStringContainsString('\\\\', $cultural, 'backslash escaped as double backslash');
+    }
+
+    #[Test]
     public function downloadFailureRaisesImportFailedException(): void
     {
         $httpClient = new MockHttpClient(new MockResponse('not found', ['http_code' => 404]));

--- a/provisioner/tests/DataTourismeImporterTest.php
+++ b/provisioner/tests/DataTourismeImporterTest.php
@@ -117,8 +117,8 @@ final class DataTourismeImporterTest extends TestCase
 
         $importer->run($this->workDir);
 
-        // 1 staging DDL + 3 \copy + 3 index + 1 swap.
-        self::assertCount(8, $this->captured);
+        // 1 staging DDL + 3 \copy + 3 GIST index + 1 events-date index + 1 swap.
+        self::assertCount(9, $this->captured);
 
         $ddl = implode(' ', $this->captured[0]);
         self::assertStringContainsString('CREATE SCHEMA tourism_staging', $ddl);

--- a/provisioner/tests/DataTourismeMapperTest.php
+++ b/provisioner/tests/DataTourismeMapperTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Provisioner\Tests;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Provisioner\DataTourismeMapper;
+
+final class DataTourismeMapperTest extends TestCase
+{
+    private DataTourismeMapper $mapper;
+
+    protected function setUp(): void
+    {
+        $this->mapper = new DataTourismeMapper();
+    }
+
+    /**
+     * @param array{lat?: string, lon?: string} $geo
+     *
+     * @return array<string, mixed>
+     */
+    private function object(array $type, array $extra = [], array $geo = ['lat' => '49.1', 'lon' => '7.13']): array
+    {
+        return array_merge([
+            '@id' => 'https://data.datatourisme.fr/10/abc',
+            '@type' => $type,
+            'rdfs:label' => ['fr' => ['Sample']],
+            'isLocatedAt' => [[
+                'schema:geo' => ['schema:latitude' => $geo['lat'], 'schema:longitude' => $geo['lon']],
+            ]],
+        ], $extra);
+    }
+
+    #[Test]
+    public function mapsCulturalSiteToTheCulturalHead(): void
+    {
+        $row = $this->mapper->map($this->object(
+            ['ArcheologicalSite', 'CulturalSite', 'PlaceOfInterest', 'PointOfInterest'],
+            ['rdfs:comment' => ['fr' => ['Une villa gallo-romaine.']]],
+        ));
+
+        self::assertNotNull($row);
+        self::assertSame('cultural', $row['head']);
+        self::assertSame('monument', $row['category']);
+        self::assertSame('Sample', $row['name']);
+        self::assertEqualsWithDelta(49.1, $row['lat'], 0.0001);
+        self::assertEqualsWithDelta(7.13, $row['lon'], 0.0001);
+        self::assertSame('Une villa gallo-romaine.', $row['description']);
+    }
+
+    #[Test]
+    public function mapsAccommodationWithCapacityAndPrice(): void
+    {
+        $row = $this->mapper->map($this->object(
+            ['schema:Accommodation', 'Accommodation', 'RentalAccommodation', 'SelfCateringAccommodation'],
+            [
+                'allowedPersons' => 4,
+                'offers' => [['schema:priceSpecification' => [['schema:price' => '75']]]],
+            ],
+        ));
+
+        self::assertNotNull($row);
+        self::assertSame('accommodation', $row['head']);
+        self::assertSame('apartment', $row['category']);
+        self::assertSame(4, $row['capacity']);
+        self::assertSame(75.0, $row['price']);
+    }
+
+    #[Test]
+    public function mapsAccommodationSubtypeToAppCategory(): void
+    {
+        $hotel = $this->mapper->map($this->object(['Accommodation', 'Hotel']));
+        self::assertNotNull($hotel);
+        self::assertSame('hotel', $hotel['category']);
+
+        $camping = $this->mapper->map($this->object(['Accommodation', 'CampingAndCaravanning']));
+        self::assertNotNull($camping);
+        self::assertSame('camp_site', $camping['category']);
+    }
+
+    #[Test]
+    public function mapsEventWithDates(): void
+    {
+        $row = $this->mapper->map($this->object(
+            ['schema:Event', 'EntertainmentAndEvent', 'CulturalEvent', 'Festival'],
+            ['schema:startDate' => ['2026-09-26'], 'schema:endDate' => ['2026-09-27']],
+        ));
+
+        self::assertNotNull($row);
+        self::assertSame('event', $row['head']);
+        self::assertSame('festival', $row['category']);
+        self::assertSame('2026-09-26', $row['startDate']);
+        self::assertSame('2026-09-27', $row['endDate']);
+    }
+
+    #[Test]
+    public function classifiesEventBeforePlaceWhenBothTypesPresent(): void
+    {
+        // An event venue can also carry place types; the event head wins.
+        $row = $this->mapper->map($this->object(['CulturalSite', 'EntertainmentAndEvent', 'SportsEvent']));
+
+        self::assertNotNull($row);
+        self::assertSame('event', $row['head']);
+        self::assertSame('sports', $row['category']);
+    }
+
+    #[Test]
+    public function ignoresUnsupportedCategories(): void
+    {
+        // Food establishments and shops are out of the import scope.
+        self::assertNull($this->mapper->map($this->object(['FoodEstablishment', 'Restaurant'])));
+        self::assertNull($this->mapper->map($this->object(['Store', 'BoutiqueOrLocalShop'])));
+    }
+
+    #[Test]
+    public function returnsNullWithoutAnIdOrCoordinates(): void
+    {
+        $noId = $this->object(['CulturalSite']);
+        unset($noId['@id']);
+        self::assertNull($this->mapper->map($noId));
+
+        $noGeo = $this->object(['CulturalSite']);
+        unset($noGeo['isLocatedAt']);
+        self::assertNull($this->mapper->map($noGeo));
+    }
+
+    #[Test]
+    public function resolvesLabelByLanguagePreference(): void
+    {
+        $en = $this->object(['CulturalSite']);
+        $en['rdfs:label'] = ['en' => ['English name'], 'de' => ['Deutscher Name']];
+        $rowEn = $this->mapper->map($en);
+        self::assertNotNull($rowEn);
+        self::assertSame('English name', $rowEn['name'], 'falls back to en when fr is absent');
+
+        $de = $this->object(['CulturalSite']);
+        $de['rdfs:label'] = ['de' => ['Deutscher Name']];
+        $rowDe = $this->mapper->map($de);
+        self::assertNotNull($rowDe);
+        self::assertSame('Deutscher Name', $rowDe['name'], 'falls back to any language as a last resort');
+    }
+
+    #[Test]
+    public function extractsWikidataIdFromSameAs(): void
+    {
+        $object = $this->object(['CulturalSite'], [
+            'owl:sameAs' => ['https://www.wikidata.org/entity/Q12345'],
+        ]);
+
+        $row = $this->mapper->map($object);
+        self::assertNotNull($row);
+        self::assertSame('Q12345', $row['wikidata']);
+    }
+}

--- a/provisioner/tests/DataTourismeMapperTest.php
+++ b/provisioner/tests/DataTourismeMapperTest.php
@@ -18,7 +18,9 @@ final class DataTourismeMapperTest extends TestCase
     }
 
     /**
-     * @param array{lat?: string, lon?: string} $geo
+     * @param list<string>                    $type
+     * @param array<string, mixed>            $extra
+     * @param array{lat: string, lon: string} $geo
      *
      * @return array<string, mixed>
      */


### PR DESCRIPTION
## Contexte

Première moitié de la migration DataTourisme local-first (ADR-040) : le **provisioner** importe le flux DataTourisme dans un schéma PostGIS `tourism`, en remplacement de l'API REST DataTourisme runtime. DataTourisme est **FR-only** et vit dans son **propre schéma** (pas `osm` : le swap osm2pgsql `DROP SCHEMA osm CASCADE` le détruirait), avec son propre swap atomique.

**Cette PR peuple les tables ; aucun consommateur API ne les lit encore** (le cutover des registries + dédup vs OSM = PR-DT2 à suivre).

## Découverte : la forme du flux ≠ API REST

Le flux sérialise l'ontologie DataTourisme avec des termes `@type` **non préfixés** (`CulturalSite`/`Accommodation`/`EntertainmentAndEvent`, pas `schema:Museum`/`urn:resource:*`), des labels en language-map (`{"fr":["…"]}`), et la géométrie sous `isLocatedAt[0]."schema:geo"`. Les mappers REST existants n'auraient rien matché → mapper **spécifique au flux**.

## Changements

- **Migration** : schéma `tourism` (`cultural_pois` / `accommodations` / `events`, points PostGIS + GIST, events indexé par date). PK = `@id` DataTourisme (upsert idempotent au refresh).
- **`DataTourismeMapper`** : objet flux → ligne normalisée, classifié sur la superclasse d'ontologie (events > accommodation > cultural). Capacité (`allowedPersons`), prix (`offers`), dates (`schema:startDate/endDate`), description (lang-map), wikidata (`owl:sameAs`).
- **`DataTourismeImporter`** : download du ZIP (Symfony HttpClient, gère le gzip transport) → stream `objects/` entrée-par-entrée (`ZipArchive::getStream`, **mémoire O(constant)** sur ~390k objets) → écriture de fichiers COPF format-texte par table → bulk-load `psql COPY` dans `tourism_staging` → **swap atomique** vers `tourism` (même forme que `PostgisImporter`). `geom` reçoit de l'EWKT que PostGIS parse à l'insertion.
- **`ProvisionCommand`** : flag `--with-datatourisme` (étape indépendante du flow OSM, hors `--dry-run`), credentials via `DATATOURISME_FLUX_ID` + `DATATOURISME_APP_KEY`.
- **Dockerfile provisioner** : `ext-zip` (dev + prod). **compose** : credentials flux passés au service provisioner.
- **Tests** : `DataTourismeMapperTest` (classification + extraction + fallbacks + garde-fous) ; `DataTourismeImporterTest` (ZIP synthétique via `run()`, HTTP mocké + commandes psql capturées → DDL staging, fichiers COPY par table, swap).

## Vérification

- **Validé sur le vrai flux** (390 982 objets, fichier réel) : 0 crash, 0 sans nom, **58 s** ; classés **128 109** hébergements / **96 007** événements / **56 461** POI culturels (110 405 resto/commerce/itinéraires hors périmètre, correctement ignorés). Distribution cohérente (apartment 85k, sports 26k, monument 25k…).
- `php -l` + PHP-CS-Fixer 0 sur tous les fichiers ; `docker compose config` valide.
- PHPStan L9 / PHPUnit (provisioner) / Hadolint → CI (worktree sans vendor).

## Périmètre / suite

- **Resto/commerce** (`FoodEstablishment`/`Store`) et **itinéraires cyclables** (`CyclingTour`) volontairement laissés pour plus tard (pas de consommateur immédiat).
- **PR-DT2** : cutover des registries (`CulturalPoiSourceRegistry`, `AccommodationSourceRegistry`, `ScanEventsHandler`) vers `tourism.*` + dédup vs OSM (spatial+nom, wikidata secondaire) + retrait du `DataTourismeClient` runtime.

<!-- claude-review-start -->
## Claude Review

Reviewed commit `d04dd0b`.

**0 warnings, 2 non-blocking suggestions** — approved.

### Checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Findings

| # | Severity | Location | Summary |
|---|----------|----------|---------|
| 1 | suggestion (non-blocking) | `DataTourismeImporter.php` L357 | `default => []` in `copyLine` silently emits an empty COPY row instead of failing fast |
| 2 | suggestion (non-blocking) | `DataTourismeImporter.php` L334 | `fwrite` return value not checked in `extract` loop — silent data loss on disk full |

Resolved 1 previously open bot thread (HTTP scoping warning — addressed in `d04dd0b`).

Posted 2 inline comments.
<!-- claude-review-end -->