### PR TITLE
fix(datatourisme): stop truncating the flux tags to the type list

### DIFF
--- a/api/src/AccommodationSource/DataTourismeAccommodationSource.php
+++ b/api/src/AccommodationSource/DataTourismeAccommodationSource.php
@@ -56,12 +56,17 @@ final readonly class DataTourismeAccommodationSource implements AccommodationSou
                 $isExact = $pricing['isExact'];
             }
 
-            // The flux publishes fields, not OSM tags, and tourism.accommodations has
-            // no website column: `tagCount` counts the attributes actually filled for
-            // this entry and `hasWebsite` follows the URL we can expose, so neither is
-            // a hardcoded constant penalising the curated source (#869).
-            /** @var ?string $url tourism.accommodations exposes no website column yet */
-            $url = null;
+            // The contact block and the opening hours the flux carries are preserved
+            // in `tourism.accommodations.tags` by the provisioner (#871), pending the
+            // dedicated columns of #872. Reading them here is what lets the
+            // completeness ranking score this source and SeasonalityChecker decide
+            // `possibleClosed` on a DataTourisme entry at all.
+            $tags = $accommodation['tags'];
+            $url = $tags['website'] ?? $tags['booking_url'] ?? null;
+
+            // `tagCount` counts the attributes actually filled for this entry: the
+            // flux publishes fields, not OSM tags, so the OSM tag-richness proxy would
+            // read as 0 and penalise the curated source (#869).
             $filledAttributes = array_filter(
                 [$name, $accommodation['category'], $accommodation['description'], $accommodation['capacity'], $accommodation['price']],
                 static fn (string|int|float|null $value): bool => null !== $value && '' !== $value,
@@ -82,11 +87,8 @@ final readonly class DataTourismeAccommodationSource implements AccommodationSou
                 'capacity' => $accommodation['capacity'],
                 'fee' => null,
                 'tagCount' => \count($filledAttributes),
-                // Necessarily false today: `$url` above is null until #872 adds the
-                // website column. Derived from `$url` rather than written as `false`
-                // so it starts reporting the truth the moment that column lands.
                 'hasWebsite' => null !== $url,
-                'tags' => [],
+                'tags' => $tags,
                 'source' => 'datatourisme',
                 'wikidataId' => null,
                 'description' => $accommodation['description'],
@@ -95,7 +97,7 @@ final readonly class DataTourismeAccommodationSource implements AccommodationSou
                 // tourism.cultural_pois / food_pois): these stay null by design.
                 'imageUrl' => null,
                 'wikipediaUrl' => null,
-                'openingHours' => null,
+                'openingHours' => $tags['opening_hours'] ?? null,
             ];
         }
 

--- a/api/src/Tourism/AccommodationRepository.php
+++ b/api/src/Tourism/AccommodationRepository.php
@@ -37,7 +37,7 @@ final readonly class AccommodationRepository implements AccommodationRepositoryI
      * @param list<array{lat: float, lon: float}> $points
      * @param list<string>                        $categories
      *
-     * @return list<array{name: ?string, category: string, lat: float, lon: float, capacity: ?int, price: ?float, description: ?string}>
+     * @return list<array{name: ?string, category: string, lat: float, lon: float, capacity: ?int, price: ?float, description: ?string, tags: array<string, string>}>
      */
     public function findNear(array $points, int $radiusMeters, array $categories): array
     {
@@ -72,7 +72,7 @@ final readonly class AccommodationRepository implements AccommodationRepositoryI
                 SELECT ranked.*
                 FROM (
                     SELECT a.id,
-                           a.name, a.category, a.capacity, a.price, a.description,
+                           a.name, a.category, a.capacity, a.price, a.description, a.tags,
                            ST_Y(a.geom) AS lat, ST_X(a.geom) AS lon,
                            nearest.point_index, nearest.distance,
                            ROW_NUMBER() OVER (
@@ -119,9 +119,40 @@ final readonly class AccommodationRepository implements AccommodationRepositoryI
                 'capacity' => null !== $row['capacity'] ? (int) $row['capacity'] : null,
                 'price' => null !== $row['price'] ? (float) $row['price'] : null,
                 'description' => null !== $row['description'] && '' !== $row['description'] ? (string) $row['description'] : null,
+                'tags' => $this->decodeTags($row['tags']),
             ];
         }
 
         return $accommodations;
+    }
+
+    /**
+     * The flux keys the provisioner preserved (DataTourismeMapper::tags), flattened
+     * to the OSM-tag contract the consumers share: `opening_hours` is what
+     * SeasonalityChecker reads, `website` what the completeness ranking scores.
+     * List-valued keys (`type`, `labels`) stay in the jsonb and are not projected
+     * here, that contract being string → string.
+     *
+     * @return array<string, string>
+     */
+    private function decodeTags(mixed $raw): array
+    {
+        if (!\is_string($raw)) {
+            return [];
+        }
+
+        $decoded = json_decode($raw, true);
+        if (!\is_array($decoded)) {
+            return [];
+        }
+
+        $tags = [];
+        foreach ($decoded as $key => $value) {
+            if (is_scalar($value)) {
+                $tags[(string) $key] = (string) $value;
+            }
+        }
+
+        return $tags;
     }
 }

--- a/api/src/Tourism/AccommodationRepositoryInterface.php
+++ b/api/src/Tourism/AccommodationRepositoryInterface.php
@@ -11,12 +11,14 @@ interface AccommodationRepositoryInterface
      * any point, grouped by the end point they belong to (nearest first within each
      * group) and capped per end point, so a dense end point cannot starve a sparse
      * one. `price` is the structured offer price when DataTourisme provided one
-     * (exact), null otherwise (the caller falls back to a heuristic).
+     * (exact), null otherwise (the caller falls back to a heuristic). `tags` carries
+     * the flux keys the provisioner preserved, flattened to the OSM-tag contract
+     * (`opening_hours`, `website`, `phone`, …).
      *
      * @param list<array{lat: float, lon: float}> $points
      * @param list<string>                        $categories
      *
-     * @return list<array{name: ?string, category: string, lat: float, lon: float, capacity: ?int, price: ?float, description: ?string}>
+     * @return list<array{name: ?string, category: string, lat: float, lon: float, capacity: ?int, price: ?float, description: ?string, tags: array<string, string>}>
      */
     public function findNear(array $points, int $radiusMeters, array $categories): array;
 }

