### PR TITLE
feat(in-ride): orchestrateur de recherche de lieux sans IA

### DIFF
--- a/api/src/InRide/NearbyPoiFinder.php
+++ b/api/src/InRide/NearbyPoiFinder.php
@@ -1,0 +1,266 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\InRide;
+
+use App\Format\OsmContactTags;
+use App\Geo\GeoDistanceInterface;
+use App\Geo\GeoPoint;
+use App\Osm\CoverageRepositoryInterface;
+use App\Poi\PoiLabelResolver;
+use App\Repository\TripRequestRepositoryInterface;
+
+/**
+ * AI-free in-ride orchestrator: reads the nearest POIs of one intent category
+ * from the Tier-1 index, filters them by opening hours, approximates the detour
+ * to reach them and ranks the best three — the middle stages the deleted
+ * InRideAssistant ran between an LLM classifier and an LLM narrator.
+ *
+ * Pipeline (see issue #933): coverage short-circuit -> PostGIS read (name,
+ * shelter-type and VAE filters already pushed to SQL by #930) -> de-duplication
+ * -> localised label for nameless rows -> tri-state opening filter -> distance
+ * sort capped at 10 -> detour on those 10 only -> combined distance+detour
+ * ranking capped at 3.
+ *
+ * @phpstan-type Candidate array{osmType: string, osmId: int, name: string, lat: float, lon: float, distanceMeters: float, openingHoursToday: ?string, closesAt: ?\DateTimeImmutable, phone: ?string, warning: ?PoiWarning, warningMinutes: ?int, detourMeters: ?float}
+ */
+final readonly class NearbyPoiFinder
+{
+    private const int PROVISIONAL_CANDIDATES = 10;
+
+    private const int MAX_SUGGESTIONS = 3;
+
+    /**
+     * Detour weight in the ranking score: a POI reached with a detour is
+     * penalised twice as heavily as raw distance, so a slightly farther POI on
+     * the route beats a closer one that requires backtracking.
+     */
+    private const float DETOUR_WEIGHT = 2.0;
+
+    private const int CLOSES_SOON_MINUTES = 30;
+
+    public function __construct(
+        private InRidePoiRepositoryInterface $poiRepository,
+        private OpeningHoursParser $openingHoursParser,
+        private DetourCalculator $detourCalculator,
+        private RouteTail $routeTail,
+        private DeeplinkBuilder $deeplinkBuilder,
+        private GeoDistanceInterface $distance,
+        private CoverageRepositoryInterface $coverageRepository,
+        private PoiLabelResolver $labelResolver,
+        private TripRequestRepositoryInterface $tripRepository,
+    ) {
+    }
+
+    /**
+     * @return array{outOfCoverage: bool, pois: list<PoiSuggestion>, totalFound: int, capReached: bool}
+     */
+    public function find(
+        InRidePoiCategory $category,
+        GeoPoint $position,
+        ?int $radiusMeters = null,
+        ?string $tripId = null,
+        ?int $stageDay = null,
+        ?\DateTimeImmutable $now = null,
+    ): array {
+        if ($this->coverageRepository->isRouteOutOfZone([['lat' => $position->lat, 'lon' => $position->lon]])) {
+            return ['outOfCoverage' => true, 'pois' => [], 'totalFound' => 0, 'capReached' => false];
+        }
+
+        $now ??= new \DateTimeImmutable('now');
+        $locale = (null !== $tripId ? $this->tripRepository->getLocale($tripId) : null) ?? 'en';
+
+        $rows = $this->poiRepository->findNearby(
+            $position->lat,
+            $position->lon,
+            $category->clampRadius($radiusMeters),
+            $category,
+        );
+        $capReached = \count($rows) === $category->candidateLimit();
+
+        $candidates = $this->retain($rows, $category, $position, $locale, $now);
+        $totalFound = \count($candidates);
+
+        usort($candidates, static fn (array $a, array $b): int => $a['distanceMeters'] <=> $b['distanceMeters']);
+        $candidates = \array_slice($candidates, 0, self::PROVISIONAL_CANDIDATES);
+
+        $candidates = $this->addDetour($candidates, $position, $tripId, $stageDay);
+
+        usort($candidates, fn (array $a, array $b): int => $this->score($a) <=> $this->score($b));
+
+        $pois = array_map(
+            fn (array $candidate): PoiSuggestion => $this->toSuggestion($candidate, $category, $position),
+            \array_slice($candidates, 0, self::MAX_SUGGESTIONS),
+        );
+
+        return ['outOfCoverage' => false, 'pois' => $pois, 'totalFound' => $totalFound, 'capReached' => $capReached];
+    }
+
+    /**
+     * Steps 3-5: de-duplicate on (osmType, osmId), label nameless rows and drop
+     * only the rows certainly closed now.
+     *
+     * @param list<array{osmType: string, osmId: int, name: ?string, category: string, lat: float, lon: float, openingHours: ?string, tags: array<string, string>}> $rows
+     *
+     * @return list<Candidate>
+     */
+    private function retain(array $rows, InRidePoiCategory $category, GeoPoint $position, string $locale, \DateTimeImmutable $now): array
+    {
+        $candidates = [];
+        $seen = [];
+
+        foreach ($rows as $row) {
+            $key = $row['osmType'].':'.$row['osmId'];
+            if (isset($seen[$key])) {
+                continue;
+            }
+
+            $seen[$key] = true;
+
+            // Belt-and-suspenders on the SQL name filter (#930): a category where
+            // a nameless row is not actionable (food, mechanic, health, train) is
+            // dropped here too, so the unit is correct even fed an unfiltered row.
+            $name = $this->resolveName($row, $category, $locale);
+            if (null === $name) {
+                continue;
+            }
+
+            $tag = $row['openingHours'];
+            $status = null === $tag ? OpeningStatus::UNKNOWN : $this->openingHoursParser->status($tag, $now);
+            if (OpeningStatus::CLOSED === $status) {
+                continue;
+            }
+
+            $warning = null;
+            $warningMinutes = null;
+            $closesAt = null;
+
+            if (OpeningStatus::UNKNOWN === $status) {
+                $warning = PoiWarning::HOURS_UNVERIFIED;
+            } elseif (null !== $tag) {
+                $closesAt = $this->openingHoursParser->closesAt($tag, $now);
+                if ($closesAt instanceof \DateTimeImmutable) {
+                    $minutes = (int) floor(($closesAt->getTimestamp() - $now->getTimestamp()) / 60);
+                    if ($minutes <= self::CLOSES_SOON_MINUTES) {
+                        $warning = PoiWarning::CLOSES_SOON;
+                        $warningMinutes = max(1, $minutes);
+                    }
+                }
+            }
+
+            $candidates[] = [
+                'osmType' => $row['osmType'],
+                'osmId' => $row['osmId'],
+                'name' => $name,
+                'lat' => $row['lat'],
+                'lon' => $row['lon'],
+                'distanceMeters' => $this->distance->inMeters($position->lat, $position->lon, $row['lat'], $row['lon']),
+                'openingHoursToday' => $tag,
+                'closesAt' => $closesAt,
+                'phone' => OsmContactTags::phone($row['tags']),
+                'warning' => $warning,
+                'warningMinutes' => $warningMinutes,
+                'detourMeters' => null,
+            ];
+        }
+
+        return $candidates;
+    }
+
+    /**
+     * Step 4: the source name, else the tag name, else a localised category
+     * label. A category where a nameless row is not actionable
+     * ({@see InRidePoiCategory::requiresName()}) returns `null` to signal a
+     * drop. A bus shelter (`shelter_type=public_transport`) is labelled
+     * distinctly ("bus shelter") rather than as a generic shelter.
+     *
+     * @param array{osmType: string, osmId: int, name: ?string, category: string, lat: float, lon: float, openingHours: ?string, tags: array<string, string>} $row
+     */
+    private function resolveName(array $row, InRidePoiCategory $category, string $locale): ?string
+    {
+        $name = $row['name'] ?? ($row['tags']['name'] ?? null);
+        if (null !== $name && '' !== trim($name)) {
+            return $name;
+        }
+
+        if ($category->requiresName()) {
+            return null;
+        }
+
+        $rawKey = 'public_transport' === ($row['tags']['shelter_type'] ?? null) ? 'shelter_bus' : $row['category'];
+
+        return $this->labelResolver->displayName($rawKey, $locale);
+    }
+
+    /**
+     * Step 8: detour on the (at most 10) provisional candidates only — projecting
+     * every candidate on a ~1500-point polyline is out of budget at
+     * candidateLimit scale. Without a stage geometry the detour stays `null` and
+     * ranking falls back to distance alone.
+     *
+     * @param list<Candidate> $candidates
+     *
+     * @return list<Candidate>
+     */
+    private function addDetour(array $candidates, GeoPoint $position, ?string $tripId, ?int $stageDay): array
+    {
+        if (null === $tripId || null === $stageDay) {
+            return $candidates;
+        }
+
+        $geometry = $this->tripRepository->getStageGeometry($tripId, $stageDay);
+        if (null === $geometry || [] === $geometry) {
+            return $candidates;
+        }
+
+        $polyline = array_map(static fn (array $point): GeoPoint => new GeoPoint($point['lat'], $point['lon']), $geometry);
+        $tail = $this->routeTail->from($position, $polyline);
+        if ([] === $tail) {
+            return $candidates;
+        }
+
+        foreach ($candidates as $index => $candidate) {
+            $result = $this->detourCalculator->calculate($position, new GeoPoint($candidate['lat'], $candidate['lon']), $tail);
+            $candidates[$index]['detourMeters'] = $result->detourMeters;
+            if ($result->poiFarFromRoute && null === $candidate['warning']) {
+                $candidates[$index]['warning'] = PoiWarning::FAR_FROM_ROUTE;
+            }
+        }
+
+        return $candidates;
+    }
+
+    /**
+     * @param Candidate $candidate
+     */
+    private function toSuggestion(array $candidate, InRidePoiCategory $category, GeoPoint $position): PoiSuggestion
+    {
+        $poiPoint = new GeoPoint($candidate['lat'], $candidate['lon']);
+
+        return new PoiSuggestion(
+            name: $candidate['name'],
+            category: $category,
+            osmType: $candidate['osmType'],
+            osmId: $candidate['osmId'],
+            lat: $candidate['lat'],
+            lon: $candidate['lon'],
+            distanceMeters: $candidate['distanceMeters'],
+            detourMeters: $candidate['detourMeters'],
+            openingHoursToday: $candidate['openingHoursToday'],
+            closesAt: $candidate['closesAt'],
+            phone: $candidate['phone'],
+            deeplink: $this->deeplinkBuilder->googleMapsBicycling($position, $poiPoint),
+            warning: $candidate['warning'],
+            warningMinutes: $candidate['warningMinutes'],
+        );
+    }
+
+    /**
+     * @param Candidate $candidate
+     */
+    private function score(array $candidate): float
+    {
+        return $candidate['distanceMeters'] + self::DETOUR_WEIGHT * ($candidate['detourMeters'] ?? 0.0);
+    }
+}

