### PR TITLE
feat(ai): typed error taxonomy for provider failures

### DIFF
--- a/api/src/Llm/AiErrorClassifier.php
+++ b/api/src/Llm/AiErrorClassifier.php
@@ -84,6 +84,19 @@ final class AiErrorClassifier
     {
         $value = $headers['retry-after'][0] ?? null;
 
-        return null !== $value && ctype_digit($value) ? (int) $value : null;
+        if (null === $value) {
+            return null;
+        }
+
+        if (ctype_digit($value)) {
+            return (int) $value;
+        }
+
+        // HTTP-date form (RFC 9110 §10.2.3, e.g. "Wed, 21 Oct 2015 07:28:00 GMT"):
+        // convert to a delay-seconds offset so a dated throttle is still classified
+        // as a transient rate-limit rather than an exhausted quota.
+        $timestamp = strtotime($value);
+
+        return false !== $timestamp ? max(0, $timestamp - time()) : null;
     }
 }

--- a/api/src/Llm/AiErrorClassifier.php
+++ b/api/src/Llm/AiErrorClassifier.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Llm;
+
+use App\Llm\Exception\AiFailureReason;
+use App\Llm\Exception\AiUnavailableException;
+use Symfony\AI\Platform\Exception\AuthenticationException;
+use Symfony\AI\Platform\Exception\RateLimitExceededException;
+use Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface;
+
+/**
+ * Translates a provider/transport failure into a typed {@see AiUnavailableException}
+ * (ADR-042) by inspecting the `symfony/ai-platform` bridge exceptions and the
+ * underlying HTTP status, so callers can degrade precisely and only retry
+ * transient failures (5xx/timeout and rate-limits with a Retry-After hint).
+ */
+final class AiErrorClassifier
+{
+    public function classify(\Throwable $exception, string $model): AiUnavailableException
+    {
+        [$reason, $retryAfter] = $this->resolve($exception);
+
+        return new AiUnavailableException(
+            \sprintf('AI request for model "%s" failed (%s): %s', $model, $reason->value, $exception->getMessage()),
+            $reason,
+            $retryAfter,
+            previous: $exception,
+        );
+    }
+
+    /**
+     * @return array{AiFailureReason, int|null}
+     */
+    private function resolve(\Throwable $exception): array
+    {
+        if ($exception instanceof AuthenticationException) {
+            return [AiFailureReason::INVALID_TOKEN, null];
+        }
+
+        if ($exception instanceof RateLimitExceededException) {
+            $retryAfter = $exception->getRetryAfter();
+
+            // A Retry-After hint marks a transient throttle; its absence points to
+            // an exhausted plan/credit, which retrying would only waste.
+            return [null !== $retryAfter ? AiFailureReason::RATE_LIMITED : AiFailureReason::QUOTA_EXCEEDED, $retryAfter];
+        }
+
+        if ($exception instanceof HttpExceptionInterface) {
+            return $this->fromStatus($exception);
+        }
+
+        // Transport errors (timeout, connection refused) and any other platform
+        // failure are treated as a transient outage.
+        return [AiFailureReason::UNAVAILABLE, null];
+    }
+
+    /**
+     * @return array{AiFailureReason, int|null}
+     */
+    private function fromStatus(HttpExceptionInterface $exception): array
+    {
+        $response = $exception->getResponse();
+        $status = $response->getStatusCode();
+
+        if (401 === $status || 403 === $status) {
+            return [AiFailureReason::INVALID_TOKEN, null];
+        }
+
+        if (429 === $status) {
+            $retryAfter = $this->retryAfter($response->getHeaders(false));
+
+            return [null !== $retryAfter ? AiFailureReason::RATE_LIMITED : AiFailureReason::QUOTA_EXCEEDED, $retryAfter];
+        }
+
+        return [AiFailureReason::UNAVAILABLE, null];
+    }
+
+    /**
+     * @param array<string, list<string>> $headers
+     */
+    private function retryAfter(array $headers): ?int
+    {
+        $value = $headers['retry-after'][0] ?? null;
+
+        return null !== $value && ctype_digit($value) ? (int) $value : null;
+    }
+}

