### PR TITLE
feat(accommodations): rank candidates by completeness, use stars and capacity

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@
 | `wilderness_hut` | `tourism=wilderness_hut` | free / donation (€0–€10) |
 | `shelter` | `amenity=shelter` + `shelter_type~basic_hut\|weather_shelter\|lean_to` | free (€0) |
 
+The bracket above is the *unrated* estimate. A `charge` tag or a numeric `fee` overrides it with an exact price, `fee=no` prices the entry as free, and a known `stars` rating lifts the bracket floor by 25% of its span per star above 2, capped at 75% (a 4-star hotel is estimated €85–€120, not €50–€120).
+
+Only a few candidates are kept per stage: they are ranked by **completeness** (website, description, opening hours, Wikidata Q-ID, stars, capacity, tag richness) with the price as tiebreaker, and a per-family cap reserves one slot for the camping/shelter family so a stage never returns hotels only.
+
 ---
 
 ## Quick start

--- a/api/src/Accommodation/CandidateRanker.php
+++ b/api/src/Accommodation/CandidateRanker.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Accommodation;
+
+/**
+ * Ranks the accommodation candidates of one stage and keeps the best few.
+ *
+ * Completeness first, price second. Ordering on price alone (the pre-#869
+ * behaviour) systematically retained the cheapest categories, because the price
+ * of most candidates comes from PricingHeuristicEngine (type + tags) and not from
+ * a real offer: shelters and camp sites always won on their low heuristic floor,
+ * and the rich, bookable entries never made the cut. Completeness ranks on
+ * signals that are actually observed in the index — website, description, opening
+ * hours, wikidata Q-ID, stars, capacity, and (for OSM) tag richness.
+ *
+ * Source-bias guard: completeness alone favours DataTourisme, whose entries are
+ * always named and usually described, and OSM camp sites — sparse by nature —
+ * would be evicted from every stage. The guard is a **per-family cap** of
+ * `limit - 1`: at least one slot always goes to the other family when it has any
+ * candidate, so a stage offering camp sites and hotels never returns only one of
+ * the two. A per-*source* cap was rejected: DataTourisme is France-only, so it
+ * would be a no-op outside France, where the eviction risk is identical (the
+ * families come from both sources). A per-*type* cap was rejected too: hotel +
+ * guest_house + motel are three distinct types but one family, and the camp site
+ * would still be evicted.
+ *
+ * Reproducibility: the comparator is a total order up to (score, priceMin) ties,
+ * and PHP's sort has been stable since 8.0, so ties keep the caller's order —
+ * which the repositories make deterministic (KNN order, primary-key tiebreak,
+ * bounded LIMIT; #868). Two runs of the same scan therefore retain the same set
+ * in the same order.
+ */
+final readonly class CandidateRanker
+{
+    private const int WEIGHT_WEBSITE = 3;
+
+    private const int WEIGHT_DESCRIPTION = 3;
+
+    private const int WEIGHT_OPENING_HOURS = 2;
+
+    private const int WEIGHT_WIKIDATA = 2;
+
+    private const int WEIGHT_STARS = 2;
+
+    private const int WEIGHT_CAPACITY = 1;
+
+    /** OSM tags per completeness point, and the cap on that contribution. */
+    private const int TAGS_PER_POINT = 3;
+
+    /**
+     * Tag richness is capped so it stays a tiebreaker: it is an OSM-only signal
+     * (DataTourisme publishes fields, not tags) and must not outweigh a described,
+     * bookable entry on its own.
+     */
+    private const int MAX_TAG_POINTS = 2;
+
+    /**
+     * Minimal-facility types, poor in metadata by nature: they lose the
+     * completeness ranking and are what the family cap protects.
+     */
+    private const array OUTDOOR_TYPES = ['camp_site', 'shelter', 'wilderness_hut'];
+
+    /**
+     * @param list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, stars?: ?int, capacity?: ?int, fee?: ?string, source?: string, wikidataId?: ?string, description?: ?string, imageUrl?: ?string, wikipediaUrl?: ?string, openingHours?: ?string}> $candidates
+     *
+     * @return list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, stars?: ?int, capacity?: ?int, fee?: ?string, source?: string, wikidataId?: ?string, description?: ?string, imageUrl?: ?string, wikipediaUrl?: ?string, openingHours?: ?string}>
+     */
+    public function rank(array $candidates, int $limit): array
+    {
+        $ranked = $candidates;
+        usort(
+            $ranked,
+            fn (array $a, array $b): int => $this->completeness($b) <=> $this->completeness($a)
+                ?: $a['priceMin'] <=> $b['priceMin'],
+        );
+
+        $perFamily = max(1, $limit - 1);
+        $kept = [];
+        $counts = [];
+        $capped = [];
+
+        foreach ($ranked as $candidate) {
+            $family = $this->family($candidate['type']);
+            if (($counts[$family] ?? 0) >= $perFamily) {
+                $capped[] = $candidate;
+                continue;
+            }
+
+            $kept[] = $candidate;
+            $counts[$family] = ($counts[$family] ?? 0) + 1;
+
+            if (\count($kept) === $limit) {
+                return $kept;
+            }
+        }
+
+        // Only one family around this stage: the reserved slot has nothing to hold,
+        // so give it back to the ranking instead of returning fewer candidates.
+        foreach ($capped as $candidate) {
+            if (\count($kept) === $limit) {
+                break;
+            }
+
+            $kept[] = $candidate;
+        }
+
+        return $kept;
+    }
+
+    /**
+     * @param array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, stars?: ?int, capacity?: ?int, fee?: ?string, source?: string, wikidataId?: ?string, description?: ?string, imageUrl?: ?string, wikipediaUrl?: ?string, openingHours?: ?string} $candidate
+     */
+    private function completeness(array $candidate): int
+    {
+        $score = 0;
+
+        if ($candidate['hasWebsite'] || null !== $candidate['url']) {
+            $score += self::WEIGHT_WEBSITE;
+        }
+
+        if ($this->filled($candidate['description'] ?? null)) {
+            $score += self::WEIGHT_DESCRIPTION;
+        }
+
+        if ($this->filled($candidate['openingHours'] ?? null)) {
+            $score += self::WEIGHT_OPENING_HOURS;
+        }
+
+        if ($this->filled($candidate['wikidataId'] ?? null)) {
+            $score += self::WEIGHT_WIKIDATA;
+        }
+
+        if (null !== ($candidate['stars'] ?? null)) {
+            $score += self::WEIGHT_STARS;
+        }
+
+        if (null !== ($candidate['capacity'] ?? null)) {
+            $score += self::WEIGHT_CAPACITY;
+        }
+
+        return $score + min(self::MAX_TAG_POINTS, intdiv($candidate['tagCount'], self::TAGS_PER_POINT));
+    }
+
+    private function family(string $type): string
+    {
+        return \in_array($type, self::OUTDOOR_TYPES, true) ? 'outdoor' : 'indoor';
+    }
+
+    private function filled(?string $value): bool
+    {
+        return null !== $value && '' !== trim($value);
+    }
+}

--- a/api/src/AccommodationSource/AccommodationSourceInterface.php
+++ b/api/src/AccommodationSource/AccommodationSourceInterface.php
@@ -14,7 +14,7 @@ interface AccommodationSourceInterface
      * @param array<int, Coordinate> $endPoints
      * @param list<string>           $enabledTypes
      *
-     * @return list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, source: string, wikidataId: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, openingHours: ?string}>
+     * @return list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, stars: ?int, capacity: ?int, fee: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, source: string, wikidataId: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, openingHours: ?string}>
      */
     public function fetch(array $endPoints, int $radiusMeters, array $enabledTypes): array;
 

--- a/api/src/AccommodationSource/AccommodationSourceRegistry.php
+++ b/api/src/AccommodationSource/AccommodationSourceRegistry.php
@@ -31,7 +31,7 @@ class AccommodationSourceRegistry
      * @param array<int, Coordinate> $endPoints
      * @param list<string>           $enabledTypes
      *
-     * @return list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, source: string, wikidataId: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, openingHours: ?string}>
+     * @return list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, stars: ?int, capacity: ?int, fee: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, source: string, wikidataId: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, openingHours: ?string}>
      */
     public function fetchAll(array $endPoints, int $radiusMeters, array $enabledTypes): array
     {
@@ -47,7 +47,7 @@ class AccommodationSourceRegistry
             }
         }
 
-        /** @var list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, source: string, wikidataId: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, openingHours: ?string}> $deduped */
+        /** @var list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, stars: ?int, capacity: ?int, fee: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, source: string, wikidataId: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, openingHours: ?string}> $deduped */
         $deduped = $this->deduplicator->dedupe($all);
 
         return $deduped;

