### PR TITLE
feat(provisioner): enrich osm.cultural_pois + osm.accommodations from Wikidata

### DIFF
--- a/api/migrations/Version20260617150000.php
+++ b/api/migrations/Version20260617150000.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Adds the Wikidata enrichment columns to the OSM reference tables that carry a
+ * `wikidata` Q-ID (ADR-040/041): osm.cultural_pois and osm.accommodations, filled
+ * by the provisioner's shared enrichment pass joining provisioner.wikidata_cache.
+ *
+ * cultural_pois had only name/category/wikidata, so it gains the full set;
+ * accommodations already had website/opening_hours from OSM tags, so it only
+ * gains the Wikidata-specific columns. Bootstraps the columns for the first
+ * provisioning run and the functional tests; tier1.lua carries the same columns
+ * so osm2pgsql creates them in staging and the atomic swap preserves them.
+ */
+final class Version20260617150000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add Wikidata enrichment columns to osm.cultural_pois and osm.accommodations';
+    }
+
+    public function up(Schema $schema): void
+    {
+        foreach (['description', 'opening_hours', 'website', 'image_url', 'wikipedia_url'] as $column) {
+            $this->addSql(\sprintf('ALTER TABLE osm.cultural_pois ADD COLUMN IF NOT EXISTS %s text', $column));
+        }
+
+        foreach (['description', 'image_url', 'wikipedia_url'] as $column) {
+            $this->addSql(\sprintf('ALTER TABLE osm.accommodations ADD COLUMN IF NOT EXISTS %s text', $column));
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        foreach (['description', 'opening_hours', 'website', 'image_url', 'wikipedia_url'] as $column) {
+            $this->addSql(\sprintf('ALTER TABLE osm.cultural_pois DROP COLUMN IF EXISTS %s', $column));
+        }
+
+        foreach (['description', 'image_url', 'wikipedia_url'] as $column) {
+            $this->addSql(\sprintf('ALTER TABLE osm.accommodations DROP COLUMN IF EXISTS %s', $column));
+        }
+    }
+}

--- a/provisioner/osm2pgsql/tier1.lua
+++ b/provisioner/osm2pgsql/tier1.lua
@@ -81,6 +81,10 @@ local accommodations = osm2pgsql.define_table({
         { column = 'website', type = 'text' },
         { column = 'wikidata', type = 'text' },
         { column = 'opening_hours', type = 'text' },
+        -- Filled by the Wikidata enrichment pass (WikidataEnrichmentPass).
+        { column = 'description', type = 'text' },
+        { column = 'image_url', type = 'text' },
+        { column = 'wikipedia_url', type = 'text' },
         { column = 'tags', type = 'jsonb' },
         { column = 'geom', type = 'point', projection = SRID, not_null = true },
     },
@@ -173,6 +177,12 @@ local cultural_pois = osm2pgsql.define_table({
         { column = 'name', type = 'text' },
         { column = 'category', type = 'text', not_null = true },
         { column = 'wikidata', type = 'text' },
+        -- Filled by the Wikidata enrichment pass (WikidataEnrichmentPass), not from OSM tags.
+        { column = 'description', type = 'text' },
+        { column = 'opening_hours', type = 'text' },
+        { column = 'website', type = 'text' },
+        { column = 'image_url', type = 'text' },
+        { column = 'wikipedia_url', type = 'text' },
         { column = 'tags', type = 'jsonb' },
         { column = 'geom', type = 'point', projection = SRID, not_null = true },
     },

--- a/provisioner/src/DataTourismeImporter.php
+++ b/provisioner/src/DataTourismeImporter.php
@@ -59,27 +59,12 @@ final readonly class DataTourismeImporter
     ];
 
     /**
-     * Tables enriched from Wikidata (those carrying a `wikidata` Q-ID column),
-     * with the columns the {@see WikidataEnricher} fills. Source-provided fields
-     * (description, opening_hours) are kept when present (COALESCE); the rest are
-     * Wikidata-only.
+     * Tables carrying a `wikidata` Q-ID column, enriched from Wikidata via the
+     * shared {@see WikidataEnrichmentPass} after load and before the swap.
+     *
+     * @var list<string>
      */
     private const array WIKIDATA_TABLES = ['cultural_pois', 'food_pois'];
-
-    /**
-     * Persistent enrichment cache (ADR-041), in a stable schema that survives the
-     * tourism swap. Only Q-IDs absent or older than the TTL are re-queried, so
-     * enrichment resumes after a crash and the daily refresh reuses the cache
-     * (Wikidata's effective cadence stays monthly). Scratch tables hold the
-     * per-run candidate / fetched sets; both live here and are dropped each run.
-     */
-    private const string CACHE_SCHEMA = 'provisioner';
-
-    private const string CACHE_TABLE = 'provisioner.wikidata_cache';
-
-    private const string CANDIDATES_TABLE = 'provisioner.wikidata_candidates';
-
-    private const string FETCH_TABLE = 'provisioner.wikidata_fetch';
 
     private HttpClientInterface $httpClient;
 
@@ -87,6 +72,8 @@ final readonly class DataTourismeImporter
      * @var \Closure(list<string>): Process
      */
     private \Closure $processFactory;
+
+    private WikidataEnrichmentPass $enrichmentPass;
 
     /**
      * @param (\Closure(list<string>): Process)|null $processFactory factory used to build the psql processes; defaults to a real {@see Process}
@@ -97,9 +84,9 @@ final readonly class DataTourismeImporter
         ?HttpClientInterface $httpClient = null,
         ?\Closure $processFactory = null,
         private float $timeoutSeconds = 1800.0,
-        private WikidataEnricher $enricher = new WikidataEnricher(),
-        private string $locale = 'fr',
-        private int $cacheTtlDays = 30,
+        WikidataEnricher $enricher = new WikidataEnricher(),
+        string $locale = 'fr',
+        int $cacheTtlDays = 30,
     ) {
         // Scoped to the DataTourisme origin (SSRF policy, see CLAUDE.md). Cap the
         // total transfer (ADR-041) so a stalled flux endpoint fails fast rather
@@ -113,6 +100,7 @@ final readonly class DataTourismeImporter
             'https://diffuseur.datatourisme.fr/',
         );
         $this->processFactory = $processFactory ?? static fn (array $command): Process => new Process($command);
+        $this->enrichmentPass = new WikidataEnrichmentPass($this->processFactory, $enricher, $locale, $cacheTtlDays, $this->timeoutSeconds);
     }
 
     /**
@@ -122,9 +110,9 @@ final readonly class DataTourismeImporter
     {
         $zipPath = $workDir.'/datatourisme-flux.zip';
         $this->download($zipPath);
-        ['files' => $copyFiles, 'wikidataIds' => $wikidataIds] = $this->extract($zipPath, $workDir);
+        $copyFiles = $this->extract($zipPath, $workDir);
         $this->load($copyFiles);
-        $this->enrich($workDir, $wikidataIds);
+        $this->enrichmentPass->run($workDir, self::STAGING_SCHEMA, self::WIKIDATA_TABLES);
         $this->swap();
     }
 
@@ -162,11 +150,11 @@ final readonly class DataTourismeImporter
     }
 
     /**
-     * Streams the flux ZIP and writes one text-format COPY file per table,
-     * collecting the distinct Wikidata Q-IDs seen on enrichable rows for the
-     * post-load enrichment pass.
+     * Streams the flux ZIP and writes one text-format COPY file per table. The
+     * Wikidata enrichment collects its Q-IDs straight from the loaded staging
+     * tables (see {@see WikidataEnrichmentPass}), so nothing is tracked here.
      *
-     * @return array{files: array<string, string>, wikidataIds: list<string>}
+     * @return array<string, string> table name => COPY file path
      *
      * @throws ImportFailedException
      */
@@ -191,9 +179,6 @@ final readonly class DataTourismeImporter
         }
 
         $heads = ['cultural' => 'cultural_pois', 'food' => 'food_pois', 'accommodation' => 'accommodations', 'event' => 'events'];
