### PR TITLE
feat(provisioner): import signed cycle routes into osm.cycle_routes

### DIFF
--- a/api/migrations/Version20260616150000.php
+++ b/api/migrations/Version20260616150000.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Adds osm.cycle_routes to the local-first Tier-1 reference schema (ADR-040):
+ * signed cycle route relations (type=route, route=bicycle — EuroVelo, national
+ * (ncn) / regional (rcn) / local (lcn) networks, voies vertes) stored as PostGIS
+ * MultiLineStrings. The API measures how much of each stage follows one (the
+ * "on cycle network" indicator).
+ *
+ * Mirrors the osm2pgsql flex output (provisioner/osm2pgsql/tier1.lua): the
+ * provisioner imports into a staging schema and atomically swaps it onto `osm`.
+ * This migration bootstraps the table so it exists before the first provisioning
+ * run and for the functional tests.
+ */
+final class Version20260616150000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add the osm.cycle_routes reference table (signed cycle networks) for the on-cycle-network indicator';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE SCHEMA IF NOT EXISTS osm');
+
+        $this->addSql(<<<'SQL'
+            CREATE TABLE IF NOT EXISTS osm.cycle_routes (
+                osm_id bigint NOT NULL,
+                name text,
+                network text,
+                ref text,
+                tags jsonb,
+                geom geometry(MultiLineString, 4326) NOT NULL,
+                PRIMARY KEY (osm_id)
+            )
+            SQL);
+
+        $this->addSql('CREATE INDEX IF NOT EXISTS cycle_routes_geom_idx ON osm.cycle_routes USING gist (geom)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE IF EXISTS osm.cycle_routes');
+    }
+}

--- a/provisioner/osm2pgsql/tier1.lua
+++ b/provisioner/osm2pgsql/tier1.lua
@@ -5,8 +5,7 @@
 -- the live `osm` schema atomically. The API reads these tables via ST_DWithin
 -- corridor queries, replacing the runtime Overpass dependency.
 --
--- Scope of this style: pois, accommodations, water_points, bike_shops, health_services, railway_stations, charging_stations, cultural_pois, ways, admin_boundaries. The
--- cycle_routes table lands later.
+-- Scope of this style: pois, accommodations, water_points, bike_shops, health_services, railway_stations, charging_stations, cultural_pois, ways, admin_boundaries, cycle_routes.
 
 -- MUST match PostgisImporter::STAGING_SCHEMA: osm2pgsql writes the output tables
 -- here, and the importer creates/swaps this exact schema onto the live `osm`.
@@ -213,6 +212,26 @@ local admin_boundaries = osm2pgsql.define_table({
     },
 })
 
+-- Signed cycle routes (relations type=route, route=bicycle: EuroVelo, national
+-- (ncn) / regional (rcn) / local (lcn) networks, voies vertes), stored as
+-- multilinestrings. The API measures how much of a stage follows one (the
+-- "on cycle network" indicator).
+local cycle_routes = osm2pgsql.define_table({
+    name = 'cycle_routes',
+    schema = SCHEMA,
+    ids = { type = 'relation', id_column = 'osm_id' },
+    columns = {
+        { column = 'name', type = 'text' },
+        { column = 'network', type = 'text' },
+        { column = 'ref', type = 'text' },
+        { column = 'tags', type = 'jsonb' },
+        { column = 'geom', type = 'multilinestring', projection = SRID, not_null = true },
+    },
+    indexes = {
+        { column = 'geom', method = 'gist' },
+    },
+})
+
 local function poi_category(tags)
     if tags.amenity and POI_AMENITY[tags.amenity] then return tags.amenity end
     if tags.shop and POI_SHOP[tags.shop] then return tags.shop end
@@ -284,6 +303,11 @@ end
 -- True for country-level administrative boundary relations.
 local function is_country_boundary(tags)
     return tags.boundary == 'administrative' and tags.admin_level == '2'
+end
+
+-- True for signed cycle route relations (EuroVelo / national / regional / local).
+local function is_cycle_route(tags)
+    return tags.type == 'route' and tags.route == 'bicycle'
 end
 
 local function is_relevant(tags)
@@ -436,17 +460,33 @@ function osm2pgsql.process_way(object)
 end
 
 function osm2pgsql.process_relation(object)
-    if not is_country_boundary(object.tags) then return end
+    if is_country_boundary(object.tags) then
+        -- as_multipolygon() builds the area from the boundary's member ways; a
+        -- broken/incomplete relation yields nil and is skipped.
+        local ok, geom = pcall(function() return object:as_multipolygon() end)
+        if not ok or geom == nil then return end
 
-    -- as_multipolygon() builds the area from the boundary's member ways; a
-    -- broken/incomplete relation yields nil and is skipped.
-    local ok, geom = pcall(function() return object:as_multipolygon() end)
-    if not ok or geom == nil then return end
+        admin_boundaries:insert({
+            name = object.tags.name,
+            admin_level = to_int(object.tags.admin_level),
+            tags = object.tags,
+            geom = geom,
+        })
+        return
+    end
 
