### PR TITLE
fix(accommodations): deterministic ordering and bounded result sets

### DIFF
--- a/api/src/Osm/AccommodationRepository.php
+++ b/api/src/Osm/AccommodationRepository.php
@@ -50,12 +50,21 @@ final readonly class AccommodationRepository implements AccommodationRepositoryI
         // The cap is per end point, not global: a single `ORDER BY geom <-> multipoint
         // LIMIT n` is a top-N over the *combined* multipoint, so one dense urban stage
         // can consume the whole budget and evict a rural stage down to zero candidate.
-        // Each row is therefore assigned to its nearest end point (`nearest`, the same
-        // rule GeometryBasedDistributor::distributeByEndpoint applies downstream) and
+        // Each row is therefore assigned to its nearest end point (`nearest`) and
         // ranked inside that partition, so every stage gets its own MAX_ROWS_PER_POINT.
         // ROW_NUMBER over one pass, rather than a LATERAL sub-select per point: the
         // radius filter costs a full scan (no index on `geom::geography`), so a
         // per-point sub-select would repeat it once per stage.
+        //
+        // The assignment casts to `geography` on purpose: `<->` on `geometry` is a
+        // planar distance in raw WGS84 degrees, where a degree of longitude is
+        // cos(latitude) shorter than a degree of latitude, so near the bisector of two
+        // end points it can pick a different one than the metric
+        // GeometryBasedDistributor::distributeByEndpoint uses downstream — leaving the
+        // row ranked under a stage that will never receive it. `geography <->` is
+        // metres on the sphere, i.e. the same great circle as HaversineDistance
+        // (radii 6371008.8 m vs 6371000 m, a 1.4 ppm scale factor that cannot reorder
+        // two rows a human could tell apart).
         //
         // The order is fully specified — end point, then distance, then the
         // (osm_type, osm_id) primary key — so two runs of the same scan return the
@@ -78,9 +87,10 @@ final readonly class AccommodationRepository implements AccommodationRepositoryI
                            ) AS point_rank
                     FROM osm.accommodations a
                     CROSS JOIN LATERAL (
-                        SELECT pt.path[1] AS point_index, a.geom <-> pt.geom AS distance
+                        SELECT pt.path[1] AS point_index,
+                               a.geom::geography <-> pt.geom::geography AS distance
                         FROM ST_Dump(ST_SetSRID(ST_GeomFromText(:wkt), 4326)) AS pt
-                        ORDER BY a.geom <-> pt.geom, pt.path
+                        ORDER BY a.geom::geography <-> pt.geom::geography, pt.path
                         LIMIT 1
                     ) AS nearest
                     WHERE a.category IN (:categories)

--- a/api/src/Osm/AccommodationRepository.php
+++ b/api/src/Osm/AccommodationRepository.php
@@ -6,6 +6,7 @@ namespace App\Osm;
 
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\ParameterType;
 
 /**
  * Reads accommodations from the local-first Tier-1 index within a radius of the
@@ -14,12 +15,22 @@ use Doctrine\DBAL\Connection;
  */
 final readonly class AccommodationRepository implements AccommodationRepositoryInterface
 {
+    /**
+     * Rows fetched per stage end point. ScanAccommodationsHandler retains
+     * MAX_CANDIDATES_PER_STAGE = 3 per stage after cross-source deduplication and
+     * the price ranking, so 30 leaves a 10x margin while bounding the scan: a
+     * 15 km radius over a dense area otherwise rapatriates every row — and its
+     * full `tags` jsonb — for three kept per stage.
+     */
+    private const int MAX_ROWS_PER_POINT = 30;
+
     public function __construct(private Connection $connection)
     {
     }
 
     /**
-     * Accommodations of the given categories within $radiusMeters of any point.
+     * Accommodations of the given categories within $radiusMeters of any point,
+     * nearest first.
      *
      * @param list<array{lat: float, lon: float}> $points
      * @param list<string>                        $categories
@@ -34,6 +45,10 @@ final readonly class AccommodationRepository implements AccommodationRepositoryI
 
         // description / image_url / wikipedia_url are enriched from Wikidata at
         // provision time (ADR-041); website / opening_hours come from OSM tags.
+        // `ORDER BY geom <-> multipoint` is the GiST KNN order (like
+        // CulturalPoiRepository), so the LIMIT keeps the nearest rows instead of an
+        // arbitrary slice; (osm_type, osm_id) breaks distance ties on the primary
+        // key so two runs of the same scan return the same rows in the same order.
         /** @var list<array<string, scalar|null>> $rows */
         $rows = $this->connection->fetchAllAssociative(
             <<<'SQL'
@@ -47,14 +62,18 @@ final readonly class AccommodationRepository implements AccommodationRepositoryI
                       ST_SetSRID(ST_GeomFromText(:wkt), 4326)::geography,
                       :radius
                   )
+                ORDER BY geom <-> ST_SetSRID(ST_GeomFromText(:wkt), 4326), osm_type, osm_id
+                LIMIT :limit
                 SQL,
             [
                 'wkt' => WktGeometry::multiPoint($points),
                 'radius' => $radiusMeters,
                 'categories' => $categories,
+                'limit' => \count($points) * self::MAX_ROWS_PER_POINT,
             ],
             [
                 'categories' => ArrayParameterType::STRING,
+                'limit' => ParameterType::INTEGER,
             ],
         );
 

