### PR TITLE
fix(pwa): guard malformed accommodation urls and translate the wikipedia link

### DIFF
--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -155,7 +155,8 @@
     "select": "Select accommodation",
     "deselect": "Deselect accommodation",
     "selected": "Selected",
-    "selectTooltip": "Select this accommodation as your stopover for this stage"
+    "selectTooltip": "Select this accommodation as your stopover for this stage",
+    "see_on_wikipedia": "See on Wikipedia"
   },
   "addStage": {
     "add": "Add stage",
@@ -340,7 +341,8 @@
   },
   "alertList": {
     "addToItinerary": "Add to itinerary",
-    "free": "Free admission"
+    "free": "Free admission",
+    "see_on_wikipedia": "See on Wikipedia"
   },
   "poiPopover": {
     "close": "Close",

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -155,7 +155,8 @@
     "select": "Sélectionner cet hébergement",
     "deselect": "Désélectionner l'hébergement",
     "selected": "Sélectionné",
-    "selectTooltip": "Sélectionner cet hébergement comme étape de nuit"
+    "selectTooltip": "Sélectionner cet hébergement comme étape de nuit",
+    "see_on_wikipedia": "Voir sur Wikipedia"
   },
   "addStage": {
     "add": "Ajouter une étape",
@@ -340,7 +341,8 @@
   },
   "alertList": {
     "addToItinerary": "Ajouter à l'itinéraire",
-    "free": "Entrée gratuite"
+    "free": "Entrée gratuite",
+    "see_on_wikipedia": "Voir sur Wikipedia"
   },
   "poiPopover": {
     "close": "Fermer",

--- a/pwa/src/components/accommodation-item.test.tsx
+++ b/pwa/src/components/accommodation-item.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { AccommodationItem } from "./accommodation-item";
+import type { AccommodationData } from "@/lib/validation/schemas";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+function accommodation(
+  overrides: Partial<AccommodationData> = {},
+): AccommodationData {
+  return {
+    name: "Hotel du Pont",
+    type: "hotel",
+    lat: 44.5,
+    lon: 4.38,
+    estimatedPriceMin: 65,
+    estimatedPriceMax: 85,
+    isExactPrice: false,
+    possibleClosed: false,
+    distanceToEndPoint: 0.5,
+    source: "osm",
+    ...overrides,
+  };
+}
+
+function renderItem(data: AccommodationData, onUpdate = vi.fn()) {
+  return {
+    onUpdate,
+    ...render(
+      <AccommodationItem
+        accommodation={data}
+        onUpdate={onUpdate}
+        onRemove={vi.fn()}
+      />,
+    ),
+  };
+}
+
+describe("AccommodationItem website link", () => {
+  it("renders an absolute link for a schemeless OSM website tag", () => {
+    renderItem(accommodation({ url: "www.hotel.fr" }));
+
+    const link = screen.getByTestId("accommodation-website-link");
+    expect(link).toHaveAttribute("href", "https://www.hotel.fr");
+    expect(link).toHaveTextContent("www.hotel.fr");
+  });
+
+  it("keeps an already absolute https URL untouched", () => {
+    renderItem(accommodation({ url: "https://www.hotel.fr/chambres" }));
+
+    expect(screen.getByTestId("accommodation-website-link")).toHaveAttribute(
+      "href",
+      "https://www.hotel.fr/chambres",
+    );
+  });
+
+  it.each(["appeler le 06 12 34 56 78", "mailto:contact@hotel.fr", "   "])(
+    "renders no link and does not throw for %s",
+    (url) => {
+      expect(() => renderItem(accommodation({ url }))).not.toThrow();
+      expect(
+        screen.queryByTestId("accommodation-website-link"),
+      ).not.toBeInTheDocument();
+    },
+  );
+});
+
+describe("AccommodationItem edits", () => {
+  function editAndSave(typed: string) {
+    const onUpdate = vi.fn();
+    render(
+      <AccommodationItem
+        accommodation={accommodation()}
+        onUpdate={onUpdate}
+        onRemove={vi.fn()}
+        initialEditing
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("urlLabel"), {
+      target: { value: typed },
+    });
+    fireEvent.click(screen.getByText("save"));
+
+    return onUpdate;
+  }
+
+  it("normalizes a schemeless URL typed by the user before saving", () => {
+    expect(editAndSave("www.hotel.fr")).toHaveBeenCalledWith(
+      expect.objectContaining({ url: "https://www.hotel.fr" }),
+    );
+  });
+
+  it("saves null when the typed URL is not usable", () => {
+    expect(editAndSave("je ne sais pas")).toHaveBeenCalledWith(
+      expect.objectContaining({ url: null }),
+    );
+  });
+});
+
+describe("AccommodationItem Wikipedia link", () => {
+  it("uses the translated label", () => {
+    renderItem(
+      accommodation({ wikipediaUrl: "https://fr.wikipedia.org/wiki/Pont" }),
+    );
+
+    const link = screen.getByText("see_on_wikipedia");
+    expect(link).toHaveAttribute("href", "https://fr.wikipedia.org/wiki/Pont");
+  });
+
+  it("renders no link for an unusable Wikipedia value", () => {
+    renderItem(accommodation({ wikipediaUrl: "voir wikipedia" }));
+
+    expect(screen.queryByText("see_on_wikipedia")).not.toBeInTheDocument();
+  });
+});

--- a/pwa/src/components/accommodation-item.tsx
+++ b/pwa/src/components/accommodation-item.tsx
@@ -18,6 +18,10 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import type { AccommodationData } from "@/lib/validation/schemas";
 import { formatPrice, formatDistanceKm } from "@/lib/formatters";
+import {
+  externalUrlHostname,
+  normalizeExternalUrl,
+} from "@/lib/validation/url";
 
 const typeIcons: Record<string, React.ElementType> = {
   hotel: Hotel,
@@ -92,6 +96,11 @@ export function AccommodationItem({
     "type_other";
   const typeLabel = t(typeKey);
   const distLabel = formatDistanceKm(accommodation.distanceToEndPoint ?? 0);
+  // OSM `website` tags and user input are unvalidated: normalize before render,
+  // and drop the link entirely when the value is not a usable http(s) URL.
+  const websiteHref = normalizeExternalUrl(accommodation.url);
+  const websiteHostname = externalUrlHostname(accommodation.url);
+  const wikipediaHref = normalizeExternalUrl(accommodation.wikipediaUrl);
 
   function startEditing() {
     setEditUrl(accommodation.url ?? "");
@@ -108,7 +117,7 @@ export function AccommodationItem({
       type: editType,
       estimatedPriceMin: parseFloat(editPriceMin) || 0,
       estimatedPriceMax: parseFloat(editPriceMax) || 0,
-      url: editUrl || null,
+      url: normalizeExternalUrl(editUrl),
     });
     setEditing(false);
   }
@@ -283,14 +292,15 @@ export function AccommodationItem({
             {t("selected")}
           </span>
         )}
-        {accommodation.url && (
+        {websiteHref && (
           <a
-            href={accommodation.url}
+            href={websiteHref}
             target="_blank"
             rel="noopener noreferrer"
             className="text-sm text-muted-foreground font-normal flex items-center gap-0.5 hover:underline"
+            data-testid="accommodation-website-link"
           >
-            {new URL(accommodation.url).hostname}
+            {websiteHostname}
             <ExternalLink className="h-3 w-3" />
           </a>
         )}
@@ -336,16 +346,16 @@ export function AccommodationItem({
       </div>
 
       {/* Wikipedia link */}
-      {accommodation.wikipediaUrl && (
+      {wikipediaHref && (
         <div className="mt-1">
           <a
-            href={accommodation.wikipediaUrl}
+            href={wikipediaHref}
             target="_blank"
             rel="noopener noreferrer"
             className="text-xs text-primary flex items-center gap-0.5 hover:underline"
           >
             <ExternalLink className="h-3 w-3" />
-            Voir sur Wikipedia
+            {t("see_on_wikipedia")}
           </a>
         </div>
       )}

--- a/pwa/src/components/alert-list.test.tsx
+++ b/pwa/src/components/alert-list.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { AlertList } from "./alert-list";
+import type { AlertData } from "@/lib/validation/schemas";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+/**
+ * A cultural-POI alert, the only shape that renders the Wikipedia link.
+ * `wikipediaUrl` reaches this component through the unvalidated
+ * `JSON.parse(event.data) as MercureEvent` cast, so it can be anything.
+ */
+function culturalPoiAlert(overrides: Partial<AlertData> = {}): AlertData {
+  return {
+    type: "nudge",
+    message: "Pont du Gard à 2 km",
+    source: "cultural_poi",
+    poiName: "Pont du Gard",
+    poiLat: 43.947,
+    poiLon: 4.535,
+    description: "Aqueduc romain",
+    ...overrides,
+  };
+}
+
+describe("AlertList Wikipedia link", () => {
+  it("renders an absolute link with the translated label for a usable url", () => {
+    render(
+      <AlertList
+        alerts={[
+          culturalPoiAlert({
+            wikipediaUrl: "https://fr.wikipedia.org/wiki/Pont_du_Gard",
+          }),
+        ]}
+      />,
+    );
+
+    const link = screen.getByTestId("poi-wikipedia-link");
+    expect(link).toHaveAttribute(
+      "href",
+      "https://fr.wikipedia.org/wiki/Pont_du_Gard",
+    );
+    expect(link).toHaveTextContent("see_on_wikipedia");
+  });
+
+  it("normalizes a schemeless url into an absolute link", () => {
+    render(
+      <AlertList
+        alerts={[
+          culturalPoiAlert({ wikipediaUrl: "fr.wikipedia.org/wiki/Nimes" }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByTestId("poi-wikipedia-link")).toHaveAttribute(
+      "href",
+      "https://fr.wikipedia.org/wiki/Nimes",
+    );
+  });
+
+  it.each(["javascript:alert(1)", "mailto:contact@wikipedia.org", "   "])(
+    "renders no link and does not throw for %j",
+    (wikipediaUrl) => {
+      expect(() =>
+        render(<AlertList alerts={[culturalPoiAlert({ wikipediaUrl })]} />),
+      ).not.toThrow();
+
+      expect(
+        screen.queryByTestId("poi-wikipedia-link"),
+      ).not.toBeInTheDocument();
+    },
+  );
+});

--- a/pwa/src/components/alert-list.tsx
+++ b/pwa/src/components/alert-list.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/components/Map/icons";
 import { cn } from "@/lib/utils";
 import type { AlertActionData, AlertData } from "@/lib/validation/schemas";
+import { normalizeExternalUrl } from "@/lib/validation/url";
 
 interface AlertListProps {
   alerts: AlertData[];
@@ -156,6 +157,8 @@ export function AlertList({ alerts, onAddPoiWaypoint }: AlertListProps) {
                   alert.estimatedPrice,
                 );
 
+              const wikipediaHref = normalizeExternalUrl(alert.wikipediaUrl);
+
               // Some action kinds are not wired yet; surface them as disabled.
               const isActionDisabled = Boolean(
                 action &&
@@ -233,15 +236,15 @@ export function AlertList({ alerts, onAddPoiWaypoint }: AlertListProps) {
                             : `${alert.estimatedPrice.toFixed(2)} €`}
                         </span>
                       )}
-                      {alert.wikipediaUrl && (
+                      {wikipediaHref && (
                         <a
-                          href={alert.wikipediaUrl}
+                          href={wikipediaHref}
                           target="_blank"
                           rel="noopener noreferrer"
                           className="text-xs text-primary flex items-center gap-0.5 hover:underline"
                           data-testid="poi-wikipedia-link"
                         >
-                          Voir sur Wikipedia
+                          {t("see_on_wikipedia")}
                         </a>
                       )}
                     </div>

--- a/pwa/src/lib/validation/url.test.ts
+++ b/pwa/src/lib/validation/url.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { isSupportedSourceUrl } from "./url";
+import {
+  externalUrlHostname,
+  isSupportedSourceUrl,
+  normalizeExternalUrl,
+} from "./url";
 
 describe("isSupportedSourceUrl", () => {
   it.each([
@@ -17,4 +21,47 @@ describe("isSupportedSourceUrl", () => {
     "https://www.komoot.com/tour/",
     "",
   ])("rejects %s", (url) => expect(isSupportedSourceUrl(url)).toBe(false));
+});
+
+describe("normalizeExternalUrl", () => {
+  it.each([
+    ["www.hotel.fr", "https://www.hotel.fr"],
+    ["hotel.fr", "https://hotel.fr"],
+    ["hotel.fr/chambres?lang=fr", "https://hotel.fr/chambres?lang=fr"],
+    ["www.hotel.fr:8080/reserver", "https://www.hotel.fr:8080/reserver"],
+    ["  www.hotel.fr  ", "https://www.hotel.fr"],
+  ])("prefixes the missing scheme: %s", (value, expected) =>
+    expect(normalizeExternalUrl(value)).toBe(expected),
+  );
+
+  it.each([
+    "https://www.hotel.fr",
+    "https://www.hotel.fr/chambres",
+    "http://hotel.fr",
+  ])("leaves %s untouched", (value) =>
+    expect(normalizeExternalUrl(value)).toBe(value),
+  );
+
+  it.each([
+    ["mailto:contact@hotel.fr"],
+    ["javascript:alert(1)"],
+    ["data:text/html,<script>alert(1)</script>"],
+    ["ftp://hotel.fr"],
+    ["tel:+33123456789"],
+    ["appeler le 06 12 34 56 78"],
+    ["Hôtel"],
+    ["localhost"],
+    [""],
+    ["   "],
+    [null],
+    [undefined],
+  ])("rejects %s", (value) => expect(normalizeExternalUrl(value)).toBeNull());
+});
+
+describe("externalUrlHostname", () => {
+  it("returns the hostname of a schemeless value", () =>
+    expect(externalUrlHostname("www.hotel.fr/chambres")).toBe("www.hotel.fr"));
+
+  it("returns null when the value is unusable", () =>
+    expect(externalUrlHostname("mailto:contact@hotel.fr")).toBeNull());
 });

--- a/pwa/src/lib/validation/url.ts
+++ b/pwa/src/lib/validation/url.ts
@@ -18,6 +18,49 @@ export function isValidHttpsUrl(value: string): boolean {
   }
 }
 
+/** A scheme prefix (`mailto:`, `javascript:`, `https://`…). Dots are excluded
+ * on purpose so `www.hotel.fr:8080` is read as a host, not as a scheme. */
+const SCHEME_PREFIX = /^[a-z][a-z0-9+-]*:/i;
+
+/**
+ * Normalize a hand-typed website value (OSM `website` tag, user input) into an
+ * absolute http(s) URL, or `null` when it is not usable as a link.
+ *
+ * Last-resort frontend guard: the value reaches us straight from an OSM tag or
+ * from the accommodation edit field, so schemeless values (`www.hotel.fr`) and
+ * free text are both common. Returns the input untouched when it already is an
+ * absolute http(s) URL.
+ */
+export function normalizeExternalUrl(
+  value: string | null | undefined,
+): string | null {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+
+  const hasScheme = SCHEME_PREFIX.test(trimmed);
+  if (hasScheme && !/^https?:\/\//i.test(trimmed)) return null;
+
+  const candidate = hasScheme ? trimmed : `https://${trimmed}`;
+  let url: URL;
+  try {
+    url = new URL(candidate);
+  } catch {
+    return null;
+  }
+  // A hostname without a dot (`Hôtel`, `localhost`) is not a reachable website.
+  if (!url.hostname.includes(".")) return null;
+
+  return candidate;
+}
+
+/** Hostname to display for an external link, or `null` if unusable. */
+export function externalUrlHostname(
+  value: string | null | undefined,
+): string | null {
+  const normalized = normalizeExternalUrl(value);
+  return normalized === null ? null : new URL(normalized).hostname;
+}
+
 /**
  * Supported source URL patterns.
  *

--- a/pwa/tests/fixtures/mock-data.ts
+++ b/pwa/tests/fixtures/mock-data.ts
@@ -193,6 +193,9 @@ export function accommodationsFoundEvent(
           possibleClosed: false,
           distanceToEndPoint: 1.2,
           source: "osm",
+          // Schemeless OSM `website` tag (issue #867): must render as an
+          // absolute link instead of throwing during render.
+          url: "www.camping-les-oliviers.fr",
         },
         {
           name: "Hotel du Pont",
@@ -205,6 +208,8 @@ export function accommodationsFoundEvent(
           possibleClosed: false,
           distanceToEndPoint: 0.5,
           source: "osm",
+          // Unusable OSM `website` tag: renders no link at all, no error.
+          url: "appeler le 06 12 34 56 78",
         },
       ],
     },

--- a/pwa/tests/mocked/accommodation.spec.ts
+++ b/pwa/tests/mocked/accommodation.spec.ts
@@ -31,6 +31,34 @@ test.describe("Accommodations", () => {
     await expect(stageCard).toContainText("0.5 km");
   });
 
+  test("normalizes malformed OSM website tags (issue #867)", async ({
+    submitUrl,
+    injectSequence,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    await injectSequence([
+      routeParsedEvent(),
+      stagesComputedEvent(),
+      accommodationsFoundEvent(0),
+      tripCompleteEvent(),
+    ]);
+    const stageCard = mockedPage.getByTestId("stage-card-1");
+    await expect(stageCard).toContainText("Camping Les Oliviers");
+
+    // Schemeless `www.camping-les-oliviers.fr` becomes an absolute link…
+    const links = stageCard.getByTestId("accommodation-website-link");
+    await expect(links).toHaveCount(1);
+    await expect(links).toHaveAttribute(
+      "href",
+      "https://www.camping-les-oliviers.fr",
+    );
+    await expect(links).toHaveText(/www\.camping-les-oliviers\.fr/);
+    // …while the unusable value on "Hotel du Pont" renders no link at all
+    // (and no error boundary: the card is still there).
+    await expect(stageCard).toContainText("Hotel du Pont");
+  });
+
   test("adds manual accommodation", async ({ createFullTrip, mockedPage }) => {
     await createFullTrip();
     const stageCard = mockedPage.getByTestId("stage-card-1");


### PR DESCRIPTION
Closes #867

## Contexte

`new URL(accommodation.url)` n'était pas gardé dans le rendu, alors que `url` vient d'un tag OSM saisi à la main (`website` / `contact:website`) ou du champ d'édition utilisateur. Une valeur sans schéma (`www.hotel.fr`) faisait lever un `TypeError` **pendant le rendu**, envoyant la fiche — et potentiellement le panneau d'étape — dans l'error boundary. Second effet : `href="www.hotel.fr"` est un lien relatif, donc cassé.

Et « Voir sur Wikipedia » était codé en dur dans deux composants d'une application internationalisée.

## Changements

**Utilitaire** — extension de `pwa/src/lib/validation/url.ts` (qui porte déjà `isValidUrl` / `isValidHttpsUrl` / `isSupportedSourceUrl`) plutôt que la création du `pwa/src/lib/url.ts` suggéré par l'issue : deux modules `url` auraient été un doublon. Deux exports ajoutés :

- `normalizeExternalUrl(value)` — trim, rejette tout schéma non http(s), préfixe `https://` quand le schéma manque, passe par `new URL()` en `try/catch`, exige un hostname avec un point, et retourne la valeur d'origine **inchangée** quand elle est déjà absolue (pas de `/` ajouté par `toString()`). Le motif de détection de schéma exclut les points, donc `www.hotel.fr:8080` reste un hôte et `mailto:` est bien rejeté au lieu de devenir `https://mailto:...`.
- `externalUrlHostname(value)` — hostname à afficher.

**`accommodation-item.tsx`** — `websiteHref` / `websiteHostname` / `wikipediaHref` calculés en tête de composant, plus aucun `new URL()` dans le rendu, lien absent si la valeur est inexploitable, `commitEdits` normalise avant enregistrement, `t("see_on_wikipedia")`.

**`alert-list.tsx`** — même garde sur le lien Wikipédia + clé de traduction.

**i18n** — `see_on_wikipedia` ajoutée aux namespaces `accommodation` et `alertList`, en `fr` et `en`.

**Fixtures E2E** — les deux hébergements de `accommodationsFoundEvent` reçoivent une `url` : un cas valide sans schéma (`www.camping-les-oliviers.fr`) et un cas inexploitable (`appeler le 06 12 34 56 78`). Volontairement **pas** de troisième entrée : des specs assertent `toHaveCount(2)`.

## Vérification

Les tests ont été **prouvés capables d'échouer** : code remis en état d'avant-correctif → `7 failed | 2 passed (9)` sur `accommodation-item.test.tsx`, avec le `TypeError: Invalid URL` reproduit ; préfixage retiré de `normalizeExternalUrl` → `6 failed | 26 passed (32)` sur `url.test.ts`. Code restauré, tout revert vérifié vert ensuite.

Legs exécutés individuellement (`make qa` ne peut pas aboutir en local, cf. CLAUDE.md) :

- `tsc --noEmit` : exit 0, aucune sortie
- `eslint` sur les 7 fichiers touchés : `0 errors, 1 warning` — warning `@next/next/no-img-element` préexistant sur la vignette Wikidata, hors du diff
- `prettier@3.9.6 --check` : `All matched files use Prettier code style!`
- `npm run i18n:check` : `i18n-check OK: 919 keys in sync across fr, en`
- `vitest run` : `36 passed (36)` fichiers, `351 passed (351)` tests

Aucun fichier PHP touché : legs Rector / PHPStan / PHP-CS-Fixer / PHPUnit non applicables.

**Playwright : aucune couverture locale.** Un worktree n'a pas de PWA construite servie sur `https://localhost` ; le nouveau test `accommodation.spec.ts` et les fixtures modifiées sont validés par la CI seule.

## Auto-critique

- L'issue demandait `pwa/src/lib/url.ts` ; j'ai étendu le module de validation existant. Écart assumé, justifié plus haut.
- `normalizeExternalUrl` rejette les hostnames sans point, ce qui écarte `localhost` — sans intérêt pour un site d'hébergement, mais c'est une décision de fait.
- Hors périmètre, non corrigé : `pwa/src/lib/text-export.ts:62` imprime encore `acc.url` brut (texte, sans `new URL`, donc sans risque de lever) et `event-item.tsx:98` a un `href={event.url}` non normalisé.
- Pas de `@testing-library/user-event` dans le projet : les tests utilisent `fireEvent`. Aucune dépendance ajoutée.

## Recoupements attendus au merge (sprint 45)

- `pwa/src/components/accommodation-item.tsx` — #865 et #866 touchent les maps `typeLabelKeys` / `typeIcons`, intactes ici.
- `pwa/messages/{fr,en}.json` — ajouts de clés disjoints avec #865 / #866.
- `pwa/tests/fixtures/mock-data.ts` — #870 ajoute `description` / `imageUrl` / `source` sur les deux mêmes entrées.

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 critical, 0 warnings, 0 nitpicks.

**Resolved threads:** Resolved 1 previously open thread (missing `alert-list.tsx` test coverage) — addressed by the second commit adding `alert-list.test.tsx`.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Commit reviewed:** c11fb9ad03772df2bade72ef96198662985732c7

**Inline comments:** No inline comments.
<!-- claude-review-end -->
