### PR TITLE
fix(pwa): suppression d'un voyage possible même verrouillé

### DIFF
--- a/pwa/src/components/config-panel.tsx
+++ b/pwa/src/components/config-panel.tsx
@@ -45,6 +45,8 @@ interface ConfigPanelProps {
   onAccommodationTypesChange: (types: AccommodationType[]) => void;
   /** When true, date/pacing/accommodation controls are disabled (trip is locked). */
   readOnly?: boolean;
+  /** Whether the client is online. Deletion is a server call, so it stays gated on this. */
+  isOnline?: boolean;
   hasTripLoaded?: boolean;
   /** Title of the loaded trip — surfaced in the delete confirmation dialog. */
   tripTitle?: string;
@@ -92,6 +94,7 @@ export function ConfigPanel({
   onDepartureHourChange,
   onAccommodationTypesChange,
   readOnly = false,
+  isOnline = true,
   hasTripLoaded = false,
   tripTitle,
   onDuplicate,
@@ -384,13 +387,16 @@ export function ConfigPanel({
               </Button>
 
               {/* Delete — destructive action, mirrors the "Mes voyages" list
-                  deletion but available from the trip itself (recette #649). */}
+                  deletion but available from the trip itself (recette #649).
+                  Not gated on readOnly (isLocked/outOfZone): a locked or
+                  out-of-zone trip must still be deletable (#980); only online
+                  status matters, since deletion is a server call. */}
               {onDelete && (
                 <Button
                   variant="outline"
                   size="sm"
                   className="w-full justify-start gap-2 border-destructive/40 text-destructive hover:bg-destructive/10 hover:text-destructive"
-                  disabled={!hasTripLoaded || readOnly}
+                  disabled={!hasTripLoaded || !isOnline}
                   aria-label={t("deleteLabel")}
                   onClick={() => setIsDeleteDialogOpen(true)}
                   data-testid="delete-trip-button"

--- a/pwa/src/components/trip-planner.tsx
+++ b/pwa/src/components/trip-planner.tsx
@@ -707,6 +707,7 @@ export function TripPlanner() {
           onDepartureHourChange={handleDepartureHourChange}
           onAccommodationTypesChange={handleAccommodationTypesChange}
           readOnly={isLocked || !isOnline || outOfZone}
+          isOnline={isOnline}
           hasTripLoaded={!!trip}
           tripTitle={trip?.title}
           onDuplicate={handleDuplicateTrip}


### PR DESCRIPTION
Closes #980.

## Résumé
Le bouton de suppression du `ConfigPanel` était gaté sur `readOnly` (`isLocked || !isOnline || outOfZone`). Retrait de `isLocked`/`outOfZone`, conservation de `!isOnline` (la suppression est un appel serveur). `config-panel.tsx` reçoit désormais `isOnline` séparément (`trip-planner.tsx` le passe) ; le reste du gating (dates/pacing/hébergements via `readOnly`) est inchangé.

## Vérification (legs QA)
tsc/eslint exit 0 ; prettier conforme ; `i18n-check OK: 925 keys`.

## Auto-critique
`trip-planner.tsx` édité en plus de `config-panel.tsx` (l'issue ne citait que ce dernier) pour exposer `isOnline` distinctement — changement minimal, limité à l'action de suppression. E2E = CI.

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 critical, 0 warning, 1 suggestion (test coverage gap). The fix itself is minimal, correctly scoped, and functionally verified — `handleDeleteTrip` has no independent `isLocked`/`outOfZone` gate, so the new prop wiring is sufficient to satisfy #980's acceptance criteria.

**PR title check:** `fix(pwa): suppression d'un voyage possible même verrouillé` — the description reads as a noun phrase rather than imperative mood (e.g. "allow deleting a locked/out-of-zone trip" / "permettre la suppression..."). Minor, not blocking.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [ ] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** Posted 1 inline comment.

Commit reviewed: `2ae376bbc6431768c56711470a6ca58f1696d7d1`
<!-- claude-review-end -->