### PR TITLE
docs: capture sprint 51 retrospective gotchas in CLAUDE.md and /sprint

### DIFF
--- a/.claude/skills/sprint/SKILL.md
+++ b/.claude/skills/sprint/SKILL.md
@@ -72,7 +72,10 @@ You are implementing GitHub issue #<number>: <title>
      [ -d "$MAIN/$p" ] && rsync -a --link-dest="$MAIN/$p/" "$MAIN/$p/" "$p/"
    done
    ```
-4. Implement the solution following CLAUDE.md rules (architecture, SOLID, patterns)
+4. Implement the solution following CLAUDE.md rules (architecture, SOLID, patterns). Two CLAUDE.md test-contract gotchas that cost Sprint 51 a CI round-trip each — honour them up front:
+   - **API error codes:** a non-owner on an item operation gets **404, not 403** (object-authz masking, ADR-038); an unknown backed-enum value in the body is **422, not 400** (denormalization → validation). Write the functional test and the `openapi` responses to 404 / 422, whatever the issue text guesses.
+   - **French `.feature` files** must begin with `# language: fr` (with `Fonctionnalité:`), else `bddgen` dies parsing `Scénario:`. Validate with `npx bddgen --config playwright.bdd.config.ts`.
+   - **Timezone:** CI runs `Europe/Paris`; pin any offset/ATOM assertion's `DateTimeImmutable` to explicit UTC (a hard-coded `+00:00` passes in a UTC dev container and fails in CI).
 5. **`make qa` will NOT complete — do not spend turns on it.** Read the "Local QA" section of CLAUDE.md and run the legs individually with the container recipes given there: the `php` service is capped at 768M in `compose.yaml` and Rector's parallel workers get OOM-killed (exit 137), and a worktree's `pwa_node_modules` volume is empty so `make qa-pwa` reports `eslint: not found`. Every leg must be green individually — Rector especially, because a skipped autofix fails CI in dry-run mode and costs a round-trip (observed Sprint 34.5: #580 PHP 8.4 `new` without parentheses, #585 `NewlineAfterStatementRector`). Commit autofixes (PHP-CS-Fixer, Rector, Prettier). PHPStan / TypeScript / ESLint errors must be fixed by hand. **Do NOT run `make test` / `make install`.**
    - Report the per-leg output verbatim in your final message. Do not write "make qa passes" — it cannot; say which legs you ran and what they printed.
 6. Commit your changes using Conventional Commits format (final commit must include any QA autofixes — never leave a dirty worktree)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,16 @@ Two traps in that command:
 
 `make test-e2e` needs the PWA built and served on `https://localhost`; a worktree's changes are not in the main stack's bundle. **CI is the real gate for Playwright** — say so plainly rather than implying local coverage you did not have. Since the pre-commit hook replays `make qa`, commit with `git -c core.hooksPath=/dev/null commit` once the legs are individually green.
 
+### Test & CI gotchas that pass locally but fail in CI
+
+These bit Sprint 51 — each was green on a dev machine and red in CI, or vice-versa. Check them before writing the test, not after the round-trip.
+
+- **Timezone-fragile PHPUnit.** CI runs PHP in **`Europe/Paris`**; a throwaway local container defaults to **UTC**. Any test asserting a formatted offset or RFC 3339 / ATOM string (e.g. `closesAt?->format(DateTimeInterface::ATOM)`) must build its `DateTimeImmutable` with an **explicit `new \DateTimeZone('UTC')`**, or pass `-e TZ=Europe/Paris` + `php -d date.timezone=Europe/Paris` when reproducing locally. A hard-coded `+00:00` expectation is green in UTC and red in CI. `closesAt`/interval times inherit the timezone of the `$now` you pass in — pin `$now`.
+- **API error-contract codes are not what you'd guess.** Object-level authorization denials are **masked as 404, never 403** (ADR-038) — a non-owner hitting an item operation gets 404, so a test expecting 403 is wrong. A request body carrying an **unknown backed-enum value fails denormalization and surfaces as 422** (a validation violation), **not 400** — API Platform 4.3 collects the type error as a constraint violation. Assert 404 / 422 accordingly, and document 422 (not 400) in the operation's `openapi` responses.
+- **French Gherkin needs a language header.** A `.fr.feature` using `Fonctionnalité:` / `Contexte:` / `Scénario:` / `Étant donné` **must** start with `# language: fr`; without it `bddgen` parses in English mode and dies at the first `Scénario:`. Validate with `npx bddgen --config playwright.bdd.config.ts` before pushing — it parses every feature and exits non-zero on a syntax error, which no unit leg catches.
+- **Simulating a geolocation failure in Playwright.** `context().clearPermissions()` does **not** make `navigator.geolocation.getCurrentPosition()` reject in headless Chromium — the previously `setGeolocation()`'d fix is still returned, so `geo.error` never fires. To exercise a denial/timeout path, stub it in the page: `page.evaluate(() => { navigator.geolocation.getCurrentPosition = (_ok, err) => err?.({ code: 1, ... } as GeolocationPositionError); })` (toggle via a `window` flag to restore success for a retry assertion).
+- **A stacked PR whose base you retarget may not re-trigger CI.** After a squash-merge of a parent, retargeting the child's base to `main` **and** force-pushing sometimes fires no workflow run at all (the head shows "no checks reported"). **Close and reopen the PR** to re-trigger — no noise commit needed.
+
 ### `make` swallows `--flags`
 
 A target that forwards `$(ARGS)` cannot receive an option: `make` claims anything starting


### PR DESCRIPTION
Rétrospective du sprint 51 (in-ride sans IA). Ajoute les 4 gotchas qui ont chacun coûté un aller-retour CI (verts en local, rouges en CI) à `CLAUDE.md`, et durcit le prompt d'agent de `/sprint` pour les deux plus rattrapables au moment d'écrire le code.

## `CLAUDE.md` — nouvelle sous-section « Test & CI gotchas that pass locally but fail in CI »
1. **PHPUnit sensible au fuseau** — la CI tourne en `Europe/Paris`, un conteneur local en UTC ; toute assertion d'offset/ATOM doit fixer son `DateTimeImmutable` en UTC explicite (sinon `+00:00` vert en local, rouge en CI). Cas réel : `NearbyPoiFinderTest::flagsAVenueClosingWithinThirtyMinutes`.
2. **Codes du contrat d'erreur** — refus authz objet = **404 (pas 403)** (ADR-038) ; valeur d'enum inconnue = **422 (pas 400)** (dénormalisation → violation de validation). Cas réel : `NearbyPoiSearchTest` de #934.
3. **Gherkin FR** — un `.fr.feature` a besoin de `# language: fr` (+ `Fonctionnalité:`), sinon `bddgen` casse sur `Scénario:` ; valider avec `npx bddgen`. Cas réel : `in-ride.fr.feature` de #935.
4. **Échec géoloc Playwright** — `clearPermissions()` ne fait pas rejeter `getCurrentPosition()` en headless ; stubber la méthode. Cas réel : `in-ride-search.spec.ts`.
5. **PR stackée re-ciblée + force-push** — ne re-déclenche pas toujours la CI ; close/reopen la PR. Cas réel : #968 après retarget `feature/934`→`main`.

## `/sprint` (SKILL.md) — prompt d'agent
Garde en amont sur les codes d'erreur (404/422) et l'en-tête `# language: fr`, plus le rappel fuseau UTC — pour que les agents écrivent directement le bon test au lieu de le corriger en review.

## Portée
- Aucune modification de `settings.json` → **aucune application manuelle requise**.
- `SKILL.md` sous `.claude/**` n'est pas dans le périmètre markdownlint de la CI (`!.claude/**`) ; `CLAUDE.md` (racine, linté) est vert.
- Périmètre volontairement limité aux gotchas **1 à 4** (+ #5 close/reopen, inclus dans la même sous-section) validés en revue ; les points 6-7 (npm-audit live, vérif overlap via `gh api files`) laissés de côté à ta demande.


<!-- claude-review-start -->
## Claude Review

**Summary:** 0 findings (0 critical, 0 warning, 0 nit). Docs-only change — no source code touched.

**Review checklist:**
- [x] Code respects the project architecture (N/A — docs only)
- [x] SOLID principles and Law of Demeter followed (N/A — docs only)
- [x] Design patterns used where appropriate (N/A — docs only)
- [x] Tests cover new/changed cases (N/A — no behavior change)
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Verification performed:** cross-checked every factual claim added to `CLAUDE.md` against the actual codebase — ADR-038 (404 vs 403), `NearbyPoiSearchTest` (422 vs 400), `NearbyPoiFinderTest::flagsAVenueClosingWithinThirtyMinutes` (explicit UTC), `in-ride.fr.feature` (`# language: fr` header), `in-ride-search.spec.ts` (`clearPermissions()` / `getCurrentPosition()` stub), and the `npx bddgen --config playwright.bdd.config.ts` invocation (matches `ci.yml`). All claims are accurate. PR title follows Conventional Commits.

**Commit reviewed:** `6a5c1e894597c3ad5d02b94263e18acd5bc01ca3`
<!-- claude-review-end -->
