### PR TITLE
feat(provisioner): import ferry crossings into osm.ferries

### DIFF
--- a/api/migrations/Version20260616160000.php
+++ b/api/migrations/Version20260616160000.php
@@ -9,8 +9,10 @@ use Doctrine\Migrations\AbstractMigration;
 
 /**
  * Adds osm.ferries to the local-first Tier-1 reference schema (ADR-040): ferry
- * crossings (ways tagged route=ferry) stored as PostGIS LineStrings. The API
- * flags stages whose route runs along one (the ferry-crossing alert).
+ * crossings tagged route=ferry, either on a way (LineString) or on a
+ * type=route relation (MultiLineString) — hence a generic geometry column and a
+ * composite (osm_type, osm_id) key. The API flags stages whose route runs along
+ * one (the ferry-crossing alert).
  *
  * Mirrors the osm2pgsql flex output (provisioner/osm2pgsql/tier1.lua): the
  * provisioner imports into a staging schema and atomically swaps it onto `osm`.
@@ -21,7 +23,7 @@ final class Version20260616160000 extends AbstractMigration
 {
     public function getDescription(): string
     {
-        return 'Add the osm.ferries reference table (route=ferry crossings) for the ferry-crossing alert';
+        return 'Add the osm.ferries reference table (route=ferry ways + relations) for the ferry-crossing alert';
     }
 
     public function up(Schema $schema): void
@@ -30,11 +32,12 @@ final class Version20260616160000 extends AbstractMigration
 
         $this->addSql(<<<'SQL'
             CREATE TABLE IF NOT EXISTS osm.ferries (
+                osm_type character(1) NOT NULL,
                 osm_id bigint NOT NULL,
                 name text,
                 tags jsonb,
-                geom geometry(LineString, 4326) NOT NULL,
-                PRIMARY KEY (osm_id)
+                geom geometry(Geometry, 4326) NOT NULL,
+                PRIMARY KEY (osm_type, osm_id)
             )
             SQL);
 

--- a/api/migrations/Version20260616160000.php
+++ b/api/migrations/Version20260616160000.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Adds osm.ferries to the local-first Tier-1 reference schema (ADR-040): ferry
+ * crossings (ways tagged route=ferry) stored as PostGIS LineStrings. The API
+ * flags stages whose route runs along one (the ferry-crossing alert).
+ *
+ * Mirrors the osm2pgsql flex output (provisioner/osm2pgsql/tier1.lua): the
+ * provisioner imports into a staging schema and atomically swaps it onto `osm`.
+ * This migration bootstraps the table so it exists before the first provisioning
+ * run and for the functional tests.
+ */
+final class Version20260616160000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add the osm.ferries reference table (route=ferry crossings) for the ferry-crossing alert';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE SCHEMA IF NOT EXISTS osm');
+
+        $this->addSql(<<<'SQL'
+            CREATE TABLE IF NOT EXISTS osm.ferries (
+                osm_id bigint NOT NULL,
+                name text,
+                tags jsonb,
+                geom geometry(LineString, 4326) NOT NULL,
+                PRIMARY KEY (osm_id)
+            )
+            SQL);
+
+        $this->addSql('CREATE INDEX IF NOT EXISTS ferries_geom_idx ON osm.ferries USING gist (geom)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE IF EXISTS osm.ferries');
+    }
+}

--- a/provisioner/osm2pgsql/tier1.lua
+++ b/provisioner/osm2pgsql/tier1.lua
@@ -194,16 +194,19 @@ local ways = osm2pgsql.define_table({
     },
 })
 
