### PR TITLE
feat(provisioner): import DataTourisme food layer into tourism.food_pois

### DIFF
--- a/api/migrations/Version20260616140000.php
+++ b/api/migrations/Version20260616140000.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Adds tourism.food_pois (ADR-040): the DataTourisme food layer — eateries
+ * (FoodEstablishment: restaurants, bars, cafes, fast food, bakeries) and food
+ * shops (Store subtypes Bakery / LocalProductsShop) — imported by the
+ * provisioner alongside the existing cultural_pois. It feeds the resupply
+ * consumer (ScanPoisHandler / supply timeline), merged with the OSM pois by
+ * proximity + name in a follow-up read-side slice.
+ *
+ * Same shape as tourism.cultural_pois; the DataTourisme `@id` URI is the primary
+ * key so daily refreshes upsert in place. Bootstraps the table for the first
+ * provisioning run and the functional tests.
+ */
+final class Version20260616140000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add tourism.food_pois (DataTourisme eateries + food shops) for local-first resupply reads';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE SCHEMA IF NOT EXISTS tourism');
+
+        $this->addSql(<<<'SQL'
+            CREATE TABLE IF NOT EXISTS tourism.food_pois (
+                id text NOT NULL,
+                name text,
+                category text NOT NULL,
+                opening_hours text,
+                description text,
+                wikidata text,
+                tags jsonb,
+                geom geometry(Point, 4326) NOT NULL,
+                PRIMARY KEY (id)
+            )
+            SQL);
+        $this->addSql('CREATE INDEX IF NOT EXISTS food_pois_geom_idx ON tourism.food_pois USING gist (geom)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE IF EXISTS tourism.food_pois');
+    }
+}

--- a/provisioner/src/DataTourismeImporter.php
+++ b/provisioner/src/DataTourismeImporter.php
@@ -45,12 +45,14 @@ final readonly class DataTourismeImporter
      */
     private const array TABLE_COLUMNS = [
         'cultural_pois' => ['id', 'name', 'category', 'opening_hours', 'description', 'wikidata', 'tags', 'geom'],
+        'food_pois' => ['id', 'name', 'category', 'opening_hours', 'description', 'wikidata', 'tags', 'geom'],
         'accommodations' => ['id', 'name', 'category', 'capacity', 'price', 'description', 'tags', 'geom'],
         'events' => ['id', 'name', 'category', 'start_date', 'end_date', 'url', 'description', 'price_min', 'tags', 'geom'],
     ];
 
     private const array STAGING_DDL = [
         'cultural_pois' => 'id text NOT NULL PRIMARY KEY, name text, category text NOT NULL, opening_hours text, description text, wikidata text, tags jsonb, geom geometry(Point, 4326) NOT NULL',
+        'food_pois' => 'id text NOT NULL PRIMARY KEY, name text, category text NOT NULL, opening_hours text, description text, wikidata text, tags jsonb, geom geometry(Point, 4326) NOT NULL',
         'accommodations' => 'id text NOT NULL PRIMARY KEY, name text, category text NOT NULL, capacity int, price numeric(10, 2), description text, tags jsonb, geom geometry(Point, 4326) NOT NULL',
         'events' => 'id text NOT NULL PRIMARY KEY, name text, category text NOT NULL, start_date date, end_date date, url text, description text, price_min numeric(10, 2), tags jsonb, geom geometry(Point, 4326) NOT NULL',
     ];
@@ -152,7 +154,7 @@ final readonly class DataTourismeImporter
             $files[$table] = $path;
         }
 
