### PR TITLE
feat(ai): store the per-user AI provider and encrypted token

### DIFF
--- a/api/config/services.php
+++ b/api/config/services.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Llm\AiTokenEncryptor;
 use App\Llm\LlmClientFactory;
 use App\Llm\LlmClientInterface;
 use App\Llm\OllamaClient;
@@ -21,7 +22,12 @@ use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 return static function (ContainerConfigurator $containerConfigurator): void {
     $containerConfigurator->parameters()
         ->set('app.commit_sha', '%env(default:default_commit_sha:APP_COMMIT)%')
-        ->set('default_commit_sha', 'unknown');
+        ->set('default_commit_sha', 'unknown')
+        // AI token encryption key (ADR-042). PRODUCTION MUST set AI_TOKEN_ENC_KEY;
+        // the dev/CI default below only keeps the container bootable (throwaway dev
+        // tokens, never used to protect real credentials).
+        ->set('app.ai_token_enc_key', '%env(default:default_ai_token_enc_key:AI_TOKEN_ENC_KEY)%')
+        ->set('default_ai_token_enc_key', 'dev-only-ai-token-encryption-key-change-in-prod');
 
     $services = $containerConfigurator->services();
 
@@ -72,6 +78,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             service('openai.client'),
             service('gemini.client'),
             service('logger'),
+            service(AiTokenEncryptor::class),
         ]);
 
     // Async analysis handlers (pass-1 per stage, pass-2 overview) use the analysis client.

--- a/api/migrations/Version20260617160000.php
+++ b/api/migrations/Version20260617160000.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Adds the optional per-user AI provider configuration (ADR-042): the chosen
+ * provider and the encrypted API token. ai_token holds ciphertext only (see
+ * App\Llm\AiTokenEncryptor); both are cleared on GDPR anonymisation.
+ */
+final class Version20260617160000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add ai_provider and ai_token (encrypted) columns to the user table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE "user" ADD COLUMN IF NOT EXISTS ai_provider VARCHAR(32) DEFAULT NULL');
+        $this->addSql('ALTER TABLE "user" ADD COLUMN IF NOT EXISTS ai_token TEXT DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE "user" DROP COLUMN IF EXISTS ai_provider');
+        $this->addSql('ALTER TABLE "user" DROP COLUMN IF EXISTS ai_token');
+    }
+}

--- a/api/src/Entity/User.php
+++ b/api/src/Entity/User.php
@@ -33,6 +33,21 @@ class User implements UserInterface
     #[ORM\Column(length: 5, options: ['default' => 'fr'])]
     private string $locale = 'fr';
 
+    /**
+     * Optional bring-your-own AI provider (ADR-042): the {@see App\Llm\AiProvider}
+     * value the user picked, or null when AI is not configured.
+     */
+    #[ORM\Column(length: 32, nullable: true)]
+    private ?string $aiProvider = null;
+
+    /**
+     * The user's provider API token stored as ciphertext (see AiTokenEncryptor),
+     * never the plaintext: encrypted at the write boundary, decrypted only at
+     * call time.
+     */
+    #[ORM\Column(type: 'text', nullable: true)]
+    private ?string $aiToken = null;
+
     /** @var Collection<int, TripRequest> */
     #[ORM\OneToMany(targetEntity: TripRequest::class, mappedBy: 'user', fetch: 'EXTRA_LAZY')]
     private Collection $trips;
@@ -108,6 +123,35 @@ class User implements UserInterface
         $this->email = \sprintf('deleted-%s@deleted.invalid', $this->id->toRfc4122());
         $this->roles = [];
         $this->locale = 'fr';
