### PR TITLE
feat(provisioner): per-table completeness metrics in metadata and health

### DIFF
--- a/TRACKING.md
+++ b/TRACKING.md
@@ -1413,7 +1413,7 @@ Sprint volontairement court : ce sont des mesures, et elles **arbitrent les spri
 
 | Ordre | ID | Titre | Effort | PRs | Dépend de |
 |-------|----|-------|--------|-----|-----------|
-| 1 | [#877](https://github.com/vincentchalamon/bike-trip-planner/issues/877) | feat(provisioner): per-table completeness metrics in metadata and health | - | - | - |
+| 1 | [#877](https://github.com/vincentchalamon/bike-trip-planner/issues/877) | feat(provisioner): per-table completeness metrics in metadata and health | - | [#926](https://github.com/vincentchalamon/bike-trip-planner/pull/926) `feature/877` En cours | - |
 | 2 | [#878](https://github.com/vincentchalamon/bike-trip-planner/issues/878) | chore(quality): measure unnamed osm accommodations per category | - | - | - |
 | 3 | [#879](https://github.com/vincentchalamon/bike-trip-planner/issues/879) | chore(datatourisme): audit flux fields for accueil-velo and minimum stay | - | - | - |
 

--- a/api/migrations/Version20260804120000.php
+++ b/api/migrations/Version20260804120000.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Adds the completeness and rejection columns to the provisioning metadata tables
+ * bootstrapped by Version20260616130000 (issue #877).
+ *
+ * The importers only recorded row counts, so no data-quality decision was
+ * verifiable over time: `completeness` holds the per-table share of rows with a
+ * name / a link / opening hours (plus the per-category breakdown for
+ * accommodations), `rejections` the discarded-row counts and their motive.
+ *
+ * As with the row counts, the provisioner builds these in its staging schema and
+ * swaps them onto the live schema, so this only bootstraps the columns for
+ * instances (and functional tests) that query the metadata before the first
+ * provisioning run.
+ */
+final class Version20260804120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add completeness and rejection columns to the provisioning metadata tables';
+    }
+
+    public function up(Schema $schema): void
+    {
+        foreach (['osm', 'tourism'] as $source) {
+            $this->addSql(\sprintf('ALTER TABLE %s.metadata ADD COLUMN IF NOT EXISTS completeness jsonb', $source));
+            $this->addSql(\sprintf('ALTER TABLE %s.metadata ADD COLUMN IF NOT EXISTS rejections jsonb', $source));
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        foreach (['osm', 'tourism'] as $source) {
+            $this->addSql(\sprintf('ALTER TABLE %s.metadata DROP COLUMN IF EXISTS completeness', $source));
+            $this->addSql(\sprintf('ALTER TABLE %s.metadata DROP COLUMN IF EXISTS rejections', $source));
+        }
+    }
+}

--- a/api/src/Controller/HealthController.php
+++ b/api/src/Controller/HealthController.php
@@ -82,8 +82,8 @@ final readonly class HealthController
             $deps[$name] = $this->finishHttpCheck($pair);
         }
 
-        // reference_data is non-required: a stale or unprovisioned PostGIS index
-        // degrades features (fewer/no POI), it never takes readiness down (ADR-040).
+        // reference_data is non-required: an unprovisioned PostGIS index degrades
+        // features (fewer/no POI), it never takes readiness down (ADR-040).
         $required = ['postgres', 'redis', 'mercure', 'valhalla'];
         $status = 'ok';
         foreach ($required as $dep) {
@@ -175,27 +175,28 @@ final readonly class HealthController
     }
 
     /**
-     * Maximum age (seconds) before a source's last refresh is considered stale,
-     * derived from each source's provisioning cadence (ADR-041): OSM is refreshed
-     * weekly, DataTourisme daily — so a comfortable buffer above each cadence
-     * flags a silently-failing or unscheduled cron without false positives.
+     * Sources whose provisioning metadata is reported; doubles as the allowlist
+     * for the schema name interpolated into the metadata query.
      *
-     * @var array<string, int>
+     * @var list<string>
      */
-    private const array STALE_THRESHOLDS = [
-        'osm' => 8 * 86400,      // 8 days (weekly cadence)
-        'tourism' => 36 * 3600,  // 36 hours (daily cadence)
-    ];
+    private const array SOURCES = ['osm', 'tourism'];
 
     /**
-     * Reports the freshness of the local-first PostGIS reference index
-     * (ADR-040/041): the last refresh timestamp, its age, a per-source `stale`
-     * flag (refresh older than the source cadence) and per-table feature counts
-     * the provisioner records in osm.metadata / tourism.metadata.
+     * Reports the state of the local-first PostGIS reference index (ADR-040/041):
+     * the last refresh timestamp, its raw age, the per-table feature counts and
+     * the per-table completeness ratios the provisioner records in osm.metadata /
+     * tourism.metadata.
      *
-     * Non-critical: `down` (never provisioned) or `stale` (refresh overdue, so an
-     * operator/uptime probe can alert on dated data) degrade features only — they
-     * never flip readiness, so the probe stays 200 (ADR-040).
+     * The age carries **no** staleness verdict, and must not grow one back: no
+     * scheduler refreshes these sources since ADR-036 removed the OSM cron, so any
+     * threshold would be permanently red — and since data obsolescence is assumed
+     * (opening a zone is a deliberate act, the data is dated by construction and
+     * the user is the one who verifies), a threshold has nothing to judge. Age
+     * stays an internal metric.
+     *
+     * Non-critical: `down` (never provisioned) degrades features only — it never
+     * flips readiness, so the probe stays 200 (ADR-040).
      *
      * @return array<string, mixed>
      */
@@ -209,12 +210,7 @@ final readonly class HealthController
             $osm = $this->fetchProvisioningMetadata('osm');
             $tourism = $this->fetchProvisioningMetadata('tourism');
 
-            $present = array_filter([$osm, $tourism]);
-            $status = match (true) {
-                [] === $present => 'down',
-                array_any($present, static fn (array $source): bool => $source['stale']) => 'stale',
-                default => 'ok',
-            };
+            $status = null === $osm && null === $tourism ? 'down' : 'ok';
 
             return [
                 'status' => $status,
@@ -239,20 +235,23 @@ final readonly class HealthController
     }
 
     /**
-     * @return array{refreshed_at: ?string, age_seconds: ?int, stale: bool, feature_counts: array<string, int>}|null null when the schema was never provisioned (no metadata row)
+     * @return array{refreshed_at: ?string, age_seconds: ?int, feature_counts: array<string, mixed>, completeness: array<string, mixed>, rejections: array<string, mixed>}|null null when the schema was never provisioned (no metadata row)
      */
     private function fetchProvisioningMetadata(string $schema): ?array
     {
         // The schema name is interpolated into SQL; allowlist it so a future
         // caller can never turn this into an injection point.
-        if (!\array_key_exists($schema, self::STALE_THRESHOLDS)) {
+        if (!\in_array($schema, self::SOURCES, true)) {
             return null;
         }
 
         try {
+            // `SELECT *` on purpose: an index provisioned before the completeness
+            // columns existed must still report its counts rather than read as
+            // unprovisioned, which naming the columns here would cause.
             // Age is computed in SQL (now() - refreshed_at) to stay timezone-safe.
             $row = $this->connection->fetchAssociative(
-                \sprintf('SELECT refreshed_at, EXTRACT(EPOCH FROM (now() - refreshed_at))::bigint AS age_seconds, feature_counts FROM %s.metadata LIMIT 1', $schema),
+                \sprintf('SELECT *, EXTRACT(EPOCH FROM (now() - refreshed_at))::bigint AS age_seconds FROM %s.metadata LIMIT 1', $schema),
             );
         } catch (\Throwable) {
             // Schema/table absent (never migrated on this instance): treat as unprovisioned.
@@ -263,23 +262,28 @@ final readonly class HealthController
             return null;
         }
 
-        $counts = [];
-        if (\is_string($row['feature_counts'])) {
-            $decoded = json_decode($row['feature_counts'], true);
-            if (\is_array($decoded)) {
-                /** @var array<string, int> $decoded */
-                $counts = $decoded;
-            }
-        }
-
-        $ageSeconds = is_numeric($row['age_seconds']) ? (int) $row['age_seconds'] : null;
-
         return [
             'refreshed_at' => \is_string($row['refreshed_at']) ? $row['refreshed_at'] : null,
-            'age_seconds' => $ageSeconds,
-            'stale' => null !== $ageSeconds && $ageSeconds > self::STALE_THRESHOLDS[$schema],
-            'feature_counts' => $counts,
+            'age_seconds' => is_numeric($row['age_seconds']) ? (int) $row['age_seconds'] : null,
+            'feature_counts' => $this->decodeJsonColumn($row['feature_counts'] ?? null),
+            'completeness' => $this->decodeJsonColumn($row['completeness'] ?? null),
+            'rejections' => $this->decodeJsonColumn($row['rejections'] ?? null),
         ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeJsonColumn(mixed $value): array
+    {
+        if (!\is_string($value)) {
+            return [];
+        }
+
+        $decoded = json_decode($value, true);
+
+        /* @var array<string, mixed> */
+        return \is_array($decoded) ? $decoded : [];
     }
 
     /**

--- a/api/tests/Functional/HealthControllerTest.php
+++ b/api/tests/Functional/HealthControllerTest.php
@@ -214,14 +214,21 @@ final class HealthControllerTest extends ApiTestCase
     }
 
     #[Test]
-    public function readinessReportsReferenceDataFreshnessAndCounts(): void
+    public function readinessReportsReferenceDataFreshnessCountsAndCompleteness(): void
     {
         $this->truncateProvisioningMetadata();
         $connection = self::getContainer()->get('doctrine.dbal.default_connection');
         \assert($connection instanceof Connection);
         $connection->executeStatement(<<<'SQL'
-            INSERT INTO osm.metadata (refreshed_at, feature_counts)
-            VALUES (now(), '{"pois": 12, "admin_boundaries": 4}'::jsonb)
+            INSERT INTO osm.metadata (refreshed_at, feature_counts, completeness, rejections)
+            VALUES (
+                now(),
+                '{"pois": 12, "admin_boundaries": 4}'::jsonb,
+                '{"pois": {"rows": 12, "named": 9, "named_ratio": 0.75},
+                  "accommodations": {"rows": 4, "named": 1, "named_ratio": 0.25,
+                                     "by_category": {"shelter": {"rows": 3, "named": 0, "named_ratio": 0.0}}}}'::jsonb,
+                '{}'::jsonb
+            )
             SQL);
 
         $this->mockHealthHttpClients(
@@ -237,23 +244,29 @@ final class HealthControllerTest extends ApiTestCase
         $this->assertSame('ok', $reference['status']);
         $this->assertNotNull($reference['osm']);
         $this->assertIsString($reference['osm']['refreshed_at']);
-        $this->assertFalse($reference['osm']['stale'], 'a just-refreshed index is fresh');
         $this->assertLessThan(60, $reference['osm']['age_seconds']);
         $this->assertSame(12, $reference['osm']['feature_counts']['pois']);
         $this->assertSame(4, $reference['osm']['feature_counts']['admin_boundaries']);
+        // Completeness ratios per table, plus the per-category breakdown that
+        // arbitrates excluding unnamed accommodations (#877).
+        $this->assertSame(0.75, $reference['osm']['completeness']['pois']['named_ratio']);
+        $this->assertSame(0, $reference['osm']['completeness']['accommodations']['by_category']['shelter']['named']);
+        $this->assertSame([], $reference['osm']['rejections']);
         $this->assertNull($reference['tourism'], 'tourism index still unprovisioned');
     }
 
     #[Test]
-    public function readinessFlagsAStaleReferenceIndexWithoutFailingReadiness(): void
+    public function readinessReportsTheReferenceIndexAgeWithoutAStalenessVerdict(): void
     {
         $this->truncateProvisioningMetadata();
         $connection = self::getContainer()->get('doctrine.dbal.default_connection');
         \assert($connection instanceof Connection);
-        // OSM refreshed 10 days ago — past the 8-day weekly-cadence threshold.
+        // OSM refreshed 100 days ago. No scheduler refreshes these sources
+        // (ADR-036) and obsolescence is assumed, so age carries no verdict: any
+        // threshold would be permanently red, i.e. a dead signal.
         $connection->executeStatement(<<<'SQL'
             INSERT INTO osm.metadata (refreshed_at, feature_counts)
-            VALUES (now() - interval '10 days', '{"pois": 12}'::jsonb)
+            VALUES (now() - interval '100 days', '{"pois": 12}'::jsonb)
             SQL);
 
         $this->mockHealthHttpClients(
@@ -263,14 +276,41 @@ final class HealthControllerTest extends ApiTestCase
 
         $response = $this->client->request('GET', '/api/health');
 
-        // Stale data degrades features only — readiness stays 200 (ADR-040/041).
         $this->assertResponseStatusCodeSame(200);
         $data = $response->toArray();
         $this->assertSame('ok', $data['status'], 'reference_data is non-required');
         $reference = $data['deps']['reference_data'];
-        $this->assertSame('stale', $reference['status']);
-        $this->assertTrue($reference['osm']['stale']);
-        $this->assertGreaterThan(8 * 86400, $reference['osm']['age_seconds']);
+        $this->assertSame('ok', $reference['status'], 'a dated index is not a degraded one');
+        $this->assertGreaterThan(99 * 86400, $reference['osm']['age_seconds']);
+        $this->assertArrayNotHasKey('stale', $reference['osm']);
+        $this->assertArrayNotHasKey('stale', $reference);
+    }
+
+    #[Test]
+    public function readinessStillReportsAnIndexProvisionedBeforeTheCompletenessColumns(): void
+    {
+        // A metadata row written by the previous provisioner (counts only) must keep
+        // reporting its counts, not read as unprovisioned.
+        $this->truncateProvisioningMetadata();
+        $connection = self::getContainer()->get('doctrine.dbal.default_connection');
+        \assert($connection instanceof Connection);
+        $connection->executeStatement(<<<'SQL'
+            INSERT INTO osm.metadata (refreshed_at, feature_counts)
+            VALUES (now(), '{"pois": 12}'::jsonb)
+            SQL);
+
+        $this->mockHealthHttpClients(
+            valhalla: new MockResponse('OK', ['http_code' => 200]),
+            mercure: new MockResponse('', ['http_code' => 200]),
+        );
+
+        $response = $this->client->request('GET', '/api/health');
+
+        $this->assertResponseStatusCodeSame(200);
+        $reference = $response->toArray()['deps']['reference_data'];
+        $this->assertSame('ok', $reference['status']);
+        $this->assertSame(12, $reference['osm']['feature_counts']['pois']);
+        $this->assertSame([], $reference['osm']['completeness']);
     }
 
     private function truncateProvisioningMetadata(): void

--- a/docs/adr/adr-040-local-first-reference-data-postgis.md
+++ b/docs/adr/adr-040-local-first-reference-data-postgis.md
@@ -45,7 +45,7 @@ The existing `provisioner/` (already a Geofabrik PBF downloader/merger for Valha
 - **Accommodation pricing (no scraping):** `price = structured open data (DataTourisme priceSpecification, OSM charge/fee) ?? heuristic (type/region/stars)`. Live HTML price scraping has been removed (PR2b): all prices come from pre-loaded sources or the heuristic, set by each `AccommodationSource` at fetch time.
 - **Atomic versioned swap:** import into a staging schema, then switch in a single transaction; the previous dataset is kept until the new one is complete. Idempotent, never a partial state.
 - **Coverage polygon:** the provisioner materialises `osm.coverage` (union of the provisioned countries' `admin_boundaries`, admin_level = 2) inside the staging schema, so it ships atomically with the data; the API tests trip geometry against it via `ST_Covers`.
-- **Monitoring:** the provisioner records `osm.metadata` / `tourism.metadata` (last refresh timestamp + per-table feature counts) on each run; `/api/health` surfaces them under a non-required `reference_data` dependency. Cron cadence (OSM weekly, DataTourisme daily, Wikidata monthly).
+- **Monitoring:** the provisioner records `osm.metadata` / `tourism.metadata` on each run — last refresh timestamp, per-table feature counts, per-table completeness ratios and the discarded-row counts (issue #877); `/api/health` surfaces them under a non-required `reference_data` dependency, with no staleness verdict on the age (see [ADR-041 R5](adr-041-provisioner-resilience.md#r5--staleness-alerting-superseded-by-completeness-reporting)). Cron cadence (OSM weekly, DataTourisme daily, Wikidata monthly).
 
 ### API — local read only
 

--- a/docs/adr/adr-041-provisioner-resilience.md
+++ b/docs/adr/adr-041-provisioner-resilience.md
@@ -1,6 +1,6 @@
 # ADR-041: Provisioner Resilience — Failure Isolation, Resumable Enrichment, Detailed Logging
 
-- **Status:** Accepted — all five workstreams (R1–R5) have landed: orchestration hardening, the resumable Wikidata cache, network timeouts/retries, the memory budget guard, and staleness alerting
+- **Status:** Accepted — all five workstreams (R1–R5) have landed: orchestration hardening, the resumable Wikidata cache, network timeouts/retries, the memory budget guard, and reference-data reporting. **R5 was superseded** (2026-08-04, issue #877): the staleness verdict it introduced is gone, replaced by raw age plus per-table completeness metrics — see [R5 (superseded)](#r5--staleness-alerting-superseded-by-completeness-reporting)
 - **Date:** 2026-06-17
 - **Depends on:** ADR-040 (Local-first reference data — single PostGIS source), ADR-039 (Beta right-sizing)
 
@@ -41,15 +41,24 @@ Harden the provisioner so third-party and resource failures degrade only the aff
 
 The streaming enricher (R2) removes the largest avoidable PHP allocation. On top of that, the provisioner entrypoint caps PHP at `memory_limit=512M` so a regression in the streaming / enrichment paths fails with a clean PHP fatal instead of a silent container OOM-kill. The heavy import processes run **outside** PHP: `osm2pgsql` is bounded by `--cache 800` (MB) plus its node cache, and `psql` by the DB config — together they fit the provisioner's 2 GB container alongside the bounded PHP process. The container limit stays the backstop for the native tools.
 
-### R5 — Staleness alerting (implemented)
+### R5 — Staleness alerting (superseded by completeness reporting)
 
-`/api/health` `reference_data` now reports, per source, the refresh `age_seconds` and a `stale` flag (refresh older than the source cadence: OSM 8 days, DataTourisme 36 hours), and an overall `stale` status when any source is overdue. It stays **non-required** — stale data degrades features only, never flipping readiness — so an uptime probe (Uptime Kuma) can alert on `deps.reference_data.status == "stale"` (or a per-source `stale` flag) and catch a silently-failing or unscheduled cron by data age, not only by a failed run. Wikidata freshness rides on the OSM/tourism refresh that re-runs the cache-backed enrichment.
+**Originally decided:** `/api/health` `reference_data` reported, per source, the refresh `age_seconds` and a `stale` flag (refresh older than the source cadence: OSM 8 days, DataTourisme 36 hours), plus an overall `stale` status when any source was overdue, so an uptime probe could alert on data age rather than only on a failed run.
+
+**Superseded (2026-08-04, issue #877).** The thresholds were removed and not replaced. Two reasons:
+
+- **The signal was dead.** No scheduler refreshes these sources since [ADR-036](adr-036-manual-osm-data-refresh.md) removed `osm-cron`; refreshes are irregular manual runs. The flag was therefore permanently lit in any real deployment, and a signal that is always red carries no information.
+- **The verdict has nothing to judge.** Under assumed obsolescence, opening a zone is a deliberate act, the data is dated by construction and the user is the one who verifies (which is why lodgings expose a link and a phone number). Age remains useful as an **internal metric**; a threshold on it does not.
+
+What `reference_data` reports instead, still **non-required** (only `down`, i.e. never provisioned, is a state — and it degrades features without flipping readiness): the refresh timestamp, the raw `age_seconds` with no verdict, the per-table `feature_counts`, and the per-table `completeness` ratios (share of rows with a name, with an exploitable link, with opening hours) with a per-category breakdown for accommodations. `rejections` records what an import discarded and why — today the DataTourisme accommodations whose subtype maps to no app category, and the quality gate's counts once it lands.
+
+Without those ratios no data-quality decision was verifiable over time, and the remaining trade-offs were taken on intuition — which is exactly what produced one false inference during the diagnosis ("a 15 km radius with no pharmacy is an index gap" was a guess). Wikidata freshness rides on the OSM/tourism refresh that re-runs the cache-backed enrichment.
 
 ## Consequences
 
 - A Wikidata/DataTourisme/mirror outage degrades only the next refresh of that source; the live dataset and the other sources are unaffected.
 - The daily DataTourisme refresh no longer pays the full Wikidata cost; enrichment resumes from the cache after any interruption.
 - Provisioner memory is bounded: the PHP process is capped at 512 MB, and the native import tools fit the 2 GB container under their own caps.
-- A silently-failing or unscheduled refresh is detectable by data age via `/api/health` (`reference_data` stale flag), not only by a failed run.
+- Data age and per-table completeness are readable via `/api/health` (`reference_data`), so a data-quality trade-off can be measured instead of guessed. No staleness verdict is derived from the age (see R5).
 - Failures leave a persistent, detailed trace (command + stderr) for later diagnosis.
 - The cache adds a stable `provisioner` schema, bootstrapped by a migration and self-created by the provisioner if absent.

--- a/provisioner/src/CompletenessMetrics.php
+++ b/provisioner/src/CompletenessMetrics.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Provisioner;
+
+/**
+ * Builds the SQL expression recording per-table completeness ratios in the
+ * provisioning metadata (issue #877).
+ *
+ * The importers only ever counted rows, never their quality, so no data-quality
+ * decision was verifiable over time. This produces, per table, the share of rows
+ * carrying a name, an exploitable link and opening hours — plus, where asked, the
+ * same breakdown per `category`, which is what arbitrates excluding unnamed
+ * entries category by category.
+ *
+ * Emitted as a single `jsonb_build_object(...)` expression, so the metrics ride in
+ * the same `CREATE TABLE ... AS SELECT` as the row counts and go live with the
+ * atomic schema swap. Each measured table costs one extra sequential scan (two
+ * when a per-category breakdown is asked), which is why callers leave out the
+ * tables that carry nothing to measure — `osm.ways` above all, by far the largest.
+ *
+ * Presence is `nullif(btrim(col), '') IS NOT NULL`: an empty or blank string is a
+ * missing value, not a value. Metric columns must therefore be text columns.
+ */
+final readonly class CompletenessMetrics
+{
+    public function __construct(private string $schema)
+    {
+    }
+
+    /**
+     * @param array<string, array<string, string>> $tables     table => metric key => text column whose presence is measured
+     * @param list<string>                         $byCategory tables that additionally get the same metrics grouped by `category`
+     */
+    public function expression(array $tables, array $byCategory = []): string
+    {
+        $parts = [];
+        foreach ($tables as $table => $metrics) {
+            $parts[] = \sprintf("'%s', %s", $table, $this->tableExpression($table, $metrics, \in_array($table, $byCategory, true)));
+        }
+
+        return \sprintf('jsonb_build_object(%s)', implode(', ', $parts));
+    }
+
+    /**
+     * @param array<string, string> $metrics
+     */
+    private function tableExpression(string $table, array $metrics, bool $byCategory): string
+    {
+        $expression = \sprintf(
+            '(SELECT %s FROM %s.%s)',
+            $this->metricsObject($metrics),
+            $this->schema,
+            $table,
+        );
+
+        if (!$byCategory) {
+            return $expression;
+        }
+
+        // A separate scalar subquery merged with `||` rather than a subquery
+        // nested in the aggregate select list: both stay uncorrelated and
+        // readable, and an empty table yields `{}` instead of NULL.
+        return \sprintf(
+            "%s || jsonb_build_object('by_category', coalesce((SELECT jsonb_object_agg(category, metrics) FROM (SELECT category, %s AS metrics FROM %s.%s GROUP BY category) grouped), '{}'::jsonb))",
+            $expression,
+            $this->metricsObject($metrics),
+            $this->schema,
+            $table,
+        );
+    }
+
+    /**
+     * @param array<string, string> $metrics
+     */
+    private function metricsObject(array $metrics): string
+    {
+        $parts = ["'rows', count(*)"];
+        foreach ($metrics as $key => $column) {
+            $present = \sprintf("count(nullif(btrim(%s), ''))", $column);
+            $parts[] = \sprintf("'%s', %s", $key, $present);
+            $parts[] = \sprintf("'%s_ratio', round(%s::numeric / nullif(count(*), 0), 4)", $key, $present);
+        }
+
+        return \sprintf('jsonb_build_object(%s)', implode(', ', $parts));
+    }
+}

--- a/provisioner/src/DataTourismeImporter.php
+++ b/provisioner/src/DataTourismeImporter.php
@@ -72,6 +72,27 @@ final readonly class DataTourismeImporter
      */
     private const array WIKIDATA_TABLES = ['cultural_pois', 'food_pois', 'accommodations'];
 
+    /**
+     * Completeness metrics recorded per table (issue #877): metric key => the text
+     * column whose presence is measured. Events carry their link in `url` and have
+     * no opening hours (they have a date range instead).
+     *
+     * @var array<string, array<string, string>>
+     */
+    private const array COMPLETENESS_METRICS = [
+        'cultural_pois' => ['named' => 'name', 'with_link' => 'website', 'with_hours' => 'opening_hours'],
+        'food_pois' => ['named' => 'name', 'with_link' => 'website', 'with_hours' => 'opening_hours'],
+        'accommodations' => ['named' => 'name', 'with_link' => 'website', 'with_hours' => 'opening_hours', 'with_phone' => 'phone'],
+        'events' => ['named' => 'name', 'with_link' => 'url'],
+    ];
+
+    /**
+     * Tables also broken down per `category`; see PostgisImporter for the rationale.
+     *
+     * @var list<string>
+     */
+    private const array COMPLETENESS_BY_CATEGORY = ['accommodations'];
+
     private HttpClientInterface $httpClient;
 
     /**
@@ -303,15 +324,31 @@ final readonly class DataTourismeImporter
             \sprintf('CREATE INDEX ON %s.events (start_date, end_date);', self::STAGING_SCHEMA),
         ], 'psql index events dates');
 
-        // Provisioning metadata (refresh timestamp + per-table counts), surfaced
-        // by /api/health so operators see the DataTourisme index freshness.
+        // Provisioning metadata (refresh timestamp, per-table counts, per-table
+        // completeness ratios and the discarded-row counts), surfaced by
+        // /api/health so operators see what the DataTourisme index is worth.
         $counts = implode(', ', array_map(
             static fn (string $table): string => \sprintf("'%1\$s', (SELECT count(*) FROM %2\$s.%1\$s)", $table, self::STAGING_SCHEMA),
             array_keys(self::TABLE_COLUMNS),
         ));
+        $completeness = new CompletenessMetrics(self::STAGING_SCHEMA)
+            ->expression(self::COMPLETENESS_METRICS, self::COMPLETENESS_BY_CATEGORY);
+        // The only rejection measurable before the sprint-49 quality gate: flux
+        // accommodations whose subtype maps to no app category (see the mapper).
+        $rejections = \sprintf(
+            "jsonb_build_object('accommodation_unmapped_category', %d)",
+            $this->mapper->unmappedAccommodationCount(),
+        );
+
         $this->runProcess([
             'psql', '-v', 'ON_ERROR_STOP=1', '-c',
-            \sprintf('CREATE TABLE %1$s.metadata AS SELECT now() AS refreshed_at, jsonb_build_object(%2$s) AS feature_counts;', self::STAGING_SCHEMA, $counts),
+            \sprintf(
+                'CREATE TABLE %1$s.metadata AS SELECT now() AS refreshed_at, jsonb_build_object(%2$s) AS feature_counts, %3$s AS completeness, %4$s AS rejections;',
+                self::STAGING_SCHEMA,
+                $counts,
+                $completeness,
+                $rejections,
+            ),
         ], 'psql build tourism metadata');
     }
 

--- a/provisioner/src/PostgisImporter.php
+++ b/provisioner/src/PostgisImporter.php
@@ -82,6 +82,41 @@ final readonly class PostgisImporter
     private const array WIKIDATA_TABLES = ['cultural_pois', 'accommodations'];
 
     /**
+     * Completeness metrics recorded per table (issue #877): metric key => the text
+     * column whose presence is measured. `website` is the exploitable link — what
+     * the user opens to verify a place themselves — so a table without one simply
+     * has no `with_link` metric.
+     *
+     * `ways` is absent on purpose: it carries only `tags` + `geom`, so there is
+     * nothing to measure, and it is the largest table by an order of magnitude.
+     *
+     * @var array<string, array<string, string>>
+     */
+    private const array COMPLETENESS_METRICS = [
+        'pois' => ['named' => 'name', 'with_link' => 'website', 'with_hours' => 'opening_hours'],
+        'accommodations' => ['named' => 'name', 'with_link' => 'website', 'with_hours' => 'opening_hours'],
+        'cultural_pois' => ['named' => 'name', 'with_link' => 'website', 'with_hours' => 'opening_hours'],
+        'water_points' => ['named' => 'name'],
+        'bike_shops' => ['named' => 'name'],
+        'health_services' => ['named' => 'name'],
+        'railway_stations' => ['named' => 'name'],
+        'charging_stations' => ['named' => 'name'],
+        'admin_boundaries' => ['named' => 'name'],
+        'cycle_routes' => ['named' => 'name'],
+        'ferries' => ['named' => 'name'],
+        'fords' => ['named' => 'name'],
+    ];
+
+    /**
+     * Tables also broken down per `category`. Accommodations only: the per-category
+     * share of unnamed rows is what arbitrates excluding them (issue #878), and
+     * each breakdown costs one extra scan.
+     *
+     * @var list<string>
+     */
+    private const array COMPLETENESS_BY_CATEGORY = ['accommodations'];
+
+    /**
      * @var \Closure(list<string>): Process
      */
     private \Closure $processFactory;
@@ -159,8 +194,8 @@ final readonly class PostgisImporter
      * Builds the derived tables in the staging schema (so the atomic swap ships
      * them with the data): the coverage polygon (union of the admin_level=2
      * country boundaries, tested by the API via ST_Covers to flag out-of-zone
-     * trips) and the provisioning metadata (refresh timestamp + per-table feature
-     * counts, surfaced by /api/health).
+     * trips) and the provisioning metadata (refresh timestamp, per-table feature
+     * counts and per-table completeness ratios, surfaced by /api/health).
      *
      * @throws ImportFailedException
      */
@@ -178,12 +213,21 @@ final readonly class PostgisImporter
             static fn (string $table): string => \sprintf("'%1\$s', (SELECT count(*) FROM %2\$s.%1\$s)", $table, self::STAGING_SCHEMA),
             self::FEATURE_TABLES,
         ));
+        $completeness = new CompletenessMetrics(self::STAGING_SCHEMA)
+            ->expression(self::COMPLETENESS_METRICS, self::COMPLETENESS_BY_CATEGORY);
+
+        // `rejections` stays empty here: nothing measurable is discarded on this
+        // side today (osmium filters the PBF before osm2pgsql ever sees it). The
+        // column exists so the quality gate can fill it with its accepted /
+        // discarded counts and motives without a schema change, and so
+        // /api/health reports the same shape for both sources.
         $this->runProcess([
             'psql', '-v', 'ON_ERROR_STOP=1', '-c',
             \sprintf(
-                'CREATE TABLE %1$s.metadata AS SELECT now() AS refreshed_at, jsonb_build_object(%2$s) AS feature_counts;',
+                'CREATE TABLE %1$s.metadata AS SELECT now() AS refreshed_at, jsonb_build_object(%2$s) AS feature_counts, %3$s AS completeness, \'{}\'::jsonb AS rejections;',
                 self::STAGING_SCHEMA,
                 $counts,
+                $completeness,
             ),
         ], 'psql build metadata');
     }

--- a/provisioner/tests/DataTourismeImporterTest.php
+++ b/provisioner/tests/DataTourismeImporterTest.php
@@ -280,6 +280,57 @@ final class DataTourismeImporterTest extends TestCase
         self::assertStringContainsString('rental', $accommodations);
         self::assertStringNotContainsString('unmapped', $accommodations);
         self::assertSame(1, $importer->unmappedAccommodationCount());
+
+        // The only rejection measurable before the sprint-49 quality gate is
+        // recorded in the metadata, motive included (issue #877).
+        self::assertStringContainsString(
+            "jsonb_build_object('accommodation_unmapped_category', 1) AS rejections",
+            $this->capturedMetadataSql(),
+        );
+    }
+
+    #[Test]
+    public function metadataRecordsPerTableCompletenessRatios(): void
+    {
+        $importer = new DataTourismeImporter(
+            fluxUrl: 'https://diffuseur.datatourisme.fr/webservice/flux/key',
+            httpClient: new MockHttpClient(new MockResponse($this->fluxZipBytes())),
+            processFactory: $this->capturingFactory(),
+        );
+
+        $importer->run($this->workDir);
+
+        $metadata = $this->capturedMetadataSql();
+        self::assertStringContainsString('AS completeness', $metadata);
+        // Everything after the counts: the completeness expression and nothing else
+        // of the counts, whose per-table subqueries share the same table names.
+        $completeness = substr($metadata, (int) strpos($metadata, 'AS feature_counts,'));
+
+        self::assertStringContainsString(
+            "'cultural_pois', (SELECT jsonb_build_object('rows', count(*), 'named', count(nullif(btrim(name), '')), 'named_ratio', round(count(nullif(btrim(name), ''))::numeric / nullif(count(*), 0), 4), 'with_link', count(nullif(btrim(website), ''))",
+            $completeness,
+        );
+        // Events carry their link in `url` and have a date range, not opening hours.
+        self::assertSame(1, preg_match("/'events', \\(SELECT (.*?) FROM tourism_staging\\.events\\)/s", $completeness, $matches));
+        self::assertStringContainsString("'with_link', count(nullif(btrim(url), ''))", $matches[1]);
+        self::assertStringNotContainsString('opening_hours', $matches[1]);
+
+        // Accommodations also break down per category: the condition for arbitrating
+        // the exclusion of unnamed entries category by category (#878).
+        self::assertStringContainsString('FROM tourism_staging.accommodations GROUP BY category', $completeness);
+        self::assertStringContainsString("'with_phone', count(nullif(btrim(phone), ''))", $completeness);
+    }
+
+    private function capturedMetadataSql(): string
+    {
+        foreach ($this->captured as $command) {
+            $sql = implode(' ', $command);
+            if (str_contains($sql, 'CREATE TABLE tourism_staging.metadata AS')) {
+                return $sql;
+            }
+        }
+
+        self::fail('no metadata command was captured');
     }
 
     #[Test]

--- a/provisioner/tests/PostgisImporterTest.php
+++ b/provisioner/tests/PostgisImporterTest.php
@@ -138,6 +138,45 @@ final class PostgisImporterTest extends TestCase
     }
 
     #[Test]
