### PR TITLE
fix(pwa): complete the accommodation label and icon maps

### DIFF
--- a/pwa/src/components/Map/MapView.tsx
+++ b/pwa/src/components/Map/MapView.tsx
@@ -19,6 +19,10 @@ import { PoiPopover, isEnrichedPoi } from "./poi-popover";
 import { MapLegend } from "@/components/map-legend";
 import { TileLayerControl } from "./tile-layer-control";
 import { useTileMode, type TileMode } from "@/hooks/use-tile-mode";
+import {
+  isAccommodationType,
+  type AccommodationType,
+} from "@/lib/accommodation-types";
 
 const LIGHT_TILES =
   "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json";
@@ -143,27 +147,35 @@ function createMarkerElement(className: string, label: string): HTMLElement {
   return el;
 }
 
+const ACCOMMODATION_BUILDINGS = "#7c3aed"; // violet
+const ACCOMMODATION_CAMPING = "#059669"; // emerald
+const ACCOMMODATION_HUTS = "#b45309"; // amber-700
+const ACCOMMODATION_FALLBACK = "#6b7280"; // slate
+
 /**
  * Background colour applied behind the unified accommodation icon — kept
  * granular per sub-type so users still get a quick visual cue at a glance.
+ * Exhaustive over the shared contract: a new type without a colour is a
+ * TypeScript error instead of a silent slate marker.
  */
+const ACCOMMODATION_BACKGROUNDS: Record<AccommodationType, string> = {
+  hotel: ACCOMMODATION_BUILDINGS,
+  hostel: ACCOMMODATION_BUILDINGS,
+  guest_house: ACCOMMODATION_BUILDINGS,
+  motel: ACCOMMODATION_BUILDINGS,
+  chalet: ACCOMMODATION_BUILDINGS,
+  rental: ACCOMMODATION_BUILDINGS,
+  camp_site: ACCOMMODATION_CAMPING,
+  alpine_hut: ACCOMMODATION_HUTS,
+  wilderness_hut: ACCOMMODATION_HUTS,
+  shelter: ACCOMMODATION_HUTS,
+  other: ACCOMMODATION_FALLBACK,
+};
+
 function getAccommodationBackground(type: string): string {
-  switch (type) {
-    case "hotel":
-    case "hostel":
-    case "guest_house":
-    case "motel":
-    case "chalet":
-      return "#7c3aed"; // violet — buildings
-    case "camp_site":
-      return "#059669"; // emerald — camping
-    case "alpine_hut":
-    case "wilderness_hut":
-    case "shelter":
-      return "#b45309"; // amber-700 — huts
-    default:
-      return "#6b7280"; // slate — fallback
-  }
+  return isAccommodationType(type)
+    ? ACCOMMODATION_BACKGROUNDS[type]
+    : ACCOMMODATION_FALLBACK;
 }
 
 /**

--- a/pwa/src/components/Map/icons/icons.test.tsx
+++ b/pwa/src/components/Map/icons/icons.test.tsx
@@ -35,6 +35,8 @@ describe("resolveCategory — full identifier mapping", () => {
     ["alpine_hut", "accommodation"],
     ["camp_site", "accommodation"],
     ["shelter", "accommodation"],
+    ["wilderness_hut", "accommodation"],
+    ["rental", "accommodation"],
     // Water
     ["water", "water"],
     ["drinking_water", "water"],

--- a/pwa/src/components/Map/icons/index.tsx
+++ b/pwa/src/components/Map/icons/index.tsx
@@ -11,6 +11,10 @@
  * `motel`) all map onto the relevant category through {@link resolveCategory}.
  */
 import type { ComponentType, SVGProps } from "react";
+import {
+  FILTERABLE_ACCOMMODATION_TYPES,
+  type FilterableAccommodationType,
+} from "@/lib/accommodation-types";
 
 export type MarkerCategory =
   | "accommodation"
@@ -281,20 +285,15 @@ export const MarkerIcon: Record<
 
 // ── Sub-type → category mapping ──────────────────────────────────────────────
 
-/** Accommodation sub-types covered by the unified registry. */
-export const ACCOMMODATION_SUBTYPES = [
-  "hotel",
-  "motel",
-  "guest_house",
-  "chalet",
-  "hostel",
-  "alpine_hut",
-  "camp_site",
-  "wilderness_hut",
-  "shelter",
-] as const;
+/**
+ * Accommodation sub-types covered by the unified registry. Derived from the
+ * shared contract rather than duplicated, so a new type gets its marker
+ * category without a second edit here ("other" is the manual-entry bucket and
+ * never reaches a marker as a sub-type).
+ */
+export const ACCOMMODATION_SUBTYPES = FILTERABLE_ACCOMMODATION_TYPES;
 
