### PR TITLE
feat(pwa): surface out-of-zone trips (notice + edit-action gating)

### DIFF
--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -422,6 +422,10 @@
   "tripLocked": {
     "banner": "This trip is underway or has passed — view only. Use \"Duplicate\" to plan a new variant."
   },
+  "outOfZone": {
+    "banner": "This route lies outside our covered area (France, Belgium, Netherlands, Luxembourg). Distances and points of interest are shown, but the trip can't be edited or re-routed.",
+    "editDisabled": "This trip is outside the covered area and can't be edited."
+  },
   "tripList": {
     "title": "My Trips",
     "newTrip": "New trip",

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -422,6 +422,10 @@
   "tripLocked": {
     "banner": "Ce trip est en cours ou passé — consultation uniquement. Utilisez « Dupliquer » pour planifier une nouvelle variante."
   },
+  "outOfZone": {
+    "banner": "Cet itinéraire sort de notre zone couverte (France, Belgique, Pays-Bas, Luxembourg). Les distances et points d'intérêt restent affichés, mais tu ne peux pas modifier ni recalculer ce voyage.",
+    "editDisabled": "Ce voyage est hors zone couverte et ne peut pas être modifié."
+  },
   "tripList": {
     "title": "Mes voyages",
     "newTrip": "Nouveau voyage",

--- a/pwa/src/app/trips/[id]/trip-page.tsx
+++ b/pwa/src/app/trips/[id]/trip-page.tsx
@@ -41,6 +41,7 @@ function TripLoader({ tripId }: { tripId: string }) {
     (s) => s.setEnabledAccommodationTypes,
   );
   const setIsLocked = useTripStore((s) => s.setIsLocked);
+  const setOutOfZone = useTripStore((s) => s.setOutOfZone);
   const clearTrip = useTripStore((s) => s.clearTrip);
 
   useEffect(() => {
@@ -87,6 +88,7 @@ function TripLoader({ tripId }: { tripId: string }) {
           (data.enabledAccommodationTypes ?? []) as AccommodationType[],
         );
         setIsLocked(data.isLocked === true);
+        setOutOfZone(data.outOfZone === true);
 
         // Convert stages to Zustand StageData shape
         const stages: StageData[] = (data.stages ?? []).map((s) => {
@@ -171,6 +173,7 @@ function TripLoader({ tripId }: { tripId: string }) {
     setDepartureHour,
     setEnabledAccommodationTypes,
     setIsLocked,
+    setOutOfZone,
     clearTrip,
   ]);
 

--- a/pwa/src/components/out-of-zone-banner.tsx
+++ b/pwa/src/components/out-of-zone-banner.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { MapPinOff } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+export function OutOfZoneBanner() {
+  const t = useTranslations("outOfZone");
+
+  return (
+    <div
+      role="alert"
+      className="flex items-center gap-2 rounded-md bg-amber-50 border border-amber-200 text-amber-800 dark:bg-amber-900/20 dark:border-amber-800/40 dark:text-amber-300 px-4 py-3 text-sm font-medium"
+      data-testid="out-of-zone-banner"
+    >
+      <MapPinOff className="h-4 w-4 shrink-0" aria-hidden="true" />
+      <span>{t("banner")}</span>
+    </div>
+  );
+}

--- a/pwa/src/components/trip-planner.tsx
+++ b/pwa/src/components/trip-planner.tsx
@@ -15,6 +15,7 @@ import { Loader2, X } from "lucide-react";
 import { CardSelection } from "@/components/card-selection";
 import { GpxDropZone } from "@/components/gpx-drop-zone";
 import { TripLockedBanner } from "@/components/trip-locked-banner";
+import { OutOfZoneBanner } from "@/components/out-of-zone-banner";
 import { TripPreview } from "@/components/trip-preview";
 import { ProcessingProgress } from "@/components/processing-progress";
 import { TripSummary } from "@/components/trip-summary";
@@ -81,6 +82,7 @@ export function TripPlanner({
   const {
     trip,
     isLocked,
+    outOfZone,
     totalDistance,
     totalElevation,
     totalElevationLoss,
@@ -650,6 +652,14 @@ export function TripPlanner({
               </div>
             )}
 
+            {/* Out-of-zone banner — route outside the provisioned coverage area:
+                display-only, no Valhalla rerouting (ADR-040). */}
+            {outOfZone && (
+              <div className="mt-4">
+                <OutOfZoneBanner />
+              </div>
+            )}
+
             <div className="mt-8 space-y-8">
               {/* Summary */}
               <TripSummary
@@ -741,7 +751,7 @@ export function TripPlanner({
                       stages={stages}
                       startDate={startDate}
                       isProcessing={isProcessing}
-                      readOnly={isLocked || !isOnline}
+                      readOnly={isLocked || !isOnline || outOfZone}
                       onDeleteStage={handleDeleteStage}
                       onAddStage={handleAddStage}
                       onInsertRestDay={handleInsertRestDay}
@@ -833,7 +843,7 @@ export function TripPlanner({
           onEbikeModeChange={handleEbikeModeChange}
           onDepartureHourChange={handleDepartureHourChange}
           onAccommodationTypesChange={handleAccommodationTypesChange}
-          readOnly={isLocked || !isOnline}
+          readOnly={isLocked || !isOnline || outOfZone}
           hasTripLoaded={!!trip}
           tripTitle={trip?.title}
           onDuplicate={handleDuplicateTrip}

--- a/pwa/src/hooks/use-trip-planner.ts
+++ b/pwa/src/hooks/use-trip-planner.ts
@@ -72,6 +72,7 @@ export function useTripPlanner() {
     startDate,
     endDate,
     isLocked,
+    outOfZone,
   } = useTripStore(
     useShallow((s) => ({
       trip: s.trip,
@@ -82,6 +83,7 @@ export function useTripPlanner() {
       startDate: s.startDate,
       endDate: s.endDate,
       isLocked: s.isLocked,
+      outOfZone: s.outOfZone,
     })),
   );
 
@@ -672,6 +674,14 @@ export function useTripPlanner() {
   ) {
     if (!tripId) return;
 
+    // Inserting a POI waypoint re-routes the stage via Valhalla, which has no
+    // tiles outside the provisioned coverage area — block it for out-of-zone trips.
+    if (outOfZone) {
+      toast.error(t("outOfZone.editDisabled"));
+
+      return;
+    }
+
     try {
       const ok = await addPoiWaypointToRoute(
         tripId,
@@ -1089,6 +1099,7 @@ export function useTripPlanner() {
   return {
     trip,
     isLocked,
+    outOfZone,
     totalDistance,
     totalElevation,
     totalElevationLoss,

--- a/pwa/src/lib/api/schema.d.ts
+++ b/pwa/src/lib/api/schema.d.ts
@@ -191,11 +191,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /**
-         * Download a stage as GPX or FIT file.
-         * @description Download a stage as GPX or FIT file.
-         */
-        get: operations["api_trips_tripIdstages_index_get"];
+        get?: never;
         put?: never;
         post?: never;
         /**
@@ -230,6 +226,26 @@ export interface paths {
          * @description Select or deselect an accommodation for a stage. Selecting updates stage endPoint and next stage startPoint.
          */
         patch: operations["api_trips_tripIdstages_indexaccommodation_patch"];
+        trace?: never;
+    };
+    "/trips/{tripId}/stages/{index}/export": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Download a stage as GPX or FIT file.
+         * @description Download a stage as GPX or FIT file.
+         */
+        get: operations["api_trips_tripIdstages_indexexport_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
         trace?: never;
     };
     "/trips/{tripId}/stages/{index}/move": {
@@ -344,8 +360,8 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Download the full trip as a single GPX file containing all stages.
-         * @description Download the full trip as a single GPX file containing all stages.
+         * Download the full trip as a single GPX or FIT file containing all stages.
+         * @description Download the full trip as a single GPX or FIT file containing all stages.
          */
         get: operations["api_trips_id_get"];
         put?: never;
@@ -496,6 +512,26 @@ export interface paths {
          * @description View a shared trip via short code (anonymous).
          */
         get: operations["api_s_shortCode_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/s/{shortCode}.fit": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Download shared trip as FIT via short code.
+         * @description Download shared trip as FIT via short code.
+         */
+        get: operations["api_s_shortCode.fit_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1293,6 +1329,14 @@ export interface components {
             title?: string | null;
             readonly aiOverview?: components["schemas"]["TripAiOverview"] | null;
         };
+        "Trip.fit": {
+            id?: string;
+            /** @description Map of ComputationName->value to status string */
+            computationStatus?: {
+                [key: string]: string;
+            };
+            isLocked?: boolean;
+        };
         "Trip.gpx": {
             id?: string;
             /** @description Map of ComputationName->value to status string */
@@ -1386,6 +1430,8 @@ export interface components {
             departureHour?: number;
             enabledAccommodationTypes?: string[];
             isLocked?: boolean;
+            /** @description True when the route falls outside the provisioned coverage area: the trip is display-only (no Valhalla rerouting). */
+            outOfZone?: boolean;
             /** @description Serialized stage DTOs */
             stages?: {
                 dayNumber?: number;
@@ -1522,6 +1568,14 @@ export interface components {
             elevationLoss?: number;
             isRestDay?: boolean;
         };
+        "TripShare.Trip.fit": {
+            id?: string;
+            /** @description Map of ComputationName->value to status string */
+            computationStatus?: {
+                [key: string]: string;
+            };
+            isLocked?: boolean;
+        };
         "TripShare.Trip.gpx": {
             id?: string;
             /** @description Map of ComputationName->value to status string */
@@ -1546,6 +1600,8 @@ export interface components {
             departureHour?: number;
             enabledAccommodationTypes?: string[];
             isLocked?: boolean;
+            /** @description True when the route falls outside the provisioned coverage area: the trip is display-only (no Valhalla rerouting). */
+            outOfZone?: boolean;
             /** @description Serialized stage DTOs */
             stages?: {
                 dayNumber?: number;
@@ -2097,54 +2153,6 @@ export interface operations {
             };
         };
     };
-    api_trips_tripIdstages_index_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Stage identifier */
-                tripId: string;
-                /** @description Stage identifier */
-                index: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Stage resource */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/gpx+xml": components["schemas"]["Stage.gpx"];
-                    "application/vnd.ant.fit": components["schemas"]["Stage.fit"];
-                };
-            };
-            /** @description Forbidden */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/ld+json": components["schemas"]["Error.jsonld"];
-                    "application/problem+json": components["schemas"]["Error"];
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/ld+json": components["schemas"]["Error.jsonld"];
-                    "application/problem+json": components["schemas"]["Error"];
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-        };
-    };
     api_trips_tripIdstages_index_delete: {
         parameters: {
             query?: never;
@@ -2334,6 +2342,54 @@ export interface operations {
                     "application/ld+json": components["schemas"]["ConstraintViolation.jsonld"];
                     "application/problem+json": components["schemas"]["ConstraintViolation"];
                     "application/json": components["schemas"]["ConstraintViolation"];
+                };
+            };
+        };
+    };
+    api_trips_tripIdstages_indexexport_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Stage identifier */
+                tripId: string;
+                /** @description Stage identifier */
+                index: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Stage resource */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/gpx+xml": components["schemas"]["Stage.gpx"];
+                    "application/vnd.ant.fit": components["schemas"]["Stage.fit"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["Error.jsonld"];
+                    "application/problem+json": components["schemas"]["Error"];
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["Error.jsonld"];
+                    "application/problem+json": components["schemas"]["Error"];
+                    "application/json": components["schemas"]["Error"];
                 };
             };
         };
@@ -2743,6 +2799,7 @@ export interface operations {
                 };
                 content: {
                     "application/gpx+xml": components["schemas"]["Trip.gpx"];
+                    "application/vnd.ant.fit": components["schemas"]["Trip.fit"];
                 };
             };
             /** @description Forbidden */
@@ -3236,6 +3293,17 @@ export interface operations {
                     "application/ld+json": components["schemas"]["TripDetail.jsonld"];
                 };
             };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["Error.jsonld"];
+                    "application/problem+json": components["schemas"]["Error"];
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not found */
             404: {
                 headers: {
@@ -3268,6 +3336,51 @@ export interface operations {
                 };
                 content: {
                     "application/ld+json": components["schemas"]["TripShare.TripDetail.jsonld"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["Error.jsonld"];
+                    "application/problem+json": components["schemas"]["Error"];
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["Error.jsonld"];
+                    "application/problem+json": components["schemas"]["Error"];
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    "api_s_shortCode.fit_get": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description TripShare identifier */
+                shortCode: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description TripShare resource */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/vnd.ant.fit": components["schemas"]["TripShare.Trip.fit"];
                 };
             };
             /** @description Forbidden */

--- a/pwa/src/store/trip-store.test.ts
+++ b/pwa/src/store/trip-store.test.ts
@@ -111,6 +111,28 @@ describe("getUndoableSlice", () => {
   });
 });
 
+describe("outOfZone", () => {
+  it("defaults to false", () => {
+    useTripStore.getState().clearTrip();
+    expect(useTripStore.getState().outOfZone).toBe(false);
+  });
+
+  it("is set and reset by setOutOfZone", () => {
+    const store = useTripStore.getState();
+    store.setOutOfZone(true);
+    expect(useTripStore.getState().outOfZone).toBe(true);
+    store.setOutOfZone(false);
+    expect(useTripStore.getState().outOfZone).toBe(false);
+  });
+
+  it("is reset to false by clearTrip", () => {
+    const store = useTripStore.getState();
+    store.setOutOfZone(true);
+    store.clearTrip();
+    expect(useTripStore.getState().outOfZone).toBe(false);
+  });
+});
+
 describe("selectedStageIndex (master/detail)", () => {
   it("defaults to 0", () => {
     useTripStore.getState().clearTrip();

--- a/pwa/src/store/trip-store.ts
+++ b/pwa/src/store/trip-store.ts
@@ -47,6 +47,8 @@ interface TripIdentity {
 interface TripState {
   trip: TripIdentity | null;
   isLocked: boolean;
+  /** Route falls outside the provisioned coverage area: display-only (no Valhalla rerouting). */
+  outOfZone: boolean;
   totalDistance: number | null;
   totalElevation: number | null;
   totalElevationLoss: number | null;
@@ -161,6 +163,7 @@ interface TripState {
   setEnabledAccommodationTypes: (types: AccommodationType[]) => void;
   setComputationStatus: (status: Record<string, string>) => void;
   setIsLocked: (isLocked: boolean) => void;
+  setOutOfZone: (outOfZone: boolean) => void;
   deleteStage: (stageIndex: number) => void;
   insertRestDay: (afterIndex: number) => void;
   /** Optimistically inserts a stage placeholder at `afterIndex + 1`. Undoable. */
@@ -250,6 +253,7 @@ interface TripState {
 const initialState = {
   trip: null,
   isLocked: false,
+  outOfZone: false,
   totalDistance: null,
   totalElevation: null,
   totalElevationLoss: null,
@@ -540,6 +544,11 @@ export const useTripStore = create<TripState>()(
     setIsLocked: (isLocked) =>
       set((state) => {
         state.isLocked = isLocked;
+      }),
+
+    setOutOfZone: (outOfZone) =>
+      set((state) => {
+        state.outOfZone = outOfZone;
       }),
 
     deleteStage: (stageIndex) => {

--- a/pwa/tests/mocked/trip-out-of-zone.spec.ts
+++ b/pwa/tests/mocked/trip-out-of-zone.spec.ts
@@ -1,0 +1,110 @@
+import { test, expect } from "../fixtures/base.fixture";
+import type { Page } from "@playwright/test";
+import { fullTripEventSequence } from "../fixtures/mock-data";
+
+async function mockOutOfZoneTrip(page: Page, tripId: string): Promise<void> {
+  await page.route("**/trips", async (route, request) => {
+    if (request.method() !== "POST") return route.fallback();
+    return route.fulfill({
+      status: 202,
+      contentType: "application/ld+json",
+      body: JSON.stringify({
+        "@context": "/contexts/Trip",
+        "@id": `/trips/${tripId}`,
+        "@type": "Trip",
+        id: tripId,
+        computationStatus: {},
+      }),
+    });
+  });
+
+  // The detail endpoint carries outOfZone; TripLoader restores it into the store.
+  await page.route("**/trips/*/detail", async (route, request) => {
+    if (request.method() !== "GET") return route.fallback();
+    return route.fulfill({
+      status: 200,
+      contentType: "application/ld+json",
+      body: JSON.stringify({
+        "@context": "/contexts/TripDetail",
+        "@id": `/trips/${tripId}/detail`,
+        "@type": "TripDetail",
+        id: tripId,
+        title: "Test Trip",
+        sourceUrl: "https://www.komoot.com/fr-fr/tour/2795080048",
+        startDate: null,
+        endDate: null,
+        fatigueFactor: 0.8,
+        elevationPenalty: 100,
+        maxDistancePerDay: 80,
+        averageSpeed: 15,
+        ebikeMode: false,
+        departureHour: 8,
+        enabledAccommodationTypes: [
+          "camp_site",
+          "hotel",
+          "hostel",
+          "chalet",
+          "guest_house",
+          "motel",
+          "alpine_hut",
+        ],
+        isLocked: false,
+        outOfZone: true,
+        stages: [],
+        computationStatus: {},
+      }),
+    });
+  });
+}
+
+test.describe("Out-of-zone trips", () => {
+  test("shows the out-of-zone banner and hides edit controls when outOfZone is true", async ({
+    mockedPage,
+    injectSequence,
+  }) => {
+    await mockOutOfZoneTrip(mockedPage, "out-of-zone-1");
+
+    const input = mockedPage.getByTestId("magic-link-input");
+    await input.fill("https://www.komoot.com/fr-fr/tour/2795080048");
+    await input.press("Enter");
+    await mockedPage.waitForURL(/\/trips\//, { timeout: 5000 });
+    await expect(
+      mockedPage
+        .getByTestId("trip-title-skeleton")
+        .or(mockedPage.getByTestId("trip-title")),
+    ).toBeVisible({ timeout: 5000 });
+
+    await injectSequence(fullTripEventSequence());
+    await expect(mockedPage.getByTestId("stage-card-3")).toBeVisible({
+      timeout: 10000,
+    });
+
+    // Out-of-zone banner should be visible
+    await expect(mockedPage.getByTestId("out-of-zone-banner")).toBeVisible();
+
+    // Edit controls (which depend on Valhalla rerouting) should be hidden
+    await expect(mockedPage.getByTestId("delete-stage-1")).not.toBeVisible();
+    await expect(
+      mockedPage.getByTestId("add-stage-button-0"),
+    ).not.toBeVisible();
+    await expect(
+      mockedPage.getByTestId("add-rest-day-button-0"),
+    ).not.toBeVisible();
+  });
+
+  test("does not show the out-of-zone banner when outOfZone is false", async ({
+    createFullTrip,
+    mockedPage,
+  }) => {
+    await createFullTrip();
+
+    // Default mock does not set outOfZone → banner should be absent
+    await expect(
+      mockedPage.getByTestId("out-of-zone-banner"),
+    ).not.toBeVisible();
+
+    // Edit controls should be available
+    await expect(mockedPage.getByTestId("delete-stage-1")).toBeVisible();
+    await expect(mockedPage.getByTestId("add-stage-button-0")).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Contexte

Dernière brique du plan local-first PostGIS (ADR-040) : consommation côté PWA du flag `outOfZone` exposé par le backend (#689).

## Changements

- **Store Zustand** : nouvel état `outOfZone` + setter, en miroir d'`isLocked` (reset par `clearTrip`).
- **Hydratation** (`trip-page.tsx`) : `setOutOfZone(data.outOfZone === true)` depuis `/trips/{id}/detail`.
- **Notice** : `OutOfZoneBanner` (non bloquante, calquée sur `TripLockedBanner`) affichée sur la page voyage quand `outOfZone`.
- **Gating** : `readOnly={isLocked || !isOnline || outOfZone}` sur le roadbook et le panneau de config → désactive split/merge/ajout d'étape/jour de repos/distance/hébergement. `handleAddPoiWaypoint` (reroutage Valhalla) bloqué avec toast quand hors-zone (defense-in-depth).
- **i18n** : clés `outOfZone.{banner,editDisabled}` (en + fr, tutoiement).
- **typegen** : `schema.d.ts` régénéré. Au-delà d'`outOfZone`, ça rattrape une dérive **préexistante** (endpoints FIT `/export` + `.fit` partagés dont les types n'avaient jamais été régénérés) — le hook interdit l'édition manuelle, donc régénération complète.

## Tests

- `trip-store.test.ts` : défaut `false`, set/reset, reset par `clearTrip` (10/10 verts en local).
- `tests/mocked/trip-out-of-zone.spec.ts` (E2E) : bannière visible + contrôles d'édition masqués quand `outOfZone: true` ; absente sinon.
- Local : vitest store ✓, ESLint ✓ sur les fichiers touchés, i18n parité en/fr ✓. tsc/prettier/Playwright via CI (worktree sans node_modules complet).

## Clôture

Termine la migration local-first PostGIS : OSM + DataTourisme importés, zéro dépendance tierce runtime, polygone de couverture + monitoring (#688), détection + UI hors-zone (#689 + celle-ci).

<!-- claude-review-start -->
## Claude Review

Clean, well-scoped implementation. The `outOfZone` flag mirrors `isLocked` faithfully across store, hydration, banner, gating, i18n, and tests. No correctness, security, performance, or architecture issues found.

Reviewed commit: `1c583a80d1da0b108cda91d0cc7f5b56f5cd7bb4`

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

No inline comments. No previously open threads to resolve.
<!-- claude-review-end -->