### PR TITLE
fix(pwa): localise per-day roadbook dates + restore shared-view footer (recette #649)

### DIFF
--- a/pwa/src/app/s/[code]/shared-trip-page.tsx
+++ b/pwa/src/app/s/[code]/shared-trip-page.tsx
@@ -13,6 +13,7 @@ import { ViewModeToggle } from "@/components/ViewModeToggle";
 import { HydrationBoundary } from "@/components/hydration-boundary";
 import { SharedTopBar } from "@/components/shared-top-bar";
 import { SharedViewBanner } from "@/components/shared-view-banner";
+import { LandingFooter } from "@/components/landing/footer";
 import { fetchSharedTrip } from "@/lib/api/client";
 import { ShareProvider } from "@/lib/share-context";
 import { useUiStore } from "@/store/ui-store";
@@ -305,6 +306,10 @@ function SharedTripLoader({ code }: { code: string }) {
           </div>
         </div>
       </main>
+
+      {/* Site footer — the shared view uses SharedTopBar (not SiteChrome), so
+          the homepage footer must be rendered explicitly here (recette #649). */}
+      <LandingFooter />
     </ShareProvider>
   );
 }

--- a/pwa/src/components/Timeline/StageDetailPanel.test.ts
+++ b/pwa/src/components/Timeline/StageDetailPanel.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { formatDayDate } from "./StageDetailPanel";
+
+describe("formatDayDate (recette #649 #6)", () => {
+  it("formats the day date in English", () => {
+    expect(formatDayDate("2026-07-12", 1, "en")).toBe("Sunday 12 July 2026");
+  });
+
+  it("formats the day date in French", () => {
+    expect(formatDayDate("2026-07-12", 1, "fr")).toBe(
+      "dimanche 12 juillet 2026",
+    );
+  });
+
+  it("offsets the date by the day number", () => {
+    expect(formatDayDate("2026-07-12", 3, "en")).toBe("Tuesday 14 July 2026");
+  });
+});

--- a/pwa/src/components/Timeline/StageDetailPanel.tsx
+++ b/pwa/src/components/Timeline/StageDetailPanel.tsx
@@ -50,7 +50,8 @@ interface StageDetailPanelProps {
   onClearNewAcc?: () => void;
 }
 
-function formatDayDate(
+// Exported for unit testing the locale-aware formatting (recette #649 #6).
+export function formatDayDate(
   startDate: string | null,
   dayNumber: number,
   locale: string,

--- a/pwa/src/components/Timeline/StageDetailPanel.tsx
+++ b/pwa/src/components/Timeline/StageDetailPanel.tsx
@@ -1,7 +1,10 @@
 "use client";
 
 import { useCallback, useEffect, useRef } from "react";
-import { useTranslations } from "next-intl";
+import { useTranslations, useLocale } from "next-intl";
+import dayjs from "dayjs";
+import "dayjs/locale/fr";
+import "dayjs/locale/en";
 import { StageCard } from "@/components/stage-card";
 import { StagePanelSkeleton } from "@/components/stage-panel-skeleton";
 import { StageSkeleton } from "@/components/stage-skeleton";
@@ -47,16 +50,16 @@ interface StageDetailPanelProps {
   onClearNewAcc?: () => void;
 }
 
-function formatDayDate(startDate: string | null, dayNumber: number): string {
-  const base = startDate ? new Date(`${startDate}T00:00:00`) : new Date();
-  const date = new Date(base);
-  date.setDate(date.getDate() + dayNumber - 1);
-  return date.toLocaleDateString(undefined, {
-    weekday: "long",
-    day: "numeric",
-    month: "long",
-    year: "numeric",
-  });
+function formatDayDate(
+  startDate: string | null,
+  dayNumber: number,
+  locale: string,
+): string {
+  const base = startDate ? dayjs(`${startDate}T00:00:00`) : dayjs();
+  return base
+    .add(dayNumber - 1, "day")
+    .locale(locale)
+    .format("dddd D MMMM YYYY");
 }
 
 /**
@@ -88,6 +91,7 @@ export function StageDetailPanel({
   onClearNewAcc,
 }: StageDetailPanelProps) {
   const tStage = useTranslations("stage");
+  const locale = useLocale();
   const recomputingStages = useTripStore((s) => s.recomputingStages);
   const setSelectedStageIndex = useTripStore((s) => s.setSelectedStageIndex);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -228,7 +232,7 @@ export function StageDetailPanel({
                 {tStage("day", { dayNumber: stage.dayNumber })}
               </h2>
               <span className="text-xs md:text-sm text-muted-foreground">
-                {formatDayDate(startDate, stage.dayNumber)}
+                {formatDayDate(startDate, stage.dayNumber, locale)}
               </span>
             </header>
 

--- a/pwa/tests/mocked/share-page.spec.ts
+++ b/pwa/tests/mocked/share-page.spec.ts
@@ -92,6 +92,9 @@ test.describe("/s/[code] page", () => {
 
     // Read-only banner
     await expect(page.getByTestId("read-only-banner")).toBeVisible();
+
+    // Footer restored in the shared view (recette #649 fix #4).
+    await expect(page.getByTestId("section-footer")).toBeVisible();
   });
 
   test("shows error state for an invalid short code", async ({ page }) => {


### PR DESCRIPTION
## Recette #649 — round 7

Two independent display fixes from the round-7 batch.

### #6 — Per-day roadbook dates not translated

`formatDayDate` in `Timeline/StageDetailPanel.tsx` used `toLocaleDateString(undefined, ...)`, which ignores the app locale, so the per-day headings ("dimanche 12 juillet 2026") stayed in French under the EN locale. Switched to `dayjs().locale(useLocale()).format("dddd D MMMM YYYY")`, matching the rest of the date rendering (`trip-summary`, `trip-card`, `recent-trips`).

### #4 — Footer missing in the shared view

The rest of the app gets its footer from `SiteChrome` (`<LandingFooter/>`), but the shared trip view (`/s/[code]`) uses `SharedTopBar` instead of `SiteChrome`, so no footer was ever mounted. Render `<LandingFooter/>` explicitly after `</main>` in the loaded branch.

## Verification

Local (host toolchain, dev Docker stack not up — recette `pwa:ci` image has no dev deps):

- `tsc --noEmit`: 0 source errors (only stale `.next/types` route-type artifacts, absent in CI)
- `eslint` on both files: clean (exit 0)
- `prettier --check` on both files: clean

No i18n keys added/removed (footer reuses `landing.footer.*`; date format uses no message key).

<!-- claude-review-start -->
## Claude Review

Reviewed commit `ad0315b8274a6ac23c897eab4b41d616ddc41385`.

All findings from the previous review have been addressed: `formatDayDate` is now exported and covered by a Vitest unit test (`StageDetailPanel.test.ts`) with EN/FR/offset cases, and the shared-view Playwright spec now asserts `section-footer` is visible. The implementation is clean — no security, performance, or architecture concerns.

**Findings:** 0 critical · 0 warnings · 0 suggestions

Resolved 2 previously open threads that were addressed.

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Inline comments

No inline comments.
<!-- claude-review-end -->