### PR TITLE
feat: persist reverse-geocoded stage labels server-side for the shared view + reloads (recette #649)

### DIFF
--- a/api/config/packages/messenger.php
+++ b/api/config/packages/messenger.php
@@ -19,6 +19,7 @@ use App\Message\FetchWeather;
 use App\Message\GenerateStages;
 use App\Message\RecalculateRouteSegment;
 use App\Message\RecalculateStages;
+use App\Message\ResolveStageLabels;
 use App\Message\ScanAccommodations;
 use App\Message\ScanEvents;
 use App\Message\ScanPois;
@@ -79,6 +80,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 CheckWaterPoints::class => 'async',
                 RecalculateRouteSegment::class => 'async',
                 RecalculateStages::class => 'async',
+                ResolveStageLabels::class => 'async',
                 ScanEvents::class => 'async',
                 AllEnrichmentsCompleted::class => 'async',
                 AnalyzeStageWithLlmMessage::class => 'llm',

--- a/api/migrations/Version20260627120000.php
+++ b/api/migrations/Version20260627120000.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Recette #649 (#3c / #9): persist reverse-geocoded stage endpoint labels.
+ *
+ * Adds `stage.start_label` / `stage.end_label` (city names) so the anonymous
+ * shared view — which cannot call the auth-gated /geocode endpoint — and a
+ * reloaded trip both render city names instead of raw GPS coordinates.
+ * Existing rows keep NULL until the next structural recompute resolves them.
+ */
+final class Version20260627120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Persist reverse-geocoded stage endpoint labels (start_label / end_label) (recette #649)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE stage ADD start_label VARCHAR(255) DEFAULT NULL');
+        $this->addSql('ALTER TABLE stage ADD end_label VARCHAR(255) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE stage DROP start_label');
+        $this->addSql('ALTER TABLE stage DROP end_label');
+    }
+}

--- a/api/src/ApiResource/Stage.php
+++ b/api/src/ApiResource/Stage.php
@@ -171,6 +171,18 @@ final class Stage
     #[ApiProperty(writable: false)]
     public float $onCycleNetwork = 0.0;
 
+    /**
+     * Reverse-geocoded city names for the stage endpoints (recette #649, #3c/#9),
+     * resolved server-side and persisted so the anonymous shared view and a
+     * reloaded trip render city names instead of raw GPS coordinates. Readable
+     * (the frontend consumes them) but never writable.
+     */
+    #[ApiProperty(writable: false)]
+    public ?string $startLabel = null;
+
+    #[ApiProperty(writable: false)]
+    public ?string $endLabel = null;
+
     /** @var Event[] */
     public array $events = [];
 

--- a/api/src/ApiResource/TripDetail.php
+++ b/api/src/ApiResource/TripDetail.php
@@ -80,6 +80,8 @@ final readonly class TripDetail
                     'endPoint' => ['type' => 'object', 'properties' => ['lat' => ['type' => 'number'], 'lon' => ['type' => 'number'], 'ele' => ['type' => 'number']]],
                     'geometry' => ['type' => 'array', 'items' => ['type' => 'object', 'properties' => ['lat' => ['type' => 'number'], 'lon' => ['type' => 'number'], 'ele' => ['type' => 'number']]]],
                     'label' => ['oneOf' => [['type' => 'string'], ['type' => 'null']]],
