### PR TITLE
fix(docker): drop prod php_var volume so the read-only image uses its baked warm cache

### DIFF
--- a/api/config/packages/cache.php
+++ b/api/config/packages/cache.php
@@ -8,6 +8,11 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $containerConfigurator->extension('framework', [
         'cache' => [
             'default_redis_provider' => '%env(REDIS_URL)%',
+            // Pin the framework default pool to Redis: doctrine.result_cache_pool
+            // is backed by cache.app, whose default adapter is the filesystem one.
+            // Under read_only (no var volume, see ADR-037 / #728) a filesystem write
+            // would fail, so every cache write must go to Redis.
+            'app' => 'cache.adapter.redis',
             'pools' => [
                 'cache.trip_state' => [
                     'adapter' => 'cache.adapter.redis',

--- a/api/config/packages/doctrine.php
+++ b/api/config/packages/doctrine.php
@@ -93,7 +93,10 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                         'adapter' => 'cache.app',
                     ],
                     'doctrine.system_cache_pool' => [
-                        'adapter' => 'cache.system',
+                        // Redis, not cache.system (PhpFiles): the DQL query cache is
+                        // written at runtime on parse miss, which would fail under
+                        // read_only (no var volume, see ADR-037 / #728).
+                        'adapter' => 'cache.adapter.redis',
                     ],
                 ],
             ],

--- a/compose.yaml
+++ b/compose.yaml
@@ -96,7 +96,6 @@ services:
     volumes:
       - caddy_data:/data
       - caddy_config:/config
-      - php_var:/app/var
       # Mounted as zz-app.ini so it loads after docker.ini (which sets Europe/Brussels)
       # and our date.timezone=UTC override takes effect.
       - .docker/php/conf.d/10-app.ini:/usr/local/etc/php/conf.d/zz-app.ini:ro
@@ -167,7 +166,6 @@ services:
       - jwt_private_key
       - jwt_public_key
     volumes:
-      - php_var:/app/var
       # Mounted as zz-app.ini so it loads after docker.ini (which sets Europe/Brussels)
       # and our date.timezone=UTC override takes effect.
       - .docker/php/conf.d/10-app.ini:/usr/local/etc/php/conf.d/zz-app.ini:ro
@@ -243,7 +241,6 @@ services:
       - jwt_private_key
       - jwt_public_key
     volumes:
-      - php_var:/app/var
       # Mounted as zz-app.ini so it loads after docker.ini (which sets Europe/Brussels)
       # and our date.timezone=UTC override takes effect.
       - .docker/php/conf.d/10-app.ini:/usr/local/etc/php/conf.d/zz-app.ini:ro
@@ -443,6 +440,5 @@ services:
 volumes:
   caddy_data: ~
   caddy_config: ~
-  php_var: ~
   database_data: ~
   valhalla-tiles: ~

--- a/docs/adr/adr-037-docker-dev-prod-convergence.md
+++ b/docs/adr/adr-037-docker-dev-prod-convergence.md
@@ -44,6 +44,7 @@ Docker auto-loads `compose.override.yaml` next to `compose.yaml`. Coolify's exac
 
 - Dev installs Composer deps and runs migrations at first boot (vendor is not baked into `frankenphp_dev`), so the first `make start-dev` is slower; the dev `php` healthcheck uses a longer `start_period` to absorb it.
 - A few keys need the Compose `!override` / `!reset` tags so the dev layer replaces (rather than merges into) the prod volume and secret lists.
+- Prod bakes a warmed `var/cache/prod` into the image at build (Composer `post-install-cmd` → `cache:clear`, no external deps). Prod therefore mounts **no** writable volume on `/app/var`: `php`/`worker`/`worker-llm` run `read_only` on the baked cache. This is safe because nothing writes under `var` at runtime (Monolog → `stderr`, all cache pools + Symfony lock → Redis). A prior `php_var` named volume on `/app/var` masked and froze that cache across deploys, causing stale-container 500s (`/trips/{id}/detail`) and 404s (`/users/me/ai-settings`) — issue #728; it has been removed.
 
 ### Neutral
 


### PR DESCRIPTION
Closes #728.

## Résumé

`compose.yaml` montait un volume nommé `php_var` sur `/app/var`, qui **masque le `var/cache/prod` baké dans l'image** (au 1er remplissage du volume) puis **fige le conteneur DI compilé entre déploiements** → 500 sur `/trips/{id}/detail` (`TripDetailProvider` à 4 args depuis #689/#695, absent du cache figé) et 404 sur `/users/me/ai-settings` (route IA ~#708-#723 absente du cache figé).

Le build warme **déjà** le cache (`composer post-install-cmd` → `cache:clear`, sans dépendance externe — prouvé par les builds CI). Le fix **supprime le volume `php_var`** (php/worker/worker-llm + déclaration) : les conteneurs prod tournent `read_only` sur le cache baké de l'image, donc **frais à chaque déploiement**. Rien n'écrit sous `var` au runtime — Monolog → `php://stderr`, tous les pools cache + le lock Symfony → Redis — donc le `read_only` tient sans volume. ADR-037 mis à jour.

> **Approche révisée suite à la review.** La 1ʳᵉ version réchauffait le cache au **boot** (entrypoint `cache:clear`/`cache:warmup`), ce qui impose un `var` writable au runtime et va à l'encontre du `read_only`. Réchauffer au **build** + supprimer le volume est plus simple, préserve le `read_only`, et évite la latence de boot.

## Auto-critique

- `read_only` sans volume sur `/app/var` est **validé par le job CI "Playwright BDD Recette"** (qui boote le vrai stack prod). Si un écrit-runtime imprévu sous `var` surgissait, fallback documenté = `tmpfs` éphémère sur `/app/var` (toujours sans persistance stale).
- Dev inchangé : `compose.dev.yaml` fait `volumes: !override` avec un `/app/var` anonyme.
- Diff minimal : `compose.yaml` (-4 lignes) + `docs/adr/adr-037` (+1). L'entrypoint reste identique à `main`.

<!-- claude-review-start -->
## Claude Review

**Reviewed commit:** `aa48a9161d31b11988916c2baa4682658453dc8b`

**Summary:** The second commit correctly closes the only finding from the previous review. `cache.app` is now explicitly pinned to `cache.adapter.redis`, and `doctrine.system_cache_pool` is moved from `cache.system` (PhpFiles) to `cache.adapter.redis`. Combined with the volume removal, the `read_only` invariant is fully satisfied — no latent write paths remain under `var/` at container runtime.

**Findings:** 0 critical · 0 warning · 0 suggestion

**Resolved threads:** Resolved 1 previously open thread (`cache.app` filesystem adapter — addressed by routing to `cache.adapter.redis`).

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases (infrastructure change validated by "Playwright BDD Recette" CI job against real prod stack)
- [x] Documentation is up to date (ADR-037 updated)
- [x] Dependent tickets accounted for (#728)

**Inline comments:** No inline comments.
<!-- claude-review-end -->