### PR TITLE
fix(pwa): a11y contrast and label-in-name on the trip view

### DIFF
--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -53,10 +53,8 @@
     "downloadGpx": "Download full trip GPX",
     "downloadFit": "Download full trip FIT",
     "downloadFailed": "Download failed. Please try again.",
-    "datesLabel": "Trip dates",
     "editDatesHint": "Edit dates",
     "noDates": "Dates not set",
-    "profileLabel": "Rider profile",
     "editProfileHint": "Edit rider profile",
     "customProfile": "Custom",
     "loadingAriaLabel": "Loading trip summary"

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -53,10 +53,8 @@
     "downloadGpx": "Télécharger le GPX complet",
     "downloadFit": "Télécharger le FIT complet",
     "downloadFailed": "Le téléchargement a échoué. Réessaie.",
-    "datesLabel": "Dates du voyage",
     "editDatesHint": "Modifier les dates",
     "noDates": "Dates non définies",
-    "profileLabel": "Profil cyclo",
     "editProfileHint": "Modifier le profil cyclo",
     "customProfile": "Personnalisé",
     "loadingAriaLabel": "Chargement du résumé du voyage"

--- a/pwa/src/components/Map/tile-layer-control.tsx
+++ b/pwa/src/components/Map/tile-layer-control.tsx
@@ -96,7 +96,10 @@ export function TileLayerControl({
               "transition-colors",
               "focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]",
               isActive
-                ? "bg-[var(--brand)] text-white shadow-sm"
+                // --brand-fill (not --brand): in dark mode --brand is the light
+                // accent #e08040 where white text fails AA (2.86); --brand-fill is
+                // the darker amber tuned for white-on-fill contrast (A11Y-001).
+                ? "bg-[var(--brand-fill)] text-white shadow-sm"
                 : "text-[var(--ink)] hover:bg-[var(--accent)]",
             ].join(" ")}
           >

