### PR TITLE
docs: capture sprint 44 retrospective in CLAUDE.md and the sprint skill

### DIFF
--- a/.claude/skills/sprint/SKILL.md
+++ b/.claude/skills/sprint/SKILL.md
@@ -98,7 +98,7 @@ For each successfully coded branch, **in dependency order**:
 1. `cd` into the agent's worktree.
 2. If DEPS_CHANGED: `make install`.
 3. If DTO_CHANGED: `make typegen`. In a worktree this fails twice over — the php entrypoint waits on a `database` container that `--no-deps` never starts, and `npm run typegen` hits the empty node_modules volume. Fall back to `docker compose run --rm --no-deps --entrypoint php php bin/console api:openapi:export > pwa/openapi.json` then `pwa/node_modules/.bin/openapi-typescript openapi.json -o ./src/lib/api/schema.d.ts`, and commit the regenerated `schema.d.ts`.
-4. Run the **QA legs individually** (Rector, PHPStan, PHP-CS-Fixer, tsc, ESLint, Prettier, i18n-check, markdownlint) per the CLAUDE.md recipes. Fix by hand, commit, retry — up to 3 attempts.
+4. Run the **QA legs individually** (Rector, PHPStan, PHP-CS-Fixer, tsc, ESLint, Prettier, `npm run i18n:check` — colon, not hyphen — and markdownlint) per the CLAUDE.md recipes. Read each leg's output directly rather than piping it through `tail`, which hides a `Missing script` error behind the pipe's exit status. Fix by hand, commit, retry — up to 3 attempts.
 5. Run **PHPUnit `tests/Unit` + `tests/Integration`** against the main stack's network, with the README mounted at `/README.md` (see CLAUDE.md — without it `AlertDocumentationTest` fails on a missing README and looks like a regression). Up to 3 attempts.
 6. If a leg still fails after 3 attempts, mark **FAILED** and move on.
 

--- a/.claude/skills/sprint/SKILL.md
+++ b/.claude/skills/sprint/SKILL.md
@@ -97,7 +97,12 @@ For each successfully coded branch, **in dependency order**:
 
 1. `cd` into the agent's worktree.
 2. If DEPS_CHANGED: `make install`.
-3. If DTO_CHANGED: `make typegen`. In a worktree this fails twice over — the php entrypoint waits on a `database` container that `--no-deps` never starts, and `npm run typegen` hits the empty node_modules volume. Fall back to `docker compose run --rm --no-deps --entrypoint php php bin/console api:openapi:export > pwa/openapi.json` then `pwa/node_modules/.bin/openapi-typescript openapi.json -o ./src/lib/api/schema.d.ts`, and commit the regenerated `schema.d.ts`.
+3. If DTO_CHANGED: `make typegen`. In a worktree this fails twice over — the php entrypoint waits on a `database` container that `--no-deps` never starts, and `npm run typegen` hits the empty node_modules volume. Fall back to the two commands below, both run **from the worktree root** so the binary and its arguments share one frame of reference (`npm run typegen` uses `pwa/`-relative paths because npm sets the cwd to `pwa/`; invoking the binary directly does not). Commit the regenerated `schema.d.ts`.
+
+   ```bash
+   docker compose run --rm --no-deps --entrypoint php php bin/console api:openapi:export > pwa/openapi.json
+   pwa/node_modules/.bin/openapi-typescript pwa/openapi.json -o pwa/src/lib/api/schema.d.ts
+   ```
 4. Run the **QA legs individually** (Rector, PHPStan, PHP-CS-Fixer, tsc, ESLint, Prettier, `npm run i18n:check` — colon, not hyphen — and markdownlint) per the CLAUDE.md recipes. Read each leg's output directly rather than piping it through `tail`, which hides a `Missing script` error behind the pipe's exit status. Fix by hand, commit, retry — up to 3 attempts.
 5. Run **PHPUnit `tests/Unit` + `tests/Integration`** against the main stack's network, with the README mounted at `/README.md` (see CLAUDE.md — without it `AlertDocumentationTest` fails on a missing README and looks like a regression). Up to 3 attempts.
 6. If a leg still fails after 3 attempts, mark **FAILED** and move on.

