### PR TITLE
fix(pwa): texte de partage — bouton copier (icône), tooltip budget, espacement, gras WhatsApp

### DIFF
--- a/pwa/src/components/share-modal.tsx
+++ b/pwa/src/components/share-modal.tsx
@@ -439,29 +439,20 @@ export function ShareModal({
           </h3>
 
           <div className="relative">
-            <TooltipProvider>
-              <Tooltip open={textCopied}>
-                <TooltipTrigger asChild>
-                  <Button
-                    onClick={() => void handleCopyText()}
-                    variant="outline"
-                    size="icon"
-                    className="absolute top-2 right-2 cursor-pointer"
-                    aria-label={t("copyText")}
-                    data-testid="share-copy-text-button"
-                  >
-                    {textCopied ? (
-                      <Check className="h-4 w-4" />
-                    ) : (
-                      <Copy className="h-4 w-4" />
-                    )}
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">
-                  {t("textCopiedBtn")}
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
+            <Button
+              onClick={() => void handleCopyText()}
+              variant="outline"
+              size="icon"
+              className="absolute top-2 right-2 cursor-pointer"
+              aria-label={textCopied ? t("textCopiedBtn") : t("copyText")}
+              data-testid="share-copy-text-button"
+            >
+              {textCopied ? (
+                <Check className="h-4 w-4" />
+              ) : (
+                <Copy className="h-4 w-4" />
+              )}
+            </Button>
 
             <div className="whitespace-pre-wrap break-words rounded-md bg-muted p-4 pr-14 text-sm leading-relaxed max-h-[30vh] overflow-y-auto">
               {fullText.split("\n").map((line, i) => (

--- a/pwa/src/components/share-modal.tsx
+++ b/pwa/src/components/share-modal.tsx
@@ -11,6 +11,7 @@ import {
   Download,
   Image as ImageIcon,
   FileText,
+  Info,
   Loader2,
   Trash2,
 } from "lucide-react";
@@ -419,35 +420,56 @@ export function ShareModal({
           >
             <FileText className="h-4 w-4" />
             {t("textTitle")}
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    className="text-muted-foreground cursor-help"
+                    aria-label={tTextExport("budgetNote")}
+                  >
+                    <Info className="h-4 w-4" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" className="max-w-xs">
+                  {tTextExport("budgetNote")}
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           </h3>
 
-          <div className="whitespace-pre-wrap break-words rounded-md bg-muted p-4 text-sm leading-relaxed max-h-[30vh] overflow-y-auto">
-            {fullText.split("\n").map((line, i) => (
-              <p key={i} className="min-h-[1em]">
-                {renderTextLine(line)}
-              </p>
-            ))}
-          </div>
+          <div className="relative">
+            <TooltipProvider>
+              <Tooltip open={textCopied}>
+                <TooltipTrigger asChild>
+                  <Button
+                    onClick={() => void handleCopyText()}
+                    variant="outline"
+                    size="icon"
+                    className="absolute top-2 right-2 cursor-pointer"
+                    aria-label={t("copyText")}
+                    data-testid="share-copy-text-button"
+                  >
+                    {textCopied ? (
+                      <Check className="h-4 w-4" />
+                    ) : (
+                      <Copy className="h-4 w-4" />
+                    )}
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">
+                  {t("textCopiedBtn")}
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
 
-          <p className="text-xs text-muted-foreground/70 leading-relaxed mt-2">
-            {tTextExport("budgetNote")}
-          </p>
-
-          <div className="flex justify-end mt-2">
-            <Button
-              onClick={() => void handleCopyText()}
-              variant="outline"
-              size="sm"
-              className="gap-2 cursor-pointer"
-              data-testid="share-copy-text-button"
-            >
-              {textCopied ? (
-                <Check className="h-4 w-4" />
-              ) : (
-                <Copy className="h-4 w-4" />
-              )}
-              {textCopied ? t("textCopiedBtn") : t("copyText")}
-            </Button>
+            <div className="whitespace-pre-wrap break-words rounded-md bg-muted p-4 pr-14 text-sm leading-relaxed max-h-[30vh] overflow-y-auto">
+              {fullText.split("\n").map((line, i) => (
+                <p key={i} className="min-h-[1em]">
+                  {renderTextLine(line, i === 0)}
+                </p>
+              ))}
+            </div>
           </div>
         </section>
       </DialogContent>
@@ -456,15 +478,15 @@ export function ShareModal({
 }
 
 /**
- * Render a single line of text, converting *bold* markers to <strong>
- * and URLs to clickable links.
+ * Render a single line of text, rendering the title line as bold and
+ * URLs as clickable links. The exported text contains no bold markers.
  */
-function renderTextLine(line: string): React.ReactNode[] {
-  const parts = line.split(/(\*[^*]+\*|https?:\/\/[^\s,)]+)/);
+function renderTextLine(line: string, isTitle = false): React.ReactNode[] {
+  if (isTitle && line) {
+    return [<strong key="title">{line}</strong>];
+  }
+  const parts = line.split(/(https?:\/\/[^\s,)]+)/);
   return parts.map((part, j) => {
-    if (/^\*[^*]+\*$/.test(part)) {
-      return <strong key={j}>{part.slice(1, -1)}</strong>;
-    }
     if (/^https?:\/\//.test(part)) {
       return (
         <a

--- a/pwa/src/lib/text-export.test.ts
+++ b/pwa/src/lib/text-export.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { buildTripText } from "./text-export";
+import type { StageData } from "./validation/schemas";
+
+function buildStage(
+  dayNumber: number,
+  distance: number,
+  elevation: number,
+  isRestDay = false,
+): StageData {
+  return {
+    dayNumber,
+    distance,
+    elevation,
+    elevationLoss: elevation,
+    startPoint: { lat: 45, lon: 4, ele: 0 },
+    endPoint: { lat: 45, lon: 4.1, ele: 0 },
+    geometry: [],
+    label: `Stage ${dayNumber}`,
+    startLabel: null,
+    endLabel: null,
+    weather: null,
+    alerts: [],
+    pois: [],
+    accommodations: [],
+    accommodationSearchRadiusKm: 5,
+    isRestDay,
+    supplyTimeline: [],
+    events: [],
+  };
+}
+
+const labels = { totalDistance: "Distance totale", totalElevation: "Dénivelé" };
+
+describe("buildTripText", () => {
+  it("contains no literal bold markers", () => {
+    const text = buildTripText({
+      title: "Mon voyage",
+      totalDistance: 120,
+      totalElevation: 1500,
+      totalElevationLoss: 1400,
+      sourceUrl: "https://www.komoot.com/tour/123",
+      stages: [buildStage(1, 60, 800), buildStage(2, 60, 700)],
+      startDate: "2026-06-25",
+      labels,
+    });
+
+    expect(text).not.toContain("*");
+  });
+
+  it("renders the title and date lines without asterisks", () => {
+    const text = buildTripText({
+      title: "Mon voyage",
+      totalDistance: 60,
+      totalElevation: 800,
+      totalElevationLoss: 800,
+      sourceUrl: "",
+      stages: [buildStage(1, 60, 800)],
+      startDate: "2026-06-25",
+      labels,
+    });
+
+    const lines = text.split("\n");
+    expect(lines[0]).toBe("Mon voyage");
+    expect(lines.some((l) => l.includes("*"))).toBe(false);
+  });
+
+  it("uses the bike emoji without a dangling zero-width joiner", () => {
+    const text = buildTripText({
+      title: "T",
+      totalDistance: 10,
+      totalElevation: null,
+      totalElevationLoss: null,
+      sourceUrl: "",
+      stages: [],
+      startDate: null,
+      labels,
+    });
+
+    expect(text).toContain("🚴 Distance totale");
+    expect(text).not.toContain("‍");
+  });
+});

--- a/pwa/src/lib/text-export.ts
+++ b/pwa/src/lib/text-export.ts
@@ -42,7 +42,7 @@ function formatStageLine(
   const elevUp = `⬆️ ${Math.round(stage.elevation)}m`;
   const elevDown = `⬇️ ${Math.round(stage.elevationLoss ?? 0)}m`;
 
-  let line = `*${date}* : ${distance}, ${elevUp} ${elevDown}`;
+  let line = `${date} : ${distance}, ${elevUp} ${elevDown}`;
 
   const acc = isLast
     ? null
@@ -111,14 +111,12 @@ export function buildTripText(params: TextExportParams): string {
   const lines: string[] = [];
 
   // Title
-  lines.push(`*${title}*`);
+  lines.push(title);
   lines.push("");
 
   // Global stats
   if (totalDistance !== null) {
-    lines.push(
-      `- 🚴‍ ${labels.totalDistance} : ${Math.round(totalDistance)}km`,
-    );
+    lines.push(`- 🚴 ${labels.totalDistance} : ${Math.round(totalDistance)}km`);
   }
   if (totalElevation !== null) {
     lines.push(


### PR DESCRIPTION
Closes #773. Sprint 42 (recette #649 round 5).

## Changements
- **Espacement picto** : ZWJ orphelin (U+200D) retiré après 🚴 sur la ligne "Distance totale".
- **Bouton copier** : déplacé en haut à droite de l'encart, icône seule (aria-label + feedback conservés).
- **Note budget** : remplacée par une icône info + tooltip au survol, à côté du titre "Texte formaté".
- **Gras WhatsApp** : marqueurs `*...*` retirés du texte exporté (titre + dates) ; preview in-app via `<strong>`. Plus aucun `*` dans le texte copié.
- Test Vitest `text-export.test.ts` (asserte absence de `*`/ZWJ).

## Auto-critique
Vérif ciblée verte (prettier/eslint/tsc/vitest 3/3). Pas de DTO/deps.

<!-- claude-review-start -->
## Claude Review

**Commit reviewed:** `4ddc7041aa6b333fd62daff2983957ad2267d9fd`

**Summary:** 0 critical · 0 warning · 0 suggestions. Clean, well-scoped fix: bold markers removed from exported text, ZWJ orphan stripped, copy button relocated as icon-only with `aria-label`, budget note converted to a hover tooltip, and all three behavioural changes backed by targeted Vitest assertions.

### Review Checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Resolved Threads

Resolved 1 previously open thread (controlled-tooltip on copy button — addressed by removing the Tooltip component from that button entirely).

### Inline Comments

No inline comments.
<!-- claude-review-end -->