### PR TITLE
docs: reconcile Overpass references with the local-first PostGIS migration (ADR-040)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ Commit messages **must** follow [Conventional Commits](https://www.conventionalc
 ```
 
 - **Types:** `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`
-- **Scopes** (optional): subsystem or area, e.g. `feat(overpass):`, `fix(pacing):`, `chore(deps):`
+- **Scopes** (optional): subsystem or area, e.g. `feat(datatourisme):`, `fix(pacing):`, `chore(deps):`
 - **Description:** imperative mood, lowercase, no trailing period
 - Breaking changes: add `!` after type/scope, e.g. `feat!: remove legacy endpoint`
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Rules are executed in priority order (lower = higher priority):
 | **Cultural POI** | -- | ![nudge](https://img.shields.io/badge/-nudge-0288d1) | Museum, monument, castle, church, viewpoint, or attraction within 500 m of route — enriched with opening hours, price and description when sourced from DataTourisme |
 | **Railway station** | -- | ![nudge](https://img.shields.io/badge/-nudge-0288d1) | No train station within 10 km of a stage endpoint (emergency evacuation) |
 | **Health services** | -- | ![nudge](https://img.shields.io/badge/-nudge-0288d1) | No pharmacy, hospital, or clinic within 15 km of a stage |
-| **Border crossing** | -- | ![nudge](https://img.shields.io/badge/-nudge-0288d1) | Route crosses an international border (country change detected via Overpass is_in) |
+| **Border crossing** | -- | ![nudge](https://img.shields.io/badge/-nudge-0288d1) | Route crosses an international border (country change detected via the local PostGIS admin-boundary index) |
 
 **Terrain rules** (Continuity, Elevation, Steep gradient, Surface, Traffic, E-bike range, Sunset, Rest day) implement `StageAnalyzerInterface` and are auto-discovered via `#[AutoconfigureTag('app.stage_analyzer')]`. Rules with `--` priority (Calendar, Wind + Comfort, Bike shops, Resupply, Accommodation, Water points, Cultural POI, Railway station, Health services, Border crossing) are separate async Symfony Message handlers; Comfort is co-located with Wind inside `AnalyzeWindHandler`.
 
@@ -154,7 +154,7 @@ Rules are executed in priority order (lower = higher priority):
 Browser (Next.js 16)           PHP Backend (API Platform 4.3)
   Zustand + Immer (in-memory)    Stateless computation
   Zod validation                 GPX parsing + pacing engine
-  openapi-fetch (typed)          OSM Overpass + weather APIs
+  openapi-fetch (typed)          Local PostGIS reference index + weather
   Mercure SSE (real-time)  <--   Async workers (Symfony Messenger)
                                  Redis cache + Mercure publisher
 ```
@@ -207,7 +207,7 @@ Type safety is enforced end-to-end: PHP DTOs define the schema -> API Platform e
 
 ### OpenStreetMap
 
-All geographic and infrastructure data is sourced from [OpenStreetMap](https://www.openstreetmap.org) via the public Overpass API. OSM data is cached in Redis for 24 hours per query.
+All geographic and infrastructure data is derived from [OpenStreetMap](https://www.openstreetmap.org). The provisioner imports OSM extracts into a local PostGIS reference index that the API queries directly with spatial predicates (`ST_DWithin` / `ST_Covers`); there is no runtime Overpass dependency. See [ADR-040](docs/adr/adr-040-local-first-reference-data-postgis.md).
 
 **Licence:** [ODbL 1.0](https://opendatacommons.org/licenses/odbl/) — attribution required: "© OpenStreetMap contributors".
 

--- a/docs/adr/adr-017-valhalla-routing-engine-and-self-hosted-overpass-integration.md
+++ b/docs/adr/adr-017-valhalla-routing-engine-and-self-hosted-overpass-integration.md
@@ -3,7 +3,7 @@
 - **Status:** Accepted
 - **Date:** 2026-03-03
 - **Supersedes:** ADR-016 Option F (Self-hosted Overpass — deferred)
-- **Partially superseded by:** [ADR-025](adr-025-removal-of-self-hosted-overpass.md) — Self-hosted Overpass removed; sections §17.1 (Overpass Docker service), §17.4 (Overpass fallback strategy), and §17.5 (OSM data update strategy) are no longer in effect. Valhalla routing (§17.2, §17.3) remains active.
+- **Partially superseded by:** [ADR-025](adr-025-removal-of-self-hosted-overpass.md) — Self-hosted Overpass removed; sections §17.1 (Overpass Docker service), §17.4 (Overpass fallback strategy), and §17.5 (OSM data update strategy) are no longer in effect — and [ADR-040](adr-040-local-first-reference-data-postgis.md), which removed the runtime Overpass dependency entirely (OSM features now come from a local PostGIS index). Valhalla routing (§17.2, §17.3) remains active.
 
 ## Context and Problem Statement
 

--- a/docs/adr/adr-020-dynamic-overpass-region-provisioning.md
+++ b/docs/adr/adr-020-dynamic-overpass-region-provisioning.md
@@ -2,10 +2,9 @@
 
 - **Status:** Superseded
 - **Date:** 2026-03-05
-- **Superseded by:** [ADR-025](adr-025-removal-of-self-hosted-overpass.md) (self-hosted Overpass removed) and [ADR-040](adr-040-local-first-reference-data-postgis.md) (runtime Overpass replaced by a local PostGIS reference index)
 - **Extends:** ADR-017 (Valhalla Routing Engine and Self-Hosted Overpass Integration)
 - **Depends on:** ADR-016 Option F (Self-hosted Overpass — foundation implemented)
-- **Superseded by:** [ADR-025](adr-025-removal-of-self-hosted-overpass.md) — Self-hosted Overpass removed. The provisioner and PBF pipeline remain active for Valhalla only.
+- **Superseded by:** [ADR-025](adr-025-removal-of-self-hosted-overpass.md) — Self-hosted Overpass removed; runtime Overpass dependency later fully replaced by the local PostGIS index ([ADR-040](adr-040-local-first-reference-data-postgis.md)). The PBF provisioner pipeline remains active for Valhalla only.
 
 ## Context and Problem Statement
 

--- a/docs/adr/adr-020-dynamic-overpass-region-provisioning.md
+++ b/docs/adr/adr-020-dynamic-overpass-region-provisioning.md
@@ -2,6 +2,7 @@
 
 - **Status:** Superseded
 - **Date:** 2026-03-05
+- **Superseded by:** [ADR-025](adr-025-removal-of-self-hosted-overpass.md) (self-hosted Overpass removed) and [ADR-040](adr-040-local-first-reference-data-postgis.md) (runtime Overpass replaced by a local PostGIS reference index)
 - **Extends:** ADR-017 (Valhalla Routing Engine and Self-Hosted Overpass Integration)
 - **Depends on:** ADR-016 Option F (Self-hosted Overpass — foundation implemented)
 - **Superseded by:** [ADR-025](adr-025-removal-of-self-hosted-overpass.md) — Self-hosted Overpass removed. The provisioner and PBF pipeline remain active for Valhalla only.

--- a/docs/adr/adr-025-removal-of-self-hosted-overpass.md
+++ b/docs/adr/adr-025-removal-of-self-hosted-overpass.md
@@ -3,6 +3,7 @@
 - **Status:** Accepted
 - **Date:** 2026-04-09
 - **Supersedes:** ADR-017 §17.1 (Overpass Docker service), §17.4 (Overpass fallback strategy), §17.5 (OSM data update strategy), ADR-020 (Dynamic Overpass Region Provisioning)
+- **Partially superseded by:** [ADR-040](adr-040-local-first-reference-data-postgis.md) — the public Overpass runtime this kept is removed; OSM features now come from a local PostGIS index imported by the provisioner.
 
 ## Context and Problem Statement
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,10 +47,12 @@ terrain, accommodations) across five Messenger workers backed by Redis. A two-ph
 
 GPX is parsed with a streaming XMLReader (constant memory), elevation-smoothed, then decimated
 with Douglas-Peucker (~25k -> ~1.5k points). Routing uses a self-hosted Valhalla engine fed by
-Geofabrik extracts; OSM features come from the public Overpass API (cached in Redis). See
+Geofabrik extracts; OSM features come from a local PostGIS reference index imported by the
+provisioner, which the API queries directly — no runtime Overpass dependency. See
 [ADR-004](adr/adr-004-spatial-engineering-gpx-parsing-and-data-decimation.md),
-[ADR-017](adr/adr-017-valhalla-routing-engine-and-self-hosted-overpass-integration.md) and
-[ADR-033](adr/adr-033-osm-data-refresh-strategy.md).
+[ADR-017](adr/adr-017-valhalla-routing-engine-and-self-hosted-overpass-integration.md),
+[ADR-033](adr/adr-033-osm-data-refresh-strategy.md) and
+[ADR-040](adr/adr-040-local-first-reference-data-postgis.md).
 
 ## Alert engine
 

--- a/docs/runbooks/valhalla-overpass-rebuild.md
+++ b/docs/runbooks/valhalla-overpass-rebuild.md
@@ -7,7 +7,7 @@ Valhalla provides routing (ADR-017); Overpass usage was moved off the self-hoste
 - `/api/health` reports `valhalla: 503` or routing requests return 5xx
 - Valhalla logs: `tile not found`, `unable to load tile`, `corrupted`
 - New regions are missing routes after a fresh provision (Lille stub only)
-- POI extension queries fail because Overpass returns 504 / 429 from the public endpoint
+- POI / accommodation / event results are empty because the `osm` / `tourism` PostGIS schemas were never provisioned
 
 ## Diagnostic
 
@@ -64,10 +64,7 @@ ls -lh .docker/default.osm.pbf
      -d '{"locations":[{"lat":50.63,"lon":3.06},{"lat":50.64,"lon":3.07}],"costing":"bicycle"}'
    ```
 
-5. **Overpass** — the project relies on the public Overpass mirrors via scoped HTTP clients (ADR-025). If those are rate-limited, no rebuild is possible; the only mitigations are:
-   - Wait out the 429 (typically minutes)
-   - Lower request rate temporarily by reducing concurrent trip computations (scale workers down via Coolify)
-   - Switch the configured Overpass endpoint to an alternate mirror in the relevant env var
+5. **Reference data** — POI / accommodation / event data is no longer fetched from Overpass at runtime; it is served from the local `osm` / `tourism` PostGIS schemas populated by the `provisioner` (ADR-040). If those queries return nothing, it is a provisioning gap, not a routing one: re-run the provisioner (`make provision` with `--with-postgis` / `--with-datatourisme`) rather than rebuilding tiles here.
 
 ## Post-action
 


### PR DESCRIPTION
## Contexte

La dépendance Overpass runtime a été supprimée de bout en bout (#666→#684), mais plusieurs docs la décrivaient encore comme la source live. Cette PR aligne la **doc de vérité courante** sur la réalité local-first PostGIS et chaîne les ADR historiques vers ADR-040.

## Changements

**Vérité courante** (lues comme l'état actuel) :
- **README** : diagramme d'archi (`OSM Overpass` → index PostGIS local), le paragraphe « OpenStreetMap » (données importées dans un index PostGIS local par le provisioner, plus d'Overpass runtime), et l'alerte border-crossing (« via Overpass is_in » → « via l'index PostGIS admin-boundary »).
- **architecture.md** : les features OSM viennent de l'index PostGIS local + lien ADR-040.
- **CLAUDE.md** : exemple de scope de commit (`feat(overpass):` → `feat(datatourisme):`).

**ADR historiques** (corps intacts — ce sont des archives ; seule la chaîne de supersession est mise à jour) :
- ADR-017 / ADR-020 / ADR-025 : ajout de pointeurs « superseded by ADR-040 ».

**Runbook** :
- `valhalla-overpass-rebuild` : le symptôme/mitigation « Overpass 504/429 / mirrors publics » devient une note de provisioning PostGIS (les POI/héberg/événements viennent du schéma local).

## Hors scope

Les runbooks de refresh OSM (`osm-france-refresh`) référencent des imports OSM **toujours valides** (le provisioner télécharge encore des PBF) — non touchés. Les ADR-005/013/033/036 ont des mentions incidentes ou encore valides (refresh OSM) — non modifiés.

Doc-only ; markdownlink/markdownlint → CI.

<!-- claude-review-start -->
## Claude Review

**Summary:** Clean docs-only PR that correctly aligns README, architecture.md, CLAUDE.md, three historical ADRs, and the Valhalla runbook with the local-first PostGIS migration. The previously flagged duplicate `Superseded by` header in ADR-020 was addressed in the follow-up commit by extending the existing line rather than inserting a second one — the fix is correct.

**Findings:** 0 issues

**Commit reviewed:** `568e6f265b53dd92dabbc0ca6b9a1823c21fd869`

**Resolved threads:** Resolved 1 previously open thread (duplicate `Superseded by` header in ADR-020 — fixed in follow-up commit).

### Review checklist
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases *(docs-only — N/A)*
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Inline comments
No inline comments.
<!-- claude-review-end -->