### PR TITLE
feat(poi): use real opening hours instead of hardcoded schedules

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Rules are executed in priority order (lower = higher priority):
 | **Comfort** | -- | ![warning](https://img.shields.io/badge/-warning-ed6c02) | Poor comfort index (< 40/100) on at least one stage |
 | **Bike shops** | -- | ![nudge](https://img.shields.io/badge/-nudge-0288d1) | No repair resource within 2 km of stage midpoint (trips > 5 stages) |
 | **Resupply** | -- | ![nudge](https://img.shields.io/badge/-nudge-0288d1) | Stage >= 40 km with no food/resupply POI along the route |
-| **Resupply** | -- | ![warning](https://img.shields.io/badge/-warning-ed6c02) | All resupply POIs on the stage are closed at estimated passage time |
+| **Resupply** | -- | ![warning](https://img.shields.io/badge/-warning-ed6c02) | All resupply POIs on the stage are known to be closed at estimated passage time (a POI whose OpenStreetMap `opening_hours` is missing or unparsable is treated as unknown and suppresses the warning) |
 | **Accommodation** | -- | ![warning](https://img.shields.io/badge/-warning-ed6c02) | All detected accommodations on the stage are likely closed due to seasonality |
 | **Water points** | -- | ![nudge](https://img.shields.io/badge/-nudge-0288d1) | Stretch > 30 km without a detected drinking water source |
 | **Rest day** | 100 | ![nudge](https://img.shields.io/badge/-nudge-0288d1) | Every N consecutive cycling days without a rest day (default: every 3 days), except on the trip's last day or when the following day is already a rest day |

--- a/api/src/ApiResource/Model/CulturalPoiAlert.php
+++ b/api/src/ApiResource/Model/CulturalPoiAlert.php
@@ -15,7 +15,8 @@ use App\Enum\AlertType;
  * via the RecalculateRouteSegment Messenger message — ADR-017).
  *
  * Optional enrichment fields (openingHours, estimatedPrice, description,
- * wikidataId, source) are populated when the POI comes from DataTourisme.
+ * wikidataId, source) are populated when the POI comes from DataTourisme;
+ * website comes from the OpenStreetMap `website` tag.
  */
 final readonly class CulturalPoiAlert extends Alert
 {
@@ -37,6 +38,8 @@ final readonly class CulturalPoiAlert extends Alert
         ?AlertAction $action = null,
         #[ApiProperty(description: 'Opening hours as a human-readable string (DataTourisme only).')]
         public ?string $openingHours = null,
+        #[ApiProperty(description: 'Official website of the POI, when OpenStreetMap knows one.')]
+        public ?string $website = null,
         #[ApiProperty(description: 'Estimated entrance price in euros (DataTourisme only).')]
         public ?float $estimatedPrice = null,
         #[ApiProperty(description: 'Short description of the POI (DataTourisme only).')]

--- a/api/src/ApiResource/Model/PointOfInterest.php
+++ b/api/src/ApiResource/Model/PointOfInterest.php
@@ -22,6 +22,10 @@ final readonly class PointOfInterest
         public ?string $osmType = null,
         #[ApiProperty(description: 'OpenStreetMap object id. Null when the entry does not come from OSM.')]
         public ?int $osmId = null,
+        #[ApiProperty(description: 'Raw OpenStreetMap opening_hours value, when the POI carries one.')]
+        public ?string $openingHours = null,
+        #[ApiProperty(description: 'Official website of the POI, when OpenStreetMap knows one.')]
+        public ?string $website = null,
     ) {
     }
 }

--- a/api/src/CulturalPoiSource/CulturalPoiSourceInterface.php
+++ b/api/src/CulturalPoiSource/CulturalPoiSourceInterface.php
@@ -17,7 +17,7 @@ interface CulturalPoiSourceInterface
      *
      * @param list<list<array{lat: float, lon: float}>> $stageGeometries
      *
-     * @return list<array{name: string|null, type: string, lat: float, lon: float, osmType: string|null, osmId: int|null, openingHours: string|null, estimatedPrice: float|null, description: string|null, wikidataId: string|null, source: string, imageUrl: string|null, wikipediaUrl: string|null}>
+     * @return list<array{name: string|null, type: string, lat: float, lon: float, osmType: string|null, osmId: int|null, openingHours: string|null, website: string|null, estimatedPrice: float|null, description: string|null, wikidataId: string|null, source: string, imageUrl: string|null, wikipediaUrl: string|null}>
      */
     public function fetchForStages(array $stageGeometries, int $radiusMeters): array;
 

--- a/api/src/CulturalPoiSource/CulturalPoiSourceRegistry.php
+++ b/api/src/CulturalPoiSource/CulturalPoiSourceRegistry.php
@@ -30,7 +30,7 @@ readonly class CulturalPoiSourceRegistry
      *
      * @param list<list<array{lat: float, lon: float}>> $stageGeometries
      *
-     * @return list<array{name: string|null, type: string, lat: float, lon: float, osmType?: string|null, osmId?: int|null, openingHours?: string|null, estimatedPrice?: float|null, description?: string|null, wikidataId?: string|null, source: string, imageUrl?: string|null, wikipediaUrl?: string|null}>
+     * @return list<array{name: string|null, type: string, lat: float, lon: float, osmType?: string|null, osmId?: int|null, openingHours?: string|null, website?: string|null, estimatedPrice?: float|null, description?: string|null, wikidataId?: string|null, source: string, imageUrl?: string|null, wikipediaUrl?: string|null}>
      */
     public function fetchAllForStages(array $stageGeometries, int $radiusMeters): array
     {
@@ -46,7 +46,7 @@ readonly class CulturalPoiSourceRegistry
             }
         }
 
-        /** @var list<array{name: string|null, type: string, lat: float, lon: float, osmType?: string|null, osmId?: int|null, openingHours?: string|null, estimatedPrice?: float|null, description?: string|null, wikidataId?: string|null, source: string, imageUrl?: string|null, wikipediaUrl?: string|null}> $deduped */
+        /** @var list<array{name: string|null, type: string, lat: float, lon: float, osmType?: string|null, osmId?: int|null, openingHours?: string|null, website?: string|null, estimatedPrice?: float|null, description?: string|null, wikidataId?: string|null, source: string, imageUrl?: string|null, wikipediaUrl?: string|null}> $deduped */
         $deduped = $this->deduplicator->dedupe($all);
 
         return $deduped;

--- a/api/src/CulturalPoiSource/DataTourismeCulturalPoiSource.php
+++ b/api/src/CulturalPoiSource/DataTourismeCulturalPoiSource.php
@@ -22,7 +22,7 @@ final readonly class DataTourismeCulturalPoiSource implements CulturalPoiSourceI
     /**
      * @param list<list<array{lat: float, lon: float}>> $stageGeometries
      *
-     * @return list<array{name: string|null, type: string, lat: float, lon: float, osmType: string|null, osmId: int|null, openingHours: string|null, estimatedPrice: float|null, description: string|null, wikidataId: string|null, source: string, imageUrl: string|null, wikipediaUrl: string|null}>
+     * @return list<array{name: string|null, type: string, lat: float, lon: float, osmType: string|null, osmId: int|null, openingHours: string|null, website: string|null, estimatedPrice: float|null, description: string|null, wikidataId: string|null, source: string, imageUrl: string|null, wikipediaUrl: string|null}>
      */
     public function fetchForStages(array $stageGeometries, int $radiusMeters): array
     {
@@ -41,6 +41,8 @@ final readonly class DataTourismeCulturalPoiSource implements CulturalPoiSourceI
                 'osmType' => null,
                 'osmId' => null,
                 'openingHours' => $poi['openingHours'],
+                // The flux mapping does not carry a website for cultural POIs.
+                'website' => null,
                 'estimatedPrice' => null,
                 'description' => $poi['description'],
                 'wikidataId' => $poi['wikidata'],

--- a/api/src/CulturalPoiSource/OsmCulturalPoiSource.php
+++ b/api/src/CulturalPoiSource/OsmCulturalPoiSource.php
@@ -16,7 +16,7 @@ final readonly class OsmCulturalPoiSource implements CulturalPoiSourceInterface
     /**
      * @param list<list<array{lat: float, lon: float}>> $stageGeometries
      *
-     * @return list<array{name: string|null, type: string, lat: float, lon: float, osmType: string|null, osmId: int|null, openingHours: string|null, estimatedPrice: float|null, description: string|null, wikidataId: string|null, source: string, imageUrl: string|null, wikipediaUrl: string|null}>
+     * @return list<array{name: string|null, type: string, lat: float, lon: float, osmType: string|null, osmId: int|null, openingHours: string|null, website: string|null, estimatedPrice: float|null, description: string|null, wikidataId: string|null, source: string, imageUrl: string|null, wikipediaUrl: string|null}>
      */
     public function fetchForStages(array $stageGeometries, int $radiusMeters): array
     {
@@ -36,6 +36,7 @@ final readonly class OsmCulturalPoiSource implements CulturalPoiSourceInterface
                 'osmType' => $poi['osmType'],
                 'osmId' => $poi['osmId'],
                 'openingHours' => $poi['openingHours'],
+                'website' => $poi['website'],
                 'estimatedPrice' => null,
                 'description' => $poi['description'],
                 'wikidataId' => $poi['wikidata'],

--- a/api/src/Engine/FixedSchedule.php
+++ b/api/src/Engine/FixedSchedule.php
@@ -5,7 +5,11 @@ declare(strict_types=1);
 namespace App\Engine;
 
 /**
- * Immutable value object representing a set of fixed opening slots for a POI category.
+ * Category-typical opening slots, used **only as a fallback** when a POI carries
+ * no real `opening_hours` (OSM coverage is partial). These slots are an
+ * approximation, so callers must never let them conclude that a POI is closed —
+ * see {@see OpeningHours} for the real, parsed schedule which always takes
+ * precedence.
  *
  * Each slot is an [open, close] pair of decimal hours (e.g. 9.0 = 09:00, 13.5 = 13:30).
  * A null $slots value means "no filter" — the POI is always considered open.
@@ -18,6 +22,19 @@ final readonly class FixedSchedule
     private function __construct(
         private ?array $slots,
     ) {
+    }
+
+    /**
+     * Typical slots for a POI category, for the POIs OSM has no `opening_hours` for.
+     */
+    public static function forCategory(string $category): self
+    {
+        return match (true) {
+            \in_array($category, ['supermarket', 'convenience', 'general', 'farm', 'greengrocer', 'butcher', 'deli'], true) => self::supermarket(),
+            \in_array($category, ['restaurant', 'cafe', 'bar', 'fast_food'], true) => self::restaurant(),
+            \in_array($category, ['bakery', 'pastry'], true) => self::bakery(),
+            default => self::noFilter(),
+        };
     }
 
     /**

--- a/api/src/Engine/OpeningHours.php
+++ b/api/src/Engine/OpeningHours.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Engine;
+
+/**
+ * A deliberately small reader of the OSM `opening_hours` grammar.
+ *
+ * Only the shapes that cover the vast majority of resupply POIs are modelled:
+ * `24/7`, a bare list of time spans (`09:00-12:00,14:00-19:00`), and
+ * `;`-separated rules made of an optional weekday selector (`Mo`, `Mo-Fr`,
+ * `Mo,We,Fr`, `Mo-Fr,Su`) followed by either `off`/`closed` or time spans.
+ *
+ * Anything else — month ranges, `week`, `sunrise`, `Su[1]`, `open`, comments —
+ * makes {@see parse} return null. The value is then *unknown*, never *closed*:
+ * callers must not conclude on a string they did not understand.
+ *
+ * `PH`/`SH` (public/school holiday) rules are skipped rather than rejected.
+ * Whether a date is a public holiday is the calendar checker's business, and
+ * ignoring such an exception can only make a POI look open — the safe direction
+ * for a warning that fires when everything is closed.
+ */
+final readonly class OpeningHours
+{
+    /** @var array<string, int> ISO-8601 weekday numbers (1 = Monday). */
+    private const array WEEKDAYS = [
+        'mo' => 1, 'tu' => 2, 'we' => 3, 'th' => 4,
+        'fr' => 5, 'sa' => 6, 'su' => 7,
+    ];
+
+    /**
+     * @param array<int, list<array{open: float, close: float}>> $slotsByWeekday ISO weekday => open slots, in decimal hours
+     */
+    private function __construct(
+        private array $slotsByWeekday,
+    ) {
+    }
+
+    /**
+     * Returns null when the string is not one of the modelled shapes.
+     */
+    public static function parse(string $spec): ?self
+    {
+        $spec = trim($spec);
+
+        if ('24/7' === $spec) {
+            return new self(array_fill_keys(range(1, 7), [['open' => 0.0, 'close' => 24.0]]));
+        }
+
+        $slotsByWeekday = [];
+        $matched = false;
+
+        foreach (explode(';', $spec) as $rawRule) {
+            $rule = trim($rawRule);
+
+            if ('' === $rule) {
+                continue;
+            }
+
+            if (1 === preg_match('/^(?:PH|SH)\b/i', $rule)) {
+                continue;
+            }
+
+            $parsed = self::parseRule($rule);
+
+            if (null === $parsed) {
+                return null;
+            }
+
+            [$days, $slots] = $parsed;
+
+            foreach ($days as $day) {
+                $slotsByWeekday[$day] = $slots;
+            }
+
+            $matched = true;
+        }
+
+        if (!$matched) {
+            return null;
+        }
+
+        // Weekdays no rule mentions are closed — standard opening_hours semantics.
+        foreach (range(1, 7) as $day) {
+            $slotsByWeekday[$day] ??= [];
+        }
+
+        return new self($slotsByWeekday);
+    }
+
+    /**
+     * Tri-state openness: true = open, false = closed, null = the answer depends
+     * on the weekday and the weekday is unknown, so nothing can be concluded.
+     *
+     * @param float    $decimalHour e.g. 13.5 for 13:30
+     * @param int|null $isoWeekday  1 (Monday) to 7 (Sunday), null when the date is unknown
+     */
+    public function isOpenAt(float $decimalHour, ?int $isoWeekday = null): ?bool
+    {
+        if (null !== $isoWeekday) {
+            return $this->isWithin($this->slotsByWeekday[$isoWeekday] ?? [], $decimalHour);
+        }
+
+        $open = $this->isWithin($this->slotsByWeekday[1], $decimalHour);
+
+        foreach ($this->slotsByWeekday as $slots) {
+            if ($this->isWithin($slots, $decimalHour) !== $open) {
+                return null;
+            }
+        }
+
+        return $open;
+    }
+
+    /**
+     * A single `;`-separated rule: `[<weekday selector> ]<time spans|off>`.
+     *
+     * @return array{list<int>, list<array{open: float, close: float}>}|null
+     */
+    private static function parseRule(string $rule): ?array
+    {
+        $days = range(1, 7);
+        $rest = $rule;
+
+        if (1 === preg_match('/^((?:Mo|Tu|We|Th|Fr|Sa|Su)(?:\s*[-,]\s*(?:Mo|Tu|We|Th|Fr|Sa|Su))*)\s+(.*)$/i', $rule, $matches)) {
+            $selected = self::parseWeekdays($matches[1]);
+
+            if (null === $selected) {
+                return null;
+            }
+
+            $days = $selected;
+            $rest = trim($matches[2]);
+        }
+
+        if (\in_array(strtolower($rest), ['off', 'closed'], true)) {
+            return [$days, []];
+        }
+
+        $slots = [];
+
+        foreach (explode(',', $rest) as $rawSpan) {
+            if (1 !== preg_match('/^\s*(\d{1,2}):(\d{2})\s*-\s*(\d{1,2}):(\d{2})\s*$/', $rawSpan, $span)) {
+                return null;
+            }
+
+            $open = (int) $span[1] + (int) $span[2] / 60;
+            $close = (int) $span[3] + (int) $span[4] / 60;
+
+            if ($open > 24.0 || $close > 24.0) {
+                return null;
+            }
+
+            if ($close < $open) {
+                // Crossing midnight: the tail really belongs to the next day, but
+                // folding it back into the same day only widens the open window,
+                // which is the safe direction here.
+                $slots[] = ['open' => $open, 'close' => 24.0];
+                $slots[] = ['open' => 0.0, 'close' => $close];
+
+                continue;
+            }
+
+            $slots[] = ['open' => $open, 'close' => $close];
+        }
+
+        return [$days, $slots];
+    }
+
+    /**
+     * @return list<int>|null
+     */
+    private static function parseWeekdays(string $selector): ?array
+    {
+        $days = [];
+
+        foreach (explode(',', $selector) as $part) {
+            $part = trim($part);
+
+            if (1 === preg_match('/^([A-Za-z]{2})\s*-\s*([A-Za-z]{2})$/', $part, $range)) {
+                $from = self::WEEKDAYS[strtolower($range[1])] ?? null;
+                $to = self::WEEKDAYS[strtolower($range[2])] ?? null;
+
+                if (null === $from || null === $to) {
+                    return null;
+                }
+
+                for ($day = $from;; $day = $day % 7 + 1) {
+                    $days[] = $day;
+
+                    if ($day === $to) {
+                        break;
+                    }
+                }
+
+                continue;
+            }
+
+            $day = self::WEEKDAYS[strtolower($part)] ?? null;
+
+            if (null === $day) {
+                return null;
+            }
+
+            $days[] = $day;
+        }
+
+        return array_values(array_unique($days));
+    }
+
+    /**
+     * @param list<array{open: float, close: float}> $slots
+     */
+    private function isWithin(array $slots, float $decimalHour): bool
+    {
+        return array_any($slots, static fn (array $slot): bool => $decimalHour >= $slot['open'] && $decimalHour <= $slot['close']);
+    }
+}

--- a/api/src/Engine/OpeningHours.php
+++ b/api/src/Engine/OpeningHours.php
@@ -153,9 +153,17 @@ final readonly class OpeningHours
             }
 
             if ($close < $open) {
-                // Crossing midnight: the tail really belongs to the next day, but
-                // folding it back into the same day only widens the open window,
-                // which is the safe direction here.
+                if (7 !== \count(array_unique($days))) {
+                    // The tail belongs to the *next* day, which this reader does not
+                    // track per day. Folding it back would leave that next day with no
+                    // rule at all, hence reported as known closed during the spillover —
+                    // a closure nothing established. Unknown is the honest answer.
+                    return null;
+                }
+
+                // Crossing midnight, but every day carries the same rule, so folding the
+                // tail into the same day cannot misattribute it: the next day owns an
+                // identical slot anyway. This only widens the open window.
                 $slots[] = ['open' => $open, 'close' => 24.0];
                 $slots[] = ['open' => 0.0, 'close' => $close];
 

--- a/api/src/Geo/NearbyNameDeduplicator.php
+++ b/api/src/Geo/NearbyNameDeduplicator.php
@@ -53,11 +53,36 @@ final readonly class NearbyNameDeduplicator
             // Same place from two sources, in its first-seen position: keep the
             // curated DataTourisme entry.
             if ('datatourisme' === ($item['source'] ?? null) && 'datatourisme' !== ($kept[$match]['source'] ?? null)) {
-                $kept[$match] = $item;
+                $kept[$match] = $this->withoutLosingKnownValues($item, $kept[$match]);
             }
         }
 
         return array_values($kept);
+    }
+
+    /**
+     * The curated entry wins, but preferring a source must not destroy what the
+     * other one knew: the flux carries no website for cultural and food POIs, so
+     * a plain overwrite dropped the OSM website for every place both sources
+     * describe — precisely the ones a rider is most likely to look up.
+     *
+     * Only keys the winner leaves null are backfilled, so the winner never loses
+     * a value, and no key it does not declare is invented.
+     *
+     * @param array<string, mixed> $winner
+     * @param array<string, mixed> $loser
+     *
+     * @return array<string, mixed>
+     */
+    private function withoutLosingKnownValues(array $winner, array $loser): array
+    {
+        foreach ($winner as $key => $value) {
+            if (null === $value && null !== ($loser[$key] ?? null)) {
+                $winner[$key] = $loser[$key];
+            }
+        }
+
+        return $winner;
     }
 
     /**

--- a/api/src/MessageHandler/CheckCulturalPoisHandler.php
+++ b/api/src/MessageHandler/CheckCulturalPoisHandler.php
@@ -164,6 +164,10 @@ final readonly class CheckCulturalPoisHandler extends AbstractTripMessageHandler
                         $alert['openingHours'] = $poi['openingHours'];
                     }
 
+                    if (null !== ($poi['website'] ?? null)) {
+                        $alert['website'] = $poi['website'];
+                    }
+
                     if (null !== ($poi['estimatedPrice'] ?? null)) {
                         $alert['estimatedPrice'] = $poi['estimatedPrice'];
                     }

--- a/api/src/MessageHandler/ScanPoisHandler.php
+++ b/api/src/MessageHandler/ScanPoisHandler.php
@@ -12,6 +12,7 @@ use App\ApiResource\TripRequest;
 use App\ComputationTracker\ComputationTrackerInterface;
 use App\ComputationTracker\TripGenerationTrackerInterface;
 use App\Engine\FixedSchedule;
+use App\Engine\OpeningHours;
 use App\Engine\RiderTimeEstimatorInterface;
 use App\Enum\AlertType;
 use App\Enum\ComputationName;
@@ -76,8 +77,10 @@ final readonly class ScanPoisHandler extends AbstractTripMessageHandler
         $request = $this->tripStateManager->getRequest($tripId);
         $departureHour = $request instanceof TripRequest ? $request->departureHour : 8;
         $averageSpeed = $request instanceof TripRequest ? $request->averageSpeed : 15.0;
+        // Needed to evaluate weekday-dependent opening_hours rules ("Mo-Sa 08:00-19:00").
+        $startDate = $request instanceof TripRequest ? $request->startDate : null;
 
-        $this->executeWithTracking($tripId, ComputationName::POIS, function () use ($tripId, $stages, $locale, $departureHour, $averageSpeed): void {
+        $this->executeWithTracking($tripId, ComputationName::POIS, function () use ($tripId, $stages, $locale, $departureHour, $averageSpeed, $startDate): void {
             // Decode the route corridor from the decimated points (fallback: stage geometry).
             $decimatedData = $this->tripStateManager->getDecimatedPoints($tripId);
             $allPoints = null !== $decimatedData
@@ -105,10 +108,12 @@ final readonly class ScanPoisHandler extends AbstractTripMessageHandler
                     'category' => $poi['category'],
                     'lat' => $poi['lat'],
                     'lon' => $poi['lon'],
+                    'openingHours' => $poi['openingHours'],
+                    'website' => $poi['website'],
                 ];
             }
 
-            /** @var array<int, list<array{name: string, category: string, lat: float, lon: float}>> $poisByStage */
+            /** @var array<int, list<array{name: string, category: string, lat: float, lon: float, openingHours: string|null, website: string|null}>> $poisByStage */
             $poisByStage = $this->distributor->distributeByGeometry($allPois, $stages);
 
             $allWaterPoints = $this->waterPointRepository->findInCorridor($route, self::CORRIDOR_RADIUS_METERS);
@@ -126,6 +131,8 @@ final readonly class ScanPoisHandler extends AbstractTripMessageHandler
                         lon: $raw['lon'],
                         osmType: $raw['osmType'] ?? null,
                         osmId: $raw['osmId'] ?? null,
+                        openingHours: $raw['openingHours'],
+                        website: $raw['website'],
                     );
 
                     $stage->addPoi($poi);
@@ -147,9 +154,11 @@ final readonly class ScanPoisHandler extends AbstractTripMessageHandler
                     $alerts[] = ['type' => 'nudge', 'message' => $alert->message, 'lat' => $alert->lat, 'lon' => $alert->lon];
                 }
 
-                // Resupply timing warning: warn when all resupply POIs on this stage
-                // would be closed at the estimated rider passage time
-                if (!$stage->isRestDay && $this->hasResupplyPoi($stage) && !$this->hasAnyOpenResupplyPoi($stage, $departureHour, $averageSpeed)) {
+                // Resupply timing warning: warn when every resupply POI on this stage is
+                // *known* to be closed at the estimated rider passage time.
+                $stageDate = $startDate?->modify(\sprintf('+%d days', $i));
+
+                if (!$stage->isRestDay && $this->allResupplyPoisAreClosed($stage, $departureHour, $averageSpeed, null !== $stageDate ? (int) $stageDate->format('N') : null)) {
                     $alert = new Alert(
                         type: AlertType::WARNING,
                         message: $this->translator->trans(
@@ -216,14 +225,21 @@ final readonly class ScanPoisHandler extends AbstractTripMessageHandler
     }
 
     /**
-     * Returns true when at least one resupply POI on the stage is open
+     * Returns true only when every resupply POI on the stage is *known* to be closed
      * at the estimated rider passage time.
+     *
+     * A single POI that is open — or whose hours cannot be established — makes the
+     * stage inconclusive and suppresses the warning: it used to be raised from the
+     * category-typical slots alone, i.e. from schedules nobody had checked (#875).
+     *
+     * @param int|null $isoWeekday 1 (Monday) to 7 (Sunday), null when the trip has no start date
      */
-    private function hasAnyOpenResupplyPoi(Stage $stage, int $departureHour, float $averageSpeed): bool
+    private function allResupplyPoisAreClosed(Stage $stage, int $departureHour, float $averageSpeed, ?int $isoWeekday): bool
     {
         $geometry = $stage->geometry ?: [$stage->startPoint, $stage->endPoint];
         $cumulativeDistances = $this->supplyTimelineBuilder->buildCumulativeDistances($geometry);
         $totalDistance = $stage->distance;
+        $closed = 0;
 
         foreach ($stage->pois as $poi) {
             if (!\in_array($poi->category, self::RESUPPLY_CATEGORIES, true)) {
@@ -233,23 +249,31 @@ final readonly class ScanPoisHandler extends AbstractTripMessageHandler
             $nearestIndex = $this->supplyTimelineBuilder->findNearestGeometryIndex($geometry, $poi->lat, $poi->lon);
             $distanceFromStart = $cumulativeDistances[$nearestIndex];
             $estimatedTime = $this->riderTimeEstimator->estimateTimeAtDistance($distanceFromStart, $totalDistance, $departureHour, $averageSpeed, $stage->elevation);
-            $schedule = $this->resolveSchedule($poi->category);
 
-            if ($schedule->isOpenAt($estimatedTime)) {
-                return true;
+            if (false !== $this->isOpenAt($poi, $estimatedTime, $isoWeekday)) {
+                return false;
             }
+
+            ++$closed;
         }
 
-        return false;
+        return $closed > 0;
     }
 
-    private function resolveSchedule(string $category): FixedSchedule
+    /**
+     * Tri-state openness of a POI: true = open, false = closed, null = unknown.
+     *
+     * The real OSM `opening_hours` wins whenever it is present and understood.
+     * Without it, the category-typical {@see FixedSchedule} is only allowed to
+     * answer "probably open" — never "closed", which would put an invented
+     * schedule behind a user-facing warning.
+     */
+    private function isOpenAt(PointOfInterest $poi, float $decimalHour, ?int $isoWeekday): ?bool
     {
-        return match (true) {
-            \in_array($category, ['supermarket', 'convenience', 'general', 'farm', 'greengrocer', 'butcher', 'deli'], true) => FixedSchedule::supermarket(),
-            \in_array($category, ['restaurant', 'cafe', 'bar', 'fast_food'], true) => FixedSchedule::restaurant(),
-            \in_array($category, ['bakery', 'pastry'], true) => FixedSchedule::bakery(),
-            default => FixedSchedule::noFilter(),
-        };
+        if (null !== $poi->openingHours) {
+            return OpeningHours::parse($poi->openingHours)?->isOpenAt($decimalHour, $isoWeekday);
+        }
+
+        return FixedSchedule::forCategory($poi->category)->isOpenAt($decimalHour) ? true : null;
     }
 }

--- a/api/src/Osm/CulturalPoiRepository.php
+++ b/api/src/Osm/CulturalPoiRepository.php
@@ -22,7 +22,7 @@ final readonly class CulturalPoiRepository implements CulturalPoiRepositoryInter
      *
      * @param list<array{lat: float, lon: float}> $route
      *
-     * @return list<array{osmType: ?string, osmId: ?int, name: ?string, category: string, lat: float, lon: float, wikidata: ?string, openingHours: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string}>
+     * @return list<array{osmType: ?string, osmId: ?int, name: ?string, category: string, lat: float, lon: float, wikidata: ?string, openingHours: ?string, website: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string}>
      */
     public function findInCorridor(array $route, int $radiusMeters): array
     {
@@ -38,7 +38,7 @@ final readonly class CulturalPoiRepository implements CulturalPoiRepositoryInter
         /** @var list<array<string, scalar|null>> $rows */
         $rows = $this->connection->fetchAllAssociative(
             <<<'SQL'
-                SELECT osm_type, osm_id, name, category, wikidata, opening_hours, description, image_url, wikipedia_url,
+                SELECT osm_type, osm_id, name, category, wikidata, opening_hours, website, description, image_url, wikipedia_url,
                        ST_Y(geom) AS lat, ST_X(geom) AS lon
                 FROM osm.cultural_pois
                 WHERE ST_DWithin(
@@ -68,6 +68,7 @@ final readonly class CulturalPoiRepository implements CulturalPoiRepositoryInter
                 'lon' => (float) $row['lon'],
                 'wikidata' => null !== $row['wikidata'] && '' !== $row['wikidata'] ? (string) $row['wikidata'] : null,
                 'openingHours' => null !== $row['opening_hours'] && '' !== $row['opening_hours'] ? (string) $row['opening_hours'] : null,
+                'website' => null !== $row['website'] && '' !== $row['website'] ? (string) $row['website'] : null,
                 'description' => null !== $row['description'] && '' !== $row['description'] ? (string) $row['description'] : null,
                 'imageUrl' => null !== $row['image_url'] && '' !== $row['image_url'] ? (string) $row['image_url'] : null,
                 'wikipediaUrl' => null !== $row['wikipedia_url'] && '' !== $row['wikipedia_url'] ? (string) $row['wikipedia_url'] : null,

--- a/api/src/Osm/CulturalPoiRepositoryInterface.php
+++ b/api/src/Osm/CulturalPoiRepositoryInterface.php
@@ -12,7 +12,7 @@ interface CulturalPoiRepositoryInterface
      *
      * @param list<array{lat: float, lon: float}> $route
      *
-     * @return list<array{osmType: ?string, osmId: ?int, name: ?string, category: string, lat: float, lon: float, wikidata: ?string, openingHours: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string}>
+     * @return list<array{osmType: ?string, osmId: ?int, name: ?string, category: string, lat: float, lon: float, wikidata: ?string, openingHours: ?string, website: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string}>
      */
     public function findInCorridor(array $route, int $radiusMeters): array;
 }

--- a/api/src/Osm/PoiRepository.php
+++ b/api/src/Osm/PoiRepository.php
@@ -22,7 +22,7 @@ final readonly class PoiRepository implements PoiRepositoryInterface
      *
      * @param list<array{lat: float, lon: float}> $route
      *
-     * @return list<array{osmType: ?string, osmId: ?int, name: ?string, category: string, lat: float, lon: float}>
+     * @return list<array{osmType: ?string, osmId: ?int, name: ?string, category: string, lat: float, lon: float, openingHours: ?string, website: ?string}>
      */
     public function findInCorridor(array $route, int $radiusMeters): array
     {
@@ -33,7 +33,7 @@ final readonly class PoiRepository implements PoiRepositoryInterface
         /** @var list<array<string, scalar|null>> $rows */
         $rows = $this->connection->fetchAllAssociative(
             <<<'SQL'
-                SELECT osm_type, osm_id, name, category, ST_Y(geom) AS lat, ST_X(geom) AS lon
+                SELECT osm_type, osm_id, name, category, opening_hours, website, ST_Y(geom) AS lat, ST_X(geom) AS lon
                 FROM osm.pois
                 WHERE ST_DWithin(
                     geom::geography,
@@ -58,6 +58,8 @@ final readonly class PoiRepository implements PoiRepositoryInterface
                 'category' => (string) $row['category'],
                 'lat' => (float) $row['lat'],
                 'lon' => (float) $row['lon'],
+                'openingHours' => null !== $row['opening_hours'] && '' !== $row['opening_hours'] ? (string) $row['opening_hours'] : null,
+                'website' => null !== $row['website'] && '' !== $row['website'] ? (string) $row['website'] : null,
             ];
         }
 

--- a/api/src/Osm/PoiRepositoryInterface.php
+++ b/api/src/Osm/PoiRepositoryInterface.php
@@ -11,7 +11,7 @@ interface PoiRepositoryInterface
      *
      * @param list<array{lat: float, lon: float}> $route
      *
-     * @return list<array{osmType: ?string, osmId: ?int, name: ?string, category: string, lat: float, lon: float}>
+     * @return list<array{osmType: ?string, osmId: ?int, name: ?string, category: string, lat: float, lon: float, openingHours: ?string, website: ?string}>
      */
     public function findInCorridor(array $route, int $radiusMeters): array;
 }

--- a/api/src/Poi/DataTourismeFoodPoiSource.php
+++ b/api/src/Poi/DataTourismeFoodPoiSource.php
@@ -31,6 +31,9 @@ final readonly class DataTourismeFoodPoiSource implements PoiSourceInterface
                 // A curated entry has no OSM identity: there is no join key from the flux.
                 'osmType' => null,
                 'osmId' => null,
+                'openingHours' => $poi['openingHours'],
+                // The flux mapping does not carry a website for food POIs.
+                'website' => null,
                 'wikidataId' => $poi['wikidata'],
                 'source' => 'datatourisme',
             ];

--- a/api/src/Poi/OsmPoiSource.php
+++ b/api/src/Poi/OsmPoiSource.php
@@ -28,6 +28,8 @@ final readonly class OsmPoiSource implements PoiSourceInterface
                 'lon' => $poi['lon'],
                 'osmType' => $poi['osmType'],
                 'osmId' => $poi['osmId'],
+                'openingHours' => $poi['openingHours'],
+                'website' => $poi['website'],
                 'wikidataId' => null,
                 'source' => 'osm',
             ];

--- a/api/src/Poi/PoiSourceInterface.php
+++ b/api/src/Poi/PoiSourceInterface.php
@@ -22,7 +22,7 @@ interface PoiSourceInterface
      *
      * @param list<array{lat: float, lon: float}> $route
      *
-     * @return list<array{name: string|null, category: string, lat: float, lon: float, osmType: string|null, osmId: int|null, wikidataId: string|null, source: string}>
+     * @return list<array{name: string|null, category: string, lat: float, lon: float, osmType: string|null, osmId: int|null, openingHours: string|null, website: string|null, wikidataId: string|null, source: string}>
      */
     public function fetchInCorridor(array $route, int $radiusMeters): array;
 }

--- a/api/src/Poi/PoiSourceRegistry.php
+++ b/api/src/Poi/PoiSourceRegistry.php
@@ -29,7 +29,7 @@ readonly class PoiSourceRegistry
      *
      * @param list<array{lat: float, lon: float}> $route
      *
-     * @return list<array{name: string|null, category: string, lat: float, lon: float, osmType: string|null, osmId: int|null, wikidataId: string|null, source: string}>
+     * @return list<array{name: string|null, category: string, lat: float, lon: float, osmType: string|null, osmId: int|null, openingHours: string|null, website: string|null, wikidataId: string|null, source: string}>
      */
     public function fetchAllInCorridor(array $route, int $radiusMeters): array
     {
@@ -40,7 +40,7 @@ readonly class PoiSourceRegistry
             }
         }
 
-        /** @var list<array{name: string|null, category: string, lat: float, lon: float, osmType: string|null, osmId: int|null, wikidataId: string|null, source: string}> $deduped */
+        /** @var list<array{name: string|null, category: string, lat: float, lon: float, osmType: string|null, osmId: int|null, openingHours: string|null, website: string|null, wikidataId: string|null, source: string}> $deduped */
         $deduped = $this->deduplicator->dedupe($all);
 
         return $deduped;

--- a/api/src/Poi/SupplyTimelineBuilder.php
+++ b/api/src/Poi/SupplyTimelineBuilder.php
@@ -68,9 +68,9 @@ final readonly class SupplyTimelineBuilder
      * Computes the distance from stage start for each supply point and returns
      * them sorted by distance.
      *
-     * @param list<Coordinate>                                                         $geometry
-     * @param list<float>                                                              $cumulativeDistances
-     * @param list<array{name: string|null, category: string, lat: float, lon: float}> $items
+     * @param list<Coordinate>                                                              $geometry
+     * @param list<float>                                                                   $cumulativeDistances
+     * @param list<array{name: string|null, category: string, lat: float, lon: float, ...}> $items               only these four keys are read; callers may carry more
      *
      * @return list<array{name: string|null, category: string, lat: float, lon: float, distanceFromStart: float}>
      */

--- a/api/src/Repository/DoctrineTripRequestRepository.php
+++ b/api/src/Repository/DoctrineTripRequestRepository.php
@@ -782,7 +782,7 @@ final class DoctrineTripRequestRepository extends ServiceEntityRepository implem
         );
     }
 
-    /** @return array{name: string, category: string, lat: float, lon: float, distanceFromStart: ?float, osmType: ?string, osmId: ?int} */
+    /** @return array{name: string, category: string, lat: float, lon: float, distanceFromStart: ?float, osmType: ?string, osmId: ?int, openingHours: ?string, website: ?string} */
     private function poiToArray(PointOfInterest $poi): array
     {
         return [
@@ -795,10 +795,12 @@ final class DoctrineTripRequestRepository extends ServiceEntityRepository implem
             // exactly as the accommodation enrichment fields did before issue #870.
             'osmType' => $poi->osmType,
             'osmId' => $poi->osmId,
+            'openingHours' => $poi->openingHours,
+            'website' => $poi->website,
         ];
     }
 
-    /** @param array{name: string, category: string, lat: float, lon: float, distanceFromStart?: ?float, osmType?: ?string, osmId?: ?int} $data */
+    /** @param array{name: string, category: string, lat: float, lon: float, distanceFromStart?: ?float, osmType?: ?string, osmId?: ?int, openingHours?: ?string, website?: ?string} $data */
     private function arrayToPoi(array $data): PointOfInterest
     {
         return new PointOfInterest(
@@ -809,6 +811,8 @@ final class DoctrineTripRequestRepository extends ServiceEntityRepository implem
             distanceFromStart: $data['distanceFromStart'] ?? null,
             osmType: $data['osmType'] ?? null,
             osmId: $data['osmId'] ?? null,
+            openingHours: $data['openingHours'] ?? null,
+            website: $data['website'] ?? null,
         );
     }
 

--- a/api/tests/Integration/Osm/CulturalPoiIndexReadTest.php
+++ b/api/tests/Integration/Osm/CulturalPoiIndexReadTest.php
@@ -34,10 +34,10 @@ final class CulturalPoiIndexReadTest extends KernelTestCase
         // A museum (with wikidata + provisioner-enriched columns) and a castle on
         // the corridor; a far museum (~50 km).
         $this->connection->executeStatement(<<<'SQL'
-            INSERT INTO osm.cultural_pois (osm_type, osm_id, name, category, wikidata, description, opening_hours, image_url, wikipedia_url, tags, geom) VALUES
-              ('n', 1, 'Louvre', 'museum', 'Q19675', 'Art museum', '09:00-18:00', 'https://img.test/louvre.jpg', 'https://fr.wikipedia.org/wiki/Louvre', '{}'::jsonb, ST_SetSRID(ST_MakePoint(6.14, 49.61), 4326)),
-              ('n', 2, 'Château', 'castle', NULL, NULL, NULL, NULL, NULL, '{}'::jsonb, ST_SetSRID(ST_MakePoint(6.145, 49.615), 4326)),
-              ('n', 3, 'Musée Lointain', 'museum', NULL, NULL, NULL, NULL, NULL, '{}'::jsonb, ST_SetSRID(ST_MakePoint(6.80, 49.90), 4326))
+            INSERT INTO osm.cultural_pois (osm_type, osm_id, name, category, wikidata, description, opening_hours, website, image_url, wikipedia_url, tags, geom) VALUES
+              ('n', 1, 'Louvre', 'museum', 'Q19675', 'Art museum', '09:00-18:00', 'https://louvre.test', 'https://img.test/louvre.jpg', 'https://fr.wikipedia.org/wiki/Louvre', '{}'::jsonb, ST_SetSRID(ST_MakePoint(6.14, 49.61), 4326)),
+              ('n', 2, 'Château', 'castle', NULL, NULL, NULL, NULL, NULL, NULL, '{}'::jsonb, ST_SetSRID(ST_MakePoint(6.145, 49.615), 4326)),
+              ('n', 3, 'Musée Lointain', 'museum', NULL, NULL, NULL, NULL, NULL, NULL, '{}'::jsonb, ST_SetSRID(ST_MakePoint(6.80, 49.90), 4326))
             SQL);
     }
 
@@ -61,10 +61,12 @@ final class CulturalPoiIndexReadTest extends KernelTestCase
         // Provisioner-enriched columns are surfaced by the read layer (ADR-041).
         self::assertSame('Art museum', $byName['Louvre']['description']);
         self::assertSame('09:00-18:00', $byName['Louvre']['openingHours']);
+        self::assertSame('https://louvre.test', $byName['Louvre']['website']);
         self::assertSame('https://img.test/louvre.jpg', $byName['Louvre']['imageUrl']);
         self::assertSame('https://fr.wikipedia.org/wiki/Louvre', $byName['Louvre']['wikipediaUrl']);
         self::assertSame('castle', $byName['Château']['category']);
         self::assertNull($byName['Château']['wikidata']);
+        self::assertNull($byName['Château']['website']);
         self::assertNull($byName['Château']['imageUrl']);
         self::assertArrayNotHasKey('Musée Lointain', $byName);
     }

