### PR TITLE
feat(provisioner): import fords into osm.fords

### DIFF
--- a/api/migrations/Version20260617120000.php
+++ b/api/migrations/Version20260617120000.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Adds osm.fords to the local-first Tier-1 reference schema (ADR-040): fords
+ * (ford=yes/stream/... on a node or a highway way) stored as PostGIS points
+ * (node position or way centroid). The API flags stages passing close to one
+ * (the ford alert, escalated to a warning when rain is forecast).
+ *
+ * Mirrors the osm2pgsql flex output (provisioner/osm2pgsql/tier1.lua): the
+ * provisioner imports into a staging schema and atomically swaps it onto `osm`.
+ * This migration bootstraps the table so it exists before the first provisioning
+ * run and for the functional tests.
+ */
+final class Version20260617120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add the osm.fords reference table (ford crossings) for the ford alert';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE SCHEMA IF NOT EXISTS osm');
+
+        $this->addSql(<<<'SQL'
+            CREATE TABLE IF NOT EXISTS osm.fords (
+                osm_type character(1) NOT NULL,
+                osm_id bigint NOT NULL,
+                name text,
+                tags jsonb,
+                geom geometry(Point, 4326) NOT NULL,
+                PRIMARY KEY (osm_type, osm_id)
+            )
+            SQL);
+
+        $this->addSql('CREATE INDEX IF NOT EXISTS fords_geom_idx ON osm.fords USING gist (geom)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE IF EXISTS osm.fords');
+    }
+}

--- a/provisioner/osm2pgsql/tier1.lua
+++ b/provisioner/osm2pgsql/tier1.lua
@@ -5,7 +5,7 @@
 -- the live `osm` schema atomically. The API reads these tables via ST_DWithin
 -- corridor queries, replacing the runtime Overpass dependency.
 --
--- Scope of this style: pois, accommodations, water_points, bike_shops, health_services, railway_stations, charging_stations, cultural_pois, ways, admin_boundaries, cycle_routes, ferries.
+-- Scope of this style: pois, accommodations, water_points, bike_shops, health_services, railway_stations, charging_stations, cultural_pois, ways, admin_boundaries, cycle_routes, ferries, fords.
 
 -- MUST match PostgisImporter::STAGING_SCHEMA: osm2pgsql writes the output tables
 -- here, and the importer creates/swaps this exact schema onto the live `osm`.
@@ -213,6 +213,23 @@ local ferries = osm2pgsql.define_table({
     },
 })
 
+-- Fords (ford=yes/stream/... on a node or a highway way), stored as points
+-- (node position, or way centroid). The API flags stages passing close to one
+-- (the ford alert, escalated to a warning when rain is forecast).
+local fords = osm2pgsql.define_table({
+    name = 'fords',
+    schema = SCHEMA,
+    ids = { type = 'any', id_column = 'osm_id', type_column = 'osm_type' },
+    columns = {
+        { column = 'name', type = 'text' },
+        { column = 'tags', type = 'jsonb' },
+        { column = 'geom', type = 'point', projection = SRID, not_null = true },
+    },
+    indexes = {
+        { column = 'geom', method = 'gist' },
+    },
+})
+
 -- Country boundaries (admin_level=2), stored as multipolygons. The API resolves
 -- the country at a point via ST_Covers, replacing the runtime Overpass is_in
 -- query; their union also forms the coverage polygon.
@@ -333,6 +350,11 @@ end
 -- type=route relation whose member ways may not repeat the tag.
 local function is_ferry(tags)
     return tags.route == 'ferry'
+end
+
+-- True for fords (ford=yes/stream/tidal/...), on a node or a highway way.
+local function is_ford(tags)
+    return tags.ford ~= nil and tags.ford ~= 'no'
 end
 
 local function is_relevant(tags)
@@ -459,12 +481,26 @@ local function way_centroid(object)
 end
 
 function osm2pgsql.process_node(object)
+    -- Fords are commonly mapped as a node on the crossing; not a POI category.
+    if is_ford(object.tags) then
+        fords:insert({ name = object.tags.name, tags = object.tags, geom = object:as_point() })
+    end
+
     -- tags-filter keeps untagged nodes referenced by ways; skip them here.
     if not is_relevant(object.tags) then return end
     insert_features(object.tags, object:as_point())
 end
 
 function osm2pgsql.process_way(object)
