### PR TITLE
feat(provisioner): reference-data staleness alerting + PHP memory guard (ADR-041 R4+R5)

### DIFF
--- a/.docker/provisioner/Dockerfile
+++ b/.docker/provisioner/Dockerfile
@@ -42,7 +42,10 @@ COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
 WORKDIR /app
 
-ENTRYPOINT ["php", "bin/provision"]
+# Cap PHP memory so a regression in the streaming/enrichment paths fails with a
+# clean PHP fatal instead of a silent container OOM-kill (ADR-041 R4). osm2pgsql
+# and psql run as separate processes, bounded by --cache and the DB config.
+ENTRYPOINT ["php", "-d", "memory_limit=512M", "bin/provision"]
 
 # Stage 3: Production
 FROM php:8.5-cli-bookworm AS prod
@@ -64,4 +67,7 @@ RUN install-php-extensions zip
 WORKDIR /app
 COPY --from=deps /app/ ./
 
-ENTRYPOINT ["php", "bin/provision"]
+# Cap PHP memory so a regression in the streaming/enrichment paths fails with a
+# clean PHP fatal instead of a silent container OOM-kill (ADR-041 R4). osm2pgsql
+# and psql run as separate processes, bounded by --cache and the DB config.
+ENTRYPOINT ["php", "-d", "memory_limit=512M", "bin/provision"]

--- a/.docker/uptime-kuma/README.md
+++ b/.docker/uptime-kuma/README.md
@@ -51,6 +51,7 @@ sync with the deployed configuration.
 | 3 | Keyword  | `https://biketrip.mooo.com/`, keyword `Bike Trip Planner`           | 300 s    | 2       | **P1**   | Detects PWA shell regressions (blank page, SSR crash).      |
 | 4 | DNS      | `biketrip.mooo.com`, resolver `1.1.1.1`, record type `A`            | 300 s    | 2       | **P2**   | Detects FreeDNS / DynDNS expiration.                        |
 | 5 | HTTP(s)  | `https://biketrip.mooo.com/.well-known/mercure?topic=test`          | 300 s    | 2       | **P2**   | Accept HTTP status `200,401`. Anything `5xx` = down.        |
+| 6 | JSON query | `https://biketrip.mooo.com/api/health`                            | 3600 s   | 1       | **P3**   | Reference-data freshness: alert when the local index is stale (ADR-041). |
 
 ### Per-monitor configuration tips
 
@@ -65,6 +66,13 @@ sync with the deployed configuration.
 - **Monitor 5 (Mercure)** — `Accepted Status Codes: 200-299, 401`. Mercure
   returns `401` for unauthenticated subscribers, which is the healthy answer
   here. Any `502/503/504` indicates the hub is unreachable.
+- **Monitor 6 (reference-data freshness)** — type **HTTP(s) - JSON Query**,
+  `JSON Query: $.deps.reference_data.status`, `Expected Value: stale`,
+  `Condition: !=`. The provisioner refreshes the local PostGIS index on a cron
+  (OSM weekly, DataTourisme daily); `/api/health` flags the index `stale` once a
+  refresh is overdue (ADR-041). This is a **low-severity (P3)** data-freshness
+  alarm, **not** an availability alarm — the probe deliberately returns `200`
+  even when stale, so only the JSON query (not the status code) detects it.
 
 ## 3. Notification webhook (prepares P1.3)
 

--- a/api/src/Controller/HealthController.php
+++ b/api/src/Controller/HealthController.php
@@ -194,11 +194,27 @@ final readonly class HealthController
     }
 
     /**
-     * Reports the freshness of the local-first PostGIS reference index (ADR-040):
-     * the last successful refresh timestamp and per-table feature counts the
-     * provisioner records in osm.metadata / tourism.metadata. Non-critical: a
-     * missing/empty index reports `down` (never provisioned) without flipping
-     * readiness, since it only degrades features.
+     * Maximum age (seconds) before a source's last refresh is considered stale,
+     * derived from each source's provisioning cadence (ADR-041): OSM is refreshed
+     * weekly, DataTourisme daily — so a comfortable buffer above each cadence
+     * flags a silently-failing or unscheduled cron without false positives.
+     *
+     * @var array<string, int>
+     */
+    private const array STALE_THRESHOLDS = [
+        'osm' => 8 * 86400,      // 8 days (weekly cadence)
+        'tourism' => 36 * 3600,  // 36 hours (daily cadence)
+    ];
+
+    /**
+     * Reports the freshness of the local-first PostGIS reference index
+     * (ADR-040/041): the last refresh timestamp, its age, a per-source `stale`
+     * flag (refresh older than the source cadence) and per-table feature counts
+     * the provisioner records in osm.metadata / tourism.metadata.
+     *
+     * Non-critical: `down` (never provisioned) or `stale` (refresh overdue, so an
+     * operator/uptime probe can alert on dated data) degrade features only — they
+     * never flip readiness, so the probe stays 200 (ADR-040).
      *
      * @return array<string, mixed>
      */
