### PR TITLE
feat(provisioner): enrich tourism POIs from Wikidata at provision time

### DIFF
--- a/api/migrations/Version20260617130000.php
+++ b/api/migrations/Version20260617130000.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Adds the Wikidata enrichment columns to tourism.cultural_pois and
+ * tourism.food_pois (ADR-040): website, image_url and wikipedia_url, filled by
+ * the provisioner's post-load enrichment pass (batch SPARQL keyed on the
+ * `wikidata` Q-ID). This moves the former runtime Wikidata enrichment into the
+ * provisioner so the API reads enriched reference data from PostGIS only.
+ *
+ * Bootstraps the columns for the first provisioning run and the functional
+ * tests; the provisioner's staging DDL carries the same columns so the atomic
+ * schema swap preserves them.
+ */
+final class Version20260617130000 extends AbstractMigration
+{
+    private const array TABLES = ['cultural_pois', 'food_pois'];
+
+    public function getDescription(): string
+    {
+        return 'Add Wikidata enrichment columns (website, image_url, wikipedia_url) to tourism POI tables';
+    }
+
+    public function up(Schema $schema): void
+    {
+        foreach (self::TABLES as $table) {
+            $this->addSql(\sprintf('ALTER TABLE tourism.%s ADD COLUMN IF NOT EXISTS website text', $table));
+            $this->addSql(\sprintf('ALTER TABLE tourism.%s ADD COLUMN IF NOT EXISTS image_url text', $table));
+            $this->addSql(\sprintf('ALTER TABLE tourism.%s ADD COLUMN IF NOT EXISTS wikipedia_url text', $table));
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        foreach (self::TABLES as $table) {
+            $this->addSql(\sprintf('ALTER TABLE tourism.%s DROP COLUMN IF EXISTS website', $table));
+            $this->addSql(\sprintf('ALTER TABLE tourism.%s DROP COLUMN IF EXISTS image_url', $table));
+            $this->addSql(\sprintf('ALTER TABLE tourism.%s DROP COLUMN IF EXISTS wikipedia_url', $table));
+        }
+    }
+}

--- a/provisioner/src/DataTourismeImporter.php
+++ b/provisioner/src/DataTourismeImporter.php
@@ -52,11 +52,21 @@ final readonly class DataTourismeImporter
     ];
 
     private const array STAGING_DDL = [
-        'cultural_pois' => 'id text NOT NULL PRIMARY KEY, name text, category text NOT NULL, opening_hours text, description text, wikidata text, tags jsonb, geom geometry(Point, 4326) NOT NULL',
-        'food_pois' => 'id text NOT NULL PRIMARY KEY, name text, category text NOT NULL, opening_hours text, description text, wikidata text, tags jsonb, geom geometry(Point, 4326) NOT NULL',
+        'cultural_pois' => 'id text NOT NULL PRIMARY KEY, name text, category text NOT NULL, opening_hours text, description text, website text, image_url text, wikipedia_url text, wikidata text, tags jsonb, geom geometry(Point, 4326) NOT NULL',
+        'food_pois' => 'id text NOT NULL PRIMARY KEY, name text, category text NOT NULL, opening_hours text, description text, website text, image_url text, wikipedia_url text, wikidata text, tags jsonb, geom geometry(Point, 4326) NOT NULL',
         'accommodations' => 'id text NOT NULL PRIMARY KEY, name text, category text NOT NULL, capacity int, price numeric(10, 2), description text, tags jsonb, geom geometry(Point, 4326) NOT NULL',
         'events' => 'id text NOT NULL PRIMARY KEY, name text, category text NOT NULL, start_date date, end_date date, url text, description text, price_min numeric(10, 2), tags jsonb, geom geometry(Point, 4326) NOT NULL',
     ];
+
+    /**
+     * Tables enriched from Wikidata (those carrying a `wikidata` Q-ID column),
+     * with the columns the {@see WikidataEnricher} fills. Source-provided fields
+     * (description, opening_hours) are kept when present (COALESCE); the rest are
+     * Wikidata-only.
+     */
+    private const array WIKIDATA_TABLES = ['cultural_pois', 'food_pois'];
+
+    private const string WIKIDATA_ENRICH_TABLE = 'wikidata_enrich';
 
     private HttpClientInterface $httpClient;
 
