### PR TITLE
feat(api): expose accommodation url, phone and osm identity

### DIFF
--- a/api/src/Accommodation/CandidateRanker.php
+++ b/api/src/Accommodation/CandidateRanker.php
@@ -63,9 +63,9 @@ final readonly class CandidateRanker
     private const array OUTDOOR_TYPES = ['camp_site', 'shelter', 'wilderness_hut'];
 
     /**
-     * @param list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, stars?: ?int, capacity?: ?int, fee?: ?string, source?: string, wikidataId?: ?string, description?: ?string, imageUrl?: ?string, wikipediaUrl?: ?string, openingHours?: ?string}> $candidates
+     * @param list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, stars?: ?int, capacity?: ?int, fee?: ?string, source?: string, wikidataId?: ?string, description?: ?string, imageUrl?: ?string, wikipediaUrl?: ?string, openingHours?: ?string, phone?: ?string, osmType?: ?string, osmId?: ?int}> $candidates
      *
-     * @return list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, stars?: ?int, capacity?: ?int, fee?: ?string, source?: string, wikidataId?: ?string, description?: ?string, imageUrl?: ?string, wikipediaUrl?: ?string, openingHours?: ?string}>
+     * @return list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, stars?: ?int, capacity?: ?int, fee?: ?string, source?: string, wikidataId?: ?string, description?: ?string, imageUrl?: ?string, wikipediaUrl?: ?string, openingHours?: ?string, phone?: ?string, osmType?: ?string, osmId?: ?int}>
      */
     public function rank(array $candidates, int $limit): array
     {
@@ -110,7 +110,7 @@ final readonly class CandidateRanker
     }
 
     /**
-     * @param array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, stars?: ?int, capacity?: ?int, fee?: ?string, source?: string, wikidataId?: ?string, description?: ?string, imageUrl?: ?string, wikipediaUrl?: ?string, openingHours?: ?string} $candidate
+     * @param array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, stars?: ?int, capacity?: ?int, fee?: ?string, source?: string, wikidataId?: ?string, description?: ?string, imageUrl?: ?string, wikipediaUrl?: ?string, openingHours?: ?string, phone?: ?string, osmType?: ?string, osmId?: ?int} $candidate
      */
     private function completeness(array $candidate): int
     {

--- a/api/src/AccommodationSource/AccommodationSourceInterface.php
+++ b/api/src/AccommodationSource/AccommodationSourceInterface.php
@@ -14,7 +14,7 @@ interface AccommodationSourceInterface
      * @param array<int, Coordinate> $endPoints
      * @param list<string>           $enabledTypes
      *
-     * @return list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, stars: ?int, capacity: ?int, fee: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, source: string, wikidataId: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, openingHours: ?string}>
+     * @return list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, stars: ?int, capacity: ?int, fee: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, source: string, wikidataId: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, openingHours: ?string, phone: ?string, osmType: ?string, osmId: ?int}>
      */
     public function fetch(array $endPoints, int $radiusMeters, array $enabledTypes): array;
 

--- a/api/src/AccommodationSource/AccommodationSourceRegistry.php
+++ b/api/src/AccommodationSource/AccommodationSourceRegistry.php
@@ -31,7 +31,7 @@ class AccommodationSourceRegistry
      * @param array<int, Coordinate> $endPoints
      * @param list<string>           $enabledTypes
      *
-     * @return list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, stars: ?int, capacity: ?int, fee: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, source: string, wikidataId: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, openingHours: ?string}>
+     * @return list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, stars: ?int, capacity: ?int, fee: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, source: string, wikidataId: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, openingHours: ?string, phone: ?string, osmType: ?string, osmId: ?int}>
      */
     public function fetchAll(array $endPoints, int $radiusMeters, array $enabledTypes): array
     {
@@ -47,7 +47,7 @@ class AccommodationSourceRegistry
             }
         }
 
-        /** @var list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, stars: ?int, capacity: ?int, fee: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, source: string, wikidataId: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, openingHours: ?string}> $deduped */
+        /** @var list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, stars: ?int, capacity: ?int, fee: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, source: string, wikidataId: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, openingHours: ?string, phone: ?string, osmType: ?string, osmId: ?int}> $deduped */
         $deduped = $this->deduplicator->dedupe($all);
 
         return $deduped;

--- a/api/src/AccommodationSource/DataTourismeAccommodationSource.php
+++ b/api/src/AccommodationSource/DataTourismeAccommodationSource.php
@@ -28,7 +28,7 @@ final readonly class DataTourismeAccommodationSource implements AccommodationSou
      * @param array<int, Coordinate> $endPoints
      * @param list<string>           $enabledTypes
      *
-     * @return list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, stars: ?int, capacity: ?int, fee: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, source: string, wikidataId: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, openingHours: ?string}>
+     * @return list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, stars: ?int, capacity: ?int, fee: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, source: string, wikidataId: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, openingHours: ?string, phone: ?string, osmType: ?string, osmId: ?int}>
      */
     public function fetch(array $endPoints, int $radiusMeters, array $enabledTypes = TripRequest::ALL_ACCOMMODATION_TYPES): array
     {
@@ -104,6 +104,13 @@ final readonly class DataTourismeAccommodationSource implements AccommodationSou
                 'imageUrl' => $accommodation['imageUrl'] ?? WebsiteUrl::normalize($tags['image_url'] ?? null),
                 'wikipediaUrl' => $accommodation['wikipediaUrl'],
                 'openingHours' => $accommodation['openingHours'] ?? $tags['opening_hours'] ?? null,
+                // Column since #872, with the same pre-migration `tags` fallback as
+                // the fields above; it stopped at the repository until now.
+                'phone' => $accommodation['phone'] ?? $tags['phone'] ?? null,
+                // A flux entry is identified by its DataTourisme URI, not by an OSM
+                // object: there is nothing to link to on openstreetmap.org.
+                'osmType' => null,
+                'osmId' => null,
             ];
         }
 

--- a/api/src/AccommodationSource/OsmAccommodationSource.php
+++ b/api/src/AccommodationSource/OsmAccommodationSource.php
@@ -7,6 +7,8 @@ namespace App\AccommodationSource;
 use App\ApiResource\Model\Coordinate;
 use App\ApiResource\TripRequest;
 use App\Engine\PricingHeuristicEngine;
+use App\Format\OsmContactTags;
+use App\Format\WebsiteUrl;
 use App\Osm\AccommodationRepositoryInterface;
 
 final readonly class OsmAccommodationSource implements AccommodationSourceInterface
@@ -21,7 +23,7 @@ final readonly class OsmAccommodationSource implements AccommodationSourceInterf
      * @param array<int, Coordinate> $endPoints
      * @param list<string>           $enabledTypes
      *
-     * @return list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, stars: ?int, capacity: ?int, fee: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, source: string, wikidataId: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, openingHours: ?string}>
+     * @return list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, stars: ?int, capacity: ?int, fee: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, source: string, wikidataId: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, openingHours: ?string, phone: ?string, osmType: ?string, osmId: ?int}>
      */
     public function fetch(array $endPoints, int $radiusMeters, array $enabledTypes = TripRequest::ALL_ACCOMMODATION_TYPES): array
     {
@@ -53,6 +55,13 @@ final readonly class OsmAccommodationSource implements AccommodationSourceInterf
                 $accommodation['fee'],
             );
 
+            // The indexed `website` column is the projection of the same contact
+            // block, so it comes first; the tag cascade (website, contact:website,
+            // url, contact:url) covers the spellings the column misses and the rows
+            // indexed before it was widened. Both go through WebsiteUrl, so a
+            // schema-less "www.gite.fr" is served absolute and free text is dropped.
+            $url = WebsiteUrl::normalize($accommodation['website']) ?? OsmContactTags::website($tags);
+
             $candidates[] = [
                 'name' => $name,
                 'type' => $accommodation['category'],
@@ -61,12 +70,12 @@ final readonly class OsmAccommodationSource implements AccommodationSourceInterf
                 'priceMin' => $pricing['min'],
                 'priceMax' => $pricing['max'],
                 'isExact' => $pricing['isExact'],
-                'url' => $accommodation['website'] ?? ($tags['contact:website'] ?? null),
+                'url' => $url,
                 'stars' => $accommodation['stars'],
                 'capacity' => $accommodation['capacity'],
                 'fee' => $accommodation['fee'],
                 'tagCount' => \count($tags),
-                'hasWebsite' => null !== $accommodation['website'] || isset($tags['contact:website']),
+                'hasWebsite' => null !== $url,
                 'tags' => $tags,
                 'source' => 'osm',
                 'wikidataId' => $accommodation['wikidata'],
@@ -74,6 +83,9 @@ final readonly class OsmAccommodationSource implements AccommodationSourceInterf
                 'imageUrl' => $accommodation['imageUrl'],
                 'wikipediaUrl' => $accommodation['wikipediaUrl'],
                 'openingHours' => $accommodation['openingHours'],
+                'phone' => OsmContactTags::phone($tags),
+                'osmType' => $accommodation['osmType'],
+                'osmId' => $accommodation['osmId'],
             ];
         }
 

