### PR TITLE
feat(alerts): warn when a stage takes a ferry crossing

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,9 @@ Rules are executed in priority order (lower = higher priority):
 | **Railway station** | -- | ![nudge](https://img.shields.io/badge/-nudge-0288d1) | No train station within 10 km of a stage endpoint (emergency evacuation) |
 | **Health services** | -- | ![nudge](https://img.shields.io/badge/-nudge-0288d1) | No pharmacy, hospital, or clinic within 15 km of a stage |
 | **Border crossing** | -- | ![nudge](https://img.shields.io/badge/-nudge-0288d1) | Route crosses an international border (country change detected via the local PostGIS admin-boundary index) |
+| **Ferry** | -- | ![warning](https://img.shields.io/badge/-warning-ed6c02) | Stage takes a ferry crossing (route runs within 100 m of an `osm.ferries` line; check schedule/booking) |
 
-**Terrain rules** (Continuity, Elevation, Steep gradient, Surface, Traffic, E-bike range, Sunset, Rest day) implement `StageAnalyzerInterface` and are auto-discovered via `#[AutoconfigureTag('app.stage_analyzer')]`. Rules with `--` priority (Calendar, Wind + Comfort, Bike shops, Resupply, Accommodation, Water points, Cultural POI, Railway station, Health services, Border crossing) are separate async Symfony Message handlers; Comfort is co-located with Wind inside `AnalyzeWindHandler`.
+**Terrain rules** (Continuity, Elevation, Steep gradient, Surface, Traffic, E-bike range, Sunset, Rest day) implement `StageAnalyzerInterface` and are auto-discovered via `#[AutoconfigureTag('app.stage_analyzer')]`. Rules with `--` priority (Calendar, Wind + Comfort, Bike shops, Resupply, Accommodation, Water points, Cultural POI, Railway station, Health services, Border crossing, Ferry) are separate async Symfony Message handlers; Comfort is co-located with Wind inside `AnalyzeWindHandler`.
 
 ---
 

--- a/api/src/Enum/ComputationName.php
+++ b/api/src/Enum/ComputationName.php
@@ -21,6 +21,7 @@ enum ComputationName: string
     case RAILWAY_STATIONS = 'railway_stations';
     case HEALTH_SERVICES = 'health_services';
     case BORDER_CROSSING = 'border_crossing';
+    case FERRIES = 'ferries';
     case EVENTS = 'events';
     /**
      * LLaMA 8B pass-1 — per-stage AI analysis (issue #303).
@@ -70,7 +71,7 @@ enum ComputationName: string
             self::POIS => 'points_of_interest',
             self::ACCOMMODATIONS => 'accommodations',
             self::TERRAIN, self::BIKE_SHOPS, self::WATER_POINTS,
-            self::HEALTH_SERVICES, self::RAILWAY_STATIONS, self::BORDER_CROSSING => 'terrain_security',
+            self::HEALTH_SERVICES, self::RAILWAY_STATIONS, self::BORDER_CROSSING, self::FERRIES => 'terrain_security',
             self::WEATHER, self::WIND => 'weather',
             self::CALENDAR, self::EVENTS, self::CULTURAL_POIS => 'context',
             self::STAGE_AI_ANALYSIS, self::TRIP_AI_OVERVIEW => 'ai_analysis',

--- a/api/src/Mercure/MercureEventType.php
+++ b/api/src/Mercure/MercureEventType.php
@@ -22,6 +22,7 @@ enum MercureEventType: string
     case RAILWAY_STATION_ALERTS = 'railway_station_alerts';
     case HEALTH_SERVICE_ALERTS = 'health_service_alerts';
     case BORDER_CROSSING_ALERTS = 'border_crossing_alerts';
+    case FERRY_ALERTS = 'ferry_alerts';
     case EVENTS_FOUND = 'events_found';
     case VALIDATION_ERROR = 'validation_error';
     case COMPUTATION_ERROR = 'computation_error';

--- a/api/src/Message/CheckFerries.php
+++ b/api/src/Message/CheckFerries.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Message;
+
+final readonly class CheckFerries
+{
+    public function __construct(
+        public string $tripId,
+        public ?int $generation = null,
+    ) {
+    }
+}

--- a/api/src/MessageHandler/CheckFerriesHandler.php
+++ b/api/src/MessageHandler/CheckFerriesHandler.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MessageHandler;
+
+use App\ApiResource\Model\AlertActionKind;
+use App\ApiResource\Model\Coordinate;
+use App\ComputationTracker\ComputationTrackerInterface;
+use App\ComputationTracker\TripGenerationTrackerInterface;
+use App\Enum\AlertType;
+use App\Enum\ComputationName;
+use App\Mercure\MercureEventType;
+use App\Mercure\TripUpdatePublisherInterface;
+use App\Message\CheckFerries;
+use App\Osm\FerryRepositoryInterface;
+use App\Repository\TripRequestRepositoryInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * Flags stages whose route takes a ferry crossing.
+ *
+ * For each stage, looks up the local osm.ferries lines (route=ferry) running
+ * within a tolerance of the stage geometry (ADR-040). A ferry on a stage emits a
+ * warning — ferries run on schedules, may require booking and can block progress.
+ * Deduplicates per stage by ferry name.
+ */
+#[AsMessageHandler]
+final readonly class CheckFerriesHandler extends AbstractTripMessageHandler
+{
+    /** Max distance (m) between the stage line and a ferry line to count the stage as taking it. */
+    private const int FERRY_TOLERANCE_METERS = 100;
+
+    public function __construct(
+        ComputationTrackerInterface $computationTracker,
+        TripUpdatePublisherInterface $publisher,
+        TripGenerationTrackerInterface $generationTracker,
+        LoggerInterface $logger,
+        private TripRequestRepositoryInterface $tripStateManager,
+        private FerryRepositoryInterface $ferryRepository,
+        private TranslatorInterface $translator,
+        MessageBusInterface $messageBus,
+    ) {
+        parent::__construct($computationTracker, $publisher, $generationTracker, $logger, $tripStateManager, $messageBus);
+    }
+
+    public function __invoke(CheckFerries $message): void
+    {
+        $tripId = $message->tripId;
+        $generation = $message->generation;
+        $stages = $this->tripStateManager->getStages($tripId);
+
+        if (null === $stages) {
+            return;
+        }
+
+        $locale = $this->tripStateManager->getLocale($tripId) ?? 'en';
+
+        $this->executeWithTracking($tripId, ComputationName::FERRIES, function () use ($tripId, $stages, $locale): void {
+            $alerts = [];
+
+            foreach ($stages as $i => $stage) {
+                if ($stage->isRestDay) {
+                    continue;
+                }
+
+                $stagePoints = array_map(
+                    static fn (Coordinate $c): array => ['lat' => $c->lat, 'lon' => $c->lon],
+                    $stage->geometry,
+                );
+
+                /** @var list<string> $seenNames */
+                $seenNames = [];
+                foreach ($this->ferryRepository->findNearStage($stagePoints, self::FERRY_TOLERANCE_METERS) as $ferry) {
+                    $key = $ferry['name'] ?? \sprintf('%.5F,%.5F', $ferry['lat'], $ferry['lon']);
+                    if (\in_array($key, $seenNames, true)) {
+                        continue;
+                    }
+
+                    $seenNames[] = $key;
+
+                    $alerts[] = [
+                        'stageIndex' => $i,
+                        'dayNumber' => $stage->dayNumber,
+                        'type' => AlertType::WARNING->value,
+                        'message' => $this->translator->trans(
+                            'alert.ferry.warning',
+                            ['%stage%' => $stage->dayNumber],
+                            'alerts',
+                            $locale,
+                        ),
+                        'action' => [
+                            'kind' => AlertActionKind::NAVIGATE->value,
+                            'label' => $this->translator->trans('alert.ferry.action', [], 'alerts', $locale),
+                            'payload' => ['lat' => $ferry['lat'], 'lon' => $ferry['lon']],
+                        ],
+                        'lat' => $ferry['lat'],
+                        'lon' => $ferry['lon'],
+                    ];
+                }
+            }
+
+            $this->publisher->publish($tripId, MercureEventType::FERRY_ALERTS, [
+                'alerts' => $alerts,
+            ]);
+        }, $generation);
+    }
+}

--- a/api/src/Osm/FerryRepository.php
+++ b/api/src/Osm/FerryRepository.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Osm;
+
+use Doctrine\DBAL\Connection;
+
+/**
+ * Reads ferry crossings from the local-first Tier-1 index (ADR-040): the
+ * osm.ferries lines (route=ferry ways + relations) running within a tolerance of
+ * a stage's route. A route that takes a ferry has its geometry follow the ferry
+ * line, so proximity to the stage line is the signal. Drives the ferry-crossing
+ * alert.
+ */
+final readonly class FerryRepository implements FerryRepositoryInterface
+{
+    public function __construct(private Connection $connection)
+    {
+    }
+
+    public function findNearStage(array $stagePoints, int $toleranceMeters): array
+    {
+        if (\count($stagePoints) < 2) {
+            return [];
+        }
+
+        $line = WktGeometry::lineStringOrPoint($stagePoints);
+
+        /** @var list<array<string, scalar|null>> $rows */
+        $rows = $this->connection->fetchAllAssociative(
+            <<<'SQL'
+                SELECT f.name,
+                       ST_Y(ST_ClosestPoint(f.geom, s.line)) AS lat,
+                       ST_X(ST_ClosestPoint(f.geom, s.line)) AS lon
+                FROM osm.ferries f,
+                     (SELECT ST_SetSRID(ST_GeomFromText(:wkt), 4326) AS line) AS s
+                WHERE ST_DWithin(f.geom::geography, s.line::geography, :tol)
+                SQL,
+            [
+                'wkt' => $line,
+                'tol' => $toleranceMeters,
+            ],
+        );
+
+        $ferries = [];
+        foreach ($rows as $row) {
+            $ferries[] = [
+                'name' => null !== $row['name'] ? (string) $row['name'] : null,
+                'lat' => (float) $row['lat'],
+                'lon' => (float) $row['lon'],
+            ];
+        }
+
+        return $ferries;
+    }
+}

--- a/api/src/Osm/FerryRepositoryInterface.php
+++ b/api/src/Osm/FerryRepositoryInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Osm;
+
+interface FerryRepositoryInterface
+{
+    /**
+     * Ferry crossings (osm.ferries) running within $toleranceMeters of the stage
+     * line — i.e. the stage's route follows them. Each entry carries the point on
+     * the ferry closest to the route, for the alert marker.
+     *
+     * @param list<array{lat: float, lon: float}> $stagePoints
+     *
+     * @return list<array{name: ?string, lat: float, lon: float}>
+     */
+    public function findNearStage(array $stagePoints, int $toleranceMeters): array;
+}

--- a/api/src/Service/TripAnalysisDispatcher.php
+++ b/api/src/Service/TripAnalysisDispatcher.php
@@ -10,6 +10,7 @@ use App\Message\CheckBikeShops;
 use App\Message\CheckBorderCrossing;
 use App\Message\CheckCalendar;
 use App\Message\CheckCulturalPois;
+use App\Message\CheckFerries;
 use App\Message\CheckHealthServices;
 use App\Message\CheckRailwayStations;
 use App\Message\CheckWaterPoints;
@@ -57,6 +58,7 @@ final readonly class TripAnalysisDispatcher
         $this->messageBus->dispatch(new CheckCulturalPois($tripId, $generation));
         $this->messageBus->dispatch(new CheckRailwayStations($tripId, $generation));
         $this->messageBus->dispatch(new CheckBorderCrossing($tripId, $generation));
+        $this->messageBus->dispatch(new CheckFerries($tripId, $generation));
         $this->messageBus->dispatch(new ScanEvents($tripId, $generation));
     }
 }

--- a/api/tests/Functional/trip-schema.json
+++ b/api/tests/Functional/trip-schema.json
@@ -45,6 +45,7 @@
         "railway_stations",
         "health_services",
         "border_crossing",
+        "ferries",
         "events"
       ],
       "additionalProperties": false,
@@ -167,6 +168,15 @@
           ]
         },
         "border_crossing": {
+          "type": "string",
+          "enum": [
+            "pending",
+            "running",
+            "done",
+            "failed"
+          ]
+        },
+        "ferries": {
           "type": "string",
           "enum": [
             "pending",

--- a/api/tests/Integration/Osm/FerryIndexReadTest.php
+++ b/api/tests/Integration/Osm/FerryIndexReadTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Osm;
+
+use App\Osm\FerryRepository;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * Integration coverage for the local-first ferry read layer (ADR-040): seeds a
+ * real PostGIS ferry line in osm.ferries and asserts the proximity detection the
+ * ferry-crossing alert relies on (a stage whose route follows the ferry line).
+ */
+final class FerryIndexReadTest extends KernelTestCase
+{
+    use ResetDatabase;
+
+    private const int TOLERANCE = 100;
+
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get('doctrine.dbal.default_connection');
+        $this->connection = $connection;
+
+        // A ferry crossing running east along lat 47, from lon 2.0 to 2.1.
+        $this->connection->executeStatement('TRUNCATE osm.ferries');
+        $this->connection->executeStatement(<<<'SQL'
+            INSERT INTO osm.ferries (osm_type, osm_id, name, tags, geom) VALUES
+              ('W', 1, 'Bac de Test', '{}'::jsonb,
+                  ST_SetSRID(ST_GeomFromText('LINESTRING(2.0 47.0, 2.1 47.0)'), 4326))
+            SQL);
+    }
+
+    #[Test]
+    public function aStageFollowingTheFerryDetectsIt(): void
+    {
+        $ferries = new FerryRepository($this->connection)->findNearStage([
+            ['lat' => 47.0, 'lon' => 2.02],
+            ['lat' => 47.0, 'lon' => 2.08],
+        ], self::TOLERANCE);
+
+        self::assertCount(1, $ferries);
+        self::assertSame('Bac de Test', $ferries[0]['name']);
+        self::assertEqualsWithDelta(47.0, $ferries[0]['lat'], 0.01);
+    }
+
+    #[Test]
+    public function aStageAwayFromTheFerryDetectsNothing(): void
+    {
+        $ferries = new FerryRepository($this->connection)->findNearStage([
+            ['lat' => 48.0, 'lon' => 5.0],
+            ['lat' => 48.1, 'lon' => 5.1],
+        ], self::TOLERANCE);
+
+        self::assertSame([], $ferries);
+    }
+
+    #[Test]
+    public function aDegenerateStageDetectsNothing(): void
+    {
+        $repository = new FerryRepository($this->connection);
+
+        self::assertSame([], $repository->findNearStage([], self::TOLERANCE));
+        self::assertSame([], $repository->findNearStage([['lat' => 47.0, 'lon' => 2.05]], self::TOLERANCE));
+    }
+}

--- a/api/tests/Unit/AlertDocumentationTest.php
+++ b/api/tests/Unit/AlertDocumentationTest.php
@@ -47,6 +47,7 @@ final class AlertDocumentationTest extends TestCase
         'railway_station' => 'Railway station',
         'health_service' => 'Health services',
         'border_crossing' => 'Border crossing',
+        'ferry' => 'Ferry',
     ];
 
     /**

--- a/api/tests/Unit/MessageHandler/CheckFerriesHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/CheckFerriesHandlerTest.php
@@ -113,7 +113,10 @@ final class CheckFerriesHandlerTest extends TestCase
                         && 'warning' === $alerts[0]['type']
                         && 0 === $alerts[0]['stageIndex']
                         && str_contains((string) $alerts[0]['message'], 'ferry')
-                        && abs($alerts[0]['lat'] - 47.05) < 0.001;
+                        && abs($alerts[0]['lat'] - 47.05) < 0.001
+                        && abs($alerts[0]['lon'] - (-2.05)) < 0.001
+                        && 'navigate' === $alerts[0]['action']['kind']
+                        && ['lat' => 47.05, 'lon' => -2.05] === $alerts[0]['action']['payload'];
                 }),
             );
 

--- a/api/tests/Unit/MessageHandler/CheckFerriesHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/CheckFerriesHandlerTest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\MessageHandler;
+
+use App\ApiResource\Model\Coordinate;
+use App\ApiResource\Stage;
+use App\ComputationTracker\ComputationTrackerInterface;
+use App\ComputationTracker\TripGenerationTrackerInterface;
+use App\Mercure\MercureEventType;
+use App\Mercure\TripUpdatePublisherInterface;
+use App\Message\CheckFerries;
+use App\MessageHandler\CheckFerriesHandler;
+use App\Osm\FerryRepositoryInterface;
+use App\Repository\TripRequestRepositoryInterface;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class CheckFerriesHandlerTest extends TestCase
+{
+    private function createHandler(
+        TripRequestRepositoryInterface $tripStateManager,
+        TripUpdatePublisherInterface $publisher,
+        FerryRepositoryInterface $ferryRepository,
+    ): CheckFerriesHandler {
+        $computationTracker = $this->createStub(ComputationTrackerInterface::class);
+        $computationTracker->method('getProgress')->willReturn(['completed' => 0, 'failed' => 0, 'total' => 1]);
+
+        $translator = $this->createStub(TranslatorInterface::class);
+        $translator->method('trans')->willReturnCallback(
+            static fn (string $id, array $params): string => match ($id) {
+                'alert.ferry.warning' => \sprintf('Stage %s takes a ferry.', $params['%stage%']),
+                default => $id,
+            },
+        );
+
+        return new CheckFerriesHandler(
+            $computationTracker,
+            $publisher,
+            $this->createStub(TripGenerationTrackerInterface::class),
+            new NullLogger(),
+            $tripStateManager,
+            $ferryRepository,
+            $translator,
+            $this->createStub(MessageBusInterface::class),
+        );
+    }
+
+    /** @param list<Stage>|null $stages */
+    private function createTripStateManager(?array $stages): TripRequestRepositoryInterface
+    {
+        $manager = $this->createStub(TripRequestRepositoryInterface::class);
+        $manager->method('getStages')->willReturn($stages);
+        $manager->method('getLocale')->willReturn('en');
+
+        return $manager;
+    }
+
+    private function stage(int $day, bool $isRestDay = false): Stage
+    {
+        return new Stage(
+            tripId: 'trip-1',
+            dayNumber: $day,
+            distance: 60.0,
+            elevation: 100.0,
+            startPoint: new Coordinate(47.0, -2.0),
+            endPoint: new Coordinate(47.1, -2.1),
+            geometry: [new Coordinate(47.0, -2.0), new Coordinate(47.1, -2.1)],
+            isRestDay: $isRestDay,
+        );
+    }
+
+    /**
+     * @param array<int, list<array{name: ?string, lat: float, lon: float}>> $byStageCall ferries returned per findNearStage call, in order
+     */
+    private function ferryRepository(array $byStageCall): FerryRepositoryInterface
+    {
+        $repository = $this->createStub(FerryRepositoryInterface::class);
+        $index = 0;
+        $repository->method('findNearStage')->willReturnCallback(
+            static function () use ($byStageCall, &$index): array {
+                return $byStageCall[$index++] ?? [];
+            },
+        );
+
+        return $repository;
+    }
+
+    #[Test]
+    public function emitsWarningForAStageTakingAFerry(): void
+    {
+        $tripStateManager = $this->createTripStateManager([$this->stage(1), $this->stage(2)]);
+        // Stage 0: a ferry; stage 1: none.
+        $ferryRepository = $this->ferryRepository([
+            [['name' => 'Le Passage du Gois', 'lat' => 47.05, 'lon' => -2.05]],
+            [],
+        ]);
+
+        $publisher = $this->createMock(TripUpdatePublisherInterface::class);
+        $publisher->expects($this->once())
+            ->method('publish')
+            ->with(
+                'trip-1',
+                MercureEventType::FERRY_ALERTS,
+                $this->callback(static function (array $data): bool {
+                    $alerts = $data['alerts'];
+
+                    return 1 === \count($alerts)
+                        && 'warning' === $alerts[0]['type']
+                        && 0 === $alerts[0]['stageIndex']
+                        && str_contains((string) $alerts[0]['message'], 'ferry')
+                        && abs($alerts[0]['lat'] - 47.05) < 0.001;
+                }),
+            );
+
+        $handler = $this->createHandler($tripStateManager, $publisher, $ferryRepository);
+        $handler(new CheckFerries('trip-1'));
+    }
+
+    #[Test]
+    public function deduplicatesTheSameFerryWithinAStage(): void
+    {
+        $tripStateManager = $this->createTripStateManager([$this->stage(1)]);
+        $ferryRepository = $this->ferryRepository([
+            [
+                ['name' => 'Bac de X', 'lat' => 47.05, 'lon' => -2.05],
+                ['name' => 'Bac de X', 'lat' => 47.06, 'lon' => -2.06],
+            ],
+        ]);
+
+        $publisher = $this->createMock(TripUpdatePublisherInterface::class);
+        $publisher->expects($this->once())
+            ->method('publish')
+            ->with(
+                'trip-1',
+                MercureEventType::FERRY_ALERTS,
+                $this->callback(static fn (array $data): bool => 1 === \count($data['alerts'])),
+            );
+
+        $handler = $this->createHandler($tripStateManager, $publisher, $ferryRepository);
+        $handler(new CheckFerries('trip-1'));
+    }
+
+    #[Test]
+    public function skipsRestDaysAndEmitsNoAlertWhenNoFerry(): void
+    {
+        $tripStateManager = $this->createTripStateManager([$this->stage(1, isRestDay: true)]);
+
+        $ferryRepository = $this->createMock(FerryRepositoryInterface::class);
+        $ferryRepository->expects($this->never())->method('findNearStage');
+
+        $publisher = $this->createMock(TripUpdatePublisherInterface::class);
+        $publisher->expects($this->once())
+            ->method('publish')
+            ->with(
+                'trip-1',
+                MercureEventType::FERRY_ALERTS,
+                $this->callback(static fn (array $data): bool => [] === $data['alerts']),
+            );
+
+        $handler = $this->createHandler($tripStateManager, $publisher, $ferryRepository);
+        $handler(new CheckFerries('trip-1'));
+    }
+
+    #[Test]
+    public function nullStagesYieldsNoPublish(): void
+    {
+        $tripStateManager = $this->createTripStateManager(null);
+
+        $publisher = $this->createMock(TripUpdatePublisherInterface::class);
+        $publisher->expects($this->never())->method('publish');
+
+        $handler = $this->createHandler($tripStateManager, $publisher, $this->createStub(FerryRepositoryInterface::class));
+        $handler(new CheckFerries('trip-1'));
+    }
+}

