### PR TITLE
feat(provisioner): add the zone opening report and the manual override import

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := help
-.PHONY: help start build start-dev stop install qa test test-pwa php-shell pwa-shell ensure-jwt-recette provision provision-recette routing-build routing-up coverage coverage-ci migration migrate db-create fixtures
+.PHONY: help start build start-dev stop install qa test test-pwa php-shell pwa-shell ensure-jwt-recette provision provision-override provision-recette routing-build routing-up coverage coverage-ci migration migrate db-create fixtures
 
 # Dev loads the iso-prod base + dev overrides automatically. Prod targets pass an
 # explicit `-f compose.yaml`, which takes precedence over COMPOSE_FILE, so the dev
@@ -9,7 +9,7 @@ export COMPOSE_FILE ?= compose.yaml:compose.dev.yaml
 # Forward extra CLI words after the goal (e.g. `make link-check -- --external`,
 # `make phpunit -- --filter=Foo`) into $(ARGS) and stub them as no-op goals so
 # Make does not try to build them. Only triggers for targets that read $(ARGS).
-ARGS_TARGETS := link-check phpunit test-php phpstan rector test-e2e playwright test-recette visual-test visual-update screenshots routing-build provision provision-recette
+ARGS_TARGETS := link-check phpunit test-php phpstan rector test-e2e playwright test-recette visual-test visual-update screenshots routing-build provision provision-recette provision-override
 ifneq (,$(filter $(ARGS_TARGETS),$(firstword $(MAKECMDGOALS))))
   ARGS := $(filter-out --,$(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS)))
   $(eval $(ARGS):;@:)
@@ -209,6 +209,14 @@ test: qa test-php test-e2e openapi-lint security-check ## Run full test suite (R
 provision: ## Open one OSM reference zone (e.g. make provision bretagne)
 	@test -n "$(ARGS)" || { echo "Usage: make provision <zone> (e.g. make provision bretagne). Zones: see GeofabrikRegionRegistry"; exit 1; }
 	@docker compose --profile provisioning run --rm provisioner $(ARGS)
+
+# Opening a zone writes .docker/osm/data/zones/<zone>/rejected.tsv, ranked by distance to
+# the nearest signed cycle route. Correct the rows worth fixing into an override.tsv next to
+# it and import them with this target (#886). Nothing stores that file — keep it, or a
+# rebuilt database loses the corrections. See docs/runbooks/zone-opening-corrections.md.
+provision-override: ## Import operator corrections for a zone (e.g. make provision-override bretagne)
+	@test -n "$(ARGS)" || { echo "Usage: make provision-override <zone> [file] (defaults to /data/zones/<zone>/override.tsv)"; exit 1; }
+	@docker compose --profile provisioning run --rm --entrypoint php provisioner -d memory_limit=512M bin/provision-override $(ARGS)
 
 provision-recette: ensure-jwt-recette ## Open one reference zone on the iso-prod recette stack (e.g. make provision-recette nord-pas-de-calais)
 	@test -n "$(ARGS)" || { echo "Usage: make provision-recette <zone> (e.g. make provision-recette nord-pas-de-calais)"; exit 1; }

--- a/README.md
+++ b/README.md
@@ -281,6 +281,13 @@ Three properties of that model (ADR-049), all of them checkable from the command
 
 `osm.zones` is the source of truth for what is open; there is no selection file.
 
+Each opening also writes `.docker/osm/data/zones/<zone>/rejected.tsv`: what the completeness
+gate refused, **ranked by distance to the nearest signed cycle route**, so an operator works
+the thirty refusals that border a véloroute rather than the three thousand lost in open
+country. Corrections go back in as an `override.tsv` via `make provision-override <zone>` —
+no endpoint, no interface, no versioning, and nothing stores the file. See the
+[corrections runbook](docs/runbooks/zone-opening-corrections.md).
+
 **Refresh (manual):**
 
 Both datasets are refreshed manually — there is no scheduled job — and independently:

--- a/docs/runbooks/zone-opening-corrections.md
+++ b/docs/runbooks/zone-opening-corrections.md
@@ -1,0 +1,124 @@
+# Runbook: correcting what a zone opening refused
+
+Opening a zone runs a completeness gate: a bookable accommodation that no resolver can
+name is **not imported** (ADR-049 §3). This runbook covers the loop that lets an operator
+fix the refusals worth fixing — reading the report, writing the corrections, importing
+them — and the one limitation the design accepts.
+
+It is deliberately narrow. The zone-opening procedure itself lives in
+[valhalla-routing-graph.md](valhalla-routing-graph.md) for the routing half and in the
+zone-opening runbook for the reference half; this file is only about the corrections.
+
+## 1. Read the report
+
+Every opening and re-opening writes, per zone:
+
+```text
+.docker/osm/data/zones/<zone>/rejected.tsv                  # OSM refusals
+.docker/osm/data/zones/<zone>/rejected-datatourisme.tsv     # flux refusals
+```
+
+Tab-separated with a header:
+
+| Column | Meaning |
+|---|---|
+| `source` | `osm` or `datatourisme` |
+| `source_id` | `N/123` for OSM (type + id), the flux id otherwise |
+| `category` | `hotel`, `camp_site`, … |
+| `lat`, `lon` | where it is |
+| `commune` | resolved offline from the imported boundaries |
+| `reason` | why the gate refused it |
+| `cycle_route_m` | metres to the nearest signed cycle route |
+| `tags` | the raw OSM tags, for context |
+
+**The file is sorted by `cycle_route_m`, nearest first, and that is the point.** You work
+the thirty refusals that border a véloroute, not the three thousand lost in open country.
+The human effort is bounded by the ordering, not by your discipline — stop whenever the
+distances stop being interesting.
+
+The console also prints the counts: names resolved, how many came from the curated flux,
+entries refused, and the refusals broken down by motive.
+
+## 2. Read the size of the file as a signal about the code
+
+A long `rejected.tsv` is **not** a backlog of manual work. It means the resolvers are weak.
+The first of them — projecting tags the database already holds — should absorb most of the
+volume, so a long file says it did not. The command says so itself when refusals outnumber
+resolutions.
+
+Before working through a large file, check whether the fix belongs in
+`provisioner/src/NameResolver.php` instead. Manual corrections do not scale and are lost on
+a rebuild (§5); a resolver improvement is retroactive — bump `NameResolver::VERSION` and the
+next opening retries every entry that version refused, and only those.
+
+## 3. Write the corrections
+
+Copy the report, keep the rows you want to fix, and give each one a name:
+
+```bash
+cd .docker/osm/data/zones/bretagne
+cp rejected.tsv override.tsv
+# edit override.tsv: keep the useful rows, fill in `name`
+```
+
+The required columns are the first six, in order, and the header row is skipped so you can
+edit the report in place:
+
+<!-- markdownlint-disable MD010 -- the tabs below are the file format, not indentation -->
+
+```text
+source	source_id	category	lat	lon	name
+osm	N/1234567	camp_site	48.512345	-2.765432	Camping municipal du Moulin
+```
+
+<!-- markdownlint-enable MD010 -->
+
+Three optional columns may follow, in this order: `website`, `description`,
+`opening_hours`. Leave them empty or omit them entirely.
+
+A malformed file is refused **whole**, naming the offending line. The parse completes before
+any statement runs and the insert is one transaction, so there is no such thing as a
+half-applied override.
+
+## 4. Import them
+
+```bash
+make provision-override bretagne
+# or, for a file elsewhere:
+make provision-override bretagne /data/zones/bretagne/override.tsv
+```
+
+What happens, and what does not:
+
+- The rows are inserted into `osm.accommodations` / `tourism.accommodations` with the zone
+  that corrected them and `ON CONFLICT DO NOTHING`. **An override adds what the gate refused;
+  it never rewrites a row already imported** (ADR-049 §5). If you need to change a value that
+  is already live, this file cannot do it — deliberately, because the alternative is a
+  mechanism that can silently overwrite the sources.
+- Re-opening the zone will not re-analyse them: the enrichment cache holds a negative entry
+  for each, and the promotion's identity anti-join sees the row present. They also stop
+  appearing in `rejected.tsv`, so you are not asked to fix them twice.
+
+There is no endpoint, no authentication, no interface and no versioning. It is data, it does
+not belong in git, and it does not justify a table.
+
+## 5. The limitation, stated rather than discovered
+
+**Nothing stores your file.** The corrections live only in the live tables, so a database
+rebuilt from scratch loses every one whose `override.tsv` you did not keep.
+
+That is the accepted price of "no table, no versioning". Two consequences:
+
+- **Keep the file**, somewhere that survives the database. The command reminds you.
+- **Prefer a resolver fix** whenever a correction generalises. A pattern fixed in
+  `NameResolver` applies to every zone, past and future, and survives any rebuild; a hand
+  correction applies to one row until someone drops the database.
+
+## 6. Check nothing reached git
+
+The report and override files live under `.docker/osm/data/`, which is gitignored in full
+(`.docker/osm/data/*`). If you moved a file elsewhere in the tree, check before committing:
+
+```bash
+git status --short
+```