--- a/api/src/ApiResource/Model/Accommodation.php
+++ b/api/src/ApiResource/Model/Accommodation.php
@@ -28,6 +28,16 @@ final readonly class Accommodation
         public ?string $wikipediaUrl = null,
         #[ApiProperty(description: 'Opening hours (Wikidata P8989 or DataTourisme).')]
         public ?string $openingHours = null,
+        #[ApiProperty(description: 'Contact phone number, from the OSM contact block or the DataTourisme flux.')]
+        public ?string $phone = null,
+        // The (osmType, osmId) pair is the primary key of the Tier-1 index and the
+        // only stable identity an OSM entry has: it is what lets the rider open the
+        // object on openstreetmap.org to check it still exists — or fix it at the
+        // source. Null for a DataTourisme entry, which has no OSM identity.
+        #[ApiProperty(description: 'OpenStreetMap object type: node, way or relation. Null when the entry does not come from OSM.')]
+        public ?string $osmType = null,
+        #[ApiProperty(description: 'OpenStreetMap object id. Null when the entry does not come from OSM.')]
+        public ?int $osmId = null,
     ) {
     }
 }

--- a/api/src/Format/OsmContactTags.php
+++ b/api/src/Format/OsmContactTags.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Format;
+
+/**
+ * Reads the OSM contact block, which is written under two competing schemes:
+ * the bare keys (`phone`, `website`) and the `contact:` namespace
+ * (`contact:phone`, `contact:website`), plus `url` as a third spelling of the
+ * website. Both live side by side in the wild, so a mapper who only filled
+ * `contact:phone` is invisible to a reader that looks up `phone` alone.
+ *
+ * Static, without DI, like {@see WebsiteUrl}: this is a pure tag lookup, and
+ * both the in-ride assistant (raw Overpass tags) and the planned path (the
+ * `tags` jsonb of the Tier-1 index) call it on plain arrays.
+ */
+final class OsmContactTags
+{
+    /** @var list<string> */
+    private const array PHONE_KEYS = ['phone', 'contact:phone'];
+
+    /** @var list<string> */
+    private const array WEBSITE_KEYS = ['website', 'contact:website', 'url', 'contact:url'];
+
+    /**
+     * First non-empty phone number of the contact block, verbatim.
+     *
+     * Not reformatted: OSM holds international, national and free-text spellings,
+     * and a `tel:` link works with all of them.
+     *
+     * @param array<string, mixed> $tags
+     */
+    public static function phone(array $tags): ?string
+    {
+        return self::firstNonEmpty($tags, self::PHONE_KEYS);
+    }
+
+    /**
+     * First website of the contact block that normalises to a usable http(s)
+     * URL. A key holding free text ("nous contacter") is skipped rather than
+     * shadowing a valid `contact:url` further down the list.
+     *
+     * @param array<string, mixed> $tags
+     */
+    public static function website(array $tags): ?string
+    {
+        foreach (self::WEBSITE_KEYS as $key) {
+            $url = WebsiteUrl::normalize(self::firstNonEmpty($tags, [$key]));
+            if (null !== $url) {
+                return $url;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, mixed> $tags
+     * @param list<string>         $keys
+     */
+    private static function firstNonEmpty(array $tags, array $keys): ?string
+    {
+        foreach ($keys as $key) {
+            $value = $tags[$key] ?? null;
+            if (\is_string($value) && '' !== trim($value)) {
+                return trim($value);
+            }
+        }
+
+        return null;
+    }
+}

--- a/api/src/InRide/InRideAssistant.php
+++ b/api/src/InRide/InRideAssistant.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\InRide;
 
 use App\ApiResource\Model\GeoPosition;
+use App\Format\OsmContactTags;
 use App\Geo\GeoDistanceInterface;
 use App\Geo\GeoPoint;
 use App\Llm\Exception\AiUnavailableException;
@@ -226,7 +227,7 @@ final readonly class InRideAssistant
                 detourMeters: $detourMeters,
                 openingHoursToday: $openingHoursTag,
                 closesAt: $closesAt,
-                phone: \is_string($tags['phone'] ?? null) ? $tags['phone'] : (\is_string($tags['contact:phone'] ?? null) ? $tags['contact:phone'] : null),
+                phone: OsmContactTags::phone($tags),
                 deeplink: $deeplink,
                 warning: $warning,
             );

--- a/api/src/Mercure/StagePayloadMapper.php
+++ b/api/src/Mercure/StagePayloadMapper.php
@@ -140,6 +140,9 @@ final readonly class StagePayloadMapper
             'imageUrl' => $accommodation->imageUrl,
             'wikipediaUrl' => $accommodation->wikipediaUrl,
             'openingHours' => $accommodation->openingHours,
+            'phone' => $accommodation->phone,
+            'osmType' => $accommodation->osmType,
+            'osmId' => $accommodation->osmId,
         ];
     }
 

--- a/api/src/MessageHandler/ScanAccommodationsHandler.php
+++ b/api/src/MessageHandler/ScanAccommodationsHandler.php
@@ -89,7 +89,7 @@ final readonly class ScanAccommodationsHandler extends AbstractTripMessageHandle
             $allCandidates = $this->registry->fetchAll($endPoints, $radiusMeters, $enabledAccommodationTypes);
 
             // Distribute candidates to their nearest stage endpoint (output keys match $stagesToProcess keys)
-            /** @var array<int, list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, stars?: ?int, capacity?: ?int, fee?: ?string, source?: string, wikidataId?: ?string, description?: ?string, imageUrl?: ?string, wikipediaUrl?: ?string, openingHours?: ?string}>> $candidatesByStage */
+            /** @var array<int, list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, stars?: ?int, capacity?: ?int, fee?: ?string, source?: string, wikidataId?: ?string, description?: ?string, imageUrl?: ?string, wikipediaUrl?: ?string, openingHours?: ?string, phone?: ?string, osmType?: ?string, osmId?: ?int}>> $candidatesByStage */
             $candidatesByStage = $this->distributor->distributeByEndpoint($allCandidates, $stagesToProcess);
 
             // Deduplicate, then rank + limit per stage. Prices are already set by
@@ -133,6 +133,9 @@ final readonly class ScanAccommodationsHandler extends AbstractTripMessageHandle
                             'imageUrl' => $existing->imageUrl,
                             'wikipediaUrl' => $existing->wikipediaUrl,
                             'openingHours' => $existing->openingHours,
+                            'phone' => $existing->phone,
+                            'osmType' => $existing->osmType,
+                            'osmId' => $existing->osmId,
                         ];
                     }
                 } else {
@@ -176,6 +179,9 @@ final readonly class ScanAccommodationsHandler extends AbstractTripMessageHandle
                         imageUrl: $raw['imageUrl'] ?? null,
                         wikipediaUrl: $raw['wikipediaUrl'] ?? null,
                         openingHours: $raw['openingHours'] ?? null,
+                        phone: $raw['phone'] ?? null,
+                        osmType: $raw['osmType'] ?? null,
+                        osmId: $raw['osmId'] ?? null,
                     );
 
                     $stage->addAccommodation($accommodation);
@@ -195,6 +201,9 @@ final readonly class ScanAccommodationsHandler extends AbstractTripMessageHandle
                         'imageUrl' => $accommodation->imageUrl,
                         'wikipediaUrl' => $accommodation->wikipediaUrl,
                         'openingHours' => $accommodation->openingHours,
+                        'phone' => $accommodation->phone,
+                        'osmType' => $accommodation->osmType,
+                        'osmId' => $accommodation->osmId,
                     ];
                 }
 
