### PR TITLE
feat(ai): reactivate Gemini + shared-view read-only + origin-relative build (recette #649)

### DIFF
--- a/.docker/pwa/Dockerfile
+++ b/.docker/pwa/Dockerfile
@@ -47,6 +47,14 @@ ARG NEXT_PUBLIC_SENTRY_DSN
 # AI must stay visible (CI E2E in ci.yml, dev in compose.dev.yaml). The code and
 # endpoints are kept for a later re-enable; this is a single reversible switch.
 ARG NEXT_PUBLIC_ENABLE_AI=false
+# Client-facing origins, inlined at build time. Empty API URL → the browser calls
+# the API on the SAME origin it was served from (relative URLs), so the build
+# works unchanged on https://localhost, in prod (PWA + API share the origin), and
+# behind a tunnel (ngrok) for mobile testing. Empty Mercure URL → the client
+# derives the hub from the current origin too (see use-mercure). Only the native
+# Capacitor build sets NEXT_PUBLIC_MERCURE_URL to reach its remote hub.
+ARG NEXT_PUBLIC_API_URL=
+ARG NEXT_PUBLIC_MERCURE_URL=
 
 COPY --link pwa/. .
 
@@ -59,6 +67,8 @@ RUN --mount=type=secret,id=sentry_auth_token \
     NEXT_PUBLIC_APP_ENV="${NEXT_PUBLIC_APP_ENV}" \
     NEXT_PUBLIC_SENTRY_DSN="${NEXT_PUBLIC_SENTRY_DSN}" \
     NEXT_PUBLIC_ENABLE_AI="${NEXT_PUBLIC_ENABLE_AI}" \
+    NEXT_PUBLIC_API_URL="${NEXT_PUBLIC_API_URL}" \
+    NEXT_PUBLIC_MERCURE_URL="${NEXT_PUBLIC_MERCURE_URL}" \
     npm run build
 
 

--- a/api/src/Generation/AiTripGenerationService.php
+++ b/api/src/Generation/AiTripGenerationService.php
@@ -38,6 +38,42 @@ final readonly class AiTripGenerationService implements AiTripGenerationServiceI
      */
     private const float TARGET_TOLERANCE = 0.4;
 
+    /**
+     * Structured-output contract for the itinerary spec. Passed as the provider
+     * `response_format` (symfony/ai standard, honoured by the Gemini/OpenAI/
+     * Anthropic bridges) so the model returns a single valid JSON object with the
+     * right field TYPES — `loop` a real boolean, `days`/`km_per_day` real integers.
+     * Without it, weaker models (e.g. gemini-2.5-flash-lite) drift to prose or drop
+     * `loop`/`days`, so a "2-day loop" brief degrades to a 1-day point-to-point
+     * (recette #649). The prompt still describes the semantics; this guarantees the
+     * envelope is machine-parseable and complete.
+     *
+     * @var array<string, mixed>
+     */
+    private const array RESPONSE_FORMAT = [
+        'response_format' => [
+            'type' => 'json_schema',
+            'json_schema' => [
+                'name' => 'itinerary_spec',
+                'schema' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'start' => ['type' => 'string'],
+                        'loop' => ['type' => 'boolean'],
+                        'end' => ['type' => 'string'],
+                        'days' => ['type' => 'integer'],
+                        'km_per_day' => ['type' => 'integer'],
+                        'accommodation' => ['type' => 'string'],
+                        'waypoints' => ['type' => 'array', 'items' => ['type' => 'string']],
+                        'out_of_zone' => ['type' => 'boolean'],
+                        'out_of_zone_reason' => ['type' => 'string'],
+                    ],
+                    'required' => ['start', 'loop', 'days', 'km_per_day'],
+                ],
+            ],
+        ],
+    ];
+
     public function __construct(
         private SystemPromptLoader $promptLoader,
         private GeocoderInterface $geocoder,
@@ -164,7 +200,7 @@ final readonly class AiTripGenerationService implements AiTripGenerationServiceI
      */
     private function extractSpec(ResolvedLlmClient $resolved, string $model, string $systemPrompt, string $userMessage): ?array
     {
-        $response = $resolved->client->generate($model, $userMessage, $systemPrompt);
+        $response = $resolved->client->generate($model, $userMessage, $systemPrompt, self::RESPONSE_FORMAT);
         $raw = $response['response'] ?? null;
         if (!\is_string($raw)) {
             return null;

--- a/api/src/Llm/AiProvider.php
+++ b/api/src/Llm/AiProvider.php
@@ -41,7 +41,7 @@ enum AiProvider: string
     {
         return match ($this) {
             self::ANTHROPIC => 'claude-haiku-4-5-20251001',
-            self::GEMINI => 'gemini-2.0-flash',
+            self::GEMINI => 'gemini-2.5-flash-lite',
             self::OPENAI => 'gpt-4o-mini',
         };
     }
@@ -53,7 +53,7 @@ enum AiProvider: string
     {
         return match ($this) {
             self::ANTHROPIC => 'claude-sonnet-4-6',
-            self::GEMINI => 'gemini-2.0-flash',
+            self::GEMINI => 'gemini-2.5-flash-lite',
             self::OPENAI => 'gpt-4o-mini',
         };
     }

--- a/api/src/Llm/BriefChatInterpreter.php
+++ b/api/src/Llm/BriefChatInterpreter.php
@@ -94,9 +94,18 @@ final readonly class BriefChatInterpreter
     }
 
     /**
+     * A brief field is a short scalar (a city, a duration, a profile word). This
+     * caps string values so a model that leaks its chain-of-thought into a field
+     * — Gemini 2.5-flash occasionally dumps reasoning into e.g. `resupply` — cannot
+     * pollute the recap or the consolidated generation brief.
+     */
+    private const int MAX_COLLECTED_VALUE_LENGTH = 120;
+
+    /**
      * Keeps only string-keyed scalar (or null) entries from the model's
      * `collected` map, so the structured recap forwarded to the client stays a
-     * flat, predictable shape regardless of model noise.
+     * flat, predictable shape regardless of model noise. Over-long strings are
+     * dropped as noise, not truncated: a paragraph is never a real brief value.
      *
      * @param array<array-key, mixed> $collected
      *
@@ -110,7 +119,14 @@ final readonly class BriefChatInterpreter
                 continue;
             }
 
-            if (null === $value || \is_scalar($value)) {
+            if (\is_string($value)) {
+                $value = trim($value);
+                if ('' === $value || mb_strlen($value) > self::MAX_COLLECTED_VALUE_LENGTH) {
+                    continue;
+                }
+
+                $result[$key] = $value;
+            } elseif (null === $value || \is_scalar($value)) {
                 $result[$key] = $value;
             }
         }

--- a/api/src/State/TripAiChatProcessor.php
+++ b/api/src/State/TripAiChatProcessor.php
@@ -55,6 +55,49 @@ final readonly class TripAiChatProcessor implements ProcessorInterface
 {
     public const string PROMPT_NAME = 'brief-chat';
 
+    /**
+     * Structured-output contract for the brief-chat turn. Passed as the provider
+     * `response_format` (symfony/ai standard, honoured by the Gemini/OpenAI/
+     * Anthropic bridges) so the model is forced to emit a single valid JSON object
+     * every turn. Without it, the model drifts to plain prose across turns — the
+     * conversation history the client re-sends carries only the assistant `reply`
+     * text, so the model mimics prose and {@see BriefChatInterpreter} falls back to
+     * an empty `collected` / `readyToGenerate:false`, emptying the recap and
+     * disabling the launch button (recette #649). The prompt still describes the
+     * shape; this only guarantees the envelope is machine-parseable.
+     *
+     * @var array<string, mixed>
+     */
+    private const array RESPONSE_FORMAT = [
+        'response_format' => [
+            'type' => 'json_schema',
+            'json_schema' => [
+                'name' => 'brief_chat_reply',
+                'schema' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'reply' => ['type' => 'string'],
+                        'readyToGenerate' => ['type' => 'boolean'],
+                        'collected' => [
+                            'type' => 'object',
+                            'properties' => [
+                                'start' => ['type' => 'string'],
+                                'end' => ['type' => 'string'],
+                                'loop' => ['type' => 'boolean'],
+                                'durationDays' => ['type' => 'integer'],
+                                'profile' => ['type' => 'string'],
+                                'elevationTolerance' => ['type' => 'string'],
+                                'dates' => ['type' => 'string'],
+                                'resupply' => ['type' => 'string'],
+                            ],
+                        ],
+                    ],
+                    'required' => ['reply', 'readyToGenerate', 'collected'],
+                ],
+            ],
+        ],
+    ];
+
     public function __construct(
         private UserLlmResolverInterface $clientFactory,
         private SystemPromptLoader $promptLoader,
@@ -108,6 +151,7 @@ final readonly class TripAiChatProcessor implements ProcessorInterface
                 model: $resolved->provider->chatModel(),
                 messages: $messages,
                 systemPrompt: $systemPrompt,
+                options: self::RESPONSE_FORMAT,
             );
         } catch (AiUnavailableException $aiUnavailableException) {
             $reason = $aiUnavailableException->getReason();

--- a/api/tests/Unit/Generation/AiTripGenerationServiceTest.php
+++ b/api/tests/Unit/Generation/AiTripGenerationServiceTest.php
@@ -60,6 +60,31 @@ final class AiTripGenerationServiceTest extends TestCase
     }
 
     #[Test]
