### PR TITLE
fix(auth): encrypt refresh tokens at rest + look up by digest (SEC-003)

### DIFF
--- a/.docker/php/entrypoint.sh
+++ b/.docker/php/entrypoint.sh
@@ -21,6 +21,17 @@ case "${MERCURE_JWT_SECRET:-}" in
 		;;
 esac
 
+# Fail closed (SEC-003): AI_TOKEN_ENC_KEY encrypts AI provider tokens AND refresh
+# tokens at rest. Unset, it falls back to the committed dev default in services.php,
+# so both bearer credentials would be "encrypted" under a key anyone with the source
+# can read. Refuse to boot on the missing/default key. CI and iso-prod set a real one.
+case "${AI_TOKEN_ENC_KEY:-}" in
+	'' | 'dev-only-ai-token-encryption-key-change-in-prod')
+		echo 'FATAL: AI_TOKEN_ENC_KEY is unset or still the dev default; refusing to boot (SEC-003). Set a strong AI_TOKEN_ENC_KEY.' >&2
+		exit 1
+		;;
+esac
+
 if [ "${MIGRATIONS_ON_BOOT:-false}" = "true" ]; then
 	# Wait for the database to accept connections before migrating. The compose
 	# healthcheck (pg_isready) can briefly report ready during Postgres' init

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -559,6 +559,9 @@ jobs:
       # Non-default so the SEC-004 fail-closed boot guard passes (the prod image
       # refuses to boot on the public Mercure skeleton default).
       MERCURE_JWT_KEY: "ci-test-mercure-key"
+      # Non-default so the SEC-003 fail-closed boot guard passes (the prod image
+      # refuses to boot on the committed dev token-encryption key).
+      AI_TOKEN_ENC_KEY: "ci-test-ai-enc-key"
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -628,6 +631,9 @@ jobs:
       # Non-default so the SEC-004 fail-closed boot guard passes (the prod image
       # refuses to boot on the public Mercure skeleton default).
       MERCURE_JWT_KEY: "ci-test-mercure-key"
+      # Non-default so the SEC-003 fail-closed boot guard passes (the prod image
+      # refuses to boot on the committed dev token-encryption key).
+      AI_TOKEN_ENC_KEY: "ci-test-ai-enc-key"
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/api/migrations/Version20260704120000.php
+++ b/api/migrations/Version20260704120000.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Encrypts refresh tokens at rest (SEC-003).
+ *
+ * The token column now stores a reversible libsodium ciphertext (see
+ * RefreshTokenEncryptor) instead of the plaintext credential, and rows are
+ * looked up by a deterministic `token_digest` (sha256). Existing rows hold
+ * plaintext incompatible with the new format, so they are purged — active
+ * sessions transparently re-authenticate via the refresh flow / magic link.
+ */
+final class Version20260704120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Encrypt refresh tokens at rest + look up by digest (SEC-003)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // Plaintext rows are incompatible with the encrypted format; purge them.
+        $this->addSql(<<<'SQL'
+            DELETE FROM refresh_token
+            SQL);
+        $this->addSql(<<<'SQL'
+            DROP INDEX uniq_refresh_token_token
+            SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE refresh_token ALTER COLUMN token TYPE TEXT
+            SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE refresh_token ADD token_digest VARCHAR(64) NOT NULL
+            SQL);
+        $this->addSql(<<<'SQL'
+            CREATE UNIQUE INDEX uniq_refresh_token_digest ON refresh_token (token_digest)
+            SQL);
+        // replaced_by_token now holds the successor's 64-char digest, not the token.
+        $this->addSql(<<<'SQL'
+            ALTER TABLE refresh_token ALTER COLUMN replaced_by_token TYPE VARCHAR(64)
+            SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            DELETE FROM refresh_token
+            SQL);
+        $this->addSql(<<<'SQL'
+            DROP INDEX uniq_refresh_token_digest
+            SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE refresh_token DROP token_digest
+            SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE refresh_token ALTER COLUMN token TYPE VARCHAR(128)
+            SQL);
+        $this->addSql(<<<'SQL'
+            CREATE UNIQUE INDEX uniq_refresh_token_token ON refresh_token (token)
+            SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE refresh_token ALTER COLUMN replaced_by_token TYPE VARCHAR(128)
+            SQL);
+    }
+}

--- a/api/src/Entity/RefreshToken.php
+++ b/api/src/Entity/RefreshToken.php
@@ -5,12 +5,13 @@ declare(strict_types=1);
 namespace App\Entity;
 
 use App\Repository\RefreshTokenRepository;
+use App\Security\RefreshTokenEncryptor;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Uid\Uuid;
 
 #[ORM\Entity(repositoryClass: RefreshTokenRepository::class)]
 #[ORM\Table(name: 'refresh_token')]
