### PR TITLE
feat(provisioner): resilient orchestration + resumable Wikidata cache (ADR-041)

### DIFF
--- a/api/migrations/Version20260617140000.php
+++ b/api/migrations/Version20260617140000.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Adds the persistent Wikidata enrichment cache (ADR-041): a stable schema the
+ * provisioner reads/writes across runs, so enrichment resumes instead of
+ * re-querying every Q-ID from scratch after a crash or on the daily DataTourisme
+ * refresh (Wikidata's effective cadence is monthly, TTL-driven).
+ *
+ * Lives in its own `provisioner` schema — NOT in `tourism`/`osm`, which the
+ * provisioner drops and recreates on every atomic swap; the cache must survive
+ * those swaps. `payload` holds the enrichment fields
+ * (label/description/website/imageUrl/openingHours/wikipediaUrl), or `{}` for a
+ * Q-ID Wikidata returned no data for (negative cache, avoids re-querying it).
+ */
+final class Version20260617140000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add provisioner.wikidata_cache for resumable, TTL-driven Wikidata enrichment';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE SCHEMA IF NOT EXISTS provisioner');
+        $this->addSql(<<<'SQL'
+            CREATE TABLE IF NOT EXISTS provisioner.wikidata_cache (
+                qid text NOT NULL,
+                payload jsonb NOT NULL,
+                fetched_at timestamptz NOT NULL,
+                PRIMARY KEY (qid)
+            )
+            SQL);
+        $this->addSql('CREATE INDEX IF NOT EXISTS wikidata_cache_fetched_at_idx ON provisioner.wikidata_cache (fetched_at)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE IF EXISTS provisioner.wikidata_cache');
+        $this->addSql('DROP SCHEMA IF EXISTS provisioner');
+    }
+}

--- a/docs/adr/adr-041-provisioner-resilience.md
+++ b/docs/adr/adr-041-provisioner-resilience.md
@@ -1,0 +1,54 @@
+# ADR-041: Provisioner Resilience — Failure Isolation, Resumable Enrichment, Detailed Logging
+
+- **Status:** Accepted — orchestration hardening, the resumable Wikidata cache and network timeouts/retries have landed; staleness alerting and the remaining memory budget work follow
+- **Date:** 2026-06-17
+- **Depends on:** ADR-040 (Local-first reference data — single PostGIS source), ADR-039 (Beta right-sizing)
+
+## Context and Problem Statement
+
+ADR-040 made the provisioner the single aggregator of Tier-1 reference data: it downloads OSM PBFs, imports them with `osm2pgsql`, imports the DataTourisme flux (~1.87 GB ZIP, ~390k objects), and enriches the Wikidata-bearing rows — all behind atomic schema swaps. As more sources landed (cycle routes, ferries, fords, DataTourisme food layer, Wikidata enrichment), a single `bin/provision` invocation now chains many phases in one one-shot container (2 GB limit). Operationally that surfaces gaps:
+
+- **Long daily run.** DataTourisme is meant to refresh daily, but Wikidata enrichment was coupled to it and re-queried every Q-ID on each run, even though Wikidata's effective cadence is monthly.
+- **No resume.** A crash (OOM-kill, fatal, exception) in the middle of enrichment discarded all the network work already done; the next run restarted Wikidata from scratch.
+- **Unbounded memory.** The enricher accumulated the whole Q-ID → enrichment map in memory before writing it.
+- **Silent best-effort.** A throttled/blocked Wikidata produced zero enrichment with no signal.
+- **No concurrency guard.** Two overlapping runs (cron + manual) would both write the same staging schema and race destructively.
+- **Thin failure diagnostics.** Errors printed only a short message; the failing command and stderr were not consistently captured, and nothing survived the container logs.
+- **All-or-nothing exit.** One source failing aborted the others and produced a single opaque failure.
+
+## Decision
+
+Harden the provisioner so third-party and resource failures degrade only the affected source, never corrupt live data, and always leave enough trace to diagnose later. The target spans five workstreams (R1–R5); this ADR records all five, and the first three are implemented here.
+
+### R1 — Resilient orchestration (implemented)
+
+- **Continue-on-error per source.** Each reference source (OSM, DataTourisme) runs as an independent step; one failing does not abort the others. The command aggregates per-source outcomes into the exit code and prints a summary (`✓`/`✗` per source).
+- **Concurrency lock.** A non-blocking exclusive `flock` on `/data/provision.lock`, held for the whole run, serialises overlapping invocations. The OS releases it on process death (including a crash), so a killed run never leaves a stale lock. Scope: same `/data` volume / host (the beta deployment); a cross-host DB-level lock is deferred.
+- **Detailed, persistent logging.** Failures are written both to the console and appended (timestamped) to `/data/provisioner.log`, so the cause survives lost container logs. Importer process failures now carry the **failing command and full stderr** in the exception message.
+
+### R2 — Resumable, memory-bounded Wikidata enrichment (implemented)
+
+- **Persistent cache.** `provisioner.wikidata_cache(qid, payload jsonb, fetched_at)` lives in a stable `provisioner` schema (NOT `tourism`/`osm`, which are dropped on every swap). Only Q-IDs absent or older than the TTL (30 days) are re-queried; the live tables are enriched by joining the cache, so previously cached Q-IDs enrich the fresh staging tables with **no network call**. This gives resume after a crash and decouples Wikidata's cadence from the daily DataTourisme refresh.
+- **Negative caching.** A Q-ID Wikidata returns no data for is cached as `{}` so it is not re-queried for the TTL. A Q-ID whose batch *failed* (transient outage) is left uncached and retried next run — the two are distinguished so an outage is never negatively cached.
+- **Streaming.** The enricher yields one batch (50 Q-IDs) at a time straight into a COPY file; the cache, not a PHP map, is the join source. Memory stays bounded regardless of how many Q-IDs are enriched.
+
+### R3 — Network resilience (implemented)
+
+- **Explicit timeouts.** OSM PBF and DataTourisme flux downloads cap both the per-chunk idle wait and the total transfer (`max_duration`), so a stalled mirror fails fast instead of hanging the run.
+- **Retry with backoff.** Wikidata SPARQL batches retry on transient failures (HTTP 429/5xx, transport errors) with exponential backoff before being skipped.
+
+### R4 — Memory budget (partially implemented, rest deferred)
+
+The streaming enricher (R2) removes the largest avoidable PHP allocation. Remaining work: document and validate the `osm2pgsql --cache` vs container-limit budget, and set an explicit PHP `memory_limit`.
+
+### R5 — Staleness alerting (deferred)
+
+`/api/health` already exposes `osm.metadata` / `tourism.metadata` `refreshed_at`. Planned: age thresholds per source (and a Wikidata refresh marker) surfaced as a degraded-feature signal, plus an uptime probe and runbook — so a silently-failing cron is detected by data age, not only by a failed run.
+
+## Consequences
+
+- A Wikidata/DataTourisme/mirror outage degrades only the next refresh of that source; the live dataset and the other sources are unaffected.
+- The daily DataTourisme refresh no longer pays the full Wikidata cost; enrichment resumes from the cache after any interruption.
+- Provisioner memory stays bounded on the enrichment path; the import path budget is the remaining R4 item.
+- Failures leave a persistent, detailed trace (command + stderr) for later diagnosis.
+- The cache adds a stable `provisioner` schema, bootstrapped by a migration and self-created by the provisioner if absent.

