### PR TITLE
ci: run each CI job only when its area changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,10 @@ jobs:
           fi
           echo "Changed files:"; printf '%s\n' "$files"
 
-          # Fail-safe: run the full suite on non-PR events, on CI-definition changes,
-          # or as soon as a changed file falls outside every recognised zone.
-          known='^api/|^provisioner/|^pwa/|^\.docker/|^\.dockerignore$|^compose[^/]*\.yaml$|\.md$'
+          # Recognised zones. Repo meta files (.git*, .github/** except workflows) have no code
+          # impact, so they are recognised here and skip the code/heavy jobs. Fail-safe: run the
+          # full suite on non-PR events, on workflow changes, or when a file matches no zone.
+          known='^api/|^provisioner/|^pwa/|^\.docker/|^\.dockerignore$|^compose[^/]*\.yaml$|^\.git|\.md$'
           run_all=false
           [ "$EVENT_NAME" != "pull_request" ] && run_all=true || true
           printf '%s\n' "$files" | grep -qE '^\.github/workflows/' && run_all=true || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,8 @@ jobs:
           # full suite on non-PR events, on workflow changes, or when a file matches no zone.
           known='^api/|^provisioner/|^pwa/|^\.docker/|^\.dockerignore$|^compose[^/]*\.yaml$|^\.git|\.md$'
           run_all=false
