### PR TITLE
feat(ai): wire async analysis to the trip owner's provider + AI_ENABLED kill-switch

### DIFF
--- a/api/config/services.php
+++ b/api/config/services.php
@@ -9,8 +9,6 @@ use App\Llm\OllamaClient;
 use App\Mercure\NullTripUpdatePublisher;
 use App\Mercure\TripUpdatePublisher;
 use App\Mercure\TripUpdatePublisherInterface;
-use App\MessageHandler\AnalyzeStageWithLlmHandler;
-use App\MessageHandler\AnalyzeTripOverviewWithLlmHandler;
 use App\Repository\RedisTripRequestRepository;
 use App\Repository\TripRequestRepositoryInterface;
 use Symfony\AI\Platform\Bridge\Ollama\Factory as OllamaPlatformFactory;
@@ -27,7 +25,11 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         // the dev/CI default below only keeps the container bootable (throwaway dev
         // tokens, never used to protect real credentials).
         ->set('app.ai_token_enc_key', '%env(default:default_ai_token_enc_key:AI_TOKEN_ENC_KEY)%')
-        ->set('default_ai_token_enc_key', 'dev-only-ai-token-encryption-key-change-in-prod');
+        ->set('default_ai_token_enc_key', 'dev-only-ai-token-encryption-key-change-in-prod')
+        // Instance-wide AI kill-switch (ADR-042): on by default; set AI_ENABLED=0 to
+        // hide every AI feature on a deployment regardless of per-user configuration.
+        ->set('app.ai_enabled', '%env(bool:default:default_ai_enabled:AI_ENABLED)%')
+        ->set('default_ai_enabled', true);
 
     $services = $containerConfigurator->services();
 
@@ -72,6 +74,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     // Per-user multi-provider client factory (ADR-042): the 3 HttpClientInterface
     // args are ambiguous for autowiring, so bind each provider's scoped client.
+    // The AI_ENABLED kill-switch is autowired from the app.ai_enabled parameter.
     $services->set(LlmClientFactory::class)
         ->args([
             service('anthropic.client'),
@@ -80,12 +83,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             service('logger'),
             service(AiTokenEncryptor::class),
         ]);
-
-    // Async analysis handlers (pass-1 per stage, pass-2 overview) use the analysis client.
-    $services->get(AnalyzeStageWithLlmHandler::class)
-        ->arg('$llmClient', service('app.llm.ollama_client.analysis'));
-    $services->get(AnalyzeTripOverviewWithLlmHandler::class)
-        ->arg('$llmClient', service('app.llm.ollama_client.analysis'));
 
     if ('test' === $containerConfigurator->env()) {
         $services->alias(TripUpdatePublisherInterface::class, NullTripUpdatePublisher::class);

--- a/api/src/Llm/Exception/OllamaUnavailableException.php
+++ b/api/src/Llm/Exception/OllamaUnavailableException.php
@@ -5,11 +5,15 @@ declare(strict_types=1);
 namespace App\Llm\Exception;
 
 /**
- * Thrown when the Ollama LLM service cannot be reached or returns an unrecoverable error.
- *
- * Callers may catch this exception to perform a graceful fallback (e.g. skip enrichment)
- * or rethrow it to fail explicitly when the LLM is a hard dependency.
+ * Thrown when the (legacy) Ollama LLM service cannot be reached or returns an
+ * unrecoverable error. Specialisation of {@see AiUnavailableException} so the
+ * provider-neutral contract holds while the self-hosted Ollama path is phased
+ * out (ADR-042); always reports the UNAVAILABLE reason.
  */
-final class OllamaUnavailableException extends \RuntimeException
+final class OllamaUnavailableException extends AiUnavailableException
 {
+    public function __construct(string $message, ?\Throwable $previous = null)
+    {
+        parent::__construct($message, AiFailureReason::UNAVAILABLE, null, $previous);
+    }
 }

--- a/api/src/Llm/LlmClientFactory.php
+++ b/api/src/Llm/LlmClientFactory.php
@@ -9,6 +9,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\AI\Platform\Bridge\Anthropic\Factory as AnthropicFactory;
 use Symfony\AI\Platform\Bridge\Gemini\Factory as GeminiFactory;
 use Symfony\AI\Platform\Bridge\OpenAi\Factory as OpenAiFactory;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
@@ -25,16 +26,23 @@ final readonly class LlmClientFactory
         private HttpClientInterface $geminiClient,
         private LoggerInterface $logger,
         private AiTokenEncryptor $tokenEncryptor,
+        #[Autowire(param: 'app.ai_enabled')]
+        private bool $aiEnabled = true,
     ) {
     }
 
     /**
-     * Returns the client for the user's configured provider, or null when AI is
-     * not configured (no provider/token), the provider is unknown, or the stored
-     * token cannot be decrypted (e.g. key rotation) — so callers degrade cleanly.
+     * Returns the user's client paired with its provider, or null when AI is
+     * disabled instance-wide (AI_ENABLED kill-switch), not configured (no
+     * provider/token), the provider is unknown, or the stored token cannot be
+     * decrypted (e.g. key rotation) — so callers degrade cleanly.
      */
-    public function forUser(User $user): ?LlmClientInterface
+    public function forUser(User $user): ?ResolvedLlmClient
     {
+        if (!$this->aiEnabled) {
+            return null;
+        }
+
         $provider = AiProvider::tryFrom((string) $user->getAiProvider());
         $encrypted = $user->getAiToken();
         if (null === $provider || null === $encrypted) {
@@ -46,7 +54,7 @@ final readonly class LlmClientFactory
             return null;
         }
 
-        return $this->create($provider, $token);
+        return new ResolvedLlmClient($this->create($provider, $token), $provider);
     }
 
     public function create(AiProvider $provider, #[\SensitiveParameter] string $token): LlmClientInterface

--- a/api/src/Llm/LlmClientInterface.php
+++ b/api/src/Llm/LlmClientInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Llm;
 
-use App\Llm\Exception\OllamaUnavailableException;
+use App\Llm\Exception\AiUnavailableException;
 
 /**
  * LLM client abstraction (Dependency Inversion Principle).
@@ -33,7 +33,7 @@ interface LlmClientInterface
      *
      * @return array<string, mixed>|null parsed JSON response, or null when the client is disabled
      *
-     * @throws OllamaUnavailableException when the LLM is enabled but unreachable or returns an invalid response
+     * @throws AiUnavailableException when the provider is reachable-but-failing or returns an invalid response
      */
     public function generate(string $model, string $prompt, ?string $systemPrompt = null, array $options = []): ?array;
 
@@ -47,7 +47,7 @@ interface LlmClientInterface
      *
      * @return array<string, mixed>|null parsed JSON response, or null when the client is disabled
      *
-     * @throws OllamaUnavailableException when the LLM is enabled but unreachable or returns an invalid response
+     * @throws AiUnavailableException when the provider is reachable-but-failing or returns an invalid response
      */
     public function chat(string $model, array $messages, ?string $systemPrompt = null, array $options = []): ?array;
 }

--- a/api/src/Llm/OllamaClient.php
+++ b/api/src/Llm/OllamaClient.php
@@ -102,7 +102,7 @@ final readonly class OllamaClient implements LlmClientInterface
                 'error' => $exception->getMessage(),
             ]);
 
-            throw new OllamaUnavailableException(\sprintf('Ollama request for model "%s" failed: %s', $model, $exception->getMessage()), $exception->getCode(), previous: $exception);
+            throw new OllamaUnavailableException(\sprintf('Ollama request for model "%s" failed: %s', $model, $exception->getMessage()), previous: $exception);
         }
     }
 

--- a/api/src/Llm/ResolvedLlmClient.php
+++ b/api/src/Llm/ResolvedLlmClient.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Llm;
+
+/**
+ * A user's ready-to-use LLM client paired with the provider it was built for,
+ * so callers can pick the right per-provider model (chat vs analysis) without a
+ * second provider lookup (ADR-042).
+ */
+final readonly class ResolvedLlmClient
+{
+    public function __construct(
+        public LlmClientInterface $client,
+        public AiProvider $provider,
+    ) {
+    }
+}

--- a/api/src/Llm/TripLlmResolver.php
+++ b/api/src/Llm/TripLlmResolver.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Llm;
+
+use App\Entity\User;
+
+/**
+ * Default {@see TripLlmResolverInterface}: resolves the trip owner via
+ * {@see TripOwnerResolver} then builds their provider client via
+ * {@see LlmClientFactory} (which also enforces the AI_ENABLED kill-switch).
+ */
+final readonly class TripLlmResolver implements TripLlmResolverInterface
+{
+    public function __construct(
+        private TripOwnerResolver $ownerResolver,
+        private LlmClientFactory $clientFactory,
+    ) {
+    }
+
+    public function resolveForTrip(string $tripId): ?ResolvedLlmClient
+    {
+        $owner = $this->ownerResolver->resolve($tripId);
+
+        return $owner instanceof User ? $this->clientFactory->forUser($owner) : null;
+    }
+}

--- a/api/src/Llm/TripLlmResolverInterface.php
+++ b/api/src/Llm/TripLlmResolverInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Llm;
+
+/**
+ * Resolves the LLM client to use for a trip's async analysis (ADR-042): finds the
+ * trip owner and builds their configured provider client, or returns null when AI
+ * is unavailable (kill-switch off, owner unknown, or owner has no token).
+ */
+interface TripLlmResolverInterface
+{
+    public function resolveForTrip(string $tripId): ?ResolvedLlmClient;
+}

