### PR TITLE
fix(ai): clarify the generation chat stub reply (guide to "Validate and continue")

### DIFF
--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -583,7 +583,7 @@
     "subtitle": "Describe your project — the assistant will draft an itinerary.",
     "historyAriaLabel": "Conversation with the AI assistant",
     "stubGreeting": "Hi! Tell me about the adventure you have in mind (region, duration, dates, fitness level...) and I'll draft a custom itinerary for you.",
-    "stubReply": "Got it! Once the assistant is connected, I'll suggest a detailed itinerary with stages tailored to your request.",
+    "stubReply": "Got it! Add any details you like (duration, elevation, road type…), then click \"Validate and continue\" so I can generate your itinerary.",
     "inputLabel": "Your request",
     "inputPlaceholder": "E.g. \"I want to ride around Corsica for 10 days in September\"",
     "inputHint": "Enter to send · Shift + Enter for a new line",

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -583,7 +583,7 @@
     "subtitle": "Décris ton projet, l'assistant proposera un itinéraire.",
     "historyAriaLabel": "Conversation avec l'assistant IA",
     "stubGreeting": "Bonjour ! Décris l'aventure que tu imagines (région, durée, période, niveau...) et je te proposerai un itinéraire sur mesure.",
-    "stubReply": "C'est noté ! Une fois la connexion à l'assistant activée, je te proposerai un itinéraire détaillé avec des étapes adaptées.",
+    "stubReply": "C'est noté ! Ajoute des précisions si tu veux (durée, dénivelé, type de route…), puis clique sur « Valider et continuer » pour que je génère ton itinéraire.",
     "inputLabel": "Ta demande",
     "inputPlaceholder": "Ex : « Je veux faire le tour de Corse en 10 jours en septembre »",
     "inputHint": "Entrée pour envoyer · Maj + Entrée pour un retour à la ligne",


### PR DESCRIPTION
## Contexte

Recette #649. Sur l'etape « Saisie », la card « Assistant IA » (`pwa/src/components/ai-chat-card.tsx`) affiche un chat **stub** : les reponses de l'assistant sont des messages locaux codes en dur, il n'y a aucun appel LLM a ce stade. La vraie generation d'itineraire se declenche au clic sur le bouton « Valider et continuer » (`POST /trips/ai-generate`, ADR-042).

Le message `aiChat.stubReply` actuel etait **trompeur** :

> C'est noté ! **Une fois la connexion à l'assistant activée**, je te proposerai un itinéraire détaillé avec des étapes adaptées.

Il laissait croire que l'IA n'etait pas connectee, alors qu'il suffit de cliquer sur « Valider et continuer ».

## Correctif

Reformulation de `aiChat.stubReply` (fr + en) pour :

- ne suggerer **aucun** defaut de connexion IA ;
- orienter l'utilisateur vers le bouton **« Valider et continuer »** (le libelle exact du bouton submit, `aiChat.submitLabel`, est repris a l'identique entre guillemets pour faire le lien).

**FR** — `"C'est noté ! Ajoute des précisions si tu veux (durée, dénivelé, type de route…), puis clique sur « Valider et continuer » pour que je génère ton itinéraire."`

**EN** — `"Got it! Add any details you like (duration, elevation, road type…), then click \"Validate and continue\" so I can generate your itinerary."`

`stubGreeting` est inchange (l'invitation ne suggere pas de chat live). Aucun test n'asserte l'ancien texte (`grep stubReply pwa/tests` -> aucun match).

## Verification

```
i18n-check OK: 893 keys in sync across fr, en
```

JSON fr/en valides. Playwright via la CI.

<!-- claude-review-start -->
## Claude Review

Reviewed commit `00e1d340a64adb48b6a6210fc40cd53ffa1b1af7`.

Clean, purposeful copy fix. Both locale strings correctly drop the misleading "once the assistant is connected" framing and orient the user toward the "Validate and continue" button, which is the actual action that triggers itinerary generation. The EN and FR reformulations are consistent and coherent.

**PR title check:** `fix(ai): clarify the generation chat stub reply (guide to "Validate and continue")` — valid Conventional Commits format. ✓

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases (no test asserted on this copy — appropriate for UX strings)
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Findings:** 0 (0 critical, 0 warning, 0 suggestion)

No inline comments.
<!-- claude-review-end -->