### PR TITLE
fix(api): éliminer la race de persistance des enrichissements d'étape (recette #649)

### DIFF
--- a/api/src/MessageHandler/AnalyzeTerrainHandler.php
+++ b/api/src/MessageHandler/AnalyzeTerrainHandler.php
@@ -84,7 +84,13 @@ final readonly class AnalyzeTerrainHandler extends AbstractTripMessageHandler
                 }
             }
 
-            $this->tripStateManager->storeStages($tripId, $stages);
+            // Persist alerts with an atomic per-column UPDATE per stage (recette #649).
+            // AnalyzeTerrain is the authority for persisted alerts; the extra
+            // lunch/seasonal alerts from pois/accommodations are delivered live via
+            // Mercure only.
+            foreach ($stages as $stage) {
+                $this->tripStateManager->updateStageAlerts($tripId, $stage->dayNumber, $stage->alerts);
+            }
 
             $alertsData = [];
             foreach ($stages as $i => $stage) {

--- a/api/src/MessageHandler/AnalyzeTerrainHandler.php
+++ b/api/src/MessageHandler/AnalyzeTerrainHandler.php
@@ -89,7 +89,7 @@ final readonly class AnalyzeTerrainHandler extends AbstractTripMessageHandler
             // lunch/seasonal alerts from pois/accommodations are delivered live via
             // Mercure only.
             foreach ($stages as $stage) {
-                $this->tripStateManager->updateStageAlerts($tripId, $stage->dayNumber, $stage->alerts);
+                $this->tripStateManager->updateStageAlerts($tripId, $stage->dayNumber, array_values($stage->alerts));
             }
 
             $alertsData = [];

--- a/api/src/MessageHandler/FetchWeatherHandler.php
+++ b/api/src/MessageHandler/FetchWeatherHandler.php
@@ -161,7 +161,12 @@ final readonly class FetchWeatherHandler extends AbstractTripMessageHandler
                 }
             }
 
-            $this->tripStateManager->storeStages($tripId, $stages);
+            // Persist each stage's weather with an atomic per-column UPDATE so a
+            // slower sibling handler (pois/terrain) re-writing the whole collection
+            // can no longer wipe it (recette #649).
+            foreach ($stages as $stage) {
+                $this->tripStateManager->updateStageWeather($tripId, $stage->dayNumber, $stage->weather);
+            }
 
             $this->publisher->publish($tripId, MercureEventType::WEATHER_FETCHED, [
                 'stagesWithWeather' => \count(array_filter(

--- a/api/src/MessageHandler/ScanAccommodationsHandler.php
+++ b/api/src/MessageHandler/ScanAccommodationsHandler.php
@@ -213,9 +213,6 @@ final readonly class ScanAccommodationsHandler extends AbstractTripMessageHandle
                 }
 
                 $this->publisher->publish($tripId, MercureEventType::ACCOMMODATIONS_FOUND, $payload);
-
-                // Update the stage in the full stages array
-                $stages[$i] = $stage;
             }
 
             // Persist accommodations with an atomic per-column UPDATE, only for the

--- a/api/src/MessageHandler/ScanAccommodationsHandler.php
+++ b/api/src/MessageHandler/ScanAccommodationsHandler.php
@@ -218,7 +218,12 @@ final readonly class ScanAccommodationsHandler extends AbstractTripMessageHandle
                 $stages[$i] = $stage;
             }
 
-            $this->tripStateManager->storeStages($tripId, array_values($stages));
+            // Persist accommodations with an atomic per-column UPDATE, only for the
+            // processed stage(s) (single-stage expand or all) — recette #649. The
+            // seasonal alert is delivered live via Mercure (above), not persisted here.
+            foreach ($stagesToProcess as $stage) {
+                $this->tripStateManager->updateStageAccommodations($tripId, $stage->dayNumber, $stage->accommodations);
+            }
         }, $generation);
     }
 

