### PR TITLE
fix(gpx): prevent XXE local-file read via LIBXML_NOENT

### DIFF
--- a/api/src/RouteParser/GpxStreamRouteParser.php
+++ b/api/src/RouteParser/GpxStreamRouteParser.php
@@ -10,16 +10,33 @@ use App\ApiResource\Model\Coordinate;
 final class GpxStreamRouteParser implements GpxRouteParserInterface
 {
     /**
+     * Rejects any GPX carrying a DOCTYPE. Legitimate GPX is schema-based and
+     * never declares a DTD, so a DOCTYPE only ever introduces entity/XXE
+     * vectors — refusing it up front is the first XXE defense layer.
+     */
+    private static function hasDoctype(string $content): bool
+    {
+        return 1 === preg_match('/<!DOCTYPE/i', $content);
+    }
+
+    /**
      * Extracts the first track name from a GPX string.
      * Uses XMLReader for O(constant) memory usage.
      */
     public function extractTitle(string $content): ?string
     {
+        if (self::hasDoctype($content)) {
+            return null;
+        }
+
         $previous = libxml_use_internal_errors(true);
 
         $reader = new \XMLReader();
 
-        if (!$reader->XML($content, null, \LIBXML_NONET | \LIBXML_NOENT)) {
+        // LIBXML_NONET blocks network entity fetches. LIBXML_NOENT is deliberately
+        // NOT set: it would enable external-entity substitution (XXE / local-file
+        // read via file://), which LIBXML_NONET does not prevent.
+        if (!$reader->XML($content, null, \LIBXML_NONET)) {
             libxml_clear_errors();
             libxml_use_internal_errors($previous);
 
@@ -59,19 +76,26 @@ final class GpxStreamRouteParser implements GpxRouteParserInterface
     /**
      * Parses a GPX string and returns all track points.
      * Uses XMLReader for O(constant) memory usage.
-     * Protected against XXE with LIBXML_NONET | LIBXML_NOENT.
+     *
+     * XXE hardening: any DOCTYPE is rejected outright, and parsing uses
+     * LIBXML_NONET WITHOUT LIBXML_NOENT so external entities are never
+     * substituted (LIBXML_NOENT would re-enable file:// entity reads).
      *
      * {@inheritdoc}
      */
     public function parse(string $content): array
     {
+        if (self::hasDoctype($content)) {
+            throw new \RuntimeException('GPX documents with a DOCTYPE are not allowed.');
+        }
+
         $points = [];
 
         $previous = libxml_use_internal_errors(true);
 
         $reader = new \XMLReader();
 
-        $options = \LIBXML_NONET | \LIBXML_NOENT;
+        $options = \LIBXML_NONET;
 
         if (!$reader->XML($content, null, $options)) {
             libxml_clear_errors();

--- a/api/src/RouteParser/GpxStreamRouteParser.php
+++ b/api/src/RouteParser/GpxStreamRouteParser.php
@@ -14,7 +14,7 @@ final class GpxStreamRouteParser implements GpxRouteParserInterface
      * never declares a DTD, so a DOCTYPE only ever introduces entity/XXE
      * vectors — refusing it up front is the first XXE defense layer.
      */
-    private static function hasDoctype(string $content): bool
+    private function hasDoctype(string $content): bool
     {
         return 1 === preg_match('/<!DOCTYPE/i', $content);
     }
@@ -25,7 +25,7 @@ final class GpxStreamRouteParser implements GpxRouteParserInterface
      */
     public function extractTitle(string $content): ?string
     {
-        if (self::hasDoctype($content)) {
+        if ($this->hasDoctype($content)) {
             return null;
         }
 
@@ -85,7 +85,7 @@ final class GpxStreamRouteParser implements GpxRouteParserInterface
      */
     public function parse(string $content): array
     {
-        if (self::hasDoctype($content)) {
+        if ($this->hasDoctype($content)) {
             throw new \RuntimeException('GPX documents with a DOCTYPE are not allowed.');
         }
 

--- a/api/tests/Unit/RouteParser/GpxStreamRouteParserTest.php
+++ b/api/tests/Unit/RouteParser/GpxStreamRouteParserTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\RouteParser;
+
+use App\RouteParser\GpxStreamRouteParser;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Guards the XXE hardening of the GPX parser (audit finding SEC-001): a malicious
+ * external entity must never be substituted, and a DOCTYPE must be rejected.
+ */
+final class GpxStreamRouteParserTest extends TestCase
+{
+    private const string VALID_GPX = <<<'GPX'
+        <?xml version="1.0" encoding="UTF-8"?>
+        <gpx version="1.1" creator="test" xmlns="http://www.topografix.com/GPX/1/1">
+        <trk><name>My Trip</name><trkseg>
+        <trkpt lat="50.6292" lon="3.0573"><ele>20</ele></trkpt>
+        <trkpt lat="50.6400" lon="3.0800"><ele>30</ele></trkpt>
+        </trkseg></trk></gpx>
+        GPX;
+
+    #[Test]
+    public function it_extracts_the_track_title_from_a_valid_gpx(): void
+    {
+        self::assertSame('My Trip', new GpxStreamRouteParser()->extractTitle(self::VALID_GPX));
+    }
+
+    #[Test]
+    public function it_parses_track_points_from_a_valid_gpx(): void
+    {
+        $points = new GpxStreamRouteParser()->parse(self::VALID_GPX);
+
+        self::assertCount(2, $points);
+        self::assertEqualsWithDelta(50.6292, $points[0]->lat, 1e-6);
+    }
+
+    #[Test]
+    public function it_does_not_substitute_an_external_entity_when_extracting_the_title(): void
+    {
+        $secret = tempnam(sys_get_temp_dir(), 'xxe');
+        self::assertIsString($secret);
+        file_put_contents($secret, 'TOP-SECRET-XXE-PROBE');
+
+        try {
+            $payload = \sprintf(
+                "<?xml version=\"1.0\"?>\n<!DOCTYPE gpx [<!ENTITY xxe SYSTEM \"file://%s\">]>\n"
+                ."<gpx version=\"1.1\" xmlns=\"http://www.topografix.com/GPX/1/1\">"
+                ."<trk><name>&xxe;</name><trkseg>"
+                ."<trkpt lat=\"50.6\" lon=\"3.0\"><ele>20</ele></trkpt>"
+                ."</trkseg></trk></gpx>",
+                $secret,
+            );
+
+            $title = new GpxStreamRouteParser()->extractTitle($payload);
+
+            self::assertNotSame('TOP-SECRET-XXE-PROBE', $title, 'XXE: external entity was substituted — local file leaked.');
+            self::assertNull($title);
+        } finally {
+            @unlink($secret);
+        }
+    }
+
+    #[Test]
+    public function it_rejects_a_gpx_carrying_a_doctype_when_parsing(): void
+    {
+        $this->expectException(\RuntimeException::class);
+
+        new GpxStreamRouteParser()->parse(
+            "<?xml version=\"1.0\"?>\n<!DOCTYPE gpx [<!ENTITY x \"y\">]>\n"
+            .'<gpx version="1.1" xmlns="http://www.topografix.com/GPX/1/1">'
+            .'<trk><trkseg><trkpt lat="50.6" lon="3.0"><ele>20</ele></trkpt></trkseg></trk></gpx>',
+        );
+    }
+}

--- a/api/tests/Unit/RouteParser/GpxStreamRouteParserTest.php
+++ b/api/tests/Unit/RouteParser/GpxStreamRouteParserTest.php
@@ -14,23 +14,23 @@ use PHPUnit\Framework\TestCase;
  */
 final class GpxStreamRouteParserTest extends TestCase
 {
-    private const string VALID_GPX = <<<'GPX'
-        <?xml version="1.0" encoding="UTF-8"?>
-        <gpx version="1.1" creator="test" xmlns="http://www.topografix.com/GPX/1/1">
-        <trk><name>My Trip</name><trkseg>
-        <trkpt lat="50.6292" lon="3.0573"><ele>20</ele></trkpt>
-        <trkpt lat="50.6400" lon="3.0800"><ele>30</ele></trkpt>
-        </trkseg></trk></gpx>
-        GPX;
+    private const string VALID_GPX = <<<'GPX_WRAP'
+    <?xml version="1.0" encoding="UTF-8"?>
+    <gpx version="1.1" creator="test" xmlns="http://www.topografix.com/GPX/1/1">
+    <trk><name>My Trip</name><trkseg>
+    <trkpt lat="50.6292" lon="3.0573"><ele>20</ele></trkpt>
+    <trkpt lat="50.6400" lon="3.0800"><ele>30</ele></trkpt>
+    </trkseg></trk></gpx>
+    GPX_WRAP;
 
     #[Test]
-    public function it_extracts_the_track_title_from_a_valid_gpx(): void
+    public function itExtractsTheTrackTitleFromAValidGpx(): void
     {
         self::assertSame('My Trip', new GpxStreamRouteParser()->extractTitle(self::VALID_GPX));
     }
 
     #[Test]
-    public function it_parses_track_points_from_a_valid_gpx(): void
+    public function itParsesTrackPointsFromAValidGpx(): void
     {
         $points = new GpxStreamRouteParser()->parse(self::VALID_GPX);
 
@@ -39,7 +39,7 @@ final class GpxStreamRouteParserTest extends TestCase
     }
 
     #[Test]
-    public function it_does_not_substitute_an_external_entity_when_extracting_the_title(): void
+    public function itDoesNotSubstituteAnExternalEntityWhenExtractingTheTitle(): void
     {
         $secret = tempnam(sys_get_temp_dir(), 'xxe');
         self::assertIsString($secret);
@@ -48,10 +48,10 @@ final class GpxStreamRouteParserTest extends TestCase
         try {
             $payload = \sprintf(
                 "<?xml version=\"1.0\"?>\n<!DOCTYPE gpx [<!ENTITY xxe SYSTEM \"file://%s\">]>\n"
-                ."<gpx version=\"1.1\" xmlns=\"http://www.topografix.com/GPX/1/1\">"
-                ."<trk><name>&xxe;</name><trkseg>"
-                ."<trkpt lat=\"50.6\" lon=\"3.0\"><ele>20</ele></trkpt>"
-                ."</trkseg></trk></gpx>",
+                .'<gpx version="1.1" xmlns="http://www.topografix.com/GPX/1/1">'
+                .'<trk><name>&xxe;</name><trkseg>'
+                .'<trkpt lat="50.6" lon="3.0"><ele>20</ele></trkpt>'
+                .'</trkseg></trk></gpx>',
                 $secret,
             );
 
@@ -65,7 +65,7 @@ final class GpxStreamRouteParserTest extends TestCase
     }
 
     #[Test]
-    public function it_rejects_a_gpx_carrying_a_doctype_when_parsing(): void
+    public function itRejectsAGpxCarryingADoctypeWhenParsing(): void
     {
         $this->expectException(\RuntimeException::class);
 

--- a/docs/adr/adr-011-security-input-validation-and-ssrf-prevention-for-gpx-url-ingestion.md
+++ b/docs/adr/adr-011-security-input-validation-and-ssrf-prevention-for-gpx-url-ingestion.md
@@ -141,36 +141,36 @@ final class TripRequest
 
 ### 10.3 — Hardening the XML GPX Parser (XXE Protection)
 
-Although PHP 8.0+ (and libxml2 >= 2.9.0) disables external entity loading by default, we will explicitly configure the
-`XMLReader` (from ADR-004) to prevent any network calls or entity substitutions during parsing, acting as a
-defense-in-depth measure.
+We harden `XMLReader` (from ADR-004) against XXE with two layers: reject any document
+declaring a `DOCTYPE` (legitimate GPX is schema-based and never uses a DTD), and parse
+with `LIBXML_NONET` only.
 
-**File:** `api/src/Spatial/GpxStreamParser.php`
+> **Correction (audit SEC-001, 2026-07).** An earlier revision of this ADR recommended
+> `LIBXML_NONET | LIBXML_NOENT`, described as "disable entity substitution". That is wrong
+> and was actively dangerous: `LIBXML_NOENT` **enables** entity substitution/loading, and
+> `LIBXML_NONET` only blocks the *network* scheme — not `file://`. The combination allowed
+> an authenticated user to read arbitrary server files (e.g. the JWT signing key) by
+> declaring an external `SYSTEM` entity and referencing it in `<trk><name>`, with the file
+> contents reflected as the trip title. The fix removes `LIBXML_NOENT` (so external entities
+> are never substituted) and rejects `DOCTYPE` up front. Billion-laughs is separately
+> capped by libxml's entity-amplification guard.
+
+**File:** `api/src/RouteParser/GpxStreamRouteParser.php`
 
 ```php
-namespace App\Spatial;
-
 use XMLReader;
-use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
-final class GpxStreamParser
-{
-    public function parse(string $filePath): iterable
-    {
-        $reader = new XMLReader();
-        
-        // Disable network access for the XML parser (prevents fetching external DTDs)
-        // Disable entity substitution (prevents Billion Laughs DoS)
-        $options = LIBXML_NONET | LIBXML_NOENT; 
-        
-        if (!$reader->open($filePath, null, $options)) {
-            throw new BadRequestHttpException('Invalid or corrupted GPX file.');
-        }
+// Reject any DOCTYPE (no legitimate GPX declares one).
+if (preg_match('/<!DOCTYPE/i', $content)) {
+    throw new \RuntimeException('GPX documents with a DOCTYPE are not allowed.');
+}
 
-        // ... continue with stream parsing as defined in ADR-004
-        
-        $reader->close();
-    }
+$reader = new XMLReader();
+
+// LIBXML_NONET blocks network entity fetches. LIBXML_NOENT is deliberately NOT set:
+// it would re-enable external-entity substitution (XXE / file:// local-file read).
+if (!$reader->XML($content, null, LIBXML_NONET)) {
+    throw new \RuntimeException('Invalid or corrupted GPX file.');
 }
 ```
 


### PR DESCRIPTION
## Summary

Corrige une **XXE (lecture de fichier arbitraire)** dans le parser GPX (finding audit **SEC-001**, HIGH).

- `GpxStreamRouteParser` parsait avec `LIBXML_NONET | LIBXML_NOENT`. Or `LIBXML_NOENT` **active** la substitution d'entités externes, et `LIBXML_NONET` ne bloque que le schéma réseau — **pas `file://`**.
- Un utilisateur authentifié pouvait uploader un `.gpx` déclarant une entité externe (`<!DOCTYPE gpx [<!ENTITY xxe SYSTEM "file:///run/secrets/jwt_private_key">]>` référencée dans `<trk><name>&xxe;</name>`) : le contenu du fichier était renvoyé comme **titre du voyage** (et persisté). Impact : lecture de la clé de signature JWT → usurpation de n'importe quel compte, `APP_SECRET`, identifiants DB.

### Fix

- Retrait de `LIBXML_NOENT` aux deux points d'appel (`LIBXML_NONET` seul → entités externes jamais substituées).
- Rejet de tout `DOCTYPE` en amont (un GPX légitime, schema-based, n'en déclare jamais) — défense-en-profondeur.
- Correction du commentaire du code et de l'**ADR-011**, qui documentait à tort `LIBXML_NOENT` comme une défense.

## Test plan

- [x] Nouveau test unitaire `GpxStreamRouteParserTest` : GPX valide OK (titre + points), payload XXE `file://` → titre `null` (aucune fuite), `DOCTYPE` → `RuntimeException`.
- [x] Vérifié fonctionnellement (PHP 8.5) : le payload qui fuyait `/etc/hostname` renvoie désormais `null` ; GPX légitime toujours parsé.
- [ ] CI (PHPUnit + QA).

## Auto-critique

Reproduit en amont contre la stack iso-prod (`title` = hostname du conteneur) ; le fix a été revalidé fonctionnellement. Le rejet de `DOCTYPE` pourrait théoriquement refuser un GPX exotique, mais la spec GPX est XSD, sans DTD — risque nul en pratique.

Réf. audit interne SEC-001 (recette #245).

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 code-level findings (0 critical, 0 warning). The fix correctly removes `LIBXML_NOENT` (which counter-intuitively *enables* entity substitution) while keeping `LIBXML_NONET`, and adds a `DOCTYPE` pre-check as defense-in-depth at both `parse()` and `extractTitle()`. Call sites (`GpxUploadController` → `GpxUploadService`, `StravaRouteFetcher`) always invoke `parse()` before `extractTitle()`, so the throw-vs-null asymmetry between the two methods on a malicious payload is not reachable in practice. Test coverage (valid GPX, XXE `file://` probe, `DOCTYPE` rejection) is appropriate. One non-blocking process note: `SEC-001` is already used in `TRACKING.md` (PR #630) for an unrelated CSP/Report-Only finding — reusing the same ID for this XXE finding creates a traceability collision across audit docs; worth a rename in a follow-up.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date (ADR-011 corrected)
- [ ] Dependent tickets accounted for — see `SEC-001` ID collision note above

**Commit reviewed:** `e705a1be8a4569e8eae29c6b3afcb16e59b62918`
<!-- claude-review-end -->