-        $heads = ['cultural' => 'cultural_pois', 'accommodation' => 'accommodations', 'event' => 'events'];
+        $heads = ['cultural' => 'cultural_pois', 'food' => 'food_pois', 'accommodation' => 'accommodations', 'event' => 'events'];
 
         for ($i = 0, $n = $zip->numFiles; $i < $n; ++$i) {
             $name = $zip->getNameIndex($i);
@@ -204,7 +206,7 @@ final readonly class DataTourismeImporter
         $tags = json_encode(['type' => $row['type']], \JSON_UNESCAPED_UNICODE | \JSON_UNESCAPED_SLASHES) ?: '{}';
 
         $values = match ($table) {
-            'cultural_pois' => [$row['id'], $row['name'], $row['category'], $row['openingHours'], $row['description'], $row['wikidata'], $tags, $geom],
+            'cultural_pois', 'food_pois' => [$row['id'], $row['name'], $row['category'], $row['openingHours'], $row['description'], $row['wikidata'], $tags, $geom],
             'accommodations' => [$row['id'], $row['name'], $row['category'], $row['capacity'], $row['price'], $row['description'], $tags, $geom],
             'events' => [$row['id'], $row['name'], $row['category'], $row['startDate'], $row['endDate'], null, $row['description'], $row['price'], $tags, $geom],
             default => [],

--- a/provisioner/src/DataTourismeImporter.php
+++ b/provisioner/src/DataTourismeImporter.php
@@ -39,7 +39,8 @@ final readonly class DataTourismeImporter
 
     /**
      * Target tables and their COPY column order. `geom` always comes last and is
-     * fed EWKT. Must match Version20260616120000 (the live-schema bootstrap).
+     * fed EWKT. Must match Version20260616120000 / Version20260616140000 (the
+     * live-schema bootstraps).
      *
      * @var array<string, list<string>>
      */

--- a/provisioner/src/DataTourismeMapper.php
+++ b/provisioner/src/DataTourismeMapper.php
@@ -15,7 +15,7 @@ namespace Provisioner;
  * runtime REST API shape, so this is a flux-specific mapper. The raw type list
  * is preserved in the row's tags so nothing is lost.
  *
- * @phpstan-type Row array{head: 'cultural'|'accommodation'|'event', id: string, name: string|null, category: string, lat: float, lon: float, description: string|null, openingHours: string|null, wikidata: string|null, capacity: int|null, price: float|null, startDate: string|null, endDate: string|null, type: list<string>}
+ * @phpstan-type Row array{head: 'cultural'|'accommodation'|'event'|'food', id: string, name: string|null, category: string, lat: float, lon: float, description: string|null, openingHours: string|null, wikidata: string|null, capacity: int|null, price: float|null, startDate: string|null, endDate: string|null, type: list<string>}
  */
 final class DataTourismeMapper
 {
@@ -43,6 +43,28 @@ final class DataTourismeMapper
         'ParkAndGarden' => 'viewpoint', 'Forest' => 'viewpoint', 'Beach' => 'viewpoint', 'Lake' => 'viewpoint',
         'Dune' => 'viewpoint', 'Glacier' => 'viewpoint', 'CaveSinkholeOrAven' => 'viewpoint', 'Source' => 'viewpoint',
     ];
+
+    /**
+     * Food establishment / food shop subtype (unprefixed ontology type) → app
+     * resupply category (must stay within ScanPoisHandler::RESUPPLY_CATEGORIES).
+     */
+    private const array FOOD_CATEGORY = [
+        'FastFoodRestaurant' => 'fast_food', 'StreetFood' => 'fast_food',
+        'BarOrPub' => 'bar', 'BistroOrWineBar' => 'bar',
+        'CafeOrTeahouse' => 'cafe',
+        'Bakery' => 'bakery',
+        'Restaurant' => 'restaurant', 'GourmetRestaurant' => 'restaurant',
+        'BrasserieOrTavern' => 'restaurant', 'FarmhouseInn' => 'restaurant',
+        'LocalProductsShop' => 'farm',
+    ];
+
+    /**
+     * Store subtypes that are food/resupply relevant. A `Store` without one of
+     * these is skipped: DataTourisme tags many non-food businesses as Store
+     * (boutiques, craftsmen, parking, taxis, tourist offices), which carry no
+     * resupply value and would pollute the supply timeline.
+     */
+    private const array FOOD_STORE_TYPES = ['Bakery', 'LocalProductsShop'];
 
     /** Event subtype (unprefixed ontology type) → app event category. */
     private const array EVENT_CATEGORY = [
@@ -104,7 +126,7 @@ final class DataTourismeMapper
     /**
      * @param list<string> $types
      *
-     * @return array{'cultural'|'accommodation'|'event'|null, string}
+     * @return array{'cultural'|'accommodation'|'event'|'food'|null, string}
      */
     private function classify(array $types): array
     {
@@ -113,12 +135,22 @@ final class DataTourismeMapper
             return ['event', $this->resolve($types, self::EVENT_CATEGORY, 'event')];
         }
 
+        // Accommodation before food: a HotelRestaurant is primarily lodging.
         if (\in_array('Accommodation', $types, true)) {
             return ['accommodation', $this->resolve($types, self::ACCOMMODATION_CATEGORY, 'apartment')];
         }
 
         if (\in_array('CulturalSite', $types, true) || \in_array('NaturalHeritage', $types, true)) {
             return ['cultural', $this->resolve($types, self::CULTURAL_CATEGORY, 'attraction')];
+        }
+
+        // Eateries (any FoodEstablishment) and food shops (Store with a food subtype).
+        if (\in_array('FoodEstablishment', $types, true)) {
+            return ['food', $this->resolve($types, self::FOOD_CATEGORY, 'restaurant')];
+        }
+
+        if (\in_array('Store', $types, true) && [] !== array_intersect(self::FOOD_STORE_TYPES, $types)) {
+            return ['food', $this->resolve($types, self::FOOD_CATEGORY, 'general')];
         }
 
         return [null, ''];

--- a/provisioner/tests/DataTourismeImporterTest.php
+++ b/provisioner/tests/DataTourismeImporterTest.php
@@ -81,6 +81,14 @@ final class DataTourismeImporterTest extends TestCase
                 'rdfs:label' => ['fr' => ['Resto test']],
                 'isLocatedAt' => [['schema:geo' => ['schema:latitude' => '44.0', 'schema:longitude' => '4.0']]],
             ]),
+            // Food shop (Store + LocalProductsShop) → also the food head, exercising
+            // the Store branch end-to-end through the COPY pipeline.
+            $this->place('objects/0/00/farm.json', [
+                '@id' => 'https://data.datatourisme.fr/10/farm',
+                '@type' => ['LocalProductsShop', 'Store'],
+                'rdfs:label' => ['fr' => ['Épicerie locale']],
+                'isLocatedAt' => [['schema:geo' => ['schema:latitude' => '43.5', 'schema:longitude' => '3.5']]],
+            ]),
             // Non-food store → still skipped, not written to any COPY file.
             $this->place('objects/0/00/shop.json', [
                 '@id' => 'https://data.datatourisme.fr/10/shop',
@@ -171,11 +179,15 @@ final class DataTourismeImporterTest extends TestCase
         $accommodations = (string) file_get_contents($this->workDir.'/tourism-accommodations.copy');
 
         self::assertSame(1, substr_count($cultural, "\n"), 'one cultural row');
-        self::assertSame(1, substr_count($food, "\n"), 'one food row (the eatery)');
+        self::assertSame(2, substr_count($food, "\n"), 'two food rows (eatery + food store)');
         self::assertSame(1, substr_count($events, "\n"), 'one event row');
         self::assertSame('', $accommodations, 'no accommodation in the fixture');
 
-        // The eatery lands in food_pois (with its category) and the non-food store is skipped.
+        // The eatery (restaurant) and the food store (LocalProductsShop → farm) both
+        // land in food_pois; the non-food store is skipped.
+        self::assertStringContainsString('restaurant', $food);
+        self::assertStringContainsString('farm', $food);
+        self::assertStringContainsString('https://data.datatourisme.fr/10/farm', $food);
         self::assertStringContainsString('SRID=4326;POINT(', $cultural);
         self::assertStringContainsString('https://data.datatourisme.fr/10/cultural', $cultural);
         self::assertStringContainsString('https://data.datatourisme.fr/10/food', $food);

--- a/provisioner/tests/DataTourismeImporterTest.php
+++ b/provisioner/tests/DataTourismeImporterTest.php
@@ -191,7 +191,6 @@ final class DataTourismeImporterTest extends TestCase
         self::assertStringContainsString('SRID=4326;POINT(', $cultural);
         self::assertStringContainsString('https://data.datatourisme.fr/10/cultural', $cultural);
         self::assertStringContainsString('https://data.datatourisme.fr/10/food', $food);
-        self::assertStringContainsString('restaurant', $food);
         self::assertStringContainsString('2026-07-01', $events);
         self::assertStringNotContainsString('food', $cultural.$events);
         self::assertStringNotContainsString('shop', $cultural.$food.$events);

--- a/provisioner/tests/DataTourismeImporterTest.php
+++ b/provisioner/tests/DataTourismeImporterTest.php
@@ -74,12 +74,19 @@ final class DataTourismeImporterTest extends TestCase
                 'schema:endDate' => ['2026-07-03'],
                 'isLocatedAt' => [['schema:geo' => ['schema:latitude' => '45.0', 'schema:longitude' => '5.0']]],
             ]),
-            // Out of scope (food) → must be skipped, not written to any COPY file.
+            // Eatery → mapped to the food head (food_pois COPY file).
             $this->place('objects/0/00/food.json', [
                 '@id' => 'https://data.datatourisme.fr/10/food',
                 '@type' => ['FoodEstablishment', 'Restaurant'],
                 'rdfs:label' => ['fr' => ['Resto test']],
                 'isLocatedAt' => [['schema:geo' => ['schema:latitude' => '44.0', 'schema:longitude' => '4.0']]],
+            ]),
+            // Non-food store → still skipped, not written to any COPY file.
+            $this->place('objects/0/00/shop.json', [
+                '@id' => 'https://data.datatourisme.fr/10/shop',
+                '@type' => ['Store', 'BoutiqueOrLocalShop'],
+                'rdfs:label' => ['fr' => ['Boutique test']],
+                'isLocatedAt' => [['schema:geo' => ['schema:latitude' => '43.0', 'schema:longitude' => '3.0']]],
             ]),
         ];
         foreach ($entries as [$name, $contents]) {
@@ -117,12 +124,13 @@ final class DataTourismeImporterTest extends TestCase
 
         $importer->run($this->workDir);
 
-        // 1 staging DDL + 3 \copy + 3 GIST index + 1 events-date index + 1 metadata + 1 swap.
-        self::assertCount(10, $this->captured);
+        // 1 staging DDL + 4 \copy + 4 GIST index + 1 events-date index + 1 metadata + 1 swap.
+        self::assertCount(12, $this->captured);
 
         $ddl = implode(' ', $this->captured[0]);
         self::assertStringContainsString('CREATE SCHEMA tourism_staging', $ddl);
         self::assertStringContainsString('CREATE TABLE tourism_staging.cultural_pois', $ddl);
+        self::assertStringContainsString('CREATE TABLE tourism_staging.food_pois', $ddl);
         self::assertStringContainsString('CREATE TABLE tourism_staging.events', $ddl);
 
         $joinedAll = array_map(static fn (array $c): string => implode(' ', $c), $this->captured);
@@ -158,18 +166,23 @@ final class DataTourismeImporterTest extends TestCase
         $importer->run($this->workDir);
 
         $cultural = (string) file_get_contents($this->workDir.'/tourism-cultural_pois.copy');
+        $food = (string) file_get_contents($this->workDir.'/tourism-food_pois.copy');
         $events = (string) file_get_contents($this->workDir.'/tourism-events.copy');
         $accommodations = (string) file_get_contents($this->workDir.'/tourism-accommodations.copy');
 
         self::assertSame(1, substr_count($cultural, "\n"), 'one cultural row');
+        self::assertSame(1, substr_count($food, "\n"), 'one food row (the eatery)');
         self::assertSame(1, substr_count($events, "\n"), 'one event row');
         self::assertSame('', $accommodations, 'no accommodation in the fixture');
 
-        // The geometry column carries EWKT and the food POI was skipped.
+        // The eatery lands in food_pois (with its category) and the non-food store is skipped.
         self::assertStringContainsString('SRID=4326;POINT(', $cultural);
         self::assertStringContainsString('https://data.datatourisme.fr/10/cultural', $cultural);
+        self::assertStringContainsString('https://data.datatourisme.fr/10/food', $food);
+        self::assertStringContainsString('restaurant', $food);
         self::assertStringContainsString('2026-07-01', $events);
         self::assertStringNotContainsString('food', $cultural.$events);
+        self::assertStringNotContainsString('shop', $cultural.$food.$events);
     }
 
     #[Test]