--- a/pwa/src/components/stage-downloads.tsx
+++ b/pwa/src/components/stage-downloads.tsx
@@ -49,7 +49,7 @@ export function StageDownloads({
       <Button
         variant="ghost"
         size="sm"
-        className="h-6 gap-1 text-muted-icon px-1.5 cursor-pointer"
+        className="h-6 gap-1 text-muted-foreground px-1.5 cursor-pointer"
         disabled={(!tripId && !share) || !!downloading}
         onClick={() => void handleDownload("gpx")}
         aria-label={t("downloadGpx", { dayNumber })}
@@ -65,7 +65,7 @@ export function StageDownloads({
       <Button
         variant="ghost"
         size="sm"
-        className="h-6 gap-1 text-muted-icon px-1.5 cursor-pointer"
+        className="h-6 gap-1 text-muted-foreground px-1.5 cursor-pointer"
         disabled={(!tripId && !share) || !!downloading}
         onClick={() => void handleDownload("fit")}
         aria-label={t("downloadFit", { dayNumber })}

--- a/pwa/src/components/trip-summary.tsx
+++ b/pwa/src/components/trip-summary.tsx
@@ -191,11 +191,13 @@ export function TripSummary({
             type="button"
             className="group flex items-center gap-1.5 hover:text-foreground transition-colors cursor-pointer"
             onClick={() => openConfigPanelAt("dates")}
-            aria-label={t("datesLabel")}
+            // No aria-label: it would override the visible dates and break WCAG
+            // 2.5.3 (Label in Name). The visible text is the accessible name; the
+            // edit affordance is conveyed by the title (A11Y-002).
             title={t("editDatesHint")}
             data-testid="summary-dates"
           >
-            <CalendarDays className="h-4 w-4 text-brand" />
+            <CalendarDays className="h-4 w-4 text-brand" aria-hidden="true" />
             <span>{datesDisplay}</span>
             <Pencil
               className="h-3 w-3 text-muted-foreground/60 group-hover:text-foreground transition-colors"
@@ -219,11 +221,12 @@ export function TripSummary({
             type="button"
             className="group flex items-center gap-1.5 hover:text-foreground transition-colors cursor-pointer"
             onClick={() => openConfigPanelAt("pacing")}
-            aria-label={t("profileLabel")}
+            // No aria-label: it would override the visible profile and break WCAG
+            // 2.5.3 (Label in Name). The visible text is the accessible name (A11Y-002).
             title={t("editProfileHint")}
             data-testid="summary-profile"
           >
-            <User className="h-4 w-4 text-brand" />
+            <User className="h-4 w-4 text-brand" aria-hidden="true" />
             <span>{profileLabel}</span>
             <Pencil
               className="h-3 w-3 text-muted-foreground/60 group-hover:text-foreground transition-colors"
@@ -244,8 +247,8 @@ export function TripSummary({
         </div>
       )}
 
-      <p className="flex items-center justify-center gap-1 text-xs text-muted-foreground/70">
-        <Info className="h-3 w-3" />
+      <p className="flex items-center justify-center gap-1 text-xs text-muted-foreground">
+        <Info className="h-3 w-3" aria-hidden="true" />
         {t("disclaimer")}
       </p>
     </div>

--- a/pwa/src/components/trip-summary.tsx
+++ b/pwa/src/components/trip-summary.tsx
@@ -183,7 +183,7 @@ export function TripSummary({
             read-only shared view (recette #649). */}
         {readOnly ? (
           <div className="flex items-center gap-1.5" data-testid="summary-dates">
-            <CalendarDays className="h-4 w-4 text-brand" />
+            <CalendarDays className="h-4 w-4 text-brand" aria-hidden="true" />
             <span>{datesDisplay}</span>
           </div>
         ) : (
@@ -213,7 +213,7 @@ export function TripSummary({
             className="flex items-center gap-1.5"
             data-testid="summary-profile"
           >
-            <User className="h-4 w-4 text-brand" />
+            <User className="h-4 w-4 text-brand" aria-hidden="true" />
             <span>{profileLabel}</span>
           </div>
         ) : (

--- a/pwa/src/components/trip-title.tsx
+++ b/pwa/src/components/trip-title.tsx
@@ -79,7 +79,9 @@ export function TripTitle({
         onChange={onChange}
         className="text-xl md:text-2xl font-semibold"
         placeholder={t("placeholder")}
-        aria-label={t("ariaLabel")}
+        // Include the visible title in the accessible name so it is not hidden
+        // behind the field label (WCAG 2.5.3 Label in Name, A11Y-002).
+        aria-label={[t("ariaLabel"), title].filter(Boolean).join(" : ")}
         data-testid="trip-title"
       />
 


### PR DESCRIPTION
## Summary

Corrige les findings d'accessibilité de la vue voyage (Lighthouse a11y 96 → cible 100) : **A11Y-001** (contraste WCAG AA) et **A11Y-002** (WCAG 2.5.3 Label in Name).

### A11Y-001 — contraste (mode sombre)
- **Toggle de couche carte actif** : `text-white` sur `--brand` = **2.86:1** en dark (où `--brand` est l'accent clair `#e08040`). Bascule sur **`--brand-fill`** (`#a8561a`), le token amber foncé déjà prévu dans `globals.css` pour le white-on-fill AA.
- Disclaimer du résumé : retrait du fade `/70` (`text-muted-foreground/70` → `text-muted-foreground`).
- Labels de téléchargement GPX/FIT : sortie du token `text-muted-icon` trop pâle → `text-muted-foreground`.

### A11Y-002 — Label in Name
Le titre, les dates et le profil avaient un `aria-label` statique qui **masquait le texte visible** du nom accessible (un utilisateur de commande vocale prononçant la valeur visible ne pouvait pas cibler le contrôle). Le texte visible est désormais inclus dans le nom accessible (titre) ou l'`aria-label` masquant est retiré, le contexte d'édition restant porté par `title` (dates/profil). Icônes décoratives passées en `aria-hidden`.

### Différés (avec rationale)
- **SEC-012** (listener `__test_mercure_event` en prod, INFO) : les tests E2E mockés **injectent cet événement sur le build de prod** en CI ; le gater derrière `NODE_ENV`/un flag casserait l'injection SSE de toute la suite mockée. Impact négligeable (nécessite déjà une exécution JS sur la page). À traiter avec un marqueur de test dédié en follow-up.
- **SUP-001** (undici HIGH) : l'undici signalé est **bundlé par le standalone Next.js** (hors `overrides`, dont les floors 6.27.0/7.28.0 sont déjà le max de leur majeure) ; le correctif exige une bump undici 8.x ou Next → investigation dépendances dédiée.

## Test plan

- [x] Changements JSX/className + aria (revue).
- [ ] CI (eslint / tsc / vitest).
- [ ] ⚠️ **Re-vérifier via Lighthouse a11y** (clair + sombre) : le fix toggle est haute-confiance (token dédié), les ajustements de petit texte sont directionnels et méritent confirmation navigateur.

Réf. audit interne A11Y-001/002 (recette #245, issue #245).
<!-- claude-review-start -->
## Claude Review

**Summary:** APPROVE — 0 blocking findings, 1 non-blocking suggestion, 1 informational doc note. The latest commit adds `aria-hidden` to the read-only-variant `CalendarDays`/`User` icons, closing the last open gap. Contrast math for `--brand-fill` still checks out (≈5.24:1 vs ≈2.86:1 on the buggy `--brand` in dark) and holds across every theme variant (`forest` 5.06:1, `indigo` 5.86:1, `brick` 5.46:1). The `aria-label` concatenation in `trip-title.tsx` correctly folds the visible title into the accessible name, fixing the `EditableField` view-mode `<span aria-label>` override that was hiding it.

**Resolved threads:** Resolved 1 previously open thread (read-only dates/profile icons now marked `aria-hidden`, fixed by the latest commit).

**PR title check:** type/scope are valid (`fix(pwa)`), but the description "a11y contrast and label-in-name on the trip view" is a noun phrase, not imperative mood (e.g. "fix a11y contrast and label-in-name issues on the trip view").

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate (reuses the existing `--brand-fill` token rather than introducing a new one)
- [ ] Tests cover new/changed cases — still no test asserts on the accessible-name fix itself; `title-editing.spec.ts`'s `getByRole(..., { name: "Titre du voyage" })` would keep passing even if this regressed to a static label (see open thread on `trip-title.tsx`)
- [ ] Documentation is up to date — `TRACKING.md`/`docs/recette/audit-report.md` already use `A11Y-001`/`A11Y-002` for a closed, unrelated landing-page finding (PR #633); reusing the same IDs here for the trip-view fixes will confuse future cross-referencing
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

**Commit reviewed:** `5bdc86046bde324997b55242f0dde80c8345600a`
<!-- claude-review-end -->
