### PR TITLE
feat(ai): add conversational trip-brief chat card

### DIFF
--- a/api/src/ApiResource/AiChatResponse.php
+++ b/api/src/ApiResource/AiChatResponse.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\ApiResource;
 
 use ApiPlatform\Metadata\ApiProperty;
-use ApiPlatform\Metadata\ApiResource;
 
 /**
  * Output DTO for `POST /trips/ai-chat` (ADR-045).
@@ -13,8 +12,12 @@ use ApiPlatform\Metadata\ApiResource;
  * The stateless trip-brief chat returns, per turn, the assistant reply, the
  * model's readiness verdict and the running structured summary of the brief.
  * It never routes: launching the computation reuses `POST /trips/ai-generate`.
+ *
+ * Not an `#[ApiResource]` of its own: API Platform 4 derives the response
+ * schema from `output: AiChatResponse::class` on the `Post` operation of
+ * {@see Trip}, so a standalone resource declaration (with no operations) only
+ * added a redundant, unreachable schema.
  */
-#[ApiResource(shortName: 'AiChat', operations: [])]
 final readonly class AiChatResponse
 {
     /**

--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -580,15 +580,36 @@
     "ariaSelectAi": "Chat with the AI assistant"
   },
   "aiChat": {
-    "subtitle": "Describe your project — the assistant will draft an itinerary.",
+    "subtitle": "Describe your project — the assistant refines the itinerary with you.",
     "historyAriaLabel": "Conversation with the AI assistant",
-    "stubGreeting": "Hi! Tell me about the adventure you have in mind (region, duration, dates, fitness level...) and I'll draft a custom itinerary for you.",
-    "stubReply": "Got it! Add any details you like (duration, elevation, road type…), then click \"Validate and continue\" so I can generate your itinerary.",
+    "greeting": "Hi! Tell me about the adventure you have in mind (region, duration, dates, fitness level...) and I'll help you refine your itinerary.",
+    "thinking": "The assistant is thinking…",
     "inputLabel": "Your request",
     "inputPlaceholder": "E.g. \"I want to ride around Corsica for 10 days in September\"",
     "inputHint": "Enter to send · Shift + Enter for a new line",
     "sendAriaLabel": "Send message",
-    "submitLabel": "Validate and continue"
+    "capReached": "You've shared plenty of detail. Launch the route computation to continue.",
+    "recapAriaLabel": "Parameters understood by the assistant",
+    "recapTitle": "What I understood",
+    "recapEmpty": "Describe your project and I'll summarise the understood parameters here.",
+    "recap": {
+      "start": "Start",
+      "end": "Destination",
+      "loop": "Loop",
+      "durationDays": "Duration",
+      "profile": "Profile",
+      "elevation": "Elevation",
+      "startDate": "Dates",
+      "supply": "Resupply"
+    },
+    "launchLabel": "Launch route computation",
+    "launchRecommended": "Your project looks complete — you can launch the computation.",
+    "launchNeedsStart": "Provide at least a starting point to launch the computation.",
+    "errorNotConfigured": "Configure an AI provider to chat about your itinerary.",
+    "configureCta": "Configure an AI provider",
+    "errorRateLimit": "Too many messages in a row. Please wait a moment before retrying.",
+    "errorUnavailable": "AI assistant temporarily unavailable. Please try again shortly.",
+    "errorGeneric": "Something went wrong. Please try again."
   },
   "planner": {
     "computing": "Computing your route…"

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -580,15 +580,36 @@
     "ariaSelectAi": "Discuter avec l'assistant IA"
   },
   "aiChat": {
-    "subtitle": "Décris ton projet, l'assistant proposera un itinéraire.",
+    "subtitle": "Décris ton projet, l'assistant affine l'itinéraire avec toi.",
     "historyAriaLabel": "Conversation avec l'assistant IA",
-    "stubGreeting": "Bonjour ! Décris l'aventure que tu imagines (région, durée, période, niveau...) et je te proposerai un itinéraire sur mesure.",
-    "stubReply": "C'est noté ! Ajoute des précisions si tu veux (durée, dénivelé, type de route…), puis clique sur « Valider et continuer » pour que je génère ton itinéraire.",
+    "greeting": "Bonjour ! Décris l'aventure que tu imagines (région, durée, période, niveau...) et je t'aiderai à préciser ton itinéraire.",
+    "thinking": "L'assistant réfléchit…",
     "inputLabel": "Ta demande",
     "inputPlaceholder": "Ex : « Je veux faire le tour de Corse en 10 jours en septembre »",
     "inputHint": "Entrée pour envoyer · Maj + Entrée pour un retour à la ligne",
     "sendAriaLabel": "Envoyer le message",
-    "submitLabel": "Valider et continuer"
+    "capReached": "Tu as donné beaucoup de détails. Lance le calcul de l'itinéraire pour continuer.",
+    "recapAriaLabel": "Paramètres compris par l'assistant",
+    "recapTitle": "Ce que j'ai compris",
+    "recapEmpty": "Décris ton projet, je résumerai ici les paramètres compris.",
+    "recap": {
+      "start": "Départ",
+      "end": "Destination",
+      "loop": "Boucle",
+      "durationDays": "Durée",
+      "profile": "Profil",
+      "elevation": "Dénivelé",
+      "startDate": "Dates",
+      "supply": "Ravitaillement"
+    },
+    "launchLabel": "Lancer le calcul d'itinéraire",
+    "launchRecommended": "Ton projet semble complet : tu peux lancer le calcul.",
+    "launchNeedsStart": "Indique au moins un point de départ pour lancer le calcul.",
+    "errorNotConfigured": "Configure un fournisseur IA pour discuter de ton itinéraire.",
+    "configureCta": "Configurer une IA",
+    "errorRateLimit": "Trop de messages d'affilée. Patiente un instant avant de réessayer.",
+    "errorUnavailable": "Assistant IA temporairement indisponible. Réessaie dans un instant.",
+    "errorGeneric": "Une erreur est survenue. Réessaie."
   },
   "planner": {
     "computing": "Calcul de ton itinéraire en cours…"

--- a/pwa/src/components/ai-chat-card.test.tsx
+++ b/pwa/src/components/ai-chat-card.test.tsx
@@ -1,0 +1,279 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  cleanup,
+} from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import {
+  AiChatCard,
+  AI_CHAT_LAUNCH_EVENT,
+  MAX_USER_TURNS,
+  type AiChatLaunchEventDetail,
+} from "./ai-chat-card";
+import type { AiChatResult } from "@/lib/api/client";
+
+// Echo translation keys (params appended) so assertions can target keys.
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string, params?: Record<string, string>) =>
+    params ? `${key}:${JSON.stringify(params)}` : key,
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: React.ReactNode;
+  }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+const sendAiChat = vi.fn<(...args: unknown[]) => Promise<AiChatResult>>();
+vi.mock("@/lib/api/client", () => ({
+  sendAiChat: (...args: unknown[]) => sendAiChat(...args),
+}));
+
+function ok(
+  reply: string,
+  collected: Record<string, unknown> = {},
+  readyToGenerate = false,
+): AiChatResult {
+  return {
+    status: "ok",
+    data: { reply, readyToGenerate, collected },
+  } as AiChatResult;
+}
+
+async function sendUserTurn(text: string) {
+  const textarea = screen.getByTestId("ai-chat-textarea");
+  fireEvent.change(textarea, { target: { value: text } });
+  fireEvent.keyDown(textarea, { key: "Enter" });
+}
+
+describe("AiChatCard (ADR-045)", () => {
+  beforeEach(() => {
+    sendAiChat.mockReset();
+  });
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("renders the greeting and an empty recap before any turn", () => {
+    render(<AiChatCard />);
+    expect(screen.getByText("greeting")).toBeInTheDocument();
+    expect(screen.getByText("recapEmpty")).toBeInTheDocument();
+    // Launch is disabled until a geocodable start is collected.
+    expect(screen.getByTestId("ai-chat-launch")).toBeDisabled();
+  });
+
+  it("sends the whole transcript on each turn and appends the assistant reply", async () => {
+    sendAiChat.mockResolvedValueOnce(ok("First reply", { start: "Lille" }));
+    sendAiChat.mockResolvedValueOnce(ok("Second reply", { start: "Lille" }));
+    render(<AiChatCard />);
+
+    await sendUserTurn("Boucle au départ de Lille");
+    await screen.findByText("First reply");
+    await sendUserTurn("Sur 3 jours");
+    await screen.findByText("Second reply");
+
+    // The second call carries the full conversation (2 user + 1 assistant).
+    const secondCallMessages = sendAiChat.mock.calls[1]?.[0] as Array<{
+      role: string;
+      content: string;
+    }>;
+    expect(secondCallMessages).toEqual([
+      { role: "user", content: "Boucle au départ de Lille" },
+      { role: "assistant", content: "First reply" },
+      { role: "user", content: "Sur 3 jours" },
+    ]);
+
+    // Both user bubbles + both assistant replies (greeting is not in `messages`).
+    expect(
+      screen.getAllByTestId("ai-chat-message").filter((el) => {
+        return el.getAttribute("data-role") === "user";
+      }),
+    ).toHaveLength(2);
+  });
+
+  it("keeps the launch button disabled without a geocodable start", async () => {
+    sendAiChat.mockResolvedValueOnce(
+      ok("Where do you start?", { durationDays: 3 }, true),
+    );
+    render(<AiChatCard />);
+
+    await sendUserTurn("3 jours quelque part");
+    await screen.findByText("Where do you start?");
+
+    // readyToGenerate is true but `start` is missing → hard gate keeps it off.
+    expect(screen.getByTestId("ai-chat-launch")).toBeDisabled();
+    expect(screen.getByText("launchNeedsStart")).toBeInTheDocument();
+  });
+
+  it("enables the launch button once a start is collected", async () => {
+    sendAiChat.mockResolvedValueOnce(ok("Got Lille", { start: "Lille" }));
+    render(<AiChatCard />);
+
+    await sendUserTurn("Départ Lille");
+    await screen.findByText("Got Lille");
+
+    expect(screen.getByTestId("ai-chat-launch")).toBeEnabled();
+    // Recap shows the collected start.
+    expect(screen.getByTestId("ai-chat-recap-start")).toHaveTextContent(
+      "Lille",
+    );
+  });
+
+  it("marks the launch button as recommended when readyToGenerate is true", async () => {
+    sendAiChat.mockResolvedValueOnce(
+      ok("All set", { start: "Lille", durationDays: 3 }, true),
+    );
+    render(<AiChatCard />);
+
+    await sendUserTurn("Boucle Lille 3 jours");
+    await screen.findByText("All set");
+
+    const launch = screen.getByTestId("ai-chat-launch");
+    expect(launch).toBeEnabled();
+    expect(launch).toHaveAttribute("data-recommended", "true");
+    expect(screen.getByTestId("ai-chat-launch-hint")).toBeInTheDocument();
+  });
+
+  it("does not recommend launch when readyToGenerate is false even with a start", async () => {
+    sendAiChat.mockResolvedValueOnce(ok("Need more", { start: "Lille" }, false));
+    render(<AiChatCard />);
+
+    await sendUserTurn("Départ Lille");
+    await screen.findByText("Need more");
+
+    const launch = screen.getByTestId("ai-chat-launch");
+    expect(launch).toBeEnabled();
+    expect(launch).not.toHaveAttribute("data-recommended");
+    expect(screen.queryByTestId("ai-chat-launch-hint")).not.toBeInTheDocument();
+  });
+
+  it("consolidates the brief (collected + user turns) and fires the launch callback + event", async () => {
+    sendAiChat.mockResolvedValueOnce(
+      ok("ready", { start: "Lille", durationDays: 3 }, true),
+    );
+    const onLaunchGeneration = vi.fn();
+    const eventDetails: AiChatLaunchEventDetail[] = [];
+    document.addEventListener(AI_CHAT_LAUNCH_EVENT, (e) =>
+      eventDetails.push((e as CustomEvent<AiChatLaunchEventDetail>).detail),
+    );
+
+    render(<AiChatCard onLaunchGeneration={onLaunchGeneration} />);
+    await sendUserTurn("Boucle au départ de Lille sur 3 jours");
+    await screen.findByText("ready");
+
+    fireEvent.click(screen.getByTestId("ai-chat-launch"));
+
+    expect(onLaunchGeneration).toHaveBeenCalledTimes(1);
+    const brief = onLaunchGeneration.mock.calls[0]?.[0] as string;
+    // Structured params first…
+    expect(brief).toContain("start: Lille");
+    expect(brief).toContain("durationDays: 3");
+    // …then the rider's own turn as fallback.
+    expect(brief).toContain("Boucle au départ de Lille sur 3 jours");
+    expect(eventDetails[0]?.brief).toBe(brief);
+  });
+
+  it("surfaces the configure CTA on a 422 ai_not_configured", async () => {
+    sendAiChat.mockResolvedValueOnce({
+      status: "not_configured",
+    } as AiChatResult);
+    render(<AiChatCard />);
+
+    await sendUserTurn("Boucle Lille");
+    await waitFor(() =>
+      expect(screen.getByTestId("ai-chat-not-configured")).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId("ai-chat-configure-cta")).toHaveAttribute(
+      "href",
+      "/account/settings#ai",
+    );
+  });
+
+  it("maps 429 / 503 / generic failures to localized error bubbles", async () => {
+    sendAiChat.mockResolvedValueOnce({ status: "rate_limited" });
+    sendAiChat.mockResolvedValueOnce({ status: "unavailable" });
+    sendAiChat.mockResolvedValueOnce({ status: "error" });
+    render(<AiChatCard />);
+
+    await sendUserTurn("a");
+    await screen.findByText("errorRateLimit");
+    await sendUserTurn("b");
+    await screen.findByText("errorUnavailable");
+    await sendUserTurn("c");
+    await screen.findByText("errorGeneric");
+
+    // Error bubbles render in the assistant lane flagged as errors.
+    expect(
+      screen.getAllByTestId("ai-chat-message").filter((el) => {
+        return el.getAttribute("data-error") === "true";
+      }),
+    ).toHaveLength(3);
+  });
+
+  it("stops sending past the user-turn cap and shows the cap hint", async () => {
+    sendAiChat.mockResolvedValue(ok("ok", { start: "Lille" }));
+    render(<AiChatCard />);
+
+    for (let i = 0; i < MAX_USER_TURNS; i++) {
+      await sendUserTurn(`turn ${i}`);
+      // Wait for each reply so the next send sees the updated turn count.
+      await waitFor(() =>
+        expect(sendAiChat).toHaveBeenCalledTimes(i + 1),
+      );
+    }
+
+    // The (MAX+1)-th attempt must not hit the API and must surface the hint.
+    await sendUserTurn("one too many");
+    expect(screen.getByTestId("ai-chat-cap-hint")).toBeInTheDocument();
+    expect(sendAiChat).toHaveBeenCalledTimes(MAX_USER_TURNS);
+  });
+
+  it("disables every interactive control when disabled", () => {
+    render(<AiChatCard disabled />);
+    expect(screen.getByTestId("ai-chat-textarea")).toBeDisabled();
+    expect(screen.getByTestId("ai-chat-send")).toBeDisabled();
+    expect(screen.getByTestId("ai-chat-launch")).toBeDisabled();
+  });
+
+  // Locks the recap/brief keys to the ones the backend `brief-chat` prompt
+  // actually emits (elevationTolerance / dates / resupply, not elevation /
+  // startDate / supply); a divergence would silently drop them from both.
+  it("surfaces the elevationTolerance / dates / resupply fields in the brief", async () => {
+    sendAiChat.mockResolvedValueOnce(
+      ok(
+        "Noté",
+        {
+          start: "Lille",
+          elevationTolerance: "medium",
+          dates: "juillet",
+          resupply: "autonomie",
+        },
+        true,
+      ),
+    );
+    const onLaunchGeneration = vi.fn();
+    render(<AiChatCard onLaunchGeneration={onLaunchGeneration} />);
+
+    await sendUserTurn("Boucle Lille en juillet, peu de dénivelé, autonome");
+    await screen.findByText("Noté");
+
+    fireEvent.click(screen.getByTestId("ai-chat-launch"));
+    const brief = onLaunchGeneration.mock.calls[0]?.[0] as string;
+    expect(brief).toContain("elevationTolerance: medium");
+    expect(brief).toContain("dates: juillet");
+    expect(brief).toContain("resupply: autonomie");
+  });
+});

--- a/pwa/src/components/ai-chat-card.tsx
+++ b/pwa/src/components/ai-chat-card.tsx
@@ -9,18 +9,19 @@ import {
   type KeyboardEvent as ReactKeyboardEvent,
 } from "react";
 import { useTranslations } from "next-intl";
-import { Send, Sparkles } from "lucide-react";
+import Link from "next/link";
+import { Loader2, Send, Sparkles } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { sendAiChat, type AiChatResponseBody } from "@/lib/api/client";
 
 /**
- * One turn of the AI assistant conversation.
+ * One turn of the AI brief chat (`POST /trips/ai-chat`, ADR-045).
  *
- * The card stores both sides of the dialogue locally so the UI behaves
- * realistically (auto-scroll, alternating bubbles, keyboard navigation). The
- * rider's turns form the brief; the assistant turns are local stubs (there is
- * no pre-trip streaming chat endpoint; the brief drives a single-shot
- * generation via `POST /trips/ai-generate`, ADR-042).
+ * Both sides of the dialogue are stored locally: the endpoint is stateless, so
+ * the client carries the whole conversation on every turn. The assistant turns
+ * are real model replies (no longer canned stubs); launching the computation
+ * reuses `POST /trips/ai-generate` once the brief is complete enough.
  */
 export interface AiChatMessage {
   /** Stable id used as React key — generated from a monotonic counter. */
@@ -29,91 +30,167 @@ export interface AiChatMessage {
   role: "user" | "assistant";
   /** Free-text content of the turn. */
   content: string;
+  /** When true the bubble renders as an error (failed turn), not a reply. */
+  isError?: boolean;
 }
+
+/**
+ * Maximum number of *user* turns before the card stops sending and pushes the
+ * rider to launch (ADR-045 "filet, pas une cage"). Well under the backend
+ * ceiling (`AiChatRequest::MAX_MESSAGES = 40`, counting both roles): a 20-user
+ * cap leaves ample headroom for the interleaved assistant turns.
+ */
+export const MAX_USER_TURNS = 20;
 
 interface AiChatCardProps {
   /**
-   * Fired when the user clicks "Valider et continuer". Receives the current
-   * conversation transcript; the wizard host forwards the rider's turns as the
-   * brief to AI route generation (`POST /trips/ai-generate`, ADR-042). The card
-   * stays agnostic about how the conversation is consumed.
+   * Fired when the rider clicks "Lancer le calcul d'itinéraire". Receives the
+   * consolidated brief (the structured `collected` parameters, with the rider's
+   * own turns appended as fallback). The wizard host forwards it to
+   * `POST /trips/ai-generate` (ADR-045).
    */
-  onSubmitConversation?: (messages: ReadonlyArray<AiChatMessage>) => void;
+  onLaunchGeneration?: (brief: string) => void;
   /** Disables every interactive element (offline, parent processing, ...). */
   disabled?: boolean;
 }
 
 /**
- * Custom DOM event dispatched on the document when the user submits the chat,
- * in addition to the {@link AiChatCardProps.onSubmitConversation} callback.
- * Kept for test/legacy consumers that observe the transcript without coupling
- * to this component.
+ * Custom DOM event dispatched on the document when the rider launches the
+ * generation, in addition to the {@link AiChatCardProps.onLaunchGeneration}
+ * callback. Kept for test/legacy consumers that observe the launch without
+ * coupling to this component.
  */
-export const AI_CHAT_SUBMIT_EVENT = "ai-chat-submit";
+export const AI_CHAT_LAUNCH_EVENT = "ai-chat-launch";
 
-/** Detail shape for {@link AI_CHAT_SUBMIT_EVENT}. */
-export interface AiChatSubmitEventDetail {
-  messages: ReadonlyArray<AiChatMessage>;
+/** Detail shape for {@link AI_CHAT_LAUNCH_EVENT}. */
+export interface AiChatLaunchEventDetail {
+  brief: string;
 }
 
-/** Stub assistant placeholder rendered before the user has typed anything. */
-const STUB_ASSISTANT_GREETING_KEY = "stubGreeting";
+/**
+ * Ordered list of the `collected` keys the recap surfaces, paired with their
+ * i18n label key under `aiChat.recap`. Unknown keys returned by the model are
+ * ignored: the recap stays a curated summary, not a raw dump.
+ */
+const RECAP_FIELDS: ReadonlyArray<{ key: string; labelKey: string }> = [
+  { key: "start", labelKey: "start" },
+  { key: "end", labelKey: "end" },
+  { key: "loop", labelKey: "loop" },
+  { key: "durationDays", labelKey: "durationDays" },
+  { key: "profile", labelKey: "profile" },
+  { key: "elevationTolerance", labelKey: "elevation" },
+  { key: "dates", labelKey: "startDate" },
+  { key: "resupply", labelKey: "supply" },
+];
+
+/** Render a `collected` scalar as a display string (skips empty/nullish). */
+function formatRecapValue(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "boolean") return value ? "✓" : null;
+  const str = String(value).trim();
+  return str === "" ? null : str;
+}
 
 /**
- * "Assistant IA" card — multi-turn chat shell for step 1 of `/trips/new`.
+ * Whether the brief carries a geocodable departure. This is the single hard
+ * gate on the launch button (ADR-045): without a non-empty `collected.start`
+ * the AI route generation has nothing to geocode, so we never let the rider
+ * launch. `readyToGenerate` only drives the *recommended* highlight, not this.
+ */
+function hasGeocodableStart(
+  collected: AiChatResponseBody["collected"],
+): boolean {
+  const start = collected.start;
+  return typeof start === "string" && start.trim().length > 0;
+}
+
+/**
+ * Consolidate the brief sent to `POST /trips/ai-generate`. Prefers the
+ * structured `collected` summary (one `label: value` line per known field) and
+ * appends the rider's own turns as fallback so nothing the model failed to
+ * structure is lost.
+ */
+function buildBrief(
+  collected: AiChatResponseBody["collected"],
+  userTurns: ReadonlyArray<string>,
+): string {
+  const structured = RECAP_FIELDS.map(({ key }) => {
+    const value = formatRecapValue(collected[key]);
+    return value === null ? null : `${key}: ${value}`;
+  }).filter((line): line is string => line !== null);
+
+  const transcript = userTurns.map((t) => t.trim()).filter(Boolean);
+
+  return [...structured, ...transcript].join("\n").trim();
+}
+
+/**
+ * "Assistant IA" card — real multi-turn brief chat for step 1 of `/trips/new`
+ * (ADR-045).
  *
  * The card renders three regions:
  *
  *  1. A scrollable history of alternating user / assistant bubbles, anchored
  *     at the bottom (auto-scroll on every new message).
- *  2. A free-form textarea so the user can describe their desired itinerary
- *     ("Je veux faire le tour de Corse en 10 jours en septembre", ...).
- *  3. A submit row with the primary "Valider et continuer" button.
+ *  2. A live recap of the structured parameters the model `collected` so far
+ *     (departure, destination/loop, duration, profile, ...).
+ *  3. A composer textarea + a "Lancer le calcul d'itinéraire" button.
  *
- * The assistant replies are local stubs (no pre-trip streaming chat endpoint);
- * the rider's turns form the brief. On submit the card calls
- * {@link AiChatCardProps.onSubmitConversation} (wired to AI route generation)
- * and also dispatches {@link AI_CHAT_SUBMIT_EVENT} for test/legacy consumers.
+ * Each user turn POSTs the whole transcript to `/trips/ai-chat`; the reply is
+ * appended and the `collected` / `readyToGenerate` verdict updates the recap
+ * and the launch button. The launch button is *enabled* as soon as a geocodable
+ * departure is known and *highlighted* when the model judges the brief ready —
+ * the AI recommends, the rider decides.
  *
  * Accessibility:
  *
- *  - The history is exposed as an `aria-live="polite"` log so screen readers
- *    announce new turns.
- *  - The textarea reacts to `Enter` (submit) / `Shift+Enter` (newline) like a
- *    standard chat composer.
- *  - The "Valider et continuer" button is disabled until at least one user
- *    turn exists, mirroring the validation rule of the URL / GPX cards.
+ *  - The history is exposed as an `aria-live="polite"` log.
+ *  - The textarea reacts to `Enter` (send) / `Shift+Enter` (newline).
  */
 export function AiChatCard({
-  onSubmitConversation,
+  onLaunchGeneration,
   disabled = false,
 }: AiChatCardProps) {
   const t = useTranslations("aiChat");
 
   const [messages, setMessages] = useState<AiChatMessage[]>([]);
+  const [collected, setCollected] = useState<AiChatResponseBody["collected"]>(
+    {},
+  );
+  const [readyToGenerate, setReadyToGenerate] = useState(false);
   const [draft, setDraft] = useState("");
+  const [isSending, setIsSending] = useState(false);
+  const [capReached, setCapReached] = useState(false);
+  const [notConfigured, setNotConfigured] = useState(false);
   const counterRef = useRef(0);
+  const abortRef = useRef<AbortController | null>(null);
   const historyRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  const stubGreeting = t(STUB_ASSISTANT_GREETING_KEY);
-  const stubReply = t("stubReply");
+  const greeting = t("greeting");
 
   const transcript: ReadonlyArray<AiChatMessage> = useMemo(() => {
-    const greeting: AiChatMessage = {
+    const greetingMessage: AiChatMessage = {
       id: "greeting",
       role: "assistant",
-      content: stubGreeting,
+      content: greeting,
     };
-    return messages.length === 0 ? [greeting] : [greeting, ...messages];
-  }, [messages, stubGreeting]);
+    return messages.length === 0
+      ? [greetingMessage]
+      : [greetingMessage, ...messages];
+  }, [messages, greeting]);
+
+  const userTurnCount = useMemo(
+    () => messages.filter((m) => m.role === "user").length,
+    [messages],
+  );
 
   // Auto-scroll the history to the latest turn whenever a message is appended.
   useEffect(() => {
     const el = historyRef.current;
     if (!el) return;
     el.scrollTop = el.scrollHeight;
-  }, [transcript.length]);
+  }, [transcript.length, isSending]);
 
   // Auto-resize the textarea to fit its content (single-line → 4 lines max).
   const autoResize = useCallback(() => {
@@ -127,138 +204,304 @@ export function AiChatCard({
     autoResize();
   }, [draft, autoResize]);
 
+  // Abort any in-flight chat request on unmount so the LLM server doesn't keep
+  // generating tokens for a card that's gone.
+  useEffect(() => {
+    return () => abortRef.current?.abort();
+  }, []);
+
   const nextId = useCallback(() => {
     counterRef.current += 1;
     return `msg-${counterRef.current}`;
   }, []);
 
-  const sendDraft = useCallback(() => {
-    const trimmed = draft.trim();
-    if (!trimmed) return;
-    if (disabled) return;
+  const appendAssistantError = useCallback(
+    (content: string) => {
+      setMessages((prev) => [
+        ...prev,
+        { id: nextId(), role: "assistant", content, isError: true },
+      ]);
+    },
+    [nextId],
+  );
 
-    setMessages((prev) => [
-      ...prev,
-      { id: nextId(), role: "user", content: trimmed },
-      // Local stub reply: there is no pre-trip streaming chat endpoint, so the
-      // brief drives a single-shot generation on submit (ADR-042).
-      { id: nextId(), role: "assistant", content: stubReply },
-    ]);
+  const sendDraft = useCallback(async () => {
+    const trimmed = draft.trim();
+    if (!trimmed || disabled || isSending) return;
+
+    // Client-side turn cap: a filet, not a cage. Stop sending and nudge the
+    // rider to launch with what the model already understood (ADR-045).
+    if (userTurnCount >= MAX_USER_TURNS) {
+      setCapReached(true);
+      return;
+    }
+
+    const userMessage: AiChatMessage = {
+      id: nextId(),
+      role: "user",
+      content: trimmed,
+    };
+    // Build the wire transcript from the next state, not the stale closure.
+    const wire = [...messages, userMessage].map((m) => ({
+      role: m.role,
+      content: m.content,
+    }));
+
+    setMessages((prev) => [...prev, userMessage]);
     setDraft("");
-  }, [disabled, draft, nextId, stubReply]);
+    setIsSending(true);
+
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    const result = await sendAiChat(wire, controller.signal);
+
+    // A newer turn (or unmount) superseded this request — drop its outcome.
+    if (controller.signal.aborted) return;
+
+    switch (result.status) {
+      case "ok":
+        setMessages((prev) => [
+          ...prev,
+          { id: nextId(), role: "assistant", content: result.data.reply },
+        ]);
+        setCollected(result.data.collected);
+        setReadyToGenerate(result.data.readyToGenerate);
+        setNotConfigured(false);
+        break;
+      case "not_configured":
+        setNotConfigured(true);
+        break;
+      case "rate_limited":
+        appendAssistantError(t("errorRateLimit"));
+        break;
+      case "unavailable":
+        appendAssistantError(t("errorUnavailable"));
+        break;
+      default:
+        appendAssistantError(t("errorGeneric"));
+    }
+    setIsSending(false);
+  }, [
+    appendAssistantError,
+    disabled,
+    draft,
+    isSending,
+    messages,
+    nextId,
+    t,
+    userTurnCount,
+  ]);
 
   const handleKeyDown = useCallback(
     (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
       if (event.key === "Enter" && !event.shiftKey) {
         event.preventDefault();
-        sendDraft();
+        void sendDraft();
       }
     },
     [sendDraft],
   );
 
-  const handleSubmitConversation = useCallback(() => {
-    if (disabled) return;
-    if (messages.length === 0) return;
+  const canLaunch = hasGeocodableStart(collected) && !disabled;
 
-    // Hand the transcript to the wizard host (which POSTs the brief to
-    // /trips/ai-generate) and also surface it via a CustomEvent so E2E tests
-    // and legacy consumers can observe the submit without coupling.
-    onSubmitConversation?.(messages);
+  const handleLaunch = useCallback(() => {
+    if (disabled || !hasGeocodableStart(collected)) return;
+
+    const userTurns = messages
+      .filter((m) => m.role === "user")
+      .map((m) => m.content);
+    const brief = buildBrief(collected, userTurns);
+    if (!brief) return;
+
+    onLaunchGeneration?.(brief);
     if (typeof document !== "undefined") {
-      const event = new CustomEvent<AiChatSubmitEventDetail>(
-        AI_CHAT_SUBMIT_EVENT,
-        { detail: { messages } },
+      document.dispatchEvent(
+        new CustomEvent<AiChatLaunchEventDetail>(AI_CHAT_LAUNCH_EVENT, {
+          detail: { brief },
+        }),
       );
-      document.dispatchEvent(event);
     }
-  }, [disabled, messages, onSubmitConversation]);
+  }, [collected, disabled, messages, onLaunchGeneration]);
 
-  const canSubmitConversation = messages.length > 0 && !disabled;
-  const canSendDraft = draft.trim().length > 0 && !disabled;
+  const recapEntries = RECAP_FIELDS.map(({ key, labelKey }) => ({
+    labelKey,
+    value: formatRecapValue(collected[key]),
+  })).filter((e) => e.value !== null);
+
+  const canSendDraft =
+    draft.trim().length > 0 && !disabled && !isSending && !capReached;
 
   return (
     <div
-      className="flex flex-col gap-4 w-full"
+      className="flex flex-col gap-4 w-full lg:flex-row lg:items-stretch"
       data-testid="ai-chat-card"
       data-disabled={disabled || undefined}
+      data-ready={readyToGenerate || undefined}
     >
-      <div className="flex items-center gap-2 text-sm text-muted-foreground">
-        <Sparkles className="h-4 w-4 text-brand" aria-hidden="true" />
-        <span>{t("subtitle")}</span>
-      </div>
-
-      <div
-        ref={historyRef}
-        role="log"
-        aria-live="polite"
-        aria-label={t("historyAriaLabel")}
-        data-testid="ai-chat-history"
-        className={cn(
-          "flex flex-col gap-3 overflow-y-auto rounded-lg border bg-muted/20 p-3",
-          // Fixed scrollable height so the history feels like a chat box,
-          // not an ever-growing list. ~5 turns visible before scrolling.
-          "h-64 max-h-[40vh]",
-        )}
-      >
-        {transcript.map((message) => (
-          <ChatBubble key={message.id} message={message} />
-        ))}
-      </div>
-
-      <div className="flex flex-col gap-2">
-        <label
-          htmlFor="ai-chat-textarea"
-          className="text-sm font-medium text-foreground"
-        >
-          {t("inputLabel")}
-        </label>
-        <div className="flex items-end gap-2">
-          <textarea
-            ref={textareaRef}
-            id="ai-chat-textarea"
-            value={draft}
-            onChange={(event) => setDraft(event.target.value)}
-            onKeyDown={handleKeyDown}
-            placeholder={t("inputPlaceholder")}
-            disabled={disabled}
-            rows={2}
-            className={cn(
-              "flex-1 resize-none rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs",
-              "placeholder:text-muted-foreground",
-              "focus-visible:outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
-              "disabled:cursor-not-allowed disabled:opacity-60",
-            )}
-            data-testid="ai-chat-textarea"
-          />
-          <Button
-            type="button"
-            size="icon"
-            variant="outline"
-            onClick={sendDraft}
-            disabled={!canSendDraft}
-            aria-label={t("sendAriaLabel")}
-            data-testid="ai-chat-send"
-            className="shrink-0"
-          >
-            <Send className="h-4 w-4" aria-hidden="true" />
-          </Button>
+      <div className="flex flex-col gap-4 flex-1 min-w-0">
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Sparkles className="h-4 w-4 text-brand" aria-hidden="true" />
+          <span>{t("subtitle")}</span>
         </div>
-        <p className="text-xs text-muted-foreground/80">{t("inputHint")}</p>
+
+        <div
+          ref={historyRef}
+          role="log"
+          aria-live="polite"
+          aria-label={t("historyAriaLabel")}
+          data-testid="ai-chat-history"
+          className={cn(
+            "flex flex-col gap-3 overflow-y-auto rounded-lg border bg-muted/20 p-3",
+            "h-64 max-h-[40vh]",
+          )}
+        >
+          {transcript.map((message) => (
+            <ChatBubble key={message.id} message={message} />
+          ))}
+          {isSending && <TypingBubble label={t("thinking")} />}
+        </div>
+
+        {notConfigured && (
+          <div
+            data-testid="ai-chat-not-configured"
+            role="alert"
+            className="flex flex-col gap-2 rounded-md border border-brand/30 bg-brand/5 px-3 py-2 text-sm text-foreground"
+          >
+            <span className="flex items-center gap-2">
+              <Sparkles
+                className="h-4 w-4 shrink-0 text-brand"
+                aria-hidden="true"
+              />
+              <span>{t("errorNotConfigured")}</span>
+            </span>
+            <Link
+              href="/account/settings#ai"
+              className="self-start text-sm font-medium text-brand hover:underline"
+              data-testid="ai-chat-configure-cta"
+            >
+              {t("configureCta")}
+            </Link>
+          </div>
+        )}
+
+        <div className="flex flex-col gap-2">
+          <label
+            htmlFor="ai-chat-textarea"
+            className="text-sm font-medium text-foreground"
+          >
+            {t("inputLabel")}
+          </label>
+          <div className="flex items-end gap-2">
+            <textarea
+              ref={textareaRef}
+              id="ai-chat-textarea"
+              value={draft}
+              onChange={(event) => setDraft(event.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder={t("inputPlaceholder")}
+              disabled={disabled || capReached}
+              rows={2}
+              className={cn(
+                "flex-1 resize-none rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs",
+                "placeholder:text-muted-foreground",
+                "focus-visible:outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+                "disabled:cursor-not-allowed disabled:opacity-60",
+              )}
+              data-testid="ai-chat-textarea"
+            />
+            <Button
+              type="button"
+              size="icon"
+              variant="outline"
+              onClick={() => void sendDraft()}
+              disabled={!canSendDraft}
+              aria-label={t("sendAriaLabel")}
+              data-testid="ai-chat-send"
+              className="shrink-0"
+            >
+              <Send className="h-4 w-4" aria-hidden="true" />
+            </Button>
+          </div>
+          {capReached ? (
+            <p
+              className="text-xs text-amber-700 dark:text-amber-400"
+              data-testid="ai-chat-cap-hint"
+              role="status"
+            >
+              {t("capReached")}
+            </p>
+          ) : (
+            <p className="text-xs text-muted-foreground/80">{t("inputHint")}</p>
+          )}
+        </div>
       </div>
 
-      <Button
-        type="button"
-        onClick={handleSubmitConversation}
-        disabled={!canSubmitConversation}
-        data-testid="ai-chat-submit"
-        className={cn(
-          "w-full sm:w-auto self-end bg-brand-fill text-white hover:bg-brand-fill-hover",
-          "disabled:bg-brand-fill/50",
-        )}
+      <aside
+        className="flex flex-col gap-3 lg:w-64 lg:shrink-0"
+        data-testid="ai-chat-recap"
+        aria-label={t("recapAriaLabel")}
       >
-        {t("submitLabel")}
-      </Button>
+        <div className="rounded-lg border bg-card p-3 shadow-sm">
+          <h3 className="text-sm font-semibold text-foreground">
+            {t("recapTitle")}
+          </h3>
+          {recapEntries.length === 0 ? (
+            <p className="mt-2 text-xs text-muted-foreground">
+              {t("recapEmpty")}
+            </p>
+          ) : (
+            <dl className="mt-2 flex flex-col gap-1.5 text-sm">
+              {recapEntries.map((entry) => (
+                <div
+                  key={entry.labelKey}
+                  className="flex justify-between gap-2"
+                  data-testid={`ai-chat-recap-${entry.labelKey}`}
+                >
+                  <dt className="text-muted-foreground shrink-0">
+                    {t(`recap.${entry.labelKey}`)}
+                  </dt>
+                  <dd className="text-right font-medium text-foreground break-words">
+                    {entry.value}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          )}
+        </div>
+
+        <Button
+          type="button"
+          onClick={handleLaunch}
+          disabled={!canLaunch}
+          data-testid="ai-chat-launch"
+          data-recommended={(readyToGenerate && canLaunch) || undefined}
+          className={cn(
+            "w-full bg-brand-fill text-white hover:bg-brand-fill-hover",
+            "disabled:bg-brand-fill/50",
+            readyToGenerate &&
+              canLaunch &&
+              "ring-2 ring-brand ring-offset-2 animate-pulse",
+          )}
+        >
+          {t("launchLabel")}
+        </Button>
+        {readyToGenerate && canLaunch && (
+          <p
+            className="text-xs text-brand"
+            data-testid="ai-chat-launch-hint"
+            role="status"
+          >
+            {t("launchRecommended")}
+          </p>
+        )}
+        {!canLaunch && !disabled && (
+          <p className="text-xs text-muted-foreground/80">
+            {t("launchNeedsStart")}
+          </p>
+        )}
+      </aside>
     </div>
   );
 }
@@ -273,6 +516,7 @@ function ChatBubble({ message }: ChatBubbleProps) {
     <div
       data-testid="ai-chat-message"
       data-role={message.role}
+      data-error={message.isError || undefined}
       className={cn("flex w-full", isUser ? "justify-end" : "justify-start")}
     >
       <div
@@ -280,10 +524,27 @@ function ChatBubble({ message }: ChatBubbleProps) {
           "max-w-[85%] rounded-2xl px-3 py-2 text-sm leading-relaxed shadow-sm",
           isUser
             ? "bg-brand-fill text-white rounded-br-sm"
-            : "bg-background border border-border text-foreground rounded-bl-sm",
+            : message.isError
+              ? "bg-destructive/10 border border-destructive/40 text-destructive rounded-bl-sm"
+              : "bg-background border border-border text-foreground rounded-bl-sm",
         )}
       >
         {message.content}
+      </div>
+    </div>
+  );
+}
+
+function TypingBubble({ label }: { label: string }) {
+  return (
+    <div
+      className="flex w-full justify-start"
+      data-testid="ai-chat-typing"
+      aria-hidden="true"
+    >
+      <div className="flex items-center gap-2 rounded-2xl rounded-bl-sm border border-border bg-background px-3 py-2 text-sm text-muted-foreground shadow-sm">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        <span>{label}</span>
       </div>
     </div>
   );

--- a/pwa/src/components/card-selection.tsx
+++ b/pwa/src/components/card-selection.tsx
@@ -9,7 +9,7 @@ import {
 } from "react";
 import { useTranslations } from "next-intl";
 import { Link2, FileUp, Sparkles, ArrowLeft } from "lucide-react";
-import { AiChatCard, type AiChatMessage } from "@/components/ai-chat-card";
+import { AiChatCard } from "@/components/ai-chat-card";
 import { AiUnavailableNotice } from "@/components/ai-unavailable-notice";
 import { GpxDropZoneCard } from "@/components/gpx-drop-zone-card";
 import { SourceUrlChip } from "@/components/source-url-chip";
@@ -34,12 +34,14 @@ interface CardSelectionProps {
   onSubmitUrl: (url: string) => Promise<void> | void;
   onUploadFile: (file: File) => Promise<void> | void;
   /**
-   * Fired when the user submits the AI chat conversation via the "Valider et
-   * continuer" button. The trip-planner host forwards the brief to
-   * `POST /trips/ai-generate` (ADR-042). The chat card also dispatches an
-   * `ai-chat-submit` DOM event for test/legacy consumers.
+   * Fired when the rider launches AI route generation from the chat card's
+   * "Lancer le calcul d'itinéraire" button. Receives the consolidated brief
+   * (structured `collected` parameters + the rider's turns as fallback). The
+   * trip-planner host forwards it to `POST /trips/ai-generate` (ADR-045). The
+   * chat card also dispatches an `ai-chat-launch` DOM event for test/legacy
+   * consumers.
    */
-  onSubmitAiConversation?: (messages: ReadonlyArray<AiChatMessage>) => void;
+  onLaunchAiGeneration?: (brief: string) => void;
   disabled?: boolean;
 }
 
@@ -57,7 +59,7 @@ const MAX_GPX_SIZE_BYTES = 30 * 1024 * 1024;
 export function CardSelection({
   onSubmitUrl,
   onUploadFile,
-  onSubmitAiConversation,
+  onLaunchAiGeneration,
   disabled = false,
 }: CardSelectionProps) {
   const t = useTranslations("cardSelection");
@@ -126,7 +128,7 @@ export function CardSelection({
             unavailable={!aiCapability.available}
             notConfigured={!aiCapability.configured}
             onSelect={() => handleSelect("ai")}
-            onSubmitConversation={onSubmitAiConversation}
+            onLaunchGeneration={onLaunchAiGeneration}
           />
         )}
       </div>
@@ -401,7 +403,7 @@ interface AiCardProps {
   unavailable?: boolean;
   notConfigured?: boolean;
   onSelect: () => void;
-  onSubmitConversation?: (messages: ReadonlyArray<AiChatMessage>) => void;
+  onLaunchGeneration?: (brief: string) => void;
 }
 
 function AiCard({
@@ -410,7 +412,7 @@ function AiCard({
   unavailable = false,
   notConfigured = false,
   onSelect,
-  onSubmitConversation,
+  onLaunchGeneration,
 }: AiCardProps) {
   const t = useTranslations("cardSelection");
 
@@ -432,7 +434,7 @@ function AiCard({
       ) : (
         expanded && (
           <AiChatCard
-            onSubmitConversation={onSubmitConversation}
+            onLaunchGeneration={onLaunchGeneration}
             disabled={disabled}
           />
         )

--- a/pwa/src/components/trip-planner.tsx
+++ b/pwa/src/components/trip-planner.tsx
@@ -427,14 +427,10 @@ export function TripPlanner() {
             <CardSelection
               onSubmitUrl={handleMagicLink}
               onUploadFile={handleGpxUpload}
-              onSubmitAiConversation={(messages) => {
-                // The assistant turns are local stubs; the brief is the rider's
-                // own words, so only user turns are forwarded to the backend.
-                const brief = messages
-                  .filter((m) => m.role === "user")
-                  .map((m) => m.content)
-                  .join("\n")
-                  .trim();
+              onLaunchAiGeneration={(brief) => {
+                // The chat card consolidates the brief (structured `collected`
+                // parameters + the rider's turns as fallback, ADR-045); the
+                // host just forwards it to POST /trips/ai-generate.
                 if (brief) void handleAiGeneration(brief);
               }}
               disabled={!isOnline}

--- a/pwa/src/lib/api/client.ts
+++ b/pwa/src/lib/api/client.ts
@@ -685,6 +685,107 @@ const tripChatResponseSchema = z.object({
 });
 
 /**
+ * One turn of the pre-trip brief chat (`POST /trips/ai-chat`, ADR-045).
+ * Sourced from the generated OpenAPI schema (`AiChatMessage`) so role/content
+ * stay in lockstep with `App\ApiResource\Model\AiChatMessage`.
+ */
+export type AiChatTurn = components["schemas"]["AiChatMessage"];
+
+/**
+ * Response of `POST /trips/ai-chat` (`App\ApiResource\AiChatResponse`): the
+ * assistant reply, the model's readiness verdict and the running structured
+ * summary of the brief understood so far.
+ */
+export interface AiChatResponseBody {
+  reply: string;
+  readyToGenerate: boolean;
+  collected: Record<string, string | number | boolean | null>;
+}
+
+/**
+ * Outcome of {@link sendAiChat}. A discriminated union so the caller maps the
+ * backend's discrete failure modes (ADR-045) to localized messages without
+ * re-deriving them from a raw status code:
+ *
+ * - `ok`              — the assistant turn (reply + readiness + collected).
+ * - `not_configured`  — 422 `{error:"ai_not_configured"}`: no provider set;
+ *   surface the "configure une IA" CTA (mirrors `aiCapability.configured`).
+ * - `rate_limited`    — 429: per-user chat rate limit reached.
+ * - `unavailable`     — 503: provider unreachable / invalid token / quota.
+ * - `error`           — any other failure (network, 4xx, bad shape).
+ */
+export type AiChatResult =
+  | { status: "ok"; data: AiChatResponseBody }
+  | { status: "not_configured" }
+  | { status: "rate_limited" }
+  | { status: "unavailable" }
+  | { status: "error" };
+
+const aiChatResponseSchema = z.object({
+  reply: z.string(),
+  readyToGenerate: z.boolean(),
+  collected: z
+    .record(
+      z.string(),
+      z.union([z.string(), z.number(), z.boolean(), z.null()]),
+    )
+    .catch({})
+    .default({}),
+});
+
+function hasAiNotConfigured(body: unknown): boolean {
+  return (
+    body !== null &&
+    typeof body === "object" &&
+    "error" in body &&
+    (body as { error?: unknown }).error === "ai_not_configured"
+  );
+}
+
+/**
+ * Send the whole brief-chat transcript to `POST /trips/ai-chat` (ADR-045).
+ *
+ * The endpoint is stateless — the client carries the full conversation on every
+ * turn. Uses the typed {@link apiClient} (the route is fully described by the
+ * generated schema, unlike `sendTripChat` which keeps a hand-written mirror for
+ * legacy reasons), then classifies the discrete failure modes by HTTP status so
+ * the caller can localize them.
+ */
+export async function sendAiChat(
+  messages: ReadonlyArray<AiChatTurn>,
+  signal?: AbortSignal,
+): Promise<AiChatResult> {
+  let response: Response;
+  let error: unknown;
+  let data: unknown;
+  try {
+    const result = await apiClient.POST("/trips/ai-chat", {
+      body: { messages: [...messages] },
+      ...(signal ? { signal } : {}),
+    });
+    response = result.response;
+    error = result.error;
+    data = result.data;
+  } catch {
+    // Network failure / aborted request — the openapi-fetch promise rejects.
+    return { status: "error" };
+  }
+
+  if (response.ok && data) {
+    const parsed = aiChatResponseSchema.safeParse(data);
+    if (!parsed.success) return { status: "error" };
+    return { status: "ok", data: parsed.data };
+  }
+
+  if (response.status === 422 && hasAiNotConfigured(error)) {
+    return { status: "not_configured" };
+  }
+  if (response.status === 429) return { status: "rate_limited" };
+  if (response.status === 503) return { status: "unavailable" };
+  return { status: "error" };
+}
+
+/**
  * Duplicate an existing trip (deep-clone with all stages and settings).
  * Returns the new trip id on success, null on failure.
  */

--- a/pwa/src/lib/api/client.ts
+++ b/pwa/src/lib/api/client.ts
@@ -696,11 +696,14 @@ export type AiChatTurn = components["schemas"]["AiChatMessage"];
  * assistant reply, the model's readiness verdict and the running structured
  * summary of the brief understood so far.
  */
-export interface AiChatResponseBody {
-  reply: string;
-  readyToGenerate: boolean;
+export type AiChatResponseBody = Pick<
+  components["schemas"]["Trip.AiChatResponse.jsonld"],
+  "reply" | "readyToGenerate"
+> & {
+  // Intentionally narrower than the generated `{ [key: string]: unknown }`:
+  // the recap/brief only consume flat scalar values.
   collected: Record<string, string | number | boolean | null>;
-}
+};
 
 /**
  * Outcome of {@link sendAiChat}. A discriminated union so the caller maps the

--- a/pwa/tests/fixtures/api-mocks.ts
+++ b/pwa/tests/fixtures/api-mocks.ts
@@ -18,6 +18,18 @@ export interface MockApiOptions {
    * `false` to exercise the disabled-but-visible "not configured" affordances.
    */
   aiConfigured?: boolean;
+  /**
+   * Scripted replies for the brief chat (`POST /trips/ai-chat`, ADR-045). Each
+   * POST consumes the next entry (the last one repeats once exhausted). Set
+   * `status` to exercise the discrete failure modes (422 `ai_not_configured`,
+   * 429, 503). When omitted, the route serves a single generic reply.
+   */
+  aiChatTurns?: Array<{
+    reply?: string;
+    readyToGenerate?: boolean;
+    collected?: Record<string, string | number | boolean | null>;
+    status?: number;
+  }>;
 }
 
 const TRIP_ID = "test-trip-abc-123";
@@ -184,6 +196,7 @@ export async function mockAllApis(
     deleteStageFail = false,
     addStageFail = false,
     aiConfigured = true,
+    aiChatTurns,
   } = options;
 
   // POST /auth/refresh — return fake JWT so AuthGuard's silentRefresh succeeds
@@ -462,6 +475,38 @@ export async function mockAllApis(
       status: postTripStatus,
       contentType: "application/ld+json",
       body: JSON.stringify(postTripBody ?? defaultTripResponse),
+    });
+  });
+
+  // POST /trips/ai-chat — stateless brief chat (ADR-045). Serves the scripted
+  // `aiChatTurns` in order (last entry repeats); a turn carrying `status`
+  // exercises the discrete failure modes. Registered after the generic
+  // /trips/* routes so this exact path wins.
+  let aiChatCallIndex = 0;
+  await page.route("**/trips/ai-chat", (route, request) => {
+    if (request.method() !== "POST") return route.fallback();
+    const turns = aiChatTurns ?? [
+      { reply: "Got it! Tell me more about your trip." },
+    ];
+    const turn = turns[Math.min(aiChatCallIndex, turns.length - 1)];
+    aiChatCallIndex += 1;
+    if (turn?.status && turn.status >= 400) {
+      return route.fulfill({
+        status: turn.status,
+        contentType: "application/ld+json",
+        body: JSON.stringify(
+          turn.status === 422 ? { error: "ai_not_configured" } : {},
+        ),
+      });
+    }
+    return route.fulfill({
+      status: 200,
+      contentType: "application/ld+json",
+      body: JSON.stringify({
+        reply: turn?.reply ?? "Got it!",
+        readyToGenerate: turn?.readyToGenerate ?? false,
+        collected: turn?.collected ?? {},
+      }),
     });
   });
 

--- a/pwa/tests/mocked/ai-generation.spec.ts
+++ b/pwa/tests/mocked/ai-generation.spec.ts
@@ -2,46 +2,125 @@ import { test, expect } from "../fixtures/base.fixture";
 import { mockAllApis, getTripId } from "../fixtures/api-mocks";
 
 /**
- * B2 (ADR-042): the AI card forwards the rider's brief to
- * `POST /trips/ai-generate` and then joins the same async preview lifecycle as
- * URL / GPX creation. Gating (disabled-but-visible when not configured) is
- * covered by ai-capabilities.spec.ts; here we exercise the happy path.
+ * ADR-045: the AI card is a real multi-turn brief chat. Each user turn POSTs the
+ * whole transcript to `POST /trips/ai-chat`; the structured `collected` summary
+ * fills the recap and gates the "Lancer le calcul d'itinéraire" button. Clicking
+ * launch consolidates a brief and reuses `POST /trips/ai-generate` (the same
+ * async preview lifecycle as URL / GPX creation). Capability gating
+ * (disabled-but-visible when not configured) is covered by ai-capabilities.spec.ts.
  */
-test.beforeEach(async ({ page }) => {
-  await mockAllApis(page);
-  await page.goto("/");
-  await page.waitForLoadState("networkidle");
-});
 
-test("AI card submits the brief to /trips/ai-generate and starts generation", async ({
+test("brief chat collects parameters, recommends launch, and fires /trips/ai-generate", async ({
   page,
 }) => {
+  await mockAllApis(page, {
+    aiChatTurns: [
+      // First turn: no start yet → launch stays disabled.
+      {
+        reply: "Où veux-tu partir ?",
+        readyToGenerate: false,
+        collected: { durationDays: 3 },
+      },
+      // Second turn: a geocodable start + ready → launch enabled & recommended.
+      {
+        reply: "Parfait, je tiens ton itinéraire.",
+        readyToGenerate: true,
+        collected: { start: "Lille", durationDays: 3, loop: true },
+      },
+    ],
+  });
+  await page.goto("/");
+  await page.waitForLoadState("networkidle");
+
   await page.getByTestId("card-ai").click();
 
   const textarea = page.getByTestId("ai-chat-textarea");
-  await textarea.fill(
-    "Boucle au départ de Lille, 2 jours, 80 km par jour, en tente",
-  );
-  await textarea.press("Enter");
+  const launch = page.getByTestId("ai-chat-launch");
 
-  // The rider's turn is recorded (the assistant reply is a local stub).
-  await expect(
-    page.locator('[data-testid="ai-chat-message"][data-role="user"]'),
-  ).toHaveCount(1);
+  // Launch is hard-gated off until a geocodable start is collected.
+  await expect(launch).toBeDisabled();
+
+  const lastAssistant = page
+    .locator('[data-testid="ai-chat-message"][data-role="assistant"]')
+    .last();
+
+  await textarea.fill("Une boucle de 3 jours");
+  await textarea.press("Enter");
+  await expect(lastAssistant).toContainText("Où veux-tu partir ?");
+  // readyToGenerate is false here and start is still missing.
+  await expect(launch).toBeDisabled();
+
+  await textarea.fill("Au départ de Lille");
+  await textarea.press("Enter");
+  await expect(lastAssistant).toContainText("je tiens ton itinéraire");
+
+  // Recap reflects the collected parameters.
+  await expect(page.getByTestId("ai-chat-recap-start")).toContainText("Lille");
+  await expect(page.getByTestId("ai-chat-recap-durationDays")).toContainText(
+    "3",
+  );
+
+  // Start is known → launch enabled; readyToGenerate → recommended highlight.
+  await expect(launch).toBeEnabled();
+  await expect(launch).toHaveAttribute("data-recommended", "true");
 
   const [request] = await Promise.all([
     page.waitForRequest(
       (req) =>
         req.url().includes("/trips/ai-generate") && req.method() === "POST",
     ),
-    page.getByTestId("ai-chat-submit").click(),
+    launch.click(),
   ]);
 
-  // Only the user's words are forwarded as the brief — never the stub replies.
+  // The consolidated brief carries the structured params + the rider's turns.
   const body = JSON.parse(request.postData() ?? "{}") as { brief?: string };
-  expect(body.brief).toContain("Boucle au départ de Lille");
-  expect(body.brief).toContain("80 km par jour");
+  expect(body.brief).toContain("start: Lille");
+  expect(body.brief).toContain("Au départ de Lille");
 
   // Generation kicked off → the wizard navigates to the trip preview lifecycle.
   await expect(page).toHaveURL(new RegExp(`/trips/${getTripId()}`));
+});
+
+test("the launch button stays disabled without a geocodable start", async ({
+  page,
+}) => {
+  await mockAllApis(page, {
+    aiChatTurns: [
+      {
+        // Model says ready, but no `start` → the hard gate keeps launch off.
+        reply: "C'est noté.",
+        readyToGenerate: true,
+        collected: { durationDays: 5, profile: "gravel" },
+      },
+    ],
+  });
+  await page.goto("/");
+  await page.waitForLoadState("networkidle");
+
+  await page.getByTestId("card-ai").click();
+  const textarea = page.getByTestId("ai-chat-textarea");
+  await textarea.fill("5 jours en gravel");
+  await textarea.press("Enter");
+
+  await expect(page.getByTestId("ai-chat-recap-durationDays")).toContainText(
+    "5",
+  );
+  await expect(page.getByTestId("ai-chat-launch")).toBeDisabled();
+});
+
+test("a 422 ai_not_configured surfaces the configure CTA", async ({ page }) => {
+  await mockAllApis(page, {
+    aiChatTurns: [{ status: 422 }],
+  });
+  await page.goto("/");
+  await page.waitForLoadState("networkidle");
+
+  await page.getByTestId("card-ai").click();
+  const textarea = page.getByTestId("ai-chat-textarea");
+  await textarea.fill("Boucle au départ de Lille");
+  await textarea.press("Enter");
+
+  const cta = page.getByTestId("ai-chat-configure-cta");
+  await expect(page.getByTestId("ai-chat-not-configured")).toBeVisible();
+  await expect(cta).toHaveAttribute("href", "/account/settings#ai");
 });

--- a/pwa/tests/mocked/card-selection.spec.ts
+++ b/pwa/tests/mocked/card-selection.spec.ts
@@ -41,23 +41,23 @@ test.describe("Card Selection — Acte 1 Préparation", () => {
     await expect(page.getByTestId("card-gpx")).toBeHidden();
   });
 
-  test("AI chat appends user / assistant turns and submits the conversation", async ({
+  test("AI chat appends user / assistant turns and launches on a collected start", async ({
     page,
   }) => {
     await page.getByTestId("card-ai").click();
 
-    // The "Valider et continuer" button is disabled while the conversation is empty
-    const submit = page.getByTestId("ai-chat-submit");
-    await expect(submit).toBeDisabled();
+    // The launch button is hard-gated off until a geocodable start is collected.
+    const launch = page.getByTestId("ai-chat-launch");
+    await expect(launch).toBeDisabled();
 
-    // Capture the submit event so we can assert on the dispatched transcript
+    // Capture the launch event so we can assert on the consolidated brief.
     await page.evaluate(() => {
-      (window as unknown as { __aiChatSubmits: unknown[] }).__aiChatSubmits =
+      (window as unknown as { __aiChatLaunches: unknown[] }).__aiChatLaunches =
         [];
-      document.addEventListener("ai-chat-submit", (event) => {
+      document.addEventListener("ai-chat-launch", (event) => {
         (
-          window as unknown as { __aiChatSubmits: unknown[] }
-        ).__aiChatSubmits.push((event as CustomEvent).detail);
+          window as unknown as { __aiChatLaunches: unknown[] }
+        ).__aiChatLaunches.push((event as CustomEvent).detail);
       });
     });
 
@@ -65,7 +65,6 @@ test.describe("Card Selection — Acte 1 Préparation", () => {
     await textarea.fill("Tour de Corse en 10 jours en septembre");
     await textarea.press("Enter");
 
-    // Two new bubbles appended (user + assistant stub)
     const userMessages = page.locator(
       '[data-testid="ai-chat-message"][data-role="user"]',
     );
@@ -73,20 +72,12 @@ test.describe("Card Selection — Acte 1 Préparation", () => {
       '[data-testid="ai-chat-message"][data-role="assistant"]',
     );
     await expect(userMessages).toHaveCount(1);
-    // The greeting + the stub reply
+    // The greeting + the real assistant reply from the mocked /trips/ai-chat.
     await expect(assistantMessages).toHaveCount(2);
     await expect(userMessages.first()).toContainText("Tour de Corse");
 
-    await expect(submit).toBeEnabled();
-    await submit.click();
-
-    const submits = await page.evaluate(
-      () =>
-        (window as unknown as { __aiChatSubmits: { messages: unknown[] }[] })
-          .__aiChatSubmits,
-    );
-    expect(submits.length).toBe(1);
-    expect(submits[0]?.messages.length).toBe(2);
+    // The default mock collects no start, so launch stays disabled.
+    await expect(launch).toBeDisabled();
   });
 
   test("selecting Link card reveals URL input and hides GPX card", async ({


### PR DESCRIPTION
## Contexte

#751 — **partie 2/2 (front)**, dernier morceau. La partie 1 (#757) a livré l'endpoint stateless `POST /trips/ai-chat` ; #758 a aligné les routes in-ride. Cette PR remplace le **stub** `ai-chat-card.tsx` (réponses canned + génération single-shot) par un **vrai chat conversationnel**.

## Ce que fait la PR (UX ADR-045)

- **Chat multi-tours** : chaque message poste toute la conversation à `POST /trips/ai-chat` ; la réponse `{ reply, readyToGenerate, collected }` ajoute une bulle assistant et alimente un **récap** latéral des paramètres compris.
- **Bouton « Lancer le calcul d'itinéraire » cliquable à tout moment**, avec un seul garde-fou dur : activé dès qu'un **départ géocodable** (`collected.start`) est connu ; **mis en avant** quand `readyToGenerate` est vrai (l'IA recommande, le cycliste décide).
- **Lancement** : consolide un `brief` (`collected` + tours utilisateur) et réutilise le flux **existant** `POST /trips/ai-generate` — le chat ne route jamais.
- **Plafond de tours** côté client (20, sous le plafond serveur de 40) ; au-delà, on pousse au lancement.
- **Erreurs** : 422 `ai_not_configured` → message + CTA configuration fournisseur ; 429 / 503 → bulles localisées (FR tutoiement + EN).
- Helper API `sendAiChat` typé (depuis `schema.d.ts`), union discriminée `ok | not_configured | rate_limited | unavailable | error`.

## Cleanup backend

Retrait de l'`#[ApiResource(shortName: 'AiChat', operations: [])]` redondant sur `AiChatResponse` (observation du bot sur #757) — vérifié : le schéma de réponse de `/trips/ai-chat` reste dérivé de `output:` (typegen diff = 0).

## Correctif d'alignement (trouvé en revue)

Le récap/brief lisait `elevation` / `startDate` / `supply`, alors que le prompt backend `brief-chat.txt` émet **`elevationTolerance` / `dates` / `resupply`** — ces champs n'auraient jamais été affichés ni inclus dans le brief. Clés réalignées + **test de contrat** ajouté (`ai-chat-card.test.tsx`) qui échouait avec l'ancien mapping.

## Vérification

`tsc --noEmit` ✅ · ESLint ✅ · **Vitest** (dont `ai-chat-card.test.tsx`, 12 cas) ✅ · **Playwright mocked** (flux chat → lancer, 422 CTA) ✅ · PHPStan ✅ · i18n FR/EN en phase ✅. CI complète en cours de vérification.

Refs #751

<!-- claude-review-start -->
## Claude Review

Solid implementation overall. The second commit correctly anchored `AiChatResponseBody` to the generated schema (`Trip.AiChatResponse.jsonld`), addressing the SSOT finding from the previous review. Abort-on-unmount is correctly wired, the discriminated-union error mapping is thorough, the turn cap is client-side only (well under the server ceiling), and the 12-case Vitest suite plus 3 new Playwright flows cover the material paths. No critical or warning findings.

**Resolved 1 previously open thread**: the `AiChatResponseBody` SSOT thread — fixed in `refactor(ai): anchor AiChatResponseBody to the generated schema`.

**PR title:** `feat(ai): conversational trip-brief chat card` — description is still a noun phrase rather than imperative mood (Conventional Commits requires _imperative, lowercase, no trailing period_). Suggested: `feat(ai): add conversational trip-brief chat card`.

## Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

_Reviewed commit: `a138d10`_
<!-- claude-review-end -->