### PR TITLE
fix(pwa): infographie PNG — carte centrée + marge copyright, profil à l'échelle

### DIFF
--- a/pwa/src/lib/infographic.ts
+++ b/pwa/src/lib/infographic.ts
@@ -63,7 +63,7 @@ const MAP_ATTRIBUTION_GAP = 12;
 const MAP_ATTRIBUTION_H = 16 + MAP_ATTRIBUTION_GAP;
 const FOOTER_BAND_H = 28;
 const CONTENT_BOTTOM = CARD_HEIGHT - FOOTER_BAND_H; // 452
-const MAP_HEIGHT = CONTENT_BOTTOM - CONTENT_TOP - MAP_ATTRIBUTION_H; // 328
+const MAP_HEIGHT = CONTENT_BOTTOM - CONTENT_TOP - MAP_ATTRIBUTION_H; // 316
 // Right column: fixed-height stat rows, then the elevation profile fills the
 // remaining height down to the map's baseline.
 const STAT_ROW_H = 40;

--- a/pwa/src/lib/infographic.ts
+++ b/pwa/src/lib/infographic.ts
@@ -56,9 +56,11 @@ const MAP_WIDTH = Math.round((CONTENT_WIDTH - COLUMN_GAP) * 0.7); // ~510
 // Layout positions (fixed, always reserve space for the date line)
 const SEP_Y = PADDING + 32 + 24 + 8; // 92
 const CONTENT_TOP = SEP_Y + 16; // 108
-// Reserve a line under the map for the OSM attribution and a footer band for
-// the branding line, then let the map fill the rest of the left column.
-const MAP_ATTRIBUTION_H = 16;
+// Reserve a band under the map for the OSM attribution (with a clear gap above
+// the copyright line) and a footer band for the branding line, then let the
+// map fill the rest of the left column.
+const MAP_ATTRIBUTION_GAP = 12;
+const MAP_ATTRIBUTION_H = 16 + MAP_ATTRIBUTION_GAP;
 const FOOTER_BAND_H = 28;
 const CONTENT_BOTTOM = CARD_HEIGHT - FOOTER_BAND_H; // 452
 const MAP_HEIGHT = CONTENT_BOTTOM - CONTENT_TOP - MAP_ATTRIBUTION_H; // 328
@@ -159,7 +161,7 @@ export async function renderInfographic(
   ctx.fillText(
     "© OpenStreetMap contributors",
     PADDING,
-    CONTENT_TOP + MAP_HEIGHT + 4,
+    CONTENT_TOP + MAP_HEIGHT + MAP_ATTRIBUTION_GAP,
   );
 
   // Right column (~30% width): stats stacked above the elevation profile.
@@ -498,7 +500,15 @@ function drawElevationProfile(
 
   const minEle = allEles.reduce((a, b) => (b < a ? b : a), allEles[0]!);
   const maxEle = allEles.reduce((a, b) => (b > a ? b : a), allEles[0]!);
-  const eleRange = maxEle - minEle || 1;
+  // Match the app's ElevationProfile.tsx padded domain so the PNG profile uses
+  // the same vertical scale (terrain in the bottom third, peaks breathing)
+  // instead of stretching the stage's own min/max to fill the box.
+  const elevRange = maxEle - minEle;
+  const bufferBelow = Math.max(elevRange * 0.1, 10);
+  const bufferAbove = Math.max(elevRange * 1.5, 100);
+  const displayMinEle = minEle - bufferBelow;
+  const displayMaxEle = maxEle + bufferAbove;
+  const displayRange = displayMaxEle - displayMinEle || 1;
   const padY = 4;
   const ph = h - padY * 2;
   const totalPoints = allEles.length;
@@ -506,7 +516,7 @@ function drawElevationProfile(
   const toCanvasX = (globalIdx: number) =>
     x + (globalIdx / (totalPoints - 1)) * w;
   const toCanvasY = (ele: number) =>
-    y + h - padY - ((ele - minEle) / eleRange) * ph;
+    y + h - padY - ((ele - displayMinEle) / displayRange) * ph;
 
   // Filled area under the profile (subtle gradient per segment)
   let globalIdx = 0;


### PR DESCRIPTION
Closes #772. Sprint 42 (recette #649 round 5).

## Changements
- **Carte + marge** : `MAP_ATTRIBUTION_GAP = 12` ; la ligne "© OpenStreetMap contributors" est repositionnée avec une marge visible sous la carte (la carte reste centrée via `offX/offY`).
- **Échelle du profil altimétrique** : réplique le domaine padé de `Map/ElevationProfile.tsx` (`bufferBelow`/`bufferAbove`) — fin des pics "titanesques", le profil PNG correspond à celui de l'app.

## Auto-critique
Vérif ciblée verte (prettier/eslint/tsc/vitest 4/4). Stub canvas du test inchangé (toujours valide). Pas de DTO/deps.

<!-- claude-review-start -->
## Claude Review

**Summary:** Focused, correct fix. The `bufferBelow`/`bufferAbove` constants in `drawElevationProfile` are verified to be an exact copy of those in `ElevationProfile.tsx`; the attribution gap math is sound; the stale `// 328` comment was fixed in the follow-up commit. Code is approved.

**Resolved threads:** Resolved 1 previously open thread (stale `MAP_HEIGHT` comment — addressed by the second commit).

**PR title:** The description is still a noun phrase rather than imperative mood as required by Conventional Commits. Since this title becomes the squash-commit message on merge, please update it before merging. Suggested: `fix(pwa): align infographic elevation scale with app domain and add copyright margin`.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [ ] Tests cover new/changed cases — the existing stub only verifies `renderInfographic` resolves; there is no assertion on the computed `displayMinEle`/`displayRange` values used in `toCanvasY`. `drawElevationProfile` is private so this requires either exporting it or capturing `lineTo` call arguments from the stub.
- [x] Documentation is up to date (stale comment fixed)
- [x] Dependent tickets accounted for

**Inline comments:** No new inline comments.

Reviewed commit: `76dc78ce78c0c6b4b4c433aa8f0de0b044d3d294`
<!-- claude-review-end -->