### PR TITLE
fix(wizard): clear the analysis-phase flag at the final trip state

### DIFF
--- a/pwa/src/components/trip-planner.tsx
+++ b/pwa/src/components/trip-planner.tsx
@@ -335,6 +335,11 @@ export function TripPlanner({
       completeStep("preview");
       completeStep("analysis");
       goToStep("my_trip");
+      // Reaching the final state clears the Acte 2 flag so the creation
+      // progress bar / Acte 2 screen can't linger. trip_ready already resets
+      // it, but an interrupted analysis (e.g. a validation_error during Acte 2)
+      // leaves it true; my_trip is the authoritative "analysis is over" point.
+      useUiStore.getState().setAnalysisPhaseActive(false);
     } else if (trip && stages.length === 0) {
       // Trip identity loaded but no stages yet: preview state (loading).
       completeStep("preparation");

--- a/pwa/tests/mocked/processing-progress.spec.ts
+++ b/pwa/tests/mocked/processing-progress.spec.ts
@@ -5,6 +5,7 @@ import {
   routeParsedEvent,
   stagesComputedEvent,
   tripReadyEvent,
+  validationErrorEvent,
 } from "../fixtures/mock-data";
 import type { MercureEvent } from "../../src/lib/mercure/types";
 
@@ -40,6 +41,32 @@ async function enterAnalysingState(
     timeout: 5000,
   });
 }
+
+test.describe("ProcessingProgress — interrupted analysis clears the Acte 2 flag", () => {
+  // Regression (#10): a validation_error during Acte 2 stops processing but used
+  // to leave `isAnalysisPhaseActive` true at the final state, keeping the
+  // creation progress bar / AI bubble in a confusing state. Reaching `my_trip`
+  // must reset the flag.
+  test("a validation_error during analysis returns to the loaded trip with the AI bubble restored", async ({
+    submitUrl,
+    injectEvent,
+    mockedPage,
+  }) => {
+    await enterAnalysingState(submitUrl, injectEvent, mockedPage);
+
+    await injectEvent(validationErrorEvent());
+
+    // The Acte 2 progress screen is gone...
+    await expect(mockedPage.getByTestId("processing-progress")).toHaveCount(0, {
+      timeout: 5000,
+    });
+    // ...and the AI bubble (hidden while isAnalysisPhaseActive is true) is back,
+    // proving the final state reset the flag.
+    await expect(mockedPage.getByTestId("ai-bubble")).toBeVisible({
+      timeout: 5000,
+    });
+  });
+});
 
 test.describe("ProcessingProgress — display", () => {
   test("renders the six narrative categories during analysis", async ({


### PR DESCRIPTION
## Problème

`isAnalysisPhaseActive` pouvait rester `true` après une analyse (Acte 2) **interrompue** : un `validation_error` arrête le traitement (`isProcessing=false`) mais, contrairement à `trip_ready`/`trip_complete`, ne remet pas le flag à `false`. À l'état final (`my_trip`), cela laissait la progress bar de création / l'écran Acte 2 traîner et **masquait la bulle IA** (`ai-bubble.tsx` retourne `null` tant que `isAnalysisPhaseActive` est vrai) — état confus.

## Correctif

Atteindre `my_trip` dans la machine d'états du stepper (`trip-planner.tsx`) est le point qui fait autorité pour « l'analyse est terminée ». On y remet donc `isAnalysisPhaseActive=false`, en plus de `trip_ready`. Une ligne, défensive : dans le flux normal le flag est déjà `false` à ce stade ; le fix couvre les chemins d'interruption (validation_error, et tout futur chemin laissant le flag).

```ts
} else if (trip && stages.length > 0 && hasAnalysisStarted) {
  // ... goToStep("my_trip")
  useUiStore.getState().setAnalysisPhaseActive(false); // <-- ajout
}
```

## Test

E2E mocké ajouté dans `processing-progress.spec.ts` : on entre en Acte 2, on injecte un `validation_error`, puis on vérifie que l'écran de progression a disparu **et** que la bulle IA est de retour (preuve que le flag a été remis à `false`). Avant le fix, la bulle restait cachée → le test échouerait.

## Vérification (locale)

- `tsc --noEmit` : **0 erreur** · ESLint : clean · Prettier : clean (fichiers modifiés)
- Playwright (mocké) : tourne en CI (baseURL `https://localhost` = stack servie, pas exécutable depuis le worktree).

<!-- claude-review-start -->
## Claude Review

**Findings:** 0 critical · 0 warning · 0 suggestion

Reviewed commit `3feb8ce`.

Clean, targeted bug fix. The defensive `setAnalysisPhaseActive(false)` call at the authoritative `my_trip` terminal state correctly covers all interrupted-analysis paths without touching the normal flow (the call is idempotent — the flag is already `false` on the happy path). The regression test is structurally sound: `enterAnalysingState` sets both `hasAnalysisStarted` and `isAnalysisPhaseActive` to `true` via the `__test_set_analysis_started` hook (lines 229–232 of `trip-planner.tsx`), so `processing-progress` visibility proves the flag is truly active before the `validation_error` is injected, and the subsequent `ai-bubble` assertion provides direct proof that the fix cleared it.

**Review checklist**

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**No inline comments.**
<!-- claude-review-end -->