### PR TITLE
feat(security): rate-limit abuse-prone endpoints and validate GPX pacing params

### DIFF
--- a/api/config/packages/rate_limiter.php
+++ b/api/config/packages/rate_limiter.php
@@ -37,6 +37,37 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 'interval' => '60 seconds',
                 'cache_pool' => 'cache.rate_limiter',
             ],
+            // GPX upload is a second trip-creation entry point: throttle it like
+            // trip_create so it cannot bypass the create limiter (SEC-006).
+            'gpx_upload' => [
+                'policy' => 'sliding_window',
+                'limit' => 10,
+                'interval' => '60 seconds',
+                'cache_pool' => 'cache.rate_limiter',
+            ],
+            // Trip duplication clones DB rows + Redis blobs; cap per user (SEC-009).
+            'trip_duplicate' => [
+                'policy' => 'sliding_window',
+                'limit' => 10,
+                'interval' => '60 seconds',
+                'cache_pool' => 'cache.rate_limiter',
+            ],
+            // Recompute re-dispatches the full enrichment pipeline onto the shared
+            // workers; cap per user so it cannot be scripted faster than they drain (SEC-010).
+            'trip_recompute' => [
+                'policy' => 'sliding_window',
+                'limit' => 10,
+                'interval' => '60 seconds',
+                'cache_pool' => 'cache.rate_limiter',
+            ],
+            // Geocoding proxies to the public Nominatim instance (1 req/s policy,
+            // IP bans for bulk use); cap per user to protect the shared app IP (SEC-005).
+            'geocode' => [
+                'policy' => 'sliding_window',
+                'limit' => 30,
+                'interval' => '60 seconds',
+                'cache_pool' => 'cache.rate_limiter',
+            ],
             'access_request_ip' => [
                 'policy' => 'sliding_window',
                 'limit' => 3,

--- a/api/config/packages/rate_limiter.php
+++ b/api/config/packages/rate_limiter.php
@@ -61,7 +61,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 'cache_pool' => 'cache.rate_limiter',
             ],
             // Geocoding proxies to the public Nominatim instance (1 req/s policy,
-            // IP bans for bulk use); cap per user to protect the shared app IP (SEC-005).
+            // IP bans for bulk use); cap per user to protect the shared app IP
+            // (geocode rate-limit — 2026-07 security audit).
             'geocode' => [
                 'policy' => 'sliding_window',
                 'limit' => 30,

--- a/api/src/Controller/GeocodeController.php
+++ b/api/src/Controller/GeocodeController.php
@@ -5,10 +5,13 @@ declare(strict_types=1);
 namespace App\Controller;
 
 use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -21,7 +24,22 @@ final readonly class GeocodeController
         private HttpClientInterface $nominatimClient,
         #[Autowire(service: 'cache.osm')]
         private CacheItemPoolInterface $osmCache,
+        private Security $security,
+        #[Autowire(service: 'limiter.geocode')]
+        private RateLimiterFactory $geocodeLimiter,
     ) {
+    }
+
+    /**
+     * Throttles outbound calls to the public Nominatim instance (1 req/s policy,
+     * IP bans for bulk use) per user, protecting the shared app IP (SEC-005).
+     */
+    private function throttleOutbound(): void
+    {
+        $key = $this->security->getUser()?->getUserIdentifier() ?? 'anonymous';
+        if (!$this->geocodeLimiter->create($key)->consume()->isAccepted()) {
+            throw new TooManyRequestsHttpException();
+        }
     }
 
     #[Route('/geocode/search', methods: ['GET'])]
@@ -45,6 +63,8 @@ final readonly class GeocodeController
 
             return new JsonResponse(['results' => $cached]);
         }
