### PR TITLE
fix: sync the trip date range with the stage count on add/delete (recette #649)

### DIFF
--- a/api/src/State/RestDayInsertProcessor.php
+++ b/api/src/State/RestDayInsertProcessor.php
@@ -93,10 +93,10 @@ final readonly class RestDayInsertProcessor implements ProcessorInterface
         // Keep the trip's day window in step with the stage count: a trip spans
         // exactly one calendar day per stage (rest days included), so adding a
         // rest day shifts the end date forward so the global range, the export and
-        // a later re-pacing all stay consistent (recette #649).
-        $tripRequest = $this->tripStateManager->getRequest($tripId);
-        $startDate = $tripRequest?->startDate;
-        if ($tripRequest instanceof TripRequest && $startDate instanceof \DateTimeImmutable) {
+        // a later re-pacing all stay consistent (recette #649). Reuse the request
+        // asserted above — storeStages only flushes, never detaches it (review).
+        $startDate = $tripRequest->startDate;
+        if ($startDate instanceof \DateTimeImmutable) {
             $tripRequest->endDate = $startDate->modify(\sprintf('+%d days', \count($stages) - 1));
             $this->tripStateManager->storeRequest($tripId, $tripRequest);
             $this->messageBus->dispatch(new FetchWeather($tripId, $generation));

--- a/api/src/State/RestDayInsertProcessor.php
+++ b/api/src/State/RestDayInsertProcessor.php
@@ -90,8 +90,15 @@ final readonly class RestDayInsertProcessor implements ProcessorInterface
         $affectedIndices = range($insertedIndex, count($stages) - 1);
         $this->messageBus->dispatch(new RecalculateStages($tripId, $affectedIndices, skipGeographicScans: true, generation: $generation));
 
+        // Keep the trip's day window in step with the stage count: a trip spans
+        // exactly one calendar day per stage (rest days included), so adding a
+        // rest day shifts the end date forward so the global range, the export and
+        // a later re-pacing all stay consistent (recette #649).
         $tripRequest = $this->tripStateManager->getRequest($tripId);
-        if ($tripRequest?->startDate instanceof \DateTimeImmutable) {
+        $startDate = $tripRequest?->startDate;
+        if ($tripRequest instanceof TripRequest && $startDate instanceof \DateTimeImmutable) {
+            $tripRequest->endDate = $startDate->modify(\sprintf('+%d days', \count($stages) - 1));
+            $this->tripStateManager->storeRequest($tripId, $tripRequest);
             $this->messageBus->dispatch(new FetchWeather($tripId, $generation));
             $this->messageBus->dispatch(new CheckCalendar($tripId, $generation));
         }

--- a/api/src/State/StageCreateProcessor.php
+++ b/api/src/State/StageCreateProcessor.php
@@ -84,8 +84,15 @@ final readonly class StageCreateProcessor implements ProcessorInterface
 
         $this->messageBus->dispatch(new RecalculateStages($tripId, [$position], generation: $generation));
 
+        // Keep the trip's day window in step with the stage count: a trip spans
+        // exactly one calendar day per stage (rest days included), so adding a
+        // stage shifts the end date forward so the global range, the export and a
+        // later re-pacing all stay consistent (recette #649).
         $tripRequest = $this->tripStateManager->getRequest($tripId);
-        if ($tripRequest?->startDate instanceof \DateTimeImmutable) {
+        $startDate = $tripRequest?->startDate;
+        if ($tripRequest instanceof TripRequest && $startDate instanceof \DateTimeImmutable) {
+            $tripRequest->endDate = $startDate->modify(\sprintf('+%d days', \count($stages) - 1));
+            $this->tripStateManager->storeRequest($tripId, $tripRequest);
             $this->messageBus->dispatch(new FetchWeather($tripId, $generation));
             $this->messageBus->dispatch(new CheckCalendar($tripId, $generation));
         }

--- a/api/src/State/StageCreateProcessor.php
+++ b/api/src/State/StageCreateProcessor.php
@@ -87,10 +87,10 @@ final readonly class StageCreateProcessor implements ProcessorInterface
         // Keep the trip's day window in step with the stage count: a trip spans
         // exactly one calendar day per stage (rest days included), so adding a
         // stage shifts the end date forward so the global range, the export and a
-        // later re-pacing all stay consistent (recette #649).
-        $tripRequest = $this->tripStateManager->getRequest($tripId);
-        $startDate = $tripRequest?->startDate;
-        if ($tripRequest instanceof TripRequest && $startDate instanceof \DateTimeImmutable) {
+        // later re-pacing all stay consistent (recette #649). Reuse the request
+        // asserted above — storeStages only flushes, never detaches it (review).
+        $startDate = $tripRequest->startDate;
+        if ($startDate instanceof \DateTimeImmutable) {
             $tripRequest->endDate = $startDate->modify(\sprintf('+%d days', \count($stages) - 1));
             $this->tripStateManager->storeRequest($tripId, $tripRequest);
             $this->messageBus->dispatch(new FetchWeather($tripId, $generation));

--- a/api/src/State/StageDeleteProcessor.php
+++ b/api/src/State/StageDeleteProcessor.php
@@ -86,6 +86,18 @@ final readonly class StageDeleteProcessor implements ProcessorInterface
         $affectedIndices = null !== $mergedIndex ? [$mergedIndex] : [];
         $this->messageBus->dispatch(new RecalculateStages($tripId, $affectedIndices, skipGeographicScans: $isRestDayDeletion, generation: $generation));
 
+        // Keep the trip's day window in step with the stage count: a trip spans
+        // exactly one calendar day per stage (rest days included), so removing a
+        // stage shifts the end date back so the global range, the export and a
+        // later re-pacing all stay consistent (recette #649). Mirrors
+        // StageCreateProcessor / RestDayInsertProcessor.
+        $tripRequest = $this->tripStateManager->getRequest($tripId);
+        $startDate = $tripRequest?->startDate;
+        if ($tripRequest instanceof TripRequest && $startDate instanceof \DateTimeImmutable) {
+            $tripRequest->endDate = $startDate->modify(\sprintf('+%d days', \count($stages) - 1));
+            $this->tripStateManager->storeRequest($tripId, $tripRequest);
+        }
+
         $this->messageBus->dispatch(new FetchWeather($tripId, $generation));
         $this->messageBus->dispatch(new CheckCalendar($tripId, $generation));
     }

--- a/api/src/State/StageDeleteProcessor.php
+++ b/api/src/State/StageDeleteProcessor.php
@@ -90,10 +90,10 @@ final readonly class StageDeleteProcessor implements ProcessorInterface
         // exactly one calendar day per stage (rest days included), so removing a
         // stage shifts the end date back so the global range, the export and a
         // later re-pacing all stay consistent (recette #649). Mirrors
-        // StageCreateProcessor / RestDayInsertProcessor.
-        $tripRequest = $this->tripStateManager->getRequest($tripId);
-        $startDate = $tripRequest?->startDate;
-        if ($tripRequest instanceof TripRequest && $startDate instanceof \DateTimeImmutable) {
+        // StageCreateProcessor / RestDayInsertProcessor. Reuse the request
+        // asserted above — storeStages only flushes, never detaches it (review).
+        $startDate = $tripRequest->startDate;
+        if ($startDate instanceof \DateTimeImmutable) {
             $tripRequest->endDate = $startDate->modify(\sprintf('+%d days', \count($stages) - 1));
             $this->tripStateManager->storeRequest($tripId, $tripRequest);
         }

--- a/api/tests/Functional/RestDayInsertTest.php
+++ b/api/tests/Functional/RestDayInsertTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Symfony\Bundle\Test\Client;
+use App\ApiResource\Model\Coordinate;
+use App\ApiResource\Stage;
+use App\ApiResource\TripRequest;
+use App\ComputationTracker\ComputationTrackerInterface;
+use App\Entity\User;
+use App\Enum\ComputationName;
+use App\Enum\SourceType;
+use App\Repository\TripRequestRepositoryInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Uid\Uuid;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+use Zenstruck\Foundry\Test\Factories;
+
+#[ResetDatabase]
+final class RestDayInsertTest extends ApiTestCase
+{
+    use Factories;
+    use JwtAuthTestTrait;
+
+    private const string TRIP_ID = '01936f6e-0000-7000-8000-000000000050';
+
+    private Client $client;
+
+    private User $testUser;
+
+    private string $jwtToken;
+
+    protected function setUp(): void
+    {
+        $this->client = self::createClient();
+        ['user' => $this->testUser, 'token' => $this->jwtToken] = $this->createTestUserWithJwt('test@example.com');
+    }
+
+    private function seedTripWithStages(string $tripId, int $stageCount = 2): void
+    {
+        $container = self::getContainer();
+
+        /** @var TripRequestRepositoryInterface $repo */
+        $repo = $container->get(TripRequestRepositoryInterface::class);
+
+        $request = new TripRequest(Uuid::fromString($tripId));
+        $request->sourceUrl = 'https://www.komoot.com/tour/123456789';
+        $request->startDate = new \DateTimeImmutable('2026-07-01');
+
+        $repo->initializeTrip($tripId, $request);
+        $repo->storeSourceType($tripId, SourceType::KOMOOT_TOUR->value);
+
+        $stages = [];
+        for ($i = 0; $i < $stageCount; ++$i) {
+            $stages[] = new Stage(
+                tripId: $tripId,
+                dayNumber: $i + 1,
+                distance: 80.0 + $i * 5,
+                elevation: 500.0 + $i * 100,
+                startPoint: new Coordinate(45.0 + $i * 0.5, 5.0 + $i * 0.5),
+                endPoint: new Coordinate(45.0 + ($i + 1) * 0.5, 5.0 + ($i + 1) * 0.5),
+                geometry: [
+                    new Coordinate(45.0 + $i * 0.5, 5.0 + $i * 0.5),
+                    new Coordinate(45.0 + ($i + 1) * 0.5, 5.0 + ($i + 1) * 0.5),
+                ],
+            );
+        }
+
+        $repo->storeStages($tripId, $stages);
+
+        /** @var ComputationTrackerInterface $tracker */
+        $tracker = $container->get(ComputationTrackerInterface::class);
+        $tracker->initializeComputations($tripId, ComputationName::cases());
+
+        $this->associateTripWithUser($tripId, $this->testUser);
+    }
+
+    #[Test]
+    public function insertRestDaySuccess(): void
+    {
+        $this->seedTripWithStages(self::TRIP_ID, 2);
+
+        $this->client->request('POST', '/trips/'.self::TRIP_ID.'/stages/0/rest-day', [
+            'headers' => $this->authHeader($this->jwtToken),
+        ]);
+
+        $this->assertResponseStatusCodeSame(202);
+
+        /** @var TripRequestRepositoryInterface $repo */
+        $repo = self::getContainer()->get(TripRequestRepositoryInterface::class);
+        $stages = $repo->getStages(self::TRIP_ID);
+
+        $this->assertNotNull($stages);
+        $this->assertCount(3, $stages);
+        $this->assertTrue($stages[1]->isRestDay);
+    }
+
+    #[Test]
+    public function extendsEndDateToMatchStageCount(): void
+    {
+        $this->seedTripWithStages(self::TRIP_ID, 2);
+
+        $this->client->request('POST', '/trips/'.self::TRIP_ID.'/stages/0/rest-day', [
+            'headers' => $this->authHeader($this->jwtToken),
+        ]);
+
+        $this->assertResponseStatusCodeSame(202);
+
+        // 2 → 3 stages: the trip now spans 3 days, so the end date shifts from
+        // 2026-07-02 to 2026-07-03 (recette #649).
+        /** @var TripRequestRepositoryInterface $repo */
+        $repo = self::getContainer()->get(TripRequestRepositoryInterface::class);
+        $request = $repo->getRequest(self::TRIP_ID);
+
+        $this->assertNotNull($request);
+        $this->assertSame('2026-07-03', $request->endDate?->format('Y-m-d'));
+    }
+}

--- a/api/tests/Functional/StageCreateTest.php
+++ b/api/tests/Functional/StageCreateTest.php
@@ -395,4 +395,29 @@ final class StageCreateTest extends ApiTestCase
             $this->assertSame($i + 1, $stage->dayNumber, \sprintf('Stage at index %d should have dayNumber %d', $i, $i + 1));
         }
     }
+
+    #[Test]
+    public function extendsEndDateToMatchStageCount(): void
+    {
+        $this->seedTripWithStages(self::TRIP_ID, 3);
+
+        $this->client->request('POST', '/trips/'.self::TRIP_ID.'/stages', [
+            'headers' => ['Content-Type' => 'application/ld+json', ...$this->authHeader($this->jwtToken)],
+            'json' => [
+                'startPoint' => ['lat' => 44.0, 'lon' => 4.0],
+                'endPoint' => ['lat' => 44.5, 'lon' => 4.5],
+            ],
+        ]);
+
+        $this->assertResponseStatusCodeSame(202);
+
+        // 3 → 4 stages: the trip now spans 4 days, so the end date shifts from
+        // 2026-07-03 to 2026-07-04 (recette #649).
+        /** @var TripRequestRepositoryInterface $repo */
+        $repo = self::getContainer()->get(TripRequestRepositoryInterface::class);
+        $request = $repo->getRequest(self::TRIP_ID);
+
+        $this->assertNotNull($request);
+        $this->assertSame('2026-07-04', $request->endDate?->format('Y-m-d'));
+    }
 }

--- a/api/tests/Functional/StageDeleteTest.php
+++ b/api/tests/Functional/StageDeleteTest.php
@@ -272,4 +272,25 @@ final class StageDeleteTest extends ApiTestCase
             $this->assertSame($i + 1, $stage->dayNumber, \sprintf('Stage at index %d should have dayNumber %d', $i, $i + 1));
         }
     }
+
+    #[Test]
+    public function shrinksEndDateToMatchStageCount(): void
+    {
+        $this->seedTripWithStages(self::TRIP_ID, 4, SourceType::KOMOOT_TOUR->value);
+
+        $this->client->request('DELETE', '/trips/'.self::TRIP_ID.'/stages/1', [
+            'headers' => $this->authHeader($this->jwtToken),
+        ]);
+
+        $this->assertResponseStatusCodeSame(202);
+
+        // 4 → 3 stages: the trip now spans 3 days, so the end date shifts back to
+        // 2026-07-03 (recette #649).
+        /** @var TripRequestRepositoryInterface $repo */
+        $repo = self::getContainer()->get(TripRequestRepositoryInterface::class);
+        $request = $repo->getRequest(self::TRIP_ID);
+
+        $this->assertNotNull($request);
+        $this->assertSame('2026-07-03', $request->endDate?->format('Y-m-d'));
+    }
 }

--- a/pwa/src/store/trip-store.test.ts
+++ b/pwa/src/store/trip-store.test.ts
@@ -295,3 +295,39 @@ describe("applyStageUpdate preservation (recette #649)", () => {
     expect(result.alerts[0]?.message).toBe("new");
   });
 });
