### PR TITLE
feat(ai): AI-settings account API (provider + encrypted token)

### DIFF
--- a/api/src/ApiResource/Account/AiSettings.php
+++ b/api/src/ApiResource/Account/AiSettings.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ApiResource\Account;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Delete;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Put;
+use App\Llm\AiProvider;
+use App\State\Account\AiSettingsClearProcessor;
+use App\State\Account\AiSettingsProcessor;
+use App\State\Account\AiSettingsProvider;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * Per-user AI configuration (ADR-042): the chosen cloud provider and its API
+ * token (bring-your-own-token). AI is opt-in — without a configured token every
+ * AI feature stays disabled.
+ *
+ * - GET    /users/me/ai-settings  current provider + whether a token is stored
+ * - PUT    /users/me/ai-settings  set provider + token (token format validated)
+ * - DELETE /users/me/ai-settings  clear both
+ *
+ * The token is write-only: it is encrypted at rest and the API never returns it,
+ * only the boolean {@see $tokenConfigured}. The current user is resolved from the
+ * security token, never from a URL identifier (no IDOR surface).
+ */
+#[ApiResource(
+    shortName: 'AiSettings',
+    operations: [
+        new Get(
+            uriTemplate: '/users/me/ai-settings',
+            security: "is_granted('ROLE_USER')",
+            provider: AiSettingsProvider::class,
+        ),
+        new Put(
+            uriTemplate: '/users/me/ai-settings',
+            security: "is_granted('ROLE_USER')",
+            read: false,
+            processor: AiSettingsProcessor::class,
+        ),
+        new Delete(
+            uriTemplate: '/users/me/ai-settings',
+            status: 204,
+            security: "is_granted('ROLE_USER')",
+            output: false,
+            read: false,
+            processor: AiSettingsClearProcessor::class,
+        ),
+    ],
+)]
+final class AiSettings
+{
+    /**
+     * Chosen provider, or null when AI is not configured.
+     */
+    #[Assert\Choice(callback: [AiProvider::class, 'values'], message: 'Unknown AI provider.')]
+    public ?string $provider = null;
+
+    /**
+     * Write-only: the stored token is never serialised back, only whether one is set.
+     */
+    #[ApiProperty(readable: false)]
+    #[Assert\Length(max: 500)]
+    public ?string $token = null;
+
+    /**
+     * Read-only signal that a (non-empty) token is stored.
+     */
+    #[ApiProperty(writable: false)]
+    public bool $tokenConfigured = false;
+}