+
+        $this->throttleOutbound();
 
         try {
             $response = $this->nominatimClient->request('GET', '/search', [
@@ -103,6 +123,8 @@ final readonly class GeocodeController
 
             return new JsonResponse(['results' => $cached]);
         }
+
+        $this->throttleOutbound();
 
         try {
             $response = $this->nominatimClient->request('GET', '/reverse', [

--- a/api/src/Controller/GeocodeController.php
+++ b/api/src/Controller/GeocodeController.php
@@ -32,7 +32,8 @@ final readonly class GeocodeController
 
     /**
      * Throttles outbound calls to the public Nominatim instance (1 req/s policy,
-     * IP bans for bulk use) per user, protecting the shared app IP (SEC-005).
+     * IP bans for bulk use) per user, protecting the shared app IP
+     * (geocode rate-limit — 2026-07 security audit).
      */
     private function throttleOutbound(): void
     {

--- a/api/src/Controller/GpxUploadController.php
+++ b/api/src/Controller/GpxUploadController.php
@@ -8,10 +8,13 @@ use App\ApiResource\TripRequest;
 use App\Entity\User;
 use App\Service\GpxUploadService;
 use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\Routing\Attribute\Route;
 
 /**
@@ -27,12 +30,23 @@ final readonly class GpxUploadController
     public function __construct(
         private GpxUploadService $gpxUploadService,
         private Security $security,
+        #[Autowire(service: 'limiter.gpx_upload')]
+        private RateLimiterFactory $gpxUploadLimiter,
     ) {
     }
 
     #[Route('/trips/gpx-upload', methods: ['POST'])]
     public function __invoke(Request $request): JsonResponse
     {
+        /** @var User $user */
+        $user = $this->security->getUser();
+
+        // GPX upload is a second trip-creation entry point: throttle it per user
+        // like POST /trips so it cannot be scripted to exhaust storage/workers (SEC-006).
+        if (!$this->gpxUploadLimiter->create($user->getId()->toRfc4122())->consume()->isAccepted()) {
+            throw new TooManyRequestsHttpException();
+        }
+
         $file = $request->files->get('gpxFile');
 
         if (!$file instanceof UploadedFile) {
@@ -103,9 +117,6 @@ final readonly class GpxUploadController
 
         $locale = $request->getPreferredLanguage(['en', 'fr']) ?? 'en';
 
-        /** @var User $user */
-        $user = $this->security->getUser();
-
         $result = $this->gpxUploadService->createTrip($points, $title, $tripRequest, $locale, $user);
 
         $response = [
@@ -150,14 +161,24 @@ final readonly class GpxUploadController
             }
         }
 
+        // Enforce the same bounds as the TripRequest DTO (Assert\Range / Assert\Positive):
+        // this custom controller bypasses API Platform validation, and an out-of-range
+        // value — notably elevationPenalty=0 — would reach the pacing engine and throw
+        // DivisionByZeroError (HTTP 500) after a partial trip was already persisted (BUG-002).
         $fatigueFactor = $request->request->get('fatigueFactor');
         if (null !== $fatigueFactor && '' !== $fatigueFactor && is_numeric($fatigueFactor)) {
-            $tripRequest->fatigueFactor = (float) $fatigueFactor;
+            $value = (float) $fatigueFactor;
+            if ($value >= 0.5 && $value <= 1.0) {
+                $tripRequest->fatigueFactor = $value;
+            }
         }
 
         $elevationPenalty = $request->request->get('elevationPenalty');
         if (null !== $elevationPenalty && '' !== $elevationPenalty && is_numeric($elevationPenalty)) {
-            $tripRequest->elevationPenalty = (float) $elevationPenalty;
+            $value = (float) $elevationPenalty;
+            if ($value > 0.0) {
+                $tripRequest->elevationPenalty = $value;
+            }
         }
 
         $ebikeMode = $request->request->get('ebikeMode');

--- a/api/src/Controller/GpxUploadController.php
+++ b/api/src/Controller/GpxUploadController.php
@@ -38,15 +38,6 @@ final readonly class GpxUploadController
     #[Route('/trips/gpx-upload', methods: ['POST'])]
     public function __invoke(Request $request): JsonResponse
     {
-        /** @var User $user */
-        $user = $this->security->getUser();
-
-        // GPX upload is a second trip-creation entry point: throttle it per user
-        // like POST /trips so it cannot be scripted to exhaust storage/workers (SEC-006).
-        if (!$this->gpxUploadLimiter->create($user->getId()->toRfc4122())->consume()->isAccepted()) {
-            throw new TooManyRequestsHttpException();
-        }
-
         $file = $request->files->get('gpxFile');
 
         if (!$file instanceof UploadedFile) {
@@ -116,6 +107,17 @@ final readonly class GpxUploadController
         $this->applyOptionalParameters($tripRequest, $request);
 
         $locale = $request->getPreferredLanguage(['en', 'fr']) ?? 'en';
+
+        /** @var User $user */
+        $user = $this->security->getUser();
+
+        // GPX upload is a second trip-creation entry point: throttle it per user like
+        // POST /trips, just before the expensive createTrip, so it cannot be scripted
+        // to exhaust storage/workers (SEC-006). Cheap early validation 4xx are not
+        // throttled (and need no authenticated user).
+        if (!$this->gpxUploadLimiter->create($user->getId()->toRfc4122())->consume()->isAccepted()) {
+            throw new TooManyRequestsHttpException();
+        }
 
         $result = $this->gpxUploadService->createTrip($points, $title, $tripRequest, $locale, $user);
 

--- a/api/src/State/TripBatchRecomputeProcessor.php
+++ b/api/src/State/TripBatchRecomputeProcessor.php
@@ -15,9 +15,12 @@ use App\ComputationTracker\TripGenerationTrackerInterface;
 use App\Repository\TripRequestRepositoryInterface;
 use App\Service\ComputationDependencyResolver;
 use App\Service\TripAnalysisDispatcher;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
 
 /**
  * Processes the batch recompute endpoint: applies N pending modifications in a
@@ -42,6 +45,8 @@ final readonly class TripBatchRecomputeProcessor implements ProcessorInterface
         private MessageBusInterface $messageBus,
         private ComputationTrackerInterface $computationTracker,
         private TripAnalysisDispatcher $analysisDispatcher,
+        #[Autowire(service: 'limiter.trip_recompute')]
+        private RateLimiterFactory $recomputeLimiter,
     ) {
     }
 
@@ -57,6 +62,12 @@ final readonly class TripBatchRecomputeProcessor implements ProcessorInterface
 
         if ('' === $tripId) {
             throw new NotFoundHttpException('Trip not found.');
+        }
+
+        // Cap per trip: recompute re-dispatches the full enrichment pipeline onto
+        // the shared workers, so it must not be scriptable faster than they drain (SEC-010).
+        if (!$this->recomputeLimiter->create($tripId)->consume()->isAccepted()) {
+            throw new TooManyRequestsHttpException();
         }
 
         $stages = $this->tripStateManager->getStages($tripId);

--- a/api/src/State/TripDuplicateProcessor.php
+++ b/api/src/State/TripDuplicateProcessor.php
@@ -20,6 +20,8 @@ use Doctrine\ORM\EntityManagerInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\Uid\Uuid;
 
 /**
@@ -37,6 +39,8 @@ final readonly class TripDuplicateProcessor implements ProcessorInterface
         private Security $security,
         #[Autowire(service: 'cache.trip_state')]
         private CacheItemPoolInterface $tripStateCache,
+        #[Autowire(service: 'limiter.trip_duplicate')]
+        private RateLimiterFactory $duplicateLimiter,
     ) {
     }
 
@@ -48,6 +52,14 @@ final readonly class TripDuplicateProcessor implements ProcessorInterface
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): Trip
     {
         \assert($data instanceof TripRequest);
+
+        // Cap per user: duplication clones DB rows + Redis blobs (SEC-009).
+        $user = $this->security->getUser();
+        \assert($user instanceof User);
+        if (!$this->duplicateLimiter->create($user->getId()->toRfc4122())->consume()->isAccepted()) {
+            throw new TooManyRequestsHttpException();
+        }
+
         $source = $data;
         $sourceId = $uriVariables['id'] ?? '';
 

--- a/api/tests/Functional/GpxUploadTest.php
+++ b/api/tests/Functional/GpxUploadTest.php
@@ -346,35 +346,14 @@ final class GpxUploadTest extends ApiTestCase
         $this->assertResponseStatusCodeSame(202);
     }
 
-    #[Test]
-    public function gpxUploadIsRateLimited(): void
-    {
-        // SEC-006: the GPX upload path consumes limiter.gpx_upload (10/60s per user),
-        // so a scripted burst is throttled with 429 like POST /trips.
-        // Keep the kernel across requests so the in-memory (array) limiter store
-        // accumulates instead of resetting on each rebooted request.
-        $this->client->disableReboot();
-        $status = 0;
-        for ($i = 0; $i < 11; ++$i) {
-            $file = new UploadedFile(
-                self::FIXTURES_DIR.'/valid-route.gpx',
-                'valid-route.gpx',
-                'application/gpx+xml',
-                null,
-                true,
-            );
-            $response = $this->client->request('POST', '/trips/gpx-upload', [
-                'headers' => array_merge(['Content-Type' => 'multipart/form-data'], $this->authHeader($this->jwtToken)),
-                'extra' => ['files' => ['gpxFile' => $file]],
-            ]);
-            $status = $response->getStatusCode();
-            if (429 === $status) {
-                break;
-            }
-        }
-
-        $this->assertSame(429, $status, 'An upload burst beyond the per-user limit must be throttled (429).');
-    }
+    // Note: a functional "11 uploads → 429" test is intentionally omitted. The
+    // test cache pool is cache.adapter.array, which implements ResetInterface and
+    // is cleared by Symfony's service resetter after every request (independently
+    // of disableReboot()), so a real sliding-window limiter never accumulates
+    // across HTTP requests here. This is why the existing 429 tests in the suite
+    // mock a provider 429 rather than exhausting a real limiter. The limiter
+    // wiring itself (limiter.gpx_upload consumed before createTrip) is covered by
+    // the controller change.
 
     #[Test]
     public function uploadWithOptionalParameters(): void

--- a/api/tests/Functional/GpxUploadTest.php
+++ b/api/tests/Functional/GpxUploadTest.php
@@ -351,6 +351,9 @@ final class GpxUploadTest extends ApiTestCase
     {
         // SEC-006: the GPX upload path consumes limiter.gpx_upload (10/60s per user),
         // so a scripted burst is throttled with 429 like POST /trips.
+        // Keep the kernel across requests so the in-memory (array) limiter store
+        // accumulates instead of resetting on each rebooted request.
+        $this->client->disableReboot();
         $status = 0;
         for ($i = 0; $i < 11; ++$i) {
             $file = new UploadedFile(

--- a/api/tests/Functional/GpxUploadTest.php
+++ b/api/tests/Functional/GpxUploadTest.php
@@ -322,6 +322,58 @@ final class GpxUploadTest extends ApiTestCase
     }
 
     #[Test]
+    public function uploadWithZeroElevationPenaltyReturns202NotServerError(): void
+    {
+        // BUG-002 regression: elevationPenalty=0 is numeric but out of range. It must
+        // be clamped (ignored), never reach the pacing engine as a DivisionByZeroError
+        // (which surfaced as an unhandled HTTP 500 before the fix).
+        $file = new UploadedFile(
+            self::FIXTURES_DIR.'/valid-route.gpx',
+            'valid-route.gpx',
+            'application/gpx+xml',
+            null,
+            true,
+        );
+
+        $this->client->request('POST', '/trips/gpx-upload', [
+            'headers' => array_merge(['Content-Type' => 'multipart/form-data'], $this->authHeader($this->jwtToken)),
+            'extra' => [
+                'files' => ['gpxFile' => $file],
+                'parameters' => ['elevationPenalty' => '0', 'fatigueFactor' => '0.3'],
+            ],
+        ]);
+
+        $this->assertResponseStatusCodeSame(202);
+    }
+
+    #[Test]
+    public function gpxUploadIsRateLimited(): void
+    {
+        // SEC-006: the GPX upload path consumes limiter.gpx_upload (10/60s per user),
+        // so a scripted burst is throttled with 429 like POST /trips.
+        $status = 0;
+        for ($i = 0; $i < 11; ++$i) {
+            $file = new UploadedFile(
+                self::FIXTURES_DIR.'/valid-route.gpx',
+                'valid-route.gpx',
+                'application/gpx+xml',
+                null,
+                true,
+            );
+            $response = $this->client->request('POST', '/trips/gpx-upload', [
+                'headers' => array_merge(['Content-Type' => 'multipart/form-data'], $this->authHeader($this->jwtToken)),
+                'extra' => ['files' => ['gpxFile' => $file]],
+            ]);
+            $status = $response->getStatusCode();
+            if (429 === $status) {
+                break;
+            }
+        }
+
+        $this->assertSame(429, $status, 'An upload burst beyond the per-user limit must be throttled (429).');
+    }
+
+    #[Test]
     public function uploadWithOptionalParameters(): void
     {
         $file = new UploadedFile(

--- a/api/tests/Unit/Controller/GeocodeControllerTest.php
+++ b/api/tests/Unit/Controller/GeocodeControllerTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Controller;
+
+use App\Controller\GeocodeController;
+use App\Entity\User;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+final class GeocodeControllerTest extends TestCase
+{
+    #[Test]
+    public function searchIsRateLimited(): void
+    {
+        // Geocode rate-limit (2026-07 audit): on a cache miss, the outbound Nominatim
+        // call is throttled per user; an exhausted limiter rejects with 429 first.
+        $user = new User('geo@example.com');
+
+        $limiter = new RateLimiterFactory(
+            ['id' => 'geocode', 'policy' => 'sliding_window', 'limit' => 1, 'interval' => '60 seconds'],
+            new InMemoryStorage(),
+        );
+        $limiter->create($user->getUserIdentifier())->consume();
+
+        $security = $this->createStub(Security::class);
+        $security->method('getUser')->willReturn($user);
+
+        $missItem = $this->createStub(CacheItemInterface::class);
+        $missItem->method('isHit')->willReturn(false);
+        $cache = $this->createStub(CacheItemPoolInterface::class);
+        $cache->method('getItem')->willReturn($missItem);
+
+        $controller = new GeocodeController(
+            $this->createStub(HttpClientInterface::class),
+            $cache,
+            $security,
+            $limiter,
+        );
+
+        $this->expectException(TooManyRequestsHttpException::class);
+        $controller->search(new Request(['q' => 'paris']));
+    }
+}

--- a/api/tests/Unit/State/TripBatchRecomputeProcessorTest.php
+++ b/api/tests/Unit/State/TripBatchRecomputeProcessorTest.php
@@ -22,6 +22,8 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
 
 final class TripBatchRecomputeProcessorTest extends TestCase
 {
@@ -68,6 +70,7 @@ final class TripBatchRecomputeProcessorTest extends TestCase
             $messageBus,
             $computationTracker,
             new TripAnalysisDispatcher($messageBus),
+            new RateLimiterFactory(['id' => 'trip_recompute_test', 'policy' => 'no_limit'], new InMemoryStorage()),
         );
 
         $request = new TripBatchRecomputeRequest([

--- a/api/tests/Unit/State/TripBatchRecomputeProcessorTest.php
+++ b/api/tests/Unit/State/TripBatchRecomputeProcessorTest.php
@@ -20,6 +20,7 @@ use App\Service\TripAnalysisDispatcher;
 use App\State\TripBatchRecomputeProcessor;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\RateLimiter\RateLimiterFactory;
@@ -27,6 +28,39 @@ use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
 
 final class TripBatchRecomputeProcessorTest extends TestCase
 {
+    #[Test]
+    public function recomputeIsRateLimited(): void
+    {
+        // SEC-010: once the per-trip recompute limiter is exhausted, the endpoint
+        // must reject with 429 instead of re-dispatching the enrichment pipeline.
+        $messageBus = $this->createStub(MessageBusInterface::class);
+        $messageBus->method('dispatch')->willReturnCallback(static fn (object $m): Envelope => new Envelope($m));
+
+        $limiter = new RateLimiterFactory(
+            ['id' => 'trip_recompute', 'policy' => 'sliding_window', 'limit' => 1, 'interval' => '60 seconds'],
+            new InMemoryStorage(),
+        );
+        // Exhaust the single token for this trip so the processor's own consume() fails.
+        $limiter->create('t')->consume();
+
+        $processor = new TripBatchRecomputeProcessor(
+            $this->createStub(TripRequestRepositoryInterface::class),
+            $this->createStub(TripGenerationTrackerInterface::class),
+            new ComputationDependencyResolver(),
+            $messageBus,
+            $this->createStub(ComputationTrackerInterface::class),
+            new TripAnalysisDispatcher($messageBus),
+            $limiter,
+        );
+
+        $this->expectException(TooManyRequestsHttpException::class);
+        $processor->process(
+            new TripBatchRecomputeRequest([new TripModification(type: 'pacing')]),
+            new Post(),
+            ['id' => 't'],
+        );
+    }
+
     /**
      * Runs a `pacing` recompute with the given tracker progress and returns the
      * dispatched message class names.

--- a/api/tests/Unit/State/TripDuplicateProcessorTest.php
+++ b/api/tests/Unit/State/TripDuplicateProcessorTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\State;
+
+use ApiPlatform\Metadata\Post;
+use App\ApiResource\TripRequest;
+use App\ComputationTracker\ComputationTrackerInterface;
+use App\ComputationTracker\TripGenerationTrackerInterface;
+use App\Entity\User;
+use App\Repository\TripRequestRepositoryInterface;
+use App\State\TripDuplicateProcessor;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
+
+final class TripDuplicateProcessorTest extends TestCase
+{
+    #[Test]
+    public function duplicateIsRateLimited(): void
+    {
+        // SEC-009: once the per-user duplicate limiter is exhausted, the endpoint
+        // must reject with 429 before cloning any DB rows / Redis blobs.
+        $user = new User('dup@example.com');
+
+        $limiter = new RateLimiterFactory(
+            ['id' => 'trip_duplicate', 'policy' => 'sliding_window', 'limit' => 1, 'interval' => '60 seconds'],
+            new InMemoryStorage(),
+        );
+        $limiter->create($user->getId()->toRfc4122())->consume();
+
+        $security = $this->createStub(Security::class);
+        $security->method('getUser')->willReturn($user);
+
+        $processor = new TripDuplicateProcessor(
+            $this->createStub(TripRequestRepositoryInterface::class),
+            $this->createStub(EntityManagerInterface::class),
+            $this->createStub(ComputationTrackerInterface::class),
+            $this->createStub(TripGenerationTrackerInterface::class),
+            $security,
+            $this->createStub(CacheItemPoolInterface::class),
+            $limiter,
+        );
+
+        $this->expectException(TooManyRequestsHttpException::class);
+        $processor->process(new TripRequest(), new Post(), ['id' => 't']);
+    }
+}


### PR DESCRIPTION
## Summary

Ferme quatre findings de rate-limit manquant + une validation d'entrée (audit **SEC-005/006/009/010**, **BUG-002**).

Ajoute des limiteurs par-utilisateur/par-voyage (`sliding_window`, Redis) aux endpoints qui n'en avaient aucun :

| Endpoint | Limiteur | Finding |
|---|---|---|
| `POST /trips/gpx-upload` | `gpx_upload` (10/60s, /user) | SEC-006 (2e voie de création non throttlée) |
| `GET /geocode/{search,reverse}` | `geocode` (30/60s, /user, sur cache-miss) | SEC-005 (ban IP Nominatim) |
| `POST /trips/{id}/duplicate` | `trip_duplicate` (10/60s, /user) | SEC-009 |
| `POST /trips/{id}/recompute` | `trip_recompute` (10/60s, /trip) | SEC-010 (re-dispatch pipeline) |

**BUG-002** : `GpxUploadController::applyOptionalParameters` bornait `fatigueFactor` (0.5–1.0) et `elevationPenalty` (>0) selon les mêmes contraintes que le DTO. `elevationPenalty=0` contournait la validation → `DivisionByZeroError` (HTTP 500) dans le moteur de pacing après persistance partielle du voyage.

## Test plan

- [x] `php -l` OK sur tous les fichiers.
- [x] Test unitaire `TripBatchRecomputeProcessorTest` adapté (nouveau `RateLimiterFactory` no_limit).
- [ ] CI (PHPUnit).

## Auto-critique

Le limiter geocode est consommé **sur cache-miss uniquement** (avant l'appel Nominatim, hors du try/catch pour ne pas transformer le 429 en 502), donc les hits de cache ne sont pas pénalisés. Recompute keyé par `tripId` (throttle per-trip du re-dispatch) plutôt que d'ajouter `Security` au processor.

Réf. audit interne SEC-005/006/009/010 + BUG-002 (recette #245).

<!-- claude-review-start -->
## Claude Review

**Summary:** No new correctness or security issues. Since the last review (`69b6ef6e`), the final commit adds real-limiter unit tests for `trip_duplicate` and `geocode` (`TripDuplicateProcessorTest::duplicateIsRateLimited`, `GeocodeControllerTest::searchIsRateLimited`), closing two more legs of the test-coverage thread, and drops the colliding `SEC-005` label from the geocode code comments in favor of a generic `2026-07 security audit` reference. Verified: the `/geocode/*` routes fall under the app's default `IS_AUTHENTICATED_FULLY` access-control rule (not in the `PUBLIC_ACCESS` list), so `throttleOutbound()`'s `?? 'anonymous'` fallback is unreachable in practice, not a shared-bucket bypass. The `fatigueFactor`/`elevationPenalty` clamps in `GpxUploadController::applyOptionalParameters` match the DTO's `Assert\Range(0.5, 1.0)` / `Assert\Positive` bounds exactly, and the upload rate limiter is consumed after validation/parsing as intended (per the earlier `fix(gpx)` commit). PR title follows Conventional Commits.

**Resolved threads:** Resolved 1 previously open thread — the `SEC-005` ID-collision thread (`rate_limiter.php`) is fixed: the geocode finding no longer cites `SEC-005` (which still names a different, already-closed finding in `docs/recette/audit-report.md`) anywhere in the backend code, taking the "drop the finding-ID reference" option the thread offered.

**Open item carried over:** The test-coverage thread (`rate_limiter.php:71`) stays open but is now 3/4 addressed — only `gpx_upload` has no test asserting its 429 path fires. Per the thread discussion: extracting an interface from `GpxUploadService` solely to unit-test this guard isn't warranted here — the wiring is 3 lines, identical to the three now-tested siblings, and reviewed directly. Recommend accepting this as a documented, low-risk gap rather than adding an abstraction for it in this PR.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases — `trip_recompute`, `trip_duplicate`, and `geocode` each have a unit test exhausting a real `sliding_window` limiter and asserting `TooManyRequestsHttpException`; `gpx_upload` remains untested for the reasons above (accepted gap); BUG-002 has a regression test (`uploadWithZeroElevationPenaltyReturns202NotServerError`)
- [x] Documentation is up to date — the `SEC-005` collision is resolved; `SEC-006/009/010`/`BUG-002` aren't mirrored into `docs/recette/audit-report.md`/`TRACKING.md`, consistent with the PR body's own reference to internal recette tracking (`recette #245`) rather than that file
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments — no new code-level findings this round.

_Commit reviewed: 97ac50a0cd69c57ee0369a99f38ca1a7284722bb_
<!-- claude-review-end -->