### PR TITLE
feat(alerts): surligner le segment concerné sur la carte interne

### DIFF
--- a/api/src/Analyzer/Rules/SurfaceAlertAnalyzer.php
+++ b/api/src/Analyzer/Rules/SurfaceAlertAnalyzer.php
@@ -62,7 +62,7 @@ final readonly class SurfaceAlertAnalyzer implements StageAnalyzerInterface
             return [];
         }
 
-        /** @var list<array{surface?: string, tracktype?: string, smoothness?: string, length?: float}> $osmWays */
+        /** @var list<array{surface?: string, tracktype?: string, smoothness?: string, length?: float, geometry?: list<list<array{0: float, 1: float}>>}> $osmWays */
         $osmWays = $context['osmWays'] ?? [];
 
         if ([] === $osmWays) {
@@ -81,7 +81,7 @@ final readonly class SurfaceAlertAnalyzer implements StageAnalyzerInterface
     }
 
     /**
-     * @param list<array{surface?: string, tracktype?: string, smoothness?: string, length?: float}> $osmWays
+     * @param list<array{surface?: string, tracktype?: string, smoothness?: string, length?: float, geometry?: list<list<array{0: float, 1: float}>>}> $osmWays
      *
      * @return list<Alert>
      */
@@ -89,6 +89,8 @@ final readonly class SurfaceAlertAnalyzer implements StageAnalyzerInterface
     {
         $roughLength = 0.0;
         $surfaces = [];
+        /** @var list<list<array{0: float, 1: float}>> $segments */
+        $segments = [];
 
         foreach ($osmWays as $way) {
             $matched = $this->roughSurfacesOf($way);
@@ -99,6 +101,10 @@ final readonly class SurfaceAlertAnalyzer implements StageAnalyzerInterface
             $roughLength += $way['length'] ?? 0.0;
             foreach ($matched as $surface) {
                 $surfaces[$surface] = true;
+            }
+
+            foreach ($way['geometry'] ?? [] as $polyline) {
+                $segments[] = $polyline;
             }
         }
 
@@ -128,7 +134,11 @@ final readonly class SurfaceAlertAnalyzer implements StageAnalyzerInterface
             action: new AlertAction(
                 kind: AlertActionKind::NAVIGATE,
                 label: $this->translator->trans('alert.surface.action', [], 'alerts', $locale),
-                payload: ['lat' => $stage->startPoint->lat, 'lon' => $stage->startPoint->lon],
+                payload: [
+                    'lat' => $stage->startPoint->lat,
+                    'lon' => $stage->startPoint->lon,
+                    'segments' => $segments,
+                ],
             ),
         )];
     }
@@ -140,7 +150,7 @@ final readonly class SurfaceAlertAnalyzer implements StageAnalyzerInterface
      * tested. `tracktype` / `smoothness` are only a fallback: an explicit
      * `surface` always wins, so `surface=asphalt` + `smoothness=bad` is smooth.
      *
-     * @param array{surface?: string, tracktype?: string, smoothness?: string, length?: float} $way
+     * @param array{surface?: string, tracktype?: string, smoothness?: string, length?: float, geometry?: list<list<array{0: float, 1: float}>>} $way
      *
      * @return list<string>
      */

--- a/api/src/Analyzer/Rules/TrafficDangerAnalyzer.php
+++ b/api/src/Analyzer/Rules/TrafficDangerAnalyzer.php
@@ -39,7 +39,7 @@ final readonly class TrafficDangerAnalyzer implements StageAnalyzerInterface
             return [];
         }
 
-        /** @var list<array{highway?: string, cycleway?: string, 'cycleway:right'?: string, 'cycleway:left'?: string, 'cycleway:both'?: string, bicycle?: string, maxspeed?: string, length?: float, lat?: float, lon?: float}> $osmWays */
+        /** @var list<array{highway?: string, cycleway?: string, 'cycleway:right'?: string, 'cycleway:left'?: string, 'cycleway:both'?: string, bicycle?: string, maxspeed?: string, length?: float, lat?: float, lon?: float, geometry?: list<list<array{0: float, 1: float}>>}> $osmWays */
         $osmWays = $context['osmWays'] ?? [];
 
         /** @var string $locale */
@@ -102,7 +102,7 @@ final readonly class TrafficDangerAnalyzer implements StageAnalyzerInterface
                 action: new AlertAction(
                     kind: AlertActionKind::NAVIGATE,
                     label: $this->translator->trans('alert.traffic.action', [], 'alerts', $locale),
-                    payload: ['lat' => $lat, 'lon' => $lon],
+                    payload: ['lat' => $lat, 'lon' => $lon, 'segments' => $this->collectSegments($criticalSegments)],
                 ),
             );
         }
@@ -126,7 +126,7 @@ final readonly class TrafficDangerAnalyzer implements StageAnalyzerInterface
                 action: new AlertAction(
                     kind: AlertActionKind::NAVIGATE,
                     label: $this->translator->trans('alert.traffic.action', [], 'alerts', $locale),
-                    payload: ['lat' => $lat, 'lon' => $lon],
+                    payload: ['lat' => $lat, 'lon' => $lon, 'segments' => $this->collectSegments($warningSegments)],
                 ),
             );
         }
@@ -155,7 +155,7 @@ final readonly class TrafficDangerAnalyzer implements StageAnalyzerInterface
                 action: new AlertAction(
                     kind: AlertActionKind::NAVIGATE,
                     label: $this->translator->trans('alert.traffic.action', [], 'alerts', $locale),
-                    payload: ['lat' => $lat, 'lon' => $lon],
+                    payload: ['lat' => $lat, 'lon' => $lon, 'segments' => $this->collectSegments($nudgeSegments)],
                 ),
             );
         }
@@ -164,7 +164,28 @@ final readonly class TrafficDangerAnalyzer implements StageAnalyzerInterface
     }
 
     /**
-     * @param array{highway?: string, cycleway?: string, 'cycleway:right'?: string, 'cycleway:left'?: string, 'cycleway:both'?: string, bicycle?: string, maxspeed?: string, length?: float, lat?: float, lon?: float} $way
+     * Flattens the clipped geometry of the ways in one severity bucket into a
+     * single list of `[lat, lon]` polylines — the highlight payload the internal
+     * map draws for the alert (issue #982).
+     *
+     * @param list<array{geometry?: list<list<array{0: float, 1: float}>>, ...}> $ways
+     *
+     * @return list<list<array{0: float, 1: float}>>
+     */
+    private function collectSegments(array $ways): array
+    {
+        $segments = [];
+        foreach ($ways as $way) {
+            foreach ($way['geometry'] ?? [] as $polyline) {
+                $segments[] = $polyline;
+            }
+        }
+
+        return $segments;
+    }
+
+    /**
+     * @param array{highway?: string, cycleway?: string, 'cycleway:right'?: string, 'cycleway:left'?: string, 'cycleway:both'?: string, bicycle?: string, maxspeed?: string, length?: float, lat?: float, lon?: float, geometry?: list<list<array{0: float, 1: float}>>} $way
      */
     private function hasCycleInfrastructure(array $way): bool
     {

--- a/api/src/ApiResource/Model/AlertAction.php
+++ b/api/src/ApiResource/Model/AlertAction.php
@@ -17,7 +17,7 @@ final readonly class AlertAction
         #[ApiProperty(description: 'Human-readable label for the action button.', required: true)]
         public string $label,
         #[ApiProperty(
-            description: 'Machine-readable payload for the action.',
+            description: 'Machine-readable payload for the action. A `navigate` action carries `lat`/`lon` and, for the terrain rules, `segments`: the ordered geometry of the concerned road stretch as a list of `[lat, lon]` polylines, highlighted on the internal map (issue #982).',
             openapiContext: ['type' => 'object', 'additionalProperties' => true],
         )]
         public array $payload = [],

