### PR TITLE
feat(provisioner): match osm places against the curated datatourisme flux geometrically

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,18 @@ carries a minimum-stay field.
 
 Since #884, a bookable accommodation that arrives without a name is **not imported**
 rather than filtered out when read. The provisioner first tries to complete it — the
-Wikidata label when the row carries a Q-ID, then `operator`, then `brand`, qualified by
-the commune resolved offline from the imported boundaries ("Camping municipal — Sarlat")
-— and a per-category `CHECK` refuses what is left. The one exemption is `shelter`, whose
+a geometric match against the curated DataTourisme flux (same category, within 50 m), then
+the Wikidata label when the row carries a Q-ID, then `operator`, then `brand`, the tag-based
+ones qualified by the commune resolved offline from the imported boundaries ("Camping
+municipal — Sarlat") — and a per-category `CHECK` refuses what is left.
+
+The geometric match is what the runtime deduplicator structurally cannot do: it pairs
+places **by name**, so the one thing it needs is the one thing missing. At import there is
+no such constraint, and DataTourisme names every one of its 124 240 accommodations. Two
+curated candidates in range produce a **rejection**, never a pick — attributing the wrong
+name is worse than attributing none — and each accepted match records the record it came
+from and its distance, for audit. The 50 m radius is a starting point; `/api/health` reports
+the match and ambiguity counts per run, which is what will confirm or move it. The one exemption is `shelter`, whose
 useful sorting key is `shelter_type`, not the name. Categories a rider can act on from
 coordinates alone (water points, fords, ferries) and generic POIs carry no such
 constraint. See [ADR-049](docs/adr/adr-049-zone-opening-and-import-time-completeness.md).

--- a/provisioner/src/DataTourismeImporter.php
+++ b/provisioner/src/DataTourismeImporter.php
@@ -441,6 +441,18 @@ final readonly class DataTourismeImporter
                 'psql', '-v', 'ON_ERROR_STOP=1', '-c',
                 \sprintf('CREATE INDEX ON %s.%s USING gist (geom);', $stagingSchema, $table),
             ], \sprintf('psql index %s', $table));
+
+            // Separate index on the *geography* cast, for the geometric match of #885. A cast
+            // makes the plain `geom` index above unusable, so without this the correlated
+            // `ST_DWithin(t.geom::geography, …)` subquery scans all ~124 240 staged
+            // accommodations once per unnamed OSM row. Only that one table is ever matched
+            // against, so only it pays for the extra index.
+            if ('accommodations' === $table) {
+                $this->runProcess([
+                    'psql', '-v', 'ON_ERROR_STOP=1', '-c',
+                    \sprintf('CREATE INDEX ON %s.%s USING gist ((geom::geography));', $stagingSchema, $table),
+                ], \sprintf('psql index %s geography', $table));
+            }
         }
     }
 

--- a/provisioner/src/DataTourismeImporter.php
+++ b/provisioner/src/DataTourismeImporter.php
@@ -173,9 +173,18 @@ final readonly class DataTourismeImporter
     }
 
     /**
+     * Downloads and loads the flux into the zone's staging schema, without promoting it.
+     *
+     * Split from {@see promote()} for #885. The flux is the **curated** source — over
+     * 124 240 accommodations, not one has an empty name — so the OSM side must be able to
+     * borrow a name from it, and that means the flux has to be staged *before* the OSM
+     * gate decides what to reject. Promotion still comes last, because it clips to the
+     * zone geometry that only the OSM import produces: staging first, promoting last, is
+     * the only ordering that satisfies both.
+     *
      * @throws ImportFailedException
      */
-    public function run(string $workDir, string $zoneSlug): void
+    public function stage(string $workDir, string $zoneSlug): string
     {
         $staging = self::stagingSchema($zoneSlug);
 
@@ -184,12 +193,36 @@ final readonly class DataTourismeImporter
         $copyFiles = $this->extract($zipPath, $workDir);
         $this->load($staging, $copyFiles);
         $this->enrichmentPass->run($workDir, $staging, self::WIKIDATA_TABLES);
+
+        return $staging;
+    }
+
+    /**
+     * Gates the staged flux and promotes what survives into the live schema.
+     *
+     * @throws ImportFailedException
+     */
+    public function finish(string $workDir, string $zoneSlug): void
+    {
+        $staging = self::stagingSchema($zoneSlug);
+
         // The gate runs before promotion here too. The flux names its places far more
         // reliably than OSM does, so this mostly refuses nothing — but the decision must
         // live in one place for both sources, which is the whole point of #884.
         $gate = $this->placeEnrichmentPass->run($workDir, $staging, 'accommodations');
         $this->promote($zoneSlug, $staging, $gate);
         $this->dropStaging($staging);
+    }
+
+    /**
+     * Stages and promotes in one call, for a run with no OSM step to interleave.
+     *
+     * @throws ImportFailedException
+     */
+    public function run(string $workDir, string $zoneSlug): void
+    {
+        $this->stage($workDir, $zoneSlug);
+        $this->finish($workDir, $zoneSlug);
     }
 
     /**
@@ -376,7 +409,7 @@ final readonly class DataTourismeImporter
      * (refresh timestamp, per-table counts, per-table completeness ratios and the
      * discarded-row counts), which is what /api/health reports.
      *
-     * @param array{resolved?: int, rejected?: int, reasons?: array<string, int>} $gate what the completeness gate resolved and refused
+     * @param array{resolved?: int, rejected?: int, matched?: int, ambiguous?: int, reasons?: array<string, int>} $gate what the completeness gate resolved and refused
      *
      * @throws ImportFailedException
      */

--- a/provisioner/src/DataTourismeImporter.php
+++ b/provisioner/src/DataTourismeImporter.php
@@ -200,11 +200,28 @@ final readonly class DataTourismeImporter
     /**
      * Gates the staged flux and promotes what survives into the live schema.
      *
+     * @return bool false when the zone has no registry geometry to clip against, so nothing
+     *              was promoted — a skip, not a failure
+     *
      * @throws ImportFailedException
      */
-    public function finish(string $workDir, string $zoneSlug): void
+    public function finish(string $workDir, string $zoneSlug): bool
     {
         $staging = self::stagingSchema($zoneSlug);
+
+        // The promotion clips to the zone's registry geometry, so with no geometry it would
+        // promote exactly nothing and report success — silently, which is worse than
+        // refusing. That happens when the OSM step failed before writing the registry row,
+        // and also when it succeeded but its clipped extract yielded no boundary at all
+        // (#880). The precondition is therefore the geometry, not the sibling step's exit
+        // code: gating on the OSM outcome would make a failed OSM download also block a
+        // DataTourisme refresh for a zone that is already open, which is precisely the
+        // cross-source coupling ADR-041 forbids.
+        if (!$this->zoneHasGeometry($workDir, $zoneSlug)) {
+            $this->dropStaging($staging);
+
+            return false;
+        }
 
         // The gate runs before promotion here too. The flux names its places far more
         // reliably than OSM does, so this mostly refuses nothing — but the decision must
@@ -212,6 +229,30 @@ final readonly class DataTourismeImporter
         $gate = $this->placeEnrichmentPass->run($workDir, $staging, 'accommodations');
         $this->promote($zoneSlug, $staging, $gate);
         $this->dropStaging($staging);
+
+        return true;
+    }
+
+    /**
+     * Whether the zone has a geometry in the registry to clip the promotion against.
+     *
+     * @throws ImportFailedException
+     */
+    private function zoneHasGeometry(string $workDir, string $zoneSlug): bool
+    {
+        $path = $workDir.'/zone-geometry.tsv';
+        $this->runProcess([
+            'psql', '-v', 'ON_ERROR_STOP=1', '-c',
+            \sprintf(
+                "\\copy (SELECT count(*) FROM osm.zones WHERE slug = %s AND geom IS NOT NULL) TO '%s'",
+                ZonePromotion::literal($zoneSlug),
+                $path,
+            ),
+        ], 'psql check zone geometry');
+
+        $contents = is_file($path) ? file_get_contents($path) : false;
+
+        return \is_string($contents) && 0 < (int) trim($contents);
     }
 
     /**

--- a/provisioner/src/NameResolver.php
+++ b/provisioner/src/NameResolver.php
@@ -17,13 +17,18 @@ namespace Provisioner;
  * data behind it. What is left, and what this implements: `operator` then `brand`, never
  * on `shelter`.
  *
- * Order of the cascade. #884 lists the tag projection before the Wikidata label, ordered
- * "du moins coûteux au plus coûteux" — but by the time this runs, the Wikidata pass has
- * already populated its cache, so both steps cost zero network calls and the cost argument
- * no longer separates them. Quality does: a Wikidata label is the place's own name, while
- * `operator` is whoever runs it ("Commune de Jongieux"). The label therefore comes first.
- * The choice is nearly moot in practice — an unnamed row carrying a Q-ID is rare — which is
- * why it is a stated preference rather than a load-bearing decision.
+ * Order of the cascade, most specific first: a **geometric match against DataTourisme**
+ * (#885) names *this* place from a curated record; a Wikidata label names the entity; then
+ * `operator` and `brand`, which name whoever runs it. #884 ordered these by cost ("du moins
+ * coûteux au plus coûteux"), but by the time this runs both the Wikidata cache and the flux
+ * staging are already loaded, so every step costs zero network calls and the cost argument
+ * no longer separates them. Specificity does.
+ *
+ * The match is where the loop #885 describes gets broken. `App\Geo\NearbyNameDeduplicator`
+ * pairs places at runtime **by name**, so it can never complete a row whose name is missing:
+ * the only information lacking is the one it requires to find the correspondence. At import
+ * there is no such constraint — the full context of both datasets is in hand, and nobody is
+ * waiting — so category plus proximity is enough.
  *
  * `shelter` never reaches this class: it is exempt from the gate (#878 — `shelter_type`, not
  * the name, is what separates a mountain refuge from a bus shelter), so resolving it would
@@ -63,17 +68,33 @@ final readonly class NameResolver
     private const int MIN_LENGTH = 3;
 
     /**
-     * @param array<string, string> $tags          the row's OSM tags, complete as imported
-     * @param string|null           $wikidataLabel label already in provisioner.wikidata_cache for this row's Q-ID
-     * @param string|null           $locality      commune resolved offline from the imported admin_level=8 boundaries (#880)
+     * @param array<string, string>                                                                                                              $tags          the row's OSM tags, complete as imported
+     * @param string|null                                                                                                                        $wikidataLabel label already in provisioner.wikidata_cache for this row's Q-ID
+     * @param string|null                                                                                                                        $locality      commune resolved offline from the imported admin_level=8 boundaries (#880)
+     * @param array{n: int, id: ?string, name: ?string, description: ?string, website: ?string, opening_hours: ?string, distance_m: ?float}|null $match         curated candidates of a compatible category within the match radius (#885)
      *
-     * @return array{name: string, via: string}|array{name: null, via: null, reason: string} the resolved name and which step produced it, or the motive for giving up
+     * @return array{name: string, via: string, description?: string, website?: string, opening_hours?: string, matched_id?: string, distance_m?: float}|array{name: null, via: null, reason: string, candidates?: int} the resolved name plus what came with it, or the motive for giving up
      */
