### PR TITLE
fix(pwa): gate API requests on auth readiness so ?link= trip creation works (recette #649 #8)

### DIFF
--- a/pwa/src/hooks/use-link-param.ts
+++ b/pwa/src/hooks/use-link-param.ts
@@ -34,13 +34,17 @@ export function useLinkParam(onSubmit: (url: string) => Promise<void>) {
       return;
     }
 
-    // Valid link: hand it to the planner, which redirects to /trips/{id} on
-    // success. Crucially we do NOT also `router.replace("/")` here — that extra
-    // navigation to the home route raced the trip-creation redirect (the real
-    // POST takes seconds, vs. an instant mock in tests), stranding the planner
-    // on "/" so the trip never opened (recette #649 #8). `onSubmit` resolves the
-    // address bar by navigating away; a failed creation simply leaves `?link=`
-    // in place — a sensible retry-on-reload.
+    // Strip the param from the CURRENT history entry before handing off, so that
+    // pressing Back from the resulting /trips/{id} lands on a clean "/" and does
+    // not re-mount this hook (fresh consumedRef) → which would create a duplicate
+    // trip on every Back (review on #800). We use window.history.replaceState —
+    // a Next-supported in-place URL rewrite that syncs with useSearchParams —
+    // rather than router.replace("/"): the latter is a real navigation that raced
+    // the trip-creation redirect and stranded the planner on "/" (recette #649 #8).
+    window.history.replaceState(null, "", "/");
+
+    // Hand the link to the planner, which redirects to /trips/{id} on success.
+    // A failed creation leaves the user on "/" — they can retry from the planner.
     void onSubmitRef.current(link);
   }, [searchParams, router]);
 }

--- a/pwa/src/hooks/use-link-param.ts
+++ b/pwa/src/hooks/use-link-param.ts
@@ -6,8 +6,8 @@ import { isValidUrl } from "@/lib/validation/url";
 
 /**
  * Reads the `?link=` query parameter on mount.
- * If present, calls `onSubmit` with the decoded URL and removes the param
- * from the address bar via `router.replace`.
+ * If present and valid, hands the decoded URL to `onSubmit` (which creates the
+ * trip and redirects to it). An invalid link is dropped from the address bar.
  *
  * Must be rendered inside a Suspense boundary for static export compatibility.
  */
@@ -27,10 +27,20 @@ export function useLinkParam(onSubmit: (url: string) => Promise<void>) {
     if (!link) return;
 
     consumedRef.current = true;
-    router.replace("/", { scroll: false });
 
-    if (!isValidUrl(link)) return;
+    if (!isValidUrl(link)) {
+      // Unusable link: just strip the param so a reload doesn't re-trigger it.
+      router.replace("/", { scroll: false });
+      return;
+    }
 
+    // Valid link: hand it to the planner, which redirects to /trips/{id} on
+    // success. Crucially we do NOT also `router.replace("/")` here — that extra
+    // navigation to the home route raced the trip-creation redirect (the real
+    // POST takes seconds, vs. an instant mock in tests), stranding the planner
+    // on "/" so the trip never opened (recette #649 #8). `onSubmit` resolves the
+    // address bar by navigating away; a failed creation simply leaves `?link=`
+    // in place — a sensible retry-on-reload.
     void onSubmitRef.current(link);
   }, [searchParams, router]);
 }

--- a/pwa/src/lib/api/client.test.ts
+++ b/pwa/src/lib/api/client.test.ts
@@ -129,3 +129,49 @@ describe("sendTripChat error-code extraction (#761)", () => {
     expect(result.error).toBe("HTTP 502");
   });
 });
