### PR TITLE
feat(ai): wire the AI card to /trips/ai-generate (B2)

### DIFF
--- a/pwa/src/components/ai-chat-card.tsx
+++ b/pwa/src/components/ai-chat-card.tsx
@@ -16,15 +16,11 @@ import { cn } from "@/lib/utils";
 /**
  * One turn of the AI assistant conversation.
  *
- * The shell stores both sides of the dialogue locally so the UI behaves
- * realistically (auto-scroll, alternating bubbles, keyboard navigation) before
- * the backend is wired in.
- *
- * @remarks
- * TODO(sprint 31, #309) — replace the local message list with the real chat
- * stream from the backend AI endpoint. The Ollama infrastructure ships in
- * sprint 28, after which this card will plug into the streaming chat API and
- * actually generate stages instead of dispatching a stub navigation event.
+ * The card stores both sides of the dialogue locally so the UI behaves
+ * realistically (auto-scroll, alternating bubbles, keyboard navigation). The
+ * rider's turns form the brief; the assistant turns are local stubs (there is
+ * no pre-trip streaming chat endpoint; the brief drives a single-shot
+ * generation via `POST /trips/ai-generate`, ADR-042).
  */
 export interface AiChatMessage {
   /** Stable id used as React key — generated from a monotonic counter. */
@@ -38,9 +34,9 @@ export interface AiChatMessage {
 interface AiChatCardProps {
   /**
    * Fired when the user clicks "Valider et continuer". Receives the current
-   * conversation transcript so the parent can hand it off to the wizard or
-   * forward it to the AI endpoint (sprint 31). The shell remains agnostic
-   * about how the conversation is consumed.
+   * conversation transcript; the wizard host forwards the rider's turns as the
+   * brief to AI route generation (`POST /trips/ai-generate`, ADR-042). The card
+   * stays agnostic about how the conversation is consumed.
    */
   onSubmitConversation?: (messages: ReadonlyArray<AiChatMessage>) => void;
   /** Disables every interactive element (offline, parent processing, ...). */
@@ -48,12 +44,10 @@ interface AiChatCardProps {
 }
 
 /**
- * Custom DOM event dispatched on the document when the user submits the chat.
- *
- * Sprint 31 / #309 will replace this with a proper navigation flow once the
- * backend chat endpoint exists; for now the wizard host listens to this event
- * to advance to the preview step (or simply ignores it during the shell-only
- * milestone).
+ * Custom DOM event dispatched on the document when the user submits the chat,
+ * in addition to the {@link AiChatCardProps.onSubmitConversation} callback.
+ * Kept for test/legacy consumers that observe the transcript without coupling
+ * to this component.
  */
 export const AI_CHAT_SUBMIT_EVENT = "ai-chat-submit";
 
@@ -76,10 +70,10 @@ const STUB_ASSISTANT_GREETING_KEY = "stubGreeting";
  *     ("Je veux faire le tour de Corse en 10 jours en septembre", ...).
  *  3. A submit row with the primary "Valider et continuer" button.
  *
- * Until sprint 31 wires the backend (#309), the assistant replies are stubbed
- * locally so the interaction can be exercised end-to-end in mocked tests. The
- * primary button dispatches {@link AI_CHAT_SUBMIT_EVENT} with the transcript
- * so the wizard host can react without coupling to this component.
+ * The assistant replies are local stubs (no pre-trip streaming chat endpoint);
+ * the rider's turns form the brief. On submit the card calls
+ * {@link AiChatCardProps.onSubmitConversation} (wired to AI route generation)
+ * and also dispatches {@link AI_CHAT_SUBMIT_EVENT} for test/legacy consumers.
  *
  * Accessibility:
  *
@@ -146,8 +140,8 @@ export function AiChatCard({
     setMessages((prev) => [
       ...prev,
       { id: nextId(), role: "user", content: trimmed },
-      // TODO(sprint 31, #309) — replace this stub assistant reply with the
-      // streamed response from the backend chat endpoint (Ollama, see #309).
+      // Local stub reply: there is no pre-trip streaming chat endpoint, so the
+      // brief drives a single-shot generation on submit (ADR-042).
       { id: nextId(), role: "assistant", content: stubReply },
     ]);
     setDraft("");
@@ -167,11 +161,9 @@ export function AiChatCard({
     if (disabled) return;
     if (messages.length === 0) return;
 
-    // TODO(sprint 31, #309) — once the backend chat endpoint is available,
-    // replace this stub navigation event with a proper API call that returns
-    // the generated stages and lets the wizard advance to step 2 with real
-    // data. Until then, we surface the transcript via a CustomEvent so the
-    // wizard host (or E2E tests) can observe it without coupling.
+    // Hand the transcript to the wizard host (which POSTs the brief to
+    // /trips/ai-generate) and also surface it via a CustomEvent so E2E tests
+    // and legacy consumers can observe the submit without coupling.
     onSubmitConversation?.(messages);
     if (typeof document !== "undefined") {
       const event = new CustomEvent<AiChatSubmitEventDetail>(

--- a/pwa/src/components/card-selection.tsx
+++ b/pwa/src/components/card-selection.tsx
@@ -26,7 +26,7 @@ import { useUiStore } from "@/store/ui-store";
  * - `null`: no selection yet, all three cards displayed side-by-side
  * - `link`: Komoot/Strava/RideWithGPS URL input
  * - `gpx`: GPX file drag & drop + file picker
- * - `ai`: free-form chat with the AI assistant (UI shell only — see #392)
+ * - `ai`: free-form natural-language brief that drives AI route generation (ADR-042)
  */
 export type InputMode = "link" | "gpx" | "ai" | null;
 
@@ -34,10 +34,10 @@ interface CardSelectionProps {
   onSubmitUrl: (url: string) => Promise<void> | void;
   onUploadFile: (file: File) => Promise<void> | void;
   /**
-   * Optional callback fired when the AI chat conversation is submitted via the
-   * "Valider et continuer" button. Until the backend AI endpoint ships
-   * (sprint 31, #309) the parent typically leaves this `undefined` and lets
-   * the chat card dispatch its own `ai-chat-submit` DOM event.
+   * Fired when the user submits the AI chat conversation via the "Valider et
+   * continuer" button. The trip-planner host forwards the brief to
+   * `POST /trips/ai-generate` (ADR-042). The chat card also dispatches an
+   * `ai-chat-submit` DOM event for test/legacy consumers.
    */
   onSubmitAiConversation?: (messages: ReadonlyArray<AiChatMessage>) => void;
   disabled?: boolean;
@@ -51,8 +51,8 @@ const MAX_GPX_SIZE_BYTES = 30 * 1024 * 1024;
  *
  * Shows three active cards (Lien + GPX + Assistant IA). Selecting a card
  * expands it and collapses the others, revealing the appropriate input
- * (URL field, drop zone or chat composer). The AI assistant ships as a UI
- * shell only — its backend wiring lands in sprint 31 (see #309).
+ * (URL field, drop zone or chat composer). The AI assistant card forwards a
+ * natural-language brief to AI route generation (ADR-042).
  */
 export function CardSelection({
   onSubmitUrl,
@@ -115,10 +115,10 @@ export function CardSelection({
           />
         )}
 
-        {/* Card: AI Assistant — multi-turn chat shell (#392). Always visible:
-            disabled with an inline notice when the LLM tier is unreachable
-            (#304), or disabled-but-visible with a "Configurez une IA" CTA when
-            no provider is set on the account (ADR-042). */}
+        {/* Card: AI Assistant - natural-language brief to AI route generation
+            (ADR-042). Always visible: disabled with an inline notice when the
+            LLM tier is unreachable (#304), or disabled-but-visible with a
+            "Configurez une IA" CTA when no provider is set on the account. */}
         {(selected === null || selected === "ai") && (
           <AiCard
             expanded={selected === "ai"}

--- a/pwa/src/components/trip-planner.tsx
+++ b/pwa/src/components/trip-planner.tsx
@@ -107,6 +107,7 @@ export function TripPlanner({
     removeLocalAccommodation,
     handleMagicLink,
     handleGpxUpload,
+    handleAiGeneration,
     handleDatesChange,
     handleDeleteStage,
     handleAddStage,
@@ -513,6 +514,16 @@ export function TripPlanner({
             <CardSelection
               onSubmitUrl={handleMagicLink}
               onUploadFile={handleGpxUpload}
+              onSubmitAiConversation={(messages) => {
+                // The assistant turns are local stubs; the brief is the rider's
+                // own words, so only user turns are forwarded to the backend.
+                const brief = messages
+                  .filter((m) => m.role === "user")
+                  .map((m) => m.content)
+                  .join("\n")
+                  .trim();
+                if (brief) void handleAiGeneration(brief);
+              }}
               disabled={!isOnline}
             />
             <RecentTrips />

--- a/pwa/src/hooks/use-trip-planner.ts
+++ b/pwa/src/hooks/use-trip-planner.ts
@@ -215,6 +215,55 @@ export function useTripPlanner() {
     }
   }
 
+  /**
+   * Create a trip from a free-form natural-language brief (B2, ADR-042). Mirrors
+   * {@link handleMagicLink} but POSTs to `/trips/ai-generate`: the LLM call,
+   * geocoding and Valhalla routing run on the worker, so the same async Mercure
+   * lifecycle (route_parsed → stages_computed → preview) drives the wizard.
+   * Generation-specific failures (out-of-zone, unparseable, unavailable, ...)
+   * surface as Mercure `validation_error` toasts via {@link useMercure}.
+   */
+  async function handleAiGeneration(brief: string) {
+    actions.clearTrip();
+    setMercureToken(null);
+    setProcessing(true);
+    setAccommodationScanning(true);
+
+    try {
+      const { data, error, response } = await apiClient.POST(
+        "/trips/ai-generate",
+        { body: { brief } },
+      );
+
+      if (error || !data) {
+        const apiError = parseApiError(response.status, error);
+        toast.error(apiError.message);
+        setProcessing(false);
+        setAccommodationScanning(false);
+        return;
+      }
+
+      actions.setIsLocked(data.isLocked === true);
+      const token = response.headers.get("X-Mercure-Token");
+      if (token) setMercureToken(token);
+      actions.setTrip({
+        id: data.id ?? "",
+        title: getRandomTripName(),
+        sourceUrl: "",
+      });
+      trackEvent("trip_created", { source: "ai" });
+      router.push(`/trips/${data.id ?? ""}`);
+    } catch (err) {
+      if (isNetworkError(err)) {
+        toast.error(t("errors.networkError"));
+      } else {
+        toast.error(t("errors.unexpectedError"));
+      }
+      setProcessing(false);
+      setAccommodationScanning(false);
+    }
+  }
+
   async function handleGpxUpload(file: File) {
     actions.clearTrip();
     setMercureToken(null);
@@ -1123,6 +1172,7 @@ export function useTripPlanner() {
     removeLocalAccommodation: actions.removeLocalAccommodation,
     handleMagicLink,
     handleGpxUpload,
+    handleAiGeneration,
     handleDatesChange,
     handleDeleteStage,
     handleAddStage,

--- a/pwa/src/lib/api/schema.d.ts
+++ b/pwa/src/lib/api/schema.d.ts
@@ -84,6 +84,34 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/users/me/ai-settings": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Retrieves a AiSettings resource.
+         * @description Retrieves a AiSettings resource.
+         */
+        get: operations["api_usersmeai-settings_get"];
+        /**
+         * Replaces the AiSettings resource.
+         * @description Replaces the AiSettings resource.
+         */
+        put: operations["api_usersmeai-settings_put"];
+        post?: never;
+        /**
+         * Removes the AiSettings resource.
+         * @description Removes the AiSettings resource.
+         */
+        delete: operations["api_usersmeai-settings_delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/auth/logout": {
         parameters: {
             query?: never;
@@ -326,6 +354,26 @@ export interface paths {
          * @description Creates a Trip resource.
          */
         post: operations["api_trips_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/trips/ai-generate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Generate a trip from a natural-language brief using the user's configured AI provider.
+         * @description Generate a trip from a natural-language brief using the user's configured AI provider.
+         */
+        post: operations["api_tripsai-generate_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -708,6 +756,60 @@ export interface components {
          *     URL identifier, so there is no IDOR surface.
          */
         "Account.jsonld": components["schemas"]["HydraItemBaseSchema"] & Record<string, never>;
+        /**
+         * @description Per-user AI configuration (ADR-042): the chosen cloud provider and its API
+         *     token (bring-your-own-token). AI is opt-in — without a configured token every
+         *     AI feature stays disabled.
+         *
+         *     - GET    /users/me/ai-settings  current provider + whether a token is stored
+         *     - PUT    /users/me/ai-settings  set provider + token (token format validated)
+         *     - DELETE /users/me/ai-settings  clear both
+         *
+         *     The token is write-only: it is encrypted at rest and the API never returns it,
+         *     only the boolean {@see $tokenConfigured}. The current user is resolved from the
+         *     security token, never from a URL identifier (no IDOR surface).
+         */
+        AiSettings: {
+            /**
+             * @description Chosen provider. Required on write; null only when AI is not configured.
+             * @enum {string|null}
+             */
+            provider: "anthropic" | "gemini" | "openai" | null;
+            /** @description Write-only: the stored token is never serialised back, only whether one is set. */
+            token: string | null;
+            /**
+             * @description Read-only signal that a (non-empty) token is stored.
+             * @default false
+             */
+            readonly tokenConfigured: boolean;
+        };
+        /**
+         * @description Per-user AI configuration (ADR-042): the chosen cloud provider and its API
+         *     token (bring-your-own-token). AI is opt-in — without a configured token every
+         *     AI feature stays disabled.
+         *
+         *     - GET    /users/me/ai-settings  current provider + whether a token is stored
+         *     - PUT    /users/me/ai-settings  set provider + token (token format validated)
+         *     - DELETE /users/me/ai-settings  clear both
+         *
+         *     The token is write-only: it is encrypted at rest and the API never returns it,
+         *     only the boolean {@see $tokenConfigured}. The current user is resolved from the
+         *     security token, never from a URL identifier (no IDOR surface).
+         */
+        "AiSettings.jsonld": components["schemas"]["HydraItemBaseSchema"] & {
+            /**
+             * @description Chosen provider. Required on write; null only when AI is not configured.
+             * @enum {string|null}
+             */
+            provider: "anthropic" | "gemini" | "openai" | null;
+            /** @description Write-only: the stored token is never serialised back, only whether one is set. */
+            token: string | null;
+            /**
+             * @description Read-only signal that a (non-empty) token is stored.
+             * @default false
+             */
+            readonly tokenConfigured: boolean;
+        };
         "Alert.fit": {
             /** @enum {string} */
             type?: "critical" | "warning" | "nudge";
@@ -1194,6 +1296,10 @@ export interface components {
             promptVersion: number;
             /** @description RFC3339 timestamp when the analysis was generated */
             generatedAt: string;
+        };
+        "Trip.TripAiGenerateRequest": {
+            /** @description Free-form description of the desired trip (e.g. "boucle au départ de Lille, 2 jours, 80 km/jour, en tente"). */
+            brief: string;
         };
         "Trip.TripBatchRecomputeRequest": {
             modifications: components["schemas"]["TripModification"][];
@@ -1890,6 +1996,157 @@ export interface operations {
                 content: {
                     "application/ld+json": components["schemas"]["Account.jsonld"];
                 };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["Error.jsonld"];
+                    "application/problem+json": components["schemas"]["Error"];
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["Error.jsonld"];
+                    "application/problem+json": components["schemas"]["Error"];
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    "api_usersmeai-settings_get": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description AiSettings resource */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["AiSettings.jsonld"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["Error.jsonld"];
+                    "application/problem+json": components["schemas"]["Error"];
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["Error.jsonld"];
+                    "application/problem+json": components["schemas"]["Error"];
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    "api_usersmeai-settings_put": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description The updated AiSettings resource */
+        requestBody: {
+            content: {
+                "application/ld+json": components["schemas"]["AiSettings"];
+            };
+        };
+        responses: {
+            /** @description AiSettings resource updated */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["AiSettings.jsonld"];
+                };
+            };
+            /** @description Invalid input */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["Error.jsonld"];
+                    "application/problem+json": components["schemas"]["Error"];
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["Error.jsonld"];
+                    "application/problem+json": components["schemas"]["Error"];
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["Error.jsonld"];
+                    "application/problem+json": components["schemas"]["Error"];
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description An error occurred */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["ConstraintViolation.jsonld"];
+                    "application/problem+json": components["schemas"]["ConstraintViolation"];
+                    "application/json": components["schemas"]["ConstraintViolation"];
+                };
+            };
+        };
+    };
+    "api_usersmeai-settings_delete": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description AiSettings resource deleted */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Forbidden */
             403: {
@@ -2692,6 +2949,71 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ConstraintViolation"];
                     "application/json": components["schemas"]["ConstraintViolation"];
                 };
+            };
+        };
+    };
+    "api_tripsai-generate_post": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description The new Trip resource */
+        requestBody: {
+            content: {
+                "application/ld+json": components["schemas"]["Trip.TripAiGenerateRequest"];
+            };
+        };
+        responses: {
+            /** @description Trip resource created */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["Trip.jsonld"];
+                };
+            };
+            /** @description Invalid input */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["Error.jsonld"];
+                    "application/problem+json": components["schemas"]["Error"];
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["Error.jsonld"];
+                    "application/problem+json": components["schemas"]["Error"];
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description AI provider not configured */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["ConstraintViolation.jsonld"];
+                    "application/problem+json": components["schemas"]["ConstraintViolation"];
+                    "application/json": components["schemas"]["ConstraintViolation"];
+                };
+            };
+            /** @description Rate limit reached */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };

--- a/pwa/tests/fixtures/api-mocks.ts
+++ b/pwa/tests/fixtures/api-mocks.ts
@@ -321,6 +321,18 @@ export async function mockAllApis(
     });
   });
 
+  // POST /trips/ai-generate — AI route generation (B2, ADR-042). Returns the
+  // same 202 envelope as POST /trips so the async preview lifecycle kicks in.
+  // Registered after the generic /trips/* routes so it wins for this exact path.
+  await page.route("**/trips/ai-generate", (route, request) => {
+    if (request.method() !== "POST") return route.fallback();
+    return route.fulfill({
+      status: postTripStatus,
+      contentType: "application/ld+json",
+      body: JSON.stringify(postTripBody ?? defaultTripResponse),
+    });
+  });
+
   // GET /.well-known/mercure — abort real SSE (we use __test_mercure_event)
   await page.route("**/.well-known/mercure*", (route) => route.abort());
 

--- a/pwa/tests/mocked/ai-generation.spec.ts
+++ b/pwa/tests/mocked/ai-generation.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from "../fixtures/base.fixture";
+import { mockAllApis, getTripId } from "../fixtures/api-mocks";
+
+/**
+ * B2 (ADR-042): the AI card forwards the rider's brief to
+ * `POST /trips/ai-generate` and then joins the same async preview lifecycle as
+ * URL / GPX creation. Gating (disabled-but-visible when not configured) is
+ * covered by ai-capabilities.spec.ts; here we exercise the happy path.
+ */
+test.beforeEach(async ({ page }) => {
+  await mockAllApis(page);
+  await page.goto("/");
+  await page.waitForLoadState("networkidle");
+});
+
+test("AI card submits the brief to /trips/ai-generate and starts generation", async ({
+  page,
+}) => {
+  await page.getByTestId("card-ai").click();
+
+  const textarea = page.getByTestId("ai-chat-textarea");
+  await textarea.fill(
+    "Boucle au départ de Lille, 2 jours, 80 km par jour, en tente",
+  );
+  await textarea.press("Enter");
+
+  // The rider's turn is recorded (the assistant reply is a local stub).
+  await expect(
+    page.locator('[data-testid="ai-chat-message"][data-role="user"]'),
+  ).toHaveCount(1);
+
+  const [request] = await Promise.all([
+    page.waitForRequest(
+      (req) =>
+        req.url().includes("/trips/ai-generate") && req.method() === "POST",
+    ),
+    page.getByTestId("ai-chat-submit").click(),
+  ]);
+
+  // Only the user's words are forwarded as the brief — never the stub replies.
+  const body = JSON.parse(request.postData() ?? "{}") as { brief?: string };
+  expect(body.brief).toContain("Boucle au départ de Lille");
+  expect(body.brief).toContain("80 km par jour");
+
+  // Generation kicked off → the wizard navigates to the trip preview lifecycle.
+  await expect(page).toHaveURL(new RegExp(`/trips/${getTripId()}`));
+});


### PR DESCRIPTION
## Contexte

Dernière étape du plan « IA optionnelle multi-provider + génération d'itinéraire par IA » (ADR-042). **B2** branche la carte IA (livrée en shell par A5) sur l'endpoint backend `POST /trips/ai-generate` (B1, #722).

## Changements

- **`handleAiGeneration(brief)`** dans `use-trip-planner` : calque `handleMagicLink` mais POST `/trips/ai-generate`. Le voyage est créé (202), puis **le cycle Mercure existant** (`route_parsed` → `stages_computed` → preview) pilote le wizard **sans modification**. Aucun nouveau code de preview/analyse.
- **Câblage carte IA** : `CardSelection.onSubmitAiConversation` est branché dans `trip-planner` ; le brief = les tours **`user`** concaténés (les réponses assistant sont des stubs locaux du shell).
- **Erreurs de génération** (`OUT_OF_ZONE`, `UNPARSEABLE`, `UNGEOCODABLE`, `ROUTING_FAILED`, `AI_NOT_CONFIGURED`, `AI_UNAVAILABLE`) : remontent via le handler Mercure `validation_error` **déjà en place** (toast localisé envoyé par le backend) — rien à ajouter.
- **`schema.d.ts` régénéré** (typegen) : ajoute l'opération `/trips/ai-generate` + `Trip.TripAiGenerateRequest`. Diff **purement additif** (`+322/-0`) : le `schema.d.ts` commité avait dérivé sur main (endpoints backend mergés sans typegen) ; la régénération le remet à niveau sans rien casser.
- **E2E** : `ai-generation.spec` vérifie que le brief atteint l'endpoint et que la génération démarre (navigation vers la preview) ; `mockAllApis` gagne une route `/trips/ai-generate`.

## Notes

- Le gating « désactivé-mais-visible + CTA configurer » quand l'IA n'est pas configurée reste celui d'A5 (couvert par `ai-capabilities.spec.ts`) — inchangé.
- Le shell de chat reste local (pas d'endpoint de chat pré-voyage) : l'utilisateur décrit son voyage, le backend fait une génération single-shot. Les réponses assistant par tour restent des stubs.

## Vérification (locale)

- `tsc --noEmit` : **aucune erreur** (nouvel appel typé + handler + wiring)
- i18n : **883 clés en phase** fr/en (aucune nouvelle clé)
- ESLint : **0 erreur** (warnings pré-existants hors de mes fichiers)
- Prettier : clean (`schema.d.ts` est dans `.prettierignore`)
- Playwright (`ai-generation.spec`) nécessite la stack complète → exécuté en CI.

<!-- claude-review-start -->
## Claude Review

Reviewed commit `e379910cab60f61ca59e4474f6d9e7e748dfc623`.

The wiring is clean and complete. `handleAiGeneration` correctly mirrors `handleMagicLink` — identical state lifecycle (`clearTrip` → `setProcessing` → POST → `setTrip` → `router.push`), same Mercure hand-off, same error/catch paths. The user-turn filter (`role === "user"`) is the right design for stripping stub assistant replies before forwarding the brief. The second commit addressed the only finding from the previous review (stale shell-era sprint references across `ai-chat-card.tsx` and `card-selection.tsx`). No new issues found.

**Resolved threads:** Dismissed 1 previous `CHANGES_REQUESTED` bot review (finding addressed by commit `e379910`). No open review threads.

**Review checklist**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases (happy path; gating covered by `ai-capabilities.spec.ts`)
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.
<!-- claude-review-end -->