### PR TITLE
test(gpx): cover gpx_upload rate-limit via a service interface (SEC-006)

### DIFF
--- a/api/src/Controller/GpxUploadController.php
+++ b/api/src/Controller/GpxUploadController.php
@@ -6,7 +6,7 @@ namespace App\Controller;
 
 use App\ApiResource\TripRequest;
 use App\Entity\User;
-use App\Service\GpxUploadService;
+use App\Service\GpxUploadServiceInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
@@ -28,7 +28,7 @@ final readonly class GpxUploadController
     private const int MAX_FILE_SIZE = 30 * 1024 * 1024; // 30 MB
 
     public function __construct(
-        private GpxUploadService $gpxUploadService,
+        private GpxUploadServiceInterface $gpxUploadService,
         private Security $security,
         #[Autowire(service: 'limiter.gpx_upload')]
         private RateLimiterFactory $gpxUploadLimiter,

--- a/api/src/Service/GpxUploadService.php
+++ b/api/src/Service/GpxUploadService.php
@@ -35,7 +35,7 @@ use Symfony\Component\Uid\Uuid;
  * response already carries the computed stages and the persisted `ready` status.
  * Only the network/LLM enrichments stay asynchronous (dispatched at the end).
  */
-final readonly class GpxUploadService
+final readonly class GpxUploadService implements GpxUploadServiceInterface
 {
     public function __construct(
         private GpxRouteParserInterface $gpxParser,

--- a/api/src/Service/GpxUploadServiceInterface.php
+++ b/api/src/Service/GpxUploadServiceInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\ApiResource\Model\Coordinate;
+use App\ApiResource\TripRequest;
+use App\Entity\User;
+
+/**
+ * GPX upload business logic, behind an interface so the HTTP controller can be
+ * unit-tested (the concrete service is `final readonly` and cannot be doubled).
+ */
+interface GpxUploadServiceInterface
+{
+    /**
+     * @return list<Coordinate>
+     *
+     * @throws \RuntimeException When GPX content is invalid
+     */
+    public function parseGpx(string $content): array;
+
+    public function extractTitle(string $content): ?string;
+
+    /**
+     * @param list<Coordinate> $points
+     *
+     * @return array{tripId: string, computationStatus: array<string, string>, totalDistance: float, totalElevation: int, totalElevationLoss: int, status: string, stages: list<array<string, mixed>>}
+     */
+    public function createTrip(
+        array $points,
+        ?string $title,
+        TripRequest $tripRequest,
+        string $locale,
+        User $user,
+    ): array;
+}

--- a/api/tests/Unit/Controller/GpxUploadControllerTest.php
+++ b/api/tests/Unit/Controller/GpxUploadControllerTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Controller;
+
+use App\ApiResource\Model\Coordinate;
+use App\Controller\GpxUploadController;
+use App\Entity\User;
+use App\Service\GpxUploadServiceInterface;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
+
+final class GpxUploadControllerTest extends TestCase
+{
+    #[Test]
+    public function uploadIsRateLimited(): void
+    {
+        // SEC-006: a valid upload that passes parsing must be throttled per user,
+        // just before the expensive createTrip, once the limiter is exhausted.
+        $user = new User('gpx@example.com');
+
+        $limiter = new RateLimiterFactory(
+            ['id' => 'gpx_upload', 'policy' => 'sliding_window', 'limit' => 1, 'interval' => '60 seconds'],
+            new InMemoryStorage(),
+        );
+        $limiter->create($user->getId()->toRfc4122())->consume();
+
+        $security = $this->createStub(Security::class);
+        $security->method('getUser')->willReturn($user);
+
+        $gpxService = $this->createStub(GpxUploadServiceInterface::class);
+        $gpxService->method('parseGpx')->willReturn([new Coordinate(50.0, 3.0)]);
+        $gpxService->method('extractTitle')->willReturn('Trip');
+
+        $tmp = tempnam(sys_get_temp_dir(), 'gpx');
+        self::assertIsString($tmp);
+        file_put_contents($tmp, '<gpx/>');
+
+        try {
+            $file = $this->createStub(UploadedFile::class);
+            $file->method('isValid')->willReturn(true);
+            $file->method('getSize')->willReturn(100);
+            $file->method('getClientOriginalExtension')->willReturn('gpx');
+            $file->method('getMimeType')->willReturn('application/gpx+xml');
+            $file->method('getPathname')->willReturn($tmp);
+
+            $controller = new GpxUploadController($gpxService, $security, $limiter);
+            $request = new Request([], [], [], [], ['gpxFile' => $file]);
+
+            $this->expectException(TooManyRequestsHttpException::class);
+            $controller($request);
+        } finally {
+            @unlink($tmp);
+        }
+    }
+}


### PR DESCRIPTION
## Contexte

Audit 2026-07 — couverture de test manquante pour **SEC-006**. C'était le seul rate-limit ajouté par SEC-006 sans test unitaire : `GpxUploadController` dépend de `GpxUploadService` qui est `final readonly` (avec des collaborateurs eux-mêmes `final`), donc non-doublable par PHPUnit.

## Correctif

- Extraction de **`GpxUploadServiceInterface`** (`parseGpx` / `extractTitle` / `createTrip`) ; `GpxUploadService` l'implémente. Unique implémentation → Symfony auto-alias l'interface (comme `GpxRouteParserInterface`), **aucun changement de config DI**.
- `GpxUploadController` dépend désormais de l'interface.
- **`GpxUploadControllerTest::uploadIsRateLimited`** : un upload valide (parsing stubé) contre un vrai `RateLimiterFactory` épuisé (`InMemoryStorage`) lève `TooManyRequestsHttpException` avant `createTrip` — même pattern que les tests `trip_recompute` / `trip_duplicate` / `geocode`.

## Vérification

Le test asservit le 429 sur le limiter épuisé sans dépendre du cache de test. Aligne la couverture des 4 limiteurs de l'audit (recompute, duplicate, geocode, gpx_upload).

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 findings (0 critical, 0 warning, 0 nitpick — nitpicks suppressed per review policy).

**Review checklist:**
- [x] Code respects the project architecture (DIP interface extraction, mirrors existing `GpxRouteParserInterface` pattern; single-implementation auto-alias confirmed — no DI config touched)
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases (`uploadIsRateLimited` matches the established `GeocodeControllerTest`/`trip_recompute`/`trip_duplicate` pattern; verified the interface's `createTrip` return shape matches the implementation)
- [x] Documentation is up to date
- [x] Dependent tickets accounted for (SEC-006 gap closed)

**Inline comments:** No inline comments.

**Commit reviewed:** `55270b96b27fc87b28c965607efb4e6e4b937e50`
<!-- claude-review-end -->