### PR TITLE
feat(api): flag out-of-zone trips from the coverage polygon

### DIFF
--- a/api/src/ApiResource/TripDetail.php
+++ b/api/src/ApiResource/TripDetail.php
@@ -50,6 +50,8 @@ final readonly class TripDetail
         /** @var string[] */
         public array $enabledAccommodationTypes,
         public bool $isLocked,
+        /** True when the route falls outside the provisioned coverage area: the trip is display-only (no Valhalla rerouting). */
+        public bool $outOfZone,
         #[ApiProperty(openapiContext: [
             'type' => 'array',
             'items' => [

--- a/api/src/Osm/CoverageRepository.php
+++ b/api/src/Osm/CoverageRepository.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Osm;
+
+use Doctrine\DBAL\Connection;
+
+/**
+ * Tests a route against the local-first coverage polygon (ADR-040): the single-row
+ * osm.coverage table holds the union of the provisioned countries' admin_level=2
+ * boundaries, materialised by the provisioner. A route not fully covered cannot be
+ * (re)routed by Valhalla (no tiles out of zone), so the frontend renders it
+ * display-only.
+ *
+ * Coverage is treated as "unknown" (never out of zone) when the polygon was never
+ * provisioned (empty table or NULL geom), so a missing index never blocks the user.
+ */
+final readonly class CoverageRepository implements CoverageRepositoryInterface
+{
+    public function __construct(private Connection $connection)
+    {
+    }
+
+    public function isRouteOutOfZone(array $points): bool
+    {
+        if ([] === $points) {
+            return false;
+        }
+
+        $result = $this->connection->fetchOne(
+            <<<'SQL'
+                SELECT (geom IS NOT NULL AND NOT ST_Covers(geom, ST_SetSRID(ST_GeomFromText(:wkt), 4326)))::int
+                FROM osm.coverage
+                LIMIT 1
+                SQL,
+            ['wkt' => $this->toWkt($points)],
+        );
+
+        return \in_array($result, [1, '1', true], true);
+    }
+
+    /**
+     * @param non-empty-list<array{lat: float, lon: float}> $points
+     */
+    private function toWkt(array $points): string
+    {
+        $coords = array_map(
+            static fn (array $point): string => \sprintf('%.7F %.7F', $point['lon'], $point['lat']),
+            $points,
+        );
+
+        if (1 === \count($coords)) {
+            return \sprintf('POINT(%s)', $coords[0]);
+        }
+
+        return \sprintf('LINESTRING(%s)', implode(', ', $coords));
+    }
+}

--- a/api/src/Osm/CoverageRepositoryInterface.php
+++ b/api/src/Osm/CoverageRepositoryInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Osm;
+
+interface CoverageRepositoryInterface
+{
+    /**
+     * Returns true when the route lies (even partly) outside the provisioned
+     * coverage polygon (osm.coverage) — i.e. Valhalla has no routing tiles for
+     * it, so the trip is display-only. Returns false when the route is fully
+     * covered, when given no points, or when coverage was never provisioned
+     * (unknown coverage must not block the user).
+     *
+     * @param list<array{lat: float, lon: float}> $points
+     */
+    public function isRouteOutOfZone(array $points): bool;
+}

--- a/api/src/State/TripDetailProvider.php
+++ b/api/src/State/TripDetailProvider.php
@@ -14,6 +14,7 @@ use App\ApiResource\Model\WeatherForecast;
 use App\ApiResource\Stage;
 use App\ApiResource\TripDetail;
 use App\ApiResource\TripRequest;
+use App\Osm\CoverageRepositoryInterface;
 use App\Repository\DoctrineTripRequestRepository;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Uid\Uuid;
@@ -31,6 +32,7 @@ final readonly class TripDetailProvider implements ProviderInterface
     public function __construct(
         private DoctrineTripRequestRepository $tripStateManager,
         private TripLocker $tripLocker,
+        private CoverageRepositoryInterface $coverageRepository,
     ) {
     }
 
@@ -66,8 +68,38 @@ final readonly class TripDetailProvider implements ProviderInterface
             departureHour: $request->departureHour,
             enabledAccommodationTypes: $request->enabledAccommodationTypes,
             isLocked: $this->tripLocker->isLocked($request),
+            outOfZone: $this->coverageRepository->isRouteOutOfZone($this->routePoints($stages)),
             stages: array_map($this->serializeStage(...), $stages),
         );
