### PR TITLE
feat(ai): async /trips/ai-generate endpoint (B1b)

### DIFF
--- a/api/config/packages/rate_limiter.php
+++ b/api/config/packages/rate_limiter.php
@@ -43,6 +43,15 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 'interval' => '60 seconds',
                 'cache_pool' => 'cache.rate_limiter',
             ],
+            // AI route generation is heavier than chat (LLM + geocoding + Valhalla,
+            // possibly a corrective re-prompt) and runs on the user's own quota,
+            // so it is throttled more tightly.
+            'ai_generate' => [
+                'policy' => 'sliding_window',
+                'limit' => 5,
+                'interval' => '60 seconds',
+                'cache_pool' => 'cache.rate_limiter',
+            ],
             'health_liveness' => [
                 'policy' => 'sliding_window',
                 'limit' => 60,

--- a/api/src/ApiResource/Trip.php
+++ b/api/src/ApiResource/Trip.php
@@ -16,6 +16,7 @@ use ApiPlatform\OpenApi\Model\Operation;
 use App\State\AnalyzeTripProcessor;
 use App\State\TripBatchRecomputeProcessor;
 use App\State\TripChatProcessor;
+use App\State\TripAiGenerateProcessor;
 use App\State\TripCollectionProvider;
 use App\State\TripCreateProcessor;
 use App\State\TripDeleteProcessor;
@@ -71,6 +72,21 @@ use App\State\TripUpdateProcessor;
             input: TripRequest::class,
             mercure: true,
             processor: TripCreateProcessor::class,
+        ),
+        new Post(
+            uriTemplate: '/trips/ai-generate{._format}',
+            status: 202,
+            openapi: new Operation(
+                responses: [
+                    422 => new Response(description: 'AI provider not configured'),
+                    429 => new Response(description: 'Rate limit reached'),
+                ],
+                summary: "Generate a trip from a natural-language brief using the user's configured AI provider.",
+            ),
+            security: "is_granted('ROLE_USER')",
+            input: TripAiGenerateRequest::class,
+            mercure: true,
+            processor: TripAiGenerateProcessor::class,
         ),
         new Post(
             uriTemplate: '/trips/{id}/duplicate{._format}',

--- a/api/src/ApiResource/TripAiGenerateRequest.php
+++ b/api/src/ApiResource/TripAiGenerateRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ApiResource;
+
+use ApiPlatform\Metadata\ApiProperty;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * Input DTO for `POST /trips/ai-generate` (B1, ADR-042).
+ *
+ * Carries the rider's free-form trip description. The brief is never the full
+ * prompt: {@see \App\Generation\AiTripGenerationService} wraps it in the
+ * versioned `itinerary-generation` system prompt before calling the user's
+ * configured provider.
+ */
+final class TripAiGenerateRequest
+{
+    public function __construct(
+        #[Assert\NotBlank]
+        #[Assert\Length(min: 10, max: 2000)]
+        #[ApiProperty(description: 'Free-form description of the desired trip (e.g. "boucle au départ de Lille, 2 jours, 80 km/jour, en tente").')]
+        public string $brief = '',
+    ) {
+    }
+}

--- a/api/src/Generation/AiTripGenerationService.php
+++ b/api/src/Generation/AiTripGenerationService.php
@@ -28,7 +28,7 @@ use Psr\Log\LoggerInterface;
  * Stateless: returns an {@see AiGeneratedRoute}; persistence + the async pipeline
  * dispatch live in the caller.
  */
-final readonly class AiTripGenerationService
+final readonly class AiTripGenerationService implements AiTripGenerationServiceInterface
 {
     public const string PROMPT_NAME = 'itinerary-generation';
 

--- a/api/src/Generation/AiTripGenerationServiceInterface.php
+++ b/api/src/Generation/AiTripGenerationServiceInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Generation;
+
+use App\Llm\Exception\AiUnavailableException;
+use App\Llm\ResolvedLlmClient;
+
+interface AiTripGenerationServiceInterface
+{
+    /**
+     * @throws AiUnavailableException when the provider is unreachable
+     */
+    public function generate(string $brief, ResolvedLlmClient $resolved, string $locale = 'fr'): AiGeneratedRoute;
+}

--- a/api/src/Message/GenerateAiRoute.php
+++ b/api/src/Message/GenerateAiRoute.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Message;
+
+/**
+ * Async request to generate a routed itinerary from a natural-language brief
+ * (B1, ADR-042). Dispatched by {@see \App\State\TripAiGenerateProcessor} and
+ * handled by {@see \App\MessageHandler\GenerateAiRouteHandler}.
+ *
+ * The brief is plain user text; the provider token is NEVER carried here — the
+ * handler resolves the trip owner's client at processing time.
+ */
+final readonly class GenerateAiRoute
+{
+    public function __construct(
+        public string $tripId,
+        public string $brief,
+        public string $locale,
+        public ?int $generation = null,
+    ) {
+    }
+}

--- a/api/src/MessageHandler/GenerateAiRouteHandler.php
+++ b/api/src/MessageHandler/GenerateAiRouteHandler.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MessageHandler;
+
+use App\ApiResource\Model\Coordinate;
+use App\ApiResource\TripRequest;
+use App\ComputationTracker\ComputationTrackerInterface;
+use App\ComputationTracker\TripGenerationTrackerInterface;
+use App\Engine\RouteSimplifierInterface;
+use App\Enum\ComputationName;
+use App\Enum\SourceType;
+use App\Generation\AiGeneratedRoute;
+use App\Generation\AiTripGenerationServiceInterface;
+use App\Llm\Exception\AiFailureReason;
+use App\Llm\Exception\AiUnavailableException;
+use App\Llm\ResolvedLlmClient;
+use App\Llm\TripLlmResolverInterface;
+use App\Mercure\MercureEventType;
+use App\Mercure\TripUpdatePublisherInterface;
+use App\Message\GenerateAiRoute;
+use App\Message\GenerateStages;
+use App\Repository\TripRequestRepositoryInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+/**
+ * Async route generation (B1, ADR-042): turns the rider's brief into a routed
+ * itinerary using the trip owner's configured provider, then hands off to the
+ * unchanged pacing pipeline.
+ *
+ * Mirrors {@see FetchAndParseRouteHandler}: it owns the ROUTE computation step,
+ * stores the raw + decimated geometry, sets {@see SourceType::AI_GENERATED} and
+ * dispatches {@see GenerateStages}. Non-success outcomes (out-of-zone,
+ * unparseable, ungeocodable, routing-failed) surface as a Mercure validation
+ * error and stop the pipeline. A transient provider failure is re-thrown so
+ * Messenger retries with back-off; a terminal one (invalid token / quota) fails
+ * fast so the user's quota is not burned.
+ */
+#[AsMessageHandler]
+final readonly class GenerateAiRouteHandler extends AbstractTripMessageHandler
+{
+    public function __construct(
+        ComputationTrackerInterface $computationTracker,
+        TripUpdatePublisherInterface $publisher,
+        TripGenerationTrackerInterface $generationTracker,
+        LoggerInterface $logger,
+        private TripRequestRepositoryInterface $tripStateManager,
+        private TripLlmResolverInterface $tripLlmResolver,
+        private AiTripGenerationServiceInterface $generationService,
+        private RouteSimplifierInterface $routeSimplifier,
+        MessageBusInterface $messageBus,
+    ) {
+        parent::__construct($computationTracker, $publisher, $generationTracker, $logger, $tripStateManager, $messageBus);
+    }
+
+    public function __invoke(GenerateAiRoute $message): void
+    {
+        $tripId = $message->tripId;
+        $generation = $message->generation;
+
+        $this->executeWithTracking($tripId, ComputationName::ROUTE, function () use ($tripId, $message, $generation): void {
+            $resolved = $this->tripLlmResolver->resolveForTrip($tripId);
+            if (!$resolved instanceof ResolvedLlmClient) {
+                // The owner cleared their AI configuration between the request and
+                // its processing. Nothing to retry — surface and stop.
+                $this->publisher->publishValidationError($tripId, 'AI_NOT_CONFIGURED', $this->notConfiguredMessage($message->locale));
+
+                return;
+            }
+
+            try {
+                $route = $this->generationService->generate($message->brief, $resolved, $message->locale);
+            } catch (AiUnavailableException $aiUnavailableException) {
+                // Transient (5xx / timeout / throttle): re-throw so executeWithTracking
+                // marks the step failed and Messenger retries with back-off.
+                if ($aiUnavailableException->isTransient()) {
+                    throw $aiUnavailableException;
+                }
+
+                // Terminal (invalid token / quota): fail fast, do not burn the quota.
+                $this->logger->warning('AI generation aborted on a terminal provider error.', [
+                    'tripId' => $tripId,
+                    'reason' => $aiUnavailableException->getReason()->value,
+                ]);
+                $this->publisher->publishValidationError($tripId, 'AI_UNAVAILABLE', $this->unavailableMessage($aiUnavailableException->getReason(), $message->locale));
+
+                return;
+            }
+
+            if (!$route->isSuccess()) {
+                $this->publisher->publishValidationError($tripId, strtoupper($route->outcome->value), $route->message);
+
+                return;
+            }
+
+            $this->storeRouteAndDispatch($tripId, $route, $message->locale, $generation);
+        }, $generation);
+    }
+
+    private function storeRouteAndDispatch(string $tripId, AiGeneratedRoute $route, string $locale, ?int $generation): void
+    {
+        $this->tripStateManager->storeRawPoints($tripId, $this->toPointArrays($route->coordinates));
+
+        // Decimate exactly like the fetch pipeline so GenerateStages finds the
+        // simplified geometry it reads for pacing.
+        $decimated = $this->routeSimplifier->simplify($route->coordinates);
+        $this->tripStateManager->storeDecimatedPoints($tripId, $this->toPointArrays($decimated));
+
+        $this->tripStateManager->storeSourceType($tripId, SourceType::AI_GENERATED->value);
+
+        $title = $this->title($route, $locale);
+        $this->tripStateManager->storeTitle($tripId, $title);
+
+        // The pacing engine derives the number of days from maxDistancePerDay;
+        // align it with the model's km/day so the routed distance is split into
+        // roughly the requested number of stages.
+        $this->applyKmPerDay($tripId, $route);
+
+        // Valhalla geometry carries no elevation, so D+/D- are reported as 0 here
+        // (the pacing engine computes flat profiles for AI-generated routes).
+        $this->publisher->publish($tripId, MercureEventType::ROUTE_PARSED, [
+            'totalDistance' => round($route->distanceKm, 1),
+            'totalElevation' => 0,
+            'totalElevationLoss' => 0,
+            'sourceType' => SourceType::AI_GENERATED->value,
+            'title' => $title,
+        ]);
+
+        $this->messageBus->dispatch(new GenerateStages($tripId, $generation));
+    }
+
+    private function applyKmPerDay(string $tripId, AiGeneratedRoute $route): void
+    {
+        $request = $this->tripStateManager->getRequest($tripId);
+        if (!$request instanceof TripRequest) {
+            return;
+        }
+
+        $kmPerDay = $route->spec['km_per_day'] ?? null;
+        if (!is_numeric($kmPerDay)) {
+            return;
+        }
+
+        // Clamp to the same bounds the API enforces (Assert\Range on the entity)
+        // so a stray model value cannot drive pacing out of range.
+        $request->maxDistancePerDay = (float) max(30, min(300, (int) $kmPerDay));
+        $this->tripStateManager->storeRequest($tripId, $request);
+    }
+
+    private function title(AiGeneratedRoute $route, string $locale): string
+    {
+        $start = $this->specString($route->spec, 'start');
+        $end = $this->specString($route->spec, 'end');
+        $loop = true === ($route->spec['loop'] ?? false);
+
+        if ('' === $start) {
+            return 'fr' === $locale ? 'Itinéraire généré' : 'Generated route';
+        }
+
+        if ($loop || '' === $end) {
+            return 'fr' === $locale ? \sprintf('Boucle au départ de %s', $start) : \sprintf('Loop from %s', $start);
+        }
+
+        return \sprintf('%s - %s', $start, $end);
+    }
+
+    /**
+     * @param list<Coordinate> $coordinates
+     *
+     * @return list<array{lat: float, lon: float, ele: float}>
+     */
+    private function toPointArrays(array $coordinates): array
+    {
+        return array_map(
+            static fn (Coordinate $c): array => ['lat' => $c->lat, 'lon' => $c->lon, 'ele' => $c->ele],
+            $coordinates,
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $spec
+     */
+    private function specString(array $spec, string $key): string
+    {
+        $value = $spec[$key] ?? null;
+
+        return \is_string($value) ? $value : '';
+    }
+
+    private function notConfiguredMessage(string $locale): string
+    {
+        return 'fr' === $locale
+            ? 'Configurez une IA dans vos réglages pour générer un itinéraire.'
+            : 'Configure an AI provider in your settings to generate a route.';
+    }
+
+    private function unavailableMessage(AiFailureReason $reason, string $locale): string
+    {
+        if ('fr' === $locale) {
+            return match ($reason) {
+                AiFailureReason::INVALID_TOKEN => 'Votre clé IA semble invalide. Vérifiez-la dans vos réglages.',
+                AiFailureReason::QUOTA_EXCEEDED => 'Le quota de votre offre IA est épuisé. Vérifiez votre compte chez le fournisseur.',
+                default => 'Assistant IA temporairement indisponible. Réessayez dans un instant.',
+            };
+        }
+
+        return match ($reason) {
+            AiFailureReason::INVALID_TOKEN => 'Your AI key looks invalid. Check it in your settings.',
+            AiFailureReason::QUOTA_EXCEEDED => 'Your AI plan quota is exhausted. Check your provider account.',
+            default => 'AI assistant temporarily unavailable. Please try again shortly.',
+        };
+    }
+}

--- a/api/src/State/TripAiGenerateProcessor.php
+++ b/api/src/State/TripAiGenerateProcessor.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\State\ProcessorInterface;
+use App\ApiResource\Trip;
+use App\ApiResource\TripAiGenerateRequest;
+use App\ApiResource\TripRequest;
+use App\ComputationTracker\ComputationTrackerInterface;
+use App\ComputationTracker\TripGenerationTrackerInterface;
+use App\Entity\User;
+use App\Enum\ComputationName;
+use App\Llm\ResolvedLlmClient;
+use App\Llm\UserLlmResolverInterface;
+use App\Message\GenerateAiRoute;
+use App\Repository\TripRequestRepositoryInterface;
+use App\Security\Voter\TripVoter;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Handles `POST /trips/ai-generate` (B1, ADR-042): creates an empty trip and
+ * kicks off async AI route generation.
+ *
+ * Mirrors {@see TripCreateProcessor} (UUID v7, owner cache, pipeline
+ * computations, generation tracker) but dispatches {@see GenerateAiRoute}
+ * instead of FetchAndParseRoute — the LLM call + geocoding + Valhalla routing
+ * run on the worker so the HTTP request returns immediately (202).
+ *
+ * @implements ProcessorInterface<TripAiGenerateRequest, Trip>
+ */
+final readonly class TripAiGenerateProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private MessageBusInterface $messageBus,
+        private TripRequestRepositoryInterface $tripStateManager,
+        private ComputationTrackerInterface $computationTracker,
+        private TripGenerationTrackerInterface $generationTracker,
+        private UserLlmResolverInterface $clientFactory,
+        private RequestStack $requestStack,
+        private Security $security,
+        #[Autowire(service: 'cache.trip_state')]
+        private CacheItemPoolInterface $tripStateCache,
+        #[Autowire(service: 'limiter.ai_generate')]
+        private RateLimiterFactory $aiGenerateLimiter,
+    ) {
+    }
+
+    /**
+     * @param TripAiGenerateRequest $data
+     * @param Post                  $operation
+     */
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): Trip
+    {
+        \assert($data instanceof TripAiGenerateRequest);
+
+        /** @var User $user */
+        $user = $this->security->getUser();
+
+        // Fail fast — and before consuming a rate-limit token — when the user has
+        // no provider configured: generation is impossible without one.
+        if (!$this->clientFactory->forUser($user) instanceof ResolvedLlmClient) {
+            throw new UnprocessableEntityHttpException('Configure an AI provider in your settings to generate a route.');
+        }
+
+        $limiter = $this->aiGenerateLimiter->create($user->getId()->toRfc4122());
+        if (!$limiter->consume()->isAccepted()) {
+            throw new TooManyRequestsHttpException(message: 'AI generation rate limit reached. Please wait a moment before retrying.');
+        }
+
+        $tripId = Uuid::v7()->toRfc4122();
+
+        $request = new TripRequest();
+        $request->user = $user;
+
+        $this->tripStateManager->initializeTrip($tripId, $request);
+
+        $locale = $this->requestStack->getCurrentRequest()?->getPreferredLanguage(['en', 'fr']) ?? 'en';
+        $this->tripStateManager->storeLocale($tripId, $locale);
+
+        // Store userId in Redis for fast ownership checks during computation
+        // (the async handler resolves the owner's provider from this key).
+        $item = $this->tripStateCache->getItem(\sprintf('trip.%s.user_id', $tripId));
+        $item->set($user->getId()->toRfc4122());
+        $item->expiresAfter(TripVoter::CACHE_TTL);
+
+        $this->tripStateCache->save($item);
+
+        $computations = ComputationName::pipeline();
+        $this->computationTracker->initializeComputations($tripId, $computations);
+
+        $this->generationTracker->initialize($tripId);
+        $generation = 1;
+
+        $this->messageBus->dispatch(new GenerateAiRoute($tripId, $data->brief, $locale, $generation));
+
+        return new Trip(
+            id: $tripId,
+            computationStatus: $this->buildInitialStatus($computations),
+        );
+    }
+
+    /**
+     * @param list<ComputationName> $computations
+     *
+     * @return array<string, string>
+     */
+    private function buildInitialStatus(array $computations): array
+    {
+        $status = [];
+        foreach ($computations as $computation) {
+            $status[$computation->value] = 'pending';
+        }
+
+        return $status;
+    }
+}

--- a/api/src/State/TripAiGenerateProcessor.php
+++ b/api/src/State/TripAiGenerateProcessor.php
@@ -75,8 +75,12 @@ final readonly class TripAiGenerateProcessor implements ProcessorInterface
         }
 
         $limiter = $this->aiGenerateLimiter->create($user->getId()->toRfc4122());