-
-        /** @var array<string, true> $wikidataIds */
-        $wikidataIds = [];
 
         for ($i = 0, $n = $zip->numFiles; $i < $n; ++$i) {
             $name = $zip->getNameIndex($i);
@@ -225,10 +210,6 @@ final readonly class DataTourismeImporter
 
             $table = $heads[$row['head']];
             fwrite($handles[$table], $this->copyLine($table, $row));
-
-            if (\in_array($table, self::WIKIDATA_TABLES, true) && null !== $row['wikidata']) {
-                $wikidataIds[$row['wikidata']] = true;
-            }
         }
 
         foreach ($handles as $handle) {
@@ -237,7 +218,7 @@ final readonly class DataTourismeImporter
 
         $zip->close();
 
-        return ['files' => $files, 'wikidataIds' => array_keys($wikidataIds)];
+        return $files;
     }
 
     /**
@@ -313,158 +294,6 @@ final readonly class DataTourismeImporter
             'psql', '-v', 'ON_ERROR_STOP=1', '-c',
             \sprintf('CREATE TABLE %1$s.metadata AS SELECT now() AS refreshed_at, jsonb_build_object(%2$s) AS feature_counts;', self::STAGING_SCHEMA, $counts),
         ], 'psql build tourism metadata');
-    }
-
-    /**
-     * Enriches the staged Wikidata-bearing tables from the persistent cache
-     * (ADR-040/041). Runs after {@see load} (rows are in staging) and before
-     * {@see swap} so the enrichment lands in the dataset that goes live
-     * atomically.
-     *
-     * Resumable + memory-bounded: only the Q-IDs absent from the cache or older
-     * than the TTL are queried from Wikidata, streamed one batch at a time into a
-     * COPY file (never the whole set in memory), upserted into the cache, then
-     * the live tables are UPDATEd by joining the cache — so previously cached
-     * Q-IDs enrich the fresh staging tables without any network call.
-     *
-     * Best-effort: a Wikidata outage leaves the missing Q-IDs uncached (retried
-     * next run) and the rows enriched only from whatever the cache already held.
-     *
-     * @param list<string> $wikidataIds
-     *
-     * @throws ImportFailedException
-     */
-    private function enrich(string $workDir, array $wikidataIds): void
-    {
-        if ([] === $wikidataIds) {
-            return;
-        }
-
-        // Self-contained: create the cache schema/table if the API migration has
-        // not run on this DB, plus fresh per-run scratch tables (drop any leftover
-        // from a prior crash — they live in the stable schema, not the swap).
-        $this->runProcess([
-            'psql', '-v', 'ON_ERROR_STOP=1', '-c',
-            \sprintf(
-                'CREATE SCHEMA IF NOT EXISTS %1$s; CREATE TABLE IF NOT EXISTS %2$s (qid text PRIMARY KEY, payload jsonb NOT NULL, fetched_at timestamptz NOT NULL); DROP TABLE IF EXISTS %3$s, %4$s; CREATE TABLE %3$s (qid text); CREATE TABLE %4$s (qid text, payload jsonb);',
-                self::CACHE_SCHEMA,
-                self::CACHE_TABLE,
-                self::CANDIDATES_TABLE,
-                self::FETCH_TABLE,
-            ),
-        ], 'psql prepare wikidata cache');
-
-        // Load the candidate Q-IDs, then export those missing/stale in the cache.
-        $candidatesPath = $workDir.'/tourism-wikidata-candidates.copy';
-        $this->writeColumn($candidatesPath, $wikidataIds);
-        $this->runProcess([
-            'psql', '-v', 'ON_ERROR_STOP=1', '-c',
-            \sprintf("\\copy %s (qid) FROM '%s'", self::CANDIDATES_TABLE, $candidatesPath),
-        ], 'psql copy wikidata candidates');
-
-        $missingPath = $workDir.'/tourism-wikidata-missing.copy';
-        $this->runProcess([
-            'psql', '-v', 'ON_ERROR_STOP=1', '-c',
-            \sprintf(
-                "\\copy (SELECT cand.qid FROM %1\$s cand WHERE NOT EXISTS (SELECT 1 FROM %2\$s c WHERE c.qid = cand.qid AND c.fetched_at > now() - make_interval(days => %3\$d))) TO '%4\$s'",
-                self::CANDIDATES_TABLE,
-                self::CACHE_TABLE,
-                $this->cacheTtlDays,
-                $missingPath,
-            ),
-        ], 'psql select missing wikidata');
-
-        // Query only the missing Q-IDs, streaming each batch straight to the COPY
-        // file, then upsert them into the cache (negative cache for no-data Q-IDs).
-        $missing = $this->readColumn($missingPath);
-        if ([] !== $missing) {
-            $fetchPath = $workDir.'/tourism-wikidata-fetch.copy';
-            $handle = fopen($fetchPath, 'w');
-            if (false === $handle) {
-                throw new ImportFailedException(\sprintf('Cannot open enrichment COPY file "%s"', $fetchPath));
-            }
-
-            foreach ($this->enricher->enrich($missing, $this->locale) as $row) {
-                $payload = json_encode((object) ($row['enrichment'] ?? []), \JSON_UNESCAPED_UNICODE | \JSON_UNESCAPED_SLASHES) ?: '{}';
-                fwrite($handle, $this->copyValue($row['qid'])."\t".$this->copyValue($payload)."\n");
-            }
-
-            fclose($handle);
-
-            $this->runProcess([
-                'psql', '-v', 'ON_ERROR_STOP=1', '-c',
-                \sprintf("\\copy %s (qid, payload) FROM '%s'", self::FETCH_TABLE, $fetchPath),
-            ], 'psql copy wikidata fetched');
-
-            $this->runProcess([
-                'psql', '-v', 'ON_ERROR_STOP=1', '-c',
-                \sprintf(
-                    'INSERT INTO %1$s (qid, payload, fetched_at) SELECT qid, payload, now() FROM %2$s ON CONFLICT (qid) DO UPDATE SET payload = excluded.payload, fetched_at = excluded.fetched_at;',
-                    self::CACHE_TABLE,
-                    self::FETCH_TABLE,
-                ),
-            ], 'psql upsert wikidata cache');
-        }
-
-        // Enrich the live tables from the cache (fresh + previously cached). The
-        // source fields (description, opening_hours) win when present; the rest are
-        // Wikidata-only.
-        foreach (self::WIKIDATA_TABLES as $target) {
-            $this->runProcess([
-                'psql', '-v', 'ON_ERROR_STOP=1', '-c',
-                \sprintf(
-                    "UPDATE %1\$s.%2\$s t SET description = COALESCE(t.description, c.payload->>'description'), opening_hours = COALESCE(t.opening_hours, c.payload->>'openingHours'), website = c.payload->>'website', image_url = c.payload->>'imageUrl', wikipedia_url = c.payload->>'wikipediaUrl' FROM %3\$s c WHERE t.wikidata = c.qid;",
-                    self::STAGING_SCHEMA,
-                    $target,
-                    self::CACHE_TABLE,
-                ),
-            ], \sprintf('psql enrich %s', $target));
-        }
-
-        $this->runProcess([
-            'psql', '-v', 'ON_ERROR_STOP=1', '-c',
-            \sprintf('DROP TABLE IF EXISTS %s, %s;', self::CANDIDATES_TABLE, self::FETCH_TABLE),
-        ], 'psql drop wikidata scratch tables');
-    }
-
-    /**
-     * Writes a single-column COPY file (one escaped value per line).
-     *
-     * @param list<string> $values
-     *
-     * @throws ImportFailedException
-     */
-    private function writeColumn(string $path, array $values): void
-    {
-        $handle = fopen($path, 'w');
-        if (false === $handle) {
-            throw new ImportFailedException(\sprintf('Cannot open COPY file "%s"', $path));
-        }
-
-        foreach ($values as $value) {
-            fwrite($handle, $this->copyValue($value)."\n");
-        }
-
-        fclose($handle);
-    }
-
-    /**
-     * Reads a single-column psql COPY-out file back into a list.
-     *
-     * @return list<string>
-     */
-    private function readColumn(string $path): array
-    {
-        if (!is_file($path)) {
-            return [];
-        }
-
-        $contents = file_get_contents($path);
-        if (false === $contents || '' === trim($contents)) {
-            return [];
-        }
-
-        return array_values(array_filter(array_map(trim(...), explode("\n", $contents)), static fn (string $line): bool => '' !== $line));
     }
 
     /**

--- a/provisioner/src/PostgisImporter.php
+++ b/provisioner/src/PostgisImporter.php
@@ -74,9 +74,19 @@ final readonly class PostgisImporter
     ];
 
     /**
+     * OSM tables carrying a `wikidata` Q-ID column, enriched from Wikidata via the
+     * shared {@see WikidataEnrichmentPass} after import and before the swap.
+     *
+     * @var list<string>
+     */
+    private const array WIKIDATA_TABLES = ['cultural_pois', 'accommodations'];
+
+    /**
      * @var \Closure(list<string>): Process
      */
     private \Closure $processFactory;
