### PR TITLE
fix(trip): stop legacy STAGES_COMPUTED overwriting edited stage distance

### DIFF
--- a/api/migrations/Version20260625120000.php
+++ b/api/migrations/Version20260625120000.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Issue #775: persist the expensive PostGIS trip-detail metrics at stage-store time.
+ *
+ * Adds `stage.on_cycle_network` (fraction 0..1 of the stage following a signed cycle
+ * route) and `trip.out_of_zone` (route outside the provisioned coverage area) so the
+ * trip-detail read path no longer runs the costly `onNetworkFractions` / `isRouteOutOfZone`
+ * PostGIS queries on every reload. Existing rows keep the column defaults (0 / false)
+ * until the next structural recompute persists the real values.
+ */
+final class Version20260625120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Persist on_cycle_network (stage) and out_of_zone (trip) for O(1) trip-detail reads (#775)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE stage ADD on_cycle_network DOUBLE PRECISION DEFAULT 0 NOT NULL');
+        $this->addSql('ALTER TABLE trip ADD out_of_zone BOOLEAN DEFAULT false NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE stage DROP on_cycle_network');
+        $this->addSql('ALTER TABLE trip DROP out_of_zone');
+    }
+}

--- a/api/src/ApiResource/Stage.php
+++ b/api/src/ApiResource/Stage.php
@@ -160,6 +160,17 @@ final class Stage
 
     public ?Accommodation $selectedAccommodation = null;
 
+    /**
+     * Fraction (0..1) of the stage line that follows a signed cycle route,
+     * persisted at stage-store time and read back here (issue #775).
+     *
+     * Server-computed from PostGIS: readable (the frontend consumes it) but never
+     * writable, so a client PATCH/PUT on a Stage cannot overwrite the computed
+     * value (review on #787).
+     */
+    #[ApiProperty(writable: false)]
+    public float $onCycleNetwork = 0.0;
+
     /** @var Event[] */
     public array $events = [];
 

--- a/api/src/ApiResource/TripRequest.php
+++ b/api/src/ApiResource/TripRequest.php
@@ -129,6 +129,19 @@ final class TripRequest
     #[ApiProperty(readable: false, writable: false)]
     public string $locale = 'en';
 
+    /**
+     * True when the route falls (even partly) outside the provisioned coverage
+     * area: the trip is display-only (no Valhalla rerouting).
+     *
+     * Persisted at stage-store time (issue #775) from the expensive PostGIS
+     * {@see \App\Osm\CoverageRepositoryInterface::isRouteOutOfZone()} query so
+     * {@see \App\State\TripDetailProvider} reads it in O(1) instead of recomputing
+     * it on every trip reload.
+     */
+    #[ORM\Column(options: ['default' => false])]
+    #[ApiProperty(readable: false, writable: false)]
+    public bool $outOfZone = false;
+
     #[ORM\Column]
     #[ApiProperty(readable: false, writable: false)]
     public \DateTimeImmutable $createdAt;

--- a/api/src/Entity/Stage.php
+++ b/api/src/Entity/Stage.php
@@ -60,6 +60,17 @@ class Stage
     #[ORM\Column]
     private bool $isRestDay = false;
 
+    /**
+     * Fraction (0..1) of the stage line that follows a signed cycle route.
+     *
+     * Persisted at stage-store time (issue #775) from the expensive PostGIS
+     * {@see \App\Osm\CycleRouteRepositoryInterface::onNetworkFractions()} query so
+     * {@see \App\State\TripDetailProvider} reads it in O(1) instead of recomputing
+     * it on every trip reload.
+     */
+    #[ORM\Column(options: ['default' => 0])]
+    private float $onCycleNetwork = 0.0;
+
     /** @var array<string, mixed>|null */
     #[ORM\Column(type: 'jsonb', nullable: true)]
     private ?array $weather = null;
@@ -275,6 +286,18 @@ class Stage
     public function setIsRestDay(bool $isRestDay): self
     {
         $this->isRestDay = $isRestDay;
+
+        return $this;
+    }
+
+    public function getOnCycleNetwork(): float
+    {
+        return $this->onCycleNetwork;
+    }
+
+    public function setOnCycleNetwork(float $onCycleNetwork): self
+    {
+        $this->onCycleNetwork = $onCycleNetwork;
 
         return $this;
     }

--- a/api/src/MessageHandler/RecalculateStagesHandler.php
+++ b/api/src/MessageHandler/RecalculateStagesHandler.php
@@ -5,12 +5,9 @@ declare(strict_types=1);
 namespace App\MessageHandler;
 
 use App\ApiResource\TripRequest;
-use App\ApiResource\Model\Coordinate;
-use App\ApiResource\Stage;
 use App\ComputationTracker\ComputationTrackerInterface;
 use App\ComputationTracker\TripGenerationTrackerInterface;
 use App\Llm\LlmAnalysisTrackerInterface;
-use App\Mercure\MercureEventType;
 use App\Mercure\TripUpdatePublisherInterface;
 use App\Message\AnalyzeTerrain;
 use App\Message\CheckBikeShops;
@@ -76,44 +73,19 @@ final readonly class RecalculateStagesHandler extends AbstractTripMessageHandler
 
         // Mode 2 — inline modification (Act 3): emit one `stage_updated` event per
         // affected stage so the frontend mutates the corresponding slice of its
-        // store without rebuilding the whole trip. Also publish the legacy
-        // `STAGES_COMPUTED` event so consumers still relying on the wholesale
-        // payload (progress bar, undo, offline snapshot) keep working until the
-        // downstream refactor (#323 / #325) removes it.
+        // store without rebuilding the whole trip. The per-stage events carry the
+        // authoritative stored values (including a user-requested distance honored
+        // by StageUpdateProcessor::applyDistanceChange). We intentionally do NOT
+        // also publish the legacy wholesale `STAGES_COMPUTED` here: its partial-merge
+        // branch on the frontend re-hydrated the edited stage from the wire payload,
+        // racing the `stage_updated` slice and reverting a user-set distance
+        // (e.g. 80km -> 60km snapping back). The initial generation path still emits
+        // `STAGES_COMPUTED` (GenerateStagesHandler / GpxUploadService) (issue #774).
         foreach ($affectedIndices as $idx) {
             if (isset($stages[$idx])) {
                 $this->publisher->publishStageUpdated($tripId, $stages[$idx]);
             }
         }