-          [ "$EVENT_NAME" != "pull_request" ] && run_all=true || true
-          printf '%s\n' "$files" | grep -qE '^\.github/workflows/' && run_all=true || true
+          if [ "$EVENT_NAME" != "pull_request" ]; then run_all=true; fi
+          if printf '%s\n' "$files" | grep -qE '^\.github/workflows/'; then run_all=true; fi
           if [ -n "$files" ] && printf '%s\n' "$files" | grep -qvE "$known"; then run_all=true; fi
 
           flag() { if [ "$run_all" = true ] || printf '%s\n' "$files" | grep -qE "$1"; then echo true; else echo false; fi; }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,68 @@ env:
   NODE_ENV: test
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      api: ${{ steps.filter.outputs.api }}
+      provisioner: ${{ steps.filter.outputs.provisioner }}
+      pwa: ${{ steps.filter.outputs.pwa }}
+      docker: ${{ steps.filter.outputs.docker }}
+      docs: ${{ steps.filter.outputs.docs }}
+      e2e: ${{ steps.filter.outputs.e2e }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0 # merge-base required for the PR diff
+      - name: Compute changed areas
+        id: filter
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            files="$(git diff --name-only "$BASE_SHA...$HEAD_SHA")"
+          else
+            files=""
+          fi
+          echo "Changed files:"; printf '%s\n' "$files"
+
+          # Fail-safe: run the full suite on non-PR events, on CI-definition changes,
+          # or as soon as a changed file falls outside every recognised zone.
+          known='^api/|^provisioner/|^pwa/|^\.docker/|^\.dockerignore$|^compose[^/]*\.yaml$|\.md$'
+          run_all=false
+          [ "$EVENT_NAME" != "pull_request" ] && run_all=true || true
+          printf '%s\n' "$files" | grep -qE '^\.github/workflows/' && run_all=true || true
+          if [ -n "$files" ] && printf '%s\n' "$files" | grep -qvE "$known"; then run_all=true; fi
+
+          flag() { if [ "$run_all" = true ] || printf '%s\n' "$files" | grep -qE "$1"; then echo true; else echo false; fi; }
+          api=$(flag '^api/')
+          provisioner=$(flag '^provisioner/')
+          pwa=$(flag '^pwa/')
+          docker=$(flag '^\.docker/|^\.dockerignore$|^compose[^/]*\.yaml$')
+          docs=$(flag '\.md$')
+          if [ "$api" = true ] || [ "$pwa" = true ] || [ "$docker" = true ]; then e2e=true; else e2e=false; fi
+
+          {
+            echo "api=$api"
+            echo "provisioner=$provisioner"
+            echo "pwa=$pwa"
+            echo "docker=$docker"
+            echo "docs=$docs"
+            echo "e2e=$e2e"
+          } | tee -a "$GITHUB_OUTPUT"
+
   phpunit:
     name: PHPUnit
+    needs: changes
+    if: >-
+      !cancelled() &&
+      (needs.changes.outputs.api == 'true' || needs.changes.outputs.provisioner == 'true' ||
+      needs.changes.result == 'failure')
     runs-on: ubuntu-latest
     container:
       image: docker.io/esoledad/php:8.5
@@ -97,6 +157,10 @@ jobs:
 
   openapi-lint:
     name: OpenAPI Lint
+    needs: changes
+    if: >-
+      !cancelled() &&
+      (needs.changes.outputs.api == 'true' || needs.changes.result == 'failure')
     runs-on: ubuntu-latest
     container:
       image: docker.io/esoledad/php:8.5
@@ -125,6 +189,10 @@ jobs:
 
   hadolint:
     name: Hadolint
+    needs: changes
+    if: >-
+      !cancelled() &&
+      (needs.changes.outputs.docker == 'true' || needs.changes.result == 'failure')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -136,6 +204,11 @@ jobs:
 
   php-cs-fixer:
     name: PHP CS Fixer
+    needs: changes
+    if: >-
+      !cancelled() &&
+      (needs.changes.outputs.api == 'true' || needs.changes.outputs.provisioner == 'true' ||
+      needs.changes.result == 'failure')
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -173,6 +246,10 @@ jobs:
 
   markdown-lint:
     name: Markdown Lint
+    needs: changes
+    if: >-
+      !cancelled() &&
+      (needs.changes.outputs.docs == 'true' || needs.changes.result == 'failure')
     runs-on: ubuntu-latest
     container:
       image: davidanson/markdownlint-cli2
@@ -185,6 +262,10 @@ jobs:
 
   markdown-links:
     name: Markdown Links
+    needs: changes
+    if: >-
+      !cancelled() &&
+      (needs.changes.outputs.docs == 'true' || needs.changes.result == 'failure')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -203,6 +284,11 @@ jobs:
 
   symfony-security-check:
     name: Security Check
+    needs: changes
+    if: >-
+      !cancelled() &&
+      (needs.changes.outputs.api == 'true' || needs.changes.outputs.provisioner == 'true' ||
+      needs.changes.result == 'failure')
     runs-on: ubuntu-latest
     container:
       image: docker.io/esoledad/php:8.5
@@ -224,6 +310,11 @@ jobs:
 
   phpstan:
     name: PHPStan
+    needs: changes
+    if: >-
+      !cancelled() &&
+      (needs.changes.outputs.api == 'true' || needs.changes.outputs.provisioner == 'true' ||
+      needs.changes.result == 'failure')
     runs-on: ubuntu-latest
     container:
       image: docker.io/esoledad/php:8.5
@@ -264,6 +355,11 @@ jobs:
 
   rector:
     name: Rector
+    needs: changes
+    if: >-
+      !cancelled() &&
+      (needs.changes.outputs.api == 'true' || needs.changes.outputs.provisioner == 'true' ||
+      needs.changes.result == 'failure')
     runs-on: ubuntu-latest
     container:
       image: docker.io/esoledad/php:8.5
@@ -298,6 +394,10 @@ jobs:
 
   playwright:
     name: Playwright
+    needs: changes
+    if: >-
+      !cancelled() &&
+      (needs.changes.outputs.e2e == 'true' || needs.changes.result == 'failure')
     runs-on: ubuntu-latest
     env:
       COMPOSE_FILE: compose.yaml
@@ -360,6 +460,10 @@ jobs:
 
   playwright-recette:
     name: Playwright BDD Recette
+    needs: changes
+    if: >-
+      !cancelled() &&
+      (needs.changes.outputs.e2e == 'true' || needs.changes.result == 'failure')
     runs-on: ubuntu-latest
     env:
       COMPOSE_FILE: compose.yaml
@@ -424,6 +528,10 @@ jobs:
 
   eslint:
     name: Eslint
+    needs: changes
+    if: >-
+      !cancelled() &&
+      (needs.changes.outputs.pwa == 'true' || needs.changes.result == 'failure')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -443,6 +551,10 @@ jobs:
 
   npm-audit:
     name: npm audit
+    needs: changes
+    if: >-
+      !cancelled() &&
+      (needs.changes.outputs.pwa == 'true' || needs.changes.result == 'failure')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -462,6 +574,10 @@ jobs:
 
   i18n-check:
     name: i18n check
+    needs: changes
+    if: >-
+      !cancelled() &&
+      (needs.changes.outputs.pwa == 'true' || needs.changes.result == 'failure')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -481,6 +597,10 @@ jobs:
 
   typescript-check:
     name: TypeScript Check
+    needs: changes
+    if: >-
+      !cancelled() &&
+      (needs.changes.outputs.pwa == 'true' || needs.changes.result == 'failure')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -500,6 +620,10 @@ jobs:
 
   unit-tests:
     name: Unit Tests (Vitest)
+    needs: changes
+    if: >-
+      !cancelled() &&
+      (needs.changes.outputs.pwa == 'true' || needs.changes.result == 'failure')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -519,6 +643,10 @@ jobs:
 
   mobile-build:
     name: Mobile APK Build
+    needs: changes
+    if: >-
+      !cancelled() &&
+      (needs.changes.outputs.pwa == 'true' || needs.changes.result == 'failure')
     runs-on: ubuntu-latest
     continue-on-error: true # TODO: remove once APK build is consistently stable
     steps:


### PR DESCRIPTION
## Summary

Toute la CI (`ci.yml`, 18 jobs) se lançait sur chaque PR, y compris les tests lourds (PHPUnit, Playwright, build APK) quand seule la doc changeait. Cette PR gate chaque job pour ne le jouer que si sa zone du dépôt est touchée.

Détection **native**, sans action tierce (`git diff` dans un job `changes`) et **sans toucher à la protection de branche** : les noms de jobs/contextes sont inchangés, et un check requis `skipped` compte comme réussi côté GitHub.

## Changes

- Nouveau job `changes` : `git diff` natif -> sorties `api`, `provisioner`, `pwa`, `docker`, `docs`, `e2e`.
- Chaque job existant reçoit `needs: changes` + un `if:` conditionnel (motif matriciel `api || provisioner` pour les 5 jobs matriciels, `matrix` n'étant pas dispo dans `jobs.<id>.if`).
- **Fail-safe** : événements non-PR, changement de `.github/workflows/`, ou tout fichier hors zones reconnues -> suite complète. Garde-fou `!cancelled()` + fallback `needs.changes.result == 'failure'` -> si la détection plante, tout se relance (jamais de check requis skippé en silence).
- `e2e = api || pwa || docker` : une PR provisioner-only skippe Playwright (le provisioner n'est pas dans le stack E2E).

## Test plan

- [x] `actionlint` (Docker) : 0 erreur de syntaxe/expression, 0 finding sur le job `changes` ni sur les `if:` ajoutés (les 13 findings `shellcheck` restants sont préexistants sur `git config`/`composer config`).
- [x] Dry-run de la logique de détection sur 11 scénarios (docs-only, api-only, provisioner-only, pwa-only, compose/Dockerfile, Makefile/inconnu, workflow-change, mixte, push) : sorties conformes.
- [ ] `make qa` : sans objet ici (aucun lint de `make qa` ne couvre le YAML de workflow ; validé via `actionlint`).
- [x] Cette PR touche `.github/workflows/**` -> `run_all` -> la suite complète tourne sur cette PR même, ce qui valide que le workflow parse et s'exécute. La preuve du *skip* se verra sur une PR docs-only ultérieure.

## Verification

- [x] Aucun secret introduit/retiré.
- [x] Aucun runbook impacté.

## Auto-critique

- [x] Pas de `console.log`/`dump()`/`dd()`/debug.
- [x] Pas de TODO/FIXME ajouté.
- [x] Pas de code mort.
- [x] Respecte l'architecture (changement CI uniquement).
- [x] Pas de DTO backend modifié -> pas de `make typegen`.



<!-- claude-review-start -->
## Claude Review

**Summary:** 0 findings (0 critical, 0 warning, 0 suggestion). The prior SC2015 finding was fixed in `7603761` (explicit `if` blocks replace the `A && B || C` idiom) — independently re-verified with `shellcheck` against the extracted `changes`-job script: 0 findings. Also independently re-ran the 11-scenario dry-run (docs-only, api-only, provisioner-only, pwa-only, compose/dockerignore, workflow-change, unknown-root-file, meta-only-.gitignore, meta-only-CODEOWNERS, mixed-api-and-unknown, push-event) plus an empty-diff-PR edge case — all outputs match the documented fail-safe design, including `.github/**` meta files (non-workflow) correctly recognized as no-code-impact.

Resolved 1 previously open thread that was addressed.

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases (manual actionlint + shellcheck + 11-scenario dry-run documented in PR description and independently reproduced; not unit/E2E-testable since this is CI-only YAML)
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Inline comments

No inline comments.

_Commit reviewed: `760376122e6c58a71067cdf6eb86813950208cb1`_
<!-- claude-review-end -->