### PR TITLE
fix(recompute): guard distance recompute against day-count races

### DIFF
--- a/pwa/src/hooks/use-trip-planner.ts
+++ b/pwa/src/hooks/use-trip-planner.ts
@@ -45,6 +45,14 @@ export function importEventForUrl(url: string): PlausibleEvent | null {
   return null;
 }
 
+/**
+ * Last-resort delay after which a recompute that never fully settled (a lost
+ * or obsolete `stage_updated`, e.g. after the day count changed) has its
+ * `processing` overlay force-lifted. Generous enough to outlast a real
+ * recompute + enrichment pass so it only fires on a genuinely stuck run (#840).
+ */
+const RECOMPUTE_OVERLAY_TIMEOUT_MS = 30000;
+
 /** Read current pacing + config state from the store without subscribing. */
 function getPacingState() {
   const s = useTripStore.getState();
@@ -154,6 +162,7 @@ export function useTripPlanner() {
     typeof getUndoableSlice
   > | null>(null);
   const chatAbortRef = useRef<AbortController | null>(null);
+  const recomputeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const tripId = trip?.id ?? null;
   useMercure(tripId, mercureToken);
@@ -168,6 +177,15 @@ export function useTripPlanner() {
     chatAbortRef.current = null;
     useUiStore.getState().clearHistory();
   }, [tripId]);
+
+  // Clear the recompute safety-net timer on unmount so it can't fire against a
+  // torn-down view (#840).
+  useEffect(
+    () => () => {
+      if (recomputeTimerRef.current) clearTimeout(recomputeTimerRef.current);
+    },
+    [],
+  );
 
   async function handleMagicLink(sourceUrl: string) {
     actions.clearTrip();
@@ -489,6 +507,29 @@ export function useTripPlanner() {
     }
   }
 
+  /**
+   * Arm a last-resort timer that lifts the `processing` overlay if the current
+   * recompute never fully settles (lost/obsolete `stage_updated`, or a day-count
+   * change that leaves marked indices without a matching event). The timer
+   * captures the recompute token at arm time and no-ops if a newer edit has
+   * since bumped it — so overlapping edits can't clear each other's overlay (#840).
+   */
+  function armRecomputeSafetyNet() {
+    if (recomputeTimerRef.current) clearTimeout(recomputeTimerRef.current);
+    const version = useTripStore.getState().recomputeVersion;
+    recomputeTimerRef.current = setTimeout(() => {
+      recomputeTimerRef.current = null;
+      const s = useTripStore.getState();
+      // A newer recompute superseded this one, or everything already settled.
+      if (s.recomputeVersion !== version || s.recomputingStages.size === 0) {
+        return;
+      }
+      s.clearRecomputingStages();
+      setProcessing(false);
+      setAccommodationScanning(false);
+    }, RECOMPUTE_OVERLAY_TIMEOUT_MS);
+  }
+
   async function handleDistanceChange(index: number, distance: number) {
     if (!tripId) return;
 
@@ -512,8 +553,18 @@ export function useTripPlanner() {
         useTripTemporalStore.getState()._push(snapshot);
         setProcessing(true);
         setAccommodationScanning(true);
-        // Mark this stage as recomputing so the shimmer skeleton appears.
-        actions.startStageRecomputation([index]);
+        // Mark this stage and every subsequent one as recomputing: the backend
+        // re-splits from `index` onward (StageUpdateProcessor dispatches
+        // RecalculateStages over `range(index, count-1)`), so the shimmer must
+        // cover the same range instead of the single edited card (#840).
+        const stageCount = useTripStore.getState().stages.length;
+        actions.startStageRecomputation(
+          Array.from(
+            { length: Math.max(1, stageCount - index) },
+            (_, k) => index + k,
+          ),
+        );
+        armRecomputeSafetyNet();
       }
     } catch {
       toast.error(t("errors.failedUpdateLocation"));

--- a/pwa/src/hooks/use-trip-planner.ts
+++ b/pwa/src/hooks/use-trip-planner.ts
@@ -180,11 +180,13 @@ export function useTripPlanner() {
 
   // Clear the recompute safety-net timer on unmount so it can't fire against a
   // torn-down view (#840).
+  // Clear any pending safety-net timer on unmount and whenever the active trip
+  // changes, so a timer armed for one trip can never fire against another.
   useEffect(
     () => () => {
       if (recomputeTimerRef.current) clearTimeout(recomputeTimerRef.current);
     },
-    [],
+    [tripId],
   );
 
   async function handleMagicLink(sourceUrl: string) {
@@ -511,17 +513,27 @@ export function useTripPlanner() {
    * Arm a last-resort timer that lifts the `processing` overlay if the current
    * recompute never fully settles (lost/obsolete `stage_updated`, or a day-count
    * change that leaves marked indices without a matching event). The timer
-   * captures the recompute token at arm time and no-ops if a newer edit has
-   * since bumped it — so overlapping edits can't clear each other's overlay (#840).
+   * captures the recompute token (and the trip it belongs to) at arm time and
+   * no-ops if a newer edit has since bumped the token or the user switched
+   * trips — so overlapping edits (or a trip switch) can't clear each other's
+   * overlay (#840).
    */
   function armRecomputeSafetyNet() {
     if (recomputeTimerRef.current) clearTimeout(recomputeTimerRef.current);
     const version = useTripStore.getState().recomputeVersion;
+    const armedTripId = useTripStore.getState().trip?.id ?? null;
     recomputeTimerRef.current = setTimeout(() => {
       recomputeTimerRef.current = null;
       const s = useTripStore.getState();
-      // A newer recompute superseded this one, or everything already settled.
-      if (s.recomputeVersion !== version || s.recomputingStages.size === 0) {
+      // Bail if a newer recompute superseded this one, everything already
+      // settled, or the user switched trips since arming — otherwise a stale
+      // timer from a previous trip could force-clear a different trip's
+      // legitimately in-flight overlay.
+      if (
+        s.recomputeVersion !== version ||
+        s.recomputingStages.size === 0 ||
+        (s.trip?.id ?? null) !== armedTripId
+      ) {
         return;
       }
       s.clearRecomputingStages();

--- a/pwa/src/store/trip-store.test.ts
+++ b/pwa/src/store/trip-store.test.ts
@@ -433,6 +433,18 @@ describe("recompute concurrency guard (#840)", () => {
     // The set is empty, so use-mercure's `size === 0` branch lifts `processing`.
     expect(state.recomputingStages.size).toBe(0);
   });
+
+  it("prunes out-of-bounds recomputing markers when a stage is deleted", () => {
+    const store = useTripStore.getState();
+    store.clearTrip();
+    store.setStages([makeStage(1), makeStage(2), makeStage(3)]);
+    store.startStageRecomputation([0, 1, 2]);
+    // Deleting a stage shrinks the array; index 2 can no longer be settled.
+    store.deleteStage(2);
+    expect([...useTripStore.getState().recomputingStages].sort()).toEqual([
+      0, 1,
+    ]);
+  });
 });
 
 describe("date window stays in sync with stage count (recette #649)", () => {

--- a/pwa/src/store/trip-store.test.ts
+++ b/pwa/src/store/trip-store.test.ts
@@ -370,6 +370,71 @@ describe("applyStageUpdate preservation (recette #649)", () => {
   });
 });
 
+describe("recompute concurrency guard (#840)", () => {
+  it("bumps recomputeVersion on every startStageRecomputation", () => {
+    const store = useTripStore.getState();
+    store.clearTrip();
+    const before = useTripStore.getState().recomputeVersion;
+    store.startStageRecomputation([0]);
+    store.startStageRecomputation([1]);
+    expect(useTripStore.getState().recomputeVersion).toBe(before + 2);
+  });
+
+  it("appends the new trailing day when its stage_updated lands out of bounds", () => {
+    const store = useTripStore.getState();
+    store.setStages([makeStage(1), makeStage(2), makeStage(3)]);
+
+    // Reducing the last stage's distance split off a brand-new day at index 3;
+    // its stage_updated lands at the next contiguous index.
+    const newDay = makeStage(4, 25);
+    newDay.endPoint = { lat: 1, lon: 1, ele: 0 };
+    store.applyStageUpdate(3, newDay);
+
+    const stages = useTripStore.getState().stages;
+    expect(stages).toHaveLength(4);
+    expect(stages[3]?.distance).toBe(25);
+  });
+
+  it("ignores a far out-of-range stage_updated (stale event)", () => {
+    const store = useTripStore.getState();
+    store.setStages([makeStage(1), makeStage(2)]);
+    store.applyStageUpdate(5, makeStage(6));
+    expect(useTripStore.getState().stages).toHaveLength(2);
+  });
+
+  it("prunes recomputing markers for indices that no longer exist (overlay unstuck)", () => {
+    const store = useTripStore.getState();
+    store.clearTrip();
+    store.setStages([makeStage(1), makeStage(2), makeStage(3)]);
+    store.startStageRecomputation([0, 1, 2]);
+    // Day count shrinks: indices 1 and 2 can never receive a stage_updated.
+    store.setStages([makeStage(1)]);
+    expect([...useTripStore.getState().recomputingStages]).toEqual([0]);
+  });
+
+  it("lifts the overlay on a last-stage edit that adds a day, losing no data", () => {
+    const store = useTripStore.getState();
+    store.clearTrip();
+    store.setStages([makeStage(1), makeStage(2), makeStage(3)]);
+    // Edit last stage: mark the affected range (single last index here).
+    store.startStageRecomputation([2]);
+
+    // Backend re-splits and emits stage_updated for the edited stage and the
+    // freshly created trailing day.
+    store.applyStageUpdate(2, makeStage(3, 40));
+    store.finishStageRecomputation(2);
+    const newDay = makeStage(4, 20);
+    newDay.endPoint = { lat: 2, lon: 2, ele: 0 };
+    store.applyStageUpdate(3, newDay);
+
+    const state = useTripStore.getState();
+    expect(state.stages).toHaveLength(4);
+    expect(state.stages[3]?.distance).toBe(20);
+    // The set is empty, so use-mercure's `size === 0` branch lifts `processing`.
+    expect(state.recomputingStages.size).toBe(0);
+  });
+});
+
 describe("date window stays in sync with stage count (recette #649)", () => {
   it("extends endDate when a rest day is inserted", () => {
     const store = useTripStore.getState();

--- a/pwa/src/store/trip-store.test.ts
+++ b/pwa/src/store/trip-store.test.ts
@@ -481,4 +481,17 @@ describe("date window stays in sync with stage count (recette #649)", () => {
     store.insertRestDay(0);
     expect(useTripStore.getState().endDate).toBeNull();
   });
+
+  it("extends endDate when a last-stage edit appends a trailing day (#840)", () => {
+    const store = useTripStore.getState();
+    store.setStages([makeStage(1), makeStage(2)]);
+    store.updateDatesInternal("2026-07-10", "2026-07-11"); // 2 stages → 2 days
+    // A last-stage distance edit splits off a new day whose stage_updated
+    // lands at the next contiguous index.
+    const newDay = makeStage(3, 20);
+    newDay.endPoint = { lat: 3, lon: 3, ele: 0 };
+    store.applyStageUpdate(2, newDay);
+    // 3 stages → 3 days: 10–12 July.
+    expect(useTripStore.getState().endDate).toBe("2026-07-12");
+  });
 });

--- a/pwa/src/store/trip-store.ts
+++ b/pwa/src/store/trip-store.ts
@@ -73,6 +73,15 @@ interface TripState {
    */
   recomputingStages: Set<number>;
   /**
+   * Monotonic counter bumped every time a recomputation is started
+   * ({@link startStageRecomputation}). Acts as a concurrency token: the hook
+   * captures the value when it dispatches an edit and a safety-net timer only
+   * lifts the `processing` overlay if the token is still current, so a rapid
+   * follow-up edit (which bumps the token) invalidates the earlier, obsolete
+   * completion path (#840).
+   */
+  recomputeVersion: number;
+  /**
    * Map of stage index → set of changed field names, populated after a
    * `stage_updated` event lands. Each entry expires after ~3 seconds via a
    * client-side timer. Used by `DiffHighlight` to transiently highlight the
@@ -202,7 +211,8 @@ interface TripState {
   applyStageUpdate: (stageIndex: number, stage: StageData) => void;
   /**
    * Mark a set of stage indices as "recomputing" — their cards show a shimmer
-   * skeleton until the corresponding `stage_updated` events arrive.
+   * skeleton until the corresponding `stage_updated` events arrive. Also bumps
+   * {@link recomputeVersion} so overlapping edits can be disambiguated (#840).
    */
   startStageRecomputation: (indices: number[]) => void;
   /**
@@ -273,6 +283,7 @@ const initialState = {
   stages: [],
   computationStatus: {},
   recomputingStages: new Set<number>(),
+  recomputeVersion: 0,
   stageDiffs: new Map<number, Set<string>>(),
   pendingModifications: [] as Modification[],
   selectedStageIndex: 0,
@@ -403,6 +414,13 @@ export const useTripStore = create<TripState>()(
         const max = Math.max(0, stages.length - 1);
         if (state.selectedStageIndex > max) {
           state.selectedStageIndex = max;
+        }
+        // Drop recomputing markers for indices that no longer exist after the
+        // array changed length. Otherwise a phantom index (e.g. a stage that
+        // vanished when the day count shrank) is never cleared by a matching
+        // `stage_updated`, holding the `processing` overlay open forever (#840).
+        for (const i of [...state.recomputingStages]) {
+          if (i >= state.stages.length) state.recomputingStages.delete(i);
         }
       }),
 
@@ -743,7 +761,17 @@ export const useTripStore = create<TripState>()(
     applyStageUpdate: (stageIndex, stage) =>
       set((state) => {
         const prev = state.stages[stageIndex];
-        if (!prev) return;
+        if (!prev) {
+          // Reducing the last stage's distance splits off a brand-new trailing
+          // day on the backend (StageUpdateProcessor::applyDistanceChange),
+          // whose `stage_updated` lands at the next contiguous index. Append it
+          // so the new day is not silently dropped (#840). A larger index can
+          // only be a stale/obsolete event, so ignore it.
+          if (stageIndex === state.stages.length) {
+            state.stages.push(stage);
+          }
+          return;
+        }
 
         const endMatch =
           prev.endPoint.lat === stage.endPoint.lat &&
@@ -796,6 +824,9 @@ export const useTripStore = create<TripState>()(
 
     startStageRecomputation: (indices) =>
       set((state) => {
+        // Bump the concurrency token so a rapid follow-up edit supersedes any
+        // in-flight safety-net timer keyed to the previous value (#840).
+        state.recomputeVersion += 1;
         for (const index of indices) {
           state.recomputingStages.add(index);
         }

--- a/pwa/src/store/trip-store.ts
+++ b/pwa/src/store/trip-store.ts
@@ -360,6 +360,21 @@ export function getUndoableSlice(state: {
  */
 type StageAlert = AlertData & { _group?: string };
 
+/**
+ * Drop recompute markers for indices that fell out of bounds after the stage
+ * array changed length. Shared by every mutation that resizes `state.stages`
+ * (resync, delete, rest-day/placeholder insert) so an in-flight recompute
+ * never holds the `processing` overlay open on a phantom index (#840).
+ */
+function pruneStaleRecomputing(state: {
+  stages: StageData[];
+  recomputingStages: Set<number>;
+}): void {
+  for (const i of [...state.recomputingStages]) {
+    if (i >= state.stages.length) state.recomputingStages.delete(i);
+  }
+}
+
 export const useTripStore = create<TripState>()(
   immer((set) => ({
     ...initialState,
@@ -419,9 +434,7 @@ export const useTripStore = create<TripState>()(
         // array changed length. Otherwise a phantom index (e.g. a stage that
         // vanished when the day count shrank) is never cleared by a matching
         // `stage_updated`, holding the `processing` overlay open forever (#840).
-        for (const i of [...state.recomputingStages]) {
-          if (i >= state.stages.length) state.recomputingStages.delete(i);
-        }
+        pruneStaleRecomputing(state);
       }),
 
     updateStageWeather: (dayNumber, weather) =>
@@ -612,6 +625,9 @@ export const useTripStore = create<TripState>()(
         if (state.selectedStageIndex > max) {
           state.selectedStageIndex = max;
         }
+        // The array shrank: drop recompute markers that fell out of bounds so a
+        // structural edit mid-recompute can't strand the overlay (#840).
+        pruneStaleRecomputing(state);
         // Shrink the trip's day window to match the new stage count (recette
         // #649) — see insertRestDay.
         if (state.startDate) {
@@ -656,6 +672,7 @@ export const useTripStore = create<TripState>()(
         state.stages.forEach((s, i) => {
           s.dayNumber = i + 1;
         });
+        pruneStaleRecomputing(state);
         // A trip spans one calendar day per stage (rest days included): extend
         // the end date so the global range and the export reflect the new day
         // immediately (recette #649). The backend mirrors this on persist.
@@ -677,6 +694,7 @@ export const useTripStore = create<TripState>()(
         state.stages.forEach((s, i) => {
           s.dayNumber = i + 1;
         });
+        pruneStaleRecomputing(state);
         // Extend the trip's day window to match the new stage count (recette
         // #649) — see insertRestDay.
         if (state.startDate) {

--- a/pwa/src/store/trip-store.ts
+++ b/pwa/src/store/trip-store.ts
@@ -787,6 +787,16 @@ export const useTripStore = create<TripState>()(
           // only be a stale/obsolete event, so ignore it.
           if (stageIndex === state.stages.length) {
             state.stages.push(stage);
+            // Keep the trip's day window in sync with the new stage count,
+            // mirroring insertRestDay/insertStagePlaceholder/deleteStage
+            // (recette #649). Otherwise a last-stage edit that splits off a
+            // day leaves endDate one day short for downstream readers
+            // (trip-summary, infographic export, date-range-picker, shared page).
+            if (state.startDate) {
+              state.endDate = dayjs(state.startDate)
+                .add(state.stages.length - 1, "day")
+                .format("YYYY-MM-DD");
+            }
           }
           return;
         }


### PR DESCRIPTION
Closes #840.

## Contexte
Feedback Thomas (#830) : petits bugs en stressant l'app, en changeant la distance depuis la dernière carte.

## Cause racine
Modifier la distance de la dernière étape scinde un nouveau jour côté backend (`range(index, count-1)`), mais le front ne suivait le recompute que par index positionnel : le `stage_updated` du nouveau jour tombait hors bornes (jour perdu), et aucun jeton de version ne protégeait contre les events obsolètes d'éditions rapides (overlay `processing` bloqué).

## Changements
- **Jeton de version** `recomputeVersion` (compteur monotone) incrémenté par `startStageRecomputation` ; `handleDistanceChange` le capture et arme un filet de sécurité (30s) qui ne lève l'overlay que si le jeton est toujours courant (une édition suivante le neutralise). Timer nettoyé à l'unmount.
- `applyStageUpdate` : append du nouveau jour quand l'event tombe sur l'index contigu suivant ; events plus lointains ignorés (stale).
- `setStages` : purge des indices `recomputingStages` hors bornes quand le nombre d'étapes rétrécit.
- `handleDistanceChange` marque toute la plage `index..fin` (reflète le backend).
- 5 tests dans `trip-store.test.ts` (bloc concurrency guard).

## Auto-critique
- 100% frontend ; vitest store 29/29, tsc/ESLint/Prettier verts. Legs PHP en CI (rector OOM local).
- Chevauche `use-trip-planner.ts` avec #845 (#835 toast import) : fonctions disjointes, conflit de merge possible selon l'ordre.

<!-- claude-review-start -->
## Claude Review

**Summary:** No new findings. The previously flagged safety-net timer trip-switch bug was fixed in 40c1dbac (the timer now captures the trip id at arm time and bails if the active trip changed, and the cleanup effect now also re-runs on `tripId` change). No correctness, security, or performance issues found in this round.

**Resolved threads:** Resolved 1 previously open thread — the safety-net timer trip-switch race, confirmed fixed in 40c1dbac. The E2E test-coverage thread on `armRecomputeSafetyNet` remains open — the author has explicitly deferred it as a follow-up and it is non-blocking.

### Review checklist
- [x] Code respects the project architecture (local-first Zustand store, no backend/DTO contract change)
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate (concurrency token now correctly scoped to the trip session)
- [x] Tests cover new/changed cases (store-level reducer logic and endDate invariant covered; hook-level timer/token wiring remains untested per the deferred, non-blocking thread)
- [x] Documentation is up to date
- [x] Dependent tickets accounted for (PR body flags the #845 merge-conflict risk)

**Inline comments:** No inline comments.

_Reviewed commit: 40c1dbac23b786236475684a299ad6083be8c08d_
<!-- claude-review-end -->