### PR TITLE
feat(route-fetch): retry transient failures + clear error on terminal fetch failure

### DIFF
--- a/api/config/packages/framework.php
+++ b/api/config/packages/framework.php
@@ -25,6 +25,12 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                     'base_uri' => 'https://www.komoot.com',
                     'max_redirects' => 2,
                     'timeout' => 10,
+                    // On-demand route fetch (Tier 3): retry transient failures
+                    // (429/5xx + transport errors) with back-off; permanent client
+                    // errors (404/403) are not retried, so they fail fast.
+                    'retry_failed' => [
+                        'max_retries' => 2,
+                    ],
                     'headers' => [
                         'Accept' => 'text/html',
                         'User-Agent' => 'BikeTripPlanner/1.0',
@@ -34,6 +40,9 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                     'base_uri' => 'https://www.strava.com',
                     'max_redirects' => 2,
                     'timeout' => 10,
+                    'retry_failed' => [
+                        'max_retries' => 2,
+                    ],
                     'headers' => [
                         'Accept' => 'application/gpx+xml',
                         'User-Agent' => 'BikeTripPlanner/1.0',
@@ -43,6 +52,9 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                     'base_uri' => 'https://ridewithgps.com',
                     'max_redirects' => 2,
                     'timeout' => 10,
+                    'retry_failed' => [
+                        'max_retries' => 2,
+                    ],
                     'headers' => [
                         'Accept' => 'application/json',
                         'User-Agent' => 'BikeTripPlanner/1.0',

--- a/api/src/MessageHandler/FetchAndParseRouteHandler.php
+++ b/api/src/MessageHandler/FetchAndParseRouteHandler.php
@@ -63,8 +63,10 @@ final readonly class FetchAndParseRouteHandler extends AbstractTripMessageHandle
                 $fetcher = $this->routeFetcherRegistry->get($sourceUrl);
                 $result = $fetcher->fetch($sourceUrl);
             } catch (\RuntimeException $runtimeException) {
+                // Keep the technical detail (incl. raw cURL/transport messages) in
+                // the logs; show the user a stable, friendly message.
                 $this->logger->warning('Route fetch failed.', ['url' => $sourceUrl, 'error' => $runtimeException->getMessage()]);
-                $this->publisher->publishValidationError($tripId, 'ROUTE_FETCH_FAILED', $runtimeException->getMessage());
+                $this->publisher->publishValidationError($tripId, 'ROUTE_FETCH_FAILED', 'The route could not be fetched. Please check the URL and try again.');
 
                 return;
             }

--- a/api/src/MessageHandler/FetchAndParseRouteHandler.php
+++ b/api/src/MessageHandler/FetchAndParseRouteHandler.php
@@ -53,8 +53,21 @@ final readonly class FetchAndParseRouteHandler extends AbstractTripMessageHandle
         $sourceUrl = $request->sourceUrl;
 
         $this->executeWithTracking($tripId, ComputationName::ROUTE, function () use ($tripId, $sourceUrl, $generation): void {
-            $fetcher = $this->routeFetcherRegistry->get($sourceUrl);
-            $result = $fetcher->fetch($sourceUrl);
+            // The route source is a live, on-demand third party (Tier 3). HTTP-level
+            // transient failures are already retried with back-off by the scoped
+            // client; a RuntimeException here is therefore a clear, terminal fetch
+            // failure (private/removed tour, unreachable source, unparseable
+            // response). Surface it to the user as a validation error and stop —
+            // re-throwing would only trigger pointless Messenger retries.
+            try {
+                $fetcher = $this->routeFetcherRegistry->get($sourceUrl);
+                $result = $fetcher->fetch($sourceUrl);
+            } catch (\RuntimeException $runtimeException) {
+                $this->logger->warning('Route fetch failed.', ['url' => $sourceUrl, 'error' => $runtimeException->getMessage()]);
+                $this->publisher->publishValidationError($tripId, 'ROUTE_FETCH_FAILED', $runtimeException->getMessage());
+
+                return;
+            }
 
             if ([] === $result->tracks) {
                 $this->publisher->publishValidationError($tripId, 'EMPTY_ROUTE', 'Empty route.');

--- a/api/tests/Unit/MessageHandler/FetchAndParseRouteHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/FetchAndParseRouteHandlerTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\MessageHandler;
+
+use App\ApiResource\TripRequest;
+use App\ComputationTracker\ComputationTrackerInterface;
+use App\ComputationTracker\TripGenerationTrackerInterface;
+use App\Engine\DistanceCalculatorInterface;
+use App\Engine\ElevationCalculatorInterface;
+use App\Engine\RouteSimplifierInterface;
+use App\Message\FetchAndParseRoute;
+use App\MessageHandler\FetchAndParseRouteHandler;
+use App\Mercure\TripUpdatePublisherInterface;
+use App\Repository\TripRequestRepositoryInterface;
+use App\RouteFetcher\RouteFetcherInterface;
+use App\RouteFetcher\RouteFetcherRegistryInterface;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final class FetchAndParseRouteHandlerTest extends TestCase
+{
+    #[Test]
+    public function aFailedFetchPublishesAClearValidationErrorWithoutRetrying(): void
+    {
+        $request = new TripRequest();
+        $request->sourceUrl = 'https://www.komoot.com/tour/123';
+
+        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
+        $tripStateManager->method('getRequest')->willReturn($request);
+
+        // The fetcher fails with the documented RuntimeException (e.g. a private tour).
+        $fetcher = $this->createStub(RouteFetcherInterface::class);
+        $fetcher->method('fetch')->willThrowException(new \RuntimeException('Komoot tour 123 is private or access denied (403).'));
+        $registry = $this->createStub(RouteFetcherRegistryInterface::class);
+        $registry->method('get')->willReturn($fetcher);
+
+        $computationTracker = $this->createStub(ComputationTrackerInterface::class);
+        $computationTracker->method('getProgress')->willReturn(['completed' => 0, 'failed' => 0, 'total' => 1]);
+
+        $publisher = $this->createMock(TripUpdatePublisherInterface::class);
+        $publisher->expects($this->once())
+            ->method('publishValidationError')
+            ->with('trip-1', 'ROUTE_FETCH_FAILED', 'Komoot tour 123 is private or access denied (403).');
+
+        // A terminal fetch failure must not re-dispatch: no GenerateStages, no retry.
+        $messageBus = $this->createMock(MessageBusInterface::class);
+        $messageBus->expects($this->never())->method('dispatch');
+
+        $handler = new FetchAndParseRouteHandler(
+            $computationTracker,
+            $publisher,
+            $this->createStub(TripGenerationTrackerInterface::class),
+            new NullLogger(),
+            $tripStateManager,
+            $registry,
+            $this->createStub(DistanceCalculatorInterface::class),
+            $this->createStub(ElevationCalculatorInterface::class),
+            $this->createStub(RouteSimplifierInterface::class),
+            $messageBus,
+        );
+
+        // The handler must return normally (computation marked done), not re-throw.
+        $handler(new FetchAndParseRoute('trip-1'));
+    }
+}

--- a/api/tests/Unit/MessageHandler/FetchAndParseRouteHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/FetchAndParseRouteHandlerTest.php
@@ -42,9 +42,11 @@ final class FetchAndParseRouteHandlerTest extends TestCase
         $computationTracker->method('getProgress')->willReturn(['completed' => 0, 'failed' => 0, 'total' => 1]);
 
         $publisher = $this->createMock(TripUpdatePublisherInterface::class);
+        // The raw exception detail stays in the logs; the user gets a stable,
+        // friendly message (no leaked cURL/transport internals).
         $publisher->expects($this->once())
             ->method('publishValidationError')
-            ->with('trip-1', 'ROUTE_FETCH_FAILED', 'Komoot tour 123 is private or access denied (403).');
+            ->with('trip-1', 'ROUTE_FETCH_FAILED', 'The route could not be fetched. Please check the URL and try again.');
 
         // A terminal fetch failure must not re-dispatch: no GenerateStages, no retry.
         $messageBus = $this->createMock(MessageBusInterface::class);


### PR DESCRIPTION
## Contexte

Second volet du **Tier 3 — résilience live**. Le fetch d'itinéraire (Komoot/Strava/RWGPS) est une source live on-demand : aujourd'hui sans retry HTTP, et un échec (`RuntimeException`) remonte en **erreur de calcul opaque + 3 retries Messenger inutiles** (même pour un 404/403). Le plan demande « retries/timeouts + messages d'erreur clairs ».

## Changements

- **Retries HTTP** : `retry_failed` (2 retries, back-off) activé sur `komoot.client` / `strava.client` / `ridewithgps.client`. Les 429/5xx/erreurs transport transitoires sont retentés ; les erreurs client permanentes (404/403) ne le sont pas → échec rapide.
- **Message d'erreur clair + pas de retry inutile** : `FetchAndParseRouteHandler` capture la `RuntimeException` terminale (tour privé/supprimé, source injoignable, réponse non parsable — le transport transitoire ayant déjà été retenté côté client) et publie une **`ROUTE_FETCH_FAILED`** (`validation_error` → toast clair + spinner arrêté côté front) au lieu d'une `computation_error` opaque suivie de 3 retries Messenger. Le détail technique part dans les logs.

`TransportException` étend `RuntimeException`, donc le catch couvre aussi les timeouts/DNS résiduels. 2 retries (et non 3) car l'utilisateur attend pendant la création — latence bornée.

## Vérification

API (host, vendor installé) : **phpstan level 9 no errors**, **phpunit tests/Unit 1020 OK**, **rector** clean, **php-cs-fixer** clean, **cache:clear** OK (config retry valide). Nouveau `FetchAndParseRouteHandlerTest` : un fetch en échec publie `ROUTE_FETCH_FAILED` et ne re-dispatche rien (pas de `GenerateStages`, pas de retry).

Le code `validation_error` est déjà géré génériquement côté front (`use-mercure.ts`) → pas de changement PWA. Pas de changement de schéma OpenAPI.

## Bilan Tier 3

Avec #706 (météo) + cette PR (fetch d'itinéraire), le **Tier 3 résilience live** du plan est complet : retries/back-off + dégradation propre (null météo, erreur claire de fetch) sur les deux sources live.

<!-- claude-review-start -->
## Claude Review

**Reviewed commit:** `ab22ae3`

Clean, well-reasoned PR. The retry config is correctly scoped (429/5xx/transport retried; 404/403 fail-fast), the Messenger short-circuit is sound, the user-facing message is stable and free of transport internals, and the test verifies both the published validation error and the absence of re-dispatch. The previous warning finding (raw exception message forwarded to toast) was fully addressed in the second commit.

**Findings summary:** 0 critical, 0 warnings.

**Resolved threads:** Resolved 1 previously open thread that was addressed.

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.
<!-- claude-review-end -->