### PR TITLE
feat(in-ride): enum de catégories et lecteur PostGIS 8 buckets

### DIFF
--- a/api/src/InRide/InRidePoiCategory.php
+++ b/api/src/InRide/InRidePoiCategory.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\InRide;
+
+/**
+ * In-ride intent categories served from the local-first Tier-1 index (ADR-040).
+ *
+ * Widens the four legacy intents (water/shelter/food/mechanic) to the eight
+ * actionable buckets the index already holds: resupply (the shopping half of
+ * osm.pois), health services, railway stations and e-bike charging points
+ * (#927/#928). Each case drives {@see InRidePoiRepository}: the target osm.*
+ * table, the KNN candidate cap, whether an unnamed row is actionable, and the
+ * default search radius.
+ */
+enum InRidePoiCategory: string
+{
+    case WATER = 'water';
+    case SHELTER = 'shelter';
+    case FOOD = 'food';
+    case RESUPPLY = 'resupply';
+    case MECHANIC = 'mechanic';
+    case HEALTH = 'health';
+    case TRAIN = 'train';
+    case CHARGING = 'charging';
+
+    // Floor lowered from 2000 to 1000 m (#930): a rider in a village wants the
+    // fountain on the next street, not one kilometre out.
+    public const int MIN_RADIUS_METERS = 1_000;
+
+    public const int MAX_RADIUS_METERS = 20_000;
+
+    /**
+     * Default reach when the caller sends none: immediate needs (water, cover,
+     * a meal) stay close; resupply and health widen; a bike shop, a station or a
+     * charger is worth a longer detour because they are sparse.
+     */
+    public function defaultRadiusMeters(): int
+    {
+        return match ($this) {
+            self::WATER, self::SHELTER, self::FOOD => 3_000,
+            self::RESUPPLY, self::HEALTH => 5_000,
+            self::MECHANIC, self::TRAIN, self::CHARGING => 10_000,
+        };
+    }
+
+    /**
+     * Category default when null, otherwise the requested radius clamped to
+     * [MIN_RADIUS_METERS, MAX_RADIUS_METERS].
+     */
+    public function clampRadius(?int $requested): int
+    {
+        if (null === $requested) {
+            return $this->defaultRadiusMeters();
+        }
+
+        return max(self::MIN_RADIUS_METERS, min(self::MAX_RADIUS_METERS, $requested));
+    }
+
+    /**
+     * Buckets where an entry without a name is not actionable: you cannot tell a
+     * rider to head for an unnamed restaurant, bike shop, pharmacy or station.
+     * Water points, shelters and chargers stay useful nameless (a fountain, a
+     * bus shelter, a charging post are found by position), so the name filter
+     * drops down to SQL only for these.
+     */
+    public function requiresName(): bool
+    {
+        return match ($this) {
+            self::FOOD, self::MECHANIC, self::HEALTH, self::TRAIN => true,
+            default => false,
+        };
+    }
+
+    /**
+     * KNN candidate cap. 50 restored the old Overpass ceiling, but where an
+     * opening-hours filter still runs in PHP after the read (the venues a rider
+     * needs open now: food, resupply, health, a bike shop) the 50 nearest can
+     * all be closed and leave an empty answer, and widening the radius does not
+     * change which 50 are nearest. Those buckets fetch 200; the always-available
+     * ones (water, shelter, station, charger) keep 50.
+     */
+    public function candidateLimit(): int
+    {
+        return match ($this) {
+            self::FOOD, self::RESUPPLY, self::MECHANIC, self::HEALTH => 200,
+            default => 50,
+        };
+    }
+}

--- a/api/src/InRide/InRidePoiRepository.php
+++ b/api/src/InRide/InRidePoiRepository.php
@@ -10,6 +10,13 @@ use Doctrine\DBAL\Connection;
  * Reads nearby in-ride POIs from the local-first Tier-1 index (ADR-040), mapping
  * each in-ride intent category to its osm.* table around the rider position —
  * replacing the runtime Overpass in-ride scan and its 5-minute cache.
