### PR TITLE
fix(ai): make LLM provider calls resilient (retry 5xx, 20s timeout, actionable errors)

### DIFF
--- a/api/config/packages/framework.php
+++ b/api/config/packages/framework.php
@@ -91,10 +91,12 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 // Per-user BYO-token AI providers (ADR-042). The symfony/ai-platform
                 // bridge sends the user's key per request; these scoped clients add a
                 // descriptive User-Agent + timeout and lock each one to its provider
-                // host (SSRF). retry_failed retries transient provider failures
-                // (429 and 503 "overloaded"/"high demand", POST included, with
-                // exponential back-off); permanent 401/403 token errors are not
-                // retried and degrade gracefully via the error taxonomy (ADR-042).
+                // host (SSRF). retry_failed retries only transient server-side
+                // failures (5xx: 502/503/504..., "overloaded"/"high demand", POST
+                // included, with exponential back-off). 429 is NOT retried; the error
+                // taxonomy distinguishes a transient rate-limit (Retry-After) from an
+                // exhausted quota ("fail fast"), and 401/403 token errors degrade
+                // gracefully (ADR-042).
                 // timeout (20s) stays under PHP's 30s max_execution_time so a slow
                 // provider yields a handled TransportException (-> 503 "retry") rather
                 // than a fatal 500; capped at 2 retries to keep the worst case (a few
@@ -105,6 +107,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                     'timeout' => 20,
                     'retry_failed' => [
                         'max_retries' => 2,
+                        'http_codes' => [500, 502, 503, 504, 507, 510],
                     ],
                     'headers' => ['User-Agent' => 'BikeTripPlanner/1.0 (https://github.com/vincentchalamon/bike-trip-planner)'],
                 ],
@@ -114,6 +117,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                     'timeout' => 20,
                     'retry_failed' => [
                         'max_retries' => 2,
+                        'http_codes' => [500, 502, 503, 504, 507, 510],
                     ],
                     'headers' => ['User-Agent' => 'BikeTripPlanner/1.0 (https://github.com/vincentchalamon/bike-trip-planner)'],
                 ],
@@ -123,6 +127,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                     'timeout' => 20,
                     'retry_failed' => [
                         'max_retries' => 2,
+                        'http_codes' => [500, 502, 503, 504, 507, 510],
                     ],
                     'headers' => ['User-Agent' => 'BikeTripPlanner/1.0 (https://github.com/vincentchalamon/bike-trip-planner)'],
                 ],

--- a/api/config/packages/framework.php
+++ b/api/config/packages/framework.php
@@ -91,23 +91,35 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 // Per-user BYO-token AI providers (ADR-042). The symfony/ai-platform
                 // bridge sends the user's key per request; these scoped clients add a
                 // descriptive User-Agent + timeout and lock each one to its provider
-                // host (SSRF). Selective retry is layered on with the error taxonomy.
+                // host (SSRF). retry_failed retries transient provider failures
+                // (429 and 503 "overloaded"/"high demand", POST included, with
+                // exponential back-off); permanent 401/403 token errors are not
+                // retried and degrade gracefully via the error taxonomy (ADR-042).
                 'anthropic.client' => [
                     'scope' => '^https://api\\.anthropic\\.com',
                     'max_redirects' => 2,
                     'timeout' => 30,
+                    'retry_failed' => [
+                        'max_retries' => 3,
+                    ],
                     'headers' => ['User-Agent' => 'BikeTripPlanner/1.0 (https://github.com/vincentchalamon/bike-trip-planner)'],
                 ],
                 'openai.client' => [
                     'scope' => '^https://api\\.openai\\.com',
                     'max_redirects' => 2,
                     'timeout' => 30,
+                    'retry_failed' => [
+                        'max_retries' => 3,
+                    ],
                     'headers' => ['User-Agent' => 'BikeTripPlanner/1.0 (https://github.com/vincentchalamon/bike-trip-planner)'],
                 ],
                 'gemini.client' => [
                     'scope' => '^https://generativelanguage\\.googleapis\\.com',
                     'max_redirects' => 2,
                     'timeout' => 30,
+                    'retry_failed' => [
+                        'max_retries' => 3,
+                    ],
                     'headers' => ['User-Agent' => 'BikeTripPlanner/1.0 (https://github.com/vincentchalamon/bike-trip-planner)'],
                 ],
             ],

--- a/api/config/packages/framework.php
+++ b/api/config/packages/framework.php
@@ -95,30 +95,34 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 // (429 and 503 "overloaded"/"high demand", POST included, with
                 // exponential back-off); permanent 401/403 token errors are not
                 // retried and degrade gracefully via the error taxonomy (ADR-042).