--- a/api/src/MessageHandler/ScanAccommodationsHandler.php
+++ b/api/src/MessageHandler/ScanAccommodationsHandler.php
@@ -222,7 +222,7 @@ final readonly class ScanAccommodationsHandler extends AbstractTripMessageHandle
             // processed stage(s) (single-stage expand or all) — recette #649. The
             // seasonal alert is delivered live via Mercure (above), not persisted here.
             foreach ($stagesToProcess as $stage) {
-                $this->tripStateManager->updateStageAccommodations($tripId, $stage->dayNumber, $stage->accommodations);
+                $this->tripStateManager->updateStageAccommodations($tripId, $stage->dayNumber, array_values($stage->accommodations));
             }
         }, $generation);
     }

--- a/api/src/MessageHandler/ScanEventsHandler.php
+++ b/api/src/MessageHandler/ScanEventsHandler.php
@@ -88,10 +88,12 @@ final readonly class ScanEventsHandler extends AbstractTripMessageHandler
                     'events' => array_map($this->eventToArray(...), $events),
                 ]);
 
-                $stages[$i] = $stage;
             }
 
-            $this->tripStateManager->storeStages($tripId, array_values($stages));
+            // Events are not a persisted stage column (no Stage::events DB column);
+            // they are delivered live via Mercure above. The previous storeStages()
+            // call persisted nothing useful and re-wrote the whole stages collection,
+            // wiping concurrent weather/accommodations writes (recette #649).
         }, $generation);
     }
 

--- a/api/src/MessageHandler/ScanPoisHandler.php
+++ b/api/src/MessageHandler/ScanPoisHandler.php
@@ -195,7 +195,7 @@ final readonly class ScanPoisHandler extends AbstractTripMessageHandler
             // The lunch/resupply alerts added above are delivered live via Mercure
             // (above); AnalyzeTerrain owns the persisted alerts column.
             foreach ($stages as $stage) {
-                $this->tripStateManager->updateStagePois($tripId, $stage->dayNumber, $stage->pois);
+                $this->tripStateManager->updateStagePois($tripId, $stage->dayNumber, array_values($stage->pois));
             }
         }, $generation);
     }

--- a/api/src/MessageHandler/ScanPoisHandler.php
+++ b/api/src/MessageHandler/ScanPoisHandler.php
@@ -191,7 +191,12 @@ final readonly class ScanPoisHandler extends AbstractTripMessageHandler
                 }
             }
 
-            $this->tripStateManager->storeStages($tripId, $stages);
+            // Persist POIs with an atomic per-column UPDATE per stage (recette #649).
+            // The lunch/resupply alerts added above are delivered live via Mercure
+            // (above); AnalyzeTerrain owns the persisted alerts column.
+            foreach ($stages as $stage) {
+                $this->tripStateManager->updateStagePois($tripId, $stage->dayNumber, $stage->pois);
+            }
         }, $generation);
     }
 

--- a/api/src/Repository/DoctrineTripRequestRepository.php
+++ b/api/src/Repository/DoctrineTripRequestRepository.php
@@ -367,6 +367,55 @@ final class DoctrineTripRequestRepository extends ServiceEntityRepository implem
             ->execute();
     }
 
