### PR TITLE
fix(share): révocation/recréation de lien + masquer GPX/FIT sur partage révoqué

### DIFF
--- a/api/src/State/TripShareCreateProcessor.php
+++ b/api/src/State/TripShareCreateProcessor.php
@@ -40,8 +40,14 @@ final readonly class TripShareCreateProcessor implements ProcessorInterface
 
         $trip = $this->resolveTrip($uriVariables);
 
+        // Always create a brand-new active share. The POST shares its URI template
+        // with GET/DELETE, so API Platform may hand us a previously soft-deleted
+        // row; reusing it would yield an invalid ("revoked") link. Starting from a
+        // fresh entity guarantees a clean, active share even after a revoke.
+        $share = new TripShare();
+
         if ($trip instanceof TripRequest) {
-            $data->setTrip($trip);
+            $share->setTrip($trip);
 
             // Only one active share per trip
             if ($this->tripShareRepository->findActiveByTrip((string) $trip->id) instanceof TripShare) {
@@ -49,10 +55,10 @@ final readonly class TripShareCreateProcessor implements ProcessorInterface
             }
         }
 
-        $data->generateToken();
+        $share->generateToken();
 
         try {
-            $result = $this->persistProcessor->process($data, $operation, $uriVariables, $context);
+            $result = $this->persistProcessor->process($share, $operation, $uriVariables, $context);
         } catch (UniqueConstraintViolationException) {
             throw new ConflictHttpException('An active share link already exists for this trip.');
         }

--- a/api/src/State/TripShareDeleteProcessor.php
+++ b/api/src/State/TripShareDeleteProcessor.php
@@ -8,11 +8,12 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use App\Entity\TripShare;
 use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Soft-deletes a TripShare by setting deletedAt instead of removing the row.
  *
- * @implements ProcessorInterface<TripShare, null>
+ * @implements ProcessorInterface<TripShare, Response>
  */
 final readonly class TripShareDeleteProcessor implements ProcessorInterface
 {
@@ -21,13 +22,13 @@ final readonly class TripShareDeleteProcessor implements ProcessorInterface
     ) {
     }
 
-    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): null
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): Response
     {
         \assert($data instanceof TripShare);
 
         $data->softDelete();
         $this->entityManager->flush();
 
-        return null;
+        return new Response('', Response::HTTP_NO_CONTENT);
     }
 }