--- a/provisioner/src/DataTourismeImporter.php
+++ b/provisioner/src/DataTourismeImporter.php
@@ -66,7 +66,20 @@ final readonly class DataTourismeImporter
      */
     private const array WIKIDATA_TABLES = ['cultural_pois', 'food_pois'];
 
-    private const string WIKIDATA_ENRICH_TABLE = 'wikidata_enrich';
+    /**
+     * Persistent enrichment cache (ADR-041), in a stable schema that survives the
+     * tourism swap. Only Q-IDs absent or older than the TTL are re-queried, so
+     * enrichment resumes after a crash and the daily refresh reuses the cache
+     * (Wikidata's effective cadence stays monthly). Scratch tables hold the
+     * per-run candidate / fetched sets; both live here and are dropped each run.
+     */
+    private const string CACHE_SCHEMA = 'provisioner';
+
+    private const string CACHE_TABLE = 'provisioner.wikidata_cache';
+
+    private const string CANDIDATES_TABLE = 'provisioner.wikidata_candidates';
+
+    private const string FETCH_TABLE = 'provisioner.wikidata_fetch';
 
     private HttpClientInterface $httpClient;
 
@@ -86,10 +99,17 @@ final readonly class DataTourismeImporter
         private float $timeoutSeconds = 1800.0,
         private WikidataEnricher $enricher = new WikidataEnricher(),
         private string $locale = 'fr',
