### PR TITLE
fix(pwa): loader hébergements parasite + préservation alertes/hébergements (SSE)

### DIFF
--- a/pwa/src/hooks/use-trip-planner.ts
+++ b/pwa/src/hooks/use-trip-planner.ts
@@ -173,7 +173,6 @@ export function useTripPlanner() {
     actions.clearTrip();
     setMercureToken(null);
     setProcessing(true);
-    setAccommodationScanning(true);
 
     try {
       const pacing = getPacingState();
@@ -228,7 +227,6 @@ export function useTripPlanner() {
     actions.clearTrip();
     setMercureToken(null);
     setProcessing(true);
-    setAccommodationScanning(true);
 
     try {
       const { data, error, response } = await apiClient.POST(
@@ -269,7 +267,6 @@ export function useTripPlanner() {
     actions.clearTrip();
     setMercureToken(null);
     setProcessing(true);
-    setAccommodationScanning(true);
 
     try {
       const pacing = getPacingState();
@@ -1069,7 +1066,6 @@ export function useTripPlanner() {
         }
       } else {
         setProcessing(true);
-        setAccommodationScanning(true);
         // Mark affected stages as recomputing: the selected stage and the
         // next one (its startPoint may have shifted to the accommodation).
         const affectedIndices = [stageIndex];

--- a/pwa/src/store/trip-store.test.ts
+++ b/pwa/src/store/trip-store.test.ts
@@ -265,4 +265,33 @@ describe("applyStageUpdate preservation (recette #649)", () => {
     const result = useTripStore.getState().stages[0]!;
     expect(result.accommodations[0]?.name).toBe("New");
   });
+
+  it("keeps alerts when the endpoint is stable", () => {
+    const store = useTripStore.getState();
+    const current = makeStage(1);
+    current.alerts = [makeAlert("Stock up before the climb")];
+    store.setStages([current]);
+
+    const incoming = makeStage(1);
+    store.applyStageUpdate(0, incoming);
+
+    const result = useTripStore.getState().stages[0]!;
+    expect(result.alerts).toHaveLength(1);
+    expect(result.alerts[0]?.message).toBe("Stock up before the climb");
+  });
+
+  it("takes incoming alerts when the endpoint moved", () => {
+    const store = useTripStore.getState();
+    const current = makeStage(1);
+    current.alerts = [makeAlert("old")];
+    store.setStages([current]);
+
+    const incoming = makeStage(1);
+    incoming.endPoint = { lat: 9, lon: 9, ele: 0 };
+    incoming.alerts = [makeAlert("new")];
+    store.applyStageUpdate(0, incoming);
+
+    const result = useTripStore.getState().stages[0]!;
+    expect(result.alerts[0]?.message).toBe("new");
+  });
 });

--- a/pwa/src/store/trip-store.test.ts
+++ b/pwa/src/store/trip-store.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { getUndoableSlice, useTripStore } from "./trip-store";
-import type { StageData } from "@/lib/validation/schemas";
+import type {
+  AccommodationData,
+  AlertData,
+  StageData,
+} from "@/lib/validation/schemas";
 
 function makeStage(dayNumber: number, distance = 50): StageData {
   return {
@@ -23,6 +27,25 @@ function makeStage(dayNumber: number, distance = 50): StageData {
     supplyTimeline: [],
     events: [],
   };
+}
+
+function makeAccommodation(name: string): AccommodationData {
+  return {
+    name,
+    type: "hotel",
+    lat: 1,
+    lon: 1,
+    estimatedPriceMin: 50,
+    estimatedPriceMax: 80,
+    isExactPrice: false,
+    possibleClosed: false,
+    distanceToEndPoint: 0,
+    source: "osm",
+  };
+}
+
+function makeAlert(message: string): AlertData {
+  return { type: "warning", message, source: "accommodations" };
 }
 
 describe("getUndoableSlice", () => {
@@ -167,5 +190,79 @@ describe("selectedStageIndex (master/detail)", () => {
     store.setSelectedStageIndex(3);
     store.setStages([makeStage(1)]);
     expect(useTripStore.getState().selectedStageIndex).toBe(0);
+  });
+});
+
+describe("applyTripReady preservation (recette #649)", () => {
+  it("keeps accommodations/selection/alerts when the endpoint is stable", () => {
+    const store = useTripStore.getState();
+    const acc = makeAccommodation("Gîte du Tour");
+    const current = makeStage(1);
+    current.accommodations = [acc];
+    current.selectedAccommodation = acc;
+    current.alerts = [makeAlert("Stock up before the climb")];
+    store.setStages([current]);
+
+    // trip_ready payload arrives with empty accommodations/alerts.
+    const incoming = makeStage(1);
+    store.applyTripReady([incoming]);
+
+    const result = useTripStore.getState().stages[0]!;
+    expect(result.accommodations).toEqual([acc]);
+    expect(result.selectedAccommodation).toEqual(acc);
+    expect(result.alerts).toHaveLength(1);
+  });
+
+  it("takes incoming accommodations/alerts when the endpoint moved", () => {
+    const store = useTripStore.getState();
+    const old = makeAccommodation("Old");
+    const current = makeStage(1);
+    current.accommodations = [old];
+    current.alerts = [makeAlert("old")];
+    store.setStages([current]);
+
+    const incoming = makeStage(1);
+    incoming.endPoint = { lat: 9, lon: 9, ele: 0 };
+    incoming.accommodations = [makeAccommodation("New")];
+    incoming.alerts = [makeAlert("new")];
+    store.applyTripReady([incoming]);
+
+    const result = useTripStore.getState().stages[0]!;
+    expect(result.accommodations[0]?.name).toBe("New");
+    expect(result.alerts[0]?.message).toBe("new");
+  });
+});
+
+describe("applyStageUpdate preservation (recette #649)", () => {
+  it("keeps accommodations/selection when the endpoint is stable", () => {
+    const store = useTripStore.getState();
+    const acc = makeAccommodation("Gîte du Tour");
+    const current = makeStage(1);
+    current.accommodations = [acc];
+    current.selectedAccommodation = acc;
+    store.setStages([current]);
+
+    // stage_updated payload after a re-route carries an empty list.
+    const incoming = makeStage(1);
+    store.applyStageUpdate(0, incoming);
+
+    const result = useTripStore.getState().stages[0]!;
+    expect(result.accommodations).toEqual([acc]);
+    expect(result.selectedAccommodation).toEqual(acc);
+  });
+
+  it("takes incoming accommodations when the endpoint moved", () => {
+    const store = useTripStore.getState();
+    const current = makeStage(1);
+    current.accommodations = [makeAccommodation("Old")];
+    store.setStages([current]);
+
+    const incoming = makeStage(1);
+    incoming.endPoint = { lat: 9, lon: 9, ele: 0 };
+    incoming.accommodations = [makeAccommodation("New")];
+    store.applyStageUpdate(0, incoming);
+
+    const result = useTripStore.getState().stages[0]!;
+    expect(result.accommodations[0]?.name).toBe("New");
   });
 });

--- a/pwa/src/store/trip-store.ts
+++ b/pwa/src/store/trip-store.ts
@@ -717,8 +717,8 @@ export const useTripStore = create<TripState>()(
           // handler delivers fresh data via a supply_timeline event.
           supplyTimeline: prev.supplyTimeline,
           // A stage_updated event (e.g. after selecting an accommodation)
-          // re-routes the stage but does not re-scan accommodations: the
-          // payload may carry an empty list, so preserve the current ones
+          // re-routes the stage but does not re-scan accommodations/alerts:
+          // the payload may carry an empty list, so preserve the current ones
           // (and the selection) when the endpoint is stable (recette #649).
           accommodations:
             endMatch && prev.accommodations.length > 0
@@ -727,6 +727,8 @@ export const useTripStore = create<TripState>()(
           selectedAccommodation: endMatch
             ? (prev.selectedAccommodation ?? stage.selectedAccommodation)
             : stage.selectedAccommodation,
+          alerts:
+            endMatch && prev.alerts.length > 0 ? prev.alerts : stage.alerts,
         };
       }),
 

--- a/pwa/src/store/trip-store.ts
+++ b/pwa/src/store/trip-store.ts
@@ -662,6 +662,24 @@ export const useTripStore = create<TripState>()(
             // event), so the timeline already set in the store is current
             // — preserve it rather than blanking it.
             supplyTimeline: prev?.supplyTimeline ?? [],
+            // Accommodations + alerts arrive via their own SSE events
+            // (accommodations_found) that may land before trip_ready. The
+            // terminal payload can carry an empty list, so preserve the
+            // current ones when the stage endpoint is stable to avoid
+            // blanking already-displayed data (recette #649).
+            accommodations: endMatch
+              ? prev.accommodations.length > 0
+                ? prev.accommodations
+                : incoming.accommodations
+              : incoming.accommodations,
+            selectedAccommodation: endMatch
+              ? (prev.selectedAccommodation ?? incoming.selectedAccommodation)
+              : incoming.selectedAccommodation,
+            alerts: endMatch
+              ? prev.alerts.length > 0
+                ? prev.alerts
+                : incoming.alerts
+              : incoming.alerts,
           };
         });
       }),
@@ -698,6 +716,17 @@ export const useTripStore = create<TripState>()(
           // Keep current supply timeline until the re-dispatched ScanPois
           // handler delivers fresh data via a supply_timeline event.
           supplyTimeline: prev.supplyTimeline,
+          // A stage_updated event (e.g. after selecting an accommodation)
+          // re-routes the stage but does not re-scan accommodations: the
+          // payload may carry an empty list, so preserve the current ones
+          // (and the selection) when the endpoint is stable (recette #649).
+          accommodations:
+            endMatch && prev.accommodations.length > 0
+              ? prev.accommodations
+              : stage.accommodations,
+          selectedAccommodation: endMatch
+            ? (prev.selectedAccommodation ?? stage.selectedAccommodation)
+            : stage.selectedAccommodation,
         };
       }),
 


