### PR TITLE
feat(in-ride): polyligne restante côté serveur pour le calcul de détour

### DIFF
--- a/api/src/InRide/DetourCalculator.php
+++ b/api/src/InRide/DetourCalculator.php
@@ -66,7 +66,7 @@ final readonly class DetourCalculator
             $a = $remainingRoute[$i];
             $b = $remainingRoute[$i + 1];
 
-            [$projection, $rawT] = $this->projectOnSegment($poi, $a, $b);
+            [$projection, $rawT] = self::projectOnSegment($poi, $a, $b);
             $perpendicular = $this->distance->inMeters(
                 $poi->lat,
                 $poi->lon,
@@ -113,9 +113,12 @@ final readonly class DetourCalculator
      * The resulting parameter t is clamped to [0, 1] so the projection always lies on
      * the segment (extremities included), which is what we want for a "rejoin point".
      *
+     * Static and stateless so {@see RouteTail} can reuse the exact same
+     * projection to truncate the polyline at the rider position (issue #932).
+     *
      * @return array{GeoPoint, float} the clamped projection point and the raw (unclamped) parameter t
      */
-    private function projectOnSegment(GeoPoint $poi, GeoPoint $a, GeoPoint $b): array
+    public static function projectOnSegment(GeoPoint $poi, GeoPoint $a, GeoPoint $b): array
     {
         if ($a->lat === $b->lat && $a->lon === $b->lon) {
             return [$a, 0.0];

--- a/api/src/InRide/RouteTail.php
+++ b/api/src/InRide/RouteTail.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\InRide;
+
+use App\Geo\GeoDistanceInterface;
+use App\Geo\GeoPoint;
+
+/**
+ * Truncates a stage polyline at the rider's current position so the remaining
+ * itinerary starts exactly where the rider is.
+ *
+ * {@see DetourCalculator} carries a "POI behind the rider" bound that only fires on
+ * the first segment (`segmentIndex === 0 && rawT < 0`). Feeding it the WHOLE stage
+ * polyline makes that bound unreachable (the rider sits in the middle), so a POI
+ * already passed would score a positive detour. `from()` returns a polyline that
+ * begins at the rider's projection, restoring the bound.
+ *
+ * The rider is projected with {@see DetourCalculator::projectOnSegment()} — the same
+ * equirectangular projection the detour uses — onto the nearest segment.
+ */
+final readonly class RouteTail
+{
+    public function __construct(
+        private GeoDistanceInterface $distance,
+    ) {
+    }
+
+    /**
+     * @param list<GeoPoint> $polyline stage polyline, ordered from start to end
+     *
+     * @return list<GeoPoint> the rider's projection, followed by the polyline points ahead of it
+     */
+    public function from(GeoPoint $rider, array $polyline): array
+    {
+        if ([] === $polyline) {
+            return [];
+        }
+
+        $segmentsCount = \count($polyline) - 1;
+        if (0 === $segmentsCount) {
+            return [$polyline[0]];
+        }
+
+        $bestIndex = 0;
+        $bestProjection = $polyline[0];
+        $bestRawT = 0.0;
+        $minPerpendicular = \PHP_FLOAT_MAX;
+
+        for ($i = 0; $i < $segmentsCount; ++$i) {
+            [$projection, $rawT] = DetourCalculator::projectOnSegment($rider, $polyline[$i], $polyline[$i + 1]);
+            $perpendicular = $this->distance->inMeters($rider->lat, $rider->lon, $projection->lat, $projection->lon);
+
+            if ($perpendicular < $minPerpendicular) {
+                $minPerpendicular = $perpendicular;
+                $bestIndex = $i;
+                $bestProjection = $projection;
+                $bestRawT = $rawT;
+            }
+        }
+
+        // The projection leads the tail. Append only the polyline points strictly ahead
+        // of it: when the rider sits at (or past) the segment end (rawT >= 1) the clamped
+        // projection coincides with polyline[bestIndex + 1], so skip that point to avoid a
+        // duplicate; otherwise the next point is polyline[bestIndex + 1].
+        $firstAhead = $bestRawT >= 1.0 ? $bestIndex + 2 : $bestIndex + 1;
+
+        $tail = [$bestProjection];
+        for ($i = $firstAhead, $count = \count($polyline); $i < $count; ++$i) {
+            $tail[] = $polyline[$i];
+        }
+
+        return $tail;
+    }
+}

--- a/api/src/Repository/DoctrineTripRequestRepository.php
+++ b/api/src/Repository/DoctrineTripRequestRepository.php
@@ -21,6 +21,7 @@ use App\Llm\Dto\StageAiAnalysis;
 use App\Osm\CoverageRepositoryInterface;
 use App\Osm\CycleRouteRepositoryInterface;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\AbstractQuery;
 use Doctrine\Persistence\ManagerRegistry;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\DependencyInjection\Attribute\AsAlias;
@@ -324,6 +325,37 @@ final class DoctrineTripRequestRepository extends ServiceEntityRepository implem
         }
 
         return $result;
+    }
+
+    /**
+     * Scalar read of the single `geometry` JSONB column — no join, no hydration of the
+     * stage collection (weather, POIs, accommodations…) that {@see self::getStages()}
+     * would pull in.
+     *
+     * @return list<array{lat: float, lon: float}>|null
+     */
+    public function getStageGeometry(string $tripId, int $dayNumber): ?array
+    {
+        if (!Uuid::isValid($tripId)) {
+            return null;
+        }
+
+        /** @var array{geometry: list<array{lat: float, lon: float, ele: float}>}|null $row */
+        $row = $this->getEntityManager()->createQuery(
+            'SELECT s.geometry FROM App\Entity\Stage s WHERE s.trip = :tripId AND s.dayNumber = :dayNumber',
+        )
+            ->setParameter('tripId', Uuid::fromString($tripId))
+            ->setParameter('dayNumber', $dayNumber)
+            ->getOneOrNullResult(AbstractQuery::HYDRATE_ARRAY);
+
+        if (null === $row || [] === $row['geometry']) {
+            return null;
+        }
+
+        return array_map(
+            static fn (array $point): array => ['lat' => $point['lat'], 'lon' => $point['lon']],
+            $row['geometry'],
+        );
     }
 
     /**

--- a/api/src/Repository/RedisTripRequestRepository.php
+++ b/api/src/Repository/RedisTripRequestRepository.php
@@ -6,6 +6,7 @@ namespace App\Repository;
 
 use App\ApiResource\Model\Accommodation;
 use App\ApiResource\Model\Alert;
+use App\ApiResource\Model\Coordinate;
 use App\ApiResource\Model\PointOfInterest;
 use App\ApiResource\Model\WeatherForecast;
 use App\ApiResource\Stage;
@@ -100,6 +101,32 @@ final readonly class RedisTripRequestRepository implements TripRequestRepository
         $value = $this->get($this->stagesKey($tripId));
 
         return $value;
+    }
+
+    /** @return list<array{lat: float, lon: float}>|null */
+    public function getStageGeometry(string $tripId, int $dayNumber): ?array
+    {
+        $stages = $this->getStages($tripId);
+        if (null === $stages) {
+            return null;
+        }
+
+        foreach ($stages as $stage) {
+            if ($stage->dayNumber !== $dayNumber) {
+                continue;
+            }
+
+            if ([] === $stage->geometry) {
+                return null;
+            }
+
+            return array_map(
+                static fn (Coordinate $point): array => ['lat' => $point->lat, 'lon' => $point->lon],
+                $stage->geometry,
+            );
+        }
+
+        return null;
     }
 
     /**

--- a/api/src/Repository/TripRequestRepositoryInterface.php
+++ b/api/src/Repository/TripRequestRepositoryInterface.php
@@ -49,6 +49,19 @@ interface TripRequestRepositoryInterface
     public function getStages(string $tripId): ?array;
 
     /**
+     * Returns a single stage's route geometry, in travel order, projected to 2D.
+     *
+     * Feeds the in-ride detour calculation ({@see \App\InRide\DetourCalculator}),
+     * which is planar; `ele` is intentionally dropped. A read of only the geometry,
+     * not the whole aggregate ({@see self::getStages()} hydrates weather, POIs,
+     * accommodations…).
+     *
+     * @return list<array{lat: float, lon: float}>|null null when the trip, the day,
+     *                                                  or the geometry does not exist
+     */
+    public function getStageGeometry(string $tripId, int $dayNumber): ?array;
+
+    /**
      * Persists the LLaMA 8B pass-1 AI analysis for a single stage atomically.
      *
      * Targeted by `dayNumber` (1-indexed, matches {@see Stage::$dayNumber}). Required

--- a/api/tests/Integration/LlmPipelineTest.php
+++ b/api/tests/Integration/LlmPipelineTest.php
@@ -386,6 +386,20 @@ final class InMemoryTripRequestRepository implements TripRequestRepositoryInterf
         );
     }
 
+    public function getStageGeometry(string $tripId, int $dayNumber): ?array
+    {
+        foreach ($this->stages as $stage) {
+            if ($stage->dayNumber === $dayNumber && [] !== $stage->geometry) {
+                return array_map(
+                    static fn (Coordinate $point): array => ['lat' => $point->lat, 'lon' => $point->lon],
+                    $stage->geometry,
+                );
+            }
+        }
+
+        return null;
+    }
+
     public function getRequest(string $tripId): TripRequest
     {
         return $this->request;

--- a/api/tests/Integration/Repository/DoctrineTripRequestGeometryTest.php
+++ b/api/tests/Integration/Repository/DoctrineTripRequestGeometryTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Repository;
+
+use App\ApiResource\Model\Coordinate;
+use App\ApiResource\Stage as StageDto;
+use App\ApiResource\TripRequest;
+use App\Entity\Stage as StageEntity;
+use App\Repository\TripRequestRepositoryInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Uid\Uuid;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * Integration coverage for {@see \App\Repository\DoctrineTripRequestRepository::getStageGeometry}:
+ * the in-ride detour input (issue #932). It must read the single `geometry` JSONB column
+ * without hydrating the stage aggregate (weather, POIs, accommodations…).
+ */
+final class DoctrineTripRequestGeometryTest extends KernelTestCase
+{
+    use ResetDatabase;
+
+    private TripRequestRepositoryInterface $repository;
+
+    private EntityManagerInterface $entityManager;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        self::bootKernel();
+
+        $container = self::getContainer();
+
+        /** @var TripRequestRepositoryInterface $repository */
+        $repository = $container->get(TripRequestRepositoryInterface::class);
+        $this->repository = $repository;
+
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = $container->get(EntityManagerInterface::class);
+        $this->entityManager = $entityManager;
+    }
+
+    #[Test]
+    public function returnsStagePointsInTravelOrderWithoutElevation(): void
+    {
+        $tripId = Uuid::v7()->toRfc4122();
+        $this->seedTrip($tripId);
+
+        $this->entityManager->clear();
+
+        self::assertSame(
+            [
+                ['lat' => 48.0, 'lon' => 2.0],
+                ['lat' => 48.1, 'lon' => 2.1],
+                ['lat' => 48.2, 'lon' => 2.2],
+            ],
+            $this->repository->getStageGeometry($tripId, 2),
+        );
+    }
+
+    #[Test]
+    public function doesNotHydrateTheStageAggregate(): void
+    {
+        $tripId = Uuid::v7()->toRfc4122();
+        $this->seedTrip($tripId);
+
+        // Start from a cold identity map: the scalar geometry read must not pull any
+        // Stage entity into the unit of work (unlike getStages(), which hydrates them).
+        $this->entityManager->clear();
+
+        $this->repository->getStageGeometry($tripId, 2);
+
+        $identityMap = $this->entityManager->getUnitOfWork()->getIdentityMap();
+        self::assertArrayNotHasKey(StageEntity::class, $identityMap);
+    }
+
+    #[Test]
+    public function returnsNullForUnknownTrip(): void
+    {
+        self::assertNull($this->repository->getStageGeometry(Uuid::v7()->toRfc4122(), 1));
+    }
+
+    #[Test]
+    public function returnsNullForInvalidTripId(): void
+    {
+        self::assertNull($this->repository->getStageGeometry('not-a-uuid', 1));
+    }
+
+    #[Test]
+    public function returnsNullForUnknownDay(): void
+    {
+        $tripId = Uuid::v7()->toRfc4122();
+        $this->seedTrip($tripId);
+
+        $this->entityManager->clear();
+
+        self::assertNull($this->repository->getStageGeometry($tripId, 99));
+    }
+
+    #[Test]
+    public function returnsNullForEmptyGeometry(): void
+    {
+        $tripId = Uuid::v7()->toRfc4122();
+        $this->repository->initializeTrip($tripId, new TripRequest(Uuid::fromString($tripId)));
+        // Day 1 has no geometry (StageDto default is []).
+        $this->repository->storeStages($tripId, [
+            new StageDto(
+                tripId: $tripId,
+                dayNumber: 1,
+                distance: 10.0,
+                elevation: 50.0,
+                startPoint: new Coordinate(48.0, 2.0),
+                endPoint: new Coordinate(48.1, 2.1),
+            ),
+        ]);
+
+        $this->entityManager->clear();
+
+        self::assertNull($this->repository->getStageGeometry($tripId, 1));
+    }
+
+    private function seedTrip(string $tripId): void
+    {
+        $this->repository->initializeTrip($tripId, new TripRequest(Uuid::fromString($tripId)));
+        $this->repository->storeStages($tripId, [
+            new StageDto(
+                tripId: $tripId,
+                dayNumber: 2,
+                distance: 40.0,
+                elevation: 200.0,
+                startPoint: new Coordinate(48.0, 2.0),
+                endPoint: new Coordinate(48.2, 2.2),
+                geometry: [
+                    new Coordinate(48.0, 2.0, 100.0),
+                    new Coordinate(48.1, 2.1, 110.0),
+                    new Coordinate(48.2, 2.2, 120.0),
+                ],
+            ),
+        ]);
+    }
+}

--- a/api/tests/Unit/InRide/RouteTailTest.php
+++ b/api/tests/Unit/InRide/RouteTailTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\InRide;
+
+use App\Geo\GeoPoint;
+use App\Geo\HaversineDistance;
+use App\InRide\DetourCalculator;
+use App\InRide\RouteTail;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class RouteTailTest extends TestCase
+{
+    private RouteTail $routeTail;
+
+    private DetourCalculator $detour;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->routeTail = new RouteTail(new HaversineDistance());
+        $this->detour = new DetourCalculator(new HaversineDistance());
+    }
+
+    #[Test]
+    public function emptyPolylineYieldsEmptyTail(): void
+    {
+        $this->assertSame([], $this->routeTail->from(new GeoPoint(45.0, 5.0), []));
+    }
+
+    #[Test]
+    public function singlePointPolylineYieldsThatPoint(): void
+    {
+        $tail = $this->routeTail->from(new GeoPoint(45.0, 5.0), [new GeoPoint(45.0, 5.001)]);
+
+        $this->assertCount(1, $tail);
+        $this->assertEqualsWithDelta(45.0, $tail[0]->lat, 1e-9);
+        $this->assertEqualsWithDelta(5.001, $tail[0]->lon, 1e-9);
+    }
+
+    #[Test]
+    public function riderMidSegmentStartsTheTailAtItsProjection(): void
+    {
+        // Straight west-east polyline along latitude 45.
+        $polyline = [
+            new GeoPoint(45.0, 5.000),
+            new GeoPoint(45.0, 5.010),
+            new GeoPoint(45.0, 5.020),
+            new GeoPoint(45.0, 5.030),
+        ];
+        // Rider in the middle of segment 1 (5.010 → 5.020).
+        $rider = new GeoPoint(45.0, 5.015);
+
+        $tail = $this->routeTail->from($rider, $polyline);
+
+        // Projection first, then the two points ahead — the two behind are dropped.
+        $this->assertCount(3, $tail);
+        $this->assertEqualsWithDelta(45.0, $tail[0]->lat, 1e-6);
+        $this->assertEqualsWithDelta(5.015, $tail[0]->lon, 1e-6);
+        $this->assertEqualsWithDelta(5.020, $tail[1]->lon, 1e-9);
+        $this->assertEqualsWithDelta(5.030, $tail[2]->lon, 1e-9);
+    }
+
+    #[Test]
+    public function riderOnFirstPointKeepsTheWholePolylineWithoutDuplicate(): void
+    {
+        $polyline = [
+            new GeoPoint(45.0, 5.000),
+            new GeoPoint(45.0, 5.010),
+            new GeoPoint(45.0, 5.020),
+        ];
+        $rider = new GeoPoint(45.0, 5.000); // exactly on the first vertex
+
+        $tail = $this->routeTail->from($rider, $polyline);
+
+        $this->assertCount(3, $tail);
+        $this->assertEqualsWithDelta(5.000, $tail[0]->lon, 1e-9);
+        $this->assertEqualsWithDelta(5.010, $tail[1]->lon, 1e-9);
+        $this->assertEqualsWithDelta(5.020, $tail[2]->lon, 1e-9);
+    }
+
+    #[Test]
+    public function riderOnLastPointYieldsThatPointWithoutDuplicateOrEmptyTail(): void
+    {
+        $polyline = [
+            new GeoPoint(45.0, 5.000),
+            new GeoPoint(45.0, 5.010),
+            new GeoPoint(45.0, 5.020),
+        ];
+        $rider = new GeoPoint(45.0, 5.020); // exactly on the last vertex
+
+        $tail = $this->routeTail->from($rider, $polyline);
+
+        $this->assertCount(1, $tail);
+        $this->assertEqualsWithDelta(5.020, $tail[0]->lon, 1e-6);
+    }
+
+    /**
+     * The reason RouteTail exists: a POI already passed must keep DetourCalculator's
+     * "behind the rider" bound (detour clamped to 0, flag raised). With the entire
+     * polyline the rider is in the middle so the bound is unreachable and the same POI
+     * scores a positive detour.
+     */
+    #[Test]
+    public function poiBehindRiderIsClampedWithTheTailButNotWithTheWholePolyline(): void
+    {
+        $polyline = [
+            new GeoPoint(45.0, 5.000),
+            new GeoPoint(45.0, 5.010),
+            new GeoPoint(45.0, 5.020),
+            new GeoPoint(45.0, 5.030),
+        ];
+        $rider = new GeoPoint(45.0, 5.015); // middle of the polyline
+        // ~111 m north of 5.005, i.e. behind the rider and off the route.
+        $poi = new GeoPoint(45.001, 5.005);
+
+        $withWholePolyline = $this->detour->calculate($rider, $poi, $polyline);
+        $this->assertFalse($withWholePolyline->detourClampedToZero);
+        $this->assertGreaterThan(0.0, $withWholePolyline->detourMeters);
+
+        $tail = $this->routeTail->from($rider, $polyline);
+        $withTail = $this->detour->calculate($rider, $poi, $tail);
+        $this->assertTrue($withTail->detourClampedToZero);
+        $this->assertSame(0.0, $withTail->detourMeters);
+    }
+}