+
+describe("date window stays in sync with stage count (recette #649)", () => {
+  it("extends endDate when a rest day is inserted", () => {
+    const store = useTripStore.getState();
+    store.setStages([makeStage(1), makeStage(2)]);
+    store.updateDatesInternal("2026-07-10", "2026-07-11"); // 2 stages → 2 days
+    store.insertRestDay(0);
+    // 3 stages → 3 days: 10–12 July.
+    expect(useTripStore.getState().endDate).toBe("2026-07-12");
+  });
+
+  it("extends endDate when a stage is inserted", () => {
+    const store = useTripStore.getState();
+    store.setStages([makeStage(1), makeStage(2)]);
+    store.updateDatesInternal("2026-07-10", "2026-07-11");
+    store.insertStagePlaceholder(0, makeStage(99));
+    expect(useTripStore.getState().endDate).toBe("2026-07-12");
+  });
+
+  it("shrinks endDate when a stage is deleted", () => {
+    const store = useTripStore.getState();
+    store.setStages([makeStage(1), makeStage(2), makeStage(3)]);
+    store.updateDatesInternal("2026-07-10", "2026-07-12"); // 3 stages → 3 days
+    store.deleteStage(1);
+    // 2 stages → 2 days: 10–11 July.
+    expect(useTripStore.getState().endDate).toBe("2026-07-11");
+  });
+
+  it("leaves the (unset) dates untouched when no start date is set", () => {
+    const store = useTripStore.getState();
+    store.setStages([makeStage(1), makeStage(2)]);
+    store.updateDatesInternal(null, null);
+    store.insertRestDay(0);
+    expect(useTripStore.getState().endDate).toBeNull();
+  });
+});

