### PR TITLE
fix(infra): fail closed on default Mercure secret, enforce CSP subset, trim health

### DIFF
--- a/.docker/php/Caddyfile
+++ b/.docker/php/Caddyfile
@@ -100,6 +100,15 @@
         # CSP endpoint, turning the Report-Only phase into a real safety net.
         header @pwa Content-Security-Policy-Report-Only "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self' 'unsafe-inline' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://basemaps.cartocdn.com https://server.arcgisonline.com https://tile.openstreetmap.org https://commons.wikimedia.org; connect-src 'self' https://basemaps.cartocdn.com https://server.arcgisonline.com https://tile.openstreetmap.org; worker-src 'self' blob:; font-src 'self' data:; manifest-src 'self'; report-uri {$CSP_REPORT_URI:}"
 
+        # Enforced CSP (SEC-008): the full policy above stays Report-Only until the
+        # script/style origins are validated with a nonce strategy. This enforced
+        # policy deliberately omits default-src so the fetch directives
+        # (script/style/img/connect/font/worker) stay UNrestricted — otherwise they
+        # would inherit default-src and break Next.js hydration + map tiles. It only
+        # enforces the non-fetch directives, which carry zero regression risk: they
+        # gate framing, plugins, base-uri hijacking and form exfiltration.
+        header @pwa Content-Security-Policy "object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+
         # Comment the following line if you don't want Next.js to catch requests for HTML documents.
         # In this case, they will be handled by the PHP app.
         reverse_proxy @pwa http://{$PWA_UPSTREAM}

--- a/.docker/php/entrypoint.sh
+++ b/.docker/php/entrypoint.sh
@@ -9,6 +9,18 @@
 # See docs/adr/adr-032-migrations-and-rollback-strategy.md
 set -e
 
+# Fail closed (SEC-004): the Mercure hub is internet-facing and verifies subscriber
+# JWTs with this key, so booting prod on the public API Platform skeleton default
+# would let anyone forge a token and read every trip's live stream. compose resolves
+# MERCURE_JWT_KEY into MERCURE_JWT_SECRET, so we check the resolved container value.
+# CI and local iso-prod (recette) provide a non-default key; real prod MUST set one.
+case "${MERCURE_JWT_SECRET:-}" in
+	'' | *'!ChangeThisMercureHubJWTSecretKey!'*)
+		echo 'FATAL: MERCURE_JWT_KEY is unset or still the public skeleton default; refusing to boot (SEC-004). Set a strong MERCURE_JWT_KEY.' >&2
+		exit 1
+		;;
+esac
+
 if [ "${MIGRATIONS_ON_BOOT:-false}" = "true" ]; then
 	# Wait for the database to accept connections before migrating. The compose
 	# healthcheck (pg_isready) can briefly report ready during Postgres' init

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -406,6 +406,9 @@ jobs:
       JWT_PASSPHRASE: "ci-test-passphrase"
       FRONTEND_URL: "https://localhost"
       MAILER_DSN: "null://null"
+      # Non-default so the SEC-004 fail-closed boot guard passes (the prod image
+      # refuses to boot on the public Mercure skeleton default).
+      MERCURE_JWT_KEY: "ci-test-mercure-key"
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -472,6 +475,9 @@ jobs:
       JWT_PASSPHRASE: "ci-test-passphrase"
       FRONTEND_URL: "https://localhost"
       MAILER_DSN: "null://null"
+      # Non-default so the SEC-004 fail-closed boot guard passes (the prod image
+      # refuses to boot on the public Mercure skeleton default).
+      MERCURE_JWT_KEY: "ci-test-mercure-key"
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/api/config/services.php
+++ b/api/config/services.php
@@ -15,8 +15,6 @@ use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $containerConfigurator->parameters()
-        ->set('app.commit_sha', '%env(default:default_commit_sha:APP_COMMIT)%')
-        ->set('default_commit_sha', 'unknown')
         // AI token encryption key (ADR-042). PRODUCTION MUST set AI_TOKEN_ENC_KEY;
         // the dev/CI default below only keeps the container bootable (throwaway dev
         // tokens, never used to protect real credentials).

--- a/api/src/Controller/HealthController.php
+++ b/api/src/Controller/HealthController.php
@@ -37,8 +37,6 @@ final readonly class HealthController
         private RateLimiterFactory $healthLivenessLimiter,
         #[Autowire(service: 'limiter.health_readiness')]
         private RateLimiterFactory $healthReadinessLimiter,
-        #[Autowire(param: 'app.commit_sha')]
-        private string $commitSha,
         private RedisHealthClientFactory $redisClientFactory,
     ) {
     }
@@ -53,7 +51,6 @@ final readonly class HealthController
 
         return new JsonResponse([
             'status' => 'ok',
-            'commit' => $this->commitSha,
         ]);
     }
 
@@ -100,7 +97,6 @@ final readonly class HealthController
 
         return new JsonResponse([
             'status' => $status,
-            'commit' => $this->commitSha,
             'deps' => $deps,
         ], $httpStatus);
     }

--- a/api/tests/Functional/HealthControllerTest.php
+++ b/api/tests/Functional/HealthControllerTest.php
@@ -39,7 +39,7 @@ final class HealthControllerTest extends ApiTestCase
     }
 
     #[Test]
