### PR TITLE
feat(trip): compute GPX pacing synchronously and persist trip status

### DIFF
--- a/api/migrations/Version20260621120000.php
+++ b/api/migrations/Version20260621120000.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * ADR-043: add the persisted structural-readiness status to the trip table.
+ *
+ * `draft` until the pacing stages are persisted, then `ready`. The status is
+ * independent of the asynchronous enrichment completion gate. Existing trips that
+ * already have stages are backfilled to `ready` so reload-safe hydration is correct.
+ */
+final class Version20260621120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add structural-readiness status column to trip table (ADR-043)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE trip ADD status VARCHAR(20) DEFAULT 'draft' NOT NULL");
+        $this->addSql("UPDATE trip SET status = 'ready' WHERE id IN (SELECT DISTINCT trip_id FROM stage)");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE trip DROP status');
+    }
+}

--- a/api/src/ApiResource/TripDetail.php
+++ b/api/src/ApiResource/TripDetail.php
@@ -52,6 +52,11 @@ final readonly class TripDetail
         public bool $isLocked,
         /** True when the route falls outside the provisioned coverage area: the trip is display-only (no Valhalla rerouting). */
         public bool $outOfZone,
+        #[ApiProperty(
+            description: 'Structural-readiness status (ADR-043): "draft" until pacing stages are persisted, then "ready".',
+            openapiContext: ['type' => 'string', 'enum' => ['draft', 'ready']],
+        )]
+        public string $status,
         #[ApiProperty(openapiContext: [
             'type' => 'array',
             'items' => [

--- a/api/src/ApiResource/TripRequest.php
+++ b/api/src/ApiResource/TripRequest.php
@@ -117,6 +117,14 @@ final class TripRequest
     #[ApiProperty(readable: false, writable: false)]
     public ?string $sourceType = null;
 
+    /**
+     * Structural-readiness status (ADR-043): `draft` until the pacing stages are persisted,
+     * then `ready`. Independent of the asynchronous enrichment completion gate.
+     */
+    #[ORM\Column(length: 20, options: ['default' => 'draft'])]
+    #[ApiProperty(readable: false, writable: false)]
+    public string $status = 'draft';
+
     #[ORM\Column(length: 5)]
     #[ApiProperty(readable: false, writable: false)]
     public string $locale = 'en';

--- a/api/src/Controller/GpxUploadController.php
+++ b/api/src/Controller/GpxUploadController.php
@@ -111,6 +111,10 @@ final readonly class GpxUploadController
             'totalDistance' => $result['totalDistance'],
             'totalElevation' => $result['totalElevation'],
             'totalElevationLoss' => $result['totalElevationLoss'],
+            // ADR-043: structural data is computed synchronously, so the response
+            // already carries the persisted status and the computed stages.
+            'status' => $result['status'],
+            'stages' => $result['stages'],
         ];
 
         if (null !== $title) {

--- a/api/src/Enum/ComputationName.php
+++ b/api/src/Enum/ComputationName.php
@@ -59,6 +59,21 @@ enum ComputationName: string
     }
 
     /**
+     * The structural computations that make a trip renderable (ADR-043).
+     *
+     * Pure local CPU work (route parsing + pacing). Used to express the intent
+     * behind posting the persisted `ready` status — it does NOT fragment the
+     * {@see self::pipeline()} tracker, whose completion still gates the terminal
+     * `AllEnrichmentsCompleted` / TripCompletionGate event.
+     *
+     * @return list<self>
+     */
+    public static function structuralPipeline(): array
+    {
+        return [self::ROUTE, self::STAGES];
+    }
+
+    /**
      * Returns the user-facing progress category this computation belongs to.
      *
      * The category groups several individual computations under the same progress

--- a/api/src/Enum/TripStatus.php
+++ b/api/src/Enum/TripStatus.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enum;
+
+/**
+ * Persisted structural-readiness status of a trip (ADR-043).
+ *
+ * Reflects whether the structural computation (route + pacing stages) has settled,
+ * independently of the asynchronous per-block enrichments (weather, AI, …) which
+ * are tracked separately by the {@see \App\ComputationTracker\ComputationTrackerInterface}.
+ *
+ *  - `draft`: created, stages not yet generated.
+ *  - `ready`: stages persisted (>= {@see self::MIN_STAGES}); the trip is renderable.
+ */
+enum TripStatus: string
+{
+    case DRAFT = 'draft';
+    case READY = 'ready';
+
+    /**
+     * Minimum number of stages a trip must have to be considered structurally valid
+     * (mirrors the MIN_STAGES validation in the stage-generation pipeline).
+     */
+    public const int MIN_STAGES = 2;
+}

--- a/api/src/MessageHandler/GenerateStagesHandler.php
+++ b/api/src/MessageHandler/GenerateStagesHandler.php
@@ -4,21 +4,16 @@ declare(strict_types=1);
 
 namespace App\MessageHandler;
 
-use App\ApiResource\Model\Coordinate;
-use App\ApiResource\Stage;
 use App\ApiResource\TripRequest;
 use App\ComputationTracker\ComputationTrackerInterface;
 use App\ComputationTracker\TripGenerationTrackerInterface;
-use App\Engine\DistanceCalculatorInterface;
-use App\Engine\ElevationCalculatorInterface;
-use App\Engine\PacingEngineInterface;
-use App\Engine\RouteSimplifierInterface;
 use App\Enum\ComputationName;
-use App\Enum\SourceType;
+use App\Enum\TripStatus;
 use App\Mercure\MercureEventType;
 use App\Mercure\TripUpdatePublisherInterface;
 use App\Message\GenerateStages;
 use App\Repository\TripRequestRepositoryInterface;
+use App\Service\StructuralComputationService;
 use App\Service\TripAnalysisDispatcher;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
@@ -33,10 +28,7 @@ final readonly class GenerateStagesHandler extends AbstractTripMessageHandler
         TripGenerationTrackerInterface $generationTracker,
         LoggerInterface $logger,
         private TripRequestRepositoryInterface $tripStateManager,