+
+    private WikidataEnrichmentPass $enrichmentPass;
 
     /**
      * @param (\Closure(list<string>): Process)|null $processFactory factory used to build the osmium/osm2pgsql/psql processes; defaults to a real {@see Process}
@@ -87,8 +97,12 @@ final readonly class PostgisImporter
         private int $cacheMb = 800,
         ?\Closure $processFactory = null,
         private float $timeoutSeconds = 1800.0,
+        WikidataEnricher $enricher = new WikidataEnricher(),
+        string $locale = 'fr',
+        int $cacheTtlDays = 30,
     ) {
         $this->processFactory = $processFactory ?? static fn (array $command): Process => new Process($command);
+        $this->enrichmentPass = new WikidataEnrichmentPass($this->processFactory, $enricher, $locale, $cacheTtlDays, $this->timeoutSeconds);
     }
 
     /**
@@ -98,6 +112,10 @@ final readonly class PostgisImporter
     {
         $this->filter($mergedPbf, $filteredPbf);
         $this->import($filteredPbf);
+        // Enrich the Wikidata-bearing tables before deriving coverage/metadata and
+        // swapping, so the enrichment ships with the dataset that goes live. The
+        // COPY scratch files go next to the filtered PBF (the /data work dir).
+        $this->enrichmentPass->run(\dirname($filteredPbf), self::STAGING_SCHEMA, self::WIKIDATA_TABLES);
         $this->buildDerived();
         $this->swap();
     }

--- a/provisioner/src/WikidataEnrichmentPass.php
+++ b/provisioner/src/WikidataEnrichmentPass.php
@@ -112,12 +112,14 @@ final readonly class WikidataEnrichmentPass
                 throw new ImportFailedException(\sprintf('Cannot open enrichment COPY file "%s"', $fetchPath));
             }
 
-            foreach ($this->enricher->enrich($missing, $this->locale) as $row) {
-                $payload = json_encode((object) ($row['enrichment'] ?? []), \JSON_UNESCAPED_UNICODE | \JSON_UNESCAPED_SLASHES) ?: '{}';
-                fwrite($handle, $this->copyValue($row['qid'])."\t".$this->copyValue($payload)."\n");
+            try {
+                foreach ($this->enricher->enrich($missing, $this->locale) as $row) {
+                    $payload = json_encode((object) ($row['enrichment'] ?? []), \JSON_UNESCAPED_UNICODE | \JSON_UNESCAPED_SLASHES) ?: '{}';
+                    fwrite($handle, $this->copyValue($row['qid'])."\t".$this->copyValue($payload)."\n");
+                }
+            } finally {
+                fclose($handle);
             }
-
-            fclose($handle);
 
             $this->psql(\sprintf("\\copy %s (qid, payload) FROM '%s'", self::FETCH_TABLE, $fetchPath), 'psql copy wikidata fetched');
             $this->psql(\sprintf(

--- a/provisioner/src/WikidataEnrichmentPass.php
+++ b/provisioner/src/WikidataEnrichmentPass.php
@@ -40,10 +40,6 @@ final readonly class WikidataEnrichmentPass
 
     private const string CACHE_TABLE = 'provisioner.wikidata_cache';
 
-    private const string CANDIDATES_TABLE = 'provisioner.wikidata_candidates';
-
-    private const string FETCH_TABLE = 'provisioner.wikidata_fetch';
-
     /**
      * @var \Closure(list<string>): Process
      */
