### PR TITLE
fix(pwa): section recommandations culturelles + fin du doublon d'alertes (recette #649)

### DIFF
--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -366,7 +366,8 @@
     "userWaypoint": "User waypoints"
   },
   "stageAlerts": {
-    "heading": "Alerts ({count})"
+    "heading": "Alerts ({count})",
+    "culturalHeading": "Cultural recommendations ({count})"
   },
   "alertGroup": {
     "title": {

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -366,7 +366,8 @@
     "userWaypoint": "Waypoints utilisateur"
   },
   "stageAlerts": {
-    "heading": "Alertes ({count})"
+    "heading": "Alertes ({count})",
+    "culturalHeading": "Recommandations culturelles ({count})"
   },
   "alertGroup": {
     "title": {

--- a/pwa/src/app/(app)/trips/[id]/trip-page.tsx
+++ b/pwa/src/app/(app)/trips/[id]/trip-page.tsx
@@ -111,7 +111,15 @@ function TripLoader({ tripId }: { tripId: string }) {
           startLabel: null,
           endLabel: null,
           weather: (s.weather as StageData["weather"]) ?? null,
-          alerts: (s.alerts as StageData["alerts"]) ?? [],
+          // Tag persisted alerts with their producing group so a later
+          // `terrain_alerts` Mercure event (e.g. after selecting an
+          // accommodation) REPLACES rather than duplicates them. Since #794,
+          // AnalyzeTerrain is the sole writer of the persisted alerts column,
+          // so that group is always "terrain" (recette #649 round 7, #2).
+          alerts: ((s.alerts as StageData["alerts"]) ?? []).map((a) => ({
+            ...a,
+            _group: "terrain",
+          })),
           pois: (s.pois as StageData["pois"]) ?? [],
           accommodations:
             (s.accommodations as StageData["accommodations"]) ?? [],

--- a/pwa/src/components/stage-alerts.tsx
+++ b/pwa/src/components/stage-alerts.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import { useState, useCallback } from "react";
-import { AlertTriangle, ChevronDown, ChevronUp } from "lucide-react";
+import {
+  AlertTriangle,
+  ChevronDown,
+  ChevronUp,
+  Landmark,
+} from "lucide-react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
@@ -14,51 +19,91 @@ interface StageAlertsProps {
 }
 
 /**
- * Section wrapper for the per-stage alerts. The section itself is collapsible
- * (`stage-alerts-toggle`); inside, alerts are rendered by `AlertList`, which
- * groups them by severity (Critical expanded by default; Warning + Nudge
- * collapsed) — see #397.
+ * Per-stage alerts + cultural recommendations. Cultural-POI suggestions arrive
+ * tagged `source: "cultural_poi"` (live via Mercure); they are split out of the
+ * "Alertes" list into a dedicated "Recommandations culturelles" section so they
+ * no longer inflate the alert count (recette #649 round 7). Each section is
+ * collapsible; inside, `AlertList` groups by severity (#397).
  */
 export function StageAlerts({ alerts, onAddPoiWaypoint }: StageAlertsProps) {
   const t = useTranslations("stageAlerts");
-  const [expanded, setExpanded] = useState(true);
+  const [alertsExpanded, setAlertsExpanded] = useState(true);
+  const [culturalExpanded, setCulturalExpanded] = useState(true);
 
-  const toggleExpanded = useCallback(() => setExpanded((prev) => !prev), []);
+  const toggleAlerts = useCallback(() => setAlertsExpanded((p) => !p), []);
+  const toggleCultural = useCallback(() => setCulturalExpanded((p) => !p), []);
+
+  const cultural = alerts.filter((a) => a.source === "cultural_poi");
+  const others = alerts.filter((a) => a.source !== "cultural_poi");
 
   if (alerts.length === 0) return null;
 
   return (
-    <div data-testid="stage-alerts">
-      {/* Section header — mirrors the events panel layout (icon + count). */}
-      <Separator className="mt-4 mb-3" />
-      <Button
-        variant="ghost"
-        className="w-full justify-between px-0 h-auto py-1 text-sm font-medium hover:bg-transparent cursor-pointer"
-        onClick={toggleExpanded}
-        aria-expanded={expanded}
-        data-testid="stage-alerts-toggle"
-      >
-        <span className="flex items-center gap-1.5">
-          <AlertTriangle className="h-4 w-4 text-muted-foreground" />
-          <span data-testid="stage-alerts-count">
-            {t("heading", { count: alerts.length })}
-          </span>
-        </span>
-        {expanded ? (
-          <ChevronUp className="h-4 w-4 text-muted-foreground" />
-        ) : (
-          <ChevronDown className="h-4 w-4 text-muted-foreground" />
-        )}
-      </Button>
+    <>
+      {others.length > 0 && (
+        <div data-testid="stage-alerts">
+          <Separator className="mt-4 mb-3" />
+          <Button
+            variant="ghost"
+            className="w-full justify-between px-0 h-auto py-1 text-sm font-medium hover:bg-transparent cursor-pointer"
+            onClick={toggleAlerts}
+            aria-expanded={alertsExpanded}
+            data-testid="stage-alerts-toggle"
+          >
+            <span className="flex items-center gap-1.5">
+              <AlertTriangle className="h-4 w-4 text-muted-foreground" />
+              <span data-testid="stage-alerts-count">
+                {t("heading", { count: others.length })}
+              </span>
+            </span>
+            {alertsExpanded ? (
+              <ChevronUp className="h-4 w-4 text-muted-foreground" />
+            ) : (
+              <ChevronDown className="h-4 w-4 text-muted-foreground" />
+            )}
+          </Button>
 
-      {/* Collapsible body — alerts are grouped by severity inside. Left
-          padding lines the content up with the header title (past the icon)
-          and right padding gives it breathing room. */}
-      {expanded && (
-        <div className="mt-2 pl-[22px] pr-1" data-testid="stage-alerts-body">
-          <AlertList alerts={alerts} onAddPoiWaypoint={onAddPoiWaypoint} />
+          {alertsExpanded && (
+            <div className="mt-2 pl-[22px] pr-1" data-testid="stage-alerts-body">
+              <AlertList alerts={others} onAddPoiWaypoint={onAddPoiWaypoint} />
+            </div>
+          )}
         </div>
       )}
-    </div>
+
+      {cultural.length > 0 && (
+        <div data-testid="stage-cultural">
+          <Separator className="mt-4 mb-3" />
+          <Button
+            variant="ghost"
+            className="w-full justify-between px-0 h-auto py-1 text-sm font-medium hover:bg-transparent cursor-pointer"
+            onClick={toggleCultural}
+            aria-expanded={culturalExpanded}
+            data-testid="stage-cultural-toggle"
+          >
+            <span className="flex items-center gap-1.5">
+              <Landmark className="h-4 w-4 text-muted-foreground" />
+              <span data-testid="stage-cultural-count">
+                {t("culturalHeading", { count: cultural.length })}
+              </span>
+            </span>
+            {culturalExpanded ? (
+              <ChevronUp className="h-4 w-4 text-muted-foreground" />
+            ) : (
+              <ChevronDown className="h-4 w-4 text-muted-foreground" />
+            )}
+          </Button>
+
+          {culturalExpanded && (
+            <div
+              className="mt-2 pl-[22px] pr-1"
+              data-testid="stage-cultural-body"
+            >
+              <AlertList alerts={cultural} onAddPoiWaypoint={onAddPoiWaypoint} />
+            </div>
+          )}
+        </div>
+      )}
+    </>
   );
 }

--- a/pwa/src/hooks/use-mercure.ts
+++ b/pwa/src/hooks/use-mercure.ts
@@ -668,7 +668,11 @@ function enrichedPayloadToStageData(payload: EnrichedStagePayload): StageData {
     startLabel: null,
     endLabel: null,
     weather: payload.weather,
-    alerts: payload.alerts,
+    // Tag with the producing group so a later terrain_alerts event REPLACES
+    // (not duplicates) these. AnalyzeTerrain is the sole writer of the persisted
+    // alerts column since #794 (recette #649 round 7, #2; mirrors the trip-page
+    // hydrate). Covers stages_computed / trip_ready / stage_updated payloads.
+    alerts: (payload.alerts ?? []).map((a) => ({ ...a, _group: "terrain" })),
     pois: payload.pois,
     accommodations: payload.accommodations,
     selectedAccommodation: payload.selectedAccommodation,

--- a/pwa/src/store/trip-store.test.ts
+++ b/pwa/src/store/trip-store.test.ts
@@ -294,4 +294,27 @@ describe("applyStageUpdate preservation (recette #649)", () => {
     const result = useTripStore.getState().stages[0]!;
     expect(result.alerts[0]?.message).toBe("new");
   });
+
+  it("preserves cultural-POI recommendations when the endpoint moved (recette #649)", () => {
+    const store = useTripStore.getState();
+    const cultural: AlertData = {
+      ...makeAlert("Visit the abbey"),
+      source: "cultural_poi",
+    };
+    const current = makeStage(1);
+    current.alerts = [cultural, makeAlert("old terrain")];
+    store.setStages([current]);
+
+    // Accommodation selection re-routes the stage (endpoint moves) and carries a
+    // terrain-only payload; the cultural recommendation must not vanish.
+    const incoming = makeStage(1);
+    incoming.endPoint = { lat: 9, lon: 9, ele: 0 };
+    incoming.alerts = [makeAlert("new terrain")];
+    store.applyStageUpdate(0, incoming);
+
+    const result = useTripStore.getState().stages[0]!;
+    expect(result.alerts.some((a) => a.source === "cultural_poi")).toBe(true);
+    expect(result.alerts.some((a) => a.message === "new terrain")).toBe(true);
+    expect(result.alerts.some((a) => a.message === "old terrain")).toBe(false);
+  });
 });

--- a/pwa/src/store/trip-store.ts
+++ b/pwa/src/store/trip-store.ts
@@ -728,7 +728,18 @@ export const useTripStore = create<TripState>()(
             ? (prev.selectedAccommodation ?? stage.selectedAccommodation)
             : stage.selectedAccommodation,
           alerts:
-            endMatch && prev.alerts.length > 0 ? prev.alerts : stage.alerts,
+            endMatch && prev.alerts.length > 0
+              ? prev.alerts
+              : [
+                  // Cultural-POI recommendations come from a separate scan and
+                  // are absent from this terrain-only payload, so a bare replace
+                  // on reroute (e.g. accommodation selection moves the endpoint)
+                  // would make the dedicated "cultural recommendations" section
+                  // vanish. Preserve them from `prev`, take the rest from the
+                  // incoming payload (recette #649).
+                  ...prev.alerts.filter((a) => a.source === "cultural_poi"),
+                  ...stage.alerts.filter((a) => a.source !== "cultural_poi"),
+                ],
         };
       }),
 


### PR DESCRIPTION
## Contexte (recette #649, round 7)

**#1 — Recommandations culturelles dans une section dédiée.** Les POI culturels (`source: "cultural_poi"`, poussés en alertes `nudge` via Mercure) étaient mélangés dans la liste « Alertes » et gonflaient le compteur. Ils sont désormais sortis dans une section dédiée **« Recommandations culturelles »** (`StageAlerts`), avec leur propre compteur ; la liste « Alertes » ne contient plus que les vraies alertes terrain/surface.

**#2 — Doublon d'alertes après sélection d'un hébergement** (« Alertes (10) » au lieu de 5). Cause : les alertes **hydratées** au chargement du trip (`trip-page.tsx`) n'étaient pas taguées (`_group` absent) ; `updateStageAlerts` remplace les alertes par `_group`, donc l'event `terrain_alerts` (déclenché par le recompute de la sélection d'hébergement) **s'ajoutait** par-dessus au lieu de remplacer → ×2. Fix : taguer les alertes hydratées `_group: "terrain"` (depuis #794, `AnalyzeTerrain` est le seul writer de la colonne `alerts` persistée), pour que l'event live les remplace proprement. Régression aiguisée par #794.

## Vérification

`tsc` OK (aucune erreur dans les fichiers modifiés) ; clé i18n `culturalHeading` ajoutée fr + en (catalogues équilibrés). Legs complets en CI.

<!-- claude-review-start -->
## Claude Review

**Commit reviewed:** `375b34285f6584a77dce3c319f763c146a15492b`

All findings from the previous review have been addressed. The third commit closes the `applyStageUpdate` correctness gap (cultural POIs vanishing on reroute) and adds a unit test covering the exact failure path. Code is clean, architecture-compliant, and correct.

**Findings:** 0 critical / 0 warnings / 1 hint (no inline comments).

**Resolved threads:** 1 previously open bot thread was already resolved before this review pass (the `enrichedPayloadToStageData` `_group` gap, addressed by commit `9b351b6f`).

**Hint — E2E coverage for the `stage-cultural` section:** The new sidebar section (`stage-cultural`, `stage-cultural-count`, `stage-cultural-body` testids) has no Playwright test that injects a `cultural_poi_alerts` event and verifies the section renders. The fixture `culturalPoiAlertsEvent()` already exists in `mock-data.ts` and is used by `map.spec.ts` for the popover tests — a similar test in `actionable-alerts.spec.ts` would close the gap. Not a blocker given the unit test coverage of the store logic.

**Review checklist**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases — unit test added for `applyStageUpdate` cultural-POI preservation
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

No inline comments.
<!-- claude-review-end -->