### PR TITLE
fix(pwa): keep client-resolved stage labels so Komoot trips show city names immediately (recette #649)

### DIFF
--- a/pwa/src/app/(app)/trips/[id]/trip-page.tsx
+++ b/pwa/src/app/(app)/trips/[id]/trip-page.tsx
@@ -49,6 +49,11 @@ function TripLoader({ tripId }: { tripId: string }) {
   const setIsLocked = useTripStore((s) => s.setIsLocked);
   const setOutOfZone = useTripStore((s) => s.setOutOfZone);
   const clearTrip = useTripStore((s) => s.clearTrip);
+  // Track the stage count so the label-fill effect below re-runs when a Komoot
+  // trip's stages transition from empty (stageless draft) to populated — the
+  // first hydrate has no stages, so gating on `isLoaded` alone would never fill
+  // labels for that flow (recette #649).
+  const stageCount = useTripStore((s) => s.stages.length);
 
   useEffect(() => {
     let cancelled = false;
@@ -311,7 +316,11 @@ function TripLoader({ tripId }: { tripId: string }) {
       controller.abort();
       clearTimeout(timer);
     };
-  }, [isLoaded]);
+    // `stageCount` re-fires this effect when stages appear (Komoot draft →
+    // populated) or their number changes; it stays stable while labels resolve
+    // (updateStageLabel does not change the count), so resolution runs once per
+    // transition without spamming /geocode/reverse (recette #649).
+  }, [isLoaded, stageCount]);
 
   if (loadError) {
     return <TripNotFound />;

--- a/pwa/src/store/trip-store.test.ts
+++ b/pwa/src/store/trip-store.test.ts
@@ -193,6 +193,57 @@ describe("selectedStageIndex (master/detail)", () => {
   });
 });
 
