### PR TITLE
feat(ai): AI route-generation core service (B1a)

### DIFF
--- a/api/src/Enum/SourceType.php
+++ b/api/src/Enum/SourceType.php
@@ -11,4 +11,5 @@ enum SourceType: string
     case GPX_UPLOAD = 'gpx_upload';
     case STRAVA_ROUTE = 'strava_route';
     case RIDE_WITH_GPS = 'ride_with_gps';
+    case AI_GENERATED = 'ai_generated';
 }

--- a/api/src/Generation/AiGeneratedRoute.php
+++ b/api/src/Generation/AiGeneratedRoute.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Generation;
+
+use App\ApiResource\Model\Coordinate;
+
+/**
+ * Result of {@see AiTripGenerationService::generate()}: the routed geometry on
+ * success, or an outcome + human-readable message to surface as a clarification
+ * / validation error.
+ */
+final readonly class AiGeneratedRoute
+{
+    /**
+     * @param array<string, mixed> $spec        the parsed LLM spec (empty when unparseable)
+     * @param list<Coordinate>     $coordinates the routed geometry (empty unless SUCCESS)
+     */
+    private function __construct(
+        public AiGenerationOutcome $outcome,
+        public string $message,
+        public array $spec = [],
+        public array $coordinates = [],
+        public float $distanceKm = 0.0,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $spec
+     * @param list<Coordinate>     $coordinates
+     */
+    public static function success(array $spec, array $coordinates, float $distanceKm): self
+    {
+        return new self(AiGenerationOutcome::SUCCESS, '', $spec, $coordinates, $distanceKm);
+    }
+
+    public static function unparseable(): self
+    {
+        return new self(AiGenerationOutcome::UNPARSEABLE, "L'assistant n'a pas pu proposer d'itinéraire exploitable. Reformulez votre demande.");
+    }
+
+    public static function outOfZone(string $message): self
+    {
+        return new self(AiGenerationOutcome::OUT_OF_ZONE, '' !== $message ? $message : 'La génération d\'itinéraire est limitée à la France et au Benelux.');
+    }
+
+    /**
+     * @param array<string, mixed> $spec
+     */
+    public static function ungeocodable(array $spec, string $message): self
+    {
+        return new self(AiGenerationOutcome::UNGEOCODABLE, $message, $spec);
+    }
+
+    /**
+     * @param array<string, mixed> $spec
+     */
+    public static function routingFailed(array $spec): self
+    {
+        return new self(AiGenerationOutcome::ROUTING_FAILED, 'Le calcul de l\'itinéraire a échoué. Réessayez dans un instant.', $spec);
+    }
+
+    public function isSuccess(): bool
+    {
+        return AiGenerationOutcome::SUCCESS === $this->outcome;
+    }
+}

--- a/api/src/Generation/AiGeneratedRoute.php
+++ b/api/src/Generation/AiGeneratedRoute.php
@@ -35,17 +35,25 @@ final readonly class AiGeneratedRoute
         return new self(AiGenerationOutcome::SUCCESS, '', $spec, $coordinates, $distanceKm);
     }
 
-    public static function unparseable(): self
+    public static function unparseable(string $locale = 'fr'): self
     {
-        return new self(AiGenerationOutcome::UNPARSEABLE, "L'assistant n'a pas pu proposer d'itinéraire exploitable. Reformulez votre demande.");
+        return new self(AiGenerationOutcome::UNPARSEABLE, 'fr' === $locale
+            ? "L'assistant n'a pas pu proposer d'itinéraire exploitable. Reformulez votre demande."
+            : 'The assistant could not produce a usable itinerary. Please rephrase your request.');
     }
 
-    public static function outOfZone(string $message): self
+    public static function outOfZone(string $message, string $locale = 'fr'): self
     {
-        return new self(AiGenerationOutcome::OUT_OF_ZONE, '' !== $message ? $message : 'La génération d\'itinéraire est limitée à la France et au Benelux.');
+        $fallback = 'fr' === $locale
+            ? "La génération d'itinéraire est limitée à la France et au Benelux."
+            : 'Route generation is limited to France and the Benelux.';
+
+        return new self(AiGenerationOutcome::OUT_OF_ZONE, '' !== $message ? $message : $fallback);
     }
 
     /**
+     * The message is built (and localised) by the caller, which knows the missing places.
+     *
      * @param array<string, mixed> $spec
      */
     public static function ungeocodable(array $spec, string $message): self
@@ -56,9 +64,11 @@ final readonly class AiGeneratedRoute
     /**
      * @param array<string, mixed> $spec
      */
-    public static function routingFailed(array $spec): self
+    public static function routingFailed(array $spec, string $locale = 'fr'): self
     {
-        return new self(AiGenerationOutcome::ROUTING_FAILED, 'Le calcul de l\'itinéraire a échoué. Réessayez dans un instant.', $spec);
+        return new self(AiGenerationOutcome::ROUTING_FAILED, 'fr' === $locale
+            ? "Le calcul de l'itinéraire a échoué. Réessayez dans un instant."
+            : 'Routing failed. Please try again shortly.', $spec);
     }
 
     public function isSuccess(): bool

--- a/api/src/Generation/AiGenerationOutcome.php
+++ b/api/src/Generation/AiGenerationOutcome.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Generation;
+
+/**
+ * Outcome of an AI route-generation attempt (B1, ADR-042). Only SUCCESS yields a
+ * routable geometry; the others are surfaced to the rider as a clarification or
+ * a validation error rather than a hard failure.
+ */
+enum AiGenerationOutcome: string
+{
+    case SUCCESS = 'success';
+    /** The model could not produce a parseable spec. */
+    case UNPARSEABLE = 'unparseable';
+    /** The brief targets a place outside the supported coverage area (France + Benelux). */
+    case OUT_OF_ZONE = 'out_of_zone';
+    /** One or more named places could not be geocoded inside the coverage area. */
+    case UNGEOCODABLE = 'ungeocodable';
+    /** Geocoding succeeded but routing (Valhalla) failed. */
+    case ROUTING_FAILED = 'routing_failed';
+}