-
-        $this->publisher->publish($tripId, MercureEventType::STAGES_COMPUTED, [
-            'stages' => array_map(
-                static fn (Stage $s): array => [
-                    'dayNumber' => $s->dayNumber,
-                    'distance' => round($s->distance, 1),
-                    'elevation' => (int) $s->elevation,
-                    'elevationLoss' => (int) $s->elevationLoss,
-                    'startPoint' => [
-                        'lat' => $s->startPoint->lat,
-                        'lon' => $s->startPoint->lon,
-                        'ele' => $s->startPoint->ele,
-                    ],
-                    'endPoint' => [
-                        'lat' => $s->endPoint->lat,
-                        'lon' => $s->endPoint->lon,
-                        'ele' => $s->endPoint->ele,
-                    ],
-                    'label' => $s->label,
-                    'isRestDay' => $s->isRestDay,
-                    'geometry' => array_map(
-                        static fn (Coordinate $c): array => ['lat' => $c->lat, 'lon' => $c->lon, 'ele' => $c->ele],
-                        $s->geometry,
-                    ),
-                ],
-                $stages,
-            ),
-            'affectedIndices' => array_values($affectedIndices),
-        ]);
 
         // Dispatch POI/Accommodation/BikeShop scans for affected stages
         if ([] !== $affectedIndices && !$message->skipGeographicScans) {

--- a/api/src/Repository/DoctrineTripRequestRepository.php
+++ b/api/src/Repository/DoctrineTripRequestRepository.php
@@ -15,6 +15,8 @@ use App\ApiResource\TripRequest;
 use App\Entity\Stage as StageEntity;
 use App\Enum\AlertType;
 use App\Llm\Dto\StageAiAnalysis;
+use App\Osm\CoverageRepositoryInterface;
+use App\Osm\CycleRouteRepositoryInterface;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 use Psr\Cache\CacheItemPoolInterface;
@@ -30,10 +32,15 @@ final class DoctrineTripRequestRepository extends ServiceEntityRepository implem
 {
     private const int CACHE_TTL = 1800; // 30 minutes for transient data
 
+    /** Tolerance (m) between the stage line and a cycle route to count as "on network". */
+    private const int CYCLE_NETWORK_TOLERANCE_METERS = 30;
+
     public function __construct(
         ManagerRegistry $registry,
         #[Autowire(service: 'cache.trip_state')]
         private readonly CacheItemPoolInterface $tripStateCache,
+        private readonly CycleRouteRepositoryInterface $cycleRouteRepository,
+        private readonly CoverageRepositoryInterface $coverageRepository,
     ) {
         parent::__construct($registry, TripRequest::class);
     }
@@ -181,7 +188,18 @@ final class DoctrineTripRequestRepository extends ServiceEntityRepository implem
             return;
         }
 
-        $this->getEntityManager()->wrapInTransaction(function () use ($trip, $stages): void {
+        // The on-cycle-network fraction and out-of-zone flag are derived purely
+        // from the route geometry, so they only change when the geometry does
+        // (initial compute, route recalculation). storeStages() also runs on
+        // every enrichment/edit pass (weather, accommodation select, distance
+        // edit), which leaves the geometry untouched — guard the two heavy PostGIS
+        // scans behind a geometry-change check so frequent edits reuse the already
+        // persisted values (issue #775, perf review on #787).
+        [$cycleNetwork, $outOfZone] = $this->geometryUnchanged($trip, $stages)
+            ? [$this->persistedCycleNetwork($trip), $trip->outOfZone]
+            : $this->computeRouteMetrics($stages);
+
+        $this->getEntityManager()->wrapInTransaction(function () use ($trip, $stages, $cycleNetwork, $outOfZone): void {
             // Bulk delete: O(1) vs O(N) orphan-removal DELETEs (1 SELECT + N DELETE)
             $this->getEntityManager()
                 ->createQuery('DELETE FROM App\Entity\Stage s WHERE s.trip = :trip')
@@ -189,13 +207,104 @@ final class DoctrineTripRequestRepository extends ServiceEntityRepository implem
                 ->execute();
             $trip->clearStages(); // Keep UoW in sync with the deleted rows
 
+            // Mutate the managed entity inside the transaction so a flush failure
+            // does not leave a stale out-of-zone flag on the in-memory entity
+            // (correctness review on #787).
+            $trip->outOfZone = $outOfZone;
+
             foreach ($stages as $index => $stageDto) {
                 $stageEntity = $this->stageDtoToEntity($stageDto, $trip, $index);
+                $stageEntity->setOnCycleNetwork($cycleNetwork[$index] ?? 0.0);
                 $trip->addStage($stageEntity);
             }
 
             $this->getEntityManager()->flush();
         });
+    }
+
+    /**
+     * Computes the geometry-derived trip-detail metrics: the per-stage on-cycle-network
+     * fraction (index-aligned with $stages) and the out-of-zone flag.
+     *
+     * @param list<StageDto> $stages
+     *
+     * @return array{0: list<float>, 1: bool}
+     */
+    private function computeRouteMetrics(array $stages): array
+    {
+        $cycleNetwork = $this->cycleRouteRepository->onNetworkFractions(
+            array_map(
+                static fn (StageDto $stage): array => array_map(
+                    static fn (Coordinate $c): array => ['lat' => $c->lat, 'lon' => $c->lon],
+                    $stage->geometry,
+                ),
+                $stages,
+            ),
+            self::CYCLE_NETWORK_TOLERANCE_METERS,
+        );
+
+        $outOfZone = $this->coverageRepository->isRouteOutOfZone($this->stageRoutePoints($stages));
+
+        return [$cycleNetwork, $outOfZone];
+    }
+
+    /**
+     * Returns true when the incoming stage geometry (and endpoints) match what is
+     * already persisted, so the geometry-derived PostGIS metrics can be reused.
+     *
+     * @param list<StageDto> $stages
+     */
+    private function geometryUnchanged(TripRequest $trip, array $stages): bool
+    {
+        $persisted = $trip->stages;
+        if ($persisted->count() !== \count($stages)) {
+            return false;
+        }
+
+        foreach ($persisted->getValues() as $index => $entity) {
+            if ($this->stageGeometrySignature($stages[$index]) !== $this->entityGeometrySignature($entity)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /** @return list<float> The persisted on-cycle-network fractions, index-aligned with the stages. */
+    private function persistedCycleNetwork(TripRequest $trip): array
+    {
+        return array_map(
+            static fn (StageEntity $entity): float => $entity->getOnCycleNetwork(),
+            $trip->stages->getValues(),
+        );
+    }
+
+    /** @return list<array{float, float}> Endpoints + geometry coordinates of an incoming stage DTO. */
+    private function stageGeometrySignature(StageDto $stage): array
+    {
+        $signature = [
+            [$stage->startPoint->lat, $stage->startPoint->lon],
+            [$stage->endPoint->lat, $stage->endPoint->lon],
+        ];
+        foreach ($stage->geometry as $coord) {
+            $signature[] = [$coord->lat, $coord->lon];
+        }
+
+        return $signature;
+    }
+
+    /** @return list<array{float, float}> Endpoints + geometry coordinates of a persisted stage entity. */
+    private function entityGeometrySignature(StageEntity $entity): array
+    {
+        $signature = [
+            [$entity->getStartLat(), $entity->getStartLon()],
+            [$entity->getEndLat(), $entity->getEndLon()],
+        ];
+        foreach ($entity->getGeometry() as $coord) {
+            $signature[] = [$coord['lat'], $coord['lon']];
+        }
+
+        return $signature;
     }
 
     /** @return list<StageDto>|null */
@@ -259,6 +368,35 @@ final class DoctrineTripRequestRepository extends ServiceEntityRepository implem
     }
 
     // --- Private helpers ---
+
+    /**
+     * Flattens the stage geometries into the route's coordinates for the coverage
+     * test, falling back to stage start/end points when geometry is unavailable.
+     *
+     * @param list<StageDto> $stages
+     *
+     * @return list<array{lat: float, lon: float}>
+     */
+    private function stageRoutePoints(array $stages): array
+    {
+        $points = [];
+        foreach ($stages as $stage) {
+            foreach ($stage->geometry as $coord) {
+                $points[] = ['lat' => $coord->lat, 'lon' => $coord->lon];
+            }
+        }
+
+        if ([] !== $points) {
+            return $points;
+        }
+
+        foreach ($stages as $stage) {
+            $points[] = ['lat' => $stage->startPoint->lat, 'lon' => $stage->startPoint->lon];
+            $points[] = ['lat' => $stage->endPoint->lat, 'lon' => $stage->endPoint->lon];
+        }
+
+        return $points;
+    }
 
     private function findTripRequest(string $tripId): ?TripRequest
     {
@@ -371,6 +509,8 @@ final class DoctrineTripRequestRepository extends ServiceEntityRepository implem
             elevationLoss: $entity->getElevationLoss(),
             isRestDay: $entity->isRestDay(),
         );
+
+        $dto->onCycleNetwork = $entity->getOnCycleNetwork();
 
         // Weather
         /** @var array{icon: string, description: string, tempMin: float, tempMax: float, windSpeed: float, windDirection: string, precipitationProbability: int, humidity: int, comfortIndex: int, relativeWindDirection: string}|null $weatherData */

--- a/api/src/State/TripDetailProvider.php
+++ b/api/src/State/TripDetailProvider.php
@@ -17,8 +17,6 @@ use App\ApiResource\TripRequest;
 use App\ComputationTracker\ComputationTrackerInterface;
 use App\Enum\ComputationName;
 use App\Enum\TripStatus;
-use App\Osm\CoverageRepositoryInterface;
-use App\Osm\CycleRouteRepositoryInterface;
 use App\Repository\DoctrineTripRequestRepository;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Uid\Uuid;
@@ -33,14 +31,9 @@ use Symfony\Component\Uid\Uuid;
  */
 final readonly class TripDetailProvider implements ProviderInterface
 {
-    /** Tolerance (m) between the stage line and a cycle route to count as "on network". */
-    private const int CYCLE_NETWORK_TOLERANCE_METERS = 30;
-
     public function __construct(
         private DoctrineTripRequestRepository $tripStateManager,
         private TripLocker $tripLocker,
-        private CoverageRepositoryInterface $coverageRepository,
-        private CycleRouteRepositoryInterface $cycleRouteRepository,
         private ComputationTrackerInterface $computationTracker,
     ) {
     }
@@ -65,18 +58,6 @@ final readonly class TripDetailProvider implements ProviderInterface
 
         $statuses = $this->computationTracker->getStatuses($id);
 
-        // One batched query for the on-cycle-network fraction of every stage.
-        $cycleNetwork = $this->cycleRouteRepository->onNetworkFractions(
-            array_map(
-                static fn (Stage $stage): array => array_map(
-                    static fn (Coordinate $c): array => ['lat' => $c->lat, 'lon' => $c->lon],
-                    $stage->geometry,
-                ),
-                $stages,
-            ),
-            self::CYCLE_NETWORK_TOLERANCE_METERS,
-        );
-
         return new TripDetail(
             id: $request->id->toRfc4122(),
             title: $request->title,
@@ -91,13 +72,14 @@ final readonly class TripDetailProvider implements ProviderInterface
             departureHour: $request->departureHour,
             enabledAccommodationTypes: $request->enabledAccommodationTypes,
             isLocked: $this->tripLocker->isLocked($request),
-            outOfZone: $this->coverageRepository->isRouteOutOfZone($this->routePoints($stages)),
+            // Persisted at stage-store time (issue #775) — no PostGIS query here.
+            outOfZone: $request->outOfZone,
             // Fallback for trips persisted before the status column existed: infer
             // readiness from whether stages are present.
             status: '' !== $request->status ? $request->status : ([] !== $stages ? TripStatus::READY->value : TripStatus::DRAFT->value),
             weatherStatus: $this->deriveBlockStatus($this->computationsInCategory('weather'), $statuses),
             aiStatus: $this->deriveBlockStatus($this->computationsInCategory('ai_analysis'), $statuses),
-            stages: array_map($this->serializeStage(...), $stages, $cycleNetwork),
+            stages: array_map($this->serializeStage(...), $stages),
         );
     }
 
@@ -172,40 +154,11 @@ final readonly class TripDetailProvider implements ProviderInterface
     }
 
     /**
-     * Flattens the stage geometries into the route's coordinates for the coverage
-     * test, falling back to stage start/end points when geometry is unavailable.
-     *
-     * @param list<Stage> $stages
-     *
-     * @return list<array{lat: float, lon: float}>
-     */
-    private function routePoints(array $stages): array
-    {
-        $points = [];
-        foreach ($stages as $stage) {
-            foreach ($stage->geometry as $coord) {
-                $points[] = ['lat' => $coord->lat, 'lon' => $coord->lon];
-            }
-        }
-
-        if ([] !== $points) {
-            return $points;
-        }
-
-        foreach ($stages as $stage) {
-            $points[] = ['lat' => $stage->startPoint->lat, 'lon' => $stage->startPoint->lon];
-            $points[] = ['lat' => $stage->endPoint->lat, 'lon' => $stage->endPoint->lon];
-        }
-
-        return $points;
-    }
-
-    /**
      * Converts a Stage DTO to the JSON shape the frontend Zustand store expects.
      *
      * @return array<string, mixed>
      */
-    private function serializeStage(Stage $stage, float $onCycleNetwork): array
+    private function serializeStage(Stage $stage): array
     {
         return [
             'dayNumber' => $stage->dayNumber,
@@ -217,7 +170,7 @@ final readonly class TripDetailProvider implements ProviderInterface
             'geometry' => array_map($this->serializeCoord(...), $stage->geometry),
             'label' => $stage->label,
             'isRestDay' => $stage->isRestDay,
-            'onCycleNetwork' => $onCycleNetwork,
+            'onCycleNetwork' => $stage->onCycleNetwork,
             'weather' => $stage->weather instanceof WeatherForecast ? $this->serializeWeather($stage->weather) : null,
             'alerts' => array_map($this->serializeAlert(...), $stage->alerts),
             'pois' => array_map($this->serializePoi(...), $stage->pois),

--- a/api/tests/Functional/TripDetailTest.php
+++ b/api/tests/Functional/TripDetailTest.php
@@ -265,10 +265,21 @@ final class TripDetailTest extends ApiTestCase
     #[Test]
     public function detailFlagsOutOfZoneFromStageEndpointsWhenGeometryIsEmpty(): void
     {
-        // Exercises the routePoints() fallback (no stage geometry → start/end points)
-        // against the real ST_Covers query: endpoints sit at lon 10, outside the
-        // seeded coverage polygon (2..4 lon, 48..50 lat), so the trip is out of zone.
+        // Exercises the stageRoutePoints() fallback (no stage geometry → start/end
+        // points) against the real ST_Covers query: endpoints sit at lon 10, outside
+        // the seeded coverage polygon (2..4 lon, 48..50 lat), so the trip is out of
+        // zone. The flag is now computed and persisted at storeStages() time (#775),
+        // so the coverage polygon must exist before storing the stages.
         $repo = $this->seedTrip(self::TRIP_ID);
+
+        $connection = self::getContainer()->get('doctrine.dbal.default_connection');
+        \assert($connection instanceof Connection);
+        $connection->executeStatement('TRUNCATE osm.coverage');
+        $connection->executeStatement(<<<'SQL'
+            INSERT INTO osm.coverage (geom) VALUES (
+                ST_Multi(ST_SetSRID(ST_GeomFromText('POLYGON((2 48, 4 48, 4 50, 2 50, 2 48))'), 4326))
+            )
+            SQL);
 
         $stage = new StageDto(
             tripId: self::TRIP_ID,
@@ -280,21 +291,59 @@ final class TripDetailTest extends ApiTestCase
         );
         $repo->storeStages(self::TRIP_ID, [$stage]);
 
-        $connection = self::getContainer()->get('doctrine.dbal.default_connection');
-        \assert($connection instanceof Connection);
-        $connection->executeStatement('TRUNCATE osm.coverage');
-        $connection->executeStatement(<<<'SQL'
-            INSERT INTO osm.coverage (geom) VALUES (
-                ST_Multi(ST_SetSRID(ST_GeomFromText('POLYGON((2 48, 4 48, 4 50, 2 50, 2 48))'), 4326))
-            )
-            SQL);
-
         $response = $this->client->request('GET', \sprintf('/trips/%s/detail', self::TRIP_ID), [
             'headers' => array_merge(['Accept' => 'application/ld+json'], $this->authHeader($this->jwtToken)),
         ]);
 
         $this->assertResponseIsSuccessful();
         $this->assertTrue($response->toArray(false)['outOfZone']);
+    }
+
+    #[Test]
+    public function detailReadsPersistedOnCycleNetworkFraction(): void
+    {
+        // #775: onCycleNetwork is computed by the expensive PostGIS query once at
+        // storeStages() time and persisted on the stage row, then read back O(1)
+        // by the detail provider. Seed a cycle route, store a stage running along
+        // it, and assert the persisted fraction surfaces in the detail payload.
+        $repo = $this->seedTrip(self::TRIP_ID);
+
+        $connection = self::getContainer()->get('doctrine.dbal.default_connection');
+        \assert($connection instanceof Connection);
+        $connection->executeStatement('TRUNCATE osm.cycle_routes');
+        $connection->executeStatement(<<<'SQL'
+            INSERT INTO osm.cycle_routes (osm_id, name, network, ref, tags, geom) VALUES
+              (1, 'EuroVelo Test', 'icn', 'EV-T', '{}'::jsonb,
+                  ST_Multi(ST_SetSRID(ST_GeomFromText('LINESTRING(2 48, 2 49)'), 4326)))
+            SQL);
+
+        $stage = new StageDto(
+            tripId: self::TRIP_ID,
+            dayNumber: 1,
+            distance: 55.0,
+            elevation: 100.0,
+            startPoint: new Coordinate(48.1, 2.0, 0.0),
+            endPoint: new Coordinate(48.9, 2.0, 0.0),
+            geometry: [
+                new Coordinate(48.1, 2.0, 0.0),
+                new Coordinate(48.5, 2.0, 0.0),
+                new Coordinate(48.9, 2.0, 0.0),
+            ],
+        );
+        $repo->storeStages(self::TRIP_ID, [$stage]);
+
+        // Verify the value is actually persisted on the row (not recomputed on read).
+        $persisted = $connection->fetchOne('SELECT on_cycle_network FROM stage WHERE trip_id = :id', ['id' => self::TRIP_ID]);
+        self::assertIsNumeric($persisted);
+        self::assertGreaterThan(0.95, (float) $persisted);
+
+        $response = $this->client->request('GET', \sprintf('/trips/%s/detail', self::TRIP_ID), [
+            'headers' => array_merge(['Accept' => 'application/ld+json'], $this->authHeader($this->jwtToken)),
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $data = $response->toArray(false);
+        self::assertGreaterThan(0.95, $data['stages'][0]['onCycleNetwork']);
     }
 
     #[Test]

--- a/api/tests/Unit/MessageHandler/RecalculateStagesHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/RecalculateStagesHandlerTest.php
@@ -10,7 +10,6 @@ use App\ApiResource\TripRequest;
 use App\ComputationTracker\ComputationTrackerInterface;
 use App\ComputationTracker\TripGenerationTrackerInterface;
 use App\Llm\LlmAnalysisTrackerInterface;
-use App\Mercure\MercureEventType;
 use App\Mercure\TripUpdatePublisherInterface;
 use App\Message\RecalculateStages;
 use App\Message\ScanAccommodations;
@@ -46,14 +45,17 @@ final class RecalculateStagesHandlerTest extends TestCase
     }
 
     #[Test]
-    public function stagesComputedPayloadIncludesGeometry(): void
+    public function publishesPerStageUpdatedWithGeometryAndStoredDistance(): void
     {
         $coordinate = new Coordinate(48.8566, 2.3522, 35.0);
 
+        // A stage whose distance was set by the user (e.g. 80km -> 60km via
+        // StageUpdateProcessor::applyDistanceChange). The handler must surface
+        // this stored value verbatim through the per-stage `stage_updated` event.
         $stage = new Stage(
             tripId: 'trip-1',
             dayNumber: 1,
-            distance: 80.0,
+            distance: 60.0,
             elevation: 500.0,
             startPoint: $coordinate,
             endPoint: new Coordinate(49.0, 2.5, 50.0),
@@ -68,21 +70,17 @@ final class RecalculateStagesHandlerTest extends TestCase
 
         $publisher = $this->createMock(TripUpdatePublisherInterface::class);
         $publisher->expects($this->once())
-            ->method('publish')
+            ->method('publishStageUpdated')
             ->with(
                 'trip-1',
-                MercureEventType::STAGES_COMPUTED,
-                $this->callback(static function (array $data): bool {
-                    $geometry = $data['stages'][0]['geometry'] ?? null;
-
-                    return \is_array($geometry)
-                        && 1 === \count($geometry)
-                        && \is_array($geometry[0])
-                        && 48.8566 === $geometry[0]['lat']
-                        && 2.3522 === $geometry[0]['lon']
-                        && 35.0 === $geometry[0]['ele'];
-                }),
+                $this->callback(static fn (Stage $s): bool => 60.0 === $s->distance
+                    && 1 === \count($s->geometry)
+                    && 48.8566 === $s->geometry[0]->lat),
             );
+        // The legacy wholesale STAGES_COMPUTED must NOT be re-published on the
+        // inline recompute path: it raced the per-stage update and reverted the
+        // user-requested distance (issue #774).
+        $publisher->expects($this->never())->method('publish');
 
         $handler = $this->createHandler($tripStateManager, $publisher, $messageBus);
 

--- a/api/tests/Unit/Repository/DoctrineTripRequestRepositoryTest.php
+++ b/api/tests/Unit/Repository/DoctrineTripRequestRepositoryTest.php
@@ -16,6 +16,8 @@ use App\ApiResource\Model\WeatherForecast;
 use App\ApiResource\Stage as StageDto;
 use App\ApiResource\TripRequest;
 use App\Enum\AlertType;
+use App\Osm\CoverageRepositoryInterface;
+use App\Osm\CycleRouteRepositoryInterface;
 use App\Repository\DoctrineTripRequestRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
@@ -35,6 +37,10 @@ final class DoctrineTripRequestRepositoryTest extends TestCase
 
     private CacheItemPoolInterface&MockObject $cache;
 
+    private CycleRouteRepositoryInterface&MockObject $cycleRouteRepository;
+
+    private CoverageRepositoryInterface&MockObject $coverageRepository;
+
     private DoctrineTripRequestRepository $repository;
 
     #[\Override]
@@ -49,10 +55,17 @@ final class DoctrineTripRequestRepositoryTest extends TestCase
 
         $this->cache = $this->createMock(CacheItemPoolInterface::class);
 
+        // The PostGIS metrics are computed at storeStages() time (#775); stub them
+        // with neutral defaults so the persistence round-trips stay deterministic.
+        $this->cycleRouteRepository = $this->createMock(CycleRouteRepositoryInterface::class);
+        $this->cycleRouteRepository->method('onNetworkFractions')->willReturn([]);
+        $this->coverageRepository = $this->createMock(CoverageRepositoryInterface::class);
+        $this->coverageRepository->method('isRouteOutOfZone')->willReturn(false);
+
         $registry = $this->createMock(ManagerRegistry::class);
         $registry->method('getManagerForClass')->willReturn($this->entityManager);
 
-        $this->repository = new DoctrineTripRequestRepository($registry, $this->cache);
+        $this->repository = new DoctrineTripRequestRepository($registry, $this->cache, $this->cycleRouteRepository, $this->coverageRepository);
     }
 
     #[Test]
@@ -95,7 +108,7 @@ final class DoctrineTripRequestRepositoryTest extends TestCase
         $registry2 = $this->createMock(ManagerRegistry::class);
         $registry2->method('getManagerForClass')->willReturn($em2);
 
-        $repo2 = new DoctrineTripRequestRepository($registry2, $this->cache);
+        $repo2 = new DoctrineTripRequestRepository($registry2, $this->cache, $this->cycleRouteRepository, $this->coverageRepository);
         $result = $repo2->getRequest($tripId);
 
         self::assertSame($request, $result);
@@ -726,5 +739,86 @@ final class DoctrineTripRequestRepositoryTest extends TestCase
         $this->entityManager->expects(self::never())->method('createQuery');
 
         $this->repository->updateTripAiOverview('not-a-uuid', null);
+    }
+
+    #[Test]
+    public function storeStagesSkipsPostGisScansWhenGeometryIsUnchanged(): void
+    {
+        // #787: the heavy PostGIS metrics are geometry-derived, so a second store
+        // of the identical route (an enrichment/edit pass that leaves geometry
+        // untouched) must reuse the persisted values instead of re-scanning.
+        $tripId = Uuid::v7()->toRfc4122();
+        $trip = new TripRequest(Uuid::fromString($tripId));
+
+        $cycleRoute = $this->createMock(CycleRouteRepositoryInterface::class);
+        $cycleRoute->expects(self::once())->method('onNetworkFractions')->willReturn([0.42]);
+        $coverage = $this->createMock(CoverageRepositoryInterface::class);
+        $coverage->expects(self::once())->method('isRouteOutOfZone')->willReturn(false);
+
+        $repository = $this->repositoryWithOsm($trip, $cycleRoute, $coverage);
+
+        $repository->storeStages($tripId, [$this->stageWithGeometry($tripId)]);
+        // Re-storing the same geometry must not trigger another PostGIS scan.
+        $repository->storeStages($tripId, [$this->stageWithGeometry($tripId)]);
+
+        // The persisted fraction is preserved across the guarded second store.
+        $stages = $repository->getStages($tripId);
+        self::assertNotNull($stages);
+        self::assertEqualsWithDelta(0.42, $stages[0]->onCycleNetwork, 0.0001);
+    }
+
+    #[Test]
+    public function storeStagesRecomputesPostGisScansWhenGeometryChanges(): void
+    {
+        $tripId = Uuid::v7()->toRfc4122();
+        $trip = new TripRequest(Uuid::fromString($tripId));
+
+        $cycleRoute = $this->createMock(CycleRouteRepositoryInterface::class);
+        $cycleRoute->expects(self::exactly(2))->method('onNetworkFractions')->willReturn([0.1]);
+        $coverage = $this->createMock(CoverageRepositoryInterface::class);
+        $coverage->expects(self::exactly(2))->method('isRouteOutOfZone')->willReturn(false);
+
+        $repository = $this->repositoryWithOsm($trip, $cycleRoute, $coverage);
+
+        $repository->storeStages($tripId, [$this->stageWithGeometry($tripId)]);
+        // A moved endpoint changes the geometry signature → recompute.
+        $moved = $this->stageWithGeometry($tripId);
+        $moved->endPoint = new Coordinate(49.0, 3.0, 0.0);
+
+        $repository->storeStages($tripId, [$moved]);
+    }
+
+    private function stageWithGeometry(string $tripId): StageDto
+    {
+        return new StageDto(
+            tripId: $tripId,
+            dayNumber: 1,
+            distance: 55.0,
+            elevation: 100.0,
+            startPoint: new Coordinate(48.1, 2.0, 0.0),
+            endPoint: new Coordinate(48.9, 2.0, 0.0),
+            geometry: [
+                new Coordinate(48.1, 2.0, 0.0),
+                new Coordinate(48.5, 2.0, 0.0),
+                new Coordinate(48.9, 2.0, 0.0),
+            ],
+        );
+    }
+
+    private function repositoryWithOsm(
+        TripRequest $trip,
+        CycleRouteRepositoryInterface&MockObject $cycleRoute,
+        CoverageRepositoryInterface&MockObject $coverage,
+    ): DoctrineTripRequestRepository {
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('wrapInTransaction')->willReturnCallback(static fn (callable $cb): mixed => $cb());
+        $em->method('getClassMetadata')->willReturn(new ClassMetadata(TripRequest::class));
+        $em->method('find')->willReturn($trip);
+        $em->method('createQuery')->willReturn($this->createStub(Query::class));
+
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->method('getManagerForClass')->willReturn($em);
+
+        return new DoctrineTripRequestRepository($registry, $this->cache, $cycleRoute, $coverage);
     }
 }

--- a/api/tests/Unit/State/StageUpdateProcessorTest.php
+++ b/api/tests/Unit/State/StageUpdateProcessorTest.php
@@ -330,4 +330,72 @@ final class StageUpdateProcessorTest extends TestCase
             self::assertSame(423, $httpException->getStatusCode());
         }
     }
+
+    #[Test]
+    public function editedStageStoresRequestedSplitDistance(): void
+    {
+        // Reduce an 80km stage: splitting the route yields a 60km segment that
+        // must be persisted verbatim (issue #774). The stored value is what the
+        // RecalculateStages recompute later replays to the frontend.
+        $p = $this->decimatedPoints;
+
+        $stages = [
+            new Stage(tripId: 't', dayNumber: 1, distance: 80.0, elevation: 500.0, startPoint: $p[0], endPoint: $p[3]),
+            new Stage(tripId: 't', dayNumber: 2, distance: 40.0, elevation: 200.0, startPoint: $p[3], endPoint: $p[4]),
+        ];
+
+        $splitPoint = new Coordinate(48.25, 2.25, 25.0);
+        $distanceCalculator = $this->createStub(DistanceCalculatorInterface::class);
+        $distanceCalculator->method('splitAtDistance')->willReturn([
+            [$p[0], $splitPoint],
+            [$splitPoint, $p[3], $p[4]],
+            20.0,
+        ]);
+        $distanceCalculator->method('findClosestIndex')->willReturn(0);
+        $distanceCalculator->method('calculateTotalDistance')->willReturn(60.0);
+
+        $elevationCalculator = $this->createStub(ElevationCalculatorInterface::class);
+        $elevationCalculator->method('calculateTotalAscent')->willReturn(300.0);
+        $elevationCalculator->method('calculateTotalDescent')->willReturn(100.0);
+
+        $routeSimplifier = $this->createStub(RouteSimplifierInterface::class);
+        $routeSimplifier->method('simplify')->willReturnArgument(0);
+
+        $storedStages = null;
+        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
+        $tripStateManager->method('getStages')->willReturn($stages);
+        $tripStateManager->method('getDecimatedPoints')->willReturn($this->decimatedPointsRaw);
+        $tripStateManager->method('getRequest')->willReturn($this->makeUnlockedRequest());
+        $tripStateManager->method('storeStages')->willReturnCallback(
+            static function (string $tripId, array $stages) use (&$storedStages): void {
+                $storedStages = $stages;
+            },
+        );
+
+        $messageBus = $this->createStub(MessageBusInterface::class);
+        $messageBus->method('dispatch')->willReturn(new Envelope(new \stdClass()));
+
+        $generationTracker = $this->createStub(TripGenerationTrackerInterface::class);
+        $generationTracker->method('increment')->willReturn(2);
+
+        $processor = new StageUpdateProcessor(
+            $tripStateManager,
+            $messageBus,
+            $distanceCalculator,
+            $elevationCalculator,
+            $routeSimplifier,
+            new StageResponseMapper($this->createStub(ComputationTrackerInterface::class)),
+            $generationTracker,
+            new TripLocker(),
+        );
+
+        $request = new StageRequest();
+        $request->distance = 60.0;
+
+        $response = $processor->process($request, new Patch(), ['tripId' => 't', 'index' => 0]);
+
+        self::assertNotNull($storedStages);
+        self::assertSame(60.0, $storedStages[0]->distance, 'Edited stage must store the requested split distance');
+        self::assertSame(60.0, $response->distance, 'PATCH response must echo the requested distance');
+    }
 }

--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -425,6 +425,7 @@
     "backToList": "Back to trips",
     "noTrips": "No trips yet. Create your first trip!",
     "loading": "Loading trips...",
+    "loadingOne": "Loading trip...",
     "loadingError": "Failed to load trips.",
     "stages": "{count, plural, one {# stage} other {# stages}}",
     "noDates": "Dates not set",

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -425,6 +425,7 @@
     "backToList": "Retour aux voyages",
     "noTrips": "Aucun voyage pour l'instant. Crée ton premier voyage !",
     "loading": "Chargement des voyages...",
+    "loadingOne": "Chargement du voyage...",
     "loadingError": "Impossible de charger les voyages.",
     "stages": "{count, plural, one {# étape} other {# étapes}}",
     "noDates": "Dates non définies",

--- a/pwa/src/app/(app)/trips/[id]/trip-page.tsx
+++ b/pwa/src/app/(app)/trips/[id]/trip-page.tsx
@@ -146,16 +146,6 @@ function TripLoader({ tripId }: { tripId: string }) {
           sourceType: "persisted",
           title: data.title ?? null,
         });
-
-        // The backend does not persist reverse-geocoded labels (they are a
-        // client-side concern), and on a reload no Mercure event fires to fill
-        // them — so the stage cards would fall back to raw GPS coordinates.
-        // Resolve them here, after hydration, like the Mercure path does
-        // (recette #649).
-        void resolveStageLabels(
-          stages,
-          stages.map((_, i) => i),
-        );
       }
 
       // Drive the synchronous-flow loader vs. trip view from `status`
