### PR TITLE
feat(datatourisme): map rental accommodations and drop the silent category default

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@
 | `camp_site` | `tourism=camp_site` | €8–€25 (€8–€15 if `backpack=yes` or `tents=yes`) |
 | `wilderness_hut` | `tourism=wilderness_hut` | free / donation (€0–€10) |
 | `shelter` | `amenity=shelter` + `shelter_type~basic_hut\|weather_shelter\|lean_to` | free (€0) |
+| `rental` | `tourism=apartment` + DataTourisme meublés (`RentalAccommodation`, `SelfCateringAccommodation`, …) | €40–€100 |
+
+`rental` (gîte / meublé de tourisme) is searchable but **disabled by default**: a large share of that market is let by the week, so it is opt-in per trip.
 
 The bracket above is the *unrated* estimate. A `charge` tag or a numeric `fee` overrides it with an exact price, `fee=no` prices the entry as free, and a known `stars` rating lifts the bracket floor by 25% of its span per star above 2, capped at 75% (a 4-star hotel is estimated €85–€120, not €50–€120).
 

--- a/api/src/ApiResource/TripRequest.php
+++ b/api/src/ApiResource/TripRequest.php
@@ -88,23 +88,36 @@ final class TripRequest
     #[Assert\Range(min: 5, max: 50)]
     public float $averageSpeed = 15.0;
 
-    /** @var list<string> Single source of truth for all supported OSM accommodation types (tourism= and logical types). */
-    public const array ALL_ACCOMMODATION_TYPES = ['camp_site', 'hostel', 'alpine_hut', 'chalet', 'guest_house', 'motel', 'hotel', 'wilderness_hut', 'shelter'];
+    /** @var list<string> Single source of truth for the searchable accommodation vocabulary (OSM tourism= values, logical types and the `rental` meublé bucket). */
+    public const array ALL_ACCOMMODATION_TYPES = ['camp_site', 'hostel', 'alpine_hut', 'chalet', 'guest_house', 'motel', 'hotel', 'wilderness_hut', 'shelter', 'rental'];
 
     /**
-     * Enabled accommodation types for Overpass filtering.
-     * All 9 accommodation types are enabled by default.
+     * Types enabled on a new trip: everything except `rental`.
+     *
+     * `rental` (gîte / meublé de tourisme) is searchable but opt-in — a large
+     * share of the French rental market is let by the week and neither OSM nor
+     * DataTourisme carries a reliable minimum-stay field, so offering it by
+     * default would suggest lodging the rider cannot book for a single night.
+     * Trips created before it existed keep their persisted list untouched.
+     *
+     * @var list<string>
+     */
+    public const array DEFAULT_ACCOMMODATION_TYPES = ['camp_site', 'hostel', 'alpine_hut', 'chalet', 'guest_house', 'motel', 'hotel', 'wilderness_hut', 'shelter'];
+
+    /**
+     * Enabled accommodation types for the reference-index search.
+     * Defaults to {@see DEFAULT_ACCOMMODATION_TYPES} (all types but `rental`).
      * At least one type must remain enabled.
      *
      * @var list<string>
      */
     #[ORM\Column(type: 'text[]')]
-    #[ApiProperty(description: 'Enabled OSM accommodation types for search (default: all 9 types)')]
+    #[ApiProperty(description: 'Enabled accommodation types for search (default: every type except `rental`, which is opt-in)')]
     #[Assert\Count(min: 1, minMessage: 'At least one accommodation type must be enabled.')]
     #[Assert\All([
         new Assert\Choice(choices: self::ALL_ACCOMMODATION_TYPES),
     ])]
-    public array $enabledAccommodationTypes = self::ALL_ACCOMMODATION_TYPES;
+    public array $enabledAccommodationTypes = self::DEFAULT_ACCOMMODATION_TYPES;
 
     // --- Persistence-only fields (not exposed in API input/output) ---
 

--- a/api/src/Engine/PricingHeuristicEngine.php
+++ b/api/src/Engine/PricingHeuristicEngine.php
@@ -14,6 +14,7 @@ final readonly class PricingHeuristicEngine
         'alpine_hut' => ['min' => 25.0, 'max' => 45.0],
         'chalet' => ['min' => 30.0, 'max' => 70.0],
         'guest_house' => ['min' => 40.0, 'max' => 80.0],
+        'rental' => ['min' => 40.0, 'max' => 100.0],
         'motel' => ['min' => 45.0, 'max' => 90.0],
         'hotel' => ['min' => 50.0, 'max' => 120.0],
         'wilderness_hut' => ['min' => 0.0, 'max' => 10.0],

--- a/api/tests/Integration/Tourism/TourismIndexReadTest.php
+++ b/api/tests/Integration/Tourism/TourismIndexReadTest.php
@@ -121,7 +121,7 @@ final class TourismIndexReadTest extends KernelTestCase
         $rows = new AccommodationRepository($this->connection)->findNear(
             [['lat' => 48.50, 'lon' => 2.50]],
             5000,
-            ['apartment'],
+            ['rental'],
         );
 
         // MAX_ROWS_PER_POINT = 30 per end point, and the KNN order means the cap
@@ -152,8 +152,8 @@ final class TourismIndexReadTest extends KernelTestCase
         $repository = new AccommodationRepository($this->connection);
         $points = [['lat' => 48.50, 'lon' => 2.50]];
 
-        $first = $repository->findNear($points, 5000, ['apartment', 'hotel']);
-        $second = $repository->findNear($points, 5000, ['apartment', 'hotel']);
+        $first = $repository->findNear($points, 5000, ['rental', 'hotel']);
+        $second = $repository->findNear($points, 5000, ['rental', 'hotel']);
 
         self::assertSame($first, $second, 'the same scan must return the same rows in the same order (ADR-040)');
         self::assertCount(30, $first);
@@ -171,7 +171,7 @@ final class TourismIndexReadTest extends KernelTestCase
         // closer than anything around the isolated end point below.
         $this->connection->executeStatement(<<<'SQL'
             INSERT INTO tourism.accommodations (id, name, category, capacity, price, description, tags, geom)
-            SELECT 'g' || lpad(i::text, 2, '0'), 'Gîte ' || lpad(i::text, 2, '0'), 'apartment', NULL, NULL, NULL, '{}'::jsonb,
+            SELECT 'g' || lpad(i::text, 2, '0'), 'Gîte ' || lpad(i::text, 2, '0'), 'rental', NULL, NULL, NULL, '{}'::jsonb,
                    ST_SetSRID(ST_MakePoint(2.50, 48.50 + i * 0.0002), 4326)
             FROM generate_series(80, 1, -1) AS i
             SQL);
