### PR TITLE
feat(planner): confirm trip saved to account after import

### DIFF
--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -603,7 +603,8 @@
     "errorGeneric": "Something went wrong. Please try again."
   },
   "planner": {
-    "computing": "Computing your route…"
+    "computing": "Computing your route…",
+    "tripSavedToAccount": "Trip saved to My trips."
   },
   "tripPreview": {
     "title": "Your route preview",

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -603,7 +603,8 @@
     "errorGeneric": "Une erreur est survenue. Réessaie."
   },
   "planner": {
-    "computing": "Calcul de ton itinéraire en cours…"
+    "computing": "Calcul de ton itinéraire en cours…",
+    "tripSavedToAccount": "Voyage enregistré dans Mes voyages."
   },
   "tripPreview": {
     "title": "Aperçu de ton itinéraire",

--- a/pwa/src/hooks/use-trip-planner.ts
+++ b/pwa/src/hooks/use-trip-planner.ts
@@ -203,6 +203,7 @@ export function useTripPlanner() {
       const importEvent = importEventForUrl(sourceUrl);
       if (importEvent) trackEvent(importEvent);
       trackEvent("trip_created", { source: importEvent ?? "url" });
+      toast.success(t("planner.tripSavedToAccount"));
       router.push(`/trips/${data.id ?? ""}`);
     } catch (err) {
       if (isNetworkError(err)) {
@@ -291,6 +292,7 @@ export function useTripPlanner() {
       });
       trackEvent("import_gpx");
       trackEvent("trip_created", { source: "gpx" });
+      toast.success(t("planner.tripSavedToAccount"));
       // Navigate to /trips/{id} like the magic-link flow (#729): the planner
       // re-hydrates from the detail endpoint and the async Mercure lifecycle
       // (route_parsed → stages_computed → preview) drives the wizard. Without


### PR DESCRIPTION
Closes #835.

## Contexte
Feedback Thomas (#830) : l'import GPX crée un voyage sans indice qu'il est sauvegardé dans le compte.

## Changements
- `use-trip-planner.ts` : `toast.success` au succès de `handleGpxUpload` (GPX) et `handleMagicLink` (lien), avant le `router.push`.
- i18n : `planner.tripSavedToAccount` (fr « Voyage enregistré dans Mes voyages. » / en "Trip saved to My trips.").

## Auto-critique
- Toast uniquement (indice UI persistant écarté, optionnel dans l'issue).
- 100% frontend ; tsc/ESLint/Prettier verts en local. Legs PHP en CI (rector OOM local).
- Chevauche `use-trip-planner.ts` avec #840 (recompute) : handlers disjoints, conflit de merge possible selon l'ordre.

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 critical, 0 warning, 0 new suggestions. One previously-flagged non-blocking suggestion (missing e2e coverage for the new toast) remains open — author has acknowledged and deferred it.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases (still open: no e2e coverage for the new success toast — pre-existing thread, not newly re-flagged)
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No new inline comments.

**Commit reviewed:** `09c6ee8`
<!-- claude-review-end -->