### PR TITLE
feat(pwa): strengthen day-distance edit affordance

### DIFF
--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -268,6 +268,7 @@
     "durationUnavailable": "—",
     "budget": "Budget",
     "distanceEditTooltip": "Edit this stage's distance. The rest of the route is recalculated accordingly.",
+    "distanceEditHint": "Editing the distance re-splits the following days.",
     "budgetTooltip": "Estimate based on the day's meals and accommodation (selected option or average of nearby options)."
   },
   "stageAiSummary": {
@@ -385,7 +386,9 @@
     "step3Title": "Configure your rider profile",
     "step3Description": "Open Settings to adjust your <strong>pacing</strong>, fatigue factor, elevation penalty, and accommodation preferences before computing your stages.",
     "step4Title": "Explore your stages",
-    "step4Description": "Once your trip is loaded, stages appear in the <strong>timeline</strong>. Each stage shows distance, elevation, travel time, alerts, and accommodation suggestions. You can reorder, split, or add rest days as needed."
+    "step4Description": "Once your trip is loaded, stages appear in the <strong>timeline</strong>. Each stage shows distance, elevation, travel time, alerts, and accommodation suggestions. You can reorder, split, or add rest days as needed.",
+    "step5Title": "Adjust a day's distance",
+    "step5Description": "Click <strong>Edit distance</strong> on a stage to change that day's mileage. The rest of the trip is automatically <strong>re-split</strong>: this is the main lever to fine-tune your day-by-day breakdown."
   },
   "undoRedo": {
     "undoTitle": "Undo (Ctrl+Z)",

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -268,6 +268,7 @@
     "durationUnavailable": "—",
     "budget": "Budget",
     "distanceEditTooltip": "Modifie la distance de cette étape. Le reste de l'itinéraire est recalculé en conséquence.",
+    "distanceEditHint": "Modifier la distance redécoupe les jours suivants.",
     "budgetTooltip": "Estimation basée sur les repas de la journée et l'hébergement (sélectionné ou moyenne des options trouvées)."
   },
   "stageAiSummary": {
@@ -385,7 +386,9 @@
     "step3Title": "Configure ton profil cyclo",
     "step3Description": "Ouvre les Paramètres pour ajuster le <strong>pacing</strong>, le facteur de fatigue, l'indice de dénivelé et tes préférences d'hébergements avant de calculer tes étapes.",
     "step4Title": "Explore tes étapes",
-    "step4Description": "Une fois ton voyage chargé, les étapes apparaissent dans la <strong>timeline</strong>. Chaque étape affiche distance, dénivelé, temps de trajet, alertes et suggestions d'hébergements. Tu peux réordonner, fractionner ou insérer des jours de repos."
+    "step4Description": "Une fois ton voyage chargé, les étapes apparaissent dans la <strong>timeline</strong>. Chaque étape affiche distance, dénivelé, temps de trajet, alertes et suggestions d'hébergements. Tu peux réordonner, fractionner ou insérer des jours de repos.",
+    "step5Title": "Ajuste la distance d'un jour",
+    "step5Description": "Clique sur <strong>Modifier la distance</strong> d'une étape pour changer le kilométrage de la journée. Le reste du voyage est automatiquement <strong>redécoupé</strong> : c'est le levier principal pour ajuster ton découpage jour par jour."
   },
   "undoRedo": {
     "undoTitle": "Annuler (Ctrl+Z)",

--- a/pwa/src/components/StageDetail/StageStatsRow.tsx
+++ b/pwa/src/components/StageDetail/StageStatsRow.tsx
@@ -198,7 +198,7 @@ export function StageStatsRow({
                 onCancel={() => setEditingDistance(false)}
               />
             ) : distance !== null ? (
-              <span className="flex items-center gap-1.5">
+              <span className="flex flex-wrap items-center gap-x-2 gap-y-1">
                 <span>
                   {Number.isInteger(distance) ? distance : distance.toFixed(1)}
                   <span className="ml-1 text-sm font-normal text-muted-foreground">
@@ -209,14 +209,15 @@ export function StageStatsRow({
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <Button
-                        variant="ghost"
-                        size="icon"
-                        className="h-6 w-6 text-muted-icon cursor-pointer"
+                        variant="outline"
+                        size="sm"
+                        className="h-7 gap-1 px-2 text-xs font-medium text-brand border-brand/40 hover:bg-brand/10 hover:text-brand cursor-pointer"
                         onClick={() => setEditingDistance(true)}
                         aria-label={tStage("editDistance")}
                         data-testid="stat-distance-edit"
                       >
                         <Pencil className="h-3.5 w-3.5" />
+                        {tStage("editDistance")}
                       </Button>
                     </TooltipTrigger>
                     <TooltipContent side="top" className="max-w-[15rem]">
@@ -228,6 +229,14 @@ export function StageStatsRow({
             ) : (
               <Skeleton className="w-16 h-5" />
             )
+          }
+          hint={
+            !readOnly &&
+            onDistanceChange &&
+            !editingDistance &&
+            distance !== null
+              ? t("distanceEditHint")
+              : null
           }
         />
       </DiffHighlight>
@@ -242,7 +251,10 @@ export function StageStatsRow({
         value={
           elevation !== null ? (
             <span className="inline-flex items-center gap-1">
-              <ArrowUp className="h-3.5 w-3.5 text-red-500" aria-hidden="true" />
+              <ArrowUp
+                className="h-3.5 w-3.5 text-red-500"
+                aria-hidden="true"
+              />
               {Math.round(elevation)}
               <span className="text-sm font-normal text-muted-foreground">
                 m

--- a/pwa/src/components/onboarding-tour.tsx
+++ b/pwa/src/components/onboarding-tour.tsx
@@ -12,11 +12,12 @@ import { useAuthStore } from "@/store/auth-store";
  * OnboardingTour — renders nothing in the DOM.
  *
  * On an authenticated user's first home-page visit (no localStorage flag), it
- * starts a 4-step driver.js tour through the core workflow:
+ * starts a 5-step driver.js tour through the core workflow:
  *   1. Paste a Komoot link
  *   2. Upload a GPX file (alternative input)
  *   3. Configure the rider profile (pacing / fatigue)
  *   4. Read stages in the timeline (shown after a trip loads)
+ *   5. Edit a day's distance to re-split the following days
  *
  * Steps 1–2 target elements that only exist on the authenticated home page
  * (`card-link` / `card-gpx`). Steps 3–4 are centred modals (no DOM target):
@@ -102,6 +103,19 @@ export function OnboardingTour() {
           popover: {
             title: t("step4Title"),
             description: t.raw("step4Description"),
+          },
+        },
+        {
+          // Step 5 — points at the inline distance editor. The target only
+          // exists on an open trip's stage detail panel; on the welcome screen
+          // driver.js falls back to a centred modal, so this step still explains
+          // that editing a day's distance re-splits the following days (#837).
+          element: "[data-testid='stat-distance-edit']",
+          popover: {
+            title: t("step5Title"),
+            description: t.raw("step5Description"),
+            side: "bottom",
+            align: "start",
           },
         },
       ],


### PR DESCRIPTION
Closes #837.

## Contexte
Feedback Thomas (#830) : pas assez d'affordance sur le fait que modifier les distances des jours redécoupe le voyage.

## Changements
- `StageStatsRow.tsx` : crayon discret remplacé par un bouton `variant="outline"` teinté brand avec libellé « Modifier la distance » ; hint persistant « Modifier la distance redécoupe les jours suivants. » sous la valeur (quand éditable).
- `onboarding-tour.tsx` : nouvelle étape (step 5) ciblant `stat-distance-edit`.
- i18n : `stageStats.distanceEditHint`, `onboarding.step5Title/Description` (fr + en).

## Auto-critique
- 100% frontend ; ESLint/tsc/i18n-check/Prettier verts en local. Legs PHP en CI (rector OOM local).
- Chevauche `StageStatsRow.tsx` avec #832 (cellule Budget) : zones disjointes (Distance vs Budget), conflit de merge possible selon l'ordre.

<!-- claude-review-start -->
## Claude Review

**Summary:** Small, well-scoped frontend-only change (button affordance + persistent hint + a 5th onboarding step). No new commits since the last review pass — re-reviewed commit `bbf62f1bd7bb5c4b25995426c2f33f821fd30209` from scratch rather than trusting the prior review body. Independently re-verified the driver.js fallback claim by pulling `driver.js@1.4.0` from the npm registry and reading `dist/driver.js.mjs`: `j()` substitutes a dummy centred element (`driver-dummy-element`) on a `querySelector` miss, and the popover-positioning code explicitly forces `side = "over"` when `element.id === "driver-dummy-element"` — so step 5 renders as a centred popover identical to steps 3/4, and the previously-resolved "breaks the tour" thread is correctly resolved. Confirmed the remaining open thread is still accurate: no test drives the onboarding tour to step 5 or asserts `distanceEditHint` renders (`onboarding.spec.ts` only exercises step 1 and completion). i18n keys are consistent across fr/en, the new `stat-distance-edit` button/hint wiring is correct, and no debug leftovers, security, or performance concerns were found.

**Resolved threads:** none newly resolved this pass (the test-coverage thread remains genuinely open; the driver.js-fallback thread was already resolved and stays that way).

**Review checklist:**
- [x] Code respects the project architecture (local-first frontend, no backend touched)
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [ ] Tests cover new/changed cases (no test exercises onboarding step 5 or the new hint text — pre-existing open thread, still unaddressed)
- [x] Documentation is up to date (JSDoc on `OnboardingTour` updated for the 5-step flow)
- [x] Dependent tickets accounted for (#837, references #830, #649, #832)

**Inline comments:** No new inline comments — the one open finding (test-coverage gap) already has an unresolved thread from a prior pass; re-posting would duplicate it.

**Commit reviewed:** `bbf62f1bd7bb5c4b25995426c2f33f821fd30209`
<!-- claude-review-end -->