-    public function resolve(string $category, array $tags, ?string $wikidataLabel = null, ?string $locality = null): array
+    public function resolve(string $category, array $tags, ?string $wikidataLabel = null, ?string $locality = null, ?array $match = null): array
     {
         if ('shelter' === $category) {
             // Exempt from the gate, so nothing to resolve; see the class docblock.
             return ['name' => null, 'via' => null, 'reason' => 'shelter_exempt'];
+        }
+
+        if (null !== $match) {
+            $matched = $this->fromMatch($match);
+            if (null !== $matched) {
+                return $matched;
+            }
+
+            // More than one curated candidate in range: refuse rather than pick. Attributing
+            // the wrong name to an accommodation is worse than attributing none — the rider
+            // books elsewhere, or turns up at the wrong place — and nothing here can tell two
+            // neighbouring campsites apart. The gate decides what happens next.
+            if ($match['n'] > 1) {
+                return ['name' => null, 'via' => null, 'reason' => 'ambiguous_match', 'candidates' => $match['n']];
+            }
         }
 
         foreach (['wikidata' => $wikidataLabel, 'operator' => $tags['operator'] ?? null, 'brand' => $tags['brand'] ?? null] as $via => $candidate) {
@@ -86,6 +107,46 @@ final readonly class NameResolver
         }
 
         return ['name' => null, 'via' => null, 'reason' => 'no_usable_name_source'];
+    }
+
+    /**
+     * The single curated candidate's name, with what usefully comes with it, or null when
+     * there is not exactly one usable candidate.
+     *
+     * @param array{n: int, id: ?string, name: ?string, description: ?string, website: ?string, opening_hours: ?string, distance_m: ?float} $match
+     *
+     * @return array{name: string, via: string, description?: string, website?: string, opening_hours?: string, matched_id?: string, distance_m?: float}|null
+     */
+    private function fromMatch(array $match): ?array
+    {
+        if (1 !== $match['n']) {
+            return null;
+        }
+
+        $name = $this->usable($match['name']);
+        if (null === $name) {
+            return null;
+        }
+
+        // No locality qualifier here: a curated record is already named the way the place
+        // presents itself, so appending the commune would only add noise.
+        $resolved = ['name' => $name, 'via' => 'datatourisme'];
+        foreach (['description', 'website', 'opening_hours'] as $field) {
+            $value = $match[$field];
+            if (\is_string($value) && '' !== trim($value)) {
+                $resolved[$field] = trim($value);
+            }
+        }
+
+        if (\is_string($match['id'])) {
+            $resolved['matched_id'] = $match['id'];
+        }
+
+        if (null !== $match['distance_m']) {
+            $resolved['distance_m'] = $match['distance_m'];
+        }
+
+        return $resolved;
     }
 
     /**

--- a/provisioner/src/PlaceEnrichmentPass.php
+++ b/provisioner/src/PlaceEnrichmentPass.php
@@ -41,18 +41,34 @@ final readonly class PlaceEnrichmentPass
     private const string CACHE_TABLE = 'provisioner.place_enrichment';
 
     /**
+     * Radius for the geometric match, in metres.
+     *
+     * Deliberately stricter than the 75 m of `App\Geo\NearbyNameDeduplicator`, whose match
+     * is corroborated by equal names; this one has no name to corroborate it, so geometry is
+     * the only evidence and it has to be stronger. 50 m is the starting point #885 proposes
+     * and it is **not yet justified by a measurement** — the opening report now emits the
+     * match and ambiguity counts precisely so the first real provisioning run produces the
+     * numbers that will confirm or move it.
+     */
+    public const int DEFAULT_MATCH_RADIUS_METERS = 50;
+
+    /**
      * @var \Closure(list<string>): Process
      */
     private \Closure $processFactory;
 
     /**
-     * @param string       $source           cache partition, also the report label ('osm', 'datatourisme')
-     * @param string       $identity         SQL expression identifying a row `a` of the target table
-     * @param list<string> $exemptCategories categories the gate does not apply to, and which are therefore
-     *                                       not resolved either (`shelter`, arbitrated by #878)
-     * @param string|null  $boundariesSchema schema holding `admin_boundaries` for the offline locality
-     *                                       lookup; null uses the staging schema, which is where the zone
-     *                                       being opened has its own freshly imported boundaries
+     * @param string       $source            cache partition, also the report label ('osm', 'datatourisme')
+     * @param string       $identity          SQL expression identifying a row `a` of the target table
+     * @param list<string> $exemptCategories  categories the gate does not apply to, and which are therefore
+     *                                        not resolved either (`shelter`, arbitrated by #878)
+     * @param string|null  $boundariesSchema  schema holding `admin_boundaries` for the offline locality
+     *                                        lookup; null uses the staging schema, which is where the zone
+     *                                        being opened has its own freshly imported boundaries
+     * @param string|null  $matchTable        qualified table of curated places to match unnamed rows against
+     *                                        (`<tourism staging>.accommodations`); null disables matching
+     * @param int          $matchRadiusMeters strictly under the runtime deduplicator's 75 m: this match has no
+     *                                        name to corroborate it, so it must be geometrically tighter
      */
     public function __construct(
         private string $source,
@@ -62,12 +78,14 @@ final readonly class PlaceEnrichmentPass
         ?\Closure $processFactory = null,
         private NameResolver $resolver = new NameResolver(),
         private float $timeoutSeconds = 1800.0,
+        private ?string $matchTable = null,
+        private int $matchRadiusMeters = self::DEFAULT_MATCH_RADIUS_METERS,
     ) {
         $this->processFactory = $processFactory ?? static fn (array $command): Process => new Process($command);
     }
 
     /**
-     * @return array{resolved: int, rejected: int, reasons: array<string, int>}
+     * @return array{resolved: int, rejected: int, matched: int, ambiguous: int, reasons: array<string, int>}
      *
      * @throws ImportFailedException
      */
@@ -88,7 +106,7 @@ final readonly class PlaceEnrichmentPass
         $this->psql($this->exportCandidates($stagingSchema, $table, $candidatesPath), 'psql export name candidates');
 
         $decisions = $this->resolveAll($candidatesPath);
-        $counts = ['resolved' => 0, 'rejected' => 0, 'reasons' => []];
+        $counts = ['resolved' => 0, 'rejected' => 0, 'matched' => 0, 'ambiguous' => 0, 'reasons' => []];
 
         if ([] !== $decisions) {
             $copyPath = $workDir.'/place-resolved.copy';
@@ -121,9 +139,11 @@ final readonly class PlaceEnrichmentPass
             ), 'psql upsert place enrichment cache');
         }
 