--- Ferry crossings (ways tagged route=ferry), stored as linestrings. The API
--- flags stages whose route runs along one (the ferry-crossing alert).
+-- Ferry crossings, stored as a generic geometry to hold both way LineStrings
+-- (route=ferry on the way) and relation MultiLineStrings (type=route,
+-- route=ferry, whose member ways may not repeat the tag). The `ids` use the
+-- 'any' type so way and relation ids share the table. The API flags stages
+-- whose route runs along one (the ferry-crossing alert).
 local ferries = osm2pgsql.define_table({
     name = 'ferries',
     schema = SCHEMA,
-    ids = { type = 'way', id_column = 'osm_id' },
+    ids = { type = 'any', id_column = 'osm_id', type_column = 'osm_type' },
     columns = {
         { column = 'name', type = 'text' },
         { column = 'tags', type = 'jsonb' },
-        { column = 'geom', type = 'linestring', projection = SRID, not_null = true },
+        { column = 'geom', type = 'geometry', projection = SRID, not_null = true },
     },
     indexes = {
         { column = 'geom', method = 'gist' },
@@ -326,7 +329,8 @@ local function is_cycle_route(tags)
     return tags.type == 'route' and tags.route == 'bicycle'
 end
 
--- True for ferry crossing ways (route=ferry).
+-- True for ferry crossings (route=ferry), tagged on a way directly or on a
+-- type=route relation whose member ways may not repeat the tag.
 local function is_ferry(tags)
     return tags.route == 'ferry'
 end
@@ -516,6 +520,21 @@ function osm2pgsql.process_relation(object)
             name = object.tags.name,
             network = object.tags.network,
             ref = object.tags.ref,
+            tags = object.tags,
+            geom = geom,
+        })
+
+        return
+    end
+
+    if is_ferry(object.tags) then
+        -- as_multilinestring() stitches the ferry relation's member ways; a
+        -- broken relation yields nil and is skipped.
+        local ok, geom = pcall(function() return object:as_multilinestring() end)
+        if not ok or geom == nil then return end
+
+        ferries:insert({
+            name = object.tags.name,
             tags = object.tags,
             geom = geom,
         })

--- a/provisioner/osm2pgsql/tier1.lua
+++ b/provisioner/osm2pgsql/tier1.lua
@@ -5,7 +5,7 @@
 -- the live `osm` schema atomically. The API reads these tables via ST_DWithin
 -- corridor queries, replacing the runtime Overpass dependency.
 --
--- Scope of this style: pois, accommodations, water_points, bike_shops, health_services, railway_stations, charging_stations, cultural_pois, ways, admin_boundaries, cycle_routes.
+-- Scope of this style: pois, accommodations, water_points, bike_shops, health_services, railway_stations, charging_stations, cultural_pois, ways, admin_boundaries, cycle_routes, ferries.
 
 -- MUST match PostgisImporter::STAGING_SCHEMA: osm2pgsql writes the output tables
 -- here, and the importer creates/swaps this exact schema onto the live `osm`.
@@ -194,6 +194,22 @@ local ways = osm2pgsql.define_table({
     },
 })
 
+-- Ferry crossings (ways tagged route=ferry), stored as linestrings. The API
+-- flags stages whose route runs along one (the ferry-crossing alert).
+local ferries = osm2pgsql.define_table({
+    name = 'ferries',
+    schema = SCHEMA,
+    ids = { type = 'way', id_column = 'osm_id' },
+    columns = {
+        { column = 'name', type = 'text' },
+        { column = 'tags', type = 'jsonb' },
+        { column = 'geom', type = 'linestring', projection = SRID, not_null = true },
+    },
+    indexes = {
+        { column = 'geom', method = 'gist' },
+    },
+})
+
 -- Country boundaries (admin_level=2), stored as multipolygons. The API resolves
 -- the country at a point via ST_Covers, replacing the runtime Overpass is_in
 -- query; their union also forms the coverage polygon.
@@ -308,6 +324,11 @@ end
 -- True for signed cycle route relations (EuroVelo / national / regional / local).
 local function is_cycle_route(tags)
     return tags.type == 'route' and tags.route == 'bicycle'
+end
+
+-- True for ferry crossing ways (route=ferry).
+local function is_ferry(tags)
+    return tags.route == 'ferry'
 end
 
 local function is_relevant(tags)
@@ -440,6 +461,16 @@ function osm2pgsql.process_node(object)
 end
 
 function osm2pgsql.process_way(object)
+    -- Ferry crossings are not highways/POIs (is_relevant skips them); handle first.
+    if is_ferry(object.tags) then
+        local ok, line = pcall(function() return object:as_linestring() end)
+        if ok and line ~= nil then
+            ferries:insert({ name = object.tags.name, tags = object.tags, geom = line })
+        end
+
+        return
+    end
+
     if not is_relevant(object.tags) then return end
 
     -- The ways table keeps the full linestring for surface/traffic analysis.

--- a/provisioner/src/PostgisImporter.php
+++ b/provisioner/src/PostgisImporter.php
@@ -57,6 +57,7 @@ final readonly class PostgisImporter
         'r/admin_level=2',
         'r/route=bicycle',
         'w/route=ferry',