+                // timeout (20s) stays under PHP's 30s max_execution_time so a slow
+                // provider yields a handled TransportException (-> 503 "retry") rather
+                // than a fatal 500; capped at 2 retries to keep the worst case (a few
+                // 503s then a timeout) below that ceiling.
                 'anthropic.client' => [
                     'scope' => '^https://api\\.anthropic\\.com',
                     'max_redirects' => 2,
-                    'timeout' => 30,
+                    'timeout' => 20,
                     'retry_failed' => [
-                        'max_retries' => 3,
+                        'max_retries' => 2,
                     ],
                     'headers' => ['User-Agent' => 'BikeTripPlanner/1.0 (https://github.com/vincentchalamon/bike-trip-planner)'],
                 ],
                 'openai.client' => [
                     'scope' => '^https://api\\.openai\\.com',
                     'max_redirects' => 2,
-                    'timeout' => 30,
+                    'timeout' => 20,
                     'retry_failed' => [
-                        'max_retries' => 3,
+                        'max_retries' => 2,
                     ],
                     'headers' => ['User-Agent' => 'BikeTripPlanner/1.0 (https://github.com/vincentchalamon/bike-trip-planner)'],
                 ],
                 'gemini.client' => [
                     'scope' => '^https://generativelanguage\\.googleapis\\.com',
                     'max_redirects' => 2,
-                    'timeout' => 30,
+                    'timeout' => 20,
                     'retry_failed' => [
-                        'max_retries' => 3,
+                        'max_retries' => 2,
                     ],
                     'headers' => ['User-Agent' => 'BikeTripPlanner/1.0 (https://github.com/vincentchalamon/bike-trip-planner)'],
                 ],

--- a/api/src/Llm/AiProvider.php
+++ b/api/src/Llm/AiProvider.php
@@ -41,7 +41,7 @@ enum AiProvider: string
     {
         return match ($this) {
             self::ANTHROPIC => 'claude-haiku-4-5-20251001',
-            self::GEMINI => 'gemini-2.5-flash',
+            self::GEMINI => 'gemini-2.0-flash',
             self::OPENAI => 'gpt-4o-mini',
         };
     }
@@ -53,7 +53,7 @@ enum AiProvider: string
     {
         return match ($this) {
             self::ANTHROPIC => 'claude-sonnet-4-6',
-            self::GEMINI => 'gemini-2.5-flash',
+            self::GEMINI => 'gemini-2.0-flash',
             self::OPENAI => 'gpt-4o-mini',
         };
     }

--- a/api/src/State/TripAiChatProcessor.php
+++ b/api/src/State/TripAiChatProcessor.php
@@ -25,7 +25,6 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
-use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
 use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 use Symfony\Component\RateLimiter\RateLimiterFactory;
@@ -111,12 +110,29 @@ final readonly class TripAiChatProcessor implements ProcessorInterface
                 systemPrompt: $systemPrompt,
             );
         } catch (AiUnavailableException $aiUnavailableException) {
-            $this->logger->critical('AI provider unreachable — ai-chat endpoint returning 503.', [
-                'reason' => $aiUnavailableException->getReason()->value,
+            $reason = $aiUnavailableException->getReason();
+
+            $this->logger->critical('AI provider call failed — ai-chat endpoint degrading.', [
+                'reason' => $reason->value,
                 'error' => $aiUnavailableException->getMessage(),
             ]);
 
-            throw new ServiceUnavailableHttpException(retryAfter: $aiUnavailableException->getRetryAfter(), message: $this->unavailableMessage($aiUnavailableException->getReason(), $locale), previous: $aiUnavailableException);
+            // Propagate the classified reason (ADR-042/045) so the UI can show an
+            // actionable message instead of a generic "retry": an exhausted quota
+            // or a revoked token are not transient, so retrying is misleading.
+            [$status, $error] = match ($reason) {
+                AiFailureReason::INVALID_TOKEN => [Response::HTTP_UNPROCESSABLE_ENTITY, 'ai_invalid_token'],
+                AiFailureReason::QUOTA_EXCEEDED => [Response::HTTP_UNPROCESSABLE_ENTITY, 'ai_quota_exceeded'],
+                AiFailureReason::RATE_LIMITED => [Response::HTTP_TOO_MANY_REQUESTS, 'ai_rate_limited'],
+                AiFailureReason::UNAVAILABLE => [Response::HTTP_SERVICE_UNAVAILABLE, 'ai_unavailable'],
+            };
+
+            $headers = [];
+            if (AiFailureReason::RATE_LIMITED === $reason && null !== $aiUnavailableException->getRetryAfter()) {
+                $headers['Retry-After'] = (string) $aiUnavailableException->getRetryAfter();
+            }
+
+            return new JsonResponse(['error' => $error], $status, $headers);
         }
 
         $rawContent = null === $response ? '' : ($this->responseParser->extractText($response) ?? '');
@@ -164,22 +180,5 @@ final readonly class TripAiChatProcessor implements ProcessorInterface
         }
 
         return $built;
-    }
-
-    private function unavailableMessage(AiFailureReason $reason, string $locale): string
-    {
-        if ('fr' === $locale) {
-            return match ($reason) {
-                AiFailureReason::INVALID_TOKEN => 'Votre clé IA semble invalide. Vérifiez-la dans vos réglages.',
-                AiFailureReason::QUOTA_EXCEEDED => 'Le quota de votre offre IA est épuisé. Vérifiez votre compte chez le fournisseur.',
-                default => 'Assistant IA temporairement indisponible. Réessayez dans un instant.',
-            };
-        }
-
-        return match ($reason) {
-            AiFailureReason::INVALID_TOKEN => 'Your AI key looks invalid. Check it in your settings.',
-            AiFailureReason::QUOTA_EXCEEDED => 'Your AI plan quota is exhausted. Check your provider account.',
-            default => 'AI assistant temporarily unavailable. Please try again shortly.',
-        };
     }
 }