@@ -212,8 +228,15 @@ final readonly class HealthController
             $osm = $this->fetchProvisioningMetadata('osm');
             $tourism = $this->fetchProvisioningMetadata('tourism');
 
+            $present = array_filter([$osm, $tourism]);
+            $status = match (true) {
+                [] === $present => 'down',
+                array_any($present, static fn (array $source): bool => $source['stale']) => 'stale',
+                default => 'ok',
+            };
+
             return [
-                'status' => null === $osm && null === $tourism ? 'down' : 'ok',
+                'status' => $status,
                 'latency_ms' => $this->elapsedMs($start),
                 'osm' => $osm,
                 'tourism' => $tourism,
@@ -235,19 +258,20 @@ final readonly class HealthController
     }
 
     /**
-     * @return array{refreshed_at: ?string, feature_counts: array<string, int>}|null null when the schema was never provisioned (no metadata row)
+     * @return array{refreshed_at: ?string, age_seconds: ?int, stale: bool, feature_counts: array<string, int>}|null null when the schema was never provisioned (no metadata row)
      */
     private function fetchProvisioningMetadata(string $schema): ?array
     {
         // The schema name is interpolated into SQL; allowlist it so a future
         // caller can never turn this into an injection point.
-        if (!\in_array($schema, ['osm', 'tourism'], true)) {
+        if (!\array_key_exists($schema, self::STALE_THRESHOLDS)) {
             return null;
         }
 
         try {
+            // Age is computed in SQL (now() - refreshed_at) to stay timezone-safe.
             $row = $this->connection->fetchAssociative(
-                \sprintf('SELECT refreshed_at, feature_counts FROM %s.metadata LIMIT 1', $schema),
+                \sprintf('SELECT refreshed_at, EXTRACT(EPOCH FROM (now() - refreshed_at))::bigint AS age_seconds, feature_counts FROM %s.metadata LIMIT 1', $schema),
             );
         } catch (\Throwable) {
             // Schema/table absent (never migrated on this instance): treat as unprovisioned.
@@ -267,8 +291,12 @@ final readonly class HealthController
             }
         }
 
+        $ageSeconds = is_numeric($row['age_seconds']) ? (int) $row['age_seconds'] : null;
+
         return [
             'refreshed_at' => \is_string($row['refreshed_at']) ? $row['refreshed_at'] : null,
+            'age_seconds' => $ageSeconds,
+            'stale' => null !== $ageSeconds && $ageSeconds > self::STALE_THRESHOLDS[$schema],
             'feature_counts' => $counts,
         ];
     }

--- a/api/tests/Functional/HealthControllerTest.php
+++ b/api/tests/Functional/HealthControllerTest.php
@@ -291,9 +291,41 @@ final class HealthControllerTest extends ApiTestCase
         $this->assertSame('ok', $reference['status']);
         $this->assertNotNull($reference['osm']);
         $this->assertIsString($reference['osm']['refreshed_at']);
+        $this->assertFalse($reference['osm']['stale'], 'a just-refreshed index is fresh');
+        $this->assertLessThan(60, $reference['osm']['age_seconds']);
         $this->assertSame(12, $reference['osm']['feature_counts']['pois']);
         $this->assertSame(4, $reference['osm']['feature_counts']['admin_boundaries']);
         $this->assertNull($reference['tourism'], 'tourism index still unprovisioned');