+        'r/route=ferry',
     ];
 
     /**

--- a/provisioner/src/PostgisImporter.php
+++ b/provisioner/src/PostgisImporter.php
@@ -56,6 +56,7 @@ final readonly class PostgisImporter
         'w/highway=primary,secondary,tertiary,unclassified,residential,living_street,service,track,path,cycleway,footway,bridleway',
         'r/admin_level=2',
         'r/route=bicycle',
+        'w/route=ferry',
     ];
 
     /**
@@ -67,7 +68,7 @@ final readonly class PostgisImporter
      */
     private const array FEATURE_TABLES = [
         'pois', 'accommodations', 'water_points', 'bike_shops', 'health_services',
-        'railway_stations', 'charging_stations', 'cultural_pois', 'ways', 'admin_boundaries', 'cycle_routes',
+        'railway_stations', 'charging_stations', 'cultural_pois', 'ways', 'admin_boundaries', 'cycle_routes', 'ferries',
     ];
 
     /**

--- a/provisioner/tests/PostgisImporterTest.php
+++ b/provisioner/tests/PostgisImporterTest.php
@@ -67,6 +67,8 @@ final class PostgisImporterTest extends TestCase
         self::assertContains('r/admin_level=2', $this->captured[0]);
         // Signed cycle route relations for the cycle_routes table.
         self::assertContains('r/route=bicycle', $this->captured[0]);
+        // Ferry crossings (ways) for the ferries table.
+        self::assertContains('w/route=ferry', $this->captured[0]);
     }
 
     #[Test]
@@ -125,6 +127,7 @@ final class PostgisImporterTest extends TestCase
         self::assertStringContainsString("'pois', (SELECT count(*) FROM osm_staging.pois)", $metadata);
         self::assertStringContainsString("'admin_boundaries', (SELECT count(*) FROM osm_staging.admin_boundaries)", $metadata);
         self::assertStringContainsString("'cycle_routes', (SELECT count(*) FROM osm_staging.cycle_routes)", $metadata);
+        self::assertStringContainsString("'ferries', (SELECT count(*) FROM osm_staging.ferries)", $metadata);
     }
 
     #[Test]

--- a/provisioner/tests/PostgisImporterTest.php
+++ b/provisioner/tests/PostgisImporterTest.php
@@ -67,8 +67,9 @@ final class PostgisImporterTest extends TestCase
         self::assertContains('r/admin_level=2', $this->captured[0]);
         // Signed cycle route relations for the cycle_routes table.
         self::assertContains('r/route=bicycle', $this->captured[0]);
-        // Ferry crossings (ways) for the ferries table.
+        // Ferry crossings (ways + route relations) for the ferries table.
         self::assertContains('w/route=ferry', $this->captured[0]);
+        self::assertContains('r/route=ferry', $this->captured[0]);
     }
 
     #[Test]


### PR DESCRIPTION
## Contexte

Première PR de l'alerte **"traversée en ferry"** (alertes d'enrichissement 2e vague). Import provisioner ; l'alerte API + Mercure + front suit en PR dédiée.

## Changements

- **`tier1.lua`** : nouvelle table `ferries` (LineString). `process_way` traite `route=ferry` **avant** le filtre `is_relevant` (les ferries ne sont ni highway ni POI), via `as_linestring` — même logique que la branche highway. Colonnes `name`/`tags`/`geom` + index GIST.
- **`PostgisImporter`** : `w/route=ferry` ajouté au `osmium tags-filter`, `ferries` ajouté aux `FEATURE_TABLES` (compteurs `/health`).
- **Migration** `Version20260616160000` : bootstrap `osm.ferries`.

## Tests

- `PostgisImporterTest` : filtre `w/route=ferry`, métadonnées comptent `ferries`. **59/59 verts en local.**
- Lua validé par osm2pgsql au provisioning.

## Suite

PR2 (API) : `FerryRepository` (corridor `ST_DWithin`) + `CheckFerriesHandler` → alerte **warning** « traversée en ferry » par étape (dédup nom), publiée via Mercure (`FERRY_ALERTS`, pattern border-crossing) + cas SSE front + i18n + `README`/`ALERT_RULE_MAP`.

<!-- claude-review-start -->
## Claude Review

Solid follow-up. The second commit fully resolves the ferry relation gap flagged in the previous review — `r/route=ferry` osmium filter, `process_relation` ferry branch with `as_multilinestring()`, and `geometry(Geometry, 4326)` in the migration to accommodate both way LineStrings and relation MultiLineStrings. All layers (Lua, PHP constants, migration DDL, tests) are consistent.

**Commit reviewed:** 0e909c5cc4424ac40dcd79a88cf3eba64b2d05a2

**Review summary:** 0 critical · 0 warnings · 0 suggestions

**Resolved 1 previously open thread** (ferry route relations are now captured by both the osmium filter and the Lua `process_relation` branch).

### Review checklist
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.
<!-- claude-review-end -->