### PR TITLE
chore(docker): drop orphaned COMMIT_SHA plumbing + base-image CVE cadence (SUP-002, #820)

### DIFF
--- a/.docker/php/Dockerfile
+++ b/.docker/php/Dockerfile
@@ -79,9 +79,7 @@ CMD [ "frankenphp", "run", "--config", "/etc/frankenphp/Caddyfile", "--watch" ]
 # Prod FrankenPHP image
 FROM frankenphp_base AS frankenphp_prod
 
-ARG COMMIT_SHA=unknown
 ENV APP_ENV=prod
-ENV APP_COMMIT=${COMMIT_SHA}
 # Default to running Doctrine migrations at boot in prod (see ADR-032).
 ENV MIGRATIONS_ON_BOOT=true
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,7 +83,6 @@ jobs:
           push: true
           tags: ${{ steps.tags.outputs.tags }}
           build-args: |
-            COMMIT_SHA=${{ github.sha }}
             NEXT_PUBLIC_APP_RELEASE=${{ github.sha }}
             NEXT_PUBLIC_APP_ENV=production
             NEXT_PUBLIC_SENTRY_DSN=${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}

--- a/compose.yaml
+++ b/compose.yaml
@@ -19,8 +19,6 @@ services:
       context: ./
       dockerfile: .docker/php/Dockerfile
       target: frankenphp_prod
-      args:
-        COMMIT_SHA: ${COMMIT_SHA:-unknown}
     restart: unless-stopped
     read_only: true
     tmpfs:
@@ -71,11 +69,6 @@ services:
       # Error tracking (P1.1 / ADR-031). Leave SENTRY_DSN empty to disable.
       SENTRY_DSN: "${SENTRY_DSN:-}"
       APP_RELEASE: "${APP_RELEASE:-}"
-      # APP_COMMIT is baked into the image at build time (ARG COMMIT_SHA →
-      # ENV APP_COMMIT in .docker/php/Dockerfile). Do NOT set it here: a compose
-      # `environment:` entry overrides the image ENV, and COMMIT_SHA is a CI
-      # build-time concept absent from the Coolify runtime, so it would collapse
-      # to "unknown" and /api/healthz would lose the deployed git SHA.
       # Doctrine migrations executed at container boot via entrypoint.sh (ADR-032).
       # Set to "false" if a migration is suspected to be problematic — then run migrations manually.
       MIGRATIONS_ON_BOOT: "${MIGRATIONS_ON_BOOT:-true}"

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -30,6 +30,7 @@ Every runbook follows the same four sections:
 | [uptime-monitoring.md](uptime-monitoring.md) | Uptime Kuma + UptimeRobot configuration |
 | [secrets-inventory.md](secrets-inventory.md) | Source of truth for every production secret |
 | [secrets-rotation.md](secrets-rotation.md) | Rotation policy + per-class procedures |
+| [base-image-cve-maintenance.md](base-image-cve-maintenance.md) | Base-image CVE refresh cadence (triage `fixed` vs Debian won't-fix) |
 
 ## Conventions
 

--- a/docs/runbooks/base-image-cve-maintenance.md
+++ b/docs/runbooks/base-image-cve-maintenance.md
@@ -1,0 +1,52 @@
+# Base Image CVE Maintenance
+
+Recurring maintenance for the OS-level CVE volume reported by Trivy on the Docker
+images (SUP-002, 2026-07 security audit). This is a **cadence**, not an incident
+response: base images are pinned by digest (reproducible builds) which also freezes
+their OS CVEs until the digest is bumped.
+
+## Symptômes (when to use)
+
+- Scheduled base-image refresh (recommended monthly, or on a published CVE with a
+  fix that affects a package we actually use).
+- Trivy / Dependabot flags a HIGH/CRITICAL on the `php`, `pwa`, or `provisioner`
+  image.
+
+## Diagnostic
+
+```bash
+# Scan the built images (same as the audit).
+trivy image --severity HIGH,CRITICAL bike-trip-planner-php
+trivy image --severity HIGH,CRITICAL bike-trip-planner-provisioner
+```
+
+**Read the `Status` column, not the raw count.** The bulk of the volume on the
+Debian Bookworm bases (`perl`, `python3.x`, `zlib1g`, `curl`, `libssh2`, `acl`,
+`linux-libc-dev`, ...) is `will_not_fix` / `fix_deferred` / `affected` — no
+upstream patch exists, so a rebuild cannot clear them. The **actionable** subset is
+only the rows with `Status: fixed`. Triage those; ignore the won't-fix noise.
+
+## Procédure
+
+1. Bump the digest of the affected base to the latest published for its tag:
+   - `.docker/php/Dockerfile` — `dunglas/frankenphp:1-php8.5@sha256:...`
+   - `.docker/pwa/Dockerfile` — `node:26@sha256:...`
+   - `.docker/provisioner/Dockerfile` — `php:8.5-cli-bookworm` (tag-pinned; pin a
+     digest here too if reproducibility is needed).
+
+   ```bash
+   docker pull dunglas/frankenphp:1-php8.5
+   docker inspect --format='{{index .RepoDigests 0}}' dunglas/frankenphp:1-php8.5
+   ```
+
+2. Rebuild and re-scan (`make build` + the Trivy commands above); confirm the
+   `fixed`-status rows dropped.
+3. Run the full suite (`make test`) — a base bump can shift a system library.
+
+## Post-action
+
+- The `osmium-tool` decision keeps the provisioner on Bookworm (no Alpine
+  migration — osmium has no prebuilt Alpine binary). Distroless is only viable for
+  stages that don't need osmium/osm2pgsql.
+- Note in the PR which `fixed` CVEs were actually cleared vs. the won't-fix volume
+  that remains by design.


### PR DESCRIPTION
## Contexte

Reliquats de l'audit 2026-07 : nettoyage **#820** (config `COMMIT_SHA` orpheline) + **SUP-002** (cadence CVE images de base). Statut **SUP-001** clarifié.

## #820 — plumbing `COMMIT_SHA` / `APP_COMMIT` orphelin

SEC-011 (#820) a retiré le SHA de commit de la réponse publique `/api/health`. Résultat : `APP_COMMIT` n'était plus lu par personne (Sentry utilise `APP_RELEASE`, distinct). Suppression du plumbing mort :

- `.docker/php/Dockerfile` : `ARG COMMIT_SHA` + `ENV APP_COMMIT`.
- `compose.yaml` : build arg `COMMIT_SHA` + son commentaire.
- `.github/workflows/deploy.yml` : `COMMIT_SHA=${{ github.sha }}`.

`APP_RELEASE` (release Sentry) intact.

## SUP-002 — cadence CVE images de base (LOW, opérationnel)

Nouveau runbook `docs/runbooks/base-image-cve-maintenance.md` : procédure de bump des digests + **triage** (agir sur les lignes `Status: fixed` ; le gros du volume Debian Bookworm est `will_not_fix` et ne peut pas être purgé par un rebuild). Référence la décision osmium-tool (Bookworm conservé).

## SUP-001 — undici CVE-2026-12151 : déjà mitigé

L'artefact Trivy de l'audit indique : installé `6.26.0`, corrigé en `6.27.0 / 7.28.0 / 8.5.0`. Le `overrides` de `pwa/package.json` épingle déjà undici au **plancher corrigé** (`^6.27.0` pour les transitifs, `^7.28.0` sous jsdom) et le lock actuel résout 6.27.0 / 7.28.0 — **aucun undici < 6.27.0**. Rien à bumper (un passage à 8.x casserait les consommateurs undici 6.x). Pas de changement de dépendance dans cette PR.

## Vérification

- `grep -rn "COMMIT_SHA\|APP_COMMIT"` sur `.docker`/`compose.yaml`/`deploy.yml` → vide.
- Lock : aucun `undici < 6.27.0`.

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 findings (0 critical, 0 warning). Clean dead-code removal + docs-only PR — verified `COMMIT_SHA`/`APP_COMMIT` have zero remaining readers anywhere in the repo (Dockerfile, compose.yaml, deploy.yml, docs), and that the SUP-001 undici claim holds against the actual lockfile (no `undici < 6.27.0` resolved).

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases (no behavior change; no test gap)
- [x] Documentation is up to date (new runbook added + linked from `docs/runbooks/README.md`)
- [x] Dependent tickets accounted for (#820, SUP-001, SUP-002)

**Inline comments:** No inline comments.

**Commit reviewed:** c297bcf8027dfb7a13a44d9115fc8d32acb40090
<!-- claude-review-end -->