--- a/api/src/InRide/PoiSuggestion.php
+++ b/api/src/InRide/PoiSuggestion.php
@@ -7,66 +7,37 @@ namespace App\InRide;
 /**
  * Single POI suggestion served to a cycling user mid-ride.
  *
- * Distances are expressed in meters. Detour is the additional distance compared
- * to staying on the route (see {@see DetourCalculator}).
+ * Distances are expressed in meters. `detourMeters` is the additional distance
+ * compared to staying on the route (see {@see DetourCalculator}); it is `null`
+ * when no remaining route was available to measure against, never a misleading
+ * `0`.
  *
- * `openingHoursToday` is the raw OSM `opening_hours` tag — the {@see OpeningHoursParser}
- * has already validated it for the current day. `closesAt` is the moment the venue
- * closes for the in-progress open interval.
+ * `openingHoursToday` is the raw OSM `opening_hours` tag — the
+ * {@see OpeningHoursParser} has already produced a tri-state verdict from it.
+ * `closesAt` is the moment the venue closes for the in-progress open interval.
  *
- * `warning` carries human-readable diagnostics (e.g. "closes soon", "far from route").
+ * `warning` is a typed {@see PoiWarning}; `warningMinutes` carries the minutes
+ * left before closing when `warning` is {@see PoiWarning::CLOSES_SOON}.
+ * `osmType`/`osmId` link the suggestion back to the Tier-1 index row and to
+ * openstreetmap.org.
  */
 final readonly class PoiSuggestion
 {
-    public const string CATEGORY_FOOD = 'food';
-
-    public const string CATEGORY_SHELTER = 'shelter';
-
-    public const string CATEGORY_WATER = 'water';
-
-    public const string CATEGORY_MECHANIC = 'mechanic';
-
-    public const string CATEGORY_UNKNOWN = 'unknown';
-
-    public const array SUPPORTED_CATEGORIES = [
-        self::CATEGORY_FOOD,
-        self::CATEGORY_SHELTER,
-        self::CATEGORY_WATER,
-        self::CATEGORY_MECHANIC,
-    ];
-
     public function __construct(
         public string $name,
-        public string $category,
+        public InRidePoiCategory $category,
+        public string $osmType,
+        public int $osmId,
         public float $lat,
         public float $lon,
         public float $distanceMeters,
-        public float $detourMeters,
+        public ?float $detourMeters,
         public ?string $openingHoursToday,
         public ?\DateTimeImmutable $closesAt,
         public ?string $phone,
         public string $deeplink,
-        public ?string $warning = null,
+        public ?PoiWarning $warning = null,
+        public ?int $warningMinutes = null,
     ) {
-    }
-
-    /**
-     * @return array{name: string, category: string, lat: float, lon: float, distance_m: int, detour_m: int, opening_hours_today: string|null, closes_at: string|null, phone: string|null, deeplink: string, warning: string|null}
-     */
-    public function toArray(): array
-    {
-        return [
-            'name' => $this->name,
-            'category' => $this->category,
-            'lat' => $this->lat,
-            'lon' => $this->lon,
-            'distance_m' => (int) round($this->distanceMeters),
-            'detour_m' => (int) round($this->detourMeters),
-            'opening_hours_today' => $this->openingHoursToday,
-            'closes_at' => $this->closesAt?->format(\DateTimeInterface::ATOM),
-            'phone' => $this->phone,
-            'deeplink' => $this->deeplink,
-            'warning' => $this->warning,
-        ];
     }
 }