--- a/api/tests/Unit/Repository/RedisTripRequestRepositoryTest.php
+++ b/api/tests/Unit/Repository/RedisTripRequestRepositoryTest.php
@@ -238,4 +238,99 @@ final class RedisTripRequestRepositoryTest extends TestCase
 
         $this->repository->updateStageAlerts($tripId, 1, [$alert]);
     }
+
+    #[Test]
+    public function getStageGeometryReturnsPointsInTravelOrder(): void
+    {
+        $tripId = Uuid::v7()->toRfc4122();
+        $stage = new Stage(
+            tripId: $tripId,
+            dayNumber: 2,
+            distance: 40.0,
+            elevation: 200.0,
+            startPoint: new Coordinate(48.0, 2.0),
+            endPoint: new Coordinate(48.2, 2.2),
+            geometry: [
+                new Coordinate(48.0, 2.0, 100.0),
+                new Coordinate(48.1, 2.1, 110.0),
+                new Coordinate(48.2, 2.2, 120.0),
+            ],
+        );
+
+        $readItem = $this->createMock(CacheItemInterface::class);
+        $readItem->method('isHit')->willReturn(true);
+        $readItem->method('get')->willReturn([$stage]);
+        $readItem->method('expiresAfter')->willReturnSelf();
+        $this->cache->expects(self::atLeastOnce())
+            ->method('getItem')
+            ->with(\sprintf('trip.%s.stages', $tripId))
+            ->willReturn($readItem);
+
+        // ele is dropped: DetourCalculator works in 2D.
+        self::assertSame(
+            [
+                ['lat' => 48.0, 'lon' => 2.0],
+                ['lat' => 48.1, 'lon' => 2.1],
+                ['lat' => 48.2, 'lon' => 2.2],
+            ],
+            $this->repository->getStageGeometry($tripId, 2),
+        );
+    }
+
+    #[Test]
+    public function getStageGeometryReturnsNullForUnknownDay(): void
+    {
+        $tripId = Uuid::v7()->toRfc4122();
+        $stage = new Stage(
+            tripId: $tripId,
+            dayNumber: 1,
+            distance: 40.0,
+            elevation: 200.0,
+            startPoint: new Coordinate(48.0, 2.0),
+            endPoint: new Coordinate(48.2, 2.2),
+            geometry: [new Coordinate(48.0, 2.0, 100.0)],
+        );
+
+        $readItem = $this->createMock(CacheItemInterface::class);
+        $readItem->method('isHit')->willReturn(true);
+        $readItem->method('get')->willReturn([$stage]);
+        $readItem->method('expiresAfter')->willReturnSelf();
+        $this->cache->method('getItem')->willReturn($readItem);
+
+        self::assertNull($this->repository->getStageGeometry($tripId, 9));
+    }
+
+    #[Test]
+    public function getStageGeometryReturnsNullWhenTripMissing(): void
+    {
+        $tripId = Uuid::v7()->toRfc4122();
+
+        $missing = $this->createMock(CacheItemInterface::class);
+        $missing->method('isHit')->willReturn(false);
+        $this->cache->method('getItem')->willReturn($missing);
+
+        self::assertNull($this->repository->getStageGeometry($tripId, 1));
+    }
+
+    #[Test]
+    public function getStageGeometryReturnsNullForEmptyGeometry(): void
+    {
+        $tripId = Uuid::v7()->toRfc4122();
+        $stage = new Stage(
+            tripId: $tripId,
+            dayNumber: 1,
+            distance: 40.0,
+            elevation: 200.0,
+            startPoint: new Coordinate(48.0, 2.0),
+            endPoint: new Coordinate(48.2, 2.2),
+        );
+
+        $readItem = $this->createMock(CacheItemInterface::class);
+        $readItem->method('isHit')->willReturn(true);
+        $readItem->method('get')->willReturn([$stage]);
+        $readItem->method('expiresAfter')->willReturnSelf();
+        $this->cache->method('getItem')->willReturn($readItem);
+
+        self::assertNull($this->repository->getStageGeometry($tripId, 1));
+    }
 }