--- a/api/src/ApiResource/Account/AiSettings.php
+++ b/api/src/ApiResource/Account/AiSettings.php
@@ -55,8 +55,9 @@ use Symfony\Component\Validator\Constraints as Assert;
 final class AiSettings
 {
     /**
-     * Chosen provider, or null when AI is not configured.
+     * Chosen provider. Required on write; null only when AI is not configured.
      */
+    #[Assert\NotBlank]
     #[Assert\Choice(callback: [AiProvider::class, 'values'], message: 'Unknown AI provider.')]
     public ?string $provider = null;
 
@@ -64,6 +65,7 @@ final class AiSettings
      * Write-only: the stored token is never serialised back, only whether one is set.
      */
     #[ApiProperty(readable: false)]
+    #[Assert\NotBlank]
     #[Assert\Length(max: 500)]
     public ?string $token = null;
 

--- a/api/src/Llm/AiProvider.php
+++ b/api/src/Llm/AiProvider.php
@@ -17,6 +17,14 @@ enum AiProvider: string
     case GEMINI = 'gemini';
     case OPENAI = 'openai';
 
+    /**
+     * @return list<string>
+     */
+    public static function values(): array
+    {
+        return array_map(static fn (self $provider): string => $provider->value, self::cases());
+    }
+
     public function label(): string
     {
         return match ($this) {

--- a/api/src/State/Account/AiSettingsClearProcessor.php
+++ b/api/src/State/Account/AiSettingsClearProcessor.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\State\Account;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\ApiResource\Account\AiSettings;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Clears the current user's AI configuration: provider + encrypted token are
+ * wiped, disabling every AI feature again.
+ *
+ * @implements ProcessorInterface<AiSettings, Response>
+ */
+final readonly class AiSettingsClearProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private Security $security,
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    /**
+     * @param AiSettings $data
+     */
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): JsonResponse
+    {
+        $user = $this->security->getUser();
+
+        \assert($user instanceof User);
+
+        $user->setAiProvider(null);
+        $user->setAiToken(null);
+
+        $this->entityManager->flush();
+
+        return new JsonResponse(null, Response::HTTP_NO_CONTENT);
+    }
+}

--- a/api/src/State/Account/AiSettingsProcessor.php
+++ b/api/src/State/Account/AiSettingsProcessor.php
@@ -42,15 +42,10 @@ final readonly class AiSettingsProcessor implements ProcessorInterface
 
         \assert($user instanceof User);
 
-        $provider = AiProvider::tryFrom((string) $data->provider);
-        if (null === $provider) {
-            throw new UnprocessableEntityHttpException('Unknown AI provider.');
-        }
-
+        // Provider + token are guaranteed present and valid by the DTO's
+        // Assert\NotBlank + Assert\Choice constraints (validation runs first).
+        $provider = AiProvider::from((string) $data->provider);
         $token = (string) $data->token;
-        if ('' === $token) {
-            throw new UnprocessableEntityHttpException('An API token is required.');
-        }
 
         // Format validation only (e.g. OpenAI rejects keys without the sk- prefix
         // at construction); a real provider ping is deferred to A3.

--- a/api/src/State/Account/AiSettingsProcessor.php
+++ b/api/src/State/Account/AiSettingsProcessor.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\State\Account;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\ApiResource\Account\AiSettings;
+use App\Entity\User;
+use App\Llm\AiProvider;
+use App\Llm\AiTokenEncryptor;
+use App\Llm\LlmClientFactory;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+
+/**
+ * Stores the current user's AI provider + token (ADR-042). The token is
+ * format-validated against the chosen provider's bridge (no network call — the
+ * live provider ping lands in A3 with the error classifier), encrypted at rest,
+ * and never logged or returned.
+ *
+ * @implements ProcessorInterface<AiSettings, AiSettings>
+ */
+final readonly class AiSettingsProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private Security $security,
+        private EntityManagerInterface $entityManager,
+        private AiTokenEncryptor $tokenEncryptor,
+        private LlmClientFactory $clientFactory,
+    ) {
+    }
+
+    /**
+     * @param AiSettings $data
+     */
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): AiSettings
+    {
+        $user = $this->security->getUser();
+
+        \assert($user instanceof User);
+
+        $provider = AiProvider::tryFrom((string) $data->provider);
+        if (null === $provider) {
+            throw new UnprocessableEntityHttpException('Unknown AI provider.');
+        }
+
+        $token = (string) $data->token;
+        if ('' === $token) {
+            throw new UnprocessableEntityHttpException('An API token is required.');
+        }
+
+        // Format validation only (e.g. OpenAI rejects keys without the sk- prefix
+        // at construction); a real provider ping is deferred to A3.
+        try {
+            $this->clientFactory->create($provider, $token);
+        } catch (\InvalidArgumentException) {
+            throw new UnprocessableEntityHttpException('The API token format is invalid for this provider.');
+        }
+
+        $user->setAiProvider($provider->value);
+        $user->setAiToken($this->tokenEncryptor->encrypt($token));
+
+        $this->entityManager->flush();
+
+        $result = new AiSettings();
+        $result->provider = $provider->value;
+        $result->tokenConfigured = true;
+
+        return $result;
+    }
+}

--- a/api/src/State/Account/AiSettingsProvider.php
+++ b/api/src/State/Account/AiSettingsProvider.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\State\Account;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProviderInterface;
+use App\ApiResource\Account\AiSettings;
+use App\Entity\User;
+use Symfony\Bundle\SecurityBundle\Security;
+
+/**
+ * Exposes the current user's AI configuration without ever revealing the stored
+ * token — only whether one is set.
+ *
+ * @implements ProviderInterface<AiSettings>
+ */
+final readonly class AiSettingsProvider implements ProviderInterface
+{
+    public function __construct(
+        private Security $security,
+    ) {
+    }
+
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): AiSettings
+    {
+        $user = $this->security->getUser();
+
+        \assert($user instanceof User);
+
+        $settings = new AiSettings();
+        $settings->provider = $user->getAiProvider();
+        $settings->tokenConfigured = null !== $user->getAiToken() && '' !== $user->getAiToken();
+
+        return $settings;
+    }
+}