--- a/api/tests/Functional/TripShareLifecycleTest.php
+++ b/api/tests/Functional/TripShareLifecycleTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Symfony\Bundle\Test\Client;
+use App\ApiResource\Model\Coordinate;
+use App\ApiResource\Stage as StageDto;
+use App\ApiResource\TripRequest;
+use App\Entity\User;
+use App\Repository\TripRequestRepositoryInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Uid\Uuid;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+use Zenstruck\Foundry\Test\Factories;
+
+#[ResetDatabase]
+final class TripShareLifecycleTest extends ApiTestCase
+{
+    use Factories;
+    use JwtAuthTestTrait;
+
+    private const string TRIP_ID = '01936f6e-0000-7000-8000-000000000901';
+
+    private Client $client;
+
+    private User $testUser;
+
+    private string $jwtToken;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->client = self::createClient();
+        ['user' => $this->testUser, 'token' => $this->jwtToken] = $this->createTestUserWithJwt('share@example.com');
+    }
+
+    private function seedTripWithStages(string $tripId): void
+    {
+        /** @var TripRequestRepositoryInterface $repo */
+        $repo = self::getContainer()->get(TripRequestRepositoryInterface::class);
+
+        $request = new TripRequest(Uuid::fromString($tripId));
+        $request->sourceUrl = 'https://www.komoot.com/tour/123456789';
+
+        $repo->initializeTrip($tripId, $request);
+        $repo->storeTitle($tripId, 'Share lifecycle trip');
+        $this->associateTripWithUser($tripId, $this->testUser);
+
+        $stage = new StageDto(
+            tripId: $tripId,
+            dayNumber: 1,
+            distance: 85.5,
+            elevation: 1200.0,
+            startPoint: new Coordinate(45.0, 6.0, 1000.0),
+            endPoint: new Coordinate(45.5, 6.5, 800.0),
+            geometry: [new Coordinate(45.0, 6.0, 1000.0), new Coordinate(45.5, 6.5, 800.0)],
+        );
+        $repo->storeStages($tripId, [$stage]);
+    }
+
+    #[Test]
+    public function revokeReturns204(): void
+    {
+        $this->seedTripWithStages(self::TRIP_ID);
+
+        $this->client->request('POST', \sprintf('/trips/%s/share', self::TRIP_ID), [
+            'headers' => array_merge(['Content-Type' => 'application/ld+json'], $this->authHeader($this->jwtToken)),
+            'json' => [],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+
+        $this->client->request('DELETE', \sprintf('/trips/%s/share', self::TRIP_ID), [
+            'headers' => $this->authHeader($this->jwtToken),
+        ]);
+
+        $this->assertResponseStatusCodeSame(204);
+    }
+
+    #[Test]
+    public function recreateAfterRevokeYieldsAValidActiveShare(): void
+    {
+        $this->seedTripWithStages(self::TRIP_ID);
+
+        $first = $this->client->request('POST', \sprintf('/trips/%s/share', self::TRIP_ID), [
+            'headers' => array_merge(['Content-Type' => 'application/ld+json'], $this->authHeader($this->jwtToken)),
+            'json' => [],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+        /** @var array{shortCode: string} $firstBody */
+        $firstBody = $first->toArray();
+
+        $this->client->request('DELETE', \sprintf('/trips/%s/share', self::TRIP_ID), [
+            'headers' => $this->authHeader($this->jwtToken),
+        ]);
+        $this->assertResponseStatusCodeSame(204);
+
+        // Recreating after revocation must succeed (no 409 from the soft-deleted row).
+        $second = $this->client->request('POST', \sprintf('/trips/%s/share', self::TRIP_ID), [
+            'headers' => array_merge(['Content-Type' => 'application/ld+json'], $this->authHeader($this->jwtToken)),
+            'json' => [],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+        /** @var array{shortCode: string, active: bool} $secondBody */
+        $secondBody = $second->toArray();
+
+        // The recreated link is a brand-new active share, not the revoked one.
+        $this->assertNotSame($firstBody['shortCode'], $secondBody['shortCode']);
+        $this->assertTrue($secondBody['active']);
+
+        // The owner endpoint now resolves the trip to the fresh active share.
+        $active = $this->client->request('GET', \sprintf('/trips/%s/share', self::TRIP_ID), [
+            'headers' => array_merge(['Accept' => 'application/ld+json'], $this->authHeader($this->jwtToken)),
+        ]);
+        $this->assertResponseIsSuccessful();
+        /** @var array{shortCode: string} $activeBody */
+        $activeBody = $active->toArray();
+        $this->assertSame($secondBody['shortCode'], $activeBody['shortCode']);
+    }
+}

--- a/api/tests/Unit/State/TripShareCreateProcessorTest.php
+++ b/api/tests/Unit/State/TripShareCreateProcessorTest.php
@@ -62,13 +62,17 @@ final class TripShareCreateProcessorTest extends TestCase
 
         $this->tripShareRepository->expects($this->once())->method('findActiveByTrip')->willReturn(null);
 
-        $share = new TripShare();
-        $this->persistProcessor->expects($this->once())->method('process')->with($share)->willReturn($share);
+        // The processor builds a fresh active share (it never reuses the incoming,
+        // possibly soft-deleted, entity). Persist echoes back what it receives.
+        $this->persistProcessor->expects($this->once())->method('process')
+            ->with($this->isInstanceOf(TripShare::class))
+            ->willReturnArgument(0);
 
-        $result = $this->processor->process($share, new Post(), ['tripId' => (string) $tripId]);
+        $result = $this->processor->process(new TripShare(), new Post(), ['tripId' => (string) $tripId]);
 
         self::assertSame($trip, $result->getTrip());
         self::assertNotEmpty($result->getToken());
+        self::assertTrue($result->isActive());
     }
 
     #[Test]
@@ -83,13 +87,15 @@ final class TripShareCreateProcessorTest extends TestCase
 
         $this->tripShareRepository->expects($this->once())->method('findActiveByTrip')->willReturn(null);
 
-        $share = new TripShare();
-        $this->persistProcessor->expects($this->once())->method('process')->with($share)->willReturn($share);
+        $this->persistProcessor->expects($this->once())->method('process')
+            ->with($this->isInstanceOf(TripShare::class))
+            ->willReturnArgument(0);
 
-        $result = $this->processor->process($share, new Post(), ['tripId' => $tripId]);
+        $result = $this->processor->process(new TripShare(), new Post(), ['tripId' => $tripId]);
 
         self::assertSame($trip, $result->getTrip());
         self::assertNotEmpty($result->getToken());
+        self::assertTrue($result->isActive());
     }
 
     #[Test]
@@ -100,12 +106,35 @@ final class TripShareCreateProcessorTest extends TestCase
         $this->entityManager->expects($this->never())->method('find');
         $this->tripShareRepository->expects($this->once())->method('findActiveByTrip')->willReturn(null);
 
-        $share = new TripShare();
-        $this->persistProcessor->expects($this->once())->method('process')->with($share)->willReturn($share);
+        $this->persistProcessor->expects($this->once())->method('process')
+            ->with($this->isInstanceOf(TripShare::class))
+            ->willReturnArgument(0);
 
-        $result = $this->processor->process($share, new Post(), ['tripId' => $trip]);
+        $result = $this->processor->process(new TripShare(), new Post(), ['tripId' => $trip]);
 
         self::assertSame($trip, $result->getTrip());
+        self::assertNotEmpty($result->getToken());
+        self::assertTrue($result->isActive());
+    }
+
+    #[Test]
+    public function itIgnoresASoftDeletedIncomingEntityAndCreatesAFreshActiveShare(): void
+    {
+        $trip = new TripRequest();
+
+        $this->tripShareRepository->expects($this->once())->method('findActiveByTrip')->willReturn(null);
+        $this->persistProcessor->expects($this->once())->method('process')
+            ->with($this->isInstanceOf(TripShare::class))
+            ->willReturnArgument(0);
+
+        // Simulate API Platform handing us the previously revoked row.
+        $revoked = new TripShare();
+        $revoked->softDelete();
+
+        $result = $this->processor->process($revoked, new Post(), ['tripId' => $trip]);
+
+        self::assertNotSame($revoked, $result);
+        self::assertTrue($result->isActive());
         self::assertNotEmpty($result->getToken());
     }
 

--- a/api/tests/Unit/State/TripShareDeleteProcessorTest.php
+++ b/api/tests/Unit/State/TripShareDeleteProcessorTest.php
@@ -10,6 +10,7 @@ use App\State\TripShareDeleteProcessor;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Response;
 
 final class TripShareDeleteProcessorTest extends TestCase
 {
@@ -27,5 +28,17 @@ final class TripShareDeleteProcessorTest extends TestCase
 
         self::assertFalse($share->isActive());
         self::assertNotNull($share->getDeletedAt());
+    }
+
+    #[Test]
+    public function itReturnsAnEmpty204Response(): void
+    {
+        $entityManager = $this->createStub(EntityManagerInterface::class);
+
+        $processor = new TripShareDeleteProcessor($entityManager);
+        $response = $processor->process(new TripShare(), new Delete());
+
+        self::assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        self::assertSame('', $response->getContent());
     }
 }

--- a/pwa/src/app/s/[code]/shared-trip-page.tsx
+++ b/pwa/src/app/s/[code]/shared-trip-page.tsx
@@ -179,7 +179,7 @@ function SharedTripLoader({ code }: { code: string }) {
   if (loadError) {
     return (
       <ShareProvider value={null}>
-        <SharedTopBar />
+        <SharedTopBar isError />
         <div data-testid="share-error">
           <TripNotFound variant="share" />
         </div>

--- a/pwa/src/components/share-modal.tsx
+++ b/pwa/src/components/share-modal.tsx
@@ -439,29 +439,20 @@ export function ShareModal({
           </h3>
 
           <div className="relative">
-            <TooltipProvider>
-              <Tooltip open={textCopied}>
-                <TooltipTrigger asChild>
-                  <Button
-                    onClick={() => void handleCopyText()}
-                    variant="outline"
-                    size="icon"
-                    className="absolute top-2 right-2 cursor-pointer"
-                    aria-label={t("copyText")}
-                    data-testid="share-copy-text-button"
-                  >
-                    {textCopied ? (
-                      <Check className="h-4 w-4" />
-                    ) : (
-                      <Copy className="h-4 w-4" />
-                    )}
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">
-                  {t("textCopiedBtn")}
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
+            <Button
+              onClick={() => void handleCopyText()}
+              variant="outline"
+              size="icon"
+              className="absolute top-2 right-2 cursor-pointer"
+              aria-label={textCopied ? t("textCopiedBtn") : t("copyText")}
+              data-testid="share-copy-text-button"
+            >
+              {textCopied ? (
+                <Check className="h-4 w-4" />
+              ) : (
+                <Copy className="h-4 w-4" />
+              )}
+            </Button>
 
             <div className="whitespace-pre-wrap break-words rounded-md bg-muted p-4 pr-14 text-sm leading-relaxed max-h-[30vh] overflow-y-auto">
               {fullText.split("\n").map((line, i) => (

--- a/pwa/src/components/share-modal.tsx
+++ b/pwa/src/components/share-modal.tsx
@@ -11,6 +11,7 @@ import {
   Download,
   Image as ImageIcon,
   FileText,
+  Info,
   Loader2,
   Trash2,
 } from "lucide-react";
@@ -419,35 +420,56 @@ export function ShareModal({
           >
             <FileText className="h-4 w-4" />
             {t("textTitle")}
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    className="text-muted-foreground cursor-help"
+                    aria-label={tTextExport("budgetNote")}
+                  >
+                    <Info className="h-4 w-4" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" className="max-w-xs">
+                  {tTextExport("budgetNote")}
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           </h3>
 
-          <div className="whitespace-pre-wrap break-words rounded-md bg-muted p-4 text-sm leading-relaxed max-h-[30vh] overflow-y-auto">
-            {fullText.split("\n").map((line, i) => (
-              <p key={i} className="min-h-[1em]">
-                {renderTextLine(line)}
-              </p>
-            ))}
-          </div>
+          <div className="relative">
+            <TooltipProvider>
+              <Tooltip open={textCopied}>
+                <TooltipTrigger asChild>
+                  <Button
+                    onClick={() => void handleCopyText()}
+                    variant="outline"
+                    size="icon"
+                    className="absolute top-2 right-2 cursor-pointer"
+                    aria-label={t("copyText")}
+                    data-testid="share-copy-text-button"
+                  >
+                    {textCopied ? (
+                      <Check className="h-4 w-4" />
+                    ) : (
+                      <Copy className="h-4 w-4" />
+                    )}
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">
+                  {t("textCopiedBtn")}
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
 
-          <p className="text-xs text-muted-foreground/70 leading-relaxed mt-2">
-            {tTextExport("budgetNote")}
-          </p>
-
-          <div className="flex justify-end mt-2">
-            <Button
-              onClick={() => void handleCopyText()}
-              variant="outline"
-              size="sm"
-              className="gap-2 cursor-pointer"
-              data-testid="share-copy-text-button"
-            >
-              {textCopied ? (
-                <Check className="h-4 w-4" />
-              ) : (
-                <Copy className="h-4 w-4" />
-              )}
-              {textCopied ? t("textCopiedBtn") : t("copyText")}
-            </Button>
+            <div className="whitespace-pre-wrap break-words rounded-md bg-muted p-4 pr-14 text-sm leading-relaxed max-h-[30vh] overflow-y-auto">
+              {fullText.split("\n").map((line, i) => (
+                <p key={i} className="min-h-[1em]">
+                  {renderTextLine(line, i === 0)}
+                </p>
+              ))}
+            </div>
           </div>
         </section>
       </DialogContent>
@@ -456,15 +478,15 @@ export function ShareModal({
 }
 
 /**
- * Render a single line of text, converting *bold* markers to <strong>
- * and URLs to clickable links.
+ * Render a single line of text, rendering the title line as bold and
+ * URLs as clickable links. The exported text contains no bold markers.
  */
-function renderTextLine(line: string): React.ReactNode[] {
-  const parts = line.split(/(\*[^*]+\*|https?:\/\/[^\s,)]+)/);
+function renderTextLine(line: string, isTitle = false): React.ReactNode[] {
+  if (isTitle && line) {
+    return [<strong key="title">{line}</strong>];
+  }
+  const parts = line.split(/(https?:\/\/[^\s,)]+)/);
   return parts.map((part, j) => {
-    if (/^\*[^*]+\*$/.test(part)) {
-      return <strong key={j}>{part.slice(1, -1)}</strong>;
-    }
     if (/^https?:\/\//.test(part)) {
       return (
         <a

--- a/pwa/src/components/shared-top-bar.test.tsx
+++ b/pwa/src/components/shared-top-bar.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { SharedTopBar } from "./shared-top-bar";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => <a {...props}>{children}</a>,
+}));
+
+describe("SharedTopBar", () => {
+  it("renders GPX/FIT downloads by default", () => {
+    render(<SharedTopBar tripTitle="My trip" />);
+    expect(screen.getByTestId("trip-download-gpx")).toBeInTheDocument();
+    expect(screen.getByTestId("trip-download-fit")).toBeInTheDocument();
+  });
+
+  it("hides GPX/FIT downloads on a revoked/404 share (isError)", () => {
+    render(<SharedTopBar isError />);
+    expect(screen.queryByTestId("trip-download-gpx")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("trip-download-fit")).not.toBeInTheDocument();
+  });
+});

--- a/pwa/src/components/shared-top-bar.tsx
+++ b/pwa/src/components/shared-top-bar.tsx
@@ -8,6 +8,8 @@ import { TripDownloads } from "@/components/trip-downloads";
 interface SharedTopBarProps {
   /** Trip title rendered next to the brand. Omitted when not loaded yet. */
   tripTitle?: string;
+  /** When true (e.g. revoked/404 share), hide the GPX/FIT download links. */
+  isError?: boolean;
 }
 
 /**
@@ -21,7 +23,7 @@ interface SharedTopBarProps {
  * Garmin Connect sync (direct upload to the watch) remains out of scope — see
  * issue #404.
  */
-export function SharedTopBar({ tripTitle }: SharedTopBarProps) {
+export function SharedTopBar({ tripTitle, isError }: SharedTopBarProps) {
   const t = useTranslations("sharedTopBar");
 
   return (
@@ -54,10 +56,13 @@ export function SharedTopBar({ tripTitle }: SharedTopBarProps) {
         {/* Spacer when no title to push the download button to the right */}
         {!tripTitle && <div className="flex-1" />}
 
-        {/* Global GPX / FIT download — only action available in read-only mode */}
-        <div className="shrink-0">
-          <TripDownloads tripId={undefined} tripTitle={tripTitle ?? ""} />
-        </div>
+        {/* Global GPX / FIT download — only action available in read-only mode.
+            Hidden on error pages (e.g. revoked share) where no trip exists. */}
+        {!isError && (
+          <div className="shrink-0">
+            <TripDownloads tripId={undefined} tripTitle={tripTitle ?? ""} />
+          </div>
+        )}
       </div>
     </header>
   );

--- a/pwa/src/lib/text-export.test.ts
+++ b/pwa/src/lib/text-export.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { buildTripText } from "./text-export";
+import type { StageData } from "./validation/schemas";
+
+function buildStage(
+  dayNumber: number,
+  distance: number,
+  elevation: number,
+  isRestDay = false,
+): StageData {
+  return {
+    dayNumber,
+    distance,
+    elevation,
+    elevationLoss: elevation,
+    startPoint: { lat: 45, lon: 4, ele: 0 },
+    endPoint: { lat: 45, lon: 4.1, ele: 0 },
+    geometry: [],
+    label: `Stage ${dayNumber}`,
+    startLabel: null,
+    endLabel: null,
+    weather: null,
+    alerts: [],
+    pois: [],
+    accommodations: [],
+    accommodationSearchRadiusKm: 5,
+    isRestDay,
+    supplyTimeline: [],
+    events: [],
+  };
+}
+
+const labels = { totalDistance: "Distance totale", totalElevation: "Dénivelé" };
+
+describe("buildTripText", () => {
+  it("contains no literal bold markers", () => {
+    const text = buildTripText({
+      title: "Mon voyage",
+      totalDistance: 120,
+      totalElevation: 1500,
+      totalElevationLoss: 1400,
+      sourceUrl: "https://www.komoot.com/tour/123",
+      stages: [buildStage(1, 60, 800), buildStage(2, 60, 700)],
+      startDate: "2026-06-25",
+      labels,
+    });
+
+    expect(text).not.toContain("*");
+  });
+
+  it("renders the title and date lines without asterisks", () => {
+    const text = buildTripText({
+      title: "Mon voyage",
+      totalDistance: 60,
+      totalElevation: 800,
+      totalElevationLoss: 800,
+      sourceUrl: "",
+      stages: [buildStage(1, 60, 800)],
+      startDate: "2026-06-25",
+      labels,
+    });
+
+    const lines = text.split("\n");
+    expect(lines[0]).toBe("Mon voyage");
+    expect(lines.some((l) => l.includes("*"))).toBe(false);
+  });
+
+  it("uses the bike emoji without a dangling zero-width joiner", () => {
+    const text = buildTripText({
+      title: "T",
+      totalDistance: 10,
+      totalElevation: null,
+      totalElevationLoss: null,
+      sourceUrl: "",
+      stages: [],
+      startDate: null,
+      labels,
+    });
+
+    expect(text).toContain("🚴 Distance totale");
+    expect(text).not.toContain("‍");
+  });
+});

--- a/pwa/src/lib/text-export.ts
+++ b/pwa/src/lib/text-export.ts
@@ -42,7 +42,7 @@ function formatStageLine(
   const elevUp = `⬆️ ${Math.round(stage.elevation)}m`;
   const elevDown = `⬇️ ${Math.round(stage.elevationLoss ?? 0)}m`;
 
-  let line = `*${date}* : ${distance}, ${elevUp} ${elevDown}`;
+  let line = `${date} : ${distance}, ${elevUp} ${elevDown}`;
 
   const acc = isLast
     ? null
@@ -111,14 +111,12 @@ export function buildTripText(params: TextExportParams): string {
   const lines: string[] = [];
 
   // Title
-  lines.push(`*${title}*`);
+  lines.push(title);
   lines.push("");
 
   // Global stats
   if (totalDistance !== null) {
-    lines.push(
-      `- 🚴‍ ${labels.totalDistance} : ${Math.round(totalDistance)}km`,
-    );
+    lines.push(`- 🚴 ${labels.totalDistance} : ${Math.round(totalDistance)}km`);
   }
   if (totalElevation !== null) {
     lines.push(


### PR DESCRIPTION
Closes #776. Sprint 42 (recette #649 round 5).

> **Stack** : basé sur `feature/773` (PR #782) — à merger **après** #782.

## Changements
- **Révocation** : `TripShareDeleteProcessor` retourne `Response('', 204)` explicite (au lieu de `null` → réponse non-2xx → toast d'erreur trompeur).
- **Recréation** (cause racine runtime) : le POST partageait l'`uriTemplate` `/trips/{tripId}/share` avec GET/DELETE → API Platform fournissait l'entité **soft-deletée** au processor de création → nouveau lien « révoqué ». `TripShareCreateProcessor` construit désormais systématiquement un `new TripShare()`.
- **GPX/FIT sur 404** : prop `isError` sur `SharedTopBar` masquant les téléchargements ; passée dans la branche `loadError` de `shared-trip-page`.
- Tests : `TripShareLifecycleTest` (revoke 204, recreate valide), `TripShareDeleteProcessorTest`, `TripShareCreateProcessorTest`, `shared-top-bar.test.tsx`. 34 tests TripShare OK.

## Auto-critique
PHPStan L9/Rector/CS-Fixer clean ; vitest 2/2 ; tsc clean. Pas de DTO. `make qa`/`test` complets délégués à la CI.

<!-- claude-review-start -->
## Claude Review

**Commit reviewed:** `f923eb17196f3bd26d0891127bae680c016c4d15`

Solid, well-targeted fix: the root cause (API Platform reusing a soft-deleted entity due to shared URI templates) is correctly diagnosed, and both processors are now correct — the create processor always starts fresh, and the delete processor returns an explicit 204. The `isError` guard on `SharedTopBar` is a clean, minimal frontend fix. Test coverage across functional, unit, and component layers is thorough.

### Summary

1 finding (PR title convention). No inline comments.

### PR title

⚠️ The PR title `fix(share): révocation/recréation de lien + masquer GPX/FIT sur partage révoqué` uses a French noun phrase instead of the required English imperative mood. Conventional Commits requires an imperative English description. The single commit message already has the correct form — consider updating the PR title to match it: `fix(share): return 204 on revoke and recreate a fresh active link`.

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Inline comments

No inline comments.
<!-- claude-review-end -->