--- a/api/tests/Unit/Service/TripAnalysisDispatcherTest.php
+++ b/api/tests/Unit/Service/TripAnalysisDispatcherTest.php
@@ -10,6 +10,7 @@ use App\Message\CheckBikeShops;
 use App\Message\CheckBorderCrossing;
 use App\Message\CheckCalendar;
 use App\Message\CheckCulturalPois;
+use App\Message\CheckFerries;
 use App\Message\CheckHealthServices;
 use App\Message\CheckRailwayStations;
 use App\Message\CheckWaterPoints;
@@ -45,6 +46,7 @@ final class TripAnalysisDispatcherTest extends TestCase
             CheckCulturalPois::class,
             CheckRailwayStations::class,
             CheckBorderCrossing::class,
+            CheckFerries::class,
             ScanEvents::class,
         ];
 

--- a/api/translations/alerts.en.yaml
+++ b/api/translations/alerts.en.yaml
@@ -39,6 +39,8 @@ alert.health_service.nudge: "No pharmacy, hospital, or clinic detected within 15
 alert.sunset.action: "Advance departure time"
 alert.cultural_poi.suggestion: "Cultural POI nearby on stage %stage%: %name% (%type%, %distance%m from route). Add it to your itinerary?"
 alert.border_crossing.nudge: "You are entering %country%. Check phone coverage, payment methods, and local regulations."