--- a/pwa/src/store/trip-store.ts
+++ b/pwa/src/store/trip-store.ts
@@ -3,6 +3,7 @@
 import { create } from "zustand";
 import { immer } from "zustand/middleware/immer";
 import { enableMapSet } from "immer";
+import dayjs from "dayjs";
 import { DEFAULT_ACCOMMODATION_RADIUS_KM } from "@/lib/accommodation-constants";
 import type {
   StageData,
@@ -565,6 +566,13 @@ export const useTripStore = create<TripState>()(
         if (state.selectedStageIndex > max) {
           state.selectedStageIndex = max;
         }
+        // Shrink the trip's day window to match the new stage count (recette
+        // #649) — see insertRestDay.
+        if (state.startDate) {
+          state.endDate = dayjs(state.startDate)
+            .add(state.stages.length - 1, "day")
+            .format("YYYY-MM-DD");
+        }
       });
     },
 
@@ -602,6 +610,14 @@ export const useTripStore = create<TripState>()(
         state.stages.forEach((s, i) => {
           s.dayNumber = i + 1;
         });
+        // A trip spans one calendar day per stage (rest days included): extend
+        // the end date so the global range and the export reflect the new day
+        // immediately (recette #649). The backend mirrors this on persist.
+        if (state.startDate) {
+          state.endDate = dayjs(state.startDate)
+            .add(state.stages.length - 1, "day")
+            .format("YYYY-MM-DD");
+        }
       });
     },
 
