### PR TITLE
feat(api): add the nearby-pois search endpoint

### DIFF
--- a/api/config/packages/rate_limiter.php
+++ b/api/config/packages/rate_limiter.php
@@ -75,9 +75,12 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 'interval' => '3600 seconds',
                 'cache_pool' => 'cache.rate_limiter',
             ],
-            'trip_chat' => [
+            // In-ride nearby-POI search (#934): a read-only PostGIS lookup a rider
+            // can fire repeatedly while moving, so it is capped more loosely than
+            // the LLM chats.
+            'nearby_pois' => [
                 'policy' => 'sliding_window',
-                'limit' => 20,
+                'limit' => 30,
                 'interval' => '60 seconds',
                 'cache_pool' => 'cache.rate_limiter',
             ],

--- a/api/src/ApiResource/Model/GeoPosition.php
+++ b/api/src/ApiResource/Model/GeoPosition.php
@@ -8,11 +8,10 @@ use ApiPlatform\Metadata\ApiProperty;
 use Symfony\Component\Validator\Constraints as Assert;
 
 /**
- * Validated geographic position (WGS84) carried by in-ride chat requests.
+ * Validated geographic position (WGS84) carried by a nearby-POI search request.
  *
  * Latitude is constrained to [-90, 90] and longitude to [-180, 180] per the
- * WGS84 convention. The bearing (heading), when provided, is expressed in
- * degrees clockwise from the geographic north, in the half-open range [0, 360).
+ * WGS84 convention.
  */
 final class GeoPosition
 {
@@ -25,10 +24,6 @@ final class GeoPosition
         #[Assert\Range(min: -180, max: 180)]
         #[ApiProperty(description: 'Longitude in decimal degrees (WGS84).')]
         public float $lon,
-        #[Assert\GreaterThanOrEqual(value: 0, message: 'Bearing must be in [0, 360).')]
-        #[Assert\LessThan(value: 360, message: 'Bearing must be in [0, 360).')]
-        #[ApiProperty(description: 'Optional bearing (heading) in degrees clockwise from north.')]
-        public ?float $bearing = null,
     ) {
     }
 }

--- a/api/src/ApiResource/Model/PoiSuggestionDto.php
+++ b/api/src/ApiResource/Model/PoiSuggestionDto.php
@@ -5,34 +5,38 @@ declare(strict_types=1);
 namespace App\ApiResource\Model;
 
 use ApiPlatform\Metadata\ApiProperty;
+use App\InRide\InRidePoiCategory;
+use App\InRide\PoiSuggestion;
+use App\InRide\PoiWarning;
 
 /**
- * Wire-shape mirror of {@see \App\InRide\PoiSuggestion::toArray()}.
+ * Wire-shape mirror of {@see PoiSuggestion}, built by {@see self::fromSuggestion()}.
  *
  * Exposing a typed DTO (rather than a raw `?array`) keeps the PHP → OpenAPI
  * → TypeScript contract honest: every field is documented, the generated
- * `schema.d.ts` carries the exact shape, and the PWA Zod schema can rely on
- * the typegen output instead of duplicating the field list.
+ * `schema.d.ts` carries the exact shape (including the category and warning
+ * enums as TS unions), and the PWA Zod schema can rely on the typegen output
+ * instead of duplicating the field list.
  *
  * Property names are intentionally snake_case to match the JSON the backend
- * produces — `PoiSuggestion::toArray()` is the canonical serialiser and the
- * PWA reads `distance_m`/`detour_m`/`opening_hours_today`/… directly.
+ * produces — the PWA reads `distance_m`/`detour_m`/`opening_hours_today`/…
+ * directly.
  */
 final readonly class PoiSuggestionDto
 {
     public function __construct(
         #[ApiProperty(description: 'Display name of the POI.', required: true)]
         public string $name,
-        #[ApiProperty(description: 'POI category (food, water, shelter, mechanic).', required: true)]
-        public string $category,
+        #[ApiProperty(description: 'POI intent category.', required: true)]
+        public InRidePoiCategory $category,
         #[ApiProperty(description: 'POI latitude (WGS84).', required: true)]
         public float $lat,
         #[ApiProperty(description: 'POI longitude (WGS84).', required: true)]
         public float $lon,
         #[ApiProperty(description: 'Straight-line distance from the rider to the POI, in meters (rounded).', required: true)]
         public int $distance_m,
-        #[ApiProperty(description: 'Estimated additional meters if the rider detours to the POI (0 when no remaining route is known, rounded).', required: true)]
-        public int $detour_m,
+        #[ApiProperty(description: 'Estimated additional meters if the rider detours to the POI (null when no remaining route is known, rounded).')]
+        public ?int $detour_m,
         #[ApiProperty(description: 'Raw OSM `opening_hours` tag for the current day, when available.')]
         public ?string $opening_hours_today,
         #[ApiProperty(description: 'RFC 3339 closing time of the currently-open interval, or null when the POI never closes / is closed.')]
@@ -41,51 +45,28 @@ final readonly class PoiSuggestionDto
         public ?string $phone,
         #[ApiProperty(description: 'Pre-built deeplink the rider can tap to open the POI in their map app.', required: true)]
         public string $deeplink,
-        #[ApiProperty(description: 'Optional warning surfaced on the POI card (e.g. opening hours unreliable, POI far from route).')]
-        public ?string $warning,
+        #[ApiProperty(description: 'Optional typed warning surfaced on the POI card (venue closes soon, POI far from route, opening hours unverified).')]
+        public ?PoiWarning $warning,
+        #[ApiProperty(description: 'Minutes left before closing when `warning` is `closes_soon`, otherwise null.')]
+        public ?int $warning_minutes,
     ) {
     }
 
-    /**
-     * @param array{
-     *     name: string,
-     *     category: string,
-     *     lat: float,
-     *     lon: float,
-     *     distance_m: int,
-     *     detour_m: int,
-     *     opening_hours_today?: ?string,
-     *     closes_at?: ?string,
-     *     phone?: ?string,
-     *     deeplink: string,
-     *     warning?: ?string,
-     * } $payload
-     */
-    public static function fromArray(array $payload): self
+    public static function fromSuggestion(PoiSuggestion $suggestion): self
     {
-        // The pois JSONB column accepts arbitrary shapes, so a corrupted row
-        // (legacy migration, manual SQL fix, …) could surface missing keys
-        // and yield a runtime TypeError far away from the read site. Assert
-        // the contract here so a bad row fails fast with an explicit message
-        // the operator can correlate with the offending trip_chat_message id.
-        foreach (['name', 'category', 'lat', 'lon', 'distance_m', 'detour_m', 'deeplink'] as $key) {
-            if (!\array_key_exists($key, $payload)) {
-                throw new \InvalidArgumentException(\sprintf('PoiSuggestionDto: missing required key "%s".', $key));
-            }
-        }
-
         return new self(
-            name: $payload['name'],
-            category: $payload['category'],
-            lat: $payload['lat'],
-            lon: $payload['lon'],
-            distance_m: $payload['distance_m'],
-            detour_m: $payload['detour_m'],
-            opening_hours_today: $payload['opening_hours_today'] ?? null,
-            closes_at: $payload['closes_at'] ?? null,
-            phone: $payload['phone'] ?? null,
-            deeplink: $payload['deeplink'],
-            warning: $payload['warning'] ?? null,
+            name: $suggestion->name,
+            category: $suggestion->category,
+            lat: $suggestion->lat,
+            lon: $suggestion->lon,
+            distance_m: (int) round($suggestion->distanceMeters),
+            detour_m: null === $suggestion->detourMeters ? null : (int) round($suggestion->detourMeters),
+            opening_hours_today: $suggestion->openingHoursToday,
+            closes_at: $suggestion->closesAt?->format(\DateTimeInterface::ATOM),
+            phone: $suggestion->phone,
+            deeplink: $suggestion->deeplink,
+            warning: $suggestion->warning,
+            warning_minutes: $suggestion->warningMinutes,
         );
     }
 }

