### PR TITLE
fix(pwa): drop sub-AA opacity on small muted-text labels (a11y light+dark)

### DIFF
--- a/pwa/src/components/StageDetail/StageWeatherCard.tsx
+++ b/pwa/src/components/StageDetail/StageWeatherCard.tsx
@@ -206,7 +206,7 @@ export function StageWeatherCard({
             <span className="tabular-nums">
               {formatSunTime(sunTimes.sunrise)}
             </span>
-            <span className="text-muted-foreground/70">
+            <span className="text-muted-foreground">
               {t("sunriseShort")}
             </span>
           </div>
@@ -231,7 +231,7 @@ export function StageWeatherCard({
           )}
 
           <div className="flex items-center gap-1.5">
-            <span className="text-muted-foreground/70">{t("sunsetShort")}</span>
+            <span className="text-muted-foreground">{t("sunsetShort")}</span>
             <span className="tabular-nums">
               {formatSunTime(sunTimes.sunset)}
             </span>

--- a/pwa/src/components/accommodation-item.tsx
+++ b/pwa/src/components/accommodation-item.tsx
@@ -327,7 +327,7 @@ export function AccommodationItem({
           </div>
         )}
         {accommodation.source && accommodation.source !== "osm" && (
-          <span className="inline-flex items-center text-[10px] font-medium uppercase tracking-wide text-muted-foreground/70 bg-muted rounded px-1.5 py-0.5">
+          <span className="inline-flex items-center text-[10px] font-medium uppercase tracking-wide text-muted-foreground bg-muted rounded px-1.5 py-0.5">
             {accommodation.source === "datatourisme"
               ? "DataTourisme"
               : accommodation.source}

--- a/pwa/src/components/gpx-drop-zone-card.tsx
+++ b/pwa/src/components/gpx-drop-zone-card.tsx
@@ -291,7 +291,7 @@ export const GpxDropZoneCard = forwardRef<HTMLDivElement, GpxDropZoneCardProps>(
                 {t("browse")}
               </Button>
               {sizeHintMb && (
-                <p className="text-xs text-muted-foreground/70">
+                <p className="text-xs text-muted-foreground">
                   {t("sizeLimit", { size: sizeHintMb })}
                 </p>
               )}


### PR DESCRIPTION
## Contexte

Audit 2026-07 — levée de la limite « **mode clair non testé** » (A11Y-001). En calculant les ratios WCAG à partir des variables de thème :

- `text-muted-foreground/70` sur petit texte (< 18px) = **3.03:1 en mode clair** et **3.64:1 en mode sombre** → échec AA (4.5:1) **dans les deux modes**.
- #821 n'avait corrigé que les éléments précis de la vue voyage en mode sombre, pas ce **pattern d'opacité**.

## Correctif

Retrait de l'opacité `/70` sur 3 labels **informatifs** en petit texte :
- badge source hébergement (`text-[10px]`, `accommodation-item`)
- indice de taille GPX (`text-xs`, `gpx-drop-zone-card`)
- labels lever/coucher (`StageWeatherCard`)

`--muted-foreground` en pleine opacité passe AA dans les deux thèmes (**clair 5.67:1, sombre 6.1:1** — calculé). Laissés inchangés : les icônes de survol **décoratives** (`trip-summary`, `h-3 w-3`) et le **placeholder** de champ vide (`editable-field`, affordance de saisie).

## Vérification

Ratios WCAG calculés (oklch→sRGB + alpha-compositing). Validation visuelle runtime sur la stack iso-prod en cours (mode clair + sombre).

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 blocking findings, 1 non-blocking suggestion. Independently recomputed the oklch→sRGB contrast ratios for `--muted-foreground` against both theme backgrounds and confirmed the PR's numbers exactly (light 5.67:1 / dark 6.1:1 at full opacity; 3.03:1 / 3.64:1 at `/70`). The three changed elements are correctly classified as small informational text (<18px) requiring AA 4.5:1, and the excluded elements (decorative hover icons, empty-field placeholder) are correctly out of scope.

**Suggestion (non-blocking, out of diff scope):** `text-muted-foreground/80` on other small informational text — `StageSurfaceBreakdown.tsx:220`, `ai-chat-card.tsx:463`, `ai-chat-card.tsx:527` — computes to 3.68:1 (light) / 4.34:1 (dark), also failing AA 4.5:1, the same failure mode this PR fixes. These files aren't touched by this diff, so not blocking here, but worth a follow-up given this audit's stated goal of closing the opacity-pattern gap.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases (CSS-only opacity fix; existing non-gating axe smoke test unaffected — consistent with prior PR #821)
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

_Commit reviewed: ccca19e015fed03c4b1cde6b8b87f8aebdb205b3_
<!-- claude-review-end -->