--- a/api/tests/Functional/Account/AiSettingsTest.php
+++ b/api/tests/Functional/Account/AiSettingsTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Account;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\User;
+use App\Llm\AiTokenEncryptor;
+use Doctrine\ORM\EntityManagerInterface;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Uid\Uuid;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+use Zenstruck\Foundry\Test\Factories;
+
+#[ResetDatabase]
+final class AiSettingsTest extends ApiTestCase
+{
+    use Factories;
+
+    #[\Override]
+    public static function setUpBeforeClass(): void
+    {
+        self::$alwaysBootKernel = false;
+    }
+
+    private function getEntityManager(): EntityManagerInterface
+    {
+        return self::getContainer()->get('doctrine.orm.entity_manager');
+    }
+
+    /**
+     * @param non-empty-string $email
+     *
+     * @return array{user: User, jwt: string}
+     */
+    private function createUser(string $email): array
+    {
+        $em = $this->getEntityManager();
+
+        $user = new User($email);
+        $em->persist($user);
+        $em->flush();
+
+        /** @var JWTTokenManagerInterface $jwtManager */
+        $jwtManager = self::getContainer()->get('lexik_jwt_authentication.jwt_manager');
+
+        return ['user' => $user, 'jwt' => $jwtManager->create($user)];
+    }
+
+    #[Test]
+    public function getReturnsUnconfiguredByDefault(): void
+    {
+        $fixtures = $this->createUser('ai-unconfigured@example.com');
+
+        self::createClient()->request('GET', '/users/me/ai-settings', [
+            'headers' => ['Authorization' => 'Bearer '.$fixtures['jwt']],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonContains(['provider' => null, 'tokenConfigured' => false]);
+    }
+
+    #[Test]
+    public function putStoresProviderAndEncryptedToken(): void
+    {
+        $fixtures = $this->createUser('ai-store@example.com');
+        $userId = $fixtures['user']->getId()->toRfc4122();
+
+        $response = self::createClient()->request('PUT', '/users/me/ai-settings', [
+            'headers' => ['Authorization' => 'Bearer '.$fixtures['jwt']],
+            'json' => ['provider' => 'anthropic', 'token' => 'sk-ant-secret-token'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonContains(['provider' => 'anthropic', 'tokenConfigured' => true]);
+        // The token is write-only: it must never be echoed back.
+        $this->assertArrayNotHasKey('token', $response->toArray());
+
+        $em = $this->getEntityManager();
+        $em->clear();
+
+        $user = $em->find(User::class, Uuid::fromString($userId));
+        \assert($user instanceof User);
+
+        $stored = $user->getAiToken();
+        $this->assertNotNull($stored);
+        $this->assertNotSame('sk-ant-secret-token', $stored, 'the token must be encrypted at rest');
+
+        /** @var AiTokenEncryptor $encryptor */
+        $encryptor = self::getContainer()->get(AiTokenEncryptor::class);
+        $this->assertSame('sk-ant-secret-token', $encryptor->decrypt($stored));
+    }
+
+    #[Test]
+    public function putRejectsAnUnknownProvider(): void
+    {
+        $fixtures = $this->createUser('ai-bad-provider@example.com');
+
+        self::createClient()->request('PUT', '/users/me/ai-settings', [
+            'headers' => ['Authorization' => 'Bearer '.$fixtures['jwt']],
+            'json' => ['provider' => 'ollama', 'token' => 'whatever'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    #[Test]
+    public function putRejectsATokenWithAnInvalidFormat(): void
+    {
+        // OpenAI's bridge rejects keys without the sk- prefix at construction.
+        $fixtures = $this->createUser('ai-bad-token@example.com');
+
+        self::createClient()->request('PUT', '/users/me/ai-settings', [
+            'headers' => ['Authorization' => 'Bearer '.$fixtures['jwt']],
+            'json' => ['provider' => 'openai', 'token' => 'not-an-openai-key'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    #[Test]
+    public function putRejectsAMissingToken(): void
+    {
+        $fixtures = $this->createUser('ai-no-token@example.com');
+
+        self::createClient()->request('PUT', '/users/me/ai-settings', [
+            'headers' => ['Authorization' => 'Bearer '.$fixtures['jwt']],
+            'json' => ['provider' => 'anthropic'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    #[Test]
+    public function deleteClearsTheConfiguration(): void
+    {
+        $fixtures = $this->createUser('ai-clear@example.com');
+        $userId = $fixtures['user']->getId()->toRfc4122();
+
+        $client = self::createClient();
+        $client->request('PUT', '/users/me/ai-settings', [
+            'headers' => ['Authorization' => 'Bearer '.$fixtures['jwt']],
+            'json' => ['provider' => 'anthropic', 'token' => 'sk-ant-secret-token'],
+        ]);
+        $this->assertResponseIsSuccessful();
+
+        $client->request('DELETE', '/users/me/ai-settings', [
+            'headers' => ['Authorization' => 'Bearer '.$fixtures['jwt']],
+        ]);
+        $this->assertResponseStatusCodeSame(204);
+
+        $em = $this->getEntityManager();
+        $em->clear();
+
+        $user = $em->find(User::class, Uuid::fromString($userId));
+        \assert($user instanceof User);
+
+        $this->assertNull($user->getAiProvider());
+        $this->assertNull($user->getAiToken());
+    }
+
+    #[Test]
+    public function endpointsRequireAuthentication(): void
+    {
+        self::createClient()->request('GET', '/users/me/ai-settings');
+
+        $this->assertResponseStatusCodeSame(401);
+    }
+}

--- a/api/tests/Functional/Account/AiSettingsTest.php
+++ b/api/tests/Functional/Account/AiSettingsTest.php
@@ -54,12 +54,14 @@ final class AiSettingsTest extends ApiTestCase
     {
         $fixtures = $this->createUser('ai-unconfigured@example.com');
 
-        self::createClient()->request('GET', '/users/me/ai-settings', [
+        $response = self::createClient()->request('GET', '/users/me/ai-settings', [
             'headers' => ['Authorization' => 'Bearer '.$fixtures['jwt']],
         ]);
 
         $this->assertResponseIsSuccessful();
-        $this->assertJsonContains(['provider' => null, 'tokenConfigured' => false]);
+        $this->assertJsonContains(['tokenConfigured' => false]);
+        // A null provider is omitted from the payload (skip_null_values).
+        $this->assertArrayNotHasKey('provider', $response->toArray());
     }
 
     #[Test]
@@ -159,6 +161,39 @@ final class AiSettingsTest extends ApiTestCase
 
         $this->assertNull($user->getAiProvider());
         $this->assertNull($user->getAiToken());
+    }
+
+    #[Test]
+    public function putOverwritesExistingSettings(): void
+    {
+        $fixtures = $this->createUser('ai-overwrite@example.com');
+        $userId = $fixtures['user']->getId()->toRfc4122();
+        $client = self::createClient();
+        $headers = ['Content-Type' => 'application/ld+json', 'Authorization' => 'Bearer '.$fixtures['jwt']];
+
+        $client->request('PUT', '/users/me/ai-settings', [
+            'headers' => $headers,
+            'json' => ['provider' => 'anthropic', 'token' => 'sk-ant-initial'],
+        ]);
+        $this->assertResponseIsSuccessful();
+
+        $client->request('PUT', '/users/me/ai-settings', [
+            'headers' => $headers,
+            'json' => ['provider' => 'openai', 'token' => 'sk-updated'],
+        ]);
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonContains(['provider' => 'openai', 'tokenConfigured' => true]);
+
+        $em = $this->getEntityManager();
+        $em->clear();
+
+        $user = $em->find(User::class, Uuid::fromString($userId));
+        \assert($user instanceof User);
+
+        /** @var AiTokenEncryptor $encryptor */
+        $encryptor = self::getContainer()->get(AiTokenEncryptor::class);
+        $this->assertSame('openai', $user->getAiProvider());
+        $this->assertSame('sk-updated', $encryptor->decrypt((string) $user->getAiToken()));
     }
 
     #[Test]

--- a/api/tests/Functional/Account/AiSettingsTest.php
+++ b/api/tests/Functional/Account/AiSettingsTest.php
@@ -164,8 +164,15 @@ final class AiSettingsTest extends ApiTestCase
     #[Test]
     public function endpointsRequireAuthentication(): void
     {
-        self::createClient()->request('GET', '/users/me/ai-settings');
+        $client = self::createClient();
 
+        $client->request('GET', '/users/me/ai-settings');
+        $this->assertResponseStatusCodeSame(401);
+
+        $client->request('PUT', '/users/me/ai-settings', ['json' => []]);
+        $this->assertResponseStatusCodeSame(401);
+
+        $client->request('DELETE', '/users/me/ai-settings');
         $this->assertResponseStatusCodeSame(401);
     }
 }

--- a/api/tests/Functional/Account/AiSettingsTest.php
+++ b/api/tests/Functional/Account/AiSettingsTest.php
@@ -65,6 +65,27 @@ final class AiSettingsTest extends ApiTestCase
     }
 
     #[Test]
+    public function getReturnsConfiguredStateAfterPut(): void
+    {
+        $fixtures = $this->createUser('ai-get-configured@example.com');
+        $client = self::createClient();
+
+        $client->request('PUT', '/users/me/ai-settings', [
+            'headers' => ['Content-Type' => 'application/ld+json', 'Authorization' => 'Bearer '.$fixtures['jwt']],
+            'json' => ['provider' => 'anthropic', 'token' => 'sk-ant-secret-token'],
+        ]);
+        $this->assertResponseIsSuccessful();
+
+        $response = $client->request('GET', '/users/me/ai-settings', [
+            'headers' => ['Authorization' => 'Bearer '.$fixtures['jwt']],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonContains(['provider' => 'anthropic', 'tokenConfigured' => true]);
+        $this->assertArrayNotHasKey('token', $response->toArray());
+    }
+
+    #[Test]
     public function putStoresProviderAndEncryptedToken(): void
     {
         $fixtures = $this->createUser('ai-store@example.com');

--- a/api/tests/Functional/Account/AiSettingsTest.php
+++ b/api/tests/Functional/Account/AiSettingsTest.php
@@ -69,7 +69,7 @@ final class AiSettingsTest extends ApiTestCase
         $userId = $fixtures['user']->getId()->toRfc4122();
 
         $response = self::createClient()->request('PUT', '/users/me/ai-settings', [
-            'headers' => ['Authorization' => 'Bearer '.$fixtures['jwt']],
+            'headers' => ['Content-Type' => 'application/ld+json', 'Authorization' => 'Bearer '.$fixtures['jwt']],
             'json' => ['provider' => 'anthropic', 'token' => 'sk-ant-secret-token'],
         ]);
 
@@ -99,7 +99,7 @@ final class AiSettingsTest extends ApiTestCase
         $fixtures = $this->createUser('ai-bad-provider@example.com');
 
         self::createClient()->request('PUT', '/users/me/ai-settings', [
-            'headers' => ['Authorization' => 'Bearer '.$fixtures['jwt']],
+            'headers' => ['Content-Type' => 'application/ld+json', 'Authorization' => 'Bearer '.$fixtures['jwt']],
             'json' => ['provider' => 'ollama', 'token' => 'whatever'],
         ]);
 
@@ -113,7 +113,7 @@ final class AiSettingsTest extends ApiTestCase
         $fixtures = $this->createUser('ai-bad-token@example.com');
 
         self::createClient()->request('PUT', '/users/me/ai-settings', [
-            'headers' => ['Authorization' => 'Bearer '.$fixtures['jwt']],
+            'headers' => ['Content-Type' => 'application/ld+json', 'Authorization' => 'Bearer '.$fixtures['jwt']],
             'json' => ['provider' => 'openai', 'token' => 'not-an-openai-key'],
         ]);
 
@@ -126,7 +126,7 @@ final class AiSettingsTest extends ApiTestCase
         $fixtures = $this->createUser('ai-no-token@example.com');
 
         self::createClient()->request('PUT', '/users/me/ai-settings', [
-            'headers' => ['Authorization' => 'Bearer '.$fixtures['jwt']],
+            'headers' => ['Content-Type' => 'application/ld+json', 'Authorization' => 'Bearer '.$fixtures['jwt']],
             'json' => ['provider' => 'anthropic'],
         ]);
 
@@ -141,7 +141,7 @@ final class AiSettingsTest extends ApiTestCase
 
         $client = self::createClient();
         $client->request('PUT', '/users/me/ai-settings', [
-            'headers' => ['Authorization' => 'Bearer '.$fixtures['jwt']],
+            'headers' => ['Content-Type' => 'application/ld+json', 'Authorization' => 'Bearer '.$fixtures['jwt']],
             'json' => ['provider' => 'anthropic', 'token' => 'sk-ant-secret-token'],
         ]);
         $this->assertResponseIsSuccessful();
@@ -169,7 +169,10 @@ final class AiSettingsTest extends ApiTestCase
         $client->request('GET', '/users/me/ai-settings');
         $this->assertResponseStatusCodeSame(401);
 
-        $client->request('PUT', '/users/me/ai-settings', ['json' => []]);
+        $client->request('PUT', '/users/me/ai-settings', [
+            'headers' => ['Content-Type' => 'application/ld+json'],
+            'json' => [],
+        ]);
         $this->assertResponseStatusCodeSame(401);
 
         $client->request('DELETE', '/users/me/ai-settings');


### PR DESCRIPTION
## Contexte

Partie A du chantier **IA optionnelle multi-provider (BYO token)** (ADR-042). Suite de #708 (client multi-provider) et #709 (stockage chiffré du token). Cette PR expose l'API compte qui pilote la configuration IA de l'utilisateur.

## Changements

Nouvelle ressource API Platform `AiSettings` (`api/src/ApiResource/Account/AiSettings.php`), même socle GDPR self-service que `Account` :

- **`GET /users/me/ai-settings`** → `{ provider, tokenConfigured }`. Ne renvoie **jamais** le token, seulement le booléen.
- **`PUT /users/me/ai-settings`** → enregistre `provider` + `token` :
  - provider validé contre l'enum `AiProvider` (`Assert\Choice` + `tryFrom`) → `422` si inconnu ;
  - token requis non vide → `422` sinon ;
  - **validation de format** via `LlmClientFactory::create()` (ex. OpenAI rejette une clé sans préfixe `sk-` à la construction, sans appel réseau) → `422` si invalide ;
  - token **chiffré au repos** (`AiTokenEncryptor`) puis flush.
- **`DELETE /users/me/ai-settings`** → efface provider + token (`204`), réactive l'état « IA non configurée ».

L'utilisateur courant est résolu depuis le token de sécurité, jamais depuis un identifiant d'URL (pas d'IDOR). Le champ `token` est **write-only** (`ApiProperty(readable: false)`).

La **validation live** (ping provider distinguant 401/quota/indispo) est repoussée en **A3**, où arrive le classifieur d'erreurs.

## Vérification

`make qa` local (hôte) : PHPStan L9 OK, PHP-CS-Fixer OK, Rector OK, conteneur boote (cache:clear), **1042 tests unitaires verts**. Tests **fonctionnels** ajoutés (`AiSettingsTest`, exécutés en CI sur DB PostGIS) : GET non configuré, PUT chiffre + ne renvoie pas le token + round-trip déchiffrement en base, PUT provider inconnu / format token invalide / token manquant → 422, DELETE efface, endpoints exigent l'authentification.

## Suite

**A3** : câblage des consommateurs par-utilisateur (sync via `Security`, async via propriétaire du trip) + taxonomie d'erreurs (`AiUnavailableException` + classifieur) + validation live du token + kill-switch `AI_ENABLED`.

<!-- claude-review-start -->
## Claude Review

All 5 previously open review threads have been addressed across the 6 commits. The implementation is clean and complete: stateless processors, no IDOR, write-only token with encryption at rest, DTO-level constraints (`Assert\NotBlank` + `Assert\Choice`) yielding consistent violation bodies, and full functional test coverage including GET configured state, overwrite path, and auth enforcement on all three operations.

**Findings:** 0. Commit reviewed: `36f9e8513e387d9bb160f99f77ded10b2ce97a87`.

### Resolved threads

Resolved 1 previously open bot-authored thread that was addressed by the last commit (`getReturnsConfiguredStateAfterPut`).

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Inline comments

No inline comments.
<!-- claude-review-end -->