### PR TITLE
fix(alerts): skip rest-day nudge on the last stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Rules are executed in priority order (lower = higher priority):
 | **Resupply** | -- | ![warning](https://img.shields.io/badge/-warning-ed6c02) | All resupply POIs on the stage are closed at estimated passage time |
 | **Accommodation** | -- | ![warning](https://img.shields.io/badge/-warning-ed6c02) | All detected accommodations on the stage are likely closed due to seasonality |
 | **Water points** | -- | ![nudge](https://img.shields.io/badge/-nudge-0288d1) | Stretch > 30 km without a detected drinking water source |
-| **Rest day** | 100 | ![nudge](https://img.shields.io/badge/-nudge-0288d1) | Every N consecutive cycling days without a rest day (default: every 3 days) |
+| **Rest day** | 100 | ![nudge](https://img.shields.io/badge/-nudge-0288d1) | Every N consecutive cycling days without a rest day (default: every 3 days), except on the trip's last day |
 | **Cultural POI** | -- | ![nudge](https://img.shields.io/badge/-nudge-0288d1) | Museum, monument, castle, church, viewpoint, or attraction within 500 m of route — enriched with opening hours, price and description when sourced from DataTourisme |
 | **Railway station** | -- | ![nudge](https://img.shields.io/badge/-nudge-0288d1) | No train station within 10 km of a stage endpoint (emergency evacuation) |
 | **Health services** | -- | ![nudge](https://img.shields.io/badge/-nudge-0288d1) | No pharmacy, hospital, or clinic within 15 km of a stage |

--- a/api/src/Analyzer/Rules/RestDayNudgeAnalyzer.php
+++ b/api/src/Analyzer/Rules/RestDayNudgeAnalyzer.php
@@ -58,6 +58,11 @@ final readonly class RestDayNudgeAnalyzer implements StageAnalyzerInterface
             return [];
         }
 
+        // No point suggesting a rest day on the very last stage of the trip
+        if ($stageIndex === \count($allStages) - 1) {
+            return [];
+        }
+
         // Count consecutive non-rest-day stages ending at this stage
         $consecutiveCount = 0;
         for ($i = $stageIndex; $i >= 0; --$i) {

--- a/api/tests/Unit/Analyzer/RestDayNudgeAnalyzerTest.php
+++ b/api/tests/Unit/Analyzer/RestDayNudgeAnalyzerTest.php
@@ -59,6 +59,7 @@ final class RestDayNudgeAnalyzerTest extends TestCase
             $this->createStage(1, false),
             $this->createStage(2, false),
             $this->createStage(3, false),
+            $this->createStage(4, false),
         ];
 
         $alerts = $analyzer->analyze($stages[2], ['allStages' => $stages]);
@@ -68,6 +69,22 @@ final class RestDayNudgeAnalyzerTest extends TestCase
         $this->assertNotNull($alerts[0]->action);
         $this->assertSame(AlertActionKind::AUTO_FIX, $alerts[0]->action->kind);
         $this->assertSame(3, $alerts[0]->action->payload['afterStage']);
+    }
+
+    #[Test]
+    public function noNudgeOnLastStage(): void
+    {
+        $analyzer = new RestDayNudgeAnalyzer($this->translator, 3);
+        $stages = [
+            $this->createStage(1, false),
+            $this->createStage(2, false),
+            $this->createStage(3, false),
+        ];
+
+        // Day 3 reaches the threshold but is the last stage of the trip
+        $alerts = $analyzer->analyze($stages[2], ['allStages' => $stages]);
+
+        $this->assertSame([], $alerts);
     }
 
     #[Test]
@@ -96,6 +113,7 @@ final class RestDayNudgeAnalyzerTest extends TestCase
             $this->createStage(4, false),
             $this->createStage(5, false),
             $this->createStage(6, false),
+            $this->createStage(7, false),
         ];
 
         // Day 4, 5, 6 are the first 3 consecutive after the rest: nudge on 6
@@ -132,7 +150,7 @@ final class RestDayNudgeAnalyzerTest extends TestCase
         $analyzer = new RestDayNudgeAnalyzer($this->translator, 3);
         $stages = array_map(
             fn (int $n): Stage => $this->createStage($n, false),
-            range(1, 6),
+            range(1, 7),
         );
 
         $alertsDay3 = $analyzer->analyze($stages[2], ['allStages' => $stages]);
@@ -164,6 +182,7 @@ final class RestDayNudgeAnalyzerTest extends TestCase
             $this->createStage(1, false),
             $this->createStage(2, false),
             $this->createStage(3, false),
+            $this->createStage(4, false),
         ];
 
         $alerts = $analyzer->analyze($stages[2], ['allStages' => $stages, 'locale' => 'fr']);


### PR DESCRIPTION
## Contexte

Lot 4 de la recette #649.

**Symptome** : l'alerte de proposition de jour de repos (`RestDayNudgeAnalyzer`, nudge "ajouter un jour de repos apres N jours consecutifs") s'affichait sur le **dernier jour** du voyage. Proposer un jour de repos apres la derniere etape n'a aucun sens : il n'y a plus aucune etape ensuite.

## Cause

`RestDayNudgeAnalyzer::analyze()` comptait les jours consecutifs de velo et emettait le nudge des que le seuil etait atteint, sans jamais consulter la position de l'etape par rapport a la fin du voyage. La derniere etape pouvait donc declencher l'alerte.

## Correction

Ajout d'une garde "pas la derniere etape" juste apres la resolution de `$stageIndex`, avant tout calcul d'emission : si `$stageIndex === \count($allStages) - 1`, l'analyzer retourne `[]`. La garde reutilise les variables deja presentes localement (`$allStages`, `$stageIndex`), aucun nouveau calcul.

## Tests

- Nouveau cas `noNudgeOnLastStage` : prouve qu'aucun nudge n'est emis quand l'etape atteignant le seuil est la derniere du voyage.
- Cas existants ajustes (`nudgeOnNthConsecutiveDay`, `noNudgeAfterRestDay`, `nudgeEmittedEveryNthDay`, `usesLocaleFromContext`) : une etape supplementaire est ajoutee apres celle qui declenche le nudge, afin que ces cas continuent de prouver l'emission sur une etape **intermediaire** atteignant le seuil (et non sur la derniere).

```
PHPUnit 13.2.1 by Sebastian Bergmann and contributors.
..........                                                        10 / 10 (100%)
OK (10 tests, 22 assertions)
```

`AlertDocumentationTest` reste vert (1 test, 46 assertions) : la signature de la regle est inchangee, `ALERT_RULE_MAP` n'a pas ete touche.

## Documentation

Wording de la table alert-engine du `README.md` (entree "Rest day") precise desormais "except on the trip's last day".

<!-- claude-review-start -->
## Claude Review

**Findings:** 0 (no critical, warning, or informational issues)

**Commit reviewed:** `1914ca5f9d88a63b986d4df2e2f59992693d61ad`

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.
<!-- claude-review-end -->