### PR TITLE
feat(ai): drop the NEXT_PUBLIC_AI_ENABLED gate + AI FAQ entries

### DIFF
--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -1015,6 +1015,7 @@
     "categoryProject": "The project",
     "categoryHowItWorks": "How it works",
     "categoryAccess": "Access",
+    "categoryAi": "AI assistant",
     "q1": "What sets Bike Trip Planner apart from Komoot or RideWithGPS?",
     "a1": "Komoot and RideWithGPS are GPS navigation platforms. Bike Trip Planner is a multi-day itinerary planning tool: it automatically splits your route into daily stages based on your cyclist profile (speed, accumulated fatigue, elevation), suggests accommodations at each stage endpoint, and generates contextual alerts (weather, resupply, health services, etc.). It complements your navigation apps rather than replacing them.",
     "q2": "Why use this tool instead of planning manually on a map?",
@@ -1032,7 +1033,11 @@
     "q8": "How do I get access to the app?",
     "a8": "The app uses a magic link sign-in system: enter your email address on the sign-in page and you will receive a secure sign-in link. No password is required.",
     "q9": "Is the app free and open source?",
-    "a9": "The source code is open source and available on GitHub. The hosted app is free to use. Infrastructure costs may eventually justify a freemium model, but no paid access is planned at this stage."
+    "a9": "The source code is open source and available on GitHub. The hosted app is free to use. Infrastructure costs may eventually justify a freemium model, but no paid access is planned at this stage.",
+    "q10": "How do I enable the AI assistant?",
+    "a10": "The AI assistant is enabled from your account settings: choose a provider (Anthropic/Claude, Google/Gemini, or OpenAI) and enter your own API key. As long as no key is provided, AI stays disabled and the related features are shown in a disabled state.",
+    "q11": "Is my data shared with the AI?",
+    "a11": "Only if you enable AI. In that case, your trip data is sent to the provider you chose, using your own API key (billed to your account). Your key is encrypted and is never shared in any other way. You can remove it at any time from your account settings."
   },
   "events": {
     "type_festival": "Festival",

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -1015,6 +1015,7 @@
     "categoryProject": "Le projet",
     "categoryHowItWorks": "Fonctionnement",
     "categoryAccess": "Accès",
+    "categoryAi": "Assistant IA",
     "q1": "Qu'est-ce qui différencie Bike Trip Planner de Komoot ou RideWithGPS ?",
     "a1": "Komoot et RideWithGPS sont des plateformes de navigation GPS. Bike Trip Planner est un outil de planification d'itinéraire multi-étapes : il découpe automatiquement votre parcours en étapes journalières en tenant compte de votre profil cycliste (vitesse, fatigue accumulée, dénivelé), suggère des hébergements au point d'arrivée de chaque étape, et génère des alertes contextuelles (météo, ravitaillement, services de santé, etc.). Il complète vos outils de navigation plutôt qu'il ne les remplace.",
     "q2": "Pourquoi utiliser cet outil plutôt que de planifier manuellement sur une carte ?",
@@ -1032,7 +1033,11 @@
     "q8": "Comment obtenir un accès à l'application ?",
     "a8": "L'application utilise un système de connexion par lien magique : entrez votre adresse email sur la page de connexion et vous recevrez un lien de connexion sécurisé. Aucun mot de passe n'est requis.",
     "q9": "L'application est-elle gratuite et open source ?",
-    "a9": "Le code source est open source et disponible sur GitHub. L'application hébergée est accessible gratuitement. Des coûts d'infrastructure peuvent à terme justifier une offre freemium, mais aucun accès payant n'est prévu à ce stade."
+    "a9": "Le code source est open source et disponible sur GitHub. L'application hébergée est accessible gratuitement. Des coûts d'infrastructure peuvent à terme justifier une offre freemium, mais aucun accès payant n'est prévu à ce stade.",
+    "q10": "Comment activer l'assistant IA ?",
+    "a10": "L'assistant IA s'active depuis les réglages de votre compte : choisissez un fournisseur (Anthropic/Claude, Google/Gemini ou OpenAI) et renseignez votre propre clé API. Tant qu'aucune clé n'est fournie, l'IA reste désactivée et les fonctionnalités correspondantes s'affichent en mode désactivé.",
+    "q11": "Mes données sont-elles partagées avec l'IA ?",
+    "a11": "Uniquement si vous activez l'IA. Dans ce cas, vos données de voyage sont envoyées au fournisseur que vous avez choisi, avec votre propre clé API (facturée sur votre compte). Votre clé est chiffrée et n'est jamais partagée d'aucune autre manière. Vous pouvez la retirer à tout moment depuis les réglages du compte."
   },
   "events": {
     "type_festival": "Festival",

--- a/pwa/src/app/faq/page.tsx
+++ b/pwa/src/app/faq/page.tsx
@@ -36,6 +36,14 @@ export default async function FaqPage() {
         { question: t("q9"), answer: t("a9") },
       ],
     },