@@ -74,6 +70,12 @@ final readonly class WikidataEnrichmentPass
             return;
         }
 
+        // Scratch tables are scoped to the staging schema so concurrent passes
+        // (osm vs tourism) never drop each other's data, independent of the
+        // run-level lock (ADR-041).
+        $candidatesTable = $this->scratchTable('candidates', $stagingSchema);
+        $fetchTable = $this->scratchTable('fetch', $stagingSchema);
+
         // Ensure the persistent cache (the API migration may not have run here) and
         // fresh per-run scratch tables (drop any leftover from a prior crash; they
         // live in the stable schema, never in the swapped one).
@@ -81,8 +83,8 @@ final readonly class WikidataEnrichmentPass
             'CREATE SCHEMA IF NOT EXISTS %1$s; CREATE TABLE IF NOT EXISTS %2$s (qid text PRIMARY KEY, payload jsonb NOT NULL, fetched_at timestamptz NOT NULL); DROP TABLE IF EXISTS %3$s, %4$s; CREATE TABLE %3$s (qid text); CREATE TABLE %4$s (qid text, payload jsonb);',
             self::CACHE_SCHEMA,
             self::CACHE_TABLE,
-            self::CANDIDATES_TABLE,
-            self::FETCH_TABLE,
+            $candidatesTable,
+            $fetchTable,
         ), 'psql prepare wikidata cache');
 
         // Collect the distinct Q-IDs straight from the staging tables.
@@ -90,13 +92,13 @@ final readonly class WikidataEnrichmentPass
             static fn (string $table): string => \sprintf('SELECT DISTINCT wikidata FROM %s.%s WHERE wikidata IS NOT NULL', $stagingSchema, $table),
             $tables,
         ));
-        $this->psql(\sprintf('INSERT INTO %s (qid) %s;', self::CANDIDATES_TABLE, $union), 'psql collect wikidata candidates');
+        $this->psql(\sprintf('INSERT INTO %s (qid) %s;', $candidatesTable, $union), 'psql collect wikidata candidates');
 
         // Export those missing or older than the TTL.
         $missingPath = $workDir.'/wikidata-missing.copy';
         $this->psql(\sprintf(
             "\\copy (SELECT cand.qid FROM %1\$s cand WHERE NOT EXISTS (SELECT 1 FROM %2\$s c WHERE c.qid = cand.qid AND c.fetched_at > now() - make_interval(days => %3\$d))) TO '%4\$s'",
-            self::CANDIDATES_TABLE,
+            $candidatesTable,
             self::CACHE_TABLE,
             $this->cacheTtlDays,
             $missingPath,
@@ -121,11 +123,11 @@ final readonly class WikidataEnrichmentPass
                 fclose($handle);
             }
 
-            $this->psql(\sprintf("\\copy %s (qid, payload) FROM '%s'", self::FETCH_TABLE, $fetchPath), 'psql copy wikidata fetched');
+            $this->psql(\sprintf("\\copy %s (qid, payload) FROM '%s'", $fetchTable, $fetchPath), 'psql copy wikidata fetched');
             $this->psql(\sprintf(
                 'INSERT INTO %1$s (qid, payload, fetched_at) SELECT qid, payload, now() FROM %2$s ON CONFLICT (qid) DO UPDATE SET payload = excluded.payload, fetched_at = excluded.fetched_at;',
                 self::CACHE_TABLE,
-                self::FETCH_TABLE,
+                $fetchTable,
             ), 'psql upsert wikidata cache');
         }
 
@@ -140,7 +142,16 @@ final readonly class WikidataEnrichmentPass
             ), \sprintf('psql enrich %s.%s', $stagingSchema, $table));
         }
 
