### PR TITLE
fix(alerts): rest-day guard, local-time sunset and multi-year calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ Rules are executed in priority order (lower = higher priority):
 | **Traffic** | 20 | ![warning](https://img.shields.io/badge/-warning-ed6c02) | Secondary road, no cycleway, `maxspeed` tagged and > 50 km/h |
 | **Traffic** | 20 | ![nudge](https://img.shields.io/badge/-nudge-0288d1) | Secondary road, no cycleway, `maxspeed` <= 50 km/h or absent/unreadable |
 | **E-bike range** | 20 | ![warning](https://img.shields.io/badge/-warning-ed6c02) | Day distance > effective range (80 km - elevation / 25); action navigates to the nearest charging station within 2 km, else suggests shortening the stage |
-| **Sunset** | 20 | ![warning](https://img.shields.io/badge/-warning-ed6c02) | Estimated arrival time exceeds civil twilight end at stage end point |
-| **Calendar** | -- | ![nudge](https://img.shields.io/badge/-nudge-0288d1) | Stage falls on a French public holiday |
+| **Sunset** | 20 | ![warning](https://img.shields.io/badge/-warning-ed6c02) | Estimated arrival time exceeds civil twilight end at stage end point (times shown in the stage's local timezone) |
+| **Calendar** | -- | ![nudge](https://img.shields.io/badge/-nudge-0288d1) | Stage falls on a public holiday of a country the route crosses, for any year the trip spans (France as fallback when no boundary resolves) |
 | **Calendar** | -- | ![nudge](https://img.shields.io/badge/-nudge-0288d1) | Stage falls on a Sunday (businesses may be closed) |
 | **Wind** | -- | ![warning](https://img.shields.io/badge/-warning-ed6c02) | Headwind >= 25 km/h on >= 60 % of stages with weather data |
 | **Comfort** | -- | ![warning](https://img.shields.io/badge/-warning-ed6c02) | Poor comfort index (< 40/100) on at least one stage |
@@ -146,6 +146,8 @@ Rules are executed in priority order (lower = higher priority):
 | **Ford** | -- | ![warning](https://img.shields.io/badge/-warning-ed6c02) | Stage crosses a ford and rain is forecast (precipitation probability >= 50 %): possibly impassable in high water |
 
 **Terrain rules** (Continuity, Elevation, Steep gradient, Surface, Traffic, E-bike range, Sunset, Rest day) implement `StageAnalyzerInterface` and are auto-discovered via `#[AutoconfigureTag('app.stage_analyzer')]`. Rules with `--` priority (Calendar, Wind + Comfort, Bike shops, Resupply, Accommodation, Water points, Cultural POI, Railway station, Health services, Border crossing, Ferry, Ford) are separate async Symfony Message handlers; Comfort is co-located with Wind inside `AnalyzeWindHandler`. Ford runs after the weather computation (its severity depends on the per-stage forecast).
+
+**Rest days** are skipped by every rule that describes riding (Elevation, Steep gradient, Surface, Traffic, E-bike range, Sunset, Bike shops, Water points, Resupply). Three rules run on rest days on purpose: Continuity (a rest day duplicates the previous stage's end point, so its check is the real gap between the two ridden stages around it), Health services (evaluated at the stage midpoint, i.e. where the rider stays all day) and Calendar (a holiday closes shops whether or not you pedal).
 
 ---
 

--- a/api/src/Analyzer/Rules/ContinuityAnalyzer.php
+++ b/api/src/Analyzer/Rules/ContinuityAnalyzer.php
@@ -14,6 +14,12 @@ use App\Enum\AlertType;
 use App\Format\DistanceFormatter;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+/**
+ * Deliberately has no `isRestDay` guard: a rest day duplicates the previous stage's
+ * end point as both its start and end, so the rest-day → next-stage check IS the real
+ * continuity check between the two ridden stages around it. Skipping rest days would
+ * silently drop a genuine route gap.
+ */
 final readonly class ContinuityAnalyzer implements StageAnalyzerInterface
 {
     private const float CRITICAL_THRESHOLD_METERS = 500.0;

--- a/api/src/Analyzer/Rules/EbikeRangeAnalyzer.php
+++ b/api/src/Analyzer/Rules/EbikeRangeAnalyzer.php
@@ -31,6 +31,12 @@ final readonly class EbikeRangeAnalyzer implements StageAnalyzerInterface
 
     public function analyze(Stage $stage, array $context = []): array
     {
+        // A rest day is not ridden: the battery is not drained, and it is where the
+        // bike gets charged anyway.
+        if ($stage->isRestDay) {
+            return [];
+        }
+
         if (true !== ($context['ebikeMode'] ?? false)) {
             return [];
         }

--- a/api/src/Analyzer/Rules/ElevationAlertAnalyzer.php
+++ b/api/src/Analyzer/Rules/ElevationAlertAnalyzer.php
@@ -23,6 +23,11 @@ final readonly class ElevationAlertAnalyzer implements StageAnalyzerInterface
 
     public function analyze(Stage $stage, array $context = []): array
     {
+        // A rest day is not ridden: it has no climbing to report.
+        if ($stage->isRestDay) {
+            return [];
+        }
+
         if ($stage->elevation <= self::THRESHOLD_METERS) {
             return [];
         }

--- a/api/src/Analyzer/Rules/SteepGradientAnalyzer.php
+++ b/api/src/Analyzer/Rules/SteepGradientAnalyzer.php
@@ -32,6 +32,11 @@ final readonly class SteepGradientAnalyzer implements StageAnalyzerInterface
 
     public function analyze(Stage $stage, array $context = []): array
     {
+        // A rest day is not ridden: it has no climb to report.
+        if ($stage->isRestDay) {
+            return [];
+        }
+
         $geometry = $stage->geometry;
         if (\count($geometry) < 2) {
             return [];

--- a/api/src/Analyzer/Rules/SunsetAlertAnalyzer.php
+++ b/api/src/Analyzer/Rules/SunsetAlertAnalyzer.php
@@ -63,6 +63,10 @@ final readonly class SunsetAlertAnalyzer implements StageAnalyzerInterface
         $baseDate = $startDate ?? new \DateTimeImmutable('today', new \DateTimeZone('UTC'));
         $stageDate = $baseDate->modify(\sprintf('+%d days', $stageIndex));
 
+        if (false === $stageDate) {
+            return [];
+        }
+
         // The rider's timezone at the stage end point: everything below is local time.
         $timezone = $this->timezoneResolver->resolve($stage->endPoint->lat, $stage->endPoint->lon);
 

--- a/api/src/Analyzer/Rules/SunsetAlertAnalyzer.php
+++ b/api/src/Analyzer/Rules/SunsetAlertAnalyzer.php
@@ -11,6 +11,7 @@ use App\ApiResource\Model\AlertActionKind;
 use App\ApiResource\Stage;
 use App\Engine\RiderTimeEstimatorInterface;
 use App\Enum\AlertType;
+use App\Geo\TimezoneResolverInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -19,6 +20,11 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  *
  * Uses PHP native date_sun_info() — no external API, no extra dependency.
  * Twilight threshold: CIVIL_TWILIGHT_END (sun 6° below horizon — still light enough to ride safely).
+ *
+ * Every hour handled here is the rider's local time at the stage end point: the
+ * timezone is resolved from the coordinates (TimezoneResolver), so the comparison
+ * against `departureHour` (local by definition) is homogeneous and the displayed
+ * sunset/twilight times match what the rider sees out the window.
  *
  * Context keys consumed:
  *  - 'startDate'     (\DateTimeImmutable|null) — trip start date; falls back to today
@@ -32,6 +38,7 @@ final readonly class SunsetAlertAnalyzer implements StageAnalyzerInterface
     public function __construct(
         private RiderTimeEstimatorInterface $riderTimeEstimator,
         private TranslatorInterface $translator,
+        private TimezoneResolverInterface $timezoneResolver,
     ) {
     }
 
@@ -56,13 +63,15 @@ final readonly class SunsetAlertAnalyzer implements StageAnalyzerInterface
         $baseDate = $startDate ?? new \DateTimeImmutable('today', new \DateTimeZone('UTC'));
         $stageDate = $baseDate->modify(\sprintf('+%d days', $stageIndex));
 
-        if (false === $stageDate) {
-            return [];
-        }
+        // The rider's timezone at the stage end point: everything below is local time.
+        $timezone = $this->timezoneResolver->resolve($stage->endPoint->lat, $stage->endPoint->lon);
 
-        // Compute sun information for the stage end point at the stage date
+        // Compute sun information for the stage end point at local noon on the stage
+        // date, so the solar day matches the calendar day the rider planned.
+        $localNoon = new \DateTimeImmutable($stageDate->format('Y-m-d').' 12:00:00', $timezone);
+
         $sunInfo = date_sun_info(
-            (int) $stageDate->format('U'),
+            $localNoon->getTimestamp(),
             $stage->endPoint->lat,
             $stage->endPoint->lon,
         );
@@ -75,11 +84,7 @@ final readonly class SunsetAlertAnalyzer implements StageAnalyzerInterface
             return [];
         }
 
-        // Compute estimated arrival as decimal hour (UTC).
-        // Note: departureHour is the rider's local time. Since the architecture does not
-        // carry timezone information, we treat it as UTC for comparison purposes.
-        // For European locations (UTC+1 to UTC+3), this may produce a conservative alert
-        // (off by 1–3 h), which is acceptable for a planning tool.
+        // Estimated arrival as a decimal hour, derived from departureHour (local time).
         $estimatedArrival = $this->riderTimeEstimator->estimateTimeAtDistance(
             $stage->distance,
             $stage->distance,
@@ -88,8 +93,8 @@ final readonly class SunsetAlertAnalyzer implements StageAnalyzerInterface
             $stage->elevation,
         );
 
-        // Convert civil twilight end timestamp to a decimal hour of the day (UTC)
-        $twilightDate = new \DateTimeImmutable('@'.$civilTwilightEnd, new \DateTimeZone('UTC'));
+        // Convert the civil twilight end timestamp to a local decimal hour of the day
+        $twilightDate = new \DateTimeImmutable('@'.$civilTwilightEnd)->setTimezone($timezone);
         $twilightDecimalHours = (float) $twilightDate->format('G') + (float) $twilightDate->format('i') / 60.0;
 
         if ($estimatedArrival <= $twilightDecimalHours) {
@@ -98,7 +103,7 @@ final readonly class SunsetAlertAnalyzer implements StageAnalyzerInterface
 
         $rawSunset = $sunInfo['sunset'];
         $sunsetTimestamp = \is_int($rawSunset) ? $rawSunset : $civilTwilightEnd;
-        $sunsetDate = new \DateTimeImmutable('@'.$sunsetTimestamp, new \DateTimeZone('UTC'));
+        $sunsetDate = new \DateTimeImmutable('@'.$sunsetTimestamp)->setTimezone($timezone);
         $sunsetHm = $sunsetDate->format('H:i');
         $twilightHm = $twilightDate->format('H:i');
 

--- a/api/src/Analyzer/Rules/SurfaceAlertAnalyzer.php
+++ b/api/src/Analyzer/Rules/SurfaceAlertAnalyzer.php
@@ -56,6 +56,11 @@ final readonly class SurfaceAlertAnalyzer implements StageAnalyzerInterface
 
     public function analyze(Stage $stage, array $context = []): array
     {
+        // A rest day is not ridden: its surface is irrelevant.
+        if ($stage->isRestDay) {
+            return [];
+        }
+
         /** @var list<array{surface?: string, tracktype?: string, smoothness?: string, length?: float}> $osmWays */
         $osmWays = $context['osmWays'] ?? [];
 

--- a/api/src/Analyzer/Rules/TrafficDangerAnalyzer.php
+++ b/api/src/Analyzer/Rules/TrafficDangerAnalyzer.php
@@ -33,6 +33,11 @@ final readonly class TrafficDangerAnalyzer implements StageAnalyzerInterface
 
     public function analyze(Stage $stage, array $context = []): array
     {
+        // A rest day is not ridden: its traffic exposure is irrelevant.
+        if ($stage->isRestDay) {
+            return [];
+        }
+
         /** @var list<array{highway?: string, cycleway?: string, 'cycleway:right'?: string, 'cycleway:left'?: string, 'cycleway:both'?: string, bicycle?: string, maxspeed?: string, length?: float, lat?: float, lon?: float}> $osmWays */
         $osmWays = $context['osmWays'] ?? [];
 

--- a/api/src/Geo/TimezoneResolver.php
+++ b/api/src/Geo/TimezoneResolver.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Geo;
+
+use App\Osm\AdminBoundaryRepositoryInterface;
+
+/**
+ * Resolves a timezone from a position, with no external service and no extra
+ * dependency: the country is read from the local admin-boundary index (ADR-040),
+ * which narrows the candidates to that country's zones, then the closest reference
+ * location among them wins (\DateTimeZone::getLocation()).
+ *
+ * The country step matters: a plain nearest-city match over all identifiers puts
+ * Nantes on Europe/Jersey (UTC+0), an hour off. Narrowing to FR leaves Europe/Paris.
+ * When no boundary resolves — admin_level=2 relations can be missing from a regional
+ * OSM extract — the search falls back to the closest reference location worldwide,
+ * which is still far better than assuming UTC.
+ */
+final class TimezoneResolver implements TimezoneResolverInterface
+{
+    /** @var list<array{id: string, lat: float, lon: float}>|null */
+    private ?array $worldLocations = null;
+
+    public function __construct(
+        private readonly GeoDistanceInterface $distance,
+        private readonly AdminBoundaryRepositoryInterface $adminBoundaryRepository,
+    ) {
+    }
+
+    public function resolve(float $lat, float $lon): \DateTimeZone
+    {
+        $countryCode = $this->adminBoundaryRepository->findCountryCodeAt($lat, $lon);
+        $candidates = null !== $countryCode
+            ? \DateTimeZone::listIdentifiers(\DateTimeZone::PER_COUNTRY, $countryCode)
+            : [];
+
+        if (1 === \count($candidates)) {
+            return new \DateTimeZone($candidates[0]);
+        }
+
+        $locations = [] !== $candidates ? $this->locationsOf($candidates) : $this->worldLocations();
+        $nearestId = $this->nearest($lat, $lon, $locations) ?? ($candidates[0] ?? null);
+
+        return new \DateTimeZone($nearestId ?? 'UTC');
+    }
+
+    /**
+     * @param list<array{id: string, lat: float, lon: float}> $locations
+     */
+    private function nearest(float $lat, float $lon, array $locations): ?string
+    {
+        $nearestId = null;
+        $nearestDistance = PHP_FLOAT_MAX;
+
+        foreach ($locations as $location) {
+            $candidate = $this->distance->inMeters($lat, $lon, $location['lat'], $location['lon']);
+            if ($candidate < $nearestDistance) {
+                $nearestDistance = $candidate;
+                $nearestId = $location['id'];
+            }
+        }
+
+        return $nearestId;
+    }
+
+    /**
+     * @return list<array{id: string, lat: float, lon: float}>
+     */
+    private function worldLocations(): array
+    {
+        return $this->worldLocations ??= $this->locationsOf(\DateTimeZone::listIdentifiers());
+    }
+
+    /**
+     * @param list<string> $identifiers
+     *
+     * @return list<array{id: string, lat: float, lon: float}>
+     */
+    private function locationsOf(array $identifiers): array
+    {
+        $locations = [];
+
+        foreach ($identifiers as $identifier) {
+            $location = new \DateTimeZone($identifier)->getLocation();
+            if (false === $location) {
+                continue;
+            }
+
+            $locations[] = [
+                'id' => $identifier,
+                'lat' => $location['latitude'],
+                'lon' => $location['longitude'],
+            ];
+        }
+
+        return $locations;
+    }
+}

--- a/api/src/Geo/TimezoneResolverInterface.php
+++ b/api/src/Geo/TimezoneResolverInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Geo;
+
+interface TimezoneResolverInterface
+{
+    /**
+     * Resolves the timezone that applies at the given position, so times computed
+     * from coordinates (sunset, twilight…) can be displayed in the rider's local time.
+     * Always returns a zone: the resolution degrades rather than fails.
+     */
+    public function resolve(float $lat, float $lon): \DateTimeZone;
+}

--- a/api/src/MessageHandler/CheckBikeShopsHandler.php
+++ b/api/src/MessageHandler/CheckBikeShopsHandler.php
@@ -91,6 +91,11 @@ final readonly class CheckBikeShopsHandler extends AbstractTripMessageHandler
             // Check each stage for nearby bike shops
             $stagesWithoutBikeShop = [];
             foreach ($stages as $i => $stage) {
+                // A rest day is not ridden: no mid-ride mechanical failure to cover.
+                if ($stage->isRestDay) {
+                    continue;
+                }
+
                 $geometry = $stage->geometry ?: [$stage->startPoint, $stage->endPoint];
                 $midpoint = $geometry[(int) (\count($geometry) / 2)];
                 $hasNearbyRepair = array_any($repairShopLocations, fn (array $shop): bool => $this->haversine->inMeters($midpoint->lat, $midpoint->lon, $shop['lat'], $shop['lon']) < self::BIKE_SHOP_PROXIMITY_METERS);

--- a/api/src/MessageHandler/CheckCalendarHandler.php
+++ b/api/src/MessageHandler/CheckCalendarHandler.php
@@ -4,30 +4,58 @@ declare(strict_types=1);
 
 namespace App\MessageHandler;
 
+use App\ApiResource\Model\AlertActionKind;
+use App\ApiResource\Stage;
 use App\ApiResource\TripRequest;
 use App\ComputationTracker\ComputationTrackerInterface;
 use App\ComputationTracker\TripGenerationTrackerInterface;
+use App\Enum\AlertType;
 use App\Enum\ComputationName;
 use App\Mercure\MercureEventType;
 use App\Mercure\TripUpdatePublisherInterface;
-use App\ApiResource\Model\AlertActionKind;
 use App\Message\CheckCalendar;
+use App\Osm\AdminBoundaryRepositoryInterface;
 use App\Repository\TripRequestRepositoryInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
+use Yasumi\Holiday;
+use Yasumi\ProviderInterface;
 use Yasumi\Yasumi;
 
+/**
+ * Flags stages falling on a public holiday or a Sunday (businesses may be closed).
+ *
+ * The countries are resolved from the route itself, via the same admin_level=2
+ * ST_Covers lookup as CheckBorderCrossingHandler, and holidays are loaded for every
+ * calendar year the trip spans (a trip straddling 31 December sees both years).
+ * When no country can be resolved — the admin_level=2 relations may be missing from
+ * a regional OSM extract — France is kept as the fallback, which is the behaviour
+ * this handler had before.
+ *
+ * Deliberately has no `isRestDay` guard: a public holiday or a Sunday closes shops
+ * and restaurants whether or not the rider pedals, and a rest day is precisely when
+ * they are needed.
+ */
 #[AsMessageHandler]
 final readonly class CheckCalendarHandler extends AbstractTripMessageHandler
 {
+    /**
+     * Kept when the route's countries cannot be resolved: replacing a hard-coded
+     * country by no country at all would be worse (no holiday detected anywhere).
+     */
+    private const string FALLBACK_COUNTRY_CODE = 'FR';
+
+    private const string FALLBACK_YASUMI_LOCALE = 'en_US';
+
     public function __construct(
         ComputationTrackerInterface $computationTracker,
         TripUpdatePublisherInterface $publisher,
         TripGenerationTrackerInterface $generationTracker,
         LoggerInterface $logger,
         private TripRequestRepositoryInterface $tripStateManager,
+        private AdminBoundaryRepositoryInterface $adminBoundaryRepository,
         private TranslatorInterface $translator,
         MessageBusInterface $messageBus,
     ) {
@@ -49,70 +77,201 @@ final readonly class CheckCalendarHandler extends AbstractTripMessageHandler
 
         $this->executeWithTracking($tripId, ComputationName::CALENDAR, function () use ($tripId, $request, $stages, $locale): void {
             $startDate = $request->startDate ?? new \DateTimeImmutable('today');
-            $year = (int) $startDate->format('Y');
+            $providers = $this->resolveProviders($stages, $startDate, $locale);
 
-            $holidays = Yasumi::create('France', $year, $locale);
-
-            $nudges = [];
+            $alerts = [];
 
             foreach ($stages as $i => $stage) {
                 $stageDate = $startDate->modify(\sprintf('+%d days', $i));
-                $isHoliday = $holidays->isHoliday($stageDate);
-                $isSunday = '7' === $stageDate->format('N');
+                $holiday = $this->findHoliday($providers, $stageDate);
 
-                if ($isHoliday) {
-                    $holidayName = null;
-                    foreach ($holidays->getHolidays() as $holiday) {
-                        if ($holiday->format('Y-m-d') === $stageDate->format('Y-m-d')) {
-                            $holidayName = $holiday->getName();
-                            break;
-                        }
-                    }
-
-                    $fallback = $this->translator->trans('alert.calendar.fallback', [], 'alerts', $locale);
-                    $nudges[] = [
-                        'stageIndex' => $i,
-                        'type' => 'holiday',
-                        'date' => $stageDate->format('Y-m-d'),
-                        'holiday' => $holidayName ?? $fallback,
-                        'message' => $this->translator->trans(
-                            'alert.calendar.nudge',
-                            [
-                                '%stage%' => $stage->dayNumber,
-                                '%holiday%' => $holidayName ?? $fallback,
-                            ],
-                            'alerts',
-                            $locale,
-                        ),
-                        'action' => [
-                            'kind' => AlertActionKind::DISMISS->value,
-                            'label' => $this->translator->trans('alert.calendar.action', [], 'alerts', $locale),
-                            'payload' => [],
-                        ],
-                    ];
-                } elseif ($isSunday) {
-                    $nudges[] = [
-                        'stageIndex' => $i,
-                        'type' => 'sunday',
-                        'date' => $stageDate->format('Y-m-d'),
-                        'message' => $this->translator->trans(
-                            'alert.calendar.sunday_nudge',
-                            ['%stage%' => $stage->dayNumber],
-                            'alerts',
-                            $locale,
-                        ),
-                        'action' => [
-                            'kind' => AlertActionKind::DISMISS->value,
-                            'label' => $this->translator->trans('alert.calendar.action', [], 'alerts', $locale),
-                            'payload' => [],
-                        ],
-                    ];
+                if ($holiday instanceof Holiday) {
+                    $holidayName = $this->resolveHolidayName($holiday);
+                    $alerts[] = $this->buildAlert(
+                        $i,
+                        $stage,
+                        $stageDate,
+                        null !== $holidayName ? 'alert.calendar.nudge' : 'alert.calendar.unnamed_nudge',
+                        null !== $holidayName
+                            ? ['%stage%' => $stage->dayNumber, '%holiday%' => $holidayName]
+                            : ['%stage%' => $stage->dayNumber],
+                        $locale,
+                    );
+                } elseif ('7' === $stageDate->format('N')) {
+                    $alerts[] = $this->buildAlert(
+                        $i,
+                        $stage,
+                        $stageDate,
+                        'alert.calendar.sunday_nudge',
+                        ['%stage%' => $stage->dayNumber],
+                        $locale,
+                    );
                 }
             }
 
             $this->publisher->publish($tripId, MercureEventType::CALENDAR_ALERTS, [
-                'nudges' => $nudges,
+                'alerts' => $alerts,
             ]);
         }, $generation);
+    }
+
+    /**
+     * @param array<string, int|string> $parameters
+     *
+     * @return array{stageIndex: int, dayNumber: int, type: string, date: string, message: string, action: array{kind: string, label: string, payload: array<string, mixed>}}
+     */
+    private function buildAlert(int $stageIndex, Stage $stage, \DateTimeImmutable $stageDate, string $translationKey, array $parameters, string $locale): array
+    {
+        return [
+            'stageIndex' => $stageIndex,
+            'dayNumber' => $stage->dayNumber,
+            'type' => AlertType::NUDGE->value,
+            'date' => $stageDate->format('Y-m-d'),
+            'message' => $this->translator->trans($translationKey, $parameters, 'alerts', $locale),
+            'action' => [
+                'kind' => AlertActionKind::DISMISS->value,
+                'label' => $this->translator->trans('alert.calendar.action', [], 'alerts', $locale),
+                'payload' => [],
+            ],
+        ];
+    }
+
+    /**
+     * One Yasumi provider per (country, year) pair covered by the trip.
+     *
+     * @param list<Stage> $stages
+     *
+     * @return list<ProviderInterface>
+     */
+    private function resolveProviders(array $stages, \DateTimeImmutable $startDate, string $locale): array
+    {
+        $years = $this->resolveYears($stages, $startDate);
+        $yasumiLocale = \in_array($locale, Yasumi::getAvailableLocales(), true) ? $locale : self::FALLBACK_YASUMI_LOCALE;
+
+        $countryCodes = $this->resolveCountryCodes($stages);
+        if ([] === $countryCodes) {
+            $countryCodes = [self::FALLBACK_COUNTRY_CODE];
+        }
+
+        $providers = $this->createProviders($countryCodes, $years, $yasumiLocale);
+
+        // Every resolved country lacks a Yasumi provider: fall back to France rather
+        // than reporting no holiday at all.
+        if ([] === $providers && [self::FALLBACK_COUNTRY_CODE] !== $countryCodes) {
+            $providers = $this->createProviders([self::FALLBACK_COUNTRY_CODE], $years, $yasumiLocale);
+        }
+
+        return $providers;
+    }
+
+    /**
+     * @param list<string> $countryCodes
+     * @param list<int>    $years
+     *
+     * @return list<ProviderInterface>
+     */
+    private function createProviders(array $countryCodes, array $years, string $yasumiLocale): array
+    {
+        $providers = [];
+
+        foreach ($countryCodes as $countryCode) {
+            foreach ($years as $year) {
+                try {
+                    $providers[] = Yasumi::createByISO3166_2($countryCode, $year, $yasumiLocale);
+                } catch (\Throwable $throwable) {
+                    $this->logger->warning('No holiday provider for country {country} in {year}.', [
+                        'country' => $countryCode,
+                        'year' => $year,
+                        'exception' => $throwable,
+                    ]);
+                }
+            }
+        }
+
+        return $providers;
+    }
+
+    /**
+     * Every calendar year the trip spans (one day per stage, rest days included).
+     *
+     * @param list<Stage> $stages
+     *
+     * @return list<int>
+     */
+    private function resolveYears(array $stages, \DateTimeImmutable $startDate): array
+    {
+        $endDate = $startDate->modify(\sprintf('+%d days', max(0, \count($stages) - 1)));
+
+        $years = [];
+        for ($year = (int) $startDate->format('Y'), $lastYear = (int) $endDate->format('Y'); $year <= $lastYear; ++$year) {
+            $years[] = $year;
+        }
+
+        return $years;
+    }
+
+    /**
+     * The distinct ISO 3166-1 alpha-2 codes of the countries the route runs through,
+     * resolved from the local admin-boundary index (ADR-040) at the first stage's start
+     * point and at every stage end point.
+     *
+     * @param list<Stage> $stages
+     *
+     * @return list<string>
+     */
+    private function resolveCountryCodes(array $stages): array
+    {
+        if ([] === $stages) {
+            return [];
+        }
+
+        $points = [$stages[0]->startPoint];
+        foreach ($stages as $stage) {
+            $points[] = $stage->endPoint;
+        }
+
+        $codes = [];
+        foreach ($points as $point) {
+            $code = $this->adminBoundaryRepository->findCountryCodeAt($point->lat, $point->lon);
+            if (null !== $code && !\in_array($code, $codes, true)) {
+                $codes[] = $code;
+            }
+        }
+
+        return $codes;
+    }
+
+    /**
+     * @param list<ProviderInterface> $providers
+     */
+    private function findHoliday(array $providers, \DateTimeImmutable $date): ?Holiday
+    {
+        $day = $date->format('Y-m-d');
+
+        foreach ($providers as $provider) {
+            foreach ($provider->getHolidays() as $holiday) {
+                if ($holiday->format('Y-m-d') === $day) {
+                    return $holiday;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * The translated holiday name, or null when Yasumi has no translation for the
+     * active locale. Callers then emit a message without a name rather than the
+     * tautological "coincides with a public holiday (Public holiday)".
+     */
+    private function resolveHolidayName(Holiday $holiday): ?string
+    {
+        try {
+            $name = $holiday->getName();
+        } catch (\Throwable) {
+            return null;
+        }
+
+        return '' !== $name ? $name : null;
     }
 }

--- a/api/src/MessageHandler/CheckHealthServicesHandler.php
+++ b/api/src/MessageHandler/CheckHealthServicesHandler.php
@@ -26,6 +26,10 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  * Checks for pharmacies, hospitals and clinics within 15 km of each stage.
  *
  * Emits a NUDGE alert when no health service is found near a stage.
+ *
+ * Deliberately has no `isRestDay` guard: the check is evaluated at the stage midpoint,
+ * which for a rest day is the place the rider stays for a whole day. Knowing there is
+ * no pharmacy within 15 km is at least as useful there as on a transit day.
  */
 #[AsMessageHandler]
 final readonly class CheckHealthServicesHandler extends AbstractTripMessageHandler

--- a/api/src/MessageHandler/CheckWaterPointsHandler.php
+++ b/api/src/MessageHandler/CheckWaterPointsHandler.php
@@ -91,7 +91,9 @@ final readonly class CheckWaterPointsHandler extends AbstractTripMessageHandler
                     'waterPoints' => $waterPointsWithDistance,
                 ];
 
-                if ($this->hasWaterGap($stage, $waterPointsWithDistance)) {
+                // A rest day is not ridden: no on-route hydration gap to warn about.
+                // Its water points still ship in the payload above (useful where you stay).
+                if (!$stage->isRestDay && $this->hasWaterGap($stage, $waterPointsWithDistance)) {
                     $nearestWp = $this->findNearestWaterPoint($stage, $allWaterPoints);
                     $alerts[] = [
                         'stageIndex' => $i,

--- a/api/src/MessageHandler/ScanPoisHandler.php
+++ b/api/src/MessageHandler/ScanPoisHandler.php
@@ -124,9 +124,11 @@ final readonly class ScanPoisHandler extends AbstractTripMessageHandler
                     $pois[] = ['name' => $poi->name, 'category' => $poi->category];
                 }
 
-                // Lunch nudge: flag long stages with no food POIs
+                // Lunch nudge: flag long stages with no food POIs.
+                // Both alerts below are about passing through while riding, so a rest day
+                // is skipped — its POIs are still scanned and published (useful on the spot).
                 $alerts = [];
-                if ($stage->distance >= self::LUNCH_NUDGE_DISTANCE_KM && !$this->hasResupplyPoi($stage)) {
+                if (!$stage->isRestDay && $stage->distance >= self::LUNCH_NUDGE_DISTANCE_KM && !$this->hasResupplyPoi($stage)) {
                     $alert = new Alert(
                         type: AlertType::NUDGE,
                         message: $this->translator->trans('alert.lunch.nudge', [], 'alerts', $locale),
@@ -139,7 +141,7 @@ final readonly class ScanPoisHandler extends AbstractTripMessageHandler
 
                 // Resupply timing warning: warn when all resupply POIs on this stage
                 // would be closed at the estimated rider passage time
-                if ($this->hasResupplyPoi($stage) && !$this->hasAnyOpenResupplyPoi($stage, $departureHour, $averageSpeed)) {
+                if (!$stage->isRestDay && $this->hasResupplyPoi($stage) && !$this->hasAnyOpenResupplyPoi($stage, $departureHour, $averageSpeed)) {
                     $alert = new Alert(
                         type: AlertType::WARNING,
                         message: $this->translator->trans(

--- a/api/src/Osm/AdminBoundaryRepository.php
+++ b/api/src/Osm/AdminBoundaryRepository.php
@@ -41,4 +41,28 @@ final readonly class AdminBoundaryRepository implements AdminBoundaryRepositoryI
 
         return \is_string($country) && '' !== $country ? $country : null;
     }
+
+    public function findCountryCodeAt(float $lat, float $lon): ?string
+    {
+        $code = $this->connection->fetchOne(
+            <<<'SQL'
+                SELECT COALESCE(tags->>'ISO3166-1', tags->>'ISO3166-1:alpha2')
+                FROM osm.admin_boundaries
+                WHERE admin_level = 2
+                  AND ST_Covers(geom, ST_SetSRID(ST_MakePoint(:lon, :lat), 4326))
+                ORDER BY osm_id
+                LIMIT 1
+                SQL,
+            [
+                'lon' => $lon,
+                'lat' => $lat,
+            ],
+        );
+
+        if (!\is_string($code) || 1 !== preg_match('/^[A-Za-z]{2}$/', $code)) {
+            return null;
+        }
+
+        return strtoupper($code);
+    }
 }

--- a/api/src/Osm/AdminBoundaryRepositoryInterface.php
+++ b/api/src/Osm/AdminBoundaryRepositoryInterface.php
@@ -12,4 +12,12 @@ interface AdminBoundaryRepositoryInterface
      * the default name), or null when the point lies outside every stored country.
      */
     public function findCountryAt(float $lat, float $lon, string $locale): ?string;
+
+    /**
+     * Resolves the ISO 3166-1 alpha-2 code of the country containing the given point,
+     * or null when the point lies outside every stored country or the boundary carries
+     * no ISO code. Callers needing a country-keyed dataset (public holidays…) use this
+     * instead of the localised name.
+     */
+    public function findCountryCodeAt(float $lat, float $lon): ?string;
 }

--- a/api/tests/Unit/Analyzer/ContinuityAnalyzerTest.php
+++ b/api/tests/Unit/Analyzer/ContinuityAnalyzerTest.php
@@ -134,6 +134,29 @@ final class ContinuityAnalyzerTest extends TestCase
         return new ContinuityAnalyzer($distanceCalculator, $translator, $this->createDistanceFormatter());
     }
 
+    #[Test]
+    public function restDayIsStillChecked(): void
+    {
+        // A rest day copies the previous stage's end point, so this check IS the real
+        // continuity check between the two ridden stages around it: no isRestDay guard.
+        $analyzer = $this->makeAnalyzer(800.0);
+        $restDay = new Stage(
+            tripId: 'trip-1',
+            dayNumber: 2,
+            distance: 0.0,
+            elevation: 0.0,
+            startPoint: new Coordinate(45.1, 5.1),
+            endPoint: new Coordinate(45.1, 5.1),
+            isRestDay: true,
+        );
+        $nextStage = $this->createStage(45.2, 5.2, 45.3, 5.3);
+
+        $alerts = $analyzer->analyze($restDay, ['nextStage' => $nextStage]);
+
+        $this->assertCount(1, $alerts);
+        $this->assertSame(AlertType::CRITICAL, $alerts[0]->type);
+    }
+
     private function createStage(float $startLat, float $startLon, float $endLat, float $endLon): Stage
     {
         return new Stage(

--- a/api/tests/Unit/Analyzer/EbikeRangeAnalyzerTest.php
+++ b/api/tests/Unit/Analyzer/EbikeRangeAnalyzerTest.php
@@ -160,6 +160,24 @@ final class EbikeRangeAnalyzerTest extends TestCase
     }
 
     #[Test]
+    public function noAlertForRestDay(): void
+    {
+        $stage = new Stage(
+            tripId: 'trip-1',
+            dayNumber: 1,
+            distance: 200.0,
+            elevation: 0.0,
+            startPoint: new Coordinate(45.0, 5.0),
+            endPoint: new Coordinate(45.0, 5.0),
+            isRestDay: true,
+        );
+
+        $alerts = $this->analyzer->analyze($stage, ['ebikeMode' => true]);
+
+        $this->assertSame([], $alerts);
+    }
+
+    #[Test]
     public function priority(): void
     {
         $this->assertSame(20, EbikeRangeAnalyzer::getPriority());

--- a/api/tests/Unit/Analyzer/ElevationAlertAnalyzerTest.php
+++ b/api/tests/Unit/Analyzer/ElevationAlertAnalyzerTest.php
@@ -120,6 +120,24 @@ final class ElevationAlertAnalyzerTest extends TestCase
     }
 
     #[Test]
+    public function noAlertForRestDay(): void
+    {
+        $stage = new Stage(
+            tripId: 'trip-1',
+            dayNumber: 1,
+            distance: 0.0,
+            elevation: 2000.0,
+            startPoint: new Coordinate(45.0, 5.0),
+            endPoint: new Coordinate(45.0, 5.0),
+            isRestDay: true,
+        );
+
+        $alerts = $this->analyzer->analyze($stage);
+
+        $this->assertSame([], $alerts);
+    }
+
+    #[Test]
     public function priority(): void
     {
         $this->assertSame(10, ElevationAlertAnalyzer::getPriority());

--- a/api/tests/Unit/Analyzer/SteepGradientAnalyzerTest.php
+++ b/api/tests/Unit/Analyzer/SteepGradientAnalyzerTest.php
@@ -228,6 +228,32 @@ final class SteepGradientAnalyzerTest extends TestCase
     }
 
     #[Test]
+    public function noAlertForRestDay(): void
+    {
+        $stage = new Stage(
+            tripId: 'trip-1',
+            dayNumber: 1,
+            distance: 0.0,
+            elevation: 0.0,
+            startPoint: new Coordinate(45.0, 5.0),
+            endPoint: new Coordinate(45.005, 5.0),
+            geometry: [
+                new Coordinate(45.0, 5.0, 200.0),
+                new Coordinate(45.001, 5.0, 220.0),
+                new Coordinate(45.002, 5.0, 240.0),
+                new Coordinate(45.003, 5.0, 260.0),
+                new Coordinate(45.004, 5.0, 280.0),
+                new Coordinate(45.005, 5.0, 300.0),
+            ],
+            isRestDay: true,
+        );
+
+        $alerts = $this->analyzer->analyze($stage);
+
+        $this->assertSame([], $alerts);
+    }
+
+    #[Test]
     public function priority(): void
     {
         $this->assertSame(20, SteepGradientAnalyzer::getPriority());

--- a/api/tests/Unit/Analyzer/SunsetAlertAnalyzerTest.php
+++ b/api/tests/Unit/Analyzer/SunsetAlertAnalyzerTest.php
@@ -10,6 +10,9 @@ use App\ApiResource\Model\Coordinate;
 use App\ApiResource\Stage;
 use App\Engine\RiderTimeEstimatorInterface;
 use App\Enum\AlertType;
+use App\Geo\HaversineDistance;
+use App\Geo\TimezoneResolver;
+use App\Osm\AdminBoundaryRepositoryInterface;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
@@ -36,6 +39,7 @@ final class SunsetAlertAnalyzerTest extends TestCase
         $this->analyzer = new SunsetAlertAnalyzer(
             $this->riderTimeEstimator,
             $this->translator,
+            $this->timezoneResolver(),
         );
     }
 
@@ -116,6 +120,28 @@ final class SunsetAlertAnalyzerTest extends TestCase
     }
 
     #[Test]
+    public function displaysSunsetAndTwilightInLocalTime(): void
+    {
+        // Paris on 21 June 2026: sunset 21:57 CEST / 19:57 UTC, civil twilight end
+        // 22:40 CEST / 20:40 UTC. The message must show the CEST times — a rider in
+        // France reading "19:57" would not believe it.
+        $stage = $this->createStage(lat: 48.85, lon: 2.35);
+
+        $this->riderTimeEstimator->method('estimateTimeAtDistance')->willReturn(23.0);
+
+        $alerts = $this->analyzer->analyze($stage, [
+            'startDate' => new \DateTimeImmutable('2026-06-21', new \DateTimeZone('UTC')),
+            'stageIndex' => 0,
+            'departureHour' => 8,
+            'averageSpeed' => 15.0,
+        ]);
+
+        $this->assertCount(1, $alerts);
+        $this->assertStringContainsString('21:57', $alerts[0]->message);
+        $this->assertStringContainsString('22:40', $alerts[0]->message);
+    }
+
+    #[Test]
     public function noAlertWhenNoStartDateAndArrivalBeforeTwilight(): void
     {
         // Uses today's date as fallback — just check that it doesn't crash with null startDate
@@ -152,7 +178,7 @@ final class SunsetAlertAnalyzerTest extends TestCase
         $riderTimeEstimator = $this->createStub(RiderTimeEstimatorInterface::class);
         $riderTimeEstimator->method('estimateTimeAtDistance')->willReturn(22.0);
 
-        $analyzer = new SunsetAlertAnalyzer($riderTimeEstimator, $translator);
+        $analyzer = new SunsetAlertAnalyzer($riderTimeEstimator, $translator, $this->timezoneResolver());
         $stage = $this->createStage(lat: 48.85, lon: 2.35);
 
         $alerts = $analyzer->analyze($stage, [
@@ -200,7 +226,7 @@ final class SunsetAlertAnalyzerTest extends TestCase
         // estimateTimeAtDistance should NOT be called for polar conditions
         $riderTimeEstimator = $this->createMock(RiderTimeEstimatorInterface::class);
         $riderTimeEstimator->expects($this->never())->method('estimateTimeAtDistance');
-        $analyzer = new SunsetAlertAnalyzer($riderTimeEstimator, $this->translator);
+        $analyzer = new SunsetAlertAnalyzer($riderTimeEstimator, $this->translator, $this->timezoneResolver());
 
         $alerts = $analyzer->analyze($stage, [
             'startDate' => new \DateTimeImmutable('2024-12-15', new \DateTimeZone('UTC')),
@@ -210,6 +236,14 @@ final class SunsetAlertAnalyzerTest extends TestCase
         ]);
 
         $this->assertSame([], $alerts);
+    }
+
+    private function timezoneResolver(?string $countryCode = 'FR'): TimezoneResolver
+    {
+        $adminBoundaryRepository = $this->createStub(AdminBoundaryRepositoryInterface::class);
+        $adminBoundaryRepository->method('findCountryCodeAt')->willReturn($countryCode);
+
+        return new TimezoneResolver(new HaversineDistance(), $adminBoundaryRepository);
     }
 
     private function createStage(

--- a/api/tests/Unit/Analyzer/SurfaceAlertAnalyzerTest.php
+++ b/api/tests/Unit/Analyzer/SurfaceAlertAnalyzerTest.php
@@ -344,6 +344,26 @@ final class SurfaceAlertAnalyzerTest extends TestCase
     }
 
     #[Test]
+    public function noAlertForRestDay(): void
+    {
+        $stage = new Stage(
+            tripId: 'trip-1',
+            dayNumber: 1,
+            distance: 0.0,
+            elevation: 0.0,
+            startPoint: new Coordinate(45.0, 5.0),
+            endPoint: new Coordinate(45.0, 5.0),
+            isRestDay: true,
+        );
+
+        $alerts = $this->analyzer->analyze($stage, [
+            'osmWays' => [['surface' => 'gravel', 'length' => 5000.0]],
+        ]);
+
+        $this->assertSame([], $alerts);
+    }
+
+    #[Test]
     public function priority(): void
     {
         $this->assertSame(20, SurfaceAlertAnalyzer::getPriority());

--- a/api/tests/Unit/Analyzer/TrafficDangerAnalyzerTest.php
+++ b/api/tests/Unit/Analyzer/TrafficDangerAnalyzerTest.php
@@ -391,6 +391,26 @@ final class TrafficDangerAnalyzerTest extends TestCase
     }
 
     #[Test]
+    public function noAlertForRestDay(): void
+    {
+        $stage = new Stage(
+            tripId: 'trip-1',
+            dayNumber: 1,
+            distance: 0.0,
+            elevation: 0.0,
+            startPoint: new Coordinate(45.0, 5.0),
+            endPoint: new Coordinate(45.0, 5.0),
+            isRestDay: true,
+        );
+
+        $alerts = $this->analyzer->analyze($stage, [
+            'osmWays' => [['highway' => 'primary', 'length' => 3000.0]],
+        ]);
+
+        $this->assertSame([], $alerts);
+    }
+
+    #[Test]
     public function priority(): void
     {
         $this->assertSame(20, TrafficDangerAnalyzer::getPriority());

--- a/api/tests/Unit/Geo/TimezoneResolverTest.php
+++ b/api/tests/Unit/Geo/TimezoneResolverTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Geo;
+
+use App\Geo\HaversineDistance;
+use App\Geo\TimezoneResolver;
+use App\Osm\AdminBoundaryRepositoryInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class TimezoneResolverTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('frenchCities')]
+    public function resolvesEveryFrenchCityToParis(float $lat, float $lon): void
+    {
+        // A plain nearest-city match over all identifiers puts Nantes on Europe/Jersey
+        // (UTC+0) and Marseille on Europe/Monaco: narrowing by country avoids that.
+        $resolver = $this->resolver('FR');
+
+        $this->assertSame('Europe/Paris', $resolver->resolve($lat, $lon)->getName());
+    }
+
+    /**
+     * @return iterable<string, array{float, float}>
+     */
+    public static function frenchCities(): iterable
+    {
+        yield 'Paris' => [48.85, 2.35];
+        yield 'Nantes' => [47.22, -1.55];
+        yield 'Marseille' => [43.30, 5.37];
+        yield 'Perpignan' => [42.70, 2.90];
+    }
+
+    #[Test]
+    public function picksTheNearestZoneWhenTheCountryHasSeveral(): void
+    {
+        $resolver = $this->resolver('ES');
+
+        // Spain owns Europe/Madrid, Africa/Ceuta and Atlantic/Canary.
+        $this->assertSame('Europe/Madrid', $resolver->resolve(40.42, -3.70)->getName());
+        $this->assertSame('Atlantic/Canary', $resolver->resolve(28.10, -15.41)->getName());
+    }
+
+    #[Test]
+    public function fallsBackToTheNearestZoneWorldwideWhenNoCountryResolves(): void
+    {
+        // admin_level=2 boundaries may be missing from a regional OSM extract: the
+        // resolution degrades to a worldwide nearest match, never to UTC-by-default.
+        $resolver = $this->resolver(null);
+
+        $this->assertSame('Europe/Paris', $resolver->resolve(48.85, 2.35)->getName());
+    }
+
+    #[Test]
+    public function unknownCountryCodeStillYieldsAZone(): void
+    {
+        $resolver = $this->resolver('ZZ');
+
+        $this->assertSame('Europe/Paris', $resolver->resolve(48.85, 2.35)->getName());
+    }
+
+    private function resolver(?string $countryCode): TimezoneResolver
+    {
+        $adminBoundaryRepository = $this->createStub(AdminBoundaryRepositoryInterface::class);
+        $adminBoundaryRepository->method('findCountryCodeAt')->willReturn($countryCode);
+
+        return new TimezoneResolver(new HaversineDistance(), $adminBoundaryRepository);
+    }
+}

--- a/api/tests/Unit/MessageHandler/CheckBikeShopsHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/CheckBikeShopsHandlerTest.php
@@ -204,6 +204,50 @@ final class CheckBikeShopsHandlerTest extends TestCase
     }
 
     #[Test]
+    public function restDayIsSkipped(): void
+    {
+        $stages = $this->createStages('trip-1');
+        $stages[2] = new Stage(
+            tripId: 'trip-1',
+            dayNumber: 3,
+            distance: 0.0,
+            elevation: 0.0,
+            startPoint: new Coordinate(48.5, 2.5),
+            endPoint: new Coordinate(48.5, 2.5),
+            isRestDay: true,
+        );
+
+        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
+        $tripStateManager->method('getStages')->willReturn($stages);
+        $tripStateManager->method('getLocale')->willReturn('en');
+        $tripStateManager->method('getDecimatedPoints')->willReturn(null);
+
+        $publisher = $this->createMock(TripUpdatePublisherInterface::class);
+        $publisher->expects($this->once())
+            ->method('publish')
+            ->with(
+                'trip-1',
+                MercureEventType::BIKE_SHOP_ALERTS,
+                $this->callback(static function (array $data): bool {
+                    $alerts = $data['alerts'];
+                    \assert(\is_array($alerts));
+
+                    // 6 stages, one of which is a rest day: only the 5 ridden days alert.
+                    return 5 === \count($alerts)
+                        && !\in_array(2, array_column($alerts, 'stageIndex'), true);
+                }),
+            );
+
+        $handler = $this->createHandler(
+            $tripStateManager,
+            $publisher,
+            $this->bikeShopRepository([]),
+            $this->createStub(GeoDistanceInterface::class),
+        );
+        $handler(new CheckBikeShops('trip-1'));
+    }
+
+    #[Test]
     public function tripWithFewStagesIsSkipped(): void
     {
         // BR-06: trips of 5 days or fewer skip the check entirely, but must still mark

--- a/api/tests/Unit/MessageHandler/CheckCalendarHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/CheckCalendarHandlerTest.php
@@ -13,6 +13,7 @@ use App\Mercure\MercureEventType;
 use App\Mercure\TripUpdatePublisherInterface;
 use App\Message\CheckCalendar;
 use App\MessageHandler\CheckCalendarHandler;
+use App\Osm\AdminBoundaryRepositoryInterface;
 use App\Repository\TripRequestRepositoryInterface;
 use App\Tests\Unit\AlertMessageTestTrait;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -55,31 +56,72 @@ final class CheckCalendarHandlerTest extends TestCase
                 'trip-1',
                 MercureEventType::CALENDAR_ALERTS,
                 $this->callback(static function (array $data) use ($expected): bool {
-                    self::assertSame($expected, $data['nudges'][0]['message']);
+                    self::assertSame($expected, $data['alerts'][0]['message']);
 
                     return true;
                 }),
             );
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $this->createAlertTranslator());
+        $handler = $this->createHandler(
+            $tripStateManager,
+            $publisher,
+            $this->adminBoundaryRepository(['FR']),
+            $this->createAlertTranslator(),
+        );
         $handler(new CheckCalendar('trip-1'));
     }
 
-    private function createStage(string $tripId, int $dayNumber): Stage
+    private function createStage(string $tripId, int $dayNumber, float $lat = 48.0, float $lon = 2.0): Stage
     {
         return new Stage(
             tripId: $tripId,
             dayNumber: $dayNumber,
             distance: 80000.0,
             elevation: 500.0,
-            startPoint: new Coordinate(48.0, 2.0),
-            endPoint: new Coordinate(48.1, 2.1),
+            startPoint: new Coordinate($lat, $lon),
+            endPoint: new Coordinate($lat + 0.1, $lon + 0.1),
         );
+    }
+
+    /**
+     * @param list<Stage> $stages
+     */
+    private function tripStateManager(array $stages, \DateTimeImmutable $startDate): TripRequestRepositoryInterface
+    {
+        $request = new TripRequest();
+        $request->startDate = $startDate;
+
+        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
+        $tripStateManager->method('getRequest')->willReturn($request);
+        $tripStateManager->method('getStages')->willReturn($stages);
+        $tripStateManager->method('getLocale')->willReturn('en');
+
+        return $tripStateManager;
+    }
+
+    /**
+     * @param list<string|null> $countryCodes cycled over the checked points
+     */
+    private function adminBoundaryRepository(array $countryCodes): AdminBoundaryRepositoryInterface
+    {
+        $call = 0;
+        $repository = $this->createStub(AdminBoundaryRepositoryInterface::class);
+        $repository->method('findCountryCodeAt')->willReturnCallback(
+            static function () use ($countryCodes, &$call): ?string {
+                $code = $countryCodes[$call % \count($countryCodes)];
+                ++$call;
+
+                return $code;
+            },
+        );
+
+        return $repository;
     }
 
     private function createHandler(
         TripRequestRepositoryInterface $tripStateManager,
         TripUpdatePublisherInterface $publisher,
+        AdminBoundaryRepositoryInterface $adminBoundaryRepository,
         ?TranslatorInterface $translator = null,
     ): CheckCalendarHandler {
         $computationTracker = $this->createStub(ComputationTrackerInterface::class);
@@ -90,7 +132,7 @@ final class CheckCalendarHandlerTest extends TestCase
             static fn (string $id, array $params): string => match ($id) {
                 'alert.calendar.sunday_nudge' => \sprintf('Stage %s falls on a Sunday.', $params['%stage%']),
                 'alert.calendar.nudge' => \sprintf('Stage %s: holiday %s.', $params['%stage%'], $params['%holiday%']),
-                'alert.calendar.fallback' => 'Public holiday',
+                'alert.calendar.unnamed_nudge' => \sprintf('Stage %s: public holiday.', $params['%stage%']),
                 default => $id,
             },
         );
@@ -103,103 +145,172 @@ final class CheckCalendarHandlerTest extends TestCase
             $generationTracker,
             new NullLogger(),
             $tripStateManager,
+            $adminBoundaryRepository,
             $translator ?? $stubTranslator,
             $this->createStub(MessageBusInterface::class),
         );
+    }
+
+    /**
+     * Runs the handler and returns the published alert payload.
+     *
+     * @param list<Stage>       $stages
+     * @param list<string|null> $countryCodes
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function publishedAlerts(array $stages, \DateTimeImmutable $startDate, array $countryCodes): array
+    {
+        $captured = [];
+        $publisher = $this->createStub(TripUpdatePublisherInterface::class);
+        $publisher->method('publish')->willReturnCallback(
+            static function (string $tripId, MercureEventType $type, array $payload) use (&$captured): void {
+                self::assertSame(MercureEventType::CALENDAR_ALERTS, $type);
+                \assert(\is_array($payload['alerts']));
+                $captured = array_values($payload['alerts']);
+            },
+        );
+
+        $handler = $this->createHandler(
+            $this->tripStateManager($stages, $startDate),
+            $publisher,
+            $this->adminBoundaryRepository($countryCodes),
+        );
+        $handler(new CheckCalendar('trip-1'));
+
+        /** @var list<array<string, mixed>> $alerts */
+        $alerts = $captured;
+
+        return $alerts;
     }
 
     #[Test]
     public function sundayNonHolidayEmitsSundayNudge(): void
     {
         // 2026-03-15 is a Sunday, not a French holiday
-        $request = new TripRequest();
-        $request->startDate = new \DateTimeImmutable('2026-03-15');
+        $alerts = $this->publishedAlerts(
+            [$this->createStage('trip-1', 1)],
+            new \DateTimeImmutable('2026-03-15'),
+            ['FR'],
+        );
 
-        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
-        $tripStateManager->method('getRequest')->willReturn($request);
-        $tripStateManager->method('getStages')->willReturn([$this->createStage('trip-1', 1)]);
-        $tripStateManager->method('getLocale')->willReturn('en');
-
-        $publisher = $this->createMock(TripUpdatePublisherInterface::class);
-        $publisher->expects($this->once())
-            ->method('publish')
-            ->with(
-                'trip-1',
-                MercureEventType::CALENDAR_ALERTS,
-                $this->callback(static function (array $data): bool {
-                    $nudges = $data['nudges'];
-
-                    return 1 === \count($nudges)
-                        && 'sunday' === $nudges[0]['type']
-                        && 0 === $nudges[0]['stageIndex']
-                        && str_contains((string) $nudges[0]['message'], 'Sunday')
-                        && \is_array($nudges[0]['action'])
-                        && 'dismiss' === $nudges[0]['action']['kind'];
-                }),
-            );
-
-        $handler = $this->createHandler($tripStateManager, $publisher);
-        $handler(new CheckCalendar('trip-1'));
+        $this->assertCount(1, $alerts);
+        $this->assertSame(0, $alerts[0]['stageIndex']);
+        $this->assertSame(1, $alerts[0]['dayNumber']);
+        $this->assertSame('nudge', $alerts[0]['type']);
+        $this->assertSame('2026-03-15', $alerts[0]['date']);
+        $this->assertIsString($alerts[0]['message']);
+        $this->assertStringContainsString('Sunday', $alerts[0]['message']);
+        \assert(\is_array($alerts[0]['action']));
+        $this->assertSame('dismiss', $alerts[0]['action']['kind']);
     }
 
     #[Test]
     public function sundayHolidayEmitsOnlyHolidayNudge(): void
     {
-        // 2026-12-25 is a Friday... let's find a Sunday that is also a holiday in France.
-        // In France, May 1st (Labour Day) — check if 2033-05-01 is a Sunday: yes!
-        // Actually, let's use a simpler approach: 2022-01-01 was a Saturday... no.
-        // 2023-01-01 is a Sunday and is New Year's Day (holiday in France).
-        $request = new TripRequest();
-        $request->startDate = new \DateTimeImmutable('2023-01-01');
+        // 2023-01-01 is a Sunday and New Year's Day in France
+        $alerts = $this->publishedAlerts(
+            [$this->createStage('trip-1', 1)],
+            new \DateTimeImmutable('2023-01-01'),
+            ['FR'],
+        );
 
-        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
-        $tripStateManager->method('getRequest')->willReturn($request);
-        $tripStateManager->method('getStages')->willReturn([$this->createStage('trip-1', 1)]);
-        $tripStateManager->method('getLocale')->willReturn('en');
-
-        $publisher = $this->createMock(TripUpdatePublisherInterface::class);
-        $publisher->expects($this->once())
-            ->method('publish')
-            ->with(
-                'trip-1',
-                MercureEventType::CALENDAR_ALERTS,
-                $this->callback(static function (array $data): bool {
-                    $nudges = $data['nudges'];
-
-                    return 1 === \count($nudges)
-                        && 'holiday' === $nudges[0]['type']
-                        && 0 === $nudges[0]['stageIndex']
-                        && \is_array($nudges[0]['action'])
-                        && 'dismiss' === $nudges[0]['action']['kind'];
-                }),
-            );
-
-        $handler = $this->createHandler($tripStateManager, $publisher);
-        $handler(new CheckCalendar('trip-1'));
+        $this->assertCount(1, $alerts);
+        $this->assertSame('nudge', $alerts[0]['type']);
+        $this->assertIsString($alerts[0]['message']);
+        $this->assertStringContainsString('holiday', $alerts[0]['message']);
+        $this->assertStringNotContainsString('Sunday', $alerts[0]['message']);
     }
 
     #[Test]
     public function weekdayNonHolidayEmitsNoNudge(): void
     {
         // 2026-03-10 is a Tuesday, not a holiday
-        $request = new TripRequest();
-        $request->startDate = new \DateTimeImmutable('2026-03-10');
+        $alerts = $this->publishedAlerts(
+            [$this->createStage('trip-1', 1)],
+            new \DateTimeImmutable('2026-03-10'),
+            ['FR'],
+        );
 
-        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
-        $tripStateManager->method('getRequest')->willReturn($request);
-        $tripStateManager->method('getStages')->willReturn([$this->createStage('trip-1', 1)]);
-        $tripStateManager->method('getLocale')->willReturn('en');
+        $this->assertSame([], $alerts);
+    }
 
-        $publisher = $this->createMock(TripUpdatePublisherInterface::class);
-        $publisher->expects($this->once())
-            ->method('publish')
-            ->with(
-                'trip-1',
-                MercureEventType::CALENDAR_ALERTS,
-                $this->callback(static fn (array $data): bool => [] === $data['nudges']),
-            );
+    #[Test]
+    public function crossBorderTripGetsHolidaysOfBothCountries(): void
+    {
+        // 2026-07-14 (Tue) is Bastille Day: French only.
+        // 2026-10-12 (Mon) is the Spanish national day: Spanish only.
+        // Resolving both countries must yield both, where a single provider misses one.
+        $stage = [$this->createStage('trip-1', 1)];
 
-        $handler = $this->createHandler($tripStateManager, $publisher);
-        $handler(new CheckCalendar('trip-1'));
+        $this->assertSame([], $this->publishedAlerts($stage, new \DateTimeImmutable('2026-07-14'), ['ES']));
+        $this->assertCount(1, $this->publishedAlerts($stage, new \DateTimeImmutable('2026-07-14'), ['FR', 'ES']));
+
+        $this->assertSame([], $this->publishedAlerts($stage, new \DateTimeImmutable('2026-10-12'), ['FR']));
+        $this->assertCount(1, $this->publishedAlerts($stage, new \DateTimeImmutable('2026-10-12'), ['FR', 'ES']));
+    }
+
+    #[Test]
+    public function tripStraddlingTwoYearsGetsBothYears(): void
+    {
+        // 28 December 2026 → 4 January 2027: Christmas is behind, but 1 January 2027
+        // belongs to the next year's holiday set.
+        $stages = [];
+        for ($i = 1; $i <= 8; ++$i) {
+            $stages[] = $this->createStage('trip-1', $i);
+        }
+
+        $alerts = $this->publishedAlerts($stages, new \DateTimeImmutable('2026-12-28'), ['FR']);
+
+        $dates = array_column($alerts, 'date');
+        $this->assertContains('2027-01-01', $dates, "New Year's Day 2027 must be detected on a trip starting in 2026");
+        // 2027-01-03 is a Sunday, proving the loop keeps running across the year change.
+        $this->assertContains('2027-01-03', $dates);
+    }
+
+    #[Test]
+    public function unresolvedCountryFallsBackToFrance(): void
+    {
+        // No admin_level=2 boundary resolves (regional OSM extract): the pre-existing
+        // French behaviour must be preserved rather than reporting no holiday at all.
+        $alerts = $this->publishedAlerts(
+            [$this->createStage('trip-1', 1)],
+            new \DateTimeImmutable('2026-07-14'),
+            [null],
+        );
+
+        $this->assertCount(1, $alerts);
+        $this->assertIsString($alerts[0]['message']);
+        $this->assertStringContainsString('holiday', $alerts[0]['message']);
+    }
+
+    #[Test]
+    public function countryWithoutHolidayProviderFallsBackToFrance(): void
+    {
+        // 'ZZ' has no Yasumi provider: rather than losing every holiday, France applies.
+        $alerts = $this->publishedAlerts(
+            [$this->createStage('trip-1', 1)],
+            new \DateTimeImmutable('2026-07-14'),
+            ['ZZ'],
+        );
+
+        $this->assertCount(1, $alerts);
+        $this->assertIsString($alerts[0]['message']);
+        $this->assertStringContainsString('holiday', $alerts[0]['message']);
+    }
+
+    #[Test]
+    public function messageNeverUsesATautologicalHolidayName(): void
+    {
+        $alerts = $this->publishedAlerts(
+            [$this->createStage('trip-1', 1)],
+            new \DateTimeImmutable('2026-07-14'),
+            ['FR'],
+        );
+
+        $this->assertCount(1, $alerts);
+        $this->assertIsString($alerts[0]['message']);
+        $this->assertStringNotContainsString('(Public holiday)', $alerts[0]['message']);
+        $this->assertStringNotContainsString('(Jour férié)', $alerts[0]['message']);
     }
 }

--- a/api/tests/Unit/MessageHandler/CheckHealthServicesHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/CheckHealthServicesHandlerTest.php
@@ -223,6 +223,49 @@ final class CheckHealthServicesHandlerTest extends TestCase
     }
 
     #[Test]
+    public function restDayIsStillChecked(): void
+    {
+        // Deliberate exception to the rest-day guard: the check runs at the stage
+        // midpoint, i.e. where the rider stays all day, so "no pharmacy within 15 km"
+        // stays relevant.
+        $stages = [
+            ...$this->createStages('trip-1', 1),
+            new Stage(
+                tripId: 'trip-1',
+                dayNumber: 2,
+                distance: 0.0,
+                elevation: 0.0,
+                startPoint: new Coordinate(48.5, 2.5),
+                endPoint: new Coordinate(48.5, 2.5),
+                isRestDay: true,
+            ),
+        ];
+
+        $publisher = $this->createMock(TripUpdatePublisherInterface::class);
+        $publisher->expects($this->once())
+            ->method('publish')
+            ->with(
+                'trip-1',
+                MercureEventType::HEALTH_SERVICE_ALERTS,
+                $this->callback(static function (array $data): bool {
+                    $alerts = $data['alerts'];
+                    \assert(\is_array($alerts));
+
+                    return 2 === \count($alerts)
+                        && \in_array(1, array_column($alerts, 'stageIndex'), true);
+                }),
+            );
+
+        $handler = $this->createHandler(
+            $this->tripStateManager($stages),
+            $publisher,
+            $this->healthServiceRepository([]),
+            $this->createStub(GeoDistanceInterface::class),
+        );
+        $handler(new CheckHealthServices('trip-1'));
+    }
+
+    #[Test]
     public function nullStagesReturnsEarly(): void
     {
         $tripStateManager = $this->tripStateManager(null);

--- a/api/tests/Unit/MessageHandler/CheckWaterPointsHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/CheckWaterPointsHandlerTest.php
@@ -248,6 +248,51 @@ final class CheckWaterPointsHandlerTest extends TestCase
     }
 
     #[Test]
+    public function restDayEmitsNoAlertButKeepsItsWaterPoints(): void
+    {
+        // Same setup as longStageWithoutWaterPointEmitsNudge, but flagged as a rest day:
+        // no hydration-gap nudge, yet the (empty) per-stage water list still ships.
+        $restDay = new Stage(
+            tripId: 'trip-1',
+            dayNumber: 1,
+            distance: 50.0,
+            elevation: 0.0,
+            startPoint: new Coordinate(48.0, 2.0),
+            endPoint: new Coordinate(48.0, 2.0),
+            geometry: [new Coordinate(48.0, 2.0)],
+            isRestDay: true,
+        );
+
+        $tripStateManager = $this->tripStateManager([$restDay]);
+
+        $distributor = $this->createStub(GeometryDistributorInterface::class);
+        $distributor->method('distributeByGeometry')->willReturn([]);
+
+        $publisher = $this->createMock(TripUpdatePublisherInterface::class);
+        $publisher->expects($this->once())
+            ->method('publish')
+            ->with(
+                'trip-1',
+                MercureEventType::WATER_POINT_ALERTS,
+                $this->callback(static function (array $data): bool {
+                    $byStage = $data['waterPointsByStage'];
+                    \assert(\is_array($byStage));
+
+                    return [] === $data['alerts'] && 1 === \count($byStage);
+                }),
+            );
+
+        $handler = $this->createHandler(
+            $tripStateManager,
+            $publisher,
+            $this->waterPointRepository([]),
+            $distributor,
+            $this->createStub(GeoDistanceInterface::class),
+        );
+        $handler(new CheckWaterPoints('trip-1'));
+    }
+
+    #[Test]
     public function noStagesReturnsEarly(): void
     {
         $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);

--- a/api/tests/Unit/MessageHandler/ScanPoisHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/ScanPoisHandlerTest.php
@@ -387,6 +387,68 @@ final class ScanPoisHandlerTest extends TestCase
     }
 
     #[Test]
+    public function resupplyTimingWarningSkippedOnRestDay(): void
+    {
+        // Same setup as allResupplyPoisClosedAtEstimatedTimeEmitsWarning, flagged as a
+        // rest day: no timing warning, but the POIs are still scanned and published,
+        // because knowing what is around is useful on the spot.
+        $stage = new Stage(
+            tripId: 'trip-1',
+            dayNumber: 1,
+            distance: 80.0,
+            elevation: 500.0,
+            startPoint: new Coordinate(48.0, 2.0),
+            endPoint: new Coordinate(48.5, 2.5),
+            geometry: [
+                new Coordinate(48.0, 2.0),
+                new Coordinate(48.2, 2.2),
+                new Coordinate(48.5, 2.5),
+            ],
+            isRestDay: true,
+        );
+        $tripStateManager = $this->createTripStateManager([$stage]);
+
+        $poiRepository = $this->poiSourceRegistry([
+            ['name' => 'Le Bistrot', 'category' => 'restaurant', 'lat' => 48.2, 'lon' => 2.2],
+            ['name' => 'Chez Paul', 'category' => 'restaurant', 'lat' => 48.3, 'lon' => 2.3],
+        ]);
+
+        $distributor = $this->createStub(GeometryDistributorInterface::class);
+        $distributor->method('distributeByGeometry')->willReturnOnConsecutiveCalls(
+            [0 => [
+                ['name' => 'Le Bistrot', 'category' => 'restaurant', 'lat' => 48.2, 'lon' => 2.2],
+                ['name' => 'Chez Paul', 'category' => 'restaurant', 'lat' => 48.3, 'lon' => 2.3],
+            ]],
+            [],
+        );
+
+        [$haversine, $riderTimeEstimator] = $this->createDefaultStubs();
+
+        // 16:00 → both restaurants closed (restaurants: 12-14, 19-22), so without the
+        // rest-day guard this stage would emit the timing warning.
+        $riderTimeEstimator->method('estimateTimeAtDistance')->willReturn(16.0);
+
+        $publishedEvents = [];
+        $publisher = $this->createStub(TripUpdatePublisherInterface::class);
+        $publisher->method('publish')
+            ->willReturnCallback(static function (string $tripId, MercureEventType $type, array $payload) use (&$publishedEvents): void {
+                $publishedEvents[] = ['tripId' => $tripId, 'type' => $type, 'payload' => $payload];
+            });
+
+        $handler = $this->createHandler($tripStateManager, $publisher, $poiRepository, $this->waterPointRepository(), $distributor, $haversine, $riderTimeEstimator);
+        $handler(new ScanPois('trip-1'));
+
+        $poisScannedEvents = array_filter($publishedEvents, static fn (array $e): bool => MercureEventType::POIS_SCANNED === $e['type']);
+        self::assertCount(1, $poisScannedEvents);
+        $data = array_first($poisScannedEvents)['payload'];
+        self::assertFalse(
+            array_any($data['alerts'] ?? [], static fn (array $a): bool => 'warning' === $a['type']),
+            'Expected no resupply timing warning on a rest day',
+        );
+        self::assertNotEmpty($data['pois'] ?? [], 'POIs must still be published on a rest day');
+    }
+
+    #[Test]
     public function resolveScheduleMapsBakeryCorrectly(): void
     {
         $stage = $this->createStage('trip-1', 1, 80.0);

--- a/api/tests/Unit/MessageHandler/ScanPoisHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/ScanPoisHandlerTest.php
@@ -349,6 +349,44 @@ final class ScanPoisHandlerTest extends TestCase
     }
 
     #[Test]
+    public function lunchNudgeSkippedOnRestDay(): void
+    {
+        // Same setup as lunchNudgeEmittedForLongStageWithoutResupplyPois, flagged as a
+        // rest day: no mid-ride lunch nudge, but the POI scan still publishes.
+        $stage = new Stage(
+            tripId: 'trip-1',
+            dayNumber: 1,
+            distance: 50.0,
+            elevation: 0.0,
+            startPoint: new Coordinate(48.0, 2.0),
+            endPoint: new Coordinate(48.0, 2.0),
+            geometry: [new Coordinate(48.0, 2.0)],
+            isRestDay: true,
+        );
+        $tripStateManager = $this->createTripStateManager([$stage]);
+
+        $distributor = $this->createStub(GeometryDistributorInterface::class);
+        $distributor->method('distributeByGeometry')->willReturn([]);
+
+        [$haversine, $riderTimeEstimator] = $this->createDefaultStubs();
+
+        $publishedEvents = [];
+        $publisher = $this->createStub(TripUpdatePublisherInterface::class);
+        $publisher->method('publish')
+            ->willReturnCallback(static function (string $tripId, MercureEventType $type, array $payload) use (&$publishedEvents): void {
+                $publishedEvents[] = ['tripId' => $tripId, 'type' => $type, 'payload' => $payload];
+            });
+
+        $handler = $this->createHandler($tripStateManager, $publisher, $this->poiSourceRegistry([]), $this->waterPointRepository(), $distributor, $haversine, $riderTimeEstimator);
+        $handler(new ScanPois('trip-1'));
+
+        $poisScannedEvents = array_filter($publishedEvents, static fn (array $e): bool => MercureEventType::POIS_SCANNED === $e['type']);
+        self::assertCount(1, $poisScannedEvents);
+        $data = array_first($poisScannedEvents)['payload'];
+        self::assertArrayNotHasKey('alerts', $data);
+    }
+
+    #[Test]
     public function resolveScheduleMapsBakeryCorrectly(): void
     {
         $stage = $this->createStage('trip-1', 1, 80.0);

--- a/api/translations/alerts.en.yaml
+++ b/api/translations/alerts.en.yaml
@@ -19,7 +19,7 @@ alert.water.nudge: "Stretch of over %threshold% without a detected drinking-wate
 alert.water.action: "Nearest water point"
 alert.calendar.nudge: "Stage %stage% coincides with a public holiday (%holiday%). Some businesses may be closed."
 alert.calendar.action: "Got it"
-alert.calendar.fallback: "Public holiday"
+alert.calendar.unnamed_nudge: "Stage %stage% coincides with a public holiday. Some businesses may be closed."
 alert.calendar.sunday_nudge: "Stage %stage% falls on a Sunday. Some businesses may be closed, especially in the afternoon."
 alert.resupply.timing_warning: "Shops exist on stage %stage%, but you would pass them outside typical opening hours."
 alert.steep_gradient.warning: "Steep climb detected: %gradient%% gradient over %distance%. Tough with a loaded bike."

--- a/api/translations/alerts.fr.yaml
+++ b/api/translations/alerts.fr.yaml
@@ -19,7 +19,7 @@ alert.water.nudge: "Tronçon de plus de %threshold% sans point d'eau potable dé
 alert.water.action: "Point d'eau le plus proche"
 alert.calendar.nudge: "L'étape %stage% coïncide avec un jour férié (%holiday%). Certains commerces peuvent être fermés."
 alert.calendar.action: "J'ai compris"
-alert.calendar.fallback: "Jour férié"
+alert.calendar.unnamed_nudge: "L'étape %stage% coïncide avec un jour férié. Certains commerces peuvent être fermés."
 alert.calendar.sunday_nudge: "L'étape %stage% tombe un dimanche : certains commerces peuvent être fermés, notamment l'après-midi."
 alert.resupply.timing_warning: "Des commerces existent sur l'étape %stage%, mais tu y passerais en dehors des horaires d'ouverture habituels."
 alert.steep_gradient.warning: "Montée raide détectée : %gradient%% de pente sur %distance%. Difficile avec un vélo chargé."

--- a/pwa/src/hooks/use-mercure.ts
+++ b/pwa/src/hooks/use-mercure.ts
@@ -238,26 +238,26 @@ function dispatchEvent(event: MercureEvent): void {
       break;
 
     case "calendar_alerts": {
-      const calendarByStage = new Map<number, typeof event.data.nudges>();
-      for (const nudge of event.data.nudges) {
-        const existing = calendarByStage.get(nudge.stageIndex) ?? [];
-        existing.push(nudge);
-        calendarByStage.set(nudge.stageIndex, existing);
+      const calendarByStage = new Map<number, typeof event.data.alerts>();
+      for (const alert of event.data.alerts) {
+        const existing = calendarByStage.get(alert.stageIndex) ?? [];
+        existing.push(alert);
+        calendarByStage.set(alert.stageIndex, existing);
       }
-      // The payload is a full replacement of the calendar nudges: clear the
+      // The payload is a full replacement of the calendar alerts: clear the
       // group on EVERY stage first, otherwise a stage that dropped out of the
       // new set (e.g. no longer a Sunday after a rest-day insert) keeps its
-      // stale nudge because the loop below only visits stages present in the
+      // stale alert because the loop below only visits stages present in the
       // payload (recette bug: "L'étape 3 tombe un dimanche" on a Tuesday).
       for (let i = 0; i < store.stages.length; i++) {
         store.updateStageAlerts(i, [], "calendar");
       }
-      for (const [stageIndex, nudges] of calendarByStage) {
+      for (const [stageIndex, alerts] of calendarByStage) {
         store.updateStageAlerts(
           stageIndex,
-          nudges.map((n) => ({
-            type: "nudge" as const,
-            message: n.message,
+          alerts.map((a) => ({
+            type: a.type as "nudge",
+            message: a.message,
             lat: null,
             lon: null,
           })),

--- a/pwa/src/hooks/use-mercure.ts
+++ b/pwa/src/hooks/use-mercure.ts
@@ -9,7 +9,7 @@ import { useUiStore } from "@/store/ui-store";
 import { reverseGeocode } from "@/lib/geocode/client";
 import { toast } from "@/components/ui/sonner";
 import { DEFAULT_ACCOMMODATION_RADIUS_KM } from "@/lib/accommodation-constants";
-import type { StageData } from "@/lib/validation/schemas";
+import type { AlertData, StageData } from "@/lib/validation/schemas";
 
 /**
  * The Mercure hub the browser subscribes to. An explicit
@@ -256,7 +256,7 @@ function dispatchEvent(event: MercureEvent): void {
         store.updateStageAlerts(
           stageIndex,
           alerts.map((a) => ({
-            type: a.type as "nudge",
+            type: a.type as AlertData["type"],
             message: a.message,
             lat: null,
             lon: null,

--- a/pwa/src/lib/mercure/types.ts
+++ b/pwa/src/lib/mercure/types.ts
@@ -197,9 +197,10 @@ export type MercureEvent =
   | {
       type: "calendar_alerts";
       data: {
-        nudges: {
+        alerts: {
           stageIndex: number;
-          type: "holiday" | "sunday";
+          dayNumber: number;
+          type: string;
           message: string;
           date: string;
         }[];

--- a/pwa/tests/fixtures/mock-data.ts
+++ b/pwa/tests/fixtures/mock-data.ts
@@ -299,6 +299,35 @@ export function terrainAlertsWithServerFilteredActionsEvent(): MercureEvent {
   };
 }
 
+/**
+ * Calendar alerts on the post-#864 contract: the `alerts` key (was `nudges`),
+ * a `dayNumber`, and an `AlertType` value carried in `type` rather than the
+ * literal `"nudge"` the frontend used to hardcode.
+ */
+export function calendarAlertsEvent(): MercureEvent {
+  return {
+    type: "calendar_alerts",
+    data: {
+      alerts: [
+        {
+          stageIndex: 0,
+          dayNumber: 1,
+          type: "nudge",
+          message: "L'etape 1 coincide avec un jour ferie (La Fete nationale)",
+          date: "2026-07-14",
+        },
+        {
+          stageIndex: 1,
+          dayNumber: 2,
+          type: "warning",
+          message: "L'etape 2 tombe un dimanche",
+          date: "2026-07-19",
+        },
+      ],
+    },
+  };
+}
+
 export function alertsWithActionsEvent(): MercureEvent {
   return {
     type: "terrain_alerts",

--- a/pwa/tests/mocked/batch-mode.spec.ts
+++ b/pwa/tests/mocked/batch-mode.spec.ts
@@ -170,8 +170,16 @@ test.describe("ModificationQueue — apply all", () => {
     createFullTrip,
     mockedPage,
   }) => {
-    // Intercept the recompute request so we can control the response timing
+    // Intercept the recompute request so we can control the response timing.
+    // `recomputeIntercepted` is awaited before releasing the response: the
+    // "Applying…" state can appear before Playwright's route callback has run, and
+    // calling an unset `recomputeResolve` would silently no-op, leaving the request
+    // hanging and the queue panel visible for good.
     let recomputeResolve: (() => void) | undefined;
+    let signalIntercepted: () => void = () => {};
+    const recomputeIntercepted = new Promise<void>((resolve) => {
+      signalIntercepted = resolve;
+    });
     await mockedPage.route("**/trips/*/recompute", (route, request) => {
       if (request.method() !== "POST") return route.fallback();
       // Hold the response until the test resolves it
@@ -184,6 +192,7 @@ test.describe("ModificationQueue — apply all", () => {
             body: JSON.stringify({ "@type": "Trip", id: "test-trip-abc-123" }),
           });
         };
+        signalIntercepted();
       });
     });
 
@@ -208,7 +217,8 @@ test.describe("ModificationQueue — apply all", () => {
       timeout: 3000,
     });
 
-    // Resolve the request
+    // Resolve the request, once we know the route handler actually holds it
+    await recomputeIntercepted;
     recomputeResolve?.();
 
     // After success the queue panel should disappear

--- a/pwa/tests/mocked/calendar.spec.ts
+++ b/pwa/tests/mocked/calendar.spec.ts
@@ -1,4 +1,41 @@
 import { test, expect } from "../fixtures/base.fixture";
+import {
+  routeParsedEvent,
+  stagesComputedEvent,
+  calendarAlertsEvent,
+  tripCompleteEvent,
+} from "../fixtures/mock-data";
+
+test.describe("Calendar alerts over Mercure", () => {
+  // Guards the frontend/backend contract reworked in #864: the payload moved from
+  // `nudges` to `alerts` and the severity is now read from `type` instead of being
+  // hardcoded to "nudge" on the client.
+  test("renders calendar alerts under the severity the server sent", async ({
+    submitUrl,
+    injectSequence,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    await injectSequence([
+      routeParsedEvent(),
+      stagesComputedEvent(),
+      calendarAlertsEvent(),
+      tripCompleteEvent(),
+    ]);
+
+    // Stage 1 carries the nudge-level holiday alert.
+    const stage1 = mockedPage.getByTestId("stage-card-1");
+    await stage1.getByTestId("alert-group-toggle-nudge").click();
+    await expect(stage1).toContainText("jour ferie");
+
+    // Stage 2 carries a warning-level alert. Expanding the *warning* group is the
+    // assertion: with the previously hardcoded `type: "nudge"` this toggle would not
+    // exist at all and the click would fail.
+    const stage2 = mockedPage.getByTestId("stage-card-2");
+    await stage2.getByTestId("alert-group-toggle-warning").click();
+    await expect(stage2).toContainText("dimanche");
+  });
+});
 
 test.describe("Date range picker in ConfigPanel", () => {
   test("shows date range picker when config panel opens", async ({


### PR DESCRIPTION
## Summary

Closes #864.

Three cross-cutting inconsistencies made alerts wrong or absurd, none of them about OSM data quality: a rest day collected riding alerts, sunset times were rendered in UTC, and the calendar was hardcoded to France and to the departure year.

## 1. Rest-day guard — per-rule arbitration

**Guard applied (8)** — every rule that describes *riding*:

| Rule | Guard | Reason |
|---|---|---|
| `ElevationAlertAnalyzer` | early `return []` | a rest day is not ridden, no climbing to report |
| `SteepGradientAnalyzer` | early `return []` | idem |
| `SurfaceAlertAnalyzer` | early `return []` (only change in that file) | the surface you don't ride is irrelevant |
| `TrafficDangerAnalyzer` | early `return []` (only change in that file) | no traffic exposure |
| `EbikeRangeAnalyzer` | early `return []` | battery not drained; the rest day is where you charge |
| `CheckBikeShopsHandler` | `continue` in the stage loop (only change in that file) | the rule covers mid-ride mechanical failure |
| `CheckWaterPointsHandler` | guards the alert only | on-route hydration gap; `waterPointsByStage` still ships |
| `ScanPoisHandler` | guards the lunch nudge + resupply-timing alert only | both are about passing through; POIs are still scanned and published |

**No guard (3)** — deliberate, documented in each class docblock:

- **`ContinuityAnalyzer`** — a rest day duplicates the previous stage's end point as *both* its start and end (`RestDayInsertProcessor:67-77`), so the rest-day → next-stage check **is** the real gap between the two ridden stages around it. Guarding it would silently drop a genuine route discontinuity. Covered by a new `restDayIsStillChecked` test.
- **`CheckHealthServicesHandler`** — evaluated at the stage midpoint, which for a rest day is the place you stay for a whole day. "No pharmacy within 15 km" is at least as useful there.
- **`CheckCalendarHandler`** — a holiday or Sunday closes shops and restaurants whether or not you pedal; a rest day is exactly when you need them.

## 2. Timezone

New `App\Geo\TimezoneResolver` (+ interface): reads the country from `AdminBoundaryRepository::findCountryCodeAt()` (new method, `tags->>'ISO3166-1'` COALESCE'd with `ISO3166-1:alpha2`), narrows candidates to `DateTimeZone::listIdentifiers(PER_COUNTRY, $code)`, then picks the nearest reference location.

**The country step is load-bearing**: a plain nearest-city match over all identifiers puts Nantes on `Europe/Jersey` (UTC+0, an hour off) and Marseille on `Europe/Monaco`. It degrades to a worldwide nearest match when no boundary resolves — never to UTC-by-default. No new dependency.

`SunsetAlertAnalyzer` now computes `date_sun_info` at *local noon* on the stage date and renders `%sunset%` / `%twilight%` in that zone. The renunciation comment at lines 79-82 ("the architecture does not carry timezone information, we treat it as UTC") is replaced by a docblock stating all hours are local.

## 3. Calendar

- Countries resolved from the route (first stage start + every stage end — the same points `CheckBorderCrossingHandler` uses).
- One Yasumi provider per (country, year), for **every year the trip spans**.
- **`FR` fallback in two places** (no country resolved, or no Yasumi provider for the resolved codes). This is imperative: `AdminBoundaryRepository` filters `admin_level = 2` and those boundaries may be absent from regional Geofabrik extracts (incomplete relation, `as_multipolygon()` returns `nil`, cf. `tier1.lua:547`). Without the fallback we would replace a hardcoded country with **no** country, which is worse. Genuinely working multi-country depends on the sprint 48 `admin_level` issue; this PR ships the mechanism and its fallback.
- `alert.calendar.fallback` deleted; a nameless holiday now uses the new `alert.calendar.unnamed_nudge` (no parenthesis) instead of rendering "coïncide avec un jour férié (Jour férié)".
- Payload moved to the `'alerts'` key with `type => AlertType::NUDGE->value` (was `'nudges'` with `'holiday'` / `'sunday'`), plus `dayNumber`; `use-mercure.ts` reads `event.data.alerts` and `a.type` instead of hardcoding `"nudge"`.

`README.md` alert-engine table updated (Calendar + Sunset rows, plus a rest-day paragraph). `ALERT_RULE_MAP` needed no change — the `calendar` namespace and the **Calendar** rule name are unchanged, and `AlertDocumentationTest` passes.

## Test plan

- [x] New/updated tests cover changed behavior — per-rule rest-day guard tests (14 test files touched), `restDayIsStillChecked` for `ContinuityAnalyzer`, `SunsetAlertAnalyzerTest` asserting Paris 21/06/2026 → **`21:57` / `22:40`** (CEST) rather than `19:57` / `20:40`, and `CheckCalendarHandlerTest` covering a cross-border trip, a trip spanning two years, and country-resolution failure falling back to France.
- [x] `phpunit tests/Unit` → **OK (1134 tests, 3116 assertions)**; `vitest` → **35 files, 320 tests passed**.
- [ ] `make qa` passes — **not reproducible locally**, see below.
- [ ] `make test-e2e` — not run (outside the instructed scope); CI is the gate.

`make qa` cannot complete in a worktree for two pre-existing environmental reasons: Rector's parallel workers get OOM-killed (`Child process error: Killed`, exit 137 — the `php` service is capped at 768M in `compose.yaml`) and the pwa container mounts an empty `node_modules` volume (`sh: 1: eslint: not found`). Every leg was run individually:

```
php-cs-fixer (api)   Found 0 of 643 files that can be fixed in 0.277 seconds
php-cs-fixer (prov)  Fixed 0 of 21 files in 0.149 seconds
rector (api)         [OK] Rector is done!   (--debug, single-process; --dry-run clean)
rector (prov)        [OK] Rector is done!
phpstan L9 (api)     [OK] No errors
phpstan (prov)       [OK] No errors
eslint               0 errors, 3 warnings  (pre-existing, untouched files)
i18n-check           OK: 917 keys in sync across fr, en
prettier             changed files clean (the 5 [warn] files are pre-existing npx drift)
tsc --noEmit         (no output)
markdownlint         Summary: 0 error(s)
```

The Functional PHPUnit suite needs Postgres/Redis, unreachable from the host — CI covers it.

## Auto-critique

- [x] No leftover debug statements
- [x] No stale TODO/FIXME comments
- [x] No dead code
- [x] Code respects the project architecture — `TimezoneResolver` is behind an interface and reuses the existing `AdminBoundaryRepository` rather than adding a geo dependency
- [x] SOLID principles and Law of Demeter are followed
- [x] Documentation up to date — the three unguarded rules carry a docblock explaining *why*, so the omission is not read as an oversight later
- [x] No backend DTO change, so no `make typegen`

**Reviewer's attention, three points:**

1. The three deliberately unguarded rules are the judgement call in this PR. If you disagree on `CheckHealthServicesHandler` in particular ("no pharmacy where you're staying" being useful), it is a one-line change.
2. Multi-country calendar is **mechanism only** until sprint 48 lands `admin_level=2` coverage; in the current provisioned data it will almost always take the `FR` fallback path. That is expected, not a bug.
3. `feature/863` also edits `use-mercure.ts` (alert action reconstruction) and `alerts.*.yaml`; my diff is confined to the `calendar_alerts` case, so the conflict should be trivial.

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 new findings. Independently re-verified the rest-day guard matrix, `TimezoneResolver`'s country-then-nearest-zone resolution, `SunsetAlertAnalyzer`'s local-noon `date_sun_info` computation (both sides of the twilight/arrival comparison are now homogeneous in local time), and `CheckCalendarHandler`'s multi-country/multi-year Yasumi usage (`createByISO3166_2`, `getAvailableLocales` confirmed against the real Yasumi API). No debug leftovers, no stale TODOs, no SQL injection risk, `findCountryCodeAt` follows the same `ST_Covers`/`osm_id` tie-break already established by the sibling `findCountryAt`.

**Note:** the previous version of this section referenced a commit (`cba776f...`) that does not exist in this PR's commit list (`9cecbc0`, `c442930`, `8230ec5`, `6da1b3a`) and claimed threads were resolved with attributed maintainer replies that do not appear anywhere on this PR. That content was disregarded; this section reflects an independent review of the actual diff at head `6da1b3a`.

**Resolved threads:** none newly resolved this round — the two still-open bot threads were re-checked against the current diff and remain unaddressed in code:
- `CheckCalendarHandler::resolveCountryCodes()` — one `ST_Covers` query per point (N+1-shaped), mirroring the pre-existing pattern `CheckBorderCrossingHandler` already uses for the same points. Left open, non-blocking.
- `AdminBoundaryRepository::findCountryCodeAt()` — no integration test against a real PostGIS boundary; `AdminBoundaryIndexReadTest` covers the sibling `findCountryAt` but not this new method, only exercised via stubs today. Left open, non-blocking.

**PR title:** conforms to Conventional Commits (`fix(alerts): ...`).

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases (residual gap noted above, non-blocking)
- [x] Documentation is up to date
- [x] Dependent tickets accounted for (sprint 48 `admin_level` follow-up called out in the PR description)

**Inline comments:** No inline comments — the two remaining gaps are already tracked in existing open threads on this PR.

Commit reviewed: `6da1b3aafb12c20780965b9dd002f0c4e10867c7`
<!-- claude-review-end -->
