### PR TITLE
perf(osm): make cycle-route on-network scan index-friendly

### DIFF
--- a/api/src/Osm/CycleRouteRepository.php
+++ b/api/src/Osm/CycleRouteRepository.php
@@ -49,7 +49,29 @@ final readonly class CycleRouteRepository implements CycleRouteRepositoryInterfa
                 LEFT JOIN LATERAL (
                     SELECT ST_Buffer(ST_Collect(c.geom)::geography, :tol)::geometry AS g
                     FROM osm.cycle_routes c
-                    WHERE ST_DWithin(c.geom::geography, stage.g::geography, :tol)
+                    -- Index-usable bbox pre-filter (ADR-043 PR1, same shape as
+                    -- WaysRepository): the per-row c.geom::geography cast in
+                    -- ST_DWithin defeats the GiST index, so gate it behind
+                    -- `c.geom && <expanded bbox>`. The box pads the stage envelope
+                    -- by the tolerance (lat: ~111 320 m/deg; lon: divided by cos at
+                    -- the envelope's highest |lat|, clamped), strictly containing
+                    -- the metric corridor — so the candidate set is a superset and
+                    -- the measured fraction is identical to the unfiltered scan.
+                    WHERE c.geom && ST_Expand(
+                            ST_Envelope(stage.g),
+                            :tol / (111320.0 * GREATEST(
+                                cos(radians(LEAST(
+                                    GREATEST(
+                                        abs(ST_YMin(ST_Envelope(stage.g))),
+                                        abs(ST_YMax(ST_Envelope(stage.g)))
+                                    ) + :tol / 111320.0,
+                                    89.9
+                                ))),
+                                0.01
+                            )),
+                            :tol / 111320.0
+                        )
+                      AND ST_DWithin(c.geom::geography, stage.g::geography, :tol)
                 ) AS buffer ON TRUE
                 ORDER BY t.idx
                 SQL,


### PR DESCRIPTION
## Contexte

Recette #649 / #750 (item E — P1). Recharger un trip prenait 5-10 s : `TripDetailProvider` (GET `/trips/{id}/detail`) appelle `CycleRouteRepository::onNetworkFractions` à **chaque** requête, et le cast `c.geom::geography` dans le `ST_DWithin` **défait l'index GiST** de `osm.cycle_routes` → scan séquentiel par étape.

## Correctif

Même approche que #743 (`WaysRepository`) : on garde le prédicat métrique exact `ST_DWithin(geography, 30 m)` mais on le précède d'un pré-filtre **index-friendly** `c.geom && <bbox élargie de l'étape>`. La bbox (envelope de l'étape + padding = tolérance convertie en degrés, longitude divisée par `cos(lat)` au point le plus haut, borné) **contient strictement** le corridor métrique → le candidat est un **superset** → la fraction mesurée reste **identique** (garantie par `CycleRouteIndexReadTest`).

## Choix : bornage vs persistance

Le plan évoquait deux options : (1) persister `onCycleNetwork` au compute structurel (lecture O(1) au GET), (2) borner la requête. J'ai retenu **(2)** : localisée à un seul fichier, sans migration ni refactor du DTO/entité/compute, et alignée sur le pattern #743 déjà éprouvé. Le calcul reste au GET mais redevient rapide (scan borné par l'index, ~25× sur #743). Sortir totalement le calcul du chemin chaud (option 1) reste ouvert en suivi si besoin.

## Vérification

`make phpunit` (dont `CycleRouteIndexReadTest`, garde de comportement : résultats identiques) + `make phpstan` en CI.

Refs #750

<!-- claude-review-start -->
## Claude Review

**Reviewed commit:** `1a5f0d24fe37cafa4973238998f4a7636e5414e5`

Focused, correct performance fix. The padded-envelope pre-filter formula is mathematically sound (strictly contains the metric corridor at all latitudes), is byte-for-byte identical to the established `WaysRepository` pattern from #743, and `CycleRouteIndexReadTest` guards the behavioural contract with five distinct cases. No issues found.

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate (mirrors #743/`WaysRepository`)
- [x] Tests cover new/changed cases (`CycleRouteIndexReadTest`: on-network, off-network, partial, degenerate, empty)
- [x] Documentation is up to date (inline comment cites ADR-043 and explains the superset guarantee)
- [x] Dependent tickets accounted for (refs #750)

No inline comments. No previously open threads to resolve.
<!-- claude-review-end -->