### PR TITLE
feat(events): rendre les événements multi-source + filtrage pertinence + cap

### DIFF
--- a/api/migrations/Version20260810120000.php
+++ b/api/migrations/Version20260810120000.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Adds `source` to tourism.events (issue #975).
+ *
+ * Events were the last mono-source reference layer: the runtime hard-coded
+ * `source: 'datatourisme'` because the column did not exist. The multi-source
+ * scan (EventSourceRegistry, OpenAgenda foundation, ADR-051) reads the source
+ * from the row instead, so the column has to exist and carry the origin per row.
+ *
+ * The default 'datatourisme' backfills the rows already imported by the flux and
+ * lets the provisioner promote a batch without spelling the source out on every
+ * COPY line where it is not written explicitly.
+ */
+final class Version20260810120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add source column to tourism.events (multi-source events, ADR-051)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE tourism.events ADD COLUMN source text NOT NULL DEFAULT 'datatourisme'");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE tourism.events DROP COLUMN source');
+    }
+}

--- a/api/src/EventSource/DataTourismeEventSource.php
+++ b/api/src/EventSource/DataTourismeEventSource.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventSource;
+
+use App\Tourism\EventRepositoryInterface;
+
+/**
+ * DataTourisme contribution to the events scan: the tourism.events layer read
+ * from the local-first PostGIS schema (ADR-040). The repository already filters
+ * out linkless events, orders by distance and stamps the `source` column, so this
+ * only adapts it to the tagged-iterator {@see EventSourceRegistry}. A second
+ * source (OpenAgenda, #984) joins by implementing the same interface.
+ */
+final readonly class DataTourismeEventSource implements EventSourceInterface
+{
+    public function __construct(private EventRepositoryInterface $eventRepository)
+    {
+    }
+
+    public function findActiveNear(float $lat, float $lon, int $radiusMeters, string $date): array
+    {
+        return $this->eventRepository->findActiveNear($lat, $lon, $radiusMeters, $date);
+    }
+}

--- a/api/src/EventSource/EventSourceInterface.php
+++ b/api/src/EventSource/EventSourceInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventSource;
+
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+#[AutoconfigureTag('app.event_source')]
+interface EventSourceInterface
+{
+    /**
+     * Dated events active on $date (start_date <= $date <= end_date) within
+     * $radiusMeters of the point, each carrying its origin `source`.
+     *
+     * Only events with a usable link are returned: an event a rider cannot open
+     * is noise. `name` may be null (the row shape is shared with the deduplicator,
+     * which never merges an anonymous entry); the `category` is the app-normalised
+     * event vocabulary, the same across every source so relevance can be decided
+     * once in {@see EventSourceRegistry}.
+     *
+     * @param string $date Y-m-d
+     *
+     * @return list<array{name: ?string, category: string, lat: float, lon: float, startDate: string, endDate: string, url: string, description: ?string, priceMin: ?float, source: string}>
+     */
+    public function findActiveNear(float $lat, float $lon, int $radiusMeters, string $date): array;
+}

--- a/api/src/EventSource/EventSourceRegistry.php
+++ b/api/src/EventSource/EventSourceRegistry.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventSource;
+
+use App\Geo\GeoDistanceInterface;
+use App\Geo\NearbyNameDeduplicator;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
+
+/**
+ * Reads every event source active on a stage date and returns a relevant,
+ * deduplicated, distance-ranked and capped list for the stage end point (ADR-051).
+ *
+ * The cross-source pass mirrors {@see \App\Poi\PoiSourceRegistry}: merge every
+ * source, collapse the same event reported twice (name + proximity via
+ * {@see NearbyNameDeduplicator}, the curated DataTourisme entry winning on a tie),
+ * then apply the rules that must hold identically whatever the origin:
+ *
+ * - **Relevance.** Only the event categories a bikepacker plans a detour around are
+ *   kept ({@see RELEVANT_CATEGORIES}); the generic `event` fallback and any
+ *   young-audience / children category a source normalises outside this set are
+ *   dropped. Categories are pre-normalised to the app vocabulary by each source,
+ *   so this single whitelist is the shared audience filter across sources.
+ * - **A link is mandatory.** Enforced in SQL too (EventRepository), re-checked here
+ *   so a source that forgets cannot leak a linkless event into the stage.
+ * - **Ranked by distance to the end point, capped.** A rider cares about what is
+ *   near where the day ends, not about the earliest start date, and a stage shows a
+ *   handful of events, not a hundred.
+ */
+readonly class EventSourceRegistry
+{
+    /**
+     * App-normalised event categories worth surfacing. Matches the DataTourisme
+     * mapper's EVENT_CATEGORY targets; a new source maps its own taxonomy onto the
+     * same vocabulary.
+     */
+    public const array RELEVANT_CATEGORIES = ['festival', 'concert', 'exhibition', 'sports', 'fair', 'show'];
+
+    private const int CAP = 20;
+
+    /** @var list<EventSourceInterface> */
+    private array $sources;
+
+    /**
+     * @param iterable<EventSourceInterface> $sources
+     */
+    public function __construct(
+        #[AutowireIterator('app.event_source')]
+        iterable $sources,
+        private NearbyNameDeduplicator $deduplicator,
+        private GeoDistanceInterface $haversine,
+    ) {
+        $this->sources = iterator_to_array($sources, false);
+    }
+
+    /**
+     * @param string $date Y-m-d
+     *
+     * @return list<array{name: ?string, category: string, lat: float, lon: float, startDate: string, endDate: string, url: string, description: ?string, priceMin: ?float, source: string, distanceToEndPoint: float}>
+     */
+    public function findAllActiveNear(float $lat, float $lon, int $radiusMeters, string $date): array
+    {
+        $all = [];
+        foreach ($this->sources as $source) {
+            foreach ($source->findActiveNear($lat, $lon, $radiusMeters, $date) as $event) {
+                if ('' === $event['url'] || !\in_array($event['category'], self::RELEVANT_CATEGORIES, true)) {
+                    continue;
+                }
+
+                $all[] = $event;
+            }
+        }
+
+        /** @var list<array{name: ?string, category: string, lat: float, lon: float, startDate: string, endDate: string, url: string, description: ?string, priceMin: ?float, source: string}> $deduped */
+        $deduped = $this->deduplicator->dedupe($all);
+
+        $ranked = array_map(
+            fn (array $event): array => $event + [
+                'distanceToEndPoint' => $this->haversine->inMeters($event['lat'], $event['lon'], $lat, $lon),
+            ],
+            $deduped,
+        );
+
+        usort($ranked, static fn (array $a, array $b): int => $a['distanceToEndPoint'] <=> $b['distanceToEndPoint']);
+
+        return \array_slice($ranked, 0, self::CAP);
+    }
+}