### PR DESCRIPTION
Sprint 51, vague 2. **Base `feature/929`**. Alimente `DetourCalculator`, code mort depuis son écriture (`$remainingRoute` restait `[]`).

## Changements
- **Nouveau** `api/src/InRide/RouteTail.php` — `from(GeoPoint $rider, array $polyline): array` : projette le cycliste (réutilise `DetourCalculator::projectOnSegment`) et renvoie `[projection, ...points restants]`. Indispensable : la borne « POI derrière le cycliste » de `DetourCalculator` ne se déclenche que sur le premier segment ; passer la polyligne entière la rend inatteignable.
- `TripRequestRepositoryInterface::getStageGeometry(string, int): ?array` : lecture scalaire de la **seule** colonne `geometry` côté Doctrine (`HYDRATE_ARRAY`, pas `getStages()` qui hydrate tout l'agrégat) ; implémentation Redis (env test) via `getStages()` ; `ele` non projeté (2D).
- `DetourCalculator::projectOnSegment` passée en `public static` (sans état, constructeur inchangé) pour la réutiliser sans réécrire la projection.
- Tests : `RouteTailTest` (6), `DoctrineTripRequestGeometryTest` (6, dont non-hydratation de l'agrégat), `RedisTripRequestRepositoryTest` (+4).

## Écart de périmètre signalé
Édité aussi `DetourCalculator.php` (instruction « réutiliser projectOnSegment, pas réécrire ») et `LlmPipelineTest.php` (3e implémentation de l'interface, sinon PHPStan `method.abstract`). Aucun chevauchement avec #930/#931.

## QA (jambe par jambe)
- Rector : `[OK]`. PHP-CS-Fixer : `Fixed 2 of 645 files` (docblocks). PHPStan level 9 : `[OK] No errors`.
- PHPUnit Unit + Integration : `Tests: 1428, Assertions: 3845, Skipped: 1`.
- Preuve de mutation : `RouteTail::from` renvoyant la polyligne entière → `poiBehindRiderIsClampedWithTheTailButNotWithTheWholePolyline` rouge ; restauré → vert.

## Auto-critique
- `detourMeters` reste `float` ici ; sa nullabilité (`null`=inconnu, jamais `0`) est posée en #933/#934 comme prévu par le plan.

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 critical, 0 warning, 1 suggestion (carried over from the previous review pass, still open).

### Review checklist
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Commit reviewed:** `1816334f5e8995d97d762e3577d34acd8ed45365`
<!-- claude-review-end -->