### PR TITLE
perf(trip): chargement trip + vue partagée + libellé "Chargement du voyage"

### DIFF
--- a/api/migrations/Version20260625120000.php
+++ b/api/migrations/Version20260625120000.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Issue #775: persist the expensive PostGIS trip-detail metrics at stage-store time.
+ *
+ * Adds `stage.on_cycle_network` (fraction 0..1 of the stage following a signed cycle
+ * route) and `trip.out_of_zone` (route outside the provisioned coverage area) so the
+ * trip-detail read path no longer runs the costly `onNetworkFractions` / `isRouteOutOfZone`
+ * PostGIS queries on every reload. Existing rows keep the column defaults (0 / false)
+ * until the next structural recompute persists the real values.
+ */
+final class Version20260625120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Persist on_cycle_network (stage) and out_of_zone (trip) for O(1) trip-detail reads (#775)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE stage ADD on_cycle_network DOUBLE PRECISION DEFAULT 0 NOT NULL');
+        $this->addSql('ALTER TABLE trip ADD out_of_zone BOOLEAN DEFAULT false NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE stage DROP on_cycle_network');
+        $this->addSql('ALTER TABLE trip DROP out_of_zone');
+    }
+}

--- a/api/src/ApiResource/Stage.php
+++ b/api/src/ApiResource/Stage.php
@@ -160,6 +160,12 @@ final class Stage
 
     public ?Accommodation $selectedAccommodation = null;
 
+    /**
+     * Fraction (0..1) of the stage line that follows a signed cycle route,
+     * persisted at stage-store time and read back here (issue #775).
+     */
+    public float $onCycleNetwork = 0.0;
+
     /** @var Event[] */
     public array $events = [];
 

--- a/api/src/ApiResource/Stage.php
+++ b/api/src/ApiResource/Stage.php
@@ -163,7 +163,12 @@ final class Stage
     /**
      * Fraction (0..1) of the stage line that follows a signed cycle route,
      * persisted at stage-store time and read back here (issue #775).
+     *
+     * Server-computed from PostGIS: readable (the frontend consumes it) but never
+     * writable, so a client PATCH/PUT on a Stage cannot overwrite the computed
+     * value (review on #787).
      */
+    #[ApiProperty(writable: false)]
     public float $onCycleNetwork = 0.0;
 
     /** @var Event[] */

--- a/api/src/ApiResource/TripRequest.php
+++ b/api/src/ApiResource/TripRequest.php
@@ -129,6 +129,19 @@ final class TripRequest
     #[ApiProperty(readable: false, writable: false)]
     public string $locale = 'en';
 
+    /**
+     * True when the route falls (even partly) outside the provisioned coverage
+     * area: the trip is display-only (no Valhalla rerouting).
+     *
+     * Persisted at stage-store time (issue #775) from the expensive PostGIS
+     * {@see \App\Osm\CoverageRepositoryInterface::isRouteOutOfZone()} query so
+     * {@see \App\State\TripDetailProvider} reads it in O(1) instead of recomputing
+     * it on every trip reload.
+     */
+    #[ORM\Column(options: ['default' => false])]
+    #[ApiProperty(readable: false, writable: false)]
+    public bool $outOfZone = false;
+
     #[ORM\Column]
     #[ApiProperty(readable: false, writable: false)]
     public \DateTimeImmutable $createdAt;

--- a/api/src/Entity/Stage.php
+++ b/api/src/Entity/Stage.php
@@ -60,6 +60,17 @@ class Stage
     #[ORM\Column]
     private bool $isRestDay = false;
 
+    /**
+     * Fraction (0..1) of the stage line that follows a signed cycle route.
+     *
+     * Persisted at stage-store time (issue #775) from the expensive PostGIS
+     * {@see \App\Osm\CycleRouteRepositoryInterface::onNetworkFractions()} query so
+     * {@see \App\State\TripDetailProvider} reads it in O(1) instead of recomputing
+     * it on every trip reload.
+     */
+    #[ORM\Column(options: ['default' => 0])]
+    private float $onCycleNetwork = 0.0;
+
     /** @var array<string, mixed>|null */
     #[ORM\Column(type: 'jsonb', nullable: true)]
     private ?array $weather = null;
@@ -275,6 +286,18 @@ class Stage
     public function setIsRestDay(bool $isRestDay): self
     {
         $this->isRestDay = $isRestDay;
+
+        return $this;
+    }
+
+    public function getOnCycleNetwork(): float
+    {
+        return $this->onCycleNetwork;
+    }
+
+    public function setOnCycleNetwork(float $onCycleNetwork): self
+    {
+        $this->onCycleNetwork = $onCycleNetwork;
 
         return $this;
     }

--- a/api/src/Repository/DoctrineTripRequestRepository.php
+++ b/api/src/Repository/DoctrineTripRequestRepository.php
@@ -188,9 +188,50 @@ final class DoctrineTripRequestRepository extends ServiceEntityRepository implem
             return;
         }
 
