### PR TITLE
fix(pwa): make trip detail load resilient (retry 404, re-sync missed stages)

### DIFF
--- a/pwa/src/app/trips/[id]/trip-load.test.ts
+++ b/pwa/src/app/trips/[id]/trip-load.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import {
+  MAX_INITIAL_ATTEMPTS,
+  needsResync,
+  shouldRetryInitialLoad,
+} from "./trip-load";
+
+describe("shouldRetryInitialLoad", () => {
+  const res404 = new Response(null, { status: 404 });
+  const res500 = new Response(null, { status: 500 });
+
+  it("retries a 404 on our freshly-created trip until attempts run out", () => {
+    expect(shouldRetryInitialLoad(res404, 0, true)).toBe(true);
+    expect(shouldRetryInitialLoad(res404, MAX_INITIAL_ATTEMPTS - 1, true)).toBe(
+      true,
+    );
+    // Exhausted: the caller surfaces "Voyage introuvable" instead of spinning.
+    expect(shouldRetryInitialLoad(res404, MAX_INITIAL_ATTEMPTS, true)).toBe(
+      false,
+    );
+  });
+
+  it("never retries a 404 on a foreign / missing trip (isolation, ADR-038)", () => {
+    expect(shouldRetryInitialLoad(res404, 0, false)).toBe(false);
+  });
+
+  it("retries a transient network failure regardless of ownership", () => {
+    expect(shouldRetryInitialLoad(null, 0, false)).toBe(true);
+    expect(shouldRetryInitialLoad(null, MAX_INITIAL_ATTEMPTS, false)).toBe(
+      false,
+    );
+  });
+
+  it("never retries a definitive server error (5xx)", () => {
+    expect(shouldRetryInitialLoad(res500, 0, true)).toBe(false);
+  });
+});
+
+describe("needsResync", () => {
+  it("re-syncs a draft trip with no stages", () => {
+    expect(needsResync({ status: "draft", stages: [] })).toBe(true);
+  });
+
+  it("stops once the trip is ready", () => {
+    expect(needsResync({ status: "ready", stages: [] })).toBe(false);
+  });
+
+  it("stops as soon as stages are present, even without a status", () => {
+    expect(needsResync({ stages: [{}] })).toBe(false);
+  });
+});

--- a/pwa/src/app/trips/[id]/trip-load.ts
+++ b/pwa/src/app/trips/[id]/trip-load.ts
@@ -1,0 +1,52 @@
+// Pure load/retry policy for the trip detail page, split out so it can be unit
+// tested without mounting the (map-heavy) TripPlanner tree.
+
+// Right after creation the trip row may not be readable yet (commit / ownership
+// association timing), so the first /detail can transiently 404. Retry a few
+// times before rendering "Voyage introuvable" (recette #649, bug C).
+export const INITIAL_RETRY_MS = 1200;
+export const MAX_INITIAL_ATTEMPTS = 5;
+
+// While the structural computation hasn't produced stages, keep re-fetching
+// /detail: the SSE subscription is re-established only after the post-creation
+// navigation, so `route_parsed` / `stages_computed` emitted in between are never
+// received and the loader stays up until a manual reload (recette #649, bug B).
+// Bounded so a genuinely stuck computation does not poll forever.
+export const RESYNC_INTERVAL_MS = 2500;
+export const MAX_RESYNC_MS = 90_000;
+
+/**
+ * The trip still needs re-syncing while its structural computation hasn't
+ * produced stages (status not `ready` AND no stages in the payload). Once stages
+ * are present the view is renderable, so polling stops — this also avoids
+ * needless polling for payloads that omit `status`.
+ */
+export function needsResync(data: {
+  status?: string | null;
+  stages?: readonly unknown[] | null;
+}): boolean {
+  return (
+    (data.status ?? "draft") !== "ready" && (data.stages ?? []).length === 0
+  );
+}
+
+/**
+ * Whether a failed initial /detail load should be retried.
+ *
+ * A network blip (`res === null`), or a 404 on the trip we just created
+ * (`ownsFreshTrip` — already in the store via setTrip before the post-creation
+ * router.push, so the row may not be readable yet), is transient. A 404 on a
+ * foreign / missing trip (object-level authz is hidden as 404, ADR-038) and
+ * definitive errors (5xx, 403) are NOT retried — they surface immediately.
+ * Retries are capped at {@link MAX_INITIAL_ATTEMPTS} so the loader can't spin
+ * forever.
+ */
+export function shouldRetryInitialLoad(
+  res: Response | null,
+  attempt: number,
+  ownsFreshTrip: boolean,
+): boolean {
+  if (attempt >= MAX_INITIAL_ATTEMPTS) return false;
+
+  return res === null || (res.status === 404 && ownsFreshTrip);
+}

