### PR TITLE
feat(provisioner): add the persistent enrichment cache, name resolver and completeness gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,15 @@ because `tourism=motel` is a north-American concept, empty in France; and `renta
 (meublé de tourisme) because that market is let by the week and neither source
 carries a minimum-stay field.
 
+Since #884, a bookable accommodation that arrives without a name is **not imported**
+rather than filtered out when read. The provisioner first tries to complete it — the
+Wikidata label when the row carries a Q-ID, then `operator`, then `brand`, qualified by
+the commune resolved offline from the imported boundaries ("Camping municipal — Sarlat")
+— and a per-category `CHECK` refuses what is left. The one exemption is `shelter`, whose
+useful sorting key is `shelter_type`, not the name. Categories a rider can act on from
+coordinates alone (water points, fords, ferries) and generic POIs carry no such
+constraint. See [ADR-049](docs/adr/adr-049-zone-opening-and-import-time-completeness.md).
+
 The bracket above is the *unrated* estimate. A `charge` tag or a numeric `fee` overrides it with an exact price, `fee=no` prices the entry as free, and a known `stars` rating lifts the bracket floor by 25% of its span per star above 2, capped at 75% (a 4-star hotel is estimated €85–€120, not €50–€120).
 
 Only a few candidates are kept per stage: they are ranked by **completeness** (website, description, opening hours, Wikidata Q-ID, stars, capacity, tag richness) with the price as tiebreaker, and a per-family cap reserves one slot for the outdoor family (camping, wilderness hut) so a stage never returns hotels only.

--- a/api/migrations/Version20260806120000.php
+++ b/api/migrations/Version20260806120000.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Import-time completeness, carried by the schema (ADR-049 §3, issue #884).
+ *
+ * An unnamed accommodation used to be dropped at **read** time, by an identical `continue`
+ * in two accommodation sources. Three things were wrong with that: the rows crossed the
+ * network to be thrown away, the decision lived in two places, and nothing had ever tried
+ * to *complete* the name before giving up. The decision moves to the import: the
+ * provisioner resolves what it can and refuses the rest, and this constraint is what makes
+ * a gate bug a loud failure instead of a quietly thinned result set.
+ *
+ * **Per category, because generalising would do damage.** You do not book a place you
+ * cannot name — so every bookable category requires one. A water point, a ford or a ferry
+ * is actionable from its coordinates alone, and an anonymous bakery is still a bakery, so
+ * `water_points`, `fords`, `ferries`, `pois` and `cultural_pois` get no constraint at all.
+ *
+ * `shelter` is the one exemption, and the measurement in #878 is what arbitrates it: over
+ * 8 062 shelters, a constraint on `name` would drop 429 relevant ones and keep 2 516 named
+ * bus shelters, because `shelter_type` — not the name — is what separates a mountain
+ * refuge from street furniture. `wilderness_hut` gets **no** exemption (20 unnamed of 316,
+ * 6,3 %, the level of `guest_house`), nor does `alpine_hut` (2,8 %).
+ *
+ * **This migration deletes rows, and that needs saying plainly.** The constraint is added
+ * `VALID`, so the rows already imported that violate it have to go. They are exactly the
+ * rows the read filter has always skipped, so nothing the application ever served is lost
+ * — `App\Osm\AccommodationRepository` separately excludes `shelter` from lodging results,
+ * so the exempted category is unaffected either way. `down()` cannot restore them; the
+ * next `make provision <zone>` re-imports whatever the gate now accepts.
+ */
+final class Version20260806120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add the per-category completeness constraints and the place-enrichment cache';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // The persistent name-resolution cache, sibling of provisioner.wikidata_cache in
+        // the same stable schema: never in a promoted schema, so re-opening a zone is
+        // cheap and a rejected row is remembered with the resolver version that rejected
+        // it. `resolver_version` lives here rather than on the live tables or the registry
+        // (ADR-049 §4): the anti-join against live stays purely identity-based, and
+        // retroactivity is carried where it costs least.
+        $this->addSql('CREATE SCHEMA IF NOT EXISTS provisioner');
+        $this->addSql(<<<'SQL'
+            CREATE TABLE IF NOT EXISTS provisioner.place_enrichment (
+                source text NOT NULL,
+                source_id text NOT NULL,
+                payload jsonb NOT NULL,
+                status text NOT NULL,
+                resolver_version integer NOT NULL,
+                fetched_at timestamptz NOT NULL,
+                PRIMARY KEY (source, source_id)
+            )
+            SQL);
+        // The retry scan reads (status, resolver_version) to find what a newer resolver
+        // should reconsider; without it that is a full scan of the cache per zone.
+        $this->addSql('CREATE INDEX IF NOT EXISTS place_enrichment_status_version_idx ON provisioner.place_enrichment (status, resolver_version)');
+
+        // Rows the read path has always skipped. Deleted so the constraint can be VALID:
+        // a NOT VALID constraint would leave them in place and, with the read filters now
+        // gone, they would start being served — the exact regression the filters existed
+        // to prevent.
+        $this->addSql("DELETE FROM osm.accommodations WHERE category <> 'shelter' AND nullif(btrim(name), '') IS NULL");
+        $this->addSql("DELETE FROM tourism.accommodations WHERE nullif(btrim(name), '') IS NULL");
+
+        $this->addSql(<<<'SQL'
+            ALTER TABLE osm.accommodations
+                ADD CONSTRAINT accommodations_named_unless_shelter
+                CHECK (category = 'shelter' OR nullif(btrim(name), '') IS NOT NULL)
+            SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE tourism.accommodations
+                ADD CONSTRAINT accommodations_named
+                CHECK (nullif(btrim(name), '') IS NOT NULL)
+            SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        // The deleted rows are not restorable here; a provisioning run re-imports what the
+        // gate accepts.
+        $this->addSql('ALTER TABLE tourism.accommodations DROP CONSTRAINT IF EXISTS accommodations_named');
+        $this->addSql('ALTER TABLE osm.accommodations DROP CONSTRAINT IF EXISTS accommodations_named_unless_shelter');
+        $this->addSql('DROP TABLE IF EXISTS provisioner.place_enrichment');
+    }
+}

--- a/api/src/AccommodationSource/DataTourismeAccommodationSource.php
+++ b/api/src/AccommodationSource/DataTourismeAccommodationSource.php
@@ -39,12 +39,10 @@ final readonly class DataTourismeAccommodationSource implements AccommodationSou
 
         $candidates = [];
         foreach ($this->accommodationRepository->findNear($points, $radiusMeters, $enabledTypes) as $accommodation) {
-            // Skip unnamed entries: an unnamed accommodation the rider cannot
-            // identify is not a usable suggestion (recette).
+            // No name filter here any more (#884): the completeness gate decides at import
+            // time and a CHECK on tourism.accommodations enforces it, so an unnamed row
+            // cannot reach this loop. See OsmAccommodationSource for the full rationale.
             $name = $accommodation['name'];
-            if (null === $name || '' === trim($name)) {
-                continue;
-            }
 
             if (null !== $accommodation['price']) {
                 $priceMin = $accommodation['price'];

--- a/api/src/AccommodationSource/OsmAccommodationSource.php
+++ b/api/src/AccommodationSource/OsmAccommodationSource.php
@@ -37,13 +37,17 @@ final readonly class OsmAccommodationSource implements AccommodationSourceInterf
 
         $candidates = [];
         foreach ($this->accommodationRepository->findNear($points, $radiusMeters, $enabledTypes) as $accommodation) {
-            // Skip unnamed entries: a nameless "shelter" surfaced as its raw OSM
-            // category ("shelter", labelled "Autre" in the UI) is meaningless to
-            // the rider, who cannot tell such candidates apart (recette).
+            // No name filter here any more (#884). Completeness is decided once, at
+            // import time, and enforced by a per-category CHECK on osm.accommodations: a
+            // bookable row without a name cannot be inserted, so it cannot be read. A read
+            // filter would duplicate that decision and, worse, mask a gate bug by quietly
+            // thinning the results instead of failing the import.
+            //
+            // The recette motive the old filter cited was misdiagnosed anyway: "Autre" came
+            // from a missing entry in the frontend's `typeLabelKeys`, fixed in sprint 45.
+            // The exempt category, `shelter`, never reaches lodging results — the repository
+            // excludes it separately (#927).
             $name = $accommodation['name'];
-            if (null === $name || '' === trim($name)) {
-                continue;
-            }
 
             $tags = $accommodation['tags'];
             // stars / fee are indexed columns, not just raw tags: the heuristic

--- a/api/src/Osm/AccommodationRepository.php
+++ b/api/src/Osm/AccommodationRepository.php
@@ -51,7 +51,11 @@ final readonly class AccommodationRepository implements AccommodationRepositoryI
      * @param list<array{lat: float, lon: float}> $points
      * @param list<string>                        $categories
      *
-     * @return list<array{osmType: ?string, osmId: ?int, name: ?string, category: string, lat: float, lon: float, stars: ?int, capacity: ?int, fee: ?string, website: ?string, wikidata: ?string, openingHours: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, tags: array<string, string>}>
+     * `name` is non-nullable by construction since #884: completeness is decided at import
+     * time and a per-category CHECK enforces it, and this query excludes the one exempt
+     * category (`shelter`). A row without a name therefore cannot exist among these results.
+     *
+     * @return list<array{osmType: ?string, osmId: ?int, name: string, category: string, lat: float, lon: float, stars: ?int, capacity: ?int, fee: ?string, website: ?string, wikidata: ?string, openingHours: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, tags: array<string, string>}>
      */
     public function findNear(array $points, int $radiusMeters, array $categories): array
     {
@@ -140,7 +144,7 @@ final readonly class AccommodationRepository implements AccommodationRepositoryI
                 // on openstreetmap.org: it used to be dropped at this very first hop.
                 'osmType' => OsmObjectType::fromChar($row['osm_type']),
                 'osmId' => null !== $row['osm_id'] ? (int) $row['osm_id'] : null,
-                'name' => null !== $row['name'] ? (string) $row['name'] : null,
+                'name' => (string) $row['name'],
                 'category' => (string) $row['category'],
                 'lat' => (float) $row['lat'],
                 'lon' => (float) $row['lon'],

--- a/api/src/Osm/AccommodationRepositoryInterface.php
+++ b/api/src/Osm/AccommodationRepositoryInterface.php
@@ -14,7 +14,11 @@ interface AccommodationRepositoryInterface
      * @param list<array{lat: float, lon: float}> $points
      * @param list<string>                        $categories
      *
-     * @return list<array{osmType: ?string, osmId: ?int, name: ?string, category: string, lat: float, lon: float, stars: ?int, capacity: ?int, fee: ?string, website: ?string, wikidata: ?string, openingHours: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, tags: array<string, string>}>
+     * `name` is non-nullable by construction since #884: completeness is decided at import
+     * time and a per-category CHECK enforces it, and this query excludes the one exempt
+     * category (`shelter`). A row without a name therefore cannot exist among these results.
+     *
+     * @return list<array{osmType: ?string, osmId: ?int, name: string, category: string, lat: float, lon: float, stars: ?int, capacity: ?int, fee: ?string, website: ?string, wikidata: ?string, openingHours: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, tags: array<string, string>}>
      */
     public function findNear(array $points, int $radiusMeters, array $categories): array;
 }

--- a/api/src/Tourism/AccommodationRepository.php
+++ b/api/src/Tourism/AccommodationRepository.php
@@ -37,7 +37,11 @@ final readonly class AccommodationRepository implements AccommodationRepositoryI
      * @param list<array{lat: float, lon: float}> $points
      * @param list<string>                        $categories
      *
-     * @return list<array{name: ?string, category: string, lat: float, lon: float, capacity: ?int, price: ?float, description: ?string, website: ?string, phone: ?string, openingHours: ?string, wikidata: ?string, imageUrl: ?string, wikipediaUrl: ?string, tags: array<string, string>}>
+     * `name` is non-nullable by construction since #884: completeness is decided at import
+     * time and a per-category CHECK enforces it, and this query excludes the one exempt
+     * category (`shelter`). A row without a name therefore cannot exist among these results.
+     *
+     * @return list<array{name: string, category: string, lat: float, lon: float, capacity: ?int, price: ?float, description: ?string, website: ?string, phone: ?string, openingHours: ?string, wikidata: ?string, imageUrl: ?string, wikipediaUrl: ?string, tags: array<string, string>}>
      */
     public function findNear(array $points, int $radiusMeters, array $categories): array
     {
@@ -113,7 +117,7 @@ final readonly class AccommodationRepository implements AccommodationRepositoryI
         $accommodations = [];
         foreach ($rows as $row) {
             $accommodations[] = [
-                'name' => null !== $row['name'] ? (string) $row['name'] : null,
+                'name' => (string) $row['name'],
                 'category' => (string) $row['category'],
                 'lat' => (float) $row['lat'],
                 'lon' => (float) $row['lon'],

--- a/api/src/Tourism/AccommodationRepositoryInterface.php
+++ b/api/src/Tourism/AccommodationRepositoryInterface.php
@@ -22,7 +22,11 @@ interface AccommodationRepositoryInterface
      * @param list<array{lat: float, lon: float}> $points
      * @param list<string>                        $categories
      *
-     * @return list<array{name: ?string, category: string, lat: float, lon: float, capacity: ?int, price: ?float, description: ?string, website: ?string, phone: ?string, openingHours: ?string, wikidata: ?string, imageUrl: ?string, wikipediaUrl: ?string, tags: array<string, string>}>
+     * `name` is non-nullable by construction since #884: completeness is decided at import
+     * time and a per-category CHECK enforces it, and this query excludes the one exempt
+     * category (`shelter`). A row without a name therefore cannot exist among these results.
+     *
+     * @return list<array{name: string, category: string, lat: float, lon: float, capacity: ?int, price: ?float, description: ?string, website: ?string, phone: ?string, openingHours: ?string, wikidata: ?string, imageUrl: ?string, wikipediaUrl: ?string, tags: array<string, string>}>
      */
     public function findNear(array $points, int $radiusMeters, array $categories): array;
 }

--- a/api/tests/Integration/Osm/AccommodationIndexReadTest.php
+++ b/api/tests/Integration/Osm/AccommodationIndexReadTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Integration\Osm;
 
+use Doctrine\DBAL\Exception;
 use App\AccommodationSource\OsmAccommodationSource;
 use App\ApiResource\Model\Coordinate;
 use App\Engine\PricingHeuristicEngine;
@@ -82,7 +83,7 @@ final class AccommodationIndexReadTest extends KernelTestCase
             ['shelter', 'hotel'],
         );
 
-        $names = array_map(static fn (array $row): ?string => $row['name'], $results);
+        $names = array_column($results, 'name');
 
         self::assertNotContains('Abri de la Gare', $names);
         self::assertContains('Hotel du Centre', $names);
@@ -323,6 +324,62 @@ final class AccommodationIndexReadTest extends KernelTestCase
         self::assertSame('https://gite-du-lac.example/reserver', $byName['Camping Way']['url']);
         self::assertTrue($byName['Camping Way']['hasWebsite']);
         self::assertNull($byName['Hotel Node']['url']);
+    }
+
+    #[Test]
+    public function theCheckConstraintRefusesABookableAccommodationWithoutAName(): void
+    {
+        // The invariant of #884 is carried by the schema, not by a read clause: a read filter
+        // would duplicate the decision and, worse, mask a bug in the import gate by quietly
+        // thinning results. Here it is the database that says no.
+        $this->expectException(Exception::class);
+
+        $this->connection->executeStatement(<<<'SQL'
+            INSERT INTO osm.accommodations (osm_type, osm_id, name, category, tags, geom)
+            VALUES ('n', 7001, NULL, 'camp_site', '{}'::jsonb, ST_SetSRID(ST_MakePoint(2.5, 48.5), 4326))
+            SQL);
+    }
+
+    #[Test]
+    public function theCheckConstraintAlsoRefusesABlankName(): void
+    {
+        // Presence is `nullif(btrim(name), '') IS NOT NULL`: a blank string is a missing
+        // value, not a value, exactly as the completeness metrics already measure it.
+        $this->expectException(Exception::class);
+
+        $this->connection->executeStatement(<<<'SQL'
+            INSERT INTO osm.accommodations (osm_type, osm_id, name, category, tags, geom)
+            VALUES ('n', 7002, '   ', 'hotel', '{}'::jsonb, ST_SetSRID(ST_MakePoint(2.5, 48.5), 4326))
+            SQL);
+    }
+
+    #[Test]
+    public function theCheckConstraintExemptsSheltersAndLeavesWaterPointsAlone(): void
+    {
+        // Per category, because generalising would do damage. #878 measured that a constraint
+        // on `name` would drop 429 relevant shelters while keeping 2 516 named bus shelters —
+        // `shelter_type`, not the name, is what separates them. And a water point is
+        // actionable from its coordinates alone, so it carries no constraint at all.
+        $this->connection->executeStatement(<<<'SQL'
+            INSERT INTO osm.accommodations (osm_type, osm_id, name, category, tags, geom)
+            VALUES ('n', 7003, NULL, 'shelter', '{}'::jsonb, ST_SetSRID(ST_MakePoint(2.5, 48.5), 4326))
+            SQL);
+        $this->connection->executeStatement(<<<'SQL'
+            INSERT INTO osm.water_points (osm_type, osm_id, name, category, tags, geom)
+            VALUES ('n', 7004, NULL, 'drinking_water', '{}'::jsonb, ST_SetSRID(ST_MakePoint(2.5, 48.5), 4326))
+            SQL);
+
+        self::assertSame(1, $this->countWhere('osm.accommodations', 7003));
+        self::assertSame(1, $this->countWhere('osm.water_points', 7004));
+
+        $this->connection->executeStatement('DELETE FROM osm.water_points WHERE osm_id = 7004');
+    }
+
+    private function countWhere(string $table, int $osmId): int
+    {
+        $count = $this->connection->fetchOne(\sprintf('SELECT count(*) FROM %s WHERE osm_id = %d', $table, $osmId));
+
+        return is_numeric($count) ? (int) $count : -1;
     }
 
     /**

--- a/api/tests/Unit/AccommodationSource/DataTourismeAccommodationSourceTest.php
+++ b/api/tests/Unit/AccommodationSource/DataTourismeAccommodationSourceTest.php
@@ -23,7 +23,7 @@ final class DataTourismeAccommodationSourceTest extends TestCase
      * @return array{name: ?string, category: string, lat: float, lon: float, capacity: ?int, price: ?float, description: ?string, website: ?string, phone: ?string, openingHours: ?string, wikidata: ?string, imageUrl: ?string, wikipediaUrl: ?string, tags: array<string, string>}
      */
     private function row(
-        ?string $name = 'Gîte du Lac',
+        string $name = 'Gîte du Lac',
         string $category = 'chalet',
         float $lat = 48.0,
         float $lon = 2.0,
@@ -105,20 +105,26 @@ final class DataTourismeAccommodationSourceTest extends TestCase
     }
 
     #[Test]
-    public function skipsUnnamedEntries(): void
+    public function noLongerFiltersOnTheName(): void
     {
+        // #884 moved completeness to import time, enforced by a CHECK on
+        // tourism.accommodations. This reader must therefore hand back everything the
+        // repository returns: a read filter would duplicate the decision and mask a gate bug
+        // by quietly thinning the results instead of failing the import.
+        //
+        // A blank name is what the old filter dropped, so serving it is the observable
+        // difference. The gate is what makes it unreachable in practice.
         $repository = $this->createStub(AccommodationRepositoryInterface::class);
         $repository->method('findNear')->willReturn([
-            $this->row(name: null, category: 'hotel'),
-            $this->row(name: '   ', lat: 48.1, lon: 2.1),
-            $this->row(lat: 48.2, lon: 2.2, capacity: 4, price: 75.0),
+            $this->row(name: '   ', category: 'hotel'),
+            $this->row(lat: 48.1, lon: 2.1),
         ]);
 
         $result = new DataTourismeAccommodationSource($repository, new PricingHeuristicEngine())
             ->fetch([new Coordinate(48.0, 2.0)], 5000, ['hotel', 'chalet']);
 
-        self::assertCount(1, $result);
-        self::assertSame('Gîte du Lac', $result[0]['name']);
+        self::assertCount(2, $result);
+        self::assertSame(['   ', 'Gîte du Lac'], array_column($result, 'name'));
     }
 
     #[Test]

--- a/api/tests/Unit/AccommodationSource/OsmAccommodationSourceTest.php
+++ b/api/tests/Unit/AccommodationSource/OsmAccommodationSourceTest.php
@@ -42,21 +42,6 @@ final class OsmAccommodationSourceTest extends TestCase
     }
 
     #[Test]
-    public function fetchSkipsUnnamedEntries(): void
-    {
-        $source = $this->createSource($this->repository([
-            $this->row(category: 'wilderness_hut', name: null),
-            $this->row(category: 'wilderness_hut', name: '  '),
-            $this->row(category: 'hotel', name: 'Hotel du Nord'),
-        ]));
-
-        $results = $source->fetch([new Coordinate(48.5, 2.5)], 5000, ['wilderness_hut', 'hotel']);
-
-        $this->assertCount(1, $results);
-        $this->assertSame('Hotel du Nord', $results[0]['name']);
-    }
-
-    #[Test]
     public function fetchUsesWikidataFromRepositoryRow(): void
     {
         $source = $this->createSource($this->repository([$this->row(wikidata: 'Q12345')]));
@@ -314,14 +299,36 @@ final class OsmAccommodationSourceTest extends TestCase
         $this->assertSame([], $results);
     }
 
+    #[Test]
+    public function noLongerFiltersOnTheName(): void
+    {
+        // #884 moved completeness to import time, enforced by a per-category CHECK on
+        // osm.accommodations. This reader hands back everything the repository returns: a
+        // read filter would duplicate the decision and mask a gate bug by quietly thinning
+        // the results instead of failing the import.
+        //
+        // A blank name is what the old filter dropped, so serving it is the observable
+        // difference. The exempt category, `shelter`, cannot reach here anyway —
+        // AccommodationRepository excludes it from lodging results (#927).
+        $source = $this->createSource($this->repository([
+            $this->row(name: '   '),
+            $this->row(category: 'camp_site', name: 'Camping du Lac'),
+        ]));
+
+        $result = $source->fetch([new Coordinate(48.6, 2.6)], 5000, ['hotel', 'camp_site']);
+
+        self::assertCount(2, $result);
+        self::assertSame(['   ', 'Camping du Lac'], array_column($result, 'name'));
+    }
+
     /**
      * @param array<string, string> $tags
      *
-     * @return array{osmType: ?string, osmId: ?int, name: ?string, category: string, lat: float, lon: float, stars: ?int, capacity: ?int, fee: ?string, website: ?string, wikidata: ?string, openingHours: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, tags: array<string, string>}
+     * @return array{osmType: ?string, osmId: ?int, name: string, category: string, lat: float, lon: float, stars: ?int, capacity: ?int, fee: ?string, website: ?string, wikidata: ?string, openingHours: ?string, description: ?string, imageUrl: ?string, wikipediaUrl: ?string, tags: array<string, string>}
      */
     private function row(
         string $category = 'hotel',
-        ?string $name = 'Hotel du Nord',
+        string $name = 'Hotel du Nord',
         ?string $website = null,
         ?string $wikidata = null,
         array $tags = [],

--- a/provisioner/src/DataTourismeImporter.php
+++ b/provisioner/src/DataTourismeImporter.php
@@ -121,6 +121,8 @@ final readonly class DataTourismeImporter
 
     private ZonePromotion $promotion;
 
+    private PlaceEnrichmentPass $placeEnrichmentPass;
+
     /**
      * @param (\Closure(list<string>): Process)|null $processFactory factory used to build the psql processes; defaults to a real {@see Process}
      */
@@ -148,6 +150,17 @@ final readonly class DataTourismeImporter
         $this->processFactory = $processFactory ?? static fn (array $command): Process => new Process($command);
         $this->enrichmentPass = new WikidataEnrichmentPass($this->processFactory, $enricher, $locale, $cacheTtlDays, $this->timeoutSeconds);
         $this->promotion = new ZonePromotion('datatourisme', self::LIVE_SCHEMA, self::IDENTITY);
+        // Boundaries come from the live `osm` schema: the flux carries no administrative
+        // geometry of its own, and the zone's own boundaries were promoted by the OSM step
+        // that always runs first.
+        $this->placeEnrichmentPass = new PlaceEnrichmentPass(
+            source: 'datatourisme',
+            identity: 'a.id',
+            exemptCategories: [],
+            boundariesSchema: 'osm',
+            processFactory: $this->processFactory,
+            timeoutSeconds: $this->timeoutSeconds,
+        );
     }
 
     /**
@@ -171,7 +184,11 @@ final readonly class DataTourismeImporter
         $copyFiles = $this->extract($zipPath, $workDir);
         $this->load($staging, $copyFiles);
         $this->enrichmentPass->run($workDir, $staging, self::WIKIDATA_TABLES);
-        $this->promote($zoneSlug, $staging);
+        // The gate runs before promotion here too. The flux names its places far more
+        // reliably than OSM does, so this mostly refuses nothing — but the decision must
+        // live in one place for both sources, which is the whole point of #884.
+        $gate = $this->placeEnrichmentPass->run($workDir, $staging, 'accommodations');
+        $this->promote($zoneSlug, $staging, $gate);
         $this->dropStaging($staging);
     }
 
@@ -359,9 +376,11 @@ final readonly class DataTourismeImporter
      * (refresh timestamp, per-table counts, per-table completeness ratios and the
      * discarded-row counts), which is what /api/health reports.
      *
+     * @param array{resolved?: int, rejected?: int, reasons?: array<string, int>} $gate what the completeness gate resolved and refused
+     *
      * @throws ImportFailedException
      */
-    private function promote(string $zoneSlug, string $stagingSchema): void
+    private function promote(string $zoneSlug, string $stagingSchema, array $gate): void
     {
         $counts = implode(', ', array_map(
             static fn (string $table): string => \sprintf("'%1\$s', (SELECT count(*) FROM %2\$s.%1\$s)", $table, self::LIVE_SCHEMA),
@@ -372,8 +391,10 @@ final readonly class DataTourismeImporter
         // The only rejection measurable before the completeness gate of #884: flux
         // accommodations whose subtype maps to no app category (see the mapper).
         $rejections = \sprintf(
-            "jsonb_build_object('accommodation_unmapped_category', %d)",
+            "jsonb_build_object('accommodation_unmapped_category', %d, 'accommodation_incomplete', %d, 'accommodation_name_resolved', %d)",
             $this->mapper->unmappedAccommodationCount(),
+            $gate['rejected'] ?? 0,
+            $gate['resolved'] ?? 0,
         );
 
         $metadataRefresh = \sprintf(

--- a/provisioner/src/NameResolver.php
+++ b/provisioner/src/NameResolver.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Provisioner;
+
+/**
+ * Resolves a readable name for an accommodation that arrives without one, before the
+ * completeness gate decides whether to keep it (ADR-049 §3, issue #884).
+ *
+ * **The cascade is short because the measurement says it should be.** #884 sketched five
+ * tag keys; #878 counted them over 16 886 rows on nord-pas-de-calais + rhone-alpes and
+ * found `name:fr` **0** occurrences, `official_name` **0**, `alt_name` 11 (every one of
+ * them "Salle hors-sac", i.e. not a name), `brand` 1 — the whole fallback resting on
+ * `operator`, of which **184 of 199 values on `shelter` are transport operators**
+ * (JCDecaux, Transdev, STAS, S.N.C.F., Keolis). A five-key resolver would be code with no
+ * data behind it. What is left, and what this implements: `operator` then `brand`, never
+ * on `shelter`.
+ *
+ * Order of the cascade. #884 lists the tag projection before the Wikidata label, ordered
+ * "du moins coûteux au plus coûteux" — but by the time this runs, the Wikidata pass has
+ * already populated its cache, so both steps cost zero network calls and the cost argument
+ * no longer separates them. Quality does: a Wikidata label is the place's own name, while
+ * `operator` is whoever runs it ("Commune de Jongieux"). The label therefore comes first.
+ * The choice is nearly moot in practice — an unnamed row carrying a Q-ID is rare — which is
+ * why it is a stated preference rather than a load-bearing decision.
+ *
+ * `shelter` never reaches this class: it is exempt from the gate (#878 — `shelter_type`, not
+ * the name, is what separates a mountain refuge from a bus shelter), so resolving it would
+ * only attach a carrier's name to street furniture.
+ */
+final readonly class NameResolver
+{
+    /**
+     * Bumped when this class starts resolving something it used to reject. Stored per entry
+     * in `provisioner.place_enrichment`, which is what lets a later resolver reconsider the
+     * rows it rejected: without it, every zone would stay at the data quality of the day it
+     * was opened (ADR-049 §4).
+     */
+    public const int VERSION = 1;
+
+    /**
+     * Values that are a tag rather than a name. `yes` is the common one — the tag says a
+     * feature is operated, not by whom — and the transport operators are what #878 found
+     * behind almost every `operator` on `shelter`. They are listed here rather than relied
+     * on being filtered by the shelter exemption alone, because a bus company still names
+     * no campsite.
+     *
+     * Matched case-insensitively and ignoring punctuation, since #878's first count missed
+     * `S.N.C.F.` (9 rows) for exactly that reason.
+     *
+     * @var list<string>
+     */
+    private const array NOT_A_NAME = [
+        'yes', 'no', 'unknown', 'private', 'public', 'none',
+        'jcdecaux', 'transdev', 'stas', 'sncf', 'keolis', 'ratp', 'ter', 'tcl', 'oui',
+    ];
+
+    /**
+     * Shortest value worth using. Two characters cannot identify a place to a rider, and
+     * this is what stops an initial or a stray code from passing the gate.
+     */
+    private const int MIN_LENGTH = 3;
+
+    /**
+     * @param array<string, string> $tags          the row's OSM tags, complete as imported
+     * @param string|null           $wikidataLabel label already in provisioner.wikidata_cache for this row's Q-ID
+     * @param string|null           $locality      commune resolved offline from the imported admin_level=8 boundaries (#880)
+     *
+     * @return array{name: string, via: string}|array{name: null, via: null, reason: string} the resolved name and which step produced it, or the motive for giving up
+     */
+    public function resolve(string $category, array $tags, ?string $wikidataLabel = null, ?string $locality = null): array
+    {
+        if ('shelter' === $category) {
+            // Exempt from the gate, so nothing to resolve; see the class docblock.
+            return ['name' => null, 'via' => null, 'reason' => 'shelter_exempt'];
+        }
+
+        foreach (['wikidata' => $wikidataLabel, 'operator' => $tags['operator'] ?? null, 'brand' => $tags['brand'] ?? null] as $via => $candidate) {
+            $name = $this->usable($candidate);
+            if (null === $name) {
+                continue;
+            }
+
+            return ['name' => $this->qualify($name, $locality), 'via' => $via];
+        }
+
+        return ['name' => null, 'via' => null, 'reason' => 'no_usable_name_source'];
+    }
+
+    /**
+     * A candidate value, or null when it is a tag rather than a name.
+     */
+    private function usable(?string $value): ?string
+    {
+        if (null === $value) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+        if (mb_strlen($trimmed) < self::MIN_LENGTH) {
+            return null;
+        }
+
+        // Punctuation-insensitive, so `S.N.C.F.` and `SNCF` are the same value.
+        $normalised = mb_strtolower((string) preg_replace('/[^\p{L}\p{N}]+/u', '', $trimmed));
+
+        return \in_array($normalised, self::NOT_A_NAME, true) ? null : $trimmed;
+    }
+
+    /**
+     * Appends the commune when it adds information, which is what turns a generic
+     * "Camping municipal" into "Camping municipal — Sarlat". Skipped when the locality is
+     * already in the name, so a place named after its village is not repeated.
+     */
+    private function qualify(string $name, ?string $locality): string
+    {
+        if (null === $locality || '' === trim($locality)) {
+            return $name;
+        }
+
+        $locality = trim($locality);
+        if (false !== mb_stripos($name, $locality)) {
+            return $name;
+        }
+
+        return \sprintf('%s — %s', $name, $locality);
+    }
+}

--- a/provisioner/src/PlaceEnrichmentPass.php
+++ b/provisioner/src/PlaceEnrichmentPass.php
@@ -1,0 +1,329 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Provisioner;
+
+use Provisioner\Exception\ImportFailedException;
+use Symfony\Component\Process\Exception\ProcessTimedOutException;
+use Symfony\Component\Process\Process;
+
+/**
+ * Resolves the missing names of a staging table and applies the completeness gate before
+ * promotion (ADR-049 §3/§4, issue #884).
+ *
+ * The mechanism is not new: {@see WikidataEnrichmentPass} already does exactly this for
+ * Q-IDs — persistent cache outside any promoted schema, anti-join so only the undecided is
+ * worked on, negative caching for what yields nothing, `COPY` streaming, then
+ * `UPDATE ... JOIN`. This generalises it to names, and the shape is deliberately the same
+ * so the two read as one idiom.
+ *
+ * Four properties worth stating, because each is an acceptance criterion:
+ *
+ * - **Re-opening an unchanged zone makes no enrichment call.** Every row already decided by
+ *   this resolver version is excluded from the export, so the resolver sees nothing and no
+ *   file is written.
+ * - **A row already present and complete is neither read nor rewritten.** The candidate scan
+ *   only looks at rows arriving without a name; the apply step is `COALESCE(a.name, …)`, so
+ *   an existing value can never be replaced — the literal pattern of
+ *   `WikidataEnrichmentPass`.
+ * - **A rejection is remembered with the version that rejected it**, so bumping
+ *   {@see NameResolver::VERSION} makes the next opening retry the `insufficient` entries and
+ *   only those. Without it, a zone would stay at the data quality of the day it was opened.
+ * - **The gate deletes from staging, not from live.** The promotion's `INSERT` therefore
+ *   never violates the `CHECK`; the constraint exists so that a *bug* in this gate becomes a
+ *   failed insert instead of a quietly thinned index.
+ */
+final readonly class PlaceEnrichmentPass
+{
+    private const string CACHE_SCHEMA = 'provisioner';
+
+    private const string CACHE_TABLE = 'provisioner.place_enrichment';
+
+    /**
+     * @var \Closure(list<string>): Process
+     */
+    private \Closure $processFactory;
+
+    /**
+     * @param string       $source           cache partition, also the report label ('osm', 'datatourisme')
+     * @param string       $identity         SQL expression identifying a row `a` of the target table
+     * @param list<string> $exemptCategories categories the gate does not apply to, and which are therefore
+     *                                       not resolved either (`shelter`, arbitrated by #878)
+     * @param string|null  $boundariesSchema schema holding `admin_boundaries` for the offline locality
+     *                                       lookup; null uses the staging schema, which is where the zone
+     *                                       being opened has its own freshly imported boundaries
+     */
+    public function __construct(
+        private string $source,
+        private string $identity,
+        private array $exemptCategories = [],
+        private ?string $boundariesSchema = null,
+        ?\Closure $processFactory = null,
+        private NameResolver $resolver = new NameResolver(),
+        private float $timeoutSeconds = 1800.0,
+    ) {
+        $this->processFactory = $processFactory ?? static fn (array $command): Process => new Process($command);
+    }
+
+    /**
+     * @return array{resolved: int, rejected: int, reasons: array<string, int>}
+     *
+     * @throws ImportFailedException
+     */
+    public function run(string $workDir, string $stagingSchema, string $table): array
+    {
+        // The cache may predate the API migration on this database (same reason
+        // WikidataEnrichmentPass creates its own), and the scratch table is scoped to the
+        // staging schema so two passes never drop each other's rows.
+        $scratch = \sprintf('%s.place_resolved_%s', self::CACHE_SCHEMA, (string) preg_replace('/[^a-z0-9_]/i', '_', $stagingSchema));
+        $this->psql(\sprintf(
+            'CREATE SCHEMA IF NOT EXISTS %1$s; CREATE TABLE IF NOT EXISTS %2$s (source text NOT NULL, source_id text NOT NULL, payload jsonb NOT NULL, status text NOT NULL, resolver_version integer NOT NULL, fetched_at timestamptz NOT NULL, PRIMARY KEY (source, source_id)); DROP TABLE IF EXISTS %3$s; CREATE TABLE %3$s (source_id text, payload jsonb, status text);',
+            self::CACHE_SCHEMA,
+            self::CACHE_TABLE,
+            $scratch,
+        ), 'psql prepare place enrichment cache');
+
+        $candidatesPath = $workDir.'/place-candidates.tsv';
+        $this->psql($this->exportCandidates($stagingSchema, $table, $candidatesPath), 'psql export name candidates');
+
+        $decisions = $this->resolveAll($candidatesPath);
+        $counts = ['resolved' => 0, 'rejected' => 0, 'reasons' => []];
+
+        if ([] !== $decisions) {
+            $copyPath = $workDir.'/place-resolved.copy';
+            $handle = fopen($copyPath, 'w');
+            if (false === $handle) {
+                throw new ImportFailedException(\sprintf('Cannot open enrichment COPY file "%s"', $copyPath));
+            }
+
+            try {
+                foreach ($decisions as $decision) {
+                    fwrite($handle, implode("\t", [
+                        $this->copyValue($decision['source_id']),
+                        $this->copyValue($decision['payload']),
+                        $this->copyValue($decision['status']),
+                    ])."\n");
+                }
+            } finally {
+                fclose($handle);
+            }
+
+            $this->psql(\sprintf("\\copy %s (source_id, payload, status) FROM '%s'", $scratch, $copyPath), 'psql copy resolved names');
+            // Negative decisions are cached too, with the version that made them: that is
+            // what makes a re-opening cheap and a resolver improvement retroactive.
+            $this->psql(\sprintf(
+                'INSERT INTO %1$s (source, source_id, payload, status, resolver_version, fetched_at) SELECT %2$s, source_id, payload, status, %3$d, now() FROM %4$s ON CONFLICT (source, source_id) DO UPDATE SET payload = excluded.payload, status = excluded.status, resolver_version = excluded.resolver_version, fetched_at = excluded.fetched_at;',
+                self::CACHE_TABLE,
+                $this->literal($this->source),
+                NameResolver::VERSION,
+                $scratch,
+            ), 'psql upsert place enrichment cache');
+        }
+
+        // COALESCE only: completion, never rewriting (ADR-049 §4).
+        $this->psql(\sprintf(
+            "UPDATE %1\$s.%2\$s a SET name = COALESCE(a.name, c.payload->>'name') FROM %3\$s c WHERE c.source = %4\$s AND c.source_id = %5\$s AND c.status = 'resolved';",
+            $stagingSchema,
+            $table,
+            self::CACHE_TABLE,
+            $this->literal($this->source),
+            $this->identity,
+        ), \sprintf('psql apply resolved names to %s.%s', $stagingSchema, $table));
+
+        $rejectedPath = $workDir.'/place-rejected.tsv';
+        $this->psql(\sprintf(
+            "\\copy (SELECT count(*) FROM %s.%s a WHERE %s) TO '%s'",
+            $stagingSchema,
+            $table,
+            $this->gatePredicate(),
+            $rejectedPath,
+        ), 'psql count gated rows');
+        $counts['rejected'] = (int) ($this->readLines($rejectedPath)[0] ?? '0');
+
+        // The gate itself. Deleting from staging keeps the promotion's INSERT clean, so the
+        // CHECK on the live table only ever fires on a bug here — which is the point.
+        $this->psql(\sprintf(
+            'DELETE FROM %s.%s a WHERE %s;',
+            $stagingSchema,
+            $table,
+            $this->gatePredicate(),
+        ), 'psql apply completeness gate');
+
+        $this->psql(\sprintf('DROP TABLE IF EXISTS %s;', $scratch), 'psql drop place enrichment scratch');
+
+        foreach ($decisions as $decision) {
+            if ('resolved' === $decision['status']) {
+                ++$counts['resolved'];
+                continue;
+            }
+
+            $reason = $decision['reason'];
+            $counts['reasons'][$reason] = ($counts['reasons'][$reason] ?? 0) + 1;
+        }
+
+        return $counts;
+    }
+
+    /**
+     * Rows arriving without a usable name that no current-version decision covers yet.
+     *
+     * A `resolved` entry is excluded whatever its version: it already produced a name, and
+     * re-resolving could *change* it, which the no-rewrite rule forbids. An `insufficient`
+     * entry from an older version is included — that is the retroactivity.
+     */
+    private function exportCandidates(string $stagingSchema, string $table, string $path): string
+    {
+        $boundaries = \sprintf('%s.admin_boundaries', $this->boundariesSchema ?? $stagingSchema);
+
+        return \sprintf(
+            <<<'SQL'
+                \copy (SELECT %1$s,
+                              a.category,
+                              coalesce(a.tags::text, '{}'),
+                              coalesce(w.payload->>'label', ''),
+                              coalesce((SELECT b.name FROM %2$s b WHERE b.admin_level = 8 AND ST_Covers(b.geom, a.geom) LIMIT 1), '')
+                         FROM %3$s.%4$s a
+                         LEFT JOIN provisioner.wikidata_cache w ON w.qid = a.wikidata
+                        WHERE nullif(btrim(a.name), '') IS NULL
+                          AND %5$s
+                          AND NOT EXISTS (SELECT 1 FROM %6$s c WHERE c.source = %7$s AND c.source_id = %1$s AND (c.status = 'resolved' OR c.resolver_version >= %8$d))) TO '%9$s'
+                SQL,
+            $this->identity,
+            $boundaries,
+            $stagingSchema,
+            $table,
+            $this->notExempt(),
+            self::CACHE_TABLE,
+            $this->literal($this->source),
+            NameResolver::VERSION,
+            $path,
+        );
+    }
+
+    /**
+     * Rows the gate refuses: still without a name after the cascade, and not exempt.
+     */
+    private function gatePredicate(): string
+    {
+        return \sprintf("nullif(btrim(a.name), '') IS NULL AND %s", $this->notExempt());
+    }
+
+    private function notExempt(): string
+    {
+        if ([] === $this->exemptCategories) {
+            return 'true';
+        }
+
+        return \sprintf(
+            'a.category NOT IN (%s)',
+            implode(', ', array_map($this->literal(...), $this->exemptCategories)),
+        );
+    }
+
+    /**
+     * @return list<array{source_id: string, payload: string, status: string, reason: string}>
+     */
+    private function resolveAll(string $path): array
+    {
+        $decisions = [];
+        foreach ($this->readLines($path) as $line) {
+            $fields = explode("\t", $line);
+            if (5 !== \count($fields)) {
+                continue;
+            }
+
+            [$sourceId, $category, $tagsJson, $wikidataLabel, $locality] = $fields;
+            $decision = $this->resolver->resolve(
+                $category,
+                $this->decodeTags($tagsJson),
+                '' === $wikidataLabel ? null : $wikidataLabel,
+                '' === $locality ? null : $locality,
+            );
+
+            $resolved = null !== $decision['name'];
+            $payload = $resolved
+                ? ['name' => $decision['name'], 'via' => $decision['via']]
+                : ['reason' => $decision['reason'] ?? 'unknown'];
+
+            $decisions[] = [
+                'source_id' => $sourceId,
+                'payload' => json_encode($payload, \JSON_UNESCAPED_UNICODE | \JSON_UNESCAPED_SLASHES) ?: '{}',
+                'status' => $resolved ? 'resolved' : 'insufficient',
+                'reason' => $resolved ? '' : ($decision['reason'] ?? 'unknown'),
+            ];
+        }
+
+        return $decisions;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function decodeTags(string $json): array
+    {
+        // COPY escapes tabs and newlines inside the jsonb text; undo that before decoding.
+        $decoded = json_decode(str_replace(['\\t', '\\n', '\\r', '\\\\'], ["\t", "\n", "\r", '\\'], $json), true);
+        if (!\is_array($decoded)) {
+            return [];
+        }
+
+        $tags = [];
+        foreach ($decoded as $key => $value) {
+            if (\is_string($key) && \is_scalar($value)) {
+                $tags[$key] = (string) $value;
+            }
+        }
+
+        return $tags;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function readLines(string $path): array
+    {
+        if (!is_file($path)) {
+            return [];
+        }
+
+        $contents = file_get_contents($path);
+        if (false === $contents || '' === trim($contents)) {
+            return [];
+        }
+
+        return array_values(array_filter(
+            array_map(static fn (string $line): string => rtrim($line, "\r\n"), explode("\n", $contents)),
+            static fn (string $line): bool => '' !== trim($line),
+        ));
+    }
+
+    private function copyValue(string $value): string
+    {
+        return str_replace(['\\', "\t", "\n", "\r"], ['\\\\', '\\t', '\\n', '\\r'], $value);
+    }
+
+    private function literal(string $value): string
+    {
+        return ZonePromotion::literal($value);
+    }
+
+    /**
+     * @throws ImportFailedException
+     */
+    private function psql(string $sql, string $label): void
+    {
+        $process = ($this->processFactory)(['psql', '-v', 'ON_ERROR_STOP=1', '-c', $sql]);
+        $process->setTimeout($this->timeoutSeconds);
+
+        try {
+            $process->run();
+        } catch (ProcessTimedOutException $processTimedOutException) {
+            throw new ImportFailedException(\sprintf('%s timed out after %.1fs', $label, $this->timeoutSeconds), 0, $processTimedOutException);
+        }
+
+        if (!$process->isSuccessful()) {
+            throw new ImportFailedException(\sprintf("%s failed (exit %s).\nStderr: %s", $label, (string) $process->getExitCode(), $process->getErrorOutput()));
+        }
+    }
+}

--- a/provisioner/src/PostgisImporter.php
+++ b/provisioner/src/PostgisImporter.php
@@ -104,6 +104,20 @@ final readonly class PostgisImporter
     ];
 
     /**
+     * Accommodation categories the completeness gate does not apply to, and which are
+     * therefore not name-resolved either.
+     *
+     * `shelter` only, and the measurement in #878 is what arbitrates it: `shelter_type`, not
+     * the name, is what separates a mountain refuge from a bus shelter, so a constraint on
+     * `name` would drop 429 relevant shelters while keeping 2 516 named ones.
+     * `wilderness_hut` gets no exemption (20 unnamed of 316, the level of `guest_house`),
+     * nor does `alpine_hut`.
+     *
+     * @var list<string>
+     */
+    private const array GATE_EXEMPT_CATEGORIES = ['shelter'];
+
+    /**
      * OSM tables carrying a `wikidata` Q-ID column, enriched from Wikidata via the
      * shared {@see WikidataEnrichmentPass} after import and before promotion.
      *
@@ -153,6 +167,8 @@ final readonly class PostgisImporter
 
     private WikidataEnrichmentPass $enrichmentPass;
 
+    private PlaceEnrichmentPass $placeEnrichmentPass;
+
     private ZonePromotion $promotion;
 
     /**
@@ -170,6 +186,15 @@ final readonly class PostgisImporter
     ) {
         $this->processFactory = $processFactory ?? static fn (array $command): Process => new Process($command);
         $this->enrichmentPass = new WikidataEnrichmentPass($this->processFactory, $enricher, $locale, $cacheTtlDays, $this->timeoutSeconds);
+        // Boundaries come from the staging schema: the zone being opened has just imported
+        // its own, and they are the ones covering its places (#880).
+        $this->placeEnrichmentPass = new PlaceEnrichmentPass(
+            source: 'osm',
+            identity: "a.osm_type || '/' || a.osm_id",
+            exemptCategories: self::GATE_EXEMPT_CATEGORIES,
+            processFactory: $this->processFactory,
+            timeoutSeconds: $this->timeoutSeconds,
+        );
         $this->promotion = new ZonePromotion('osm', $this->liveSchema, self::FEATURE_TABLES);
     }
 
@@ -200,7 +225,10 @@ final readonly class PostgisImporter
         // with the rows that go live. The COPY scratch files go next to the filtered PBF
         // (the /data work dir).
         $this->enrichmentPass->run(\dirname($filteredPbf), $staging, self::WIKIDATA_TABLES);
-        $this->promote($zoneSlug, $zoneName, $countrySlug, $staging);
+        // Names are resolved and the completeness gate applied *before* promotion, so the
+        // gate decides once and the live CHECK only ever fires on a bug here (#884).
+        $gate = $this->placeEnrichmentPass->run(\dirname($filteredPbf), $staging, 'accommodations');
+        $this->promote($zoneSlug, $zoneName, $countrySlug, $staging, $gate);
         $this->dropStaging($staging);
     }
 
@@ -252,9 +280,11 @@ final readonly class PostgisImporter
      * build contributes the levels that did (#880) — and a zone that yielded no boundary
      * at all keeps whatever geometry a previous run recorded rather than losing it.
      *
+     * @param array{resolved?: int, rejected?: int, reasons?: array<string, int>} $gate what the completeness gate resolved and refused, recorded in the metadata
+     *
      * @throws ImportFailedException
      */
-    public function promote(string $zoneSlug, string $zoneName, string $countrySlug, string $stagingSchema): void
+    public function promote(string $zoneSlug, string $zoneName, string $countrySlug, string $stagingSchema, array $gate = []): void
     {
         $counts = implode(', ', array_map(
             fn (string $table): string => \sprintf("'%1\$s', (SELECT count(*) FROM %2\$s.%1\$s)", $table, $this->liveSchema),
@@ -263,9 +293,9 @@ final readonly class PostgisImporter
         $completeness = new CompletenessMetrics($this->liveSchema)
             ->expression(self::COMPLETENESS_METRICS, self::COMPLETENESS_BY_CATEGORY);
 
-        // `rejections` stays empty here: nothing measurable is discarded on this side
-        // today (osmium filters the PBF before osm2pgsql ever sees it). The completeness
-        // gate of #884 is what fills it, without a schema change.
+        // What the completeness gate refused, with its motive, so a gate that starts
+        // rejecting everything is visible in /api/health instead of showing up as a
+        // quietly thinner index (#884).
         $registryUpsert = \sprintf(
             <<<'SQL'
                 INSERT INTO %1$s.zones (slug, name, country, opened_at, refreshed_at, pipeline_version, feature_counts, new_entries, geom)
@@ -286,7 +316,7 @@ final readonly class PostgisImporter
 
                 DELETE FROM %1$s.metadata;
                 INSERT INTO %1$s.metadata (refreshed_at, feature_counts, completeness, rejections)
-                SELECT now(), jsonb_build_object(%7$s), %8$s, '{}'::jsonb;
+                SELECT now(), jsonb_build_object(%7$s), %8$s, %9$s;
                 SQL,
             $this->liveSchema,
             ZonePromotion::literal($zoneSlug),
@@ -296,6 +326,7 @@ final readonly class PostgisImporter
             $stagingSchema,
             $counts,
             $completeness,
+            $this->rejectionsExpression($gate),
         );
 
         $this->runProcess([
@@ -306,6 +337,31 @@ final readonly class PostgisImporter
             'psql', '-v', 'ON_ERROR_STOP=1', '--single-transaction', '-c',
             $this->promotion->sql($zoneSlug, $stagingSchema, registryUpsert: $registryUpsert),
         ], \sprintf('psql promote zone %s', $zoneSlug));
+    }
+
+    /**
+     * The gate's outcome as a jsonb literal for `osm.metadata.rejections`: how many rows the
+     * completeness gate refused and why. Empty when the gate did not run (a direct
+     * {@see promote()} call in a test), which reads the same as "nothing was refused".
+     *
+     * @param array{resolved?: int, rejected?: int, reasons?: array<string, int>} $gate
+     */
+    private function rejectionsExpression(array $gate): string
+    {
+        if ([] === $gate) {
+            return "'{}'::jsonb";
+        }
+
+        $payload = [
+            'accommodation_incomplete' => $gate['rejected'] ?? 0,
+            'accommodation_name_resolved' => $gate['resolved'] ?? 0,
+            'accommodation_incomplete_reasons' => $gate['reasons'] ?? [],
+        ];
+
+        return \sprintf(
+            '%s::jsonb',
+            ZonePromotion::literal(json_encode($payload, \JSON_UNESCAPED_UNICODE | \JSON_UNESCAPED_SLASHES) ?: '{}'),
+        );
     }
 
     /**

--- a/provisioner/tests/DataTourismeImporterTest.php
+++ b/provisioner/tests/DataTourismeImporterTest.php
@@ -144,10 +144,12 @@ final class DataTourismeImporterTest extends TestCase
         $importer->run($this->workDir, 'bretagne');
 
         // 1 staging DDL + 4 \copy + 4 GIST index
-        // + 7 enrichment-pass psql calls (prepare, collect, export, one UPDATE per
-        // Wikidata table, drop; no Q-IDs to fetch in this fixture)
+        // + 7 Wikidata-pass psql calls (prepare, collect, export, one UPDATE per Wikidata
+        // table, drop; no Q-IDs to fetch in this fixture)
+        // + 6 name-resolution psql calls (prepare, export candidates, apply, count gated,
+        // gate, drop scratch; nothing to resolve in this fixture, so no cache write)
         // + 1 report DDL + 1 promotion + 1 staging drop.
-        self::assertCount(19, $this->captured);
+        self::assertCount(25, $this->captured);
 
         $ddl = implode(' ', $this->captured[0]);
         self::assertStringContainsString('CREATE SCHEMA tourism_staging_bretagne', $ddl);
@@ -296,7 +298,7 @@ final class DataTourismeImporterTest extends TestCase
         // The only rejection measurable before the completeness gate of #884 is
         // recorded in the metadata, motive included (issue #877).
         self::assertStringContainsString(
-            "jsonb_build_object('accommodation_unmapped_category', 2);",
+            "jsonb_build_object('accommodation_unmapped_category', 2, 'accommodation_incomplete', 0, 'accommodation_name_resolved', 0);",
             $this->capturedMetadataSql(),
         );
     }

--- a/provisioner/tests/NameResolverTest.php
+++ b/provisioner/tests/NameResolverTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Provisioner\Tests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Provisioner\NameResolver;
+
+final class NameResolverTest extends TestCase
+{
+    private NameResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->resolver = new NameResolver();
+    }
+
+    #[Test]
+    public function usesTheOperatorWhenThereIsNoName(): void
+    {
+        // The one tag key #878 found any volume behind, and the acceptance criterion of
+        // #884: an OSM accommodation with no name but an exploitable operator is imported
+        // with a readable label.
+        $resolved = $this->resolver->resolve('camp_site', ['operator' => 'Commune de Jongieux']);
+
+        self::assertSame('Commune de Jongieux', $resolved['name']);
+        self::assertSame('operator', $resolved['via']);
+    }
+
+    #[Test]
+    public function fallsBackToTheBrandAfterTheOperator(): void
+    {
+        self::assertSame('brand', $this->resolver->resolve('hotel', ['brand' => 'Ibis Budget'])['via']);
+
+        // Operator wins when both are present: it names who runs this place, the brand names
+        // a chain that may cover thousands.
+        $both = $this->resolver->resolve('hotel', ['operator' => 'Hoteliers du Nord', 'brand' => 'Ibis Budget']);
+        self::assertSame('Hoteliers du Nord', $both['name']);
+    }
+
+    #[Test]
+    public function prefersTheWikidataLabelOverTheOperator(): void
+    {
+        // A Wikidata label is the place's own name; `operator` is whoever runs it. Both cost
+        // zero network calls by this point (the Wikidata pass has already filled its cache),
+        // so quality decides the order rather than cost.
+        $resolved = $this->resolver->resolve('hotel', ['operator' => 'Commune de Sarlat'], 'Hotel de la Madeleine');
+
+        self::assertSame('Hotel de la Madeleine', $resolved['name']);
+        self::assertSame('wikidata', $resolved['via']);
+    }
+
+    /**
+     * @return iterable<string, array{0: string}>
+     */
+    public static function notANameProvider(): iterable
+    {
+        // `yes` says a feature is operated, not by whom. The carriers are what #878 found
+        // behind 184 of the 199 `operator` values on `shelter`.
+        yield 'the yes tag' => ['yes'];
+        yield 'a transport operator' => ['Transdev'];
+        yield 'a dotted transport operator' => ['S.N.C.F.'];
+        yield 'a lowercase carrier' => ['jcdecaux'];
+        yield 'too short to identify anything' => ['AB'];
+        yield 'blank' => ['   '];
+    }
+
+    #[Test]
+    #[DataProvider('notANameProvider')]
+    public function rejectsValuesThatAreATagRatherThanAName(string $value): void
+    {
+        $resolved = $this->resolver->resolve('camp_site', ['operator' => $value]);
+
+        self::assertNull($resolved['name']);
+        self::assertSame('no_usable_name_source', $resolved['reason']);
+    }
+
+    #[Test]
+    public function givesUpWithAMotiveWhenNothingIsExploitable(): void
+    {
+        // The gate needs the motive: a rejection with no reason is invisible in the opening
+        // report, which is the one blind spot ADR-049 names for this model.
+        $resolved = $this->resolver->resolve('guest_house', ['tourism' => 'guest_house', 'building' => 'yes']);
+
+        self::assertNull($resolved['name']);
+        self::assertNull($resolved['via']);
+        self::assertSame('no_usable_name_source', $resolved['reason']);
+    }
+
+    #[Test]
+    public function neverResolvesShelters(): void
+    {
+        // Exempt from the gate (#878: `shelter_type`, not the name, separates a refuge from
+        // street furniture), so resolving one would only pin a bus company's name onto
+        // street furniture.
+        $resolved = $this->resolver->resolve('shelter', ['operator' => 'Transdev'], 'Abri de la gare');
+
+        self::assertNull($resolved['name']);
+        self::assertSame('shelter_exempt', $resolved['reason']);
+    }
+
+    #[Test]
+    public function qualifiesAGenericNameWithTheOfflineLocality(): void
+    {
+        // What turns an ambiguous "Camping municipal" into something a rider can tell apart,
+        // using the commune boundaries imported by #880 — no network call.
+        $resolved = $this->resolver->resolve('camp_site', ['operator' => 'Camping municipal'], null, 'Sarlat');
+
+        self::assertSame('Camping municipal — Sarlat', $resolved['name']);
+    }
+
+    #[Test]
+    public function doesNotRepeatALocalityAlreadyInTheName(): void
+    {
+        $resolved = $this->resolver->resolve('camp_site', ['operator' => 'Camping de Sarlat'], null, 'Sarlat');
+
+        self::assertSame('Camping de Sarlat', $resolved['name']);
+    }
+
+    #[Test]
+    public function aLocalityAloneNeverProducesAName(): void
+    {
+        // Otherwise the gate could never reject anything, and the 631 rows #878 measured as
+        // unrecoverable would all be imported under a locality that identifies nothing. The
+        // locality qualifies a name; it is not a name.
+        $resolved = $this->resolver->resolve('camp_site', [], null, 'Sarlat');
+
+        self::assertNull($resolved['name']);
+        self::assertSame('no_usable_name_source', $resolved['reason']);
+    }
+
+    #[Test]
+    public function versionIsAnIntegerCallersCanCompare(): void
+    {
+        // Stored per entry in the cache; a bump is what makes the next opening retry the
+        // rows this version rejected.
+        self::assertGreaterThan(0, NameResolver::VERSION);
+    }
+}

--- a/provisioner/tests/PlaceEnrichmentPassTest.php
+++ b/provisioner/tests/PlaceEnrichmentPassTest.php
@@ -1,0 +1,276 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Provisioner\Tests;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Provisioner\NameResolver;
+use Provisioner\PlaceEnrichmentPass;
+use Symfony\Component\Process\Process;
+
+final class PlaceEnrichmentPassTest extends TestCase
+{
+    private string $workDir;
+
+    /**
+     * @var list<list<string>>
+     */
+    private array $captured = [];
+
+    protected function setUp(): void
+    {
+        $this->workDir = sys_get_temp_dir().'/place-enrichment-'.uniqid('', true);
+        mkdir($this->workDir, 0o755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->workDir.'/*') ?: [] as $file) {
+            unlink($file);
+        }
+
+        if (is_dir($this->workDir)) {
+            rmdir($this->workDir);
+        }
+    }
+
+    /**
+     * Captures each psql command and, when asked, plays the part of the database by writing
+     * the file a `\copy ... TO` would have produced.
+     *
+     * @param list<string> $candidateLines rows the export hands back, tab-separated:
+     *                                     source_id, category, tags json, wikidata label, locality
+     */
+    private function pass(array $candidateLines = [], string $rejectedCount = '0'): PlaceEnrichmentPass
+    {
+        return new PlaceEnrichmentPass(
+            source: 'osm',
+            identity: "a.osm_type || '/' || a.osm_id",
+            exemptCategories: ['shelter'],
+            processFactory: function (array $command) use ($candidateLines, $rejectedCount): Process {
+                /** @var list<string> $cmd */
+                $cmd = $command;
+                $this->captured[] = $cmd;
+                $sql = end($cmd);
+
+                if (\is_string($sql) && 1 === preg_match("/TO '([^']+)'/", $sql, $matches)) {
+                    file_put_contents(
+                        $matches[1],
+                        str_contains($matches[1], 'place-candidates')
+                            ? implode("\n", $candidateLines)."\n"
+                            : $rejectedCount."\n",
+                    );
+                }
+
+                return new Process(['true']);
+            },
+        );
+    }
+
+    private function sqlContaining(string $needle): string
+    {
+        foreach ($this->captured as $command) {
+            $sql = end($command);
+            if (\is_string($sql) && str_contains($sql, $needle)) {
+                return $sql;
+            }
+        }
+
+        self::fail(\sprintf('no captured psql command contains "%s"', $needle));
+    }
+
+    private function hasSqlContaining(string $needle): bool
+    {
+        foreach ($this->captured as $command) {
+            $sql = end($command);
+            if (\is_string($sql) && str_contains($sql, $needle)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    #[Test]
+    public function theCacheLivesOutsideAnyPromotedSchema(): void
+    {
+        // Same reason as provisioner.wikidata_cache: a cache inside a schema that gets
+        // promoted (or, before ADR-049, swapped) would be thrown away exactly when it is
+        // most valuable, and ADR-049 §4 puts resolver_version here on purpose.
+        $this->pass()->run($this->workDir, 'osm_staging_bretagne', 'accommodations');
+
+        $ddl = $this->sqlContaining('CREATE TABLE IF NOT EXISTS provisioner.place_enrichment');
+        self::assertStringContainsString('resolver_version integer NOT NULL', $ddl);
+        self::assertStringContainsString('status text NOT NULL', $ddl);
+        self::assertStringNotContainsString('osm_staging_bretagne.place_enrichment', $ddl);
+    }
+
+    #[Test]
+    public function onlyScansRowsArrivingWithoutAName(): void
+    {
+        // A row already present and complete is neither read nor rewritten: the candidate
+        // scan never looks at it.
+        $this->pass()->run($this->workDir, 'osm_staging_bretagne', 'accommodations');
+
+        $export = $this->sqlContaining('place-candidates.tsv');
+        self::assertStringContainsString("WHERE nullif(btrim(a.name), '') IS NULL", $export);
+        self::assertStringContainsString("a.category NOT IN ('shelter')", $export);
+    }
+
+    #[Test]
+    public function skipsWhatThisResolverVersionHasAlreadyDecided(): void
+    {
+        // The acceptance criterion "a re-opening without a source change triggers no
+        // enrichment network call": everything already decided is excluded from the export,
+        // so the resolver sees nothing.
+        $this->pass()->run($this->workDir, 'osm_staging_bretagne', 'accommodations');
+
+        $export = $this->sqlContaining('place-candidates.tsv');
+        self::assertStringContainsString(\sprintf("(c.status = 'resolved' OR c.resolver_version >= %d)", NameResolver::VERSION), $export);
+    }
+
+    #[Test]
+    public function withNothingToResolveItWritesNothingToTheCache(): void
+    {
+        $this->pass()->run($this->workDir, 'osm_staging_bretagne', 'accommodations');
+
+        self::assertFalse($this->hasSqlContaining('INSERT INTO provisioner.place_enrichment'), 'no cache write when the export is empty');
+        self::assertFileDoesNotExist($this->workDir.'/place-resolved.copy');
+    }
+
+    #[Test]
+    public function resolvesAnOperatorIntoANameAndCachesIt(): void
+    {
+        $counts = $this->pass([
+            "N/1\tcamp_site\t{\"operator\": \"Commune de Jongieux\"}\t\tJongieux",
+        ])->run($this->workDir, 'osm_staging_bretagne', 'accommodations');
+
+        self::assertSame(1, $counts['resolved']);
+
+        $copy = (string) file_get_contents($this->workDir.'/place-resolved.copy');
+        self::assertStringContainsString('Commune de Jongieux', $copy);
+        self::assertStringContainsString('resolved', $copy);
+
+        $upsert = $this->sqlContaining('INSERT INTO provisioner.place_enrichment');
+        self::assertStringContainsString(\sprintf('%d, now()', NameResolver::VERSION), $upsert);
+        self::assertStringContainsString('ON CONFLICT (source, source_id) DO UPDATE', $upsert);
+    }
+
+    #[Test]
+    public function cachesTheRejectionWithItsMotiveAndVersion(): void
+    {
+        // The negative cache: without it a re-opening would re-resolve every hopeless row,
+        // and a later resolver could never tell which rows to reconsider.
+        $counts = $this->pass([
+            "N/2\tguest_house\t{\"building\": \"yes\"}\t\t",
+        ])->run($this->workDir, 'osm_staging_bretagne', 'accommodations');
+
+        self::assertSame(0, $counts['resolved']);
+        self::assertSame(['no_usable_name_source' => 1], $counts['reasons']);
+
+        $copy = (string) file_get_contents($this->workDir.'/place-resolved.copy');
+        self::assertStringContainsString('insufficient', $copy);
+        self::assertStringContainsString('no_usable_name_source', $copy);
+    }
+
+    #[Test]
+    public function appliesResolvedNamesByCoalesceOnly(): void
+    {
+        // Completion, never rewriting (ADR-049 §4): the literal pattern of
+        // WikidataEnrichmentPass:138. An existing value cannot be replaced.
+        $this->pass()->run($this->workDir, 'osm_staging_bretagne', 'accommodations');
+
+        $apply = $this->sqlContaining('UPDATE osm_staging_bretagne.accommodations a SET');
+        self::assertStringContainsString("SET name = COALESCE(a.name, c.payload->>'name')", $apply);
+        self::assertStringContainsString("c.status = 'resolved'", $apply);
+        // Nothing else is assigned, so no payload column can be touched.
+        self::assertSame(1, preg_match_all('/SET [a-z_]+ =/', $apply));
+    }
+
+    #[Test]
+    public function theGateDeletesFromStagingAndNeverFromLive(): void
+    {
+        // Deleting from staging keeps the promotion's INSERT clean, so the live CHECK only
+        // ever fires on a bug in this gate — which is exactly what it is for.
+        $this->pass()->run($this->workDir, 'osm_staging_bretagne', 'accommodations');
+
+        $gate = $this->sqlContaining('DELETE FROM osm_staging_bretagne.accommodations');
+        self::assertStringContainsString("nullif(btrim(a.name), '') IS NULL", $gate);
+        self::assertStringContainsString("a.category NOT IN ('shelter')", $gate);
+        self::assertFalse($this->hasSqlContaining('DELETE FROM osm.accommodations'), 'the live table is never touched');
+    }
+
+    #[Test]
+    public function countsWhatTheGateRefusedSoItCanBeReported(): void
+    {
+        // ADR-049 names this the model's blind spot: a CHECK that rejects is invisible
+        // without the count, and the constraint alone would trade one blind spot for another.
+        $counts = $this->pass(rejectedCount: '17')->run($this->workDir, 'osm_staging_bretagne', 'accommodations');
+
+        self::assertSame(17, $counts['rejected']);
+        self::assertStringContainsString('SELECT count(*) FROM osm_staging_bretagne.accommodations', $this->sqlContaining('place-rejected.tsv'));
+    }
+
+    #[Test]
+    public function countsBeforeDeletingSoTheReportIsNotAlwaysZero(): void
+    {
+        $this->pass(rejectedCount: '3')->run($this->workDir, 'osm_staging_bretagne', 'accommodations');
+
+        $count = $this->commandIndex('place-rejected.tsv');
+        $delete = $this->commandIndex('DELETE FROM osm_staging_bretagne.accommodations');
+        self::assertGreaterThan(-1, $count);
+        self::assertLessThan($delete, $count);
+    }
+
+    #[Test]
+    public function resolvesLocalityFromTheStagingBoundariesWhenNoSchemaIsGiven(): void
+    {
+        // The zone being opened has just imported its own commune boundaries; the live schema
+        // does not have them until promotion.
+        $this->pass()->run($this->workDir, 'osm_staging_bretagne', 'accommodations');
+
+        $export = $this->sqlContaining('place-candidates.tsv');
+        self::assertStringContainsString('FROM osm_staging_bretagne.admin_boundaries b WHERE b.admin_level = 8', $export);
+        self::assertStringContainsString('ST_Covers(b.geom, a.geom)', $export);
+    }
+
+    #[Test]
+    public function readsBoundariesFromTheGivenSchemaWhenOneIsSet(): void
+    {
+        // The DataTourisme side: the flux carries no administrative geometry, and the zone's
+        // boundaries were promoted by the OSM step that always runs first.
+        new PlaceEnrichmentPass(
+            source: 'datatourisme',
+            identity: 'a.id',
+            exemptCategories: [],
+            boundariesSchema: 'osm',
+            processFactory: function (array $command): Process {
+                /** @var list<string> $cmd */
+                $cmd = $command;
+                $this->captured[] = $cmd;
+
+                return new Process(['true']);
+            },
+        )->run($this->workDir, 'tourism_staging_bretagne', 'accommodations');
+
+        $export = $this->sqlContaining('place-candidates.tsv');
+        self::assertStringContainsString('FROM osm.admin_boundaries b', $export);
+        // No exemption on this side: every flux accommodation category is bookable.
+        self::assertStringContainsString('AND true', $export);
+        self::assertStringNotContainsString('NOT IN (', $export);
+    }
+
+    private function commandIndex(string $needle): int
+    {
+        foreach ($this->captured as $index => $command) {
+            $sql = end($command);
+            if (\is_string($sql) && str_contains($sql, $needle)) {
+                return $index;
+            }
+        }
+
+        return -1;
+    }
+}

--- a/provisioner/tests/ZonePromotionExecutionTest.php
+++ b/provisioner/tests/ZonePromotionExecutionTest.php
@@ -62,6 +62,9 @@ final class ZonePromotionExecutionTest extends TestCase
             try {
                 $this->exec('SELECT 1');
             } catch (\RuntimeException $runtimeException) {
+                // Reset before skipping, or tearDown() would try to clean up through a
+                // connection that was just proven unusable and turn the skip into an error.
+                $this->psql = null;
                 self::markTestSkipped(\sprintf('no reachable PostgreSQL: %s', $runtimeException->getMessage()));
             }
         } else {


### PR DESCRIPTION
Closes #884. Implements ADR-049 §3/§4: completeness is decided once, at import time, and enforced by the schema.

## What changed

An unnamed accommodation used to be dropped by an identical `continue` in `OsmAccommodationSource` and `DataTourismeAccommodationSource`. Three things were wrong with that: the rows crossed the network to be thrown away, the decision lived in two places, and **nothing had ever tried to complete the name before giving up**.

**`NameResolver`** tries. **`PlaceEnrichmentPass`** orchestrates it as a generalisation of the mechanism `WikidataEnrichmentPass` already used for Q-IDs — persistent cache outside any promoted schema (`provisioner.place_enrichment`), anti-join so only the undecided is worked on, negative caching carrying the `resolver_version` that decided, `COPY` streaming, then `UPDATE ... JOIN` by `COALESCE` only. The shape is deliberately identical so the two read as one idiom.

**The cascade is short because the measurement says it should be.** #884 sketched five tag keys; the #878 comment counted them over 16 886 rows and found `name:fr` **0** occurrences, `official_name` **0**, `alt_name` 11 (every one "Salle hors-sac"), `brand` 1 — everything resting on `operator`, of which **184 of 199 values on `shelter` are transport operators**. A five-key resolver would be code with no data behind it. What ships: Wikidata label → `operator` → `brand`, never on `shelter`, each qualified by the commune resolved offline from the boundaries of #880 ("Camping municipal — Sarlat").

**The invariant is carried by a per-category `CHECK`**, not by a read clause. `shelter` is the one exemption (#878: `shelter_type`, not the name, separates a refuge from street furniture — a name constraint would drop 429 relevant shelters and keep 2 516 named bus shelters); `wilderness_hut` (6,3 %) and `alpine_hut` (2,8 %) get none; water points, fords, ferries and generic POIs carry no constraint at all.

Both read filters are gone, and the two repository contracts now type `name` as non-nullable — the schema guarantees it, so the type says so.

## Verification

`make qa` cannot complete on a dev machine (CLAUDE.md); the legs were run individually.

| Leg | Result |
|---|---|
| PHPStan (api) | `[OK] No errors` |
| PHPStan (provisioner) | `[OK] No errors` |
| Rector (api / provisioner) | autofixes applied and committed, re-check `[OK] Rector is done!` |
| PHP-CS-Fixer (api / provisioner) | `Fixed 0 of 666` / `Fixed 0 of 30` on re-run |
| markdownlint | `Summary: 0 error(s)` |
| PHPUnit provisioner | `OK (148 tests, 730 assertions)` |
| PHPUnit api Unit+Integration | `Tests: 1494, Assertions: 4146, Skipped: 1` |
| PHPUnit api Functional | `OK (307 tests, 1102 assertions)` |

No `pwa/` file changed, so the TypeScript / ESLint / Prettier / i18n legs have nothing to check. **Playwright is CI's job.**

Both non-obvious new tests were mutation-checked: weakening the migration's `CHECK` to `(true)` reddens `theCheckConstraintRefusesABookableAccommodationWithoutAName` and `theCheckConstraintAlsoRefusesABlankName`. (Dropping the constraint directly on `app_test` does *not* work as a mutation — `ResetDatabase` replays the migrations per class, which is itself worth knowing.)

## Auto-critique

- **The migration deletes rows.** Exactly those the read filter has always skipped, so nothing the application ever served is lost, and `AccommodationRepository` excludes `shelter` from lodging separately so the exempt category is untouched either way. But it is a destructive migration and `down()` cannot restore them — the next `make provision <zone>` re-imports whatever the gate accepts. A `NOT VALID` constraint would have avoided the delete and been worse: the rows would stay and, with the filters now gone, start being served.
- **I reordered the cascade against the issue.** #884 lists the tag projection before the Wikidata label, ordered by cost; by the time this runs the Wikidata cache is already populated, so both cost zero network calls and the cost argument no longer separates them. Quality does — a label is the place's name, `operator` is whoever runs it. The choice is nearly moot (an unnamed row carrying a Q-ID is rare), which is why it is a stated preference and not hidden.
- **The locality qualifies a name; it never creates one.** Otherwise the gate could reject nothing and the 631 unrecoverable rows #878 measured would all be imported under a locality that identifies nothing. That reading is narrower than the issue's "(d) localité … pour produire « Camping municipal — Sarlat »" may suggest, and it is the reading that keeps the gate meaningful.
- **`NOT_A_NAME` is a hand-maintained list.** It encodes what one measurement over two regions found. A carrier operating elsewhere will pass it, and the only cost is one accommodation labelled with a bus company — no worse than today's outcome for that row, which is exclusion.
- **The gate deletes from staging, so the `CHECK` is never exercised in a healthy run.** That is intentional (the constraint is there to make a gate bug loud), but it does mean the constraint's own behaviour is only covered by the integration tests, never by a provisioning run.
- **`resolved` entries are never re-resolved, whatever the version.** A bump therefore improves rejected rows only, never a name that a better resolver would now render differently. That follows the no-rewrite rule, and it means a bad name resolved by version 1 is permanent short of manual intervention — which is what #886's override import is for.
- **DataTourisme gains almost nothing here.** The flux carries no `operator`, so the pass mostly walks its tables to resolve nothing. It runs anyway because the decision must live in one place for both sources; the geometric matching that would actually help is #885.

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 findings (0 critical, 0 warning). This PR is unusually thorough — the migration, `NameResolver`, and `PlaceEnrichmentPass` were checked line-by-line against the shape of the sibling `WikidataEnrichmentPass` idiom (anti-join exclusion, `resolver_version` retroactivity, `COALESCE`-only apply, gate-before-promote ordering), against the CHECK-constraint/shelter-exemption logic in both repositories, and against the destructive migration's own auto-critique. No correctness, security, performance, or architecture issues survived that check.

**PR title:** non-conforming — `feat(provisioner): persistent enrichment cache, name resolver and completeness gate` is a noun phrase, not imperative mood. Consider e.g. `feat(provisioner): add persistent enrichment cache, name resolver and completeness gate`.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

_Commit reviewed: 462a2499ae59187986fbb178e81740d055dc4a50_
<!-- claude-review-end -->