### PR DESCRIPTION
Closes #770. Sprint 42 (recette #649 round 5).

## Changements
- **Loader hébergements au 1er chargement** : retrait de `setAccommodationScanning(true)` inconditionnel dans `handleMagicLink`/`handleAiGeneration`/`handleGpxUpload` ; le flag n'est plus piloté que par "Élargir le rayon" + éteint par l'event `accommodations_found`.
- **Alertes/hébergements qui disparaissent (event `trip_ready`)** : `applyTripReady` préserve `accommodations`/`selectedAccommodation`/`alerts` quand l'endpoint d'étape est stable.
- **Loader réapparaît à la sélection** : `handleSelectAccommodation` ne réactive plus le flag scanning ; `applyStageUpdate` préserve les accommodations sur endpoint stable.
- 4 tests Vitest store ajoutés (suite 14/14).

## Auto-critique
Vérif ciblée verte (prettier/eslint/tsc/vitest). Le cycle de vie du flag (glue React-hook) n'est pas unit-testé (disproportionné) ; la logique store l'est. `make qa`/`test` complets délégués à la CI.

<!-- claude-review-start -->
## Claude Review

**Commit reviewed:** `809b22f45e7b4cb77bca27db75305b107f836095`

**Findings:** 0 issues.

**Resolved threads:** Resolved 1 previously open thread — alert preservation in `applyStageUpdate` addressed by the second commit.

## Review checklist
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** None.
<!-- claude-review-end -->