### PR TITLE
fix(terrain): attribute ways to the ridden route, not to a 100 m neighbourhood

### DIFF
--- a/api/src/MessageHandler/AnalyzeTerrainHandler.php
+++ b/api/src/MessageHandler/AnalyzeTerrainHandler.php
@@ -24,8 +24,14 @@ use Symfony\Component\Messenger\MessageBusInterface;
 #[AsMessageHandler]
 final readonly class AnalyzeTerrainHandler extends AbstractTripMessageHandler
 {
-    /** Corridor half-width (m) for the local-first ways reads (ADR-040). */
-    private const int WAYS_CORRIDOR_RADIUS_METERS = 100;
+    /**
+     * Corridor half-width (m) for the local-first ways reads (ADR-040). Sized on
+     * the route's own positional error -- Douglas-Peucker decimation at 20 m
+     * (ADR-004) dominates GPS noise -- so a way actually ridden stays inside it,
+     * while roads merely running alongside (greenway next to a trunk road) fall
+     * out instead of being counted as ridden.
+     */
+    private const int WAYS_CORRIDOR_RADIUS_METERS = 20;
 
     public function __construct(
         ComputationTrackerInterface $computationTracker,
@@ -108,8 +114,9 @@ final readonly class AnalyzeTerrainHandler extends AbstractTripMessageHandler
 
     /**
      * Reads OSM ways along the route from the local-first index and distributes
-     * them to stages (ADR-040). The index already reduces each way to its centroid,
-     * length (m) and surface/traffic tags, so no per-way geometry math is needed here.
+     * them to stages (ADR-040). The index already reduces each way to the centroid
+     * and length (m) of its portion inside the corridor plus the surface/traffic
+     * tags, so no per-way geometry math is needed here.
      *
      * @param list<Stage> $stages
      *

--- a/api/src/Osm/WaysRepository.php
+++ b/api/src/Osm/WaysRepository.php
@@ -7,20 +7,26 @@ namespace App\Osm;
 use Doctrine\DBAL\Connection;
 
 /**
- * Reads highway ways from the local-first Tier-1 index along the route corridor
- * (ST_DWithin), replacing the runtime Overpass ways scan (ADR-040). Each way is
- * reduced in SQL to the shape the terrain analyzers consume: centroid + length
- * (meters, via geography) + the surface/traffic tags. The full linestring stays
- * in the table; only the derived fields cross the wire.
+ * Reads highway ways from the local-first Tier-1 index along the route corridor,
+ * replacing the runtime Overpass ways scan (ADR-040). Each way is reduced in SQL
+ * to the shape the terrain analyzers consume: centroid + length (meters, via
+ * geography) + the surface/traffic tags. The full linestring stays in the table;
+ * only the derived fields cross the wire.
+ *
+ * Both the length and the centroid describe the *clipped* way -- the portion
+ * running inside the metric corridor -- not the whole way. A 40 km departemental
+ * that shares 200 m with the route contributes 200 m to the surface / traffic
+ * totals, and its centroid lands on that shared portion so the stage
+ * distribution (GeometryBasedDistributor) attributes it to the right day.
  *
  * This is the only Tier-1 corridor scan that runs against linestrings of the
  * whole road network (the POI tables hold sparse points), so the per-row
  * `geom::geography` cast that defeats the GiST index is unacceptable here. The
- * query keeps the exact ST_DWithin(geography, 100 m) predicate but gates it
- * behind an index-usable `geom && <expanded bbox>` pre-filter (ADR-043, PR1):
- * the bounding box strictly contains the 100 m corridor, so the candidate set
- * is a superset and the returned ways are byte-for-byte identical to the
- * unoptimised scan. See WaysIndexReadTest for the behaviour guard.
+ * metric predicate is an intersection with the buffered corridor, gated behind
+ * an index-usable `geom && <expanded bbox>` pre-filter (ADR-043, PR1): the
+ * bounding box strictly contains the corridor, so the candidate set is a
+ * superset and the result is identical to the unfiltered scan. See
+ * WaysIndexReadTest for the behaviour guard.
  *
  * @phpstan-type WayRow = array{lat: float, lon: float, surface: string, highway: string, cycleway: string, 'cycleway:right': string, 'cycleway:left': string, 'cycleway:both': string, bicycle: string, maxspeed: string, length: float}
  */
@@ -53,8 +59,8 @@ final readonly class WaysRepository implements WaysRepositoryInterface
                     -- metres-per-degree shrink with latitude, so divide by the
                     -- cosine at the envelope's highest |lat| (the widest box, the
                     -- safe over-cover), clamped to keep the box finite near the
-                    -- poles. The result strictly contains the metric ST_DWithin
-                    -- corridor, so the candidate set is a superset.
+                    -- poles. The result strictly contains the metric corridor
+                    -- below, so the candidate set is a superset.
                     SELECT ST_Expand(
                         ST_Envelope(geom),
                         :radius / (111320.0 * GREATEST(
@@ -70,28 +76,45 @@ final readonly class WaysRepository implements WaysRepositoryInterface
                         :radius / 111320.0
                     ) AS geom
                     FROM corridor
+                ),
+                ridden AS MATERIALIZED (
+                    -- The metric corridor itself: the route line buffered by the
+                    -- radius in metres (geography buffer, i.e. projected by PostGIS
+                    -- in the best local SRID, so the width is metric everywhere).
+                    -- MATERIALIZED is load-bearing: inlined, the buffer of a ~1.5k
+                    -- point route would be rebuilt for every candidate row.
+                    SELECT ST_Buffer(geom::geography, :radius)::geometry AS geom
+                    FROM corridor
+                ),
+                followed AS MATERIALIZED (
+                    -- Clip each candidate way to the corridor. Materialised so the
+                    -- clip runs once per way and feeds both the length and the
+                    -- centroid below.
+                    SELECT w.tags AS tags,
+                           ST_Intersection(w.geom, r.geom) AS geom
+                    FROM osm.ways AS w,
+                         bbox AS b,
+                         ridden AS r
+                    WHERE w.geom && b.geom
+                      AND ST_Intersects(w.geom, r.geom)
                 )
                 SELECT ST_Y(_c.centroid) AS lat,
                        ST_X(_c.centroid) AS lon,
-                       ST_Length(w.geom::geography) AS length,
-                       w.tags->>'surface' AS surface,
-                       w.tags->>'highway' AS highway,
-                       w.tags->>'cycleway' AS cycleway,
-                       w.tags->>'cycleway:right' AS cycleway_right,
-                       w.tags->>'cycleway:left' AS cycleway_left,
-                       w.tags->>'cycleway:both' AS cycleway_both,
-                       w.tags->>'bicycle' AS bicycle,
-                       w.tags->>'maxspeed' AS maxspeed
-                FROM osm.ways AS w,
-                     corridor AS c,
-                     bbox AS b,
-                     LATERAL (SELECT ST_Centroid(w.geom) AS centroid) AS _c
-                WHERE w.geom && b.geom
-                  AND ST_DWithin(
-                      w.geom::geography,
-                      c.geom::geography,
-                      :radius
-                  )
+                       _l.length AS length,
+                       f.tags->>'surface' AS surface,
+                       f.tags->>'highway' AS highway,
+                       f.tags->>'cycleway' AS cycleway,
+                       f.tags->>'cycleway:right' AS cycleway_right,
+                       f.tags->>'cycleway:left' AS cycleway_left,
+                       f.tags->>'cycleway:both' AS cycleway_both,
+                       f.tags->>'bicycle' AS bicycle,
+                       f.tags->>'maxspeed' AS maxspeed
+                FROM followed AS f,
+                     LATERAL (SELECT ST_Length(f.geom::geography) AS length) AS _l,
+                     LATERAL (SELECT ST_Centroid(f.geom) AS centroid) AS _c
+                -- Ways that only graze the corridor boundary clip to an empty or
+                -- punctual geometry: they are not followed, so they are dropped.
+                WHERE _l.length > 0
                 SQL,
             [
                 'wkt' => WktGeometry::lineStringOrPoint($route),

--- a/api/src/Osm/WaysRepositoryInterface.php
+++ b/api/src/Osm/WaysRepositoryInterface.php
@@ -7,9 +7,11 @@ namespace App\Osm;
 interface WaysRepositoryInterface
 {
     /**
-     * Highway ways whose geometry is within $radiusMeters of the route corridor,
-     * each reduced to its centroid, length (m) and the tags the terrain analyzers
-     * read (surface, highway, cycleway*, bicycle, maxspeed).
+     * Highway ways whose geometry runs within $radiusMeters of the route corridor,
+     * each reduced to the tags the terrain analyzers read (surface, highway,
+     * cycleway*, bicycle, maxspeed) plus the centroid and the length (m) of the
+     * portion inside the corridor -- not of the whole way, so a way the route only
+     * brushes weighs no more than the metres actually shared with it.
      *
      * @param list<array{lat: float, lon: float}> $route
      *

--- a/api/tests/Integration/Osm/WaysIndexReadTest.php
+++ b/api/tests/Integration/Osm/WaysIndexReadTest.php
@@ -13,8 +13,8 @@ use Zenstruck\Foundry\Test\ResetDatabase;
 
 /**
  * Integration coverage for the local-first ways read layer (ADR-040): seeds real
- * PostGIS LineStrings in osm.ways and asserts the ST_DWithin corridor filtering
- * plus the centroid / geography-length / tag projection the terrain analyzers consume.
+ * PostGIS LineStrings in osm.ways and asserts the corridor filtering plus the
+ * centroid / clipped-geography-length / tag projection the terrain analyzers consume.
  *
  * @phpstan-import-type WayRow from WaysRepository
  */
@@ -22,10 +22,19 @@ final class WaysIndexReadTest extends KernelTestCase
 {
     use ResetDatabase;
 
+    /** The production corridor half-width (AnalyzeTerrainHandler). */
+    private const int RADIUS_METERS = 20;
+
     /** Route running along the seeded secondary road. */
     private const array CORRIDOR_ROUTE = [
         ['lat' => 49.60, 'lon' => 6.13],
         ['lat' => 49.62, 'lon' => 6.15],
+    ];
+
+    /** Straight west-east route at lat 49.60, ~7.2 km long, for the clipping cases. */
+    private const array STRAIGHT_ROUTE = [
+        ['lat' => 49.60, 'lon' => 6.10],
+        ['lat' => 49.60, 'lon' => 6.20],
     ];
 
     private Connection $connection;
@@ -53,9 +62,9 @@ final class WaysIndexReadTest extends KernelTestCase
     #[Test]
     public function findInCorridorProjectsCentroidLengthAndTags(): void
     {
-        $ways = new WaysRepository($this->connection)->findInCorridor(self::CORRIDOR_ROUTE, 100);
+        $ways = new WaysRepository($this->connection)->findInCorridor(self::CORRIDOR_ROUTE, self::RADIUS_METERS);
 
-        // The far primary road is excluded by ST_DWithin.
+        // The far primary road is outside the corridor.
         self::assertCount(1, $ways);
 
         $way = $ways[0];
@@ -72,16 +81,68 @@ final class WaysIndexReadTest extends KernelTestCase
     }
 
     /**
+     * The measured length is the length of the portion running inside the corridor,
+     * and only the ways the route actually follows are returned. Four cases on the
+     * same straight route: followed end to end, followed for 200 m then leaving,
+     * parallel inside the radius, parallel outside it.
+     */
+    #[Test]
+    public function lengthIsClippedToTheCorridorAndParallelRoadsAreExcluded(): void
+    {
+        $this->connection->executeStatement('TRUNCATE osm.ways');
+        $this->connection->executeStatement(<<<'SQL'
+            INSERT INTO osm.ways (osm_id, tags, geom) VALUES
+              -- Followed end to end: the clipped length is the full length (~7229 m).
+              (20, '{"highway":"residential","surface":"asphalt"}'::jsonb,
+                   ST_SetSRID(ST_GeomFromText('LINESTRING(6.10 49.60, 6.20 49.60)'), 4326)),
+              -- 202 m along the route, then 5.5 km due south: a 5763 m way of which
+              -- only the shared part (plus the 20 m the corridor extends over the
+              -- turn) may be counted.
+              (21, '{"highway":"unclassified","surface":"gravel"}'::jsonb,
+                   ST_SetSRID(ST_GeomFromText('LINESTRING(6.10 49.60, 6.1028 49.60, 6.1028 49.55)'), 4326)),
+              -- Parallel 40 m north (the greenway-along-a-trunk-road false positive
+              -- the 100 m corridor used to report): beyond the radius, dropped.
+              (22, '{"highway":"trunk","surface":"asphalt"}'::jsonb,
+                   ST_SetSRID(ST_GeomFromText('LINESTRING(6.12 49.6003593, 6.18 49.6003593)'), 4326)),
+              -- Parallel 10 m north: within GPS/decimation error, still followed.
+              (23, '{"highway":"service","surface":"asphalt"}'::jsonb,
+                   ST_SetSRID(ST_GeomFromText('LINESTRING(6.12 49.6000898, 6.18 49.6000898)'), 4326))
+            SQL);
+
+        $ways = new WaysRepository($this->connection)->findInCorridor(self::STRAIGHT_ROUTE, self::RADIUS_METERS);
+
+        $byHighway = [];
+        foreach ($ways as $way) {
+            $byHighway[$way['highway']] = $way;
+        }
+
+        // The trunk road running 40 m alongside is not part of the ride.
+        $highways = array_keys($byHighway);
+        sort($highways);
+        self::assertSame(['residential', 'service', 'unclassified'], $highways);
+        // Non-regression: a way followed from end to end keeps its full length.
+        self::assertEqualsWithDelta(7228.9, $byHighway['residential']['length'], 1.0);
+        // Clipped: 202 m shared + the 20 m of the southern branch inside the corridor,
+        // instead of the 5763 m of the whole way.
+        self::assertEqualsWithDelta(222.4, $byHighway['unclassified']['length'], 1.0);
+        // The centroid describes the clipped portion too, so the stage distribution
+        // sees the way where the route meets it, not 3 km south.
+        self::assertEqualsWithDelta(49.60, $byHighway['unclassified']['lat'], 0.001);
+        self::assertEqualsWithDelta(6.1015, $byHighway['unclassified']['lon'], 0.001);
+        self::assertEqualsWithDelta(4337.3, $byHighway['service']['length'], 1.0);
+    }
+
+    /**
      * Behaviour guard for the index-friendly rewrite (ADR-043, PR1): the bbox
      * pre-filter must not change which ways the corridor scan returns. We seed a
      * varied network -- in/out of the corridor, mixed highway/surface tags, and a
-     * way whose bounding box overlaps the corridor envelope yet sits >100 m from
-     * the route (a bbox false positive the metric ST_DWithin must still reject) --
-     * and assert the optimised query returns exactly the same set as the original
-     * naive `geom::geography` scan run against the same data.
+     * way whose bounding box overlaps the corridor envelope yet sits ~600 m from
+     * the route (a bbox false positive the metric predicate must still reject) --
+     * and assert the optimised query returns exactly the same set as the same clip
+     * run without the bbox pre-filter against the same data.
      */
     #[Test]
-    public function indexFriendlyScanMatchesTheNaiveCorridorScan(): void
+    public function indexFriendlyScanMatchesTheUnfilteredCorridorScan(): void
     {
         $this->connection->executeStatement('TRUNCATE osm.ways');
         $this->connection->executeStatement(<<<'SQL'
@@ -96,7 +157,7 @@ final class WaysIndexReadTest extends KernelTestCase
               (12, '{"highway":"residential"}'::jsonb,
                    ST_SetSRID(ST_GeomFromText('LINESTRING(6.140 49.610, 6.142 49.612)'), 4326)),
               -- Bbox false positive: within the padded envelope but ~600 m north of
-              -- the route line, so excluded by the 100 m metric predicate.
+              -- the route line, so excluded by the metric predicate.
               (13, '{"highway":"primary","surface":"asphalt"}'::jsonb,
                    ST_SetSRID(ST_GeomFromText('LINESTRING(6.138 49.6165, 6.142 49.6165)'), 4326)),
               -- Far outside the corridor entirely.
@@ -104,8 +165,8 @@ final class WaysIndexReadTest extends KernelTestCase
                    ST_SetSRID(ST_GeomFromText('LINESTRING(6.80 49.90, 6.81 49.91)'), 4326))
             SQL);
 
-        $expected = $this->naiveCorridorScan(self::CORRIDOR_ROUTE, 100);
-        $actual = new WaysRepository($this->connection)->findInCorridor(self::CORRIDOR_ROUTE, 100);
+        $expected = $this->unfilteredCorridorScan(self::CORRIDOR_ROUTE, self::RADIUS_METERS);
+        $actual = new WaysRepository($this->connection)->findInCorridor(self::CORRIDOR_ROUTE, self::RADIUS_METERS);
 
         // Order is not guaranteed by either query; compare as sets keyed by centroid.
         usort($expected, $this->byCentroid(...));
@@ -120,26 +181,34 @@ final class WaysIndexReadTest extends KernelTestCase
     #[Test]
     public function emptyRouteYieldsNoQuery(): void
     {
-        self::assertSame([], new WaysRepository($this->connection)->findInCorridor([], 100));
+        self::assertSame([], new WaysRepository($this->connection)->findInCorridor([], self::RADIUS_METERS));
     }
 
     /**
-     * The pre-optimisation query (per-row `geom::geography`, no bbox pre-filter),
-     * used as the behaviour oracle. Projects the exact same columns/shape as
-     * WaysRepository so the two results are directly comparable.
+     * The same corridor clip without the index-usable bbox pre-filter, used as the
+     * behaviour oracle. Projects the exact same columns/shape as WaysRepository so
+     * the two results are directly comparable.
      *
      * @param list<array{lat: float, lon: float}> $route
      *
      * @return list<WayRow>
      */
-    private function naiveCorridorScan(array $route, int $radiusMeters): array
+    private function unfilteredCorridorScan(array $route, int $radiusMeters): array
     {
         /** @var list<array<string, scalar|null>> $rows */
         $rows = $this->connection->fetchAllAssociative(
             <<<'SQL'
+                WITH ridden AS MATERIALIZED (
+                    SELECT ST_Buffer(ST_SetSRID(ST_GeomFromText(:wkt), 4326)::geography, :radius)::geometry AS geom
+                ),
+                followed AS MATERIALIZED (
+                    SELECT w.tags AS tags, ST_Intersection(w.geom, r.geom) AS geom
+                    FROM osm.ways AS w, ridden AS r
+                    WHERE ST_Intersects(w.geom, r.geom)
+                )
                 SELECT ST_Y(_c.centroid) AS lat,
                        ST_X(_c.centroid) AS lon,
-                       ST_Length(geom::geography) AS length,
+                       _l.length AS length,
                        tags->>'surface' AS surface,
                        tags->>'highway' AS highway,
                        tags->>'cycleway' AS cycleway,
@@ -148,13 +217,10 @@ final class WaysIndexReadTest extends KernelTestCase
                        tags->>'cycleway:both' AS cycleway_both,
                        tags->>'bicycle' AS bicycle,
                        tags->>'maxspeed' AS maxspeed
-                FROM osm.ways,
-                LATERAL (SELECT ST_Centroid(geom) AS centroid) AS _c
-                WHERE ST_DWithin(
-                    geom::geography,
-                    ST_SetSRID(ST_GeomFromText(:wkt), 4326)::geography,
-                    :radius
-                )
+                FROM followed AS f,
+                     LATERAL (SELECT ST_Length(f.geom::geography) AS length) AS _l,
+                     LATERAL (SELECT ST_Centroid(f.geom) AS centroid) AS _c
+                WHERE _l.length > 0
                 SQL,
             [
                 'wkt' => WktGeometry::lineStringOrPoint($route),

--- a/api/tests/Unit/MessageHandler/AnalyzeTerrainHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/AnalyzeTerrainHandlerTest.php
@@ -51,7 +51,7 @@ final class AnalyzeTerrainHandlerTest extends TestCase
         $repository = $this->createStub(WaysRepositoryInterface::class);
         $repository->method('findInCorridor')->willReturnCallback(
             static function (array $route, int $radiusMeters) use ($ways): array {
-                self::assertSame(100, $radiusMeters, 'findInCorridor must use the 100 m ways corridor');
+                self::assertSame(20, $radiusMeters, 'findInCorridor must use the 20 m ways corridor');
 
                 return $ways;
             },
@@ -225,7 +225,7 @@ final class AnalyzeTerrainHandlerTest extends TestCase
         $waysRepository = $this->createStub(WaysRepositoryInterface::class);
         $waysRepository->method('findInCorridor')->willReturnCallback(
             static function (array $route, int $radiusMeters): array {
-                self::assertSame(100, $radiusMeters);
+                self::assertSame(20, $radiusMeters);
                 self::assertSame([
                     ['lat' => 48.0, 'lon' => 2.0],
                     ['lat' => 48.25, 'lon' => 2.25],


### PR DESCRIPTION
## Summary

Closes #859.

`WaysRepository::findInCorridor()` returned each way's **total** length in the database and used a **100 m** corridor. A 40 km departmental road brushing the corridor for 200 m contributed 40 000 m to `SurfaceAlertAnalyzer` / `TrafficDangerAnalyzer`, and a national road running parallel to a greenway was counted as "dangerous traffic" on a road the rider never uses. Both halves are fixed here: clipping alone would reduce the magnitude without fixing the attribution.

## Changes

- `api/src/Osm/WaysRepository.php` — the corridor becomes a metric polygon (`ST_Buffer(route::geography, :radius)::geometry`, CTE `ridden AS MATERIALIZED`) and every candidate way is **clipped** to it (CTE `followed AS MATERIALIZED`). `ST_Length(w.geom::geography)` becomes `ST_Length(<intersection>::geography)`, and the **centroid now describes the clipped portion too** — otherwise a 40 km way shared over 200 m gets distributed to the wrong stage by `GeometryBasedDistributor`. Metric predicate `ST_Intersects(w.geom, r.geom)` + `WHERE _l.length > 0` discards ways that only graze the boundary.
- `MATERIALIZED` is load-bearing: inlined, the buffer of a 1 500-point route was recomputed for **every** candidate row (59.8 s measured vs 0.6 s materialized).
- `api/src/MessageHandler/AnalyzeTerrainHandler.php` — `WAYS_CORRIDOR_RADIUS_METERS` 100 → **20** (the radius is a `findInCorridor()` parameter, so the tightening happens at the call site).
- `api/src/Osm/WaysRepositoryInterface.php` — contract documented. `WayRow` keys unchanged; `SurfaceAlertAnalyzer` and `TrafficDangerAnalyzer` are untouched.
- The ADR-043 bbox pre-filter is preserved verbatim.

## Why 20 m

- **Lower bound (false negatives):** the stored route is Douglas-Peucker decimated to **20 m** (ADR-004), so the polyline can sit up to 20 m off the real track; add consumer GPS noise (~5-10 m) and the centreline offset of OSM dual carriageways. 20 m aligns the radius on the dominant term instead of dipping below it. Under ~15 m we start losing true positives.
- **Upper bound (false positives):** the patterns that polluted traffic alerts — greenway on a former railway or towpath alongside a national road, service road, parallel departmental — sit tens to hundreds of metres away. At 100 m they were all captured; at 20 m they drop out. Sub-10 m separations (cycle lane hugging the carriageway) are not separable by any radius and are not the target case.
- **Bounded side effect:** the buffer's round caps add at most one radius (20 m) where a way leaves the corridor — visible in the test (202 m shared, measured 222 m). Negligible against the order-of-magnitude error it fixes.

## EXPLAIN — the GiST index is still used

Test set: `osm.ways` = 300 000 synthetic linestrings, 1 500-point route (~100 km), radius 20 m, PostGIS 3.6.4 / PG 18. Query = exactly the one committed.

```
 CTE Scan on followed f  (cost=71.94..74.49 rows=1 width=280) (actual time=24.996..626.670 rows=32.00 loops=1)
   Filter: (st_length((geom)::geography, true) > '0'::double precision)
   CTE followed
     ->  Nested Loop  (actual time=21.862..622.334 rows=32.00 loops=1)
           ->  CTE Scan on ridden r  (actual time=19.880..19.993 rows=1.00 loops=1)
           ->  Nested Loop  (actual time=0.965..574.535 rows=32.00 loops=1)
                 ->  CTE Scan on corridor corridor_1
                 ->  Index Scan using ways_geom_idx on ways w  (actual time=0.912..574.390 rows=32.00 loops=1)
                       Index Cond: ((geom && st_expand(st_envelope(corridor_1.geom), ...)) AND (geom && r.geom))
                       Filter: st_intersects(geom, r.geom)
                       Rows Removed by Filter: 22468
                       Index Searches: 1
 Planning Time: 4.659 ms
 Execution Time: 627.203 ms
```

`Index Scan using ways_geom_idx`, `Index Cond` = the ADR-043 `ST_Expand(ST_Envelope(...))` (PostGIS adds its own `geom && r.geom`). No per-row `geom::geography` in the predicate.

**Perf bonus:** same data, same radius, pre-patch query → `Execution Time: 15105.513 ms`. **15.1 s → 0.63 s**, from the disappearance of the per-row `::geography` cast. Worth noting for ADR-043, which listed this scan as a structural over-budget item.

## Test plan

- [x] New/updated tests cover changed behavior — `api/tests/Integration/Osm/WaysIndexReadTest.php`: new `lengthIsClippedToTheCorridorAndParallelRoadsAreExcluded` (4 cases: followed end-to-end → full length 7228.9 m; 5763 m way followed over 202 m → 222.4 m; parallel at 40 m → absent; parallel at 10 m → present 4337.3 m, plus a clipped-centroid assertion). The bbox guard oracle becomes `unfilteredCorridorScan()` (same clip without the pre-filter) instead of the old naive `ST_DWithin` scan. `api/tests/Unit/MessageHandler/AnalyzeTerrainHandlerTest.php`: radius assertions 100 → 20.
- [x] PHPUnit API full suite: `Tests: 1503, Assertions: 4458, Skipped: 1` — OK.
- [ ] `make qa` passes — **not reproducible locally**, see below. Relying on CI.

`make qa` does not complete on this host: the `rector` leg dies with `Child process error: Killed` (exit 137) because the `php` service is capped at 768M in `compose.yaml` while Rector spawns 13 workers and has no `--no-parallel` flag. Legs run individually, all green:

```
php-cs-fixer (api + provisioner)  Fixed 0 of 640 files / Fixed 0 of 21 files
rector (api + provisioner)        [OK] Rector is done!  (602 files) / [OK] Rector is done!  (22 files)
phpstan L9 (api + provisioner)    [OK] No errors / [OK] No errors
eslint                            0 errors, 3 warnings (pre-existing)
i18n-check                        OK: 917 keys in sync across fr, en
prettier                          All matched files use Prettier code style!
tsc --noEmit                      (no output)
markdownlint                      Summary: 0 error(s)
```

The 300 k synthetic ways inserted for the EXPLAIN were `TRUNCATE`d afterwards.

## Auto-critique

- [x] No leftover `console.log`, `dump()`, `dd()`, or debug statements
- [x] No stale TODO/FIXME comments
- [x] No dead code
- [x] Code respects the project architecture — the `WayRow` contract is unchanged, so both consuming analyzers are untouched by design
- [x] SOLID principles and Law of Demeter are followed
- [x] Documentation up to date — `WaysRepositoryInterface` now states that length and centroid describe the portion inside the corridor
- [x] No backend DTO change, so no `make typegen`

**Reviewer's attention:** the 20 m radius is a behavioural threshold, not a mechanical fix — it will make existing surface and traffic alerts markedly rarer and smaller. That is the point, but it is worth confirming on a real imported route that useful alerts survive. Also note `feature/860` adds two columns to the same `SELECT`; the conflict should be trivial but merge order matters.

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 findings (0 critical, 0 warning). Reviewed the corridor-clipping SQL rewrite in `WaysRepository::findInCorridor()`, the radius change, and test coverage — the implementation correctly matches issue #859's scope (clip length to the corridor intersection, tighten the radius to 20 m, weight by intersected length, preserve the ADR-043 bbox pre-filter). No correctness, security, or architecture issues found.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

**Commit reviewed:** `7d1c6b1e1076badee97c41748dec15586bc2e01e`
<!-- claude-review-end -->
