### PR TITLE
fix(test): seed stage tests with a future start date so TripLocker doesn't lock them

### DIFF
--- a/api/tests/Functional/RestDayInsertTest.php
+++ b/api/tests/Functional/RestDayInsertTest.php
@@ -48,7 +48,7 @@ final class RestDayInsertTest extends ApiTestCase
 
         $request = new TripRequest(Uuid::fromString($tripId));
         $request->sourceUrl = 'https://www.komoot.com/tour/123456789';
-        $request->startDate = new \DateTimeImmutable('2026-07-01');
+        $request->startDate = new \DateTimeImmutable('today +1 year');
 
         $repo->initializeTrip($tripId, $request);
         $repo->storeSourceType($tripId, SourceType::KOMOOT_TOUR->value);
@@ -109,13 +109,16 @@ final class RestDayInsertTest extends ApiTestCase
 
         $this->assertResponseStatusCodeSame(202);
 
-        // 2 → 3 stages: the trip now spans 3 days, so the end date shifts from
-        // 2026-07-02 to 2026-07-03 (recette #649).
+        // 2 → 3 stages: the trip now spans 3 days, so the end date shifts one day
+        // forward to start date + 2 (recette #649).
         /** @var TripRequestRepositoryInterface $repo */
         $repo = self::getContainer()->get(TripRequestRepositoryInterface::class);
         $request = $repo->getRequest(self::TRIP_ID);
 
         $this->assertNotNull($request);
-        $this->assertSame('2026-07-03', $request->endDate?->format('Y-m-d'));
+        $this->assertSame(
+            (new \DateTimeImmutable('today +1 year'))->modify('+2 days')->format('Y-m-d'),
+            $request->endDate?->format('Y-m-d'),
+        );
     }
 }

--- a/api/tests/Functional/RestDayInsertTest.php
+++ b/api/tests/Functional/RestDayInsertTest.php
@@ -117,7 +117,7 @@ final class RestDayInsertTest extends ApiTestCase
 
         $this->assertNotNull($request);
         $this->assertSame(
-            (new \DateTimeImmutable('today +1 year'))->modify('+2 days')->format('Y-m-d'),
+            new \DateTimeImmutable('today +1 year')->modify('+2 days')->format('Y-m-d'),
             $request->endDate?->format('Y-m-d'),
         );
     }

--- a/api/tests/Functional/StageCreateTest.php
+++ b/api/tests/Functional/StageCreateTest.php
@@ -419,7 +419,7 @@ final class StageCreateTest extends ApiTestCase
 
         $this->assertNotNull($request);
         $this->assertSame(
-            (new \DateTimeImmutable('today +1 year'))->modify('+3 days')->format('Y-m-d'),
+            new \DateTimeImmutable('today +1 year')->modify('+3 days')->format('Y-m-d'),
             $request->endDate?->format('Y-m-d'),
         );
     }

--- a/api/tests/Functional/StageCreateTest.php
+++ b/api/tests/Functional/StageCreateTest.php
@@ -51,7 +51,7 @@ final class StageCreateTest extends ApiTestCase
 
         $request = new TripRequest(Uuid::fromString($tripId));
         $request->sourceUrl = 'https://www.komoot.com/tour/123456789';
-        $request->startDate = new \DateTimeImmutable('2026-07-01');
+        $request->startDate = new \DateTimeImmutable('today +1 year');
 
         $repo->initializeTrip($tripId, $request);
         $repo->storeSourceType($tripId, SourceType::KOMOOT_TOUR->value);
@@ -411,13 +411,16 @@ final class StageCreateTest extends ApiTestCase
 
         $this->assertResponseStatusCodeSame(202);
 
-        // 3 → 4 stages: the trip now spans 4 days, so the end date shifts from
-        // 2026-07-03 to 2026-07-04 (recette #649).
+        // 3 → 4 stages: the trip now spans 4 days, so the end date shifts one day
+        // forward from the start date + 2 to start date + 3 (recette #649).
         /** @var TripRequestRepositoryInterface $repo */
         $repo = self::getContainer()->get(TripRequestRepositoryInterface::class);
         $request = $repo->getRequest(self::TRIP_ID);
 
         $this->assertNotNull($request);
-        $this->assertSame('2026-07-04', $request->endDate?->format('Y-m-d'));
+        $this->assertSame(
+            (new \DateTimeImmutable('today +1 year'))->modify('+3 days')->format('Y-m-d'),
+            $request->endDate?->format('Y-m-d'),
+        );
     }
 }