@@ -236,9 +245,9 @@ final readonly class ScanAccommodationsHandler extends AbstractTripMessageHandle
     }
 
     /**
-     * @param list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, stars?: ?int, capacity?: ?int, fee?: ?string, source?: string, wikidataId?: ?string, description?: ?string, imageUrl?: ?string, wikipediaUrl?: ?string, openingHours?: ?string}> $accommodations
+     * @param list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, stars?: ?int, capacity?: ?int, fee?: ?string, source?: string, wikidataId?: ?string, description?: ?string, imageUrl?: ?string, wikipediaUrl?: ?string, openingHours?: ?string, phone?: ?string, osmType?: ?string, osmId?: ?int}> $accommodations
      *
-     * @return list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, stars?: ?int, capacity?: ?int, fee?: ?string, source?: string, wikidataId?: ?string, description?: ?string, imageUrl?: ?string, wikipediaUrl?: ?string, openingHours?: ?string}>
+     * @return list<array{name: string, type: string, lat: float, lon: float, priceMin: float, priceMax: float, isExact: bool, url: ?string, tagCount: int, hasWebsite: bool, tags: array<string, string>, stars?: ?int, capacity?: ?int, fee?: ?string, source?: string, wikidataId?: ?string, description?: ?string, imageUrl?: ?string, wikipediaUrl?: ?string, openingHours?: ?string, phone?: ?string, osmType?: ?string, osmId?: ?int}>
      */
     private function deduplicate(array $accommodations): array
     {

--- a/api/src/Osm/AccommodationRepository.php
+++ b/api/src/Osm/AccommodationRepository.php
@@ -36,7 +36,7 @@ final readonly class AccommodationRepository implements AccommodationRepositoryI
      * @param list<array{lat: float, lon: float}> $points
      * @param list<string>                        $categories
      *
-     * @return list<array{name: ?string, category: string, lat: float, lon: float, stars: ?int, capacity: ?int, fee: ?string, website: ?string, wikidata: ?string, openingHours: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, tags: array<string, string>}>
+     * @return list<array{osmType: ?string, osmId: ?int, name: ?string, category: string, lat: float, lon: float, stars: ?int, capacity: ?int, fee: ?string, website: ?string, wikidata: ?string, openingHours: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, tags: array<string, string>}>
      */
     public function findNear(array $points, int $radiusMeters, array $categories): array
     {
@@ -118,6 +118,10 @@ final readonly class AccommodationRepository implements AccommodationRepositoryI
         $accommodations = [];
         foreach ($rows as $row) {
             $accommodations[] = [
+                // Primary key of the index, kept so the rider can reach the object
+                // on openstreetmap.org: it used to be dropped at this very first hop.
+                'osmType' => OsmObjectType::fromChar($row['osm_type']),
+                'osmId' => null !== $row['osm_id'] ? (int) $row['osm_id'] : null,
                 'name' => null !== $row['name'] ? (string) $row['name'] : null,
                 'category' => (string) $row['category'],
                 'lat' => (float) $row['lat'],

--- a/api/src/Osm/AccommodationRepositoryInterface.php
+++ b/api/src/Osm/AccommodationRepositoryInterface.php
@@ -14,7 +14,7 @@ interface AccommodationRepositoryInterface
      * @param list<array{lat: float, lon: float}> $points
      * @param list<string>                        $categories
      *
-     * @return list<array{name: ?string, category: string, lat: float, lon: float, stars: ?int, capacity: ?int, fee: ?string, website: ?string, wikidata: ?string, openingHours: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, tags: array<string, string>}>
+     * @return list<array{osmType: ?string, osmId: ?int, name: ?string, category: string, lat: float, lon: float, stars: ?int, capacity: ?int, fee: ?string, website: ?string, wikidata: ?string, openingHours: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, tags: array<string, string>}>
      */
     public function findNear(array $points, int $radiusMeters, array $categories): array;
 }

--- a/api/src/Osm/CulturalPoiRepository.php
+++ b/api/src/Osm/CulturalPoiRepository.php
@@ -22,7 +22,7 @@ final readonly class CulturalPoiRepository implements CulturalPoiRepositoryInter
      *
      * @param list<array{lat: float, lon: float}> $route
      *
-     * @return list<array{name: ?string, category: string, lat: float, lon: float, wikidata: ?string, openingHours: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string}>
+     * @return list<array{osmType: ?string, osmId: ?int, name: ?string, category: string, lat: float, lon: float, wikidata: ?string, openingHours: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string}>
      */
     public function findInCorridor(array $route, int $radiusMeters): array
     {
@@ -38,7 +38,7 @@ final readonly class CulturalPoiRepository implements CulturalPoiRepositoryInter
         /** @var list<array<string, scalar|null>> $rows */
         $rows = $this->connection->fetchAllAssociative(
             <<<'SQL'
-                SELECT name, category, wikidata, opening_hours, description, image_url, wikipedia_url,
+                SELECT osm_type, osm_id, name, category, wikidata, opening_hours, description, image_url, wikipedia_url,
                        ST_Y(geom) AS lat, ST_X(geom) AS lon
                 FROM osm.cultural_pois
                 WHERE ST_DWithin(
@@ -58,6 +58,10 @@ final readonly class CulturalPoiRepository implements CulturalPoiRepositoryInter
         $pois = [];
         foreach ($rows as $row) {
             $pois[] = [
+                // Primary key of the index (ADR-040), carried so a reader can reach
+                // the object on openstreetmap.org instead of losing its identity here.
+                'osmType' => OsmObjectType::fromChar($row['osm_type']),
+                'osmId' => null !== $row['osm_id'] ? (int) $row['osm_id'] : null,
                 'name' => null !== $row['name'] ? (string) $row['name'] : null,
                 'category' => (string) $row['category'],
                 'lat' => (float) $row['lat'],

--- a/api/src/Osm/CulturalPoiRepositoryInterface.php
+++ b/api/src/Osm/CulturalPoiRepositoryInterface.php
@@ -12,7 +12,7 @@ interface CulturalPoiRepositoryInterface
      *
      * @param list<array{lat: float, lon: float}> $route
      *
-     * @return list<array{name: ?string, category: string, lat: float, lon: float, wikidata: ?string, openingHours: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string}>
+     * @return list<array{osmType: ?string, osmId: ?int, name: ?string, category: string, lat: float, lon: float, wikidata: ?string, openingHours: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string}>
      */
     public function findInCorridor(array $route, int $radiusMeters): array;
 }

--- a/api/src/Osm/OsmObjectType.php
+++ b/api/src/Osm/OsmObjectType.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Osm;
+
+/**
+ * Translates the one-character `osm_type` osm2pgsql stores (`N`, `W`, `R`) into
+ * the word openstreetmap.org uses in its object URLs (`node`, `way`,
+ * `relation`), so a reader can build `https://www.openstreetmap.org/<type>/<id>`
+ * without knowing the storage convention.
+ */
+final class OsmObjectType
+{
+    /** @var array<string, string> */
+    private const array NAMES = ['N' => 'node', 'W' => 'way', 'R' => 'relation'];
+
+    public static function fromChar(mixed $raw): ?string
+    {
+        return \is_string($raw) ? (self::NAMES[strtoupper(trim($raw))] ?? null) : null;
+    }
+}

--- a/api/src/Osm/PoiRepository.php
+++ b/api/src/Osm/PoiRepository.php
@@ -22,7 +22,7 @@ final readonly class PoiRepository implements PoiRepositoryInterface
      *
      * @param list<array{lat: float, lon: float}> $route
      *
-     * @return list<array{name: ?string, category: string, lat: float, lon: float}>
+     * @return list<array{osmType: ?string, osmId: ?int, name: ?string, category: string, lat: float, lon: float}>
      */
     public function findInCorridor(array $route, int $radiusMeters): array
     {
@@ -33,7 +33,7 @@ final readonly class PoiRepository implements PoiRepositoryInterface
         /** @var list<array<string, scalar|null>> $rows */
         $rows = $this->connection->fetchAllAssociative(
             <<<'SQL'
-                SELECT name, category, ST_Y(geom) AS lat, ST_X(geom) AS lon
+                SELECT osm_type, osm_id, name, category, ST_Y(geom) AS lat, ST_X(geom) AS lon
                 FROM osm.pois
                 WHERE ST_DWithin(
                     geom::geography,
@@ -50,6 +50,10 @@ final readonly class PoiRepository implements PoiRepositoryInterface
         $pois = [];
         foreach ($rows as $row) {
             $pois[] = [
+                // Primary key of the index (ADR-040), carried so a reader can reach
+                // the object on openstreetmap.org instead of losing its identity here.
+                'osmType' => OsmObjectType::fromChar($row['osm_type']),
+                'osmId' => null !== $row['osm_id'] ? (int) $row['osm_id'] : null,
                 'name' => null !== $row['name'] ? (string) $row['name'] : null,
                 'category' => (string) $row['category'],
                 'lat' => (float) $row['lat'],

--- a/api/src/Osm/PoiRepositoryInterface.php
+++ b/api/src/Osm/PoiRepositoryInterface.php
@@ -11,7 +11,7 @@ interface PoiRepositoryInterface
      *
      * @param list<array{lat: float, lon: float}> $route
      *
-     * @return list<array{name: ?string, category: string, lat: float, lon: float}>
+     * @return list<array{osmType: ?string, osmId: ?int, name: ?string, category: string, lat: float, lon: float}>
      */
     public function findInCorridor(array $route, int $radiusMeters): array;
 }

--- a/api/src/Repository/DoctrineTripRequestRepository.php
+++ b/api/src/Repository/DoctrineTripRequestRepository.php
@@ -806,7 +806,7 @@ final class DoctrineTripRequestRepository extends ServiceEntityRepository implem
         );
     }
 
-    /** @return array{name: string, type: string, lat: float, lon: float, estimatedPriceMin: float, estimatedPriceMax: float, isExactPrice: bool, url: ?string, possibleClosed: bool, distanceToEndPoint: float, source: string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, openingHours: ?string} */
+    /** @return array{name: string, type: string, lat: float, lon: float, estimatedPriceMin: float, estimatedPriceMax: float, isExactPrice: bool, url: ?string, possibleClosed: bool, distanceToEndPoint: float, source: string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, openingHours: ?string, phone: ?string, osmType: ?string, osmId: ?int} */
     private function accommodationToArray(Accommodation $acc): array
     {
         return [
@@ -828,10 +828,16 @@ final class DoctrineTripRequestRepository extends ServiceEntityRepository implem
             'imageUrl' => $acc->imageUrl,
             'wikipediaUrl' => $acc->wikipediaUrl,
             'openingHours' => $acc->openingHours,
+            // Contact block and OSM identity (issue #873): same trap as the five
+            // keys above — omitting them here drops the tel: link and the "see on
+            // OSM" affordance on every reload and in the shared view.
+            'phone' => $acc->phone,
+            'osmType' => $acc->osmType,
+            'osmId' => $acc->osmId,
         ];
     }
 
-    /** @param array{name: string, type: string, lat: float, lon: float, estimatedPriceMin: float, estimatedPriceMax: float, isExactPrice: bool, url?: ?string, possibleClosed?: bool, distanceToEndPoint?: float, source?: ?string, description?: ?string, imageUrl?: ?string, wikipediaUrl?: ?string, openingHours?: ?string} $data */
+    /** @param array{name: string, type: string, lat: float, lon: float, estimatedPriceMin: float, estimatedPriceMax: float, isExactPrice: bool, url?: ?string, possibleClosed?: bool, distanceToEndPoint?: float, source?: ?string, description?: ?string, imageUrl?: ?string, wikipediaUrl?: ?string, openingHours?: ?string, phone?: ?string, osmType?: ?string, osmId?: ?int} $data */
     private function arrayToAccommodation(array $data): Accommodation
     {
         return new Accommodation(
@@ -852,6 +858,9 @@ final class DoctrineTripRequestRepository extends ServiceEntityRepository implem
             imageUrl: $data['imageUrl'] ?? null,
             wikipediaUrl: $data['wikipediaUrl'] ?? null,
             openingHours: $data['openingHours'] ?? null,
+            phone: $data['phone'] ?? null,
+            osmType: $data['osmType'] ?? null,
+            osmId: $data['osmId'] ?? null,
         );
     }
 

--- a/api/src/State/TripDetailProvider.php
+++ b/api/src/State/TripDetailProvider.php
@@ -262,13 +262,16 @@ final readonly class TripDetailProvider implements ProviderInterface
             'url' => $acc->url,
             'possibleClosed' => $acc->possibleClosed,
             'distanceToEndPoint' => $acc->distanceToEndPoint,
-            // Same five enrichment fields as StagePayloadMapper (issue #870), so a
+            // Same enrichment fields as StagePayloadMapper (issues #870, #873), so a
             // reload and the anonymous shared view are as detailed as the live SSE.
             'source' => $acc->source,
             'description' => $acc->description,
             'imageUrl' => $acc->imageUrl,
             'wikipediaUrl' => $acc->wikipediaUrl,
             'openingHours' => $acc->openingHours,
+            'phone' => $acc->phone,
+            'osmType' => $acc->osmType,
+            'osmId' => $acc->osmId,
         ];
     }
 }

--- a/api/tests/Integration/Osm/AccommodationIndexReadTest.php
+++ b/api/tests/Integration/Osm/AccommodationIndexReadTest.php
@@ -262,6 +262,45 @@ final class AccommodationIndexReadTest extends KernelTestCase
         );
     }
 
+    #[Test]
+    public function fetchPropagatesTheContactBlockAndTheOsmIdentity(): void
+    {
+        // Own fixtures: the OSM identity is a per-row property, so the three object
+        // types must be told apart, which the shared setUp rows (all nodes) cannot do.
+        $this->connection->executeStatement('TRUNCATE osm.accommodations');
+        $this->connection->executeStatement(<<<'SQL'
+            INSERT INTO osm.accommodations (osm_type, osm_id, name, category, website, tags, geom) VALUES
+              ('n', 11, 'Hotel Node', 'hotel', NULL, '{"contact:phone": "+33 4 66 00 00 01"}'::jsonb, ST_SetSRID(ST_MakePoint(2.5, 48.5), 4326)),
+              ('w', 22, 'Camping Way', 'camp_site', NULL, '{"contact:url": "gite-du-lac.example/reserver"}'::jsonb, ST_SetSRID(ST_MakePoint(2.5, 48.5), 4326)),
+              ('r', 33, 'Auberge Relation', 'hostel', NULL, '{"phone": "0466000003", "contact:phone": "ignored"}'::jsonb, ST_SetSRID(ST_MakePoint(2.5, 48.5), 4326))
+            SQL);
+
+        $byName = [];
+        foreach ($this->source()->fetch([new Coordinate(48.5, 2.5)], 5000, ['hotel', 'camp_site', 'hostel']) as $candidate) {
+            $byName[$candidate['name']] = $candidate;
+        }
+
+        // osm_type is stored as the one-character osm2pgsql code; the candidate
+        // carries the word openstreetmap.org expects in an object URL.
+        self::assertSame('node', $byName['Hotel Node']['osmType']);
+        self::assertSame(11, $byName['Hotel Node']['osmId']);
+        self::assertSame('way', $byName['Camping Way']['osmType']);
+        self::assertSame(22, $byName['Camping Way']['osmId']);
+        self::assertSame('relation', $byName['Auberge Relation']['osmType']);
+        self::assertSame(33, $byName['Auberge Relation']['osmId']);
+
+        // The contact block: `contact:phone` alone is enough, `phone` wins a tie.
+        self::assertSame('+33 4 66 00 00 01', $byName['Hotel Node']['phone']);
+        self::assertSame('0466000003', $byName['Auberge Relation']['phone']);
+        self::assertNull($byName['Camping Way']['phone']);
+
+        // A `contact:url`-only entry gets a link, normalised to an absolute URL
+        // even though the flux value carried no scheme.
+        self::assertSame('https://gite-du-lac.example/reserver', $byName['Camping Way']['url']);
+        self::assertTrue($byName['Camping Way']['hasWebsite']);
+        self::assertNull($byName['Hotel Node']['url']);
+    }
+
     /**
      * 40 extra hotels, 111 m apart along the meridian, all inside the 5 km radius
      * (41 rows in range with the setUp hotel, for a 30-row cap). Inserted farthest

--- a/api/tests/Unit/AccommodationSource/OsmAccommodationSourceTest.php
+++ b/api/tests/Unit/AccommodationSource/OsmAccommodationSourceTest.php
@@ -125,6 +125,65 @@ final class OsmAccommodationSourceTest extends TestCase
     }
 
     #[Test]
+    public function fetchFallsBackToUrlTagForUrl(): void
+    {
+        $source = $this->createSource($this->repository([$this->row(tags: ['url' => 'https://url-tag.example'])]));
+
+        $results = $source->fetch([new Coordinate(48.5, 2.5)], 5000, ['hotel']);
+
+        $this->assertSame('https://url-tag.example', $results[0]['url']);
+        $this->assertTrue($results[0]['hasWebsite']);
+    }
+
+    #[Test]
+    public function fetchFallsBackToContactUrlTagForUrl(): void
+    {
+        // The fourth and last spelling of the contact block: an accommodation whose
+        // only site is under `contact:url` used to be served without any link.
+        $source = $this->createSource($this->repository([$this->row(tags: ['contact:url' => 'https://contact-url.example'])]));
+
+        $results = $source->fetch([new Coordinate(48.5, 2.5)], 5000, ['hotel']);
+
+        $this->assertSame('https://contact-url.example', $results[0]['url']);
+        $this->assertTrue($results[0]['hasWebsite']);
+    }
+
+    #[Test]
+    public function fetchNormalizesASchemelessWebsite(): void
+    {
+        $source = $this->createSource($this->repository([$this->row(website: 'www.gite-du-pont.fr/chambres')]));
+
+        $results = $source->fetch([new Coordinate(48.5, 2.5)], 5000, ['hotel']);
+
+        $this->assertSame('https://www.gite-du-pont.fr/chambres', $results[0]['url']);
+    }
+
+    #[Test]
+    public function fetchSkipsAnUnusableWebsiteAndKeepsLookingDownTheCascade(): void
+    {
+        // Free text in `website` must not shadow a usable `contact:url` further
+        // down: the cascade is by usability, not by mere presence.
+        $source = $this->createSource($this->repository([
+            $this->row(website: 'nous contacter', tags: ['website' => 'nous contacter', 'contact:url' => 'https://vrai-site.example']),
+        ]));
+
+        $results = $source->fetch([new Coordinate(48.5, 2.5)], 5000, ['hotel']);
+
+        $this->assertSame('https://vrai-site.example', $results[0]['url']);
+    }
+
+    #[Test]
+    public function fetchRejectsANonHttpWebsite(): void
+    {
+        $source = $this->createSource($this->repository([$this->row(website: 'mailto:contact@gite.fr')]));
+
+        $results = $source->fetch([new Coordinate(48.5, 2.5)], 5000, ['hotel']);
+
+        $this->assertNull($results[0]['url']);
+        $this->assertFalse($results[0]['hasWebsite']);
+    }
+
+    #[Test]
     public function fetchSetsNoUrlWhenNeitherWebsiteNorContactPresent(): void
     {
         $source = $this->createSource($this->repository([$this->row()]));
@@ -133,6 +192,47 @@ final class OsmAccommodationSourceTest extends TestCase
 
         $this->assertNull($results[0]['url']);
         $this->assertFalse($results[0]['hasWebsite']);
+    }
+
+    #[Test]
+    public function fetchReadsThePhoneFromTheContactNamespace(): void
+    {
+        $source = $this->createSource($this->repository([$this->row(tags: ['contact:phone' => '+33 4 66 00 00 00'])]));
+
+        $results = $source->fetch([new Coordinate(48.5, 2.5)], 5000, ['hotel']);
+
+        $this->assertSame('+33 4 66 00 00 00', $results[0]['phone']);
+    }
+
+    #[Test]
+    public function fetchPrefersThePlainPhoneTagOverTheContactOne(): void
+    {
+        $source = $this->createSource($this->repository([
+            $this->row(tags: ['phone' => '+33 1 11 11 11 11', 'contact:phone' => '+33 2 22 22 22 22']),
+        ]));
+
+        $results = $source->fetch([new Coordinate(48.5, 2.5)], 5000, ['hotel']);
+
+        $this->assertSame('+33 1 11 11 11 11', $results[0]['phone']);
+    }
+
+    #[Test]
+    public function fetchSetsNoPhoneWhenTheContactBlockIsEmpty(): void
+    {
+        $results = $this->createSource($this->repository([$this->row()]))->fetch([new Coordinate(48.5, 2.5)], 5000, ['hotel']);
+
+        $this->assertNull($results[0]['phone']);
+    }
+
+    #[Test]
+    public function fetchPropagatesTheOsmIdentity(): void
+    {
+        $source = $this->createSource($this->repository([$this->row(osmType: 'way', osmId: 123456)]));
+
+        $results = $source->fetch([new Coordinate(48.5, 2.5)], 5000, ['hotel']);
+
+        $this->assertSame('way', $results[0]['osmType']);
+        $this->assertSame(123456, $results[0]['osmId']);
     }
 
     #[Test]
@@ -217,7 +317,7 @@ final class OsmAccommodationSourceTest extends TestCase
     /**
      * @param array<string, string> $tags
      *
-     * @return array{name: ?string, category: string, lat: float, lon: float, stars: ?int, capacity: ?int, fee: ?string, website: ?string, wikidata: ?string, openingHours: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, tags: array<string, string>}
+     * @return array{osmType: ?string, osmId: ?int, name: ?string, category: string, lat: float, lon: float, stars: ?int, capacity: ?int, fee: ?string, website: ?string, wikidata: ?string, openingHours: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, tags: array<string, string>}
      */
     private function row(
         string $category = 'hotel',
@@ -228,8 +328,12 @@ final class OsmAccommodationSourceTest extends TestCase
         ?int $stars = null,
         ?int $capacity = null,
         ?string $fee = null,
+        ?string $osmType = 'node',
+        ?int $osmId = 8001,
     ): array {
         return [
+            'osmType' => $osmType,
+            'osmId' => $osmId,
             'name' => $name,
             'category' => $category,
             'lat' => 48.6,
@@ -248,7 +352,7 @@ final class OsmAccommodationSourceTest extends TestCase
     }
 
     /**
-     * @param list<array{name: ?string, category: string, lat: float, lon: float, stars: ?int, capacity: ?int, fee: ?string, website: ?string, wikidata: ?string, openingHours: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, tags: array<string, string>}> $rows
+     * @param list<array{osmType: ?string, osmId: ?int, name: ?string, category: string, lat: float, lon: float, stars: ?int, capacity: ?int, fee: ?string, website: ?string, wikidata: ?string, openingHours: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, tags: array<string, string>}> $rows
      */
     private function repository(array $rows): AccommodationRepositoryInterface
     {

--- a/api/tests/Unit/Format/OsmContactTagsTest.php
+++ b/api/tests/Unit/Format/OsmContactTagsTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Format;
+
+use App\Format\OsmContactTags;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class OsmContactTagsTest extends TestCase
+{
+    #[Test]
+    public function phoneReadsThePlainTag(): void
+    {
+        self::assertSame('+33 1 23 45 67 89', OsmContactTags::phone(['phone' => '+33 1 23 45 67 89']));
+    }
+
+    #[Test]
+    public function phoneFallsBackToTheContactNamespace(): void
+    {
+        self::assertSame('0466378200', OsmContactTags::phone(['contact:phone' => '0466378200']));
+    }
+
+    #[Test]
+    public function phonePrefersThePlainTagOverTheContactOne(): void
+    {
+        self::assertSame('first', OsmContactTags::phone(['phone' => 'first', 'contact:phone' => 'second']));
+    }
+
+    #[Test]
+    public function phoneTrimsTheValue(): void
+    {
+        self::assertSame('0102030405', OsmContactTags::phone(['phone' => "  0102030405\n"]));
+    }
+
+    /**
+     * A whitespace-only tag is as unusable as an absent one, and a non-string
+     * value can reach us from the raw Overpass JSON the in-ride path parses.
+     *
+     * @param array<string, mixed> $tags
+     */
+    #[Test]
+    #[DataProvider('unusablePhoneTags')]
+    public function phoneReturnsNullForAnUnusableValue(array $tags): void
+    {
+        self::assertNull(OsmContactTags::phone($tags));
+    }
+
+    /**
+     * @return iterable<string, array{array<string, mixed>}>
+     */
+    public static function unusablePhoneTags(): iterable
+    {
+        yield 'no contact tag' => [['name' => 'Hotel du Nord']];
+        yield 'empty string' => [['phone' => '']];
+        yield 'blank string' => [['phone' => '   ']];
+        yield 'non-string value' => [['phone' => 33123456789]];
+        yield 'blank plain tag with no fallback' => [['phone' => ' ', 'contact:phone' => '']];
+    }
+
+    #[Test]
+    public function phoneSkipsABlankPlainTagInFavourOfTheContactOne(): void
+    {
+        self::assertSame('0102030405', OsmContactTags::phone(['phone' => '  ', 'contact:phone' => '0102030405']));
+    }
+
+    /**
+     * @param array<string, mixed> $tags
+     */
+    #[Test]
+    #[DataProvider('websiteCascade')]
+    public function websiteWalksTheFourSpellings(array $tags, ?string $expected): void
+    {
+        self::assertSame($expected, OsmContactTags::website($tags));
+    }
+
+    /**
+     * @return iterable<string, array{array<string, mixed>, ?string}>
+     */
+    public static function websiteCascade(): iterable
+    {
+        yield 'website' => [['website' => 'https://a.example'], 'https://a.example'];
+        yield 'contact:website' => [['contact:website' => 'https://b.example'], 'https://b.example'];
+        yield 'url' => [['url' => 'https://c.example'], 'https://c.example'];
+        yield 'contact:url' => [['contact:url' => 'https://d.example'], 'https://d.example'];
+        yield 'website wins over the rest' => [
+            ['contact:url' => 'https://d.example', 'website' => 'https://a.example'],
+            'https://a.example',
+        ];
+        // Usability, not mere presence, drives the cascade: free text in an earlier
+        // key must not shadow a real URL in a later one.
+        yield 'free text does not shadow a usable later key' => [
+            ['website' => 'nous contacter', 'contact:url' => 'https://d.example'],
+            'https://d.example',
+        ];
+        yield 'an e-mail is not a website' => [['website' => 'contact@gite.fr'], null];
+        yield 'a mailto: scheme is rejected' => [['website' => 'mailto:contact@gite.fr'], null];
+        yield 'a schemeless value is absolutised' => [['website' => 'www.gite.fr'], 'https://www.gite.fr'];
+        yield 'nothing at all' => [['name' => 'Gîte'], null];
+    }
+}

--- a/api/tests/Unit/Repository/DoctrineTripRequestRepositoryTest.php
+++ b/api/tests/Unit/Repository/DoctrineTripRequestRepositoryTest.php
@@ -357,6 +357,56 @@ final class DoctrineTripRequestRepositoryTest extends TestCase
     }
 
     #[Test]
+    public function accommodationContactBlockAndOsmIdentitySurviveARoundTrip(): void
+    {
+        // #873: exactly the trap #870 documented — omitting the three new keys from
+        // accommodationToArray() drops the tel: link and the "see on OSM" link on
+        // every reload and in the anonymous shared view, while the live SSE shows them.
+        $tripId = Uuid::v7()->toRfc4122();
+        $trip = new TripRequest(Uuid::fromString($tripId));
+
+        $this->entityManager->method('find')->willReturn($trip);
+        $this->entityManager->method('createQuery')->willReturn($this->createStub(Query::class));
+
+        $osmEntry = new Accommodation(
+            name: 'Camping du Pont',
+            type: 'camp_site',
+            lat: 43.947,
+            lon: 4.535,
+            estimatedPriceMin: 18.0,
+            estimatedPriceMax: 18.0,
+            isExactPrice: true,
+            phone: '+33 4 66 37 82 00',
+            osmType: 'way',
+            osmId: 987654321,
+        );
+
+        $stageDto = new StageDto(
+            tripId: $tripId,
+            dayNumber: 1,
+            distance: 60.0,
+            elevation: 500.0,
+            startPoint: new Coordinate(43.9, 4.5, 0.0),
+            endPoint: new Coordinate(43.95, 4.54, 0.0),
+        );
+        $stageDto->addAccommodation($osmEntry);
+        $stageDto->selectedAccommodation = $osmEntry;
+
+        $this->repository->storeStages($tripId, [$stageDto]);
+
+        $stages = $this->repository->getStages($tripId);
+
+        self::assertNotNull($stages);
+
+        foreach ([$stages[0]->accommodations[0], $stages[0]->selectedAccommodation] as $result) {
+            self::assertNotNull($result);
+            self::assertSame('+33 4 66 37 82 00', $result->phone);
+            self::assertSame('way', $result->osmType);
+            self::assertSame(987654321, $result->osmId);
+        }
+    }
+
+    #[Test]
     public function accommodationPersistedWithoutEnrichmentKeysFallsBackToDefaults(): void
     {
         // Accommodations persisted before #870 carry only the ten legacy keys; they
@@ -405,6 +455,9 @@ final class DoctrineTripRequestRepositoryTest extends TestCase
             self::assertNull($result->imageUrl);
             self::assertNull($result->wikipediaUrl);
             self::assertNull($result->openingHours);
+            self::assertNull($result->phone);
+            self::assertNull($result->osmType);
+            self::assertNull($result->osmId);
         }
     }
 

--- a/provisioner/osm2pgsql/tier1.lua
+++ b/provisioner/osm2pgsql/tier1.lua
@@ -391,6 +391,15 @@ local function to_int(v)
     return math.floor(n)
 end
 
+-- The website lives under four competing spellings in OSM: the bare `website`,
+-- the `contact:` namespace, and `url` in both forms. Projecting `tags.website`
+-- alone hid the site of every object mapped with one of the other three. The
+-- raw value is stored as-is; App\Format\WebsiteUrl normalises it on read, since
+-- rows indexed before this widening need the same treatment anyway.
+local function website_tag(tags)
+    return tags.website or tags['contact:website'] or tags.url or tags['contact:url']
+end
+
 local function insert_features(tags, geom)
     local cat = poi_category(tags)
     if cat then
@@ -398,7 +407,7 @@ local function insert_features(tags, geom)
             name = tags.name,
             category = cat,
             opening_hours = tags.opening_hours,
-            website = tags.website,
+            website = website_tag(tags),
             tags = tags,
             geom = geom,
         })
@@ -412,7 +421,7 @@ local function insert_features(tags, geom)
             stars = to_int(tags.stars),
             capacity = to_int(tags.capacity),
             fee = tags.fee or tags.charge,
-            website = tags.website,
+            website = website_tag(tags),
             wikidata = tags.wikidata,
             opening_hours = tags.opening_hours,
             tags = tags,

--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -157,7 +157,8 @@
     "deselect": "Deselect accommodation",
     "selected": "Selected",
     "selectTooltip": "Select this accommodation as your stopover for this stage",
-    "see_on_wikipedia": "See on Wikipedia"
+    "see_on_wikipedia": "See on Wikipedia",
+    "see_on_osm": "See on OpenStreetMap"
   },
   "addStage": {
     "add": "Add stage",

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -157,7 +157,8 @@
     "deselect": "Désélectionner l'hébergement",
     "selected": "Sélectionné",
     "selectTooltip": "Sélectionner cet hébergement comme étape de nuit",
-    "see_on_wikipedia": "Voir sur Wikipedia"
+    "see_on_wikipedia": "Voir sur Wikipedia",
+    "see_on_osm": "Voir sur OpenStreetMap"
   },
   "addStage": {
     "add": "Ajouter une étape",

--- a/pwa/src/components/accommodation-item.test.tsx
+++ b/pwa/src/components/accommodation-item.test.tsx
@@ -145,6 +145,61 @@ describe("AccommodationItem Wikipedia link", () => {
   });
 });
 
