### PR TITLE
docs(ai): ADR-042 + optional per-user multi-provider AI documentation

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -360,20 +360,20 @@ Caches : OSM 24h, Wikidata 7j, DataTourisme (par ressource), Open-Meteo 3h.
 | ✅ | Adoption `symfony/ai` | `symfony/ai-platform` + bridges cloud (ADR-030, migré en ADR-042). |
 | 🗑️ | Service OllamaClient + Docker Ollama | Retiré (ADR-042) ; remplacé par les bridges cloud par-utilisateur. Anciennement Sprint 25 #298 / ADR-028 |
 
-### Analyse 2 passes (LLaMA 8B)
+### Analyse 2 passes (IA — modèle d'analyse du fournisseur)
 
 | Statut | Fonctionnalité | Détail |
 |---|---|---|
 | ✅ | Passe 1 — analyse par étape | Message Messenger parallélisable (`AnalyzeStageWithLlmHandler`). Sprint 26 #301 |
 | ✅ | Passe 2 — vue d'ensemble du trip | Résumé global (`AnalyzeTripOverviewWithLlmHandler`). Sprint 26 #302 |
-| ✅ | Pipeline gate → LLaMA → TRIP_READY | Orchestration Mercure. Sprint 26 #303 |
+| ✅ | Pipeline gate → IA → TRIP_READY | Orchestration Mercure. Sprint 26 #303 |
 | ✅ | Fallback gracieux sans IA | Dégradation propre (`AiUnavailableException` + raison). Sprint 26 #304 / ADR-042 |
 
 ### Frontend IA
 
 | Statut | Fonctionnalité | Détail |
 |---|---|---|
-| ✅ | Résumé IA global dans Mon voyage | Passe 2 LLaMA 8B (`TripAiOverview`). Sprint 27 #305 |
+| ✅ | Résumé IA global dans Mon voyage | Passe 2 d'analyse (`TripAiOverview`). Sprint 27 #305 |
 | ✅ | Résumé IA par étape + layout hybride | Résumé + alertes repliables (`StageAiSummary`). Sprint 27 #306 |
 | ✅ | Bandeau « Actualiser l'analyse IA » | Si différé ou désactivé. Sprint 27 #307 |
 | ✅ | Fallback frontend sans LLaMA | Alertes dépliées, résumé masqué. Sprint 27 #308 |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -25,7 +25,7 @@ Inventaire complet des fonctionnalités de **Bike Trip Planner** — livrées et
 | ✅ | Import URL RideWithGPS | `ridewithgps.com/routes/{id}` |
 | ✅ | Création via query param `?link=...` | Démarrage direct depuis un lien partagé. Sprint 9 |
 | ✅ | Card Selection mutuellement exclusive | 3 cartes : Lien / GPX / Assistant IA (IA grisée « bientôt »). Sprint 22 |
-| 📅 | Génération d'itinéraire par IA | LLaMA 3B génère un tracé à partir d'une description texte. Sprint 28 / Hors sprint #67 |
+| 📅 | Génération d'itinéraire par IA | L'IA génère un tracé à partir d'une description texte (modèle du fournisseur). Sprint 28 / Hors sprint #67 |
 
 ### Wizard 4 étapes
 
@@ -54,7 +54,7 @@ Inventaire complet des fonctionnalités de **Bike Trip Planner** — livrées et
 | ✅ | Insertion jours de repos | Décale les dates des étapes suivantes. Sprint 4 |
 | ✅ | Dates de voyage | Picker start/end, influence météo et événements |
 | ✅ | Panneau de configuration latéral | Drawer accessible depuis le roadbook. Sprint 4 |
-| ✅ | Affinage par IA (prompt texte) | Text area pour demander ajustements (LLaMA). Sprint 27 |
+| ✅ | Affinage par IA (prompt texte) | Text area pour demander ajustements (modèle de chat du fournisseur). Sprint 27 |
 
 ---
 
@@ -169,7 +169,7 @@ Caches : OSM 24h, Wikidata 7j, DataTourisme (par ressource), Open-Meteo 3h.
 | ✅ | Events panel | Fêtes, jours fériés, festivals datés |
 | ✅ | Téléchargements par étape | GPX, GeoJSON, texte |
 | ✅ | Export FIT par étape | Format Garmin natif (`FitEncoder`/`FitNormalizer`). Sprint 31 |
-| ✅ | Résumé IA par étape | Narratif + insights + suggestions, LLaMA 8B passe 1 (`StageAiSummary`). Sprint 27 #306 |
+| ✅ | Résumé IA par étape | Narratif + insights + suggestions, passe 1 d'analyse (`StageAiSummary`). Sprint 27 #306 |
 | 📅 | Shimmer/skeleton recalcul | État visuel pendant recomputation. Sprint 24 |
 | 📅 | Diff post-recalcul | Surbrillance des changements. Sprint 24 |
 
@@ -376,13 +376,13 @@ Caches : OSM 24h, Wikidata 7j, DataTourisme (par ressource), Open-Meteo 3h.
 | ✅ | Résumé IA global dans Mon voyage | Passe 2 d'analyse (`TripAiOverview`). Sprint 27 #305 |
 | ✅ | Résumé IA par étape + layout hybride | Résumé + alertes repliables (`StageAiSummary`). Sprint 27 #306 |
 | ✅ | Bandeau « Actualiser l'analyse IA » | Si différé ou désactivé. Sprint 27 #307 |
-| ✅ | Fallback frontend sans LLaMA | Alertes dépliées, résumé masqué. Sprint 27 #308 |
+| ✅ | Fallback frontend sans IA | Alertes dépliées, résumé masqué. Sprint 27 #308 |
 
-### Bulle IA conversationnelle (LLaMA 3B)
+### Bulle IA conversationnelle (modèle de chat du fournisseur)
 
 | Statut | Fonctionnalité | Détail |
 |---|---|---|
-| ✅ | Endpoint chat IA | LLaMA 3B context-aware. Sprint 28 #309 |
+| ✅ | Endpoint chat IA | Context-aware (modèle de chat du fournisseur). Sprint 28 #309 |
 | ✅ | Composant AiBubble | Bulle flottante + panneau chat. Sprint 28 #310 |
 | ✅ | Intégration ↔ recomputation inline | `skipAiAnalysis` flag. Sprint 28 #311 |
 | ✅ | Chat in-ride (POI à proximité) | Détection d'intention + calcul de détour avec géolocalisation (`InRide/*`), historique persisté (`TripChatMessage`). Sprint 32 |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -346,17 +346,19 @@ Caches : OSM 24h, Wikidata 7j, DataTourisme (par ressource), Open-Meteo 3h.
 
 ## 11. Intelligence artificielle
 
