### PR TITLE
feat(pwa): per-stage on-cycle-network badge

### DIFF
--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -426,6 +426,9 @@
     "banner": "This route lies outside our covered area (France, Belgium, Netherlands, Luxembourg). Distances and points of interest are shown, but the trip can't be edited or re-routed.",
     "editDisabled": "This trip is outside the covered area and can't be edited."
   },
+  "cycleNetwork": {
+    "badge": "Cycle route · {percent}%"
+  },
   "tripList": {
     "title": "My Trips",
     "newTrip": "New trip",

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -426,6 +426,9 @@
     "banner": "Cet itinéraire sort de notre zone couverte (France, Belgique, Pays-Bas, Luxembourg). Les distances et points d'intérêt restent affichés, mais tu ne peux pas modifier ni recalculer ce voyage.",
     "editDisabled": "Ce voyage est hors zone couverte et ne peut pas être modifié."
   },
+  "cycleNetwork": {
+    "badge": "Voie cyclable · {percent} %"
+  },
   "tripList": {
     "title": "Mes voyages",
     "newTrip": "Nouveau voyage",

--- a/pwa/src/app/trips/[id]/trip-page.tsx
+++ b/pwa/src/app/trips/[id]/trip-page.tsx
@@ -121,6 +121,7 @@ function TripLoader({ tripId }: { tripId: string }) {
               null,
             accommodationSearchRadiusKm: 5,
             isRestDay: s.isRestDay ?? false,
+            onCycleNetwork: s.onCycleNetwork ?? 0,
             supplyTimeline: [],
             events: [],
           };

--- a/pwa/src/components/stage-card.tsx
+++ b/pwa/src/components/stage-card.tsx
@@ -12,6 +12,7 @@ import { AccommodationPanel } from "@/components/accommodation-panel";
 import { EventsPanel } from "@/components/events-panel";
 import { StageDownloads } from "@/components/stage-downloads";
 import { DiffHighlight } from "@/components/diff-highlight";
+import { StageCycleNetworkBadge } from "@/components/stage-cycle-network-badge";
 import { SupplyTimeline } from "@/components/SupplyTimeline/SupplyTimeline";
 import {
   StageAiSummary as StageAiSummaryLegacy,
@@ -212,6 +213,12 @@ export function StageCard({
             (forward-compatible: see StageDataSchema.surfaceBreakdown). */}
         {stage.surfaceBreakdown && stage.surfaceBreakdown.length > 0 && (
           <StageSurfaceBreakdown breakdown={stage.surfaceBreakdown} />
+        )}
+
+        {/* 4c. On-cycle-network badge — shown when the stage largely follows a
+            signed cycle route (ADR-040). Self-hides below its threshold. */}
+        {!stage.isRestDay && (
+          <StageCycleNetworkBadge fraction={stage.onCycleNetwork ?? 0} />
         )}
 
         {/* 5. Enriched weather card */}

--- a/pwa/src/components/stage-cycle-network-badge.test.tsx
+++ b/pwa/src/components/stage-cycle-network-badge.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { StageCycleNetworkBadge } from "./stage-cycle-network-badge";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string, params?: Record<string, number>) =>
+    params ? `${key}:${JSON.stringify(params)}` : key,
+}));
+
+describe("StageCycleNetworkBadge", () => {
+  it("renders the badge with a rounded percentage when mostly on network", () => {
+    render(<StageCycleNetworkBadge fraction={0.82} />);
+
+    const badge = screen.getByTestId("cycle-network-badge");
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveTextContent('badge:{"percent":82}');
+  });
+
+  it("renders at the 0.5 threshold", () => {
+    render(<StageCycleNetworkBadge fraction={0.5} />);
+
+    expect(screen.getByTestId("cycle-network-badge")).toBeInTheDocument();
+  });
+
+  it("renders nothing below the threshold", () => {
+    render(<StageCycleNetworkBadge fraction={0.49} />);
+
+    expect(screen.queryByTestId("cycle-network-badge")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing for a stage with no cycle-route overlap", () => {
+    render(<StageCycleNetworkBadge fraction={0} />);
+
+    expect(screen.queryByTestId("cycle-network-badge")).not.toBeInTheDocument();
+  });
+});

--- a/pwa/src/components/stage-cycle-network-badge.tsx
+++ b/pwa/src/components/stage-cycle-network-badge.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { Bike } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+/**
+ * Quality badge shown when a stage largely follows a signed cycle route
+ * (EuroVelo, voie verte...). Rendered only above a meaningful share so it stays
+ * a positive signal rather than noise (ADR-040).
+ */
+const THRESHOLD = 0.5;
+
+export function StageCycleNetworkBadge({ fraction }: { fraction: number }) {
+  const t = useTranslations("cycleNetwork");
+
+  if (fraction < THRESHOLD) {
+    return null;
+  }
+
+  return (
+    <div
+      className="inline-flex items-center gap-1.5 rounded-full bg-green-50 border border-green-200 text-green-800 dark:bg-green-900/20 dark:border-green-800/40 dark:text-green-300 px-3 py-1 text-xs font-medium"
+      data-testid="cycle-network-badge"
+    >
+      <Bike className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+      <span>{t("badge", { percent: Math.round(fraction * 100) })}</span>
+    </div>
+  );
+}

--- a/pwa/src/lib/api/schema.d.ts
+++ b/pwa/src/lib/api/schema.d.ts
@@ -1458,6 +1458,8 @@ export interface components {
                 }[];
                 label?: string | null;
                 isRestDay?: boolean;
+                /** Format: float */
+                onCycleNetwork?: number;
                 weather?: {
                     icon?: string;
                     description?: string;
@@ -1628,6 +1630,8 @@ export interface components {
                 }[];
                 label?: string | null;
                 isRestDay?: boolean;
+                /** Format: float */
+                onCycleNetwork?: number;
                 weather?: {
                     icon?: string;
                     description?: string;

--- a/pwa/src/lib/validation/schemas.ts
+++ b/pwa/src/lib/validation/schemas.ts
@@ -174,6 +174,12 @@ export const StageDataSchema = z.object({
     .positive()
     .default(DEFAULT_ACCOMMODATION_RADIUS_KM),
   isRestDay: z.boolean().default(false),
+  /**
+   * Fraction (0..1) of the stage that follows a signed cycle route (ADR-040).
+   * Optional/forward-compatible: present on the persisted trip detail, absent
+   * from the live SSE payloads (treated as 0).
+   */
+  onCycleNetwork: z.number().min(0).max(1).optional(),
   supplyTimeline: z.array(SupplyMarkerSchema).default([]),
   events: z.array(EventSchema).default([]),
   /**


### PR DESCRIPTION
## Contexte

PR3 (finale) de l'indicateur "sur réseau cyclable" : affichage du flag `onCycleNetwork` exposé par le backend (#695).

## Changements

- **typegen** : `schema.d.ts` régénéré (`onCycleNetwork` sur le stage de `TripDetail` — diff de 4 lignes, pas de dérive).
- **`StageData`** : champ `onCycleNetwork` (0..1) **optionnel/forward-compatible** (comme `surfaceBreakdown`) — présent sur le détail persisté, absent des payloads SSE live (traité comme 0).
- **Hydratation** (`trip-page.tsx`) : `onCycleNetwork` mappé depuis `/detail`.
- **`StageCycleNetworkBadge`** : badge vert (icône vélo + pourcentage) rendu sur la carte d'étape quand le tracé suit majoritairement (≥ 50 %) un itinéraire cyclable balisé. Se masque sous le seuil.
- **i18n** : `cycleNetwork.badge` (en + fr).

## Tests

- `stage-cycle-network-badge.test.tsx` (Vitest + Testing Library) : rendu ≥ seuil (avec %), seuil 0.5, masqué en dessous, masqué à 0.
- **Local** : tsc clean, ESLint clean, parité i18n en/fr, test composant 4/4 vert. Playwright/Prettier via CI.

## Clôture

Termine la dernière couche flux différée : l'indicateur réseau cyclable est complet (import #694, analyseur #695, badge ici). Reste éventuel : seconde source DataTourisme `CyclingTour` si elle apporte un complément.

<!-- claude-review-start -->
## Claude Review

Reviewed commit `46ac6364fed49aa472725ef32527598014dd00eb`.

Clean, focused PR that closes out the cycle-network indicator stack. The component is well-isolated, the Zod schema correctly mirrors the optional/forward-compatible pattern used for `surfaceBreakdown`, and the two `?? 0` fallbacks (hydration + render site) cover the two distinct undefined scenarios (missing field in persisted detail vs. SSE-only stage). No security, performance, or architecture concerns.

**PR title check:** `feat(pwa): per-stage on-cycle-network badge` — the description is a noun phrase rather than imperative mood. Per the project's Conventional Commits convention it should read `feat(pwa): add per-stage on-cycle-network badge`.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

No inline comments.
<!-- claude-review-end -->