--- a/api/src/Llm/Exception/AiFailureReason.php
+++ b/api/src/Llm/Exception/AiFailureReason.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Llm\Exception;
+
+/**
+ * Classified reason a user's AI provider call failed (ADR-042), so callers can
+ * degrade precisely and only retry what is worth retrying.
+ *
+ * - INVALID_TOKEN  401/403: the stored token is wrong/revoked → the user must
+ *   reconfigure; never retried.
+ * - QUOTA_EXCEEDED 429 with no Retry-After: the user's plan/credit is exhausted
+ *   → fail fast, do not burn more calls.
+ * - RATE_LIMITED   429 with Retry-After: a transient throttle → retry honouring
+ *   the hint.
+ * - UNAVAILABLE    5xx / timeout / transport: a transient provider outage →
+ *   retry a bounded number of times.
+ */
+enum AiFailureReason: string
+{
+    case INVALID_TOKEN = 'invalid_token';
+    case QUOTA_EXCEEDED = 'quota_exceeded';
+    case RATE_LIMITED = 'rate_limited';
+    case UNAVAILABLE = 'unavailable';
+
+    /**
+     * Whether retrying the same call could plausibly succeed.
+     */
+    public function isTransient(): bool
+    {
+        return match ($this) {
+            self::RATE_LIMITED, self::UNAVAILABLE => true,
+            self::INVALID_TOKEN, self::QUOTA_EXCEEDED => false,
+        };
+    }
+}

--- a/api/src/Llm/Exception/AiUnavailableException.php
+++ b/api/src/Llm/Exception/AiUnavailableException.php
@@ -7,9 +7,35 @@ namespace App\Llm\Exception;
 /**
  * Thrown when a user's configured AI provider cannot be reached or returns an
  * unrecoverable error. Provider-neutral successor to OllamaUnavailableException
- * (ADR-042). A typed failure reason (invalid token / quota / rate-limit /
- * unavailable) is layered on in a follow-up so callers can degrade precisely.
+ * (ADR-042). Carries a typed {@see AiFailureReason} (and an optional Retry-After
+ * hint) so callers can degrade precisely and only retry transient failures.
  */
 class AiUnavailableException extends \RuntimeException
 {
+    public function __construct(
+        string $message,
+        private readonly AiFailureReason $reason = AiFailureReason::UNAVAILABLE,
+        private readonly ?int $retryAfter = null,
+        ?\Throwable $previous = null,
+    ) {
+        parent::__construct($message, previous: $previous);
+    }
+
+    public function getReason(): AiFailureReason
+    {
+        return $this->reason;
+    }
+
+    /**
+     * Provider-suggested delay in seconds before retrying, when known.
+     */
+    public function getRetryAfter(): ?int
+    {
+        return $this->retryAfter;
+    }
+
+    public function isTransient(): bool
+    {
+        return $this->reason->isTransient();
+    }
 }

--- a/api/src/Llm/PlatformLlmClient.php
+++ b/api/src/Llm/PlatformLlmClient.php
@@ -31,6 +31,7 @@ final readonly class PlatformLlmClient implements LlmClientInterface
     public function __construct(
         private PlatformInterface $platform,
         private LoggerInterface $logger,
+        private AiErrorClassifier $errorClassifier = new AiErrorClassifier(),
     ) {
     }
 
@@ -41,6 +42,9 @@ final readonly class PlatformLlmClient implements LlmClientInterface
         return true;
     }
 
+    /**
+     * @throws AiUnavailableException when the provider request fails
+     */
     public function generate(string $model, string $prompt, ?string $systemPrompt = null, array $options = []): array
     {
         $messages = [];
@@ -53,6 +57,9 @@ final readonly class PlatformLlmClient implements LlmClientInterface
         return ['response' => $this->invoke($model, $messages, $options)];
     }
 