-> Pile IA auto-hébergée via Ollama (`symfony/ai`, ADR-028 / ADR-030). Dégradation gracieuse : sans Ollama, les résumés IA sont masqués et les alertes restent affichées.
+> IA **optionnelle, multi-fournisseur, à clé personnelle** (`symfony/ai-platform`, **ADR-042**). L'IA est activée par utilisateur en configurant un fournisseur (Anthropic/Claude, Google/Gemini, OpenAI) et son propre token dans les réglages du compte ; il n'y a pas de toggle d'environnement. Token chiffré au repos. Dégradation gracieuse : sans clé (ou clé invalide / quota / fournisseur indisponible), les résumés IA sont masqués et les alertes restent affichées. L'ancienne pile Ollama auto-hébergée (ADR-028 / ADR-030) est retirée.
 
 ### Fondations backend
 
 | Statut | Fonctionnalité | Détail |
 |---|---|---|
-| ✅ | Service OllamaClient PHP | Client HTTP vers Ollama (`Llm/OllamaClient`). Sprint 25 #298 |
+| ✅ | IA optionnelle multi-fournisseur (BYO token) | `PlatformLlmClient` + `LlmClientFactory` par-utilisateur (Anthropic/Gemini/OpenAI). ADR-042 |
+| ✅ | Token IA chiffré + API compte | `AiTokenEncryptor` (libsodium) + `/users/me/ai-settings`. ADR-042 |
+| ✅ | Taxonomie d'erreurs + mode dégradé | `AiFailureReason` + `AiErrorClassifier` (token invalide / quota / rate-limit / indisponible). ADR-042 |
 | ✅ | Gate mechanism | Blocage/déblocage dans ComputationTracker (`LlmAnalysisTracker`). Sprint 25 #299 |
-| ✅ | System prompts cyclotourisme versionnés | Template FR/EN LLaMA 8B. Sprint 25 #300 |
-| ✅ | Docker Ollama | Container dédié. ADR-028 |
-| ✅ | Adoption `symfony/ai` | Platform Ollama (tool-calling désactivé sur le 3B). ADR-030 |
+| ✅ | System prompts cyclotourisme versionnés | Template FR/EN. Sprint 25 #300 |
+| ✅ | Adoption `symfony/ai` | `symfony/ai-platform` + bridges cloud (ADR-030, migré en ADR-042). |
+| 🗑️ | Service OllamaClient + Docker Ollama | Retiré (ADR-042) ; remplacé par les bridges cloud par-utilisateur. Anciennement Sprint 25 #298 / ADR-028 |
 
 ### Analyse 2 passes (LLaMA 8B)
 
@@ -365,7 +367,7 @@ Caches : OSM 24h, Wikidata 7j, DataTourisme (par ressource), Open-Meteo 3h.
 | ✅ | Passe 1 — analyse par étape | Message Messenger parallélisable (`AnalyzeStageWithLlmHandler`). Sprint 26 #301 |
 | ✅ | Passe 2 — vue d'ensemble du trip | Résumé global (`AnalyzeTripOverviewWithLlmHandler`). Sprint 26 #302 |
 | ✅ | Pipeline gate → LLaMA → TRIP_READY | Orchestration Mercure. Sprint 26 #303 |
-| ✅ | Fallback gracieux sans Ollama | Dégradation propre (`OllamaUnavailableException`). Sprint 26 #304 |
+| ✅ | Fallback gracieux sans IA | Dégradation propre (`AiUnavailableException` + raison). Sprint 26 #304 / ADR-042 |
 
 ### Frontend IA
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -54,7 +54,7 @@
 
 **Traitement temps réel** — Des workers asynchrones calculent votre voyage en parallèle ; les mises à jour de statut sont poussées vers le navigateur via Mercure SSE. Aucun rechargement de page.
 