+
+describe("apiClient 401 retry (recette #649 #8)", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it("resends the original body on the post-refresh retry, not an empty one", async () => {
+    const bodies: unknown[] = [];
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      bodies.push(init?.body);
+      // First call: 401 (the access token isn't ready yet, as on a fresh
+      // `?link=` load). The post-refresh retry must succeed.
+      return new Response("{}", {
+        status: bodies.length === 1 ? 401 : 201,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    // Stub BEFORE importing the client so openapi-fetch captures the mock + a
+    // valid absolute base URL (the test env injects NEXT_PUBLIC_API_URL="").
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubEnv("NEXT_PUBLIC_API_URL", "https://localhost");
+    vi.resetModules();
+
+    const { useAuthStore } = await import("@/store/auth-store");
+    useAuthStore.setState({
+      accessToken: "stale-token",
+      silentRefresh: vi.fn(async () => {
+        useAuthStore.setState({ accessToken: "fresh-token" });
+        return true;
+      }),
+    } as never);
+
+    const { apiClient } = await import("./client");
+    await apiClient.POST("/trips", {
+      body: { sourceUrl: "https://www.komoot.com/fr-fr/tour/1" } as never,
+    });
+
+    // The 401 triggers exactly one retry...
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    // ...and it must carry the original payload. The bug cached the body as a
+    // single-use ReadableStream, so the retry POST went out empty → 400.
+    expect(String(bodies[1] ?? "")).toContain("komoot");
+  });
+});

--- a/pwa/src/lib/api/client.ts
+++ b/pwa/src/lib/api/client.ts
@@ -68,6 +68,11 @@ export async function apiFetch(
   input: string,
   init?: RequestInit,
 ): Promise<Response> {
+  // Wait for the initial auth check to settle so the call carries the resolved
+  // token instead of firing before the bootstrap silent-refresh — same gating as
+  // the openapi-fetch middleware (recette #649 #8). Every apiFetch endpoint is
+  // authenticated; the anonymous shared view uses a raw fetch, not apiFetch.
+  await useAuthStore.getState().ensureResolved();
   const authHeader = getAuthHeader();
   const baseHeaders: Record<string, string> = {
     "Accept-Language": getBrowserLocale(),

--- a/pwa/src/lib/api/client.ts
+++ b/pwa/src/lib/api/client.ts
@@ -129,8 +129,10 @@ export async function apiFetch(
  * 2. If refresh succeeds → retry the original request with the new token
  * 3. If refresh fails → redirect to `/login`
  */
-// Cache request bodies before they are consumed by fetch, so the retry can reuse them.
-const requestBodyCache = new WeakMap<Request, BodyInit | null>();
+// Cache request bodies (as text) before fetch consumes them, so a 401 retry can
+// resend them. A string body is single-shot-safe and needs no `duplex` option,
+// unlike the ReadableStream a cloned Request exposes (recette #649 #8).
+const requestBodyCache = new WeakMap<Request, string | null>();
 
 /**
  * openapi-fetch middleware that propagates the correlation ID:
@@ -156,11 +158,17 @@ const requestIdMiddleware: Middleware = {
 };
 
 const authMiddleware: Middleware = {
-  onRequest({ request }) {
-    // Clone body before it is consumed so the retry in onResponse can reuse it.
-    // request.body is a ReadableStream — once fetch() consumes it, it's locked.
-    // request.clone() creates an independent copy whose stream remains unconsumed.
-    requestBodyCache.set(request, request.body ? request.clone().body : null);
+  async onRequest({ request }) {
+    // Read the body to TEXT before fetch consumes it, so the 401 retry in
+    // onResponse can resend it. Caching the cloned ReadableStream instead made
+    // the retry POST go out with an EMPTY body (a stream body is single-use and
+    // needs `duplex: "half"`), so the API saw no payload → 400 "Syntax error".
+    // This broke `?link=` trip creation, whose POST fires before the access
+    // token is ready (401 → retry) (recette #649 #8).
+    requestBodyCache.set(
+      request,
+      request.body ? await request.clone().text() : null,
+    );
     const authValue = getAuthHeader();
     if (authValue) {
       request.headers.set("Authorization", authValue);

--- a/pwa/src/lib/api/client.ts
+++ b/pwa/src/lib/api/client.ts
@@ -169,6 +169,13 @@ const authMiddleware: Middleware = {
       request,
       request.body ? await request.clone().text() : null,
     );
+    // Wait for the initial auth check to settle so we attach the resolved token
+    // rather than firing before the app's bootstrap silent-refresh has run — the
+    // primary cause of the `?link=` 401→retry round-trip (recette #649 #8). The
+    // refresh is deduped, so this triggers at most one per session; once settled
+    // it is a no-op. The 401 retry below remains the safety net for a token that
+    // expires mid-session.
+    await useAuthStore.getState().ensureResolved();
     const authValue = getAuthHeader();
     if (authValue) {
       request.headers.set("Authorization", authValue);

--- a/pwa/src/store/auth-store.test.ts
+++ b/pwa/src/store/auth-store.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { parseJwtPayload, useAuthStore } from "./auth-store";
 
 // Helper: build a JWT with a given payload (no signature verification needed)
@@ -81,5 +81,35 @@ describe("setUserEmail", () => {
     useAuthStore.getState().setUserEmail("new@example.com");
 
     expect(useAuthStore.getState().user).toBeNull();
+  });
+});
+
+describe("ensureResolved (recette #649 #8)", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  it("runs a one-time bootstrap refresh, then is a no-op", async () => {
+    const token = buildJwt({ sub: "u1", username: "rider@example.com" });
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ token }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    // Fresh module so the one-shot `authChecked` flag starts unset.
+    vi.resetModules();
+    const { useAuthStore: store } = await import("./auth-store");
+
+    await store.getState().ensureResolved();
+    expect(store.getState().isAuthenticated).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // Already settled → no second /auth/refresh.
+    await store.getState().ensureResolved();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/pwa/src/store/auth-store.ts
+++ b/pwa/src/store/auth-store.ts
@@ -19,6 +19,13 @@ interface AuthState {
   requestMagicLink: (email: string) => Promise<void>;
   logout: () => Promise<void>;
   silentRefresh: () => Promise<boolean>;
+  /**
+   * Resolves once the initial auth state has settled (authenticated or
+   * anonymous). Triggers a one-time bootstrap `silentRefresh` if none has run
+   * yet, then is a no-op. Lets API callers wait for a known token instead of
+   * firing early and round-tripping through a 401 (recette #649 #8).
+   */
+  ensureResolved: () => Promise<void>;
   clearAuth: () => void;
 }
 
@@ -80,6 +87,10 @@ export function parseJwtPayload(
 // flight, all callers share the same promise rather than firing multiple
 // /auth/refresh requests.
 let pendingRefresh: Promise<boolean> | null = null;
+
+// Set once the first silentRefresh has settled (regardless of outcome), so the
+// bootstrap in ensureResolved() runs at most once per session.
+let authChecked = false;
 
 export const useAuthStore = create<AuthState>()(
   immer((set, get) => ({
@@ -184,10 +195,16 @@ export const useAuthStore = create<AuthState>()(
           return false;
         } finally {
           pendingRefresh = null;
+          authChecked = true;
         }
       })();
 
       return pendingRefresh;
+    },
+
+    ensureResolved: async (): Promise<void> => {
+      if (authChecked) return;
+      await get().silentRefresh();
     },
 
     clearAuth: () =>

--- a/pwa/tests/mocked/trip-creation.spec.ts
+++ b/pwa/tests/mocked/trip-creation.spec.ts
@@ -22,22 +22,16 @@ test.describe("Trip creation flow", () => {
     const input = mockedPage.getByTestId("magic-link-input");
     await input.fill("not-a-url");
     await input.press("Enter");
-    await expect(
-      mockedPage.getByText("Entre une URL valide."),
-    ).toBeVisible();
+    await expect(mockedPage.getByText("Entre une URL valide.")).toBeVisible();
   });
 
   test("clears validation error when typing", async ({ mockedPage }) => {
     const input = mockedPage.getByTestId("magic-link-input");
     await input.fill("not-a-url");
     await input.press("Enter");
-    await expect(
-      mockedPage.getByText("Entre une URL valide."),
-    ).toBeVisible();
+    await expect(mockedPage.getByText("Entre une URL valide.")).toBeVisible();
     await input.fill("https://");
-    await expect(
-      mockedPage.getByText("Entre une URL valide."),
-    ).toBeHidden();
+    await expect(mockedPage.getByText("Entre une URL valide.")).toBeHidden();
   });
 
   test("creates trip on valid URL submit", async ({
@@ -194,6 +188,22 @@ test.describe("Trip creation flow", () => {
         .getByTestId("trip-loader")
         .or(mockedPage.getByTestId("trip-title")),
     ).not.toBeVisible();
+  });
+
+  test("back-navigation after ?link= creation does not re-trigger the hook (#800)", async ({
+    mockedPage,
+  }) => {
+    await mockedPage.goto(
+      "/?link=" +
+        encodeURIComponent("https://www.komoot.com/fr-fr/tour/2795080048"),
+    );
+    await expect(mockedPage).toHaveURL(/\/trips\//, { timeout: 5000 });
+
+    // The param is stripped from history in place, so Back lands on a clean "/"
+    // instead of re-running useLinkParam and creating a duplicate trip.
+    await mockedPage.goBack();
+    await expect(mockedPage).not.toHaveURL(/\?link=/);
+    await expect(mockedPage).not.toHaveURL(/\/trips\//);
   });
 
   test("shows stage locations after geocode resolves", async ({


### PR DESCRIPTION
## Recette #649 — round 7 (#8)

> La création d'un trip par `?link=` (ex. `https://localhost/?link=https://www.komoot.com/fr-fr/tour/2795080048`) ne marche pas.

### Root cause — reproduced live against the recette

Drove a real browser through it (logged in as the recette user via a Mailcatcher magic link):

- **`/?link=…`** → `POST /trips` returns **400 "Syntax error"** → stays on the welcome screen, no trip. ❌
- The **"Lien" button** (same `handleMagicLink`, same body) → **202**, trip created. ✅

Network trace: **two** `POST /trips`, `401` then `400`. On a fresh load the POST fires **before the access token is ready** (child-effect order: `TripPlanner`'s `useLinkParam` runs before `HomeContent`'s bootstrap `silentRefresh`) → `401` → the auth middleware refreshes and **retries**, but the retry resent the body from a cached **`ReadableStream`**, which goes out **empty** (single-use, needs `duplex: "half"`) → the API got no payload → `400`. Confirmed by curl: `POST /trips` with no body → `400 "Syntax error"` (the exact 187-byte response); with the real body → `202`.

### Fix — wait for auth instead of firing blind (suggested approach)

Rather than firing optimistically and recovering on a 401, **gate requests on auth readiness**:

- `authStore.ensureResolved()` — a one-shot, deduped bootstrap `silentRefresh` that settles to *authenticated* or *anonymous*.
- `authMiddleware.onRequest` **awaits** it before attaching the token, so the request carries the resolved token. This removes the speculative `401 → retry` round-trip for fresh-load requests — the #8 cause.

The `401` retry is kept as a **safety net for mid-session token expiry**, and now caches the body as **text** so it resends the real JSON if it ever fires.

Also: a valid `?link=` goes straight to `onSubmit` (no redundant `router.replace("/")`).

### Tests

- `auth-store.test.ts`: `ensureResolved` runs one bootstrap refresh, then is a no-op.
- `client.test.ts`: a `401` retry carries the original body (not empty).
- Existing `trip-creation.spec.ts` `?link=` + recette BDD scenario stay green.

## Verification

- Reproduced the failure live (browser + network trace + curl bisection).
- `vitest`: 25 passed (auth-store + client); `tsc` 0 source errors; `eslint`/`prettier` clean.

<!-- claude-review-start -->
## Claude Review

**Commit reviewed:** `4a0004cd` (HEAD)

### Summary

Clean pass. The three-pronged fix (auth gating via `ensureResolved`, body-as-text caching for the 401 retry, and `window.history.replaceState` to strip `?link=` in-place) correctly addresses both the primary root cause and the back-navigation regression flagged in the previous round. Test coverage is complete — unit tests for `ensureResolved` idempotency and 401 body resend, plus a Playwright regression test for back-navigation.

**Resolved threads:** 1 — the back-navigation regression thread (`use-link-param.ts:48`) is addressed: `window.history.replaceState(null, "", "/")` replaces the `/?link=…` history entry before `onSubmit` redirects to `/trips/{id}`, so Back lands on a clean `/` and the hook is silent.

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Findings by severity

| Severity | Count |
|----------|-------|
| critical | 0 |
| warning  | 0 |

**No inline comments.**
<!-- claude-review-end -->