@@ -180,15 +180,15 @@ final class TourismIndexReadTest extends KernelTestCase
         // 3.9 km out, all inside the radius but all farther than the dense cluster.
         $this->connection->executeStatement(<<<'SQL'
             INSERT INTO tourism.accommodations (id, name, category, capacity, price, description, tags, geom) VALUES
-              ('i1', 'Gîte Isolé 1', 'apartment', NULL, NULL, NULL, '{}'::jsonb, ST_SetSRID(ST_MakePoint(3.50, 49.50), 4326)),
-              ('i2', 'Gîte Isolé 2', 'apartment', NULL, NULL, NULL, '{}'::jsonb, ST_SetSRID(ST_MakePoint(3.50, 49.55), 4326)),
-              ('i3', 'Gîte Isolé 3', 'apartment', NULL, NULL, NULL, '{}'::jsonb, ST_SetSRID(ST_MakePoint(3.50, 49.555), 4326))
+              ('i1', 'Gîte Isolé 1', 'rental', NULL, NULL, NULL, '{}'::jsonb, ST_SetSRID(ST_MakePoint(3.50, 49.50), 4326)),
+              ('i2', 'Gîte Isolé 2', 'rental', NULL, NULL, NULL, '{}'::jsonb, ST_SetSRID(ST_MakePoint(3.50, 49.55), 4326)),
+              ('i3', 'Gîte Isolé 3', 'rental', NULL, NULL, NULL, '{}'::jsonb, ST_SetSRID(ST_MakePoint(3.50, 49.555), 4326))
             SQL);
 
         $rows = new AccommodationRepository($this->connection)->findNear(
             [['lat' => 48.50, 'lon' => 2.50], ['lat' => 49.52, 'lon' => 3.50]],
             5000,
-            ['apartment'],
+            ['rental'],
         );
 
         // A single top-N over the combined multipoint (the flat `LIMIT 200` on a
@@ -214,19 +214,19 @@ final class TourismIndexReadTest extends KernelTestCase
         // dropped — surviving proves it went to B.
         $this->connection->executeStatement(<<<'SQL'
             INSERT INTO tourism.accommodations (id, name, category, capacity, price, description, tags, geom)
-            SELECT 'd' || lpad(i::text, 2, '0'), 'Gîte Dense ' || lpad(i::text, 2, '0'), 'apartment', NULL, NULL, NULL, '{}'::jsonb,
+            SELECT 'd' || lpad(i::text, 2, '0'), 'Gîte Dense ' || lpad(i::text, 2, '0'), 'rental', NULL, NULL, NULL, '{}'::jsonb,
                    ST_SetSRID(ST_MakePoint(0.0, 60.10 + i * 0.00001), 4326)
             FROM generate_series(1, 30) AS i
             SQL);
         $this->connection->executeStatement(<<<'SQL'
             INSERT INTO tourism.accommodations (id, name, category, capacity, price, description, tags, geom) VALUES
-              ('zz', 'Gîte Bissectrice', 'apartment', NULL, NULL, NULL, '{}'::jsonb, ST_SetSRID(ST_MakePoint(0.0, 60.00), 4326))
+              ('zz', 'Gîte Bissectrice', 'rental', NULL, NULL, NULL, '{}'::jsonb, ST_SetSRID(ST_MakePoint(0.0, 60.00), 4326))
             SQL);
 
         $rows = new AccommodationRepository($this->connection)->findNear(
             [['lat' => 60.10, 'lon' => 0.0], ['lat' => 60.00, 'lon' => 0.12]],
             15000,
-            ['apartment'],
+            ['rental'],
         );
 
         self::assertContains(
@@ -238,7 +238,7 @@ final class TourismIndexReadTest extends KernelTestCase
     }
 
     /**
-     * 40 extra apartments, 111 m apart along the meridian, all inside the 5 km
+     * 40 extra rentals, 111 m apart along the meridian, all inside the 5 km
      * radius (41 rows in range with the setUp gîte, for a 30-row cap). Inserted
      * farthest first so the physical row order reverses the expected KNN order.
      */