--- a/api/src/ApiResource/NearbyPoiSearchRequest.php
+++ b/api/src/ApiResource/NearbyPoiSearchRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ApiResource;
+
+use App\ApiResource\Model\GeoPosition;
+use App\InRide\InRidePoiCategory;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * Input DTO for `POST /trips/{id}/nearby-pois`.
+ *
+ * An unknown `category` is rejected by the denormalizer (NotNormalizableValue ->
+ * 400) before validation runs, so the enum type carries the whitelist. The
+ * position is sent in the body, never the query string, so the rider's GPS
+ * coordinates never land in logs, the `Referer` header or the browser history.
+ *
+ * `radiusMeters` carries no validation range on purpose: an out-of-bounds value
+ * is clamped to [MIN_RADIUS_METERS, MAX_RADIUS_METERS] by
+ * {@see InRidePoiCategory::clampRadius()} rather than rejected, so a rider never
+ * gets a 422 for asking too wide or too narrow.
+ */
+final class NearbyPoiSearchRequest
+{
+    public function __construct(
+        #[Assert\NotNull]
+        public ?InRidePoiCategory $category = null,
+        #[Assert\NotNull]
+        #[Assert\Valid]
+        public ?GeoPosition $position = null,
+        public ?int $radiusMeters = null,
+        #[Assert\Range(min: 1)]
+        public ?int $stageDay = null,
+    ) {
+    }
+}

--- a/api/src/ApiResource/NearbyPoiSearchRequest.php
+++ b/api/src/ApiResource/NearbyPoiSearchRequest.php
@@ -11,8 +11,8 @@ use Symfony\Component\Validator\Constraints as Assert;
 /**
  * Input DTO for `POST /trips/{id}/nearby-pois`.
  *
- * An unknown `category` is rejected by the denormalizer (NotNormalizableValue ->
- * 400) before validation runs, so the enum type carries the whitelist. The
+ * An unknown `category` fails enum denormalization and surfaces as a validation
+ * violation (422), not a 400, so the enum type itself carries the whitelist. The
  * position is sent in the body, never the query string, so the rider's GPS
  * coordinates never land in logs, the `Referer` header or the browser history.
  *

--- a/api/src/ApiResource/NearbyPoiSearchResponse.php
+++ b/api/src/ApiResource/NearbyPoiSearchResponse.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ApiResource;
+
+use App\ApiResource\Model\PoiSuggestionDto;
+use App\InRide\InRidePoiCategory;
+
+/**
+ * Output DTO for `POST /trips/{id}/nearby-pois`: the ranked POI suggestions plus
+ * the search envelope ({@see \App\InRide\NearbyPoiFinder}).
+ */
+final readonly class NearbyPoiSearchResponse
+{
+    /**
+     * @param list<PoiSuggestionDto> $pois
+     */
+    public function __construct(
+        public string $tripId,
+        public InRidePoiCategory $category,
+        // The radius effectively applied, after clamp to [1000, 20000].
+        public int $radiusMeters,
+        public int $totalFound,
+        public bool $capReached,
+        public bool $outOfCoverage,
+        public array $pois,
+    ) {
+    }
+}

--- a/api/src/ApiResource/Trip.php
+++ b/api/src/ApiResource/Trip.php
@@ -14,6 +14,7 @@ use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
 use ApiPlatform\OpenApi\Model\Operation;
 use App\State\AnalyzeTripProcessor;
+use App\State\NearbyPoiSearchProcessor;
 use App\State\TripAiChatProcessor;
 use App\State\TripBatchRecomputeProcessor;
 use App\State\TripAiGenerateProcessor;
@@ -117,6 +118,23 @@ use App\State\TripUpdateProcessor;
             input: false,
             provider: TripRequestProvider::class,
             processor: TripDuplicateProcessor::class,