+    /**
+     * @throws AiUnavailableException when the provider request fails
+     */
     public function chat(string $model, array $messages, ?string $systemPrompt = null, array $options = []): array
     {
         $bag = [];
@@ -74,6 +81,8 @@ final readonly class PlatformLlmClient implements LlmClientInterface
     /**
      * @param list<MessageInterface> $messages
      * @param array<string, mixed>   $options
+     *
+     * @throws AiUnavailableException when the provider request fails
      */
     private function invoke(string $model, array $messages, array $options): string
     {
@@ -84,11 +93,17 @@ final readonly class PlatformLlmClient implements LlmClientInterface
         try {
             return $this->platform->invoke($model, new MessageBag(...$messages), $options)->asText();
         } catch (PlatformExceptionInterface|HttpExceptionInterface $exception) {
+            $failure = $this->errorClassifier->classify($exception, $model);
+
             // Log before throwing so failures are visible in monitoring even when
             // AiUnavailableException is caught and degraded gracefully upstream.
-            $this->logger->warning('AI provider request failed.', ['model' => $model, 'error' => $exception->getMessage()]);
+            $this->logger->warning('AI provider request failed.', [
+                'model' => $model,
+                'reason' => $failure->getReason()->value,
+                'error' => $exception->getMessage(),
+            ]);
 
-            throw new AiUnavailableException(\sprintf('AI request for model "%s" failed: %s', $model, $exception->getMessage()), $exception->getCode(), previous: $exception);
+            throw $failure;
         }
     }
 }

--- a/api/tests/Unit/Llm/AiErrorClassifierTest.php
+++ b/api/tests/Unit/Llm/AiErrorClassifierTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Llm;
+
+use App\Llm\AiErrorClassifier;
+use App\Llm\Exception\AiFailureReason;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Exception\AuthenticationException;
+use Symfony\AI\Platform\Exception\BadRequestException;
+use Symfony\AI\Platform\Exception\RateLimitExceededException;
+use Symfony\Component\HttpClient\Exception\TransportException;
+use Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+final class AiErrorClassifierTest extends TestCase
+{
+    private AiErrorClassifier $classifier;
+
+    protected function setUp(): void
+    {
+        $this->classifier = new AiErrorClassifier();
+    }
+
+    #[Test]
+    public function authenticationFailureIsAnInvalidTokenAndNotTransient(): void
+    {
+        $failure = $this->classifier->classify(new AuthenticationException('nope'), 'gpt-4o-mini');
+
+        self::assertSame(AiFailureReason::INVALID_TOKEN, $failure->getReason());
+        self::assertFalse($failure->isTransient());
+        self::assertNull($failure->getRetryAfter());
+    }
+
+    #[Test]
+    public function rateLimitWithRetryAfterIsTransient(): void
+    {
+        $failure = $this->classifier->classify(new RateLimitExceededException(30), 'gpt-4o-mini');
+
+        self::assertSame(AiFailureReason::RATE_LIMITED, $failure->getReason());
+        self::assertTrue($failure->isTransient());
+        self::assertSame(30, $failure->getRetryAfter());
+    }
+
+    #[Test]
+    public function rateLimitWithoutRetryAfterIsAnExhaustedQuota(): void
+    {
+        $failure = $this->classifier->classify(new RateLimitExceededException(), 'gpt-4o-mini');
+
+        self::assertSame(AiFailureReason::QUOTA_EXCEEDED, $failure->getReason());
+        self::assertFalse($failure->isTransient());
+    }
+
+    #[Test]
+    public function httpUnauthorizedAndForbiddenAreInvalidToken(): void
+    {
+        self::assertSame(AiFailureReason::INVALID_TOKEN, $this->classifier->classify($this->httpError(401), 'm')->getReason());
+        self::assertSame(AiFailureReason::INVALID_TOKEN, $this->classifier->classify($this->httpError(403), 'm')->getReason());
+    }
+
+    #[Test]
+    public function http429WithRetryAfterHeaderIsRateLimited(): void
+    {
+        $failure = $this->classifier->classify($this->httpError(429, ['retry-after' => ['12']]), 'm');
+
+        self::assertSame(AiFailureReason::RATE_LIMITED, $failure->getReason());
+        self::assertSame(12, $failure->getRetryAfter());
+    }
+
+    #[Test]
+    public function http429WithoutRetryAfterHeaderIsAnExhaustedQuota(): void
+    {
+        $failure = $this->classifier->classify($this->httpError(429), 'm');
+
+        self::assertSame(AiFailureReason::QUOTA_EXCEEDED, $failure->getReason());
+        self::assertNull($failure->getRetryAfter());
+    }
+
+    #[Test]
+    public function serverErrorIsTransientUnavailable(): void
+    {
+        $failure = $this->classifier->classify($this->httpError(503), 'm');
+
+        self::assertSame(AiFailureReason::UNAVAILABLE, $failure->getReason());
+        self::assertTrue($failure->isTransient());
+    }
+
+    #[Test]
+    public function transportErrorIsTransientUnavailable(): void
+    {
+        $failure = $this->classifier->classify(new TransportException('connection refused'), 'm');
+
+        self::assertSame(AiFailureReason::UNAVAILABLE, $failure->getReason());
+        self::assertTrue($failure->isTransient());
+    }
+
+    #[Test]
+    public function anUnrecognisedPlatformErrorFallsBackToUnavailable(): void
+    {
+        self::assertSame(AiFailureReason::UNAVAILABLE, $this->classifier->classify(new BadRequestException('bad'), 'm')->getReason());
+    }
+
+    #[Test]
+    public function preservesTheOriginalExceptionAsPrevious(): void
+    {
+        $original = new AuthenticationException('boom');
+
+        self::assertSame($original, $this->classifier->classify($original, 'm')->getPrevious());
+    }
+
+    /**
+     * @param array<string, list<string>> $headers
+     */
+    private function httpError(int $status, array $headers = []): HttpExceptionInterface
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn($status);
+        $response->method('getHeaders')->willReturn($headers);
+
+        // A real throwable: \Throwable::getMessage() cannot be stubbed on a mock.
+        return new class ($response, \sprintf('HTTP %d', $status)) extends \RuntimeException implements HttpExceptionInterface {
+            public function __construct(private readonly ResponseInterface $response, string $message)
+            {
+                parent::__construct($message);
+            }
+
+            public function getResponse(): ResponseInterface
+            {
+                return $this->response;
+            }
+        };
+    }
+}

