### PR TITLE
fix(trips): stop dropping accommodation enrichment on persist

### DIFF
--- a/api/src/Repository/DoctrineTripRequestRepository.php
+++ b/api/src/Repository/DoctrineTripRequestRepository.php
@@ -806,7 +806,7 @@ final class DoctrineTripRequestRepository extends ServiceEntityRepository implem
         );
     }
 
-    /** @return array{name: string, type: string, lat: float, lon: float, estimatedPriceMin: float, estimatedPriceMax: float, isExactPrice: bool, url: ?string, possibleClosed: bool, distanceToEndPoint: float} */
+    /** @return array{name: string, type: string, lat: float, lon: float, estimatedPriceMin: float, estimatedPriceMax: float, isExactPrice: bool, url: ?string, possibleClosed: bool, distanceToEndPoint: float, source: string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, openingHours: ?string} */
     private function accommodationToArray(Accommodation $acc): array
     {
         return [
@@ -820,10 +820,18 @@ final class DoctrineTripRequestRepository extends ServiceEntityRepository implem
             'url' => $acc->url,
             'possibleClosed' => $acc->possibleClosed,
             'distanceToEndPoint' => $acc->distanceToEndPoint,
+            // Provisioning-time enrichment (Wikidata, ADR-041) and the source
+            // attribution badge: dropped before issue #870, which degraded every
+            // reload and the anonymous shared view.
+            'source' => $acc->source,
+            'description' => $acc->description,
+            'imageUrl' => $acc->imageUrl,
+            'wikipediaUrl' => $acc->wikipediaUrl,
+            'openingHours' => $acc->openingHours,
         ];
     }
 
-    /** @param array{name: string, type: string, lat: float, lon: float, estimatedPriceMin: float, estimatedPriceMax: float, isExactPrice: bool, url?: ?string, possibleClosed?: bool, distanceToEndPoint?: float} $data */
+    /** @param array{name: string, type: string, lat: float, lon: float, estimatedPriceMin: float, estimatedPriceMax: float, isExactPrice: bool, url?: ?string, possibleClosed?: bool, distanceToEndPoint?: float, source?: ?string, description?: ?string, imageUrl?: ?string, wikipediaUrl?: ?string, openingHours?: ?string} $data */
     private function arrayToAccommodation(array $data): Accommodation
     {
         return new Accommodation(
@@ -837,6 +845,13 @@ final class DoctrineTripRequestRepository extends ServiceEntityRepository implem
             url: $data['url'] ?? null,
             possibleClosed: $data['possibleClosed'] ?? false,
             distanceToEndPoint: $data['distanceToEndPoint'] ?? 0.0,
+            // Accommodations persisted before issue #870 carry none of the five
+            // enrichment keys: fall back on the constructor defaults.
+            source: $data['source'] ?? 'osm',
+            description: $data['description'] ?? null,
+            imageUrl: $data['imageUrl'] ?? null,
+            wikipediaUrl: $data['wikipediaUrl'] ?? null,
+            openingHours: $data['openingHours'] ?? null,
         );
     }
 

--- a/api/src/State/TripDetailProvider.php
+++ b/api/src/State/TripDetailProvider.php
@@ -262,6 +262,13 @@ final readonly class TripDetailProvider implements ProviderInterface
             'url' => $acc->url,
             'possibleClosed' => $acc->possibleClosed,
             'distanceToEndPoint' => $acc->distanceToEndPoint,
+            // Same five enrichment fields as StagePayloadMapper (issue #870), so a
+            // reload and the anonymous shared view are as detailed as the live SSE.
+            'source' => $acc->source,
+            'description' => $acc->description,
+            'imageUrl' => $acc->imageUrl,
+            'wikipediaUrl' => $acc->wikipediaUrl,
+            'openingHours' => $acc->openingHours,
         ];
     }
 }

--- a/api/tests/Functional/TripDetailTest.php
+++ b/api/tests/Functional/TripDetailTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Functional;
 
 use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
 use ApiPlatform\Symfony\Bundle\Test\Client;