-        $this->psql(\sprintf('DROP TABLE IF EXISTS %s, %s;', self::CANDIDATES_TABLE, self::FETCH_TABLE), 'psql drop wikidata scratch tables');
+        $this->psql(\sprintf('DROP TABLE IF EXISTS %s, %s;', $candidatesTable, $fetchTable), 'psql drop wikidata scratch tables');
+    }
+
+    /**
+     * Scratch table name scoped to the staging schema (sanitised to a safe
+     * identifier), so concurrent passes never collide on a shared name.
+     */
+    private function scratchTable(string $kind, string $stagingSchema): string
+    {
+        return \sprintf('%s.wikidata_%s_%s', self::CACHE_SCHEMA, $kind, (string) preg_replace('/[^a-z0-9_]/i', '_', $stagingSchema));
     }
 
     /**

--- a/provisioner/src/WikidataEnrichmentPass.php
+++ b/provisioner/src/WikidataEnrichmentPass.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Provisioner;
+
+use Provisioner\Exception\ImportFailedException;
+use Symfony\Component\Process\Exception\ProcessTimedOutException;
+use Symfony\Component\Process\Process;
+
+/**
+ * Shared Wikidata enrichment pass (ADR-040/041) used by both the OSM and the
+ * DataTourisme importers: it enriches the Wikidata-bearing staging tables from
+ * the persistent cache, querying Wikidata only for the Q-IDs that are missing or
+ * older than the TTL.
+ *
+ * Runs after a schema's tables are loaded and before its atomic swap, against
+ * the staging schema, so the enrichment ships with the dataset that goes live.
+ * Resumable + memory-bounded:
+ *
+ * 1. collect the distinct Q-IDs straight from the staging tables (no app-side
+ *    bookkeeping) into a scratch table;
+ * 2. export those absent/stale in {@see provisioner.wikidata_cache};
+ * 3. query only those from Wikidata, streaming one batch at a time into a COPY
+ *    file, and upsert them into the cache (negative cache for no-data Q-IDs);
+ * 4. UPDATE each table by joining the cache (fresh + previously cached), so
+ *    cached Q-IDs enrich the fresh staging tables with no network call.
+ *
+ * Every target table must carry a `wikidata` column plus the enrichment columns
+ * (description, opening_hours, website, image_url, wikipedia_url). Source-set
+ * fields win when present (COALESCE); image_url / wikipedia_url are Wikidata-only.
+ *
+ * The cache and scratch tables live in a stable `provisioner` schema (NOT the
+ * swapped schema); the pass creates them if absent so it works even when the API
+ * migration has not run on this DB.
+ */
+final readonly class WikidataEnrichmentPass
+{
+    private const string CACHE_SCHEMA = 'provisioner';
+
+    private const string CACHE_TABLE = 'provisioner.wikidata_cache';
+
+    private const string CANDIDATES_TABLE = 'provisioner.wikidata_candidates';
+
+    private const string FETCH_TABLE = 'provisioner.wikidata_fetch';
+
+    /**
+     * @var \Closure(list<string>): Process
+     */
+    private \Closure $processFactory;
+
+    /**
+     * @param (\Closure(list<string>): Process)|null $processFactory psql process factory; shared with the calling importer so commands are captured in tests
+     */
+    public function __construct(
+        ?\Closure $processFactory = null,
+        private WikidataEnricher $enricher = new WikidataEnricher(),
+        private string $locale = 'fr',
+        private int $cacheTtlDays = 30,
+        private float $timeoutSeconds = 1800.0,
+    ) {
+        $this->processFactory = $processFactory ?? static fn (array $command): Process => new Process($command);
+    }
+
+    /**
+     * @param string       $stagingSchema schema whose tables are enriched (before its swap)
+     * @param list<string> $tables        table names within $stagingSchema, each with a `wikidata` column + the enrichment columns
+     *
+     * @throws ImportFailedException
+     */
+    public function run(string $workDir, string $stagingSchema, array $tables): void
+    {
+        if ([] === $tables) {
+            return;
+        }
+
+        // Ensure the persistent cache (the API migration may not have run here) and
+        // fresh per-run scratch tables (drop any leftover from a prior crash; they
+        // live in the stable schema, never in the swapped one).
+        $this->psql(\sprintf(
+            'CREATE SCHEMA IF NOT EXISTS %1$s; CREATE TABLE IF NOT EXISTS %2$s (qid text PRIMARY KEY, payload jsonb NOT NULL, fetched_at timestamptz NOT NULL); DROP TABLE IF EXISTS %3$s, %4$s; CREATE TABLE %3$s (qid text); CREATE TABLE %4$s (qid text, payload jsonb);',
+            self::CACHE_SCHEMA,
+            self::CACHE_TABLE,
+            self::CANDIDATES_TABLE,
+            self::FETCH_TABLE,
+        ), 'psql prepare wikidata cache');
+
+        // Collect the distinct Q-IDs straight from the staging tables.
+        $union = implode(' UNION ', array_map(
+            static fn (string $table): string => \sprintf('SELECT DISTINCT wikidata FROM %s.%s WHERE wikidata IS NOT NULL', $stagingSchema, $table),
+            $tables,
+        ));
+        $this->psql(\sprintf('INSERT INTO %s (qid) %s;', self::CANDIDATES_TABLE, $union), 'psql collect wikidata candidates');
+
+        // Export those missing or older than the TTL.
+        $missingPath = $workDir.'/wikidata-missing.copy';
+        $this->psql(\sprintf(
+            "\\copy (SELECT cand.qid FROM %1\$s cand WHERE NOT EXISTS (SELECT 1 FROM %2\$s c WHERE c.qid = cand.qid AND c.fetched_at > now() - make_interval(days => %3\$d))) TO '%4\$s'",
+            self::CANDIDATES_TABLE,
+            self::CACHE_TABLE,
+            $this->cacheTtlDays,
+            $missingPath,
+        ), 'psql select missing wikidata');
+
+        // Query only the missing Q-IDs, streaming each batch into the COPY file,
+        // then upsert them into the cache.
+        $missing = $this->readColumn($missingPath);
+        if ([] !== $missing) {
+            $fetchPath = $workDir.'/wikidata-fetch.copy';
+            $handle = fopen($fetchPath, 'w');
+            if (false === $handle) {
+                throw new ImportFailedException(\sprintf('Cannot open enrichment COPY file "%s"', $fetchPath));
+            }
+
+            foreach ($this->enricher->enrich($missing, $this->locale) as $row) {
+                $payload = json_encode((object) ($row['enrichment'] ?? []), \JSON_UNESCAPED_UNICODE | \JSON_UNESCAPED_SLASHES) ?: '{}';
+                fwrite($handle, $this->copyValue($row['qid'])."\t".$this->copyValue($payload)."\n");
+            }
+
+            fclose($handle);
+
+            $this->psql(\sprintf("\\copy %s (qid, payload) FROM '%s'", self::FETCH_TABLE, $fetchPath), 'psql copy wikidata fetched');
+            $this->psql(\sprintf(
+                'INSERT INTO %1$s (qid, payload, fetched_at) SELECT qid, payload, now() FROM %2$s ON CONFLICT (qid) DO UPDATE SET payload = excluded.payload, fetched_at = excluded.fetched_at;',
+                self::CACHE_TABLE,
+                self::FETCH_TABLE,
+            ), 'psql upsert wikidata cache');
+        }
+
+        // Enrich each table from the cache. Source-set fields win when present;
+        // image_url / wikipedia_url are Wikidata-only.
+        foreach ($tables as $table) {
+            $this->psql(\sprintf(
+                "UPDATE %1\$s.%2\$s t SET description = COALESCE(t.description, c.payload->>'description'), opening_hours = COALESCE(t.opening_hours, c.payload->>'openingHours'), website = COALESCE(t.website, c.payload->>'website'), image_url = c.payload->>'imageUrl', wikipedia_url = c.payload->>'wikipediaUrl' FROM %3\$s c WHERE t.wikidata = c.qid;",
+                $stagingSchema,
+                $table,
+                self::CACHE_TABLE,
+            ), \sprintf('psql enrich %s.%s', $stagingSchema, $table));
+        }
+
+        $this->psql(\sprintf('DROP TABLE IF EXISTS %s, %s;', self::CANDIDATES_TABLE, self::FETCH_TABLE), 'psql drop wikidata scratch tables');
+    }
+
+    /**
+     * @throws ImportFailedException
+     */
+    private function psql(string $sql, string $label): void
+    {
+        $process = ($this->processFactory)(['psql', '-v', 'ON_ERROR_STOP=1', '-c', $sql]);
+        $process->setTimeout($this->timeoutSeconds);
+
+        try {
+            $process->run();
+        } catch (ProcessTimedOutException $processTimedOutException) {
+            throw new ImportFailedException(\sprintf('%s timed out after %.1fs', $label, $this->timeoutSeconds), 0, $processTimedOutException);
+        }
+
+        if (!$process->isSuccessful()) {
+            throw new ImportFailedException(\sprintf("%s failed (exit %s).\nStderr: %s", $label, (string) $process->getExitCode(), $process->getErrorOutput()));
+        }
+    }
+
+    private function copyValue(string $value): string
+    {
+        return str_replace(['\\', "\t", "\n", "\r"], ['\\\\', '\\t', '\\n', '\\r'], $value);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function readColumn(string $path): array
+    {
+        if (!is_file($path)) {
+            return [];
+        }
+
+        $contents = file_get_contents($path);
+        if (false === $contents || '' === trim($contents)) {
+            return [];
+        }
+
+        return array_values(array_filter(array_map(trim(...), explode("\n", $contents)), static fn (string $line): bool => '' !== $line));
+    }
+}

--- a/provisioner/tests/DataTourismeImporterTest.php
+++ b/provisioner/tests/DataTourismeImporterTest.php
@@ -109,21 +109,21 @@ final class DataTourismeImporterTest extends TestCase
         return $bytes;
     }
 
