### PR TITLE
build(provisioner): add make provision-recette target for the iso-prod recette stack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := help
-.PHONY: help start stop install qa test php-shell pwa-shell ensure-default-pbf provision provision-update coverage coverage-ci migration migrate db-create fixtures
+.PHONY: help start stop install qa test php-shell pwa-shell ensure-default-pbf provision provision-update provision-recette coverage coverage-ci migration migrate db-create fixtures
 
 # Dev loads the iso-prod base + dev overrides automatically. Prod targets pass an
 # explicit `-f compose.yaml`, which takes precedence over COMPOSE_FILE, so the dev
@@ -195,6 +195,13 @@ provision: ensure-default-pbf ## Provision OSM regions + import the Tier-1 PostG
 
 provision-update: ## Trigger a non-interactive provisioner update (re-download OSM + re-import PostGIS)
 	@docker compose --profile provisioning run --rm provisioner --no-interaction --with-postgis
+
+# `--build` is required: it builds the `prod` provisioner stage (which COPYs the code) instead
+# of reusing a `dev`-tagged image whose /app is empty (code is bind-mounted in dev), which would
+# fail with "Could not open input file: bin/provision". `-f compose.yaml -f compose.recette.yaml`
+# is passed explicitly so the dev COMPOSE_FILE layer never leaks in.
+provision-recette: ensure-default-pbf ## Provision the iso-prod recette PostGIS index (non-interactive; first run needs a seeded .docker/osm/data/regions.json, e.g. {"slugs":["nord-pas-de-calais"]}, or a prior `make provision`)
+	@JWT_PRIVATE_KEY_PATH=$(CURDIR)/.docker/jwt-recette/private.pem JWT_PUBLIC_KEY_PATH=$(CURDIR)/.docker/jwt-recette/public.pem JWT_PASSPHRASE=recette docker compose -f compose.yaml -f compose.recette.yaml --profile provisioning run --build --rm -T provisioner --no-interaction --with-postgis
 
 ## --- 🗄️ Database ---
 migration: ## Generate a Doctrine migration

--- a/README.md
+++ b/README.md
@@ -237,6 +237,16 @@ make provision-update            # re-download the configured regions (non-inter
 docker compose restart valhalla  # rebuild routing tiles from the new PBF
 ```
 
+**Iso-prod recette stack:**
+
+`make provision` / `make provision-update` inherit the dev `COMPOSE_FILE` and target the dev provisioner overlay. To provision against the iso-prod recette stack started with `make start-recette`, use the dedicated target instead:
+
+```bash
+make provision-recette           # provision the recette PostGIS index (non-interactive)
+```
+
+It targets `-f compose.yaml -f compose.recette.yaml` with the recette JWT vars and forces `--build` so the `prod` provisioner stage (which COPYs the code) is rebuilt rather than reusing a `dev`-tagged image whose `/app` is empty. The first run needs a seeded region selection in `.docker/osm/data/regions.json` (e.g. `{"slugs":["nord-pas-de-calais"]}`) or a prior interactive `make provision`.
+
 See [ADR-036](docs/adr/adr-036-manual-osm-data-refresh.md) for why the automated nightly job (`osm-cron`) was dropped.
 
 ### DataTourisme


### PR DESCRIPTION
## Contexte

Pendant la recette #649 (stack iso-prod via `make start-recette`), il n'existait aucune cible pour provisionner l'index PostGIS (Tier-1 OSM) contre cette stack.

`make provision` / `make provision-update` heritent du `COMPOSE_FILE` dev (`compose.yaml:compose.dev.yaml`) et ciblent donc l'overlay dev : le provisioner est construit en `target: dev` avec le code monte en bind-mount. Lance contre la stack recette, sans `--build`, Docker reutilise l'image `provisioner` taguee en `dev` dont `/app` est vide (le code n'y est present qu'en bind-mount dev) :

```
Could not open input file: bin/provision
```

## Cause racine

Reutilisation d'une image `dev` vide faute de `--build`. Le stage `prod` du `.docker/provisioner/Dockerfile` COPIe le code dans l'image ; il faut donc forcer sa (re)construction.

## Cible ajoutee

Nouvelle cible `provision-recette`, modelee sur `provision-update` mais :

- passe les memes variables JWT que `start-recette` (`JWT_PRIVATE_KEY_PATH` / `JWT_PUBLIC_KEY_PATH` / `JWT_PASSPHRASE=recette` avec `$(CURDIR)`) ;
- cible explicitement `-f compose.yaml -f compose.recette.yaml` (ne herite **pas** du `COMPOSE_FILE` dev) ;
- force `--build` pour construire le stage `prod` (qui COPIe le code) au lieu de reutiliser une image `dev` vide ;
- reste non-interactif : `--profile provisioning run --build --rm -T provisioner --no-interaction --with-postgis`.

```makefile
provision-recette: ensure-default-pbf ## Provision the iso-prod recette PostGIS index (non-interactive; ...)
	@JWT_PRIVATE_KEY_PATH=$(CURDIR)/.docker/jwt-recette/private.pem JWT_PUBLIC_KEY_PATH=$(CURDIR)/.docker/jwt-recette/public.pem JWT_PASSPHRASE=recette docker compose -f compose.yaml -f compose.recette.yaml --profile provisioning run --build --rm -T provisioner --no-interaction --with-postgis
```

Ajout a `.PHONY` + note README (section provisioning / recette).

> Le premier run requiert une selection de regions seedee dans `.docker/osm/data/regions.json` (ex. `{"slugs":["nord-pas-de-calais"]}`) ou un `make provision` interactif prealable.

## Verification

`make -n provision-recette` (commande resolue, provisioning reel non lance car lourd) :

```
test -f .docker/osm/data/default.osm.pbf || cp .docker/osm/lille-stub.osm.pbf .docker/osm/data/default.osm.pbf
JWT_PRIVATE_KEY_PATH=.../.docker/jwt-recette/private.pem JWT_PUBLIC_KEY_PATH=.../.docker/jwt-recette/public.pem JWT_PASSPHRASE=recette docker compose -f compose.yaml -f compose.recette.yaml --profile provisioning run --build --rm -T provisioner --no-interaction --with-postgis
```

`make help` liste bien la nouvelle cible ; aucune autre cible n'est cassee (Makefile parse OK).

<!-- claude-review-start -->
## Claude Review

**0 findings** (0 critical, 0 warnings, 0 suggestions) · Commit `45222d6`

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases (N/A — tooling only, no application code)
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### No inline comments.
<!-- claude-review-end -->