+use App\ApiResource\Model\Accommodation;
 use App\ApiResource\Model\Alert;
 use App\ApiResource\Model\AlertAction;
 use App\ApiResource\Model\AlertActionKind;
@@ -412,6 +413,63 @@ final class TripDetailTest extends ApiTestCase
         $this->assertResponseIsSuccessful();
         $data = $response->toArray(false);
         self::assertGreaterThan(0.95, $data['stages'][0]['onCycleNetwork']);
+    }
+
+    /**
+     * #870: the enrichment paid for at provision time (Wikidata, ADR-041) used to be
+     * dropped both on write and on read, so a reload — and the anonymous shared view,
+     * which hydrates from the same payload — showed a bare OSM card.
+     */
+    #[Test]
+    public function detailExposesPersistedAccommodationEnrichment(): void
+    {
+        $repo = $this->seedTrip(self::TRIP_ID);
+
+        $accommodation = new Accommodation(
+            name: 'Gîte du Morvan',
+            type: 'guest_house',
+            lat: 47.212,
+            lon: 3.951,
+            estimatedPriceMin: 55.0,
+            estimatedPriceMax: 80.0,
+            isExactPrice: true,
+            url: 'https://example.com/gite',
+            distanceToEndPoint: 1.4,
+            source: 'datatourisme',
+            description: 'Maison de maître du XIXe siècle.',
+            imageUrl: 'https://commons.example.org/gite.jpg',
+            wikipediaUrl: 'https://fr.wikipedia.org/wiki/Gite',
+            openingHours: 'Mo-Su 08:00-20:00',
+        );
+
+        $stage = new StageDto(
+            tripId: self::TRIP_ID,
+            dayNumber: 1,
+            distance: 60.0,
+            elevation: 500.0,
+            startPoint: new Coordinate(48.0, 3.0, 0.0),
+            endPoint: new Coordinate(48.2, 3.1, 0.0),
+        );
+        $stage->addAccommodation($accommodation);
+        $stage->selectedAccommodation = $accommodation;
+
+        $repo->storeStages(self::TRIP_ID, [$stage]);
+        $repo->storeStatus(self::TRIP_ID, 'ready');
+
+        $stages = $this->fetchDetail()['stages'];
+        $this->assertIsArray($stages);
+        $this->assertIsArray($stages[0]);
+        $accommodations = $stages[0]['accommodations'];
+        $this->assertIsArray($accommodations);
+
+        foreach ([$accommodations[0], $stages[0]['selectedAccommodation']] as $payload) {
+            $this->assertIsArray($payload);
+            $this->assertSame('datatourisme', $payload['source']);
+            $this->assertSame('Maison de maître du XIXe siècle.', $payload['description']);
+            $this->assertSame('https://commons.example.org/gite.jpg', $payload['imageUrl']);
+            $this->assertSame('https://fr.wikipedia.org/wiki/Gite', $payload['wikipediaUrl']);
+            $this->assertSame('Mo-Su 08:00-20:00', $payload['openingHours']);
+        }
     }
 
     #[Test]

--- a/api/tests/Unit/Repository/DoctrineTripRequestRepositoryTest.php
+++ b/api/tests/Unit/Repository/DoctrineTripRequestRepositoryTest.php
@@ -295,6 +295,120 @@ final class DoctrineTripRequestRepositoryTest extends TestCase
     }
 
     #[Test]