-        if (!$limiter->consume()->isAccepted()) {
-            throw new TooManyRequestsHttpException(message: 'AI generation rate limit reached. Please wait a moment before retrying.');
+        $rateLimit = $limiter->consume();
+        if (!$rateLimit->isAccepted()) {
+            $retryAfter = $rateLimit->getRetryAfter();
+            $secondsUntilRetry = max(0, $retryAfter->getTimestamp() - new \DateTimeImmutable()->getTimestamp());
+
+            throw new TooManyRequestsHttpException(retryAfter: $secondsUntilRetry, message: 'AI generation rate limit reached. Please wait a moment before retrying.');
         }
 
         $tripId = Uuid::v7()->toRfc4122();

--- a/api/tests/Integration/AiGenerationRoutingTest.php
+++ b/api/tests/Integration/AiGenerationRoutingTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration;
+
+use App\ApiResource\Model\Coordinate;
+use App\Generation\AiGenerationOutcome;
+use App\Generation\AiTripGenerationService;
+use App\Geo\GeocoderInterface;
+use App\Llm\AiProvider;
+use App\Llm\LlmClientInterface;
+use App\Llm\ResolvedLlmClient;
+use App\Llm\SystemPromptLoader;
+use App\Osm\CoverageRepositoryInterface;
+use App\Routing\ValhallaRoutingProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+
+/**
+ * Integration coverage for the AI-generation routing leg (B0 condition 2): the
+ * real {@see ValhallaRoutingProvider} — including its polyline6 decoder and the
+ * km->meters conversion — wired into {@see AiTripGenerationService} against a
+ * Valhalla-shaped HTTP response. The B0 spike could not reach the Valhalla
+ * container from the CLI, so this closes that gap without provisioned tiles.
+ */
+final class AiGenerationRoutingTest extends TestCase
+{
+    private string $promptDir = '';
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->promptDir = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'ai-gen-routing-'.bin2hex(random_bytes(4));
+        mkdir($this->promptDir, 0o755, true);
+        file_put_contents(
+            $this->promptDir.\DIRECTORY_SEPARATOR.AiTripGenerationService::PROMPT_NAME.'.txt',
+            'Plan a trip in {{language}}. Respond with JSON.',
+        );
+    }
+
+    #[\Override]
+    protected function tearDown(): void
+    {
+        @unlink($this->promptDir.\DIRECTORY_SEPARATOR.AiTripGenerationService::PROMPT_NAME.'.txt');
+        @rmdir($this->promptDir);
+    }
+
+    #[Test]
+    public function decodesAValhallaLoopIntoARoutedItinerary(): void
+    {
+        // Loop brief: start + one waypoint (>= 2 geocoded points). Target is
+        // 2 x 80 = 160 km; the Valhalla summary reports 150 km — in range, so no
+        // corrective re-prompt fires.
+        $llm = $this->createStub(LlmClientInterface::class);
+        $llm->method('generate')->willReturn([
+            'response' => '{"start":"Lille","loop":true,"days":2,"km_per_day":80,"waypoints":["Cambrai"]}',
+        ]);
+
+        $service = new AiTripGenerationService(
+            promptLoader: new SystemPromptLoader($this->promptDir),
+            geocoder: $this->geocoder(),
+            coverageRepository: $this->coverage(),
+            routingProvider: $this->valhalla('_izlhA_yrwGAA', 150.0),
+            logger: new NullLogger(),
+        );
+
+        $result = $service->generate('boucle Lille 80 km/j', new ResolvedLlmClient($llm, AiProvider::GEMINI));
+
+        self::assertSame(AiGenerationOutcome::SUCCESS, $result->outcome);
+        self::assertNotEmpty($result->coordinates, 'the decoded Valhalla polyline must yield geometry');
+        self::assertContainsOnlyInstancesOf(Coordinate::class, $result->coordinates);
+        self::assertEqualsWithDelta(150.0, $result->distanceKm, 0.01, 'distance comes from the Valhalla summary (km)');
+    }
+
+    private function geocoder(): GeocoderInterface
+    {
+        // Every named place resolves to an in-zone French coordinate.
+        $geocoder = $this->createStub(GeocoderInterface::class);
+        $geocoder->method('geocode')->willReturn(new Coordinate(50.63, 3.06));
+
+        return $geocoder;
+    }
+
+    private function coverage(): CoverageRepositoryInterface
+    {
+        $coverage = $this->createStub(CoverageRepositoryInterface::class);
+        $coverage->method('isRouteOutOfZone')->willReturn(false);
+
+        return $coverage;
+    }
+
+    private function valhalla(string $shape, float $lengthKm): ValhallaRoutingProvider
+    {
+        $body = json_encode([
+            'trip' => [
+                'legs' => [['shape' => $shape]],
+                'summary' => ['length' => $lengthKm, 'elevation_gain' => 0.0, 'time' => 18000.0],
+            ],
+        ], \JSON_THROW_ON_ERROR);
+
+        // Callable client: the same payload answers every routing call (the route
+        // plus any corrective re-prompt), so the test never trips on an exhausted
+        // response queue.
+        $httpClient = new MockHttpClient(
+            static fn (): MockResponse => new MockResponse($body, ['http_code' => 200]),
+            'http://valhalla:8002',
+        );
+
+        return new ValhallaRoutingProvider($httpClient, $this->passthroughCache());
+    }
+
+    private function passthroughCache(): CacheInterface
+    {
+        $cache = $this->createStub(CacheInterface::class);
+        $cache->method('get')->willReturnCallback(
+            fn (string $key, callable $callback): mixed => $callback($this->createStub(ItemInterface::class)),
+        );
+
+        return $cache;
+    }
+}