-    private function capturingFactory(): \Closure
+    /**
+     * @param list<string> $missingQids written to the `\copy (… missing …) TO 'file'`
+     *                                  destination so the enrichment fetch path runs in tests
+     */
+    private function capturingFactory(array $missingQids = []): \Closure
     {
-        return function (array $command): Process {
+        return function (array $command) use ($missingQids): Process {
             /** @var list<string> $cmd */
             $cmd = $command;
             $this->captured[] = $cmd;
 
-            // Emulate psql `\copy (SELECT … missing …) TO 'file'`: with an empty
-            // cache every candidate is missing, so copy the candidates COPY file
-            // into the destination so the enrichment fetch path runs in tests.
-            if (1 === preg_match("/TO '([^']+)'/", implode(' ', $cmd), $matches)) {
-                $candidates = $this->workDir.'/tourism-wikidata-candidates.copy';
-                if (is_file($candidates)) {
-                    copy($candidates, $matches[1]);
-                }
+            // Emulate psql exporting the missing Q-IDs (the enrichment pass reads
+            // this file back); the no-op `true` process never writes it itself.
+            if ([] !== $missingQids && 1 === preg_match("/TO '([^']+)'/", implode(' ', $cmd), $matches)) {
+                file_put_contents($matches[1], implode("\n", $missingQids)."\n");
             }
 
             return new Process(['true']);
@@ -143,8 +143,9 @@ final class DataTourismeImporterTest extends TestCase
 
         $importer->run($this->workDir);
 
-        // 1 staging DDL + 4 \copy + 4 GIST index + 1 events-date index + 1 metadata + 1 swap.
-        self::assertCount(12, $this->captured);
+        // 1 staging DDL + 4 \copy + 4 GIST index + 1 events-date index + 1 metadata
+        // + 6 enrichment-pass psql calls (no Q-IDs to fetch in this fixture) + 1 swap.
+        self::assertCount(18, $this->captured);
 
         $ddl = implode(' ', $this->captured[0]);
         self::assertStringContainsString('CREATE SCHEMA tourism_staging', $ddl);
@@ -271,7 +272,8 @@ final class DataTourismeImporterTest extends TestCase
         $importer = new DataTourismeImporter(
             fluxUrl: 'https://example.test/flux',
             httpClient: new MockHttpClient(new MockResponse($bytes)),
-            processFactory: $this->capturingFactory(),
+            // The cache is empty, so emulate psql exporting Q243 as the missing Q-ID.
+            processFactory: $this->capturingFactory(['Q243']),
             enricher: new WikidataEnricher($sparql),
         );
         $importer->run($this->workDir);
@@ -284,18 +286,21 @@ final class DataTourismeImporterTest extends TestCase
 
         self::assertTrue($has('CREATE TABLE IF NOT EXISTS provisioner.wikidata_cache'), 'the persistent cache is ensured');
         self::assertTrue($has('CREATE TABLE provisioner.wikidata_candidates'), 'a candidates scratch table is created');
-        self::assertTrue($has('\copy provisioner.wikidata_candidates (qid) FROM'), 'candidate Q-IDs are loaded');
+        self::assertTrue(
+            $has('INSERT INTO provisioner.wikidata_candidates', 'SELECT DISTINCT wikidata FROM tourism_staging.cultural_pois', 'SELECT DISTINCT wikidata FROM tourism_staging.food_pois'),
+            'candidate Q-IDs are collected straight from the staging tables',
+        );
         self::assertTrue($has('TO ', 'SELECT cand.qid', 'NOT EXISTS', 'make_interval'), 'missing/stale Q-IDs are selected against the TTL');
         self::assertTrue($has('\copy provisioner.wikidata_fetch (qid, payload) FROM'), 'fetched enrichments are staged');
         self::assertTrue($has('INSERT INTO provisioner.wikidata_cache', 'ON CONFLICT (qid) DO UPDATE'), 'fetched enrichments are upserted into the cache');
         self::assertTrue(
-            $has('UPDATE tourism_staging.cultural_pois t SET', "website = c.payload->>'website'", "COALESCE(t.description, c.payload->>'description')", 'FROM provisioner.wikidata_cache c'),
-            'cultural_pois is enriched from the cache, keeping the source description',
+            $has('UPDATE tourism_staging.cultural_pois t SET', "COALESCE(t.website, c.payload->>'website')", "COALESCE(t.description, c.payload->>'description')", 'FROM provisioner.wikidata_cache c'),
+            'cultural_pois is enriched from the cache, keeping source-set fields',
         );
         self::assertTrue($has('UPDATE tourism_staging.food_pois t SET', 'FROM provisioner.wikidata_cache c'), 'food_pois is enriched from the cache');
         self::assertTrue($has('DROP TABLE IF EXISTS provisioner.wikidata_candidates, provisioner.wikidata_fetch'), 'scratch tables are dropped');
 
-        $fetch = (string) file_get_contents($this->workDir.'/tourism-wikidata-fetch.copy');
+        $fetch = (string) file_get_contents($this->workDir.'/wikidata-fetch.copy');
         self::assertStringContainsString('Q243', $fetch);
         self::assertStringContainsString('https://museum.test', $fetch);
         self::assertStringContainsString('https://fr.wikipedia.org/wiki/Musee', $fetch);

--- a/provisioner/tests/DataTourismeImporterTest.php
+++ b/provisioner/tests/DataTourismeImporterTest.php
@@ -291,14 +291,14 @@ final class DataTourismeImporterTest extends TestCase
             'candidate Q-IDs are collected straight from the staging tables',
         );
         self::assertTrue($has('TO ', 'SELECT cand.qid', 'NOT EXISTS', 'make_interval'), 'missing/stale Q-IDs are selected against the TTL');
-        self::assertTrue($has('\copy provisioner.wikidata_fetch (qid, payload) FROM'), 'fetched enrichments are staged');
+        self::assertTrue($has('\copy provisioner.wikidata_fetch_tourism_staging (qid, payload) FROM'), 'fetched enrichments are staged');
         self::assertTrue($has('INSERT INTO provisioner.wikidata_cache', 'ON CONFLICT (qid) DO UPDATE'), 'fetched enrichments are upserted into the cache');
         self::assertTrue(
             $has('UPDATE tourism_staging.cultural_pois t SET', "COALESCE(t.website, c.payload->>'website')", "COALESCE(t.description, c.payload->>'description')", 'FROM provisioner.wikidata_cache c'),
             'cultural_pois is enriched from the cache, keeping source-set fields',
         );
         self::assertTrue($has('UPDATE tourism_staging.food_pois t SET', 'FROM provisioner.wikidata_cache c'), 'food_pois is enriched from the cache');
-        self::assertTrue($has('DROP TABLE IF EXISTS provisioner.wikidata_candidates, provisioner.wikidata_fetch'), 'scratch tables are dropped');
+        self::assertTrue($has('DROP TABLE IF EXISTS provisioner.wikidata_candidates_tourism_staging, provisioner.wikidata_fetch_tourism_staging'), 'scratch tables are dropped');
 
         $fetch = (string) file_get_contents($this->workDir.'/wikidata-fetch.copy');
         self::assertStringContainsString('Q243', $fetch);

--- a/provisioner/tests/PostgisImporterTest.php
+++ b/provisioner/tests/PostgisImporterTest.php
@@ -8,6 +8,9 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Provisioner\Exception\ImportFailedException;
 use Provisioner\PostgisImporter;
+use Provisioner\WikidataEnricher;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Process\Exception\ProcessTimedOutException;
 use Symfony\Component\Process\Process;
 
@@ -153,6 +156,89 @@ final class PostgisImporterTest extends TestCase
         $sql = end($cmd);
         self::assertStringContainsString('DROP SCHEMA IF EXISTS osm CASCADE', $sql);
         self::assertStringContainsString('ALTER SCHEMA osm_staging RENAME TO osm', $sql);
+    }
+
+    #[Test]
+    public function runEnrichesWikidataBearingOsmTablesBeforeSwap(): void
+    {
+        $workDir = sys_get_temp_dir().'/postgis-enrich-'.uniqid('', true);
+        mkdir($workDir, 0o755, true);
+
+        $sparql = new MockHttpClient(new MockResponse((string) json_encode([
+            'results' => ['bindings' => [[
+                'item' => ['value' => 'http://www.wikidata.org/entity/Q42'],
+                'website' => ['value' => 'https://w.test'],
+            ]]],
+        ])));
+
+        // Empty cache: emulate psql exporting Q42 as the missing Q-ID so the
+        // enrichment fetch path runs against the mocked SPARQL endpoint.
+        $factory = function (array $command): Process {
+            /** @var list<string> $cmd */
+            $cmd = $command;
+            $this->captured[] = $cmd;
+            if (1 === preg_match("/TO '([^']+)'/", implode(' ', $cmd), $matches)) {
+                file_put_contents($matches[1], "Q42\n");
+            }
+
+            return new Process(['true']);
+        };
+
+        $importer = new PostgisImporter(
+            flexStylePath: '/app/osm2pgsql/tier1.lua',
+            processFactory: $factory,
+            enricher: new WikidataEnricher($sparql),
+        );
+
+        try {
+            $importer->run($workDir.'/default.osm.pbf', $workDir.'/tier1-filtered.osm.pbf');
+
+            $joined = array_map(static fn (array $c): string => implode(' ', $c), $this->captured);
+            $has = static fn (string ...$needles): bool => (bool) array_filter(
+                $joined,
+                static fn (string $c): bool => array_all($needles, static fn (string $n): bool => str_contains($c, $n)),
+            );
+
+            self::assertTrue(
+                $has('INSERT INTO provisioner.wikidata_candidates', 'SELECT DISTINCT wikidata FROM osm_staging.cultural_pois', 'SELECT DISTINCT wikidata FROM osm_staging.accommodations'),
+                'candidate Q-IDs are collected from the OSM staging tables',
+            );
+            self::assertTrue(
+                $has('UPDATE osm_staging.cultural_pois t SET', 'FROM provisioner.wikidata_cache c'),
+                'osm.cultural_pois is enriched from the cache',
+            );
+            self::assertTrue(
+                $has('UPDATE osm_staging.accommodations t SET', "COALESCE(t.website, c.payload->>'website')", 'FROM provisioner.wikidata_cache c'),
+                'osm.accommodations is enriched from the cache, keeping the OSM website',
+            );
+
+            $fetch = (string) file_get_contents($workDir.'/wikidata-fetch.copy');
+            self::assertStringContainsString('Q42', $fetch);
+            self::assertStringContainsString('https://w.test', $fetch);
+
+            // Enrichment (scratch drop) precedes the schema swap.
+            $dropIndex = $this->commandIndex('DROP TABLE IF EXISTS provisioner.wikidata_candidates');
+            $swapIndex = $this->commandIndex('ALTER SCHEMA osm_staging RENAME TO osm');
+            self::assertGreaterThan(-1, $dropIndex);
+            self::assertGreaterThan($dropIndex, $swapIndex);
+        } finally {
+            foreach (glob($workDir.'/*') ?: [] as $file) {
+                unlink($file);
+            }
+
+            rmdir($workDir);
+        }
+    }
+
+    private function commandIndex(string $needle): int
+    {
+        foreach ($this->captured as $index => $command) {
+            if (str_contains(implode(' ', $command), $needle)) {
+                return $index;
+            }
+        }
+
+        return -1;
     }
 
     #[Test]


### PR DESCRIPTION
## Contexte

Chantier #15 PR2 : étend l'enrichissement Wikidata aux tables `osm.*` portant un Q-ID, en réutilisant le cache persistant posé par #702 (ADR-041). Suite de PR1 (tourism) ; PR3 fera la lecture API + retrait du runtime.

## Refactor : passe d'enrichissement partagée

Extraction de la logique cache dans **`WikidataEnrichmentPass`**, utilisée par les deux importers :
- collecte les Q-ID **directement depuis les tables staging** via SQL (`INSERT INTO … SELECT DISTINCT wikidata FROM <table> WHERE wikidata IS NOT NULL`) — plus de comptabilité applicative (l'ancienne collecte à l'`extract()` de DataTourisme est supprimée) ;
- réutilise `provisioner.wikidata_cache` (reprise + TTL 30j), streaming par batch, cache négatif ;
- `UPDATE` chaque table en joignant le cache : `COALESCE` pour les champs déjà renseignés par la source (description/opening_hours/website), set direct pour `image_url`/`wikipedia_url`.

`DataTourismeImporter` délègue désormais à la passe (suppression de son `enrich()` inline). `PostgisImporter` l'appelle entre l'import et le swap pour `osm.cultural_pois` + `osm.accommodations`.

## Schéma

- **tier1.lua** : colonnes d'enrichissement ajoutées aux tables `cultural_pois` (description, opening_hours, website, image_url, wikipedia_url) et `accommodations` (description, image_url, wikipedia_url ; website/opening_hours viennent déjà des tags OSM).
- **Migration `Version20260617150000`** : mêmes colonnes sur les tables live `osm.*` (bootstrap + tests ; le swap les conserve via la DDL Lua).

## Vérification

Provisioner (host) : **phpunit 70/448 OK**, **phpstan level 9**, **rector** + **php-cs-fixer** clean. Nouveau test `PostgisImporterTest::runEnrichesWikidataBearingOsmTablesBeforeSwap` (collecte depuis `osm_staging`, UPDATE depuis le cache, scratch droppé avant swap) ; test tourism adapté à la passe partagée.

## Suite

- **#15 PR3** : repos API lisent les colonnes enrichies (`image_url`/`wikipedia_url`/`website`/`description`/`opening_hours`) + **retrait complet** de `App\Wikidata\WikidataEnricher`/`WikidataClient` runtime.

<!-- claude-review-start -->
## Claude Review

**Reviewed commit:** `292d060ae5287044cb48bb57a46d35df0d371dda`

All three commits together produce a clean, well-tested result. `WikidataEnrichmentPass` is correctly shaped (`final readonly`, single responsibility, clear contract). Commit 3 fully addresses the only outstanding warning from the prior review — scratch tables are now scoped per staging schema via `scratchTable(string $kind, string $stagingSchema)` with identifier sanitisation, preventing concurrent-pass collisions. The `COALESCE`-on-`website` is the right semantics for all target tables. No new findings.

### Findings summary

| Severity | Count |
|---|---|
| warning | 0 |
| note | 0 |

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Resolved threads

Resolved 1 previously open thread (scratch table naming — fixed in commit 3 with per-schema `scratchTable()` helper).

### Inline comments

No inline comments.
<!-- claude-review-end -->