--- a/api/tests/Integration/Osm/OsmRepositoriesTest.php
+++ b/api/tests/Integration/Osm/OsmRepositoriesTest.php
@@ -59,6 +59,32 @@ final class OsmRepositoriesTest extends KernelTestCase
     }
 
     #[Test]
+    public function poiRepositoryReadsOpeningHoursAndWebsite(): void
+    {
+        $this->connection->executeStatement(<<<'SQL'
+            INSERT INTO osm.pois (osm_type, osm_id, name, category, opening_hours, website, tags, geom) VALUES
+              ('n', 8001, 'Boulangerie', 'bakery', 'Tu-Su 07:00-13:00', 'https://boulangerie.test', '{}'::jsonb, ST_SetSRID(ST_MakePoint(6.14, 49.61), 4326)),
+              ('n', 8002, 'Épicerie', 'convenience', NULL, '', '{}'::jsonb, ST_SetSRID(ST_MakePoint(6.141, 49.611), 4326))
+            SQL);
+
+        $pois = new PoiRepository($this->connection)->findInCorridor([
+            ['lat' => 49.60, 'lon' => 6.13],
+            ['lat' => 49.62, 'lon' => 6.15],
+        ], 2000);
+
+        $byName = [];
+        foreach ($pois as $poi) {
+            $byName[(string) $poi['name']] = $poi;
+        }
+
+        self::assertSame('Tu-Su 07:00-13:00', $byName['Boulangerie']['openingHours']);
+        self::assertSame('https://boulangerie.test', $byName['Boulangerie']['website']);
+        // A missing tag and an empty string both mean "unknown", never "closed".
+        self::assertNull($byName['Épicerie']['openingHours']);
+        self::assertNull($byName['Épicerie']['website']);
+    }
+
+    #[Test]
     public function waterPointRepositoryReturnsPotablePointsWithinTheCorridor(): void
     {
         $this->seedWaterPoint('drinking_water', 49.61, 6.14);

--- a/api/tests/Unit/CulturalPoiSource/OsmCulturalPoiSourceTest.php
+++ b/api/tests/Unit/CulturalPoiSource/OsmCulturalPoiSourceTest.php
@@ -80,12 +80,13 @@ final class OsmCulturalPoiSourceTest extends TestCase
     public function propagatesEnrichmentColumnsFromRepository(): void
     {
         $source = $this->makeSource($this->repository([
-            ['name' => 'Louvre', 'category' => 'museum', 'lat' => 48.2, 'lon' => 2.2, 'wikidata' => 'Q19675', 'openingHours' => '09:00-18:00', 'description' => 'Art museum', 'imageUrl' => 'https://img.test/louvre.jpg', 'wikipediaUrl' => 'https://fr.wikipedia.org/wiki/Louvre'],
+            ['name' => 'Louvre', 'category' => 'museum', 'lat' => 48.2, 'lon' => 2.2, 'wikidata' => 'Q19675', 'openingHours' => '09:00-18:00', 'website' => 'https://louvre.test', 'description' => 'Art museum', 'imageUrl' => 'https://img.test/louvre.jpg', 'wikipediaUrl' => 'https://fr.wikipedia.org/wiki/Louvre'],
         ]));
 
         $poi = $source->fetchForStages($this->stageGeometries(), 500)[0];
 
         self::assertSame('09:00-18:00', $poi['openingHours']);
+        self::assertSame('https://louvre.test', $poi['website']);
         self::assertSame('Art museum', $poi['description']);
         self::assertSame('https://img.test/louvre.jpg', $poi['imageUrl']);
         self::assertSame('https://fr.wikipedia.org/wiki/Louvre', $poi['wikipediaUrl']);
@@ -142,7 +143,7 @@ final class OsmCulturalPoiSourceTest extends TestCase
     {
         // Default the provisioner-enriched columns the read layer now returns.
         $rows = array_map(
-            static fn (array $row): array => $row + ['osmType' => null, 'osmId' => null, 'openingHours' => null, 'description' => null, 'imageUrl' => null, 'wikipediaUrl' => null],
+            static fn (array $row): array => $row + ['osmType' => null, 'osmId' => null, 'openingHours' => null, 'website' => null, 'description' => null, 'imageUrl' => null, 'wikipediaUrl' => null],
             $rows,
         );
 

--- a/api/tests/Unit/Engine/OpeningHoursTest.php
+++ b/api/tests/Unit/Engine/OpeningHoursTest.php
@@ -68,6 +68,11 @@ final class OpeningHoursTest extends TestCase
         yield 'plain prose' => ['summer only'];
         yield 'weekday selector without hours' => ['Mo-Fr'];
         yield 'out-of-range hour' => ['Mo-Fr 09:00-25:00'];
+        // The tail of a midnight-crossing span belongs to the next day, which this
+        // reader does not track. Folding it back would leave Saturday 01:00 with no
+        // rule, hence reported as known closed while the venue is actually open.
+        yield 'midnight crossing on a single day' => ['Fr 18:00-02:00'];
+        yield 'midnight crossing on a partial week' => ['Mo-Fr 18:00-02:00'];
     }
 
     #[Test]

--- a/api/tests/Unit/Engine/OpeningHoursTest.php
+++ b/api/tests/Unit/Engine/OpeningHoursTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Engine;
+
+use App\Engine\OpeningHours;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The parser is deliberately narrow: it must read the common OSM shapes and
+ * return null on everything else, so callers can tell "closed" from "unknown".
+ */
+final class OpeningHoursTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{string, float, int, bool}>
+     */
+    public static function knownSchedules(): iterable
+    {
+        // spec, decimal hour, ISO weekday, expected openness
+        yield '24/7 is always open' => ['24/7', 3.5, 3, true];
+        yield 'bare span, inside' => ['09:00-19:00', 12.0, 3, true];
+        yield 'bare span, outside' => ['09:00-19:00', 20.0, 3, false];
+        yield 'split day, in the morning slot' => ['07:00-13:00,15:00-19:30', 8.0, 2, true];
+        yield 'split day, during the break' => ['07:00-13:00,15:00-19:30', 14.0, 2, false];
+        yield 'split day, inside the half-hour end' => ['07:00-13:00,15:00-19:30', 19.25, 2, true];
+        yield 'weekday range, on a covered day' => ['Mo-Fr 08:00-18:00', 10.0, 5, true];
+        yield 'weekday range, on an uncovered day' => ['Mo-Fr 08:00-18:00', 10.0, 6, false];
+        yield 'weekday list' => ['Mo,We,Fr 08:00-12:00', 10.0, 3, true];
+        yield 'weekday list, day not listed' => ['Mo,We,Fr 08:00-12:00', 10.0, 4, false];
+        yield 'range wrapping the week end' => ['Sa-Su 10:00-18:00', 12.0, 7, true];
+        yield 'explicit day off' => ['Tu-Su 10:00-18:00; Mo off', 12.0, 1, false];
+        yield 'explicit day off, other days stand' => ['Tu-Su 10:00-18:00; Mo off', 12.0, 2, true];
+        yield 'later rule overrides earlier one' => ['Mo-Su 09:00-19:00; Su 10:00-12:00', 15.0, 7, false];
+        yield 'public holiday rule is ignored' => ['Mo-Sa 09:00-19:00; PH off', 10.0, 6, true];
+        yield 'lowercase weekdays' => ['mo-fr 09:00-17:00', 10.0, 1, true];
+        yield 'span crossing midnight, late evening' => ['Mo-Su 18:00-02:00', 23.0, 4, true];
+        yield 'span crossing midnight, afternoon' => ['Mo-Su 18:00-02:00', 15.0, 4, false];
+        yield 'single-digit hour' => ['Mo-Fr 8:00-18:00', 9.0, 1, true];
+    }
+
+    #[Test]
+    #[DataProvider('knownSchedules')]
+    public function commonOsmShapesAreUnderstood(string $spec, float $hour, int $weekday, bool $expected): void
+    {
+        $hours = OpeningHours::parse($spec);
+
+        self::assertInstanceOf(OpeningHours::class, $hours, \sprintf('"%s" must be understood', $spec));
+        self::assertSame($expected, $hours->isOpenAt($hour, $weekday));
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function unsupportedSchedules(): iterable
+    {
+        yield 'empty string' => [''];
+        yield 'month range' => ['Apr-Oct 10:00-20:00'];
+        yield 'week selector' => ['week 1-53/2 Mo-Fr 09:00-17:00'];
+        yield 'nth weekday' => ['Su[1] 10:00-12:00'];
+        yield 'variable time' => ['sunrise-sunset'];
+        yield 'open-ended' => ['Mo-Fr 09:00+'];
+        yield 'unknown keyword' => ['unknown'];
+        yield 'free-form comment' => ['Mo-Fr 09:00-17:00 "ring the bell"'];
+        yield 'plain prose' => ['summer only'];
+        yield 'weekday selector without hours' => ['Mo-Fr'];
+        yield 'out-of-range hour' => ['Mo-Fr 09:00-25:00'];
+    }
+
+    #[Test]
+    #[DataProvider('unsupportedSchedules')]
+    public function unrecognisedShapesYieldNull(string $spec): void
+    {
+        self::assertNull(OpeningHours::parse($spec), \sprintf('"%s" must stay unknown, never be read as closed', $spec));
+    }
+
+    #[Test]
+    public function weekdayDependentScheduleIsInconclusiveWithoutAWeekday(): void
+    {
+        $hours = OpeningHours::parse('Mo-Fr 09:00-17:00');
+
+        self::assertInstanceOf(OpeningHours::class, $hours);
+        // 10:00 is inside the slot on Mo-Fr but outside it on Sa-Su: with no date,
+        // the answer depends on the weekday, so there is nothing to conclude.
+        self::assertNull($hours->isOpenAt(10.0));
+        // 03:00 is outside the slot every single day, so the weekday does not matter.
+        self::assertFalse($hours->isOpenAt(3.0));
+    }
+
+    #[Test]
+    public function weekdayIndependentScheduleAnswersWithoutAWeekday(): void
+    {
+        $hours = OpeningHours::parse('09:00-19:00');
+
+        self::assertInstanceOf(OpeningHours::class, $hours);
+        self::assertTrue($hours->isOpenAt(12.0));
+        self::assertFalse($hours->isOpenAt(21.0));
+    }
+}

--- a/api/tests/Unit/Geo/NearbyNameDeduplicatorTest.php
+++ b/api/tests/Unit/Geo/NearbyNameDeduplicatorTest.php
@@ -124,4 +124,48 @@ final class NearbyNameDeduplicatorTest extends TestCase
 
         self::assertCount(2, $result);
     }
+
+    #[Test]
+    public function theCuratedWinnerInheritsWhatOnlyTheOtherSourceKnew(): void
+    {
+        // The flux carries no website for cultural and food POIs, so preferring the
+        // curated entry used to drop the OSM website for every place both sources
+        // describe. The winner keeps its own values and only fills its own gaps.
+        $result = $this->deduplicator(5.0)->dedupe([
+            ['name' => 'Musée', 'lat' => 48.0, 'lon' => 2.0, 'wikidataId' => null, 'source' => 'osm', 'website' => 'https://musee.test', 'openingHours' => 'Mo-Fr 09:00-17:00', 'description' => null],
+            ['name' => 'Musée', 'lat' => 48.0, 'lon' => 2.0, 'wikidataId' => null, 'source' => 'datatourisme', 'website' => null, 'openingHours' => null, 'description' => 'Collection permanente.'],
+        ]);
+
+        self::assertCount(1, $result);
+        self::assertSame('datatourisme', $result[0]['source'], 'The curated entry still wins.');
+        self::assertSame('Collection permanente.', $result[0]['description'], 'Its own values are untouched.');
+        self::assertSame('https://musee.test', $result[0]['website'], 'The OSM website must survive the merge.');
+        self::assertSame('Mo-Fr 09:00-17:00', $result[0]['openingHours']);
+    }
+
+    #[Test]
+    public function theCuratedWinnerNeverLosesItsOwnValueToTheOtherSource(): void
+    {
+        $result = $this->deduplicator(5.0)->dedupe([
+            ['name' => 'Musée', 'lat' => 48.0, 'lon' => 2.0, 'wikidataId' => null, 'source' => 'osm', 'website' => 'https://osm.test'],
+            ['name' => 'Musée', 'lat' => 48.0, 'lon' => 2.0, 'wikidataId' => null, 'source' => 'datatourisme', 'website' => 'https://curated.test'],
+        ]);
+
+        self::assertCount(1, $result);
+        self::assertSame('https://curated.test', $result[0]['website']);
+    }
+
+    #[Test]
+    public function theBackfillNeverAddsAKeyTheWinnerDoesNotDeclare(): void
+    {
+        // Sources do not all share the same shape: a food POI has no description.
+        // Filling gaps must not graft a foreign key onto the winner's contract.
+        $result = $this->deduplicator(5.0)->dedupe([
+            ['name' => 'Café', 'lat' => 48.0, 'lon' => 2.0, 'wikidataId' => null, 'source' => 'osm', 'description' => 'Texte OSM'],
+            ['name' => 'Café', 'lat' => 48.0, 'lon' => 2.0, 'wikidataId' => null, 'source' => 'datatourisme', 'website' => null],
+        ]);
+
+        self::assertCount(1, $result);
+        self::assertArrayNotHasKey('description', $result[0]);
+    }
 }