-        // COALESCE only: completion, never rewriting (ADR-049 §4).
+        // COALESCE only: completion, never rewriting (ADR-049 §4). A matched DataTourisme
+        // record brings its description, site and hours along with the name (#885), under the
+        // same rule — so an OSM value that exists always wins.
         $this->psql(\sprintf(
-            "UPDATE %1\$s.%2\$s a SET name = COALESCE(a.name, c.payload->>'name') FROM %3\$s c WHERE c.source = %4\$s AND c.source_id = %5\$s AND c.status = 'resolved';",
+            "UPDATE %1\$s.%2\$s a SET name = COALESCE(a.name, c.payload->>'name'), description = COALESCE(a.description, c.payload->>'description'), website = COALESCE(a.website, c.payload->>'website'), opening_hours = COALESCE(a.opening_hours, c.payload->>'opening_hours') FROM %3\$s c WHERE c.source = %4\$s AND c.source_id = %5\$s AND c.status = 'resolved';",
             $stagingSchema,
             $table,
             self::CACHE_TABLE,
@@ -155,10 +175,18 @@ final readonly class PlaceEnrichmentPass
         foreach ($decisions as $decision) {
             if ('resolved' === $decision['status']) {
                 ++$counts['resolved'];
+                if ('datatourisme' === $decision['via']) {
+                    ++$counts['matched'];
+                }
+
                 continue;
             }
 
             $reason = $decision['reason'];
+            if ('ambiguous_match' === $reason) {
+                ++$counts['ambiguous'];
+            }
+
             $counts['reasons'][$reason] = ($counts['reasons'][$reason] ?? 0) + 1;
         }
 
@@ -182,7 +210,8 @@ final readonly class PlaceEnrichmentPass
                               a.category,
                               coalesce(a.tags::text, '{}'),
                               coalesce(w.payload->>'label', ''),
-                              coalesce((SELECT b.name FROM %2$s b WHERE b.admin_level = 8 AND ST_Covers(b.geom, a.geom) LIMIT 1), '')
+                              coalesce((SELECT b.name FROM %2$s b WHERE b.admin_level = 8 AND ST_Covers(b.geom, a.geom) LIMIT 1), ''),
+                              %10$s
                          FROM %3$s.%4$s a
                          LEFT JOIN provisioner.wikidata_cache w ON w.qid = a.wikidata
                         WHERE nullif(btrim(a.name), '') IS NULL
@@ -198,6 +227,44 @@ final readonly class PlaceEnrichmentPass
             $this->literal($this->source),
             NameResolver::VERSION,
             $path,
+            $this->matchExpression(),
+        );
+    }
+
+    /**
+     * The curated candidates within the radius, as one jsonb: how many there are, and the
+     * single one's fields (`min()` over one row is that row).
+     *
+     * The count is what makes the conservative behaviour possible. Attributing the wrong name
+     * to an accommodation is worse than attributing none — the rider books elsewhere, or turns
+     * up at the wrong place — so two candidates produce a rejection rather than a pick, and the
+     * resolver is never handed a reason to choose between them.
+     *
+     * Category equality is the compatibility rule: both sides use the same vocabulary, and a
+     * looser rule is exactly how a hotel would inherit its restaurant's name.
+     */
+    private function matchExpression(): string
+    {
+        if (null === $this->matchTable) {
+            return "'{}'";
+        }
+
+        return \sprintf(
+            <<<'SQL'
+                coalesce((SELECT jsonb_build_object(
+                                   'n', count(*),
+                                   'id', min(t.id),
+                                   'name', min(t.name),
+                                   'description', min(t.description),
+                                   'website', min(t.website),
+                                   'opening_hours', min(t.opening_hours),
+                                   'distance_m', round(min(ST_Distance(t.geom::geography, a.geom::geography))::numeric, 1))
+                            FROM %1$s t
+                           WHERE t.category = a.category
+                             AND ST_DWithin(t.geom::geography, a.geom::geography, %2$d))::text, '{}')
+                SQL,
+            $this->matchTable,
+            $this->matchRadiusMeters,
         );
     }
 
@@ -222,39 +289,76 @@ final readonly class PlaceEnrichmentPass
     }
 
     /**
-     * @return list<array{source_id: string, payload: string, status: string, reason: string}>
+     * @return list<array{source_id: string, payload: string, status: string, via: string, reason: string}>
      */
     private function resolveAll(string $path): array
     {
         $decisions = [];
         foreach ($this->readLines($path) as $line) {
             $fields = explode("\t", $line);
-            if (5 !== \count($fields)) {
+            if (6 !== \count($fields)) {
                 continue;
             }
 
-            [$sourceId, $category, $tagsJson, $wikidataLabel, $locality] = $fields;
+            [$sourceId, $category, $tagsJson, $wikidataLabel, $locality, $matchJson] = $fields;
             $decision = $this->resolver->resolve(
                 $category,
                 $this->decodeTags($tagsJson),
                 '' === $wikidataLabel ? null : $wikidataLabel,
                 '' === $locality ? null : $locality,
+                $this->decodeMatch($matchJson),
             );
 
             $resolved = null !== $decision['name'];
+            // The payload is the audit trail #885 asks for: which step produced the name, and
+            // for a geometric match the record it came from and how far away it was. A
+            // rejection records how many candidates made it ambiguous.
             $payload = $resolved
-                ? ['name' => $decision['name'], 'via' => $decision['via']]
-                : ['reason' => $decision['reason'] ?? 'unknown'];
+                ? array_filter([
+                    'name' => $decision['name'],
+                    'via' => $decision['via'],
+                    'description' => $decision['description'] ?? null,
+                    'website' => $decision['website'] ?? null,
+                    'opening_hours' => $decision['opening_hours'] ?? null,
+                    'matched_id' => $decision['matched_id'] ?? null,
+                    'distance_m' => $decision['distance_m'] ?? null,
+                ], static fn (mixed $value): bool => null !== $value)
+                : array_filter([
+                    'reason' => $decision['reason'] ?? 'unknown',
+                    'candidates' => $decision['candidates'] ?? null,
+                ], static fn (mixed $value): bool => null !== $value);
 
             $decisions[] = [
                 'source_id' => $sourceId,
                 'payload' => json_encode($payload, \JSON_UNESCAPED_UNICODE | \JSON_UNESCAPED_SLASHES) ?: '{}',
                 'status' => $resolved ? 'resolved' : 'insufficient',
+                'via' => $resolved ? (string) $decision['via'] : '',
                 'reason' => $resolved ? '' : ($decision['reason'] ?? 'unknown'),
             ];
         }
 
         return $decisions;
+    }
+
+    /**
+     * @return array{n: int, id: ?string, name: ?string, description: ?string, website: ?string, opening_hours: ?string, distance_m: ?float}|null null when matching is off or nothing was in range
+     */
+    private function decodeMatch(string $json): ?array
+    {
+        $decoded = json_decode(str_replace(['\\t', '\\n', '\\r', '\\\\'], ["\t", "\n", "\r", '\\'], $json), true);
+        if (!\is_array($decoded) || !isset($decoded['n']) || !is_numeric($decoded['n']) || 0 === (int) $decoded['n']) {
+            return null;
+        }
+
+        return [
+            'n' => (int) $decoded['n'],
+            'id' => \is_string($decoded['id'] ?? null) ? $decoded['id'] : null,
+            'name' => \is_string($decoded['name'] ?? null) ? $decoded['name'] : null,
+            'description' => \is_string($decoded['description'] ?? null) ? $decoded['description'] : null,
+            'website' => \is_string($decoded['website'] ?? null) ? $decoded['website'] : null,
+            'opening_hours' => \is_string($decoded['opening_hours'] ?? null) ? $decoded['opening_hours'] : null,
+            'distance_m' => is_numeric($decoded['distance_m'] ?? null) ? (float) $decoded['distance_m'] : null,
+        ];
     }
 
     /**

--- a/provisioner/src/PostgisImporter.php
+++ b/provisioner/src/PostgisImporter.php
@@ -167,8 +167,6 @@ final readonly class PostgisImporter
 
     private WikidataEnrichmentPass $enrichmentPass;
 
-    private PlaceEnrichmentPass $placeEnrichmentPass;
-
     private ZonePromotion $promotion;
 
     /**
@@ -186,15 +184,6 @@ final readonly class PostgisImporter
     ) {
         $this->processFactory = $processFactory ?? static fn (array $command): Process => new Process($command);
         $this->enrichmentPass = new WikidataEnrichmentPass($this->processFactory, $enricher, $locale, $cacheTtlDays, $this->timeoutSeconds);
-        // Boundaries come from the staging schema: the zone being opened has just imported
-        // its own, and they are the ones covering its places (#880).
-        $this->placeEnrichmentPass = new PlaceEnrichmentPass(
-            source: 'osm',
-            identity: "a.osm_type || '/' || a.osm_id",
-            exemptCategories: self::GATE_EXEMPT_CATEGORIES,
-            processFactory: $this->processFactory,
-            timeoutSeconds: $this->timeoutSeconds,
-        );
         $this->promotion = new ZonePromotion('osm', $this->liveSchema, self::FEATURE_TABLES);
     }
 
@@ -215,7 +204,7 @@ final readonly class PostgisImporter
      *
      * @throws ImportFailedException
      */
-    public function run(string $zoneSlug, string $zoneName, string $countrySlug, string $regionPbf, string $filteredPbf): void
+    public function run(string $zoneSlug, string $zoneName, string $countrySlug, string $regionPbf, string $filteredPbf, ?string $curatedTable = null): void
     {
         $staging = self::stagingSchema($zoneSlug);
 
@@ -227,7 +216,7 @@ final readonly class PostgisImporter
         $this->enrichmentPass->run(\dirname($filteredPbf), $staging, self::WIKIDATA_TABLES);
         // Names are resolved and the completeness gate applied *before* promotion, so the
         // gate decides once and the live CHECK only ever fires on a bug here (#884).
-        $gate = $this->placeEnrichmentPass->run(\dirname($filteredPbf), $staging, 'accommodations');
+        $gate = $this->placeEnrichmentPass($curatedTable)->run(\dirname($filteredPbf), $staging, 'accommodations');
         $this->promote($zoneSlug, $zoneName, $countrySlug, $staging, $gate);
         $this->dropStaging($staging);
     }
@@ -269,6 +258,28 @@ final readonly class PostgisImporter
     }
 
     /**
+     * The name-resolution + gate pass, built per run because its curated match table depends
+     * on the zone being opened.
+     *
+     * Boundaries come from the staging schema: the zone has just imported its own, and they
+     * are the ones covering its places (#880). `$curatedTable` is the DataTourisme staging
+     * table when the flux was staged for this run, which is what lets an anonymous OSM
+     * accommodation borrow a name from the curated source (#885); null when DataTourisme is
+     * not configured, in which case the resolver simply has one fewer step.
+     */
+    private function placeEnrichmentPass(?string $curatedTable): PlaceEnrichmentPass
+    {
+        return new PlaceEnrichmentPass(
+            source: 'osm',
+            identity: "a.osm_type || '/' || a.osm_id",
+            exemptCategories: self::GATE_EXEMPT_CATEGORIES,
+            processFactory: $this->processFactory,
+            timeoutSeconds: $this->timeoutSeconds,
+            matchTable: $curatedTable,
+        );
+    }
+
+    /**
      * Promotes the zone's staging tables into the live schema in one transaction, and
      * with them everything derived from the live state: the registry row (its geometry
      * being the union of the boundaries this extract actually yielded), the coverage
@@ -280,7 +291,7 @@ final readonly class PostgisImporter
      * build contributes the levels that did (#880) — and a zone that yielded no boundary
      * at all keeps whatever geometry a previous run recorded rather than losing it.
      *
-     * @param array{resolved?: int, rejected?: int, reasons?: array<string, int>} $gate what the completeness gate resolved and refused, recorded in the metadata
+     * @param array{resolved?: int, rejected?: int, matched?: int, ambiguous?: int, reasons?: array<string, int>} $gate what the completeness gate resolved and refused, recorded in the metadata
      *
      * @throws ImportFailedException
      */