--- a/provisioner/tests/DataTourismeMapperTest.php
+++ b/provisioner/tests/DataTourismeMapperTest.php
@@ -110,11 +110,66 @@ final class DataTourismeMapperTest extends TestCase
     }
 
     #[Test]
+    public function mapsFoodEstablishmentToTheFoodHead(): void
+    {
+        $restaurant = $this->mapper->map($this->object(['schema:FoodEstablishment', 'schema:Restaurant', 'FoodEstablishment', 'Restaurant']));
+        self::assertNotNull($restaurant);
+        self::assertSame('food', $restaurant['head']);
+        self::assertSame('restaurant', $restaurant['category']);
+
+        $bar = $this->mapper->map($this->object(['FoodEstablishment', 'BarOrPub']));
+        self::assertNotNull($bar);
+        self::assertSame('food', $bar['head']);
+        self::assertSame('bar', $bar['category']);
+
+        $fastFood = $this->mapper->map($this->object(['FastFoodRestaurant', 'FoodEstablishment', 'Restaurant']));
+        self::assertNotNull($fastFood);
+        self::assertSame('fast_food', $fastFood['category']);
+
+        // A bare FoodEstablishment with no known subtype defaults to restaurant.
+        $bare = $this->mapper->map($this->object(['FoodEstablishment', 'PlaceOfInterest']));
+        self::assertNotNull($bare);
+        self::assertSame('restaurant', $bare['category']);
+    }
+
+    #[Test]
+    public function mapsFoodShopsButSkipsNonFoodStores(): void
+    {
+        // A bakery shop (Store + Bakery) and a local-products shop are resupply-relevant.
+        $bakery = $this->mapper->map($this->object(['Bakery', 'BoutiqueOrLocalShop', 'FoodEstablishment', 'Store']));
+        self::assertNotNull($bakery);
+        self::assertSame('food', $bakery['head']);
+        self::assertSame('bakery', $bakery['category']);
+
+        $farm = $this->mapper->map($this->object(['LocalProductsShop', 'Store']));
+        self::assertNotNull($farm);
+        self::assertSame('food', $farm['head']);
+        self::assertSame('farm', $farm['category']);
+
+        // Non-food stores (boutiques, craftsmen, parking, taxis) carry no resupply
+        // value and must be skipped.
+        self::assertNull($this->mapper->map($this->object(['Store', 'BoutiqueOrLocalShop'])));
+        self::assertNull($this->mapper->map($this->object(['Store', 'CraftsmanShop'])));
+        self::assertNull($this->mapper->map($this->object(['Store', 'Parking', 'Transport'])));
+    }
+
+    #[Test]
+    public function classifiesHotelRestaurantAsAccommodationNotFood(): void
+    {
+        // A HotelRestaurant carries both Accommodation and FoodEstablishment; lodging wins.
+        $row = $this->mapper->map($this->object(['Accommodation', 'FoodEstablishment', 'Hotel', 'HotelRestaurant', 'Restaurant']));
+
+        self::assertNotNull($row);
+        self::assertSame('accommodation', $row['head']);
+        self::assertSame('hotel', $row['category']);
+    }
+
+    #[Test]
     public function ignoresUnsupportedCategories(): void
     {
-        // Food establishments and shops are out of the import scope.
-        self::assertNull($this->mapper->map($this->object(['FoodEstablishment', 'Restaurant'])));
-        self::assertNull($this->mapper->map($this->object(['Store', 'BoutiqueOrLocalShop'])));
+        // A type list with no place/event/food head we map is skipped.
+        self::assertNull($this->mapper->map($this->object(['PlaceOfInterest', 'PointOfInterest'])));
+        self::assertNull($this->mapper->map($this->object(['ServiceProvider', 'ActivityProvider'])));
     }
 
     #[Test]