--- a/api/tests/Unit/MessageHandler/GenerateAiRouteHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/GenerateAiRouteHandlerTest.php
@@ -1,0 +1,257 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\MessageHandler;
+
+use App\ApiResource\Model\Coordinate;
+use App\ApiResource\TripRequest;
+use App\ComputationTracker\ComputationTrackerInterface;
+use App\ComputationTracker\TripGenerationTrackerInterface;
+use App\Engine\RouteSimplifierInterface;
+use App\Enum\SourceType;
+use App\Generation\AiGeneratedRoute;
+use App\Generation\AiTripGenerationServiceInterface;
+use App\Llm\AiProvider;
+use App\Llm\Exception\AiFailureReason;
+use App\Llm\Exception\AiUnavailableException;
+use App\Llm\LlmClientInterface;
+use App\Llm\ResolvedLlmClient;
+use App\Llm\TripLlmResolverInterface;
+use App\Mercure\MercureEventType;
+use App\Mercure\TripUpdatePublisherInterface;
+use App\Message\GenerateAiRoute;
+use App\Message\GenerateStages;
+use App\MessageHandler\GenerateAiRouteHandler;
+use App\Repository\TripRequestRepositoryInterface;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+#[AllowMockObjectsWithoutExpectations]
+final class GenerateAiRouteHandlerTest extends TestCase
+{
+    private const string TRIP_ID = 'trip-ai-1';
+
+    #[Test]
+    public function successStoresGeometrySetsAiSourceAndDispatchesGenerateStages(): void
+    {
+        $route = AiGeneratedRoute::success(
+            ['start' => 'Lille', 'loop' => true, 'km_per_day' => 80],
+            [new Coordinate(50.6, 3.0), new Coordinate(50.2, 3.2)],
+            150.0,
+        );
+
+        $service = $this->createMock(AiTripGenerationServiceInterface::class);
+        $service->method('generate')->willReturn($route);
+
+        $capturedRequest = null;
+        $repository = $this->createMock(TripRequestRepositoryInterface::class);
+        $repository->method('getRequest')->willReturn(new TripRequest());
+        $repository->expects(self::once())->method('storeRawPoints')
+            ->with(self::TRIP_ID, self::callback(static fn (array $points): bool => 2 === \count($points)));
+        $repository->expects(self::once())->method('storeDecimatedPoints');
+        $repository->expects(self::once())->method('storeSourceType')
+            ->with(self::TRIP_ID, SourceType::AI_GENERATED->value);
+        $repository->expects(self::once())->method('storeTitle')
+            ->with(self::TRIP_ID, self::callback(static fn (?string $t): bool => \is_string($t) && str_contains($t, 'Lille')));
+        $repository->expects(self::once())->method('storeRequest')
+            ->willReturnCallback(static function (string $id, TripRequest $r) use (&$capturedRequest): void {
+                $capturedRequest = $r;
+            });
+
+        $publisher = $this->createMock(TripUpdatePublisherInterface::class);
+        $publisher->expects(self::never())->method('publishValidationError');
+        $publisher->expects(self::once())->method('publish')
+            ->with(self::TRIP_ID, MercureEventType::ROUTE_PARSED, self::anything());
+
+        $bus = $this->newMessageBus();
+        $handler = $this->handler($service, $this->resolved(), $repository, $publisher, $bus);
+
+        $handler(new GenerateAiRoute(self::TRIP_ID, 'boucle Lille 80 km/j', 'fr', 1));
+
+        $dispatched = $this->collectDispatched($bus, GenerateStages::class);
+        self::assertCount(1, $dispatched);
+        self::assertSame(self::TRIP_ID, $dispatched[0]->tripId);
+        self::assertSame(1, $dispatched[0]->generation);
+
+        // The model's km/day drives the pacing day count.
+        self::assertInstanceOf(TripRequest::class, $capturedRequest);
+        self::assertEqualsWithDelta(80.0, $capturedRequest->maxDistancePerDay, 0.01);
+    }
+
+    /**
+     * @return iterable<string, array{AiGeneratedRoute, string}>
+     */
+    public static function nonSuccessOutcomes(): iterable
+    {
+        yield 'out of zone' => [AiGeneratedRoute::outOfZone('', 'fr'), 'OUT_OF_ZONE'];
+        yield 'unparseable' => [AiGeneratedRoute::unparseable('fr'), 'UNPARSEABLE'];
+        yield 'ungeocodable' => [AiGeneratedRoute::ungeocodable([], 'Impossible de localiser Atlantis.'), 'UNGEOCODABLE'];
+        yield 'routing failed' => [AiGeneratedRoute::routingFailed([], 'fr'), 'ROUTING_FAILED'];
+    }
+
+    #[Test]
+    #[DataProvider('nonSuccessOutcomes')]
+    public function nonSuccessOutcomePublishesValidationErrorAndStops(AiGeneratedRoute $route, string $expectedCode): void
+    {
+        $service = $this->createMock(AiTripGenerationServiceInterface::class);
+        $service->method('generate')->willReturn($route);
+
+        $repository = $this->createMock(TripRequestRepositoryInterface::class);
+        $repository->expects(self::never())->method('storeRawPoints');
+
+        $publisher = $this->createMock(TripUpdatePublisherInterface::class);
+        $publisher->expects(self::once())->method('publishValidationError')
+            ->with(self::TRIP_ID, $expectedCode, self::callback(static fn (string $m): bool => '' !== $m));
+
+        $bus = $this->newMessageBus();
+        $handler = $this->handler($service, $this->resolved(), $repository, $publisher, $bus);
+
+        $handler(new GenerateAiRoute(self::TRIP_ID, 'brief', 'fr', 1));
+
+        self::assertCount(0, $this->collectDispatched($bus, GenerateStages::class));
+    }
+
+    #[Test]
+    public function transientProviderErrorIsRethrownForRetry(): void
+    {
+        $service = $this->createMock(AiTripGenerationServiceInterface::class);
+        $service->method('generate')->willThrowException(
+            new AiUnavailableException('upstream 503', AiFailureReason::UNAVAILABLE),
+        );
+
+        $publisher = $this->createMock(TripUpdatePublisherInterface::class);
+        // A transient failure is not a user-facing validation error — it is retried.
+        $publisher->expects(self::never())->method('publishValidationError');
+
+        $bus = $this->newMessageBus();
+        $handler = $this->handler($service, $this->resolved(), $this->createStub(TripRequestRepositoryInterface::class), $publisher, $bus);
+
+        try {
+            $handler(new GenerateAiRoute(self::TRIP_ID, 'brief', 'fr', 1));
+            self::fail('Expected AiUnavailableException to propagate for Messenger retry.');
+        } catch (AiUnavailableException) {
+            // Expected: executeWithTracking re-throws so the message is retried.
+        }
+
+        self::assertCount(0, $this->collectDispatched($bus, GenerateStages::class));
+    }
+
+    #[Test]
+    public function terminalProviderErrorFailsFastWithoutRetry(): void
+    {
+        $service = $this->createMock(AiTripGenerationServiceInterface::class);
+        $service->method('generate')->willThrowException(
+            new AiUnavailableException('401 unauthorized', AiFailureReason::INVALID_TOKEN),
+        );
+
+        $publisher = $this->createMock(TripUpdatePublisherInterface::class);
+        $publisher->expects(self::once())->method('publishValidationError')
+            ->with(self::TRIP_ID, 'AI_UNAVAILABLE', self::callback(static fn (string $m): bool => '' !== $m));
+
+        $bus = $this->newMessageBus();
+        $handler = $this->handler($service, $this->resolved(), $this->createStub(TripRequestRepositoryInterface::class), $publisher, $bus);
+
+        // Must return normally (no re-throw) so Messenger does not retry on a terminal error.
+        $handler(new GenerateAiRoute(self::TRIP_ID, 'brief', 'fr', 1));
+
+        self::assertCount(0, $this->collectDispatched($bus, GenerateStages::class));
+    }
+
+    #[Test]
+    public function publishesValidationErrorWhenOwnerHasNoProvider(): void
+    {
+        $service = $this->createMock(AiTripGenerationServiceInterface::class);
+        $service->expects(self::never())->method('generate');
+
+        $publisher = $this->createMock(TripUpdatePublisherInterface::class);
+        $publisher->expects(self::once())->method('publishValidationError')
+            ->with(self::TRIP_ID, 'AI_NOT_CONFIGURED', self::callback(static fn (string $m): bool => '' !== $m));
+
+        $bus = $this->newMessageBus();
+        $handler = $this->handler($service, null, $this->createStub(TripRequestRepositoryInterface::class), $publisher, $bus);
+
+        $handler(new GenerateAiRoute(self::TRIP_ID, 'brief', 'fr', 1));
+
+        self::assertCount(0, $this->collectDispatched($bus, GenerateStages::class));
+    }
+
+    private function handler(
+        AiTripGenerationServiceInterface $service,
+        ?ResolvedLlmClient $resolved,
+        TripRequestRepositoryInterface $repository,
+        TripUpdatePublisherInterface $publisher,
+        MessageBusInterface $messageBus,
+    ): GenerateAiRouteHandler {
+        $tripLlmResolver = $this->createStub(TripLlmResolverInterface::class);
+        $tripLlmResolver->method('resolveForTrip')->willReturn($resolved);
+
+        $computationTracker = $this->createStub(ComputationTrackerInterface::class);
+        // Total > settled so the AllEnrichmentsCompleted gate never fires here.
+        $computationTracker->method('getProgress')->willReturn(['completed' => 1, 'failed' => 0, 'total' => 18]);
+
+        $routeSimplifier = $this->createStub(RouteSimplifierInterface::class);
+        $routeSimplifier->method('simplify')->willReturnArgument(0);
+
+        return new GenerateAiRouteHandler(
+            $computationTracker,
+            $publisher,
+            $this->createStub(TripGenerationTrackerInterface::class),
+            new NullLogger(),
+            $repository,
+            $tripLlmResolver,
+            $service,
+            $routeSimplifier,
+            $messageBus,
+        );
+    }
+
+    private function resolved(): ResolvedLlmClient
+    {
+        return new ResolvedLlmClient($this->createStub(LlmClientInterface::class), AiProvider::ANTHROPIC);
+    }
+
+    private function newMessageBus(): MessageBusInterface
+    {
+        return new class () implements MessageBusInterface {
+            /** @var list<Envelope> */
+            public array $dispatched = [];
+
+            public function dispatch(object $message, array $stamps = []): Envelope
+            {
+                $envelope = $message instanceof Envelope ? $message : new Envelope($message, $stamps);
+                $this->dispatched[] = $envelope;
+
+                return $envelope;
+            }
+        };
+    }
+
+    /**
+     * @template T of object
+     *
+     * @param class-string<T> $messageClass
+     *
+     * @return list<T>
+     */
+    private function collectDispatched(MessageBusInterface $bus, string $messageClass): array
+    {
+        \assert(property_exists($bus, 'dispatched'));
+
+        $collected = [];
+        /** @var Envelope $envelope */
+        foreach ($bus->dispatched as $envelope) {
+            $message = $envelope->getMessage();
+            if ($message instanceof $messageClass) {
+                $collected[] = $message;
+            }
+        }
+
+        return $collected;
+    }
+}

