### PR TITLE
feat(weather): retry transient open-meteo failures + stop fabricating forecasts

### DIFF
--- a/api/config/packages/framework.php
+++ b/api/config/packages/framework.php
@@ -51,6 +51,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 'open_meteo.client' => [
                     'base_uri' => 'https://api.open-meteo.com',
                     'timeout' => 10,
+                    'max_redirects' => 2,
                     // Live, on-demand source (Tier 3): retry transient failures
                     // (429/5xx + transport errors) with exponential back-off rather
                     // than dropping the forecast on the first hiccup.

--- a/api/config/packages/framework.php
+++ b/api/config/packages/framework.php
@@ -51,6 +51,12 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 'open_meteo.client' => [
                     'base_uri' => 'https://api.open-meteo.com',
                     'timeout' => 10,
+                    // Live, on-demand source (Tier 3): retry transient failures
+                    // (429/5xx + transport errors) with exponential back-off rather
+                    // than dropping the forecast on the first hiccup.
+                    'retry_failed' => [
+                        'max_retries' => 3,
+                    ],
                 ],
                 'routing.client' => [
                     'base_uri' => 'http://valhalla:8002',

--- a/api/src/MessageHandler/FetchWeatherHandler.php
+++ b/api/src/MessageHandler/FetchWeatherHandler.php
@@ -99,6 +99,12 @@ final readonly class FetchWeatherHandler extends AbstractTripMessageHandler
                     $forecasts = $this->weatherProvider->fetchForecasts($locations, $locale);
 
                     foreach ($forecasts as $idx => $forecast) {
+                        // No usable forecast for this location: leave the stage
+                        // weather absent and do not cache a fabricated value.
+                        if (null === $forecast) {
+                            continue;
+                        }
+
                         $stageIndex = $uncachedIndices[$idx];
                         $stages[$stageIndex]->weather = $forecast;
 

--- a/api/src/Weather/OpenMeteoProvider.php
+++ b/api/src/Weather/OpenMeteoProvider.php
@@ -19,7 +19,7 @@ final readonly class OpenMeteoProvider implements WeatherProviderInterface
     ) {
     }
 
-    public function fetchForecast(float $lat, float $lon, string $locale = 'en'): WeatherForecast
+    public function fetchForecast(float $lat, float $lon, string $locale = 'en'): ?WeatherForecast
     {
         $response = $this->httpClient->request('GET', '/v1/forecast', [
             'query' => [
@@ -31,30 +31,10 @@ final readonly class OpenMeteoProvider implements WeatherProviderInterface
             ],
         ]);
 
-        /** @var array{daily?: array{weather_code?: list<int>, temperature_2m_max?: list<float>, temperature_2m_min?: list<float>, precipitation_probability_max?: list<int>, wind_speed_10m_max?: list<float>, wind_direction_10m_dominant?: list<int>, relative_humidity_2m_mean?: list<int>}} $data */
+        /** @var array{daily?: array<string, list<float|int>>} $data */
         $data = $response->toArray();
 
-        $daily = $data['daily'] ?? [];
-        $weatherCode = ($daily['weather_code'] ?? [0])[0];
-        $tempMax = ($daily['temperature_2m_max'] ?? [0.0])[0];
-        $tempMin = ($daily['temperature_2m_min'] ?? [0.0])[0];
-        $precipProb = ($daily['precipitation_probability_max'] ?? [0])[0];
-        $windSpeed = ($daily['wind_speed_10m_max'] ?? [0.0])[0];
-        $windDeg = (int) ($daily['wind_direction_10m_dominant'] ?? [0])[0];
-        $humidity = (int) ($daily['relative_humidity_2m_mean'] ?? [50])[0];
-
-        return new WeatherForecast(
-            icon: $this->wmoToIcon($weatherCode),
-            description: $this->wmoToDescription($weatherCode, $locale),
-            tempMin: (float) $tempMin,
-            tempMax: (float) $tempMax,
-            windSpeed: (float) $windSpeed,
-            windDirection: $this->degToDirection($windDeg),
-            precipitationProbability: (int) $precipProb,
-            humidity: $humidity,
-            comfortIndex: $this->comfortIndexCalculator->compute((float) $tempMax, (float) $windSpeed, $humidity, (int) $precipProb),
-            relativeWindDirection: WeatherForecast::RELATIVE_WIND_UNKNOWN,
-        );
+        return $this->parseForecast($data['daily'] ?? [], $locale);
     }
 
     /**
@@ -62,7 +42,7 @@ final readonly class OpenMeteoProvider implements WeatherProviderInterface
      *
      * @param list<array{lat: float, lon: float}> $locations
      *
-     * @return list<WeatherForecast>
+     * @return list<?WeatherForecast>
      */
     public function fetchForecasts(array $locations, string $locale = 'en'): array
     {
@@ -88,36 +68,47 @@ final readonly class OpenMeteoProvider implements WeatherProviderInterface
             ],
         ]);
 
