### PR TITLE
fix(pwa): style radius-expand actions as buttons

### DIFF
--- a/pwa/src/components/accommodation-panel.tsx
+++ b/pwa/src/components/accommodation-panel.tsx
@@ -133,16 +133,16 @@ export function AccommodationPanel({
                 ) : (
                   <>
                     <Button
-                      variant="link"
-                      size="sm"
-                      className="h-auto p-0 text-xs text-primary justify-start"
+                      variant="outline"
+                      size="xs"
+                      className="self-start"
                       onClick={async () => {
                         setExpandingFromRadius(searchRadiusKm);
                         const ok = await onExpandRadius(searchRadiusKm);
                         if (!ok) setExpandingFromRadius(null);
                       }}
                     >
-                      <ChevronRight className="h-3 w-3 mr-1" />
+                      <ChevronRight className="h-3 w-3" />
                       {t("expandRadius", { radius: nextRadiusKm })}
                     </Button>
                     <p className="text-xs text-muted-foreground">
@@ -214,16 +214,15 @@ export function AccommodationPanel({
         !isExpanding && (
           <div className="mt-2">
             <Button
-              variant="link"
-              size="sm"
-              className="h-auto p-0 text-xs text-primary"
+              variant="outline"
+              size="xs"
               onClick={async () => {
                 setExpandingFromRadius(searchRadiusKm);
                 const ok = await onExpandRadius(searchRadiusKm);
                 if (!ok) setExpandingFromRadius(null);
               }}
             >
-              <ChevronRight className="h-3 w-3 mr-1" />
+              <ChevronRight className="h-3 w-3" />
               {t("expandRadius", { radius: nextRadiusKm })}
             </Button>
           </div>


### PR DESCRIPTION
Closes #833.

## Contexte
Feedback Thomas (#830) : usage du style lien (souligné au hover) pour des actions (« Élargir le rayon à 7km »).

## Changements
- `accommodation-panel.tsx` : les 2 boutons « Élargir le rayon » passent de `variant="link"` (style lien discret) à `variant="outline" size="xs"`, icône `ChevronRight` conservée.
- Audit : ce sont les seules occurrences de `variant="link"` d'action dans `pwa/src/components` ; aucun vrai lien de navigation converti.

## Auto-critique
- 100% frontend ; ESLint/tsc/Prettier verts en local. Legs PHP validés en CI (rector OOM local).

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 findings (0 critical, 0 warning). Minimal, correct cosmetic change — swaps `variant="link"` for `variant="outline" size="xs"` on the two "Élargir le rayon" buttons, dropping the now-redundant `mr-1` icon margin (the `xs` size variant already applies a `gap-1`). Both variant/size combos exist in `button.tsx`'s `cva` config; `onClick` handlers are untouched; no tests reference the removed classes.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases (no new behavior introduced; styling-only change)
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

**Commit reviewed:** `5bd1ab4aa658b0368032ad33fcb8af4fd09ff02a`
<!-- claude-review-end -->