### PR TITLE
feat(ai): optional-AI account settings + disabled-but-visible affordances

### DIFF
--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -633,7 +633,8 @@
     "errorGeneric": "Something went wrong. Please try again later.",
     "fullAnalysisHint": "This change requires a brand-new full analysis.",
     "relaunchAnalysis": "Relaunch analysis",
-    "unavailableTitle": "AI assistant unavailable"
+    "unavailableTitle": "AI assistant unavailable",
+    "notConfiguredTitle": "Configure an AI provider to enable the assistant"
   },
   "chat": {
     "offline": {
@@ -682,7 +683,9 @@
   "aiUnavailable": {
     "analysis": "AI analysis unavailable: the AI service is currently offline.",
     "refinement": "AI assistant unavailable, try again later.",
-    "chat": "AI assistant unavailable."
+    "chat": "AI assistant unavailable.",
+    "notConfigured": "Configure an AI provider for a deeper analysis.",
+    "configureCta": "Configure an AI provider"
   },
   "errors": {
     "networkError": "Network error. Please check your connection.",
@@ -956,6 +959,30 @@
       "description": "You will be logged out of this device.",
       "button": "Log out",
       "logoutFailed": "Logout failed. Please try again."
+    },
+    "ai": {
+      "title": "AI assistant",
+      "description": "Enable AI features by setting a provider and your own API key.",
+      "providerLabel": "Provider",
+      "providerPlaceholder": "Choose a provider",
+      "providers": {
+        "anthropic": "Anthropic (Claude)",
+        "gemini": "Google (Gemini)",
+        "openai": "OpenAI"
+      },
+      "tokenLabel": "API key",
+      "tokenPlaceholder": "Paste your API key",
+      "tokenConfigured": "An API key is stored.",
+      "tokenNotConfigured": "No API key stored.",
+      "save": "Save",
+      "saving": "Saving…",
+      "clear": "Clear configuration",
+      "clearing": "Clearing…",
+      "saved": "AI configuration saved.",
+      "saveFailed": "Could not save the AI configuration.",
+      "cleared": "AI configuration cleared.",
+      "clearFailed": "Could not clear the AI configuration.",
+      "rgpd": "Your trip data (route, towns, dates) is sent to the chosen provider with your API key. Review its privacy policy before enabling AI."
     }
   },
   "errorPages": {

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -633,7 +633,8 @@
     "errorGeneric": "Une erreur est survenue. Réessayez plus tard.",
     "fullAnalysisHint": "Cette modification nécessite une nouvelle analyse complète.",
     "relaunchAnalysis": "Relancer l'analyse",
-    "unavailableTitle": "Assistant IA indisponible"
+    "unavailableTitle": "Assistant IA indisponible",
+    "notConfiguredTitle": "Configurez une IA pour activer l'assistant"
   },
   "chat": {
     "offline": {
@@ -682,7 +683,9 @@
   "aiUnavailable": {
     "analysis": "Analyse IA indisponible : le service IA est actuellement hors ligne.",
     "refinement": "Assistant IA indisponible, réessayez plus tard.",
-    "chat": "Assistant IA indisponible."
+    "chat": "Assistant IA indisponible.",
+    "notConfigured": "Configurez une IA pour profiter d'une analyse plus approfondie.",
+    "configureCta": "Configurer une IA"
   },
   "errors": {
     "networkError": "Erreur réseau. Vérifiez votre connexion.",
@@ -956,6 +959,30 @@
       "description": "Vous serez déconnecté de cet appareil.",
       "button": "Se déconnecter",
       "logoutFailed": "Échec de la déconnexion. Veuillez réessayer."
+    },
+    "ai": {
+      "title": "Assistant IA",
+      "description": "Activez les fonctionnalités d'IA en renseignant un fournisseur et votre propre clé API.",
+      "providerLabel": "Fournisseur",
+      "providerPlaceholder": "Choisissez un fournisseur",
+      "providers": {
+        "anthropic": "Anthropic (Claude)",
+        "gemini": "Google (Gemini)",
+        "openai": "OpenAI"
+      },
+      "tokenLabel": "Clé API",
+      "tokenPlaceholder": "Collez votre clé API",
+      "tokenConfigured": "Une clé API est enregistrée.",
+      "tokenNotConfigured": "Aucune clé API enregistrée.",
+      "save": "Enregistrer",
+      "saving": "Enregistrement…",
+      "clear": "Supprimer la configuration",
+      "clearing": "Suppression…",
+      "saved": "Configuration IA enregistrée.",
+      "saveFailed": "Impossible d'enregistrer la configuration IA.",
+      "cleared": "Configuration IA supprimée.",
+      "clearFailed": "Impossible de supprimer la configuration IA.",
+      "rgpd": "Vos données de voyage (itinéraire, villes, dates) sont transmises au fournisseur choisi avec votre clé API. Consultez sa politique de confidentialité avant d'activer l'IA."
     }
   },
   "errorPages": {

--- a/pwa/src/app/account/settings/page.tsx
+++ b/pwa/src/app/account/settings/page.tsx
@@ -5,6 +5,7 @@ import { TopBar } from "@/components/top-bar";
 import { AccountRail } from "@/components/account/account-rail";
 import { AccountSection } from "@/components/account/account-section";
 import { PreferencesSection } from "@/components/account/preferences-section";
+import { AiProviderSection } from "@/components/account/ai-provider-section";
 import { DataSection } from "@/components/account/data-section";
 import { DangerZoneSection } from "@/components/account/danger-zone-section";
 import { LandingFooter } from "@/components/landing/footer";
@@ -48,6 +49,7 @@ export default function AccountSettingsPage() {
           <div className="flex flex-col gap-6 min-w-0">
             <AccountSection />
             <PreferencesSection />
+            <AiProviderSection />
             <DataSection />
             <DangerZoneSection />
           </div>

--- a/pwa/src/app/trips/new/page.tsx
+++ b/pwa/src/app/trips/new/page.tsx
@@ -177,7 +177,10 @@ function WizardContent() {
           hideStepper
           previewSlot={
             aiCapability.enabled ? (
-              <AiRefinementCard unavailable={!aiCapability.available} />
+              <AiRefinementCard
+                unavailable={!aiCapability.available}
+                notConfigured={!aiCapability.configured}
+              />
             ) : undefined
           }
         />

--- a/pwa/src/components/account/ai-provider-section.tsx
+++ b/pwa/src/components/account/ai-provider-section.tsx
@@ -1,0 +1,226 @@
+"use client";
+
+import { useEffect, useId, useState } from "react";
+import { useTranslations } from "next-intl";
+import { Loader2, Sparkles, Trash2 } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { toast } from "@/components/ui/sonner";
+import { cn } from "@/lib/utils";
+import {
+  AI_PROVIDERS,
+  clearAiSettings,
+  fetchAiSettings,
+  saveAiSettings,
+  type AiProvider,
+} from "@/lib/api/client";
+import { useUiStore } from "@/store/ui-store";
+
+/**
+ * "Assistant IA" account section (ADR-042): the bring-your-own-token AI
+ * configuration. Picks a cloud provider + masked API key, then Save (PUT) /
+ * Clear (DELETE) against `/users/me/ai-settings`. On load the current state is
+ * read (selected provider + a "token configured" indicator — never the token
+ * itself).
+ *
+ * 422 validation errors are surfaced inline; the `configured` capability flag
+ * in {@link useUiStore} is kept in sync so the disabled-but-visible AI surfaces
+ * react immediately to a save/clear without a reload.
+ *
+ * RGPD: trip data (route, towns, dates) is sent to the chosen provider with the
+ * user's key — disclosed explicitly below the form.
+ */
+export function AiProviderSection() {
+  const t = useTranslations("accountSettings.ai");
+  const setAiConfigured = useUiStore((s) => s.setAiConfigured);
+  const providerId = useId();
+  const tokenId = useId();
+  const errorId = useId();
+
+  const [provider, setProvider] = useState<AiProvider | "">("");
+  const [token, setToken] = useState("");
+  const [tokenConfigured, setTokenConfigured] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isClearing, setIsClearing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void fetchAiSettings().then((settings) => {
+      if (cancelled || !settings) return;
+      setProvider(settings.provider ?? "");
+      setTokenConfigured(settings.tokenConfigured);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  async function handleSave() {
+    if (!provider || token.trim().length === 0) return;
+    setIsSaving(true);
+    setError(null);
+    try {
+      const { data, error: apiError } = await saveAiSettings(provider, token);
+      if (apiError) {
+        setError(apiError.message);
+        return;
+      }
+      setProvider(data.provider ?? provider);
+      setTokenConfigured(data.tokenConfigured);
+      setToken("");
+      setAiConfigured(Boolean(data.provider));
+      toast.success(t("saved"));
+    } catch {
+      toast.error(t("saveFailed"));
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  async function handleClear() {
+    setIsClearing(true);
+    setError(null);
+    try {
+      const ok = await clearAiSettings();
+      if (!ok) {
+        toast.error(t("clearFailed"));
+        return;
+      }
+      setProvider("");
+      setToken("");
+      setTokenConfigured(false);
+      setAiConfigured(false);
+      toast.success(t("cleared"));
+    } catch {
+      toast.error(t("clearFailed"));
+    } finally {
+      setIsClearing(false);
+    }
+  }
+
+  const busy = isSaving || isClearing;
+  const canSave = provider !== "" && token.trim().length > 0 && !busy;
+
+  return (
+    <Card data-testid="ai-provider-section" id="ai">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Sparkles className="h-5 w-5 text-brand" aria-hidden="true" />
+          {t("title")}
+        </CardTitle>
+        <CardDescription>{t("description")}</CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        <div className="flex flex-col gap-2">
+          <label htmlFor={providerId} className="text-sm font-medium">
+            {t("providerLabel")}
+          </label>
+          <select
+            id={providerId}
+            value={provider}
+            onChange={(e) => setProvider(e.target.value as AiProvider | "")}
+            disabled={busy}
+            data-testid="ai-provider-select"
+            className={cn(
+              "w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-xs",
+              "focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:border-ring",
+              "disabled:cursor-not-allowed disabled:opacity-50",
+            )}
+          >
+            <option value="">{t("providerPlaceholder")}</option>
+            {AI_PROVIDERS.map((p) => (
+              <option key={p} value={p}>
+                {t(`providers.${p}`)}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <label htmlFor={tokenId} className="text-sm font-medium">
+            {t("tokenLabel")}
+          </label>
+          <Input
+            id={tokenId}
+            type="password"
+            autoComplete="off"
+            value={token}
+            onChange={(e) => {
+              setToken(e.target.value);
+              setError(null);
+            }}
+            placeholder={t("tokenPlaceholder")}
+            disabled={busy}
+            data-testid="ai-token-input"
+            aria-invalid={!!error}
+            aria-describedby={error ? errorId : undefined}
+            className={cn(error && "ring-2 ring-destructive")}
+          />
+          <span
+            className="text-xs text-muted-foreground"
+            data-testid="ai-token-status"
+          >
+            {tokenConfigured ? t("tokenConfigured") : t("tokenNotConfigured")}
+          </span>
+          {error && (
+            <p
+              id={errorId}
+              role="alert"
+              className="text-sm text-destructive"
+              data-testid="ai-settings-error"
+            >
+              {error}
+            </p>
+          )}
+        </div>
+
+        <p
+          className="text-xs text-muted-foreground"
+          data-testid="ai-settings-rgpd"
+        >
+          {t("rgpd")}
+        </p>
+
+        <div className="flex flex-wrap gap-2">
+          <Button
+            type="button"
+            className="gap-2 cursor-pointer"
+            onClick={() => void handleSave()}
+            disabled={!canSave}
+            data-testid="ai-settings-save"
+          >
+            {isSaving ? (
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+            ) : (
+              <Sparkles className="h-4 w-4" aria-hidden="true" />
+            )}
+            {isSaving ? t("saving") : t("save")}
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            className="gap-2 cursor-pointer"
+            onClick={() => void handleClear()}
+            disabled={busy || (!tokenConfigured && provider === "")}
+            data-testid="ai-settings-clear"
+          >
+            {isClearing ? (
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+            ) : (
+              <Trash2 className="h-4 w-4" aria-hidden="true" />
+            )}
+            {isClearing ? t("clearing") : t("clear")}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/pwa/src/components/ai-bubble.tsx
+++ b/pwa/src/components/ai-bubble.tsx
@@ -99,7 +99,7 @@ export function AiBubble() {
           href="/account/settings#ai"
           aria-label={t("notConfiguredTitle")}
           data-testid="ai-bubble"
-          data-not-configured
+          data-not-configured=""
           title={title}
           className={bubbleClassName}
         >

--- a/pwa/src/components/ai-bubble.tsx
+++ b/pwa/src/components/ai-bubble.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
+import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { Sparkles } from "lucide-react";
 import { useShallow } from "zustand/react/shallow";
@@ -59,58 +60,86 @@ export function AiBubble() {
   // AI disabled by config (NEXT_PUBLIC_AI_ENABLED=0) — hide the assistant entirely.
   if (!aiCapability.enabled) return null;
 
-  // Disabled affordance when the network is down OR the (enabled) AI tier is
-  // unreachable: same visual treatment, distinct title + data attribute (#304).
+  // Disabled-but-visible affordance when the network is down, the (enabled) AI
+  // tier is unreachable (#304), or no provider is configured on the account
+  // (ADR-042): same visual treatment, distinct title + data attribute. The
+  // not-configured state links to the settings via its title.
   const isAiDown = !aiCapability.available;
-  const isUnavailable = !isOnline || isAiDown;
+  const isNotConfigured = !aiCapability.configured;
+  const isUnavailable = !isOnline || isAiDown || isNotConfigured;
+
+  // When the only reason the bubble is unavailable is a missing provider
+  // (online + tier reachable), render it as a link to the account settings so
+  // the CTA is actionable rather than a dead button.
+  const linksToSettings = isNotConfigured && isOnline && !isAiDown;
+
+  const bubbleClassName = cn(
+    "fixed bottom-6 right-6 z-30 inline-flex items-center justify-center",
+    "h-14 w-14 rounded-full bg-brand-fill text-white shadow-lg",
+    "hover:bg-brand-fill-hover transition-transform hover:scale-105",
+    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-hover focus-visible:ring-offset-2",
+    isUnavailable &&
+      !linksToSettings &&
+      "cursor-not-allowed opacity-60 hover:scale-100 hover:bg-brand-fill",
+    linksToSettings && "opacity-80",
+  );
+
+  const title = !isOnline
+    ? tOffline("label")
+    : isAiDown
+      ? t("unavailableTitle")
+      : isNotConfigured
+        ? t("notConfiguredTitle")
+        : undefined;
 
   return (
     <>
-      <button
-        type="button"
-        onClick={isUnavailable ? undefined : handleToggle}
-        aria-disabled={isUnavailable}
-        aria-label={isBubbleOpen ? t("closeAria") : t("openAria")}
-        aria-expanded={isBubbleOpen}
-        aria-controls="ai-chat-panel"
-        data-testid="ai-bubble"
-        data-open={isBubbleOpen || undefined}
-        data-offline={!isOnline || undefined}
-        data-ai-down={(isOnline && isAiDown) || undefined}
-        title={
-          !isOnline
-            ? tOffline("label")
-            : isAiDown
-              ? t("unavailableTitle")
-              : undefined
-        }
-        className={cn(
-          "fixed bottom-6 right-6 z-30 inline-flex items-center justify-center",
-          "h-14 w-14 rounded-full bg-brand-fill text-white shadow-lg",
-          "hover:bg-brand-fill-hover transition-transform hover:scale-105",
-          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-hover focus-visible:ring-offset-2",
-          isUnavailable &&
-            "cursor-not-allowed opacity-60 hover:scale-100 hover:bg-brand-fill",
-        )}
-      >
-        <Sparkles className="h-6 w-6" aria-hidden="true" />
-        {!isOnline && <ChatOfflineBadge />}
-        {isOnline && !isAiDown && !hasSeenBubble && (
-          <span
-            data-testid="ai-bubble-badge"
-            className={cn(
-              "absolute -top-1 -right-1 inline-flex items-center justify-center",
-              "rounded-full bg-red-500 text-white text-[10px] font-semibold",
-              "px-1.5 py-0.5 shadow-sm",
-            )}
-          >
-            {t("newBadge")}
-          </span>
-        )}
-        <span className="sr-only">{t("label")}</span>
-      </button>
+      {linksToSettings ? (
+        <Link
+          href="/account/settings#ai"
+          aria-label={t("notConfiguredTitle")}
+          data-testid="ai-bubble"
+          data-not-configured
+          title={title}
+          className={bubbleClassName}
+        >
+          <Sparkles className="h-6 w-6" aria-hidden="true" />
+          <span className="sr-only">{t("label")}</span>
+        </Link>
+      ) : (
+        <button
+          type="button"
+          onClick={isUnavailable ? undefined : handleToggle}
+          aria-disabled={isUnavailable}
+          aria-label={isBubbleOpen ? t("closeAria") : t("openAria")}
+          aria-expanded={isBubbleOpen}
+          aria-controls="ai-chat-panel"
+          data-testid="ai-bubble"
+          data-open={isBubbleOpen || undefined}
+          data-offline={!isOnline || undefined}
+          data-ai-down={(isOnline && isAiDown) || undefined}
+          title={title}
+          className={bubbleClassName}
+        >
+          <Sparkles className="h-6 w-6" aria-hidden="true" />
+          {!isOnline && <ChatOfflineBadge />}
+          {isOnline && !isAiDown && !hasSeenBubble && (
+            <span
+              data-testid="ai-bubble-badge"
+              className={cn(
+                "absolute -top-1 -right-1 inline-flex items-center justify-center",
+                "rounded-full bg-red-500 text-white text-[10px] font-semibold",
+                "px-1.5 py-0.5 shadow-sm",
+              )}
+            >
+              {t("newBadge")}
+            </span>
+          )}
+          <span className="sr-only">{t("label")}</span>
+        </button>
+      )}
 
-      {isBubbleOpen && <AiChatPanel onClose={closeBubble} />}
+      {isBubbleOpen && !isUnavailable && <AiChatPanel onClose={closeBubble} />}
     </>
   );
 }

--- a/pwa/src/components/ai-refinement-card.tsx
+++ b/pwa/src/components/ai-refinement-card.tsx
@@ -40,6 +40,11 @@ interface AiRefinementCardProps {
    * disabled and an explicit "unavailable" notice is shown inline.
    */
   unavailable?: boolean;
+  /**
+   * When `true`, AI is enabled but no provider is configured on the account
+   * (ADR-042): the card is disabled-but-visible with a "Configurez une IA" CTA.
+   */
+  notConfigured?: boolean;
   className?: string;
 }
 
@@ -64,6 +69,7 @@ export function AiRefinementCard({
   onApply,
   disabled = false,
   unavailable = false,
+  notConfigured = false,
   className,
 }: AiRefinementCardProps) {
   const t = useTranslations("aiRefinement");
@@ -72,7 +78,7 @@ export function AiRefinementCard({
   const [suggestion, setSuggestion] = useState("");
   const [isApplying, setIsApplying] = useState(false);
 
-  const isDisabled = disabled || unavailable;
+  const isDisabled = disabled || unavailable || notConfigured;
   const trimmed = suggestion.trim();
   const remaining = MAX_SUGGESTION_LENGTH - suggestion.length;
   const canApply = trimmed.length > 0 && !isApplying && !isDisabled;
@@ -131,7 +137,11 @@ export function AiRefinementCard({
         </p>
       </CardHeader>
       <CardContent className="space-y-3">
-        {unavailable && <AiUnavailableNotice context="refinement" />}
+        {notConfigured ? (
+          <AiUnavailableNotice variant="notConfigured" context="refinement" />
+        ) : (
+          unavailable && <AiUnavailableNotice context="refinement" />
+        )}
         <label htmlFor={textareaId} className="sr-only">
           {t("textareaLabel")}
         </label>

--- a/pwa/src/components/ai-unavailable-notice.tsx
+++ b/pwa/src/components/ai-unavailable-notice.tsx
@@ -1,24 +1,58 @@
 "use client";
 
+import Link from "next/link";
 import { useTranslations } from "next-intl";
-import { CloudOff } from "lucide-react";
+import { CloudOff, Sparkles } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 /**
- * Discreet inline notice shown when the AI tier is enabled but unreachable
- * (explicit degraded mode, #304). Surfaces the outage instead of silently
- * dropping the AI-driven feature. Used by the Acte 3 analysis zone and the
- * refinement card; the chat bubble conveys the same state via its disabled
- * affordance + title.
+ * Discreet inline notice shown when an AI surface cannot be used.
+ *
+ * Two flavours:
+ * - `outage` (default): the AI tier is enabled but unreachable (explicit
+ *   degraded mode, #304) — surfaces the outage instead of silently dropping
+ *   the AI-driven feature.
+ * - `notConfigured` (ADR-042): AI is enabled but the account has no provider +
+ *   token set — surfaces a "Configurez une IA" CTA linking to the account
+ *   settings so the disabled-but-visible control is actionable.
+ *
+ * Used by the Acte 3 analysis zone, the refinement card and the AI card; the
+ * chat bubble conveys the same state via its disabled affordance + title.
  */
 export function AiUnavailableNotice({
   context = "analysis",
+  variant = "outage",
   className,
 }: {
   context?: "analysis" | "refinement" | "chat";
+  variant?: "outage" | "notConfigured";
   className?: string;
 }) {
   const t = useTranslations("aiUnavailable");
+
+  if (variant === "notConfigured") {
+    return (
+      <div
+        data-testid="ai-not-configured-notice"
+        className={cn(
+          "flex flex-col gap-2 rounded-md border border-brand/30 bg-brand/5 px-3 py-2 text-sm text-foreground",
+          className,
+        )}
+      >
+        <span className="flex items-center gap-2">
+          <Sparkles className="h-4 w-4 shrink-0 text-brand" aria-hidden="true" />
+          <span>{t("notConfigured")}</span>
+        </span>
+        <Link
+          href="/account/settings#ai"
+          className="self-start text-sm font-medium text-brand hover:underline"
+          data-testid="ai-configure-cta"
+        >
+          {t("configureCta")}
+        </Link>
+      </div>
+    );
+  }
 
   return (
     <div

--- a/pwa/src/components/ai-unavailable-notice.tsx
+++ b/pwa/src/components/ai-unavailable-notice.tsx
@@ -40,7 +40,10 @@ export function AiUnavailableNotice({
         )}
       >
         <span className="flex items-center gap-2">
-          <Sparkles className="h-4 w-4 shrink-0 text-brand" aria-hidden="true" />
+          <Sparkles
+            className="h-4 w-4 shrink-0 text-brand"
+            aria-hidden="true"
+          />
           <span>{t("notConfigured")}</span>
         </span>
         <Link

--- a/pwa/src/components/card-selection.tsx
+++ b/pwa/src/components/card-selection.tsx
@@ -116,13 +116,16 @@ export function CardSelection({
         )}
 
         {/* Card: AI Assistant — multi-turn chat shell (#392). Gated on AI
-            availability (#304): hidden when AI is off by config, disabled with
-            an inline notice when enabled but the LLM tier is unreachable. */}
+            availability: hidden when AI is off by config (#304), disabled with
+            an inline notice when enabled but the LLM tier is unreachable, or
+            disabled-but-visible with a "Configurez une IA" CTA when no provider
+            is set on the account (ADR-042). */}
         {aiCapability.enabled && (selected === null || selected === "ai") && (
           <AiCard
             expanded={selected === "ai"}
             disabled={disabled}
             unavailable={!aiCapability.available}
+            notConfigured={!aiCapability.configured}
             onSelect={() => handleSelect("ai")}
             onSubmitConversation={onSubmitAiConversation}
           />
@@ -397,6 +400,7 @@ interface AiCardProps {
   expanded: boolean;
   disabled: boolean;
   unavailable?: boolean;
+  notConfigured?: boolean;
   onSelect: () => void;
   onSubmitConversation?: (messages: ReadonlyArray<AiChatMessage>) => void;
 }
@@ -405,6 +409,7 @@ function AiCard({
   expanded,
   disabled,
   unavailable = false,
+  notConfigured = false,
   onSelect,
   onSubmitConversation,
 }: AiCardProps) {
@@ -415,13 +420,15 @@ function AiCard({
       testId="card-ai"
       ariaLabel={t("ariaSelectAi")}
       expanded={expanded}
-      disabled={disabled || unavailable}
+      disabled={disabled || unavailable || notConfigured}
       onSelect={onSelect}
       icon={<Sparkles className="h-6 w-6" aria-hidden="true" />}
       title={t("aiTitle")}
       description={t("aiDescription")}
     >
-      {unavailable ? (
+      {notConfigured ? (
+        <AiUnavailableNotice variant="notConfigured" context="chat" />
+      ) : unavailable ? (
         <AiUnavailableNotice context="chat" />
       ) : (
         expanded && (

--- a/pwa/src/components/trip-planner.tsx
+++ b/pwa/src/components/trip-planner.tsx
@@ -23,6 +23,7 @@ import { TripAiOverview } from "@/components/trip-ai-overview";
 import { AiUnavailableNotice } from "@/components/ai-unavailable-notice";
 import { TripHeader } from "@/components/trip-header";
 import { AiBubble } from "@/components/ai-bubble";
+import { useAiSettings } from "@/hooks/use-ai-settings";
 import { RoadbookMasterDetail } from "@/components/Timeline";
 import { ConfigPanel } from "@/components/config-panel";
 import { HelpModal } from "@/components/help-modal";
@@ -148,6 +149,7 @@ export function TripPlanner({
   const isAnalysisPhaseActive = useUiStore((s) => s.isAnalysisPhaseActive);
   const aiEnabled = useUiStore((s) => s.aiCapability.enabled);
   const aiAvailable = useUiStore((s) => s.aiCapability.available);
+  const aiConfigured = useUiStore((s) => s.aiCapability.configured);
   const setAiAvailable = useUiStore((s) => s.setAiAvailable);
 
   // Probe the LLM tier once on mount so AI features can be gated explicitly when it
@@ -162,6 +164,10 @@ export function TripPlanner({
       cancelled = true;
     };
   }, [aiEnabled, setAiAvailable]);
+
+  // Sync the `configured` signal from the account (ADR-042): AI surfaces stay
+  // disabled-but-visible until a provider + token is set.
+  useAiSettings();
 
   const activeStages = useMemo(
     () => stages.filter((s) => !s.isRestDay),
@@ -245,9 +251,21 @@ export function TripPlanner({
     };
     const onSetAiCapability = (e: Event) => {
       const detail = (
-        e as CustomEvent<{ enabled: boolean; available: boolean }>
+        e as CustomEvent<{
+          enabled: boolean;
+          available: boolean;
+          configured?: boolean;
+        }>
       ).detail;
-      if (detail) useUiStore.getState().setAiCapability(detail);
+      if (detail) {
+        // `configured` defaults to true so the pre-ADR-042 capability tests
+        // (which only drive enabled/available) keep exercising the active path.
+        useUiStore.getState().setAiCapability({
+          enabled: detail.enabled,
+          available: detail.available,
+          configured: detail.configured ?? true,
+        });
+      }
     };
     window.addEventListener("__test_set_ai_capability", onSetAiCapability);
     window.addEventListener("__test_set_processing", onProcessing);
@@ -685,8 +703,14 @@ export function TripPlanner({
                   silently when the LLM pipeline is disabled or did not produce
                   an overview. Placed above the stage timeline so it gives the
                   user a high-level view before they dive into per-stage data. */}
-              {aiEnabled && !aiAvailable && (
-                <AiUnavailableNotice context="analysis" />
+              {aiEnabled && !aiConfigured ? (
+                <AiUnavailableNotice
+                  variant="notConfigured"
+                  context="analysis"
+                />
+              ) : (
+                aiEnabled &&
+                !aiAvailable && <AiUnavailableNotice context="analysis" />
               )}
               <TripAiOverview />
 

--- a/pwa/src/hooks/use-ai-settings.ts
+++ b/pwa/src/hooks/use-ai-settings.ts
@@ -1,0 +1,30 @@
+"use client";
+
+import { useEffect } from "react";
+import { fetchAiSettings } from "@/lib/api/client";
+import { useUiStore } from "@/store/ui-store";
+
+/**
+ * Sync the `configured` AI-capability signal from the account (ADR-042).
+ *
+ * Reads `GET /users/me/ai-settings` once on mount and flips
+ * `aiCapability.configured` to whether a provider is set. AI surfaces stay
+ * disabled-but-visible (with a "Configurez une IA" CTA) until this confirms a
+ * configured provider. No network call at all when AI is disabled by build
+ * config (`AI_ENABLED`).
+ */
+export function useAiSettings(): void {
+  const aiEnabled = useUiStore((s) => s.aiCapability.enabled);
+  const setAiConfigured = useUiStore((s) => s.setAiConfigured);
+
+  useEffect(() => {
+    if (!aiEnabled) return;
+    let cancelled = false;
+    void fetchAiSettings().then((settings) => {
+      if (!cancelled) setAiConfigured(Boolean(settings?.provider));
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [aiEnabled, setAiConfigured]);
+}

--- a/pwa/src/lib/api/client.ts
+++ b/pwa/src/lib/api/client.ts
@@ -782,6 +782,85 @@ export async function deleteAccount(): Promise<boolean> {
 }
 
 /**
+ * Per-user AI configuration (ADR-042): the cloud provider chosen for the
+ * bring-your-own-token model. Mirrors `App\Llm\AiProvider`. Kept as a const
+ * tuple so the settings dropdown and the typed payloads stay in lockstep.
+ */
+export const AI_PROVIDERS = ["anthropic", "gemini", "openai"] as const;
+export type AiProvider = (typeof AI_PROVIDERS)[number];
+
+/**
+ * Shape of `GET /users/me/ai-settings` (`App\ApiResource\Account\AiSettings`).
+ *
+ * Declared locally until `make typegen` ingests the schema change introduced by
+ * ADR-042 — the resource is absent from the current generated `schema.d.ts`
+ * (the spec export needs the backend DB, unavailable at build time here). Once
+ * the typegen catches up this can be swapped for
+ * `components["schemas"]["AiSettings.jsonld"]`.
+ *
+ * `provider` is omitted from the payload when AI is unconfigured, hence
+ * optional/null here.
+ */
+export interface AiSettingsResponse {
+  provider?: AiProvider | null;
+  tokenConfigured: boolean;
+}
+
+/**
+ * Fetch the current user's AI settings. Returns `null` on any failure so the
+ * caller treats a transient error as "unconfigured" (fail-closed: AI surfaces
+ * stay disabled-but-visible until the settings load confirms a provider).
+ */
+export async function fetchAiSettings(): Promise<AiSettingsResponse | null> {
+  const res = await apiFetch(`${API_URL}/users/me/ai-settings`, {
+    headers: { Accept: "application/ld+json" },
+  });
+  if (!res.ok) return null;
+  return res.json() as Promise<AiSettingsResponse>;
+}
+
+/**
+ * Persist the user's AI provider + token (`PUT /users/me/ai-settings`). The
+ * token is write-only — the response never echoes it back.
+ *
+ * @returns the updated settings on 200, or the parsed {@link ApiError} on 422
+ * (structured `violations[]` for blank/unknown provider or blank token; a
+ * `detail`-only message for an invalid token format).
+ */
+export async function saveAiSettings(
+  provider: string,
+  token: string,
+): Promise<
+  | { data: AiSettingsResponse; error: null }
+  | { data: null; error: ApiError }
+> {
+  const res = await apiFetch(`${API_URL}/users/me/ai-settings`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/ld+json",
+      Accept: "application/ld+json",
+    },
+    body: JSON.stringify({ provider, token }),
+  });
+  if (res.ok) {
+    return { data: (await res.json()) as AiSettingsResponse, error: null };
+  }
+  const body = (await res.json().catch(() => null)) as unknown;
+  return { data: null, error: parseApiError(res.status, body) };
+}
+
+/**
+ * Clear the user's AI settings (`DELETE /users/me/ai-settings`).
+ * @returns true on HTTP 204, false otherwise.
+ */
+export async function clearAiSettings(): Promise<boolean> {
+  const res = await apiFetch(`${API_URL}/users/me/ai-settings`, {
+    method: "DELETE",
+  });
+  return res.ok;
+}
+
+/**
  * Build the frontend share URL from a short code.
  */
 export function buildShareUrl(shortCode: string): string {

--- a/pwa/src/store/ui-store.ts
+++ b/pwa/src/store/ui-store.ts
@@ -175,13 +175,20 @@ interface UiState {
    */
   hasSeenBubble: boolean;
   /**
-   * AI tier availability driving the explicit degraded-mode gating (#304).
+   * AI tier availability driving the explicit gating (#304, ADR-042).
    * - `enabled`: build-time config (`AI_ENABLED`); when false, AI features are hidden.
    * - `available`: runtime reachability of the LLM tier, read from `/api/health`
    *   (`deps.ollama_chat`). Starts optimistic (`true`) to avoid a disabled→enabled
-   *   flash; flipped to `false` only once an outage is confirmed.
+   *   flash; flipped to `false` only once an outage is confirmed. For the
+   *   bring-your-own-token cloud providers (ADR-042) there is no self-hosted tier
+   *   to probe, so this stays `true`.
+   * - `configured`: whether the account has an AI provider + token set
+   *   (`GET /users/me/ai-settings`). When false, AI surfaces are shown
+   *   disabled-but-visible with a "Configurez une IA" CTA. Starts `false`
+   *   (fail-closed) so the controls stay disabled until the settings confirm
+   *   a provider.
    */
-  aiCapability: { enabled: boolean; available: boolean };
+  aiCapability: { enabled: boolean; available: boolean; configured: boolean };
 
   setProcessing: (value: boolean) => void;
   setAccommodationScanning: (value: boolean) => void;
@@ -244,10 +251,13 @@ interface UiState {
   setChatSending: (value: boolean) => void;
   /** Update the runtime AI availability (from the `/api/health` probe, #304). */
   setAiAvailable: (value: boolean) => void;
-  /** Replace the whole AI capability — E2E override hook for the 3 states (#304). */
+  /** Update whether the account has a configured AI provider (ADR-042). */
+  setAiConfigured: (value: boolean) => void;
+  /** Replace the whole AI capability — E2E override hook for the states. */
   setAiCapability: (capability: {
     enabled: boolean;
     available: boolean;
+    configured: boolean;
   }) => void;
 }
 
@@ -323,7 +333,7 @@ export const useUiStore = create<UiState>()(
     currentContext: { currentStage: null },
     isChatSending: false,
     hasSeenBubble: readBubbleSeenFromStorage(),
-    aiCapability: { enabled: AI_ENABLED, available: true },
+    aiCapability: { enabled: AI_ENABLED, available: true, configured: false },
 
     setProcessing: (value) =>
       set((state) => {
@@ -491,6 +501,11 @@ export const useUiStore = create<UiState>()(
     setAiAvailable: (value) =>
       set((state) => {
         state.aiCapability.available = value;
+      }),
+
+    setAiConfigured: (value) =>
+      set((state) => {
+        state.aiCapability.configured = value;
       }),
 
     setAiCapability: (capability) =>

--- a/pwa/tests/fixtures/api-mocks.ts
+++ b/pwa/tests/fixtures/api-mocks.ts
@@ -17,6 +17,13 @@ export interface MockApiOptions {
    * (bubble, chat) keep passing; set `false` to exercise the degraded mode (#304).
    */
   aiAvailable?: boolean;
+  /**
+   * Whether the account has a configured AI provider, surfaced by the mocked
+   * `GET /users/me/ai-settings` (ADR-042). Defaults to `true` so existing AI
+   * specs (bubble, chat, generation card) keep exercising the active path; set
+   * `false` to exercise the disabled-but-visible "not configured" affordances.
+   */
+  aiConfigured?: boolean;
 }
 
 const TRIP_ID = "test-trip-abc-123";
@@ -52,6 +59,7 @@ export async function mockAllApis(
     deleteStageFail = false,
     addStageFail = false,
     aiAvailable = true,
+    aiConfigured = true,
   } = options;
 
   // POST /auth/refresh — return fake JWT so AuthGuard's silentRefresh succeeds
@@ -84,6 +92,22 @@ export async function mockAllApis(
           ollama_analysis: { status: ollamaStatus },
         },
       }),
+    });
+  });
+
+  // GET /users/me/ai-settings — per-user AI config the PWA reads to gate AI
+  // surfaces (ADR-042). `aiConfigured` toggles whether a provider is set; the
+  // token is never echoed back (write-only).
+  await page.route("**/users/me/ai-settings", (route, request) => {
+    if (request.method() !== "GET") return route.fallback();
+    return route.fulfill({
+      status: 200,
+      contentType: "application/ld+json",
+      body: JSON.stringify(
+        aiConfigured
+          ? { provider: "anthropic", tokenConfigured: true }
+          : { tokenConfigured: false },
+      ),
     });
   });
 

--- a/pwa/tests/mocked/account-settings.spec.ts
+++ b/pwa/tests/mocked/account-settings.spec.ts
@@ -314,9 +314,7 @@ test.describe("AI provider settings (ADR-042)", () => {
     await page.goto("/account/settings");
     await page.waitForLoadState("networkidle");
 
-    await page
-      .getByTestId("ai-provider-select")
-      .selectOption("openai");
+    await page.getByTestId("ai-provider-select").selectOption("openai");
     await page.getByTestId("ai-token-input").fill("sk-test-key");
     await page.getByTestId("ai-settings-save").click();
 
@@ -351,9 +349,7 @@ test.describe("AI provider settings (ADR-042)", () => {
     await page.goto("/account/settings");
     await page.waitForLoadState("networkidle");
 
-    await page
-      .getByTestId("ai-provider-select")
-      .selectOption("anthropic");
+    await page.getByTestId("ai-provider-select").selectOption("anthropic");
     await page.getByTestId("ai-token-input").fill("bad");
     await page.getByTestId("ai-settings-save").click();
 

--- a/pwa/tests/mocked/account-settings.spec.ts
+++ b/pwa/tests/mocked/account-settings.spec.ts
@@ -20,9 +20,33 @@ async function mockAuthenticated(page: import("@playwright/test").Page) {
   await page.route("**/.well-known/mercure*", (route) => route.abort());
 }
 
+/**
+ * Mock GET /users/me/ai-settings (ADR-042). Defaults to unconfigured so the
+ * AI section renders its "not configured" baseline; pass `provider` to simulate
+ * an account that already has an AI provider set.
+ */
+async function mockAiSettingsGet(
+  page: import("@playwright/test").Page,
+  provider: string | null = null,
+) {
+  await page.route("**/users/me/ai-settings", (route, request) => {
+    if (request.method() !== "GET") return route.fallback();
+    return route.fulfill({
+      status: 200,
+      contentType: "application/ld+json",
+      body: JSON.stringify(
+        provider
+          ? { provider, tokenConfigured: true }
+          : { tokenConfigured: false },
+      ),
+    });
+  });
+}
+
 test.describe("Account settings", () => {
   test("renders all sections for an authenticated user", async ({ page }) => {
     await mockAuthenticated(page);
+    await mockAiSettingsGet(page);
 
     await page.goto("/account/settings");
     await page.waitForLoadState("networkidle");
@@ -30,6 +54,7 @@ test.describe("Account settings", () => {
     await expect(page.getByTestId("account-settings-page")).toBeVisible();
     await expect(page.getByTestId("account-section")).toBeVisible();
     await expect(page.getByTestId("preferences-section")).toBeVisible();
+    await expect(page.getByTestId("ai-provider-section")).toBeVisible();
     await expect(page.getByTestId("data-section")).toBeVisible();
     await expect(page.getByTestId("danger-zone-section")).toBeVisible();
     await expect(page.getByTestId("logout-section")).toBeVisible();
@@ -241,5 +266,123 @@ test.describe("Account settings", () => {
     await expect(button).toBeEnabled();
     // URL must not change — user stays on the settings page.
     await expect(page).toHaveURL(/\/account\/settings$/);
+  });
+});
+
+test.describe("AI provider settings (ADR-042)", () => {
+  test("loads the current provider + token-configured indicator", async ({
+    page,
+  }) => {
+    await mockAuthenticated(page);
+    await mockAiSettingsGet(page, "anthropic");
+
+    await page.goto("/account/settings");
+    await page.waitForLoadState("networkidle");
+
+    await expect(page.getByTestId("ai-provider-select")).toHaveValue(
+      "anthropic",
+    );
+    await expect(page.getByTestId("ai-token-status")).toHaveText(
+      "Une clé API est enregistrée.",
+    );
+    // The token itself is never returned, so the input stays empty.
+    await expect(page.getByTestId("ai-token-input")).toHaveValue("");
+    // RGPD disclosure is always shown.
+    await expect(page.getByTestId("ai-settings-rgpd")).toBeVisible();
+  });
+
+  test("saving sends PUT and confirms the configured state", async ({
+    page,
+  }) => {
+    await mockAuthenticated(page);
+    await mockAiSettingsGet(page, null);
+
+    let putBody: Record<string, unknown> | null = null;
+    await page.route("**/users/me/ai-settings", (route, request) => {
+      if (request.method() !== "PUT") return route.fallback();
+      putBody = JSON.parse(request.postData() ?? "{}") as Record<
+        string,
+        unknown
+      >;
+      return route.fulfill({
+        status: 200,
+        contentType: "application/ld+json",
+        body: JSON.stringify({ provider: "openai", tokenConfigured: true }),
+      });
+    });
+
+    await page.goto("/account/settings");
+    await page.waitForLoadState("networkidle");
+
+    await page
+      .getByTestId("ai-provider-select")
+      .selectOption("openai");
+    await page.getByTestId("ai-token-input").fill("sk-test-key");
+    await page.getByTestId("ai-settings-save").click();
+
+    await expect.poll(() => putBody).toEqual({
+      provider: "openai",
+      token: "sk-test-key",
+    });
+    await expect(page.getByTestId("ai-token-status")).toHaveText(
+      "Une clé API est enregistrée.",
+    );
+    // Token is cleared from the input after a successful save.
+    await expect(page.getByTestId("ai-token-input")).toHaveValue("");
+  });
+
+  test("surfaces a 422 validation error inline", async ({ page }) => {
+    await mockAuthenticated(page);
+    await mockAiSettingsGet(page, null);
+
+    await page.route("**/users/me/ai-settings", (route, request) => {
+      if (request.method() !== "PUT") return route.fallback();
+      return route.fulfill({
+        status: 422,
+        contentType: "application/ld+json",
+        body: JSON.stringify({
+          violations: [
+            { propertyPath: "token", message: "Invalid token format." },
+          ],
+        }),
+      });
+    });
+
+    await page.goto("/account/settings");
+    await page.waitForLoadState("networkidle");
+
+    await page
+      .getByTestId("ai-provider-select")
+      .selectOption("anthropic");
+    await page.getByTestId("ai-token-input").fill("bad");
+    await page.getByTestId("ai-settings-save").click();
+
+    await expect(page.getByTestId("ai-settings-error")).toHaveText(
+      "Invalid token format.",
+    );
+  });
+
+  test("clearing sends DELETE and resets the form", async ({ page }) => {
+    await mockAuthenticated(page);
+    await mockAiSettingsGet(page, "gemini");
+
+    let deleteCalled = false;
+    await page.route("**/users/me/ai-settings", (route, request) => {
+      if (request.method() !== "DELETE") return route.fallback();
+      deleteCalled = true;
+      return route.fulfill({ status: 204, body: "" });
+    });
+
+    await page.goto("/account/settings");
+    await page.waitForLoadState("networkidle");
+
+    await expect(page.getByTestId("ai-provider-select")).toHaveValue("gemini");
+    await page.getByTestId("ai-settings-clear").click();
+
+    await expect.poll(() => deleteCalled).toBe(true);
+    await expect(page.getByTestId("ai-provider-select")).toHaveValue("");
+    await expect(page.getByTestId("ai-token-status")).toHaveText(
+      "Aucune clé API enregistrée.",
+    );
   });
 });

--- a/pwa/tests/mocked/ai-capabilities.spec.ts
+++ b/pwa/tests/mocked/ai-capabilities.spec.ts
@@ -15,7 +15,7 @@ import { mockAllApis } from "../fixtures/api-mocks";
 
 function setAiCapability(
   page: import("@playwright/test").Page,
-  capability: { enabled: boolean; available: boolean },
+  capability: { enabled: boolean; available: boolean; configured?: boolean },
 ): Promise<void> {
   return page.evaluate((detail) => {
     window.dispatchEvent(
@@ -132,5 +132,64 @@ test.describe("AI generation card gating (#304)", () => {
 
     await expect(page.getByTestId("card-ai")).toHaveCount(0);
     await expect(page.getByTestId("card-link")).toBeVisible();
+  });
+
+  test("no provider configured: the generation card is disabled-but-visible with a configure CTA", async ({
+    page,
+  }) => {
+    await mockAllApis(page, { aiConfigured: false });
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    const card = page.getByTestId("card-ai");
+    await expect(card).toBeVisible();
+    await expect(card).toHaveAttribute("data-disabled", "true");
+
+    // The disabled-but-visible affordance carries an actionable settings CTA.
+    const notice = page.getByTestId("ai-not-configured-notice");
+    await expect(notice).toBeVisible();
+    await expect(page.getByTestId("ai-configure-cta")).toHaveAttribute(
+      "href",
+      "/account/settings#ai",
+    );
+
+    // Disabled → a forced click must not expand the chat composer.
+    await card.click({ force: true });
+    await expect(page.getByTestId("ai-chat-card")).toHaveCount(0);
+  });
+});
+
+/**
+ * ADR-042 — disabled-but-visible AI surfaces in Acte 3 ("Mon voyage") when the
+ * account has no AI provider configured. The capability is driven via the test
+ * hook with `configured: false`.
+ */
+test.describe("AI not-configured gating (ADR-042)", () => {
+  // Drive the account GET so the `configured` capability resolves to false from
+  // the real `useAiSettings` fetch (no race with the test-hook dispatch).
+  test.use({ mockOptions: { aiConfigured: false } });
+
+  test("the chat bubble links to the settings instead of opening the panel", async ({
+    createFullTrip,
+    mockedPage,
+  }) => {
+    await createFullTrip();
+    await setAiCapability(mockedPage, {
+      enabled: true,
+      available: true,
+      configured: false,
+    });
+
+    const bubble = mockedPage.getByTestId("ai-bubble");
+    await expect(bubble).toBeVisible();
+    await expect(bubble).toHaveAttribute("data-not-configured", "");
+    await expect(bubble).toHaveAttribute("href", "/account/settings#ai");
+    // It must not open the chat panel.
+    await expect(mockedPage.getByTestId("ai-chat-panel")).toHaveCount(0);
+
+    // The Acte 3 analysis zone surfaces the configure CTA.
+    await expect(
+      mockedPage.getByTestId("ai-not-configured-notice"),
+    ).toBeVisible();
   });
 });


### PR DESCRIPTION
## Résumé

Chantier A5 d'ADR-042 (l'IA devient optionnelle + multi-provider, bring-your-own-token), côté frontend (`pwa/`).

### 1. Section « Assistant IA » du compte
Nouveau composant `pwa/src/components/account/ai-provider-section.tsx` ajouté à `/account/settings`, entre Préférences et Mes données :
- menu déroulant fournisseur (Anthropic / Google Gemini / OpenAI),
- champ clé API masqué (`type=password`), indicateur « clé enregistrée » (jamais la clé elle-même),
- boutons Enregistrer / Supprimer,
- au chargement, `GET /users/me/ai-settings` peuple le fournisseur courant + l'indicateur,
- Enregistrer → `PUT` (erreurs 422 affichées inline via `parseApiError`), Supprimer → `DELETE`,
- ligne de divulgation RGPD explicite.

Appels passés par le client typé : nouvelles fonctions `fetchAiSettings` / `saveAiSettings` / `clearAiSettings` dans `pwa/src/lib/api/client.ts`, suivant le pattern existant (interfaces déclarées localement en attendant que le typegen ingère la ressource — voir note ci-dessous).

### 2. Signal `configured`
`aiCapability` passe de `{ enabled, available }` à `{ enabled, available, configured }` (`store/ui-store.ts`).
- **Source du signal** : `GET /users/me/ai-settings` (provider non nul ?), via le hook `pwa/src/hooks/use-ai-settings.ts`, monté dans `TripPlanner` — **pas** `/health`.
- `enabled` = feature présente dans le build (`AI_ENABLED`) ; `available` ≈ true pour les providers cloud (pas de tier auto-hébergé à sonder) ; `configured` démarre à `false` (fail-closed).

### 3. Affordances disabled-but-visible + CTA « Configurer une IA »
Quand `!configured`, les contrôles IA restent **visibles mais désactivés** avec un CTA vers `/account/settings#ai` :
- `ai-unavailable-notice.tsx` : nouvelle variante `notConfigured` (CTA actionnable),
- `ai-bubble.tsx` : la bulle devient un lien vers les réglages au lieu d'ouvrir le panneau,
- `card-selection.tsx` (carte IA), `ai-refinement-card.tsx`, `trip-planner.tsx` (zone d'analyse Acte 3) : prop/branche `notConfigured`.

### RGPD
Divulgation explicite dans la section réglages : « Vos données de voyage (itinéraire, villes, dates) sont transmises au fournisseur choisi avec votre clé API. Consultez sa politique de confidentialité avant d'activer l'IA. »

## Tests
- E2E `tests/mocked/account-settings.spec.ts` : chargement de l'état, save (PUT), 422 inline, clear (DELETE).
- E2E `tests/mocked/ai-capabilities.spec.ts` : carte IA disabled-but-visible + CTA quand non configurée, bulle qui pointe vers les réglages.
- Fixtures `api-mocks.ts` : option `aiConfigured` + mock `GET /users/me/ai-settings`. Le hook de test `__test_set_ai_capability` défaut `configured: true` pour préserver les specs #304 existantes.

## Note typegen
`make typegen`/`openapigen` exportent l'OpenAPI via un conteneur PHP qui requiert la base de données (indispo en build isolé : `could not translate host name "database"`). Les types `AiSettings` sont donc déclarés manuellement dans `client.ts` (même pattern que les routes `chat`/`analyze` non encore régénérées), à remplacer par `components["schemas"]["AiSettings.jsonld"]` au prochain typegen.

## QA (sortie réelle)
Le volume `pwa_node_modules` du worktree était vide (gotcha connu) ; `make qa` échoue sur les legs PHP (`vendor/bin/php-cs-fixer` absent) avant d'atteindre le PWA. J'ai exécuté les legs PWA pertinents dans le conteneur `pwa` en bind-montant les `node_modules` du repo principal :

- **ESLint** sur les 14 fichiers modifiés → `EXIT=0` (aucun problème). Le run global ne remonte qu'une erreur React-Compiler préexistante dans `ai-chat-panel.tsx` (fichier **non touché** par cette branche) + warnings préexistants (`accommodation-item`, `event-item`, `use-tile-mode`).
- **tsc --noEmit** → aucune erreur sur aucun de mes fichiers `src/`/`app/`/`tests/` modifiés.
- **i18n-check** → `OK: 878 keys in sync across fr, en`.
- **Prettier** : non exécutable localement (package absent des `node_modules` disponibles) ; style manuel conforme (2-espaces, double-quotes, trailing commas, < 80 col). **Déféré à la CI.**

<!-- claude-review-start -->
## Claude Review

**Reviewed commit:** `af6b415`

Clean follow-up: the `data-not-configured=""` fix from commit 3 correctly resolves the only blocking issue found in the first pass. No new findings in the updated diff. The BYOT settings section is well-structured — fail-closed default, GDPR disclosure, write-only token handling, and discriminated-union error returns are all solid. The `setAiCapability` backward-compat default (`configured ?? true`) correctly keeps pre-ADR-042 E2E tests on the active path.

**Resolved threads:** Resolved 1 previously open thread (the `data-not-configured=""` attribute fix, now addressed in commit 3).

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Findings by severity

| Severity | Count |
|---|---|
| critical | 0 |
| warning | 0 |
| suggestion | 0 |

**No inline comments.**
<!-- claude-review-end -->