### PR TITLE
chore(deps): pin hono >=4.12.25 to clear the path-traversal advisory

### DIFF
--- a/pwa/package-lock.json
+++ b/pwa/package-lock.json
@@ -13419,9 +13419,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.21",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.21.tgz",
-      "integrity": "sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ==",
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/pwa/package.json
+++ b/pwa/package.json
@@ -67,6 +67,7 @@
   "overrides": {
     "undici": "^6.24.0",
     "tmp": "^0.2.6",
+    "hono": "^4.12.25",
     "jsdom": {
       "undici": "^7.25.0"
     }


### PR DESCRIPTION
## Problème

`npm audit --audit-level=high` (leg CI `npm audit`) échoue **repo-wide** sur une advisory **high** récemment publiée dans `hono` (path traversal `serve-static` via backslash encodé, + autres — GHSA). Le lockfile résolvait `hono` en 4.12.21 (dépendance transitive).

Indépendant de toute PR feature en cours (#691 ne touche aucune dépendance JS) : ça casse l'audit de toutes les PRs.

## Fix

Override `"hono": "^4.12.25"` (même pattern que `undici`/`tmp` déjà présents) → lock régénéré sur la version patchée 4.12.25. Dans les plages existantes `^4` / `^4.11.4` → **non-breaking**. Diff minimal (override + lock).

Les vulnérabilités restantes (postcss via next, uuid via cucumber) sont **moderate** et ignorées par `--audit-level=high` ; elles relèvent de bumps majeurs (next/lhci) à traiter séparément.

## Vérification

La CI fait foi (mon audit local est faussé par un node_modules de worktree pollué). Le `npm ci` propre de la CI + le leg `npm audit` valideront que la high `hono` est levée.

<!-- claude-review-start -->
## Claude Review

**Summary:** Minimal, well-targeted security patch. The `overrides` approach is consistent with the project's existing pattern (`undici`, `tmp`) and correctly forces the lockfile off the vulnerable `4.12.21` to the patched `4.12.25`. No functional code changes; diff is exactly what it needs to be.

**Findings:** 0 critical · 0 warnings · 0 info

**Commit reviewed:** `6d78236ef2d5a980e86e5f129e72bdcbd21dbc99`

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases *(N/A — dependency pin)*
- [x] Documentation is up to date *(N/A — security patch)*
- [x] Dependent tickets accounted for *(#691 unaffected, acknowledged in PR body)*

No inline comments.
<!-- claude-review-end -->