--- a/api/tests/Functional/StageDeleteTest.php
+++ b/api/tests/Functional/StageDeleteTest.php
@@ -292,7 +292,7 @@ final class StageDeleteTest extends ApiTestCase
 
         $this->assertNotNull($request);
         $this->assertSame(
-            (new \DateTimeImmutable('today +1 year'))->modify('+2 days')->format('Y-m-d'),
+            new \DateTimeImmutable('today +1 year')->modify('+2 days')->format('Y-m-d'),
             $request->endDate?->format('Y-m-d'),
         );
     }

--- a/api/tests/Functional/StageDeleteTest.php
+++ b/api/tests/Functional/StageDeleteTest.php
@@ -51,7 +51,7 @@ final class StageDeleteTest extends ApiTestCase
 
         $request = new TripRequest(Uuid::fromString($tripId));
         $request->sourceUrl = 'https://www.komoot.com/tour/123456789';
-        $request->startDate = new \DateTimeImmutable('2026-07-01');
+        $request->startDate = new \DateTimeImmutable('today +1 year');
 
         $repo->initializeTrip($tripId, $request);
         $repo->storeSourceType($tripId, $sourceType);
@@ -285,12 +285,15 @@ final class StageDeleteTest extends ApiTestCase
         $this->assertResponseStatusCodeSame(202);
 
         // 4 → 3 stages: the trip now spans 3 days, so the end date shifts back to
-        // 2026-07-03 (recette #649).
+        // start date + 2 (recette #649).
         /** @var TripRequestRepositoryInterface $repo */
         $repo = self::getContainer()->get(TripRequestRepositoryInterface::class);
         $request = $repo->getRequest(self::TRIP_ID);
 
         $this->assertNotNull($request);
-        $this->assertSame('2026-07-03', $request->endDate?->format('Y-m-d'));
+        $this->assertSame(
+            (new \DateTimeImmutable('today +1 year'))->modify('+2 days')->format('Y-m-d'),
+            $request->endDate?->format('Y-m-d'),
+        );
     }
 }

--- a/api/tests/Functional/StageMoveTest.php
+++ b/api/tests/Functional/StageMoveTest.php
@@ -51,7 +51,7 @@ final class StageMoveTest extends ApiTestCase
 
         $request = new TripRequest(Uuid::fromString($tripId));
         $request->sourceUrl = 'https://www.komoot.com/tour/123456789';
-        $request->startDate = new \DateTimeImmutable('2026-07-01');
+        $request->startDate = new \DateTimeImmutable('today +1 year');
 
         $repo->initializeTrip($tripId, $request);
         $repo->storeSourceType($tripId, SourceType::KOMOOT_TOUR->value);

--- a/api/tests/Functional/StageSelectAccommodationTest.php
+++ b/api/tests/Functional/StageSelectAccommodationTest.php
@@ -55,7 +55,7 @@ final class StageSelectAccommodationTest extends ApiTestCase
 
         $request = new TripRequest(Uuid::fromString($tripId));
         $request->sourceUrl = 'https://www.komoot.com/tour/987654321';
-        $request->startDate = new \DateTimeImmutable('2026-07-01');
+        $request->startDate = new \DateTimeImmutable('today +1 year');
 
         $repo->initializeTrip($tripId, $request);
         $repo->storeSourceType($tripId, SourceType::KOMOOT_TOUR->value);
@@ -176,7 +176,7 @@ final class StageSelectAccommodationTest extends ApiTestCase
 
         $request = new TripRequest(Uuid::fromString($tripId));
         $request->sourceUrl = 'https://www.komoot.com/tour/987654321';
-        $request->startDate = new \DateTimeImmutable('2026-07-01');
+        $request->startDate = new \DateTimeImmutable('today +1 year');
 
         $repo->initializeTrip($tripId, $request);
         $repo->storeSourceType($tripId, SourceType::KOMOOT_TOUR->value);
@@ -272,7 +272,7 @@ final class StageSelectAccommodationTest extends ApiTestCase
 
         $request = new TripRequest(Uuid::fromString($tripId));
         $request->sourceUrl = 'https://www.komoot.com/tour/987654321';
