### PR TITLE
fix(provisioner): read accommodations DDL from the baseline schema

### DIFF
--- a/provisioner/tests/DataTourismeImporterTest.php
+++ b/provisioner/tests/DataTourismeImporterTest.php
@@ -641,12 +641,18 @@ final class DataTourismeImporterTest extends TestCase
      * The migrations live in the API package, which is not mounted in the
      * provisioner container; CI runs this suite from the repository root, where it
      * is the real gate.
+     *
+     * Since the sprint-51 baseline reset (#972) the `CREATE TABLE` DDL lives in
+     * `migrations/schema/baseline_schema.sql`, a `pg_dump --schema-only`; any
+     * column added afterwards ships as an `ALTER` migration whose `COLUMNS`
+     * constant this test still reads back.
      */
     #[Test]
     public function theStagingDdlIsASubsetOfTheAccommodationMigrations(): void
     {
         $migrationsDir = __DIR__.'/../../api/migrations';
-        if (!is_dir($migrationsDir)) {
+        $baselineSchema = $migrationsDir.'/schema/baseline_schema.sql';
+        if (!is_file($baselineSchema)) {
             self::markTestSkipped('api/migrations is not reachable from here (provisioner container mounts ./provisioner alone)');
         }
 
@@ -656,12 +662,12 @@ final class DataTourismeImporterTest extends TestCase
         $staging = $this->columnNames($stagingDdl['accommodations']);
 
         $migrated = [];
+        if (1 === preg_match('/CREATE TABLE tourism\.accommodations \((.*?)\n\);/s', (string) file_get_contents($baselineSchema), $matches)) {
+            $migrated = array_merge($migrated, $this->columnNames($matches[1]));
+        }
+
         foreach (glob($migrationsDir.'/Version*.php') ?: [] as $file) {
             $source = (string) file_get_contents($file);
-
-            if (1 === preg_match('/CREATE TABLE IF NOT EXISTS tourism\.accommodations \((.*?)\n\s*\)/s', $source, $matches)) {
-                $migrated = array_merge($migrated, $this->columnNames($matches[1]));
-            }
 
             // Two shapes of ALTER: one naming the table, one applying the same columns to
             // every reference table through sprintf. Both must declare what they add in a


### PR DESCRIPTION
## Problème

`Provisioner\Tests\DataTourismeImporterTest::theStagingDdlIsASubsetOfTheAccommodationMigrations` plante en CI sur `main` ([run](https://github.com/vincentchalamon/bike-trip-planner/actions/runs/31176005729/job/93383131752)) :

```
the staging DDL carries columns the live tourism.accommodations does not have, which aborts the promotion
Failed asserting that two arrays are identical.
```

## Cause

Le baseline reset du sprint 51 (#972) a collapsé les 43 migrations et déplacé la DDL `CREATE TABLE tourism.accommodations` hors des `Version*.php` vers `migrations/schema/baseline_schema.sql` (dump `pg_dump --schema-only`). Le test ne scannait que les `Version*.php` avec la regex `CREATE TABLE IF NOT EXISTS tourism.accommodations`, qui ne matche plus rien. `$migrated` restait donc vide et chaque colonne stagée apparaissait comme absente du live.

## Fix

Lire le `CREATE TABLE` depuis `baseline_schema.sql`. Le scan des `Version*.php` est conservé pour le contrat `COLUMNS` des futures migrations `ALTER`, afin de continuer à détecter les ajouts de colonnes.

## Vérification

Depuis la racine du repo (le container provisioner ne monte que `./provisioner`) :

- `vendor/bin/phpunit` (provisioner) : `Tests: 201, Assertions: 874, Skipped: 6` -> **OK** (0 échec)
- PHPStan : `[OK] No errors`
- Rector : `[OK] Rector is done!`
- PHP-CS-Fixer : `Found 0 of 1 files that can be fixed`

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 findings (0 critical, 0 warning, 0 nitpick suppressed by policy).

**Verification performed:** Extracted the new regex and re-ran it standalone against the real `api/migrations/schema/baseline_schema.sql` — it correctly captures the 16-column `accommodations` DDL (constraint line excluded, as intended) and the resulting `array_diff` against `STAGING_DDL` reproduces exactly the expected `['last_seen_at', 'zone']` live-only set, confirming the fix resolves the CI failure described in the PR.

### Review checklist

- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases (this PR *is* the test fix; verified against the real baseline file)
- [x] Documentation is up to date (docblock updated to explain the new DDL source)
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

**Reviewed commit:** f5c9f8fa621f7173478b2c6be7b861e7211d7ff2
<!-- claude-review-end -->