-**Analyse IA (optionnelle)** — Un modèle LLaMA auto-hébergé (via Ollama) rédige un résumé par étape et pour l'ensemble du voyage, et alimente un assistant conversationnel context-aware — y compris un mode « in-ride » qui repère les points d'intérêt à proximité. Dégradation gracieuse : sans le modèle, les alertes restent affichées.
+**Analyse IA (optionnelle, à clé personnelle)** — Désactivée par défaut, entièrement opt-in. Activez-la dans les réglages de votre compte en choisissant un fournisseur — Anthropic (Claude), Google (Gemini) ou OpenAI — et en collant votre propre clé API. Votre clé alimente un résumé par étape et pour l'ensemble du voyage, ainsi qu'un assistant conversationnel context-aware — y compris un mode « in-ride » qui repère les points d'intérêt à proximité. La clé est chiffrée au repos et n'est jamais renvoyée par l'API. Quand l'IA est active, les données du voyage (tracé, villes, dates) sont envoyées au fournisseur que vous avez choisi avec votre propre clé et facturées sur votre compte ; rien n'est transmis à un tiers sans votre opt-in. Dégradation gracieuse : sans clé, avec une clé invalide, un quota atteint ou un fournisseur indisponible, les alertes basées sur les règles restent affichées.
 
 **Export multi-format** — Exportez des fichiers GPX enrichis de waypoints (hébergements, points d'eau, POI), prêts pour votre GPS. Téléchargez les fichiers FIT par étape pour Garmin, ou générez un résumé texte du roadbook.
 
@@ -181,11 +181,11 @@ La sécurité des types est appliquée de bout en bout : les DTO PHP définissen
 | Carte | MapLibre GL |
 | Style | Tailwind CSS, shadcn/ui |
 | Persistance | PostgreSQL 18 (Doctrine ORM), Redis (transitoire + caches) |
-| IA | Ollama (LLaMA), `symfony/ai` |
+| IA | `symfony/ai-platform` (Anthropic, Gemini, OpenAI — BYO token) |
 | Tests | PHPUnit 13 (backend), Playwright 1.60 (E2E) |
 | Qualité | PHPStan niveau 9, PHP-CS-Fixer, Rector, ESLint, Prettier |
 | Asynchrone | Symfony Messenger, transport Redis, 5 workers |
-| Runtime | Docker (Caddy, Mercure, Redis, PostgreSQL, Node, Ollama) |
+| Runtime | Docker (Caddy, Mercure, Redis, PostgreSQL, Node) |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@
 
 **Real-time processing** — Async workers compute your trip in parallel; live status updates stream to the browser via Mercure SSE. No page reload needed.
 
-**AI trip analysis (optional)** — A self-hosted LLaMA model (via Ollama) writes per-stage and whole-trip summaries and powers a context-aware chat assistant, including an in-ride mode that surfaces nearby points of interest. It degrades gracefully: when the model is unavailable, alerts stay fully visible.
+**AI trip analysis (optional, bring-your-own token)** — Off by default and fully opt-in. Enable it in your account settings by choosing a provider — Anthropic (Claude), Google (Gemini), or OpenAI — and pasting your own API key. Your key powers per-stage and whole-trip summaries and a context-aware chat assistant, including an in-ride mode that surfaces nearby points of interest. The key is encrypted at rest and never returned by the API. When AI is on, trip data (route, towns, dates) is sent to your chosen provider with your own key and billed to your account; nothing leaves to a third party unless you opt in. It degrades gracefully: with no key, a bad key, a quota wall, or a provider outage, the rule-based alerts stay fully visible.
 
 **Multi-format export** — Export enriched GPX files with waypoints for accommodation, water points, and POIs — ready for your GPS device. Download per-stage FIT files for Garmin, or generate a text roadbook summary.
 
@@ -192,7 +192,7 @@ Type safety is enforced end-to-end: PHP DTOs define the schema -> API Platform e
 | [Contributing](docs/contributing.md) | Development workflow, standards, and tooling |
 | [Deployment](docs/deployment.md) | CI/CD pipeline, required secrets, rollback procedure |
 | [Architecture Decisions](docs/adr/) | 35 ADRs explaining every major technical choice |
-| [Runbooks](docs/runbooks/) | On-call playbooks: workers, DB, Redis, Mercure, Ollama, releases |
+| [Runbooks](docs/runbooks/) | On-call playbooks: workers, DB, Redis, Mercure, releases |
 | [Claude Code Tooling](docs/claude-code-tooling.md) | MCP servers, hooks, and skills for AI-assisted development |
 | [Architecture](docs/architecture.md) | System overview and the reasoning behind the ADRs |
 | [Legal & Licensing](docs/legal-and-licensing.md) | Project licence, data attribution, and GDPR posture |

--- a/docs/LLaMA.md
+++ b/docs/LLaMA.md
@@ -1,6 +1,8 @@
 # Architecture Project: Bike Trip Planner AI (2026)
 
-**Stack :** Next.js, Symfony/API Platform, Ollama (LLaMA 3.2 3B & 3.1 8B), Valhalla, Photon.
+> **⚠️ Obsolète (2026-06-19) — voir [ADR-042](adr/adr-042-optional-multi-provider-ai-byo-token.md).** L'IA auto-hébergée (Ollama/LLaMA) décrite ici a été remplacée par un modèle **optionnel, multi-fournisseur, à clé personnelle (BYO token)** : Anthropic (Claude), Google (Gemini), OpenAI. Ce document est conservé pour son raisonnement d'architecture historique ; le pipeline (analyse 2 passes, chat, in-ride) reste valable mais le transport est désormais le fournisseur cloud choisi par l'utilisateur avec sa propre clé.
+
+**Stack :** Next.js, Symfony/API Platform, `symfony/ai-platform` (Anthropic/Claude, Google/Gemini, OpenAI — BYO token), Valhalla, Photon.
 **Infra :** Oracle Cloud Free Tier (4 OCPUs ARM, 24GB RAM).
 
 > **Statut :** l'analyse IA (par étape + vue d'ensemble, LLaMA 8B) et l'assistant conversationnel (LLaMA 3B, dont le mode in-ride POI) sont livrés — voir [ADR-028](adr/adr-028-ollama-llama-integration.md) et [ADR-030](adr/adr-030-symfony-ai-adoption.md). La génération d'itinéraire à partir d'un prompt texte (le flux « Brief de Mission » ci-dessous) est une cible non encore implémentée (#67). Ce document décrit l'architecture visée et son raisonnement.