+    }
+
+    #[Test]
+    public function readinessFlagsAStaleReferenceIndexWithoutFailingReadiness(): void
+    {
+        $this->truncateProvisioningMetadata();
+        $connection = self::getContainer()->get('doctrine.dbal.default_connection');
+        \assert($connection instanceof Connection);
+        // OSM refreshed 10 days ago — past the 8-day weekly-cadence threshold.
+        $connection->executeStatement(<<<'SQL'
+            INSERT INTO osm.metadata (refreshed_at, feature_counts)
+            VALUES (now() - interval '10 days', '{"pois": 12}'::jsonb)
+            SQL);
+
+        $this->mockHealthHttpClients(
+            valhalla: new MockResponse('OK', ['http_code' => 200]),
+            ollama: new MockResponse('{"models":[]}', ['http_code' => 200]),
+            mercure: new MockResponse('', ['http_code' => 200]),
+        );
+
+        $response = $this->client->request('GET', '/api/health');
+
+        // Stale data degrades features only — readiness stays 200 (ADR-040/041).
+        $this->assertResponseStatusCodeSame(200);
+        $data = $response->toArray();
+        $this->assertSame('ok', $data['status'], 'reference_data is non-required');
+        $reference = $data['deps']['reference_data'];
+        $this->assertSame('stale', $reference['status']);
+        $this->assertTrue($reference['osm']['stale']);
+        $this->assertGreaterThan(8 * 86400, $reference['osm']['age_seconds']);
     }
 
     private function truncateProvisioningMetadata(): void

--- a/docs/adr/adr-041-provisioner-resilience.md
+++ b/docs/adr/adr-041-provisioner-resilience.md
@@ -1,6 +1,6 @@
 # ADR-041: Provisioner Resilience — Failure Isolation, Resumable Enrichment, Detailed Logging
 
-- **Status:** Accepted — orchestration hardening, the resumable Wikidata cache and network timeouts/retries have landed; staleness alerting and the remaining memory budget work follow
+- **Status:** Accepted — all five workstreams (R1–R5) have landed: orchestration hardening, the resumable Wikidata cache, network timeouts/retries, the memory budget guard, and staleness alerting
 - **Date:** 2026-06-17
 - **Depends on:** ADR-040 (Local-first reference data — single PostGIS source), ADR-039 (Beta right-sizing)
 
@@ -37,18 +37,19 @@ Harden the provisioner so third-party and resource failures degrade only the aff
 - **Explicit timeouts.** OSM PBF and DataTourisme flux downloads cap both the per-chunk idle wait and the total transfer (`max_duration`), so a stalled mirror fails fast instead of hanging the run.
 - **Retry with backoff.** Wikidata SPARQL batches retry on transient failures (HTTP 429/5xx, transport errors) with exponential backoff before being skipped.
 
-### R4 — Memory budget (partially implemented, rest deferred)
+### R4 — Memory budget (implemented)
 
-The streaming enricher (R2) removes the largest avoidable PHP allocation. Remaining work: document and validate the `osm2pgsql --cache` vs container-limit budget, and set an explicit PHP `memory_limit`.
+The streaming enricher (R2) removes the largest avoidable PHP allocation. On top of that, the provisioner entrypoint caps PHP at `memory_limit=512M` so a regression in the streaming / enrichment paths fails with a clean PHP fatal instead of a silent container OOM-kill. The heavy import processes run **outside** PHP: `osm2pgsql` is bounded by `--cache 800` (MB) plus its node cache, and `psql` by the DB config — together they fit the provisioner's 2 GB container alongside the bounded PHP process. The container limit stays the backstop for the native tools.
 
-### R5 — Staleness alerting (deferred)
+### R5 — Staleness alerting (implemented)
 
-`/api/health` already exposes `osm.metadata` / `tourism.metadata` `refreshed_at`. Planned: age thresholds per source (and a Wikidata refresh marker) surfaced as a degraded-feature signal, plus an uptime probe and runbook — so a silently-failing cron is detected by data age, not only by a failed run.
+`/api/health` `reference_data` now reports, per source, the refresh `age_seconds` and a `stale` flag (refresh older than the source cadence: OSM 8 days, DataTourisme 36 hours), and an overall `stale` status when any source is overdue. It stays **non-required** — stale data degrades features only, never flipping readiness — so an uptime probe (Uptime Kuma) can alert on `deps.reference_data.status == "stale"` (or a per-source `stale` flag) and catch a silently-failing or unscheduled cron by data age, not only by a failed run. Wikidata freshness rides on the OSM/tourism refresh that re-runs the cache-backed enrichment.
 
 ## Consequences
 
 - A Wikidata/DataTourisme/mirror outage degrades only the next refresh of that source; the live dataset and the other sources are unaffected.
 - The daily DataTourisme refresh no longer pays the full Wikidata cost; enrichment resumes from the cache after any interruption.