--- a/pwa/src/app/trips/[id]/trip-page.tsx
+++ b/pwa/src/app/trips/[id]/trip-page.tsx
@@ -19,6 +19,13 @@ import { API_URL } from "@/lib/constants";
 import type { StageData } from "@/lib/validation/schemas";
 import type { AccommodationType } from "@/lib/accommodation-types";
 import type { components } from "@/lib/api/schema";
+import {
+  INITIAL_RETRY_MS,
+  MAX_RESYNC_MS,
+  RESYNC_INTERVAL_MS,
+  needsResync,
+  shouldRetryInitialLoad,
+} from "./trip-load";
 
 type TripDetailResponse = components["schemas"]["TripDetail.jsonld"];
 
@@ -44,134 +51,206 @@ function TripLoader({ tripId }: { tripId: string }) {
 
   useEffect(() => {
     let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
 
-    async function loadTrip() {
+    // A 404 is only treated as transient (worth retrying) when this trip is the
+    // one we just created: it's already in the store via setTrip() before the
+    // post-creation router.push, so the row may simply not be readable yet. A
+    // direct visit to a foreign / missing trip has an empty store, and its 404
+    // (object-level authz is hidden as 404, ADR-038) must surface immediately.
+    const ownsFreshTrip = useTripStore.getState().trip?.id === tripId;
+
+    // Hydrate the Zustand store from a /detail payload.
+    function hydrate(data: TripDetailResponse): void {
+      setTrip({
+        id: data.id ?? "",
+        title: data.title ?? "",
+        sourceUrl: data.sourceUrl ?? "",
+      });
+
+      updateDatesInternal(
+        data.startDate?.split("T")[0] ?? null,
+        data.endDate?.split("T")[0] ?? null,
+      );
+
+      updatePacingSettingsInternal(
+        data.fatigueFactor ?? 0.9,
+        data.elevationPenalty ?? 50,
+        data.maxDistancePerDay ?? 80,
+        data.averageSpeed ?? 15,
+      );
+
+      setEbikeMode(data.ebikeMode ?? false);
+      setDepartureHour(data.departureHour ?? 8);
+      setEnabledAccommodationTypes(
+        (data.enabledAccommodationTypes ?? []) as AccommodationType[],
+      );
+      setIsLocked(data.isLocked === true);
+      setOutOfZone(data.outOfZone === true);
+
+      // Convert stages to Zustand StageData shape
+      const stages: StageData[] = (data.stages ?? []).map((s) => {
+        return {
+          dayNumber: s.dayNumber ?? 0,
+          distance: s.distance ?? 0,
+          elevation: s.elevation ?? 0,
+          elevationLoss: s.elevationLoss ?? 0,
+          startPoint: (s.startPoint as StageData["startPoint"]) ?? {
+            lat: 0,
+            lon: 0,
+            ele: 0,
+          },
+          endPoint: (s.endPoint as StageData["endPoint"]) ?? {
+            lat: 0,
+            lon: 0,
+            ele: 0,
+          },
+          geometry: (s.geometry as StageData["geometry"]) ?? [],
+          label: s.label ?? null,
+          startLabel: null,
+          endLabel: null,
+          weather: (s.weather as StageData["weather"]) ?? null,
+          alerts: (s.alerts as StageData["alerts"]) ?? [],
+          pois: (s.pois as StageData["pois"]) ?? [],
+          accommodations:
+            (s.accommodations as StageData["accommodations"]) ?? [],
+          selectedAccommodation:
+            (s.selectedAccommodation as StageData["selectedAccommodation"]) ??
+            null,
+          accommodationSearchRadiusKm: 5,
+          isRestDay: s.isRestDay ?? false,
+          onCycleNetwork: s.onCycleNetwork ?? 0,
+          supplyTimeline: [],
+          events: [],
+        };
+      });
+
+      setStages(stages);
+
+      if (stages.length > 0) {
+        const totalDistance = stages
+          .filter((s) => !s.isRestDay)
+          .reduce((sum, s) => sum + s.distance, 0);
+        const totalElevation = stages
+          .filter((s) => !s.isRestDay)
+          .reduce((sum, s) => sum + s.elevation, 0);
+
+        useTripStore.getState().updateRouteData({
+          totalDistance,
+          totalElevation,
+          totalElevationLoss: stages.reduce(
+            (sum, s) => sum + (s.elevationLoss ?? 0),
+            0,
+          ),
+          sourceType: "persisted",
+          title: data.title ?? null,
+        });
+      }
+
+      // Drive the synchronous-flow loader vs. trip view from `status`
+      // (ADR-043, PR4-front). A `draft` trip has no structural stages yet:
+      // keep the global processing flag on so the planner shows the single
+      // loader until the trip becomes `ready`. A `ready` trip renders the full
+      // view immediately.
+      const ui = useUiStore.getState();
+      ui.setProcessing(data.status !== "ready");
+
+      // Hydrate the per-block async enrichment status from the detail payload so
+      // the weather / AI spinners reflect server-side progress on reload (a
+      // running block keeps spinning; a done/failed block renders its terminal
+      // state). Mercure events keep these live afterwards.
+      ui.setBlockStatus("weather", data.weatherStatus ?? null);
+      ui.setBlockStatus("ai", data.aiStatus ?? null);
+    }
+
+    async function fetchDetail(): Promise<Response | null> {
       try {
-        const res = await apiFetch(
+        return await apiFetch(
           `${API_URL}/trips/${encodeURIComponent(tripId)}/detail`,
           { headers: { Accept: "application/ld+json" } },
         );
-
-        if (!res.ok || cancelled) {
-          if (!cancelled) setLoadError(true);
-          return;
-        }
-
-        const data = (await res.json()) as TripDetailResponse;
-
-        if (cancelled) return;
-
-        // Hydrate the Zustand store with persisted data
-        setTrip({
-          id: data.id ?? "",
-          title: data.title ?? "",
-          sourceUrl: data.sourceUrl ?? "",
-        });
-
-        updateDatesInternal(
-          data.startDate?.split("T")[0] ?? null,
-          data.endDate?.split("T")[0] ?? null,
-        );
-
-        updatePacingSettingsInternal(
-          data.fatigueFactor ?? 0.9,
-          data.elevationPenalty ?? 50,
-          data.maxDistancePerDay ?? 80,
-          data.averageSpeed ?? 15,
-        );
-
-        setEbikeMode(data.ebikeMode ?? false);
-        setDepartureHour(data.departureHour ?? 8);
-        setEnabledAccommodationTypes(
-          (data.enabledAccommodationTypes ?? []) as AccommodationType[],
-        );
-        setIsLocked(data.isLocked === true);
-        setOutOfZone(data.outOfZone === true);
-
-        // Convert stages to Zustand StageData shape
-        const stages: StageData[] = (data.stages ?? []).map((s) => {
-          return {
-            dayNumber: s.dayNumber ?? 0,
-            distance: s.distance ?? 0,
-            elevation: s.elevation ?? 0,
-            elevationLoss: s.elevationLoss ?? 0,
-            startPoint: (s.startPoint as StageData["startPoint"]) ?? {
-              lat: 0,
-              lon: 0,
-              ele: 0,
-            },
-            endPoint: (s.endPoint as StageData["endPoint"]) ?? {
-              lat: 0,
-              lon: 0,
-              ele: 0,
-            },
-            geometry: (s.geometry as StageData["geometry"]) ?? [],
-            label: s.label ?? null,
-            startLabel: null,
-            endLabel: null,
-            weather: (s.weather as StageData["weather"]) ?? null,
-            alerts: (s.alerts as StageData["alerts"]) ?? [],
-            pois: (s.pois as StageData["pois"]) ?? [],
-            accommodations:
-              (s.accommodations as StageData["accommodations"]) ?? [],
-            selectedAccommodation:
-              (s.selectedAccommodation as StageData["selectedAccommodation"]) ??
-              null,
-            accommodationSearchRadiusKm: 5,
-            isRestDay: s.isRestDay ?? false,
-            onCycleNetwork: s.onCycleNetwork ?? 0,
-            supplyTimeline: [],
-            events: [],
-          };
-        });
-
-        setStages(stages);
-
-        if (stages.length > 0) {
-          const totalDistance = stages
-            .filter((s) => !s.isRestDay)
-            .reduce((sum, s) => sum + s.distance, 0);
-          const totalElevation = stages
-            .filter((s) => !s.isRestDay)
-            .reduce((sum, s) => sum + s.elevation, 0);
-
-          useTripStore.getState().updateRouteData({
-            totalDistance,
-            totalElevation,
-            totalElevationLoss: stages.reduce(
-              (sum, s) => sum + (s.elevationLoss ?? 0),
-              0,
-            ),
-            sourceType: "persisted",
-            title: data.title ?? null,
-          });
-        }
-
-        // Drive the synchronous-flow loader vs. trip view from `status`
-        // (ADR-043, PR4-front). A `draft` trip has no structural stages yet:
-        // keep the global processing flag on so the planner shows the single
-        // loader until Mercure (`stages_computed` / route lifecycle) resolves.
-        // A `ready` trip renders the full view immediately.
-        const ui = useUiStore.getState();
-        ui.setProcessing(data.status !== "ready");
-
-        // Hydrate the per-block async enrichment status from the detail
-        // payload so the weather / AI spinners reflect server-side progress on
-        // reload (a running block keeps spinning; a done/failed block renders
-        // its terminal state). Mercure events keep these live afterwards.
-        ui.setBlockStatus("weather", data.weatherStatus ?? null);
-        ui.setBlockStatus("ai", data.aiStatus ?? null);
-
-        setIsLoaded(true);
       } catch {
-        if (!cancelled) setLoadError(true);
+        return null;
       }
     }
 
-    void loadTrip();
+    // Phase 2 — keep polling while the trip has no stages yet. Re-hydrate only
+    // once stages are present so we never overwrite stages already pushed live
+    // by Mercure with an empty draft payload; until then we just re-check.
+    function scheduleResync(startedAt: number): void {
+      if (cancelled) return;
+      if (Date.now() - startedAt >= MAX_RESYNC_MS) {
+        // Gave up waiting for the structural computation. The single loader is
+        // driven by stages.length (not `processing`), so if nothing ever
+        // rendered — no stages from /detail nor from a live Mercure event —
+        // surface the error instead of an endless spinner. If stages did arrive
+        // meanwhile, leave the rendered view alone.
+        if (useTripStore.getState().stages.length === 0) setLoadError(true);
+        return;
+      }
+
+      timer = setTimeout(() => {
+        void (async () => {
+          const res = await fetchDetail();
+          if (cancelled) return;
+
+          if (res?.ok) {
+            try {
+              const data = (await res.json()) as TripDetailResponse;
+              if (cancelled) return;
+              if (!needsResync(data)) {
+                hydrate(data);
+                return; // structural stages present — stop polling
+              }
+            } catch {
+              // Malformed payload — treat as a transient blip and keep polling.
+            }
+          }
+
+          scheduleResync(startedAt);
+        })();
+      }, RESYNC_INTERVAL_MS);
+    }
+
+    // Phase 1 — initial load with bounded retry on a transient failure.
+    async function initialLoad(attempt: number): Promise<void> {
+      const res = await fetchDetail();
+      if (cancelled) return;
+
+      if (!res?.ok) {
+        if (shouldRetryInitialLoad(res, attempt, ownsFreshTrip)) {
+          timer = setTimeout(
+            () => void initialLoad(attempt + 1),
+            INITIAL_RETRY_MS,
+          );
+        } else {
+          setLoadError(true);
+        }
+        return;
+      }
+
+      let data: TripDetailResponse;
+      try {
+        data = (await res.json()) as TripDetailResponse;
+      } catch {
+        // A 200 with a non-JSON body (e.g. an HTML error page from a proxy)
+        // would otherwise reject and hang the loader — surface the error.
+        if (!cancelled) setLoadError(true);
+        return;
+      }
+      if (cancelled) return;
+
+      hydrate(data);
+      setIsLoaded(true);
+
+      if (needsResync(data)) scheduleResync(Date.now());
+    }
+
+    void initialLoad(0);
 
     return () => {
       cancelled = true;
+      if (timer) clearTimeout(timer);
       clearTrip();
     };
   }, [

--- a/pwa/tests/mocked/trip-detail.spec.ts
+++ b/pwa/tests/mocked/trip-detail.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "@playwright/test";
-import { FAKE_JWT_TOKEN } from "../fixtures/api-mocks";
+import { FAKE_JWT_TOKEN, mockAllApis } from "../fixtures/api-mocks";
+import { expandLinkCard } from "../fixtures/base.fixture";
 
 const TRIP_ID = "01936f6e-0000-7000-8000-000000000101";
 
@@ -145,6 +146,105 @@ test.describe("/trips/[id] detail page", () => {
       timeout: 5000,
     });
     await expect(page.getByTestId("trip-not-found-back")).toBeVisible();
+  });
+
+  test("shows not found immediately on a 404 from a direct visit (recette #649)", async ({
+    page,
+  }) => {
+    // A 404 on a trip we did NOT just create (empty store — a foreign or missing
+    // trip, object-level authz hidden as 404 per ADR-038) must surface the error
+    // immediately, without retrying (a direct visit / reload never owns a fresh
+    // trip in the store).
+    await page.route(`**/trips/${TRIP_ID}/detail`, (route, request) => {
+      const accept = request.headers()["accept"] ?? "";
+      if (!accept.includes("application/ld+json")) return route.fallback();
+      return route.fulfill({ status: 404, body: "" });
+    });
+
+    await page.goto(`/trips/${TRIP_ID}`);
+
+    await expect(page.getByTestId("trip-not-found-page")).toBeVisible({
+      timeout: 5000,
+    });
+  });
+
+  test("shows not found when the detail payload is not valid JSON (recette #649)", async ({
+    page,
+  }) => {
+    // A 200 with a non-JSON body (proxy / CDN HTML error page) must surface the
+    // error instead of hanging the loader — res.json() would otherwise reject.
+    await page.route(`**/trips/${TRIP_ID}/detail`, (route, request) => {
+      const accept = request.headers()["accept"] ?? "";
+      if (!accept.includes("application/ld+json")) return route.fallback();
+      return route.fulfill({
+        status: 200,
+        headers: { "Content-Type": "text/html; charset=utf-8" },
+        body: "<html><body>Bad gateway</body></html>",
+      });
+    });
+
+    await page.goto(`/trips/${TRIP_ID}`);
+
+    await expect(page.getByTestId("trip-not-found-page")).toBeVisible({
+      timeout: 5000,
+    });
+  });
+
+  test("re-syncs a draft trip via /detail when the stages event is missed (recette #649)", async ({
+    page,
+  }) => {
+    // First load is a draft with no stages (single loader). No Mercure event is
+    // injected, so only the /detail re-sync can surface the computed trip —
+    // this is the "had to reload the page" symptom.
+    let calls = 0;
+    await page.route(`**/trips/${TRIP_ID}/detail`, (route, request) => {
+      const accept = request.headers()["accept"] ?? "";
+      if (!accept.includes("application/ld+json")) return route.fallback();
+      calls += 1;
+      const ready = calls > 1;
+      return route.fulfill({
+        status: 200,
+        headers: { "Content-Type": "application/ld+json; charset=utf-8" },
+        body: JSON.stringify({
+          ...MOCK_DETAIL,
+          status: ready ? "ready" : "draft",
+          stages: ready ? MOCK_STAGES : [],
+        }),
+      });
+    });
+
+    await page.goto(`/trips/${TRIP_ID}`);
+
+    await expect(page.getByTestId("trip-actions")).toBeVisible({
+      timeout: 10000,
+    });
+  });
+
+  test("retries 404s on our freshly-created trip then shows not found (recette #649)", async ({
+    page,
+  }) => {
+    // Full creation flow → ownsFreshTrip === true (the trip is in the store via
+    // setTrip before the router.push). The detail endpoint always 404s, so the
+    // loader must exhaust its retries and surface "Voyage introuvable" rather
+    // than spin forever.
+    await mockAllApis(page, { postTripBody: { id: TRIP_ID, isLocked: false } });
+    await page.route(`**/trips/${TRIP_ID}/detail`, (route, request) => {
+      const accept = request.headers()["accept"] ?? "";
+      if (!accept.includes("application/ld+json")) return route.fallback();
+      return route.fulfill({ status: 404, body: "" });
+    });
+
+    await page.goto("/");
+    await expandLinkCard(page);
+    const input = page.getByTestId("magic-link-input");
+    await input.fill("https://www.komoot.com/fr-fr/tour/2795080048");
+    await input.press("Enter");
+
+    await page.waitForURL(new RegExp(`/trips/${TRIP_ID}`), { timeout: 5000 });
+    // 5 retries × 1200 ms + navigation overhead.
+    await expect(page.getByTestId("trip-not-found-page")).toBeVisible({
+      timeout: 12000,
+    });
   });
 });
 


### PR DESCRIPTION
## Contexte

Recette #649 / #750 (items B et C — P0). Après création d'un trip, le planner navigue vers `/trips/{id}` et `TripLoader` fetche `/detail` **une seule fois** :

- un **404 transitoire** (la ligne n'est pas encore lisible juste après la création) affichait « Voyage introuvable » de façon définitive (**bug C**, upload GPX) ;
- un trip **`draft`** dont l'event Mercure `stages_computed` est manqué — l'abonnement SSE n'est ré-établi qu'**après** la navigation (le `mercureToken`, state local de `useTripPlanner`, est perdu au `router.push`) — laissait le **loader figé** jusqu'à un rechargement manuel (**bug B**, lien Komoot / génération IA).

## Correctif (`trip-page.tsx`)

- **Retry borné** sur 404 transitoire / coupure réseau au chargement initial (un 5xx/403 échoue immédiatement → pas de régression sur le cas « vrai trip introuvable »).
- **Re-sync `/detail`** tant que le trip n'a pas de stages (`status != ready` **et** `stages` vide), jusqu'à ce que le calcul structurel les produise — borné dans le temps. Ne ré-hydrate jamais tant qu'il n'y a pas de stages, pour ne pas écraser ceux poussés en direct par Mercure.

## Tests

2 tests E2E mockés dans `trip-detail.spec.ts` : retry d'un 404 transitoire puis rendu du trip ; re-sync d'un trip `draft` via `/detail` sans event Mercure injecté.

## Vérification

`make test-e2e` (Playwright, exécuté en CI ; non lançable depuis le worktree, pas de `node_modules`).

Refs #750

<!-- claude-review-start -->
## Claude Review

All findings from the three previous review rounds are now resolved. The final push adds the missing E2E test for the `ownsFreshTrip === true` retry-exhaustion path — a full creation flow that navigates to `/trips/{id}` with the store already populated, then hits persistent 404s until all retries are consumed and "Voyage introuvable" is rendered. This was the only outstanding gap.

**Findings: 0 new findings.**

### Resolved threads
Resolved 2 previously open threads (`PRRT_kwDORUitfM6Lgmht` and `PRRT_kwDORUitfM6Lg_8c` — retry-exhaustion E2E test now covered by "retries 404s on our freshly-created trip then shows not found").

### Review checklist
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Commit reviewed:** `ba354f736cbcf30297985f5ab849cdfcbb2ff2ff`

No inline comments.
<!-- claude-review-end -->