### PR TITLE
build(provisioner): load DataTourisme in provision-recette when DATATOURISME_FLUX_ID is set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,8 +200,8 @@ provision-update: ## Trigger a non-interactive provisioner update (re-download O
 # of reusing a `dev`-tagged image whose /app is empty (code is bind-mounted in dev), which would
 # fail with "Could not open input file: bin/provision". `-f compose.yaml -f compose.recette.yaml`
 # is passed explicitly so the dev COMPOSE_FILE layer never leaks in.
-provision-recette: ensure-default-pbf ## Provision the iso-prod recette PostGIS index (non-interactive; first run needs a seeded .docker/osm/data/regions.json, e.g. {"slugs":["nord-pas-de-calais"]}, or a prior `make provision`)
-	@JWT_PRIVATE_KEY_PATH=$(CURDIR)/.docker/jwt-recette/private.pem JWT_PUBLIC_KEY_PATH=$(CURDIR)/.docker/jwt-recette/public.pem JWT_PASSPHRASE=recette docker compose -f compose.yaml -f compose.recette.yaml --profile provisioning run --build --rm -T provisioner --no-interaction --with-postgis
+provision-recette: ensure-default-pbf ## Provision the iso-prod recette sources: OSM PostGIS always, DataTourisme too when DATATOURISME_FLUX_ID (+ DATATOURISME_APP_KEY) are set (non-interactive; first run needs a seeded .docker/osm/data/regions.json, e.g. {"slugs":["nord-pas-de-calais"]}, or a prior `make provision`)
+	@JWT_PRIVATE_KEY_PATH=$(CURDIR)/.docker/jwt-recette/private.pem JWT_PUBLIC_KEY_PATH=$(CURDIR)/.docker/jwt-recette/public.pem JWT_PASSPHRASE=recette docker compose -f compose.yaml -f compose.recette.yaml --profile provisioning run --build --rm -T provisioner --no-interaction --with-postgis $(if $(DATATOURISME_FLUX_ID),--with-datatourisme,)
 
 ## --- 🗄️ Database ---
 migration: ## Generate a Doctrine migration

--- a/README.md
+++ b/README.md
@@ -242,10 +242,12 @@ docker compose restart valhalla  # rebuild routing tiles from the new PBF
 `make provision` / `make provision-update` inherit the dev `COMPOSE_FILE` and target the dev provisioner overlay. To provision against the iso-prod recette stack started with `make start-recette`, use the dedicated target instead:
 
 ```bash
-make provision-recette           # provision the recette PostGIS index (non-interactive)
+make provision-recette           # provision the recette sources (OSM PostGIS, plus DataTourisme when configured; non-interactive)
 ```
 
 It targets `-f compose.yaml -f compose.recette.yaml` with the recette JWT vars and forces `--build` so the `prod` provisioner stage (which COPYs the code) is rebuilt rather than reusing a `dev`-tagged image whose `/app` is empty. The first run needs a seeded region selection in `.docker/osm/data/regions.json` (e.g. `{"slugs":["nord-pas-de-calais"]}`) or a prior interactive `make provision`.
+
+It always imports the OSM PostGIS index (`--with-postgis`). It additionally imports DataTourisme (`--with-datatourisme`) when `DATATOURISME_FLUX_ID` is set in the environment (exported shell var or `.env`); the compose `provisioner` service resolves `DATATOURISME_FLUX_ID` / `DATATOURISME_APP_KEY` from the environment. Without `DATATOURISME_FLUX_ID`, only OSM is provisioned.
 
 See [ADR-036](docs/adr/adr-036-manual-osm-data-refresh.md) for why the automated nightly job (`osm-cron`) was dropped.
 


### PR DESCRIPTION
## Contexte

La cible `make provision-recette` (créée en #741) ne provisionnait que la source OSM (`--with-postgis`). Or le provisioner gère aussi DataTourisme via `--with-datatourisme` (schéma `tourism.*`). Pour une recette représentative (détection d'hébergements/POI issus à la fois d'OSM et de DataTourisme, avec dédup read-time), on veut charger les **deux** sources.

Référence : recette #649 (Lot 7 — provisioning PostGIS recette / données).

## Modification

`provision-recette` importe désormais :

- **OSM PostGIS** : toujours (`--with-postgis`, inchangé).
- **DataTourisme** : ajouté conditionnellement via `$(if $(DATATOURISME_FLUX_ID),--with-datatourisme,)`, donc uniquement si `DATATOURISME_FLUX_ID` est défini dans l'environnement (export shell ou `.env`).

Sans `DATATOURISME_FLUX_ID`, seul OSM est provisionné : pas d'échec du provisioning quand les creds DataTourisme sont absentes (le provisioner est résilient par-source — ADR-041 — mais on évite carrément d'invoquer DataTourisme sans fluxId).

Les creds ne sont **pas** passées explicitement dans la recette make : le service `provisioner` du `compose.yaml` les résout depuis l'environnement (`DATATOURISME_FLUX_ID: "${DATATOURISME_FLUX_ID:-}"` / `DATATOURISME_APP_KEY: "${DATATOURISME_APP_KEY:-}"`).

Commentaire d'aide `##` de la cible et note `make provision-recette` du `README.md` mis à jour en conséquence.

## Vérification

`make -n provision-recette` (preuve réelle, sans lancer l'import) :

Sans `DATATOURISME_FLUX_ID` — la commande **ne contient pas** `--with-datatourisme` :

```
... run --build --rm -T provisioner --no-interaction --with-postgis
```

Avec `DATATOURISME_FLUX_ID=dummy` — la commande **contient** `--with-datatourisme` :

```
... run --build --rm -T provisioner --no-interaction --with-postgis --with-datatourisme
```

`make help` liste toujours `provision-recette` (le Makefile parse correctement).

<!-- claude-review-start -->
## Claude Review

**Commit reviewed:** `6ff248c5a4fb51a57f70c9afeaf0ed140711bcd5`

**Summary:** Clean, minimal build-tooling change that correctly adds conditional DataTourisme provisioning via Make's `$(if ...)` function. The variable's emptiness is tested as the condition — its value is never interpolated into the shell command — so there is no injection risk. Documentation is updated appropriately.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

No inline comments.
<!-- claude-review-end -->