+    -- A ford may be tagged on a highway way; store its centroid (the way is also
+    -- kept in `ways` below as a highway, so do not return here).
+    if is_ford(object.tags) then
+        local centroid = way_centroid(object)
+        if centroid ~= nil then
+            fords:insert({ name = object.tags.name, tags = object.tags, geom = centroid })
+        end
+    end
+
     -- Ferry crossings are not highways/POIs (is_relevant skips them); handle first.
     if is_ferry(object.tags) then
         local ok, line = pcall(function() return object:as_linestring() end)

--- a/provisioner/src/PostgisImporter.php
+++ b/provisioner/src/PostgisImporter.php
@@ -58,6 +58,7 @@ final readonly class PostgisImporter
         'r/route=bicycle',
         'w/route=ferry',
         'r/route=ferry',
+        'nw/ford',
     ];
 
     /**
@@ -69,7 +70,7 @@ final readonly class PostgisImporter
      */
     private const array FEATURE_TABLES = [
         'pois', 'accommodations', 'water_points', 'bike_shops', 'health_services',
-        'railway_stations', 'charging_stations', 'cultural_pois', 'ways', 'admin_boundaries', 'cycle_routes', 'ferries',
+        'railway_stations', 'charging_stations', 'cultural_pois', 'ways', 'admin_boundaries', 'cycle_routes', 'ferries', 'fords',
     ];
 
     /**

--- a/provisioner/tests/PostgisImporterTest.php
+++ b/provisioner/tests/PostgisImporterTest.php
@@ -70,6 +70,8 @@ final class PostgisImporterTest extends TestCase
         // Ferry crossings (ways + route relations) for the ferries table.
         self::assertContains('w/route=ferry', $this->captured[0]);
         self::assertContains('r/route=ferry', $this->captured[0]);
+        // Fords (nodes + ways) for the fords table.
+        self::assertContains('nw/ford', $this->captured[0]);
     }
 
     #[Test]
@@ -129,6 +131,7 @@ final class PostgisImporterTest extends TestCase
         self::assertStringContainsString("'admin_boundaries', (SELECT count(*) FROM osm_staging.admin_boundaries)", $metadata);
         self::assertStringContainsString("'cycle_routes', (SELECT count(*) FROM osm_staging.cycle_routes)", $metadata);
         self::assertStringContainsString("'ferries', (SELECT count(*) FROM osm_staging.ferries)", $metadata);
+        self::assertStringContainsString("'fords', (SELECT count(*) FROM osm_staging.fords)", $metadata);
     }
 
     #[Test]


### PR DESCRIPTION
## Contexte

Première PR de l'alerte **gué** (contextualisée météo). Import provisioner ; l'alerte API (chaînée après la météo) suit en PR dédiée — comme ferry (#697 → #698).

## Changements

- **`tier1.lua`** : nouvelle table `fords` (Point). `is_ford` (`ford=yes/stream/tidal/...`, hors `no`) ; branche `process_node` (position du nœud) et `process_way` (centroïde — le gué-way reste aussi dans `ways` comme highway, donc pas de `return`). Clé composite `(osm_type, osm_id)`.
- **`PostgisImporter`** : `nw/ford` ajouté au `osmium tags-filter`, `fords` aux `FEATURE_TABLES` (compteurs `/health`).
- **Migration** `Version20260617120000` : bootstrap `osm.fords`.

## Tests

- `PostgisImporterTest` : filtre `nw/ford`, métadonnées comptent `fords`. **59/59 verts en local.**

## Suite

PR2 (API) : `FordRepository` (gués à ≤ 25 m du tracé) + `CheckFordsHandler` **chaîné après `FetchWeatherHandler`** (comme `AnalyzeWind`) pour lire `stage.weather` → **nudge** « gué sur le parcours » si temps sec, **warning** « gué + pluie prévue » si précipitations notables. + cas SSE front + i18n + `README`/`ALERT_RULE_MAP`.

<!-- claude-review-start -->
## Claude Review

Clean foundation PR that faithfully mirrors the ferry pattern. The three-layer approach (osmium filter → Lua flex style → migration) is consistent with the existing OSM provisioner design, the nil guard on `way_centroid` is correct, and tests cover the critical invariants.

**Reviewed commit:** `413df3e4ca1a1877ff538ce4553c869e3e04a720`

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

No inline comments.
<!-- claude-review-end -->