### PR TITLE
fix(events): affichage aligné comme les alertes + pagination « voir plus »

### DIFF
--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -1094,7 +1094,8 @@
     "see_on_wikipedia": "See on Wikipedia",
     "see_on_wikipedia_label": "See {name} on Wikipedia",
     "see_website": "Visit website",
-    "see_website_label": "Visit {name}'s website"
+    "see_website_label": "Visit {name}'s website",
+    "show_more": "Show more ({count})"
   },
   "modificationQueue": {
     "panelLabel": "Pending modifications",

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -1094,7 +1094,8 @@
     "see_on_wikipedia": "Voir sur Wikipedia",
     "see_on_wikipedia_label": "Voir {name} sur Wikipedia",
     "see_website": "Voir le site",
-    "see_website_label": "Voir le site de {name}"
+    "see_website_label": "Voir le site de {name}",
+    "show_more": "Voir plus ({count})"
   },
   "modificationQueue": {
     "panelLabel": "Modifications en attente",

--- a/pwa/src/components/event-item.tsx
+++ b/pwa/src/components/event-item.tsx
@@ -43,70 +43,53 @@ export function EventItem({ event }: EventItemProps) {
 
   return (
     <div className="py-2 first:pt-0 last:pb-0">
-      <div className="flex items-start justify-between gap-2">
-        <div className="flex-1 min-w-0">
-          <p className="text-sm font-medium leading-tight truncate">
-            {event.name}
-          </p>
-          <div className="flex items-center gap-2 mt-0.5 flex-wrap">
-            <span className="text-xs text-muted-foreground">{dateRange}</span>
+      <p className="text-sm font-medium leading-tight">{event.name}</p>
+      <div className="flex items-center gap-2 mt-0.5 flex-wrap">
+        <span className="text-xs text-muted-foreground">{dateRange}</span>
+        <span className="text-xs text-muted-foreground">·</span>
+        <span className="text-xs text-muted-foreground">{typeLabel}</span>
+        {event.priceMin !== null && event.priceMin !== undefined && (
+          <>
             <span className="text-xs text-muted-foreground">·</span>
-            <span className="text-xs text-muted-foreground">{typeLabel}</span>
-            {event.priceMin !== null && event.priceMin !== undefined && (
-              <>
-                <span className="text-xs text-muted-foreground">·</span>
-                <span className="text-xs text-muted-foreground">
-                  {t("from_price", { price: event.priceMin })}
-                </span>
-              </>
-            )}
-          </div>
-          {event.description && (
-            <p className="text-xs text-muted-foreground mt-1 line-clamp-2">
-              {event.description}
-            </p>
-          )}
-          {event.openingHours && (
-            <p className="text-xs text-muted-foreground mt-0.5">
-              {event.openingHours}
-            </p>
-          )}
+            <span className="text-xs text-muted-foreground">
+              {t("from_price", { price: event.priceMin })}
+            </span>
+          </>
+        )}
+      </div>
+      {event.openingHours && (
+        <p className="text-xs text-muted-foreground mt-0.5">
+          {event.openingHours}
+        </p>
+      )}
+      {(event.wikipediaUrl || event.url) && (
+        <div className="mt-0.5 flex items-center gap-3 flex-wrap">
           {event.wikipediaUrl && (
             <a
               href={event.wikipediaUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="mt-0.5 flex items-center gap-0.5 text-xs text-primary hover:underline"
+              className="flex items-center gap-0.5 text-xs text-primary hover:underline"
               aria-label={t("see_on_wikipedia_label", { name: event.name })}
             >
               <ExternalLink className="h-3 w-3" />
               {t("see_on_wikipedia")}
             </a>
           )}
-        </div>
-        <div className="flex flex-col items-end gap-1 shrink-0">
-          {event.imageUrl && (
-            <img
-              src={event.imageUrl}
-              alt={event.name}
-              loading="lazy"
-              className="rounded aspect-[3/2] object-cover w-16"
-            />
-          )}
           {event.url && (
             <a
               href={event.url}
               target="_blank"
               rel="noopener noreferrer"
-              className="flex items-center gap-1 text-xs text-primary hover:underline"
+              className="flex items-center gap-0.5 text-xs text-primary hover:underline"
               aria-label={t("see_website_label", { name: event.name })}
             >
               <ExternalLink className="h-3 w-3" />
-              <span className="hidden sm:inline">{t("see_website")}</span>
+              {t("see_website")}
             </a>
           )}
         </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/pwa/src/components/events-panel.tsx
+++ b/pwa/src/components/events-panel.tsx
@@ -2,17 +2,22 @@
 
 import { useState } from "react";
 import { CalendarDays, ChevronDown, ChevronUp } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { EventItem } from "@/components/event-item";
 import type { EventData } from "@/lib/validation/schemas";
+
+const DEFAULT_VISIBLE = 3;
 
 interface EventsPanelProps {
   events: EventData[];
 }
 
 export function EventsPanel({ events }: EventsPanelProps) {
+  const t = useTranslations("events");
   const [expanded, setExpanded] = useState(false);
+  const [showAll, setShowAll] = useState(false);
 
   if (events.length === 0) {
     return null;
@@ -21,6 +26,9 @@ export function EventsPanel({ events }: EventsPanelProps) {
   const sorted = [...events].sort(
     (a, b) => new Date(a.startDate).getTime() - new Date(b.startDate).getTime(),
   );
+
+  const visible = showAll ? sorted : sorted.slice(0, DEFAULT_VISIBLE);
+  const hidden = sorted.length - visible.length;
 
   return (
     <div data-testid="events-panel">
@@ -44,13 +52,23 @@ export function EventsPanel({ events }: EventsPanelProps) {
       </Button>
 
       {expanded && (
-        <div
-          className="mt-2 divide-y divide-border"
-          data-testid="events-panel-content"
-        >
-          {sorted.map((event, i) => (
-            <EventItem key={`${event.name}-${i}`} event={event} />
-          ))}
+        <div className="mt-2 pl-[22px] pr-1" data-testid="events-panel-content">
+          <div className="divide-y divide-border">
+            {visible.map((event, i) => (
+              <EventItem key={`${event.name}-${i}`} event={event} />
+            ))}
+          </div>
+          {hidden > 0 && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="mt-1 h-auto px-0 py-1 text-xs text-primary hover:bg-transparent hover:underline"
+              onClick={() => setShowAll(true)}
+              data-testid="events-panel-show-more"
+            >
+              {t("show_more", { count: hidden })}
+            </Button>
+          )}
         </div>
       )}
     </div>

--- a/pwa/tests/mocked/events-panel.spec.ts
+++ b/pwa/tests/mocked/events-panel.spec.ts
@@ -45,6 +45,29 @@ function eventsFoundEvent(stageIndex: number): MercureEvent {
   };
 }
 
+function manyEventsFoundEvent(stageIndex: number, count: number): MercureEvent {
+  return {
+    type: "events_found",
+    data: {
+      stageIndex,
+      events: Array.from({ length: count }, (_, i) => ({
+        name: `Événement ${i + 1}`,
+        type: "schema:Festival",
+        lat: 44.5,
+        lon: 4.3,
+        startDate: `2025-07-${String(i + 1).padStart(2, "0")}T00:00:00+02:00`,
+        endDate: `2025-07-${String(i + 1).padStart(2, "0")}T00:00:00+02:00`,
+        url: `https://example.com/${i + 1}`,
+        description: null,
+        priceMin: null,
+        distanceToEndPoint: 100 * (i + 1),
+        source: "datatourisme",
+        wikidataId: null,
+      })),
+    },
+  };
+}
+
 test.describe("Events panel", () => {
   test("shows events panel toggle when events are present", async ({
     submitUrl,
@@ -157,6 +180,37 @@ test.describe("Events panel", () => {
 
     const stageCard = mockedPage.getByTestId("stage-card-1");
     await expect(stageCard.getByTestId("events-panel")).not.toBeAttached();
+  });
+
+  test("paginates events with a 'show more' button", async ({
+    submitUrl,
+    injectSequence,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    await injectSequence([
+      routeParsedEvent(),
+      stagesComputedEvent(),
+      manyEventsFoundEvent(0, 7),
+      tripCompleteEvent(),
+    ]);
+
+    const stageCard = mockedPage.getByTestId("stage-card-1");
+    await stageCard.getByTestId("events-panel-toggle").click();
+
+    const content = stageCard.getByTestId("events-panel-content");
+    // Only the first 3 events are shown by default.
+    await expect(content.getByText("Événement 1")).toBeVisible();
+    await expect(content.getByText("Événement 3")).toBeVisible();
+    await expect(content.getByText("Événement 4")).toHaveCount(0);
+
+    const showMore = stageCard.getByTestId("events-panel-show-more");
+    await expect(showMore).toContainText("Voir plus (4)");
+    await showMore.click();
+
+    // All events revealed; the button is gone.
+    await expect(content.getByText("Événement 7")).toBeVisible();
+    await expect(showMore).toHaveCount(0);
   });
 
   test("events are grouped by stage index", async ({


### PR DESCRIPTION
Closes #981.

## Résumé
- `event-item.tsx` : suppression du bloc description (`line-clamp-2`) et de la vignette ; pile texte unique alignée sur les alertes (nom, date · type · prix, horaires, liens Wikipedia + site, `url` conservé).
- `events-panel.tsx` : indentation `pl-[22px]` identique au corps des alertes ; pagination `DEFAULT_VISIBLE = 3` + bouton « Voir plus (N) ».
- i18n : clé `events.show_more` (fr/en).
- Test mocké de pagination (`events-panel.spec.ts`, 7 events → 3 + « Voir plus (4) » → tout).

## Vérification (legs QA)
tsc/eslint exit 0 ; prettier conforme (1 autofix committé) ; `i18n-check OK: 926 keys`.

## Auto-critique
Exclusion sans lien + tri/cap = backend #975 (pas de conflit `EventRepository`). Clé i18n disjointe de #976/#984. E2E de pagination = CI.

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 findings (0 critical, 0 warning). Clean, well-scoped frontend refactor: `EventItem`/`EventsPanel` restructured to match the alert list layout, with a `showAll`-gated pagination and matching i18n keys added consistently to both locales. The new mocked Playwright test (`events-panel.spec.ts`) covers the pagination happy path (7 events → 3 shown → "Voir plus (4)" → all shown).

**PR title check:** non-conforming — `fix(events): affichage aligné comme les alertes + pagination « voir plus »` is in French and phrased as a noun clause rather than imperative mood (contrast with the commit message itself: "align event display with alerts and add show-more pagination"). Non-blocking, but worth tightening before merge since PR titles typically become the squash-commit message.

**Review checklist:**
- [x] Code respects the project architecture (local-first frontend, no backend touch, no state persisted beyond Zustand-free local component state)
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate (no unjustified quick and dirty)
- [x] Tests cover new/changed cases (pagination path covered; no regression risk to existing single-event-list test)
- [x] Documentation is up to date (i18n key parity verified in both locales)
- [ ] Dependent tickets accounted for — `TRACKING.md` line 1706 still shows #981 as "📋 Planifiée" with no PR link; likely updated by the sprint-close tooling rather than per-PR, flagging for awareness only

**Inline comments:** No inline comments.
<!-- claude-review-end -->