@@ -344,7 +355,7 @@ final readonly class PostgisImporter
      * completeness gate refused and why. Empty when the gate did not run (a direct
      * {@see promote()} call in a test), which reads the same as "nothing was refused".
      *
-     * @param array{resolved?: int, rejected?: int, reasons?: array<string, int>} $gate
+     * @param array{resolved?: int, rejected?: int, matched?: int, ambiguous?: int, reasons?: array<string, int>} $gate
      */
     private function rejectionsExpression(array $gate): string
     {
@@ -355,6 +366,11 @@ final readonly class PostgisImporter
         $payload = [
             'accommodation_incomplete' => $gate['rejected'] ?? 0,
             'accommodation_name_resolved' => $gate['resolved'] ?? 0,
+            // The measurement #885 asks for, emitted by every run rather than produced once:
+            // how many anonymous rows the curated source actually named, and how many matches
+            // were refused as ambiguous. Those two numbers are what justify or move the radius.
+            'accommodation_matched_from_datatourisme' => $gate['matched'] ?? 0,
+            'accommodation_ambiguous_matches' => $gate['ambiguous'] ?? 0,
             'accommodation_incomplete_reasons' => $gate['reasons'] ?? [],
         ];
 

--- a/provisioner/src/ProvisionCommand.php
+++ b/provisioner/src/ProvisionCommand.php
@@ -132,10 +132,31 @@ final class ProvisionCommand extends Command
             // Outcomes are aggregated into the final exit code.
             $outcomes = [];
 
-            $outcomes['osm'] = $this->runOsm($io, $zone, $dryRun);
+            // DataTourisme is staged *before* the OSM import and promoted *after* it (#885).
+            // The flux is the curated source — not one of its 124 240 accommodations has an
+            // empty name — so the OSM gate must be able to borrow a name from it, which means
+            // having it in hand before deciding what to reject. Promotion still comes last,
+            // because it clips to the zone geometry only the OSM import produces. A staging
+            // failure degrades that source alone: OSM then runs with one fewer resolver step.
+            // Resolved once and reused for both halves: the unmapped-subtype count is
+            // accumulated by the mapper while staging and read after promoting, so a second
+            // instance would report zero.
+            $curated = $dryRun ? null : $this->resolveDataTourismeImporter($io);
+            $curatedTable = null;
+            $curatedOutcome = Command::SUCCESS;
+
+            if ($curated instanceof DataTourismeImporter) {
+                [$curatedOutcome, $curatedTable] = $this->stageDataTourisme($io, $curated, $zone['slug']);
+            }
+
+            $outcomes['osm'] = $this->runOsm($io, $zone, $dryRun, $curatedTable);
+
+            if ($curated instanceof DataTourismeImporter && Command::SUCCESS === $curatedOutcome) {
+                $curatedOutcome = $this->finishDataTourisme($io, $curated, $zone['slug']);
+            }
 
             if (!$dryRun) {
-                $outcomes['datatourisme'] = $this->runDataTourisme($io, $zone['slug']);
+                $outcomes['datatourisme'] = $curatedOutcome;
                 $this->reportPromotion($io, $zone['slug']);
             }
 
@@ -283,35 +304,65 @@ final class ProvisionCommand extends Command
         @file_put_contents($this->logFile, $line, \FILE_APPEND);
     }
 
