### PR TITLE
feat(datatourisme): add website, phone, wikidata and opening hours to tourism accommodations

### DIFF
--- a/api/migrations/Version20260803120000.php
+++ b/api/migrations/Version20260803120000.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Brings tourism.accommodations up to the shape of its sibling tables (#872).
+ *
+ * It was the poorest table of the schema: no `website`, no `phone`, no
+ * `opening_hours` and no `wikidata`, while tourism.cultural_pois and
+ * tourism.food_pois carried all four plus the Wikidata enrichment columns. The
+ * consequences chained: no DataTourisme lodging could expose a link even though
+ * the flux publishes `foaf:homepage`, the shared Wikidata enrichment pass could
+ * not run on the table for lack of a Q-ID column, and NearbyNameDeduplicator was
+ * left with the name + 75 m heuristic alone to pair an OSM and a DataTourisme
+ * entry.
+ *
+ * `website` / `phone` / `opening_hours` / `wikidata` are filled by the importer
+ * from the flux; `image_url` / `wikipedia_url` are Wikidata-only, filled by the
+ * provisioner's enrichment pass, exactly as on the POI tables.
+ *
+ * Bootstraps the columns for the first provisioning run and the tests; the
+ * provisioner's staging DDL declares the same set so the atomic schema swap
+ * preserves them.
+ */
+final class Version20260803120000 extends AbstractMigration
+{
+    /**
+     * Mirrors the `accommodations` entry of DataTourismeImporter::STAGING_DDL;
+     * DataTourismeImporterTest asserts the two stay aligned.
+     */
+    private const array COLUMNS = ['opening_hours', 'website', 'phone', 'image_url', 'wikipedia_url', 'wikidata'];
+
+    public function getDescription(): string
+    {
+        return 'Add website, phone, opening_hours, wikidata and the Wikidata enrichment columns to tourism.accommodations';
+    }
+
+    public function up(Schema $schema): void
+    {
+        foreach (self::COLUMNS as $column) {
+            $this->addSql(\sprintf('ALTER TABLE tourism.accommodations ADD COLUMN IF NOT EXISTS %s text', $column));
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        foreach (self::COLUMNS as $column) {
+            $this->addSql(\sprintf('ALTER TABLE tourism.accommodations DROP COLUMN IF EXISTS %s', $column));
+        }
+    }
+}

--- a/api/src/Accommodation/CandidateRanker.php
+++ b/api/src/Accommodation/CandidateRanker.php
@@ -63,9 +63,9 @@ final readonly class CandidateRanker
     private const array OUTDOOR_TYPES = ['camp_site', 'shelter', 'wilderness_hut'];
 
     /**
-     * @param list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, stars?: ?int, capacity?: ?int, fee?: ?string, source?: string, wikidataId?: ?string, description?: ?string, imageUrl?: ?string, wikipediaUrl?: ?string, openingHours?: ?string}> $candidates
+     * @param list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, stars?: ?int, capacity?: ?int, fee?: ?string, source?: string, wikidataId?: ?string, description?: ?string, imageUrl?: ?string, wikipediaUrl?: ?string, openingHours?: ?string, phone?: ?string, osmType?: ?string, osmId?: ?int}> $candidates
      *
-     * @return list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, stars?: ?int, capacity?: ?int, fee?: ?string, source?: string, wikidataId?: ?string, description?: ?string, imageUrl?: ?string, wikipediaUrl?: ?string, openingHours?: ?string}>
+     * @return list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, stars?: ?int, capacity?: ?int, fee?: ?string, source?: string, wikidataId?: ?string, description?: ?string, imageUrl?: ?string, wikipediaUrl?: ?string, openingHours?: ?string, phone?: ?string, osmType?: ?string, osmId?: ?int}>
      */
     public function rank(array $candidates, int $limit): array
     {
@@ -110,7 +110,7 @@ final readonly class CandidateRanker
     }
 
     /**
-     * @param array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, stars?: ?int, capacity?: ?int, fee?: ?string, source?: string, wikidataId?: ?string, description?: ?string, imageUrl?: ?string, wikipediaUrl?: ?string, openingHours?: ?string} $candidate
+     * @param array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, stars?: ?int, capacity?: ?int, fee?: ?string, source?: string, wikidataId?: ?string, description?: ?string, imageUrl?: ?string, wikipediaUrl?: ?string, openingHours?: ?string, phone?: ?string, osmType?: ?string, osmId?: ?int} $candidate
      */
     private function completeness(array $candidate): int
     {

--- a/api/src/AccommodationSource/AccommodationSourceInterface.php
+++ b/api/src/AccommodationSource/AccommodationSourceInterface.php
@@ -14,7 +14,7 @@ interface AccommodationSourceInterface
      * @param array<int, Coordinate> $endPoints
      * @param list<string>           $enabledTypes
      *
-     * @return list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, stars: ?int, capacity: ?int, fee: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, source: string, wikidataId: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, openingHours: ?string}>
+     * @return list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, stars: ?int, capacity: ?int, fee: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, source: string, wikidataId: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, openingHours: ?string, phone: ?string, osmType: ?string, osmId: ?int}>
      */
     public function fetch(array $endPoints, int $radiusMeters, array $enabledTypes): array;
 

--- a/api/src/AccommodationSource/AccommodationSourceRegistry.php
+++ b/api/src/AccommodationSource/AccommodationSourceRegistry.php
@@ -31,7 +31,7 @@ class AccommodationSourceRegistry
      * @param array<int, Coordinate> $endPoints
      * @param list<string>           $enabledTypes
      *
-     * @return list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, stars: ?int, capacity: ?int, fee: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, source: string, wikidataId: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, openingHours: ?string}>
+     * @return list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, stars: ?int, capacity: ?int, fee: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, source: string, wikidataId: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, openingHours: ?string, phone: ?string, osmType: ?string, osmId: ?int}>
      */
     public function fetchAll(array $endPoints, int $radiusMeters, array $enabledTypes): array
     {
@@ -47,7 +47,7 @@ class AccommodationSourceRegistry
             }
         }
 
-        /** @var list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, stars: ?int, capacity: ?int, fee: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, source: string, wikidataId: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, openingHours: ?string}> $deduped */
+        /** @var list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, stars: ?int, capacity: ?int, fee: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, source: string, wikidataId: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, openingHours: ?string, phone: ?string, osmType: ?string, osmId: ?int}> $deduped */
         $deduped = $this->deduplicator->dedupe($all);
 
         return $deduped;

--- a/api/src/AccommodationSource/DataTourismeAccommodationSource.php
+++ b/api/src/AccommodationSource/DataTourismeAccommodationSource.php
@@ -28,7 +28,7 @@ final readonly class DataTourismeAccommodationSource implements AccommodationSou
      * @param array<int, Coordinate> $endPoints
      * @param list<string>           $enabledTypes
      *
-     * @return list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, stars: ?int, capacity: ?int, fee: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, source: string, wikidataId: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, openingHours: ?string}>
+     * @return list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, stars: ?int, capacity: ?int, fee: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, source: string, wikidataId: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, openingHours: ?string, phone: ?string, osmType: ?string, osmId: ?int}>
      */
     public function fetch(array $endPoints, int $radiusMeters, array $enabledTypes = TripRequest::ALL_ACCOMMODATION_TYPES): array
     {
@@ -104,6 +104,13 @@ final readonly class DataTourismeAccommodationSource implements AccommodationSou
                 'imageUrl' => $accommodation['imageUrl'] ?? WebsiteUrl::normalize($tags['image_url'] ?? null),
                 'wikipediaUrl' => $accommodation['wikipediaUrl'],
                 'openingHours' => $accommodation['openingHours'] ?? $tags['opening_hours'] ?? null,
+                // Column since #872, with the same pre-migration `tags` fallback as
+                // the fields above; it stopped at the repository until now.
+                'phone' => $accommodation['phone'] ?? $tags['phone'] ?? null,
+                // A flux entry is identified by its DataTourisme URI, not by an OSM
+                // object: there is nothing to link to on openstreetmap.org.
+                'osmType' => null,
+                'osmId' => null,
             ];
         }
 

--- a/api/src/AccommodationSource/DataTourismeAccommodationSource.php
+++ b/api/src/AccommodationSource/DataTourismeAccommodationSource.php
@@ -7,6 +7,7 @@ namespace App\AccommodationSource;
 use App\ApiResource\Model\Coordinate;
 use App\ApiResource\TripRequest;
 use App\Engine\PricingHeuristicEngine;
+use App\Format\WebsiteUrl;
 use App\Tourism\AccommodationRepositoryInterface;
 
 /**
@@ -56,13 +57,15 @@ final readonly class DataTourismeAccommodationSource implements AccommodationSou
                 $isExact = $pricing['isExact'];
             }
 
-            // The contact block and the opening hours the flux carries are preserved
-            // in `tourism.accommodations.tags` by the provisioner (#871), pending the
-            // dedicated columns of #872. Reading them here is what lets the
-            // completeness ranking score this source and SeasonalityChecker decide
-            // `possibleClosed` on a DataTourisme entry at all.
+            // The contact block and the opening hours now live in real columns
+            // (#872); `tags` remains the fallback for rows imported before them and
+            // the only home of `booking_url` / `image_url`, which have no column.
+            // Reading them is what lets the completeness ranking score this source
+            // and SeasonalityChecker decide `possibleClosed` on a DataTourisme entry.
             $tags = $accommodation['tags'];
-            $url = $tags['website'] ?? $tags['booking_url'] ?? null;
+            // Normalised even coming from the column: the fallbacks are raw flux
+            // text, and a database provisioned before #872 holds unnormalised values.
+            $url = WebsiteUrl::normalize($accommodation['website'] ?? $tags['website'] ?? $tags['booking_url'] ?? null);
 
             // `tagCount` counts the attributes actually filled for this entry: the
             // flux publishes fields, not OSM tags, so the OSM tag-richness proxy would
@@ -90,14 +93,17 @@ final readonly class DataTourismeAccommodationSource implements AccommodationSou
                 'hasWebsite' => null !== $url,
                 'tags' => $tags,
                 'source' => 'datatourisme',
-                'wikidataId' => null,
+                // The Q-ID the flux publishes as `owl:sameAs`, now a column: it is
+                // what lets NearbyNameDeduplicator pair this entry with its OSM twin
+                // instead of relying on the name + 75 m heuristic alone.
+                'wikidataId' => $accommodation['wikidata'],
                 'description' => $accommodation['description'],
-                // tourism.accommodations carries no `wikidata` Q-ID column, so it is
-                // not Wikidata-enriched at provision time (ADR-041 enriches only
-                // tourism.cultural_pois / food_pois): these stay null by design.
-                'imageUrl' => null,
-                'wikipediaUrl' => null,
-                'openingHours' => $tags['opening_hours'] ?? null,
+                // Wikidata-only columns, filled at provision time now that
+                // tourism.accommodations carries a Q-ID (ADR-041). The flux photo,
+                // which has no column, is the fallback.
+                'imageUrl' => $accommodation['imageUrl'] ?? WebsiteUrl::normalize($tags['image_url'] ?? null),
+                'wikipediaUrl' => $accommodation['wikipediaUrl'],
+                'openingHours' => $accommodation['openingHours'] ?? $tags['opening_hours'] ?? null,
             ];
         }
 

--- a/api/src/AccommodationSource/OsmAccommodationSource.php
+++ b/api/src/AccommodationSource/OsmAccommodationSource.php
@@ -7,6 +7,8 @@ namespace App\AccommodationSource;
 use App\ApiResource\Model\Coordinate;
 use App\ApiResource\TripRequest;
 use App\Engine\PricingHeuristicEngine;
+use App\Format\OsmContactTags;
+use App\Format\WebsiteUrl;
 use App\Osm\AccommodationRepositoryInterface;
 
 final readonly class OsmAccommodationSource implements AccommodationSourceInterface
@@ -21,7 +23,7 @@ final readonly class OsmAccommodationSource implements AccommodationSourceInterf
      * @param array<int, Coordinate> $endPoints
      * @param list<string>           $enabledTypes
      *
-     * @return list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, stars: ?int, capacity: ?int, fee: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, source: string, wikidataId: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, openingHours: ?string}>
+     * @return list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, stars: ?int, capacity: ?int, fee: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, source: string, wikidataId: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, openingHours: ?string, phone: ?string, osmType: ?string, osmId: ?int}>
      */
     public function fetch(array $endPoints, int $radiusMeters, array $enabledTypes = TripRequest::ALL_ACCOMMODATION_TYPES): array
     {
@@ -53,6 +55,13 @@ final readonly class OsmAccommodationSource implements AccommodationSourceInterf
                 $accommodation['fee'],
             );
 
+            // The indexed `website` column is the projection of the same contact
+            // block, so it comes first; the tag cascade (website, contact:website,
+            // url, contact:url) covers the spellings the column misses and the rows
+            // indexed before it was widened. Both go through WebsiteUrl, so a
+            // schema-less "www.gite.fr" is served absolute and free text is dropped.
+            $url = WebsiteUrl::normalize($accommodation['website']) ?? OsmContactTags::website($tags);
+
             $candidates[] = [
                 'name' => $name,
                 'type' => $accommodation['category'],
@@ -61,12 +70,12 @@ final readonly class OsmAccommodationSource implements AccommodationSourceInterf
                 'priceMin' => $pricing['min'],
                 'priceMax' => $pricing['max'],
                 'isExact' => $pricing['isExact'],
-                'url' => $accommodation['website'] ?? ($tags['contact:website'] ?? null),
+                'url' => $url,
                 'stars' => $accommodation['stars'],
                 'capacity' => $accommodation['capacity'],
                 'fee' => $accommodation['fee'],
                 'tagCount' => \count($tags),
-                'hasWebsite' => null !== $accommodation['website'] || isset($tags['contact:website']),
+                'hasWebsite' => null !== $url,
                 'tags' => $tags,
                 'source' => 'osm',
                 'wikidataId' => $accommodation['wikidata'],
@@ -74,6 +83,9 @@ final readonly class OsmAccommodationSource implements AccommodationSourceInterf
                 'imageUrl' => $accommodation['imageUrl'],
                 'wikipediaUrl' => $accommodation['wikipediaUrl'],
                 'openingHours' => $accommodation['openingHours'],
+                'phone' => OsmContactTags::phone($tags),
+                'osmType' => $accommodation['osmType'],
+                'osmId' => $accommodation['osmId'],
             ];
         }
 

--- a/api/src/ApiResource/Model/Accommodation.php
+++ b/api/src/ApiResource/Model/Accommodation.php
@@ -28,6 +28,16 @@ final readonly class Accommodation
         public ?string $wikipediaUrl = null,
         #[ApiProperty(description: 'Opening hours (Wikidata P8989 or DataTourisme).')]
         public ?string $openingHours = null,
+        #[ApiProperty(description: 'Contact phone number, from the OSM contact block or the DataTourisme flux.')]
+        public ?string $phone = null,
+        // The (osmType, osmId) pair is the primary key of the Tier-1 index and the
+        // only stable identity an OSM entry has: it is what lets the rider open the
+        // object on openstreetmap.org to check it still exists — or fix it at the
+        // source. Null for a DataTourisme entry, which has no OSM identity.
+        #[ApiProperty(description: 'OpenStreetMap object type: node, way or relation. Null when the entry does not come from OSM.')]
+        public ?string $osmType = null,
+        #[ApiProperty(description: 'OpenStreetMap object id. Null when the entry does not come from OSM.')]
+        public ?int $osmId = null,
     ) {
     }
 }

--- a/api/src/ApiResource/Model/CulturalPoiAlert.php
+++ b/api/src/ApiResource/Model/CulturalPoiAlert.php
@@ -49,6 +49,14 @@ final readonly class CulturalPoiAlert extends Alert
         public ?string $imageUrl = null,
         #[ApiProperty(description: 'Wikipedia article URL.')]
         public ?string $wikipediaUrl = null,
+        // The (osmType, osmId) pair is the primary key of the Tier-1 index and the
+        // only stable identity an OSM entry has: it is what lets the rider open the
+        // object on openstreetmap.org to check it still exists — or fix it at the
+        // source. Null for a DataTourisme entry, which has no OSM identity.
+        #[ApiProperty(description: 'OpenStreetMap object type: node, way or relation. Null when the entry does not come from OSM.')]
+        public ?string $osmType = null,
+        #[ApiProperty(description: 'OpenStreetMap object id. Null when the entry does not come from OSM.')]
+        public ?int $osmId = null,
     ) {
         parent::__construct($type, $message, $lat, $lon, $action);
     }

--- a/api/src/ApiResource/Model/PointOfInterest.php
+++ b/api/src/ApiResource/Model/PointOfInterest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\ApiResource\Model;
 
+use ApiPlatform\Metadata\ApiProperty;
+
 final readonly class PointOfInterest
 {
     public function __construct(
@@ -12,6 +14,14 @@ final readonly class PointOfInterest
         public float $lat,
         public float $lon,
         public ?float $distanceFromStart = null,
+        // The (osmType, osmId) pair is the primary key of the Tier-1 index and the
+        // only stable identity an OSM entry has: it is what lets the rider open the
+        // object on openstreetmap.org to check it still exists — or fix it at the
+        // source. Null for a DataTourisme entry, which has no OSM identity.
+        #[ApiProperty(description: 'OpenStreetMap object type: node, way or relation. Null when the entry does not come from OSM.')]
+        public ?string $osmType = null,
+        #[ApiProperty(description: 'OpenStreetMap object id. Null when the entry does not come from OSM.')]
+        public ?int $osmId = null,
     ) {
     }
 }

--- a/api/src/ApiResource/TripDetail.php
+++ b/api/src/ApiResource/TripDetail.php
@@ -134,6 +134,9 @@ final readonly class TripDetail
                         'lat' => ['type' => 'number'],
                         'lon' => ['type' => 'number'],
                         'distanceFromStart' => ['oneOf' => [['type' => 'number'], ['type' => 'null']]],
