### PR TITLE
docs(tracking): record sprint 44 PRs and the expected merge conflicts

### DIFF
--- a/TRACKING.md
+++ b/TRACKING.md
@@ -1200,14 +1200,24 @@ Assainissement du moteur d'alertes : ce qui est faux, ce qui n'est pas fondé, c
 >
 > **Ordre interne impératif :** #862 (formateur) **après** #859 (attribution). Formater joliment un nombre mal attribué est pire que de le laisser brut : « 43,9 km » se lit comme une mesure autorisée, `43871m` se lit comme un artefact machine.
 
-| Ordre | ID | Titre | Effort | PRs | Dépend de |
-|-------|----|-------|--------|-----|-----------|
-| 1 | [#859](https://github.com/vincentchalamon/bike-trip-planner/issues/859) | fix(terrain): attribute ways to the ridden route, not to a 100 m neighbourhood | - | - | - |
-| 2 | [#860](https://github.com/vincentchalamon/bike-trip-planner/issues/860) | fix(terrain): widen the unpaved surface vocabulary | - | - | - |
-| 3 | [#861](https://github.com/vincentchalamon/bike-trip-planner/issues/861) | fix(alerts): drop the tag-presence rules and the dead surface fallback | - | - | - |
-| 4 | [#862](https://github.com/vincentchalamon/bike-trip-planner/issues/862) | feat(alerts): locale-aware distance formatter and translated tag values | - | - | [#859](https://github.com/vincentchalamon/bike-trip-planner/issues/859) |
-| 5 | [#863](https://github.com/vincentchalamon/bike-trip-planner/issues/863) | fix(alerts): restore navigate and dismiss actions with coordinates end-to-end | - | - | - |
-| 6 | [#864](https://github.com/vincentchalamon/bike-trip-planner/issues/864) | fix(alerts): rest-day guard, local-time sunset and multi-year calendar | - | - | - |
+| Ordre | ID | Titre | Effort | PRs | Statut | Dépend de |
+|-------|----|-------|--------|-----|--------|-----------|
+| 1 | [#859](https://github.com/vincentchalamon/bike-trip-planner/issues/859) | fix(terrain): attribute ways to the ridden route, not to a 100 m neighbourhood | - | [#894](https://github.com/vincentchalamon/bike-trip-planner/pull/894) `feature/859` | En cours | - |
+| 2 | [#860](https://github.com/vincentchalamon/bike-trip-planner/issues/860) | fix(terrain): widen the unpaved surface vocabulary | - | [#895](https://github.com/vincentchalamon/bike-trip-planner/pull/895) `feature/860` | En cours | - |
+| 3 | [#861](https://github.com/vincentchalamon/bike-trip-planner/issues/861) | fix(alerts): drop the tag-presence rules and the dead surface fallback | - | [#896](https://github.com/vincentchalamon/bike-trip-planner/pull/896) `feature/861` | En cours | - |
+| 4 | [#862](https://github.com/vincentchalamon/bike-trip-planner/issues/862) | feat(alerts): locale-aware distance formatter and translated tag values | - | [#899](https://github.com/vincentchalamon/bike-trip-planner/pull/899) `feature/862` → base `feature/859` | En cours | [#859](https://github.com/vincentchalamon/bike-trip-planner/issues/859) |
+| 5 | [#863](https://github.com/vincentchalamon/bike-trip-planner/issues/863) | fix(alerts): restore navigate and dismiss actions with coordinates end-to-end | - | [#897](https://github.com/vincentchalamon/bike-trip-planner/pull/897) `feature/863` | En cours | - |
+| 6 | [#864](https://github.com/vincentchalamon/bike-trip-planner/issues/864) | fix(alerts): rest-day guard, local-time sunset and multi-year calendar | - | [#898](https://github.com/vincentchalamon/bike-trip-planner/pull/898) `feature/864` | En cours | - |
+
+### Ordre de merge et conflits attendus (sprint 44)
+
+Les 6 issues ont été traitées en parallèle via `/sprint 44`, donc plusieurs branches touchent les mêmes fichiers. Points à surveiller au merge :
+
+- **#899 est empilée sur `feature/859`** (base ≠ `main`) : merger **#894 d'abord**, puis #899 se retargette automatiquement sur `main`.
+- **`SurfaceAlertAnalyzer.php`** — #895 étend le vocabulaire, #896 **supprime** `detectMissingSurfaceData()`, #898 y ajoute le garde `isRestDay`, #899 y injecte le formateur. La suppression de #896 doit gagner ; vérifier que le repli `tracktype` de #895 ne la réintroduit pas.
+- **`WaysRepository.php`** — #894 réécrit le SQL du corridor, #895 ajoute deux colonnes au `SELECT`. Diffs disjoints par construction.
+- **`alerts.fr.yaml` / `alerts.en.yaml`** — touchés par #895, #896, #897, #898 et #899. #899 laisse volontairement `alert.surface.fallback` en place parce que #896 la supprime (évite une suppression concurrente).
+- **`use-mercure.ts`** — #897 (reconstruction d'action) et #898 (payload calendrier) ; diffs sur des `case` distincts.
 
 ### Recette Sprint 44
 

--- a/TRACKING.md
+++ b/TRACKING.md
@@ -1203,7 +1203,7 @@ Assainissement du moteur d'alertes : ce qui est faux, ce qui n'est pas fondé, c
 | Ordre | ID | Titre | Effort | PRs | Statut | Dépend de |
 |-------|----|-------|--------|-----|--------|-----------|
 | 1 | [#859](https://github.com/vincentchalamon/bike-trip-planner/issues/859) | fix(terrain): attribute ways to the ridden route, not to a 100 m neighbourhood | - | [#894](https://github.com/vincentchalamon/bike-trip-planner/pull/894) `feature/859` | ✅ Mergée | - |
-| 2 | [#860](https://github.com/vincentchalamon/bike-trip-planner/issues/860) | fix(terrain): widen the unpaved surface vocabulary | - | [#895](https://github.com/vincentchalamon/bike-trip-planner/pull/895) `feature/860` | En cours (rebasée) | - |
+| 2 | [#860](https://github.com/vincentchalamon/bike-trip-planner/issues/860) | fix(terrain): widen the unpaved surface vocabulary | - | [#895](https://github.com/vincentchalamon/bike-trip-planner/pull/895) `feature/860` | ✅ Mergée | - |
 | 3 | [#861](https://github.com/vincentchalamon/bike-trip-planner/issues/861) | fix(alerts): drop the tag-presence rules and the dead surface fallback | - | [#896](https://github.com/vincentchalamon/bike-trip-planner/pull/896) `feature/861` | ✅ Mergée | - |
 | 4 | [#862](https://github.com/vincentchalamon/bike-trip-planner/issues/862) | feat(alerts): locale-aware distance formatter and translated tag values | - | [#899](https://github.com/vincentchalamon/bike-trip-planner/pull/899) `feature/862` | En cours (rebasée sur `main`) | [#859](https://github.com/vincentchalamon/bike-trip-planner/issues/859) ✅ |
 | 5 | [#863](https://github.com/vincentchalamon/bike-trip-planner/issues/863) | fix(alerts): restore navigate and dismiss actions with coordinates end-to-end | - | [#897](https://github.com/vincentchalamon/bike-trip-planner/pull/897) `feature/863` | ✅ Mergée | - |
@@ -1211,7 +1211,7 @@ Assainissement du moteur d'alertes : ce qui est faux, ce qui n'est pas fondé, c
 
 ### Conflits de merge : résolutions appliquées (sprint 44)
 
-Les 6 issues ont été traitées en parallèle via `/sprint 44`, donc plusieurs branches touchaient les mêmes fichiers. **#894, #896 et #897 sont mergées** ; les trois PRs restantes ont été rebasées sur `main` et les conflits résolus comme suit.
+Les 6 issues ont été traitées en parallèle via `/sprint 44`, donc plusieurs branches touchaient les mêmes fichiers. **#894, #895, #896 et #897 sont mergées** ; #898 et #899 ont été rebasées sur `main` et les conflits résolus comme suit.
 
 - **#899 était empilée sur `feature/859`.** Après le squash-merge de #894, GitHub l'a retargettée sur `main` mais la branche portait encore le commit pré-squash de #859. Résolu par `git rebase --onto origin/main <commit-859>` (pas un rebase simple, qui aurait rejoué du code déjà mergé).
 - **`SurfaceAlertAnalyzer.php`** — la suppression de `detectMissingSurfaceData()` par #896 a gagné dans #895 et #899, comme prévu. Effets de bord traités : le `$surfaceList` de #895 avait disparu (#896 a inliné le `implode`), et 5 cas de `SurfaceAlertAnalyzerTest` attendaient 2 alertes au lieu d'1.
@@ -1219,6 +1219,7 @@ Les 6 issues ont été traitées en parallèle via `/sprint 44`, donc plusieurs 
 - **`WaysIndexReadTest.php`** — #894 et #895 avaient chacune ajouté un test au même endroit : **les deux sont conservés**, et les deux colonnes de #895 ont été portées sur l'oracle réécrit par #894.
 - **`alerts.*.yaml`** — les clés supprimées par #896 (`alert.surface.fallback`, `alert.surface.missing_data`) ne sont pas réintroduites ; la ligne `alert.railway_station.action` ajoutée par #897 est préservée, et les reformulations de #895 / #899 conservées.
 - **`mock-data.ts`** — #897 et #898 avaient inséré une fixture au même endroit : **les deux sont conservées**.
+- **Arbitrage non prévu par les deux PRs — signaux de repli traduits.** #895 fait remonter `tracktype=grade4` / `smoothness=bad` comme pseudo-valeurs de surface dans le message, et #899 interdit toute valeur de tag brute dans un message traduit. Les deux étant désormais dans le même code, il fallait trancher : laisser passer la pseudo-valeur (fuite d'un tag brut, contraire au contrat de #899) ou la rabattre sur `surface.unknown` (perte de l'information de #895). **Choix retenu : 8 clés de traduction dédiées** (`surface.tracktype_grade3..5`, `surface.smoothness_bad..impassable`), et `translateSurface()` normalise le `=` en `_`. Le message reste informatif _et_ entièrement traduit. Les 5 tests de #895 qui assertaient la valeur brute ont été alignés.
 - **Interaction #897 ↔ #899** — #897 assertait que le libellé d'action valait la _clé_ de traduction (son stub renvoyait la clé) alors que #899 branche le vrai `Translator` ; l'assertion a été alignée sur la chaîne rendue.
 
 Note outillage : GitHub sait désormais gérer les [PRs empilées](https://docs.github.com/en/pull-requests/how-tos/stacked-pull-requests) — à utiliser pour les prochains sprints plutôt qu'une base `feature/<n>` manuelle.

--- a/TRACKING.md
+++ b/TRACKING.md
@@ -1202,22 +1202,26 @@ Assainissement du moteur d'alertes : ce qui est faux, ce qui n'est pas fondé, c
 
 | Ordre | ID | Titre | Effort | PRs | Statut | Dépend de |
 |-------|----|-------|--------|-----|--------|-----------|
-| 1 | [#859](https://github.com/vincentchalamon/bike-trip-planner/issues/859) | fix(terrain): attribute ways to the ridden route, not to a 100 m neighbourhood | - | [#894](https://github.com/vincentchalamon/bike-trip-planner/pull/894) `feature/859` | En cours | - |
-| 2 | [#860](https://github.com/vincentchalamon/bike-trip-planner/issues/860) | fix(terrain): widen the unpaved surface vocabulary | - | [#895](https://github.com/vincentchalamon/bike-trip-planner/pull/895) `feature/860` | En cours | - |
-| 3 | [#861](https://github.com/vincentchalamon/bike-trip-planner/issues/861) | fix(alerts): drop the tag-presence rules and the dead surface fallback | - | [#896](https://github.com/vincentchalamon/bike-trip-planner/pull/896) `feature/861` | En cours | - |
-| 4 | [#862](https://github.com/vincentchalamon/bike-trip-planner/issues/862) | feat(alerts): locale-aware distance formatter and translated tag values | - | [#899](https://github.com/vincentchalamon/bike-trip-planner/pull/899) `feature/862` → base `feature/859` | En cours | [#859](https://github.com/vincentchalamon/bike-trip-planner/issues/859) |
-| 5 | [#863](https://github.com/vincentchalamon/bike-trip-planner/issues/863) | fix(alerts): restore navigate and dismiss actions with coordinates end-to-end | - | [#897](https://github.com/vincentchalamon/bike-trip-planner/pull/897) `feature/863` | En cours | - |
-| 6 | [#864](https://github.com/vincentchalamon/bike-trip-planner/issues/864) | fix(alerts): rest-day guard, local-time sunset and multi-year calendar | - | [#898](https://github.com/vincentchalamon/bike-trip-planner/pull/898) `feature/864` | En cours | - |
+| 1 | [#859](https://github.com/vincentchalamon/bike-trip-planner/issues/859) | fix(terrain): attribute ways to the ridden route, not to a 100 m neighbourhood | - | [#894](https://github.com/vincentchalamon/bike-trip-planner/pull/894) `feature/859` | ✅ Mergée | - |
+| 2 | [#860](https://github.com/vincentchalamon/bike-trip-planner/issues/860) | fix(terrain): widen the unpaved surface vocabulary | - | [#895](https://github.com/vincentchalamon/bike-trip-planner/pull/895) `feature/860` | En cours (rebasée) | - |
+| 3 | [#861](https://github.com/vincentchalamon/bike-trip-planner/issues/861) | fix(alerts): drop the tag-presence rules and the dead surface fallback | - | [#896](https://github.com/vincentchalamon/bike-trip-planner/pull/896) `feature/861` | ✅ Mergée | - |
+| 4 | [#862](https://github.com/vincentchalamon/bike-trip-planner/issues/862) | feat(alerts): locale-aware distance formatter and translated tag values | - | [#899](https://github.com/vincentchalamon/bike-trip-planner/pull/899) `feature/862` | En cours (rebasée sur `main`) | [#859](https://github.com/vincentchalamon/bike-trip-planner/issues/859) ✅ |
+| 5 | [#863](https://github.com/vincentchalamon/bike-trip-planner/issues/863) | fix(alerts): restore navigate and dismiss actions with coordinates end-to-end | - | [#897](https://github.com/vincentchalamon/bike-trip-planner/pull/897) `feature/863` | ✅ Mergée | - |
+| 6 | [#864](https://github.com/vincentchalamon/bike-trip-planner/issues/864) | fix(alerts): rest-day guard, local-time sunset and multi-year calendar | - | [#898](https://github.com/vincentchalamon/bike-trip-planner/pull/898) `feature/864` | En cours (rebasée) | - |
 
-### Ordre de merge et conflits attendus (sprint 44)
+### Conflits de merge : résolutions appliquées (sprint 44)
 
-Les 6 issues ont été traitées en parallèle via `/sprint 44`, donc plusieurs branches touchent les mêmes fichiers. Points à surveiller au merge :
+Les 6 issues ont été traitées en parallèle via `/sprint 44`, donc plusieurs branches touchaient les mêmes fichiers. **#894, #896 et #897 sont mergées** ; les trois PRs restantes ont été rebasées sur `main` et les conflits résolus comme suit.
 
-- **#899 est empilée sur `feature/859`** (base ≠ `main`) : merger **#894 d'abord**, puis #899 se retargette automatiquement sur `main`.
-- **`SurfaceAlertAnalyzer.php`** — #895 étend le vocabulaire, #896 **supprime** `detectMissingSurfaceData()`, #898 y ajoute le garde `isRestDay`, #899 y injecte le formateur. La suppression de #896 doit gagner ; vérifier que le repli `tracktype` de #895 ne la réintroduit pas.
-- **`WaysRepository.php`** — #894 réécrit le SQL du corridor, #895 ajoute deux colonnes au `SELECT`. Diffs disjoints par construction.
-- **`alerts.fr.yaml` / `alerts.en.yaml`** — touchés par #895, #896, #897, #898 et #899. #899 laisse volontairement `alert.surface.fallback` en place parce que #896 la supprime (évite une suppression concurrente).
-- **`use-mercure.ts`** — #897 (reconstruction d'action) et #898 (payload calendrier) ; diffs sur des `case` distincts.
+- **#899 était empilée sur `feature/859`.** Après le squash-merge de #894, GitHub l'a retargettée sur `main` mais la branche portait encore le commit pré-squash de #859. Résolu par `git rebase --onto origin/main <commit-859>` (pas un rebase simple, qui aurait rejoué du code déjà mergé).
+- **`SurfaceAlertAnalyzer.php`** — la suppression de `detectMissingSurfaceData()` par #896 a gagné dans #895 et #899, comme prévu. Effets de bord traités : le `$surfaceList` de #895 avait disparu (#896 a inliné le `implode`), et 5 cas de `SurfaceAlertAnalyzerTest` attendaient 2 alertes au lieu d'1.
+- **`WaysRepository.php`** — la requête clippée de #894 a été conservée, augmentée des deux colonnes `tracktype` / `smoothness` de #895 avec l'alias de la CTE `followed` (`f.tags`, pas `w.tags`).
+- **`WaysIndexReadTest.php`** — #894 et #895 avaient chacune ajouté un test au même endroit : **les deux sont conservés**, et les deux colonnes de #895 ont été portées sur l'oracle réécrit par #894.
+- **`alerts.*.yaml`** — les clés supprimées par #896 (`alert.surface.fallback`, `alert.surface.missing_data`) ne sont pas réintroduites ; la ligne `alert.railway_station.action` ajoutée par #897 est préservée, et les reformulations de #895 / #899 conservées.
+- **`mock-data.ts`** — #897 et #898 avaient inséré une fixture au même endroit : **les deux sont conservées**.
+- **Interaction #897 ↔ #899** — #897 assertait que le libellé d'action valait la _clé_ de traduction (son stub renvoyait la clé) alors que #899 branche le vrai `Translator` ; l'assertion a été alignée sur la chaîne rendue.
+
+Note outillage : GitHub sait désormais gérer les [PRs empilées](https://docs.github.com/en/pull-requests/how-tos/stacked-pull-requests) — à utiliser pour les prochains sprints plutôt qu'une base `feature/<n>` manuelle.
 
 ### Recette Sprint 44
 


### PR DESCRIPTION
## Summary

Records the outcome of `/sprint 44` in `TRACKING.md`: the six issues (#859-#864) are all coded, reviewed and green, and now carry their PR links.

| Issue | PR | Branch |
|---|---|---|
| #859 | #894 | `feature/859` |
| #860 | #895 | `feature/860` |
| #861 | #896 | `feature/861` |
| #862 | #899 | `feature/862` → base `feature/859` |
| #863 | #897 | `feature/863` |
| #864 | #898 | `feature/864` |

## Changes

- Sprint 44 table: added a `Statut` column (matching the sprint 43 table's shape), filled the `PRs` column with links + branch names, and flagged #899's non-`main` base.
- New **"Ordre de merge et conflits attendus"** section. This is the part worth reviewing: six branches were developed in parallel from the same commit, so four files are touched by more than one of them. The section names each overlap and says which side should win — notably that #896's deletion of `detectMissingSurfaceData()` must survive #895's extension of the same class, and that #899 deliberately leaves `alert.surface.fallback` in the YAML so it does not race #896's deletion of the same key.

## Test plan

- [x] `markdownlint-cli2 TRACKING.md` → `Summary: 0 issues in 0 files`
- [x] Docs-only change; no code touched

## Auto-critique

- [x] No leftover debug statements
- [x] No stale TODO/FIXME comments
- [x] No dead code
- [x] Code respects the project architecture — documentation only
- [x] SOLID / Law of Demeter — n/a
- [x] Documentation is the change itself
- [x] No backend DTO change, so no `make typegen`

**Note:** statuses are recorded as `En cours` rather than `Done` because the PRs are open and merging is the maintainer's call, not this branch's.

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 findings (0 critical, 0 warning). Docs-only change to `TRACKING.md`, adding a `Statut` column to the sprint 44 table and a new "Conflits de merge : résolutions appliquées" section. Every checkable factual claim in that section was independently cross-verified against the live state of the referenced branches/PRs (`main`, `feature/862`, `feature/864`, and PRs #894-#899): merge states (4 merged, #898/#899 open) match; `detectMissingSurfaceData()` is gone from `SurfaceAlertAnalyzer.php` on `main`; `alert.surface.fallback` / `alert.surface.missing_data` are absent and `alert.railway_station.action` is present in the translation YAML; `WaysRepository.php` reads `tracktype`/`smoothness` off the `followed` CTE's `f.tags` alias; both `WaysIndexReadTest.php` oracle tests are present; `feature/862` implements `translateSurface()` with the 8 dedicated translation keys described; and `CheckRailwayStationsHandlerTest.php` on `feature/862` now asserts against the rendered translation rather than the raw key, matching the described #897↔#899 arbitration.

**Note (non-blocking):** the PR description's "Changes" section is stale relative to the final diff — it references the section under its earlier working title ("Ordre de merge et conflits attendus" / "expected merge conflicts") and states that `alert.surface.fallback` is deliberately *kept* in the YAML, whereas the actual `TRACKING.md` content added by this PR (and the real state of `main`) confirms that key was removed by #896 and is *not* reintroduced. This doesn't affect the merged `TRACKING.md` content, which is accurate, but worth tidying the PR description before merge so it doesn't mislead anyone skimming it instead of the diff.

No previously open bot reviews required resolution (both prior `claude[bot]` reviews were already dismissed; the one that wasn't yet minimized has been minimized as outdated). No unresolved review threads exist.

**Review checklist:**
- [x] Code respects the project architecture (docs-only)
- [x] SOLID principles and Law of Demeter followed (n/a)
- [x] Design patterns used where appropriate (n/a)
- [x] Tests cover new/changed cases (docs-only, `markdownlint-cli2` proof provided)
- [x] Documentation is up to date (this PR *is* the documentation update; see non-blocking staleness note on the PR description above)
- [x] Dependent tickets accounted for (sprint 44 issues #859-#864 all linked)

**Inline comments:** No inline comments.

**Commit reviewed:** `de30f1df03c55e8d037245c00e11f6284a149814`
<!-- claude-review-end -->