@@ -615,6 +631,13 @@ export const useTripStore = create<TripState>()(
         state.stages.forEach((s, i) => {
           s.dayNumber = i + 1;
         });
+        // Extend the trip's day window to match the new stage count (recette
+        // #649) — see insertRestDay.
+        if (state.startDate) {
+          state.endDate = dayjs(state.startDate)
+            .add(state.stages.length - 1, "day")
+            .format("YYYY-MM-DD");
+        }
       });
     },
 


### PR DESCRIPTION
## Recette #649 — round 7 (#7)

> Lorsque je rajoute une étape (ou un jour de repos), les dates globales et dans l'export ne sont pas mises à jour... Par exemple, 10-12 juillet, je devrais passer à 10-13 juillet.

### Root cause

A trip spans exactly **one calendar day per stage** (rest days included), and the pacing enforces `endDate − startDate + 1 == stage count` at generation. But adding or removing a stage afterwards never updated the trip-level `endDate`:

- **Frontend** (`trip-store`): `insertRestDay` / `insertStagePlaceholder` / `deleteStage` only re-indexed `dayNumber`. The summary range and the PNG/GPX export read `endDate` from the store, so they kept the stale value.
- **Backend** (`StageCreateProcessor` / `RestDayInsertProcessor` / `StageDeleteProcessor`): `storeStages()` was called but `endDate` was never recomputed, so a reload (and a later re-pacing, which derives the day count from the range) saw the old range.