-        // Compute the expensive PostGIS metrics once, here at store time, so the
-        // trip-detail read path stays O(1) on reload (issue #775). The fractions
-        // are index-aligned with $stages.
+        // The on-cycle-network fraction and out-of-zone flag are derived purely
+        // from the route geometry, so they only change when the geometry does
+        // (initial compute, route recalculation). storeStages() also runs on
+        // every enrichment/edit pass (weather, accommodation select, distance
+        // edit), which leaves the geometry untouched — guard the two heavy PostGIS
+        // scans behind a geometry-change check so frequent edits reuse the already
+        // persisted values (issue #775, perf review on #787).
+        [$cycleNetwork, $outOfZone] = $this->geometryUnchanged($trip, $stages)
+            ? [$this->persistedCycleNetwork($trip), $trip->outOfZone]
+            : $this->computeRouteMetrics($stages);
+
+        $this->getEntityManager()->wrapInTransaction(function () use ($trip, $stages, $cycleNetwork, $outOfZone): void {
+            // Bulk delete: O(1) vs O(N) orphan-removal DELETEs (1 SELECT + N DELETE)
+            $this->getEntityManager()
+                ->createQuery('DELETE FROM App\Entity\Stage s WHERE s.trip = :trip')
+                ->setParameter('trip', $trip)
+                ->execute();
+            $trip->clearStages(); // Keep UoW in sync with the deleted rows
+
+            // Mutate the managed entity inside the transaction so a flush failure
+            // does not leave a stale out-of-zone flag on the in-memory entity
+            // (correctness review on #787).
+            $trip->outOfZone = $outOfZone;
+
+            foreach ($stages as $index => $stageDto) {
+                $stageEntity = $this->stageDtoToEntity($stageDto, $trip, $index);
+                $stageEntity->setOnCycleNetwork($cycleNetwork[$index] ?? 0.0);
+                $trip->addStage($stageEntity);
+            }
+
+            $this->getEntityManager()->flush();
+        });
+    }
+
+    /**
+     * Computes the geometry-derived trip-detail metrics: the per-stage on-cycle-network
+     * fraction (index-aligned with $stages) and the out-of-zone flag.
+     *
+     * @param list<StageDto> $stages
+     *
+     * @return array{0: list<float>, 1: bool}
+     */
+    private function computeRouteMetrics(array $stages): array
+    {
         $cycleNetwork = $this->cycleRouteRepository->onNetworkFractions(
             array_map(
                 static fn (StageDto $stage): array => array_map(
@@ -202,24 +243,68 @@ final class DoctrineTripRequestRepository extends ServiceEntityRepository implem
             self::CYCLE_NETWORK_TOLERANCE_METERS,
         );
 
-        $trip->outOfZone = $this->coverageRepository->isRouteOutOfZone($this->stageRoutePoints($stages));
+        $outOfZone = $this->coverageRepository->isRouteOutOfZone($this->stageRoutePoints($stages));
 
-        $this->getEntityManager()->wrapInTransaction(function () use ($trip, $stages, $cycleNetwork): void {
-            // Bulk delete: O(1) vs O(N) orphan-removal DELETEs (1 SELECT + N DELETE)
-            $this->getEntityManager()
-                ->createQuery('DELETE FROM App\Entity\Stage s WHERE s.trip = :trip')
-                ->setParameter('trip', $trip)
-                ->execute();
-            $trip->clearStages(); // Keep UoW in sync with the deleted rows
+        return [$cycleNetwork, $outOfZone];
+    }
 
-            foreach ($stages as $index => $stageDto) {
-                $stageEntity = $this->stageDtoToEntity($stageDto, $trip, $index);
-                $stageEntity->setOnCycleNetwork($cycleNetwork[$index] ?? 0.0);
-                $trip->addStage($stageEntity);
+    /**
+     * Returns true when the incoming stage geometry (and endpoints) match what is
+     * already persisted, so the geometry-derived PostGIS metrics can be reused.
+     *
+     * @param list<StageDto> $stages
+     */
+    private function geometryUnchanged(TripRequest $trip, array $stages): bool
+    {
+        $persisted = $trip->stages;
+        if ($persisted->count() !== \count($stages)) {
+            return false;
+        }
+
+        foreach ($persisted->getValues() as $index => $entity) {
+            if ($this->stageGeometrySignature($stages[$index]) !== $this->entityGeometrySignature($entity)) {
+                return false;
             }
+        }
 
-            $this->getEntityManager()->flush();
-        });
+        return true;
+    }
+
+    /** @return list<float> The persisted on-cycle-network fractions, index-aligned with the stages. */
+    private function persistedCycleNetwork(TripRequest $trip): array
+    {
+        return array_map(
+            static fn (StageEntity $entity): float => $entity->getOnCycleNetwork(),
+            $trip->stages->getValues(),
+        );
+    }
+
+    /** @return list<array{float, float}> Endpoints + geometry coordinates of an incoming stage DTO. */
+    private function stageGeometrySignature(StageDto $stage): array
+    {
+        $signature = [
+            [$stage->startPoint->lat, $stage->startPoint->lon],
+            [$stage->endPoint->lat, $stage->endPoint->lon],
+        ];
+        foreach ($stage->geometry as $coord) {
+            $signature[] = [$coord->lat, $coord->lon];
+        }
+
+        return $signature;
+    }
+
+    /** @return list<array{float, float}> Endpoints + geometry coordinates of a persisted stage entity. */
+    private function entityGeometrySignature(StageEntity $entity): array
+    {
+        $signature = [
+            [$entity->getStartLat(), $entity->getStartLon()],
+            [$entity->getEndLat(), $entity->getEndLon()],
+        ];
+        foreach ($entity->getGeometry() as $coord) {
+            $signature[] = [$coord['lat'], $coord['lon']];
+        }
+
+        return $signature;
     }
 
     /** @return list<StageDto>|null */

--- a/api/src/Repository/DoctrineTripRequestRepository.php
+++ b/api/src/Repository/DoctrineTripRequestRepository.php
@@ -15,6 +15,8 @@ use App\ApiResource\TripRequest;
 use App\Entity\Stage as StageEntity;
 use App\Enum\AlertType;
 use App\Llm\Dto\StageAiAnalysis;
+use App\Osm\CoverageRepositoryInterface;
+use App\Osm\CycleRouteRepositoryInterface;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 use Psr\Cache\CacheItemPoolInterface;
@@ -30,10 +32,15 @@ final class DoctrineTripRequestRepository extends ServiceEntityRepository implem
 {
     private const int CACHE_TTL = 1800; // 30 minutes for transient data
 
+    /** Tolerance (m) between the stage line and a cycle route to count as "on network". */
+    private const int CYCLE_NETWORK_TOLERANCE_METERS = 30;
+
     public function __construct(
         ManagerRegistry $registry,
         #[Autowire(service: 'cache.trip_state')]
         private readonly CacheItemPoolInterface $tripStateCache,
+        private readonly CycleRouteRepositoryInterface $cycleRouteRepository,
+        private readonly CoverageRepositoryInterface $coverageRepository,
     ) {
         parent::__construct($registry, TripRequest::class);
     }
@@ -181,7 +188,23 @@ final class DoctrineTripRequestRepository extends ServiceEntityRepository implem
             return;
         }
 
-        $this->getEntityManager()->wrapInTransaction(function () use ($trip, $stages): void {
+        // Compute the expensive PostGIS metrics once, here at store time, so the
+        // trip-detail read path stays O(1) on reload (issue #775). The fractions
+        // are index-aligned with $stages.
+        $cycleNetwork = $this->cycleRouteRepository->onNetworkFractions(
+            array_map(
+                static fn (StageDto $stage): array => array_map(
+                    static fn (Coordinate $c): array => ['lat' => $c->lat, 'lon' => $c->lon],
+                    $stage->geometry,
+                ),
+                $stages,
+            ),
+            self::CYCLE_NETWORK_TOLERANCE_METERS,
+        );
+
+        $trip->outOfZone = $this->coverageRepository->isRouteOutOfZone($this->stageRoutePoints($stages));
+
+        $this->getEntityManager()->wrapInTransaction(function () use ($trip, $stages, $cycleNetwork): void {
             // Bulk delete: O(1) vs O(N) orphan-removal DELETEs (1 SELECT + N DELETE)
             $this->getEntityManager()
                 ->createQuery('DELETE FROM App\Entity\Stage s WHERE s.trip = :trip')
@@ -191,6 +214,7 @@ final class DoctrineTripRequestRepository extends ServiceEntityRepository implem
 
             foreach ($stages as $index => $stageDto) {
                 $stageEntity = $this->stageDtoToEntity($stageDto, $trip, $index);
+                $stageEntity->setOnCycleNetwork($cycleNetwork[$index] ?? 0.0);
                 $trip->addStage($stageEntity);
             }
 
@@ -259,6 +283,35 @@ final class DoctrineTripRequestRepository extends ServiceEntityRepository implem
     }
 
     // --- Private helpers ---
+
+    /**
+     * Flattens the stage geometries into the route's coordinates for the coverage
+     * test, falling back to stage start/end points when geometry is unavailable.
+     *
+     * @param list<StageDto> $stages
+     *
+     * @return list<array{lat: float, lon: float}>
+     */
+    private function stageRoutePoints(array $stages): array
+    {
+        $points = [];
+        foreach ($stages as $stage) {
+            foreach ($stage->geometry as $coord) {
+                $points[] = ['lat' => $coord->lat, 'lon' => $coord->lon];
+            }
+        }
+
+        if ([] !== $points) {
+            return $points;
+        }
+
+        foreach ($stages as $stage) {
+            $points[] = ['lat' => $stage->startPoint->lat, 'lon' => $stage->startPoint->lon];
+            $points[] = ['lat' => $stage->endPoint->lat, 'lon' => $stage->endPoint->lon];
+        }
+
+        return $points;
+    }
 
     private function findTripRequest(string $tripId): ?TripRequest
     {
@@ -371,6 +424,8 @@ final class DoctrineTripRequestRepository extends ServiceEntityRepository implem
             elevationLoss: $entity->getElevationLoss(),
             isRestDay: $entity->isRestDay(),
         );
+
+        $dto->onCycleNetwork = $entity->getOnCycleNetwork();
 
         // Weather
         /** @var array{icon: string, description: string, tempMin: float, tempMax: float, windSpeed: float, windDirection: string, precipitationProbability: int, humidity: int, comfortIndex: int, relativeWindDirection: string}|null $weatherData */

--- a/api/src/State/TripDetailProvider.php
+++ b/api/src/State/TripDetailProvider.php
@@ -17,8 +17,6 @@ use App\ApiResource\TripRequest;
 use App\ComputationTracker\ComputationTrackerInterface;
 use App\Enum\ComputationName;
 use App\Enum\TripStatus;
-use App\Osm\CoverageRepositoryInterface;
-use App\Osm\CycleRouteRepositoryInterface;
 use App\Repository\DoctrineTripRequestRepository;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Uid\Uuid;
@@ -33,14 +31,9 @@ use Symfony\Component\Uid\Uuid;
  */
 final readonly class TripDetailProvider implements ProviderInterface
 {
-    /** Tolerance (m) between the stage line and a cycle route to count as "on network". */
-    private const int CYCLE_NETWORK_TOLERANCE_METERS = 30;
-
     public function __construct(
         private DoctrineTripRequestRepository $tripStateManager,
         private TripLocker $tripLocker,
-        private CoverageRepositoryInterface $coverageRepository,
-        private CycleRouteRepositoryInterface $cycleRouteRepository,
         private ComputationTrackerInterface $computationTracker,
     ) {
     }
@@ -65,18 +58,6 @@ final readonly class TripDetailProvider implements ProviderInterface
 
         $statuses = $this->computationTracker->getStatuses($id);
 
-        // One batched query for the on-cycle-network fraction of every stage.
-        $cycleNetwork = $this->cycleRouteRepository->onNetworkFractions(
-            array_map(
-                static fn (Stage $stage): array => array_map(
-                    static fn (Coordinate $c): array => ['lat' => $c->lat, 'lon' => $c->lon],
-                    $stage->geometry,
-                ),
-                $stages,
-            ),
-            self::CYCLE_NETWORK_TOLERANCE_METERS,
-        );
-
         return new TripDetail(
             id: $request->id->toRfc4122(),
             title: $request->title,
@@ -91,13 +72,14 @@ final readonly class TripDetailProvider implements ProviderInterface
             departureHour: $request->departureHour,
             enabledAccommodationTypes: $request->enabledAccommodationTypes,
             isLocked: $this->tripLocker->isLocked($request),
-            outOfZone: $this->coverageRepository->isRouteOutOfZone($this->routePoints($stages)),
+            // Persisted at stage-store time (issue #775) — no PostGIS query here.
+            outOfZone: $request->outOfZone,
             // Fallback for trips persisted before the status column existed: infer
             // readiness from whether stages are present.
             status: '' !== $request->status ? $request->status : ([] !== $stages ? TripStatus::READY->value : TripStatus::DRAFT->value),
             weatherStatus: $this->deriveBlockStatus($this->computationsInCategory('weather'), $statuses),
             aiStatus: $this->deriveBlockStatus($this->computationsInCategory('ai_analysis'), $statuses),
-            stages: array_map($this->serializeStage(...), $stages, $cycleNetwork),
+            stages: array_map($this->serializeStage(...), $stages),
         );
     }
 
@@ -172,40 +154,11 @@ final readonly class TripDetailProvider implements ProviderInterface
     }
 
     /**
-     * Flattens the stage geometries into the route's coordinates for the coverage
-     * test, falling back to stage start/end points when geometry is unavailable.
-     *
-     * @param list<Stage> $stages
-     *
-     * @return list<array{lat: float, lon: float}>
-     */
-    private function routePoints(array $stages): array
-    {
-        $points = [];
-        foreach ($stages as $stage) {
-            foreach ($stage->geometry as $coord) {
-                $points[] = ['lat' => $coord->lat, 'lon' => $coord->lon];
-            }
-        }
-
-        if ([] !== $points) {
-            return $points;
-        }
-
-        foreach ($stages as $stage) {
-            $points[] = ['lat' => $stage->startPoint->lat, 'lon' => $stage->startPoint->lon];
-            $points[] = ['lat' => $stage->endPoint->lat, 'lon' => $stage->endPoint->lon];
-        }
-
-        return $points;
-    }
-
-    /**
      * Converts a Stage DTO to the JSON shape the frontend Zustand store expects.
      *
      * @return array<string, mixed>
      */
-    private function serializeStage(Stage $stage, float $onCycleNetwork): array
+    private function serializeStage(Stage $stage): array
     {
         return [
             'dayNumber' => $stage->dayNumber,
@@ -217,7 +170,7 @@ final readonly class TripDetailProvider implements ProviderInterface
             'geometry' => array_map($this->serializeCoord(...), $stage->geometry),
             'label' => $stage->label,
             'isRestDay' => $stage->isRestDay,
-            'onCycleNetwork' => $onCycleNetwork,
+            'onCycleNetwork' => $stage->onCycleNetwork,
             'weather' => $stage->weather instanceof WeatherForecast ? $this->serializeWeather($stage->weather) : null,
             'alerts' => array_map($this->serializeAlert(...), $stage->alerts),
             'pois' => array_map($this->serializePoi(...), $stage->pois),

--- a/api/tests/Functional/TripDetailTest.php
+++ b/api/tests/Functional/TripDetailTest.php
@@ -265,10 +265,21 @@ final class TripDetailTest extends ApiTestCase
     #[Test]
     public function detailFlagsOutOfZoneFromStageEndpointsWhenGeometryIsEmpty(): void
     {
-        // Exercises the routePoints() fallback (no stage geometry → start/end points)
-        // against the real ST_Covers query: endpoints sit at lon 10, outside the
-        // seeded coverage polygon (2..4 lon, 48..50 lat), so the trip is out of zone.
+        // Exercises the stageRoutePoints() fallback (no stage geometry → start/end
+        // points) against the real ST_Covers query: endpoints sit at lon 10, outside
+        // the seeded coverage polygon (2..4 lon, 48..50 lat), so the trip is out of
+        // zone. The flag is now computed and persisted at storeStages() time (#775),
+        // so the coverage polygon must exist before storing the stages.
         $repo = $this->seedTrip(self::TRIP_ID);
+
+        $connection = self::getContainer()->get('doctrine.dbal.default_connection');
+        \assert($connection instanceof Connection);
+        $connection->executeStatement('TRUNCATE osm.coverage');
+        $connection->executeStatement(<<<'SQL'
+            INSERT INTO osm.coverage (geom) VALUES (
+                ST_Multi(ST_SetSRID(ST_GeomFromText('POLYGON((2 48, 4 48, 4 50, 2 50, 2 48))'), 4326))
+            )
+            SQL);
 
         $stage = new StageDto(
             tripId: self::TRIP_ID,
@@ -280,21 +291,59 @@ final class TripDetailTest extends ApiTestCase
         );
         $repo->storeStages(self::TRIP_ID, [$stage]);
 
-        $connection = self::getContainer()->get('doctrine.dbal.default_connection');
-        \assert($connection instanceof Connection);
-        $connection->executeStatement('TRUNCATE osm.coverage');
-        $connection->executeStatement(<<<'SQL'
-            INSERT INTO osm.coverage (geom) VALUES (
-                ST_Multi(ST_SetSRID(ST_GeomFromText('POLYGON((2 48, 4 48, 4 50, 2 50, 2 48))'), 4326))
-            )
-            SQL);
-
         $response = $this->client->request('GET', \sprintf('/trips/%s/detail', self::TRIP_ID), [
             'headers' => array_merge(['Accept' => 'application/ld+json'], $this->authHeader($this->jwtToken)),
         ]);
 
         $this->assertResponseIsSuccessful();
         $this->assertTrue($response->toArray(false)['outOfZone']);
+    }
+
+    #[Test]
+    public function detailReadsPersistedOnCycleNetworkFraction(): void
+    {
+        // #775: onCycleNetwork is computed by the expensive PostGIS query once at
+        // storeStages() time and persisted on the stage row, then read back O(1)
+        // by the detail provider. Seed a cycle route, store a stage running along
+        // it, and assert the persisted fraction surfaces in the detail payload.
+        $repo = $this->seedTrip(self::TRIP_ID);
+
+        $connection = self::getContainer()->get('doctrine.dbal.default_connection');
+        \assert($connection instanceof Connection);
+        $connection->executeStatement('TRUNCATE osm.cycle_routes');
+        $connection->executeStatement(<<<'SQL'
+            INSERT INTO osm.cycle_routes (osm_id, name, network, ref, tags, geom) VALUES
+              (1, 'EuroVelo Test', 'icn', 'EV-T', '{}'::jsonb,
+                  ST_Multi(ST_SetSRID(ST_GeomFromText('LINESTRING(2 48, 2 49)'), 4326)))
+            SQL);
+
+        $stage = new StageDto(
+            tripId: self::TRIP_ID,
+            dayNumber: 1,
+            distance: 55.0,
+            elevation: 100.0,
+            startPoint: new Coordinate(48.1, 2.0, 0.0),
+            endPoint: new Coordinate(48.9, 2.0, 0.0),
+            geometry: [
+                new Coordinate(48.1, 2.0, 0.0),
+                new Coordinate(48.5, 2.0, 0.0),
+                new Coordinate(48.9, 2.0, 0.0),
+            ],
+        );
+        $repo->storeStages(self::TRIP_ID, [$stage]);
+
+        // Verify the value is actually persisted on the row (not recomputed on read).
+        $persisted = $connection->fetchOne('SELECT on_cycle_network FROM stage WHERE trip_id = :id', ['id' => self::TRIP_ID]);
+        self::assertIsNumeric($persisted);
+        self::assertGreaterThan(0.95, (float) $persisted);
+
+        $response = $this->client->request('GET', \sprintf('/trips/%s/detail', self::TRIP_ID), [
+            'headers' => array_merge(['Accept' => 'application/ld+json'], $this->authHeader($this->jwtToken)),
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $data = $response->toArray(false);
+        self::assertGreaterThan(0.95, $data['stages'][0]['onCycleNetwork']);
     }
 
     #[Test]

--- a/api/tests/Unit/Repository/DoctrineTripRequestRepositoryTest.php
+++ b/api/tests/Unit/Repository/DoctrineTripRequestRepositoryTest.php
@@ -16,6 +16,8 @@ use App\ApiResource\Model\WeatherForecast;
 use App\ApiResource\Stage as StageDto;
 use App\ApiResource\TripRequest;
 use App\Enum\AlertType;
+use App\Osm\CoverageRepositoryInterface;
+use App\Osm\CycleRouteRepositoryInterface;
 use App\Repository\DoctrineTripRequestRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
@@ -35,6 +37,10 @@ final class DoctrineTripRequestRepositoryTest extends TestCase
 
     private CacheItemPoolInterface&MockObject $cache;
 
+    private CycleRouteRepositoryInterface&MockObject $cycleRouteRepository;
+
+    private CoverageRepositoryInterface&MockObject $coverageRepository;
+
     private DoctrineTripRequestRepository $repository;
 
     #[\Override]
@@ -49,10 +55,17 @@ final class DoctrineTripRequestRepositoryTest extends TestCase
 
         $this->cache = $this->createMock(CacheItemPoolInterface::class);
 
+        // The PostGIS metrics are computed at storeStages() time (#775); stub them
+        // with neutral defaults so the persistence round-trips stay deterministic.
+        $this->cycleRouteRepository = $this->createMock(CycleRouteRepositoryInterface::class);
+        $this->cycleRouteRepository->method('onNetworkFractions')->willReturn([]);
+        $this->coverageRepository = $this->createMock(CoverageRepositoryInterface::class);
+        $this->coverageRepository->method('isRouteOutOfZone')->willReturn(false);
+
         $registry = $this->createMock(ManagerRegistry::class);
         $registry->method('getManagerForClass')->willReturn($this->entityManager);
 
-        $this->repository = new DoctrineTripRequestRepository($registry, $this->cache);
+        $this->repository = new DoctrineTripRequestRepository($registry, $this->cache, $this->cycleRouteRepository, $this->coverageRepository);
     }
 
     #[Test]
@@ -95,7 +108,7 @@ final class DoctrineTripRequestRepositoryTest extends TestCase
         $registry2 = $this->createMock(ManagerRegistry::class);
         $registry2->method('getManagerForClass')->willReturn($em2);
 
-        $repo2 = new DoctrineTripRequestRepository($registry2, $this->cache);
+        $repo2 = new DoctrineTripRequestRepository($registry2, $this->cache, $this->cycleRouteRepository, $this->coverageRepository);
         $result = $repo2->getRequest($tripId);
 
         self::assertSame($request, $result);

--- a/api/tests/Unit/Repository/DoctrineTripRequestRepositoryTest.php
+++ b/api/tests/Unit/Repository/DoctrineTripRequestRepositoryTest.php
@@ -784,6 +784,7 @@ final class DoctrineTripRequestRepositoryTest extends TestCase
         // A moved endpoint changes the geometry signature → recompute.
         $moved = $this->stageWithGeometry($tripId);
         $moved->endPoint = new Coordinate(49.0, 3.0, 0.0);
+
         $repository->storeStages($tripId, [$moved]);
     }
 

--- a/api/tests/Unit/Repository/DoctrineTripRequestRepositoryTest.php
+++ b/api/tests/Unit/Repository/DoctrineTripRequestRepositoryTest.php
@@ -740,4 +740,84 @@ final class DoctrineTripRequestRepositoryTest extends TestCase
 
         $this->repository->updateTripAiOverview('not-a-uuid', null);
     }
+
+    #[Test]
+    public function storeStagesSkipsPostGisScansWhenGeometryIsUnchanged(): void
+    {
+        // #787: the heavy PostGIS metrics are geometry-derived, so a second store
+        // of the identical route (an enrichment/edit pass that leaves geometry
+        // untouched) must reuse the persisted values instead of re-scanning.
+        $tripId = Uuid::v7()->toRfc4122();
+        $trip = new TripRequest(Uuid::fromString($tripId));
+
+        $cycleRoute = $this->createMock(CycleRouteRepositoryInterface::class);
+        $cycleRoute->expects(self::once())->method('onNetworkFractions')->willReturn([0.42]);
+        $coverage = $this->createMock(CoverageRepositoryInterface::class);
+        $coverage->expects(self::once())->method('isRouteOutOfZone')->willReturn(false);
+
+        $repository = $this->repositoryWithOsm($trip, $cycleRoute, $coverage);
+
+        $repository->storeStages($tripId, [$this->stageWithGeometry($tripId)]);
+        // Re-storing the same geometry must not trigger another PostGIS scan.
+        $repository->storeStages($tripId, [$this->stageWithGeometry($tripId)]);
+
+        // The persisted fraction is preserved across the guarded second store.
+        $stages = $repository->getStages($tripId);
+        self::assertNotNull($stages);
+        self::assertEqualsWithDelta(0.42, $stages[0]->onCycleNetwork, 0.0001);
+    }
+
+    #[Test]
+    public function storeStagesRecomputesPostGisScansWhenGeometryChanges(): void
+    {
+        $tripId = Uuid::v7()->toRfc4122();
+        $trip = new TripRequest(Uuid::fromString($tripId));
+
+        $cycleRoute = $this->createMock(CycleRouteRepositoryInterface::class);
+        $cycleRoute->expects(self::exactly(2))->method('onNetworkFractions')->willReturn([0.1]);
+        $coverage = $this->createMock(CoverageRepositoryInterface::class);
+        $coverage->expects(self::exactly(2))->method('isRouteOutOfZone')->willReturn(false);
+
+        $repository = $this->repositoryWithOsm($trip, $cycleRoute, $coverage);
+
+        $repository->storeStages($tripId, [$this->stageWithGeometry($tripId)]);
+        // A moved endpoint changes the geometry signature → recompute.
+        $moved = $this->stageWithGeometry($tripId);
+        $moved->endPoint = new Coordinate(49.0, 3.0, 0.0);
+        $repository->storeStages($tripId, [$moved]);
+    }
+
+    private function stageWithGeometry(string $tripId): StageDto
+    {
+        return new StageDto(
+            tripId: $tripId,
+            dayNumber: 1,
+            distance: 55.0,
+            elevation: 100.0,
+            startPoint: new Coordinate(48.1, 2.0, 0.0),
+            endPoint: new Coordinate(48.9, 2.0, 0.0),
+            geometry: [
+                new Coordinate(48.1, 2.0, 0.0),
+                new Coordinate(48.5, 2.0, 0.0),
+                new Coordinate(48.9, 2.0, 0.0),
+            ],
+        );
+    }
+
+    private function repositoryWithOsm(
+        TripRequest $trip,
+        CycleRouteRepositoryInterface&MockObject $cycleRoute,
+        CoverageRepositoryInterface&MockObject $coverage,
+    ): DoctrineTripRequestRepository {
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('wrapInTransaction')->willReturnCallback(static fn (callable $cb): mixed => $cb());
+        $em->method('getClassMetadata')->willReturn(new ClassMetadata(TripRequest::class));
+        $em->method('find')->willReturn($trip);
+        $em->method('createQuery')->willReturn($this->createStub(Query::class));
+
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->method('getManagerForClass')->willReturn($em);
+
+        return new DoctrineTripRequestRepository($registry, $this->cache, $cycleRoute, $coverage);
+    }
 }

--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -435,6 +435,7 @@
     "backToList": "Back to trips",
     "noTrips": "No trips yet. Create your first trip!",
     "loading": "Loading trips...",
+    "loadingOne": "Loading trip...",
     "loadingError": "Failed to load trips.",
     "stages": "{count, plural, one {# stage} other {# stages}}",
     "noDates": "Dates not set",

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -435,6 +435,7 @@
     "backToList": "Retour aux voyages",
     "noTrips": "Aucun voyage pour l'instant. Crée ton premier voyage !",
     "loading": "Chargement des voyages...",
+    "loadingOne": "Chargement du voyage...",
     "loadingError": "Impossible de charger les voyages.",
     "stages": "{count, plural, one {# étape} other {# étapes}}",
     "noDates": "Dates non définies",

--- a/pwa/src/app/(app)/trips/[id]/trip-page.tsx
+++ b/pwa/src/app/(app)/trips/[id]/trip-page.tsx
@@ -146,16 +146,6 @@ function TripLoader({ tripId }: { tripId: string }) {
           sourceType: "persisted",
           title: data.title ?? null,
         });
-
-        // The backend does not persist reverse-geocoded labels (they are a
-        // client-side concern), and on a reload no Mercure event fires to fill
-        // them — so the stage cards would fall back to raw GPS coordinates.
-        // Resolve them here, after hydration, like the Mercure path does
-        // (recette #649).
-        void resolveStageLabels(
-          stages,
-          stages.map((_, i) => i),
-        );
       }
 
       // Drive the synchronous-flow loader vs. trip view from `status`
@@ -278,6 +268,34 @@ function TripLoader({ tripId }: { tripId: string }) {
     clearTrip,
   ]);
 
+  // Defer reverse-geocoding off the load critical path (issue #775): the backend
+  // does not persist reverse-geocoded labels (a client-side concern) and no
+  // Mercure event fires on reload, so the stage cards fall back to raw GPS
+  // coordinates until these resolve. Running the N Nominatim calls inside the
+  // hydrate path blocked the first render for several seconds; instead we kick
+  // them off only once the trip view is rendered, after first paint. The cards
+  // already show coordinates meanwhile and update live as each label lands.
+  useEffect(() => {
+    if (!isLoaded) return;
+
+    const stages = useTripStore.getState().stages;
+    if (stages.length === 0) return;
+
+    let cancelled = false;
+    const timer = setTimeout(() => {
+      if (cancelled) return;
+      void resolveStageLabels(
+        stages,
+        stages.map((_, i) => i),
+      );
+    }, 0);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [isLoaded]);
+
   if (loadError) {
     return <TripNotFound />;
   }
@@ -292,7 +310,7 @@ function TripLoader({ tripId }: { tripId: string }) {
         <TripSummarySkeleton />
         <div className="flex items-center justify-center gap-3 text-muted-foreground text-sm">
           <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
-          <span>{t("loading")}</span>
+          <span>{t("loadingOne")}</span>
         </div>
         {/* Single-column roadbook skeleton — mirrors the new layout where the
             horizontal day timeline sits above the stage cards (recette #649). */}

--- a/pwa/src/app/(app)/trips/[id]/trip-page.tsx
+++ b/pwa/src/app/(app)/trips/[id]/trip-page.tsx
@@ -281,17 +281,20 @@ function TripLoader({ tripId }: { tripId: string }) {
     const stages = useTripStore.getState().stages;
     if (stages.length === 0) return;
 
-    let cancelled = false;
+    const controller = new AbortController();
     const timer = setTimeout(() => {
-      if (cancelled) return;
+      if (controller.signal.aborted) return;
       void resolveStageLabels(
         stages,
         stages.map((_, i) => i),
+        controller.signal,
       );
     }, 0);
 
     return () => {
-      cancelled = true;
+      // Abort on unmount / trip-switch so in-flight Nominatim responses are
+      // dropped instead of corrupting another trip's labels (#787).
+      controller.abort();
       clearTimeout(timer);
     };
   }, [isLoaded]);

--- a/pwa/src/hooks/use-mercure.ts
+++ b/pwa/src/hooks/use-mercure.ts
@@ -689,6 +689,7 @@ export async function resolveStageLabels(
     endPoint: { lat: number; lon: number };
   }[],
   indices?: number[],
+  signal?: AbortSignal,
 ): Promise<void> {
   const store = useTripStore.getState();
   const promises = stages.flatMap((stage, i) => {
@@ -696,12 +697,16 @@ export async function resolveStageLabels(
     return [
       reverseGeocode(stage.startPoint.lat, stage.startPoint.lon).then(
         (result) => {
-          if (result)
+          // Drop late responses after the caller aborted (e.g. unmount /
+          // trip-switch) so a stale Nominatim reply cannot overwrite the labels
+          // of a different trip (#787).
+          if (result && !signal?.aborted)
             store.updateStageLabel(storeIndex, "startLabel", result.name);
         },
       ),
       reverseGeocode(stage.endPoint.lat, stage.endPoint.lon).then((result) => {
-        if (result) store.updateStageLabel(storeIndex, "endLabel", result.name);
+        if (result && !signal?.aborted)
+          store.updateStageLabel(storeIndex, "endLabel", result.name);
       }),
     ];
   });


### PR DESCRIPTION
Closes #775. Sprint 42 (recette #649 round 5).

> **Stack** : basé sur `feature/774` (PR #785) — lui-même basé sur `feature/770` (PR #780). À merger **après** #780 puis #785.

## Changements
- **Persistance au store-time (ADR-043)** : `DoctrineTripRequestRepository::storeStages` calcule `onNetworkFractions` + `isRouteOutOfZone` une seule fois et les persiste (`Stage.on_cycle_network`, `trip.out_of_zone`) ; `TripDetailProvider` lit en O(1) (plus de requête PostGIS coûteuse au GET). Corrige aussi le double coût de la vue partagée (SSR + client).
- **Reverse-geocoding différé** : `resolveStageLabels` sort du `hydrate` (post-render `useEffect`), ne bloque plus le 1er rendu (fallback coords).
- **Libellé** : clé `tripList.loadingOne` → "Chargement du voyage..." (singulier).
- Migration additive `Version20260625120000` ; test `TripDetailTest` (round-trip `on_cycle_network`).

## Auto-critique
**DTO_CHANGED** → la CI doit régénérer les types (`make typegen`). PHPStan L9 clean sur les fichiers modifiés ; tsc/eslint/prettier clean. PHPUnit fonctionnel (PostGIS) délégué à la CI.

<!-- claude-review-start -->
## Claude Review

**Reviewed commit:** `a7a884669f1088c9b8c6c507098e212e21e75abf`

### Summary

All four findings from the previous two review passes are now addressed. The geometry-change guard prevents redundant PostGIS scans on enrichment passes, the `outOfZone` mutation lands correctly inside the transaction, the `AbortController`/signal check prevents stale Nominatim labels from corrupting a newly loaded trip, and `Stage.onCycleNetwork` now carries `#[ApiProperty(writable: false)]`. The PR is clean to merge once CI clears (author has correctly deferred `make typegen` to CI).

### Resolved threads

Resolved 1 previously open thread: `Stage.onCycleNetwork` writable guard — addressed by the final commit.

### PR title

**Non-conforming.** The description is a French noun phrase. CLAUDE.md requires imperative-mood English. The commit message headline itself is a good candidate: `perf(trip): persist on-cycle-network + out-of-zone, defer reverse-geocoding`

### Review checklist
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Inline comments

No inline comments.
<!-- claude-review-end -->