-        private DistanceCalculatorInterface $distanceCalculator,
-        private ElevationCalculatorInterface $elevationCalculator,
-        private RouteSimplifierInterface $routeSimplifier,
-        private PacingEngineInterface $pacingEngine,
+        private StructuralComputationService $structuralComputation,
         private TripAnalysisDispatcher $analysisDispatcher,
         MessageBusInterface $messageBus,
     ) {
@@ -54,136 +46,28 @@ final readonly class GenerateStagesHandler extends AbstractTripMessageHandler
         }
 
         $this->executeWithTracking($tripId, ComputationName::STAGES, function () use ($tripId, $request, $generation): void {
-            $sourceType = $this->tripStateManager->getSourceType($tripId);
+            $stages = $this->structuralComputation->generateStages($tripId, $request);
 
-            if ($sourceType === SourceType::KOMOOT_COLLECTION->value) {
-                $stages = $this->generateCollectionStages($tripId);
-            } else {
-                $stages = $this->generatePacingStages($tripId, $request);
-            }
-
-            if (\count($stages) < 2) {
+            if (\count($stages) < TripStatus::MIN_STAGES) {
                 $this->publisher->publishValidationError($tripId, 'MIN_STAGES', 'A minimum of 2 stages is required.');
             }
 
             $this->tripStateManager->storeStages($tripId, $stages);
 
-            $this->publisher->publish($tripId, MercureEventType::STAGES_COMPUTED, [
-                'stages' => array_map(
-                    static fn (Stage $s): array => [
-                        'dayNumber' => $s->dayNumber,
-                        'distance' => round($s->distance, 1),
-                        'elevation' => (int) $s->elevation,
-                        'elevationLoss' => (int) $s->elevationLoss,
-                        'startPoint' => [
-                            'lat' => $s->startPoint->lat,
-                            'lon' => $s->startPoint->lon,
-                            'ele' => $s->startPoint->ele,
-                        ],
-                        'endPoint' => [
-                            'lat' => $s->endPoint->lat,
-                            'lon' => $s->endPoint->lon,
-                            'ele' => $s->endPoint->ele,
-                        ],
-                        'label' => $s->label,
-                        'geometry' => array_map(
-                            static fn (Coordinate $c): array => ['lat' => $c->lat, 'lon' => $c->lon, 'ele' => $c->ele],
-                            $s->geometry,
-                        ),
-                    ],
-                    $stages,
-                ),
-            ]);
+            // ADR-043: structural readiness is reached as soon as the stages are
+            // persisted — independently of the terminal enrichment gate, so a trip
+            // without dates (weather/calendar never settle) still becomes `ready`.
+            if (\count($stages) >= TripStatus::MIN_STAGES) {
+                $this->tripStateManager->storeStatus($tripId, TripStatus::READY->value);
+            }
+
+            $this->publisher->publish(
+                $tripId,
+                MercureEventType::STAGES_COMPUTED,
+                ['stages' => $this->structuralComputation->serializeStagesForEvent($stages)],
+            );
 
             $this->analysisDispatcher->dispatch($tripId, $request, $generation);
         }, $generation);
-    }
-
-    /** @return list<Stage> */
-    private function generateCollectionStages(string $tripId): array
-    {
-        $tracksData = $this->tripStateManager->getTracksData($tripId);
-
-        if (null === $tracksData) {
-            return [];
-        }
-
-        $stages = [];
-
-        foreach ($tracksData as $i => $trackData) {
-            $points = array_map(
-                static fn (array $p): Coordinate => new Coordinate($p['lat'], $p['lon'], $p['ele']),
-                $trackData,
-            );
-
-            if ([] === $points) {
-                continue;
-            }
-
-            $distance = $this->distanceCalculator->calculateTotalDistance($points);
-            $elevation = $this->elevationCalculator->calculateTotalAscent($points);
-            $elevationLoss = $this->elevationCalculator->calculateTotalDescent($points);
-            $geometry = $this->routeSimplifier->simplify($points);
-
-            $stages[] = new Stage(
-                tripId: $tripId,
-                dayNumber: $i + 1,
-                distance: $distance,
-                elevation: $elevation,
-                startPoint: $points[0],
-                endPoint: $points[\count($points) - 1],
-                geometry: $geometry,
-                elevationLoss: $elevationLoss,
-            );
-        }
-
-        return $stages;
-    }
-
-    /**
-     * @return list<Stage>
-     */
-    private function generatePacingStages(string $tripId, TripRequest $request): array
-    {
-        $decimatedData = $this->tripStateManager->getDecimatedPoints($tripId);
-
-        if (null === $decimatedData) {
-            return [];
-        }
-
-        $decimatedPoints = array_map(
-            static fn (array $p): Coordinate => new Coordinate($p['lat'], $p['lon'], $p['ele']),
-            $decimatedData,
-        );
-
-        $allPointsData = $this->tripStateManager->getRawPoints($tripId);
-        $allPoints = null !== $allPointsData
-            ? array_map(static fn (array $p): Coordinate => new Coordinate($p['lat'], $p['lon'], $p['ele']), $allPointsData)
-            : $decimatedPoints;
-
-        $totalDistance = $this->distanceCalculator->calculateTotalDistance($allPoints);
-
-        if ($request->endDate instanceof \DateTimeImmutable && $request->startDate instanceof \DateTimeImmutable) {
-            $numberOfDays = (int) $request->startDate->diff($request->endDate)->days + 1;
-        } else {
-            $numberOfDays = (int) ceil($totalDistance / $request->maxDistancePerDay);
-            $numberOfDays = max(1, $numberOfDays);
-        }
-
-        // Pass raw points for accurate elevation calculation (decimated points lose altitude detail).
-        // rawPoints is null when no full-resolution data was loaded (e.g. routing-only trips),
-        // in which case the pacing engine falls back to decimated points.
-        $rawPoints = null !== $allPointsData ? $allPoints : null;
-
-        return $this->pacingEngine->generateStages(
-            $tripId,
-            $decimatedPoints,
-            $numberOfDays,
-            $totalDistance,
-            $request->fatigueFactor,
-            $request->elevationPenalty,
-            $rawPoints,
-            $request->maxDistancePerDay,
-        );
     }
 }

--- a/api/src/Repository/DoctrineTripRequestRepository.php
+++ b/api/src/Repository/DoctrineTripRequestRepository.php
@@ -146,6 +146,17 @@ final class DoctrineTripRequestRepository extends ServiceEntityRepository implem
         return $this->findTripRequest($tripId)?->sourceType;
     }
 
+    public function storeStatus(string $tripId, string $status): void
+    {
+        $trip = $this->findTripRequest($tripId);
+        if (!$trip instanceof TripRequest) {
+            return;
+        }
+
+        $trip->status = $status;
+        $this->getEntityManager()->flush();
+    }
+
     public function storeLocale(string $tripId, string $locale): void
     {
         $trip = $this->findTripRequest($tripId);

--- a/api/src/Repository/RedisTripRequestRepository.php
+++ b/api/src/Repository/RedisTripRequestRepository.php
@@ -181,6 +181,17 @@ final readonly class RedisTripRequestRepository implements TripRequestRepository
         return $value;
     }
 
+    public function storeStatus(string $tripId, string $status): void
+    {
+        $request = $this->getRequest($tripId);
+        if (!$request instanceof TripRequest) {
+            return;
+        }
+
+        $request->status = $status;
+        $this->set($this->requestKey($tripId), $request);
+    }
+
     private function set(string $key, mixed $value): void
     {
         $item = $this->tripStateCache->getItem($key);

--- a/api/src/Repository/TripRequestRepositoryInterface.php
+++ b/api/src/Repository/TripRequestRepositoryInterface.php
@@ -83,6 +83,13 @@ interface TripRequestRepositoryInterface
 
     public function getSourceType(string $tripId): ?string;
 
+    /**
+     * Persists the structural-readiness status of a trip (ADR-043), e.g. `draft` → `ready`.
+     *
+     * Returns silently if the trip does not exist anymore.
+     */
+    public function storeStatus(string $tripId, string $status): void;
+
     public function storeLocale(string $tripId, string $locale): void;
 
     public function getLocale(string $tripId): ?string;

--- a/api/src/Service/GpxUploadService.php
+++ b/api/src/Service/GpxUploadService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Service;
 
+use App\ApiResource\Stage;
 use App\ApiResource\Model\Coordinate;
 use App\ApiResource\TripRequest;
 use App\ComputationTracker\ComputationTrackerInterface;
@@ -12,19 +13,23 @@ use App\Engine\ElevationCalculatorInterface;
 use App\Engine\RouteSimplifierInterface;
 use App\Enum\ComputationName;
 use App\Enum\SourceType;
+use App\Enum\TripStatus;
 use App\Mercure\MercureEventType;
 use App\Mercure\TripUpdatePublisherInterface;
-use App\Message\GenerateStages;
-use App\Repository\TripRequestRepositoryInterface;
 use App\RouteParser\GpxRouteParserInterface;
-use Symfony\Component\Messenger\MessageBusInterface;
+use App\Repository\TripRequestRepositoryInterface;
 use Symfony\Component\Uid\Uuid;
 
 /**
  * Encapsulates GPX upload business logic: trip initialization, route storage,
- * computation tracking, Mercure publishing, and downstream message dispatching.
+ * synchronous structural computation (pacing), computation tracking, Mercure
+ * publishing, and the asynchronous enrichment fan-out.
  *
  * Extracted from GpxUploadController to satisfy SRP and reduce coupling.
+ *
+ * ADR-043: the pacing is pure local CPU, so it runs synchronously here — the HTTP
+ * response already carries the computed stages and the persisted `ready` status.
+ * Only the network/LLM enrichments stay asynchronous (dispatched at the end).
  */
 final readonly class GpxUploadService
 {
@@ -32,11 +37,12 @@ final readonly class GpxUploadService
         private GpxRouteParserInterface $gpxParser,
         private TripRequestRepositoryInterface $tripStateManager,
         private ComputationTrackerInterface $computationTracker,
-        private MessageBusInterface $messageBus,
         private DistanceCalculatorInterface $distanceCalculator,
         private ElevationCalculatorInterface $elevationCalculator,
         private RouteSimplifierInterface $routeSimplifier,
         private TripUpdatePublisherInterface $publisher,
+        private StructuralComputationService $structuralComputation,
+        private TripAnalysisDispatcher $analysisDispatcher,
     ) {
     }
 
@@ -61,11 +67,12 @@ final readonly class GpxUploadService
     }
 
     /**
-     * Creates a trip from parsed GPX data and dispatches downstream computations.
+     * Creates a trip from parsed GPX data, computes its stages synchronously, then
+     * dispatches the asynchronous enrichments.
      *
      * @param list<Coordinate> $points
      *
-     * @return array{tripId: string, computationStatus: array<string, string>, totalDistance: float, totalElevation: int, totalElevationLoss: int}
+     * @return array{tripId: string, computationStatus: array<string, string>, totalDistance: float, totalElevation: int, totalElevationLoss: int, status: string, stages: list<array<string, mixed>>}
      */
     public function createTrip(
         array $points,
@@ -88,7 +95,15 @@ final readonly class GpxUploadService
         $totalElevationLoss = (int) $this->elevationCalculator->calculateTotalDescent($points);
 
         $this->publishRouteEvent($tripId, $totalDistance, $totalElevation, $totalElevationLoss, $title);
-        $this->dispatchDownstreamMessages($tripId);
+
+        // ADR-043: pacing is pure local CPU — compute the stages synchronously so the
+        // structural trip is already available in the HTTP response.
+        $request = $this->tripStateManager->getRequest($tripId) ?? $tripRequest;
+        $stages = $this->structuralComputation->generateStages($tripId, $request);
+        $status = $this->storeStructuralStages($tripId, $stages);
+
+        // Hand off the network/LLM enrichments to the workers (unchanged async fan-out).
+        $this->analysisDispatcher->dispatch($tripId, $request);
 
         return [
             'tripId' => $tripId,
@@ -96,6 +111,8 @@ final readonly class GpxUploadService
             'totalDistance' => $totalDistance,
             'totalElevation' => $totalElevation,
             'totalElevationLoss' => $totalElevationLoss,
+            'status' => $status->value,
+            'stages' => $this->structuralComputation->serializeStagesForEvent($stages),
         ];
     }
 