-        /** @var list<array{daily?: array{weather_code?: list<int>, temperature_2m_max?: list<float>, temperature_2m_min?: list<float>, precipitation_probability_max?: list<int>, wind_speed_10m_max?: list<float>, wind_direction_10m_dominant?: list<int>, relative_humidity_2m_mean?: list<int>}}> $dataList */
+        /** @var list<array{daily?: array<string, list<float|int>>}> $dataList */
         $dataList = $response->toArray();
 
-        // @todo #89 SRP: extract parseForecastData() to eliminate duplication with fetchForecast()
-        $forecasts = [];
-        foreach ($dataList as $data) {
-            $daily = $data['daily'] ?? [];
-            $weatherCode = ($daily['weather_code'] ?? [0])[0];
-            $tempMax = ($daily['temperature_2m_max'] ?? [0.0])[0];
-            $tempMin = ($daily['temperature_2m_min'] ?? [0.0])[0];
-            $precipProb = ($daily['precipitation_probability_max'] ?? [0])[0];
-            $windSpeed = ($daily['wind_speed_10m_max'] ?? [0.0])[0];
-            $windDeg = (int) ($daily['wind_direction_10m_dominant'] ?? [0])[0];
-            $humidity = (int) ($daily['relative_humidity_2m_mean'] ?? [50])[0];
+        return array_map(fn (array $data): ?WeatherForecast => $this->parseForecast($data['daily'] ?? [], $locale), $dataList);
+    }
 
-            $forecasts[] = new WeatherForecast(
-                icon: $this->wmoToIcon($weatherCode),
-                description: $this->wmoToDescription($weatherCode, $locale),
-                tempMin: (float) $tempMin,
-                tempMax: (float) $tempMax,
-                windSpeed: (float) $windSpeed,
-                windDirection: $this->degToDirection($windDeg),
-                precipitationProbability: (int) $precipProb,
-                humidity: $humidity,
-                comfortIndex: $this->comfortIndexCalculator->compute((float) $tempMax, (float) $windSpeed, $humidity, (int) $precipProb),
-                relativeWindDirection: WeatherForecast::RELATIVE_WIND_UNKNOWN,
-            );
+    /**
+     * Builds a forecast from one open-meteo `daily` block, or null when the core
+     * fields (weather code + both temperatures) are absent — so a 200 response
+     * with an empty/partial body yields no weather rather than a fabricated 0 °C
+     * clear-sky forecast (ADR — Tier 3 "no fake data").
+     *
+     * @param array<string, list<float|int>> $daily
+     */
+    private function parseForecast(array $daily, string $locale): ?WeatherForecast
+    {
+        if (!isset($daily['weather_code'][0], $daily['temperature_2m_max'][0], $daily['temperature_2m_min'][0])) {
+            return null;
         }
 
-        return $forecasts;
+        $weatherCode = (int) $daily['weather_code'][0];
+        $tempMax = (float) $daily['temperature_2m_max'][0];
+        $tempMin = (float) $daily['temperature_2m_min'][0];
+        // Secondary fields keep conservative defaults when absent (dry, calm).
+        $precipProb = (int) ($daily['precipitation_probability_max'][0] ?? 0);
+        $windSpeed = (float) ($daily['wind_speed_10m_max'][0] ?? 0.0);
+        $windDeg = (int) ($daily['wind_direction_10m_dominant'][0] ?? 0);
+        $humidity = (int) ($daily['relative_humidity_2m_mean'][0] ?? 50);
+
+        return new WeatherForecast(
+            icon: $this->wmoToIcon($weatherCode),
+            description: $this->wmoToDescription($weatherCode, $locale),
+            tempMin: $tempMin,
+            tempMax: $tempMax,
+            windSpeed: $windSpeed,
+            windDirection: $this->degToDirection($windDeg),
+            precipitationProbability: $precipProb,
+            humidity: $humidity,
+            comfortIndex: $this->comfortIndexCalculator->compute($tempMax, $windSpeed, $humidity, $precipProb),
+            relativeWindDirection: WeatherForecast::RELATIVE_WIND_UNKNOWN,
+        );
     }
 
     private function wmoToIcon(int $code): string