+ *
+ * GiST caveat (same as {@see \App\Osm\AccommodationRepository}): the
+ * `ST_DWithin(geom::geography, ...)` radius predicate does NOT use the GiST index
+ * on `geom` (it casts to `geography`); it is the KNN `ORDER BY geom <-> point
+ * LIMIT n` that the index accelerates and that bounds the scan. The two work
+ * together: the ORDER BY caps the candidate set to the n nearest, ST_DWithin then
+ * drops those past the radius.
  */
 final readonly class InRidePoiRepository implements InRidePoiRepositoryInterface
 {
@@ -17,40 +24,33 @@ final readonly class InRidePoiRepository implements InRidePoiRepositoryInterface
     {
     }
 
-    public function findNearby(float $lat, float $lon, int $radiusMeters, string $category): array
+    public function findNearby(float $lat, float $lon, int $radiusMeters, InRidePoiCategory $category): array
     {
-        // `ORDER BY geom <-> point LIMIT 50` uses the GiST KNN operator to fetch
-        // the 50 nearest candidates only (restoring the old Overpass cap), so a
-        // dense city centre never floods buildSuggestions' per-row work.
-        $sql = match ($category) {
-            PoiSuggestion::CATEGORY_WATER => <<<'SQL'
-                SELECT ST_Y(geom) AS lat, ST_X(geom) AS lon, tags FROM osm.water_points
-                WHERE ST_DWithin(geom::geography, ST_SetSRID(ST_MakePoint(:lon, :lat), 4326)::geography, :radius)
-                ORDER BY geom <-> ST_SetSRID(ST_MakePoint(:lon, :lat), 4326) LIMIT 50
-                SQL,
-            PoiSuggestion::CATEGORY_SHELTER => <<<'SQL'
-                SELECT ST_Y(geom) AS lat, ST_X(geom) AS lon, tags FROM osm.accommodations
-                WHERE category = 'shelter'
-                  AND ST_DWithin(geom::geography, ST_SetSRID(ST_MakePoint(:lon, :lat), 4326)::geography, :radius)
-                ORDER BY geom <-> ST_SetSRID(ST_MakePoint(:lon, :lat), 4326) LIMIT 50
-                SQL,
-            PoiSuggestion::CATEGORY_FOOD => <<<'SQL'
-                SELECT ST_Y(geom) AS lat, ST_X(geom) AS lon, tags FROM osm.pois
-                WHERE category IN ('restaurant', 'cafe', 'fast_food')
-                  AND ST_DWithin(geom::geography, ST_SetSRID(ST_MakePoint(:lon, :lat), 4326)::geography, :radius)
-                ORDER BY geom <-> ST_SetSRID(ST_MakePoint(:lon, :lat), 4326) LIMIT 50
-                SQL,
-            PoiSuggestion::CATEGORY_MECHANIC => <<<'SQL'
-                SELECT ST_Y(geom) AS lat, ST_X(geom) AS lon, tags FROM osm.bike_shops
-                WHERE ST_DWithin(geom::geography, ST_SetSRID(ST_MakePoint(:lon, :lat), 4326)::geography, :radius)
-                ORDER BY geom <-> ST_SetSRID(ST_MakePoint(:lon, :lat), 4326) LIMIT 50
-                SQL,
-            default => null,
-        };
+        [$table, $openingHours, $filters] = $this->target($category);
 
-        if (null === $sql) {
-            return [];
+        $where = ['ST_DWithin(geom::geography, ST_SetSRID(ST_MakePoint(:lon, :lat), 4326)::geography, :radius)'];
+        foreach ($filters as $filter) {
+            $where[] = $filter;
         }
+
+        // A named venue is required for buckets where an unnamed row is not
+        // actionable; pushed to SQL so it does not eat into candidateLimit().
+        if ($category->requiresName()) {
+            $where[] = "name IS NOT NULL AND btrim(name) <> ''";
+        }
+
+        $whereSql = implode("\n              AND ", $where);
+        $limit = $category->candidateLimit();
+
+        // $table/$openingHours/$limit come from the enum, never from a caller,
+        // so interpolating them is safe; the runtime values stay bound.
+        $sql = <<<SQL
+            SELECT osm_type, osm_id, name, category, {$openingHours} AS opening_hours,
+                   ST_Y(geom) AS lat, ST_X(geom) AS lon, tags
+            FROM {$table}
+            WHERE {$whereSql}
+            ORDER BY geom <-> ST_SetSRID(ST_MakePoint(:lon, :lat), 4326) LIMIT {$limit}
+            SQL;
 
         /** @var list<array<string, scalar|null>> $rows */
         $rows = $this->connection->fetchAllAssociative($sql, [
@@ -62,13 +62,60 @@ final readonly class InRidePoiRepository implements InRidePoiRepositoryInterface
         $features = [];
         foreach ($rows as $row) {
             $features[] = [
+                'osmType' => (string) $row['osm_type'],
+                'osmId' => (int) $row['osm_id'],
+                'name' => null === $row['name'] ? null : (string) $row['name'],
+                'category' => (string) $row['category'],
                 'lat' => (float) $row['lat'],
                 'lon' => (float) $row['lon'],
+                'openingHours' => null === $row['opening_hours'] ? null : (string) $row['opening_hours'],
                 'tags' => $this->decodeTags($row['tags']),
             ];
         }
 
         return $features;
+    }
+
+    /**
+     * Table, opening-hours source expression and extra WHERE clauses for a bucket.
+     *
+     * The shelter bucket keeps the exclusion-list stance decided in #928, NOT the
+     * strict whitelist the README carried before it: on the ride an `amenity=shelter`
+     * of any kind keeps rain off, so only the useless street furniture is dropped
+     * (`carport`, `gazebo`, `umbrella`, `shopping_cart`), and `public_transport`
+     * (the bus shelter, 75% of the layer) is deliberately KEPT — the reader labels
+     * it distinctly downstream (`shelter_bus` -> "Abribus"). Unlike lodging
+     * ({@see \App\Osm\OsmAccommodationSource}), an unnamed shelter is not discarded.
+     *
+     * Resupply reads the shopping half of osm.pois; its whitelist already leaves out
+     * `fuel` and `pharmacy` (a pharmacy is served by the health bucket instead), so a
+     * pharmacy indexed in both osm.pois and osm.health_services surfaces once per
+     * search, never twice. Charging keeps only bike-usable posts (`bicycle=yes` or a
+     * bike-compatible socket key) so an unqualified car charger is dropped.
+     *
+     * @return array{0: string, 1: string, 2: list<string>}
+     */
+    private function target(InRidePoiCategory $category): array
+    {
+        return match ($category) {
+            InRidePoiCategory::WATER => ['osm.water_points', "tags->>'opening_hours'", []],
+            InRidePoiCategory::SHELTER => ['osm.accommodations', 'opening_hours', [
+                "category = 'shelter'",
+                "coalesce(tags->>'shelter_type', '') NOT IN ('carport', 'gazebo', 'umbrella', 'shopping_cart')",
+            ]],
+            InRidePoiCategory::FOOD => ['osm.pois', 'opening_hours', [
+                "category IN ('restaurant', 'cafe', 'fast_food', 'bar', 'pub')",
+            ]],
+            InRidePoiCategory::RESUPPLY => ['osm.pois', 'opening_hours', [
+                "category IN ('supermarket', 'convenience', 'bakery', 'butcher', 'greengrocer', 'deli', 'general', 'pastry', 'farm', 'marketplace')",
+            ]],
+            InRidePoiCategory::MECHANIC => ['osm.bike_shops', "tags->>'opening_hours'", []],
+            InRidePoiCategory::HEALTH => ['osm.health_services', "tags->>'opening_hours'", []],
+            InRidePoiCategory::TRAIN => ['osm.railway_stations', "tags->>'opening_hours'", []],
+            InRidePoiCategory::CHARGING => ['osm.charging_stations', "tags->>'opening_hours'", [
+                "(tags->>'bicycle' = 'yes' OR jsonb_exists(tags, 'socket:schuko') OR jsonb_exists(tags, 'socket:typee') OR jsonb_exists(tags, 'socket:type2'))",
+            ]],
+        };
     }
 
     /**

--- a/api/src/InRide/InRidePoiRepositoryInterface.php
+++ b/api/src/InRide/InRidePoiRepositoryInterface.php
@@ -8,9 +8,12 @@ interface InRidePoiRepositoryInterface
 {
     /**
      * Nearby features of the given in-ride category within $radiusMeters of the
-     * rider position, with their raw OSM tags (name, opening_hours, phone...).
+     * rider position. `name` and `openingHours` are read from a column where the
+     * table has one, otherwise from `tags->>'opening_hours'`; `osmType`/`osmId`
+     * carry the index primary key so a suggestion can be de-duplicated and linked
+     * back to openstreetmap.org.
      *
-     * @return list<array{lat: float, lon: float, tags: array<string, string>}>
+     * @return list<array{osmType: string, osmId: int, name: ?string, category: string, lat: float, lon: float, openingHours: ?string, tags: array<string, string>}>
      */
-    public function findNearby(float $lat, float $lon, int $radiusMeters, string $category): array;
+    public function findNearby(float $lat, float $lon, int $radiusMeters, InRidePoiCategory $category): array;
 }

--- a/api/tests/Integration/Osm/InRidePoiIndexReadTest.php
+++ b/api/tests/Integration/Osm/InRidePoiIndexReadTest.php
@@ -4,17 +4,19 @@ declare(strict_types=1);
 
 namespace App\Tests\Integration\Osm;
 
+use App\InRide\InRidePoiCategory;
 use App\InRide\InRidePoiRepository;
-use App\InRide\PoiSuggestion;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Foundry\Test\ResetDatabase;
 
 /**
- * Integration coverage for the local-first in-ride read layer (ADR-040): each
- * in-ride intent category maps to its osm.* table around the rider position,
- * with raw tags decoded — replacing the runtime Overpass in-ride scan.
+ * Integration coverage for the local-first in-ride read layer (ADR-040): each of
+ * the eight in-ride intent categories maps to its osm.* table around the rider
+ * position, with the SQL-side filters (name, shelter furniture, resupply
+ * whitelist, e-bike sockets) applied — replacing the runtime Overpass in-ride
+ * scan.
  */
 final class InRidePoiIndexReadTest extends KernelTestCase
 {
@@ -30,47 +32,129 @@ final class InRidePoiIndexReadTest extends KernelTestCase
         $connection = self::getContainer()->get('doctrine.dbal.default_connection');
         $this->connection = $connection;
 
-        $this->connection->executeStatement('TRUNCATE osm.water_points, osm.accommodations, osm.pois, osm.bike_shops');
+        $this->connection->executeStatement(
+            'TRUNCATE osm.water_points, osm.accommodations, osm.pois, osm.bike_shops, '
+            .'osm.health_services, osm.railway_stations, osm.charging_stations'
+        );
 
-        // One feature per category at (49.61, 6.14), plus decoys that the category
-        // mapping must exclude (a hotel for shelter, a viewpoint for food).
+        // One actionable feature per bucket at (49.61, 6.14), plus the decoys each
+        // filter must reject. All at the same point so only the category mapping and
+        // the SQL predicates decide what comes back, not the distance.
         $this->connection->executeStatement(<<<'SQL'
             INSERT INTO osm.water_points (osm_type, osm_id, name, category, tags, geom) VALUES
-              ('n', 1, 'Fontaine', 'drinking_water', '{"name":"Fontaine"}'::jsonb, ST_SetSRID(ST_MakePoint(6.14, 49.61), 4326));
+              ('n', 1, 'Fontaine', 'drinking_water', '{"name":"Fontaine","opening_hours":"24/7"}'::jsonb, ST_SetSRID(ST_MakePoint(6.14, 49.61), 4326));
+
             INSERT INTO osm.accommodations (osm_type, osm_id, name, category, tags, geom) VALUES
-              ('n', 2, 'Abri', 'shelter', '{"name":"Abri"}'::jsonb, ST_SetSRID(ST_MakePoint(6.14, 49.61), 4326)),
-              ('n', 3, 'Hotel', 'hotel', '{"name":"Hotel"}'::jsonb, ST_SetSRID(ST_MakePoint(6.14, 49.61), 4326));
-            INSERT INTO osm.pois (osm_type, osm_id, name, category, tags, geom) VALUES
-              ('n', 4, 'Resto', 'restaurant', '{"name":"Resto","opening_hours":"24/7"}'::jsonb, ST_SetSRID(ST_MakePoint(6.14, 49.61), 4326)),
-              ('n', 5, 'Belvedere', 'viewpoint', '{"name":"Belvedere"}'::jsonb, ST_SetSRID(ST_MakePoint(6.14, 49.61), 4326));
+              ('n', 10, 'Abribus', 'shelter', '{"name":"Abribus","shelter_type":"public_transport"}'::jsonb, ST_SetSRID(ST_MakePoint(6.14, 49.61), 4326)),
+              ('n', 11, NULL, 'shelter', '{"shelter_type":"public_transport"}'::jsonb, ST_SetSRID(ST_MakePoint(6.14, 49.61), 4326)),
+              ('n', 12, 'Chariots', 'shelter', '{"name":"Chariots","shelter_type":"shopping_cart"}'::jsonb, ST_SetSRID(ST_MakePoint(6.14, 49.61), 4326)),
+              ('n', 13, 'Carport', 'shelter', '{"name":"Carport","shelter_type":"carport"}'::jsonb, ST_SetSRID(ST_MakePoint(6.14, 49.61), 4326)),
+              ('n', 14, 'Hotel', 'hotel', '{"name":"Hotel"}'::jsonb, ST_SetSRID(ST_MakePoint(6.14, 49.61), 4326));
+
+            INSERT INTO osm.pois (osm_type, osm_id, name, category, opening_hours, tags, geom) VALUES
+              ('n', 20, 'Resto', 'restaurant', 'Mo-Su 12:00-14:00', '{"name":"Resto","opening_hours":"Mo-Su 12:00-14:00"}'::jsonb, ST_SetSRID(ST_MakePoint(6.14, 49.61), 4326)),
+              ('n', 21, 'Super', 'supermarket', NULL, '{"name":"Super"}'::jsonb, ST_SetSRID(ST_MakePoint(6.14, 49.61), 4326)),
+              ('n', 22, 'Station-service', 'fuel', NULL, '{"name":"Station-service"}'::jsonb, ST_SetSRID(ST_MakePoint(6.14, 49.61), 4326)),
+              ('n', 30, 'Pharmacie', 'pharmacy', NULL, '{"name":"Pharmacie"}'::jsonb, ST_SetSRID(ST_MakePoint(6.14, 49.61), 4326));
+
             INSERT INTO osm.bike_shops (osm_type, osm_id, name, category, tags, geom) VALUES
-              ('n', 6, 'Cycles', 'bicycle', '{"name":"Cycles"}'::jsonb, ST_SetSRID(ST_MakePoint(6.14, 49.61), 4326));
+              ('n', 40, 'Cycles', 'bicycle', '{"name":"Cycles"}'::jsonb, ST_SetSRID(ST_MakePoint(6.14, 49.61), 4326));
+
+            INSERT INTO osm.health_services (osm_type, osm_id, name, category, tags, geom) VALUES
+              ('n', 30, 'Pharmacie', 'pharmacy', '{"name":"Pharmacie","opening_hours":"Mo-Sa 09:00-19:00"}'::jsonb, ST_SetSRID(ST_MakePoint(6.14, 49.61), 4326));
+
+            INSERT INTO osm.railway_stations (osm_type, osm_id, name, category, tags, geom) VALUES
+              ('n', 50, 'Gare', 'station', '{"name":"Gare"}'::jsonb, ST_SetSRID(ST_MakePoint(6.14, 49.61), 4326));
+
+            INSERT INTO osm.charging_stations (osm_type, osm_id, name, category, tags, geom) VALUES
+              ('n', 60, 'Borne VAE', 'charging_station', '{"name":"Borne VAE","bicycle":"yes"}'::jsonb, ST_SetSRID(ST_MakePoint(6.14, 49.61), 4326)),
+              ('n', 61, 'Borne voiture', 'charging_station', '{"name":"Borne voiture","socket:chademo":"1"}'::jsonb, ST_SetSRID(ST_MakePoint(6.14, 49.61), 4326));
             SQL);
     }
 
     #[Test]
-    public function findNearbyMapsEachCategoryToItsTableWithDecodedTags(): void
+    public function eachBucketReadsItsTable(): void
     {
         $repository = new InRidePoiRepository($this->connection);
 
-        $water = $repository->findNearby(49.61, 6.14, 2000, PoiSuggestion::CATEGORY_WATER);
+        $water = $repository->findNearby(49.61, 6.14, 5000, InRidePoiCategory::WATER);
         self::assertCount(1, $water);
-        self::assertSame('Fontaine', $water[0]['tags']['name']);
+        self::assertSame('Fontaine', $water[0]['name']);
+        // opening_hours has no column on water_points -> read from tags->>'opening_hours'.
+        self::assertSame('24/7', $water[0]['openingHours']);
+        self::assertSame('n', $water[0]['osmType']);
+        self::assertSame(1, $water[0]['osmId']);
         self::assertEqualsWithDelta(49.61, $water[0]['lat'], 0.0001);
 
-        // Shelter reads osm.accommodations filtered to category 'shelter' — the hotel is excluded.
-        $shelter = $repository->findNearby(49.61, 6.14, 2000, PoiSuggestion::CATEGORY_SHELTER);
-        self::assertCount(1, $shelter);
-        self::assertSame('Abri', $shelter[0]['tags']['name']);
+        $food = $repository->findNearby(49.61, 6.14, 5000, InRidePoiCategory::FOOD);
+        self::assertSame(['Resto'], array_column($food, 'name'));
+        // opening_hours read from its column on osm.pois.
+        self::assertSame('Mo-Su 12:00-14:00', $food[0]['openingHours']);
 
-        // Food reads osm.pois filtered to restaurant/cafe/fast_food — the viewpoint is excluded.
-        $food = $repository->findNearby(49.61, 6.14, 2000, PoiSuggestion::CATEGORY_FOOD);
-        self::assertCount(1, $food);
-        self::assertSame('24/7', $food[0]['tags']['opening_hours']);
+        $mechanic = $repository->findNearby(49.61, 6.14, 5000, InRidePoiCategory::MECHANIC);
+        self::assertSame(['Cycles'], array_column($mechanic, 'name'));
 
-        $mechanic = $repository->findNearby(49.61, 6.14, 2000, PoiSuggestion::CATEGORY_MECHANIC);
-        self::assertCount(1, $mechanic);
-        self::assertSame('Cycles', $mechanic[0]['tags']['name']);
+        $train = $repository->findNearby(49.61, 6.14, 5000, InRidePoiCategory::TRAIN);
+        self::assertSame(['Gare'], array_column($train, 'name'));
+    }
+
+    #[Test]
+    public function shelterKeepsBusSheltersAndDropsStreetFurnitureWithoutRequiringAName(): void
+    {
+        $repository = new InRidePoiRepository($this->connection);
+
+        $shelter = $repository->findNearby(49.61, 6.14, 5000, InRidePoiCategory::SHELTER);
+        $names = array_column($shelter, 'name');
+
+        // public_transport is kept (named bus shelter + the unnamed one), the hotel is
+        // not a shelter, and carport/shopping_cart street furniture is excluded.
+        self::assertCount(2, $shelter);
+        self::assertContains('Abribus', $names);
+        self::assertContains(null, $names, 'an unnamed shelter must not be dropped');
+        self::assertNotContains('Carport', $names);
+        self::assertNotContains('Chariots', $names);
+        self::assertNotContains('Hotel', $names);
+
+        foreach ($shelter as $row) {
+            self::assertSame('public_transport', $row['tags']['shelter_type']);
+        }
+    }
+
+    #[Test]
+    public function resupplyExcludesFuelAndPharmacy(): void
+    {
+        $repository = new InRidePoiRepository($this->connection);
+
+        $resupply = $repository->findNearby(49.61, 6.14, 5000, InRidePoiCategory::RESUPPLY);
+
+        self::assertSame(['Super'], array_column($resupply, 'name'));
+    }
+
+    #[Test]
+    public function pharmacyIndexedInPoisAndHealthServicesSurfacesOncePerSearch(): void
+    {
+        $repository = new InRidePoiRepository($this->connection);
+
+        // Resupply reads osm.pois, whose whitelist leaves out pharmacy: 0 occurrence.
+        $resupplyNames = array_column($repository->findNearby(49.61, 6.14, 5000, InRidePoiCategory::RESUPPLY), 'name');
+        self::assertNotContains('Pharmacie', $resupplyNames);
+
+        // Health reads osm.health_services: the pharmacy appears exactly once, never
+        // duplicated by its osm.pois twin (same osm_type/osm_id).
+        $health = $repository->findNearby(49.61, 6.14, 5000, InRidePoiCategory::HEALTH);
+        self::assertSame(['Pharmacie'], array_column($health, 'name'));
+        self::assertSame('Mo-Sa 09:00-19:00', $health[0]['openingHours']);
+    }
+
+    #[Test]
+    public function chargingKeepsOnlyBikeUsablePosts(): void
+    {
+        $repository = new InRidePoiRepository($this->connection);
+
+        $charging = $repository->findNearby(49.61, 6.14, 5000, InRidePoiCategory::CHARGING);
+
+        // The unqualified car charger (socket:chademo, no bicycle=yes) is dropped.
+        self::assertSame(['Borne VAE'], array_column($charging, 'name'));
     }
 
     #[Test]
@@ -78,7 +162,7 @@ final class InRidePoiIndexReadTest extends KernelTestCase
     {
         $repository = new InRidePoiRepository($this->connection);
 
-        // ~130 km from the seeded features → nothing in a 2 km radius.
-        self::assertSame([], $repository->findNearby(48.0, 2.0, 2000, PoiSuggestion::CATEGORY_WATER));
+        // ~130 km from the seeded features -> nothing in a 1 km radius.
+        self::assertSame([], $repository->findNearby(48.0, 2.0, 1000, InRidePoiCategory::WATER));
     }
 }

--- a/api/tests/Unit/InRide/InRidePoiCategoryTest.php
+++ b/api/tests/Unit/InRide/InRidePoiCategoryTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\InRide;
+
+use App\InRide\InRidePoiCategory;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class InRidePoiCategoryTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('defaultRadiusProvider')]
+    public function defaultRadiusMetersFollowsTheTier(InRidePoiCategory $category, int $expected): void
+    {
+        self::assertSame($expected, $category->defaultRadiusMeters());
+    }
+
+    /**
+     * @return iterable<string, array{InRidePoiCategory, int}>
+     */
+    public static function defaultRadiusProvider(): iterable
+    {
+        yield 'water' => [InRidePoiCategory::WATER, 3_000];
+        yield 'shelter' => [InRidePoiCategory::SHELTER, 3_000];
+        yield 'food' => [InRidePoiCategory::FOOD, 3_000];
+        yield 'resupply' => [InRidePoiCategory::RESUPPLY, 5_000];
+        yield 'health' => [InRidePoiCategory::HEALTH, 5_000];
+        yield 'mechanic' => [InRidePoiCategory::MECHANIC, 10_000];
+        yield 'train' => [InRidePoiCategory::TRAIN, 10_000];
+        yield 'charging' => [InRidePoiCategory::CHARGING, 10_000];
+    }
+
+    #[Test]
+    public function clampRadiusUsesTheCategoryDefaultWhenNull(): void
+    {
+        self::assertSame(3_000, InRidePoiCategory::WATER->clampRadius(null));
+        self::assertSame(10_000, InRidePoiCategory::TRAIN->clampRadius(null));
+    }
+
+    #[Test]
+    public function clampRadiusFloorsBelowMinimum(): void
+    {
+        self::assertSame(InRidePoiCategory::MIN_RADIUS_METERS, InRidePoiCategory::FOOD->clampRadius(10));
+    }
+
+    #[Test]
+    public function clampRadiusCapsAboveMaximum(): void
+    {
+        self::assertSame(InRidePoiCategory::MAX_RADIUS_METERS, InRidePoiCategory::MECHANIC->clampRadius(50_000));
+    }
+
+    #[Test]
+    public function clampRadiusKeepsAnInRangeValue(): void
+    {
+        self::assertSame(7_500, InRidePoiCategory::HEALTH->clampRadius(7_500));
+    }
+
+    #[Test]
+    #[DataProvider('requiresNameProvider')]
+    public function requiresNameOnlyForUnnamedUnactionableBuckets(InRidePoiCategory $category, bool $expected): void
+    {
+        self::assertSame($expected, $category->requiresName());
+    }
+
+    /**
+     * @return iterable<string, array{InRidePoiCategory, bool}>
+     */
+    public static function requiresNameProvider(): iterable
+    {
+        yield 'food' => [InRidePoiCategory::FOOD, true];
+        yield 'mechanic' => [InRidePoiCategory::MECHANIC, true];
+        yield 'health' => [InRidePoiCategory::HEALTH, true];
+        yield 'train' => [InRidePoiCategory::TRAIN, true];
+        yield 'water' => [InRidePoiCategory::WATER, false];
+        yield 'shelter' => [InRidePoiCategory::SHELTER, false];
+        yield 'resupply' => [InRidePoiCategory::RESUPPLY, false];
+        yield 'charging' => [InRidePoiCategory::CHARGING, false];
+    }
+
+    #[Test]
+    #[DataProvider('candidateLimitProvider')]
+    public function candidateLimitIs200WhereAPhpHoursFilterRemains(InRidePoiCategory $category, int $expected): void
+    {
+        self::assertSame($expected, $category->candidateLimit());
+    }
+
+    /**
+     * @return iterable<string, array{InRidePoiCategory, int}>
+     */
+    public static function candidateLimitProvider(): iterable
+    {
+        yield 'food' => [InRidePoiCategory::FOOD, 200];
+        yield 'resupply' => [InRidePoiCategory::RESUPPLY, 200];
+        yield 'mechanic' => [InRidePoiCategory::MECHANIC, 200];
+        yield 'health' => [InRidePoiCategory::HEALTH, 200];
+        yield 'water' => [InRidePoiCategory::WATER, 50];
+        yield 'shelter' => [InRidePoiCategory::SHELTER, 50];
+        yield 'train' => [InRidePoiCategory::TRAIN, 50];
+        yield 'charging' => [InRidePoiCategory::CHARGING, 50];
+    }
+}