+                    'startLabel' => ['oneOf' => [['type' => 'string'], ['type' => 'null']]],
+                    'endLabel' => ['oneOf' => [['type' => 'string'], ['type' => 'null']]],
                     'isRestDay' => ['type' => 'boolean'],
                     'onCycleNetwork' => ['type' => 'number', 'format' => 'float', 'minimum' => 0, 'maximum' => 1],
                     'weather' => ['oneOf' => [['type' => 'object', 'properties' => [

--- a/api/src/Entity/Stage.php
+++ b/api/src/Entity/Stage.php
@@ -57,6 +57,18 @@ class Stage
     #[ORM\Column(length: 255, nullable: true)]
     private ?string $label = null;
 
+    /**
+     * Reverse-geocoded city names for the stage endpoints, resolved server-side
+     * and persisted (recette #649) so the anonymous shared view — which cannot
+     * call the auth-gated /geocode endpoint — and a reloaded trip both show city
+     * names instead of raw GPS coordinates. Null until {@see \App\MessageHandler\ResolveStageLabelsHandler} fills them.
+     */
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $startLabel = null;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $endLabel = null;
+
     #[ORM\Column]
     private bool $isRestDay = false;
 
@@ -274,6 +286,30 @@ class Stage
     public function setLabel(?string $label): self
     {
         $this->label = $label;
+
+        return $this;
+    }
+
+    public function getStartLabel(): ?string
+    {
+        return $this->startLabel;
+    }
+
+    public function setStartLabel(?string $startLabel): self
+    {
+        $this->startLabel = $startLabel;
+
+        return $this;
+    }
+
+    public function getEndLabel(): ?string
+    {
+        return $this->endLabel;
+    }
+
+    public function setEndLabel(?string $endLabel): self
+    {
+        $this->endLabel = $endLabel;
 
         return $this;
     }

--- a/api/src/Geo/ReverseGeocoder.php
+++ b/api/src/Geo/ReverseGeocoder.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Geo;
+
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Server-side reverse geocoding for stage endpoint labels (recette #649, #3c/#9).
+ *
+ * Resolves a coordinate to a city-preferred place name via Nominatim, cached for
+ * 24h. Shares the cache key/shape with {@see \App\Controller\GeocodeController}'s
+ * `/geocode/reverse` endpoint, so a lookup from either path warms the other.
+ * Used by {@see \App\MessageHandler\ResolveStageLabelsHandler} to persist labels
+ * so the anonymous shared view — which cannot call the auth-gated endpoint — and
+ * a reloaded trip render city names instead of raw GPS coordinates.
+ */
+final readonly class ReverseGeocoder
+{
+    private const int CACHE_TTL = 86400; // 24 hours
+
+    public function __construct(
+        #[Autowire(service: 'nominatim.client')]
+        private HttpClientInterface $nominatimClient,
+        #[Autowire(service: 'cache.osm')]
+        private CacheItemPoolInterface $osmCache,
+    ) {
+    }
+
+    /**
+     * Returns the city-preferred place name for the coordinate, or null when the
+     * service is unavailable or finds nothing. Coordinates are rounded to 4
+     * decimals (~11 m) for the cache key, matching the search endpoint.
+     */
+    public function cityName(float $lat, float $lon): ?string
+    {
+        $cacheKey = \sprintf('geocode.reverse.%s.%s', round($lat, 4), round($lon, 4));
+        $item = $this->osmCache->getItem($cacheKey);
+
+        if ($item->isHit()) {
+            /** @var list<array{name: string, lat: float, lon: float, displayName: string, type: string}> $cached */
+            $cached = $item->get();
+            $name = $cached[0]['name'] ?? '';
+
+            return '' === $name ? null : $name;
+        }
+
+        try {
+            $response = $this->nominatimClient->request('GET', '/reverse', [
+                'query' => [
+                    'lat' => $lat,
+                    'lon' => $lon,
+                    'format' => 'jsonv2',
+                    'addressdetails' => 1,
+                ],
+            ]);
+
+            /** @var array{name?: string, display_name?: string, lat?: string, lon?: string, type?: string, addresstype?: string, address?: array{city?: string, town?: string, village?: string, hamlet?: string, municipality?: string}, error?: string} $data */
+            $data = $response->toArray();
+        } catch (\Throwable) {
+            return null;
+        }
+
+        if (isset($data['error'])) {
+            return null;
+        }
+
+        // Prefer the city/town/village name over the raw POI name.
+        $address = $data['address'] ?? [];
+        $name = $data['name'] ?? '';
+        $cityName = $address['city'] ?? $address['town'] ?? $address['village'] ?? $address['hamlet'] ?? $address['municipality'] ?? null;
+        if (null !== $cityName && '' !== $cityName) {
+            $name = $cityName;
+        }
+
+        // Cache in the same shape as GeocodeController so both paths share entries.
+        $item->set([[
+            'name' => $name,
+            'lat' => (float) ($data['lat'] ?? $lat),
+            'lon' => (float) ($data['lon'] ?? $lon),
+            'displayName' => $data['display_name'] ?? '',
+            'type' => $data['addresstype'] ?? $data['type'] ?? 'place',
+        ]]);
+        $item->expiresAfter(self::CACHE_TTL);
+
+        $this->osmCache->save($item);
+
+        return '' === $name ? null : $name;
+    }
+}

--- a/api/src/Message/ResolveStageLabels.php
+++ b/api/src/Message/ResolveStageLabels.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Message;
+
+/**
+ * Resolve and persist reverse-geocoded city labels for a trip's stage endpoints
+ * (recette #649, #3c/#9). Dispatched after stage generation so the anonymous
+ * shared view and a reloaded trip render city names instead of GPS coordinates.
+ */
+final readonly class ResolveStageLabels
+{
+    public function __construct(
+        public string $tripId,
+        public ?int $generation = null,
+    ) {
+    }
+}

--- a/api/src/MessageHandler/ResolveStageLabelsHandler.php
+++ b/api/src/MessageHandler/ResolveStageLabelsHandler.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MessageHandler;
+
+use App\ComputationTracker\TripGenerationTrackerInterface;
+use App\Geo\ReverseGeocoder;
+use App\Message\ResolveStageLabels;
+use App\Repository\TripRequestRepositoryInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+/**
+ * Resolves and persists reverse-geocoded city labels for each stage endpoint
+ * (recette #649, #3c/#9).
+ *
+ * Best-effort enrichment — not a tracked computation and not gated on: the
+ * anonymous shared view and a reloaded trip read the persisted labels, while the
+ * authenticated editor resolves them client-side meanwhile. Labels survive on
+ * the Stage so subsequent reads render city names instead of GPS coordinates.
+ */
+#[AsMessageHandler]
+final readonly class ResolveStageLabelsHandler
+{
+    public function __construct(
+        private TripRequestRepositoryInterface $tripStateManager,
+        private ReverseGeocoder $reverseGeocoder,
+        private TripGenerationTrackerInterface $generationTracker,
+    ) {
+    }
+
+    public function __invoke(ResolveStageLabels $message): void
+    {
+        $tripId = $message->tripId;
+
+        // Skip a superseded generation: a newer recompute may have moved the stage
+        // endpoints, so resolving labels for the old ones would persist them
+        // against the wrong dayNumbers.
+        $current = $this->generationTracker->current($tripId);
+        if (null !== $message->generation && null !== $current && $message->generation < $current) {
+            return;
+        }
+
+        $stages = $this->tripStateManager->getStages($tripId);
+        if (null === $stages) {
+            return;
+        }
+
+        foreach ($stages as $stage) {
+            $startLabel = $this->reverseGeocoder->cityName($stage->startPoint->lat, $stage->startPoint->lon);
+            // A rest day shares its endpoint with the previous arrival, so reuse
+            // the start label instead of a second identical lookup.
+            $endLabel = $stage->isRestDay
+                ? $startLabel
+                : $this->reverseGeocoder->cityName($stage->endPoint->lat, $stage->endPoint->lon);
+
+            $this->tripStateManager->updateStageLabels($tripId, $stage->dayNumber, $startLabel, $endLabel);
+        }
+    }
+}

--- a/api/src/Repository/DoctrineTripRequestRepository.php
+++ b/api/src/Repository/DoctrineTripRequestRepository.php
@@ -439,6 +439,22 @@ final class DoctrineTripRequestRepository extends ServiceEntityRepository implem
             ->execute();
     }
 
+    public function updateStageLabels(string $tripId, int $dayNumber, ?string $startLabel, ?string $endLabel): void
+    {
+        if (!Uuid::isValid($tripId)) {
+            return;
+        }
+
+        $this->getEntityManager()->createQuery(
+            'UPDATE App\Entity\Stage s SET s.startLabel = :startLabel, s.endLabel = :endLabel WHERE s.trip = :tripId AND s.dayNumber = :dayNumber',
+        )
+            ->setParameter('tripId', Uuid::fromString($tripId))
+            ->setParameter('dayNumber', $dayNumber)
+            ->setParameter('startLabel', $startLabel)
+            ->setParameter('endLabel', $endLabel)
+            ->execute();
+    }
+
     // --- Private helpers ---
 
     /**
@@ -511,6 +527,8 @@ final class DoctrineTripRequestRepository extends ServiceEntityRepository implem
         $entity->setEndLon($dto->endPoint->lon);
         $entity->setEndEle($dto->endPoint->ele);
         $entity->setLabel($dto->label);
+        $entity->setStartLabel($dto->startLabel);
+        $entity->setEndLabel($dto->endLabel);
         $entity->setIsRestDay($dto->isRestDay);
 
         // Geometry: list<Coordinate> → list<array{lat, lon, ele}>
@@ -583,6 +601,8 @@ final class DoctrineTripRequestRepository extends ServiceEntityRepository implem
         );
 
         $dto->onCycleNetwork = $entity->getOnCycleNetwork();
+        $dto->startLabel = $entity->getStartLabel();
+        $dto->endLabel = $entity->getEndLabel();
 
         // Weather
         /** @var array{icon: string, description: string, tempMin: float, tempMax: float, windSpeed: float, windDirection: string, precipitationProbability: int, humidity: int, comfortIndex: int, relativeWindDirection: string}|null $weatherData */

--- a/api/src/Repository/RedisTripRequestRepository.php
+++ b/api/src/Repository/RedisTripRequestRepository.php
@@ -168,6 +168,14 @@ final readonly class RedisTripRequestRepository implements TripRequestRepository
         });
     }
 
+    public function updateStageLabels(string $tripId, int $dayNumber, ?string $startLabel, ?string $endLabel): void
+    {
+        $this->updateStageField($tripId, $dayNumber, static function (Stage $stage) use ($startLabel, $endLabel): void {
+            $stage->startLabel = $startLabel;
+            $stage->endLabel = $endLabel;
+        });
+    }
+
     /**
      * Lock-guarded read-modify-write of a single stage (matched by dayNumber) in the
      * monolithic blob, so concurrent enrichment handlers can't lose each other's

--- a/api/src/Repository/TripRequestRepositoryInterface.php
+++ b/api/src/Repository/TripRequestRepositoryInterface.php
@@ -105,6 +105,11 @@ interface TripRequestRepositoryInterface
     public function updateStageAccommodations(string $tripId, int $dayNumber, array $accommodations): void;
 
     /**
+     * Persists a single stage's reverse-geocoded endpoint labels atomically (see {@see self::updateStageWeather()}).
+     */
+    public function updateStageLabels(string $tripId, int $dayNumber, ?string $startLabel, ?string $endLabel): void;
+
+    /**
      * Stores multi-track data for Komoot Collection source type.
      *
      * @param list<list<array{lat: float, lon: float, ele: float}>> $tracksData

--- a/api/src/Service/TripAnalysisDispatcher.php
+++ b/api/src/Service/TripAnalysisDispatcher.php
@@ -15,6 +15,7 @@ use App\Message\CheckHealthServices;
 use App\Message\CheckRailwayStations;
 use App\Message\CheckWaterPoints;
 use App\Message\FetchWeather;
+use App\Message\ResolveStageLabels;
 use App\Message\ScanAccommodations;
 use App\Message\ScanEvents;
 use App\Message\ScanPois;
@@ -60,5 +61,6 @@ final readonly class TripAnalysisDispatcher
         $this->messageBus->dispatch(new CheckBorderCrossing($tripId, $generation));
         $this->messageBus->dispatch(new CheckFerries($tripId, $generation));
         $this->messageBus->dispatch(new ScanEvents($tripId, $generation));
+        $this->messageBus->dispatch(new ResolveStageLabels($tripId, $generation));
     }
 }

--- a/api/src/State/TripDetailProvider.php
+++ b/api/src/State/TripDetailProvider.php
@@ -169,6 +169,8 @@ final readonly class TripDetailProvider implements ProviderInterface
             'endPoint' => $this->serializeCoord($stage->endPoint),
             'geometry' => array_map($this->serializeCoord(...), $stage->geometry),
             'label' => $stage->label,
+            'startLabel' => $stage->startLabel,
+            'endLabel' => $stage->endLabel,
             'isRestDay' => $stage->isRestDay,
             'onCycleNetwork' => $stage->onCycleNetwork,
             'weather' => $stage->weather instanceof WeatherForecast ? $this->serializeWeather($stage->weather) : null,

--- a/api/tests/Functional/TripAnalyzeTest.php
+++ b/api/tests/Functional/TripAnalyzeTest.php
@@ -23,6 +23,7 @@ use App\Message\CheckHealthServices;
 use App\Message\CheckRailwayStations;
 use App\Message\CheckWaterPoints;
 use App\Message\FetchWeather;
+use App\Message\ResolveStageLabels;
 use App\Message\ScanAccommodations;
 use App\Message\ScanEvents;
 use App\Message\ScanPois;

--- a/api/tests/Functional/TripAnalyzeTest.php
+++ b/api/tests/Functional/TripAnalyzeTest.php
@@ -180,6 +180,7 @@ final class TripAnalyzeTest extends ApiTestCase
             CheckRailwayStations::class,
             CheckBorderCrossing::class,
             ScanEvents::class,
+            ResolveStageLabels::class,
         ];
 
         $this->assertSame($expected, $dispatched, 'Exactly one message per enrichment step must be dispatched, in order.');

--- a/api/tests/Integration/LlmPipelineTest.php
+++ b/api/tests/Integration/LlmPipelineTest.php
@@ -474,6 +474,10 @@ final class InMemoryTripRequestRepository implements TripRequestRepositoryInterf
     {
     }
 
+    public function updateStageLabels(string $tripId, int $dayNumber, ?string $startLabel, ?string $endLabel): void
+    {
+    }
+
     public function storeTracksData(string $tripId, array $tracksData): void
     {
     }

--- a/api/tests/Unit/Geo/ReverseGeocoderTest.php
+++ b/api/tests/Unit/Geo/ReverseGeocoderTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Geo;
+
+use App\Geo\ReverseGeocoder;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+final class ReverseGeocoderTest extends TestCase
+{
+    #[Test]
+    public function prefersTheCityNameOverTheRawPoiName(): void
+    {
+        $geocoder = new ReverseGeocoder(
+            new MockHttpClient(new MockResponse('{"name":"Gare de Lyon-Part-Dieu","address":{"city":"Lyon"}}')),
+            $this->cache(),
+        );
+
+        self::assertSame('Lyon', $geocoder->cityName(45.76, 4.84));
+    }
+
+    #[Test]
+    public function fallsBackThroughTownVillageHamletMunicipality(): void
+    {
+        $geocoder = new ReverseGeocoder(
+            new MockHttpClient(new MockResponse('{"name":"POI","address":{"village":"Saint-Bonnet-en-Champsaur"}}')),
+            $this->cache(),
+        );
+
+        self::assertSame('Saint-Bonnet-en-Champsaur', $geocoder->cityName(44.67, 6.07));
+    }
+
+    #[Test]
+    public function fallsBackToTheRawNameWhenAddressHasNoLocality(): void
+    {
+        $geocoder = new ReverseGeocoder(
+            new MockHttpClient(new MockResponse('{"name":"Col du Galibier","address":{}}')),
+            $this->cache(),
+        );
+
+        self::assertSame('Col du Galibier', $geocoder->cityName(45.06, 6.41));
+    }
+
+    #[Test]
+    public function returnsNullWhenNominatimReportsAnError(): void
+    {
+        $geocoder = new ReverseGeocoder(
+            new MockHttpClient(new MockResponse('{"error":"Unable to geocode"}')),
+            $this->cache(),
+        );
+
+        self::assertNull($geocoder->cityName(0.0, 0.0));
+    }
+
+    #[Test]
+    public function returnsNullOnTransportError(): void
+    {
+        $geocoder = new ReverseGeocoder(
+            new MockHttpClient(new MockResponse('', ['http_code' => 503])),
+            $this->cache(),
+        );
+
+        self::assertNull($geocoder->cityName(45.0, 4.0));
+    }
+
+    #[Test]
+    public function cachesTheResultAcrossCalls(): void
+    {
+        // Only one response queued: a second HTTP call would throw, so the second
+        // lookup of the same coordinate must be served from cache.
+        $geocoder = new ReverseGeocoder(
+            new MockHttpClient(new MockResponse('{"address":{"city":"Lille"}}')),
+            $this->cache(),
+        );
+
+        self::assertSame('Lille', $geocoder->cityName(50.6365, 3.0635));
+        self::assertSame('Lille', $geocoder->cityName(50.6365, 3.0635));
+    }
+
+    private function cache(): CacheItemPoolInterface
+    {
+        return new ArrayAdapter();
+    }
+}

--- a/api/tests/Unit/MessageHandler/ResolveStageLabelsHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/ResolveStageLabelsHandlerTest.php
@@ -39,7 +39,7 @@ final class ResolveStageLabelsHandlerTest extends TestCase
             ->method('updateStageLabels')
             ->with(self::TRIP_ID, 1, 'Lyon', 'Lyon');
 
-        $tracker = $this->createMock(TripGenerationTrackerInterface::class);
+        $tracker = $this->createStub(TripGenerationTrackerInterface::class);
         $tracker->method('current')->willReturn(null);
 
         $handler = new ResolveStageLabelsHandler($repo, $this->geocoder('Lyon'), $tracker);
@@ -53,7 +53,7 @@ final class ResolveStageLabelsHandlerTest extends TestCase
         $repo->expects(self::never())->method('getStages');
         $repo->expects(self::never())->method('updateStageLabels');
 
-        $tracker = $this->createMock(TripGenerationTrackerInterface::class);
+        $tracker = $this->createStub(TripGenerationTrackerInterface::class);
         $tracker->method('current')->willReturn(5); // newer than the message's generation 2
 
         // No HTTP responses queued: a geocoding call would throw, proving none happens.
@@ -82,7 +82,7 @@ final class ResolveStageLabelsHandlerTest extends TestCase
             ->method('updateStageLabels')
             ->with(self::TRIP_ID, 2, 'Lyon', 'Lyon');
 
-        $tracker = $this->createMock(TripGenerationTrackerInterface::class);
+        $tracker = $this->createStub(TripGenerationTrackerInterface::class);
         $tracker->method('current')->willReturn(null);
 
         // A single queued response: a second HTTP call would throw, so the rest day
@@ -94,6 +94,23 @@ final class ResolveStageLabelsHandlerTest extends TestCase
 
         $handler = new ResolveStageLabelsHandler($repo, $geocoder, $tracker);
         $handler(new ResolveStageLabels(self::TRIP_ID, generation: 1));
+    }
+
+    #[Test]
+    public function doesNothingWhenNoStagesAreFound(): void
+    {
+        $repo = $this->createMock(TripRequestRepositoryInterface::class);
+        $repo->method('getStages')->willReturn(null);
+        $repo->expects(self::never())->method('updateStageLabels');
+
+        $tracker = $this->createStub(TripGenerationTrackerInterface::class);
+        $tracker->method('current')->willReturn(null);
+
+        // No HTTP responses queued: a geocoding call would throw, proving none happens.
+        $geocoder = new ReverseGeocoder(new MockHttpClient([]), new ArrayAdapter());
+
+        $handler = new ResolveStageLabelsHandler($repo, $geocoder, $tracker);
+        $handler(new ResolveStageLabels(self::TRIP_ID));
     }
 
     private function geocoder(string $city): ReverseGeocoder

--- a/api/tests/Unit/MessageHandler/ResolveStageLabelsHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/ResolveStageLabelsHandlerTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\MessageHandler;
+
+use App\ApiResource\Model\Coordinate;
+use App\ApiResource\Stage;
+use App\ComputationTracker\TripGenerationTrackerInterface;
+use App\Geo\ReverseGeocoder;
+use App\Message\ResolveStageLabels;
+use App\MessageHandler\ResolveStageLabelsHandler;
+use App\Repository\TripRequestRepositoryInterface;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+final class ResolveStageLabelsHandlerTest extends TestCase
+{
+    private const string TRIP_ID = '01936f6e-0000-7000-8000-000000000099';
+
+    #[Test]
+    public function resolvesAndPersistsLabelsForEachStage(): void
+    {
+        $stage = new Stage(
+            tripId: self::TRIP_ID,
+            dayNumber: 1,
+            distance: 50.0,
+            elevation: 0.0,
+            startPoint: new Coordinate(45.76, 4.84),
+            endPoint: new Coordinate(45.90, 4.90),
+        );
+
+        $repo = $this->createMock(TripRequestRepositoryInterface::class);
+        $repo->method('getStages')->willReturn([$stage]);
+        $repo->expects(self::once())
+            ->method('updateStageLabels')
+            ->with(self::TRIP_ID, 1, 'Lyon', 'Lyon');
+
+        $tracker = $this->createMock(TripGenerationTrackerInterface::class);
+        $tracker->method('current')->willReturn(null);
+
+        $handler = new ResolveStageLabelsHandler($repo, $this->geocoder('Lyon'), $tracker);
+        $handler(new ResolveStageLabels(self::TRIP_ID, generation: 1));
+    }
+
+    #[Test]
+    public function skipsASupersededGeneration(): void
+    {
+        $repo = $this->createMock(TripRequestRepositoryInterface::class);
+        $repo->expects(self::never())->method('getStages');
+        $repo->expects(self::never())->method('updateStageLabels');
+
+        $tracker = $this->createMock(TripGenerationTrackerInterface::class);
+        $tracker->method('current')->willReturn(5); // newer than the message's generation 2
+
+        // No HTTP responses queued: a geocoding call would throw, proving none happens.
+        $geocoder = new ReverseGeocoder(new MockHttpClient([]), new ArrayAdapter());
+
+        $handler = new ResolveStageLabelsHandler($repo, $geocoder, $tracker);
+        $handler(new ResolveStageLabels(self::TRIP_ID, generation: 2));
+    }
+
+    #[Test]
+    public function resolvesARestDayWithASingleLookup(): void
+    {
+        $restDay = new Stage(
+            tripId: self::TRIP_ID,
+            dayNumber: 2,
+            distance: 0.0,
+            elevation: 0.0,
+            startPoint: new Coordinate(45.76, 4.84),
+            endPoint: new Coordinate(45.76, 4.84),
+            isRestDay: true,
+        );
+
+        $repo = $this->createMock(TripRequestRepositoryInterface::class);
+        $repo->method('getStages')->willReturn([$restDay]);
+        $repo->expects(self::once())
+            ->method('updateStageLabels')
+            ->with(self::TRIP_ID, 2, 'Lyon', 'Lyon');
+
+        $tracker = $this->createMock(TripGenerationTrackerInterface::class);
+        $tracker->method('current')->willReturn(null);
+
+        // A single queued response: a second HTTP call would throw, so the rest day
+        // must resolve both endpoints from one lookup.
+        $geocoder = new ReverseGeocoder(
+            new MockHttpClient(new MockResponse('{"address":{"city":"Lyon"}}')),
+            new ArrayAdapter(),
+        );
+
+        $handler = new ResolveStageLabelsHandler($repo, $geocoder, $tracker);
+        $handler(new ResolveStageLabels(self::TRIP_ID, generation: 1));
+    }
+
+    private function geocoder(string $city): ReverseGeocoder
+    {
+        return new ReverseGeocoder(
+            new MockHttpClient(static fn (): MockResponse => new MockResponse(\sprintf('{"address":{"city":"%s"}}', $city))),
+            new ArrayAdapter(),
+        );
+    }
+}

--- a/api/tests/Unit/Service/TripAnalysisDispatcherTest.php
+++ b/api/tests/Unit/Service/TripAnalysisDispatcherTest.php
@@ -15,6 +15,7 @@ use App\Message\CheckHealthServices;
 use App\Message\CheckRailwayStations;
 use App\Message\CheckWaterPoints;
 use App\Message\FetchWeather;
+use App\Message\ResolveStageLabels;
 use App\Message\ScanAccommodations;
 use App\Message\ScanEvents;
 use App\Message\ScanPois;
@@ -48,6 +49,7 @@ final class TripAnalysisDispatcherTest extends TestCase
             CheckBorderCrossing::class,
             CheckFerries::class,
             ScanEvents::class,
+            ResolveStageLabels::class,
         ];
 
         $dispatched = [];

--- a/pwa/src/app/(app)/trips/[id]/trip-page.tsx
+++ b/pwa/src/app/(app)/trips/[id]/trip-page.tsx
@@ -108,8 +108,8 @@ function TripLoader({ tripId }: { tripId: string }) {
           },
           geometry: (s.geometry as StageData["geometry"]) ?? [],
           label: s.label ?? null,
-          startLabel: null,
-          endLabel: null,
+          startLabel: s.startLabel ?? null,
+          endLabel: s.endLabel ?? null,
           weather: (s.weather as StageData["weather"]) ?? null,
           alerts: (s.alerts as StageData["alerts"]) ?? [],
           pois: (s.pois as StageData["pois"]) ?? [],
@@ -278,15 +278,21 @@ function TripLoader({ tripId }: { tripId: string }) {
   useEffect(() => {
     if (!isLoaded) return;
 
+    // The backend now persists reverse-geocoded labels (recette #649), so only
+    // resolve stages that still lack one (e.g. their async resolution hasn't
+    // landed yet) — a fully-labelled trip skips the Nominatim round-trips.
     const stages = useTripStore.getState().stages;
-    if (stages.length === 0) return;
+    const pending = stages
+      .map((s, i) => ({ s, i }))
+      .filter(({ s }) => s.startLabel === null || s.endLabel === null);
+    if (pending.length === 0) return;
 
     const controller = new AbortController();
     const timer = setTimeout(() => {
       if (controller.signal.aborted) return;
       void resolveStageLabels(
-        stages,
-        stages.map((_, i) => i),
+        pending.map(({ s }) => s),
+        pending.map(({ i }) => i),
         controller.signal,
       );
     }, 0);

--- a/pwa/src/app/s/[code]/shared-trip-page.tsx
+++ b/pwa/src/app/s/[code]/shared-trip-page.tsx
@@ -85,8 +85,11 @@ function SharedTripLoader({ code }: { code: string }) {
           },
           geometry: (s.geometry as StageData["geometry"]) ?? [],
           label: (s.label as string) ?? null,
-          startLabel: null,
-          endLabel: null,
+          // Server-persisted reverse-geocoded labels (recette #649 #3c): the
+          // anonymous shared view cannot call the auth-gated /geocode endpoint,
+          // so it relies entirely on these to show city names, not coordinates.
+          startLabel: (s.startLabel as string) ?? null,
+          endLabel: (s.endLabel as string) ?? null,
           weather: (s.weather as StageData["weather"]) ?? null,
           alerts: (s.alerts as StageData["alerts"]) ?? [],
           pois: (s.pois as StageData["pois"]) ?? [],

--- a/pwa/src/lib/api/schema.d.ts
+++ b/pwa/src/lib/api/schema.d.ts
@@ -192,6 +192,46 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/users/me/email-change": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Creates a EmailChange resource.
+         * @description Creates a EmailChange resource.
+         */
+        post: operations["api_usersmeemail-change_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/users/me/email-change/verify": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Creates a EmailChange resource.
+         * @description Creates a EmailChange resource.
+         */
+        post: operations["api_usersmeemail-changeverify_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/trips/{tripId}/stages": {
         parameters: {
             query?: never;
@@ -974,6 +1014,23 @@ export interface components {
             lon?: number;
             ele?: number;
         };
+        /**
+         * @description Email-change-by-magic-link flow for the authenticated user (#777).
+         *
+         *     - POST /users/me/email-change         request a change to {newEmail}; a
+         *       confirmation link is sent to the NEW address.
+         *     - POST /users/me/email-change/verify  consume the {token} from that link and
+         *       commit the new email (single-use, atomic, email uniqueness enforced).
+         *
+         *     The current user is always resolved from the security token, never from a URL
+         *     identifier (no IDOR surface). Distinct from the login magic link, which only
+         *     re-authenticates the SAME email.
+         */
+        EmailChange: {
+            /** Format: email */
+            newEmail: string;
+            token?: string;
+        };
         /** @description A representation of common errors. */
         Error: {
             /** @description A short, human-readable summary of the problem. */
@@ -1233,6 +1290,20 @@ export interface components {
             pois?: components["schemas"]["PointOfInterest.fit"][];
             accommodations?: components["schemas"]["Accommodation.fit"][];
             selectedAccommodation?: components["schemas"]["Accommodation.fit"] | null;
+            /**
+             * @description Fraction (0..1) of the stage line that follows a signed cycle route,
+             *     persisted at stage-store time and read back here (issue #775).
+             * @default 0
+             */
+            readonly onCycleNetwork: number;
+            /**
+             * @description Reverse-geocoded city names for the stage endpoints (recette #649, #3c/#9),
+             *     resolved server-side and persisted so the anonymous shared view and a
+             *     reloaded trip render city names instead of raw GPS coordinates. Readable
+             *     (the frontend consumes them) but never writable.
+             */
+            readonly startLabel?: string | null;
+            readonly endLabel?: string | null;
             events?: components["schemas"]["Event.fit"][];
             readonly aiAnalysis?: components["schemas"]["StageAiAnalysis.fit"] | null;
             tripId?: string;
@@ -1252,6 +1323,20 @@ export interface components {
             pois?: components["schemas"]["PointOfInterest.gpx"][];
             accommodations?: components["schemas"]["Accommodation.gpx"][];
             selectedAccommodation?: components["schemas"]["Accommodation.gpx"] | null;
+            /**
+             * @description Fraction (0..1) of the stage line that follows a signed cycle route,
+             *     persisted at stage-store time and read back here (issue #775).
+             * @default 0
+             */
+            readonly onCycleNetwork: number;
+            /**
+             * @description Reverse-geocoded city names for the stage endpoints (recette #649, #3c/#9),
+             *     resolved server-side and persisted so the anonymous shared view and a
+             *     reloaded trip render city names instead of raw GPS coordinates. Readable
+             *     (the frontend consumes them) but never writable.
+             */
+            readonly startLabel?: string | null;
+            readonly endLabel?: string | null;
             events?: components["schemas"]["Event.gpx"][];
             readonly aiAnalysis?: components["schemas"]["StageAiAnalysis.gpx"] | null;
             tripId?: string;
@@ -1271,6 +1356,20 @@ export interface components {
             pois?: components["schemas"]["PointOfInterest.jsonld"][];
             accommodations?: components["schemas"]["Accommodation.jsonld"][];
             selectedAccommodation?: components["schemas"]["Accommodation.jsonld"] | null;
+            /**
+             * @description Fraction (0..1) of the stage line that follows a signed cycle route,
+             *     persisted at stage-store time and read back here (issue #775).
+             * @default 0
+             */
+            readonly onCycleNetwork: number;
+            /**
+             * @description Reverse-geocoded city names for the stage endpoints (recette #649, #3c/#9),
+             *     resolved server-side and persisted so the anonymous shared view and a
+             *     reloaded trip render city names instead of raw GPS coordinates. Readable
+             *     (the frontend consumes them) but never writable.
+             */
+            readonly startLabel?: string | null;
+            readonly endLabel?: string | null;
             events?: components["schemas"]["Event.jsonld"][];
             readonly aiAnalysis?: components["schemas"]["StageAiAnalysis.jsonld"] | null;
             tripId?: string;
@@ -1619,6 +1718,8 @@ export interface components {
                     ele?: number;
                 }[];
                 label?: string | null;
+                startLabel?: string | null;
+                endLabel?: string | null;
                 isRestDay?: boolean;
                 /** Format: float */
                 onCycleNetwork?: number;
@@ -1700,6 +1801,20 @@ export interface components {
             pois?: components["schemas"]["PointOfInterest.fit"][];
             accommodations?: components["schemas"]["Accommodation.fit"][];
             selectedAccommodation?: components["schemas"]["Accommodation.fit"] | null;
+            /**
+             * @description Fraction (0..1) of the stage line that follows a signed cycle route,
+             *     persisted at stage-store time and read back here (issue #775).
+             * @default 0
+             */
+            readonly onCycleNetwork: number;
+            /**
+             * @description Reverse-geocoded city names for the stage endpoints (recette #649, #3c/#9),
+             *     resolved server-side and persisted so the anonymous shared view and a
+             *     reloaded trip render city names instead of raw GPS coordinates. Readable
+             *     (the frontend consumes them) but never writable.
+             */
+            readonly startLabel?: string | null;
+            readonly endLabel?: string | null;
             events?: components["schemas"]["Event.fit"][];
             readonly aiAnalysis?: components["schemas"]["StageAiAnalysis.fit"] | null;
             tripId?: string;
@@ -1719,6 +1834,20 @@ export interface components {
             pois?: components["schemas"]["PointOfInterest.gpx"][];
             accommodations?: components["schemas"]["Accommodation.gpx"][];
             selectedAccommodation?: components["schemas"]["Accommodation.gpx"] | null;
+            /**
+             * @description Fraction (0..1) of the stage line that follows a signed cycle route,
+             *     persisted at stage-store time and read back here (issue #775).
+             * @default 0
+             */
+            readonly onCycleNetwork: number;
+            /**
+             * @description Reverse-geocoded city names for the stage endpoints (recette #649, #3c/#9),
+             *     resolved server-side and persisted so the anonymous shared view and a
+             *     reloaded trip render city names instead of raw GPS coordinates. Readable
+             *     (the frontend consumes them) but never writable.
+             */
+            readonly startLabel?: string | null;
+            readonly endLabel?: string | null;
             events?: components["schemas"]["Event.gpx"][];
             readonly aiAnalysis?: components["schemas"]["StageAiAnalysis.gpx"] | null;
             tripId?: string;
@@ -1806,6 +1935,8 @@ export interface components {
                     ele?: number;
                 }[];
                 label?: string | null;
+                startLabel?: string | null;
+                endLabel?: string | null;
                 isRestDay?: boolean;
                 /** Format: float */
                 onCycleNetwork?: number;
@@ -2402,6 +2533,118 @@ export interface operations {
             };
             /** @description Invalid input */
             400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["Error.jsonld"];
+                    "application/problem+json": components["schemas"]["Error"];
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description An error occurred */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["ConstraintViolation.jsonld"];
+                    "application/problem+json": components["schemas"]["ConstraintViolation"];
+                    "application/json": components["schemas"]["ConstraintViolation"];
+                };
+            };
+        };
+    };
+    "api_usersmeemail-change_post": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description The new EmailChange resource */
+        requestBody: {
+            content: {
+                "application/ld+json": components["schemas"]["EmailChange"];
+            };
+        };
+        responses: {
+            /** @description EmailChange resource created */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Invalid input */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["Error.jsonld"];
+                    "application/problem+json": components["schemas"]["Error"];
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["Error.jsonld"];
+                    "application/problem+json": components["schemas"]["Error"];
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description An error occurred */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["ConstraintViolation.jsonld"];
+                    "application/problem+json": components["schemas"]["ConstraintViolation"];
+                    "application/json": components["schemas"]["ConstraintViolation"];
+                };
+            };
+        };
+    };
+    "api_usersmeemail-changeverify_post": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description The new EmailChange resource */
+        requestBody: {
+            content: {
+                "application/ld+json": components["schemas"]["EmailChange"];
+            };
+        };
+        responses: {
+            /** @description EmailChange resource created */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Invalid input */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["Error.jsonld"];
+                    "application/problem+json": components["schemas"]["Error"];
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };


### PR DESCRIPTION
## Recette #649 — round 7 (#3c + #9)

> #3c — Dans la vue partagée, je vois encore les coordonnées GPS au lieu des noms des villes.
> #9 — La création d'un trip par lien Komoot génère bien les étapes mais avec des coordonnées GPS au lieu des noms des villes.

### Root cause

Stage labels (city names) were resolved **client-side** via `/geocode/reverse` (issue #775 deliberately kept them off the persisted model). But that endpoint is auth-gated (`access_control: ^/ ⇒ IS_AUTHENTICATED_FULLY`), and the **anonymous shared view** (`/s/`, `PUBLIC_ACCESS`) cannot call it — so it always fell back to raw GPS coordinates (#3c). A reloaded Komoot trip showed coordinates until the client-side pass landed (#9).

The shared (anonymous) case can only be solved by resolving labels **server-side and persisting them**. #775's client-only model didn't account for the anonymous viewer. (Approach confirmed with the maintainer.)

### Change

**Schema** — `stage.start_label` / `end_label` columns (+ migration), exposed read-only on the Stage DTO, mapped both ways in the Doctrine repo, with an atomic `updateStageLabels()` on the repository interface + all implementations.

**Resolution** — a `ReverseGeocoder` service (in `App\Geo`, alongside the forward `Geocoder`; shares the `/geocode/reverse` cache key/shape) and an async `ResolveStageLabels` handler dispatched after stage generation (`TripAnalysisDispatcher`). It is best-effort and **untracked** (not gated on), resolving + persisting city labels per stage; a rest day reuses its start label.

**Serving** — `TripDetailProvider` emits `startLabel`/`endLabel` (flows to the authenticated `/detail` and the anonymous `/s/` via `TripShareShortCodeProvider`), declared in the `TripDetail` OpenAPI schema.

**Frontend** — `trip-page` and `shared-trip-page` hydrate the labels from the payload; the editor's existing client-side resolution now only fills stages **still missing** a label (so a fully-labelled trip skips the Nominatim round-trips — preserving #775's "off the load path" intent). API types regenerated.

### Tests

- `ReverseGeocoderTest` — city/town/village/hamlet/municipality preference, raw-name fallback, Nominatim error + transport error → null, cache reuse.
- `ResolveStageLabelsHandlerTest` — per-stage persist, superseded-generation skip, rest-day single lookup.

## Verification

- `tsc --noEmit`: 0 source errors; `eslint` + `prettier` clean on the changed frontend files.
- `php -l` clean on all changed/new PHP files; new unit tests are discovered by PHPUnit (`--list-tests`).
- OpenAPI export + `npm run typegen` regenerated `schema.d.ts` (additive: `startLabel`/`endLabel` on the stage items; also picked up the already-merged `email-change` endpoint that hadn't been regenerated).
- PHPUnit / PHPStan / PHP-CS-Fixer run in CI (the local recette image lacks dev deps; the suite's Foundry bootstrap needs the DB).

<!-- claude-review-start -->
## Claude Review

Reviewed commit `6a574f92ebe23a54ebee4e33dd0218bb82885c44`.

Solid, complete implementation. `ReverseGeocoder` correctly inherits the scoped Nominatim client (SSRF-safe), DQL updates use named parameters (injection-safe), all handler branches are covered (superseded generation, null stages, regular stage, rest-day single-lookup), and the generation-staleness guard + cache-sharing with `/geocode/reverse` are correctly wired. The 5th commit's php-cs-fixer import fix is a clean housekeeping commit. No security, correctness, performance, or architecture issues found.

The single previously open bot thread (`doesNothingWhenNoStagesAreFound`) was already resolved by the prior push. Previous bot reviews were already dismissed.

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

No inline comments.
<!-- claude-review-end -->