--- a/api/src/Weather/WeatherProviderInterface.php
+++ b/api/src/Weather/WeatherProviderInterface.php
@@ -8,14 +8,21 @@ use App\ApiResource\Model\WeatherForecast;
 
 interface WeatherProviderInterface
 {
-    public function fetchForecast(float $lat, float $lon, string $locale = 'en'): WeatherForecast;
+    /**
+     * Returns null when the provider has no usable forecast for the location (a
+     * failed call after retries, or a response missing the core fields) — never a
+     * fabricated default, so the caller leaves the stage weather genuinely absent.
+     */
+    public function fetchForecast(float $lat, float $lon, string $locale = 'en'): ?WeatherForecast;
 
     /**
-     * Fetch forecasts for multiple locations in a single API call.
+     * Fetch forecasts for multiple locations in a single API call. The result is
+     * aligned to $locations by index; an entry is null when that location has no
+     * usable forecast.
      *
      * @param list<array{lat: float, lon: float}> $locations
      *
-     * @return list<WeatherForecast>
+     * @return list<?WeatherForecast>
      */
     public function fetchForecasts(array $locations, string $locale = 'en'): array;
 }

--- a/api/tests/Unit/MessageHandler/FetchWeatherHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/FetchWeatherHandlerTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\MessageHandler;
+
+use App\ApiResource\Model\Coordinate;
+use App\ApiResource\Model\WeatherForecast;
+use App\ApiResource\Stage;
+use App\ApiResource\TripRequest;
+use App\ComputationTracker\ComputationTrackerInterface;
+use App\ComputationTracker\TripGenerationTrackerInterface;
+use App\Message\FetchWeather;
+use App\MessageHandler\FetchWeatherHandler;
+use App\Mercure\TripUpdatePublisherInterface;
+use App\Repository\TripRequestRepositoryInterface;
+use App\Weather\WeatherProviderInterface;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final class FetchWeatherHandlerTest extends TestCase
+{
+    private function stage(int $day, float $lat, float $lon): Stage
+    {
+        return new Stage(
+            tripId: 'trip-1',
+            dayNumber: $day,
+            distance: 60.0,
+            elevation: 100.0,
+            startPoint: new Coordinate($lat, $lon),
+            endPoint: new Coordinate($lat + 0.1, $lon + 0.1),
+            geometry: [new Coordinate($lat, $lon), new Coordinate($lat + 0.1, $lon + 0.1)],
+        );
+    }
+
+    private function forecast(): WeatherForecast
+    {
+        return new WeatherForecast(
+            icon: '10d',
+            description: 'Rain',
+            tempMin: 9.0,
+            tempMax: 18.0,
+            windSpeed: 22.0,
+            windDirection: 'S',
+            precipitationProbability: 70,
+            humidity: 80,
+            comfortIndex: 60,
+            relativeWindDirection: WeatherForecast::RELATIVE_WIND_UNKNOWN,
+        );
+    }
+
+    private function cacheKey(string $locale, float $lat, float $lon, int $i): string
+    {
+        return \sprintf('weather.%s.%s.%s.%d', $locale, round($lat, 2), round($lon, 2), $i);
+    }
+
+    /**
+     * @param list<Stage> $stages
+     */
+    private function createHandler(array $stages, WeatherProviderInterface $provider, ArrayAdapter $cache): FetchWeatherHandler
+    {
+        $computationTracker = $this->createStub(ComputationTrackerInterface::class);
+        $computationTracker->method('getProgress')->willReturn(['completed' => 0, 'failed' => 0, 'total' => 1]);
+
+        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
+        $tripStateManager->method('getRequest')->willReturn(new TripRequest());
+        $tripStateManager->method('getStages')->willReturn($stages);
+        $tripStateManager->method('getLocale')->willReturn('en');
+
+        $messageBus = $this->createStub(MessageBusInterface::class);
+        // dispatch() returns the final Envelope class, which cannot be doubled.
+        $messageBus->method('dispatch')->willReturn(new Envelope(new \stdClass()));
+
+        return new FetchWeatherHandler(
+            $computationTracker,
+            $this->createStub(TripUpdatePublisherInterface::class),
+            $this->createStub(TripGenerationTrackerInterface::class),
+            new NullLogger(),
+            $tripStateManager,
+            $provider,
+            $cache,
+            $messageBus,
+        );
+    }
+
+    #[Test]
+    public function skipsNullForecastsWithoutCachingAndStillProcessesOthers(): void
+    {
+        $stage0 = $this->stage(1, 47.0, -2.0); // provider returns null for this one
+        $stage1 = $this->stage(2, 48.0, 3.0);  // provider returns a valid forecast
+
+        $provider = $this->createStub(WeatherProviderInterface::class);
+        $provider->method('fetchForecasts')->willReturn([null, $this->forecast()]);
+
+        $cache = new ArrayAdapter();
+
+        ($this->createHandler([$stage0, $stage1], $provider, $cache))(new FetchWeather('trip-1'));
+
+        self::assertNull($stage0->weather, 'a null forecast leaves the stage weather absent');
+        self::assertInstanceOf(WeatherForecast::class, $stage1->weather, 'other forecasts in the same batch still apply');
+
+        self::assertFalse(
+            $cache->getItem($this->cacheKey('en', 47.0, -2.0, 0))->isHit(),
+            'a null forecast is never cached',
+        );
+        self::assertTrue(
+            $cache->getItem($this->cacheKey('en', 48.0, 3.0, 1))->isHit(),
+            'a valid forecast is cached',
+        );
+    }
+}