-    private function runDataTourisme(SymfonyStyle $io, string $zoneSlug): int
+    /**
+     * Downloads and stages the flux, without promoting it.
+     *
+     * @return array{0: int, 1: string|null} exit code, and the staged accommodation table the
+     *                                       OSM gate can match against (null when there is none)
+     */
+    private function stageDataTourisme(SymfonyStyle $io, DataTourismeImporter $importer, string $zoneSlug): array
     {
-        $importer = $this->dataTourismeImporter;
-        if (!$importer instanceof DataTourismeImporter) {
-            $fluxId = getenv('DATATOURISME_FLUX_ID') ?: '';
-            $appKey = getenv('DATATOURISME_APP_KEY') ?: '';
-            if ('' === $fluxId || '' === $appKey) {
-                // Skip gracefully when DataTourisme is not configured: OSM is the
-                // primary source and must still provision (ADR-041 continue-on-error).
-                $io->warning('DataTourisme import skipped: DATATOURISME_FLUX_ID and DATATOURISME_APP_KEY are not set.');
-
-                return Command::SUCCESS;
-            }
-
-            $importer = new DataTourismeImporter(
-                \sprintf('https://diffuseur.datatourisme.fr/webservice/%s/%s', $fluxId, $appKey),
-            );
-        }
-
         if (!is_dir($this->dataTourismeDir) && !mkdir($this->dataTourismeDir, 0o755, true) && !is_dir($this->dataTourismeDir)) {
             $io->error(\sprintf('Cannot create DataTourisme work directory "%s"', $this->dataTourismeDir));
 
-            return Command::FAILURE;
+            return [Command::FAILURE, null];
         }
 
-        $io->section('Importing DataTourisme into PostGIS');
+        $io->section('Staging the DataTourisme flux');
 
         try {
-            $importer->run($this->dataTourismeDir, $zoneSlug);
+            $staging = $importer->stage($this->dataTourismeDir, $zoneSlug);
+        } catch (ImportFailedException $importFailedException) {
+            $this->fail($io, $importFailedException->getMessage());
+
+            return [Command::FAILURE, null];
+        }
+
+        $io->writeln('  Staged; the OSM gate can now borrow names from it.');
+
+        return [Command::SUCCESS, $staging.'.accommodations'];
+    }
+
+    /**
+     * The configured importer, or null when DataTourisme is not set up — in which case OSM is
+     * the primary source and must still provision (ADR-041 continue-on-error), with one fewer
+     * resolver step.
+     */
+    private function resolveDataTourismeImporter(SymfonyStyle $io): ?DataTourismeImporter
+    {
+        if ($this->dataTourismeImporter instanceof DataTourismeImporter) {
+            return $this->dataTourismeImporter;
+        }
+
+        $fluxId = getenv('DATATOURISME_FLUX_ID') ?: '';
+        $appKey = getenv('DATATOURISME_APP_KEY') ?: '';
+        if ('' === $fluxId || '' === $appKey) {
+            $io->warning('DataTourisme import skipped: DATATOURISME_FLUX_ID and DATATOURISME_APP_KEY are not set.');
+
+            return null;
+        }
+
+        return new DataTourismeImporter(
+            \sprintf('https://diffuseur.datatourisme.fr/webservice/%s/%s', $fluxId, $appKey),
+        );
+    }
+
+    private function finishDataTourisme(SymfonyStyle $io, DataTourismeImporter $importer, string $zoneSlug): int
+    {
+        $io->section('Promoting DataTourisme into PostGIS');
+
+        try {
+            $importer->finish($this->dataTourismeDir, $zoneSlug);
         } catch (ImportFailedException $importFailedException) {
             $this->fail($io, $importFailedException->getMessage());
 
@@ -328,7 +379,7 @@ final class ProvisionCommand extends Command
     /**
      * @param array{name: string, slug: string, size: string, country: string} $zone
      */
-    private function runOsm(SymfonyStyle $io, array $zone, bool $dryRun): int
+    private function runOsm(SymfonyStyle $io, array $zone, bool $dryRun, ?string $curatedTable = null): int
     {
         $io->section(\sprintf('Opening zone %s (%s, %s)', $zone['name'], $zone['slug'], $zone['size']));
 
@@ -368,7 +419,7 @@ final class ProvisionCommand extends Command
         $io->write('  Importing Tier-1 features into PostGIS... ');
 
         try {
-            $this->postgisImporter->run($zone['slug'], $zone['name'], $zone['country'], $targetPath, $this->filteredPbf);
+            $this->postgisImporter->run($zone['slug'], $zone['name'], $zone['country'], $targetPath, $this->filteredPbf, $curatedTable);
         } catch (ImportFailedException $importFailedException) {
             $io->newLine();
             $this->fail($io, $importFailedException->getMessage());

--- a/provisioner/src/ProvisionCommand.php
+++ b/provisioner/src/ProvisionCommand.php
@@ -151,6 +151,10 @@ final class ProvisionCommand extends Command
 
             $outcomes['osm'] = $this->runOsm($io, $zone, $dryRun, $curatedTable);
 
+            // Deliberately not gated on $outcomes['osm']: a failed OSM refresh must not block a
+            // DataTourisme refresh for a zone that is already open (ADR-041). The real
+            // precondition — a registry geometry to clip against — is checked by finish()
+            // itself, which skips rather than promoting nothing and calling it a success.
             if ($curated instanceof DataTourismeImporter && Command::SUCCESS === $curatedOutcome) {
                 $curatedOutcome = $this->finishDataTourisme($io, $curated, $zone['slug']);
             }
@@ -362,11 +366,22 @@ final class ProvisionCommand extends Command
         $io->section('Promoting DataTourisme into PostGIS');
 
         try {
-            $importer->finish($this->dataTourismeDir, $zoneSlug);
+            $promoted = $importer->finish($this->dataTourismeDir, $zoneSlug);
         } catch (ImportFailedException $importFailedException) {
             $this->fail($io, $importFailedException->getMessage());
 
             return Command::FAILURE;
+        }
+
+        if (!$promoted) {
+            // No registry geometry to clip against, so there was nothing to promote into. A
+            // skip, not a failure: the flux is national and the next opening of this zone
+            // re-downloads it anyway.
+            $message = 'DataTourisme promotion skipped: the zone has no registry geometry to clip against, so the OSM step did not complete.';
+            $io->warning($message);
+            $this->logLine('INFO', $message);
+
+            return Command::SUCCESS;
         }
 
         $unmapped = $importer->unmappedAccommodationCount();

--- a/provisioner/tests/DataTourismeImporterTest.php
+++ b/provisioner/tests/DataTourismeImporterTest.php
@@ -148,14 +148,14 @@ final class DataTourismeImporterTest extends TestCase
 
         $importer->run($this->workDir, 'bretagne');
 
-        // 1 staging DDL + 4 \copy + 4 GIST index
+        // 1 staging DDL + 4 \copy + 4 GIST index + 1 geography index on accommodations
         // + 7 Wikidata-pass psql calls (prepare, collect, export, one UPDATE per Wikidata
         // table, drop; no Q-IDs to fetch in this fixture)
         // + 1 zone-geometry precondition read (#885: no geometry, no promotion)
         // + 6 name-resolution psql calls (prepare, export candidates, apply, count gated,
         // gate, drop scratch; nothing to resolve in this fixture, so no cache write)
         // + 1 report DDL + 1 promotion + 1 staging drop.
-        self::assertCount(26, $this->captured);
+        self::assertCount(27, $this->captured);
 
         $ddl = implode(' ', $this->captured[0]);
         self::assertStringContainsString('CREATE SCHEMA tourism_staging_bretagne', $ddl);
@@ -182,6 +182,28 @@ final class DataTourismeImporterTest extends TestCase
             self::assertStringNotContainsString('DROP SCHEMA IF EXISTS tourism CASCADE', $command);
             self::assertStringNotContainsString('RENAME TO tourism', $command);
         }
+    }
+
+    #[Test]
+    public function stagesAGeographyIndexForTheGeometricMatch(): void
+    {
+        // The match of #885 filters on `ST_DWithin(t.geom::geography, …)`, and a cast makes the
+        // plain `geom` GiST index unusable: measured on 40 000 rows, the plan is a Seq Scan
+        // without this index and an Index Scan with it. Without it the correlated subquery
+        // scans every staged accommodation once per unnamed OSM row.
+        $importer = new DataTourismeImporter(
+            fluxUrl: 'https://diffuseur.datatourisme.fr/webservice/flux/key',
+            httpClient: new MockHttpClient(new MockResponse($this->fluxZipBytes())),
+            processFactory: $this->capturingFactory(),
+        );
+
+        $importer->run($this->workDir, 'bretagne');
+
+        $joined = array_map(static fn (array $c): string => implode(' ', $c), $this->captured);
+        $geographyIndexes = array_values(array_filter($joined, static fn (string $c): bool => str_contains($c, 'USING gist ((geom::geography))')));
+
+        self::assertCount(1, $geographyIndexes, 'only the matched table pays for the extra index');
+        self::assertStringContainsString('tourism_staging_bretagne.accommodations', $geographyIndexes[0]);
     }
 
     #[Test]

--- a/provisioner/tests/DataTourismeImporterTest.php
+++ b/provisioner/tests/DataTourismeImporterTest.php
@@ -120,10 +120,15 @@ final class DataTourismeImporterTest extends TestCase
             $cmd = $command;
             $this->captured[] = $cmd;
 
-            // Emulate psql exporting the missing Q-IDs (the enrichment pass reads
-            // this file back); the no-op `true` process never writes it itself.
-            if ([] !== $missingQids && 1 === preg_match("/TO '([^']+)'/", implode(' ', $cmd), $matches)) {
-                file_put_contents($matches[1], implode("\n", $missingQids)."\n");
+            // Emulate psql exporting files the passes read back; the no-op `true` process
+            // never writes them itself.
+            if (1 === preg_match("/TO '([^']+)'/", implode(' ', $cmd), $matches)) {
+                if (str_contains($matches[1], 'zone-geometry')) {
+                    // The zone is open, so the promotion has a geometry to clip against.
+                    file_put_contents($matches[1], "1\n");
+                } elseif ([] !== $missingQids) {
+                    file_put_contents($matches[1], implode("\n", $missingQids)."\n");
+                }
             }
 
             return new Process(['true']);
@@ -146,10 +151,11 @@ final class DataTourismeImporterTest extends TestCase
         // 1 staging DDL + 4 \copy + 4 GIST index
         // + 7 Wikidata-pass psql calls (prepare, collect, export, one UPDATE per Wikidata
         // table, drop; no Q-IDs to fetch in this fixture)
+        // + 1 zone-geometry precondition read (#885: no geometry, no promotion)
         // + 6 name-resolution psql calls (prepare, export candidates, apply, count gated,
         // gate, drop scratch; nothing to resolve in this fixture, so no cache write)
         // + 1 report DDL + 1 promotion + 1 staging drop.
-        self::assertCount(25, $this->captured);
+        self::assertCount(26, $this->captured);
 
         $ddl = implode(' ', $this->captured[0]);
         self::assertStringContainsString('CREATE SCHEMA tourism_staging_bretagne', $ddl);

--- a/provisioner/tests/NameResolverTest.php
+++ b/provisioner/tests/NameResolverTest.php
@@ -132,6 +132,111 @@ final class NameResolverTest extends TestCase
         self::assertSame('no_usable_name_source', $resolved['reason']);
     }
 
+    /**
+     * @return array{n: int, id: ?string, name: ?string, description: ?string, website: ?string, opening_hours: ?string, distance_m: ?float}
+     */
+    private function curated(int $n = 1, ?string $name = 'Camping du Moulin'): array
+    {
+        return [
+            'n' => $n,
+            'id' => 'FR-123',
+            'name' => $name,
+            'description' => 'Au bord de la riviere',
+            'website' => 'https://moulin.test',
+            'opening_hours' => 'Apr-Oct',
+            'distance_m' => 12.4,
+        ];
+    }
+
+    #[Test]
+    public function namesAnAnonymousEntryFromASingleCuratedMatch(): void
+    {
+        // The nominal case of #885, and the loop it breaks: the runtime deduplicator matches
+        // by name, so it can never complete a row whose name is missing.
+        $resolved = $this->resolver->resolve('camp_site', [], null, null, $this->curated());
+
+        self::assertSame('Camping du Moulin', $resolved['name']);
+        self::assertSame('datatourisme', $resolved['via']);
+        self::assertSame('Au bord de la riviere', $resolved['description'] ?? null);
+        self::assertSame('https://moulin.test', $resolved['website'] ?? null);
+        self::assertSame('Apr-Oct', $resolved['opening_hours'] ?? null);
+        // Traceable for audit: the record it came from and how far away it was.
+        self::assertSame('FR-123', $resolved['matched_id'] ?? null);
+        self::assertSame(12.4, $resolved['distance_m'] ?? null);
+    }
+
+    #[Test]
+    public function preferstheCuratedMatchOverEveryTagAndTheWikidataLabel(): void
+    {
+        // Most specific first: a curated record names *this* place, a Wikidata label names the
+        // entity, `operator` names whoever runs it.
+        $resolved = $this->resolver->resolve(
+            'camp_site',
+            ['operator' => 'Commune de Sarlat', 'brand' => 'Huttopia'],
+            'Camping de Sarlat',
+            null,
+            $this->curated(),
+        );
+
+        self::assertSame('Camping du Moulin', $resolved['name']);
+        self::assertSame('datatourisme', $resolved['via']);
+    }
+
+    #[Test]
+    public function refusesRatherThanChoosingBetweenTwoCuratedCandidates(): void
+    {
+        // Two neighbouring campsites, or a hotel and its restaurant at one address. A wrong
+        // name is worse than no name: the rider books elsewhere, or turns up at the wrong
+        // place. So the ambiguity is a rejection, not a pick — and it does *not* fall through
+        // to the tags either, because proximity already said this row is contested.
+        $resolved = $this->resolver->resolve('camp_site', ['operator' => 'Commune de Sarlat'], null, null, $this->curated(n: 2));
+
+        self::assertNull($resolved['name']);
+        self::assertSame('ambiguous_match', $resolved['reason']);
+        self::assertSame(2, $resolved['candidates'] ?? null);
+    }
+
+    #[Test]
+    public function fallsThroughToTheTagsWhenNothingWasInRange(): void
+    {
+        // Nothing in range is not ambiguity: the cascade carries on.
+        $resolved = $this->resolver->resolve('camp_site', ['operator' => 'Commune de Jongieux']);
+
+        self::assertSame('Commune de Jongieux', $resolved['name']);
+        self::assertSame('operator', $resolved['via']);
+    }
+
+    #[Test]
+    public function ignoresACuratedCandidateWhoseOwnNameIsNotUsable(): void
+    {
+        // The flux has no empty names today, but a value that is a tag rather than a name gets
+        // the same treatment here as anywhere else, and the cascade carries on.
+        $resolved = $this->resolver->resolve('camp_site', ['brand' => 'Huttopia'], null, null, $this->curated(name: 'yes'));
+
+        self::assertSame('Huttopia', $resolved['name']);
+        self::assertSame('brand', $resolved['via']);
+    }
+
+    #[Test]
+    public function doesNotQualifyACuratedNameWithTheLocality(): void
+    {
+        // A curated record is already named the way the place presents itself; appending the
+        // commune would only add noise.
+        $resolved = $this->resolver->resolve('camp_site', [], null, 'Sarlat', $this->curated());
+
+        self::assertSame('Camping du Moulin', $resolved['name']);
+    }
+
+    #[Test]
+    public function neverMatchesAShelter(): void
+    {
+        // Exempt from the gate, so it is never resolved — by a match no more than by a tag.
+        $resolved = $this->resolver->resolve('shelter', [], null, null, $this->curated());
+
+        self::assertNull($resolved['name']);
+        self::assertSame('shelter_exempt', $resolved['reason']);
+    }
+
     #[Test]
     public function versionIsAnIntegerCallersCanCompare(): void
     {

--- a/provisioner/tests/PlaceEnrichmentPassTest.php
+++ b/provisioner/tests/PlaceEnrichmentPassTest.php
@@ -43,7 +43,7 @@ final class PlaceEnrichmentPassTest extends TestCase
      * @param list<string> $candidateLines rows the export hands back, tab-separated:
      *                                     source_id, category, tags json, wikidata label, locality
      */
-    private function pass(array $candidateLines = [], string $rejectedCount = '0'): PlaceEnrichmentPass
+    private function pass(array $candidateLines = [], string $rejectedCount = '0', ?string $matchTable = null): PlaceEnrichmentPass
     {
         return new PlaceEnrichmentPass(
             source: 'osm',
@@ -66,6 +66,7 @@ final class PlaceEnrichmentPassTest extends TestCase
 
                 return new Process(['true']);
             },
+            matchTable: $matchTable,
         );
     }
 
@@ -144,7 +145,7 @@ final class PlaceEnrichmentPassTest extends TestCase
     public function resolvesAnOperatorIntoANameAndCachesIt(): void
     {
         $counts = $this->pass([
-            "N/1\tcamp_site\t{\"operator\": \"Commune de Jongieux\"}\t\tJongieux",
+            "N/1\tcamp_site\t{\"operator\": \"Commune de Jongieux\"}\t\tJongieux\t{}",
         ])->run($this->workDir, 'osm_staging_bretagne', 'accommodations');
 
         self::assertSame(1, $counts['resolved']);
@@ -164,7 +165,7 @@ final class PlaceEnrichmentPassTest extends TestCase
         // The negative cache: without it a re-opening would re-resolve every hopeless row,
         // and a later resolver could never tell which rows to reconsider.
         $counts = $this->pass([
-            "N/2\tguest_house\t{\"building\": \"yes\"}\t\t",
+            "N/2\tguest_house\t{\"building\": \"yes\"}\t\t\t{}",
         ])->run($this->workDir, 'osm_staging_bretagne', 'accommodations');
 
         self::assertSame(0, $counts['resolved']);
@@ -260,6 +261,125 @@ final class PlaceEnrichmentPassTest extends TestCase
         // No exemption on this side: every flux accommodation category is bookable.
         self::assertStringContainsString('AND true', $export);
         self::assertStringNotContainsString('NOT IN (', $export);
+    }
+
+    #[Test]
+    public function matchingIsOffUnlessACuratedTableIsGiven(): void
+    {
+        // DataTourisme may not be configured at all, and the OSM import must still run — with
+        // one fewer resolver step, not with a broken query.
+        $this->pass()->run($this->workDir, 'osm_staging_bretagne', 'accommodations');
+
+        $export = $this->sqlContaining('place-candidates.tsv');
+        self::assertStringNotContainsString('ST_DWithin', $export);
+        // Six columns either way, the last a constant, so the reader's field count is stable.
+        self::assertSame(1, preg_match("/LIMIT 1\), ''\),\s+'\{\}'/", $export), 'a constant stands in for the match');
+    }
+
+    #[Test]
+    public function matchesOnCategoryAndProximityAlone(): void
+    {
+        // The loop #885 breaks: the runtime deduplicator pairs places *by name*, so it can
+        // never complete a row whose name is missing. At import, category plus proximity is
+        // enough — and the radius is tighter than the runtime's 75 m precisely because there
+        // is no name to corroborate the match.
+        $this->pass(matchTable: 'tourism_staging_bretagne.accommodations')
+            ->run($this->workDir, 'osm_staging_bretagne', 'accommodations');
+
+        $export = $this->sqlContaining('place-candidates.tsv');
+        self::assertStringContainsString('FROM tourism_staging_bretagne.accommodations t', $export);
+        self::assertStringContainsString('WHERE t.category = a.category', $export);
+        self::assertStringContainsString(\sprintf('ST_DWithin(t.geom::geography, a.geom::geography, %d)', PlaceEnrichmentPass::DEFAULT_MATCH_RADIUS_METERS), $export);
+        self::assertLessThan(75, PlaceEnrichmentPass::DEFAULT_MATCH_RADIUS_METERS, 'stricter than NearbyNameDeduplicator, which has equal names to corroborate it');
+        // The count travels with the payload, which is what makes the ambiguity check possible
+        // without a second query.
+        self::assertStringContainsString("'n', count(*)", $export);
+    }
+
+    #[Test]
+    public function inheritsTheNameAndWhatComesWithItFromASingleCuratedCandidate(): void
+    {
+        $counts = $this->pass([
+            "N/1\tcamp_site\t{}\t\tSarlat\t".json_encode([
+                'n' => 1,
+                'id' => 'FR-123',
+                'name' => 'Camping du Moulin',
+                'description' => 'Au bord de la riviere',
+                'website' => 'https://moulin.test',
+                'opening_hours' => 'Apr-Oct',
+                'distance_m' => 12.4,
+            ], \JSON_THROW_ON_ERROR),
+        ], matchTable: 'tourism_staging_bretagne.accommodations')
+            ->run($this->workDir, 'osm_staging_bretagne', 'accommodations');
+
+        self::assertSame(1, $counts['resolved']);
+        self::assertSame(1, $counts['matched']);
+
+        $copy = (string) file_get_contents($this->workDir.'/place-resolved.copy');
+        self::assertStringContainsString('Camping du Moulin', $copy);
+        self::assertStringContainsString('Au bord de la riviere', $copy);
+        self::assertStringContainsString('https://moulin.test', $copy);
+        // Traceable for audit: which record it came from, and how far away it was.
+        self::assertStringContainsString('FR-123', $copy);
+        self::assertStringContainsString('12.4', $copy);
+        self::assertStringContainsString('datatourisme', $copy);
+        // A curated record is already named the way the place presents itself, so the commune
+        // is not appended on top of it.
+        self::assertStringNotContainsString('Sarlat', $copy);
+    }
+
+    #[Test]
+    public function refusesRatherThanChoosingBetweenTwoCandidates(): void
+    {
+        // Two neighbouring campsites, or a hotel and its restaurant at one address. Nothing
+        // here can tell them apart, and a wrong name is worse than no name — the rider books
+        // elsewhere, or turns up at the wrong place.
+        $counts = $this->pass([
+            "N/1\tcamp_site\t{}\t\t\t".json_encode([
+                'n' => 2,
+                'id' => 'FR-123',
+                'name' => 'Camping du Moulin',
+                'distance_m' => 9.0,
+            ], \JSON_THROW_ON_ERROR),
+        ], matchTable: 'tourism_staging_bretagne.accommodations')
+            ->run($this->workDir, 'osm_staging_bretagne', 'accommodations');
+
+        self::assertSame(0, $counts['resolved']);
+        self::assertSame(1, $counts['ambiguous']);
+        self::assertSame(['ambiguous_match' => 1], $counts['reasons']);
+
+        $copy = (string) file_get_contents($this->workDir.'/place-resolved.copy');
+        self::assertStringContainsString('ambiguous_match', $copy);
+        // How many candidates made it ambiguous, for audit.
+        self::assertStringContainsString('"candidates":2', $copy);
+        self::assertStringNotContainsString('Camping du Moulin', $copy, 'no name is borrowed from an ambiguous match');
+    }
+
+    #[Test]
+    public function fallsBackToTheTagsWhenNothingIsInRange(): void
+    {
+        // Out of range is not ambiguity: the cascade simply carries on to the next step.
+        $counts = $this->pass([
+            "N/1\tcamp_site\t{\"operator\": \"Commune de Jongieux\"}\t\t\t{}",
+        ], matchTable: 'tourism_staging_bretagne.accommodations')
+            ->run($this->workDir, 'osm_staging_bretagne', 'accommodations');
+
+        self::assertSame(1, $counts['resolved']);
+        self::assertSame(0, $counts['matched'], 'resolved by the operator tag, not by a match');
+    }
+
+    #[Test]
+    public function carriesTheCuratedFieldsThroughTheSameCoalesceRule(): void
+    {
+        // An OSM value that exists always wins, description and site included: the match
+        // completes a row, it never rewrites one.
+        $this->pass(matchTable: 'tourism_staging_bretagne.accommodations')
+            ->run($this->workDir, 'osm_staging_bretagne', 'accommodations');
+
+        $apply = $this->sqlContaining('UPDATE osm_staging_bretagne.accommodations a SET');
+        foreach (['name', 'description', 'website', 'opening_hours'] as $column) {
+            self::assertStringContainsString($column.' = COALESCE(a.'.$column.", c.payload->>'".$column."')", $apply);
+        }
     }
 
     private function commandIndex(string $needle): int

--- a/provisioner/tests/ProvisionCommandTest.php
+++ b/provisioner/tests/ProvisionCommandTest.php
@@ -341,6 +341,11 @@ final class ProvisionCommandTest extends TestCase
                     $record('datatourisme:stage');
                 }
 
+                // The zone has a geometry, so the promotion has something to clip against.
+                if (\is_string($sql) && 1 === preg_match("/TO '([^']+zone-geometry[^']*)'/", $sql, $matches)) {
+                    file_put_contents($matches[1], "1\n");
+                }
+
                 return new Process(['true']);
             },
         );