--- a/api/src/MessageHandler/ScanEventsHandler.php
+++ b/api/src/MessageHandler/ScanEventsHandler.php
@@ -9,20 +9,21 @@ use App\ApiResource\Stage;
 use App\ComputationTracker\ComputationTrackerInterface;
 use App\ComputationTracker\TripGenerationTrackerInterface;
 use App\Enum\ComputationName;
-use App\Geo\GeoDistanceInterface;
+use App\EventSource\EventSourceRegistry;
 use App\Mercure\MercureEventType;
 use App\Mercure\TripUpdatePublisherInterface;
 use App\Message\ScanEvents;
 use App\Repository\TripRequestRepositoryInterface;
-use App\Tourism\EventRepositoryInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 /**
- * Attaches dated events to each stage: DataTourisme events read from the
- * local-first `tourism` schema (ADR-040, no longer the runtime REST API),
- * filtered to the stage's own date and a radius around its end point.
+ * Attaches dated events to each stage: multi-source events (DataTourisme today,
+ * OpenAgenda next — ADR-051) read from the local-first `tourism` schema (ADR-040,
+ * no longer the runtime REST API), filtered to the stage's own date and a radius
+ * around its end point, then deduplicated, relevance-filtered and distance-ranked
+ * by {@see EventSourceRegistry}.
  */
 #[AsMessageHandler]
 final readonly class ScanEventsHandler extends AbstractTripMessageHandler
@@ -35,8 +36,7 @@ final readonly class ScanEventsHandler extends AbstractTripMessageHandler
         TripGenerationTrackerInterface $generationTracker,
         LoggerInterface $logger,
         private TripRequestRepositoryInterface $tripStateManager,
-        private EventRepositoryInterface $eventRepository,
-        private GeoDistanceInterface $haversine,
+        private EventSourceRegistry $eventSources,
         MessageBusInterface $messageBus,
     ) {
         parent::__construct($computationTracker, $publisher, $generationTracker, $logger, $tripStateManager, $messageBus);
@@ -77,8 +77,6 @@ final readonly class ScanEventsHandler extends AbstractTripMessageHandler
                     continue;
                 }
 
-                usort($events, static fn (Event $a, Event $b): int => $a->startDate <=> $b->startDate);
-
                 foreach ($events as $event) {
                     $stage->addEvent($event);
                 }