--- a/api/src/State/TripAiChatProcessor.php
+++ b/api/src/State/TripAiChatProcessor.php
@@ -112,10 +112,14 @@ final readonly class TripAiChatProcessor implements ProcessorInterface
         } catch (AiUnavailableException $aiUnavailableException) {
             $reason = $aiUnavailableException->getReason();
 
-            $this->logger->critical('AI provider call failed — ai-chat endpoint degrading.', [
-                'reason' => $reason->value,
-                'error' => $aiUnavailableException->getMessage(),
-            ]);
+            // Only a genuine provider outage (UNAVAILABLE) is worth paging on; a bad
+            // key or an exhausted quota is a user-config error, logged as a warning
+            // to avoid false on-call alerts.
+            $this->logger->log(
+                AiFailureReason::UNAVAILABLE === $reason ? 'critical' : 'warning',
+                'AI provider call failed — ai-chat endpoint degrading.',
+                ['reason' => $reason->value, 'error' => $aiUnavailableException->getMessage()],
+            );
 
             // Propagate the classified reason (ADR-042/045) so the UI can show an
             // actionable message instead of a generic "retry": an exhausted quota

--- a/api/src/State/TripChatProcessor.php
+++ b/api/src/State/TripChatProcessor.php
@@ -161,11 +161,16 @@ final readonly class TripChatProcessor implements ProcessorInterface
                 systemPrompt: $systemPrompt,
             );
         } catch (AiUnavailableException $aiUnavailableException) {
-            $this->logger->critical('AI provider unreachable — chat endpoint returning 503.', [
-                'tripId' => $tripId,
-                'reason' => $aiUnavailableException->getReason()->value,
-                'error' => $aiUnavailableException->getMessage(),
-            ]);
+            $reason = $aiUnavailableException->getReason();
+
+            // Page only on a genuine provider outage (UNAVAILABLE); a bad key or an
+            // exhausted quota is a user-config error, logged as a warning to avoid
+            // false on-call alerts.
+            $this->logger->log(
+                AiFailureReason::UNAVAILABLE === $reason ? 'critical' : 'warning',
+                'AI provider unreachable — chat endpoint returning 503.',
+                ['tripId' => $tripId, 'reason' => $reason->value, 'error' => $aiUnavailableException->getMessage()],
+            );
 
             throw new ServiceUnavailableHttpException(retryAfter: $aiUnavailableException->getRetryAfter(), message: $this->unavailableMessage($aiUnavailableException), previous: $aiUnavailableException);
         }

--- a/api/tests/Functional/TripAiChatTest.php
+++ b/api/tests/Functional/TripAiChatTest.php
@@ -137,6 +137,48 @@ final class TripAiChatTest extends ApiTestCase
     }
 
     #[Test]