+    }
+
+    /**
+     * Flattens the stage geometries into the route's coordinates for the coverage
+     * test, falling back to stage start/end points when geometry is unavailable.
+     *
+     * @param list<Stage> $stages
+     *
+     * @return list<array{lat: float, lon: float}>
+     */
+    private function routePoints(array $stages): array
+    {
+        $points = [];
+        foreach ($stages as $stage) {
+            foreach ($stage->geometry as $coord) {
+                $points[] = ['lat' => $coord->lat, 'lon' => $coord->lon];
+            }
+        }
+
+        if ([] !== $points) {
+            return $points;
+        }
+
+        foreach ($stages as $stage) {
+            $points[] = ['lat' => $stage->startPoint->lat, 'lon' => $stage->startPoint->lon];
+            $points[] = ['lat' => $stage->endPoint->lat, 'lon' => $stage->endPoint->lon];
+        }
+
+        return $points;
     }
 
     /**

--- a/api/tests/Functional/TripDetailTest.php
+++ b/api/tests/Functional/TripDetailTest.php
@@ -11,6 +11,7 @@ use App\ApiResource\Stage as StageDto;
 use App\ApiResource\TripRequest;
 use App\Entity\User;
 use App\Repository\DoctrineTripRequestRepository;
+use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\Test;
 use Zenstruck\Foundry\Attribute\ResetDatabase;
 use Zenstruck\Foundry\Test\Factories;
@@ -87,6 +88,41 @@ final class TripDetailTest extends ApiTestCase
         $this->assertArrayHasKey('geometry', $stage);
         $this->assertArrayHasKey('alerts', $stage);
         $this->assertArrayHasKey('accommodations', $stage);
+    }
+
+    #[Test]
+    public function detailFlagsOutOfZoneFromStageEndpointsWhenGeometryIsEmpty(): void
+    {
+        // Exercises the routePoints() fallback (no stage geometry → start/end points)
+        // against the real ST_Covers query: endpoints sit at lon 10, outside the
+        // seeded coverage polygon (2..4 lon, 48..50 lat), so the trip is out of zone.
+        $repo = $this->seedTrip(self::TRIP_ID);
+
+        $stage = new StageDto(
+            tripId: self::TRIP_ID,
+            dayNumber: 1,
+            distance: 40.0,
+            elevation: 300.0,
+            startPoint: new Coordinate(48.5, 10.0, 0.0),
+            endPoint: new Coordinate(48.6, 10.1, 0.0),
+        );
+        $repo->storeStages(self::TRIP_ID, [$stage]);
+
+        $connection = self::getContainer()->get('doctrine.dbal.default_connection');
+        \assert($connection instanceof Connection);
+        $connection->executeStatement('TRUNCATE osm.coverage');
+        $connection->executeStatement(<<<'SQL'
+            INSERT INTO osm.coverage (geom) VALUES (
+                ST_Multi(ST_SetSRID(ST_GeomFromText('POLYGON((2 48, 4 48, 4 50, 2 50, 2 48))'), 4326))
+            )
+            SQL);
+
+        $response = $this->client->request('GET', \sprintf('/trips/%s/detail', self::TRIP_ID), [
+            'headers' => array_merge(['Accept' => 'application/ld+json'], $this->authHeader($this->jwtToken)),
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertTrue($response->toArray(false)['outOfZone']);
     }
 
     #[Test]

--- a/api/tests/Functional/TripDetailTest.php
+++ b/api/tests/Functional/TripDetailTest.php
@@ -77,6 +77,9 @@ final class TripDetailTest extends ApiTestCase
         $this->assertArrayHasKey('stages', $data);
         $this->assertArrayHasKey('fatigueFactor', $data);
         $this->assertArrayHasKey('enabledAccommodationTypes', $data);
+        // Coverage polygon is unprovisioned in the test DB, so a valid trip is in zone.
+        $this->assertArrayHasKey('outOfZone', $data);
+        $this->assertFalse($data['outOfZone']);
         $this->assertNotEmpty($data['stages']);
         $stage = $data['stages'][0];
         $this->assertArrayHasKey('dayNumber', $stage);

--- a/api/tests/Integration/Osm/CoverageIndexReadTest.php
+++ b/api/tests/Integration/Osm/CoverageIndexReadTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Osm;
+
+use App\Osm\CoverageRepository;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * Integration coverage for the local-first coverage-polygon read layer (ADR-040):
+ * seeds the single-row osm.coverage table and asserts the ST_Covers out-of-zone
+ * test the API uses to flag display-only trips, including the "unknown coverage"
+ * fallbacks (empty table / NULL geom) that must never block the user.
+ */
+final class CoverageIndexReadTest extends KernelTestCase
+{
+    use ResetDatabase;
+
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get('doctrine.dbal.default_connection');
+        $this->connection = $connection;
+
+        // A 2x2 square around (2..4 lon, 48..50 lat): the provisioned coverage area.
+        $this->seedCoverage("ST_GeomFromText('MULTIPOLYGON(((2 48, 4 48, 4 50, 2 50, 2 48)))')");
+    }
+
+    private function seedCoverage(string $geomExpr): void
+    {
+        $this->connection->executeStatement('TRUNCATE osm.coverage');
+        $this->connection->executeStatement(\sprintf(
+            'INSERT INTO osm.coverage (geom) VALUES (ST_Multi(ST_SetSRID(%s, 4326)))',
+            $geomExpr,
+        ));
+    }
+
+    #[Test]
+    public function routeFullyInsideCoverageIsInZone(): void
+    {
+        $repository = new CoverageRepository($this->connection);
+
+        self::assertFalse($repository->isRouteOutOfZone([
+            ['lat' => 48.5, 'lon' => 2.5],
+            ['lat' => 49.0, 'lon' => 3.0],
+            ['lat' => 49.5, 'lon' => 3.5],
+        ]));
+    }
+
+    #[Test]
+    public function routeLeavingCoverageIsOutOfZone(): void
+    {
+        $repository = new CoverageRepository($this->connection);
+
+        // Starts inside, ends well outside the square.
+        self::assertTrue($repository->isRouteOutOfZone([
+            ['lat' => 48.5, 'lon' => 2.5],
+            ['lat' => 48.5, 'lon' => 10.0],
+        ]));
+    }
+
+    #[Test]
+    public function singlePointOutsideCoverageIsOutOfZone(): void
+    {
+        self::assertTrue(new CoverageRepository($this->connection)->isRouteOutOfZone([
+            ['lat' => 0.0, 'lon' => 0.0],
+        ]));
+    }
+
+    #[Test]
+    public function emptyRouteIsNeverOutOfZone(): void
+    {
+        self::assertFalse(new CoverageRepository($this->connection)->isRouteOutOfZone([]));
+    }
+
+    #[Test]
+    public function unprovisionedCoverageIsNeverOutOfZone(): void
+    {
+        // No coverage row at all (index never provisioned): unknown coverage must
+        // not flag an otherwise valid trip as out of zone.
+        $this->connection->executeStatement('TRUNCATE osm.coverage');
+
+        self::assertFalse(new CoverageRepository($this->connection)->isRouteOutOfZone([
+            ['lat' => 0.0, 'lon' => 0.0],
+        ]));
+    }
+
+    #[Test]
+    public function nullCoverageGeometryIsNeverOutOfZone(): void
+    {
+        // A coverage row with NULL geom (ST_Union over zero boundaries) is also
+        // treated as unknown.
+        $this->connection->executeStatement('TRUNCATE osm.coverage');
+        $this->connection->executeStatement('INSERT INTO osm.coverage (geom) VALUES (NULL)');
+
+        self::assertFalse(new CoverageRepository($this->connection)->isRouteOutOfZone([
+            ['lat' => 0.0, 'lon' => 0.0],
+        ]));
+    }
+}