-#[ORM\UniqueConstraint(name: 'uniq_refresh_token_token', columns: ['token'])]
+#[ORM\UniqueConstraint(name: 'uniq_refresh_token_digest', columns: ['token_digest'])]
 #[ORM\Index(name: 'idx_refresh_token_user', columns: ['user_id'])]
 class RefreshToken
 {
@@ -22,25 +23,54 @@ class RefreshToken
     private \DateTimeImmutable $createdAt;
 
     /**
-     * Successor token set when this one is rotated. Kept (rather than deleting
-     * the row) so a reload race that re-sends the pre-rotation token resolves to
-     * its successor within the grace window instead of being rejected (#649).
+     * Plaintext token, held in memory only for the request that mints it so it
+     * can be re-served to the client without a decrypt round-trip. Never
+     * persisted (the row stores {@see $token} encrypted + {@see $tokenDigest}).
      */
-    #[ORM\Column(length: 128, nullable: true)]
+    private ?string $plainToken = null;
+
+    /**
+     * Digest of the successor token when this one is rotated. Kept (rather than
+     * deleting the row) so a reload race that re-sends the pre-rotation token
+     * resolves to its successor within the grace window instead of being
+     * rejected (#649). Stores the digest, not the token, so the lookup stays on
+     * the indexed column.
+     */
+    #[ORM\Column(length: 64, nullable: true)]
     private ?string $replacedByToken = null;
 
     public function __construct(
         #[ORM\ManyToOne(targetEntity: User::class)]
         #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
         private User $user,
-        #[ORM\Column(length: 128)]
+        // Reversible ciphertext of the token (see RefreshTokenEncryptor).
+        #[ORM\Column(type: 'text')]
         private string $token,
+        // Deterministic sha256 of the plaintext token, used for lookup.
+        #[ORM\Column(length: 64)]
+        private string $tokenDigest,
         #[ORM\Column]
         private \DateTimeImmutable $expiresAt,
         ?Uuid $id = null,
     ) {
         $this->id = $id ?? Uuid::v7();
         $this->createdAt = new \DateTimeImmutable();
+    }
+
+    /**
+     * Mints a token from a plaintext: stores it encrypted + digested and keeps
+     * the plaintext in memory for immediate re-serving.
+     */
+    public static function issue(
+        User $user,
+        RefreshTokenEncryptor $encryptor,
+        #[\SensitiveParameter] string $plainToken,
+        \DateTimeImmutable $expiresAt,
+    ): self {
+        $token = new self($user, $encryptor->encrypt($plainToken), RefreshTokenEncryptor::digest($plainToken), $expiresAt);
+        $token->plainToken = $plainToken;
+
+        return $token;
     }
 
     public function getId(): Uuid
@@ -53,9 +83,23 @@ class RefreshToken
         return $this->user;
     }
 
-    public function getToken(): string
+    /**
+     * The stored ciphertext. Decrypt with RefreshTokenEncryptor to recover the
+     * plaintext, or read {@see getPlainToken()} on a freshly minted token.
+     */
+    public function getEncryptedToken(): string
     {
         return $this->token;
+    }
+
+    public function getTokenDigest(): string
+    {
+        return $this->tokenDigest;
+    }
+
+    public function getPlainToken(): ?string
+    {
+        return $this->plainToken;
     }
 
     public function getExpiresAt(): \DateTimeImmutable
@@ -69,12 +113,13 @@ class RefreshToken
     }
 
     /**
-     * Rotates this token: point it at its successor and cut its life to the grace
-     * window, so a reload race that re-sends it still resolves briefly (#649).
+     * Rotates this token: point it at its successor (by digest) and cut its life
+     * to the grace window, so a reload race that re-sends it still resolves
+     * briefly (#649).
      */
-    public function replaceWith(string $successorToken, \DateTimeImmutable $graceExpiresAt): void
+    public function replaceWith(string $successorDigest, \DateTimeImmutable $graceExpiresAt): void
     {
-        $this->replacedByToken = $successorToken;
+        $this->replacedByToken = $successorDigest;
         $this->expiresAt = $graceExpiresAt;
     }
 

--- a/api/src/Repository/RefreshTokenRepository.php
+++ b/api/src/Repository/RefreshTokenRepository.php
@@ -6,6 +6,7 @@ namespace App\Repository;
 
 use App\Entity\RefreshToken;
 use App\Entity\User;
