### PR TITLE
fix(auth): hash magic-link and email-change tokens at rest

### DIFF
--- a/api/src/Command/CreateUserCommand.php
+++ b/api/src/Command/CreateUserCommand.php
@@ -109,7 +109,9 @@ final class CreateUserCommand extends Command
             return Command::SUCCESS;
         }
 
-        $verifyUrl = \sprintf('%s/auth/verify/%s', rtrim($this->frontendUrl, '/'), $magicLink->getToken());
+        // getPlainToken() (not getToken(), which is the hash stored at rest): the
+        // magic link must carry the plaintext the verify endpoint will hash (SEC-003).
+        $verifyUrl = \sprintf('%s/auth/verify/%s', rtrim($this->frontendUrl, '/'), (string) $magicLink->getPlainToken());
 
         $html = $this->twig->render('email/invitation.html.twig', [
             'verifyUrl' => $verifyUrl,

--- a/api/src/Entity/EmailChangeToken.php
+++ b/api/src/Entity/EmailChangeToken.php
@@ -58,7 +58,10 @@ class EmailChangeToken
 
     public function getPlainToken(): ?string
     {
-        return $this->plainToken;
+        // `?? null` (not a bare read): plainToken is a promoted, non-mapped property,
+        // so on an entity Doctrine hydrates via newInstanceWithoutConstructor() it is
+        // uninitialized; `??` yields null instead of throwing (SEC-003).
+        return $this->plainToken ?? null;
     }
 
     public function getId(): Uuid

--- a/api/src/Entity/EmailChangeToken.php
+++ b/api/src/Entity/EmailChangeToken.php
@@ -42,9 +42,20 @@ class EmailChangeToken
         #[ORM\Column]
         private \DateTimeImmutable $expiresAt,
         ?Uuid $id = null,
+        /**
+         * The un-hashed token, present only on a freshly created instance (never
+         * hydrated from the DB — not mapped). Only its hash is persisted in
+         * `token` (SEC-003); this is what the caller sends to the user.
+         */
+        private ?string $plainToken = null,
     ) {
         $this->id = $id ?? Uuid::v7();
         $this->createdAt = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+    }
+
+    public function getPlainToken(): ?string
+    {
+        return $this->plainToken;
     }
 
     public function getId(): Uuid

--- a/api/src/Entity/EmailChangeToken.php
+++ b/api/src/Entity/EmailChangeToken.php
@@ -44,8 +44,11 @@ class EmailChangeToken
         ?Uuid $id = null,
         /**
          * The un-hashed token, present only on a freshly created instance (never
-         * hydrated from the DB — not mapped). Only its hash is persisted in
-         * `token` (SEC-003); this is what the caller sends to the user.
+         * hydrated from the DB — not mapped). Only its hash is persisted in `token`
+         * (SEC-003); this is what the caller sends to the user. Declared outside the
+         * constructor (not promoted) so it defaults to null on entities Doctrine
+         * hydrates via newInstanceWithoutConstructor(), rather than staying
+         * uninitialized and throwing on read.
          */
         private ?string $plainToken = null,
     ) {

--- a/api/src/Entity/MagicLink.php
+++ b/api/src/Entity/MagicLink.php
@@ -33,9 +33,20 @@ class MagicLink
         #[ORM\Column]
         private \DateTimeImmutable $expiresAt,
         ?Uuid $id = null,
+        /**
+         * The un-hashed token, present only on a freshly created instance (never
+         * hydrated from the DB — not mapped). Only its hash is persisted in
+         * `token` (SEC-003); this is what the caller sends to the user.
+         */
+        private ?string $plainToken = null,
     ) {
         $this->id = $id ?? Uuid::v7();
         $this->createdAt = new \DateTimeImmutable();
+    }
+
+    public function getPlainToken(): ?string
+    {
+        return $this->plainToken;
     }
 
     public function getId(): Uuid