--- a/provisioner/bin/provision-override
+++ b/provisioner/bin/provision-override
@@ -1,0 +1,16 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+require __DIR__.'/../vendor/autoload.php';
+
+use Provisioner\ImportOverrideCommand;
+use Symfony\Component\Console\Application;
+
+// A second binary rather than a sub-command: bin/provision runs in single-command mode, so
+// `provisioner bretagne` passes the zone as an argument. See ImportOverrideCommand.
+$app = new Application('Reference Override Importer');
+$app->addCommand(new ImportOverrideCommand());
+$app->setDefaultCommand('provision-override', true);
+$app->run();

--- a/provisioner/src/DataTourismeImporter.php
+++ b/provisioner/src/DataTourismeImporter.php
@@ -157,7 +157,8 @@ final readonly class DataTourismeImporter
             source: 'datatourisme',
             identity: 'a.id',
             exemptCategories: [],
-            boundariesSchema: 'osm',
+            osmSchema: 'osm',
+            liveSchema: self::LIVE_SCHEMA,
             processFactory: $this->processFactory,
             timeoutSeconds: $this->timeoutSeconds,
         );
@@ -205,7 +206,7 @@ final readonly class DataTourismeImporter
      *
      * @throws ImportFailedException
      */
-    public function finish(string $workDir, string $zoneSlug): bool
+    public function finish(string $workDir, string $zoneSlug, ?string $reportDir = null): bool
     {
         $staging = self::stagingSchema($zoneSlug);
 
@@ -226,7 +227,12 @@ final readonly class DataTourismeImporter
         // The gate runs before promotion here too. The flux names its places far more
         // reliably than OSM does, so this mostly refuses nothing — but the decision must
         // live in one place for both sources, which is the whole point of #884.
-        $gate = $this->placeEnrichmentPass->run($workDir, $staging, 'accommodations');
+        $gate = $this->placeEnrichmentPass->run(
+            $workDir,
+            $staging,
+            'accommodations',
+            null === $reportDir ? null : \sprintf('%s/%s/rejected-datatourisme.tsv', $reportDir, $zoneSlug),
+        );
         $this->promote($zoneSlug, $staging, $gate);
         $this->dropStaging($staging);
 

--- a/provisioner/src/ImportOverrideCommand.php
+++ b/provisioner/src/ImportOverrideCommand.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Provisioner;
+
+use Provisioner\Exception\ImportFailedException;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * `provision-override <zone> [file]` — imports an operator's corrections (#886).
+ *
+ * A second binary rather than a sub-command of `provision`, because the provisioner's
+ * console application runs in single-command mode: `provisioner bretagne` passes `bretagne`
+ * as the zone *argument*, and registering a real sub-command would turn that into an
+ * unknown-command error and break `make provision <zone>`. One binary per operation keeps
+ * the existing invocation intact and reads honestly — this is a distinct, deliberate act,
+ * not a flag on the import.
+ */
+#[AsCommand(
+    name: 'provision-override',
+    description: 'Import an operator-supplied override.tsv into the live reference tables',
+)]
+final class ImportOverrideCommand extends Command
+{
+    private const string DEFAULT_ZONES_DIR = '/data/zones';
+
+    private readonly OverrideImporter $importer;
+
+    public function __construct(
+        private readonly string $zonesDir = self::DEFAULT_ZONES_DIR,
+        ?OverrideImporter $importer = null,
+    ) {
+        parent::__construct();
+
+        $this->importer = $importer ?? new OverrideImporter();
+    }
+
+    protected function configure(): void
+    {
+        $this->addArgument('zone', InputArgument::OPTIONAL, 'Geofabrik slug of the zone the corrections belong to');
+        $this->addArgument('file', InputArgument::OPTIONAL, 'Path to the override.tsv; defaults to /data/zones/<zone>/override.tsv');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $io->title('Reference override import');
+
+        $zoneArgument = $input->getArgument('zone');
+        $zone = \is_string($zoneArgument) ? GeofabrikRegionRegistry::resolve($zoneArgument) : null;
+
+        if (null === $zone) {
+            $io->error(\sprintf(
+                'A zone is required: `make provision-override <zone> [file]`.%s%sKnown zones: %s',
+                \is_string($zoneArgument) && '' !== trim($zoneArgument) ? \sprintf(' "%s" is not a known zone.', $zoneArgument) : '',
+                \PHP_EOL,
+                implode(', ', GeofabrikRegionRegistry::slugs()),
+            ));
+
+            return Command::FAILURE;
+        }
+
+        $fileArgument = $input->getArgument('file');
+        $file = \is_string($fileArgument) && '' !== trim($fileArgument)
+            ? $fileArgument
+            : \sprintf('%s/%s/override.tsv', $this->zonesDir, $zone['slug']);
+
+        $io->section(\sprintf('Importing %s into the live tables', $file));
+
+        try {
+            $rows = $this->importer->import($file, $zone['slug']);
+        } catch (ImportFailedException $importFailedException) {
+            // Refused whole: the parse runs before any statement, and the insert is one
+            // transaction, so there is no partially applied override to undo.
+            $io->error($importFailedException->getMessage());
+            $io->writeln('  Nothing was inserted.');
+
+            return Command::FAILURE;
+        }
+
+        $io->success(\sprintf('%d correction(s) offered for %s.', $rows, $zone['name']));
+        $io->writeln('  Rows the index already held were left untouched (append-only).');
+        $io->writeln(\sprintf('  Re-opening %s will not re-analyse them.', $zone['slug']));
+        // The one limitation worth repeating at the point of use, not only in the runbook.
+        $io->note('Keep this file. Nothing stores it, so a database rebuilt from scratch loses every correction whose file was not kept.');
+
+        return Command::SUCCESS;
+    }
+}