@@ -420,6 +425,90 @@ final class ProvisionCommandTest extends TestCase
         $zip->close();
 
         return (string) file_get_contents($path);
+    }
+
+    #[Test]
+    public function aFailedOsmImportLeavesTheStagedFluxUnpromotedRatherThanPromotingNothing(): void
+    {
+        // Staging succeeds, the OSM import fails, so the registry has no geometry for this
+        // zone. The promotion clips to that geometry, so running it would promote exactly
+        // nothing and report success — silently, which is worse than refusing.
+        $fluxZip = $this->emptyFluxZip();
+        /** @var list<string> $dtCommands */
+        $dtCommands = [];
+        $dataTourisme = new DataTourismeImporter(
+            fluxUrl: 'https://example.test/flux',
+            httpClient: new MockHttpClient(static fn (): MockResponse => new MockResponse($fluxZip)),
+            processFactory: static function (array $command) use (&$dtCommands): Process {
+                $sql = end($command);
+                $dtCommands[] = \is_string($sql) ? $sql : '';
+
+                // No zone geometry yet: the precondition read comes back 0.
+                if (\is_string($sql) && 1 === preg_match("/TO '([^']+zone-geometry[^']*)'/", $sql, $matches)) {
+                    file_put_contents($matches[1], "0\n");
+                }
+
+                return new Process(['true']);
+            },
+        );
+
+        $failingOsm = new PostgisImporter(
+            flexStylePath: '/app/osm2pgsql/tier1.lua',
+            processFactory: static fn (array $command): Process => new Process(['sh', '-c', 'echo "boom" 1>&2; exit 1']),
+        );
+
+        $tester = $this->buildTester(postgisImporter: $failingOsm, dataTourismeImporter: $dataTourisme);
+        $exitCode = $tester->execute(['zone' => 'bretagne'], ['interactive' => false]);
+
+        // OSM failed, so the aggregate fails; DataTourisme is a skip, not a failure.
+        self::assertSame(1, $exitCode, $tester->getDisplay());
+        self::assertStringContainsString('no registry geometry', $tester->getDisplay());
+        self::assertMatchesRegularExpression('/\x{2717}\s*osm/u', $tester->getDisplay());
+        self::assertMatchesRegularExpression('/\x{2713}\s*datatourisme/u', $tester->getDisplay());
+
+        // Nothing was promoted, and the staging schema was still reclaimed.
+        $promotions = array_filter($dtCommands, static fn (string $c): bool => str_contains($c, 'INSERT INTO tourism.metadata'));
+        self::assertSame([], $promotions, 'no promotion without a geometry to clip against');
+        self::assertNotSame([], array_filter($dtCommands, static fn (string $c): bool => str_contains($c, 'DROP SCHEMA IF EXISTS tourism_staging_bretagne')));
+    }
+
+    #[Test]
+    public function aFailedOsmRefreshStillPromotesTheFluxForAZoneAlreadyOpen(): void
+    {
+        // The other side of the same coin (ADR-041): once the zone has a geometry, a failed
+        // OSM refresh must not block the DataTourisme refresh. The precondition is the
+        // geometry, never the sibling step's exit code.
+        $fluxZip = $this->emptyFluxZip();
+        /** @var list<string> $dtCommands */
+        $dtCommands = [];
+        $dataTourisme = new DataTourismeImporter(
+            fluxUrl: 'https://example.test/flux',
+            httpClient: new MockHttpClient(static fn (): MockResponse => new MockResponse($fluxZip)),
+            processFactory: static function (array $command) use (&$dtCommands): Process {
+                $sql = end($command);
+                $dtCommands[] = \is_string($sql) ? $sql : '';
+
+                if (\is_string($sql) && 1 === preg_match("/TO '([^']+)'/", $sql, $matches)) {
+                    file_put_contents($matches[1], str_contains($matches[1], 'zone-geometry') ? "1\n" : "0\n");
+                }
+
+                return new Process(['true']);
+            },
+        );
+
+        $failingOsm = new PostgisImporter(
+            flexStylePath: '/app/osm2pgsql/tier1.lua',
+            processFactory: static fn (array $command): Process => new Process(['sh', '-c', 'echo "boom" 1>&2; exit 1']),
+        );
+
+        $tester = $this->buildTester(postgisImporter: $failingOsm, dataTourismeImporter: $dataTourisme);
+
+        self::assertSame(1, $tester->execute(['zone' => 'bretagne'], ['interactive' => false]), $tester->getDisplay());
+        self::assertNotSame(
+            [],
+            array_filter($dtCommands, static fn (string $c): bool => str_contains($c, 'INSERT INTO tourism.metadata')),
+            'an already-open zone still gets its flux refresh',
+        );
     }
 
     #[Test]

