### PR TITLE
fix(pwa): bloc Assistant IA en opacité normale quand aucune IA n'est configurée

### DIFF
--- a/pwa/src/components/card-selection.tsx
+++ b/pwa/src/components/card-selection.tsx
@@ -414,6 +414,10 @@ function AiCard({
       ariaLabel={t("ariaSelectAi")}
       expanded={expanded}
       disabled={disabled || unavailable || notConfigured}
+      // `notConfigured` keeps the card non-interactive but must not dim it:
+      // the "Configurez une IA" invitation has to stay legible (#979). Only a
+      // real outage (`unavailable`) or a host-level `disabled` dims the shell.
+      dimmed={disabled || unavailable}
       onSelect={onSelect}
       icon={<Sparkles className="h-6 w-6" aria-hidden="true" />}
       title={t("aiTitle")}
@@ -440,6 +444,11 @@ interface CardShellProps {
   ariaLabel: string;
   expanded: boolean;
   disabled: boolean;
+  /**
+   * Visual dimming (`opacity-60` + muted icon). Defaults to `disabled`. Split
+   * out so a card can stay non-interactive without looking greyed out (#979).
+   */
+  dimmed?: boolean;
   onSelect?: () => void;
   /**
    * When `false`, the shell is never a clickable button: the interactive
@@ -459,6 +468,7 @@ function CardShell({
   ariaLabel,
   expanded,
   disabled,
+  dimmed = disabled,
   onSelect,
   selectable = true,
   icon,
@@ -494,14 +504,15 @@ function CardShell({
         interactive &&
           "cursor-pointer hover:border-brand hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-brand",
         expanded && "border-brand",
-        disabled && "opacity-60 cursor-not-allowed",
+        disabled && "cursor-not-allowed",
+        dimmed && "opacity-60",
       )}
     >
       <div className="flex items-start gap-3">
         <div
           className={cn(
             "flex items-center justify-center w-10 h-10 rounded-full bg-brand-light text-brand shrink-0",
-            disabled && "bg-muted text-muted-foreground",
+            dimmed && "bg-muted text-muted-foreground",
           )}
         >
           {icon}


### PR DESCRIPTION
Closes #979.

## Résumé
Découplage opacité/interactivité dans `CardShell` (`card-selection.tsx`) : nouvelle prop `dimmed` (défaut `= disabled`). `opacity-60` + icône grisée pilotées par `dimmed` ; `cursor-not-allowed` reste sur `disabled`. `AiCard` passe `dimmed={disabled || unavailable}` → `notConfigured` ne baisse plus l'opacité mais la carte reste non cliquable. Un vrai `unavailable` (panne) reste atténué.

## Vérification (legs QA)
tsc/eslint exit 0 ; prettier conforme ; `i18n-check OK: 925 keys`.

## Auto-critique
Fichier unique. E2E = CI.

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 critical, 0 blocking findings, 2 non-blocking suggestions (test coverage, tracking doc).

**Checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [ ] Tests cover new/changed cases — no regression test asserts the fixed visual behavior (see review body)
- [ ] Documentation is up to date — `TRACKING.md` row for #979 not yet updated with this PR
- [x] Dependent tickets accounted for

**Commit reviewed:** `1c46dcb0e6a78b951a739f3f0a9a8eb379ceb0f0`
<!-- claude-review-end -->