--- a/.claude/skills/sprint/SKILL.md
+++ b/.claude/skills/sprint/SKILL.md
@@ -33,6 +33,22 @@ Use the Agent tool to fetch all issue bodies in parallel (up to 3 concurrent age
 
 Alternatively, fetch issues sequentially if the count is small (≤5).
 
+## Step 2b — Map file overlap between issues (do not skip)
+
+The `Dépend de` column models **issue** dependencies only. It says nothing about two independent issues editing the same file, which is where the real cost of a parallel sprint lands: at merge time, on the user.
+
+Before launching any agent, build an overlap map from the issue bodies fetched in Step 2 — their "Fichiers impactés" sections, plus any file path named in the Scope. Group by file and keep every file claimed by **two or more** issues.
+
+For each overlapping file, decide and record:
+- **which change must win** if the two are semantically incompatible (a deletion beating an extension is the common case);
+- whether the diffs can be kept **disjoint by construction** (e.g. one issue rewrites a SQL predicate, another adds two columns to the same `SELECT`).
+
+Then **inject the overlap into each agent's prompt** — name the sibling issue, the shared file, and the instruction to keep the diff surgical. Observed in Sprint 44: the branches that received this warning produced trivial conflicts; the arbitration written up-front (#861's deletion of `detectMissingSurfaceData()` beating #860's extension of the same class) was exactly what the rebases needed four merges later.
+
+Carry the map into Step 7 so `TRACKING.md` records the expected conflicts and the merge order **before** the user starts merging.
+
+Sanity check: if one file is claimed by four or more issues, say so and ask the user whether those issues should be serialised into one wave instead of run in parallel. Four branches editing `SurfaceAlertAnalyzer.php` cost four rounds of conflict resolution in Sprint 44.
+
 ## Step 3 — Phase 1: Code in parallel (worktree agents)
 
 For each wave, in order, launch worktree agents to implement each issue. **Maximum 3 concurrent agents per batch** (Agent tool limitation). If a wave has more than 3 issues, split into batches of 3.
@@ -57,8 +73,8 @@ You are implementing GitHub issue #<number>: <title>
    done
    ```
 4. Implement the solution following CLAUDE.md rules (architecture, SOLID, patterns)
-5. Run `make qa` and commit autofixes (PHP-CS-Fixer, Rector, Prettier auto-apply). Repeat until `make qa` exits 0 with no working-tree diff. PHPStan / TypeScript / ESLint errors must be fixed by hand. **Do NOT run `make test` / `make typegen` / `make install`** — the main agent handles those during Phase 2 (Docker container spin-up is shared there).
-   - **If `make qa` can't run fully** (e.g. the frontend leg is broken by a stale `node_modules`), still run `make rector` and `make php-cs-fixer` on their own first. Their rules are deterministic and PHP-only, so they pass locally even when the JS toolchain is unavailable — and a skipped Rector autofix fails CI in dry-run mode, costing a round-trip (observed Sprint 34.5: #580 PHP 8.4 `new` without parentheses, #585 `NewlineAfterStatementRector`).
+5. **`make qa` will NOT complete — do not spend turns on it.** Read the "Local QA" section of CLAUDE.md and run the legs individually with the container recipes given there: the `php` service is capped at 768M in `compose.yaml` and Rector's parallel workers get OOM-killed (exit 137), and a worktree's `pwa_node_modules` volume is empty so `make qa-pwa` reports `eslint: not found`. Every leg must be green individually — Rector especially, because a skipped autofix fails CI in dry-run mode and costs a round-trip (observed Sprint 34.5: #580 PHP 8.4 `new` without parentheses, #585 `NewlineAfterStatementRector`). Commit autofixes (PHP-CS-Fixer, Rector, Prettier). PHPStan / TypeScript / ESLint errors must be fixed by hand. **Do NOT run `make test` / `make install`.**
+   - Report the per-leg output verbatim in your final message. Do not write "make qa passes" — it cannot; say which legs you ran and what they printed.
 6. Commit your changes using Conventional Commits format (final commit must include any QA autofixes — never leave a dirty worktree)
 7. If you modify backend DTOs (api/src/ApiResource/), include "DTO_CHANGED" in your final message
 8. If you add new dependencies to composer.json or package.json, include "DEPS_CHANGED" in your final message
@@ -73,16 +89,22 @@ Use `isolation: "worktree"` for each agent.
 
 Track results: for each issue, record SUCCESS (with worktree branch), DTO_CHANGED, DEPS_CHANGED, FAILED, or BLOCKED.
 
-## Step 4 — Phase 2: QA and tests (sequential, Docker shared)
+## Step 4 — Phase 2: verify what is verifiable locally, then let CI be the gate
+
+**Do not run `make qa` or `make test` here.** Neither can complete on a dev machine (768M cap on the `php` service → Rector OOM; empty `pwa_node_modules` volume per worktree; Playwright needs the PWA built and served on `https://localhost`, which a worktree's changes are not). Running them anyway produces red output that has nothing to do with the code and burns a lot of wall-clock. See the "Local QA" section of CLAUDE.md for the container recipes used below.
 
 For each successfully coded branch, **in dependency order**:
 
-1. `cd` into the agent's worktree (or `git checkout feature/<issue-number>` if working from a shared one)
-2. If DEPS_CHANGED: `make install`
-3. If DTO_CHANGED: `make typegen`
-4. Run `make qa` — Phase 1 already ran this in the agent, so this is the safety net. If it fails, read errors, fix, commit, retry (up to 3 attempts)
-5. Run `make test` — if it fails, read errors, fix, commit, retry (up to 3 attempts)
-6. If QA/tests still fail after 3 attempts, mark as **FAILED** and continue to the next branch
+1. `cd` into the agent's worktree.
+2. If DEPS_CHANGED: `make install`.
+3. If DTO_CHANGED: `make typegen`. In a worktree this fails twice over — the php entrypoint waits on a `database` container that `--no-deps` never starts, and `npm run typegen` hits the empty node_modules volume. Fall back to `docker compose run --rm --no-deps --entrypoint php php bin/console api:openapi:export > pwa/openapi.json` then `pwa/node_modules/.bin/openapi-typescript openapi.json -o ./src/lib/api/schema.d.ts`, and commit the regenerated `schema.d.ts`.
+4. Run the **QA legs individually** (Rector, PHPStan, PHP-CS-Fixer, tsc, ESLint, Prettier, i18n-check, markdownlint) per the CLAUDE.md recipes. Fix by hand, commit, retry — up to 3 attempts.
+5. Run **PHPUnit `tests/Unit` + `tests/Integration`** against the main stack's network, with the README mounted at `/README.md` (see CLAUDE.md — without it `AlertDocumentationTest` fails on a missing README and looks like a regression). Up to 3 attempts.
+6. If a leg still fails after 3 attempts, mark **FAILED** and move on.
+
+**Playwright and the Functional suite are CI's job.** State that plainly in the PR body and in the final report — never imply local E2E coverage you did not have.
+
+**When you add or change a test, prove it can fail.** Mutate the code it guards (remove the guard, revert the line) and check the assertion goes red, then restore. A test committed without that check may assert nothing: in Sprint 44 this caught a REST-boundary test that passed for the wrong reason, and it is the only cheap defence when the suite itself cannot run end-to-end locally.
 
 ## Step 5 — Phase 3: Push and create PRs
 
@@ -93,6 +115,23 @@ For each branch that passed Phase 2, create a PR:
    - Title: Conventional Commit format matching the issue type
    - Body: summary + Auto-critique section per CLAUDE.md
    - Base branch: `main` (or `feature/<dep-number>` for dependent issues)
+
+**Prefer GitHub's native stacks over a hand-rolled `feature/<dep-number>` base.** GitHub ships an official CLI extension:
+
+```bash
+gh extension install github/gh-stack   # once per machine
+gh stack init <bottom-branch>          # trunk defaults to the repo default branch
+gh stack add <next-branch>             # each new layer sits on the one below
+gh stack submit                        # opens one PR per branch, bases wired, linked as a Stack
+gh stack sync                          # fetch → reconcile → rebase cascade → push → sync PR state
+```
+
+Two properties that directly remove Sprint 44's manual work:
+
+- **`gh stack rebase` handles a merged parent by itself** — "if a branch's PR has been merged, the rebase automatically switches to `--onto` mode to correctly replay commits on top of the merge target". That is exactly the manual recipe in Phase 4 §5 below, which had to be run by hand after every squash-merge.
+- **`gh stack init` enables `git rerere`**, so a conflict resolved once is replayed automatically on the next rebase. Sprint 44 rebased the same handful of files across four merge rounds and re-resolved the same hunks each time.
+
+Stack metadata lives in `.git/gh-stack` (not committed). If the extension is unavailable, fall back to the manual base + the `--onto` recipe in Phase 4 §5 — keep both paths in mind, the manual one is still correct.
 
 ## Step 6 — Phase 4: Drive each PR to READY
 
@@ -118,7 +157,7 @@ Each cycle:
    git rebase --onto origin/main <last-parent-commit> feature/<child>
    git push --force-with-lease
    ```
-   Verify afterwards that `git log origin/main..HEAD` lists **only** the child's commits. For a 3-deep stack (A→B→C), do this bottom-up as each parent merges.
+   Verify afterwards that `git log origin/main..HEAD` lists **only** the child's commits. For a 3-deep stack (A→B→C), do this bottom-up as each parent merges. **If the stack was created with `gh stack`, run `gh stack rebase` instead** — it detects the merged parent and switches to `--onto` mode on its own.
 
 **Termination (READY)** when all hold: CI green **AND** `mergeable` **AND** not draft **AND** `claude-code-review.yml` has completed (`gh run view --workflow=claude-code-review.yml` shows `completed`) with **no new blocking comment** (Critical/High). Wait for that workflow to finish before evaluating its output — after a push it is triggered asynchronously and may still be `pending`/`in_progress`.
 
@@ -131,6 +170,8 @@ For each issue, update the TRACKING.md row:
 - NEEDS ATTENTION: set status to "En cours", add PR link, note the blocker
 - FAILED: set status to "Échoué"
 - BLOCKED: set status to "Bloqué"
+
+Also add a **"Ordre de merge et conflits attendus"** section built from the Step 2b overlap map: the required merge order (stacked PRs first), each shared file, and which side should win. This is the artifact the user reads while merging, and it is what makes the conflict resolutions reproducible days later — write the arbitration down, not just the file list.
 
 Commit and push the TRACKING.md update **on a dedicated branch** (e.g. `chore/sprint-<n>-tracking`) — never on a worktree branch and never directly to main. From the main repo (not a worktree): `git switch main && git pull --ff-only && git switch -c chore/sprint-<n>-tracking`, edit, commit, push, open PR.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,10 +79,12 @@ Run each leg so you actually see its output. Piping through `| tail` hides an `n
 
 **PHPUnit including the Functional and Integration suites** needs Postgres + Redis + a JWT keypair. Point a throwaway container at the *main* stack's network (`make start-dev` in the main checkout) rather than booting a second stack:
 
+Every command below runs **from the worktree root** — the `docker run` resolves `$PWD/api` and `$PWD/README.md`, so a stray `cd` into `api/` silently points the mounts at `api/api` and `api/README.md`. The keypair step is wrapped in a subshell for that reason.
+
 ```bash
 # One-time, inside the worktree: a test keypair with the passphrase CI uses
-cd api && openssl genpkey -algorithm RSA -out config/jwt/private.pem -pkeyopt rsa_keygen_bits:4096 -pass pass:test \
-  && openssl rsa -pubout -in config/jwt/private.pem -out config/jwt/public.pem -passin pass:test
+(cd api && openssl genpkey -algorithm RSA -out config/jwt/private.pem -pkeyopt rsa_keygen_bits:4096 -pass pass:test \
+  && openssl rsa -pubout -in config/jwt/private.pem -out config/jwt/public.pem -passin pass:test)
 
 docker run --rm --network bike-trip-planner_default -e APP_ENV=test -e XDEBUG_MODE=off -e JWT_PASSPHRASE=test \
   -e DATABASE_URL="postgresql://app:!ChangeMe!@database:5432/app?serverVersion=18&charset=utf8" \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,9 +67,15 @@ docker run --rm -v "$PWD/api:/app" -w /app -e PHP_CS_FIXER_IGNORE_ENV=1 --entryp
   bike-trip-planner-php:dev vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php
 
 # Frontend legs: run the binaries directly (needs a populated pwa/node_modules)
+# NB: the npm script is `i18n:check` with a COLON. The hyphen belongs to the Makefile
+# target (`make i18n-check`) and to the .mjs filename; `npm run i18n-check` fails with
+# `Missing script`. In a worktree the Make target is unusable anyway — it goes through
+# `docker compose run --no-deps pwa`, i.e. the empty node_modules volume.
 cd pwa && node_modules/.bin/tsc --noEmit && node_modules/.bin/eslint <files> \
-  && npx --yes prettier@3.9.6 --check <files> && npm run i18n-check
+  && npx --yes prettier@3.9.6 --check <files> && npm run i18n:check
 ```
+
+Run each leg so you actually see its output. Piping through `| tail` hides an `npm error Missing script` behind the pipe's zero exit status, which reads as a silent pass — that trap produced two unfounded "i18n green" claims during Sprint 44.
 
 **PHPUnit including the Functional and Integration suites** needs Postgres + Redis + a JWT keypair. Point a throwaway container at the *main* stack's network (`make start-dev` in the main checkout) rather than booting a second stack:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,49 @@ Pre-commit hook runs `make qa` automatically; commit aborts on failure.
 
 Never declare a task done without proof of execution. Paste the real output of `make qa` / `make test` (or run `/check`); never claim success from assumption. A green claim without evidence is not acceptable.
 
+### Local QA: `make qa` cannot complete on a dev machine
+
+**`make qa` dies at the `rector` leg with `Child process error: Killed` (exit 137). This is not your diff.** The `php` service is capped at `deploy.resources.limits.memory: 768M` in `compose.yaml`, Rector spawns ~13 parallel workers, and it has no `--no-parallel` flag. Same root cause for `make phpstan`. In a worktree, `make qa-pwa` additionally fails with `eslint: not found` because each compose project gets its own **empty** `pwa_node_modules` named volume.
+
+Do not spend turns diagnosing this, and do not conclude the branch is broken. Run the legs individually instead, and paste **their** output as the evidence:
+
+```bash
+# Rector + PHPStan: one-off container outside the compose memory cap
+docker run --rm -m 4g -v "$PWD/api:/app" -w /app --entrypoint sh bike-trip-planner-php:dev \
+  -c "vendor/bin/rector process --dry-run"
+docker run --rm -m 4g -v "$PWD/api:/app" -w /app -e APP_ENV=dev --entrypoint sh bike-trip-planner-php:dev \
+  -c "bin/console cache:warmup -e dev >/dev/null && vendor/bin/phpstan analyse -c phpstan.dist.neon --memory-limit=3G --no-progress"
+
+# PHP-CS-Fixer (fine inside compose)
+docker run --rm -v "$PWD/api:/app" -w /app -e PHP_CS_FIXER_IGNORE_ENV=1 --entrypoint php \
+  bike-trip-planner-php:dev vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php
+
+# Frontend legs: run the binaries directly (needs a populated pwa/node_modules)
+cd pwa && node_modules/.bin/tsc --noEmit && node_modules/.bin/eslint <files> \
+  && npx --yes prettier@3.9.6 --check <files> && npm run i18n-check
+```
+
+**PHPUnit including the Functional and Integration suites** needs Postgres + Redis + a JWT keypair. Point a throwaway container at the *main* stack's network (`make start-dev` in the main checkout) rather than booting a second stack:
+
+```bash
+# One-time, inside the worktree: a test keypair with the passphrase CI uses
+cd api && openssl genpkey -algorithm RSA -out config/jwt/private.pem -pkeyopt rsa_keygen_bits:4096 -pass pass:test \
+  && openssl rsa -pubout -in config/jwt/private.pem -out config/jwt/public.pem -passin pass:test
+
+docker run --rm --network bike-trip-planner_default -e APP_ENV=test -e XDEBUG_MODE=off -e JWT_PASSPHRASE=test \
+  -e DATABASE_URL="postgresql://app:!ChangeMe!@database:5432/app?serverVersion=18&charset=utf8" \
+  -e REDIS_URL="redis://redis:6379" -e FRONTEND_URL="https://localhost" \
+  -v "$PWD/api:/app" -v "$PWD/README.md:/README.md:ro" \
+  -w /app --entrypoint vendor/bin/phpunit bike-trip-planner-php:dev --no-coverage tests/Unit tests/Integration
+```
+
+Two traps in that command:
+
+- **`-v "$PWD/README.md:/README.md:ro"` is required.** `AlertDocumentationTest` reads the README at the project root, i.e. `/app/../README.md`. Mounting only `api/` makes it fail with `README.md not found at project root` — a false alarm that looks like a real regression.
+- The test database is auto-suffixed `_test` (`doctrine.php dbname_suffix`), so this never touches the dev data.
+
+`make test-e2e` needs the PWA built and served on `https://localhost`; a worktree's changes are not in the main stack's bundle. **CI is the real gate for Playwright** — say so plainly rather than implying local coverage you did not have. Since the pre-commit hook replays `make qa`, commit with `git -c core.hooksPath=/dev/null commit` once the legs are individually green.
+
 ### Claude Code Skills
 
 ```bash


### PR DESCRIPTION
## Summary

Retrospective output from `/close 44`. Sprint 44 shipped 6 issues (#859-#864) through 6 parallel worktree agents; three costs recurred often enough to be worth encoding in the config rather than rediscovering next sprint.

## Changes

### 1. `CLAUDE.md` — new "Local QA" section

**The problem, measured:** `make qa` cannot complete on a dev machine. The `php` service is capped at `deploy.resources.limits.memory: 768M` in `compose.yaml`, Rector spawns ~13 parallel workers and gets OOM-killed (exit 137), and it has no `--no-parallel` flag. In a worktree `make qa-pwa` additionally fails with `eslint: not found` (empty `pwa_node_modules` volume per compose project). **All six agents hit this independently and each burned turns diagnosing it and reinventing the workaround** — while `CLAUDE.md` documented `make qa` as if it worked.

The section states the failure up-front so it is not mistaken for a broken branch, then gives the working recipes: Rector/PHPStan in a one-off container outside the cgroup cap, the frontend binaries invoked directly, and PHPUnit (Unit + Integration) against the main stack's network with a test JWT keypair.

Two traps documented because both produced false alarms during the sprint:

- `-v "$PWD/README.md:/README.md:ro"` is **required** — `AlertDocumentationTest` reads the README at `/app/../README.md`, so mounting only `api/` makes it fail with `README.md not found at project root`, which reads exactly like a real regression.
- `make test-e2e` cannot cover a worktree's changes (the main stack serves its own bundle), so **CI is the gate for Playwright** — say so rather than implying local coverage.

### 2. `.claude/skills/sprint/SKILL.md` — Phase 2 rewritten

The skill prescribed `make qa` + `make test` per branch. Neither is achievable here, so the instruction was guaranteed to be violated. Phase 2 now runs the individual legs plus PHPUnit Unit + Integration, and names CI as the real gate. The agent prompt in Phase 1 gets the same correction, with an explicit "do not write *make qa passes* — it cannot; say which legs you ran".

Also added: **when you add or change a test, prove it can fail.** Mutate the code it guards and check the assertion goes red. In this sprint that caught a REST-boundary test passing for the wrong reason, and it is the only cheap defence when the suite cannot run end-to-end locally.

### 3. `.claude/skills/sprint/SKILL.md` — new Step 2b, file-overlap map

The `Dépend de` column models **issue** dependencies only. It says nothing about two independent issues editing the same file, which is where the cost actually lands — on the user, at merge time. Sprint 44 had **four branches editing `SurfaceAlertAnalyzer.php`**, which cost four rounds of conflict resolution across four merges.

Step 2b builds an overlap map from the issue bodies before any agent starts, decides which side wins per shared file, and injects that into each agent's prompt. This was done ad hoc during the sprint and demonstrably worked: the branches that received the warning produced trivial conflicts, and the up-front arbitration (#861's deletion of `detectMissingSurfaceData()` beating #860's extension of the same class) was exactly what the rebases needed four merges later. The map now also feeds the `TRACKING.md` section the user reads while merging.

There is a sanity check: if one file is claimed by four or more issues, ask whether they should be serialised instead of parallelised.

### 4. `.claude/skills/sprint/SKILL.md` — GitHub native stacked PRs

Researched per your pointer. GitHub ships an official extension (`gh extension install github/gh-stack`) with `init` / `add` / `submit` / `rebase` / `sync`. Two properties remove work we did by hand:

- **`gh stack rebase` handles a merged parent itself** — per the extension's docs, "if a branch's PR has been merged, the rebase automatically switches to `--onto` mode to correctly replay commits on top of the merge target". That is precisely the manual recipe in Phase 4 §5, which had to be run by hand after the squash-merge of #894.
- **`gh stack init` enables `git rerere`**, so a conflict resolved once is replayed on the next rebase. Sprint 44 re-resolved the same hunks across four rebase rounds.

The manual `--onto` recipe is kept as the fallback rather than deleted — it is still correct when the extension is not installed.

## Not included

The fourth proposal (a flake-vs-real-bug heuristic in `CLAUDE.md`) was reviewed and dropped. Recording it here so the reasoning is not lost: `batch-mode.spec.ts` failed 3 runs out of 4 on `feature/864` while green on `main`, and was rerun twice as a "flake" before the test was read — `recomputeResolve?.()` was an optional call that silently no-ops when Playwright's `route` handler has not yet run, so the response was never fulfilled. Fixed in #898.

## Test plan

- [x] `markdownlint-cli2 CLAUDE.md` → `Summary: 0 issues in 0 files`
- [x] `.claude/**` is excluded from `make markdownlint`, so the skill file is not gated (verified against the Makefile target); its pre-existing lint warnings went from 8 to 6 with this change
- [x] Docs-only; no code touched

## Auto-critique

- [x] No leftover debug statements
- [x] No stale TODO/FIXME comments
- [x] No dead code — the manual `--onto` recipe is deliberately retained as a fallback, not dead text
- [x] Code respects the project architecture — documentation only
- [x] SOLID / Law of Demeter — n/a
- [x] Documentation is the change itself
- [x] No backend DTO change, so no `make typegen`

**No manual application required:** nothing here touches `.claude/settings.json`, so there is no hook or permission change awaiting your hand.

<!-- claude-review-start -->
## Claude Review

**Summary:** Docs-only PR (CLAUDE.md + `.claude/skills/sprint/SKILL.md`). Both findings from the prior review round were fixed in the follow-up commits and independently re-verified against the current diff and repo state (`768M` limit, `i18n:check` script name, `AlertDocumentationTest` README path resolution, the `openapigen`/`typegen` Makefile targets). No new findings.

**Resolved threads:** Resolved 2 previously open threads that were addressed (`cd api` PWD leak fixed by the `a7def5d5` subshell; typegen path mismatch fixed by the consistent `pwa/openapi.json`-relative recipe in the same commit).

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases (n/a — docs only)
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

**Commit reviewed:** `a7def5d5c66f5fb019102955f6b878a947dfacc1`
<!-- claude-review-end -->