--- a/api/tests/Unit/Llm/AiErrorClassifierTest.php
+++ b/api/tests/Unit/Llm/AiErrorClassifierTest.php
@@ -70,6 +70,16 @@ final class AiErrorClassifierTest extends TestCase
     }
 
     #[Test]
+    public function http429WithHttpDateRetryAfterHeaderIsRateLimited(): void
+    {
+        // RFC 9110 allows an HTTP-date instead of delay-seconds.
+        $failure = $this->classifier->classify($this->httpError(429, ['retry-after' => ['Wed, 21 Oct 2099 07:28:00 GMT']]), 'm');
+
+        self::assertSame(AiFailureReason::RATE_LIMITED, $failure->getReason());
+        self::assertIsInt($failure->getRetryAfter());
+    }
+
+    #[Test]
     public function http429WithoutRetryAfterHeaderIsAnExhaustedQuota(): void
     {
         $failure = $this->classifier->classify($this->httpError(429), 'm');

--- a/api/tests/Unit/Llm/PlatformLlmClientTest.php
+++ b/api/tests/Unit/Llm/PlatformLlmClientTest.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Llm;
 
+use App\Llm\Exception\AiFailureReason;
 use App\Llm\Exception\AiUnavailableException;
 use App\Llm\PlatformLlmClient;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
+use Symfony\AI\Platform\Exception\AuthenticationException;
 use Symfony\AI\Platform\Exception\ExceptionInterface as PlatformExceptionInterface;
 use Symfony\AI\Platform\PlatformInterface;
 use Symfony\AI\Platform\Test\InMemoryPlatform;
@@ -65,8 +67,30 @@ final class PlatformLlmClientTest extends TestCase
             throw new TransportException('connection refused');
         }));
 
