### PR TITLE
fix(pwa): bouton d'aide présent sur tous les écrans du header

### DIFF
--- a/pwa/src/components/top-bar.tsx
+++ b/pwa/src/components/top-bar.tsx
@@ -35,13 +35,6 @@ export function TopBar() {
   const email = useAuthStore((s) => s.user?.email ?? "");
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
 
-  // The help "?" opens the roadbook help modal, which SiteChrome mounts on the
-  // app chrome. Show the button only on the planner routes (home dashboard, new
-  // trip, trip view) — not on the trips list or account settings — so it is
-  // never a dead button there (recette #649). The bar is shared via the layout
-  // now, so the visibility is decided here from the route rather than a prop.
-  const showHelp = pathname === "/" || pathname.startsWith("/trips/");
-
   const initial = email.trim().charAt(0).toUpperCase() || "?";
 
   function isActive(href: string) {
@@ -119,20 +112,18 @@ export function TopBar() {
         {/* Spacer */}
         <div className="flex-1" />
 
-        {/* Help — only where the help modal is mounted (roadbook context) */}
-        {showHelp && (
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-9 w-9 cursor-pointer"
-            onClick={() => setHelpModalOpen(true)}
-            title={t("help.openButton")}
-            aria-label={t("help.openButton")}
-            data-testid="help-button"
-          >
-            <HelpCircle className="h-4 w-4" />
-          </Button>
-        )}
+        {/* 3. Help — always visible, like the language/theme switches */}
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-9 w-9 cursor-pointer"
+          onClick={() => setHelpModalOpen(true)}
+          title={t("help.openButton")}
+          aria-label={t("help.openButton")}
+          data-testid="help-button"
+        >
+          <HelpCircle className="h-4 w-4" />
+        </Button>
 
         {/* 4-5. Language + theme (grouped for a consistent gap) */}
         <div className="flex items-center gap-1">

--- a/pwa/tests/mocked/account-settings.spec.ts
+++ b/pwa/tests/mocked/account-settings.spec.ts
@@ -77,9 +77,9 @@ test.describe("Account settings", () => {
       "test@example.com",
     );
     await expect(page.getByTestId("section-footer")).toBeVisible();
-    // SiteChrome mounts the help modal app-wide, but the top-bar help button
-    // is route-gated (only "/" and "/trips/*"), so it is suppressed here.
-    await expect(page.getByTestId("help-button")).toHaveCount(0);
+    // The help button is unconditional (like the locale/theme switches), so it
+    // is present on every screen, including account settings.
+    await expect(page.getByTestId("help-button")).toBeVisible();
   });
 
   test("unauthenticated user is redirected to login", async ({ page }) => {

--- a/pwa/tests/mocked/trips-list.spec.ts
+++ b/pwa/tests/mocked/trips-list.spec.ts
@@ -59,15 +59,15 @@ test.describe("/trips page", () => {
     await expect(page.getByText("Bretagne coastal")).toBeVisible();
   });
 
-  test("shows the global top bar without the roadbook-only help button", async ({
+  test("shows the global top bar with the unconditional help button", async ({
     page,
   }) => {
     await expect(page.getByTestId("top-bar")).toBeVisible();
     await expect(page.getByTestId("nav-my-trips")).toBeVisible();
     await expect(page.getByTestId("profile-button")).toBeVisible();
-    // The help modal is only mounted by the trip planner, so the help button
-    // is suppressed here (showHelp={false}).
-    await expect(page.getByTestId("help-button")).toHaveCount(0);
+    // The help button is unconditional (like the locale/theme switches), so it
+    // is present here too.
+    await expect(page.getByTestId("help-button")).toBeVisible();
   });
 
   test("delete button opens confirmation dialog", async ({ page }) => {


### PR DESCRIPTION
Closes #978.

## Résumé
Suppression de `showHelp` (et de son commentaire périmé) et de sa garde dans `top-bar.tsx` : le bouton d'aide est rendu inconditionnellement, comme `LocaleSwitcher`/`ThemeToggle`. `pathname` reste utilisé par `isActive`/`isNewTripActive` (aucune var orpheline).

## Vérification (legs QA)
tsc/eslint exit 0 ; prettier conforme ; `i18n-check OK: 925 keys`.

## Auto-critique
Fichier unique, aucun overlap sprint-52. E2E = CI.

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 blocking findings, 1 non-blocking note. The previous blocking finding (mocked specs still asserting `help-button` count 0) was addressed by the second commit — `trips-list.spec.ts` and `account-settings.spec.ts` now assert visibility, matching the unconditional button and #978's acceptance criteria. `HelpModal` is confirmed mounted app-wide by `SiteChrome`, so the button is never a dead control on any route.

**Resolved threads:** none open (0 previously open threads).

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Findings:**
- 🟡 Note: PR title description ("bouton d'aide présent sur tous les écrans du header") is a noun phrase, not imperative mood (Conventional Commits).

Inline comments: 0.

Commit reviewed: `907f418ceb4481e72bdc207a42ad978d2f73db86`
<!-- claude-review-end -->