--- a/provisioner/tests/ProvisionCommandTest.php
+++ b/provisioner/tests/ProvisionCommandTest.php
@@ -317,6 +317,112 @@ final class ProvisionCommandTest extends TestCase
     }
 
     #[Test]
+    public function stagesTheCuratedFluxBeforeTheOsmImportAndPromotesItAfter(): void
+    {
+        // The ordering #885 needs. The flux is the curated source — not one of its 124 240
+        // accommodations has an empty name — so the OSM gate must have it in hand before it
+        // decides what to reject. Promotion still comes last, because it clips to the zone
+        // geometry only the OSM import produces.
+        /** @var list<string> $log */
+        $log = [];
+        $record = static function (string $step) use (&$log): void {
+            $log[] = $step;
+        };
+
+        $fluxZip = $this->emptyFluxZip();
+        $dataTourisme = new DataTourismeImporter(
+            fluxUrl: 'https://example.test/flux',
+            httpClient: new MockHttpClient(static fn (): MockResponse => new MockResponse($fluxZip)),
+            processFactory: static function (array $command) use ($record): Process {
+                $sql = end($command);
+                if (\is_string($sql) && str_contains($sql, 'INSERT INTO tourism.metadata')) {
+                    $record('datatourisme:promote');
+                } elseif (\is_string($sql) && str_contains($sql, 'CREATE SCHEMA tourism_staging_bretagne')) {
+                    $record('datatourisme:stage');
+                }
+
+                return new Process(['true']);
+            },
+        );
+
+        /** @var list<string> $osmCommands */
+        $osmCommands = [];
+        $osm = new PostgisImporter(
+            flexStylePath: '/app/osm2pgsql/tier1.lua',
+            processFactory: static function (array $command) use ($record, &$osmCommands): Process {
+                $joined = implode(' ', $command);
+                $osmCommands[] = $joined;
+                if (str_contains($joined, 'osm2pgsql')) {
+                    $record('osm:import');
+                }
+
+                return new Process(['true']);
+            },
+        );
+
+        $tester = $this->buildTester(postgisImporter: $osm, dataTourismeImporter: $dataTourisme);
+
+        self::assertSame(0, $tester->execute(['zone' => 'bretagne'], ['interactive' => false]), $tester->getDisplay());
+
+        self::assertSame(['datatourisme:stage', 'osm:import', 'datatourisme:promote'], $log);
+
+        // And the staged table is the one the OSM gate matches against.
+        $export = array_values(array_filter($osmCommands, static fn (string $c): bool => str_contains($c, 'place-candidates.tsv')));
+        self::assertCount(1, $export);
+        self::assertStringContainsString('FROM tourism_staging_bretagne.accommodations t', $export[0]);
+    }
+
+    #[Test]
+    public function anUnconfiguredFluxLeavesTheOsmGateWithoutAMatchStep(): void
+    {
+        // DataTourisme is optional (ADR-041 continue-on-error): OSM must still provision, with
+        // one fewer resolver step rather than a broken query.
+        $previousFluxId = getenv('DATATOURISME_FLUX_ID');
+        $previousAppKey = getenv('DATATOURISME_APP_KEY');
+        putenv('DATATOURISME_FLUX_ID');
+        putenv('DATATOURISME_APP_KEY');
+
+        /** @var list<string> $osmCommands */
+        $osmCommands = [];
+        $osm = new PostgisImporter(
+            flexStylePath: '/app/osm2pgsql/tier1.lua',
+            processFactory: static function (array $command) use (&$osmCommands): Process {
+                $osmCommands[] = implode(' ', $command);
+
+                return new Process(['true']);
+            },
+        );
+
+        try {
+            $tester = $this->buildTester(postgisImporter: $osm);
+            $exitCode = $tester->execute(['zone' => 'bretagne'], ['interactive' => false]);
+        } finally {
+            false === $previousFluxId ? putenv('DATATOURISME_FLUX_ID') : putenv('DATATOURISME_FLUX_ID='.$previousFluxId);
+            false === $previousAppKey ? putenv('DATATOURISME_APP_KEY') : putenv('DATATOURISME_APP_KEY='.$previousAppKey);
+        }
+
+        self::assertSame(0, $exitCode, $tester->getDisplay());
+        $export = array_values(array_filter($osmCommands, static fn (string $c): bool => str_contains($c, 'place-candidates.tsv')));
+        self::assertCount(1, $export);
+        self::assertStringNotContainsString('ST_DWithin', $export[0]);
+    }
+
+    /**
+     * A syntactically valid but empty flux ZIP, so `stage()` reaches its psql calls without
+     * needing a fixture of JSON-LD objects.
+     */
+    private function emptyFluxZip(): string
+    {
+        $path = $this->tmpDir.'/empty-flux.zip';
+        $zip = new \ZipArchive();
+        self::assertTrue(true === $zip->open($path, \ZipArchive::CREATE | \ZipArchive::OVERWRITE));
+        $zip->addFromString('index.json', '{}');
+        $zip->close();
+
+        return (string) file_get_contents($path);
+    }
+
+    #[Test]
     public function postgisImportFailureReturnsFailure(): void
     {
         $importer = new PostgisImporter(


### PR DESCRIPTION
Closes #885.

## The loop this breaks

`App\Geo\NearbyNameDeduplicator::isSamePlace()` pairs places at runtime **by name** — `normalizeName()` returns `''` when the name is absent, and the comparison fails on the next line. So the only information missing is the one required to find the correspondence. At import there is no such constraint: the full context of both datasets is in hand and nobody is waiting, so **category plus proximity** is enough, and that is exactly where DataTourisme can name what OSM does not.

An anonymous OSM accommodation with exactly one DataTourisme record of the same category within 50 m now inherits its name — and its description, site and hours with it, under the same `COALESCE`-only rule, so an OSM value that exists always wins.

## The pipeline had to change

This is the part worth reviewing closely. The OSM step used to run *before* DataTourisme, so on a newly opened zone there was no curated data to match against at the moment the gate decided what to reject. The flux is now **staged before the OSM import and promoted after it**:

1. `DataTourismeImporter::stage()` — download, load into `tourism_staging_<zone>`, Wikidata pass.
2. OSM import + name resolution + gate, matching against that staged table.
3. `DataTourismeImporter::finish()` — gate the flux and promote, clipping to the zone geometry the OSM promotion just wrote.

Staging first and promoting last is the only ordering that satisfies both constraints. A flux that is absent (no credentials) or fails to stage leaves the resolver with one fewer step rather than breaking the run, and the importer instance is resolved once and reused so the unmapped-subtype count still reports correctly.

## False matching is the real risk

The default is conservative and the tests are about that, not about the happy path:

- **Two candidates in range → rejection**, with the candidate count recorded, never a pick. Two neighbouring campsites, or a hotel and its restaurant at one address, cannot be told apart here, and attributing the wrong name is worse than attributing none — the rider books elsewhere, or turns up at the wrong place.
- **Category equality** is the compatibility rule. Anything looser is precisely how a hotel inherits its restaurant's name.
- **Nothing in range is not ambiguity** — the cascade simply carries on to `operator` / `brand`.
- **Every accepted match is traceable**: `via`, `matched_id` and `distance_m` land in the enrichment cache payload.
- **A curated name is not qualified with the commune** — the record is already named the way the place presents itself.

## Verification

`make qa` cannot complete on a dev machine (CLAUDE.md); the legs were run individually. Only `provisioner/` and `README.md` changed, so the api legs and the frontend legs have nothing new to check.

| Leg | Result |
|---|---|
| PHPStan (provisioner) | `[OK] No errors` |
| Rector (provisioner) | autofixes applied and committed, re-check `[OK] Rector is done!` |
| PHP-CS-Fixer (provisioner) | `Fixed 0 of 30` on re-run |
| markdownlint | `Summary: 0 error(s)` |
| PHPUnit (provisioner) | `OK (163 tests, 785 assertions)` |

Both non-obvious behaviours were mutation-checked: making the ambiguity fall through instead of rejecting reddens `refusesRatherThanChoosingBetweenTwoCandidates` and `refusesRatherThanChoosingBetweenTwoCuratedCandidates`; promoting the flux before the OSM import instead of after reddens `stagesTheCuratedFluxBeforeTheOsmImportAndPromotesItAfter` with the exact step order.

**Playwright is CI's job.**

## Auto-critique

- **The distance threshold is not justified by a measurement, and one acceptance criterion therefore is not met.** Producing that measurement needs a real provisioning run — the flux credentials plus hours of import — which I cannot do here. What I did instead is make the run emit it: `accommodation_matched_from_datatourisme` and `accommodation_ambiguous_matches` go into `osm.metadata.rejections` and out through `/api/health`, so the first real run yields the match rate and the ambiguity rate that confirm or move the 50 m. Calling that criterion satisfied would be a false claim.
- **Reordering the pipeline is the largest part of this diff and it is not in the issue's "fichiers impactés".** The issue lists only `PlaceEnrichmentPass`, `NameResolver` and the tests, which would have produced a feature that matches nothing on a zone's first opening and only works from the second run — and only if `resolver_version` had been bumped, since the negative cache would otherwise block the retry. I took the reordering as implied by "le contexte complet des deux jeux"; if you would rather keep the old ordering and accept the one-run delay, the resolver work stands on its own and only `ProvisionCommand` changes back.
- **`min()` over the candidate set is only meaningful because `n = 1` is checked first.** With two candidates the payload holds the alphabetically-first name, which the resolver never reads. That is a correct-but-fragile arrangement: a future edit that stops checking `n` before reading the fields would silently pick a name. The two ambiguity tests are the guard.
- **The match is only wired for `accommodations`.** POIs and cultural POIs carry no gate, so nothing there needs completing today — but the pass is now general enough that pointing it at another table would work, and nobody has measured whether it should.
- **A failed OSM import means the flux is staged and then thrown away.** The review caught that this used to be worse — `finish()` promoted against a registry row that does not exist, i.e. 0 rows, and called it a success. It now checks the geometry precondition and skips with a reason, but the staged flux is still discarded rather than kept for the next attempt. Keeping it would buy nothing: the next `stage()` re-downloads the national ZIP anyway.
- **`ambiguous_match` is cached as `insufficient` like any other rejection.** So a zone whose flux later gains or loses a candidate will not be reconsidered until `NameResolver::VERSION` is bumped, even though the ambiguity may have resolved itself. That follows #884's model rather than working around it, and the alternative — treating match ambiguity as retryable — would re-resolve those rows on every single opening.

<!-- claude-review-start -->
## Claude Review

**Summary:** Well-structured, thoroughly-tested change. The perf fix in the third commit (geography-cast GiST index) resolves the missing-index finding from the prior pass; the stage/finish split and geometry-precondition check are sound. No correctness, security, or architecture issues found this pass — one documentation-consistency nitpick (stale TRACKING.md row).

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date (one stale TRACKING.md row flagged)
- [x] Dependent tickets accounted for (#884)

**Inline comments:** Posted 1 inline comment (non-blocking suggestion).

**Commit reviewed:** `d541edf2`

<!-- claude-review-end -->