--- a/api/src/Osm/AccommodationRepository.php
+++ b/api/src/Osm/AccommodationRepository.php
@@ -16,7 +16,7 @@ use Doctrine\DBAL\ParameterType;
 final readonly class AccommodationRepository implements AccommodationRepositoryInterface
 {
     /**
-     * Rows fetched per stage end point. ScanAccommodationsHandler retains
+     * Rows kept per stage end point. ScanAccommodationsHandler retains
      * MAX_CANDIDATES_PER_STAGE = 3 per stage after cross-source deduplication and
      * the price ranking, so 30 leaves a 10x margin while bounding the scan: a
      * 15 km radius over a dense area otherwise rapatriates every row — and its
@@ -30,7 +30,8 @@ final readonly class AccommodationRepository implements AccommodationRepositoryI
 
     /**
      * Accommodations of the given categories within $radiusMeters of any point,
-     * nearest first.
+     * grouped by the end point they belong to (nearest first within each group)
+     * and capped per end point.
      *
      * @param list<array{lat: float, lon: float}> $points
      * @param list<string>                        $categories
@@ -45,31 +46,58 @@ final readonly class AccommodationRepository implements AccommodationRepositoryI
 
         // description / image_url / wikipedia_url are enriched from Wikidata at
         // provision time (ADR-041); website / opening_hours come from OSM tags.
-        // `ORDER BY geom <-> multipoint` is the GiST KNN order (like
-        // CulturalPoiRepository), so the LIMIT keeps the nearest rows instead of an
-        // arbitrary slice; (osm_type, osm_id) breaks distance ties on the primary
-        // key so two runs of the same scan return the same rows in the same order.
+        //
+        // The cap is per end point, not global: a single `ORDER BY geom <-> multipoint
+        // LIMIT n` is a top-N over the *combined* multipoint, so one dense urban stage
+        // can consume the whole budget and evict a rural stage down to zero candidate.
+        // Each row is therefore assigned to its nearest end point (`nearest`, the same
+        // rule GeometryBasedDistributor::distributeByEndpoint applies downstream) and
+        // ranked inside that partition, so every stage gets its own MAX_ROWS_PER_POINT.
+        // ROW_NUMBER over one pass, rather than a LATERAL sub-select per point: the
+        // radius filter costs a full scan (no index on `geom::geography`), so a
+        // per-point sub-select would repeat it once per stage.
+        //
+        // The order is fully specified — end point, then distance, then the
+        // (osm_type, osm_id) primary key — so two runs of the same scan return the
+        // same rows in the same order. `ranked.*` carries the ranking helper columns
+        // (point_index, distance, point_rank, primary key); the mapping below reads
+        // named keys and ignores them.
         /** @var list<array<string, scalar|null>> $rows */
         $rows = $this->connection->fetchAllAssociative(
             <<<'SQL'
-                SELECT name, category, stars, capacity, fee, website, wikidata, opening_hours,
-                       description, image_url, wikipedia_url,
-                       ST_Y(geom) AS lat, ST_X(geom) AS lon, tags
-                FROM osm.accommodations
-                WHERE category IN (:categories)
-                  AND ST_DWithin(
-                      geom::geography,
-                      ST_SetSRID(ST_GeomFromText(:wkt), 4326)::geography,
-                      :radius
-                  )
-                ORDER BY geom <-> ST_SetSRID(ST_GeomFromText(:wkt), 4326), osm_type, osm_id
-                LIMIT :limit
+                SELECT ranked.*
+                FROM (
+                    SELECT a.osm_type, a.osm_id,
+                           a.name, a.category, a.stars, a.capacity, a.fee, a.website, a.wikidata,
+                           a.opening_hours, a.description, a.image_url, a.wikipedia_url,
+                           ST_Y(a.geom) AS lat, ST_X(a.geom) AS lon, a.tags,
+                           nearest.point_index, nearest.distance,
+                           ROW_NUMBER() OVER (
+                               PARTITION BY nearest.point_index
+                               ORDER BY nearest.distance, a.osm_type, a.osm_id
+                           ) AS point_rank
+                    FROM osm.accommodations a
+                    CROSS JOIN LATERAL (
+                        SELECT pt.path[1] AS point_index, a.geom <-> pt.geom AS distance
+                        FROM ST_Dump(ST_SetSRID(ST_GeomFromText(:wkt), 4326)) AS pt
+                        ORDER BY a.geom <-> pt.geom, pt.path
+                        LIMIT 1
+                    ) AS nearest
+                    WHERE a.category IN (:categories)
+                      AND ST_DWithin(
+                          a.geom::geography,
+                          ST_SetSRID(ST_GeomFromText(:wkt), 4326)::geography,
+                          :radius
+                      )
+                ) AS ranked
+                WHERE ranked.point_rank <= :limit
+                ORDER BY ranked.point_index, ranked.distance, ranked.osm_type, ranked.osm_id
                 SQL,
             [
                 'wkt' => WktGeometry::multiPoint($points),
                 'radius' => $radiusMeters,
                 'categories' => $categories,
-                'limit' => \count($points) * self::MAX_ROWS_PER_POINT,
+                'limit' => self::MAX_ROWS_PER_POINT,
             ],
             [
                 'categories' => ArrayParameterType::STRING,

--- a/api/src/Osm/AccommodationRepositoryInterface.php
+++ b/api/src/Osm/AccommodationRepositoryInterface.php
@@ -7,7 +7,8 @@ namespace App\Osm;
 interface AccommodationRepositoryInterface
 {
     /**
-     * Accommodations of the given categories within $radiusMeters of any point.
+     * Accommodations of the given categories within $radiusMeters of any point,
+     * nearest first and capped so the result set stays bounded.
      *
      * @param list<array{lat: float, lon: float}> $points
      * @param list<string>                        $categories

--- a/api/src/Osm/AccommodationRepositoryInterface.php
+++ b/api/src/Osm/AccommodationRepositoryInterface.php
@@ -8,7 +8,8 @@ interface AccommodationRepositoryInterface
 {
     /**
      * Accommodations of the given categories within $radiusMeters of any point,
-     * nearest first and capped so the result set stays bounded.
+     * grouped by the end point they belong to (nearest first within each group) and
+     * capped per end point, so a dense end point cannot starve a sparse one.
      *
      * @param list<array{lat: float, lon: float}> $points
      * @param list<string>                        $categories

--- a/api/src/Osm/WktGeometry.php
+++ b/api/src/Osm/WktGeometry.php
@@ -37,16 +37,21 @@ final class WktGeometry
     }
 
     /**
+     * One vertex per input point, in input order and *without* deduplication: the
+     * accommodation repositories partition their per-end-point budget on the
+     * ST_Dump vertex index, so collapsing two stages that share an end point (a
+     * rest day) would collapse their two budget slots into one.
+     *
      * @param list<array{lat: float, lon: float}> $points non-empty
      *
      * @throws \InvalidArgumentException when $points is empty
      */
     public static function multiPoint(array $points): string
     {
-        $coords = array_values(array_unique(array_map(
+        $coords = array_map(
             static fn (array $p): string => \sprintf('(%F %F)', $p['lon'], $p['lat']),
             $points,
-        )));
+        );
 
         if ([] === $coords) {
             throw new \InvalidArgumentException('multiPoint() requires at least one point.');

--- a/api/src/Tourism/AccommodationRepository.php
+++ b/api/src/Tourism/AccommodationRepository.php
@@ -48,11 +48,18 @@ final readonly class AccommodationRepository implements AccommodationRepositoryI
         // The cap is per end point, not global: the flat `LIMIT 200` (and any single
         // top-N over the combined multipoint) lets one dense urban stage consume the
         // whole budget and evict a rural stage down to zero candidate. Each row is
-        // therefore assigned to its nearest end point (`nearest`, the same rule
-        // GeometryBasedDistributor::distributeByEndpoint applies downstream) and
-        // ranked inside that partition. ROW_NUMBER over one pass, rather than a
-        // LATERAL sub-select per point: the radius filter costs a full scan (no index
-        // on `geom::geography`), so a per-point sub-select would repeat it per stage.
+        // therefore assigned to its nearest end point (`nearest`) and ranked inside
+        // that partition. ROW_NUMBER over one pass, rather than a LATERAL sub-select
+        // per point: the radius filter costs a full scan (no index on
+        // `geom::geography`), so a per-point sub-select would repeat it per stage.
+        //
+        // The assignment casts to `geography` on purpose: `<->` on `geometry` is a
+        // planar distance in raw WGS84 degrees, where a degree of longitude is
+        // cos(latitude) shorter than a degree of latitude, so near the bisector of two
+        // end points it can pick a different one than the metric
+        // GeometryBasedDistributor::distributeByEndpoint uses downstream — leaving the
+        // row ranked under a stage that will never receive it. `geography <->` is
+        // metres on the sphere, i.e. the same great circle as HaversineDistance.
         //
         // The order is fully specified — end point, then distance, then the `id`
         // primary key (the DataTourisme URI) — so two runs of the same scan return
@@ -74,9 +81,10 @@ final readonly class AccommodationRepository implements AccommodationRepositoryI
                            ) AS point_rank
                     FROM tourism.accommodations a
                     CROSS JOIN LATERAL (
-                        SELECT pt.path[1] AS point_index, a.geom <-> pt.geom AS distance
+                        SELECT pt.path[1] AS point_index,
+                               a.geom::geography <-> pt.geom::geography AS distance
                         FROM ST_Dump(ST_SetSRID(ST_GeomFromText(:wkt), 4326)) AS pt
-                        ORDER BY a.geom <-> pt.geom, pt.path
+                        ORDER BY a.geom::geography <-> pt.geom::geography, pt.path
                         LIMIT 1
                     ) AS nearest
                     WHERE a.category IN (:categories)

--- a/api/src/Tourism/AccommodationRepository.php
+++ b/api/src/Tourism/AccommodationRepository.php
@@ -7,6 +7,7 @@ namespace App\Tourism;
 use App\Osm\WktGeometry;
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\ParameterType;
 
 /**
  * Reads DataTourisme accommodations from the local-first `tourism` schema within
@@ -15,11 +16,23 @@ use Doctrine\DBAL\Connection;
  */
 final readonly class AccommodationRepository implements AccommodationRepositoryInterface
 {
+    /**
+     * Rows fetched per stage end point. ScanAccommodationsHandler retains
+     * MAX_CANDIDATES_PER_STAGE = 3 per stage after cross-source deduplication and
+     * the price ranking, so 30 leaves a 10x margin. It replaces the flat
+     * `LIMIT 200`, which both starved long trips and truncated non
+     * deterministically for lack of an ORDER BY.
+     */
+    private const int MAX_ROWS_PER_POINT = 30;
+
     public function __construct(private Connection $connection)
     {
     }
 
     /**
+     * DataTourisme accommodations of the given categories within $radiusMeters of
+     * any point, nearest first.
+     *
      * @param list<array{lat: float, lon: float}> $points
      * @param list<string>                        $categories
      *
@@ -31,6 +44,11 @@ final readonly class AccommodationRepository implements AccommodationRepositoryI
             return [];
         }
 
+        // `ORDER BY geom <-> multipoint` is the GiST KNN order (like
+        // CulturalPoiRepository), so the LIMIT keeps the nearest rows; `id` (the
+        // DataTourisme URI, primary key) breaks distance ties so two runs of the
+        // same scan return the same rows in the same order — the reproducibility
+        // ADR-040 promises.
         /** @var list<array<string, scalar|null>> $rows */
         $rows = $this->connection->fetchAllAssociative(
             <<<'SQL'
@@ -43,15 +61,18 @@ final readonly class AccommodationRepository implements AccommodationRepositoryI
                       ST_SetSRID(ST_GeomFromText(:wkt), 4326)::geography,
                       :radius
                   )
-                LIMIT 200
+                ORDER BY geom <-> ST_SetSRID(ST_GeomFromText(:wkt), 4326), id
+                LIMIT :limit
                 SQL,
             [
                 'wkt' => WktGeometry::multiPoint($points),
                 'radius' => $radiusMeters,
                 'categories' => $categories,
+                'limit' => \count($points) * self::MAX_ROWS_PER_POINT,
             ],
             [
                 'categories' => ArrayParameterType::STRING,
+                'limit' => ParameterType::INTEGER,
             ],
         );
 

--- a/api/src/Tourism/AccommodationRepository.php
+++ b/api/src/Tourism/AccommodationRepository.php
@@ -17,7 +17,7 @@ use Doctrine\DBAL\ParameterType;
 final readonly class AccommodationRepository implements AccommodationRepositoryInterface
 {
     /**
-     * Rows fetched per stage end point. ScanAccommodationsHandler retains
+     * Rows kept per stage end point. ScanAccommodationsHandler retains
      * MAX_CANDIDATES_PER_STAGE = 3 per stage after cross-source deduplication and
      * the price ranking, so 30 leaves a 10x margin. It replaces the flat
      * `LIMIT 200`, which both starved long trips and truncated non
@@ -31,7 +31,8 @@ final readonly class AccommodationRepository implements AccommodationRepositoryI
 
     /**
      * DataTourisme accommodations of the given categories within $radiusMeters of
-     * any point, nearest first.
+     * any point, grouped by the end point they belong to (nearest first within each
+     * group) and capped per end point.
      *
      * @param list<array{lat: float, lon: float}> $points
      * @param list<string>                        $categories
@@ -44,31 +45,55 @@ final readonly class AccommodationRepository implements AccommodationRepositoryI
             return [];
         }
 
-        // `ORDER BY geom <-> multipoint` is the GiST KNN order (like
-        // CulturalPoiRepository), so the LIMIT keeps the nearest rows; `id` (the
-        // DataTourisme URI, primary key) breaks distance ties so two runs of the
-        // same scan return the same rows in the same order — the reproducibility
-        // ADR-040 promises.
+        // The cap is per end point, not global: the flat `LIMIT 200` (and any single
+        // top-N over the combined multipoint) lets one dense urban stage consume the
+        // whole budget and evict a rural stage down to zero candidate. Each row is
+        // therefore assigned to its nearest end point (`nearest`, the same rule
+        // GeometryBasedDistributor::distributeByEndpoint applies downstream) and
+        // ranked inside that partition. ROW_NUMBER over one pass, rather than a
+        // LATERAL sub-select per point: the radius filter costs a full scan (no index
+        // on `geom::geography`), so a per-point sub-select would repeat it per stage.
+        //
+        // The order is fully specified — end point, then distance, then the `id`
+        // primary key (the DataTourisme URI) — so two runs of the same scan return
+        // the same rows in the same order, the reproducibility ADR-040 promises.
+        // `ranked.*` carries the ranking helper columns (point_index, distance,
+        // point_rank, id); the mapping below reads named keys and ignores them.
         /** @var list<array<string, scalar|null>> $rows */
         $rows = $this->connection->fetchAllAssociative(
             <<<'SQL'
-                SELECT name, category, capacity, price, description,
-                       ST_Y(geom) AS lat, ST_X(geom) AS lon
-                FROM tourism.accommodations
-                WHERE category IN (:categories)
-                  AND ST_DWithin(
-                      geom::geography,
-                      ST_SetSRID(ST_GeomFromText(:wkt), 4326)::geography,
-                      :radius
-                  )
-                ORDER BY geom <-> ST_SetSRID(ST_GeomFromText(:wkt), 4326), id
-                LIMIT :limit
+                SELECT ranked.*
+                FROM (
+                    SELECT a.id,
+                           a.name, a.category, a.capacity, a.price, a.description,
+                           ST_Y(a.geom) AS lat, ST_X(a.geom) AS lon,
+                           nearest.point_index, nearest.distance,
+                           ROW_NUMBER() OVER (
+                               PARTITION BY nearest.point_index
+                               ORDER BY nearest.distance, a.id
+                           ) AS point_rank
+                    FROM tourism.accommodations a
+                    CROSS JOIN LATERAL (
+                        SELECT pt.path[1] AS point_index, a.geom <-> pt.geom AS distance
+                        FROM ST_Dump(ST_SetSRID(ST_GeomFromText(:wkt), 4326)) AS pt
+                        ORDER BY a.geom <-> pt.geom, pt.path
+                        LIMIT 1
+                    ) AS nearest
+                    WHERE a.category IN (:categories)
+                      AND ST_DWithin(
+                          a.geom::geography,
+                          ST_SetSRID(ST_GeomFromText(:wkt), 4326)::geography,
+                          :radius
+                      )
+                ) AS ranked
+                WHERE ranked.point_rank <= :limit
+                ORDER BY ranked.point_index, ranked.distance, ranked.id
                 SQL,
             [
                 'wkt' => WktGeometry::multiPoint($points),
                 'radius' => $radiusMeters,
                 'categories' => $categories,
-                'limit' => \count($points) * self::MAX_ROWS_PER_POINT,
+                'limit' => self::MAX_ROWS_PER_POINT,
             ],
             [
                 'categories' => ArrayParameterType::STRING,

--- a/api/src/Tourism/AccommodationRepositoryInterface.php
+++ b/api/src/Tourism/AccommodationRepositoryInterface.php
@@ -8,8 +8,9 @@ interface AccommodationRepositoryInterface
 {
     /**
      * DataTourisme accommodations of the given categories within $radiusMeters of
-     * any point, nearest first and capped so the result set stays bounded.
-     * `price` is the structured offer price when DataTourisme provided one
+     * any point, grouped by the end point they belong to (nearest first within each
+     * group) and capped per end point, so a dense end point cannot starve a sparse
+     * one. `price` is the structured offer price when DataTourisme provided one
      * (exact), null otherwise (the caller falls back to a heuristic).
      *
      * @param list<array{lat: float, lon: float}> $points

--- a/api/src/Tourism/AccommodationRepositoryInterface.php
+++ b/api/src/Tourism/AccommodationRepositoryInterface.php
@@ -8,8 +8,9 @@ interface AccommodationRepositoryInterface
 {
     /**
      * DataTourisme accommodations of the given categories within $radiusMeters of
-     * any point. `price` is the structured offer price when DataTourisme provided
-     * one (exact), null otherwise (the caller falls back to a heuristic).
+     * any point, nearest first and capped so the result set stays bounded.
+     * `price` is the structured offer price when DataTourisme provided one
+     * (exact), null otherwise (the caller falls back to a heuristic).
      *
      * @param list<array{lat: float, lon: float}> $points
      * @param list<string>                        $categories

--- a/api/tests/Integration/Osm/AccommodationIndexReadTest.php
+++ b/api/tests/Integration/Osm/AccommodationIndexReadTest.php
@@ -111,6 +111,71 @@ final class AccommodationIndexReadTest extends KernelTestCase
         self::assertFalse($byType['camp_site']['hasWebsite']);
     }
 
+    #[Test]
+    public function findNearKeepsTheNearestRowsOnlyUpToTheLimit(): void
+    {
+        $this->seedFortyHotelsFarthestFirst();
+
+        $rows = new AccommodationRepository($this->connection)->findNear(
+            [['lat' => 48.5, 'lon' => 2.5]],
+            5000,
+            ['hotel'],
+        );
+
+        // MAX_ROWS_PER_POINT = 30 per end point, and the KNN order means the 30
+        // retained rows are the closest ones: Hotel 30..40 are dropped, not an
+        // arbitrary slice of the 41 in range.
+        $expected = array_merge(['Hotel du Centre'], array_map(
+            static fn (int $i): string => \sprintf('Hotel %02d', $i),
+            range(1, 29),
+        ));
+
+        self::assertSame($expected, array_column($rows, 'name'));
+    }
+
+    #[Test]
+    public function findNearReturnsTheSameRowsInTheSameOrderOnEveryRun(): void
+    {
+        $this->seedFortyHotelsFarthestFirst();
+
+        // Three rows share the end point geom (the setUp hotel and hostel plus
+        // this one, inserted last with the lowest osm_id): the distance tie is
+        // resolved on the primary key, not on the physical row order.
+        $this->connection->executeStatement(<<<'SQL'
+            INSERT INTO osm.accommodations (osm_type, osm_id, name, category, tags, geom) VALUES
+              ('n', 7999, 'Hotel Zero', 'hotel', '{}'::jsonb, ST_SetSRID(ST_MakePoint(2.5, 48.5), 4326))
+            SQL);
+
+        $repository = new AccommodationRepository($this->connection);
+        $points = [['lat' => 48.5, 'lon' => 2.5]];
+
+        $first = $repository->findNear($points, 5000, ['hotel', 'hostel']);
+        $second = $repository->findNear($points, 5000, ['hotel', 'hostel']);
+
+        self::assertSame($first, $second, 'the same scan must return the same rows in the same order (ADR-040)');
+        self::assertCount(30, $first);
+        self::assertSame(
+            ['Hotel Zero', 'Hotel du Centre', 'Auberge de Jeunesse'],
+            \array_slice(array_column($first, 'name'), 0, 3),
+            'co-located rows are ordered by (osm_type, osm_id): 7999 < 8001 < 8004',
+        );
+    }
+
+    /**
+     * 40 extra hotels, 111 m apart along the meridian, all inside the 5 km radius
+     * (41 rows in range with the setUp hotel, for a 30-row cap). Inserted farthest
+     * first so the physical row order is the reverse of the expected KNN order.
+     */
+    private function seedFortyHotelsFarthestFirst(): void
+    {
+        $this->connection->executeStatement(<<<'SQL'
+            INSERT INTO osm.accommodations (osm_type, osm_id, name, category, tags, geom)
+            SELECT 'n', 9000 + i, 'Hotel ' || lpad(i::text, 2, '0'), 'hotel', '{}'::jsonb,
+                   ST_SetSRID(ST_MakePoint(2.5, 48.5 + i * 0.001), 4326)
+            FROM generate_series(40, 1, -1) AS i
+            SQL);
+    }
+
     private function source(): OsmAccommodationSource
     {
         return new OsmAccommodationSource(

--- a/api/tests/Integration/Osm/AccommodationIndexReadTest.php
+++ b/api/tests/Integration/Osm/AccommodationIndexReadTest.php
@@ -161,6 +161,44 @@ final class AccommodationIndexReadTest extends KernelTestCase
         );
     }
 
+    #[Test]
+    public function findNearGivesEveryEndPointItsOwnBudget(): void
+    {
+        // A dense end point (48.5 2.5): 80 hotels 22 m apart, so 60 of them sit
+        // closer than anything around the isolated end point below.
+        $this->connection->executeStatement(<<<'SQL'
+            INSERT INTO osm.accommodations (osm_type, osm_id, name, category, tags, geom)
+            SELECT 'n', 9000 + i, 'Hotel ' || lpad(i::text, 2, '0'), 'hotel', '{}'::jsonb,
+                   ST_SetSRID(ST_MakePoint(2.5, 48.5 + i * 0.0002), 4326)
+            FROM generate_series(80, 1, -1) AS i
+            SQL);
+
+        // An isolated end point (49.52 3.5), ~110 km away: three hotels 2.2 to
+        // 3.9 km out, all inside the radius but all farther than the dense
+        // cluster. The setUp 'Auberge Lointaine' (3.5 49.5) is the nearest one.
+        $this->connection->executeStatement(<<<'SQL'
+            INSERT INTO osm.accommodations (osm_type, osm_id, name, category, tags, geom) VALUES
+              ('n', 9500, 'Auberge Isolee 1', 'hotel', '{}'::jsonb, ST_SetSRID(ST_MakePoint(3.5, 49.55), 4326)),
+              ('n', 9501, 'Auberge Isolee 2', 'hotel', '{}'::jsonb, ST_SetSRID(ST_MakePoint(3.5, 49.555), 4326))
+            SQL);
+
+        $rows = new AccommodationRepository($this->connection)->findNear(
+            [['lat' => 48.5, 'lon' => 2.5], ['lat' => 49.52, 'lon' => 3.5]],
+            5000,
+            ['hotel'],
+        );
+
+        // A single top-N over the combined multipoint would spend the whole budget
+        // on the dense cluster and return nothing at all for the isolated stage.
+        // The cap is per end point, so both get served: 30 + 3.
+        self::assertCount(33, $rows);
+        self::assertSame(
+            ['Auberge Lointaine', 'Auberge Isolee 1', 'Auberge Isolee 2'],
+            \array_slice(array_column($rows, 'name'), 30),
+            'the isolated end point keeps its own candidates, nearest first',
+        );
+    }
+
     /**
      * 40 extra hotels, 111 m apart along the meridian, all inside the 5 km radius
      * (41 rows in range with the setUp hotel, for a 30-row cap). Inserted farthest

--- a/api/tests/Integration/Osm/AccommodationIndexReadTest.php
+++ b/api/tests/Integration/Osm/AccommodationIndexReadTest.php
@@ -199,6 +199,69 @@ final class AccommodationIndexReadTest extends KernelTestCase
         );
     }
 
+    #[Test]
+    public function findNearAssignsBisectorRowsWithTheSameMetricAsTheDistributor(): void
+    {
+        // At latitude 60 a degree of longitude is only cos(60) = half a degree of
+        // latitude. 'Hotel Bissectrice' (60.00 0.00) sits 0.10 deg south of end point
+        // A but 0.12 deg west of end point B, so a planar degree distance calls A
+        // nearer (0.10 < 0.12) while metres call B nearer (6.7 km < 11.1 km) — and
+        // metres are what GeometryBasedDistributor::distributeByEndpoint uses.
+        //
+        // A's own budget is filled with 30 hotels within 100 m, so a row assigned to
+        // A is ranked 31st and dropped. Surviving therefore proves the row went to B.
+        $this->connection->executeStatement(<<<'SQL'
+            INSERT INTO osm.accommodations (osm_type, osm_id, name, category, tags, geom)
+            SELECT 'n', 9600 + i, 'Hotel Dense ' || lpad(i::text, 2, '0'), 'hotel', '{}'::jsonb,
+                   ST_SetSRID(ST_MakePoint(0.0, 60.10 + i * 0.00001), 4326)
+            FROM generate_series(1, 30) AS i
+            SQL);
+        $this->connection->executeStatement(<<<'SQL'
+            INSERT INTO osm.accommodations (osm_type, osm_id, name, category, tags, geom) VALUES
+              ('n', 9700, 'Hotel Bissectrice', 'hotel', '{}'::jsonb, ST_SetSRID(ST_MakePoint(0.0, 60.00), 4326))
+            SQL);
+
+        $rows = new AccommodationRepository($this->connection)->findNear(
+            [['lat' => 60.10, 'lon' => 0.0], ['lat' => 60.00, 'lon' => 0.12]],
+            15000,
+            ['hotel'],
+        );
+
+        self::assertContains(
+            'Hotel Bissectrice',
+            array_column($rows, 'name'),
+            'a bisector row must be assigned to the end point the distributor will pick (metres), not the planar-degree one',
+        );
+        self::assertCount(31, $rows);
+    }
+
+    #[Test]
+    public function findNearHandlesTwoStagesSharingAnEndPoint(): void
+    {
+        // A rest day repeats the previous stage's end point. The two identical
+        // vertices survive into the MULTIPOINT (no dedup in WktGeometry::multiPoint),
+        // and the `pt.path` tie-break sends every row to the first of them — the same
+        // stage distributeByEndpoint would award them to, with its strict `<`. What
+        // matters is that the shared location still yields its full, ordered top-30
+        // rather than an arbitrary split across the two coincident partitions.
+        $this->seedFortyHotelsFarthestFirst();
+
+        $repository = new AccommodationRepository($this->connection);
+        $restDayPoints = [['lat' => 48.5, 'lon' => 2.5], ['lat' => 48.5, 'lon' => 2.5]];
+
+        $expected = array_merge(['Hotel du Centre'], array_map(
+            static fn (int $i): string => \sprintf('Hotel %02d', $i),
+            range(1, 29),
+        ));
+
+        self::assertSame($expected, array_column($repository->findNear($restDayPoints, 5000, ['hotel']), 'name'));
+        self::assertSame(
+            $repository->findNear([['lat' => 48.5, 'lon' => 2.5]], 5000, ['hotel']),
+            $repository->findNear($restDayPoints, 5000, ['hotel']),
+            'repeating an end point must not change what that location yields',
+        );
+    }
+
     /**
      * 40 extra hotels, 111 m apart along the meridian, all inside the 5 km radius
      * (41 rows in range with the setUp hotel, for a 30-row cap). Inserted farthest

--- a/api/tests/Integration/Tourism/TourismIndexReadTest.php
+++ b/api/tests/Integration/Tourism/TourismIndexReadTest.php
@@ -114,6 +114,72 @@ final class TourismIndexReadTest extends KernelTestCase
     }
 
     #[Test]
+    public function accommodationsKeepTheNearestRowsOnlyUpToTheLimit(): void
+    {
+        $this->seedFortyGitesFarthestFirst();
+
+        $rows = new AccommodationRepository($this->connection)->findNear(
+            [['lat' => 48.50, 'lon' => 2.50]],
+            5000,
+            ['apartment'],
+        );
+
+        // MAX_ROWS_PER_POINT = 30 per end point, and the KNN order means the cap
+        // keeps the closest rows: Gîte 30..40 are dropped, not an arbitrary slice
+        // of the 41 in range (what the flat `LIMIT 200` did on a real trip).
+        $expected = array_merge(['Gîte du Lac'], array_map(
+            static fn (int $i): string => \sprintf('Gîte %02d', $i),
+            range(1, 29),
+        ));
+
+        self::assertSame($expected, array_column($rows, 'name'));
+    }
+
+    #[Test]
+    public function accommodationsAreReturnedInTheSameOrderOnEveryRun(): void
+    {
+        $this->seedFortyGitesFarthestFirst();
+
+        // Three rows share the end point geom (the setUp gîte and hotel plus this
+        // one, inserted last with the lowest id): the distance tie is resolved on
+        // the DataTourisme id, not on the physical row order.
+        $this->connection->executeStatement(<<<'SQL'
+            INSERT INTO tourism.accommodations (id, name, category, capacity, price, description, tags, geom) VALUES
+              ('a0', 'Auberge Zéro', 'hotel', NULL, NULL, NULL, '{}'::jsonb,
+                  ST_SetSRID(ST_MakePoint(2.50, 48.50), 4326))
+            SQL);
+
+        $repository = new AccommodationRepository($this->connection);
+        $points = [['lat' => 48.50, 'lon' => 2.50]];
+
+        $first = $repository->findNear($points, 5000, ['apartment', 'hotel']);
+        $second = $repository->findNear($points, 5000, ['apartment', 'hotel']);
+
+        self::assertSame($first, $second, 'the same scan must return the same rows in the same order (ADR-040)');
+        self::assertCount(30, $first);
+        self::assertSame(
+            ['Auberge Zéro', 'Gîte du Lac', 'Grand Hôtel'],
+            \array_slice(array_column($first, 'name'), 0, 3),
+            'co-located rows are ordered by id: a0 < a1 < a2',
+        );
+    }
+
+    /**
+     * 40 extra apartments, 111 m apart along the meridian, all inside the 5 km
+     * radius (41 rows in range with the setUp gîte, for a 30-row cap). Inserted
+     * farthest first so the physical row order reverses the expected KNN order.
+     */
+    private function seedFortyGitesFarthestFirst(): void
+    {
+        $this->connection->executeStatement(<<<'SQL'
+            INSERT INTO tourism.accommodations (id, name, category, capacity, price, description, tags, geom)
+            SELECT 'g' || lpad(i::text, 2, '0'), 'Gîte ' || lpad(i::text, 2, '0'), 'apartment', NULL, NULL, NULL, '{}'::jsonb,
+                   ST_SetSRID(ST_MakePoint(2.50, 48.50 + i * 0.001), 4326)
+            FROM generate_series(40, 1, -1) AS i
+            SQL);
+    }
+
+    #[Test]
     public function eventsAreFilteredByDateAndRadius(): void
     {
         $repository = new EventRepository($this->connection);

--- a/api/tests/Integration/Tourism/TourismIndexReadTest.php
+++ b/api/tests/Integration/Tourism/TourismIndexReadTest.php
@@ -202,6 +202,41 @@ final class TourismIndexReadTest extends KernelTestCase
         );
     }
 
+    #[Test]
+    public function accommodationsAssignBisectorRowsWithTheSameMetricAsTheDistributor(): void
+    {
+        // At latitude 60 a degree of longitude is only cos(60) = half a degree of
+        // latitude. 'Gîte Bissectrice' (60.00 0.00) is 0.10 deg south of end point A
+        // but 0.12 deg west of end point B: planar degrees call A nearer
+        // (0.10 < 0.12), metres call B nearer (6.7 km < 11.1 km), and metres are what
+        // GeometryBasedDistributor::distributeByEndpoint uses. A's budget is filled
+        // with 30 gîtes within 100 m, so a row assigned to A is ranked 31st and
+        // dropped — surviving proves it went to B.
+        $this->connection->executeStatement(<<<'SQL'
+            INSERT INTO tourism.accommodations (id, name, category, capacity, price, description, tags, geom)
+            SELECT 'd' || lpad(i::text, 2, '0'), 'Gîte Dense ' || lpad(i::text, 2, '0'), 'apartment', NULL, NULL, NULL, '{}'::jsonb,
+                   ST_SetSRID(ST_MakePoint(0.0, 60.10 + i * 0.00001), 4326)
+            FROM generate_series(1, 30) AS i
+            SQL);
+        $this->connection->executeStatement(<<<'SQL'
+            INSERT INTO tourism.accommodations (id, name, category, capacity, price, description, tags, geom) VALUES
+              ('zz', 'Gîte Bissectrice', 'apartment', NULL, NULL, NULL, '{}'::jsonb, ST_SetSRID(ST_MakePoint(0.0, 60.00), 4326))
+            SQL);
+
+        $rows = new AccommodationRepository($this->connection)->findNear(
+            [['lat' => 60.10, 'lon' => 0.0], ['lat' => 60.00, 'lon' => 0.12]],
+            15000,
+            ['apartment'],
+        );
+
+        self::assertContains(
+            'Gîte Bissectrice',
+            array_column($rows, 'name'),
+            'a bisector row must be assigned to the end point the distributor will pick (metres), not the planar-degree one',
+        );
+        self::assertCount(31, $rows);
+    }
+
     /**
      * 40 extra apartments, 111 m apart along the meridian, all inside the 5 km
      * radius (41 rows in range with the setUp gîte, for a 30-row cap). Inserted

--- a/api/tests/Integration/Tourism/TourismIndexReadTest.php
+++ b/api/tests/Integration/Tourism/TourismIndexReadTest.php
@@ -164,6 +164,44 @@ final class TourismIndexReadTest extends KernelTestCase
         );
     }
 
+    #[Test]
+    public function accommodationsGiveEveryEndPointItsOwnBudget(): void
+    {
+        // A dense end point (48.50 2.50): 80 gîtes 22 m apart, so 60 of them sit
+        // closer than anything around the isolated end point below.
+        $this->connection->executeStatement(<<<'SQL'
+            INSERT INTO tourism.accommodations (id, name, category, capacity, price, description, tags, geom)
+            SELECT 'g' || lpad(i::text, 2, '0'), 'Gîte ' || lpad(i::text, 2, '0'), 'apartment', NULL, NULL, NULL, '{}'::jsonb,
+                   ST_SetSRID(ST_MakePoint(2.50, 48.50 + i * 0.0002), 4326)
+            FROM generate_series(80, 1, -1) AS i
+            SQL);
+
+        // An isolated end point (49.52 3.50), ~110 km away: three gîtes 2.2 to
+        // 3.9 km out, all inside the radius but all farther than the dense cluster.
+        $this->connection->executeStatement(<<<'SQL'
+            INSERT INTO tourism.accommodations (id, name, category, capacity, price, description, tags, geom) VALUES
+              ('i1', 'Gîte Isolé 1', 'apartment', NULL, NULL, NULL, '{}'::jsonb, ST_SetSRID(ST_MakePoint(3.50, 49.50), 4326)),
+              ('i2', 'Gîte Isolé 2', 'apartment', NULL, NULL, NULL, '{}'::jsonb, ST_SetSRID(ST_MakePoint(3.50, 49.55), 4326)),
+              ('i3', 'Gîte Isolé 3', 'apartment', NULL, NULL, NULL, '{}'::jsonb, ST_SetSRID(ST_MakePoint(3.50, 49.555), 4326))
+            SQL);
+
+        $rows = new AccommodationRepository($this->connection)->findNear(
+            [['lat' => 48.50, 'lon' => 2.50], ['lat' => 49.52, 'lon' => 3.50]],
+            5000,
+            ['apartment'],
+        );
+
+        // A single top-N over the combined multipoint (the flat `LIMIT 200` on a
+        // long trip) would spend the whole budget on the dense cluster and return
+        // nothing for the isolated stage. The cap is per end point: 30 + 3.
+        self::assertCount(33, $rows);
+        self::assertSame(
+            ['Gîte Isolé 1', 'Gîte Isolé 2', 'Gîte Isolé 3'],
+            \array_slice(array_column($rows, 'name'), 30),
+            'the isolated end point keeps its own candidates, nearest first',
+        );
+    }
+
     /**
      * 40 extra apartments, 111 m apart along the meridian, all inside the 5 km
      * radius (41 rows in range with the setUp gîte, for a 30-row cap). Inserted

--- a/api/tests/Unit/Osm/WktGeometryTest.php
+++ b/api/tests/Unit/Osm/WktGeometryTest.php
@@ -47,6 +47,22 @@ final class WktGeometryTest extends TestCase
     }
 
     #[Test]
+    public function multiPointKeepsRepeatedVertices(): void
+    {
+        // Two stages sharing an end point (a rest day) must stay two vertices: the
+        // accommodation repositories budget their per-end-point cap on the ST_Dump
+        // vertex index, so collapsing them would collapse their two budget slots.
+        // Unlike lineStringOrPoint(), which must collapse to keep a valid LINESTRING.
+        self::assertSame(
+            'MULTIPOINT((6.130000 49.600000),(6.130000 49.600000))',
+            WktGeometry::multiPoint([
+                ['lat' => 49.60, 'lon' => 6.13],
+                ['lat' => 49.60, 'lon' => 6.13],
+            ]),
+        );
+    }
+
+    #[Test]
     public function lineStringOrPointRejectsEmptyInput(): void
     {
         $this->expectException(\InvalidArgumentException::class);


### PR DESCRIPTION
Closes #868

## Contexte

Les deux requêtes de lecture des hébergements étaient non déterministes ou non bornées : OSM n'avait ni `ORDER BY` ni `LIMIT` (rapatriement de tout le rayon, `tags` jsonb compris, pour n'en garder que 3 par étape), DataTourisme avait un `LIMIT 200` **sans** `ORDER BY` — l'ensemble retourné pouvait donc changer d'une exécution à l'autre, en contradiction directe avec la promesse d'ADR-040.

## Correction après revue : le premier jet affamait les étapes rurales

La première version bornait avec un `ORDER BY geom <-> :multipoint ... LIMIT count($points) * 30`. La revue a eu raison : c'est un **top-N global** sur le MULTIPOINT combiné, pas un budget par point. Au scan initial complet (`stageIndex = null`), une étape en zone dense pouvait consommer tout le budget et laisser une étape rurale à **zéro candidat** alors que des lignes qualifiantes existaient dans son rayon — une régression par rapport à `main`, où la requête OSM non bornée garantissait à chaque étape ses candidats proches.

Défaut reproduit et quantifié sur une fixture à deux points d'arrivée (un dense, un isolé à 110 km) : **60 lignes renvoyées, dont 0 pour le point isolé.**

```
 total_returned | isolated_point_kept
----------------+---------------------
             60 |                   0
```

### Le LATERAL par point n'a pas été retenu — deux raisons, mesurées

**1. Il coûte N passages sur la table.** Le filtre de rayon n'est pas indexable (`geom::geography`), donc une sous-requête par point rejoue le scan complet une fois par étape. Base DataTourisme réelle (126 k lignes, 7 points d'arrivée), planificateur par défaut :

| forme | plan | temps |
|---|---|---|
| `main` (ni ORDER BY ni LIMIT) | 1 × Parallel Seq Scan | 143 ms |
| global KNN + LIMIT (1er jet) | 1 × Parallel Seq Scan + top-N | 143 ms |
| LATERAL par point | **7 × Seq Scan** (`loops=7`, 125 717 lignes rejetées par boucle) | **1119 ms** |
| **fenêtre par point le plus proche (retenu)** | 1 × Parallel Seq Scan + WindowAgg | **154 ms** |

**2. Le LATERAL ne corrige pas complètement la famine.** Il donne un top-30 par *rayon* de point, mais `GeometryBasedDistributor::distributeByEndpoint` attribue ensuite chaque candidat à son point **le plus proche**. Sur deux étapes à rayons recouvrants — une étape rurale dont les hôtels sont à 12 km, avec le cluster dense de l'étape voisine à 9 km d'elle — son top-30 est rempli par 30 lignes du cluster, ses propres hôtels sont coupés, et le distributeur donne les 30 à l'autre étape. **Zéro à nouveau.**

### Forme retenue : fenêtre partitionnée par point d'arrivée le plus proche

Elle partitionne selon **exactement la partition que le distributeur appliquera**, donc chaque étape est classée sur les lignes qu'elle recevra réellement.

Deux propriétés qui tombent gratuitement :

- **la déduplication disparaît comme problème** — chaque ligne appartient à exactement une partition, donc aucun doublon n'est produit : ni `DISTINCT`, ni dédup en aval. Le départage du point le plus proche est lui-même déterministe (`ORDER BY a.geom <-> pt.geom, pt.path LIMIT 1`) ;
- **le déterminisme est total** — index du point d'arrivée (ordre des étapes, via `ST_Dump(...).path`), puis distance, puis clé primaire.

### SQL final — OSM

```sql
SELECT ranked.*
FROM (
    SELECT a.osm_type, a.osm_id,
           a.name, a.category, a.stars, a.capacity, a.fee, a.website, a.wikidata,
           a.opening_hours, a.description, a.image_url, a.wikipedia_url,
           ST_Y(a.geom) AS lat, ST_X(a.geom) AS lon, a.tags,
           nearest.point_index, nearest.distance,
           ROW_NUMBER() OVER (
               PARTITION BY nearest.point_index
               ORDER BY nearest.distance, a.osm_type, a.osm_id
           ) AS point_rank
    FROM osm.accommodations a
    CROSS JOIN LATERAL (
        SELECT pt.path[1] AS point_index,
               a.geom::geography <-> pt.geom::geography AS distance
        FROM ST_Dump(ST_SetSRID(ST_GeomFromText(:wkt), 4326)) AS pt
        ORDER BY a.geom::geography <-> pt.geom::geography, pt.path
        LIMIT 1
    ) AS nearest
    WHERE a.category IN (:categories)
      AND ST_DWithin(
          a.geom::geography,
          ST_SetSRID(ST_GeomFromText(:wkt), 4326)::geography,
          :radius
      )
) AS ranked
WHERE ranked.point_rank <= :limit
ORDER BY ranked.point_index, ranked.distance, ranked.osm_type, ranked.osm_id
```

DataTourisme est identique, avec le bloc de colonnes `a.id, a.name, a.category, a.capacity, a.price, a.description` et `a.id` comme départage.

`:limit` = `MAX_ROWS_PER_POINT = 30`, **sans** multiplication par `count($points)` : le plafond est désormais réellement par point. `SELECT ranked.*` évite de redupliquer le bloc de colonnes dans le SELECT externe, donc un ajout de colonne pour #869 reste un diff d'une seule ligne.

Le scan reste sur les points d'arrivée, et aucune clause de complétude n'est ajoutée.

## EXPLAIN de la forme finale

**DataTourisme, données réelles (126 k lignes), planificateur par défaut, aucun forçage :**

```
 Subquery Scan on ranked  (cost=674267.01..674267.47 rows=13 width=379) (actual time=148.032..154.496 rows=201.00 loops=1)
   ->  WindowAgg  (cost=674267.01..674267.34 rows=13 width=387) (actual time=148.030..154.479 rows=201.00 loops=1)
         Window: w1 AS (PARTITION BY (pt.path[1]) ORDER BY ((a.geom <-> pt.geom)), a.id ROWS UNBOUNDED PRECEDING)
         Run Condition: (row_number() OVER w1 <= 30)
         Storage: Memory  Maximum Storage: 18kB
         ->  Sort  (cost=674266.98..674267.02 rows=13 width=395) (actual time=148.007..154.298 rows=1745.00 loops=1)
               Sort Key: (pt.path[1]), ((a.geom <-> pt.geom)), a.id
               Sort Method: quicksort  Memory: 691kB
               ->  Nested Loop  (cost=1640.62..674266.74 rows=13 width=395) (actual time=10.574..152.463 rows=1745.00 loops=1)
                     ->  Gather  (cost=1000.00..665938.33 rows=13 width=383) (actual time=10.351..144.009 rows=1745.00 loops=1)
                           Workers Planned: 2  Workers Launched: 2
                           ->  Parallel Seq Scan on accommodations a  (... rows=581.67 loops=3)
                                 Filter: ((category = ANY (...)) AND st_dwithin((geom)::geography, '...'::geography, '15000'::double precision, true))
                                 Rows Removed by Filter: 41407
                     ->  Limit  (cost=640.62..640.63 rows=1 width=44) (actual time=0.004..0.004 rows=1.00 loops=1745)
                           ->  Sort  ... Sort Method: top-N heapsort  Memory: 25kB
                                 ->  Function Scan on st_dump pt  (... rows=7.00 loops=1745)
 Execution Time: 154.866 ms
```

Un seul passage sur la table ; le calcul du point le plus proche coûte 1745 × 4 µs ≈ 7 ms. PostgreSQL applique même un `Run Condition: (row_number() OVER w1 <= 30)`, donc il s'arrête par partition.

**OSM** (table vide en local : 120 k lignes synthétiques semées puis `TRUNCATE`, vérifié à 0 ligne et index recréés ensuite) : même forme, `Parallel Bitmap Heap Scan` via `accommodations_category_idx` + `WindowAgg` avec `Run Condition`, **283 ms**.

### Le critère « le plan montre l'usage de l'index GiST » n'est pas satisfait, et ne l'était pas non plus avant

L'index GiST **n'est plus utilisé pour l'ordre** — mais il ne l'était déjà pas par défaut : sur le premier jet, le planificateur choisissait un `Parallel Seq Scan` + top-N, et l'`Index Scan using accommodations_geom_idx` avec `Order By: (geom <-> ...)` n'apparaissait qu'avec `enable_seqscan = off` (39 ms).

Cause racine inchangée : le cast `geom::geography` du `ST_DWithin` n'a aucun index d'expression, la sélectivité estimée est absurde (`rows=13` contre 1745 réelles) et le seq scan paraît gratuit. Le trait est partagé par **toutes** les lectures Tier-1 (`CulturalPoiRepository`, `FoodPoiRepository`, `EventRepository`) et mérite son propre ticket : index GiST sur `(geom::geography)`, ou préfiltre bbox `&&`. Non traité ici — un bbox mal dimensionné supprime silencieusement des lignes, soit exactement la classe de bug que cette PR corrige.

## Second tour de revue : métrique et points d'arrivée coïncidents

### La métrique d'assignation était en degrés, pas en mètres

`<->` sur `geometry` compare des degrés WGS84 bruts, alors que `GeometryBasedDistributor::distributeByEndpoint` attribue en aval avec une distance Haversine **en mètres**. Divergence mesurée sur une ligne à (lat 60, lon 0), un point d'arrivée décalé en latitude (A), l'autre en longitude (B) :

| | A | B |
|---|---|---|
| `<->` planaire (degrés) | **0.100000** | 0.120000 |
| `geography <-> geography` | 11119.5 m | **6671.7 m** |

Verdicts opposés : la requête pouvait donc partitionner une ligne de bissectrice sous le mauvais point, l'écarter de son top-30, et elle n'atteignait jamais le distributeur pour son vrai point d'arrivée. Cast `geography` appliqué dans le SELECT et l'ORDER BY de la sous-requête d'assignation.

**Alignement vérifié, parce que « des mètres » ne suffit pas :**

```
 geog_knn_m | spheroid_m | sphere_6371_m | spheroid_minus_sphere_m
------------+------------+---------------+-------------------------
 262402.757 | 262853.117 |    262402.757 |                   450.4
```

`geography <->` rend des mètres **sur la sphère**, identiques à `ST_DistanceSphere`, pas sur le sphéroïde (+450 m sur 262 km). `HaversineDistance` est la même grande cercle avec `EARTH_RADIUS_METERS = 6_371_000.0` là où PostGIS utilise 6 371 008,8 m : **écart résiduel de 1,4 ppm**, soit 0,36 m sur 262 km. Facteur multiplicatif constant, donc il ne peut jamais réordonner deux distances (il faudrait qu'elles diffèrent de moins de 1,4 mm à 1 km). C'était bien la sphère qu'il fallait viser — le sphéroïde aurait introduit 0,17 % d'écart contre le Haversine.

Coût : **plan strictement identique**, et trois exécutions de chaque donnent geography 172 / 145 / 165 ms contre planaire 160 / 125 / 152 ms — dans le bruit.

### `array_unique` sur les sommets : retiré, mais behaviouralement neutre

`WktGeometry::multiPoint()` dédupliquait les coordonnées, donc deux étapes au même point d'arrivée (jour de repos, aller-retour) s'effondraient en un sommet. Le dedup est retiré — deux appelants seulement, les deux repositories, tous deux en `fetchAllAssociative`, et aucun test n'assertait ce dedup pour `multiPoint()` (celui de `lineStringOrPoint()` est laissé intact, un LINESTRING mono-sommet étant invalide).

**Mais la conséquence annoncée — « un budget de 30 partagé au lieu de 30 chacune » — ne se produit pas ici, et je le démontre plutôt que de fabriquer un test rouge.** Deux sommets *identiques* sont le même lieu : la distance de chaque ligne aux deux est bit-identique, donc `ORDER BY distance, pt.path LIMIT 1` envoie tout au path 1. Comparaison des deux variantes sur les mêmes fixtures :

```
 deduped | not_deduped        differing_positions      point_index | rows_assigned
---------+-------------      ---------------------    -------------+---------------
      30 |          30                          0               1 |            30
```

Ensembles strictement identiques, ordre compris, partition 2 vide. Le test `findNearHandlesTwoStagesSharingAnEndPoint` est donc versé comme **garde-fou** — il rougit sur les mutations de plafond et de tri — et non comme démonstration de bug : vérifié en remettant `array_unique`, il passe (`OK (1 test, 2 assertions)`).

Le retrait est appliqué quand même : il rend le contrat littéral (un sommet par étape, `point_index` aligné sur l'indice d'étape), il est gratuit, et il protège si le départage évolue.

### Le vrai bug du jour de repos était en aval — corrigé dans #909

`GeometryBasedDistributor::distributeByEndpoint` utilisait un `<` **strict** : pour deux étapes au même point, la première raflait tous les candidats et la seconde recevait **zéro hébergement**, quoi que renvoie cette requête. Fichier du périmètre de #869 : corrigé là-bas, sur décision du mainteneur.

## Fichier hors liste initiale

`api/src/Osm/WktGeometry.php` (retrait du dedup) et `api/tests/Unit/Osm/WktGeometryTest.php` (test **ajouté**, aucune assertion existante modifiée) ne figuraient pas dans les « Fichiers impactés » de l'issue.


## Tests

9 tests d'intégration (fixtures SQL inline, `TRUNCATE` déjà présent dans les `setUp`) : cap aux 30 plus proches sur 41 lignes dans le rayon, égalité stricte de deux exécutions successives avec 3 lignes co-localisées départagées par PK, non-régression rayon/catégorie, **les 2 tests de famine** (deux points séparés de 110 km, densité déséquilibrée, assertion que le point isolé récupère bien ses candidats), **les 2 tests de bissectrice** (métrique) et **le test du jour de repos** (garde-fou).

Les lignes de bourrage sont insérées **de la plus lointaine à la plus proche**, pour que l'ordre physique soit l'inverse de l'ordre attendu (le premier jeu de fixtures, en ordre croissant, passait **sans** `ORDER BY` — corrigé avant de conclure).

### Falsifiabilité

Rouges :

- requêtes remises dans la version revue (`LIMIT` global) → les 2 tests de famine rouges :
  ```
  1) AccommodationIndexReadTest::findNearGivesEveryEndPointItsOwnBudget
  Failed asserting that actual size 60 matches expected size 33.
  2) TourismIndexReadTest::accommodationsGiveEveryEndPointItsOwnBudget
  Failed asserting that actual size 60 matches expected size 33.
  ```
- `MAX_ROWS_PER_POINT = 1000` → 7 rouges (`actual size 84 matches expected size 33`, `43` vs `30`, ordres tronqués, dont le test jour de repos) ;
- `<->` planaire au lieu de `geography` → 2 rouges, les deux tests de bissectrice :
  ```
  1) AccommodationIndexReadTest::findNearAssignsBisectorRowsWithTheSameMetricAsTheDistributor
  a bisector row must be assigned to the end point the distributor will pick (metres), not the planar-degree one
  Failed asserting that an array contains 'Hotel Bissectrice'.
  ```
- `ORDER BY nearest.distance DESC` dans la fenêtre → 5 rouges (dont le test jour de repos).

**Deux mutations qui ne passent PAS au rouge, dites franchement :**

- suppression de l'`ORDER BY` externe : vert, parce que le tri d'entrée du `WindowAgg` produit incidemment le même ordre. Il est conservé comme garantie de contrat (un autre plan pourrait réordonner), pas comme comportement testable ;
- suppression du départage par clé primaire dans la fenêtre : vert, le quicksort de PostgreSQL rend par chance l'ordre attendu sur les lignes co-localisées. C'est précisément pourquoi le départage existe — rendre garanti ce qui n'est aujourd'hui que chanceux.

Toutes les mutations ont été restaurées.

## Vérification

Legs exécutés individuellement (`make qa` ne peut pas aboutir en local, cf. CLAUDE.md) :

- PHP-CS-Fixer : `Fixed 0 of 648 files in 0.643 seconds, 38.00 MB memory used`
- Rector (dry-run) : `[OK] Rector is done!`
- PHPStan niveau 9 : `[OK] No errors`
- PHPUnit `tests/Unit` + `tests/Integration` : `Tests: 1328, Assertions: 3693, Skipped: 1` — 1322 sur `main`, +2 famine, +2 bissectrice, +1 jour de repos, +1 unitaire `WktGeometry` ; le skip est préexistant

Aucun fichier frontend ni Markdown touché. **Playwright : couverture CI uniquement.**

## Auto-critique

- Le plan ne passe plus par l'index GiST du tout. La forme est plus rapide que le LATERAL et équivalente au global (154 ms contre 143 ms, soit +8 % pour la garantie par point), mais elle ne restaure pas l'indexabilité KNN, et le critère d'acceptation 3 de l'issue reste non satisfait tant que la dette de sélectivité du cast `geography` n'est pas traitée.
- `MAX_ROWS_PER_POINT = 30` est un choix argumenté, pas mesuré sur trafic réel.
- L'`EXPLAIN` OSM repose sur des données synthétiques.
- Deux mutations ne rougissent pas (ci-dessus) : le contrat d'ordre est plus fort que ce que les tests peuvent démontrer.

## Recoupements attendus au merge (sprint 45)

- **#869 (PR #909) est empilée sur cette branche.** La signature de `findNear()` est inchangée. Seul point de contact : le docblock de `MAX_ROWS_PER_POINT` (marge 10x → 6x, `MAX_CANDIDATES_PER_STAGE` 3 → 5) — déjà résolu par rebase sur #909.
- `api/tests/Integration/Tourism/TourismIndexReadTest.php` — #865 (PR #906) y touche 4 lignes (catégorie `rental`) : conflit trivial, les deux côtés sont additifs.


<!-- claude-review-start -->
## Claude Review

**Summary:** 0 findings (critical: 0, warning: 0). The bounded/deterministic accommodation reads are correct: independently traced the final SQL (per-nearest-end-point window partition, `geography`-cast metric, PK tie-break) against `GeometryBasedDistributor::distributeByEndpoint` and `ScanAccommodationsHandler`/`OsmAccommodationSource`/`AccommodationSourceRegistry`, and confirmed the per-point budget, tie-break, and metric all line up with what the downstream distributor actually does.

**Resolved threads:** all 5 previously open bot threads (shared-budget starvation on OSM and DataTourisme, planar-vs-geography metric mismatch on both, and the `array_unique` dedup starvation on shared end points) are already resolved — the fixes are present and correct in the current diff. Nothing needed resolving this round.

**PR title check:** `fix(accommodations): deterministic ordering and bounded result sets` reads as a noun phrase, not imperative mood (Conventional Commits requires imperative, e.g. "bound and order accommodation reads deterministically"). Non-blocking — flagged per review policy, not a code defect.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

Commit reviewed: ce74337ec2acf2e06b4ebb62a091adfea2a39536
<!-- claude-review-end -->