--- a/provisioner/src/OverrideImporter.php
+++ b/provisioner/src/OverrideImporter.php
@@ -1,0 +1,286 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Provisioner;
+
+use Provisioner\Exception\ImportFailedException;
+use Symfony\Component\Process\Exception\ProcessTimedOutException;
+use Symfony\Component\Process\Process;
+
+/**
+ * Imports an operator's `override.tsv` into the live reference tables (#886).
+ *
+ * The loop it closes: opening a zone writes `rejected.tsv`, ranked by distance to the
+ * nearest signed cycle route; the operator edits the rows worth fixing into an
+ * `override.tsv` and imports it here. There is **no correction table, no endpoint, no
+ * authentication, no interface and no versioning** — the corrected rows go straight into
+ * the live tables, and from then on the enrichment cache's negative entry keeps the
+ * resolver from re-analysing them while the promotion's identity anti-join keeps the
+ * import from touching them. Two mechanisms that already existed; this adds no third one.
+ *
+ * **The file is the operator's to keep.** Nothing here stores it, so a database rebuilt
+ * from scratch loses every correction whose file was not kept. That is the price of "no
+ * table, no versioning", and it is written down in
+ * docs/runbooks/zone-opening-corrections.md rather than left to be discovered.
+ *
+ * A malformed file is refused whole, naming the line: the insert runs in one transaction,
+ * so there is no such thing as a partially applied override.
+ */
+final readonly class OverrideImporter
+{
+    /**
+     * Columns an operator must provide, in order. Deliberately the ones `rejected.tsv`
+     * already emits (`source`, `source_id`, `category`, `lat`, `lon`) plus the values being
+     * supplied, so the workflow is "delete the columns you do not need, add a name".
+     *
+     * @var list<string>
+     */
+    public const array COLUMNS = ['source', 'source_id', 'category', 'lat', 'lon', 'name'];
+
+    /**
+     * Optional trailing columns, filled when the operator has them to hand.
+     *
+     * @var list<string>
+     */
+    public const array OPTIONAL_COLUMNS = ['website', 'description', 'opening_hours'];
+
+    /**
+     * @var \Closure(list<string>): Process
+     */
+    private \Closure $processFactory;
+
+    /**
+     * @param (\Closure(list<string>): Process)|null $processFactory psql process factory; defaults to a real {@see Process}
+     */
+    public function __construct(
+        ?\Closure $processFactory = null,
+        private float $timeoutSeconds = 300.0,
+    ) {
+        $this->processFactory = $processFactory ?? static fn (array $command): Process => new Process($command);
+    }
+
+    /**
+     * @return int the number of rows the file offered
+     *
+     * @throws ImportFailedException on a malformed file, before anything is inserted
+     */
+    public function import(string $path, string $zoneSlug): int
+    {
+        if (!is_file($path)) {
+            throw new ImportFailedException(\sprintf('Override file "%s" does not exist.', $path));
+        }
+
+        $contents = file_get_contents($path);
+        if (false === $contents) {
+            throw new ImportFailedException(\sprintf('Override file "%s" cannot be read.', $path));
+        }
+
+        // Parsed and validated in full before a single statement runs: a file the operator
+        // got half right must leave the index exactly as it was.
+        $rows = $this->parse($contents);
+        if ([] === $rows) {
+            throw new ImportFailedException(\sprintf('Override file "%s" holds no data row.', $path));
+        }
+
+        $this->psql($this->insertSql($rows, $zoneSlug), \sprintf('psql import override %s', $path));
+
+        return \count($rows);
+    }
+
+    /**
+     * @return list<array{source: string, source_id: string, category: string, lat: float, lon: float, name: string, website: ?string, description: ?string, opening_hours: ?string}>
+     *
+     * @throws ImportFailedException
+     */
+    private function parse(string $contents): array
+    {
+        $rows = [];
+        $expected = \count(self::COLUMNS);
+        $maximum = $expected + \count(self::OPTIONAL_COLUMNS);
+
+        foreach (explode("\n", $contents) as $index => $line) {
+            $line = rtrim($line, "\r");
+            $number = $index + 1;
+
+            if ('' === trim($line)) {
+                continue;
+            }
+
+            $fields = explode("\t", $line);
+            // The header `rejected.tsv` writes, so an operator can edit that file in place.
+            if (1 === $number && ($fields[0] ?? '') === self::COLUMNS[0]) {
+                continue;
+            }
+
+            if (\count($fields) < $expected || \count($fields) > $maximum) {
+                throw new ImportFailedException(\sprintf('Override line %d has %d tab-separated fields; expected %d to %d (%s[, %s]).', $number, \count($fields), $expected, $maximum, implode(', ', self::COLUMNS), implode(', ', self::OPTIONAL_COLUMNS)));
+            }
+
+            $rows[] = $this->row($fields, $number);
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @param list<string> $fields
+     *
+     * @return array{source: string, source_id: string, category: string, lat: float, lon: float, name: string, website: ?string, description: ?string, opening_hours: ?string}
+     *
+     * @throws ImportFailedException
+     */
+    private function row(array $fields, int $number): array
+    {
+        $source = trim($fields[0]);
+        if (!\in_array($source, ['osm', 'datatourisme'], true)) {
+            throw new ImportFailedException(\sprintf('Override line %d has source "%s"; expected osm or datatourisme.', $number, $source));
+        }
+
+        $sourceId = trim($fields[1]);
+        if ('osm' === $source && 1 !== preg_match('/^[NWR]\/\d+$/i', $sourceId)) {
+            throw new ImportFailedException(\sprintf('Override line %d has OSM id "%s"; expected the N/123 form rejected.tsv emits.', $number, $sourceId));
+        }
+
+        if ('' === $sourceId) {
+            throw new ImportFailedException(\sprintf('Override line %d has an empty source id.', $number));
+        }
+
+        $category = trim($fields[2]);
+        if ('' === $category) {
+            throw new ImportFailedException(\sprintf('Override line %d has an empty category.', $number));
+        }
+
+        if (!is_numeric($fields[3]) || !is_numeric($fields[4])) {
+            throw new ImportFailedException(\sprintf('Override line %d has non-numeric coordinates ("%s", "%s").', $number, $fields[3], $fields[4]));
+        }
+
+        $lat = (float) $fields[3];
+        $lon = (float) $fields[4];
+        if ($lat < -90.0 || $lat > 90.0 || $lon < -180.0 || $lon > 180.0) {
+            throw new ImportFailedException(\sprintf('Override line %d has coordinates outside the world (%s, %s).', $number, $fields[3], $fields[4]));
+        }
+
+        // The whole point of the file: a row rejected for having no usable name must arrive
+        // with one, or importing it would only reproduce the rejection.
+        $name = trim($fields[5]);
+        if ('' === $name) {
+            throw new ImportFailedException(\sprintf('Override line %d has an empty name, which is the one value the gate refused it for.', $number));
+        }
+
+        return [
+            'source' => $source,
+            'source_id' => $sourceId,
+            'category' => $category,
+            'lat' => $lat,
+            'lon' => $lon,
+            'name' => $name,
+            'website' => $this->optional($fields, 6),
+            'description' => $this->optional($fields, 7),
+            'opening_hours' => $this->optional($fields, 8),
+        ];
+    }
+
+    /**
+     * @param list<string> $fields
+     */
+    private function optional(array $fields, int $index): ?string
+    {
+        $value = trim($fields[$index] ?? '');
+
+        return '' === $value ? null : $value;
+    }
+
+    /**
+     * One transaction, and `ON CONFLICT DO NOTHING` on every row.
+     *
+     * Append-only holds here too (ADR-049 §5): an override adds what the gate refused, it
+     * never rewrites a row already imported. An operator who wants to change a value that is
+     * already live cannot do it with this file, and that is deliberate — the alternative is a
+     * mechanism that can silently overwrite the sources.
+     *
+     * @param list<array{source: string, source_id: string, category: string, lat: float, lon: float, name: string, website: ?string, description: ?string, opening_hours: ?string}> $rows
+     */
+    private function insertSql(array $rows, string $zoneSlug): string
+    {
+        $osm = [];
+        $tourism = [];
+
+        foreach ($rows as $row) {
+            if ('osm' === $row['source']) {
+                [$type, $id] = explode('/', $row['source_id']);
+                $osm[] = \sprintf(
+                    '(%s, %d, %s, %s, %s, %s, %s, %s, now())',
+                    ZonePromotion::literal(strtoupper($type)),
+                    (int) $id,
+                    ZonePromotion::literal($row['name']),
+                    ZonePromotion::literal($row['category']),
+                    $this->nullable($row['website']),
+                    $this->nullable($row['opening_hours']),
+                    $this->nullable($row['description']),
+                    $this->point($row['lat'], $row['lon']),
+                );
+                continue;
+            }
+
+            $tourism[] = \sprintf(
+                '(%s, %s, %s, %s, %s, %s, %s, now())',
+                ZonePromotion::literal($row['source_id']),
+                ZonePromotion::literal($row['name']),
+                ZonePromotion::literal($row['category']),
+                $this->nullable($row['website']),
+                $this->nullable($row['opening_hours']),
+                $this->nullable($row['description']),
+                $this->point($row['lat'], $row['lon']),
+            );
+        }
+
+        $statements = [];
+        if ([] !== $osm) {
+            $statements[] = \sprintf(
+                'INSERT INTO osm.accommodations (osm_type, osm_id, name, category, website, opening_hours, description, geom, zone, last_seen_at) SELECT v.osm_type, v.osm_id, v.name, v.category, v.website, v.opening_hours, v.description, v.geom, %s, v.seen FROM (VALUES %s) AS v(osm_type, osm_id, name, category, website, opening_hours, description, geom, seen) ON CONFLICT (osm_type, osm_id) DO NOTHING;',
+                ZonePromotion::literal($zoneSlug),
+                implode(', ', $osm),
+            );
+        }
+
+        if ([] !== $tourism) {
+            $statements[] = \sprintf(
+                'INSERT INTO tourism.accommodations (id, name, category, website, opening_hours, description, geom, zone, last_seen_at) SELECT v.id, v.name, v.category, v.website, v.opening_hours, v.description, v.geom, %s, v.seen FROM (VALUES %s) AS v(id, name, category, website, opening_hours, description, geom, seen) ON CONFLICT (id) DO NOTHING;',
+                ZonePromotion::literal($zoneSlug),
+                implode(', ', $tourism),
+            );
+        }
+
+        return implode(' ', $statements);
+    }
+
+    private function point(float $lat, float $lon): string
+    {
+        return \sprintf('ST_SetSRID(ST_MakePoint(%.7F, %.7F), 4326)', $lon, $lat);
+    }
+
+    private function nullable(?string $value): string
+    {
+        return null === $value ? 'NULL' : ZonePromotion::literal($value);
+    }
+
+    /**
+     * @throws ImportFailedException
+     */
+    private function psql(string $sql, string $label): void
+    {
+        $process = ($this->processFactory)(['psql', '-v', 'ON_ERROR_STOP=1', '--single-transaction', '-c', $sql]);
+        $process->setTimeout($this->timeoutSeconds);
+
+        try {
+            $process->run();
+        } catch (ProcessTimedOutException $processTimedOutException) {
+            throw new ImportFailedException(\sprintf('%s timed out after %.1fs', $label, $this->timeoutSeconds), 0, $processTimedOutException);
+        }
+
+        if (!$process->isSuccessful()) {
+            throw new ImportFailedException(\sprintf("%s failed (exit %s).\nStderr: %s", $label, (string) $process->getExitCode(), $process->getErrorOutput()));
+        }
+    }
+}

--- a/provisioner/src/PlaceEnrichmentPass.php
+++ b/provisioner/src/PlaceEnrichmentPass.php
@@ -62,9 +62,6 @@ final readonly class PlaceEnrichmentPass
      * @param string       $identity          SQL expression identifying a row `a` of the target table
      * @param list<string> $exemptCategories  categories the gate does not apply to, and which are therefore
      *                                        not resolved either (`shelter`, arbitrated by #878)
-     * @param string|null  $boundariesSchema  schema holding `admin_boundaries` for the offline locality
-     *                                        lookup; null uses the staging schema, which is where the zone
-     *                                        being opened has its own freshly imported boundaries
      * @param string|null  $matchTable        qualified table of curated places to match unnamed rows against
      *                                        (`<tourism staging>.accommodations`); null disables matching
      * @param int          $matchRadiusMeters strictly under the runtime deduplicator's 75 m: this match has no
@@ -74,7 +71,8 @@ final readonly class PlaceEnrichmentPass
         private string $source,
         private string $identity,
         private array $exemptCategories = [],
-        private ?string $boundariesSchema = null,
+        private ?string $osmSchema = null,
+        private ?string $liveSchema = null,
         ?\Closure $processFactory = null,
         private NameResolver $resolver = new NameResolver(),
         private float $timeoutSeconds = 1800.0,
@@ -85,11 +83,13 @@ final readonly class PlaceEnrichmentPass
     }
 
     /**
+     * @param string|null $reportPath where to write the human-readable reject report; null skips it
+     *
      * @return array{resolved: int, rejected: int, matched: int, ambiguous: int, reasons: array<string, int>}
      *
      * @throws ImportFailedException
      */
-    public function run(string $workDir, string $stagingSchema, string $table): array
+    public function run(string $workDir, string $stagingSchema, string $table, ?string $reportPath = null): array
     {
         // The cache may predate the API migration on this database (same reason
         // WikidataEnrichmentPass creates its own), and the scratch table is scoped to the
@@ -156,10 +156,15 @@ final readonly class PlaceEnrichmentPass
             "\\copy (SELECT count(*) FROM %s.%s a WHERE %s) TO '%s'",
             $stagingSchema,
             $table,
-            $this->gatePredicate(),
+            $this->gatePredicate($table),
             $rejectedPath,
         ), 'psql count gated rows');
         $counts['rejected'] = (int) ($this->readLines($rejectedPath)[0] ?? '0');
+
+        // Written before the delete, or there would be nothing left to report on.
+        if (null !== $reportPath) {
+            $this->writeRejectReport($stagingSchema, $table, $reportPath);
+        }
 
         // The gate itself. Deleting from staging keeps the promotion's INSERT clean, so the
         // CHECK on the live table only ever fires on a bug here — which is the point.
@@ -167,7 +172,7 @@ final readonly class PlaceEnrichmentPass
             'DELETE FROM %s.%s a WHERE %s;',
             $stagingSchema,
             $table,
-            $this->gatePredicate(),
+            $this->gatePredicate($table),
         ), 'psql apply completeness gate');
 
         $this->psql(\sprintf('DROP TABLE IF EXISTS %s;', $scratch), 'psql drop place enrichment scratch');