--- a/api/src/AccommodationSource/DataTourismeAccommodationSource.php
+++ b/api/src/AccommodationSource/DataTourismeAccommodationSource.php
@@ -82,6 +82,9 @@ final readonly class DataTourismeAccommodationSource implements AccommodationSou
                 'capacity' => $accommodation['capacity'],
                 'fee' => null,
                 'tagCount' => \count($filledAttributes),
+                // Necessarily false today: `$url` above is null until #872 adds the
+                // website column. Derived from `$url` rather than written as `false`
+                // so it starts reporting the truth the moment that column lands.
                 'hasWebsite' => null !== $url,
                 'tags' => [],
                 'source' => 'datatourisme',

--- a/api/src/AccommodationSource/DataTourismeAccommodationSource.php
+++ b/api/src/AccommodationSource/DataTourismeAccommodationSource.php
@@ -27,7 +27,7 @@ final readonly class DataTourismeAccommodationSource implements AccommodationSou
      * @param array<int, Coordinate> $endPoints
      * @param list<string>           $enabledTypes
      *
-     * @return list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, source: string, wikidataId: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, openingHours: ?string}>
+     * @return list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, stars: ?int, capacity: ?int, fee: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, source: string, wikidataId: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, openingHours: ?string}>
      */
     public function fetch(array $endPoints, int $radiusMeters, array $enabledTypes = TripRequest::ALL_ACCOMMODATION_TYPES): array
     {
@@ -56,6 +56,17 @@ final readonly class DataTourismeAccommodationSource implements AccommodationSou
                 $isExact = $pricing['isExact'];
             }
 
+            // The flux publishes fields, not OSM tags, and tourism.accommodations has
+            // no website column: `tagCount` counts the attributes actually filled for
+            // this entry and `hasWebsite` follows the URL we can expose, so neither is
+            // a hardcoded constant penalising the curated source (#869).
+            /** @var ?string $url tourism.accommodations exposes no website column yet */
+            $url = null;
+            $filledAttributes = array_filter(
+                [$name, $accommodation['category'], $accommodation['description'], $accommodation['capacity'], $accommodation['price']],
+                static fn (string|int|float|null $value): bool => null !== $value && '' !== $value,
+            );
+
             $candidates[] = [
                 'name' => $name,
                 'type' => $accommodation['category'],
@@ -64,9 +75,14 @@ final readonly class DataTourismeAccommodationSource implements AccommodationSou
                 'priceMin' => $priceMin,
                 'priceMax' => $priceMax,
                 'isExact' => $isExact,
-                'url' => null,
-                'tagCount' => 0,
-                'hasWebsite' => false,
+                'url' => $url,
+                // The flux carries no star rating and no fee flag; capacity
+                // (allowedPersons) is a real column and feeds the ranking.
+                'stars' => null,
+                'capacity' => $accommodation['capacity'],
+                'fee' => null,
+                'tagCount' => \count($filledAttributes),
+                'hasWebsite' => null !== $url,
                 'tags' => [],
                 'source' => 'datatourisme',
                 'wikidataId' => null,

--- a/api/src/AccommodationSource/OsmAccommodationSource.php
+++ b/api/src/AccommodationSource/OsmAccommodationSource.php
@@ -21,7 +21,7 @@ final readonly class OsmAccommodationSource implements AccommodationSourceInterf
      * @param array<int, Coordinate> $endPoints
      * @param list<string>           $enabledTypes
      *
-     * @return list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, source: string, wikidataId: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, openingHours: ?string}>
+     * @return list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, stars: ?int, capacity: ?int, fee: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, source: string, wikidataId: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, openingHours: ?string}>
      */
     public function fetch(array $endPoints, int $radiusMeters, array $enabledTypes = TripRequest::ALL_ACCOMMODATION_TYPES): array
     {
@@ -44,7 +44,14 @@ final readonly class OsmAccommodationSource implements AccommodationSourceInterf
             }
 
             $tags = $accommodation['tags'];