### PR DESCRIPTION
Sprint 51, vague 2. **Base `feature/929`** (dépend de #929 : `InRideAssistant`, seul consommateur de l'ancienne signature `findNearby()`, a disparu). Ticket de suivi de #927 / PR #928.

## Changements
- **Nouveau** `api/src/InRide/InRidePoiCategory.php` — enum 8 buckets (WATER, SHELTER, FOOD, RESUPPLY, MECHANIC, HEALTH, TRAIN, CHARGING). `MIN_RADIUS_METERS=1000` (plancher abaissé de 2000, la fenêtre 2000-5000 était une contrainte du classifieur supprimé), `MAX=20000`, `defaultRadiusMeters()` (3000/5000/10000), `clampRadius()`, `requiresName()` (FOOD/MECHANIC/HEALTH/TRAIN), `candidateLimit()` (200 quand un filtre d'horaires subsiste en PHP, 50 sinon).
- **Réécriture** `InRidePoiRepository` + interface : signature typée par l'enum, retour enrichi `{osmType, osmId, name, category, lat, lon, openingHours, tags}`, `name`/`opening_hours` lus en colonne là où elles existent sinon `tags->>'opening_hours'`, filtres descendus en SQL (nom, exclusion `shelter_type`, whitelist ravitaillement sans `fuel`/`pharmacy`, sockets VAE), `candidateLimit()` remplace le `LIMIT 50`, KNN `ORDER BY geom <-> point` conservé, mise en garde GiST reprise au docblock.
- Tests : `InRidePoiCategoryTest` (28 cas) + `InRidePoiIndexReadTest` réécrit (8 buckets + leurres : borne voiture, `shelter_type=carport`/`shopping_cart`, ligne `fuel`, ligne `pharmacy`, pharmacie en doublon pois/health_services, abri sans nom conservé).

## Décision produit
Abris : **liste d'exclusion** (`carport`, `gazebo`, `umbrella`, `shopping_cart`), pas la liste blanche stricte que le README documentait avant #928. `public_transport` **conservé** et étiqueté `shelter_bus` (« Abribus ») : en route un abribus abrite de la pluie. **Filtrage à la lecture**, pas de table `osm.shelters` (aucun changement provisioner, aucun reprovisionnement).

## QA (jambe par jambe)
- Rector : `2 files would have been changed` (style) → autofix appliqué et committé.
- PHPStan level 9 : `[OK] No errors`.
- PHP-CS-Fixer : `Fixed 0 of 644 files`.
- PHPUnit Unit + Integration (PostGIS réel via stack principal) : `Tests: 1444, Assertions: 3857, Skipped: 1`. Preuve de mutation : suppression de l'exclusion `shelter_type` + filtre VAE → 2 échecs, restauré → vert.

## Auto-critique
- `candidateLimit()=200` retenu pour FOOD/RESUPPLY/MECHANIC/HEALTH (lieux à horaires), documenté dans l'enum.
- Playwright non applicable (aucun fichier front) — CI reste le gate.

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 findings (0 critical, 0 warning, 0 minor). Enum-driven rewrite of `InRidePoiRepository::findNearby()` from 4 to 8 buckets; SQL identifiers/limits interpolated only from the enum (never caller input), verified against the real table schemas and osm2pgsql `tier1.lua` mappings — no injection risk, mapping is correct. The zero-caller state is expected per TRACKING.md sprint 51 (#929 orphaned 12 bricks intentionally, restored by #933/#935), not dead code to flag. Test coverage is thorough: enum unit tests cover all 8 cases per method, integration tests cover all 8 buckets plus the tricky edge cases (unnamed shelter kept, pois/health_services pharmacy dedup, bike-only charger filter).

**PR title check:** minor — `feat(in-ride): enum de catégories et lecteur PostGIS 8 buckets` is a noun phrase rather than an imperative-mood description. Matches the sibling issue titles in this same sprint (#930/#931/#932), so treated as informational only, not a blocking issue.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

Commit reviewed: ea118d3f0fdb796d2e2f19e3aec49016e5b503bd
<!-- claude-review-end -->