@@ -202,7 +207,7 @@ final readonly class PlaceEnrichmentPass
      */
     private function exportCandidates(string $stagingSchema, string $table, string $path): string
     {
-        $boundaries = \sprintf('%s.admin_boundaries', $this->boundariesSchema ?? $stagingSchema);
+        $boundaries = \sprintf('%s.admin_boundaries', $this->osmSchema ?? $stagingSchema);
 
         return \sprintf(
             <<<'SQL'
@@ -229,6 +234,67 @@ final readonly class PlaceEnrichmentPass
             $path,
             $this->matchExpression(),
         );
+    }
+
+    /**
+     * Writes the rejects an operator can act on, **nearest to a signed cycle route first**.
+     *
+     * That ordering is what makes the exercise finite. The signed cycle routes are already
+     * imported (`tier1.lua`, relations `type=route, route=bicycle`), so ranking by distance to
+     * them is free — and it means an operator works the thirty rejects that border a
+     * véloroute instead of the three thousand lost in open country. The human effort is
+     * bounded by construction rather than by discipline.
+     *
+     * Columns: source, source id, category, latitude, longitude, resolved commune, the motive,
+     * the metres to the nearest cycle route, and the raw tags — everything a human needs to
+     * decide, and nothing that needs a second query to interpret.
+     *
+     * @throws ImportFailedException
+     */
+    private function writeRejectReport(string $stagingSchema, string $table, string $path): void
+    {
+        $directory = \dirname($path);
+        if (!is_dir($directory) && !mkdir($directory, 0o755, true) && !is_dir($directory)) {
+            throw new ImportFailedException(\sprintf('Cannot create the report directory "%s"', $directory));
+        }
+
+        $osmSchema = $this->osmSchema ?? $stagingSchema;
+        // KNN (`<->`) rather than min(ST_Distance(...)): the operator uses the GiST index on
+        // cycle_routes.geom, so this is one index probe per reject instead of a full scan of
+        // every route. Ordering happens in degrees and the reported distance in metres — good
+        // enough to rank, exact enough to read.
+        $distance = \sprintf(
+            '(SELECT round(ST_Distance(r.geom::geography, a.geom::geography)::numeric, 1) FROM %s.cycle_routes r ORDER BY r.geom <-> a.geom LIMIT 1)',
+            $osmSchema,
+        );
+
+        $this->psql(\sprintf(
+            <<<'SQL'
+                \copy (SELECT %10$s AS source,
+                              %1$s AS source_id,
+                              a.category,
+                              round(ST_Y(a.geom)::numeric, 6) AS lat,
+                              round(ST_X(a.geom)::numeric, 6) AS lon,
+                              coalesce((SELECT b.name FROM %2$s.admin_boundaries b WHERE b.admin_level = 8 AND ST_Covers(b.geom, a.geom) LIMIT 1), '') AS commune,
+                              coalesce(c.payload->>'reason', 'unknown') AS reason,
+                              %3$s AS cycle_route_m,
+                              coalesce(a.tags::text, '{}') AS tags
+                         FROM %4$s.%5$s a
+                         LEFT JOIN %6$s c ON c.source = %7$s AND c.source_id = %1$s
+                        WHERE %8$s
+                        ORDER BY %3$s NULLS LAST) TO '%9$s' WITH (FORMAT csv, DELIMITER E'\t', HEADER true)
+                SQL,
+            $this->identity,
+            $osmSchema,
+            $distance,
+            $stagingSchema,
+            $table,
+            self::CACHE_TABLE,
+            $this->literal($this->source),
+            $this->gatePredicate($table),
+            $path,
+            $this->literal($this->source),
+        ), \sprintf('psql write reject report for %s.%s', $stagingSchema, $table));
     }
 
     /**
@@ -271,9 +337,46 @@ final readonly class PlaceEnrichmentPass
     /**
      * Rows the gate refuses: still without a name after the cascade, and not exempt.
      */
-    private function gatePredicate(): string
+    /**
+     * Rows the gate refuses: still without a name after the cascade, not exempt, and not
+     * already present in the live table.
+     *
+     * That last clause is what stops an operator's manual correction from coming back
+     * (#886). Once an `override.tsv` has inserted the row into live, re-opening the zone
+     * re-imports the same anonymous row into staging — and without this it would be counted
+     * and listed in `rejected.tsv` again, every single time, asking to be fixed once more.
+     * The promotion's own anti-join would skip it regardless, so excluding it here changes
+     * only what is reported, which is exactly the point.
+     */
+    private function gatePredicate(string $table): string
     {
-        return \sprintf("nullif(btrim(a.name), '') IS NULL AND %s", $this->notExempt());
+        $predicate = \sprintf("nullif(btrim(a.name), '') IS NULL AND %s", $this->notExempt());
+
+        if (null === $this->liveSchema) {
+            return $predicate;
+        }
+
+        return \sprintf(
+            '%s AND NOT EXISTS (SELECT 1 FROM %s.%s l WHERE %s)',
+            $predicate,
+            $this->liveSchema,
+            $table,
+            $this->liveIdentityMatch(),
+        );
+    }
+
+    /**
+     * The identity predicate against the live table, derived from the same expression the
+     * cache is keyed on so the two cannot disagree: `a.osm_type || '/' || a.osm_id` becomes
+     * the pair of column comparisons, `a.id` the single one.
+     */
+    private function liveIdentityMatch(): string
+    {
+        if (str_contains($this->identity, 'osm_type')) {
+            return 'l.osm_type = a.osm_type AND l.osm_id = a.osm_id';
+        }
+
+        return 'l.id = a.id';
     }
 
     private function notExempt(): string

