### PR TITLE
feat(trip): expose per-block weather/ai status on /detail

### DIFF
--- a/api/src/ApiResource/TripDetail.php
+++ b/api/src/ApiResource/TripDetail.php
@@ -57,6 +57,16 @@ final readonly class TripDetail
             openapiContext: ['type' => 'string', 'enum' => ['draft', 'ready']],
         )]
         public string $status,
+        #[ApiProperty(
+            description: 'Per-block weather computation status derived from the ComputationTracker (WEATHER/WIND). Null when no computations are tracked (e.g. expired Redis TTL).',
+            openapiContext: ['type' => 'string', 'enum' => ['pending', 'running', 'done', 'failed'], 'nullable' => true],
+        )]
+        public ?string $weatherStatus,
+        #[ApiProperty(
+            description: 'Per-block AI computation status derived from the ComputationTracker (STAGE_AI_ANALYSIS/TRIP_AI_OVERVIEW). Null when no computations are tracked (e.g. expired Redis TTL).',
+            openapiContext: ['type' => 'string', 'enum' => ['pending', 'running', 'done', 'failed'], 'nullable' => true],
+        )]
+        public ?string $aiStatus,
         #[ApiProperty(openapiContext: [
             'type' => 'array',
             'items' => [

--- a/api/src/ApiResource/TripDetail.php
+++ b/api/src/ApiResource/TripDetail.php
@@ -59,12 +59,12 @@ final readonly class TripDetail
         public string $status,
         #[ApiProperty(
             description: 'Per-block weather computation status derived from the ComputationTracker (WEATHER/WIND). Null when no computations are tracked (e.g. expired Redis TTL).',
-            openapiContext: ['type' => 'string', 'enum' => ['pending', 'running', 'done', 'failed'], 'nullable' => true],
+            openapiContext: ['type' => ['string', 'null'], 'enum' => ['pending', 'running', 'done', 'failed', null]],
         )]
         public ?string $weatherStatus,
         #[ApiProperty(
             description: 'Per-block AI computation status derived from the ComputationTracker (STAGE_AI_ANALYSIS/TRIP_AI_OVERVIEW). Null when no computations are tracked (e.g. expired Redis TTL).',
-            openapiContext: ['type' => 'string', 'enum' => ['pending', 'running', 'done', 'failed'], 'nullable' => true],
+            openapiContext: ['type' => ['string', 'null'], 'enum' => ['pending', 'running', 'done', 'failed', null]],
         )]
         public ?string $aiStatus,
         #[ApiProperty(openapiContext: [

--- a/api/src/State/TripDetailProvider.php
+++ b/api/src/State/TripDetailProvider.php
@@ -14,6 +14,8 @@ use App\ApiResource\Model\WeatherForecast;
 use App\ApiResource\Stage;
 use App\ApiResource\TripDetail;
 use App\ApiResource\TripRequest;
+use App\ComputationTracker\ComputationTrackerInterface;
+use App\Enum\ComputationName;
 use App\Enum\TripStatus;
 use App\Osm\CoverageRepositoryInterface;
 use App\Osm\CycleRouteRepositoryInterface;
@@ -39,6 +41,7 @@ final readonly class TripDetailProvider implements ProviderInterface
         private TripLocker $tripLocker,
         private CoverageRepositoryInterface $coverageRepository,
         private CycleRouteRepositoryInterface $cycleRouteRepository,
+        private ComputationTrackerInterface $computationTracker,
     ) {
     }
 
@@ -59,6 +62,8 @@ final readonly class TripDetailProvider implements ProviderInterface
         \assert($request->id instanceof Uuid);
 
         $stages = $this->tripStateManager->getStages($id) ?? [];
+
+        $statuses = $this->computationTracker->getStatuses($id);
 
         // One batched query for the on-cycle-network fraction of every stage.
         $cycleNetwork = $this->cycleRouteRepository->onNetworkFractions(
@@ -90,8 +95,80 @@ final readonly class TripDetailProvider implements ProviderInterface
             // Fallback for trips persisted before the status column existed: infer
             // readiness from whether stages are present.
             status: '' !== $request->status ? $request->status : ([] !== $stages ? TripStatus::READY->value : TripStatus::DRAFT->value),
+            weatherStatus: $this->deriveBlockStatus($this->computationsInCategory('weather'), $statuses),
+            aiStatus: $this->deriveBlockStatus($this->computationsInCategory('ai_analysis'), $statuses),
             stages: array_map($this->serializeStage(...), $stages, $cycleNetwork),
         );