--- a/api/src/MessageHandler/AnalyzeTerrainHandler.php
+++ b/api/src/MessageHandler/AnalyzeTerrainHandler.php
@@ -124,7 +124,7 @@ final readonly class AnalyzeTerrainHandler extends AbstractTripMessageHandler
      *
      * @param list<Stage> $stages
      *
-     * @return array<int, list<array{lat: float, lon: float, surface: string, tracktype: string, smoothness: string, highway: string, cycleway: string, 'cycleway:right': string, 'cycleway:left': string, 'cycleway:both': string, bicycle: string, maxspeed: string, length: float}>>
+     * @return array<int, list<array{id: int, lat: float, lon: float, surface: string, tracktype: string, smoothness: string, highway: string, cycleway: string, 'cycleway:right': string, 'cycleway:left': string, 'cycleway:both': string, bicycle: string, maxspeed: string, length: float, geometry: list<list<array{0: float, 1: float}>>}>>
      */
     private function fetchOsmWaysByStage(string $tripId, array $stages): array
     {

--- a/api/src/MessageHandler/AnalyzeTerrainHandler.php
+++ b/api/src/MessageHandler/AnalyzeTerrainHandler.php
@@ -124,7 +124,7 @@ final readonly class AnalyzeTerrainHandler extends AbstractTripMessageHandler
      *
      * @param list<Stage> $stages
      *
-     * @return array<int, list<array{id: int, lat: float, lon: float, surface: string, tracktype: string, smoothness: string, highway: string, cycleway: string, 'cycleway:right': string, 'cycleway:left': string, 'cycleway:both': string, bicycle: string, maxspeed: string, length: float, geometry: list<list<array{0: float, 1: float}>>}>>
+     * @return array<int, list<array{lat: float, lon: float, surface: string, tracktype: string, smoothness: string, highway: string, cycleway: string, 'cycleway:right': string, 'cycleway:left': string, 'cycleway:both': string, bicycle: string, maxspeed: string, length: float, geometry: list<list<array{0: float, 1: float}>>}>>
      */
     private function fetchOsmWaysByStage(string $tripId, array $stages): array
     {

--- a/api/src/Osm/WaysRepository.php
+++ b/api/src/Osm/WaysRepository.php
@@ -28,7 +28,14 @@ use Doctrine\DBAL\Connection;
  * superset and the result is identical to the unfiltered scan. See
  * WaysIndexReadTest for the behaviour guard.
  *
- * @phpstan-type WayRow = array{lat: float, lon: float, surface: string, tracktype: string, smoothness: string, highway: string, cycleway: string, 'cycleway:right': string, 'cycleway:left': string, 'cycleway:both': string, bicycle: string, maxspeed: string, length: float}
+ * Besides the derived fields, each row carries its `osm_id` and the ordered
+ * geometry of the *clipped* portion (`ST_AsGeoJSON`) so the terrain analyzers can
+ * highlight the exact stretch of road an alert refers to on the internal map
+ * (issue #982). The geometry is a list of polylines (a clip that enters and
+ * leaves the corridor yields a MultiLineString), each a list of `[lat, lon]`
+ * pairs.
+ *
+ * @phpstan-type WayRow = array{id: int, lat: float, lon: float, surface: string, tracktype: string, smoothness: string, highway: string, cycleway: string, 'cycleway:right': string, 'cycleway:left': string, 'cycleway:both': string, bicycle: string, maxspeed: string, length: float, geometry: list<list<array{0: float, 1: float}>>}
  */
 final readonly class WaysRepository implements WaysRepositoryInterface
 {
@@ -88,9 +95,10 @@ final readonly class WaysRepository implements WaysRepositoryInterface
                 ),
                 followed AS MATERIALIZED (
                     -- Clip each candidate way to the corridor. Materialised so the
-                    -- clip runs once per way and feeds both the length and the
-                    -- centroid below.
-                    SELECT w.tags AS tags,
+                    -- clip runs once per way and feeds the length, the centroid and
+                    -- the highlight geometry below.
+                    SELECT w.osm_id AS osm_id,
+                           w.tags AS tags,
                            ST_Intersection(w.geom, r.geom) AS geom
                     FROM osm.ways AS w,
                          bbox AS b,
@@ -98,9 +106,11 @@ final readonly class WaysRepository implements WaysRepositoryInterface
                     WHERE w.geom && b.geom
                       AND ST_Intersects(w.geom, r.geom)
                 )
-                SELECT ST_Y(_c.centroid) AS lat,
+                SELECT f.osm_id AS id,
+                       ST_Y(_c.centroid) AS lat,
                        ST_X(_c.centroid) AS lon,
                        _l.length AS length,
+                       ST_AsGeoJSON(f.geom) AS geometry,
                        f.tags->>'surface' AS surface,
                        f.tags->>'tracktype' AS tracktype,
                        f.tags->>'smoothness' AS smoothness,
@@ -127,6 +137,7 @@ final readonly class WaysRepository implements WaysRepositoryInterface
         $ways = [];
         foreach ($rows as $row) {
             $ways[] = [
+                'id' => (int) $row['id'],
                 'lat' => (float) $row['lat'],
                 'lon' => (float) $row['lon'],
                 'surface' => (string) ($row['surface'] ?? ''),
@@ -140,9 +151,56 @@ final readonly class WaysRepository implements WaysRepositoryInterface
                 'bicycle' => (string) ($row['bicycle'] ?? ''),
                 'maxspeed' => (string) ($row['maxspeed'] ?? ''),
                 'length' => (float) $row['length'],
+                'geometry' => self::parseGeometry(isset($row['geometry']) ? (string) $row['geometry'] : ''),
             ];
         }
 
         return $ways;
+    }
+
+    /**
+     * Turns a GeoJSON LineString / MultiLineString (the clipped corridor portion)
+     * into a list of polylines of `[lat, lon]` pairs — the shape the frontend map
+     * highlight consumes. GeoJSON stores coordinates as `[lon, lat]`, so each pair
+     * is flipped. Anything else (empty, punctual) yields no polyline.
+     *
+     * @return list<list<array{0: float, 1: float}>>
+     */
+    public static function parseGeometry(string $geoJson): array
+    {
+        if ('' === $geoJson) {
+            return [];
+        }
+
+        /** @var array{type?: string, coordinates?: mixed} $decoded */
+        $decoded = json_decode($geoJson, true) ?: [];
+        $type = $decoded['type'] ?? '';
+        $coordinates = $decoded['coordinates'] ?? [];
+        if (!\is_array($coordinates)) {
+            return [];
+        }
+
+        // Normalise to a list of linestrings: a bare LineString is a single one.
+        $lineStrings = 'LineString' === $type ? [$coordinates] : $coordinates;
+
+        $polylines = [];
+        foreach ($lineStrings as $lineString) {
+            if (!\is_array($lineString)) {
+                continue;
+            }
+
+            $points = [];
+            foreach ($lineString as $point) {
+                if (\is_array($point) && isset($point[0], $point[1])) {
+                    $points[] = [(float) $point[1], (float) $point[0]];
+                }
+            }
+
+            if ([] !== $points) {
+                $polylines[] = $points;
+            }
+        }
+
+        return $polylines;
     }
 }