-        $request->startDate = new \DateTimeImmutable('2026-07-01');
+        $request->startDate = new \DateTimeImmutable('today +1 year');
 
         $repo->initializeTrip($tripId, $request);
         $repo->storeSourceType($tripId, SourceType::KOMOOT_TOUR->value);

--- a/api/tests/Functional/StageUpdateTest.php
+++ b/api/tests/Functional/StageUpdateTest.php
@@ -51,7 +51,7 @@ final class StageUpdateTest extends ApiTestCase
 
         $request = new TripRequest(Uuid::fromString($tripId));
         $request->sourceUrl = 'https://www.komoot.com/tour/123456789';
-        $request->startDate = new \DateTimeImmutable('2026-07-01');
+        $request->startDate = new \DateTimeImmutable('today +1 year');
 
         $repo->initializeTrip($tripId, $request);
         $repo->storeSourceType($tripId, SourceType::KOMOOT_TOUR->value);

--- a/api/tests/Functional/TripUpdateTest.php
+++ b/api/tests/Functional/TripUpdateTest.php
@@ -278,15 +278,16 @@ final class TripUpdateTest extends ApiTestCase
     #[Test]
     public function rejectsEndDateBeforeStartDate(): void
     {
+        $startDate = new \DateTimeImmutable('today +1 year');
         $this->seedTrip(
             self::TRIP_ID,
-            startDate: new \DateTimeImmutable('2026-07-15'),
+            startDate: $startDate,
         );
 
         $this->client->request('PATCH', '/trips/'.self::TRIP_ID, [
             'headers' => array_merge(['Content-Type' => 'application/merge-patch+json'], $this->authHeader($this->jwtToken)),
             'json' => [
-                'endDate' => '2026-07-01T00:00:00+00:00',
+                'endDate' => $startDate->modify('-14 days')->format(\DateTimeInterface::ATOM),
             ],
         ]);
 
@@ -302,15 +303,16 @@ final class TripUpdateTest extends ApiTestCase
     #[Test]
     public function rejectsEndDateEqualToStartDate(): void
     {
+        $startDate = new \DateTimeImmutable('today +1 year');
         $this->seedTrip(
             self::TRIP_ID,
-            startDate: new \DateTimeImmutable('2026-07-15'),
+            startDate: $startDate,
         );
 
         $this->client->request('PATCH', '/trips/'.self::TRIP_ID, [
             'headers' => array_merge(['Content-Type' => 'application/merge-patch+json'], $this->authHeader($this->jwtToken)),
             'json' => [
-                'endDate' => '2026-07-15T00:00:00+00:00',
+                'endDate' => $startDate->format(\DateTimeInterface::ATOM),
             ],
         ]);
 


### PR DESCRIPTION
## Problème

La CI `PHPUnit (api)` échoue sur **38 tests** (repérée sur #801, mais sans lien avec le bump `actions/cache`). Toutes les erreurs sont un HTTP `423 Locked` :

> This trip is locked: its start date is today or in the past.

## Cause racine

Les tests fonctionnels de mutation d'étape (`StageCreate/Update/Delete/Move/SelectAccommodation`, `RestDayInsert`) codaient en dur `startDate = 2026-07-01`. `TripLocker::isLocked()` verrouille tout trip dont `startDate <= today (UTC)`. Le jour où l'horloge du runner a atteint le 2026-07-01, chaque requête create/update/delete/move/rest-day/accommodation a été rejetée en 423 → time bomb dans les fixtures.

Vérifié dans le conteneur :

```
old fixture    start=2026-07-01  => LOCKED (423)
new fixture    start=2027-07-02  => ok, not locked
```

## Correctif

- Remplace la date fixe par une date relative toujours future : `new \DateTimeImmutable('today +1 year')`.
- Dérive les 3 assertions `endDate` de cette même base (`->modify('+2/+3 days')`) au lieu de chaînes codées en dur, pour que le fixture n'expire plus jamais.

Preuve d'exécution complète laissée à la CI (leg PHP non rejouable en worktree local iso-prod).

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 critical, 0 warning, 0 inline comments.

**Resolved threads:** none — no prior unresolved review threads existed on this PR. Both previous `claude[bot]` reviews (1 dismissed, 1 changes-requested) have been dismissed/minimized as superseded — the finding they raised (same `TripLocker` time-bomb pattern in `TripUpdateTest.php`) was fixed by commit `527d051`.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Commit reviewed:** `527d051992d60179b5add7c8fdce6f343d40f296`
<!-- claude-review-end -->