### PR TITLE
feat(ai): wire sync chat + in-ride to the user's provider

### DIFF
--- a/api/src/InRide/InRideAssistant.php
+++ b/api/src/InRide/InRideAssistant.php
@@ -7,8 +7,8 @@ namespace App\InRide;
 use App\ApiResource\Model\GeoPosition;
 use App\Geo\GeoDistanceInterface;
 use App\Geo\GeoPoint;
-use App\Llm\Exception\OllamaUnavailableException;
-use App\Llm\LlmClientInterface;
+use App\Llm\Exception\AiUnavailableException;
+use App\Llm\ResolvedLlmClient;
 use App\Llm\SystemPromptLoader;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
@@ -43,8 +43,6 @@ use Psr\Log\NullLogger;
  */
 final readonly class InRideAssistant
 {
-    public const string NARRATIVE_MODEL = 'llama3.2:3b';
-
     private const int MAX_SUGGESTIONS = 3;
 
     /**
@@ -62,7 +60,6 @@ final readonly class InRideAssistant
         private DetourCalculator $detourCalculator,
         private DeeplinkBuilder $deeplinkBuilder,
         private GeoDistanceInterface $distance,
-        private LlmClientInterface $llmClient,
         private SystemPromptLoader $promptLoader,
         private LoggerInterface $logger = new NullLogger(),
     ) {
@@ -74,10 +71,11 @@ final readonly class InRideAssistant
     public function assist(
         string $message,
         GeoPosition $position,
+        ResolvedLlmClient $resolved,
         array $remainingRoute = [],
         ?\DateTimeImmutable $now = null,
     ): InRideResponse {
-        $intent = $this->intentDetector->detect($message);
+        $intent = $this->intentDetector->detect($message, $resolved);
 
         if ($intent->isUnknown()) {
             return new InRideResponse(
@@ -107,7 +105,7 @@ final readonly class InRideAssistant
 
         $top = \array_slice($suggestions, 0, self::MAX_SUGGESTIONS);
 
-        $narrative = $this->generateNarrative($message, $intent, $top);
+        $narrative = $this->generateNarrative($message, $intent, $top, $resolved);
 
         return new InRideResponse(
             category: $intent->category,
@@ -259,7 +257,7 @@ final readonly class InRideAssistant
     /**
      * @param list<PoiSuggestion> $pois
      */
-    private function generateNarrative(string $message, PoiIntent $intent, array $pois): string
+    private function generateNarrative(string $message, PoiIntent $intent, array $pois, ResolvedLlmClient $resolved): string
     {
         if ([] === $pois) {
             return \sprintf(
@@ -295,19 +293,16 @@ final readonly class InRideAssistant
         }
 
         try {
-            $response = $this->llmClient->generate(
-                self::NARRATIVE_MODEL,
+            $response = $resolved->client->generate(
+                $resolved->provider->chatModel(),
                 $jsonPayload,
                 $systemPrompt,
-                [
-                    'temperature' => 0.3,
-                    'num_predict' => 400,
-                    'num_ctx' => 8192,
-                ],
+                ['temperature' => 0.3],
             );
-        } catch (OllamaUnavailableException $ollamaUnavailableException) {
-            $this->logger->critical('InRideAssistant: LLM unavailable for narrative, using fallback.', [
-                'error' => $ollamaUnavailableException->getMessage(),
+        } catch (AiUnavailableException $aiUnavailableException) {
+            $this->logger->critical('InRideAssistant: AI provider unavailable for narrative, using fallback.', [
+                'reason' => $aiUnavailableException->getReason()->value,
+                'error' => $aiUnavailableException->getMessage(),
             ]);
 
             return $this->fallbackNarrative($pois);

--- a/api/src/InRide/PoiIntentDetector.php
+++ b/api/src/InRide/PoiIntentDetector.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace App\InRide;
 
-use App\Llm\Exception\OllamaUnavailableException;
-use App\Llm\LlmClientInterface;
+use App\Llm\Exception\AiUnavailableException;
+use App\Llm\ResolvedLlmClient;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
@@ -29,8 +29,6 @@ use Psr\Log\NullLogger;
  */
 final readonly class PoiIntentDetector
 {
-    public const string MODEL = 'llama3.2:3b';
-
     public const int MIN_RADIUS_METERS = 2_000;
 
     public const int MAX_RADIUS_METERS = 5_000;
@@ -64,12 +62,11 @@ Rules:
 PROMPT;
 
     public function __construct(
-        private LlmClientInterface $llmClient,
         private LoggerInterface $logger = new NullLogger(),
     ) {
     }
 
-    public function detect(string $userMessage): PoiIntent
+    public function detect(string $userMessage, ResolvedLlmClient $resolved): PoiIntent
     {
         $message = trim($userMessage);
         if ('' === $message) {
@@ -77,19 +74,16 @@ PROMPT;
         }
 
         try {
-            $response = $this->llmClient->generate(
-                self::MODEL,
+            $response = $resolved->client->generate(
+                $resolved->provider->chatModel(),
                 $message,
                 self::SYSTEM_PROMPT,
-                [
-                    'temperature' => 0.0,
-                    'num_predict' => 50,
-                    'format' => 'json',
-                ],
+                ['temperature' => 0.0],
             );
-        } catch (OllamaUnavailableException $ollamaUnavailableException) {
-            $this->logger->critical('PoiIntentDetector: LLM unavailable, defaulting to unknown intent.', [
-                'error' => $ollamaUnavailableException->getMessage(),
+        } catch (AiUnavailableException $aiUnavailableException) {
+            $this->logger->critical('PoiIntentDetector: AI provider unavailable, defaulting to unknown intent.', [
+                'reason' => $aiUnavailableException->getReason()->value,
+                'error' => $aiUnavailableException->getMessage(),
             ]);
 
             return PoiIntent::unknown();

--- a/api/src/Llm/LlmClientFactory.php
+++ b/api/src/Llm/LlmClientFactory.php
@@ -18,7 +18,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  * since the token is per-user. Each provider's `symfony/ai-platform` bridge gets
  * the matching scoped HTTP client (timeout / User-Agent / SSRF scope).
  */
-final readonly class LlmClientFactory
+final readonly class LlmClientFactory implements UserLlmResolverInterface
 {
     public function __construct(
         private HttpClientInterface $anthropicClient,

--- a/api/src/Llm/UserLlmResolverInterface.php
+++ b/api/src/Llm/UserLlmResolverInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Llm;
+
+use App\Entity\User;
+
+/**
+ * Resolves the LLM client for a given user from their configured provider/token
+ * (ADR-042). Implemented by {@see LlmClientFactory}; the interface seam lets sync
+ * consumers (which resolve the current user via Security) depend on a mockable
+ * contract.
+ */
+interface UserLlmResolverInterface
+{
+    public function forUser(User $user): ?ResolvedLlmClient;
+}

--- a/api/src/State/TripChatProcessor.php
+++ b/api/src/State/TripChatProcessor.php
@@ -20,9 +20,11 @@ use App\InRide\PoiSuggestion;
 use App\Llm\ChatActionInterpreter;
 use App\Llm\ChatHistoryStore;
 use App\Llm\Dto\ChatAction;
-use App\Llm\Exception\OllamaUnavailableException;
-use App\Llm\LlmClientInterface;
+use App\Llm\Exception\AiFailureReason;
+use App\Llm\Exception\AiUnavailableException;
+use App\Llm\ResolvedLlmClient;
 use App\Llm\SystemPromptLoader;
+use App\Llm\UserLlmResolverInterface;
 use App\Message\RecalculateStages;
 use App\Repository\TripRequestRepositoryInterface;
 use Doctrine\ORM\EntityManagerInterface;
@@ -57,10 +59,6 @@ final readonly class TripChatProcessor implements ProcessorInterface
 {
     public const string PROMPT_NAME = 'dialogue';
 
-    public const string DEFAULT_MODEL = 'llama3.2:3b';
-
-    public const int MAX_RESPONSE_TOKENS = 600;
-
     /**
      * Actions that mutate the trip and therefore require backend recomputation.
      *
@@ -77,11 +75,9 @@ final readonly class TripChatProcessor implements ProcessorInterface
         ChatAction::ACTION_ADJUST_DISTANCE,
     ];
 
-    private string $model;
-
     public function __construct(
         private TripRequestRepositoryInterface $tripStateManager,
-        private LlmClientInterface $llmClient,
+        private UserLlmResolverInterface $clientFactory,
         private SystemPromptLoader $promptLoader,
         private ChatActionInterpreter $interpreter,
         private ChatHistoryStore $historyStore,
@@ -93,10 +89,7 @@ final readonly class TripChatProcessor implements ProcessorInterface
         #[Autowire(service: 'limiter.trip_chat')]
         private RateLimiterFactory $tripChatLimiter,
         private ?EntityManagerInterface $entityManager = null,
-        #[Autowire(env: 'default::OLLAMA_DIALOGUE_MODEL')]
-        ?string $model = null,
     ) {
-        $this->model = (null === $model || '' === $model) ? self::DEFAULT_MODEL : $model;
     }
 
     /**
@@ -124,10 +117,13 @@ final readonly class TripChatProcessor implements ProcessorInterface
         // operation's provider, it throws NotFoundHttpException before this
         // processor is entered. Don't re-read the cache here.
 
-        // Feature-flag guard before consuming a rate-limit token, so a user
-        // hitting a disabled endpoint doesn't burn their 20 req/min quota.
-        if (!$this->llmClient->isEnabled()) {
-            throw new ServiceUnavailableHttpException(retryAfter: null, message: 'AI assistant is currently disabled.');
+        // Resolve the user's provider before consuming a rate-limit token, so a
+        // user without AI configured doesn't burn their 20 req/min quota. When AI
+        // is not configured (or the kill-switch is off), degrade gracefully with an
+        // in-chat hint rather than a hard error.
+        $resolved = $this->clientFactory->forUser($user);
+        if (!$resolved instanceof ResolvedLlmClient) {
+            return $this->notConfiguredResponse($tripId);
         }
 
         $limiter = $this->tripChatLimiter->create($userId);
@@ -143,7 +139,7 @@ final readonly class TripChatProcessor implements ProcessorInterface
         // POI search mode. The planning pipeline (dialogue prompt, action
         // interpreter, Messenger dispatch) is bypassed entirely.
         if ($data->position instanceof GeoPosition) {
-            return $this->processInRide($user, $tripId, $userId, $data);
+            return $this->processInRide($user, $tripId, $userId, $data, $resolved);
         }
 
         $systemPrompt = $this->promptLoader->load(self::PROMPT_NAME);
@@ -153,22 +149,21 @@ final readonly class TripChatProcessor implements ProcessorInterface
         $messages = [...$history, ['role' => 'user', 'content' => $userMessage]];
 
         try {
-            $response = $this->llmClient->chat(
-                model: $this->model,
+            // JSON is requested via the dialogue system prompt and parsed leniently
+            // by ChatActionInterpreter — no provider-specific format option.
+            $response = $resolved->client->chat(
+                model: $resolved->provider->chatModel(),
                 messages: $messages,
                 systemPrompt: $systemPrompt,
-                options: [
-                    'format' => 'json',
-                    'num_predict' => self::MAX_RESPONSE_TOKENS,
-                ],
             );
-        } catch (OllamaUnavailableException $ollamaUnavailableException) {
-            $this->logger->critical('Ollama unreachable — chat endpoint returning 503.', [
+        } catch (AiUnavailableException $aiUnavailableException) {
+            $this->logger->critical('AI provider unreachable — chat endpoint returning 503.', [
                 'tripId' => $tripId,
-                'error' => $ollamaUnavailableException->getMessage(),
+                'reason' => $aiUnavailableException->getReason()->value,
+                'error' => $aiUnavailableException->getMessage(),
             ]);
 
-            throw new ServiceUnavailableHttpException(retryAfter: null, message: 'AI assistant is temporarily unavailable. Please retry shortly.', previous: $ollamaUnavailableException);
+            throw new ServiceUnavailableHttpException(retryAfter: $aiUnavailableException->getRetryAfter(), message: $this->unavailableMessage($aiUnavailableException), previous: $aiUnavailableException);
         }
 
         if (null === $response) {
@@ -221,6 +216,32 @@ final readonly class TripChatProcessor implements ProcessorInterface
             impactedStageNumbers: $impactedStageNumbers,
             requiresFullAnalysis: $requiresFullAnalysis,
         );
+    }
+
+    /**
+     * Graceful in-chat reply when the user has not configured an AI provider:
+     * an `info` action carrying a hint that links the rider to the settings.
+     */
+    private function notConfiguredResponse(string $tripId): TripChatResponse
+    {
+        return new TripChatResponse(
+            tripId: $tripId,
+            action: ChatAction::ACTION_INFO,
+            params: [],
+            response: "Configurez une IA dans vos réglages pour discuter avec l'assistant et obtenir une analyse plus approfondie.",
+        );
+    }
+
+    /**
+     * Maps a provider failure to a rider-facing message keyed on its reason.
+     */
+    private function unavailableMessage(AiUnavailableException $exception): string
+    {
+        return match ($exception->getReason()) {
+            AiFailureReason::INVALID_TOKEN => 'Votre clé IA semble invalide. Vérifiez-la dans vos réglages.',
+            AiFailureReason::QUOTA_EXCEEDED => 'Le quota de votre offre IA est épuisé. Vérifiez votre compte chez le fournisseur.',
+            default => 'Assistant IA temporairement indisponible. Réessayez dans un instant.',
+        };
     }
 
     /**
@@ -356,16 +377,16 @@ final readonly class TripChatProcessor implements ProcessorInterface
      * a response carrying the `find_poi` action together with the structured
      * POI suggestions.
      */
-    private function processInRide(User $user, string $tripId, string $userId, TripChatRequest $data): TripChatResponse
+    private function processInRide(User $user, string $tripId, string $userId, TripChatRequest $data, ResolvedLlmClient $resolved): TripChatResponse
     {
         \assert($data->position instanceof GeoPosition);
 
-        // InRideAssistant::assist() already catches OllamaUnavailableException
-        // and produces a markdown fallback narrative, so we do not re-wrap it
-        // here.
+        // InRideAssistant::assist() already catches AiUnavailableException and
+        // produces a markdown fallback narrative, so we do not re-wrap it here.
         $response = $this->inRideAssistant->assist(
             message: $data->message,
             position: $data->position,
+            resolved: $resolved,
         );
 
         $this->historyStore->appendMany($tripId, $userId, [

--- a/api/src/State/TripChatProcessor.php
+++ b/api/src/State/TripChatProcessor.php
@@ -39,19 +39,21 @@ use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\RateLimiter\RateLimiterFactory;
 
 /**
- * Handles `POST /trips/{id}/chat`: orchestrates the LLaMA 3B dialogue assistant.
+ * Handles `POST /trips/{id}/chat`: orchestrates the AI dialogue assistant using
+ * the trip owner's configured provider (ADR-042).
  *
  * Pipeline:
- * 1. Enforce a per-user rate limit (20 req/min) to protect the local LLM.
+ * 1. Resolve the user's provider; enforce a per-user rate limit (20 req/min).
  * 2. Verify the trip exists; load minimal context for the dialogue prompt.
  * 3. Build the chat history (last {@see ChatHistoryStore::MAX_MESSAGES} turns)
- *    plus the new user message, and call {@see LlmClientInterface::chat()}.
+ *    plus the new user message, and call the resolved client's `chat()`.
  * 4. Parse the JSON envelope into a {@see ChatAction} via {@see ChatActionInterpreter}.
- * 5. Flag the response as `dispatched` for actions that require recomputation
- *    (the actual Messenger wiring is delivered by a follow-up issue).
+ * 5. Flag the response as `dispatched` for actions that require recomputation.
  *
- * When the LLM is disabled or unreachable, the endpoint returns 503 so the
- * frontend can show a clear error instead of a vague fallback message.
+ * Degradation: when AI is not configured (or the AI_ENABLED kill-switch is off)
+ * the endpoint returns 200 with an `info` action hinting the rider to configure
+ * a provider; when the configured provider is unreachable it returns 503 with a
+ * reason-aware message so the frontend can react precisely.
  *
  * @implements ProcessorInterface<TripChatRequest, TripChatResponse>
  */
@@ -172,7 +174,7 @@ final readonly class TripChatProcessor implements ProcessorInterface
 
         $rawContent = $this->extractText($response);
         if (null === $rawContent) {
-            $this->logger->warning('Ollama chat response missing message content.', ['tripId' => $tripId]);
+            $this->logger->warning('AI chat response missing message content.', ['tripId' => $tripId]);
 
             throw new ServiceUnavailableHttpException(retryAfter: null, message: 'AI assistant returned an invalid response. Please retry.');
         }

--- a/api/tests/Functional/TripChatTest.php
+++ b/api/tests/Functional/TripChatTest.php
@@ -8,8 +8,11 @@ use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
 use ApiPlatform\Symfony\Bundle\Test\Client;
 use App\ApiResource\TripRequest;
 use App\Entity\User;
-use App\Llm\Exception\OllamaUnavailableException;
+use App\Llm\AiProvider;
+use App\Llm\Exception\AiUnavailableException;
 use App\Llm\LlmClientInterface;
+use App\Llm\ResolvedLlmClient;
+use App\Llm\UserLlmResolverInterface;
 use App\Repository\TripRequestRepositoryInterface;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\Uid\Uuid;
@@ -50,9 +53,24 @@ final class TripChatTest extends ApiTestCase
         $this->associateTripWithUser($tripId, $this->testUser);
     }
 
-    private function installFakeLlmClient(LlmClientInterface $client): void
+    /**
+     * Overrides the per-user resolver: a non-null client is wrapped as the
+     * user's configured provider; null simulates "AI not configured".
+     */
+    private function installLlmClient(?LlmClientInterface $client): void
     {
-        self::getContainer()->set(LlmClientInterface::class, $client);
+        $resolver = new readonly class ($client) implements UserLlmResolverInterface {
+            public function __construct(private ?LlmClientInterface $client)
+            {
+            }
+
+            public function forUser(User $user): ?ResolvedLlmClient
+            {
+                return $this->client instanceof LlmClientInterface ? new ResolvedLlmClient($this->client, AiProvider::ANTHROPIC) : null;
+            }
+        };
+
+        self::getContainer()->set(UserLlmResolverInterface::class, $resolver);
     }
 
     #[Test]
@@ -60,7 +78,7 @@ final class TripChatTest extends ApiTestCase
     {
         $this->seedTrip(self::TRIP_ID);
 
-        $this->installFakeLlmClient(new FakeLlmClient([
+        $this->installLlmClient(new FakeLlmClient([
             'message' => [
                 'role' => 'assistant',
                 'content' => json_encode([
@@ -102,7 +120,7 @@ final class TripChatTest extends ApiTestCase
     {
         $this->seedTrip(self::TRIP_ID);
 
-        $this->installFakeLlmClient(new FakeLlmClient([
+        $this->installLlmClient(new FakeLlmClient([
             'message' => [
                 'role' => 'assistant',
                 'content' => json_encode([
@@ -136,7 +154,7 @@ final class TripChatTest extends ApiTestCase
     {
         $this->seedTrip(self::TRIP_ID);
 
-        $this->installFakeLlmClient(new FakeLlmClient([
+        $this->installLlmClient(new FakeLlmClient([
             'message' => [
                 'role' => 'assistant',
                 'content' => json_encode([
@@ -166,11 +184,37 @@ final class TripChatTest extends ApiTestCase
     }
 
     #[Test]
-    public function chatReturns503WhenLlmDisabled(): void
+    public function chatReturnsInfoHintWhenAiNotConfigured(): void
     {
         $this->seedTrip(self::TRIP_ID);
 
-        $this->installFakeLlmClient(new FakeLlmClient(response: null, enabled: false));
+        // No provider configured for the user → degrade gracefully with an
+        // in-chat `info` hint (200), not a hard error.
+        $this->installLlmClient(null);
+
+        $response = $this->client->request(
+            'POST',
+            \sprintf('/trips/%s/chat', self::TRIP_ID),
+            [
+                'json' => ['message' => 'Bonjour'],
+                'headers' => ['Content-Type' => 'application/ld+json', ...$this->authHeader($this->jwtToken)],
+            ],
+        );
+
+        $this->assertResponseStatusCodeSame(200);
+        $data = $response->toArray(false);
+        $this->assertSame('info', $data['action']);
+        $this->assertStringContainsString('Configurez une IA', $data['response']);
+    }
+
+    #[Test]
+    public function chatReturns503WhenClientReturnsNull(): void
+    {
+        $this->seedTrip(self::TRIP_ID);
+
+        // Edge case: a configured client returns null. The dedicated 503 wording
+        // for this branch is otherwise untested.
+        $this->installLlmClient(new FakeLlmClient());
 
         $this->client->request(
             'POST',
@@ -185,32 +229,11 @@ final class TripChatTest extends ApiTestCase
     }
 
     #[Test]
-    public function chatReturns503WhenLlmEnabledButReturnsNull(): void
+    public function chatReturns503WhenProviderUnreachable(): void
     {
         $this->seedTrip(self::TRIP_ID);
 
-        // Edge case: client reports as enabled but chat() returns null. The
-        // dedicated 503 wording for this branch is otherwise untested.
-        $this->installFakeLlmClient(new FakeLlmClient(response: null, enabled: true));
-
-        $this->client->request(
-            'POST',
-            \sprintf('/trips/%s/chat', self::TRIP_ID),
-            [
-                'json' => ['message' => 'Bonjour'],
-                'headers' => ['Content-Type' => 'application/ld+json', ...$this->authHeader($this->jwtToken)],
-            ],
-        );
-
-        $this->assertResponseStatusCodeSame(503);
-    }
-
-    #[Test]
-    public function chatReturns503WhenOllamaUnreachable(): void
-    {
-        $this->seedTrip(self::TRIP_ID);
-
-        $this->installFakeLlmClient(new FakeLlmClient(throwUnavailable: true));
+        $this->installLlmClient(new FakeLlmClient(throwUnavailable: true));
 
         $this->client->request(
             'POST',
@@ -241,7 +264,7 @@ final class TripChatTest extends ApiTestCase
     #[Test]
     public function chatReturns404ForUnknownTrip(): void
     {
-        $this->installFakeLlmClient(new FakeLlmClient(enabled: false));
+        $this->installLlmClient(null);
 
         $this->client->request(
             'POST',
@@ -260,7 +283,7 @@ final class TripChatTest extends ApiTestCase
     {
         $this->seedTrip(self::TRIP_ID);
 
-        $this->installFakeLlmClient(new FakeLlmClient([
+        $this->installLlmClient(new FakeLlmClient([
             'message' => ['role' => 'assistant', 'content' => '{}'],
         ]));
 
@@ -287,14 +310,13 @@ final readonly class FakeLlmClient implements LlmClientInterface
      */
     public function __construct(
         private ?array $response = null,
-        private bool $enabled = true,
         private bool $throwUnavailable = false,
     ) {
     }
 
     public function isEnabled(): bool
     {
-        return $this->enabled;
+        return true;
     }
 
     public function generate(string $model, string $prompt, ?string $systemPrompt = null, array $options = []): ?array
@@ -313,11 +335,7 @@ final readonly class FakeLlmClient implements LlmClientInterface
     private function respond(): ?array
     {
         if ($this->throwUnavailable) {
-            throw new OllamaUnavailableException('Simulated outage.');
-        }
-
-        if (!$this->enabled) {
-            return null;
+            throw new AiUnavailableException('Simulated outage.');
         }
 
         return $this->response;

--- a/api/tests/Functional/TripChatTest.php
+++ b/api/tests/Functional/TripChatTest.php
@@ -9,6 +9,7 @@ use ApiPlatform\Symfony\Bundle\Test\Client;
 use App\ApiResource\TripRequest;
 use App\Entity\User;
 use App\Llm\AiProvider;
+use App\Llm\Exception\AiFailureReason;
 use App\Llm\Exception\AiUnavailableException;
 use App\Llm\LlmClientInterface;
 use App\Llm\ResolvedLlmClient;
@@ -248,6 +249,46 @@ final class TripChatTest extends ApiTestCase
     }
 
     #[Test]
+    public function chatReturns503WithInvalidTokenMessageWhenTokenRejected(): void
+    {
+        $this->seedTrip(self::TRIP_ID);
+
+        $this->installLlmClient(new FakeLlmClient(throwUnavailable: true, unavailableReason: AiFailureReason::INVALID_TOKEN));
+
+        $response = $this->client->request(
+            'POST',
+            \sprintf('/trips/%s/chat', self::TRIP_ID),
+            [
+                'json' => ['message' => 'Bonjour'],
+                'headers' => ['Content-Type' => 'application/ld+json', ...$this->authHeader($this->jwtToken)],
+            ],
+        );
+
+        $this->assertResponseStatusCodeSame(503);
+        $this->assertStringContainsString('clé IA', $response->getContent(false));
+    }
+
+    #[Test]
+    public function chatPropagatesRetryAfterHeader(): void
+    {
+        $this->seedTrip(self::TRIP_ID);
+
+        $this->installLlmClient(new FakeLlmClient(throwUnavailable: true, unavailableReason: AiFailureReason::RATE_LIMITED, retryAfter: 60));
+
+        $this->client->request(
+            'POST',
+            \sprintf('/trips/%s/chat', self::TRIP_ID),
+            [
+                'json' => ['message' => 'Bonjour'],
+                'headers' => ['Content-Type' => 'application/ld+json', ...$this->authHeader($this->jwtToken)],
+            ],
+        );
+
+        $this->assertResponseStatusCodeSame(503);
+        $this->assertResponseHeaderSame('Retry-After', '60');
+    }
+
+    #[Test]
     public function chatRejectsUnauthenticatedRequests(): void
     {
         $this->seedTrip(self::TRIP_ID);
@@ -311,6 +352,8 @@ final readonly class FakeLlmClient implements LlmClientInterface
     public function __construct(
         private ?array $response = null,
         private bool $throwUnavailable = false,
+        private AiFailureReason $unavailableReason = AiFailureReason::UNAVAILABLE,
+        private ?int $retryAfter = null,
     ) {
     }
 
@@ -335,7 +378,7 @@ final readonly class FakeLlmClient implements LlmClientInterface
     private function respond(): ?array
     {
         if ($this->throwUnavailable) {
-            throw new AiUnavailableException('Simulated outage.');
+            throw new AiUnavailableException('Simulated outage.', $this->unavailableReason, $this->retryAfter);
         }
 
         return $this->response;

--- a/api/tests/Integration/InRideAssistantTest.php
+++ b/api/tests/Integration/InRideAssistantTest.php
@@ -13,8 +13,10 @@ use App\InRide\InRidePoiRepositoryInterface;
 use App\InRide\OpeningHoursParser;
 use App\InRide\PoiIntentDetector;
 use App\InRide\PoiSuggestion;
-use App\Llm\Exception\OllamaUnavailableException;
+use App\Llm\AiProvider;
+use App\Llm\Exception\AiUnavailableException;
 use App\Llm\LlmClientInterface;
+use App\Llm\ResolvedLlmClient;
 use App\Llm\SystemPromptLoader;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\Test;
@@ -66,11 +68,12 @@ final class InRideAssistantTest extends TestCase
         $poiRepository = $this->createMock(InRidePoiRepositoryInterface::class);
         $poiRepository->expects($this->never())->method('findNearby');
 
-        $assistant = $this->buildAssistant($llm, $poiRepository);
+        $assistant = $this->buildAssistant($poiRepository);
 
         $response = $assistant->assist(
             message: 'Quel temps fait-il ?',
             position: new GeoPosition(50.8503, 4.3517),
+            resolved: $this->resolved($llm),
         );
 
         $this->assertSame(PoiSuggestion::CATEGORY_UNKNOWN, $response->category);
@@ -105,11 +108,12 @@ final class InRideAssistantTest extends TestCase
             ['lat' => 50.8509, 'lon' => 4.3527, 'tags' => ['name' => 'Fontaine Centrale']],
         ]);
 
-        $assistant = $this->buildAssistant($llm, $poiRepository);
+        $assistant = $this->buildAssistant($poiRepository);
 
         $response = $assistant->assist(
             message: "Je cherche un point d'eau",
             position: new GeoPosition(50.8503, 4.3517),
+            resolved: $this->resolved($llm),
         );
 
         $this->assertSame(PoiSuggestion::CATEGORY_WATER, $response->category);
@@ -141,12 +145,13 @@ final class InRideAssistantTest extends TestCase
             ['lat' => 50.8510, 'lon' => 4.3525, 'tags' => ['name' => 'Frites 24/7', 'opening_hours' => '24/7']],
         ]);
 
-        $assistant = $this->buildAssistant($llm, $poiRepository);
+        $assistant = $this->buildAssistant($poiRepository);
 
         // Sunday 14:00 UTC — outside the Mo-Fr 09:00-12:00 window of the first POI.
         $response = $assistant->assist(
             message: 'Je veux des frites',
             position: new GeoPosition(50.8503, 4.3517),
+            resolved: $this->resolved($llm),
             now: new \DateTimeImmutable('2024-06-09 14:00:00', new \DateTimeZone('UTC')),
         );
 
@@ -179,11 +184,12 @@ final class InRideAssistantTest extends TestCase
             ];
         }
 
-        $assistant = $this->buildAssistant($llm, $this->poiRepository($features));
+        $assistant = $this->buildAssistant($this->poiRepository($features));
 
         $response = $assistant->assist(
             message: 'Restaurant',
             position: new GeoPosition(50.8503, 4.3517),
+            resolved: $this->resolved($llm),
         );
 
         $this->assertCount(3, $response->pois);
@@ -202,11 +208,12 @@ final class InRideAssistantTest extends TestCase
             ],
         );
 
-        $assistant = $this->buildAssistant($llm, $this->poiRepository([]));
+        $assistant = $this->buildAssistant($this->poiRepository([]));
 
         $response = $assistant->assist(
             message: 'Un abri pour la pluie',
             position: new GeoPosition(50.8503, 4.3517),
+            resolved: $this->resolved($llm),
         );
 
         $this->assertSame(PoiSuggestion::CATEGORY_SHELTER, $response->category);
@@ -215,16 +222,16 @@ final class InRideAssistantTest extends TestCase
     }
 
     #[Test]
-    public function logsAtCriticalWhenOllamaUnreachableForNarrative(): void
+    public function logsAtCriticalWhenProviderUnreachableForNarrative(): void
     {
         // Intent classification succeeds (user message) but the narrative call
-        // (JSON payload) hits an unreachable tier — it must log `critical` and
+        // (JSON payload) hits an unreachable provider — it must log `critical` and
         // still serve the fallback narrative (#304).
         $llm = $this->createMock(LlmClientInterface::class);
         $llm->method('generate')->willReturnCallback(
             static function (string $model, string $prompt): array {
                 if (str_starts_with(trim($prompt), '{')) {
-                    throw new OllamaUnavailableException('boom');
+                    throw new AiUnavailableException('boom');
                 }
 
                 return ['response' => '{"category":"water","max_distance_m":3000}'];
@@ -233,17 +240,18 @@ final class InRideAssistantTest extends TestCase
 
         $logger = $this->createMock(LoggerInterface::class);
         $logger->expects(self::once())->method('critical')
-            ->with(self::stringContains('LLM unavailable for narrative'));
+            ->with(self::stringContains('AI provider unavailable for narrative'));
 
         $poiRepository = $this->poiRepository([
             ['lat' => 50.8504, 'lon' => 4.3520, 'tags' => ['name' => 'Fontaine']],
         ]);
 
-        $assistant = $this->buildAssistant($llm, $poiRepository, $logger);
+        $assistant = $this->buildAssistant($poiRepository, $logger);
 
         $response = $assistant->assist(
             message: "Je cherche un point d'eau",
             position: new GeoPosition(50.8503, 4.3517),
+            resolved: $this->resolved($llm),
         );
 
         // Graceful degradation: POIs are still returned with a fallback narrative.
@@ -263,22 +271,25 @@ final class InRideAssistantTest extends TestCase
     }
 
     private function buildAssistant(
-        LlmClientInterface $llm,
         InRidePoiRepositoryInterface $poiRepository,
         ?LoggerInterface $logger = null,
     ): InRideAssistant {
         $distance = new HaversineDistance();
 
         return new InRideAssistant(
-            intentDetector: new PoiIntentDetector($llm),
+            intentDetector: new PoiIntentDetector($logger ?? new NullLogger()),
             poiRepository: $poiRepository,
             openingHoursParser: new OpeningHoursParser(),
             detourCalculator: new DetourCalculator($distance),
             deeplinkBuilder: new DeeplinkBuilder(),
             distance: $distance,
-            llmClient: $llm,
             promptLoader: new SystemPromptLoader($this->promptDir),
             logger: $logger ?? new NullLogger(),
         );
+    }
+
+    private function resolved(LlmClientInterface $llm): ResolvedLlmClient
+    {
+        return new ResolvedLlmClient($llm, AiProvider::ANTHROPIC);
     }
 }

--- a/api/tests/Integration/TripChatInRideTest.php
+++ b/api/tests/Integration/TripChatInRideTest.php
@@ -24,7 +24,10 @@ use App\InRide\PoiSuggestion;
 use App\Llm\ChatActionInterpreter;
 use App\Llm\ChatHistoryStore;
 use App\Llm\Dto\ChatAction;
+use App\Llm\AiProvider;
 use App\Llm\LlmClientInterface;
+use App\Llm\ResolvedLlmClient;
+use App\Llm\UserLlmResolverInterface;
 use App\Llm\SystemPromptLoader;
 use App\Message\RecalculateStages;
 use App\Repository\TripRequestRepositoryInterface;
@@ -81,7 +84,6 @@ final class TripChatInRideTest extends TestCase
         ]);
 
         $llm = $this->createMock(LlmClientInterface::class);
-        $llm->method('isEnabled')->willReturn(true);
         $llm->method('generate')->willReturnCallback(
             static function (string $model, string $prompt, ?string $systemPrompt = null, array $options = []): array {
                 // The intent detector sends the raw user message; the narrative
@@ -130,7 +132,6 @@ final class TripChatInRideTest extends TestCase
         $poiRepository->expects($this->never())->method('findNearby');
 
         $llm = $this->createMock(LlmClientInterface::class);
-        $llm->method('isEnabled')->willReturn(true);
         $llm->method('generate')->willReturn([
             'response' => '{"category":"unknown","max_distance_m":3000}',
         ]);
@@ -181,7 +182,6 @@ final class TripChatInRideTest extends TestCase
         $poiRepository->method('findNearby')->willReturn([]);
 
         $llm = $this->createMock(LlmClientInterface::class);
-        $llm->method('isEnabled')->willReturn(true);
         $llm->method('generate')->willReturn([
             'response' => '{"category":"unknown","max_distance_m":3000}',
         ]);
@@ -236,19 +236,21 @@ final class TripChatInRideTest extends TestCase
 
         $distance = new HaversineDistance();
         $inRideAssistant = new InRideAssistant(
-            intentDetector: new PoiIntentDetector($llm),
+            intentDetector: new PoiIntentDetector(),
             poiRepository: $poiRepository,
             openingHoursParser: new OpeningHoursParser(),
             detourCalculator: new DetourCalculator($distance),
             deeplinkBuilder: new DeeplinkBuilder(),
             distance: $distance,
-            llmClient: $llm,
             promptLoader: $promptLoader,
         );
 
+        $clientFactory = $this->createStub(UserLlmResolverInterface::class);
+        $clientFactory->method('forUser')->willReturn(new ResolvedLlmClient($llm, AiProvider::ANTHROPIC));
+
         return new TripChatProcessor(
             tripStateManager: $repository,
-            llmClient: $llm,
+            clientFactory: $clientFactory,
             promptLoader: $promptLoader,
             interpreter: new ChatActionInterpreter(new NullLogger()),
             historyStore: $historyStore,

--- a/api/tests/Integration/TripChatPlanningRegressionTest.php
+++ b/api/tests/Integration/TripChatPlanningRegressionTest.php
@@ -20,7 +20,10 @@ use App\InRide\OpeningHoursParser;
 use App\InRide\PoiIntentDetector;
 use App\Llm\ChatActionInterpreter;
 use App\Llm\ChatHistoryStore;
+use App\Llm\AiProvider;
 use App\Llm\LlmClientInterface;
+use App\Llm\ResolvedLlmClient;
+use App\Llm\UserLlmResolverInterface;
 use App\Llm\SystemPromptLoader;
 use App\Message\RecalculateStages;
 use App\Repository\TripRequestRepositoryInterface;
@@ -103,7 +106,6 @@ final class TripChatPlanningRegressionTest extends TestCase
         ], \JSON_THROW_ON_ERROR);
 
         $llm = $this->createMock(LlmClientInterface::class);
-        $llm->method('isEnabled')->willReturn(true);
         $llm->method('chat')->willReturn([
             'message' => ['role' => 'assistant', 'content' => $envelope],
         ]);
@@ -168,19 +170,21 @@ final class TripChatPlanningRegressionTest extends TestCase
 
         $distance = new HaversineDistance();
         $inRideAssistant = new InRideAssistant(
-            intentDetector: new PoiIntentDetector($llm),
+            intentDetector: new PoiIntentDetector(),
             poiRepository: $poiRepository,
             openingHoursParser: new OpeningHoursParser(),
             detourCalculator: new DetourCalculator($distance),
             deeplinkBuilder: new DeeplinkBuilder(),
             distance: $distance,
-            llmClient: $llm,
             promptLoader: $promptLoader,
         );
 
+        $clientFactory = $this->createStub(UserLlmResolverInterface::class);
+        $clientFactory->method('forUser')->willReturn(new ResolvedLlmClient($llm, AiProvider::ANTHROPIC));
+
         return new TripChatProcessor(
             tripStateManager: $repository,
-            llmClient: $llm,
+            clientFactory: $clientFactory,
             promptLoader: $promptLoader,
             interpreter: new ChatActionInterpreter(new NullLogger()),
             historyStore: $historyStore,

--- a/api/tests/Unit/InRide/PoiIntentDetectorTest.php
+++ b/api/tests/Unit/InRide/PoiIntentDetectorTest.php
@@ -6,8 +6,10 @@ namespace App\Tests\Unit\InRide;
 
 use App\InRide\PoiIntentDetector;
 use App\InRide\PoiSuggestion;
-use App\Llm\Exception\OllamaUnavailableException;
+use App\Llm\AiProvider;
+use App\Llm\Exception\AiUnavailableException;
 use App\Llm\LlmClientInterface;
+use App\Llm\ResolvedLlmClient;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -32,24 +34,22 @@ final class PoiIntentDetectorTest extends TestCase
         $llm = $this->createMock(LlmClientInterface::class);
         $llm->expects(self::never())->method('generate');
 
-        $detector = new PoiIntentDetector($llm, new NullLogger());
-
-        $intent = $detector->detect('   ');
+        $intent = new PoiIntentDetector(new NullLogger())->detect('   ', $this->resolved($llm));
 
         self::assertTrue($intent->isUnknown());
     }
 
     #[Test]
-    public function logsAtCriticalWhenOllamaUnreachable(): void
+    public function logsAtCriticalWhenProviderUnreachable(): void
     {
         $llm = $this->createMock(LlmClientInterface::class);
-        $llm->method('generate')->willThrowException(new OllamaUnavailableException('boom'));
+        $llm->method('generate')->willThrowException(new AiUnavailableException('boom'));
 
-        // AI enabled but unreachable must be logged at `critical` for ops alerting (#304).
+        // AI configured but unreachable must be logged at `critical` for ops alerting (#304).
         $logger = $this->createMock(LoggerInterface::class);
-        $logger->expects(self::once())->method('critical')->with(self::stringContains('LLM unavailable'));
+        $logger->expects(self::once())->method('critical')->with(self::stringContains('AI provider unavailable'));
 
-        $intent = new PoiIntentDetector($llm, $logger)->detect('Un café ?');
+        $intent = new PoiIntentDetector($logger)->detect('Un café ?', $this->resolved($llm));
 
         self::assertTrue($intent->isUnknown());
     }
@@ -58,9 +58,7 @@ final class PoiIntentDetectorTest extends TestCase
     #[DataProvider('payloadProvider')]
     public function parsesEnvelopeFromMockedLlm(string $llmResponse, string $expectedCategory, int $expectedRadius, ?int $expectedOpenForMinutes): void
     {
-        $detector = $this->detectorFor($llmResponse);
-
-        $intent = $detector->detect('Tu connais un endroit ?');
+        $intent = new PoiIntentDetector(new NullLogger())->detect('Tu connais un endroit ?', $this->resolvedFor($llmResponse));
 
         self::assertSame($expectedCategory, $intent->category);
         self::assertSame($expectedRadius, $intent->maxDistanceMeters);
@@ -172,17 +170,17 @@ final class PoiIntentDetectorTest extends TestCase
     #[Test]
     public function malformedJsonFallsBackToUnknown(): void
     {
-        $detector = $this->detectorFor('{this is not json');
+        $intent = new PoiIntentDetector(new NullLogger())->detect('Eau ?', $this->resolvedFor('{this is not json'));
 
-        self::assertTrue($detector->detect('Eau ?')->isUnknown());
+        self::assertTrue($intent->isUnknown());
     }
 
     #[Test]
     public function payloadWithoutBracesFallsBackToUnknown(): void
     {
-        $detector = $this->detectorFor('No JSON here at all, just words.');
+        $intent = new PoiIntentDetector(new NullLogger())->detect('Eau ?', $this->resolvedFor('No JSON here at all, just words.'));
 
-        self::assertTrue($detector->detect('Eau ?')->isUnknown());
+        self::assertTrue($intent->isUnknown());
     }
 
     #[Test]
@@ -191,16 +189,21 @@ final class PoiIntentDetectorTest extends TestCase
         // The parser extracts the substring between the outer braces, so an
         // array payload still goes through json_decode but yields a non-array
         // (well, an array but not an object map) and is rejected at the category check.
-        $detector = $this->detectorFor('["food", 3000]');
+        $intent = new PoiIntentDetector(new NullLogger())->detect('Eau ?', $this->resolvedFor('["food", 3000]'));
 
-        self::assertTrue($detector->detect('Eau ?')->isUnknown());
+        self::assertTrue($intent->isUnknown());
     }
 
-    private function detectorFor(string $llmResponse): PoiIntentDetector
+    private function resolved(LlmClientInterface $client): ResolvedLlmClient
     {
-        $llm = $this->createMock(LlmClientInterface::class);
+        return new ResolvedLlmClient($client, AiProvider::ANTHROPIC);
+    }
+
+    private function resolvedFor(string $llmResponse): ResolvedLlmClient
+    {
+        $llm = $this->createStub(LlmClientInterface::class);
         $llm->method('generate')->willReturn(['response' => $llmResponse]);
 
-        return new PoiIntentDetector($llm, new NullLogger());
+        return $this->resolved($llm);
     }
 }

--- a/api/tests/Unit/State/TripChatProcessorTest.php
+++ b/api/tests/Unit/State/TripChatProcessorTest.php
@@ -21,11 +21,14 @@ use App\InRide\InRideAssistant;
 use App\InRide\InRidePoiRepositoryInterface;
 use App\InRide\OpeningHoursParser;
 use App\InRide\PoiIntentDetector;
+use App\Llm\AiProvider;
 use App\Llm\ChatActionInterpreter;
 use App\Llm\ChatHistoryStore;
-use App\Llm\Exception\OllamaUnavailableException;
+use App\Llm\Exception\AiUnavailableException;
 use App\Llm\LlmClientInterface;
+use App\Llm\ResolvedLlmClient;
 use App\Llm\SystemPromptLoader;
+use App\Llm\UserLlmResolverInterface;
 use App\Message\RecalculateStages;
 use App\Repository\TripRequestRepositoryInterface;
 use App\State\TripChatProcessor;
@@ -641,19 +644,19 @@ final class TripChatProcessorTest extends TestCase
     }
 
     #[Test]
-    public function returnsServiceUnavailableAndLogsCriticalWhenOllamaUnreachable(): void
+    public function returnsServiceUnavailableAndLogsCriticalWhenProviderUnreachable(): void
     {
-        // AI enabled but the chat call hits an unreachable tier: 503 + `critical` log (#304).
+        // AI configured but the chat call hits an unreachable provider: 503 + `critical` log (#304).
         $logger = $this->createMock(LoggerInterface::class);
         $logger->expects(self::once())->method('critical')
-            ->with(self::stringContains('Ollama unreachable'));
+            ->with(self::stringContains('AI provider unreachable'));
 
         $processor = $this->newProcessor(
             llmContent: '',
             stagesCount: 1,
             messageBus: $this->newMessageBus(),
             logger: $logger,
-            chatException: new OllamaUnavailableException('boom'),
+            chatException: new AiUnavailableException('boom'),
         );
 
         $this->expectException(ServiceUnavailableHttpException::class);
@@ -697,7 +700,6 @@ final class TripChatProcessorTest extends TestCase
 
 
         $llmClient = $this->createStub(LlmClientInterface::class);
-        $llmClient->method('isEnabled')->willReturn(true);
         if ($chatException instanceof \Throwable) {
             $llmClient->method('chat')->willThrowException($chatException);
         } else {
@@ -729,19 +731,21 @@ final class TripChatProcessorTest extends TestCase
         $poiRepository = $this->createStub(InRidePoiRepositoryInterface::class);
         $poiRepository->method('findNearby')->willReturn($inRidePois ?? []);
         $inRideAssistant = new InRideAssistant(
-            intentDetector: new PoiIntentDetector($llmClient),
+            intentDetector: new PoiIntentDetector(),
             poiRepository: $poiRepository,
             openingHoursParser: new OpeningHoursParser(),
             detourCalculator: new DetourCalculator($distance),
             deeplinkBuilder: new DeeplinkBuilder(),
             distance: $distance,
-            llmClient: $llmClient,
             promptLoader: $promptLoader,
         );
 
+        $clientFactory = $this->createStub(UserLlmResolverInterface::class);
+        $clientFactory->method('forUser')->willReturn(new ResolvedLlmClient($llmClient, AiProvider::ANTHROPIC));
+
         return new TripChatProcessor(
             tripStateManager: $repository,
-            llmClient: $llmClient,
+            clientFactory: $clientFactory,
             promptLoader: $promptLoader,
             interpreter: new ChatActionInterpreter(new NullLogger()),
             historyStore: $historyStore,


### PR DESCRIPTION
## Contexte

Partie A du chantier **IA optionnelle multi-provider (BYO token)** (ADR-042). Suite de #708-#712. A3 (câblage par-utilisateur) est découpé : A3a (taxonomie, #711), A3b (analyse async, #712), **A3c (cette PR) = chemin synchrone (chat + in-ride)**.

## Changements

- **`TripChatProcessor`** : résout le provider de l'utilisateur courant via `Security` -> `UserLlmResolverInterface::forUser()` (au lieu du `LlmClientInterface` global). Modèle de chat du provider, options Ollama-only supprimées (`format`/`num_predict`). Dégradation propre :
  - **IA non configurée** (ou kill-switch `AI_ENABLED` off) -> réponse `info` 200 « Configurez une IA… » plutôt qu'une erreur (résolu **avant** de consommer le rate-limit) ;
  - **provider injoignable** (`AiUnavailableException`) -> 503 avec message **selon la raison** (token invalide / quota épuisé / indisponible) + `Retry-After` propagé.
- **`InRideAssistant` / `PoiIntentDetector`** : ne dépendent plus de `LlmClientInterface` ; le `ResolvedLlmClient` est passé en argument de `assist()` / `detect()` par le processor (qui détient l'utilisateur). Modèle du provider, catch `AiUnavailableException`, repli markdown inchangé.
- **`UserLlmResolverInterface`** (nouveau, implémenté par `LlmClientFactory`) : couture mockable `forUser(User): ?ResolvedLlmClient` pour les consommateurs sync.
- Le `OllamaClient` global n'est **plus injecté nulle part** (l'alias `LlmClientInterface` devient inutilisé) — son retrait complet est le périmètre d'A4.

## Vérification

`make qa` local : PHPStan L9 OK, CS-Fixer OK, Rector OK, conteneur boote, **1079 tests unitaires + intégration (LlmPipeline, InRideAssistant, TripChatInRide, TripChatPlanningRegression) verts**. Tests réécrits autour du resolver ; `TripChatTest` fonctionnel adapté (override de `UserLlmResolverInterface`, nouveau cas « info quand non configuré », 503 quand provider injoignable / réponse nulle) — exécuté en CI (DB).

## Suite

**A4** : retrait complet d'Ollama de la bêta (service compose, sondes `/health`, env `OLLAMA_*`, `OllamaClient` + alias + service d'analyse) + **ADR-042** et maj ADR-028/030/039 + README. Puis la série **B** (génération d'itinéraire).

<!-- claude-review-start -->
## Claude Review

Reviewed commit `ee66dd6d13c3b62a1aa51d27664ece72cdffe5ad`.

The A3c sync-path migration is complete and clean. The second commit addressed all three warnings from the prior review: the log message is now provider-neutral, the class docblock documents both degradation paths (200 `info` for unconfigured AI, reason-aware 503 for unreachable provider), and the new `chatReturns503WithInvalidTokenMessageWhenTokenRejected` and `chatPropagatesRetryAfterHeader` tests cover the previously untested branches. No new issues found.

**Findings: 0 critical · 0 warnings**

Resolved 3 previously open threads that were addressed.

## Review checklist
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

## Inline comments

No inline comments.
<!-- claude-review-end -->