@@ -246,7 +246,7 @@ final class TourismIndexReadTest extends KernelTestCase
     {
         $this->connection->executeStatement(<<<'SQL'
             INSERT INTO tourism.accommodations (id, name, category, capacity, price, description, tags, geom)
-            SELECT 'g' || lpad(i::text, 2, '0'), 'Gîte ' || lpad(i::text, 2, '0'), 'apartment', NULL, NULL, NULL, '{}'::jsonb,
+            SELECT 'g' || lpad(i::text, 2, '0'), 'Gîte ' || lpad(i::text, 2, '0'), 'rental', NULL, NULL, NULL, '{}'::jsonb,
                    ST_SetSRID(ST_MakePoint(2.50, 48.50 + i * 0.001), 4326)
             FROM generate_series(40, 1, -1) AS i
             SQL);

--- a/api/tests/Integration/Tourism/TourismIndexReadTest.php
+++ b/api/tests/Integration/Tourism/TourismIndexReadTest.php
@@ -52,7 +52,7 @@ final class TourismIndexReadTest extends KernelTestCase
 
         $this->connection->executeStatement(<<<'SQL'
             INSERT INTO tourism.accommodations (id, name, category, capacity, price, description, tags, geom) VALUES
-              ('a1', 'Gîte du Lac', 'apartment', 4, 75.00, NULL, '{}'::jsonb,
+              ('a1', 'Gîte du Lac', 'rental', 4, 75.00, NULL, '{}'::jsonb,
                   ST_SetSRID(ST_MakePoint(2.50, 48.50), 4326)),
               ('a2', 'Grand Hôtel', 'hotel', NULL, NULL, NULL, '{}'::jsonb,
                   ST_SetSRID(ST_MakePoint(2.50, 48.50), 4326))
@@ -104,7 +104,7 @@ final class TourismIndexReadTest extends KernelTestCase
         $accommodations = new AccommodationRepository($this->connection)->findNear(
             [['lat' => 48.50, 'lon' => 2.50]],
             5000,
-            ['apartment'],
+            ['rental'],
         );
 
         self::assertCount(1, $accommodations, 'only the requested category is returned');

--- a/api/tests/Unit/AccommodationSource/DataTourismeAccommodationSourceTest.php
+++ b/api/tests/Unit/AccommodationSource/DataTourismeAccommodationSourceTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\AccommodationSource;
 
 use App\AccommodationSource\DataTourismeAccommodationSource;
 use App\ApiResource\Model\Coordinate;
+use App\ApiResource\TripRequest;
 use App\Engine\PricingHeuristicEngine;
 use App\Tourism\AccommodationRepositoryInterface;
 use PHPUnit\Framework\Attributes\Test;
@@ -18,13 +19,13 @@ final class DataTourismeAccommodationSourceTest extends TestCase
     {
         $repository = $this->createStub(AccommodationRepositoryInterface::class);
         $repository->method('findNear')->willReturn([
-            ['name' => 'Gîte du Lac', 'category' => 'apartment', 'lat' => 48.0, 'lon' => 2.0, 'capacity' => 4, 'price' => 75.0, 'description' => 'Joli gîte'],
+            ['name' => 'Gîte du Lac', 'category' => 'rental', 'lat' => 48.0, 'lon' => 2.0, 'capacity' => 4, 'price' => 75.0, 'description' => 'Joli gîte'],
         ]);
 
         // The heuristic engine is final and cannot be doubled, so we pass a real
         // one; with an exact flux price it is not consulted.
         $result = new DataTourismeAccommodationSource($repository, new PricingHeuristicEngine())
-            ->fetch([new Coordinate(48.0, 2.0)], 5000, ['apartment']);
+            ->fetch([new Coordinate(48.0, 2.0)], 5000, ['rental']);
 
         self::assertCount(1, $result);
         self::assertSame('Gîte du Lac', $result[0]['name']);
@@ -67,12 +68,12 @@ final class DataTourismeAccommodationSourceTest extends TestCase
         $repository = $this->createStub(AccommodationRepositoryInterface::class);
         $repository->method('findNear')->willReturn([
             ['name' => null, 'category' => 'hotel', 'lat' => 48.0, 'lon' => 2.0, 'capacity' => null, 'price' => null, 'description' => null],
-            ['name' => '   ', 'category' => 'apartment', 'lat' => 48.1, 'lon' => 2.1, 'capacity' => null, 'price' => null, 'description' => null],
-            ['name' => 'Gîte du Lac', 'category' => 'apartment', 'lat' => 48.2, 'lon' => 2.2, 'capacity' => 4, 'price' => 75.0, 'description' => null],
+            ['name' => '   ', 'category' => 'rental', 'lat' => 48.1, 'lon' => 2.1, 'capacity' => null, 'price' => null, 'description' => null],
+            ['name' => 'Gîte du Lac', 'category' => 'rental', 'lat' => 48.2, 'lon' => 2.2, 'capacity' => 4, 'price' => 75.0, 'description' => null],
         ]);
 
         $result = new DataTourismeAccommodationSource($repository, new PricingHeuristicEngine())
-            ->fetch([new Coordinate(48.0, 2.0)], 5000, ['hotel', 'apartment']);
+            ->fetch([new Coordinate(48.0, 2.0)], 5000, ['hotel', 'rental']);
 
         self::assertCount(1, $result);
         self::assertSame('Gîte du Lac', $result[0]['name']);
@@ -119,14 +120,39 @@ final class DataTourismeAccommodationSourceTest extends TestCase
     {
         $repository = $this->createStub(AccommodationRepositoryInterface::class);
         $repository->method('findNear')->willReturn([
-            ['name' => 'Gîte du Lac', 'category' => 'apartment', 'lat' => 48.0, 'lon' => 2.0, 'capacity' => 4, 'price' => null, 'description' => null],
+            ['name' => 'Gîte du Lac', 'category' => 'rental', 'lat' => 48.0, 'lon' => 2.0, 'capacity' => 4, 'price' => null, 'description' => null],
         ]);
 
         $result = new DataTourismeAccommodationSource($repository, new PricingHeuristicEngine())
-            ->fetch([new Coordinate(48.0, 2.0)], 5000, ['apartment']);
+            ->fetch([new Coordinate(48.0, 2.0)], 5000, ['rental']);
 
         self::assertSame(4, $result[0]['capacity']);
         self::assertNull($result[0]['stars']);
         self::assertNull($result[0]['fee']);
+    }
+
+    #[Test]
+    public function exposesTheRentalCategoryAsAFilterableType(): void
+    {
+        // `rental` (meublé de tourisme) must belong to the searchable vocabulary,
+        // otherwise the repositories' `category IN (:categories)` filter can never
+        // return the ~80k DataTourisme rentals (issue #865).
+        self::assertContains('rental', TripRequest::ALL_ACCOMMODATION_TYPES);
+
+        $repository = $this->createStub(AccommodationRepositoryInterface::class);
+        $repository->method('findNear')->willReturn([
+            ['name' => 'Gîte des Prés', 'category' => 'rental', 'lat' => 48.0, 'lon' => 2.0, 'capacity' => 4, 'price' => null, 'description' => null],
+        ]);
+
+        $engine = new PricingHeuristicEngine();
+        $expected = $engine->estimatePrice('rental', []);
+
+        $result = new DataTourismeAccommodationSource($repository, $engine)
+            ->fetch([new Coordinate(48.0, 2.0)], 5000, ['rental']);
+
+        self::assertCount(1, $result);
+        self::assertSame('rental', $result[0]['type']);
+        self::assertSame($expected['min'], $result[0]['priceMin']);
+        self::assertSame($expected['max'], $result[0]['priceMax']);
     }
 }

--- a/api/tests/Unit/ApiResource/TripRequestTest.php
+++ b/api/tests/Unit/ApiResource/TripRequestTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\ApiResource;
+
+use App\ApiResource\TripRequest;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class TripRequestTest extends TestCase
+{
+    #[Test]
+    public function rentalIsSearchableButNotEnabledOnANewTrip(): void
+    {
+        // `rental` (gîte / meublé) is part of the searchable vocabulary, so the
+        // repositories' `category IN (:categories)` filter can return it, but it
+        // is opt-in: a large share of that market is let by the week.
+        self::assertContains('rental', TripRequest::ALL_ACCOMMODATION_TYPES);
+        self::assertNotContains('rental', TripRequest::DEFAULT_ACCOMMODATION_TYPES);
+        self::assertNotContains('rental', new TripRequest()->enabledAccommodationTypes);
+    }
+
+    #[Test]
+    public function theDefaultTypesAreASubsetOfTheSearchableVocabulary(): void
+    {
+        self::assertSame([], array_diff(TripRequest::DEFAULT_ACCOMMODATION_TYPES, TripRequest::ALL_ACCOMMODATION_TYPES));
+        self::assertSame(TripRequest::DEFAULT_ACCOMMODATION_TYPES, new TripRequest()->enabledAccommodationTypes);
+    }
+}

--- a/provisioner/osm2pgsql/tier1.lua
+++ b/provisioner/osm2pgsql/tier1.lua
@@ -12,12 +12,17 @@
 local SCHEMA = 'osm_staging'
 local SRID = 4326
 
--- Accommodation tourism values the app supports (TripRequest::ALL_ACCOMMODATION_TYPES);
--- `shelter` is amenity=shelter and handled separately below.
+-- OSM tourism value → app accommodation category (TripRequest::ALL_ACCOMMODATION_TYPES);
+-- `shelter` is amenity=shelter and handled separately below. Categories outside
+-- that vocabulary can never be read back, since the accommodation repositories
+-- filter on `category IN (:categories)`.
 local ACCOMMODATION_TOURISM = {
-    hotel = true, hostel = true, guest_house = true, motel = true,
-    chalet = true, camp_site = true, alpine_hut = true, wilderness_hut = true,
-    apartment = true,
+    hotel = 'hotel', hostel = 'hostel', guest_house = 'guest_house', motel = 'motel',
+    chalet = 'chalet', camp_site = 'camp_site', alpine_hut = 'alpine_hut',
+    wilderness_hut = 'wilderness_hut',
+    -- tourism=apartment is the same product as the DataTourisme rental bucket
+    -- (meublé de tourisme), so both feed the single `rental` category.
+    apartment = 'rental',
 }
 
 -- Resupply / point-of-interest categories (food, shops, services, sights).
@@ -286,7 +291,7 @@ local function poi_category(tags)
 end
 
 local function accommodation_category(tags)
-    if tags.tourism and ACCOMMODATION_TOURISM[tags.tourism] then return tags.tourism end
+    if tags.tourism and ACCOMMODATION_TOURISM[tags.tourism] then return ACCOMMODATION_TOURISM[tags.tourism] end
     if tags.amenity == 'shelter' then return 'shelter' end
     return nil
 end

--- a/provisioner/src/DataTourismeImporter.php
+++ b/provisioner/src/DataTourismeImporter.php
@@ -117,6 +117,17 @@ final readonly class DataTourismeImporter
     }
 
     /**
+     * Accommodation objects dropped during the last {@see run} because their
+     * DataTourisme subtype maps to no app category. Reported by the provisioning
+     * command: a new ontology type shows up as a number instead of being folded
+     * into an unreachable catch-all bucket (issue #865).
+     */
+    public function unmappedAccommodationCount(): int
+    {
+        return $this->mapper->unmappedAccommodationCount();
+    }
+
+    /**
      * @throws ImportFailedException
      */
     public function download(string $zipPath): void

--- a/provisioner/src/DataTourismeMapper.php
+++ b/provisioner/src/DataTourismeMapper.php
@@ -19,7 +19,16 @@ namespace Provisioner;
  */
 final class DataTourismeMapper
 {
-    /** Accommodation subtype (unprefixed ontology type) → app accommodation category. */
+    /**
+     * Accommodation subtype (unprefixed ontology type) → app accommodation
+     * category. Every category MUST exist in TripRequest::ALL_ACCOMMODATION_TYPES:
+     * the accommodation repositories filter on `category IN (:categories)`, so a
+     * category outside that vocabulary can never be read back.
+     *
+     * `AccommodationProduct` is deliberately absent: it is a commercial offer,
+     * not a place. In the flux it only ever co-occurs with a place subtype (which
+     * is what classifies the object), so it never needs a category of its own.
+     */
     private const array ACCOMMODATION_CATEGORY = [
         'Hotel' => 'hotel', 'HotelTrade' => 'hotel', 'HotelRestaurant' => 'hotel',
         'Guesthouse' => 'guest_house', 'TableHoteGuesthouse' => 'guest_house', 'BedAndBreakfast' => 'guest_house',
@@ -28,6 +37,12 @@ final class DataTourismeMapper
         'Chalet' => 'chalet', 'Hut' => 'wilderness_hut', 'TreeHouse' => 'chalet',
         'CollectiveAccommodation' => 'hostel', 'GroupLodging' => 'hostel', 'StopOverOrGroupLodge' => 'hostel',
         'ClubOrHolidayVillage' => 'hostel', 'HolidayResort' => 'hostel',
+        // French "meublé de tourisme": one filterable category for the whole
+        // self-catering rental market, matching OSM's tourism=apartment
+        // (provisioner/osm2pgsql/tier1.lua) so the two sources stay comparable.
+        'RentalAccommodation' => 'rental', 'SelfCateringAccommodation' => 'rental',
+        'House' => 'rental', 'Apartment' => 'rental', 'Bungalow' => 'rental',
+        'Yurt' => 'rental', 'CastleAndPrestigeMansion' => 'rental',
     ];
 
     /** Cultural/natural subtype (unprefixed ontology type) → app cultural-POI category. */
@@ -75,6 +90,18 @@ final class DataTourismeMapper
         'FairOrShow' => 'fair', 'SaleEvent' => 'fair', 'BusinessEvent' => 'fair', 'OpenDay' => 'fair',
         'TheaterEvent' => 'show', 'ShowEvent' => 'show', 'ScreeningEvent' => 'show', 'Cinema' => 'show',
     ];
+
+    private int $unmappedAccommodations = 0;
+
+    /**
+     * Accommodation objects dropped because no subtype of theirs is mapped to an
+     * app category. Surfaced by the provisioning command so the next unknown
+     * ontology type is a visible number instead of a silently polluted bucket.
+     */
+    public function unmappedAccommodationCount(): int
+    {
+        return $this->unmappedAccommodations;
+    }
 
     /**
      * @param array<string, mixed> $object
@@ -132,25 +159,35 @@ final class DataTourismeMapper
     {
         // Events first: an event venue can also carry place types.
         if (\in_array('EntertainmentAndEvent', $types, true)) {
-            return ['event', $this->resolve($types, self::EVENT_CATEGORY, 'event')];
+            return ['event', $this->resolve($types, self::EVENT_CATEGORY) ?? 'event'];
         }
 
         // Accommodation before food: a HotelRestaurant is primarily lodging.
         if (\in_array('Accommodation', $types, true)) {
-            return ['accommodation', $this->resolve($types, self::ACCOMMODATION_CATEGORY, 'apartment')];
+            // No default here: a fallback category outside the app vocabulary
+            // makes the row permanently unreadable (issue #865). An unmapped
+            // subtype is dropped and counted instead.
+            $category = $this->resolve($types, self::ACCOMMODATION_CATEGORY);
+            if (null === $category) {
+                ++$this->unmappedAccommodations;
+
+                return [null, ''];
+            }
+
+            return ['accommodation', $category];
         }
 
         if (\in_array('CulturalSite', $types, true) || \in_array('NaturalHeritage', $types, true)) {
-            return ['cultural', $this->resolve($types, self::CULTURAL_CATEGORY, 'attraction')];
+            return ['cultural', $this->resolve($types, self::CULTURAL_CATEGORY) ?? 'attraction'];
         }
 
         // Eateries (any FoodEstablishment) and food shops (Store with a food subtype).
         if (\in_array('FoodEstablishment', $types, true)) {
-            return ['food', $this->resolve($types, self::FOOD_CATEGORY, 'restaurant')];
+            return ['food', $this->resolve($types, self::FOOD_CATEGORY) ?? 'restaurant'];
         }
 
         if (\in_array('Store', $types, true) && [] !== array_intersect(self::FOOD_STORE_TYPES, $types)) {
-            return ['food', $this->resolve($types, self::FOOD_CATEGORY, 'general')];
+            return ['food', $this->resolve($types, self::FOOD_CATEGORY) ?? 'general'];
         }
 
         return [null, ''];
@@ -160,7 +197,7 @@ final class DataTourismeMapper
      * @param list<string>          $types
      * @param array<string, string> $map
      */
-    private function resolve(array $types, array $map, string $default): string
+    private function resolve(array $types, array $map): ?string
     {
         foreach ($types as $type) {
             if (isset($map[$type])) {
@@ -168,7 +205,7 @@ final class DataTourismeMapper
             }
         }
 
-        return $default;
+        return null;
     }
 
     /**

--- a/provisioner/src/ProvisionCommand.php
+++ b/provisioner/src/ProvisionCommand.php
@@ -225,7 +225,9 @@ final class ProvisionCommand extends Command
             return Command::FAILURE;
         }
 
-        $io->success('DataTourisme import complete.');
+        $unmapped = $importer->unmappedAccommodationCount();
+        $io->success(\sprintf('DataTourisme import complete (%d accommodations skipped: unmapped subtype).', $unmapped));
+        $this->logLine('INFO', \sprintf('datatourisme accommodations skipped (unmapped subtype) -> %d', $unmapped));
 
         return Command::SUCCESS;
     }

--- a/provisioner/tests/DataTourismeImporterTest.php
+++ b/provisioner/tests/DataTourismeImporterTest.php
@@ -242,6 +242,46 @@ final class DataTourismeImporterTest extends TestCase
     }
 
     #[Test]
+    public function importsRentalsAndPublishesTheUnmappedAccommodationCount(): void
+    {
+        // A meublé lands in the `rental` category; an Accommodation whose subtype
+        // maps to nothing is dropped rather than folded into a bucket the app
+        // cannot query back, and counted so it stays visible (issue #865).
+        $zipPath = $this->workDir.'/accommodations.zip';
+        $zip = new \ZipArchive();
+        $zip->open($zipPath, \ZipArchive::CREATE | \ZipArchive::OVERWRITE);
+        $zip->addFromString('objects/0/00/rental.json', (string) json_encode([
+            '@id' => 'https://data.datatourisme.fr/10/rental',
+            '@type' => ['schema:Accommodation', 'Accommodation', 'RentalAccommodation', 'SelfCateringAccommodation'],
+            'rdfs:label' => ['fr' => ['Gite du Lac']],
+            'isLocatedAt' => [['schema:geo' => ['schema:latitude' => '48.5', 'schema:longitude' => '2.3']]],
+        ]));
+        $zip->addFromString('objects/0/00/unmapped.json', (string) json_encode([
+            '@id' => 'https://data.datatourisme.fr/10/unmapped',
+            '@type' => ['schema:Accommodation', 'Accommodation', 'PlaceOfInterest'],
+            'rdfs:label' => ['fr' => ['Hebergement sans sous-type']],
+            'isLocatedAt' => [['schema:geo' => ['schema:latitude' => '48.6', 'schema:longitude' => '2.4']]],
+        ]));
+        $zip->close();
+
+        $bytes = (string) file_get_contents($zipPath);
+        unlink($zipPath);
+
+        $importer = new DataTourismeImporter(
+            fluxUrl: 'https://example.test/flux',
+            httpClient: new MockHttpClient(new MockResponse($bytes)),
+            processFactory: $this->capturingFactory(),
+        );
+        $importer->run($this->workDir);
+
+        $accommodations = (string) file_get_contents($this->workDir.'/tourism-accommodations.copy');
+        self::assertSame(1, substr_count($accommodations, "\n"), 'only the rental row is written');
+        self::assertStringContainsString('rental', $accommodations);
+        self::assertStringNotContainsString('unmapped', $accommodations);
+        self::assertSame(1, $importer->unmappedAccommodationCount());
+    }
+
+    #[Test]
     public function enrichesWikidataBearingRowsFromTheCacheBetweenLoadAndSwap(): void
     {
         // A cultural POI carrying a Wikidata Q-ID (owl:sameAs) triggers the

--- a/provisioner/tests/DataTourismeMapperTest.php
+++ b/provisioner/tests/DataTourismeMapperTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Provisioner\Tests;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Provisioner\DataTourismeMapper;
@@ -66,7 +67,7 @@ final class DataTourismeMapperTest extends TestCase
 
         self::assertNotNull($row);
         self::assertSame('accommodation', $row['head']);
-        self::assertSame('apartment', $row['category']);
+        self::assertSame('rental', $row['category']);
         self::assertSame(4, $row['capacity']);
         self::assertSame(75.0, $row['price']);
     }
@@ -81,6 +82,66 @@ final class DataTourismeMapperTest extends TestCase
         $camping = $this->mapper->map($this->object(['Accommodation', 'CampingAndCaravanning']));
         self::assertNotNull($camping);
         self::assertSame('camp_site', $camping['category']);
+    }
+
+    /**
+     * The whole French "meublé de tourisme" market collapses onto the single
+     * `rental` category, so it stays comparable with OSM's tourism=apartment.
+     */
+    #[Test]
+    #[DataProvider('rentalSubtypes')]
+    public function mapsEveryRentalSubtypeToTheSingleRentalCategory(string $subtype): void
+    {
+        $row = $this->mapper->map($this->object(['Accommodation', $subtype]));
+
+        self::assertNotNull($row);
+        self::assertSame('accommodation', $row['head']);
+        self::assertSame('rental', $row['category']);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function rentalSubtypes(): iterable
+    {
+        yield 'RentalAccommodation' => ['RentalAccommodation'];
+        yield 'SelfCateringAccommodation' => ['SelfCateringAccommodation'];
+        yield 'House' => ['House'];
+        yield 'Apartment' => ['Apartment'];
+        yield 'Bungalow' => ['Bungalow'];
+        yield 'Yurt' => ['Yurt'];
+        yield 'CastleAndPrestigeMansion' => ['CastleAndPrestigeMansion'];
+    }
+
+    #[Test]
+    public function discardsAccommodationProductWhichIsAnOfferNotAPlace(): void
+    {
+        // AccommodationProduct is a commercial offer; on its own it describes no
+        // place, so it must not be mapped nor imported.
+        self::assertNull($this->mapper->map($this->object(['schema:Accommodation', 'Accommodation', 'AccommodationProduct'])));
+
+        // In the flux it always co-occurs with a place subtype, which is what
+        // classifies the object: those rows are still imported as rentals.
+        $row = $this->mapper->map($this->object(['Accommodation', 'AccommodationProduct', 'RentalAccommodation']));
+        self::assertNotNull($row);
+        self::assertSame('rental', $row['category']);
+    }
+
+    #[Test]
+    public function discardsAndCountsAccommodationsWithAnUnmappedSubtype(): void
+    {
+        self::assertSame(0, $this->mapper->unmappedAccommodationCount());
+
+        // No silent default: an unknown subtype must not land in a bucket outside
+        // TripRequest::ALL_ACCOMMODATION_TYPES, which would be unreachable.
+        self::assertNull($this->mapper->map($this->object(['schema:Accommodation', 'Accommodation', 'PlaceOfInterest'])));
+        self::assertNull($this->mapper->map($this->object(['Accommodation', 'SomeBrandNewOntologyType'])));
+
+        self::assertSame(2, $this->mapper->unmappedAccommodationCount());
+
+        // Mapped accommodations do not inflate the counter.
+        self::assertNotNull($this->mapper->map($this->object(['Accommodation', 'Hotel'])));
+        self::assertSame(2, $this->mapper->unmappedAccommodationCount());
     }
 
     #[Test]

--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -126,6 +126,7 @@
     "type_alpine_hut": "Alpine hut",
     "type_wilderness_hut": "Wilderness hut",
     "type_shelter": "Shelter",
+    "type_rental": "Holiday rental",
     "type_other": "Other",
     "hotel": "Hotel",
     "gite": "Gite",

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -126,6 +126,7 @@
     "type_alpine_hut": "Refuge",
     "type_wilderness_hut": "Bivouac",
     "type_shelter": "Abri",
+    "type_rental": "Meublé / location",
     "type_other": "Autre",
     "hotel": "Hôtel",
     "gite": "Gîte",

--- a/pwa/src/components/accommodation-item.tsx
+++ b/pwa/src/components/accommodation-item.tsx
@@ -31,6 +31,7 @@ const typeIcons: Record<string, React.ElementType> = {
   motel: Hotel,
   camp_site: Tent,
   alpine_hut: MapPin,
+  rental: Home,
 };
 
 const typeLabelKeys = {
@@ -41,6 +42,7 @@ const typeLabelKeys = {
   guest_house: "type_guest_house",
   motel: "type_motel",
   alpine_hut: "type_alpine_hut",
+  rental: "type_rental",
   other: "type_other",
 } as const;
 
@@ -178,6 +180,7 @@ export function AccommodationItem({
             <option value="guest_house">{t("type_guest_house")}</option>
             <option value="motel">{t("type_motel")}</option>
             <option value="alpine_hut">{t("type_alpine_hut")}</option>
+            <option value="rental">{t("type_rental")}</option>
             <option value="other">{t("type_other")}</option>
           </select>
           <div className="flex items-center gap-1">

--- a/pwa/src/lib/accommodation-types.ts
+++ b/pwa/src/lib/accommodation-types.ts
@@ -14,13 +14,14 @@ export const ACCOMMODATION_TYPES = [
   "alpine_hut",
   "wilderness_hut",
   "shelter",
+  "rental",
   "other",
 ] as const;
 
 export type AccommodationType = (typeof ACCOMMODATION_TYPES)[number];
 
 /**
- * The 9 accommodation types that can be used for backend Overpass filtering.
+ * The accommodation types that can be used for backend filtering.
  * "other" is excluded as it is reserved for manually-added accommodations.
  */
 export const FILTERABLE_ACCOMMODATION_TYPES = [
@@ -33,7 +34,25 @@ export const FILTERABLE_ACCOMMODATION_TYPES = [
   "alpine_hut",
   "wilderness_hut",
   "shelter",
+  "rental",
 ] as const satisfies ReadonlyArray<AccommodationType>;
 
 export type FilterableAccommodationType =
   (typeof FILTERABLE_ACCOMMODATION_TYPES)[number];
+
+/**
+ * Types enabled on a new trip. Mirrors TripRequest::DEFAULT_ACCOMMODATION_TYPES:
+ * "rental" (gîte / meublé) is filterable but opt-in, because a large share of
+ * that market is let by the week and cannot be booked for a single night.
+ */
+export const DEFAULT_ACCOMMODATION_TYPES = [
+  "hotel",
+  "hostel",
+  "camp_site",
+  "chalet",
+  "guest_house",
+  "motel",
+  "alpine_hut",
+  "wilderness_hut",
+  "shelter",
+] as const satisfies ReadonlyArray<FilterableAccommodationType>;

--- a/pwa/src/lib/api/schema.d.ts
+++ b/pwa/src/lib/api/schema.d.ts
@@ -1537,7 +1537,7 @@ export interface components {
              */
             averageSpeed: number;
             /**
-             * @description Enabled OSM accommodation types for search (default: all 9 types)
+             * @description Enabled accommodation types for search (default: every type except `rental`, which is opt-in)
              * @default [
              *       "camp_site",
              *       "hostel",
@@ -1583,7 +1583,7 @@ export interface components {
              */
             averageSpeed: number;
             /**
-             * @description Enabled OSM accommodation types for search (default: all 9 types)
+             * @description Enabled accommodation types for search (default: every type except `rental`, which is opt-in)
              * @default [
              *       "camp_site",
              *       "hostel",

--- a/pwa/src/store/trip-store.test.ts
+++ b/pwa/src/store/trip-store.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { getUndoableSlice, useTripStore } from "./trip-store";
+import {
+  DEFAULT_ACCOMMODATION_TYPES,
+  FILTERABLE_ACCOMMODATION_TYPES,
+} from "@/lib/accommodation-types";
 import type {
   AccommodationData,
   AlertData,
@@ -592,5 +596,26 @@ describe("date window stays in sync with stage count (recette #649)", () => {
     store.applyStageUpdate(2, newDay);
     // 3 stages → 3 days: 10–12 July.
     expect(useTripStore.getState().endDate).toBe("2026-07-12");
+  });
+});
+
+describe("default enabled accommodation types", () => {
+  it("mirrors DEFAULT_ACCOMMODATION_TYPES on a fresh store", () => {
+    useTripStore.getState().clearTrip();
+    expect(useTripStore.getState().enabledAccommodationTypes).toEqual([
+      ...DEFAULT_ACCOMMODATION_TYPES,
+    ]);
+  });
+
+  // Value-level contract: TS strict mode cannot catch a drift here, both
+  // arrays being structurally compatible AccommodationType[]. The backend
+  // pins the same contract in TripRequestTest.
+  it("leaves rental opt-in and keeps every other filterable type", () => {
+    useTripStore.getState().clearTrip();
+    const enabled = useTripStore.getState().enabledAccommodationTypes;
+    expect(enabled).not.toContain("rental");
+    expect(enabled).toEqual(
+      FILTERABLE_ACCOMMODATION_TYPES.filter((type) => type !== "rental"),
+    );
   });
 });

--- a/pwa/src/store/trip-store.ts
+++ b/pwa/src/store/trip-store.ts
@@ -33,7 +33,7 @@ export interface Modification {
   label: string;
 }
 import type { AccommodationType } from "@/lib/accommodation-types";
-import { FILTERABLE_ACCOMMODATION_TYPES } from "@/lib/accommodation-types";
+import { DEFAULT_ACCOMMODATION_TYPES } from "@/lib/accommodation-types";
 import { createTemporalStore } from "@/store/temporal-middleware";
 
 // Required for Immer to allow mutating Set/Map drafts (used by recomputingStages).
@@ -286,7 +286,7 @@ const initialState = {
   ebikeMode: false,
   departureHour: 8,
   enabledAccommodationTypes: [
-    ...FILTERABLE_ACCOMMODATION_TYPES,
+    ...DEFAULT_ACCOMMODATION_TYPES,
   ] as AccommodationType[],
   stages: [],
   computationStatus: {},

--- a/pwa/tests/recette/features/configuration.en.feature
+++ b/pwa/tests/recette/features/configuration.en.feature
@@ -32,7 +32,7 @@ Feature: Configuration and settings
   @desktop @critical
   Scenario: Accommodation type filter switches visible
     When I open the settings panel
-    Then I see switches for types "Hôtel, Auberge, Camping, Gîte, Chambre d'hôte, Motel, Refuge, Bivouac, Abri, Meublé / location"
+    Then I see switches for types "Hotel, Hostel, Campsite, Chalet, Guest house, Motel, Alpine hut, Wilderness hut, Shelter, Holiday rental"
 
   @desktop @critical
   Scenario: Last enabled accommodation type cannot be disabled

--- a/pwa/tests/recette/features/configuration.en.feature
+++ b/pwa/tests/recette/features/configuration.en.feature
@@ -32,7 +32,7 @@ Feature: Configuration and settings
   @desktop @critical
   Scenario: Accommodation type filter switches visible
     When I open the settings panel
-    Then I see switches for types "Hôtel, Auberge, Camping, Gîte, Chambre d'hôte, Motel, Refuge, Bivouac, Abri"
+    Then I see switches for types "Hôtel, Auberge, Camping, Gîte, Chambre d'hôte, Motel, Refuge, Bivouac, Abri, Meublé / location"
 
   @desktop @critical
   Scenario: Last enabled accommodation type cannot be disabled

--- a/pwa/tests/recette/features/configuration.fr.feature
+++ b/pwa/tests/recette/features/configuration.fr.feature
@@ -33,7 +33,7 @@ Fonctionnalité: Configuration et paramètres
   @desktop @critique
   Scénario: Filtrage des types d'hébergement
     Quand j'ouvre le panneau de paramètres
-    Alors je vois les interrupteurs pour les types "Hôtel, Auberge, Camping, Gîte, Chambre d'hôte, Motel, Refuge, Bivouac, Abri"
+    Alors je vois les interrupteurs pour les types "Hôtel, Auberge, Camping, Gîte, Chambre d'hôte, Motel, Refuge, Bivouac, Abri, Meublé / location"
 
   @desktop @critique
   Scénario: Le dernier type d'hébergement activé ne peut pas être désactivé

--- a/pwa/tests/recette/steps/configuration.steps.ts
+++ b/pwa/tests/recette/steps/configuration.steps.ts
@@ -79,17 +79,42 @@ When(
   },
 );
 
+/**
+ * Assert the accommodation section shows exactly the switches named in the
+ * Gherkin list. The count used to be hardcoded, so adding a type to the
+ * contract broke this scenario without saying which label was missing; the
+ * feature file is now the single source of truth for both count and labels.
+ */
+async function expectAccommodationSwitches(
+  page: import("@playwright/test").Page,
+  typesStr: string,
+) {
+  const labels = typesStr
+    .split(",")
+    .map((label) => label.trim())
+    .filter((label) => label.length > 0);
+
+  const section = page
+    .getByRole("heading", { name: ACCOMMODATION_SECTION_HEADING })
+    .locator("xpath=ancestor::section[1]");
+
+  await expect(getAccommodationSwitches(page)).toHaveCount(labels.length);
+  for (const label of labels) {
+    await expect(section.getByText(label, { exact: true })).toBeVisible();
+  }
+}
+
 Then(
   "je vois les interrupteurs pour les types {string}",
-  async ({ mockedPage }, _typesStr: string) => {
-    await expect(getAccommodationSwitches(mockedPage)).toHaveCount(9);
+  async ({ mockedPage }, typesStr: string) => {
+    await expectAccommodationSwitches(mockedPage, typesStr);
   },
 );
 
 Then(
   "I see switches for types {string}",
-  async ({ mockedPage }, _typesStr: string) => {
-    await expect(getAccommodationSwitches(mockedPage)).toHaveCount(9);
+  async ({ mockedPage }, typesStr: string) => {
+    await expectAccommodationSwitches(mockedPage, typesStr);
   },
 );
 


### PR DESCRIPTION
Closes #865

## Contexte

66,4 % des hébergements DataTourisme importés (82 523 sur 124 240) étaient définitivement inatteignables : `DataTourismeMapper::classify()` les rabattait sur `apartment`, valeur absente de `TripRequest::ALL_ACCOMMODATION_TYPES`, alors que les deux `AccommodationRepository` filtrent `WHERE category IN (:categories)`.

## Changements

- **`provisioner/src/DataTourismeMapper.php`** — 7 sous-types du meublé français (`RentalAccommodation`, `SelfCateringAccommodation`, `House`, `Apartment`, `Bungalow`, `Yurt`, `CastleAndPrestigeMansion`) → un seul type `rental`. `resolve()` renvoie désormais `null` (plus de paramètre `$default`) ; la branche accommodation n'a **plus de défaut du tout** : sous-type inconnu → ligne écartée **et comptée**. Les autres têtes (event / cultural / food) conservent leur défaut via `?? '…'`, sinon le comportement documenté « bare `FoodEstablishment` defaults to restaurant » régressait.
- **`AccommodationProduct`** — volontairement absent de la map, avec commentaire explicite : c'est une offre commerciale, pas un lieu.
- **`provisioner/osm2pgsql/tier1.lua`** — `ACCOMMODATION_TOURISM` passe de set à map valeur→catégorie, `apartment = 'rental'` : le `tourism=apartment` d'OSM rejoint le même type, deux catégories quasi identiques auraient été un nouveau défaut de qualité.
- **Décompte publié** — `DataTourismeImporter::unmappedAccommodationCount()` délègue au mapper, `ProvisionCommand` l'affiche dans le message de succès et le journalise. Le prochain type d'ontologie inconnu devient un nombre visible au lieu de polluer un seau.
- **Désactivé par défaut** — nouvelle constante `DEFAULT_ACCOMMODATION_TYPES` (sans `rental`), qui devient la valeur par défaut de `$enabledAccommodationTypes`. Les voyages existants portent leur liste persistée, donc aucun changement pour eux et aucune migration.
- **Propagation** — `PricingHeuristicEngine` (barème `rental` 40-100 €, sinon il retombait silencieusement sur celui de l'hôtel), `accommodation-types.ts`, `trip-store.ts`, `accommodation-item.tsx` (entrée `rental` + une `<option>`), `fr.json` « Meublé / location », `en.json` « Holiday rental », ligne README + note opt-in.

## DTO_CHANGED — pas de typegen nécessaire

`TripRequest` change, mais le schéma OpenAPI reste `string[]` : le `Assert\Choice` ne génère pas d'enum. `pwa/src/lib/api/schema.d.ts` est inchangé et `tsc` est vert. Le job « OpenAPI → TS drift » de la CI le confirmera.

## Point à valider

**`AccommodationProduct` n'apparaît jamais seul dans le flux réel.** Sur les 82 523 lignes du seau `apartment`, les 13 273 qui portent ce type portent *toutes* aussi un sous-type de lieu. Une exclusion dure (écarter dès que le type est présent) aurait fait tomber `rental` à 69 046, incompatible avec le critère d'acceptation « de l'ordre de 80 000 ». J'ai retenu la lecture littérale de l'issue — « ni mappé », donc pas de catégorie propre — ce qui donne 82 319 et satisfait le critère. À confirmer, c'est une interprétation.

## Vérification sur les données réelles

Simulation du nouveau mappage sur `.docker/osm/data/datatourisme/tourism-accommodations.copy` (124 240 lignes) :

```
   82319 rental
   13177 hotel
   12637 guest_house
    9844 camp_site
    5832 hostel
     204 SKIPPED (unmapped subtype)
     143 chalet
      84 wilderness_hut
```

Plus de seau `apartment`. Les 204 écartés portent tous exactement `["schema:Accommodation","schema:LodgingBusiness","Accommodation","PlaceOfInterest","PointOfInterest"]`, c'est-à-dire aucun sous-type.

## Preuve que les nouveaux tests peuvent échouer

1. **Défaut silencieux restauré** (`?? 'apartment'`) → 3 échecs :
   ```
   1) DataTourismeImporterTest::importsRentalsAndPublishesTheUnmappedAccommodationCount
   only the rental row is written / Failed asserting that 2 is identical to 1.
   2) DataTourismeMapperTest::discardsAccommodationProductWhichIsAnOfferNotAPlace
   Failed asserting that an array is null.
   3) DataTourismeMapperTest::discardsAndCountsAccommodationsWithAnUnmappedSubtype
   Failed asserting that an array is null.
   Tests: 80, Assertions: 475, Failures: 3.
   ```
2. **`'Yurt' => 'rental'` retiré** → `mapsEveryRentalSubtypeToTheSingleRentalCategory@Yurt / Failed asserting that null is not null.`
3. **`rental` ajouté à `DEFAULT_ACCOMMODATION_TYPES`** → `TripRequestTest::rentalIsSearchableButNotEnabledOnANewTrip / Failed asserting that an array does not contain 'rental'.`
4. **`rental` retiré de `ALL_ACCOMMODATION_TYPES`** → `TripRequestTest::rentalIsSearchableButNotEnabledOnANewTrip` et `DataTourismeAccommodationSourceTest::exposesTheRentalCategoryAsAFilterableType`, tous deux `Failed asserting that an array contains 'rental'.`

Les 4 mutations ont été restaurées avant le commit, diff final relu.

## Legs QA (sorties réelles, individuels)

`make qa` n'a pas été lancé (cap 768M sur le service `php`, volume node_modules vide en worktree — cf. CLAUDE.md).

```
php-cs-fixer api          -> Fixed 0 of 649 files in 2.475 seconds, 264.00 MB memory used
php-cs-fixer provisioner  -> Fixed 0 of 21 files in 0.590 seconds, 70.00 MB memory used
rector api (dry-run)      -> [OK] Rector is done!            (611 fichiers)
rector provisioner        -> [OK] Rector is done!            (22 fichiers)
phpstan api (niveau 9)    -> [OK] No errors
phpstan provisioner       -> [OK] No errors
tsc --noEmit              -> aucune sortie, exit 0
eslint (3 fichiers)       -> 1 problem (0 errors, 1 warning), exit 0
                             warning préexistant hors diff : accommodation-item.tsx:305 @next/next/no-img-element
prettier --check          -> All matched files use Prettier code style!
npm run i18n:check        -> i18n-check OK: 918 keys in sync across fr, en
markdownlint README.md    -> Summary: 0 error(s)
```

Tests :

```
provisioner phpunit                    -> OK (80 tests, 484 assertions)
api tests/Unit + tests/Integration     -> OK, but some tests were skipped!
                                          Tests: 1321, Assertions: 3684, Skipped: 1
api tests/Functional                   -> OK (302 tests, 1066 assertions)
pwa vitest                             -> 35 files passed, 320 tests passed
```

**Playwright : couverture CI uniquement.** Vérifié par lecture que `pwa/tests/mocked/config-panel.spec.ts` reste vert par construction (les mocks n'activent que 7 types, le nouvel interrupteur s'affiche décoché) et qu'aucune baseline visuelle ne capture le panneau de configuration.

## Auto-critique

- Le nouveau type est **un seul** `rental` couvrant du studio au château, choix de l'issue : la granularité perdue (yourte, bungalow) n'est plus filtrable.
- La réserve produit reste entière : une part importante de `RentalAccommodation` se loue à la semaine et DataTourisme ne porte pas de durée minimale fiable. Le type est décoché par défaut pour cette raison ; l'audit du champ est le sujet du sprint 47 (#879).
- Les 204 lignes écartées sont un décompte de simulation, pas un ré-import réel : le critère « plus de bucket `apartment` en base » ne sera constaté qu'après provisionnement.
- Interprétation d'`AccommodationProduct` à valider, cf. plus haut.

## Recoupements attendus au merge (sprint 45)

- **#866 est empilée sur cette branche** (elle refond `typeLabelKeys` / `typeIcons` pour les dériver du contrat). À merger après celle-ci.
- `pwa/src/components/accommodation-item.tsx` — #867 (PR #904) modifie le bloc de rendu de l'URL et le lien Wikipédia, intacts ici.
- `pwa/messages/{fr,en}.json` — ajouts de clés disjoints avec #867.
- `api/tests/Integration/Tourism/TourismIndexReadTest.php` — #868 (PR #905) y ajoute deux tests ; les deux côtés sont additifs, conflit trivial attendu.
- `api/tests/Unit/AccommodationSource/DataTourismeAccommodationSourceTest.php` — #869 y ajoute des cas en fin de classe.



<!-- claude-review-start -->
## Claude Review

**Summary:** 0 findings (0 critical, 0 warning, 0 nitpick suppressed by policy). The `rental` category is threaded consistently end-to-end: `TripRequest` vocabulary/default, `DataTourismeMapper` (silent-default removal, unmapped counter), `tier1.lua` OSM mapping, `PricingHeuristicEngine`, and the full frontend contract (types, store default, UI, i18n, BDD steps), with matching test coverage on both sides (including a fresh `TripRequestTest.php` and a value-level frontend test guarding drift). No leftover `apartment` references, no orphaned imports, no debug statements.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

**Commit reviewed:** `d22a9c3c68b64d47663920ccc590140f5fb8bdc6`
<!-- claude-review-end -->