--- a/api/tests/Unit/Weather/OpenMeteoProviderTest.php
+++ b/api/tests/Unit/Weather/OpenMeteoProviderTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Weather;
+
+use App\Weather\OpenMeteoProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class OpenMeteoProviderTest extends TestCase
+{
+    private function provider(MockHttpClient $client): OpenMeteoProvider
+    {
+        $translator = $this->createStub(TranslatorInterface::class);
+        $translator->method('trans')->willReturnArgument(0);
+
+        return new OpenMeteoProvider($client, $translator);
+    }
+
+    /**
+     * @param array<string, list<float|int>> $daily
+     */
+    private function dailyResponse(array $daily): MockResponse
+    {
+        return new MockResponse((string) json_encode(['daily' => $daily]));
+    }
+
+    /**
+     * @return array<string, list<float|int>>
+     */
+    private function fullDaily(): array
+    {
+        return [
+            'weather_code' => [61],
+            'temperature_2m_max' => [18.5],
+            'temperature_2m_min' => [9.0],
+            'precipitation_probability_max' => [70],
+            'wind_speed_10m_max' => [22.0],
+            'wind_direction_10m_dominant' => [180],
+            'relative_humidity_2m_mean' => [80],
+        ];
+    }
+
+    #[Test]
+    public function parsesAValidForecast(): void
+    {
+        $forecast = $this->provider(new MockHttpClient($this->dailyResponse($this->fullDaily())))
+            ->fetchForecast(48.5, 2.3);
+
+        self::assertNotNull($forecast);
+        self::assertSame(18.5, $forecast->tempMax);
+        self::assertSame(9.0, $forecast->tempMin);
+        self::assertSame(70, $forecast->precipitationProbability);
+        self::assertSame('weather.rain', $forecast->description);
+        self::assertSame('S', $forecast->windDirection);
+    }
+
+    #[Test]
+    public function returnsNullWhenTheResponseHasNoUsableData(): void
+    {
+        // A 200 with an empty daily block must yield null, not a fabricated 0 °C
+        // clear-sky forecast.
+        self::assertNull(
+            $this->provider(new MockHttpClient($this->dailyResponse([])))->fetchForecast(48.5, 2.3),
+        );
+    }
+
+    #[Test]
+    public function returnsNullWhenCoreFieldsArePartiallyMissing(): void
+    {
+        // weather_code present but temperatures missing → not usable.
+        self::assertNull(
+            $this->provider(new MockHttpClient($this->dailyResponse(['weather_code' => [0]])))->fetchForecast(48.5, 2.3),
+        );
+    }
+
+    #[Test]
+    public function fetchForecastsReturnsEmptyForNoLocations(): void
+    {
+        self::assertSame([], $this->provider(new MockHttpClient())->fetchForecasts([]));
+    }
+
+    #[Test]
+    public function fetchForecastsAlignsNullsToLocationsForAMixedBatch(): void
+    {
+        // Multi-location batch: open-meteo returns a list; the second location has
+        // no usable data, so the result is [forecast, null] aligned to the input.
+        $client = new MockHttpClient(new MockResponse((string) json_encode([
+            ['daily' => $this->fullDaily()],
+            ['daily' => []],
+        ])));
+
+        $forecasts = $this->provider($client)->fetchForecasts([
+            ['lat' => 48.5, 'lon' => 2.3],
+            ['lat' => 45.0, 'lon' => 5.0],
+        ]);
+
+        self::assertCount(2, $forecasts);
+        self::assertNotNull($forecasts[0]);
+        self::assertSame(18.5, $forecasts[0]->tempMax);
+        self::assertNull($forecasts[1]);
+    }
+}