--- a/provisioner/src/PlaceEnrichmentPass.php
+++ b/provisioner/src/PlaceEnrichmentPass.php
@@ -335,9 +335,6 @@ final readonly class PlaceEnrichmentPass
     }
 
     /**
-     * Rows the gate refuses: still without a name after the cascade, and not exempt.
-     */
-    /**
      * Rows the gate refuses: still without a name after the cascade, not exempt, and not
      * already present in the live table.
      *

--- a/provisioner/src/PostgisImporter.php
+++ b/provisioner/src/PostgisImporter.php
@@ -199,12 +199,15 @@ final readonly class PostgisImporter
     /**
      * Opens (or re-opens) one zone.
      *
-     * @param string $zoneName    display name recorded in the registry
-     * @param string $countrySlug country the zone belongs to, compared against the routing perimeter
+     * @param string      $zoneName    display name recorded in the registry
+     * @param string      $countrySlug country the zone belongs to, compared against the routing perimeter
+     * @param string|null $reportDir   root under which `<zone>/rejected.tsv` is written (#886); null skips it
+     *
+     * @return array{resolved: int, rejected: int, matched: int, ambiguous: int, reasons: array<string, int>} what the completeness gate resolved and refused
      *
      * @throws ImportFailedException
      */
-    public function run(string $zoneSlug, string $zoneName, string $countrySlug, string $regionPbf, string $filteredPbf, ?string $curatedTable = null): void
+    public function run(string $zoneSlug, string $zoneName, string $countrySlug, string $regionPbf, string $filteredPbf, ?string $curatedTable = null, ?string $reportDir = null): array
     {
         $staging = self::stagingSchema($zoneSlug);
 
@@ -216,9 +219,16 @@ final readonly class PostgisImporter
         $this->enrichmentPass->run(\dirname($filteredPbf), $staging, self::WIKIDATA_TABLES);
         // Names are resolved and the completeness gate applied *before* promotion, so the
         // gate decides once and the live CHECK only ever fires on a bug here (#884).
-        $gate = $this->placeEnrichmentPass($curatedTable)->run(\dirname($filteredPbf), $staging, 'accommodations');
+        $gate = $this->placeEnrichmentPass($curatedTable)->run(
+            \dirname($filteredPbf),
+            $staging,
+            'accommodations',
+            null === $reportDir ? null : \sprintf('%s/%s/rejected.tsv', $reportDir, $zoneSlug),
+        );
         $this->promote($zoneSlug, $zoneName, $countrySlug, $staging, $gate);
         $this->dropStaging($staging);
+
+        return $gate;
     }
 
     /**
@@ -273,6 +283,7 @@ final readonly class PostgisImporter
             source: 'osm',
             identity: "a.osm_type || '/' || a.osm_id",
             exemptCategories: self::GATE_EXEMPT_CATEGORIES,
+            liveSchema: $this->liveSchema,
             processFactory: $this->processFactory,
             timeoutSeconds: $this->timeoutSeconds,
             matchTable: $curatedTable,

--- a/provisioner/src/ProvisionCommand.php
+++ b/provisioner/src/ProvisionCommand.php
@@ -45,6 +45,13 @@ final class ProvisionCommand extends Command
 
     private const string DEFAULT_DATATOURISME_DIR = '/data/datatourisme';
 
+    /**
+     * Root of the per-zone report directory: `<zonesDir>/<zone>/rejected.tsv` (#886). Under
+     * `/data`, which is bind-mounted, so the operator picks the file up on the host — and
+     * `.docker/osm/data/*` is gitignored, so no data file can reach the repository.
+     */
+    private const string DEFAULT_ZONES_DIR = '/data/zones';
+
     private const string DEFAULT_LOCK_FILE = '/data/provision.lock';
 
     private const string DEFAULT_LOG_FILE = '/data/provisioner.log';
@@ -71,6 +78,7 @@ final class ProvisionCommand extends Command
         private readonly string $dataTourismeDir = self::DEFAULT_DATATOURISME_DIR,
         // Built lazily in runDataTourisme() from DATATOURISME_* env when not injected.
         private readonly ?DataTourismeImporter $dataTourismeImporter = null,
+        private readonly string $zonesDir = self::DEFAULT_ZONES_DIR,
         private readonly string $lockFile = self::DEFAULT_LOCK_FILE,
         private readonly string $logFile = self::DEFAULT_LOG_FILE,
         ?RoutingPerimeter $routingPerimeter = null,
@@ -366,7 +374,7 @@ final class ProvisionCommand extends Command
         $io->section('Promoting DataTourisme into PostGIS');
 
         try {
-            $promoted = $importer->finish($this->dataTourismeDir, $zoneSlug);
+            $promoted = $importer->finish($this->dataTourismeDir, $zoneSlug, $this->zonesDir);
         } catch (ImportFailedException $importFailedException) {
             $this->fail($io, $importFailedException->getMessage());
 
@@ -434,7 +442,7 @@ final class ProvisionCommand extends Command
         $io->write('  Importing Tier-1 features into PostGIS... ');
 
         try {
-            $this->postgisImporter->run($zone['slug'], $zone['name'], $zone['country'], $targetPath, $this->filteredPbf, $curatedTable);
+            $gate = $this->postgisImporter->run($zone['slug'], $zone['name'], $zone['country'], $targetPath, $this->filteredPbf, $curatedTable, $this->zonesDir);
         } catch (ImportFailedException $importFailedException) {
             $io->newLine();
             $this->fail($io, $importFailedException->getMessage());
@@ -443,8 +451,48 @@ final class ProvisionCommand extends Command
         }
 
         $io->writeln("\u{2713}");
+        $this->reportGate($io, $zone['slug'], $gate);
         $io->success(\sprintf('Zone %s is open. Every other zone was left untouched.', $zone['name']));
 
         return Command::SUCCESS;
+    }
+
+    /**
+     * What the completeness gate accepted and refused, and where to act on the refusals.
+     *
+     * The diagnostic line matters more than the numbers. A large `rejected.tsv` is **not** a
+     * signal that more human work is needed — it is a signal that the resolvers are bad, the
+     * tag projection first among them. Saying so here keeps that reading from being buried
+     * under a long file, which is exactly what #886 asks for.
+     *
+     * @param array{resolved?: int, rejected?: int, matched?: int, ambiguous?: int, reasons?: array<string, int>} $gate
+     */
+    private function reportGate(SymfonyStyle $io, string $zoneSlug, array $gate): void
+    {
+        $resolved = $gate['resolved'] ?? 0;
+        $rejected = $gate['rejected'] ?? 0;
+        $matched = $gate['matched'] ?? 0;
+        $ambiguous = $gate['ambiguous'] ?? 0;
+
+        if (0 === $resolved && 0 === $rejected) {
+            return;
+        }
+
+        $io->section('Completeness gate');
+        $io->writeln(\sprintf('  %d name(s) resolved, of which %d from the curated flux.', $resolved, $matched));
+        $io->writeln(\sprintf('  %d entry(ies) refused%s.', $rejected, $ambiguous > 0 ? \sprintf(', %d of them as ambiguous matches', $ambiguous) : ''));
+
+        foreach ($gate['reasons'] ?? [] as $reason => $count) {
+            $io->writeln(\sprintf('    - %s: %d', $reason, $count));
+        }
+
+        if ($rejected > 0) {
+            $io->writeln(\sprintf('  Ranked by distance to the nearest cycle route in %s/%s/rejected.tsv.', $this->zonesDir, $zoneSlug));
+            $this->logLine('INFO', \sprintf('zone %s gate -> %d resolved, %d refused', $zoneSlug, $resolved, $rejected));
+        }
+
+        if ($rejected > $resolved) {
+            $io->warning('More entries were refused than resolved. Read that as the resolvers being weak, not as a backlog of manual work: the tag projection should absorb most of the volume, and a long rejected.tsv means it did not.');
+        }
     }
 }