+    public function forcesStructuredJsonOutputOnTheProvider(): void
+    {
+        // Pin the response_format pass-through: it is the fix for the "AI does
+        // nothing / drifts to prose" defect (recette #649). A future refactor
+        // dropping the options argument must fail here, not silently regress.
+        $client = $this->createMock(LlmClientInterface::class);
+        $client->expects(self::once())
+            ->method('generate')
+            ->with(
+                self::anything(),
+                self::anything(),
+                self::anything(),
+                self::callback(static fn (array $options): bool => isset($options['response_format']['json_schema']['schema'])),
+            )
+            ->willReturn(['response' => '{"start":"Lille","loop":true,"days":2,"km_per_day":80,"waypoints":["Cambrai"]}']);
+
+        $result = $this->service(
+            geocoder: $this->geocoderReturning(new Coordinate(50.6, 3.0)),
+            routing: $this->routingReturning(150_000.0),
+        )->generate('boucle Lille 80 km/j', $this->resolved($client));
+
+        self::assertSame(AiGenerationOutcome::SUCCESS, $result->outcome);
+    }
+
+    #[Test]
     public function generatesAPointToPointRoute(): void
     {
         // Exercises the loop:false branch: $to = last coordinate, $via excludes both endpoints.

--- a/api/tests/Unit/Llm/AiProviderTest.php
+++ b/api/tests/Unit/Llm/AiProviderTest.php
@@ -18,8 +18,8 @@ final class AiProviderTest extends TestCase
         self::assertSame('claude-sonnet-4-6', AiProvider::ANTHROPIC->analysisModel());
         self::assertSame('gpt-4o-mini', AiProvider::OPENAI->chatModel());
         self::assertSame('gpt-4o-mini', AiProvider::OPENAI->analysisModel());
-        self::assertSame('gemini-2.0-flash', AiProvider::GEMINI->chatModel());
-        self::assertSame('gemini-2.0-flash', AiProvider::GEMINI->analysisModel());
+        self::assertSame('gemini-2.5-flash-lite', AiProvider::GEMINI->chatModel());
+        self::assertSame('gemini-2.5-flash-lite', AiProvider::GEMINI->analysisModel());
     }
 
     #[Test]