@@ -278,6 +268,37 @@ function TripLoader({ tripId }: { tripId: string }) {
     clearTrip,
   ]);
 
+  // Defer reverse-geocoding off the load critical path (issue #775): the backend
+  // does not persist reverse-geocoded labels (a client-side concern) and no
+  // Mercure event fires on reload, so the stage cards fall back to raw GPS
+  // coordinates until these resolve. Running the N Nominatim calls inside the
+  // hydrate path blocked the first render for several seconds; instead we kick
+  // them off only once the trip view is rendered, after first paint. The cards
+  // already show coordinates meanwhile and update live as each label lands.
+  useEffect(() => {
+    if (!isLoaded) return;
+
+    const stages = useTripStore.getState().stages;
+    if (stages.length === 0) return;
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => {
+      if (controller.signal.aborted) return;
+      void resolveStageLabels(
+        stages,
+        stages.map((_, i) => i),
+        controller.signal,
+      );
+    }, 0);
+
+    return () => {
+      // Abort on unmount / trip-switch so in-flight Nominatim responses are
+      // dropped instead of corrupting another trip's labels (#787).
+      controller.abort();
+      clearTimeout(timer);
+    };
+  }, [isLoaded]);
+
   if (loadError) {
     return <TripNotFound />;
   }
@@ -292,7 +313,7 @@ function TripLoader({ tripId }: { tripId: string }) {
         <TripSummarySkeleton />
         <div className="flex items-center justify-center gap-3 text-muted-foreground text-sm">
           <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
-          <span>{t("loading")}</span>
+          <span>{t("loadingOne")}</span>
         </div>
         {/* Single-column roadbook skeleton — mirrors the new layout where the
             horizontal day timeline sits above the stage cards (recette #649). */}

--- a/pwa/src/hooks/use-mercure.ts
+++ b/pwa/src/hooks/use-mercure.ts
@@ -689,6 +689,7 @@ export async function resolveStageLabels(
     endPoint: { lat: number; lon: number };
   }[],
   indices?: number[],
+  signal?: AbortSignal,
 ): Promise<void> {
   const store = useTripStore.getState();
   const promises = stages.flatMap((stage, i) => {
@@ -696,12 +697,16 @@ export async function resolveStageLabels(
     return [
       reverseGeocode(stage.startPoint.lat, stage.startPoint.lon).then(
         (result) => {
-          if (result)
+          // Drop late responses after the caller aborted (e.g. unmount /
+          // trip-switch) so a stale Nominatim reply cannot overwrite the labels
+          // of a different trip (#787).
+          if (result && !signal?.aborted)
             store.updateStageLabel(storeIndex, "startLabel", result.name);
         },
       ),
       reverseGeocode(stage.endPoint.lat, stage.endPoint.lon).then((result) => {
-        if (result) store.updateStageLabel(storeIndex, "endLabel", result.name);
+        if (result && !signal?.aborted)
+          store.updateStageLabel(storeIndex, "endLabel", result.name);
       }),
     ];
   });

--- a/pwa/src/hooks/use-mercure.ts
+++ b/pwa/src/hooks/use-mercure.ts
@@ -695,7 +695,7 @@ export async function resolveStageLabels(
   const promises = stages.flatMap((stage, i) => {
     const storeIndex = indices ? (indices[i] ?? i) : i;
     return [
-      reverseGeocode(stage.startPoint.lat, stage.startPoint.lon).then(
+      reverseGeocode(stage.startPoint.lat, stage.startPoint.lon, signal).then(
         (result) => {
           // Drop late responses after the caller aborted (e.g. unmount /
           // trip-switch) so a stale Nominatim reply cannot overwrite the labels
@@ -704,10 +704,12 @@ export async function resolveStageLabels(
             store.updateStageLabel(storeIndex, "startLabel", result.name);
         },
       ),
-      reverseGeocode(stage.endPoint.lat, stage.endPoint.lon).then((result) => {
-        if (result && !signal?.aborted)
-          store.updateStageLabel(storeIndex, "endLabel", result.name);
-      }),
+      reverseGeocode(stage.endPoint.lat, stage.endPoint.lon, signal).then(
+        (result) => {
+          if (result && !signal?.aborted)
+            store.updateStageLabel(storeIndex, "endLabel", result.name);
+        },
+      ),
     ];
   });
 

--- a/pwa/src/lib/geocode/client.ts
+++ b/pwa/src/lib/geocode/client.ts
@@ -21,9 +21,13 @@ export async function searchPlaces(query: string): Promise<GeocodeResult[]> {
 export async function reverseGeocode(
   lat: number,
   lon: number,
+  signal?: AbortSignal,
 ): Promise<GeocodeResult | null> {
   const res = await apiFetch(
     `${API_URL}/geocode/reverse?lat=${lat}&lon=${lon}`,
+    {
+      signal,
+    },
   );
   if (!res.ok) return null;
   const data = (await res.json()) as { results: GeocodeResult[] };


### PR DESCRIPTION
Closes #774. Sprint 42 (recette #649 round 5).

> **Stack** : basé sur `feature/770` (PR #780) — à merger **après** #780.

## Changements
- `RecalculateStagesHandler` ne publie plus l'event legacy `STAGES_COMPUTED` sur le chemin de recompute inline (Mode 2) — seuls les events `stage_updated` par étape sont émis, portant la distance demandée (honorée par `StageUpdateProcessor` + persistée Redis → survit au reload). La génération initiale émet toujours `STAGES_COMPUTED` via `GenerateStagesHandler`/`GpxUploadService`.
- Tests : `RecalculateStagesHandlerTest` réécrit (publishStageUpdated porte 60.0, `publish` jamais appelé) + `StageUpdateProcessorTest::editedStageStoresRequestedSplitDistance`.

## Auto-critique
PHPStan L9/Rector/CS-Fixer clean ; PHPUnit ciblé 11/30 OK. Pas de DTO. `make qa`/`test` complets délégués à la CI.

<!-- claude-review-start -->
## Claude Review

Reviewed commit `c2b03e9acfdad4c3025be14c240c2b6cc9a7a8f4`.

**Summary:** Clean, well-layered PR. The `STAGES_COMPUTED` removal is surgical and correct; the geometry-change guard in `storeStages` is safe (`TripRequest::$stages` carries `#[ORM\OrderBy(['position' => 'ASC'])]`, ensuring consistent index alignment in `geometryUnchanged`/`persistedCycleNetwork`). The deferred geocoding effect with `AbortController` correctly prevents stale Nominatim responses from corrupting another trip's labels, and the `AbortSignal` is now properly forwarded all the way to the `fetch` call in `client.ts`.

**Resolved threads:** Resolved 1 previously open thread (AbortSignal forwarding to `reverseGeocode` — addressed in commit `c2b03e9`).

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for (stacked on #780, closes #774)

**No inline comments.**
<!-- claude-review-end -->