--- a/api/src/Osm/WaysRepository.php
+++ b/api/src/Osm/WaysRepository.php
@@ -28,14 +28,13 @@ use Doctrine\DBAL\Connection;
  * superset and the result is identical to the unfiltered scan. See
  * WaysIndexReadTest for the behaviour guard.
  *
- * Besides the derived fields, each row carries its `osm_id` and the ordered
- * geometry of the *clipped* portion (`ST_AsGeoJSON`) so the terrain analyzers can
- * highlight the exact stretch of road an alert refers to on the internal map
- * (issue #982). The geometry is a list of polylines (a clip that enters and
- * leaves the corridor yields a MultiLineString), each a list of `[lat, lon]`
- * pairs.
+ * Besides the derived fields, each row carries the ordered geometry of the
+ * *clipped* portion (`ST_AsGeoJSON`) so the terrain analyzers can highlight the
+ * exact stretch of road an alert refers to on the internal map (issue #982). The
+ * geometry is a list of polylines (a clip that enters and leaves the corridor
+ * yields a MultiLineString), each a list of `[lat, lon]` pairs.
  *
- * @phpstan-type WayRow = array{id: int, lat: float, lon: float, surface: string, tracktype: string, smoothness: string, highway: string, cycleway: string, 'cycleway:right': string, 'cycleway:left': string, 'cycleway:both': string, bicycle: string, maxspeed: string, length: float, geometry: list<list<array{0: float, 1: float}>>}
+ * @phpstan-type WayRow = array{lat: float, lon: float, surface: string, tracktype: string, smoothness: string, highway: string, cycleway: string, 'cycleway:right': string, 'cycleway:left': string, 'cycleway:both': string, bicycle: string, maxspeed: string, length: float, geometry: list<list<array{0: float, 1: float}>>}
  */
 final readonly class WaysRepository implements WaysRepositoryInterface
 {
@@ -97,8 +96,7 @@ final readonly class WaysRepository implements WaysRepositoryInterface
                     -- Clip each candidate way to the corridor. Materialised so the
                     -- clip runs once per way and feeds the length, the centroid and
                     -- the highlight geometry below.
-                    SELECT w.osm_id AS osm_id,
-                           w.tags AS tags,
+                    SELECT w.tags AS tags,
                            ST_Intersection(w.geom, r.geom) AS geom
                     FROM osm.ways AS w,
                          bbox AS b,
@@ -106,8 +104,7 @@ final readonly class WaysRepository implements WaysRepositoryInterface
                     WHERE w.geom && b.geom
                       AND ST_Intersects(w.geom, r.geom)
                 )
-                SELECT f.osm_id AS id,
-                       ST_Y(_c.centroid) AS lat,
+                SELECT ST_Y(_c.centroid) AS lat,
                        ST_X(_c.centroid) AS lon,
                        _l.length AS length,
                        ST_AsGeoJSON(f.geom) AS geometry,
@@ -137,7 +134,6 @@ final readonly class WaysRepository implements WaysRepositoryInterface
         $ways = [];
         foreach ($rows as $row) {
             $ways[] = [
-                'id' => (int) $row['id'],
                 'lat' => (float) $row['lat'],
                 'lon' => (float) $row['lon'],
                 'surface' => (string) ($row['surface'] ?? ''),

--- a/api/src/Osm/WaysRepositoryInterface.php
+++ b/api/src/Osm/WaysRepositoryInterface.php
@@ -12,13 +12,13 @@ interface WaysRepositoryInterface
      * smoothness, highway, cycleway*, bicycle, maxspeed) plus the centroid and the
      * length (m) of the portion inside the corridor -- not of the whole way, so a
      * way the route only brushes weighs no more than the metres actually shared
-     * with it. Each row also carries its `osm_id` and the ordered geometry of the
-     * clipped portion (list of `[lat, lon]` polylines) so an alert can highlight
-     * the concerned stretch on the internal map (issue #982).
+     * with it. Each row also carries the ordered geometry of the clipped portion
+     * (list of `[lat, lon]` polylines) so an alert can highlight the concerned
+     * stretch on the internal map (issue #982).
      *
      * @param list<array{lat: float, lon: float}> $route
      *
-     * @return list<array{id: int, lat: float, lon: float, surface: string, tracktype: string, smoothness: string, highway: string, cycleway: string, 'cycleway:right': string, 'cycleway:left': string, 'cycleway:both': string, bicycle: string, maxspeed: string, length: float, geometry: list<list<array{0: float, 1: float}>>}>
+     * @return list<array{lat: float, lon: float, surface: string, tracktype: string, smoothness: string, highway: string, cycleway: string, 'cycleway:right': string, 'cycleway:left': string, 'cycleway:both': string, bicycle: string, maxspeed: string, length: float, geometry: list<list<array{0: float, 1: float}>>}>
      */
     public function findInCorridor(array $route, int $radiusMeters): array;
 }

--- a/api/src/Osm/WaysRepositoryInterface.php
+++ b/api/src/Osm/WaysRepositoryInterface.php
@@ -12,11 +12,13 @@ interface WaysRepositoryInterface
      * smoothness, highway, cycleway*, bicycle, maxspeed) plus the centroid and the
      * length (m) of the portion inside the corridor -- not of the whole way, so a
      * way the route only brushes weighs no more than the metres actually shared
-     * with it.
+     * with it. Each row also carries its `osm_id` and the ordered geometry of the
+     * clipped portion (list of `[lat, lon]` polylines) so an alert can highlight
+     * the concerned stretch on the internal map (issue #982).
      *
      * @param list<array{lat: float, lon: float}> $route
      *
-     * @return list<array{lat: float, lon: float, surface: string, tracktype: string, smoothness: string, highway: string, cycleway: string, 'cycleway:right': string, 'cycleway:left': string, 'cycleway:both': string, bicycle: string, maxspeed: string, length: float}>
+     * @return list<array{id: int, lat: float, lon: float, surface: string, tracktype: string, smoothness: string, highway: string, cycleway: string, 'cycleway:right': string, 'cycleway:left': string, 'cycleway:both': string, bicycle: string, maxspeed: string, length: float, geometry: list<list<array{0: float, 1: float}>>}>
      */
     public function findInCorridor(array $route, int $radiusMeters): array;
 }

--- a/api/tests/Integration/Osm/WaysIndexReadTest.php
+++ b/api/tests/Integration/Osm/WaysIndexReadTest.php
@@ -83,6 +83,31 @@ final class WaysIndexReadTest extends KernelTestCase
     }
 
     /**
+     * The alert map highlight (issue #982) needs the way's osm_id and the ordered
+     * geometry of the clipped portion, projected as `[lat, lon]` polylines.
+     */
+    #[Test]
+    public function findInCorridorProjectsIdAndClippedGeometry(): void
+    {
+        $ways = new WaysRepository($this->connection)->findInCorridor(self::CORRIDOR_ROUTE, self::RADIUS_METERS);
+
+        self::assertCount(1, $ways);
+        $way = $ways[0];
+
+        self::assertSame(1, $way['id']);
+        // One clipped polyline, running end to end inside the corridor.
+        self::assertCount(1, $way['geometry']);
+        $polyline = $way['geometry'][0];
+        self::assertGreaterThanOrEqual(2, \count($polyline));
+        // Coordinates are flipped from GeoJSON [lon, lat] to [lat, lon] and land
+        // on the seeded secondary road (~49.6, ~6.13-6.15).
+        foreach ($polyline as [$lat, $lon]) {
+            self::assertEqualsWithDelta(49.61, $lat, 0.02);
+            self::assertEqualsWithDelta(6.14, $lon, 0.02);
+        }
+    }
+
+    /**
      * The surface analyzer falls back on tracktype / smoothness when `surface` is
      * missing, so both tags must reach it from the jsonb column (issue #860).
      */
@@ -227,13 +252,15 @@ final class WaysIndexReadTest extends KernelTestCase
                     SELECT ST_Buffer(ST_SetSRID(ST_GeomFromText(:wkt), 4326)::geography, :radius)::geometry AS geom
                 ),
                 followed AS MATERIALIZED (
-                    SELECT w.tags AS tags, ST_Intersection(w.geom, r.geom) AS geom
+                    SELECT w.osm_id AS osm_id, w.tags AS tags, ST_Intersection(w.geom, r.geom) AS geom
                     FROM osm.ways AS w, ridden AS r
                     WHERE ST_Intersects(w.geom, r.geom)
                 )