-            $pricing = $this->pricingEngine->estimatePrice($accommodation['category'], $tags);
+            // stars / fee are indexed columns, not just raw tags: the heuristic
+            // uses them (ADR-040 §45), the ranking scores them (#869).
+            $pricing = $this->pricingEngine->estimatePrice(
+                $accommodation['category'],
+                $tags,
+                $accommodation['stars'],
+                $accommodation['fee'],
+            );
 
             $candidates[] = [
                 'name' => $name,
@@ -55,6 +62,9 @@ final readonly class OsmAccommodationSource implements AccommodationSourceInterf
                 'priceMax' => $pricing['max'],
                 'isExact' => $pricing['isExact'],
                 'url' => $accommodation['website'] ?? ($tags['contact:website'] ?? null),
+                'stars' => $accommodation['stars'],
+                'capacity' => $accommodation['capacity'],
+                'fee' => $accommodation['fee'],
                 'tagCount' => \count($tags),
                 'hasWebsite' => null !== $accommodation['website'] || isset($tags['contact:website']),
                 'tags' => $tags,

--- a/api/src/Engine/PricingHeuristicEngine.php
+++ b/api/src/Engine/PricingHeuristicEngine.php
@@ -22,33 +22,75 @@ final readonly class PricingHeuristicEngine
 
     private const float BIKEPACKER_CAMP_SITE_MAX = 15.0;
 
+    /** `fee` values meaning "this place charges nothing" (OSM `fee=no`). */
+    private const array FREE_FEE_VALUES = ['no', 'false'];
+
+    /**
+     * Stars above this rating lift the bracket floor; 1 and 2 stars stay on it.
+     * ADR-013 §13.2 only distinguished `stars > 2`.
+     */
+    private const int STAR_BASELINE = 2;
+
+    /** Share of the bracket span each star above the baseline adds to the floor. */
+    private const float STAR_FLOOR_LIFT_PER_STAR = 0.25;
+
+    /** A 5-star entry keeps a bracket rather than collapsing onto its ceiling. */
+    private const float MAX_STAR_FLOOR_LIFT = 0.75;
+
     /**
      * Returns estimated price range for an accommodation type.
-     * If an exact charge tag is provided, returns it as both min and max.
+     * If an exact charge tag or a numeric indexed `fee` is provided, returns it as
+     * both min and max; `fee=no` prices the entry as free.
      * Recognises backpack=yes and tents=yes as bikepacker-friendly signals for camp_site.
+     * A known star rating lifts the bracket floor (ADR-040 §45: heuristic is
+     * type/region/**stars**), so a 4-star hotel is not budgeted like a 1-star one.
      *
      * @param array<string, string> $osmTags OSM tags for the accommodation element
+     * @param ?int                  $stars   indexed star rating (osm.accommodations.stars)
+     * @param ?string               $fee     indexed fee (osm.accommodations.fee, filled with `fee` or `charge`)
      *
      * @return array{min: float, max: float, isExact: bool}
      */
-    public function estimatePrice(string $accommodationType, array $osmTags = []): array
+    public function estimatePrice(string $accommodationType, array $osmTags = [], ?int $stars = null, ?string $fee = null): array
     {
-        // Exact price from OSM `charge` tag (e.g. "15 EUR")
-        if (isset($osmTags['charge'])) {
-            $price = $this->parseChargeTag($osmTags['charge']);
+        // Exact price from the OSM `charge` tag (e.g. "15 EUR"), or from the
+        // indexed `fee` column, which the provisioner fills with `fee` or `charge`.
+        foreach ([$osmTags['charge'] ?? null, $fee] as $rawPrice) {
+            $price = null !== $rawPrice ? $this->parseChargeTag($rawPrice) : null;
             if (null !== $price) {
                 return ['min' => $price, 'max' => $price, 'isExact' => true];
             }
         }
 
+        // `fee=no` is a statement, not a missing value: the entry is free.
+        if (null !== $fee && \in_array(mb_strtolower(trim($fee)), self::FREE_FEE_VALUES, true)) {
+            return ['min' => 0.0, 'max' => 0.0, 'isExact' => true];
+        }
+
         $bracket = self::PRICE_BRACKETS[$accommodationType] ?? self::PRICE_BRACKETS['hotel'];
+        $max = $bracket['max'];
 
         // Bikepacker-friendly camp sites (backpack=yes or tents=yes) tend to be cheaper
         if ('camp_site' === $accommodationType && ('yes' === ($osmTags['backpack'] ?? null) || 'yes' === ($osmTags['tents'] ?? null))) {
-            return ['min' => $bracket['min'], 'max' => self::BIKEPACKER_CAMP_SITE_MAX, 'isExact' => false];
+            $max = self::BIKEPACKER_CAMP_SITE_MAX;
         }
 
-        return ['min' => $bracket['min'], 'max' => $bracket['max'], 'isExact' => false];
+        return ['min' => $this->applyStars($bracket['min'], $max, $stars), 'max' => $max, 'isExact' => false];
+    }
+
+    /**
+     * Raises the bracket floor within the bracket span, proportionally to the
+     * stars above the baseline; the ceiling is unchanged.
+     */
+    private function applyStars(float $min, float $max, ?int $stars): float
+    {
+        if (null === $stars || $stars <= self::STAR_BASELINE) {
+            return $min;
+        }
+
+        $lift = min(self::MAX_STAR_FLOOR_LIFT, ($stars - self::STAR_BASELINE) * self::STAR_FLOOR_LIFT_PER_STAR);
+
+        return round($min + ($max - $min) * $lift, 2);
     }
 
     private function parseChargeTag(string $charge): ?float

--- a/api/src/Geo/GeometryBasedDistributor.php
+++ b/api/src/Geo/GeometryBasedDistributor.php
@@ -20,8 +20,19 @@ final readonly class GeometryBasedDistributor implements GeometryDistributorInte
     }
 
     /**
-     * Assigns each item to the stage whose endPoint is closest.
+     * Assigns each item to the stage whose endPoint is closest, and to *every*
+     * stage tied for that distance.
      * Output keys match the input $stages keys.
+     *
+     * Stages can share an end point: a rest day copies the previous stage's end
+     * point verbatim (RestDayInsertProcessor), and so does an out-and-back. Keeping
+     * a single winner starved the later stage of every candidate — the rider slept
+     * two nights at the same place but the second night showed no accommodation at
+     * all. Two nights at one location legitimately have the same candidates, so the
+     * item goes to both rather than being split: splitting would hand each night a
+     * disjoint, worse half of the same pool and nudge the rider into changing hotel
+     * without moving. Only an exact tie duplicates — the shared coordinate is the
+     * same value, so the two distances are the same double.
      *
      * @template T of array{lat: float, lon: float, ...}
      *
@@ -42,7 +53,7 @@ final readonly class GeometryBasedDistributor implements GeometryDistributorInte
         }
 
         foreach ($items as $item) {
-            $closestStage = 0;
+            $closestStages = [];
             $closestDistance = \PHP_FLOAT_MAX;
 
             foreach ($stages as $i => $stage) {
@@ -54,11 +65,19 @@ final readonly class GeometryBasedDistributor implements GeometryDistributorInte
                 );
                 if ($distance < $closestDistance) {
                     $closestDistance = $distance;
-                    $closestStage = $i;
+                    $closestStages = [$i];
+
+                    continue;
+                }
+
+                if ($distance === $closestDistance) {
+                    $closestStages[] = $i;
                 }
             }
 
-            $result[$closestStage][] = $item;
+            foreach ($closestStages as $i) {
+                $result[$i][] = $item;
+            }
         }
 
         return $result;

--- a/api/src/MessageHandler/ScanAccommodationsHandler.php
+++ b/api/src/MessageHandler/ScanAccommodationsHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\MessageHandler;
 
+use App\Accommodation\CandidateRanker;
 use App\Accommodation\SeasonalityCheckerInterface;
 use App\AccommodationSource\AccommodationSourceRegistry;
 use App\ApiResource\Model\Accommodation;
@@ -30,7 +31,16 @@ final readonly class ScanAccommodationsHandler extends AbstractTripMessageHandle
 {
     private const float DEDUP_DISTANCE_METERS = 200.0;
 
-    private const int MAX_CANDIDATES_PER_STAGE = 3;
+    /**
+     * Candidates retained per stage. Raised from 3 to 5 with the completeness
+     * ranking (#869): the per-family diversity guard spends one of the slots on
+     * the minority family, so three left the rider two real options for a whole
+     * night; and the pool is bounded upstream at 30 rows per end point (#868), so
+     * five still keeps a 6x margin. The panel renders the list (re-sorted by
+     * distance client-side) and has no fixed number of cards, so widening the
+     * choice costs two JSONB entries per stage and no layout change.
+     */
+    private const int MAX_CANDIDATES_PER_STAGE = 5;
 
     public function __construct(
         ComputationTrackerInterface $computationTracker,
@@ -42,6 +52,7 @@ final readonly class ScanAccommodationsHandler extends AbstractTripMessageHandle
         private GeoDistanceInterface $haversine,
         private GeometryDistributorInterface $distributor,
         private SeasonalityCheckerInterface $seasonalityChecker,
+        private CandidateRanker $ranker,
         private TranslatorInterface $translator,
         MessageBusInterface $messageBus,
     ) {
@@ -78,18 +89,18 @@ final readonly class ScanAccommodationsHandler extends AbstractTripMessageHandle
             $allCandidates = $this->registry->fetchAll($endPoints, $radiusMeters, $enabledAccommodationTypes);
 
             // Distribute candidates to their nearest stage endpoint (output keys match $stagesToProcess keys)
-            /** @var array<int, list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, source?: string, wikidataId?: ?string, description?: ?string, imageUrl?: ?string, wikipediaUrl?: ?string, openingHours?: ?string}>> $candidatesByStage */
+            /** @var array<int, list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, stars?: ?int, capacity?: ?int, fee?: ?string, source?: string, wikidataId?: ?string, description?: ?string, imageUrl?: ?string, wikipediaUrl?: ?string, openingHours?: ?string}>> $candidatesByStage */
             $candidatesByStage = $this->distributor->distributeByEndpoint($allCandidates, $stagesToProcess);
 
-            // Deduplicate + limit per stage. Prices are already set by each
-            // source at fetch time: structured open data (DataTourisme
-            // priceSpecification, OSM charge/fee) or the PricingHeuristicEngine
-            // fallback (type/region). No live HTML scraping (ADR-040).
+            // Deduplicate, then rank + limit per stage. Prices are already set by
+            // each source at fetch time: structured open data (DataTourisme
+            // priceSpecification, OSM charge/fee/stars) or the
+            // PricingHeuristicEngine fallback (type/region/stars). No live HTML
+            // scraping (ADR-040). Ranking is by completeness with price as the
+            // tiebreaker, plus a per-family diversity guard — see CandidateRanker.
             $retainedByStage = [];
             foreach ($candidatesByStage as $i => $candidates) {
-                $deduped = $this->deduplicate($candidates);
-                usort($deduped, static fn (array $a, array $b): int => $a['priceMin'] <=> $b['priceMin']);
-                $retainedByStage[$i] = \array_slice($deduped, 0, self::MAX_CANDIDATES_PER_STAGE);
+                $retainedByStage[$i] = $this->ranker->rank($this->deduplicate($candidates), self::MAX_CANDIDATES_PER_STAGE);
             }
 
             // Wikidata enrichment (description, image, Wikipedia URL) is baked into
@@ -225,9 +236,9 @@ final readonly class ScanAccommodationsHandler extends AbstractTripMessageHandle
     }
 
     /**
-     * @param list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, source?: string, wikidataId?: ?string, description?: ?string, imageUrl?: ?string, wikipediaUrl?: ?string, openingHours?: ?string}> $accommodations
+     * @param list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, stars?: ?int, capacity?: ?int, fee?: ?string, source?: string, wikidataId?: ?string, description?: ?string, imageUrl?: ?string, wikipediaUrl?: ?string, openingHours?: ?string}> $accommodations
      *
-     * @return list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, source?: string, wikidataId?: ?string, description?: ?string, imageUrl?: ?string, wikipediaUrl?: ?string, openingHours?: ?string}>
+     * @return list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, stars?: ?int, capacity?: ?int, fee?: ?string, source?: string, wikidataId?: ?string, description?: ?string, imageUrl?: ?string, wikipediaUrl?: ?string, openingHours?: ?string}>
      */
     private function deduplicate(array $accommodations): array
     {

--- a/api/src/Osm/AccommodationRepository.php
+++ b/api/src/Osm/AccommodationRepository.php
@@ -17,10 +17,10 @@ final readonly class AccommodationRepository implements AccommodationRepositoryI
 {
     /**
      * Rows kept per stage end point. ScanAccommodationsHandler retains
-     * MAX_CANDIDATES_PER_STAGE = 3 per stage after cross-source deduplication and
-     * the price ranking, so 30 leaves a 10x margin while bounding the scan: a
+     * MAX_CANDIDATES_PER_STAGE = 5 per stage after cross-source deduplication and
+     * the completeness ranking, so 30 leaves a 6x margin while bounding the scan: a
      * 15 km radius over a dense area otherwise rapatriates every row — and its
-     * full `tags` jsonb — for three kept per stage.
+     * full `tags` jsonb — for five kept per stage.
      */
     private const int MAX_ROWS_PER_POINT = 30;
 

--- a/api/src/Tourism/AccommodationRepository.php
+++ b/api/src/Tourism/AccommodationRepository.php
@@ -18,8 +18,8 @@ final readonly class AccommodationRepository implements AccommodationRepositoryI
 {
     /**
      * Rows kept per stage end point. ScanAccommodationsHandler retains
-     * MAX_CANDIDATES_PER_STAGE = 3 per stage after cross-source deduplication and
-     * the price ranking, so 30 leaves a 10x margin. It replaces the flat
+     * MAX_CANDIDATES_PER_STAGE = 5 per stage after cross-source deduplication and
+     * the completeness ranking, so 30 leaves a 6x margin. It replaces the flat
      * `LIMIT 200`, which both starved long trips and truncated non
      * deterministically for lack of an ORDER BY.
      */

--- a/api/tests/Unit/Accommodation/CandidateRankerTest.php
+++ b/api/tests/Unit/Accommodation/CandidateRankerTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Accommodation;
+
+use App\Accommodation\CandidateRanker;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class CandidateRankerTest extends TestCase
+{
+    private CandidateRanker $ranker;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->ranker = new CandidateRanker();
+    }
+
+    #[Test]
+    public function ranksTheDocumentedCandidateAboveTheCheaperBareOne(): void
+    {
+        $ranked = $this->ranker->rank([
+            $this->candidate('Abri', 'shelter', priceMin: 0.0),
+            $this->candidate(
+                'Hotel',
+                'hotel',
+                priceMin: 90.0,
+                url: 'https://hotel.example',
+                hasWebsite: true,
+                description: 'Hôtel avec garage à vélos',
+                stars: 3,
+            ),
+        ], 5);
+
+        self::assertSame(['Hotel', 'Abri'], array_column($ranked, 'name'));
+    }
+
+    #[Test]
+    public function pricesBreakCompletenessTies(): void
+    {
+        $ranked = $this->ranker->rank([
+            $this->candidate('Gîte cher', 'guest_house', priceMin: 80.0),
+            $this->candidate('Gîte abordable', 'guest_house', priceMin: 40.0),
+        ], 5);
+
+        self::assertSame(['Gîte abordable', 'Gîte cher'], array_column($ranked, 'name'));
+    }
+
+    #[Test]
+    public function tagRichnessCannotOutweighADescribedEntry(): void
+    {
+        // 30 OSM tags are capped at 2 points, below the 3 points of a description:
+        // the curated DataTourisme entry is not evicted by tag volume alone (#869).
+        $ranked = $this->ranker->rank([
+            $this->candidate('OSM verbeux', 'hotel', priceMin: 50.0, tagCount: 30),
+            $this->candidate('Fiche décrite', 'hotel', priceMin: 50.0, description: 'Une vraie description'),
+        ], 5);
+
+        self::assertSame(['Fiche décrite', 'OSM verbeux'], array_column($ranked, 'name'));
+    }
+
+    #[Test]
+    public function reservesOneSlotForTheOtherFamily(): void
+    {
+        $candidates = [];
+        foreach (range(1, 6) as $i) {
+            $candidates[] = $this->candidate(\sprintf('Hotel %d', $i), 'hotel', priceMin: 50.0, hasWebsite: true, description: 'Décrit');
+        }
+
+        $candidates[] = $this->candidate('Camping', 'camp_site', priceMin: 12.0);
+
+        $names = array_column($this->ranker->rank($candidates, 5), 'name');
+
+        self::assertCount(5, $names);
+        self::assertContains('Camping', $names);
+        self::assertCount(4, array_filter($names, static fn (string $name): bool => str_starts_with($name, 'Hotel ')));
+    }
+
+    #[Test]
+    public function givesTheReservedSlotBackWhenOnlyOneFamilyIsAround(): void
+    {
+        $candidates = [];
+        foreach (range(1, 6) as $i) {
+            $candidates[] = $this->candidate(\sprintf('Hotel %d', $i), 'hotel', priceMin: 50.0 + $i);
+        }
+
+        $names = array_column($this->ranker->rank($candidates, 5), 'name');
+
+        self::assertSame(['Hotel 1', 'Hotel 2', 'Hotel 3', 'Hotel 4', 'Hotel 5'], $names);
+    }
+
+    #[Test]
+    public function keepsEveryCandidateWhenFewerThanTheLimit(): void
+    {
+        $ranked = $this->ranker->rank([
+            $this->candidate('Camping', 'camp_site', priceMin: 12.0),
+            $this->candidate('Hotel', 'hotel', priceMin: 50.0),
+        ], 5);
+
+        self::assertCount(2, $ranked);
+    }
+
+    #[Test]
+    public function isStableOnFullTiesSoTwoRunsRetainTheSameSet(): void
+    {
+        $candidates = [];
+        foreach (range(1, 8) as $i) {
+            $candidates[] = $this->candidate(\sprintf('Gîte %d', $i), 'guest_house', priceMin: 40.0);
+        }
+
+        $first = array_column($this->ranker->rank($candidates, 5), 'name');
+        $second = array_column($this->ranker->rank($candidates, 5), 'name');
+
+        self::assertSame($first, $second);
+        // Full ties keep the caller's order, which is the deterministic KNN order
+        // of the repositories (nearest first, primary-key tiebreak; #868).
+        self::assertSame(['Gîte 1', 'Gîte 2', 'Gîte 3', 'Gîte 4', 'Gîte 5'], $first);
+    }
+
+    #[Test]
+    public function scoresStarsAndCapacityFromTheIndexedColumns(): void
+    {
+        $ranked = $this->ranker->rank([
+            $this->candidate('Sans données', 'hotel', priceMin: 50.0),
+            $this->candidate('Avec étoiles et capacité', 'hotel', priceMin: 50.0, stars: 2, capacity: 40),
+        ], 5);
+
+        self::assertSame(['Avec étoiles et capacité', 'Sans données'], array_column($ranked, 'name'));
+    }
+
+    /**
+     * @return array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, stars: ?int, capacity: ?int, fee: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, source: string, wikidataId: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, openingHours: ?string}
+     */
+    private function candidate(
+        string $name,
+        string $type,
+        float $priceMin,
+        ?string $url = null,
+        bool $hasWebsite = false,
+        ?string $description = null,
+        ?string $openingHours = null,
+        ?string $wikidataId = null,
+        ?int $stars = null,
+        ?int $capacity = null,
+        int $tagCount = 2,
+    ): array {
+        return [
+            'name' => $name,
+            'type' => $type,
+            'lat' => 48.6,
+            'lon' => 2.6,
+            'priceMin' => $priceMin,
+            'priceMax' => $priceMin + 10.0,
+            'isExact' => false,
+            'url' => $url,
+            'stars' => $stars,
+            'capacity' => $capacity,
+            'fee' => null,
+            'tagCount' => $tagCount,
+            'hasWebsite' => $hasWebsite,
+            'tags' => [],
+            'source' => 'osm',
+            'wikidataId' => $wikidataId,
+            'description' => $description,
+            'imageUrl' => null,
+            'wikipediaUrl' => null,
+            'openingHours' => $openingHours,
+        ];
+    }
+}

--- a/api/tests/Unit/AccommodationSource/DataTourismeAccommodationSourceTest.php
+++ b/api/tests/Unit/AccommodationSource/DataTourismeAccommodationSourceTest.php
@@ -77,4 +77,56 @@ final class DataTourismeAccommodationSourceTest extends TestCase
         self::assertCount(1, $result);
         self::assertSame('Gîte du Lac', $result[0]['name']);
     }
+
+    #[Test]
+    public function countsTheAttributesTheFluxActuallyFilled(): void
+    {
+        // `tagCount` used to be hardcoded to 0, which penalised the curated source on
+        // the only quality signals available (#869). It now counts the filled fields:
+        // name + category for the bare entry, plus description/capacity/price.
+        $repository = $this->createStub(AccommodationRepositoryInterface::class);
+        $repository->method('findNear')->willReturn([
+            ['name' => 'Fiche complète', 'category' => 'hotel', 'lat' => 48.0, 'lon' => 2.0, 'capacity' => 12, 'price' => 75.0, 'description' => 'Décrit'],
+            ['name' => 'Fiche nue', 'category' => 'hotel', 'lat' => 48.1, 'lon' => 2.1, 'capacity' => null, 'price' => null, 'description' => null],
+        ]);
+
+        $result = new DataTourismeAccommodationSource($repository, new PricingHeuristicEngine())
+            ->fetch([new Coordinate(48.0, 2.0)], 5000, ['hotel']);
+
+        self::assertSame(5, $result[0]['tagCount']);
+        self::assertSame(2, $result[1]['tagCount']);
+    }
+
+    #[Test]
+    public function derivesHasWebsiteFromTheExposedUrl(): void
+    {
+        // tourism.accommodations has no website column, so there is no URL to expose
+        // and `hasWebsite` follows it instead of being asserted.
+        $repository = $this->createStub(AccommodationRepositoryInterface::class);
+        $repository->method('findNear')->willReturn([
+            ['name' => 'Hôtel du Parc', 'category' => 'hotel', 'lat' => 48.0, 'lon' => 2.0, 'capacity' => null, 'price' => null, 'description' => null],
+        ]);
+
+        $result = new DataTourismeAccommodationSource($repository, new PricingHeuristicEngine())
+            ->fetch([new Coordinate(48.0, 2.0)], 5000, ['hotel']);
+
+        self::assertNull($result[0]['url']);
+        self::assertFalse($result[0]['hasWebsite']);
+    }
+
+    #[Test]
+    public function propagatesCapacityAndLeavesStarsAndFeeUnknown(): void
+    {
+        $repository = $this->createStub(AccommodationRepositoryInterface::class);
+        $repository->method('findNear')->willReturn([
+            ['name' => 'Gîte du Lac', 'category' => 'apartment', 'lat' => 48.0, 'lon' => 2.0, 'capacity' => 4, 'price' => null, 'description' => null],
+        ]);
+
+        $result = new DataTourismeAccommodationSource($repository, new PricingHeuristicEngine())
+            ->fetch([new Coordinate(48.0, 2.0)], 5000, ['apartment']);
+
+        self::assertSame(4, $result[0]['capacity']);
+        self::assertNull($result[0]['stars']);
+        self::assertNull($result[0]['fee']);
+    }
 }

--- a/api/tests/Unit/AccommodationSource/OsmAccommodationSourceTest.php
+++ b/api/tests/Unit/AccommodationSource/OsmAccommodationSourceTest.php
@@ -153,6 +153,43 @@ final class OsmAccommodationSourceTest extends TestCase
     }
 
     #[Test]
