### PR TITLE
fix(i18n): erreurs NextIntlClientProvider en rendu statique

### DIFF
--- a/pwa/src/app/(app)/account/email-change/verify/[token]/page.tsx
+++ b/pwa/src/app/(app)/account/email-change/verify/[token]/page.tsx
@@ -4,10 +4,13 @@ const EmailChangeVerifyPage = dynamic(() => import("./verify-page"), {
   loading: () => null,
 });
 
-// Required for static export (Capacitor mobile build).
-// Placeholder value: Next.js 16 treats empty arrays as missing.
+// Only prerender a placeholder for the static export (Capacitor mobile build);
+// on web, return an empty set so the route stays dynamic and next-intl can read
+// the `locale` cookie instead of being frozen to the `fr` fallback.
 export function generateStaticParams() {
-  return [{ token: "__placeholder" }];
+  return process.env.NEXT_PUBLIC_IS_MOBILE_BUILD === "1"
+    ? [{ token: "__placeholder" }]
+    : [];
 }
 
 export default function Page() {

--- a/pwa/src/app/auth/verify/[token]/page.tsx
+++ b/pwa/src/app/auth/verify/[token]/page.tsx
@@ -4,10 +4,13 @@ const VerifyPage = dynamic(() => import("./verify-page"), {
   loading: () => null,
 });
 
-// Required for static export (Capacitor mobile build).
-// Placeholder value: Next.js 16 treats empty arrays as missing.
+// Only prerender a placeholder for the static export (Capacitor mobile build);
+// on web, return an empty set so the route stays dynamic and next-intl can read
+// the `locale` cookie instead of being frozen to the `fr` fallback.
 export function generateStaticParams() {
-  return [{ token: "__placeholder" }];
+  return process.env.NEXT_PUBLIC_IS_MOBILE_BUILD === "1"
+    ? [{ token: "__placeholder" }]
+    : [];
 }
 
 export default function Page() {

--- a/pwa/src/app/layout.tsx
+++ b/pwa/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from "next";
 import { Fraunces, Inter_Tight, JetBrains_Mono } from "next/font/google";
 import { getLocale, getMessages, getTranslations } from "next-intl/server";
+import { unstable_rethrow } from "next/navigation";
 import { DEFAULT_LOCALE } from "@/i18n/locale";
 import { SITE_URL } from "@/lib/constants";
 import "./globals.css";
@@ -41,7 +42,8 @@ export async function generateMetadata(): Promise<Metadata> {
     const t = await getTranslations("layout");
     title = t("title");
     description = t("description");
-  } catch {
+  } catch (error) {
+    unstable_rethrow(error);
     // Static export prerendering: next-intl server context unavailable — keep
     // the English defaults above.
   }
@@ -92,7 +94,8 @@ export default async function RootLayout({
   try {
     locale = await getLocale();
     messages = await getMessages();
-  } catch {
+  } catch (error) {
+    unstable_rethrow(error);
     // Static export prerendering: next-intl server context unavailable
     locale = DEFAULT_LOCALE;
     messages = (await import(`../../messages/${DEFAULT_LOCALE}.json`)).default;


### PR DESCRIPTION
Closes #977.

## Résumé
- `layout.tsx` : `unstable_rethrow(error)` en tête des deux catch (`generateMetadata` + `RootLayout`) — le bailout `cookies()` n'est plus avalé, la page reste dynamique.
- `auth/verify/[token]/page.tsx` et `(app)/account/email-change/verify/[token]/page.tsx` : `generateStaticParams` conditionnel au build mobile (`NEXT_PUBLIC_IS_MOBILE_BUILD === "1" ? [{ token: "__placeholder" }] : []`).

## Vérification (legs QA)
tsc/eslint clean ; prettier conforme ; `i18n-check OK: 925 keys`. `unstable_rethrow` confirmé exporté par Next 16.2.10.

## Auto-critique
Vérif absence d'overlay en `next dev` (cookie `locale=en`) + builds web/mobile = recette/CI ; seul `tsc --noEmit` joué ici.

<!-- claude-review-start -->
## Claude Review

**Findings:** 1 blocking (test coverage), 0 warnings, 0 nitpicks.

**Checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [ ] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Commit reviewed:** `065683d89b1efcbaa04f39c5e92d25e090254205`
<!-- claude-review-end -->