### PR TITLE
fix(pwa): scroll-lock + reset du panneau de configuration (recette #649)

### DIFF
--- a/pwa/src/app/(app)/trips/new/page.tsx
+++ b/pwa/src/app/(app)/trips/new/page.tsx
@@ -31,6 +31,7 @@ function NewTripContent() {
     ui.setAccommodationScanning(false);
     ui.setBlockStatus("weather", null);
     ui.setBlockStatus("ai", null);
+    ui.setConfigPanelOpen(false);
     // Run once on mount: arriving on `/trips/new` is an explicit fresh-start
     // intent. Subsequent in-page state changes must not re-clear the trip.
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/pwa/src/components/config-panel.tsx
+++ b/pwa/src/components/config-panel.tsx
@@ -124,6 +124,16 @@ export function ConfigPanel({
     return () => document.removeEventListener("keydown", handleKeyDown);
   }, [isOpen, setConfigPanelOpen]);
 
+  // Lock body scroll while the panel is open so the page behind it stays put.
+  useEffect(() => {
+    if (!isOpen) return;
+    const previous = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = previous;
+    };
+  }, [isOpen]);
+
   // Trap focus inside panel when open
   useEffect(() => {
     if (!isOpen) return;

--- a/pwa/src/hooks/use-trip-planner.ts
+++ b/pwa/src/hooks/use-trip-planner.ts
@@ -838,6 +838,7 @@ export function useTripPlanner() {
       actions.clearTrip();
       useUiStore.getState().setProcessing(false);
       useUiStore.getState().setAccommodationScanning(false);
+      useUiStore.getState().setConfigPanelOpen(false);
       router.push("/trips");
       return true;
     } catch (err) {

--- a/pwa/tests/mocked/config-panel.spec.ts
+++ b/pwa/tests/mocked/config-panel.spec.ts
@@ -47,6 +47,29 @@ test.describe("ConfigPanel", () => {
     await expect(dialog).not.toBeInViewport();
   });
 
+  test("locks body scroll while open and restores it on close", async ({
+    createFullTrip,
+    mockedPage,
+  }) => {
+    await createFullTrip();
+    await mockedPage
+      .getByRole("button", { name: "Ouvrir les paramètres" })
+      .click();
+    await expect(
+      mockedPage.getByRole("dialog", { name: "Paramètres" }),
+    ).toBeInViewport();
+    expect(await mockedPage.evaluate(() => document.body.style.overflow)).toBe(
+      "hidden",
+    );
+
+    await mockedPage
+      .getByRole("button", { name: "Fermer les paramètres" })
+      .click();
+    expect(await mockedPage.evaluate(() => document.body.style.overflow)).toBe(
+      "",
+    );
+  });
+
   test("toggling the last enabled accommodation type is a no-op", async ({
     createFullTrip,
     mockedPage,

--- a/pwa/tests/mocked/trip-delete.spec.ts
+++ b/pwa/tests/mocked/trip-delete.spec.ts
@@ -146,4 +146,34 @@ test.describe("Delete trip from the config panel", () => {
     // No navigation on failure.
     await expect(page).toHaveURL(new RegExp(`/trips/${TRIP_ID}`));
   });
+
+  test("config panel stays closed after delete then new trip", async ({
+    page,
+  }) => {
+    await page.route(`**/trips/${TRIP_ID}`, (route, request) => {
+      if (request.method() !== "DELETE") return route.fallback();
+      return route.fulfill({ status: 204, body: "" });
+    });
+    await page.route(/\/trips\?/, (route, request) => {
+      if (request.method() !== "GET") return route.fallback();
+      return route.fulfill({
+        status: 200,
+        headers: { "Content-Type": "application/ld+json; charset=utf-8" },
+        body: JSON.stringify({ member: [], totalItems: 0 }),
+      });
+    });
+
+    await openConfig(page);
+    await page.getByTestId("delete-trip-button").click();
+    await expect(page.getByTestId("delete-trip-dialog")).toBeVisible();
+    await page.getByTestId("delete-trip-dialog-confirm").click();
+    await page.waitForURL(/\/trips$/, { timeout: 5000 });
+
+    // Regression (recette #649): the stale isConfigPanelOpen flag used to survive
+    // SPA navigation and reopen the panel over the fresh-start screen.
+    await page.goto("/trips/new");
+    await expect(
+      page.getByRole("dialog", { name: "Paramètres" }),
+    ).not.toBeInViewport();
+  });
 });

--- a/pwa/tests/mocked/trip-delete.spec.ts
+++ b/pwa/tests/mocked/trip-delete.spec.ts
@@ -170,8 +170,11 @@ test.describe("Delete trip from the config panel", () => {
     await page.waitForURL(/\/trips$/, { timeout: 5000 });
 
     // Regression (recette #649): the stale isConfigPanelOpen flag used to survive
-    // SPA navigation and reopen the panel over the fresh-start screen.
-    await page.goto("/trips/new");
+    // client-side navigation and reopen the panel over the fresh-start screen.
+    // Navigate via the empty-state CTA (a next/link SPA transition, not page.goto,
+    // which would reset the in-memory Zustand store and pass even without the fix).
+    await page.getByTestId("trips-empty-new-trip-primary").click();
+    await page.waitForURL(/\/trips\/new/);
     await expect(
       page.getByRole("dialog", { name: "Paramètres" }),
     ).not.toBeInViewport();


### PR DESCRIPTION
## Contexte (recette #649)

Deux bugs UX sur le panneau de configuration du voyage (drawer custom, pas un Radix Dialog) :

1. Quand le panneau est ouvert, la page derrière continuait de scroller.
2. Suppression d'un voyage → « Mes voyages » → « Nouveau voyage » : le panneau se rouvrait tout seul (état `isConfigPanelOpen` rémanent — `clearTrip()` ne réinitialise que le trip-store, pas le ui-store, non persisté mais survivant à la navigation SPA).

## Correctif

- `config-panel.tsx` : effet qui verrouille `document.body.style.overflow` tant que `isOpen` (restaure la valeur précédente à la fermeture).
- Reset `setConfigPanelOpen(false)` à la suppression (`handleDeleteTrip`) et au mount de `/trips/new`.

## Vérification

`tsc` OK (aucune erreur dans les fichiers modifiés). Vérif visuelle à refaire en recette.

<!-- claude-review-start -->
## Claude Review

**Commit reviewed:** `a24fe94de2f74acd3f86483bd6525347f962d6fb`

**Summary:** All previous findings addressed. Both code fixes are correct and complete; both regression scenarios are now covered by E2E tests that exercise the real failure paths (scroll lock via DOM inspection, delete→new-trip via SPA navigation rather than a hard reload).

**Resolved threads:** Resolved 1 previously open bot-authored thread (SPA navigation test confirmed fixed).

**Review checklist**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.
<!-- claude-review-end -->