+    public function propagatesStarsCapacityAndFeeToTheCandidate(): void
+    {
+        // The three columns were selected by the repository and dropped here before
+        // #869; the ranking scores them and the heuristic prices on stars.
+        $source = $this->createSource($this->repository([$this->row(stars: 4, capacity: 30, fee: 'yes')]));
+
+        $results = $source->fetch([new Coordinate(48.5, 2.5)], 5000, ['hotel']);
+
+        $this->assertSame(4, $results[0]['stars']);
+        $this->assertSame(30, $results[0]['capacity']);
+        $this->assertSame('yes', $results[0]['fee']);
+    }
+
+    #[Test]
+    public function fetchPricesAStarredHotelAboveAnUnratedOne(): void
+    {
+        $unrated = $this->createSource($this->repository([$this->row()]))
+            ->fetch([new Coordinate(48.5, 2.5)], 5000, ['hotel']);
+        $starred = $this->createSource($this->repository([$this->row(stars: 4)]))
+            ->fetch([new Coordinate(48.5, 2.5)], 5000, ['hotel']);
+
+        $this->assertSame(50.0, $unrated[0]['priceMin']);
+        $this->assertSame(85.0, $starred[0]['priceMin']);
+    }
+
+    #[Test]
+    public function fetchPricesAFeeFreeEntryAsFree(): void
+    {
+        $results = $this->createSource($this->repository([$this->row(category: 'camp_site', fee: 'no')]))
+            ->fetch([new Coordinate(48.5, 2.5)], 5000, ['camp_site']);
+
+        $this->assertSame(0.0, $results[0]['priceMin']);
+        $this->assertSame(0.0, $results[0]['priceMax']);
+        $this->assertTrue($results[0]['isExact']);
+    }
+
+    #[Test]
     public function fetchPassesPointsRadiusAndEnabledTypesToRepository(): void
     {
         $repository = $this->createStub(AccommodationRepositoryInterface::class);
@@ -188,15 +225,18 @@ final class OsmAccommodationSourceTest extends TestCase
         ?string $website = null,
         ?string $wikidata = null,
         array $tags = [],
+        ?int $stars = null,
+        ?int $capacity = null,
+        ?string $fee = null,
     ): array {
         return [
             'name' => $name,
             'category' => $category,
             'lat' => 48.6,
             'lon' => 2.6,
-            'stars' => null,
-            'capacity' => null,
-            'fee' => null,
+            'stars' => $stars,
+            'capacity' => $capacity,
+            'fee' => $fee,
             'website' => $website,
             'wikidata' => $wikidata,
             'openingHours' => null,

--- a/api/tests/Unit/Engine/PricingHeuristicEngineTest.php
+++ b/api/tests/Unit/Engine/PricingHeuristicEngineTest.php
@@ -165,4 +165,81 @@ final class PricingHeuristicEngineTest extends TestCase
         $this->assertSame(10.0, $result['max']);
         $this->assertFalse($result['isExact']);
     }
+
+    /**
+     * @return iterable<string, array{?int, float}>
+     */
+    public static function hotelStarsProvider(): iterable
+    {
+        // Bracket floor lifted by 25% of the €50–€120 span per star above 2,
+        // capped at 75% so a 5-star entry keeps a range (ADR-040 §45).
+        yield 'unrated' => [null, 50.0];
+        yield '1 star' => [1, 50.0];
+        yield '2 stars' => [2, 50.0];
+        yield '3 stars' => [3, 67.5];
+        yield '4 stars' => [4, 85.0];
+        yield '5 stars' => [5, 102.5];
+    }
+
+    #[DataProvider('hotelStarsProvider')]
+    #[Test]
+    public function estimatePriceLiftsTheBracketFloorWithTheStarRating(?int $stars, float $expectedMin): void
+    {
+        $result = $this->engine->estimatePrice('hotel', [], $stars);
+
+        $this->assertSame($expectedMin, $result['min']);
+        $this->assertSame(120.0, $result['max']);
+        $this->assertFalse($result['isExact']);
+    }
+
+    #[Test]
+    public function estimatePriceCombinesTheBikepackerCapWithTheStarRating(): void
+    {
+        // The lift applies within the capped span, not the full camp_site bracket.
+        $result = $this->engine->estimatePrice('camp_site', ['backpack' => 'yes'], 4);
+
+        $this->assertSame(11.5, $result['min']);
+        $this->assertSame(15.0, $result['max']);
+        $this->assertFalse($result['isExact']);
+    }
+
+    #[Test]
+    public function estimatePriceLeavesAStarRatingWithoutEffectOnAZeroWidthBracket(): void
+    {
+        $result = $this->engine->estimatePrice('shelter', [], 5);
+
+        $this->assertSame(0.0, $result['min']);
+        $this->assertSame(0.0, $result['max']);
+    }
+
+    #[Test]
+    public function estimatePricePricesAFeeFreeEntryAsFree(): void
+    {
+        $result = $this->engine->estimatePrice('camp_site', [], null, 'no');
+
+        $this->assertSame(0.0, $result['min']);
+        $this->assertSame(0.0, $result['max']);
+        $this->assertTrue($result['isExact']);
+    }
+
+    #[Test]
+    public function estimatePriceUsesANumericFeeColumnAsAnExactPrice(): void
+    {
+        // The provisioner fills `fee` with the OSM `fee` or `charge` tag.
+        $result = $this->engine->estimatePrice('camp_site', [], null, '18 EUR');
+
+        $this->assertSame(18.0, $result['min']);
+        $this->assertSame(18.0, $result['max']);
+        $this->assertTrue($result['isExact']);
+    }
+
+    #[Test]
+    public function estimatePriceKeepsTheBracketForAFeeYesEntry(): void
+    {
+        $result = $this->engine->estimatePrice('camp_site', [], null, 'yes');
+
+        $this->assertSame(8.0, $result['min']);
+        $this->assertSame(25.0, $result['max']);
+        $this->assertFalse($result['isExact']);
+    }
 }