+    }
+
+    /**
+     * Lists the {@see ComputationName} cases belonging to a progress category,
+     * so the block-status derivation stays aligned with {@see ComputationName::category()}
+     * instead of hardcoding the WEATHER/WIND or STAGE_AI_ANALYSIS/TRIP_AI_OVERVIEW pairs.
+     *
+     * @return list<ComputationName>
+     */
+    private function computationsInCategory(string $category): array
+    {
+        return array_values(array_filter(
+            ComputationName::cases(),
+            static fn (ComputationName $c): bool => $c->category() === $category,
+        ));
+    }
+
+    /**
+     * Aggregates the tracked statuses of a block's computations into a single label.
+     *
+     * Mirrors {@see TripCollectionProvider::computeStatus()} (30-min TTL cache that
+     * can return null). Deterministic rule, evaluated against the block's
+     * computations actually present in `$statuses`:
+     *   - `$statuses === null`                  → null (nothing tracked, e.g. expired TTL)
+     *   - no block computation present at all    → null (front falls back to data presence)
+     *   - at least one `pending` or `running`    → 'running'
+     *   - all present are `done`                 → 'done'
+     *   - all present are terminal, ≥1 `failed`,
+     *     0 `done`                               → 'failed'
+     *
+     * @param list<ComputationName>      $computationNames
+     * @param array<string, string>|null $statuses
+     */
+    private function deriveBlockStatus(array $computationNames, ?array $statuses): ?string
+    {
+        if (null === $statuses) {
+            return null;
+        }
+
+        $present = [];
+        foreach ($computationNames as $name) {
+            if (isset($statuses[$name->value])) {
+                $present[] = $statuses[$name->value];
+            }
+        }
+
+        if ([] === $present) {
+            return null;
+        }
+
+        $hasDone = false;
+        $hasFailed = false;
+        foreach ($present as $status) {
+            if ('pending' === $status || 'running' === $status) {
+                return 'running';
+            }
+
+            if ('done' === $status) {
+                $hasDone = true;
+            } elseif ('failed' === $status) {
+                $hasFailed = true;
+            }
+        }
+
+        // All present statuses are terminal here (no pending/running returned above).
+        if ($hasFailed && !$hasDone) {
+            return 'failed';
+        }
+
+        return 'done';
     }
 
     /**

--- a/api/tests/Functional/TripDetailTest.php
+++ b/api/tests/Functional/TripDetailTest.php
@@ -9,7 +9,9 @@ use ApiPlatform\Symfony\Bundle\Test\Client;
 use App\ApiResource\Model\Coordinate;
 use App\ApiResource\Stage as StageDto;
 use App\ApiResource\TripRequest;
+use App\ComputationTracker\ComputationTrackerInterface;
 use App\Entity\User;
+use App\Enum\ComputationName;
 use App\Repository\DoctrineTripRequestRepository;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
@@ -101,6 +103,94 @@ final class TripDetailTest extends ApiTestCase
         // No cycle routes provisioned in the test DB → stage is not on a network.
         $this->assertArrayHasKey('onCycleNetwork', $stage);
         $this->assertEqualsWithDelta(0.0, $stage['onCycleNetwork'], 0.0001);
+        // No computations tracked for this trip → block statuses are null. JSON-LD
+        // strips null properties, so they are absent here (the front reads them as
+        // undefined and falls back to the presence of the underlying data).
+        $this->assertNull($data['weatherStatus'] ?? null);
+        $this->assertNull($data['aiStatus'] ?? null);
+    }
+
+    #[Test]
+    public function detailExposesRunningBlockStatusWhileComputing(): void
+    {
+        $repo = $this->seedTrip(self::TRIP_ID);
+        $repo->storeStatus(self::TRIP_ID, 'ready');
+
+        $tracker = self::getContainer()->get(ComputationTrackerInterface::class);
+        \assert($tracker instanceof ComputationTrackerInterface);
+        $tracker->initializeComputations(self::TRIP_ID, [
+            ComputationName::WEATHER,
+            ComputationName::WIND,
+            ComputationName::STAGE_AI_ANALYSIS,
+            ComputationName::TRIP_AI_OVERVIEW,
+        ]);
+        // Weather: one done, one still running → running. AI: both pending → running.
+        $tracker->markDone(self::TRIP_ID, ComputationName::WEATHER);
+        $tracker->markRunning(self::TRIP_ID, ComputationName::WIND);
+
+        $data = $this->fetchDetail();
+        $this->assertSame('running', $data['weatherStatus']);
+        $this->assertSame('running', $data['aiStatus']);
+    }
+
+    #[Test]
+    public function detailExposesDoneBlockStatusWhenAllComputationsSucceed(): void
+    {
+        $repo = $this->seedTrip(self::TRIP_ID);
+        $repo->storeStatus(self::TRIP_ID, 'ready');
+
+        $tracker = self::getContainer()->get(ComputationTrackerInterface::class);
+        \assert($tracker instanceof ComputationTrackerInterface);
+        $tracker->initializeComputations(self::TRIP_ID, [
+            ComputationName::WEATHER,
+            ComputationName::WIND,
+            ComputationName::STAGE_AI_ANALYSIS,
+            ComputationName::TRIP_AI_OVERVIEW,
+        ]);
+        $tracker->markDone(self::TRIP_ID, ComputationName::WEATHER);
+        $tracker->markDone(self::TRIP_ID, ComputationName::WIND);
+        $tracker->markDone(self::TRIP_ID, ComputationName::STAGE_AI_ANALYSIS);
+        $tracker->markDone(self::TRIP_ID, ComputationName::TRIP_AI_OVERVIEW);
+
+        $data = $this->fetchDetail();
+        $this->assertSame('done', $data['weatherStatus']);
+        $this->assertSame('done', $data['aiStatus']);
+    }
+
+    #[Test]
+    public function detailExposesFailedBlockStatusWhenAllTerminalAndNoneSucceeded(): void
+    {
+        $repo = $this->seedTrip(self::TRIP_ID);
+        $repo->storeStatus(self::TRIP_ID, 'ready');
+
+        $tracker = self::getContainer()->get(ComputationTrackerInterface::class);
+        \assert($tracker instanceof ComputationTrackerInterface);
+        $tracker->initializeComputations(self::TRIP_ID, [
+            ComputationName::WEATHER,
+            ComputationName::WIND,
+        ]);
+        // All weather computations terminal with at least one failed and zero done → failed.
+        $tracker->markFailed(self::TRIP_ID, ComputationName::WEATHER);
+        $tracker->markFailed(self::TRIP_ID, ComputationName::WIND);
+
+        $data = $this->fetchDetail();
+        $this->assertSame('failed', $data['weatherStatus']);
+        // AI computations were never tracked → null, stripped from the JSON-LD payload.
+        $this->assertNull($data['aiStatus'] ?? null);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function fetchDetail(): array
+    {
+        $response = $this->client->request('GET', \sprintf('/trips/%s/detail', self::TRIP_ID), [
+            'headers' => array_merge(['Accept' => 'application/ld+json'], $this->authHeader($this->jwtToken)),
+        ]);
+
+        $this->assertResponseIsSuccessful();
+
+        return $response->toArray(false);
     }
 
     #[Test]

--- a/api/tests/Functional/TripDetailTest.php
+++ b/api/tests/Functional/TripDetailTest.php
@@ -179,6 +179,26 @@ final class TripDetailTest extends ApiTestCase
         $this->assertNull($data['aiStatus'] ?? null);
     }
 
+    #[Test]
+    public function detailExposesDoneBlockStatusOnPartialSuccess(): void
+    {
+        $repo = $this->seedTrip(self::TRIP_ID);
+        $repo->storeStatus(self::TRIP_ID, 'ready');
+
+        $tracker = self::getContainer()->get(ComputationTrackerInterface::class);
+        \assert($tracker instanceof ComputationTrackerInterface);
+        $tracker->initializeComputations(self::TRIP_ID, [
+            ComputationName::WEATHER,
+            ComputationName::WIND,
+        ]);
+        // Mixed terminal state: one done, one failed → done (partial success).
+        $tracker->markDone(self::TRIP_ID, ComputationName::WEATHER);
+        $tracker->markFailed(self::TRIP_ID, ComputationName::WIND);
+
+        $data = $this->fetchDetail();
+        $this->assertSame('done', $data['weatherStatus']);
+    }
+
     /**
      * @return array<string, mixed>
      */