+    public function buildDerivedRecordsPerTableCompletenessRatios(): void
+    {
+        $importer = new PostgisImporter(
+            flexStylePath: '/app/osm2pgsql/tier1.lua',
+            processFactory: $this->capturingFactory(),
+        );
+
+        $importer->buildDerived();
+
+        $metadata = implode(' ', $this->captured[1]);
+        self::assertStringContainsString('AS completeness', $metadata);
+        // Everything after the counts: the completeness expression and nothing else
+        // of the counts, whose per-table subqueries share the same table names.
+        $completeness = substr($metadata, (int) strpos($metadata, 'AS feature_counts,'));
+
+        // Named share + link share + hours share, with their ratios.
+        self::assertStringContainsString(
+            "'pois', (SELECT jsonb_build_object('rows', count(*), 'named', count(nullif(btrim(name), '')), 'named_ratio', round(count(nullif(btrim(name), ''))::numeric / nullif(count(*), 0), 4), 'with_link', count(nullif(btrim(website), '')), 'with_link_ratio', round(count(nullif(btrim(website), ''))::numeric / nullif(count(*), 0), 4), 'with_hours', count(nullif(btrim(opening_hours), ''))",
+            $completeness,
+        );
+
+        // Tables without a website column are measured on their name alone.
+        self::assertStringContainsString("'water_points', (SELECT jsonb_build_object('rows', count(*), 'named', count(nullif(btrim(name), '')), 'named_ratio', round(count(nullif(btrim(name), ''))::numeric / nullif(count(*), 0), 4)) FROM osm_staging.water_points)", $completeness);
+
+        // Accommodations also break down per category: the condition for arbitrating
+        // the exclusion of unnamed entries category by category (#878).
+        self::assertStringContainsString("jsonb_build_object('by_category', coalesce((SELECT jsonb_object_agg(category, metrics) FROM (SELECT category, jsonb_build_object('rows', count(*), 'named', count(nullif(btrim(name), ''))", $completeness);
+        self::assertStringContainsString('FROM osm_staging.accommodations GROUP BY category', $completeness);
+
+        // `ways` carries neither name, link nor hours, and is the largest table by an
+        // order of magnitude: measuring it would buy nothing but a scan.
+        self::assertStringNotContainsString('osm_staging.ways', $completeness);
+
+        // The quality gate lands in sprint 49; the column ships empty so it can fill
+        // its accepted/discarded counts in without a schema change.
+        self::assertStringContainsString("'{}'::jsonb AS rejections", $completeness);
+    }
+
+    #[Test]
     public function swapRenamesStagingOntoLiveInOneTransaction(): void
     {
         $importer = new PostgisImporter(


### PR DESCRIPTION
Closes #877.

The importers only ever counted rows, never their quality, so no data-quality decision was verifiable over time. This adds the measurement, and removes the one threshold that had stopped measuring anything.

## What lands

**Per-table completeness in the provisioning metadata.** A shared `Provisioner\CompletenessMetrics` builds one `jsonb_build_object(...)` expression recording, per table, `rows`, then for each measurable dimension a count and its ratio:

- `named` — `nullif(btrim(name), '') IS NOT NULL`, i.e. a blank string is a missing value, not a value
- `with_link` — `website` (the exploitable link, what the user opens to verify a place), `url` for DataTourisme events
- `with_hours` — `opening_hours`
- `with_phone` — DataTourisme accommodations only

It rides in the same `CREATE TABLE ... AS SELECT` as the existing counts, so it goes live with the atomic schema swap and adds no new round trip.

**Per-category breakdown for accommodations**, in both importers: `completeness.accommodations.by_category.<category>` carries the same metrics grouped by `category`. That is the condition for arbitrating the exclusion of unnamed entries category by category (#878) — the arbitration needs `shelter` and `wilderness_hut` separated from `hotel`, not a global ratio.

**`rejections`.** The sprint-49 quality gate does not exist yet, so this records what is measurable today: the DataTourisme accommodations whose subtype maps to no app category, with the motive as the key (`accommodation_unmapped_category`). OSM ships the column empty (`'{}'::jsonb`) — osmium filters the PBF before osm2pgsql ever sees it, so nothing measurable is discarded on that side. The column exists so the gate fills it without a schema change and so `/api/health` reports the same shape for both sources.

**`STALE_THRESHOLDS` removed, not replaced.** `/api/health` `reference_data` now reports `refreshed_at`, a raw `age_seconds`, `feature_counts`, `completeness` and `rejections`, and its status is `down` (never provisioned) or `ok` — nothing else. Two reasons, both in the code and in the ADR: no scheduler refreshes these sources since ADR-036 removed `osm-cron`, so the flag was permanently lit in any real deployment (an always-red signal is a dead signal); and under assumed obsolescence a threshold has nothing to judge. The dependency stays non-required.

`fetchProvisioningMetadata` reads `SELECT *` on purpose: an index provisioned before the new columns existed keeps reporting its counts instead of reading as unprovisioned, which naming the columns would have caused. A functional test pins that.

## Measurements (acceptance criterion: "not notably longer")

Real DataTourisme index on the local dev database (324 128 rows across 4 tables), counts-only vs counts + completeness, 3 runs each:

| SQL | run 1 | run 2 | run 3 |
|-----|-------|-------|-------|
| `feature_counts` only (today) | 49 ms | 58 ms | 61 ms |
| `feature_counts` + `completeness` | 201 ms | 254 ms | 202 ms |

**+~150 ms** on an import whose download alone is a 1.87 GB ZIP streamed over ~390k JSON objects.

Per-table upper bound, measured on a synthetic 1 M-row table with the three text metrics:

| Query | Time |
|-------|------|
| `count(*)` | 43 ms |
| the 3-metric object (named / link / hours + ratios) | 69 ms |
| `GROUP BY category` variant | 48 ms |

So **~+70 ms per million rows per measured table**. `osm.ways` is deliberately left out of the metrics: it carries only `tags` + `geom`, so there is nothing to measure, and it is the largest table by an order of magnitude. The OSM expression was executed against the real (empty) local `osm` schema to prove it is valid SQL and that an empty table yields `rows: 0`, `ratio: null`, `by_category: {}` rather than an error.

Sample of the real output on the tourism index (this local index predates #872, hence the zero link/phone shares — which is exactly the kind of fact the metric is there to show):

```json
"cultural_pois": {"rows": 55585, "named": 55585, "named_ratio": 1.0000,
                  "with_link": 775, "with_link_ratio": 0.0139,
                  "with_hours": 7, "with_hours_ratio": 0.0001}
```

## Verification

- `provisioner` PHPUnit: `OK, but some tests were skipped! Tests: 101, Assertions: 561, Skipped: 1` (the skip pre-exists)
- `api` PHPUnit, full suite against a dedicated migrated database: `OK, but some tests were skipped! Tests: 1797, Assertions: 5234, Skipped: 1`
- `HealthControllerTest` alone: `OK (12 tests, 63 assertions)`
- PHP-CS-Fixer, Rector `--dry-run` (`[OK] Rector is done!`) and PHPStan level 9 (`[OK] No errors`) on **both** `api/` and `provisioner/`
- markdownlint on the two touched ADRs: `Summary: 0 error(s)`
- No frontend leg: `/api/health` is a plain Symfony controller, absent from the OpenAPI spec (`grep -c "api/health" pwa/src/lib/api/schema.d.ts` → 0), so no `make typegen` and no TS impact. Playwright is unaffected and CI remains its gate.

`make qa` as a whole still cannot run on this machine (Rector OOM under the 768M compose cap, empty `pwa_node_modules` volume in a worktree — documented in CLAUDE.md); the legs above were run individually so their output is the evidence.

## Auto-critique

- **The completeness ratios are not free, and the PR only bounds their cost — it does not measure it on a real OSM index.** The local `osm` schema is empty, so the OSM figure is an extrapolation from the synthetic 1 M-row benchmark (~+70 ms per million rows per table). The shape is a sequential scan per measured table, which is the same shape as the counts already paid for, so the extrapolation is sound — but it is an extrapolation, and it is worth re-reading the real number after the next full OSM provisioning.
- **`with_link` measures `website` only.** `wikipedia_url` (filled by the enrichment pass, which runs before `buildDerived`) is also a link a user could open, and is not counted. That is a deliberate narrowing — `website` is the link the frontend renders — but it means `with_link_ratio` understates "has something clickable" for the two Wikidata-enriched tables.
- **`by_category` is limited to accommodations.** POI and cultural-POI categories would also be informative (which resupply categories are unnamed?), and were left out to avoid one extra scan per table. If #878 or #879 needs them, adding a table to `COMPLETENESS_BY_CATEGORY` is a one-line change.
- **`rejections` is a near-empty contract for now.** One motive on one source. It ships because the alternative — adding the column when the gate lands — costs a migration then, and because a uniform payload shape is what makes the metric readable; but until sprint 49 it carries almost no information for OSM.
- **The metrics assume text columns.** `nullif(btrim(col), '')` is meaningful for text and would be wrong for, say, `capacity`. That is stated in `CompletenessMetrics`' docblock and holds for every column declared today, but nothing in the code enforces it — a future metric on a non-text column would silently produce a cast error at provisioning time, not at review time.
- **Removing a monitoring signal is a real loss, small as it is.** ADR-041 R5 claimed detection of a silently-failing refresh by data age. That detection is genuinely gone; what replaces it is `age_seconds`, which an operator can threshold externally if they ever want to. The judgment call — that a permanently-red flag was worse than no flag — is recorded in the ADR rather than only in the diff, so it can be revisited if a scheduler ever comes back.

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 findings (0 critical, 0 warning). No inline comments.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Notes:**
- Verified the generated `CompletenessMetrics` SQL by executing it against a real Postgres 18 instance (name/link/hours metrics, per-category `GROUP BY`, and the empty-table `ratio: null` case) — all match the documented behavior.
- Confirmed no leftover `stale`/`STALE_THRESHOLDS` references remain anywhere in `api/`, `provisioner/`, or `pwa/`, and that the frontend does not consume `reference_data` (absent from the OpenAPI spec), matching the PR's stated no-frontend-impact claim.
- Column names used in the completeness metric definitions (`website`, `opening_hours`, `phone`, `url`, `category`) were cross-checked against the osm2pgsql flex style and the DataTourisme staging DDL — all exist.

Commit reviewed: a25962583b1e892f596d75ca6973eab68864d0cb
<!-- claude-review-end -->