--- a/api/tests/Unit/Geo/GeometryBasedDistributorTest.php
+++ b/api/tests/Unit/Geo/GeometryBasedDistributorTest.php
@@ -43,6 +43,48 @@ final class GeometryBasedDistributorTest extends TestCase
     }
 
     #[Test]
+    public function distributeByEndpointGivesCoincidentStagesTheSameItems(): void
+    {
+        // A rest day copies the previous stage's end point verbatim
+        // (RestDayInsertProcessor), so two stages share the same location. Both
+        // sleep there, so both must receive the candidates found around it: a
+        // strictly-closer comparison gave them all to the first stage and starved
+        // the rest day (#869).
+        $sharedEnd = new Coordinate(45.5, 5.5);
+        $stages = [
+            new Stage('trip-1', 1, 80.0, 500.0, new Coordinate(45.0, 5.0), $sharedEnd),
+            new Stage('trip-1', 2, 0.0, 0.0, $sharedEnd, $sharedEnd, geometry: [$sharedEnd], isRestDay: true),
+            new Stage('trip-1', 3, 80.0, 500.0, $sharedEnd, new Coordinate(46.0, 6.0)),
+        ];
+
+        $shared = [['lat' => 45.51, 'lon' => 5.51], ['lat' => 45.49, 'lon' => 5.49]];
+        $far = ['lat' => 45.99, 'lon' => 5.99];
+        // Interleaved on purpose: no insertion order can produce the expected
+        // per-stage lists by accident.
+        $items = [$shared[0], $far, $shared[1]];
+
+        $result = $this->distributor->distributeByEndpoint($items, $stages);
+
+        $this->assertSame($shared, $result[0]);
+        $this->assertSame($shared, $result[1], 'the rest day shares the location, so it shares the candidates');
+        $this->assertSame([$far], $result[2]);
+    }
+
+    #[Test]
+    public function distributeByEndpointKeepsItemsExclusiveWhenOneStageIsStrictlyCloser(): void
+    {
+        $stages = [
+            new Stage('trip-1', 1, 80.0, 500.0, new Coordinate(45.0, 5.0), new Coordinate(45.5, 5.5)),
+            new Stage('trip-1', 2, 80.0, 500.0, new Coordinate(45.5, 5.5), new Coordinate(46.0, 6.0)),
+        ];
+
+        $result = $this->distributor->distributeByEndpoint([['lat' => 45.51, 'lon' => 5.51]], $stages);
+
+        $this->assertCount(1, $result[0]);
+        $this->assertCount(0, $result[1]);
+    }
+
+    #[Test]
     public function distributeByEndpointWithEmptyItems(): void
     {
         $stages = [

--- a/api/tests/Unit/MessageHandler/ScanAccommodationsHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/ScanAccommodationsHandlerTest.php
@@ -13,7 +13,9 @@ use App\ApiResource\Stage;
 use App\ComputationTracker\ComputationTrackerInterface;
 use App\ComputationTracker\TripGenerationTrackerInterface;
 use App\Geo\GeoDistanceInterface;
+use App\Geo\GeometryBasedDistributor;
 use App\Geo\GeometryDistributorInterface;
+use App\Geo\HaversineDistance;
 use App\Mercure\MercureEventType;
 use App\Mercure\TripUpdatePublisherInterface;
 use App\Message\ScanAccommodations;
@@ -751,6 +753,67 @@ final class ScanAccommodationsHandlerTest extends TestCase
 
         self::assertSame($first, $second);
         self::assertSame(['Gîte 1', 'Gîte 2', 'Gîte 3', 'Gîte 4', 'Gîte 5'], $first);
+    }
+
+    #[Test]
+    public function aRestDayGetsTheSameRankedCandidatesAsTheNightBefore(): void
+    {
+        // Real distributor and real ranker: a rest day shares the previous stage's
+        // end point, so both nights must see the same ranked selection, diversity
+        // guard included — not an empty list on the second night (#869).
+        $sharedEnd = new Coordinate(48.5, 2.5);
+        $stage = new Stage('trip-rest', 1, 80.0, 500.0, new Coordinate(48.0, 2.0), $sharedEnd);
+        $restDay = new Stage('trip-rest', 2, 0.0, 0.0, $sharedEnd, $sharedEnd, geometry: [$sharedEnd], isRestDay: true);
+
+        $candidates = [];
+        foreach (range(1, 6) as $i) {
+            $candidates[] = $this->candidate(
+                \sprintf('Hotel %d', $i),
+                'hotel',
+                priceMin: 60.0 + $i,
+                url: 'https://hotel.example',
+                hasWebsite: true,
+                description: 'Chambres confortables',
+            );
+        }
+
+        $candidates[] = $this->candidate('Camping Municipal', 'camp_site', priceMin: 12.0);
+
+        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
+        $tripStateManager->method('getStages')->willReturn([$stage, $restDay]);
+        $tripStateManager->method('getLocale')->willReturn('en');
+        $tripStateManager->method('getRequest')->willReturn(null);
+
+        $registry = $this->createStub(AccommodationSourceRegistry::class);
+        $registry->method('fetchAll')->willReturn($candidates);
+
+        $published = [];
+        $publisher = $this->createStub(TripUpdatePublisherInterface::class);
+        $publisher->method('publish')->willReturnCallback(
+            static function (string $id, MercureEventType $type, array $payload) use (&$published): void {
+                /** @var list<array{name: string}> $accommodations */
+                $accommodations = $payload['accommodations'];
+                /** @var int $stageIndex */
+                $stageIndex = $payload['stageIndex'];
+                $published[$stageIndex] = array_column($accommodations, 'name');
+            },
+        );
+
+        $haversine = new HaversineDistance();
+        $handler = $this->createHandler(
+            $tripStateManager,
+            $publisher,
+            $registry,
+            $haversine,
+            new GeometryBasedDistributor($haversine),
+        );
+        $handler(new ScanAccommodations('trip-rest'));
+
+        self::assertArrayHasKey(1, $published);
+        self::assertSame($published[0], $published[1], 'both nights are spent at the same place');
+        self::assertCount(5, $published[1]);
+        self::assertContains('Camping Municipal', $published[1]);
+        self::assertCount(4, array_filter($published[1], static fn (string $name): bool => str_starts_with($name, 'Hotel ')));
     }
 
     /**

--- a/api/tests/Unit/MessageHandler/ScanAccommodationsHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/ScanAccommodationsHandlerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\MessageHandler;
 
+use App\Accommodation\CandidateRanker;
 use App\Accommodation\SeasonalityCheckerInterface;
 use App\AccommodationSource\AccommodationSourceRegistry;
 use App\ApiResource\Model\Accommodation;
@@ -68,6 +69,7 @@ final class ScanAccommodationsHandlerTest extends TestCase
             $haversine,
             $distributor,
             $seasonalityChecker,
+            new CandidateRanker(),
             $translator,
             $this->createStub(MessageBusInterface::class),
         );
@@ -674,5 +676,158 @@ final class ScanAccommodationsHandlerTest extends TestCase
 
         $handler = $this->createHandler($tripStateManager, $publisher, $registry, $haversine, $distributor);
         $handler(new ScanAccommodations('trip-source'));
+    }
+
+    #[Test]
+    public function retainsTheDocumentedHotelOverTheCheapestBareCandidates(): void
+    {
+        // Six bare shelters at €0 and one hotel with website, description and stars:
+        // ranking on price alone filled every slot with the shelters and dropped the
+        // hotel. Completeness ranking retains it, and the family cap leaves the
+        // shelters four of the five slots (#869).
+        $candidates = [];
+        foreach (range(1, 6) as $i) {
+            $candidates[] = $this->candidate(\sprintf('Abri %d', $i), 'shelter', priceMin: 0.0);
+        }
+
+        $candidates[] = $this->candidate(
+            'Hotel Documenté',
+            'hotel',
+            priceMin: 90.0,
+            url: 'https://hotel.example',
+            hasWebsite: true,
+            description: 'Hôtel de charme avec garage à vélos',
+            openingHours: 'Mo-Su 07:00-22:00',
+            stars: 3,
+        );
+
+        $names = $this->publishedNames('trip-ranking', $candidates);
+
+        self::assertSame('Hotel Documenté', $names[0], 'the documented hotel must be retained, and ranked first');
+        self::assertCount(5, $names);
+        self::assertCount(4, array_filter($names, static fn (string $name): bool => str_starts_with($name, 'Abri ')));
+    }
+
+    #[Test]
+    public function diversityGuardKeepsACampSiteAmongDocumentedHotels(): void
+    {
+        // Six fully documented hotels would win every slot on completeness alone:
+        // the per-family cap reserves one for the outdoor family, so the stage never
+        // returns hotels only (#869).
+        $candidates = [];
+        foreach (range(1, 6) as $i) {
+            $candidates[] = $this->candidate(
+                \sprintf('Hotel %d', $i),
+                'hotel',
+                priceMin: 60.0 + $i,
+                url: 'https://hotel.example',
+                hasWebsite: true,
+                description: 'Chambres confortables',
+                stars: 4,
+                capacity: 20,
+            );
+        }
+
+        $candidates[] = $this->candidate('Camping Municipal', 'camp_site', priceMin: 12.0);
+
+        $names = $this->publishedNames('trip-diversity', $candidates);
+
+        self::assertContains('Camping Municipal', $names);
+        self::assertCount(4, array_filter($names, static fn (string $name): bool => str_starts_with($name, 'Hotel ')));
+    }
+
+    #[Test]
+    public function rankingIsReproducibleAcrossRunsAndStableOnTies(): void
+    {
+        // Same completeness, same price: the retained order must be the (deterministic,
+        // nearest-first) order the repositories produced, on every run (#868/#869).
+        $candidates = [];
+        foreach (range(1, 6) as $i) {
+            $candidates[] = $this->candidate(\sprintf('Gîte %d', $i), 'guest_house', priceMin: 40.0);
+        }
+
+        $first = $this->publishedNames('trip-reproducible', $candidates);
+        $second = $this->publishedNames('trip-reproducible', $candidates);
+
+        self::assertSame($first, $second);
+        self::assertSame(['Gîte 1', 'Gîte 2', 'Gîte 3', 'Gîte 4', 'Gîte 5'], $first);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function candidate(
+        string $name,
+        string $type,
+        float $priceMin,
+        ?string $url = null,
+        bool $hasWebsite = false,
+        ?string $description = null,
+        ?string $openingHours = null,
+        ?int $stars = null,
+        ?int $capacity = null,
+    ): array {
+        return [
+            'name' => $name,
+            'type' => $type,
+            'lat' => 48.6,
+            'lon' => 2.6,
+            'priceMin' => $priceMin,
+            'priceMax' => $priceMin + 10.0,
+            'isExact' => false,
+            'url' => $url,
+            'stars' => $stars,
+            'capacity' => $capacity,
+            'fee' => null,
+            'tagCount' => 2,
+            'hasWebsite' => $hasWebsite,
+            'tags' => [],
+            'source' => 'osm',
+            'wikidataId' => null,
+            'description' => $description,
+            'openingHours' => $openingHours,
+        ];
+    }
+
+    /**
+     * Runs a full scan over the given candidates and returns the retained names, in
+     * the order the handler published them.
+     *
+     * @param list<array<string, mixed>> $candidates
+     *
+     * @return list<string>
+     */
+    private function publishedNames(string $tripId, array $candidates): array
+    {
+        $stage = $this->createStage($tripId, 48.5, 2.5);
+
+        $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
+        $tripStateManager->method('getStages')->willReturn([$stage]);
+        $tripStateManager->method('getLocale')->willReturn('en');
+        $tripStateManager->method('getRequest')->willReturn(null);
+
+        $registry = $this->createStub(AccommodationSourceRegistry::class);
+        $registry->method('fetchAll')->willReturn([]);
+
+        $distributor = $this->createStub(GeometryDistributorInterface::class);
+        $distributor->method('distributeByEndpoint')->willReturn([0 => $candidates]);
+
+        $haversine = $this->createStub(GeoDistanceInterface::class);
+        $haversine->method('inKilometers')->willReturn(1.0);
+
+        $published = [];
+        $publisher = $this->createStub(TripUpdatePublisherInterface::class);
+        $publisher->method('publish')->willReturnCallback(
+            static function (string $id, MercureEventType $type, array $payload) use (&$published): void {
+                /** @var list<array{name: string}> $accommodations */
+                $accommodations = $payload['accommodations'];
+                $published = array_column($accommodations, 'name');
+            },
+        );
+
+        $handler = $this->createHandler($tripStateManager, $publisher, $registry, $haversine, $distributor);
+        $handler(new ScanAccommodations($tripId));
+
+        return $published;
     }
 }


