### PR TITLE
chore(db)!: drop the orphaned trip_chat_message table (#937)

### DIFF
--- a/TRACKING.md
+++ b/TRACKING.md
@@ -1605,7 +1605,7 @@ Le sprint porte aussi le ticket de suivi demandé par #927 et par la PR #928 : l
 >
 > **Suppression avant construction.** L'ordre « ajouter puis retirer » est infaisable : les issues de construction changent la signature de `InRidePoiRepository::findNearby()`, la forme de `PoiSuggestion` et l'API publique de `OpeningHoursParser`, que `InRideAssistant` consomme encore. Et l'argument « rester déployable » ne tient pas : la surface était déjà masquée en prod et en recette (ADR-046, défaut off). #929 laisse donc **douze briques transitoirement orphelines**, listées dans son corps, qui retrouvent un appelant en #935.
 >
-> **#937 est hors sprint** : ADR-032 interdit une migration destructive dans la release qui cesse d'écrire. Le `DROP TABLE trip_chat_message` attend la release suivant celle de #929.
+> **#937 était hors sprint** : ADR-032 interdit une migration destructive dans la release qui cesse d'écrire, donc le `DROP TABLE trip_chat_message` devait attendre la release suivant celle de #929. **Révisé après la clôture** : aucun tag `v*` n'ayant jamais été coupé (pas de release shippée, pas de base de prod), la fenêtre de grâce n'a rien à protéger ; #937 est donc livrée en pré-lancement (PR #971) au titre d'une **exception ponctuelle enregistrée dans l'addendum ADR-032**. La règle en deux temps redevient inconditionnelle au premier tag.
 >
 > **Prérequis levé :** PR #928 mergée (`46c048a8`), elle touchait `schema.d.ts`, `messages/*.json`, `tier1.lua` et `TripRequest`.
 
@@ -1620,7 +1620,7 @@ Le sprint porte aussi le ticket de suivi demandé par #927 et par la PR #928 : l
 | 7 | [#935](https://github.com/vincentchalamon/bike-trip-planner/issues/935) | feat(pwa): panneau « en route » à questions prédéfinies | XL | 🚧 En cours | [#968](https://github.com/vincentchalamon/bike-trip-planner/pull/968) `feature/935` | #934 |
 | 8 | [#936](https://github.com/vincentchalamon/bike-trip-planner/issues/936) | docs(adr): add adr-048 in-ride assistance without ai | M | 🚧 En cours | [#966](https://github.com/vincentchalamon/bike-trip-planner/pull/966) `feature/936` | #934 |
 | 9 | [#938](https://github.com/vincentchalamon/bike-trip-planner/issues/938) | test(recette): recette sprint 51 - in-ride sans IA sur téléphone | M | ⏳ Manuelle | - | #935, #936 |
-| — | [#937](https://github.com/vincentchalamon/bike-trip-planner/issues/937) | chore(db)!: supprimer la table trip_chat_message | S | ⏳ Release suivante | - | #929 **livrée en prod** |
+| — | [#937](https://github.com/vincentchalamon/bike-trip-planner/issues/937) | chore(db)!: supprimer la table trip_chat_message | S | 🚧 En cours | [#971](https://github.com/vincentchalamon/bike-trip-planner/pull/971) `feature/937` | #929 (exception pré-lancement, addendum ADR-032) |
 
 Vagues `/sprint` : {#929} seule → {#930, #931, #932} → {#933} → {#934} seule → {#935, #936} → {#938} manuelle → release suivante {#937}.
 
@@ -1675,6 +1675,6 @@ Fichiers à **écrivain unique** dans le sprint (pas des recoupements, mais des 
   - [ ] `/s/{shortCode}` (vue partagée anonyme) n'affiche pas la bulle.
   - [ ] Avec une clé configurée : génération depuis un brief, chat de cadrage, analyse complète, briefing par étape et synthèse de voyage fonctionnent toujours.
   - [ ] Les 12 orphelins transitoires de #929 ont tous retrouvé un appelant.
-  - [ ] La table `trip_chat_message` est encore présente en base à l'issue du sprint — sa suppression est #937, release suivante.
+  - [x] La table `trip_chat_message` était encore présente à la clôture du sprint ; sa suppression (#937, PR #971) a finalement été livrée en pré-lancement plutôt qu'à la release suivante — exception ponctuelle enregistrée dans l'addendum ADR-032 (aucun tag `v*` coupé, aucune donnée de prod à protéger).
 
 </details>

--- a/api/migrations/Version20260807120000.php
+++ b/api/migrations/Version20260807120000.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Drops the orphaned `trip_chat_message` table (#937, sprint 51).
+ *
+ * The entity, repository, API resource and read path were removed in #929; the
+ * table was kept behind per ADR-032's two-step destructive-migration pattern
+ * (one release stops writing, the next drops). No `v*` tag has ever shipped, so
+ * no release exists to roll back to and the production database has never been
+ * created: the grace window has no data to protect. Under the pre-launch
+ * exception recorded in ADR-032, the drop happens in the same pre-launch window
+ * that stopped writing (#929). The two-release rule resumes at the first tag.
+ *
+ * The columns/indexes recreated by down() come from Version20260519163100
+ * (base table, #458) and Version20260520120000 (in-ride payload columns, #465).
+ */
+final class Version20260807120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Drop the orphaned trip_chat_message table (#937)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE trip_chat_message');
+    }
+
+    /**
+     * Recreates the table structure only. The chat history it once held is NOT
+     * recoverable — down() restores the empty schema so a rollback does not
+     * fail, never the data.
+     */
+    public function down(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE trip_chat_message (
+                id UUID NOT NULL,
+                trip_id UUID NOT NULL,
+                user_id UUID NOT NULL,
+                role VARCHAR(16) NOT NULL,
+                content TEXT NOT NULL,
+                action VARCHAR(32) DEFAULT NULL,
+                created_at TIMESTAMP(6) WITHOUT TIME ZONE NOT NULL,
+                geo_lat DOUBLE PRECISION DEFAULT NULL,
+                geo_lon DOUBLE PRECISION DEFAULT NULL,
+                pois JSONB DEFAULT NULL,
+                PRIMARY KEY(id)
+            )
+            SQL);
+
+        $this->addSql('CREATE INDEX idx_trip_chat_trip_user_created ON trip_chat_message (trip_id, user_id, created_at)');
+        $this->addSql('CREATE INDEX IDX_trip_chat_message_user ON trip_chat_message (user_id)');
+
+        $this->addSql(<<<'SQL'
+            ALTER TABLE trip_chat_message
+                ADD CONSTRAINT FK_trip_chat_message_trip FOREIGN KEY (trip_id)
+                REFERENCES trip (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE
+            SQL);
+
+        $this->addSql(<<<'SQL'
+            ALTER TABLE trip_chat_message
+                ADD CONSTRAINT FK_trip_chat_message_user FOREIGN KEY (user_id)
+                REFERENCES "user" (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE
+            SQL);
+    }
+}

--- a/api/src/State/Account/AccountDeleteProcessor.php
+++ b/api/src/State/Account/AccountDeleteProcessor.php
@@ -56,8 +56,8 @@ final readonly class AccountDeleteProcessor implements ProcessorInterface
         $email = $user->getEmail();
 
         $this->entityManager->wrapInTransaction(function () use ($user, $email): void {
-            // Purge trips (cascades to stages, chat messages and shares via FK
-            // ON DELETE CASCADE) which also removes the per-trip preferences.
+            // Purge trips (cascades to stages and shares via FK ON DELETE
+            // CASCADE) which also removes the per-trip preferences.
             $this->entityManager->createQueryBuilder()
                 ->delete(TripRequest::class, 't')
                 ->where('t.user = :user')

--- a/docs/adr/adr-032-migrations-and-rollback-strategy.md
+++ b/docs/adr/adr-032-migrations-and-rollback-strategy.md
@@ -78,3 +78,13 @@ A detailed playbook lives in `docs/runbooks/release-rollback.md` (created as par
 ### Neutral
 
 - Workers (`messenger:consume`) share the same image and the same `entrypoint.sh`; they skip migrations because `compose.yaml` sets `MIGRATIONS_ON_BOOT=false` on the worker service. Only the `php` service runs them, and workers wait for it to be healthy via `depends_on`.
+
+## Addendum — pre-launch exception (2026-08-07, #937)
+
+The two-release destructive rule protects a **rollback of a shipped release**: it guarantees that reverting release N+2 to N+1 never needs data restored. That protection only has an object once a release has actually been cut.
+
+**No `v*` tag has ever been pushed**, so `deploy.yml` has never shipped, the production database has never been created, and no release exists to roll back to. In this pre-launch window the grace period has nothing to protect: there is no prior release, and the table holds no production data.
+
+On that basis, `DROP TABLE trip_chat_message` (#937) is deployed in the **same** pre-launch window that stopped writing to it (#929), rather than one release later. This is a **one-time, pre-launch-only exception**, not a change to the policy.
+
+**The two-release rule applies unconditionally again the moment the first `v*` tag is cut** — from the first shipped release onward, every destructive migration must follow the additive → read-switch → destructive sequence above. Do not cite this addendum to justify a same-release `DROP` post-launch.


### PR DESCRIPTION
Ferme #937 — seconde moitié du nettoyage in-ride : la table `trip_chat_message`, orpheline depuis #929 (entité, dépôt, ressource API et endpoint supprimés, table conservée).

## Dérogation ADR-032 (corrigée + enregistrée)

**Correction de la justification initiale.** Il est inexact de dire « pas de prod ni de release » : ADR-032 et ADR-037 décrivent bien une prod (Oracle Cloud + Coolify) et une release sur tag (`deploy.yml`). Le vrai motif est **pré-lancement** : **aucun tag `v*` n'a jamais été coupé**, donc aucune release n'a shippé, la base de prod n'a jamais été créée, et la fenêtre de grâce en deux temps n'a **aucune donnée ni release antérieure à protéger**. Le `DROP` est donc livré dans la même fenêtre pré-lancement que #929.

Cette décision est désormais **enregistrée**, plus laissée en one-off :
- **Addendum à ADR-032** (« pre-launch exception, 2026-08-07, #937 ») : exception ponctuelle, la règle en deux temps redevient inconditionnelle au premier tag.
- **TRACKING.md** mis à jour aux 3 endroits qui planifiaient « release suivante » (bandeau #937, ligne du tableau, checklist de clôture).

## Changements
- **Nouvelle migration** `Version20260807120000` : `up()` = `DROP TABLE trip_chat_message` ; `down()` recrée la structure vide (colonnes de `Version20260519163100` + `geo_lat`/`geo_lon`/`pois` de `Version20260520120000`, 2 index, 2 FK `ON DELETE CASCADE`). Docblock : `down()` restaure le schéma, **pas les données**. Pas de `#[\Override]` (aligné sur les migrations existantes ; `migrations/` hors scope Rector).
- `AccountDeleteProcessor` : commentaire de cascade nettoyé (plus de « chat messages »).
- `docs/adr/adr-032-*.md` + `TRACKING.md` : voir ci-dessus.

## QA (jambe par jambe)
- PHP-CS-Fixer : `Fixed 0`. Rector (`--dry-run`, src) : `[OK]`. PHPStan level 9 : `[OK] No errors`. Markdownlint (ADR-032, TRACKING) : `0 error(s)`.
- PHPUnit `AccountDeleteTest` + `TripDeleteTest` : `OK (13 tests, 26 assertions)`.
- `grep trip_chat_message api` = seulement les 3 migrations. Exécution up/down réelle arbitrée par le job migrations de la CI.

## Auto-critique
- Migration `!` destructive assumée : justifiée par le pré-lancement + enregistrée dans ADR-032, pas seulement dans ce corps de PR.

Closes #937.

<!-- claude-review-start -->
## Claude Review

**Summary:** No new findings. The previous review's concern — the ADR-032 deviation rationale not matching the project's own ADR-032/ADR-037 text, and `TRACKING.md` not being reconciled — is fully addressed by this push: ADR-032 now has an explicit pre-launch-exception addendum, and all three `TRACKING.md` spots that planned "release suivante" are updated. The migration's `down()` was verified column-by-column, index-by-index, and FK-by-FK against `Version20260519163100` + `Version20260520120000` and matches exactly. No orphaned `trip_chat_message`/`TripChatMessage` references remain outside the three migration files and historical docs.

**Resolved threads:** Resolved 1 previously open thread that was addressed (ADR-032/TRACKING.md reconciliation).

### Review checklist
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### Findings by severity
- Critical: 0
- Warning: 0

**Inline comments:** No inline comments.

**Commit reviewed:** 84fa32508ab4a93b237aa21ac366649e627e55d7
<!-- claude-review-end -->