@@ -74,6 +84,8 @@ final readonly class DataTourismeImporter
         ?HttpClientInterface $httpClient = null,
         ?\Closure $processFactory = null,
         private float $timeoutSeconds = 1800.0,
+        private WikidataEnricher $enricher = new WikidataEnricher(),
+        private string $locale = 'fr',
     ) {
         // Scoped to the DataTourisme origin (SSRF policy, see CLAUDE.md).
         $this->httpClient = $httpClient ?? ScopingHttpClient::forBaseUri(
@@ -90,8 +102,9 @@ final readonly class DataTourismeImporter
     {
         $zipPath = $workDir.'/datatourisme-flux.zip';
         $this->download($zipPath);
-        $copyFiles = $this->extract($zipPath, $workDir);
+        ['files' => $copyFiles, 'wikidataIds' => $wikidataIds] = $this->extract($zipPath, $workDir);
         $this->load($copyFiles);
+        $this->enrich($workDir, $wikidataIds);
         $this->swap();
     }
 
@@ -129,9 +142,11 @@ final readonly class DataTourismeImporter
     }
 
     /**
-     * Streams the flux ZIP and writes one text-format COPY file per table.
+     * Streams the flux ZIP and writes one text-format COPY file per table,
+     * collecting the distinct Wikidata Q-IDs seen on enrichable rows for the
+     * post-load enrichment pass.
      *
-     * @return array<string, string> table name => COPY file path
+     * @return array{files: array<string, string>, wikidataIds: list<string>}
      *
      * @throws ImportFailedException
      */
@@ -156,6 +171,9 @@ final readonly class DataTourismeImporter
         }
 
         $heads = ['cultural' => 'cultural_pois', 'food' => 'food_pois', 'accommodation' => 'accommodations', 'event' => 'events'];