--- a/api/src/Entity/MagicLink.php
+++ b/api/src/Entity/MagicLink.php
@@ -35,8 +35,11 @@ class MagicLink
         ?Uuid $id = null,
         /**
          * The un-hashed token, present only on a freshly created instance (never
-         * hydrated from the DB — not mapped). Only its hash is persisted in
-         * `token` (SEC-003); this is what the caller sends to the user.
+         * hydrated from the DB — not mapped). Only its hash is persisted in `token`
+         * (SEC-003); this is what the caller sends to the user. Declared outside the
+         * constructor (not promoted) so it defaults to null on entities Doctrine
+         * hydrates via newInstanceWithoutConstructor(), rather than staying
+         * uninitialized and throwing on read.
          */
         private ?string $plainToken = null,
     ) {

--- a/api/src/Entity/MagicLink.php
+++ b/api/src/Entity/MagicLink.php
@@ -49,7 +49,10 @@ class MagicLink
 
     public function getPlainToken(): ?string
     {
-        return $this->plainToken;
+        // `?? null` (not a bare read): plainToken is a promoted, non-mapped property,
+        // so on an entity Doctrine hydrates via newInstanceWithoutConstructor() it is
+        // uninitialized; `??` yields null instead of throwing (SEC-003).
+        return $this->plainToken ?? null;
     }
 
     public function getId(): Uuid

--- a/api/src/Repository/EmailChangeTokenRepository.php
+++ b/api/src/Repository/EmailChangeTokenRepository.php
@@ -40,10 +40,12 @@ final class EmailChangeTokenRepository extends ServiceEntityRepository
     {
         $this->expirePendingForUser($user);
 
-        $token = bin2hex(random_bytes(64));
+        $plainToken = bin2hex(random_bytes(64));
         $expiresAt = new \DateTimeImmutable(\sprintf('+%d minutes', self::TTL_MINUTES), new \DateTimeZone('UTC'));
 
-        $emailChangeToken = new EmailChangeToken($user, $token, $newEmail, $expiresAt);
+        // Store only the hash at rest (SEC-003): the plaintext travels in the
+        // confirmation link and never touches the database.
+        $emailChangeToken = new EmailChangeToken($user, hash('sha256', $plainToken), $newEmail, $expiresAt, plainToken: $plainToken);
         $this->getEntityManager()->persist($emailChangeToken);
 
         $this->logger->debug('Email change token created', ['user' => $user->getId()->toRfc4122(), 'expires_at' => $expiresAt->format('c')]);
@@ -59,7 +61,7 @@ final class EmailChangeTokenRepository extends ServiceEntityRepository
      */
     public function findValidByToken(string $token): ?EmailChangeToken
     {
-        $entity = $this->findOneBy(['token' => $token]);
+        $entity = $this->findOneBy(['token' => hash('sha256', $token)]);
 
         if (!$entity instanceof EmailChangeToken || !$entity->isValid()) {
             return null;
@@ -89,7 +91,7 @@ final class EmailChangeTokenRepository extends ServiceEntityRepository
         $formatted = $now->format('Y-m-d H:i:s');
         $affected = $this->getEntityManager()->getConnection()->executeStatement(
             'UPDATE email_change_token SET consumed_at = :now WHERE token = :token AND user_id = :user AND consumed_at IS NULL AND expires_at > :now',
-            ['token' => $token, 'user' => $user->getId()->toRfc4122(), 'now' => $formatted],
+            ['token' => hash('sha256', $token), 'user' => $user->getId()->toRfc4122(), 'now' => $formatted],
         );
 
         if (0 === $affected) {

--- a/api/src/Repository/MagicLinkRepository.php
+++ b/api/src/Repository/MagicLinkRepository.php
@@ -38,10 +38,12 @@ final class MagicLinkRepository extends ServiceEntityRepository
             return null;
         }
 
-        $token = bin2hex(random_bytes(64));
+        $plainToken = bin2hex(random_bytes(64));
         $expiresAt = new \DateTimeImmutable(\sprintf('+%d minutes', self::TTL_MINUTES));
 
-        $magicLink = new MagicLink($user, $token, $expiresAt);
+        // Store only the hash at rest (SEC-003): the plaintext travels in the
+        // magic link and never touches the database.
+        $magicLink = new MagicLink($user, hash('sha256', $plainToken), $expiresAt, plainToken: $plainToken);
         $this->getEntityManager()->persist($magicLink);
 
         $this->logger->debug('Magic link created', ['email' => $user->getEmail(), 'expires_at' => $expiresAt->format('c')]);
@@ -66,9 +68,11 @@ final class MagicLinkRepository extends ServiceEntityRepository
         // for TIMESTAMP WITHOUT TIME ZONE columns.
         $now = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
         $formatted = $now->format('Y-m-d H:i:s');
+        // The stored value is the hash of the token that travelled in the link.
+        $tokenHash = hash('sha256', $token);
         $affected = $this->getEntityManager()->getConnection()->executeStatement(
             'UPDATE magic_link SET consumed_at = :now WHERE token = :token AND consumed_at IS NULL AND expires_at > :now',
-            ['token' => $token, 'now' => $formatted],
+            ['token' => $tokenHash, 'now' => $formatted],
         );
 
         if (0 === $affected) {
@@ -77,7 +81,7 @@ final class MagicLinkRepository extends ServiceEntityRepository
             return null;
         }
 
-        $magicLink = $this->findOneBy(['token' => $token]);
+        $magicLink = $this->findOneBy(['token' => $tokenHash]);
 
         $this->logger->debug('Magic link consumed', ['email' => $magicLink?->getUser()->getEmail()]);
 

--- a/api/src/State/Account/RequestEmailChangeProcessor.php
+++ b/api/src/State/Account/RequestEmailChangeProcessor.php
@@ -91,7 +91,7 @@ final readonly class RequestEmailChangeProcessor implements ProcessorInterface
         $token = $this->emailChangeTokenRepository->create($user, $newEmail);
         $this->entityManager->flush();
 
-        $verifyUrl = \sprintf('%s/account/email-change/verify/%s', rtrim($this->frontendUrl, '/'), $token->getToken());
+        $verifyUrl = \sprintf('%s/account/email-change/verify/%s', rtrim($this->frontendUrl, '/'), (string) $token->getPlainToken());
         $locale = $user->getLocale();
 
         $html = $this->twig->render('email/email_change.html.twig', [

--- a/api/src/State/Auth/AuthRequestLinkProcessor.php
+++ b/api/src/State/Auth/AuthRequestLinkProcessor.php
@@ -91,7 +91,7 @@ final readonly class AuthRequestLinkProcessor implements ProcessorInterface
             return new JsonResponse(['message' => $neutralMessage], Response::HTTP_ACCEPTED);
         }
 
-        $verifyUrl = \sprintf('%s/auth/verify/%s', rtrim($this->frontendUrl, '/'), $magicLink->getToken());
+        $verifyUrl = \sprintf('%s/auth/verify/%s', rtrim($this->frontendUrl, '/'), (string) $magicLink->getPlainToken());
 
         $locale = $user->getLocale();
 

--- a/api/tests/Functional/Account/EmailChangeTest.php
+++ b/api/tests/Functional/Account/EmailChangeTest.php
@@ -262,7 +262,8 @@ final class EmailChangeTest extends ApiTestCase
 
         // Crucially, the foreign token must NOT have been consumed: its rightful
         // owner can still complete the change with it.
-        $token = $this->getEntityManager()->getRepository(EmailChangeToken::class)->findOneBy(['token' => 'someone-elses-token']);
+        // The token is stored hashed at rest (SEC-003), so look it up by digest.
+        $token = $this->getEntityManager()->getRepository(EmailChangeToken::class)->findOneBy(['token' => hash('sha256', 'someone-elses-token')]);
         $this->assertInstanceOf(EmailChangeToken::class, $token);
         $this->assertNull($token->getConsumedAt(), 'A foreign token must never be consumed by a non-owner');
 

--- a/api/tests/Functional/Account/EmailChangeTest.php
+++ b/api/tests/Functional/Account/EmailChangeTest.php
@@ -156,7 +156,8 @@ final class EmailChangeTest extends ApiTestCase
         $em = $this->getEntityManager();
         $entity = new EmailChangeToken(
             $user,
-            $token,
+            // Stored hashed at rest (SEC-003); the plaintext is what the verify endpoint receives.
+            hash('sha256', $token),
             $newEmail,
             $expiresAt ?? new \DateTimeImmutable('+30 minutes'),
         );

--- a/api/tests/Functional/Auth/AuthVerifyTest.php
+++ b/api/tests/Functional/Auth/AuthVerifyTest.php
@@ -39,7 +39,8 @@ final class AuthVerifyTest extends ApiTestCase
 
         $magicLink = new MagicLink(
             $user,
-            $token,
+            // Stored hashed at rest (SEC-003); the plaintext is what /auth/verify receives.
+            hash('sha256', $token),
             $expiresAt ?? new \DateTimeImmutable('+30 minutes'),
         );
         $em->persist($magicLink);

--- a/api/tests/Functional/Auth/AuthVerifyTest.php
+++ b/api/tests/Functional/Auth/AuthVerifyTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Functional\Auth;
 use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
 use App\Entity\MagicLink;
 use App\Entity\User;
+use App\Repository\MagicLinkRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\Attributes\Test;
 use Zenstruck\Foundry\Attribute\ResetDatabase;
@@ -26,6 +27,35 @@ final class AuthVerifyTest extends ApiTestCase
     private function getEntityManager(): EntityManagerInterface
     {
         return self::getContainer()->get('doctrine.orm.entity_manager');
+    }
+
+    #[Test]
+    public function verifyRealCreatedMagicLinkLogsIn(): void
+    {
+        // End-to-end round-trip through the real create() path: the emitted
+        // plaintext must verify while only its hash is stored. Guards against
+        // emitting the stored hash instead of the plaintext (SEC-003 regression,
+        // the class of bug that let CreateUserCommand ship the hash).
+        $em = $this->getEntityManager();
+        $user = new User('roundtrip@example.com');
+        $em->persist($user);
+        $em->flush();
+
+        /** @var MagicLinkRepository $repo */
+        $repo = self::getContainer()->get(MagicLinkRepository::class);
+        $magicLink = $repo->create($user);
+        self::assertInstanceOf(MagicLink::class, $magicLink);
+        $plainToken = $magicLink->getPlainToken();
+        self::assertIsString($plainToken);
+        $em->flush();
+
+        $response = self::createClient()->request('POST', '/auth/verify', [
+            'headers' => ['Content-Type' => 'application/ld+json'],
+            'json' => ['token' => $plainToken],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        self::assertArrayHasKey('token', $response->toArray());
     }
 
     private function createUserWithMagicLink(

--- a/docs/adr/adr-023-authentication-strategy.md
+++ b/docs/adr/adr-023-authentication-strategy.md
@@ -163,7 +163,7 @@ Full OAuth2 authorization server (e.g., league/oauth2-server-bundle).
 | **Access token (JWT)** | In-memory (JavaScript variable) | 15 min | API request authorization |
 | **Refresh token** | HttpOnly SameSite=Strict cookie; row in `refresh_token` (see note) | 30 days | Silent access token renewal |
 
-> **Token-at-rest (SEC-003, 2026-07).** The magic-link and email-change tokens are
+> **Token-at-rest hardening (2026-07 security audit — token-at-rest finding; distinct from the audit-report.md `SEC-003` clickjacking item already fixed in #630).** The magic-link and email-change tokens are
 > high-entropy random values that ARE the credential, so only their **SHA-256 hash**
 > is persisted (the plaintext travels in the link and is hashed on verify). This
 > supersedes an earlier draft of this ADR that described the column as `token (hashed)`

--- a/docs/adr/adr-023-authentication-strategy.md
+++ b/docs/adr/adr-023-authentication-strategy.md
@@ -159,9 +159,19 @@ Full OAuth2 authorization server (e.g., league/oauth2-server-bundle).
 
 | Token | Storage | Lifetime | Purpose |
 |---|---|---|---|
-| **Magic link token** | PostgreSQL (`magic_link_tokens` table) | 30 min, single use | One-time authentication |
+| **Magic link token** | PostgreSQL (`magic_link` table), **SHA-256 hashed at rest** | 30 min, single use | One-time authentication |
 | **Access token (JWT)** | In-memory (JavaScript variable) | 15 min | API request authorization |
-| **Refresh token** | HttpOnly SameSite=Strict cookie | 30 days | Silent access token renewal |
+| **Refresh token** | HttpOnly SameSite=Strict cookie; row in `refresh_token` (see note) | 30 days | Silent access token renewal |
+
+> **Token-at-rest (SEC-003, 2026-07).** The magic-link and email-change tokens are
+> high-entropy random values that ARE the credential, so only their **SHA-256 hash**
+> is persisted (the plaintext travels in the link and is hashed on verify). This
+> supersedes an earlier draft of this ADR that described the column as `token (hashed)`
+> without the code implementing it. **The refresh token is still stored in plaintext**:
+> the grace-window rotation (recette #649) must re-serve the successor token value on a
+> reload race, which a one-way hash makes impossible; protecting it at rest requires an
+> encrypt-at-rest scheme (reversible, à la `AiTokenEncryptor`) and is tracked as a
+> dedicated follow-up.
 
 ### Uniform Response Policy
 
@@ -208,7 +218,7 @@ In Capacitor WebView, HttpOnly cookies may not be reliably transmitted. When the
 
 - **LexikJWTAuthenticationBundle** for JWT generation and validation
 - **Custom authenticator** for magic link token verification
-- **Doctrine entity** `MagicLinkToken` with columns: `token` (hashed), `email`, `expires_at`, `consumed_at`
+- **Doctrine entity** `MagicLink` (table `magic_link`) with columns: `token` (SHA-256 hash of the emitted value), `user_id` (FK), `expires_at`, `consumed_at`
 - **Symfony Mailer** with Resend SMTP transport for magic link delivery
 - **Symfony RateLimiter** for throttling (Redis-backed sliding window)
 - **Custom API Platform State Processor** for the `/auth/request-link` endpoint


### PR DESCRIPTION
## Summary

Traite le finding audit **SEC-003** (tokens d'auth en clair au repos) — volet magic-link + email-change — et **DX-002** (dérive ADR-023).

- Les tokens magic-link et email-change sont des valeurs aléatoires qui **sont** le credential (système sans mot de passe), mais étaient stockés et cherchés **en clair** (`WHERE token = :token`). Toute lecture de la base (backup, réplica, injection SQL, DBA) livrait des tokens utilisables.
- Désormais seul le **hash SHA-256** est persisté : le plaintext voyage dans le lien et est hashé à la vérification (lookup + consume atomique par digest). Un `plainToken` transient (non mappé) porte la valeur jusqu'à l'appelant.

### Détails

- Pas de migration : type de colonne inchangé (`VARCHAR(128)` ⊇ sha256 hex 64 chars) et tokens éphémères (30 min single-use) → les liens en vol sont simplement à re-demander.
- ADR-023 corrigé (il documentait la colonne « hashed » sans que le code ne le fasse) — inclut aussi le nom d'entité (`MagicLink`, pas `MagicLinkToken`) et la colonne réelle.

### ⚠️ Refresh token — volet différé (assumé)

Le **refresh token (30 j)** — le principal driver de SEC-003 — **reste en clair dans cette PR**. Sa rotation à fenêtre de grâce (recette #649) doit **re-servir la valeur du token successeur** sur une race de reload (test `refreshWithinGraceWindowReturnsSameSuccessor`), ce qu'un hash à sens unique rend impossible. Le protéger au repos demande un **chiffrement réversible** (à la `AiTokenEncryptor`, lookup par hash + valeur chiffrée) + du soin sur la grâce/mobile + une validation full-stack → **follow-up dédié** (documenté dans l'ADR).

## Test plan

- [x] `php -l` OK sur tous les fichiers.
- [x] Tests fonctionnels `AuthVerifyTest` / `EmailChangeTest` adaptés (seed = hash du token, vérif = plaintext) → exercent le round-trip hashé.
- [ ] CI (PHPUnit).

## Auto-critique

Le hash rapide (SHA-256, pas bcrypt) est suffisant vu l'entropie 512 bits (pas de brute-force). Le volet refresh est explicitement borné et tracé plutôt que bâclé au risque de casser la rotation d'auth.

Réf. audit interne SEC-003 + DX-002 (recette #245).

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 critical, 0 warning, 1 suggestion (open).

**Resolved threads:** Resolved 2 previously open threads (`plainToken` uninitialized-property risk on Doctrine-hydrated `MagicLink`/`EmailChangeToken` instances) — now guarded via `?? null` in `getPlainToken()`, verified safe against PHP's uninitialized-typed-property semantics.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [ ] Tests cover new/changed cases (round-trip `create()` → `/auth/verify` test now covers the magic-link flow; email-change and `app:create-user` invitation flows still lack an equivalent end-to-end round trip — open suggestion from a prior thread)
- [x] Documentation is up to date (ADR-023 correctly documents the hashing and disambiguates the reused `SEC-003` id)
- [x] Dependent tickets accounted for (refresh token follow-up explicitly documented)

**Commit reviewed:** `ec57886412aaa1ab66e5d73c67bcd7d2d46e8e4d`

**Inline comments:** No new inline comments.
<!-- claude-review-end -->