--- a/api/src/Generation/AiTripGenerationService.php
+++ b/api/src/Generation/AiTripGenerationService.php
@@ -1,0 +1,275 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Generation;
+
+use App\Llm\Exception\AiUnavailableException;
+use App\ApiResource\Model\Coordinate;
+use App\Geo\GeocoderInterface;
+use App\Llm\ResolvedLlmClient;
+use App\Llm\SystemPromptLoader;
+use App\Osm\CoverageRepositoryInterface;
+use App\Routing\RoutingProviderInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Turns a natural-language brief into a routed bikepacking itinerary (B1, ADR-042):
+ *
+ *   brief → LLM (user's provider) → structured spec + named waypoints
+ *   → geocode (France + Benelux) → coverage guard → Valhalla (loop/point-to-point)
+ *   → if the routed distance is far from the requested target, ONE corrective
+ *     re-prompt, then accept and report the real distance.
+ *
+ * The LLM never produces geometry — it only names places; Valhalla draws the real
+ * route. The model is asked to flag out-of-zone briefs (instead of silently
+ * relocating, per the B0 spike), and the coverage guard is the backstop.
+ *
+ * Stateless: returns an {@see AiGeneratedRoute}; persistence + the async pipeline
+ * dispatch live in the caller.
+ */
+final readonly class AiTripGenerationService
+{
+    public const string PROMPT_NAME = 'itinerary-generation';
+
+    /**
+     * A routed distance outside [60%, 140%] of the requested target triggers the
+     * single corrective re-prompt.
+     */
+    private const float TARGET_TOLERANCE = 0.4;
+
+    public function __construct(
+        private SystemPromptLoader $promptLoader,
+        private GeocoderInterface $geocoder,
+        private CoverageRepositoryInterface $coverageRepository,
+        private RoutingProviderInterface $routingProvider,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @throws AiUnavailableException when the provider is unreachable
+     */
+    public function generate(string $brief, ResolvedLlmClient $resolved, string $locale = 'fr'): AiGeneratedRoute
+    {
+        $systemPrompt = $this->promptLoader->load(self::PROMPT_NAME, ['language' => $locale]);
+        $model = $resolved->provider->analysisModel();
+
+        $spec = $this->extractSpec($resolved, $model, $systemPrompt, $brief);
+        if (null === $spec) {
+            return AiGeneratedRoute::unparseable();
+        }
+
+        if (true === ($spec['out_of_zone'] ?? false)) {
+            return AiGeneratedRoute::outOfZone($this->specString($spec, 'out_of_zone_reason'));
+        }
+
+        $route = $this->route($spec);
+
+        // One corrective re-prompt when the routed distance is far off the target.
+        if ($route->isSuccess() && $this->isOffTarget($spec, $route->distanceKm)) {
+            $this->logger->info('AI generation off-target, attempting one correction.', [
+                'routedKm' => round($route->distanceKm, 1),
+                'targetKm' => $this->targetKm($spec),
+            ]);
+
+            $corrected = $this->extractSpec($resolved, $model, $systemPrompt, $this->correctionBrief($brief, $spec, $route->distanceKm));
+            if (null !== $corrected && true !== ($corrected['out_of_zone'] ?? false)) {
+                $second = $this->route($corrected);
+                if ($second->isSuccess()) {
+                    return $second;
+                }
+            }
+        }
+
+        return $route;
+    }
+
+    /**
+     * @param array<string, mixed> $spec
+     */
+    private function route(array $spec): AiGeneratedRoute
+    {
+        $loop = (bool) ($spec['loop'] ?? false);
+
+        $places = [$this->specString($spec, 'start')];
+        foreach ($this->stringList($spec['waypoints'] ?? null) as $waypoint) {
+            $places[] = $waypoint;
+        }
+
+        $end = $this->specString($spec, 'end');
+        if (!$loop && '' !== $end) {
+            $places[] = $end;
+        }
+
+        $coordinates = [];
+        $missing = [];
+        foreach ($places as $place) {
+            if ('' === trim($place)) {
+                continue;
+            }
+
+            $coordinate = $this->geocoder->geocode($place);
+            if (!$coordinate instanceof Coordinate) {
+                $missing[] = $place;
+
+                continue;
+            }
+
+            $coordinates[] = $coordinate;
+        }
+
+        if ([] !== $missing) {
+            return AiGeneratedRoute::ungeocodable($spec, \sprintf('Impossible de localiser : %s. Reformulez avec des lieux plus précis.', implode(', ', $missing)));
+        }
+
+        if (\count($coordinates) < 2) {
+            return AiGeneratedRoute::ungeocodable($spec, 'Pas assez de lieux exploitables pour tracer un itinéraire.');
+        }
+
+        // Coverage backstop: even an in-zone start can route through an uncovered
+        // area; reject the whole route rather than serve a partial one.
+        if ($this->coverageRepository->isRouteOutOfZone(array_map(
+            static fn (Coordinate $c): array => ['lat' => $c->lat, 'lon' => $c->lon],
+            $coordinates,
+        ))) {
+            return AiGeneratedRoute::outOfZone('L\'itinéraire proposé sort de la zone couverte (France et Benelux).');
+        }
+
+        $from = $coordinates[0];
+        $to = $loop ? $coordinates[0] : $coordinates[\count($coordinates) - 1];
+        $via = $loop ? \array_slice($coordinates, 1) : \array_slice($coordinates, 1, -1);
+
+        try {
+            $result = $this->routingProvider->calculateRoute($from, $to, $via);
+        } catch (\Throwable $throwable) {
+            $this->logger->warning('AI generation routing failed.', ['error' => $throwable->getMessage()]);
+
+            return AiGeneratedRoute::routingFailed($spec);
+        }
+
+        return AiGeneratedRoute::success($spec, $result->coordinates, $result->distance / 1000);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function extractSpec(ResolvedLlmClient $resolved, string $model, string $systemPrompt, string $userMessage): ?array
+    {
+        $response = $resolved->client->generate($model, $userMessage, $systemPrompt);
+        $raw = $response['response'] ?? null;
+        if (!\is_string($raw)) {
+            return null;
+        }
+
+        return $this->parseJson($raw);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function parseJson(string $raw): ?array
+    {
+        $candidate = trim($raw);
+        if (str_starts_with($candidate, '```')) {
+            $candidate = (string) preg_replace('/^```(?:json)?\s*|\s*```$/i', '', trim($candidate));
+        }
+
+        $start = strpos($candidate, '{');
+        $end = strrpos($candidate, '}');
+        if (false === $start || false === $end || $end <= $start) {
+            return null;
+        }
+
+        try {
+            $decoded = json_decode(substr($candidate, $start, $end - $start + 1), true, flags: \JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return null;
+        }
+
+        if (!\is_array($decoded)) {
+            return null;
+        }
+
+        // Re-key to string keys (JSON object keys always are) so the spec is a
+        // well-typed array<string, mixed> for the accessors below.
+        $spec = [];
+        foreach ($decoded as $key => $value) {
+            $spec[(string) $key] = $value;
+        }
+
+        return $spec;
+    }
+
+    /**
+     * @param array<string, mixed> $spec
+     */
+    private function specString(array $spec, string $key): string
+    {
+        $value = $spec[$key] ?? null;
+
+        return \is_string($value) ? $value : '';
+    }
+
+    /**
+     * @param array<string, mixed> $spec
+     */
+    private function specInt(array $spec, string $key): int
+    {
+        $value = $spec[$key] ?? null;
+
+        return is_numeric($value) ? (int) $value : 0;
+    }
+
+    /**
+     * @param array<string, mixed> $spec
+     */
+    private function isOffTarget(array $spec, float $routedKm): bool
+    {
+        $target = $this->targetKm($spec);
+
+        return $target > 0 && ($routedKm < $target * (1 - self::TARGET_TOLERANCE) || $routedKm > $target * (1 + self::TARGET_TOLERANCE));
+    }
+
+    /**
+     * @param array<string, mixed> $spec
+     */
+    private function targetKm(array $spec): int
+    {
+        return max(1, $this->specInt($spec, 'days')) * max(0, $this->specInt($spec, 'km_per_day'));
+    }
+
+    /**
+     * @param array<string, mixed> $spec
+     */
+    private function correctionBrief(string $brief, array $spec, float $routedKm): string
+    {
+        return \sprintf(
+            "%s\n\n[correction] Ta proposition précédente faisait %.0f km au total, alors que la cible est ~%d km (%d jours x %d km/jour). Ajuste les waypoints (ajoute, retire ou déplace des étapes) pour t'approcher de la cible, en restant en France ou au Benelux. Réponds uniquement avec le JSON.",
+            $brief,
+            $routedKm,
+            $this->targetKm($spec),
+            max(1, $this->specInt($spec, 'days')),
+            max(0, $this->specInt($spec, 'km_per_day')),
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function stringList(mixed $value): array
+    {
+        if (!\is_array($value)) {
+            return [];
+        }
+
+        $out = [];
+        foreach ($value as $item) {
+            if (\is_string($item) && '' !== trim($item)) {
+                $out[] = $item;
+            }
+        }
+
+        return $out;
+    }
+}

--- a/api/src/Generation/AiTripGenerationService.php
+++ b/api/src/Generation/AiTripGenerationService.php
@@ -57,14 +57,14 @@ final readonly class AiTripGenerationService
 
         $spec = $this->extractSpec($resolved, $model, $systemPrompt, $brief);
         if (null === $spec) {
-            return AiGeneratedRoute::unparseable();
+            return AiGeneratedRoute::unparseable($locale);
         }
 
         if (true === ($spec['out_of_zone'] ?? false)) {
-            return AiGeneratedRoute::outOfZone($this->specString($spec, 'out_of_zone_reason'));
+            return AiGeneratedRoute::outOfZone($this->specString($spec, 'out_of_zone_reason'), $locale);
         }
 
-        $route = $this->route($spec);
+        $route = $this->route($spec, $locale);
 
         // One corrective re-prompt when the routed distance is far off the target.
         if ($route->isSuccess() && $this->isOffTarget($spec, $route->distanceKm)) {
@@ -75,7 +75,7 @@ final readonly class AiTripGenerationService
 
             $corrected = $this->extractSpec($resolved, $model, $systemPrompt, $this->correctionBrief($brief, $spec, $route->distanceKm));
             if (null !== $corrected && true !== ($corrected['out_of_zone'] ?? false)) {
-                $second = $this->route($corrected);
+                $second = $this->route($corrected, $locale);
                 if ($second->isSuccess()) {
                     return $second;
                 }
@@ -88,7 +88,7 @@ final readonly class AiTripGenerationService
     /**
      * @param array<string, mixed> $spec
      */
-    private function route(array $spec): AiGeneratedRoute
+    private function route(array $spec, string $locale): AiGeneratedRoute
     {
         $loop = (bool) ($spec['loop'] ?? false);
 
@@ -120,11 +120,17 @@ final readonly class AiTripGenerationService
         }
 
         if ([] !== $missing) {
-            return AiGeneratedRoute::ungeocodable($spec, \sprintf('Impossible de localiser : %s. Reformulez avec des lieux plus précis.', implode(', ', $missing)));
+            $places = implode(', ', $missing);
+
+            return AiGeneratedRoute::ungeocodable($spec, 'fr' === $locale
+                ? \sprintf('Impossible de localiser : %s. Reformulez avec des lieux plus précis.', $places)
+                : \sprintf('Could not locate: %s. Try more specific place names.', $places));
         }
 
         if (\count($coordinates) < 2) {
-            return AiGeneratedRoute::ungeocodable($spec, 'Pas assez de lieux exploitables pour tracer un itinéraire.');
+            return AiGeneratedRoute::ungeocodable($spec, 'fr' === $locale
+                ? 'Pas assez de lieux exploitables pour tracer un itinéraire.'
+                : 'Not enough usable places to draw an itinerary.');
         }
 
         // Coverage backstop: even an in-zone start can route through an uncovered
@@ -133,7 +139,9 @@ final readonly class AiTripGenerationService
             static fn (Coordinate $c): array => ['lat' => $c->lat, 'lon' => $c->lon],
             $coordinates,
         ))) {
-            return AiGeneratedRoute::outOfZone('L\'itinéraire proposé sort de la zone couverte (France et Benelux).');
+            return AiGeneratedRoute::outOfZone('fr' === $locale
+                ? "L'itinéraire proposé sort de la zone couverte (France et Benelux)."
+                : 'The proposed route leaves the covered area (France and the Benelux).', $locale);
         }
 
         $from = $coordinates[0];
@@ -145,7 +153,7 @@ final readonly class AiTripGenerationService
         } catch (\Throwable $throwable) {
             $this->logger->warning('AI generation routing failed.', ['error' => $throwable->getMessage()]);
 
-            return AiGeneratedRoute::routingFailed($spec);
+            return AiGeneratedRoute::routingFailed($spec, $locale);
         }
 
         return AiGeneratedRoute::success($spec, $result->coordinates, $result->distance / 1000);

--- a/api/src/Generation/AiTripGenerationService.php
+++ b/api/src/Generation/AiTripGenerationService.php
@@ -73,7 +73,7 @@ final readonly class AiTripGenerationService
                 'targetKm' => $this->targetKm($spec),
             ]);
 
-            $corrected = $this->extractSpec($resolved, $model, $systemPrompt, $this->correctionBrief($brief, $spec, $route->distanceKm));
+            $corrected = $this->extractSpec($resolved, $model, $systemPrompt, $this->correctionBrief($brief, $spec, $route->distanceKm, $locale));
             if (null !== $corrected && true !== ($corrected['out_of_zone'] ?? false)) {
                 $second = $this->route($corrected, $locale);
                 if ($second->isSuccess()) {
@@ -250,10 +250,14 @@ final readonly class AiTripGenerationService
     /**
      * @param array<string, mixed> $spec
      */
-    private function correctionBrief(string $brief, array $spec, float $routedKm): string
+    private function correctionBrief(string $brief, array $spec, float $routedKm, string $locale = 'fr'): string
     {
+        $template = 'fr' === $locale
+            ? "%s\n\n[correction] Ta proposition précédente faisait %.0f km au total, alors que la cible est ~%d km (%d jours x %d km/jour). Ajuste les waypoints (ajoute, retire ou déplace des étapes) pour t'approcher de la cible, en restant en France ou au Benelux. Réponds uniquement avec le JSON."
+            : "%s\n\n[correction] Your previous proposal was %.0f km total, but the target is ~%d km (%d days x %d km/day). Adjust the waypoints (add, remove or move stages) to get closer to the target, staying within France or the Benelux. Reply with ONLY the JSON.";
+
         return \sprintf(
-            "%s\n\n[correction] Ta proposition précédente faisait %.0f km au total, alors que la cible est ~%d km (%d jours x %d km/jour). Ajuste les waypoints (ajoute, retire ou déplace des étapes) pour t'approcher de la cible, en restant en France ou au Benelux. Réponds uniquement avec le JSON.",
+            $template,
             $brief,
             $routedKm,
             $this->targetKm($spec),

--- a/api/src/Geo/Geocoder.php
+++ b/api/src/Geo/Geocoder.php
@@ -41,7 +41,11 @@ final readonly class Geocoder implements GeocoderInterface
             return null === $cached ? null : new Coordinate($cached['lat'], $cached['lon']);
         }
 
-        $coordinate = $this->query($place);
+        try {
+            $coordinate = $this->query($place);
+        } catch (\Throwable) {
+            return null; // transient network error - do not cache
+        }
 
         $item->set($coordinate instanceof Coordinate ? ['lat' => $coordinate->lat, 'lon' => $coordinate->lon] : null);
         $item->expiresAfter(self::CACHE_TTL);
@@ -53,21 +57,19 @@ final readonly class Geocoder implements GeocoderInterface
 
     private function query(string $place): ?Coordinate
     {
-        try {
-            /** @var list<array{lat?: string, lon?: string}> $data */
-            $data = $this->nominatimClient->request('GET', '/search', [
-                'query' => [
-                    'q' => $place,
-                    'format' => 'jsonv2',
-                    'limit' => 1,
-                    // Restrict to the supported coverage area so the model cannot
-                    // pull the route outside France + Benelux via a place name.
-                    'countrycodes' => 'fr,be,lu,nl',
-                ],
-            ])->toArray();
-        } catch (\Throwable) {
-            return null;
-        }
+        // Transport exceptions propagate so geocode() skips the cache write
+        // (a transient 429/503 must not pin a place as unresolvable for 24h).
+        /** @var list<array{lat?: string, lon?: string}> $data */
+        $data = $this->nominatimClient->request('GET', '/search', [
+            'query' => [
+                'q' => $place,
+                'format' => 'jsonv2',
+                'limit' => 1,
+                // Restrict to the supported coverage area so the model cannot
+                // pull the route outside France + Benelux via a place name.
+                'countrycodes' => 'fr,be,lu,nl',
+            ],
+        ])->toArray();
 
         $first = $data[0] ?? null;
         if (!isset($first['lat'], $first['lon'])) {

--- a/api/src/Geo/Geocoder.php
+++ b/api/src/Geo/Geocoder.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Geo;
+
+use App\ApiResource\Model\Coordinate;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Nominatim-backed forward geocoder (B1, ADR-042) used by AI route generation to
+ * turn the model's named waypoints into coordinates. Biased to France + Benelux
+ * (the coverage area) and cached 24h to respect the Nominatim usage policy.
+ */
+final readonly class Geocoder implements GeocoderInterface
+{
+    private const int CACHE_TTL = 86400;
+
+    public function __construct(
+        #[Autowire(service: 'nominatim.client')]
+        private HttpClientInterface $nominatimClient,
+        #[Autowire(service: 'cache.osm')]
+        private CacheItemPoolInterface $osmCache,
+    ) {
+    }
+
+    public function geocode(string $place): ?Coordinate
+    {
+        $place = trim($place);
+        if ('' === $place) {
+            return null;
+        }
+
+        $item = $this->osmCache->getItem('geocode.fwd.'.md5($place));
+        if ($item->isHit()) {
+            /** @var array{lat: float, lon: float}|null $cached */
+            $cached = $item->get();
+
+            return null === $cached ? null : new Coordinate($cached['lat'], $cached['lon']);
+        }
+
+        $coordinate = $this->query($place);
+
+        $item->set($coordinate instanceof Coordinate ? ['lat' => $coordinate->lat, 'lon' => $coordinate->lon] : null);
+        $item->expiresAfter(self::CACHE_TTL);
+
+        $this->osmCache->save($item);
+
+        return $coordinate;
+    }
+
+    private function query(string $place): ?Coordinate
+    {
+        try {
+            /** @var list<array{lat?: string, lon?: string}> $data */
+            $data = $this->nominatimClient->request('GET', '/search', [
+                'query' => [
+                    'q' => $place,
+                    'format' => 'jsonv2',
+                    'limit' => 1,
+                    // Restrict to the supported coverage area so the model cannot
+                    // pull the route outside France + Benelux via a place name.
+                    'countrycodes' => 'fr,be,lu,nl',
+                ],
+            ])->toArray();
+        } catch (\Throwable) {
+            return null;
+        }
+
+        $first = $data[0] ?? null;
+        if (!isset($first['lat'], $first['lon'])) {
+            return null;
+        }
+
+        return new Coordinate((float) $first['lat'], (float) $first['lon']);
+    }
+}

--- a/api/src/Geo/GeocoderInterface.php
+++ b/api/src/Geo/GeocoderInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Geo;
+
+use App\ApiResource\Model\Coordinate;
+
+/**
+ * Forward geocoding: resolve a place name to a coordinate, scoped to the
+ * supported coverage area (France + Benelux). Returns null when the place cannot
+ * be resolved.
+ */
+interface GeocoderInterface
+{
+    public function geocode(string $place): ?Coordinate;
+}

--- a/api/src/Llm/SystemPrompt/itinerary-generation.txt
+++ b/api/src/Llm/SystemPrompt/itinerary-generation.txt
@@ -1,0 +1,30 @@
+You are a bikepacking route planner. From the rider's free-text brief, produce a
+structured trip spec as a SINGLE JSON object and NOTHING else — no prose, no
+Markdown, no code fences.
+
+JSON schema:
+{
+  "start": "<start city or place name>",
+  "loop": <true if the trip returns to the start, otherwise false>,
+  "end": "<destination place name, or null when loop is true>",
+  "days": <integer number of riding days>,
+  "km_per_day": <integer target kilometres per riding day>,
+  "accommodation": "<one of: tent, hotel, guesthouse, hut, unknown>",
+  "waypoints": ["<intermediate place name>", "..."],
+  "out_of_zone": <true if the requested trip lies outside the supported area, else false>,
+  "out_of_zone_reason": "<short reason in {{language}}, only when out_of_zone is true>"
+}
+
+Hard rules:
+- The supported area is FRANCE and the BENELUX (Belgium, Netherlands, Luxembourg) ONLY.
+- If the brief asks for a trip whose start, end, or clear intent is OUTSIDE that
+  area, do NOT relocate it to a nearby in-zone place. Instead set "out_of_zone": true
+  and give a one-sentence "out_of_zone_reason" in {{language}}; you may leave the
+  other fields empty.
+- Otherwise, propose roughly one waypoint per riding day, spaced about "km_per_day"
+  kilometres apart, so the daily distance matches the requested pace. For a loop,
+  the waypoints must bend the route back toward the start.
+- Use real, well-known, geocodable towns or villages (not regions, not POIs).
+- Infer "days" and "km_per_day" from the brief (dates, "weekend", "X km par jour").
+  If unspecified, choose sensible defaults (2 days, 70 km/day).
+- Respond with ONLY the JSON object.

--- a/api/tests/Unit/Generation/AiTripGenerationServiceTest.php
+++ b/api/tests/Unit/Generation/AiTripGenerationServiceTest.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Generation;
+
+use App\ApiResource\Model\Coordinate;
+use App\Generation\AiGenerationOutcome;
+use App\Generation\AiTripGenerationService;
+use App\Geo\GeocoderInterface;
+use App\Llm\AiProvider;
+use App\Llm\LlmClientInterface;
+use App\Llm\ResolvedLlmClient;
+use App\Llm\SystemPromptLoader;
+use App\Osm\CoverageRepositoryInterface;
+use App\Routing\RoutingProviderInterface;
+use App\Routing\RoutingResult;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+#[AllowMockObjectsWithoutExpectations]
+final class AiTripGenerationServiceTest extends TestCase
+{
+    private string $promptDir = '';
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->promptDir = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'gen-prompt-'.bin2hex(random_bytes(4));
+        mkdir($this->promptDir, 0o755, true);
+        file_put_contents($this->promptDir.\DIRECTORY_SEPARATOR.AiTripGenerationService::PROMPT_NAME.'.txt', 'Plan a trip in {{language}}. Respond with JSON.');
+    }
+
+    #[\Override]
+    protected function tearDown(): void
+    {
+        foreach (glob($this->promptDir.\DIRECTORY_SEPARATOR.'*') ?: [] as $file) {
+            unlink($file);
+        }
+
+        @rmdir($this->promptDir);
+    }
+
+    #[Test]
+    public function generatesAndRoutesALoop(): void
+    {
+        $client = $this->llm('{"start":"Lille","loop":true,"end":null,"days":2,"km_per_day":80,"accommodation":"tent","waypoints":["Cambrai"]}');
+
+        $result = $this->service(
+            geocoder: $this->geocoderReturning(new Coordinate(50.6, 3.0)),
+            routing: $this->routingReturning(150_000.0), // 150 km, within [96, 224] of the 160 km target
+        )->generate('boucle Lille 80 km/j', $this->resolved($client));
+
+        self::assertSame(AiGenerationOutcome::SUCCESS, $result->outcome);
+        self::assertSame('Lille', $result->spec['start']);
+        self::assertEqualsWithDelta(150.0, $result->distanceKm, 0.01);
+        self::assertNotEmpty($result->coordinates);
+    }
+
+    #[Test]
+    public function returnsUnparseableWhenTheModelDoesNotEmitJson(): void
+    {
+        $client = $this->llm('Sorry, I cannot help with that.');
+        $result = $this->service()->generate('brief', $this->resolved($client));
+
+        self::assertSame(AiGenerationOutcome::UNPARSEABLE, $result->outcome);
+    }
+
+    #[Test]
+    public function returnsOutOfZoneWhenTheModelFlagsIt(): void
+    {
+        $client = $this->llm('{"out_of_zone":true,"out_of_zone_reason":"Barcelone est hors zone."}');
+        $result = $this->service()->generate('boucle à Barcelone', $this->resolved($client));
+
+        self::assertSame(AiGenerationOutcome::OUT_OF_ZONE, $result->outcome);
+        self::assertStringContainsString('Barcelone', $result->message);
+    }
+
+    #[Test]
+    public function returnsOutOfZoneWhenTheCoverageGuardRejectsTheRoute(): void
+    {
+        $client = $this->llm('{"start":"Lille","loop":true,"days":2,"km_per_day":80,"waypoints":["Cambrai"]}');
+        $coverage = $this->createStub(CoverageRepositoryInterface::class);
+        $coverage->method('isRouteOutOfZone')->willReturn(true);
+
+        $result = $this->service(
+            geocoder: $this->geocoderReturning(new Coordinate(50.6, 3.0)),
+            coverage: $coverage,
+        )->generate('brief', $this->resolved($client));
+
+        self::assertSame(AiGenerationOutcome::OUT_OF_ZONE, $result->outcome);
+    }
+
+    #[Test]
+    public function returnsUngeocodableWhenAWaypointCannotBeResolved(): void
+    {
+        $client = $this->llm('{"start":"Lille","loop":false,"end":"Atlantis","days":1,"km_per_day":50,"waypoints":[]}');
+
+        $geocoder = $this->createStub(GeocoderInterface::class);
+        $geocoder->method('geocode')->willReturnCallback(
+            static fn (string $place): ?Coordinate => 'Atlantis' === $place ? null : new Coordinate(50.6, 3.0),
+        );
+
+        $result = $this->service(geocoder: $geocoder)->generate('brief', $this->resolved($client));
+
+        self::assertSame(AiGenerationOutcome::UNGEOCODABLE, $result->outcome);
+        self::assertStringContainsString('Atlantis', $result->message);
+    }
+
+    #[Test]
+    public function returnsRoutingFailedWhenValhallaThrows(): void
+    {
+        $client = $this->llm('{"start":"Lille","loop":true,"days":2,"km_per_day":80,"waypoints":["Cambrai"]}');
+        $routing = $this->createStub(RoutingProviderInterface::class);
+        $routing->method('calculateRoute')->willThrowException(new \RuntimeException('valhalla down'));
+
+        $result = $this->service(
+            geocoder: $this->geocoderReturning(new Coordinate(50.6, 3.0)),
+            routing: $routing,
+        )->generate('brief', $this->resolved($client));
+
+        self::assertSame(AiGenerationOutcome::ROUTING_FAILED, $result->outcome);
+    }
+
+    #[Test]
+    public function correctsOnceWhenTheFirstRouteIsFarFromTheTarget(): void
+    {
+        // First spec routes to 50 km (target 160 km -> off); the correction spec
+        // routes to 150 km (on target) and must be the returned result.
+        $client = $this->createStub(LlmClientInterface::class);
+        $client->method('generate')->willReturnOnConsecutiveCalls(
+            ['response' => '{"start":"Lille","loop":true,"days":2,"km_per_day":80,"waypoints":["Seclin"]}'],
+            ['response' => '{"start":"Lille","loop":true,"days":2,"km_per_day":80,"waypoints":["Seclin","Cambrai","Douai"]}'],
+        );
+
+        $routing = $this->createStub(RoutingProviderInterface::class);
+        $routing->method('calculateRoute')->willReturnOnConsecutiveCalls(
+            new RoutingResult([new Coordinate(50.6, 3.0)], 50_000.0, 100.0, 7200.0),
+            new RoutingResult([new Coordinate(50.6, 3.0), new Coordinate(50.2, 3.2)], 150_000.0, 400.0, 21600.0),
+        );
+
+        $result = $this->service(
+            geocoder: $this->geocoderReturning(new Coordinate(50.6, 3.0)),
+            routing: $routing,
+        )->generate('boucle Lille 80 km/j', $this->resolved($client));
+
+        self::assertSame(AiGenerationOutcome::SUCCESS, $result->outcome);
+        self::assertEqualsWithDelta(150.0, $result->distanceKm, 0.01, 'the corrected (on-target) route is returned');
+        self::assertIsArray($result->spec['waypoints']);
+        self::assertCount(3, $result->spec['waypoints']);
+    }
+
+    // -------------------------------------------------------------------------
+
+    private function service(
+        ?GeocoderInterface $geocoder = null,
+        ?CoverageRepositoryInterface $coverage = null,
+        ?RoutingProviderInterface $routing = null,
+    ): AiTripGenerationService {
+        return new AiTripGenerationService(
+            promptLoader: new SystemPromptLoader($this->promptDir),
+            geocoder: $geocoder ?? $this->geocoderReturning(new Coordinate(50.6, 3.0)),
+            coverageRepository: $coverage ?? $this->coverageReturning(false),
+            routingProvider: $routing ?? $this->routingReturning(150_000.0),
+            logger: new NullLogger(),
+        );
+    }
+
+    private function llm(string $response): LlmClientInterface
+    {
+        $client = $this->createStub(LlmClientInterface::class);
+        $client->method('generate')->willReturn(['response' => $response]);
+
+        return $client;
+    }
+
+    private function resolved(LlmClientInterface $client): ResolvedLlmClient
+    {
+        return new ResolvedLlmClient($client, AiProvider::ANTHROPIC);
+    }
+
+    private function geocoderReturning(Coordinate $coordinate): GeocoderInterface
+    {
+        $geocoder = $this->createStub(GeocoderInterface::class);
+        $geocoder->method('geocode')->willReturn($coordinate);
+
+        return $geocoder;
+    }
+
+    private function coverageReturning(bool $outOfZone): CoverageRepositoryInterface
+    {
+        $coverage = $this->createStub(CoverageRepositoryInterface::class);
+        $coverage->method('isRouteOutOfZone')->willReturn($outOfZone);
+
+        return $coverage;
+    }
+
+    private function routingReturning(float $distanceMeters): RoutingProviderInterface
+    {
+        $routing = $this->createStub(RoutingProviderInterface::class);
+        $routing->method('calculateRoute')->willReturn(
+            new RoutingResult([new Coordinate(50.6, 3.0), new Coordinate(50.2, 3.2)], $distanceMeters, 200.0, 14400.0),
+        );
+
+        return $routing;
+    }
+}

--- a/api/tests/Unit/Generation/AiTripGenerationServiceTest.php
+++ b/api/tests/Unit/Generation/AiTripGenerationServiceTest.php
@@ -60,6 +60,21 @@ final class AiTripGenerationServiceTest extends TestCase
     }
 
     #[Test]
+    public function generatesAPointToPointRoute(): void
+    {
+        // Exercises the loop:false branch: $to = last coordinate, $via excludes both endpoints.
+        $client = $this->llm('{"start":"Lille","loop":false,"end":"Paris","days":2,"km_per_day":100,"accommodation":"hotel","waypoints":["Cambrai"]}');
+
+        $result = $this->service(
+            geocoder: $this->geocoderReturning(new Coordinate(50.6, 3.0)),
+            routing: $this->routingReturning(200_000.0), // 200 km, within [120, 280] of the 200 km target
+        )->generate('Lille vers Paris', $this->resolved($client));
+
+        self::assertSame(AiGenerationOutcome::SUCCESS, $result->outcome);
+        self::assertEqualsWithDelta(200.0, $result->distanceKm, 0.01);
+    }
+
+    #[Test]
     public function returnsUnparseableWhenTheModelDoesNotEmitJson(): void
     {
         $client = $this->llm('Sorry, I cannot help with that.');

--- a/api/tests/Unit/Geo/GeocoderTest.php
+++ b/api/tests/Unit/Geo/GeocoderTest.php
@@ -78,6 +78,24 @@ final class GeocoderTest extends TestCase
         self::assertNull($second);
     }
 
+    #[Test]
+    public function doesNotCacheTransientTransportErrors(): void
+    {
+        // First call: a 503 makes toArray() throw, so geocode() returns null
+        // WITHOUT caching. The second call must retry Nominatim and succeed,
+        // proving a transient error never pins a place as unresolvable.
+        $geocoder = new Geocoder(
+            new MockHttpClient([
+                new MockResponse('', ['http_code' => 503]),
+                new MockResponse('[{"lat":"50.6","lon":"3.0"}]'),
+            ]),
+            $this->cache(),
+        );
+
+        self::assertNull($geocoder->geocode('Lille'));
+        self::assertNotNull($geocoder->geocode('Lille'));
+    }
+
     private function cache(): CacheItemPoolInterface
     {
         return new ArrayAdapter();

--- a/api/tests/Unit/Geo/GeocoderTest.php
+++ b/api/tests/Unit/Geo/GeocoderTest.php
@@ -64,6 +64,20 @@ final class GeocoderTest extends TestCase
         self::assertSame($first->lat, $second->lat);
     }
 
+    #[Test]
+    public function cachesNullForAnUnresolvablePlace(): void
+    {
+        // Only one response queued: a second HTTP call would throw, so a cached
+        // null miss is what lets the second call succeed.
+        $geocoder = new Geocoder(new MockHttpClient(new MockResponse('[]')), $this->cache());
+
+        $first = $geocoder->geocode('Atlantis-sur-Mer');
+        $second = $geocoder->geocode('Atlantis-sur-Mer');
+
+        self::assertNull($first);
+        self::assertNull($second);
+    }
+
     private function cache(): CacheItemPoolInterface
     {
         return new ArrayAdapter();

--- a/api/tests/Unit/Geo/GeocoderTest.php
+++ b/api/tests/Unit/Geo/GeocoderTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Geo;
+
+use App\Geo\Geocoder;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+final class GeocoderTest extends TestCase
+{
+    #[Test]
+    public function resolvesTheFirstNominatimResult(): void
+    {
+        $geocoder = new Geocoder(
+            new MockHttpClient(new MockResponse('[{"lat":"50.6365","lon":"3.0635","display_name":"Lille"}]')),
+            $this->cache(),
+        );
+
+        $coordinate = $geocoder->geocode('Lille');
+
+        self::assertNotNull($coordinate);
+        self::assertEqualsWithDelta(50.6365, $coordinate->lat, 0.0001);
+        self::assertEqualsWithDelta(3.0635, $coordinate->lon, 0.0001);
+    }
+
+    #[Test]
+    public function returnsNullForABlankPlaceWithoutCallingNominatim(): void
+    {
+        // MockHttpClient with no queued responses: any HTTP call would throw.
+        $geocoder = new Geocoder(new MockHttpClient([]), $this->cache());
+
+        self::assertNull($geocoder->geocode('   '));
+    }
+
+    #[Test]
+    public function returnsNullWhenNominatimHasNoMatch(): void
+    {
+        $geocoder = new Geocoder(new MockHttpClient(new MockResponse('[]')), $this->cache());
+
+        self::assertNull($geocoder->geocode('Atlantis-sur-Mer'));
+    }
+
+    #[Test]
+    public function cachesTheResultAcrossCalls(): void
+    {
+        // Only one response is queued: a second HTTP call would throw, so the
+        // second geocode must be served from cache.
+        $geocoder = new Geocoder(
+            new MockHttpClient(new MockResponse('[{"lat":"50.6","lon":"3.0"}]')),
+            $this->cache(),
+        );
+
+        $first = $geocoder->geocode('Lille');
+        $second = $geocoder->geocode('Lille');
+
+        self::assertNotNull($first);
+        self::assertNotNull($second);
+        self::assertSame($first->lat, $second->lat);
+    }
+
+    private function cache(): CacheItemPoolInterface
+    {
+        return new ArrayAdapter();
+    }
+}


### PR DESCRIPTION
## Contexte

Partie B du chantier IA (ADR-042) : génération d'itinéraire à partir d'une description. Le spike **B0 a validé GO** (Gemini : JSON + waypoints fiables, 10/10 géocodés ; voir verdict). B1 est découpé : **B1a (cette PR) = cœur de génération testable** ; B1b = endpoint async `/trips/ai-generate` + message/handler + Mercure + rate-limit.

## Changements

- **`SourceType::AI_GENERATED`** : nouveau type de source.
- **`Geocoder` / `GeocoderInterface`** : géocodage *avant* (nom → `Coordinate`) via Nominatim, **borné France + Benelux** (`countrycodes=fr,be,lu,nl`), caché 24h.
- **`AiTripGenerationService`** (stateless) : `brief → LLM (provider de l'utilisateur) → spec JSON + waypoints → géocodage → garde de couverture → Valhalla (boucle/point-à-point) → 1 re-prompt correctif si la distance routée est loin de la cible`. Le LLM ne produit jamais de géométrie (il nomme des lieux ; Valhalla trace).
- **Hors-zone (constat B0)** : le prompt demande au modèle de **signaler** `out_of_zone` au lieu de relocaliser silencieusement ; la garde de couverture (`CoverageRepository::isRouteOutOfZone`) reste le filet de sécurité. Issues surfacées via `AiGenerationOutcome` (success / unparseable / out_of_zone / ungeocodable / routing_failed) + message.
- Prompt versionné `SystemPrompt/itinerary-generation.txt`.

## Vérification

`make qa` local : PHPStan L9 OK, CS-Fixer OK, Rector OK, conteneur boote, **1061 tests unitaires verts** — `AiTripGenerationServiceTest` (loop, unparseable, out-of-zone flag + garde couverture, ungeocodable, routing failed, **correction unique on-target**) et `GeocoderTest` (1er résultat, blanc, sans match, cache). LLM/géocodeur/couverture/Valhalla mockés.

## Suite

**B1b** : `POST /trips/ai-generate` (ressource + processor + rate-limit) → message async → handler appelant le service, stockant les raw points (`storeRawPoints`) + `SourceType::AI_GENERATED` et dispatchant `GenerateStages` (pipeline pacing inchangé), avec progression/erreurs Mercure (`publishValidationError` pour out-of-zone/unparseable). La validation du **routage Valhalla réel** (tuiles régionales) y sera couverte par un test d'intégration (2e condition B0).

<!-- claude-review-start -->
## Claude Review

**Commit reviewed:** `9360e87a4efd9eb56621ed4743b63144acdae58e`

### Summary

All previous findings are addressed. The third commit threads `$locale` correctly into `correctionBrief()` at both the call site and the method itself, and makes `Geocoder::query()` propagate transport exceptions so transient 429/503 errors are never pinned to cache for 24 h. Architecture is clean, test suite is comprehensive (point-to-point branch, null-cache, transient-error bypass all covered), and no new issues were found.

### Resolved threads

Resolved 4 previously open threads that were addressed.

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Inline comments

No inline comments.
<!-- claude-review-end -->