@@ -133,9 +150,52 @@ final readonly class GpxUploadService
         ]);
     }
 
-    private function dispatchDownstreamMessages(string $tripId): void
+    /**
+     * Persists the synchronously computed stages, marks the STAGES computation done,
+     * publishes the `stages_computed` event and the progress step, and posts the
+     * structural `ready` status (ADR-043) once at least {@see TripStatus::MIN_STAGES}
+     * stages exist.
+     *
+     * The terminal enrichment gate is intentionally NOT evaluated here — readiness is
+     * structural and must not depend on the asynchronous enrichments settling.
+     *
+     * @param list<Stage> $stages
+     */
+    private function storeStructuralStages(string $tripId, array $stages): TripStatus
     {
-        $this->messageBus->dispatch(new GenerateStages($tripId));
+        $this->computationTracker->markRunning($tripId, ComputationName::STAGES);
+
+        if (\count($stages) < TripStatus::MIN_STAGES) {
+            $this->publisher->publishValidationError($tripId, 'MIN_STAGES', 'A minimum of 2 stages is required.');
+        }
+
+        $this->tripStateManager->storeStages($tripId, $stages);
+        $this->computationTracker->markDone($tripId, ComputationName::STAGES);
+
+        $status = TripStatus::DRAFT;
+        if (\count($stages) >= TripStatus::MIN_STAGES) {
+            $status = TripStatus::READY;
+            $this->tripStateManager->storeStatus($tripId, $status->value);
+        }
+
+        $this->publisher->publish(
+            $tripId,
+            MercureEventType::STAGES_COMPUTED,
+            ['stages' => $this->structuralComputation->serializeStagesForEvent($stages)],
+        );
+
+        $progress = $this->computationTracker->getProgress($tripId);
+        if (0 !== $progress['total']) {
+            $this->publisher->publishComputationStepCompleted(
+                $tripId,
+                ComputationName::STAGES,
+                $progress['completed'],
+                $progress['total'],
+                $progress['failed'],
+            );
+        }
+
+        return $status;
     }
 
     /**
@@ -145,11 +205,12 @@ final readonly class GpxUploadService
      */
     private function buildComputationStatus(array $computations): array
     {
-        $status = [];
+        $structural = ComputationName::structuralPipeline();
+        $result = [];
         foreach ($computations as $computation) {
-            $status[$computation->value] = ComputationName::ROUTE === $computation ? 'done' : 'pending';
+            $result[$computation->value] = \in_array($computation, $structural, true) ? 'done' : 'pending';
         }
 
-        return $status;
+        return $result;
     }
 }

--- a/api/src/Service/StructuralComputationService.php
+++ b/api/src/Service/StructuralComputationService.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\ApiResource\Model\Coordinate;
+use App\ApiResource\Stage;
+use App\ApiResource\TripRequest;
+use App\Engine\DistanceCalculatorInterface;
+use App\Engine\ElevationCalculatorInterface;
+use App\Engine\PacingEngineInterface;
+use App\Engine\RouteSimplifierInterface;
+use App\Enum\SourceType;
+use App\Repository\TripRequestRepositoryInterface;
+
+/**
+ * Generates the structural stages of a trip (pacing) from its stored route data.
+ *
+ * Extracted from {@see \App\MessageHandler\GenerateStagesHandler} (ADR-043) so the
+ * exact same pacing — including the Komoot-collection multi-track case — can run both:
+ *  - synchronously in {@see GpxUploadService} (the GPX upload is fully local CPU work),
+ *  - asynchronously in the link/AI path that still needs a network fetch first.
+ *
+ * Pure in-memory CPU: no DB write, no network. The caller persists and publishes.
+ */
+final readonly class StructuralComputationService
+{
+    public function __construct(
+        private TripRequestRepositoryInterface $tripStateManager,
+        private DistanceCalculatorInterface $distanceCalculator,
+        private ElevationCalculatorInterface $elevationCalculator,
+        private RouteSimplifierInterface $routeSimplifier,
+        private PacingEngineInterface $pacingEngine,
+    ) {
+    }
+
+    /**
+     * Computes the stages for a trip from its stored route data.
+     *
+     * Routes the Komoot-collection source type to per-track stage generation and
+     * everything else to the fatigue-aware pacing engine, preserving the exact
+     * behaviour previously inlined in {@see \App\MessageHandler\GenerateStagesHandler}.
+     *
+     * @return list<Stage>
+     */
+    public function generateStages(string $tripId, TripRequest $request): array
+    {
+        $sourceType = $this->tripStateManager->getSourceType($tripId);
+
+        if ($sourceType === SourceType::KOMOOT_COLLECTION->value) {
+            return $this->generateCollectionStages($tripId);
+        }
+
+        return $this->generatePacingStages($tripId, $request);
+    }
+
+    /**
+     * Serializes stages into the `stages_computed` Mercure event payload shape.
+     *
+     * Shared by both structural callers (GPX upload service and the link handler)
+     * so the wire format stays single-sourced.
+     *
+     * @param list<Stage> $stages
+     *
+     * @return list<array<string, mixed>>
+     */
+    public function serializeStagesForEvent(array $stages): array
+    {
+        return array_map(
+            static fn (Stage $s): array => [
+                'dayNumber' => $s->dayNumber,
+                'distance' => round($s->distance, 1),
+                'elevation' => (int) $s->elevation,
+                'elevationLoss' => (int) $s->elevationLoss,
+                'startPoint' => [
+                    'lat' => $s->startPoint->lat,
+                    'lon' => $s->startPoint->lon,
+                    'ele' => $s->startPoint->ele,
+                ],
+                'endPoint' => [
+                    'lat' => $s->endPoint->lat,
+                    'lon' => $s->endPoint->lon,
+                    'ele' => $s->endPoint->ele,
+                ],
+                'label' => $s->label,
+                'geometry' => array_map(
+                    static fn (Coordinate $c): array => ['lat' => $c->lat, 'lon' => $c->lon, 'ele' => $c->ele],
+                    $s->geometry,
+                ),
+            ],
+            $stages,
+        );
+    }
+
+    /** @return list<Stage> */
+    private function generateCollectionStages(string $tripId): array
+    {
+        $tracksData = $this->tripStateManager->getTracksData($tripId);
+
+        if (null === $tracksData) {
+            return [];
+        }
+
+        $stages = [];
+
+        foreach ($tracksData as $i => $trackData) {
+            $points = array_map(
+                static fn (array $p): Coordinate => new Coordinate($p['lat'], $p['lon'], $p['ele']),
+                $trackData,
+            );
+
+            if ([] === $points) {
+                continue;
+            }
+
+            $distance = $this->distanceCalculator->calculateTotalDistance($points);
+            $elevation = $this->elevationCalculator->calculateTotalAscent($points);
+            $elevationLoss = $this->elevationCalculator->calculateTotalDescent($points);
+            $geometry = $this->routeSimplifier->simplify($points);
+
+            $stages[] = new Stage(
+                tripId: $tripId,
+                dayNumber: $i + 1,
+                distance: $distance,
+                elevation: $elevation,
+                startPoint: $points[0],
+                endPoint: $points[\count($points) - 1],
+                geometry: $geometry,
+                elevationLoss: $elevationLoss,
+            );
+        }
+
+        return $stages;
+    }
+
+    /**
+     * @return list<Stage>
+     */
+    private function generatePacingStages(string $tripId, TripRequest $request): array
+    {
+        $decimatedData = $this->tripStateManager->getDecimatedPoints($tripId);
+
+        if (null === $decimatedData) {
+            return [];
+        }
+
+        $decimatedPoints = array_map(
+            static fn (array $p): Coordinate => new Coordinate($p['lat'], $p['lon'], $p['ele']),
+            $decimatedData,
+        );
+
+        $allPointsData = $this->tripStateManager->getRawPoints($tripId);
+        $allPoints = null !== $allPointsData
+            ? array_map(static fn (array $p): Coordinate => new Coordinate($p['lat'], $p['lon'], $p['ele']), $allPointsData)
+            : $decimatedPoints;
+
+        $totalDistance = $this->distanceCalculator->calculateTotalDistance($allPoints);
+
+        if ($request->endDate instanceof \DateTimeImmutable && $request->startDate instanceof \DateTimeImmutable) {
+            $numberOfDays = (int) $request->startDate->diff($request->endDate)->days + 1;
+        } else {
+            $numberOfDays = (int) ceil($totalDistance / $request->maxDistancePerDay);
+            $numberOfDays = max(1, $numberOfDays);
+        }
+
+        // Pass raw points for accurate elevation calculation (decimated points lose altitude detail).
+        // rawPoints is null when no full-resolution data was loaded (e.g. routing-only trips),
+        // in which case the pacing engine falls back to decimated points.
+        $rawPoints = null !== $allPointsData ? $allPoints : null;
+
+        return $this->pacingEngine->generateStages(
+            $tripId,
+            $decimatedPoints,
+            $numberOfDays,
+            $totalDistance,
+            $request->fatigueFactor,
+            $request->elevationPenalty,
+            $rawPoints,
+            $request->maxDistancePerDay,
+        );
+    }
+}