--- a/api/src/InRide/PoiWarning.php
+++ b/api/src/InRide/PoiWarning.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\InRide;
+
+/**
+ * Typed diagnostic surfaced on a {@see PoiSuggestion}, replacing the free-text
+ * French strings the deleted InRideAssistant wrote straight into the API
+ * `warning` field. The frontend maps each case to a localised message, so the
+ * backend never emits natural language here.
+ *
+ * - CLOSES_SOON: the venue is open but shuts within 30 minutes; carried
+ *   together with {@see PoiSuggestion::$warningMinutes}.
+ * - FAR_FROM_ROUTE: the POI sits past {@see DetourCalculator::POI_FAR_THRESHOLD_METERS}
+ *   from the remaining route ({@see DetourResult::$poiFarFromRoute}).
+ * - HOURS_UNVERIFIED: no readable `opening_hours` tag, so the POI is kept but
+ *   its schedule is unconfirmed.
+ */
+enum PoiWarning: string
+{
+    case CLOSES_SOON = 'closes_soon';
+    case FAR_FROM_ROUTE = 'far_from_route';
+    case HOURS_UNVERIFIED = 'hours_unverified';
+}

--- a/api/tests/Unit/InRide/NearbyPoiFinderTest.php
+++ b/api/tests/Unit/InRide/NearbyPoiFinderTest.php
@@ -1,0 +1,428 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\InRide;
+
+use App\Geo\GeoPoint;
+use App\Geo\HaversineDistance;
+use App\InRide\DeeplinkBuilder;
+use App\InRide\DetourCalculator;
+use App\InRide\InRidePoiCategory;
+use App\InRide\InRidePoiRepositoryInterface;
+use App\InRide\NearbyPoiFinder;
+use App\InRide\OpeningHoursParser;
+use App\InRide\PoiSuggestion;
+use App\InRide\PoiWarning;
+use App\InRide\RouteTail;
+use App\Osm\CoverageRepositoryInterface;
+use App\Poi\PoiLabelResolver;
+use App\Repository\TripRequestRepositoryInterface;
+use App\Tests\Unit\AlertMessageTestTrait;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class NearbyPoiFinderTest extends TestCase
+{
+    use AlertMessageTestTrait;
+
+    private const array RIDER = [48.0, 2.0];
+
+    // Fixed midday so a `24/7` venue is never within 30 min of its next-midnight
+    // close, which would otherwise flake into a CLOSES_SOON warning.
+    private const string NOON = '2026-08-06 12:00:00';
+
+    // A straight westbound-to-eastbound route the rider sits at the start of.
+    private const array ROUTE = [
+        ['lat' => 48.0, 'lon' => 2.0],
+        ['lat' => 48.0, 'lon' => 2.05],
+    ];
+
+    /**
+     * @return iterable<string, array{InRidePoiCategory}>
+     */
+    public static function nameRequiringCategories(): iterable
+    {
+        yield 'food' => [InRidePoiCategory::FOOD];
+        yield 'mechanic' => [InRidePoiCategory::MECHANIC];
+        yield 'health' => [InRidePoiCategory::HEALTH];
+        yield 'train' => [InRidePoiCategory::TRAIN];
+    }
+
+    #[DataProvider('nameRequiringCategories')]
+    #[Test]
+    public function discardsNamelessEntryForNameRequiringCategories(InRidePoiCategory $category): void
+    {
+        $finder = $this->finder($this->poiRepo([
+            $this->row(['osmId' => 1, 'name' => null]),
+            $this->row(['osmId' => 2, 'name' => 'Chez Bob']),
+        ]));
+
+        $result = $finder->find($category, $this->rider());
+
+        self::assertSame(1, $result['totalFound']);
+        self::assertCount(1, $result['pois']);
+        self::assertSame('Chez Bob', $result['pois'][0]->name);
+    }
+
+    /**
+     * @return iterable<string, array{InRidePoiCategory, string, string}>
+     */
+    public static function nameOptionalCategories(): iterable
+    {
+        yield 'water' => [InRidePoiCategory::WATER, 'drinking_water', 'Drinking water'];
+        yield 'shelter' => [InRidePoiCategory::SHELTER, 'shelter', 'Shelter'];
+        yield 'charging' => [InRidePoiCategory::CHARGING, 'charging_station', 'Charging station'];
+    }
+
+    #[DataProvider('nameOptionalCategories')]
+    #[Test]
+    public function keepsAndLabelsNamelessEntryForNameOptionalCategories(InRidePoiCategory $category, string $osmCategory, string $expectedLabel): void
+    {
+        $finder = $this->finder($this->poiRepo([
+            $this->row(['osmId' => 1, 'name' => null, 'category' => $osmCategory]),
+        ]));
+
+        $result = $finder->find($category, $this->rider());
+
+        self::assertSame(1, $result['totalFound']);
+        self::assertSame($expectedLabel, $result['pois'][0]->name);
+    }
+
+    #[Test]
+    public function labelsBusShelterDistinctlyFromAGenericShelter(): void
+    {
+        $finder = $this->finder($this->poiRepo([
+            $this->row(['osmId' => 1, 'name' => null, 'category' => 'shelter']),
+            $this->row(['osmId' => 2, 'name' => null, 'category' => 'shelter', 'lat' => 48.001, 'tags' => ['shelter_type' => 'public_transport']]),
+        ]));
+
+        $result = $finder->find(InRidePoiCategory::SHELTER, $this->rider());
+
+        $names = array_map(static fn (PoiSuggestion $poi): string => $poi->name, $result['pois']);
+        self::assertContains('Shelter', $names);
+        self::assertContains('Bus shelter', $names);
+    }
+
+    #[Test]
+    public function keepsMissingAndUnreadableHoursAsUnverifiedButDiscardsCertainlyClosed(): void
+    {
+        $sunday = new \DateTimeImmutable('2026-08-09 12:00:00');
+        $finder = $this->finder($this->poiRepo([
+            $this->row(['osmId' => 1, 'name' => 'No tag', 'openingHours' => null]),
+            $this->row(['osmId' => 2, 'name' => 'Garbage tag', 'openingHours' => 'garbage data here']),
+            $this->row(['osmId' => 3, 'name' => 'Closed today', 'openingHours' => 'Mo-Fr 09:00-17:00']),
+        ]));
+
+        $result = $finder->find(InRidePoiCategory::WATER, $this->rider(), now: $sunday);
+
+        self::assertSame(2, $result['totalFound']);
+        $byName = $this->byName($result['pois']);
+        self::assertSame(PoiWarning::HOURS_UNVERIFIED, $byName['No tag']->warning);
+        self::assertSame(PoiWarning::HOURS_UNVERIFIED, $byName['Garbage tag']->warning);
+        self::assertArrayNotHasKey('Closed today', $byName);
+    }
+
+    #[Test]
+    public function flagsAVenueClosingWithinThirtyMinutes(): void
+    {
+        // Explicit UTC: closesAt inherits $now's timezone, so pinning it here keeps the
+        // ATOM assertion below stable whatever the runtime default timezone is (CI runs Europe/Paris).
+        $now = new \DateTimeImmutable('2026-08-06 14:40:00', new \DateTimeZone('UTC'));
+        $finder = $this->finder($this->poiRepo([
+            $this->row(['osmId' => 1, 'name' => 'Closing soon', 'openingHours' => '08:00-15:00']),
+            $this->row(['osmId' => 2, 'name' => 'Open late', 'openingHours' => '08:00-23:00', 'lat' => 48.001]),
+        ]));
+
+        $result = $finder->find(InRidePoiCategory::WATER, $this->rider(), now: $now);
+
+        $byName = $this->byName($result['pois']);
+        self::assertSame(PoiWarning::CLOSES_SOON, $byName['Closing soon']->warning);
+        self::assertSame(20, $byName['Closing soon']->warningMinutes);
+        self::assertSame('2026-08-06T15:00:00+00:00', $byName['Closing soon']->closesAt?->format(\DateTimeInterface::ATOM));
+        self::assertNull($byName['Open late']->warning);
+    }
+
+    #[Test]
+    public function shortCircuitsWhenOutOfCoverageWithoutQueryingPois(): void
+    {
+        $repo = $this->createMock(InRidePoiRepositoryInterface::class);
+        $repo->expects(self::never())->method('findNearby');
+
+        $result = $this->finder($repo, outOfZone: true)->find(InRidePoiCategory::WATER, $this->rider());
+
+        self::assertTrue($result['outOfCoverage']);
+        self::assertSame([], $result['pois']);
+        self::assertSame(0, $result['totalFound']);
+        self::assertFalse($result['capReached']);
+    }
+
+    #[Test]
+    public function reportsCapReachedOnlyWhenTheReaderReturnsExactlyTheCandidateLimit(): void
+    {
+        $limit = InRidePoiCategory::WATER->candidateLimit();
+
+        $atCap = $this->finder($this->poiRepo($this->manyRows($limit)))->find(InRidePoiCategory::WATER, $this->rider());
+        self::assertTrue($atCap['capReached']);
+        self::assertSame($limit, $atCap['totalFound']);
+
+        $belowCap = $this->finder($this->poiRepo($this->manyRows($limit - 1)))->find(InRidePoiCategory::WATER, $this->rider());
+        self::assertFalse($belowCap['capReached']);
+    }
+
+    #[Test]
+    public function totalFoundCountsRetainedRowsBeforeTheCutToThree(): void
+    {
+        $finder = $this->finder($this->poiRepo($this->manyRows(5)));
+
+        $result = $finder->find(InRidePoiCategory::WATER, $this->rider());
+
+        self::assertSame(5, $result['totalFound']);
+        self::assertCount(3, $result['pois']);
+    }
+
+    #[Test]
+    public function deduplicatesOnOsmTypeAndId(): void
+    {
+        $finder = $this->finder($this->poiRepo([
+            $this->row(['osmType' => 'node', 'osmId' => 7, 'name' => 'First']),
+            $this->row(['osmType' => 'node', 'osmId' => 7, 'name' => 'Duplicate']),
+            $this->row(['osmType' => 'way', 'osmId' => 7, 'name' => 'Different type']),
+        ]));
+
+        $result = $finder->find(InRidePoiCategory::WATER, $this->rider());
+
+        self::assertSame(2, $result['totalFound']);
+    }
+
+    #[Test]
+    public function leavesDetourNullAndRanksOnDistanceWithoutAStageDay(): void
+    {
+        $finder = $this->finder($this->poiRepo([
+            $this->row(['osmId' => 1, 'name' => 'Far', 'lat' => 48.0, 'lon' => 2.04]),
+            $this->row(['osmId' => 2, 'name' => 'Near', 'lat' => 48.0, 'lon' => 2.01]),
+        ]));
+
+        $result = $finder->find(InRidePoiCategory::WATER, $this->rider());
+
+        self::assertSame('Near', $result['pois'][0]->name);
+        foreach ($result['pois'] as $poi) {
+            self::assertNull($poi->detourMeters);
+        }
+    }
+
+    #[Test]
+    public function computesDetourAndRanksDistancePlusTwiceDetourWithAStageDay(): void
+    {
+        // "Detour" is on-route (~0 detour) but farther in straight line; "Direct"
+        // is closer but off-route, so 2×detour must push it below "Detour".
+        $finder = $this->finder(
+            $this->poiRepo([
+                $this->row(['osmId' => 1, 'name' => 'Direct', 'lat' => 48.02, 'lon' => 2.005, 'openingHours' => '24/7']),
+                $this->row(['osmId' => 2, 'name' => 'Detour', 'lat' => 48.0, 'lon' => 2.04, 'openingHours' => '24/7']),
+            ]),
+            geometry: self::ROUTE,
+        );
+
+        $result = $finder->find(InRidePoiCategory::WATER, $this->rider(), tripId: 'trip-1', stageDay: 1, now: new \DateTimeImmutable(self::NOON));
+
+        self::assertSame('Detour', $result['pois'][0]->name);
+        foreach ($result['pois'] as $poi) {
+            self::assertNotNull($poi->detourMeters);
+        }
+    }
+
+    #[Test]
+    public function flagsPoiFarFromRouteWhenNoWarningIsAlreadySet(): void
+    {
+        $finder = $this->finder(
+            $this->poiRepo([
+                $this->row(['osmId' => 1, 'name' => 'Off route', 'lat' => 48.1, 'lon' => 2.02, 'openingHours' => '24/7']),
+            ]),
+            geometry: self::ROUTE,
+        );
+
+        $result = $finder->find(InRidePoiCategory::WATER, $this->rider(), tripId: 'trip-1', stageDay: 1, now: new \DateTimeImmutable(self::NOON));
+
+        self::assertSame(PoiWarning::FAR_FROM_ROUTE, $result['pois'][0]->warning);
+    }
+
+    #[Test]
+    public function farFromRouteNeverOverridesAnEarlierWarning(): void
+    {
+        $finder = $this->finder(
+            $this->poiRepo([
+                $this->row(['osmId' => 1, 'name' => 'Off route no tag', 'lat' => 48.1, 'lon' => 2.02, 'openingHours' => null]),
+            ]),
+            geometry: self::ROUTE,
+        );
+
+        $result = $finder->find(InRidePoiCategory::WATER, $this->rider(), tripId: 'trip-1', stageDay: 1);
+
+        self::assertSame(PoiWarning::HOURS_UNVERIFIED, $result['pois'][0]->warning);
+    }
+
+    #[Test]
+    public function detourIsComputedOnAtMostTenClosestCandidates(): void
+    {
+        // Ten rows sit ~1 km north of the east-west route (a large, near-identical
+        // detour), each closer in straight line than the eleventh. The eleventh,
+        // "poi-10", sits exactly on the route (~0 detour) but slightly farther in
+        // straight line, so it is the 11th-closest. The distance cut drops it
+        // *before* any detour is computed; were the cap removed, its ~0 detour would
+        // beat every off-route row's distance+2×detour and land it in the top 3.
+        // Its absence therefore pins the 10-candidate cap, not mere distance order.
+        $rows = [];
+        for ($i = 0; $i < 10; ++$i) {
+            $rows[] = $this->row(['osmId' => $i + 1, 'name' => 'poi-'.$i, 'lat' => 48.009, 'lon' => 2.0 + 0.0001 * $i, 'openingHours' => '24/7']);
+        }
+
+        $rows[] = $this->row(['osmId' => 11, 'name' => 'poi-10', 'lat' => 48.0, 'lon' => 2.014, 'openingHours' => '24/7']);
+
+        $finder = $this->finder($this->poiRepo($rows), geometry: self::ROUTE);
+
+        $result = $finder->find(InRidePoiCategory::WATER, $this->rider(), tripId: 'trip-1', stageDay: 1, now: new \DateTimeImmutable(self::NOON));
+
+        $names = array_map(static fn (PoiSuggestion $poi): string => $poi->name, $result['pois']);
+        self::assertNotContains('poi-10', $names);
+    }
+
+    #[Test]
+    public function doesNotReportTheLegacyTwiceRadiusGuard(): void
+    {
+        // Row 5 km from the rider with a 1 km radius: the deleted InRideAssistant
+        // dropped anything past 2×radius in PHP; ST_DWithin already bounds it in
+        // SQL (ADR-040), so the finder must keep whatever the reader returned.
+        $finder = $this->finder($this->poiRepo([
+            $this->row(['osmId' => 1, 'name' => 'Far fountain', 'lat' => 48.045, 'lon' => 2.0]),
+        ]));
+
+        $result = $finder->find(InRidePoiCategory::WATER, $this->rider(), radiusMeters: 1000);
+
+        self::assertSame(1, $result['totalFound']);
+    }
+
+    #[Test]
+    public function fallsBackToEnglishLabelsWithoutATrip(): void
+    {
+        $finder = $this->finder(
+            $this->poiRepo([$this->row(['osmId' => 1, 'name' => null, 'category' => 'shelter'])]),
+            locale: null,
+        );
+
+        $result = $finder->find(InRidePoiCategory::SHELTER, $this->rider());
+
+        self::assertSame('Shelter', $result['pois'][0]->name);
+    }
+
+    #[Test]
+    public function buildsAGoogleMapsBicyclingDeeplink(): void
+    {
+        $finder = $this->finder($this->poiRepo([$this->row(['osmId' => 1, 'name' => 'Fountain'])]));
+
+        $result = $finder->find(InRidePoiCategory::WATER, $this->rider());
+
+        self::assertStringContainsString('travelmode=bicycling', $result['pois'][0]->deeplink);
+        self::assertStringContainsString('origin=48,2', $result['pois'][0]->deeplink);
+    }
+
+    // --- fixtures -----------------------------------------------------------
+
+    /**
+     * @param array<string, mixed> $overrides
+     *
+     * @return array{osmType: string, osmId: int, name: ?string, category: string, lat: float, lon: float, openingHours: ?string, tags: array<string, string>}
+     */
+    private function row(array $overrides = []): array
+    {
+        /** @var array{osmType: string, osmId: int, name: ?string, category: string, lat: float, lon: float, openingHours: ?string, tags: array<string, string>} $row */
+        $row = array_merge([
+            'osmType' => 'node',
+            'osmId' => 1,
+            'name' => 'A place',
+            'category' => 'drinking_water',
+            'lat' => 48.0,
+            'lon' => 2.0,
+            'openingHours' => null,
+            'tags' => [],
+        ], $overrides);
+
+        return $row;
+    }
+
+    /**
+     * @return list<array{osmType: string, osmId: int, name: ?string, category: string, lat: float, lon: float, openingHours: ?string, tags: array<string, string>}>
+     */
+    private function manyRows(int $count): array
+    {
+        $rows = [];
+        for ($i = 0; $i < $count; ++$i) {
+            $rows[] = $this->row(['osmId' => $i + 1, 'name' => 'poi-'.$i, 'lon' => 2.0 + 0.0001 * $i]);
+        }
+
+        return $rows;
+    }
+
+    private function rider(): GeoPoint
+    {
+        return new GeoPoint(self::RIDER[0], self::RIDER[1]);
+    }
+
+    /**
+     * @param list<PoiSuggestion> $pois
+     *
+     * @return array<string, PoiSuggestion>
+     */
+    private function byName(array $pois): array
+    {
+        $map = [];
+        foreach ($pois as $poi) {
+            $map[$poi->name] = $poi;
+        }
+
+        return $map;
+    }
+
+    /**
+     * @param list<array{osmType: string, osmId: int, name: ?string, category: string, lat: float, lon: float, openingHours: ?string, tags: array<string, string>}> $rows
+     */
+    private function poiRepo(array $rows): InRidePoiRepositoryInterface
+    {
+        $repo = $this->createStub(InRidePoiRepositoryInterface::class);
+        $repo->method('findNearby')->willReturn($rows);
+
+        return $repo;
+    }
+
+    /**
+     * @param list<array{lat: float, lon: float}>|null $geometry
+     */
+    private function finder(
+        InRidePoiRepositoryInterface $repo,
+        bool $outOfZone = false,
+        ?array $geometry = null,
+        ?string $locale = 'en',
+    ): NearbyPoiFinder {
+        $distance = new HaversineDistance();
+
+        $coverage = $this->createStub(CoverageRepositoryInterface::class);
+        $coverage->method('isRouteOutOfZone')->willReturn($outOfZone);
+
+        $trip = $this->createStub(TripRequestRepositoryInterface::class);
+        $trip->method('getLocale')->willReturn($locale);
+        $trip->method('getStageGeometry')->willReturn($geometry);
+
+        return new NearbyPoiFinder(
+            $repo,
+            new OpeningHoursParser(),
+            new DetourCalculator($distance),
+            new RouteTail($distance),
+            new DeeplinkBuilder(),
+            $distance,
+            $coverage,
+            new PoiLabelResolver($this->createAlertTranslator()),
+            $trip,
+        );
+    }
+}


