### PR TITLE
fix(docker): attendre la BDD avant les migrations dans l'entrypoint prod

### DIFF
--- a/.docker/php/entrypoint.sh
+++ b/.docker/php/entrypoint.sh
@@ -10,7 +10,33 @@
 set -e
 
 if [ "${MIGRATIONS_ON_BOOT:-false}" = "true" ]; then
-	echo "Running Doctrine migrations..." >&2
+	# Wait for the database to accept connections before migrating. The compose
+	# healthcheck (pg_isready) can briefly report ready during Postgres' init
+	# window while the server still refuses TCP connections, so we retry a real
+	# query here. Without this, migrate fails with SQLSTATE[08006] and the php
+	# container crash-loops, leaving dependent workers stuck in `created`.
+	# Mirrors .docker/php/docker-entrypoint.sh (dev) and api-platform/demo.
+	echo 'Waiting for database to be ready...' >&2
+	ATTEMPTS_LEFT_TO_REACH_DATABASE=60
+	until [ "$ATTEMPTS_LEFT_TO_REACH_DATABASE" -eq 0 ] || DATABASE_ERROR=$(bin/console dbal:run-sql -q 'SELECT 1' 2>&1); do
+		if [ $? -eq 255 ]; then
+			# Unrecoverable error (e.g. invalid DSN) — stop retrying.
+			ATTEMPTS_LEFT_TO_REACH_DATABASE=0
+			break
+		fi
+		sleep 1
+		ATTEMPTS_LEFT_TO_REACH_DATABASE=$((ATTEMPTS_LEFT_TO_REACH_DATABASE - 1))
+		echo "Still waiting for database to be ready... $ATTEMPTS_LEFT_TO_REACH_DATABASE attempts left." >&2
+	done
+
+	if [ "$ATTEMPTS_LEFT_TO_REACH_DATABASE" -eq 0 ]; then
+		echo 'The database is not up or not reachable:' >&2
+		echo "$DATABASE_ERROR" >&2
+		exit 1
+	fi
+	echo 'The database is now ready and reachable' >&2
+
+	echo 'Running Doctrine migrations...' >&2
 	bin/console doctrine:migrations:migrate --no-interaction --allow-no-migration >&2
 fi
 


### PR DESCRIPTION
## Contexte (recette #649)

Au démarrage de la stack iso-prod (`make start-recette`), le conteneur PHP bouclait sur `SQLSTATE[08006] Connection refused` : l'entrypoint prod lançait `doctrine:migrations:migrate` immédiatement, mais le healthcheck `pg_isready` de Postgres peut répondre « prêt » pendant la fenêtre d'init alors que le serveur refuse encore les connexions TCP.

Conséquence en cascade : php crash-loope → `up --wait` échoue → les workers `messenger:consume` restent en état `created` (jamais démarrés) → **toute la chaîne asynchrone est morte** (calcul d'itinéraire, alertes, hébergements, météo).

## Correctif

Porter la boucle d'attente BDD déjà présente dans l'entrypoint **dev** (`.docker/php/docker-entrypoint.sh`) et dans api-platform/demo vers l'entrypoint **prod** (`.docker/php/entrypoint.sh`) : on retry `dbal:run-sql 'SELECT 1'` jusqu'à 60 fois avant de migrer.

## Vérification

`sh -n` OK. La cause racine (workers `created`) a été confirmée en live ; après correctif l'image php se reconstruit proprement. Les legs PHP complets passent en CI.

<!-- claude-review-start -->
## Claude Review

Reviewed commit `25ffb09e3ba16bceeca085d485647c3bcc7f0119`.

Clean, minimal fix that directly mirrors the established pattern from the dev entrypoint (`.docker/php/docker-entrypoint.sh`). The retry loop, exit-255 fast-fail, and counter-to-zero exhaustion logic are all correct. No findings.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases (`sh -n` verified; live-tested on recette)
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** None.
<!-- claude-review-end -->