--- a/api/src/State/TripDetailProvider.php
+++ b/api/src/State/TripDetailProvider.php
@@ -86,6 +86,9 @@ final readonly class TripDetailProvider implements ProviderInterface
             enabledAccommodationTypes: $request->enabledAccommodationTypes,
             isLocked: $this->tripLocker->isLocked($request),
             outOfZone: $this->coverageRepository->isRouteOutOfZone($this->routePoints($stages)),
+            // Fallback for trips persisted before the status column existed: infer
+            // readiness from whether stages are present.
+            status: '' !== $request->status ? $request->status : ([] !== $stages ? 'ready' : 'draft'),
             stages: array_map($this->serializeStage(...), $stages, $cycleNetwork),
         );
     }

--- a/api/src/State/TripDetailProvider.php
+++ b/api/src/State/TripDetailProvider.php
@@ -14,6 +14,7 @@ use App\ApiResource\Model\WeatherForecast;
 use App\ApiResource\Stage;
 use App\ApiResource\TripDetail;
 use App\ApiResource\TripRequest;
+use App\Enum\TripStatus;
 use App\Osm\CoverageRepositoryInterface;
 use App\Osm\CycleRouteRepositoryInterface;
 use App\Repository\DoctrineTripRequestRepository;
@@ -88,7 +89,7 @@ final readonly class TripDetailProvider implements ProviderInterface
             outOfZone: $this->coverageRepository->isRouteOutOfZone($this->routePoints($stages)),
             // Fallback for trips persisted before the status column existed: infer
             // readiness from whether stages are present.
-            status: '' !== $request->status ? $request->status : ([] !== $stages ? 'ready' : 'draft'),
+            status: '' !== $request->status ? $request->status : ([] !== $stages ? TripStatus::READY->value : TripStatus::DRAFT->value),
             stages: array_map($this->serializeStage(...), $stages, $cycleNetwork),
         );
     }

--- a/api/tests/Functional/GpxUploadTest.php
+++ b/api/tests/Functional/GpxUploadTest.php
@@ -8,10 +8,14 @@ use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
 use ApiPlatform\Symfony\Bundle\Test\Client;
 use App\Controller\GpxUploadController;
 use App\Enum\ComputationName;
+use App\Message\AnalyzeTerrain;
+use App\Message\FetchWeather;
 use App\Message\GenerateStages;
+use App\Message\ScanPois;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport;
 
 final class GpxUploadTest extends ApiTestCase
@@ -79,9 +83,18 @@ final class GpxUploadTest extends ApiTestCase
         $this->assertArrayHasKey('totalElevationLoss', $data);
         $this->assertIsInt($data['totalElevationLoss']);
 