--- a/api/src/Llm/TripOwnerResolver.php
+++ b/api/src/Llm/TripOwnerResolver.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Llm;
+
+use App\ApiResource\TripRequest;
+use App\Entity\User;
+use App\Repository\UserRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Resolves the owner (User) of a trip from its id, for async LLM handlers that
+ * only carry a tripId and have no security context (ADR-042). Mirrors
+ * {@see \App\Security\Voter\TripVoter}: the owner is tracked in Redis during
+ * computation (`trip.{id}.user_id`), with the persisted TripRequest as fallback.
+ *
+ * The User is always reloaded fresh from the database so its current AI token is
+ * used — never a stale snapshot from when the trip was created.
+ */
+final readonly class TripOwnerResolver
+{
+    public function __construct(
+        #[Autowire(service: 'cache.trip_state')]
+        private CacheItemPoolInterface $tripStateCache,
+        private UserRepository $userRepository,
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function resolve(string $tripId): ?User
+    {
+        if (!Uuid::isValid($tripId)) {
+            return null;
+        }
+
+        $item = $this->tripStateCache->getItem(\sprintf('trip.%s.user_id', $tripId));
+        if ($item->isHit() && \is_string($userId = $item->get()) && Uuid::isValid($userId)) {
+            $user = $this->userRepository->find(Uuid::fromString($userId));
+            if ($user instanceof User) {
+                return $user;
+            }
+        }
+
+        return $this->entityManager->find(TripRequest::class, Uuid::fromString($tripId))?->user;
+    }
+}

--- a/api/src/Llm/TripOwnerResolver.php
+++ b/api/src/Llm/TripOwnerResolver.php
@@ -6,7 +6,6 @@ namespace App\Llm;
 
 use App\ApiResource\TripRequest;
 use App\Entity\User;
-use App\Repository\UserRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
@@ -26,7 +25,6 @@ final readonly class TripOwnerResolver
     public function __construct(
         #[Autowire(service: 'cache.trip_state')]
         private CacheItemPoolInterface $tripStateCache,
-        private UserRepository $userRepository,
         private EntityManagerInterface $entityManager,
     ) {
     }
@@ -39,7 +37,7 @@ final readonly class TripOwnerResolver
 
         $item = $this->tripStateCache->getItem(\sprintf('trip.%s.user_id', $tripId));
         if ($item->isHit() && \is_string($userId = $item->get()) && Uuid::isValid($userId)) {
-            $user = $this->userRepository->find(Uuid::fromString($userId));
+            $user = $this->entityManager->find(User::class, Uuid::fromString($userId));
             if ($user instanceof User) {
                 return $user;
             }

--- a/api/src/MessageHandler/AllEnrichmentsCompletedHandler.php
+++ b/api/src/MessageHandler/AllEnrichmentsCompletedHandler.php
@@ -88,13 +88,12 @@ final readonly class AllEnrichmentsCompletedHandler
         // do not invalidate the existing AI overview / per-stage briefings.
         $skipAiAnalysis = $this->llmTracker->consumeSkipAiAnalysis($tripId);
 
-        $aiConfigured = $this->llmResolver->resolveForTrip($tripId) instanceof ResolvedLlmClient;
-
-        // Short-circuit: when the trip owner has no AI configured (or the kill-switch
-        // is off), when the rider explicitly opted out of re-analysis via the chat
-        // bubble, or when there is no stage to analyse (e.g. all rest days), publish
-        // TRIP_READY directly — no AI overview to await.
-        if (!$aiConfigured || $skipAiAnalysis || 0 === $analysableStages) {
+        // Short-circuit: when the rider opted out of re-analysis via the chat bubble,
+        // when there is no stage to analyse (e.g. all rest days), or when the trip
+        // owner has no AI configured (kill-switch off / no token), publish TRIP_READY
+        // directly — no AI overview to await. Owner resolution (Redis + DB + token
+        // decryption) is evaluated last, only when the cheap guards pass.
+        if ($skipAiAnalysis || 0 === $analysableStages || !($this->llmResolver->resolveForTrip($tripId) instanceof ResolvedLlmClient)) {
             $this->publisher->publishTripReady($tripId, $stages, [
                 'status' => $statuses,
             ]);

--- a/api/src/MessageHandler/AllEnrichmentsCompletedHandler.php
+++ b/api/src/MessageHandler/AllEnrichmentsCompletedHandler.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace App\MessageHandler;
 
+use App\Llm\ResolvedLlmClient;
 use App\ApiResource\Stage;
 use App\ComputationTracker\ComputationTrackerInterface;
 use App\Enum\ComputationName;
 use App\Llm\LlmAnalysisTrackerInterface;
-use App\Llm\LlmClientInterface;
+use App\Llm\TripLlmResolverInterface;
 use App\Mercure\TripUpdatePublisherInterface;
 use App\Message\AllEnrichmentsCompleted;
 use App\Message\AnalyzeStageWithLlmMessage;
@@ -50,7 +51,7 @@ final readonly class AllEnrichmentsCompletedHandler
         private TripRequestRepositoryInterface $tripRequestRepository,
         private LoggerInterface $logger,
         private MessageBusInterface $messageBus,
-        private LlmClientInterface $llmClient,
+        private TripLlmResolverInterface $llmResolver,
         private LlmAnalysisTrackerInterface $llmTracker,
     ) {
     }
@@ -87,11 +88,13 @@ final readonly class AllEnrichmentsCompletedHandler
         // do not invalidate the existing AI overview / per-stage briefings.
         $skipAiAnalysis = $this->llmTracker->consumeSkipAiAnalysis($tripId);
 
-        // Short-circuit: when the LLM is disabled, when the rider explicitly opted
-        // out of re-analysis via the chat bubble, or when there is no stage to
-        // analyse (e.g. all rest days), publish TRIP_READY directly — no AI
-        // overview to await.
-        if (!$this->llmClient->isEnabled() || $skipAiAnalysis || 0 === $analysableStages) {
+        $aiConfigured = $this->llmResolver->resolveForTrip($tripId) instanceof ResolvedLlmClient;
+
+        // Short-circuit: when the trip owner has no AI configured (or the kill-switch
+        // is off), when the rider explicitly opted out of re-analysis via the chat
+        // bubble, or when there is no stage to analyse (e.g. all rest days), publish
+        // TRIP_READY directly — no AI overview to await.
+        if (!$aiConfigured || $skipAiAnalysis || 0 === $analysableStages) {
             $this->publisher->publishTripReady($tripId, $stages, [
                 'status' => $statuses,
             ]);

--- a/api/src/MessageHandler/AnalyzeStageWithLlmHandler.php
+++ b/api/src/MessageHandler/AnalyzeStageWithLlmHandler.php
@@ -4,21 +4,21 @@ declare(strict_types=1);
 
 namespace App\MessageHandler;
 
+use App\Llm\ResolvedLlmClient;
 use App\ApiResource\Stage;
 use App\ApiResource\TripRequest;
 use App\Enum\ComputationName;
 use App\Llm\Dto\StageAiAnalysis;
-use App\Llm\Exception\OllamaUnavailableException;
+use App\Llm\Exception\AiUnavailableException;
 use App\Llm\LlmAnalysisTrackerInterface;
-use App\Llm\LlmClientInterface;
 use App\Llm\StageAnalysisSummaryBuilder;
 use App\Llm\SystemPromptLoader;
+use App\Llm\TripLlmResolverInterface;
 use App\Mercure\TripUpdatePublisherInterface;
 use App\Message\AnalyzeStageWithLlmMessage;
 use App\Message\AnalyzeTripOverviewWithLlmMessage;
 use App\Repository\TripRequestRepositoryInterface;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\MessageBusInterface;
 
@@ -30,13 +30,11 @@ use Symfony\Component\Messenger\MessageBusInterface;
  * {@see AllEnrichmentsCompletedHandler} so the 5-worker pool can pipeline them.
  *
  * Behaviour:
- * - When Ollama is disabled (feature flag off): the handler returns silently.
- * - When the LLM is unreachable: the {@see OllamaUnavailableException} is logged
- *   and swallowed. AI analysis is best-effort enrichment, never blocking.
+ * - When the trip owner has not configured an AI provider (or the AI_ENABLED
+ *   kill-switch is off): the handler returns silently.
+ * - When the LLM is unreachable: the {@see AiUnavailableException} is logged and
+ *   swallowed. AI analysis is best-effort enrichment, never blocking.
  * - When the response cannot be parsed: the handler logs and skips persistence.
- *
- * Each request stays under 4K tokens (compact summary + system prompt + completion),
- * the optimal window for LLaMA 8B inference on CPU.
  */
 #[AsMessageHandler]
 final readonly class AnalyzeStageWithLlmHandler
@@ -45,31 +43,23 @@ final readonly class AnalyzeStageWithLlmHandler
 
     public const int PROMPT_VERSION = 1;
 
-    public const int MAX_RESPONSE_TOKENS = 600;
-
-    public const string DEFAULT_MODEL = 'llama3.1:8b';
-
-    private string $model;
-
     public function __construct(
         private TripRequestRepositoryInterface $tripStateManager,
-        private LlmClientInterface $llmClient,
+        private TripLlmResolverInterface $llmResolver,
         private SystemPromptLoader $promptLoader,
         private StageAnalysisSummaryBuilder $summaryBuilder,
         private LoggerInterface $logger,
         private LlmAnalysisTrackerInterface $llmTracker,
         private MessageBusInterface $messageBus,
         private TripUpdatePublisherInterface $publisher,
-        #[Autowire(env: 'default::OLLAMA_STAGE_MODEL')]
-        ?string $model = null,
     ) {
-        $this->model = (null === $model || '' === $model) ? self::DEFAULT_MODEL : $model;
     }
 
     public function __invoke(AnalyzeStageWithLlmMessage $message): void
     {
-        if (!$this->llmClient->isEnabled()) {
-            $this->logger->debug('LLM disabled — skipping stage analysis.', [
+        $resolved = $this->llmResolver->resolveForTrip($message->tripId);
+        if (!$resolved instanceof ResolvedLlmClient) {
+            $this->logger->debug('AI not configured for trip owner — skipping stage analysis.', [
                 'tripId' => $message->tripId,
                 'dayNumber' => $message->dayNumber,
             ]);
@@ -129,22 +119,22 @@ final readonly class AnalyzeStageWithLlmHandler
             return;
         }
 
+        $model = $resolved->provider->analysisModel();
+
         try {
-            $response = $this->llmClient->generate(
-                model: $this->model,
+            // Options are intentionally left to provider defaults: Ollama-only knobs
+            // (format, num_predict) are not portable across cloud providers.
+            $response = $resolved->client->generate(
+                model: $model,
                 prompt: $userPrompt,
                 systemPrompt: $systemPrompt,
-                options: [
-                    // The system prompt asks for a Markdown briefing — disable Ollama's JSON mode.
-                    'format' => '',
-                    'num_predict' => self::MAX_RESPONSE_TOKENS,
-                ],
             );
-        } catch (OllamaUnavailableException $ollamaUnavailableException) {
-            $this->logger->critical('Ollama unreachable — skipping stage analysis.', [
+        } catch (AiUnavailableException $aiUnavailableException) {
+            $this->logger->critical('AI provider unreachable — skipping stage analysis.', [
                 'tripId' => $message->tripId,
                 'dayNumber' => $message->dayNumber,
-                'error' => $ollamaUnavailableException->getMessage(),
+                'reason' => $aiUnavailableException->getReason()->value,
+                'error' => $aiUnavailableException->getMessage(),
             ]);
             $this->settle($message->tripId, success: false);
 
@@ -168,7 +158,7 @@ final readonly class AnalyzeStageWithLlmHandler
             return;
         }
 
-        $analysis = $this->parseMarkdownResponse($rawText);
+        $analysis = $this->parseMarkdownResponse($rawText, $model);
 
         $this->tripStateManager->updateStageAiAnalysis(
             $message->tripId,
@@ -309,7 +299,7 @@ final readonly class AnalyzeStageWithLlmHandler
      * so the persisted DTO stays well-typed. Bullets ("- ...", "* ...") are normalised
      * into a list; the narrative section is stripped of leading/trailing whitespace.
      */
-    private function parseMarkdownResponse(string $markdown): StageAiAnalysis
+    private function parseMarkdownResponse(string $markdown, string $model): StageAiAnalysis
     {
         $sections = $this->splitMarkdownSections($markdown);
 
@@ -327,7 +317,7 @@ final readonly class AnalyzeStageWithLlmHandler
             narrative: $narrative,
             insights: $insights,
             suggestions: $suggestions,
-            model: $this->model,
+            model: $model,
             promptVersion: self::PROMPT_VERSION,
             generatedAt: new \DateTimeImmutable('now', new \DateTimeZone('UTC'))->format(\DATE_ATOM),
         );

--- a/api/src/MessageHandler/AnalyzeTripOverviewWithLlmHandler.php
+++ b/api/src/MessageHandler/AnalyzeTripOverviewWithLlmHandler.php
@@ -4,21 +4,21 @@ declare(strict_types=1);
 
 namespace App\MessageHandler;
 
+use App\Llm\ResolvedLlmClient;
 use App\ApiResource\Stage;
 use App\ApiResource\TripRequest;
 use App\ComputationTracker\ComputationTrackerInterface;
 use App\Enum\ComputationName;
 use App\Llm\Dto\StageAiAnalysis;
 use App\Llm\Dto\TripAiOverview;
-use App\Llm\Exception\OllamaUnavailableException;
+use App\Llm\Exception\AiUnavailableException;
 use App\Llm\LlmAnalysisTrackerInterface;
-use App\Llm\LlmClientInterface;
 use App\Llm\SystemPromptLoader;
+use App\Llm\TripLlmResolverInterface;
 use App\Mercure\TripUpdatePublisherInterface;
 use App\Message\AnalyzeTripOverviewWithLlmMessage;
 use App\Repository\TripRequestRepositoryInterface;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 /**
@@ -29,9 +29,10 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
  * cross-stage patterns and trip-level recommendations.
  *
  * Behaviour:
- * - When Ollama is disabled (feature flag off): the handler returns silently.
- * - When the LLM is unreachable: the {@see OllamaUnavailableException} is logged
- *   and swallowed. AI overview is best-effort enrichment, never blocking.
+ * - When the trip owner has not configured an AI provider (or the AI_ENABLED
+ *   kill-switch is off): the handler returns silently.
+ * - When the LLM is unreachable: the {@see AiUnavailableException} is logged and
+ *   swallowed. AI overview is best-effort enrichment, never blocking.
  * - When the response cannot be parsed: the handler logs and skips persistence.
  * - When NO stage has a pass-1 analysis yet (e.g. every per-stage handler failed
  *   or LLM was disabled): the handler skips, since there is nothing to summarise.
@@ -49,42 +50,28 @@ final readonly class AnalyzeTripOverviewWithLlmHandler
 
     public const int PROMPT_VERSION = 1;
 
-    public const int MAX_RESPONSE_TOKENS = 800;
-
-    public const string DEFAULT_MODEL = 'llama3.1:8b';
-
-    /**
-     * Pass 2 takes ~2000-3000 tokens of input plus ~800 tokens of output, so a
-     * 8K window leaves comfortable headroom for the system prompt.
-     */
-    public const int OVERVIEW_NUM_CTX = 8192;
-
-    private string $model;
-
     public function __construct(
         private TripRequestRepositoryInterface $tripStateManager,
-        private LlmClientInterface $llmClient,
+        private TripLlmResolverInterface $llmResolver,
         private SystemPromptLoader $promptLoader,
         private LoggerInterface $logger,
         private LlmAnalysisTrackerInterface $llmTracker,
         private ComputationTrackerInterface $computationTracker,
         private TripUpdatePublisherInterface $publisher,
-        #[Autowire(env: 'default::OLLAMA_OVERVIEW_MODEL')]
-        ?string $model = null,
     ) {
-        $this->model = (null === $model || '' === $model) ? self::DEFAULT_MODEL : $model;
     }
 
     public function __invoke(AnalyzeTripOverviewWithLlmMessage $message): void
     {
         $tripId = $message->tripId;
 
-        if (!$this->llmClient->isEnabled()) {
+        $resolved = $this->llmResolver->resolveForTrip($tripId);
+        if (!$resolved instanceof ResolvedLlmClient) {
             // The dispatcher (AllEnrichmentsCompletedHandler) already short-circuits
-            // and publishes TRIP_READY directly when the LLM is disabled. Reaching
-            // this handler with a disabled LLM means a stale / replayed message —
-            // skip silently to avoid a double publish.
-            $this->logger->debug('LLM disabled — skipping trip overview synthesis.', [
+            // and publishes TRIP_READY directly when AI is unavailable. Reaching this
+            // handler unconfigured means a stale / replayed message — skip silently
+            // to avoid a double publish.
+            $this->logger->debug('AI not configured for trip owner — skipping trip overview synthesis.', [
                 'tripId' => $tripId,
             ]);
 
@@ -132,22 +119,21 @@ final readonly class AnalyzeTripOverviewWithLlmHandler
             return;
         }
 
+        $model = $resolved->provider->analysisModel();
+
         try {
-            $response = $this->llmClient->generate(
-                model: $this->model,
+            // Options are intentionally left to provider defaults: Ollama-only knobs
+            // (format, num_ctx, num_predict) are not portable across cloud providers.
+            $response = $resolved->client->generate(
+                model: $model,
                 prompt: $userPrompt,
                 systemPrompt: $systemPrompt,
-                options: [
-                    // The system prompt asks for a Markdown briefing — disable Ollama's JSON mode.
-                    'format' => '',
-                    'num_ctx' => self::OVERVIEW_NUM_CTX,
-                    'num_predict' => self::MAX_RESPONSE_TOKENS,
-                ],
             );
-        } catch (OllamaUnavailableException $ollamaUnavailableException) {
-            $this->logger->critical('Ollama unreachable — skipping trip overview synthesis.', [
+        } catch (AiUnavailableException $aiUnavailableException) {
+            $this->logger->critical('AI provider unreachable — skipping trip overview synthesis.', [
                 'tripId' => $tripId,
-                'error' => $ollamaUnavailableException->getMessage(),
+                'reason' => $aiUnavailableException->getReason()->value,
+                'error' => $aiUnavailableException->getMessage(),
             ]);
             $this->finalize($tripId, overview: null);
 
@@ -170,7 +156,7 @@ final readonly class AnalyzeTripOverviewWithLlmHandler
             return;
         }
 
-        $overview = $this->parseMarkdownResponse($rawText);
+        $overview = $this->parseMarkdownResponse($rawText, $model);
 
         $this->tripStateManager->updateTripAiOverview(
             $tripId,
@@ -394,7 +380,7 @@ final readonly class AnalyzeTripOverviewWithLlmHandler
      * containing keywords ("attention", "warning", "danger", "risque") is
      * additionally surfaced under crossStageAlerts.
      */
-    private function parseMarkdownResponse(string $markdown): TripAiOverview
+    private function parseMarkdownResponse(string $markdown, string $model): TripAiOverview
     {
         $sections = $this->splitMarkdownSections($markdown);
 
@@ -418,7 +404,7 @@ final readonly class AnalyzeTripOverviewWithLlmHandler
             patterns: $patterns,
             recommendations: $recommendations,
             crossStageAlerts: $crossStageAlerts,
-            model: $this->model,
+            model: $model,
             promptVersion: self::PROMPT_VERSION,
             generatedAt: new \DateTimeImmutable('now', new \DateTimeZone('UTC'))->format(\DATE_ATOM),
         );

--- a/api/tests/Functional/LlmClientWiringTest.php
+++ b/api/tests/Functional/LlmClientWiringTest.php
@@ -5,37 +5,39 @@ declare(strict_types=1);
 namespace App\Tests\Functional;
 
 use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
-use App\Llm\LlmClientInterface;
-use App\Llm\OllamaClient;
+use App\Llm\TripLlmResolver;
+use App\Llm\TripLlmResolverInterface;
+use App\MessageHandler\AllEnrichmentsCompletedHandler;
 use App\MessageHandler\AnalyzeStageWithLlmHandler;
 use App\MessageHandler\AnalyzeTripOverviewWithLlmHandler;
 use PHPUnit\Framework\Attributes\Test;
 
 /**
- * Guards the DI override that wires the analysis-scoped Ollama client into the
- * async analysis handlers (#564). Without this, renaming the `$llmClient`
- * constructor arg would silently fall back to the default chat-aliased client
- * and analysis would hit the chat endpoint once OLLAMA_ANALYSIS_URL diverges —
- * no compile error, no other test failure.
+ * Guards the per-user analysis wiring (ADR-042): the async handlers resolve the
+ * LLM client from the trip owner via {@see TripLlmResolverInterface}, not from a
+ * global Ollama client. A silent fallback to a different collaborator would skip
+ * AI analysis with no compile error and no other test failure.
  */
 final class LlmClientWiringTest extends ApiTestCase
 {
     #[Test]
-    public function analyzeHandlersReceiveTheAnalysisScopedClient(): void
+    public function analysisHandlersResolveTheClientPerTripOwner(): void
     {
         self::bootKernel();
         $container = self::getContainer();
 
-        $analysisClient = $container->get('app.llm.ollama_client.analysis');
-        $chatClient = $container->get(LlmClientInterface::class);
+        self::assertInstanceOf(TripLlmResolver::class, $container->get(TripLlmResolverInterface::class));
 
-        self::assertInstanceOf(OllamaClient::class, $analysisClient);
-        self::assertNotSame($chatClient, $analysisClient, 'Analysis and chat clients must be distinct instances.');
+        $handlerIds = [
+            AnalyzeStageWithLlmHandler::class,
+            AnalyzeTripOverviewWithLlmHandler::class,
+            AllEnrichmentsCompletedHandler::class,
+        ];
 
-        foreach ([AnalyzeStageWithLlmHandler::class, AnalyzeTripOverviewWithLlmHandler::class] as $handlerId) {
+        foreach ($handlerIds as $handlerId) {
             $handler = $container->get($handlerId);
-            $injected = new \ReflectionProperty($handler, 'llmClient')->getValue($handler);
-            self::assertSame($analysisClient, $injected, \sprintf('%s must receive the analysis-scoped client.', $handlerId));
+            $injected = new \ReflectionProperty($handler, 'llmResolver')->getValue($handler);
+            self::assertInstanceOf(TripLlmResolverInterface::class, $injected, \sprintf('%s must receive the per-trip LLM resolver.', $handlerId));
         }
     }
 }

--- a/api/tests/Integration/LlmPipelineTest.php
+++ b/api/tests/Integration/LlmPipelineTest.php
@@ -9,11 +9,14 @@ use App\ApiResource\Stage;
 use App\ApiResource\TripRequest;
 use App\ComputationTracker\ComputationTrackerInterface;
 use App\Enum\ComputationName;
+use App\Llm\AiProvider;
 use App\Llm\Dto\StageAiAnalysis;
 use App\Llm\LlmAnalysisTrackerInterface;
 use App\Llm\LlmClientInterface;
+use App\Llm\ResolvedLlmClient;
 use App\Llm\StageAnalysisSummaryBuilder;
 use App\Llm\SystemPromptLoader;
+use App\Llm\TripLlmResolverInterface;
 use App\Mercure\MercureEventType;
 use App\Mercure\StagePayloadMapper;
 use App\Mercure\TripUpdatePublisherInterface;
@@ -108,7 +111,7 @@ final class LlmPipelineTest extends TestCase
 
         $stageHandler = new AnalyzeStageWithLlmHandler(
             tripStateManager: $repository,
-            llmClient: $this->stageLlmClient(),
+            llmResolver: $this->resolver($this->stageLlmClient()),
             promptLoader: new SystemPromptLoader($this->tmpPromptDir),
             summaryBuilder: new StageAnalysisSummaryBuilder(),
             logger: new NullLogger(),
@@ -119,7 +122,7 @@ final class LlmPipelineTest extends TestCase
 
         $overviewHandler = new AnalyzeTripOverviewWithLlmHandler(
             tripStateManager: $repository,
-            llmClient: $this->overviewLlmClient(),
+            llmResolver: $this->resolver($this->overviewLlmClient()),
             promptLoader: new SystemPromptLoader($this->tmpPromptDir),
             logger: new NullLogger(),
             llmTracker: $llmTracker,
@@ -150,7 +153,7 @@ final class LlmPipelineTest extends TestCase
             tripRequestRepository: $repository,
             logger: new NullLogger(),
             messageBus: $bus,
-            llmClient: $this->stageLlmClient(),
+            llmResolver: $this->resolver($this->stageLlmClient()),
             llmTracker: $llmTracker,
         );
 
@@ -208,23 +211,20 @@ final class LlmPipelineTest extends TestCase
 
         $bus = new InMemoryBus();
 
-        $disabledLlm = $this->createStub(LlmClientInterface::class);
-        $disabledLlm->method('isEnabled')->willReturn(false);
-
         $terminalHandler = new AllEnrichmentsCompletedHandler(
             computationTracker: $this->stubComputationTracker(['route' => 'done']),
             publisher: $publisher,
             tripRequestRepository: $repository,
             logger: new NullLogger(),
             messageBus: $bus,
-            llmClient: $disabledLlm,
+            llmResolver: $this->unconfiguredResolver(),
             llmTracker: new InMemoryLlmAnalysisTracker(),
         );
 
         $terminalHandler(new AllEnrichmentsCompleted(self::TRIP_ID));
 
         // No LLM message dispatched.
-        self::assertSame(0, $bus->dispatchCount(), 'No LLM message must be dispatched when Ollama is disabled.');
+        self::assertSame(0, $bus->dispatchCount(), 'No LLM message must be dispatched when AI is not configured.');
 
         // Exactly one TRIP_READY published, no ai_overview.
         $tripReadyEvents = $publisher->byType(MercureEventType::TRIP_READY);
@@ -259,16 +259,13 @@ final class LlmPipelineTest extends TestCase
 
         $bus = new InMemoryBus();
 
-        $enabledLlm = $this->createStub(LlmClientInterface::class);
-        $enabledLlm->method('isEnabled')->willReturn(true);
-
         $terminalHandler = new AllEnrichmentsCompletedHandler(
             computationTracker: $this->stubComputationTracker(['route' => 'done']),
             publisher: $publisher,
             tripRequestRepository: $repository,
             logger: new NullLogger(),
             messageBus: $bus,
-            llmClient: $enabledLlm,
+            llmResolver: $this->resolver($this->stageLlmClient()),
             llmTracker: new InMemoryLlmAnalysisTracker(),
         );
 
@@ -306,13 +303,27 @@ final class LlmPipelineTest extends TestCase
         return $request;
     }
 
+    private function resolver(LlmClientInterface $client): TripLlmResolverInterface
+    {
+        $resolver = $this->createStub(TripLlmResolverInterface::class);
+        $resolver->method('resolveForTrip')->willReturn(new ResolvedLlmClient($client, AiProvider::ANTHROPIC));
+
+        return $resolver;
+    }
+
+    private function unconfiguredResolver(): TripLlmResolverInterface
+    {
+        $resolver = $this->createStub(TripLlmResolverInterface::class);
+        $resolver->method('resolveForTrip')->willReturn(null);
+
+        return $resolver;
+    }
+
     private function stageLlmClient(): LlmClientInterface
     {
         $client = $this->createStub(LlmClientInterface::class);
-        $client->method('isEnabled')->willReturn(true);
         $client->method('generate')->willReturn([
             'response' => "## Synthèse\nÉtape exigeante.\n\n## Insights\n- Long sans eau\n\n## Recommandations\n- Faire le plein.\n",
-            'done' => true,
         ]);
 
         return $client;
@@ -321,10 +332,8 @@ final class LlmPipelineTest extends TestCase
     private function overviewLlmClient(): LlmClientInterface
     {
         $client = $this->createStub(LlmClientInterface::class);
-        $client->method('isEnabled')->willReturn(true);
         $client->method('generate')->willReturn([
             'response' => "## Vue d'ensemble\nTrip exigeant.\n\n## Charge et fatigue cumulative\nJ2 plus dure.\n\n## Patterns transversaux\n- Zones sans eau\n\n## Recommandations globales\n- Pause à mi-parcours.\n",
-            'done' => true,
         ]);
 
         return $client;

--- a/api/tests/Unit/Llm/AnalyzeStageWithLlmHandlerTest.php
+++ b/api/tests/Unit/Llm/AnalyzeStageWithLlmHandlerTest.php
@@ -163,6 +163,24 @@ final class AnalyzeStageWithLlmHandlerTest extends TestCase
         $handler(new AnalyzeStageWithLlmMessage(self::TRIP_ID, 1));
     }
 
+    #[Test]
+    public function skipsPersistenceWhenClientReturnsNull(): void
+    {
+        // A client may still return null per the interface contract (e.g. a disabled
+        // OllamaClient configured as the provider); the handler must not persist.
+        $stage = $this->makeStage(dayNumber: 1);
+
+        $repo = $this->createMock(TripRequestRepositoryInterface::class);
+        $repo->method('getStages')->willReturn([$stage]);
+        $repo->expects(self::never())->method('updateStageAiAnalysis');
+
+        $llmClient = $this->createMock(LlmClientInterface::class);
+        $llmClient->method('generate')->willReturn(null);
+
+        $handler = $this->makeHandler(repo: $repo, resolver: $this->resolver($llmClient));
+        $handler(new AnalyzeStageWithLlmMessage(self::TRIP_ID, 1));
+    }
+
     // -------------------------------------------------------------------------
     // Happy paths
     // -------------------------------------------------------------------------

--- a/api/tests/Unit/Llm/AnalyzeStageWithLlmHandlerTest.php
+++ b/api/tests/Unit/Llm/AnalyzeStageWithLlmHandlerTest.php
@@ -7,11 +7,14 @@ namespace App\Tests\Unit\Llm;
 use App\ApiResource\Model\Coordinate;
 use App\ApiResource\Stage;
 use App\ApiResource\TripRequest;
-use App\Llm\Exception\OllamaUnavailableException;
+use App\Llm\AiProvider;
+use App\Llm\Exception\AiUnavailableException;
 use App\Llm\LlmAnalysisTrackerInterface;
 use App\Llm\LlmClientInterface;
+use App\Llm\ResolvedLlmClient;
 use App\Llm\StageAnalysisSummaryBuilder;
 use App\Llm\SystemPromptLoader;
+use App\Llm\TripLlmResolverInterface;
 use App\Mercure\NullTripUpdatePublisher;
 use App\Message\AnalyzeStageWithLlmMessage;
 use App\Message\AnalyzeTripOverviewWithLlmMessage;
@@ -30,6 +33,8 @@ use Symfony\Component\Messenger\MessageBusInterface;
 final class AnalyzeStageWithLlmHandlerTest extends TestCase
 {
     private const string TRIP_ID = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
+
+    private const string ANALYSIS_MODEL = 'claude-3-7-sonnet-latest';
 
     private string $tmpPromptDir = '';
 
@@ -68,16 +73,13 @@ final class AnalyzeStageWithLlmHandlerTest extends TestCase
     // -------------------------------------------------------------------------
 
     #[Test]
-    public function skipsSilentlyWhenLlmIsDisabled(): void
+    public function skipsSilentlyWhenAiIsNotConfigured(): void
     {
-        $llmClient = $this->createMock(LlmClientInterface::class);
-        $llmClient->method('isEnabled')->willReturn(false);
-
         $repo = $this->createMock(TripRequestRepositoryInterface::class);
         $repo->expects(self::never())->method('getStages');
         $repo->expects(self::never())->method('updateStageAiAnalysis');
 
-        $handler = $this->makeHandler(repo: $repo, llmClient: $llmClient);
+        $handler = $this->makeHandler(repo: $repo, resolver: $this->resolver(null));
         $handler(new AnalyzeStageWithLlmMessage(self::TRIP_ID, 1));
     }
 
@@ -89,11 +91,10 @@ final class AnalyzeStageWithLlmHandlerTest extends TestCase
         $repo->expects(self::never())->method('updateStageAiAnalysis');
 
         $llmClient = $this->createMock(LlmClientInterface::class);
-        $llmClient->method('isEnabled')->willReturn(true);
-        // The Ollama client must NOT be called when there are no stages.
+        // The client must NOT be called when there are no stages.
         $llmClient->expects(self::never())->method('generate');
 
-        $handler = $this->makeHandler(repo: $repo, llmClient: $llmClient);
+        $handler = $this->makeHandler(repo: $repo, resolver: $this->resolver($llmClient));
         $handler(new AnalyzeStageWithLlmMessage(self::TRIP_ID, 1));
     }
 
@@ -105,10 +106,7 @@ final class AnalyzeStageWithLlmHandlerTest extends TestCase
         $repo->method('getStages')->willReturn([$stage]);
         $repo->expects(self::never())->method('updateStageAiAnalysis');
 
-        $llmClient = $this->createMock(LlmClientInterface::class);
-        $llmClient->method('isEnabled')->willReturn(true);
-
-        $handler = $this->makeHandler(repo: $repo, llmClient: $llmClient);
+        $handler = $this->makeHandler(repo: $repo, resolver: $this->resolver($this->createStub(LlmClientInterface::class)));
         // Day number 99 — no match.
         $handler(new AnalyzeStageWithLlmMessage(self::TRIP_ID, 99));
     }
@@ -123,15 +121,14 @@ final class AnalyzeStageWithLlmHandlerTest extends TestCase
         $repo->expects(self::never())->method('updateStageAiAnalysis');
 
         $llmClient = $this->createMock(LlmClientInterface::class);
-        $llmClient->method('isEnabled')->willReturn(true);
         $llmClient->expects(self::never())->method('generate');
 
-        $handler = $this->makeHandler(repo: $repo, llmClient: $llmClient);
+        $handler = $this->makeHandler(repo: $repo, resolver: $this->resolver($llmClient));
         $handler(new AnalyzeStageWithLlmMessage(self::TRIP_ID, 2));
     }
 
     #[Test]
-    public function skipsAnalysisWhenOllamaUnreachable(): void
+    public function skipsAnalysisWhenProviderUnreachable(): void
     {
         $stage = $this->makeStage(dayNumber: 1);
 
@@ -140,31 +137,13 @@ final class AnalyzeStageWithLlmHandlerTest extends TestCase
         $repo->expects(self::never())->method('updateStageAiAnalysis');
 
         $llmClient = $this->createMock(LlmClientInterface::class);
-        $llmClient->method('isEnabled')->willReturn(true);
-        $llmClient->method('generate')->willThrowException(new OllamaUnavailableException('boom'));
+        $llmClient->method('generate')->willThrowException(new AiUnavailableException('boom'));
 
-        // AI enabled but Ollama unreachable must be logged at `critical` for ops alerting (#304).
+        // AI configured but provider unreachable must be logged at `critical` for ops alerting (#304).
         $logger = $this->createMock(LoggerInterface::class);
-        $logger->expects(self::once())->method('critical')->with(self::stringContains('Ollama unreachable'));
+        $logger->expects(self::once())->method('critical')->with(self::stringContains('AI provider unreachable'));
 
-        $handler = $this->makeHandler(repo: $repo, llmClient: $llmClient, logger: $logger);
-        $handler(new AnalyzeStageWithLlmMessage(self::TRIP_ID, 1));
-    }
-
-    #[Test]
-    public function skipsPersistenceWhenLlmReturnsNull(): void
-    {
-        $stage = $this->makeStage(dayNumber: 1);
-
-        $repo = $this->createMock(TripRequestRepositoryInterface::class);
-        $repo->method('getStages')->willReturn([$stage]);
-        $repo->expects(self::never())->method('updateStageAiAnalysis');
-
-        $llmClient = $this->createMock(LlmClientInterface::class);
-        $llmClient->method('isEnabled')->willReturn(true);
-        $llmClient->method('generate')->willReturn(null);
-
-        $handler = $this->makeHandler(repo: $repo, llmClient: $llmClient);
+        $handler = $this->makeHandler(repo: $repo, resolver: $this->resolver($llmClient), logger: $logger);
         $handler(new AnalyzeStageWithLlmMessage(self::TRIP_ID, 1));
     }
 
@@ -178,10 +157,9 @@ final class AnalyzeStageWithLlmHandlerTest extends TestCase
         $repo->expects(self::never())->method('updateStageAiAnalysis');
 
         $llmClient = $this->createMock(LlmClientInterface::class);
-        $llmClient->method('isEnabled')->willReturn(true);
-        $llmClient->method('generate')->willReturn(['response' => '   ', 'done' => true]);
+        $llmClient->method('generate')->willReturn(['response' => '   ']);
 
-        $handler = $this->makeHandler(repo: $repo, llmClient: $llmClient);
+        $handler = $this->makeHandler(repo: $repo, resolver: $this->resolver($llmClient));
         $handler(new AnalyzeStageWithLlmMessage(self::TRIP_ID, 1));
     }
 
@@ -190,7 +168,7 @@ final class AnalyzeStageWithLlmHandlerTest extends TestCase
     // -------------------------------------------------------------------------
 
     #[Test]
-    public function buildsCompactJsonSummaryAndCallsOllamaWithSystemPrompt(): void
+    public function buildsCompactJsonSummaryAndCallsTheProviderModelWithSystemPrompt(): void
     {
         $stage = $this->makeStage(dayNumber: 3);
 
@@ -200,27 +178,25 @@ final class AnalyzeStageWithLlmHandlerTest extends TestCase
         $repo->expects(self::once())->method('updateStageAiAnalysis');
 
         $llmClient = $this->createMock(LlmClientInterface::class);
-        $llmClient->method('isEnabled')->willReturn(true);
 
         $captured = [];
         $llmClient->expects(self::once())
             ->method('generate')
-            ->willReturnCallback(static function (string $model, string $prompt, ?string $systemPrompt, array $options) use (&$captured): array {
+            ->willReturnCallback(static function (string $model, string $prompt, ?string $systemPrompt = null, array $options = []) use (&$captured): array {
                 $captured['model'] = $model;
                 $captured['prompt'] = $prompt;
                 $captured['systemPrompt'] = $systemPrompt;
-                $captured['options'] = $options;
 
                 return [
                     'response' => "## Synthèse\nA short narrative.\n\n## Insights\n- First insight\n\n## Recommandations\n- Drink more water\n",
-                    'done' => true,
                 ];
             });
 
-        $handler = $this->makeHandler(repo: $repo, llmClient: $llmClient);
+        $handler = $this->makeHandler(repo: $repo, resolver: $this->resolver($llmClient));
         $handler(new AnalyzeStageWithLlmMessage(self::TRIP_ID, 3));
 
-        self::assertSame(AnalyzeStageWithLlmHandler::DEFAULT_MODEL, $captured['model']);
+        // The model comes from the resolved provider, not an Ollama env.
+        self::assertSame(self::ANALYSIS_MODEL, $captured['model']);
 
         // The user prompt MUST be a valid compact JSON dump of the stage summary.
         self::assertIsString($captured['prompt']);
@@ -231,10 +207,6 @@ final class AnalyzeStageWithLlmHandlerTest extends TestCase
         // System prompt must have placeholders substituted (no remaining {{...}}).
         self::assertIsString($captured['systemPrompt']);
         self::assertStringNotContainsString('{{', $captured['systemPrompt']);
-
-        // Format must be disabled (markdown response, not JSON-mode).
-        self::assertIsArray($captured['options']);
-        self::assertSame('', $captured['options']['format']);
     }
 
     #[Test]
@@ -267,10 +239,9 @@ final class AnalyzeStageWithLlmHandlerTest extends TestCase
             MD;
 
         $llmClient = $this->createMock(LlmClientInterface::class);
-        $llmClient->method('isEnabled')->willReturn(true);
-        $llmClient->method('generate')->willReturn(['response' => $markdown, 'done' => true]);
+        $llmClient->method('generate')->willReturn(['response' => $markdown]);
 
-        $handler = $this->makeHandler(repo: $repo, llmClient: $llmClient);
+        $handler = $this->makeHandler(repo: $repo, resolver: $this->resolver($llmClient));
         $handler(new AnalyzeStageWithLlmMessage(self::TRIP_ID, 2));
 
         self::assertSame(self::TRIP_ID, $captured['tripId']);
@@ -283,7 +254,7 @@ final class AnalyzeStageWithLlmHandlerTest extends TestCase
         self::assertSame('Long segment sans eau de 45 km.', $analysis['insights'][0]);
         self::assertCount(2, $analysis['suggestions']);
         self::assertSame("Faire le plein d'eau à Florac.", $analysis['suggestions'][0]);
-        self::assertSame(AnalyzeStageWithLlmHandler::DEFAULT_MODEL, $analysis['model']);
+        self::assertSame(self::ANALYSIS_MODEL, $analysis['model']);
         self::assertSame(AnalyzeStageWithLlmHandler::PROMPT_VERSION, $analysis['promptVersion']);
         self::assertNotSame('', $analysis['generatedAt']);
     }
@@ -304,13 +275,11 @@ final class AnalyzeStageWithLlmHandlerTest extends TestCase
             });
 
         $llmClient = $this->createMock(LlmClientInterface::class);
-        $llmClient->method('isEnabled')->willReturn(true);
         $llmClient->method('generate')->willReturn([
             'response' => 'Just a plain text answer with no markdown headings at all.',
-            'done' => true,
         ]);
 
-        $handler = $this->makeHandler(repo: $repo, llmClient: $llmClient);
+        $handler = $this->makeHandler(repo: $repo, resolver: $this->resolver($llmClient));
         $handler(new AnalyzeStageWithLlmMessage(self::TRIP_ID, 1));
 
         self::assertIsArray($captured);
@@ -335,13 +304,11 @@ final class AnalyzeStageWithLlmHandlerTest extends TestCase
             });
 
         $llmClient = $this->createMock(LlmClientInterface::class);
-        $llmClient->method('isEnabled')->willReturn(true);
         $llmClient->method('generate')->willReturn([
             'message' => ['role' => 'assistant', 'content' => "## Synthèse\nText.\n\n## Insights\n- A\n\n## Recommandations\n- B"],
-            'done' => true,
         ]);
 
-        $handler = $this->makeHandler(repo: $repo, llmClient: $llmClient);
+        $handler = $this->makeHandler(repo: $repo, resolver: $this->resolver($llmClient));
         $handler(new AnalyzeStageWithLlmMessage(self::TRIP_ID, 4));
 
         self::assertIsArray($captured);
@@ -361,10 +328,8 @@ final class AnalyzeStageWithLlmHandlerTest extends TestCase
         $repo->method('updateStageAiAnalysis');
 
         $llmClient = $this->createMock(LlmClientInterface::class);
-        $llmClient->method('isEnabled')->willReturn(true);
         $llmClient->method('generate')->willReturn([
             'response' => "## Synthèse\nOK.",
-            'done' => true,
         ]);
 
         $messageBus = $this->createMock(MessageBusInterface::class);
@@ -375,7 +340,7 @@ final class AnalyzeStageWithLlmHandlerTest extends TestCase
 
         $handler = $this->makeHandler(
             repo: $repo,
-            llmClient: $llmClient,
+            resolver: $this->resolver($llmClient),
             claimsOverviewDispatch: true,
             messageBus: $messageBus,
         );
@@ -386,15 +351,24 @@ final class AnalyzeStageWithLlmHandlerTest extends TestCase
     // Helpers
     // -------------------------------------------------------------------------
 
+    private function resolver(?LlmClientInterface $client): TripLlmResolverInterface
+    {
+        $resolver = $this->createMock(TripLlmResolverInterface::class);
+        $resolver->method('resolveForTrip')->willReturn(
+            $client instanceof LlmClientInterface ? new ResolvedLlmClient($client, AiProvider::ANTHROPIC) : null,
+        );
+
+        return $resolver;
+    }
+
     /**
      * @param TripRequestRepositoryInterface&MockObject $repo
-     * @param LlmClientInterface&MockObject             $llmClient
      * @param (MessageBusInterface&MockObject)|null     $messageBus override the bus when the test asserts pass-2 dispatch
      * @param (LoggerInterface&MockObject)|null         $logger     override the logger when the test asserts a log level
      */
     private function makeHandler(
         TripRequestRepositoryInterface $repo,
-        LlmClientInterface $llmClient,
+        TripLlmResolverInterface $resolver,
         bool $claimsOverviewDispatch = false,
         ?MessageBusInterface $messageBus = null,
         ?LoggerInterface $logger = null,
@@ -405,7 +379,7 @@ final class AnalyzeStageWithLlmHandlerTest extends TestCase
 
         return new AnalyzeStageWithLlmHandler(
             tripStateManager: $repo,
-            llmClient: $llmClient,
+            llmResolver: $resolver,
             promptLoader: new SystemPromptLoader($this->tmpPromptDir),
             summaryBuilder: new StageAnalysisSummaryBuilder(),
             logger: $logger ?? new NullLogger(),

--- a/api/tests/Unit/Llm/AnalyzeTripOverviewWithLlmHandlerTest.php
+++ b/api/tests/Unit/Llm/AnalyzeTripOverviewWithLlmHandlerTest.php
@@ -8,11 +8,14 @@ use App\ApiResource\Model\Coordinate;
 use App\ApiResource\Stage;
 use App\ApiResource\TripRequest;
 use App\ComputationTracker\ComputationTrackerInterface;
+use App\Llm\AiProvider;
 use App\Llm\Dto\StageAiAnalysis;
-use App\Llm\Exception\OllamaUnavailableException;
+use App\Llm\Exception\AiUnavailableException;
 use App\Llm\LlmAnalysisTrackerInterface;
 use App\Llm\LlmClientInterface;
+use App\Llm\ResolvedLlmClient;
 use App\Llm\SystemPromptLoader;
+use App\Llm\TripLlmResolverInterface;
 use App\Mercure\NullTripUpdatePublisher;
 use App\Mercure\TripUpdatePublisherInterface;
 use App\Message\AnalyzeTripOverviewWithLlmMessage;
@@ -29,6 +32,8 @@ use Psr\Log\NullLogger;
 final class AnalyzeTripOverviewWithLlmHandlerTest extends TestCase
 {
     private const string TRIP_ID = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
+
+    private const string ANALYSIS_MODEL = 'claude-3-7-sonnet-latest';
 
     private string $tmpPromptDir = '';
 
@@ -67,16 +72,13 @@ final class AnalyzeTripOverviewWithLlmHandlerTest extends TestCase
     // -------------------------------------------------------------------------
 
     #[Test]
-    public function skipsSilentlyWhenLlmIsDisabled(): void
+    public function skipsSilentlyWhenAiIsNotConfigured(): void
     {
-        $llmClient = $this->createMock(LlmClientInterface::class);
-        $llmClient->method('isEnabled')->willReturn(false);
-
         $repo = $this->createMock(TripRequestRepositoryInterface::class);
         $repo->expects(self::never())->method('getStages');
         $repo->expects(self::never())->method('updateTripAiOverview');
 
-        $handler = $this->makeHandler(repo: $repo, llmClient: $llmClient);
+        $handler = $this->makeHandler(repo: $repo, resolver: $this->resolver(null));
         $handler(new AnalyzeTripOverviewWithLlmMessage(self::TRIP_ID));
     }
 
@@ -88,10 +90,9 @@ final class AnalyzeTripOverviewWithLlmHandlerTest extends TestCase
         $repo->expects(self::never())->method('updateTripAiOverview');
 
         $llmClient = $this->createMock(LlmClientInterface::class);
-        $llmClient->method('isEnabled')->willReturn(true);
         $llmClient->expects(self::never())->method('generate');
 
-        $handler = $this->makeHandler(repo: $repo, llmClient: $llmClient);
+        $handler = $this->makeHandler(repo: $repo, resolver: $this->resolver($llmClient));
         $handler(new AnalyzeTripOverviewWithLlmMessage(self::TRIP_ID));
     }
 
@@ -103,10 +104,9 @@ final class AnalyzeTripOverviewWithLlmHandlerTest extends TestCase
         $repo->expects(self::never())->method('updateTripAiOverview');
 
         $llmClient = $this->createMock(LlmClientInterface::class);
-        $llmClient->method('isEnabled')->willReturn(true);
         $llmClient->expects(self::never())->method('generate');
 
-        $handler = $this->makeHandler(repo: $repo, llmClient: $llmClient);
+        $handler = $this->makeHandler(repo: $repo, resolver: $this->resolver($llmClient));
         $handler(new AnalyzeTripOverviewWithLlmMessage(self::TRIP_ID));
     }
 
@@ -125,10 +125,9 @@ final class AnalyzeTripOverviewWithLlmHandlerTest extends TestCase
         $repo->expects(self::never())->method('updateTripAiOverview');
 
         $llmClient = $this->createMock(LlmClientInterface::class);
-        $llmClient->method('isEnabled')->willReturn(true);
         $llmClient->expects(self::never())->method('generate');
 
-        $handler = $this->makeHandler(repo: $repo, llmClient: $llmClient);
+        $handler = $this->makeHandler(repo: $repo, resolver: $this->resolver($llmClient));
         $handler(new AnalyzeTripOverviewWithLlmMessage(self::TRIP_ID));
     }
 
@@ -152,15 +151,14 @@ final class AnalyzeTripOverviewWithLlmHandlerTest extends TestCase
 
         $captured = [];
         $llmClient = $this->createMock(LlmClientInterface::class);
-        $llmClient->method('isEnabled')->willReturn(true);
         $llmClient->method('generate')
-            ->willReturnCallback(static function (string $model, string $prompt, ?string $systemPrompt, array $options) use (&$captured): array {
+            ->willReturnCallback(static function (string $model, string $prompt, ?string $systemPrompt = null, array $options = []) use (&$captured): array {
                 $captured['prompt'] = $prompt;
 
-                return ['response' => "## Vue d'ensemble\nOK\n", 'done' => true];
+                return ['response' => "## Vue d'ensemble\nOK\n"];
             });
 
-        $handler = $this->makeHandler(repo: $repo, llmClient: $llmClient);
+        $handler = $this->makeHandler(repo: $repo, resolver: $this->resolver($llmClient));
         $handler(new AnalyzeTripOverviewWithLlmMessage(self::TRIP_ID));
 
         self::assertIsString($captured['prompt']);
@@ -176,7 +174,7 @@ final class AnalyzeTripOverviewWithLlmHandlerTest extends TestCase
     }
 
     #[Test]
-    public function skipsAnalysisWhenOllamaUnreachable(): void
+    public function skipsAnalysisWhenProviderUnreachable(): void
     {
         $stage = $this->makeStage(dayNumber: 1);
         $stage->aiAnalysis = $this->makeAiAnalysis('A');
@@ -187,33 +185,13 @@ final class AnalyzeTripOverviewWithLlmHandlerTest extends TestCase
         $repo->expects(self::never())->method('updateTripAiOverview');
 
         $llmClient = $this->createMock(LlmClientInterface::class);
-        $llmClient->method('isEnabled')->willReturn(true);
-        $llmClient->method('generate')->willThrowException(new OllamaUnavailableException('boom'));
+        $llmClient->method('generate')->willThrowException(new AiUnavailableException('boom'));
 
-        // AI enabled but Ollama unreachable must be logged at `critical` for ops alerting (#304).
+        // AI configured but provider unreachable must be logged at `critical` for ops alerting (#304).
         $logger = $this->createMock(LoggerInterface::class);
-        $logger->expects(self::once())->method('critical')->with(self::stringContains('Ollama unreachable'));
+        $logger->expects(self::once())->method('critical')->with(self::stringContains('AI provider unreachable'));
 
-        $handler = $this->makeHandler(repo: $repo, llmClient: $llmClient, logger: $logger);
-        $handler(new AnalyzeTripOverviewWithLlmMessage(self::TRIP_ID));
-    }
-
-    #[Test]
-    public function skipsPersistenceWhenLlmReturnsNull(): void
-    {
-        $stage = $this->makeStage(dayNumber: 1);
-        $stage->aiAnalysis = $this->makeAiAnalysis('A');
-
-        $repo = $this->createMock(TripRequestRepositoryInterface::class);
-        $repo->method('getStages')->willReturn([$stage]);
-        $repo->method('getRequest')->willReturn($this->makeTripRequest());
-        $repo->expects(self::never())->method('updateTripAiOverview');
-
-        $llmClient = $this->createMock(LlmClientInterface::class);
-        $llmClient->method('isEnabled')->willReturn(true);
-        $llmClient->method('generate')->willReturn(null);
-
-        $handler = $this->makeHandler(repo: $repo, llmClient: $llmClient);
+        $handler = $this->makeHandler(repo: $repo, resolver: $this->resolver($llmClient), logger: $logger);
         $handler(new AnalyzeTripOverviewWithLlmMessage(self::TRIP_ID));
     }
 
@@ -229,10 +207,9 @@ final class AnalyzeTripOverviewWithLlmHandlerTest extends TestCase
         $repo->expects(self::never())->method('updateTripAiOverview');
 
         $llmClient = $this->createMock(LlmClientInterface::class);
-        $llmClient->method('isEnabled')->willReturn(true);
-        $llmClient->method('generate')->willReturn(['response' => '   ', 'done' => true]);
+        $llmClient->method('generate')->willReturn(['response' => '   ']);
 
-        $handler = $this->makeHandler(repo: $repo, llmClient: $llmClient);
+        $handler = $this->makeHandler(repo: $repo, resolver: $this->resolver($llmClient));
         $handler(new AnalyzeTripOverviewWithLlmMessage(self::TRIP_ID));
     }
 
@@ -241,7 +218,7 @@ final class AnalyzeTripOverviewWithLlmHandlerTest extends TestCase
     // -------------------------------------------------------------------------
 
     #[Test]
-    public function buildsPayloadAndCallsOllamaWithSystemPrompt(): void
+    public function buildsPayloadAndCallsTheProviderModelWithSystemPrompt(): void
     {
         $stage1 = $this->makeStage(dayNumber: 1, distance: 65.0, elevation: 600.0);
         $stage1->aiAnalysis = $this->makeAiAnalysis('Étape d\'approche roulante.');
@@ -256,25 +233,23 @@ final class AnalyzeTripOverviewWithLlmHandlerTest extends TestCase
 
         $captured = [];
         $llmClient = $this->createMock(LlmClientInterface::class);
-        $llmClient->method('isEnabled')->willReturn(true);
         $llmClient->expects(self::once())
             ->method('generate')
-            ->willReturnCallback(static function (string $model, string $prompt, ?string $systemPrompt, array $options) use (&$captured): array {
+            ->willReturnCallback(static function (string $model, string $prompt, ?string $systemPrompt = null, array $options = []) use (&$captured): array {
                 $captured['model'] = $model;
                 $captured['prompt'] = $prompt;
                 $captured['systemPrompt'] = $systemPrompt;
-                $captured['options'] = $options;
 
                 return [
                     'response' => "## Vue d'ensemble\nGlobal narrative.\n\n## Charge et fatigue cumulative\nOK.\n\n## Patterns transversaux\n- Pattern A\n\n## Recommandations globales\n- Reco 1\n",
-                    'done' => true,
                 ];
             });
 
-        $handler = $this->makeHandler(repo: $repo, llmClient: $llmClient);
+        $handler = $this->makeHandler(repo: $repo, resolver: $this->resolver($llmClient));
         $handler(new AnalyzeTripOverviewWithLlmMessage(self::TRIP_ID));
 
-        self::assertSame(AnalyzeTripOverviewWithLlmHandler::DEFAULT_MODEL, $captured['model']);
+        // The model comes from the resolved provider, not an Ollama env.
+        self::assertSame(self::ANALYSIS_MODEL, $captured['model']);
 
         // The user prompt MUST be a valid JSON dump of {rider_profile, stages}.
         self::assertIsString($captured['prompt']);
@@ -294,11 +269,6 @@ final class AnalyzeTripOverviewWithLlmHandlerTest extends TestCase
         // System prompt must have placeholders substituted (no remaining {{...}}).
         self::assertIsString($captured['systemPrompt']);
         self::assertStringNotContainsString('{{', $captured['systemPrompt']);
-
-        // Format must be disabled (markdown response, not JSON-mode).
-        self::assertIsArray($captured['options']);
-        self::assertSame('', $captured['options']['format']);
-        self::assertSame(AnalyzeTripOverviewWithLlmHandler::OVERVIEW_NUM_CTX, $captured['options']['num_ctx']);
     }
 
     #[Test]
@@ -335,10 +305,9 @@ final class AnalyzeTripOverviewWithLlmHandlerTest extends TestCase
             MD;
 
         $llmClient = $this->createMock(LlmClientInterface::class);
-        $llmClient->method('isEnabled')->willReturn(true);
-        $llmClient->method('generate')->willReturn(['response' => $markdown, 'done' => true]);
+        $llmClient->method('generate')->willReturn(['response' => $markdown]);
 
-        $handler = $this->makeHandler(repo: $repo, llmClient: $llmClient);
+        $handler = $this->makeHandler(repo: $repo, resolver: $this->resolver($llmClient));
         $handler(new AnalyzeTripOverviewWithLlmMessage(self::TRIP_ID));
 
         self::assertSame(self::TRIP_ID, $captured['tripId']);
@@ -354,7 +323,7 @@ final class AnalyzeTripOverviewWithLlmHandlerTest extends TestCase
         // The third pattern triggers cross-stage alert via "Attention" + "risque" keyword.
         self::assertCount(1, $overview['crossStageAlerts']);
         self::assertStringContainsString('Attention', $overview['crossStageAlerts'][0]);
-        self::assertSame(AnalyzeTripOverviewWithLlmHandler::DEFAULT_MODEL, $overview['model']);
+        self::assertSame(self::ANALYSIS_MODEL, $overview['model']);
         self::assertSame(AnalyzeTripOverviewWithLlmHandler::PROMPT_VERSION, $overview['promptVersion']);
         self::assertNotSame('', $overview['generatedAt']);
     }
@@ -376,13 +345,11 @@ final class AnalyzeTripOverviewWithLlmHandlerTest extends TestCase
             });
 
         $llmClient = $this->createMock(LlmClientInterface::class);
-        $llmClient->method('isEnabled')->willReturn(true);
         $llmClient->method('generate')->willReturn([
             'response' => 'Just a plain text answer with no markdown headings at all.',
-            'done' => true,
         ]);
 
-        $handler = $this->makeHandler(repo: $repo, llmClient: $llmClient);
+        $handler = $this->makeHandler(repo: $repo, resolver: $this->resolver($llmClient));
         $handler(new AnalyzeTripOverviewWithLlmMessage(self::TRIP_ID));
 
         self::assertIsArray($captured);
@@ -409,16 +376,14 @@ final class AnalyzeTripOverviewWithLlmHandlerTest extends TestCase
             });
 
         $llmClient = $this->createMock(LlmClientInterface::class);
-        $llmClient->method('isEnabled')->willReturn(true);
         $llmClient->method('generate')->willReturn([
             'message' => [
                 'role' => 'assistant',
                 'content' => "## Vue d'ensemble\nText.\n\n## Patterns transversaux\n- A\n\n## Recommandations globales\n- B",
             ],
-            'done' => true,
         ]);
 
-        $handler = $this->makeHandler(repo: $repo, llmClient: $llmClient);
+        $handler = $this->makeHandler(repo: $repo, resolver: $this->resolver($llmClient));
         $handler(new AnalyzeTripOverviewWithLlmMessage(self::TRIP_ID));
 
         self::assertIsArray($captured);
@@ -444,15 +409,14 @@ final class AnalyzeTripOverviewWithLlmHandlerTest extends TestCase
 
         $captured = [];
         $llmClient = $this->createMock(LlmClientInterface::class);
-        $llmClient->method('isEnabled')->willReturn(true);
         $llmClient->method('generate')
-            ->willReturnCallback(static function (string $model, string $prompt, ?string $systemPrompt, array $options) use (&$captured): array {
+            ->willReturnCallback(static function (string $model, string $prompt, ?string $systemPrompt = null, array $options = []) use (&$captured): array {
                 $captured['prompt'] = $prompt;
 
-                return ['response' => "## Vue d'ensemble\nOK\n", 'done' => true];
+                return ['response' => "## Vue d'ensemble\nOK\n"];
             });
 
-        $handler = $this->makeHandler(repo: $repo, llmClient: $llmClient);
+        $handler = $this->makeHandler(repo: $repo, resolver: $this->resolver($llmClient));
         $handler(new AnalyzeTripOverviewWithLlmMessage(self::TRIP_ID));
 
         self::assertIsString($captured['prompt']);
@@ -477,10 +441,8 @@ final class AnalyzeTripOverviewWithLlmHandlerTest extends TestCase
         $repo->method('updateTripAiOverview');
 
         $llmClient = $this->createMock(LlmClientInterface::class);
-        $llmClient->method('isEnabled')->willReturn(true);
         $llmClient->method('generate')->willReturn([
             'response' => "## Vue d'ensemble\nOK.",
-            'done' => true,
         ]);
 
         $publisher = $this->createMock(TripUpdatePublisherInterface::class);
@@ -488,7 +450,7 @@ final class AnalyzeTripOverviewWithLlmHandlerTest extends TestCase
 
         $handler = $this->makeHandler(
             repo: $repo,
-            llmClient: $llmClient,
+            resolver: $this->resolver($llmClient),
             claimsTripReadyPublication: false,
             publisher: $publisher,
         );
@@ -499,14 +461,23 @@ final class AnalyzeTripOverviewWithLlmHandlerTest extends TestCase
     // Helpers
     // -------------------------------------------------------------------------
 
+    private function resolver(?LlmClientInterface $client): TripLlmResolverInterface
+    {
+        $resolver = $this->createMock(TripLlmResolverInterface::class);
+        $resolver->method('resolveForTrip')->willReturn(
+            $client instanceof LlmClientInterface ? new ResolvedLlmClient($client, AiProvider::ANTHROPIC) : null,
+        );
+
+        return $resolver;
+    }
+
     /**
      * @param TripRequestRepositoryInterface&MockObject $repo
-     * @param LlmClientInterface&MockObject             $llmClient
-     * @param (LoggerInterface&MockObject)|null         $logger    override the logger when the test asserts a log level
+     * @param (LoggerInterface&MockObject)|null         $logger override the logger when the test asserts a log level
      */
     private function makeHandler(
         TripRequestRepositoryInterface $repo,
-        LlmClientInterface $llmClient,
+        TripLlmResolverInterface $resolver,
         bool $claimsTripReadyPublication = true,
         ?TripUpdatePublisherInterface $publisher = null,
         ?LoggerInterface $logger = null,
@@ -520,7 +491,7 @@ final class AnalyzeTripOverviewWithLlmHandlerTest extends TestCase
 
         return new AnalyzeTripOverviewWithLlmHandler(
             tripStateManager: $repo,
-            llmClient: $llmClient,
+            llmResolver: $resolver,
             promptLoader: new SystemPromptLoader($this->tmpPromptDir),
             logger: $logger ?? new NullLogger(),
             llmTracker: $llmTracker,

--- a/api/tests/Unit/Llm/AnalyzeTripOverviewWithLlmHandlerTest.php
+++ b/api/tests/Unit/Llm/AnalyzeTripOverviewWithLlmHandlerTest.php
@@ -213,6 +213,26 @@ final class AnalyzeTripOverviewWithLlmHandlerTest extends TestCase
         $handler(new AnalyzeTripOverviewWithLlmMessage(self::TRIP_ID));
     }
 
+    #[Test]
+    public function skipsPersistenceWhenClientReturnsNull(): void
+    {
+        // A client may still return null per the interface contract (e.g. a disabled
+        // OllamaClient configured as the provider); the handler must not persist.
+        $stage = $this->makeStage(dayNumber: 1);
+        $stage->aiAnalysis = $this->makeAiAnalysis('A');
+
+        $repo = $this->createMock(TripRequestRepositoryInterface::class);
+        $repo->method('getStages')->willReturn([$stage]);
+        $repo->method('getRequest')->willReturn($this->makeTripRequest());
+        $repo->expects(self::never())->method('updateTripAiOverview');
+
+        $llmClient = $this->createMock(LlmClientInterface::class);
+        $llmClient->method('generate')->willReturn(null);
+
+        $handler = $this->makeHandler(repo: $repo, resolver: $this->resolver($llmClient));
+        $handler(new AnalyzeTripOverviewWithLlmMessage(self::TRIP_ID));
+    }
+
     // -------------------------------------------------------------------------
     // Happy paths
     // -------------------------------------------------------------------------

--- a/api/tests/Unit/Llm/LlmClientFactoryTest.php
+++ b/api/tests/Unit/Llm/LlmClientFactoryTest.php
@@ -24,10 +24,10 @@ final class LlmClientFactoryTest extends TestCase
         $this->encryptor = new AiTokenEncryptor('test-key');
     }
 
-    private function factory(): LlmClientFactory
+    private function factory(bool $aiEnabled = true): LlmClientFactory
     {
         // MockHttpClient with no queued responses: construction must not hit the wire.
-        return new LlmClientFactory(new MockHttpClient(), new MockHttpClient(), new MockHttpClient(), new NullLogger(), $this->encryptor);
+        return new LlmClientFactory(new MockHttpClient(), new MockHttpClient(), new MockHttpClient(), new NullLogger(), $this->encryptor, $aiEnabled);
     }
 
     /**
@@ -55,7 +55,20 @@ final class LlmClientFactoryTest extends TestCase
         $user = new User('rider@example.test');
         $user->setAiProvider('anthropic')->setAiToken($this->encryptor->encrypt('sk-ant-secret'));
 
-        self::assertInstanceOf(PlatformLlmClient::class, $this->factory()->forUser($user));
+        $resolved = $this->factory()->forUser($user);
+
+        self::assertNotNull($resolved);
+        self::assertInstanceOf(PlatformLlmClient::class, $resolved->client);
+        self::assertSame(AiProvider::ANTHROPIC, $resolved->provider);
+    }
+
+    #[Test]
+    public function forUserReturnsNullWhenTheKillSwitchIsOff(): void
+    {
+        $user = new User('rider@example.test');
+        $user->setAiProvider('anthropic')->setAiToken($this->encryptor->encrypt('sk-ant-secret'));
+
+        self::assertNull($this->factory(aiEnabled: false)->forUser($user));
     }
 
     #[Test]

--- a/api/tests/Unit/Llm/TripOwnerResolverTest.php
+++ b/api/tests/Unit/Llm/TripOwnerResolverTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Llm;
+
+use App\ApiResource\TripRequest;
+use App\Entity\User;
+use App\Llm\TripOwnerResolver;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Uid\Uuid;
+
+final class TripOwnerResolverTest extends TestCase
+{
+    private const string TRIP_ID = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
+
+    #[Test]
+    public function returnsNullForAnInvalidTripId(): void
+    {
+        $cache = $this->createMock(CacheItemPoolInterface::class);
+        $cache->expects(self::never())->method('getItem');
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects(self::never())->method('find');
+
+        self::assertNull(new TripOwnerResolver($cache, $em)->resolve('not-a-uuid'));
+    }
+
+    #[Test]
+    public function returnsTheUserFromTheRedisOwnerId(): void
+    {
+        $user = new User('rider@example.test');
+        $cache = $this->cacheReturning($user->getId()->toRfc4122());
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects(self::once())
+            ->method('find')
+            ->with(User::class, self::callback(static fn (Uuid $id): bool => $id->equals($user->getId())))
+            ->willReturn($user);
+
+        self::assertSame($user, new TripOwnerResolver($cache, $em)->resolve(self::TRIP_ID));
+    }
+
+    #[Test]
+    public function fallsBackToPostgresWhenTheCachedUserNoLongerExists(): void
+    {
+        // Redis hit, but the user_id points to a row deleted since: fall through.
+        $owner = new User('owner@example.test');
+        $trip = new TripRequest();
+        $trip->user = $owner;
+
+        $cache = $this->cacheReturning(Uuid::v7()->toRfc4122());
+
+        $em = $this->createStub(EntityManagerInterface::class);
+        $em->method('find')->willReturnCallback(static fn (string $class): ?object => User::class === $class ? null : $trip);
+
+        self::assertSame($owner, new TripOwnerResolver($cache, $em)->resolve(self::TRIP_ID));
+    }
+
+    #[Test]
+    public function fallsBackToThePostgresTripOwnerOnCacheMiss(): void
+    {
+        $owner = new User('owner@example.test');
+        $trip = new TripRequest();
+        $trip->user = $owner;
+
+        $cache = $this->cacheMiss();
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects(self::once())
+            ->method('find')
+            ->with(TripRequest::class, self::isInstanceOf(Uuid::class))
+            ->willReturn($trip);
+
+        self::assertSame($owner, new TripOwnerResolver($cache, $em)->resolve(self::TRIP_ID));
+    }
+
+    #[Test]
+    public function returnsNullWhenNoOwnerCanBeResolved(): void
+    {
+        $cache = $this->cacheMiss();
+
+        $em = $this->createStub(EntityManagerInterface::class);
+        $em->method('find')->willReturn(null);
+
+        self::assertNull(new TripOwnerResolver($cache, $em)->resolve(self::TRIP_ID));
+    }
+
+    private function cacheReturning(string $userId): CacheItemPoolInterface
+    {
+        $item = $this->createStub(CacheItemInterface::class);
+        $item->method('isHit')->willReturn(true);
+        $item->method('get')->willReturn($userId);
+
+        $cache = $this->createStub(CacheItemPoolInterface::class);
+        $cache->method('getItem')->willReturn($item);
+
+        return $cache;
+    }
+
+    private function cacheMiss(): CacheItemPoolInterface
+    {
+        $item = $this->createStub(CacheItemInterface::class);
+        $item->method('isHit')->willReturn(false);
+
+        $cache = $this->createStub(CacheItemPoolInterface::class);
+        $cache->method('getItem')->willReturn($item);
+
+        return $cache;
+    }
+}

--- a/api/tests/Unit/MessageHandler/AllEnrichmentsCompletedHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/AllEnrichmentsCompletedHandlerTest.php
@@ -7,8 +7,11 @@ namespace App\Tests\Unit\MessageHandler;
 use App\ApiResource\Model\Coordinate;
 use App\ApiResource\Stage;
 use App\ComputationTracker\ComputationTrackerInterface;
+use App\Llm\AiProvider;
 use App\Llm\LlmAnalysisTrackerInterface;
 use App\Llm\LlmClientInterface;
+use App\Llm\ResolvedLlmClient;
+use App\Llm\TripLlmResolverInterface;
 use App\Mercure\TripUpdatePublisherInterface;
 use App\Message\AllEnrichmentsCompleted;
 use App\Message\AnalyzeStageWithLlmMessage;
@@ -69,7 +72,7 @@ final class AllEnrichmentsCompletedHandlerTest extends TestCase
             $tripStateManager,
             new NullLogger(),
             $this->createStub(MessageBusInterface::class),
-            $this->disabledLlmClient(),
+            $this->unconfiguredResolver(),
             $this->createStub(LlmAnalysisTrackerInterface::class),
         );
 
@@ -95,7 +98,7 @@ final class AllEnrichmentsCompletedHandlerTest extends TestCase
             $tripStateManager,
             new NullLogger(),
             $this->createStub(MessageBusInterface::class),
-            $this->disabledLlmClient(),
+            $this->unconfiguredResolver(),
             $this->createStub(LlmAnalysisTrackerInterface::class),
         );
 
@@ -129,7 +132,7 @@ final class AllEnrichmentsCompletedHandlerTest extends TestCase
             $tripStateManager,
             new NullLogger(),
             $this->createStub(MessageBusInterface::class),
-            $this->disabledLlmClient(),
+            $this->unconfiguredResolver(),
             $this->createStub(LlmAnalysisTrackerInterface::class),
         );
 
@@ -185,9 +188,6 @@ final class AllEnrichmentsCompletedHandlerTest extends TestCase
             ))
             ->willReturnCallback(static fn (object $message): Envelope => new Envelope($message));
 
-        $llmClient = $this->createStub(LlmClientInterface::class);
-        $llmClient->method('isEnabled')->willReturn(true);
-
         $llmAnalysisTracker = $this->createMock(LlmAnalysisTrackerInterface::class);
         $llmAnalysisTracker->expects(self::once())
             ->method('initializeStageAnalyses')
@@ -199,7 +199,7 @@ final class AllEnrichmentsCompletedHandlerTest extends TestCase
             $tripStateManager,
             new NullLogger(),
             $bus,
-            $llmClient,
+            $this->configuredResolver(),
             $llmAnalysisTracker,
         );
 
@@ -238,7 +238,7 @@ final class AllEnrichmentsCompletedHandlerTest extends TestCase
             $tripStateManager,
             new NullLogger(),
             $bus,
-            $this->disabledLlmClient(),
+            $this->unconfiguredResolver(),
             $this->createStub(LlmAnalysisTrackerInterface::class),
         );
 
@@ -266,9 +266,6 @@ final class AllEnrichmentsCompletedHandlerTest extends TestCase
         $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
         $tripStateManager->method('getStages')->willReturn([$stage]);
 
-        $llmClient = $this->createStub(LlmClientInterface::class);
-        $llmClient->method('isEnabled')->willReturn(true);
-
         $llmAnalysisTracker = $this->createMock(LlmAnalysisTrackerInterface::class);
         $llmAnalysisTracker->expects(self::once())
             ->method('consumeSkipAiAnalysis')
@@ -288,18 +285,28 @@ final class AllEnrichmentsCompletedHandlerTest extends TestCase
             $tripStateManager,
             new NullLogger(),
             $bus,
-            $llmClient,
+            $this->configuredResolver(),
             $llmAnalysisTracker,
         );
 
         $handler(new AllEnrichmentsCompleted($tripId));
     }
 
-    private function disabledLlmClient(): LlmClientInterface
+    private function configuredResolver(): TripLlmResolverInterface
     {
-        $llmClient = $this->createStub(LlmClientInterface::class);
-        $llmClient->method('isEnabled')->willReturn(false);
+        $resolver = $this->createStub(TripLlmResolverInterface::class);
+        $resolver->method('resolveForTrip')->willReturn(
+            new ResolvedLlmClient($this->createStub(LlmClientInterface::class), AiProvider::ANTHROPIC),
+        );
 
-        return $llmClient;
+        return $resolver;
+    }
+
+    private function unconfiguredResolver(): TripLlmResolverInterface
+    {
+        $resolver = $this->createStub(TripLlmResolverInterface::class);
+        $resolver->method('resolveForTrip')->willReturn(null);
+
+        return $resolver;
     }
 }


### PR DESCRIPTION
## Contexte

Partie A du chantier **IA optionnelle multi-provider (BYO token)** (ADR-042). Suite de #708/#709/#710/#711. A3 (câblage par-utilisateur) est découpé : **A3b (cette PR) = chemin async (analyse)**, A3c = chemin sync (chat / in-ride). Cette PR bascule le pipeline d'analyse async du client Ollama global vers le provider configuré par le **propriétaire du trip**.

## Changements

- **`LlmClientFactory::forUser()`** renvoie désormais un `ResolvedLlmClient` (client + provider), et applique le **kill-switch d'instance `AI_ENABLED`** (param `app.ai_enabled`, défaut `true` ; `AI_ENABLED=0` masque toute l'IA). Renvoie `null` si désactivé / non configuré / token indéchiffrable.
- **`TripOwnerResolver`** : résout le propriétaire d'un trip depuis son id, en miroir de `TripVoter` (clé Redis `trip.{id}.user_id` pendant la computation, fallback `TripRequest` Postgres). L'utilisateur est **rechargé frais** depuis la base pour utiliser son token courant (pas un snapshot).
- **`TripLlmResolverInterface` / `TripLmResolver`** : compose owner + factory en `resolveForTrip(tripId): ?ResolvedLlmClient`. Abstraction injectée dans les handlers (mockable).
- **`AnalyzeStageWithLlmHandler`, `AnalyzeTripOverviewWithLlmHandler`, `AllEnrichmentsCompletedHandler`** : résolvent le client via le resolver (skip gracieux si non configuré), utilisent le **modèle d'analyse du provider** (`AiProvider::analysisModel()`), n'envoient plus les options Ollama-only (`format`/`num_ctx`/`num_predict`, non portables), et catchent `AiUnavailableException` (log de la raison).
- **`LlmClientInterface`** documente `@throws AiUnavailableException` ; **`OllamaUnavailableException`** spécialise désormais `AiUnavailableException` (reason `UNAVAILABLE`) pour conserver un contrat unique pendant la coexistence async/sync.
- Suppression du binding DI `app.llm.ollama_client.analysis` sur les handlers (autowiring du resolver).

## Notes

- Le **retry sélectif** (transitoire only, honore `Retry-After`) sur le transport `llm` sera ajouté avec le chemin sync / la stratégie de retry en A3c.
- Le gating global `OLLAMA_ENABLED` n'est plus consulté par l'analyse ; il subsiste uniquement pour le `OllamaClient` (chat sync), retiré en A3c/A4.

## Vérification

`make qa` local : PHPStan L9 OK, CS-Fixer OK, Rector OK, conteneur boote (cache:clear), **1056 tests unitaires + `LlmPipelineTest` verts**. Tests réécrits autour du resolver (handlers stage/overview/gate, factory `forUser` + kill-switch). Tests fonctionnels/intégration exécutés en CI.

## Suite

**A3c** : chemin sync (`TripChatProcessor` + `InRideAssistant` + `PoiIntentDetector`) câblé par `Security`->`forUser`, réponse dégradée « configurez une IA », retry sélectif. Puis **A4** (retrait Ollama bêta + ADR-042).

<!-- claude-review-start -->
## Claude Review

Third pass — all three previously flagged findings have been addressed. The null-return guard in both analysis handlers is now covered by `skipsPersistenceWhenClientReturnsNull` (restored in the latest commit). `LlmClientFactory` kill-switch is covered by `forUserReturnsNullWhenTheKillSwitchIsOff`. `TripOwnerResolver` has a full five-path unit-test suite. The architecture is clean and consistent with ADR-042.

**Resolved 1 previously open thread** (null-response guard tests in both handler test suites).

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Reviewed commit:** 1d28fe746287c2a1d1b0da4ae6635d22bef21b38

**No inline comments.**
<!-- claude-review-end -->