### PR TITLE
fix(ai): treat cloud BYO-token as available

### DIFF
--- a/pwa/src/components/trip-planner.tsx
+++ b/pwa/src/components/trip-planner.tsx
@@ -161,8 +161,10 @@ export function TripPlanner({
   const aiConfigured = useUiStore((s) => s.aiCapability.configured);
   const setAiAvailable = useUiStore((s) => s.setAiAvailable);
 
-  // Probe the LLM tier once on mount so AI features can be gated explicitly when
-  // the tier is unreachable (#304).
+  // Initialise the AI availability signal on mount. Since ADR-042 there is no
+  // self-hosted tier to probe: with the BYO-token cloud model availability
+  // resolves to `true` here. A genuine provider outage surfaces reactively via
+  // the 503 the chat endpoint returns, not from this mount-time call.
   useEffect(() => {
     let cancelled = false;
     void fetchAiAvailability().then((available) => {

--- a/pwa/src/hooks/use-mercure.ts
+++ b/pwa/src/hooks/use-mercure.ts
@@ -7,7 +7,6 @@ import { TripAiOverviewSchema } from "@/lib/validation/schemas";
 import { useTripStore } from "@/store/trip-store";
 import { useUiStore } from "@/store/ui-store";
 import { reverseGeocode } from "@/lib/geocode/client";
-import { fetchAiAvailability } from "@/lib/ai-availability";
 import { toast } from "@/components/ui/sonner";
 import { DEFAULT_ACCOMMODATION_RADIUS_KM } from "@/lib/accommodation-constants";
 import type { StageData } from "@/lib/validation/schemas";
@@ -517,15 +516,6 @@ function dispatchEvent(event: MercureEvent): void {
         event.data.aiOverview,
       );
       store.setAiOverview(parsedOverview.success ? parsedOverview.data : null);
-      // If AI looked reachable at mount but no overview arrived, the tier may
-      // have gone down mid-Phase 2. Re-probe so the UI can explicitly flag the
-      // outage instead of silently showing no analysis (#304).
-      const ui = useUiStore.getState();
-      if (ui.aiCapability.available && !parsedOverview.success) {
-        void fetchAiAvailability().then((available) =>
-          ui.setAiAvailable(available),
-        );
-      }
       useUiStore.getState().setAnalysisProgress(null);
       useUiStore.getState().setAnalysisStarted(true);
       useUiStore.getState().setAnalysisPhaseActive(false);

--- a/pwa/src/lib/ai-availability.ts
+++ b/pwa/src/lib/ai-availability.ts
@@ -1,42 +1,17 @@
 /**
- * Minimal shape of the `/api/health` readiness payload this module relies on.
- * The endpoint is a plain controller (not an API Platform resource), so it is
- * absent from the generated OpenAPI schema — hence this local type rather than
- * `components["schemas"][...]`.
- */
-interface HealthResponse {
-  deps?: {
-    ollama_chat?: { status?: string };
-  };
-}
-
-/**
- * Runtime AI-tier availability probe (#304).
+ * AI-tier availability signal (#304, ADR-042).
  *
- * Answers "is the LLM tier reachable right now?" by reading `/api/health` →
- * `deps.ollama_chat.status`. When the backend
- * runs with `OLLAMA_ENABLED=0` it omits the key entirely, which resolves to
- * unavailable (covers a front-enabled / API-disabled misconfiguration).
+ * Historically this probed `/api/health` → `deps.ollama_chat.status` to answer
+ * "is the self-hosted LLM tier reachable right now?". Since ADR-042 the AI is no
+ * longer a server dependency: it is an optional, per-user cloud provider reached
+ * with the user's own token (bring-your-own-token), so the backend no longer
+ * exposes an `ollama_chat` dep and there is no server-side tier left to probe.
  *
- * Failure-open: a network/parse error — or a 429 from the per-IP readiness rate
- * limiter — resolves to `true`, so a transient health hiccup never hides a
- * working feature. A genuine outage still surfaces reactively via the 503 the
- * chat endpoint returns.
+ * Availability is therefore static `true` here; the real "configured" gate comes
+ * from the account AI-settings (`GET /users/me/ai-settings`, see `useAiSettings`).
+ * A genuine outage of the user's provider still surfaces reactively via the 503
+ * the chat endpoint returns, classified by `AiErrorClassifier`.
  */
 export async function fetchAiAvailability(): Promise<boolean> {
-  try {
-    const res = await fetch(
-      `${process.env.NEXT_PUBLIC_API_URL ?? ""}/api/health`,
-      { headers: { Accept: "application/json" } },
-    );
-
-    // The readiness probe is rate-limited per IP; a 429 is not a real outage.
-    if (res.status === 429) return true;
-
-    const body = (await res.json()) as HealthResponse;
-
-    return body.deps?.ollama_chat?.status === "ok";
-  } catch {
-    return true;
-  }
+  return true;
 }

--- a/pwa/src/store/ui-store.ts
+++ b/pwa/src/store/ui-store.ts
@@ -175,11 +175,10 @@ interface UiState {
   hasSeenBubble: boolean;
   /**
    * AI tier availability driving the explicit gating (#304, ADR-042).
-   * - `available`: runtime reachability of the LLM tier, read from `/api/health`
-   *   (`deps.ollama_chat`). Starts optimistic (`true`) to avoid a disabled→enabled
-   *   flash; flipped to `false` only once an outage is confirmed. For the
+   * - `available`: runtime reachability of the LLM tier. For the
    *   bring-your-own-token cloud providers (ADR-042) there is no self-hosted tier
-   *   to probe, so this stays `true`.
+   *   to probe, so this stays `true` (see `fetchAiAvailability`); a provider
+   *   outage surfaces reactively via the 503 the chat endpoint returns.
    * - `configured`: whether the account has an AI provider + token set
    *   (`GET /users/me/ai-settings`). When false, AI surfaces are shown
    *   disabled-but-visible with a "Configurez une IA" CTA. Starts `false`

--- a/pwa/tests/fixtures/api-mocks.ts
+++ b/pwa/tests/fixtures/api-mocks.ts
@@ -12,12 +12,6 @@ export interface MockApiOptions {
    */
   assertNoRuntimeErrors?: boolean;
   /**
-   * Runtime AI-tier availability surfaced by the mocked `/api/health`
-   * (`deps.ollama_chat.status`). Defaults to reachable so existing AI specs
-   * (bubble, chat) keep passing; set `false` to exercise the degraded mode (#304).
-   */
-  aiAvailable?: boolean;
-  /**
    * Whether the account has a configured AI provider, surfaced by the mocked
    * `GET /users/me/ai-settings` (ADR-042). Defaults to `true` so existing AI
    * specs (bubble, chat, generation card) keep exercising the active path; set
@@ -58,7 +52,6 @@ export async function mockAllApis(
     postTripBody,
     deleteStageFail = false,
     addStageFail = false,
-    aiAvailable = true,
     aiConfigured = true,
   } = options;
 
@@ -72,12 +65,13 @@ export async function mockAllApis(
     });
   });
 
-  // GET /api/health — readiness probe the PWA reads to gate AI features (#304).
-  // `aiAvailable` toggles deps.ollama_chat between "ok"/"down"; the aggregate
-  // status stays "ok" either way (Ollama is excluded from the required set).
+  // GET /api/health - readiness probe (postgres/redis/mercure/valhalla +
+  // non-required reference_data). The AI tier is no longer a server dependency
+  // (ADR-042): it is a per-user cloud provider reached with the user's own
+  // token, so it is absent from this payload. AI availability is now driven by
+  // the account AI-settings, not by this probe.
   await page.route("**/api/health", (route, request) => {
     if (request.method() !== "GET") return route.fallback();
-    const ollamaStatus = aiAvailable ? "ok" : "down";
     return route.fulfill({
       status: 200,
       contentType: "application/json",
@@ -88,8 +82,7 @@ export async function mockAllApis(
           redis: { status: "ok" },
           mercure: { status: "ok" },
           valhalla: { status: "ok" },
-          ollama_chat: { status: ollamaStatus },
-          ollama_analysis: { status: ollamaStatus },
+          reference_data: { status: "ok" },
         },
       }),
     });

--- a/pwa/tests/mocked/ai-capabilities.spec.ts
+++ b/pwa/tests/mocked/ai-capabilities.spec.ts
@@ -5,11 +5,13 @@ import { mockAllApis } from "../fixtures/api-mocks";
  * Issue #304 / ADR-042 — explicit gating of the AI features.
  *
  * AI is per-user (no build-time env gate): the controls are always present and
- * driven solely by runtime signals. Availability comes from `/api/health`, and
- * `configured` from the account `GET /users/me/ai-settings`. To pin the states
- * deterministically — and prod-safely, since the E2E build hides
- * `window.__zustand_ui_store` — the tests drive the capability via the
- * `__test_set_ai_capability` CustomEvent:
+ * driven solely by runtime signals. Since ADR-042 the AI is a bring-your-own-
+ * token cloud provider, so there is no self-hosted tier to probe: `available`
+ * stays `true` and the real gate is `configured`, read from the account
+ * `GET /users/me/ai-settings`. A provider outage surfaces reactively via the
+ * 503 the chat endpoint returns. To pin the states deterministically - and
+ * prod-safely, since the E2E build hides `window.__zustand_ui_store` - the tests
+ * drive the capability via the `__test_set_ai_capability` CustomEvent:
  *  - reachable + configured   → AI features active
  *  - unreachable              → features disabled with an explicit notice
  *  - not configured           → disabled-but-visible with a configure CTA
@@ -106,12 +108,17 @@ test.describe("AI generation card gating (#304)", () => {
   test("tier unreachable: the generation card is disabled with a notice", async ({
     page,
   }) => {
-    await mockAllApis(page, { aiAvailable: false });
+    await mockAllApis(page);
     await page.goto("/");
     await page.waitForLoadState("networkidle");
 
     const card = page.getByTestId("card-ai");
     await expect(card).toBeVisible();
+    // No self-hosted tier to probe post-ADR-042: a provider outage is driven via
+    // the test hook (mirrors the reactive 503-classified state), not the health
+    // mock.
+    await setAiCapability(page, { available: false });
+
     await expect(card).toHaveAttribute("data-disabled", "true");
     await expect(page.getByTestId("ai-unavailable-notice")).toBeVisible();
 


### PR DESCRIPTION
## Contexte (recette #649, Lot 5)

Avec une cle IA cloud valide configuree (ex. Gemini, BYO-token), l'utilisateur tombait quand meme sur le bloc **"IA indisponible"**. L'IA doit etre consideree disponible des qu'une cle cloud BYO-token est configuree.

## Cause

`pwa/src/lib/ai-availability.ts` (`fetchAiAvailability()`) sondait `/api/health` et retournait `body.deps?.ollama_chat?.status === "ok"`. Or, depuis l'**ADR-042**, l'IA n'est plus une dependance serveur : c'est un fournisseur cloud par-utilisateur joint avec le token de l'utilisateur. Le `HealthController` n'emet donc plus la cle `ollama_chat` (le payload ne contient que `postgres` / `redis` / `mercure` / `valhalla` / `reference_data`).

Resultat : l'expression valait **toujours** `false` -> `aiCapability.available = false` -> bloc d'indisponibilite affiche a tort, meme avec une cle valide.

Le store (`pwa/src/store/ui-store.ts`) documentait deja que pour le cloud BYO-token, `available` doit rester `true`, la disponibilite reelle etant geree reactivement par le 503 de l'endpoint chat (`AiErrorClassifier`).

## Correctif

- **`fetchAiAvailability()`** : plus aucun tier auto-heberge a sonder -> renvoie `true`. La signature et les deux appelants (`trip-planner.tsx` au montage, `use-mercure.ts` apres `trip_ready`) restent inchanges (no-op qui reaffirme `available=true`). Le gate reel reste `configured` (compte AI-settings).
- **`ui-store.ts`** : commentaire mis a jour (plus de reference a `deps.ollama_chat`).
- **`tests/fixtures/api-mocks.ts`** : le mock `/api/health` colle de nouveau au contrat reel du backend (suppression de `ollama_chat` / `ollama_analysis`, ajout de `reference_data`, suppression de l'option `aiAvailable` devenue morte).
- **`tests/mocked/ai-capabilities.spec.ts`** : le cas "tier unreachable" de la landing page est desormais pilote via le hook prod-safe `__test_set_ai_capability` (le mock health ne pilote plus la disponibilite). Le hook `__test_set_ai_capability` n'est pas touche.

## Verification

- `tsc --noEmit` : **0 erreur** sur tous les fichiers lies a l'AI-availability (les seules erreurs tsc sont des deps optionnelles absentes en local : `@sentry/nextjs`, `@axe-core/playwright`, pre-existantes et hors scope).
- `eslint` : **propre** (exit 0) sur les 4 fichiers modifies.
- Prettier et la spec Playwright n'ont **pas** pu etre executes localement (volume `node_modules` vide dans le worktree + serveur dev requis pour l'E2E) : **la CI les verifiera**.

<!-- claude-review-start -->
## Claude Review

**0 warnings** · 0 criticals · commit `57950c9b`

All concerns from the previous review have been resolved: the stale comment in `trip-planner.tsx` is rewritten to accurately describe the ADR-042 model, and the entire re-probe block in `use-mercure.ts` (including the stale comment that promised outage detection that no longer happens) has been removed. The fix is clean and correct.

Resolved 0 previously open review threads (none existed).

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Inline comments

No inline comments.
<!-- claude-review-end -->