+        $this->aiProvider = null;
+        $this->aiToken = null;
+    }
+
+    public function getAiProvider(): ?string
+    {
+        return $this->aiProvider;
+    }
+
+    public function setAiProvider(?string $aiProvider): self
+    {
+        $this->aiProvider = $aiProvider;
+
+        return $this;
+    }
+
+    /**
+     * Ciphertext, or null. Encrypt with AiTokenEncryptor before setting.
+     */
+    public function getAiToken(): ?string
+    {
+        return $this->aiToken;
+    }
+
+    public function setAiToken(?string $aiToken): self
+    {
+        $this->aiToken = $aiToken;
+
+        return $this;
     }
 
     public function getLocale(): string

--- a/api/src/Entity/User.php
+++ b/api/src/Entity/User.php
@@ -147,6 +147,9 @@ class User implements UserInterface
         return $this->aiToken;
     }
 
+    /**
+     * Ciphertext, or null. Encrypt with AiTokenEncryptor before setting.
+     */
     public function setAiToken(?string $aiToken): self
     {
         $this->aiToken = $aiToken;

--- a/api/src/Llm/AiTokenEncryptor.php
+++ b/api/src/Llm/AiTokenEncryptor.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Llm;
+
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * Symmetric, reversible encryption of a user's AI provider API token at rest
+ * (ADR-042). The token is a long-lived paid credential, so it is never stored or
+ * logged in clear: callers encrypt before persisting and decrypt only at call
+ * time to set the provider Authorization header.
+ *
+ * Uses libsodium's authenticated `crypto_secretbox` (XSalsa20-Poly1305) with a
+ * fresh random nonce per value (nonce is prepended to the ciphertext), so the
+ * same token yields different stored blobs and tampering is detected. The key is
+ * derived from a dedicated `AI_TOKEN_ENC_KEY` (not APP_SECRET, to decouple
+ * rotation) via a generic hash, so any-length secret yields a valid 32-byte key.
+ *
+ * Rotating the key makes existing stored tokens undecryptable (decrypt() returns
+ * null) — by design; the user simply re-enters their token.
+ */
+final readonly class AiTokenEncryptor
+{
+    private string $key;
+
+    public function __construct(
+        #[Autowire(param: 'app.ai_token_enc_key')]
+        string $key,
+    ) {
+        if ('' === $key) {
+            throw new \InvalidArgumentException('AI_TOKEN_ENC_KEY must not be empty.');
+        }
+
+        $this->key = sodium_crypto_generichash($key, '', \SODIUM_CRYPTO_SECRETBOX_KEYBYTES);
+    }
+
+    public function encrypt(#[\SensitiveParameter] string $plaintext): string
+    {
+        $nonce = random_bytes(\SODIUM_CRYPTO_SECRETBOX_NONCEBYTES);
+
+        return base64_encode($nonce.sodium_crypto_secretbox($plaintext, $nonce, $this->key));
+    }
+
+    /**
+     * Returns null when the blob is malformed, tampered, or encrypted under a
+     * different (rotated) key — never throws.
+     */
+    public function decrypt(string $encrypted): ?string
+    {
+        $decoded = base64_decode($encrypted, true);
+        if (false === $decoded || \strlen($decoded) <= \SODIUM_CRYPTO_SECRETBOX_NONCEBYTES) {
+            return null;
+        }
+
+        $nonce = substr($decoded, 0, \SODIUM_CRYPTO_SECRETBOX_NONCEBYTES);
+        $ciphertext = substr($decoded, \SODIUM_CRYPTO_SECRETBOX_NONCEBYTES);
+
+        $plaintext = sodium_crypto_secretbox_open($ciphertext, $nonce, $this->key);
+
+        return false === $plaintext ? null : $plaintext;
+    }
+}

--- a/api/src/Llm/AiTokenEncryptor.php
+++ b/api/src/Llm/AiTokenEncryptor.php
@@ -50,7 +50,7 @@ final readonly class AiTokenEncryptor
     public function decrypt(string $encrypted): ?string
     {
         $decoded = base64_decode($encrypted, true);
-        if (false === $decoded || \strlen($decoded) <= \SODIUM_CRYPTO_SECRETBOX_NONCEBYTES) {
+        if (false === $decoded || \strlen($decoded) < \SODIUM_CRYPTO_SECRETBOX_NONCEBYTES + \SODIUM_CRYPTO_SECRETBOX_MACBYTES) {
             return null;
         }
 

--- a/api/src/Llm/LlmClientFactory.php
+++ b/api/src/Llm/LlmClientFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Llm;
 
+use App\Entity\User;
 use Psr\Log\LoggerInterface;
 use Symfony\AI\Platform\Bridge\Anthropic\Factory as AnthropicFactory;
 use Symfony\AI\Platform\Bridge\Gemini\Factory as GeminiFactory;
@@ -15,10 +16,6 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  * chosen provider + API token (ADR-042) — there is no single DI-wired platform,
  * since the token is per-user. Each provider's `symfony/ai-platform` bridge gets
  * the matching scoped HTTP client (timeout / User-Agent / SSRF scope).
- *
- * The user-aware `forUser(User)` entry point (decrypt token + map provider)
- * lands with the encrypted token storage; this class keeps the provider+token
- * construction it depends on.
  */
 final readonly class LlmClientFactory
 {
@@ -27,7 +24,29 @@ final readonly class LlmClientFactory
         private HttpClientInterface $openAiClient,
         private HttpClientInterface $geminiClient,
         private LoggerInterface $logger,
+        private AiTokenEncryptor $tokenEncryptor,
     ) {
+    }
+
+    /**
+     * Returns the client for the user's configured provider, or null when AI is
+     * not configured (no provider/token), the provider is unknown, or the stored
+     * token cannot be decrypted (e.g. key rotation) — so callers degrade cleanly.
+     */
+    public function forUser(User $user): ?LlmClientInterface
+    {
+        $provider = AiProvider::tryFrom((string) $user->getAiProvider());
+        $encrypted = $user->getAiToken();
+        if (null === $provider || null === $encrypted) {
+            return null;
+        }
+
+        $token = $this->tokenEncryptor->decrypt($encrypted);
+        if (null === $token || '' === $token) {
+            return null;
+        }
+
+        return $this->create($provider, $token);
     }
 
     public function create(AiProvider $provider, #[\SensitiveParameter] string $token): LlmClientInterface

--- a/api/tests/Unit/Llm/AiTokenEncryptorTest.php
+++ b/api/tests/Unit/Llm/AiTokenEncryptorTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Llm;
+
+use App\Llm\AiTokenEncryptor;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class AiTokenEncryptorTest extends TestCase
+{
+    #[Test]
+    public function encryptsAndDecryptsRoundTrip(): void
+    {
+        $encryptor = new AiTokenEncryptor('a-secret-key');
+
+        $cipher = $encryptor->encrypt('sk-ant-secret-token');
+
+        self::assertNotSame('sk-ant-secret-token', $cipher, 'the token is not stored in clear');
+        self::assertSame('sk-ant-secret-token', $encryptor->decrypt($cipher));
+    }
+
+    #[Test]
+    public function producesADifferentCiphertextEachTime(): void
+    {
+        // Random nonce per call: same input must not yield the same blob.
+        $encryptor = new AiTokenEncryptor('a-secret-key');
+
+        self::assertNotSame($encryptor->encrypt('token'), $encryptor->encrypt('token'));
+    }
+
+    #[Test]
+    public function returnsNullForAMalformedBlob(): void
+    {
+        $encryptor = new AiTokenEncryptor('a-secret-key');
+
+        self::assertNull($encryptor->decrypt('not-base64-or-too-short'));
+        self::assertNull($encryptor->decrypt(''));
+    }
+
+    #[Test]
+    public function returnsNullWhenDecryptingUnderADifferentKey(): void
+    {
+        // Key rotation: previously stored tokens become undecryptable (by design).
+        $cipher = new AiTokenEncryptor('original-key')->encrypt('token');
+
+        self::assertNull(new AiTokenEncryptor('rotated-key')->decrypt($cipher));
+    }
+
+    #[Test]
+    public function rejectsAnEmptyKey(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        new AiTokenEncryptor('');
+    }
+}

--- a/api/tests/Unit/Llm/LlmClientFactoryTest.php
+++ b/api/tests/Unit/Llm/LlmClientFactoryTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Llm;
 
+use App\Entity\User;
 use App\Llm\AiProvider;
+use App\Llm\AiTokenEncryptor;
 use App\Llm\LlmClientFactory;
 use App\Llm\PlatformLlmClient;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -15,6 +17,19 @@ use Symfony\Component\HttpClient\MockHttpClient;
 
 final class LlmClientFactoryTest extends TestCase
 {
+    private AiTokenEncryptor $encryptor;
+
+    protected function setUp(): void
+    {
+        $this->encryptor = new AiTokenEncryptor('test-key');
+    }
+
+    private function factory(): LlmClientFactory
+    {
+        // MockHttpClient with no queued responses: construction must not hit the wire.
+        return new LlmClientFactory(new MockHttpClient(), new MockHttpClient(), new MockHttpClient(), new NullLogger(), $this->encryptor);
+    }
+
     /**
      * @return iterable<string, array{AiProvider, string}>
      */
@@ -29,11 +44,50 @@ final class LlmClientFactoryTest extends TestCase
 
     #[Test]
     #[DataProvider('providers')]
-    public function buildsAPlatformClientForEachProviderWithoutCallingTheNetwork(AiProvider $provider, string $token): void
+    public function createBuildsAPlatformClientForEachProvider(AiProvider $provider, string $token): void
     {
-        // MockHttpClient with no queued responses: construction must not hit the wire.
-        $factory = new LlmClientFactory(new MockHttpClient(), new MockHttpClient(), new MockHttpClient(), new NullLogger());
+        self::assertInstanceOf(PlatformLlmClient::class, $this->factory()->create($provider, $token));
+    }
 
-        self::assertInstanceOf(PlatformLlmClient::class, $factory->create($provider, $token));
+    #[Test]
+    public function forUserBuildsAClientWhenConfigured(): void
+    {
+        $user = new User('rider@example.test');
+        $user->setAiProvider('anthropic')->setAiToken($this->encryptor->encrypt('sk-ant-secret'));
+
+        self::assertInstanceOf(PlatformLlmClient::class, $this->factory()->forUser($user));
+    }
+
+    #[Test]
+    public function forUserReturnsNullWhenNotConfigured(): void
+    {
+        self::assertNull($this->factory()->forUser(new User('rider@example.test')));
+    }
+
+    #[Test]
+    public function forUserReturnsNullWhenTokenMissing(): void
+    {
+        $user = new User('rider@example.test')->setAiProvider('anthropic');
+
+        self::assertNull($this->factory()->forUser($user));
+    }
+
+    #[Test]
+    public function forUserReturnsNullForAnUnknownProvider(): void
+    {
+        $user = new User('rider@example.test');
+        $user->setAiProvider('ollama')->setAiToken($this->encryptor->encrypt('x'));
+
+        self::assertNull($this->factory()->forUser($user));
+    }
+
+    #[Test]
+    public function forUserReturnsNullWhenTheTokenCannotBeDecrypted(): void
+    {
+        // e.g. encryption key rotated since the token was stored.
+        $user = new User('rider@example.test');
+        $user->setAiProvider('anthropic')->setAiToken('not-decryptable-under-this-key');
+
+        self::assertNull($this->factory()->forUser($user));
     }
 }

--- a/api/tests/Unit/Llm/LlmClientFactoryTest.php
+++ b/api/tests/Unit/Llm/LlmClientFactoryTest.php
@@ -84,9 +84,11 @@ final class LlmClientFactoryTest extends TestCase
     #[Test]
     public function forUserReturnsNullWhenTheTokenCannotBeDecrypted(): void
     {
-        // e.g. encryption key rotated since the token was stored.
+        // e.g. encryption key rotated since the token was stored: a real blob
+        // built under a different key, so decrypt() walks nonce extraction + MAC
+        // failure rather than the malformed-base64 early return.
         $user = new User('rider@example.test');
-        $user->setAiProvider('anthropic')->setAiToken('not-decryptable-under-this-key');
+        $user->setAiProvider('anthropic')->setAiToken(new AiTokenEncryptor('different-key')->encrypt('sk-ant-secret'));
 
         self::assertNull($this->factory()->forUser($user));
     }


### PR DESCRIPTION
## Contexte

Partie A du chantier **IA optionnelle multi-provider (BYO token)** (ADR-042). Suite de #708 (A1 — client LLM multi-provider). Cette PR ajoute la **persistance chiffrée** du provider + token IA choisis par l'utilisateur, brique nécessaire à `LlmClientFactory::forUser()`.

## Changements

- **`User`** : nouvelles colonnes `aiProvider` (VARCHAR 32, nullable) et `aiToken` (TEXT, ciphertext, nullable) + getters/setters. `anonymize()` remet les deux à `null` (RGPD).
- **`AiTokenEncryptor`** : chiffrement libsodium `crypto_secretbox` (XSalsa20-Poly1305), nonce aléatoire préfixé, clé dérivée d'une env **dédiée `AI_TOKEN_ENC_KEY`** (découplée d'`APP_SECRET` pour la rotation). `decrypt()` renvoie `null` (jamais d'exception) sur blob malformé, altéré ou clé tournée → dégradation propre.
- **`LlmClientFactory::forUser(User): ?LlmClientInterface`** : déchiffre le token et construit le client du bon provider ; renvoie `null` si non configuré, provider inconnu, ou token indéchiffrable.
- **Migration** `Version20260617160000` : ajoute les 2 colonnes (`ADD COLUMN IF NOT EXISTS`).

## Sécurité

- Token **chiffré au repos** ; jamais loggé, jamais sérialisé. Le déchiffrement n'a lieu qu'au moment de construire le client.
- La rotation de `AI_TOKEN_ENC_KEY` rend les tokens existants illisibles (par design) → l'utilisateur re-saisit ; pas d'exception.
- Le défaut dev de `app.ai_token_enc_key` (dans `config/services.php`) garde le conteneur bootable hors prod. **La prod DOIT définir `AI_TOKEN_ENC_KEY`.**

## Vérification

`make qa` local (hôte) : PHPStan L9 OK, PHP-CS-Fixer OK, Rector OK, conteneur boote (cache:clear), **117 tests unitaires Llm verts** (round-trip chiffrement, nonces distincts, blob/clé invalides → null, clé vide → exception ; `forUser()` : configuré → client, non configuré / provider inconnu / token indéchiffrable → null). Tests fonctionnels/integration en CI (DB PostGIS).

## Suite

- **A2b** : ressource API AI-settings compte (`GET tokenConfigured` / `PATCH` set+validation format / `DELETE`).
- La validation live du token (ping provider) est repoussée en **A3** (nécessite le classifieur d'erreurs).

<!-- claude-review-start -->
## Claude Review

_Reviewed commit: `7b67b01def3dd6360ff4bbd8817f6bc3b8772417`_

### Summary

All three findings from the previous review have been addressed in the follow-up commit. The implementation is clean: XSalsa20-Poly1305 with per-value random nonce, BLAKE2b key stretch, `#[SensitiveParameter]` on the plaintext path, GDPR wipe, key-rotation graceful degradation, tight length guard in `decrypt()`, and full unit coverage across all `forUser()` branches.

### Resolved threads

Resolved 3 previously open threads that were addressed by the latest push.

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Inline comments

No inline comments.
<!-- claude-review-end -->