### PR TITLE
docs(tracking): add Sprint 40 (recette #649 round 2)

### DIFF
--- a/TRACKING.md
+++ b/TRACKING.md
@@ -1010,6 +1010,32 @@ Sprint dédié à la résilience de la donnée en production. ADR-032 (Migration
 
 ---
 
+## Sprint 40 — Recette #649 (round 2) : boot iso-prod + correctifs UI
+
+Findings de la 2ᵉ passe de recette manuelle ([#649 commentaire bloquant du 20/06](https://github.com/vincentchalamon/bike-trip-planner/issues/649#issuecomment-4758501208)). Diagnostic runtime (recette iso-prod, authentifié) : les symptômes "données" remontés — Komoot **"Voyage introuvable"** et config IA **"Resource not found"** — ne sont **pas** des bugs métier mais **une cause infra unique** côté boot iso-prod (cache DI prod figé par le volume `php_var`, antérieur à #689/#695 et à la feature IA ; + workers restés `Created`). Modèle worktree-parallèle (`/sprint`).
+
+| Ordre | ID                                                                      | Titre                                                                        | Effort | PRs | Dépend de |
+|-------|-------------------------------------------------------------------------|------------------------------------------------------------------------------|--------|-----|-----------|
+| 1     | [#728](https://github.com/vincentchalamon/bike-trip-planner/issues/728) | fix(docker): intégrité du boot iso-prod (cache DI prod figé + workers)       | M      | —   | —         |
+| 2     | [#729](https://github.com/vincentchalamon/bike-trip-planner/issues/729) | fix(wizard): parcours GPX + breadcrumb sous le header + largeur bloc "Dates" | M      | —   | —         |
+| 3     | [#730](https://github.com/vincentchalamon/bike-trip-planner/issues/730) | fix(pwa): thème "système" hors Préférences + erreurs API en français         | S      | —   | —         |
+
+**Reste manuel** (hors `/sprint` — nécessite la stack up) :
+
+- [#731](https://github.com/vincentchalamon/bike-trip-planner/issues/731) `chore(landing)` — régénérer les screenshots "Aperçu" (`make screenshots`).
+- Re-vérifier l'**upload GPX neuf** end-to-end après #728 : en recette le GPX restait à 0 stage, mais confondu par le flush d'un backlog de 30 min (erreurs `Could not acknowledge redis message`) — à reproduire proprement workers OK + cache frais.
+
+### Recette Sprint 40
+
+- **Checklist manuelle :**
+  - [ ] Voyage Komoot (lien) : création → page voyage avec stages, plus de "Voyage introuvable".
+  - [ ] Upload GPX : création → stages calculés, parcours sans blocage à l'étape 2.
+  - [ ] Config IA : enregistrement clé Gemini → 200 ; messages d'erreur affichés en français.
+  - [ ] Préférences : thème Clair/Sombre uniquement, défaut suivant l'OS.
+  - [ ] Screenshots landing à jour.
+
+---
+
 ## Hors Sprints
 
 | ID  | Titre                            | Note                     |
@@ -1071,4 +1097,5 @@ Sprint dédié à la résilience de la donnée en production. ADR-032 (Migration
 | 37        | Déploiement (incl. Ollama prod)          | 8       | ~8           |
 | 38        | Performance & Resilience Deep Dive       | 18      | ~12          |
 | 39        | Backup & Disaster Recovery               | 9       | ~9           |
-| **Total** |                                          | **231** | **~235**     |
+| 40        | Recette #649 round 2 (boot iso-prod + UI) | 4       | ~4           |
+| **Total** |                                          | **235** | **~239**     |


### PR DESCRIPTION
## Contexte

Setup de **Sprint 40** suite à la 2ᵉ passe de recette manuelle ([#649, commentaire bloquant du 20/06](https://github.com/vincentchalamon/bike-trip-planner/issues/649#issuecomment-4758501208)). Permet de lancer `/sprint 40`.

## Diagnostic runtime (recette iso-prod, authentifié)

Les symptômes "données" remontés ne sont **pas** des bugs métier mais **une cause infra unique** :

- **Komoot "Voyage introuvable"** = `GET /trips/{id}/detail` → **500** (`TripDetailProvider` à 4 args depuis #689/#695, absent du cache compilé) masqué en "introuvable" par le front.
- **Config IA "Resource not found"** = route `/users/me/ai-settings` (feature IA ~19/06) **absente** du même cache compilé → **404**.
- Cause commune : le volume `php_var` **persiste `var/cache/prod`** (figé au 11/06) et masque le cache baké dans l'image. Vérifié : après régénération du cache → `/detail` et `PUT ai-settings` repassent **200**.
- Second problème : workers restés `Created` (jamais démarrés) → 0 stage sur tous les voyages.

## Sprint 40

| Issue | Portée | `/sprint` |
|-------|--------|-----------|
| #728  | `fix(docker)` boot iso-prod (cache DI figé + workers) | ✅ |
| #729  | `fix(wizard)` parcours GPX + layout (stepper/header, bloc dates) | ✅ |
| #730  | `fix(pwa)` thème "système" hors Préférences + erreurs API en FR | ✅ |
| #731  | `chore(landing)` régénérer screenshots | ⛔ manuel (stack up requise) |

## Auto-critique

- Découpage : infra fusionnée en 1 issue (#728) pour éviter les conflits de worktree (`.docker/` + `compose.yaml`). Si la cause workers s'avère indépendante du cache, elle pourra être scindée.
- #731 et la re-vérification GPX end-to-end restent manuels (hors automatisation `/sprint`).
- Diff strictement limité à `TRACKING.md` (section Sprint 40 + récapitulatif).

<!-- claude-review-start -->
## Claude Review

> Reviewed commit `c332bae7431a12c344fdd7913fffac90115ae7c8`

**Summary:** Docs-only PR adding the Sprint 40 sprint setup to `TRACKING.md`. The section is well-structured, internally consistent (4 issues, totals 231+4=235 and 235+4=239 both check out), and clearly separates automated (`/sprint`) from manual issues. No findings.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases *(N/A — docs only)*
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.
<!-- claude-review-end -->