--- a/api/tests/Integration/Tourism/TourismIndexReadTest.php
+++ b/api/tests/Integration/Tourism/TourismIndexReadTest.php
@@ -43,16 +43,17 @@ final class TourismIndexReadTest extends KernelTestCase
             SQL);
 
         $this->connection->executeStatement(<<<'SQL'
-            INSERT INTO tourism.cultural_pois (id, name, category, opening_hours, description, wikidata, image_url, wikipedia_url, tags, geom) VALUES
-              ('c1', 'Musée du Lac', 'museum', 'Mo-Fr 09:00-17:00', 'Un musée.', 'Q42', 'https://img.test/musee.jpg', 'https://fr.wikipedia.org/wiki/Musee', '{}'::jsonb,
+            INSERT INTO tourism.cultural_pois (id, name, category, opening_hours, description, website, wikidata, image_url, wikipedia_url, tags, geom) VALUES
+              ('c1', 'Musée du Lac', 'museum', 'Mo-Fr 09:00-17:00', 'Un musée.', 'https://musee.test', 'Q42', 'https://img.test/musee.jpg', 'https://fr.wikipedia.org/wiki/Musee', '{"type": ["CulturalSite"], "city": "Nancy"}'::jsonb,
                   ST_SetSRID(ST_MakePoint(6.14, 49.61), 4326)),
-              ('c2', 'Far Museum', 'museum', NULL, NULL, NULL, NULL, NULL, '{}'::jsonb,
+              ('c2', 'Far Museum', 'museum', NULL, NULL, NULL, NULL, NULL, NULL, '{}'::jsonb,
                   ST_SetSRID(ST_MakePoint(6.80, 50.90), 4326))
             SQL);
 
         $this->connection->executeStatement(<<<'SQL'
             INSERT INTO tourism.accommodations (id, name, category, capacity, price, description, tags, geom) VALUES
-              ('a1', 'Gîte du Lac', 'rental', 4, 75.00, NULL, '{}'::jsonb,
+              ('a1', 'Gîte du Lac', 'rental', 4, 75.00, NULL,
+                  '{"type": ["Accommodation", "RentalAccommodation"], "website": "https://gite.test", "opening_hours": "Apr-Oct", "labels": ["Accueil Vélo"]}'::jsonb,
                   ST_SetSRID(ST_MakePoint(2.50, 48.50), 4326)),
               ('a2', 'Grand Hôtel', 'hotel', NULL, NULL, NULL, '{}'::jsonb,
                   ST_SetSRID(ST_MakePoint(2.50, 48.50), 4326))
@@ -111,6 +112,12 @@ final class TourismIndexReadTest extends KernelTestCase
         self::assertSame('Gîte du Lac', $accommodations[0]['name']);
         self::assertSame(4, $accommodations[0]['capacity']);
         self::assertSame(75.0, $accommodations[0]['price']);
+        // The preserved flux keys reach the source flattened to the OSM-tag contract:
+        // scalars only, so the list-valued `type` / `labels` stay in the jsonb (#871).
+        self::assertSame(
+            ['website' => 'https://gite.test', 'opening_hours' => 'Apr-Oct'],
+            $accommodations[0]['tags'],
+        );
     }
 
     #[Test]

--- a/api/tests/Unit/AccommodationSource/DataTourismeAccommodationSourceTest.php
+++ b/api/tests/Unit/AccommodationSource/DataTourismeAccommodationSourceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\AccommodationSource;
 
+use App\Accommodation\SeasonalityChecker;
 use App\AccommodationSource\DataTourismeAccommodationSource;
 use App\ApiResource\Model\Coordinate;
 use App\ApiResource\TripRequest;
@@ -19,7 +20,7 @@ final class DataTourismeAccommodationSourceTest extends TestCase
     {
         $repository = $this->createStub(AccommodationRepositoryInterface::class);
         $repository->method('findNear')->willReturn([
-            ['name' => 'Gîte du Lac', 'category' => 'rental', 'lat' => 48.0, 'lon' => 2.0, 'capacity' => 4, 'price' => 75.0, 'description' => 'Joli gîte'],
+            ['name' => 'Gîte du Lac', 'category' => 'rental', 'lat' => 48.0, 'lon' => 2.0, 'capacity' => 4, 'price' => 75.0, 'description' => 'Joli gîte', 'tags' => []],
         ]);
 
         // The heuristic engine is final and cannot be doubled, so we pass a real
@@ -47,7 +48,7 @@ final class DataTourismeAccommodationSourceTest extends TestCase
     {
         $repository = $this->createStub(AccommodationRepositoryInterface::class);
         $repository->method('findNear')->willReturn([
-            ['name' => 'Hôtel du Parc', 'category' => 'hotel', 'lat' => 48.0, 'lon' => 2.0, 'capacity' => null, 'price' => null, 'description' => null],
+            ['name' => 'Hôtel du Parc', 'category' => 'hotel', 'lat' => 48.0, 'lon' => 2.0, 'capacity' => null, 'price' => null, 'description' => null, 'tags' => []],
         ]);
 
         $engine = new PricingHeuristicEngine();
@@ -67,9 +68,9 @@ final class DataTourismeAccommodationSourceTest extends TestCase
     {
         $repository = $this->createStub(AccommodationRepositoryInterface::class);
         $repository->method('findNear')->willReturn([
-            ['name' => null, 'category' => 'hotel', 'lat' => 48.0, 'lon' => 2.0, 'capacity' => null, 'price' => null, 'description' => null],
-            ['name' => '   ', 'category' => 'rental', 'lat' => 48.1, 'lon' => 2.1, 'capacity' => null, 'price' => null, 'description' => null],
-            ['name' => 'Gîte du Lac', 'category' => 'rental', 'lat' => 48.2, 'lon' => 2.2, 'capacity' => 4, 'price' => 75.0, 'description' => null],
+            ['name' => null, 'category' => 'hotel', 'lat' => 48.0, 'lon' => 2.0, 'capacity' => null, 'price' => null, 'description' => null, 'tags' => []],
+            ['name' => '   ', 'category' => 'rental', 'lat' => 48.1, 'lon' => 2.1, 'capacity' => null, 'price' => null, 'description' => null, 'tags' => []],
+            ['name' => 'Gîte du Lac', 'category' => 'rental', 'lat' => 48.2, 'lon' => 2.2, 'capacity' => 4, 'price' => 75.0, 'description' => null, 'tags' => []],
         ]);
 
         $result = new DataTourismeAccommodationSource($repository, new PricingHeuristicEngine())
@@ -87,8 +88,8 @@ final class DataTourismeAccommodationSourceTest extends TestCase
         // name + category for the bare entry, plus description/capacity/price.
         $repository = $this->createStub(AccommodationRepositoryInterface::class);
         $repository->method('findNear')->willReturn([
-            ['name' => 'Fiche complète', 'category' => 'hotel', 'lat' => 48.0, 'lon' => 2.0, 'capacity' => 12, 'price' => 75.0, 'description' => 'Décrit'],
-            ['name' => 'Fiche nue', 'category' => 'hotel', 'lat' => 48.1, 'lon' => 2.1, 'capacity' => null, 'price' => null, 'description' => null],
+            ['name' => 'Fiche complète', 'category' => 'hotel', 'lat' => 48.0, 'lon' => 2.0, 'capacity' => 12, 'price' => 75.0, 'description' => 'Décrit', 'tags' => []],
+            ['name' => 'Fiche nue', 'category' => 'hotel', 'lat' => 48.1, 'lon' => 2.1, 'capacity' => null, 'price' => null, 'description' => null, 'tags' => []],
         ]);
 
         $result = new DataTourismeAccommodationSource($repository, new PricingHeuristicEngine())
@@ -101,11 +102,11 @@ final class DataTourismeAccommodationSourceTest extends TestCase
     #[Test]
     public function derivesHasWebsiteFromTheExposedUrl(): void
     {
-        // tourism.accommodations has no website column, so there is no URL to expose
-        // and `hasWebsite` follows it instead of being asserted.
+        // An entry the flux published without any contact exposes no URL, and
+        // `hasWebsite` follows it instead of being asserted.
         $repository = $this->createStub(AccommodationRepositoryInterface::class);
         $repository->method('findNear')->willReturn([
-            ['name' => 'Hôtel du Parc', 'category' => 'hotel', 'lat' => 48.0, 'lon' => 2.0, 'capacity' => null, 'price' => null, 'description' => null],
+            ['name' => 'Hôtel du Parc', 'category' => 'hotel', 'lat' => 48.0, 'lon' => 2.0, 'capacity' => null, 'price' => null, 'description' => null, 'tags' => []],
         ]);
 
         $result = new DataTourismeAccommodationSource($repository, new PricingHeuristicEngine())
@@ -120,7 +121,7 @@ final class DataTourismeAccommodationSourceTest extends TestCase
     {
         $repository = $this->createStub(AccommodationRepositoryInterface::class);
         $repository->method('findNear')->willReturn([
-            ['name' => 'Gîte du Lac', 'category' => 'rental', 'lat' => 48.0, 'lon' => 2.0, 'capacity' => 4, 'price' => null, 'description' => null],
+            ['name' => 'Gîte du Lac', 'category' => 'rental', 'lat' => 48.0, 'lon' => 2.0, 'capacity' => 4, 'price' => null, 'description' => null, 'tags' => []],
         ]);
 
         $result = new DataTourismeAccommodationSource($repository, new PricingHeuristicEngine())
@@ -141,7 +142,7 @@ final class DataTourismeAccommodationSourceTest extends TestCase
 
         $repository = $this->createStub(AccommodationRepositoryInterface::class);
         $repository->method('findNear')->willReturn([
-            ['name' => 'Gîte des Prés', 'category' => 'rental', 'lat' => 48.0, 'lon' => 2.0, 'capacity' => 4, 'price' => null, 'description' => null],
+            ['name' => 'Gîte des Prés', 'category' => 'rental', 'lat' => 48.0, 'lon' => 2.0, 'capacity' => 4, 'price' => null, 'description' => null, 'tags' => []],
         ]);
 
         $engine = new PricingHeuristicEngine();
@@ -154,5 +155,78 @@ final class DataTourismeAccommodationSourceTest extends TestCase
         self::assertSame('rental', $result[0]['type']);
         self::assertSame($expected['min'], $result[0]['priceMin']);
         self::assertSame($expected['max'], $result[0]['priceMax']);
+    }
+
+    /**
+     * The source used to pass `'tags' => []` whatever the index held, so the flux
+     * contact and opening hours preserved by the provisioner never reached a
+     * consumer (#871).
+     */
+    #[Test]
+    public function propagatesThePreservedFluxTags(): void
+    {
+        $repository = $this->createStub(AccommodationRepositoryInterface::class);
+        $repository->method('findNear')->willReturn([
+            [
+                'name' => 'Camping du Lac', 'category' => 'camp_site', 'lat' => 48.0, 'lon' => 2.0,
+                'capacity' => null, 'price' => null, 'description' => null,
+                'tags' => ['website' => 'https://camping.test', 'phone' => '+33 3 88 00 00 00', 'opening_hours' => 'Apr-Oct'],
+            ],
+        ]);
+
+        $result = new DataTourismeAccommodationSource($repository, new PricingHeuristicEngine())
+            ->fetch([new Coordinate(48.0, 2.0)], 5000, ['camp_site']);
+
+        self::assertSame(
+            ['website' => 'https://camping.test', 'phone' => '+33 3 88 00 00 00', 'opening_hours' => 'Apr-Oct'],
+            $result[0]['tags'],
+        );
+        self::assertSame('https://camping.test', $result[0]['url']);
+        self::assertTrue($result[0]['hasWebsite']);
+        self::assertSame('Apr-Oct', $result[0]['openingHours']);
+    }
+
+    #[Test]
+    public function fallsBackToTheBookingUrlWhenNoWebsiteWasPublished(): void
+    {
+        $repository = $this->createStub(AccommodationRepositoryInterface::class);
+        $repository->method('findNear')->willReturn([
+            [
+                'name' => 'Gîte du Lac', 'category' => 'rental', 'lat' => 48.0, 'lon' => 2.0,
+                'capacity' => null, 'price' => null, 'description' => null,
+                'tags' => ['booking_url' => 'https://booking.test/gite'],
+            ],
+        ]);
+
+        $result = new DataTourismeAccommodationSource($repository, new PricingHeuristicEngine())
+            ->fetch([new Coordinate(48.0, 2.0)], 5000, ['rental']);
+
+        self::assertSame('https://booking.test/gite', $result[0]['url']);
+        self::assertTrue($result[0]['hasWebsite']);
+    }
+
+    /**
+     * End of the chain the empty tags array used to cut: ScanAccommodationsHandler
+     * feeds `$raw['tags']` to the SeasonalityChecker, which could never return
+     * anything but null on a DataTourisme entry.
+     */
+    #[Test]
+    public function letsTheSeasonalityCheckerDecideOnADataTourismeEntry(): void
+    {
+        $repository = $this->createStub(AccommodationRepositoryInterface::class);
+        $repository->method('findNear')->willReturn([
+            [
+                'name' => 'Camping du Lac', 'category' => 'camp_site', 'lat' => 48.0, 'lon' => 2.0,
+                'capacity' => null, 'price' => null, 'description' => null,
+                'tags' => ['opening_hours' => 'Apr-Oct'],
+            ],
+        ]);
+
+        $result = new DataTourismeAccommodationSource($repository, new PricingHeuristicEngine())
+            ->fetch([new Coordinate(48.0, 2.0)], 5000, ['camp_site']);
+
+        $checker = new SeasonalityChecker();
+        self::assertFalse($checker->isLikelyOpen(new \DateTimeImmutable('2026-01-15'), $result[0]['tags']), 'closed in January → possibleClosed');
+        self::assertTrue($checker->isLikelyOpen(new \DateTimeImmutable('2026-06-15'), $result[0]['tags']));
     }
 }

--- a/provisioner/src/DataTourismeImporter.php
+++ b/provisioner/src/DataTourismeImporter.php
@@ -40,13 +40,13 @@ final readonly class DataTourismeImporter
     /**
      * Target tables and their COPY column order. `geom` always comes last and is
      * fed EWKT. Must match Version20260616120000 / Version20260616140000 (the
-     * live-schema bootstraps).
+     * live-schema bootstraps) plus Version20260617130000 (`website`).
      *
      * @var array<string, list<string>>
      */
     private const array TABLE_COLUMNS = [
-        'cultural_pois' => ['id', 'name', 'category', 'opening_hours', 'description', 'wikidata', 'tags', 'geom'],
-        'food_pois' => ['id', 'name', 'category', 'opening_hours', 'description', 'wikidata', 'tags', 'geom'],
+        'cultural_pois' => ['id', 'name', 'category', 'opening_hours', 'description', 'website', 'wikidata', 'tags', 'geom'],
+        'food_pois' => ['id', 'name', 'category', 'opening_hours', 'description', 'website', 'wikidata', 'tags', 'geom'],
         'accommodations' => ['id', 'name', 'category', 'capacity', 'price', 'description', 'tags', 'geom'],
         'events' => ['id', 'name', 'category', 'start_date', 'end_date', 'url', 'description', 'price_min', 'tags', 'geom'],
     ];
@@ -238,12 +238,14 @@ final readonly class DataTourismeImporter
     private function copyLine(string $table, array $row): string
     {
         $geom = \sprintf('SRID=4326;POINT(%.7F %.7F)', $row['lon'], $row['lat']);
-        $tags = json_encode(['type' => $row['type']], \JSON_UNESCAPED_UNICODE | \JSON_UNESCAPED_SLASHES) ?: '{}';
+        // The mapper already narrowed the source object down to the keys worth
+        // keeping (see DataTourismeMapper::tags); this only serialises them.
+        $tags = json_encode($row['tags'], \JSON_UNESCAPED_UNICODE | \JSON_UNESCAPED_SLASHES) ?: '{}';
 
         $values = match ($table) {
-            'cultural_pois', 'food_pois' => [$row['id'], $row['name'], $row['category'], $row['openingHours'], $row['description'], $row['wikidata'], $tags, $geom],
+            'cultural_pois', 'food_pois' => [$row['id'], $row['name'], $row['category'], $row['openingHours'], $row['description'], $row['website'], $row['wikidata'], $tags, $geom],
             'accommodations' => [$row['id'], $row['name'], $row['category'], $row['capacity'], $row['price'], $row['description'], $tags, $geom],
-            'events' => [$row['id'], $row['name'], $row['category'], $row['startDate'], $row['endDate'], null, $row['description'], $row['price'], $tags, $geom],
+            'events' => [$row['id'], $row['name'], $row['category'], $row['startDate'], $row['endDate'], $row['website'], $row['description'], $row['price'], $tags, $geom],
             default => [],
         };
 

--- a/provisioner/src/DataTourismeMapper.php
+++ b/provisioner/src/DataTourismeMapper.php
@@ -12,10 +12,11 @@ namespace Provisioner;
  * the JSON-LD type array (e.g. "CulturalSite", "Accommodation",
  * "EntertainmentAndEvent"), labels as language-maps ({"fr":["…"]}), and the
  * location under isLocatedAt[0]["schema:geo"] — none of which match the old
- * runtime REST API shape, so this is a flux-specific mapper. The raw type list
- * is preserved in the row's tags so nothing is lost.
+ * runtime REST API shape, so this is a flux-specific mapper. A curated subset of
+ * the source object is preserved in the row's tags (see {@see tags}), because
+ * whatever is dropped here is unrecoverable short of a full re-import (#871).
  *
- * @phpstan-type Row array{head: 'cultural'|'accommodation'|'event'|'food', id: string, name: string|null, category: string, lat: float, lon: float, description: string|null, openingHours: string|null, wikidata: string|null, capacity: int|null, price: float|null, startDate: string|null, endDate: string|null, type: list<string>}
+ * @phpstan-type Row array{head: 'cultural'|'accommodation'|'event'|'food', id: string, name: string|null, category: string, lat: float, lon: float, description: string|null, openingHours: string|null, website: string|null, wikidata: string|null, capacity: int|null, price: float|null, startDate: string|null, endDate: string|null, tags: array<string, mixed>}
  */
 final class DataTourismeMapper
 {
@@ -91,6 +92,12 @@ final class DataTourismeMapper
         'TheaterEvent' => 'show', 'ShowEvent' => 'show', 'ScreeningEvent' => 'show', 'Cinema' => 'show',
     ];
 
+    /** English 3-letter month abbreviations, the vocabulary SeasonalityChecker parses. */
+    private const array MONTH_ABBREVIATIONS = [
+        1 => 'Jan', 2 => 'Feb', 3 => 'Mar', 4 => 'Apr', 5 => 'May', 6 => 'Jun',
+        7 => 'Jul', 8 => 'Aug', 9 => 'Sep', 10 => 'Oct', 11 => 'Nov', 12 => 'Dec',
+    ];
+
     private int $unmappedAccommodations = 0;
 
     /**
@@ -131,6 +138,8 @@ final class DataTourismeMapper
         }
 
         [$startDate, $endDate] = 'event' === $head ? $this->dates($object) : [null, null];
+        $contact = $this->contact($object);
+        $openingHours = $this->openingHours($object);
 
         return [
             'head' => $head,
@@ -140,14 +149,65 @@ final class DataTourismeMapper
             'lat' => $coords['lat'],
             'lon' => $coords['lon'],
             'description' => $this->description($object),
-            'openingHours' => null,
+            'openingHours' => $openingHours,
+            'website' => $contact['website'] ?? $contact['bookingUrl'],
             'wikidata' => $this->wikidata($object),
             'capacity' => 'accommodation' === $head ? $this->intOrNull($object['allowedPersons'] ?? null) : null,
             'price' => 'accommodation' === $head || 'event' === $head ? $this->price($object['offers'] ?? null) : null,
             'startDate' => $startDate,
             'endDate' => $endDate,
-            'type' => $types,
+            'tags' => $this->tags($object, $types, $openingHours, $contact),
         ];
+    }
+
+    /**
+     * Flux keys preserved in the row's `tags` jsonb.
+     *
+     * The flux object carries ~40 predicates; storing them wholesale would turn a
+     * 4-column index into an archive of the source dump. The selection below is
+     * explicit and each key has a named consumer:
+     *
+     * - `type`: the raw ontology type list, the only way to reclassify a row (a
+     *   new subtype, a category split) without re-importing the whole flux.
+     * - `opening_hours`: OSM tag key on purpose, so `App\Accommodation\SeasonalityChecker`
+     *   — which reads `$tags['opening_hours']` — works on DataTourisme rows too.
+     * - `website`, `phone`, `email`, `booking_url`: the contact block, feeding the
+     *   accommodation URL and the `hasWebsite` completeness signal (#869).
+     * - `address`, `postal_code`, `city`: the postal address, so a stage label or a
+     *   suggestion can be shown without a reverse-geocode round trip.
+     * - `image_url`: the main photo, promoted to a column by #872.
+     * - `labels`: classification / feature labels, where quality labels such as
+     *   "Accueil Vélo" live.
+     *
+     * Deliberately dropped: the long descriptions and reviews (kilobytes of free
+     * text per row across ~390k objects, no consumer), the themes and audiences,
+     * the media list beyond the main photo, and the publication metadata. Keys with
+     * no value are omitted rather than stored as null, so a bare object still
+     * weighs exactly its type list.
+     *
+     * @param array<string, mixed>                                                         $object
+     * @param list<string>                                                                 $types
+     * @param array{website: ?string, phone: ?string, email: ?string, bookingUrl: ?string} $contact
+     *
+     * @return array<string, mixed>
+     */
+    private function tags(array $object, array $types, ?string $openingHours, array $contact): array
+    {
+        $address = $this->address($object);
+
+        return array_filter([
+            'type' => $types,
+            'opening_hours' => $openingHours,
+            'website' => $contact['website'],
+            'phone' => $contact['phone'],
+            'email' => $contact['email'],
+            'booking_url' => $contact['bookingUrl'],
+            'address' => $address['address'],
+            'postal_code' => $address['postalCode'],
+            'city' => $address['city'],
+            'image_url' => $this->imageUrl($object),
+            'labels' => $this->labels($object),
+        ], static fn (mixed $value): bool => null !== $value && [] !== $value);
     }
 
     /**
@@ -288,6 +348,214 @@ final class DataTourismeMapper
         }
 
         return $this->label($object['rdfs:comment'] ?? null);
+    }
+
+    /**
+     * Contact block: the official homepage plus the phone/email of the first
+     * contact carrying them, and the booking contact's homepage. The flux splits
+     * them over `foaf:homepage` (top level), `hasContact` and `hasBookingContact`;
+     * the first non-empty value wins, contacts being published most-relevant first.
+     *
+     * @param array<string, mixed> $object
+     *
+     * @return array{website: ?string, phone: ?string, email: ?string, bookingUrl: ?string}
+     */
+    private function contact(array $object): array
+    {
+        $website = $this->firstString($object['foaf:homepage'] ?? null);
+        $phone = null;
+        $email = null;
+        foreach ($this->objectList($object['hasContact'] ?? null) as $contact) {
+            $website ??= $this->firstString($contact['foaf:homepage'] ?? null);
+            $phone ??= $this->firstString($contact['schema:telephone'] ?? null);
+            $email ??= $this->firstString($contact['schema:email'] ?? null);
+        }
+
+        $bookingUrl = null;
+        foreach ($this->objectList($object['hasBookingContact'] ?? null) as $contact) {
+            $bookingUrl ??= $this->firstString($contact['foaf:homepage'] ?? null);
+        }
+
+        return ['website' => $website, 'phone' => $phone, 'email' => $email, 'bookingUrl' => $bookingUrl];
+    }
+
+    /**
+     * Postal address of the located place. The city is published either inline
+     * (`schema:addressLocality`) or as a linked City resource (`hasAddressCity`).
+     *
+     * @param array<string, mixed> $object
+     *
+     * @return array{address: ?string, postalCode: ?string, city: ?string}
+     */
+    private function address(array $object): array
+    {
+        $located = $this->objectList($object['isLocatedAt'] ?? null)[0] ?? [];
+        $address = $this->objectList($located['schema:address'] ?? null)[0] ?? [];
+
+        $city = $this->firstString($address['schema:addressLocality'] ?? null);
+        if (null === $city) {
+            $linkedCity = $this->objectList($address['hasAddressCity'] ?? null)[0] ?? [];
+            $city = $this->label($linkedCity['rdfs:label'] ?? null);
+        }
+
+        return [
+            'address' => $this->firstString($address['schema:streetAddress'] ?? null),
+            'postalCode' => $this->firstString($address['schema:postalCode'] ?? null),
+            'city' => $city,
+        ];
+    }
+
+    /**
+     * Opening hours as a single OSM-flavoured string ("Apr-Oct 09:00-18:00").
+     *
+     * The flux publishes one `OpeningHoursSpecification` per period, under
+     * `takesPlaceAt` or under the place's `schema:openingHoursSpecification`, with
+     * either the schema.org (`schema:validFrom`) or the DataTourisme (`startDate`)
+     * naming. Nothing downstream can consume that list, so it is reduced to its
+     * envelope: earliest month → latest month, earliest opening → latest closing.
+     * That is the syntax {@see \App\Accommodation\SeasonalityChecker} parses, and
+     * the one already displayed for the OSM and Wikidata rows.
+     *
+     * @param array<string, mixed> $object
+     */
+    private function openingHours(array $object): ?string
+    {
+        $located = $this->objectList($object['isLocatedAt'] ?? null)[0] ?? [];
+        $specifications = array_merge(
+            $this->objectList($object['takesPlaceAt'] ?? null),
+            $this->objectList($object['schema:openingHoursSpecification'] ?? null),
+            $this->objectList($located['schema:openingHoursSpecification'] ?? null),
+        );
+
+        $firstMonth = null;
+        $lastMonth = null;
+        $opensAt = null;
+        $closesAt = null;
+        foreach ($specifications as $specification) {
+            $from = $this->month($specification['schema:validFrom'] ?? $specification['startDate'] ?? $specification['schema:startDate'] ?? null);
+            $through = $this->month($specification['schema:validThrough'] ?? $specification['endDate'] ?? $specification['schema:endDate'] ?? null);
+            if (null !== $from && null !== $through) {
+                $firstMonth = null === $firstMonth ? $from : min($firstMonth, $from);
+                $lastMonth = null === $lastMonth ? $through : max($lastMonth, $through);
+            }
+
+            $open = $this->time($specification['schema:opens'] ?? $specification['startTime'] ?? $specification['schema:startTime'] ?? null);
+            $close = $this->time($specification['schema:closes'] ?? $specification['endTime'] ?? $specification['schema:endTime'] ?? null);
+            if (null !== $open && null !== $close) {
+                $opensAt = null === $opensAt ? $open : min($opensAt, $open);
+                $closesAt = null === $closesAt ? $close : max($closesAt, $close);
+            }
+        }
+
+        $parts = [];
+        if (null !== $firstMonth && null !== $lastMonth) {
+            $parts[] = \sprintf('%s-%s', self::MONTH_ABBREVIATIONS[$firstMonth], self::MONTH_ABBREVIATIONS[$lastMonth]);
+        }
+
+        if (null !== $opensAt && null !== $closesAt) {
+            $parts[] = \sprintf('%s-%s', $opensAt, $closesAt);
+        }
+
+        return [] === $parts ? null : implode(' ', $parts);
+    }
+
+    /**
+     * Main photo URL (hasMainRepresentation → MediaResource → ebucore:locator).
+     *
+     * @param array<string, mixed> $object
+     */
+    private function imageUrl(array $object): ?string
+    {
+        foreach ($this->objectList($object['hasMainRepresentation'] ?? null) as $representation) {
+            foreach ($this->objectList($representation['ebucore:hasRelatedResource'] ?? null) as $resource) {
+                $locator = $this->firstString($resource['ebucore:locator'] ?? null);
+                if (null !== $locator) {
+                    return $locator;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Classification, feature and theme labels, deduplicated. Quality labels such
+     * as "Accueil Vélo" are published as classifications.
+     *
+     * @param array<string, mixed> $object
+     *
+     * @return list<string>
+     */
+    private function labels(array $object): array
+    {
+        $labels = [];
+        foreach (['hasClassification', 'hasFeature', 'hasTheme'] as $predicate) {
+            foreach ($this->objectList($object[$predicate] ?? null) as $entry) {
+                $label = $this->label($entry['rdfs:label'] ?? null);
+                if (null !== $label) {
+                    $labels[] = $label;
+                }
+            }
+        }
+
+        return array_values(array_unique($labels));
+    }
+
+    /**
+     * Nested JSON-LD resources, which the flux publishes either as a list or, when
+     * there is a single one, as the bare object.
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function objectList(mixed $value): array
+    {
+        if (!\is_array($value)) {
+            return [];
+        }
+
+        if (isset($value['@id']) || isset($value['@type'])) {
+            return [$this->stringKeyed($value)];
+        }
+
+        $objects = [];
+        foreach ($value as $item) {
+            if (\is_array($item)) {
+                $objects[] = $this->stringKeyed($item);
+            }
+        }
+
+        return $objects;
+    }
+
+    /**
+     * @param array<mixed, mixed> $value
+     *
+     * @return array<string, mixed>
+     */
+    private function stringKeyed(array $value): array
+    {
+        $keyed = [];
+        foreach ($value as $key => $property) {
+            $keyed[(string) $key] = $property;
+        }
+
+        return $keyed;
+    }
+
+    /** Month number of an ISO date ("2026-04-01" → 4). */
+    private function month(mixed $value): ?int
+    {
+        $date = $this->firstString($value);
+
+        return null !== $date && 1 === preg_match('/^\d{4}-(0[1-9]|1[0-2])/', $date, $matches) ? (int) $matches[1] : null;
+    }
+
+    /** HH:MM of an ISO time ("09:00:00" → "09:00"). */
+    private function time(mixed $value): ?string
+    {
+        $time = $this->firstString($value);
+
+        return null !== $time && 1 === preg_match('/^([01]\d|2[0-3]):[0-5]\d/', $time) ? substr($time, 0, 5) : null;
     }
 
     /**

--- a/provisioner/tests/DataTourismeImporterTest.php
+++ b/provisioner/tests/DataTourismeImporterTest.php
@@ -363,6 +363,89 @@ final class DataTourismeImporterTest extends TestCase
         return -1;
     }
 
+    /**
+     * The `tags` jsonb used to carry the type list alone and `website` was missing
+     * from the COPY column list although the DDL creates it, so both the column and
+     * everything else the flux publishes were dropped at import time (#871).
+     */
+    #[Test]
+    public function loadsTheWebsiteColumnAndTheFullTagsPayload(): void
+    {
+        $zipPath = $this->workDir.'/rich.zip';
+        $zip = new \ZipArchive();
+        $zip->open($zipPath, \ZipArchive::CREATE | \ZipArchive::OVERWRITE);
+        $zip->addFromString('objects/0/00/cultural.json', (string) json_encode([
+            '@id' => 'https://data.datatourisme.fr/10/cultural',
+            '@type' => ['CulturalSite', 'Museum'],
+            'rdfs:label' => ['fr' => ['Musee test']],
+            'hasContact' => [[
+                '@type' => ['Agent'],
+                'foaf:homepage' => ['https://musee.test'],
+                'schema:telephone' => ['+33 3 88 00 00 00'],
+            ]],
+            'isLocatedAt' => [[
+                '@type' => ['PlaceOfInterest'],
+                'schema:geo' => ['schema:latitude' => '48.5', 'schema:longitude' => '2.3'],
+                'schema:openingHoursSpecification' => [[
+                    '@type' => ['schema:OpeningHoursSpecification'],
+                    'schema:validFrom' => '2026-04-01',
+                    'schema:validThrough' => '2026-10-31',
+                ]],
+            ]],
+        ]));
+        $zip->addFromString('objects/0/00/event.json', (string) json_encode([
+            '@id' => 'https://data.datatourisme.fr/10/event',
+            '@type' => ['EntertainmentAndEvent', 'Festival'],
+            'rdfs:label' => ['fr' => ['Festival test']],
+            'foaf:homepage' => ['https://festival.test'],
+            'schema:startDate' => ['2026-07-01'],
+            'schema:endDate' => ['2026-07-03'],
+            'isLocatedAt' => [['schema:geo' => ['schema:latitude' => '45.0', 'schema:longitude' => '5.0']]],
+        ]));
+        $zip->close();
+
+        $bytes = (string) file_get_contents($zipPath);
+        unlink($zipPath);
+
+        $importer = new DataTourismeImporter(
+            fluxUrl: 'https://example.test/flux',
+            httpClient: new MockHttpClient(new MockResponse($bytes)),
+            processFactory: $this->capturingFactory(),
+        );
+        $importer->run($this->workDir);
+
+        // The COPY column list must name `website`, otherwise the column the DDL
+        // creates stays NULL for every row.
+        $joined = array_map(static fn (array $c): string => implode(' ', $c), $this->captured);
+        self::assertTrue(
+            (bool) array_filter($joined, static fn (string $c): bool => str_contains(
+                $c,
+                '\copy tourism_staging.cultural_pois (id, name, category, opening_hours, description, website, wikidata, tags, geom)',
+            )),
+            'cultural_pois is copied with its website column',
+        );
+        self::assertTrue(
+            (bool) array_filter($joined, static fn (string $c): bool => str_contains(
+                $c,
+                '\copy tourism_staging.food_pois (id, name, category, opening_hours, description, website, wikidata, tags, geom)',
+            )),
+            'food_pois is copied with its website column',
+        );
+
+        $cultural = explode("\t", rtrim((string) file_get_contents($this->workDir.'/tourism-cultural_pois.copy'), "\n"));
+        self::assertSame('Apr-Oct', $cultural[3], 'opening_hours comes from the flux, not a hardcoded null');
+        self::assertSame('https://musee.test', $cultural[5], 'website is fed from the contact homepage');
+        self::assertSame([
+            'type' => ['CulturalSite', 'Museum'],
+            'opening_hours' => 'Apr-Oct',
+            'website' => 'https://musee.test',
+            'phone' => '+33 3 88 00 00 00',
+        ], json_decode($cultural[7], true), 'tags keeps more than the type list');
+
+        $event = explode("\t", rtrim((string) file_get_contents($this->workDir.'/tourism-events.copy'), "\n"));
+        self::assertSame('https://festival.test', $event[5], 'events.url is populated instead of always null');
+    }
+
     #[Test]
     public function downloadFailureRaisesImportFailedException(): void
     {

--- a/provisioner/tests/DataTourismeMapperTest.php
+++ b/provisioner/tests/DataTourismeMapperTest.php
@@ -277,4 +277,160 @@ final class DataTourismeMapperTest extends TestCase
         self::assertNotNull($row);
         self::assertSame('Q12345', $row['wikidata']);
     }
+
+    /**
+     * A full flux object: everything the source publishes and the row has no column
+     * for must survive in `tags`, or it is unrecoverable short of a re-import (#871).
+     */
+    #[Test]
+    public function preservesTheContactAddressMediaAndLabelsInTags(): void
+    {
+        $row = $this->mapper->map($this->object(['CulturalSite', 'Museum'], [
+            'hasContact' => [[
+                '@type' => ['Agent'],
+                'schema:telephone' => ['+33 3 88 00 00 00'],
+                'schema:email' => ['contact@musee.test'],
+                'foaf:homepage' => ['https://musee.test'],
+            ]],
+            'hasBookingContact' => [[
+                '@type' => ['Agent'],
+                'foaf:homepage' => ['https://booking.test/musee'],
+            ]],
+            'isLocatedAt' => [[
+                '@type' => ['PlaceOfInterest'],
+                'schema:geo' => ['schema:latitude' => '49.1', 'schema:longitude' => '7.13'],
+                'schema:address' => [[
+                    '@type' => ['schema:PostalAddress'],
+                    'schema:streetAddress' => ['1 place du Château'],
+                    'schema:postalCode' => '67000',
+                    'hasAddressCity' => ['@type' => ['City'], 'rdfs:label' => ['fr' => ['Strasbourg']]],
+                ]],
+            ]],
+            'hasMainRepresentation' => [[
+                '@type' => ['MediaRepresentation'],
+                'ebucore:hasRelatedResource' => [[
+                    '@type' => ['MediaResource'],
+                    'ebucore:locator' => ['https://cdn.test/musee.jpg'],
+                ]],
+            ]],
+            'hasClassification' => [['@type' => ['TouristicLabel'], 'rdfs:label' => ['fr' => ['Accueil Vélo']]]],
+            'hasFeature' => [['@type' => ['Equipment'], 'rdfs:label' => ['fr' => ['Parking à vélos']]]],
+            // Bulk free text and provenance are deliberately NOT kept.
+            'hasReview' => [['@type' => ['Review'], 'rdfs:comment' => ['fr' => ['Un très long avis.']]]],
+            'lastUpdateDatatourisme' => '2026-07-31',
+        ]));
+
+        self::assertNotNull($row);
+        self::assertSame('https://musee.test', $row['website']);
+        self::assertSame([
+            'type' => ['CulturalSite', 'Museum'],
+            'website' => 'https://musee.test',
+            'phone' => '+33 3 88 00 00 00',
+            'email' => 'contact@musee.test',
+            'booking_url' => 'https://booking.test/musee',
+            'address' => '1 place du Château',
+            'postal_code' => '67000',
+            'city' => 'Strasbourg',
+            'image_url' => 'https://cdn.test/musee.jpg',
+            'labels' => ['Accueil Vélo', 'Parking à vélos'],
+        ], $row['tags']);
+    }
+
+    #[Test]
+    public function keepsOnlyTheTypeListWhenTheObjectCarriesNothingElse(): void
+    {
+        // The selection is opt-in: a bare object must not gain null-valued keys.
+        $row = $this->mapper->map($this->object(['CulturalSite', 'Museum']));
+
+        self::assertNotNull($row);
+        self::assertSame(['type' => ['CulturalSite', 'Museum']], $row['tags']);
+        self::assertNull($row['website']);
+        self::assertNull($row['openingHours']);
+    }
+
+    #[Test]
+    public function fallsBackToTheBookingContactForTheWebsite(): void
+    {
+        $row = $this->mapper->map($this->object(['Accommodation', 'Hotel'], [
+            'hasBookingContact' => [['@type' => ['Agent'], 'foaf:homepage' => ['https://booking.test/hotel']]],
+        ]));
+
+        self::assertNotNull($row);
+        self::assertSame('https://booking.test/hotel', $row['website']);
+    }
+
+    #[Test]
+    public function usesTheTopLevelHomepageAsTheOfficialWebsite(): void
+    {
+        $row = $this->mapper->map($this->object(['EntertainmentAndEvent', 'Festival'], [
+            'foaf:homepage' => ['https://festival.test'],
+            'hasContact' => [['@type' => ['Agent'], 'foaf:homepage' => ['https://organiser.test']]],
+        ]));
+
+        self::assertNotNull($row);
+        self::assertSame('https://festival.test', $row['website']);
+    }
+
+    /**
+     * The flux publishes one OpeningHoursSpecification per period; the row keeps
+     * their envelope in the OSM-ish syntax SeasonalityChecker parses.
+     */
+    #[Test]
+    public function mapsTheOpeningSpecificationsToASeasonString(): void
+    {
+        $row = $this->mapper->map($this->object(['Accommodation', 'Camping'], [
+            'isLocatedAt' => [[
+                '@type' => ['PlaceOfInterest'],
+                'schema:geo' => ['schema:latitude' => '49.1', 'schema:longitude' => '7.13'],
+                'schema:openingHoursSpecification' => [
+                    [
+                        '@type' => ['schema:OpeningHoursSpecification'],
+                        'schema:validFrom' => '2026-04-15',
+                        'schema:validThrough' => '2026-06-30',
+                        'schema:opens' => '09:00:00',
+                        'schema:closes' => '18:00:00',
+                    ],
+                    [
+                        '@type' => ['schema:OpeningHoursSpecification'],
+                        'schema:validFrom' => '2026-07-01',
+                        'schema:validThrough' => '2026-10-31',
+                        'schema:opens' => '08:00:00',
+                        'schema:closes' => '20:00:00',
+                    ],
+                ],
+            ]],
+        ]));
+
+        self::assertNotNull($row);
+        self::assertSame('Apr-Oct 08:00-20:00', $row['openingHours']);
+        self::assertSame('Apr-Oct 08:00-20:00', $row['tags']['opening_hours']);
+    }
+
+    #[Test]
+    public function readsTheDataTourismeNamingOfTheOpeningSpecifications(): void
+    {
+        // takesPlaceAt uses startDate/endDate rather than schema:validFrom/Through.
+        $row = $this->mapper->map($this->object(['CulturalSite', 'Museum'], [
+            'takesPlaceAt' => [[
+                '@type' => ['OpeningHoursSpecification'],
+                'startDate' => '2026-05-01',
+                'endDate' => '2026-09-30',
+            ]],
+        ]));
+
+        self::assertNotNull($row);
+        self::assertSame('May-Sep', $row['openingHours']);
+    }
+
+    #[Test]
+    public function ignoresOpeningSpecificationsWithoutUsableDatesOrTimes(): void
+    {
+        $row = $this->mapper->map($this->object(['CulturalSite', 'Museum'], [
+            'takesPlaceAt' => [['@type' => ['OpeningHoursSpecification'], 'schema:dayOfWeek' => ['Monday']]],
+        ]));
+
+        self::assertNotNull($row);
+        self::assertNull($row['openingHours']);
+        self::assertArrayNotHasKey('opening_hours', $row['tags']);
+    }
 }


### PR DESCRIPTION
Closes #871.

`copyLine()` sérialisait `json_encode(['type' => $row['type']])` : le `tags` jsonb de chaque ligne `tourism.*` ne contenait **que** la liste des types d'ontologie, et tout le reste de l'objet JSON-LD était jeté à l'instant du mappage — donc irrécupérable sans ré-import. Cette PR arrête la destruction d'information à l'import. L'ajout de colonnes dédiées est le périmètre de #872, qui se branche sur celle-ci.

## Justification des clés retenues dans `tags`

L'objet flux porte une quarantaine de prédicats. La sélection est **explicite** — une clé, un consommateur nommé — et non un archivage indiscriminé :

| Clé | Source flux | Consommateur |
|---|---|---|
| `type` | `@type` | seule façon de reclasser une ligne (nouveau sous-type, split de catégorie) sans ré-import |
| `opening_hours` | specs d'ouverture | clé de tag **OSM** volontairement : `SeasonalityChecker` lit `$tags['opening_hours']` ; colonne dédiée en #872 |
| `website`, `phone`, `email`, `booking_url` | `foaf:homepage`, `hasContact`, `hasBookingContact` | URL de l'hébergement + signal `hasWebsite` du `CandidateRanker` (#869) ; colonnes en #872 |
| `address`, `postal_code`, `city` | `isLocatedAt[0].schema:address` | libellé de ville / adresse sans aller-retour de reverse-geocode |
| `image_url` | `hasMainRepresentation → ebucore:locator` | colonne `image_url` de #872 |
| `labels` | `hasClassification`, `hasFeature`, `hasTheme` | c'est là que vit « Accueil Vélo » |

**Écartés volontairement** : descriptions longues et `hasReview` (des kilo-octets de texte libre par ligne sur ~390k objets, aucun consommateur — la description courte a déjà sa colonne), thèmes et audiences bruts, la liste média au-delà de la photo principale, les métadonnées de publication.

Les clés sans valeur sont **omises** (`array_filter`), pas stockées à `null` : un objet nu pèse toujours exactement sa liste de types.

## Détail

**`DataTourismeMapper`** — la `Row` gagne `website` et `tags` (la clé `type` disparaît, elle vit désormais dans `tags`), et `openingHours` n'est plus codé `null`. Nouveaux extracteurs : `contact()`, `address()`, `openingHours()`, `imageUrl()`, `labels()`.

Sur les horaires : le flux publie une liste de `OpeningHoursSpecification`, avec un nommage `schema:validFrom/validThrough/opens/closes` **ou** `startDate/endDate/startTime/endTime`, sous `takesPlaceAt` ou sous `isLocatedAt[0].schema:openingHoursSpecification`. Elles sont réduites à leur enveloppe dans la syntaxe **OSM** que l'application parse déjà : `Apr-Oct 08:00-20:00`. C'est exactement ce que `SeasonalityChecker::parseOpeningHours()` sait lire.

**`DataTourismeImporter`** — `TABLE_COLUMNS` ajoute `website` pour `cultural_pois` et `food_pois` (la colonne existait déjà via `Version20260617130000` et le `STAGING_DDL`, elle n'était simplement jamais peuplée), `events.url` reçoit `$row['website']` au lieu de `null`, et `copyLine()` sérialise `$row['tags']`.

**`Tourism\AccommodationRepository`** — `SELECT a.tags` et `decodeTags()`, même implémentation que `App\Osm\AccommodationRepository`. Le contrat consommateur est `array<string, string>`, donc seules les valeurs scalaires sont projetées ; `type` et `labels` (valeurs listes) restent dans le jsonb.

**`DataTourismeAccommodationSource`** — `'tags' => []` disparaît au profit des tags réels, débloquant `SeasonalityChecker` sur cette source : `alert.accommodation.seasonal_warning` ne considérait en pratique que les entrées OSM. `url` = `tags['website'] ?? tags['booking_url']`, `hasWebsite` en découle, `openingHours` = `tags['opening_hours']`.

## Auto-critique

- **`CulturalPoiRepository` / `FoodPoiRepository` ne lisent pas `website`, volontairement.** La colonne est désormais peuplée en base — c'est le critère d'acceptation — mais aucun consommateur ne l'expose (ni `CulturalPoiAlert` ni `PointOfInterest` n'ont de champ site à ce stade), et l'ajouter impliquerait un changement de DTO hors périmètre. À noter : #875 ajoute justement `website` à ces deux DTO côté OSM ; la lecture côté DataTourisme sera un suivi naturel.
- `tagCount` reste le comptage d'attributs remplis, inchangé, pour ne pas double-compter avec le score `hasWebsite` / `openingHours` du `CandidateRanker`.
- La réduction des specs d'ouverture à une enveloppe `Mmm-Mmm HH:MM-HH:MM` **perd de la granularité** (plusieurs plages disjointes deviennent une seule enveloppe). C'est délibéré : c'est le seul format que le parseur existant sait lire, et une enveloppe trop large ne peut que faire paraître un établissement ouvert — la direction prudente pour une alerte de fermeture saisonnière.
- Les critères d'acceptation portant sur des `SELECT count(*)` en base ne sont vérifiables **qu'après un ré-import réel** du flux. Ils ne sont pas prouvés ici ; les tests couvrent l'ordre des colonnes et le contenu du `\copy` via `processFactory`, sans base.

## Vérification

`make qa` ne peut pas aboutir sur une machine de dev. Legs individuels :

**Provisioner** (image `bike-trip-planner-provisioner:dev`)
```
 [OK] No errors                      <- phpstan
 [OK] Rector is done!
Found 0 of 21 files that can be fixed in 0.560 seconds, 70.00 MB memory used
OK (88 tests, 509 assertions)
```

**API — PHP-CS-Fixer + Rector + PHPStan**
```
Found 0 of 651 files that can be fixed in 0.228 seconds, 22.00 MB memory used
 [OK] Rector is done!
 [OK] No errors
```

**API — PHPUnit `tests/Unit` + `tests/Integration`**
```
Time: 04:11.132, Memory: 125.00 MB
OK, but some tests were skipped!
Tests: 1367, Assertions: 3825, Skipped: 1
```

Legs front (tsc / ESLint / Prettier / i18n) et markdownlint **non exécutés** : aucun fichier `pwa/`, aucun DTO API Platform, aucun `.md` modifié — `schema.d.ts` ne peut pas dériver. **Playwright : c'est CI le gate**, aucune couverture E2E locale n'est revendiquée.

### Preuve que les tests peuvent échouer

Quatre mutations, chacune vérifiée rouge puis restaurée :

1. `tags['opening_hours'] => null` dans le mapper → `DataTourismeMapperTest::mapsTheOpeningSpecificationsToASeasonString` (`Failed asserting that null is identical to 'Apr-Oct 08:00-20:00'`) + `DataTourismeImporterTest::loadsTheWebsiteColumnAndTheFullTagsPayload`.
2. Retrait de `website` de `TABLE_COLUMNS['cultural_pois']` → `cultural_pois is copied with its website column — Failed asserting that false is true`.
3. `$tags = []` dans `DataTourismeAccommodationSource` → 3 échecs, dont `letsTheSeasonalityCheckerDecideOnADataTourismeEntry` (`closed in January → possibleClosed — Failed asserting that null is false`), qui est le cœur du point 5 du scope.
4. `decodeTags(null)` dans `Tourism\AccommodationRepository` → `TourismIndexReadTest::accommodationsAreFilteredByCategoryAndRadius`.

### Notes d'environnement

- La base `app_test` de la stack de dev était cassée localement (`postgis` installée mais migrations non enregistrées) sous l'effet des agents parallèles du sprint. Elle n'a **pas** été réparée pour ne pas perturber les autres branches : le run vert ci-dessus pointe sur une base dédiée `app871`, que Foundry crée et migre seule.
- `provisioner/tests/ProvisionCommandTest.php` ne peut pas tourner depuis l'hôte (`osmium not found`) : la suite doit être lancée dans l'image `bike-trip-planner-provisioner:dev`, où elle est verte.

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 critical, 0 warning, 1 suggestion (non-blocking).

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [ ] Dependent tickets accounted for

**Findings:**
- `suggestion (non-blocking)`: `TRACKING.md` row for #871 (Sprint 46) still shows `-` in the `PRs` column. Prior sprints (44/45) populate that column as soon as a PR opens (e.g. `#906`, `#909` while still "En cours") — this PR doesn't follow that same convention.

Commit reviewed: `6aea40b3`
<!-- claude-review-end -->