+        ),
+        new Post(
+            uriTemplate: '/trips/{id}/nearby-pois{._format}',
+            status: 200,
+            openapi: new Operation(
+                responses: [
+                    400 => new Response(description: 'Unknown POI category'),
+                    404 => new Response(description: 'Trip not found'),
+                    429 => new Response(description: 'Rate limit reached'),
+                ],
+                summary: 'Search the nearest points of interest of one intent category around a rider mid-ride.',
+            ),
+            security: "is_granted('TRIP_VIEW', object)",
+            input: NearbyPoiSearchRequest::class,
+            output: NearbyPoiSearchResponse::class,
+            provider: TripRequestProvider::class,
+            processor: NearbyPoiSearchProcessor::class,
         ),
         new Post(
             uriTemplate: '/trips/{id}/analyze{._format}',

--- a/api/src/ApiResource/Trip.php
+++ b/api/src/ApiResource/Trip.php
@@ -124,8 +124,8 @@ use App\State\TripUpdateProcessor;
             status: 200,
             openapi: new Operation(
                 responses: [
-                    400 => new Response(description: 'Unknown POI category'),
                     404 => new Response(description: 'Trip not found'),
+                    422 => new Response(description: 'Unknown POI category or invalid request payload'),
                     429 => new Response(description: 'Rate limit reached'),
                 ],
                 summary: 'Search the nearest points of interest of one intent category around a rider mid-ride.',

--- a/api/src/InRide/DeeplinkBuilder.php
+++ b/api/src/InRide/DeeplinkBuilder.php
@@ -7,44 +7,25 @@ namespace App\InRide;
 use App\Geo\GeoPoint;
 
 /**
- * Builds turn-by-turn navigation deeplinks from a rider's current position to a
- * point of interest.
+ * Builds a turn-by-turn navigation deeplink to a point of interest.
  *
  * Google Maps directions URLs (https://developers.google.com/maps/documentation/urls/get-started#directions-action)
- * are the primary target — bicycling mode renders an actionable route on both
- * mobile and desktop. The OpenStreetMap-based URL is intended as a fallback for
- * users without Google Maps access (or for privacy-conscious riders).
+ * are the target — bicycling mode renders an actionable route on both mobile and
+ * desktop. Only the destination is encoded: the rider's live position is left to
+ * the map app so it never leaves this backend in a URL.
  */
 final readonly class DeeplinkBuilder
 {
     /**
-     * Returns a Google Maps directions URL in bicycling mode.
+     * Returns a Google Maps directions URL in bicycling mode to the destination.
      *
      * Coordinates are serialised with enough precision (~1 cm) to match what
      * GPS devices export.
      */
-    public function googleMapsBicycling(GeoPoint $origin, GeoPoint $destination): string
+    public function googleMapsBicycling(GeoPoint $destination): string
     {
         return \sprintf(
-            'https://www.google.com/maps/dir/?api=1&origin=%s,%s&destination=%s,%s&travelmode=bicycling',
-            $this->formatCoord($origin->lat),
-            $this->formatCoord($origin->lon),
-            $this->formatCoord($destination->lat),
-            $this->formatCoord($destination->lon),
-        );
-    }
-
-    /**
-     * Returns an OpenStreetMap-based directions URL using the public OSRM bike
-     * profile (engine=fossgis_osrm_bike). This is the fallback when Google Maps
-     * is not available.
-     */
-    public function openStreetMap(GeoPoint $origin, GeoPoint $destination): string
-    {
-        return \sprintf(
-            'https://www.openstreetmap.org/directions?engine=fossgis_osrm_bike&route=%s%%2C%s%%3B%s%%2C%s',
-            $this->formatCoord($origin->lat),
-            $this->formatCoord($origin->lon),
+            'https://www.google.com/maps/dir/?api=1&destination=%s,%s&travelmode=bicycling',
             $this->formatCoord($destination->lat),
             $this->formatCoord($destination->lon),
         );

--- a/api/src/InRide/NearbyPoiFinder.php
+++ b/api/src/InRide/NearbyPoiFinder.php
@@ -90,7 +90,7 @@ final readonly class NearbyPoiFinder
         usort($candidates, fn (array $a, array $b): int => $this->score($a) <=> $this->score($b));
 
         $pois = array_map(
-            fn (array $candidate): PoiSuggestion => $this->toSuggestion($candidate, $category, $position),
+            fn (array $candidate): PoiSuggestion => $this->toSuggestion($candidate, $category),
             \array_slice($candidates, 0, self::MAX_SUGGESTIONS),
         );
 
@@ -234,7 +234,7 @@ final readonly class NearbyPoiFinder
     /**
      * @param Candidate $candidate
      */
-    private function toSuggestion(array $candidate, InRidePoiCategory $category, GeoPoint $position): PoiSuggestion
+    private function toSuggestion(array $candidate, InRidePoiCategory $category): PoiSuggestion
     {
         $poiPoint = new GeoPoint($candidate['lat'], $candidate['lon']);
 
@@ -250,7 +250,7 @@ final readonly class NearbyPoiFinder
             openingHoursToday: $candidate['openingHoursToday'],
             closesAt: $candidate['closesAt'],
             phone: $candidate['phone'],
-            deeplink: $this->deeplinkBuilder->googleMapsBicycling($position, $poiPoint),
+            deeplink: $this->deeplinkBuilder->googleMapsBicycling($poiPoint),
             warning: $candidate['warning'],
             warningMinutes: $candidate['warningMinutes'],
         );

--- a/api/src/State/NearbyPoiSearchProcessor.php
+++ b/api/src/State/NearbyPoiSearchProcessor.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\State\ProcessorInterface;
+use App\ApiResource\Model\PoiSuggestionDto;
+use App\ApiResource\NearbyPoiSearchRequest;
+use App\ApiResource\NearbyPoiSearchResponse;
+use App\Entity\User;
+use App\Geo\GeoPoint;
+use App\InRide\NearbyPoiFinder;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+
+/**
+ * Handles `POST /trips/{id}/nearby-pois`: runs the AI-free in-ride orchestrator
+ * (#933) over the trip's coverage zone and returns the ranked POI suggestions.
+ *
+ * Pipeline: per-user rate limit -> radius clamp -> {@see NearbyPoiFinder} ->
+ * DTO mapping. The trip is resolved (and ownership enforced via `TRIP_VIEW`) by
+ * {@see TripRequestProvider} before this processor runs; a missing trip is a 404
+ * there. Nothing here mutates the trip.
+ *
+ * @implements ProcessorInterface<NearbyPoiSearchRequest, NearbyPoiSearchResponse>
+ */
+final readonly class NearbyPoiSearchProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private NearbyPoiFinder $finder,
+        private Security $security,
+        #[Autowire(service: 'limiter.nearby_pois')]
+        private RateLimiterFactory $nearbyPoisLimiter,
+    ) {
+    }
+
+    /**
+     * @param NearbyPoiSearchRequest $data
+     * @param Post                   $operation
+     * @param array{id?: string}     $uriVariables
+     */
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): NearbyPoiSearchResponse
+    {
+        $user = $this->security->getUser();
+        \assert($user instanceof User);
+        if (!$this->nearbyPoisLimiter->create($user->getId()->toRfc4122())->consume()->isAccepted()) {
+            throw new TooManyRequestsHttpException();
+        }
+
+        $tripId = $uriVariables['id'] ?? '';
+        $category = $data->category;
+        $position = $data->position;
+        \assert(null !== $category && null !== $position);
+
+        $appliedRadius = $category->clampRadius($data->radiusMeters);
+
+        $envelope = $this->finder->find(
+            $category,
+            new GeoPoint($position->lat, $position->lon),
+            $data->radiusMeters,
+            $tripId,
+            $data->stageDay,
+        );
+
+        return new NearbyPoiSearchResponse(
+            tripId: $tripId,
+            category: $category,
+            radiusMeters: $appliedRadius,
+            totalFound: $envelope['totalFound'],
+            capReached: $envelope['capReached'],
+            outOfCoverage: $envelope['outOfCoverage'],
+            pois: array_map(
+                PoiSuggestionDto::fromSuggestion(...),
+                $envelope['pois'],
+            ),
+        );
+    }
+}

--- a/api/tests/Functional/NearbyPoiSearchTest.php
+++ b/api/tests/Functional/NearbyPoiSearchTest.php
@@ -80,7 +80,7 @@ final class NearbyPoiSearchTest extends ApiTestCase
     }
 
     #[Test]
-    public function rejectsRequestsFromANonOwnerWith403(): void
+    public function hidesANonOwnerTripAs404(): void
     {
         $other = new User('someone-else@example.com');
         $em = self::getContainer()->get('doctrine.orm.entity_manager');
@@ -94,7 +94,9 @@ final class NearbyPoiSearchTest extends ApiTestCase
             'headers' => ['Content-Type' => 'application/ld+json', ...$this->authHeader($this->jwtToken)],
         ]);
 