### PR DESCRIPTION
Closes #869

> **PR empilée** : base `feature/868` (PR #905). À merger **après** #905. Déjà rebasée sur les deux tours de correction de #905.

## Contexte

Seuls 3 candidats étaient retenus par étape, et le seul critère de tri était le prix minimum — or le prix vient très majoritairement de `PricingHeuristicEngine` (type et région), pas d'une donnée réelle. Le tri favorisait donc mécaniquement les catégories à heuristique basse (abris, campings) et écartait les fiches riches et réservables. En parallèle, `tagCount` / `hasWebsite` traversaient tout le pipeline sans jamais être lus, et `stars` / `capacity` / `fee` étaient sélectionnés par la requête puis abandonnés.

## Décisions demandées par l'issue

### Scope 2 — score de complétude primaire, prix secondaire

`api/src/Accommodation/CandidateRanker.php` additionne des signaux réellement observés : site exploitable 3, description 3, `openingHours` 2, `wikidata` 2, `stars` 2, `capacity` 1, plus la richesse de tags OSM `intdiv(tagCount, 3)` **plafonnée à 2 points**.

Le plafond est le point clé : sans lui, un signal OSM-only domine une fiche DataTourisme décrite (qui vaut 3 points à elle seule). Le prix ne départage que les ex æquo.

Rejeté : le classement **par bandes de prix**, qui aurait réintroduit une hiérarchie fondée sur une valeur heuristique — exactement le défaut que l'issue corrige.

### Scope 3 — garde de diversité : plafond par famille de `limit - 1`

Deux familles : `outdoor` (`camp_site`, `shelter`, `wilderness_hut`) et `indoor` (tout le reste). Avec 5 places, 4 au maximum par famille, donc au moins une place revient à l'autre famille si elle a un candidat. Si une seule famille est présente autour de l'étape, la place réservée est rendue au classement — pas de sous-remplissage.

Rejeté :

- **plafond par source** — DataTourisme est France-only, le garde serait inopérant hors France alors que le risque d'éviction y est identique ;
- **plafond par type** — hotel + guest_house + motel font 3 types mais une seule famille : le camping serait quand même évincé.

### Scope 5 — `stars` / `capacity` / `fee`

Les trois sont propagés jusqu'au classement. Côté tarification j'ai exploité `stars` et `fee`, **pas** `capacity` :

- le plancher du bracket monte de 25 % de son amplitude par étoile au-dessus de 2, plafonné à 75 % (hôtel : 50 → 67,5 / 85 / 102,5 €, plafond 120 € inchangé). C'est ADR-013 §13.2 généralisé, sans toucher la valeur des non-notés — donc ADR-040 §45 est enfin honoré ;
- `fee` numérique → prix exact (le provisioner remplit `fee = tags.fee or tags.charge`), `fee=no` → gratuit exact ;
- `capacity` n'a pas de relation défendable au prix : elle sert au score, pas à la tarification.

### Scope 4 — DataTourisme

`tagCount` compte les attributs réellement remplis par le flux (nom, catégorie, description, capacité, prix → 2 à 5). `hasWebsite` dérive de l'URL exposée ; `tourism.accommodations` n'a **pas** de colonne `website` (vérifié : migration `Version20260616120000` ; les colonnes d'enrichissement de `Version20260617130000` ne concernent que `cultural_pois` / `food_pois`), donc la valeur reste `false` — mais **calculée**, plus codée en dur. C'est le sprint 46 (#872) qui la remplira.

La requête `Tourism/AccommodationRepository` n'est **pas** modifiée : la réécriture KNN de #868 reste intacte et `capacity` y était déjà sélectionnée.

### Scope 6 — `MAX_CANDIDATES_PER_STAGE` : 3 → 5

Le garde consomme une place sur les trois, il ne restait donc que deux options réelles pour une nuit. Le pool est borné en amont par #868, donc 5 conserve une marge confortable. `accommodation-panel.tsx` rend la liste entière (re-triée par distance côté client) sans nombre de cartes fixe : le coût est de deux entrées JSONB par étape et zéro changement de layout. Revert = une constante si tu préfères 3.

## Ajout de périmètre : le jour de repos ne recevait aucun hébergement

Découvert par la revue de #905, corrigé ici sur décision du mainteneur — le fichier appartient à ce périmètre.

`GeometryBasedDistributor::distributeByEndpoint` utilisait `if ($distance < $closestDistance)` avec `$closestStage = 0` par défaut : sur **égalité stricte**, la clé la plus basse gagnait et les suivantes gardaient `[]`. Or `RestDayInsertProcessor` construit le jour de repos avec `startPoint: $afterStage->endPoint, endPoint: $afterStage->endPoint`, **la même instance `Coordinate`** : les deux étapes ont des `endPoint` identiques au bit près, et aucun mécanisme amont ne fusionne les étapes coïncidentes. La première raflait tous les candidats, la seconde recevait **zéro hébergement**.

Le chemin est bien emprunté : `ScanAccommodationsHandler` ne restreint `$stagesToProcess` que si `stageIndex` est fourni, et deux appelants dispatchent **sans** — `TripUpdateProcessor::dispatchAccommodationsScan` (PATCH du voyage, par exemple un changement des types d'hébergement) et `TripAnalysisDispatcher::dispatch` (utilisé par `TripBatchRecomputeProcessor`, `AnalyzeTripProcessor`, `GpxUploadService`, `GenerateStagesHandler`).

**Aggravant :** en scan complet, le handler fait `$stage->accommodations = []` puis persiste. Un jour de repos qui avait des hébergements obtenus par un scan mono-étape (`AccommodationScanProcessor`, `StageSelectAccommodationProcessor`, `ComputationDependencyResolver`) les **perdait** au premier scan global.

### Comportement retenu : les mêmes candidats aux deux étapes, pas un partage

L'item est attribué à **toutes** les étapes ex æquo pour la distance minimale.

- **Produit** : un jour de repos, on dort deux nuits au même endroit. Partager le vivier donnerait à chaque nuit une moitié disjointe et moins bonne du même ensemble, et pousserait le voyageur à changer d'hôtel sans avoir bougé. `selectedAccommodation` étant par étape, il peut choisir le même établissement pour les deux nuits — encore faut-il qu'il apparaisse dans les deux listes.
- **Cohérence avec le classement** : les deux étapes reçoivent le même vivier, donc `CandidateRanker` produit le même quintet dans le même ordre et le garde de diversité s'applique identiquement (vérifié : 4 hôtels + `Camping Municipal` sur les deux nuits, `$published[0] === $published[1]`).
- **Égalité flottante** : seule une égalité **exacte** duplique, ce qui est sûr ici puisque la coordonnée partagée est la même valeur, donc les deux distances Haversine sont le même `double`. Un aller-retour à quelques mètres près reste attribué à une seule étape — comportement inchangé, volontairement.

**Portée limitée :** `distributeByEndpoint` n'a qu'un seul consommateur, `ScanAccommodationsHandler`. `distributeByGeometry` **garde** son `<` strict — il alimente POI, points d'eau, bacs, gués et événements, où dupliquer un élément croisé en route sur deux jours est une autre question (un nudge déjeuner sur un jour de repos, par exemple) et où personne n'est privé d'une nuit. C'est écrit dans le docblock.

### Rouge avant correctif

```
1) ScanAccommodationsHandlerTest::aRestDayGetsTheSameRankedCandidatesAsTheNightBefore
both nights are spent at the same place
-    2 => 'Hotel 3',  3 => 'Hotel 4',  4 => 'Camping Municipal',
+Array &0 []
2) GeometryBasedDistributorTest::distributeByEndpointGivesCoincidentStagesTheSameItems
the rest day shares the location, so it shares the candidates
-Array &0 [ 0 => ['lat' => 45.51, 'lon' => 5.51], 1 => ['lat' => 45.49, 'lon' => 5.49] ]
+Array &0 []
Tests: 24, Assertions: 84, Failures: 2.
```

Piège de fixtures évité : dans le test du distributeur les items sont **entrelacés** (`shared[0]`, `far`, `shared[1]`) et j'assère le **contenu exact** des trois listes, pas des cardinalités ; une troisième étape non coïncidente prouve que l'exclusivité normale est préservée. La mutation qui produit le rouge est la suppression de la branche d'égalité, pas un revert du fichier de test.

Aucun changement côté requête : les deux `AccommodationRepository` et `WktGeometry` sont intacts. Le SQL de #868 reste correct tel quel — le `CROSS JOIN LATERAL ... LIMIT 1` attribue les lignes du lieu partagé au premier des deux sommets identiques, la partition du second reste vide, et c'est désormais le distributeur qui rend ces 30 lignes aux deux étapes.


## Preuve que les tests peuvent échouer

1. Comparateur réduit au prix seul → 4 rouges : `ranksTheDocumentedCandidateAboveTheCheaperBareOne`, `tagRichnessCannotOutweighADescribedEntry`, `scoresStarsAndCapacityFromTheIndexedColumns`, `retainsTheDocumentedHotelOverTheCheapestBareCandidates` (`'Abri 1'` au lieu de `'Hotel Documenté'`).
2. `$perFamily = $limit` (garde retiré) → 2 rouges : `reservesOneSlotForTheOtherFamily`, `diversityGuardKeepsACampSiteAmongDocumentedHotels` (`Camping Municipal` absent).
3. Tie-break instable ajouté (`$b['name'] <=> $a['name']`) → 2 rouges : les deux tests de reproductibilité (`Gîte 8,7,6…` au lieu de `Gîte 1,2,3…`). C'est le piège rencontré sur #868 explicitement évité : les fixtures sont en ordre croissant alors que la mutation les renverse, donc l'ordre physique ne peut pas masquer l'absence de tri.
4. `stars` ignoré dans le pricing → 5 rouges, dont `fetchPricesAStarredHotelAboveAnUnratedOne` (50.0 au lieu de 85.0).
5. `tagCount => 0` refigé pour DataTourisme → `countsTheAttributesTheFluxActuallyFilled` rouge (0 au lieu de 5).

Toutes restaurées, arbre propre, PHPUnit vert après restauration.

## Vérification

Legs exécutés individuellement (`make qa` ne peut pas aboutir en local, cf. CLAUDE.md) :

- PHP-CS-Fixer : `Fixed 0 of 650 files in 0.344 seconds`
- Rector : 2 autofixes `NewlineAfterStatementRector` appliqués et commités, puis dry-run `[OK] Rector is done!`
- PHPStan niveau 9 : `[OK] No errors` — 3 erreurs corrigées à la main (deux `argument.type` sur la shape scellée de `completeness()`, un `notIdentical.alwaysFalse` dans un test)
- markdownlint (README) : `Summary: 0 error(s)`
- PHPUnit `tests/Unit` + `tests/Integration` : `Tests: 1359, Assertions: 3768, Skipped: 1` — après rebase sur la version corrigée de `feature/868` (1356 / 3758), soit +3 tests et +10 assertions pour le correctif du jour de repos

Aucun fichier `pwa/` dans le diff, donc pas de leg frontend. **Playwright : couverture CI uniquement.**

## Auto-critique

- Les pondérations du score (3/3/2/2/2/1, plafond 2) sont un jugement, pas une mesure : rien dans le dépôt ne dit qu'une description vaut une étoile et demie. Elles sont défendables et testées, pas calibrées.
- Le garde de diversité à deux familles est grossier : « indoor » regroupe l'hôtel 4 étoiles et le refuge de montagne. Une taxonomie plus fine demanderait de savoir ce que l'utilisateur cherche, ce que le modèle ne porte pas.
- `hasWebsite` reste `false` pour toute la source DataTourisme jusqu'à #872 : la source curée est donc encore pénalisée sur ce signal précis, même s'il n'est plus figé.
- Le passage de 3 à 5 candidats augmente le volume JSONB persisté par étape.

## Recoupements attendus au merge (sprint 45)

- `api/tests/Unit/AccommodationSource/DataTourismeAccommodationSourceTest.php` — #865 (PR #906) ajoute aussi un cas en fin de classe : conflit trivial, **les deux côtés se conservent**.
- `api/src/{Osm,Tourism}/AccommodationRepository.php` — seul le docblock de `MAX_ROWS_PER_POINT` change ici (marge 10x → 6x, suite au passage de 3 à 5). **Déjà résolu** : cette branche a été rebasée sur les deux tours de correction de #905, le SQL de #905 est conservé et seul le commentaire de marge a été reporté.
- `api/src/Repository/DoctrineTripRequestRepository.php` (#870, PR #907) non touché.




<!-- claude-review-start -->
## Claude Review

**Summary:** 0 findings (0 critical, 0 warning). No new findings this pass.

**Resolved threads:** 0 newly resolved — the one prior open thread (`hasWebsite` disguised-constant nit on `DataTourismeAccommodationSource.php`) was already resolved before this review.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

Commit reviewed: `855b8cb6d001cd7ba8f174574cbc8bea536999bc`
<!-- claude-review-end -->