+    public function accommodationEnrichmentSurvivesRoundtrip(): void
+    {
+        // #870: the five enrichment fields (source + Wikidata payload) were dropped
+        // at write time, so a reload downgraded every card to a bare OSM entry.
+        $tripId = Uuid::v7()->toRfc4122();
+        $trip = new TripRequest(Uuid::fromString($tripId));
+
+        $this->entityManager->method('find')->willReturn($trip);
+        $this->entityManager->method('createQuery')->willReturn($this->createStub(Query::class));
+
+        $enriched = new Accommodation(
+            name: 'Gîte du Morvan',
+            type: 'guest_house',
+            lat: 47.212,
+            lon: 3.951,
+            estimatedPriceMin: 55.0,
+            estimatedPriceMax: 80.0,
+            isExactPrice: true,
+            url: 'https://example.com/gite',
+            possibleClosed: true,
+            distanceToEndPoint: 1.4,
+            source: 'datatourisme',
+            description: 'Maison de maître du XIXe siècle.',
+            imageUrl: 'https://commons.example.org/gite.jpg',
+            wikipediaUrl: 'https://fr.wikipedia.org/wiki/Gîte',
+            openingHours: 'Mo-Su 08:00-20:00',
+        );
+
+        $stageDto = new StageDto(
+            tripId: $tripId,
+            dayNumber: 1,
+            distance: 60.0,
+            elevation: 500.0,
+            startPoint: new Coordinate(47.0, 3.8, 0.0),
+            endPoint: new Coordinate(47.2, 3.95, 0.0),
+        );
+        $stageDto->addAccommodation($enriched);
+        $stageDto->selectedAccommodation = $enriched;
+
+        $this->repository->storeStages($tripId, [$stageDto]);
+
+        $stages = $this->repository->getStages($tripId);
+
+        self::assertNotNull($stages);
+
+        foreach ([$stages[0]->accommodations[0], $stages[0]->selectedAccommodation] as $result) {
+            self::assertNotNull($result);
+            self::assertSame('datatourisme', $result->source);
+            self::assertSame('Maison de maître du XIXe siècle.', $result->description);
+            self::assertSame('https://commons.example.org/gite.jpg', $result->imageUrl);
+            self::assertSame('https://fr.wikipedia.org/wiki/Gîte', $result->wikipediaUrl);
+            self::assertSame('Mo-Su 08:00-20:00', $result->openingHours);
+            // The ten pre-existing fields keep round-tripping unchanged.
+            self::assertSame('Gîte du Morvan', $result->name);
+            self::assertSame('guest_house', $result->type);
+            self::assertSame('https://example.com/gite', $result->url);
+            self::assertTrue($result->possibleClosed);
+            self::assertSame(1.4, $result->distanceToEndPoint);
+        }
+    }
+
+    #[Test]
+    public function accommodationPersistedWithoutEnrichmentKeysFallsBackToDefaults(): void
+    {
+        // Accommodations persisted before #870 carry only the ten legacy keys; they
+        // must rehydrate on the constructor defaults instead of raising.
+        $tripId = Uuid::v7()->toRfc4122();
+        $trip = new TripRequest(Uuid::fromString($tripId));
+
+        $legacy = [
+            'name' => 'Camping Les Oliviers',
+            'type' => 'camp_site',
+            'lat' => 47.0,
+            'lon' => 3.0,
+            'estimatedPriceMin' => 12.0,
+            'estimatedPriceMax' => 18.0,
+            'isExactPrice' => false,
+            'url' => 'https://example.com/oliviers',
+            'possibleClosed' => false,
+            'distanceToEndPoint' => 0.8,
+        ];
+
+        $stageEntity = new \App\Entity\Stage($trip);
+        $stageEntity->setPosition(0);
+        $stageEntity->setDayNumber(1);
+        $stageEntity->setDistance(10.0);
+        $stageEntity->setElevation(100.0);
+        $stageEntity->setStartLat(48.0);
+        $stageEntity->setStartLon(2.0);
+        $stageEntity->setEndLat(48.1);
+        $stageEntity->setEndLon(2.1);
+        $stageEntity->setAccommodations([$legacy]);
+        $stageEntity->setSelectedAccommodation($legacy);
+
+        $trip->addStage($stageEntity);
+
+        $this->entityManager->method('find')->willReturn($trip);
+
+        $stages = $this->repository->getStages($tripId);
+
+        self::assertNotNull($stages);
+
+        foreach ([$stages[0]->accommodations[0], $stages[0]->selectedAccommodation] as $result) {
+            self::assertNotNull($result);
+            self::assertSame('Camping Les Oliviers', $result->name);
+            self::assertSame('osm', $result->source);
+            self::assertNull($result->description);
+            self::assertNull($result->imageUrl);
+            self::assertNull($result->wikipediaUrl);
+            self::assertNull($result->openingHours);
+        }
+    }
+
+    #[Test]
     public function getRequestReturnsNullForInvalidUuid(): void
     {
         $this->entityManager->expects(self::never())

--- a/pwa/tests/fixtures/mock-data.ts
+++ b/pwa/tests/fixtures/mock-data.ts
@@ -192,9 +192,16 @@ export function accommodationsFoundEvent(
           isExactPrice: false,
           possibleClosed: false,
           distanceToEndPoint: 1.2,
-          source: "osm",
-          // Schemeless OSM `website` tag (issue #867): must render as an
-          // absolute link instead of throwing during render.
+          // Provisioning-time enrichment (issue #870): a DataTourisme entry with
+          // its Wikidata payload, so specs can assert the source badge, the
+          // thumbnail and the Wikipedia link survive a reload.
+          source: "datatourisme",
+          description: "Camping ombragé au bord de l'Ardèche.",
+          imageUrl: "https://example.com/oliviers.jpg",
+          wikipediaUrl: "https://fr.wikipedia.org/wiki/Camping",
+          openingHours: "Apr-Oct 08:00-20:00",
+          // Schemeless `website` tag (issue #867): must render as an absolute
+          // link instead of throwing during render.
           url: "www.camping-les-oliviers.fr",
         },
         {
@@ -208,6 +215,7 @@ export function accommodationsFoundEvent(
           possibleClosed: false,
           distanceToEndPoint: 0.5,
           source: "osm",
+          description: "Hôtel familial à deux pas du pont.",
           // Unusable OSM `website` tag: renders no link at all, no error.
           url: "appeler le 06 12 34 56 78",
         },

--- a/pwa/tests/mocked/accommodation.spec.ts
+++ b/pwa/tests/mocked/accommodation.spec.ts
@@ -6,6 +6,10 @@ import {
   emptyAccommodationsFoundEvent,
   tripCompleteEvent,
 } from "../fixtures/mock-data";
+import {
+  LOADED_TRIP_DETAIL_STAGES,
+  mockLoadedTripDetail,
+} from "../fixtures/api-mocks";
 
 test.describe("Accommodations", () => {
   test("shows accommodations from SSE events", async ({
@@ -248,5 +252,52 @@ test.describe("Accommodations", () => {
     await requestPromise;
 
     expect(scanRequestBody).toMatchObject({ radiusKm: 7 });
+  });
+
+  test("keeps the enrichment and the source badge after a reload", async ({
+    submitUrl,
+    injectSequence,
+    mockedPage,
+  }) => {
+    const scan = accommodationsFoundEvent(0);
+    // Narrowing keeps the reload payload in sync with the SSE fixture.
+    const persisted =
+      scan.type === "accommodations_found" ? scan.data.accommodations : [];
+
+    await submitUrl();
+    await injectSequence([
+      routeParsedEvent(),
+      stagesComputedEvent(),
+      scan,
+      tripCompleteEvent(),
+    ]);
+
+    const liveCard = mockedPage.getByTestId("stage-card-1");
+    await expect(liveCard).toContainText("DataTourisme");
+    await expect(
+      liveCard.getByRole("link", { name: "Voir sur Wikipedia" }),
+    ).toBeVisible();
+
+    // The store is in-memory (no persist), so a reload re-hydrates the cards
+    // from GET /trips/{id}/detail. Before issue #870 neither the JSONB write nor
+    // that payload carried source / description / imageUrl / wikipediaUrl /
+    // openingHours, so the reloaded card came back as a bare OSM entry.
+    const tripUrl = mockedPage.url();
+    await mockLoadedTripDetail(mockedPage, {
+      stages: LOADED_TRIP_DETAIL_STAGES.map((stage, index) =>
+        index === 0 ? { ...stage, accommodations: persisted } : stage,
+      ),
+    });
+    await mockedPage.goto(tripUrl);
+
+    const reloadedCard = mockedPage.getByTestId("stage-card-1");
+    await expect(reloadedCard).toContainText("Camping Les Oliviers");
+    await expect(reloadedCard).toContainText("DataTourisme");
+    await expect(
+      reloadedCard.getByRole("link", { name: "Voir sur Wikipedia" }),
+    ).toHaveAttribute("href", "https://fr.wikipedia.org/wiki/Camping");
+    await expect(
+      reloadedCard.getByRole("img", { name: "Camping Les Oliviers" }),
+    ).toHaveAttribute("src", "https://example.com/oliviers.jpg");
   });
 });


### PR DESCRIPTION
Closes #870

## Contexte

Le DTO `Accommodation` porte 15 champs, `accommodationToArray()` n'en écrivait que 10. Perdus à l'écriture : `source`, `description`, `imageUrl`, `wikipediaUrl`, `openingHours`. `arrayToAccommodation()` réhydratait donc `source: 'osm'` (défaut du constructeur) et `null` sur les quatre champs d'enrichissement — d'où une fiche riche en direct via Mercure, dégradée après rechargement, et une fiche DataTourisme réétiquetée `osm`.

## Le scope de l'issue ne suffisait pas

L'issue ne désigne que le repository, mais **le chemin de lecture jetait les mêmes cinq champs une seconde fois** : `TripDetailProvider::serializeAccommodation()` ne sérialisait aussi que 10 champs sur 15. Corriger seulement le JSONB aurait laissé le rechargement et la vue partagée anonyme dégradés — c'est-à-dire aurait laissé les critères d'acceptation faux malgré un correctif « conforme au scope ».

Les deux frontières sont maintenant alignées sur `StagePayloadMapper::accommodationToPayload()`, qui émettait déjà les 15 champs en direct. Preuve : en retirant `'source'` du seul provider, le test fonctionnel passe au rouge (`Failed asserting that null is identical to 'datatourisme'`).

## Changements

- `api/src/Repository/DoctrineTripRequestRepository.php` — les 5 champs ajoutés à `accommodationToArray()` et `arrayToAccommodation()`, avec les défauts du constructeur pour les lignes déjà persistées ; annotations `@return` / `@param` portées à 15 champs.
- `api/src/State/TripDetailProvider.php` — mêmes 5 champs exposés.
- Tests : aller-retour des 15 champs (liste **et** `selectedAccommodation`), aller-retour d'un tableau legacy à 10 clés sans erreur, et `/trips/{id}/detail` qui expose bien l'enrichissement persisté.
- E2E : `Camping Les Oliviers` devient une fiche DataTourisme enrichie, `Hotel du Pont` reçoit une `description` ; nouveau test en fin de fichier (scan → `goto` du même trip avec `mockLoadedTripDetail`) qui asserte le badge de source, le `src` de la vignette et le `href` Wikipédia **après rechargement**.

## Point 3 du scope — audit des autres aller-retours

- **POI** : aucun écart. `PointOfInterest` a 5 champs, `poiToArray` / `arrayToPoi` / `serializePoi` / `poiToPayload` en écrivent 5.
- **Météo** : aucun écart, 10/10.
- **Événements** : pas d'aller-retour du tout. `ScanEventsHandler.php:93` documente explicitement l'absence de colonne `Stage::events` — les événements ne vivent qu'en Mercure. C'est un écart de fonctionnalité réel (un rechargement perd les événements), mais ce n'est pas une perte à l'écriture, et c'est une décision assumée liée à la race `storeStages` de la recette #649. Hors périmètre.
- **Alertes** : `Alert` de base 5/5 OK. En revanche `CulturalPoiAlert` porte 7 champs d'enrichissement (`openingHours`, `estimatedPrice`, `description`, `wikidataId`, `source`, `imageUrl`, `wikipediaUrl`) qu'`alertToArray()` ne persiste pas. **Non corrigé volontairement** : plus aucun producteur n'instancie `CulturalPoiAlert` dans `api/src/` (les POI culturels passent par `CheckCulturalPoisHandler`, en Mercure pur) et ni `serializeAlert()` ni `alertToPayload()` n'exposent ces champs — les persister serait du code mort. À traiter avec la question « alertes culturelles persistées », si elle se pose.

## Constat annexe

`description` et `openingHours` ne sont **rendus par aucun composant** d'hébergement : `accommodation-item.tsx` n'affiche que `imageUrl`, `wikipediaUrl` et le badge `source`. Le critère « la fiche conserve sa description » est donc satisfait côté données mais invisible côté UI. Ajouter ce rendu est hors périmètre ; le test E2E asserte badge + vignette + lien Wikipédia, pas la description.

## Vérification

Legs exécutés individuellement (`make qa` ne peut pas aboutir en local, cf. CLAUDE.md) :

- PHP-CS-Fixer : `Fixed 0 of 648 files in 0.595 seconds, 42.00 MB memory used`
- Rector : autofixes `NewlineBeforeNewAssignSetRector` appliqués et commités, puis dry-run `[OK] Rector is done!`
- PHPStan niveau 9 : `[OK] No errors`
- `tsc --noEmit` : exit 0, aucune sortie
- ESLint sur les 2 fichiers front touchés : exit 0
- Prettier 3.9.6 : `All matched files use Prettier code style!`
- `npm run i18n:check` : `i18n-check OK: 917 keys in sync across fr, en`
- PHPUnit Unit + Integration : `Tests: 1320, Assertions: 3712, Skipped: 1` (skip préexistant)
- PHPUnit Functional : `OK (303 tests, 1082 assertions)`
- vitest : `35 passed (35)` fichiers, `320 passed (320)` tests

**Preuve que les tests peuvent échouer** — `'source' => $acc->source` retiré de `accommodationToArray()` :

```
1) DoctrineTripRequestRepositoryTest::accommodationEnrichmentSurvivesRoundtrip
-'datatourisme'  +'osm'
2) TripDetailTest::detailExposesPersistedAccommodationEnrichment
-'datatourisme'  +'osm'
Tests: 2, Assertions: 9, Failures: 2.
```

Puis retiré de `TripDetailProvider` seul : `Failed asserting that null is identical to 'datatourisme'`. Champs restaurés, suites re-vertes.

**Playwright : couverture CI uniquement.** Un worktree n'a pas la PWA construite et servie sur `https://localhost`.

## Auto-critique

- Le correctif dépasse le fichier annoncé par l'issue (ajout de `TripDetailProvider`). C'était nécessaire pour que les critères d'acceptation soient vrais, mais ça élargit le diff.
- Deux frontières de sérialisation restent à maintenir en parallèle (`StagePayloadMapper` pour Mercure, `TripDetailProvider` pour REST) : rien n'empêche structurellement la prochaine divergence. Un mappeur partagé serait le vrai correctif, hors périmètre ici.
- L'écart `CulturalPoiAlert` est documenté mais laissé en place.

## Recoupements attendus au merge (sprint 45)

- `pwa/tests/fixtures/mock-data.ts` et `pwa/tests/mocked/accommodation.spec.ts` — #867 (PR #904) ajoute une `url` aux deux mêmes entrées et un test. Diffs voulus disjoints : clés insérées en fin d'objet, test ajouté en fin de fichier. Conflit trivial attendu, **les deux côtés se conservent**.
- Aucun autre recoupement : `DoctrineTripRequestRepository.php` et `TripDetailProvider.php` ne sont touchés par aucune autre issue du sprint.


<!-- claude-review-start -->
## Claude Review

**Summary:** Clean, well-scoped fix. Both serialization boundaries (`DoctrineTripRequestRepository::accommodationToArray`/`arrayToAccommodation` and `TripDetailProvider::serializeAccommodation`) now emit the same 15 `Accommodation` fields as `StagePayloadMapper::accommodationToPayload`, verified field-by-field across all three implementations. The legacy-row fallback (`?? 'osm'` / `?? null`) matches the `Accommodation` constructor defaults exactly. Checked the E2E assertions (source badge text, Wikipedia link label, image `alt`) against the actual `accommodation-item.tsx` markup and translation strings — they match. Confirmed the shared `accommodationsFoundEvent(0)` fixture change (now carrying `imageUrl`) doesn't break other specs that reuse it (no count/snapshot assertions depend on the accommodation card's image). 0 findings.

**PR title check:** Conforms to Conventional Commits (`fix(trips): ...`, imperative, lowercase).

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

**Commit reviewed:** `0f35610b60f3aa03438c9cb788ae3ad965d65ecc`
<!-- claude-review-end -->
