### PR TITLE
docs(audit): measure unnamed osm accommodations per category

### DIFF
--- a/TRACKING.md
+++ b/TRACKING.md
@@ -1424,7 +1424,7 @@ Sprint volontairement court : ce sont des mesures, et elles **arbitrent les spri
   - [ ] `/api/health` expose les ratios de complétude par table sous `reference_data`, en dépendance non requise.
   - [ ] `/api/health` expose un âge par source **sans** verdict de péremption ; `STALE_THRESHOLDS` a disparu.
   - [ ] Les hébergements exposent le détail par catégorie, condition pour arbitrer l'exclusion des entrées sans nom.
-  - [ ] Le décompte des hébergements OSM sans nom, par catégorie, est publié dans #878 avec une recommandation explicite sur `shelter` et `wilderness_hut`.
+  - [x] Le décompte des hébergements OSM sans nom, par catégorie, est publié dans #878 avec une recommandation explicite sur `shelter` et `wilderness_hut` — contrainte de complétude partout sauf `shelter`, pas d'exemption pour `wilderness_hut` (6,3 % sans nom) ([rapport](docs/audit/878-hebergements-osm-sans-nom.md)).
   - [x] La présence ou l'absence du label « Accueil Vélo » dans le flux est tranchée par une mesure dans #879 — présent : `kb:LabelRating_AccueilVelo` sur 8 010 objets dont 6 006 hébergements, sous `hasReview[].hasReviewValue` ([rapport](docs/datatourisme-flux-audit.md)).
   - [ ] Les métriques n'allongent pas notablement la durée du provisionnement.
 