--- a/docs/README.fr.md
+++ b/docs/README.fr.md
@@ -19,7 +19,7 @@ Vous cherchez la présentation produit ? Voir le README ([Français](../README.f
 |---|---|
 | [Contribuer](contributing.fr.md) | Workflow de dev, QA, tests, et régénération des captures d'écran |
 | [Déploiement](deployment.md) | Pipeline de production, Coolify, monitoring, rollback (EN) |
-| [Runbooks](runbooks/) | Procédures d'astreinte : workers, BDD, Redis, Mercure, Ollama, releases (EN) |
+| [Runbooks](runbooks/) | Procédures d'astreinte : workers, BDD, Redis, Mercure, releases (EN) |
 | [Outillage Claude Code](claude-code-tooling.fr.md) | Serveurs MCP, hooks et skills pour le développement assisté par IA |
 
 ## Consulter — référence
@@ -37,7 +37,8 @@ Vous cherchez la présentation produit ? Voir le README ([Français](../README.f
 |---|---|
 | [Architecture](architecture.md) | Vue d'ensemble du système : comment les briques s'assemblent, et pourquoi (EN) |
 | [Décisions d'architecture (ADR)](adr/) | Chaque choix technique majeur, avec contexte et alternatives (EN) |
-| [Pipeline IA / LLaMA](LLaMA.md) | Structure du pipeline IA auto-hébergé |
+| [IA optionnelle (multi-fournisseur, clé personnelle)](adr/adr-042-optional-multi-provider-ai-byo-token.md) | Le modèle d'IA opt-in, par utilisateur — choisir un fournisseur (Anthropic, Gemini, OpenAI) et apporter sa propre clé (EN) |
+| [Pipeline IA / LLaMA](LLaMA.md) | Structure historique du pipeline IA auto-hébergé (obsolète — remplacé par l'ADR-042) |
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,7 @@ Looking for the product overview instead? See the README ([English](../README.md
 |---|---|
 | [Contributing](contributing.md) | Dev workflow, QA, testing, and how to regenerate screenshots |
 | [Deployment](deployment.md) | Production pipeline, Coolify, monitoring, and rollback |
-| [Runbooks](runbooks/) | On-call playbooks: workers, DB, Redis, Mercure, Ollama, releases |
+| [Runbooks](runbooks/) | On-call playbooks: workers, DB, Redis, Mercure, releases |
 | [Claude Code Tooling](claude-code-tooling.md) | MCP servers, hooks, and skills for AI-assisted development |
 
 ## Reference — looking things up
@@ -37,7 +37,8 @@ Looking for the product overview instead? See the README ([English](../README.md
 |---|---|
 | [Architecture](architecture.md) | System overview: how the pieces fit together and why |
 | [Architecture Decision Records](adr/) | Every major technical choice, with context and alternatives |
-| [AI / LLaMA pipeline](LLaMA.md) | How the self-hosted AI pipeline is structured |
+| [Optional AI (multi-provider, BYO token)](adr/adr-042-optional-multi-provider-ai-byo-token.md) | The opt-in, per-user AI model — choose a provider (Anthropic, Gemini, OpenAI) and bring your own key |
+| [AI / LLaMA pipeline](LLaMA.md) | Historical self-hosted AI pipeline structure (obsolete — superseded by ADR-042) |
 
 ---
 

--- a/docs/adr/adr-028-ollama-llama-integration.md
+++ b/docs/adr/adr-028-ollama-llama-integration.md
@@ -5,6 +5,8 @@
 - **Depends on:** ADR-001 (Global Architecture), ADR-012 (Rule-based alert engine), ADR-014 (Alert extensibility), ADR-027 (Gate mechanism and two-phase pipeline)
 - **Extends:** ADR-012 (adds an LLM-driven narrative layer on top of the rule-based alert engine)
 
+> **Superseded by [ADR-042](adr-042-optional-multi-provider-ai-byo-token.md) (2026-06-19):** the self-hosted Ollama/LLaMA tier was replaced by an optional, per-user, multi-provider bring-your-own-token model. The Ollama service, OLLAMA_* env and the bundled LLM resource have been removed. The pipeline shape (2-pass analysis, gate, graceful degradation) described below still holds, but the transport is now the user's chosen cloud provider.
+
 > **Note on numbering.** This ADR was originally tracked as "ADR-027" in the GitHub issue. ADR-027 was concurrently allocated to the gate mechanism and two-phase pipeline. To preserve numbering uniqueness, the Ollama/LLaMA integration was renumbered to ADR-028. The technical scope is unchanged.
 
 ## Context and Problem Statement

--- a/docs/adr/adr-030-symfony-ai-adoption.md
+++ b/docs/adr/adr-030-symfony-ai-adoption.md
@@ -5,6 +5,8 @@
 - **Depends on:** ADR-028 (Ollama/LLaMA Integration Architecture)
 - **Supersedes / refines:** none — operational evolution of the LLM transport layer
 
+> **Superseded by [ADR-042](adr-042-optional-multi-provider-ai-byo-token.md) (2026-06-19):** the self-hosted Ollama/LLaMA tier was replaced by an optional, per-user, multi-provider bring-your-own-token model. The Ollama service, OLLAMA_* env and the bundled LLM resource have been removed. The `symfony/ai-platform` transport layer described below still holds, but the `symfony/ai-ollama-platform` bridge is dropped in favour of the Anthropic, Gemini and OpenAI bridges, and the client is built per user with the user's own key.
+
 ## Context and Problem Statement
 
 ADR-028 chose a **custom thin wrapper around Ollama's HTTP API** (`App\Llm\OllamaClient`) plus a **JSON envelope** strategy on top of the `format: "json"` decoding mode: the model is asked to emit `{ "action", "params", "response" }` and a tolerant `ChatActionInterpreter` parses the resulting blob, falling back to an `info` action on malformed output.

--- a/docs/adr/adr-039-beta-right-sizing-free-tier.md
+++ b/docs/adr/adr-039-beta-right-sizing-free-tier.md
@@ -5,6 +5,8 @@
 - **Depends on:** ADR-019 (Deployment Infrastructure), ADR-028 (Ollama/LLaMA integration), ADR-031 (Error tracking), ADR-034 (Usage analytics), ADR-037 (Dev/Prod Docker convergence)
 - **Amends:** ADR-019 (RAM budget correction)
 
+> **Superseded by [ADR-042](adr-042-optional-multi-provider-ai-byo-token.md) (2026-06-19):** the self-hosted Ollama/LLaMA tier was replaced by an optional, per-user, multi-provider bring-your-own-token model. The Ollama service, OLLAMA_* env and the bundled LLM resource have been removed, which **frees the LLM RAM/CPU budget on the beta VM** (no resident model, no serialised `llm` worker, no CPU-only inference bottleneck — the constraint this ADR right-sized around). The pipeline shape (2-pass analysis, gate, graceful degradation) still holds, but inference now runs on the user's chosen cloud provider with their own key.
+
 > **Note on numbering.** The source GitHub issue (#570) titled this ADR "ADR-035". ADR-035 was already allocated to RGPD account erasure (sprint 34), and 036 (manual OSM refresh) / 037 (dev/prod convergence) were taken on disk. The next free number, 038, is already claimed by an open PR (#578, backup/DR for #527). To avoid a collision the number slid to **ADR-039**. The technical scope is unchanged.
 
 ## Context and Problem Statement

--- a/docs/adr/adr-042-optional-multi-provider-ai-byo-token.md
+++ b/docs/adr/adr-042-optional-multi-provider-ai-byo-token.md
@@ -43,7 +43,7 @@ Cloud providers only. No self-hosted Ollama.
 
 | Provider | `symfony/ai` bridge | Default chat model | Default analysis model |
 |----------|---------------------|--------------------|------------------------|
-| **Anthropic (Claude)** | `symfony/ai-anthropic-platform` | `claude-3-5-haiku-latest` | `claude-3-7-sonnet-latest` |
+| **Anthropic (Claude)** | `symfony/ai-anthropic-platform` | `claude-haiku-4-5-20251001` | `claude-sonnet-4-6` |
 | **Google (Gemini)** | `symfony/ai-gemini-platform` | `gemini-2.5-flash` | `gemini-2.5-flash` |
 | **OpenAI** | `symfony/ai-open-ai-platform` | `gpt-4o-mini` | `gpt-4o-mini` |
 
@@ -70,7 +70,7 @@ Account API:
 
 The `LlmClientInterface` contract (`isEnabled`, `generate`, `chat`) is preserved so every caller — the analyze handlers, the in-ride assistant, the chat processor — is untouched. The implementation is a provider-neutral `PlatformLlmClient` built **per user at runtime** by a factory: given the user's decrypted token and provider, the factory wires the matching `symfony/ai-platform` bridge and returns a client. There is no process-global model: two concurrent requests from two users run against their own providers with their own keys.
 
-Each provider HTTP client is **SSRF-scoped to that provider's host** (per ADR-001 SSRF policy) with a **30 s timeout**.
+Each provider HTTP client is **SSRF-scoped to that provider's host** (per ADR-001 SSRF policy) with a **30 s timeout** — intentionally higher than the project's 10 s default for external clients (CLAUDE.md), because LLM inference (especially the async analysis pass) routinely takes 20-30 s on the provider backend; the lower default would abort legitimate calls.
 
 ### 5. Availability is decided per-user, never by an env flag
 

--- a/docs/adr/adr-042-optional-multi-provider-ai-byo-token.md
+++ b/docs/adr/adr-042-optional-multi-provider-ai-byo-token.md
@@ -114,10 +114,12 @@ When AI is enabled, **trip data (route, towns, dates) is sent to the user-chosen
 
 ### 9. Ollama removal
 
+> **Implementation status (2026-06-19):** this section describes the target state. The code/config removal lands in PR #716 and this documentation in PR #717; until both are merged, `composer.json` may still carry `symfony/ai-ollama-platform` and the Compose files may still reference the `ollama` service.
+
 The self-hosted tier is removed entirely:
 
 - `App\Llm\OllamaClient` and the `OLLAMA_*` environment variables are deleted.
-- The bundled `ollama` Compose service (and its on-demand model-load wiring) is removed.
+- The bundled `ollama` Compose service is removed: `compose.ollama.yaml` is deleted, and the `OLLAMA_*` env, the shared `bike-trip-planner-llm` network and the `ollama` `depends_on` are dropped from `compose.yaml`/`compose.dev.yaml`/`compose.recette.yaml`.
 - The `/health` Ollama probes (`deps.ollama_chat` / `deps.ollama_analysis`) are removed; AI is no longer a server dependency or health signal — per-user token configuration alone decides availability.
 - The `symfony/ai-ollama-platform` package is dropped; the three cloud bridges replace it.
 

--- a/docs/adr/adr-042-optional-multi-provider-ai-byo-token.md
+++ b/docs/adr/adr-042-optional-multi-provider-ai-byo-token.md
@@ -1,0 +1,170 @@
+# ADR-042: Optional, Multi-Provider AI on a Bring-Your-Own Token (Per-User Cloud Models)
+
+- **Status:** Accepted
+- **Date:** 2026-06-19
+- **Depends on:** ADR-001 (Global Architecture), ADR-012 (Rule-based alert engine), ADR-027 (Gate mechanism and two-phase pipeline), ADR-030 (symfony/ai adoption), ADR-035 (GDPR account erasure)
+- **Supersedes / refines:** ADR-028 (Ollama/LLaMA integration), ADR-030 (symfony/ai transport layer), ADR-039 (beta right-sizing — the LLM RAM/CPU budget freed)
+
+## Context and Problem Statement
+
+ADR-028 chose a **self-hosted Ollama/LLaMA tier**: two LLaMA models, run on the same infrastructure as the backend workers, reachable over a scoped HTTP client, with privacy and zero marginal cost as the headline drivers. ADR-030 kept that backend but moved the transport behind `symfony/ai-platform` + the Ollama bridge. ADR-039 then right-sized the beta down to a single `llama3.2:3b` loaded on demand, because the **CPU** (not RAM) of the Oracle Free Tier ARM VM is the binding constraint — a single CPU-only inference pins several cores, and two resident models pushed the VM budget over.
+
+Operating that tier through the closed beta surfaced a different problem than the one ADR-028 set out to solve:
+
+- **The self-hosted model is heavy and fragile on the beta VM.** The model blobs occupy disk, a loaded model holds 2.3-7 GB resident depending on size, and CPU-only inference is slow (the 8B analysis pass took up to ~30 s per stage). Keeping the tier healthy (model pulls, `keep_alive` tuning, OOM avoidance, a dedicated serialised `llm` worker) is operational toil for a <10-user beta.
+- **Quality is capped by what fits on the VM.** The 3B beta model is the floor of usefulness; the genuinely good models (Claude, Gemini, GPT-4o-class) cannot run on the free tier at all. ADR-039's own migration path conceded this: better models required moving inference off the VM.
+- **Privacy was the original justification for self-hosting, but it cuts both ways.** "No payload leaves the operator's perimeter" is only valuable if the operator pays for the compute. For a free, open-source, single-operator project there is no monetisation path to fund a per-token cloud budget, and self-hosting the model to preserve privacy means the operator carries the whole server cost and footprint.
+
+The question for this ADR: **how do we offer good AI without the operator paying for inference and without pinning a heavy model to the beta VM?**
+
+The answer is to make AI **opt-in, per-user, and bring-your-own-token (BYO)**: the user chooses a cloud provider and pastes their own API key; their key powers their AI features and is billed to their account. The operator runs no model and pays nothing per inference. AI is **off by default** — without configuration, every AI feature is visible but disabled.
+
+## Decision Drivers
+
+- **Zero inference cost and zero inference footprint for the operator.** No model on the VM, no per-token bill. This is the constraint that ADR-028's self-hosting and ADR-039's right-sizing were both fighting.
+- **Access to good models.** BYO-token clouds unlock Claude / Gemini / GPT-4o-class quality that the free tier cannot host.
+- **Opt-in by default.** AI is not core to the product (the rule-based alert engine of ADR-012 is). It must be safe to ship a deployment with no AI at all, and safe for a user to never touch it.
+- **Token security.** A user's provider key is a credential. It must be encrypted at rest, never returned by the API, never logged, and wiped on account erasure (ADR-035).
+- **Explicit privacy disclosure.** Sending trip data to a third-party cloud is the opposite of ADR-028's local-first posture. It is acceptable *only* because the user opts in with their own key — and that must be disclosed plainly.
+- **Provider neutrality.** No lock-in to a single vendor. The client must be swappable per provider without touching callers.
+- **Graceful degradation, not hard dependency.** AI is best-effort. A missing key, a bad key, a quota wall, or a provider outage must never break trip computation or the rule-based alerts.
+
+## Decision
+
+Replace the self-hosted Ollama/LLaMA tier with an **optional, per-user, multi-provider, bring-your-own-token cloud model**. The pipeline shape established by ADR-028 (2-pass analysis, gate integration, graceful degradation) and the transport abstraction of ADR-030 (`symfony/ai-platform`) are kept; the model itself moves from a self-hosted Ollama daemon to a user-chosen cloud provider invoked with the user's own key.
+
+### 1. Opt-in, off by default
+
+Without any configuration, **every AI feature is visible but disabled** (greyed, with a "Configure an AI provider" call-to-action). AI is never silently absent and never silently on. A user enables it in **Account -> Settings** by choosing a provider and pasting their own API key.
+
+### 2. Supported providers (v1)
+
+Cloud providers only. No self-hosted Ollama.
+
+| Provider | `symfony/ai` bridge | Default chat model | Default analysis model |
+|----------|---------------------|--------------------|------------------------|
+| **Anthropic (Claude)** | `symfony/ai-anthropic-platform` | `claude-3-5-haiku-latest` | `claude-3-7-sonnet-latest` |
+| **Google (Gemini)** | `symfony/ai-gemini-platform` | `gemini-2.5-flash` | `gemini-2.5-flash` |
+| **OpenAI** | `symfony/ai-open-ai-platform` | `gpt-4o-mini` | `gpt-4o-mini` |
+
+Models are chosen cheap-but-capable per provider. They are **not user-selectable in v1** — the user picks a provider, not a model.
+
+### 3. Encrypted per-user token + account API
+
+The user's API key is stored encrypted at rest with **libsodium `crypto_secretbox`**, under a dedicated `AI_TOKEN_ENC_KEY` (**never** `APP_SECRET`, so the encryption key has its own rotation/exposure lifecycle). The token is:
+
+- **never returned by the API** — reads expose only `tokenConfigured: bool`, never the ciphertext or plaintext;
+- **write-only** on the wire — sent only on `PUT`;
+- **never logged**;
+- **wiped on GDPR account erasure** (ADR-035): erasing the account removes the token along with the rest of the personal data.
+
+Account API:
+
+| Verb | Route | Body | Response |
+|------|-------|------|----------|
+| `GET` | `/users/me/ai-settings` | — | `{ provider, tokenConfigured }` |
+| `PUT` | `/users/me/ai-settings` | `{ provider, token }` | `{ provider, tokenConfigured: true }` |
+| `DELETE` | `/users/me/ai-settings` | — | 204 (token wiped) |
+
+### 4. Provider-neutral `PlatformLlmClient` + per-user factory
+
+The `LlmClientInterface` contract (`isEnabled`, `generate`, `chat`) is preserved so every caller — the analyze handlers, the in-ride assistant, the chat processor — is untouched. The implementation is a provider-neutral `PlatformLlmClient` built **per user at runtime** by a factory: given the user's decrypted token and provider, the factory wires the matching `symfony/ai-platform` bridge and returns a client. There is no process-global model: two concurrent requests from two users run against their own providers with their own keys.
+
+Each provider HTTP client is **SSRF-scoped to that provider's host** (per ADR-001 SSRF policy) with a **30 s timeout**.
+
+### 5. Availability is decided per-user, never by an env flag
+
+The AI features are **always present in the build** — they are part of the product, not a deployment option. What is optional is **per-user activation**: a feature is usable only once *that user* has chosen a provider and saved their token. The application therefore does **not** enable or disable AI through an environment variable. The old global `OLLAMA_ENABLED` server flag (which answered "is the self-hosted tier reachable?") is removed and **not replaced** by any equivalent toggle.
+
+Two states, generalising the ADR-028 degraded-mode contract:
+
+- **No user token** — features visible but **disabled** with a "Configure an AI provider" CTA.
+- **User token configured** — full AI for that user.
+
+The only AI-related environment variable that remains is `AI_TOKEN_ENC_KEY` — a cryptographic secret required to decrypt stored tokens, not a feature toggle (production MUST set it; a throwaway dev default keeps the container bootable).
+
+### 6. Error taxonomy + degraded modes
+
+A provider call can fail in ways the old single-tenant Ollama daemon never did (per-user quota, rate limits, revoked keys). Failures map to an `AiFailureReason`:
+
+| Reason | Trigger |
+|--------|---------|
+| `invalid_token` | HTTP 401 / 403 |
+| `quota_exceeded` | HTTP 429, persistent (no `Retry-After` or exhausted budget) |
+| `rate_limited` | HTTP 429 with `Retry-After` |
+| `unavailable` | HTTP 5xx / timeout |
+
+Degraded behaviour:
+
+- **Synchronous chat** degrades to an HTTP **503** with a **reason-aware message** (e.g. "your API key was rejected" vs "the provider is temporarily unavailable"), so the user can act (fix the key, wait, top up).
+- **Asynchronous analysis** (per-stage + overview, ADR-027 Phase 2) is **best-effort**: on failure it is **skipped**, not retried to failure; trip computation and rule-based alerts (ADR-012) are unaffected.
+- **AI not configured** is **not an error**: the chat surfaces a graceful in-chat `info` hint ("configure a provider to enable the assistant"), not a 503.
+
+### 7. What the user's key powers
+
+A configured key powers, per user:
+
+- per-stage and whole-trip **analysis** (async, ADR-027 Phase 2);
+- the **chat assistant** and its **in-ride POI** mode;
+- (**planned**) AI route generation from a free-text brief.
+
+### 8. Privacy disclosure (mandatory)
+
+When AI is enabled, **trip data (route, towns, dates) is sent to the user-chosen provider with the user's own key and billed to their account**. This is a third-party transfer and **must be disclosed** at the point of configuration and in the legal pages. The guarantee is: **no trip data leaves to a third party unless the user opts in by configuring a provider.** With AI off (the default), the local-first posture of ADR-028 holds — nothing leaves the perimeter.
+
+### 9. Ollama removal
+
+The self-hosted tier is removed entirely:
+
+- `App\Llm\OllamaClient` and the `OLLAMA_*` environment variables are deleted.
+- The bundled `ollama` Compose service (and its on-demand model-load wiring) is removed.
+- The `/health` Ollama probes (`deps.ollama_chat` / `deps.ollama_analysis`) are removed; AI is no longer a server dependency or health signal — per-user token configuration alone decides availability.
+- The `symfony/ai-ollama-platform` package is dropped; the three cloud bridges replace it.
+
+## Consequences
+
+### Positive
+
+- **No inference cost or footprint for the operator.** No model on the VM, no per-token bill — the constraint ADR-028/ADR-039 fought is gone. The beta VM's LLM RAM/CPU budget (2.3-7 GB resident, a serialised `llm` worker, model-pull toil) is freed.
+- **Better models available.** Users opt into Claude / Gemini / GPT-4o-class quality the free tier could never host.
+- **Privacy by default is stronger, not weaker.** With AI off (the default) nothing leaves the perimeter; the third-party transfer happens only on explicit, per-user opt-in with the user's own key and is disclosed.
+- **Provider-neutral.** Adding a fourth provider is a bridge + a default-models row, not a rewrite. Callers are untouched (preserved `LlmClientInterface`).
+- **Cleaner failure model.** The explicit `AiFailureReason` taxonomy gives the user actionable messages (bad key vs quota vs outage) instead of a generic "AI unavailable".
+- **Computation is never blocked.** Async analysis is best-effort; rule-based alerts (ADR-012) remain the deterministic source of truth.
+
+### Negative
+
+- **Trip data goes to a third party when AI is on.** The local-first guarantee only holds with AI off. This is a deliberate, disclosed, opt-in trade-off — but it is a real departure from ADR-028's stance.
+- **The user bears the cost and the key management.** AI quality and availability depend on the user's own provider account, budget, and quota — outside the operator's control. A user with no key gets no AI.
+- **Per-user secret to protect.** Storing provider keys adds an encrypted-credential surface (`AI_TOKEN_ENC_KEY` management, erasure on GDPR delete) that the keyless Ollama tier did not have.
+- **Per-user, per-provider variance.** Output quality and latency now differ by provider and model, so behaviour is less uniform across users than a single self-hosted model was.
+
+### Neutral
+
+- The 2-pass analysis pipeline, the gate integration (ADR-027), and the `symfony/ai-platform` transport abstraction (ADR-030) are unchanged; only the bridge and the per-user client construction differ.
+- Default models are pinned per provider and not user-selectable in v1; making them selectable is a later, additive change.
+
+## Alternatives considered
+
+### Keep the self-hosted Ollama tier (status quo, ADR-028 / ADR-039)
+
+**Rejected.** It carries a recurring operator cost and footprint (disk, 2.3-7 GB resident, CPU-only latency, model-pull and OOM toil, a dedicated serialised worker) to host a model that, on the free tier, is capped at 3B-class quality. The privacy benefit only pays off if the operator funds the compute, which a free single-operator project cannot. ADR-039's own migration path already conceded that good models meant moving inference off the VM.
+
+### Single managed provider (operator picks one cloud, e.g. Anthropic only)
+
+**Rejected.** Removes the footprint but introduces vendor lock-in and still leaves the "who pays per token?" question unanswered. If the operator pays, there is no monetisation path (the same wall ADR-028 hit). If the user pays, there is no reason to constrain them to one vendor — the multi-provider BYO design costs little more (one bridge per provider, one factory) and gives users choice.
+
+### Server-paid keys (operator's key, shared across users)
+
+**Rejected.** A single operator-funded key for all users has no cost ceiling, is trivially abused, and reintroduces the monetisation problem the project has no answer for. It also concentrates all users' trip data under one operator-owned third-party account, which is harder to reason about for GDPR than a per-user, user-owned, user-billed key.
+
+## Sources
+
+- [ADR-001: Global Architecture and Separation of Concerns](adr-001-global-architecture-and-separation-of-concerns.md)
+- [ADR-012: Rule-based Nudge and Contextual Alert Engine](adr-012-rule-based-nudge-and-contextual-alert-engine.md)
+- [ADR-027: Gate Mechanism and Two-Phase Pipeline](adr-027-gate-mechanism-two-phase-pipeline.md)
+- [ADR-028: Ollama/LLaMA Integration](adr-028-ollama-llama-integration.md) — superseded by this ADR for the AI transport/backend
+- [ADR-030: symfony/ai Adoption](adr-030-symfony-ai-adoption.md) — the transport abstraction kept; the Ollama bridge replaced by cloud bridges
+- [ADR-035: GDPR Account Erasure](adr-035-rgpd-account-erasure.md) — the per-user token is wiped on erasure
+- [ADR-039: Beta Right-Sizing on the Oracle Free Tier](adr-039-beta-right-sizing-free-tier.md) — the LLM RAM/CPU budget freed by removing the self-hosted tier
+- [symfony/ai](https://ai.symfony.com/) — `symfony/ai-platform` and the Anthropic / Gemini / OpenAI bridges

--- a/docs/adr/adr-042-optional-multi-provider-ai-byo-token.md
+++ b/docs/adr/adr-042-optional-multi-provider-ai-byo-token.md
@@ -74,7 +74,7 @@ Each provider HTTP client is **SSRF-scoped to that provider's host** (per ADR-00
 
 ### 5. Availability is decided per-user, never by an env flag
 
-The AI features are **always present in the build** — they are part of the product, not a deployment option. What is optional is **per-user activation**: a feature is usable only once *that user* has chosen a provider and saved their token. The application therefore does **not** enable or disable AI through an environment variable. The old global `OLLAMA_ENABLED` server flag (which answered "is the self-hosted tier reachable?") is removed and **not replaced** by any equivalent toggle.
+The AI features are **always present in the build** — they are part of the product, not a deployment option. What is optional is **per-user activation**: a feature is usable only once *that user* has chosen a provider and saved their token. The application therefore does **not** enable or disable AI through an environment variable. Two env-var flags are removed and **not replaced**: the Ollama-specific `OLLAMA_ENABLED` (which answered "is the self-hosted tier reachable?") and the instance-wide `AI_ENABLED` kill-switch on `LlmClientFactory`/`services.php` (which answered "is AI enabled for all users on this server?").
 
 Two states, generalising the ADR-028 degraded-mode contract:
 

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -20,7 +20,6 @@ Every runbook follows the same four sections:
 | [database-disk-full.md](database-disk-full.md) | PostgreSQL disk pressure |
 | [redis-out-of-memory.md](redis-out-of-memory.md) | Redis `OOM` evictions or refused writes |
 | [mercure-disconnected.md](mercure-disconnected.md) | SSE clients cannot reconnect |
-| [ollama-down.md](ollama-down.md) | LLM dependency unreachable (hard dep per ADR-028) |
 | [valhalla-overpass-rebuild.md](valhalla-overpass-rebuild.md) | Routing tiles or POI cache rebuild |
 | [osm-france-refresh.md](osm-france-refresh.md) | Monthly France-wide OSM build + tile upload |
 | [oracle-vm-reclaimed.md](oracle-vm-reclaimed.md) | Oracle Always Free instance reclaimed |

--- a/docs/runbooks/ollama-down.md
+++ b/docs/runbooks/ollama-down.md
@@ -1,5 +1,7 @@
 # Ollama Down
 
+> **⚠️ Obsolete (2026-06-19) — superseded by [ADR-042](../adr/adr-042-optional-multi-provider-ai-byo-token.md).** The self-hosted Ollama/LLaMA tier this runbook covers has been removed: there is no `ollama` Compose service, no `OLLAMA_*` env, and no `/api/health` Ollama probe. AI is now an optional, per-user, multi-provider bring-your-own-token model (Anthropic, Gemini, OpenAI) — there is no operator-side inference service to restart. AI availability is decided per-user (is a token configured?) — there is no env-var toggle; provider failures degrade gracefully (reason-aware 503 on chat, skipped async analysis). This file is kept for historical reference only.
+
 Ollama is an **optional LLM tier** running in **explicit degraded mode** (ADR-028, "Decision Update — Degraded Mode Re-instated"). When it is unreachable the app **stays up**: AI passes are skipped (not retried to failure), the events are logged `critical` for alerting, `/api/health` stays HTTP **200** (Ollama is excluded from the readiness `$required` set), and the PWA **disables the AI features with an explicit "unavailable" notice** rather than silently dropping them. Trip computation, rule-based alerts, and `TRIP_READY` are unaffected.
 
 ## Symptômes


### PR DESCRIPTION
## Contexte

Volet documentaire du chantier **IA optionnelle multi-provider (BYO token)**. Documente la migration d'Ollama auto-hébergé vers un modèle **optionnel au niveau utilisateur, multi-fournisseur, à clé personnelle**.

> **Précision clé (correction)** : l'IA n'est PAS optionnelle au niveau de l'architecture — les features IA sont toujours présentes dans le build. Elle est optionnelle **au niveau utilisateur** : activable uniquement si l'utilisateur choisit un fournisseur et fournit son token. **Aucun toggle par variable d'environnement** ne pilote l'IA (l'ancien `OLLAMA_ENABLED` est supprimé et non remplacé). Seul `AI_TOKEN_ENC_KEY` (clé de chiffrement, pas un toggle) subsiste.

## Changements

- **`docs/adr/adr-042-...md`** (NEW) : ADR autoritatif — opt-in par-utilisateur, fournisseurs v1 (Anthropic/Claude, Google/Gemini, OpenAI), token chiffré (libsodium, `AI_TOKEN_ENC_KEY`) + API `/users/me/ai-settings`, `PlatformLlmClient` + factory par-utilisateur, taxonomie d'erreurs, modes dégradés, modèles par fournisseur, divulgation RGPD, retrait Ollama. **Disponibilité décidée par-utilisateur, jamais par une var d'env.**
- **ADR-028 / ADR-030 / ADR-039** : bandeau « Superseded by ADR-042 ».
- **`docs/LLaMA.md`** : bandeau obsolète + stack mise à jour.
- **`README.md` / `README.fr.md`** : section IA réécrite (opt-in, fournisseurs, clé en réglages compte, chiffrement, RGPD, dégradation) + tables tech (retrait Ollama) + index runbooks.
- **`docs/README.md` / `docs/README.fr.md`** : index docs (pointe ADR-042 ; LLaMA.md historique).
- **`docs/runbooks/ollama-down.md`** : marqué obsolète (conservé pour historique) + retiré de l'index runbooks.

## Vérification

Docs uniquement (Markdown). Pas de code touché. Markdownlint en CI.

## Suite (non incluse ici)

- **Retrait code/infra** (PR #716, à étendre) : suppression du **kill-switch `AI_ENABLED`** du backend (factory + services.php + .env) — l'IA ne dépend plus d'une var d'env — et retrait du service `ollama` des `compose*.yaml` + `compose.ollama.yaml`.
- **Frontend** : suppression du gate `NEXT_PUBLIC_AI_ENABLED` (features toujours présentes, conditionnées par `configured`) + câblage des 2 entrées FAQ IA (« activer l'IA », « partage des données »).

<!-- claude-review-start -->
## Claude Review

**Commit reviewed:** 9e4cbd0

**Summary:** All previously open threads have been addressed. The fifth commit (9e4cbd0) resolved the last remaining stale LLaMA reference (`Fallback frontend sans LLaMA` → `sans IA`). The ADR is thorough and internally consistent; the superseded banners, runbook archival, and documentation updates are all coherent. One minor note: the PR title is still a noun phrase rather than imperative mood (flagged in prior reviews).

**Resolved threads:** Resolved 1 previously open thread (PRRT_kwDORUitfM6KyK19 — `Fallback frontend sans LLaMA` in FEATURES.md §11 Frontend IA table, addressed in commit 9e4cbd0).

**PR title check**
`docs(ai): ADR-042 + optional per-user multi-provider AI documentation` — description is a noun phrase, not imperative mood. Suggested: `docs(ai): add ADR-042 for optional per-user multi-provider AI`.

**Review checklist**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases (docs only — no code)
- [x] Documentation is internally consistent
- [x] Dependent tickets accounted for (PR #716 referenced)

**Inline comments:** No inline comments.
<!-- claude-review-end -->