+alert.ferry.warning: "Stage %stage% takes a ferry crossing. Check the schedule and whether booking is required."
+alert.ferry.action: "Ferry crossing"
 stage.label: "Stage %day%"
 weather.clear_sky: "Clear sky"
 weather.mainly_clear: "Mainly clear"

--- a/api/translations/alerts.fr.yaml
+++ b/api/translations/alerts.fr.yaml
@@ -39,6 +39,8 @@ alert.health_service.nudge: "Aucune pharmacie, hôpital ni clinique détecté da
 alert.sunset.action: "Avancer l'heure de départ"
 alert.cultural_poi.suggestion: "Point d'intérêt culturel à proximité de l'étape %stage% : %name% (%type%, %distance%m du tracé). L'ajouter à votre itinéraire ?"
 alert.border_crossing.nudge: "Vous passez en %country%. Vérifiez la couverture téléphonique, les moyens de paiement et la réglementation locale."
+alert.ferry.warning: "L'étape %stage% emprunte une traversée en ferry. Vérifiez les horaires et l'éventuelle réservation."
+alert.ferry.action: "Traversée en ferry"
 stage.label: "Étape %day%"
 weather.clear_sky: "Ciel dégagé"
 weather.mainly_clear: "Plutôt dégagé"

--- a/pwa/src/hooks/use-mercure.ts
+++ b/pwa/src/hooks/use-mercure.ts
@@ -419,6 +419,11 @@ function dispatchEvent(event: MercureEvent): void {
             lat: a.lat,
             lon: a.lon,
             source: "ferry",
+            action: {
+              kind: a.action.kind,
+              label: a.action.label,
+              payload: a.action.payload,
+            },
           })),
           "ferry",
         );