--- a/provisioner/tests/ImportOverrideCommandTest.php
+++ b/provisioner/tests/ImportOverrideCommandTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Provisioner\Tests;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Provisioner\ImportOverrideCommand;
+use Provisioner\OverrideImporter;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Process\Process;
+
+final class ImportOverrideCommandTest extends TestCase
+{
+    private string $zonesDir;
+
+    /**
+     * @var list<list<string>>
+     */
+    private array $captured = [];
+
+    protected function setUp(): void
+    {
+        $this->zonesDir = sys_get_temp_dir().'/override-cmd-'.uniqid('', true);
+        mkdir($this->zonesDir.'/bretagne', 0o755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->zonesDir.'/*/*') ?: [] as $file) {
+            unlink($file);
+        }
+
+        foreach (glob($this->zonesDir.'/*') ?: [] as $dir) {
+            rmdir($dir);
+        }
+
+        if (is_dir($this->zonesDir)) {
+            rmdir($this->zonesDir);
+        }
+    }
+
+    private function tester(): CommandTester
+    {
+        $command = new ImportOverrideCommand(
+            zonesDir: $this->zonesDir,
+            importer: new OverrideImporter(function (array $command): Process {
+                /** @var list<string> $cmd */
+                $cmd = $command;
+                $this->captured[] = $cmd;
+
+                return new Process(['true']);
+            }),
+        );
+
+        $app = new Application();
+        $app->addCommand($command);
+
+        return new CommandTester($app->find('provision-override'));
+    }
+
+    private function writeOverride(string $contents, ?string $path = null): string
+    {
+        $path ??= $this->zonesDir.'/bretagne/override.tsv';
+        file_put_contents($path, $contents);
+
+        return $path;
+    }
+
+    #[Test]
+    public function importsTheZonesDefaultOverrideFile(): void
+    {
+        // The operator drops the file where the report was written; no path to remember.
+        $this->writeOverride("osm\tN/42\tcamp_site\t48.5\t2.5\tCamping du Moulin\n");
+
+        $tester = $this->tester();
+        $exitCode = $tester->execute(['zone' => 'bretagne'], ['interactive' => false]);
+
+        self::assertSame(0, $exitCode, $tester->getDisplay());
+        self::assertStringContainsString('1 correction(s) offered', $tester->getDisplay());
+        self::assertCount(1, $this->captured);
+    }
+
+    #[Test]
+    public function acceptsAnExplicitPath(): void
+    {
+        $path = $this->writeOverride("osm\tN/42\tcamp_site\t48.5\t2.5\tCamping\n", $this->zonesDir.'/elsewhere.tsv');
+
+        $tester = $this->tester();
+
+        self::assertSame(0, $tester->execute(['zone' => 'bretagne', 'file' => $path], ['interactive' => false]), $tester->getDisplay());
+    }
+
+    #[Test]
+    public function refusesAMalformedFileAndSaysNothingWasInserted(): void
+    {
+        // No partial application: the parse completes before any statement runs.
+        $this->writeOverride("osm\tN/42\tcamp_site\tnorth\t2.5\tCamping\n");
+
+        $tester = $this->tester();
+        $exitCode = $tester->execute(['zone' => 'bretagne'], ['interactive' => false]);
+
+        self::assertSame(1, $exitCode);
+        $output = $tester->getDisplay();
+        self::assertStringContainsString('non-numeric coordinates', $output);
+        self::assertStringContainsString('Nothing was inserted', $output);
+        self::assertSame([], $this->captured);
+    }
+
+    #[Test]
+    public function withoutAZoneItFailsWithAnExplicitMessage(): void
+    {
+        $tester = $this->tester();
+
+        self::assertSame(1, $tester->execute([], ['interactive' => false]));
+        $output = $tester->getDisplay();
+        self::assertStringContainsString('A zone is required', $output);
+        self::assertStringContainsString('bretagne', $output);
+    }
+
+    #[Test]
+    public function anUnknownZoneIsRefused(): void
+    {
+        $tester = $this->tester();
+
+        self::assertSame(1, $tester->execute(['zone' => '../../evil'], ['interactive' => false]));
+        self::assertStringContainsString('is not a known zone', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function aMissingFileIsReportedWithItsPath(): void
+    {
+        $tester = $this->tester();
+
+        self::assertSame(1, $tester->execute(['zone' => 'bretagne'], ['interactive' => false]));
+        // The SymfonyStyle error block word-wraps, so assert non-splittable tokens.
+        $output = $tester->getDisplay();
+        self::assertStringContainsString('Override file', $output);
+        self::assertStringContainsString('override.tsv', $output);
+        self::assertStringContainsString('Nothing was inserted', $output);
+    }
+
+    #[Test]
+    public function warnsThatNothingStoresTheFile(): void
+    {
+        // The assumed limitation of #886, repeated at the point of use rather than left in the
+        // runbook alone: a database rebuilt from scratch loses every correction whose file the
+        // operator did not keep.
+        $this->writeOverride("osm\tN/42\tcamp_site\t48.5\t2.5\tCamping\n");
+
+        $tester = $this->tester();
+        $tester->execute(['zone' => 'bretagne'], ['interactive' => false]);
+
+        self::assertStringContainsString('Keep this file', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function saysTheCorrectionsWillNotBeReanalysed(): void
+    {
+        $this->writeOverride("osm\tN/42\tcamp_site\t48.5\t2.5\tCamping\n");
+
+        $tester = $this->tester();
+        $tester->execute(['zone' => 'bretagne'], ['interactive' => false]);
+
+        $output = $tester->getDisplay();
+        self::assertStringContainsString('will not re-analyse them', $output);
+        self::assertStringContainsString('append-only', $output);
+    }
+}

--- a/provisioner/tests/OverrideImporterTest.php
+++ b/provisioner/tests/OverrideImporterTest.php
@@ -1,0 +1,253 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Provisioner\Tests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Provisioner\Exception\ImportFailedException;
+use Provisioner\OverrideImporter;
+use Symfony\Component\Process\Process;
+
+final class OverrideImporterTest extends TestCase
+{
+    private string $workDir;
+
+    /**
+     * @var list<list<string>>
+     */
+    private array $captured = [];
+
+    protected function setUp(): void
+    {
+        $this->workDir = sys_get_temp_dir().'/override-'.uniqid('', true);
+        mkdir($this->workDir, 0o755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->workDir.'/*') ?: [] as $file) {
+            unlink($file);
+        }
+
+        if (is_dir($this->workDir)) {
+            rmdir($this->workDir);
+        }
+    }
+
+    private function importer(): OverrideImporter
+    {
+        return new OverrideImporter(function (array $command): Process {
+            /** @var list<string> $cmd */
+            $cmd = $command;
+            $this->captured[] = $cmd;
+
+            return new Process(['true']);
+        });
+    }
+
+    private function file(string $contents): string
+    {
+        $path = $this->workDir.'/override.tsv';
+        file_put_contents($path, $contents);
+
+        return $path;
+    }
+
+    private function sql(): string
+    {
+        self::assertCount(1, $this->captured, 'exactly one psql call, so the import is one transaction');
+        $sql = end($this->captured[0]);
+        self::assertIsString($sql);
+
+        return $sql;
+    }
+
+    #[Test]
+    public function importsAnOsmCorrectionIntoTheLiveTable(): void
+    {
+        $rows = $this->importer()->import(
+            $this->file("osm\tN/42\tcamp_site\t48.5\t2.5\tCamping du Moulin\n"),
+            'bretagne',
+        );
+
+        self::assertSame(1, $rows);
+
+        $sql = $this->sql();
+        self::assertStringContainsString('INSERT INTO osm.accommodations', $sql);
+        self::assertStringContainsString("('N', 42, 'Camping du Moulin', 'camp_site'", $sql);
+        self::assertStringContainsString('ST_SetSRID(ST_MakePoint(2.5000000, 48.5000000), 4326)', $sql);
+        self::assertStringContainsString("'bretagne'", $sql, 'the row carries the zone that corrected it');
+        self::assertContains('--single-transaction', $this->captured[0]);
+    }
+
+    #[Test]
+    public function importsADataTourismeCorrectionIntoItsOwnTable(): void
+    {
+        $this->importer()->import(
+            $this->file("datatourisme\tFR-123\thotel\t48.5\t2.5\tHotel du Parc\n"),
+            'bretagne',
+        );
+
+        $sql = $this->sql();
+        self::assertStringContainsString('INSERT INTO tourism.accommodations', $sql);
+        self::assertStringContainsString("('FR-123', 'Hotel du Parc', 'hotel'", $sql);
+        self::assertStringNotContainsString('INSERT INTO osm.accommodations', $sql);
+    }
+
+    #[Test]
+    public function carriesTheOptionalColumnsWhenTheOperatorSuppliesThem(): void
+    {
+        $this->importer()->import(
+            $this->file("osm\tN/42\tcamp_site\t48.5\t2.5\tCamping du Moulin\thttps://moulin.test\tAu bord de l'eau\tApr-Oct\n"),
+            'bretagne',
+        );
+
+        $sql = $this->sql();
+        self::assertStringContainsString("'https://moulin.test'", $sql);
+        // Quotes in free text must not end the literal.
+        self::assertStringContainsString("'Au bord de l''eau'", $sql);
+        self::assertStringContainsString("'Apr-Oct'", $sql);
+    }
+
+    #[Test]
+    public function leavesOmittedOptionalColumnsNull(): void
+    {
+        $this->importer()->import(
+            $this->file("osm\tN/42\tcamp_site\t48.5\t2.5\tCamping du Moulin\n"),
+            'bretagne',
+        );
+
+        self::assertStringContainsString('NULL, NULL, NULL', $this->sql());
+    }
+
+    #[Test]
+    public function neverOverwritesARowTheIndexAlreadyHolds(): void
+    {
+        // Append-only holds here too (ADR-049 §5): an override adds what the gate refused, it
+        // does not rewrite what is already imported. An operator wanting to change a live
+        // value cannot do it with this file, deliberately — the alternative is a mechanism
+        // that can silently overwrite the sources.
+        $this->importer()->import($this->file("osm\tN/42\tcamp_site\t48.5\t2.5\tCamping\n"), 'bretagne');
+
+        self::assertStringContainsString('ON CONFLICT (osm_type, osm_id) DO NOTHING', $this->sql());
+    }
+
+    #[Test]
+    public function skipsTheHeaderRejectedTsvWrites(): void
+    {
+        // So the operator can edit rejected.tsv in place rather than reformatting it.
+        $rows = $this->importer()->import(
+            $this->file("source\tsource_id\tcategory\tlat\tlon\tname\nosm\tN/42\tcamp_site\t48.5\t2.5\tCamping\n"),
+            'bretagne',
+        );
+
+        self::assertSame(1, $rows);
+    }
+
+    #[Test]
+    public function importsEveryRowInOneStatementPerTable(): void
+    {
+        $rows = $this->importer()->import(
+            $this->file(
+                "osm\tN/42\tcamp_site\t48.5\t2.5\tCamping A\n".
+                "osm\tW/43\thotel\t48.6\t2.6\tHotel B\n".
+                "datatourisme\tFR-1\thotel\t48.7\t2.7\tHotel C\n",
+            ),
+            'bretagne',
+        );
+
+        self::assertSame(3, $rows);
+        $sql = $this->sql();
+        self::assertSame(1, substr_count($sql, 'INSERT INTO osm.accommodations'));
+        self::assertSame(1, substr_count($sql, 'INSERT INTO tourism.accommodations'));
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1: string}>
+     */
+    public static function malformedProvider(): iterable
+    {
+        yield 'too few fields' => ["osm\tN/42\tcamp_site\n", 'expected 6 to 9'];
+        yield 'too many fields' => ["osm\tN/42\tcamp_site\t48.5\t2.5\tA\tb\tc\td\te\n", 'expected 6 to 9'];
+        yield 'unknown source' => ["overpass\tN/42\tcamp_site\t48.5\t2.5\tA\n", 'expected osm or datatourisme'];
+        yield 'malformed osm id' => ["osm\t42\tcamp_site\t48.5\t2.5\tA\n", 'expected the N/123 form'];
+        yield 'non-numeric coordinates' => ["osm\tN/42\tcamp_site\tnorth\t2.5\tA\n", 'non-numeric coordinates'];
+        yield 'coordinates off the planet' => ["osm\tN/42\tcamp_site\t91.0\t2.5\tA\n", 'outside the world'];
+        yield 'empty name' => ["osm\tN/42\tcamp_site\t48.5\t2.5\t\n", 'empty name'];
+        yield 'empty category' => ["osm\tN/42\t\t48.5\t2.5\tA\n", 'empty category'];
+    }
+
+    #[Test]
+    #[DataProvider('malformedProvider')]
+    public function refusesAMalformedFileWholeWithoutInsertingAnything(string $contents, string $expected): void
+    {
+        try {
+            $this->importer()->import($this->file($contents), 'bretagne');
+            self::fail('Expected ImportFailedException');
+        } catch (ImportFailedException $importFailedException) {
+            self::assertStringContainsString($expected, $importFailedException->getMessage());
+        }
+
+        // The parse runs to completion before any statement, so a file the operator got half
+        // right leaves the index exactly as it was.
+        self::assertSame([], $this->captured, 'nothing was inserted');
+    }
+
+    #[Test]
+    public function namesTheOffendingLineSoTheOperatorCanFixIt(): void
+    {
+        try {
+            $this->importer()->import(
+                $this->file(
+                    "osm\tN/42\tcamp_site\t48.5\t2.5\tCamping A\n".
+                    "osm\tN/43\tcamp_site\t48.6\tnorth\tCamping B\n",
+                ),
+                'bretagne',
+            );
+            self::fail('Expected ImportFailedException');
+        } catch (ImportFailedException $importFailedException) {
+            self::assertStringContainsString('line 2', $importFailedException->getMessage());
+        }
+
+        self::assertSame([], $this->captured, 'the first, valid row was not inserted either');
+    }
+
+    #[Test]
+    public function refusesAnEmptyOrMissingFile(): void
+    {
+        try {
+            $this->importer()->import($this->file("\n\n"), 'bretagne');
+            self::fail('Expected ImportFailedException');
+        } catch (ImportFailedException $importFailedException) {
+            self::assertStringContainsString('no data row', $importFailedException->getMessage());
+        }
+
+        try {
+            $this->importer()->import($this->workDir.'/absent.tsv', 'bretagne');
+            self::fail('Expected ImportFailedException');
+        } catch (ImportFailedException $importFailedException) {
+            self::assertStringContainsString('does not exist', $importFailedException->getMessage());
+        }
+
+        self::assertSame([], $this->captured);
+    }
+
+    #[Test]
+    public function aFailedInsertRaisesImportFailedExceptionWithStderr(): void
+    {
+        $importer = new OverrideImporter(
+            static fn (array $command): Process => new Process(['sh', '-c', 'echo "boom" 1>&2; exit 3']),
+        );
+
+        try {
+            $importer->import($this->file("osm\tN/42\tcamp_site\t48.5\t2.5\tCamping\n"), 'bretagne');
+            self::fail('Expected ImportFailedException');
+        } catch (ImportFailedException $importFailedException) {
+            self::assertStringContainsString('boom', $importFailedException->getMessage());
+            self::assertStringContainsString('exit 3', $importFailedException->getMessage());
+        }
+    }
+}

--- a/provisioner/tests/PlaceEnrichmentPassTest.php
+++ b/provisioner/tests/PlaceEnrichmentPassTest.php
@@ -246,7 +246,7 @@ final class PlaceEnrichmentPassTest extends TestCase
             source: 'datatourisme',
             identity: 'a.id',
             exemptCategories: [],
-            boundariesSchema: 'osm',
+            osmSchema: 'osm',
             processFactory: function (array $command): Process {
                 /** @var list<string> $cmd */
                 $cmd = $command;
@@ -380,6 +380,121 @@ final class PlaceEnrichmentPassTest extends TestCase
         foreach (['name', 'description', 'website', 'opening_hours'] as $column) {
             self::assertStringContainsString($column.' = COALESCE(a.'.$column.", c.payload->>'".$column."')", $apply);
         }
+    }
+
+    #[Test]
+    public function writesNoReportWhenNoPathIsGiven(): void
+    {
+        $this->pass()->run($this->workDir, 'osm_staging_bretagne', 'accommodations');
+
+        self::assertFalse($this->hasSqlContaining('/rejected.tsv'));
+    }
+
+    #[Test]
+    public function ranksTheRejectsByDistanceToTheNearestCycleRoute(): void
+    {
+        // The ordering is what makes the exercise finite: the operator works the thirty
+        // rejects that border a véloroute instead of the three thousand lost in open country.
+        // Signed cycle routes are already imported, so the ranking costs nothing.
+        $report = $this->workDir.'/zones/bretagne/rejected.tsv';
+        $this->pass()->run($this->workDir, 'osm_staging_bretagne', 'accommodations', $report);
+
+        $sql = $this->sqlContaining('/rejected.tsv');
+        self::assertStringContainsString('FROM osm_staging_bretagne.cycle_routes r', $sql);
+        // KNN, so the GiST index on cycle_routes.geom is one probe per reject rather than a
+        // full scan of every route.
+        self::assertStringContainsString('ORDER BY r.geom <-> a.geom LIMIT 1', $sql);
+        self::assertStringContainsString('NULLS LAST', $sql, 'a zone with no cycle route at all still produces a readable file');
+    }
+
+    #[Test]
+    public function theReportCarriesEverythingAHumanNeedsToDecide(): void
+    {
+        $report = $this->workDir.'/zones/bretagne/rejected.tsv';
+        $this->pass()->run($this->workDir, 'osm_staging_bretagne', 'accommodations', $report);
+
+        $sql = $this->sqlContaining('/rejected.tsv');
+        foreach (['AS source', 'AS source_id', 'a.category', 'AS lat', 'AS lon', 'AS commune', 'AS reason', 'AS cycle_route_m', 'AS tags'] as $column) {
+            self::assertStringContainsString($column, $sql);
+        }
+
+        // Tab-separated with a header, so the operator can edit it in place and feed it back.
+        self::assertStringContainsString("WITH (FORMAT csv, DELIMITER E'\\t', HEADER true)", $sql);
+    }
+
+    #[Test]
+    public function createsTheReportDirectory(): void
+    {
+        $report = $this->workDir.'/zones/bretagne/rejected.tsv';
+        $this->pass()->run($this->workDir, 'osm_staging_bretagne', 'accommodations', $report);
+
+        self::assertDirectoryExists($this->workDir.'/zones/bretagne');
+    }
+
+    #[Test]
+    public function writesTheReportBeforeTheGateDeletesTheRows(): void
+    {
+        $report = $this->workDir.'/zones/bretagne/rejected.tsv';
+        $this->pass()->run($this->workDir, 'osm_staging_bretagne', 'accommodations', $report);
+
+        $written = $this->commandIndex('/rejected.tsv');
+        $deleted = $this->commandIndex('DELETE FROM osm_staging_bretagne.accommodations');
+        self::assertGreaterThan(-1, $written);
+        self::assertLessThan($deleted, $written, 'otherwise there would be nothing left to report on');
+    }
+
+    #[Test]
+    public function neverReportsARowAnOperatorHasAlreadyCorrected(): void
+    {
+        // Once an override.tsv has inserted the row into live, re-opening the zone re-imports
+        // the same anonymous row into staging. Without this exclusion it would be counted and
+        // listed again every single time, asking to be fixed once more.
+        $pass = new PlaceEnrichmentPass(
+            source: 'osm',
+            identity: "a.osm_type || '/' || a.osm_id",
+            exemptCategories: ['shelter'],
+            liveSchema: 'osm',
+            processFactory: function (array $command): Process {
+                /** @var list<string> $cmd */
+                $cmd = $command;
+                $this->captured[] = $cmd;
+
+                if (1 === preg_match("/TO '([^']+)'/", end($cmd) ?: '', $matches)) {
+                    file_put_contents($matches[1], "0\n");
+                }
+
+                return new Process(['true']);
+            },
+        );
+
+        $pass->run($this->workDir, 'osm_staging_bretagne', 'accommodations', $this->workDir.'/zones/bretagne/rejected.tsv');
+
+        $sql = $this->sqlContaining('/rejected.tsv');
+        self::assertStringContainsString('NOT EXISTS (SELECT 1 FROM osm.accommodations l WHERE l.osm_type = a.osm_type AND l.osm_id = a.osm_id)', $sql);
+        // Same predicate drives the count, so the numbers and the file agree.
+        self::assertStringContainsString('NOT EXISTS (SELECT 1 FROM osm.accommodations l', $this->sqlContaining('place-rejected.tsv'));
+    }
+
+    #[Test]
+    public function matchesTheLiveIdentityOnIdForACuratedSource(): void
+    {
+        $pass = new PlaceEnrichmentPass(
+            source: 'datatourisme',
+            identity: 'a.id',
+            osmSchema: 'osm',
+            liveSchema: 'tourism',
+            processFactory: function (array $command): Process {
+                /** @var list<string> $cmd */
+                $cmd = $command;
+                $this->captured[] = $cmd;
+
+                return new Process(['true']);
+            },
+        );
+
+        $pass->run($this->workDir, 'tourism_staging_bretagne', 'accommodations');
+
+        self::assertStringContainsString('NOT EXISTS (SELECT 1 FROM tourism.accommodations l WHERE l.id = a.id)', $this->sqlContaining('place-rejected.tsv'));
     }
 
     private function commandIndex(string $needle): int


### PR DESCRIPTION
Closes #886.

## The report

Every opening writes `/data/zones/<zone>/rejected.tsv` (and `rejected-datatourisme.tsv`): source, source id, category, coordinates, the commune resolved offline, the motive, the raw tags — and the metres to the nearest signed cycle route, which the file is **sorted by**.

That ordering is the whole design. The signed cycle routes are already imported (`tier1.lua`, relations `type=route, route=bicycle`), so ranking by distance to them is free — and it means an operator works the thirty refusals that border a véloroute instead of the three thousand lost in open country. **The human effort is bounded by construction, not by discipline.** It is a KNN probe (`ORDER BY r.geom <-> a.geom LIMIT 1`) so the existing GiST index does one lookup per reject rather than a scan of every route, with `NULLS LAST` so a zone with no cycle route at all still produces a readable file.

The console prints the counts beside it — resolved, of which matched from the curated flux, refused, and refused by motive — and says out loud what a long file means:

> More entries were refused than resolved. Read that as the resolvers being weak, not as a backlog of manual work: the tag projection should absorb most of the volume, and a long rejected.tsv means it did not.

That reading is what the issue asks the report to make obvious, so it is stated rather than left to be inferred from a row count.

## The corrections

`make provision-override <zone> [file]` imports an `override.tsv` straight into the live tables. **No correction table, no endpoint, no authentication, no interface, no versioning.** From then on:

- the enrichment cache's negative entry keeps the resolver from re-analysing the row;
- the promotion's identity anti-join keeps the import from touching it;
- and the gate predicate now excludes rows already present live, so a corrected entry **stops appearing in the report** — nobody is asked to fix it twice. That last clause is the one addition; the other two already existed.

A malformed file is refused **whole**, naming the line. The parse completes before any statement runs and the insert is one transaction, so a partially applied override cannot exist. `ON CONFLICT DO NOTHING` keeps append-only intact: an override adds what the gate refused, it never rewrites what is already imported.

## Verification

`make qa` cannot complete on a dev machine (CLAUDE.md); the legs were run individually. Only `provisioner/`, `Makefile`, `README.md` and `docs/` changed, so the api and frontend legs have nothing new to check.

| Leg | Result |
|---|---|
| PHPStan (provisioner) | `[OK] No errors` |
| Rector (provisioner) | autofixes applied and committed, re-check `[OK] Rector is done!` |
| PHP-CS-Fixer (provisioner) | `Fixed 0 of 34` on re-run |
| markdownlint | `Summary: 0 error(s)` (87 files) |
| PHPUnit (provisioner) | `OK (199 tests, 894 assertions)` |

`make provision-override` was exercised for its guard and its argument forwarding:

```
$ make provision-override
Usage: make provision-override <zone> [file] (defaults to /data/zones/<zone>/override.tsv)
$ make -n provision-override bretagne
docker compose --profile provisioning run --rm --entrypoint php provisioner -d memory_limit=512M bin/provision-override bretagne
```

Both non-obvious behaviours were mutation-checked: dropping the `ORDER BY` reddens `ranksTheRejectsByDistanceToTheNearestCycleRoute`, and making the parser skip malformed rows instead of refusing the file reddens `namesTheOffendingLineSoTheOperatorCanFixIt` on its "the first, valid row was not inserted either" assertion.

**Playwright is CI's job.**

## Auto-critique

- **It is a second binary, not a sub-command, and the issue says sub-command.** `bin/provision` runs in single-command mode (`setDefaultCommand('provision', true)`), so `provisioner bretagne` passes the zone as an *argument*; registering a real sub-command turns that into an unknown-command error and breaks `make provision <zone>` and `provision-recette` with it. Two binaries keep the existing invocation intact. The alternative — dropping single-command mode and changing every call site to `provision <zone>` — is a bigger, more disruptive change for a naming preference.
- **The report is not covered by an end-to-end test against a real database.** The `\copy` command is asserted as a string, exactly like the rest of the pass, so a syntax error in the KNN subquery would surface on the first real provisioning run. `ZonePromotionExecutionTest` exists as the pattern for fixing that; I did not extend it here because seeding cycle-route multilinestrings and admin boundaries to prove an ordering is a fixture of its own, and the ordering is the part least likely to be silently wrong (it fails loudly or not at all).
- **`liveIdentityMatch()` derives the live predicate by looking for `osm_type` in the identity expression.** It is a string test on a value this class already owns, and it produces the wrong predicate for any future source whose identity is neither of the two shapes. A per-source parameter would be safer; two sources did not seem to justify one. The two tests pin both shapes.
- **The report is written per source, so an operator opening a zone gets two files.** `rejected.tsv` and `rejected-datatourisme.tsv` share a format and the override importer reads either, but nothing merges them, and the cycle-route ranking is therefore per-file rather than global. Merging would need the two passes to know about each other.
- **The override cannot fix a row that is already live.** `ON CONFLICT DO NOTHING` is deliberate (ADR-049 §5), but it means an operator who mistypes a name in an override has no way to correct it through this path — only `psql`. That is the honest consequence of "never rewritten"; a follow-up that allows a targeted correction would have to argue with §5 first.
- **The `zonesDir` default is `/data/zones` in two places.** `ProvisionCommand` and `ImportOverrideCommand` each carry the constant, so a change has to be made twice. Sharing it would mean a third class or a constant on one command referenced by the other; at two occurrences I left the duplication visible rather than adding indirection.
- **Nothing tests that the report ends up on the host.** The path lands under `/data`, which is bind-mounted to `.docker/osm/data` and gitignored in full, and I verified the gitignore covers it (`git check-ignore` on the target path). But the bind mount itself is only asserted by reading `compose.yaml`.

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 critical, 0 warning, 0 minor findings. The re-review confirms the SQL wiring (KNN ranking against the existing GiST index, the live-schema anti-join, the positional-argument report query) is correct, injection-safe (all operator-supplied override fields go through `ZonePromotion::literal`), and consistent with its own documentation and tests.

**Resolved threads:** Resolved 1 previously open thread (orphaned docblock above `gatePredicate()` — fixed by 9de70b7c).

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

**Commit reviewed:** 9de70b7c5fce8599029f28d9984cdfa28a8131c3
<!-- claude-review-end -->
