### PR TITLE
fix(docker): boot make start with local iso-prod secrets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,18 @@ start-dev: ensure-default-pbf ## Start the Docker environment (Detached) in deve
 build: ## Build the Docker environment in production mode
 	@docker compose -f compose.yaml build
 
-start: ensure-default-pbf ## Start the Docker environment (Detached) in production mode
-	@docker compose -f compose.yaml up --wait
+# compose.yaml keeps the iso-prod fail-closed defaults (read as-is by CI/Coolify):
+# the prod entrypoint refuses to boot on a default/unset Mercure key (SEC-004) or
+# AI token-encryption key (SEC-003), and reads the JWT keypair from Docker secrets.
+# So `make start` supplies non-default local placeholders + the generated keypair to
+# boot, mirroring the CI env and the compose.recette.yaml overlay.
+start: ensure-default-pbf ensure-jwt-recette ## Start the Docker environment (Detached) in production mode
+	@MERCURE_JWT_KEY=local-iso-prod-mercure-key \
+		AI_TOKEN_ENC_KEY=local-iso-prod-ai-enc-key \
+		JWT_PASSPHRASE=recette \
+		JWT_PRIVATE_KEY_PATH=.docker/jwt-recette/private.pem \
+		JWT_PUBLIC_KEY_PATH=.docker/jwt-recette/public.pem \
+		docker compose -f compose.yaml up --wait
 
 start-recette: ensure-default-pbf ensure-jwt-recette ## Boot iso-prod + Mailcatcher for the recette. Re-routing needs `make provision` + `--profile routing`.
 	@docker compose -f compose.yaml -f compose.recette.yaml up --wait


### PR DESCRIPTION
## Summary

`make start` (plain iso-prod boot) stopped working after the recent security merges. The SEC-004 (#820) and SEC-003 (#823) fail-closed entrypoint guards refuse to boot the prod image when `MERCURE_JWT_SECRET` is the API Platform skeleton default or `AI_TOKEN_ENC_KEY` is unset, and the prod JWT keypair (Docker secret) was absent locally. CI (`ci.yml`) and `make start-recette` (via `compose.recette.yaml` + `ensure-jwt-recette`) were wired for the guards; the `start` target was missed, so `docker compose -f compose.yaml up --wait` resolved `MERCURE_JWT_SECRET='!ChangeThisMercureHubJWTSecretKey!'` / `AI_TOKEN_ENC_KEY=''` and the php container exited at boot.

## Changes

- `make start`: supply non-default **local placeholders** (`MERCURE_JWT_KEY`, `AI_TOKEN_ENC_KEY`, `JWT_PASSPHRASE`) and point the JWT Docker secret at the `ensure-jwt-recette` keypair, mirroring the CI env and the `compose.recette.yaml` overlay. `compose.yaml` keeps its fail-closed iso-prod defaults untouched (read as-is by CI/Coolify), so the security posture is unchanged.

## Bug fix

- [ ] Linked GlitchTip event ID and related incident issue (if applicable) — N/A (local tooling regression, no runtime incident)

## Test plan

- [ ] `make qa` passes — not run locally: the diff is Makefile-only and touches no linted file (prettier/eslint/phpstan/markdownlint targets are unaffected); CI gates full QA on this PR.
- [ ] New/updated tests cover changed behavior — N/A (build/tooling target)
- [x] Manual verification (below)

Manual verification — `make start` from a clean worktree project (existing `:ci` images, no rebuild):

- `docker compose -f compose.yaml up --wait` → **EXIT 0**; all 7 services healthy (`database`, `redis`, `php`, `pwa`, `worker`×2, `worker-llm`)
- `GET https://localhost/api/healthz` → **200**
- `GET https://localhost/` (`Accept: text/html`) → **200**, Next.js landing + enforced CSP header
- `bin/console lexik:jwt:check-config` → *"The configuration seems correct."* (keypair + passphrase load)

## Verification

- [ ] Related runbook updated if applicable — N/A
- [x] No prod secret introduced/removed: the added values are throwaway **local** placeholders for the dev-convenience `start` target; the prod secrets (`MERCURE_JWT_KEY` / `AI_TOKEN_ENC_KEY` / `JWT_PASSPHRASE`) are unchanged, so `docs/runbooks/secrets-inventory.md` needs no update.

## Auto-critique

- [x] No leftover debug statements
- [x] No stale TODO/FIXME
- [x] No dead code
- [x] Respects project architecture (compose.yaml stays iso-prod; local wiring lives only in the Makefile target, like `start-recette`)
- [x] No backend DTO change → no `make typegen` needed

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 findings (critical: 0, warning: 0, nitpick: 0 — nitpicks suppressed per review policy).

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases (N/A — Makefile-only tooling fix, verified manually per test plan)
- [x] Documentation is up to date
- [x] Dependent tickets accounted for (SEC-003 #823, SEC-004 #820)

**Commit reviewed:** `43fd4aca38826b1ec323990e37da3ac46423c955`
<!-- claude-review-end -->