-        $this->assertResponseStatusCodeSame(403);
+        // Object-level authz denials are hidden as 404, not 403 (ADR-038), so a non-owner
+        // cannot tell an existing-but-forbidden trip apart from an unknown one.
+        $this->assertResponseStatusCodeSame(404);
     }
 
     #[Test]
@@ -109,7 +111,7 @@ final class NearbyPoiSearchTest extends ApiTestCase
     }
 
     #[Test]
-    public function returns400ForAnUnknownCategory(): void
+    public function returns422ForAnUnknownCategory(): void
     {
         $this->seedTrip(self::TRIP_ID, $this->testUser);
 
@@ -118,7 +120,9 @@ final class NearbyPoiSearchTest extends ApiTestCase
             'headers' => ['Content-Type' => 'application/ld+json', ...$this->authHeader($this->jwtToken)],
         ]);
 
-        $this->assertResponseStatusCodeSame(400);
+        // A value outside the backed enum fails denormalization; API Platform surfaces it as a
+        // validation violation (422), not a 400 malformed-request.
+        $this->assertResponseStatusCodeSame(422);
     }
 
     #[Test]

--- a/api/tests/Functional/NearbyPoiSearchTest.php
+++ b/api/tests/Functional/NearbyPoiSearchTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Symfony\Bundle\Test\Client;
+use App\ApiResource\TripRequest;
+use App\Entity\User;
+use App\Repository\TripRequestRepositoryInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Uid\Uuid;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * Functional coverage for `POST /trips/{id}/nearby-pois` (#934).
+ *
+ * Needs the real backend (Postgres + Redis) — CI is the real gate. The empty
+ * Tier-1 coverage index in the test DB means the search short-circuits to
+ * `outOfCoverage`, which is enough to exercise auth, the provider 404, the
+ * denormalizer 400 and the radius clamp echo.
+ */
+final class NearbyPoiSearchTest extends ApiTestCase
+{
+    use ResetDatabase;
+    use Factories;
+    use JwtAuthTestTrait;
+
+    private const string TRIP_ID = '01936f6e-0000-7000-8000-00000000934a';
+
+    private Client $client;
+
+    private User $testUser;
+
+    private string $jwtToken;
+
+    protected function setUp(): void
+    {
+        $this->client = self::createClient();
+        ['user' => $this->testUser, 'token' => $this->jwtToken] = $this->createTestUserWithJwt('nearby@example.com');
+    }
+
+    private function seedTrip(string $tripId, User $owner): void
+    {
+        $request = new TripRequest(Uuid::fromString($tripId));
+        $request->sourceUrl = 'https://www.komoot.com/tour/123456789';
+
+        /** @var TripRequestRepositoryInterface $repo */
+        $repo = self::getContainer()->get(TripRequestRepositoryInterface::class);
+        $repo->initializeTrip($tripId, $request);
+        $this->associateTripWithUser($tripId, $owner);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function body(mixed $category = 'water', ?int $radiusMeters = null): array
+    {
+        $body = ['category' => $category, 'position' => ['lat' => 48.0, 'lon' => 2.0]];
+        if (null !== $radiusMeters) {
+            $body['radiusMeters'] = $radiusMeters;
+        }
+
+        return $body;
+    }
+
+    #[Test]
+    public function rejectsUnauthenticatedRequests(): void
+    {
+        $this->seedTrip(self::TRIP_ID, $this->testUser);
+
+        $this->client->request('POST', \sprintf('/trips/%s/nearby-pois', self::TRIP_ID), [
+            'json' => $this->body(),
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(401);
+    }
+
+    #[Test]
+    public function rejectsRequestsFromANonOwnerWith403(): void
+    {
+        $other = new User('someone-else@example.com');
+        $em = self::getContainer()->get('doctrine.orm.entity_manager');
+        $em->persist($other);
+        $em->flush();
+
+        $this->seedTrip(self::TRIP_ID, $other);
+
+        $this->client->request('POST', \sprintf('/trips/%s/nearby-pois', self::TRIP_ID), [
+            'json' => $this->body(),
+            'headers' => ['Content-Type' => 'application/ld+json', ...$this->authHeader($this->jwtToken)],
+        ]);
+
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    #[Test]
+    public function returns404ForAnUnknownTrip(): void
+    {
+        $this->client->request('POST', '/trips/00000000-0000-0000-0000-000000000000/nearby-pois', [
+            'json' => $this->body(),
+            'headers' => ['Content-Type' => 'application/ld+json', ...$this->authHeader($this->jwtToken)],
+        ]);
+
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    #[Test]
+    public function returns400ForAnUnknownCategory(): void
+    {
+        $this->seedTrip(self::TRIP_ID, $this->testUser);
+
+        $this->client->request('POST', \sprintf('/trips/%s/nearby-pois', self::TRIP_ID), [
+            'json' => $this->body('teleporter'),
+            'headers' => ['Content-Type' => 'application/ld+json', ...$this->authHeader($this->jwtToken)],
+        ]);
+
+        $this->assertResponseStatusCodeSame(400);
+    }
+
+    #[Test]
+    public function clampsAnOutOfBoundsRadiusAndEchoesTheAppliedValue(): void
+    {
+        $this->seedTrip(self::TRIP_ID, $this->testUser);
+
+        $response = $this->client->request('POST', \sprintf('/trips/%s/nearby-pois', self::TRIP_ID), [
+            'json' => $this->body('water', 999_999),
+            'headers' => ['Content-Type' => 'application/ld+json', ...$this->authHeader($this->jwtToken)],
+        ]);
+
+        $this->assertResponseStatusCodeSame(200);
+
+        $data = $response->toArray(false);
+        $this->assertSame(self::TRIP_ID, $data['tripId']);
+        $this->assertSame('water', $data['category']);
+        $this->assertSame(20000, $data['radiusMeters']);
+        $this->assertArrayHasKey('pois', $data);
+    }
+}

--- a/api/tests/Unit/ApiResource/Model/PoiSuggestionDtoTest.php
+++ b/api/tests/Unit/ApiResource/Model/PoiSuggestionDtoTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\ApiResource\Model;
+
+use App\ApiResource\Model\PoiSuggestionDto;
+use App\InRide\InRidePoiCategory;
+use App\InRide\PoiSuggestion;
+use App\InRide\PoiWarning;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class PoiSuggestionDtoTest extends TestCase
+{
+    #[Test]
+    public function roundsDistanceAndDetourAndFormatsClosingTime(): void
+    {
+        $dto = PoiSuggestionDto::fromSuggestion(new PoiSuggestion(
+            name: 'Fontaine',
+            category: InRidePoiCategory::WATER,
+            osmType: 'node',
+            osmId: 42,
+            lat: 48.1,
+            lon: 2.3,
+            distanceMeters: 123.6,
+            detourMeters: 87.4,
+            openingHoursToday: '08:00-15:00',
+            closesAt: new \DateTimeImmutable('2026-08-06T15:00:00+00:00'),
+            phone: '+33123456789',
+            deeplink: 'https://www.google.com/maps/dir/?api=1&destination=48.1,2.3&travelmode=bicycling',
+            warning: PoiWarning::CLOSES_SOON,
+            warningMinutes: 20,
+        ));
+
+        self::assertSame(124, $dto->distance_m);
+        self::assertSame(87, $dto->detour_m);
+        self::assertSame('2026-08-06T15:00:00+00:00', $dto->closes_at);
+        self::assertSame(PoiWarning::CLOSES_SOON, $dto->warning);
+        self::assertSame(20, $dto->warning_minutes);
+        self::assertSame('08:00-15:00', $dto->opening_hours_today);
+    }
+
+    #[Test]
+    public function keepsAnUnknownDetourAsNullRatherThanZero(): void
+    {
+        $dto = PoiSuggestionDto::fromSuggestion(new PoiSuggestion(
+            name: 'Abri',
+            category: InRidePoiCategory::SHELTER,
+            osmType: 'way',
+            osmId: 7,
+            lat: 48.0,
+            lon: 2.0,
+            distanceMeters: 40.2,
+            detourMeters: null,
+            openingHoursToday: null,
+            closesAt: null,
+            phone: null,
+            deeplink: 'https://www.google.com/maps/dir/?api=1&destination=48,2&travelmode=bicycling',
+            warning: PoiWarning::HOURS_UNVERIFIED,
+        ));
+
+        self::assertNull($dto->detour_m);
+        self::assertNull($dto->closes_at);
+        self::assertNull($dto->warning_minutes);
+        self::assertSame(40, $dto->distance_m);
+        self::assertSame(PoiWarning::HOURS_UNVERIFIED, $dto->warning);
+    }
+}

--- a/api/tests/Unit/InRide/DeeplinkBuilderTest.php
+++ b/api/tests/Unit/InRide/DeeplinkBuilderTest.php
@@ -20,64 +20,38 @@ final class DeeplinkBuilderTest extends TestCase
     }
 
     #[Test]
-    public function googleMapsLinkIsBicycling(): void
+    public function googleMapsLinkIsBicyclingToTheDestinationOnly(): void
     {
-        $url = $this->builder->googleMapsBicycling(
-            new GeoPoint(50.8503, 4.3517),
-            new GeoPoint(50.8500, 4.3525),
-        );
+        $url = $this->builder->googleMapsBicycling(new GeoPoint(50.8500, 4.3525));
 
         $this->assertStringStartsWith('https://www.google.com/maps/dir/?api=1', $url);
         $this->assertStringContainsString('travelmode=bicycling', $url);
-        $this->assertStringContainsString('origin=50.8503,4.3517', $url);
         $this->assertStringContainsString('destination=50.85,4.3525', $url);
+        // The rider's live position must never leak into the URL.
+        $this->assertStringNotContainsString('origin=', $url);
     }
 
     #[Test]
     public function googleMapsTrimsTrailingZeros(): void
     {
-        $url = $this->builder->googleMapsBicycling(
-            new GeoPoint(50.0, 4.0),
-            new GeoPoint(50.1234500, 4.0000000),
-        );
+        $url = $this->builder->googleMapsBicycling(new GeoPoint(50.1234500, 4.0000000));
 
-        $this->assertStringContainsString('origin=50,4', $url);
         $this->assertStringContainsString('destination=50.12345,4', $url);
     }
 
     #[Test]
     public function googleMapsAcceptsNegativeCoordinates(): void
     {
-        $url = $this->builder->googleMapsBicycling(
-            new GeoPoint(-33.8688, 151.2093),
-            new GeoPoint(-33.8700, 151.2100),
-        );
+        $url = $this->builder->googleMapsBicycling(new GeoPoint(-33.8700, 151.2100));
 
-        $this->assertStringContainsString('origin=-33.8688,151.2093', $url);
-    }
-
-    #[Test]
-    public function openStreetMapUsesBikeEngine(): void
-    {
-        $url = $this->builder->openStreetMap(
-            new GeoPoint(48.8566, 2.3522),
-            new GeoPoint(48.8606, 2.3376),
-        );
-
-        $this->assertStringStartsWith('https://www.openstreetmap.org/directions', $url);
-        $this->assertStringContainsString('engine=fossgis_osrm_bike', $url);
-        // Coordinates are url-encoded: "lat,lon;lat,lon" → "%2C" between lat/lon and "%3B" between origin/destination.
-        $this->assertStringContainsString('route=48.8566%2C2.3522%3B48.8606%2C2.3376', $url);
+        $this->assertStringContainsString('destination=-33.87,151.21', $url);
     }
 
     #[Test]
     public function precisionIsAtMostSevenDecimals(): void
     {
-        $url = $this->builder->googleMapsBicycling(
-            new GeoPoint(50.85031234567890, 4.35171234567890),
-            new GeoPoint(0.0, 0.0),
-        );
+        $url = $this->builder->googleMapsBicycling(new GeoPoint(50.85031234567890, 4.35171234567890));
 
-        $this->assertStringContainsString('origin=50.8503123,4.3517123', $url);
+        $this->assertStringContainsString('destination=50.8503123,4.3517123', $url);
     }
 }

--- a/api/tests/Unit/InRide/NearbyPoiFinderTest.php
+++ b/api/tests/Unit/InRide/NearbyPoiFinderTest.php
@@ -324,7 +324,8 @@ final class NearbyPoiFinderTest extends TestCase
         $result = $finder->find(InRidePoiCategory::WATER, $this->rider());
 
         self::assertStringContainsString('travelmode=bicycling', $result['pois'][0]->deeplink);
-        self::assertStringContainsString('origin=48,2', $result['pois'][0]->deeplink);
+        self::assertStringContainsString('destination=48,2', $result['pois'][0]->deeplink);
+        self::assertStringNotContainsString('origin=', $result['pois'][0]->deeplink);
     }
 
     // --- fixtures -----------------------------------------------------------

--- a/api/tests/Unit/State/NearbyPoiSearchProcessorTest.php
+++ b/api/tests/Unit/State/NearbyPoiSearchProcessorTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\State;
+
+use ApiPlatform\Metadata\Post;
+use App\ApiResource\Model\GeoPosition;
+use App\ApiResource\NearbyPoiSearchRequest;
+use App\Entity\User;
+use App\Geo\HaversineDistance;
+use App\InRide\DeeplinkBuilder;
+use App\InRide\DetourCalculator;
+use App\InRide\InRidePoiCategory;
+use App\InRide\InRidePoiRepositoryInterface;
+use App\InRide\NearbyPoiFinder;
+use App\InRide\OpeningHoursParser;
+use App\InRide\RouteTail;
+use App\Osm\CoverageRepositoryInterface;
+use App\Poi\PoiLabelResolver;
+use App\Repository\TripRequestRepositoryInterface;
+use App\State\NearbyPoiSearchProcessor;
+use App\Tests\Unit\AlertMessageTestTrait;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
+
+final class NearbyPoiSearchProcessorTest extends TestCase
+{
+    use AlertMessageTestTrait;
+
+    #[Test]
+    public function rejectsWith429WhenTheLimiterIsExhausted(): void
+    {
+        $user = new User('rider@example.com');
+
+        $limiter = new RateLimiterFactory(
+            ['id' => 'nearby_pois', 'policy' => 'sliding_window', 'limit' => 1, 'interval' => '60 seconds'],
+            new InMemoryStorage(),
+        );
+        $limiter->create($user->getId()->toRfc4122())->consume();
+
+        $processor = new NearbyPoiSearchProcessor($this->finder([]), $this->security($user), $limiter);
+
+        $this->expectException(TooManyRequestsHttpException::class);
+        $processor->process($this->request(InRidePoiCategory::WATER), new Post(), ['id' => 'trip-1']);
+    }
+
+    #[Test]
+    public function mapsTheFinderEnvelopeAndSuggestionsToTheResponse(): void
+    {
+        $finder = $this->finder([
+            ['osmType' => 'node', 'osmId' => 1, 'name' => 'Fountain', 'category' => 'drinking_water', 'lat' => 48.0, 'lon' => 2.0, 'openingHours' => null, 'tags' => []],
+        ]);
+
+        $processor = new NearbyPoiSearchProcessor($finder, $this->security(new User('rider@example.com')), $this->freshLimiter());
+
+        $response = $processor->process($this->request(InRidePoiCategory::WATER), new Post(), ['id' => 'trip-1']);
+
+        self::assertSame('trip-1', $response->tripId);
+        self::assertSame(InRidePoiCategory::WATER, $response->category);
+        self::assertFalse($response->outOfCoverage);
+        self::assertSame(1, $response->totalFound);
+        self::assertCount(1, $response->pois);
+        self::assertSame('Fountain', $response->pois[0]->name);
+        self::assertSame(InRidePoiCategory::WATER, $response->pois[0]->category);
+        self::assertStringContainsString('travelmode=bicycling', $response->pois[0]->deeplink);
+    }
+
+    #[Test]
+    public function usesTheCategoryDefaultRadiusWhenNoneIsRequested(): void
+    {
+        $processor = new NearbyPoiSearchProcessor($this->finder([]), $this->security(new User('rider@example.com')), $this->freshLimiter());
+
+        $response = $processor->process($this->request(InRidePoiCategory::WATER, null), new Post(), ['id' => 'trip-1']);
+
+        self::assertSame(InRidePoiCategory::WATER->defaultRadiusMeters(), $response->radiusMeters);
+    }
+
+    #[Test]
+    public function clampsAnOutOfBoundsRadiusWithoutErrorAndEchoesTheAppliedValue(): void
+    {
+        $processor = new NearbyPoiSearchProcessor($this->finder([]), $this->security(new User('rider@example.com')), $this->freshLimiter());
+
+        $tooWide = $processor->process($this->request(InRidePoiCategory::WATER, 999_999), new Post(), ['id' => 'trip-1']);
+        self::assertSame(InRidePoiCategory::MAX_RADIUS_METERS, $tooWide->radiusMeters);
+
+        $tooNarrow = $processor->process($this->request(InRidePoiCategory::WATER, 10), new Post(), ['id' => 'trip-1']);
+        self::assertSame(InRidePoiCategory::MIN_RADIUS_METERS, $tooNarrow->radiusMeters);
+    }
+
+    private function request(InRidePoiCategory $category, ?int $radiusMeters = 3_000): NearbyPoiSearchRequest
+    {
+        return new NearbyPoiSearchRequest($category, new GeoPosition(48.0, 2.0), $radiusMeters);
+    }
+
+    private function security(User $user): Security
+    {
+        $security = $this->createStub(Security::class);
+        $security->method('getUser')->willReturn($user);
+
+        return $security;
+    }
+
+    private function freshLimiter(): RateLimiterFactory
+    {
+        return new RateLimiterFactory(
+            ['id' => 'nearby_pois', 'policy' => 'sliding_window', 'limit' => 30, 'interval' => '60 seconds'],
+            new InMemoryStorage(),
+        );
+    }
+
+    /**
+     * @param list<array{osmType: string, osmId: int, name: ?string, category: string, lat: float, lon: float, openingHours: ?string, tags: array<string, string>}> $rows
+     */
+    private function finder(array $rows): NearbyPoiFinder
+    {
+        $distance = new HaversineDistance();
+
+        $repo = $this->createStub(InRidePoiRepositoryInterface::class);
+        $repo->method('findNearby')->willReturn($rows);
+
+        $coverage = $this->createStub(CoverageRepositoryInterface::class);
+        $coverage->method('isRouteOutOfZone')->willReturn(false);
+
+        $trip = $this->createStub(TripRequestRepositoryInterface::class);
+        $trip->method('getLocale')->willReturn('en');
+        $trip->method('getStageGeometry')->willReturn(null);
+
+        return new NearbyPoiFinder(
+            $repo,
+            new OpeningHoursParser(),
+            new DetourCalculator($distance),
+            new RouteTail($distance),
+            new DeeplinkBuilder(),
+            $distance,
+            $coverage,
+            new PoiLabelResolver($this->createAlertTranslator()),
+            $trip,
+        );
+    }
+}

--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -644,7 +644,11 @@
       "noOpeningHours": "Opening hours unverified — confirm on site.",
       "routeNotModified": "Your planned route is not modified.",
       "osmDisclaimer": "OpenStreetMap data — verify on the ground when in doubt.",
-      "geolocPrompt": "Share my location for nearby suggestions"
+      "geolocPrompt": "Share my location for nearby suggestions",
+      "warning": {
+        "closesSoon": "Closes in {minutes} min.",
+        "farFromRoute": "Far from your route."
+      }
     }
   },
   "aiOverview": {

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -644,7 +644,11 @@
       "noOpeningHours": "Horaires non vérifiés — confirme sur place.",
       "routeNotModified": "Ton itinéraire de base n'est pas modifié.",
       "osmDisclaimer": "Données OpenStreetMap — vérifier sur place en cas de doute.",
-      "geolocPrompt": "Partager ma position pour des suggestions à proximité"
+      "geolocPrompt": "Partager ma position pour des suggestions à proximité",
+      "warning": {
+        "closesSoon": "Ferme dans {minutes} min.",
+        "farFromRoute": "Loin de ton itinéraire."
+      }
     }
   },
   "aiOverview": {

--- a/pwa/package-lock.json
+++ b/pwa/package-lock.json
@@ -13528,9 +13528,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/pwa/package.json
+++ b/pwa/package.json
@@ -70,7 +70,7 @@
     "postcss": "^8.5.25",
     "playwright-core": "1.62.1",
     "sharp": "^0.35.3",
-    "js-yaml": "^4.3.0",
+    "js-yaml": "^4.3.1",
     "minimatch": "^10.1.1",
     "brace-expansion": "^5.0.9",
     "@hono/node-server": "^2.1.0",

--- a/pwa/src/components/chat/PoiCard.tsx
+++ b/pwa/src/components/chat/PoiCard.tsx
@@ -100,7 +100,7 @@ export function PoiCard({ poi }: PoiCardProps) {
           </h3>
           <p className="mt-0.5 text-xs text-muted-foreground">
             {formatDistance(poi.distance_m)}
-            {poi.detour_m > 0 && (
+            {poi.detour_m != null && poi.detour_m > 0 && (
               <span
                 data-testid="poi-card-detour"
                 className="ml-2 inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-[10px] font-medium text-muted-foreground"

--- a/pwa/src/components/chat/PoiCard.tsx
+++ b/pwa/src/components/chat/PoiCard.tsx
@@ -73,7 +73,15 @@ export function PoiCard({ poi }: PoiCardProps) {
   const closesAt = formatClosingTime(poi.closes_at ?? null);
   const hasOpeningHours =
     !!poi.opening_hours_today && poi.opening_hours_today.trim() !== "";
-  const hasWarning = !!poi.warning && poi.warning.trim() !== "";
+  const hasWarning = poi.warning != null && poi.warning !== "";
+  const warningText =
+    poi.warning === "closes_soon"
+      ? t("warning.closesSoon", { minutes: poi.warning_minutes ?? 0 })
+      : poi.warning === "far_from_route"
+        ? t("warning.farFromRoute")
+        : poi.warning === "hours_unverified"
+          ? t("noOpeningHours")
+          : null;
 
   return (
     <article
@@ -152,7 +160,7 @@ export function PoiCard({ poi }: PoiCardProps) {
           </a>
         )}
 
-        {hasWarning && (
+        {hasWarning && warningText && (
           <p
             data-testid="poi-card-warning"
             className="flex items-start gap-1 text-amber-700"
@@ -161,7 +169,7 @@ export function PoiCard({ poi }: PoiCardProps) {
               className="mt-0.5 h-3 w-3 shrink-0"
               aria-hidden="true"
             />
-            <span>{poi.warning}</span>
+            <span>{warningText}</span>
           </p>
         )}
       </div>

--- a/pwa/src/lib/api/client.ts
+++ b/pwa/src/lib/api/client.ts
@@ -510,12 +510,16 @@ const poiSuggestionSchema = z.object({
   lat: z.number(),
   lon: z.number(),
   distance_m: z.number(),
-  detour_m: z.number(),
+  // null = no remaining route was available to measure the detour against.
+  detour_m: z.number().nullable(),
   opening_hours_today: z.string().nullable(),
   closes_at: z.string().nullable(),
   phone: z.string().nullable(),
   deeplink: safeUrlSchema,
+  // Typed backend warning code (closes_soon | far_from_route | hours_unverified).
   warning: z.string().nullable(),
+  // Minutes left before closing when `warning` is `closes_soon`.
+  warning_minutes: z.number().nullable(),
 });
 
 /**

--- a/pwa/src/lib/api/schema.d.ts
+++ b/pwa/src/lib/api/schema.d.ts
@@ -3935,7 +3935,7 @@ export interface operations {
                     "application/ld+json": components["schemas"]["Trip.NearbyPoiSearchResponse.jsonld"];
                 };
             };
-            /** @description Unknown POI category */
+            /** @description Invalid input */
             400: {
                 headers: {
                     [name: string]: unknown;
@@ -3964,7 +3964,7 @@ export interface operations {
                 };
                 content?: never;
             };
-            /** @description An error occurred */
+            /** @description Unknown POI category or invalid request payload */
             422: {
                 headers: {
                     [name: string]: unknown;

--- a/pwa/src/lib/api/schema.d.ts
+++ b/pwa/src/lib/api/schema.d.ts
@@ -548,6 +548,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/trips/{id}/nearby-pois": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Search the nearest points of interest of one intent category around a rider mid-ride.
+         * @description Search the nearest points of interest of one intent category around a rider mid-ride.
+         */
+        post: operations["api_trips_idnearby-pois_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/trips/{id}/recompute": {
         parameters: {
             query?: never;
@@ -1148,6 +1168,12 @@ export interface components {
             /** @description Opening hours (Wikidata P8989). */
             openingHours?: string | null;
         };
+        GeoPosition: {
+            /** @description Latitude in decimal degrees (WGS84). */
+            lat: number;
+            /** @description Longitude in decimal degrees (WGS84). */
+            lon: number;
+        };
         HydraCollectionBaseSchema: components["schemas"]["HydraCollectionBaseSchemaNoPagination"] & {
             /**
              * @example {
@@ -1197,6 +1223,38 @@ export interface components {
             });
             "@id": string;
             "@type": string;
+        };
+        "PoiSuggestionDto.jsonld": {
+            /** @description Display name of the POI. */
+            name: string;
+            /**
+             * @description POI intent category.
+             * @enum {string}
+             */
+            category: "water" | "shelter" | "food" | "resupply" | "mechanic" | "health" | "train" | "charging";
+            /** @description POI latitude (WGS84). */
+            lat: number;
+            /** @description POI longitude (WGS84). */
+            lon: number;
+            /** @description Straight-line distance from the rider to the POI, in meters (rounded). */
+            distance_m: number;
+            /** @description Estimated additional meters if the rider detours to the POI (null when no remaining route is known, rounded). */
+            detour_m?: number | null;
+            /** @description Raw OSM `opening_hours` tag for the current day, when available. */
+            opening_hours_today?: string | null;
+            /** @description RFC 3339 closing time of the currently-open interval, or null when the POI never closes / is closed. */
+            closes_at?: string | null;
+            /** @description Optional phone number extracted from the OSM tag. */
+            phone?: string | null;
+            /** @description Pre-built deeplink the rider can tap to open the POI in their map app. */
+            deeplink: string;
+            /**
+             * @description Optional typed warning surfaced on the POI card (venue closes soon, POI far from route, opening hours unverified).
+             * @enum {string|null}
+             */
+            warning?: "closes_soon" | "far_from_route" | "hours_unverified" | null;
+            /** @description Minutes left before closing when `warning` is `closes_soon`, otherwise null. */
+            warning_minutes?: number | null;
         };
         "PointOfInterest.fit": {
             name?: string;
@@ -1446,6 +1504,23 @@ export interface components {
             collected: {
                 [key: string]: unknown;
             };
+        };
+        "Trip.NearbyPoiSearchRequest": {
+            /** @enum {string|null} */
+            category: "water" | "shelter" | "food" | "resupply" | "mechanic" | "health" | "train" | "charging" | null;
+            position: components["schemas"]["GeoPosition"] | null;
+            radiusMeters?: number | null;
+            stageDay?: number | null;
+        };
+        "Trip.NearbyPoiSearchResponse.jsonld": components["schemas"]["HydraItemBaseSchema"] & {
+            tripId?: string;
+            /** @enum {string} */
+            category?: "water" | "shelter" | "food" | "resupply" | "mechanic" | "health" | "train" | "charging";
+            radiusMeters?: number;
+            totalFound?: number;
+            capReached?: boolean;
+            outOfCoverage?: boolean;
+            pois?: components["schemas"]["PoiSuggestionDto.jsonld"][];
         };
         "Trip.TripAiGenerateRequest": {
             /** @description Free-form description of the desired trip (e.g. "boucle au départ de Lille, 2 jours, 80 km/jour, en tente"). */
@@ -3831,6 +3906,81 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ConstraintViolation"];
                     "application/json": components["schemas"]["ConstraintViolation"];
                 };
+            };
+        };
+    };
+    "api_trips_idnearby-pois_post": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Trip identifier */
+                id: string;
+            };
+            cookie?: never;
+        };
+        /** @description The new Trip resource */
+        requestBody: {
+            content: {
+                "application/ld+json": components["schemas"]["Trip.NearbyPoiSearchRequest"];
+            };
+        };
+        responses: {
+            /** @description Trip resource created */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["Trip.NearbyPoiSearchResponse.jsonld"];
+                };
+            };
+            /** @description Unknown POI category */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["Error.jsonld"];
+                    "application/problem+json": components["schemas"]["Error"];
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["Error.jsonld"];
+                    "application/problem+json": components["schemas"]["Error"];
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Trip not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description An error occurred */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["ConstraintViolation.jsonld"];
+                    "application/problem+json": components["schemas"]["ConstraintViolation"];
+                    "application/json": components["schemas"]["ConstraintViolation"];
+                };
+            };
+            /** @description Rate limit reached */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };


### PR DESCRIPTION
Sprint 51, vague 4. **Base `feature/933`** (dépend de #933 : orchestrateur `NearbyPoiFinder`, `PoiSuggestion` remodelé, enum `PoiWarning`). Expose l'orchestrateur sur une opération dédiée et corrige le deeplink.

> Stack : `main → #932 (#962) → #933 (#963) → #934`. À merger dans cet ordre. La branche sera rebasée sur `main` au fil des merges des parents.

## Changements
- **Opération** `POST /trips/{id}/nearby-pois` sur `Trip.php`, en remplacement du bloc `/trips/{id}/ai-chat` : `TRIP_VIEW` (lecture, ne mute rien), `TripRequestProvider` (404 + objet au voter), `openapi` documente 400/404/429. **POST et non GET** (la position GPS ne doit pas finir dans les logs/Referer/historique ; corps réutilisant `GeoPosition` validé).
- **Nouveaux DTOs** `NearbyPoiSearchRequest` (category NotNull, position Valid, radiusMeters borné [1000,20000], stageDay) et `NearbyPoiSearchResponse` (tripId, category, radiusMeters appliqué, totalFound, capReached, outOfCoverage, pois). **Aucune prose ne traverse le contrat.**
- **`PoiSuggestionDto` remodelé** : `category`→`InRidePoiCategory`, `detour_m`→`?int`, `warning`→`?PoiWarning`+`?int warning_minutes` ; `fromArray()` supprimée, remplacée par `fromSuggestion(PoiSuggestion)`.
- **Deeplink** : `origin` retiré (Google Maps part de la position vive et recalcule), `openStreetMap()` supprimée. URL : `https://www.google.com/maps/dir/?api=1&destination=LAT,LON&travelmode=bicycling`.
- `GeoPosition` : champ `bearing` retiré (aucun consommateur serveur). `rate_limiter` : `trip_chat` → `nearby_pois`, 30/min. `schema.d.ts` régénéré (union TS de catégories). `PoiCard.tsx`/`client.ts` : minimum pour `tsc` vert.

## Vue partagée anonyme : hors périmètre (volontaire)
`TripVoter` renvoie false sans User ; aucune opération `nearby-pois` sur `TripShare`.

## QA (jambe par jambe, exécutée par l'orchestrateur après reprise de l'agent stallé)
- PHP-CS-Fixer : `Fixed 0 of 656 files`. Rector `--dry-run` : `[OK] Rector is done!`. PHPStan level 9 : `[OK] No errors`.
- tsc `--noEmit` : OK. ESLint (PoiCard, client) : OK. Prettier `--check` : `All matched files use Prettier code style!`. i18n:check : `891 keys in sync`.
- PHPUnit Unit + Integration (stack principal, README monté) : `Tests: 1509, Assertions: 3998, Skipped: 1` (skip préexistant).
- Greps : `bearing` ne renvoie que météo, `openStreetMap`/`PoiSuggestionDto::fromArray`/`limiter.trip_chat` absents.
- **NearbyPoiSearchTest (Functional)** : arbitré par la CI (backend réel requis).

## Auto-critique
- Catégorie inconnue rejetée par le dénormaliseur (`NotNormalizableValueException` → 400), donc `openapi` documente 400, pas 422.
- L'agent worktree ayant stallé (watchdog d'infra) avant de committer, la finalisation (commit + QA + rebase du stack) a été reprise manuellement ; le code produit est intact et intégralement re-vérifié ci-dessus.

<!-- claude-review-start -->
## Claude Review

**Summary:** Fresh full pass over the whole diff, including the dependency-bump commit added since the last review round. No new findings. The endpoint follows the established `TripRequestProvider`/`TRIP_VIEW` + ADR-038 (403→404) pattern, keeps the GPS position POST-body-only, rate-limits per user (`nearby_pois`, 30/min), and clamps `radiusMeters` server-side so the echoed value always matches what was actually applied by `NearbyPoiFinder::find()`. Removals (`GeoPosition::$bearing`, `DeeplinkBuilder::openStreetMap()`, `PoiSuggestionDto::fromArray()`, the `trip_chat` limiter key) leave no orphaned callers (verified by grep across the whole repo). `PoiSuggestionDto::fromSuggestion()`'s rounding, null-detour and ATOM-`closesAt` branches have direct unit coverage, and `PoiCard.tsx` maps the typed `PoiWarning` codes to localised strings (`en.json`/`fr.json`) instead of rendering the raw enum value. The `js-yaml` override bump (4.3.0 → 4.3.1, GHSA-5p4m-2wfm-xmqj) is a dev-only transitive pin for `openapi-typescript` and doesn't touch the shipped bundle. The `NearbyPoiSearchProcessor::process()` `\assert($user instanceof User)` type-narrowing after `getUser()` matches the established idiom used across dozens of other processors/providers in this codebase (`TripDuplicateProcessor`, `TripCollectionProvider`, the `Account/*` processors, …) — authentication itself is enforced upstream by the firewall, not by this assertion.

**PR title check:** `feat(api): add the nearby-pois search endpoint` — conforms to Conventional Commits.

**Resolved threads:** All 3 previously open bot threads (test coverage on `fromSuggestion()`, the stale 400/422 docblock, and the `PoiCard.tsx` raw-warning rendering) are already resolved as of the last push — nothing new to resolve this round.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for (stack `#932 → #933 → #934`)

**Inline comments:** No inline comments.

Commit reviewed: `e2367b8600e84bf82c0119f8abf0715ce6a6b949`
<!-- claude-review-end -->