### PR DESCRIPTION
## Contexte

Premier volet du **Tier 3 — résilience live** (plan local-first). La météo est une source live on-demand (open-meteo) : aujourd'hui sans retry, et le provider **fabrique** une prévision 0 °C ciel clair quand la réponse est vide/partielle (fausse donnée). Le plan demande « retries/back-off + null propre, pas de fausse donnée ».

## Changements

- **Retry/back-off** : `retry_failed` (3 retries, back-off exponentiel) activé sur `open_meteo.client` → un 429/5xx/erreur transport transitoire ne fait plus tomber la prévision au premier coup.
- **Plus de fausse donnée** : `OpenMeteoProvider::fetchForecast()` renvoie désormais `?WeatherForecast`. Une réponse sans les champs cœur (`weather_code` + les deux températures) renvoie `null` au lieu d'une prévision fabriquée à 0 °C. Champs secondaires (précip/vent/humidité) gardent des défauts conservateurs (sec/calme) quand absents. Extraction de `parseForecast()` (résout le `@todo #89` de duplication).
- **Handler** : `FetchWeatherHandler` ignore les forecasts `null` (l'étape reste sans météo, rien n'est mis en cache). Le cache 3h et le catch best-effort existants sont conservés.

Le contrat `WeatherForecast` est inchangé (champs identiques) → pas de changement de schéma OpenAPI ni de typegen. `Stage.weather` était déjà nullable côté lecture.

## Vérification

API (host, vendor installé) : **phpstan level 9 no errors**, **phpunit tests/Unit 1018 OK**, **rector** clean, **php-cs-fixer** clean, **cache:clear** OK (config retry valide). Nouveau `OpenMeteoProviderTest` (parse valide, null sur réponse vide/partielle, alignement des null sur un batch multi-locations).

## Suite

Second volet Tier 3 : **résilience du fetch d'itinéraire** (Komoot/Strava/RWGPS) — retries/timeouts + messages d'erreur clairs — dans une PR séparée.

<!-- claude-review-start -->
## Claude Review

Reviewed commit `b58213a`.

**Summary:** Both findings from the previous review have been addressed — `max_redirects: 2` is now set on `open_meteo.client` and `FetchWeatherHandlerTest` covers the null-skip path. The PR is clean: the `parseForecast()` extraction eliminates the `@todo #89` duplication, the null-propagation contract is clearly defined in the interface, and the retry configuration is correctly scoped. No new findings.

**Findings:** 0 findings.

**Resolved threads:** Resolved 2 previously open threads that were addressed.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.
<!-- claude-review-end -->