--- a/pwa/src/hooks/use-mercure.ts
+++ b/pwa/src/hooks/use-mercure.ts
@@ -36,7 +36,7 @@ const stageDiffTimers = new Map<number, ReturnType<typeof setTimeout>>();
  * - `accommodations_found` — accommodation options per stage
  * - `events_found` — DataTourisme dated events per stage
  * - `supply_timeline` — clustered supply markers per stage (water + food POIs)
- * - `terrain_alerts` / `calendar_alerts` / `wind_alerts` / `bike_shop_alerts` / `water_point_alerts` / `railway_station_alerts` / `health_service_alerts` / `border_crossing_alerts` — alert categories
+ * - `terrain_alerts` / `calendar_alerts` / `wind_alerts` / `bike_shop_alerts` / `water_point_alerts` / `railway_station_alerts` / `health_service_alerts` / `border_crossing_alerts` / `ferry_alerts` — alert categories
  * - `computation_step_completed` — Mode 1 progress tick (drives progress bar)
  * - `trip_ready` — Mode 1 atomic enriched payload (final analysis swap)
  * - `stage_updated` — Mode 2 per-stage update (inline modifications)
@@ -398,6 +398,29 @@ function dispatchEvent(event: MercureEvent): void {
             },
           })),
           "border_crossing",