+    public function returns422WithInvalidTokenErrorWhenProviderRejectsKey(): void
+    {
+        $client = new readonly class () implements LlmClientInterface {
+            public function isEnabled(): bool
+            {
+                return true;
+            }
+
+            public function generate(string $model, string $prompt, ?string $systemPrompt = null, array $options = []): array
+            {
+                throw new AiUnavailableException('bad key', AiFailureReason::INVALID_TOKEN);
+            }
+
+            public function chat(string $model, array $messages, ?string $systemPrompt = null, array $options = []): array
+            {
+                throw new AiUnavailableException('bad key', AiFailureReason::INVALID_TOKEN);
+            }
+        };
+
+        $resolver = new readonly class ($client) implements UserLlmResolverInterface {
+            public function __construct(private LlmClientInterface $client)
+            {
+            }
+
+            public function forUser(User $user): ResolvedLlmClient
+            {
+                return new ResolvedLlmClient($this->client, AiProvider::ANTHROPIC);
+            }
+        };
+
+        self::getContainer()->set(UserLlmResolverInterface::class, $resolver);
+
+        $response = $this->client->request('POST', '/trips/ai-chat', [
+            'json' => ['messages' => [['role' => 'user', 'content' => 'Bonjour']]],
+            'headers' => ['Content-Type' => 'application/ld+json', ...$this->authHeader($this->jwtToken)],
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+        $this->assertSame(['error' => 'ai_invalid_token'], $response->toArray(false));
+    }
+
+    #[Test]
     public function rejectsSystemRole(): void
     {
         $this->installLlmClient([

--- a/api/tests/Functional/TripAiChatTest.php
+++ b/api/tests/Functional/TripAiChatTest.php
@@ -8,6 +8,8 @@ use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
 use ApiPlatform\Symfony\Bundle\Test\Client;
 use App\Entity\User;
 use App\Llm\AiProvider;
+use App\Llm\Exception\AiFailureReason;
+use App\Llm\Exception\AiUnavailableException;
 use App\Llm\LlmClientInterface;
 use App\Llm\ResolvedLlmClient;
 use App\Llm\UserLlmResolverInterface;

--- a/api/tests/Integration/Llm/AiProviderClientRetryTest.php
+++ b/api/tests/Integration/Llm/AiProviderClientRetryTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Llm;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\HttpClient\RetryableHttpClient;
+
+/**
+ * Guards that every per-user AI provider scoped client (ADR-042) enables
+ * `retry_failed`, i.e. is wrapped in a {@see RetryableHttpClient}. Gemini (and
+ * occasionally the others) returns transient `503 "high demand"` / `429` under
+ * load on the default model; without retry these surface as a one-shot 503 to
+ * the rider. Symfony's default retry status codes retry 429 and 503 on every
+ * method (POST included), with exponential back-off — so activating the wrapper
+ * here is what makes the AI endpoints resilient.
+ */
+final class AiProviderClientRetryTest extends KernelTestCase
+{
+    #[Test]
+    #[DataProvider('aiScopedClientIds')]
+    public function aiScopedClientEnablesRetry(string $serviceId): void
+    {
+        self::bootKernel();
+
+        self::assertInstanceOf(
+            RetryableHttpClient::class,
+            self::getContainer()->get($serviceId),
+            \sprintf('AI scoped client "%s" must enable retry_failed so transient 429/503 provider failures are retried (ADR-042).', $serviceId),
+        );
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function aiScopedClientIds(): iterable
+    {
+        yield 'anthropic' => ['anthropic.client'];
+        yield 'openai' => ['openai.client'];
+        yield 'gemini' => ['gemini.client'];
+    }
+}

--- a/api/tests/Integration/Llm/AiProviderClientRetryTest.php
+++ b/api/tests/Integration/Llm/AiProviderClientRetryTest.php
@@ -36,7 +36,7 @@ final class AiProviderClientRetryTest extends KernelTestCase
 
         self::assertContains(
             RetryableHttpClient::class,
-            self::decoratorChain($client),
+            $this->decoratorChain($client),
             \sprintf('AI scoped client "%s" must enable retry_failed so transient 429/503 provider failures are retried (ADR-042).', $serviceId),
         );
     }
@@ -57,7 +57,7 @@ final class AiProviderClientRetryTest extends KernelTestCase
      *
      * @return list<class-string>
      */
-    private static function decoratorChain(HttpClientInterface $client): array
+    private function decoratorChain(HttpClientInterface $client): array
     {
         $chain = [];
         $current = $client;

--- a/api/tests/Integration/Llm/AiProviderClientRetryTest.php
+++ b/api/tests/Integration/Llm/AiProviderClientRetryTest.php
@@ -8,15 +8,20 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\HttpClient\RetryableHttpClient;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
  * Guards that every per-user AI provider scoped client (ADR-042) enables
- * `retry_failed`, i.e. is wrapped in a {@see RetryableHttpClient}. Gemini (and
- * occasionally the others) returns transient `503 "high demand"` / `429` under
- * load on the default model; without retry these surface as a one-shot 503 to
- * the rider. Symfony's default retry status codes retry 429 and 503 on every
- * method (POST included), with exponential back-off — so activating the wrapper
- * here is what makes the AI endpoints resilient.
+ * `retry_failed`. Gemini (and occasionally the others) returns transient
+ * `503 "high demand"` / `429` under load on the default model; without retry
+ * these surface as a one-shot 503 to the rider. Symfony's default retry status
+ * codes retry 429 and 503 on every method (POST included) with exponential
+ * back-off, so having a {@see RetryableHttpClient} in the stack is what makes
+ * the AI endpoints resilient.
+ *
+ * A scoped client is a stack of decorators (UriTemplate -> Retryable -> Scoping
+ * -> transport), so the assertion walks the chain rather than checking the
+ * outermost type.
  */
 final class AiProviderClientRetryTest extends KernelTestCase
 {
@@ -26,9 +31,12 @@ final class AiProviderClientRetryTest extends KernelTestCase
     {
         self::bootKernel();
 
-        self::assertInstanceOf(
+        $client = self::getContainer()->get($serviceId);
+        self::assertInstanceOf(HttpClientInterface::class, $client);
+
+        self::assertContains(
             RetryableHttpClient::class,
-            self::getContainer()->get($serviceId),
+            self::decoratorChain($client),
             \sprintf('AI scoped client "%s" must enable retry_failed so transient 429/503 provider failures are retried (ADR-042).', $serviceId),
         );
     }
@@ -41,5 +49,35 @@ final class AiProviderClientRetryTest extends KernelTestCase
         yield 'anthropic' => ['anthropic.client'];
         yield 'openai' => ['openai.client'];
         yield 'gemini' => ['gemini.client'];
+    }
+
+    /**
+     * Walks the HttpClient decorator stack through the conventional private
+     * `client` property and returns the class name of each layer.
+     *
+     * @return list<class-string>
+     */
+    private static function decoratorChain(HttpClientInterface $client): array
+    {
+        $chain = [];
+        $current = $client;
+
+        while (true) {
+            $chain[] = $current::class;
+
+            $reflection = new \ReflectionObject($current);
+            if (!$reflection->hasProperty('client')) {
+                break;
+            }
+
+            $inner = $reflection->getProperty('client')->getValue($current);
+            if (!$inner instanceof HttpClientInterface) {
+                break;
+            }
+
+            $current = $inner;
+        }
+
+        return $chain;
     }
 }

--- a/api/tests/Integration/Llm/AiProviderClientRetryTest.php
+++ b/api/tests/Integration/Llm/AiProviderClientRetryTest.php
@@ -39,7 +39,7 @@ final class AiProviderClientRetryTest extends KernelTestCase
         self::assertContains(
             RetryableHttpClient::class,
             $this->decoratorChain($client),
-            \sprintf('AI scoped client "%s" must enable retry_failed so transient 429/503 provider failures are retried (ADR-042).', $serviceId),
+            \sprintf('AI scoped client "%s" must enable retry_failed so transient 5xx provider failures are retried (ADR-042).', $serviceId),
         );
     }
 

--- a/api/tests/Integration/Llm/AiProviderClientRetryTest.php
+++ b/api/tests/Integration/Llm/AiProviderClientRetryTest.php
@@ -13,11 +13,13 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * Guards that every per-user AI provider scoped client (ADR-042) enables
  * `retry_failed`. Gemini (and occasionally the others) returns transient
- * `503 "high demand"` / `429` under load on the default model; without retry
- * these surface as a one-shot 503 to the rider. Symfony's default retry status
- * codes retry 429 and 503 on every method (POST included) with exponential
- * back-off, so having a {@see RetryableHttpClient} in the stack is what makes
- * the AI endpoints resilient.
+ * `503 "high demand"` under load on the default model; without retry these
+ * surface as a one-shot 503 to the rider. The clients retry 5xx codes only
+ * (POST included) with exponential back-off; 429 is explicitly excluded so an
+ * exhausted-quota 429 fails fast (ADR-042). Having a {@see RetryableHttpClient}
+ * in the stack is what makes the AI endpoints resilient; this asserts the
+ * wrapper is present, not the `http_codes` value (that lives in framework.php,
+ * validated by Symfony's config parser on kernel boot).
  *
  * A scoped client is a stack of decorators (UriTemplate -> Retryable -> Scoping
  * -> transport), so the assertion walks the chain rather than checking the

--- a/api/tests/Unit/Llm/AiProviderTest.php
+++ b/api/tests/Unit/Llm/AiProviderTest.php
@@ -18,8 +18,8 @@ final class AiProviderTest extends TestCase
         self::assertSame('claude-sonnet-4-6', AiProvider::ANTHROPIC->analysisModel());
         self::assertSame('gpt-4o-mini', AiProvider::OPENAI->chatModel());
         self::assertSame('gpt-4o-mini', AiProvider::OPENAI->analysisModel());
-        self::assertSame('gemini-2.5-flash', AiProvider::GEMINI->chatModel());
-        self::assertSame('gemini-2.5-flash', AiProvider::GEMINI->analysisModel());
+        self::assertSame('gemini-2.0-flash', AiProvider::GEMINI->chatModel());
+        self::assertSame('gemini-2.0-flash', AiProvider::GEMINI->analysisModel());
     }
 
     #[Test]

--- a/api/tests/Unit/State/TripAiChatProcessorTest.php
+++ b/api/tests/Unit/State/TripAiChatProcessorTest.php
@@ -11,6 +11,7 @@ use App\ApiResource\Model\AiChatMessage;
 use App\Entity\User;
 use App\Llm\AiProvider;
 use App\Llm\BriefChatInterpreter;
+use App\Llm\Exception\AiFailureReason;
 use App\Llm\Exception\AiUnavailableException;
 use App\Llm\LlmClientInterface;
 use App\Llm\LlmResponseParser;
@@ -26,7 +27,6 @@ use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
 use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 use Symfony\Component\RateLimiter\RateLimiterFactory;
@@ -174,7 +174,7 @@ final class TripAiChatProcessorTest extends TestCase
     }
 
     #[Test]
-    public function returns503WithEnglishMessageWhenProviderUnreachable(): void
+    public function returns503WhenProviderUnreachable(): void
     {
         $processor = $this->newProcessor(
             configured: true,
@@ -182,36 +182,72 @@ final class TripAiChatProcessorTest extends TestCase
             chatException: new AiUnavailableException('boom'),
         );
 
-        try {
-            $processor->process(
-                new AiChatRequest([new AiChatMessage('user', 'Bonjour')]),
-                new Post(),
-            );
-            self::fail('Expected ServiceUnavailableHttpException.');
-        } catch (ServiceUnavailableHttpException $serviceUnavailableHttpException) {
-            self::assertStringContainsString('unavailable', $serviceUnavailableHttpException->getMessage());
-        }
+        $result = $processor->process(
+            new AiChatRequest([new AiChatMessage('user', 'Bonjour')]),
+            new Post(),
+        );
+
+        self::assertInstanceOf(JsonResponse::class, $result);
+        self::assertSame(503, $result->getStatusCode());
+        self::assertSame('{"error":"ai_unavailable"}', $result->getContent());
     }
 
     #[Test]
-    public function returns503WithFrenchMessageWhenLocaleIsFrench(): void
+    public function returns422WithInvalidTokenError(): void
     {
         $processor = $this->newProcessor(
             configured: true,
             llmContent: '',
-            chatException: new AiUnavailableException('boom'),
-            acceptLanguage: 'fr',
+            chatException: new AiUnavailableException('bad key', AiFailureReason::INVALID_TOKEN),
         );
 
-        try {
-            $processor->process(
-                new AiChatRequest([new AiChatMessage('user', 'Bonjour')]),
-                new Post(),
-            );
-            self::fail('Expected ServiceUnavailableHttpException.');
-        } catch (ServiceUnavailableHttpException $serviceUnavailableHttpException) {
-            self::assertStringContainsString('indisponible', $serviceUnavailableHttpException->getMessage());
-        }
+        $result = $processor->process(
+            new AiChatRequest([new AiChatMessage('user', 'Bonjour')]),
+            new Post(),
+        );
+
+        self::assertInstanceOf(JsonResponse::class, $result);
+        self::assertSame(422, $result->getStatusCode());
+        self::assertSame('{"error":"ai_invalid_token"}', $result->getContent());
+    }
+
+    #[Test]
+    public function returns422WithQuotaExceededError(): void
+    {
+        $processor = $this->newProcessor(
+            configured: true,
+            llmContent: '',
+            chatException: new AiUnavailableException('no credit', AiFailureReason::QUOTA_EXCEEDED),
+        );
+
+        $result = $processor->process(
+            new AiChatRequest([new AiChatMessage('user', 'Bonjour')]),
+            new Post(),
+        );
+
+        self::assertInstanceOf(JsonResponse::class, $result);
+        self::assertSame(422, $result->getStatusCode());
+        self::assertSame('{"error":"ai_quota_exceeded"}', $result->getContent());
+    }
+
+    #[Test]
+    public function returns429WithRateLimitedErrorAndRetryAfterHeader(): void
+    {
+        $processor = $this->newProcessor(
+            configured: true,
+            llmContent: '',
+            chatException: new AiUnavailableException('slow down', AiFailureReason::RATE_LIMITED, retryAfter: 12),
+        );
+
+        $result = $processor->process(
+            new AiChatRequest([new AiChatMessage('user', 'Bonjour')]),
+            new Post(),
+        );
+
+        self::assertInstanceOf(JsonResponse::class, $result);
+        self::assertSame(429, $result->getStatusCode());
+        self::assertSame('{"error":"ai_rate_limited"}', $result->getContent());
+        self::assertSame('12', $result->headers->get('Retry-After'));
     }
 
     private function newProcessor(

--- a/api/tests/Unit/State/TripChatProcessorTest.php
+++ b/api/tests/Unit/State/TripChatProcessorTest.php
@@ -649,8 +649,8 @@ final class TripChatProcessorTest extends TestCase
     {
         // AI configured but the chat call hits an unreachable provider: 503 + `critical` log (#304).
         $logger = $this->createMock(LoggerInterface::class);
-        $logger->expects(self::once())->method('critical')
-            ->with(self::stringContains('AI provider unreachable'));
+        $logger->expects(self::once())->method('log')
+            ->with('critical', self::stringContains('AI provider unreachable'), self::anything());
 
         $processor = $this->newProcessor(
             llmContent: '',

--- a/api/tests/Unit/State/TripChatProcessorTest.php
+++ b/api/tests/Unit/State/TripChatProcessorTest.php
@@ -669,6 +669,32 @@ final class TripChatProcessorTest extends TestCase
         );
     }
 
+    #[Test]
+    public function logsWarningNotCriticalForUserConfigErrors(): void
+    {
+        // A bad key / exhausted quota is a user-config error: warning, not critical
+        // (no on-call page). Still returns 503 on the in-ride path for now.
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())->method('log')
+            ->with('warning', self::stringContains('AI provider unreachable'), self::anything());
+
+        $processor = $this->newProcessor(
+            llmContent: '',
+            stagesCount: 1,
+            messageBus: $this->newMessageBus(),
+            logger: $logger,
+            chatException: new AiUnavailableException('bad key', AiFailureReason::INVALID_TOKEN),
+        );
+
+        $this->expectException(ServiceUnavailableHttpException::class);
+
+        $processor->process(
+            new TripChatRequest('Bonjour'),
+            new Post(),
+            ['id' => self::TRIP_ID],
+        );
+    }
+
     /**
      * @param list<array{lat: float, lon: float, tags: array<string, string>}>|null $inRidePois optional features returned by the in-ride index mock
      */

--- a/api/tests/Unit/State/TripChatProcessorTest.php
+++ b/api/tests/Unit/State/TripChatProcessorTest.php
@@ -24,6 +24,7 @@ use App\InRide\PoiIntentDetector;
 use App\Llm\AiProvider;
 use App\Llm\ChatActionInterpreter;
 use App\Llm\ChatHistoryStore;
+use App\Llm\Exception\AiFailureReason;
 use App\Llm\Exception\AiUnavailableException;
 use App\Llm\LlmClientInterface;
 use App\Llm\LlmResponseParser;

--- a/docs/adr/adr-042-optional-multi-provider-ai-byo-token.md
+++ b/docs/adr/adr-042-optional-multi-provider-ai-byo-token.md
@@ -44,7 +44,7 @@ Cloud providers only. No self-hosted Ollama.
 | Provider | `symfony/ai` bridge | Default chat model | Default analysis model |
 |----------|---------------------|--------------------|------------------------|
 | **Anthropic (Claude)** | `symfony/ai-anthropic-platform` | `claude-haiku-4-5-20251001` | `claude-sonnet-4-6` |
-| **Google (Gemini)** | `symfony/ai-gemini-platform` | `gemini-2.5-flash` | `gemini-2.5-flash` |
+| **Google (Gemini)** | `symfony/ai-gemini-platform` | `gemini-2.0-flash` | `gemini-2.0-flash` |
 | **OpenAI** | `symfony/ai-open-ai-platform` | `gpt-4o-mini` | `gpt-4o-mini` |
 
 Models are chosen cheap-but-capable per provider. They are **not user-selectable in v1** — the user picks a provider, not a model.

--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -606,6 +606,8 @@
     "launchRecommended": "Your project looks complete — you can launch the computation.",
     "launchNeedsStart": "Provide at least a starting point to launch the computation.",
     "errorNotConfigured": "Configure an AI provider to chat about your itinerary.",
+    "errorInvalidToken": "Your AI key looks invalid. Check it in your settings.",
+    "errorQuotaExceeded": "Your AI plan quota is exhausted. Check your provider account.",
     "configureCta": "Configure an AI provider",
     "errorRateLimit": "Too many messages in a row. Please wait a moment before retrying.",
     "errorUnavailable": "AI assistant temporarily unavailable. Please try again shortly.",

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -606,6 +606,8 @@
     "launchRecommended": "Ton projet semble complet : tu peux lancer le calcul.",
     "launchNeedsStart": "Indique au moins un point de départ pour lancer le calcul.",
     "errorNotConfigured": "Configure un fournisseur IA pour discuter de ton itinéraire.",
+    "errorInvalidToken": "Ta clé IA semble invalide. Vérifie-la dans tes réglages.",
+    "errorQuotaExceeded": "Le quota de ton offre IA est épuisé. Vérifie ton compte chez le fournisseur.",
     "configureCta": "Configurer une IA",
     "errorRateLimit": "Trop de messages d'affilée. Patiente un instant avant de réessayer.",
     "errorUnavailable": "Assistant IA temporairement indisponible. Réessaie dans un instant.",

--- a/pwa/src/components/ai-chat-card.test.tsx
+++ b/pwa/src/components/ai-chat-card.test.tsx
@@ -202,6 +202,40 @@ describe("AiChatCard (ADR-045)", () => {
     );
   });
 
+  it("surfaces the invalid-token message + settings CTA on a 422 ai_invalid_token", async () => {
+    sendAiChat.mockResolvedValueOnce({
+      status: "invalid_token",
+    } as AiChatResult);
+    render(<AiChatCard />);
+
+    await sendUserTurn("Boucle Lille");
+    await waitFor(() =>
+      expect(screen.getByTestId("ai-chat-not-configured")).toBeInTheDocument(),
+    );
+    expect(screen.getByText("errorInvalidToken")).toBeInTheDocument();
+    expect(screen.getByTestId("ai-chat-configure-cta")).toHaveAttribute(
+      "href",
+      "/account/settings#ai",
+    );
+  });
+
+  it("surfaces the quota-exceeded message + settings CTA on a 422 ai_quota_exceeded", async () => {
+    sendAiChat.mockResolvedValueOnce({
+      status: "quota_exceeded",
+    } as AiChatResult);
+    render(<AiChatCard />);
+
+    await sendUserTurn("Boucle Lille");
+    await waitFor(() =>
+      expect(screen.getByTestId("ai-chat-not-configured")).toBeInTheDocument(),
+    );
+    expect(screen.getByText("errorQuotaExceeded")).toBeInTheDocument();
+    expect(screen.getByTestId("ai-chat-configure-cta")).toHaveAttribute(
+      "href",
+      "/account/settings#ai",
+    );
+  });
+
   it("maps 429 / 503 / generic failures to localized error bubbles", async () => {
     sendAiChat.mockResolvedValueOnce({ status: "rate_limited" });
     sendAiChat.mockResolvedValueOnce({ status: "unavailable" });

--- a/pwa/src/components/ai-chat-card.tsx
+++ b/pwa/src/components/ai-chat-card.tsx
@@ -161,7 +161,11 @@ export function AiChatCard({
   const [draft, setDraft] = useState("");
   const [isSending, setIsSending] = useState(false);
   const [capReached, setCapReached] = useState(false);
-  const [notConfigured, setNotConfigured] = useState(false);
+  // i18n key of the message rendered in the settings-CTA banner, or null when
+  // hidden. Shared by the non-actionable-by-retry failures (no provider set,
+  // invalid token, exhausted quota): each shows the same "go to settings" CTA
+  // with its own message instead of a misleading "retry" error bubble.
+  const [configErrorKey, setConfigErrorKey] = useState<string | null>(null);
   const counterRef = useRef(0);
   const abortRef = useRef<AbortController | null>(null);
   const historyRef = useRef<HTMLDivElement>(null);
@@ -268,10 +272,16 @@ export function AiChatCard({
         ]);
         setCollected(result.data.collected);
         setReadyToGenerate(result.data.readyToGenerate);
-        setNotConfigured(false);
+        setConfigErrorKey(null);
         break;
       case "not_configured":
-        setNotConfigured(true);
+        setConfigErrorKey("errorNotConfigured");
+        break;
+      case "invalid_token":
+        setConfigErrorKey("errorInvalidToken");
+        break;
+      case "quota_exceeded":
+        setConfigErrorKey("errorQuotaExceeded");
         break;
       case "rate_limited":
         appendAssistantError(t("errorRateLimit"));
@@ -363,7 +373,7 @@ export function AiChatCard({
           {isSending && <TypingBubble label={t("thinking")} />}
         </div>
 
-        {notConfigured && (
+        {configErrorKey && (
           <div
             data-testid="ai-chat-not-configured"
             role="alert"
@@ -374,7 +384,7 @@ export function AiChatCard({
                 className="h-4 w-4 shrink-0 text-brand"
                 aria-hidden="true"
               />
-              <span>{t("errorNotConfigured")}</span>
+              <span>{t(configErrorKey)}</span>
             </span>
             <Link
               href="/account/settings#ai"

--- a/pwa/src/lib/api/client.ts
+++ b/pwa/src/lib/api/client.ts
@@ -713,13 +713,19 @@ export type AiChatResponseBody = Pick<
  * - `ok`              — the assistant turn (reply + readiness + collected).
  * - `not_configured`  — 422 `{error:"ai_not_configured"}`: no provider set;
  *   surface the "configure une IA" CTA (mirrors `aiCapability.configured`).
- * - `rate_limited`    — 429: per-user chat rate limit reached.
- * - `unavailable`     — 503: provider unreachable / invalid token / quota.
+ * - `invalid_token`   — 422 `{error:"ai_invalid_token"}`: the stored key is
+ *   wrong/revoked; surface the settings CTA (retrying is pointless).
+ * - `quota_exceeded`  — 422 `{error:"ai_quota_exceeded"}`: the provider plan is
+ *   exhausted; surface the settings CTA to switch provider.
+ * - `rate_limited`    — 429: per-user chat rate limit reached (transient).
+ * - `unavailable`     — 503: provider unreachable / transient outage.
  * - `error`           — any other failure (network, 4xx, bad shape).
  */
 export type AiChatResult =
   | { status: "ok"; data: AiChatResponseBody }
   | { status: "not_configured" }
+  | { status: "invalid_token" }
+  | { status: "quota_exceeded" }
   | { status: "rate_limited" }
   | { status: "unavailable" }
   | { status: "error" };
@@ -736,13 +742,13 @@ const aiChatResponseSchema = z.object({
     .default({}),
 });
 
-function hasAiNotConfigured(body: unknown): boolean {
-  return (
-    body !== null &&
-    typeof body === "object" &&
-    "error" in body &&
-    (body as { error?: unknown }).error === "ai_not_configured"
-  );
+/** Read the discrete `{error}` code carried by an ai-chat failure body. */
+function aiChatErrorCode(body: unknown): string | null {
+  if (body !== null && typeof body === "object" && "error" in body) {
+    const value = (body as { error?: unknown }).error;
+    return typeof value === "string" ? value : null;
+  }
+  return null;
 }
 
 /**
@@ -780,8 +786,17 @@ export async function sendAiChat(
     return { status: "ok", data: parsed.data };
   }
 
-  if (response.status === 422 && hasAiNotConfigured(error)) {
-    return { status: "not_configured" };
+  if (response.status === 422) {
+    switch (aiChatErrorCode(error)) {
+      case "ai_not_configured":
+        return { status: "not_configured" };
+      case "ai_invalid_token":
+        return { status: "invalid_token" };
+      case "ai_quota_exceeded":
+        return { status: "quota_exceeded" };
+      default:
+        return { status: "error" };
+    }
   }
   if (response.status === 429) return { status: "rate_limited" };
   if (response.status === 503) return { status: "unavailable" };


### PR DESCRIPTION
## Contexte

En recette, le chat IA renvoyait systematiquement une erreur. Les logs montraient un 503 transitoire de l'API Gemini ("high demand" sur `gemini-2.5-flash`), pas un bug de notre code, mais les 3 scoped clients AI n'avaient aucun retry (le commentaire en promettait un sans l'implementer) : le moindre pic echouait au premier coup. Deux problemes annexes sont apparus pendant la recette : un timeout AI egal au `max_execution_time` (30s) provoquait un FatalError 500 au lieu d'une 503 geree, et une cle Gemini sans quota free-tier (`limit: 0`) renvoyait un 429 "quota" que le retry par defaut aurait retente inutilement.

## Correctif

- **Retry transitoire (5xx uniquement)** : `retry_failed` sur `anthropic.client` / `openai.client` / `gemini.client`, `http_codes => [500, 502, 503, 504, 507, 510]`, `max_retries: 2`, back-off exponentiel. **429 explicitement exclu** : un quota epuise echoue vite (pas d'appels gaches), conformement a la taxonomie d'erreurs (ADR-042).
- **Timeout borne** : 20s sur les 3 clients AI, sous le `max_execution_time` (30s) de PHP, pour qu'un provider lent produise une `TransportException` geree (-> 503 "reessaie") au lieu d'un FatalError 500.
- **Modele Gemini par defaut** : `gemini-2.5-flash` -> `gemini-2.0-flash` (plus disponible, moins sujet aux pics) ; ADR-042 mis a jour.
- **Mapping erreur -> HTTP actionnable** (`TripAiChatProcessor`) : `INVALID_TOKEN` / `QUOTA_EXCEEDED` -> 422 (`ai_invalid_token` / `ai_quota_exceeded`), `RATE_LIMITED` -> 429 + `Retry-After`, `UNAVAILABLE` -> 503. Le front affiche un message actionnable + CTA reglages selon le code.
- **Logging conditionnel** : `critical` seulement pour `UNAVAILABLE` (vraie panne provider, alerte on-call), `warning` pour les erreurs de config / quota utilisateur. Applique aux deux processors.

## Verification

- `AiProviderClientRetryTest` (integration) : les 3 clients AI exposent bien un `RetryableHttpClient` dans la pile de decorateurs.
- Tests unitaires / fonctionnels du mapping (422/429/503 + codes `{error}`) et du niveau de log.
- `make qa` + `make test` verts en CI.

## Suivi

L'in-ride `TripChatProcessor` throw encore `ServiceUnavailableHttpException` (503) pour tous les cas. L'aligner sur le meme mapping reason->HTTP est trace dans #761 (a faire quand l'IA sera reactivee et que le front in-ride consommera le 422 ; l'IA va etre masquee derriere un flag, decision recette).

Refs #649

<!-- claude-review-start -->
## Claude Review

Solid, well-scoped fix. Every stated goal (retry 5xx, timeout below max_execution_time, 429 exclusion, actionable error codes, conditional log severity) is implemented correctly and covered by tests. The intentional gap in `TripChatProcessor` (HTTP response mapping deferred to #761) is clearly documented in the PR body.

**Resolved threads:** 0 new resolutions this pass — all previously resolved threads remain closed; the 2 open threads on `TripChatProcessor`'s HTTP mapping are intentionally left open pending #761.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date (ADR-042 updated)
- [x] Dependent tickets accounted for (#761 tracks the in-ride follow-up)

**Reviewed commit:** `0bdca0033cf2f275d86111c6bf92f3754ac3dbe5`

**No inline comments.**
<!-- claude-review-end -->