-        // Other computations should be pending
+        // ADR-043: stages are computed synchronously, so the structural pipeline
+        // (route + stages) is already done and the response carries status + stages.
+        $this->assertSame('done', $data['computationStatus']['stages']);
+        $this->assertArrayHasKey('status', $data);
+        $this->assertContains($data['status'], ['draft', 'ready']);
+        $this->assertArrayHasKey('stages', $data);
+        $this->assertIsArray($data['stages']);
+
+        // Enrichment computations (everything but the structural pipeline) stay pending.
+        $structural = ComputationName::structuralPipeline();
         foreach (ComputationName::pipeline() as $computation) {
-            if (ComputationName::ROUTE === $computation) {
+            if (\in_array($computation, $structural, true)) {
                 continue;
             }
 
@@ -91,7 +104,40 @@ final class GpxUploadTest extends ApiTestCase
     }
 
     #[Test]
-    public function uploadDispatchesDownstreamMessages(): void
+    public function uploadLongRouteIsReadyWithStages(): void
+    {
+        // A ~100km route splits into >= 2 stages (30km minimum per stage), so the
+        // synchronously computed trip reaches the structural `ready` status.
+        $file = new UploadedFile(
+            self::FIXTURES_DIR.'/multi-stage-route.gpx',
+            'multi-stage-route.gpx',
+            'application/gpx+xml',
+            null,
+            true,
+        );
+
+        $response = $this->client->request('POST', '/trips/gpx-upload', [
+            'headers' => array_merge(['Content-Type' => 'multipart/form-data'], $this->authHeader($this->jwtToken)),
+            'extra' => [
+                'files' => ['gpxFile' => $file],
+            ],
+        ]);
+
+        $this->assertResponseStatusCodeSame(202);
+
+        $data = $response->toArray(false);
+        $this->assertSame('ready', $data['status']);
+        $this->assertGreaterThanOrEqual(2, \count($data['stages']));
+        $this->assertSame('done', $data['computationStatus']['stages']);
+
+        $firstStage = $data['stages'][0];
+        $this->assertArrayHasKey('dayNumber', $firstStage);
+        $this->assertArrayHasKey('distance', $firstStage);
+        $this->assertArrayHasKey('geometry', $firstStage);
+    }
+
+    #[Test]
+    public function uploadDispatchesEnrichmentMessagesNotStageGeneration(): void
     {
         $file = new UploadedFile(
             self::FIXTURES_DIR.'/valid-route.gpx',
@@ -112,10 +158,17 @@ final class GpxUploadTest extends ApiTestCase
 
         /** @var InMemoryTransport $transport */
         $transport = self::getContainer()->get('messenger.transport.async');
-        $sentMessages = $transport->getSent();
+        $dispatched = array_map(
+            static fn (Envelope $envelope): string => $envelope->getMessage()::class,
+            $transport->getSent(),
+        );
 
-        $this->assertCount(1, $sentMessages);
-        $this->assertInstanceOf(GenerateStages::class, $sentMessages[0]->getMessage());
+        // ADR-043: stage generation now runs synchronously, so GenerateStages is no
+        // longer dispatched; instead the async enrichment fan-out is dispatched directly.
+        $this->assertNotContains(GenerateStages::class, $dispatched);
+        $this->assertContains(ScanPois::class, $dispatched);
+        $this->assertContains(FetchWeather::class, $dispatched);
+        $this->assertContains(AnalyzeTerrain::class, $dispatched);
     }
 
     #[Test]

--- a/api/tests/Functional/TripDetailTest.php
+++ b/api/tests/Functional/TripDetailTest.php
@@ -32,6 +32,12 @@ final class TripDetailTest extends ApiTestCase
     private string $jwtToken;
 
     #[\Override]
+    public static function setUpBeforeClass(): void
+    {
+        self::$alwaysBootKernel = false;
+    }
+
+    #[\Override]
     protected function setUp(): void
     {
         $this->client = self::createClient();

--- a/api/tests/Functional/TripDetailTest.php
+++ b/api/tests/Functional/TripDetailTest.php
@@ -12,6 +12,7 @@ use App\ApiResource\TripRequest;
 use App\Entity\User;
 use App\Repository\DoctrineTripRequestRepository;
 use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\Attributes\Test;
 use Zenstruck\Foundry\Attribute\ResetDatabase;
 use Zenstruck\Foundry\Test\Factories;
@@ -66,6 +67,7 @@ final class TripDetailTest extends ApiTestCase
             geometry: [new Coordinate(45.0, 6.0, 1000.0)],
         );
         $repo->storeStages(self::TRIP_ID, [$stage]);
+        $repo->storeStatus(self::TRIP_ID, 'ready');
 
         $response = $this->client->request('GET', \sprintf('/trips/%s/detail', self::TRIP_ID), [
             'headers' => array_merge(['Accept' => 'application/ld+json'], $this->authHeader($this->jwtToken)),
@@ -76,6 +78,8 @@ final class TripDetailTest extends ApiTestCase
         $data = $response->toArray(false);
         $this->assertSame(self::TRIP_ID, $data['id']);
         $this->assertArrayHasKey('stages', $data);
+        $this->assertArrayHasKey('status', $data);
+        $this->assertSame('ready', $data['status']);
         $this->assertArrayHasKey('fatigueFactor', $data);
         $this->assertArrayHasKey('enabledAccommodationTypes', $data);
         // Coverage polygon is unprovisioned in the test DB, so a valid trip is in zone.
@@ -91,6 +95,55 @@ final class TripDetailTest extends ApiTestCase
         // No cycle routes provisioned in the test DB → stage is not on a network.
         $this->assertArrayHasKey('onCycleNetwork', $stage);
         $this->assertEqualsWithDelta(0.0, $stage['onCycleNetwork'], 0.0001);
+    }
+
+    #[Test]
+    public function detailExposesDraftStatusForTripWithoutStages(): void
+    {
+        // A freshly initialized trip with no stages keeps the default `draft` status.
+        $this->seedTrip(self::TRIP_ID);
+
+        $response = $this->client->request('GET', \sprintf('/trips/%s/detail', self::TRIP_ID), [
+            'headers' => array_merge(['Accept' => 'application/ld+json'], $this->authHeader($this->jwtToken)),
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSame('draft', $response->toArray(false)['status']);
+    }
+
+    #[Test]
+    public function detailFallsBackToReadyForLegacyTripWithStagesAndEmptyStatus(): void
+    {
+        // Simulates a trip persisted before the status column existed: status is blank
+        // in DB, so the provider infers readiness from the presence of stages.
+        $repo = $this->seedTrip(self::TRIP_ID);
+
+        $stage = new StageDto(
+            tripId: self::TRIP_ID,
+            dayNumber: 1,
+            distance: 40.0,
+            elevation: 300.0,
+            startPoint: new Coordinate(48.5, 3.0, 0.0),
+            endPoint: new Coordinate(48.6, 3.1, 0.0),
+        );
+        $repo->storeStages(self::TRIP_ID, [$stage]);
+
+        $connection = self::getContainer()->get('doctrine.dbal.default_connection');
+        \assert($connection instanceof Connection);
+        $connection->executeStatement("UPDATE trip SET status = '' WHERE id = :id", ['id' => self::TRIP_ID]);
+
+        // Drop the Doctrine identity map so the provider re-reads the blanked status
+        // from the DB instead of returning the still-managed entity (status='draft').
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+        $em->clear();
+
+        $response = $this->client->request('GET', \sprintf('/trips/%s/detail', self::TRIP_ID), [
+            'headers' => array_merge(['Accept' => 'application/ld+json'], $this->authHeader($this->jwtToken)),
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSame('ready', $response->toArray(false)['status']);
     }
 
     #[Test]

--- a/api/tests/Integration/LlmPipelineTest.php
+++ b/api/tests/Integration/LlmPipelineTest.php
@@ -472,6 +472,10 @@ final class InMemoryTripRequestRepository implements TripRequestRepositoryInterf
         return null;
     }
 
+    public function storeStatus(string $tripId, string $status): void
+    {
+    }
+
     public function storeLocale(string $tripId, string $locale): void
     {
     }

--- a/api/tests/Unit/MessageHandler/GenerateStagesHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/GenerateStagesHandlerTest.php
@@ -14,11 +14,13 @@ use App\Engine\ElevationCalculatorInterface;
 use App\Engine\PacingEngineInterface;
 use App\Engine\RouteSimplifierInterface;
 use App\Enum\SourceType;
+use App\Enum\TripStatus;
 use App\Mercure\MercureEventType;
 use App\Mercure\TripUpdatePublisherInterface;
 use App\Message\GenerateStages;
 use App\MessageHandler\GenerateStagesHandler;
 use App\Repository\TripRequestRepositoryInterface;
+use App\Service\StructuralComputationService;
 use App\Service\TripAnalysisDispatcher;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -28,10 +30,24 @@ use Symfony\Component\Messenger\MessageBusInterface;
 
 final class GenerateStagesHandlerTest extends TestCase
 {
+    private function structuralComputation(
+        TripRequestRepositoryInterface $tripStateManager,
+        PacingEngineInterface $pacingEngine,
+        ?DistanceCalculatorInterface $distanceCalculator = null,
+    ): StructuralComputationService {
+        return new StructuralComputationService(
+            $tripStateManager,
+            $distanceCalculator ?? $this->createStub(DistanceCalculatorInterface::class),
+            $this->createStub(ElevationCalculatorInterface::class),
+            $this->createStub(RouteSimplifierInterface::class),
+            $pacingEngine,
+        );
+    }
+
     private function createHandler(
         TripRequestRepositoryInterface $tripStateManager,
         TripUpdatePublisherInterface $publisher,
-        PacingEngineInterface $pacingEngine,
+        StructuralComputationService $structuralComputation,
         MessageBusInterface $messageBus,
     ): GenerateStagesHandler {
         $computationTracker = $this->createStub(ComputationTrackerInterface::class);
@@ -45,10 +61,7 @@ final class GenerateStagesHandlerTest extends TestCase
             $generationTracker,
             new NullLogger(),
             $tripStateManager,
-            $this->createStub(DistanceCalculatorInterface::class),
-            $this->createStub(ElevationCalculatorInterface::class),
-            $this->createStub(RouteSimplifierInterface::class),
-            $pacingEngine,
+            $structuralComputation,
             new TripAnalysisDispatcher($messageBus),
             $messageBus,
         );
@@ -107,22 +120,10 @@ final class GenerateStagesHandlerTest extends TestCase
                 }),
             );
 
-        $computationTracker = $this->createStub(ComputationTrackerInterface::class);
-        $computationTracker->method('getProgress')->willReturn(['completed' => 0, 'failed' => 0, 'total' => 1]);
-
-        $generationTracker = $this->createStub(TripGenerationTrackerInterface::class);
-
-        $handler = new GenerateStagesHandler(
-            $computationTracker,
-            $publisher,
-            $generationTracker,
-            new NullLogger(),
+        $handler = $this->createHandler(
             $tripStateManager,
-            $distanceCalculator,
-            $this->createStub(ElevationCalculatorInterface::class),
-            $this->createStub(RouteSimplifierInterface::class),
-            $pacingEngine,
-            new TripAnalysisDispatcher($messageBus),
+            $publisher,
+            $this->structuralComputation($tripStateManager, $pacingEngine, $distanceCalculator),
             $messageBus,
         );
 
@@ -175,22 +176,113 @@ final class GenerateStagesHandlerTest extends TestCase
 
         $publisher = $this->createStub(TripUpdatePublisherInterface::class);
 
-        $computationTracker = $this->createStub(ComputationTrackerInterface::class);
-        $computationTracker->method('getProgress')->willReturn(['completed' => 0, 'failed' => 0, 'total' => 1]);
-
-        $generationTracker = $this->createStub(TripGenerationTrackerInterface::class);
-
-        $handler = new GenerateStagesHandler(
-            $computationTracker,
-            $publisher,
-            $generationTracker,
-            new NullLogger(),
+        $handler = $this->createHandler(
             $tripStateManager,
-            $distanceCalculator,
-            $this->createStub(ElevationCalculatorInterface::class),
-            $this->createStub(RouteSimplifierInterface::class),
-            $pacingEngine,
-            new TripAnalysisDispatcher($messageBus),
+            $publisher,
+            $this->structuralComputation($tripStateManager, $pacingEngine, $distanceCalculator),
+            $messageBus,
+        );
+
+        $handler(new GenerateStages('trip-1'));
+    }
+
+    #[Test]
+    public function postsReadyStatusAfterStoringStages(): void
+    {
+        $coordinate = new Coordinate(48.8566, 2.3522, 35.0);
+
+        $stage = new Stage(
+            tripId: 'trip-1',
+            dayNumber: 1,
+            distance: 80.0,
+            elevation: 500.0,
+            startPoint: $coordinate,
+            endPoint: $coordinate,
+            geometry: [$coordinate],
+        );
+
+        $tripRequest = new TripRequest();
+
+        $tripStateManager = $this->createMock(TripRequestRepositoryInterface::class);
+        $tripStateManager->method('getRequest')->willReturn($tripRequest);
+        $tripStateManager->method('getSourceType')->willReturn(SourceType::KOMOOT_TOUR->value);
+        $tripStateManager->method('getDecimatedPoints')->willReturn([
+            ['lat' => 48.8566, 'lon' => 2.3522, 'ele' => 35.0],
+            ['lat' => 49.0, 'lon' => 2.5, 'ele' => 50.0],
+        ]);
+        $tripStateManager->method('getRawPoints')->willReturn(null);
+
+        // Status must be posted to `ready` once at least MIN_STAGES stages are stored.
+        $tripStateManager->expects($this->once())
+            ->method('storeStatus')
+            ->with('trip-1', TripStatus::READY->value);
+
+        $pacingEngine = $this->createStub(PacingEngineInterface::class);
+        $pacingEngine->method('generateStages')->willReturn([$stage, $stage]);
+
+        $distanceCalculator = $this->createStub(DistanceCalculatorInterface::class);
+        $distanceCalculator->method('calculateTotalDistance')->willReturn(80.0);
+
+        $messageBus = $this->createStub(MessageBusInterface::class);
+        $messageBus->method('dispatch')->willReturn(new Envelope(new \stdClass()));
+
+        $publisher = $this->createStub(TripUpdatePublisherInterface::class);
+
+        $handler = $this->createHandler(
+            $tripStateManager,
+            $publisher,
+            $this->structuralComputation($tripStateManager, $pacingEngine, $distanceCalculator),
+            $messageBus,
+        );
+
+        $handler(new GenerateStages('trip-1'));
+    }
+
+    #[Test]
+    public function doesNotPostReadyStatusWhenBelowMinStages(): void
+    {
+        $coordinate = new Coordinate(48.8566, 2.3522, 35.0);
+
+        $stage = new Stage(
+            tripId: 'trip-1',
+            dayNumber: 1,
+            distance: 80.0,
+            elevation: 500.0,
+            startPoint: $coordinate,
+            endPoint: $coordinate,
+            geometry: [$coordinate],
+        );
+
+        $tripRequest = new TripRequest();
+
+        $tripStateManager = $this->createMock(TripRequestRepositoryInterface::class);
+        $tripStateManager->method('getRequest')->willReturn($tripRequest);
+        $tripStateManager->method('getSourceType')->willReturn(SourceType::KOMOOT_TOUR->value);
+        $tripStateManager->method('getDecimatedPoints')->willReturn([
+            ['lat' => 48.8566, 'lon' => 2.3522, 'ele' => 35.0],
+        ]);
+        $tripStateManager->method('getRawPoints')->willReturn(null);
+
+        $tripStateManager->expects($this->never())->method('storeStatus');
+
+        $pacingEngine = $this->createStub(PacingEngineInterface::class);
+        $pacingEngine->method('generateStages')->willReturn([$stage]); // single stage → below MIN_STAGES
+
+        $distanceCalculator = $this->createStub(DistanceCalculatorInterface::class);
+        $distanceCalculator->method('calculateTotalDistance')->willReturn(20.0);
+
+        $messageBus = $this->createStub(MessageBusInterface::class);
+        $messageBus->method('dispatch')->willReturn(new Envelope(new \stdClass()));
+
+        $publisher = $this->createMock(TripUpdatePublisherInterface::class);
+        $publisher->expects($this->once())
+            ->method('publishValidationError')
+            ->with('trip-1', 'MIN_STAGES', $this->anything());
+
+        $handler = $this->createHandler(
+            $tripStateManager,
+            $publisher,
+            $this->structuralComputation($tripStateManager, $pacingEngine, $distanceCalculator),
             $messageBus,
         );
 
@@ -211,7 +303,7 @@ final class GenerateStagesHandlerTest extends TestCase
         $handler = $this->createHandler(
             $tripStateManager,
             $publisher,
-            $this->createStub(PacingEngineInterface::class),
+            $this->structuralComputation($tripStateManager, $this->createStub(PacingEngineInterface::class)),
             $messageBus,
         );
 

--- a/api/tests/Unit/Repository/DoctrineTripRequestRepositoryTest.php
+++ b/api/tests/Unit/Repository/DoctrineTripRequestRepositoryTest.php
@@ -533,6 +533,36 @@ final class DoctrineTripRequestRepositoryTest extends TestCase
     }
 
     #[Test]
+    public function storeStatus(): void
+    {
+        $tripId = Uuid::v7()->toRfc4122();
+        $trip = new TripRequest(Uuid::fromString($tripId));
+
+        self::assertSame('draft', $trip->status);
+
+        $this->entityManager->method('find')
+            ->willReturn($trip);
+        $this->entityManager->expects(self::once())
+            ->method('flush');
+
+        $this->repository->storeStatus($tripId, 'ready');
+        self::assertSame('ready', $trip->status);
+    }
+
+    #[Test]
+    public function storeStatusIgnoresNonExistentTrip(): void
+    {
+        $tripId = Uuid::v7()->toRfc4122();
+
+        $this->entityManager->method('find')
+            ->willReturn(null);
+        $this->entityManager->expects(self::never())
+            ->method('flush');
+
+        $this->repository->storeStatus($tripId, 'ready');
+    }
+
+    #[Test]
     public function storeStagesIgnoresNonExistentTrip(): void
     {
         $tripId = Uuid::v7()->toRfc4122();

--- a/api/tests/Unit/Service/StructuralComputationServiceTest.php
+++ b/api/tests/Unit/Service/StructuralComputationServiceTest.php
@@ -1,0 +1,270 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service;
+
+use App\ApiResource\Model\Coordinate;
+use App\ApiResource\Stage;
+use App\ApiResource\TripRequest;
+use App\Engine\DistanceCalculatorInterface;
+use App\Engine\ElevationCalculatorInterface;
+use App\Engine\PacingEngineInterface;
+use App\Engine\RouteSimplifierInterface;
+use App\Enum\SourceType;
+use App\Repository\TripRequestRepositoryInterface;
+use App\Service\StructuralComputationService;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class StructuralComputationServiceTest extends TestCase
+{
+    #[Test]
+    public function pacingPathDelegatesToPacingEngineWithProfileSettings(): void
+    {
+        $coordinate = new Coordinate(48.8566, 2.3522, 35.0);
+
+        $request = new TripRequest();
+        $request->maxDistancePerDay = 45.0;
+        $request->fatigueFactor = 0.85;
+        $request->elevationPenalty = 40.0;
+
+        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
+        $tripStateManager->method('getSourceType')->willReturn(SourceType::KOMOOT_TOUR->value);
+        $tripStateManager->method('getDecimatedPoints')->willReturn([
+            ['lat' => 48.8566, 'lon' => 2.3522, 'ele' => 35.0],
+            ['lat' => 49.0, 'lon' => 2.5, 'ele' => 50.0],
+        ]);
+        $tripStateManager->method('getRawPoints')->willReturn(null);
+
+        $distanceCalculator = $this->createStub(DistanceCalculatorInterface::class);
+        $distanceCalculator->method('calculateTotalDistance')->willReturn(142.0);
+
+        $expected = [
+            new Stage(tripId: 'trip-1', dayNumber: 1, distance: 40.0, elevation: 100.0, startPoint: $coordinate, endPoint: $coordinate),
+            new Stage(tripId: 'trip-1', dayNumber: 2, distance: 40.0, elevation: 100.0, startPoint: $coordinate, endPoint: $coordinate),
+        ];
+
+        $pacingEngine = $this->createMock(PacingEngineInterface::class);
+        $pacingEngine->expects($this->once())
+            ->method('generateStages')
+            ->with(
+                'trip-1',
+                $this->anything(),
+                4, // ceil(142/45)
+                142.0,
+                0.85,
+                40.0,
+                null, // rawPoints null when no full-resolution data
+                45.0,
+            )
+            ->willReturn($expected);
+
+        $service = new StructuralComputationService(
+            $tripStateManager,
+            $distanceCalculator,
+            $this->createStub(ElevationCalculatorInterface::class),
+            $this->createStub(RouteSimplifierInterface::class),
+            $pacingEngine,
+        );
+
+        self::assertSame($expected, $service->generateStages('trip-1', $request));
+    }
+
+    #[Test]
+    public function pacingPathUsesDateRangeForNumberOfDays(): void
+    {
+        $coordinate = new Coordinate(48.8566, 2.3522, 35.0);
+
+        $request = new TripRequest();
+        $request->startDate = new \DateTimeImmutable('2026-07-01');
+        $request->endDate = new \DateTimeImmutable('2026-07-03'); // 3 days inclusive
+
+        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
+        $tripStateManager->method('getSourceType')->willReturn(SourceType::GPX_UPLOAD->value);
+        $tripStateManager->method('getDecimatedPoints')->willReturn([
+            ['lat' => 48.8566, 'lon' => 2.3522, 'ele' => 35.0],
+            ['lat' => 49.0, 'lon' => 2.5, 'ele' => 50.0],
+        ]);
+        $tripStateManager->method('getRawPoints')->willReturn([
+            ['lat' => 48.8566, 'lon' => 2.3522, 'ele' => 35.0],
+            ['lat' => 49.0, 'lon' => 2.5, 'ele' => 50.0],
+        ]);
+
+        $distanceCalculator = $this->createStub(DistanceCalculatorInterface::class);
+        $distanceCalculator->method('calculateTotalDistance')->willReturn(200.0);
+
+        $pacingEngine = $this->createMock(PacingEngineInterface::class);
+        $pacingEngine->expects($this->once())
+            ->method('generateStages')
+            ->with(
+                'trip-1',
+                $this->anything(),
+                3, // from the date range, not the distance
+                200.0,
+                $this->anything(),
+                $this->anything(),
+                $this->isArray(), // rawPoints passed through
+                $this->anything(),
+            )
+            ->willReturn([
+                new Stage(tripId: 'trip-1', dayNumber: 1, distance: 70.0, elevation: 100.0, startPoint: $coordinate, endPoint: $coordinate),
+            ]);
+
+        $service = new StructuralComputationService(
+            $tripStateManager,
+            $distanceCalculator,
+            $this->createStub(ElevationCalculatorInterface::class),
+            $this->createStub(RouteSimplifierInterface::class),
+            $pacingEngine,
+        );
+
+        $service->generateStages('trip-1', $request);
+    }
+
+    #[Test]
+    public function collectionPathBuildsOneStagePerTrack(): void
+    {
+        $request = new TripRequest();
+
+        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
+        $tripStateManager->method('getSourceType')->willReturn(SourceType::KOMOOT_COLLECTION->value);
+        $tripStateManager->method('getTracksData')->willReturn([
+            // Track 1
+            [
+                ['lat' => 48.0, 'lon' => 2.0, 'ele' => 10.0],
+                ['lat' => 48.5, 'lon' => 2.5, 'ele' => 20.0],
+            ],
+            // Track 2
+            [
+                ['lat' => 49.0, 'lon' => 3.0, 'ele' => 30.0],
+                ['lat' => 49.5, 'lon' => 3.5, 'ele' => 40.0],
+            ],
+        ]);
+
+        $distanceCalculator = $this->createStub(DistanceCalculatorInterface::class);
+        $distanceCalculator->method('calculateTotalDistance')->willReturn(60.0);
+
+        $elevationCalculator = $this->createStub(ElevationCalculatorInterface::class);
+        $elevationCalculator->method('calculateTotalAscent')->willReturn(120.0);
+        $elevationCalculator->method('calculateTotalDescent')->willReturn(80.0);
+
+        $routeSimplifier = $this->createStub(RouteSimplifierInterface::class);
+        $routeSimplifier->method('simplify')->willReturnArgument(0);
+
+        // The pacing engine must NOT be used on the collection path.
+        $pacingEngine = $this->createMock(PacingEngineInterface::class);
+        $pacingEngine->expects($this->never())->method('generateStages');
+
+        $service = new StructuralComputationService(
+            $tripStateManager,
+            $distanceCalculator,
+            $elevationCalculator,
+            $routeSimplifier,
+            $pacingEngine,
+        );
+
+        $stages = $service->generateStages('trip-1', $request);
+
+        self::assertCount(2, $stages);
+        self::assertSame(1, $stages[0]->dayNumber);
+        self::assertSame(2, $stages[1]->dayNumber);
+        self::assertSame(60.0, $stages[0]->distance);
+        self::assertSame(120.0, $stages[0]->elevation);
+        self::assertSame(80.0, $stages[0]->elevationLoss);
+        // start/end derived from the track's first/last points
+        self::assertSame(48.0, $stages[0]->startPoint->lat);
+        self::assertSame(48.5, $stages[0]->endPoint->lat);
+        self::assertSame(49.0, $stages[1]->startPoint->lat);
+        self::assertSame(49.5, $stages[1]->endPoint->lat);
+    }
+
+    #[Test]
+    public function collectionPathSkipsEmptyTracks(): void
+    {
+        $request = new TripRequest();
+
+        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
+        $tripStateManager->method('getSourceType')->willReturn(SourceType::KOMOOT_COLLECTION->value);
+        $tripStateManager->method('getTracksData')->willReturn([
+            [],
+            [
+                ['lat' => 49.0, 'lon' => 3.0, 'ele' => 30.0],
+                ['lat' => 49.5, 'lon' => 3.5, 'ele' => 40.0],
+            ],
+        ]);
+
+        $distanceCalculator = $this->createStub(DistanceCalculatorInterface::class);
+        $distanceCalculator->method('calculateTotalDistance')->willReturn(30.0);
+        $elevationCalculator = $this->createStub(ElevationCalculatorInterface::class);
+        $routeSimplifier = $this->createStub(RouteSimplifierInterface::class);
+        $routeSimplifier->method('simplify')->willReturnArgument(0);
+
+        $service = new StructuralComputationService(
+            $tripStateManager,
+            $distanceCalculator,
+            $elevationCalculator,
+            $routeSimplifier,
+            $this->createStub(PacingEngineInterface::class),
+        );
+
+        $stages = $service->generateStages('trip-1', $request);
+
+        self::assertCount(1, $stages);
+        // dayNumber keeps the original track index (i + 1), the empty track is skipped.
+        self::assertSame(2, $stages[0]->dayNumber);
+    }
+
+    #[Test]
+    public function returnsEmptyWhenNoDecimatedPoints(): void
+    {
+        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
+        $tripStateManager->method('getSourceType')->willReturn(SourceType::KOMOOT_TOUR->value);
+        $tripStateManager->method('getDecimatedPoints')->willReturn(null);
+
+        $service = new StructuralComputationService(
+            $tripStateManager,
+            $this->createStub(DistanceCalculatorInterface::class),
+            $this->createStub(ElevationCalculatorInterface::class),
+            $this->createStub(RouteSimplifierInterface::class),
+            $this->createStub(PacingEngineInterface::class),
+        );
+
+        self::assertSame([], $service->generateStages('trip-1', new TripRequest()));
+    }
+
+    #[Test]
+    public function serializeStagesForEventRoundsAndFlattensCoordinates(): void
+    {
+        $service = new StructuralComputationService(
+            $this->createStub(TripRequestRepositoryInterface::class),
+            $this->createStub(DistanceCalculatorInterface::class),
+            $this->createStub(ElevationCalculatorInterface::class),
+            $this->createStub(RouteSimplifierInterface::class),
+            $this->createStub(PacingEngineInterface::class),
+        );
+
+        $stage = new Stage(
+            tripId: 'trip-1',
+            dayNumber: 1,
+            distance: 80.456,
+            elevation: 512.7,
+            startPoint: new Coordinate(48.8566, 2.3522, 35.0),
+            endPoint: new Coordinate(49.0, 2.5, 50.0),
+            geometry: [new Coordinate(48.8566, 2.3522, 35.0)],
+            label: 'Etape 1',
+            elevationLoss: 200.9,
+        );
+
+        $payload = $service->serializeStagesForEvent([$stage]);
+
+        self::assertCount(1, $payload);
+        self::assertSame(1, $payload[0]['dayNumber']);
+        self::assertSame(80.5, $payload[0]['distance']);
+        self::assertSame(512, $payload[0]['elevation']);
+        self::assertSame(200, $payload[0]['elevationLoss']);
+        self::assertSame('Etape 1', $payload[0]['label']);
+        self::assertSame(['lat' => 48.8566, 'lon' => 2.3522, 'ele' => 35.0], $payload[0]['startPoint']);
+        self::assertSame([['lat' => 48.8566, 'lon' => 2.3522, 'ele' => 35.0]], $payload[0]['geometry']);
+    }
+}

--- a/api/tests/Unit/State/TripShareShortCodeProviderTest.php
+++ b/api/tests/Unit/State/TripShareShortCodeProviderTest.php
@@ -61,6 +61,7 @@ final class TripShareShortCodeProviderTest extends TestCase
             enabledAccommodationTypes: [],
             isLocked: false,
             outOfZone: false,
+            status: 'ready',
             stages: [],
         );
         $this->tripDetailProvider->expects($this->once())->method('provide')->willReturn($detail);

--- a/api/tests/fixtures/multi-stage-route.gpx
+++ b/api/tests/fixtures/multi-stage-route.gpx
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.1" creator="bike-trip-planner-tests" xmlns="http://www.topografix.com/GPX/1/1">
+  <metadata>
+    <name>Multi Stage Route</name>
+  </metadata>
+  <trk>
+    <name>Multi Stage Route</name>
+    <trkseg>
+      <trkpt lat="45.0000" lon="5.0000"><ele>300</ele></trkpt>
+      <trkpt lat="45.1000" lon="5.0500"><ele>320</ele></trkpt>
+      <trkpt lat="45.2000" lon="5.0000"><ele>340</ele></trkpt>
+      <trkpt lat="45.3000" lon="5.0500"><ele>360</ele></trkpt>
+      <trkpt lat="45.4000" lon="5.0000"><ele>380</ele></trkpt>
+      <trkpt lat="45.5000" lon="5.0500"><ele>400</ele></trkpt>
+      <trkpt lat="45.6000" lon="5.0000"><ele>420</ele></trkpt>
+      <trkpt lat="45.7000" lon="5.0500"><ele>440</ele></trkpt>
+      <trkpt lat="45.8000" lon="5.0000"><ele>460</ele></trkpt>
+      <trkpt lat="45.9000" lon="5.0500"><ele>480</ele></trkpt>
+      <trkpt lat="46.0000" lon="5.0000"><ele>500</ele></trkpt>
+    </trkseg>
+  </trk>
+</gpx>

--- a/pwa/src/lib/api/schema.d.ts
+++ b/pwa/src/lib/api/schema.d.ts
@@ -1538,6 +1538,11 @@ export interface components {
             isLocked?: boolean;
             /** @description True when the route falls outside the provisioned coverage area: the trip is display-only (no Valhalla rerouting). */
             outOfZone?: boolean;
+            /**
+             * @description Structural-readiness status (ADR-043): "draft" until pacing stages are persisted, then "ready".
+             * @enum {string}
+             */
+            status?: "draft" | "ready";
             /** @description Serialized stage DTOs */
             stages?: {
                 dayNumber?: number;
@@ -1710,6 +1715,11 @@ export interface components {
             isLocked?: boolean;
             /** @description True when the route falls outside the provisioned coverage area: the trip is display-only (no Valhalla rerouting). */
             outOfZone?: boolean;
+            /**
+             * @description Structural-readiness status (ADR-043): "draft" until pacing stages are persisted, then "ready".
+             * @enum {string}
+             */
+            status?: "draft" | "ready";
             /** @description Serialized stage DTOs */
             stages?: {
                 dayNumber?: number;


### PR DESCRIPTION
## PR2 du plan ADR-043 (Sprint 41)

PR **strictement additive et rétro-compatible** : mergeable seule, le front reste intact, `POST /trips/{id}/analyze` et les events Mercure existants (`route_parsed` / `stages_computed` / `trip_complete` / `trip_ready`) sont conservés. La suppression du gate UX est reportée en **PR4 (front)**.

Voir [ADR-043](docs/adr/adr-043-synchronous-structural-computation.md) (calcul structurel synchrone, supersede le gate ADR-027) et la recette #649.

### A) Pacing structurel synchrone pour l'upload GPX

- Extraction du pacing (`generatePacingStages` + `generateCollectionStages`, **cas collection Komoot multi-tracks préservé à l'identique**) de `GenerateStagesHandler` vers un service partagé `App\Service\StructuralComputationService` (CPU pur, pas d'I/O ; la sérialisation de l'event `stages_computed` est mutualisée).
- `GpxUploadService::createTrip()` exécute désormais le pacing en **synchrone** : `generateStages` -> `storeStages` -> publie `STAGES_COMPUTED` -> pose le statut `ready`, puis dispatche les enrichissements asynchrones (fan-out inchangé). La réponse HTTP de `GpxUploadController` porte en plus `stages` + `status` (champs **additifs**, ignorés par le front actuel).
- `GenerateStagesHandler` (chemin lien/IA, reste async car fetch réseau) : pose aussi `ready` après `storeStages`, puis enchaîne l'analyse comme avant.
- Les 11 scans PostGIS restent **asynchrones** : le « structurel synchrone » de PR2 se limite à `route` + `stages` (budget HTTP < 2s).

### B) Statut de trip persisté (`draft` -> `ready`)

- Colonne `status` (string, défaut `'draft'`) sur l'entité `App\ApiResource\TripRequest` (table `trip`).
- Migration `Version20260621120000` : ajout de la colonne + backfill `UPDATE trip SET status='ready' WHERE id IN (SELECT DISTINCT trip_id FROM stage)` (up/down conformes au style existant).
- `ready` posé dès que les stages sont persistés (`count >= MIN_STAGES`, soit 2), **indépendamment du gate terminal** `AllEnrichmentsCompleted` / `TripCompletionGate` : un trip sans dates (météo/calendar jamais complétés) atteint quand même `ready`.
- Méthode repo `storeStatus(string $tripId, string $status)` (miroir de `storeSourceType`) sur l'interface + les implémentations Doctrine et Redis.

### C) Exposition de `status` sur `/trips/{id}/detail`

- Champ `status` ajouté au DTO `App\ApiResource\TripDetail` (schéma OpenAPI inline, enum `draft`/`ready`) et renseigné dans `App\State\TripDetailProvider` depuis `$request->status`, avec fallback pour les trips antérieurs (`stageCount > 0 ? 'ready' : 'draft'`).
- Client TS régénéré : champ `status` additif sur la réponse `/detail` dans `pwa/src/lib/api/schema.d.ts`.

### D) Helper `ComputationName::structuralPipeline()`

`[ROUTE, STAGES]` — clarifie l'intention de la pose du statut. **Ne fragmente pas** `pipeline()`, qui reste l'ensemble de complétion terminal du gate (inchangé).

### Méthode typegen

`make typegen` (Docker) est bloqué par le volume `node_modules` vide du worktree (gotcha connu). Le client a été régénéré via `openapi-typescript` sur l'export OpenAPI réel du backend (`bin/console api:openapi:export`), dans un conteneur node jetable, puis vérifié **équivalent** à l'édition commitée pour le champ `status` (les seules autres divergences sont des `| null` de pagination Hydra préexistants sur `main`, hors périmètre). Validation finale par `tsc --noEmit`.

### Vérifications (sorties réelles)

Exécutées dans un conteneur dev jetable branché sur le réseau Docker `bike-trip-planner_default`, base de test dédiée créée puis supprimée (stack iso-prod non perturbée) :

- **PHPUnit Unit + Integration** : `OK (42 tests, 237 assertions)` — inclut `StructuralComputationServiceTest` (pacing isolé + cas collection Komoot), `GenerateStagesHandlerTest` (pose `ready` après `storeStages`), `DoctrineTripRequestRepositoryTest::storeStatus`, `LlmPipelineTest`.
- **PHPUnit Functional** (ciblés) : `OK (26 tests, 116 assertions)` — `GpxUploadTest` (réponse porte `stages` + `status: 'ready'`), `TripDetailTest` (`status` `draft` sans stages / `ready` avec / fallback legacy), `TripAnalyzeTest` **reste vert** (`/analyze` conservé).
- **PHPStan niveau 9** sur le **projet complet** (`phpstan.dist.neon`, sans argument de chemin) : `[OK] No errors`. L'analyse complète a révélé un `storeStatus()` manquant sur `InMemoryTripRequestRepository` (test Integration) — corrigé.
- **Rector** : 1 fichier ajusté (import `Stage`), appliqué.
- **PHP-CS-Fixer** : `Fixed 0 of 606 files`.
- **tsc --noEmit** : aucune erreur.

<!-- claude-review-start -->
## Claude Review

> Reviewed commit `e88c6d917b718155f3ecbf3b7cdbca45801f64e3`

**Summary:** Clean, well-scoped PR. The `StructuralComputationService` extraction is a genuine SRP improvement, synchronous pacing for GPX upload is correctly limited to pure local CPU work (no I/O), the `TripStatus` enum cleanly centralises the status contract, the additive approach leaves the existing frontend and async enrichment pipeline intact, and test coverage is comprehensive across unit, integration, and functional layers.

**Findings:** 0 critical, 0 warnings, 0 suggestions.

### Review checklist
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.
<!-- claude-review-end -->