+                        // Tier-1 primary key: the OSM link, null for a DataTourisme POI.
+                        'osmType' => ['oneOf' => [['type' => 'string', 'enum' => ['node', 'way', 'relation']], ['type' => 'null']]],
+                        'osmId' => ['oneOf' => [['type' => 'integer'], ['type' => 'null']]],
                     ]]],
                     'accommodations' => ['type' => 'array', 'items' => ['type' => 'object', 'properties' => [
                         'name' => ['type' => 'string'],

--- a/api/src/CulturalPoiSource/CulturalPoiSourceInterface.php
+++ b/api/src/CulturalPoiSource/CulturalPoiSourceInterface.php
@@ -17,7 +17,7 @@ interface CulturalPoiSourceInterface
      *
      * @param list<list<array{lat: float, lon: float}>> $stageGeometries
      *
-     * @return list<array{name: string|null, type: string, lat: float, lon: float, openingHours: string|null, estimatedPrice: float|null, description: string|null, wikidataId: string|null, source: string, imageUrl: string|null, wikipediaUrl: string|null}>
+     * @return list<array{name: string|null, type: string, lat: float, lon: float, osmType: string|null, osmId: int|null, openingHours: string|null, estimatedPrice: float|null, description: string|null, wikidataId: string|null, source: string, imageUrl: string|null, wikipediaUrl: string|null}>
      */
     public function fetchForStages(array $stageGeometries, int $radiusMeters): array;
 

--- a/api/src/CulturalPoiSource/CulturalPoiSourceRegistry.php
+++ b/api/src/CulturalPoiSource/CulturalPoiSourceRegistry.php
@@ -30,7 +30,7 @@ readonly class CulturalPoiSourceRegistry
      *
      * @param list<list<array{lat: float, lon: float}>> $stageGeometries
      *
-     * @return list<array{name: string|null, type: string, lat: float, lon: float, openingHours?: string|null, estimatedPrice?: float|null, description?: string|null, wikidataId?: string|null, source: string, imageUrl?: string|null, wikipediaUrl?: string|null}>
+     * @return list<array{name: string|null, type: string, lat: float, lon: float, osmType?: string|null, osmId?: int|null, openingHours?: string|null, estimatedPrice?: float|null, description?: string|null, wikidataId?: string|null, source: string, imageUrl?: string|null, wikipediaUrl?: string|null}>
      */
     public function fetchAllForStages(array $stageGeometries, int $radiusMeters): array
     {
@@ -46,7 +46,7 @@ readonly class CulturalPoiSourceRegistry
             }
         }
 
-        /** @var list<array{name: string|null, type: string, lat: float, lon: float, openingHours?: string|null, estimatedPrice?: float|null, description?: string|null, wikidataId?: string|null, source: string, imageUrl?: string|null, wikipediaUrl?: string|null}> $deduped */
+        /** @var list<array{name: string|null, type: string, lat: float, lon: float, osmType?: string|null, osmId?: int|null, openingHours?: string|null, estimatedPrice?: float|null, description?: string|null, wikidataId?: string|null, source: string, imageUrl?: string|null, wikipediaUrl?: string|null}> $deduped */
         $deduped = $this->deduplicator->dedupe($all);
 
         return $deduped;

--- a/api/src/CulturalPoiSource/DataTourismeCulturalPoiSource.php
+++ b/api/src/CulturalPoiSource/DataTourismeCulturalPoiSource.php
@@ -22,7 +22,7 @@ final readonly class DataTourismeCulturalPoiSource implements CulturalPoiSourceI
     /**
      * @param list<list<array{lat: float, lon: float}>> $stageGeometries
      *
-     * @return list<array{name: string|null, type: string, lat: float, lon: float, openingHours: string|null, estimatedPrice: float|null, description: string|null, wikidataId: string|null, source: string, imageUrl: string|null, wikipediaUrl: string|null}>
+     * @return list<array{name: string|null, type: string, lat: float, lon: float, osmType: string|null, osmId: int|null, openingHours: string|null, estimatedPrice: float|null, description: string|null, wikidataId: string|null, source: string, imageUrl: string|null, wikipediaUrl: string|null}>
      */
     public function fetchForStages(array $stageGeometries, int $radiusMeters): array
     {
@@ -37,6 +37,9 @@ final readonly class DataTourismeCulturalPoiSource implements CulturalPoiSourceI
                 'type' => $poi['category'],
                 'lat' => $poi['lat'],
                 'lon' => $poi['lon'],
+                // A curated entry has no OSM identity: there is no join key from the flux.
+                'osmType' => null,
+                'osmId' => null,
                 'openingHours' => $poi['openingHours'],
                 'estimatedPrice' => null,
                 'description' => $poi['description'],

--- a/api/src/CulturalPoiSource/OsmCulturalPoiSource.php
+++ b/api/src/CulturalPoiSource/OsmCulturalPoiSource.php
@@ -16,7 +16,7 @@ final readonly class OsmCulturalPoiSource implements CulturalPoiSourceInterface
     /**
      * @param list<list<array{lat: float, lon: float}>> $stageGeometries
      *
-     * @return list<array{name: string|null, type: string, lat: float, lon: float, openingHours: string|null, estimatedPrice: float|null, description: string|null, wikidataId: string|null, source: string, imageUrl: string|null, wikipediaUrl: string|null}>
+     * @return list<array{name: string|null, type: string, lat: float, lon: float, osmType: string|null, osmId: int|null, openingHours: string|null, estimatedPrice: float|null, description: string|null, wikidataId: string|null, source: string, imageUrl: string|null, wikipediaUrl: string|null}>
      */
     public function fetchForStages(array $stageGeometries, int $radiusMeters): array
     {
@@ -33,6 +33,8 @@ final readonly class OsmCulturalPoiSource implements CulturalPoiSourceInterface
                 'type' => $poi['category'],
                 'lat' => $poi['lat'],
                 'lon' => $poi['lon'],
+                'osmType' => $poi['osmType'],
+                'osmId' => $poi['osmId'],
                 'openingHours' => $poi['openingHours'],
                 'estimatedPrice' => null,
                 'description' => $poi['description'],

--- a/api/src/Format/OsmContactTags.php
+++ b/api/src/Format/OsmContactTags.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Format;
+
+/**
+ * Reads the OSM contact block, which is written under two competing schemes:
+ * the bare keys (`phone`, `website`) and the `contact:` namespace
+ * (`contact:phone`, `contact:website`), plus `url` as a third spelling of the
+ * website. Both live side by side in the wild, so a mapper who only filled
+ * `contact:phone` is invisible to a reader that looks up `phone` alone.
+ *
+ * Static, without DI, like {@see WebsiteUrl}: this is a pure tag lookup, and
+ * both the in-ride assistant (raw Overpass tags) and the planned path (the
+ * `tags` jsonb of the Tier-1 index) call it on plain arrays.
+ */
+final class OsmContactTags
+{
+    /** @var list<string> */
+    private const array PHONE_KEYS = ['phone', 'contact:phone'];
+
+    /** @var list<string> */
+    private const array WEBSITE_KEYS = ['website', 'contact:website', 'url', 'contact:url'];
+
+    /**
+     * First non-empty phone number of the contact block, verbatim.
+     *
+     * Not reformatted: OSM holds international, national and free-text spellings,
+     * and a `tel:` link works with all of them.
+     *
+     * @param array<string, mixed> $tags
+     */
+    public static function phone(array $tags): ?string
+    {
+        return self::firstNonEmpty($tags, self::PHONE_KEYS);
+    }
+
+    /**
+     * First website of the contact block that normalises to a usable http(s)
+     * URL. A key holding free text ("nous contacter") is skipped rather than
+     * shadowing a valid `contact:url` further down the list.
+     *
+     * @param array<string, mixed> $tags
+     */
+    public static function website(array $tags): ?string
+    {
+        foreach (self::WEBSITE_KEYS as $key) {
+            $url = WebsiteUrl::normalize(self::firstNonEmpty($tags, [$key]));
+            if (null !== $url) {
+                return $url;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, mixed> $tags
+     * @param list<string>         $keys
+     */
+    private static function firstNonEmpty(array $tags, array $keys): ?string
+    {
+        foreach ($keys as $key) {
+            $value = $tags[$key] ?? null;
+            if (\is_string($value) && '' !== trim($value)) {
+                return trim($value);
+            }
+        }
+
+        return null;
+    }
+}

--- a/api/src/Format/WebsiteUrl.php
+++ b/api/src/Format/WebsiteUrl.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Format;
+
+/**
+ * Normalises a hand-typed website value into an absolute http(s) URL, or null
+ * when it is not one.
+ *
+ * Both source sets are free text: the DataTourisme flux publishes whatever the
+ * office de tourisme typed in `foaf:homepage`, and OSM `website` /
+ * `contact:website` are no better. So the value reaching the rider ranges from
+ * "www.gite.fr" (schema-less, which a browser resolves relative to the app
+ * origin) to "nous contacter" or "contact@gite.fr". Normalising here, on the
+ * server, keeps the frontend guard (sprint 45) as a second line of defence
+ * rather than the only one.
+ *
+ * Rules, deliberately conservative — an unusable value becomes null instead of
+ * being passed through:
+ *
+ * - a missing scheme is assumed to be `https`, and so is a `//host/path`;
+ * - any scheme other than http/https (`mailto:`, `tel:`, `javascript:`, `data:`)
+ *   is rejected;
+ * - userinfo is rejected, which is what an e-mail typed in a website field
+ *   becomes once absolutised (`https://contact@gite.fr`);
+ * - the host must be a dotted name, so "nous contacter" and "localhost" are out;
+ * - scheme and host are lowercased, the rest of the URL is preserved verbatim.
+ *
+ * The provisioner has its own copy ({@see \Provisioner\WebsiteUrl}) because it
+ * is a separate Composer package: it normalises at import time so the column is
+ * clean at rest, while this one guards the read path (raw `tags` fallbacks, rows
+ * loaded before the flux was normalised, OSM tags which are indexed verbatim).
+ */
+final class WebsiteUrl
+{
+    /** Scheme prefix, e.g. `https://`, `mailto:`. */
+    private const string SCHEME_PATTERN = '#^[a-zA-Z][a-zA-Z0-9+.\-]*:#';
+
+    /** Dotted host name with a 2+ letter TLD; accented (IDN) labels allowed. */
+    private const string HOST_PATTERN = '/^(?:[\p{L}\p{N}](?:[\p{L}\p{N}\-]*[\p{L}\p{N}])?\.)+\p{L}{2,}$/u';
+
+    public static function normalize(?string $value): ?string
+    {
+        if (null === $value) {
+            return null;
+        }
+
+        $candidate = trim($value);
+        // A free-text answer ("nous contacter", "voir la page Facebook") only ever
+        // yields a host with a space in it, which no absolutisation can rescue.
+        if ('' === $candidate || 1 === preg_match('/[\s\x00-\x1F\x7F]/', $candidate)) {
+            return null;
+        }
+
+        if (str_starts_with($candidate, '//')) {
+            $candidate = 'https:'.$candidate;
+        } elseif (1 !== preg_match(self::SCHEME_PATTERN, $candidate)) {
+            $candidate = 'https://'.$candidate;
+        }
+
+        $parts = parse_url($candidate);
+        if (false === $parts || !isset($parts['host']) || isset($parts['user']) || isset($parts['pass'])) {
+            return null;
+        }
+
+        $scheme = strtolower($parts['scheme'] ?? '');
+        if ('http' !== $scheme && 'https' !== $scheme) {
+            return null;
+        }
+
+        $host = strtolower($parts['host']);
+        if (1 !== preg_match(self::HOST_PATTERN, $host)) {
+            return null;
+        }
+
+        $url = $scheme.'://'.$host;
+        if (isset($parts['port'])) {
+            $url .= ':'.$parts['port'];
+        }
+
+        $url .= $parts['path'] ?? '';
+        if (isset($parts['query'])) {
+            $url .= '?'.$parts['query'];
+        }
+
+        if (isset($parts['fragment'])) {
+            $url .= '#'.$parts['fragment'];
+        }
+
+        return $url;
+    }
+}

--- a/api/src/InRide/InRideAssistant.php
+++ b/api/src/InRide/InRideAssistant.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\InRide;
 
 use App\ApiResource\Model\GeoPosition;
+use App\Format\OsmContactTags;
 use App\Geo\GeoDistanceInterface;
 use App\Geo\GeoPoint;
 use App\Llm\Exception\AiUnavailableException;
@@ -226,7 +227,7 @@ final readonly class InRideAssistant
                 detourMeters: $detourMeters,
                 openingHoursToday: $openingHoursTag,
                 closesAt: $closesAt,
-                phone: \is_string($tags['phone'] ?? null) ? $tags['phone'] : (\is_string($tags['contact:phone'] ?? null) ? $tags['contact:phone'] : null),
+                phone: OsmContactTags::phone($tags),
                 deeplink: $deeplink,
                 warning: $warning,
             );

--- a/api/src/Mercure/StagePayloadMapper.php
+++ b/api/src/Mercure/StagePayloadMapper.php
@@ -140,6 +140,9 @@ final readonly class StagePayloadMapper
             'imageUrl' => $accommodation->imageUrl,
             'wikipediaUrl' => $accommodation->wikipediaUrl,
             'openingHours' => $accommodation->openingHours,
+            'phone' => $accommodation->phone,
+            'osmType' => $accommodation->osmType,
+            'osmId' => $accommodation->osmId,
         ];
     }
 

--- a/api/src/Mercure/StagePayloadMapper.php
+++ b/api/src/Mercure/StagePayloadMapper.php
@@ -118,6 +118,8 @@ final readonly class StagePayloadMapper
             'lat' => $poi->lat,
             'lon' => $poi->lon,
             'distanceFromStart' => $poi->distanceFromStart,
+            'osmType' => $poi->osmType,
+            'osmId' => $poi->osmId,
         ];
     }
 

--- a/api/src/MessageHandler/CheckCulturalPoisHandler.php
+++ b/api/src/MessageHandler/CheckCulturalPoisHandler.php
@@ -188,6 +188,12 @@ final readonly class CheckCulturalPoisHandler extends AbstractTripMessageHandler
                         $alert['wikipediaUrl'] = $poi['wikipediaUrl'];
                     }
 
+                    // Only an OSM entry has one; a curated DataTourisme POI does not.
+                    if (null !== ($poi['osmType'] ?? null) && null !== ($poi['osmId'] ?? null)) {
+                        $alert['osmType'] = $poi['osmType'];
+                        $alert['osmId'] = $poi['osmId'];
+                    }
+
                     $alerts[] = $alert;
                 }
             }

--- a/api/src/MessageHandler/ScanAccommodationsHandler.php
+++ b/api/src/MessageHandler/ScanAccommodationsHandler.php
@@ -89,7 +89,7 @@ final readonly class ScanAccommodationsHandler extends AbstractTripMessageHandle
             $allCandidates = $this->registry->fetchAll($endPoints, $radiusMeters, $enabledAccommodationTypes);
 
             // Distribute candidates to their nearest stage endpoint (output keys match $stagesToProcess keys)
-            /** @var array<int, list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, stars?: ?int, capacity?: ?int, fee?: ?string, source?: string, wikidataId?: ?string, description?: ?string, imageUrl?: ?string, wikipediaUrl?: ?string, openingHours?: ?string}>> $candidatesByStage */
+            /** @var array<int, list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, stars?: ?int, capacity?: ?int, fee?: ?string, source?: string, wikidataId?: ?string, description?: ?string, imageUrl?: ?string, wikipediaUrl?: ?string, openingHours?: ?string, phone?: ?string, osmType?: ?string, osmId?: ?int}>> $candidatesByStage */
             $candidatesByStage = $this->distributor->distributeByEndpoint($allCandidates, $stagesToProcess);
 
             // Deduplicate, then rank + limit per stage. Prices are already set by
@@ -133,6 +133,9 @@ final readonly class ScanAccommodationsHandler extends AbstractTripMessageHandle
                             'imageUrl' => $existing->imageUrl,
                             'wikipediaUrl' => $existing->wikipediaUrl,
                             'openingHours' => $existing->openingHours,
+                            'phone' => $existing->phone,
+                            'osmType' => $existing->osmType,
+                            'osmId' => $existing->osmId,
                         ];
                     }
                 } else {
@@ -176,6 +179,9 @@ final readonly class ScanAccommodationsHandler extends AbstractTripMessageHandle
                         imageUrl: $raw['imageUrl'] ?? null,
                         wikipediaUrl: $raw['wikipediaUrl'] ?? null,
                         openingHours: $raw['openingHours'] ?? null,
+                        phone: $raw['phone'] ?? null,
+                        osmType: $raw['osmType'] ?? null,
+                        osmId: $raw['osmId'] ?? null,
                     );
 
                     $stage->addAccommodation($accommodation);
@@ -195,6 +201,9 @@ final readonly class ScanAccommodationsHandler extends AbstractTripMessageHandle
                         'imageUrl' => $accommodation->imageUrl,
                         'wikipediaUrl' => $accommodation->wikipediaUrl,
                         'openingHours' => $accommodation->openingHours,
+                        'phone' => $accommodation->phone,
+                        'osmType' => $accommodation->osmType,
+                        'osmId' => $accommodation->osmId,
                     ];
                 }
 
@@ -236,9 +245,9 @@ final readonly class ScanAccommodationsHandler extends AbstractTripMessageHandle
     }
 
     /**
-     * @param list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, stars?: ?int, capacity?: ?int, fee?: ?string, source?: string, wikidataId?: ?string, description?: ?string, imageUrl?: ?string, wikipediaUrl?: ?string, openingHours?: ?string}> $accommodations
+     * @param list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, stars?: ?int, capacity?: ?int, fee?: ?string, source?: string, wikidataId?: ?string, description?: ?string, imageUrl?: ?string, wikipediaUrl?: ?string, openingHours?: ?string, phone?: ?string, osmType?: ?string, osmId?: ?int}> $accommodations
      *
-     * @return list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, stars?: ?int, capacity?: ?int, fee?: ?string, source?: string, wikidataId?: ?string, description?: ?string, imageUrl?: ?string, wikipediaUrl?: ?string, openingHours?: ?string}>
+     * @return list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, stars?: ?int, capacity?: ?int, fee?: ?string, source?: string, wikidataId?: ?string, description?: ?string, imageUrl?: ?string, wikipediaUrl?: ?string, openingHours?: ?string, phone?: ?string, osmType?: ?string, osmId?: ?int}>
      */
     private function deduplicate(array $accommodations): array
     {

--- a/api/src/MessageHandler/ScanPoisHandler.php
+++ b/api/src/MessageHandler/ScanPoisHandler.php
@@ -124,6 +124,8 @@ final readonly class ScanPoisHandler extends AbstractTripMessageHandler
                         category: $raw['category'],
                         lat: $raw['lat'],
                         lon: $raw['lon'],
+                        osmType: $raw['osmType'] ?? null,
+                        osmId: $raw['osmId'] ?? null,
                     );
 
                     $stage->addPoi($poi);

--- a/api/src/Osm/AccommodationRepository.php
+++ b/api/src/Osm/AccommodationRepository.php
@@ -36,7 +36,7 @@ final readonly class AccommodationRepository implements AccommodationRepositoryI
      * @param list<array{lat: float, lon: float}> $points
      * @param list<string>                        $categories
      *
