### PR TITLE
fix(computation): serialize status updates to prevent stuck trips

### DIFF
--- a/api/src/ComputationTracker/ComputationTracker.php
+++ b/api/src/ComputationTracker/ComputationTracker.php
@@ -7,6 +7,7 @@ namespace App\ComputationTracker;
 use App\Enum\ComputationName;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Lock\LockFactory;
 
 final readonly class ComputationTracker implements ComputationTrackerInterface
 {
@@ -23,6 +24,7 @@ final readonly class ComputationTracker implements ComputationTrackerInterface
     public function __construct(
         #[Autowire(service: 'cache.trip_state')]
         private CacheItemPoolInterface $tripStateCache,
+        private LockFactory $lockFactory,
     ) {
     }
 
@@ -137,11 +139,25 @@ final readonly class ComputationTracker implements ComputationTrackerInterface
         return $result;
     }
 
+    /**
+     * The whole status map lives under one Redis key, so a naive get-modify-set
+     * lets two parallel enrichment workers clobber each other's write — a lost
+     * `done` reverts a computation to `running` for good, and the completion gate
+     * never fires (loader spins forever on a computed trip). Serialise the
+     * read-modify-write behind a per-trip lock, mirroring LlmAnalysisTracker.
+     */
     private function updateStatus(string $tripId, ComputationName $computation, string $status): void
     {
-        $statuses = $this->getStatuses($tripId) ?? [];
-        $statuses[$computation->value] = $status;
-        $this->set($this->statusKey($tripId), $statuses);
+        $lock = $this->lockFactory->createLock(\sprintf('trip.%s.computation_status.update', $tripId), ttl: 5);
+        $lock->acquire(blocking: true);
+
+        try {
+            $statuses = $this->getStatuses($tripId) ?? [];
+            $statuses[$computation->value] = $status;
+            $this->set($this->statusKey($tripId), $statuses);
+        } finally {
+            $lock->release();
+        }
     }
 
     private function set(string $key, mixed $value): void

--- a/api/tests/Unit/Computation/GateComputationTrackerTest.php
+++ b/api/tests/Unit/Computation/GateComputationTrackerTest.php
@@ -9,6 +9,8 @@ use App\Enum\ComputationName;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\Store\InMemoryStore;
 
 /**
  * Targets the gate semantics added in issue #299:
@@ -29,7 +31,7 @@ final class GateComputationTrackerTest extends TestCase
     #[\Override]
     protected function setUp(): void
     {
-        $this->tracker = new ComputationTracker(new ArrayAdapter());
+        $this->tracker = new ComputationTracker(new ArrayAdapter(), new LockFactory(new InMemoryStore()));
     }
 
     #[Test]

--- a/api/tests/Unit/ComputationTracker/ComputationTrackerTest.php
+++ b/api/tests/Unit/ComputationTracker/ComputationTrackerTest.php
@@ -9,6 +9,8 @@ use App\Enum\ComputationName;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\Store\InMemoryStore;
 
 final class ComputationTrackerTest extends TestCase
 {
@@ -17,7 +19,7 @@ final class ComputationTrackerTest extends TestCase
     #[\Override]
     protected function setUp(): void
     {
-        $this->tracker = new ComputationTracker(new ArrayAdapter());
+        $this->tracker = new ComputationTracker(new ArrayAdapter(), new LockFactory(new InMemoryStore()));
     }
 
     #[Test]

--- a/api/tests/Unit/EventListener/ComputationFailureSubscriberTest.php
+++ b/api/tests/Unit/EventListener/ComputationFailureSubscriberTest.php
@@ -17,6 +17,8 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\Store\InMemoryStore;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -37,7 +39,7 @@ final class ComputationFailureSubscriberTest extends TestCase
     #[\Override]
     protected function setUp(): void
     {
-        $this->tracker = new ComputationTracker(new ArrayAdapter());
+        $this->tracker = new ComputationTracker(new ArrayAdapter(), new LockFactory(new InMemoryStore()));
     }
 
     #[Test]

--- a/api/tests/Unit/Service/TripCompletionGateTest.php
+++ b/api/tests/Unit/Service/TripCompletionGateTest.php
@@ -12,6 +12,8 @@ use App\Service\TripCompletionGate;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\Store\InMemoryStore;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 
@@ -24,7 +26,7 @@ final class TripCompletionGateTest extends TestCase
     #[\Override]
     protected function setUp(): void
     {
-        $this->tracker = new ComputationTracker(new ArrayAdapter());
+        $this->tracker = new ComputationTracker(new ArrayAdapter(), new LockFactory(new InMemoryStore()));
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

Corrige une **race last-writer** provoquant un **loader infini** (finding audit **BUG-001**, HIGH).

- La map de statuts d'un voyage est stockée sous **une seule** clé Redis (`trip.<id>.computation_status`), mutée par un get-modify-set **non atomique** dans `ComputationTracker::updateStatus`.
- Avec plusieurs workers d'enrichissement en parallèle sur un même voyage, deux `markDone()` concurrents se clobbent : un `done` perdu repasse une computation à `running` **de façon permanente** (les succès ne retentent pas). `TripCompletionGate` ne voit alors jamais `completed+failed===total` → `TRIP_COMPLETE` jamais publié → **le front tourne indéfiniment sur un voyage pourtant calculé**.
- Même classe de race que celle déjà corrigée pour le JSONB des stages ; le sibling `LlmAnalysisTracker` protège d'ailleurs son read-modify-write identique par un `LockFactory` — ce tracker-ci ne l'avait pas.

### Fix

- `updateStatus()` sérialisé derrière un lock Symfony par voyage (`trip.<id>.computation_status.update`, ttl 5s), à l'identique de `LlmAnalysisTracker`.
- Mise à jour des 4 tests unitaires qui instancient `ComputationTracker` directement (ajout du `LockFactory` in-memory).

## Test plan

- [x] `php -l` OK sur tous les fichiers touchés.
- [x] Tests unitaires existants adaptés (nouvelle dépendance).
- [ ] CI (PHPUnit).
- ⚠️ La reproduction sous vraie concurrence n'est pas testable en unitaire mono-processus ; le fix reprend le motif de lock déjà éprouvé dans le codebase.

## Auto-critique

Le lock TTL 5s > durée d'un update Redis, sans risque d'interblocage (release en `finally`). Alternative envisagée (hash Redis `HSET` atomique) écartée pour rester cohérent avec `LlmAnalysisTracker` et l'abstraction PSR-6 existante.

Réf. audit interne BUG-001 (recette #649/#245).

<!-- claude-review-start -->
## Claude Review

**Findings:** 0 blocking, 0 warning, 1 suggestion

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases (existing tests updated; core lock mechanism itself untested — see suggestion)
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Commit reviewed:** `571a1f73940b41d45ecb9814365c00047a416719`
<!-- claude-review-end -->