+describe("AccommodationItem contact and OSM affordances", () => {
+  it("renders a clickable tel: link for the phone number", () => {
+    renderItem(accommodation({ phone: "+33 4 66 37 82 00" }));
+
+    const link = screen.getByTestId("accommodation-phone-link");
+    expect(link).toHaveAttribute("href", "tel:+33 4 66 37 82 00");
+    expect(link).toHaveTextContent("+33 4 66 37 82 00");
+  });
+
+  it("renders no phone link without a phone number", () => {
+    renderItem(accommodation());
+
+    expect(
+      screen.queryByTestId("accommodation-phone-link"),
+    ).not.toBeInTheDocument();
+  });
+
+  it.each([
+    ["node", 11] as const,
+    ["way", 22] as const,
+    ["relation", 33] as const,
+  ])("links a %s to its own object on OSM", (osmType, osmId) => {
+    renderItem(accommodation({ osmType, osmId }));
+
+    expect(screen.getByTestId("accommodation-osm-link")).toHaveAttribute(
+      "href",
+      `https://www.openstreetmap.org/${osmType}/${osmId}`,
+    );
+  });
+
+  it("uses the translated OSM label", () => {
+    renderItem(accommodation({ osmType: "node", osmId: 11 }));
+
+    expect(screen.getByTestId("accommodation-osm-link")).toHaveTextContent(
+      fr.accommodation.see_on_osm,
+    );
+  });
+
+  it("renders no OSM link for an entry without an OSM identity", () => {
+    renderItem(accommodation({ source: "datatourisme" }));
+
+    expect(
+      screen.queryByTestId("accommodation-osm-link"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders no OSM link when only half the key is known", () => {
+    renderItem(accommodation({ osmType: "node" }));
+
+    expect(
+      screen.queryByTestId("accommodation-osm-link"),
+    ).not.toBeInTheDocument();
+  });
+});
+
 describe("AccommodationItem type rendering", () => {
   it.each(ACCOMMODATION_TYPES)("labels and illustrates a %s", (type) => {
     renderType(type);

--- a/pwa/src/components/accommodation-item.tsx
+++ b/pwa/src/components/accommodation-item.tsx
@@ -11,6 +11,7 @@ import {
   MapPin,
   Euro,
   ExternalLink,
+  Phone,
   CheckCircle2,
   Circle,
   BedDouble,
@@ -111,6 +112,12 @@ export function AccommodationItem({
   const websiteHref = normalizeExternalUrl(accommodation.url);
   const websiteHostname = externalUrlHostname(accommodation.url);
   const wikipediaHref = normalizeExternalUrl(accommodation.wikipediaUrl);
+  // Both halves of the OSM primary key are needed to address the object; an
+  // entry the rider typed in, or one coming from DataTourisme, has neither.
+  const osmHref =
+    accommodation.osmType && accommodation.osmId
+      ? `https://www.openstreetmap.org/${accommodation.osmType}/${accommodation.osmId}`
+      : null;
 
   function startEditing() {
     setEditUrl(accommodation.url ?? "");
@@ -346,6 +353,16 @@ export function AccommodationItem({
             <span>{distLabel}</span>
           </div>
         )}
+        {accommodation.phone && (
+          <a
+            href={`tel:${accommodation.phone}`}
+            className="flex items-center gap-1 hover:underline"
+            data-testid="accommodation-phone-link"
+          >
+            <Phone className="h-3.5 w-3.5" />
+            <span>{accommodation.phone}</span>
+          </a>
+        )}
         {accommodation.source && accommodation.source !== "osm" && (
           <span className="inline-flex items-center text-[10px] font-medium uppercase tracking-wide text-muted-foreground bg-muted rounded px-1.5 py-0.5">
             {accommodation.source === "datatourisme"
@@ -355,18 +372,32 @@ export function AccommodationItem({
         )}
       </div>
 
-      {/* Wikipedia link */}
-      {wikipediaHref && (
-        <div className="mt-1">
-          <a
-            href={wikipediaHref}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-xs text-primary flex items-center gap-0.5 hover:underline"
-          >
-            <ExternalLink className="h-3 w-3" />
-            {t("see_on_wikipedia")}
-          </a>
+      {/* Wikipedia + OpenStreetMap links */}
+      {(wikipediaHref || osmHref) && (
+        <div className="mt-1 flex items-center gap-3 flex-wrap">
+          {wikipediaHref && (
+            <a
+              href={wikipediaHref}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-xs text-primary flex items-center gap-0.5 hover:underline"
+            >
+              <ExternalLink className="h-3 w-3" />
+              {t("see_on_wikipedia")}
+            </a>
+          )}
+          {osmHref && (
+            <a
+              href={osmHref}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-xs text-primary flex items-center gap-0.5 hover:underline"
+              data-testid="accommodation-osm-link"
+            >
+              <ExternalLink className="h-3 w-3" />
+              {t("see_on_osm")}
+            </a>
+          )}
         </div>
       )}
     </div>

--- a/pwa/src/lib/api/schema.d.ts
+++ b/pwa/src/lib/api/schema.d.ts
@@ -764,6 +764,12 @@ export interface components {
             wikipediaUrl?: string | null;
             /** @description Opening hours (Wikidata P8989 or DataTourisme). */
             openingHours?: string | null;
+            /** @description Contact phone number, from the OSM contact block or the DataTourisme flux. */
+            phone?: string | null;
+            /** @description OpenStreetMap object type: node, way or relation. Null when the entry does not come from OSM. */
+            osmType?: string | null;
+            /** @description OpenStreetMap object id. Null when the entry does not come from OSM. */
+            osmId?: number | null;
         };
         "Accommodation.gpx": {
             name?: string;
@@ -785,6 +791,12 @@ export interface components {
             wikipediaUrl?: string | null;
             /** @description Opening hours (Wikidata P8989 or DataTourisme). */
             openingHours?: string | null;
+            /** @description Contact phone number, from the OSM contact block or the DataTourisme flux. */
+            phone?: string | null;
+            /** @description OpenStreetMap object type: node, way or relation. Null when the entry does not come from OSM. */
+            osmType?: string | null;
+            /** @description OpenStreetMap object id. Null when the entry does not come from OSM. */
+            osmId?: number | null;
         };
         "Accommodation.jsonld": {
             name?: string;
@@ -806,6 +818,12 @@ export interface components {
             wikipediaUrl?: string | null;
             /** @description Opening hours (Wikidata P8989 or DataTourisme). */
             openingHours?: string | null;
+            /** @description Contact phone number, from the OSM contact block or the DataTourisme flux. */
+            phone?: string | null;
+            /** @description OpenStreetMap object type: node, way or relation. Null when the entry does not come from OSM. */
+            osmType?: string | null;
+            /** @description OpenStreetMap object id. Null when the entry does not come from OSM. */
+            osmId?: number | null;
         };
         "AccommodationScan.AccommodationScanRequest": {
             /**

--- a/pwa/src/lib/mercure/types.ts
+++ b/pwa/src/lib/mercure/types.ts
@@ -100,6 +100,9 @@ export interface AccommodationPayload {
   imageUrl?: string | null;
   wikipediaUrl?: string | null;
   openingHours?: string | null;
+  phone?: string | null;
+  osmType?: "node" | "way" | "relation" | null;
+  osmId?: number | null;
 }
 
 export interface EventPayload {

--- a/pwa/src/lib/validation/schemas.ts
+++ b/pwa/src/lib/validation/schemas.ts
@@ -116,6 +116,15 @@ export const AccommodationSchema = z.object({
   imageUrl: z.string().url().nullable().optional().catch(null),
   wikipediaUrl: z.string().url().nullable().optional().catch(null),
   openingHours: z.string().nullable().optional(),
+  phone: z.string().nullable().optional(),
+  // OSM identity of the entry: `null` on a DataTourisme one, and on anything the
+  // rider added by hand, so the "see on OSM" link only renders when both are set.
+  osmType: z
+    .enum(["node", "way", "relation"])
+    .nullable()
+    .optional()
+    .catch(null),
+  osmId: z.number().int().nullable().optional().catch(null),
 });
 
 /**

--- a/pwa/tests/fixtures/mock-data.ts
+++ b/pwa/tests/fixtures/mock-data.ts
@@ -218,6 +218,12 @@ export function accommodationsFoundEvent(
           description: "Hôtel familial à deux pas du pont.",
           // Unusable OSM `website` tag: renders no link at all, no error.
           url: "appeler le 06 12 34 56 78",
+          // Contact block and OSM identity (issue #873): the phone renders as a
+          // `tel:` link, and the (way, 42) pair as a link to that exact object —
+          // a hardcoded `node` would point at a different feature entirely.
+          phone: "+33 4 75 00 00 00",
+          osmType: "way",
+          osmId: 42,
         },
       ],
     },

--- a/pwa/tests/mocked/accommodation.spec.ts
+++ b/pwa/tests/mocked/accommodation.spec.ts
@@ -63,6 +63,38 @@ test.describe("Accommodations", () => {
     await expect(stageCard).toContainText("Hotel du Pont");
   });
 
+  test("offers a tel: link and an OSM link on an OSM entry (issue #873)", async ({
+    submitUrl,
+    injectSequence,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    await injectSequence([
+      routeParsedEvent(),
+      stagesComputedEvent(),
+      accommodationsFoundEvent(0),
+      tripCompleteEvent(),
+    ]);
+    const stageCard = mockedPage.getByTestId("stage-card-1");
+    await expect(stageCard).toContainText("Hotel du Pont");
+
+    const phoneLink = stageCard.getByTestId("accommodation-phone-link");
+    await expect(phoneLink).toHaveCount(1);
+    await expect(phoneLink).toHaveAttribute("href", "tel:+33 4 75 00 00 00");
+
+    // The link addresses the object by its own type: the fixture is a `way`, so
+    // a hardcoded `node` would silently point at an unrelated feature.
+    const osmLink = stageCard.getByTestId("accommodation-osm-link");
+    await expect(osmLink).toHaveCount(1);
+    await expect(osmLink).toHaveAttribute(
+      "href",
+      "https://www.openstreetmap.org/way/42",
+    );
+
+    // The DataTourisme entry has no OSM identity and no phone: no stray links.
+    await expect(stageCard).toContainText("Camping Les Oliviers");
+  });
+
   test("adds manual accommodation", async ({ createFullTrip, mockedPage }) => {
     await createFullTrip();
     const stageCard = mockedPage.getByTestId("stage-card-1");


### PR DESCRIPTION
Closes #873.

> **Sommet d'une pile de 3.** `main` → `feature/871` (#915) → `feature/872` (#917) → celle-ci. À merger en dernier. Le diff propre est le seul commit `77854383`.

Le nom seul d'un hébergement ne suffit pas : pour réserver, ou vérifier qu'un camping existe encore, il faut pouvoir **atteindre l'établissement**. Le téléphone était déjà en base et déjà rendu par le chemin in-ride ; l'identité OSM est la clé primaire de la table et était jetée dès la première requête.

## Détail

**Extracteur de téléphone partagé** — `api/src/Format/OsmContactTags.php` (créé) : `phone()` et `website()`, statiques et sans DI, sur le précédent de `WebsiteUrl` posé par #872. **`InRideAssistant` ne garde plus sa copie** : la ligne 229 est devenue `phone: OsmContactTags::phone($tags)` et le chemin planifié appelle le même helper. Le critère de non-duplication est tenu **par suppression**, pas par ajout.

**Cascade de site** — `website`, `contact:website`, `url`, `contact:url`, parcourus **par exploitabilité et non par présence** : du texte libre dans `website` ne masque plus un `contact:url` valide. Chaque valeur passe par le `WebsiteUrl::normalize` de #872 — normaliseur réutilisé, pas réécrit. `hasWebsite` dérive désormais de l'URL résolue, donc une valeur inexploitable cesse de gonfler le rang de complétude. `tier1.lua` projette la même cascade via un helper `website_tag(tags)` pour `pois` et `accommodations`.

**Identité OSM** — `api/src/Osm/OsmObjectType.php` (créé) traduit le `character(1)` stocké (`N`/`W`/`R`) vers le mot d'URL (`node`/`way`/`relation`). Ajouté aux formes de ligne des trois repositories OSM. À noter : `AccommodationRepository` **sélectionnait déjà** `osm_type`/`osm_id` depuis l'ordonnancement de #905 ; seul le mapping les perdait.

**Persistance — le piège que l'issue signale.** `accommodationToArray()` / `arrayToAccommodation()`, plus `StagePayloadMapper` et `TripDetailProvider`, portent `phone` / `osmType` / `osmId`. Sans quoi ils auraient disparu au rechargement, exactement comme les cinq champs d'enrichissement.

**Front** — lien `tel:` et « Voir sur OpenStreetMap » sur la fiche, plus `AccommodationSchema`, `AccommodationPayload` et `schema.d.ts` régénéré. Nouvelle clé i18n `accommodation.see_on_osm` dans les deux catalogues.

## Auto-critique

- **Écart de périmètre à trancher.** Le §2 du scope dit « faire de même pour les POI et les POI culturels », alors que la liste des fichiers impactés ne nomme que les deux repositories. **Je me suis arrêté aux formes de ligne des repositories** pour les POI. Pousser `osmType`/`osmId` jusqu'aux DTO `PointOfInterest` et `CulturalPoiAlert` demandait ~17 fichiers de plus (`PoiSourceInterface`, les deux sources POI, les deux sources culturelles, les deux registries, `ScanPoisHandler`, `CheckCulturalPoisHandler`, `poiToArray`, les schémas POI du front) — précisément les fichiers que #913 et #914 réécrivent — pour **zéro critère d'acceptation et aucune UI**. Mérite une issue de suivi plutôt qu'un conflit à quatre branches.
- Le parcours de la cascade « par exploitabilité » est un changement de comportement subtil : un `website` renseigné mais inexploitable n'est plus retenu. C'est l'intention, mais cela veut dire qu'une valeur volontairement bizarre côté OSM sera silencieusement remplacée par la suivante de la cascade.
- Le deeplink de réservation reste **hors périmètre**, conformément à l'issue : ADR-013 §13.4 le spécifie avec un volet monétisation par affiliation, ce qui appelle sa propre décision.

## Frontières avec les PRs soeurs

- **#916 (#876)** : je n'ai touché que `accommodationToArray()`. `alertToArray()` / `arrayToAlert()` sont intacts — diffs disjoints. `schemas.ts`, `mercure/types.ts` : ajouts additifs. **`pwa/src/lib/api/schema.d.ts` se régénère au merge, il ne se résout jamais à la main.**
- **#914 (#875)** : les deux colonnes `osm_type` / `osm_id` ont été ajoutées aux `SELECT` existants de `PoiRepository` et `CulturalPoiRepository` **sans reformater la requête**, pour coexister avec l'ajout de `opening_hours` / `website`.
- **#913 (#874)** : les lignes de résolution du **nom** n'ont pas été touchées.

## Vérification

`make qa` ne peut pas aboutir sur une machine de dev. Legs individuels :

| Leg | Résultat |
|---|---|
| Rector (api) | `[OK] Rector is done!` |
| PHP-CS-Fixer (api) | `Fixed 0 of 657 files` |
| PHPStan L9 (api) | `[OK] No errors` — après élargissement de 4 docblocks de forme qu'il avait signalés |
| Rector + PHPStan (provisioner) | `[OK] Rector is done!` / `[OK] No errors` |
| PHPUnit provisioner (dépôt entier monté) | `OK (99 tests, 548 assertions)` |
| PHPUnit api Unit + Integration | `OK, Tests: 1424, Assertions: 3929, Skipped: 1` |
| PHPUnit api Functional | `OK (303 tests, 1082 assertions)` |
| `tsc --noEmit` | exit 0 |
| ESLint | 0 erreur, 1 avertissement préexistant `no-img-element` (vignette de #870) |
| Prettier | un autofix sur `schemas.ts`, committé |
| `npm run i18n:check` | `OK: 921 keys in sync across fr, en` |
| Vitest | `38 files / 417 tests passed` |

Run sur une base dédiée `app873` pour éviter la contention de la stack partagée.

### Preuve que les tests peuvent échouer

Quatre mutations, chacune restaurée :

1. Suppression des trois clés d'`accommodationToArray()` → `accommodationContactBlockAndOsmIdentitySurviveARoundTrip` : `Failed asserting that null is identical to '+33 4 66 37 82 00'`.
2. `WEBSITE_KEYS` réduit à `['website', 'contact:website']` → **6 échecs**, dont `fetchFallsBackToContactUrlTagForUrl` et `fetchSkipsAnUnusableWebsiteAndKeepsLookingDownTheCascade`.
3. `OsmObjectType::fromChar()` figé à `'node'` → test d'intégration : `-'way' / +'node'`.
4. `node` codé en dur dans le lien du front → 2 échecs Vitest (`links a way…`, `links a relation…`).

### E2E — non exécuté localement

Un spec Playwright a été ajouté (`offers a tel: link and an OSM link on an OSM entry` dans `pwa/tests/mocked/accommodation.spec.ts`) et la fixture `Hotel du Pont` enrichie de `phone` / `osmType: "way"` / `osmId: 42` — un `way` **à dessein**, pour qu'un `node` codé en dur soit attrapé. **Il n'a pas été exécuté ici** : les changements d'un worktree ne sont pas dans le bundle de la stack principale. **CI est le vrai gate pour Playwright.**

**DTO_CHANGED** — `schema.d.ts` régénéré après la dernière édition backend et committé ; `pwa/openapi.json` non committé (gitignoré). Aucune dépendance ajoutée.

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 findings (0 critical, 0 warning). Reviewed the shared `OsmContactTags`/`OsmObjectType` helpers, the website-cascade change to usability-based resolution, OSM-identity propagation through the three repositories, and the persistence/serialization round-trip (`accommodationToArray`/`arrayToAccommodation`, `StagePayloadMapper`, `TripDetailProvider`) plus the frontend `tel:`/OSM-link rendering. `WebsiteUrl::normalize` already rejects non-http(s) schemes and userinfo, so the new `tel:` and OSM links carry no injection risk. Verified `osm_type`/`osm_id` were already selected in `AccommodationRepository`'s SQL (only the mapping dropped them) and that `tier1.lua`'s `osm_type`/`osm_id` columns pre-existed via `define_table`'s `ids` config. Test coverage is thorough: new unit tests for `OsmContactTags`, integration test for the repository-level OSM identity/contact propagation, a persistence round-trip test, and both Vitest + Playwright coverage for the new UI affordances.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

Commit reviewed: `778543832c62527e9236428f7f279d2e839b01a7`
<!-- claude-review-end -->
