### PR TITLE
fix(pwa): drop the white ring offset + activate the day at viewport middle (Lot E)

### DIFF
--- a/pwa/src/components/Timeline/StageDetailPanel.tsx
+++ b/pwa/src/components/Timeline/StageDetailPanel.tsx
@@ -115,12 +115,13 @@ export function StageDetailPanel({
     selectedRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
   }, [selectedIndex]);
 
-  // Scroll-spy: mark a stage active as soon as it reaches the top of the
-  // viewport while scrolling (recette #649). An IntersectionObserver with a
-  // top-anchored root margin defines a thin band just below the sticky header;
-  // the topmost section currently inside that band becomes the selected stage.
-  // Visibility is tracked in a Map because the observer callback only reports
-  // sections whose intersection *changed* — not every visible one.
+  // Scroll-spy: mark a stage active as soon as it reaches the middle of the
+  // viewport (~50% of its height) while scrolling (recette #649). An
+  // IntersectionObserver with a centred, zero-height root margin defines a thin
+  // band at the vertical middle; the topmost section currently crossing that
+  // line becomes the selected stage. Visibility is tracked in a Map because the
+  // observer callback only reports sections whose intersection *changed* — not
+  // every visible one.
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return;
@@ -157,9 +158,10 @@ export function StageDetailPanel({
         fromScrollSpyRef.current = true;
         setSelectedStageIndex(bestIndex);
       },
-      // Anchor near the top of the viewport (below the sticky header) so the
-      // stage occupying that band is the "current" one.
-      { rootMargin: "-96px 0px -65% 0px", threshold: 0 },
+      // Anchor a thin band at ~50% of the viewport height: the stage crossing
+      // the vertical middle is the "current" one, so a day activates as soon as
+      // it scrolls past the middle of the screen.
+      { rootMargin: "-50% 0px -50% 0px", threshold: 0 },
     );
 
     sections.forEach((section) => observer.observe(section));
@@ -214,7 +216,7 @@ export function StageDetailPanel({
             className={[
               "flex flex-col gap-4 rounded-xl p-1 transition-colors",
               isSelected
-                ? "ring-2 ring-brand/20 ring-offset-2"
+                ? "ring-2 ring-brand/20"
                 : "opacity-60 hover:opacity-80",
             ].join(" ")}
           >


### PR DESCRIPTION
## Contexte (recette #649, Lot E)

UX du jour actif dans le roadbook (`StageDetailPanel`).

## Correctifs

1. **Bordure blanche autour du jour actif** — la section active portait `ring-2 ring-brand/20 ring-offset-2`. Le `ring-offset-2` dessine un écart de 2px dans la couleur d'offset (le fond, blanc), qui se lisait comme une bordure blanche. Je retire `ring-offset-2` (l'anneau brand subtil reste, sans liseré blanc).
2. **Jour actif à ~50% de la hauteur du viewport** — le scroll-spy (IntersectionObserver) ancrait une bande près du haut (`rootMargin: -96px 0px -65% 0px`, ~35%). Je passe à une bande de hauteur nulle centrée (`-50% 0px -50% 0px`) : un jour devient actif dès qu'il franchit le **milieu** de l'écran.

## Vérification

- Vitest : 251 verts ; tsc / ESLint / Prettier clean.
- La sélection au **clic** (timeline) et l'injection directe restent inchangées ; `trip-detail.spec` (clic jour 2) et `ai-bubble.spec` (injection `activeDayNumber`) ne testent pas le scroll-spy → non impactés. Le scroll-spy réel est validé par les specs Playwright en CI.

Refs #649

<!-- claude-review-start -->
## Claude Review

**Commit reviewed:** `ab8ceca4b6144ad2462d5fc380ea695c54242d3d`

Clean, focused, two-fix PR with no critical issues found.

**Findings:** 0 critical · 0 warnings · 0 suggestions

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

No inline comments.
<!-- claude-review-end -->