-    admin_boundaries:insert({
-        name = object.tags.name,
-        admin_level = to_int(object.tags.admin_level),
-        tags = object.tags,
-        geom = geom,
-    })
+    if is_cycle_route(object.tags) then
+        -- as_multilinestring() stitches the route's member ways; a broken
+        -- relation yields nil and is skipped.
+        local ok, geom = pcall(function() return object:as_multilinestring() end)
+        if not ok or geom == nil then return end
+
+        cycle_routes:insert({
+            name = object.tags.name,
+            network = object.tags.network,
+            ref = object.tags.ref,
+            tags = object.tags,
+            geom = geom,
+        })
+    end
 end

--- a/provisioner/src/PostgisImporter.php
+++ b/provisioner/src/PostgisImporter.php
@@ -55,6 +55,7 @@ final readonly class PostgisImporter
         'nwr/natural=spring',
         'w/highway=primary,secondary,tertiary,unclassified,residential,living_street,service,track,path,cycleway,footway,bridleway',
         'r/admin_level=2',
+        'r/route=bicycle',
     ];
 
     /**
@@ -66,7 +67,7 @@ final readonly class PostgisImporter
      */
     private const array FEATURE_TABLES = [
         'pois', 'accommodations', 'water_points', 'bike_shops', 'health_services',
-        'railway_stations', 'charging_stations', 'cultural_pois', 'ways', 'admin_boundaries',
+        'railway_stations', 'charging_stations', 'cultural_pois', 'ways', 'admin_boundaries', 'cycle_routes',
     ];
 
     /**

--- a/provisioner/tests/PostgisImporterTest.php
+++ b/provisioner/tests/PostgisImporterTest.php
@@ -65,6 +65,8 @@ final class PostgisImporterTest extends TestCase
         self::assertStringContainsString('w/highway=', $joined);
         // Country boundaries (relations) for the admin_boundaries table.
         self::assertContains('r/admin_level=2', $this->captured[0]);
+        // Signed cycle route relations for the cycle_routes table.
+        self::assertContains('r/route=bicycle', $this->captured[0]);
     }
 
     #[Test]
@@ -122,6 +124,7 @@ final class PostgisImporterTest extends TestCase
         // Counts cover every flex feature table so /health reports each one.
         self::assertStringContainsString("'pois', (SELECT count(*) FROM osm_staging.pois)", $metadata);
         self::assertStringContainsString("'admin_boundaries', (SELECT count(*) FROM osm_staging.admin_boundaries)", $metadata);
+        self::assertStringContainsString("'cycle_routes', (SELECT count(*) FROM osm_staging.cycle_routes)", $metadata);
     }
 
     #[Test]


### PR DESCRIPTION
## Contexte

Première PR de l'indicateur **"sur réseau cyclable" par étape** (dernière couche flux différée). Import provisioner des tracés cyclables ; l'analyseur d'étape (API) puis l'affichage (front) suivent en PRs dédiées — comme le food (#691 → #693).

## Changements

- **`tier1.lua`** : nouvelle table `cycle_routes` (MultiLineString). `process_relation` gère désormais aussi `type=route, route=bicycle` (EuroVelo, réseaux ncn/rcn/lcn, voies vertes) via `as_multilinestring` (même pattern que `admin_boundaries`). Colonnes `name`/`network`/`ref`/`tags`/`geom` + index GIST.
- **`PostgisImporter`** : `r/route=bicycle` ajouté au `osmium tags-filter` (garde les relations + ways membres), `cycle_routes` ajouté aux `FEATURE_TABLES` (compteurs `/health`).
- **Migration** `Version20260616150000` : bootstrap `osm.cycle_routes`.

## Choix de source

Les **relations OSM `route=bicycle`** sont la source de réseau cyclable la plus complète et pan-européenne (incluent les itinéraires touristiques via les tags `network`/`ref`). La couche DataTourisme `CyclingTour` pourra être ajoutée comme seconde source plus tard si elle apporte un complément.

## Tests

- `PostgisImporterTest` : filtre `r/route=bicycle`, métadonnées comptent `cycle_routes`. **59/59 verts en local.**
- Lua validé par osm2pgsql au provisioning (pas de leg CI dédié).

## Suite

PR2 (API) : analyseur d'étape calculant la fraction du tracé qui suit un `cycle_routes` (corridor `ST_DWithin` / `ST_Length` du recouvrement) → champ/badge `onCycleNetwork`. PR3 (front) : affichage de l'indicateur.

<!-- claude-review-start -->
## Claude Review

**Findings: 0 critical, 0 warnings, 1 observation (docs)**
Reviewed commit: `6ca4ce2e430062c11f050573c1e55ec281072145`

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [ ] Documentation is up to date — ADR-040 implementation status paragraph (last updated 2026-06-15) does not yet mention `cycle_routes` provisioner landing; reasonable to defer until all three PRs (provisioner + API + frontend) land and update together
- [x] Dependent tickets accounted for

### Inline comments

No inline comments.
<!-- claude-review-end -->