-                SELECT ST_Y(_c.centroid) AS lat,
+                SELECT f.osm_id AS id,
+                       ST_Y(_c.centroid) AS lat,
                        ST_X(_c.centroid) AS lon,
                        _l.length AS length,
+                       ST_AsGeoJSON(f.geom) AS geometry,
                        tags->>'surface' AS surface,
                        tags->>'tracktype' AS tracktype,
                        tags->>'smoothness' AS smoothness,
@@ -258,6 +285,7 @@ final class WaysIndexReadTest extends KernelTestCase
         $ways = [];
         foreach ($rows as $row) {
             $ways[] = [
+                'id' => (int) $row['id'],
                 'lat' => (float) $row['lat'],
                 'lon' => (float) $row['lon'],
                 'surface' => (string) ($row['surface'] ?? ''),
@@ -271,6 +299,7 @@ final class WaysIndexReadTest extends KernelTestCase
                 'bicycle' => (string) ($row['bicycle'] ?? ''),
                 'maxspeed' => (string) ($row['maxspeed'] ?? ''),
                 'length' => (float) $row['length'],
+                'geometry' => WaysRepository::parseGeometry(isset($row['geometry']) ? (string) $row['geometry'] : ''),
             ];
         }
 

--- a/api/tests/Integration/Osm/WaysIndexReadTest.php
+++ b/api/tests/Integration/Osm/WaysIndexReadTest.php
@@ -83,18 +83,17 @@ final class WaysIndexReadTest extends KernelTestCase
     }
 
     /**
-     * The alert map highlight (issue #982) needs the way's osm_id and the ordered
-     * geometry of the clipped portion, projected as `[lat, lon]` polylines.
+     * The alert map highlight (issue #982) needs the ordered geometry of the
+     * clipped portion, projected as `[lat, lon]` polylines.
      */
     #[Test]
-    public function findInCorridorProjectsIdAndClippedGeometry(): void
+    public function findInCorridorProjectsTheClippedGeometry(): void
     {
         $ways = new WaysRepository($this->connection)->findInCorridor(self::CORRIDOR_ROUTE, self::RADIUS_METERS);
 
         self::assertCount(1, $ways);
         $way = $ways[0];
 
-        self::assertSame(1, $way['id']);
         // One clipped polyline, running end to end inside the corridor.
         self::assertCount(1, $way['geometry']);
         $polyline = $way['geometry'][0];
@@ -252,12 +251,11 @@ final class WaysIndexReadTest extends KernelTestCase
                     SELECT ST_Buffer(ST_SetSRID(ST_GeomFromText(:wkt), 4326)::geography, :radius)::geometry AS geom
                 ),
                 followed AS MATERIALIZED (
-                    SELECT w.osm_id AS osm_id, w.tags AS tags, ST_Intersection(w.geom, r.geom) AS geom
+                    SELECT w.tags AS tags, ST_Intersection(w.geom, r.geom) AS geom
                     FROM osm.ways AS w, ridden AS r
                     WHERE ST_Intersects(w.geom, r.geom)
                 )
-                SELECT f.osm_id AS id,
-                       ST_Y(_c.centroid) AS lat,
+                SELECT ST_Y(_c.centroid) AS lat,
                        ST_X(_c.centroid) AS lon,
                        _l.length AS length,
                        ST_AsGeoJSON(f.geom) AS geometry,
