### PR TITLE
docs(makefile): fix redocly alias help text

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ phpunit: test-php ## Alias for "test-php"
 openapi-lint: ## Run OpenAPI lint
 	@docker compose run --rm --no-deps php bin/console api:openapi:export --yaml | docker compose exec -T php redocly lint /dev/stdin
 
-redocly: openapi-lint ## Alias for "test-php"
+redocly: openapi-lint ## Alias for "openapi-lint"
 
 security-check: ## Run Security Check
 	@docker compose run --rm --no-deps php symfony check:security


### PR DESCRIPTION
## Summary

Corrige **DX-004** : l'aide de la cible `redocly` affichait « Alias for "test-php" » (erreur de copier-coller) alors qu'elle alias `openapi-lint`.

> **Scope réduit après rebase.** Cette PR portait aussi le nettoyage des références Ollama (**DX-001**) dans `getting-started(.fr).md` et `deployment.md`. Depuis, **#811 (docs full audit, English-only)** a été mergé sur `main` et a déjà supprimé toutes ces références (0 occurrence Ollama ; `getting-started.fr.md` supprimé ; section AI de `deployment.md` déjà réécrite). Rebasée sur `main`, cette PR ne conserve donc que le fix Makefile — DX-001 est couvert par #811.

Réf. audit interne DX-004 (recette #245).