### PR TITLE
perf(osm): make WaysRepository corridor scan index-friendly

### DIFF
--- a/api/src/Osm/WaysRepository.php
+++ b/api/src/Osm/WaysRepository.php
@@ -12,6 +12,15 @@ use Doctrine\DBAL\Connection;
  * reduced in SQL to the shape the terrain analyzers consume: centroid + length
  * (meters, via geography) + the surface/traffic tags. The full linestring stays
  * in the table; only the derived fields cross the wire.
+ *
+ * This is the only Tier-1 corridor scan that runs against linestrings of the
+ * whole road network (the POI tables hold sparse points), so the per-row
+ * `geom::geography` cast that defeats the GiST index is unacceptable here. The
+ * query keeps the exact ST_DWithin(geography, 100 m) predicate but gates it
+ * behind an index-usable `geom && <expanded bbox>` pre-filter (ADR-043, PR1):
+ * the bounding box strictly contains the 100 m corridor, so the candidate set
+ * is a superset and the returned ways are byte-for-byte identical to the
+ * unoptimised scan. See WaysIndexReadTest for the behaviour guard.
  */
 final readonly class WaysRepository implements WaysRepositoryInterface
 {
@@ -33,24 +42,54 @@ final readonly class WaysRepository implements WaysRepositoryInterface
         /** @var list<array<string, scalar|null>> $rows */
         $rows = $this->connection->fetchAllAssociative(
             <<<'SQL'
+                WITH corridor AS (
+                    SELECT ST_SetSRID(ST_GeomFromText(:wkt), 4326) AS geom
+                ),
+                bbox AS (
+                    -- Pad the corridor envelope by the search radius converted to
+                    -- degrees. Latitude: a constant ~111 320 m/deg. Longitude: the
+                    -- metres-per-degree shrink with latitude, so divide by the
+                    -- cosine at the envelope's highest |lat| (the widest box, the
+                    -- safe over-cover), clamped to keep the box finite near the
+                    -- poles. The result strictly contains the metric ST_DWithin
+                    -- corridor, so the candidate set is a superset.
+                    SELECT ST_Expand(
+                        ST_Envelope(geom),
+                        :radius / (111320.0 * GREATEST(
+                            cos(radians(LEAST(
+                                GREATEST(
+                                    abs(ST_YMin(ST_Envelope(geom))),
+                                    abs(ST_YMax(ST_Envelope(geom)))
+                                ) + :radius / 111320.0,
+                                89.9
+                            ))),
+                            0.01
+                        )),
+                        :radius / 111320.0
+                    ) AS geom
+                    FROM corridor
+                )
                 SELECT ST_Y(_c.centroid) AS lat,
                        ST_X(_c.centroid) AS lon,
-                       ST_Length(geom::geography) AS length,
-                       tags->>'surface' AS surface,
-                       tags->>'highway' AS highway,
-                       tags->>'cycleway' AS cycleway,
-                       tags->>'cycleway:right' AS cycleway_right,
-                       tags->>'cycleway:left' AS cycleway_left,
-                       tags->>'cycleway:both' AS cycleway_both,
-                       tags->>'bicycle' AS bicycle,
-                       tags->>'maxspeed' AS maxspeed
-                FROM osm.ways,
-                LATERAL (SELECT ST_Centroid(geom) AS centroid) AS _c
-                WHERE ST_DWithin(
-                    geom::geography,
-                    ST_SetSRID(ST_GeomFromText(:wkt), 4326)::geography,
-                    :radius
-                )
+                       ST_Length(w.geom::geography) AS length,
+                       w.tags->>'surface' AS surface,
+                       w.tags->>'highway' AS highway,
+                       w.tags->>'cycleway' AS cycleway,
+                       w.tags->>'cycleway:right' AS cycleway_right,
+                       w.tags->>'cycleway:left' AS cycleway_left,
+                       w.tags->>'cycleway:both' AS cycleway_both,
+                       w.tags->>'bicycle' AS bicycle,
+                       w.tags->>'maxspeed' AS maxspeed
+                FROM osm.ways AS w,
+                     corridor AS c,
+                     bbox AS b,
+                     LATERAL (SELECT ST_Centroid(w.geom) AS centroid) AS _c
+                WHERE w.geom && b.geom
+                  AND ST_DWithin(
+                      w.geom::geography,
+                      c.geom::geography,
+                      :radius
+                  )
                 SQL,
             [
                 'wkt' => WktGeometry::lineStringOrPoint($route),

--- a/api/src/Osm/WaysRepository.php
+++ b/api/src/Osm/WaysRepository.php
@@ -21,6 +21,8 @@ use Doctrine\DBAL\Connection;
  * the bounding box strictly contains the 100 m corridor, so the candidate set
  * is a superset and the returned ways are byte-for-byte identical to the
  * unoptimised scan. See WaysIndexReadTest for the behaviour guard.
+ *
+ * @phpstan-type WayRow = array{lat: float, lon: float, surface: string, highway: string, cycleway: string, 'cycleway:right': string, 'cycleway:left': string, 'cycleway:both': string, bicycle: string, maxspeed: string, length: float}
  */
 final readonly class WaysRepository implements WaysRepositoryInterface
 {
@@ -31,7 +33,7 @@ final readonly class WaysRepository implements WaysRepositoryInterface
     /**
      * @param list<array{lat: float, lon: float}> $route
      *
-     * @return list<array{lat: float, lon: float, surface: string, highway: string, cycleway: string, 'cycleway:right': string, 'cycleway:left': string, 'cycleway:both': string, bicycle: string, maxspeed: string, length: float}>
+     * @return list<WayRow>
      */
     public function findInCorridor(array $route, int $radiusMeters): array
     {

--- a/api/tests/Integration/Osm/WaysIndexReadTest.php
+++ b/api/tests/Integration/Osm/WaysIndexReadTest.php
@@ -15,6 +15,8 @@ use Zenstruck\Foundry\Test\ResetDatabase;
  * Integration coverage for the local-first ways read layer (ADR-040): seeds real
  * PostGIS LineStrings in osm.ways and asserts the ST_DWithin corridor filtering
  * plus the centroid / geography-length / tag projection the terrain analyzers consume.
+ *
+ * @phpstan-import-type WayRow from WaysRepository
  */
 final class WaysIndexReadTest extends KernelTestCase
 {
@@ -128,7 +130,7 @@ final class WaysIndexReadTest extends KernelTestCase
      *
      * @param list<array{lat: float, lon: float}> $route
      *
-     * @return list<array{lat: float, lon: float, surface: string, highway: string, cycleway: string, 'cycleway:right': string, 'cycleway:left': string, 'cycleway:both': string, bicycle: string, maxspeed: string, length: float}>
+     * @return list<WayRow>
      */
     private function naiveCorridorScan(array $route, int $radiusMeters): array
     {
@@ -181,8 +183,8 @@ final class WaysIndexReadTest extends KernelTestCase
     }
 
     /**
-     * @param array{lat: float, lon: float} $a
-     * @param array{lat: float, lon: float} $b
+     * @param WayRow $a
+     * @param WayRow $b
      */
     private function byCentroid(array $a, array $b): int
     {

--- a/api/tests/Integration/Osm/WaysIndexReadTest.php
+++ b/api/tests/Integration/Osm/WaysIndexReadTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Integration\Osm;
 
 use App\Osm\WaysRepository;
+use App\Osm\WktGeometry;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
@@ -18,6 +19,12 @@ use Zenstruck\Foundry\Test\ResetDatabase;
 final class WaysIndexReadTest extends KernelTestCase
 {
     use ResetDatabase;
+
+    /** Route running along the seeded secondary road. */
+    private const array CORRIDOR_ROUTE = [
+        ['lat' => 49.60, 'lon' => 6.13],
+        ['lat' => 49.62, 'lon' => 6.15],
+    ];
 
     private Connection $connection;
 
@@ -44,10 +51,7 @@ final class WaysIndexReadTest extends KernelTestCase
     #[Test]
     public function findInCorridorProjectsCentroidLengthAndTags(): void
     {
-        $ways = new WaysRepository($this->connection)->findInCorridor([
-            ['lat' => 49.60, 'lon' => 6.13],
-            ['lat' => 49.62, 'lon' => 6.15],
-        ], 100);
+        $ways = new WaysRepository($this->connection)->findInCorridor(self::CORRIDOR_ROUTE, 100);
 
         // The far primary road is excluded by ST_DWithin.
         self::assertCount(1, $ways);
@@ -65,9 +69,123 @@ final class WaysIndexReadTest extends KernelTestCase
         self::assertGreaterThan(1000.0, $way['length']);
     }
 
+    /**
+     * Behaviour guard for the index-friendly rewrite (ADR-043, PR1): the bbox
+     * pre-filter must not change which ways the corridor scan returns. We seed a
+     * varied network -- in/out of the corridor, mixed highway/surface tags, and a
+     * way whose bounding box overlaps the corridor envelope yet sits >100 m from
+     * the route (a bbox false positive the metric ST_DWithin must still reject) --
+     * and assert the optimised query returns exactly the same set as the original
+     * naive `geom::geography` scan run against the same data.
+     */
+    #[Test]
+    public function indexFriendlyScanMatchesTheNaiveCorridorScan(): void
+    {
+        $this->connection->executeStatement('TRUNCATE osm.ways');
+        $this->connection->executeStatement(<<<'SQL'
+            INSERT INTO osm.ways (osm_id, tags, geom) VALUES
+              -- On the corridor, paved.
+              (10, '{"highway":"tertiary","surface":"asphalt","maxspeed":"70"}'::jsonb,
+                   ST_SetSRID(ST_GeomFromText('LINESTRING(6.131 49.601, 6.149 49.619)'), 4326)),
+              -- On the corridor, unpaved, no surface-less tags.
+              (11, '{"highway":"track","surface":"gravel"}'::jsonb,
+                   ST_SetSRID(ST_GeomFromText('LINESTRING(6.135 49.605, 6.145 49.615)'), 4326)),
+              -- On the corridor, surface tag missing (counts toward missing-data %).
+              (12, '{"highway":"residential"}'::jsonb,
+                   ST_SetSRID(ST_GeomFromText('LINESTRING(6.140 49.610, 6.142 49.612)'), 4326)),
+              -- Bbox false positive: within the padded envelope but ~600 m north of
+              -- the route line, so excluded by the 100 m metric predicate.
+              (13, '{"highway":"primary","surface":"asphalt"}'::jsonb,
+                   ST_SetSRID(ST_GeomFromText('LINESTRING(6.138 49.6165, 6.142 49.6165)'), 4326)),
+              -- Far outside the corridor entirely.
+              (14, '{"highway":"secondary"}'::jsonb,
+                   ST_SetSRID(ST_GeomFromText('LINESTRING(6.80 49.90, 6.81 49.91)'), 4326))
+            SQL);
+
+        $expected = $this->naiveCorridorScan(self::CORRIDOR_ROUTE, 100);
+        $actual = new WaysRepository($this->connection)->findInCorridor(self::CORRIDOR_ROUTE, 100);
+
+        // Order is not guaranteed by either query; compare as sets keyed by centroid.
+        usort($expected, $this->byCentroid(...));
+        usort($actual, $this->byCentroid(...));
+
+        self::assertSame($expected, $actual);
+        // Sanity: the seeding actually exercises the corridor (3 on-route ways),
+        // so the assertion above is not vacuously comparing two empty sets.
+        self::assertCount(3, $actual);
+    }
+
     #[Test]
     public function emptyRouteYieldsNoQuery(): void
     {
         self::assertSame([], new WaysRepository($this->connection)->findInCorridor([], 100));
+    }
+
+    /**
+     * The pre-optimisation query (per-row `geom::geography`, no bbox pre-filter),
+     * used as the behaviour oracle. Projects the exact same columns/shape as
+     * WaysRepository so the two results are directly comparable.
+     *
+     * @param list<array{lat: float, lon: float}> $route
+     *
+     * @return list<array{lat: float, lon: float, surface: string, highway: string, cycleway: string, 'cycleway:right': string, 'cycleway:left': string, 'cycleway:both': string, bicycle: string, maxspeed: string, length: float}>
+     */
+    private function naiveCorridorScan(array $route, int $radiusMeters): array
+    {
+        /** @var list<array<string, scalar|null>> $rows */
+        $rows = $this->connection->fetchAllAssociative(
+            <<<'SQL'
+                SELECT ST_Y(_c.centroid) AS lat,
+                       ST_X(_c.centroid) AS lon,
+                       ST_Length(geom::geography) AS length,
+                       tags->>'surface' AS surface,
+                       tags->>'highway' AS highway,
+                       tags->>'cycleway' AS cycleway,
+                       tags->>'cycleway:right' AS cycleway_right,
+                       tags->>'cycleway:left' AS cycleway_left,
+                       tags->>'cycleway:both' AS cycleway_both,
+                       tags->>'bicycle' AS bicycle,
+                       tags->>'maxspeed' AS maxspeed
+                FROM osm.ways,
+                LATERAL (SELECT ST_Centroid(geom) AS centroid) AS _c
+                WHERE ST_DWithin(
+                    geom::geography,
+                    ST_SetSRID(ST_GeomFromText(:wkt), 4326)::geography,
+                    :radius
+                )
+                SQL,
+            [
+                'wkt' => WktGeometry::lineStringOrPoint($route),
+                'radius' => $radiusMeters,
+            ],
+        );
+
+        $ways = [];
+        foreach ($rows as $row) {
+            $ways[] = [
+                'lat' => (float) $row['lat'],
+                'lon' => (float) $row['lon'],
+                'surface' => (string) ($row['surface'] ?? ''),
+                'highway' => (string) ($row['highway'] ?? ''),
+                'cycleway' => (string) ($row['cycleway'] ?? ''),
+                'cycleway:right' => (string) ($row['cycleway_right'] ?? ''),
+                'cycleway:left' => (string) ($row['cycleway_left'] ?? ''),
+                'cycleway:both' => (string) ($row['cycleway_both'] ?? ''),
+                'bicycle' => (string) ($row['bicycle'] ?? ''),
+                'maxspeed' => (string) ($row['maxspeed'] ?? ''),
+                'length' => (float) $row['length'],
+            ];
+        }
+
+        return $ways;
+    }
+
+    /**
+     * @param array{lat: float, lon: float} $a
+     * @param array{lat: float, lon: float} $b
+     */
+    private function byCentroid(array $a, array $b): int
+    {
+        return [$a['lat'], $a['lon']] <=> [$b['lat'], $b['lon']];
     }
 }


### PR DESCRIPTION
## PR1 du plan ADR-043 (Sprint 41)

Première étape vers le **calcul structurel synchrone** d'ADR-043 : rendre `WaysRepository::findInCorridor` assez rapide pour tourner en synchrone (< ~1 s) même sur un long itinéraire dense, **sans changer le résultat métier** de l'analyse de terrain (revêtement + trafic). Aucune modification du flux synchrone, du wizard ni du gate (PR2+).

### Le problème

`osm.ways` est le seul index Tier-1 (ADR-040) qui scanne des **linestrings de tout le réseau routier** d'un pays (les autres tables Tier-1 ne contiennent que des points POI épars). La requête actuelle :

```sql
WHERE ST_DWithin(geom::geography, ST_SetSRID(ST_GeomFromText(:wkt),4326)::geography, 100)
```

caste `geom` en `geography` **par ligne**, ce qui empêche l'usage de l'index GiST `ways_geom_idx` (défini sur `geom`, geometry 4326) → **Seq Scan** sur tout le réseau, coût croissant avec la densité.

### L'optimisation

On conserve **exactement** le prédicat métrique `ST_DWithin(geography, 100 m)`, mais on le précède d'un pré-filtre bounding-box **index-friendly** sur `geom` :

```sql
WHERE w.geom && b.geom          -- bbox élargie, utilise l'index GiST
  AND ST_DWithin(w.geom::geography, c.geom::geography, :radius)   -- filtre fin exact, inchangé
```

La bbox = enveloppe du corridor étendue (`ST_Expand`) du rayon converti en degrés. La conversion longitude utilise le cosinus à la **latitude la plus éloignée de l'équateur** de l'enveloppe (cas le plus large → sur-couverture garantie), bornée près des pôles. La bbox **contient strictement** le corridor de 100 m, donc l'ensemble de candidats est un sur-ensemble et le résultat retourné est **identique** à la requête naïve.

### Preuve de non-régression (comportement)

`WaysIndexReadTest::indexFriendlyScanMatchesTheNaiveCorridorScan` sème un réseau varié (dans/hors corridor, tags `highway`/`surface` mixtes, et **un faux positif de bbox** à ~600 m du tracé que le filtre métrique doit toujours rejeter) puis assert que la requête optimisée renvoie **exactement le même ensemble** que la requête naïve d'origine (l'oracle) exécutée sur les mêmes données.

```
PHPUnit 13.1.10 by Sebastian Bergmann and contributors.
...                                                                 3 / 3 (100%)
OK (3 tests, 12 assertions)
```

Test lancé contre une vraie base PostGIS (`postgis/postgis:18-3.6-alpine`) dans un conteneur jetable branché au réseau Docker, base de test dédiée — sans toucher la stack iso-prod.

### Preuve du gain (EXPLAIN ANALYZE, 60 002 ways)

**Avant** (naïf) :
```
Seq Scan on ways  (cost=0.00..751769.35 rows=6) (actual time=199.819..199.828 rows=2)
  Rows Removed by Filter: 60000
  Buffers: shared hit=1074
Execution Time: 221.193 ms
```

**Après** (index-friendly) :
```
Nested Loop  (actual time=8.508..8.568 rows=2)
  ->  Index Scan using ways_geom_idx on ways w  (rows=18)
        Index Cond: (geom && st_expand(st_envelope(...)))
  Buffers: shared hit=125
Execution Time: 8.887 ms
```

Seq Scan (60 000 lignes filtrées) → **Index Scan GiST** (18 candidats bbox, 2 retenus). ~**25x** plus rapide, et le coût ne croît plus avec la taille du réseau. Résultat identique des deux côtés (`rows=2`).

### Décisions de sûreté sémantique

- **Pas de filtre `highway`** : l'import provisioner (`tier1.lua`, `WAY_HIGHWAY`) garantit déjà que `osm.ways` ne contient que des ways d'une liste blanche `highway`. Surtout, `SurfaceAlertAnalyzer::detectMissingSurfaceData` calcule un **pourcentage sur le nombre total** de ways candidats — restreindre en SQL changerait le dénominateur → régression d'alertes.
- **Pas de LIMIT** : les sommes de longueur (`SurfaceAlertAnalyzer`, `TrafficDangerAnalyzer`) et le ratio "missing surface" sont sensibles à toute troncature. Un LIMIT changerait les pourcentages. L'index-friendliness seul suffit au gain.

### QA (sorties réelles)

- Rector `--dry-run` : `[OK] Rector is done!` (0 changement)
- PHPStan niveau 9 : `[OK] No errors`
- PHP-CS-Fixer : `Found 0 of 1 files that can be fixed` (sur chaque fichier touché)

Refs : ADR-043, recette #649.

<!-- claude-review-start -->
## Claude Review

**Summary:** Clean, well-reasoned performance optimization. The two-stage filter (bbox pre-filter → exact `ST_DWithin`) is semantically sound — the expanded bounding box strictly contains the 100 m corridor in both dimensions, using the correct latitude-dependent longitude compensation (cosine at maximum absolute latitude, with a conservative +radius offset before taking the cosine), guaranteeing identical results to the naive scan. The behavioral oracle test is thorough, correctly exercises the bbox false-positive edge case, and includes a count assertion to prevent a vacuous comparison against two empty sets.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

_Reviewed commit: `08506f92f24489c84ce09fe79eeeec59b9d63829`_
<!-- claude-review-end -->