-        $this->expectException(AiUnavailableException::class);
-        $client->generate('claude-3-5-haiku-latest', 'hello');
+        try {
+            $client->generate('claude-3-5-haiku-latest', 'hello');
+            self::fail('Expected AiUnavailableException.');
+        } catch (AiUnavailableException $aiUnavailableException) {
+            // The transport failure is classified as a transient outage.
+            self::assertSame(AiFailureReason::UNAVAILABLE, $aiUnavailableException->getReason());
+            self::assertTrue($aiUnavailableException->isTransient());
+        }
+    }
+
+    #[Test]
+    public function classifiesAnAuthenticationFailureAsInvalidToken(): void
+    {
+        $client = $this->client(new InMemoryPlatform(static function (): string {
+            throw new AuthenticationException('invalid api key');
+        }));
+
+        try {
+            $client->generate('claude-3-5-haiku-latest', 'hello');
+            self::fail('Expected AiUnavailableException.');
+        } catch (AiUnavailableException $aiUnavailableException) {
+            self::assertSame(AiFailureReason::INVALID_TOKEN, $aiUnavailableException->getReason());
+            self::assertFalse($aiUnavailableException->isTransient());
+        }
     }
 
     #[Test]


### PR DESCRIPTION
## Contexte

Partie A du chantier **IA optionnelle multi-provider (BYO token)** (ADR-042). Suite de #708/#709/#710. A3 (câblage par-utilisateur) est découpé : **A3a (cette PR) = taxonomie d'erreurs**, A3b = câblage des consommateurs sync/async + kill-switch `AI_ENABLED`. A3a est autonome (ne touche aucun consommateur) et débloque le mode dégradé précis dont A3b et le front (A5) ont besoin.

## Changements

- **`AiFailureReason`** (enum) : `invalid_token` (401/403), `quota_exceeded` (429 sans Retry-After), `rate_limited` (429 avec Retry-After), `unavailable` (5xx / timeout / transport). `isTransient()` = vrai pour `rate_limited` + `unavailable` uniquement.
- **`AiErrorClassifier`** : mappe les exceptions du bridge `symfony/ai-platform` (`AuthenticationException`, `RateLimitExceededException`) et le statut HTTP sous-jacent (`HttpExceptionInterface`) vers une raison + un hint `Retry-After`. Heuristique 429 : présence d'un `Retry-After` -> throttle transitoire ; absence -> quota épuisé (échec rapide, on ne brûle pas le quota utilisateur).
- **`AiUnavailableException`** porte désormais `reason`, `retryAfter` et `isTransient()`.
- **`PlatformLlmClient`** route chaque erreur provider via le classifieur et journalise la raison ; `@throws` documenté sur `generate()`/`chat()`.

## Notes

- Le **retry sélectif** (ne réessayer que le transitoire, en honorant `Retry-After`) sera câblé en A3b au niveau du transport Messenger `llm` (async) où l'attente est acceptable ; en synchrone on échoue proprement avec la raison.
- 400/BadRequest (erreur de requête côté app, rare avec nos prompts contrôlés) retombe sur `unavailable`.

## Vérification

`make qa` local : PHPStan L9 OK, CS-Fixer OK, Rector OK, conteneur boote, **128 tests unitaires Llm verts** — `AiErrorClassifierTest` couvre chaque mapping (auth, 429 avec/sans Retry-After, 401/403, 5xx, transport, fallback, chaînage `previous`) et `PlatformLlmClientTest` vérifie la propagation de la raison.

## Suite

**A3b** : `forUser()` câblé dans les consommateurs (sync via `Security`, async via propriétaire du trip), réponses dégradées par raison, retry sélectif sur le transport `llm`, kill-switch `AI_ENABLED` remplaçant le gating global `OLLAMA_ENABLED`.

<!-- claude-review-start -->
## Claude Review

The HTTP-date `Retry-After` fix in commit 2 directly addresses the correctness gap from the previous review — the misclassification of dated throttles as exhausted quotas is resolved and fully covered by the new `http429WithHttpDateRetryAfterHeaderIsRateLimited` test. The taxonomy, classifier, and exception are all clean and ready for A3b to build on.

Reviewed commit: `0fc6fc858aff14722f481be970b36e33766e9832`

**Findings:** 0 (1 warning resolved)

**Resolved 1 previously open thread** (HTTP-date `Retry-After` misclassification — addressed by commit 2).

---

**PR title:** `feat(ai): typed error taxonomy for provider failures` — the description is a noun phrase rather than imperative mood. Convention requires an imperative verb (e.g. `feat(ai): add typed error taxonomy for provider failures`). Non-blocking for merge.

## Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**No inline comments.**
<!-- claude-review-end -->