### PR TITLE
fix(pwa): drop "system" theme from preferences and localize API errors in FR

### DIFF
--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -690,6 +690,9 @@
   "errors": {
     "networkError": "Network error. Please check your connection.",
     "unexpectedError": "An unexpected error occurred.",
+    "validationError": "Invalid data.",
+    "badRequest": "Bad request.",
+    "notFound": "Resource not found.",
     "failedUpdateDates": "Failed to update dates.",
     "failedDeleteStage": "Failed to delete stage.",
     "failedMoveStage": "Failed to move stage.",
@@ -934,8 +937,7 @@
       "languageLabel": "Language",
       "themeLabel": "Theme",
       "themeLight": "Light",
-      "themeDark": "Dark",
-      "themeSystem": "Auto"
+      "themeDark": "Dark"
     },
     "data": {
       "title": "My data",

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -690,6 +690,9 @@
   "errors": {
     "networkError": "Erreur réseau. Vérifiez votre connexion.",
     "unexpectedError": "Une erreur inattendue s'est produite.",
+    "validationError": "Données invalides.",
+    "badRequest": "Requête invalide.",
+    "notFound": "Ressource introuvable.",
     "failedUpdateDates": "Impossible de mettre à jour les dates.",
     "failedDeleteStage": "Impossible de supprimer l'étape.",
     "failedMoveStage": "Impossible de déplacer l'étape.",
@@ -934,8 +937,7 @@
       "languageLabel": "Langue",
       "themeLabel": "Thème",
       "themeLight": "Clair",
-      "themeDark": "Sombre",
-      "themeSystem": "Auto"
+      "themeDark": "Sombre"
     },
     "data": {
       "title": "Mes données",

--- a/pwa/src/components/account/ai-provider-section.tsx
+++ b/pwa/src/components/account/ai-provider-section.tsx
@@ -18,6 +18,7 @@ import {
   AI_PROVIDERS,
   clearAiSettings,
   fetchAiSettings,
+  localizedApiErrorMessage,
   saveAiSettings,
   type AiProvider,
 } from "@/lib/api/client";
@@ -39,6 +40,7 @@ import { useUiStore } from "@/store/ui-store";
  */
 export function AiProviderSection() {
   const t = useTranslations("accountSettings.ai");
+  const tErrors = useTranslations();
   const setAiConfigured = useUiStore((s) => s.setAiConfigured);
   const providerId = useId();
   const tokenId = useId();
@@ -70,7 +72,7 @@ export function AiProviderSection() {
     try {
       const { data, error: apiError } = await saveAiSettings(provider, token);
       if (apiError) {
-        setError(apiError.message);
+        setError(localizedApiErrorMessage(apiError, tErrors));
         return;
       }
       setProvider(data.provider ?? provider);

--- a/pwa/src/components/account/preferences-section.tsx
+++ b/pwa/src/components/account/preferences-section.tsx
@@ -21,7 +21,7 @@ const LOCALE_LABELS: Record<SupportedLocale, string> = {
   en: "English",
 };
 
-const THEME_OPTIONS = ["light", "dark", "system"] as const;
+const THEME_OPTIONS = ["light", "dark"] as const;
 type ThemeOption = (typeof THEME_OPTIONS)[number];
 
 const emptySubscribe = () => () => {};
@@ -30,15 +30,16 @@ const getFalse = () => false;
 
 /**
  * "Préférences" section: language (synced with the top-bar locale switcher via
- * the `locale` cookie + next-intl) and theme (Light/Dark/Auto synced with
- * next-themes).
+ * the `locale` cookie + next-intl) and theme (Light/Dark synced with
+ * next-themes). No "auto/system" option (#649) — the provider defaults to
+ * `system`, so the OS preference is the default until the user picks one.
  */
 export function PreferencesSection() {
   const t = useTranslations("accountSettings.preferences");
   const currentLocale = useLocale();
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
-  const { theme, setTheme } = useTheme();
+  const { resolvedTheme, setTheme } = useTheme();
   const mounted = useSyncExternalStore(emptySubscribe, getTrue, getFalse);
 
   function handleLocaleChange(locale: SupportedLocale) {
@@ -52,7 +53,6 @@ export function PreferencesSection() {
   const themeLabels: Record<ThemeOption, string> = {
     light: t("themeLight"),
     dark: t("themeDark"),
-    system: t("themeSystem"),
   };
 
   return (
@@ -102,7 +102,10 @@ export function PreferencesSection() {
           <span className="text-sm font-medium">{t("themeLabel")}</span>
           <div className="flex gap-2">
             {THEME_OPTIONS.map((option) => {
-              const isActive = mounted && theme === option;
+              // Reflect the resolved theme so a persisted "system" value still
+              // highlights its effective light/dark choice (UI never shows an
+              // empty selection).
+              const isActive = mounted && resolvedTheme === option;
               return (
                 <Button
                   key={option}

--- a/pwa/src/components/theme-toggle.tsx
+++ b/pwa/src/components/theme-toggle.tsx
@@ -28,8 +28,8 @@ const NEXT_THEME: Record<ThemeState, ThemeState> = {
  *
  * The provider defaults to `system`, so on first load the theme matches the
  * OS preference. A single click then flips to the opposite *resolved* theme
- * and pins it explicitly (no "auto/system" state in the top bar — #649). The
- * dedicated Account → Préférences picker still exposes the three options.
+ * and pins it explicitly (no "auto/system" state — #649). The dedicated
+ * Account → Préférences picker exposes the same two options.
  */
 export function ThemeToggle() {
   const t = useTranslations("theme");

--- a/pwa/src/hooks/use-trip-planner.ts
+++ b/pwa/src/hooks/use-trip-planner.ts
@@ -15,6 +15,7 @@ import { useMercure } from "@/hooks/use-mercure";
 import {
   apiClient,
   parseApiError,
+  localizedApiErrorMessage,
   isNetworkError,
   uploadGpxFile,
   scanAccommodations,
@@ -186,7 +187,7 @@ export function useTripPlanner() {
 
       if (error || !data) {
         const apiError = parseApiError(response.status, error);
-        toast.error(apiError.message);
+        toast.error(localizedApiErrorMessage(apiError, t));
         setProcessing(false);
         setAccommodationScanning(false);
         return;
@@ -237,7 +238,7 @@ export function useTripPlanner() {
 
       if (error || !data) {
         const apiError = parseApiError(response.status, error);
-        toast.error(apiError.message);
+        toast.error(localizedApiErrorMessage(apiError, t));
         setProcessing(false);
         setAccommodationScanning(false);
         return;
@@ -333,7 +334,7 @@ export function useTripPlanner() {
 
       if (error) {
         const apiError = parseApiError(response.status, error);
-        toast.error(apiError.message);
+        toast.error(localizedApiErrorMessage(apiError, t));
       } else {
         if (data) actions.setIsLocked(data.isLocked === true);
         setProcessing(true);
@@ -380,7 +381,7 @@ export function useTripPlanner() {
       );
       if (error) {
         const apiError = parseApiError(response.status, error);
-        toast.error(apiError.message);
+        toast.error(localizedApiErrorMessage(apiError, t));
         useTripTemporalStore.getState()._pop();
         useTripStore.getState().setStages(snapshot);
       } else {
@@ -479,7 +480,7 @@ export function useTripPlanner() {
       );
       if (error) {
         const apiError = parseApiError(response.status, error);
-        toast.error(apiError.message);
+        toast.error(localizedApiErrorMessage(apiError, t));
         useTripTemporalStore.getState()._pop();
         useTripStore.getState().setStages(currentStages);
       } else {
@@ -510,7 +511,7 @@ export function useTripPlanner() {
       );
       if (error) {
         const apiError = parseApiError(response.status, error);
-        toast.error(apiError.message);
+        toast.error(localizedApiErrorMessage(apiError, t));
       } else {
         // Push snapshot only after a successful PATCH to avoid phantom undo entries
         useTripTemporalStore.getState()._push(snapshot);
@@ -553,7 +554,7 @@ export function useTripPlanner() {
 
       if (error) {
         const apiError = parseApiError(response.status, error);
-        toast.error(apiError.message);
+        toast.error(localizedApiErrorMessage(apiError, t));
       } else {
         setProcessing(true);
         setAccommodationScanning(true);
@@ -632,7 +633,7 @@ export function useTripPlanner() {
 
       if (error) {
         const apiError = parseApiError(response.status, error);
-        toast.error(apiError.message);
+        toast.error(localizedApiErrorMessage(apiError, t));
       } else {
         setProcessing(true);
         setAccommodationScanning(true);
@@ -680,7 +681,7 @@ export function useTripPlanner() {
       if (error) {
         actions.setEnabledAccommodationTypes(previous);
         const apiError = parseApiError(response.status, error);
-        toast.error(apiError.message);
+        toast.error(localizedApiErrorMessage(apiError, t));
       } else {
         setProcessing(true);
         setAccommodationScanning(true);
@@ -1070,7 +1071,7 @@ export function useTripPlanner() {
       );
       if (error) {
         const apiError = parseApiError(response.status, error);
-        toast.error(apiError.message);
+        toast.error(localizedApiErrorMessage(apiError, t));
         useTripStore.getState().setStages([...currentStages]);
       } else {
         setProcessing(true);

--- a/pwa/src/lib/api/client.test.ts
+++ b/pwa/src/lib/api/client.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseApiError } from "./client";
+import { localizedApiErrorMessage, parseApiError } from "./client";
 
 describe("parseApiError", () => {
   it("returns validation error with joined messages for 422", () => {
@@ -16,11 +16,11 @@ describe("parseApiError", () => {
     });
   });
 
-  it("returns fallback message for 422 with empty violations", () => {
+  it("returns an empty message for 422 with empty violations", () => {
     const result = parseApiError(422, { violations: [] });
     expect(result).toEqual({
       type: "validation",
-      message: "Validation error",
+      message: "",
       violations: [],
     });
   });
@@ -32,24 +32,24 @@ describe("parseApiError", () => {
     });
   });
 
-  it("returns bad_request with fallback when body has no detail", () => {
+  it("returns bad_request with an empty message when body has no detail", () => {
     expect(parseApiError(400, {})).toEqual({
       type: "bad_request",
-      message: "Bad request",
+      message: "",
     });
   });
 
   it("returns not_found for 404", () => {
     expect(parseApiError(404, null)).toEqual({
       type: "not_found",
-      message: "Resource not found",
+      message: "",
     });
   });
 
   it("returns network error for unknown status codes", () => {
     expect(parseApiError(500, null)).toEqual({
       type: "network",
-      message: "An unexpected error occurred",
+      message: "",
     });
   });
 
@@ -57,7 +57,29 @@ describe("parseApiError", () => {
     // 422 but body doesn't match ViolationBody shape → falls through
     expect(parseApiError(422, { detail: "something" })).toEqual({
       type: "network",
-      message: "An unexpected error occurred",
+      message: "",
     });
+  });
+});
+
+describe("localizedApiErrorMessage", () => {
+  const t = (key: string) => `t:${key}`;
+
+  it("returns the API-provided message when present", () => {
+    expect(
+      localizedApiErrorMessage({ type: "bad_request", message: "Bad URL" }, t),
+    ).toBe("Bad URL");
+  });
+
+  it("falls back to the localized key when the message is empty", () => {
+    expect(
+      localizedApiErrorMessage({ type: "not_found", message: "" }, t),
+    ).toBe("t:errors.notFound");
+    expect(localizedApiErrorMessage({ type: "network", message: "" }, t)).toBe(
+      "t:errors.unexpectedError",
+    );
+    expect(
+      localizedApiErrorMessage({ type: "validation", message: "" }, t),
+    ).toBe("t:errors.validationError");
   });
 });

--- a/pwa/src/lib/api/client.ts
+++ b/pwa/src/lib/api/client.ts
@@ -240,13 +240,26 @@ function hasDetail(body: unknown): body is DetailBody {
   return body !== null && typeof body === "object" && "detail" in body;
 }
 
+/**
+ * Localized fallback message key (under the `errors` namespace) for each error
+ * `type`. Used by {@link localizedApiErrorMessage} when the API did not provide
+ * a human-readable message of its own (e.g. a 404, or a 422 with empty
+ * violations). API-provided messages (400 `detail`, 422 `violations`) — which
+ * may already be localized server-side — are preserved as-is.
+ */
+const API_ERROR_FALLBACK_KEY: Record<ApiError["type"], string> = {
+  validation: "errors.validationError",
+  bad_request: "errors.badRequest",
+  not_found: "errors.notFound",
+  network: "errors.unexpectedError",
+};
+
 export function parseApiError(status: number, body: unknown): ApiError {
   if (status === 422 && hasViolations(body)) {
     const violations = body.violations ?? [];
     return {
       type: "validation",
-      message:
-        violations.map((v) => v.message).join(", ") || "Validation error",
+      message: violations.map((v) => v.message).join(", "),
       violations,
     };
   }
@@ -255,21 +268,36 @@ export function parseApiError(status: number, body: unknown): ApiError {
     const detail = hasDetail(body) ? body.detail : undefined;
     return {
       type: "bad_request",
-      message: detail ?? "Bad request",
+      message: detail ?? "",
     };
   }
 
   if (status === 404) {
     return {
       type: "not_found",
-      message: "Resource not found",
+      message: "",
     };
   }
 
   return {
     type: "network",
-    message: "An unexpected error occurred",
+    message: "",
   };
+}
+
+/**
+ * Resolve the message to display for an {@link ApiError}: the API-provided
+ * message when present (e.g. a 422 violation or a 400 `detail`, possibly
+ * already translated server-side), otherwise the localized generic fallback
+ * for the error `type`.
+ *
+ * @param t a next-intl translator scoped to the root namespace.
+ */
+export function localizedApiErrorMessage(
+  error: ApiError,
+  t: (key: string) => string,
+): string {
+  return error.message || t(API_ERROR_FALLBACK_KEY[error.type]);
 }
 
 export function isNetworkError(error: unknown): error is TypeError {


### PR DESCRIPTION
Closes #730.

## Résumé

1. **Thème** — `THEME_OPTIONS` réduit à `["light", "dark"]` dans les Préférences (`preferences-section.tsx`) ; état actif via `resolvedTheme` (un "system" persisté reste mis en évidence) ; défaut OS toujours assuré par le `ThemeProvider` (`defaultTheme="system"`).
2. **Erreurs API en FR** — `parseApiError` ne renvoie plus de chaînes anglaises hardcodées ; nouveau helper `localizedApiErrorMessage(error, t)` + map `type → clé i18n`, clés FR/EN ajoutées (`errors.notFound/badRequest/validationError`). Appliqué aux toasts (`use-trip-planner.ts`) et à AiSettings (`ai-provider-section.tsx`).

## Auto-critique

- vitest 248 OK, tsc/eslint/prettier verts en local ; `make qa` complet délégué à la CI (rector OOM en worktree, sans rapport avec ce diff front-only).
- Modifie `pwa/src/hooks/use-trip-planner.ts`, aussi touché par #729 (parties distinctes) → **conflit possible au 2e merge**.

<!-- claude-review-start -->
## Claude Review

**Reviewed commit:** `035a5e30ac265f29150539a975721d310d3f2aab`

### Summary

Clean, well-scoped fix. Both changes (theme reduction and API error localization) are correctly implemented with no critical or warning findings. The `t` translator in `use-trip-planner.ts` is already root-level (`useTranslations()` with no namespace), so `errors.*` keys resolve correctly across all call sites. The `themeSystem` i18n key is fully removed from both message files and all component references.

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Findings

**0 critical · 0 warning · 0 issues**

No inline comments.
<!-- claude-review-end -->