### PR TITLE
feat(ui): reusable InfoTooltip + difficulty pill tooltip

### DIFF
--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -290,7 +290,8 @@
     "elevation": "Elevation",
     "physicalDetail": "{distance} km covered",
     "technicalDetail": "{ratio} m of climbing per km — average slope proxy",
-    "elevationDetail": "{elevation} m of total ascent"
+    "elevationDetail": "{elevation} m of total ascent",
+    "overallTooltip": "Overall stage difficulty (Easy, Medium or Hard), based on distance and total ascent."
   },
   "surfaceBreakdown": {
     "ariaLabel": "Surface breakdown",

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -290,7 +290,8 @@
     "elevation": "Dénivelé",
     "physicalDetail": "{distance} km parcourus",
     "technicalDetail": "{ratio} m de D+ par km — proxy de pente moyenne",
-    "elevationDetail": "{elevation} m de dénivelé positif"
+    "elevationDetail": "{elevation} m de dénivelé positif",
+    "overallTooltip": "Difficulté globale de l'étape (Facile, Moyen ou Difficile), calculée à partir de la distance et du dénivelé positif."
   },
   "surfaceBreakdown": {
     "ariaLabel": "Répartition des surfaces",

--- a/pwa/src/components/StageDetail/StageDifficultyComposed.tsx
+++ b/pwa/src/components/StageDetail/StageDifficultyComposed.tsx
@@ -6,6 +6,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { InfoTooltip } from "@/components/ui/info-tooltip";
 import { Bike, Mountain, Wrench } from "lucide-react";
 import {
   DIFFICULTY_THRESHOLDS,
@@ -192,11 +193,17 @@ export function StageDifficultyComposed({
         data-overall={overall}
         aria-label={t("ariaLabel")}
       >
-        <div className="flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
-          <span aria-hidden="true" className="text-muted-foreground">
-            <Mountain className="h-3.5 w-3.5" />
+        <div className="flex items-center justify-between gap-1.5 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+          <span className="flex items-center gap-1.5">
+            <span aria-hidden="true" className="text-muted-foreground">
+              <Mountain className="h-3.5 w-3.5" />
+            </span>
+            <span className="truncate">{t("title")}</span>
           </span>
-          <span className="truncate">{t("title")}</span>
+          <InfoTooltip
+            content={t("overallTooltip")}
+            testId="stage-difficulty-info"
+          />
         </div>
         <div>{overallPill}</div>
       </div>

--- a/pwa/src/components/StageDetail/StageStatsRow.tsx
+++ b/pwa/src/components/StageDetail/StageStatsRow.tsx
@@ -10,7 +10,6 @@ import {
   Clock,
   Wallet,
   Pencil,
-  Info,
 } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
@@ -19,6 +18,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { InfoTooltip } from "@/components/ui/info-tooltip";
 import { StageDistanceEditor } from "@/components/stage-distance-editor";
 import { DiffHighlight } from "@/components/diff-highlight";
 import { computeStageTimes, formatDecimalHour } from "@/lib/travel-time";
@@ -242,7 +242,10 @@ export function StageStatsRow({
         value={
           elevation !== null ? (
             <span className="inline-flex items-center gap-1">
-              <ArrowUp className="h-3.5 w-3.5 text-red-500" aria-hidden="true" />
+              <ArrowUp
+                className="h-3.5 w-3.5 text-red-500"
+                aria-hidden="true"
+              />
               {Math.round(elevation)}
               <span className="text-sm font-normal text-muted-foreground">
                 m
@@ -295,21 +298,7 @@ export function StageStatsRow({
         icon={<Wallet className="h-3.5 w-3.5 text-emerald-500" />}
         testId="stat-budget"
         trailing={
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                type="button"
-                className="flex items-center text-muted-foreground hover:text-foreground transition-colors cursor-help"
-                aria-label={t("budgetTooltip")}
-                data-testid="stat-budget-info"
-              >
-                <Info className="h-3.5 w-3.5" />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent side="top" className="max-w-[15rem]">
-              {t("budgetTooltip")}
-            </TooltipContent>
-          </Tooltip>
+          <InfoTooltip content={t("budgetTooltip")} testId="stat-budget-info" />
         }
         value={
           isProcessing && distance === null ? (

--- a/pwa/src/components/ui/info-tooltip.tsx
+++ b/pwa/src/components/ui/info-tooltip.tsx
@@ -9,11 +9,7 @@ import {
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
-interface InfoTooltipProps {
-  /** Tooltip body — shown on hover/focus. */
-  content: ReactNode;
-  /** Accessible label for the trigger (falls back to a plain-text `content`). */
-  label?: string;
+interface InfoTooltipBaseProps {
   /** Side the tooltip opens on. */
   side?: "top" | "right" | "bottom" | "left";
   /** Icon size in `rem` via Tailwind size classes. */
@@ -23,6 +19,18 @@ interface InfoTooltipProps {
   className?: string;
   testId?: string;
 }
+
+/**
+ * `label` (the trigger's accessible name) is optional when `content` is a plain
+ * string — it falls back to that string. When `content` is a rich `ReactNode`,
+ * `label` is required, so the icon-only trigger can never end up without an
+ * accessible name.
+ */
+type InfoTooltipProps = InfoTooltipBaseProps &
+  (
+    | { content: string; label?: string }
+    | { content: Exclude<ReactNode, string>; label: string }
+  );
 
 /**
  * Factored "ⓘ info + tooltip" affordance: a `cursor-help` Info icon wrapped in a

--- a/pwa/src/components/ui/info-tooltip.tsx
+++ b/pwa/src/components/ui/info-tooltip.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { Info } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+
+interface InfoTooltipProps {
+  /** Tooltip body — shown on hover/focus. */
+  content: ReactNode;
+  /** Accessible label for the trigger (falls back to a plain-text `content`). */
+  label?: string;
+  /** Side the tooltip opens on. */
+  side?: "top" | "right" | "bottom" | "left";
+  /** Icon size in `rem` via Tailwind size classes. */
+  iconClassName?: string;
+  /** Extra classes for the tooltip content box. */
+  contentClassName?: string;
+  className?: string;
+  testId?: string;
+}
+
+/**
+ * Factored "ⓘ info + tooltip" affordance: a `cursor-help` Info icon wrapped in a
+ * Radix tooltip. Consolidates the pattern previously copy-pasted across
+ * StageStatsRow (budget cell) and the difficulty pill.
+ */
+export function InfoTooltip({
+  content,
+  label,
+  side = "top",
+  iconClassName = "h-3.5 w-3.5",
+  contentClassName = "max-w-[15rem]",
+  className,
+  testId,
+}: InfoTooltipProps) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            "flex items-center text-muted-foreground hover:text-foreground transition-colors cursor-help",
+            className,
+          )}
+          aria-label={
+            label ?? (typeof content === "string" ? content : undefined)
+          }
+          data-testid={testId}
+        >
+          <Info className={iconClassName} aria-hidden="true" />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side={side} className={contentClassName}>
+        {content}
+      </TooltipContent>
+    </Tooltip>
+  );
+}


### PR DESCRIPTION
Closes #832.

## Contexte
Feedback Thomas (#830) : le "i" d'info au hover est parfois présent, parfois non (absent du label de difficulté d'une card journée).

## Changements
- `pwa/src/components/ui/info-tooltip.tsx` : composant factorisant « icône `Info` + `Tooltip` Radix » (props `content`, `label`, `side`, `testId`...).
- `StageStatsRow.tsx` : cellule Budget migrée sur `InfoTooltip` (testid `stat-budget-info` conservé).
- `StageDifficultyComposed.tsx` : ajout d'un `InfoTooltip` (testid `stage-difficulty-info`) sur le pill compact expliquant easy/medium/hard.
- i18n : `difficultyComposed.overallTooltip` (fr + en).

## Auto-critique
- 100% frontend ; ESLint/tsc/i18n-check/Prettier verts en local. Legs PHP validés en CI (rector OOM local).
- Le crayon d'édition Distance est laissé à #837 pour éviter le chevauchement sur `StageStatsRow.tsx`.

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 critical, 0 blocking, 1 suggestion (non-blocking). The a11y gap flagged in the previous round is now fixed at the type level (`label` is required when `content` is non-string).

**Resolved threads:** Resolved 1 previously open thread that was addressed.

**PR title:** `feat(ui): reusable InfoTooltip + difficulty pill tooltip` — description isn't in imperative mood (Conventional Commits expects e.g. `add reusable InfoTooltip...`).

**Review checklist:**
- [x] Code respects the project architecture (presentational component, no state/store touched)
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate (factors a duplicated icon+tooltip pattern into one component; discriminated union now enforces the a11y contract at compile time)
- [ ] Tests cover new/changed cases (no unit/E2E test added for the new tooltip behavior — pre-existing gap for this component family, not a regression introduced here)
- [x] Documentation is up to date (JSDoc on the new component)
- [x] Dependent tickets accounted for (#837 explicitly deferred to avoid overlap)

**Inline comments:** No inline comments.

**Commit reviewed:** 705e04f2f2f60420e8e5a95e6c01c21238641196
<!-- claude-review-end -->