+describe("setStages label preservation (recette #649)", () => {
+  it("keeps a client-resolved label when a resync payload has null labels and the endpoint is stable", () => {
+    const store = useTripStore.getState();
+    const current = makeStage(1);
+    current.startLabel = "Lille";
+    current.endLabel = "Roubaix";
+    store.setStages([current]);
+
+    // Resync /detail re-hydrate: server has not persisted labels yet (null).
+    const incoming = makeStage(1);
+    store.setStages([incoming]);
+
+    const result = useTripStore.getState().stages[0]!;
+    expect(result.startLabel).toBe("Lille");
+    expect(result.endLabel).toBe("Roubaix");
+  });
+
+  it("prefers the incoming label when the server has persisted one", () => {
+    const store = useTripStore.getState();
+    const current = makeStage(1);
+    current.startLabel = "Lille";
+    store.setStages([current]);
+
+    const incoming = makeStage(1);
+    incoming.startLabel = "Lille Centre";
+    store.setStages([incoming]);
+
+    expect(useTripStore.getState().stages[0]!.startLabel).toBe("Lille Centre");
+  });
+
+  it("does not leak a label onto a stage whose coordinates differ", () => {
+    const store = useTripStore.getState();
+    const current = makeStage(1);
+    current.startPoint = { lat: 50.63, lon: 3.05, ele: 0 };
+    current.endPoint = { lat: 50.69, lon: 3.18, ele: 0 };
+    current.startLabel = "Lille";
+    current.endLabel = "Roubaix";
+    store.setStages([current]);
+
+    // A genuinely different stage lands at index 0 (null labels).
+    const incoming = makeStage(1);
+    incoming.startPoint = { lat: 48.85, lon: 2.35, ele: 0 };
+    incoming.endPoint = { lat: 48.9, lon: 2.4, ele: 0 };
+    store.setStages([incoming]);
+
+    const result = useTripStore.getState().stages[0]!;
+    expect(result.startLabel).toBeNull();
+    expect(result.endLabel).toBeNull();
+  });
+});
+
 describe("applyTripReady preservation (recette #649)", () => {
   it("keeps accommodations/selection/alerts when the endpoint is stable", () => {
     const store = useTripStore.getState();

--- a/pwa/src/store/trip-store.ts
+++ b/pwa/src/store/trip-store.ts
@@ -371,7 +371,35 @@ export const useTripStore = create<TripState>()(
 
     setStages: (stages) =>
       set((state) => {
-        state.stages = stages;
+        const existing = state.stages;
+        state.stages = stages.map((incoming, i) => {
+          const prev = existing[i];
+          const startMatch =
+            prev &&
+            prev.startPoint.lat === incoming.startPoint.lat &&
+            prev.startPoint.lon === incoming.startPoint.lon;
+          const endMatch =
+            prev &&
+            prev.endPoint.lat === incoming.endPoint.lat &&
+            prev.endPoint.lon === incoming.endPoint.lon;
+
+          return {
+            ...incoming,
+            // Preserve client-only reverse-geocoded labels across a raw
+            // re-hydrate/resync when the endpoint has not moved and the
+            // incoming payload lacks a label (the backend has not persisted it
+            // yet). Without this, a resync `/detail` replace would blank labels
+            // the client just resolved for a Komoot trip — whose stages arrive
+            // after a stageless draft — until `trip_ready` (~30s). Mirrors the
+            // preservation in applyTripReady/applyStageUpdate (recette #649).
+            startLabel: startMatch
+              ? (incoming.startLabel ?? prev.startLabel)
+              : incoming.startLabel,
+            endLabel: endMatch
+              ? (incoming.endLabel ?? prev.endLabel)
+              : incoming.endLabel,
+          };
+        });
         const max = Math.max(0, stages.length - 1);
         if (state.selectedStageIndex > max) {
           state.selectedStageIndex = max;


### PR DESCRIPTION
## Contexte (recette #649)

La création d'un voyage depuis un **lien Komoot** (et le deep-link `?link=`) affichait le point de départ/arrivée de chaque étape en **coordonnées GPS brutes** (« 50.638°N, 3.050°E ») pendant ~30 s, avant que les **noms de villes** n'apparaissent. Un **import GPX** affichait les noms immédiatement. Le backend est symétrique et correct : le bug est purement frontend (timing + préservation des labels).

## Cause racine

Les labels d'étape viennent soit des `startLabel`/`endLabel` persistés serveur (async, lents — Nominatim ~30 s), soit d'un reverse-geocode côté client (`resolveStageLabels`). Le fallback affiche les coordonnées tant que le label est `null`.

Komoot diffère du GPX par deux défauts :

1. **Le fill client one-shot ne se relance jamais pour Komoot.** L'effet de reverse-geocode de `trip-page.tsx` était gaté sur `[isLoaded]` uniquement. En GPX, le premier hydrate `/detail` contient déjà les étapes → l'effet résout les labels. En Komoot, le premier hydrate est un **draft sans étapes** (elles arrivent plus tard via resync poll + Mercure) → l'effet ne fait rien à `isLoaded` et ne se relance jamais.

2. **`setStages`/hydrate écrasait les labels résolus côté client.** Quand les étapes arrivent, le re-hydrate resync `/detail` appelait `setStages`, qui faisait un **remplacement brut** `state.stages = stages` — écrasant à `null` tout label résolu côté client (le serveur ne l'a pas encore persisté). Même le fill Mercure `stages_computed` était effacé. Les labels ne réapparaissaient qu'à `trip_ready` (~30 s).

## Correctif (frontend uniquement, deux volets)

1. **`setStages` préserve les labels résolus côté client** (`pwa/src/store/trip-store.ts`) : lors du remplacement, on reporte un `startLabel`/`endLabel` non-null existant pour une étape dont l'endpoint (lat/lon) correspond, quand le label entrant est `null` — exactement l'idiome déjà utilisé par `applyTripReady`/`applyStageUpdate` (match sur les coordonnées, jamais sur l'index seul, pour ne pas fuiter un label vers une étape réellement différente). Un label serveur non-null l'emporte sur le label client.

2. **Le fill client se relance quand les étapes arrivent** (`pwa/src/app/(app)/trips/[id]/trip-page.tsx`) : l'effet de reverse-geocode dépend désormais aussi du **nombre d'étapes** (`stageCount`), pas seulement de `isLoaded`. Il se déclenche donc à la transition draft-vide → peuplé. `stageCount` reste stable pendant la résolution des labels (`updateStageLabel` ne change pas le compte), donc la résolution ne tourne qu'une fois par transition et ne spamme pas `/geocode/reverse`. Le filtre `pending` (étapes encore sans label) garde l'effet idempotent.

Le fallback coordonnées et son formatage ne sont pas touchés. Aucune modification backend.

## Tests

- `pwa/src/store/trip-store.test.ts` — nouveau bloc « setStages label preservation » : préservation d'un label client quand le payload resync a des labels `null` et endpoint stable ; priorité au label serveur non-null ; **pas de fuite** d'un label vers une étape aux coordonnées différentes.
- Vitest : `trip-store.test.ts` (24 tests) + `trip-load.test.ts` (7 tests) verts.
- ESLint, Prettier, `tsc --noEmit` : verts sur les fichiers touchés.

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 findings (0 critical, 0 warning). Small, well-scoped frontend fix; the coordinate-based label-preservation idiom in `setStages` mirrors the existing pattern already used in `applyTripReady`/`applyStageUpdate`, and the `stageCount` effect dependency correctly gates re-runs without causing extra Nominatim traffic (label updates don't change stage count). New tests cover preservation, server-label precedence, and the no-leak-across-different-coordinates case.

**Review checklist:**
- [x] Code respects the project architecture (local-first Zustand store, no backend changes)
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate (reuses existing coordinate-match preservation idiom)
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for (recette #649)

**Inline comments:** No inline comments.

_Reviewed commit: ead4a070ee684dbe353dc92294583d59abca6805_
<!-- claude-review-end -->