+        private int $cacheTtlDays = 30,
     ) {
-        // Scoped to the DataTourisme origin (SSRF policy, see CLAUDE.md).
+        // Scoped to the DataTourisme origin (SSRF policy, see CLAUDE.md). Cap the
+        // total transfer (ADR-041) so a stalled flux endpoint fails fast rather
+        // than blocking the run; `timeout` is the per-chunk idle wait.
         $this->httpClient = $httpClient ?? ScopingHttpClient::forBaseUri(
-            HttpClient::create(['max_redirects' => 2, 'timeout' => $this->timeoutSeconds]),
+            HttpClient::create([
+                'max_redirects' => 2,
+                'timeout' => 120.0,
+                'max_duration' => $this->timeoutSeconds,
+            ]),
             'https://diffuseur.datatourisme.fr/',
         );
         $this->processFactory = $processFactory ?? static fn (array $command): Process => new Process($command);
@@ -296,14 +316,19 @@ final readonly class DataTourismeImporter
     }
 
     /**
-     * Enriches the staged Wikidata-bearing tables from Wikidata (ADR-040): batch
-     * SPARQL over the distinct Q-IDs seen during extraction, then a single
-     * UPDATE per table joining on the `wikidata` column. Runs after {@see load}
-     * (rows are in staging) and before {@see swap} so the enrichment lands in the
-     * dataset that goes live atomically.
+     * Enriches the staged Wikidata-bearing tables from the persistent cache
+     * (ADR-040/041). Runs after {@see load} (rows are in staging) and before
+     * {@see swap} so the enrichment lands in the dataset that goes live
+     * atomically.
      *
-     * Best-effort: an empty enrichment (Wikidata outage handled in
-     * {@see WikidataEnricher}) simply leaves the source rows untouched.
+     * Resumable + memory-bounded: only the Q-IDs absent from the cache or older
+     * than the TTL are queried from Wikidata, streamed one batch at a time into a
+     * COPY file (never the whole set in memory), upserted into the cache, then
+     * the live tables are UPDATEd by joining the cache — so previously cached
+     * Q-IDs enrich the fresh staging tables without any network call.
+     *
+     * Best-effort: a Wikidata outage leaves the missing Q-IDs uncached (retried
+     * next run) and the rows enriched only from whatever the cache already held.
      *
      * @param list<string> $wikidataIds
      *
@@ -315,59 +340,131 @@ final readonly class DataTourismeImporter
             return;
         }
 
-        $enrichments = $this->enricher->enrich($wikidataIds, $this->locale);
-        if ([] === $enrichments) {
-            return;
-        }
-
-        $path = $workDir.'/tourism-wikidata.copy';
-        $handle = fopen($path, 'w');
-        if (false === $handle) {
-            throw new ImportFailedException(\sprintf('Cannot open enrichment COPY file "%s"', $path));
-        }
-
-        foreach ($enrichments as $qId => $entry) {
-            fwrite($handle, implode("\t", array_map($this->copyValue(...), [
-                $qId,
-                $entry['description'] ?? null,
-                $entry['openingHours'] ?? null,
-                $entry['website'] ?? null,
-                $entry['imageUrl'] ?? null,
-                $entry['wikipediaUrl'] ?? null,
-            ]))."\n");
-        }
-
-        fclose($handle);
-
-        $table = \sprintf('%s.%s', self::STAGING_SCHEMA, self::WIKIDATA_ENRICH_TABLE);
+        // Self-contained: create the cache schema/table if the API migration has
+        // not run on this DB, plus fresh per-run scratch tables (drop any leftover
+        // from a prior crash — they live in the stable schema, not the swap).
         $this->runProcess([
             'psql', '-v', 'ON_ERROR_STOP=1', '-c',
-            \sprintf('CREATE TABLE %s (wikidata text PRIMARY KEY, description text, opening_hours text, website text, image_url text, wikipedia_url text);', $table),
-        ], 'psql create wikidata enrich table');
+            \sprintf(
+                'CREATE SCHEMA IF NOT EXISTS %1$s; CREATE TABLE IF NOT EXISTS %2$s (qid text PRIMARY KEY, payload jsonb NOT NULL, fetched_at timestamptz NOT NULL); DROP TABLE IF EXISTS %3$s, %4$s; CREATE TABLE %3$s (qid text); CREATE TABLE %4$s (qid text, payload jsonb);',
+                self::CACHE_SCHEMA,
+                self::CACHE_TABLE,
+                self::CANDIDATES_TABLE,
+                self::FETCH_TABLE,
+            ),
+        ], 'psql prepare wikidata cache');
 
+        // Load the candidate Q-IDs, then export those missing/stale in the cache.
+        $candidatesPath = $workDir.'/tourism-wikidata-candidates.copy';
+        $this->writeColumn($candidatesPath, $wikidataIds);
         $this->runProcess([
             'psql', '-v', 'ON_ERROR_STOP=1', '-c',
-            \sprintf("\\copy %s (wikidata, description, opening_hours, website, image_url, wikipedia_url) FROM '%s'", $table, $path),
-        ], 'psql copy wikidata enrich');
+            \sprintf("\\copy %s (qid) FROM '%s'", self::CANDIDATES_TABLE, $candidatesPath),
+        ], 'psql copy wikidata candidates');
 
-        foreach (self::WIKIDATA_TABLES as $target) {
-            // description / opening_hours come from DataTourisme first, so keep the
-            // source value when present; the other columns are Wikidata-only.
+        $missingPath = $workDir.'/tourism-wikidata-missing.copy';
+        $this->runProcess([
+            'psql', '-v', 'ON_ERROR_STOP=1', '-c',
+            \sprintf(
+                "\\copy (SELECT cand.qid FROM %1\$s cand WHERE NOT EXISTS (SELECT 1 FROM %2\$s c WHERE c.qid = cand.qid AND c.fetched_at > now() - make_interval(days => %3\$d))) TO '%4\$s'",
+                self::CANDIDATES_TABLE,
+                self::CACHE_TABLE,
+                $this->cacheTtlDays,
+                $missingPath,
+            ),
+        ], 'psql select missing wikidata');
+
+        // Query only the missing Q-IDs, streaming each batch straight to the COPY
+        // file, then upsert them into the cache (negative cache for no-data Q-IDs).
+        $missing = $this->readColumn($missingPath);
+        if ([] !== $missing) {
+            $fetchPath = $workDir.'/tourism-wikidata-fetch.copy';
+            $handle = fopen($fetchPath, 'w');
+            if (false === $handle) {
+                throw new ImportFailedException(\sprintf('Cannot open enrichment COPY file "%s"', $fetchPath));
+            }
+
+            foreach ($this->enricher->enrich($missing, $this->locale) as $row) {
+                $payload = json_encode((object) ($row['enrichment'] ?? []), \JSON_UNESCAPED_UNICODE | \JSON_UNESCAPED_SLASHES) ?: '{}';
+                fwrite($handle, $this->copyValue($row['qid'])."\t".$this->copyValue($payload)."\n");
+            }
+
+            fclose($handle);
+
+            $this->runProcess([
+                'psql', '-v', 'ON_ERROR_STOP=1', '-c',
+                \sprintf("\\copy %s (qid, payload) FROM '%s'", self::FETCH_TABLE, $fetchPath),
+            ], 'psql copy wikidata fetched');
+
             $this->runProcess([
                 'psql', '-v', 'ON_ERROR_STOP=1', '-c',
                 \sprintf(
-                    'UPDATE %1$s.%2$s t SET description = COALESCE(t.description, e.description), opening_hours = COALESCE(t.opening_hours, e.opening_hours), website = e.website, image_url = e.image_url, wikipedia_url = e.wikipedia_url FROM %3$s e WHERE t.wikidata = e.wikidata;',
+                    'INSERT INTO %1$s (qid, payload, fetched_at) SELECT qid, payload, now() FROM %2$s ON CONFLICT (qid) DO UPDATE SET payload = excluded.payload, fetched_at = excluded.fetched_at;',
+                    self::CACHE_TABLE,
+                    self::FETCH_TABLE,
+                ),
+            ], 'psql upsert wikidata cache');
+        }
+
+        // Enrich the live tables from the cache (fresh + previously cached). The
+        // source fields (description, opening_hours) win when present; the rest are
+        // Wikidata-only.
+        foreach (self::WIKIDATA_TABLES as $target) {
+            $this->runProcess([
+                'psql', '-v', 'ON_ERROR_STOP=1', '-c',
+                \sprintf(
+                    "UPDATE %1\$s.%2\$s t SET description = COALESCE(t.description, c.payload->>'description'), opening_hours = COALESCE(t.opening_hours, c.payload->>'openingHours'), website = c.payload->>'website', image_url = c.payload->>'imageUrl', wikipedia_url = c.payload->>'wikipediaUrl' FROM %3\$s c WHERE t.wikidata = c.qid;",
                     self::STAGING_SCHEMA,
                     $target,
-                    $table,
+                    self::CACHE_TABLE,
                 ),
             ], \sprintf('psql enrich %s', $target));
         }
 
         $this->runProcess([
             'psql', '-v', 'ON_ERROR_STOP=1', '-c',
-            \sprintf('DROP TABLE %s;', $table),
-        ], 'psql drop wikidata enrich table');
+            \sprintf('DROP TABLE IF EXISTS %s, %s;', self::CANDIDATES_TABLE, self::FETCH_TABLE),
+        ], 'psql drop wikidata scratch tables');
+    }
+
+    /**
+     * Writes a single-column COPY file (one escaped value per line).
+     *
+     * @param list<string> $values
+     *
+     * @throws ImportFailedException
+     */
+    private function writeColumn(string $path, array $values): void
+    {
+        $handle = fopen($path, 'w');
+        if (false === $handle) {
+            throw new ImportFailedException(\sprintf('Cannot open COPY file "%s"', $path));
+        }
+
+        foreach ($values as $value) {
+            fwrite($handle, $this->copyValue($value)."\n");
+        }
+
+        fclose($handle);
+    }
+
+    /**
+     * Reads a single-column psql COPY-out file back into a list.
+     *
+     * @return list<string>
+     */
+    private function readColumn(string $path): array
+    {
+        if (!is_file($path)) {
+            return [];
+        }
+
+        $contents = file_get_contents($path);
+        if (false === $contents || '' === trim($contents)) {
+            return [];
+        }
+
+        return array_values(array_filter(array_map(trim(...), explode("\n", $contents)), static fn (string $line): bool => '' !== $line));
     }
 
     /**
@@ -398,7 +495,7 @@ final readonly class DataTourismeImporter
         }
 
         if (!$process->isSuccessful()) {
-            throw new ImportFailedException(\sprintf('%s failed (exit %s): %s', $label, (string) $process->getExitCode(), $process->getErrorOutput()));
+            throw new ImportFailedException(\sprintf("%s failed (exit %s).\nCommand: %s\nStderr: %s", $label, (string) $process->getExitCode(), implode(' ', $command), $process->getErrorOutput()));
         }
     }
 }

--- a/provisioner/src/OsmDataDownloader.php
+++ b/provisioner/src/OsmDataDownloader.php
@@ -29,8 +29,17 @@ final readonly class OsmDataDownloader
         ?HttpClientInterface $httpClient = null,
         ?\Closure $processFactory = null,
         private float $mergeTimeoutSeconds = 600.0,
+        float $idleTimeoutSeconds = 120.0,
+        float $maxDurationSeconds = 7200.0,
     ) {
-        $this->httpClient = $httpClient ?? HttpClient::create(['max_redirects' => 2]);
+        // Multi-GB PBF downloads must not hang forever (ADR-041): cap both the
+        // per-chunk idle wait and the total transfer so a stalled Geofabrik
+        // mirror fails fast instead of blocking the whole provisioning run.
+        $this->httpClient = $httpClient ?? HttpClient::create([
+            'max_redirects' => 2,
+            'timeout' => $idleTimeoutSeconds,
+            'max_duration' => $maxDurationSeconds,
+        ]);
         $this->processFactory = $processFactory ?? static fn (array $command): Process => new Process($command);
     }
 

--- a/provisioner/src/PostgisImporter.php
+++ b/provisioner/src/PostgisImporter.php
@@ -198,7 +198,7 @@ final readonly class PostgisImporter
         }
 
         if (!$process->isSuccessful()) {
-            throw new ImportFailedException(\sprintf('%s failed (exit %s): %s', $label, (string) $process->getExitCode(), $process->getErrorOutput()));
+            throw new ImportFailedException(\sprintf("%s failed (exit %s).\nCommand: %s\nStderr: %s", $label, (string) $process->getExitCode(), implode(' ', $command), $process->getErrorOutput()));
         }
     }
 }

--- a/provisioner/src/ProvisionCommand.php
+++ b/provisioner/src/ProvisionCommand.php
@@ -31,6 +31,16 @@ final class ProvisionCommand extends Command
 
     private const string DEFAULT_DATATOURISME_DIR = '/data/datatourisme';
 
+    private const string DEFAULT_LOCK_FILE = '/data/provision.lock';
+
+    private const string DEFAULT_LOG_FILE = '/data/provisioner.log';
+
+    /**
+     * @var resource|null held for the whole command so the flock is released only
+     *                    when the process ends (incl. a crash: the OS drops it)
+     */
+    private $lockHandle;
+
     private readonly RegionSelectionStore $selectionStore;
 
     private readonly OsmDataDownloader $downloader;