-     * @return list<array{name: ?string, category: string, lat: float, lon: float, stars: ?int, capacity: ?int, fee: ?string, website: ?string, wikidata: ?string, openingHours: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, tags: array<string, string>}>
+     * @return list<array{osmType: ?string, osmId: ?int, name: ?string, category: string, lat: float, lon: float, stars: ?int, capacity: ?int, fee: ?string, website: ?string, wikidata: ?string, openingHours: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, tags: array<string, string>}>
      */
     public function findNear(array $points, int $radiusMeters, array $categories): array
     {
@@ -118,6 +118,10 @@ final readonly class AccommodationRepository implements AccommodationRepositoryI
         $accommodations = [];
         foreach ($rows as $row) {
             $accommodations[] = [
+                // Primary key of the index, kept so the rider can reach the object
+                // on openstreetmap.org: it used to be dropped at this very first hop.
+                'osmType' => OsmObjectType::fromChar($row['osm_type']),
+                'osmId' => null !== $row['osm_id'] ? (int) $row['osm_id'] : null,
                 'name' => null !== $row['name'] ? (string) $row['name'] : null,
                 'category' => (string) $row['category'],
                 'lat' => (float) $row['lat'],

--- a/api/src/Osm/AccommodationRepositoryInterface.php
+++ b/api/src/Osm/AccommodationRepositoryInterface.php
@@ -14,7 +14,7 @@ interface AccommodationRepositoryInterface
      * @param list<array{lat: float, lon: float}> $points
      * @param list<string>                        $categories
      *
-     * @return list<array{name: ?string, category: string, lat: float, lon: float, stars: ?int, capacity: ?int, fee: ?string, website: ?string, wikidata: ?string, openingHours: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, tags: array<string, string>}>
+     * @return list<array{osmType: ?string, osmId: ?int, name: ?string, category: string, lat: float, lon: float, stars: ?int, capacity: ?int, fee: ?string, website: ?string, wikidata: ?string, openingHours: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, tags: array<string, string>}>
      */
     public function findNear(array $points, int $radiusMeters, array $categories): array;
 }

--- a/api/src/Osm/CulturalPoiRepository.php
+++ b/api/src/Osm/CulturalPoiRepository.php
@@ -22,7 +22,7 @@ final readonly class CulturalPoiRepository implements CulturalPoiRepositoryInter
      *
      * @param list<array{lat: float, lon: float}> $route
      *
-     * @return list<array{name: ?string, category: string, lat: float, lon: float, wikidata: ?string, openingHours: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string}>
+     * @return list<array{osmType: ?string, osmId: ?int, name: ?string, category: string, lat: float, lon: float, wikidata: ?string, openingHours: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string}>
      */
     public function findInCorridor(array $route, int $radiusMeters): array
     {
@@ -38,7 +38,7 @@ final readonly class CulturalPoiRepository implements CulturalPoiRepositoryInter
         /** @var list<array<string, scalar|null>> $rows */
         $rows = $this->connection->fetchAllAssociative(
             <<<'SQL'
-                SELECT name, category, wikidata, opening_hours, description, image_url, wikipedia_url,
+                SELECT osm_type, osm_id, name, category, wikidata, opening_hours, description, image_url, wikipedia_url,
                        ST_Y(geom) AS lat, ST_X(geom) AS lon
                 FROM osm.cultural_pois
                 WHERE ST_DWithin(
@@ -58,6 +58,10 @@ final readonly class CulturalPoiRepository implements CulturalPoiRepositoryInter
         $pois = [];
         foreach ($rows as $row) {
             $pois[] = [
+                // Primary key of the index (ADR-040), carried so a reader can reach
+                // the object on openstreetmap.org instead of losing its identity here.
+                'osmType' => OsmObjectType::fromChar($row['osm_type']),
+                'osmId' => null !== $row['osm_id'] ? (int) $row['osm_id'] : null,
                 'name' => null !== $row['name'] ? (string) $row['name'] : null,
                 'category' => (string) $row['category'],
                 'lat' => (float) $row['lat'],

--- a/api/src/Osm/CulturalPoiRepositoryInterface.php
+++ b/api/src/Osm/CulturalPoiRepositoryInterface.php
@@ -12,7 +12,7 @@ interface CulturalPoiRepositoryInterface
      *
      * @param list<array{lat: float, lon: float}> $route
      *
-     * @return list<array{name: ?string, category: string, lat: float, lon: float, wikidata: ?string, openingHours: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string}>
+     * @return list<array{osmType: ?string, osmId: ?int, name: ?string, category: string, lat: float, lon: float, wikidata: ?string, openingHours: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string}>
      */
     public function findInCorridor(array $route, int $radiusMeters): array;
 }

--- a/api/src/Osm/OsmObjectType.php
+++ b/api/src/Osm/OsmObjectType.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Osm;
+
+/**
+ * Translates the one-character `osm_type` osm2pgsql stores (`N`, `W`, `R`) into
+ * the word openstreetmap.org uses in its object URLs (`node`, `way`,
+ * `relation`), so a reader can build `https://www.openstreetmap.org/<type>/<id>`
+ * without knowing the storage convention.
+ */
+final class OsmObjectType
+{
+    /** @var array<string, string> */
+    private const array NAMES = ['N' => 'node', 'W' => 'way', 'R' => 'relation'];
+
+    public static function fromChar(mixed $raw): ?string
+    {
+        return \is_string($raw) ? (self::NAMES[strtoupper(trim($raw))] ?? null) : null;
+    }
+}

--- a/api/src/Osm/PoiRepository.php
+++ b/api/src/Osm/PoiRepository.php
@@ -22,7 +22,7 @@ final readonly class PoiRepository implements PoiRepositoryInterface
      *
      * @param list<array{lat: float, lon: float}> $route
      *
-     * @return list<array{name: ?string, category: string, lat: float, lon: float}>
+     * @return list<array{osmType: ?string, osmId: ?int, name: ?string, category: string, lat: float, lon: float}>
      */
     public function findInCorridor(array $route, int $radiusMeters): array
     {
@@ -33,7 +33,7 @@ final readonly class PoiRepository implements PoiRepositoryInterface
         /** @var list<array<string, scalar|null>> $rows */
         $rows = $this->connection->fetchAllAssociative(
             <<<'SQL'
-                SELECT name, category, ST_Y(geom) AS lat, ST_X(geom) AS lon
+                SELECT osm_type, osm_id, name, category, ST_Y(geom) AS lat, ST_X(geom) AS lon
                 FROM osm.pois
                 WHERE ST_DWithin(
                     geom::geography,
@@ -50,6 +50,10 @@ final readonly class PoiRepository implements PoiRepositoryInterface
         $pois = [];
         foreach ($rows as $row) {
             $pois[] = [
+                // Primary key of the index (ADR-040), carried so a reader can reach
+                // the object on openstreetmap.org instead of losing its identity here.
+                'osmType' => OsmObjectType::fromChar($row['osm_type']),
+                'osmId' => null !== $row['osm_id'] ? (int) $row['osm_id'] : null,
                 'name' => null !== $row['name'] ? (string) $row['name'] : null,
                 'category' => (string) $row['category'],
                 'lat' => (float) $row['lat'],

--- a/api/src/Osm/PoiRepositoryInterface.php
+++ b/api/src/Osm/PoiRepositoryInterface.php
@@ -11,7 +11,7 @@ interface PoiRepositoryInterface
      *
      * @param list<array{lat: float, lon: float}> $route
      *
-     * @return list<array{name: ?string, category: string, lat: float, lon: float}>
+     * @return list<array{osmType: ?string, osmId: ?int, name: ?string, category: string, lat: float, lon: float}>
      */
     public function findInCorridor(array $route, int $radiusMeters): array;
 }

--- a/api/src/Poi/DataTourismeFoodPoiSource.php
+++ b/api/src/Poi/DataTourismeFoodPoiSource.php
@@ -28,6 +28,9 @@ final readonly class DataTourismeFoodPoiSource implements PoiSourceInterface
                 'category' => $poi['category'],
                 'lat' => $poi['lat'],
                 'lon' => $poi['lon'],
+                // A curated entry has no OSM identity: there is no join key from the flux.
+                'osmType' => null,
+                'osmId' => null,
                 'wikidataId' => $poi['wikidata'],
                 'source' => 'datatourisme',
             ];

--- a/api/src/Poi/OsmPoiSource.php
+++ b/api/src/Poi/OsmPoiSource.php
@@ -26,6 +26,8 @@ final readonly class OsmPoiSource implements PoiSourceInterface
                 'category' => $poi['category'],
                 'lat' => $poi['lat'],
                 'lon' => $poi['lon'],
+                'osmType' => $poi['osmType'],
+                'osmId' => $poi['osmId'],
                 'wikidataId' => null,
                 'source' => 'osm',
             ];

--- a/api/src/Poi/PoiSourceInterface.php
+++ b/api/src/Poi/PoiSourceInterface.php
@@ -15,9 +15,14 @@ interface PoiSourceInterface
      * `name` is null for a POI the source has no proper name for; the localised
      * display label is resolved downstream by {@see PoiLabelResolver}.
      *
+     * The (osmType, osmId) pair is the primary key of the Tier-1 index and the only
+     * stable identity an OSM entry has: it lets the rider open the object on
+     * openstreetmap.org to check it still exists, or fix it at the source. Null for
+     * a DataTourisme entry, which carries no OSM identity.
+     *
      * @param list<array{lat: float, lon: float}> $route
      *
-     * @return list<array{name: string|null, category: string, lat: float, lon: float, wikidataId: string|null, source: string}>
+     * @return list<array{name: string|null, category: string, lat: float, lon: float, osmType: string|null, osmId: int|null, wikidataId: string|null, source: string}>
      */
     public function fetchInCorridor(array $route, int $radiusMeters): array;
 }

--- a/api/src/Poi/PoiSourceRegistry.php
+++ b/api/src/Poi/PoiSourceRegistry.php
@@ -29,7 +29,7 @@ readonly class PoiSourceRegistry
      *
      * @param list<array{lat: float, lon: float}> $route
      *
-     * @return list<array{name: string|null, category: string, lat: float, lon: float, wikidataId: string|null, source: string}>
+     * @return list<array{name: string|null, category: string, lat: float, lon: float, osmType: string|null, osmId: int|null, wikidataId: string|null, source: string}>
      */
     public function fetchAllInCorridor(array $route, int $radiusMeters): array
     {
@@ -40,7 +40,7 @@ readonly class PoiSourceRegistry
             }
         }
 
-        /** @var list<array{name: string|null, category: string, lat: float, lon: float, wikidataId: string|null, source: string}> $deduped */
+        /** @var list<array{name: string|null, category: string, lat: float, lon: float, osmType: string|null, osmId: int|null, wikidataId: string|null, source: string}> $deduped */
         $deduped = $this->deduplicator->dedupe($all);
 
         return $deduped;

--- a/api/src/Repository/DoctrineTripRequestRepository.php
+++ b/api/src/Repository/DoctrineTripRequestRepository.php
@@ -782,7 +782,7 @@ final class DoctrineTripRequestRepository extends ServiceEntityRepository implem
         );
     }
 
-    /** @return array{name: string, category: string, lat: float, lon: float, distanceFromStart: ?float} */
+    /** @return array{name: string, category: string, lat: float, lon: float, distanceFromStart: ?float, osmType: ?string, osmId: ?int} */
     private function poiToArray(PointOfInterest $poi): array
     {
         return [
@@ -791,10 +791,14 @@ final class DoctrineTripRequestRepository extends ServiceEntityRepository implem
             'lat' => $poi->lat,
             'lon' => $poi->lon,
             'distanceFromStart' => $poi->distanceFromStart,
+            // Without these the OSM link vanishes on reload and in the shared view,
+            // exactly as the accommodation enrichment fields did before issue #870.
+            'osmType' => $poi->osmType,
+            'osmId' => $poi->osmId,
         ];
     }
 
-    /** @param array{name: string, category: string, lat: float, lon: float, distanceFromStart?: ?float} $data */
+    /** @param array{name: string, category: string, lat: float, lon: float, distanceFromStart?: ?float, osmType?: ?string, osmId?: ?int} $data */
     private function arrayToPoi(array $data): PointOfInterest
     {
         return new PointOfInterest(
@@ -803,6 +807,8 @@ final class DoctrineTripRequestRepository extends ServiceEntityRepository implem
             lat: $data['lat'],
             lon: $data['lon'],
             distanceFromStart: $data['distanceFromStart'] ?? null,
+            osmType: $data['osmType'] ?? null,
+            osmId: $data['osmId'] ?? null,
         );
     }
 

--- a/api/src/Repository/DoctrineTripRequestRepository.php
+++ b/api/src/Repository/DoctrineTripRequestRepository.php
@@ -806,7 +806,7 @@ final class DoctrineTripRequestRepository extends ServiceEntityRepository implem
         );
     }
 
-    /** @return array{name: string, type: string, lat: float, lon: float, estimatedPriceMin: float, estimatedPriceMax: float, isExactPrice: bool, url: ?string, possibleClosed: bool, distanceToEndPoint: float, source: string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, openingHours: ?string} */
+    /** @return array{name: string, type: string, lat: float, lon: float, estimatedPriceMin: float, estimatedPriceMax: float, isExactPrice: bool, url: ?string, possibleClosed: bool, distanceToEndPoint: float, source: string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, openingHours: ?string, phone: ?string, osmType: ?string, osmId: ?int} */
     private function accommodationToArray(Accommodation $acc): array
     {
         return [
@@ -828,10 +828,16 @@ final class DoctrineTripRequestRepository extends ServiceEntityRepository implem
             'imageUrl' => $acc->imageUrl,
             'wikipediaUrl' => $acc->wikipediaUrl,
             'openingHours' => $acc->openingHours,
+            // Contact block and OSM identity (issue #873): same trap as the five
+            // keys above — omitting them here drops the tel: link and the "see on
+            // OSM" affordance on every reload and in the shared view.
+            'phone' => $acc->phone,
+            'osmType' => $acc->osmType,
+            'osmId' => $acc->osmId,
         ];
     }
 
-    /** @param array{name: string, type: string, lat: float, lon: float, estimatedPriceMin: float, estimatedPriceMax: float, isExactPrice: bool, url?: ?string, possibleClosed?: bool, distanceToEndPoint?: float, source?: ?string, description?: ?string, imageUrl?: ?string, wikipediaUrl?: ?string, openingHours?: ?string} $data */
+    /** @param array{name: string, type: string, lat: float, lon: float, estimatedPriceMin: float, estimatedPriceMax: float, isExactPrice: bool, url?: ?string, possibleClosed?: bool, distanceToEndPoint?: float, source?: ?string, description?: ?string, imageUrl?: ?string, wikipediaUrl?: ?string, openingHours?: ?string, phone?: ?string, osmType?: ?string, osmId?: ?int} $data */
     private function arrayToAccommodation(array $data): Accommodation
     {
         return new Accommodation(
@@ -852,6 +858,9 @@ final class DoctrineTripRequestRepository extends ServiceEntityRepository implem
             imageUrl: $data['imageUrl'] ?? null,
             wikipediaUrl: $data['wikipediaUrl'] ?? null,
             openingHours: $data['openingHours'] ?? null,
+            phone: $data['phone'] ?? null,
+            osmType: $data['osmType'] ?? null,
+            osmId: $data['osmId'] ?? null,
         );
     }
 

--- a/api/src/State/TripDetailProvider.php
+++ b/api/src/State/TripDetailProvider.php
@@ -262,13 +262,16 @@ final readonly class TripDetailProvider implements ProviderInterface
             'url' => $acc->url,
             'possibleClosed' => $acc->possibleClosed,
             'distanceToEndPoint' => $acc->distanceToEndPoint,
-            // Same five enrichment fields as StagePayloadMapper (issue #870), so a
+            // Same enrichment fields as StagePayloadMapper (issues #870, #873), so a
             // reload and the anonymous shared view are as detailed as the live SSE.
             'source' => $acc->source,
             'description' => $acc->description,
             'imageUrl' => $acc->imageUrl,
             'wikipediaUrl' => $acc->wikipediaUrl,
             'openingHours' => $acc->openingHours,
+            'phone' => $acc->phone,
+            'osmType' => $acc->osmType,
+            'osmId' => $acc->osmId,
         ];
     }
 }

--- a/api/src/State/TripDetailProvider.php
+++ b/api/src/State/TripDetailProvider.php
@@ -243,6 +243,8 @@ final readonly class TripDetailProvider implements ProviderInterface
             'lat' => $poi->lat,
             'lon' => $poi->lon,
             'distanceFromStart' => $poi->distanceFromStart,
+            'osmType' => $poi->osmType,
+            'osmId' => $poi->osmId,
         ];
     }
 

--- a/api/src/Tourism/AccommodationRepository.php
+++ b/api/src/Tourism/AccommodationRepository.php
@@ -37,7 +37,7 @@ final readonly class AccommodationRepository implements AccommodationRepositoryI
      * @param list<array{lat: float, lon: float}> $points
      * @param list<string>                        $categories
      *
-     * @return list<array{name: ?string, category: string, lat: float, lon: float, capacity: ?int, price: ?float, description: ?string, tags: array<string, string>}>
+     * @return list<array{name: ?string, category: string, lat: float, lon: float, capacity: ?int, price: ?float, description: ?string, website: ?string, phone: ?string, openingHours: ?string, wikidata: ?string, imageUrl: ?string, wikipediaUrl: ?string, tags: array<string, string>}>
      */
     public function findNear(array $points, int $radiusMeters, array $categories): array
     {
@@ -73,6 +73,7 @@ final readonly class AccommodationRepository implements AccommodationRepositoryI
                 FROM (
                     SELECT a.id,
                            a.name, a.category, a.capacity, a.price, a.description, a.tags,
+                           a.website, a.phone, a.opening_hours, a.wikidata, a.image_url, a.wikipedia_url,
                            ST_Y(a.geom) AS lat, ST_X(a.geom) AS lon,
                            nearest.point_index, nearest.distance,
                            ROW_NUMBER() OVER (
@@ -119,11 +120,24 @@ final readonly class AccommodationRepository implements AccommodationRepositoryI
                 'capacity' => null !== $row['capacity'] ? (int) $row['capacity'] : null,
                 'price' => null !== $row['price'] ? (float) $row['price'] : null,
                 'description' => null !== $row['description'] && '' !== $row['description'] ? (string) $row['description'] : null,
+                // Flux-set columns (#872); image_url / wikipedia_url come from the
+                // provisioner's Wikidata pass, which now covers this table too.
+                'website' => $this->text($row['website']),
+                'phone' => $this->text($row['phone']),
+                'openingHours' => $this->text($row['opening_hours']),
+                'wikidata' => $this->text($row['wikidata']),
+                'imageUrl' => $this->text($row['image_url']),
+                'wikipediaUrl' => $this->text($row['wikipedia_url']),
                 'tags' => $this->decodeTags($row['tags']),
             ];
         }
 
         return $accommodations;
+    }
+
+    private function text(string|int|float|bool|null $value): ?string
+    {
+        return null !== $value && '' !== $value ? (string) $value : null;
     }
 
     /**

--- a/api/src/Tourism/AccommodationRepositoryInterface.php
+++ b/api/src/Tourism/AccommodationRepositoryInterface.php
@@ -11,14 +11,18 @@ interface AccommodationRepositoryInterface
      * any point, grouped by the end point they belong to (nearest first within each
      * group) and capped per end point, so a dense end point cannot starve a sparse
      * one. `price` is the structured offer price when DataTourisme provided one
-     * (exact), null otherwise (the caller falls back to a heuristic). `tags` carries
-     * the flux keys the provisioner preserved, flattened to the OSM-tag contract
-     * (`opening_hours`, `website`, `phone`, …).
+     * (exact), null otherwise (the caller falls back to a heuristic).
+     * `website` / `phone` / `openingHours` / `wikidata` are the flux columns added
+     * by #872, `imageUrl` / `wikipediaUrl` the ones the provisioner's Wikidata pass
+     * fills. `tags` still carries the flux keys the provisioner preserved, flattened
+     * to the OSM-tag contract (`opening_hours`, `website`, `booking_url`, …): it is
+     * both the fallback for rows imported before the columns existed and the only
+     * home of the keys with no column (`booking_url`, `email`, `image_url`).
      *
      * @param list<array{lat: float, lon: float}> $points
      * @param list<string>                        $categories
      *
-     * @return list<array{name: ?string, category: string, lat: float, lon: float, capacity: ?int, price: ?float, description: ?string, tags: array<string, string>}>
+     * @return list<array{name: ?string, category: string, lat: float, lon: float, capacity: ?int, price: ?float, description: ?string, website: ?string, phone: ?string, openingHours: ?string, wikidata: ?string, imageUrl: ?string, wikipediaUrl: ?string, tags: array<string, string>}>
      */
     public function findNear(array $points, int $radiusMeters, array $categories): array;
 }

--- a/api/tests/Integration/Osm/AccommodationIndexReadTest.php
+++ b/api/tests/Integration/Osm/AccommodationIndexReadTest.php
@@ -262,6 +262,45 @@ final class AccommodationIndexReadTest extends KernelTestCase
         );
     }
 
