### PR TITLE
fix(early-access): message de succès illisible + email de vérification jamais envoyé

### DIFF
--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -24,6 +24,10 @@ services:
         cors_origins *
         demo
       MAILER_DSN: smtp://mailcatcher:1025
+      # Early-access email verification (ADR-029). Prod stays fail-closed on an
+      # empty secret; dev needs a non-empty value or AccessRequestHmacService
+      # throws at instantiation and the confirmation email is never sent.
+      ACCESS_REQUEST_HMAC_SECRET: dev-access-request-hmac-secret
       LOCK_DSN: redis://redis:6379
       # See https://xdebug.org/docs/all_settings#mode
       XDEBUG_MODE: "${XDEBUG_MODE:-off}"
@@ -57,6 +61,7 @@ services:
     environment:
       APP_ENV: dev
       MAILER_DSN: smtp://mailcatcher:1025
+      ACCESS_REQUEST_HMAC_SECRET: dev-access-request-hmac-secret
       LOCK_DSN: redis://redis:6379
       XDEBUG_MODE: "${XDEBUG_MODE:-off}"
       JWT_SECRET_KEY: /app/config/jwt/private.pem
@@ -78,6 +83,7 @@ services:
     environment:
       APP_ENV: dev
       MAILER_DSN: smtp://mailcatcher:1025
+      ACCESS_REQUEST_HMAC_SECRET: dev-access-request-hmac-secret
       LOCK_DSN: redis://redis:6379
       XDEBUG_MODE: "${XDEBUG_MODE:-off}"
       JWT_SECRET_KEY: /app/config/jwt/private.pem

--- a/compose.recette.yaml
+++ b/compose.recette.yaml
@@ -37,6 +37,9 @@ x-recette-env: &recette-env
   # Non-default token-encryption key so the SEC-003 fail-closed boot guard passes
   # locally (encrypts AI provider tokens + refresh tokens at rest).
   AI_TOKEN_ENC_KEY: recette-ai-token-enc-key
+  # Non-empty secret so AccessRequestHmacService boots (ADR-029): the early-access
+  # confirmation email is signed with it. Prod stays fail-closed on the empty default.
+  ACCESS_REQUEST_HMAC_SECRET: recette-access-request-hmac-secret
 
 services:
   php:

--- a/compose.yaml
+++ b/compose.yaml
@@ -70,6 +70,7 @@ services:
       JWT_PASSPHRASE: "${JWT_PASSPHRASE}"
       FRONTEND_URL: "${FRONTEND_URL:-https://localhost}"
       MAILER_DSN: "${MAILER_DSN:-}"
+      ACCESS_REQUEST_HMAC_SECRET: "${ACCESS_REQUEST_HMAC_SECRET:-}"
       # Error tracking (P1.1 / ADR-031). Leave SENTRY_DSN empty to disable.
       SENTRY_DSN: "${SENTRY_DSN:-}"
       APP_RELEASE: "${APP_RELEASE:-}"
@@ -158,6 +159,7 @@ services:
       JWT_PASSPHRASE: "${JWT_PASSPHRASE}"
       FRONTEND_URL: "${FRONTEND_URL:-https://localhost}"
       MAILER_DSN: "${MAILER_DSN:-}"
+      ACCESS_REQUEST_HMAC_SECRET: "${ACCESS_REQUEST_HMAC_SECRET:-}"
       # Error tracking (P1.1 / ADR-031). Leave SENTRY_DSN empty to disable.
       SENTRY_DSN: "${SENTRY_DSN:-}"
       APP_RELEASE: "${APP_RELEASE:-}"
@@ -237,6 +239,7 @@ services:
       JWT_PASSPHRASE: "${JWT_PASSPHRASE}"
       FRONTEND_URL: "${FRONTEND_URL:-https://localhost}"
       MAILER_DSN: "${MAILER_DSN:-}"
+      ACCESS_REQUEST_HMAC_SECRET: "${ACCESS_REQUEST_HMAC_SECRET:-}"
       # Error tracking (P1.1 / ADR-031). Leave SENTRY_DSN empty to disable.
       SENTRY_DSN: "${SENTRY_DSN:-}"
       APP_RELEASE: "${APP_RELEASE:-}"