@@ -49,6 +59,8 @@ final class ProvisionCommand extends Command
         private readonly string $dataTourismeDir = self::DEFAULT_DATATOURISME_DIR,
         // Built lazily in runDataTourisme() from DATATOURISME_* env when not injected.
         private readonly ?DataTourismeImporter $dataTourismeImporter = null,
+        private readonly string $lockFile = self::DEFAULT_LOCK_FILE,
+        private readonly string $logFile = self::DEFAULT_LOG_FILE,
     ) {
         parent::__construct();
 
@@ -83,17 +95,103 @@ final class ProvisionCommand extends Command
             return Command::FAILURE;
         }
 
-        $result = $hasSelection
-            ? $this->runUpdateFlow($io, $dryRun, $interactive, $importPostgis)
-            : $this->runInstallFlow($io, $dryRun, $importPostgis);
-
-        // DataTourisme is FR-only and independent of the OSM region selection,
-        // so it runs as its own step (its own download, schema and atomic swap).
-        if (Command::SUCCESS === $result && $importDataTourisme && !$dryRun) {
-            $result = $this->runDataTourisme($io);
+        // Serialise concurrent runs (cron + manual overlap): two provisioners
+        // writing the same staging schema would race destructively (ADR-041).
+        if (!$this->acquireLock($io)) {
+            return Command::FAILURE;
         }
 
-        return $result;
+        try {
+            // Each reference source runs as its own step (own download, schema and
+            // atomic swap) and is attempted independently: one source failing must
+            // not abort the others, so a single bad refresh degrades only its own
+            // dataset (ADR-041). Outcomes are aggregated into the final exit code.
+            $outcomes = [];
+
+            $outcomes['osm'] = $hasSelection
+                ? $this->runUpdateFlow($io, $dryRun, $interactive, $importPostgis)
+                : $this->runInstallFlow($io, $dryRun, $importPostgis);
+
+            if ($importDataTourisme && !$dryRun) {
+                $outcomes['datatourisme'] = $this->runDataTourisme($io);
+            }
+
+            $this->summarize($io, $outcomes);
+
+            return \in_array(Command::FAILURE, $outcomes, true) ? Command::FAILURE : Command::SUCCESS;
+        } finally {
+            $this->releaseLock();
+        }
+    }
+
+    /**
+     * Acquires an exclusive, non-blocking file lock held for the whole run. The
+     * OS releases it when the process ends — including a crash — so a killed run
+     * never leaves a stale lock behind.
+     */
+    private function acquireLock(SymfonyStyle $io): bool
+    {
+        $handle = @fopen($this->lockFile, 'c');
+        if (false === $handle) {
+            // No lock file location (e.g. /data not mounted): proceed rather than
+            // block provisioning on an inability to lock.
+            $io->warning(\sprintf('Cannot open lock file "%s"; proceeding without a concurrency lock.', $this->lockFile));
+
+            return true;
+        }
+
+        if (!flock($handle, \LOCK_EX | \LOCK_NB)) {
+            fclose($handle);
+            $message = 'Another provisioning run is already in progress; aborting.';
+            $io->error($message);
+            $this->logLine('ERROR', $message);
+
+            return false;
+        }
+
+        $this->lockHandle = $handle;
+
+        return true;
+    }
+
+    private function releaseLock(): void
+    {
+        if (\is_resource($this->lockHandle)) {
+            flock($this->lockHandle, \LOCK_UN);
+            fclose($this->lockHandle);
+            $this->lockHandle = null;
+        }
+    }
+
+    /**
+     * @param array<string, int> $outcomes source label => Command exit code
+     */
+    private function summarize(SymfonyStyle $io, array $outcomes): void
+    {
+        $io->section('Provisioning summary');
+        foreach ($outcomes as $source => $code) {
+            $ok = Command::SUCCESS === $code;
+            $io->writeln(\sprintf('  %s %s', $ok ? "\u{2713}" : "\u{2717}", $source));
+            $this->logLine($ok ? 'INFO' : 'ERROR', \sprintf('source %s -> %s', $source, $ok ? 'ok' : 'failed'));
+        }
+    }
+
+    /**
+     * Reports a failure both to the console and to the persistent log file, so
+     * the detailed cause (command + stderr) survives for later diagnosis even
+     * when the container logs are gone (ADR-041).
+     */
+    private function fail(SymfonyStyle $io, string $message): void
+    {
+        $io->error($message);
+        $this->logLine('ERROR', $message);
+    }
+
+    private function logLine(string $level, string $message): void
+    {
+        $line = \sprintf("[%s] [%s] %s\n", new \DateTimeImmutable()->format('Y-m-d H:i:s'), $level, $message);
+        // Best-effort: never let logging failure mask the real outcome.
+        @file_put_contents($this->logFile, $line, \FILE_APPEND);
     }
 
     private function runDataTourisme(SymfonyStyle $io): int
@@ -124,7 +222,7 @@ final class ProvisionCommand extends Command
         try {
             $importer->run($this->dataTourismeDir);
         } catch (ImportFailedException $importFailedException) {
-            $io->error($importFailedException->getMessage());
+            $this->fail($io, $importFailedException->getMessage());
 
             return Command::FAILURE;
         }
@@ -323,7 +421,7 @@ final class ProvisionCommand extends Command
                 $this->downloader->download($slug);
             } catch (DownloadFailedException $e) {
                 $io->newLine();
-                $io->error($e->getMessage());
+                $this->fail($io, $e->getMessage());
 
                 return Command::FAILURE;
             }
@@ -343,7 +441,7 @@ final class ProvisionCommand extends Command
                 $this->downloader->merge($pbfFiles, $this->mergedPbf);
             } catch (MergeFailedException $e) {
                 $io->newLine();
-                $io->error($e->getMessage());
+                $this->fail($io, $e->getMessage());
 
                 return Command::FAILURE;
             }
@@ -358,7 +456,7 @@ final class ProvisionCommand extends Command
                 $this->postgisImporter->run($this->mergedPbf, $this->filteredPbf);
             } catch (ImportFailedException $e) {
                 $io->newLine();
-                $io->error($e->getMessage());
+                $this->fail($io, $e->getMessage());
 
                 return Command::FAILURE;
             }