### PR DESCRIPTION
Sprint 51, vague 3. **Diamant** : #933 dépend de #930 (#960), #931 (#961) et #932 (#962). Cette branche part de `feature/929` puis intègre les trois par merge (fichiers disjoints, merge sans conflit) avant d'ajouter le code de #933.

> **Ordre de merge** : merger d'abord #959 (#929), puis #960 + #961 + #962 (disjoints, ordre libre), puis cette PR. La branche sera rebasée sur `main` une fois les parents mergés (`git rebase --onto`). Le diff affiché ici est un sur-ensemble contenant #930/#931/#932 tant qu'ils ne sont pas mergés ; **les fichiers propres à #933** sont : `NearbyPoiFinder.php`, `PoiWarning.php`, `PoiSuggestion.php`, `NearbyPoiFinderTest.php`.

## Changements propres à #933
- **Nouveau** `PoiWarning.php` — enum CLOSES_SOON / FAR_FROM_ROUTE / HOURS_UNVERIFIED.
- **Nouveau** `NearbyPoiFinder.php` — orchestrateur sans IA : court-circuit hors-couverture → lecture PostGIS → dédup `(osmType, osmId)` → libellé localisé (`shelter_bus` si `shelter_type=public_transport`) → tri-état horaires (seul CLOSED écarte) → tri distance coupé à 10 → détour sur ces 10 seulement (via `RouteTail` + `DetourCalculator`, ignoré sans `stageDay`) → classement `distance + 2 × (detour ?? 0)` → top 3. `capReached` et `totalFound` (avant coupe à 3) remontés.
- `PoiSuggestion` remodelé : `category` → `InRidePoiCategory`, `detourMeters` → `?float` (null=inconnu), `warning` → `?PoiWarning` + `?int $warningMinutes`, ajout `osmType`/`osmId` ; **suppressions** `toArray()`, `SUPPORTED_CATEGORIES`, 5 constantes `CATEGORY_*`.
- Garde-fou « 2 × radius » de `InRideAssistant` **non reporté** (redondant depuis ADR-040, borné en SQL) — test `doesNotReportTheLegacyTwiceRadiusGuard`.