--- a/docs/runbooks/secrets-inventory.md
+++ b/docs/runbooks/secrets-inventory.md
@@ -25,6 +25,7 @@ Pour la rotation : voir [secrets-rotation.md](secrets-rotation.md).
 | `DATABASE_PASSWORD` | Password Postgres | Coolify env | `php`, `worker`, `database` | Oui | Bi-annuel + on-compromise | ADR-022 |
 | `DATABASE_NAME` | Nom de base | Coolify env | `php`, `worker`, `database` | Oui | Statique | ADR-022 |
 | `MAILER_DSN` | DSN Resend (contient API key) | Coolify env | `php`, `worker` | Oui | On-compromise | ADR-029 |
+| `ACCESS_REQUEST_HMAC_SECRET` | Secret HMAC-SHA256 | Coolify env | `php`, `worker`, `worker-llm` | Oui | On-compromise (invalide les liens d'activation en attente) | ADR-029 |
 | `DATATOURISME_API_KEY` | API key | Coolify env | `worker` (multi-source) | Oui | On-compromise | ADR-026 |
 | `SENTRY_DSN` | DSN GlitchTip (public côté projet, technique côté ingestion) | Coolify env | `php`, `worker`, `pwa` (SSR) | Oui | On-compromise (projet GlitchTip recréé) | ADR-031 |
 | `NEXT_PUBLIC_SENTRY_DSN` | Idem, exposé au bundle client | Coolify env (build arg) | `pwa` (client) | Oui | Idem `SENTRY_DSN` | ADR-031 |

--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -930,6 +930,7 @@
     "sending": "Sending...",
     "successMessage": "Thank you! You will receive a confirmation email shortly.",
     "throttledMessage": "Too many requests. Please wait a few minutes before trying again.",
+    "errorMessage": "Something went wrong. Please try again in a moment.",
     "verifying": "Verifying your email address...",
     "accessConfirmed": "Your email address has been confirmed! We will notify you when your access is granted.",
     "loginBoxTitle": "Don't have an account yet?",

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -930,6 +930,7 @@
     "sending": "Envoi en cours...",
     "successMessage": "Merci ! Tu vas recevoir un email de confirmation.",
     "throttledMessage": "Trop de requêtes. Patiente quelques minutes avant de réessayer.",
+    "errorMessage": "Une erreur est survenue. Merci de réessayer dans quelques instants.",
     "verifying": "Vérification de ton adresse email...",
     "accessConfirmed": "Ton adresse email a été confirmée ! Tu seras notifié lorsque ton accès sera accordé.",
     "loginBoxTitle": "Pas encore de compte ?",

--- a/pwa/src/components/early-access-form.tsx
+++ b/pwa/src/components/early-access-form.tsx
@@ -16,9 +16,9 @@ export function EarlyAccessForm() {
   const t = useTranslations("earlyAccess");
   const [email, setEmail] = useState("");
   const [loading, setLoading] = useState(false);
-  const [status, setStatus] = useState<"idle" | "success" | "throttled">(
-    "idle",
-  );
+  const [status, setStatus] = useState<
+    "idle" | "success" | "throttled" | "error"
+  >("idle");
   const [emailError, setEmailError] = useState<string | null>(null);
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -44,12 +44,14 @@ export function EarlyAccessForm() {
 
       if (response.status === 429) {
         setStatus("throttled");
+      } else if (response.status >= 400) {
+        setStatus("error");
       } else {
         setStatus("success");
       }
     } catch {
-      // Network error — still show neutral confirmation
-      setStatus("success");
+      // Network error — surface a real failure, not a false confirmation.
+      setStatus("error");
     } finally {
       setLoading(false);
     }
@@ -58,7 +60,7 @@ export function EarlyAccessForm() {
   if (status === "success") {
     return (
       <div
-        className="bg-muted rounded-lg p-4 text-center text-sm"
+        className="bg-muted text-muted-foreground rounded-lg p-4 text-center text-sm"
         role="status"
         data-testid="early-access-success"
       >
@@ -75,6 +77,18 @@ export function EarlyAccessForm() {
         data-testid="early-access-throttled"
       >
         {t("throttledMessage")}
+      </div>
+    );
+  }
+
+  if (status === "error") {
+    return (
+      <div
+        className="bg-destructive/10 border border-destructive/30 rounded-lg p-4 text-center text-sm text-destructive"
+        role="alert"
+        data-testid="early-access-error"
+      >
+        {t("errorMessage")}
       </div>
     );
   }

--- a/pwa/tests/mocked/early-access.spec.ts
+++ b/pwa/tests/mocked/early-access.spec.ts
@@ -134,6 +134,32 @@ test.describe("Early access form", () => {
     await expect(page.getByTestId("early-access-form")).not.toBeVisible();
   });
 
+  test("shows error message on server failure (not a false 'thank you')", async ({
+    page,
+  }) => {
+    await mockUnauthenticated(page);
+
+    // Mock POST /access-requests -> 500 (e.g. mailer down). The bug was that any
+    // non-429 status was treated as success; a 5xx must now surface as an error.
+    await page.route("**/access-requests", (route, request) => {
+      if (request.method() !== "POST") return route.fallback();
+      return route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({ message: "Internal error." }),
+      });
+    });
+
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    await page.getByTestId("early-access-email-input").fill("test@example.com");
+    await page.getByTestId("early-access-submit").click();
+
+    await expect(page.getByTestId("early-access-error")).toBeVisible();
+    await expect(page.getByTestId("early-access-success")).toHaveCount(0);
+  });
+
   test("shows validation error for invalid email", async ({ page }) => {
     await mockUnauthenticated(page);
 


### PR DESCRIPTION
Closes #976.

## Résumé
- **Message illisible** : ajout de `text-muted-foreground` sur le div de succès (`early-access-form.tsx`) — le texte n'hérite plus du `text-background` inversé de la section parente (light + dark).
- **Échec masqué** : nouvel état `error` (status >= 400 ou catch réseau) au lieu de forcer `success` ; bloc `text-destructive` réutilisant le pattern `throttled` ; le 429 reste `throttled`.
- **Secret HMAC** : `ACCESS_REQUEST_HMAC_SECRET` fourni en dev (`compose.dev.yaml` sur `php`/`worker`/`worker-llm`) et recette (`compose.recette.yaml` via `x-recette-env`). Prod reste fail-closed (secret vide → refus).
- **i18n** : clé `earlyAccess.errorMessage` (fr/en). **Doc** : `secrets-inventory.md`.

## Vérification (legs QA)
tsc/eslint clean ; prettier `All matched files use Prettier code style!` ; `i18n-check OK: 926 keys` ; `docker compose config` (dev + recette) exit 0 avec le secret sur les 3 services.

## Auto-critique
Recette manuelle (email Mailcatcher → clic → VERIFIED) et E2E = CI/user. Clé i18n disjointe de #984 (attribution OpenAgenda) → merge trivial sur `pwa/messages/*`.

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 critical, 0 warning, 0 note. The previously flagged deployment wiring gap (secret not reaching prod containers) is now fixed by commit `76d184f`; frontend logic, tests, and compose wiring all check out. `docker compose config` verified locally for prod/dev/recette overlays across `php`/`worker`/`worker-llm`.

**Resolved threads:** Resolved 1 previously open thread (`ACCESS_REQUEST_HMAC_SECRET` missing from `compose.yaml` — fixed by commit `76d184f`, verified via `docker compose config`).

**PR title check:** the description clause (`message de succès illisible + email de vérification jamais envoyé`) is a noun phrase describing symptoms, not an imperative-mood action (e.g. "corriger …" / "fix …"). Minor, non-blocking — unchanged from the prior review.

**Review checklist:**
- [x] Code respects the project architecture (prod/dev/recette compose wiring now consistent for all three PHP services)
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases (server-failure path covered by the new Playwright test)
- [x] Documentation is up to date (secrets-inventory.md updated)
- [x] Dependent tickets accounted for

**Commit reviewed:** 76d184f7cd3b18c99084fe8fa3052a54495e8085

**Inline comments:** No inline comments.
<!-- claude-review-end -->