### PR TITLE
fix(security): gate accommodation re-scan by trip ownership

### DIFF
--- a/api/src/ApiResource/AccommodationScan.php
+++ b/api/src/ApiResource/AccommodationScan.php
@@ -20,6 +20,7 @@ use App\State\AccommodationScanProcessor;
             ],
             status: 202,
             openapi: new Operation(summary: 'Re-scan accommodations for all stages with a custom radius.'),
+            security: "is_granted('TRIP_EDIT', request.attributes.get('tripId'))",
             input: AccommodationScanRequest::class,
             output: Trip::class,
             processor: AccommodationScanProcessor::class,

--- a/api/tests/Functional/AccommodationScanTest.php
+++ b/api/tests/Functional/AccommodationScanTest.php
@@ -53,6 +53,7 @@ final class AccommodationScanTest extends ApiTestCase
 
         $request = new TripRequest(Uuid::fromString($tripId));
         $request->sourceUrl = 'https://www.komoot.com/tour/123456789';
+
         $repo->initializeTrip($tripId, $request);
         $repo->storeSourceType($tripId, SourceType::KOMOOT_TOUR->value);
         $repo->storeStages($tripId, [

--- a/api/tests/Functional/AccommodationScanTest.php
+++ b/api/tests/Functional/AccommodationScanTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Symfony\Bundle\Test\Client;
+use App\ApiResource\Model\Coordinate;
+use App\ApiResource\Stage;
+use App\ApiResource\TripRequest;
+use App\ComputationTracker\ComputationTrackerInterface;
+use App\Entity\User;
+use App\Enum\ComputationName;
+use App\Enum\SourceType;
+use App\Repository\TripRequestRepositoryInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Uid\Uuid;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+use Zenstruck\Foundry\Test\Factories;
+
+/**
+ * Object-level authorization on POST /trips/{tripId}/accommodations/scan
+ * (audit finding SEC-002): the operation must be gated by trip ownership, and a
+ * foreign trip is hidden as 404 (ADR-038), not silently scanned.
+ */
+#[ResetDatabase]
+final class AccommodationScanTest extends ApiTestCase
+{
+    use Factories;
+    use JwtAuthTestTrait;
+
+    private const string TRIP_ID = '01936f6e-0000-7000-8000-0000000000a0';
+
+    private Client $client;
+
+    private User $testUser;
+
+    private string $jwtToken;
+
+    protected function setUp(): void
+    {
+        $this->client = self::createClient();
+        ['user' => $this->testUser, 'token' => $this->jwtToken] = $this->createTestUserWithJwt('owner@example.com');
+    }
+
+    private function seedTrip(string $tripId): void
+    {
+        $container = self::getContainer();
+
+        /** @var TripRequestRepositoryInterface $repo */
+        $repo = $container->get(TripRequestRepositoryInterface::class);
+
+        $request = new TripRequest(Uuid::fromString($tripId));
+        $request->sourceUrl = 'https://www.komoot.com/tour/123456789';
+        $repo->initializeTrip($tripId, $request);
+        $repo->storeSourceType($tripId, SourceType::KOMOOT_TOUR->value);
+        $repo->storeStages($tripId, [
+            new Stage(
+                tripId: $tripId,
+                dayNumber: 1,
+                distance: 80.0,
+                elevation: 500.0,
+                startPoint: new Coordinate(45.0, 5.0),
+                endPoint: new Coordinate(45.5, 5.5),
+                geometry: [new Coordinate(45.0, 5.0), new Coordinate(45.5, 5.5)],
+                label: 'Stage 1',
+            ),
+        ]);
+
+        /** @var ComputationTrackerInterface $tracker */
+        $tracker = $container->get(ComputationTrackerInterface::class);
+        $tracker->initializeComputations($tripId, ComputationName::cases());
+
+        $this->associateTripWithUser($tripId, $this->testUser);
+    }
+
+    #[Test]
+    public function ownerCanTriggerScan(): void
+    {
+        $this->seedTrip(self::TRIP_ID);
+
+        $this->client->request('POST', \sprintf('/trips/%s/accommodations/scan', self::TRIP_ID), [
+            'headers' => array_merge(['Content-Type' => 'application/ld+json'], $this->authHeader($this->jwtToken)),
+            'json' => ['radiusKm' => 5],
+        ]);
+
+        $this->assertResponseStatusCodeSame(202);
+    }
+
+    #[Test]
+    public function foreignUserGets404(): void
+    {
+        // SEC-002 regression: a trip owned by someone else must not be scannable,
+        // and is hidden as 404 (not 403) so its existence is not revealed (ADR-038).
+        $this->seedTrip(self::TRIP_ID);
+
+        ['token' => $intruderToken] = $this->createTestUserWithJwt('intruder@example.com');
+
+        $this->client->request('POST', \sprintf('/trips/%s/accommodations/scan', self::TRIP_ID), [
+            'headers' => array_merge(['Content-Type' => 'application/ld+json'], $this->authHeader($intruderToken)),
+            'json' => ['radiusKm' => 5],
+        ]);
+
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    #[Test]
+    public function unauthenticatedRequestReturns401(): void
+    {
+        $this->seedTrip(self::TRIP_ID);
+
+        $this->client->request('POST', \sprintf('/trips/%s/accommodations/scan', self::TRIP_ID), [
+            'headers' => ['Content-Type' => 'application/ld+json'],
+            'json' => ['radiusKm' => 5],
+        ]);
+
+        $this->assertResponseStatusCodeSame(401);
+    }
+}


### PR DESCRIPTION
## Summary

Corrige un **IDOR** (finding audit **SEC-002**, HIGH) sur `POST /trips/{tripId}/accommodations/scan`.

- L'opération n'avait **aucune** expression `security:`, alors que toutes les autres sous-ressources d'un voyage exigent `TRIP_EDIT`.
- Un utilisateur authentifié A pouvait, avec l'UUID d'un voyage de B, réinitialiser l'état de calcul `ACCOMMODATIONS` de B et déclencher un scan async sur ses étapes (mutation d'état non autorisée + abus de ressources Overpass/PostGIS + fuite des statuts).

### Fix

- Ajout de `security: "is_granted('TRIP_EDIT', request.attributes.get('tripId'))"` sur le `Post` → un voyage étranger renvoie **404** (ADR-038, existence non divulguée).

## Test plan

- [x] Nouveau `AccommodationScanTest` : propriétaire → 202, utilisateur étranger → **404**, anonyme → 401.
- [x] Reproduit en amont contre la stack iso-prod (B obtenait 202 sur le voyage de A ; désormais 404).
- [ ] CI (PHPUnit).

## Auto-critique

Fix minimal alignant l'endpoint sur le motif des sous-ressources `Stage`. Le voter `TripVoter` (TRIP_EDIT = ownership) était déjà en place ; seul le câblage manquait.

Réf. audit interne SEC-002 (recette #245).

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 code-level findings (0 critical, 0 warning). The fix mirrors the exact `security:` idiom already used on every sibling `Stage` sub-resource operation (`is_granted('TRIP_EDIT', request.attributes.get('tripId'))`), correctly relies on the existing `TripVoter` (DB-then-Redis ownership check), and correctly benefits from the global `HideForbiddenAsNotFoundListener` to surface denials as 404 per ADR-038. New `AccommodationScanTest` covers owner (202), foreign user (404), and anonymous (401) — matching the existing `JwtAuthTestTrait` pattern used by other `Stage*Test` files. Swept all other `ApiResource` classes with path-scoped operations; this was the only trip sub-resource missing `security:`.

**Note (non-blocking):** the PR/commit label this finding `SEC-002`, but `SEC-002` is already assigned in `docs/recette/audit-report.md` / `TRACKING.md` to a distinct, already-closed finding ("Pas de HSTS", fixed in #630). This new IDOR should probably follow the repo's own `IDOR-*` naming convention (cf. `IDOR-DETAIL` in #616/#618) to avoid an ID collision in the audit trail.

**PR title:** conforms to Conventional Commits (`fix(security): gate accommodation re-scan by trip ownership`).

**Commit reviewed:** `5b5a56f0df7d4155ac0e566a500866ae827904e7`

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for
<!-- claude-review-end -->