### PR TITLE
docs(adr): add ADR-043 synchronous structural computation, supersede ADR-027 gate

### DIFF
--- a/TRACKING.md
+++ b/TRACKING.md
@@ -1036,6 +1036,43 @@ Findings de la 2ᵉ passe de recette manuelle ([#649 commentaire bloquant du 20/
 
 ---
 
+## Sprint 41 — Recette #649 (round 3) : correctifs + refonte du flux en modèle synchrone (ADR-043)
+
+Findings de la 3ᵉ passe de recette manuelle ([#649 commentaire du 21/06](https://github.com/vincentchalamon/bike-trip-planner/issues/649#issuecomment-4762100806)). Deux volets : (a) correctifs ciblés livrés en PRs directes ; (b) **refonte du flux de création** — la migration PostGIS (ADR-040) rend le calcul structurel quasi-instantané, donc on supprime les étapes Aperçu/Analyse et le gate two-phase (ADR-027) au profit d'un **calcul structurel synchrone + enrichissements réseau/IA asynchrones par bloc** ([ADR-043](docs/adr/adr-043-synchronous-structural-computation-async-enrichments.md)).
+
+### Correctifs livrés (PRs directes)
+
+| PR | Titre | Statut |
+|----|-------|--------|
+| [#737](https://github.com/vincentchalamon/bike-trip-planner/pull/737) | fix(alerts): pas de nudge jour de repos sur la dernière étape | mergé |
+| [#736](https://github.com/vincentchalamon/bike-trip-planner/pull/736) | fix(ai): IA disponible avec un token cloud BYO (ADR-042) | mergé |
+| [#738](https://github.com/vincentchalamon/bike-trip-planner/pull/738) | feat(ai): état « clé configurée » sans révéler la clé | mergé |
+| [#739](https://github.com/vincentchalamon/bike-trip-planner/pull/739) | chore(i18n): tutoiement dans toute l'UI française | en cours |
+| [#740](https://github.com/vincentchalamon/bike-trip-planner/pull/740) | fix(trip): publier l'event terminal même si une computation échoue | en cours |
+| [#741](https://github.com/vincentchalamon/bike-trip-planner/pull/741) | build(provisioner): cible `make provision-recette` (iso-prod) | en cours |
+
+### Refonte flux synchrone — ADR-043 (5 PRs, ordre imposé)
+
+| Ordre | Titre | Effort | Dépend de |
+|-------|-------|--------|-----------|
+| PR1 | perf(osm): borner `WaysRepository::findInCorridor` (LIMIT + filtre `highway`, éviter le cast `::geography`) | S | — |
+| PR2 | refactor(trip): calcul structurel synchrone (pacing + scans PostGIS + alertes), suppression du gate two-phase + de `POST /trips/{id}/analyze`, statut trip `draft`→`ready` + états par bloc dans `/detail` | L | PR1, #740 |
+| PR3 | feat(trip): enrichissements météo + IA asynchrones par bloc (spinner par bloc ; IA auto si token + régénérer, chat à la demande ; édition `skipAiAnalysis` par défaut) | M | PR2 |
+| PR4 | feat(pwa): effondrer le wizard (Saisie → loader → Voyage), spinners par bloc, édition recalculée en place | L | PR2, PR3 |
+| PR5 | test: aligner specs mockées + BDD recette + baselines visuelles (VR) sur le flux synchrone | M | PR4 |
+
+> **Dépendance dure :** PR1 (`WaysRepository` borné) doit land **avant** PR2, sinon le calcul structurel synchrone peut dépasser le budget (~1s) sur un long itinéraire dense. PR2/PR3 supposent [#740](https://github.com/vincentchalamon/bike-trip-planner/pull/740) mergé (le `TripCompletionGate` coordonne les blocs météo/IA asynchrones restants).
+
+### Recette Sprint 41
+
+- **Checklist manuelle :**
+  - [ ] Provisioning PostGIS (Nord-Pas-de-Calais) : hébergements/POI détectés sur le tour de test, plus de faux positif « lunch ».
+  - [ ] Création (GPX & lien) : un seul loader → page voyage complète (étapes, distances, hébergements, alertes), sans étapes Aperçu/Analyse.
+  - [ ] Météo + rapport IA : se remplissent en place avec spinner par bloc ; chat à la demande.
+  - [ ] Édition distance/profil : recalcul en place quasi-instantané, sans re-analyse bloquante.
+
+---
+
 ## Hors Sprints
 
 | ID  | Titre                            | Note                     |
@@ -1098,4 +1135,5 @@ Findings de la 2ᵉ passe de recette manuelle ([#649 commentaire bloquant du 20/
 | 38        | Performance & Resilience Deep Dive       | 18      | ~12          |
 | 39        | Backup & Disaster Recovery               | 9       | ~9           |
 | 40        | Recette #649 round 2 (boot iso-prod + UI) | 4       | ~4           |
-| **Total** |                                          | **235** | **~239**     |
+| 41        | Recette #649 round 3 (correctifs + flux synchrone ADR-043) | —       | ~12          |
+| **Total** |                                          | **235** | **~251**     |

--- a/docs/adr/adr-027-gate-mechanism-two-phase-pipeline.md
+++ b/docs/adr/adr-027-gate-mechanism-two-phase-pipeline.md
@@ -1,6 +1,6 @@
 # ADR-027: Gate Mechanism and Two-Phase Pipeline (Preview → Analysis)
 
-- **Status:** Accepted
+- **Status:** Superseded by [ADR-043](adr-043-synchronous-structural-computation-async-enrichments.md) (the Preview→Analysis user gate and the wizard's Aperçu/Analyse steps are removed now that PostGIS makes structural computation near-instant; the ComputationTracker completion-gate machinery is retained for the async enrichments)
 - **Date:** 2026-04-19
 - **Depends on:** ADR-001 (Global Architecture), ADR-005 (External API caching), ADR-022 (Persistent Storage)
 - **Supersedes:** ADR-001 (single-phase synchronous computation model described in the Backend Implementation section)

--- a/docs/adr/adr-043-synchronous-structural-computation-async-enrichments.md
+++ b/docs/adr/adr-043-synchronous-structural-computation-async-enrichments.md
@@ -1,0 +1,99 @@
+# ADR-043: Synchronous Structural Computation with Per-Block Asynchronous Enrichments
+
+- **Status:** Proposed — flips to Accepted once the implementing PRs land.
+- **Date:** 2026-06-21
+- **Depends on:** ADR-006 (Pacing Engine), ADR-040 (Local-First Reference Data in PostGIS), ADR-042 (Optional Per-User AI, BYO token)
+- **Supersedes:** ADR-027 (Gate Mechanism and Two-Phase Pipeline) — specifically the user-facing Preview→Analysis gate and the wizard's *Aperçu*/*Analyse* steps. The `ComputationTracker` completion-gate machinery introduced by ADR-027 is **retained** for the asynchronous enrichments.
+
+## Context and Problem Statement
+
+ADR-027 split trip computation into a Preview phase and a user-gated Analysis phase. Its premise was that analysis was dominated by slow runtime calls — Overpass OSM scans plus weather — taking 10–30s, so a "Launch full analysis" gate gave early feedback and avoided wasting expensive calls on a wrong route.
+
+Two later decisions invalidated that premise:
+
+1. **ADR-040** moved all OSM/tourism reference data into a local PostGIS index (Tier-1). POI / accommodation / alert detection is now indexed spatial SQL (`ST_DWithin`/`ST_Covers`), sub-millisecond, with no runtime network. The pacing engine (ADR-006) was always pure in-memory CPU.
+2. **ADR-042** turned AI into an optional per-user BYO-token feature (no self-hosted Ollama). The LLM is now the dominant — and only user-cost-bearing — slow step.
+
+Code-level reality confirms it: `GenerateStagesHandler` / `PacingEngineRegistry` are pure in-memory (no Valhalla, no DB); 13 of 15 enrichment handlers read PostGIS locally; only **weather** (Open-Meteo, network, cached 3h) and the **LLM** passes remain slow; the external **route fetch** for a link (Komoot/Strava/RideWithGPS) is a network call (10s timeout, 2 retries). One structural scan is an outlier: `WaysRepository::findInCorridor` is currently unbounded (no `LIMIT`, no `highway` filter, `::geography` cast) and can exceed 1s on a long, dense route.
+
+Therefore the two-phase user gate no longer protects against a long *structural* computation — it would only gate the LLM (the user's token/cost). The *Aperçu* step, which existed only to precede *Analyse*, loses its purpose. The recette (#649) also reported the wizard's Aperçu/Analyse steps as confusing and frequently skipped.
+
+## Decision Drivers
+
+- **UX first** — minimize visible waiting and remove artificial steps.
+- **Reload-safe / shareable** — the trip URL must re-render the correct state on reload.
+- **Respect the BYO AI token** — never burn the user's token automatically and silently.
+- **Simpler backend** where the asynchronous machinery is no longer warranted.
+
+## Considered Options
+
+### Option A — Keep the ADR-027 two-phase user gate
+
+Rejected. The gate's premise (slow structural analysis) no longer holds post-PostGIS; the Aperçu/Analyse steps are now friction the recette flagged.
+
+### Option B — Fully synchronous, including network (fetch + weather + LLM in the HTTP request)
+
+Rejected. The external link fetch (up to ~30s with retries) and weather/LLM are third-party network calls; blocking the HTTP request on them is fragile (timeouts) and ties up a web worker for the whole duration.
+
+### Option C — Synchronous structural computation, per-block asynchronous enrichments (Chosen)
+
+Structural data (pacing + PostGIS scans + alerts) is computed without a user gate; the network/LLM enrichments are asynchronous, each surfaced as its own block with a spinner.
+
+## Decision
+
+**Option C.**
+
+### Structural computation (no user gate)
+
+Structural = pacing (stage splitting) + all PostGIS scans (accommodations, POIs, water, bike shops, health services, stations, borders, ferries, fords, cultural POIs, events) + the alert engine.
+
+- **GPX upload:** runs synchronously in the State Processor (parsing is local), so the HTTP response already carries the structured trip.
+- **External link:** the fetch stays asynchronous (it is a network call) behind a single loader; the worker chains fetch → stages → scans → alerts and publishes one terminal *trip ready (structural)* Mercure event. Same UX: one loader, then the complete trip — no intermediate step.
+
+### Asynchronous enrichments (per block, with spinner)
+
+- **Weather** (Open-Meteo) and its dependents (wind, fords-from-weather).
+- **AI**: trip overview / per-stage insights / chat. Triggered automatically when a token is configured (configuring the key is the consent), with a manual "regenerate" affordance; chat is on demand. AI never blocks the structural trip.
+
+### Editing at the trip page
+
+Per-day distance and profile/pacing edits re-pace and re-scan the affected stages **synchronously / in place** (no Valhalla re-routing, no network). AI is **not** re-run in a blocking way — it is skipped by default (reusing the existing `skipAiAnalysis` flag) and refreshed on demand / in the background.
+
+### State model
+
+The persisted trip status reflects structural readiness (e.g. `draft` → `ready`) plus per-block enrichment states (weather: pending/ready, ai: pending/ready/idle), exposed by `GET /trips/{id}/detail` so the page is reload-safe and authoritative on mount. Mercure SSE only drives live updates; a missed event is recovered from the persisted state on reload.
+
+### Performance prerequisite
+
+`WaysRepository::findInCorridor` must be bounded (add a `LIMIT` and a `highway` pre-filter, and avoid the `::geography` cast that defeats the GIST index) so the synchronous structural budget stays well under ~1s even on long, dense routes. If a route still exceeds budget, terrain may fall back to an asynchronous block with a spinner.
+
+### Reused machinery
+
+The `ComputationTracker` completion gate and `TripCompletionGate` (ADR-027, hardened in PR #740) are retained to coordinate the asynchronous weather/AI blocks and publish their terminal events.
+
+## Consequences
+
+### Positive
+
+- Two visible states (Saisie → Voyage) instead of four wizard steps; the structural trip is visible almost immediately.
+- Reload-safe and shareable URLs; the BYO AI token is spent deliberately.
+- The asynchronous fan-out shrinks to weather + AI; in-place edits with no re-analysis wait.
+
+### Negative
+
+- Backend refactor: move structural computation out of the async fan-out; collapse the wizard; introduce per-block statuses.
+- The `WaysRepository` bound must land first (PR1).
+- Visual baselines (VR) and recette/mocked specs that assume the wizard must be updated.
+- `POST /trips/{id}/analyze` is removed/repurposed (OpenAPI + TypeScript client regenerated via `make typegen`).
+
+### Neutral
+
+- The route fetch for links remains asynchronous (it is a network call); weather/LLM latency is unchanged, only relocated to non-blocking blocks.
+- ADR-027's tracker/Mercure machinery is reused, not rebuilt.
+
+## Sources
+
+- [ADR-006: Pacing Engine and Dynamic Stage Generation Algorithm](adr-006-pacing-engine-and-dynamic-stage-generation-algorithm.md)
+- [ADR-027: Gate Mechanism and Two-Phase Pipeline](adr-027-gate-mechanism-two-phase-pipeline.md)
+- [ADR-040: Local-First Reference Data in PostGIS](adr-040-local-first-reference-data-postgis.md)
+- [ADR-042: Optional Multi-Provider AI (BYO Token)](adr-042-optional-multi-provider-ai-byo-token.md)

--- a/docs/adr/adr-043-synchronous-structural-computation-async-enrichments.md
+++ b/docs/adr/adr-043-synchronous-structural-computation-async-enrichments.md
@@ -1,6 +1,6 @@
 # ADR-043: Synchronous Structural Computation with Per-Block Asynchronous Enrichments
 
-- **Status:** Proposed — flips to Accepted once the implementing PRs land.
+- **Status:** Accepted — the decision is taken; implementation is tracked as the 5-PR plan in TRACKING.md (Sprint 41), with PR1 (the `WaysRepository` bound) landing before PR2.
 - **Date:** 2026-06-21
 - **Depends on:** ADR-006 (Pacing Engine), ADR-040 (Local-First Reference Data in PostGIS), ADR-042 (Optional Per-User AI, BYO token)
 - **Supersedes:** ADR-027 (Gate Mechanism and Two-Phase Pipeline) — specifically the user-facing Preview→Analysis gate and the wizard's *Aperçu*/*Analyse* steps. The `ComputationTracker` completion-gate machinery introduced by ADR-027 is **retained** for the asynchronous enrichments.
@@ -82,7 +82,7 @@ The `ComputationTracker` completion gate and `TripCompletionGate` (ADR-027, hard
 ### Negative
 
 - Backend refactor: move structural computation out of the async fan-out; collapse the wizard; introduce per-block statuses.
-- The `WaysRepository` bound must land first (PR1).
+- The `WaysRepository` bound must land first (PR1); the PR1→PR5 sequencing is tracked in TRACKING.md (Sprint 41).
 - Visual baselines (VR) and recette/mocked specs that assume the wizard must be updated.
 - `POST /trips/{id}/analyze` is removed/repurposed (OpenAPI + TypeScript client regenerated via `make typegen`).
 


### PR DESCRIPTION
## Contexte

Doc-only. Introduit **ADR-043 — Synchronous Structural Computation with Per-Block Asynchronous Enrichments** et marque **ADR-027 (Gate Mechanism / Two-Phase Pipeline)** comme `Superseded`.

## Décision (ADR-043)

Depuis ADR-040 (référentiel OSM/tourisme local en PostGIS) et ADR-042 (IA optionnelle par utilisateur, BYO token), la prémisse d'ADR-027 — une phase d'analyse lente justifiant un gate utilisateur Aperçu→Analyse — ne tient plus :

- Le **calcul structurel** (pacing ADR-006 + scans PostGIS + moteur d'alertes) est désormais quasi instantané (SQL spatial indexé, pas de réseau runtime). Il est exécuté **sans gate utilisateur** :
  - **Upload GPX** : synchrone dans le State Processor (la réponse HTTP porte déjà le voyage structuré).
  - **Lien externe** (Komoot/Strava/RideWithGPS) : le fetch reste asynchrone (appel réseau) derrière un loader unique ; le worker enchaîne fetch → étapes → scans → alertes et publie un seul événement Mercure terminal « trip ready (structural) ».
- Les **enrichissements lents** deviennent **asynchrones, par bloc, avec spinner** :
  - **Météo** (Open-Meteo, réseau, cache 3h) et ses dépendants (vent, gués).
  - **IA** (synthèse / insights par étape / chat) : déclenchée automatiquement si un token est configuré (la config de la clé vaut consentement), avec un bouton « regénérer » ; l'IA ne bloque jamais le voyage structurel.
- **Édition sur la page voyage** : la modification de distance/jour ou de profil re-pace et re-scanne les étapes concernées **synchroniquement / sur place** (pas de re-routing Valhalla, pas de réseau). L'IA n'est pas relancée de façon bloquante (réutilise `skipAiAnalysis`, rafraîchie à la demande / en arrière-plan).
- **Modèle d'état** reload-safe : statut structurel persisté (`draft` → `ready`) + états par bloc (météo, IA) exposés par `GET /trips/{id}/detail` ; Mercure ne sert qu'aux mises à jour live, un événement manqué est récupéré depuis l'état persisté au reload.

Résultat UX : **deux états visibles (Saisie → Voyage)** au lieu de quatre étapes de wizard ; suppression des étapes **Aperçu/Analyse** (jugées confuses et souvent sautées lors de la recette **#649**).

### Prérequis perf

`WaysRepository::findInCorridor` est aujourd'hui non borné (pas de `LIMIT`, pas de filtre `highway`, cast `::geography` qui casse l'index GIST) et peut dépasser ~1s sur un itinéraire long et dense. Il **doit être borné en premier** pour garder le budget structurel synchrone < ~1s.

### Machinerie réutilisée

Le completion-gate `ComputationTracker` / `TripCompletionGate` d'ADR-027 (durci en PR #740) **est conservé** pour coordonner les blocs asynchrones météo/IA et publier leurs événements terminaux.

## Plan d'implémentation (5 PRs)

1. **PR1** — borner `WaysRepository::findInCorridor` (`LIMIT` + pré-filtre `highway`, suppression du cast `::geography`).
2. **PR2** — backend : sortir le calcul structurel du fan-out async (calcul structurel sans gate).
3. **PR3** — enrichissements asynchrones par bloc (météo + IA), statuts par bloc, événements Mercure.
4. **PR4** — front : effondrer le wizard (Saisie → Voyage), supprimer les étapes Aperçu/Analyse, blocs avec spinner.
5. **PR5** — tests / baselines VR / recette : mise à jour des specs mockées et baselines visuelles, retrait/repurpose de `POST /trips/{id}/analyze` (OpenAPI + client TS via `make typegen`).

## Fichiers

- `docs/adr/adr-043-synchronous-structural-computation-async-enrichments.md` (nouveau, `Status: Accepted`)
- `docs/adr/adr-027-gate-mechanism-two-phase-pipeline.md` (statut → `Superseded by ADR-043`)

## Vérification

- `make markdownlint` (markdownlint-cli2) : **0 erreur** sur les 2 fichiers.
- `make link-check` (liens/ancres internes) : **0 cassure interne** ; les 4 liens relatifs de la section Sources (ADR-006/027/040/042) pointent vers des fichiers existants.

<!-- claude-review-start -->
## Claude Review

**Commit reviewed:** `75b7ffb74179a578b530ede27f3288b2aeda1ff8`

A clean follow-up to the previous review. The second commit adds the TRACKING.md Sprint 41 section with the 5-PR ordered table (including `Dépend de` column), and flips the ADR status to `Accepted` with the implementation tracking anchor — both issues flagged in the prior round are fully resolved. All four relative `Sources` links verify against the tree; the bidirectional ADR-027 ↔ ADR-043 link is correct. No debug artefacts, no security surface (doc-only). Ready to merge.

**Findings:** 0 warnings, 0 critical

Resolved 2 previously open threads (both addressed by commit `75b7ffb`).

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases — N/A (doc-only)
- [x] Documentation is up to date — TRACKING.md updated with Sprint 41; ADR-027 superseded correctly; ADR-043 status is `Accepted`
- [x] Dependent tickets accounted for — 5-PR plan tracked with sequencing and dependencies in TRACKING.md Sprint 41

**No inline comments.**
<!-- claude-review-end -->