--- a/api/tests/Unit/Llm/BriefChatInterpreterTest.php
+++ b/api/tests/Unit/Llm/BriefChatInterpreterTest.php
@@ -128,6 +128,25 @@ final class BriefChatInterpreterTest extends TestCase
     }
 
     #[Test]
+    public function dropsOverLongCollectedValuesAndTrimsShortOnes(): void
+    {
+        // A "thinking" model (Gemini 2.5-flash) occasionally leaks its reasoning
+        // into a field value; such a paragraph is never a real brief field.
+        $blob = str_repeat('la ', 100); // 300 chars
+
+        $reply = $this->interpreter->interpret(
+            json_encode([
+                'reply' => 'OK.',
+                'readyToGenerate' => true,
+                'collected' => ['start' => '  Lille  ', 'resupply' => $blob],
+            ], \JSON_THROW_ON_ERROR),
+        );
+
+        // The over-long value is dropped; the short one is trimmed and kept.
+        $this->assertSame(['start' => 'Lille'], $reply->collected);
+    }
+
+    #[Test]
     public function readyToGenerateIsFalseUnlessStrictlyTrue(): void
     {
         $reply = $this->interpreter->interpret(

--- a/api/tests/Unit/State/TripAiChatProcessorTest.php
+++ b/api/tests/Unit/State/TripAiChatProcessorTest.php
@@ -71,6 +71,33 @@ final class TripAiChatProcessorTest extends TestCase
     }
 
     #[Test]
+    public function forcesStructuredJsonOutputOnTheProvider(): void
+    {
+        // Pin the response_format pass-through: it stops the brief-chat drifting
+        // to prose across turns (recette #649). A refactor dropping the options
+        // argument must fail here, not silently regress.
+        $llmClient = $this->createMock(LlmClientInterface::class);
+        $llmClient->expects(self::once())
+            ->method('chat')
+            ->with(
+                self::anything(),
+                self::anything(),
+                self::anything(),
+                self::callback(static fn (array $options): bool => isset($options['response_format']['json_schema']['schema'])),
+            )
+            ->willReturn(['message' => ['role' => 'assistant', 'content' => '{"reply":"ok","readyToGenerate":false,"collected":{}}']]);
+
+        $processor = $this->newProcessor(configured: true, llmContent: '', llmClient: $llmClient);
+
+        $result = $processor->process(
+            new AiChatRequest([new AiChatMessage('user', 'Bonjour')]),
+            new Post(),
+        );
+
+        self::assertInstanceOf(AiChatResponse::class, $result);
+    }
+
+    #[Test]
     public function nonJsonReplyFallsBackToRawTextWithReadyFalse(): void
     {
         $processor = $this->newProcessor(

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -31,7 +31,7 @@ services:
       JWT_SECRET_KEY: /app/config/jwt/private.pem
       JWT_PUBLIC_KEY: /app/config/jwt/public.pem
       JWT_PASSPHRASE: ""
-      FRONTEND_URL: "https://${SERVER_NAME:-localhost}"
+      FRONTEND_URL: "${FRONTEND_URL:-https://${SERVER_NAME:-localhost}}"
     secrets: !reset null
     extra_hosts:
       # Ensure that host.docker.internal is correctly defined on Linux
@@ -62,7 +62,7 @@ services:
       JWT_SECRET_KEY: /app/config/jwt/private.pem
       JWT_PUBLIC_KEY: /app/config/jwt/public.pem
       JWT_PASSPHRASE: ""
-      FRONTEND_URL: "https://${SERVER_NAME:-localhost}"
+      FRONTEND_URL: "${FRONTEND_URL:-https://${SERVER_NAME:-localhost}}"
     secrets: !reset null
     extra_hosts:
       - host.docker.internal:host-gateway
@@ -83,7 +83,7 @@ services:
       JWT_SECRET_KEY: /app/config/jwt/private.pem
       JWT_PUBLIC_KEY: /app/config/jwt/public.pem
       JWT_PASSPHRASE: ""
-      FRONTEND_URL: "https://${SERVER_NAME:-localhost}"
+      FRONTEND_URL: "${FRONTEND_URL:-https://${SERVER_NAME:-localhost}}"
     secrets: !reset null
     extra_hosts:
       - host.docker.internal:host-gateway
@@ -103,6 +103,14 @@ services:
       # and its code keeps being exercised while it is masked in prod/recette.
       # `next dev` reads NEXT_PUBLIC_* from the runtime env (no rebuild needed).
       NEXT_PUBLIC_ENABLE_AI: "true"
+      # Client API base. Default empty → the browser calls the API on the SAME
+      # origin it loaded from (relative URLs), so the app works unchanged whether
+      # served on https://localhost or through a tunnel (ngrok) for mobile
+      # testing. SSR keeps using the internal API_BACKEND_URL (http://php).
+      NEXT_PUBLIC_API_URL: "${NEXT_PUBLIC_API_URL-}"
+      # Mercure hub the browser subscribes to. Point it at the tunnel origin to
+      # get live SSE updates on mobile; the localhost default is fine on desktop.
+      NEXT_PUBLIC_MERCURE_URL: "${NEXT_PUBLIC_MERCURE_URL:-https://localhost/.well-known/mercure}"
     volumes: !override
       - ./pwa:/srv/app
       - pwa_node_modules:/srv/app/node_modules

--- a/compose.recette.yaml
+++ b/compose.recette.yaml
@@ -42,6 +42,17 @@ services:
     environment:
       <<: *recette-env
 
+  # Recette re-enables the AI surface to be tested end-to-end (ADR-046's
+  # default-off is a prod fail-safe; recette is where AI is exercised — see the
+  # header note). NEXT_PUBLIC_ENABLE_AI is inlined into the PWA bundle at build
+  # time, so this only takes effect on a rebuild: after toggling, run
+  #   docker compose -f compose.yaml -f compose.recette.yaml build pwa
+  # (`make start-recette` uses `up --wait`, which does not rebuild on its own).
+  pwa:
+    build:
+      args:
+        NEXT_PUBLIC_ENABLE_AI: "true"
+
   mailcatcher:
     # Pinned by digest: schickling/mailcatcher has no versioned tags, and the
     # mutable tag would let an upstream rebuild change the HTTP API recette-seed.sh relies on.

--- a/compose.yaml
+++ b/compose.yaml
@@ -278,6 +278,13 @@ services:
         # Override to "true" only where AI must show (CI E2E bake args, dev). The
         # code and endpoints are kept for a later re-enable (ADR-042).
         NEXT_PUBLIC_ENABLE_AI: "${NEXT_PUBLIC_ENABLE_AI:-false}"
+        # Client API + Mercure origins. Empty by default → the browser uses the
+        # SAME origin it was served from (relative API calls, same-origin Mercure
+        # hub), so the build is origin-agnostic: it works on https://localhost, in
+        # prod (PWA + API share the origin), and behind a tunnel (ngrok) for
+        # mobile testing without rebaking. Override only for a native/remote hub.
+        NEXT_PUBLIC_API_URL: "${NEXT_PUBLIC_API_URL-}"
+        NEXT_PUBLIC_MERCURE_URL: "${NEXT_PUBLIC_MERCURE_URL-}"
       # SENTRY_AUTH_TOKEN (source-map upload) is a real secret: passed as a
       # BuildKit secret so it never lands in an image layer or the build cache.
       secrets:

--- a/docs/adr/adr-042-optional-multi-provider-ai-byo-token.md
+++ b/docs/adr/adr-042-optional-multi-provider-ai-byo-token.md
@@ -45,10 +45,12 @@ Cloud providers only. No self-hosted Ollama.
 | Provider | `symfony/ai` bridge | Default chat model | Default analysis model |
 |----------|---------------------|--------------------|------------------------|
 | **Anthropic (Claude)** | `symfony/ai-anthropic-platform` | `claude-haiku-4-5-20251001` | `claude-sonnet-4-6` |
-| **Google (Gemini)** | `symfony/ai-gemini-platform` | `gemini-2.0-flash` | `gemini-2.0-flash` |
+| **Google (Gemini)** | `symfony/ai-gemini-platform` | `gemini-2.5-flash-lite` | `gemini-2.5-flash-lite` |
 | **OpenAI** | `symfony/ai-open-ai-platform` | `gpt-4o-mini` | `gpt-4o-mini` |
 
 Models are chosen cheap-but-capable per provider. They are **not user-selectable in v1** — the user picks a provider, not a model.
+
+> **Update (2026-07-02):** the Gemini default moved `gemini-2.0-flash` → `gemini-2.5-flash` → `gemini-2.5-flash-lite`. Google's free tier returns `limit: 0` for `generate_content` on `gemini-2.0-flash` (a `quota_exceeded` failure even with a valid key). `gemini-2.5-flash` works but its free tier is capped at **20 requests/day (RPD) and 5 RPM**, which recette testing exhausts quickly; **`gemini-2.5-flash-lite`** has a separate, higher free-tier budget (10 RPM, its own 20 RPD) — the current pin so testing isn't blocked by the daily cap. Limits are **per model**, so switching models resets the counter. Pinned in `AiProvider::chatModel()`/`analysisModel()`; a config/env override (instead of a hardcoded pin) is the natural next step if models need to change without a rebuild.
 
 ### 3. Encrypted per-user token + account API
 

--- a/pwa/src/components/accommodation-item.tsx
+++ b/pwa/src/components/accommodation-item.tsx
@@ -50,6 +50,8 @@ interface AccommodationItemProps {
   initialEditing?: boolean;
   onHoverStart?: () => void;
   onHoverEnd?: () => void;
+  /** Read-only surfaces (shared view): hide every mutating control. */
+  readOnly?: boolean;
 }
 
 export function AccommodationItem({
@@ -62,6 +64,7 @@ export function AccommodationItem({
   initialEditing = false,
   onHoverStart,
   onHoverEnd,
+  readOnly = false,
 }: AccommodationItemProps) {
   const t = useTranslations("accommodation");
   const [editing, setEditing] = useState(initialEditing);
@@ -220,52 +223,56 @@ export function AccommodationItem({
       onMouseEnter={onHoverStart}
       onMouseLeave={onHoverEnd}
     >
-      {/* Action buttons */}
-      <div className="absolute top-2 right-0 flex gap-0.5">
-        {(onSelect || onDeselect) && (
+      {/* Action buttons — hidden on read-only surfaces (shared view) so the
+          accommodation, including the selected one, cannot be re-selected,
+          edited or removed. */}
+      {!readOnly && (
+        <div className="absolute top-2 right-0 flex gap-0.5">
+          {(onSelect || onDeselect) && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className={`h-6 w-6 transition-opacity cursor-pointer ${
+                isSelected
+                  ? "text-primary opacity-100"
+                  : "text-muted-icon opacity-100 md:opacity-0 md:group-hover:opacity-100"
+              }`}
+              onClick={isSelected ? onDeselect : onSelect}
+              aria-label={isSelected ? t("deselect") : t("select")}
+              title={isSelected ? t("deselect") : t("selectTooltip")}
+            >
+              {isSelected ? (
+                <CheckCircle2 className="h-3.5 w-3.5" />
+              ) : (
+                <Circle className="h-3.5 w-3.5" />
+              )}
+            </Button>
+          )}
           <Button
             variant="ghost"
             size="icon"
-            className={`h-6 w-6 transition-opacity cursor-pointer ${
-              isSelected
-                ? "text-primary opacity-100"
-                : "text-muted-icon opacity-100 md:opacity-0 md:group-hover:opacity-100"
-            }`}
-            onClick={isSelected ? onDeselect : onSelect}
-            aria-label={isSelected ? t("deselect") : t("select")}
-            title={isSelected ? t("deselect") : t("selectTooltip")}
+            className="h-6 w-6 text-muted-icon opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-opacity cursor-pointer"
+            onClick={startEditing}
+            aria-label={t("edit")}
+            title={t("edit")}
           >
-            {isSelected ? (
-              <CheckCircle2 className="h-3.5 w-3.5" />
-            ) : (
-              <Circle className="h-3.5 w-3.5" />
-            )}
+            <Pencil className="h-3.5 w-3.5" />
           </Button>
-        )}
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-6 w-6 text-muted-icon opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-opacity cursor-pointer"
-          onClick={startEditing}
-          aria-label={t("edit")}
-          title={t("edit")}
-        >
-          <Pencil className="h-3.5 w-3.5" />
-        </Button>
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-6 w-6 text-muted-icon opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-opacity cursor-pointer"
-          onClick={() => {
-            if (isSelected) onDeselect?.();
-            onRemove();
-          }}
-          aria-label={t("remove")}
-          title={t("remove")}
-        >
-          <X className="h-3.5 w-3.5" />
-        </Button>
-      </div>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-6 w-6 text-muted-icon opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-opacity cursor-pointer"
+            onClick={() => {
+              if (isSelected) onDeselect?.();
+              onRemove();
+            }}
+            aria-label={t("remove")}
+            title={t("remove")}
+          >
+            <X className="h-3.5 w-3.5" />
+          </Button>
+        </div>
+      )}
 
       {/* Name + URL */}
       <div className="font-semibold text-sm pr-16 flex items-center gap-2 flex-wrap">

--- a/pwa/src/components/accommodation-panel.tsx
+++ b/pwa/src/components/accommodation-panel.tsx
@@ -162,6 +162,7 @@ export function AccommodationPanel({
             {displayIndex > 0 && <Separator className="my-2" />}
             <AccommodationItem
               accommodation={acc}
+              readOnly={readOnly}
               isSelected={isAccommodationSelected(originalIndex)}
               onUpdate={(data) => {
                 onUpdate(originalIndex, data);

--- a/pwa/src/components/ai-chat-card.tsx
+++ b/pwa/src/components/ai-chat-card.tsx
@@ -92,6 +92,35 @@ function formatRecapValue(value: unknown): string | null {
 }
 
 /**
+ * Serialize a `collected` value for the brief text handed to the generator.
+ * Unlike the recap display (booleans → "✓"), the brief must be unambiguous for
+ * the LLM spec extraction: a boolean becomes the literal `true`/`false`, so
+ * `loop` is not lost as a checkmark and generation keeps it a loop (recette #649).
+ */
+function briefValue(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "boolean") return value ? "true" : "false";
+  const str = String(value).trim();
+  return str === "" ? null : str;
+}
+
+/**
+ * Maps a `collected` key to the itinerary-spec vocabulary the generation prompt
+ * expects (`durationDays` → `days`), so the model maps the brief straight onto
+ * its spec fields instead of guessing.
+ */
+const BRIEF_KEYS: Readonly<Record<string, string>> = {
+  start: "start",
+  end: "end",
+  loop: "loop",
+  durationDays: "days",
+  profile: "profile",
+  elevationTolerance: "elevation_tolerance",
+  dates: "dates",
+  resupply: "resupply",
+};
+
+/**
  * Whether the brief carries a geocodable departure. This is the single hard
  * gate on the launch button (ADR-045): without a non-empty `collected.start`
  * the AI route generation has nothing to geocode, so we never let the rider
@@ -115,8 +144,8 @@ function buildBrief(
   userTurns: ReadonlyArray<string>,
 ): string {
   const structured = RECAP_FIELDS.map(({ key }) => {
-    const value = formatRecapValue(collected[key]);
-    return value === null ? null : `${key}: ${value}`;
+    const value = briefValue(collected[key]);
+    return value === null ? null : `${BRIEF_KEYS[key] ?? key}: ${value}`;
   }).filter((line): line is string => line !== null);
 
   const transcript = userTurns.map((t) => t.trim()).filter(Boolean);
@@ -270,7 +299,11 @@ export function AiChatCard({
           ...prev,
           { id: nextId(), role: "assistant", content: result.data.reply },
         ]);
-        setCollected(result.data.collected);
+        // Merge, don't overwrite: the recap accumulates across turns, so a turn
+        // that returns a partial (or, on a parse miss, empty) `collected` never
+        // wipes a departure already known — which would empty the recap and
+        // disable the launch button mid-conversation (recette #649).
+        setCollected((prev) => ({ ...prev, ...result.data.collected }));
         setReadyToGenerate(result.data.readyToGenerate);
         setConfigErrorKey(null);
         break;

--- a/pwa/src/components/ai-chat-card.tsx
+++ b/pwa/src/components/ai-chat-card.tsx
@@ -105,22 +105,6 @@ function briefValue(value: unknown): string | null {
 }
 
 /**
- * Maps a `collected` key to the itinerary-spec vocabulary the generation prompt
- * expects (`durationDays` → `days`), so the model maps the brief straight onto
- * its spec fields instead of guessing.
- */
-const BRIEF_KEYS: Readonly<Record<string, string>> = {
-  start: "start",
-  end: "end",
-  loop: "loop",
-  durationDays: "days",
-  profile: "profile",
-  elevationTolerance: "elevation_tolerance",
-  dates: "dates",
-  resupply: "resupply",
-};
-
-/**
  * Whether the brief carries a geocodable departure. This is the single hard
  * gate on the launch button (ADR-045): without a non-empty `collected.start`
  * the AI route generation has nothing to geocode, so we never let the rider
@@ -145,7 +129,7 @@ function buildBrief(
 ): string {
   const structured = RECAP_FIELDS.map(({ key }) => {
     const value = briefValue(collected[key]);
-    return value === null ? null : `${BRIEF_KEYS[key] ?? key}: ${value}`;
+    return value === null ? null : `${key}: ${value}`;
   }).filter((line): line is string => line !== null);
 
   const transcript = userTurns.map((t) => t.trim()).filter(Boolean);

--- a/pwa/src/components/chat/ChatHistoryLoader.tsx
+++ b/pwa/src/components/chat/ChatHistoryLoader.tsx
@@ -58,15 +58,6 @@ function toAiChatMessage(entry: TripChatMessageHistoryEntry): AiChatMessage {
 }
 
 /**
- * Module-level set of trip IDs whose persisted history has already been pulled
- * during this PWA session. The chat panel unmounts (and remounts) the loader
- * every time the rider closes the drawer, so without this guard each reopen
- * would refetch and wipe any in-memory messages added since the last fetch —
- * notably in-ride POI turns that are persisted asynchronously.
- */
-const hydratedTrips = new Set<string>();
-
-/**
  * Rehydrates the floating chat panel with the persisted history for a given
  * trip.
  *
@@ -81,12 +72,21 @@ export function ChatHistoryLoader({
   children,
 }: ChatHistoryLoaderProps) {
   const t = useTranslations("chat.history");
-  const alreadyHydrated = hydratedTrips.has(tripId);
-  const [isLoading, setIsLoading] = useState(!alreadyHydrated);
-  const [isHydrated, setIsHydrated] = useState(alreadyHydrated);
+  // Gate on the in-memory history, not a one-shot "already fetched" flag: the
+  // panel unmounts on close and the history is wiped on a trip switch
+  // (use-trip-planner clears it), so a reopen must be able to re-pull the
+  // persisted turns from PostgreSQL. We skip the fetch only when the store
+  // still holds turns (freshly typed, or an async in-ride POI turn) that a
+  // refetch could wipe (recette #649).
+  const [isLoading, setIsLoading] = useState(
+    () => useUiStore.getState().chatHistory.length === 0,
+  );
+  const [isHydrated, setIsHydrated] = useState(
+    () => useUiStore.getState().chatHistory.length > 0,
+  );
 
   useEffect(() => {
-    if (hydratedTrips.has(tripId)) {
+    if (useUiStore.getState().chatHistory.length > 0) {
       setIsLoading(false);
       setIsHydrated(true);
       return;
@@ -106,16 +106,13 @@ export function ChatHistoryLoader({
 
         const ui = useUiStore.getState();
         // Race guard: if the rider sent a message while the fetch was in
-        // flight the in-memory store is no longer empty. Wiping it via
-        // clearHistory() would discard their freshly-typed turn (already on
-        // its way to the backend), so we skip seeding entirely and let the
-        // next reload pick up the merged history from PostgreSQL.
+        // flight the in-memory store is no longer empty. Seeding would then
+        // duplicate the live turn, so skip it and keep what's on screen.
         if (entries.length > 0 && ui.chatHistory.length === 0) {
           for (const entry of entries) {
             ui.appendMessage(toAiChatMessage(entry));
           }
         }
-        hydratedTrips.add(tripId);
         setIsHydrated(true);
       } catch {
         // Silent fail — the rider can still chat without prior history.

--- a/pwa/src/hooks/use-mercure.ts
+++ b/pwa/src/hooks/use-mercure.ts
@@ -11,9 +11,23 @@ import { toast } from "@/components/ui/sonner";
 import { DEFAULT_ACCOMMODATION_RADIUS_KM } from "@/lib/accommodation-constants";
 import type { StageData } from "@/lib/validation/schemas";
 
-const MERCURE_URL =
-  process.env.NEXT_PUBLIC_MERCURE_URL ??
-  "https://localhost/.well-known/mercure";
+/**
+ * The Mercure hub the browser subscribes to. An explicit
+ * `NEXT_PUBLIC_MERCURE_URL` wins (the native Capacitor build targets its remote
+ * hub); otherwise the hub is taken from the CURRENT origin, so the web app works
+ * unchanged on https://localhost, in prod (same origin), and behind a tunnel
+ * (ngrok) for mobile testing — without baking a URL into the bundle. The
+ * localhost fallback only applies during SSR, where no EventSource is opened.
+ */
+function resolveMercureHubUrl(): string {
+  if (process.env.NEXT_PUBLIC_MERCURE_URL) {
+    return process.env.NEXT_PUBLIC_MERCURE_URL;
+  }
+  if (typeof window !== "undefined") {
+    return `${window.location.origin}/.well-known/mercure`;
+  }
+  return "https://localhost/.well-known/mercure";
+}
 
 const stageDiffTimers = new Map<number, ReturnType<typeof setTimeout>>();
 
@@ -743,7 +757,10 @@ export function useMercure(
     if (!tripId) return;
 
     // TODO: wire authHeaderFactory when auth store is implemented (#78)
-    const client = new MercureClient(MERCURE_URL, `/trips/${tripId}`);
+    const client = new MercureClient(
+      resolveMercureHubUrl(),
+      `/trips/${tripId}`,
+    );
     if (mercureToken) {
       client.setMercureToken(mercureToken);
     }

--- a/pwa/src/lib/api/client.ts
+++ b/pwa/src/lib/api/client.ts
@@ -730,7 +730,12 @@ export async function fetchTripChatHistory(
 const tripChatResponseSchema = z.object({
   tripId: z.string(),
   action: z.string(),
-  params: z.record(z.string(), z.unknown()),
+  // PHP serialises an empty params map as a JSON array (`[]`), which a bare
+  // `z.record` rejects (parsed type "array") — failing the WHOLE parse and
+  // surfacing a spurious "Une erreur est survenue" on every `info` reply
+  // (recette #649). `.catch({})` coerces that (and any malformed value) to an
+  // empty map, mirroring the brief-chat `collected` schema.
+  params: z.record(z.string(), z.unknown()).catch({}),
   response: z.string(),
   dispatched: z.boolean(),
   impactedStageNumbers: z.array(z.number()).optional(),

--- a/scripts/ngrok-recette.sh
+++ b/scripts/ngrok-recette.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env sh
+# Expose the RUNNING recette stack over an ngrok tunnel for mobile browser
+# testing, without changing your ngrok command.
+#
+# Usage:
+#   1. Boot recette once with the URL-agnostic PWA build:
+#        docker compose -f compose.yaml -f compose.recette.yaml build php pwa
+#        docker compose -f compose.yaml -f compose.recette.yaml up --wait
+#   2. Start your tunnel to the local Caddy (default HTTPS):
+#        ngrok http https://localhost
+#   3. Point the backend at the tunnel host (re-run whenever the ngrok URL
+#      changes — ngrok-free rotates it on every restart):
+#        scripts/ngrok-recette.sh <ngrok-host>
+#      e.g. scripts/ngrok-recette.sh abcd-1234.ngrok-free.app
+#
+# Why: Caddy only serves the hosts in SERVER_NAME. ngrok connects to the local
+# Caddy over TLS with SNI=localhost and forwards the original Host (the ngrok
+# domain), so Caddy must serve BOTH: "localhost" (for the tunnel's TLS handshake)
+# and the ngrok domain (to route + trust the request). local_certs keeps every
+# cert self-signed (no failing Let's Encrypt attempt for the ngrok domain). The
+# PWA bundle is already origin-relative, so no rebuild is needed on URL change.
+set -eu
+
+HOST="${1:?Usage: $0 <ngrok-host> (e.g. abcd-1234.ngrok-free.app)}"
+# Escape dots for the TRUSTED_HOSTS regex.
+ESC=$(printf '%s' "$HOST" | sed 's/[.]/\\./g')
+
+SERVER_NAME="localhost, $HOST" \
+CADDY_GLOBAL_OPTIONS="local_certs" \
+TRUSTED_HOSTS="^(localhost|$ESC|php)$" \
+FRONTEND_URL="https://$HOST" \
+  docker compose -f compose.yaml -f compose.recette.yaml up -d --no-deps php
+
+echo "Recette now served for https://$HOST (and https://localhost)."
+echo "Open https://$HOST on your phone (accept the ngrok interstitial once)."


### PR DESCRIPTION
## Summary

Recette-testing round: the AI surface is functional again with a real Gemini key, several assistant/shared-view bugs are fixed, and the PWA build is made origin-relative so the stack can be reached from a mobile browser through a tunnel.

Root cause of "AI does nothing": Google's free tier now serves `gemini-2.0-flash` with `limit: 0` (a `quota_exceeded` failure even with a valid key), so the pinned model made every AI feature fail. The fix moves the pin to `gemini-2.5-flash-lite` and forces structured JSON output so weaker models stop drifting to prose across turns.

## Changes

- **`feat(ai)`** — reactivate + harden the assistant:
  - pin Gemini chat/analysis to `gemini-2.5-flash-lite` (`AiProvider` + test + ADR-042).
  - `TripAiChatProcessor` / `AiTripGenerationService`: pass a `response_format` json_schema so brief-chat returns a parseable envelope every turn (recap + launch button stay live) and a "2-day loop" brief is no longer degraded to a 1-day point-to-point.
  - `BriefChatInterpreter`: drop over-long `collected` values (thinking models occasionally leak reasoning into a field).
  - PWA: send an unambiguous brief (`loop`, `days`), merge the `collected` recap across turns, coerce an empty `params` map (`[]` → `{}`) so `info` replies no longer surface a spurious "Une erreur est survenue", and reload persisted chat history when the panel reopens.
  - enable the AI surface in the iso-prod recette build (`compose.recette.yaml`).
- **`fix(pwa)`** — the shared view now stays read-only for accommodations: `readOnly` is threaded to `AccommodationItem` and every mutating control (select / deselect / edit / remove) is hidden, so the selected accommodation can no longer be changed.
- **`feat(build)`** — origin-relative PWA so the app works behind a tunnel (ngrok, mobile): the client API base defaults to empty (same-origin) via a build arg wired through `compose.yaml` + the PWA Dockerfile, the Mercure hub is derived from `window.location.origin` (explicit `NEXT_PUBLIC_MERCURE_URL` still wins for the native build), `FRONTEND_URL` is decoupled from `SERVER_NAME` in the dev overrides, and `scripts/ngrok-recette.sh` points the running recette at a tunnel host.

## Bug fix

Fixes several recette #649 findings (AI unusable / brief-chat button toggling / in-ride chat error / lost chat history / editable shared-view accommodation / blank mobile screen).

- [ ] Linked GlitchTip event ID and related incident issue (if applicable) — n/a

## Test plan

- [x] `make qa` — run locally: php-cs-fixer (0 changes), targeted PHPStan L9 on changed files (no errors), ESLint (0 errors), Prettier (formatted); full `rector`/PHPStan/e2e run in CI.
- [x] New/updated tests cover changed behavior — `AiProviderTest` (new pin), `BriefChatInterpreterTest` (over-long drop).
- [x] Tests: Vitest **208 passed**; PHPUnit on the affected suites (`Llm`, `Generation`, `State/TripAiChat`, `Functional/TripAiChat`) green.
- [x] Manual verification: end-to-end via ngrok (app renders, API `401`, JS chunks `200`); brief-chat 2-turn returns a populated `collected` + `readyToGenerate`; AI generation of a Lille loop; async stage analysis + trip overview persisted (worker logs); loaded-trip + in-ride chat; shared-view accommodation controls hidden (type-check + `readOnly` chain traced).

## Verification

- [ ] Related runbook updated if applicable — n/a
- [x] If this PR introduces or removes a secret, `docs/runbooks/secrets-inventory.md` is updated — no new secret (the tunnel URL is a runtime env, not committed; `AI_TOKEN_ENC_KEY` unchanged).

## Auto-critique

- [x] No leftover `console.log`, `dump()`, `dd()`, or debug statements
- [x] No stale TODO/FIXME comments
- [x] No dead code
- [x] Code respects the project architecture (stateless backend, local-first frontend, DTO contract)
- [x] SOLID principles and Law of Demeter are followed
- [x] Documentation (PHPDoc, JSDoc) is up to date for modified public APIs
- [x] If backend DTOs changed: `schema.d.ts` is regenerated — n/a, no API DTO shape changed (only internal `response_format` options + model strings)

<!-- claude-review-start -->
## Claude Review

**Findings:** 0 critical, 0 warning, 0 suggestion.

**Resolved threads:** Resolved 2 previously open threads — both flagged the `response_format` pass-through was unpinned by a test assertion; fixed in the latest commit (`8874668`) with `forcesStructuredJsonOutputOnTheProvider` tests in `AiTripGenerationServiceTest` and `TripAiChatProcessorTest`.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Commit reviewed:** `8874668e2bad21ae7c61ac3df5a2afa321c3bfdb`
<!-- claude-review-end -->