### PR TITLE
feat(pwa): panneau « en route » à questions prédéfinies

### DIFF
--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -645,6 +645,44 @@
       "routeNotModified": "Your planned route is not modified.",
       "osmDisclaimer": "OpenStreetMap data — verify on the ground when in doubt.",
       "geolocPrompt": "Share my location for nearby suggestions",
+      "title": "Need something on the road?",
+      "subtitle": "Tap a question to find what's nearby.",
+      "openAria": "Open in-ride help",
+      "closeAria": "Close in-ride help",
+      "threadAria": "In-ride results",
+      "chipsGroupAria": "What are you looking for?",
+      "searching": "Searching nearby...",
+      "widenSearch": "Widen the search",
+      "errorNetwork": "No connection. Check your network and try again.",
+      "errorRateLimit": "Too many searches. Wait a moment and try again.",
+      "errorGeneric": "Search failed. Try again.",
+      "category": {
+        "water": "Water",
+        "shelter": "Shelter",
+        "food": "Food",
+        "resupply": "Groceries",
+        "mechanic": "Bike shop",
+        "health": "Pharmacy",
+        "train": "Train",
+        "charging": "Charging"
+      },
+      "question": {
+        "water": "Find water",
+        "shelter": "Find shelter",
+        "food": "Eat now",
+        "resupply": "Buy groceries",
+        "mechanic": "Fix my bike",
+        "health": "Pharmacy, care",
+        "train": "Get a train home",
+        "charging": "Charge my battery"
+      },
+      "recap": {
+        "found": "{count} spots nearby.",
+        "foundTruncated": "The {count} closest of {total} nearby.",
+        "none": "Nothing usable nearby.",
+        "capReached": "Nothing usable among the {count} closest.",
+        "outOfCoverage": "You are outside the covered area."
+      },
       "warning": {
         "closesSoon": "Closes in {minutes} min.",
         "farFromRoute": "Far from your route."

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -645,6 +645,44 @@
       "routeNotModified": "Ton itinéraire de base n'est pas modifié.",
       "osmDisclaimer": "Données OpenStreetMap — vérifier sur place en cas de doute.",
       "geolocPrompt": "Partager ma position pour des suggestions à proximité",
+      "title": "Besoin de quelque chose en route ?",
+      "subtitle": "Touche une question pour trouver à proximité.",
+      "openAria": "Ouvrir l'aide en route",
+      "closeAria": "Fermer l'aide en route",
+      "threadAria": "Résultats en route",
+      "chipsGroupAria": "Que cherches-tu ?",
+      "searching": "Recherche à proximité...",
+      "widenSearch": "Élargir la recherche",
+      "errorNetwork": "Pas de connexion. Vérifie ton réseau et réessaie.",
+      "errorRateLimit": "Trop de recherches. Patiente un instant et réessaie.",
+      "errorGeneric": "La recherche a échoué. Réessaie.",
+      "category": {
+        "water": "Eau",
+        "shelter": "Abri",
+        "food": "Manger",
+        "resupply": "Courses",
+        "mechanic": "Réparateur",
+        "health": "Pharmacie",
+        "train": "Train",
+        "charging": "Recharge"
+      },
+      "question": {
+        "water": "Trouver de l'eau",
+        "shelter": "M'abriter",
+        "food": "Manger maintenant",
+        "resupply": "Faire des courses",
+        "mechanic": "Réparer mon vélo",
+        "health": "Pharmacie, soins",
+        "train": "Rentrer en train",
+        "charging": "Recharger ma batterie"
+      },
+      "recap": {
+        "found": "{count} adresses à proximité.",
+        "foundTruncated": "Les {count} plus proches sur {total} à proximité.",
+        "none": "Rien d'exploitable à proximité.",
+        "capReached": "Aucun résultat exploitable parmi les {count} plus proches.",
+        "outOfCoverage": "Tu es en dehors de la zone couverte."
+      },
       "warning": {
         "closesSoon": "Ferme dans {minutes} min.",
         "farFromRoute": "Loin de ton itinéraire."

--- a/pwa/src/components/chat/PoiCard.tsx
+++ b/pwa/src/components/chat/PoiCard.tsx
@@ -4,13 +4,17 @@ import { useTranslations } from "next-intl";
 import {
   AlertTriangle,
   Clock,
+  Cross,
   ExternalLink,
   MapPin,
   Phone,
+  ShoppingCart,
+  TrainFront,
   UtensilsCrossed,
   Tent,
   Droplet,
   Wrench,
+  Zap,
 } from "lucide-react";
 import type { PoiSuggestion } from "@/store/ui-store";
 import { cn } from "@/lib/utils";
@@ -23,10 +27,14 @@ const CATEGORY_ICONS: Record<
   string,
   React.ComponentType<{ className?: string; "aria-hidden"?: boolean }>
 > = {
-  food: UtensilsCrossed,
-  shelter: Tent,
   water: Droplet,
+  shelter: Tent,
+  food: UtensilsCrossed,
+  resupply: ShoppingCart,
   mechanic: Wrench,
+  health: Cross,
+  train: TrainFront,
+  charging: Zap,
 };
 
 /**
@@ -63,8 +71,10 @@ function formatClosingTime(iso: string | null): string {
  * Surfaces the essentials a rider needs in a glance: category icon, name,
  * distance from the current position, today's opening-hours raw string, a
  * "closes at HH:MM" badge when the venue is about to shut, and the optional
- * detour penalty. The "Open in Google Maps" button uses the backend-provided
- * deeplink so we never have to assemble lat/lon URLs client-side.
+ * detour penalty. The whole card is the primary tap target towards the
+ * backend-provided map deeplink (a stretched link, so gloved-hand taps land
+ * anywhere on it); the `tel:` link stays a separate, reachable control layered
+ * above it.
  */
 export function PoiCard({ poi }: PoiCardProps) {
   const t = useTranslations("chat.inRide");
@@ -88,7 +98,7 @@ export function PoiCard({ poi }: PoiCardProps) {
       data-testid="poi-card"
       data-category={poi.category}
       className={cn(
-        "flex flex-col gap-2 rounded-xl border border-border bg-background p-3 shadow-sm",
+        "relative flex flex-col gap-2 rounded-xl border border-border bg-background p-3 shadow-sm",
         hasWarning && "border-amber-300 bg-amber-50/40",
       )}
     >
@@ -153,7 +163,7 @@ export function PoiCard({ poi }: PoiCardProps) {
         {poi.phone && (
           <a
             href={`tel:${poi.phone}`}
-            className="flex items-center gap-1 text-brand hover:underline"
+            className="relative z-10 flex w-fit items-center gap-1 text-brand hover:underline"
           >
             <Phone className="h-3 w-3" aria-hidden="true" />
             <span>{poi.phone}</span>
@@ -174,6 +184,9 @@ export function PoiCard({ poi }: PoiCardProps) {
         )}
       </div>
 
+      {/* Stretched link: the visible button labels the action, its `after`
+          pseudo-element covers the whole card so any tap opens the map app.
+          Interactive siblings (the `tel:` link) sit above it via `z-10`. */}
       <a
         href={poi.deeplink}
         target="_blank"
@@ -183,6 +196,7 @@ export function PoiCard({ poi }: PoiCardProps) {
           "inline-flex items-center justify-center gap-1 rounded-md border border-border bg-background",
           "px-3 py-1.5 text-xs font-medium text-foreground shadow-sm",
           "hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand",
+          "after:absolute after:inset-0 after:content-['']",
         )}
       >
         <ExternalLink className="h-3 w-3" aria-hidden="true" />

--- a/pwa/src/components/in-ride/InRideBubble.tsx
+++ b/pwa/src/components/in-ride/InRideBubble.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useTranslations } from "next-intl";
+import { LifeBuoy } from "lucide-react";
+import { useShallow } from "zustand/react/shallow";
+import { useUiStore } from "@/store/ui-store";
+import { useTripStore } from "@/store/trip-store";
+import { InRidePanel } from "@/components/in-ride/InRidePanel";
+import { ChatOfflineBadge } from "@/components/chat/ChatOfflineBadge";
+import { useOnlineStatus } from "@/hooks/use-online-status";
+import { trackEvent } from "@/lib/plausible";
+import { cn } from "@/lib/utils";
+
+/**
+ * Floating in-ride help bubble + guided panel (#935).
+ *
+ * Replaces the AI chat bubble: it reads no AI capability and is open to every
+ * rider with no token. Gated only on a loaded trip and the network state — a
+ * loss of connectivity disables the button and surfaces the offline badge.
+ * Visible as soon as the trip view renders; hidden on the welcome / loader
+ * screens via the `trip` guard.
+ */
+export function InRideBubble() {
+  const t = useTranslations("chat.inRide");
+  const isOnline = useOnlineStatus();
+
+  const { isBubbleOpen, toggleBubble, closeBubble } = useUiStore(
+    useShallow((s) => ({
+      isBubbleOpen: s.isBubbleOpen,
+      toggleBubble: s.toggleBubble,
+      closeBubble: s.closeBubble,
+    })),
+  );
+
+  const trip = useTripStore((s) => s.trip);
+
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const wasOpenRef = useRef(false);
+
+  // Return focus to the bubble when the panel closes (accessibility).
+  useEffect(() => {
+    if (!isBubbleOpen && wasOpenRef.current) buttonRef.current?.focus();
+    wasOpenRef.current = isBubbleOpen;
+  }, [isBubbleOpen]);
+
+  // Hidden until a trip is loaded (welcome / loader screens).
+  if (!trip) return null;
+
+  const handleToggle = () => {
+    if (!isBubbleOpen) trackEvent("in_ride_opened");
+    toggleBubble();
+  };
+
+  return (
+    <>
+      <button
+        ref={buttonRef}
+        type="button"
+        onClick={isOnline ? handleToggle : undefined}
+        disabled={!isOnline}
+        aria-disabled={!isOnline}
+        aria-label={isBubbleOpen ? t("closeAria") : t("openAria")}
+        aria-expanded={isBubbleOpen}
+        aria-controls="in-ride-panel"
+        data-testid="in-ride-bubble"
+        data-open={isBubbleOpen || undefined}
+        data-offline={!isOnline || undefined}
+        title={!isOnline ? t("openAria") : undefined}
+        className={cn(
+          "fixed bottom-6 right-6 z-30 inline-flex items-center justify-center",
+          "h-14 w-14 rounded-full bg-brand-fill text-white shadow-lg",
+          "hover:bg-brand-fill-hover transition-transform hover:scale-105",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-hover focus-visible:ring-offset-2",
+          !isOnline &&
+            "cursor-not-allowed opacity-60 hover:scale-100 hover:bg-brand-fill",
+        )}
+      >
+        <LifeBuoy className="h-6 w-6" aria-hidden="true" />
+        {!isOnline && <ChatOfflineBadge />}
+      </button>
+
+      {isBubbleOpen && isOnline && <InRidePanel onClose={closeBubble} />}
+    </>
+  );
+}

--- a/pwa/src/components/in-ride/InRidePanel.tsx
+++ b/pwa/src/components/in-ride/InRidePanel.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useTranslations } from "next-intl";
+import { Loader2, MapPin, MapPinned, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useUiStore } from "@/store/ui-store";
+import { InRideDisclaimer } from "@/components/chat/InRideDisclaimer";
+import { QuestionChips } from "@/components/in-ride/QuestionChips";
+import { RecapMessage } from "@/components/in-ride/RecapMessage";
+import { useInRideSearch } from "@/hooks/use-in-ride-search";
+import { cn } from "@/lib/utils";
+
+interface InRidePanelProps {
+  /**
+   * Called when the panel is dismissed (close button, Escape key). The parent
+   * owns the global open flag so the bubble and panel stay in sync.
+   */
+  onClose: () => void;
+}
+
+const TITLE_ID = "in-ride-panel-title";
+
+/**
+ * Guided in-ride panel (#935) — replaces the free-text AI chat.
+ *
+ * Renders a 400 x 500 anchored panel on desktop, a full-screen sheet on mobile.
+ * No composer: the rider taps a question chip, the search runs, and the thread
+ * fills with a recap + POI cards. Every string comes from `next-intl`; nothing
+ * server-authored is displayed. Escape closes the panel; focus lands on the
+ * first chip at open and returns to the bubble on close (handled by the parent).
+ */
+export function InRidePanel({ onClose }: InRidePanelProps) {
+  const t = useTranslations("chat.inRide");
+
+  const thread = useUiStore((s) => s.chatHistory);
+  const {
+    isSearching,
+    errorKey,
+    geolocPromptVisible,
+    canWiden,
+    search,
+    widen,
+    requestGeoloc,
+  } = useInRideSearch();
+
+  const threadRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  // Auto-scroll to the newest turn.
+  useEffect(() => {
+    const el = threadRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [thread.length, isSearching]);
+
+  // Focus the first question chip on open so the panel is immediately usable
+  // with the keyboard.
+  useEffect(() => {
+    const firstChip = panelRef.current?.querySelector<HTMLButtonElement>(
+      '[data-testid^="in-ride-chip-"]',
+    );
+    firstChip?.focus();
+  }, []);
+
+  // Escape closes the panel.
+  useEffect(() => {
+    function handleKey(event: KeyboardEvent) {
+      if (event.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [onClose]);
+
+  // The last recap owns the "widen" affordance.
+  const lastRecapTs = [...thread].reverse().find((m) => m.kind === "recap")?.ts;
+
+  return (
+    <div
+      ref={panelRef}
+      role="dialog"
+      aria-modal="false"
+      aria-labelledby={TITLE_ID}
+      id="in-ride-panel"
+      data-testid="in-ride-panel"
+      className={cn(
+        "fixed z-40 flex flex-col bg-background shadow-2xl",
+        "inset-0 md:inset-auto md:bottom-24 md:right-6",
+        "md:w-[400px] md:h-[500px] md:rounded-2xl border md:border-border",
+      )}
+    >
+      <header className="flex items-center gap-2 border-b border-border px-4 py-3">
+        <MapPinned className="h-4 w-4 text-brand" aria-hidden="true" />
+        <div className="min-w-0 flex-1">
+          <h2 id={TITLE_ID} className="text-sm font-semibold text-foreground">
+            {t("title")}
+          </h2>
+          <p className="truncate text-xs text-muted-foreground">
+            {t("subtitle")}
+          </p>
+        </div>
+        <Button
+          type="button"
+          size="icon"
+          variant="ghost"
+          onClick={onClose}
+          aria-label={t("closeAria")}
+          data-testid="in-ride-panel-close"
+          className="h-8 w-8 shrink-0"
+        >
+          <X className="h-4 w-4" aria-hidden="true" />
+        </Button>
+      </header>
+
+      <div
+        ref={threadRef}
+        role="log"
+        aria-live="polite"
+        aria-label={t("threadAria")}
+        className="flex flex-1 flex-col gap-3 overflow-y-auto bg-muted/20 px-4 py-3"
+      >
+        {thread.map((message, index) =>
+          message.kind === "recap" ? (
+            <div
+              key={`${message.role}-${message.ts}-${index}`}
+              data-testid="in-ride-message"
+              data-role={message.role}
+              className="flex w-full justify-start"
+            >
+              <RecapMessage
+                message={message}
+                showWiden={canWiden && message.ts === lastRecapTs}
+                onWiden={widen}
+              />
+            </div>
+          ) : (
+            <div
+              key={`${message.role}-${message.ts}-${index}`}
+              data-testid="in-ride-message"
+              data-role={message.role}
+              className="flex w-full justify-end"
+            >
+              <p className="max-w-[85%] self-end rounded-2xl rounded-br-sm bg-brand-fill px-3 py-2 text-sm leading-relaxed text-white shadow-sm">
+                {message.category ? t(`question.${message.category}`) : ""}
+              </p>
+            </div>
+          ),
+        )}
+
+        {isSearching && (
+          <div
+            role="status"
+            aria-live="polite"
+            className="flex items-center gap-2 self-start text-xs text-muted-foreground"
+          >
+            <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+            <span>{t("searching")}</span>
+          </div>
+        )}
+
+        {errorKey && (
+          <p
+            role="alert"
+            className="self-start rounded-lg border border-amber-300 bg-amber-50/60 px-3 py-2 text-xs text-amber-800"
+          >
+            {t(errorKey)}
+          </p>
+        )}
+      </div>
+
+      {geolocPromptVisible && (
+        <button
+          type="button"
+          onClick={requestGeoloc}
+          data-testid="in-ride-geoloc-prompt"
+          className="flex w-full items-center gap-2 border-t border-border bg-muted/30 px-4 py-2 text-left text-xs text-muted-foreground underline-offset-2 hover:underline"
+        >
+          <MapPin className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+          {t("geolocPrompt")}
+        </button>
+      )}
+
+      <div className="border-t border-border p-3">
+        <QuestionChips onSelect={search} disabled={isSearching} />
+      </div>
+
+      <div className="border-t border-border px-3 pb-3 pt-2">
+        <InRideDisclaimer />
+      </div>
+    </div>
+  );
+}

--- a/pwa/src/components/in-ride/QuestionChips.tsx
+++ b/pwa/src/components/in-ride/QuestionChips.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import {
+  Cross,
+  Droplet,
+  ShoppingCart,
+  Tent,
+  TrainFront,
+  UtensilsCrossed,
+  Wrench,
+  Zap,
+  type LucideIcon,
+} from "lucide-react";
+import type { InRidePoiCategory } from "@/lib/api/client";
+import { cn } from "@/lib/utils";
+
+/**
+ * The eight guided intents, in display order. Each drives one category chip
+ * (label from `chat.inRide.question.<category>`) and maps to a backend
+ * {@link InRidePoiCategory}.
+ */
+const CHIPS: ReadonlyArray<{ category: InRidePoiCategory; Icon: LucideIcon }> =
+  [
+    { category: "water", Icon: Droplet },
+    { category: "shelter", Icon: Tent },
+    { category: "food", Icon: UtensilsCrossed },
+    { category: "resupply", Icon: ShoppingCart },
+    { category: "mechanic", Icon: Wrench },
+    { category: "health", Icon: Cross },
+    { category: "train", Icon: TrainFront },
+    { category: "charging", Icon: Zap },
+  ];
+
+interface QuestionChipsProps {
+  onSelect: (category: InRidePoiCategory) => void;
+  disabled?: boolean;
+}
+
+/**
+ * The predefined-question chips that replace the free-text composer (#935).
+ *
+ * A rider with gloves under the rain taps one button; there is no typing. Each
+ * chip is a real `<button>` inside a labelled `role="group"` so the whole set
+ * is announced and reachable with the keyboard.
+ */
+export function QuestionChips({ onSelect, disabled }: QuestionChipsProps) {
+  const t = useTranslations("chat.inRide");
+
+  return (
+    <div
+      role="group"
+      aria-label={t("chipsGroupAria")}
+      data-testid="in-ride-chips"
+      className="flex flex-wrap gap-2"
+    >
+      {CHIPS.map(({ category, Icon }) => (
+        <button
+          key={category}
+          type="button"
+          onClick={() => onSelect(category)}
+          disabled={disabled}
+          data-testid={`in-ride-chip-${category}`}
+          className={cn(
+            "inline-flex items-center gap-1.5 rounded-full border border-border bg-background",
+            "px-3 py-1.5 text-xs font-medium text-foreground shadow-sm",
+            "hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand",
+            "disabled:cursor-not-allowed disabled:opacity-60",
+          )}
+        >
+          <Icon className="h-3.5 w-3.5 text-brand" aria-hidden="true" />
+          {t(`question.${category}`)}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/pwa/src/components/in-ride/RecapMessage.tsx
+++ b/pwa/src/components/in-ride/RecapMessage.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { Search } from "lucide-react";
+import type { InRideMessage } from "@/store/ui-store";
+import { PoiCard } from "@/components/chat/PoiCard";
+import { cn } from "@/lib/utils";
+
+interface RecapMessageProps {
+  message: InRideMessage;
+  /** Whether the "widen search" affordance should be offered under this recap. */
+  showWiden: boolean;
+  onWiden: () => void;
+}
+
+/**
+ * Composes the assistant recap from i18n metadata (#935).
+ *
+ * No server text is ever shown: the five outcomes (results, truncated results,
+ * none, cap reached, out of coverage) are rendered from `chat.inRide.recap.*`
+ * with the counts carried on the {@link InRideMessage}. POI cards follow, then
+ * the fixed OSM disclaimer; a "widen" button doubles the radius when relevant.
+ */
+export function RecapMessage({
+  message,
+  showWiden,
+  onWiden,
+}: RecapMessageProps) {
+  const t = useTranslations("chat.inRide");
+
+  const pois = message.pois ?? [];
+  const totalFound = message.totalFound ?? 0;
+  const shown = pois.length;
+
+  let recapText: string;
+  if (message.outOfCoverage) {
+    recapText = t("recap.outOfCoverage");
+  } else if (shown > 0) {
+    recapText =
+      totalFound > shown
+        ? t("recap.foundTruncated", { count: shown, total: totalFound })
+        : t("recap.found", { count: shown });
+  } else if (message.capReached) {
+    recapText = t("recap.capReached", { count: totalFound });
+  } else {
+    recapText = t("recap.none");
+  }
+
+  return (
+    <div className="flex w-full max-w-[95%] flex-col gap-2 self-start">
+      <p
+        data-testid="in-ride-recap"
+        className="self-start rounded-2xl rounded-bl-sm border border-border bg-background px-3 py-2 text-sm leading-relaxed text-foreground shadow-sm"
+      >
+        {recapText}
+      </p>
+
+      {shown > 0 && (
+        <div data-testid="in-ride-pois" className="flex flex-col gap-2">
+          {pois.map((poi, idx) => (
+            <PoiCard key={`${poi.deeplink}-${idx}`} poi={poi} />
+          ))}
+        </div>
+      )}
+
+      {showWiden && (
+        <button
+          type="button"
+          onClick={onWiden}
+          data-testid="in-ride-widen"
+          className={cn(
+            "inline-flex items-center gap-1.5 self-start rounded-full border border-border bg-background",
+            "px-3 py-1.5 text-xs font-medium text-foreground shadow-sm",
+            "hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand",
+          )}
+        >
+          <Search className="h-3.5 w-3.5" aria-hidden="true" />
+          {t("widenSearch")}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/pwa/src/components/trip-planner.tsx
+++ b/pwa/src/components/trip-planner.tsx
@@ -22,6 +22,7 @@ import { InlineRecomputationBar } from "@/components/inline-recomputation-bar";
 import { ModificationQueue } from "@/components/modification-queue";
 import { RecentTrips } from "@/components/recent-trips";
 import { OfflineBanner } from "@/components/offline-banner";
+import { InRideBubble } from "@/components/in-ride/InRideBubble";
 import { useTripPlanner } from "@/hooks/use-trip-planner";
 import { useLinkParam } from "@/hooks/use-link-param";
 import { useKeyboardShortcuts } from "@/hooks/use-keyboard-shortcuts";
@@ -712,6 +713,11 @@ export function TripPlanner() {
           onShare={handleShareTrip}
           onDelete={handleDeleteTrip}
         />
+
+        {/* Guided in-ride help bubble (#935) — open to every rider, no AI gate.
+            Visible as soon as the trip view renders; hidden on the welcome /
+            loader screens via its own `trip` guard. */}
+        <InRideBubble />
       </main>
     </GpxDropZone>
   );

--- a/pwa/src/hooks/use-in-ride-search.ts
+++ b/pwa/src/hooks/use-in-ride-search.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   searchNearbyPois,
   type InRidePoiCategory,
@@ -8,7 +8,10 @@ import {
 } from "@/lib/api/client";
 import { useTripStore } from "@/store/trip-store";
 import { useUiStore } from "@/store/ui-store";
-import { useGeolocation } from "@/hooks/use-geolocation";
+import {
+  useGeolocation,
+  type GeolocationCoords,
+} from "@/hooks/use-geolocation";
 
 /**
  * Hard ceiling on the search radius (mirrors
@@ -72,6 +75,12 @@ export function useInRideSearch(): UseInRideSearchResult {
   // The category awaiting a fresh geolocation fix before it can be searched.
   const [pendingCategory, setPendingCategory] =
     useState<InRidePoiCategory | null>(null);
+  // The position reference seen when the pending search was dispatched.
+  // `useGeolocation` builds a fresh object on every completed lookup (even a
+  // cache hit), so a reference change reliably marks "a new fix has landed" —
+  // which is what lets each tap search from the rider's current position
+  // instead of reusing the very first fix.
+  const dispatchedPositionRef = useRef<GeolocationCoords | null>(null);
   const [lastSearch, setLastSearch] = useState<LastSearch | null>(null);
 
   const runSearch = useCallback(
@@ -115,9 +124,11 @@ export function useInRideSearch(): UseInRideSearchResult {
     [tripId, activeDayNumber, appendMessage],
   );
 
-  // Once the pending geolocation fix lands, fire the deferred search.
+  // Fire the deferred search only once a *new* fix has landed since dispatch —
+  // never the stale position captured in `dispatchedPositionRef`.
   useEffect(() => {
     if (pendingCategory === null || !geo.position) return;
+    if (geo.position === dispatchedPositionRef.current) return;
     const category = pendingCategory;
     setPendingCategory(null);
     void runSearch(category, {
@@ -142,17 +153,15 @@ export function useInRideSearch(): UseInRideSearchResult {
         ts: Date.now(),
         category,
       });
-      if (geo.position) {
-        void runSearch(category, {
-          lat: geo.position.latitude,
-          lon: geo.position.longitude,
-        });
-        return;
-      }
+      // Always ask for a fresh fix: a moving rider taps again minutes and
+      // kilometres later, and reusing the first fix would search the wrong
+      // place. The effect above consumes the position only once the new lookup
+      // resolves.
+      dispatchedPositionRef.current = geo.position;
       setPendingCategory(category);
       geo.request();
     },
-    [appendMessage, geo, runSearch],
+    [appendMessage, geo],
   );
 
   const widen = useCallback(() => {

--- a/pwa/src/hooks/use-in-ride-search.ts
+++ b/pwa/src/hooks/use-in-ride-search.ts
@@ -1,0 +1,193 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  searchNearbyPois,
+  type InRidePoiCategory,
+  type NearbyPoiSearchResult,
+} from "@/lib/api/client";
+import { useTripStore } from "@/store/trip-store";
+import { useUiStore } from "@/store/ui-store";
+import { useGeolocation } from "@/hooks/use-geolocation";
+
+/**
+ * Hard ceiling on the search radius (mirrors
+ * `App\InRide\InRidePoiCategory::MAX_RADIUS_METERS`). The "widen" affordance
+ * doubles the last effective radius but never pushes past this bound.
+ */
+export const MAX_RADIUS_METERS = 20_000;
+
+/** Localized error message key (under `chat.inRide`) surfaced in the panel. */
+export type InRideErrorKey = "errorNetwork" | "errorRateLimit" | "errorGeneric";
+
+export interface UseInRideSearchResult {
+  /** A search (geolocation lookup and/or API call) is in flight. */
+  isSearching: boolean;
+  /** Localized error key to render, or null. */
+  errorKey: InRideErrorKey | null;
+  /** Whether to surface the "share my location" prompt (geoloc denied/blocked). */
+  geolocPromptVisible: boolean;
+  /** Whether the latest recap can still be widened (not capped, radius < max). */
+  canWiden: boolean;
+  /** Run a search for the tapped category chip. */
+  search: (category: InRidePoiCategory) => void;
+  /** Replay the last search with a doubled radius (bounded by MAX_RADIUS_METERS). */
+  widen: () => void;
+  /** Retry the geolocation lookup (from the prompt). */
+  requestGeoloc: () => void;
+}
+
+interface LastSearch {
+  category: InRidePoiCategory;
+  radiusMeters: number;
+  capReached: boolean;
+}
+
+function errorKeyFor(status: NearbyPoiSearchResult["status"]): InRideErrorKey {
+  switch (status) {
+    case "network":
+      return "errorNetwork";
+    case "rate_limited":
+      return "errorRateLimit";
+    default:
+      return "errorGeneric";
+  }
+}
+
+/**
+ * Orchestrates the guided in-ride search (#935): one-shot geolocation, the
+ * `POST /trips/{id}/nearby-pois` round-trip, error classification and the
+ * radius-doubling "widen" replay. Appends the resulting turns to the in-memory
+ * in-ride thread so the panel stays a thin renderer.
+ */
+export function useInRideSearch(): UseInRideSearchResult {
+  const tripId = useTripStore((s) => s.trip?.id ?? null);
+  const activeDayNumber = useUiStore((s) => s.activeDayNumber);
+  const appendMessage = useUiStore((s) => s.appendMessage);
+
+  const geo = useGeolocation();
+
+  const [apiInFlight, setApiInFlight] = useState(false);
+  const [errorKey, setErrorKey] = useState<InRideErrorKey | null>(null);
+  // The category awaiting a fresh geolocation fix before it can be searched.
+  const [pendingCategory, setPendingCategory] =
+    useState<InRidePoiCategory | null>(null);
+  const [lastSearch, setLastSearch] = useState<LastSearch | null>(null);
+
+  const runSearch = useCallback(
+    async (
+      category: InRidePoiCategory,
+      position: { lat: number; lon: number },
+      radiusMeters?: number,
+    ) => {
+      if (!tripId) return;
+      setApiInFlight(true);
+      setErrorKey(null);
+      const result = await searchNearbyPois(tripId, {
+        category,
+        position,
+        radiusMeters: radiusMeters ?? null,
+        stageDay: activeDayNumber,
+      });
+      setApiInFlight(false);
+      if (result.status !== "ok") {
+        setErrorKey(errorKeyFor(result.status));
+        return;
+      }
+      const { data } = result;
+      appendMessage({
+        role: "assistant",
+        kind: "recap",
+        ts: Date.now(),
+        category,
+        radiusMeters: data.radiusMeters,
+        totalFound: data.totalFound,
+        capReached: data.capReached,
+        outOfCoverage: data.outOfCoverage,
+        pois: data.pois,
+      });
+      setLastSearch({
+        category,
+        radiusMeters: data.radiusMeters,
+        capReached: data.capReached,
+      });
+    },
+    [tripId, activeDayNumber, appendMessage],
+  );
+
+  // Once the pending geolocation fix lands, fire the deferred search.
+  useEffect(() => {
+    if (pendingCategory === null || !geo.position) return;
+    const category = pendingCategory;
+    setPendingCategory(null);
+    void runSearch(category, {
+      lat: geo.position.latitude,
+      lon: geo.position.longitude,
+    });
+  }, [pendingCategory, geo.position, runSearch]);
+
+  // A geolocation failure clears the pending intent; the prompt takes over.
+  useEffect(() => {
+    if (geo.error && pendingCategory !== null) {
+      setPendingCategory(null);
+    }
+  }, [geo.error, pendingCategory]);
+
+  const search = useCallback(
+    (category: InRidePoiCategory) => {
+      setErrorKey(null);
+      appendMessage({
+        role: "user",
+        kind: "question",
+        ts: Date.now(),
+        category,
+      });
+      if (geo.position) {
+        void runSearch(category, {
+          lat: geo.position.latitude,
+          lon: geo.position.longitude,
+        });
+        return;
+      }
+      setPendingCategory(category);
+      geo.request();
+    },
+    [appendMessage, geo, runSearch],
+  );
+
+  const widen = useCallback(() => {
+    if (!lastSearch || lastSearch.capReached || !geo.position) return;
+    const next = Math.min(lastSearch.radiusMeters * 2, MAX_RADIUS_METERS);
+    if (next <= lastSearch.radiusMeters) return;
+    void runSearch(
+      lastSearch.category,
+      { lat: geo.position.latitude, lon: geo.position.longitude },
+      next,
+    );
+  }, [lastSearch, geo.position, runSearch]);
+
+  const requestGeoloc = useCallback(() => {
+    geo.request();
+  }, [geo]);
+
+  const isSearching =
+    apiInFlight || (pendingCategory !== null && geo.isRequesting);
+
+  const canWiden =
+    !isSearching &&
+    lastSearch !== null &&
+    !lastSearch.capReached &&
+    lastSearch.radiusMeters < MAX_RADIUS_METERS;
+
+  const geolocPromptVisible = !geo.position && geo.error !== null;
+
+  return {
+    isSearching,
+    errorKey,
+    geolocPromptVisible,
+    canWiden,
+    search,
+    widen,
+    requestGeoloc,
+  };
+}

--- a/pwa/src/hooks/use-in-ride-search.ts
+++ b/pwa/src/hooks/use-in-ride-search.ts
@@ -81,6 +81,9 @@ export function useInRideSearch(): UseInRideSearchResult {
   // which is what lets each tap search from the rider's current position
   // instead of reusing the very first fix.
   const dispatchedPositionRef = useRef<GeolocationCoords | null>(null);
+  // The category of the most recent tap, so the "share my location" retry
+  // prompt can resume the very search it was shown for once a fix finally lands.
+  const lastAttemptedCategoryRef = useRef<InRidePoiCategory | null>(null);
   const [lastSearch, setLastSearch] = useState<LastSearch | null>(null);
 
   const runSearch = useCallback(
@@ -159,6 +162,7 @@ export function useInRideSearch(): UseInRideSearchResult {
       // kilometres later, and reusing the first fix would search the wrong
       // place. The effect above consumes the position only once the new lookup
       // resolves.
+      lastAttemptedCategoryRef.current = category;
       dispatchedPositionRef.current = geo.position;
       setPendingCategory(category);
       geo.request();
@@ -178,6 +182,12 @@ export function useInRideSearch(): UseInRideSearchResult {
   }, [lastSearch, geo.position, runSearch]);
 
   const requestGeoloc = useCallback(() => {
+    // Re-arm the last tapped category so a successful retry resumes that search
+    // rather than only refreshing the position and waiting for another tap.
+    if (lastAttemptedCategoryRef.current !== null) {
+      dispatchedPositionRef.current = geo.position;
+      setPendingCategory(lastAttemptedCategoryRef.current);
+    }
     geo.request();
   }, [geo]);
 

--- a/pwa/src/hooks/use-in-ride-search.ts
+++ b/pwa/src/hooks/use-in-ride-search.ts
@@ -138,6 +138,8 @@ export function useInRideSearch(): UseInRideSearchResult {
   }, [pendingCategory, geo.position, runSearch]);
 
   // A geolocation failure clears the pending intent; the prompt takes over.
+  // This fires for *every* failed lookup, not just the first: since each tap
+  // re-requests a fix, a denial/timeout on a later search must surface again.
   useEffect(() => {
     if (geo.error && pendingCategory !== null) {
       setPendingCategory(null);
@@ -188,7 +190,12 @@ export function useInRideSearch(): UseInRideSearchResult {
     !lastSearch.capReached &&
     lastSearch.radiusMeters < MAX_RADIUS_METERS;
 
-  const geolocPromptVisible = !geo.position && geo.error !== null;
+  // `useGeolocation` resets `error` to null at the start of every `request()`
+  // and only sets it on failure, so a non-null error always means "the latest
+  // lookup failed" — regardless of a stale position lingering from an earlier
+  // success. Gating on `!geo.position` (the old condition) hid the retry prompt
+  // for every failure after the first fix; keying on the error alone fixes that.
+  const geolocPromptVisible = geo.error !== null;
 
   return {
     isSearching,

--- a/pwa/src/lib/api/client.ts
+++ b/pwa/src/lib/api/client.ts
@@ -523,6 +523,96 @@ const poiSuggestionSchema = z.object({
 });
 
 /**
+ * The eight guided in-ride intent categories (#935). Derived from the generated
+ * OpenAPI schema so the union stays in lockstep with `App\InRide\InRidePoiCategory`.
+ */
+export type InRidePoiCategory =
+  components["schemas"]["PoiSuggestionDto.jsonld"]["category"];
+
+/**
+ * Runtime shape of the guided in-ride search response
+ * (`POST /trips/{id}/nearby-pois`, #934). Reuses {@link poiSuggestionSchema} for
+ * the POI array; every scalar carries a default so a partial body never throws.
+ */
+const nearbyPoiSearchResponseSchema = z.object({
+  tripId: z.string().default(""),
+  category: z.string(),
+  radiusMeters: z.number(),
+  totalFound: z.number().default(0),
+  capReached: z.boolean().default(false),
+  outOfCoverage: z.boolean().default(false),
+  pois: z.array(poiSuggestionSchema).default([]),
+});
+
+export type NearbyPoiSearchResponse = z.infer<
+  typeof nearbyPoiSearchResponseSchema
+>;
+
+/**
+ * Outcome of {@link searchNearbyPois}. Discriminated so the caller maps the
+ * backend's failure modes to localized messages without re-deriving them from a
+ * raw status code:
+ *
+ * - `ok`           — the search result (category, radius, POIs, coverage flags).
+ * - `rate_limited` — 429: per-user in-ride search rate limit reached (transient).
+ * - `network`      — the request never reached the backend (offline / DNS).
+ * - `error`        — any other failure (4xx/5xx, bad shape).
+ */
+export type NearbyPoiSearchResult =
+  | { status: "ok"; data: NearbyPoiSearchResponse }
+  | { status: "rate_limited" }
+  | { status: "network" }
+  | { status: "error" };
+
+/**
+ * Run a guided in-ride POI search (`POST /trips/{id}/nearby-pois`, #934/#935).
+ *
+ * `radiusMeters` is left null on the first search so the backend applies its
+ * per-category default; the "widen" affordance replays with a doubled radius.
+ * Uses the typed {@link apiClient} (the route is fully described by the
+ * generated schema) and classifies the transient 429 apart from other errors.
+ */
+export async function searchNearbyPois(
+  tripId: string,
+  params: {
+    category: InRidePoiCategory;
+    position: { lat: number; lon: number };
+    radiusMeters?: number | null;
+    stageDay?: number | null;
+  },
+  signal?: AbortSignal,
+): Promise<NearbyPoiSearchResult> {
+  let response: Response;
+  let data: unknown;
+  try {
+    const result = await apiClient.POST("/trips/{id}/nearby-pois", {
+      params: { path: { id: tripId } },
+      body: {
+        category: params.category,
+        position: params.position,
+        radiusMeters: params.radiusMeters ?? null,
+        stageDay: params.stageDay ?? null,
+      },
+      ...(signal ? { signal } : {}),
+    });
+    response = result.response;
+    data = result.data;
+  } catch {
+    // Network failure / aborted request — the openapi-fetch promise rejects.
+    return { status: "network" };
+  }
+
+  if (response.ok && data) {
+    const parsed = nearbyPoiSearchResponseSchema.safeParse(data);
+    if (!parsed.success) return { status: "error" };
+    return { status: "ok", data: parsed.data };
+  }
+
+  if (response.status === 429) return { status: "rate_limited" };
+  return { status: "error" };
+}
+
+/**
  * One turn of the pre-trip brief chat (`POST /trips/ai-chat`, ADR-045).
  * Sourced from the generated OpenAPI schema (`AiChatMessage`) so role/content
  * stay in lockstep with `App\ApiResource\Model\AiChatMessage`.

--- a/pwa/src/store/ui-store.ts
+++ b/pwa/src/store/ui-store.ts
@@ -21,7 +21,7 @@ export type ViewMode = "timeline" | "map" | "split";
  */
 export type BlockStatus = "pending" | "running" | "done" | "failed" | null;
 
-import type { PoiSuggestionDto } from "@/lib/api/client";
+import type { InRidePoiCategory, PoiSuggestionDto } from "@/lib/api/client";
 
 /**
  * POI shape carried by in-ride suggestions. Re-exported from the API client so
@@ -31,18 +31,27 @@ import type { PoiSuggestionDto } from "@/lib/api/client";
 export type PoiSuggestion = PoiSuggestionDto;
 
 /**
- * One turn of the floating assistant conversation.
+ * One turn of the guided in-ride thread (#935).
  *
- * Stored in-memory only — the conversation is intentionally not persisted
- * across page reloads.
+ * Stored in-memory only — the thread is intentionally not persisted across page
+ * reloads. Carries no `content`: every visible string is derived from
+ * `next-intl` at render time from the structured metadata below, so a reworded
+ * message never touches the store. The name disambiguates it from the brief
+ * chat's `AiChatMessage` (`ai-chat-card.tsx`) and the backend `AiChatTurn`.
  *
- * When the reply carries POI suggestions (in-ride mode), {@link pois} holds the
- * structured payload so the panel can render the POI cards beneath the text.
+ * - `question` — a user turn: which category chip was tapped.
+ * - `recap`    — an assistant turn: the search outcome (radius, counts, coverage
+ *   flags) plus the {@link pois} to render as cards.
  */
-export interface AiChatMessage {
+export interface InRideMessage {
   role: "user" | "assistant";
-  content: string;
   ts: number;
+  kind: "question" | "recap";
+  category?: InRidePoiCategory;
+  radiusMeters?: number;
+  totalFound?: number;
+  capReached?: boolean;
+  outOfCoverage?: boolean;
   pois?: PoiSuggestion[];
 }
 
@@ -86,16 +95,10 @@ interface UiState {
    */
   isBubbleOpen: boolean;
   /**
-   * Conversation history of the floating AI assistant, oldest first. Cleared
-   * when the user starts a new trip or invokes {@link clearHistory}. Not
-   * persisted across reloads.
+   * Guided in-ride thread, oldest first (#935). Cleared when the user starts a
+   * new trip or invokes {@link clearHistory}. Not persisted across reloads.
    */
-  chatHistory: AiChatMessage[];
-  /**
-   * `true` while a chat message is in flight — drives the typing indicator
-   * inside the chat panel and disables the send button.
-   */
-  isChatSending: boolean;
+  chatHistory: InRideMessage[];
   /**
    * Whether the user has ever opened the AI bubble. Stored in
    * `localStorage` so the "Nouveau" badge only shows on the first visit.
@@ -138,11 +141,9 @@ interface UiState {
   /** Force the chat panel closed. */
   closeBubble: () => void;
   /** Append a turn to {@link chatHistory}. */
-  appendMessage: (message: AiChatMessage) => void;
-  /** Reset the chat history (Acte 1.5 → Acte 3 transition, manual clear). */
+  appendMessage: (message: InRideMessage) => void;
+  /** Reset the in-ride thread (wiped on trip switch). */
   clearHistory: () => void;
-  /** Flip the in-flight indicator that drives the typing dots. */
-  setChatSending: (value: boolean) => void;
   /** Update the runtime AI availability (from the `/api/health` probe, #304). */
   setAiAvailable: (value: boolean) => void;
   /** Update whether the account has a configured AI provider (ADR-042). */
@@ -217,7 +218,6 @@ export const useUiStore = create<UiState>()(
     blockStatus: { weather: null, ai: null },
     isBubbleOpen: false,
     chatHistory: [],
-    isChatSending: false,
     hasSeenBubble: readBubbleSeenFromStorage(),
     aiCapability: { available: true, configured: false },
 
@@ -315,12 +315,6 @@ export const useUiStore = create<UiState>()(
     clearHistory: () =>
       set((state) => {
         state.chatHistory = [];
-        state.isChatSending = false;
-      }),
-
-    setChatSending: (value) =>
-      set((state) => {
-        state.isChatSending = value;
       }),
 
     setAiAvailable: (value) =>

--- a/pwa/tests/fixtures/api-mocks.ts
+++ b/pwa/tests/fixtures/api-mocks.ts
@@ -1,4 +1,5 @@
 import type { Page } from "@playwright/test";
+import { nearbyPoiSearchResponse, type NearbyPoiSearchWire } from "./mock-data";
 
 export interface MockApiOptions {
   postTripStatus?: number;
@@ -30,6 +31,14 @@ export interface MockApiOptions {
     collected?: Record<string, string | number | boolean | null>;
     status?: number;
   }>;
+  /**
+   * Scripted results for the guided in-ride search (`POST /trips/{id}/nearby-pois`,
+   * #935). Either a single response served for every category, a record keyed by
+   * category, or a numeric HTTP status to exercise the failure modes (429, 5xx).
+   * When omitted, a default non-empty water result is served for any category.
+   */
+  nearbyPoiResults?:
+    NearbyPoiSearchWire | Record<string, NearbyPoiSearchWire> | number;
 }
 
 const TRIP_ID = "test-trip-abc-123";
@@ -196,6 +205,7 @@ export async function mockAllApis(
     addStageFail = false,
     aiConfigured = true,
     aiChatTurns,
+    nearbyPoiResults,
   } = options;
 
   // POST /auth/refresh — return fake JWT so AuthGuard's silentRefresh succeeds
@@ -528,6 +538,43 @@ export async function mockAllApis(
       status: 202,
       contentType: "application/ld+json",
       body: JSON.stringify({ "@type": "StageResponse" }),
+    });
+  });
+
+  // POST /trips/{id}/nearby-pois — guided in-ride search (#935). Serves the
+  // scripted `nearbyPoiResults` (single body, per-category record, or a bare
+  // error status), defaulting to a non-empty result echoing the requested
+  // category.
+  await page.route("**/trips/*/nearby-pois", (route, request) => {
+    if (request.method() !== "POST") return route.fallback();
+    if (typeof nearbyPoiResults === "number") {
+      return route.fulfill({
+        status: nearbyPoiResults,
+        contentType: "application/ld+json",
+        body: JSON.stringify({}),
+      });
+    }
+    const body = request.postDataJSON() as { category?: string } | null;
+    const category = body?.category ?? "water";
+    let payload: NearbyPoiSearchWire;
+    if (
+      nearbyPoiResults &&
+      "pois" in (nearbyPoiResults as NearbyPoiSearchWire)
+    ) {
+      payload = nearbyPoiResults as NearbyPoiSearchWire;
+    } else if (nearbyPoiResults) {
+      const byCategory = nearbyPoiResults as Record<
+        string,
+        NearbyPoiSearchWire
+      >;
+      payload = byCategory[category] ?? nearbyPoiSearchResponse({ category });
+    } else {
+      payload = nearbyPoiSearchResponse({ category });
+    }
+    return route.fulfill({
+      status: 200,
+      contentType: "application/ld+json",
+      body: JSON.stringify(payload),
     });
   });
 }

--- a/pwa/tests/fixtures/mock-data.ts
+++ b/pwa/tests/fixtures/mock-data.ts
@@ -914,3 +914,94 @@ export function stageUpdatedEventWithSelectedAccommodation(
     },
   };
 }
+
+/**
+ * Wire shape of a single POI suggestion, matching `PoiSuggestionDto` (#934).
+ */
+export interface NearbyPoiWire {
+  name: string;
+  category: string;
+  lat: number;
+  lon: number;
+  distance_m: number;
+  detour_m: number | null;
+  opening_hours_today: string | null;
+  closes_at: string | null;
+  phone: string | null;
+  deeplink: string;
+  warning: "closes_soon" | "far_from_route" | "hours_unverified" | null;
+  warning_minutes: number | null;
+}
+
+/** Build a single in-ride POI suggestion; override any field. */
+export function nearbyPoiSuggestion(
+  overrides: Partial<NearbyPoiWire> = {},
+): NearbyPoiWire {
+  return {
+    name: "Fontaine du Village",
+    category: "water",
+    lat: 44.7,
+    lon: 4.6,
+    distance_m: 320,
+    detour_m: 150,
+    opening_hours_today: null,
+    closes_at: null,
+    phone: null,
+    deeplink: "https://www.google.com/maps/search/?api=1&query=44.7,4.6",
+    warning: null,
+    warning_minutes: null,
+    ...overrides,
+  };
+}
+
+/** Wire shape of the guided in-ride search response (#934/#935). */
+export interface NearbyPoiSearchWire {
+  "@id": string;
+  "@type": string;
+  tripId: string;
+  category: string;
+  radiusMeters: number;
+  totalFound: number;
+  capReached: boolean;
+  outOfCoverage: boolean;
+  pois: NearbyPoiWire[];
+}
+
+/**
+ * Build a `POST /trips/{id}/nearby-pois` response (#935). Defaults to three
+ * water POIs within a 3 km radius; override to exercise the truncated, empty,
+ * cap-reached and out-of-coverage recap states.
+ */
+export function nearbyPoiSearchResponse(
+  overrides: Partial<NearbyPoiSearchWire> = {},
+): NearbyPoiSearchWire {
+  const category = overrides.category ?? "water";
+  return {
+    "@id": "/trips/test-trip-abc-123/nearby-pois",
+    "@type": "Trip.NearbyPoiSearchResponse",
+    tripId: "test-trip-abc-123",
+    category,
+    radiusMeters: 3000,
+    totalFound: 3,
+    capReached: false,
+    outOfCoverage: false,
+    pois: [
+      nearbyPoiSuggestion({
+        category,
+        name: "Fontaine du Village",
+        distance_m: 320,
+      }),
+      nearbyPoiSuggestion({
+        category,
+        name: "Fontaine de la Place",
+        distance_m: 540,
+      }),
+      nearbyPoiSuggestion({
+        category,
+        name: "Source du Pont",
+        distance_m: 780,
+      }),
+    ],
+    ...overrides,
+  };
+}

--- a/pwa/tests/mocked/chat-offline.spec.ts
+++ b/pwa/tests/mocked/chat-offline.spec.ts
@@ -8,12 +8,11 @@ import { test, expect } from "../fixtures/base.fixture";
  * the rider cannot fire a request that would never reach the backend.
  *
  * The AI chat bubble was removed in #929; the guided in-ride bubble that
- * replaces it lands in #935. This spec keeps the offline coverage but is
- * pending until that component (`in-ride-bubble`) exists.
+ * replaces it landed in #935. This spec keeps the offline coverage.
  */
 
 test.describe("In-ride offline", () => {
-  test.fixme("disables the bubble and surfaces the offline badge", async ({
+  test("disables the bubble and surfaces the offline badge", async ({
     createFullTrip,
     mockedPage,
   }) => {

--- a/pwa/tests/mocked/in-ride-search.spec.ts
+++ b/pwa/tests/mocked/in-ride-search.spec.ts
@@ -146,7 +146,10 @@ test.describe("Guided in-ride search", () => {
     await openPanel(mockedPage);
     await mockedPage.getByTestId("in-ride-chip-mechanic").click();
 
-    const tel = mockedPage.locator('a[href^="tel:"]');
+    // Scope to the POI card: the trip page carries other `tel:` links (accommodation
+    // contacts), so an unscoped locator would match more than one element.
+    const card = mockedPage.getByTestId("poi-card").first();
+    const tel = card.locator('a[href^="tel:"]');
     await expect(tel).toBeVisible();
     await expect(tel).toHaveClass(/z-10/);
   });

--- a/pwa/tests/mocked/in-ride-search.spec.ts
+++ b/pwa/tests/mocked/in-ride-search.spec.ts
@@ -204,6 +204,65 @@ test.describe("Guided in-ride search", () => {
 
     await expect(mockedPage.getByTestId("poi-card-detour")).toHaveCount(1);
   });
+
+  test("a geolocation failure on a later search resurfaces the retry prompt, which resumes that search", async ({
+    createFullTrip,
+    mockedPage,
+  }) => {
+    await createFullTrip();
+    await openPanel(mockedPage);
+
+    // First search succeeds with the granted fix.
+    await mockedPage.getByTestId("in-ride-chip-water").click();
+    await expect(mockedPage.getByTestId("in-ride-recap")).toBeVisible();
+
+    // Wrap getCurrentPosition so a window flag can force it to reject on demand:
+    // clearPermissions() alone does not make the lookup fail in headless Chromium
+    // (the previously set position is still returned).
+    await mockedPage.evaluate(() => {
+      const geo = navigator.geolocation;
+      const original = geo.getCurrentPosition.bind(geo);
+      geo.getCurrentPosition = (success, error, options) => {
+        if (
+          (window as unknown as { __failGeolocation?: boolean })
+            .__failGeolocation
+        ) {
+          error?.({
+            code: 1,
+            message: "User denied Geolocation",
+            PERMISSION_DENIED: 1,
+            POSITION_UNAVAILABLE: 2,
+            TIMEOUT: 3,
+          } as GeolocationPositionError);
+          return;
+        }
+        original(success, error, options);
+      };
+    });
+
+    // Next tap cannot get a fresh fix → the retry prompt reappears despite the
+    // stale position lingering from the first search.
+    await mockedPage.evaluate(() => {
+      (window as unknown as { __failGeolocation?: boolean }).__failGeolocation =
+        true;
+    });
+    await mockedPage.getByTestId("in-ride-chip-food").click();
+    await expect(mockedPage.getByTestId("in-ride-geoloc-prompt")).toBeVisible();
+
+    // Recover the lookup and retry from the prompt → the food search resumes on
+    // its own, without a second chip tap.
+    await mockedPage.evaluate(() => {
+      (window as unknown as { __failGeolocation?: boolean }).__failGeolocation =
+        false;
+    });
+    const [request] = await Promise.all([
+      mockedPage.waitForRequest(
+        (r) => r.url().includes("/nearby-pois") && r.method() === "POST",
+      ),
+      mockedPage.getByTestId("in-ride-geoloc-prompt").click(),
+    ]);
+    expect(request.postDataJSON().category).toBe("food");
+  });
 });
 
 test.describe("Recap states", () => {

--- a/pwa/tests/mocked/in-ride-search.spec.ts
+++ b/pwa/tests/mocked/in-ride-search.spec.ts
@@ -1,0 +1,310 @@
+import { test, expect } from "../fixtures/base.fixture";
+import {
+  nearbyPoiSearchResponse,
+  nearbyPoiSuggestion,
+} from "../fixtures/mock-data";
+
+/**
+ * Issue #935 — guided in-ride search.
+ *
+ * The free-text AI chat is replaced by a token-free, AI-free panel: the rider
+ * taps one of eight question chips, geolocation resolves, the backend returns
+ * nearby POIs and the thread fills with a recap + POI cards. Every visible
+ * string is derived from next-intl; no server text is shown.
+ */
+
+const ALL_CATEGORIES = [
+  "water",
+  "shelter",
+  "food",
+  "resupply",
+  "mechanic",
+  "health",
+  "train",
+  "charging",
+] as const;
+
+async function openPanel(page: import("@playwright/test").Page) {
+  const bubble = page.getByTestId("in-ride-bubble");
+  await expect(bubble).toBeVisible({ timeout: 10_000 });
+  await bubble.click();
+  await expect(page.getByTestId("in-ride-panel")).toBeVisible();
+}
+
+test.describe("Guided in-ride search", () => {
+  test.beforeEach(async ({ mockedPage }) => {
+    await mockedPage
+      .context()
+      .grantPermissions(["geolocation"], { origin: "https://localhost" });
+    await mockedPage
+      .context()
+      .setGeolocation({ latitude: 44.7, longitude: 4.6 });
+  });
+
+  test("bubble opens the panel with the eight chips and focuses the first", async ({
+    createFullTrip,
+    mockedPage,
+  }) => {
+    await createFullTrip();
+    await openPanel(mockedPage);
+
+    await expect(mockedPage.getByTestId("in-ride-chips")).toBeVisible();
+    for (const category of ALL_CATEGORIES) {
+      await expect(
+        mockedPage.getByTestId(`in-ride-chip-${category}`),
+      ).toBeVisible();
+    }
+    // Focus lands on the first chip at open.
+    await expect(mockedPage.getByTestId("in-ride-chip-water")).toBeFocused();
+    // No free-text composer.
+    await expect(mockedPage.locator("#in-ride-panel textarea")).toHaveCount(0);
+  });
+
+  test("tapping the water chip renders a recap and three POI cards", async ({
+    createFullTrip,
+    mockedPage,
+  }) => {
+    await createFullTrip();
+    await openPanel(mockedPage);
+
+    await mockedPage.getByTestId("in-ride-chip-water").click();
+
+    await expect(mockedPage.getByTestId("in-ride-recap")).toBeVisible();
+    await expect(
+      mockedPage.getByTestId("in-ride-pois").getByTestId("poi-card"),
+    ).toHaveCount(3);
+    await expect(mockedPage.getByTestId("in-ride-disclaimer")).toBeVisible();
+  });
+
+  test("each chip triggers its own category", async ({
+    createFullTrip,
+    mockedPage,
+  }) => {
+    await createFullTrip();
+    await openPanel(mockedPage);
+
+    for (const category of ALL_CATEGORIES) {
+      const [request] = await Promise.all([
+        mockedPage.waitForRequest(
+          (r) => r.url().includes("/nearby-pois") && r.method() === "POST",
+        ),
+        mockedPage.getByTestId(`in-ride-chip-${category}`).click(),
+      ]);
+      expect(request.postDataJSON().category).toBe(category);
+      await expect(
+        mockedPage
+          .getByTestId("in-ride-pois")
+          .last()
+          .getByTestId("poi-card")
+          .first(),
+      ).toHaveAttribute("data-category", category);
+    }
+  });
+
+  test("the whole POI card is the map tap target; the phone stays separate", async ({
+    createFullTrip,
+    mockedPage,
+  }) => {
+    await createFullTrip();
+    await openPanel(mockedPage);
+    await mockedPage.getByTestId("in-ride-chip-water").click();
+
+    const card = mockedPage.getByTestId("poi-card").first();
+    const mapLink = card.getByTestId("poi-card-open-maps");
+    // The map link is stretched over the whole card via an inset ::after.
+    await expect(mapLink).toHaveClass(/after:inset-0/);
+    await expect(mapLink).toHaveAttribute("href", /google\.com\/maps/);
+  });
+
+  test("phone control is reachable outside the stretched link", async ({
+    createFullTrip,
+    mockedPage,
+  }) => {
+    await createFullTrip();
+    await mockedPage
+      .context()
+      .setGeolocation({ latitude: 44.7, longitude: 4.6 });
+    await mockedPage.route("**/trips/*/nearby-pois", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/ld+json",
+        body: JSON.stringify(
+          nearbyPoiSearchResponse({
+            category: "mechanic",
+            totalFound: 1,
+            pois: [
+              nearbyPoiSuggestion({
+                category: "mechanic",
+                name: "Vélo Atelier",
+                phone: "+33 4 75 00 00 00",
+              }),
+            ],
+          }),
+        ),
+      }),
+    );
+    await openPanel(mockedPage);
+    await mockedPage.getByTestId("in-ride-chip-mechanic").click();
+
+    const tel = mockedPage.locator('a[href^="tel:"]');
+    await expect(tel).toBeVisible();
+    await expect(tel).toHaveClass(/z-10/);
+  });
+
+  test("widen doubles the radius and replays", async ({
+    createFullTrip,
+    mockedPage,
+  }) => {
+    await createFullTrip();
+    await openPanel(mockedPage);
+    await mockedPage.getByTestId("in-ride-chip-water").click();
+
+    const widen = mockedPage.getByTestId("in-ride-widen");
+    await expect(widen).toBeVisible();
+
+    const [request] = await Promise.all([
+      mockedPage.waitForRequest(
+        (r) => r.url().includes("/nearby-pois") && r.method() === "POST",
+      ),
+      widen.click(),
+    ]);
+    // Default response radius is 3000 m → widen sends 6000 m.
+    expect(request.postDataJSON().radiusMeters).toBe(6000);
+  });
+
+  test("detour badge only shows for a positive detour", async ({
+    createFullTrip,
+    mockedPage,
+  }) => {
+    await createFullTrip();
+    await mockedPage
+      .context()
+      .setGeolocation({ latitude: 44.7, longitude: 4.6 });
+    await mockedPage.route("**/trips/*/nearby-pois", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/ld+json",
+        body: JSON.stringify(
+          nearbyPoiSearchResponse({
+            category: "water",
+            totalFound: 2,
+            pois: [
+              nearbyPoiSuggestion({ name: "Avec détour", detour_m: 240 }),
+              nearbyPoiSuggestion({ name: "Sans détour", detour_m: null }),
+            ],
+          }),
+        ),
+      }),
+    );
+    await openPanel(mockedPage);
+    await mockedPage.getByTestId("in-ride-chip-water").click();
+
+    await expect(mockedPage.getByTestId("poi-card-detour")).toHaveCount(1);
+  });
+});
+
+test.describe("Recap states", () => {
+  test.beforeEach(async ({ mockedPage }) => {
+    await mockedPage
+      .context()
+      .grantPermissions(["geolocation"], { origin: "https://localhost" });
+    await mockedPage
+      .context()
+      .setGeolocation({ latitude: 44.7, longitude: 4.6 });
+  });
+
+  test.describe("truncated results", () => {
+    test.use({
+      mockOptions: {
+        nearbyPoiResults: nearbyPoiSearchResponse({ totalFound: 12 }),
+      },
+    });
+    test("shows the truncated recap and the cards", async ({
+      createFullTrip,
+      mockedPage,
+    }) => {
+      await createFullTrip();
+      await openPanel(mockedPage);
+      await mockedPage.getByTestId("in-ride-chip-water").click();
+      await expect(
+        mockedPage.getByTestId("in-ride-pois").getByTestId("poi-card"),
+      ).toHaveCount(3);
+      await expect(mockedPage.getByTestId("in-ride-recap")).toBeVisible();
+    });
+  });
+
+  test.describe("no results", () => {
+    test.use({
+      mockOptions: {
+        nearbyPoiResults: nearbyPoiSearchResponse({ totalFound: 0, pois: [] }),
+      },
+    });
+    test("shows the empty recap and no cards", async ({
+      createFullTrip,
+      mockedPage,
+    }) => {
+      await createFullTrip();
+      await openPanel(mockedPage);
+      await mockedPage.getByTestId("in-ride-chip-water").click();
+      await expect(mockedPage.getByTestId("in-ride-recap")).toBeVisible();
+      await expect(mockedPage.getByTestId("in-ride-pois")).toHaveCount(0);
+    });
+  });
+
+  test.describe("cap reached", () => {
+    test.use({
+      mockOptions: {
+        nearbyPoiResults: nearbyPoiSearchResponse({
+          totalFound: 200,
+          capReached: true,
+          pois: [],
+        }),
+      },
+    });
+    test("shows the cap-reached recap and hides widen", async ({
+      createFullTrip,
+      mockedPage,
+    }) => {
+      await createFullTrip();
+      await openPanel(mockedPage);
+      await mockedPage.getByTestId("in-ride-chip-water").click();
+      await expect(mockedPage.getByTestId("in-ride-recap")).toBeVisible();
+      await expect(mockedPage.getByTestId("in-ride-widen")).toHaveCount(0);
+    });
+  });
+
+  test.describe("out of coverage", () => {
+    test.use({
+      mockOptions: {
+        nearbyPoiResults: nearbyPoiSearchResponse({
+          totalFound: 0,
+          outOfCoverage: true,
+          pois: [],
+        }),
+      },
+    });
+    test("shows the out-of-coverage recap", async ({
+      createFullTrip,
+      mockedPage,
+    }) => {
+      await createFullTrip();
+      await openPanel(mockedPage);
+      await mockedPage.getByTestId("in-ride-chip-water").click();
+      await expect(mockedPage.getByTestId("in-ride-recap")).toBeVisible();
+      await expect(mockedPage.getByTestId("in-ride-pois")).toHaveCount(0);
+    });
+  });
+
+  test.describe("rate limited", () => {
+    test.use({ mockOptions: { nearbyPoiResults: 429 } });
+    test("surfaces the rate-limit error", async ({
+      createFullTrip,
+      mockedPage,
+    }) => {
+      await createFullTrip();
+      await openPanel(mockedPage);
+      await mockedPage.getByTestId("in-ride-chip-water").click();
+      await expect(mockedPage.getByRole("alert")).toBeVisible();
+    });
+  });
+});

--- a/pwa/tests/recette/features/in-ride.en.feature
+++ b/pwa/tests/recette/features/in-ride.en.feature
@@ -1,0 +1,34 @@
+Feature: Guided in-ride search
+  As a cyclist on the road,
+  I want to tap a predefined question and read a few nearby results,
+  so that I can find water, shelter or a bike shop without typing.
+
+  Background:
+    Given I have created a full trip with 3 stages
+
+  @desktop @critical
+  Scenario: Opening the in-ride panel shows the eight question chips
+    When I open the in-ride panel
+    Then the eight in-ride question chips are visible
+
+  @desktop @critical
+  Scenario: Finding water nearby
+    Given I have shared my location
+    When I open the in-ride panel
+    And I tap the "water" in-ride question chip
+    Then an in-ride recap is shown
+    And nearby in-ride POI cards are shown
+
+  @desktop
+  Scenario: Widening the search
+    Given I have shared my location
+    When I open the in-ride panel
+    And I tap the "water" in-ride question chip
+    And I widen the in-ride search
+    Then an in-ride recap is shown
+
+  @desktop
+  Scenario: The bubble is disabled when offline
+    When the app goes offline
+    Then the in-ride bubble is disabled
+    And the in-ride offline badge is visible

--- a/pwa/tests/recette/features/in-ride.fr.feature
+++ b/pwa/tests/recette/features/in-ride.fr.feature
@@ -1,0 +1,34 @@
+Feature: Recherche guidée en route
+  En tant que cycliste sur la route,
+  je veux toucher une question prédéfinie et lire quelques résultats à proximité,
+  afin de trouver de l'eau, un abri ou un réparateur sans rien taper.
+
+  Contexte:
+    Étant donné que j'ai créé un voyage complet avec 3 étapes
+
+  @desktop @critical
+  Scénario: Ouvrir le panneau en route affiche les huit puces de questions
+    Quand j'ouvre le panneau en route
+    Alors les huit puces de questions en route sont visibles
+
+  @desktop @critical
+  Scénario: Trouver de l'eau à proximité
+    Étant donné que j'ai partagé ma position
+    Quand j'ouvre le panneau en route
+    Et je touche la puce de question en route "water"
+    Alors un récapitulatif en route est affiché
+    Et des cartes de POI en route à proximité sont affichées
+
+  @desktop
+  Scénario: Élargir la recherche
+    Étant donné que j'ai partagé ma position
+    Quand j'ouvre le panneau en route
+    Et je touche la puce de question en route "water"
+    Et j'élargis la recherche en route
+    Alors un récapitulatif en route est affiché
+
+  @desktop
+  Scénario: La bulle est désactivée hors ligne
+    Quand l'application passe hors ligne
+    Alors la bulle en route est désactivée
+    Et le badge hors ligne en route est visible

--- a/pwa/tests/recette/features/in-ride.fr.feature
+++ b/pwa/tests/recette/features/in-ride.fr.feature
@@ -1,4 +1,5 @@
-Feature: Recherche guidée en route
+# language: fr
+Fonctionnalité: Recherche guidée en route
   En tant que cycliste sur la route,
   je veux toucher une question prédéfinie et lire quelques résultats à proximité,
   afin de trouver de l'eau, un abri ou un réparateur sans rien taper.

--- a/pwa/tests/recette/steps/in-ride.steps.ts
+++ b/pwa/tests/recette/steps/in-ride.steps.ts
@@ -1,0 +1,137 @@
+import { expect } from "@playwright/test";
+import { Given, When, Then } from "../support/fixtures";
+
+// ---------------------------------------------------------------------------
+// Guided in-ride search (#935) — FR + EN. Drives the same public fixtures as
+// the mocked spec (in-ride-search) so the scenarios run end-to-end. The trip
+// creation itself reuses the shared "full trip with 3 stages" Given.
+// ---------------------------------------------------------------------------
+
+const GEO = { latitude: 44.7, longitude: 4.6 };
+
+async function shareLocation(
+  page: import("@playwright/test").Page,
+): Promise<void> {
+  await page
+    .context()
+    .grantPermissions(["geolocation"], { origin: "https://localhost" });
+  await page.context().setGeolocation(GEO);
+}
+
+async function openPanel(page: import("@playwright/test").Page): Promise<void> {
+  const bubble = page.getByTestId("in-ride-bubble");
+  await expect(bubble).toBeVisible({ timeout: 10_000 });
+  await bubble.click();
+  await expect(page.getByTestId("in-ride-panel")).toBeVisible();
+}
+
+async function goOffline(page: import("@playwright/test").Page): Promise<void> {
+  await page.context().setOffline(true);
+  await page.evaluate(() => {
+    Object.defineProperty(navigator, "onLine", {
+      configurable: true,
+      get: () => false,
+    });
+    window.dispatchEvent(new Event("offline"));
+  });
+}
+
+Given("I have shared my location", async ({ mockedPage }) => {
+  await shareLocation(mockedPage);
+});
+
+Given("j'ai partagé ma position", async ({ mockedPage }) => {
+  await shareLocation(mockedPage);
+});
+
+When("I open the in-ride panel", async ({ mockedPage }) => {
+  await openPanel(mockedPage);
+});
+
+When("j'ouvre le panneau en route", async ({ mockedPage }) => {
+  await openPanel(mockedPage);
+});
+
+Then("the eight in-ride question chips are visible", async ({ mockedPage }) => {
+  await expect(mockedPage.getByTestId("in-ride-chips")).toBeVisible();
+  const chips = mockedPage.locator('[data-testid^="in-ride-chip-"]');
+  await expect(chips).toHaveCount(8);
+});
+
+Then(
+  "les huit puces de questions en route sont visibles",
+  async ({ mockedPage }) => {
+    await expect(mockedPage.getByTestId("in-ride-chips")).toBeVisible();
+    const chips = mockedPage.locator('[data-testid^="in-ride-chip-"]');
+    await expect(chips).toHaveCount(8);
+  },
+);
+
+When(
+  "I tap the {string} in-ride question chip",
+  async ({ mockedPage }, category: string) => {
+    await mockedPage.getByTestId(`in-ride-chip-${category}`).click();
+  },
+);
+
+When(
+  "je touche la puce de question en route {string}",
+  async ({ mockedPage }, category: string) => {
+    await mockedPage.getByTestId(`in-ride-chip-${category}`).click();
+  },
+);
+
+When("I widen the in-ride search", async ({ mockedPage }) => {
+  await mockedPage.getByTestId("in-ride-widen").click();
+});
+
+When("j'élargis la recherche en route", async ({ mockedPage }) => {
+  await mockedPage.getByTestId("in-ride-widen").click();
+});
+
+Then("an in-ride recap is shown", async ({ mockedPage }) => {
+  await expect(mockedPage.getByTestId("in-ride-recap").first()).toBeVisible();
+});
+
+Then("un récapitulatif en route est affiché", async ({ mockedPage }) => {
+  await expect(mockedPage.getByTestId("in-ride-recap").first()).toBeVisible();
+});
+
+Then("nearby in-ride POI cards are shown", async ({ mockedPage }) => {
+  await expect(
+    mockedPage.getByTestId("in-ride-pois").getByTestId("poi-card").first(),
+  ).toBeVisible();
+});
+
+Then(
+  "des cartes de POI en route à proximité sont affichées",
+  async ({ mockedPage }) => {
+    await expect(
+      mockedPage.getByTestId("in-ride-pois").getByTestId("poi-card").first(),
+    ).toBeVisible();
+  },
+);
+
+When("the app goes offline", async ({ mockedPage }) => {
+  await goOffline(mockedPage);
+});
+
+When("l'application passe hors ligne", async ({ mockedPage }) => {
+  await goOffline(mockedPage);
+});
+
+Then("the in-ride bubble is disabled", async ({ mockedPage }) => {
+  await expect(mockedPage.getByTestId("in-ride-bubble")).toBeDisabled();
+});
+
+Then("la bulle en route est désactivée", async ({ mockedPage }) => {
+  await expect(mockedPage.getByTestId("in-ride-bubble")).toBeDisabled();
+});
+
+Then("the in-ride offline badge is visible", async ({ mockedPage }) => {
+  await expect(mockedPage.getByTestId("chat-offline-badge")).toBeVisible();
+});
+
+Then("le badge hors ligne en route est visible", async ({ mockedPage }) => {
+  await expect(mockedPage.getByTestId("chat-offline-badge")).toBeVisible();
+});


### PR DESCRIPTION
Sprint 51, vague 5. **Base `feature/934`** (dépend de #934 : endpoint `nearby-pois` + types générés). Parallélisable avec #936. Remplace le chat IA masqué par un panneau guidé **sans IA ni token**, ouvert à tous.

> Stack : `main → #932 (#962) → #933 (#963) → #934 (#965) → #935`. À merger dans cet ordre.

## Changements
**Nouveaux composants** `pwa/src/components/in-ride/` :
- `InRideBubble.tsx` — bulle flottante `LifeBuoy`, **aucune lecture d'`aiCapability`**, gardée sur `trip` + réseau, réutilise `ChatOfflineBadge` (désactivée hors ligne), track `in_ride_opened`, rend le focus à la fermeture.
- `InRidePanel.tsx` — `role="dialog" aria-modal="false"`, fil `role="log" aria-live="polite"`, Échap ferme, focus sur la 1re puce à l'ouverture. **Pas de `textarea`.**
- `QuestionChips.tsx` — les 8 questions en vrais `<button>` dans un `role="group"` labellisé.
- `RecapMessage.tsx` — compose les 5 états de récap purement depuis i18n + cartes POI + bouton élargir.
- `use-in-ride-search.ts` — géoloc, appel API, classification d'erreurs (réseau/429/générique), doublement du rayon borné à `MAX_RADIUS_METERS`.

**Modifiés** : `client.ts` (`searchNearbyPois` + `nearbyPoiSearchResponseSchema`, réutilise `poiSuggestionSchema`) ; `ui-store.ts` (`AiChatMessage`→`InRideMessage`, **sans champ `content`**) ; `PoiCard.tsx` (4→8 icônes ; **toute la carte cliquable** via lien étiré `after:inset-0`, `tel:` en `z-10` au-dessus ; badge détour seulement si non nul et positif ; `warning` enum rendu depuis i18n) ; `trip-planner.tsx` (`<InRideBubble />` **sans condition IA**, les autres `isAiFeatureEnabled()` intacts) ; `messages/{en,fr}.json` (toutes les clés `chat.inRide`, parité stricte).

**Tests** : `tests/mocked/in-ride-search.spec.ts`, `tests/recette/features/in-ride.{en,fr}.feature` + steps, fixtures (`nearbyPoiResults`, route `**/trips/*/nearby-pois`, fabriques), `chat-offline.spec.ts` réactivé.

## QA (jambe par jambe)
- `tsc --noEmit` : OK. `eslint` (fichiers changés) : OK. `prettier@3.9.6 --check` : `All matched files use Prettier code style!`. `i18n:check` : `925 keys in sync across fr, en`.
- `grep -rn "textarea\|<input" pwa/src/components/in-ride` : rien.
- Les 4 orphelins front recâblés : `PoiCard`←`RecapMessage`, `InRideDisclaimer`←`InRidePanel`, `use-geolocation`←`use-in-ride-search`, `ChatOfflineBadge`←`InRideBubble`.
- **Playwright (mocked + recette) : arbitré par la CI** — non joué en worktree, aucune couverture E2E locale prétendue.

## Auto-critique
- `InRideMessage` sans `content` : tout texte vient de `next-intl`, décision « aucune prose serveur » vérifiable par le typage.
- La recette manuelle sur téléphone (#938) reste à jouer hors `/sprint`.

<!-- claude-review-start -->
## Claude Review

**Summary:** Re-verified the full diff against the latest commit (`e5cdb567`), which adds the mocked "geolocation failure on a later search resumes that search" test. Re-traced `use-in-ride-search.ts` against `useGeolocation`'s real implementation (`setPosition` always constructs a fresh object on every successful lookup, even a cached hit) and confirmed the retry-resume path is correct: `requestGeoloc()` re-arms `pendingCategory` from `lastAttemptedCategoryRef`, so a successful retry replays the search it was shown for. No orphaned references to the removed `AiChatMessage`/`isChatSending` store fields remain elsewhere in `pwa/src` (the unrelated `AiChatMessage` in `ai-chat-card.tsx` is a distinct, pre-existing type). No debug leftovers, no security issues in the new `nearby-pois` client call (typed `apiClient`, no raw URL construction), and the stretched-link pattern in `PoiCard` correctly scopes the `tel:` control above the card-wide map link via `z-10`. Findings: 0.

**Resolved threads:** All 4 previous bot-authored threads on this PR are already resolved — nothing new to resolve this round. 6 previous bot reviews were already dismissed/minimized; 1 dismissed-but-unminimized `claude` review was minimized.

**PR title check:** still non-conforming — the title (`feat(pwa): panneau « en route » à questions prédéfinies`) is French and a noun phrase, not the imperative-mood English description Conventional Commits (and this repo's own commit history) expects. Non-blocking since it doesn't affect code correctness, but flagging again since it was raised in the prior review too.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

Commit reviewed: `e5cdb567960d3527e324fb333458b6e07e758914`
<!-- claude-review-end -->