+    {
+      id: "ai",
+      label: t("categoryAi"),
+      items: [
+        { question: t("q10"), answer: t("a10") },
+        { question: t("q11"), answer: t("a11") },
+      ],
+    },
   ];
 
   return (

--- a/pwa/src/app/trips/new/page.tsx
+++ b/pwa/src/app/trips/new/page.tsx
@@ -176,12 +176,10 @@ function WizardContent() {
         <TripPlanner
           hideStepper
           previewSlot={
-            aiCapability.enabled ? (
-              <AiRefinementCard
-                unavailable={!aiCapability.available}
-                notConfigured={!aiCapability.configured}
-              />
-            ) : undefined
+            <AiRefinementCard
+              unavailable={!aiCapability.available}
+              notConfigured={!aiCapability.configured}
+            />
           }
         />
       </div>

--- a/pwa/src/components/ai-bubble.tsx
+++ b/pwa/src/components/ai-bubble.tsx
@@ -57,10 +57,8 @@ export function AiBubble() {
   };
 
   if (!trip || isAnalysisPhaseActive) return null;
-  // AI disabled by config (NEXT_PUBLIC_AI_ENABLED=0) — hide the assistant entirely.
-  if (!aiCapability.enabled) return null;
 
-  // Disabled-but-visible affordance when the network is down, the (enabled) AI
+  // Disabled-but-visible affordance when the network is down, the AI
   // tier is unreachable (#304), or no provider is configured on the account
   // (ADR-042): same visual treatment, distinct title + data attribute. The
   // not-configured state links to the settings via its title.

--- a/pwa/src/components/card-selection.tsx
+++ b/pwa/src/components/card-selection.tsx
@@ -115,12 +115,11 @@ export function CardSelection({
           />
         )}
 
-        {/* Card: AI Assistant — multi-turn chat shell (#392). Gated on AI
-            availability: hidden when AI is off by config (#304), disabled with
-            an inline notice when enabled but the LLM tier is unreachable, or
-            disabled-but-visible with a "Configurez une IA" CTA when no provider
-            is set on the account (ADR-042). */}
-        {aiCapability.enabled && (selected === null || selected === "ai") && (
+        {/* Card: AI Assistant — multi-turn chat shell (#392). Always visible:
+            disabled with an inline notice when the LLM tier is unreachable
+            (#304), or disabled-but-visible with a "Configurez une IA" CTA when
+            no provider is set on the account (ADR-042). */}
+        {(selected === null || selected === "ai") && (
           <AiCard
             expanded={selected === "ai"}
             disabled={disabled}

--- a/pwa/src/components/help-modal.tsx
+++ b/pwa/src/components/help-modal.tsx
@@ -81,6 +81,14 @@ export function HelpModal() {
         { question: tFaq("q9"), answer: tFaq("a9") },
       ],
     },
+    {
+      id: "ai",
+      label: tFaq("categoryAi"),
+      items: [
+        { question: tFaq("q10"), answer: tFaq("a10") },
+        { question: tFaq("q11"), answer: tFaq("a11") },
+      ],
+    },
   ];
 
   return (

--- a/pwa/src/components/trip-planner.tsx
+++ b/pwa/src/components/trip-planner.tsx
@@ -147,15 +147,13 @@ export function TripPlanner({
   const resetStepper = useUiStore((s) => s.resetStepper);
   const hasAnalysisStarted = useUiStore((s) => s.hasAnalysisStarted);
   const isAnalysisPhaseActive = useUiStore((s) => s.isAnalysisPhaseActive);
-  const aiEnabled = useUiStore((s) => s.aiCapability.enabled);
   const aiAvailable = useUiStore((s) => s.aiCapability.available);
   const aiConfigured = useUiStore((s) => s.aiCapability.configured);
   const setAiAvailable = useUiStore((s) => s.setAiAvailable);
 
-  // Probe the LLM tier once on mount so AI features can be gated explicitly when it
-  // is enabled but unreachable (#304); no network call at all when AI is off.
+  // Probe the LLM tier once on mount so AI features can be gated explicitly when
+  // the tier is unreachable (#304).
   useEffect(() => {
-    if (!aiEnabled) return;
     let cancelled = false;
     void fetchAiAvailability().then((available) => {
       if (!cancelled) setAiAvailable(available);
@@ -163,7 +161,7 @@ export function TripPlanner({
     return () => {
       cancelled = true;
     };
-  }, [aiEnabled, setAiAvailable]);
+  }, [setAiAvailable]);
 
   // Sync the `configured` signal from the account (ADR-042): AI surfaces stay
   // disabled-but-visible until a provider + token is set.
@@ -252,16 +250,14 @@ export function TripPlanner({
     const onSetAiCapability = (e: Event) => {
       const detail = (
         e as CustomEvent<{
-          enabled: boolean;
           available: boolean;
           configured?: boolean;
         }>
       ).detail;
       if (detail) {
-        // `configured` defaults to true so the pre-ADR-042 capability tests
-        // (which only drive enabled/available) keep exercising the active path.
+        // `configured` defaults to true so the capability tests that only drive
+        // `available` keep exercising the active path.
         useUiStore.getState().setAiCapability({
-          enabled: detail.enabled,
           available: detail.available,
           configured: detail.configured ?? true,
         });
@@ -703,13 +699,12 @@ export function TripPlanner({
                   silently when the LLM pipeline is disabled or did not produce
                   an overview. Placed above the stage timeline so it gives the
                   user a high-level view before they dive into per-stage data. */}
-              {aiEnabled && !aiConfigured ? (
+              {!aiConfigured ? (
                 <AiUnavailableNotice
                   variant="notConfigured"
                   context="analysis"
                 />
               ) : (
-                aiEnabled &&
                 !aiAvailable && <AiUnavailableNotice context="analysis" />
               )}
               <TripAiOverview />

--- a/pwa/src/hooks/use-ai-settings.ts
+++ b/pwa/src/hooks/use-ai-settings.ts
@@ -10,15 +10,12 @@ import { useUiStore } from "@/store/ui-store";
  * Reads `GET /users/me/ai-settings` once on mount and flips
  * `aiCapability.configured` to whether a provider is set. AI surfaces stay
  * disabled-but-visible (with a "Configurez une IA" CTA) until this confirms a
- * configured provider. No network call at all when AI is disabled by build
- * config (`AI_ENABLED`).
+ * configured provider.
  */
 export function useAiSettings(): void {
-  const aiEnabled = useUiStore((s) => s.aiCapability.enabled);
   const setAiConfigured = useUiStore((s) => s.setAiConfigured);
 
   useEffect(() => {
-    if (!aiEnabled) return;
     let cancelled = false;
     void fetchAiSettings().then((settings) => {
       if (!cancelled) setAiConfigured(Boolean(settings?.provider));
@@ -26,5 +23,5 @@ export function useAiSettings(): void {
     return () => {
       cancelled = true;
     };
-  }, [aiEnabled, setAiConfigured]);
+  }, [setAiConfigured]);
 }

--- a/pwa/src/hooks/use-mercure.ts
+++ b/pwa/src/hooks/use-mercure.ts
@@ -517,15 +517,11 @@ function dispatchEvent(event: MercureEvent): void {
         event.data.aiOverview,
       );
       store.setAiOverview(parsedOverview.success ? parsedOverview.data : null);
-      // If AI is enabled and looked reachable at mount but no overview arrived, the
-      // tier may have gone down mid-Phase 2. Re-probe so the UI can explicitly flag
-      // the outage instead of silently showing no analysis (#304).
+      // If AI looked reachable at mount but no overview arrived, the tier may
+      // have gone down mid-Phase 2. Re-probe so the UI can explicitly flag the
+      // outage instead of silently showing no analysis (#304).
       const ui = useUiStore.getState();
-      if (
-        ui.aiCapability.enabled &&
-        ui.aiCapability.available &&
-        !parsedOverview.success
-      ) {
+      if (ui.aiCapability.available && !parsedOverview.success) {
         void fetchAiAvailability().then((available) =>
           ui.setAiAvailable(available),
         );

--- a/pwa/src/lib/ai-availability.ts
+++ b/pwa/src/lib/ai-availability.ts
@@ -13,9 +13,8 @@ interface HealthResponse {
 /**
  * Runtime AI-tier availability probe (#304).
  *
- * Orthogonal to the build-time {@link AI_ENABLED} flag (which decides whether AI
- * features should exist at all): this answers "is the LLM tier reachable right
- * now?" by reading `/api/health` → `deps.ollama_chat.status`. When the backend
+ * Answers "is the LLM tier reachable right now?" by reading `/api/health` →
+ * `deps.ollama_chat.status`. When the backend
  * runs with `OLLAMA_ENABLED=0` it omits the key entirely, which resolves to
  * unavailable (covers a front-enabled / API-disabled misconfiguration).
  *

--- a/pwa/src/lib/constants.ts
+++ b/pwa/src/lib/constants.ts
@@ -49,15 +49,6 @@ export const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "https://localhost";
 export const SITE_URL = process.env.NEXT_PUBLIC_API_URL || "https://localhost";
 
 /**
- * Whether the AI tier is enabled for this build (mirrors backend `OLLAMA_ENABLED`).
- * Build-time only — `NEXT_PUBLIC_*` is inlined, so flipping it requires a front
- * rebuild. Defaults to enabled; set `NEXT_PUBLIC_AI_ENABLED=0` to hide the AI
- * features outright (no network call). When enabled, runtime availability is read
- * from `/api/health` (see `ai-availability.ts`).
- */
-export const AI_ENABLED = process.env.NEXT_PUBLIC_AI_ENABLED !== "0";
-
-/**
  * GDPR/legal contact address shown on the legal & privacy pages. Each
  * self-hosted instance sets its own mailbox via `NEXT_PUBLIC_CONTACT_EMAIL`
  * (build-time inlined); the default is a generic RFC 2606 placeholder so the

--- a/pwa/src/store/ui-store.ts
+++ b/pwa/src/store/ui-store.ts
@@ -3,7 +3,6 @@
 import { create } from "zustand";
 import { immer } from "zustand/middleware/immer";
 import { enableMapSet } from "immer";
-import { AI_ENABLED } from "@/lib/constants";
 
 // Required for Immer to allow mutating Set/Map drafts (used by completedSteps).
 enableMapSet();
@@ -176,7 +175,6 @@ interface UiState {
   hasSeenBubble: boolean;
   /**
    * AI tier availability driving the explicit gating (#304, ADR-042).
-   * - `enabled`: build-time config (`AI_ENABLED`); when false, AI features are hidden.
    * - `available`: runtime reachability of the LLM tier, read from `/api/health`
    *   (`deps.ollama_chat`). Starts optimistic (`true`) to avoid a disabled→enabled
    *   flash; flipped to `false` only once an outage is confirmed. For the
@@ -188,7 +186,7 @@ interface UiState {
    *   (fail-closed) so the controls stay disabled until the settings confirm
    *   a provider.
    */
-  aiCapability: { enabled: boolean; available: boolean; configured: boolean };
+  aiCapability: { available: boolean; configured: boolean };
 
   setProcessing: (value: boolean) => void;
   setAccommodationScanning: (value: boolean) => void;
@@ -255,7 +253,6 @@ interface UiState {
   setAiConfigured: (value: boolean) => void;
   /** Replace the whole AI capability — E2E override hook for the states. */
   setAiCapability: (capability: {
-    enabled: boolean;
     available: boolean;
     configured: boolean;
   }) => void;
@@ -333,7 +330,7 @@ export const useUiStore = create<UiState>()(
     currentContext: { currentStage: null },
     isChatSending: false,
     hasSeenBubble: readBubbleSeenFromStorage(),
-    aiCapability: { enabled: AI_ENABLED, available: true, configured: false },
+    aiCapability: { available: true, configured: false },
 
     setProcessing: (value) =>
       set((state) => {

--- a/pwa/tests/mocked/ai-capabilities.spec.ts
+++ b/pwa/tests/mocked/ai-capabilities.spec.ts
@@ -2,20 +2,22 @@ import { test, expect } from "../fixtures/base.fixture";
 import { mockAllApis } from "../fixtures/api-mocks";
 
 /**
- * Issue #304 — explicit degraded-mode gating of the AI features.
+ * Issue #304 / ADR-042 — explicit gating of the AI features.
  *
- * `NEXT_PUBLIC_AI_ENABLED` defaults to enabled and runtime availability comes
- * from `/api/health`. To pin all three states deterministically — and prod-safely,
- * since the E2E build hides `window.__zustand_ui_store` — the tests drive the
- * capability via the `__test_set_ai_capability` CustomEvent:
- *  - enabled + reachable   → AI features active
- *  - enabled + unreachable → features disabled with an explicit notice
- *  - disabled by config    → features hidden (no notice)
+ * AI is per-user (no build-time env gate): the controls are always present and
+ * driven solely by runtime signals. Availability comes from `/api/health`, and
+ * `configured` from the account `GET /users/me/ai-settings`. To pin the states
+ * deterministically — and prod-safely, since the E2E build hides
+ * `window.__zustand_ui_store` — the tests drive the capability via the
+ * `__test_set_ai_capability` CustomEvent:
+ *  - reachable + configured   → AI features active
+ *  - unreachable              → features disabled with an explicit notice
+ *  - not configured           → disabled-but-visible with a configure CTA
  */
 
 function setAiCapability(
   page: import("@playwright/test").Page,
-  capability: { enabled: boolean; available: boolean; configured?: boolean },
+  capability: { available: boolean; configured?: boolean },
 ): Promise<void> {
   return page.evaluate((detail) => {
     window.dispatchEvent(
@@ -30,7 +32,7 @@ test.describe("AI capabilities gating (#304)", () => {
     mockedPage,
   }) => {
     await createFullTrip();
-    await setAiCapability(mockedPage, { enabled: true, available: true });
+    await setAiCapability(mockedPage, { available: true });
 
     const bubble = mockedPage.getByTestId("ai-bubble");
     await expect(bubble).toBeVisible();
@@ -43,12 +45,12 @@ test.describe("AI capabilities gating (#304)", () => {
     await expect(mockedPage.getByTestId("ai-chat-panel")).toBeVisible();
   });
 
-  test("tier enabled but unreachable: the assistant is disabled and the notice shows", async ({
+  test("tier unreachable: the assistant is disabled and the notice shows", async ({
     createFullTrip,
     mockedPage,
   }) => {
     await createFullTrip();
-    await setAiCapability(mockedPage, { enabled: true, available: false });
+    await setAiCapability(mockedPage, { available: false });
 
     const bubble = mockedPage.getByTestId("ai-bubble");
     await expect(bubble).toBeVisible();
@@ -63,25 +65,27 @@ test.describe("AI capabilities gating (#304)", () => {
     await expect(mockedPage.getByTestId("ai-unavailable-notice")).toBeVisible();
   });
 
-  test("disabled by config: AI features are hidden with no notice", async ({
+  test("not configured: the assistant is visible-but-disabled with a configure CTA", async ({
     createFullTrip,
     mockedPage,
   }) => {
     await createFullTrip();
-    await setAiCapability(mockedPage, { enabled: false, available: false });
+    await setAiCapability(mockedPage, { available: true, configured: false });
 
-    await expect(mockedPage.getByTestId("ai-bubble")).toHaveCount(0);
-    await expect(mockedPage.getByTestId("ai-unavailable-notice")).toHaveCount(
-      0,
-    );
+    const bubble = mockedPage.getByTestId("ai-bubble");
+    await expect(bubble).toBeVisible();
+    await expect(bubble).toHaveAttribute("data-not-configured", "");
+    await expect(
+      mockedPage.getByTestId("ai-not-configured-notice"),
+    ).toBeVisible();
   });
 });
 
 /**
- * Same three states for the Acte 1 AI generation card (card-selection): hidden
- * when AI is off by config, disabled with an inline notice when enabled but the
- * LLM tier is unreachable, active otherwise. Availability is driven via the
- * mocked `/api/health` probe; the build-time "disabled" state via the test hook.
+ * Same states for the Acte 1 AI generation card (card-selection): always
+ * visible, disabled with an inline notice when the LLM tier is unreachable or no
+ * provider is configured, active otherwise. Availability is driven via the
+ * mocked `/api/health` probe; `configured` via the account mock.
  */
 test.describe("AI generation card gating (#304)", () => {
   test("tier reachable: the generation card is active and expands to the chat", async ({
@@ -99,7 +103,7 @@ test.describe("AI generation card gating (#304)", () => {
     await expect(page.getByTestId("ai-chat-card")).toBeVisible();
   });
 
-  test("tier enabled but unreachable: the generation card is disabled with a notice", async ({
+  test("tier unreachable: the generation card is disabled with a notice", async ({
     page,
   }) => {
     await mockAllApis(page, { aiAvailable: false });
@@ -116,21 +120,15 @@ test.describe("AI generation card gating (#304)", () => {
     await expect(page.getByTestId("ai-chat-card")).toHaveCount(0);
   });
 
-  test("disabled by config: the generation card is hidden", async ({ page }) => {
+  test("always visible: the generation card stays present alongside the link card", async ({
+    page,
+  }) => {
     await mockAllApis(page);
     await page.goto("/");
     await page.waitForLoadState("networkidle");
 
-    // Build-time AI_ENABLED can't be flipped at runtime; drive it via the hook.
-    await page.evaluate(() =>
-      window.dispatchEvent(
-        new CustomEvent("__test_set_ai_capability", {
-          detail: { enabled: false, available: false },
-        }),
-      ),
-    );
-
-    await expect(page.getByTestId("card-ai")).toHaveCount(0);
+    // AI is per-user (no env gate): the card is always rendered.
+    await expect(page.getByTestId("card-ai")).toBeVisible();
     await expect(page.getByTestId("card-link")).toBeVisible();
   });
 
@@ -175,7 +173,6 @@ test.describe("AI not-configured gating (ADR-042)", () => {
   }) => {
     await createFullTrip();
     await setAiCapability(mockedPage, {
-      enabled: true,
       available: true,
       configured: false,
     });

--- a/pwa/tests/mocked/faq.spec.ts
+++ b/pwa/tests/mocked/faq.spec.ts
@@ -26,12 +26,12 @@ test.describe("/faq page", () => {
     await expect(page.getByTestId("section-footer")).toBeVisible();
   });
 
-  test("displays all three FAQ categories", async ({ page }) => {
+  test("displays all four FAQ categories", async ({ page }) => {
     await page.goto("/faq");
     await page.waitForLoadState("networkidle");
 
     const headings = page.getByRole("heading", { level: 2 });
-    await expect(headings).toHaveCount(3);
+    await expect(headings).toHaveCount(4);
   });
 
   test("accordion items are collapsed by default", async ({ page }) => {

--- a/pwa/tests/recette/steps/ai-features.steps.ts
+++ b/pwa/tests/recette/steps/ai-features.steps.ts
@@ -170,7 +170,7 @@ async function enterRefinementPreview(
   await page.evaluate((avail) => {
     window.dispatchEvent(
       new CustomEvent("__test_set_ai_capability", {
-        detail: { enabled: true, available: avail },
+        detail: { available: avail },
       }),
     );
     window.dispatchEvent(


### PR DESCRIPTION
## Contexte (ADR-042)

L'IA est optionnelle **au niveau utilisateur**, pas via une variable d'environnement de build. Les fonctionnalites IA sont toujours presentes dans le build ; elles s'activent par utilisateur une fois qu'un fournisseur + une cle API personnelle sont configures dans les reglages du compte. L'app ne doit donc plus activer/desactiver l'IA via une variable d'env.

## Changements

### 1. Suppression du gate `NEXT_PUBLIC_AI_ENABLED` / `enabled`

La disponibilite de l'IA est desormais pilotee uniquement par les signaux runtime :
- `configured` (un fournisseur est defini sur le compte, lu depuis `GET /users/me/ai-settings`)
- `available` conserve pour la joignabilite du tier LLM (#304)

Le booleen build-time `enabled` est entierement supprime. **L'affordance IA est toujours visible** : desactivee-mais-visible avec un CTA "Configurez une IA" tant que `!configured`, active une fois configuree.

Fichiers :
- `pwa/src/lib/constants.ts` : suppression de la constante `AI_ENABLED`.
- `pwa/src/store/ui-store.ts` : suppression du champ `enabled` de `aiCapability` (type, valeur initiale, import, docblock, signature de `setAiCapability`).
- `pwa/src/lib/ai-availability.ts` : docblock nettoye (plus de reference au flag build-time).
- `pwa/src/hooks/use-ai-settings.ts` : suppression du early-return `!enabled` ; le hook synchronise toujours `configured` depuis le compte.
- `pwa/src/components/ai-bubble.tsx` : la bulle est desormais **toujours rendue** (suppression du `if (!enabled) return null`) ; etat desactive-mais-visible quand `!configured`.
- `pwa/src/components/trip-planner.tsx` : suppression du selecteur `aiEnabled`, du gate de l'effet de probe, du `enabled &&` dans la CTA `notConfigured`, et de `enabled` dans le handler de test `__test_set_ai_capability`.
- `pwa/src/components/card-selection.tsx` : la carte IA (Acte 1) est toujours affichee.
- `pwa/src/app/trips/new/page.tsx` : `AiRefinementCard` toujours rendue dans le `previewSlot`.
- `pwa/src/hooks/use-mercure.ts` : re-probe du tier sans la condition `enabled`.
- E2E `pwa/tests/mocked/ai-capabilities.spec.ts` : nouveau contrat "les controles IA sont toujours visibles ; desactives-mais-visibles avec CTA quand non configures ; actifs quand configures". La couverture `configured` true/false est conservee.

### 2. Entrees FAQ IA

Deux nouvelles entrees (nouvelle categorie "Assistant IA"), cablees dans la page FAQ et la modale d'aide, synchronisees `fr`/`en` :
- **Comment activer l'assistant IA ?** : configurer un fournisseur (Anthropic/Claude, Google/Gemini, OpenAI) + sa propre cle API dans les reglages du compte ; l'IA est desactivee tant qu'aucune cle n'est fournie.
- **Mes donnees sont-elles partagees avec l'IA ?** : uniquement si l'IA est activee ; les donnees de voyage sont envoyees au fournisseur choisi avec la cle de l'utilisateur (facturee sur son compte) ; la cle est chiffree, jamais partagee autrement, et retirable a tout moment.

## Verification

QA frontend executee dans le worktree (apres `npm ci` dans le volume node_modules) :
- ESLint : 0 erreur (warnings pre-existants uniquement, hors fichiers modifies)
- i18n-check : `883 keys in sync across fr, en`
- Prettier : tous les fichiers modifies conformes (10 fichiers en drift pre-existant non touches)
- TypeScript (`tsc --noEmit`) : aucune erreur
- E2E `ai-capabilities.spec.ts` : 8/8 passent (contre le serveur dev du worktree)
- E2E `faq.spec.ts` : 12/12 passent

La leg `qa-php` n'a pas pu tourner dans le worktree (vendor PHP non installe) ; sans rapport avec ce changement frontend-only, on s'appuie sur la CI.

> Note : `compose.dev.yaml` reference encore `NEXT_PUBLIC_AI_ENABLED` (ligne 131) ; non touche ici comme demande (gere ailleurs).

<!-- claude-review-start -->
## Claude Review

Clean, well-scoped removal of the build-time `NEXT_PUBLIC_AI_ENABLED` gate. The `enabled` field is consistently purged from the store type, initial state, selectors, and the `__test_set_ai_capability` E2E hook across all 10 modified files. The test contract accurately reflects the new always-visible AI affordance with `configured`/`available` as the sole runtime signals.

**Commit reviewed:** `c2b694429b40ebf4467cf662b8a2d18822b8f831`

**Findings:** 0 critical · 0 warning · 0 info

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

No inline comments.
<!-- claude-review-end -->
