### PR TITLE
fix(pwa): roadbook — bordure jour actif, largeur bloc, alertes = événements, ravito désactivé

### DIFF
--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -366,7 +366,6 @@
     "userWaypoint": "User waypoints"
   },
   "stageAlerts": {
-    "title": "{count, plural, one {# alert} other {# alerts}}",
     "heading": "Alerts ({count})"
   },
   "alertGroup": {

--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -366,7 +366,8 @@
     "userWaypoint": "User waypoints"
   },
   "stageAlerts": {
-    "title": "{count, plural, one {# alert} other {# alerts}}"
+    "title": "{count, plural, one {# alert} other {# alerts}}",
+    "heading": "Alerts ({count})"
   },
   "alertGroup": {
     "title": {

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -366,7 +366,8 @@
     "userWaypoint": "Waypoints utilisateur"
   },
   "stageAlerts": {
-    "title": "{count, plural, one {# alerte} other {# alertes}}"
+    "title": "{count, plural, one {# alerte} other {# alertes}}",
+    "heading": "Alertes ({count})"
   },
   "alertGroup": {
     "title": {

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -366,7 +366,6 @@
     "userWaypoint": "Waypoints utilisateur"
   },
   "stageAlerts": {
-    "title": "{count, plural, one {# alerte} other {# alertes}}",
     "heading": "Alertes ({count})"
   },
   "alertGroup": {

--- a/pwa/src/components/SupplyTimeline/SupplyTimeline.tsx
+++ b/pwa/src/components/SupplyTimeline/SupplyTimeline.tsx
@@ -20,6 +20,12 @@ import type {
  */
 const CLUSTER_THRESHOLD_PCT = 4;
 
+/**
+ * Per-day supply timeline disabled pending an UX redesign (recette #649,
+ * issue #771). The component code is kept intact for the follow-up rework.
+ */
+const SUPPLY_TIMELINE_ENABLED = false;
+
 interface ClusteredMarker {
   type: SupplyMarkerData["type"];
   /** Average distanceFromStart of all clustered markers (km). */
@@ -237,6 +243,10 @@ export function SupplyTimeline({
   const handleOpenChange = useCallback((index: number, isOpen: boolean) => {
     setOpenClusterIndex(isOpen ? index : null);
   }, []);
+
+  if (!SUPPLY_TIMELINE_ENABLED) {
+    return null;
+  }
 
   if (markers.length === 0 || stageDistance <= 0) {
     return null;

--- a/pwa/src/components/Timeline/StageDetailPanel.tsx
+++ b/pwa/src/components/Timeline/StageDetailPanel.tsx
@@ -214,10 +214,8 @@ export function StageDetailPanel({
             aria-label={tStage("day", { dayNumber: stage.dayNumber })}
             data-stage-index={i}
             className={[
-              "flex flex-col gap-4 rounded-xl p-1 transition-colors",
-              isSelected
-                ? "ring-2 ring-brand/20"
-                : "opacity-60 hover:opacity-80",
+              "flex w-full flex-col gap-4 rounded-xl p-1 transition-colors",
+              isSelected ? "" : "opacity-60 hover:opacity-80",
             ].join(" ")}
           >
             {/* Day heading — anchor preserved for scroll-spy and in-app
@@ -300,7 +298,7 @@ export function StageDetailPanel({
             {!readOnly &&
               i < stages.length - 1 &&
               (onAddStage || onInsertRestDay) && (
-                <div className="flex flex-wrap gap-2">
+                <div className="flex w-full flex-wrap gap-2">
                   {onInsertRestDay &&
                     !stage.isRestDay &&
                     !stages[i + 1]?.isRestDay && (

--- a/pwa/src/components/add-rest-day-button.tsx
+++ b/pwa/src/components/add-rest-day-button.tsx
@@ -21,7 +21,7 @@ export function AddRestDayButton({
   return (
     <Button
       variant="outline"
-      className="w-full md:max-w-[80%] border-dashed border-muted-icon bg-muted/30 text-muted-icon hover:text-foreground hover:border-brand hover:bg-muted/50 cursor-pointer"
+      className="w-full flex-1 border-dashed border-muted-icon bg-muted/30 text-muted-icon hover:text-foreground hover:border-brand hover:bg-muted/50 cursor-pointer"
       onClick={onClick}
       disabled={disabled}
       aria-label={t("ariaLabel", { dayNumber })}

--- a/pwa/src/components/add-stage-button.tsx
+++ b/pwa/src/components/add-stage-button.tsx
@@ -19,7 +19,7 @@ export function AddStageButton({
   return (
     <Button
       variant="outline"
-      className="w-full md:max-w-[80%] border-dashed border-muted-icon text-muted-icon hover:text-foreground hover:border-brand cursor-pointer"
+      className="w-full flex-1 border-dashed border-muted-icon text-muted-icon hover:text-foreground hover:border-brand cursor-pointer"
       onClick={onClick}
       disabled={disabled}
       title={disabled ? t("insufficientSpace") : undefined}

--- a/pwa/src/components/stage-alerts.tsx
+++ b/pwa/src/components/stage-alerts.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { useState, useCallback } from "react";
-import { ChevronDown, ChevronUp } from "lucide-react";
+import { AlertTriangle, ChevronDown, ChevronUp } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
 import { AlertList } from "@/components/alert-list";
 import type { AlertData } from "@/lib/validation/schemas";
 
@@ -27,33 +29,33 @@ export function StageAlerts({ alerts, onAddPoiWaypoint }: StageAlertsProps) {
 
   return (
     <div data-testid="stage-alerts">
-      {/* Section header */}
-      <button
-        type="button"
-        className="flex w-full items-center justify-between gap-2 py-1 text-sm font-medium text-foreground hover:text-foreground/80 transition-colors"
+      {/* Section header — mirrors the events panel layout (icon + count). */}
+      <Separator className="mt-4 mb-3" />
+      <Button
+        variant="ghost"
+        className="w-full justify-between px-0 h-auto py-1 text-sm font-medium hover:bg-transparent cursor-pointer"
         onClick={toggleExpanded}
         aria-expanded={expanded}
         data-testid="stage-alerts-toggle"
       >
-        <span data-testid="stage-alerts-count">
-          {t("title", { count: alerts.length })}
+        <span className="flex items-center gap-1.5">
+          <AlertTriangle className="h-4 w-4 text-muted-foreground" />
+          <span data-testid="stage-alerts-count">
+            {t("heading", { count: alerts.length })}
+          </span>
         </span>
         {expanded ? (
-          <ChevronUp
-            className="h-4 w-4 shrink-0 text-muted-foreground"
-            aria-hidden="true"
-          />
+          <ChevronUp className="h-4 w-4 text-muted-foreground" />
         ) : (
-          <ChevronDown
-            className="h-4 w-4 shrink-0 text-muted-foreground"
-            aria-hidden="true"
-          />
+          <ChevronDown className="h-4 w-4 text-muted-foreground" />
         )}
-      </button>
+      </Button>
 
-      {/* Collapsible body — alerts are grouped by severity inside */}
+      {/* Collapsible body — alerts are grouped by severity inside. Left
+          padding lines the content up with the header title (past the icon)
+          and right padding gives it breathing room. */}
       {expanded && (
-        <div className="mt-2" data-testid="stage-alerts-body">
+        <div className="mt-2 pl-[22px] pr-1" data-testid="stage-alerts-body">
           <AlertList alerts={alerts} onAddPoiWaypoint={onAddPoiWaypoint} />
         </div>
       )}

--- a/pwa/tests/mocked/supply-timeline.spec.ts
+++ b/pwa/tests/mocked/supply-timeline.spec.ts
@@ -279,7 +279,8 @@ test.describe.skip("Supply timeline", () => {
   });
 });
 
-test.describe("supply timeline — marker clustering", () => {
+// Supply timeline disabled pending an UX redesign (#771, follow-up #778).
+test.describe.skip("supply timeline — marker clustering", () => {
   test("two nearby markers are merged into a single cluster", async ({
     submitUrl,
     injectSequence,

--- a/pwa/tests/mocked/supply-timeline.spec.ts
+++ b/pwa/tests/mocked/supply-timeline.spec.ts
@@ -7,7 +7,9 @@ import {
   supplyTimelineClusterEvent,
 } from "../fixtures/mock-data";
 
-test.describe("Supply timeline", () => {
+// Supply timeline disabled pending an UX redesign (#771, follow-up #778).
+// Re-enable these specs alongside the new UX.
+test.describe.skip("Supply timeline", () => {
   test("is not visible before supply data arrives", async ({
     submitUrl,
     injectSequence,

--- a/pwa/tests/recette/features/stage-management.en.feature
+++ b/pwa/tests/recette/features/stage-management.en.feature
@@ -74,26 +74,26 @@ Feature: Stage management
     When I submit a valid Komoot link
     Then I see a progress bar while stages are being computed
 
-  @desktop @supply
+  @desktop @supply @skip
   Scenario: Supply timeline displayed on a stage
     Given supply data is available for stage 1
     Then the supply timeline of stage 1 is visible
 
-  @desktop @supply
+  @desktop @supply @skip
   Scenario: Supply markers with water, food and mixed icons
     Given supply data is available for stage 1
     Then the supply marker at 15 km shows the water icon
     And the supply marker at 42 km shows the food icon
     And the supply marker at 59 km shows the mixed icon
 
-  @desktop @supply
+  @desktop @supply @skip
   Scenario: Hovering a marker shows the name and distance
     Given supply data is available for stage 1
     When I open the supply marker at 15 km
     Then the supply tooltip shows "Cimetière de Vals"
     And the supply tooltip shows "15 km"
 
-  @mobile @supply
+  @mobile @supply @skip
   Scenario: Horizontal scroll of the supply timeline on mobile
     Given supply data is available for stage 1 on mobile
     Then the supply timeline of stage 1 is visible

--- a/pwa/tests/recette/features/stage-management.fr.feature
+++ b/pwa/tests/recette/features/stage-management.fr.feature
@@ -75,26 +75,26 @@ Fonctionnalité: Gestion des étapes
     Quand je soumets un lien Komoot valide
     Alors je vois une barre de progression pendant le calcul des étapes
 
-  @desktop @ravitaillement
+  @desktop @ravitaillement @skip
   Scénario: Affichage de la timeline des ravitaillements sur une étape
     Étant donné que des données de ravitaillement sont disponibles pour l'étape 1
     Alors la timeline des ravitaillements de l'étape 1 est visible
 
-  @desktop @ravitaillement
+  @desktop @ravitaillement @skip
   Scénario: Marqueurs de ravitaillement avec icônes eau, nourriture et mixte
     Étant donné que des données de ravitaillement sont disponibles pour l'étape 1
     Alors le marqueur de ravitaillement à 15 km affiche l'icône eau
     Et le marqueur de ravitaillement à 42 km affiche l'icône nourriture
     Et le marqueur de ravitaillement à 59 km affiche l'icône mixte
 
-  @desktop @ravitaillement
+  @desktop @ravitaillement @skip
   Scénario: Survol d'un marqueur affiche le nom et la distance
     Étant donné que des données de ravitaillement sont disponibles pour l'étape 1
     Quand j'ouvre le marqueur de ravitaillement à 15 km
     Alors l'info-bulle de ravitaillement affiche "Cimetière de Vals"
     Et l'info-bulle de ravitaillement affiche "15 km"
 
-  @mobile @ravitaillement
+  @mobile @ravitaillement @skip
   Scénario: Défilement horizontal de la timeline des ravitaillements sur mobile
     Étant donné que des données de ravitaillement sont disponibles pour l'étape 1 sur mobile
     Alors la timeline des ravitaillements de l'étape 1 est visible


### PR DESCRIPTION
Closes #771. Sprint 42 (recette #649 round 5).

> **Stack** : basé sur `feature/769` (PR #779) — à merger **après** #779.

## Changements
- **Bordure jour actif** : `ring-2 ring-brand/20` retiré (opacity des non-sélectionnés conservée).
- **Largeur bloc Jour** : `w-full` sur la section + rangée de boutons ; `add-stage-button`/`add-rest-day-button` passent de `md:max-w-[80%]` à `flex-1` (suppression de l'espace mort à droite).
- **Liste alertes = événements** : en-tête repris d'`events-panel` (Separator, Button ghost cursor-pointer, picto `AlertTriangle` + count via `stageAlerts.heading`), corps `pl-[22px] pr-1` aligné sur le titre.
- **Timeline ravito** : désactivée via flag `SUPPLY_TIMELINE_ENABLED = false` + early-return (code conservé) ; spec `describe.skip`. **Issue de suivi #778** créée.

## Auto-critique
Vérif ciblée verte (prettier/eslint/tsc). Parité i18n. `make qa` complet délégué à la CI.

<!-- claude-review-start -->
## Claude Review

Clean UX-polish PR — three focused commits, no backend changes. No correctness, security, performance, or architecture issues found. The supply timeline disable is cleanly guarded with a named constant and comprehensive test skips (both Playwright `describe.skip` blocks and all BDD `@skip` tags in both locale feature files). The `stageAlerts.heading` i18n key is used consistently; the orphaned `title` key has been removed.

### Review summary

| Severity | Count |
|---|---|
| 🔴 Critical | 0 |
| 🟠 Warning | 0 |
| 🔵 Suggestion | 0 |

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

_Reviewed commit: a175f9e5112979b344d3a45d10cf4681d1eea6a3_
<!-- claude-review-end -->