@@ -104,7 +102,7 @@ final readonly class ScanEventsHandler extends AbstractTripMessageHandler
     {
         $events = [];
 
-        foreach ($this->eventRepository->findActiveNear(
+        foreach ($this->eventSources->findAllActiveNear(
             $stage->endPoint->lat,
             $stage->endPoint->lon,
             self::EVENT_RADIUS_METERS,
@@ -131,8 +129,8 @@ final readonly class ScanEventsHandler extends AbstractTripMessageHandler
                 url: $row['url'],
                 description: $row['description'],
                 priceMin: $row['priceMin'],
-                distanceToEndPoint: $this->haversine->inMeters($row['lat'], $row['lon'], $stage->endPoint->lat, $stage->endPoint->lon),
-                source: 'datatourisme',
+                distanceToEndPoint: $row['distanceToEndPoint'],
+                source: $row['source'],
             );
         }
 

--- a/api/src/Tourism/EventRepository.php
+++ b/api/src/Tourism/EventRepository.php
@@ -10,6 +10,11 @@ use Doctrine\DBAL\Connection;
  * Reads DataTourisme events from the local-first `tourism` schema (ADR-040),
  * replacing the runtime DataTourisme REST API. Events are dated, so the query
  * filters on the stage date as well as the spatial radius around its end point.
+ *
+ * Only linkable events are returned (an event a rider cannot open is noise), the
+ * result is ranked by distance to the end point (relevance, not start date) and
+ * capped: pertinence and the cross-source cap live in {@see \App\EventSource\EventSourceRegistry},
+ * this bounds the per-source read (ADR-051, issue #975).
  */
 final readonly class EventRepository implements EventRepositoryInterface
 {
@@ -20,26 +25,27 @@ final readonly class EventRepository implements EventRepositoryInterface
     /**
      * @param string $date Y-m-d
      *
-     * @return list<array{name: ?string, category: string, lat: float, lon: float, startDate: string, endDate: string, url: ?string, description: ?string, priceMin: ?float}>
+     * @return list<array{name: ?string, category: string, lat: float, lon: float, startDate: string, endDate: string, url: string, description: ?string, priceMin: ?float, source: string}>
      */
     public function findActiveNear(float $lat, float $lon, int $radiusMeters, string $date): array
     {
         /** @var list<array<string, scalar|null>> $rows */
         $rows = $this->connection->fetchAllAssociative(
             <<<'SQL'
-                SELECT name, category, url, description, price_min,
+                SELECT name, category, url, description, price_min, source,
                        to_char(start_date, 'YYYY-MM-DD') AS start_date,
                        to_char(end_date, 'YYYY-MM-DD') AS end_date,
                        ST_Y(geom) AS lat, ST_X(geom) AS lon
                 FROM tourism.events
                 WHERE start_date <= :date AND end_date >= :date
+                  AND url IS NOT NULL AND url <> ''
                   AND ST_DWithin(
                       geom::geography,
                       ST_SetSRID(ST_MakePoint(:lon, :lat), 4326)::geography,
                       :radius
                   )
-                ORDER BY start_date
-                LIMIT 100
+                ORDER BY geom::geography <-> ST_SetSRID(ST_MakePoint(:lon, :lat), 4326)::geography
+                LIMIT 20
                 SQL,
             [
                 'date' => $date,
@@ -58,9 +64,10 @@ final readonly class EventRepository implements EventRepositoryInterface
                 'lon' => (float) $row['lon'],
                 'startDate' => (string) $row['start_date'],
                 'endDate' => (string) $row['end_date'],
-                'url' => null !== $row['url'] && '' !== $row['url'] ? (string) $row['url'] : null,
+                'url' => (string) $row['url'],
                 'description' => null !== $row['description'] && '' !== $row['description'] ? (string) $row['description'] : null,
                 'priceMin' => null !== $row['price_min'] ? (float) $row['price_min'] : null,
+                'source' => (string) $row['source'],
             ];
         }
 

--- a/api/src/Tourism/EventRepositoryInterface.php
+++ b/api/src/Tourism/EventRepositoryInterface.php
@@ -8,11 +8,12 @@ interface EventRepositoryInterface
 {
     /**
      * DataTourisme events active on $date (start_date <= $date <= end_date)
-     * within $radiusMeters of the point, nearest dates first.
+     * within $radiusMeters of the point, ranked by distance to it, capped, and
+     * limited to events carrying a link (`url IS NOT NULL AND url <> ''`).
      *
      * @param string $date Y-m-d
      *
-     * @return list<array{name: ?string, category: string, lat: float, lon: float, startDate: string, endDate: string, url: ?string, description: ?string, priceMin: ?float}>
+     * @return list<array{name: ?string, category: string, lat: float, lon: float, startDate: string, endDate: string, url: string, description: ?string, priceMin: ?float, source: string}>
      */
     public function findActiveNear(float $lat, float $lon, int $radiusMeters, string $date): array;
 }

--- a/api/tests/Integration/Tourism/TourismIndexReadTest.php
+++ b/api/tests/Integration/Tourism/TourismIndexReadTest.php
@@ -62,11 +62,15 @@ final class TourismIndexReadTest extends KernelTestCase
                   ST_SetSRID(ST_MakePoint(2.50, 48.50), 4326))
             SQL);
 
+        // `source` is omitted on purpose: the column defaults to 'datatourisme'
+        // (Version20260810120000), which the read layer must surface.
         $this->connection->executeStatement(<<<'SQL'
             INSERT INTO tourism.events (id, name, category, start_date, end_date, url, description, price_min, tags, geom) VALUES
               ('e1', 'Festival', 'festival', '2026-07-01', '2026-07-05', 'https://ex.test', 'Desc', 12.5, '{}'::jsonb,
                   ST_SetSRID(ST_MakePoint(5.00, 45.00), 4326)),
               ('e2', 'Past Event', 'concert', '2026-06-01', '2026-06-02', NULL, NULL, NULL, '{}'::jsonb,
+                  ST_SetSRID(ST_MakePoint(5.00, 45.00), 4326)),
+              ('e3', 'Linkless Event', 'festival', '2026-07-01', '2026-07-05', '', NULL, NULL, '{}'::jsonb,
                   ST_SetSRID(ST_MakePoint(5.00, 45.00), 4326))
             SQL);
     }
@@ -285,11 +289,15 @@ final class TourismIndexReadTest extends KernelTestCase
         $repository = new EventRepository($this->connection);
 
         $active = $repository->findActiveNear(45.00, 5.00, 20000, '2026-07-03');
-        self::assertCount(1, $active, 'only the event active on the date is returned');
+        // The linkless event (e3) is active on the date and in range but excluded:
+        // an event a rider cannot open is noise (issue #975).
+        self::assertCount(1, $active, 'only the active, linked event is returned');
         self::assertSame('Festival', $active[0]['name']);
         self::assertSame('2026-07-01', $active[0]['startDate']);
         self::assertSame('2026-07-05', $active[0]['endDate']);
         self::assertSame(12.5, $active[0]['priceMin']);
+        // The source column is populated (defaulted here) and surfaced.
+        self::assertSame('datatourisme', $active[0]['source']);
 
         // A date outside every event's range yields nothing.
         self::assertSame([], $repository->findActiveNear(45.00, 5.00, 20000, '2026-08-01'));

--- a/api/tests/Unit/EventSource/EventSourceRegistryTest.php
+++ b/api/tests/Unit/EventSource/EventSourceRegistryTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\EventSource;
+
+use App\EventSource\EventSourceInterface;
+use App\EventSource\EventSourceRegistry;
+use App\Geo\HaversineDistance;
+use App\Geo\NearbyNameDeduplicator;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class EventSourceRegistryTest extends TestCase
+{
+    /**
+     * Fixtures state only what a case is about; the rest of the source-row shape
+     * defaults to a nearby, relevant, linked, unnamed event so a case can assert one
+     * axis without spelling the others out.
+     *
+     * @param list<array<string, mixed>> $events
+     */
+    private function source(array $events): EventSourceInterface
+    {
+        $events = array_map(
+            static fn (array $event): array => $event + [
+                'name' => null,
+                'category' => 'festival',
+                'lat' => 48.0,
+                'lon' => 2.0,
+                'startDate' => '2026-07-10',
+                'endDate' => '2026-07-14',
+                'url' => 'https://event.example.com',
+                'description' => null,
+                'priceMin' => null,
+                'source' => 'datatourisme',
+            ],
+            $events,
+        );
+
+        return new readonly class ($events) implements EventSourceInterface {
+            /** @param list<array<string, mixed>> $events */
+            public function __construct(private array $events)
+            {
+            }
+
+            public function findActiveNear(float $lat, float $lon, int $radiusMeters, string $date): array
+            {
+                /** @var list<array{name: ?string, category: string, lat: float, lon: float, startDate: string, endDate: string, url: string, description: ?string, priceMin: ?float, source: string}> $events */
+                $events = $this->events;
+
+                return $events;
+            }
+        };
+    }
+
+    /**
+     * @param list<EventSourceInterface> $sources
+     */
+    private function registry(array $sources): EventSourceRegistry
+    {
+        return new EventSourceRegistry($sources, new NearbyNameDeduplicator(new HaversineDistance()), new HaversineDistance());
+    }
+
+    #[Test]
+    public function mergesEventsFromEverySource(): void
+    {
+        $a = $this->source([['name' => 'Festival A', 'lat' => 48.10, 'lon' => 2.10]]);
+        $b = $this->source([['name' => 'Concert B', 'category' => 'concert', 'lat' => 48.20, 'lon' => 2.20, 'source' => 'openagenda']]);
+
+        $result = $this->registry([$a, $b])->findAllActiveNear(48.0, 2.0, 20_000, '2026-07-10');
+
+        self::assertCount(2, $result);
+    }
+
+    #[Test]
+    public function collapsesSameNamedNearbyEventsPreferringDataTourisme(): void
+    {
+        $openagenda = $this->source([['name' => 'Fete de la Musique', 'lat' => 48.1000, 'lon' => 2.1000, 'source' => 'openagenda']]);
+        $datatourisme = $this->source([['name' => 'Fete de la Musique', 'lat' => 48.1001, 'lon' => 2.1001, 'source' => 'datatourisme']]);
+
+        $result = $this->registry([$openagenda, $datatourisme])->findAllActiveNear(48.0, 2.0, 20_000, '2026-07-10');
+
+        self::assertCount(1, $result);
+        self::assertSame('datatourisme', $result[0]['source']);
+    }
+
+    #[Test]
+    public function dropsIrrelevantCategories(): void
+    {
+        // The generic `event` fallback and a young-audience category are noise; only
+        // the whitelisted categories a rider plans around survive.
+        $source = $this->source([
+            ['name' => 'Grand Festival', 'category' => 'festival'],
+            ['name' => 'Atelier enfants', 'category' => 'children'],
+            ['name' => 'Evenement divers', 'category' => 'event'],
+            ['name' => 'Expo', 'category' => 'exhibition'],
+        ]);
+
+        $result = $this->registry([$source])->findAllActiveNear(48.0, 2.0, 20_000, '2026-07-10');
+
+        $names = array_map(static fn (array $e): ?string => $e['name'], $result);
+        self::assertSame(['Grand Festival', 'Expo'], $names);
+    }
+
+    #[Test]
+    public function excludesEventsWithoutLink(): void
+    {
+        $source = $this->source([
+            ['name' => 'With Link', 'url' => 'https://event.example.com'],
+            ['name' => 'No Link', 'url' => ''],
+        ]);
+
+        $result = $this->registry([$source])->findAllActiveNear(48.0, 2.0, 20_000, '2026-07-10');
+
+        self::assertCount(1, $result);
+        self::assertSame('With Link', $result[0]['name']);
+    }
+
+    #[Test]
+    public function ranksByDistanceToTheEndPointAndExposesIt(): void
+    {
+        $source = $this->source([
+            ['name' => 'Far', 'lat' => 48.30, 'lon' => 2.30],
+            ['name' => 'Near', 'lat' => 48.001, 'lon' => 2.001],
+            ['name' => 'Mid', 'lat' => 48.10, 'lon' => 2.10],
+        ]);
+
+        $result = $this->registry([$source])->findAllActiveNear(48.0, 2.0, 40_000, '2026-07-10');
+
+        self::assertSame(['Near', 'Mid', 'Far'], array_map(static fn (array $e): ?string => $e['name'], $result));
+        self::assertGreaterThan(0.0, $result[0]['distanceToEndPoint']);
+        self::assertLessThan($result[1]['distanceToEndPoint'], $result[0]['distanceToEndPoint']);
+    }
+
+    #[Test]
+    public function capsTheListToTwenty(): void
+    {
+        $events = [];
+        for ($i = 0; $i < 30; ++$i) {
+            $events[] = ['name' => 'Festival '.$i, 'lat' => 48.0 + $i / 1000, 'lon' => 2.0];
+        }
+
+        $result = $this->registry([$this->source($events)])->findAllActiveNear(48.0, 2.0, 40_000, '2026-07-10');
+
+        self::assertCount(20, $result);
+        // The nearest 20 are kept, so the farthest (index 29) is dropped.
+        self::assertSame('Festival 0', $result[0]['name']);
+        self::assertSame('Festival 19', $result[19]['name']);
+    }
+
+    #[Test]
+    public function emptySourcesReturnEmptyArray(): void
+    {
+        self::assertSame([], $this->registry([])->findAllActiveNear(48.0, 2.0, 20_000, '2026-07-10'));
+    }
+}

--- a/api/tests/Unit/MessageHandler/ScanEventsHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/ScanEventsHandlerTest.php
@@ -9,13 +9,15 @@ use App\ApiResource\Stage;
 use App\ApiResource\TripRequest;
 use App\ComputationTracker\ComputationTrackerInterface;
 use App\ComputationTracker\TripGenerationTrackerInterface;
-use App\Geo\GeoDistanceInterface;
+use App\EventSource\EventSourceInterface;
+use App\EventSource\EventSourceRegistry;
+use App\Geo\HaversineDistance;
+use App\Geo\NearbyNameDeduplicator;
 use App\Mercure\MercureEventType;
 use App\Mercure\TripUpdatePublisherInterface;
 use App\Message\ScanEvents;
 use App\MessageHandler\ScanEventsHandler;
 use App\Repository\TripRequestRepositoryInterface;
-use App\Tourism\EventRepositoryInterface;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
@@ -39,8 +41,7 @@ final class ScanEventsHandlerTest extends TestCase
     private function createHandler(
         TripRequestRepositoryInterface $tripStateManager,
         TripUpdatePublisherInterface $publisher,
-        EventRepositoryInterface $eventRepository,
-        GeoDistanceInterface $haversine,
+        EventSourceInterface $eventSource,
     ): ScanEventsHandler {
         $computationTracker = $this->createStub(ComputationTrackerInterface::class);
         $computationTracker->method('getProgress')->willReturn(['completed' => 0, 'failed' => 0, 'total' => 1]);
@@ -53,8 +54,7 @@ final class ScanEventsHandlerTest extends TestCase
             $generationTracker,
             new NullLogger(),
             $tripStateManager,
-            $eventRepository,
-            $haversine,
+            new EventSourceRegistry([$eventSource], new NearbyNameDeduplicator(new HaversineDistance()), new HaversineDistance()),
             $this->createStub(MessageBusInterface::class),
         );
     }
@@ -68,9 +68,9 @@ final class ScanEventsHandlerTest extends TestCase
     }
 
     /**
-     * @return array{name: string, category: string, lat: float, lon: float, startDate: string, endDate: string, url: ?string, description: ?string, priceMin: ?float}
+     * @return array{name: string, category: string, lat: float, lon: float, startDate: string, endDate: string, url: string, description: ?string, priceMin: ?float, source: string}
      */
-    private function eventRow(string $name, string $category, string $startDate, string $endDate, ?string $url = null, ?string $description = null): array
+    private function eventRow(string $name, string $category, string $startDate, string $endDate, string $url = 'https://event.example.com'): array
     {
         return [
             'name' => $name,
@@ -80,8 +80,9 @@ final class ScanEventsHandlerTest extends TestCase
             'startDate' => $startDate,
             'endDate' => $endDate,
             'url' => $url,
-            'description' => $description,
+            'description' => null,
             'priceMin' => null,
+            'source' => 'datatourisme',
         ];
     }
 
@@ -94,7 +95,7 @@ final class ScanEventsHandlerTest extends TestCase
         $tripStateManager = $this->createStub(TripRequestRepositoryInterface::class);
         $tripStateManager->method('getStages')->willReturn(null);
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $this->createStub(EventRepositoryInterface::class), $this->createStub(GeoDistanceInterface::class));
+        $handler = $this->createHandler($tripStateManager, $publisher, $this->createStub(EventSourceInterface::class));
         $handler(new ScanEvents('trip-1'));
     }
 