+    public function updateStageWeather(string $tripId, int $dayNumber, ?WeatherForecast $weather): void
+    {
+        $this->updateStageColumn($tripId, $dayNumber, 'weather', $weather instanceof WeatherForecast ? $this->weatherToArray($weather) : null);
+    }
+
+    /** @param list<Alert> $alerts */
+    public function updateStageAlerts(string $tripId, int $dayNumber, array $alerts): void
+    {
+        $this->updateStageColumn($tripId, $dayNumber, 'alerts', array_map($this->alertToArray(...), $alerts));
+    }
+
+    /** @param list<PointOfInterest> $pois */
+    public function updateStagePois(string $tripId, int $dayNumber, array $pois): void
+    {
+        $this->updateStageColumn($tripId, $dayNumber, 'pois', array_map($this->poiToArray(...), $pois));
+    }
+
+    /** @param list<Accommodation> $accommodations */
+    public function updateStageAccommodations(string $tripId, int $dayNumber, array $accommodations): void
+    {
+        $this->updateStageColumn($tripId, $dayNumber, 'accommodations', array_map($this->accommodationToArray(...), $accommodations));
+    }
+
+    /**
+     * Atomic per-stage UPDATE of one JSONB column, keyed by dayNumber. Lets parallel
+     * enrichment handlers persist only their own column instead of the whole-collection
+     * read-modify-write of {@see self::storeStages()} (which let a slow handler overwrite
+     * a sibling's freshly-written column — recette #649). Mirrors {@see self::updateStageAiAnalysis()}.
+     *
+     * @param 'weather'|'alerts'|'pois'|'accommodations' $column
+     * @param array<mixed>|null                          $value
+     */
+    private function updateStageColumn(string $tripId, int $dayNumber, string $column, ?array $value): void
+    {
+        if (!Uuid::isValid($tripId)) {
+            return;
+        }
+
+        $this->getEntityManager()->createQuery(
+            \sprintf('UPDATE App\Entity\Stage s SET s.%s = :value WHERE s.trip = :tripId AND s.dayNumber = :dayNumber', $column),
+        )
+            ->setParameter('tripId', Uuid::fromString($tripId))
+            ->setParameter('dayNumber', $dayNumber)
+            // Bind as a single JSONB value (see updateStageAiAnalysis): without the
+            // explicit type Doctrine infers ArrayParameterType and expands the list.
+            ->setParameter('value', $value, 'jsonb')
+            ->execute();
+    }
+
     // --- Private helpers ---
 
     /**

--- a/api/src/Repository/DoctrineTripRequestRepository.php
+++ b/api/src/Repository/DoctrineTripRequestRepository.php
@@ -367,52 +367,75 @@ final class DoctrineTripRequestRepository extends ServiceEntityRepository implem
             ->execute();
     }
 
+    // Atomic per-stage UPDATE of one JSONB column, keyed by dayNumber: lets parallel
+    // enrichment handlers persist only their own column instead of the whole-collection
+    // read-modify-write of storeStages() (which let a slow handler overwrite a sibling's
+    // freshly-written column — recette #649). One literal DQL per column (a dynamic,
+    // sprintf-built query string is not validated by phpstan-doctrine and avoids any
+    // column-name interpolation). Mirrors updateStageAiAnalysis(). The value is bound as a
+    // single 'jsonb' parameter — without the explicit type Doctrine infers
+    // ArrayParameterType and expands the list into $1, $2, … .
+
     public function updateStageWeather(string $tripId, int $dayNumber, ?WeatherForecast $weather): void
-    {
-        $this->updateStageColumn($tripId, $dayNumber, 'weather', $weather instanceof WeatherForecast ? $this->weatherToArray($weather) : null);
-    }
-
-    /** @param list<Alert> $alerts */
-    public function updateStageAlerts(string $tripId, int $dayNumber, array $alerts): void
-    {
-        $this->updateStageColumn($tripId, $dayNumber, 'alerts', array_map($this->alertToArray(...), $alerts));
-    }
-
-    /** @param list<PointOfInterest> $pois */
-    public function updateStagePois(string $tripId, int $dayNumber, array $pois): void
-    {
-        $this->updateStageColumn($tripId, $dayNumber, 'pois', array_map($this->poiToArray(...), $pois));
-    }
-
-    /** @param list<Accommodation> $accommodations */
-    public function updateStageAccommodations(string $tripId, int $dayNumber, array $accommodations): void
-    {
-        $this->updateStageColumn($tripId, $dayNumber, 'accommodations', array_map($this->accommodationToArray(...), $accommodations));
-    }
-
-    /**
-     * Atomic per-stage UPDATE of one JSONB column, keyed by dayNumber. Lets parallel
-     * enrichment handlers persist only their own column instead of the whole-collection
-     * read-modify-write of {@see self::storeStages()} (which let a slow handler overwrite
-     * a sibling's freshly-written column — recette #649). Mirrors {@see self::updateStageAiAnalysis()}.
-     *
-     * @param 'weather'|'alerts'|'pois'|'accommodations' $column
-     * @param array<mixed>|null                          $value
-     */
-    private function updateStageColumn(string $tripId, int $dayNumber, string $column, ?array $value): void
     {
         if (!Uuid::isValid($tripId)) {
             return;
         }
 
         $this->getEntityManager()->createQuery(
-            \sprintf('UPDATE App\Entity\Stage s SET s.%s = :value WHERE s.trip = :tripId AND s.dayNumber = :dayNumber', $column),
+            'UPDATE App\Entity\Stage s SET s.weather = :value WHERE s.trip = :tripId AND s.dayNumber = :dayNumber',
         )
             ->setParameter('tripId', Uuid::fromString($tripId))
             ->setParameter('dayNumber', $dayNumber)
-            // Bind as a single JSONB value (see updateStageAiAnalysis): without the
-            // explicit type Doctrine infers ArrayParameterType and expands the list.
-            ->setParameter('value', $value, 'jsonb')
+            ->setParameter('value', $weather instanceof WeatherForecast ? $this->weatherToArray($weather) : null, 'jsonb')
+            ->execute();
+    }
+
+    /** @param list<Alert> $alerts */
+    public function updateStageAlerts(string $tripId, int $dayNumber, array $alerts): void
+    {
+        if (!Uuid::isValid($tripId)) {
+            return;
+        }
+
+        $this->getEntityManager()->createQuery(
+            'UPDATE App\Entity\Stage s SET s.alerts = :value WHERE s.trip = :tripId AND s.dayNumber = :dayNumber',
+        )
+            ->setParameter('tripId', Uuid::fromString($tripId))
+            ->setParameter('dayNumber', $dayNumber)
+            ->setParameter('value', array_map($this->alertToArray(...), $alerts), 'jsonb')
+            ->execute();
+    }
+
+    /** @param list<PointOfInterest> $pois */
+    public function updateStagePois(string $tripId, int $dayNumber, array $pois): void
+    {
+        if (!Uuid::isValid($tripId)) {
+            return;
+        }
+
+        $this->getEntityManager()->createQuery(
+            'UPDATE App\Entity\Stage s SET s.pois = :value WHERE s.trip = :tripId AND s.dayNumber = :dayNumber',
+        )
+            ->setParameter('tripId', Uuid::fromString($tripId))
+            ->setParameter('dayNumber', $dayNumber)
+            ->setParameter('value', array_map($this->poiToArray(...), $pois), 'jsonb')
+            ->execute();
+    }
+
+    /** @param list<Accommodation> $accommodations */
+    public function updateStageAccommodations(string $tripId, int $dayNumber, array $accommodations): void
+    {
+        if (!Uuid::isValid($tripId)) {
+            return;
+        }
+
+        $this->getEntityManager()->createQuery(
+            'UPDATE App\Entity\Stage s SET s.accommodations = :value WHERE s.trip = :tripId AND s.dayNumber = :dayNumber',
+        )
+            ->setParameter('tripId', Uuid::fromString($tripId))
+            ->setParameter('dayNumber', $dayNumber)
+            ->setParameter('value', array_map($this->accommodationToArray(...), $accommodations), 'jsonb')
             ->execute();
     }
 