--- a/api/tests/Unit/MessageHandler/CheckCulturalPoisHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/CheckCulturalPoisHandlerTest.php
@@ -407,6 +407,7 @@ final class CheckCulturalPoisHandlerTest extends TestCase
                 'lat' => 48.8606,
                 'lon' => 2.3376,
                 'openingHours' => 'Mon–Sat 09:00–18:00',
+                'website' => 'https://www.louvre.fr',
                 'estimatedPrice' => 15.0,
                 'description' => 'World-famous art museum.',
                 'wikidataId' => 'Q19675',
@@ -441,6 +442,7 @@ final class CheckCulturalPoisHandlerTest extends TestCase
 
         self::assertCount(1, $alerts);
         self::assertSame('Mon–Sat 09:00–18:00', $alerts[0]['openingHours']);
+        self::assertSame('https://www.louvre.fr', $alerts[0]['website']);
         self::assertSame(15.0, $alerts[0]['estimatedPrice']);
         self::assertSame('World-famous art museum.', $alerts[0]['description']);
         self::assertSame('Q19675', $alerts[0]['wikidataId']);
@@ -460,6 +462,7 @@ final class CheckCulturalPoisHandlerTest extends TestCase
                 'lat' => 48.2,
                 'lon' => 2.2,
                 'openingHours' => null,