-    public function livenessReturns200WithCommitSha(): void
+    public function livenessReturns200(): void
     {
         $response = $this->client->request('GET', '/api/healthz');
 
@@ -47,8 +47,8 @@ final class HealthControllerTest extends ApiTestCase
 
         $data = $response->toArray();
         $this->assertSame('ok', $data['status']);
-        $this->assertArrayHasKey('commit', $data);
-        $this->assertIsString($data['commit']);
+        // The commit SHA is no longer exposed on the public endpoint (SEC-011).
+        $this->assertArrayNotHasKey('commit', $data);
     }
 
     #[Test]

--- a/compose.recette.yaml
+++ b/compose.recette.yaml
@@ -28,6 +28,12 @@ secrets:
 x-recette-env: &recette-env
   MAILER_DSN: smtp://mailcatcher:1025
   JWT_PASSPHRASE: recette
+  # Non-default Mercure key so the SEC-004 fail-closed boot guard passes locally.
+  # Publisher/subscriber/secret must match for the embedded hub to verify the
+  # app-issued subscriber tokens (HS256).
+  MERCURE_PUBLISHER_JWT_KEY: recette-mercure-jwt-secret
+  MERCURE_SUBSCRIBER_JWT_KEY: recette-mercure-jwt-secret
+  MERCURE_JWT_SECRET: recette-mercure-jwt-secret
 
 services:
   php:

--- a/docs/runbooks/release-checklist.md
+++ b/docs/runbooks/release-checklist.md
@@ -29,7 +29,7 @@ A green release is one where every line below is checked. If any line is unknown
 ### 3. Smoke on staging
 
 - [ ] Stack started cleanly on staging (`docker compose up -d`)
-- [ ] `curl https://staging.../api/healthz` returns 200 with the staging commit SHA
+- [ ] `curl https://staging.../api/healthz` returns 200 (the commit SHA is no longer exposed publicly — SEC-011; check the deployed SHA via the image label / deployment logs instead)
 - [ ] `curl https://staging.../api/health | jq` reports every dependency `ok`
 - [ ] End-to-end trip creation through the PWA succeeded on staging (`make test-e2e` against staging if applicable)
 


### PR DESCRIPTION
## Summary

Durcit l'exposition prod — findings audit **SEC-004** (secrets par défaut), **SEC-008** (CSP), **SEC-011** (info-disclosure health).

### SEC-004 — boot fail-closed sur le secret Mercure par défaut (MEDIUM)
Le hub Mercure est internet-facing et vérifie les JWT abonnés avec `MERCURE_JWT_KEY`. Si un déploiement omet la variable, la stack bootait silencieusement sur la valeur publique du skeleton API Platform → un attaquant forge un JWT `subscribe:["*"]` et lit le flux temps réel de **tous** les voyages. L'entrypoint prod **refuse désormais de booter** si `MERCURE_JWT_SECRET` est vide ou égal au placeholder.
- `compose.recette.yaml` (x-recette-env) et les jobs CI playwright fournissent une clé non-défaut → ils bootent toujours.
- `APP_ENV: prod` étant codé en dur dans `compose.yaml`, la CI utilise l'image prod ; d'où la clé CI ajoutée.
- *Note : `DATABASE_PASSWORD` par défaut (interne-only, aucun port publié) est un risque bien moindre — laissé hors du guard, à ajouter ultérieurement si souhaité.*

### SEC-008 — CSP appliquée (sous-ensemble sûr) (LOW)
Émet une `Content-Security-Policy` **appliquée** pour les directives non-fetch (`object-src`/`frame-ancestors`/`base-uri`/`form-action`) — **zéro risque de régression** (elles ne touchent ni script/style/img). La politique complète reste `Report-Only` tant que `script-src` n'est pas passé en nonce (retrait de `'unsafe-inline'`). `default-src` est volontairement omis de la version appliquée pour ne pas contraindre les directives fetch par héritage.

### SEC-011 — retrait du commit SHA public (LOW)
`/api/healthz` et `/api/health` n'exposent plus le `commit` (version-disclosure). Le smoke-test de déploiement (`.status == "ok"`) et le frontend ne le consomment pas ; le SHA reste dispo via les labels d'image / logs de déploiement.

## Test plan

- [x] `php -l`, `sh -n` (entrypoint), YAML lint OK.
- [x] `HealthControllerTest` mis à jour (assert `commit` absent).
- [ ] CI (dont le boot du stack playwright avec la clé Mercure fournie).

Réf. audit interne SEC-004/008/011 (recette #245).

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 new critical/warning/suggestion findings. 1 previously-flagged suggestion (dead build-time commit-SHA config) remains unaddressed — no new inline comment posted since the thread is already open and tracked.

**Resolved threads:** Resolved 1 previously open thread that was addressed (stale release-checklist runbook wording, fixed by the `docs(runbook)` commit).

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [ ] Documentation is up to date (`.docker/php/Dockerfile` `ARG COMMIT_SHA`/`ENV APP_COMMIT` and `compose.yaml`'s build arg + stale comment at lines 72-78 still describe the removed healthz commit-SHA behavior — see open thread on `api/config/services.php`)
- [x] Dependent tickets accounted for

**Inline comments:** No new inline comments.

Commit reviewed: `59edbb0513dd7cdc7f46b189c65f6180e1b41f69`
<!-- claude-review-end -->