+use App\Security\RefreshTokenEncryptor;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -16,33 +17,48 @@ final class RefreshTokenRepository extends ServiceEntityRepository
 {
     private const int TTL_DAYS = 30;
 
-    public function __construct(ManagerRegistry $registry)
-    {
+    public function __construct(
+        ManagerRegistry $registry,
+        private readonly RefreshTokenEncryptor $encryptor,
+    ) {
         parent::__construct($registry, RefreshToken::class);
     }
 
     /**
-     * Creates a new refresh token for the given user.
+     * Creates a new refresh token for the given user. The token is stored
+     * encrypted at rest and looked up by its digest; the plaintext is kept on
+     * the returned entity ({@see RefreshToken::getPlainToken()}) for immediate
+     * re-serving to the client.
      *
      * Persists the entity but does NOT flush — the caller is responsible for flushing.
      */
     public function createForUser(User $user): RefreshToken
     {
-        $token = bin2hex(random_bytes(64));
+        $plain = bin2hex(random_bytes(64));
         $expiresAt = new \DateTimeImmutable(\sprintf('+%d days', self::TTL_DAYS));
 
-        $refreshToken = new RefreshToken($user, $token, $expiresAt);
+        $refreshToken = RefreshToken::issue($user, $this->encryptor, $plain, $expiresAt);
         $this->getEntityManager()->persist($refreshToken);
 
         return $refreshToken;
     }
 
     /**
-     * Finds a valid (non-expired) refresh token by its token string.
+     * Finds a valid (non-expired) refresh token by its plaintext token string,
+     * matching on the stored digest.
      */
-    public function findValidByToken(string $token): ?RefreshToken
+    public function findValidByToken(#[\SensitiveParameter] string $token): ?RefreshToken
     {
-        $refreshToken = $this->findOneBy(['token' => $token]);
+        return $this->findValidByDigest(RefreshTokenEncryptor::digest($token));
+    }
+
+    /**
+     * Finds a valid (non-expired) refresh token by its digest (used to follow a
+     * rotation chain, where the predecessor stores its successor's digest).
+     */
+    public function findValidByDigest(string $digest): ?RefreshToken
+    {
+        $refreshToken = $this->findOneBy(['tokenDigest' => $digest]);
 
         if (null === $refreshToken || !$refreshToken->isValid()) {
             return null;

--- a/api/src/Security/RefreshTokenEncryptor.php
+++ b/api/src/Security/RefreshTokenEncryptor.php
@@ -19,9 +19,11 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
  *
  * Uses libsodium's authenticated `crypto_secretbox` (XSalsa20-Poly1305) with a
  * fresh random nonce per value (prepended to the ciphertext). Reuses the app's
- * token-encryption key (`AI_TOKEN_ENC_KEY`, already mandatory and fail-closed
- * at boot) rather than introducing a new mandatory prod secret; rotating that
- * key invalidates both AI tokens and refresh sessions (users simply re-login).
+ * token-encryption key (`AI_TOKEN_ENC_KEY`) rather than introducing a new
+ * mandatory prod secret; the prod entrypoint now refuses to boot when it is unset
+ * or still the committed dev default (SEC-003 fail-closed guard), so the key can
+ * never silently fall back to a public value. Rotating it invalidates both AI
+ * tokens and refresh sessions (users simply re-login).
  * Kept separate from AiTokenEncryptor so the auth subsystem does not depend on
  * the AI module.
  */

--- a/api/src/Security/RefreshTokenEncryptor.php
+++ b/api/src/Security/RefreshTokenEncryptor.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Security;
+
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * Symmetric, reversible encryption of refresh tokens at rest (SEC-003).
+ *
+ * In a passwordless system the refresh token *is* the credential (a 30-day
+ * bearer secret): storing it in clear means one database read (backup leak,
+ * replica, SQL injection, DBA/insider) yields tokens usable to forge JWTs. The
+ * token must still be recoverable — the rotation grace window re-serves the
+ * successor token loaded from the row (#649) — so a one-way hash is unusable
+ * here; the row is looked up by a deterministic `token_digest` (sha256) while
+ * the token itself is stored encrypted.
+ *
+ * Uses libsodium's authenticated `crypto_secretbox` (XSalsa20-Poly1305) with a
+ * fresh random nonce per value (prepended to the ciphertext). Reuses the app's
+ * token-encryption key (`AI_TOKEN_ENC_KEY`, already mandatory and fail-closed
+ * at boot) rather than introducing a new mandatory prod secret; rotating that
+ * key invalidates both AI tokens and refresh sessions (users simply re-login).
+ * Kept separate from AiTokenEncryptor so the auth subsystem does not depend on
+ * the AI module.
+ */
+final readonly class RefreshTokenEncryptor
+{
+    private string $key;
+
+    public function __construct(
+        #[Autowire(param: 'app.ai_token_enc_key')]
+        #[\SensitiveParameter]
+        string $key,
+    ) {
+        if ('' === $key) {
+            throw new \InvalidArgumentException('Token encryption key must not be empty.');
+        }
+
+        $this->key = sodium_crypto_generichash($key, '', \SODIUM_CRYPTO_SECRETBOX_KEYBYTES);
+    }
+
+    public function encrypt(#[\SensitiveParameter] string $plaintext): string
+    {
+        $nonce = random_bytes(\SODIUM_CRYPTO_SECRETBOX_NONCEBYTES);
+
+        return base64_encode($nonce.sodium_crypto_secretbox($plaintext, $nonce, $this->key));
+    }
+
+    /**
+     * Returns null when the blob is malformed, tampered, or encrypted under a
+     * different (rotated) key — never throws.
+     */
+    public function decrypt(string $encrypted): ?string
+    {
+        $decoded = base64_decode($encrypted, true);
+        if (false === $decoded || \strlen($decoded) < \SODIUM_CRYPTO_SECRETBOX_NONCEBYTES + \SODIUM_CRYPTO_SECRETBOX_MACBYTES) {
+            return null;
+        }
+
+        $nonce = substr($decoded, 0, \SODIUM_CRYPTO_SECRETBOX_NONCEBYTES);
+        $ciphertext = substr($decoded, \SODIUM_CRYPTO_SECRETBOX_NONCEBYTES);
+
+        $plaintext = sodium_crypto_secretbox_open($ciphertext, $nonce, $this->key);
+
+        return false === $plaintext ? null : $plaintext;
+    }
+
+    public static function digest(#[\SensitiveParameter] string $plaintext): string
+    {
+        return hash('sha256', $plaintext);
+    }
+}

--- a/api/src/State/Auth/AuthRefreshProcessor.php
+++ b/api/src/State/Auth/AuthRefreshProcessor.php
@@ -12,6 +12,7 @@ use App\Entity\RefreshToken;
 use App\Entity\User;
 use App\Repository\RefreshTokenRepository;
 use App\Security\AuthCookies;
+use App\Security\RefreshTokenEncryptor;
 use Doctrine\ORM\EntityManagerInterface;
 use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
 use Psr\Log\LoggerInterface;
@@ -45,6 +46,7 @@ final readonly class AuthRefreshProcessor implements ProcessorInterface
         private RequestStack $requestStack,
         private LoggerInterface $logger,
         private TranslatorInterface $translator,
+        private RefreshTokenEncryptor $encryptor,
     ) {
     }
 
@@ -95,12 +97,22 @@ final readonly class AuthRefreshProcessor implements ProcessorInterface
         // that clears the cookie and destroys the session (recette #649).
         $replacedBy = $existing->getReplacedByToken();
         $live = null !== $replacedBy
-            ? $this->refreshTokenRepository->findValidByToken($replacedBy)
+            ? $this->refreshTokenRepository->findValidByDigest($replacedBy)
             : $this->rotate($existing, $user);
 
         if (!$live instanceof RefreshToken) {
             // The successor itself fell out of its grace window: genuinely stale.
             $this->logger->debug('Auth refresh successor no longer valid');
+
+            return $this->unauthorized();
+        }
+
+        // Recover the plaintext to re-serve: fresh on the just-minted successor,
+        // decrypted from the stored ciphertext on the grace-window path.
+        $livePlain = $live->getPlainToken() ?? $this->encryptor->decrypt($live->getEncryptedToken());
+        if (null === $livePlain) {
+            // Ciphertext undecryptable (encryption key rotated): treat as stale.
+            $this->logger->warning('Auth refresh successor could not be decrypted');
 
             return $this->unauthorized();
         }
@@ -111,11 +123,11 @@ final readonly class AuthRefreshProcessor implements ProcessorInterface
 
         $responseData = ['token' => $jwt];
         if ($isCapacitor) {
-            $responseData['refresh_token'] = $live->getToken();
+            $responseData['refresh_token'] = $livePlain;
         }
 
         $response = new JsonResponse($responseData);
-        $this->setRefreshTokenCookie($response, $live->getToken(), $live->getExpiresAt());
+        $this->setRefreshTokenCookie($response, $livePlain, $live->getExpiresAt());
 
         return $response;
     }
@@ -140,7 +152,7 @@ final readonly class AuthRefreshProcessor implements ProcessorInterface
             $claimed = $this->entityManager->getConnection()->executeStatement(
                 'UPDATE refresh_token SET replaced_by_token = :new, expires_at = :grace WHERE id = :id AND replaced_by_token IS NULL AND expires_at > NOW()',
                 [
-                    'new' => $successor->getToken(),
+                    'new' => $successor->getTokenDigest(),
                     'grace' => $grace->format('Y-m-d H:i:s'),
                     'id' => $existing->getId()->toRfc4122(),
                 ],
@@ -150,7 +162,7 @@ final readonly class AuthRefreshProcessor implements ProcessorInterface
                 // Won: mirror the claim onto the managed entity so the successor is
                 // flushed and the mapped property is assigned in PHP (PHPStan can't
                 // see Doctrine's hydration of replaced_by_token).
-                $existing->replaceWith($successor->getToken(), $grace);
+                $existing->replaceWith($successor->getTokenDigest(), $grace);
             } else {
                 // Lost: drop the pending successor so the flush can't INSERT it.
                 $this->entityManager->detach($successor);
@@ -165,7 +177,7 @@ final readonly class AuthRefreshProcessor implements ProcessorInterface
         $this->entityManager->refresh($existing);
         $replacedBy = $existing->getReplacedByToken();
 
-        return null !== $replacedBy ? $this->refreshTokenRepository->findValidByToken($replacedBy) : null;
+        return null !== $replacedBy ? $this->refreshTokenRepository->findValidByDigest($replacedBy) : null;
     }
 
     private function unauthorized(): JsonResponse

--- a/api/src/State/Auth/AuthVerifyProcessor.php
+++ b/api/src/State/Auth/AuthVerifyProcessor.php
@@ -82,15 +82,19 @@ final readonly class AuthVerifyProcessor implements ProcessorInterface
 
         $isCapacitor = $this->isCapacitorRequest();
 
+        // Plaintext is available on the freshly minted token (stored encrypted).
+        $plainToken = $refreshToken->getPlainToken();
+        \assert(null !== $plainToken);
+
         $this->logger->debug('Auth verify token verified', ['user' => $user->getEmail()]);
 
         $responseData = ['token' => $jwt];
         if ($isCapacitor) {
-            $responseData['refresh_token'] = $refreshToken->getToken();
+            $responseData['refresh_token'] = $plainToken;
         }
 
         $response = new JsonResponse($responseData);
-        $this->setRefreshTokenCookie($response, $refreshToken->getToken(), $refreshToken->getExpiresAt());
+        $this->setRefreshTokenCookie($response, $plainToken, $refreshToken->getExpiresAt());
 
         return $response;
     }

--- a/api/tests/Functional/Account/AccountDeleteTest.php
+++ b/api/tests/Functional/Account/AccountDeleteTest.php
@@ -13,6 +13,7 @@ use App\Entity\User;
 use App\Repository\AccessRequestRepository;
 use App\Repository\MagicLinkRepository;
 use App\Repository\RefreshTokenRepository;
+use App\Security\RefreshTokenEncryptor;
 use Doctrine\ORM\EntityManagerInterface;
 use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
 use PHPUnit\Framework\Attributes\Test;
@@ -48,8 +49,9 @@ final class AccountDeleteTest extends ApiTestCase
         $user = new User($email);
         $em->persist($user);
 
-        $refreshToken = new RefreshToken(
+        $refreshToken = RefreshToken::issue(
             $user,
+            self::getContainer()->get(RefreshTokenEncryptor::class),
             bin2hex(random_bytes(32)),
             new \DateTimeImmutable('+30 days'),
         );

--- a/api/tests/Functional/Auth/AuthLogoutTest.php
+++ b/api/tests/Functional/Auth/AuthLogoutTest.php
@@ -8,6 +8,7 @@ use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
 use App\Entity\RefreshToken;
 use App\Entity\User;
 use App\Repository\RefreshTokenRepository;
+use App\Security\RefreshTokenEncryptor;
 use Doctrine\ORM\EntityManagerInterface;
 use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
 use PHPUnit\Framework\Attributes\Test;
@@ -36,8 +37,9 @@ final class AuthLogoutTest extends ApiTestCase
         $user = new User($email);
         $em->persist($user);
 
-        $refreshToken = new RefreshToken(
+        $refreshToken = RefreshToken::issue(
             $user,
+            self::getContainer()->get(RefreshTokenEncryptor::class),
             bin2hex(random_bytes(32)),
             new \DateTimeImmutable('+30 days'),
         );

--- a/api/tests/Functional/Auth/AuthRefreshTest.php
+++ b/api/tests/Functional/Auth/AuthRefreshTest.php
@@ -87,6 +87,44 @@ final class AuthRefreshTest extends ApiTestCase
     }
 
     #[Test]
+    public function refreshFailsClosedWhenSuccessorCiphertextIsUndecryptable(): void
+    {
+        // Grace-window path (SEC-003): the successor loaded from the DB must be
+        // decrypted to be re-served. If it was encrypted under a since-rotated key,
+        // decrypt() returns null and the request must fail closed (401), never 500
+        // or a garbage token.
+        $em = $this->getEntityManager();
+        $user = new User('rotated-key@example.com');
+        $em->persist($user);
+
+        $grace = new \DateTimeImmutable('+20 seconds');
+        // Successor ciphertext under a different key → undecryptable by the app key.
+        $successor = RefreshToken::issue(
+            $user,
+            new RefreshTokenEncryptor('a-since-rotated-key'),
+            'successor-plain',
+            $grace,
+        );
+        $em->persist($successor);
+
+        // Predecessor still in its grace window, pointing at the successor's digest.
+        $predecessor = RefreshToken::issue(
+            $user,
+            self::getContainer()->get(RefreshTokenEncryptor::class),
+            'predecessor-plain',
+            $grace,
+        );
+        $predecessor->replaceWith(RefreshTokenEncryptor::digest('successor-plain'), $grace);
+        $em->persist($predecessor);
+        $em->flush();
+        $em->clear();
+
+        $this->sendRefreshRequest('predecessor-plain');
+
+        $this->assertResponseStatusCodeSame(401);
+    }
+
+    #[Test]
     public function refreshWithValidTokenReturnsNewJwt(): void
     {
         $this->createUserWithRefreshToken('alice@example.com', 'alice-refresh-token');

--- a/api/tests/Functional/Auth/AuthRefreshTest.php
+++ b/api/tests/Functional/Auth/AuthRefreshTest.php
@@ -95,26 +95,17 @@ final class AuthRefreshTest extends ApiTestCase
         // or a garbage token.
         $em = $this->getEntityManager();
         $user = new User('rotated-key@example.com');
-        $em->persist($user);
-
         $grace = new \DateTimeImmutable('+20 seconds');
-        // Successor ciphertext under a different key → undecryptable by the app key.
-        $successor = RefreshToken::issue(
-            $user,
-            new RefreshTokenEncryptor('a-since-rotated-key'),
-            'successor-plain',
-            $grace,
-        );
-        $em->persist($successor);
+
+        // Successor ciphertext under a since-rotated key → undecryptable by the app key.
+        $successor = RefreshToken::issue($user, new RefreshTokenEncryptor('a-since-rotated-key'), 'successor-plain', $grace);
 
         // Predecessor still in its grace window, pointing at the successor's digest.
-        $predecessor = RefreshToken::issue(
-            $user,
-            self::getContainer()->get(RefreshTokenEncryptor::class),
-            'predecessor-plain',
-            $grace,
-        );
+        $predecessor = RefreshToken::issue($user, self::getContainer()->get(RefreshTokenEncryptor::class), 'predecessor-plain', $grace);
         $predecessor->replaceWith(RefreshTokenEncryptor::digest('successor-plain'), $grace);
+
+        $em->persist($user);
+        $em->persist($successor);
         $em->persist($predecessor);
         $em->flush();
         $em->clear();

--- a/api/tests/Functional/Auth/AuthRefreshTest.php
+++ b/api/tests/Functional/Auth/AuthRefreshTest.php
@@ -8,6 +8,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
 use App\Entity\RefreshToken;
 use App\Entity\User;
+use App\Security\RefreshTokenEncryptor;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\Attributes\Test;
 use Zenstruck\Foundry\Attribute\ResetDatabase;
@@ -38,8 +39,9 @@ final class AuthRefreshTest extends ApiTestCase
         $user = new User($email);
         $em->persist($user);
 
-        $refreshToken = new RefreshToken(
+        $refreshToken = RefreshToken::issue(
             $user,
+            self::getContainer()->get(RefreshTokenEncryptor::class),
             $token,
             $expiresAt ?? new \DateTimeImmutable('+30 days'),
         );
@@ -62,6 +64,25 @@ final class AuthRefreshTest extends ApiTestCase
             ],
             'json' => ['refresh_token' => $refreshToken],
         ]);
+    }
+
+    #[Test]
+    public function storesTheTokenEncryptedAtRest(): void
+    {
+        // SEC-003: the row must not hold the plaintext credential; it stores a
+        // reversible ciphertext, looked up by digest.
+        $this->createUserWithRefreshToken('atrest@example.com', 'plaintext-at-rest');
+
+        $em = $this->getEntityManager();
+        $em->clear();
+        $stored = $em->getRepository(RefreshToken::class)->findOneBy([
+            'tokenDigest' => RefreshTokenEncryptor::digest('plaintext-at-rest'),
+        ]);
+        $this->assertNotNull($stored);
+        $this->assertNotSame('plaintext-at-rest', $stored->getEncryptedToken());
+
+        $encryptor = self::getContainer()->get(RefreshTokenEncryptor::class);
+        $this->assertSame('plaintext-at-rest', $encryptor->decrypt($stored->getEncryptedToken()));
     }
 
     #[Test]
@@ -153,7 +174,9 @@ final class AuthRefreshTest extends ApiTestCase
         $em = $this->getEntityManager();
         $em->clear();
 
-        $old = $em->getRepository(RefreshToken::class)->findOneBy(['token' => 'rotated-token']);
+        $old = $em->getRepository(RefreshToken::class)->findOneBy([
+            'tokenDigest' => RefreshTokenEncryptor::digest('rotated-token'),
+        ]);
 
         $this->assertNotNull($old, 'Rotated token is kept for reload-race idempotency');
         $this->assertNotNull($old->getReplacedByToken(), 'Rotated token points at its successor');

--- a/api/tests/Functional/Auth/AuthRefreshTest.php
+++ b/api/tests/Functional/Auth/AuthRefreshTest.php
@@ -75,6 +75,7 @@ final class AuthRefreshTest extends ApiTestCase
 
         $em = $this->getEntityManager();
         $em->clear();
+
         $stored = $em->getRepository(RefreshToken::class)->findOneBy([
             'tokenDigest' => RefreshTokenEncryptor::digest('plaintext-at-rest'),
         ]);

--- a/api/tests/Functional/Auth/AuthSessionTest.php
+++ b/api/tests/Functional/Auth/AuthSessionTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Functional\Auth;
 use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
 use App\Entity\RefreshToken;
 use App\Entity\User;
+use App\Security\RefreshTokenEncryptor;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\BrowserKit\Cookie as BrowserKitCookie;
@@ -46,8 +47,9 @@ final class AuthSessionTest extends ApiTestCase
         $user = new User($email);
         $em->persist($user);
 
-        $refreshToken = new RefreshToken(
+        $refreshToken = RefreshToken::issue(
             $user,
+            self::getContainer()->get(RefreshTokenEncryptor::class),
             $token,
             $expiresAt ?? new \DateTimeImmutable('+30 days'),
         );
@@ -152,7 +154,9 @@ final class AuthSessionTest extends ApiTestCase
         $em = $this->getEntityManager();
         $em->clear();
 
-        $token = $em->getRepository(RefreshToken::class)->findOneBy(['token' => 'idempotent-token']);
+        $token = $em->getRepository(RefreshToken::class)->findOneBy([
+            'tokenDigest' => RefreshTokenEncryptor::digest('idempotent-token'),
+        ]);
         $this->assertNotNull($token);
         $this->assertNull($token->getReplacedByToken(), 'session must not rotate the token');
     }

--- a/api/tests/Functional/Auth/PurgeExpiredTokensCommandTest.php
+++ b/api/tests/Functional/Auth/PurgeExpiredTokensCommandTest.php
@@ -8,6 +8,7 @@ use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
 use App\Entity\RefreshToken;
 use App\Entity\User;
 use App\Repository\RefreshTokenRepository;
+use App\Security\RefreshTokenEncryptor;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
@@ -24,6 +25,11 @@ final class PurgeExpiredTokensCommandTest extends ApiTestCase
     private function getEntityManager(): EntityManagerInterface
     {
         return self::getContainer()->get('doctrine.orm.entity_manager');
+    }
+
+    private function refreshToken(User $user, string $plain, \DateTimeImmutable $expiresAt): RefreshToken
+    {
+        return RefreshToken::issue($user, self::getContainer()->get(RefreshTokenEncryptor::class), $plain, $expiresAt);
     }
 
     private function createCommandTester(): CommandTester
@@ -43,11 +49,7 @@ final class PurgeExpiredTokensCommandTest extends ApiTestCase
         $user = new User('purge@example.com');
         $em->persist($user);
 
-        $expiredToken = new RefreshToken(
-            $user,
-            'expired-token-abc',
-            new \DateTimeImmutable('-1 day'),
-        );
+        $expiredToken = $this->refreshToken($user, 'expired-token-abc', new \DateTimeImmutable('-1 day'));
         $em->persist($expiredToken);
         $em->flush();
 
@@ -71,11 +73,7 @@ final class PurgeExpiredTokensCommandTest extends ApiTestCase
         $user = new User('keep@example.com');
         $em->persist($user);
 
-        $validToken = new RefreshToken(
-            $user,
-            'valid-token-xyz',
-            new \DateTimeImmutable('+30 days'),
-        );
+        $validToken = $this->refreshToken($user, 'valid-token-xyz', new \DateTimeImmutable('+30 days'));
         $em->persist($validToken);
         $em->flush();
 
@@ -99,18 +97,10 @@ final class PurgeExpiredTokensCommandTest extends ApiTestCase
         $user = new User('mixed@example.com');
         $em->persist($user);
 
-        $expiredToken = new RefreshToken(
-            $user,
-            'expired-one',
-            new \DateTimeImmutable('-2 days'),
-        );
+        $expiredToken = $this->refreshToken($user, 'expired-one', new \DateTimeImmutable('-2 days'));
         $em->persist($expiredToken);
 
-        $validToken = new RefreshToken(
-            $user,
-            'still-valid',
-            new \DateTimeImmutable('+15 days'),
-        );
+        $validToken = $this->refreshToken($user, 'still-valid', new \DateTimeImmutable('+15 days'));
         $em->persist($validToken);
         $em->flush();
 
@@ -124,7 +114,10 @@ final class PurgeExpiredTokensCommandTest extends ApiTestCase
         $repo = self::getContainer()->get(RefreshTokenRepository::class);
         $remaining = $repo->findAll();
         $this->assertCount(1, $remaining);
-        $this->assertSame('still-valid', $remaining[0]->getToken());
+        $this->assertSame(
+            RefreshTokenEncryptor::digest('still-valid'),
+            $remaining[0]->getTokenDigest(),
+        );
     }
 
     #[Test]
@@ -148,18 +141,10 @@ final class PurgeExpiredTokensCommandTest extends ApiTestCase
         $user2 = new User('user2@example.com');
         $em->persist($user2);
 
-        $expired1 = new RefreshToken(
-            $user1,
-            'expired-user1',
-            new \DateTimeImmutable('-3 days'),
-        );
+        $expired1 = $this->refreshToken($user1, 'expired-user1', new \DateTimeImmutable('-3 days'));
         $em->persist($expired1);
 
-        $expired2 = new RefreshToken(
-            $user2,
-            'expired-user2',
-            new \DateTimeImmutable('-1 day'),
-        );
+        $expired2 = $this->refreshToken($user2, 'expired-user2', new \DateTimeImmutable('-1 day'));
         $em->persist($expired2);
         $em->flush();
 

--- a/api/tests/Unit/Security/RefreshTokenEncryptorTest.php
+++ b/api/tests/Unit/Security/RefreshTokenEncryptorTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Security;
+
+use App\Security\RefreshTokenEncryptor;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class RefreshTokenEncryptorTest extends TestCase
+{
+    #[Test]
+    public function encryptsAndDecryptsRoundTrip(): void
+    {
+        $encryptor = new RefreshTokenEncryptor('a-secret-key');
+
+        $cipher = $encryptor->encrypt('refresh-token-plaintext');
+
+        self::assertNotSame('refresh-token-plaintext', $cipher, 'the token is not stored in clear');
+        self::assertSame('refresh-token-plaintext', $encryptor->decrypt($cipher));
+    }
+
+    #[Test]
+    public function producesADifferentCiphertextEachTime(): void
+    {
+        // Random nonce per call: same input must not yield the same blob.
+        $encryptor = new RefreshTokenEncryptor('a-secret-key');
+
+        self::assertNotSame($encryptor->encrypt('token'), $encryptor->encrypt('token'));
+    }
+
+    #[Test]
+    public function returnsNullForAMalformedBlob(): void
+    {
+        $encryptor = new RefreshTokenEncryptor('a-secret-key');
+
+        self::assertNull($encryptor->decrypt('not-base64-or-too-short'));
+        self::assertNull($encryptor->decrypt(''));
+    }
+
+    #[Test]
+    public function returnsNullWhenDecryptingUnderADifferentKey(): void
+    {
+        // Key rotation: previously stored tokens become undecryptable (by design).
+        $cipher = new RefreshTokenEncryptor('original-key')->encrypt('token');
+
+        self::assertNull(new RefreshTokenEncryptor('rotated-key')->decrypt($cipher));
+    }
+
+    #[Test]
+    public function rejectsAnEmptyKey(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        new RefreshTokenEncryptor('');
+    }
+
+    #[Test]
+    public function digestIsDeterministicAndDoesNotRevealThePlaintext(): void
+    {
+        self::assertSame(
+            RefreshTokenEncryptor::digest('token'),
+            RefreshTokenEncryptor::digest('token'),
+        );
+        self::assertNotSame('token', RefreshTokenEncryptor::digest('token'));
+        self::assertMatchesRegularExpression('/^[0-9a-f]{64}$/', RefreshTokenEncryptor::digest('token'));
+    }
+}

--- a/compose.recette.yaml
+++ b/compose.recette.yaml
@@ -34,6 +34,9 @@ x-recette-env: &recette-env
   MERCURE_PUBLISHER_JWT_KEY: recette-mercure-jwt-secret
   MERCURE_SUBSCRIBER_JWT_KEY: recette-mercure-jwt-secret
   MERCURE_JWT_SECRET: recette-mercure-jwt-secret
+  # Non-default token-encryption key so the SEC-003 fail-closed boot guard passes
+  # locally (encrypts AI provider tokens + refresh tokens at rest).
+  AI_TOKEN_ENC_KEY: recette-ai-token-enc-key
 
 services:
   php:

--- a/compose.yaml
+++ b/compose.yaml
@@ -55,6 +55,10 @@ services:
       MERCURE_URL: ${MERCURE_URL:-http://php/.well-known/mercure}
       MERCURE_PUBLIC_URL: ${MERCURE_PUBLIC_URL:-https://${SERVER_NAME:-localhost}/.well-known/mercure}
       MERCURE_JWT_SECRET: "${MERCURE_JWT_KEY:-!ChangeThisMercureHubJWTSecretKey!}"
+      # Encrypts AI provider tokens + refresh tokens at rest. Forwarded from the
+      # Coolify/host env (like MERCURE_JWT_KEY); empty here so the SEC-003 boot
+      # guard fails closed rather than silently using the committed dev default.
+      AI_TOKEN_ENC_KEY: "${AI_TOKEN_ENC_KEY:-}"
       MESSENGER_TRANSPORT_DSN: redis://redis:6379/messages
       MESSENGER_FAILED_DSN: redis://redis:6379/failed
       REDIS_URL: redis://redis:6379
@@ -144,6 +148,10 @@ services:
       MERCURE_URL: ${MERCURE_URL:-http://php/.well-known/mercure}
       MERCURE_PUBLIC_URL: ${MERCURE_PUBLIC_URL:-https://${SERVER_NAME:-localhost}/.well-known/mercure}
       MERCURE_JWT_SECRET: "${MERCURE_JWT_KEY:-!ChangeThisMercureHubJWTSecretKey!}"
+      # Encrypts AI provider tokens + refresh tokens at rest. Forwarded from the
+      # Coolify/host env (like MERCURE_JWT_KEY); empty here so the SEC-003 boot
+      # guard fails closed rather than silently using the committed dev default.
+      AI_TOKEN_ENC_KEY: "${AI_TOKEN_ENC_KEY:-}"
       MESSENGER_TRANSPORT_DSN: redis://redis:6379/messages
       MESSENGER_FAILED_DSN: redis://redis:6379/failed
       REDIS_URL: redis://redis:6379
@@ -219,6 +227,10 @@ services:
       MERCURE_URL: ${MERCURE_URL:-http://php/.well-known/mercure}
       MERCURE_PUBLIC_URL: ${MERCURE_PUBLIC_URL:-https://${SERVER_NAME:-localhost}/.well-known/mercure}
       MERCURE_JWT_SECRET: "${MERCURE_JWT_KEY:-!ChangeThisMercureHubJWTSecretKey!}"
+      # Encrypts AI provider tokens + refresh tokens at rest. Forwarded from the
+      # Coolify/host env (like MERCURE_JWT_KEY); empty here so the SEC-003 boot
+      # guard fails closed rather than silently using the committed dev default.
+      AI_TOKEN_ENC_KEY: "${AI_TOKEN_ENC_KEY:-}"
       MESSENGER_TRANSPORT_DSN: redis://redis:6379/messages
       MESSENGER_FAILED_DSN: redis://redis:6379/failed
       REDIS_URL: redis://redis:6379

--- a/docs/adr/adr-023-authentication-strategy.md
+++ b/docs/adr/adr-023-authentication-strategy.md
@@ -161,17 +161,21 @@ Full OAuth2 authorization server (e.g., league/oauth2-server-bundle).
 |---|---|---|---|
 | **Magic link token** | PostgreSQL (`magic_link` table), **SHA-256 hashed at rest** | 30 min, single use | One-time authentication |
 | **Access token (JWT)** | In-memory (JavaScript variable) | 15 min | API request authorization |
-| **Refresh token** | HttpOnly SameSite=Strict cookie; row in `refresh_token` (see note) | 30 days | Silent access token renewal |
+| **Refresh token** | HttpOnly SameSite=Strict cookie; row in `refresh_token`, **encrypted at rest** (see note) | 30 days | Silent access token renewal |
 
 > **Token-at-rest hardening (2026-07 security audit — token-at-rest finding; distinct from the audit-report.md `SEC-003` clickjacking item already fixed in #630).** The magic-link and email-change tokens are
 > high-entropy random values that ARE the credential, so only their **SHA-256 hash**
 > is persisted (the plaintext travels in the link and is hashed on verify). This
 > supersedes an earlier draft of this ADR that described the column as `token (hashed)`
-> without the code implementing it. **The refresh token is still stored in plaintext**:
-> the grace-window rotation (recette #649) must re-serve the successor token value on a
-> reload race, which a one-way hash makes impossible; protecting it at rest requires an
-> encrypt-at-rest scheme (reversible, à la `AiTokenEncryptor`) and is tracked as a
-> dedicated follow-up.
+> without the code implementing it.
+>
+> The refresh token is **encrypted at rest** rather than hashed: the grace-window
+> rotation (recette #649) must re-serve the successor token value on a reload race,
+> which a one-way hash makes impossible. The `token` column holds a reversible
+> libsodium ciphertext (`RefreshTokenEncryptor`, reusing the app's `AI_TOKEN_ENC_KEY`)
+> and rows are looked up by a deterministic `token_digest` (SHA-256) — so a database
+> read yields neither a usable token nor its plaintext. Rotating the encryption key
+> invalidates stored refresh tokens (users transparently re-login).
 
 ### Uniform Response Policy
 

--- a/docs/runbooks/secrets-inventory.md
+++ b/docs/runbooks/secrets-inventory.md
@@ -20,6 +20,7 @@ Pour la rotation : voir [secrets-rotation.md](secrets-rotation.md).
 | `JWT_PUBLIC_KEY_PATH` (PEM) | PEM RSA | Fichier monté `/etc/bike-trip-planner/jwt/public.pem` (VM) | `php`, `worker` (LexikJWT) | Oui | On-compromise (avec la clé privée) | ADR-023 |
 | `JWT_PASSPHRASE` | Passphrase | Coolify env | `php`, `worker` | Oui | On-compromise (avec la clé privée) | ADR-023 |
 | `MERCURE_JWT_KEY` | Passphrase HS256 | Coolify env | `php` (publisher + subscriber + Mercure hub) | Oui | On-compromise | `compose.yaml` |
+| `AI_TOKEN_ENC_KEY` | Clé de chiffrement (libsodium) | Coolify env | `php`, `worker`, `worker-llm` | Oui | On-compromise (invalide tokens IA + sessions refresh → re-login) | ADR-042 / SEC-003 |
 | `DATABASE_USERNAME` | Identifiant Postgres | Coolify env | `php`, `worker`, `database` | Oui | Statique | ADR-022 |
 | `DATABASE_PASSWORD` | Password Postgres | Coolify env | `php`, `worker`, `database` | Oui | Bi-annuel + on-compromise | ADR-022 |
 | `DATABASE_NAME` | Nom de base | Coolify env | `php`, `worker`, `database` | Oui | Statique | ADR-022 |


### PR DESCRIPTION
## Contexte

Audit 2026-07 — **SEC-003** (dernier volet). Dans un système sans mot de passe, le refresh token **est** le credential (bearer 30 jours). Il était persisté et cherché en clair (`WHERE token = :token`) : une seule lecture de la base (fuite de backup, réplica, injection SQL, DBA/insider) livrait des tokens exploitables pour forger des JWT pendant un mois.

Les tokens magic-link et email-change ont déjà été **hachés** au repos (#816). Le refresh token ne peut pas l'être : la **fenêtre de grâce de rotation** (#649) doit **re-servir la valeur du token successeur** chargée depuis la ligne lors d'une course au reload, ce qu'un hash unidirectionnel rend impossible.

## Correctif

Chiffrement **réversible** au repos + lookup déterministe par digest :

- **`RefreshTokenEncryptor`** (libsodium `crypto_secretbox`, calqué sur `AiTokenEncryptor`) — réutilise la clé applicative `AI_TOKEN_ENC_KEY` (déjà obligatoire + fail-closed au boot) → **aucun nouveau secret prod**. Rotation de clé = invalidation des sessions (re-login transparent).
- **`RefreshToken`** : colonne `token` → ciphertext (`TEXT`), nouvelle colonne `token_digest` (`sha256`, unique, indexée) pour le `WHERE`, `replaced_by_token` → **digest** du successeur, `plainToken` transient (jamais persisté) pour re-servir sans déchiffrer sur le chemin frais. Fabrique `RefreshToken::issue()` partagée par le repository et les tests.
- **`AuthRefreshProcessor` / `AuthVerifyProcessor`** : re-serve le plaintext via `plainToken` (frais) ou `decrypt()` (chemin grâce) ; résolution du successeur par `findValidByDigest()`.
- **Migration** `Version20260704120000` : purge les lignes plaintext (incompatibles) — les sessions actives se ré-authentifient via refresh/magic-link.

## Vérification

- Un `SELECT token FROM refresh_token` ne contient plus ni token utilisable ni son plaintext (nouveau test `AuthRefreshTest::storesTheTokenEncryptedAtRest`).
- `RefreshTokenEncryptorTest` (roundtrip / nonce / tamper / rotation clé / digest).
- Tests d'auth existants (refresh, grace-window, rotation, session, logout, purge, account-delete) adaptés au nouveau stockage et conservés verts.
- ADR-023 mis à jour (supersede la note « plaintext, follow-up »).

Isolé du sous-système IA (classe dédiée) pour limiter le blast radius côté auth.

<!-- claude-review-start -->
## Claude Review

**Summary:** Re-review of the current head commit (unchanged since the last review pass). `RefreshTokenEncryptor` correctly mirrors `AiTokenEncryptor`'s libsodium `crypto_secretbox` pattern with a random nonce per value, `token_digest` (SHA-256) keeps the lookup on an indexed column without ever storing the plaintext, and the migration purges incompatible plaintext rows as documented. Both previously-blocking issues (the non-enforced `AI_TOKEN_ENC_KEY` fail-closed guard, and the `compose.yaml` env-forwarding regression that would have crash-looped `php`/`worker`/`worker-llm`) remain fixed. No new blocking findings. Same two non-blocking items as before remain open by design: the `RefreshToken::issue()` ↔ `RefreshTokenEncryptor` coupling (author's rationale accepted) and the `TRACKING.md` gap.

**PR title check:** OK — `fix(auth): encrypt refresh tokens at rest + look up by digest (SEC-003)` follows Conventional Commits.

**Review checklist:**
- [ ] Code respects the project architecture — `RefreshToken::issue()` still couples the entity to `RefreshTokenEncryptor` (open thread, non-blocking; author has responded with rationale, left as-is)
- [x] SOLID principles and Law of Demeter followed — acceptable per author's rationale (pure, I/O-free domain service)
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases — decrypt-failure branch (key-rotation grace path) covered by `refreshFailsClosedWhenSuccessorCiphertextIsUndecryptable`; encrypt-at-rest covered by `storesTheTokenEncryptedAtRest`; `RefreshTokenEncryptorTest` covers roundtrip/tamper/rotation/digest
- [ ] Documentation is up to date — ADR-023 and the secrets inventory are correctly updated; `TRACKING.md` still has no entry for this 2026-07 audit chain (#816, #823), unlike every other tracked security fix in the file
- [x] Dependent tickets accounted for

**Commit reviewed:** a443f8bf332273b7a6ba5aac64997b003cf407ab

**Inline comments:** No inline comments.
<!-- claude-review-end -->