+                'website' => null,
                 'estimatedPrice' => null,
                 'description' => null,
                 'wikidataId' => null,
@@ -498,6 +501,7 @@ final class CheckCulturalPoisHandlerTest extends TestCase
         self::assertSame('nudge', $alerts[0]['type']);
         self::assertSame(250, $alerts[0]['distanceFromRoute']);
         self::assertArrayNotHasKey('openingHours', $alerts[0]);
+        self::assertArrayNotHasKey('website', $alerts[0]);
         self::assertArrayNotHasKey('estimatedPrice', $alerts[0]);
         self::assertArrayNotHasKey('description', $alerts[0]);
         self::assertArrayNotHasKey('wikidataId', $alerts[0]);

--- a/api/tests/Unit/MessageHandler/ScanPoisHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/ScanPoisHandlerTest.php
@@ -175,14 +175,14 @@ final class ScanPoisHandlerTest extends TestCase
      * optional callback captures the corridor route the source receives.
      *
      * @param list<array{name: string|null, category: string, lat: float, lon: float, osmType?: ?string, osmId?: ?int, openingHours: string|null, website: string|null}> $pois
-     * @param (\Closure(list<array{lat: float, lon: float}>, int): void)|null $captureRoute
+     * @param (\Closure(list<array{lat: float, lon: float}>, int): void)|null                                                                                            $captureRoute
      */
     private function poiSourceRegistry(array $pois, ?\Closure $captureRoute = null): PoiSourceRegistry
     {
         $source = new readonly class ($pois, $captureRoute) implements PoiSourceInterface {
             /**
              * @param list<array{name: string|null, category: string, lat: float, lon: float, osmType?: ?string, osmId?: ?int, openingHours: string|null, website: string|null}> $pois
-             * @param (\Closure(list<array{lat: float, lon: float}>, int): void)|null $captureRoute
+             * @param (\Closure(list<array{lat: float, lon: float}>, int): void)|null                                                                                            $captureRoute
              */
             public function __construct(private array $pois, private ?\Closure $captureRoute)
             {

--- a/api/tests/Unit/MessageHandler/ScanPoisHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/ScanPoisHandlerTest.php
@@ -46,8 +46,8 @@ final class ScanPoisHandlerTest extends TestCase
         $tripStateManager = $this->createTripStateManager([$stage], 'fr');
 
         $registry = $this->poiSourceRegistry([
-            ['name' => null, 'category' => 'bakery', 'lat' => 48.1000, 'lon' => 2.1],
-            ['name' => null, 'category' => 'bakery', 'lat' => 48.1003, 'lon' => 2.1],
+            ['name' => null, 'category' => 'bakery', 'lat' => 48.1000, 'lon' => 2.1, 'openingHours' => null, 'website' => null],
+            ['name' => null, 'category' => 'bakery', 'lat' => 48.1003, 'lon' => 2.1, 'openingHours' => null, 'website' => null],
         ]);
 
         $distributor = $this->createStub(GeometryDistributorInterface::class);
@@ -174,14 +174,14 @@ final class ScanPoisHandlerTest extends TestCase
      * deduplicator (transparent here: every fixture has a distinct name). An
      * optional callback captures the corridor route the source receives.
      *
-     * @param list<array{name: ?string, category: string, lat: float, lon: float, osmType?: ?string, osmId?: ?int, openingHours: string|null, website: string|null}> $pois
+     * @param list<array{name: string|null, category: string, lat: float, lon: float, osmType?: ?string, osmId?: ?int, openingHours: string|null, website: string|null}> $pois
      * @param (\Closure(list<array{lat: float, lon: float}>, int): void)|null $captureRoute
      */
     private function poiSourceRegistry(array $pois, ?\Closure $captureRoute = null): PoiSourceRegistry
     {
         $source = new readonly class ($pois, $captureRoute) implements PoiSourceInterface {
             /**
-             * @param list<array{name: ?string, category: string, lat: float, lon: float, osmType?: ?string, osmId?: ?int, openingHours: string|null, website: string|null}> $pois
+             * @param list<array{name: string|null, category: string, lat: float, lon: float, osmType?: ?string, osmId?: ?int, openingHours: string|null, website: string|null}> $pois
              * @param (\Closure(list<array{lat: float, lon: float}>, int): void)|null $captureRoute
              */
             public function __construct(private array $pois, private ?\Closure $captureRoute)
@@ -536,7 +536,7 @@ final class ScanPoisHandlerTest extends TestCase
      * Runs the handler on an 80 km stage carrying $pois, the rider passing each of
      * them at $passageTime, and returns the alerts published for that stage.
      *
-     * @param list<array{name: string, category: string, lat: float, lon: float, openingHours: string|null, website: string|null}> $pois
+     * @param list<array{name: string|null, category: string, lat: float, lon: float, openingHours: string|null, website: string|null}> $pois
      *
      * @return list<array<string, mixed>>
      */

--- a/api/tests/Unit/MessageHandler/ScanPoisHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/ScanPoisHandlerTest.php
@@ -153,19 +153,36 @@ final class ScanPoisHandlerTest extends TestCase
     }
 
     /**
+     * A raw corridor POI as the sources and the distributor hand it over.
+     *
+     * @return array{name: string, category: string, lat: float, lon: float, openingHours: string|null, website: string|null}
+     */
+    private function poi(string $name, string $category, float $lat, float $lon, ?string $openingHours = null): array
+    {
+        return [
+            'name' => $name,
+            'category' => $category,
+            'lat' => $lat,
+            'lon' => $lon,
+            'openingHours' => $openingHours,
+            'website' => null,
+        ];
+    }
+
+    /**
      * Real registry wrapping a single fake source returning $pois. Uses the real
      * deduplicator (transparent here: every fixture has a distinct name). An
      * optional callback captures the corridor route the source receives.
      *
-     * @param list<array{name: ?string, category: string, lat: float, lon: float, osmType?: ?string, osmId?: ?int}> $pois
-     * @param (\Closure(list<array{lat: float, lon: float}>, int): void)|null                                       $captureRoute
+     * @param list<array{name: ?string, category: string, lat: float, lon: float, osmType?: ?string, osmId?: ?int, openingHours: string|null, website: string|null}> $pois
+     * @param (\Closure(list<array{lat: float, lon: float}>, int): void)|null $captureRoute
      */
     private function poiSourceRegistry(array $pois, ?\Closure $captureRoute = null): PoiSourceRegistry
     {
         $source = new readonly class ($pois, $captureRoute) implements PoiSourceInterface {
             /**
-             * @param list<array{name: ?string, category: string, lat: float, lon: float, osmType?: ?string, osmId?: ?int}> $pois
-             * @param (\Closure(list<array{lat: float, lon: float}>, int): void)|null                                       $captureRoute
+             * @param list<array{name: ?string, category: string, lat: float, lon: float, osmType?: ?string, osmId?: ?int, openingHours: string|null, website: string|null}> $pois
+             * @param (\Closure(list<array{lat: float, lon: float}>, int): void)|null $captureRoute
              */
             public function __construct(private array $pois, private ?\Closure $captureRoute)
             {
@@ -184,6 +201,8 @@ final class ScanPoisHandlerTest extends TestCase
                     'lon' => $p['lon'],
                     'osmType' => $p['osmType'] ?? null,
                     'osmId' => $p['osmId'] ?? null,
+                    'openingHours' => $p['openingHours'],
+                    'website' => $p['website'],
                     'wikidataId' => null,
                     'source' => 'osm',
                 ], $this->pois);
@@ -226,23 +245,19 @@ final class ScanPoisHandlerTest extends TestCase
         $stage = $this->createStage('trip-1', 1, 80.0);
         $tripStateManager = $this->createTripStateManager([$stage]);
 
-        $poiRepository = $this->poiSourceRegistry([
-            ['name' => 'Le Bistrot', 'category' => 'restaurant', 'lat' => 48.2, 'lon' => 2.2],
-            ['name' => 'Chez Paul', 'category' => 'restaurant', 'lat' => 48.3, 'lon' => 2.3],
-        ]);
+        // Both carry real OSM hours, so the passage time can actually be judged.
+        $pois = [
+            $this->poi('Le Bistrot', 'restaurant', 48.2, 2.2, '12:00-14:00,19:00-22:00'),
+            $this->poi('Chez Paul', 'restaurant', 48.3, 2.3, '12:00-14:30'),
+        ];
+        $poiRepository = $this->poiSourceRegistry($pois);
 
         $distributor = $this->createStub(GeometryDistributorInterface::class);
-        $distributor->method('distributeByGeometry')->willReturnOnConsecutiveCalls(
-            [0 => [
-                ['name' => 'Le Bistrot', 'category' => 'restaurant', 'lat' => 48.2, 'lon' => 2.2],
-                ['name' => 'Chez Paul', 'category' => 'restaurant', 'lat' => 48.3, 'lon' => 2.3],
-            ]],
-            [],
-        );
+        $distributor->method('distributeByGeometry')->willReturnOnConsecutiveCalls([0 => $pois], []);
 
         [$haversine, $riderTimeEstimator] = $this->createDefaultStubs();
 
-        // 16:00 → both restaurants closed (restaurants: 12-14, 19-22)
+        // 16:00 → both restaurants closed according to their own opening_hours
         $riderTimeEstimator->method('estimateTimeAtDistance')->willReturn(16.0);
 
         $publishedEvents = [];
@@ -271,19 +286,14 @@ final class ScanPoisHandlerTest extends TestCase
         $stage = $this->createStage('trip-1', 1, 80.0);
         $tripStateManager = $this->createTripStateManager([$stage]);
 
-        $poiRepository = $this->poiSourceRegistry([
-            ['name' => 'Le Bistrot', 'category' => 'restaurant', 'lat' => 48.2, 'lon' => 2.2],
-            ['name' => 'Carrefour', 'category' => 'supermarket', 'lat' => 48.3, 'lon' => 2.3],
-        ]);
+        $pois = [
+            $this->poi('Le Bistrot', 'restaurant', 48.2, 2.2, '12:00-14:00,19:00-22:00'),
+            $this->poi('Carrefour', 'supermarket', 48.3, 2.3, '09:00-20:00'),
+        ];
+        $poiRepository = $this->poiSourceRegistry($pois);
 
         $distributor = $this->createStub(GeometryDistributorInterface::class);
-        $distributor->method('distributeByGeometry')->willReturnOnConsecutiveCalls(
-            [0 => [
-                ['name' => 'Le Bistrot', 'category' => 'restaurant', 'lat' => 48.2, 'lon' => 2.2],
-                ['name' => 'Carrefour', 'category' => 'supermarket', 'lat' => 48.3, 'lon' => 2.3],
-            ]],
-            [],
-        );
+        $distributor->method('distributeByGeometry')->willReturnOnConsecutiveCalls([0 => $pois], []);
 
         [$haversine, $riderTimeEstimator] = $this->createDefaultStubs();
 
@@ -316,17 +326,11 @@ final class ScanPoisHandlerTest extends TestCase
         $stage = $this->createStage('trip-1', 1, 80.0);
         $tripStateManager = $this->createTripStateManager([$stage]);
 
-        $poiRepository = $this->poiSourceRegistry([
-            ['name' => 'Belvedere', 'category' => 'viewpoint', 'lat' => 48.2, 'lon' => 2.2],
-        ]);
+        $pois = [$this->poi('Belvedere', 'viewpoint', 48.2, 2.2)];
+        $poiRepository = $this->poiSourceRegistry($pois);
 
         $distributor = $this->createStub(GeometryDistributorInterface::class);
-        $distributor->method('distributeByGeometry')->willReturnOnConsecutiveCalls(
-            [0 => [
-                ['name' => 'Belvedere', 'category' => 'viewpoint', 'lat' => 48.2, 'lon' => 2.2],
-            ]],
-            [],
-        );
+        $distributor->method('distributeByGeometry')->willReturnOnConsecutiveCalls([0 => $pois], []);
 
         [$haversine, $riderTimeEstimator] = $this->createDefaultStubs();
 
@@ -455,23 +459,18 @@ final class ScanPoisHandlerTest extends TestCase
         );
         $tripStateManager = $this->createTripStateManager([$stage]);
 
-        $poiRepository = $this->poiSourceRegistry([
-            ['name' => 'Le Bistrot', 'category' => 'restaurant', 'lat' => 48.2, 'lon' => 2.2],
-            ['name' => 'Chez Paul', 'category' => 'restaurant', 'lat' => 48.3, 'lon' => 2.3],
-        ]);
+        $pois = [
+            $this->poi('Le Bistrot', 'restaurant', 48.2, 2.2, '12:00-14:00,19:00-22:00'),
+            $this->poi('Chez Paul', 'restaurant', 48.3, 2.3, '12:00-14:30'),
+        ];
+        $poiRepository = $this->poiSourceRegistry($pois);
 
         $distributor = $this->createStub(GeometryDistributorInterface::class);
-        $distributor->method('distributeByGeometry')->willReturnOnConsecutiveCalls(
-            [0 => [
-                ['name' => 'Le Bistrot', 'category' => 'restaurant', 'lat' => 48.2, 'lon' => 2.2],
-                ['name' => 'Chez Paul', 'category' => 'restaurant', 'lat' => 48.3, 'lon' => 2.3],
-            ]],
-            [],
-        );
+        $distributor->method('distributeByGeometry')->willReturnOnConsecutiveCalls([0 => $pois], []);
 
         [$haversine, $riderTimeEstimator] = $this->createDefaultStubs();
 
-        // 16:00 → both restaurants closed (restaurants: 12-14, 19-22), so without the
+        // 16:00 → both restaurants closed per their own opening_hours, so without the
         // rest-day guard this stage would emit the timing warning.
         $riderTimeEstimator->method('estimateTimeAtDistance')->willReturn(16.0);
 
@@ -501,17 +500,12 @@ final class ScanPoisHandlerTest extends TestCase
         $stage = $this->createStage('trip-1', 1, 80.0);
         $tripStateManager = $this->createTripStateManager([$stage]);
 
-        $poiRepository = $this->poiSourceRegistry([
-            ['name' => 'Boulangerie', 'category' => 'bakery', 'lat' => 48.2, 'lon' => 2.2],
-        ]);
+        // No OSM hours: the category fallback is still allowed to conclude "open".
+        $pois = [$this->poi('Boulangerie', 'bakery', 48.2, 2.2)];
+        $poiRepository = $this->poiSourceRegistry($pois);
 
         $distributor = $this->createStub(GeometryDistributorInterface::class);
-        $distributor->method('distributeByGeometry')->willReturnOnConsecutiveCalls(
-            [0 => [
-                ['name' => 'Boulangerie', 'category' => 'bakery', 'lat' => 48.2, 'lon' => 2.2],
-            ]],
-            [],
-        );
+        $distributor->method('distributeByGeometry')->willReturnOnConsecutiveCalls([0 => $pois], []);
 
         [$haversine, $riderTimeEstimator] = $this->createDefaultStubs();
 
@@ -538,27 +532,172 @@ final class ScanPoisHandlerTest extends TestCase
         );
     }
 
+    /**
+     * Runs the handler on an 80 km stage carrying $pois, the rider passing each of
+     * them at $passageTime, and returns the alerts published for that stage.
+     *
+     * @param list<array{name: string, category: string, lat: float, lon: float, openingHours: string|null, website: string|null}> $pois
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function alertsForStage(array $pois, float $passageTime, ?TripRequest $tripRequest = null): array
+    {
+        $stage = $this->createStage('trip-1', 1, 80.0);
+        $tripStateManager = $this->createTripStateManager([$stage], 'en', $tripRequest);
+
+        $distributor = $this->createStub(GeometryDistributorInterface::class);
+        $distributor->method('distributeByGeometry')->willReturnOnConsecutiveCalls([0 => $pois], []);
+
+        [$haversine, $riderTimeEstimator] = $this->createDefaultStubs();
+        $riderTimeEstimator->method('estimateTimeAtDistance')->willReturn($passageTime);
+
+        $publishedEvents = [];
+        $publisher = $this->createStub(TripUpdatePublisherInterface::class);
+        $publisher->method('publish')
+            ->willReturnCallback(static function (string $tripId, MercureEventType $type, array $payload) use (&$publishedEvents): void {
+                $publishedEvents[] = ['tripId' => $tripId, 'type' => $type, 'payload' => $payload];
+            });
+
+        $handler = $this->createHandler($tripStateManager, $publisher, $this->poiSourceRegistry($pois), $this->waterPointRepository(), $distributor, $haversine, $riderTimeEstimator);
+        $handler(new ScanPois('trip-1'));
+
+        $poisScannedEvents = array_filter($publishedEvents, static fn (array $e): bool => MercureEventType::POIS_SCANNED === $e['type']);
+        self::assertCount(1, $poisScannedEvents);
+
+        /** @var list<array<string, mixed>> $alerts */
+        $alerts = array_first($poisScannedEvents)['payload']['alerts'] ?? [];
+
+        return $alerts;
+    }
+
+    /**
+     * @param list<array<string, mixed>> $alerts
+     */
+    private function hasTimingWarning(array $alerts): bool
+    {
+        return array_any($alerts, static fn (array $alert): bool => 'warning' === $alert['type']);
+    }
+
+    #[Test]
+    public function poiWithoutOpeningHoursDoesNotTriggerTimingWarning(): void
+    {
+        // 16:00 is outside the generic restaurant slots (12-14, 19-22), which is
+        // exactly what used to raise the warning. OSM knows nothing about this
+        // restaurant's hours, so there is nothing to warn about.
+        $alerts = $this->alertsForStage([$this->poi('Le Bistrot', 'restaurant', 48.2, 2.2)], 16.0);
+
+        self::assertFalse(
+            $this->hasTimingWarning($alerts),
+            'A POI with unknown opening hours must never raise alert.resupply.timing_warning',
+        );
+    }
+
+    #[Test]
+    public function poiWithUnparsableOpeningHoursDoesNotTriggerTimingWarning(): void
+    {
+        // A shape the parser does not model is unknown, not closed.
+        $alerts = $this->alertsForStage([$this->poi('Le Bistrot', 'restaurant', 48.2, 2.2, 'sunrise-sunset; by appointment')], 16.0);
+
+        self::assertFalse(
+            $this->hasTimingWarning($alerts),
+            'An opening_hours value that could not be read must be treated as unknown',
+        );
+    }
+
+    #[Test]
+    public function unknownHoursOnOnePoiSuppressTheWarningForTheWholeStage(): void
+    {
+        $alerts = $this->alertsForStage([
+            $this->poi('Le Bistrot', 'restaurant', 48.2, 2.2, '12:00-14:00'),
+            $this->poi('Chez Paul', 'restaurant', 48.3, 2.3),
+        ], 16.0);
+
+        self::assertFalse(
+            $this->hasTimingWarning($alerts),
+            'One POI whose hours are unknown makes the stage inconclusive',
+        );
+    }
+
+    #[Test]
+    public function realOpeningHoursTakePrecedenceOverTheCategoryFallback(): void
+    {
+        // The generic restaurant slots would call 16:00 closed; OSM says otherwise.
+        $alerts = $this->alertsForStage([$this->poi('Le Bistrot', 'restaurant', 48.2, 2.2, '15:00-18:00')], 16.0);
+
+        self::assertFalse(
+            $this->hasTimingWarning($alerts),
+            'The real opening_hours must win over the category-typical slots',
+        );
+    }
+
+    #[Test]
+    public function realOpeningHoursOutsideThePassageTimeEmitTheWarning(): void
+    {
+        // Conversely, a POI the generic slots would call open (a supermarket at
+        // 10:00) is warned about when its own hours say it is closed.
+        $alerts = $this->alertsForStage([$this->poi('Carrefour', 'supermarket', 48.2, 2.2, '14:00-19:00')], 10.0);
+
+        self::assertTrue(
+            $this->hasTimingWarning($alerts),
+            'A POI known to be closed at the passage time must raise the warning',
+        );
+    }
+
+    #[Test]
+    public function weekdayDependentHoursAreEvaluatedOnTheStageDate(): void
+    {
+        $request = new TripRequest();
+        $request->startDate = new \DateTimeImmutable('2026-08-02'); // a Sunday
+
+        $pois = [$this->poi('Carrefour', 'supermarket', 48.2, 2.2, 'Mo-Sa 09:00-19:00')];
+
+        self::assertTrue(
+            $this->hasTimingWarning($this->alertsForStage($pois, 10.0, $request)),
+            'The shop is closed on Sundays, and day 1 of this trip is a Sunday',
+        );
+
+        $request->startDate = new \DateTimeImmutable('2026-08-03'); // a Monday
+
+        self::assertFalse(
+            $this->hasTimingWarning($this->alertsForStage($pois, 10.0, $request)),
+            'The same shop is open on Mondays',
+        );
+    }
+
+    #[Test]
+    public function weekdayDependentHoursAreInconclusiveWithoutAStartDate(): void
+    {
+        // No start date → the weekday is unknown, and "Mo-Sa" cannot be resolved.
+        $alerts = $this->alertsForStage([$this->poi('Carrefour', 'supermarket', 48.2, 2.2, 'Mo-Sa 09:00-19:00')], 21.0);
+
+        self::assertTrue(
+            $this->hasTimingWarning($alerts),
+            '21:00 is outside the slot on every weekday, so the answer holds without a date',
+        );
+
+        $alerts = $this->alertsForStage([$this->poi('Carrefour', 'supermarket', 48.2, 2.2, 'Mo-Sa 09:00-19:00')], 10.0);
+
+        self::assertFalse(
+            $this->hasTimingWarning($alerts),
+            '10:00 depends on the weekday, which is unknown here: nothing can be concluded',
+        );
+    }
+
     #[Test]
     public function poisWithin500mAreClusteredIntoSingleMarker(): void
     {
         $stage = $this->createStage('trip-1', 1, 80.0);
         $tripStateManager = $this->createTripStateManager([$stage]);
 
-        $poiRepository = $this->poiSourceRegistry([
-            ['name' => 'Bistrot A', 'category' => 'restaurant', 'lat' => 48.2, 'lon' => 2.2],
-            ['name' => 'Bistrot B', 'category' => 'restaurant', 'lat' => 48.2, 'lon' => 2.2001],
-            ['name' => 'Remote Bistrot', 'category' => 'restaurant', 'lat' => 48.5, 'lon' => 2.5],
-        ]);
+        $pois = [
+            $this->poi('Bistrot A', 'restaurant', 48.2, 2.2),
+            $this->poi('Bistrot B', 'restaurant', 48.2, 2.2001),
+            $this->poi('Remote Bistrot', 'restaurant', 48.5, 2.5),
+        ];
+        $poiRepository = $this->poiSourceRegistry($pois);
 
         $distributor = $this->createStub(GeometryDistributorInterface::class);
-        $distributor->method('distributeByGeometry')->willReturnOnConsecutiveCalls(
-            [0 => [
-                ['name' => 'Bistrot A', 'category' => 'restaurant', 'lat' => 48.2, 'lon' => 2.2],
-                ['name' => 'Bistrot B', 'category' => 'restaurant', 'lat' => 48.2, 'lon' => 2.2001],
-                ['name' => 'Remote Bistrot', 'category' => 'restaurant', 'lat' => 48.5, 'lon' => 2.5],
-            ]],
-            [],
-        );
+        $distributor->method('distributeByGeometry')->willReturnOnConsecutiveCalls([0 => $pois], []);
 
         $haversine = $this->createStub(GeoDistanceInterface::class);
         $haversine->method('inKilometers')->willReturn(10.0);
@@ -670,21 +809,15 @@ final class ScanPoisHandlerTest extends TestCase
         $stage = $this->createStage('trip-1', 1, 80.0);
         $tripStateManager = $this->createTripStateManager([$stage]);
 
-        $poiRepository = $this->poiSourceRegistry([
-            ['name' => 'POI A', 'category' => 'restaurant', 'lat' => 48.0, 'lon' => 2.0],
-            ['name' => 'POI B', 'category' => 'restaurant', 'lat' => 48.0, 'lon' => 2.005],
-            ['name' => 'POI C', 'category' => 'restaurant', 'lat' => 48.0, 'lon' => 2.010],
-        ]);
+        $pois = [
+            $this->poi('POI A', 'restaurant', 48.0, 2.0),
+            $this->poi('POI B', 'restaurant', 48.0, 2.005),
+            $this->poi('POI C', 'restaurant', 48.0, 2.010),
+        ];
+        $poiRepository = $this->poiSourceRegistry($pois);
 
         $distributor = $this->createStub(GeometryDistributorInterface::class);
-        $distributor->method('distributeByGeometry')->willReturnOnConsecutiveCalls(
-            [0 => [
-                ['name' => 'POI A', 'category' => 'restaurant', 'lat' => 48.0, 'lon' => 2.0],
-                ['name' => 'POI B', 'category' => 'restaurant', 'lat' => 48.0, 'lon' => 2.005],
-                ['name' => 'POI C', 'category' => 'restaurant', 'lat' => 48.0, 'lon' => 2.010],
-            ]],
-            [],
-        );
+        $distributor->method('distributeByGeometry')->willReturnOnConsecutiveCalls([0 => $pois], []);
 
         $haversine = $this->createStub(GeoDistanceInterface::class);
         $haversine->method('inKilometers')->willReturn(10.0);

--- a/api/tests/Unit/Poi/OsmPoiSourceTest.php
+++ b/api/tests/Unit/Poi/OsmPoiSourceTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
 final class OsmPoiSourceTest extends TestCase
 {
     /**
-     * @param list<array{name: ?string, category: string, lat: float, lon: float, osmType?: ?string, osmId?: ?int}> $rows
+     * @param list<array{name: ?string, category: string, lat: float, lon: float, osmType?: ?string, osmId?: ?int, openingHours: ?string, website: ?string}> $rows
      */
     private function source(array $rows): OsmPoiSource
     {
@@ -38,7 +38,7 @@ final class OsmPoiSourceTest extends TestCase
     public function mapsRepositoryRowToCandidate(): void
     {
         $poi = $this->source([
-            ['name' => 'Boulangerie du Centre', 'category' => 'bakery', 'lat' => 48.1, 'lon' => 2.1, 'osmType' => 'node', 'osmId' => 12],
+            ['name' => 'Boulangerie du Centre', 'category' => 'bakery', 'lat' => 48.1, 'lon' => 2.1, 'osmType' => 'node', 'osmId' => 12, 'openingHours' => null, 'website' => null],
         ])->fetchInCorridor($this->route(), 2000)[0];
 
         self::assertSame('Boulangerie du Centre', $poi['name']);
@@ -59,7 +59,7 @@ final class OsmPoiSourceTest extends TestCase
         // rider, and it must not make two anonymous shops look identical to the
         // deduplicator (issue #874).
         $poi = $this->source([
-            ['name' => null, 'category' => 'supermarket', 'lat' => 48.1, 'lon' => 2.1],
+            ['name' => null, 'category' => 'supermarket', 'lat' => 48.1, 'lon' => 2.1, 'openingHours' => null, 'website' => null],
         ])->fetchInCorridor($this->route(), 2000)[0];
 
         self::assertNull($poi['name']);

--- a/api/tests/Unit/Poi/PoiSourceRegistryTest.php
+++ b/api/tests/Unit/Poi/PoiSourceRegistryTest.php
@@ -22,12 +22,20 @@ final class PoiSourceRegistryTest extends TestCase
     }
 
     /**
-     * @param list<array{name: string|null, category: string, lat: float, lon: float, wikidataId: string|null, source: string, osmType?: string|null, osmId?: int|null}> $pois
+     * The dedupe pass reads name/coordinates/wikidataId/source only, so the fixtures
+     * leave the enrichment columns of the source shape defaulted.
+     *
+     * @param list<array{name: string|null, category: string, lat: float, lon: float, wikidataId: string|null, source: string, osmType?: string|null, osmId?: int|null, openingHours?: string|null, website?: string|null}> $pois
      */
     private function source(array $pois): PoiSourceInterface
     {
+        $pois = array_map(
+            static fn (array $poi): array => $poi + ['openingHours' => null, 'website' => null],
+            $pois,
+        );
+
         return new readonly class ($pois) implements PoiSourceInterface {
-            /** @param list<array{name: string|null, category: string, lat: float, lon: float, wikidataId: string|null, source: string, osmType?: string|null, osmId?: int|null}> $pois */
+            /** @param list<array{name: string|null, category: string, lat: float, lon: float, wikidataId: string|null, source: string, osmType?: string|null, osmId?: int|null, openingHours?: string|null, website?: string|null}> $pois */
             public function __construct(private array $pois)
             {
             }

--- a/api/tests/Unit/Poi/PoiSourceRegistryTest.php
+++ b/api/tests/Unit/Poi/PoiSourceRegistryTest.php
@@ -42,9 +42,13 @@ final class PoiSourceRegistryTest extends TestCase
 
             public function fetchInCorridor(array $route, int $radiusMeters): array
             {
-                // Fixtures state only what a case is about; the OSM identity defaults
-                // to "not an OSM entry", which is what a curated source looks like.
-                return array_map(static fn (array $p): array => $p + ['osmType' => null, 'osmId' => null], $this->pois);
+                // Fixtures state only what a case is about; the rest of the source
+                // shape defaults to "nothing known", which is what a curated entry
+                // without an OSM identity looks like.
+                return array_map(
+                    static fn (array $p): array => $p + ['osmType' => null, 'osmId' => null, 'openingHours' => null, 'website' => null],
+                    $this->pois,
+                );
             }
         };
     }

--- a/pwa/src/lib/api/schema.d.ts
+++ b/pwa/src/lib/api/schema.d.ts
@@ -1265,6 +1265,10 @@ export interface components {
             osmType?: string | null;
             /** @description OpenStreetMap object id. Null when the entry does not come from OSM. */
             osmId?: number | null;
+            /** @description Raw OpenStreetMap opening_hours value, when the POI carries one. */
+            openingHours?: string | null;
+            /** @description Official website of the POI, when OpenStreetMap knows one. */
+            website?: string | null;
         };
         "PointOfInterest.gpx": {
             name?: string;
@@ -1276,6 +1280,10 @@ export interface components {
             osmType?: string | null;
             /** @description OpenStreetMap object id. Null when the entry does not come from OSM. */
             osmId?: number | null;
+            /** @description Raw OpenStreetMap opening_hours value, when the POI carries one. */
+            openingHours?: string | null;
+            /** @description Official website of the POI, when OpenStreetMap knows one. */
+            website?: string | null;
         };
         "PointOfInterest.jsonld": {
             name?: string;
@@ -1287,6 +1295,10 @@ export interface components {
             osmType?: string | null;
             /** @description OpenStreetMap object id. Null when the entry does not come from OSM. */
             osmId?: number | null;
+            /** @description Raw OpenStreetMap opening_hours value, when the POI carries one. */
+            openingHours?: string | null;
+            /** @description Official website of the POI, when OpenStreetMap knows one. */
+            website?: string | null;
         };
         "Stage.StagePoiWaypointRequest": {
             /** @description POI latitude to insert as waypoint. */


### PR DESCRIPTION
Closes #875.

## Le livrable

`alert.resupply.timing_warning` affirmait quelque chose de précis sur des horaires inventés : `ScanPoisHandler` jugeait l'ouverture d'un commerce sur les créneaux codés en dur de `FixedSchedule` (supermarché 9h-20h, boulangerie 7h-13h/15h-19h), alors que `osm.pois.opening_hours` est peuplée à l'import et n'était **jamais lue**.

Désormais l'alerte ne se déclenche que sur des horaires **réellement connus**.

- Nouveau `api/src/Engine/OpeningHours.php` — lecteur volontairement conservateur de la grammaire OSM `opening_hours`. Il modélise `24/7`, les plages nues (`09:00-12:00,14:00-19:00`) et les règles séparées par `;` de la forme `[<sélecteur de jours>] <plages|off/closed>`. Il renvoie `null` sur **tout le reste** (plages de mois, `week`, `sunrise`, `Su[1]`, horaires ouverts, commentaires) : format non reconnu = inconnu, jamais fermé. Aucune dépendance ajoutée.
- `isOpenAt(float, ?int $isoWeekday): ?bool` est **tri-état** et renvoie `null` quand la réponse dépendrait d'un jour de semaine qu'on ne lui a pas donné.
- Les règles `PH` / `SH` sont ignorées, jamais rejetées : ignorer une exception de jour férié ne peut que faire paraître un POI ouvert, ce qui est la direction prudente pour un avertissement « tout est fermé ».
- `ScanPoisHandler::allResupplyPoisAreClosed()` remplace `hasAnyOpenResupplyPoi()` : l'avertissement ne sort que si **tous** les POI de ravitaillement sont *connus* fermés. Les horaires réels priment ; à défaut, `FixedSchedule::forCategory()` ne peut conclure que « probablement ouvert », jamais « fermé ». Le jour de semaine vient de `TripRequest::$startDate` plus l'index d'étape.
- `FixedSchedule` est documenté comme repli et récupère `forCategory()` (le mapping quitte le handler).

## Plomberie

`PoiRepository` sélectionne `opening_hours` et `website`, `CulturalPoiRepository` sélectionne `website` ; propagés à travers `PoiSourceInterface` / `OsmPoiSource` / `DataTourismeFoodPoiSource` / `PoiSourceRegistry`, les sources culturelles et `CheckCulturalPoisHandler`, jusqu'à `PointOfInterest` (`+openingHours`, `+website`) et `CulturalPoiAlert` (`+website`). L'aller-retour Doctrine des POI est mis à jour. Les chaînes vides deviennent `null`.

La ligne du moteur d'alertes du README est reformulée. Aucun code d'alerte n'est ajouté ni supprimé, donc `ALERT_RULE_MAP` est inchangé.

**DTO_CHANGED** : `PointOfInterest` et `CulturalPoiAlert`. `pwa/src/lib/api/schema.d.ts` est régénéré (export OpenAPI + `openapi-typescript`), 12 lignes ajoutées sur les trois schémas `PointOfInterest.*`. `CulturalPoiAlert` n'apparaît pas dans la sortie OpenAPI et ne produit donc aucun changement TS. Aucune source PWA touchée.

## Conflit attendu avec #913 (issue #874)

Les deux branches partent de `main` et partagent 13 fichiers. Un `git merge-tree` donne **6 fichiers en conflit**, tous sur les mêmes annotations `list<array{...}>` :

`CulturalPoiSourceInterface.php`, `CulturalPoiSourceRegistry.php`, `DataTourismeCulturalPoiSource.php`, `OsmCulturalPoiSource.php`, `PoiSourceInterface.php`, `PoiSourceRegistry.php`.

**La résolution est l'union des deux élargissements**, sans arbitrage à rendre : `name: string|null` (#874) **et** `openingHours` / `website` (#875) coexistent dans la même forme. Aucune des deux modifications n'invalide l'autre. Merger #913 en premier, puis rebaser cette branche.

Les lignes de résolution du **nom** dans les sources de POI (#874), la forme d'émission des alertes dans `ScanPoisHandler` (#876) et `Alert.php` ont été délibérément laissées intactes ici.

## Auto-critique

- `OpeningHours` est un lecteur partiel et l'assume. Il ne gère ni les plages de mois, ni les sélecteurs ordinaux, ni les horaires ouverts — il renvoie `null` dessus. C'est le comportement prudent demandé par l'issue (« en cas de format non reconnu, ne pas conclure »), mais cela veut dire qu'un POI aux horaires exprimés en saisonnalité ne contribuera jamais à l'alerte. Élargir la grammaire est une amélioration incrémentale, pas une correction.
- L'alerte devient **plus silencieuse** : elle ne sort que si tous les POI de ravitaillement sont connus fermés. C'est l'intention (moins de faux positifs, classe visée par ADR-040), mais le volume d'alertes va mesurablement baisser sur les zones à faible couverture d'horaires OSM. C'est le bon compromis : ne rien dire vaut mieux qu'affirmer un horaire inventé.
- Le jour de semaine dérive de `startDate + index d'étape`. Sur un voyage sans date de départ, la règle dépendante du jour retombe sur `null`, donc sur « inconnu ».

## Vérification

`make qa` ne peut pas aboutir sur une machine de dev. Legs exécutés individuellement :

- **PHP-CS-Fixer** : `Fixed 1 of 653 files` (autofix committé), re-run propre.
- **Rector** : première passe `2 files would have been changed` (`LocallyCalledStaticMethodToNonStaticRector`), appliquée et committée → `[OK] Rector is done!`
- **PHPStan** niveau 9 : `[OK] No errors`. Deux erreurs réelles corrigées à la main : une forme de tableau scellée sur `SupplyTimelineBuilder::computeDistancesForSupply()` et une fixture périmée dans `PoiSourceRegistryTest`.
- **PHPUnit `tests/Unit`** : `Tests: 1302, Assertions: 3517, Skipped: 1` — OK (inclut `AlertDocumentationTest`).
- **PHPUnit `tests/Integration`** : `OK (102 tests, 379 assertions)`.
- **tsc `--noEmit`** : exit 0. **ESLint** : exit 0. **Prettier** : `All matched files use Prettier code style!` **i18n** : `i18n-check OK: 920 keys in sync across fr, en`. **markdownlint** `README.md` : `Summary: 0 error(s)`.
- **Playwright : c'est CI le gate.** Aucune couverture E2E locale n'est revendiquée.

### Preuve que les tests peuvent échouer

Deux mutations de `ScanPoisHandler::isOpenAt()`, exécutées puis annulées :

1. Laisser `FixedSchedule` conclure « fermé » (l'ancien comportement) → 3 rouges, dont le cœur du livrable :
```
1) ScanPoisHandlerTest::poiWithoutOpeningHoursDoesNotTriggerTimingWarning
   A POI with unknown opening hours must never raise alert.resupply.timing_warning
   Failed asserting that true is false.
2) ScanPoisHandlerTest::poiWithUnparsableOpeningHoursDoesNotTriggerTimingWarning
3) ScanPoisHandlerTest::unknownHoursOnOnePoiSuppressTheWarningForTheWholeStage
Tests: 19, Assertions: 50, Failures: 3.
```
2. Ignorer entièrement les horaires réels + laisser le repli conclure « fermé » → 6 rouges, ajoutant `realOpeningHoursTakePrecedenceOverTheCategoryFallback`, `realOpeningHoursOutsideThePassageTimeEmitTheWarning`, `weekdayDependentHoursAreEvaluatedOnTheStageDate`, `allResupplyPoisClosedAtEstimatedTimeEmitsWarning`.

Après restauration : `OK (163 tests, 355 assertions)`.

### Note d'environnement

Le premier run Integration a échoué en bloc sur `schema "osm" does not exist` : la base `app_test` locale était à demi-migrée par une course sur `CREATE EXTENSION IF NOT EXISTS postgis` entre le reset Foundry d'un agent parallèle et la migration. Supprimer `app_test` et rejouer `doctrine:migrations:migrate` une fois a rendu tous les runs suivants verts. Sans rapport avec ce diff.

<!-- claude-review-start -->
## Claude Review

**Summary:** No correctness, security, or performance issues found. `OpeningHours`'s tri-state parsing (midnight-crossing fold only applied when a rule spans all 7 days), `ScanPoisHandler::allResupplyPoisAreClosed()`'s closed-only-when-known precedence (a single open/unknown POI suppresses the warning), and `NearbyNameDeduplicator::withoutLosingKnownValues()`'s null-only backfill all trace correctly against the code and are covered by unit/integration tests. Confirmed `osm.pois.opening_hours`/`website` and `osm.cultural_pois.website` already exist from prior migrations (`Version20260614120000`, `Version20260617150000`) — no migration gap for the new `SELECT`s. PR title follows Conventional Commits.

Resolved threads: both previously open bot threads (midnight-crossing fold, dedup website loss) were already resolved by the fix commits on this branch — no new resolutions needed this pass. One previously-dismissed bot review was left unminimized; minimized it now.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

Reviewed at commit `57ca843bbfa79a8723f20b47b7b9518b8d9ef11a`.
<!-- claude-review-end -->