@@ -108,15 +109,15 @@ final class ScanEventsHandlerTest extends TestCase
         $tripStateManager->method('getStages')->willReturn([$this->createStage(1)]);
         $tripStateManager->method('getRequest')->willReturn(new TripRequest());
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $this->createStub(EventRepositoryInterface::class), $this->createStub(GeoDistanceInterface::class));
+        $handler = $this->createHandler($tripStateManager, $publisher, $this->createStub(EventSourceInterface::class));
         $handler(new ScanEvents('trip-1'));
     }
 
     #[Test]
     public function restDayStageIsSkipped(): void
     {
-        $eventRepository = $this->createMock(EventRepositoryInterface::class);
-        $eventRepository->expects($this->never())->method('findActiveNear');
+        $eventSource = $this->createMock(EventSourceInterface::class);
+        $eventSource->expects($this->never())->method('findActiveNear');
 
         $publisher = $this->createMock(TripUpdatePublisherInterface::class);
         $publisher->expects($this->never())->method('publish');
@@ -125,7 +126,7 @@ final class ScanEventsHandlerTest extends TestCase
         $tripStateManager->method('getStages')->willReturn([$this->createStage(1, true)]);
         $tripStateManager->method('getRequest')->willReturn($this->createTripRequest(new \DateTimeImmutable('2026-07-01')));
 
-        $handler = $this->createHandler($tripStateManager, $publisher, $eventRepository, $this->createStub(GeoDistanceInterface::class));
+        $handler = $this->createHandler($tripStateManager, $publisher, $eventSource);
         $handler(new ScanEvents('trip-1'));
     }
 