--- a/provisioner/tests/DataTourismeMapperTest.php
+++ b/provisioner/tests/DataTourismeMapperTest.php
@@ -130,6 +130,11 @@ final class DataTourismeMapperTest extends TestCase
         $bare = $this->mapper->map($this->object(['FoodEstablishment', 'PlaceOfInterest']));
         self::assertNotNull($bare);
         self::assertSame('restaurant', $bare['category']);
+
+        // CulturalSite wins over FoodEstablishment (cultural check runs first in classify()).
+        $cultural = $this->mapper->map($this->object(['CulturalSite', 'FoodEstablishment', 'Restaurant']));
+        self::assertNotNull($cultural);
+        self::assertSame('cultural', $cultural['head']);
     }
 
     #[Test]


### PR DESCRIPTION
## Contexte

Première des couches flux différées : la donnée **resto/commerce** DataTourisme, jusqu'ici ignorée à l'import (~110k objets `FoodEstablishment`/`Store` skippés). Import provisioner (cette PR) ; la lecture/dédup côté API (fusion avec `osm.pois` dans `ScanPoisHandler`) suivra en PR dédiée, comme pour les POI culturels (#682 → #683/#684).

## Changements

**`DataTourismeMapper`** (mapping validé sur le flux réel extrait localement)
- Nouveau head `food`. `FoodEstablishment` → restaurant/bar/cafe/fast_food/bakery selon sous-type.
- `Store` importé **uniquement** sur sous-type alimentaire (`Bakery`, `LocalProductsShop`) ; les `Store` non-food (boutiques, artisans, parking, taxis, offices de tourisme) restent ignorés pour ne pas polluer le ravitaillement.
- `HotelRestaurant` reste un hébergement (Accommodation prioritaire sur food).
- Catégories cantonnées au jeu `RESUPPLY_CATEGORIES` du `ScanPoisHandler`.

**`DataTourismeImporter`** : table `food_pois` (même forme que `cultural_pois`) dans TABLE_COLUMNS / STAGING_DDL / `$heads` / `copyLine` ; les métadonnées `/health` l'incluent automatiquement.

**Migration** `Version20260616140000` : bootstrap `tourism.food_pois` (+ index GIST).

## Tests

- `DataTourismeMapperTest` : classification food (eateries + sous-types), shops food vs non-food skippés, HotelRestaurant→accommodation.
- `DataTourismeImporterTest` : eatery → `food_pois` (count psql 10→12), `Store` non-food skippé.
- **59/59 verts en local** (host PHP 8.5).

## Suite

PR2 (lecture) : `DataTourismePoiSource` + `OsmPoiSource` + `PoiSourceRegistry` (dédup proximité+nom via `NearbyNameDeduplicator`, DataTourisme préféré) + refacto `ScanPoisHandler` pour lire le registre au lieu d'`osm.pois` seul.

<!-- claude-review-start -->
## Claude Review

Clean, complete provisioner extension. All new categories (`restaurant`, `cafe`, `bar`, `bakery`, `fast_food`, `farm`, `general`) are confirmed members of `ScanPoisHandler::RESUPPLY_CATEGORIES`; the Event > Accommodation > Cultural > Food priority ordering is correctly implemented and fully covered by dedicated tests; the Store/non-food discrimination is exercised end-to-end through the COPY pipeline. No findings.

**Resolved threads:** Resolved 1 previously open thread (duplicate `restaurant` assertion in the food COPY test — dropped by commit f949ed76).

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

*Reviewed commit: f949ed769a630956b0f30a77ddf3c327736e12c0*
<!-- claude-review-end -->