+
+        /** @var array<string, true> $wikidataIds */
+        $wikidataIds = [];
 
         for ($i = 0, $n = $zip->numFiles; $i < $n; ++$i) {
             $name = $zip->getNameIndex($i);
@@ -187,6 +205,10 @@ final readonly class DataTourismeImporter
 
             $table = $heads[$row['head']];
             fwrite($handles[$table], $this->copyLine($table, $row));
+
+            if (\in_array($table, self::WIKIDATA_TABLES, true) && null !== $row['wikidata']) {
+                $wikidataIds[$row['wikidata']] = true;
+            }
         }
 
         foreach ($handles as $handle) {
@@ -195,7 +217,7 @@ final readonly class DataTourismeImporter
 
         $zip->close();
 
-        return $files;
+        return ['files' => $files, 'wikidataIds' => array_keys($wikidataIds)];
     }
 
     /**
@@ -271,6 +293,81 @@ final readonly class DataTourismeImporter
             'psql', '-v', 'ON_ERROR_STOP=1', '-c',
             \sprintf('CREATE TABLE %1$s.metadata AS SELECT now() AS refreshed_at, jsonb_build_object(%2$s) AS feature_counts;', self::STAGING_SCHEMA, $counts),
         ], 'psql build tourism metadata');
+    }
+
+    /**
+     * Enriches the staged Wikidata-bearing tables from Wikidata (ADR-040): batch
+     * SPARQL over the distinct Q-IDs seen during extraction, then a single
+     * UPDATE per table joining on the `wikidata` column. Runs after {@see load}
+     * (rows are in staging) and before {@see swap} so the enrichment lands in the
+     * dataset that goes live atomically.
+     *
+     * Best-effort: an empty enrichment (Wikidata outage handled in
+     * {@see WikidataEnricher}) simply leaves the source rows untouched.
+     *
+     * @param list<string> $wikidataIds
+     *
+     * @throws ImportFailedException
+     */
+    private function enrich(string $workDir, array $wikidataIds): void
+    {
+        if ([] === $wikidataIds) {
+            return;
+        }
+
+        $enrichments = $this->enricher->enrich($wikidataIds, $this->locale);
+        if ([] === $enrichments) {
+            return;
+        }
+
+        $path = $workDir.'/tourism-wikidata.copy';
+        $handle = fopen($path, 'w');
+        if (false === $handle) {
+            throw new ImportFailedException(\sprintf('Cannot open enrichment COPY file "%s"', $path));
+        }
+
+        foreach ($enrichments as $qId => $entry) {
+            fwrite($handle, implode("\t", array_map($this->copyValue(...), [
+                $qId,
+                $entry['description'] ?? null,
+                $entry['openingHours'] ?? null,
+                $entry['website'] ?? null,
+                $entry['imageUrl'] ?? null,
+                $entry['wikipediaUrl'] ?? null,
+            ]))."\n");
+        }
+
+        fclose($handle);
+
+        $table = \sprintf('%s.%s', self::STAGING_SCHEMA, self::WIKIDATA_ENRICH_TABLE);
+        $this->runProcess([
+            'psql', '-v', 'ON_ERROR_STOP=1', '-c',
+            \sprintf('CREATE TABLE %s (wikidata text PRIMARY KEY, description text, opening_hours text, website text, image_url text, wikipedia_url text);', $table),
+        ], 'psql create wikidata enrich table');
+
+        $this->runProcess([
+            'psql', '-v', 'ON_ERROR_STOP=1', '-c',
+            \sprintf("\\copy %s (wikidata, description, opening_hours, website, image_url, wikipedia_url) FROM '%s'", $table, $path),
+        ], 'psql copy wikidata enrich');
+
+        foreach (self::WIKIDATA_TABLES as $target) {
+            // description / opening_hours come from DataTourisme first, so keep the
+            // source value when present; the other columns are Wikidata-only.
+            $this->runProcess([
+                'psql', '-v', 'ON_ERROR_STOP=1', '-c',
+                \sprintf(
+                    'UPDATE %1$s.%2$s t SET description = COALESCE(t.description, e.description), opening_hours = COALESCE(t.opening_hours, e.opening_hours), website = e.website, image_url = e.image_url, wikipedia_url = e.wikipedia_url FROM %3$s e WHERE t.wikidata = e.wikidata;',
+                    self::STAGING_SCHEMA,
+                    $target,
+                    $table,
+                ),
+            ], \sprintf('psql enrich %s', $target));
+        }
+
+        $this->runProcess([
+            'psql', '-v', 'ON_ERROR_STOP=1', '-c',
+            \sprintf('DROP TABLE %s;', $table),
+        ], 'psql drop wikidata enrich table');
     }
 
     /**

--- a/provisioner/src/WikidataEnricher.php
+++ b/provisioner/src/WikidataEnricher.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Provisioner;
+
+use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Component\HttpClient\ScopingHttpClient;
+use Symfony\Contracts\HttpClient\Exception\ExceptionInterface as HttpClientExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Enriches reference places from Wikidata at provisioning time (ADR-040),
+ * replacing the former runtime enrichment: a batched SPARQL query over the
+ * bounded set of Q-IDs imported into PostGIS, returning label / description /
+ * image / website / opening hours / Wikipedia URL per item.
+ *
+ * Best-effort: a failed batch (Wikidata outage, timeout, malformed JSON) yields
+ * no enrichment for that batch rather than aborting the import — stale or absent
+ * enrichment never blocks provisioning.
+ *
+ * @phpstan-type Enrichment array{label?: string, description?: string, imageUrl?: string, website?: string, openingHours?: string, wikipediaUrl?: string}
+ */
+final readonly class WikidataEnricher
+{
+    private const int BATCH_SIZE = 50;
+
+    private const string SPARQL_ENDPOINT = 'https://query.wikidata.org/sparql';
+
+    private HttpClientInterface $httpClient;
+
+    public function __construct(
+        ?HttpClientInterface $httpClient = null,
+        private float $timeoutSeconds = 60.0,
+    ) {
+        $this->httpClient = $httpClient ?? ScopingHttpClient::forBaseUri(
+            HttpClient::create(['max_redirects' => 2, 'timeout' => $this->timeoutSeconds]),
+            'https://query.wikidata.org/',
+        );
+    }
+
+    /**
+     * @param list<string> $qIds
+     *
+     * @return array<string, Enrichment>
+     */
+    public function enrich(array $qIds, string $locale): array
+    {
+        $result = [];
+        foreach (array_chunk($qIds, self::BATCH_SIZE) as $batch) {
+            foreach ($this->fetchBatch($batch, $locale) as $qId => $entry) {
+                $result[$qId] = $entry;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param list<string> $qIds
+     *
+     * @return array<string, Enrichment>
+     */
+    private function fetchBatch(array $qIds, string $locale): array
+    {
+        $safeIds = array_values(array_filter($qIds, static fn (string $id): bool => 1 === preg_match('/^Q\d+$/', $id)));
+        if ([] === $safeIds) {
+            return [];
+        }
+
+        $values = implode(' ', array_map(static fn (string $id): string => 'wd:'.$id, $safeIds));
+        $lang = strtolower(substr($locale, 0, 2));
+
+        $sparql = <<<SPARQL
+            SELECT ?item ?itemLabel ?itemDescription ?image ?website ?openingHours ?article WHERE {
+              VALUES ?item { {$values} }
+              OPTIONAL { ?item wdt:P18 ?image. }
+              OPTIONAL { ?item wdt:P856 ?website. }
+              OPTIONAL { ?item wdt:P8989 ?openingHours. }
+              OPTIONAL {
+                ?article schema:about ?item ;
+                         schema:isPartOf <https://{$lang}.wikipedia.org/>.
+              }
+              SERVICE wikibase:label { bd:serviceParam wikibase:language "{$lang},en". }
+            }
+            SPARQL;
+
+        return $this->parseBindings($this->query($sparql));
+    }
+
+    /**
+     * @return list<array<string, array{value?: string}>>
+     */
+    private function query(string $sparql): array
+    {
+        try {
+            $response = $this->httpClient->request('GET', self::SPARQL_ENDPOINT, [
+                'query' => ['query' => $sparql, 'format' => 'json'],
+            ]);
+
+            $data = $response->toArray();
+        } catch (HttpClientExceptionInterface|\JsonException) {
+            return [];
+        }
+
+        $results = $data['results'] ?? null;
+        $bindings = \is_array($results) ? ($results['bindings'] ?? null) : null;
+        if (!\is_array($bindings)) {
+            return [];
+        }
+
+        /** @var list<array<string, array{value?: string}>> $list */
+        $list = array_values(array_filter($bindings, is_array(...)));
+
+        return $list;
+    }
+
+    /**
+     * @param list<array<string, array{value?: string}>> $bindings
+     *
+     * @return array<string, Enrichment>
+     */
+    private function parseBindings(array $bindings): array
+    {
+        $enrichments = [];
+
+        foreach ($bindings as $row) {
+            $itemUri = $row['item']['value'] ?? null;
+            if (!\is_string($itemUri)) {
+                continue;
+            }
+
+            $qId = substr((string) strrchr($itemUri, '/'), 1);
+            if (1 !== preg_match('/^Q\d+$/', $qId)) {
+                continue;
+            }
+
+            /** @var Enrichment $entry */
+            $entry = $enrichments[$qId] ?? [];
+
+            $entry['label'] ??= $this->stringField($row, 'itemLabel');
+            $entry['description'] ??= $this->stringField($row, 'itemDescription');
+            $entry['website'] ??= $this->stringField($row, 'website');
+            $entry['openingHours'] ??= $this->stringField($row, 'openingHours');
+            $entry['wikipediaUrl'] ??= $this->stringField($row, 'article');
+
+            $image = $this->stringField($row, 'image');
+            if (null !== $image && !isset($entry['imageUrl'])) {
+                $entry['imageUrl'] = $this->buildCommonsThumbUrl($image);
+            }
+
+            $enrichments[$qId] = array_filter($entry, static fn (?string $v): bool => null !== $v);
+        }
+
+        return $enrichments;
+    }
+
+    /**
+     * @param array<string, array{value?: string}> $row
+     */
+    private function stringField(array $row, string $key): ?string
+    {
+        $value = $row[$key]['value'] ?? null;
+
+        return \is_string($value) && '' !== $value ? $value : null;
+    }
+
+    /**
+     * Wikimedia Commons file URI -> direct 400 px thumbnail URL.
+     */
+    private function buildCommonsThumbUrl(string $fileUri): string
+    {
+        $cleaned = str_replace('http://', 'https://', $fileUri);
+        $separator = str_contains($cleaned, '?') ? '&' : '?';
+
+        return $cleaned.$separator.'width=400';
+    }
+}

--- a/provisioner/src/WikidataEnricher.php
+++ b/provisioner/src/WikidataEnricher.php
@@ -33,8 +33,16 @@ final readonly class WikidataEnricher
         ?HttpClientInterface $httpClient = null,
         private float $timeoutSeconds = 60.0,
     ) {
+        // Wikidata's SPARQL endpoint throttles unidentified agents aggressively
+        // (the generic Symfony default), and enrichment failures are swallowed as
+        // best-effort, so a block would silently disable enrichment: send a
+        // descriptive User-Agent per Wikidata's bot policy.
         $this->httpClient = $httpClient ?? ScopingHttpClient::forBaseUri(
-            HttpClient::create(['max_redirects' => 2, 'timeout' => $this->timeoutSeconds]),
+            HttpClient::create([
+                'max_redirects' => 2,
+                'timeout' => $this->timeoutSeconds,
+                'headers' => ['User-Agent' => 'BikeTripPlanner/1.0 (https://github.com/vincentchalamon/bike-trip-planner)'],
+            ]),
             'https://query.wikidata.org/',
         );
     }

--- a/provisioner/tests/DataTourismeImporterTest.php
+++ b/provisioner/tests/DataTourismeImporterTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Provisioner\DataTourismeImporter;
 use Provisioner\Exception\ImportFailedException;
+use Provisioner\WikidataEnricher;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Process\Process;
@@ -227,6 +228,84 @@ final class DataTourismeImporterTest extends TestCase
         self::assertStringContainsString('\t', $cultural, 'tab escaped as backslash-t');
         self::assertStringContainsString('\n', $cultural, 'newline escaped as backslash-n');
         self::assertStringContainsString('\\\\', $cultural, 'backslash escaped as double backslash');
+    }
+
+    #[Test]
+    public function enrichesWikidataBearingRowsBetweenLoadAndSwap(): void
+    {
+        // A cultural POI carrying a Wikidata Q-ID (owl:sameAs) triggers the
+        // post-load enrichment pass before the atomic swap.
+        $zipPath = $this->workDir.'/enriched.zip';
+        $zip = new \ZipArchive();
+        $zip->open($zipPath, \ZipArchive::CREATE | \ZipArchive::OVERWRITE);
+        $zip->addFromString('objects/0/00/cultural.json', (string) json_encode([
+            '@id' => 'https://data.datatourisme.fr/10/cultural',
+            '@type' => ['CulturalSite', 'Museum', 'PointOfInterest'],
+            'rdfs:label' => ['fr' => ['Musee test']],
+            'owl:sameAs' => ['https://www.wikidata.org/entity/Q243'],
+            'isLocatedAt' => [['schema:geo' => ['schema:latitude' => '48.5', 'schema:longitude' => '2.3']]],
+        ]));
+        $zip->close();
+
+        $bytes = (string) file_get_contents($zipPath);
+        unlink($zipPath);
+
+        $sparql = new MockHttpClient(new MockResponse((string) json_encode([
+            'results' => ['bindings' => [[
+                'item' => ['value' => 'http://www.wikidata.org/entity/Q243'],
+                'website' => ['value' => 'https://museum.test'],
+                'article' => ['value' => 'https://fr.wikipedia.org/wiki/Musee'],
+            ]]],
+        ])));
+
+        $importer = new DataTourismeImporter(
+            fluxUrl: 'https://example.test/flux',
+            httpClient: new MockHttpClient(new MockResponse($bytes)),
+            processFactory: $this->capturingFactory(),
+            enricher: new WikidataEnricher($sparql),
+        );
+        $importer->run($this->workDir);
+
+        $joined = array_map(static fn (array $c): string => implode(' ', $c), $this->captured);
+
+        self::assertTrue(
+            (bool) array_filter($joined, static fn (string $c): bool => str_contains($c, 'CREATE TABLE tourism_staging.wikidata_enrich')),
+            'an enrichment staging table is created',
+        );
+        self::assertTrue(
+            (bool) array_filter($joined, static fn (string $c): bool => str_contains($c, 'UPDATE tourism_staging.cultural_pois t SET') && str_contains($c, 'website = e.website') && str_contains($c, 'COALESCE(t.description, e.description)')),
+            'cultural_pois is updated from the enrichment table, keeping the source description',
+        );
+        self::assertTrue(
+            (bool) array_filter($joined, static fn (string $c): bool => str_contains($c, 'UPDATE tourism_staging.food_pois t SET')),
+            'food_pois is updated from the enrichment table',
+        );
+        self::assertTrue(
+            (bool) array_filter($joined, static fn (string $c): bool => str_contains($c, 'DROP TABLE tourism_staging.wikidata_enrich')),
+            'the enrichment staging table is dropped before the swap',
+        );
+
+        $enrich = (string) file_get_contents($this->workDir.'/tourism-wikidata.copy');
+        self::assertStringContainsString('Q243', $enrich);
+        self::assertStringContainsString('https://museum.test', $enrich);
+        self::assertStringContainsString('https://fr.wikipedia.org/wiki/Musee', $enrich);
+
+        // The DROP of the enrichment table must precede the schema swap.
+        $dropIndex = $this->commandIndex('DROP TABLE tourism_staging.wikidata_enrich');
+        $swapIndex = $this->commandIndex('ALTER SCHEMA tourism_staging RENAME TO tourism');
+        self::assertGreaterThan(-1, $dropIndex);
+        self::assertGreaterThan($dropIndex, $swapIndex);
+    }
+
+    private function commandIndex(string $needle): int
+    {
+        foreach ($this->captured as $index => $command) {
+            if (str_contains(implode(' ', $command), $needle)) {
+                return $index;
+            }
+        }
+
+        return -1;
     }
 
     #[Test]

--- a/provisioner/tests/WikidataEnricherTest.php
+++ b/provisioner/tests/WikidataEnricherTest.php
@@ -62,8 +62,8 @@ final class WikidataEnricherTest extends TestCase
     public function skipsInvalidQIdsAndSendsOnlySafeValues(): void
     {
         $captured = null;
-        $enricher = $this->enricher([], function (string $method, string $url) use (&$captured): void {
-            $captured = $url;
+        $enricher = $this->enricher([], function (string $method, string $url, array $options) use (&$captured): void {
+            $captured = $options['query']['query'] ?? $url;
         });
 
         $result = $enricher->enrich(['Q1', 'not-a-qid', 'Q2; DROP TABLE'], 'en');

--- a/provisioner/tests/WikidataEnricherTest.php
+++ b/provisioner/tests/WikidataEnricherTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Provisioner\Tests;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Provisioner\WikidataEnricher;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+final class WikidataEnricherTest extends TestCase
+{
+    /**
+     * @param list<array<string, array{value: string}>> $bindings
+     */
+    private function enricher(array $bindings, ?\Closure $onRequest = null): WikidataEnricher
+    {
+        $response = new MockResponse((string) json_encode(['results' => ['bindings' => $bindings]]));
+        $client = new MockHttpClient(static function (string $method, string $url, array $options) use ($response, $onRequest): MockResponse {
+            if ($onRequest instanceof \Closure) {
+                $onRequest($method, $url, $options);
+            }
+
+            return $response;
+        });
+
+        return new WikidataEnricher($client);
+    }
+
+    #[Test]
+    public function parsesAllFieldsFromASparqlBinding(): void
+    {
+        $enricher = $this->enricher([
+            [
+                'item' => ['value' => 'http://www.wikidata.org/entity/Q243'],
+                'itemLabel' => ['value' => 'Tour Eiffel'],
+                'itemDescription' => ['value' => 'tour de fer a Paris'],
+                'image' => ['value' => 'http://commons.wikimedia.org/wiki/Special:FilePath/Tour%20Eiffel.jpg'],
+                'website' => ['value' => 'https://www.toureiffel.paris'],
+                'openingHours' => ['value' => '09:00-23:00'],
+                'article' => ['value' => 'https://fr.wikipedia.org/wiki/Tour_Eiffel'],
+            ],
+        ]);
+
+        $result = $enricher->enrich(['Q243'], 'fr');
+
+        self::assertSame([
+            'Q243' => [
+                'label' => 'Tour Eiffel',
+                'description' => 'tour de fer a Paris',
+                'website' => 'https://www.toureiffel.paris',
+                'openingHours' => '09:00-23:00',
+                'wikipediaUrl' => 'https://fr.wikipedia.org/wiki/Tour_Eiffel',
+                'imageUrl' => 'https://commons.wikimedia.org/wiki/Special:FilePath/Tour%20Eiffel.jpg?width=400',
+            ],
+        ], $result);
+    }
+
+    #[Test]
+    public function skipsInvalidQIdsAndSendsOnlySafeValues(): void
+    {
+        $captured = null;
+        $enricher = $this->enricher([], function (string $method, string $url) use (&$captured): void {
+            $captured = $url;
+        });
+
+        $result = $enricher->enrich(['Q1', 'not-a-qid', 'Q2; DROP TABLE'], 'en');
+
+        self::assertSame([], $result);
+        self::assertIsString($captured);
+        self::assertStringContainsString('wd:Q1', $captured);
+        self::assertStringNotContainsString('DROP', $captured);
+    }
+
+    #[Test]
+    public function returnsEmptyWhenNoQIds(): void
+    {
+        $enricher = new WikidataEnricher(new MockHttpClient(new MockResponse('boom', ['http_code' => 500])));
+
+        self::assertSame([], $enricher->enrich([], 'fr'));
+    }
+
+    #[Test]
+    public function swallowsHttpFailuresAndYieldsNoEnrichment(): void
+    {
+        $enricher = new WikidataEnricher(new MockHttpClient(new MockResponse('boom', ['http_code' => 500])));
+
+        self::assertSame([], $enricher->enrich(['Q243'], 'fr'));
+    }
+}


### PR DESCRIPTION
## Contexte

Premier lot du chantier #15 (enrichissement Wikidata). Conformément à la décision produit, l'enrichissement des données **statiques/pseudo-statiques** est déplacé du runtime vers le **provisioner** (ADR-040, ligne 44 : « Enrich (in the provisioner only): Wikidata batched SPARQL over the bounded set of Q-IDs »).

Ce lot couvre uniquement les tables **tourism** (DataTourisme). Les suites :
- **PR2** : enrichissement des tables `osm.*` portant un Q-ID (`cultural_pois`, `accommodations`).
- **PR3** : lecture des colonnes enrichies côté API + **retrait complet** du `WikidataEnricher`/`WikidataClient` runtime.

## Changements

- **`provisioner/src/WikidataEnricher.php`** : port de la logique SPARQL runtime, en PHP simple. `HttpClient` scopé `query.wikidata.org` (politique SSRF), **sans cache**. Best-effort : une panne Wikidata (timeout, 5xx, JSON invalide) ne renvoie rien pour le batch concerné et **n'interrompt jamais l'import**. Q-IDs filtrés `^Q\d+$` avant la requête.
- **`provisioner/src/DataTourismeImporter.php`** : collecte des Q-IDs distincts pendant le streaming du flux (lignes `cultural_pois`/`food_pois`), puis passe d'enrichissement **post-load / pré-swap** : COPY des champs dans une table temporaire de staging, `UPDATE ... FROM` par Q-ID, `DROP` avant le `RENAME` atomique. `description`/`opening_hours` gardent la valeur DataTourisme si présente (`COALESCE`) ; `website`/`image_url`/`wikipedia_url` sont Wikidata-only.
- **Migration `Version20260617130000`** + STAGING_DDL : colonnes `website`, `image_url`, `wikipedia_url` sur `tourism.cultural_pois` et `tourism.food_pois`.
- Tests unitaires : `WikidataEnricherTest` (parsing des bindings, filtrage des Q-IDs, tolérance aux pannes HTTP) + nouveau cas `DataTourismeImporterTest::enrichesWikidataBearingRowsBetweenLoadAndSwap` (ordre des commandes psql, contenu du COPY, DROP avant swap).

## Vérification

Provisioner (host) : `phpunit` (64 tests OK), `phpstan` (level 9, no errors), `rector --dry-run` (clean), `php-cs-fixer` (clean). L'intégration psql/SPARQL réelle est validée au provisioning (non testable sur host).

<!-- claude-review-start -->
## Claude Review

**Summary:** Both previously flagged issues have been addressed: the `User-Agent` header is now properly set, and the injection-safety test correctly captures `$options['query']['query']` to assert raw SPARQL content. The implementation is clean and correct — SSRF scoping follows project policy, Q-ID filtering is applied before SPARQL interpolation, the pre-swap ordering is right, and best-effort error handling is properly implemented throughout.

**Resolved threads:** Resolved 2 previously open bot-authored threads (User-Agent header fixed; SPARQL injection-safety test assertion fixed).

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

Commit reviewed: `9a135902ccd6532a659b74475f73f0bbe2b02b1e`
<!-- claude-review-end -->