### PR TITLE
fix(wizard): stepper under header, no-dates banner width, GPX navigation

### DIFF
--- a/pwa/src/app/trips/new/page.tsx
+++ b/pwa/src/app/trips/new/page.tsx
@@ -142,9 +142,21 @@ function WizardContent() {
     [navigateToStep],
   );
 
-  // Render the WizardStepper outside TripPlanner's main layout because
-  // TripPlanner manages its own padded section. We mount everything inside
-  // a single page wrapper so `/trips/new` looks coherent.
+  // The WizardStepper is injected into TripPlanner via `stepperSlot` so it
+  // renders under the <TopBar> header (where the internal stepper sits),
+  // instead of above it (issue #729).
+  // {@link WizardStepId} and {@link StepId} share the same string union, so the
+  // cast is structurally safe — it only narrows the nominal type.
+  const stepper = (
+    <div className="mb-8 pb-6" data-testid="wizard-stepper-wrapper">
+      <WizardStepper
+        currentStep={currentStep as WizardStepId}
+        completedSteps={completedSteps as Set<WizardStepId>}
+        onNavigate={handleStepperNavigate}
+      />
+    </div>
+  );
+
   return (
     <div data-testid="wizard-trip-new" data-current-step={currentStep}>
       <a
@@ -153,17 +165,6 @@ function WizardContent() {
       >
         {t("ariaLabel")}
       </a>
-
-      {/* Step indicator — desktop horizontal stepper, mobile compact label.
-          {@link WizardStepId} and {@link StepId} share the same string union,
-          so the cast is structurally safe — it only narrows the nominal type. */}
-      <div className="max-w-[1200px] mx-auto px-4 md:px-6 pt-6 pb-2">
-        <WizardStepper
-          currentStep={currentStep as WizardStepId}
-          completedSteps={completedSteps as Set<WizardStepId>}
-          onNavigate={handleStepperNavigate}
-        />
-      </div>
 
       <div id="wizard-content">
         {/* Step 2 ("Aperçu") embeds the single-shot AI refinement card
@@ -175,6 +176,7 @@ function WizardContent() {
             (sprint 31) once it ships. */}
         <TripPlanner
           hideStepper
+          stepperSlot={stepper}
           previewSlot={
             <AiRefinementCard
               unavailable={!aiCapability.available}

--- a/pwa/src/components/trip-planner.tsx
+++ b/pwa/src/components/trip-planner.tsx
@@ -64,10 +64,19 @@ const MapPanel = dynamic(
 export function TripPlanner({
   onClose,
   hideStepper = false,
+  stepperSlot,
   previewSlot,
 }: {
   onClose?: () => void;
   hideStepper?: boolean;
+  /**
+   * Optional step indicator rendered in place of the internal {@link Stepper},
+   * i.e. under the {@link TopBar} header and at the top of the creation flow.
+   * Used by the `/trips/new` wizard to mount its URL-synced {@link WizardStepper}
+   * below the header instead of above it (issue #729). Only honoured while the
+   * trip is not fully loaded — same visibility window as the internal stepper.
+   */
+  stepperSlot?: ReactNode;
   /**
    * Optional content rendered inside the Acte 1.5 preview screen, between
    * the per-stage breakdown and the action bar. Used by the `/trips/new`
@@ -504,14 +513,18 @@ export function TripPlanner({
             the creation progress bar no longer serves a purpose there and was
             confused with the horizontal day timeline on scroll (recette #649).
             Hidden on landing page, FAQ and trips list since those pages don't
-            render TripPlanner at all. The wizard at `/trips/new` renders its
-            own {@link WizardStepper} synced with the URL and passes
-            `hideStepper` to suppress this internal one. */}
-        {!hideStepper && !isTripLoaded && (
-          <div className="mb-8 pb-6" data-testid="stepper-wrapper">
-            <Stepper />
-          </div>
-        )}
+            render TripPlanner at all. The wizard at `/trips/new` passes
+            `hideStepper` to suppress this internal one and injects its own
+            URL-synced {@link WizardStepper} via `stepperSlot` so it renders
+            here — below the header — instead of above it (issue #729). */}
+        {!isTripLoaded &&
+          (hideStepper ? (
+            stepperSlot
+          ) : (
+            <div className="mb-8 pb-6" data-testid="stepper-wrapper">
+              <Stepper />
+            </div>
+          ))}
 
         {/* === State 1: Welcome (no trip, not processing) === */}
         {isWelcome && (

--- a/pwa/src/components/trip-planner.tsx
+++ b/pwa/src/components/trip-planner.tsx
@@ -513,18 +513,17 @@ export function TripPlanner({
             the creation progress bar no longer serves a purpose there and was
             confused with the horizontal day timeline on scroll (recette #649).
             Hidden on landing page, FAQ and trips list since those pages don't
-            render TripPlanner at all. The wizard at `/trips/new` passes
-            `hideStepper` to suppress this internal one and injects its own
-            URL-synced {@link WizardStepper} via `stepperSlot` so it renders
-            here — below the header — instead of above it (issue #729). */}
+            render TripPlanner at all. The wizard at `/trips/new` injects its
+            own URL-synced {@link WizardStepper} via `stepperSlot`, which takes
+            precedence over this internal one and renders here — below the
+            header — instead of above it (issue #729). */}
         {!isTripLoaded &&
-          (hideStepper ? (
-            stepperSlot
-          ) : (
-            <div className="mb-8 pb-6" data-testid="stepper-wrapper">
-              <Stepper />
-            </div>
-          ))}
+          (stepperSlot ??
+            (!hideStepper && (
+              <div className="mb-8 pb-6" data-testid="stepper-wrapper">
+                <Stepper />
+              </div>
+            )))}
 
         {/* === State 1: Welcome (no trip, not processing) === */}
         {isWelcome && (

--- a/pwa/src/components/trip-summary.tsx
+++ b/pwa/src/components/trip-summary.tsx
@@ -198,9 +198,11 @@ export function TripSummary({
 
       {/* No-dates alert — moved here (recette #649) so it sits directly under
           the trip info and above the disclaimer, keeping its amber alert style.
-          Only shown in the editable trip view when no start date is set. */}
+          Only shown in the editable trip view when no start date is set.
+          Centered so the banner shrinks to its content and lines up with the
+          centered info block above instead of stretching full-width (#729). */}
       {showNoDatesBanner && !startDate && (
-        <div className="pt-1">
+        <div className="flex justify-center pt-1">
           <NoDatesBanner onOpenConfig={() => openConfigPanelAt("dates")} />
         </div>
       )}

--- a/pwa/src/hooks/use-trip-planner.ts
+++ b/pwa/src/hooks/use-trip-planner.ts
@@ -291,16 +291,14 @@ export function useTripPlanner() {
         title: data.title ?? file.name.replace(/\.gpx$/i, ""),
         sourceUrl: "",
       });
-
-      actions.updateRouteData({
-        totalDistance: data.totalDistance,
-        totalElevation: data.totalElevation,
-        totalElevationLoss: data.totalElevationLoss,
-        sourceType: "gpx_upload",
-        title: data.title ?? null,
-      });
       trackEvent("import_gpx");
       trackEvent("trip_created", { source: "gpx" });
+      // Navigate to /trips/{id} like the magic-link flow (#729): the planner
+      // re-hydrates from the detail endpoint and the async Mercure lifecycle
+      // (route_parsed → stages_computed → preview) drives the wizard. Without
+      // this the GPX flow stayed on /trips/new and the preview gate ("Lancer
+      // l'analyse") was unreachable.
+      router.push(`/trips/${data.id}`);
     } catch (err) {
       if (isNetworkError(err)) {
         toast.error(t("errors.networkError"));

--- a/pwa/tests/mocked/gpx-upload.spec.ts
+++ b/pwa/tests/mocked/gpx-upload.spec.ts
@@ -1,9 +1,5 @@
 import { test, expect, expandGpxCard } from "../fixtures/base.fixture";
-import {
-  routeParsedEvent,
-  stagesComputedEvent,
-  fullTripEventSequence,
-} from "../fixtures/mock-data";
+import { routeParsedEvent, stagesComputedEvent } from "../fixtures/mock-data";
 import path from "node:path";
 
 const GPX_FIXTURE = path.resolve(__dirname, "../fixtures/test-route.gpx");
@@ -31,7 +27,7 @@ test.describe("GPX upload flow", () => {
     });
   });
 
-  test("happy path: upload GPX file, metrics from response, stages from SSE", async ({
+  test("happy path: upload GPX file navigates to /trips/{id}, metrics + stages from SSE", async ({
     mockedPage,
     injectSequence,
   }) => {
@@ -41,20 +37,23 @@ test.describe("GPX upload flow", () => {
     const fileInput = mockedPage.getByTestId("gpx-file-input");
     await fileInput.setInputFiles(GPX_FIXTURE);
 
-    // Trip title should appear (from backend response title)
+    // Like the magic-link flow (#729), a successful upload navigates to
+    // /trips/{id}; the planner then re-hydrates and the async Mercure
+    // lifecycle drives the rest.
+    await mockedPage.waitForURL(/\/trips\//, { timeout: 5000 });
+
+    // Trip title should appear (from the detail endpoint after navigation)
     await expect(
       mockedPage
         .getByTestId("trip-title-skeleton")
         .or(mockedPage.getByTestId("trip-title")),
     ).toBeVisible({ timeout: 5000 });
 
-    // Metrics available immediately from HTTP response — no SSE needed
+    // Metrics arrive via SSE (route_parsed), mirroring the magic-link flow.
+    await injectSequence([routeParsedEvent(), stagesComputedEvent()]);
     await expect(mockedPage.getByTestId("total-distance")).toContainText(
       "187km",
     );
-
-    // Inject stages computed (still via SSE)
-    await injectSequence([stagesComputedEvent()]);
 
     // Stage cards should appear
     await expect(mockedPage.getByTestId("stage-card-1")).toBeVisible({
@@ -64,10 +63,12 @@ test.describe("GPX upload flow", () => {
     await expect(mockedPage.getByTestId("stage-card-3")).toBeVisible();
   });
 
-  test("uses filename as fallback title when backend returns no title", async ({
+  test("upload with no title in response still navigates and loads the trip", async ({
     mockedPage,
   }) => {
-    // Override mock to return no title
+    // Override mock to return no title — the local filename fallback is only
+    // transient now (the detail endpoint owns the title post-navigation, #729),
+    // so we just assert the upload succeeds and lands on the trip.
     await mockedPage.route("**/trips/gpx-upload", (route, request) => {
       if (request.method() !== "POST") return route.fallback();
       return route.fulfill({
@@ -90,7 +91,9 @@ test.describe("GPX upload flow", () => {
     const fileInput = mockedPage.getByTestId("gpx-file-input");
     await fileInput.setInputFiles(GPX_FIXTURE);
 
-    // Trip title should appear (fallback to filename without .gpx)
+    await mockedPage.waitForURL(/\/trips\//, { timeout: 5000 });
+
+    // A title (skeleton or editable) is shown after the detail load.
     await expect(
       mockedPage
         .getByTestId("trip-title-skeleton")
@@ -149,8 +152,9 @@ test.describe("GPX upload flow", () => {
     expect(uploadCalled).toBe(false);
   });
 
-  test("drag & drop: GPX file drop triggers upload and displays metrics from response", async ({
+  test("drag & drop: GPX file drop triggers upload and navigates to the trip", async ({
     mockedPage,
+    injectSequence,
   }) => {
     await mockedPage.evaluate(() => {
       const dt = new DataTransfer();
@@ -164,14 +168,18 @@ test.describe("GPX upload flow", () => {
       );
     });
 
-    // Trip title should appear from the HTTP response
+    // A successful drop uploads then navigates to /trips/{id} (#729).
+    await mockedPage.waitForURL(/\/trips\//, { timeout: 5000 });
+
+    // Trip title should appear after the detail load
     await expect(
       mockedPage
         .getByTestId("trip-title-skeleton")
         .or(mockedPage.getByTestId("trip-title")),
     ).toBeVisible({ timeout: 5000 });
 
-    // Metrics available immediately from HTTP response — no SSE injection needed
+    // Metrics arrive via SSE, mirroring the magic-link flow.
+    await injectSequence([routeParsedEvent()]);
     await expect(mockedPage.getByTestId("total-distance")).toContainText(
       "187km",
     );

--- a/pwa/tests/mocked/gpx-upload.spec.ts
+++ b/pwa/tests/mocked/gpx-upload.spec.ts
@@ -40,7 +40,7 @@ test.describe("GPX upload flow", () => {
     // Like the magic-link flow (#729), a successful upload navigates to
     // /trips/{id}; the planner then re-hydrates and the async Mercure
     // lifecycle drives the rest.
-    await mockedPage.waitForURL(/\/trips\//, { timeout: 5000 });
+    await mockedPage.waitForURL(/\/trips\/(?!new\b)/, { timeout: 5000 });
 
     // Trip title should appear (from the detail endpoint after navigation)
     await expect(
@@ -91,7 +91,7 @@ test.describe("GPX upload flow", () => {
     const fileInput = mockedPage.getByTestId("gpx-file-input");
     await fileInput.setInputFiles(GPX_FIXTURE);
 
-    await mockedPage.waitForURL(/\/trips\//, { timeout: 5000 });
+    await mockedPage.waitForURL(/\/trips\/(?!new\b)/, { timeout: 5000 });
 
     // A title (skeleton or editable) is shown after the detail load.
     await expect(
@@ -169,7 +169,7 @@ test.describe("GPX upload flow", () => {
     });
 
     // A successful drop uploads then navigates to /trips/{id} (#729).
-    await mockedPage.waitForURL(/\/trips\//, { timeout: 5000 });
+    await mockedPage.waitForURL(/\/trips\/(?!new\b)/, { timeout: 5000 });
 
     // Trip title should appear after the detail load
     await expect(

--- a/pwa/tests/recette/steps/golden-paths.steps.ts
+++ b/pwa/tests/recette/steps/golden-paths.steps.ts
@@ -39,11 +39,10 @@ async function selectAccommodation(
 
 /**
  * Upload a valid GPX file through the welcome-screen GPX card. The upload POSTs
- * to `/trips/gpx-upload` (mocked, 202 + trip body) which seeds the store via
- * `setTrip` and mounts the Mercure subscriber so injected SSE events are
- * processed. Unlike the magic-link flow, a GPX upload does not navigate to
- * /trips/{id} — the planner renders in place. Mirrors `tests/mocked/
- * gpx-upload.spec.ts`.
+ * to `/trips/gpx-upload` (mocked, 202 + trip body), then — like the magic-link
+ * flow (#729) — navigates to /trips/{id}, where the planner re-hydrates from the
+ * detail endpoint and mounts the Mercure subscriber so injected SSE events are
+ * processed. Mirrors `tests/mocked/gpx-upload.spec.ts`.
  */
 async function importGpxFile(page: Page): Promise<void> {
   await page.route("**/trips/gpx-upload", (route, request) => {
@@ -76,7 +75,9 @@ async function importGpxFile(page: Page): Promise<void> {
         "</trkseg></trk></gpx>",
     ),
   });
-  // The 202 response carries the title, so the planner renders in place.
+  // A successful upload navigates to /trips/{id}; wait for the URL change then
+  // the trip title rendered after the detail load.
+  await page.waitForURL(/\/trips\//, { timeout: 10000 });
   await expect(
     page.getByTestId("trip-title-skeleton").or(page.getByTestId("trip-title")),
   ).toBeVisible({ timeout: 10000 });

--- a/pwa/tests/recette/steps/golden-paths.steps.ts
+++ b/pwa/tests/recette/steps/golden-paths.steps.ts
@@ -77,7 +77,7 @@ async function importGpxFile(page: Page): Promise<void> {
   });
   // A successful upload navigates to /trips/{id}; wait for the URL change then
   // the trip title rendered after the detail load.
-  await page.waitForURL(/\/trips\//, { timeout: 10000 });
+  await page.waitForURL(/\/trips\/(?!new\b)/, { timeout: 10000 });
   await expect(
     page.getByTestId("trip-title-skeleton").or(page.getByTestId("trip-title")),
   ).toBeVisible({ timeout: 10000 });


### PR DESCRIPTION
Closes #729.

## Résumé

Trois correctifs sur le wizard `/trips/new` :

1. **Stepper sous le header** — rendu via un slot `stepperSlot` dans `TripPlanner` (sous `<TopBar>`), au lieu d'être rendu avant `<TripPlanner>`.
2. **Bannière "Dates non renseignées"** — wrapper `flex justify-center` → largeur du contenu, alignée sur le bloc d'infos au-dessus (plus de pleine largeur).
3. **Parcours GPX** — `handleGpxUpload` navigue vers `/trips/{id}` après upload réussi, comme `handleMagicLink`. La gate preview était inatteignable sur `/trips/new` (`stages_computed` ne remet pas `isProcessing=false`) ; la navigation réutilise le cycle Mercure prouvé du lien Komoot.

Tests mockés (`gpx-upload.spec.ts`) et golden-path adaptés au nouveau flux.

## Auto-critique

- Choix **navigate** (vs gate in-place) = option recommandée par l'issue ; parcours désormais identique à Komoot.
- Playwright E2E non lancé en local (worktree) → repose sur la CI.
- Modifie `pwa/src/hooks/use-trip-planner.ts`, aussi touché par #730 (parties distinctes) → **conflit possible au 2e merge**.

<!-- claude-review-start -->
## Claude Review

Reviewed commit `42c28fc`.

All three fixes are well-scoped and architecturally sound. Every issue raised in the previous round has been addressed: `stepperSlot` now takes precedence over the internal stepper (commit `95e3c17`), both `gpx-upload.spec.ts` and `golden-paths.steps.ts` use the tighter `/\/trips\/(?!new\b)/` regex that actually guards against a missing `router.push` (commits `3c05e42` and `42c28fc`). The `updateRouteData` removal is correct — navigation triggers full re-hydration from the detail endpoint, so the in-place store update was made redundant. No new findings.

**Resolved 2 previously open threads** (`stepperSlot` precedence — addressed by commit `95e3c17`; `waitForURL` regex in `golden-paths.steps.ts` — addressed by commit `42c28fc`).

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**No inline comments.**
<!-- claude-review-end -->