--- a/api/tests/Unit/State/TripAiGenerateProcessorTest.php
+++ b/api/tests/Unit/State/TripAiGenerateProcessorTest.php
@@ -82,8 +82,14 @@ final class TripAiGenerateProcessorTest extends TestCase
         // First call consumes the only token.
         $processor->process(new TripAiGenerateRequest('boucle au départ de Lille'), new Post());
 
-        $this->expectException(TooManyRequestsHttpException::class);
-        $processor->process(new TripAiGenerateRequest('boucle au départ de Tours'), new Post());
+        try {
+            $processor->process(new TripAiGenerateRequest('boucle au départ de Tours'), new Post());
+            self::fail('Expected TooManyRequestsHttpException.');
+        } catch (TooManyRequestsHttpException $tooManyRequestsHttpException) {
+            // The 429 must carry a Retry-After header so clients can back off.
+            self::assertArrayHasKey('Retry-After', $tooManyRequestsHttpException->getHeaders());
+            self::assertGreaterThanOrEqual(0, $tooManyRequestsHttpException->getHeaders()['Retry-After']);
+        }
     }
 
     private function newProcessor(

--- a/api/tests/Unit/State/TripAiGenerateProcessorTest.php
+++ b/api/tests/Unit/State/TripAiGenerateProcessorTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\State;
+
+use ApiPlatform\Metadata\Post;
+use App\ApiResource\TripAiGenerateRequest;
+use App\ComputationTracker\ComputationTrackerInterface;
+use App\ComputationTracker\TripGenerationTrackerInterface;
+use App\Entity\User;
+use App\Llm\AiProvider;
+use App\Llm\LlmClientInterface;
+use App\Llm\ResolvedLlmClient;
+use App\Llm\UserLlmResolverInterface;
+use App\Message\GenerateAiRoute;
+use App\Repository\TripRequestRepositoryInterface;
+use App\State\TripAiGenerateProcessor;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
+use Symfony\Component\Uid\Uuid;
+
+#[AllowMockObjectsWithoutExpectations]
+final class TripAiGenerateProcessorTest extends TestCase
+{
+    #[Test]
+    public function dispatchesGenerateAiRouteAndReturnsAPendingTrip(): void
+    {
+        $bus = $this->newMessageBus();
+        $processor = $this->newProcessor(configured: true, messageBus: $bus);
+
+        $trip = $processor->process(
+            new TripAiGenerateRequest('boucle au départ de Lille, 2 jours, 80 km/jour'),
+            new Post(),
+        );
+
+        self::assertArrayHasKey('route', $trip->computationStatus);
+        self::assertSame('pending', $trip->computationStatus['route']);
+
+        $messages = $this->collectDispatched($bus, GenerateAiRoute::class);
+        self::assertCount(1, $messages);
+        self::assertSame($trip->id, $messages[0]->tripId);
+        self::assertSame('boucle au départ de Lille, 2 jours, 80 km/jour', $messages[0]->brief);
+        self::assertSame(1, $messages[0]->generation);
+    }
+
+    #[Test]
+    public function throws422WhenNoProviderIsConfigured(): void
+    {
+        $bus = $this->newMessageBus();
+        $processor = $this->newProcessor(configured: false, messageBus: $bus);
+
+        try {
+            $processor->process(new TripAiGenerateRequest('boucle au départ de Lille'), new Post());
+            self::fail('Expected UnprocessableEntityHttpException.');
+        } catch (UnprocessableEntityHttpException) {
+            // No trip is created and no generation is dispatched for an unconfigured user.
+            self::assertCount(0, $this->collectDispatched($bus, GenerateAiRoute::class));
+        }
+    }
+
+    #[Test]
+    public function throws429WhenRateLimitExceeded(): void
+    {
+        $factory = new RateLimiterFactory(
+            ['id' => 'ai_generate_test_429', 'policy' => 'fixed_window', 'limit' => 1, 'interval' => '1 hour'],
+            new InMemoryStorage(),
+        );
+        $processor = $this->newProcessor(configured: true, messageBus: $this->newMessageBus(), limiterFactory: $factory);
+
+        // First call consumes the only token.
+        $processor->process(new TripAiGenerateRequest('boucle au départ de Lille'), new Post());
+
+        $this->expectException(TooManyRequestsHttpException::class);
+        $processor->process(new TripAiGenerateRequest('boucle au départ de Tours'), new Post());
+    }
+
+    private function newProcessor(
+        bool $configured,
+        MessageBusInterface $messageBus,
+        ?RateLimiterFactory $limiterFactory = null,
+    ): TripAiGenerateProcessor {
+        $user = new User('gen@example.com', Uuid::v7());
+
+        $security = $this->createStub(Security::class);
+        $security->method('getUser')->willReturn($user);
+
+        $clientFactory = $this->createStub(UserLlmResolverInterface::class);
+        $clientFactory->method('forUser')->willReturn(
+            $configured ? new ResolvedLlmClient($this->createStub(LlmClientInterface::class), AiProvider::ANTHROPIC) : null,
+        );
+
+        $requestStack = new RequestStack();
+        $requestStack->push(Request::create('/trips/ai-generate'));
+
+        return new TripAiGenerateProcessor(
+            messageBus: $messageBus,
+            tripStateManager: $this->createStub(TripRequestRepositoryInterface::class),
+            computationTracker: $this->createStub(ComputationTrackerInterface::class),
+            generationTracker: $this->createStub(TripGenerationTrackerInterface::class),
+            clientFactory: $clientFactory,
+            requestStack: $requestStack,
+            security: $security,
+            tripStateCache: new ArrayAdapter(),
+            aiGenerateLimiter: $limiterFactory ?? $this->newNoLimiterFactory(),
+        );
+    }
+
+    private function newMessageBus(): MessageBusInterface
+    {
+        return new class () implements MessageBusInterface {
+            /** @var list<Envelope> */
+            public array $dispatched = [];
+
+            public function dispatch(object $message, array $stamps = []): Envelope
+            {
+                $envelope = $message instanceof Envelope ? $message : new Envelope($message, $stamps);
+                $this->dispatched[] = $envelope;
+
+                return $envelope;
+            }
+        };
+    }
+
+    /**
+     * @template T of object
+     *
+     * @param class-string<T> $messageClass
+     *
+     * @return list<T>
+     */
+    private function collectDispatched(MessageBusInterface $bus, string $messageClass): array
+    {
+        \assert(property_exists($bus, 'dispatched'));
+
+        $collected = [];
+        /** @var Envelope $envelope */
+        foreach ($bus->dispatched as $envelope) {
+            $message = $envelope->getMessage();
+            if ($message instanceof $messageClass) {
+                $collected[] = $message;
+            }
+        }
+
+        return $collected;
+    }
+
+    private function newNoLimiterFactory(): RateLimiterFactory
+    {
+        return new RateLimiterFactory(
+            ['id' => 'ai_generate_test', 'policy' => 'no_limit'],
+            new InMemoryStorage(),
+        );
+    }
+}


### PR DESCRIPTION
## Contexte

Partie B du plan « IA optionnelle multi-provider + génération d'itinéraire par IA » (ADR-042). **B1b** branche l'endpoint asynchrone de génération sur le service cœur livré en B1a (#721).

## Changements

- **`POST /trips/ai-generate`** (input `TripAiGenerateRequest`, statut **202**) → `TripAiGenerateProcessor`, qui calque `TripCreateProcessor` (UUID v7, cache propriétaire `trip.{id}.user_id`, `ComputationName::pipeline()`, generation tracker). Il **échoue vite (422)** si aucun provider n'est configuré et est **rate-limité** (`limiter.ai_generate`, 5/min).
- **Génération asynchrone** : message `GenerateAiRoute` + `GenerateAiRouteHandler`. Le handler résout le provider du propriétaire du trip (`TripLlmResolverInterface`), exécute `AiTripGenerationService` sur le worker (pas de requête HTTP tenue sur la latence cloud), stocke la géométrie **raw + décimée**, pose `SourceType::AI_GENERATED`, **aligne `maxDistancePerDay` sur le km/jour** du modèle, puis dispatche le pipeline pacing **inchangé** (`GenerateStages`).
- **Erreurs** : les sorties non-success (`out_of_zone`, `unparseable`, `ungeocodable`, `routing_failed`) deviennent des erreurs de validation Mercure et stoppent le pipeline ; un échec provider **transitoire** est relancé (retry Messenger), un échec **terminal** (token invalide / quota) échoue vite sans brûler le quota (taxonomie A3).
- `AiTripGenerationServiceInterface` extraite (câblage DI + testabilité).

## Notes

- La géométrie Valhalla ne porte pas d'altitude → D+/D- = 0 pour les itinéraires générés en v1 (le tracé reste valide ; le pacing calcule un profil plat).
- Le token n'est **jamais** porté par le message Messenger : le handler résout le client au moment du traitement.

## Tests

- **Processor** : dispatch + trip pending / 422 non configuré / 429 rate limit.
- **Handler** : succès (stockage géométrie + source IA + `GenerateStages`), chaque sortie d'échec → erreur de validation + pas de dispatch, transitoire → relancé, terminal → fail-fast, propriétaire non configuré.
- **Intégration routage Valhalla** : `AiTripGenerationService` + vrai `ValhallaRoutingProvider` (décodage polyline réel) sur réponse Valhalla mockée → **clôt la condition n°2 du spike B0** (routage non validé faute d'accès au conteneur Valhalla depuis le CLI).

Local : `tests/Unit` **1075/1075 vert**, PHPStan L9 OK, PHP-CS-Fixer + Rector OK. Les tests d'intégration `Osm\*`/`Tourism\*` (lecture PostGIS) nécessitent une base et tournent en CI.

Suite : **B2** (front — carte IA chat → `/trips/ai-generate` → aperçu wizard).

<!-- claude-review-start -->
## Claude Review

**0 findings.** Reviewed commit `d9d426b`.

All previous review threads have been addressed. The `Retry-After` header is correctly set on 429 responses, and the processor test now asserts both its presence and a non-negative value. The overall PR is well-structured: the processor faithfully mirrors `TripCreateProcessor`, the handler's error taxonomy (transient → Messenger retry, terminal → fail-fast Mercure error) is consistent with the chat handler, security constraints are respected (no token in message, brief bounded at 2000 chars, 422 checked before consuming the rate-limit token), and test coverage is comprehensive across unit and integration layers.

### Resolved threads

Resolved 2 previously open threads that were addressed: missing `Retry-After` header (fixed in `02044d8`) and the missing test assertion for that header (fixed in `d9d426b`).

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Inline comments

No inline comments.
<!-- claude-review-end -->