+        );
+      }
+      break;
+    }
+
+    case "ferry_alerts": {
+      const ferryByStage = new Map<number, typeof event.data.alerts>();
+      for (const alert of event.data.alerts) {
+        const existing = ferryByStage.get(alert.stageIndex) ?? [];
+        existing.push(alert);
+        ferryByStage.set(alert.stageIndex, existing);
+      }
+      for (const [stageIndex, alerts] of ferryByStage) {
+        store.updateStageAlerts(
+          stageIndex,
+          alerts.map((a) => ({
+            type: a.type,
+            message: a.message,
+            lat: a.lat,
+            lon: a.lon,
+            source: "ferry",
+          })),
+          "ferry",
         );
       }
       break;

--- a/pwa/src/lib/mercure/types.ts
+++ b/pwa/src/lib/mercure/types.ts
@@ -318,6 +318,11 @@ export type MercureEvent =
           dayNumber: number;
           type: "warning";
           message: string;
+          action: {
+            kind: "navigate";
+            label: string;
+            payload: { lat: number; lon: number };
+          };
           lat: number;
           lon: number;
         }[];

--- a/pwa/src/lib/mercure/types.ts
+++ b/pwa/src/lib/mercure/types.ts
@@ -311,6 +311,19 @@ export type MercureEvent =
       };
     }
   | {
+      type: "ferry_alerts";
+      data: {
+        alerts: {
+          stageIndex: number;
+          dayNumber: number;
+          type: "warning";
+          message: string;
+          lat: number;
+          lon: number;
+        }[];
+      };
+    }
+  | {
       type: "route_segment_recalculated";
       data: {
         stageIndex: number;


### PR DESCRIPTION
## Contexte

PR2 (et finale) de l'alerte **« traversée en ferry »** : consomme `osm.ferries` (importé en #697) pour signaler par étape un trajet empruntant un ferry. Pattern identique à la détection border-crossing.

## Changements

**API**
- **`FerryRepository`** (`App\Osm`, + interface) : `findNearStage(stagePoints, tol)` → ferries `osm.ferries` à moins de **100 m** de la ligne d'étape (`ST_DWithin`), avec le point du ferry le plus proche (`ST_ClosestPoint`) pour le marqueur.
- **`CheckFerriesHandler`** : alerte **warning** « l'étape X emprunte une traversée en ferry » par étape (dédup par nom, saute les jours de repos), publiée via le nouveau `MercureEventType::FERRY_ALERTS`.
- **`ComputationName::FERRIES`** (catégorie `terrain_security`) + dispatch dans `TripAnalysisDispatcher`.

**Frontend** : cas SSE `ferry_alerts` dans `use-mercure` (merge dans les alertes d'étape, `source: ferry`) + typage `types.ts`.

**i18n** : `alert.ferry.warning` / `alert.ferry.action` (en + fr). **Doc** : ligne table alertes README + `ALERT_RULE_MAP`.

## Tests

- `CheckFerriesHandlerTest` : warning émis, dédup par nom, jour de repos sauté, stages null.
- `FerryIndexReadTest` (intégration PostGIS) : détection sur étape suivant le ferry, rien sinon, étape dégénérée.
- `TripAnalysisDispatcherTest` : `CheckFerries` dispatché. `AlertDocumentationTest` : namespace `ferry` mappé + README.
- **Local** : PHPStan L9, Rector, CS-Fixer clean ; tsc + ESLint front clean ; tests unit verts. Tests DB via CI.

## Suite

Restent : **gué (contextualisé météo)** puis **#15 Wikidata au provisioner**.

<!-- claude-review-start -->
## Claude Review

The ferry-crossing alert feature is complete and correct across all three commits. The previously flagged issues (missing `action` type in `types.ts`, action not forwarded in `use-mercure.ts`, missing action assertion in the unit test) have all been addressed. The implementation faithfully follows the border-crossing async-handler pattern end-to-end: parameterized PostGIS proximity query → per-stage dedup by ferry name → typed SSE event → Zustand store update with the navigate action wired through.

**Reviewed commit:** `b9dacdbaa1d295cc2280330238cf1084811d3d1f`

### Resolved threads
Resolved 1 previously open bot-authored thread (outdated suggestion to add action assertion — addressed in the third commit).

### Review checklist
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**No inline comments.**
<!-- claude-review-end -->