-- Provisioner memory stays bounded on the enrichment path; the import path budget is the remaining R4 item.
+- Provisioner memory is bounded: the PHP process is capped at 512 MB, and the native import tools fit the 2 GB container under their own caps.
+- A silently-failing or unscheduled refresh is detectable by data age via `/api/health` (`reference_data` stale flag), not only by a failed run.
 - Failures leave a persistent, detailed trace (command + stderr) for later diagnosis.
 - The cache adds a stable `provisioner` schema, bootstrapped by a migration and self-created by the provisioner if absent.


### PR DESCRIPTION
## Contexte

Clôt le chantier robustesse provisioner de l'ADR-041 (R1-R3 livrés en #702). Couvre les deux workstreams restants — répond directement à ta question « comment anticiper les erreurs » (détecter une donnée périmée / un cron muet) et « OOM ».

## R5 — Alerte de staleness sur `/api/health`

`deps.reference_data` expose désormais, **par source**, l'âge du dernier refresh (`age_seconds`) et un drapeau `stale` (refresh plus vieux que la cadence : OSM 8j, DataTourisme 36h), plus un **statut global `stale`** dès qu'une source est en retard.

- **Non bloquant** : une donnée périmée ne dégrade que les features, ne fait jamais tomber la readiness — la sonde reste `200`. C'est volontaire : seul le contenu JSON (pas le code HTTP) signale le retard, pour qu'une sonde alerte sur l'**âge de la donnée** et attrape un cron silencieusement en échec ou non planifié.
- Âge calculé en SQL (`now() - refreshed_at`, timezone-safe).
- Monitor Uptime Kuma #6 (HTTP JSON Query, P3) documenté : `$.deps.reference_data.status != "stale"`.

## R4 — Garde-fou mémoire

Entrypoint provisioner plafonné à `memory_limit=512M` : une régression dans les chemins streaming/enrichissement échoue en **fatal PHP propre** plutôt qu'en OOM-kill conteneur silencieux. Les outils d'import natifs (`osm2pgsql --cache 800`, `psql`) tournent hors PHP et tiennent sous la limite conteneur 2 Go (documenté dans l'ADR).

## Docs

ADR-041 : R4 + R5 passent de « deferred » à « implemented » (statut + conséquences + budget mémoire + seuils de staleness). Monitor de fraîcheur ajouté au README uptime-kuma.

## Vérification

API (host, vendor installé) : **phpstan level 9 no errors**, **phpunit tests/Unit 1013 OK**, **rector** clean, **php-cs-fixer** clean. Nouveau test fonctionnel `HealthControllerTest::readinessFlagsAStaleReferenceIndexWithoutFailingReadiness` (refresh à -10j → `reference_data.status=stale`, HTTP 200) + assertions `stale`/`age_seconds` sur le cas frais — tournent en CI (PostGIS).

<!-- claude-review-start -->
## Claude Review

**Reviewed commit:** `0baf25e9b14ce22bf332b2ce5f197d42476b2849`

**Summary:** 0 findings (0 critical, 0 warnings). Clean close of the ADR-041 robustness chantier. Both workstreams are well-scoped and production-ready: the PHP memory guard is applied consistently to both dev and prod Dockerfile stages, and the staleness alerting is carefully non-breaking — data age never flips readiness, only the JSON payload, exactly as ADR-040/041 intended. The SQL age computation in `EXTRACT(EPOCH FROM (now() - refreshed_at))::bigint` is timezone-safe, the schema-name allowlist is improved by tying it to `STALE_THRESHOLDS` instead of a parallel array, and the functional test covers both the fresh and stale paths against a real PostGIS instance.

**Resolved threads:** No previously open threads.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date (ADR-041 + Uptime Kuma README)
- [x] Dependent tickets accounted for (closes ADR-041 R1–R5 chantier)

**Inline comments:** None.
<!-- claude-review-end -->