@@ -285,7 +283,6 @@ final class WaysIndexReadTest extends KernelTestCase
         $ways = [];
         foreach ($rows as $row) {
             $ways[] = [
-                'id' => (int) $row['id'],
                 'lat' => (float) $row['lat'],
                 'lon' => (float) $row['lon'],
                 'surface' => (string) ($row['surface'] ?? ''),

--- a/api/tests/Unit/Analyzer/SurfaceAlertAnalyzerTest.php
+++ b/api/tests/Unit/Analyzer/SurfaceAlertAnalyzerTest.php
@@ -99,6 +99,30 @@ final class SurfaceAlertAnalyzerTest extends TestCase
         $this->assertSame(AlertActionKind::NAVIGATE, $alerts[0]->action->kind);
         $this->assertEqualsWithDelta($stage->startPoint->lat, $alerts[0]->action->payload['lat'], 0.001);
         $this->assertEqualsWithDelta($stage->startPoint->lon, $alerts[0]->action->payload['lon'], 0.001);
+        // No geometry on the way → no highlight segment (issue #982).
+        $this->assertSame([], $alerts[0]->action->payload['segments']);
+    }
+
+    #[Test]
+    public function navigateActionCarriesTheConcernedRoughSegments(): void
+    {
+        $stage = $this->createStage();
+
+        $alerts = $this->analyzer->analyze($stage, [
+            'osmWays' => [
+                ['surface' => 'gravel', 'length' => 300.0, 'geometry' => [[[45.0, 5.0], [45.1, 5.1]]]],
+                // Smooth way: its geometry must NOT be highlighted.
+                ['surface' => 'asphalt', 'length' => 9000.0, 'geometry' => [[[45.5, 5.5], [45.6, 5.6]]]],
+                ['surface' => 'dirt', 'length' => 300.0, 'geometry' => [[[45.2, 5.2], [45.3, 5.3]]]],
+            ],
+        ]);
+
+        $this->assertCount(1, $alerts);
+        $this->assertNotNull($alerts[0]->action);
+        $this->assertSame(
+            [[[45.0, 5.0], [45.1, 5.1]], [[45.2, 5.2], [45.3, 5.3]]],
+            $alerts[0]->action->payload['segments'],
+        );
     }
 
     /**

--- a/api/tests/Unit/Analyzer/TrafficDangerAnalyzerTest.php
+++ b/api/tests/Unit/Analyzer/TrafficDangerAnalyzerTest.php
@@ -330,6 +330,31 @@ final class TrafficDangerAnalyzerTest extends TestCase
     }
 
     #[Test]
+    public function navigateActionCarriesTheConcernedSegmentsPerSeverity(): void
+    {
+        $stage = $this->createStage();
+
+        $alerts = $this->analyzer->analyze($stage, [
+            'osmWays' => [
+                ['highway' => 'primary', 'length' => 600.0, 'geometry' => [[[45.5, 5.5], [45.6, 5.6]]]],
+                ['highway' => 'primary', 'length' => 700.0, 'geometry' => [[[45.7, 5.7], [45.8, 5.8]]]],
+                ['highway' => 'secondary', 'maxspeed' => '90', 'length' => 800.0, 'geometry' => [[[46.0, 6.0], [46.1, 6.1]]]],
+            ],
+        ]);
+
+        $this->assertCount(2, $alerts);
+        // Critical bucket: both primary segments.
+        $this->assertNotNull($alerts[0]->action);
+        $this->assertSame(
+            [[[45.5, 5.5], [45.6, 5.6]], [[45.7, 5.7], [45.8, 5.8]]],
+            $alerts[0]->action->payload['segments'],
+        );
+        // Warning bucket: only the fast secondary segment.
+        $this->assertNotNull($alerts[1]->action);
+        $this->assertSame([[[46.0, 6.0], [46.1, 6.1]]], $alerts[1]->action->payload['segments']);
+    }
+
+    #[Test]
     public function fallsBackToStageStartPointWhenNoCoords(): void
     {
         $stage = $this->createStage();

--- a/api/tests/Unit/Osm/WaysRepositoryParseGeometryTest.php
+++ b/api/tests/Unit/Osm/WaysRepositoryParseGeometryTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Osm;
+
+use App\Osm\WaysRepository;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Direct coverage of the pure GeoJSON parsing, without a Postgres fixture: the
+ * integration test only ever produces a single clipped LineString, so the
+ * MultiLineString and the defensive branches are exercised here.
+ */
+final class WaysRepositoryParseGeometryTest extends TestCase
+{
+    #[Test]
+    public function splitsAMultiLineStringIntoPolylinesAndFlipsToLatLon(): void
+    {
+        $geoJson = '{"type":"MultiLineString","coordinates":[[[6.14,49.61],[6.15,49.62]],[[6.20,49.65],[6.21,49.66]]]}';
+
+        self::assertSame(
+            [[[49.61, 6.14], [49.62, 6.15]], [[49.65, 6.20], [49.66, 6.21]]],
+            WaysRepository::parseGeometry($geoJson),
+        );
+    }
+
+    #[Test]
+    public function wrapsABareLineStringAsASinglePolyline(): void
+    {
+        $geoJson = '{"type":"LineString","coordinates":[[6.14,49.61],[6.15,49.62]]}';
+
+        self::assertSame(
+            [[[49.61, 6.14], [49.62, 6.15]]],
+            WaysRepository::parseGeometry($geoJson),
+        );
+    }
+
+    /**
+     * @param string $geoJson a geometry a corridor-boundary graze can produce
+     */
+    #[Test]
+    #[DataProvider('degenerateGeometries')]
+    public function yieldsNoPolylineForNonLineGeometry(string $geoJson): void
+    {
+        self::assertSame([], WaysRepository::parseGeometry($geoJson));
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function degenerateGeometries(): iterable
+    {
+        yield 'empty string' => [''];
+        yield 'malformed json' => ['{not json'];
+        yield 'point' => ['{"type":"Point","coordinates":[6.14,49.61]}'];
+        yield 'non-array coordinates' => ['{"type":"LineString","coordinates":null}'];
+        yield 'geometry collection (no coordinates)' => ['{"type":"GeometryCollection","geometries":[]}'];
+    }
+}

--- a/pwa/src/components/Map/MapView.tsx
+++ b/pwa/src/components/Map/MapView.tsx
@@ -233,6 +233,8 @@ export const MapView = memo(function MapView({
 
   const storeStages = useTripStore((s) => s.stages);
   const stages = externalStages ?? storeStages;
+  const focusedAlertSegment = useTripStore((s) => s.focusedAlertSegment);
+  const setFocusedAlertSegment = useTripStore((s) => s.setFocusedAlertSegment);
   const hoveredAccommodation = useUiStore((s) => s.hoveredAccommodation);
   const setHoveredAccommodation = useUiStore((s) => s.setHoveredAccommodation);
   const { resolvedTheme } = useTheme();
@@ -298,6 +300,27 @@ export const MapView = memo(function MapView({
           source: "route",
           layout: { "line-join": "round", "line-cap": "round" },
           paint: { "line-color": "rgba(0,0,0,0)", "line-width": 16 },
+        });
+      }
+      // Highlight layer for the road stretch an alert refers to (issue #982),
+      // drawn on top of the route line. Empty until an alert action fires.
+      if (!map.getSource("alert-segment")) {
+        map.addSource("alert-segment", {
+          type: "geojson",
+          data: { type: "FeatureCollection", features: [] },
+        });
+      }
+      if (!map.getLayer("alert-segment-line")) {
+        map.addLayer({
+          id: "alert-segment-line",
+          type: "line",
+          source: "alert-segment",
+          layout: { "line-join": "round", "line-cap": "round" },
+          paint: {
+            "line-color": "#ef4444",
+            "line-width": 7,
+            "line-opacity": 0.9,
+          },
         });
       }
     },
@@ -608,6 +631,64 @@ export const MapView = memo(function MapView({
     }
   }, [focusedStageIndex, activeStages, mapReady]);
 
+  // Highlight the road stretch an alert refers to and frame it (issue #982).
+  // A single-point "segment" (a coordinate-only navigate alert) draws no line
+  // but still recenters the map on it.
+  useEffect(() => {
+    if (!mapRef.current || !mapReady) return;
+    const map = mapRef.current;
+    const source = map.getSource("alert-segment") as
+      maplibregl.GeoJSONSource | undefined;
+    if (!source) return;
+
+    if (!focusedAlertSegment || focusedAlertSegment.length === 0) {
+      source.setData({ type: "FeatureCollection", features: [] });
+      return;
+    }
+
+    source.setData({
+      type: "FeatureCollection",
+      features: focusedAlertSegment
+        .filter((seg) => seg.length >= 2)
+        .map((seg) => ({
+          type: "Feature",
+          properties: {},
+          geometry: {
+            type: "LineString",
+            coordinates: seg.map(([lat, lon]) => [lon, lat]),
+          },
+        })),
+    });
+
+    let minLng = Infinity,
+      maxLng = -Infinity,
+      minLat = Infinity,
+      maxLat = -Infinity;
+    for (const seg of focusedAlertSegment) {
+      for (const [lat, lon] of seg) {
+        if (lon < minLng) minLng = lon;
+        if (lon > maxLng) maxLng = lon;
+        if (lat < minLat) minLat = lat;
+        if (lat > maxLat) maxLat = lat;
+      }
+    }
+    if (minLng !== Infinity) {
+      map.fitBounds(
+        [
+          [minLng, minLat],
+          [maxLng, maxLat],
+        ],
+        { padding: 80, maxZoom: 15, duration: 600 },
+      );
+    }
+  }, [focusedAlertSegment, mapReady]);
+
+  // Focusing a stage supersedes an alert-segment highlight: clear it so the two
+  // camera framings never fight (issue #982).
+  useEffect(() => {
+    if (focusedStageIndex !== null) setFocusedAlertSegment(null);
+  }, [focusedStageIndex, setFocusedAlertSegment]);
+
   // Hover highlight — toggle CSS class on accommodation markers without rebuilding
   useEffect(() => {
     for (const el of accMarkerElementsRef.current.values()) {
@@ -694,7 +775,11 @@ export const MapView = memo(function MapView({
   }
 
   return (
-    <div className="relative w-full h-full" data-testid="map-view">
+    <div
+      className="relative w-full h-full"
+      data-testid="map-view"
+      data-alert-segment={focusedAlertSegment ? focusedAlertSegment.length : ""}
+    >
       <div
         ref={mapContainerRef}
         className="w-full h-full rounded-xl overflow-hidden"
@@ -707,10 +792,13 @@ export const MapView = memo(function MapView({
         className="absolute top-3 left-3 z-10"
       />
 
-      {focusedStageIndex !== null && (
+      {(focusedStageIndex !== null || focusedAlertSegment !== null) && (
         <button
           type="button"
-          onClick={onResetView}
+          onClick={() => {
+            setFocusedAlertSegment(null);
+            onResetView();
+          }}
           className="absolute top-14 left-3 z-10 bg-background/90 backdrop-blur-sm border border-border text-foreground text-xs font-medium px-3 py-1.5 rounded-lg shadow-sm hover:bg-accent transition-colors cursor-pointer"
           aria-label={t("resetView")}
           data-testid="map-reset-view"

--- a/pwa/src/components/alert-action-button.tsx
+++ b/pwa/src/components/alert-action-button.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Sparkles, Shuffle, Compass, X, type LucideIcon } from "lucide-react";
+import { Sparkles, Shuffle, Map, X, type LucideIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { trackEvent } from "@/lib/plausible";
@@ -15,7 +15,9 @@ import type { AlertActionData } from "@/lib/validation/schemas";
 const ACTION_ICON: Record<AlertActionData["kind"], LucideIcon> = {
   auto_fix: Sparkles,
   detour: Shuffle,
-  navigate: Compass,
+  // `navigate` highlights the concerned road stretch on the internal map
+  // (issue #982): a map icon, not the old external-link compass.
+  navigate: Map,
   dismiss: X,
 };
 
@@ -65,8 +67,8 @@ export function AlertActionButton({
         className,
       )}
     >
-      <Icon className="h-3 w-3" aria-hidden="true" />
       <span>{action.label}</span>
+      <Icon className="h-3 w-3" aria-hidden="true" />
     </Button>
   );
 }

--- a/pwa/src/components/alert-list.tsx
+++ b/pwa/src/components/alert-list.tsx
@@ -16,6 +16,7 @@ import {
 import { cn } from "@/lib/utils";
 import type { AlertActionData, AlertData } from "@/lib/validation/schemas";
 import { normalizeExternalUrl } from "@/lib/validation/url";
+import { useTripStore } from "@/store/trip-store";
 
 interface AlertListProps {
   alerts: AlertData[];
@@ -94,6 +95,7 @@ function groupBySeverity(
 export function AlertList({ alerts, onAddPoiWaypoint }: AlertListProps) {
   const t = useTranslations("alertList");
   const [dismissedKeys, setDismissedKeys] = useState<Set<string>>(new Set());
+  const setFocusedAlertSegment = useTripStore((s) => s.setFocusedAlertSegment);
 
   const handleDismiss = useCallback((key: string) => {
     setDismissedKeys((prev) => {
@@ -110,16 +112,15 @@ export function AlertList({ alerts, onAddPoiWaypoint }: AlertListProps) {
           handleDismiss(key);
           break;
         case "navigate": {
-          const payload = action.payload as { lat?: number; lon?: number };
-          if (
-            typeof payload?.lat === "number" &&
-            typeof payload?.lon === "number"
-          ) {
-            window.open(
-              `https://www.openstreetmap.org/?mlat=${payload.lat}&mlon=${payload.lon}&zoom=15`,
-              "_blank",
-              "noopener,noreferrer",
-            );
+          // Highlight the concerned road stretch on the internal map (issue
+          // #982) — no more OpenStreetMap external tab. Terrain rules ship the
+          // full geometry as `segments`; alerts carrying only a point (e.g. a
+          // stage discontinuity) recenter the map on that single coordinate.
+          const { lat, lon, segments } = action.payload;
+          if (segments && segments.length > 0) {
+            setFocusedAlertSegment(segments);
+          } else if (typeof lat === "number" && typeof lon === "number") {
+            setFocusedAlertSegment([[[lat, lon]]] as [number, number][][]);
           }
           break;
         }
@@ -131,7 +132,7 @@ export function AlertList({ alerts, onAddPoiWaypoint }: AlertListProps) {
           break;
       }
     },
-    [handleDismiss],
+    [handleDismiss, setFocusedAlertSegment],
   );
 
   const groups = useMemo(() => groupBySeverity(alerts), [alerts]);
@@ -212,15 +213,18 @@ export function AlertList({ alerts, onAddPoiWaypoint }: AlertListProps) {
                       </span>
                     )}
                     <AlertBadge type={alert.type} message={alert.message} />
-                    {action && !isDismissed && (
-                      <AlertActionButton
-                        action={action}
-                        disabled={isActionDisabled}
-                        onClick={() => handleAction(key, action)}
-                        className="ml-auto"
-                      />
-                    )}
                   </div>
+
+                  {/* Below the alert text, not on the badge row (recette point
+                      5): the action reads as a follow-up to the message. */}
+                  {action && !isDismissed && (
+                    <AlertActionButton
+                      action={action}
+                      disabled={isActionDisabled}
+                      onClick={() => handleAction(key, action)}
+                      className="self-start"
+                    />
+                  )}
 
                   {isCulturalPoiAlert(alert) && (
                     <div className="ml-1 flex flex-col gap-0.5">

--- a/pwa/src/lib/api/schema.d.ts
+++ b/pwa/src/lib/api/schema.d.ts
@@ -944,7 +944,7 @@ export interface components {
             kind: "auto_fix" | "detour" | "navigate" | "dismiss";
             /** @description Human-readable label for the action button. */
             label: string;
-            /** @description Machine-readable payload for the action. */
+            /** @description Machine-readable payload for the action. A `navigate` action carries `lat`/`lon` and, for the terrain rules, `segments`: the ordered geometry of the concerned road stretch as a list of `[lat, lon]` polylines, highlighted on the internal map (issue #982). */
             payload?: {
                 [key: string]: unknown;
             };
@@ -957,7 +957,7 @@ export interface components {
             kind: "auto_fix" | "detour" | "navigate" | "dismiss";
             /** @description Human-readable label for the action button. */
             label: string;
-            /** @description Machine-readable payload for the action. */
+            /** @description Machine-readable payload for the action. A `navigate` action carries `lat`/`lon` and, for the terrain rules, `segments`: the ordered geometry of the concerned road stretch as a list of `[lat, lon]` polylines, highlighted on the internal map (issue #982). */
             payload?: {
                 [key: string]: unknown;
             };
@@ -970,7 +970,7 @@ export interface components {
             kind: "auto_fix" | "detour" | "navigate" | "dismiss";
             /** @description Human-readable label for the action button. */
             label: string;
-            /** @description Machine-readable payload for the action. */
+            /** @description Machine-readable payload for the action. A `navigate` action carries `lat`/`lon` and, for the terrain rules, `segments`: the ordered geometry of the concerned road stretch as a list of `[lat, lon]` polylines, highlighted on the internal map (issue #982). */
             payload?: {
                 [key: string]: unknown;
             };

--- a/pwa/src/lib/validation/schemas.ts
+++ b/pwa/src/lib/validation/schemas.ts
@@ -7,10 +7,22 @@ export const CoordinateSchema = z.object({
   ele: z.number().default(0),
 });
 
+// A single highlighted road stretch: an ordered list of [lat, lon] points.
+export const AlertSegmentSchema = z.array(z.tuple([z.number(), z.number()]));
+
 export const AlertActionSchema = z.object({
   kind: z.enum(["auto_fix", "detour", "navigate", "dismiss"]),
   label: z.string(),
-  payload: z.record(z.string(), z.unknown()).optional().default({}),
+  // `segments` carries the geometry of the concerned road stretch for the
+  // internal-map highlight (issue #982); other keys (lat/lon) stay loose.
+  payload: z
+    .looseObject({
+      lat: z.number().optional(),
+      lon: z.number().optional(),
+      segments: z.array(AlertSegmentSchema).optional(),
+    })
+    .optional()
+    .default({}),
 });
 
 export const AlertSchema = z.object({

--- a/pwa/src/store/trip-store.ts
+++ b/pwa/src/store/trip-store.ts
@@ -118,6 +118,13 @@ interface TripState {
    */
   selectedStageIndex: number;
 
+  /**
+   * Road stretch highlighted on the internal map after clicking an alert's
+   * "see the segment on the map" action (issue #982). A list of polylines, each
+   * an ordered list of `[lat, lon]` points. `null` = nothing highlighted.
+   */
+  focusedAlertSegment: [number, number][][] | null;
+
   setTrip: (trip: TripIdentity) => void;
   updateRouteData: (data: {
     totalDistance: number;
@@ -266,6 +273,9 @@ interface TripState {
    */
   setSelectedStageIndex: (index: number) => void;
 
+  /** Highlight (or clear, with `null`) a road stretch on the internal map. */
+  setFocusedAlertSegment: (segments: [number, number][][] | null) => void;
+
   clearTrip: () => void;
 }
 
@@ -297,6 +307,7 @@ const initialState = {
   selectedStageIndex: 0,
   aiOverview: null as TripAiOverviewPayload | null,
   aiOverviewStale: false,
+  focusedAlertSegment: null as [number, number][][] | null,
 };
 
 /**
@@ -964,6 +975,11 @@ export const useTripStore = create<TripState>()(
           ? Math.min(Math.max(0, Math.floor(index)), max)
           : 0;
         state.selectedStageIndex = safe;
+      }),
+
+    setFocusedAlertSegment: (segments) =>
+      set((state) => {
+        state.focusedAlertSegment = segments;
       }),
 
     clearTrip: () => {

--- a/pwa/tests/fixtures/mock-data.ts
+++ b/pwa/tests/fixtures/mock-data.ts
@@ -349,6 +349,45 @@ export function calendarAlertsEvent(): MercureEvent {
   };
 }
 
+/**
+ * A critical terrain alert whose `navigate` action carries the geometry of the
+ * concerned road stretch (`segments`), highlighted on the internal map — the
+ * post-#982 contract that replaces the old OSM external link.
+ */
+export function terrainAlertWithSegmentsEvent(): MercureEvent {
+  return {
+    type: "terrain_alerts",
+    data: {
+      alertsByStage: {
+        "0": [
+          {
+            type: "critical",
+            code: "traffic_main_road",
+            message: "1 segment on main road without bike lane (1.2 km)",
+            lat: 44.6,
+            lon: 4.5,
+            action: {
+              kind: "navigate",
+              label: "See the segment on the map",
+              payload: {
+                lat: 44.6,
+                lon: 4.5,
+                segments: [
+                  [
+                    [44.6, 4.5],
+                    [44.58, 4.48],
+                    [44.55, 4.45],
+                  ],
+                ],
+              },
+            },
+          },
+        ],
+      },
+    },
+  };
+}
+
 export function alertsWithActionsEvent(): MercureEvent {
   return {
     type: "terrain_alerts",

--- a/pwa/tests/mocked/alert-actions.spec.ts
+++ b/pwa/tests/mocked/alert-actions.spec.ts
@@ -172,6 +172,42 @@ test.describe("Alert actions", () => {
     await expect(mapView).toHaveAttribute("data-alert-segment", "");
   });
 
+  test("navigate on a point-only alert recenters the internal map (no OSM tab)", async ({
+    submitUrl,
+    injectSequence,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    await injectSequence([
+      routeParsedEvent(),
+      stagesComputedEvent(),
+      // The discontinuity alert carries only a point (lat/lon), no `segments`.
+      terrainAlertsWithServerFilteredActionsEvent(),
+      tripCompleteEvent(),
+    ]);
+
+    const mapView = mockedPage.getByTestId("map-view");
+    await expect(mapView).toHaveAttribute("data-alert-segment", "");
+
+    // A blank tab would open on window.open; assert none is created.
+    let openedExternally = false;
+    mockedPage.on("popup", () => {
+      openedExternally = true;
+    });
+
+    const stage1 = mockedPage.getByTestId("stage-card-1");
+    await stage1.getByText("Show the discontinuity on the map").click();
+
+    // The point recenters the internal map (a single one-coordinate focus) and the
+    // reset affordance appears — the OSM external tab is gone (#982).
+    await expect(mapView).toHaveAttribute("data-alert-segment", "1");
+    await expect(mockedPage.getByTestId("map-reset-view")).toBeVisible();
+    expect(openedExternally).toBe(false);
+
+    await mockedPage.getByTestId("map-reset-view").click();
+    await expect(mapView).toHaveAttribute("data-alert-segment", "");
+  });
+
   test("detour action button is displayed and disabled", async ({
     submitUrl,
     injectSequence,

--- a/pwa/tests/mocked/alert-actions.spec.ts
+++ b/pwa/tests/mocked/alert-actions.spec.ts
@@ -4,6 +4,7 @@ import {
   stagesComputedEvent,
   alertsWithActionsEvent,
   terrainAlertsEvent,
+  terrainAlertWithSegmentsEvent,
   terrainAlertsWithServerFilteredActionsEvent,
   tripCompleteEvent,
 } from "../fixtures/mock-data";
@@ -138,6 +139,37 @@ test.describe("Alert actions", () => {
     await stage2.getByTestId("alert-group-toggle-warning").click();
     await expect(stage2).toContainText("Significant elevation gain (1200m)");
     await expect(stage2.getByTestId("alert-action-button")).toHaveCount(0);
+  });
+
+  test("navigate action highlights the concerned segment on the internal map", async ({
+    submitUrl,
+    injectSequence,
+    mockedPage,
+  }) => {
+    await submitUrl();
+    await injectSequence([
+      routeParsedEvent(),
+      stagesComputedEvent(),
+      terrainAlertWithSegmentsEvent(),
+      tripCompleteEvent(),
+    ]);
+
+    // The critical group is expanded by default; the map starts with nothing
+    // highlighted.
+    const mapView = mockedPage.getByTestId("map-view");
+    await expect(mapView).toHaveAttribute("data-alert-segment", "");
+
+    const stage1 = mockedPage.getByTestId("stage-card-1");
+    await stage1.getByText("See the segment on the map").click();
+
+    // The clicked segment is now highlighted (one polyline) and the reset-view
+    // affordance appears — no external OSM tab is opened.
+    await expect(mapView).toHaveAttribute("data-alert-segment", "1");
+    await expect(mockedPage.getByTestId("map-reset-view")).toBeVisible();
+
+    // Resetting clears the highlight.
+    await mockedPage.getByTestId("map-reset-view").click();
+    await expect(mapView).toHaveAttribute("data-alert-segment", "");
   });
 
   test("detour action button is displayed and disabled", async ({


### PR DESCRIPTION
Closes #982.

## Résumé
**Backend** : `WaysRepository`/`WayRow` portent `id` + géométrie ordonnée (`ST_AsGeoJSON`, MultiLineString-aware, flip `[lon,lat]→[lat,lon]`) ; `SurfaceAlertAnalyzer` (agrégat) et `TrafficDangerAnalyzer` (par bucket de sévérité) collectent les tronçons dans `AlertAction.payload['segments']`.
**Frontend** : `schemas.ts` porte `segments` ; `alert-action-button.tsx` icône `Map` après le texte ; `alert-list.tsx` sort le bouton de la ligne du badge (`flex-col`, sous le message) et l'action `navigate` pose `focusedAlertSegment` (store) au lieu d'ouvrir OSM ; `MapView.tsx` ajoute source/layer GeoJSON surlignée + `fitBounds` + reset.

## Tests
Unit backend (collecte géométrie + analyzers) ; intégration (id + géométrie clippée) ; e2e mocké (`alert-actions.spec.ts` : clic → `data-alert-segment`, reset). Négatif prouvé (segments à zéro → rouge, restauré).

## Vérification (legs QA)
PHP-CS-Fixer `Fixed 0` ; Rector `[OK]` (2 autofixes committés) ; PHPStan L9 `[OK] No errors` ; tsc/eslint clean ; prettier conforme (1 autofix) ; `i18n-check OK: 925 keys` ; PHPUnit `OK, 1514 tests` ; vitest 5 passed.

## Auto-critique
DTO modifié (`AlertAction`) → `schema.d.ts` régénéré, **diff confiné à la section AlertAction** (section Event de #975 intacte). **Aucun `AlertCode` ajouté/modifié** → README/table alertes intacts (pas de conflit avec #983). Playwright/Functional = CI.

<!-- claude-review-start -->
## Claude Review

**Summary:** 1 finding (suggestion, non-blocking). Both findings from the previous review (unused `osm_id`/`id` column, untested `parseGeometry` branches) are fixed by the `refactor(osm)` follow-up commit; their threads are resolved and the superseded review dismissed.

**Resolved threads:** Resolved 2 previously open threads — the unused `osm_id`/`id` column has been dropped end-to-end, and `WaysRepositoryParseGeometryTest` now directly covers the MultiLineString / malformed-GeoJSON branches.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** Posted 1 inline comment.

**Commit reviewed:** 6c151b448711133f6ca971bf0bdd8b408ffc8bce
<!-- claude-review-end -->