### PR TITLE
feat(api): per-stage on-cycle-network indicator from osm.cycle_routes

### DIFF
--- a/api/src/ApiResource/TripDetail.php
+++ b/api/src/ApiResource/TripDetail.php
@@ -66,6 +66,7 @@ final readonly class TripDetail
                     'geometry' => ['type' => 'array', 'items' => ['type' => 'object', 'properties' => ['lat' => ['type' => 'number'], 'lon' => ['type' => 'number'], 'ele' => ['type' => 'number']]]],
                     'label' => ['oneOf' => [['type' => 'string'], ['type' => 'null']]],
                     'isRestDay' => ['type' => 'boolean'],
+                    'onCycleNetwork' => ['type' => 'number', 'format' => 'float', 'minimum' => 0, 'maximum' => 1],
                     'weather' => ['oneOf' => [['type' => 'object', 'properties' => [
                         'icon' => ['type' => 'string'],
                         'description' => ['type' => 'string'],

--- a/api/src/Osm/CycleRouteRepository.php
+++ b/api/src/Osm/CycleRouteRepository.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Osm;
+
+use Doctrine\DBAL\Connection;
+
+/**
+ * Measures how much of a stage follows a signed cycle route, from the local-first
+ * osm.cycle_routes index (ADR-040): the length of the stage line lying within a
+ * tolerance of a cycle route, over the stage length. Drives the per-stage
+ * "on cycle network" indicator.
+ */
+final readonly class CycleRouteRepository implements CycleRouteRepositoryInterface
+{
+    public function __construct(private Connection $connection)
+    {
+    }
+
+    public function onNetworkFraction(array $stagePoints, int $toleranceMeters): float
+    {
+        if (\count($stagePoints) < 2) {
+            return 0.0;
+        }
+
+        // Buffer (geography, metres) the cycle routes running within the tolerance
+        // of the stage, then measure the stage length inside that buffer over the
+        // total stage length. A stage with no nearby cycle route yields 0.
+        $fraction = $this->connection->fetchOne(
+            <<<'SQL'
+                SELECT CASE
+                    WHEN ST_Length(stage.g::geography) = 0 THEN 0
+                    ELSE COALESCE(ST_Length(ST_Intersection(stage.g, buffer.g)::geography), 0)
+                         / ST_Length(stage.g::geography)
+                END
+                FROM (SELECT ST_SetSRID(ST_GeomFromText(:wkt), 4326) AS g) AS stage
+                LEFT JOIN LATERAL (
+                    SELECT ST_Buffer(ST_Collect(c.geom)::geography, :tol)::geometry AS g
+                    FROM osm.cycle_routes c
+                    WHERE ST_DWithin(c.geom::geography, stage.g::geography, :tol)
+                ) AS buffer ON TRUE
+                SQL,
+            [
+                'wkt' => WktGeometry::lineStringOrPoint($stagePoints),
+                'tol' => $toleranceMeters,
+            ],
+        );
+
+        return is_numeric($fraction) ? (float) $fraction : 0.0;
+    }
+}

--- a/api/src/Osm/CycleRouteRepository.php
+++ b/api/src/Osm/CycleRouteRepository.php
@@ -7,10 +7,13 @@ namespace App\Osm;
 use Doctrine\DBAL\Connection;
 
 /**
- * Measures how much of a stage follows a signed cycle route, from the local-first
- * osm.cycle_routes index (ADR-040): the length of the stage line lying within a
- * tolerance of a cycle route, over the stage length. Drives the per-stage
- * "on cycle network" indicator.
+ * Measures how much of each stage follows a signed cycle route, from the
+ * local-first osm.cycle_routes index (ADR-040): the length of the stage line
+ * lying within a tolerance of a cycle route, over the stage length. Drives the
+ * per-stage "on cycle network" indicator.
+ *
+ * All stages are measured in a single query (a stage WKT per row via
+ * jsonb_array_elements_text WITH ORDINALITY), avoiding a round trip per stage.
  */
 final readonly class CycleRouteRepository implements CycleRouteRepositoryInterface
 {
@@ -18,35 +21,49 @@ final readonly class CycleRouteRepository implements CycleRouteRepositoryInterfa
     {
     }
 
-    public function onNetworkFraction(array $stagePoints, int $toleranceMeters): float
+    public function onNetworkFractions(array $stageGeometries, int $toleranceMeters): array
     {
-        if (\count($stagePoints) < 2) {
-            return 0.0;
+        if ([] === $stageGeometries) {
+            return [];
         }
 
-        // Buffer (geography, metres) the cycle routes running within the tolerance
-        // of the stage, then measure the stage length inside that buffer over the
-        // total stage length. A stage with no nearby cycle route yields 0.
-        $fraction = $this->connection->fetchOne(
+        // One WKT per stage, index-aligned. A stage with fewer than two points
+        // cannot be measured → an empty linestring (length 0) yields fraction 0.
+        $wkts = array_map(
+            static fn (array $points): string => \count($points) >= 2 ? WktGeometry::lineStringOrPoint($points) : 'LINESTRING EMPTY',
+            $stageGeometries,
+        );
+
+        // For each stage line, buffer (geography, metres) the cycle routes running
+        // within the tolerance, then measure the stage length inside that buffer
+        // over the total stage length.
+        $rows = $this->connection->fetchAllAssociative(
             <<<'SQL'
-                SELECT CASE
+                SELECT t.idx AS idx, CASE
                     WHEN ST_Length(stage.g::geography) = 0 THEN 0
                     ELSE COALESCE(ST_Length(ST_Intersection(stage.g, buffer.g)::geography), 0)
                          / ST_Length(stage.g::geography)
-                END
-                FROM (SELECT ST_SetSRID(ST_GeomFromText(:wkt), 4326) AS g) AS stage
+                END AS fraction
+                FROM jsonb_array_elements_text(:wkts::jsonb) WITH ORDINALITY AS t(wkt, idx)
+                CROSS JOIN LATERAL (SELECT ST_SetSRID(ST_GeomFromText(t.wkt), 4326) AS g) AS stage
                 LEFT JOIN LATERAL (
                     SELECT ST_Buffer(ST_Collect(c.geom)::geography, :tol)::geometry AS g
                     FROM osm.cycle_routes c
                     WHERE ST_DWithin(c.geom::geography, stage.g::geography, :tol)
                 ) AS buffer ON TRUE
+                ORDER BY t.idx
                 SQL,
             [
-                'wkt' => WktGeometry::lineStringOrPoint($stagePoints),
+                'wkts' => json_encode($wkts, \JSON_THROW_ON_ERROR),
                 'tol' => $toleranceMeters,
             ],
         );
 
-        return is_numeric($fraction) ? (float) $fraction : 0.0;
+        $fractions = [];
+        foreach ($rows as $row) {
+            $fractions[] = is_numeric($row['fraction']) ? (float) $row['fraction'] : 0.0;
+        }
+
+        return $fractions;
     }
 }

--- a/api/src/Osm/CycleRouteRepositoryInterface.php
+++ b/api/src/Osm/CycleRouteRepositoryInterface.php
@@ -7,12 +7,15 @@ namespace App\Osm;
 interface CycleRouteRepositoryInterface
 {
     /**
-     * Fraction (0..1) of the stage that follows a signed cycle route (within
-     * $toleranceMeters of an osm.cycle_routes geometry) — the "on cycle network"
-     * indicator. Returns 0 for an empty/degenerate stage or when no cycle route
-     * runs near it.
+     * For each stage, the fraction (0..1) that follows a signed cycle route
+     * (within $toleranceMeters of an osm.cycle_routes geometry) — the per-stage
+     * "on cycle network" indicator. Computed for every stage in a single query.
+     * A stage yields 0 when it has fewer than two points or no cycle route runs
+     * near it.
      *
-     * @param list<array{lat: float, lon: float}> $stagePoints
+     * @param list<list<array{lat: float, lon: float}>> $stageGeometries
+     *
+     * @return list<float> one fraction per stage, in the same order
      */
-    public function onNetworkFraction(array $stagePoints, int $toleranceMeters): float;
+    public function onNetworkFractions(array $stageGeometries, int $toleranceMeters): array;
 }

--- a/api/src/Osm/CycleRouteRepositoryInterface.php
+++ b/api/src/Osm/CycleRouteRepositoryInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Osm;
+
+interface CycleRouteRepositoryInterface
+{
+    /**
+     * Fraction (0..1) of the stage that follows a signed cycle route (within
+     * $toleranceMeters of an osm.cycle_routes geometry) — the "on cycle network"
+     * indicator. Returns 0 for an empty/degenerate stage or when no cycle route
+     * runs near it.
+     *
+     * @param list<array{lat: float, lon: float}> $stagePoints
+     */
+    public function onNetworkFraction(array $stagePoints, int $toleranceMeters): float;
+}

--- a/api/src/State/TripDetailProvider.php
+++ b/api/src/State/TripDetailProvider.php
@@ -15,6 +15,7 @@ use App\ApiResource\Stage;
 use App\ApiResource\TripDetail;
 use App\ApiResource\TripRequest;
 use App\Osm\CoverageRepositoryInterface;
+use App\Osm\CycleRouteRepositoryInterface;
 use App\Repository\DoctrineTripRequestRepository;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Uid\Uuid;
@@ -29,10 +30,14 @@ use Symfony\Component\Uid\Uuid;
  */
 final readonly class TripDetailProvider implements ProviderInterface
 {
+    /** Tolerance (m) between the stage line and a cycle route to count as "on network". */
+    private const int CYCLE_NETWORK_TOLERANCE_METERS = 30;
+
     public function __construct(
         private DoctrineTripRequestRepository $tripStateManager,
         private TripLocker $tripLocker,
         private CoverageRepositoryInterface $coverageRepository,
+        private CycleRouteRepositoryInterface $cycleRouteRepository,
     ) {
     }
 
@@ -119,6 +124,10 @@ final readonly class TripDetailProvider implements ProviderInterface
             'geometry' => array_map($this->serializeCoord(...), $stage->geometry),
             'label' => $stage->label,
             'isRestDay' => $stage->isRestDay,
+            'onCycleNetwork' => $this->cycleRouteRepository->onNetworkFraction(
+                array_map(static fn (Coordinate $c): array => ['lat' => $c->lat, 'lon' => $c->lon], $stage->geometry),
+                self::CYCLE_NETWORK_TOLERANCE_METERS,
+            ),
             'weather' => $stage->weather instanceof WeatherForecast ? $this->serializeWeather($stage->weather) : null,
             'alerts' => array_map($this->serializeAlert(...), $stage->alerts),
             'pois' => array_map($this->serializePoi(...), $stage->pois),

--- a/api/src/State/TripDetailProvider.php
+++ b/api/src/State/TripDetailProvider.php
@@ -59,6 +59,18 @@ final readonly class TripDetailProvider implements ProviderInterface
 
         $stages = $this->tripStateManager->getStages($id) ?? [];
 
+        // One batched query for the on-cycle-network fraction of every stage.
+        $cycleNetwork = $this->cycleRouteRepository->onNetworkFractions(
+            array_map(
+                static fn (Stage $stage): array => array_map(
+                    static fn (Coordinate $c): array => ['lat' => $c->lat, 'lon' => $c->lon],
+                    $stage->geometry,
+                ),
+                $stages,
+            ),
+            self::CYCLE_NETWORK_TOLERANCE_METERS,
+        );
+
         return new TripDetail(
             id: $request->id->toRfc4122(),
             title: $request->title,
@@ -74,7 +86,7 @@ final readonly class TripDetailProvider implements ProviderInterface
             enabledAccommodationTypes: $request->enabledAccommodationTypes,
             isLocked: $this->tripLocker->isLocked($request),
             outOfZone: $this->coverageRepository->isRouteOutOfZone($this->routePoints($stages)),
-            stages: array_map($this->serializeStage(...), $stages),
+            stages: array_map($this->serializeStage(...), $stages, $cycleNetwork),
         );
     }
 
@@ -112,7 +124,7 @@ final readonly class TripDetailProvider implements ProviderInterface
      *
      * @return array<string, mixed>
      */
-    private function serializeStage(Stage $stage): array
+    private function serializeStage(Stage $stage, float $onCycleNetwork): array
     {
         return [
             'dayNumber' => $stage->dayNumber,
@@ -124,10 +136,7 @@ final readonly class TripDetailProvider implements ProviderInterface
             'geometry' => array_map($this->serializeCoord(...), $stage->geometry),
             'label' => $stage->label,
             'isRestDay' => $stage->isRestDay,
-            'onCycleNetwork' => $this->cycleRouteRepository->onNetworkFraction(
-                array_map(static fn (Coordinate $c): array => ['lat' => $c->lat, 'lon' => $c->lon], $stage->geometry),
-                self::CYCLE_NETWORK_TOLERANCE_METERS,
-            ),
+            'onCycleNetwork' => $onCycleNetwork,
             'weather' => $stage->weather instanceof WeatherForecast ? $this->serializeWeather($stage->weather) : null,
             'alerts' => array_map($this->serializeAlert(...), $stage->alerts),
             'pois' => array_map($this->serializePoi(...), $stage->pois),

--- a/api/tests/Functional/TripDetailTest.php
+++ b/api/tests/Functional/TripDetailTest.php
@@ -88,6 +88,9 @@ final class TripDetailTest extends ApiTestCase
         $this->assertArrayHasKey('geometry', $stage);
         $this->assertArrayHasKey('alerts', $stage);
         $this->assertArrayHasKey('accommodations', $stage);
+        // No cycle routes provisioned in the test DB → stage is not on a network.
+        $this->assertArrayHasKey('onCycleNetwork', $stage);
+        $this->assertEqualsWithDelta(0.0, $stage['onCycleNetwork'], 0.0001);
     }
 
     #[Test]

--- a/api/tests/Integration/Osm/CycleRouteIndexReadTest.php
+++ b/api/tests/Integration/Osm/CycleRouteIndexReadTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Osm;
+
+use App\Osm\CycleRouteRepository;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * Integration coverage for the local-first cycle-network read layer (ADR-040):
+ * seeds a real PostGIS cycle route in osm.cycle_routes and asserts the
+ * "on cycle network" fraction the API computes (length of the stage within a
+ * tolerance of a cycle route over the stage length).
+ */
+final class CycleRouteIndexReadTest extends KernelTestCase
+{
+    use ResetDatabase;
+
+    private const int TOLERANCE = 30;
+
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get('doctrine.dbal.default_connection');
+        $this->connection = $connection;
+
+        // A cycle route running due north along lon 2, from lat 48 to 49.
+        $this->connection->executeStatement('TRUNCATE osm.cycle_routes');
+        $this->connection->executeStatement(<<<'SQL'
+            INSERT INTO osm.cycle_routes (osm_id, name, network, ref, tags, geom) VALUES
+              (1, 'EuroVelo Test', 'icn', 'EV-T', '{}'::jsonb,
+                  ST_Multi(ST_SetSRID(ST_GeomFromText('LINESTRING(2 48, 2 49)'), 4326)))
+            SQL);
+    }
+
+    #[Test]
+    public function aStageFollowingACycleRouteIsFullyOnNetwork(): void
+    {
+        $fraction = new CycleRouteRepository($this->connection)->onNetworkFraction([
+            ['lat' => 48.1, 'lon' => 2.0],
+            ['lat' => 48.5, 'lon' => 2.0],
+            ['lat' => 48.9, 'lon' => 2.0],
+        ], self::TOLERANCE);
+
+        self::assertGreaterThan(0.95, $fraction);
+    }
+
+    #[Test]
+    public function aStageAwayFromAnyCycleRouteIsNotOnNetwork(): void
+    {
+        $fraction = new CycleRouteRepository($this->connection)->onNetworkFraction([
+            ['lat' => 48.1, 'lon' => 10.0],
+            ['lat' => 48.9, 'lon' => 10.0],
+        ], self::TOLERANCE);
+
+        self::assertEqualsWithDelta(0.0, $fraction, 0.0001);
+    }
+
+    #[Test]
+    public function aStageHalfOnNetworkIsAroundOneHalf(): void
+    {
+        // First half follows the route (lon 2), second half veers away (lon 2.05 ~3.7km off).
+        $fraction = new CycleRouteRepository($this->connection)->onNetworkFraction([
+            ['lat' => 48.0, 'lon' => 2.0],
+            ['lat' => 48.5, 'lon' => 2.0],
+            ['lat' => 48.5, 'lon' => 2.05],
+        ], self::TOLERANCE);
+
+        self::assertGreaterThan(0.3, $fraction);
+        self::assertLessThan(0.7, $fraction);
+    }
+
+    #[Test]
+    public function aDegenerateStageIsNotOnNetwork(): void
+    {
+        $repository = new CycleRouteRepository($this->connection);
+
+        self::assertSame(0.0, $repository->onNetworkFraction([], self::TOLERANCE));
+        self::assertSame(0.0, $repository->onNetworkFraction([['lat' => 48.0, 'lon' => 2.0]], self::TOLERANCE));
+    }
+}

--- a/api/tests/Integration/Osm/CycleRouteIndexReadTest.php
+++ b/api/tests/Integration/Osm/CycleRouteIndexReadTest.php
@@ -41,49 +41,63 @@ final class CycleRouteIndexReadTest extends KernelTestCase
             SQL);
     }
 
+    /**
+     * @param list<array{lat: float, lon: float}> $points
+     */
+    private function fractionFor(array $points): float
+    {
+        return new CycleRouteRepository($this->connection)->onNetworkFractions([$points], self::TOLERANCE)[0];
+    }
+
     #[Test]
     public function aStageFollowingACycleRouteIsFullyOnNetwork(): void
     {
-        $fraction = new CycleRouteRepository($this->connection)->onNetworkFraction([
+        self::assertGreaterThan(0.95, $this->fractionFor([
             ['lat' => 48.1, 'lon' => 2.0],
             ['lat' => 48.5, 'lon' => 2.0],
             ['lat' => 48.9, 'lon' => 2.0],
-        ], self::TOLERANCE);
-
-        self::assertGreaterThan(0.95, $fraction);
+        ]));
     }
 
     #[Test]
     public function aStageAwayFromAnyCycleRouteIsNotOnNetwork(): void
     {
-        $fraction = new CycleRouteRepository($this->connection)->onNetworkFraction([
+        self::assertEqualsWithDelta(0.0, $this->fractionFor([
             ['lat' => 48.1, 'lon' => 10.0],
             ['lat' => 48.9, 'lon' => 10.0],
-        ], self::TOLERANCE);
-
-        self::assertEqualsWithDelta(0.0, $fraction, 0.0001);
+        ]), 0.0001);
     }
 
     #[Test]
     public function aStageHalfOnNetworkIsAroundOneHalf(): void
     {
-        // First half follows the route (lon 2), second half veers away (lon 2.05 ~3.7km off).
-        $fraction = new CycleRouteRepository($this->connection)->onNetworkFraction([
+        // Segment 1 (lon 2, lat 48→48.5) follows the route (~55.7 km on network).
+        // Segment 2 (lat 48.5, lon 2→2.755) is perpendicular and far off route (~55.7 km off).
+        $fraction = $this->fractionFor([
             ['lat' => 48.0, 'lon' => 2.0],
             ['lat' => 48.5, 'lon' => 2.0],
-            ['lat' => 48.5, 'lon' => 2.05],
-        ], self::TOLERANCE);
+            ['lat' => 48.5, 'lon' => 2.755],
+        ]);
 
         self::assertGreaterThan(0.3, $fraction);
         self::assertLessThan(0.7, $fraction);
     }
 
     #[Test]
-    public function aDegenerateStageIsNotOnNetwork(): void
+    public function degenerateStagesAreNotOnNetwork(): void
     {
-        $repository = new CycleRouteRepository($this->connection);
+        $fractions = new CycleRouteRepository($this->connection)->onNetworkFractions(
+            [[], [['lat' => 48.0, 'lon' => 2.0]]],
+            self::TOLERANCE,
+        );
 
-        self::assertSame(0.0, $repository->onNetworkFraction([], self::TOLERANCE));
-        self::assertSame(0.0, $repository->onNetworkFraction([['lat' => 48.0, 'lon' => 2.0]], self::TOLERANCE));
+        self::assertEqualsWithDelta(0.0, $fractions[0], 0.0001);
+        self::assertEqualsWithDelta(0.0, $fractions[1], 0.0001);
+    }
+
+    #[Test]
+    public function emptyInputReturnsEmptyArray(): void
+    {
+        self::assertSame([], new CycleRouteRepository($this->connection)->onNetworkFractions([], self::TOLERANCE));
     }
 }


### PR DESCRIPTION
## Contexte

PR2 de l'indicateur "sur réseau cyclable" : exploite `osm.cycle_routes` (importé en #694) pour calculer, par étape, la fraction du tracé suivant un itinéraire cyclable balisé. Affichage front en PR3.

## Changements

- **`CycleRouteRepository`** (`App\Osm`, + interface) : `onNetworkFraction(stagePoints, tol)` = longueur de l'étape située à moins de `tol` m (30 m) d'un `osm.cycle_routes`, sur la longueur totale (via `ST_Buffer` géographie + `ST_Intersection` + `ST_Length`). 0 pour une étape vide/dégénérée ou sans réseau à proximité.
- **`TripDetailProvider`** : champ `onCycleNetwork` (float 0..1) par étape, calculé au read — **même approche qu'`outOfZone`**, sans persistance/handler/Mercure.
- **`TripDetail`** : schéma OpenAPI du stage enrichi (`onCycleNetwork`).

Choix : calcul au read (cohérent avec `outOfZone`) plutôt qu'un pipeline complet (entité+migration+handler+Mercure) — donnée statique du tracé, coût négligeable (N requêtes ST indexées par fetch).

## Tests

- `CycleRouteIndexReadTest` (intégration PostGIS) : étape pleinement sur réseau (>0.95), hors réseau (0), à moitié (~0.5), dégénérée (0).
- `TripDetailTest` : `onCycleNetwork` présent, 0 sans réseau provisionné.
- **Local** : PHPStan L9 clean (projet complet), Rector + CS-Fixer clean. Tests DB via CI.

## Suite

PR3 (front) : `make typegen` + badge/indicateur par étape + E2E.

<!-- claude-review-start -->
## Claude Review

The second commit addresses both findings from the previous review: the half-on-network test geometry is corrected (lon `2.755` gives the correct ≈55.7 km off-network leg) and the N+1 query is replaced by a single batched `jsonb_array_elements_text … WITH ORDINALITY` query. The implementation is clean, consistent with the `outOfZone` pattern, fully parameterised, and well-guarded against degenerate inputs.

**Resolved 2 previously open threads** (test geometry correctness, N+1 performance).

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

_Reviewed commit: `3dfab572a2d3eba5640bc0305ab01e2486614de3`_
<!-- claude-review-end -->