--- a/api/src/Repository/RedisTripRequestRepository.php
+++ b/api/src/Repository/RedisTripRequestRepository.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace App\Repository;
 
+use App\ApiResource\Model\Accommodation;
+use App\ApiResource\Model\Alert;
+use App\ApiResource\Model\PointOfInterest;
+use App\ApiResource\Model\WeatherForecast;
 use App\ApiResource\Stage;
 use App\ApiResource\TripRequest;
 use App\Llm\Dto\StageAiAnalysis;
@@ -120,6 +124,72 @@ final readonly class RedisTripRequestRepository implements TripRequestRepository
             foreach ($stages as $stage) {
                 if ($stage->dayNumber === $dayNumber) {
                     $stage->aiAnalysis = null === $aiAnalysis ? null : StageAiAnalysis::fromArray($aiAnalysis);
+                    $changed = true;
+                    break;
+                }
+            }
+
+            if ($changed) {
+                $this->storeStages($tripId, $stages);
+            }
+        } finally {
+            $lock->release();
+        }
+    }
+
+    public function updateStageWeather(string $tripId, int $dayNumber, ?WeatherForecast $weather): void
+    {
+        $this->updateStageField($tripId, $dayNumber, static function (Stage $stage) use ($weather): void {
+            $stage->weather = $weather;
+        });
+    }
+
+    /** @param list<Alert> $alerts */
+    public function updateStageAlerts(string $tripId, int $dayNumber, array $alerts): void
+    {
+        $this->updateStageField($tripId, $dayNumber, static function (Stage $stage) use ($alerts): void {
+            $stage->alerts = $alerts;
+        });
+    }
+
+    /** @param list<PointOfInterest> $pois */
+    public function updateStagePois(string $tripId, int $dayNumber, array $pois): void
+    {
+        $this->updateStageField($tripId, $dayNumber, static function (Stage $stage) use ($pois): void {
+            $stage->pois = $pois;
+        });
+    }
+
+    /** @param list<Accommodation> $accommodations */
+    public function updateStageAccommodations(string $tripId, int $dayNumber, array $accommodations): void
+    {
+        $this->updateStageField($tripId, $dayNumber, static function (Stage $stage) use ($accommodations): void {
+            $stage->accommodations = $accommodations;
+        });
+    }
+
+    /**
+     * Lock-guarded read-modify-write of a single stage (matched by dayNumber) in the
+     * monolithic blob, so concurrent enrichment handlers can't lose each other's
+     * column updates (recette #649). Mirrors {@see self::updateStageAiAnalysis()}.
+     *
+     * @param callable(Stage): void $mutator
+     */
+    private function updateStageField(string $tripId, int $dayNumber, callable $mutator): void
+    {
+        $lock = $this->lockFactory->createLock(\sprintf('trip.%s.stages.update', $tripId), ttl: 5);
+        $lock->acquire(blocking: true);
+
+        try {
+            $stages = $this->getStages($tripId);
+            if (null === $stages) {
+                return;
+            }
+
+            $changed = false;
+            foreach ($stages as $stage) {
+                if ($stage->dayNumber === $dayNumber) {
+                    $mutator($stage);
                     $changed = true;
                     break;
                 }

--- a/api/src/Repository/TripRequestRepositoryInterface.php
+++ b/api/src/Repository/TripRequestRepositoryInterface.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace App\Repository;
 
+use App\ApiResource\Model\Accommodation;
+use App\ApiResource\Model\Alert;
+use App\ApiResource\Model\PointOfInterest;
+use App\ApiResource\Model\WeatherForecast;
 use App\ApiResource\Stage;
 use App\ApiResource\TripRequest;
 
@@ -68,6 +72,37 @@ interface TripRequestRepositoryInterface
      * @param array{narrative: string, patterns: list<string>, recommendations: list<string>, crossStageAlerts: list<string>, model: string, promptVersion: int, generatedAt: string}|null $aiOverview
      */
     public function updateTripAiOverview(string $tripId, ?array $aiOverview): void;
+
+    /**
+     * Persists a single stage's weather atomically, keyed by dayNumber.
+     *
+     * Parallel enrichment handlers each own one JSONB column; routing them through
+     * {@see self::storeStages()} re-writes the whole stages collection, so a slow
+     * handler reading a stale snapshot overwrites a sibling's freshly-written column
+     * (the weather/accommodations "disappear" bug — recette #649).
+     */
+    public function updateStageWeather(string $tripId, int $dayNumber, ?WeatherForecast $weather): void;
+
+    /**
+     * Persists a single stage's alerts atomically (see {@see self::updateStageWeather()}).
+     *
+     * @param list<Alert> $alerts
+     */
+    public function updateStageAlerts(string $tripId, int $dayNumber, array $alerts): void;
+
+    /**
+     * Persists a single stage's POIs atomically (see {@see self::updateStageWeather()}).
+     *
+     * @param list<PointOfInterest> $pois
+     */
+    public function updateStagePois(string $tripId, int $dayNumber, array $pois): void;
+
+    /**
+     * Persists a single stage's accommodations atomically (see {@see self::updateStageWeather()}).
+     *
+     * @param list<Accommodation> $accommodations
+     */
+    public function updateStageAccommodations(string $tripId, int $dayNumber, array $accommodations): void;
 
     /**
      * Stores multi-track data for Komoot Collection source type.

--- a/api/tests/Integration/LlmPipelineTest.php
+++ b/api/tests/Integration/LlmPipelineTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Integration;
 
+use App\ApiResource\Model\WeatherForecast;
 use App\ApiResource\Model\Coordinate;
 use App\ApiResource\Stage;
 use App\ApiResource\TripRequest;
@@ -454,6 +455,22 @@ final class InMemoryTripRequestRepository implements TripRequestRepositoryInterf
     }
 
     public function storeStages(string $tripId, array $stages): void
+    {
+    }
+
+    public function updateStageWeather(string $tripId, int $dayNumber, ?WeatherForecast $weather): void
+    {
+    }
+
+    public function updateStageAlerts(string $tripId, int $dayNumber, array $alerts): void
+    {
+    }
+
+    public function updateStagePois(string $tripId, int $dayNumber, array $pois): void
+    {
+    }
+
+    public function updateStageAccommodations(string $tripId, int $dayNumber, array $accommodations): void
     {
     }
 

--- a/api/tests/Unit/Repository/RedisTripRequestRepositoryTest.php
+++ b/api/tests/Unit/Repository/RedisTripRequestRepositoryTest.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Repository;
 
+use App\ApiResource\Model\Alert;
 use App\ApiResource\Model\Coordinate;
+use App\ApiResource\Model\WeatherForecast;
 use App\ApiResource\Stage;
 use App\ApiResource\TripRequest;
+use App\Enum\AlertType;
 use App\Llm\Dto\StageAiAnalysis;
 use App\Repository\RedisTripRequestRepository;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
@@ -141,5 +144,69 @@ final class RedisTripRequestRepositoryTest extends TestCase
         $this->cache->expects(self::atLeastOnce())->method('save');
 
         $this->repository->updateStageAiAnalysis($tripId, 2, $analysis);
+    }
+
+    /**
+     * Regression for the persistence race (recette #649): a per-column update must
+     * read the stage fresh and write back only its own column, so it cannot wipe a
+     * sibling column (here: weather) a concurrent enrichment handler already persisted.
+     */
+    #[Test]
+    public function updateStageAlertsPreservesSiblingColumns(): void
+    {
+        $tripId = Uuid::v7()->toRfc4122();
+
+        $stage = new Stage(
+            tripId: $tripId,
+            dayNumber: 1,
+            distance: 50.0,
+            elevation: 200.0,
+            startPoint: new Coordinate(48.0, 2.0),
+            endPoint: new Coordinate(48.1, 2.1),
+        );
+        // A sibling handler (FetchWeather) already wrote weather on this stage.
+        $stage->weather = new WeatherForecast(
+            icon: '10d',
+            description: 'Rain',
+            tempMin: 12.0,
+            tempMax: 18.0,
+            windSpeed: 10.0,
+            windDirection: 'N',
+            precipitationProbability: 80,
+            humidity: 70,
+            comfortIndex: 90,
+            relativeWindDirection: WeatherForecast::RELATIVE_WIND_UNKNOWN,
+        );
+
+        $alert = new Alert(type: AlertType::WARNING, message: 'steep gradient');
+
+        $lock = $this->createMock(SharedLockInterface::class);
+        $lock->expects(self::once())->method('acquire')->with(true)->willReturn(true);
+        $lock->expects(self::once())->method('release');
+        $this->lockFactory->expects(self::once())
+            ->method('createLock')
+            ->with(self::stringContains($tripId), 5)
+            ->willReturn($lock);
+
+        $readItem = $this->createMock(CacheItemInterface::class);
+        $readItem->method('isHit')->willReturn(true);
+        $readItem->method('get')->willReturn([$stage]);
+        $readItem->method('expiresAfter')->willReturnSelf();
+
+        $writeItem = $this->createMock(CacheItemInterface::class);
+        $writeItem->expects(self::once())
+            ->method('set')
+            ->with(self::callback(static fn (array $stages): bool => 1 === \count($stages)
+                // the alert is written...
+                && [$alert] === $stages[0]->alerts
+                // ...without wiping the weather a sibling handler already persisted.
+                && $stages[0]->weather instanceof WeatherForecast
+                && '10d' === $stages[0]->weather->icon));
+        $writeItem->method('expiresAfter')->willReturnSelf();
+
+        $this->cache->method('getItem')->willReturnOnConsecutiveCalls($readItem, $writeItem);
+        $this->cache->expects(self::atLeastOnce())->method('save');
+
+        $this->repository->updateStageAlerts($tripId, 1, [$alert]);
     }
 }


### PR DESCRIPTION
## Contexte (recette #649)

La **météo** et les **hébergements** « disparaissaient » après le calcul d'un voyage. Cause racine (pas les dates, pas le fetch) : une **race « last-writer-wins »** sur la persistance des étapes.

Chaque handler d'enrichissement asynchrone faisait un read-modify-write de **toute la collection** : `getStages()` puis `storeStages()` (`DELETE` + ré-`INSERT` de toutes les lignes). Un handler lent (terrain ~20 s, pois ~60 s+) lisait son snapshot **avant** que la météo soit écrite, puis ré-écrivait ce snapshot périmé à la fin → il écrasait la colonne météo fraîchement persistée. Les alertes survivaient seulement parce que terrain (dernier writer) les ré-écrivait.

## Correctif

UPDATE atomiques par étape **et par colonne** (calqués sur `updateStageAiAnalysis` qui existait déjà), chaque handler n'écrivant que sa colonne :

- `FetchWeather → updateStageWeather`, `AnalyzeTerrain → updateStageAlerts`, `ScanPois → updateStagePois`, `ScanAccommodations → updateStageAccommodations`.
- `AnalyzeTerrain` devient le **seul** writer de la colonne `alerts` persistée ; les alertes lunch/ravito/saisonnier de pois/accommodations restent livrées **en live via Mercure** (comme avant) et ne sont plus persistées par un rewrite global.
- `ScanEvents` n'appelle plus `storeStages` : `events` n'est pas une colonne persistée, il ne faisait que clobber.

Impl Doctrine = `UPDATE` DQL ciblé par colonne JSONB ; impl Redis (tests) = read-modify-write sous verrou. Test de non-régression : écrire les alertes n'efface plus la colonne météo d'un handler frère.

## Vérification

PHPUnit API complet **`OK — 1459 tests, 4338 assertions`** (dont le nouveau test de non-régression). PHPStan Level 9 → CI (OOM en local).

<!-- claude-review-start -->
## Claude Review

Clean implementation. The per-column atomic UPDATE strategy correctly eliminates the last-writer-wins race. All four enrichment handlers now own exactly one JSONB column, `ScanEvents` correctly drops its `storeStages()` call (events were never persisted), and `array_values()` guards both PHPStan narrowing and JSON array serialization in one stroke. The lock-guarded read-modify-write in `RedisTripRequestRepository` faithfully mirrors the existing `updateStageAiAnalysis` pattern, and the regression test directly exercises the original failure mode.

**0 findings.** Resolved 1 previously open thread (dead `$stages[$i]` assignment in `ScanAccommodationsHandler`, removed in commit `917b0d52`).

**PR title check (informational):** The description is in French. Conventional Commits does not mandate English, but the rest of the project commit history uses English. Optional alternative: `fix(api): eliminate the stage enrichment persistence race (recette #649)`.

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Inline comments

No inline comments.

---
*Reviewed commit: `917b0d52ecef5fd427c94f3a865027309f8a1db9`*
<!-- claude-review-end -->