### PR TITLE
feat(pwa): unify brand mark + locale switcher select

### DIFF
--- a/pwa/src/components/brand.tsx
+++ b/pwa/src/components/brand.tsx
@@ -1,0 +1,40 @@
+import { Bike } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { cn } from "@/lib/utils";
+
+/**
+ * Shared brand mark (#831).
+ *
+ * Single source of truth for the logo + wordmark so the header and footer no
+ * longer drift (different icon/typography). The wordmark uses Fraunces
+ * (`font-serif`) + `text-brand`, matching the hero and footer.
+ *
+ * `labelClassName` lets the caller hide the wordmark on narrow screens
+ * (`hidden sm:inline`) while keeping the icon.
+ */
+export function Brand({
+  className,
+  iconClassName,
+  labelClassName,
+}: {
+  className?: string;
+  iconClassName?: string;
+  labelClassName?: string;
+}) {
+  const t = useTranslations("navigation");
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-2 font-serif font-semibold text-brand",
+        className,
+      )}
+    >
+      <Bike
+        className={cn("h-5 w-5 shrink-0", iconClassName)}
+        aria-hidden="true"
+      />
+      <span className={labelClassName}>{t("brand")}</span>
+    </span>
+  );
+}

--- a/pwa/src/components/faq-accordion.tsx
+++ b/pwa/src/components/faq-accordion.tsx
@@ -33,6 +33,7 @@ function AccordionItem({
     <div className="border-b border-border last:border-0">
       <button
         type="button"
+        data-testid="faq-accordion-trigger"
         className="flex w-full items-center justify-between gap-4 py-4 text-left text-sm font-medium transition-colors hover:text-foreground/80"
         aria-expanded={isOpen}
         aria-controls={panelId}

--- a/pwa/src/components/landing/footer.tsx
+++ b/pwa/src/components/landing/footer.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { AttributionFooter } from "@/components/attribution-footer";
+import { Brand } from "@/components/brand";
 import { useAuthStore } from "@/store/auth-store";
 
 // lucide-react 1.x dropped brand icons; inline the GitHub mark.
@@ -42,9 +43,7 @@ export function LandingFooter() {
         <div className="flex flex-col md:flex-row items-start md:items-center justify-between gap-8">
           {/* Brand */}
           <div>
-            <p className="font-serif text-xl font-semibold text-brand mb-1">
-              Bike Trip Planner
-            </p>
+            <Brand className="text-xl mb-1" />
             <p className="text-sm text-muted-foreground max-w-xs">
               {t("tagline")}
             </p>

--- a/pwa/src/components/locale-switcher.tsx
+++ b/pwa/src/components/locale-switcher.tsx
@@ -3,8 +3,13 @@
 import { useTransition } from "react";
 import { useLocale, useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
-import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
+import { Globe } from "lucide-react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+} from "@/components/ui/select";
 import { SUPPORTED_LOCALES, type SupportedLocale } from "@/i18n/locale";
 import { setLocale } from "@/i18n/set-locale";
 
@@ -13,8 +18,8 @@ const LOCALE_LABELS: Record<SupportedLocale, string> = {
   en: "English",
 };
 
-// Compact pill labels shown on narrow screens to keep the top bar within the
-// viewport. The accessible name keeps the full language name (see aria-label).
+// Compact code shown on the trigger on narrow screens to keep the top bar
+// within the viewport. The accessible name keeps the full title (aria-label).
 const LOCALE_SHORT_LABELS: Record<SupportedLocale, string> = {
   fr: "FR",
   en: "EN",
@@ -22,51 +27,47 @@ const LOCALE_SHORT_LABELS: Record<SupportedLocale, string> = {
 
 export function LocaleSwitcher() {
   const t = useTranslations("config");
-  const currentLocale = useLocale();
+  const currentLocale = useLocale() as SupportedLocale;
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
 
-  function handleLocaleChange(locale: SupportedLocale) {
+  function handleLocaleChange(locale: string) {
     if (locale === currentLocale) return;
 
     startTransition(() => {
-      setLocale(locale);
+      setLocale(locale as SupportedLocale);
       router.refresh();
     });
   }
 
   return (
-    <div
-      className="flex items-center gap-2"
-      role="group"
-      aria-label={t("languageTitle")}
+    <Select
+      value={currentLocale}
+      onValueChange={handleLocaleChange}
+      disabled={isPending}
     >
-      <div className="flex gap-1">
-        {SUPPORTED_LOCALES.map((locale) => {
-          const isActive = locale === currentLocale;
-          return (
-            <Button
-              key={locale}
-              variant={isActive ? "default" : "outline"}
-              size="sm"
-              className={cn(
-                "h-7 px-2.5 text-xs cursor-pointer",
-                isActive && "pointer-events-none",
-              )}
-              disabled={isPending}
-              onClick={() => handleLocaleChange(locale)}
-              aria-label={t("switchLanguage", {
-                language: LOCALE_LABELS[locale],
-              })}
-              aria-pressed={isActive}
-              data-testid={`locale-switch-${locale}`}
-            >
-              <span className="sm:hidden">{LOCALE_SHORT_LABELS[locale]}</span>
-              <span className="hidden sm:inline">{LOCALE_LABELS[locale]}</span>
-            </Button>
-          );
-        })}
-      </div>
-    </div>
+      <SelectTrigger
+        size="sm"
+        className="gap-1.5"
+        aria-label={t("languageTitle")}
+        data-testid="locale-switch"
+        data-locale={currentLocale}
+      >
+        <Globe className="h-4 w-4" aria-hidden="true" />
+        <span className="sm:hidden">{LOCALE_SHORT_LABELS[currentLocale]}</span>
+        <span className="hidden sm:inline">{LOCALE_LABELS[currentLocale]}</span>
+      </SelectTrigger>
+      <SelectContent align="end">
+        {SUPPORTED_LOCALES.map((locale) => (
+          <SelectItem
+            key={locale}
+            value={locale}
+            data-testid={`locale-switch-${locale}`}
+          >
+            {LOCALE_LABELS[locale]}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
   );
 }

--- a/pwa/src/components/public-top-bar.tsx
+++ b/pwa/src/components/public-top-bar.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
-import { Bike } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
+import { Brand } from "@/components/brand";
 import { LocaleSwitcher } from "@/components/locale-switcher";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { cn } from "@/lib/utils";
@@ -31,18 +31,19 @@ export function PublicTopBar({ transparent = false }: { transparent?: boolean })
       <div className="max-w-[1200px] mx-auto flex items-center gap-1 sm:gap-2 px-3 sm:px-4 md:px-6 h-16">
         <Link
           href="/"
-          className="flex items-center gap-2 font-bold text-base text-brand hover:opacity-80 transition-opacity shrink-0"
+          className="flex items-center hover:opacity-80 transition-opacity shrink-0"
           aria-label={t("brandHome")}
           data-testid="public-top-bar-brand"
         >
-          <Bike className="h-5 w-5" aria-hidden="true" />
-          <span className="hidden sm:inline">{t("brand")}</span>
+          <Brand className="text-base" labelClassName="hidden sm:inline" />
         </Link>
 
         <div className="flex-1" />
 
-        <LocaleSwitcher />
-        <ThemeToggle />
+        <div className="flex items-center gap-1">
+          <LocaleSwitcher />
+          <ThemeToggle />
+        </div>
 
         <Button
           asChild

--- a/pwa/src/components/top-bar.tsx
+++ b/pwa/src/components/top-bar.tsx
@@ -3,8 +3,9 @@
 import { useTranslations } from "next-intl";
 import { usePathname } from "next/navigation";
 import Link from "next/link";
-import { Bike, HelpCircle, Plus, Map, User } from "lucide-react";
+import { HelpCircle, Plus, Map, User } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Brand } from "@/components/brand";
 import { LocaleSwitcher } from "@/components/locale-switcher";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { cn } from "@/lib/utils";
@@ -61,12 +62,11 @@ export function TopBar() {
         {/* 1. Brand */}
         <Link
           href="/"
-          className="flex items-center gap-2 font-bold text-base text-brand hover:opacity-80 transition-opacity shrink-0"
+          className="flex items-center hover:opacity-80 transition-opacity shrink-0"
           aria-label={tNav("brandHome")}
           data-testid="top-bar-brand"
         >
-          <Bike className="h-5 w-5" aria-hidden="true" />
-          <span className="hidden sm:inline">{tNav("brand")}</span>
+          <Brand className="text-base" labelClassName="hidden sm:inline" />
         </Link>
 
         {/* 2. Navigation tabs — hidden on the smallest screens to keep the bar
@@ -134,11 +134,11 @@ export function TopBar() {
           </Button>
         )}
 
-        {/* 4. Language pills */}
-        <LocaleSwitcher />
-
-        {/* 5. Theme toggle */}
-        <ThemeToggle />
+        {/* 4-5. Language + theme (grouped for a consistent gap) */}
+        <div className="flex items-center gap-1">
+          <LocaleSwitcher />
+          <ThemeToggle />
+        </div>
 
         {/* 6. Profile circle (authenticated) or sign-in (public pages) */}
         {isAuthenticated ? (

--- a/pwa/src/components/ui/select.tsx
+++ b/pwa/src/components/ui/select.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import * as React from "react";
+import { Select as SelectPrimitive } from "radix-ui";
+import { Check, ChevronDown, ChevronUp } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+function Select({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />;
+}
+
+function SelectGroup({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Group>) {
+  return <SelectPrimitive.Group data-slot="select-group" {...props} />;
+}
+
+function SelectValue({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />;
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+  size?: "sm" | "default";
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 cursor-pointer",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDown className="size-4 opacity-50" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  );
+}
+
+function SelectContent({
+  className,
+  children,
+  position = "popper",
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot="select-content"
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
+          position === "popper" &&
+            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+          className,
+        )}
+        position={position}
+        {...props}
+      >
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          className={cn(
+            "p-1",
+            position === "popper" &&
+              "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1",
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  );
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Label>) {
+  return (
+    <SelectPrimitive.Label
+      data-slot="select-label"
+      className={cn("text-muted-foreground px-2 py-1.5 text-xs", className)}
+      {...props}
+    />
+  );
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-pointer items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className,
+      )}
+      {...props}
+    >
+      <span className="absolute right-2 flex size-3.5 items-center justify-center">
+        <SelectPrimitive.ItemIndicator>
+          <Check className="size-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  );
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("bg-border pointer-events-none -mx-1 my-1 h-px", className)}
+      {...props}
+    />
+  );
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className,
+      )}
+      {...props}
+    >
+      <ChevronUp className="size-4" />
+    </SelectPrimitive.ScrollUpButton>
+  );
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className,
+      )}
+      {...props}
+    >
+      <ChevronDown className="size-4" />
+    </SelectPrimitive.ScrollDownButton>
+  );
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+};

--- a/pwa/tests/mocked/faq.spec.ts
+++ b/pwa/tests/mocked/faq.spec.ts
@@ -39,7 +39,7 @@ test.describe("/faq page", () => {
     await page.waitForLoadState("networkidle");
 
     // All accordion buttons should have aria-expanded="false" initially
-    const buttons = page.locator("button[aria-expanded]");
+    const buttons = page.getByTestId("faq-accordion-trigger");
     const count = await buttons.count();
     expect(count).toBeGreaterThan(0);
 
@@ -54,7 +54,7 @@ test.describe("/faq page", () => {
     await page.goto("/faq");
     await page.waitForLoadState("networkidle");
 
-    const firstButton = page.locator("button[aria-expanded]").first();
+    const firstButton = page.getByTestId("faq-accordion-trigger").first();
     await expect(firstButton).toHaveAttribute("aria-expanded", "false");
 
     await firstButton.click();
@@ -65,7 +65,7 @@ test.describe("/faq page", () => {
     await page.goto("/faq");
     await page.waitForLoadState("networkidle");
 
-    const firstButton = page.locator("button[aria-expanded]").first();
+    const firstButton = page.getByTestId("faq-accordion-trigger").first();
 
     // Open
     await firstButton.click();
@@ -82,7 +82,7 @@ test.describe("/faq page", () => {
     await page.goto("/faq");
     await page.waitForLoadState("networkidle");
 
-    const buttons = page.locator("button[aria-expanded]");
+    const buttons = page.getByTestId("faq-accordion-trigger");
     const firstButton = buttons.nth(0);
     const secondButton = buttons.nth(1);
 

--- a/pwa/tests/mocked/locale-switcher.spec.ts
+++ b/pwa/tests/mocked/locale-switcher.spec.ts
@@ -2,26 +2,36 @@ import { test, expect } from "../fixtures/base.fixture";
 
 // Since #384 the locale switcher lives permanently in the top bar, so it is
 // reachable directly on the welcome screen without opening the config panel.
+// Since #831 it is a compact <Select> (trigger + fr/en options) rather than
+// two pill buttons: the trigger carries `data-testid="locale-switch"` and a
+// `data-locale` attribute reflecting the active locale; the options keep the
+// `locale-switch-{fr,en}` testids but only render while the select is open.
 test.describe("LocaleSwitcher", () => {
-  test("displays locale buttons with correct active state", async ({
+  test("trigger reflects the active locale", async ({ mockedPage }) => {
+    const trigger = mockedPage.getByTestId("locale-switch");
+    await expect(trigger).toBeVisible();
+    // French is the default locale.
+    await expect(trigger).toHaveAttribute("data-locale", "fr");
+  });
+
+  test("switching to English updates the active locale", async ({
     mockedPage,
   }) => {
-    // Verify French locale button is active (default locale)
-    const englishButton = mockedPage.getByTestId("locale-switch-en");
-    const frenchButton = mockedPage.getByTestId("locale-switch-fr");
-    await expect(frenchButton).toHaveAttribute("aria-pressed", "true");
-    await expect(englishButton).toHaveAttribute("aria-pressed", "false");
+    const trigger = mockedPage.getByTestId("locale-switch");
+    await trigger.click();
+    await mockedPage.getByTestId("locale-switch-en").click();
+    await mockedPage.waitForLoadState("networkidle");
+    await expect(mockedPage.getByTestId("locale-switch")).toHaveAttribute(
+      "data-locale",
+      "en",
+    );
   });
 
-  test("English button is clickable", async ({ mockedPage }) => {
-    const englishButton = mockedPage.getByTestId("locale-switch-en");
-    await expect(englishButton).toBeEnabled();
-    // Click should not throw — the server action triggers router.refresh()
-    await englishButton.click();
-  });
-
-  test("locale group has correct ARIA role", async ({ mockedPage }) => {
-    const group = mockedPage.getByRole("group", { name: /langue/i });
-    await expect(group).toBeVisible();
+  test("switcher exposes an accessible language label", async ({
+    mockedPage,
+  }) => {
+    await expect(
+      mockedPage.getByRole("combobox", { name: /langue/i }),
+    ).toBeVisible();
   });
 });

--- a/pwa/tests/mocked/top-bar.spec.ts
+++ b/pwa/tests/mocked/top-bar.spec.ts
@@ -17,8 +17,7 @@ test.describe("Desktop top bar", () => {
     await expect(mockedPage.getByTestId("nav-new-trip")).toBeVisible();
     await expect(mockedPage.getByTestId("nav-my-trips")).toBeVisible();
     await expect(mockedPage.getByTestId("help-button")).toBeVisible();
-    await expect(mockedPage.getByTestId("locale-switch-fr")).toBeVisible();
-    await expect(mockedPage.getByTestId("locale-switch-en")).toBeVisible();
+    await expect(mockedPage.getByTestId("locale-switch")).toBeVisible();
     await expect(mockedPage.getByTestId("theme-toggle")).toBeVisible();
     await expect(mockedPage.getByTestId("profile-button")).toBeVisible();
   });
@@ -72,19 +71,17 @@ test.describe("Desktop top bar", () => {
     ).toBeVisible({ timeout: 5000 });
   });
 
-  test("language pills toggle the active locale", async ({ mockedPage }) => {
-    const fr = mockedPage.getByTestId("locale-switch-fr");
-    const en = mockedPage.getByTestId("locale-switch-en");
+  test("language select toggles the active locale", async ({ mockedPage }) => {
+    const trigger = mockedPage.getByTestId("locale-switch");
+    await expect(trigger).toHaveAttribute("data-locale", "fr");
 
-    await expect(fr).toHaveAttribute("aria-pressed", "true");
-    await expect(en).toHaveAttribute("aria-pressed", "false");
-
-    // Clicking EN triggers the locale change (router.refresh under the hood)
-    await en.click();
+    // Open the select and pick EN — triggers the locale change (router.refresh)
+    await trigger.click();
+    await mockedPage.getByTestId("locale-switch-en").click();
     await mockedPage.waitForLoadState("networkidle");
-    await expect(mockedPage.getByTestId("locale-switch-en")).toHaveAttribute(
-      "aria-pressed",
-      "true",
+    await expect(mockedPage.getByTestId("locale-switch")).toHaveAttribute(
+      "data-locale",
+      "en",
     );
   });
 

--- a/pwa/tests/recette/steps/cross-cutting-ux.steps.ts
+++ b/pwa/tests/recette/steps/cross-cutting-ux.steps.ts
@@ -683,14 +683,26 @@ When("I reload the page", async ({ page }) => {
   await page.reload();
 });
 
+// The compact trigger now shows only the *active* locale (the switcher is a
+// Select, no longer two always-visible pills), so pin the locale to French
+// before loading to keep the "FR" assertion independent of any locale left
+// over by a previous scenario in the same worker.
+async function pinFrenchLocale(page: import("@playwright/test").Page) {
+  await page
+    .context()
+    .addCookies([{ name: "locale", value: "fr", url: "https://localhost" }]);
+}
+
 Given("j'affiche l'application sur un écran étroit", async ({ mockedPage }) => {
   await mockedPage.setViewportSize({ width: 390, height: 844 });
+  await pinFrenchLocale(mockedPage);
   await mockedPage.goto("/");
   await mockedPage.waitForLoadState("networkidle");
 });
 
 Given("I am displaying the app on a narrow screen", async ({ mockedPage }) => {
   await mockedPage.setViewportSize({ width: 390, height: 844 });
+  await pinFrenchLocale(mockedPage);
   await mockedPage.goto("/");
   await mockedPage.waitForLoadState("networkidle");
 });

--- a/pwa/tests/recette/steps/cross-cutting-ux.steps.ts
+++ b/pwa/tests/recette/steps/cross-cutting-ux.steps.ts
@@ -1,14 +1,14 @@
 import { expect } from "@playwright/test";
 import { Given, When, Then } from "../support/fixtures";
 
+// Since #831 the locale switcher is a compact <Select>: open the trigger, then
+// pick the fr/en option (options only render while the select is open).
 async function clickLocaleSwitch(
   page: import("@playwright/test").Page,
   localeCode: "fr" | "en",
 ): Promise<void> {
-  const switchButton = page.getByTestId(`locale-switch-${localeCode}`);
-  await switchButton.evaluate((element) => {
-    (element as HTMLButtonElement).click();
-  });
+  await page.getByTestId("locale-switch").click();
+  await page.getByTestId(`locale-switch-${localeCode}`).click();
 }
 
 // The theme toggle (#384) is a permanent control in the top bar that flips
@@ -61,9 +61,9 @@ Given(
 Given("l'interface est en anglais", async ({ mockedPage }) => {
   // The locale switcher lives permanently in the top bar (#384).
   await clickLocaleSwitch(mockedPage, "en");
-  await expect(mockedPage.getByTestId("locale-switch-en")).toHaveAttribute(
-    "aria-pressed",
-    "true",
+  await expect(mockedPage.getByTestId("locale-switch")).toHaveAttribute(
+    "data-locale",
+    "en",
     { timeout: 5000 },
   );
 });
@@ -118,9 +118,9 @@ Given(
 Given("the interface is in English", async ({ mockedPage }) => {
   // The locale switcher lives permanently in the top bar (#384).
   await clickLocaleSwitch(mockedPage, "en");
-  await expect(mockedPage.getByTestId("locale-switch-en")).toHaveAttribute(
-    "aria-pressed",
-    "true",
+  await expect(mockedPage.getByTestId("locale-switch")).toHaveAttribute(
+    "data-locale",
+    "en",
     { timeout: 5000 },
   );
 });
@@ -300,17 +300,17 @@ Then("la modification est rétablie", async ({ mockedPage }) => {
 });
 
 Then("l'interface s'affiche en anglais", async ({ mockedPage }) => {
-  await expect(mockedPage.getByTestId("locale-switch-en")).toHaveAttribute(
-    "aria-pressed",
-    "true",
+  await expect(mockedPage.getByTestId("locale-switch")).toHaveAttribute(
+    "data-locale",
+    "en",
     { timeout: 5000 },
   );
 });
 
 Then("l'interface s'affiche en français", async ({ mockedPage }) => {
-  await expect(mockedPage.getByTestId("locale-switch-fr")).toHaveAttribute(
-    "aria-pressed",
-    "true",
+  await expect(mockedPage.getByTestId("locale-switch")).toHaveAttribute(
+    "data-locale",
+    "fr",
     { timeout: 5000 },
   );
 });
@@ -384,17 +384,17 @@ Then("the modification is redone", async ({ mockedPage }) => {
 });
 
 Then("the interface is displayed in English", async ({ mockedPage }) => {
-  await expect(mockedPage.getByTestId("locale-switch-en")).toHaveAttribute(
-    "aria-pressed",
-    "true",
+  await expect(mockedPage.getByTestId("locale-switch")).toHaveAttribute(
+    "data-locale",
+    "en",
     { timeout: 5000 },
   );
 });
 
 Then("the interface is displayed in French", async ({ mockedPage }) => {
-  await expect(mockedPage.getByTestId("locale-switch-fr")).toHaveAttribute(
-    "aria-pressed",
-    "true",
+  await expect(mockedPage.getByTestId("locale-switch")).toHaveAttribute(
+    "data-locale",
+    "fr",
     { timeout: 5000 },
   );
 });
@@ -661,7 +661,7 @@ Then(
   "le label compact de langue {string} est visible",
   async ({ mockedPage }, label: string) => {
     await expect(
-      mockedPage.getByTestId("locale-switch-fr").getByText(label, {
+      mockedPage.getByTestId("locale-switch").getByText(label, {
         exact: true,
       }),
     ).toBeVisible({ timeout: 5000 });
@@ -672,7 +672,7 @@ Then(
   "the compact language label {string} is visible",
   async ({ mockedPage }, label: string) => {
     await expect(
-      mockedPage.getByTestId("locale-switch-fr").getByText(label, {
+      mockedPage.getByTestId("locale-switch").getByText(label, {
         exact: true,
       }),
     ).toBeVisible({ timeout: 5000 });


### PR DESCRIPTION
Closes #831.

## Contexte
Feedbacks Thomas (#830) : incohérence marque header/footer (typo/logo), espacements incohérents des langues, et switcher de langue en 2 boutons plutôt qu'un select.

## Changements
- Composant `<Brand>` partagé (`pwa/src/components/brand.tsx`) : icône `Bike` + wordmark Fraunces serif, utilisé par les deux top-bars et le footer (marque unifiée).
- Composant shadcn `ui/select.tsx` (primitive `radix-ui` déjà présente, **aucune nouvelle dépendance**).
- `locale-switcher.tsx` réécrit en select compact (Globe + FR/EN). Testid déclencheur `locale-switch` (+ `data-locale`), options `locale-switch-fr/en`.
- Espacements langue+thème harmonisés dans `top-bar.tsx` / `public-top-bar.tsx`.
- Tests mis à jour (`locale-switcher.spec.ts`, `top-bar.spec.ts`, `cross-cutting-ux.steps.ts`).

## Auto-critique
- Changement 100% frontend ; legs PHP non concernés (rector OOM en local → validés en CI).
- Prettier non exécuté en local (sandbox), formatage vérifié à la main → à confirmer par la CI.
- Le testid du déclencheur passe de `locale-switch-fr/en` (boutons) à `locale-switch` + options ; tests adaptés en conséquence.

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 critical, 0 warning, 1 non-blocking suggestion (pre-existing, still unaddressed).

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [ ] Documentation is up to date (see suggestion below)
- [x] Dependent tickets accounted for

**Findings:**
- `pwa/src/components/locale-switcher.tsx`: `config.switchLanguage` translation key is still orphaned in `en.json`/`fr.json` (non-blocking; open thread left unresolved, not fixed by the latest commit either).

The latest commit (`test(i18n): pin locale to fr for the compact-label narrow-screen scenario`) correctly fixes cross-scenario test pollution by pinning the `locale` cookie before load; no new issues found.

Commit reviewed: `cde8e03318c3f219891f0d5d8445365486640cb4`
<!-- claude-review-end -->