### PR TITLE
chore: apply the sprint 49 retrospective to the review workflow, /pick and CLAUDE.md

### DIFF
--- a/.claude/skills/pick/SKILL.md
+++ b/.claude/skills/pick/SKILL.md
@@ -17,7 +17,9 @@ Check that the issue number is a valid number. If not, ask the user for a valid 
 
 ## Step 2 -- Fetch and confirm
 
-Run `gh issue view <issue-number>` and display the issue title and body summary. Ask the user to confirm before proceeding. Also ask if they want to use a different base branch than the default.
+Run `gh issue view <issue-number> --comments` and display the issue title and body summary. Ask the user to confirm before proceeding. Also ask if they want to use a different base branch than the default.
+
+**Read the comments, not only the body — a comment can contradict the scope and then it is the comment that is authoritative.** Sprint 49, #884: the body sketched a five-key name-resolution cascade; a comment carried the measurement from #878 showing two of those keys had **0 occurrences** over 16 886 rows and a third only 11, all of them useless values. Implementing the body as written would have shipped code with no data behind it. `gh issue view` alone does **not** show comments, which is why the flag is not optional.
 
 ## Step 3 -- Create worktree
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -48,7 +48,7 @@ jobs:
           allowed_bots: "claude[bot]"
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
-            --allowedTools "mcp__github__*,mcp__github_inline_comment__*,Bash(*),Read,Glob,Grep,Write,WebFetch,WebSearch"
+            --allowedTools "mcp__github__*,mcp__github_inline_comment__*,Bash(*),Read,Glob,Grep,Write,Edit,WebFetch,WebSearch"
           prompt: |
             You are a senior code reviewer for the Bike Trip Planner project.
             Review pull request #${{ github.event.pull_request.number }} following the project's review standards.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,22 @@ Two traps in that command:
 
 `make test-e2e` needs the PWA built and served on `https://localhost`; a worktree's changes are not in the main stack's bundle. **CI is the real gate for Playwright** — say so plainly rather than implying local coverage you did not have. Since the pre-commit hook replays `make qa`, commit with `git -c core.hooksPath=/dev/null commit` once the legs are individually green.
 
+### `make` swallows `--flags`
+
+A target that forwards `$(ARGS)` cannot receive an option: `make` claims anything starting
+with `--` for itself and dies before the recipe runs.
+
+```bash
+$ make provision corse --allow-unrouted-zone
+make : l'option « --allow-unrouted-zone » n'a pas été reconnue
+```
+
+Pass the flag to the container directly instead, keeping the target for the common case:
+
+```bash
+docker compose --profile provisioning run --rm provisioner corse --allow-unrouted-zone
+```
+
 ### Claude Code Skills
 
 ```bash


### PR DESCRIPTION
Retrospective of sprint 49 (#883-#886, #891, all merged). Three of the five findings, the ones you retained.

## 1. `claude-review` was losing its inline comments

The allowlist had `Write` but not `Edit`, and the bot edits `/tmp/pr<n>_body.txt` to publish its summary — so the job failed on a permission denial **after** deciding its verdict but **before** posting the comments.

Cost this sprint, on three PRs:

| PR | What was lost |
|---|---|
| [#946](https://github.com/vincentchalamon/bike-trip-planner/pull/946) | job failed twice; verdict only readable in the workflow log |
| [#950](https://github.com/vincentchalamon/bike-trip-planner/pull/950) | an **approving** review whose 2 inline suggestions were never posted — one of them a real missing index |
| [#952](https://github.com/vincentchalamon/bike-trip-planner/pull/952) | 1 inline comment idem |

```diff
-            --allowedTools "…,Write,WebFetch,WebSearch"
+            --allowedTools "…,Write,Edit,WebFetch,WebSearch"
```

Worth noting because it corrects the record: the project memory attributes this failure to *rebased* PRs. It is not about rebasing — it happens on any PR whose body the bot updates, which is every one.

## 2. `/pick` was reading issue bodies without their comments

On #884 the body sketched a five-key name-resolution cascade. A comment carried the #878 measurement: two of those keys had **0 occurrences** over 16 886 rows, a third only 11 (all "Salle hors-sac"), and the remaining one was 92% transport operators. Implementing the body as written would have shipped code with no data behind it.

`gh issue view` does **not** show comments, so the skill now passes `--comments` and states that a comment can contradict the scope and then wins.

## 3. `make` swallows `--flags`

```text
$ make provision corse --allow-unrouted-zone
make : l'option « --allow-unrouted-zone » n'a pas été reconnue
```

A target forwarding `$(ARGS)` cannot receive an option. Documented in the Local QA section with the container form to use instead — it cost a wrong instruction in the #891 runbook until I checked.

## Not retained

Proposed and dropped at your call, recorded here so they are not lost:

- **`ResetDatabase` replays the migrations per test class**, so mutating a constraint by hand on `app_test` to prove it rejects does nothing — you must mutate the migration. Cost one false-negative mutation check on #884.
- **The provisioner image ships `psql` without `pdo_pgsql`; the CI container image is the reverse.** A DB-dependent provisioner test written for one path skips silently on both sides, and `markTestSkipped` in `setUp` lets `tearDown` turn the skip into an error. Both hit `ZonePromotionExecutionTest` on #946.

## Verification

| Leg | Result |
|---|---|
| markdownlint (`CLAUDE.md`) | `Summary: 0 error(s)` |
| link-check | `cassures internes: 0` (96 files) |
| workflow YAML | re-parsed with `yq`; `allowedTools` now contains `Edit` |

No manual application required: none of these touch `.claude/settings.json`.

## Auto-critique

- **The workflow change is not verified, and this PR cannot verify it.** I initially wrote that the next review on this very PR would be the proof. It is not: the workflow skips itself when `claude-code-review.yml` is in the diff (`Skipping code review: the workflow file itself was modified in this PR`), which is a sensible guard and means `claude-review` reported `SUCCESS` here **without running**. Whether adding `Edit` is sufficient — rather than the bot needing `Edit(/tmp/**)` or something else — is provable only by the first PR after this one that does *not* touch the workflow. If its review posts inline comments and stays green, that is the proof; if it fails again, the log will name the next denied tool.
- **Finding 1 makes the reviewer able to edit files in its checkout, not only `/tmp`.** The allowlist is not path-scoped, so `Edit` is granted broadly for a need that is narrow. `Edit(/tmp/**)` would be tighter, but I do not know that the harness accepts that syntax for `Edit` the way it does for `Bash`, and guessing would risk a second broken run. Worth narrowing once observed working.
- **A fourth, unrequested finding surfaced while verifying this PR** and I did not act on it: `make markdownlint` lints `pwa/test-results/`, so a machine with stale Playwright artifacts fails the target on files that are gitignored and not part of the repo. It is a local-only annoyance, but it means the target's output cannot be trusted as-is without reading which files failed.
- **The two dropped findings are now only in this PR body.** They are real and will bite again; if you would rather have them in `CLAUDE.md` after all, they are two short gotchas.