--- a/api/tests/Unit/State/TripShareShortCodeProviderTest.php
+++ b/api/tests/Unit/State/TripShareShortCodeProviderTest.php
@@ -62,6 +62,8 @@ final class TripShareShortCodeProviderTest extends TestCase
             isLocked: false,
             outOfZone: false,
             status: 'ready',
+            weatherStatus: null,
+            aiStatus: null,
             stages: [],
         );
         $this->tripDetailProvider->expects($this->once())->method('provide')->willReturn($detail);

--- a/pwa/src/lib/api/schema.d.ts
+++ b/pwa/src/lib/api/schema.d.ts
@@ -1543,6 +1543,16 @@ export interface components {
              * @enum {string}
              */
             status?: "draft" | "ready";
+            /**
+             * @description Per-block weather computation status derived from the ComputationTracker (WEATHER/WIND). Null when no computations are tracked (e.g. expired Redis TTL).
+             * @enum {string|null}
+             */
+            weatherStatus?: "pending" | "running" | "done" | "failed" | null;
+            /**
+             * @description Per-block AI computation status derived from the ComputationTracker (STAGE_AI_ANALYSIS/TRIP_AI_OVERVIEW). Null when no computations are tracked (e.g. expired Redis TTL).
+             * @enum {string|null}
+             */
+            aiStatus?: "pending" | "running" | "done" | "failed" | null;
             /** @description Serialized stage DTOs */
             stages?: {
                 dayNumber?: number;
@@ -1720,6 +1730,16 @@ export interface components {
              * @enum {string}
              */
             status?: "draft" | "ready";
+            /**
+             * @description Per-block weather computation status derived from the ComputationTracker (WEATHER/WIND). Null when no computations are tracked (e.g. expired Redis TTL).
+             * @enum {string|null}
+             */
+            weatherStatus?: "pending" | "running" | "done" | "failed" | null;
+            /**
+             * @description Per-block AI computation status derived from the ComputationTracker (STAGE_AI_ANALYSIS/TRIP_AI_OVERVIEW). Null when no computations are tracked (e.g. expired Redis TTL).
+             * @enum {string|null}
+             */
+            aiStatus?: "pending" | "running" | "done" | "failed" | null;
             /** @description Serialized stage DTOs */
             stages?: {
                 dayNumber?: number;


### PR DESCRIPTION
## PR3-back du plan ADR-043 (Sprint 41)

PR **additive et rétro-compatible**. Elle ajoute deux champs optionnels au schéma de `GET /trips/{id}/detail`. Le front ne les consomme pas encore : ce sera la PR4 (spinners par bloc). Comme la PR2 (#744, qui a ajouté `status`), `main` reste déployable.

### Objectif

Exposer dans `TripDetail` deux statuts par bloc, dérivés du `ComputationTracker`, pour que la PR4 puisse afficher des spinners par bloc (météo et IA) sans appel supplémentaire :

- `weatherStatus: 'pending' | 'running' | 'done' | 'failed' | null`
- `aiStatus: 'pending' | 'running' | 'done' | 'failed' | null`

`null` = aucune computation trackée pour ce trip (p.ex. TTL Redis 30 min expiré sur un vieux trip) → le front retombera sur la simple présence de la donnée.

### Dérivation

- Chaque bloc agrège les statuts des `ComputationName` de sa **catégorie** (`ComputationName::category()`), pas de pairs codées en dur :
  - bloc **weather** = catégorie `'weather'` → `WEATHER`, `WIND`
  - bloc **ai** = catégorie `'ai_analysis'` → `STAGE_AI_ANALYSIS`, `TRIP_AI_OVERVIEW`
- `TripDetailProvider` injecte `ComputationTrackerInterface` (même service que `TripCollectionProvider`) et lit `getStatuses($id)` (cache 30 min, peut renvoyer `null`).
- Règle déterministe de `deriveBlockStatus()`, évaluée sur les computations du bloc **présentes** dans la map :
  - `$statuses === null` → `null` (rien trackée)
  - aucune computation du bloc présente → `null` (le front retombe sur la présence de la donnée)
  - au moins un `pending`/`running` → `running`
  - toutes `done` → `done`
  - toutes terminales avec au moins un `failed` et zéro `done` → `failed`

Le pattern calque `TripCollectionProvider::computeStatus()`.

### Contrat de types

`pwa/src/lib/api/schema.d.ts` a été mis à jour (champs additifs sur `TripDetail.jsonld` et `TripShare.TripDetail.jsonld`). `make typegen` est bloqué en worktree (volume `node_modules` vide), donc l'édition a été faite à la main puis **validée objectivement** : export OpenAPI réel (`bin/console api:openapi:export`) → `openapi-typescript` (7.13.0, même version que le projet) dans un conteneur node jetable → `diff` du fichier généré contre le fichier édité = **0 divergence** (byte-identique).

### Vérifications (sorties réelles)

- PHPStan **projet complet** (`vendor/bin/phpstan analyse -c phpstan.dist.neon`) : `[OK] No errors`
- Rector `--dry-run` : `[OK] Rector is done!` (0 changement)
- PHP-CS-Fixer (fichiers touchés) : `Found 0 of 4 files that can be fixed`
- `TripDetailTest` contre PostGIS (conteneur dev jetable, base de test dédiée créée puis supprimée, stack iso-prod non touchée) : `OK (10 tests, 37 assertions)` — incluant les cas `running`, `done`, `failed` et `null`.

### Périmètre

N'est pas touché : events Mercure, `/analyze`, le front (hors `schema.d.ts`), le wizard.

Référence : recette #649, ADR-043.

<!-- claude-review-start -->
## Claude Review

Reviewed commit `ec8fe0df639c23284d0db70e8250386c9fa62fdf`.

**Summary:** All previous findings have been addressed. The mixed terminal state (`done` + `failed` → `'done'`) is now covered by `detailExposesDoneBlockStatusOnPartialSuccess()`. The PR is clean, additive, and correctly mirrors the `TripCollectionProvider::computeStatus()` pattern with full test coverage across all documented derivation branches.

**Findings:** 0 critical, 0 warnings.

Resolved 1 previously open thread (missing mixed done/failed block-status test — now addressed).

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**No inline comments.**
<!-- claude-review-end -->