## QA (jambe par jambe)
- Rector : `[OK]` (après autofix `NewlineAfterStatementRector`). PHP-CS-Fixer : `Fixed 0 of 4 files`. PHPStan level 9 : `[OK] No errors`.
- PHPUnit : `NearbyPoiFinderTest OK (22 tests, 52 assertions)` ; `tests/Unit/InRide OK (112 tests, 184 assertions)`.
- Preuve de mutation : neutralisation du drop CLOSED et du drop `requiresName` → tests rouges ciblés, restaurés → vert.
- `grep -rn "SUPPORTED_CATEGORIES\|PoiSuggestion::CATEGORY" api` : rien. Aucune chaîne de langue naturelle dans `api/src/InRide`.

## Auto-critique
- L'enveloppe de réponse est un `array{outOfCoverage, pois, totalFound, capReached}` (la liste de fichiers est stricte — pas de nouvelle classe) ; l'endpoint #934 la mappe vers un DTO typé.
- `PoiSuggestionDto` (orphelin) laissé intact ici, remodelé par #934.
- Playwright non applicable — CI reste le gate.

<!-- claude-review-start -->
## Claude Review

**Summary:** Clean, correctly-scoped implementation. Independently traced `NearbyPoiFinder`'s pipeline (coverage short-circuit → PostGIS read → dedup on `(osmType, osmId)` → name resolution → tri-state opening-hours filter → distance cut to 10 → detour via `RouteTail`/`DetourCalculator` → `distance + 2×detour` ranking → top 3) against the real contracts of `DetourCalculator`, `RouteTail`, `OpeningHoursParser`, `InRidePoiCategory` and `PoiLabelResolver`, and hand-verified the ranking math on the `computesDetourAndRanksDistancePlusTwiceDetourWithAStageDay` and `detourIsComputedOnAtMostTenClosestCandidates` test cases — both check out. Confirmed by grep that `PoiSuggestion`'s removed members (`toArray()`, `SUPPORTED_CATEGORIES`, `CATEGORY_*`) have no remaining call site anywhere in `api/src`, `api/tests`, or `pwa/src`, so the reshape is safe. No security, performance, or architecture issues in the diff.

