### PR TITLE
feat(ai): move "configure an AI" notice below the header

### DIFF
--- a/pwa/src/components/ai-unavailable-notice.tsx
+++ b/pwa/src/components/ai-unavailable-notice.tsx
@@ -33,6 +33,7 @@ export function AiUnavailableNotice({
   if (variant === "notConfigured") {
     return (
       <div
+        role="alert"
         data-testid="ai-not-configured-notice"
         className={cn(
           "flex flex-col gap-2 rounded-md border border-brand/30 bg-brand/5 px-3 py-2 text-sm text-foreground",

--- a/pwa/src/components/trip-planner.tsx
+++ b/pwa/src/components/trip-planner.tsx
@@ -455,6 +455,19 @@ export function TripPlanner() {
              per-block spinners (ADR-043). === */}
         {isTripLoaded && (
           <>
+            {/* "Configure une IA" banner (feedback #830) — pinned just under
+                the site header, at the top of the trip content zone, so the
+                actionable CTA is the first thing the user sees rather than
+                buried above the AI overview. */}
+            {isAiFeatureEnabled() && !aiConfigured && (
+              <div className="mb-6">
+                <AiUnavailableNotice
+                  variant="notConfigured"
+                  context="analysis"
+                />
+              </div>
+            )}
+
             {/* Inline recomputation progress bar — thin bar at top of page */}
             <InlineRecomputationBar />
 
@@ -532,13 +545,8 @@ export function TripPlanner() {
                   user a high-level view before they dive into per-stage data. */}
               {isAiFeatureEnabled() && (
                 <>
-                  {!aiConfigured ? (
-                    <AiUnavailableNotice
-                      variant="notConfigured"
-                      context="analysis"
-                    />
-                  ) : (
-                    !aiAvailable && <AiUnavailableNotice context="analysis" />
+                  {aiConfigured && !aiAvailable && (
+                    <AiUnavailableNotice context="analysis" />
                   )}
                   <TripAiOverview
                     onRegenerate={() => void relaunchFullAnalysis()}


### PR DESCRIPTION
Closes #836.

## Contexte
Feedback Thomas (#830) : l'alerte « Configure une IA... » serait plus pertinente juste sous le header.

## Changements
- `trip-planner.tsx` : la variante `notConfigured` est rendue en tête de la zone de contenu (juste sous le header `SiteChrome`), avant `InlineRecomputationBar` et le titre. Condition d'affichage et CTA `/account/settings#ai` conservés. Ancien emplacement (entre `TripSummary` et `TripAiOverview`) nettoyé, pas de duplication.
- `ai-unavailable-notice.tsx` : `role="alert"` ajouté à la variante `notConfigured` (parité avec `outage`).

## Auto-critique
- 100% frontend ; ESLint/tsc/Prettier verts en local. Legs PHP en CI (rector OOM local).
- Tests `ai-capabilities.spec.ts` n'assertent que la visibilité du testid, pas la position → toujours valides.

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 findings (0 critical, 0 warning, 0 nitpick — nitpicks not posted per review policy).

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Commit reviewed:** `4a02607`

<!-- claude-review-end -->