@@ -135,11 +136,11 @@ final class ScanEventsHandlerTest extends TestCase
         $startDate = new \DateTimeImmutable('2026-07-10');
         $stages = [$this->createStage(1), $this->createStage(2), $this->createStage(3)];
 
-        $eventRepository = $this->createStub(EventRepositoryInterface::class);
+        $eventSource = $this->createStub(EventSourceInterface::class);
         // Stage 0 → 2026-07-10, stage 1 → 2026-07-11, stage 2 → 2026-07-12.
-        $eventRepository->method('findActiveNear')->willReturnCallback(
+        $eventSource->method('findActiveNear')->willReturnCallback(
             fn (float $lat, float $lon, int $radius, string $date): array => match ($date) {
-                '2026-07-10' => [$this->eventRow('Festival de Jazz', 'festival', '2026-07-10', '2026-07-14', 'https://festival.example.com', 'Grand festival')],
+                '2026-07-10' => [$this->eventRow('Festival de Jazz', 'festival', '2026-07-10', '2026-07-14', 'https://festival.example.com')],
                 '2026-07-11' => [$this->eventRow('Expo Renoir', 'exhibition', '2026-07-11', '2026-07-30')],
                 default => [],
             },
@@ -157,10 +158,7 @@ final class ScanEventsHandlerTest extends TestCase
         $tripStateManager->method('getStages')->willReturn($stages);
         $tripStateManager->method('getRequest')->willReturn($this->createTripRequest($startDate));
 
-        $haversine = $this->createStub(GeoDistanceInterface::class);
-        $haversine->method('inMeters')->willReturn(500.0);
-
-        $handler = $this->createHandler($tripStateManager, $publisher, $eventRepository, $haversine);
+        $handler = $this->createHandler($tripStateManager, $publisher, $eventSource);
         $handler(new ScanEvents('trip-1'));
 
         $events = array_values(array_filter($published, static fn (array $e): bool => MercureEventType::EVENTS_FOUND === $e['type']));

--- a/docs/adr/adr-051-multi-source-events-openagenda-temporal-lifecycle.md
+++ b/docs/adr/adr-051-multi-source-events-openagenda-temporal-lifecycle.md
@@ -1,0 +1,73 @@
+# ADR-051: Multi-source Events, OpenAgenda, and the Temporal Lifecycle
+
+- **Status:** Accepted — events become a multi-source layer with a relevance-filtered, deduplicated, distance-ranked read. OpenAgenda is the second source (delivered separately, [#984](https://github.com/vincentchalamon/bike-trip-planner/issues/984)); the weekly temporal refresh is delivered separately ([#985](https://github.com/vincentchalamon/bike-trip-planner/issues/985)). This ADR records the shared decision the three issues build on.
+- **Date:** 2026-08-10
+- **Depends on:** ADR-040 (Local-first reference data — single PostGIS source), ADR-026 (external data sources and attribution), ADR-049 (Zone opening and import-time completeness).
+- **Supersedes / relates to:** ADR-044 (removal of the data.gouv markets source) — the multi-source *shape* this ADR generalises is the one ADR-044 removed for markets; events reintroduce it deliberately, with the deduplication and relevance the markets experiment lacked.
+- **Numbering note:** ADR-048 is reserved by [#936](https://github.com/vincentchalamon/bike-trip-planner/issues/936), ADR-049/050 are taken. The next free number is 051.
+
+## Context and Problem Statement
+
+Events were the last reference layer wired to a single source in a way no other layer still is. Concretely, before this decision:
+
+- `tourism.events` had **no `source` column**; the runtime stamped `source: 'datatourisme'` as a hard-coded constant in `ScanEventsHandler`.
+- There was **no deduplication**: had a second source existed, the same festival would have appeared twice.
+- `EventRepository::findActiveNear` ordered by `start_date`, capped at `LIMIT 100`, with **no link filter and no relevance filter** — it returned up to a hundred events a day, earliest-starting first, including linkless entries a rider cannot act on and categories (a generic fallback, young-audience activities) a bikepacker does not plan a detour around.
+
+Every other curated layer already had the multi-source shape this one lacked: POIs, food POIs, cultural POIs and accommodations each expose a `…SourceInterface` + `…SourceRegistry` tagged-iterator, and the OSM/DataTourisme overlap is collapsed by `NearbyNameDeduplicator` (ADR-040). Events were the exception, and adding OpenAgenda as a second events source ([#984](https://github.com/vincentchalamon/bike-trip-planner/issues/984)) is impossible without first giving events the same shape.
+
+Two further properties of events, absent from the other layers, shape this decision:
+
+1. **Events are dated and perishable.** A POI is there next year; an event that ended last week is dead weight. The append-only, obsolescence-assumed storage model of ADR-040 is correct for places but wrong for events, which need a *temporal* lifecycle — a periodic refresh that adds what is upcoming and drops what has passed ([#985](https://github.com/vincentchalamon/bike-trip-planner/issues/985)).
+2. **Relevance is about the rider's detour, not the catalogue.** A curated catalogue lists everything; a stage roadbook should surface the handful of events near where the day ends that a rider would actually reroute for.
+
+## Decision
+
+### 1. `source` becomes a per-row column, not a runtime constant
+
+`tourism.events` gains `source text NOT NULL DEFAULT 'datatourisme'` (forward migration `Version20260810120000`, on top of the collapsed baseline of [#972](https://github.com/vincentchalamon/bike-trip-planner/issues/972)). The default backfills the rows the flux already imported and lets a DataTourisme promotion run without spelling the origin out on every COPY line. The provisioner writes it explicitly all the same (`DataTourismeImporter::TABLE_COLUMNS`, staging DDL), so a second source that writes a different value slots in with no schema change. The runtime reads the column instead of the constant.
+
+### 2. The multi-source runtime mirrors the POI pattern exactly
+
+A tagged-iterator `EventSourceInterface` (`app.event_source`) + `EventSourceRegistry`, copied from `App\Poi\PoiSource*`. `DataTourismeEventSource` adapts the existing `EventRepository`; OpenAgenda joins by implementing the same interface, tagged automatically. The registry merges every source and collapses the same event reported twice through the shared `NearbyNameDeduplicator` (name + 75 m proximity, the curated DataTourisme entry winning on a tie — the same rule already used for places). Reusing the existing deduplicator, rather than inventing an event-specific key, is deliberate: events carry no stable cross-source id, so name-and-proximity is the only identity available, and it is exactly what ADR-040 already settled for the OSM/DataTourisme place overlap.
+
+### 3. Relevance, link and cap are decided once, across sources
+
+The registry applies, after the merge and dedup, the rules that must hold identically whatever the origin:
+
+- **A link is mandatory.** `EventRepository` filters `url IS NOT NULL AND url <> ''` in SQL (efficient, before the per-source cap); the registry re-checks it so a source that forgets cannot leak a linkless event into a stage. An event a rider cannot open is noise.
+- **Relevance is a category whitelist.** Only `festival`, `concert`, `exhibition`, `sports`, `fair`, `show` survive — the app-normalised event vocabulary the DataTourisme mapper already produces. The generic `event` fallback and any young-audience / children category a source normalises outside this set are dropped. Because each source normalises its own taxonomy onto this one vocabulary *before* the registry sees it, this single whitelist **is** the shared audience filter across sources: there is no per-source relevance code to keep in sync.
+- **Ranked by distance to the stage end point, capped at 20.** A rider cares about what is near where the day ends, not about the earliest start date; and a roadbook shows a handful of events, not a hundred. The repository orders by distance and bounds the per-source read; the registry re-ranks the merged set by distance and caps it.
+
+### 4. The temporal lifecycle is a periodic refresh, not the append-only place model
+
+Events are perishable, so the append-only / obsolescence-assumed storage of ADR-040 does not carry over unchanged. The events layer is refreshed on a schedule (weekly, orchestrated out of band — the detail is [#985](https://github.com/vincentchalamon/bike-trip-planner/issues/985)'s to fix), and a refresh **purges** events that have passed rather than accumulating them. This is the one place the reference-data storage model is intentionally *not* append-only, and it is scoped to events precisely because only events have an expiry. Places keep the ADR-040 model untouched.
+
+## Consequences
+
+### Positive
+
+- Events reach parity with every other curated layer: adding OpenAgenda ([#984](https://github.com/vincentchalamon/bike-trip-planner/issues/984)) is now "implement `EventSourceInterface` and tag it", with dedup, relevance, link filtering and the cap already handled centrally.
+- The stage roadbook shows relevant, openable, nearby events instead of up to a hundred date-sorted entries including noise.
+- The relevance and audience rules live in exactly one place (`EventSourceRegistry`), so they cannot drift between sources.
+- DataTourisme is non-regressed: the column defaults to `datatourisme`, the importer still writes it, and the existing read path returns the same events minus the linkless and irrelevant ones.
+
+### Negative
+
+- The distance cap is applied per source then re-applied on the merge, so a source's nearest-20 is what feeds the union — a globally-21st-nearest event a source did not return in its own top-20 cannot reappear. Accepted: the per-source bound is generous relative to how many relevant, dated, in-radius events a 20 km disc holds on a given day.
+- The relevance whitelist is a fixed list in code. A new event category worth surfacing needs both the source's mapping and this whitelist updated. Accepted as the price of deciding relevance once rather than per source.
+
+### Neutral
+
+- The 20 km radius and the 20-event cap are constants this ADR introduces but does not sanctify; they can be tuned without reopening the decision.
+- The temporal refresh mechanism (scheduler, purge SQL) is named here as a decision but specified and delivered in [#985](https://github.com/vincentchalamon/bike-trip-planner/issues/985); this ADR fixes only that events are refreshed-and-purged rather than accumulated.
+
+## Sources
+
+- [ADR-040](adr-040-local-first-reference-data-postgis.md) — local-first PostGIS reference index, `NearbyNameDeduplicator`, and the append-only / obsolescence-assumed storage model this ADR narrows for the perishable events layer.
+- [ADR-026](adr-026-multi-source-data-integration.md) — external data sources and attribution; the parent of the multi-source data model.
+- [ADR-044](adr-044-removal-of-data-gouv-markets-source.md) — the earlier multi-source events experiment (markets), removed; the shape reintroduced here with dedup and relevance.
+- [ADR-049](adr-049-zone-opening-and-import-time-completeness.md) — per-zone promotion and import-time completeness, the pipeline the events column and COPY order slot into.
+- [Issue #975](https://github.com/vincentchalamon/bike-trip-planner/issues/975) — multi-source events, relevance filtering and cap (this ADR's origin).
+- [Issue #984](https://github.com/vincentchalamon/bike-trip-planner/issues/984) — OpenAgenda as the second events source.
+- [Issue #985](https://github.com/vincentchalamon/bike-trip-planner/issues/985) — weekly temporal refresh and purge.

--- a/provisioner/src/DataTourismeImporter.php
+++ b/provisioner/src/DataTourismeImporter.php
@@ -50,20 +50,24 @@ final readonly class DataTourismeImporter
      * `image_url` / `wikipedia_url` are absent on purpose: they exist in the DDL
      * but are written by the Wikidata pass alone, never by the flux.
      *
+     * `events.source` is written explicitly as 'datatourisme' (Version20260810120000,
+     * ADR-051): the events table is now multi-source, so the origin is a per-row
+     * value a second source overrides rather than a runtime constant.
+     *
      * @var array<string, list<string>>
      */
     private const array TABLE_COLUMNS = [
         'cultural_pois' => ['id', 'name', 'category', 'opening_hours', 'description', 'website', 'wikidata', 'tags', 'geom'],
         'food_pois' => ['id', 'name', 'category', 'opening_hours', 'description', 'website', 'wikidata', 'tags', 'geom'],
         'accommodations' => ['id', 'name', 'category', 'capacity', 'price', 'description', 'opening_hours', 'website', 'phone', 'wikidata', 'tags', 'geom'],
-        'events' => ['id', 'name', 'category', 'start_date', 'end_date', 'url', 'description', 'price_min', 'tags', 'geom'],
+        'events' => ['id', 'name', 'category', 'start_date', 'end_date', 'url', 'description', 'price_min', 'source', 'tags', 'geom'],
     ];
 
     private const array STAGING_DDL = [
         'cultural_pois' => 'id text NOT NULL PRIMARY KEY, name text, category text NOT NULL, opening_hours text, description text, website text, image_url text, wikipedia_url text, wikidata text, tags jsonb, geom geometry(Point, 4326) NOT NULL',
         'food_pois' => 'id text NOT NULL PRIMARY KEY, name text, category text NOT NULL, opening_hours text, description text, website text, image_url text, wikipedia_url text, wikidata text, tags jsonb, geom geometry(Point, 4326) NOT NULL',
         'accommodations' => 'id text NOT NULL PRIMARY KEY, name text, category text NOT NULL, capacity int, price numeric(10, 2), description text, opening_hours text, website text, phone text, image_url text, wikipedia_url text, wikidata text, tags jsonb, geom geometry(Point, 4326) NOT NULL',
-        'events' => 'id text NOT NULL PRIMARY KEY, name text, category text NOT NULL, start_date date, end_date date, url text, description text, price_min numeric(10, 2), tags jsonb, geom geometry(Point, 4326) NOT NULL',
+        'events' => "id text NOT NULL PRIMARY KEY, name text, category text NOT NULL, start_date date, end_date date, url text, description text, price_min numeric(10, 2), source text NOT NULL DEFAULT 'datatourisme', tags jsonb, geom geometry(Point, 4326) NOT NULL",
     ];
 
     /**
@@ -401,7 +405,7 @@ final readonly class DataTourismeImporter
         $values = match ($table) {
             'cultural_pois', 'food_pois' => [$row['id'], $row['name'], $row['category'], $row['openingHours'], $row['description'], $row['website'], $row['wikidata'], $tags, $geom],
             'accommodations' => [$row['id'], $row['name'], $row['category'], $row['capacity'], $row['price'], $row['description'], $row['openingHours'], $row['website'], $row['phone'], $row['wikidata'], $tags, $geom],
-            'events' => [$row['id'], $row['name'], $row['category'], $row['startDate'], $row['endDate'], $row['website'], $row['description'], $row['price'], $tags, $geom],
+            'events' => [$row['id'], $row['name'], $row['category'], $row['startDate'], $row['endDate'], $row['website'], $row['description'], $row['price'], 'datatourisme', $tags, $geom],
             default => [],
         };
 

--- a/provisioner/tests/DataTourismeImporterTest.php
+++ b/provisioner/tests/DataTourismeImporterTest.php
@@ -536,6 +536,16 @@ final class DataTourismeImporterTest extends TestCase
             )),
             'food_pois is copied with its website column',
         );
+        // The events COPY column list must name `source`, otherwise the NOT NULL
+        // column stays at its DDL default and a positional shift in TABLE_COLUMNS /
+        // copyLine would go unnoticed.
+        self::assertTrue(
+            (bool) array_filter($joined, static fn (string $c): bool => str_contains(
+                $c,
+                '\copy tourism_staging_bretagne.events (id, name, category, start_date, end_date, url, description, price_min, source, tags, geom)',
+            )),
+            'events is copied with its source column',
+        );
 
         $cultural = explode("\t", rtrim((string) file_get_contents($this->workDir.'/tourism-cultural_pois.copy'), "\n"));
         self::assertSame('Apr-Oct', $cultural[3], 'opening_hours comes from the flux, not a hardcoded null');
@@ -549,6 +559,7 @@ final class DataTourismeImporterTest extends TestCase
 
         $event = explode("\t", rtrim((string) file_get_contents($this->workDir.'/tourism-events.copy'), "\n"));
         self::assertSame('https://festival.test', $event[5], 'events.url is populated instead of always null');
+        self::assertSame('datatourisme', $event[8], 'events.source is stamped at the source column position');
     }
 
     /**


### PR DESCRIPTION
Closes #975.

## Résumé
Donne aux événements la forme multi-source des autres couches curées.

- **Schéma / provisioning** : migration forward `Version20260810120000` ajoutant `source text NOT NULL DEFAULT 'datatourisme'` à `tourism.events` (baseline collapsée intacte) ; `DataTourismeImporter` écrit `source` (DDL staging + `TABLE_COLUMNS` + `copyLine`).
- **Runtime multi-source** : nouveau `api/src/EventSource/` (`EventSourceInterface` taggé, `DataTourismeEventSource`, `EventSourceRegistry`) copié du pattern `Poi/PoiSource*`, routé via `NearbyNameDeduplicator` ; applique une fois les règles : lien obligatoire, whitelist de pertinence (festival/concert/exposition/sport/foire/spectacle), tri par distance au point d'arrivée, cap 20.
- **`EventRepository`** (+interface) : filtre `url IS NOT NULL AND url <> ''`, tri distance (KNN), `LIMIT 100 → 20`, remonte `source`.
- **`ScanEventsHandler`** : dépend de `EventSourceRegistry`, lit `source`/`distanceToEndPoint`, plus de tri `start_date`.
- **ADR-051** (`docs/adr/adr-051-...`) : multi-source + OpenAgenda + cycle de vie temporel (base pour #985).

## Tests
`EventSourceRegistryTest` (merge, dédup DataTourisme, filtre pertinence/audience, exclusion url, tri distance, cap 20) ; `ScanEventsHandlerTest` réécrit ; `TourismIndexReadTest` durci (source peuplée, event sans lien exclu au SQL). Négatif prouvé (test rouge sans le filtre, restauré).

## Vérification (legs QA individuels)
PHP-CS-Fixer `Fixed 0` ; Rector `[OK]` (1 autofix committé) ; PHPStan L9 `[OK] No errors` ; PHPUnit `tests/Unit tests/Integration` `OK, 1518 tests` ; markdownlint `0 error`. Playwright/Functional = CI.

## Auto-critique
Le `Event` DTO portait déjà `source` → **aucune régénération de `schema.d.ts`** (pas de conflit avec #982). Taxonomie catégories/audience à affiner à l'arrivée d'OpenAgenda (#984).

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 findings (0 critical, 0 warning, 0 suggestion). The multi-source events shape (`EventSourceInterface` + `EventSourceRegistry`) faithfully mirrors the existing `PoiSourceRegistry`/`NearbyNameDeduplicator` pattern; the `source`/link-filter/distance-rank/cap changes are threaded consistently end-to-end (SQL → repository → registry → handler → provisioner staging DDL/COPY order), and the second commit closed the one gap flagged in the previous pass (provisioner COPY-line assertion for `events.source`). The promotion path (`ZonePromotion`) reads its column list from `information_schema` rather than a hardcoded list, so the new column flows to the live table with no further change needed there. DI wiring relies on the existing global `App\` autowire/autoconfigure, so the new tagged iterator needs no extra service config, consistent with `Poi/PoiSource*`.

Resolved 1 previously open thread that was addressed (provisioner test coverage for `events.source`).

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

**Commit reviewed:** `358a3d35a2e2780381407ae66bc21dc090acf9b4`
<!-- claude-review-end -->
