### PR TITLE
ci: recognise docs/ tree so doc-asset changes skip code jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,10 +46,11 @@ jobs:
           fi
           echo "Changed files:"; printf '%s\n' "$files"
 
-          # Recognised zones. Repo meta files (.git*, .github/** except workflows) have no code
-          # impact, so they are recognised here and skip the code/heavy jobs. Fail-safe: run the
-          # full suite on non-PR events, on workflow changes, or when a file matches no zone.
-          known='^api/|^provisioner/|^pwa/|^\.docker/|^\.dockerignore$|^compose[^/]*\.yaml$|^\.git|\.md$'
+          # Recognised zones. Repo meta files (.git*, .github/** except workflows) and the whole
+          # docs/ tree (incl. non-markdown assets such as screenshots) have no code impact, so they
+          # are recognised here and skip the code/heavy jobs. Fail-safe: run the full suite on
+          # non-PR events, on workflow changes, or when a file matches no zone.
+          known='^api/|^provisioner/|^pwa/|^\.docker/|^\.dockerignore$|^compose[^/]*\.yaml$|^\.git|^docs/|\.md$'
           run_all=false
           if [ "$EVENT_NAME" != "pull_request" ]; then run_all=true; fi
           if printf '%s\n' "$files" | grep -qE '^\.github/workflows/'; then run_all=true; fi
@@ -60,7 +61,7 @@ jobs:
           provisioner=$(flag '^provisioner/')
           pwa=$(flag '^pwa/')
           docker=$(flag '^\.docker/|^\.dockerignore$|^compose[^/]*\.yaml$')
-          docs=$(flag '\.md$')
+          docs=$(flag '^docs/|\.md$')
           if [ "$api" = true ] || [ "$pwa" = true ] || [ "$docker" = true ]; then e2e=true; else e2e=false; fi
 
           {


### PR DESCRIPTION
## Summary

Suite à #810, une PR de doc (ex #811) déclenchait **toute** la CI, **API comprise**, alors qu'aucun fichier `api/` n'était touché.

Cause (confirmée sur le run de #811) : le détecteur de changements ne reconnaissait la doc que via `\.md$`. Les **assets non-markdown** (`docs/assets/screenshots/*.png`) ne matchaient **aucune zone** → ils déclenchaient le fail-safe `run_all` (« chemin inconnu → suite complète ») → tous les jobs, dont l'API, tournaient.

Fix : reconnaître **tout l'arbre `docs/`** (assets compris) — `^docs/` ajouté à la regex des zones connues (plus de `run_all`) et au flag `docs` (les jobs markdown tournent toujours sur un changement de doc).

## Changes

- `known` (zones reconnues) : `+ ^docs/` — un fichier sous `docs/` ne déclenche plus le fail-safe `run_all`.
- Flag `docs` : `\.md$` -> `^docs/|\.md$`.
- Commentaire mis à jour.

## Test plan

- [x] Dry-run **GNU grep** sur la vraie liste des 28 fichiers de #811 : `run_all=false`, **`api=false`** (backend skippé), `docs=true`. Avant le fix : `run_all=true`, `api=true` (reproduit le bug).
- [x] Non-régression sur : `docs/assets/x.png` (docs seul), `docs/*.md`, `README.md`, `api/`-only, `provisioner/`-only, `pwa/`-only, `.github/dependabot.yml` (rien), `Makefile`/push (`run_all`).
- [x] `actionlint` 1.7.12 : 13 findings, tous du shellcheck préexistant, **0 nouveau**, 0 erreur d'expression.
- [ ] `make qa` : sans objet (ne lint pas le YAML de workflow ; validé via actionlint).

> Note : les captures sous `pwa/public/images/**` restent dans la zone `pwa/` et déclenchent les jobs pwa + Playwright. Les exclure (assets statiques) est une optimisation distincte, à décider séparément.

## Verification

- [x] Aucun secret introduit/retiré.
- [x] Aucun runbook impacté.

## Auto-critique

- [x] Pas de debug / TODO / code mort.
- [x] Changement CI uniquement, pas de DTO backend -> pas de `make typegen`.

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 findings (0 critical, 0 warning, 0 nitpick — nitpicks not posted per review policy).

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for (#810, #811)

**Commit reviewed:** `8f775cc40f163b9ee98597f0022a9673034b19cc`
<!-- claude-review-end -->
