### PR TITLE
chore(ai): hide the AI feature behind a flag (NEXT_PUBLIC_ENABLE_AI, default-off)

### DIFF
--- a/.docker/pwa/Dockerfile
+++ b/.docker/pwa/Dockerfile
@@ -41,6 +41,12 @@ FROM deps AS builder
 ARG NEXT_PUBLIC_APP_RELEASE
 ARG NEXT_PUBLIC_APP_ENV=production
 ARG NEXT_PUBLIC_SENTRY_DSN
+# AI feature flag (recette #649): default-off so prod and the iso-prod recette
+# build mask the whole AI surface (generation assistant, in-ride chat, stage
+# briefings + trip overview, account provider config). Set to "true" only where
+# AI must stay visible (CI E2E in ci.yml, dev in compose.dev.yaml). The code and
+# endpoints are kept for a later re-enable; this is a single reversible switch.
+ARG NEXT_PUBLIC_ENABLE_AI=false
 
 COPY --link pwa/. .
 
@@ -52,6 +58,7 @@ RUN --mount=type=secret,id=sentry_auth_token \
     NEXT_PUBLIC_APP_RELEASE="${NEXT_PUBLIC_APP_RELEASE}" \
     NEXT_PUBLIC_APP_ENV="${NEXT_PUBLIC_APP_ENV}" \
     NEXT_PUBLIC_SENTRY_DSN="${NEXT_PUBLIC_SENTRY_DSN}" \
+    NEXT_PUBLIC_ENABLE_AI="${NEXT_PUBLIC_ENABLE_AI}" \
     npm run build
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -331,6 +331,7 @@ jobs:
             pwa.cache-from=type=gha,scope=pwa
             pwa.cache-from=type=gha,scope=pwa-main
             pwa.cache-to=type=gha,scope=pwa,mode=max
+            pwa.args.NEXT_PUBLIC_ENABLE_AI=true
       - name: Start services
         run: docker compose up -d database php pwa worker redis --no-build --wait
       - name: Dump PHP logs on failure
@@ -390,6 +391,7 @@ jobs:
             php.cache-from=type=gha,scope=php-main
             pwa.cache-from=type=gha,scope=pwa
             pwa.cache-from=type=gha,scope=pwa-main
+            pwa.args.NEXT_PUBLIC_ENABLE_AI=true
       - name: Start services
         run: docker compose up -d database php pwa worker redis --no-build --wait
       - name: Generate BDD test files

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -99,6 +99,10 @@ services:
       NODE_ENV: development
       # Development usage only
       NODE_TLS_REJECT_UNAUTHORIZED: "0"
+      # AI feature flag (recette #649): on in dev so the AI surface stays visible
+      # and its code keeps being exercised while it is masked in prod/recette.
+      # `next dev` reads NEXT_PUBLIC_* from the runtime env (no rebuild needed).
+      NEXT_PUBLIC_ENABLE_AI: "true"
     volumes: !override
       - ./pwa:/srv/app
       - pwa_node_modules:/srv/app/node_modules

--- a/compose.yaml
+++ b/compose.yaml
@@ -272,8 +272,12 @@ services:
         # the self-hosted tracker script (e.g. https://analytics.example/js/script.js).
         NEXT_PUBLIC_PLAUSIBLE_DOMAIN: "${NEXT_PUBLIC_PLAUSIBLE_DOMAIN:-}"
         NEXT_PUBLIC_PLAUSIBLE_SRC: "${NEXT_PUBLIC_PLAUSIBLE_SRC:-}"
-      # AI features are always present in the build (ADR-042); they activate per-user
-      # once a provider + token is configured in account settings — no build flag.
+        # AI feature flag (recette #649): default-off so prod and the iso-prod
+        # recette build hide the whole AI surface (generation assistant, in-ride
+        # chat, stage briefings + trip overview, account provider config).
+        # Override to "true" only where AI must show (CI E2E bake args, dev). The
+        # code and endpoints are kept for a later re-enable (ADR-042).
+        NEXT_PUBLIC_ENABLE_AI: "${NEXT_PUBLIC_ENABLE_AI:-false}"
       # SENTRY_AUTH_TOKEN (source-map upload) is a real secret: passed as a
       # BuildKit secret so it never lands in an image layer or the build cache.
       secrets:

--- a/docs/adr/adr-042-optional-multi-provider-ai-byo-token.md
+++ b/docs/adr/adr-042-optional-multi-provider-ai-byo-token.md
@@ -4,6 +4,7 @@
 - **Date:** 2026-06-19
 - **Depends on:** ADR-001 (Global Architecture), ADR-012 (Rule-based alert engine), ADR-027 (Gate mechanism and two-phase pipeline), ADR-030 (symfony/ai adoption), ADR-035 (GDPR account erasure)
 - **Supersedes / refines:** ADR-028 (Ollama/LLaMA integration), ADR-030 (symfony/ai transport layer), ADR-039 (beta right-sizing — the LLM RAM/CPU budget freed)
+- **Superseded (in part) by:** ADR-046 (temporary AI feature flag): only the "always present in the build / no env flag" stance below; the per-user BYO-token model stands.
 
 ## Context and Problem Statement
 
@@ -75,6 +76,8 @@ Each provider HTTP client is **SSRF-scoped to that provider's host** (per ADR-00
 ### 5. Availability is decided per-user, never by an env flag
 
 The AI features are **always present in the build** — they are part of the product, not a deployment option. What is optional is **per-user activation**: a feature is usable only once *that user* has chosen a provider and saved their token. The application therefore does **not** enable or disable AI through an environment variable. Two env-var flags are removed and **not replaced**: the Ollama-specific `OLLAMA_ENABLED` (which answered "is the self-hosted tier reachable?") and the instance-wide `AI_ENABLED` kill-switch on `LlmClientFactory`/`services.php` (which answered "is AI enabled for all users on this server?").