--- a/provisioner/src/WikidataEnricher.php
+++ b/provisioner/src/WikidataEnricher.php
@@ -37,12 +37,12 @@ final readonly class WikidataEnricher
     private HttpClientInterface $httpClient;
 
     /**
-     * @param (callable(int): void)|null $sleep injectable sleeper (seconds) so tests don't wait on backoff
+     * @param (\Closure(int): void)|null $sleep injectable sleeper (seconds) so tests don't wait on backoff
      */
     public function __construct(
         ?HttpClientInterface $httpClient = null,
         private float $timeoutSeconds = 60.0,
-        private mixed $sleep = null,
+        private ?\Closure $sleep = null,
     ) {
         // Wikidata's SPARQL endpoint throttles unidentified agents aggressively
         // (the generic Symfony default), and enrichment failures are tolerated as
@@ -212,7 +212,7 @@ final readonly class WikidataEnricher
 
     private function doSleep(int $seconds): void
     {
-        if (null !== $this->sleep) {
+        if ($this->sleep instanceof \Closure) {
             ($this->sleep)($seconds);
 
             return;

--- a/provisioner/src/WikidataEnricher.php
+++ b/provisioner/src/WikidataEnricher.php
@@ -10,14 +10,19 @@ use Symfony\Contracts\HttpClient\Exception\ExceptionInterface as HttpClientExcep
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
- * Enriches reference places from Wikidata at provisioning time (ADR-040),
+ * Enriches reference places from Wikidata at provisioning time (ADR-040/041),
  * replacing the former runtime enrichment: a batched SPARQL query over the
  * bounded set of Q-IDs imported into PostGIS, returning label / description /
  * image / website / opening hours / Wikipedia URL per item.
  *
- * Best-effort: a failed batch (Wikidata outage, timeout, malformed JSON) yields
- * no enrichment for that batch rather than aborting the import — stale or absent
- * enrichment never blocks provisioning.
+ * Streams one batch at a time (yields per Q-ID) so the caller never holds the
+ * whole enrichment set in memory — the persistent cache, not a PHP map, is the
+ * join source for the UPDATE (ADR-041 memory budget).
+ *
+ * Resilient (ADR-041): each batch is retried with backoff on transient failures
+ * (HTTP 429/5xx, transport errors). A batch that still fails is simply skipped —
+ * its Q-IDs are NOT yielded, so they stay uncached and are retried on the next
+ * run rather than being negatively cached after a transient Wikidata outage.
  *
  * @phpstan-type Enrichment array{label?: string, description?: string, imageUrl?: string, website?: string, openingHours?: string, wikipediaUrl?: string}
  */
@@ -25,16 +30,22 @@ final readonly class WikidataEnricher
 {
     private const int BATCH_SIZE = 50;
 
+    private const int MAX_ATTEMPTS = 3;
+
     private const string SPARQL_ENDPOINT = 'https://query.wikidata.org/sparql';
 
     private HttpClientInterface $httpClient;
 
+    /**
+     * @param (callable(int): void)|null $sleep injectable sleeper (seconds) so tests don't wait on backoff
+     */
     public function __construct(
         ?HttpClientInterface $httpClient = null,
         private float $timeoutSeconds = 60.0,
+        private mixed $sleep = null,
     ) {
         // Wikidata's SPARQL endpoint throttles unidentified agents aggressively
-        // (the generic Symfony default), and enrichment failures are swallowed as
+        // (the generic Symfony default), and enrichment failures are tolerated as
         // best-effort, so a block would silently disable enrichment: send a
         // descriptive User-Agent per Wikidata's bot policy.
         $this->httpClient = $httpClient ?? ScopingHttpClient::forBaseUri(
@@ -48,34 +59,40 @@ final readonly class WikidataEnricher
     }
 
     /**
+     * Yields one entry per Q-ID of every batch that completed, with its
+     * enrichment (or null when Wikidata holds no data for it — a negative-cache
+     * marker). Q-IDs of a batch that failed all attempts are not yielded.
+     *
      * @param list<string> $qIds
      *
-     * @return array<string, Enrichment>
+     * @return \Generator<int, array{qid: string, enrichment: Enrichment|null}>
      */
-    public function enrich(array $qIds, string $locale): array
+    public function enrich(array $qIds, string $locale): \Generator
     {
-        $result = [];
         foreach (array_chunk($qIds, self::BATCH_SIZE) as $batch) {
-            foreach ($this->fetchBatch($batch, $locale) as $qId => $entry) {
-                $result[$qId] = $entry;
+            $safeIds = array_values(array_filter($batch, static fn (string $id): bool => 1 === preg_match('/^Q\d+$/', $id)));
+            if ([] === $safeIds) {
+                continue;
+            }
+
+            $enrichments = $this->fetchBatch($safeIds, $locale);
+            if (null === $enrichments) {
+                continue;
+            }
+
+            foreach ($safeIds as $qId) {
+                yield ['qid' => $qId, 'enrichment' => $enrichments[$qId] ?? null];
             }
         }
-
-        return $result;
     }
 
     /**
-     * @param list<string> $qIds
+     * @param list<string> $safeIds pre-validated Q-IDs (^Q\d+$)
      *
-     * @return array<string, Enrichment>
+     * @return array<string, Enrichment>|null null when the batch failed every attempt
      */
-    private function fetchBatch(array $qIds, string $locale): array
+    private function fetchBatch(array $safeIds, string $locale): ?array
     {
-        $safeIds = array_values(array_filter($qIds, static fn (string $id): bool => 1 === preg_match('/^Q\d+$/', $id)));
-        if ([] === $safeIds) {
-            return [];
-        }
-
         $values = implode(' ', array_map(static fn (string $id): string => 'wd:'.$id, $safeIds));
         $lang = strtolower(substr($locale, 0, 2));
 
@@ -93,34 +110,43 @@ final readonly class WikidataEnricher
             }
             SPARQL;
 
-        return $this->parseBindings($this->query($sparql));
+        $bindings = $this->query($sparql);
+
+        return null === $bindings ? null : $this->parseBindings($bindings);
     }
 
     /**
-     * @return list<array<string, array{value?: string}>>
+     * @return list<array<string, array{value?: string}>>|null null when every attempt failed
      */
-    private function query(string $sparql): array
+    private function query(string $sparql): ?array
     {
-        try {
-            $response = $this->httpClient->request('GET', self::SPARQL_ENDPOINT, [
-                'query' => ['query' => $sparql, 'format' => 'json'],
-            ]);
+        for ($attempt = 1;; ++$attempt) {
+            try {
+                $response = $this->httpClient->request('GET', self::SPARQL_ENDPOINT, [
+                    'query' => ['query' => $sparql, 'format' => 'json'],
+                ]);
 
-            $data = $response->toArray();
-        } catch (HttpClientExceptionInterface|\JsonException) {
-            return [];
+                $data = $response->toArray();
+
+                $results = $data['results'] ?? null;
+                $bindings = \is_array($results) ? ($results['bindings'] ?? null) : null;
+                if (!\is_array($bindings)) {
+                    return [];
+                }
+
+                /** @var list<array<string, array{value?: string}>> $list */
+                $list = array_values(array_filter($bindings, is_array(...)));
+
+                return $list;
+            } catch (HttpClientExceptionInterface|\JsonException) {
+                if ($attempt >= self::MAX_ATTEMPTS) {
+                    return null;
+                }
+
+                // Exponential backoff (1s, 2s, …) before retrying a transient failure.
+                $this->doSleep(2 ** ($attempt - 1));
+            }
         }
-
-        $results = $data['results'] ?? null;
-        $bindings = \is_array($results) ? ($results['bindings'] ?? null) : null;
-        if (!\is_array($bindings)) {
-            return [];
-        }
-
-        /** @var list<array<string, array{value?: string}>> $list */
-        $list = array_values(array_filter($bindings, is_array(...)));
-
-        return $list;
     }
 
     /**
@@ -182,5 +208,16 @@ final readonly class WikidataEnricher
         $separator = str_contains($cleaned, '?') ? '&' : '?';
 
         return $cleaned.$separator.'width=400';
+    }
+
+    private function doSleep(int $seconds): void
+    {
+        if (null !== $this->sleep) {
+            ($this->sleep)($seconds);
+
+            return;
+        }
+
+        sleep($seconds);
     }
 }

--- a/provisioner/tests/DataTourismeImporterTest.php
+++ b/provisioner/tests/DataTourismeImporterTest.php
@@ -116,6 +116,16 @@ final class DataTourismeImporterTest extends TestCase
             $cmd = $command;
             $this->captured[] = $cmd;
 
+            // Emulate psql `\copy (SELECT … missing …) TO 'file'`: with an empty
+            // cache every candidate is missing, so copy the candidates COPY file
+            // into the destination so the enrichment fetch path runs in tests.
+            if (1 === preg_match("/TO '([^']+)'/", implode(' ', $cmd), $matches)) {
+                $candidates = $this->workDir.'/tourism-wikidata-candidates.copy';
+                if (is_file($candidates)) {
+                    copy($candidates, $matches[1]);
+                }
+            }
+
             return new Process(['true']);
         };
     }
@@ -231,10 +241,10 @@ final class DataTourismeImporterTest extends TestCase
     }
 
     #[Test]
-    public function enrichesWikidataBearingRowsBetweenLoadAndSwap(): void
+    public function enrichesWikidataBearingRowsFromTheCacheBetweenLoadAndSwap(): void
     {
         // A cultural POI carrying a Wikidata Q-ID (owl:sameAs) triggers the
-        // post-load enrichment pass before the atomic swap.
+        // post-load, cache-backed enrichment pass before the atomic swap.
         $zipPath = $this->workDir.'/enriched.zip';
         $zip = new \ZipArchive();
         $zip->open($zipPath, \ZipArchive::CREATE | \ZipArchive::OVERWRITE);
@@ -267,31 +277,31 @@ final class DataTourismeImporterTest extends TestCase
         $importer->run($this->workDir);
 
         $joined = array_map(static fn (array $c): string => implode(' ', $c), $this->captured);
-
-        self::assertTrue(
-            (bool) array_filter($joined, static fn (string $c): bool => str_contains($c, 'CREATE TABLE tourism_staging.wikidata_enrich')),
-            'an enrichment staging table is created',
-        );
-        self::assertTrue(
-            (bool) array_filter($joined, static fn (string $c): bool => str_contains($c, 'UPDATE tourism_staging.cultural_pois t SET') && str_contains($c, 'website = e.website') && str_contains($c, 'COALESCE(t.description, e.description)')),
-            'cultural_pois is updated from the enrichment table, keeping the source description',
-        );
-        self::assertTrue(
-            (bool) array_filter($joined, static fn (string $c): bool => str_contains($c, 'UPDATE tourism_staging.food_pois t SET')),
-            'food_pois is updated from the enrichment table',
-        );
-        self::assertTrue(
-            (bool) array_filter($joined, static fn (string $c): bool => str_contains($c, 'DROP TABLE tourism_staging.wikidata_enrich')),
-            'the enrichment staging table is dropped before the swap',
+        $has = static fn (string ...$needles): bool => (bool) array_filter(
+            $joined,
+            static fn (string $c): bool => array_all($needles, static fn (string $n): bool => str_contains($c, $n)),
         );
 
-        $enrich = (string) file_get_contents($this->workDir.'/tourism-wikidata.copy');
-        self::assertStringContainsString('Q243', $enrich);
-        self::assertStringContainsString('https://museum.test', $enrich);
-        self::assertStringContainsString('https://fr.wikipedia.org/wiki/Musee', $enrich);
+        self::assertTrue($has('CREATE TABLE IF NOT EXISTS provisioner.wikidata_cache'), 'the persistent cache is ensured');
+        self::assertTrue($has('CREATE TABLE provisioner.wikidata_candidates'), 'a candidates scratch table is created');
+        self::assertTrue($has('\copy provisioner.wikidata_candidates (qid) FROM'), 'candidate Q-IDs are loaded');
+        self::assertTrue($has('TO ', 'SELECT cand.qid', 'NOT EXISTS', 'make_interval'), 'missing/stale Q-IDs are selected against the TTL');
+        self::assertTrue($has('\copy provisioner.wikidata_fetch (qid, payload) FROM'), 'fetched enrichments are staged');
+        self::assertTrue($has('INSERT INTO provisioner.wikidata_cache', 'ON CONFLICT (qid) DO UPDATE'), 'fetched enrichments are upserted into the cache');
+        self::assertTrue(
+            $has('UPDATE tourism_staging.cultural_pois t SET', "website = c.payload->>'website'", "COALESCE(t.description, c.payload->>'description')", 'FROM provisioner.wikidata_cache c'),
+            'cultural_pois is enriched from the cache, keeping the source description',
+        );
+        self::assertTrue($has('UPDATE tourism_staging.food_pois t SET', 'FROM provisioner.wikidata_cache c'), 'food_pois is enriched from the cache');
+        self::assertTrue($has('DROP TABLE IF EXISTS provisioner.wikidata_candidates, provisioner.wikidata_fetch'), 'scratch tables are dropped');
 
-        // The DROP of the enrichment table must precede the schema swap.
-        $dropIndex = $this->commandIndex('DROP TABLE tourism_staging.wikidata_enrich');
+        $fetch = (string) file_get_contents($this->workDir.'/tourism-wikidata-fetch.copy');
+        self::assertStringContainsString('Q243', $fetch);
+        self::assertStringContainsString('https://museum.test', $fetch);
+        self::assertStringContainsString('https://fr.wikipedia.org/wiki/Musee', $fetch);
+
+        // The scratch tables are dropped before the schema swap.
+        $dropIndex = $this->commandIndex('DROP TABLE IF EXISTS provisioner.wikidata_candidates');
         $swapIndex = $this->commandIndex('ALTER SCHEMA tourism_staging RENAME TO tourism');
         self::assertGreaterThan(-1, $dropIndex);
         self::assertGreaterThan($dropIndex, $swapIndex);

--- a/provisioner/tests/ProvisionCommandTest.php
+++ b/provisioner/tests/ProvisionCommandTest.php
@@ -65,6 +65,7 @@ final class ProvisionCommandTest extends TestCase
         ?\Closure $downloaderProcessFactory = null,
         ?PostgisImporter $postgisImporter = null,
         ?DataTourismeImporter $dataTourismeImporter = null,
+        ?string $lockFile = null,
     ): CommandTester {
         $command = new ProvisionCommand(
             regionsDir: $this->regionsDir,
@@ -79,7 +80,7 @@ final class ProvisionCommandTest extends TestCase
             postgisImporter: $postgisImporter,
             dataTourismeDir: $this->tmpDir.'/datatourisme',
             dataTourismeImporter: $dataTourismeImporter,
-            lockFile: $this->tmpDir.'/provision.lock',
+            lockFile: $lockFile ?? $this->tmpDir.'/provision.lock',
             logFile: $this->tmpDir.'/provisioner.log',
         );
 
@@ -311,6 +312,22 @@ final class ProvisionCommandTest extends TestCase
         self::assertStringContainsString('Provisioning summary', $output);
         self::assertMatchesRegularExpression('/\x{2713}\s*osm/u', $output, 'osm reported as succeeded');
         self::assertMatchesRegularExpression('/\x{2717}\s*datatourisme/u', $output, 'datatourisme reported as failed');
+    }
+
+    #[Test]
+    public function proceedsWithWarningWhenLockFileCannotBeOpened(): void
+    {
+        // /data not mounted (fopen returns false): the run proceeds with a warning
+        // rather than blocking on an inability to lock (ADR-041 R1).
+        new RegionSelectionStore($this->selectionFile)->save(['bretagne']);
+
+        // A path under a non-directory makes fopen('…', 'c') fail.
+        $tester = $this->buildTester(lockFile: '/dev/null/no-such-path');
+        $exitCode = $tester->execute([], ['interactive' => false]);
+
+        self::assertSame(0, $exitCode, $tester->getDisplay());
+        // The warning block word-wraps, so assert a single non-splittable token.
+        self::assertStringContainsString('concurrency', $tester->getDisplay());
     }
 
     #[Test]

--- a/provisioner/tests/ProvisionCommandTest.php
+++ b/provisioner/tests/ProvisionCommandTest.php
@@ -6,6 +6,7 @@ namespace Provisioner\Tests;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Provisioner\DataTourismeImporter;
 use Provisioner\OsmDataDownloader;
 use Provisioner\PostgisImporter;
 use Provisioner\ProvisionCommand;
@@ -63,6 +64,7 @@ final class ProvisionCommandTest extends TestCase
         bool $runMerge = false,
         ?\Closure $downloaderProcessFactory = null,
         ?PostgisImporter $postgisImporter = null,
+        ?DataTourismeImporter $dataTourismeImporter = null,
     ): CommandTester {
         $command = new ProvisionCommand(
             regionsDir: $this->regionsDir,
@@ -75,6 +77,10 @@ final class ProvisionCommandTest extends TestCase
             ),
             runMerge: $runMerge,
             postgisImporter: $postgisImporter,
+            dataTourismeDir: $this->tmpDir.'/datatourisme',
+            dataTourismeImporter: $dataTourismeImporter,
+            lockFile: $this->tmpDir.'/provision.lock',
+            logFile: $this->tmpDir.'/provisioner.log',
         );
 
         $app = new Application();
@@ -279,6 +285,53 @@ final class ProvisionCommandTest extends TestCase
 
         self::assertSame(1, $exitCode);
         self::assertStringContainsString('tags-filter failed', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function aFailedDataTourismeSourceDoesNotMaskTheSucceededOsmSource(): void
+    {
+        // Continue-on-error (ADR-041): OSM succeeds, DataTourisme fails; the run
+        // attempts both, the summary records each, and the aggregate exit is a
+        // failure without aborting the OSM source.
+        new RegionSelectionStore($this->selectionFile)->save(['bretagne']);
+
+        $failingDataTourisme = new DataTourismeImporter(
+            fluxUrl: 'https://example.test/flux',
+            httpClient: new MockHttpClient(new MockResponse('nope', ['http_code' => 500])),
+            processFactory: static fn (array $command): Process => new Process(['true']),
+        );
+
+        $tester = $this->buildTester(dataTourismeImporter: $failingDataTourisme);
+
+        $exitCode = $tester->execute(['--with-datatourisme' => true], ['interactive' => false]);
+
+        self::assertSame(1, $exitCode, $tester->getDisplay());
+        $output = $tester->getDisplay();
+        self::assertStringContainsString('Update complete', $output, 'the OSM source still completed');
+        self::assertStringContainsString('Provisioning summary', $output);
+        self::assertMatchesRegularExpression('/\x{2713}\s*osm/u', $output, 'osm reported as succeeded');
+        self::assertMatchesRegularExpression('/\x{2717}\s*datatourisme/u', $output, 'datatourisme reported as failed');
+    }
+
+    #[Test]
+    public function aConcurrentRunIsRefusedWhileTheLockIsHeld(): void
+    {
+        new RegionSelectionStore($this->selectionFile)->save(['bretagne']);
+
+        // Hold the lock the command tries to acquire.
+        $lockFile = $this->tmpDir.'/provision.lock';
+        $handle = fopen($lockFile, 'c');
+        self::assertNotFalse($handle);
+        self::assertTrue(flock($handle, \LOCK_EX | \LOCK_NB));
+
+        $tester = $this->buildTester();
+        $exitCode = $tester->execute([], ['interactive' => false]);
+
+        self::assertSame(1, $exitCode);
+        self::assertStringContainsString('Another provisioning run is already in progress', $tester->getDisplay());
+
+        flock($handle, \LOCK_UN);
+        fclose($handle);
     }
 
     #[Test]

--- a/provisioner/tests/WikidataEnricherTest.php
+++ b/provisioner/tests/WikidataEnricherTest.php
@@ -13,26 +13,51 @@ use Symfony\Component\HttpClient\Response\MockResponse;
 final class WikidataEnricherTest extends TestCase
 {
     /**
-     * @param list<array<string, array{value: string}>> $bindings
+     * @param list<MockResponse>                                          $responses
+     * @param (\Closure(string, string, array<string, mixed>): void)|null $onRequest
      */
-    private function enricher(array $bindings, ?\Closure $onRequest = null): WikidataEnricher
+    private function enricher(array $responses, ?\Closure $onRequest = null): WikidataEnricher
     {
-        $response = new MockResponse((string) json_encode(['results' => ['bindings' => $bindings]]));
-        $client = new MockHttpClient(static function (string $method, string $url, array $options) use ($response, $onRequest): MockResponse {
+        $i = 0;
+        $client = new MockHttpClient(static function (string $method, string $url, array $options) use (&$i, $responses, $onRequest): MockResponse {
             if ($onRequest instanceof \Closure) {
                 $onRequest($method, $url, $options);
             }
 
-            return $response;
+            return $responses[$i++] ?? new MockResponse((string) json_encode(['results' => ['bindings' => []]]));
         });
 
-        return new WikidataEnricher($client);
+        // No-op sleeper so backoff never waits during tests.
+        return new WikidataEnricher($client, sleep: static fn (int $seconds): null => null);
+    }
+
+    /**
+     * @param list<array<string, array{value: string}>> $bindings
+     */
+    private function bindingsResponse(array $bindings): MockResponse
+    {
+        return new MockResponse((string) json_encode(['results' => ['bindings' => $bindings]]));
+    }
+
+    /**
+     * @param list<string> $qIds
+     *
+     * @return array<string, array<string, string>|null>
+     */
+    private function collect(WikidataEnricher $enricher, array $qIds, string $locale): array
+    {
+        $out = [];
+        foreach ($enricher->enrich($qIds, $locale) as $row) {
+            $out[$row['qid']] = $row['enrichment'];
+        }
+
+        return $out;
     }
 
     #[Test]
     public function parsesAllFieldsFromASparqlBinding(): void
     {
-        $enricher = $this->enricher([
+        $enricher = $this->enricher([$this->bindingsResponse([
             [
                 'item' => ['value' => 'http://www.wikidata.org/entity/Q243'],
                 'itemLabel' => ['value' => 'Tour Eiffel'],
@@ -42,9 +67,7 @@ final class WikidataEnricherTest extends TestCase
                 'openingHours' => ['value' => '09:00-23:00'],
                 'article' => ['value' => 'https://fr.wikipedia.org/wiki/Tour_Eiffel'],
             ],
-        ]);
-
-        $result = $enricher->enrich(['Q243'], 'fr');
+        ])]);
 
         self::assertSame([
             'Q243' => [
@@ -55,38 +78,70 @@ final class WikidataEnricherTest extends TestCase
                 'wikipediaUrl' => 'https://fr.wikipedia.org/wiki/Tour_Eiffel',
                 'imageUrl' => 'https://commons.wikimedia.org/wiki/Special:FilePath/Tour%20Eiffel.jpg?width=400',
             ],
-        ], $result);
+        ], $this->collect($enricher, ['Q243'], 'fr'));
+    }
+
+    #[Test]
+    public function yieldsANegativeMarkerForAQIdWithNoData(): void
+    {
+        // The batch succeeds (HTTP 200) but Wikidata returns no binding for the
+        // Q-ID: it must still be yielded with a null enrichment so the caller can
+        // negatively cache it and stop re-querying it.
+        $enricher = $this->enricher([$this->bindingsResponse([])]);
+
+        self::assertSame(['Q999' => null], $this->collect($enricher, ['Q999'], 'fr'));
     }
 
     #[Test]
     public function skipsInvalidQIdsAndSendsOnlySafeValues(): void
     {
         $captured = null;
-        $enricher = $this->enricher([], function (string $method, string $url, array $options) use (&$captured): void {
-            $captured = $options['query']['query'] ?? $url;
+        $enricher = $this->enricher([$this->bindingsResponse([])], function (string $method, string $url, array $options) use (&$captured): void {
+            $query = $options['query'] ?? null;
+            $captured = \is_array($query) && \is_string($query['query'] ?? null) ? $query['query'] : $url;
         });
 
-        $result = $enricher->enrich(['Q1', 'not-a-qid', 'Q2; DROP TABLE'], 'en');
+        $result = $this->collect($enricher, ['Q1', 'not-a-qid', 'Q2; DROP TABLE'], 'en');
 
-        self::assertSame([], $result);
+        self::assertSame(['Q1' => null], $result);
         self::assertIsString($captured);
         self::assertStringContainsString('wd:Q1', $captured);
         self::assertStringNotContainsString('DROP', $captured);
     }
 
     #[Test]
-    public function returnsEmptyWhenNoQIds(): void
+    public function yieldsNothingWhenNoQIds(): void
     {
-        $enricher = new WikidataEnricher(new MockHttpClient(new MockResponse('boom', ['http_code' => 500])));
+        $enricher = $this->enricher([]);
 
-        self::assertSame([], $enricher->enrich([], 'fr'));
+        self::assertSame([], $this->collect($enricher, [], 'fr'));
     }
 
     #[Test]
-    public function swallowsHttpFailuresAndYieldsNoEnrichment(): void
+    public function skipsABatchThatFailsEveryAttempt(): void
     {
-        $enricher = new WikidataEnricher(new MockHttpClient(new MockResponse('boom', ['http_code' => 500])));
+        // Three persistent 500s (= MAX_ATTEMPTS): the batch is dropped entirely,
+        // so its Q-IDs are not yielded (left uncached, retried next run) rather
+        // than negatively cached after a transient outage.
+        $enricher = $this->enricher([
+            new MockResponse('boom', ['http_code' => 500]),
+            new MockResponse('boom', ['http_code' => 500]),
+            new MockResponse('boom', ['http_code' => 500]),
+        ]);
 
-        self::assertSame([], $enricher->enrich(['Q243'], 'fr'));
+        self::assertSame([], $this->collect($enricher, ['Q243'], 'fr'));
+    }
+
+    #[Test]
+    public function retriesAfterATransientFailureThenSucceeds(): void
+    {
+        $enricher = $this->enricher([
+            new MockResponse('busy', ['http_code' => 503]),
+            $this->bindingsResponse([
+                ['item' => ['value' => 'http://www.wikidata.org/entity/Q243'], 'website' => ['value' => 'https://ok.test']],
+            ]),
+        ]);
+
+        self::assertSame(['Q243' => ['website' => 'https://ok.test']], $this->collect($enricher, ['Q243'], 'fr'));
     }
 }


### PR DESCRIPTION
## Contexte

Suite à ta question sur la robustesse du provisioner (durée du run quotidien, anticipation des erreurs OOM/Fatal/Exceptions, reprise au point d'arrêt, logs détaillés). Analyse actée → **ADR-041** + workstreams **R1+R2+R3** implémentés ici. R4 (budget mémoire import) partiel, R5 (alerte staleness) différé — listés dans l'ADR.

## R1 — Orchestration résiliente

- **Continue-on-error par source** : OSM et DataTourisme tournent indépendamment ; l'échec de l'un n'abandonne plus l'autre. Code de sortie agrégé + **résumé** (`✓`/`✗` par source).
- **Verrou anti-concurrence** : `flock` exclusif non bloquant sur `/data/provision.lock`, tenu pour tout le run ; l'OS le libère même en cas de crash (pas de verrou fantôme). Deux runs (cron + manuel) ne peuvent plus se télescoper sur le schéma de staging.
- **Logs détaillés persistés** : les échecs sont écrits console **et** append horodaté dans `/data/provisioner.log` (survit aux logs conteneur perdus). Les exceptions des importers portent désormais **la commande qui a échoué + stderr complet**.

## R2 — Enrichissement Wikidata reprenable + mémoire bornée

- **Cache persistant** `provisioner.wikidata_cache(qid, payload jsonb, fetched_at)` dans un schéma **stable** (hors `tourism`/`osm` swappés). Seuls les Q-ID absents ou périmés (TTL 30j) sont re-requêtés ; les tables live sont enrichies en **joignant le cache** → les Q-ID déjà en cache enrichissent le nouveau staging **sans appel réseau**. Résout reprise + découplage de cadence (Wikidata redevient mensuel de fait).
- **Cache négatif** : un Q-ID sans donnée Wikidata est mis en cache `{}` (plus re-requêté) ; un Q-ID dont le **batch a échoué** (panne transitoire) reste hors cache et est retenté au prochain run — les deux cas sont distingués pour ne jamais negative-cacher une panne.
- **Streaming** : l'enricher renvoie un générateur (un batch de 50 à la fois) écrit directement dans un fichier COPY ; la map complète n'est jamais en mémoire. Mémoire bornée quel que soit le volume de Q-ID.

## R3 — Résilience réseau

- **Timeouts explicites** (idle + `max_duration` total) sur les téléchargements PBF OSM et flux DataTourisme → un miroir qui stalle échoue vite au lieu de bloquer le run.
- **Retry/backoff exponentiel** sur les batches SPARQL transitoirement en échec (429/5xx/transport).

## Schéma

- Migration `Version20260617140000` : schéma `provisioner` + `wikidata_cache` (le provisioner le recrée aussi en `IF NOT EXISTS` s'il tourne contre une base sans la migration).

## Vérification

Provisioner (host) : **phpunit 68/439 OK**, **phpstan level 9 no errors**, **rector** clean, **php-cs-fixer** clean. Nouveaux tests : retry/backoff + cache négatif + batch échoué (enricher), flux cache-backed (importer), verrou + continue-on-error (commande). L'intégration psql/SPARQL/flock réelle est validée au provisioning (non testable sur host).

## Suite

- R5 (alerte staleness sur `metadata.refreshed_at` + marqueur Wikidata dans `/health`) en PR de suivi.
- Débloque **#15 PR2** (enrichissement `osm.*`) qui réutilisera ce cache.

<!-- claude-review-start -->
## Claude Review

**Clean re-review — approved.** Both findings from the previous pass are fixed in commit `7bcf705`: `$sleep` is now typed as `?\Closure` (native, PHPStan-safe) and the proceed-without-lock path has a dedicated test. One pre-existing open thread remains on `$timeoutSeconds` naming in `DataTourismeImporter`; still valid, not addressed here.

Resolved 2 previously open threads (fixed in commit `7bcf705`).

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date (ADR-041 added)
- [x] Dependent tickets accounted for (#15 PR2 unblocked per PR description)

No new inline comments.

_Reviewed commit: 7bcf705b7b49399c814e92860f72abf1c59b2ec7_
<!-- claude-review-end -->