+    #[Test]
+    public function fetchPropagatesTheContactBlockAndTheOsmIdentity(): void
+    {
+        // Own fixtures: the OSM identity is a per-row property, so the three object
+        // types must be told apart, which the shared setUp rows (all nodes) cannot do.
+        $this->connection->executeStatement('TRUNCATE osm.accommodations');
+        $this->connection->executeStatement(<<<'SQL'
+            INSERT INTO osm.accommodations (osm_type, osm_id, name, category, website, tags, geom) VALUES
+              ('n', 11, 'Hotel Node', 'hotel', NULL, '{"contact:phone": "+33 4 66 00 00 01"}'::jsonb, ST_SetSRID(ST_MakePoint(2.5, 48.5), 4326)),
+              ('w', 22, 'Camping Way', 'camp_site', NULL, '{"contact:url": "gite-du-lac.example/reserver"}'::jsonb, ST_SetSRID(ST_MakePoint(2.5, 48.5), 4326)),
+              ('r', 33, 'Auberge Relation', 'hostel', NULL, '{"phone": "0466000003", "contact:phone": "ignored"}'::jsonb, ST_SetSRID(ST_MakePoint(2.5, 48.5), 4326))
+            SQL);
+
+        $byName = [];
+        foreach ($this->source()->fetch([new Coordinate(48.5, 2.5)], 5000, ['hotel', 'camp_site', 'hostel']) as $candidate) {
+            $byName[$candidate['name']] = $candidate;
+        }
+
+        // osm_type is stored as the one-character osm2pgsql code; the candidate
+        // carries the word openstreetmap.org expects in an object URL.
+        self::assertSame('node', $byName['Hotel Node']['osmType']);
+        self::assertSame(11, $byName['Hotel Node']['osmId']);
+        self::assertSame('way', $byName['Camping Way']['osmType']);
+        self::assertSame(22, $byName['Camping Way']['osmId']);
+        self::assertSame('relation', $byName['Auberge Relation']['osmType']);
+        self::assertSame(33, $byName['Auberge Relation']['osmId']);
+
+        // The contact block: `contact:phone` alone is enough, `phone` wins a tie.
+        self::assertSame('+33 4 66 00 00 01', $byName['Hotel Node']['phone']);
+        self::assertSame('0466000003', $byName['Auberge Relation']['phone']);
+        self::assertNull($byName['Camping Way']['phone']);
+
+        // A `contact:url`-only entry gets a link, normalised to an absolute URL
+        // even though the flux value carried no scheme.
+        self::assertSame('https://gite-du-lac.example/reserver', $byName['Camping Way']['url']);
+        self::assertTrue($byName['Camping Way']['hasWebsite']);
+        self::assertNull($byName['Hotel Node']['url']);
+    }
+
     /**
      * 40 extra hotels, 111 m apart along the meridian, all inside the 5 km radius
      * (41 rows in range with the setUp hotel, for a 30-row cap). Inserted farthest

--- a/api/tests/Integration/Tourism/TourismIndexReadTest.php
+++ b/api/tests/Integration/Tourism/TourismIndexReadTest.php
@@ -50,12 +50,15 @@ final class TourismIndexReadTest extends KernelTestCase
                   ST_SetSRID(ST_MakePoint(6.80, 50.90), 4326))
             SQL);
 
+        // The contact / Wikidata columns exist since #872; `tags` still carries the
+        // keys with no column of their own (booking_url, image_url, labels).
         $this->connection->executeStatement(<<<'SQL'
-            INSERT INTO tourism.accommodations (id, name, category, capacity, price, description, tags, geom) VALUES
-              ('a1', 'Gîte du Lac', 'rental', 4, 75.00, NULL,
+            INSERT INTO tourism.accommodations (id, name, category, capacity, price, description, opening_hours, website, phone, wikidata, image_url, wikipedia_url, tags, geom) VALUES
+              ('a1', 'Gîte du Lac', 'rental', 4, 75.00, NULL, 'Apr-Oct', 'https://gite.test', '+33 3 88 00 00 00', 'Q1234',
+                  'https://img.test/gite.jpg', 'https://fr.wikipedia.org/wiki/Gite',
                   '{"type": ["Accommodation", "RentalAccommodation"], "website": "https://gite.test", "opening_hours": "Apr-Oct", "labels": ["Accueil Vélo"]}'::jsonb,
                   ST_SetSRID(ST_MakePoint(2.50, 48.50), 4326)),
-              ('a2', 'Grand Hôtel', 'hotel', NULL, NULL, NULL, '{}'::jsonb,
+              ('a2', 'Grand Hôtel', 'hotel', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '{}'::jsonb,
                   ST_SetSRID(ST_MakePoint(2.50, 48.50), 4326))
             SQL);
 
@@ -112,12 +115,29 @@ final class TourismIndexReadTest extends KernelTestCase
         self::assertSame('Gîte du Lac', $accommodations[0]['name']);
         self::assertSame(4, $accommodations[0]['capacity']);
         self::assertSame(75.0, $accommodations[0]['price']);
+        // The columns the migration added (#872): without them the read layer could
+        // expose neither a link nor a Q-ID for any of the 124k curated lodgings.
+        self::assertSame('https://gite.test', $accommodations[0]['website']);
+        self::assertSame('+33 3 88 00 00 00', $accommodations[0]['phone']);
+        self::assertSame('Apr-Oct', $accommodations[0]['openingHours']);
+        self::assertSame('Q1234', $accommodations[0]['wikidata']);
+        self::assertSame('https://img.test/gite.jpg', $accommodations[0]['imageUrl']);
+        self::assertSame('https://fr.wikipedia.org/wiki/Gite', $accommodations[0]['wikipediaUrl']);
         // The preserved flux keys reach the source flattened to the OSM-tag contract:
         // scalars only, so the list-valued `type` / `labels` stay in the jsonb (#871).
         self::assertSame(
             ['website' => 'https://gite.test', 'opening_hours' => 'Apr-Oct'],
             $accommodations[0]['tags'],
         );
+
+        $bare = new AccommodationRepository($this->connection)->findNear(
+            [['lat' => 48.50, 'lon' => 2.50]],
+            5000,
+            ['hotel'],
+        );
+        self::assertSame('Grand Hôtel', $bare[0]['name']);
+        self::assertNull($bare[0]['website']);
+        self::assertNull($bare[0]['wikidata']);
     }
 
     #[Test]

--- a/api/tests/Unit/AccommodationSource/DataTourismeAccommodationSourceTest.php
+++ b/api/tests/Unit/AccommodationSource/DataTourismeAccommodationSourceTest.php
@@ -15,12 +15,53 @@ use PHPUnit\Framework\TestCase;
 
 final class DataTourismeAccommodationSourceTest extends TestCase
 {
+    /**
+     * One row as App\Tourism\AccommodationRepository returns it.
+     *
+     * @param array<string, string> $tags
+     *
+     * @return array{name: ?string, category: string, lat: float, lon: float, capacity: ?int, price: ?float, description: ?string, website: ?string, phone: ?string, openingHours: ?string, wikidata: ?string, imageUrl: ?string, wikipediaUrl: ?string, tags: array<string, string>}
+     */
+    private function row(
+        ?string $name = 'Gîte du Lac',
+        string $category = 'rental',
+        float $lat = 48.0,
+        float $lon = 2.0,
+        ?int $capacity = null,
+        ?float $price = null,
+        ?string $description = null,
+        ?string $website = null,
+        ?string $phone = null,
+        ?string $openingHours = null,
+        ?string $wikidata = null,
+        ?string $imageUrl = null,
+        ?string $wikipediaUrl = null,
+        array $tags = [],
+    ): array {
+        return [
+            'name' => $name,
+            'category' => $category,
+            'lat' => $lat,
+            'lon' => $lon,
+            'capacity' => $capacity,
+            'price' => $price,
+            'description' => $description,
+            'website' => $website,
+            'phone' => $phone,
+            'openingHours' => $openingHours,
+            'wikidata' => $wikidata,
+            'imageUrl' => $imageUrl,
+            'wikipediaUrl' => $wikipediaUrl,
+            'tags' => $tags,
+        ];
+    }
+
     #[Test]
     public function usesTheExactOfferPriceWhenPresent(): void
     {
         $repository = $this->createStub(AccommodationRepositoryInterface::class);
         $repository->method('findNear')->willReturn([
-            ['name' => 'Gîte du Lac', 'category' => 'rental', 'lat' => 48.0, 'lon' => 2.0, 'capacity' => 4, 'price' => 75.0, 'description' => 'Joli gîte', 'tags' => []],
+            $this->row(capacity: 4, price: 75.0, description: 'Joli gîte'),
         ]);
 
         // The heuristic engine is final and cannot be doubled, so we pass a real
@@ -35,8 +76,8 @@ final class DataTourismeAccommodationSourceTest extends TestCase
         self::assertTrue($result[0]['isExact']);
         self::assertSame('datatourisme', $result[0]['source']);
         self::assertNull($result[0]['wikidataId']);
-        // description comes from the DataTourisme flux; tourism.accommodations is
-        // not Wikidata-enriched, so the Wikidata-only fields stay null by design.
+        // description comes from the DataTourisme flux; an entry the provisioner
+        // could not tie to a Q-ID gets no Wikidata enrichment.
         self::assertSame('Joli gîte', $result[0]['description']);
         self::assertNull($result[0]['imageUrl']);
         self::assertNull($result[0]['wikipediaUrl']);
@@ -48,7 +89,7 @@ final class DataTourismeAccommodationSourceTest extends TestCase
     {
         $repository = $this->createStub(AccommodationRepositoryInterface::class);
         $repository->method('findNear')->willReturn([
-            ['name' => 'Hôtel du Parc', 'category' => 'hotel', 'lat' => 48.0, 'lon' => 2.0, 'capacity' => null, 'price' => null, 'description' => null, 'tags' => []],
+            $this->row(name: 'Hôtel du Parc', category: 'hotel'),
         ]);
 
         $engine = new PricingHeuristicEngine();
@@ -68,9 +109,9 @@ final class DataTourismeAccommodationSourceTest extends TestCase
     {
         $repository = $this->createStub(AccommodationRepositoryInterface::class);
         $repository->method('findNear')->willReturn([
-            ['name' => null, 'category' => 'hotel', 'lat' => 48.0, 'lon' => 2.0, 'capacity' => null, 'price' => null, 'description' => null, 'tags' => []],
-            ['name' => '   ', 'category' => 'rental', 'lat' => 48.1, 'lon' => 2.1, 'capacity' => null, 'price' => null, 'description' => null, 'tags' => []],
-            ['name' => 'Gîte du Lac', 'category' => 'rental', 'lat' => 48.2, 'lon' => 2.2, 'capacity' => 4, 'price' => 75.0, 'description' => null, 'tags' => []],
+            $this->row(name: null, category: 'hotel'),
+            $this->row(name: '   ', lat: 48.1, lon: 2.1),
+            $this->row(lat: 48.2, lon: 2.2, capacity: 4, price: 75.0),
         ]);
 
         $result = new DataTourismeAccommodationSource($repository, new PricingHeuristicEngine())
@@ -88,8 +129,8 @@ final class DataTourismeAccommodationSourceTest extends TestCase
         // name + category for the bare entry, plus description/capacity/price.
         $repository = $this->createStub(AccommodationRepositoryInterface::class);
         $repository->method('findNear')->willReturn([
-            ['name' => 'Fiche complète', 'category' => 'hotel', 'lat' => 48.0, 'lon' => 2.0, 'capacity' => 12, 'price' => 75.0, 'description' => 'Décrit', 'tags' => []],
-            ['name' => 'Fiche nue', 'category' => 'hotel', 'lat' => 48.1, 'lon' => 2.1, 'capacity' => null, 'price' => null, 'description' => null, 'tags' => []],
+            $this->row(name: 'Fiche complète', category: 'hotel', capacity: 12, price: 75.0, description: 'Décrit'),
+            $this->row(name: 'Fiche nue', category: 'hotel', lat: 48.1, lon: 2.1),
         ]);
 
         $result = new DataTourismeAccommodationSource($repository, new PricingHeuristicEngine())
@@ -106,7 +147,7 @@ final class DataTourismeAccommodationSourceTest extends TestCase
         // `hasWebsite` follows it instead of being asserted.
         $repository = $this->createStub(AccommodationRepositoryInterface::class);
         $repository->method('findNear')->willReturn([
-            ['name' => 'Hôtel du Parc', 'category' => 'hotel', 'lat' => 48.0, 'lon' => 2.0, 'capacity' => null, 'price' => null, 'description' => null, 'tags' => []],
+            $this->row(name: 'Hôtel du Parc', category: 'hotel'),
         ]);
 
         $result = new DataTourismeAccommodationSource($repository, new PricingHeuristicEngine())
@@ -120,9 +161,7 @@ final class DataTourismeAccommodationSourceTest extends TestCase
     public function propagatesCapacityAndLeavesStarsAndFeeUnknown(): void
     {
         $repository = $this->createStub(AccommodationRepositoryInterface::class);
-        $repository->method('findNear')->willReturn([
-            ['name' => 'Gîte du Lac', 'category' => 'rental', 'lat' => 48.0, 'lon' => 2.0, 'capacity' => 4, 'price' => null, 'description' => null, 'tags' => []],
-        ]);
+        $repository->method('findNear')->willReturn([$this->row(capacity: 4)]);
 
         $result = new DataTourismeAccommodationSource($repository, new PricingHeuristicEngine())
             ->fetch([new Coordinate(48.0, 2.0)], 5000, ['rental']);
@@ -142,7 +181,7 @@ final class DataTourismeAccommodationSourceTest extends TestCase
 
         $repository = $this->createStub(AccommodationRepositoryInterface::class);
         $repository->method('findNear')->willReturn([
-            ['name' => 'Gîte des Prés', 'category' => 'rental', 'lat' => 48.0, 'lon' => 2.0, 'capacity' => 4, 'price' => null, 'description' => null, 'tags' => []],
+            $this->row(name: 'Gîte des Prés', capacity: 4),
         ]);
 
         $engine = new PricingHeuristicEngine();
@@ -158,20 +197,77 @@ final class DataTourismeAccommodationSourceTest extends TestCase
     }
 
     /**
+     * The columns #872 added are what the rider verifies a booking with; the
+     * `wikidata` one is also the only key NearbyNameDeduplicator can match an OSM
+     * lodging on before falling back to name + 75 m.
+     */
+    #[Test]
+    public function propagatesTheContactColumnsAndTheWikidataId(): void
+    {
+        $repository = $this->createStub(AccommodationRepositoryInterface::class);
+        $repository->method('findNear')->willReturn([
+            $this->row(
+                name: 'Camping du Lac',
+                category: 'camp_site',
+                website: 'https://camping.test',
+                phone: '+33 3 88 00 00 00',
+                openingHours: 'Apr-Oct',
+                wikidata: 'Q1234',
+                imageUrl: 'https://img.test/camping.jpg',
+                wikipediaUrl: 'https://fr.wikipedia.org/wiki/Camping',
+            ),
+        ]);
+
+        $result = new DataTourismeAccommodationSource($repository, new PricingHeuristicEngine())
+            ->fetch([new Coordinate(48.0, 2.0)], 5000, ['camp_site']);
+
+        self::assertSame('https://camping.test', $result[0]['url']);
+        self::assertTrue($result[0]['hasWebsite']);
+        self::assertSame('Q1234', $result[0]['wikidataId']);
+        self::assertSame('Apr-Oct', $result[0]['openingHours']);
+        self::assertSame('https://img.test/camping.jpg', $result[0]['imageUrl']);
+        self::assertSame('https://fr.wikipedia.org/wiki/Camping', $result[0]['wikipediaUrl']);
+    }
+
+    /**
+     * A value the flux published before #872 normalised it at import — or one that
+     * only exists in the preserved tags — is still absolutised on read, and an
+     * unusable one is dropped rather than handed to the rider as a dead link.
+     */
+    #[Test]
+    public function normalisesTheWebsiteItReads(): void
+    {
+        $repository = $this->createStub(AccommodationRepositoryInterface::class);
+        $repository->method('findNear')->willReturn([
+            $this->row(name: 'Gîte sans schéma', website: 'www.gite.test/chambres'),
+            $this->row(name: 'Gîte injoignable', lat: 48.1, lon: 2.1, website: 'nous contacter'),
+        ]);
+
+        $result = new DataTourismeAccommodationSource($repository, new PricingHeuristicEngine())
+            ->fetch([new Coordinate(48.0, 2.0)], 5000, ['rental']);
+
+        self::assertSame('https://www.gite.test/chambres', $result[0]['url']);
+        self::assertTrue($result[0]['hasWebsite']);
+        self::assertNull($result[1]['url']);
+        self::assertFalse($result[1]['hasWebsite']);
+    }
+
+    /**
      * The source used to pass `'tags' => []` whatever the index held, so the flux
      * contact and opening hours preserved by the provisioner never reached a
-     * consumer (#871).
+     * consumer (#871). They remain the fallback for rows imported before #872 gave
+     * them columns, and the only home of `booking_url` / `image_url`.
      */
     #[Test]
     public function propagatesThePreservedFluxTags(): void
     {
         $repository = $this->createStub(AccommodationRepositoryInterface::class);
         $repository->method('findNear')->willReturn([
-            [
-                'name' => 'Camping du Lac', 'category' => 'camp_site', 'lat' => 48.0, 'lon' => 2.0,
-                'capacity' => null, 'price' => null, 'description' => null,
-                'tags' => ['website' => 'https://camping.test', 'phone' => '+33 3 88 00 00 00', 'opening_hours' => 'Apr-Oct'],
-            ],
+            $this->row(
+                name: 'Camping du Lac',
+                category: 'camp_site',
+                tags: ['website' => 'https://camping.test', 'phone' => '+33 3 88 00 00 00', 'opening_hours' => 'Apr-Oct'],
+            ),
         ]);
 
         $result = new DataTourismeAccommodationSource($repository, new PricingHeuristicEngine())
@@ -191,11 +287,7 @@ final class DataTourismeAccommodationSourceTest extends TestCase
     {
         $repository = $this->createStub(AccommodationRepositoryInterface::class);
         $repository->method('findNear')->willReturn([
-            [
-                'name' => 'Gîte du Lac', 'category' => 'rental', 'lat' => 48.0, 'lon' => 2.0,
-                'capacity' => null, 'price' => null, 'description' => null,
-                'tags' => ['booking_url' => 'https://booking.test/gite'],
-            ],
+            $this->row(tags: ['booking_url' => 'https://booking.test/gite', 'image_url' => 'https://cdn.test/gite.jpg']),
         ]);
 
         $result = new DataTourismeAccommodationSource($repository, new PricingHeuristicEngine())
@@ -203,6 +295,8 @@ final class DataTourismeAccommodationSourceTest extends TestCase
 
         self::assertSame('https://booking.test/gite', $result[0]['url']);
         self::assertTrue($result[0]['hasWebsite']);
+        // The flux photo has no column of its own: image_url is Wikidata-only.
+        self::assertSame('https://cdn.test/gite.jpg', $result[0]['imageUrl']);
     }
 
     /**
@@ -215,11 +309,7 @@ final class DataTourismeAccommodationSourceTest extends TestCase
     {
         $repository = $this->createStub(AccommodationRepositoryInterface::class);
         $repository->method('findNear')->willReturn([
-            [
-                'name' => 'Camping du Lac', 'category' => 'camp_site', 'lat' => 48.0, 'lon' => 2.0,
-                'capacity' => null, 'price' => null, 'description' => null,
-                'tags' => ['opening_hours' => 'Apr-Oct'],
-            ],
+            $this->row(name: 'Camping du Lac', category: 'camp_site', tags: ['opening_hours' => 'Apr-Oct']),
         ]);
 
         $result = new DataTourismeAccommodationSource($repository, new PricingHeuristicEngine())

--- a/api/tests/Unit/AccommodationSource/OsmAccommodationSourceTest.php
+++ b/api/tests/Unit/AccommodationSource/OsmAccommodationSourceTest.php
@@ -125,6 +125,65 @@ final class OsmAccommodationSourceTest extends TestCase
     }
 
     #[Test]
+    public function fetchFallsBackToUrlTagForUrl(): void
+    {
+        $source = $this->createSource($this->repository([$this->row(tags: ['url' => 'https://url-tag.example'])]));
+
+        $results = $source->fetch([new Coordinate(48.5, 2.5)], 5000, ['hotel']);
+
+        $this->assertSame('https://url-tag.example', $results[0]['url']);
+        $this->assertTrue($results[0]['hasWebsite']);
+    }
+
+    #[Test]
+    public function fetchFallsBackToContactUrlTagForUrl(): void
+    {
+        // The fourth and last spelling of the contact block: an accommodation whose
+        // only site is under `contact:url` used to be served without any link.
+        $source = $this->createSource($this->repository([$this->row(tags: ['contact:url' => 'https://contact-url.example'])]));
+
+        $results = $source->fetch([new Coordinate(48.5, 2.5)], 5000, ['hotel']);
+
+        $this->assertSame('https://contact-url.example', $results[0]['url']);
+        $this->assertTrue($results[0]['hasWebsite']);
+    }
+
+    #[Test]
+    public function fetchNormalizesASchemelessWebsite(): void
+    {
+        $source = $this->createSource($this->repository([$this->row(website: 'www.gite-du-pont.fr/chambres')]));
+
+        $results = $source->fetch([new Coordinate(48.5, 2.5)], 5000, ['hotel']);
+
+        $this->assertSame('https://www.gite-du-pont.fr/chambres', $results[0]['url']);
+    }
+
+    #[Test]
+    public function fetchSkipsAnUnusableWebsiteAndKeepsLookingDownTheCascade(): void
+    {
+        // Free text in `website` must not shadow a usable `contact:url` further
+        // down: the cascade is by usability, not by mere presence.
+        $source = $this->createSource($this->repository([
+            $this->row(website: 'nous contacter', tags: ['website' => 'nous contacter', 'contact:url' => 'https://vrai-site.example']),
+        ]));
+
+        $results = $source->fetch([new Coordinate(48.5, 2.5)], 5000, ['hotel']);
+
+        $this->assertSame('https://vrai-site.example', $results[0]['url']);
+    }
+
+    #[Test]
+    public function fetchRejectsANonHttpWebsite(): void
+    {
+        $source = $this->createSource($this->repository([$this->row(website: 'mailto:contact@gite.fr')]));
+
+        $results = $source->fetch([new Coordinate(48.5, 2.5)], 5000, ['hotel']);
+
+        $this->assertNull($results[0]['url']);
+        $this->assertFalse($results[0]['hasWebsite']);
+    }
+
+    #[Test]
     public function fetchSetsNoUrlWhenNeitherWebsiteNorContactPresent(): void
     {
         $source = $this->createSource($this->repository([$this->row()]));
@@ -133,6 +192,47 @@ final class OsmAccommodationSourceTest extends TestCase
 
         $this->assertNull($results[0]['url']);
         $this->assertFalse($results[0]['hasWebsite']);
+    }
+
+    #[Test]
+    public function fetchReadsThePhoneFromTheContactNamespace(): void
+    {
+        $source = $this->createSource($this->repository([$this->row(tags: ['contact:phone' => '+33 4 66 00 00 00'])]));
+
+        $results = $source->fetch([new Coordinate(48.5, 2.5)], 5000, ['hotel']);
+
+        $this->assertSame('+33 4 66 00 00 00', $results[0]['phone']);
+    }
+
+    #[Test]
+    public function fetchPrefersThePlainPhoneTagOverTheContactOne(): void
+    {
+        $source = $this->createSource($this->repository([
+            $this->row(tags: ['phone' => '+33 1 11 11 11 11', 'contact:phone' => '+33 2 22 22 22 22']),
+        ]));
+
+        $results = $source->fetch([new Coordinate(48.5, 2.5)], 5000, ['hotel']);
+
+        $this->assertSame('+33 1 11 11 11 11', $results[0]['phone']);
+    }
+
+    #[Test]
+    public function fetchSetsNoPhoneWhenTheContactBlockIsEmpty(): void
+    {
+        $results = $this->createSource($this->repository([$this->row()]))->fetch([new Coordinate(48.5, 2.5)], 5000, ['hotel']);
+
+        $this->assertNull($results[0]['phone']);
+    }
+
+    #[Test]
+    public function fetchPropagatesTheOsmIdentity(): void
+    {
+        $source = $this->createSource($this->repository([$this->row(osmType: 'way', osmId: 123456)]));
+
+        $results = $source->fetch([new Coordinate(48.5, 2.5)], 5000, ['hotel']);
+
+        $this->assertSame('way', $results[0]['osmType']);
+        $this->assertSame(123456, $results[0]['osmId']);
     }
 
     #[Test]
@@ -217,7 +317,7 @@ final class OsmAccommodationSourceTest extends TestCase
     /**
      * @param array<string, string> $tags
      *
-     * @return array{name: ?string, category: string, lat: float, lon: float, stars: ?int, capacity: ?int, fee: ?string, website: ?string, wikidata: ?string, openingHours: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, tags: array<string, string>}
+     * @return array{osmType: ?string, osmId: ?int, name: ?string, category: string, lat: float, lon: float, stars: ?int, capacity: ?int, fee: ?string, website: ?string, wikidata: ?string, openingHours: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, tags: array<string, string>}
      */
     private function row(
         string $category = 'hotel',
@@ -228,8 +328,12 @@ final class OsmAccommodationSourceTest extends TestCase
         ?int $stars = null,
         ?int $capacity = null,
         ?string $fee = null,
+        ?string $osmType = 'node',
+        ?int $osmId = 8001,
     ): array {
         return [
+            'osmType' => $osmType,
+            'osmId' => $osmId,
             'name' => $name,
             'category' => $category,
             'lat' => 48.6,
@@ -248,7 +352,7 @@ final class OsmAccommodationSourceTest extends TestCase
     }
 
     /**
-     * @param list<array{name: ?string, category: string, lat: float, lon: float, stars: ?int, capacity: ?int, fee: ?string, website: ?string, wikidata: ?string, openingHours: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, tags: array<string, string>}> $rows
+     * @param list<array{osmType: ?string, osmId: ?int, name: ?string, category: string, lat: float, lon: float, stars: ?int, capacity: ?int, fee: ?string, website: ?string, wikidata: ?string, openingHours: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, tags: array<string, string>}> $rows
      */
     private function repository(array $rows): AccommodationRepositoryInterface
     {

--- a/api/tests/Unit/CulturalPoiSource/OsmCulturalPoiSourceTest.php
+++ b/api/tests/Unit/CulturalPoiSource/OsmCulturalPoiSourceTest.php
@@ -27,7 +27,7 @@ final class OsmCulturalPoiSourceTest extends TestCase
     public function mapsRepositoryRowToCandidate(): void
     {
         $source = $this->makeSource($this->repository([
-            ['name' => 'Louvre', 'category' => 'museum', 'lat' => 48.2, 'lon' => 2.2, 'wikidata' => null],
+            ['name' => 'Louvre', 'category' => 'museum', 'lat' => 48.2, 'lon' => 2.2, 'wikidata' => null, 'osmType' => 'relation', 'osmId' => 99],
         ]));
 
         $result = $source->fetchForStages($this->stageGeometries(), 500);
@@ -38,6 +38,9 @@ final class OsmCulturalPoiSourceTest extends TestCase
         self::assertSame(48.2, $result[0]['lat']);
         self::assertSame(2.2, $result[0]['lon']);
         self::assertSame('osm', $result[0]['source']);
+        // Tier-1 primary key: without it the "see on OSM" link cannot be built.
+        self::assertSame('relation', $result[0]['osmType']);
+        self::assertSame(99, $result[0]['osmId']);
         self::assertNull($result[0]['openingHours']);
         self::assertNull($result[0]['estimatedPrice']);
         self::assertNull($result[0]['description']);
@@ -139,7 +142,7 @@ final class OsmCulturalPoiSourceTest extends TestCase
     {
         // Default the provisioner-enriched columns the read layer now returns.
         $rows = array_map(
-            static fn (array $row): array => $row + ['openingHours' => null, 'description' => null, 'imageUrl' => null, 'wikipediaUrl' => null],
+            static fn (array $row): array => $row + ['osmType' => null, 'osmId' => null, 'openingHours' => null, 'description' => null, 'imageUrl' => null, 'wikipediaUrl' => null],
             $rows,
         );
 

--- a/api/tests/Unit/Format/OsmContactTagsTest.php
+++ b/api/tests/Unit/Format/OsmContactTagsTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Format;
+
+use App\Format\OsmContactTags;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class OsmContactTagsTest extends TestCase
+{
+    #[Test]
+    public function phoneReadsThePlainTag(): void
+    {
+        self::assertSame('+33 1 23 45 67 89', OsmContactTags::phone(['phone' => '+33 1 23 45 67 89']));
+    }
+
+    #[Test]
+    public function phoneFallsBackToTheContactNamespace(): void
+    {
+        self::assertSame('0466378200', OsmContactTags::phone(['contact:phone' => '0466378200']));
+    }
+
+    #[Test]
+    public function phonePrefersThePlainTagOverTheContactOne(): void
+    {
+        self::assertSame('first', OsmContactTags::phone(['phone' => 'first', 'contact:phone' => 'second']));
+    }
+
+    #[Test]
+    public function phoneTrimsTheValue(): void
+    {
+        self::assertSame('0102030405', OsmContactTags::phone(['phone' => "  0102030405\n"]));
+    }
+
+    /**
+     * A whitespace-only tag is as unusable as an absent one, and a non-string
+     * value can reach us from the raw Overpass JSON the in-ride path parses.
+     *
+     * @param array<string, mixed> $tags
+     */
+    #[Test]
+    #[DataProvider('unusablePhoneTags')]
+    public function phoneReturnsNullForAnUnusableValue(array $tags): void
+    {
+        self::assertNull(OsmContactTags::phone($tags));
+    }
+
+    /**
+     * @return iterable<string, array{array<string, mixed>}>
+     */
+    public static function unusablePhoneTags(): iterable
+    {
+        yield 'no contact tag' => [['name' => 'Hotel du Nord']];
+        yield 'empty string' => [['phone' => '']];
+        yield 'blank string' => [['phone' => '   ']];
+        yield 'non-string value' => [['phone' => 33123456789]];
+        yield 'blank plain tag with no fallback' => [['phone' => ' ', 'contact:phone' => '']];
+    }
+
+    #[Test]
+    public function phoneSkipsABlankPlainTagInFavourOfTheContactOne(): void
+    {
+        self::assertSame('0102030405', OsmContactTags::phone(['phone' => '  ', 'contact:phone' => '0102030405']));
+    }
+
+    /**
+     * @param array<string, mixed> $tags
+     */
+    #[Test]
+    #[DataProvider('websiteCascade')]
+    public function websiteWalksTheFourSpellings(array $tags, ?string $expected): void
+    {
+        self::assertSame($expected, OsmContactTags::website($tags));
+    }
+
+    /**
+     * @return iterable<string, array{array<string, mixed>, ?string}>
+     */
+    public static function websiteCascade(): iterable
+    {
+        yield 'website' => [['website' => 'https://a.example'], 'https://a.example'];
+        yield 'contact:website' => [['contact:website' => 'https://b.example'], 'https://b.example'];
+        yield 'url' => [['url' => 'https://c.example'], 'https://c.example'];
+        yield 'contact:url' => [['contact:url' => 'https://d.example'], 'https://d.example'];
+        yield 'website wins over the rest' => [
+            ['contact:url' => 'https://d.example', 'website' => 'https://a.example'],
+            'https://a.example',
+        ];
+        // Usability, not mere presence, drives the cascade: free text in an earlier
+        // key must not shadow a real URL in a later one.
+        yield 'free text does not shadow a usable later key' => [
+            ['website' => 'nous contacter', 'contact:url' => 'https://d.example'],
+            'https://d.example',
+        ];
+        yield 'an e-mail is not a website' => [['website' => 'contact@gite.fr'], null];
+        yield 'a mailto: scheme is rejected' => [['website' => 'mailto:contact@gite.fr'], null];
+        yield 'a schemeless value is absolutised' => [['website' => 'www.gite.fr'], 'https://www.gite.fr'];
+        yield 'nothing at all' => [['name' => 'Gîte'], null];
+    }
+}

--- a/api/tests/Unit/Format/WebsiteUrlTest.php
+++ b/api/tests/Unit/Format/WebsiteUrlTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Format;
+
+use App\Format\WebsiteUrl;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class WebsiteUrlTest extends TestCase
+{
+    /**
+     * @return array<string, array{string, string}>
+     */
+    public static function normalisedValues(): array
+    {
+        return [
+            'already absolute' => ['https://gite-du-lac.test/chambres', 'https://gite-du-lac.test/chambres'],
+            'http is kept' => ['http://gite-du-lac.test', 'http://gite-du-lac.test'],
+            'schema-less host' => ['www.gite-du-lac.test', 'https://www.gite-du-lac.test'],
+            'schema-less with path' => ['gite-du-lac.test/chambres', 'https://gite-du-lac.test/chambres'],
+            'protocol relative' => ['//gite-du-lac.test/x', 'https://gite-du-lac.test/x'],
+            'surrounding spaces' => ['  https://gite-du-lac.test  ', 'https://gite-du-lac.test'],
+            'uppercase scheme and host' => ['HTTPS://Gite-Du-Lac.TEST/Chambres', 'https://gite-du-lac.test/Chambres'],
+            'query and fragment kept' => ['gite-du-lac.test/x?a=1#b', 'https://gite-du-lac.test/x?a=1#b'],
+            'port kept' => ['https://gite-du-lac.test:8443/x', 'https://gite-du-lac.test:8443/x'],
+            'accented host' => ['gîte-du-lac.test', 'https://gîte-du-lac.test'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('normalisedValues')]
+    public function normalisesHandTypedValuesToAnAbsoluteUrl(string $raw, string $expected): void
+    {
+        self::assertSame($expected, WebsiteUrl::normalize($raw));
+    }
+
+    /**
+     * @return array<string, array{?string}>
+     */
+    public static function unusableValues(): array
+    {
+        return [
+            'null' => [null],
+            'empty' => [''],
+            'blank' => ['   '],
+            'free text' => ['nous contacter'],
+            'bare word' => ['gite'],
+            'e-mail address' => ['contact@gite.test'],
+            'mailto scheme' => ['mailto:contact@gite.test'],
+            'tel scheme' => ['tel:+33388000000'],
+            'javascript scheme' => ['javascript:alert(1)'],
+            'data scheme' => ['data:text/html,<script>'],
+            'ftp scheme' => ['ftp://gite.test/x'],
+            'credentials' => ['https://user:pass@gite.test'],
+            'no dotted host' => ['http://localhost:8000'],
+            'ip address' => ['http://169.254.169.254/latest'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('unusableValues')]
+    public function rejectsWhatIsNotAnOpenableWebsite(?string $raw): void
+    {
+        self::assertNull(WebsiteUrl::normalize($raw));
+    }
+}

--- a/api/tests/Unit/MessageHandler/CheckCulturalPoisHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/CheckCulturalPoisHandlerTest.php
@@ -202,6 +202,65 @@ final class CheckCulturalPoisHandlerTest extends TestCase
         return $registry;
     }
 
+    /**
+     * @return iterable<string, array{array<string, mixed>, ?string, ?int}>
+     */
+    public static function osmIdentityProvider(): iterable
+    {
+        yield 'osm way' => [['osmType' => 'way', 'osmId' => 4242], 'way', 4242];
+        yield 'osm relation' => [['osmType' => 'relation', 'osmId' => 7], 'relation', 7];
+        // A curated entry carries no OSM identity: the flux has no join key toward
+        // OSM, so the alert must not advertise a link it cannot build.
+        yield 'datatourisme entry' => [['osmType' => null, 'osmId' => null], null, null];
+    }
+
+    /**
+     * @param array<string, mixed> $identity
+     */
+    #[DataProvider('osmIdentityProvider')]
+    #[Test]
+    public function theOsmIdentityReachesTheAlert(array $identity, ?string $expectedType, ?int $expectedId): void
+    {
+        $tripStateManager = $this->createTripStateManager([$this->createStage(1)]);
+
+        $registry = $this->makeRegistryWithPois([
+            ['name' => 'Castle Rock', 'type' => 'castle', 'lat' => 48.2, 'lon' => 2.2, 'source' => 'osm'] + $identity,
+        ]);
+
+        $publishedEvents = [];
+        $publisher = $this->createStub(TripUpdatePublisherInterface::class);
+        $publisher->method('publish')
+            ->willReturnCallback(static function (string $tripId, MercureEventType $type, array $payload) use (&$publishedEvents): void {
+                $publishedEvents[] = ['type' => $type, 'payload' => $payload];
+            });
+
+        $haversine = $this->createStub(GeoDistanceInterface::class);
+        $haversine->method('inMeters')->willReturn(250.0);
+
+        $distributor = $this->createStub(GeometryDistributorInterface::class);
+        $distributor->method('distributeByGeometry')->willReturnCallback(
+            static fn (array $items): array => [0 => $items],
+        );
+
+        $handler = $this->createHandler($tripStateManager, $publisher, $registry, $haversine, $distributor);
+        $handler(new CheckCulturalPois('trip-1'));
+
+        $alertEvents = array_filter($publishedEvents, static fn (array $e): bool => MercureEventType::CULTURAL_POI_ALERTS === $e['type']);
+        $event = array_first($alertEvents);
+        self::assertNotNull($event);
+        $alert = $event['payload']['alerts'][0];
+
+        if (null === $expectedType) {
+            self::assertArrayNotHasKey('osmType', $alert);
+            self::assertArrayNotHasKey('osmId', $alert);
+
+            return;
+        }
+
+        self::assertSame($expectedType, $alert['osmType']);
+        self::assertSame($expectedId, $alert['osmId']);
+    }
+
     #[Test]
     public function nullStagesYieldsNoPublish(): void
     {

--- a/api/tests/Unit/MessageHandler/ScanPoisHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/ScanPoisHandlerTest.php
@@ -157,15 +157,15 @@ final class ScanPoisHandlerTest extends TestCase
      * deduplicator (transparent here: every fixture has a distinct name). An
      * optional callback captures the corridor route the source receives.
      *
-     * @param list<array{name: ?string, category: string, lat: float, lon: float}> $pois
-     * @param (\Closure(list<array{lat: float, lon: float}>, int): void)|null      $captureRoute
+     * @param list<array{name: ?string, category: string, lat: float, lon: float, osmType?: ?string, osmId?: ?int}> $pois
+     * @param (\Closure(list<array{lat: float, lon: float}>, int): void)|null                                       $captureRoute
      */
     private function poiSourceRegistry(array $pois, ?\Closure $captureRoute = null): PoiSourceRegistry
     {
         $source = new readonly class ($pois, $captureRoute) implements PoiSourceInterface {
             /**
-             * @param list<array{name: ?string, category: string, lat: float, lon: float}> $pois
-             * @param (\Closure(list<array{lat: float, lon: float}>, int): void)|null      $captureRoute
+             * @param list<array{name: ?string, category: string, lat: float, lon: float, osmType?: ?string, osmId?: ?int}> $pois
+             * @param (\Closure(list<array{lat: float, lon: float}>, int): void)|null                                       $captureRoute
              */
             public function __construct(private array $pois, private ?\Closure $captureRoute)
             {
@@ -182,6 +182,8 @@ final class ScanPoisHandlerTest extends TestCase
                     'category' => $p['category'],
                     'lat' => $p['lat'],
                     'lon' => $p['lon'],
+                    'osmType' => $p['osmType'] ?? null,
+                    'osmId' => $p['osmId'] ?? null,
                     'wikidataId' => null,
                     'source' => 'osm',
                 ], $this->pois);

--- a/api/tests/Unit/Poi/OsmPoiSourceTest.php
+++ b/api/tests/Unit/Poi/OsmPoiSourceTest.php
@@ -12,12 +12,16 @@ use PHPUnit\Framework\TestCase;
 final class OsmPoiSourceTest extends TestCase
 {
     /**
-     * @param list<array{name: ?string, category: string, lat: float, lon: float}> $rows
+     * @param list<array{name: ?string, category: string, lat: float, lon: float, osmType?: ?string, osmId?: ?int}> $rows
      */
     private function source(array $rows): OsmPoiSource
     {
         $repository = $this->createStub(PoiRepositoryInterface::class);
-        $repository->method('findInCorridor')->willReturn($rows);
+        // The repository always states the OSM identity; fixtures declare it only
+        // when the case is about it.
+        $repository->method('findInCorridor')->willReturn(
+            array_map(static fn (array $r): array => $r + ['osmType' => null, 'osmId' => null], $rows),
+        );
 
         return new OsmPoiSource($repository);
     }
@@ -34,7 +38,7 @@ final class OsmPoiSourceTest extends TestCase
     public function mapsRepositoryRowToCandidate(): void
     {
         $poi = $this->source([
-            ['name' => 'Boulangerie du Centre', 'category' => 'bakery', 'lat' => 48.1, 'lon' => 2.1],
+            ['name' => 'Boulangerie du Centre', 'category' => 'bakery', 'lat' => 48.1, 'lon' => 2.1, 'osmType' => 'node', 'osmId' => 12],
         ])->fetchInCorridor($this->route(), 2000)[0];
 
         self::assertSame('Boulangerie du Centre', $poi['name']);
@@ -43,6 +47,9 @@ final class OsmPoiSourceTest extends TestCase
         self::assertSame(2.1, $poi['lon']);
         self::assertNull($poi['wikidataId']);
         self::assertSame('osm', $poi['source']);
+        // Tier-1 primary key: without it the "see on OSM" link cannot be built.
+        self::assertSame('node', $poi['osmType']);
+        self::assertSame(12, $poi['osmId']);
     }
 
     #[Test]

--- a/api/tests/Unit/Poi/PoiSourceRegistryTest.php
+++ b/api/tests/Unit/Poi/PoiSourceRegistryTest.php
@@ -22,19 +22,21 @@ final class PoiSourceRegistryTest extends TestCase
     }
 
     /**
-     * @param list<array{name: string|null, category: string, lat: float, lon: float, wikidataId: string|null, source: string}> $pois
+     * @param list<array{name: string|null, category: string, lat: float, lon: float, wikidataId: string|null, source: string, osmType?: string|null, osmId?: int|null}> $pois
      */
     private function source(array $pois): PoiSourceInterface
     {
         return new readonly class ($pois) implements PoiSourceInterface {
-            /** @param list<array{name: string|null, category: string, lat: float, lon: float, wikidataId: string|null, source: string}> $pois */
+            /** @param list<array{name: string|null, category: string, lat: float, lon: float, wikidataId: string|null, source: string, osmType?: string|null, osmId?: int|null}> $pois */
             public function __construct(private array $pois)
             {
             }
 
             public function fetchInCorridor(array $route, int $radiusMeters): array
             {
-                return $this->pois;
+                // Fixtures state only what a case is about; the OSM identity defaults
+                // to "not an OSM entry", which is what a curated source looks like.
+                return array_map(static fn (array $p): array => $p + ['osmType' => null, 'osmId' => null], $this->pois);
             }
         };
     }

--- a/api/tests/Unit/Repository/DoctrineTripRequestRepositoryTest.php
+++ b/api/tests/Unit/Repository/DoctrineTripRequestRepositoryTest.php
@@ -357,6 +357,56 @@ final class DoctrineTripRequestRepositoryTest extends TestCase
     }
 
     #[Test]
+    public function accommodationContactBlockAndOsmIdentitySurviveARoundTrip(): void
+    {
+        // #873: exactly the trap #870 documented — omitting the three new keys from
+        // accommodationToArray() drops the tel: link and the "see on OSM" link on
+        // every reload and in the anonymous shared view, while the live SSE shows them.
+        $tripId = Uuid::v7()->toRfc4122();
+        $trip = new TripRequest(Uuid::fromString($tripId));
+
+        $this->entityManager->method('find')->willReturn($trip);
+        $this->entityManager->method('createQuery')->willReturn($this->createStub(Query::class));
+
+        $osmEntry = new Accommodation(
+            name: 'Camping du Pont',
+            type: 'camp_site',
+            lat: 43.947,
+            lon: 4.535,
+            estimatedPriceMin: 18.0,
+            estimatedPriceMax: 18.0,
+            isExactPrice: true,
+            phone: '+33 4 66 37 82 00',
+            osmType: 'way',
+            osmId: 987654321,
+        );
+
+        $stageDto = new StageDto(
+            tripId: $tripId,
+            dayNumber: 1,
+            distance: 60.0,
+            elevation: 500.0,
+            startPoint: new Coordinate(43.9, 4.5, 0.0),
+            endPoint: new Coordinate(43.95, 4.54, 0.0),
+        );
+        $stageDto->addAccommodation($osmEntry);
+        $stageDto->selectedAccommodation = $osmEntry;
+
+        $this->repository->storeStages($tripId, [$stageDto]);
+
+        $stages = $this->repository->getStages($tripId);
+
+        self::assertNotNull($stages);
+
+        foreach ([$stages[0]->accommodations[0], $stages[0]->selectedAccommodation] as $result) {
+            self::assertNotNull($result);
+            self::assertSame('+33 4 66 37 82 00', $result->phone);
+            self::assertSame('way', $result->osmType);
+            self::assertSame(987654321, $result->osmId);
+        }
+    }
+
+    #[Test]
     public function accommodationPersistedWithoutEnrichmentKeysFallsBackToDefaults(): void
     {
         // Accommodations persisted before #870 carry only the ten legacy keys; they
@@ -405,6 +455,9 @@ final class DoctrineTripRequestRepositoryTest extends TestCase
             self::assertNull($result->imageUrl);
             self::assertNull($result->wikipediaUrl);
             self::assertNull($result->openingHours);
+            self::assertNull($result->phone);
+            self::assertNull($result->osmType);
+            self::assertNull($result->osmId);
         }
     }
 

--- a/api/tests/Unit/Repository/DoctrineTripRequestRepositoryTest.php
+++ b/api/tests/Unit/Repository/DoctrineTripRequestRepositoryTest.php
@@ -165,6 +165,8 @@ final class DoctrineTripRequestRepositoryTest extends TestCase
             lat: 48.197,
             lon: 3.283,
             distanceFromStart: 85.2,
+            osmType: 'way',
+            osmId: 4242,
         );
 
         $accommodation = new Accommodation(
@@ -273,6 +275,10 @@ final class DoctrineTripRequestRepositoryTest extends TestCase
         self::assertSame(48.197, $result->pois[0]->lat);
         self::assertSame(3.283, $result->pois[0]->lon);
         self::assertSame(85.2, $result->pois[0]->distanceFromStart);
+        // Without these in poiToArray() the OSM link would vanish on reload and in
+        // the shared view, exactly as the accommodation enrichment did (#870).
+        self::assertSame('way', $result->pois[0]->osmType);
+        self::assertSame(4242, $result->pois[0]->osmId);
 
         // Accommodations
         self::assertCount(1, $result->accommodations);

--- a/provisioner/osm2pgsql/tier1.lua
+++ b/provisioner/osm2pgsql/tier1.lua
@@ -391,6 +391,15 @@ local function to_int(v)
     return math.floor(n)
 end
 
+-- The website lives under four competing spellings in OSM: the bare `website`,
+-- the `contact:` namespace, and `url` in both forms. Projecting `tags.website`
+-- alone hid the site of every object mapped with one of the other three. The
+-- raw value is stored as-is; App\Format\WebsiteUrl normalises it on read, since
+-- rows indexed before this widening need the same treatment anyway.
+local function website_tag(tags)
+    return tags.website or tags['contact:website'] or tags.url or tags['contact:url']
+end
+
 local function insert_features(tags, geom)
     local cat = poi_category(tags)
     if cat then
@@ -398,7 +407,7 @@ local function insert_features(tags, geom)
             name = tags.name,
             category = cat,
             opening_hours = tags.opening_hours,
-            website = tags.website,
+            website = website_tag(tags),
             tags = tags,
             geom = geom,
         })
@@ -412,7 +421,7 @@ local function insert_features(tags, geom)
             stars = to_int(tags.stars),
             capacity = to_int(tags.capacity),
             fee = tags.fee or tags.charge,
-            website = tags.website,
+            website = website_tag(tags),
             wikidata = tags.wikidata,
             opening_hours = tags.opening_hours,
             tags = tags,

--- a/provisioner/src/DataTourismeImporter.php
+++ b/provisioner/src/DataTourismeImporter.php
@@ -40,31 +40,37 @@ final readonly class DataTourismeImporter
     /**
      * Target tables and their COPY column order. `geom` always comes last and is
      * fed EWKT. Must match Version20260616120000 / Version20260616140000 (the
-     * live-schema bootstraps) plus Version20260617130000 (`website`).
+     * live-schema bootstraps) plus Version20260617130000 (`website` on the POI
+     * tables) and Version20260803120000 (the accommodation contact columns).
+     *
+     * `image_url` / `wikipedia_url` are absent on purpose: they exist in the DDL
+     * but are written by the Wikidata pass alone, never by the flux.
      *
      * @var array<string, list<string>>
      */
     private const array TABLE_COLUMNS = [
         'cultural_pois' => ['id', 'name', 'category', 'opening_hours', 'description', 'website', 'wikidata', 'tags', 'geom'],
         'food_pois' => ['id', 'name', 'category', 'opening_hours', 'description', 'website', 'wikidata', 'tags', 'geom'],
-        'accommodations' => ['id', 'name', 'category', 'capacity', 'price', 'description', 'tags', 'geom'],
+        'accommodations' => ['id', 'name', 'category', 'capacity', 'price', 'description', 'opening_hours', 'website', 'phone', 'wikidata', 'tags', 'geom'],
         'events' => ['id', 'name', 'category', 'start_date', 'end_date', 'url', 'description', 'price_min', 'tags', 'geom'],
     ];
 
     private const array STAGING_DDL = [
         'cultural_pois' => 'id text NOT NULL PRIMARY KEY, name text, category text NOT NULL, opening_hours text, description text, website text, image_url text, wikipedia_url text, wikidata text, tags jsonb, geom geometry(Point, 4326) NOT NULL',
         'food_pois' => 'id text NOT NULL PRIMARY KEY, name text, category text NOT NULL, opening_hours text, description text, website text, image_url text, wikipedia_url text, wikidata text, tags jsonb, geom geometry(Point, 4326) NOT NULL',
-        'accommodations' => 'id text NOT NULL PRIMARY KEY, name text, category text NOT NULL, capacity int, price numeric(10, 2), description text, tags jsonb, geom geometry(Point, 4326) NOT NULL',
+        'accommodations' => 'id text NOT NULL PRIMARY KEY, name text, category text NOT NULL, capacity int, price numeric(10, 2), description text, opening_hours text, website text, phone text, image_url text, wikipedia_url text, wikidata text, tags jsonb, geom geometry(Point, 4326) NOT NULL',
         'events' => 'id text NOT NULL PRIMARY KEY, name text, category text NOT NULL, start_date date, end_date date, url text, description text, price_min numeric(10, 2), tags jsonb, geom geometry(Point, 4326) NOT NULL',
     ];
 
     /**
      * Tables carrying a `wikidata` Q-ID column, enriched from Wikidata via the
      * shared {@see WikidataEnrichmentPass} after load and before the swap.
+     * `accommodations` joined the list with its Q-ID column (#872), which is also
+     * what lets NearbyNameDeduplicator pair an OSM and a DataTourisme lodging.
      *
      * @var list<string>
      */
-    private const array WIKIDATA_TABLES = ['cultural_pois', 'food_pois'];
+    private const array WIKIDATA_TABLES = ['cultural_pois', 'food_pois', 'accommodations'];
 
     private HttpClientInterface $httpClient;
 
@@ -244,7 +250,7 @@ final readonly class DataTourismeImporter
 
         $values = match ($table) {
             'cultural_pois', 'food_pois' => [$row['id'], $row['name'], $row['category'], $row['openingHours'], $row['description'], $row['website'], $row['wikidata'], $tags, $geom],
-            'accommodations' => [$row['id'], $row['name'], $row['category'], $row['capacity'], $row['price'], $row['description'], $tags, $geom],
+            'accommodations' => [$row['id'], $row['name'], $row['category'], $row['capacity'], $row['price'], $row['description'], $row['openingHours'], $row['website'], $row['phone'], $row['wikidata'], $tags, $geom],
             'events' => [$row['id'], $row['name'], $row['category'], $row['startDate'], $row['endDate'], $row['website'], $row['description'], $row['price'], $tags, $geom],
             default => [],
         };

--- a/provisioner/src/DataTourismeMapper.php
+++ b/provisioner/src/DataTourismeMapper.php
@@ -16,7 +16,7 @@ namespace Provisioner;
  * the source object is preserved in the row's tags (see {@see tags}), because
  * whatever is dropped here is unrecoverable short of a full re-import (#871).
  *
- * @phpstan-type Row array{head: 'cultural'|'accommodation'|'event'|'food', id: string, name: string|null, category: string, lat: float, lon: float, description: string|null, openingHours: string|null, website: string|null, wikidata: string|null, capacity: int|null, price: float|null, startDate: string|null, endDate: string|null, tags: array<string, mixed>}
+ * @phpstan-type Row array{head: 'cultural'|'accommodation'|'event'|'food', id: string, name: string|null, category: string, lat: float, lon: float, description: string|null, openingHours: string|null, website: string|null, phone: string|null, wikidata: string|null, capacity: int|null, price: float|null, startDate: string|null, endDate: string|null, tags: array<string, mixed>}
  */
 final class DataTourismeMapper
 {
@@ -151,6 +151,7 @@ final class DataTourismeMapper
             'description' => $this->description($object),
             'openingHours' => $openingHours,
             'website' => $contact['website'] ?? $contact['bookingUrl'],
+            'phone' => $contact['phone'],
             'wikidata' => $this->wikidata($object),
             'capacity' => 'accommodation' === $head ? $this->intOrNull($object['allowedPersons'] ?? null) : null,
             'price' => 'accommodation' === $head || 'event' === $head ? $this->price($object['offers'] ?? null) : null,
@@ -172,10 +173,16 @@ final class DataTourismeMapper
      * - `opening_hours`: OSM tag key on purpose, so `App\Accommodation\SeasonalityChecker`
      *   — which reads `$tags['opening_hours']` — works on DataTourisme rows too.
      * - `website`, `phone`, `email`, `booking_url`: the contact block, feeding the
-     *   accommodation URL and the `hasWebsite` completeness signal (#869).
+     *   accommodation URL and the `hasWebsite` completeness signal (#869). `website`
+     *   and `phone` are also columns since #872; they stay here as the fallback the
+     *   read path uses for rows imported before that, and `booking_url` / `email`
+     *   have no column of their own.
      * - `address`, `postal_code`, `city`: the postal address, so a stage label or a
      *   suggestion can be shown without a reverse-geocode round trip.
-     * - `image_url`: the main photo, promoted to a column by #872.
+     * - `image_url`: the main photo. It stays a tag rather than becoming a column:
+     *   the `image_url` column is Wikidata-only across every table (the shared
+     *   {@see WikidataEnrichmentPass} overwrites it), so a flux photo written there
+     *   would be erased for any row carrying a Q-ID.
      * - `labels`: classification / feature labels, where quality labels such as
      *   "Accueil Vélo" live.
      *
@@ -356,24 +363,30 @@ final class DataTourismeMapper
      * them over `foaf:homepage` (top level), `hasContact` and `hasBookingContact`;
      * the first non-empty value wins, contacts being published most-relevant first.
      *
+     * The homepages go through {@see WebsiteUrl}: they are hand-typed, so a
+     * schema-less "www.gite.fr" is absolutised and an unusable value ("nous
+     * contacter", an e-mail address) becomes null rather than being stored as is
+     * (#872). A homepage rejected there does not disqualify the contact — the
+     * next one is still considered, exactly as an absent homepage would be.
+     *
      * @param array<string, mixed> $object
      *
      * @return array{website: ?string, phone: ?string, email: ?string, bookingUrl: ?string}
      */
     private function contact(array $object): array
     {
-        $website = $this->firstString($object['foaf:homepage'] ?? null);
+        $website = WebsiteUrl::normalize($this->firstString($object['foaf:homepage'] ?? null));
         $phone = null;
         $email = null;
         foreach ($this->objectList($object['hasContact'] ?? null) as $contact) {
-            $website ??= $this->firstString($contact['foaf:homepage'] ?? null);
+            $website ??= WebsiteUrl::normalize($this->firstString($contact['foaf:homepage'] ?? null));
             $phone ??= $this->firstString($contact['schema:telephone'] ?? null);
             $email ??= $this->firstString($contact['schema:email'] ?? null);
         }
 
         $bookingUrl = null;
         foreach ($this->objectList($object['hasBookingContact'] ?? null) as $contact) {
-            $bookingUrl ??= $this->firstString($contact['foaf:homepage'] ?? null);
+            $bookingUrl ??= WebsiteUrl::normalize($this->firstString($contact['foaf:homepage'] ?? null));
         }
 
         return ['website' => $website, 'phone' => $phone, 'email' => $email, 'bookingUrl' => $bookingUrl];
@@ -468,7 +481,7 @@ final class DataTourismeMapper
     {
         foreach ($this->objectList($object['hasMainRepresentation'] ?? null) as $representation) {
             foreach ($this->objectList($representation['ebucore:hasRelatedResource'] ?? null) as $resource) {
-                $locator = $this->firstString($resource['ebucore:locator'] ?? null);
+                $locator = WebsiteUrl::normalize($this->firstString($resource['ebucore:locator'] ?? null));
                 if (null !== $locator) {
                     return $locator;
                 }

--- a/provisioner/src/WebsiteUrl.php
+++ b/provisioner/src/WebsiteUrl.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Provisioner;
+
+/**
+ * Normalises a hand-typed website value into an absolute http(s) URL, or null
+ * when it is not one, so the imported columns are clean at rest.
+ *
+ * The DataTourisme flux publishes `foaf:homepage` as free text: an office de
+ * tourisme types "www.gite.fr" (schema-less, which a browser resolves relative
+ * to the app origin), "nous contacter", or an e-mail address. Storing those
+ * verbatim pushes the problem to every consumer, so an unusable value is stored
+ * NULL instead (#872).
+ *
+ * Rules, deliberately conservative:
+ *
+ * - a missing scheme is assumed to be `https`, and so is a `//host/path`;
+ * - any scheme other than http/https (`mailto:`, `tel:`, `javascript:`) is out;
+ * - userinfo is rejected, which is what an e-mail becomes once absolutised;
+ * - the host must be a dotted name, so "nous contacter" and "localhost" are out;
+ * - scheme and host are lowercased, the rest of the URL is preserved verbatim.
+ *
+ * Mirrored by {@see \App\Format\WebsiteUrl} on the API side, which guards the
+ * read path; the two live in separate Composer packages and cannot share code.
+ */
+final class WebsiteUrl
+{
+    /** Scheme prefix, e.g. `https://`, `mailto:`. */
+    private const string SCHEME_PATTERN = '#^[a-zA-Z][a-zA-Z0-9+.\-]*:#';
+
+    /** Dotted host name with a 2+ letter TLD; accented (IDN) labels allowed. */
+    private const string HOST_PATTERN = '/^(?:[\p{L}\p{N}](?:[\p{L}\p{N}\-]*[\p{L}\p{N}])?\.)+\p{L}{2,}$/u';
+
+    public static function normalize(?string $value): ?string
+    {
+        if (null === $value) {
+            return null;
+        }
+
+        $candidate = trim($value);
+        if ('' === $candidate || 1 === preg_match('/[\s\x00-\x1F\x7F]/', $candidate)) {
+            return null;
+        }
+
+        if (str_starts_with($candidate, '//')) {
+            $candidate = 'https:'.$candidate;
+        } elseif (1 !== preg_match(self::SCHEME_PATTERN, $candidate)) {
+            $candidate = 'https://'.$candidate;
+        }
+
+        $parts = parse_url($candidate);
+        if (false === $parts || !isset($parts['host']) || isset($parts['user']) || isset($parts['pass'])) {
+            return null;
+        }
+
+        $scheme = strtolower($parts['scheme'] ?? '');
+        if ('http' !== $scheme && 'https' !== $scheme) {
+            return null;
+        }
+
+        $host = strtolower($parts['host']);
+        if (1 !== preg_match(self::HOST_PATTERN, $host)) {
+            return null;
+        }
+
+        $url = $scheme.'://'.$host;
+        if (isset($parts['port'])) {
+            $url .= ':'.$parts['port'];
+        }
+
+        $url .= $parts['path'] ?? '';
+        if (isset($parts['query'])) {
+            $url .= '?'.$parts['query'];
+        }
+
+        if (isset($parts['fragment'])) {
+            $url .= '#'.$parts['fragment'];
+        }
+
+        return $url;
+    }
+}

--- a/provisioner/tests/DataTourismeImporterTest.php
+++ b/provisioner/tests/DataTourismeImporterTest.php
@@ -144,8 +144,9 @@ final class DataTourismeImporterTest extends TestCase
         $importer->run($this->workDir);
 
         // 1 staging DDL + 4 \copy + 4 GIST index + 1 events-date index + 1 metadata
-        // + 6 enrichment-pass psql calls (no Q-IDs to fetch in this fixture) + 1 swap.
-        self::assertCount(18, $this->captured);
+        // + 7 enrichment-pass psql calls (prepare, collect, export, one UPDATE per
+        // Wikidata table, drop; no Q-IDs to fetch in this fixture) + 1 swap.
+        self::assertCount(19, $this->captured);
 
         $ddl = implode(' ', $this->captured[0]);
         self::assertStringContainsString('CREATE SCHEMA tourism_staging', $ddl);
@@ -338,6 +339,15 @@ final class DataTourismeImporterTest extends TestCase
             'cultural_pois is enriched from the cache, keeping source-set fields',
         );
         self::assertTrue($has('UPDATE tourism_staging.food_pois t SET', 'FROM provisioner.wikidata_cache c'), 'food_pois is enriched from the cache');
+        // accommodations joined the enriched tables with its `wikidata` column (#872).
+        self::assertTrue(
+            $has('INSERT INTO provisioner.wikidata_candidates', 'SELECT DISTINCT wikidata FROM tourism_staging.accommodations'),
+            'accommodation Q-IDs are collected too',
+        );
+        self::assertTrue(
+            $has('UPDATE tourism_staging.accommodations t SET', "image_url = c.payload->>'imageUrl'", "wikipedia_url = c.payload->>'wikipediaUrl'", 'FROM provisioner.wikidata_cache c'),
+            'accommodations receives the Wikidata description, image and Wikipedia URL',
+        );
         self::assertTrue($has('DROP TABLE IF EXISTS provisioner.wikidata_candidates_tourism_staging, provisioner.wikidata_fetch_tourism_staging'), 'scratch tables are dropped');
 
         $fetch = (string) file_get_contents($this->workDir.'/wikidata-fetch.copy');
@@ -444,6 +454,152 @@ final class DataTourismeImporterTest extends TestCase
 
         $event = explode("\t", rtrim((string) file_get_contents($this->workDir.'/tourism-events.copy'), "\n"));
         self::assertSame('https://festival.test', $event[5], 'events.url is populated instead of always null');
+    }
+
+    /**
+     * tourism.accommodations was the poorest table of the schema: no website, no
+     * phone, no opening_hours, no wikidata, so no curated lodging could ever expose
+     * a link and none of them could be Wikidata-enriched (#872).
+     */
+    #[Test]
+    public function loadsTheAccommodationContactColumns(): void
+    {
+        $zipPath = $this->workDir.'/lodging.zip';
+        $zip = new \ZipArchive();
+        $zip->open($zipPath, \ZipArchive::CREATE | \ZipArchive::OVERWRITE);
+        $zip->addFromString('objects/0/00/camping.json', (string) json_encode([
+            '@id' => 'https://data.datatourisme.fr/10/camping',
+            '@type' => ['Accommodation', 'Camping'],
+            'rdfs:label' => ['fr' => ['Camping du Lac']],
+            'owl:sameAs' => ['https://www.wikidata.org/entity/Q1234'],
+            // Schema-less on purpose: the stored value must be absolutised.
+            'foaf:homepage' => ['www.camping-du-lac.test'],
+            'hasContact' => [[
+                '@type' => ['Agent'],
+                'schema:telephone' => ['+33 3 88 00 00 00'],
+            ]],
+            'isLocatedAt' => [[
+                '@type' => ['PlaceOfInterest'],
+                'schema:geo' => ['schema:latitude' => '48.5', 'schema:longitude' => '2.3'],
+                'schema:openingHoursSpecification' => [[
+                    '@type' => ['schema:OpeningHoursSpecification'],
+                    'schema:validFrom' => '2026-04-01',
+                    'schema:validThrough' => '2026-10-31',
+                ]],
+            ]],
+        ]));
+        // A homepage no browser can open must be stored NULL, not as is.
+        $zip->addFromString('objects/0/00/hotel.json', (string) json_encode([
+            '@id' => 'https://data.datatourisme.fr/10/hotel',
+            '@type' => ['Accommodation', 'Hotel'],
+            'rdfs:label' => ['fr' => ['Hotel du Parc']],
+            'foaf:homepage' => ['nous contacter'],
+            'isLocatedAt' => [['schema:geo' => ['schema:latitude' => '48.6', 'schema:longitude' => '2.4']]],
+        ]));
+        $zip->close();
+
+        $bytes = (string) file_get_contents($zipPath);
+        unlink($zipPath);
+
+        $importer = new DataTourismeImporter(
+            fluxUrl: 'https://example.test/flux',
+            httpClient: new MockHttpClient(new MockResponse($bytes)),
+            processFactory: $this->capturingFactory(),
+        );
+        $importer->run($this->workDir);
+
+        $joined = array_map(static fn (array $c): string => implode(' ', $c), $this->captured);
+        self::assertTrue(
+            (bool) array_filter($joined, static fn (string $c): bool => str_contains(
+                $c,
+                '\copy tourism_staging.accommodations (id, name, category, capacity, price, description, opening_hours, website, phone, wikidata, tags, geom)',
+            )),
+            'accommodations is copied with its contact columns',
+        );
+
+        $rows = array_map(
+            static fn (string $line): array => explode("\t", $line),
+            explode("\n", rtrim((string) file_get_contents($this->workDir.'/tourism-accommodations.copy'), "\n")),
+        );
+        self::assertCount(2, $rows);
+
+        [$camping, $hotel] = $rows;
+        self::assertSame('Apr-Oct', $camping[6]);
+        self::assertSame('https://www.camping-du-lac.test', $camping[7], 'a schema-less homepage is absolutised');
+        self::assertSame('+33 3 88 00 00 00', $camping[8]);
+        self::assertSame('Q1234', $camping[9], 'the Q-ID reaches the column the enrichment pass joins on');
+
+        self::assertSame('\N', $hotel[7], 'an unusable homepage is stored NULL rather than as is');
+    }
+
+    /**
+     * The staging DDL and the live-schema migrations must describe the same
+     * tourism.accommodations, or the atomic swap silently changes the table the API
+     * reads. Asserted rather than eyeballed (#872).
+     *
+     * The migrations live in the API package, which is not mounted in the
+     * provisioner container; CI runs this suite from the repository root, where it
+     * is the real gate.
+     */
+    #[Test]
+    public function theStagingDdlMatchesTheAccommodationMigrations(): void
+    {
+        $migrationsDir = __DIR__.'/../../api/migrations';
+        if (!is_dir($migrationsDir)) {
+            self::markTestSkipped('api/migrations is not reachable from here (provisioner container mounts ./provisioner alone)');
+        }
+
+        $reflection = new \ReflectionClass(DataTourismeImporter::class);
+        /** @var array<string, string> $stagingDdl */
+        $stagingDdl = $reflection->getConstant('STAGING_DDL');
+        $staging = $this->columnNames($stagingDdl['accommodations']);
+
+        $migrated = [];
+        foreach (glob($migrationsDir.'/Version*.php') ?: [] as $file) {
+            $source = (string) file_get_contents($file);
+            if (!str_contains($source, 'tourism.accommodations')) {
+                continue;
+            }
+
+            if (1 === preg_match('/CREATE TABLE IF NOT EXISTS tourism\.accommodations \((.*?)\n\s*\)/s', $source, $matches)) {
+                $migrated = array_merge($migrated, $this->columnNames($matches[1]));
+            }
+
+            if (!str_contains($source, 'ALTER TABLE tourism.accommodations ADD COLUMN')) {
+                continue;
+            }
+
+            // Contract with the migration: the added columns are declared in a
+            // `COLUMNS` constant so this test can read them back.
+            self::assertSame(1, preg_match('/const array COLUMNS = \[(.*?)\];/s', $source, $matches), \sprintf('%s alters tourism.accommodations but does not list its columns in a COLUMNS constant', basename($file)));
+            preg_match_all("/'([a-z_]+)'/", $matches[1], $names);
+            $migrated = array_merge($migrated, $names[1]);
+        }
+
+        sort($staging);
+        sort($migrated);
+        self::assertSame($migrated, $staging, 'the provisioner staging DDL and the Doctrine migrations describe a different tourism.accommodations');
+    }
+
+    /**
+     * Column names of a comma-separated column-definition list, parenthesised
+     * type arguments (`numeric(10, 2)`, `geometry(Point, 4326)`) removed first so
+     * their commas do not split a definition, and table constraints skipped.
+     *
+     * @return list<string>
+     */
+    private function columnNames(string $definitions): array
+    {
+        $flattened = (string) preg_replace('/\([^)]*\)/', '', $definitions);
+
+        $names = [];
+        foreach (explode(',', $flattened) as $definition) {
+            if (1 === preg_match('/^\s*([a-z_]+)\s/', $definition, $matches)) {
+                $names[] = $matches[1];
+            }
+        }
+
+        return $names;
     }
 
     #[Test]

--- a/provisioner/tests/DataTourismeMapperTest.php
+++ b/provisioner/tests/DataTourismeMapperTest.php
@@ -433,4 +433,89 @@ final class DataTourismeMapperTest extends TestCase
         self::assertNull($row['openingHours']);
         self::assertArrayNotHasKey('opening_hours', $row['tags']);
     }
+
+    /**
+     * tourism.accommodations gained website / phone / opening_hours / wikidata
+     * columns (#872), so the row must carry each of them, not just the tags.
+     */
+    #[Test]
+    public function exposesTheAccommodationContactAndQidAsRowFields(): void
+    {
+        $row = $this->mapper->map($this->object(['Accommodation', 'Camping'], [
+            'owl:sameAs' => ['https://www.wikidata.org/entity/Q1234'],
+            'hasContact' => [[
+                '@type' => ['Agent'],
+                'foaf:homepage' => ['https://camping.test'],
+                'schema:telephone' => ['+33 3 88 00 00 00'],
+            ]],
+            'takesPlaceAt' => [[
+                '@type' => ['OpeningHoursSpecification'],
+                'startDate' => '2026-04-01',
+                'endDate' => '2026-10-31',
+            ]],
+        ]));
+
+        self::assertNotNull($row);
+        self::assertSame('https://camping.test', $row['website']);
+        self::assertSame('+33 3 88 00 00 00', $row['phone']);
+        self::assertSame('Apr-Oct', $row['openingHours']);
+        self::assertSame('Q1234', $row['wikidata']);
+    }
+
+    /**
+     * A schema-less homepage — what an office de tourisme types most often — is
+     * absolutised, otherwise the browser resolves it against the app origin.
+     */
+    #[Test]
+    public function absolutisesASchemaLessHomepage(): void
+    {
+        $row = $this->mapper->map($this->object(['Accommodation', 'Hotel'], [
+            'foaf:homepage' => ['www.Hotel-Du-Parc.fr/chambres?ref=dt'],
+        ]));
+
+        self::assertNotNull($row);
+        self::assertSame('https://www.hotel-du-parc.fr/chambres?ref=dt', $row['website']);
+        self::assertSame('https://www.hotel-du-parc.fr/chambres?ref=dt', $row['tags']['website']);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function unusableHomepages(): array
+    {
+        return [
+            'free text' => ['nous contacter'],
+            'e-mail address' => ['contact@gite.test'],
+            'mailto scheme' => ['mailto:contact@gite.test'],
+            'tel scheme' => ['tel:+33388000000'],
+            'script scheme' => ['javascript:alert(1)'],
+            'bare word' => ['gite'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('unusableHomepages')]
+    public function dropsAHomepageThatIsNotAUsableUrl(string $homepage): void
+    {
+        $row = $this->mapper->map($this->object(['Accommodation', 'Hotel'], [
+            'foaf:homepage' => [$homepage],
+        ]));
+
+        self::assertNotNull($row);
+        self::assertNull($row['website'], 'an unusable value is stored NULL rather than as is');
+        self::assertArrayNotHasKey('website', $row['tags']);
+    }
+
+    #[Test]
+    public function fallsBackToTheNextHomepageWhenTheFirstIsUnusable(): void
+    {
+        // A rejected top-level homepage must not shadow a usable contact one.
+        $row = $this->mapper->map($this->object(['Accommodation', 'Hotel'], [
+            'foaf:homepage' => ['nous contacter'],
+            'hasContact' => [['@type' => ['Agent'], 'foaf:homepage' => ['hotel-du-parc.fr']]],
+        ]));
+
+        self::assertNotNull($row);
+        self::assertSame('https://hotel-du-parc.fr', $row['website']);
+    }
 }

--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -157,7 +157,8 @@
     "deselect": "Deselect accommodation",
     "selected": "Selected",
     "selectTooltip": "Select this accommodation as your stopover for this stage",
-    "see_on_wikipedia": "See on Wikipedia"
+    "see_on_wikipedia": "See on Wikipedia",
+    "see_on_osm": "See on OpenStreetMap"
   },
   "addStage": {
     "add": "Add stage",

--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -344,7 +344,8 @@
   "alertList": {
     "addToItinerary": "Add to itinerary",
     "free": "Free admission",
-    "see_on_wikipedia": "See on Wikipedia"
+    "see_on_wikipedia": "See on Wikipedia",
+    "see_on_osm": "See on OpenStreetMap"
   },
   "poiPopover": {
     "close": "Close",

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -344,7 +344,8 @@
   "alertList": {
     "addToItinerary": "Ajouter à l'itinéraire",
     "free": "Entrée gratuite",
-    "see_on_wikipedia": "Voir sur Wikipedia"
+    "see_on_wikipedia": "Voir sur Wikipedia",
+    "see_on_osm": "Voir sur OpenStreetMap"
   },
   "poiPopover": {
     "close": "Fermer",

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -157,7 +157,8 @@
     "deselect": "Désélectionner l'hébergement",
     "selected": "Sélectionné",
     "selectTooltip": "Sélectionner cet hébergement comme étape de nuit",
-    "see_on_wikipedia": "Voir sur Wikipedia"
+    "see_on_wikipedia": "Voir sur Wikipedia",
+    "see_on_osm": "Voir sur OpenStreetMap"
   },
   "addStage": {
     "add": "Ajouter une étape",

--- a/pwa/src/components/accommodation-item.test.tsx
+++ b/pwa/src/components/accommodation-item.test.tsx
@@ -145,6 +145,61 @@ describe("AccommodationItem Wikipedia link", () => {
   });
 });
 
+describe("AccommodationItem contact and OSM affordances", () => {
+  it("renders a clickable tel: link for the phone number", () => {
+    renderItem(accommodation({ phone: "+33 4 66 37 82 00" }));
+
+    const link = screen.getByTestId("accommodation-phone-link");
+    expect(link).toHaveAttribute("href", "tel:+33 4 66 37 82 00");
+    expect(link).toHaveTextContent("+33 4 66 37 82 00");
+  });
+
+  it("renders no phone link without a phone number", () => {
+    renderItem(accommodation());
+
+    expect(
+      screen.queryByTestId("accommodation-phone-link"),
+    ).not.toBeInTheDocument();
+  });
+
+  it.each([
+    ["node", 11] as const,
+    ["way", 22] as const,
+    ["relation", 33] as const,
+  ])("links a %s to its own object on OSM", (osmType, osmId) => {
+    renderItem(accommodation({ osmType, osmId }));
+
+    expect(screen.getByTestId("accommodation-osm-link")).toHaveAttribute(
+      "href",
+      `https://www.openstreetmap.org/${osmType}/${osmId}`,
+    );
+  });
+
+  it("uses the translated OSM label", () => {
+    renderItem(accommodation({ osmType: "node", osmId: 11 }));
+
+    expect(screen.getByTestId("accommodation-osm-link")).toHaveTextContent(
+      fr.accommodation.see_on_osm,
+    );
+  });
+
+  it("renders no OSM link for an entry without an OSM identity", () => {
+    renderItem(accommodation({ source: "datatourisme" }));
+
+    expect(
+      screen.queryByTestId("accommodation-osm-link"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders no OSM link when only half the key is known", () => {
+    renderItem(accommodation({ osmType: "node" }));
+
+    expect(
+      screen.queryByTestId("accommodation-osm-link"),
+    ).not.toBeInTheDocument();
+  });
+});
+
 describe("AccommodationItem type rendering", () => {
   it.each(ACCOMMODATION_TYPES)("labels and illustrates a %s", (type) => {
     renderType(type);

--- a/pwa/src/components/accommodation-item.tsx
+++ b/pwa/src/components/accommodation-item.tsx
@@ -11,6 +11,7 @@ import {
   MapPin,
   Euro,
   ExternalLink,
+  Phone,
   CheckCircle2,
   Circle,
   BedDouble,
@@ -111,6 +112,12 @@ export function AccommodationItem({
   const websiteHref = normalizeExternalUrl(accommodation.url);
   const websiteHostname = externalUrlHostname(accommodation.url);
   const wikipediaHref = normalizeExternalUrl(accommodation.wikipediaUrl);
+  // Both halves of the OSM primary key are needed to address the object; an
+  // entry the rider typed in, or one coming from DataTourisme, has neither.
+  const osmHref =
+    accommodation.osmType && accommodation.osmId
+      ? `https://www.openstreetmap.org/${accommodation.osmType}/${accommodation.osmId}`
+      : null;
 
   function startEditing() {
     setEditUrl(accommodation.url ?? "");
@@ -346,6 +353,16 @@ export function AccommodationItem({
             <span>{distLabel}</span>
           </div>
         )}
+        {accommodation.phone && (
+          <a
+            href={`tel:${accommodation.phone}`}
+            className="flex items-center gap-1 hover:underline"
+            data-testid="accommodation-phone-link"
+          >
+            <Phone className="h-3.5 w-3.5" />
+            <span>{accommodation.phone}</span>
+          </a>
+        )}
         {accommodation.source && accommodation.source !== "osm" && (
           <span className="inline-flex items-center text-[10px] font-medium uppercase tracking-wide text-muted-foreground bg-muted rounded px-1.5 py-0.5">
             {accommodation.source === "datatourisme"
@@ -355,18 +372,32 @@ export function AccommodationItem({
         )}
       </div>
 
-      {/* Wikipedia link */}
-      {wikipediaHref && (
-        <div className="mt-1">
-          <a
-            href={wikipediaHref}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-xs text-primary flex items-center gap-0.5 hover:underline"
-          >
-            <ExternalLink className="h-3 w-3" />
-            {t("see_on_wikipedia")}
-          </a>
+      {/* Wikipedia + OpenStreetMap links */}
+      {(wikipediaHref || osmHref) && (
+        <div className="mt-1 flex items-center gap-3 flex-wrap">
+          {wikipediaHref && (
+            <a
+              href={wikipediaHref}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-xs text-primary flex items-center gap-0.5 hover:underline"
+            >
+              <ExternalLink className="h-3 w-3" />
+              {t("see_on_wikipedia")}
+            </a>
+          )}
+          {osmHref && (
+            <a
+              href={osmHref}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-xs text-primary flex items-center gap-0.5 hover:underline"
+              data-testid="accommodation-osm-link"
+            >
+              <ExternalLink className="h-3 w-3" />
+              {t("see_on_osm")}
+            </a>
+          )}
         </div>
       )}
     </div>

--- a/pwa/src/components/alert-list.tsx
+++ b/pwa/src/components/alert-list.tsx
@@ -158,6 +158,12 @@ export function AlertList({ alerts, onAddPoiWaypoint }: AlertListProps) {
                 );
 
               const wikipediaHref = normalizeExternalUrl(alert.wikipediaUrl);
+              // Tier-1 primary key: the rider can check the POI still exists, or
+              // fix it at the source. Absent on a curated DataTourisme entry.
+              const osmHref =
+                alert.osmType && alert.osmId
+                  ? `https://www.openstreetmap.org/${alert.osmType}/${alert.osmId}`
+                  : null;
 
               // Some action kinds are not wired yet; surface them as disabled.
               const isActionDisabled = Boolean(
@@ -245,6 +251,17 @@ export function AlertList({ alerts, onAddPoiWaypoint }: AlertListProps) {
                           data-testid="poi-wikipedia-link"
                         >
                           {t("see_on_wikipedia")}
+                        </a>
+                      )}
+                      {osmHref && (
+                        <a
+                          href={osmHref}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-xs text-primary flex items-center gap-0.5 hover:underline"
+                          data-testid="poi-osm-link"
+                        >
+                          {t("see_on_osm")}
                         </a>
                       )}
                     </div>

--- a/pwa/src/lib/api/schema.d.ts
+++ b/pwa/src/lib/api/schema.d.ts
@@ -764,6 +764,12 @@ export interface components {
             wikipediaUrl?: string | null;
             /** @description Opening hours (Wikidata P8989 or DataTourisme). */
             openingHours?: string | null;
+            /** @description Contact phone number, from the OSM contact block or the DataTourisme flux. */
+            phone?: string | null;
+            /** @description OpenStreetMap object type: node, way or relation. Null when the entry does not come from OSM. */
+            osmType?: string | null;
+            /** @description OpenStreetMap object id. Null when the entry does not come from OSM. */
+            osmId?: number | null;
         };
         "Accommodation.gpx": {
             name?: string;
@@ -785,6 +791,12 @@ export interface components {
             wikipediaUrl?: string | null;
             /** @description Opening hours (Wikidata P8989 or DataTourisme). */
             openingHours?: string | null;
+            /** @description Contact phone number, from the OSM contact block or the DataTourisme flux. */
+            phone?: string | null;
+            /** @description OpenStreetMap object type: node, way or relation. Null when the entry does not come from OSM. */
+            osmType?: string | null;
+            /** @description OpenStreetMap object id. Null when the entry does not come from OSM. */
+            osmId?: number | null;
         };
         "Accommodation.jsonld": {
             name?: string;
@@ -806,6 +818,12 @@ export interface components {
             wikipediaUrl?: string | null;
             /** @description Opening hours (Wikidata P8989 or DataTourisme). */
             openingHours?: string | null;
+            /** @description Contact phone number, from the OSM contact block or the DataTourisme flux. */
+            phone?: string | null;
+            /** @description OpenStreetMap object type: node, way or relation. Null when the entry does not come from OSM. */
+            osmType?: string | null;
+            /** @description OpenStreetMap object id. Null when the entry does not come from OSM. */
+            osmId?: number | null;
         };
         "AccommodationScan.AccommodationScanRequest": {
             /**

--- a/pwa/src/lib/api/schema.d.ts
+++ b/pwa/src/lib/api/schema.d.ts
@@ -1261,6 +1261,10 @@ export interface components {
             lat?: number;
             lon?: number;
             distanceFromStart?: number | null;
+            /** @description OpenStreetMap object type: node, way or relation. Null when the entry does not come from OSM. */
+            osmType?: string | null;
+            /** @description OpenStreetMap object id. Null when the entry does not come from OSM. */
+            osmId?: number | null;
         };
         "PointOfInterest.gpx": {
             name?: string;
@@ -1268,6 +1272,10 @@ export interface components {
             lat?: number;
             lon?: number;
             distanceFromStart?: number | null;
+            /** @description OpenStreetMap object type: node, way or relation. Null when the entry does not come from OSM. */
+            osmType?: string | null;
+            /** @description OpenStreetMap object id. Null when the entry does not come from OSM. */
+            osmId?: number | null;
         };
         "PointOfInterest.jsonld": {
             name?: string;
@@ -1275,6 +1283,10 @@ export interface components {
             lat?: number;
             lon?: number;
             distanceFromStart?: number | null;
+            /** @description OpenStreetMap object type: node, way or relation. Null when the entry does not come from OSM. */
+            osmType?: string | null;
+            /** @description OpenStreetMap object id. Null when the entry does not come from OSM. */
+            osmId?: number | null;
         };
         "Stage.StagePoiWaypointRequest": {
             /** @description POI latitude to insert as waypoint. */
@@ -1811,6 +1823,8 @@ export interface components {
                     lat?: number;
                     lon?: number;
                     distanceFromStart?: number | null;
+                    osmType?: ("node" | "way" | "relation") | null;
+                    osmId?: number | null;
                 }[];
                 accommodations?: {
                     name?: string;
@@ -2056,6 +2070,8 @@ export interface components {
                     lat?: number;
                     lon?: number;
                     distanceFromStart?: number | null;
+                    osmType?: ("node" | "way" | "relation") | null;
+                    osmId?: number | null;
                 }[];
                 accommodations?: {
                     name?: string;

--- a/pwa/src/lib/mercure/types.ts
+++ b/pwa/src/lib/mercure/types.ts
@@ -82,6 +82,8 @@ export interface PoiPayload {
   lat: number;
   lon: number;
   distanceFromStart: number | null;
+  osmType?: "node" | "way" | "relation" | null;
+  osmId?: number | null;
 }
 
 export interface AccommodationPayload {
@@ -283,6 +285,8 @@ export type MercureEvent =
           source?: string;
           imageUrl?: string;
           wikipediaUrl?: string;
+          osmType?: "node" | "way" | "relation";
+          osmId?: number;
         }[];
       };
     }

--- a/pwa/src/lib/mercure/types.ts
+++ b/pwa/src/lib/mercure/types.ts
@@ -100,6 +100,9 @@ export interface AccommodationPayload {
   imageUrl?: string | null;
   wikipediaUrl?: string | null;
   openingHours?: string | null;
+  phone?: string | null;
+  osmType?: "node" | "way" | "relation" | null;
+  osmId?: number | null;
 }
 
 export interface EventPayload {

--- a/pwa/src/lib/validation/schemas.ts
+++ b/pwa/src/lib/validation/schemas.ts
@@ -116,6 +116,15 @@ export const AccommodationSchema = z.object({
   imageUrl: z.string().url().nullable().optional().catch(null),
   wikipediaUrl: z.string().url().nullable().optional().catch(null),
   openingHours: z.string().nullable().optional(),
+  phone: z.string().nullable().optional(),
+  // OSM identity of the entry: `null` on a DataTourisme one, and on anything the
+  // rider added by hand, so the "see on OSM" link only renders when both are set.
+  osmType: z
+    .enum(["node", "way", "relation"])
+    .nullable()
+    .optional()
+    .catch(null),
+  osmId: z.number().int().nullable().optional().catch(null),
 });
 
 /**

--- a/pwa/src/lib/validation/schemas.ts
+++ b/pwa/src/lib/validation/schemas.ts
@@ -31,6 +31,14 @@ export const AlertSchema = z.object({
   wikidataId: z.string().optional(),
   imageUrl: z.string().url().optional().catch(undefined),
   wikipediaUrl: z.string().url().optional().catch(undefined),
+  // OSM identity of the entry: `null` on a DataTourisme one, so the "see on OSM"
+  // link only renders when both are set.
+  osmType: z
+    .enum(["node", "way", "relation"])
+    .nullable()
+    .optional()
+    .catch(null),
+  osmId: z.number().int().nullable().optional().catch(null),
   // Optional contextual action
   action: AlertActionSchema.nullable().optional(),
 });
@@ -56,6 +64,14 @@ export const PointOfInterestSchema = z.object({
   lat: z.number(),
   lon: z.number(),
   distanceFromStart: z.number().nullable().optional(),
+  // OSM identity of the entry: `null` on a DataTourisme one, so the "see on OSM"
+  // link only renders when both are set.
+  osmType: z
+    .enum(["node", "way", "relation"])
+    .nullable()
+    .optional()
+    .catch(null),
+  osmId: z.number().int().nullable().optional().catch(null),
 });
 
 export const SupplyWaterPointSchema = z.object({

--- a/pwa/tests/fixtures/mock-data.ts
+++ b/pwa/tests/fixtures/mock-data.ts
@@ -218,6 +218,12 @@ export function accommodationsFoundEvent(
           description: "Hôtel familial à deux pas du pont.",
           // Unusable OSM `website` tag: renders no link at all, no error.
           url: "appeler le 06 12 34 56 78",
+          // Contact block and OSM identity (issue #873): the phone renders as a
+          // `tel:` link, and the (way, 42) pair as a link to that exact object —
+          // a hardcoded `node` would point at a different feature entirely.
+          phone: "+33 4 75 00 00 00",
+          osmType: "way",
+          osmId: 42,
         },
       ],
     },

--- a/pwa/tests/mocked/accommodation.spec.ts
+++ b/pwa/tests/mocked/accommodation.spec.ts
@@ -63,6 +63,38 @@ test.describe("Accommodations", () => {
     await expect(stageCard).toContainText("Hotel du Pont");
   });
 
+  test("offers a tel: link and an OSM link on an OSM entry (issue #873)", async ({
+    submitUrl,
+    injectSequence,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    await injectSequence([
+      routeParsedEvent(),
+      stagesComputedEvent(),
+      accommodationsFoundEvent(0),
+      tripCompleteEvent(),
+    ]);
+    const stageCard = mockedPage.getByTestId("stage-card-1");
+    await expect(stageCard).toContainText("Hotel du Pont");
+
+    const phoneLink = stageCard.getByTestId("accommodation-phone-link");
+    await expect(phoneLink).toHaveCount(1);
+    await expect(phoneLink).toHaveAttribute("href", "tel:+33 4 75 00 00 00");
+
+    // The link addresses the object by its own type: the fixture is a `way`, so
+    // a hardcoded `node` would silently point at an unrelated feature.
+    const osmLink = stageCard.getByTestId("accommodation-osm-link");
+    await expect(osmLink).toHaveCount(1);
+    await expect(osmLink).toHaveAttribute(
+      "href",
+      "https://www.openstreetmap.org/way/42",
+    );
+
+    // The DataTourisme entry has no OSM identity and no phone: no stray links.
+    await expect(stageCard).toContainText("Camping Les Oliviers");
+  });
+
   test("adds manual accommodation", async ({ createFullTrip, mockedPage }) => {
     await createFullTrip();
     const stageCard = mockedPage.getByTestId("stage-card-1");


### PR DESCRIPTION
Closes #872.

> **PR empilée.** Base = `feature/871` (PR #915). À merger **après** elle. Le diff propre à cette PR est le seul commit `a218f6f3`.

`tourism.accommodations` était la table de la source curée et la plus pauvre du schéma : ni `website`, ni `phone`, ni `opening_hours`, ni `wikidata`, là où ses tables sœurs `cultural_pois` et `food_pois` les ont toutes. Conséquence : `url` était toujours `null` sur les 124 240 fiches curées, aucun enrichissement Wikidata n'était possible, et la déduplication OSM / DataTourisme des hébergements reposait uniquement sur l'heuristique nom + 75 m.

## Détail

- **`api/migrations/Version20260803120000.php`** (créé) : ajoute `opening_hours`, `website`, `phone`, `image_url`, `wikipedia_url`, `wikidata` à `tourism.accommodations`. La liste de colonnes vit dans une constante `COLUMNS` — c'est un contrat que le test d'alignement relit.
- **`DataTourismeImporter`** : `STAGING_DDL`, `TABLE_COLUMNS` et `copyLine()` mis à jour ; `accommodations` ajouté à `WIKIDATA_TABLES`.
- **`DataTourismeMapper`** : la `Row` gagne `phone` ; les homepages et le locator média passent par le normaliseur.
- **`Tourism\AccommodationRepository`** : sélectionne et retourne `website`, `phone`, `openingHours`, `wikidata`, `imageUrl`, `wikipediaUrl`.
- **`DataTourismeAccommodationSource`** : `url` depuis la colonne, `wikidataId` / `imageUrl` / `wikipediaUrl` / `openingHours` propagés.

**Aucun DTO touché** : `api/src/ApiResource/Model/Accommodation.php` est intact, donc `phone` s'arrête au repository — c'est le périmètre de #873, qui s'empile sur cette branche.

## Normalisation d'URL — à réutiliser par #873

**`api/src/Format/WebsiteUrl.php`** — `WebsiteUrl::normalize(?string): ?string`, statique, sans DI. **C'est celui que #873 doit réutiliser** pour `website` / `contact:website` / `url` / `contact:url` côté OSM, plutôt que d'en écrire un second.

Règles : valeur sans schéma et `//host` absolutisées en `https`, schémas non-http(s) rejetés, userinfo rejeté (ce qui attrape les e-mails), hôte devant être un nom pointé (rejette `localhost` et les IP), schéma et hôte mis en minuscules.

## Auto-critique

- **Le normaliseur existe en double.** Le provisionner est un paquet Composer séparé et ne peut pas importer `App\` : il a donc son miroir `provisioner/src/WebsiteUrl.php`, les deux docblocks se référençant mutuellement. C'est de la duplication assumée — celui du provisionner normalise à l'import (colonne propre au repos), celui de l'API garde le chemin de lecture. Un paquet partagé serait la vraie réponse, mais c'est un chantier d'infrastructure hors sujet ici.
- **`image_url` et `wikipedia_url` ne sont volontairement pas dans la liste COPY.** Elles existent dans le DDL mais sont exclusivement alimentées par Wikidata sur toutes les tables : la passe partagée les **écrase** au lieu de les `COALESCE`. Y écrire une photo du flux la ferait effacer pour toute ligne portant un Q-ID. Le flux perd donc sa photo dès qu'il y a un Q-ID — c'est le comportement existant, pas une régression, mais cela mériterait un `COALESCE` dans un suivi.
- **Le repli sur `tags` est conservé**, délibérément : `$accommodation['website'] ?? $tags['website'] ?? $tags['booking_url']`, idem pour `openingHours` et `imageUrl`. Les lignes importées avant cette migration ont des colonnes `NULL`, et `booking_url` / `email` / `image_url` n'ont pas de colonne du tout. `SeasonalityChecker` continue de lire `$tags['opening_hours']`, inchangé.
- Les critères d'acceptation en `SELECT count(*)` ne sont vérifiables **qu'après un ré-import réel**. Ils ne sont pas prouvés ici.
- **`api/src/Engine/OpeningHours.php` (livré par #914) n'est pas sur cette branche**, et il n'y avait pas lieu de l'utiliser : la chaîne du flux est déjà réduite à la syntaxe OSM par #871. Aucune duplication à réconcilier.

## Vérification

`make qa` ne peut pas aboutir sur une machine de dev. Legs individuels :

| Leg | Sortie |
|---|---|
| PHP-CS-Fixer (api) | `Fixed 0 of 654 files in 2.271 seconds` |
| PHP-CS-Fixer (provisioner) | `Fixed 0 of 22 files in 0.670 seconds` |
| Rector `--dry-run` (api) | `[OK] Rector is done!` (615 fichiers) |
| Rector `--dry-run` (provisioner) | `[OK] Rector is done!` (23 fichiers) |
| PHPStan (api, niveau 9) | `[OK] No errors` |
| PHPStan (provisioner) | `[OK] No errors` |
| PHPUnit provisioner (complet, image `bike-trip-planner-provisioner:dev`) | `OK (99 tests, 548 assertions)` — 88 au niveau de #871 |
| PHPUnit api `tests/Unit` + `tests/Integration` | `OK, but some tests were skipped! Tests: 1393, Assertions: 3869, Skipped: 1` |

Le run api a utilisé une base dédiée `app872` (auto-suffixée `_test`), créée et migrée de zéro par Foundry — ce qui est en soi la preuve que la nouvelle migration s'applique.

Aucun leg frontend : rien sous `pwa/` n'a changé et aucun DTO n'a bougé, donc pas de dérive de `schema.d.ts`. **Playwright : c'est CI le gate**, aucune couverture E2E locale n'est revendiquée.

### Preuve que les tests peuvent échouer

Quatre mutations, chacune vérifiée rouge puis restaurée :

1. **Alignement migration ↔ `STAGING_DDL`** — suppression de `phone text` du `STAGING_DDL['accommodations']` :
   ```
   theStagingDdlMatchesTheAccommodationMigrations
   the provisioner staging DDL and the Doctrine migrations describe a different tourism.accommodations
   -    8 => 'phone',
   ```
2. **Normalisation d'URL, provisionner** — `Provisioner\WebsiteUrl::normalize` neutralisé (retourne son entrée) : 9 échecs, dont
   ```
   dropsAHomepageThatIsNotAUsableUrl@free text ('nous contacter')
   an unusable value is stored NULL rather than as is / Failed asserting that 'nous contacter' is null.
   ```
3. **Normalisation d'URL, API + `wikidataId`** — `App\Format\WebsiteUrl::normalize` neutralisé et `'wikidataId' => null` forcé : 22 échecs, dont
   ```
   propagatesTheContactColumnsAndTheWikidataId — Failed asserting that null is identical to 'Q1234'.
   rejectsWhatIsNotAnOpenableWebsite@ip address — Failed asserting that 'http://169.254.169.254/latest' is null.
   ```
4. **Lecture d'intégration des nouvelles colonnes** — `'wikidata' => null` forcé dans le mapping du repository :
   ```
   TourismIndexReadTest::accommodationsAreFilteredByCategoryAndRadius
   Failed asserting that null is identical to 'Q1234'.
   ```

### Un point d'attention

Le test d'alignement vit dans la suite du provisionner et lit `../api/migrations`. Ce chemin résout depuis la racine du dépôt — c'est ce que fait CI (`working-directory: provisioner`), donc le vrai gate — mais **pas** dans le conteneur provisionner de dev, qui ne monte que `./provisioner:/app` : il y `markTestSkipped`. La suite a été lancée avec tout le dépôt monté (`-v "$PWD:/repo" -w /repo/provisioner`) pour qu'il s'exécute réellement ; les 99/99 ci-dessus l'incluent.

`provisioner/vendor-bin/php-cs-fixer/vendor` n'étant pas installé localement, ce leg a tourné avec le binaire php-cs-fixer de l'image api contre `provisioner/.php-cs-fixer.dist.php` (même version 3.95.18).
<!-- claude-review-start -->
## Claude Review

**Summary:** 0 findings from an independent review of the full diff, including the third commit (`af2c36ca`) added since the last automated review. That commit finishes the `osmType`/`osmId` propagation the previous review flagged as dead code in `PoiRepository`/`CulturalPoiRepository`; it is now consumed end-to-end (source → handler → DTO → Mercure/persistence → frontend) with matching tests.

**Resolved threads:** Resolved 1 previously open thread (the `osmType`/`osmId` dead-propagation finding on `api/src/Osm/PoiRepository.php`), now fixed by the third commit.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

Commit reviewed: af2c36ca3f9559a49b4de05981c5f6a42eb8d0ef
<!-- claude-review-end -->