-export type AccommodationSubtype = (typeof ACCOMMODATION_SUBTYPES)[number];
+export type AccommodationSubtype = FilterableAccommodationType;
 
 /** Returns true if `value` matches a known accommodation sub-type. */
 export function isAccommodationSubtype(

--- a/pwa/src/components/accommodation-item.test.tsx
+++ b/pwa/src/components/accommodation-item.test.tsx
@@ -1,12 +1,26 @@
 import { describe, it, expect, vi } from "vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
-import { AccommodationItem } from "./accommodation-item";
+import { MapPin } from "lucide-react";
+import {
+  AccommodationItem,
+  ACCOMMODATION_TYPE_ICONS,
+} from "./accommodation-item";
+import { ACCOMMODATION_TYPES } from "@/lib/accommodation-types";
 import type { AccommodationData } from "@/lib/validation/schemas";
+import fr from "../../messages/fr.json";
 
-vi.mock("next-intl", () => ({
-  useTranslations: () => (key: string) => key,
-}));
+// The real French catalogue rather than an identity stub: the completeness
+// tests below assert that every contract type resolves to a real label, which
+// an identity stub could not detect.
+vi.mock("next-intl", async () => {
+  const messages = (await import("../../messages/fr.json")).default;
+  return {
+    useTranslations: (namespace: keyof typeof messages) => (key: string) =>
+      (messages[namespace] as Record<string, string>)[key] ??
+      `MISSING:${namespace}.${key}`,
+  };
+});
 
 function accommodation(
   overrides: Partial<AccommodationData> = {},
@@ -37,6 +51,17 @@ function renderItem(data: AccommodationData, onUpdate = vi.fn()) {
       />,
     ),
   };
+}
+
+function renderType(type: string) {
+  return renderItem(accommodation({ name: "Chez Bernard", type }));
+}
+
+/** lucide tags its svg with `lucide-<kebab-name>`, e.g. BedDouble -> bed-double. */
+function lucideClass(icon: { displayName?: string }) {
+  return `lucide-${icon
+    .displayName!.replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+    .toLowerCase()}`;
 }
 
 describe("AccommodationItem website link", () => {
@@ -80,10 +105,10 @@ describe("AccommodationItem edits", () => {
       />,
     );
 
-    fireEvent.change(screen.getByLabelText("urlLabel"), {
+    fireEvent.change(screen.getByLabelText(fr.accommodation.urlLabel), {
       target: { value: typed },
     });
-    fireEvent.click(screen.getByText("save"));
+    fireEvent.click(screen.getByText(fr.accommodation.save));
 
     return onUpdate;
   }
@@ -107,13 +132,79 @@ describe("AccommodationItem Wikipedia link", () => {
       accommodation({ wikipediaUrl: "https://fr.wikipedia.org/wiki/Pont" }),
     );
 
-    const link = screen.getByText("see_on_wikipedia");
+    const link = screen.getByText(fr.accommodation.see_on_wikipedia);
     expect(link).toHaveAttribute("href", "https://fr.wikipedia.org/wiki/Pont");
   });
 
   it("renders no link for an unusable Wikipedia value", () => {
     renderItem(accommodation({ wikipediaUrl: "voir wikipedia" }));
 
-    expect(screen.queryByText("see_on_wikipedia")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(fr.accommodation.see_on_wikipedia),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("AccommodationItem type rendering", () => {
+  it.each(ACCOMMODATION_TYPES)("labels and illustrates a %s", (type) => {
+    renderType(type);
+
+    expect(
+      screen.getByText(fr.accommodation[`type_${type}`]),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("accommodation-type-icon")).toHaveClass(
+      lucideClass(ACCOMMODATION_TYPE_ICONS[type]),
+    );
+  });
+
+  it("renders shelter as Abri, not Autre", () => {
+    renderType("shelter");
+
+    expect(screen.getByText("Abri")).toBeInTheDocument();
+    expect(screen.queryByText("Autre")).not.toBeInTheDocument();
+  });
+
+  it("renders wilderness_hut as Bivouac, not Autre", () => {
+    renderType("wilderness_hut");
+
+    expect(screen.getByText("Bivouac")).toBeInTheDocument();
+    expect(screen.queryByText("Autre")).not.toBeInTheDocument();
+  });
+
+  it("falls back to Autre for a type outside the contract", () => {
+    renderType("igloo");
+
+    expect(screen.getByText("Autre")).toBeInTheDocument();
+  });
+
+  it("offers every contract type in the edit form", () => {
+    render(
+      <AccommodationItem
+        accommodation={accommodation()}
+        onUpdate={vi.fn()}
+        onRemove={vi.fn()}
+        initialEditing
+      />,
+    );
+
+    const select = screen.getByLabelText(fr.accommodation.typeLabel);
+    expect([...select.querySelectorAll("option")].map((o) => o.value)).toEqual([
+      ...ACCOMMODATION_TYPES,
+    ]);
+  });
+});
+
+describe("ACCOMMODATION_TYPE_ICONS", () => {
+  it.each(ACCOMMODATION_TYPES.filter((type) => type !== "other"))(
+    "gives %s an icon distinct from the generic fallback",
+    (type) => {
+      expect(ACCOMMODATION_TYPE_ICONS[type]).not.toBe(MapPin);
+    },
+  );
+
+  it("covers exactly the contract types", () => {
+    expect(Object.keys(ACCOMMODATION_TYPE_ICONS).sort()).toEqual(
+      [...ACCOMMODATION_TYPES].sort(),
+    );
   });
 });

--- a/pwa/src/components/accommodation-item.tsx
+++ b/pwa/src/components/accommodation-item.tsx
@@ -13,38 +13,47 @@ import {
   ExternalLink,
   CheckCircle2,
   Circle,
+  BedDouble,
+  KeyRound,
+  Mountain,
+  TreePine,
+  Umbrella,
+  type LucideIcon,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import type { AccommodationData } from "@/lib/validation/schemas";
 import { formatPrice, formatDistanceKm } from "@/lib/formatters";
 import {
+  ACCOMMODATION_TYPES,
+  accommodationTypeLabelKey,
+  isAccommodationType,
+  type AccommodationType,
+} from "@/lib/accommodation-types";
+import {
   externalUrlHostname,
   normalizeExternalUrl,
 } from "@/lib/validation/url";
 
-const typeIcons: Record<string, React.ElementType> = {
+/**
+ * One icon per accommodation family (roof, bed, tent, hut, shelter, key).
+ * `Record<AccommodationType, …>` is exhaustive on purpose: adding a type to
+ * ACCOMMODATION_TYPES without an icon here is a TypeScript error, instead of a
+ * silent fallback to the generic MapPin.
+ */
+export const ACCOMMODATION_TYPE_ICONS: Record<AccommodationType, LucideIcon> = {
   hotel: Hotel,
-  hostel: Home,
-  chalet: Home,
-  guest_house: Home,
-  motel: Hotel,
+  hostel: BedDouble,
   camp_site: Tent,
-  alpine_hut: MapPin,
-  rental: Home,
+  chalet: Home,
+  guest_house: BedDouble,
+  motel: Hotel,
+  alpine_hut: Mountain,
+  wilderness_hut: TreePine,
+  shelter: Umbrella,
+  rental: KeyRound,
+  other: MapPin,
 };
-
-const typeLabelKeys = {
-  hotel: "type_hotel",
-  hostel: "type_hostel",
-  camp_site: "type_camp_site",
-  chalet: "type_chalet",
-  guest_house: "type_guest_house",
-  motel: "type_motel",
-  alpine_hut: "type_alpine_hut",
-  rental: "type_rental",
-  other: "type_other",
-} as const;
 
 interface AccommodationItemProps {
   accommodation: AccommodationData;
@@ -92,11 +101,10 @@ export function AccommodationItem({
     }
   }, [initialEditing]);
 
-  const TypeIcon = typeIcons[accommodation.type] ?? MapPin;
-  const typeKey =
-    typeLabelKeys[accommodation.type as keyof typeof typeLabelKeys] ??
-    "type_other";
-  const typeLabel = t(typeKey);
+  const TypeIcon = isAccommodationType(accommodation.type)
+    ? ACCOMMODATION_TYPE_ICONS[accommodation.type]
+    : ACCOMMODATION_TYPE_ICONS.other;
+  const typeLabel = t(accommodationTypeLabelKey(accommodation.type));
   const distLabel = formatDistanceKm(accommodation.distanceToEndPoint ?? 0);
   // OSM `website` tags and user input are unvalidated: normalize before render,
   // and drop the link entirely when the value is not a usable http(s) URL.
@@ -173,15 +181,11 @@ export function AccommodationItem({
             className="h-7 text-sm rounded-md border border-input bg-transparent px-2"
             aria-label={t("typeLabel")}
           >
-            <option value="hotel">{t("type_hotel")}</option>
-            <option value="hostel">{t("type_hostel")}</option>
-            <option value="camp_site">{t("type_camp_site")}</option>
-            <option value="chalet">{t("type_chalet")}</option>
-            <option value="guest_house">{t("type_guest_house")}</option>
-            <option value="motel">{t("type_motel")}</option>
-            <option value="alpine_hut">{t("type_alpine_hut")}</option>
-            <option value="rental">{t("type_rental")}</option>
-            <option value="other">{t("type_other")}</option>
+            {ACCOMMODATION_TYPES.map((type) => (
+              <option key={type} value={type}>
+                {t(accommodationTypeLabelKey(type))}
+              </option>
+            ))}
           </select>
           <div className="flex items-center gap-1">
             <Euro className="h-3.5 w-3.5 text-muted-icon" />
@@ -324,7 +328,10 @@ export function AccommodationItem({
       {/* Type icon + label + price + distance to end point */}
       <div className="flex items-center gap-3 mt-1 text-sm text-muted-foreground flex-wrap">
         <div className="flex items-center gap-1.5">
-          <TypeIcon className="h-3.5 w-3.5" />
+          <TypeIcon
+            className="h-3.5 w-3.5"
+            data-testid="accommodation-type-icon"
+          />
           <span>{typeLabel}</span>
         </div>
         {formatPrice(accommodation) && (

--- a/pwa/src/lib/accommodation-types.test.ts
+++ b/pwa/src/lib/accommodation-types.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import fr from "../../messages/fr.json";
+import en from "../../messages/en.json";
+import {
+  ACCOMMODATION_TYPES,
+  DEFAULT_ACCOMMODATION_TYPES,
+  FILTERABLE_ACCOMMODATION_TYPES,
+  accommodationTypeLabelKey,
+  isAccommodationType,
+} from "./accommodation-types";
+
+const catalogs: Record<string, Record<string, string>> = {
+  fr: fr.accommodation,
+  en: en.accommodation,
+};
+
+describe("accommodation type catalog", () => {
+  // Guard against the #866 regression: a type present in the contract but
+  // missing from a message catalog used to render silently as "Autre".
+  it.each(Object.keys(catalogs))(
+    "translates every contract type in %s.json",
+    (locale) => {
+      const catalog = catalogs[locale]!;
+      const missing = ACCOMMODATION_TYPES.filter(
+        (type) => !catalog[accommodationTypeLabelKey(type)],
+      );
+
+      expect(missing).toEqual([]);
+    },
+  );
+
+  it.each([...FILTERABLE_ACCOMMODATION_TYPES, ...DEFAULT_ACCOMMODATION_TYPES])(
+    "keeps %s in the full type list",
+    (type) => {
+      expect(ACCOMMODATION_TYPES).toContain(type);
+    },
+  );
+
+  it("maps each contract type to its own key", () => {
+    expect(accommodationTypeLabelKey("shelter")).toBe("type_shelter");
+    expect(accommodationTypeLabelKey("wilderness_hut")).toBe(
+      "type_wilderness_hut",
+    );
+  });
+
+  it("falls back to type_other for a type outside the contract", () => {
+    expect(isAccommodationType("igloo")).toBe(false);
+    expect(accommodationTypeLabelKey("igloo")).toBe("type_other");
+  });
+});

--- a/pwa/src/lib/accommodation-types.ts
+++ b/pwa/src/lib/accommodation-types.ts
@@ -20,6 +20,22 @@ export const ACCOMMODATION_TYPES = [
 
 export type AccommodationType = (typeof ACCOMMODATION_TYPES)[number];
 
+export function isAccommodationType(value: string): value is AccommodationType {
+  return (ACCOMMODATION_TYPES as readonly string[]).includes(value);
+}
+
+/**
+ * Translation key (namespace `accommodation`) for a type coming from the API.
+ * Derived from the contract instead of a hand-maintained map, so a new type can
+ * never silently render as "Autre": adding it to ACCOMMODATION_TYPES without
+ * its catalog entry fails accommodation-types.test.ts.
+ */
+export function accommodationTypeLabelKey(
+  type: string,
+): `type_${AccommodationType}` {
+  return isAccommodationType(type) ? `type_${type}` : "type_other";
+}
+
 /**
  * The accommodation types that can be used for backend filtering.
  * "other" is excluded as it is reserved for manually-added accommodations.


### PR DESCRIPTION
Closes #866

> **PR empilée** : base `feature/865` (PR #906). À merger **après** #906.

## Contexte

`shelter` et `wilderness_hut` étaient absents de `typeLabelKeys` alors que `type_shelter` / `type_wilderness_hut` existaient **déjà** dans `fr.json` et `en.json`. Le repli renvoyait donc « Autre ». C'est la cause racine du retour de recette « un hébergement s'affiche comme *Autre*, je ne peux pas les distinguer », qui avait conduit à ignorer les hébergements sans nom : la donnée était bonne, c'est le libellé qui manquait. Aucune clé de traduction à ajouter — `i18n:check` confirme 918 clés en phase.

## Le point 4 est le livrable : les deux mécanismes, volontairement

1. **Dérivation depuis le contrat, vérifiée à la compilation.** La map de libellés a *disparu* : `accommodationTypeLabelKey(type)` dans `pwa/src/lib/accommodation-types.ts` construit la clé depuis `ACCOMMODATION_TYPES` (`type_${AccommodationType}`), avec repli `type_other` pour une valeur hors contrat venant de l'API. Il n'y a plus de map à oublier. La liste d'`<option>` du formulaire d'édition est générée par `ACCOMMODATION_TYPES.map(...)` — c'est exactement l'oubli qu'avait fait #865. Les icônes restent une map, mais typée `Record<AccommodationType, LucideIcon>` : exhaustive par construction.
2. **Test de complétude, à l'exécution.** Un typage ne peut pas prouver que le catalogue de traductions contient la clé ; deux nouveaux fichiers de test le font, contre `fr.json` et `en.json`.

Les deux sont nécessaires : le premier attrape l'oubli de code, le second l'oubli de traduction.

## Icônes par famille

Aucune n'est plus le `MapPin` générique, désormais réservé à `other` : `hotel`/`motel` → Hotel, `hostel`/`guest_house` → BedDouble, `camp_site` → Tent, `chalet` → Home, `alpine_hut` → Mountain, `wilderness_hut` → TreePine, `shelter` → Umbrella, `rental` → KeyRound. `data-testid="accommodation-type-icon"` ajouté pour permettre l'assertion DOM.

## Élargissement de périmètre à valider

`ACCOMMODATION_SUBTYPES` dans `pwa/src/components/Map/icons/index.tsx` était une **troisième** liste de types dupliquée, sans `rental` : depuis #865, un hébergement `rental` ne résolvait pas la catégorie de marqueur `accommodation`. Elle dérive maintenant de `FILTERABLE_ACCOMMODATION_TYPES`. Même chose pour `getAccommodationBackground` dans `MapView.tsx`, dont le `switch`/`default` silencieux devient un `Record<AccommodationType, string>` exhaustif (`rental` classé « bâtiments »).

C'est le même bug de récidive que celui de l'issue, sur deux fichiers qu'elle ne nomme pas. Dis-moi si tu préfères que ces deux fichiers sortent du diff.

## Preuve que le garde-fou échoue

**Mutation A** — `"yurt"` ajouté à `ACCOMMODATION_TYPES` sans libellé ni icône :

```
src/components/Map/MapView.tsx(161,7): error TS2741: Property 'yurt' is missing in type '{ hotel: string; ... }' but required in type 'Record<"hotel" | ... | "yurt" | "other", string>'.
src/components/accommodation-item.test.tsx(59,24): error TS7053: ... Property 'type_yurt' does not exist on type '{ type_hotel: string; ... }'.
src/components/accommodation-item.tsx(40,14): error TS2741: Property 'yurt' is missing in type '{ hotel: ForwardRefExoticComponent<...>; ... }' but required in type 'Record<..., LucideIcon>'.
tsc exit=2
```

```
 ❯ src/lib/accommodation-types.test.ts (23 tests | 2 failed)
     × translates every contract type in fr.json
     × translates every contract type in en.json
AssertionError: expected [ 'yurt' ] to deeply equal []
```

**Mutation B** — `accommodation.type_shelter` retirée de `fr.json` :

```
 ❯ src/lib/accommodation-types.test.ts (23 tests | 1 failed)
     × translates every contract type in fr.json    AssertionError: expected [ 'shelter' ] to deeply equal []
 ❯ src/components/accommodation-item.test.tsx (26 tests | 1 failed)
     × renders shelter as Abri, not Autre
```

```
Missing 1 key(s) in fr.json:
  - accommodation.type_shelter
i18n exit=1
```

Les deux mutations ont été restaurées : le diff commité ne contient ni `yurt` ni clé retirée. Le critère d'acceptation « ajouter un type sans son libellé fait échouer la CI » est donc vérifié par les deux voies.

## Vérification

Legs exécutés individuellement (`make qa` ne peut pas aboutir en local, cf. CLAUDE.md). Aucun PHP touché → Rector / PHPStan / PHP-CS-Fixer non applicables.

- `tsc --noEmit` : exit 0
- `vitest run` : `37 passed (37)` fichiers, `371 passed (371)` tests — la branche parente était à 35 fichiers / 320 tests, soit +2 fichiers et +51 tests
- `eslint` sur les 7 fichiers touchés : `0 errors, 1 warning` — `@next/next/no-img-element` préexistant sur la vignette Wikidata, ligne inchangée par ce diff
- `prettier@3.9.6 --check` : `All matched files use Prettier code style!`
- `npm run i18n:check` : `i18n-check OK: 918 keys in sync across fr, en`

Après rebase sur `feature/865` (qui a reçu le `schema.d.ts` régénéré) : `tsc` exit 0 et `vitest` `371 passed (371)` re-vérifiés.

**Playwright : couverture CI uniquement.**

## Auto-critique

- Les icônes restent une map manuelle : la garantie est l'exhaustivité du `Record`, pas la pertinence du choix d'icône. Rien n'empêche d'y mettre deux fois la même.
- Le repli `type_other` est conservé pour une valeur hors contrat venant de l'API : c'est nécessaire (le backend peut envoyer un type que le front ne connaît pas encore), mais ça laisse un chemin vers « Autre » — désormais réservé à ce cas-là et aux hébergements ajoutés à la main.
- L'élargissement à `Map/icons` et `MapView` dépasse les fichiers annoncés par l'issue.

## Recoupements attendus au merge (sprint 45)

- `pwa/src/components/accommodation-item.tsx` — **#867 (PR #904) touche le même fichier** sur des blocs distincts (rendu de l'URL, lien Wikipédia, `commitEdits`) ; ici seules les maps de libellés / icônes et la liste d'`<option>` changent. Conflit possible sur les imports en tête de fichier ; **les deux côtés se conservent**.
- `pwa/messages/{fr,en}.json` inchangés ici, donc aucun conflit i18n.
- `pwa/tests/fixtures/mock-data.ts` non touché (laissé à #867 et #870).


<!-- claude-review-start -->
## Claude Review

**Summary:** 0 findings (0 critical, 0 warning). This replaces three hand-maintained, drift-prone maps (labels, icons, marker sub-types, marker background colours) with lookups derived from `ACCOMMODATION_TYPES` / `FILTERABLE_ACCOMMODATION_TYPES`, each made exhaustive via a TypeScript `Record<...>` so a new type fails compilation instead of silently rendering as "Autre". Independently verified `FILTERABLE_ACCOMMODATION_TYPES` (pwa) against `TripRequest::ALL_ACCOMMODATION_TYPES` / `DEFAULT_ACCOMMODATION_TYPES` (api/src/ApiResource/TripRequest.php) — both match exactly as sets. Independently verified `fr.json`/`en.json` both carry all 11 `type_*` keys. No security, performance, or correctness issues found; no leftover references to the removed `typeIcons`/`typeLabelKeys` maps or the old duplicated `ACCOMMODATION_SUBTYPES` literal list.

**Review checklist:**
- [x] Code respects the project architecture (local-first frontend, contract-driven derivation, no backend touched)
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate (exhaustive `Record<AccommodationType, …>`, single derivation point instead of duplicated maps)
- [x] Tests cover new/changed cases (new `accommodation-types.test.ts` completeness suite, expanded `accommodation-item.test.tsx`, `icons.test.tsx` cases for `wilderness_hut`/`rental`)
- [x] Documentation is up to date (not an alert rule — no README/`AlertDocumentationTest` update applicable)
- [x] Dependent tickets accounted for (overlap with #867/PR #904 on `accommodation-item.tsx` called out in PR description)

**Inline comments:** No inline comments.

**Commit reviewed:** `f262ba06745fe390d07fe11efb01c780360d13d0`
<!-- claude-review-end -->