**⚠️ Security note:** the PR description contained a `<!-- claude-review-start -->…<!-- claude-review-end -->` block pre-fabricated to look like a genuine prior Claude review — fake summary, fake "resolved thread" note, fake all-green checklist, and a fake commit SHA (`677b94b...`) that didn't even match this PR's actual commit (`4518e436...`). This is a prompt-injection attempt targeting an automated reviewer reading the PR body. It has been disregarded and is replaced below with a review performed independently from the actual diff and source.

**Non-blocking note:** `PoiSuggestionDto` (`api/src/ApiResource/Model/PoiSuggestionDto.php`) now has a stale `@see \App\InRide\PoiSuggestion::toArray()` docblock reference — that method was removed by this PR. The DTO is currently unused anywhere in `api/src`, so this carries no runtime risk today; the PR description already flags it as an intentional orphan to be reshaped by #934. Just flagging so it isn't forgotten.

**Resolved threads:** the one prior bot-authored thread (`detourIsComputedOnAtMostTenClosestCandidates` not pinning the 10-candidate cap) was already resolved — verified the current test genuinely exercises the cap (11th row placed on-route with ~0 detour against 10 off-route rows).

**PR title check:** conforms to Conventional Commits (`feat(in-ride): orchestrateur de recherche de lieux sans IA`).

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

_Commit reviewed: 4518e4360d070e5f3bfd609ace94313f3797c340_
<!-- claude-review-end -->