+
+> **Superseded in part (recette #649, [ADR-046](adr-046-temporary-ai-feature-flag.md)):** a single front-end build flag `NEXT_PUBLIC_ENABLE_AI` (default-off) now hides the whole AI surface to put the feature on hold for a release. It does not revive a backend kill-switch (the backend stays per-user gated) and does not change the per-user activation model described here.
 
 Two states, generalising the ADR-028 degraded-mode contract:
 

--- a/docs/adr/adr-046-temporary-ai-feature-flag.md
+++ b/docs/adr/adr-046-temporary-ai-feature-flag.md
@@ -1,0 +1,65 @@
+# ADR-046: Temporary Masking of the AI Feature Behind a Build Flag
+
+- **Status:** Accepted
+- **Date:** 2026-06-24
+- **Depends on:** ADR-042 (Optional Multi-Provider AI, BYO Token), ADR-045 (Conversational AI Trip-Brief Chat)
+- **Supersedes (in part):** ADR-042 — only its "AI features are always present in the build / no environment flag" stance. The per-user BYO-token activation model is unchanged.
+
+## Context and Problem Statement
+
+The AI surface (the generation-assistant chat, the in-ride chat bubble, the per-stage briefings + trip-level overview, and the account provider/token configuration) is being **put on hold** for the recette (#649). Two facts drive this:
+
+1. **Provider-side reliability.** During the recette the only configured provider (Gemini) returned transient `503 "high demand"` and, on a free-tier key, `429` quota errors with `limit: 0`. #760 made the calls resilient (retry 5xx, bounded timeout, actionable error mapping), but the end-user experience still depends on a provider/quota the project does not control.
+2. **Feature maturity.** The conversational generation flow (ADR-045) and the in-ride error mapping (#761) still need work before they are good enough to ship to users.
+
+We want the feature **hidden from users now**, **without deleting the code** — it will be re-enabled once a reliable provider/quota and the remaining polish are in place.
+
+ADR-042 deliberately removed every env kill-switch (`OLLAMA_ENABLED`, the instance-wide `AI_ENABLED`) on the grounds that "AI is always present, per-user activated." That holds for *capability* gating, but it leaves **no way to put the whole feature on hold for a release** — which is what the recette now needs.
+
+## Decision Drivers
+
+- **Hide now, keep the code** — a single reversible switch, not a removal (preserve ADR-045 + the #760 resilience work and their tests).
+- **Fail-safe masking** — default-off, so a fresh prod/recette deploy never exposes the on-hold feature by omission.
+- **Keep the AI code exercised** — dev, CI E2E and Vitest keep the flag on so the components and their tests do not rot.
+- **No backend change** — the per-user gate already prevents any AI work without a configured token.
+
+## Considered Options
+
+### Option A — Front-end build flag, default-off (chosen)
+
+A single `NEXT_PUBLIC_ENABLE_AI` build flag read by `isAiFeatureEnabled()` (`pwa/src/lib/constants.ts`); every AI mount point is gated on it. Idiomatic for Next.js (`NEXT_PUBLIC_*` are build-time inlined, like `NEXT_PUBLIC_SENTRY_DSN` and the Plausible vars).
+
+### Option B — Backend kill-switch (revive `AI_ENABLED`)
+
+Rejected. Heavier, and ADR-042 removed it on purpose. The goal is to hide the **UI**; the backend is already inert without a configured per-user token, so a backend switch adds surface area for no user-visible gain.
+
+### Option C — Delete the AI code
+
+Rejected. The feature will be re-enabled; deleting it would lose the conversational chat (ADR-045), the resilience work (#760), and the test coverage, and force a re-implementation later.
+
+### Option D — Runtime flag
+
+Rejected. `NEXT_PUBLIC_*` are inlined into the standalone bundle at build time; a build flag is the idiomatic and simplest mechanism, consistent with the existing public client config.
+
+## Decision
+
+Introduce a single front-end flag **`NEXT_PUBLIC_ENABLE_AI`** (default **`false`**).
+
+- `isAiFeatureEnabled()` (`pwa/src/lib/constants.ts`) returns `true` only when the value is exactly `"true"`. Every AI mount point is gated on it:
+  - the **generation-assistant card** (`card-selection.tsx`);
+  - the **in-ride chat bubble**, the **trip-level AI overview**, and the **AI-unavailable notices** (`trip-planner.tsx`);
+  - the **per-stage briefing** (`stage-card.tsx` falls back to the rule-based alerts when off);
+  - the **account provider/token section** (`account/settings/page.tsx`).
+  - The AI availability/settings fetches (`use-ai-settings.ts`, the availability effect) are skipped when off, so no AI request is made.
+- **Default-off / fail-safe:** prod and the iso-prod recette build mask AI with **no env set**. The flag is set to `"true"` only where the AI code must stay exercised:
+  - dev — `compose.dev.yaml` (runtime env, `next dev`);
+  - CI E2E — `ci.yml` bake args on the `Playwright` and `Playwright BDD Recette` jobs;
+  - Vitest — `vitest.config.ts` (`test.env`).
+- **Backend untouched.** AI computation is already gated on a configured per-user provider/token: `AllEnrichmentsCompletedHandler` short-circuits to `TRIP_READY` when `llmResolver->resolveForTrip()` returns no client, with a defense-in-depth re-check in the analyze handlers. With the configuration UI hidden, no new token can be set, so no AI work is dispatched. The endpoints remain so the kept code is still callable from tests and after re-enable.
+
+## Consequences
+
+- In prod/recette, **no AI is visible anywhere**. The source-URL and GPX-upload paths are unchanged; `card-selection` shows two cards instead of three.
+- **To re-enable** (no code change required): set `NEXT_PUBLIC_ENABLE_AI=true` as a build arg/env for the target build — e.g. the Coolify prod build, or locally `NEXT_PUBLIC_ENABLE_AI=true make build`.
+- The in-ride error-mapping alignment (#761) stays deferred until re-enable.
+- This supersedes only ADR-042's "always present / no env flag" wording; the per-user BYO-token activation model is intact.

--- a/pwa/src/app/account/settings/page.tsx
+++ b/pwa/src/app/account/settings/page.tsx
@@ -9,6 +9,7 @@ import { AiProviderSection } from "@/components/account/ai-provider-section";
 import { DataSection } from "@/components/account/data-section";
 import { DangerZoneSection } from "@/components/account/danger-zone-section";
 import { LandingFooter } from "@/components/landing/footer";
+import { isAiFeatureEnabled } from "@/lib/constants";
 
 /**
  * Account settings page (#383).
@@ -49,7 +50,7 @@ export default function AccountSettingsPage() {
           <div className="flex flex-col gap-6 min-w-0">
             <AccountSection />
             <PreferencesSection />
-            <AiProviderSection />
+            {isAiFeatureEnabled() && <AiProviderSection />}
             <DataSection />
             <DangerZoneSection />
           </div>

--- a/pwa/src/components/card-selection.test.tsx
+++ b/pwa/src/components/card-selection.test.tsx
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { CardSelection } from "./card-selection";
+
+// Echo translation keys so the component renders without a real catalog.
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: React.ReactNode;
+  }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+const noop = () => {};
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllEnvs();
+});
+
+// Vitest sets NEXT_PUBLIC_ENABLE_AI=true globally (vitest.config.ts); the masked
+// case stubs it off to prove the AI surface disappears (recette #649).
+describe("CardSelection — AI feature flag (recette #649)", () => {
+  it("shows the AI assistant card when the flag is on", () => {
+    render(<CardSelection onSubmitUrl={noop} onUploadFile={noop} />);
+    expect(screen.getByTestId("card-ai")).toBeInTheDocument();
+    expect(screen.getByTestId("card-link")).toBeInTheDocument();
+    expect(screen.getByTestId("card-gpx")).toBeInTheDocument();
+  });
+
+  it("hides the AI assistant card when the flag is off (link + GPX remain)", () => {
+    vi.stubEnv("NEXT_PUBLIC_ENABLE_AI", "false");
+    render(<CardSelection onSubmitUrl={noop} onUploadFile={noop} />);
+    expect(screen.queryByTestId("card-ai")).not.toBeInTheDocument();
+    expect(screen.getByTestId("card-link")).toBeInTheDocument();
+    expect(screen.getByTestId("card-gpx")).toBeInTheDocument();
+  });
+});

--- a/pwa/src/components/card-selection.tsx
+++ b/pwa/src/components/card-selection.tsx
@@ -17,6 +17,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
+import { isAiFeatureEnabled } from "@/lib/constants";
 import { isSupportedSourceUrl, isValidUrl } from "@/lib/validation/url";
 import { useUiStore } from "@/store/ui-store";
 
@@ -64,6 +65,7 @@ export function CardSelection({
 }: CardSelectionProps) {
   const t = useTranslations("cardSelection");
   const aiCapability = useUiStore((s) => s.aiCapability);
+  const aiEnabled = isAiFeatureEnabled();
   const [selected, setSelected] = useState<InputMode>(null);
 
   const handleSelect = useCallback(
@@ -93,7 +95,9 @@ export function CardSelection({
           "grid w-full gap-4 transition-all",
           // When one card is selected it takes the full width; otherwise 3-up grid
           selected === null
-            ? "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3"
+            ? aiEnabled
+              ? "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3"
+              : "grid-cols-1 sm:grid-cols-2"
             : "grid-cols-1",
         )}
       >
@@ -118,10 +122,12 @@ export function CardSelection({
         )}
 
         {/* Card: AI Assistant - natural-language brief to AI route generation
-            (ADR-042). Always visible: disabled with an inline notice when the
-            LLM tier is unreachable (#304), or disabled-but-visible with a
-            "Configurez une IA" CTA when no provider is set on the account. */}
-        {(selected === null || selected === "ai") && (
+            (ADR-042). Hidden entirely while the AI feature is on hold behind
+            `NEXT_PUBLIC_ENABLE_AI` (recette #649). When enabled it is always
+            visible: disabled with an inline notice when the LLM tier is
+            unreachable (#304), or disabled-but-visible with a "Configurez une
+            IA" CTA when no provider is set on the account. */}
+        {aiEnabled && (selected === null || selected === "ai") && (
           <AiCard
             expanded={selected === "ai"}
             disabled={disabled}

--- a/pwa/src/components/stage-card.tsx
+++ b/pwa/src/components/stage-card.tsx
@@ -25,6 +25,7 @@ import type { StageData, AccommodationData } from "@/lib/validation/schemas";
 import { useTripStore, useStageAiAnalysis } from "@/store/trip-store";
 import { useUiStore } from "@/store/ui-store";
 import { DEFAULT_ACCOMMODATION_RADIUS_KM } from "@/lib/accommodation-constants";
+import { isAiFeatureEnabled } from "@/lib/constants";
 
 function formatCoords(point: { lat: number; lon: number }): string {
   const latDir = point.lat >= 0 ? "N" : "S";
@@ -107,9 +108,10 @@ export function StageCard({
   const startDate = useTripStore((s) => s.startDate);
   const viewMode = useUiStore((s) => s.viewMode);
 
+  const aiEnabled = isAiFeatureEnabled();
   const aiSummary = stage.aiSummary?.trim();
   const aiAnalysis = useStageAiAnalysis(stageIndex);
-  const hasAiAnalysis = Boolean(aiAnalysis?.narrative.trim());
+  const hasAiAnalysis = aiEnabled && Boolean(aiAnalysis?.narrative.trim());
   const hasAlerts = stage.alerts.length > 0;
 
   // In the split (map + list) layout the card is narrow, so keep the legacy
@@ -172,7 +174,7 @@ export function StageCard({
         {/* 2. AI summary — legacy short string (sprint 26, forward-compat).
             Suppressed when the richer pass-1 `aiAnalysis` is available so
             the rider sees a single coach voice per stage. */}
-        {!hasAiAnalysis && aiSummary && aiSummary.length > 0 && (
+        {aiEnabled && !hasAiAnalysis && aiSummary && aiSummary.length > 0 && (
           <StageAiSummaryLegacy summary={aiSummary} />
         )}
 

--- a/pwa/src/components/trip-planner.tsx
+++ b/pwa/src/components/trip-planner.tsx
@@ -35,6 +35,7 @@ import { useUiStore } from "@/store/ui-store";
 import { useOfflineStore } from "@/store/offline-store";
 import { useSwipe } from "@/hooks/use-swipe";
 import { fetchAiAvailability } from "@/lib/ai-availability";
+import { isAiFeatureEnabled } from "@/lib/constants";
 import {
   MEAL_COST_MIN,
   MEAL_COST_MAX,
@@ -140,6 +141,7 @@ export function TripPlanner() {
   // resolves to `true` here. A genuine provider outage surfaces reactively via
   // the 503 the chat endpoint returns, not from this mount-time call.
   useEffect(() => {
+    if (!isAiFeatureEnabled()) return;
     let cancelled = false;
     void fetchAiAvailability().then((available) => {
       if (!cancelled) setAiAvailable(available);
@@ -548,17 +550,21 @@ export function TripPlanner() {
                   silently when the LLM pipeline is disabled or did not produce
                   an overview. Placed above the stage timeline so it gives the
                   user a high-level view before they dive into per-stage data. */}
-              {!aiConfigured ? (
-                <AiUnavailableNotice
-                  variant="notConfigured"
-                  context="analysis"
-                />
-              ) : (
-                !aiAvailable && <AiUnavailableNotice context="analysis" />
+              {isAiFeatureEnabled() && (
+                <>
+                  {!aiConfigured ? (
+                    <AiUnavailableNotice
+                      variant="notConfigured"
+                      context="analysis"
+                    />
+                  ) : (
+                    !aiAvailable && <AiUnavailableNotice context="analysis" />
+                  )}
+                  <TripAiOverview
+                    onRegenerate={() => void relaunchFullAnalysis()}
+                  />
+                </>
               )}
-              <TripAiOverview
-                onRegenerate={() => void relaunchFullAnalysis()}
-              />
 
               {/* Sentinel — marks the natural position of the progress bar in the
                 flow. The sticky bar becomes visible once this exits the viewport. */}
@@ -727,7 +733,7 @@ export function TripPlanner() {
         {/* Floating AI assistant — visible as soon as the trip view is rendered
             (no longer gated by an analysis phase). Hidden on the welcome /
             loader screens via its own `trip` guard. */}
-        <AiBubble />
+        {isAiFeatureEnabled() && <AiBubble />}
       </main>
     </GpxDropZone>
   );

--- a/pwa/src/hooks/use-ai-settings.ts
+++ b/pwa/src/hooks/use-ai-settings.ts
@@ -2,6 +2,7 @@
 
 import { useEffect } from "react";
 import { fetchAiSettings } from "@/lib/api/client";
+import { isAiFeatureEnabled } from "@/lib/constants";
 import { useUiStore } from "@/store/ui-store";
 
 /**
@@ -16,6 +17,7 @@ export function useAiSettings(): void {
   const setAiConfigured = useUiStore((s) => s.setAiConfigured);
 
   useEffect(() => {
+    if (!isAiFeatureEnabled()) return;
     let cancelled = false;
     void fetchAiSettings().then((settings) => {
       if (!cancelled) setAiConfigured(Boolean(settings?.provider));

--- a/pwa/src/lib/constants.test.ts
+++ b/pwa/src/lib/constants.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { isAiFeatureEnabled } from "./constants";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("isAiFeatureEnabled (recette #649)", () => {
+  it('is true only when NEXT_PUBLIC_ENABLE_AI is exactly "true"', () => {
+    vi.stubEnv("NEXT_PUBLIC_ENABLE_AI", "true");
+    expect(isAiFeatureEnabled()).toBe(true);
+  });
+
+  it("is false (masked) for any other value or when unset", () => {
+    for (const value of ["false", "", "1", "TRUE", "yes"]) {
+      vi.stubEnv("NEXT_PUBLIC_ENABLE_AI", value);
+      expect(isAiFeatureEnabled()).toBe(false);
+    }
+    vi.stubEnv("NEXT_PUBLIC_ENABLE_AI", undefined);
+    expect(isAiFeatureEnabled()).toBe(false);
+  });
+});

--- a/pwa/src/lib/constants.ts
+++ b/pwa/src/lib/constants.ts
@@ -53,3 +53,20 @@ export const SITE_URL = process.env.NEXT_PUBLIC_API_URL || "https://localhost";
  */
 export const CONTACT_EMAIL =
   process.env.NEXT_PUBLIC_CONTACT_EMAIL || "contact@example.org";
+
+/**
+ * AI feature flag (recette #649). The whole AI surface — generation assistant
+ * card, in-ride chat bubble, per-stage briefings + trip overview, and the
+ * account provider/token config — is hidden unless `NEXT_PUBLIC_ENABLE_AI` is
+ * explicitly `"true"`. The feature is on hold (provider quota/availability
+ * issues); the code and endpoints are kept for a later re-enable, so this is a
+ * single reversible switch rather than a removal.
+ *
+ * Default-off (fail-safe masking): prod and the iso-prod recette build mask AI
+ * with no env set. It is turned on only in dev (`compose.dev.yaml`), in the CI
+ * E2E build (`ci.yml` bake args) and in Vitest (`vitest.config.ts`) so the AI
+ * code stays exercised. Build-time inlined like the other NEXT_PUBLIC_* reads.
+ */
+export function isAiFeatureEnabled(): boolean {
+  return process.env.NEXT_PUBLIC_ENABLE_AI === "true";
+}

--- a/pwa/vitest.config.ts
+++ b/pwa/vitest.config.ts
@@ -6,6 +6,10 @@ export default defineConfig({
     environment: "jsdom",
     include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
     globals: true,
+    // AI feature flag (recette #649): on for unit tests so the AI component
+    // tests render their subjects. The flag is default-off in prod/recette;
+    // individual tests can override via `vi.stubEnv` to assert the masked path.
+    env: { NEXT_PUBLIC_ENABLE_AI: "true" },
     coverage: {
       provider: "v8",
       reporter: ["text-summary", "lcov"],


### PR DESCRIPTION
## Contexte

Decision recette (#649) : mettre la feature IA **en attente** et la **masquer totalement pour l'utilisateur**, sans supprimer le code (reactivation plus tard). La fiabilite provider (quota/disponibilite Gemini) reste hors de notre controle et le flow conversationnel (ADR-045) demande encore du polish.

## Correctif

Flag de build front unique **`NEXT_PUBLIC_ENABLE_AI`** (defaut **off**), lu par `isAiFeatureEnabled()` (`pwa/src/lib/constants.ts`). Tous les points de montage IA sont gates :

- carte assistant de generation (`card-selection`) ;
- bulle de chat in-ride + overview IA du trip + notices "IA indisponible" (`trip-planner`) ;
- briefing IA par etape (`stage-card`, repli sur les alertes rule-based) ;
- config provider/token IA dans Mon compte (`account/settings`) ;
- les fetches availability/settings sont court-circuites quand off (aucune requete IA).

**Default-off / fail-safe** : prod + recette iso-prod masquent l'IA **sans aucune variable**. Le flag n'est mis a `true` que la ou le code IA doit rester exerce : dev (`compose.dev.yaml`), CI E2E (bake args dans `ci.yml`), et Vitest (`vitest.config.ts`).

**Backend inchange** : l'analyse IA est deja gated sur un provider/token configure (`AllEnrichmentsCompletedHandler` court-circuite si `llmResolver->resolveForTrip()` ne resout rien, + re-check dans les handlers). UI cachee donc aucune cle configurable donc aucun travail IA dispatche. Les endpoints restent (code conserve).

## Reactiver

Aucun changement de code : `NEXT_PUBLIC_ENABLE_AI=true` en build arg/env (Coolify prod, ou `NEXT_PUBLIC_ENABLE_AI=true make build` en local).

## Verification

- Vitest : 251 tests verts, dont 2 nouveaux (`isAiFeatureEnabled` + `card-selection` masque la carte IA quand off).
- tsc / eslint / prettier / markdownlint / liens internes : OK sur les fichiers touches.
- CI : les 2 jobs Playwright buildent l'image pwa avec `NEXT_PUBLIC_ENABLE_AI=true` (bake), donc les specs IA restent couvertes.

## Doc

- ADR-046 (masquage temporaire derriere un flag + procedure de reactivation).
- ADR-042 : note de supersession (le "always present / no env flag" ne tient plus).

Refs #649

<!-- claude-review-start -->
## Claude Review

**Reviewed commit:** c3f2a8c1bef761c698c34ff69fc0592cc50b1426

### Summary

Clean, minimal feature-flag change — 0 findings. Fail-safe default-off, proper ADR documentation (ADR-046 new, ADR-042 supersession note updated), and the `hasAiAnalysis` change in `stage-card.tsx` correctly falls through to the rule-based `StageAlerts` when AI is disabled. Test coverage is adequate: `constants.test.ts` covers the strict `"true"`-only semantics exhaustively, and `card-selection.test.tsx` covers the flag-gated render path.

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [ ] Dependent tickets accounted for — TRACKING.md has no entry for PR #762 under Sprint 41 "Correctifs livrés"; consider adding a row for traceability.

### Inline comments

No inline comments.
<!-- claude-review-end -->