--- a/api/tests/Unit/State/TripShareShortCodeProviderTest.php
+++ b/api/tests/Unit/State/TripShareShortCodeProviderTest.php
@@ -60,6 +60,7 @@ final class TripShareShortCodeProviderTest extends TestCase
             departureHour: 8,
             enabledAccommodationTypes: [],
             isLocked: false,
+            outOfZone: false,
             stages: [],
         );
         $this->tripDetailProvider->expects($this->once())->method('provide')->willReturn($detail);


### PR DESCRIPTION
## Contexte

Dernière brique du plan local-first PostGIS (ADR-040) : la détection **hors-zone**, consommatrice du polygone de couverture livré en #688. Découpée en backend (cette PR) puis frontend.

## Changements (backend)

- **`CoverageRepository`** (`App\Osm`, + interface) : `isRouteOutOfZone(points)` teste la route contre `osm.coverage` via `ST_Covers`. `true` si la route sort (même partiellement) de la zone provisionnée → pas de tuiles Valhalla → trip en affichage seul. **Couverture inconnue** (index non provisionné / `geom` NULL / 0 point) → jamais hors-zone : un index manquant ne bloque jamais l'utilisateur.
- **`TripDetail`** : nouveau booléen `outOfZone` dans la réponse `/trips/{id}/detail` (source d'hydratation du store front).
- **`TripDetailProvider`** : aplatit les géométries d'étapes (fallback start/end) → appel repo → `outOfZone`.

Wiring DI : alias auto (implémentation unique), comme `AdminBoundaryRepositoryInterface`.

## Tests

- `CoverageIndexReadTest` (intégration PostGIS) : route dans/hors zone, point seul hors zone, route vide, couverture non provisionnée, `geom` NULL.
- `TripDetailTest` : `outOfZone` présent et `false` (couverture non provisionnée en DB de test).

## Suite (PR frontend dédiée)

Consommation du flag : notice non bloquante dans l'aperçu + désactivation des actions d'édition Valhalla (split/merge via `TripChatProcessor`, ajout POI waypoint via `StagePoiWaypointProcessor`) + **régénération typegen** (`make typegen`, le champ `outOfZone` n'est pas encore dans `schema.d.ts`) + E2E. typegen est volontairement différé à cette PR consommatrice.

<!-- claude-review-start -->
## Claude Review

The `routePoints()` fallback (empty geometry → start/end endpoints) is now covered end-to-end by `detailFlagsOutOfZoneFromStageEndpointsWhenGeometryIsEmpty`. The SQL logic, WKT serialization, all three null-safety fallbacks, and the provider wiring are correct. No new findings.

**Commit reviewed:** `bfd0021`

**Resolved 1 previously open thread** (fallback path coverage — addressed by the new functional test in `TripDetailTest`).

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Inline comments

No inline comments.
<!-- claude-review-end -->