### PR TITLE
docs: document `make <target> -- --flag` passthrough for provisioning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,17 +110,25 @@ These bit Sprint 51 — each was green on a dev machine and red in CI, or vice-v
 - **Simulating a geolocation failure in Playwright.** `context().clearPermissions()` does **not** make `navigator.geolocation.getCurrentPosition()` reject in headless Chromium — the previously `setGeolocation()`'d fix is still returned, so `geo.error` never fires. To exercise a denial/timeout path, stub it in the page: `page.evaluate(() => { navigator.geolocation.getCurrentPosition = (_ok, err) => err?.({ code: 1, ... } as GeolocationPositionError); })` (toggle via a `window` flag to restore success for a retry assertion).
 - **A stacked PR whose base you retarget may not re-trigger CI.** After a squash-merge of a parent, retargeting the child's base to `main` **and** force-pushing sometimes fires no workflow run at all (the head shows "no checks reported"). **Close and reopen the PR** to re-trigger — no noise commit needed.
 
-### `make` swallows `--flags`
+### Passing `--flags` through a `make` target
 
-A target that forwards `$(ARGS)` cannot receive an option: `make` claims anything starting
-with `--` for itself and dies before the recipe runs.
+A bare option is claimed by `make` itself and dies before the recipe runs:
 
 ```bash
 $ make provision corse --allow-unrouted-zone
 make : l'option « --allow-unrouted-zone » n'a pas été reconnue
 ```
 
-Pass the flag to the container directly instead, keeping the target for the common case:
+Use a `--` separator: it stops `make`'s own option parsing, and the `$(ARGS)` targets
+strip the `--` (`filter-out --`, see the top of the Makefile) so the flag reaches the
+container intact. This is the intended mechanism for every `ARGS_TARGETS` entry (e.g.
+`make phpunit -- --filter=Foo`):
+
+```bash
+make provision corse -- --allow-unrouted-zone
+```
+
+Calling the container directly still works if you prefer:
 
 ```bash
 docker compose --profile provisioning run --rm provisioner corse --allow-unrouted-zone

--- a/docs/runbooks/zone-opening.md
+++ b/docs/runbooks/zone-opening.md
@@ -194,12 +194,15 @@ observed empty perimeter and refuses. Building the national graph to work on acc
 is hours and ~30 GB, so there is an explicit way out:
 
 ```bash
-docker compose --profile provisioning run --rm provisioner corse --allow-unrouted-zone
+make provision corse -- --allow-unrouted-zone
 ```
 
-Not `make provision corse --allow-unrouted-zone`: `make` claims the flag as one of its own
-options and fails with `l'option « --allow-unrouted-zone » n'a pas été reconnue` before the
-target ever runs. Call the container directly for this one.
+The `--` separator is required: a bare `make provision corse --allow-unrouted-zone` lets
+`make` claim the flag as one of its own options and fails with
+`l'option « --allow-unrouted-zone » n'a pas été reconnue`. With `--`, `make` stops parsing
+options and the target forwards the flag to the container. Calling the container directly
+(`docker compose --profile provisioning run --rm provisioner corse --allow-unrouted-zone`)
+works too.
 
 Trips in that zone will not be routable — everything else works. **Do not** improvise the
 alternative of dropping a placeholder extract into the routing volume:


### PR DESCRIPTION
## Contexte

La doc affirmait qu'un flag comme `--allow-unrouted-zone` ne peut pas passer par une cible `make` et qu'il faut appeler `docker compose` en direct. C'est faux : le séparateur `--` arrête le parsing d'options de `make`, et les cibles `$(ARGS)` retirent le `--` (`filter-out --`, en tête du Makefile), donc le flag arrive intact au conteneur. C'est le mécanisme prévu par design (déjà utilisé pour `make phpunit -- --filter=Foo`).

```bash
make provision corse -- --allow-unrouted-zone
```

Vérifié en dry-run :

```
$ make -n provision nord-pas-de-calais -- --allow-unrouted-zone
docker compose --profile provisioning run --rm provisioner nord-pas-de-calais --allow-unrouted-zone
```

## Changements

- `CLAUDE.md` — section « `make` swallows `--flags` » renommée et corrigée : `make provision <zone> -- --flag` documenté comme la voie normale, appel direct au conteneur en fallback.
- `docs/runbooks/zone-opening.md` — même correction dans la procédure d'ouverture de zone (« Skip the routing graph »).

## Vérification

`markdownlint-cli2` : 0 erreur sur les deux fichiers.

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 findings (0 critical, 0 warning). Docs-only change; re-verified the underlying mechanism independently (`make -n provision nord-pas-de-calais -- --allow-unrouted-zone` against the current Makefile's `ARGS_TARGETS` / `filter-out --` logic) and it matches exactly what the PR documents. No prior review threads or bot reviews existed to reconcile.

**Review checklist:**
- [x] Code respects the project architecture (N/A — docs only)
- [x] SOLID principles and Law of Demeter followed (N/A — docs only)
- [x] Design patterns used where appropriate (N/A — docs only)
- [x] Tests cover new/changed cases (N/A — docs only; author ran `markdownlint-cli2`)
- [x] Documentation is up to date and technically accurate (verified against Makefile behavior)
- [x] Dependent tickets accounted for

**Commit reviewed:** `50c39adaf42bc61c646a8b4e99e403310360e1e7`
<!-- claude-review-end -->