### PR TITLE
fix(pwa): square the share infographic and restack its layout (Lot F)

### DIFF
--- a/pwa/src/lib/infographic.test.ts
+++ b/pwa/src/lib/infographic.test.ts
@@ -76,7 +76,6 @@ function makeFakeCanvas(): HTMLCanvasElement {
     closePath: vi.fn(),
     moveTo: vi.fn(),
     lineTo: vi.fn(),
-    quadraticCurveTo: vi.fn(),
     arc: vi.fn(),
     fill: vi.fn(),
     stroke: vi.fn(),

--- a/pwa/src/lib/infographic.test.ts
+++ b/pwa/src/lib/infographic.test.ts
@@ -71,6 +71,7 @@ function makeFakeCanvas(): HTMLCanvasElement {
     fillRect: vi.fn(),
     fillText: vi.fn(),
     strokeRect: vi.fn(),
+    rect: vi.fn(),
     beginPath: vi.fn(),
     closePath: vi.fn(),
     moveTo: vi.fn(),

--- a/pwa/src/lib/infographic.ts
+++ b/pwa/src/lib/infographic.ts
@@ -48,19 +48,24 @@ export function stageColor(index: number): string {
 export const CARD_WIDTH = 800;
 export const CARD_HEIGHT = 480;
 const PADDING = 28;
-// 70 / 30 split of the content row between the map and the stats column.
+// 70 / 30 split of the content row: an enlarged map fills the left column, the
+// stats and the elevation profile stack in the right column.
 const CONTENT_WIDTH = CARD_WIDTH - PADDING * 2; // 744
 const COLUMN_GAP = 16;
 const MAP_WIDTH = Math.round((CONTENT_WIDTH - COLUMN_GAP) * 0.7); // ~510
-const MAP_HEIGHT = 210;
-const ELEV_HEIGHT = 88;
 // Layout positions (fixed, always reserve space for the date line)
 const SEP_Y = PADDING + 32 + 24 + 8; // 92
 const CONTENT_TOP = SEP_Y + 16; // 108
-// Reserve a line under the map for the OSM attribution.
+// Reserve a line under the map for the OSM attribution and a footer band for
+// the branding line, then let the map fill the rest of the left column.
 const MAP_ATTRIBUTION_H = 16;
-const SEP2_Y = CONTENT_TOP + MAP_HEIGHT + MAP_ATTRIBUTION_H + 12;
-const ELEV_Y = SEP2_Y + 12;
+const FOOTER_BAND_H = 28;
+const CONTENT_BOTTOM = CARD_HEIGHT - FOOTER_BAND_H; // 452
+const MAP_HEIGHT = CONTENT_BOTTOM - CONTENT_TOP - MAP_ATTRIBUTION_H; // 328
+// Right column: fixed-height stat rows, then the elevation profile fills the
+// remaining height down to the map's baseline.
+const STAT_ROW_H = 40;
+const ELEV_GAP = 16;
 
 function computeOverallDifficulty(
   stages: StageData[],
@@ -109,8 +114,7 @@ export async function renderInfographic(
   gradient.addColorStop(0, "#1e293b");
   gradient.addColorStop(1, "#0f172a");
   ctx.fillStyle = gradient;
-  roundRect(ctx, 0, 0, CARD_WIDTH, CARD_HEIGHT, 16);
-  ctx.fill();
+  ctx.fillRect(0, 0, CARD_WIDTH, CARD_HEIGHT);
 
   // Title
   ctx.fillStyle = "#ffffff";
@@ -158,7 +162,7 @@ export async function renderInfographic(
     CONTENT_TOP + MAP_HEIGHT + 4,
   );
 
-  // Stats column (right side of content row, ~30% width) — single column
+  // Right column (~30% width): stats stacked above the elevation profile.
   const statsX = PADDING + MAP_WIDTH + COLUMN_GAP;
   const colWidth = CARD_WIDTH - statsX - PADDING;
 
@@ -214,10 +218,9 @@ export async function renderInfographic(
     },
   ];
 
-  const statRowH = MAP_HEIGHT / stats.length;
   stats.forEach((stat, i) => {
     const sx = statsX;
-    const sy = CONTENT_TOP + i * statRowH;
+    const sy = CONTENT_TOP + i * STAT_ROW_H;
 
     ctx.font = "18px system-ui, -apple-system, sans-serif";
     ctx.fillStyle = "#ffffff";
@@ -230,24 +233,31 @@ export async function renderInfographic(
 
     ctx.font = "bold 14px system-ui, -apple-system, sans-serif";
     ctx.fillStyle = stat.color;
-    ctx.fillText(truncateText(ctx, stat.value, colWidth - 28), sx + 28, sy + 15);
+    ctx.fillText(
+      truncateText(ctx, stat.value, colWidth - 28),
+      sx + 28,
+      sy + 15,
+    );
   });
 
-  // Second separator
+  // Divider between the stats and the elevation profile (right column only).
+  const statsBottom = CONTENT_TOP + stats.length * STAT_ROW_H;
   ctx.strokeStyle = "#334155";
   ctx.lineWidth = 1;
   ctx.beginPath();
-  ctx.moveTo(PADDING, SEP2_Y);
-  ctx.lineTo(CARD_WIDTH - PADDING, SEP2_Y);
+  ctx.moveTo(statsX, statsBottom + ELEV_GAP / 2);
+  ctx.lineTo(CARD_WIDTH - PADDING, statsBottom + ELEV_GAP / 2);
   ctx.stroke();
 
-  // Elevation profile
+  // Elevation profile — under the right column, its baseline aligned with the
+  // bottom of the enlarged map.
+  const elevY = statsBottom + ELEV_GAP;
   drawElevationProfile(
     ctx,
-    PADDING,
-    ELEV_Y,
-    CARD_WIDTH - PADDING * 2,
-    ELEV_HEIGHT,
+    statsX,
+    elevY,
+    colWidth,
+    CONTENT_TOP + MAP_HEIGHT - elevY,
     data.stages,
   );
 
@@ -327,8 +337,7 @@ async function drawRouteMap(
 ): Promise<void> {
   // Dark fallback background
   ctx.fillStyle = "#0f2340";
-  roundRect(ctx, x, y, w, h, 8);
-  ctx.fill();
+  ctx.fillRect(x, y, w, h);
 
   const activeStages = stages.filter(
     (s) => !s.isRestDay && s.geometry.length >= 2,
@@ -404,9 +413,10 @@ async function drawRouteMap(
     }
   }
 
-  // Clip to rounded map rect
+  // Clip to the map rect so tiles never bleed into the stats column.
   ctx.save();
-  roundRect(ctx, x, y, w, h, 8);
+  ctx.beginPath();
+  ctx.rect(x, y, w, h);
   ctx.clip();
 
   const tiles = await Promise.all(tilePromises);
@@ -567,27 +577,6 @@ export function downloadInfographicPng(
 // ---------------------------------------------------------------------------
 // Canvas utilities
 // ---------------------------------------------------------------------------
-
-function roundRect(
-  ctx: CanvasRenderingContext2D,
-  x: number,
-  y: number,
-  w: number,
-  h: number,
-  r: number,
-): void {
-  ctx.beginPath();
-  ctx.moveTo(x + r, y);
-  ctx.lineTo(x + w - r, y);
-  ctx.quadraticCurveTo(x + w, y, x + w, y + r);
-  ctx.lineTo(x + w, y + h - r);
-  ctx.quadraticCurveTo(x + w, y + h, x + w - r, y + h);
-  ctx.lineTo(x + r, y + h);
-  ctx.quadraticCurveTo(x, y + h, x, y + h - r);
-  ctx.lineTo(x, y + r);
-  ctx.quadraticCurveTo(x, y, x + r, y);
-  ctx.closePath();
-}
 
 function truncateText(
   ctx: CanvasRenderingContext2D,


### PR DESCRIPTION
## Contexte

Recette #649 (round 4) — Lot F : retours sur l'export PNG de partage (`renderInfographic`, canvas dessiné à la main dans `pwa/src/lib/infographic.ts`).

## Demandes traitées

1. **Coins arrondis supprimés** — le fond global (`roundRect 16px`) et le cadre de la carte (`roundRect 8px`, fond + clip) deviennent des rectangles à angles vifs (`fillRect` / `rect` pour le clip).
2. **Profil altimétrique sous la colonne de droite** — il occupait toute la largeur en bas ; il est désormais empilé sous les stats, dans la colonne de droite (largeur de colonne, base alignée sur le bas de la carte). Le 2e séparateur pleine largeur devient un séparateur court dans la colonne de droite.
3. **Carte agrandie** — `MAP_HEIGHT` passe de 210 à 328 px : la carte remplit toute la hauteur de la colonne de gauche (de `CONTENT_TOP` jusqu'à la ligne d'attribution OSM).

La fonction utilitaire `roundRect`, devenue morte, est supprimée.

## Layout

```
+-------------------------------------------------+
| Titre                                           |
| Dates                                           |
| ----------------------------------------------- |
| +-----------------------+  | stat 1             |
| |                       |  | stat 2             |
| |   CARTE (gauche,      |  | stat 3             |
| |   agrandie, angles    |  | stat 4             |
| |   vifs)               |  | stat 5             |
| |                       |  |------------------- |
| |                       |  | profil altimétrique|
| +-----------------------+  | (colonne droite)   |
| © OpenStreetMap contributors                    |
| © Powered by Bike Trip Planner                  |
+-------------------------------------------------+
```

## Vérification

- `prettier --check` ✓, `eslint` ✓ sur les fichiers touchés
- `vitest run src/lib/infographic.test.ts` ✓ (4/4) — le stub de canvas gagne `rect` (clip rectangulaire)
- `tsc --noEmit` : aucune erreur de type sur les fichiers touchés

Aucune spec ne dépend du layout pixel (`share-modal.spec.ts` et `sharing.steps.ts` vérifient seulement le téléchargement du `.png` ; `visual.fixture.ts` masque les `<canvas>`).

<!-- claude-review-start -->
## Claude Review

**Reviewed commit:** 3a40485fe95daced9f1d3aae20b0e3adccf71ca2

Clean, well-scoped layout refactor. The second commit correctly drops the orphaned `quadraticCurveTo` stub flagged in the prior review. The layout math is sound: `elevHeight = CONTENT_TOP + MAP_HEIGHT − elevY = 436 − 324 = 112 px` (positive, baseline-aligned with the enlarged map). Dead `roundRect` function removed. No findings.

**Resolved threads:** None.

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Findings summary

No findings.

**No inline comments.**
<!-- claude-review-end -->