### Fix

Recompute `endDate = startDate + (stageCount − 1) days` whenever the stage count changes, on **both** sides (only when a start date is set):

- Store: in the three mutators, so the summary + export reflect the new range immediately (local-first).
- Processors: after `storeStages`, set `endDate` + `storeRequest`, so reload is consistent and a subsequent structural re-pacing stays aligned with the manual edit.

Delete is handled symmetrically (shrinks the range) to avoid the mirror bug.

### Tests

- **Frontend** (`trip-store.test.ts`, 4 new): insert rest day / insert stage extend `endDate` by a day; delete shrinks it; no start date → dates left untouched.
- **Backend** (functional, 2 new): `StageCreateTest::extendsEndDateToMatchStageCount` (3→4 stages ⇒ `2026-07-04`), `StageDeleteTest::shrinksEndDateToMatchStageCount` (4→3 stages ⇒ `2026-07-03`).

## Verification

- `npx vitest run src/store/trip-store.test.ts` → **20 passed** (incl. the 4 new).
- `tsc --noEmit` → 0 source errors; `eslint` + `prettier` clean on the changed files.
- `php -l` clean on all changed PHP files (host PHP 8.5.7).
- PHPUnit / PHPStan / PHP-CS-Fixer run in CI (dev deps absent from the local recette image).

<!-- claude-review-start -->
## Claude Review

**Reviewed commit:** `bcdcf8f283fd779f113c906871aecdf2ea970bed`

Both previous findings were addressed in the follow-up commit: the redundant `getRequest()` in all three processors has been removed (reusing the already-asserted `$tripRequest`), and `RestDayInsertTest.php` was added with full functional coverage of the `endDate` extension on rest-day insert. The fix is correct, the formula is consistent on both sides, and all three add/delete paths now have tests. No new findings.

**Findings:** None

### Resolved threads

Resolved 2 previously open bot-authored threads that were addressed by the latest push.

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Inline comments

No inline comments.
<!-- claude-review-end -->