--- a/TRACKING.md
+++ b/TRACKING.md
@@ -1407,14 +1407,14 @@ C'est la confirmation de la leçon du sprint 45 : la carte de recoupement attrap
 </summary>
 Sprint volontairement court : ce sont des mesures, et elles **arbitrent les sprints 49 et 50**. Sans chiffres, on supprime des règles et on choisit des sources à l'intuition, et c'est exactement ce qui a produit une inférence fausse pendant le diagnostic (« un rayon de 15 km sans pharmacie est un trou d'index » était une supposition, probablement démentie par la couverture OSM réelle).
 
-> ⚠️ **Ce sprint ne passe pas par `/sprint`.** #878 et #879 sont des spikes en lecture seule : ils ne produisent aucun commit, alors que le pipeline attend une branche, un `make qa`, un commit et une PR. À traiter manuellement, ou à convertir en issues produisant un rapport committé sous `docs/`. Seule #877 est du code.
+> ⚠️ **Ce sprint ne passe pas par `/sprint`.** #878 et #879 sont des spikes en lecture seule : ils ne produisent aucun commit, alors que le pipeline attend une branche, un `make qa`, un commit et une PR. À traiter manuellement, ou à convertir en issues produisant un rapport committé sous `docs/`. Seule #877 est du code. #878 a été traitée par cette seconde voie : le rapport est committé sous [`docs/audit/`](docs/audit/878-hebergements-osm-sans-nom.md).
 >
 > Ces deux spikes sont des **mesures à exécuter** sur un jeu de données provisionné, pas des développements. Ils supposent donc une zone déjà ouverte, en local suffit.
 
 | Ordre | ID | Titre | Effort | PRs | Dépend de |
 |-------|----|-------|--------|-----|-----------|
 | 1 | [#877](https://github.com/vincentchalamon/bike-trip-planner/issues/877) | feat(provisioner): per-table completeness metrics in metadata and health | - | [#926](https://github.com/vincentchalamon/bike-trip-planner/pull/926) `feature/877` En cours | - |
-| 2 | [#878](https://github.com/vincentchalamon/bike-trip-planner/issues/878) | chore(quality): measure unnamed osm accommodations per category | - | - | - |
+| 2 | [#878](https://github.com/vincentchalamon/bike-trip-planner/issues/878) | chore(quality): measure unnamed osm accommodations per category | - | [#924](https://github.com/vincentchalamon/bike-trip-planner/pull/924) | - |
 | 3 | [#879](https://github.com/vincentchalamon/bike-trip-planner/issues/879) | chore(datatourisme): audit flux fields for accueil-velo and minimum stay | - | [#925](https://github.com/vincentchalamon/bike-trip-planner/pull/925) | - |
 
 ### Recette Sprint 47

--- a/TRACKING.md
+++ b/TRACKING.md
@@ -1407,7 +1407,7 @@ C'est la confirmation de la leçon du sprint 45 : la carte de recoupement attrap
 </summary>
 Sprint volontairement court : ce sont des mesures, et elles **arbitrent les sprints 49 et 50**. Sans chiffres, on supprime des règles et on choisit des sources à l'intuition, et c'est exactement ce qui a produit une inférence fausse pendant le diagnostic (« un rayon de 15 km sans pharmacie est un trou d'index » était une supposition, probablement démentie par la couverture OSM réelle).
 
-> ⚠️ **Ce sprint ne passe pas par `/sprint`.** #878 et #879 sont des spikes en lecture seule : ils ne produisent aucun commit, alors que le pipeline attend une branche, un `make qa`, un commit et une PR. À traiter manuellement, ou à convertir en issues produisant un rapport committé sous `docs/`. Seule #877 est du code. #878 a été traitée par cette seconde voie : le rapport est committé sous [`docs/audit/`](docs/audit/878-hebergements-osm-sans-nom.md).
+> ⚠️ **Ce sprint ne passe pas par `/sprint`.** #878 et #879 sont des spikes en lecture seule : ils ne produisent aucun commit, alors que le pipeline attend une branche, un `make qa`, un commit et une PR. À traiter manuellement, ou à convertir en issues produisant un rapport committé sous `docs/`. Seule #877 est du code. #878 et #879 ont été traitées par cette seconde voie : leurs rapports sont committés sous [`docs/audit/`](docs/audit/878-hebergements-osm-sans-nom.md) et [`docs/`](docs/datatourisme-flux-audit.md).
 >
 > Ces deux spikes sont des **mesures à exécuter** sur un jeu de données provisionné, pas des développements. Ils supposent donc une zone déjà ouverte, en local suffit.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,7 @@ Looking for the product overview instead? See the [README](../README.md).
 | [Alert engine](../README.md#alert-engine) | Canonical alert-rule table (severity, priority, trigger) |
 | [External data sources](../README.md#external-data-sources) | OSM, DataTourisme, Wikidata, Open-Meteo |
 | [DataTourisme flux field audit](datatourisme-flux-audit.md) | What the national flux really carries: fill rates per object type, Accueil Vélo coverage, pricing granularity |
+| [Unnamed OSM accommodations audit](audit/878-hebergements-osm-sans-nom.md) | Unnamed entries per accommodation category, real yield of the name fallback chain, `shelter` breakdown |
 | [Legal & Licensing](legal-and-licensing.md) | Project licence, data attribution, GDPR posture |
 
 ## Explanation — understanding the design

--- a/docs/audit/878-hebergements-osm-sans-nom.md
+++ b/docs/audit/878-hebergements-osm-sans-nom.md
@@ -139,11 +139,22 @@ fréquentes, quantités à droite) :
 
 Le verdict se lit par catégorie, pas globalement :
 
-- **Sur `shelter`, `operator` est nuisible.** 175 des 199 valeurs sont des transporteurs ou
-  des afficheurs (`~* 'jcdecaux|transdev|keolis|sncf|stas|tcl|sytral|tac|cars|bus|mobilit'`).
-  Proposer « JCDecaux » comme hébergement à un bikepacker est pire que ne rien proposer :
-  c'est un abribus présenté comme un abri de bivouac. Restent une vingtaine de valeurs de
-  collectivités, exploitables mais qui décrivent le propriétaire, pas le lieu.
+- **Sur `shelter`, `operator` est nuisible.** **184 des 199 valeurs** sont des transporteurs
+  ou des afficheurs. Proposer « JCDecaux » comme hébergement à un bikepacker est pire que ne
+  rien proposer : c'est un abribus présenté comme un abri de bivouac. Les 15 valeurs
+  restantes sont énumérables : « Région Auvergne-Rhône-Alpes » (3), « Institution
+  Sainte-Marie » (2), puis une occurrence chacune de « Arc Vezerontin », « CD62 »,
+  « Commune de Jongieux », « Département de l'Isère », « Grenoble Alpes Métropole »,
+  « Ondea », « Privé », « Sogedo », « commune de Maisoncelle », « École primaire privée
+  Saint-Joseph ». **Deux** produisent un libellé exploitable (les deux communes) ; cinq
+  désignent une collectivité propriétaire et non le lieu ; le reste (régie des eaux, école,
+  « Privé ») n'a aucun rapport avec un abri.
+
+  > Le premier comptage donnait 175 : le motif utilisé
+  > (`~* 'jcdecaux|transdev|keolis|sncf|stas|tcl|sytral|tac|cars|bus|mobilit'`) rate la
+  > graphie pointée `S.N.C.F.`, présente 9 fois. Un motif insensible à la ponctuation
+  > (`regexp_replace(operator, '[^a-zA-Z]', '', 'g')`) donne 184, ce qui recoupe exactement
+  > l'échantillon ci-dessus. Le sens de la conclusion ne change pas, il se renforce.
 - **Hors `shelter`, `operator` est utile mais négligeable en volume.** Les 38 valeurs
   concernées sont presque toutes de vrais libellés (enseignes, campings, noms de
   propriétaires). Mais 38 lignes sur 8 824, cela ne justifie pas une chaîne de repli en
@@ -229,7 +240,7 @@ explicitement pertinents) et laisserait 2 516 abribus nommés. La bonne clé de 
   `InRideAssistant`, au lieu de les écarter dans `OsmAccommodationSource`.
 
 **3. Abandonner la chaîne de repli à cinq clés.** Mesure : 248 rattrapages sur 5 754 entrées
-sans nom (4,3 %), dont 175 sont des noms de transporteurs sur des abribus. `name:fr` et
+sans nom (4,3 %), dont 184 sont des noms de transporteurs sur des abribus. `name:fr` et
 `official_name` n'ont **aucune** occurrence, `alt_name` 11 (toutes « Salle hors-sac »),
 `brand` 1. Si un repli est conservé, le réduire à `operator` puis `brand` **hors `shelter`**,
 pour un gain de 38 lignes : à décider au regard du coût du résolveur, pas de son rendement

--- a/docs/audit/878-hebergements-osm-sans-nom.md
+++ b/docs/audit/878-hebergements-osm-sans-nom.md
@@ -1,0 +1,266 @@
+# Audit — hébergements OSM sans nom, par catégorie
+
+Spike de mesure demandé par [#878](https://github.com/vincentchalamon/bike-trip-planner/issues/878)
+(sprint 47). Il arbitre le gate de complétude et le résolveur de nom du sprint 49
+([#884](https://github.com/vincentchalamon/bike-trip-planner/issues/884)).
+
+**Question posée.** La décision « nom résolu ou entrée exclue » repose sur une prémisse non
+mesurée : on ignore combien d'hébergements OSM sont sans nom, dans quelles catégories, et
+combien seraient rattrapés par la chaîne de repli envisagée (`name:fr`, `official_name`,
+`alt_name`, `operator`, `brand`).
+
+**Réponse courte.** La chaîne de repli ne rattrape rien (4,3 % des entrées sans nom) et, sur
+`shelter`, produit majoritairement des libellés nuisibles (« JCDecaux »). `wilderness_hut`
+n'est pas concerné : 6,3 % sans nom, comme les catégories commerciales. Le problème est
+entièrement concentré sur `shelter`, où le nom est un **mauvais discriminant** : l'exclure
+supprime 63 % des abris réellement utiles au bikepacker tout en conservant 2 516 abribus
+nommés. Recommandation : contrainte de complétude sur toutes les catégories **sauf
+`shelter`**, et filtrage des abris sur `shelter_type` plutôt que sur le nom.
+
+## Jeu de données mesuré
+
+| | |
+|---|---|
+| Régions provisionnées | `nord-pas-de-calais` + `rhone-alpes` |
+| Import | 2026-08-04 (`osm.metadata.refreshed_at` = `2026-08-04 13:09:44+00`) |
+| `osm.accommodations` | 16 886 lignes |
+| `tourism.accommodations` | 125 966 lignes (import DataTourisme du 22/07, non retouché) |
+
+Rhône-Alpes a été ajouté à la sélection pour cette mesure : Nord-Pas-de-Calais seul ne
+contient **aucun** `wilderness_hut` et un seul `alpine_hut`, soit précisément les catégories
+sur lesquelles porte la question.
+
+Deux réserves à retenir avant de généraliser :
+
+- **Deux régions, pas la France.** Les proportions sont mesurées sur 16 886 lignes. Les
+  ordres de grandeur sont nets (63 % contre 6 %), mais un chiffre exact France entière
+  demanderait un provisionnement complet.
+- **Image du provisioner du 22/06.** Elle mappe encore `tourism=apartment` sur la catégorie
+  `apartment` ; le code courant le mappe sur `rental` ([#906](https://github.com/vincentchalamon/bike-trip-planner/pull/906)).
+  Lire `apartment` comme `rental` dans les tableaux : la correspondance est 1 pour 1. Le diff
+  entre le `tier1.lua` de l'image et celui de `main` se limite à ce renommage et à
+  l'élargissement du tag `website` ; ni la sélection des lignes ni les colonnes `name` /
+  `tags` ne changent, donc la mesure reste fidèle.
+
+L'étape DataTourisme a été désactivée pendant ce provisionnement (`DATATOURISME_FLUX_ID` et
+`DATATOURISME_APP_KEY` vidées) pour ne pas retoucher les 125 966 lignes déjà en place. Au
+passage, la prémisse citée par l'issue est confirmée sur le jeu courant : **0 nom vide sur
+125 966 lignes** DataTourisme. Le problème est bien exclusivement OSM.
+
+## 1. Volume et proportion, par catégorie
+
+Requête de l'issue, exécutée telle quelle :
+
+| category | total | sans_nom | % sans nom | rattrapables |
+|---|---:|---:|---:|---:|
+| `shelter` | 8 062 | 5 123 | 63,5 % | 210 |
+| `hotel` | 2 706 | 70 | 2,6 % | 0 |
+| `chalet` | 1 423 | 253 | 17,8 % | 26 |
+| `camp_site` | 1 405 | 64 | 4,6 % | 2 |
+| `guest_house` | 1 386 | 90 | 6,5 % | 3 |
+| `apartment` (→ `rental`) | 1 069 | 114 | 10,7 % | 7 |
+| `wilderness_hut` | 316 | 20 | 6,3 % | 0 |
+| `alpine_hut` | 290 | 8 | 2,8 % | 0 |
+| `hostel` | 218 | 10 | 4,6 % | 0 |
+| `motel` | 11 | 2 | 18,2 % | 0 |
+| **Total** | **16 886** | **5 754** | **34,1 %** | **248** |
+
+Hors `shelter` : 8 824 lignes, 631 sans nom (**7,2 %**), 38 rattrapables.
+
+Le tiers d'entrées sans nom est donc un artefact d'agrégation : **89 % des entrées sans nom
+sont des `shelter`**. Les catégories réservables se situent entre 2,6 % et 17,8 %.
+
+Répartition par région, pour les catégories sensibles :
+
+| région | category | total | sans_nom |
+|---|---|---:|---:|
+| nord-pas-de-calais | `shelter` | 896 | 862 (96,2 %) |
+| nord-pas-de-calais | `chalet` | 194 | 103 |
+| nord-pas-de-calais | `camp_site` | 326 | 10 |
+| nord-pas-de-calais | `alpine_hut` | 1 | 1 |
+| rhone-alpes | `shelter` | 7 166 | 4 261 (59,5 %) |
+| rhone-alpes | `chalet` | 1 229 | 150 |
+| rhone-alpes | `camp_site` | 1 079 | 54 |
+| rhone-alpes | `wilderness_hut` | 316 | 20 |
+| rhone-alpes | `alpine_hut` | 289 | 7 |
+
+Les 96 % d'abris sans nom en Nord-Pas-de-Calais annoncent la suite : dans une région sans
+relief, `amenity=shelter` désigne presque exclusivement du mobilier urbain.
+
+## 2. Ce que la chaîne de repli rattraperait réellement
+
+Clés disponibles sur les 5 754 entrées sans nom :
+
+| category | sans_nom | `name:fr` | `official_name` | `alt_name` | `operator` | `brand` |
+|---|---:|---:|---:|---:|---:|---:|
+| `shelter` | 5 123 | 0 | 0 | 11 | 199 | 0 |
+| `chalet` | 253 | 0 | 0 | 0 | 25 | 1 |
+| `apartment` (→ `rental`) | 114 | 0 | 0 | 0 | 7 | 0 |
+| `guest_house` | 90 | 0 | 0 | 0 | 3 | 0 |
+| `hotel` | 70 | 0 | 0 | 0 | 0 | 0 |
+| `camp_site` | 64 | 0 | 0 | 0 | 2 | 0 |
+| `wilderness_hut` | 20 | 0 | 0 | 0 | 0 | 0 |
+| `hostel` | 10 | 0 | 0 | 0 | 0 | 0 |
+| `alpine_hut` | 8 | 0 | 0 | 0 | 0 | 0 |
+| `motel` | 2 | 0 | 0 | 0 | 0 | 0 |
+
+Trois des cinq clés de la chaîne sont vides ou anecdotiques : `name:fr` **0 occurrence**,
+`official_name` **0**, `alt_name` **11** — et ces 11 portent tous la même valeur,
+« Salle hors-sac », qui est une catégorie, pas un nom. `brand` compte **1** occurrence
+(« Gîtes de France »). Tout le rattrapage repose donc sur `operator` : 236 lignes, soit
+**4,1 % des entrées sans nom**.
+
+### Utilité réelle des valeurs d'`operator`
+
+Échantillon des valeurs les plus fréquentes sur les entrées sans nom (40 valeurs les plus
+fréquentes, quantités à droite) :
+
+| category | operator | n | libellé utile ? |
+|---|---|---:|---|
+| `shelter` | JCDecaux | 87 | non — afficheur publicitaire, l'abri est un abribus |
+| `shelter` | STAS | 33 | non — réseau de bus de Saint-Étienne |
+| `shelter` | Transdev | 31 | non — transporteur |
+| `shelter` | Transdev Saint-Étienne | 12 | non — transporteur |
+| `shelter` | S.N.C.F. / SNCF | 13 | non — transporteur |
+| `shelter` | Keolis / TCL / Sytral / TAC / Stas | 8 | non — transporteurs |
+| `shelter` | Région Auvergne-Rhône-Alpes | 3 | marginal — désigne le propriétaire, pas le lieu |
+| `shelter` | Commune de Jongieux, commune de Maisoncelle | 2 | oui — « Abri communal, Jongieux » est actionnable |
+| `shelter` | Département de l'Isère, CD62, Grenoble Alpes Métropole | 3 | marginal — même remarque |
+| `shelter` | Privé | 1 | non — ce n'est pas un nom |
+| `shelter` | Sogedo, Ondea, Arc Vezerontin, Institution Sainte-Marie | 5 | non — sans rapport avec un hébergement |
+| `chalet` | Huttopia | 10 | oui — enseigne identifiable |
+| `chalet` | Camping la Digue | 6 | oui — désigne le lieu |
+| `chalet` | Claire et Gilles Belanger, Martine et Gaby Jay | 4 | oui — usage courant pour un gîte |
+| `chalet` | Commune de Sonthonnax-la-Montagne | 1 | oui |
+| `chalet` | OVO Network, Immo Select, À Petits Pas, Wam Park | 4 | oui — enseignes |
+| `apartment` (→ `rental`) | Pierre et Vacances, Goélia, Dormio Resort, Gite de France | 6 | oui — enseignes |
+| `guest_house` | CléVacances, Gite les chamois, Paclaz | 3 | oui |
+| `camp_site` | Camping du Lac du Sautet | 2 | oui |
+
+Le verdict se lit par catégorie, pas globalement :
+
+- **Sur `shelter`, `operator` est nuisible.** 175 des 199 valeurs sont des transporteurs ou
+  des afficheurs (`~* 'jcdecaux|transdev|keolis|sncf|stas|tcl|sytral|tac|cars|bus|mobilit'`).
+  Proposer « JCDecaux » comme hébergement à un bikepacker est pire que ne rien proposer :
+  c'est un abribus présenté comme un abri de bivouac. Restent une vingtaine de valeurs de
+  collectivités, exploitables mais qui décrivent le propriétaire, pas le lieu.
+- **Hors `shelter`, `operator` est utile mais négligeable en volume.** Les 38 valeurs
+  concernées sont presque toutes de vrais libellés (enseignes, campings, noms de
+  propriétaires). Mais 38 lignes sur 8 824, cela ne justifie pas une chaîne de repli en
+  cinq clés dont trois sont vides.
+
+## 3. `shelter` : le nom est un mauvais discriminant
+
+C'est le résultat décisif. `amenity=shelter` mélange des objets sans rapport entre eux. En
+classant les 8 062 abris par `shelter_type` :
+
+| classe | `shelter_type` | nommés | sans nom |
+|---|---|---:|---:|
+| **bruit** | `public_transport`, `carport`, `gazebo`, `sun_shelter`, `umbrella`, `pergola`, `shopping_cart`, `changing_rooms`, `animal_shelter`, `fuel_station`, `market`, `wildlife_hide`, … | 2 523 | 3 606 |
+| **pertinent** | `weather_shelter`, `lean_to`, `picnic_shelter`, `basic_hut`, `field_shelter`, `rock_shelter`, `roof`, `basic` | 250 | 429 |
+| **indéterminé** | tag absent | 166 | 1 088 |
+
+À lui seul, `shelter_type=public_transport` compte 6 010 lignes, soit 75 % de la catégorie.
+
+Un gate sur le nom trie donc exactement à l'envers de l'intention :
+
+- il **supprime 63 %** des abris pertinents (429 sur 679) ;
+- il **conserve 2 516 abribus** nommés (`shelter_type=public_transport` portant un nom
+  d'arrêt), qui continuent de polluer la couche.
+
+Les 1 088 abris sans nom et sans `shelter_type` ne sont pas un gisement caché : 630 portent
+un tag `building` ou une `source` cadastrale (`cadastre-dgi-fr`), c'est-à-dire des emprises
+de bâti importées en masse et taguées `amenity=shelter` sans autre information. Seulement 7
+portent un indice de transport public, 69 un `bench`. Sur les 1 517 abris du résidu
+pertinent + indéterminé, 24 seulement portent une `description` et 24 un attribut de bivouac
+(`fireplace`, `mattress`, `capacity`), 14 un `access` fermé.
+
+## 4. `wilderness_hut` : hypothèse non confirmée
+
+L'issue soupçonnait une concentration sur `shelter` **et** `wilderness_hut`. La mesure ne
+confirme que la première :
+
+- `wilderness_hut` : 20 sans nom sur 316, soit **6,3 %** — même ordre que `guest_house`
+  (6,5 %) ou `camp_site` (4,6 %) ;
+- `alpine_hut` : 8 sur 290, **2,8 %**.
+
+Le détail des 20 `wilderness_hut` sans nom confirme qu'il n'y a rien à sauver en volume :
+5 portent `access=private`, 8 se réduisent à `tourism=wilderness_hut` seul ou accompagné
+d'une emprise cadastrale, aucun n'a d'`operator`, de `brand`, de `name:fr` ni
+d'`official_name`. Deux seulement mériteraient d'être conservés pour leur `description`
+(« Des bat-flancs pour 4 personnes… », « Salle hors sac »).
+
+Une exemption pour `wilderness_hut` coûterait donc la peine d'une exception dans le schéma
+pour au mieux 15 lignes utiles sur 316.
+
+## 5. Ce que le code fait déjà
+
+Deux comportements existants encadrent la décision :
+
+- `api/src/AccommodationSource/OsmAccommodationSource.php:39-45` **écarte déjà** toute
+  entrée sans nom, au moment de la lecture. La couche des abris non nommés est donc **déjà
+  vide en production** : le gate du sprint 49 ne ferait que déplacer à l'import une
+  exclusion qui a lieu à la lecture. Le coût mesuré ici est un coût déjà payé, pas un coût à
+  venir.
+- `api/src/InRide/InRideAssistant.php:147-163` tient la position inverse pour l'in-ride :
+  restauration et mécanique sans nom sont écartées, **eau et abris sont conservés** avec un
+  libellé générique (« Point d'eau », « Abri »), au motif que les coordonnées suffisent à
+  agir. Les deux chemins divergent aujourd'hui sur la même donnée.
+
+## Recommandation
+
+**1. Contrainte de complétude sur `name`, pour toutes les catégories d'hébergement sauf
+`shelter`.** Coût mesuré : 631 lignes sur 8 824 (7,2 %), dont une part sont des emprises
+cadastrales sans information. `wilderness_hut` et `alpine_hut` entrent dans la contrainte
+sans exemption : 6,3 % et 2,8 %, aucun rattrapage possible, 5 des 20 huttes concernées étant
+de surcroît `access=private`.
+
+**2. Exemption de `shelter` seul, avec libellé générique côté lecture.** Sur cette catégorie
+le nom ne discrimine pas la qualité : la contrainte supprimerait 1 517 abris (dont 429
+explicitement pertinents) et laisserait 2 516 abribus nommés. La bonne clé de tri est
+`shelter_type`, pas `name`. En conséquence :
+
+- filtrer les abris à l'import sur une liste blanche de `shelter_type`
+  (`weather_shelter`, `lean_to`, `picnic_shelter`, `basic_hut`, `field_shelter`,
+  `rock_shelter`, `roof`, `basic`, plus tag absent) et écarter le bruit urbain
+  (`public_transport` en tête) : 6 129 lignes de bruit en moins, dont 2 523 actuellement
+  servies parce qu'elles ont un nom ;
+- servir les abris sans nom avec le libellé générique « Abri », comme le fait déjà
+  `InRideAssistant`, au lieu de les écarter dans `OsmAccommodationSource`.
+
+**3. Abandonner la chaîne de repli à cinq clés.** Mesure : 248 rattrapages sur 5 754 entrées
+sans nom (4,3 %), dont 175 sont des noms de transporteurs sur des abribus. `name:fr` et
+`official_name` n'ont **aucune** occurrence, `alt_name` 11 (toutes « Salle hors-sac »),
+`brand` 1. Si un repli est conservé, le réduire à `operator` puis `brand` **hors `shelter`**,
+pour un gain de 38 lignes : à décider au regard du coût du résolveur, pas de son rendement
+supposé.
+
+**4. Ne pas rouvrir l'option « catégorie *spots* séparée ».** Elle n'est justifiée ni pour
+`wilderness_hut` (6,3 % sans nom, aucun résidu significatif), ni pour `shelter`, dont le
+résidu se traite par l'exemption ci-dessus. Créer une catégorie hors
+`TripRequest::ALL_ACCOMMODATION_TYPES` imposerait un nouveau vocabulaire au filtre front et
+aux DTO pour un gain nul par rapport à une exemption d'une seule catégorie.
+
+## Reproduire la mesure
+
+```bash
+# Sélection des régions, puis provisionnement (l'étape DataTourisme est neutralisée)
+printf '{"slugs":["nord-pas-de-calais","rhone-alpes"]}' > .docker/osm/data/regions.json
+docker compose --profile provisioning run --rm -T \
+  -e DATATOURISME_FLUX_ID= -e DATATOURISME_APP_KEY= provisioner --no-interaction
+
+# Décompte par catégorie
+docker compose exec -T database psql -U app -d bike_trip_planner -c "
+SELECT category, count(*) AS total,
+       count(*) FILTER (WHERE name IS NULL OR btrim(name) = '') AS sans_nom,
+       count(*) FILTER (WHERE (name IS NULL OR btrim(name) = '')
+                          AND (tags ? 'operator' OR tags ? 'brand' OR tags ? 'official_name'
+                            OR tags ? 'alt_name' OR tags ? 'name:fr')) AS rattrapables
+FROM osm.accommodations GROUP BY 1 ORDER BY 2 DESC;"
+
+# Classement des abris par shelter_type
+docker compose exec -T database psql -U app -d bike_trip_planner -c "
+SELECT coalesce(tags->>'shelter_type', '(absent)') AS shelter_type, count(*) AS total,
+       count(*) FILTER (WHERE name IS NULL OR btrim(name) = '') AS sans_nom
+FROM osm.accommodations WHERE category = 'shelter' GROUP BY 1 ORDER BY 2 DESC;"
+```


### PR DESCRIPTION
Ferme #878.

Spike de mesure du sprint 47, livré sous forme de rapport committé (`docs/audit/878-hebergements-osm-sans-nom.md`) plutôt qu'en simple commentaire, pour tracer durablement l'arbitrage du gate de complétude du sprint 49 (#884).

## Mesure

Jeu de données provisionné pour l'occasion : `nord-pas-de-calais` + `rhone-alpes` (16 886 lignes dans `osm.accommodations`). Rhône-Alpes a dû être ajouté : Nord-Pas-de-Calais seul ne contient **aucun** `wilderness_hut` et un seul `alpine_hut`, soit exactement les catégories sur lesquelles porte la question.

| category | total | sans nom | % | rattrapables |
|---|---:|---:|---:|---:|
| `shelter` | 8 062 | 5 123 | 63,5 % | 210 |
| `hotel` | 2 706 | 70 | 2,6 % | 0 |
| `chalet` | 1 423 | 253 | 17,8 % | 26 |
| `camp_site` | 1 405 | 64 | 4,6 % | 2 |
| `guest_house` | 1 386 | 90 | 6,5 % | 3 |
| `apartment` (→ `rental`) | 1 069 | 114 | 10,7 % | 7 |
| `wilderness_hut` | 316 | 20 | 6,3 % | 0 |
| `alpine_hut` | 290 | 8 | 2,8 % | 0 |
| `hostel` | 218 | 10 | 4,6 % | 0 |
| `motel` | 11 | 2 | 18,2 % | 0 |
| **Total** | **16 886** | **5 754** | **34,1 %** | **248** |

Trois conclusions, toutes chiffrées dans le rapport :

1. **L'hypothèse `wilderness_hut` est démentie** : 6,3 % sans nom, comme `guest_house` (6,5 %). Le problème est concentré à 89 % sur `shelter`.
2. **La chaîne de repli ne rattrape rien** : 248 lignes sur 5 754 (4,3 %). `name:fr` **0 occurrence**, `official_name` **0**, `alt_name` 11 (toutes « Salle hors-sac »), `brand` 1. Tout repose sur `operator`, dont **184 des 199 valeurs sur `shelter` sont des transporteurs** (JCDecaux 87, STAS 33, Transdev 43, SNCF 13…) : « JCDecaux » comme libellé d'hébergement est pire que rien.
3. **Sur `shelter`, le nom trie à l'envers.** En classant par `shelter_type` : le gate supprimerait 429 abris pertinents (+ 1 088 indéterminés) et conserverait **2 516 abribus nommés**. `shelter_type=public_transport` pèse à lui seul 75 % de la catégorie.

## Recommandation portée au gate

- Contrainte de complétude sur `name` pour **toutes les catégories sauf `shelter`** (coût mesuré : 631 lignes sur 8 824, soit 7,2 %) ; `wilderness_hut` et `alpine_hut` **sans exemption**.
- Exemption de `shelter` seul + libellé générique « Abri » côté lecture, comme le fait déjà `InRideAssistant`, et filtrage des abris sur une liste blanche de `shelter_type` (6 129 lignes de bruit en moins).
- Abandon de la chaîne à cinq clés ; au mieux la réduire à `operator`/`brand` hors `shelter` (38 lignes).
- **Ne pas** rouvrir l'option « catégorie *spots* séparée » : sans objet pour `wilderness_hut`, et réglé par l'exemption pour `shelter`.

> **Suite donnée en recette :** au vu de ces chiffres, `shelter`, `motel` et `rental` sortent du vocabulaire d'hébergement — #927. `shelter` reste importé pour la seule intention « abri » de l'in-ride.

## Auto-critique

- **Chiffre corrigé après review.** Le premier comptage annonçait « 175 des 199 » opérateurs de transport sur `shelter` : le motif utilisé ratait la graphie pointée `S.N.C.F.` (9 lignes). Un motif insensible à la ponctuation donne **184**, ce qui recoupe l'échantillon publié. Le rapport porte désormais la valeur corrigée **et** la note expliquant le motif fautif, pour que le sprint 49 ne reprenne pas le mauvais chiffre. La conclusion ne change pas, elle se renforce.
- **Deux régions, pas la France.** Les proportions portent sur 16 886 lignes. Les écarts sont d'un ordre de grandeur (63 % contre 6 %), donc l'arbitrage tient, mais un chiffre France entière demanderait un provisionnement complet. C'est écrit dans le rapport plutôt que passé sous silence.
- **Image du provisioner du 22/06.** Elle mappe encore `tourism=apartment` sur `apartment` au lieu de `rental` (#906). J'ai diffé son `tier1.lua` contre celui de `main` : l'écart se limite à ce renommage et à l'élargissement du tag `website`. Ni la sélection des lignes ni `name`/`tags` ne changent, donc la mesure est fidèle ; la correspondance `apartment` → `rental` est 1 pour 1 et signalée dans le rapport.
- **La classification `bruit` / `pertinent` des `shelter_type` est un jugement**, pas une donnée. Les valeurs brutes sont dans le rapport pour permettre de le contester ; les 1 088 abris sans `shelter_type` sont comptés à part, et non rangés d'office du côté qui arrange la conclusion.
- **Le rapport recommande de modifier `OsmAccommodationSource`** (qui écarte déjà les entrées sans nom) et le filtrage à l'import. Rien n'est implémenté ici : le spike est en lecture seule, le code est porté par #927 et par les issues du sprint 49.
- **L'étape DataTourisme a été neutralisée** pendant le provisionnement pour ne pas retoucher les 125 966 lignes en place. Effet de bord utile : la prémisse « 0 nom vide côté DataTourisme » est re-vérifiée sur le jeu courant, et confirmée.
- **QA :** changement documentaire uniquement, donc seule la passe Markdownlint est pertinente. `markdownlint-cli2` sur les 91 fichiers du périmètre du Makefile : `0 error(s)`. Les passes PHP/TS ne peuvent pas être affectées, aucun fichier de code n'est touché.

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 findings (0 critical, 0 warning, 0 suggestion). Docs-only PR (audit report + TRACKING/docs index updates), no code touched. Both figures the report leans on (the "184 of 199" shelter-operator count and the two code citations to `OsmAccommodationSource` and `InRideAssistant`) check out against the current source and the report's own tables.

**Resolved threads:** Resolved 2 previously open threads — the "175 vs 184" operator-count discrepancy and the unchecked sprint-47 recette checkbox were both fixed by commit `66e4d6a`.

**Checklist:**
- [x] Code respects the project architecture (docs-only change, no code touched)
- [x] SOLID principles and Law of Demeter followed (n/a — no code)
- [x] Design patterns used where appropriate (n/a — no code)
- [x] Tests cover new/changed cases (n/a — measurement report; author ran Markdownlint on the doc scope, 0 errors)
- [x] Documentation is up to date (report cross-linked from `docs/README.md` and `TRACKING.md`; recette item now ticked)
- [x] Dependent tickets accounted for (sprint 49 gate work explicitly deferred to #884; #927 already tracks the recette follow-up)

**Commit reviewed:** 66e4d6abafeb4da9026d8c3bec84d5ab6e8bfc61
<!-- claude-review-end -->