### PR TITLE
feat(provisioning): ajouter OpenAgenda comme source d'événements

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -524,6 +524,13 @@ services:
       # skipped gracefully (OSM still provisions).
       DATATOURISME_FLUX_ID: "${DATATOURISME_FLUX_ID:-}"
       DATATOURISME_APP_KEY: "${DATATOURISME_APP_KEY:-}"
+      # OpenAgenda events source (ADR-051). The dataset slug of the Opendatasoft
+      # "evenements-publics-openagenda" export; when set, the provisioner streams the
+      # national JSONL export and promotes the zone's events with source='openagenda'.
+      # When absent the OpenAgenda step is skipped (OSM + DataTourisme still provision).
+      # OPENAGENDA_API_KEY is optional (the public export needs none).
+      OPENAGENDA_DATASET: "${OPENAGENDA_DATASET:-}"
+      OPENAGENDA_API_KEY: "${OPENAGENDA_API_KEY:-}"
     # One-shot OSM extract + PostGIS import; osm2pgsql needs more headroom than
     # the osmium merge (in-RAM node cache bounded via --cache). See ADR-040.
     deploy:

--- a/docs/legal-and-licensing.md
+++ b/docs/legal-and-licensing.md
@@ -25,6 +25,7 @@ The app combines several open datasets; each keeps its own licence and attributi
 |---|---|---|
 | OpenStreetMap (PostGIS index, Valhalla tiles) | [ODbL 1.0](https://opendatacommons.org/licenses/odbl/) | Display "© OpenStreetMap contributors" (rendered on the map) |
 | DataTourisme | [Licence Ouverte 2.0](https://www.etalab.gouv.fr/licence-ouverte-open-licence) | Credit the source; commercial use and modification allowed |
+| OpenAgenda (events) | [Licence Ouverte 2.0](https://www.etalab.gouv.fr/licence-ouverte-open-licence) | Credit the source; commercial use and modification allowed |
 | Wikidata | [CC0 1.0](https://creativecommons.org/publicdomain/zero/1.0/) | Public domain — no attribution required |
 | Open-Meteo | [CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/) | Credit Open-Meteo |
 

--- a/docs/runbooks/secrets-inventory.md
+++ b/docs/runbooks/secrets-inventory.md
@@ -26,6 +26,7 @@ Pour la rotation : voir [secrets-rotation.md](secrets-rotation.md).
 | `DATABASE_NAME` | Nom de base | Coolify env | `php`, `worker`, `database` | Oui | Statique | ADR-022 |
 | `MAILER_DSN` | DSN Resend (contient API key) | Coolify env | `php`, `worker` | Oui | On-compromise | ADR-029 |
 | `DATATOURISME_API_KEY` | API key | Coolify env | `worker` (multi-source) | Oui | On-compromise | ADR-026 |
+| `OPENAGENDA_API_KEY` | API key Opendatasoft (facultative ; export public sans clé) | Coolify env | `provisioner` (source événements) | Non | On-compromise | ADR-051 |
 | `SENTRY_DSN` | DSN GlitchTip (public côté projet, technique côté ingestion) | Coolify env | `php`, `worker`, `pwa` (SSR) | Oui | On-compromise (projet GlitchTip recréé) | ADR-031 |
 | `NEXT_PUBLIC_SENTRY_DSN` | Idem, exposé au bundle client | Coolify env (build arg) | `pwa` (client) | Oui | Idem `SENTRY_DSN` | ADR-031 |
 | `AGE_RECIPIENT` | Clé publique `age` | Coolify env du service `backup` (clé publique committable) | `backup` (chiffrement dumps) | N/A (publique) | On-compromise — clé privée seule sensible | ADR-038 (#527) |

--- a/docs/runbooks/zone-opening.md
+++ b/docs/runbooks/zone-opening.md
@@ -71,8 +71,24 @@ make provision bretagne     # slug or display name
 One zone per run, and the argument is mandatory — there is no cumulative selection and no
 selection file. What happens, in order: the DataTourisme flux is staged, the zone's Geofabrik
 extract is downloaded and imported into a staging schema of its own, names are resolved, the
-completeness gate refuses what it cannot complete, and the survivors are promoted into the
-live tables in a single transaction.
+completeness gate refuses what it cannot complete, the OpenAgenda events export is imported
+(clipped to the zone), and the survivors of each source are promoted into the live tables in a
+single transaction.
+
+**Events come from two sources (ADR-051).** DataTourisme and OpenAgenda both feed
+`tourism.events`, each stamping its own `source` column; the runtime deduplicates the overlap
+at read time (`EventSourceRegistry`). Both are optional and skipped gracefully when their
+credentials are absent — OSM always provisions. The environment they read (mirrors the
+DataTourisme pattern, all set on the `provisioner` service in `compose.yaml`):
+
+| Source | Env | Notes |
+|---|---|---|
+| DataTourisme | `DATATOURISME_FLUX_ID`, `DATATOURISME_APP_KEY` | national flux ZIP; feeds POIs, accommodations and events |
+| OpenAgenda | `OPENAGENDA_DATASET` (+ optional `OPENAGENDA_API_KEY`) | Opendatasoft dataset slug of the national JSONL export (e.g. `evenements-publics-openagenda`); events only |
+
+OpenAgenda runs **after** the OSM step (it clips its national export to the zone geometry the
+OSM import produces) and **before** the DataTourisme promotion, so the DataTourisme metadata
+refresh counts its events in the live totals.
 
 **Opening a second zone keeps the first.** Promotion is an `INSERT ... SELECT` restricted to
 keys the live tables do not already hold — never a schema swap — so no other zone is exposed
@@ -152,7 +168,10 @@ The idempotence is that of the **PostGIS insertion step**, not of the whole run.
 - the 30-day TTL of the Wikidata cache has not expired, otherwise the enrichment queries
   Wikidata again for the expired Q-IDs;
 - the DataTourisme flux is unchanged — and it is a **national ZIP re-downloaded in full on
-  every run**, so this one is never free.
+  every run**, so this one is never free;
+- likewise the OpenAgenda export is a **national JSONL re-downloaded in full on every run**,
+  and events are perishable, so a re-open is how upcoming events reach the index (the weekly
+  refresh + purge is #985).
 
 Do not describe a re-opening as a no-op. It re-downloads, re-filters and re-imports into
 staging; what it does not do is write to the live tables.

--- a/provisioner/src/OpenAgendaImporter.php
+++ b/provisioner/src/OpenAgendaImporter.php
@@ -1,0 +1,343 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Provisioner;
+
+use Provisioner\Exception\ImportFailedException;
+use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Component\HttpClient\ScopingHttpClient;
+use Symfony\Component\Process\Exception\ProcessTimedOutException;
+use Symfony\Component\Process\Process;
+use Symfony\Contracts\HttpClient\Exception\ExceptionInterface as HttpClientExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Imports OpenAgenda events into the local-first `tourism.events` layer (ADR-051),
+ * as the second events source alongside DataTourisme.
+ *
+ * Flow (a leaner mirror of {@see DataTourismeImporter}, events being the only table
+ * OpenAgenda feeds): stream-download the Opendatasoft JSONL export line by line,
+ * {@see OpenAgendaMapper map} each record to an event row, write the rows to a COPY
+ * file (constant memory regardless of the record count), bulk-load them into a
+ * per-zone staging schema via psql COPY, then `INSERT ... SELECT` the ids the live
+ * table does not already hold, clipped to the zone geometry. A failed import leaves
+ * the previous dataset intact, and one source failing never touches the other's
+ * rows (ADR-041): OpenAgenda writes `source='openagenda'`, the cross-source dedup
+ * happening at read time in `App\EventSource\EventSourceRegistry`.
+ *
+ * The export is **national** while a run opens **one zone**, so the promotion is
+ * clipped to that zone's registry geometry (ADR-049 §1), exactly as DataTourisme is.
+ * That geometry is produced by the OSM step, so promotion runs after it; with no
+ * geometry there is nothing to clip against and the run skips rather than promoting
+ * a whole country's events under one zone's name.
+ *
+ * Rows are emitted in PostgreSQL text COPY format (`\N` = NULL, tab-separated,
+ * backslash-escaped); `geom` receives EWKT (`SRID=4326;POINT(lon lat)`). The DB
+ * connection comes from the libpq environment (PG*), inherited by psql.
+ *
+ * @phpstan-import-type Row from OpenAgendaMapper
+ */
+final readonly class OpenAgendaImporter
+{
+    private const string LIVE_SCHEMA = 'tourism';
+
+    private const string SOURCE = 'openagenda';
+
+    /**
+     * COPY column order for the events table. `source` is written explicitly as
+     * 'openagenda' (the multi-source column of Version20260810120000, ADR-051);
+     * `geom` always comes last and is fed EWKT.
+     *
+     * @var list<string>
+     */
+    private const array EVENT_COLUMNS = ['id', 'name', 'category', 'start_date', 'end_date', 'url', 'description', 'price_min', 'source', 'tags', 'geom'];
+
+    /**
+     * Same events staging DDL as {@see DataTourismeImporter}: a subset of the live
+     * tourism.events the promotion completes with the `zone` / `last_seen_at`
+     * provenance pair.
+     */
+    private const string EVENTS_DDL = "id text NOT NULL PRIMARY KEY, name text, category text NOT NULL, start_date date, end_date date, url text, description text, price_min numeric(10, 2), source text NOT NULL DEFAULT 'openagenda', tags jsonb, geom geometry(Point, 4326) NOT NULL";
+
+    private HttpClientInterface $httpClient;
+
+    /**
+     * @var \Closure(list<string>): Process
+     */
+    private \Closure $processFactory;
+
+    private ZonePromotion $promotion;
+
+    /**
+     * @param (\Closure(list<string>): Process)|null $processFactory factory used to build the psql processes; defaults to a real {@see Process}
+     */
+    public function __construct(
+        private string $exportUrl,
+        private OpenAgendaMapper $mapper = new OpenAgendaMapper(),
+        ?HttpClientInterface $httpClient = null,
+        ?\Closure $processFactory = null,
+        private float $timeoutSeconds = 1800.0,
+    ) {
+        // Scoped to the Opendatasoft origin (SSRF policy, see CLAUDE.md). Cap the
+        // total transfer (ADR-041) so a stalled endpoint fails fast rather than
+        // blocking the run; `timeout` is the per-chunk idle wait.
+        $this->httpClient = $httpClient ?? ScopingHttpClient::forBaseUri(
+            HttpClient::create([
+                'max_redirects' => 2,
+                'timeout' => 120.0,
+                'max_duration' => $this->timeoutSeconds,
+            ]),
+            'https://public.opendatasoft.com/',
+        );
+        $this->processFactory = $processFactory ?? static fn (array $command): Process => new Process($command);
+        $this->promotion = new ZonePromotion(self::SOURCE, self::LIVE_SCHEMA, ['events' => 'l.id = s.id']);
+    }
+
+    /**
+     * Staging schema for a zone: derived, never configured, and namespaced to the
+     * source so it can never collide with the DataTourisme staging schema of the
+     * same run.
+     */
+    public static function stagingSchema(string $zoneSlug): string
+    {
+        return 'openagenda_staging_'.preg_replace('/[^a-z0-9]+/', '_', strtolower($zoneSlug));
+    }
+
+    /**
+     * Downloads, stages and promotes the events covered by the zone.
+     *
+     * @return bool false when the zone has no registry geometry to clip against, so nothing
+     *              was promoted — a skip, not a failure
+     *
+     * @throws ImportFailedException
+     */
+    public function run(string $workDir, string $zoneSlug): bool
+    {
+        $staging = self::stagingSchema($zoneSlug);
+
+        $jsonlPath = $workDir.'/openagenda-export.jsonl';
+        $this->download($jsonlPath);
+        $copyFile = $this->extract($jsonlPath, $workDir);
+        $this->load($staging, $copyFile);
+
+        // Promotion clips to the zone's registry geometry; with none it would promote
+        // exactly nothing and report success silently, which is worse than skipping.
+        // Same precondition as DataTourisme (#885): the geometry, not the OSM exit code.
+        if (!$this->zoneHasGeometry($workDir, $zoneSlug)) {
+            $this->dropStaging($staging);
+
+            return false;
+        }
+
+        $this->promote($zoneSlug, $staging);
+        $this->dropStaging($staging);
+
+        return true;
+    }
+
+    /**
+     * @throws ImportFailedException
+     */
+    public function download(string $jsonlPath): void
+    {
+        $handle = fopen($jsonlPath, 'w');
+        if (false === $handle) {
+            throw new ImportFailedException(\sprintf('Cannot open "%s" for writing', $jsonlPath));
+        }
+
+        try {
+            $response = $this->httpClient->request('GET', $this->exportUrl);
+            $status = $response->getStatusCode();
+            if ($status < 200 || $status >= 300) {
+                throw new ImportFailedException(\sprintf('OpenAgenda export download failed with HTTP %d', $status));
+            }
+
+            foreach ($this->httpClient->stream($response) as $chunk) {
+                if (false === fwrite($handle, $chunk->getContent())) {
+                    throw new ImportFailedException(\sprintf('Failed to write the export to "%s"', $jsonlPath));
+                }
+            }
+        } catch (HttpClientExceptionInterface $httpClientException) {
+            fclose($handle);
+
+            throw new ImportFailedException(\sprintf('OpenAgenda export download failed: %s', $httpClientException->getMessage()), 0, $httpClientException);
+        } finally {
+            if (\is_resource($handle)) {
+                fclose($handle);
+            }
+        }
+    }
+
+    /**
+     * Streams the JSONL export line by line and writes the events COPY file. One JSON
+     * object per line keeps memory constant regardless of the record count.
+     *
+     * @return string the events COPY file path
+     *
+     * @throws ImportFailedException
+     */
+    private function extract(string $jsonlPath, string $workDir): string
+    {
+        $in = fopen($jsonlPath, 'r');
+        if (false === $in) {
+            throw new ImportFailedException(\sprintf('Cannot open the export "%s"', $jsonlPath));
+        }
+
+        $copyFile = $workDir.'/openagenda-events.copy';
+        $out = fopen($copyFile, 'w');
+        if (false === $out) {
+            fclose($in);
+
+            throw new ImportFailedException(\sprintf('Cannot open COPY file "%s"', $copyFile));
+        }
+
+        try {
+            while (false !== ($line = fgets($in))) {
+                $line = trim($line);
+                if ('' === $line) {
+                    continue;
+                }
+
+                $record = json_decode($line, true);
+                if (!\is_array($record)) {
+                    continue;
+                }
+
+                /** @var array<string, mixed> $record */
+                $row = $this->mapper->map($record);
+                if (null === $row) {
+                    continue;
+                }
+
+                fwrite($out, $this->copyLine($row));
+            }
+        } finally {
+            fclose($in);
+            fclose($out);
+        }
+
+        return $copyFile;
+    }
+
+    /**
+     * @phpstan-param Row $row
+     */
+    private function copyLine(array $row): string
+    {
+        $geom = \sprintf('SRID=4326;POINT(%.7F %.7F)', $row['lon'], $row['lat']);
+        $tags = json_encode($row['tags'], \JSON_UNESCAPED_UNICODE | \JSON_UNESCAPED_SLASHES) ?: '{}';
+
+        $values = [$row['id'], $row['name'], $row['category'], $row['startDate'], $row['endDate'], $row['url'], $row['description'], $row['priceMin'], self::SOURCE, $tags, $geom];
+
+        return implode("\t", array_map($this->copyValue(...), $values))."\n";
+    }
+
+    private function copyValue(string|int|float|null $value): string
+    {
+        if (null === $value) {
+            return '\N';
+        }
+
+        $string = \is_string($value) ? $value : (string) $value;
+
+        return str_replace(['\\', "\t", "\n", "\r"], ['\\\\', '\\t', '\\n', '\\r'], $string);
+    }
+
+    /**
+     * @throws ImportFailedException
+     */
+    private function load(string $stagingSchema, string $copyFile): void
+    {
+        $this->runProcess([
+            'psql', '-v', 'ON_ERROR_STOP=1', '-c',
+            \sprintf('DROP SCHEMA IF EXISTS %1$s CASCADE; CREATE SCHEMA %1$s; CREATE TABLE %1$s.events (%2$s);', $stagingSchema, self::EVENTS_DDL),
+        ], 'psql create openagenda staging');
+
+        $columns = implode(', ', self::EVENT_COLUMNS);
+        $this->runProcess([
+            'psql', '-v', 'ON_ERROR_STOP=1', '-c',
+            \sprintf("\\copy %s.events (%s) FROM '%s'", $stagingSchema, $columns, $copyFile),
+        ], 'psql copy events');
+
+        // Serves the zone clip: the promotion tests every staged row against the zone
+        // polygon with ST_Covers.
+        $this->runProcess([
+            'psql', '-v', 'ON_ERROR_STOP=1', '-c',
+            \sprintf('CREATE INDEX ON %s.events USING gist (geom);', $stagingSchema),
+        ], 'psql index events');
+    }
+
+    /**
+     * @throws ImportFailedException
+     */
+    private function zoneHasGeometry(string $workDir, string $zoneSlug): bool
+    {
+        $path = $workDir.'/openagenda-zone-geometry.tsv';
+        $this->runProcess([
+            'psql', '-v', 'ON_ERROR_STOP=1', '-c',
+            \sprintf(
+                "\\copy (SELECT count(*) FROM osm.zones WHERE slug = %s AND geom IS NOT NULL) TO '%s'",
+                ZonePromotion::literal($zoneSlug),
+                $path,
+            ),
+        ], 'psql check zone geometry');
+
+        $contents = is_file($path) ? file_get_contents($path) : false;
+
+        return \is_string($contents) && 0 < (int) trim($contents);
+    }
+
+    /**
+     * Promotes the staged events covered by the zone into the live schema in one
+     * transaction. Unlike DataTourisme, OpenAgenda does not refresh `tourism.metadata`:
+     * events feed a single table and DataTourisme owns that single-row snapshot. When
+     * both sources run, OpenAgenda is promoted before the DataTourisme finish, so the
+     * DataTourisme metadata refresh counts OpenAgenda's events in the live totals.
+     *
+     * @throws ImportFailedException
+     */
+    private function promote(string $zoneSlug, string $stagingSchema): void
+    {
+        $this->runProcess([
+            'psql', '-v', 'ON_ERROR_STOP=1', '-c', $this->promotion->reportDdl(),
+        ], 'psql prepare promotion report');
+
+        $this->runProcess([
+            'psql', '-v', 'ON_ERROR_STOP=1', '--single-transaction', '-c',
+            $this->promotion->sql($zoneSlug, $stagingSchema, clipToZone: $zoneSlug),
+        ], \sprintf('psql promote openagenda zone %s', $zoneSlug));
+    }
+
+    /**
+     * @throws ImportFailedException
+     */
+    private function dropStaging(string $stagingSchema): void
+    {
+        $this->runProcess([
+            'psql', '-v', 'ON_ERROR_STOP=1', '-c',
+            \sprintf('DROP SCHEMA IF EXISTS %s CASCADE;', $stagingSchema),
+        ], 'psql drop openagenda staging schema');
+    }
+
+    /**
+     * @param list<string> $command
+     *
+     * @throws ImportFailedException
+     */
+    private function runProcess(array $command, string $label): void
+    {
+        $process = ($this->processFactory)($command);
+        $process->setTimeout($this->timeoutSeconds);
+
+        try {
+            $process->run();
+        } catch (ProcessTimedOutException $processTimedOutException) {
+            throw new ImportFailedException(\sprintf('%s timed out after %.1fs', $label, $this->timeoutSeconds), 0, $processTimedOutException);
+        }
+
+        if (!$process->isSuccessful()) {
+            throw new ImportFailedException(\sprintf("%s failed (exit %s).\nCommand: %s\nStderr: %s", $label, (string) $process->getExitCode(), implode(' ', $command), $process->getErrorOutput()));
+        }
+    }
+}

--- a/provisioner/src/OpenAgendaMapper.php
+++ b/provisioner/src/OpenAgendaMapper.php
@@ -1,0 +1,233 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Provisioner;
+
+/**
+ * Maps one OpenAgenda record (Opendatasoft "evenements-publics-openagenda"
+ * dataset, JSONL export) to a normalised `tourism.events` row, or null when it is
+ * not an event worth importing.
+ *
+ * OpenAgenda is national, published under Licence Ouverte, with precise geo, a date
+ * range and a canonical URL on every record. Two rules drop a record here rather
+ * than later:
+ *
+ * - **A link is mandatory.** An event a rider cannot open is noise (ADR-051); a
+ *   record without a `canonicalurl` is skipped, mirroring the DataTourisme mapper.
+ * - **A usable date range is mandatory.** The events read path matches
+ *   `start_date <= day <= end_date`; an undated record can never match a stage day.
+ *
+ * The category is normalised onto the **same** app vocabulary the DataTourisme
+ * mapper produces (`festival`, `concert`, `exhibition`, `sports`, `fair`, `show`),
+ * so the shared relevance whitelist in `App\EventSource\EventSourceRegistry` filters
+ * both sources with one rule. OpenAgenda has no category taxonomy, only free
+ * keywords, so the mapping is keyword-based, with a generic `event` fallback that
+ * the whitelist drops. Young-audience records are normalised to `youth`, a category
+ * deliberately outside the whitelist: that is how the shared audience filter of
+ * ADR-051 §3 drops them without a per-source relevance branch.
+ *
+ * @phpstan-type Row array{id: string, name: string|null, category: string, lat: float, lon: float, startDate: string, endDate: string, url: string, description: string|null, priceMin: float|null, tags: array<string, mixed>}
+ */
+final class OpenAgendaMapper
+{
+    /**
+     * Normalised keyword substring → app event category, matching the DataTourisme
+     * mapper's EVENT_CATEGORY targets. Scanned in order; the first key contained in a
+     * record keyword wins, so more specific terms come before generic ones.
+     */
+    private const array KEYWORD_CATEGORY = [
+        'festival' => 'festival',
+        'carnaval' => 'festival',
+        'fete' => 'festival',
+        'exposition' => 'exhibition',
+        'vernissage' => 'exhibition',
+        'concert' => 'concert',
+        'musique' => 'concert',
+        'recital' => 'concert',
+        'opera' => 'concert',
+        'sport' => 'sports',
+        'course' => 'sports',
+        'randonnee' => 'sports',
+        'competition' => 'sports',
+        'foire' => 'fair',
+        'salon' => 'fair',
+        'brocante' => 'fair',
+        'marche' => 'fair',
+        'spectacle' => 'show',
+        'theatre' => 'show',
+        'danse' => 'show',
+        'cinema' => 'show',
+        'projection' => 'show',
+        'cirque' => 'show',
+    ];
+
+    /**
+     * Young-audience markers. A record carrying one is mapped to `youth`, which the
+     * relevance whitelist drops (ADR-051 §3): a bikepacker does not reroute for a
+     * children's activity. Audience takes precedence over the topic keywords above.
+     */
+    private const array YOUTH_KEYWORDS = ['jeune public', 'jeunesse', 'enfant', 'petite enfance', 'bebe'];
+
+    /**
+     * @param array<string, mixed> $record
+     *
+     * @phpstan-return Row|null
+     */
+    public function map(array $record): ?array
+    {
+        $url = $this->firstString($record['canonicalurl'] ?? null);
+        if (null === $url) {
+            return null;
+        }
+
+        $uid = $record['uid'] ?? null;
+        if (!\is_string($uid) && !\is_int($uid)) {
+            return null;
+        }
+
+        $coords = $this->coordinates($record['location_coordinates'] ?? null);
+        if (null === $coords) {
+            return null;
+        }
+
+        $startDate = $this->date($record['firstdate_begin'] ?? $record['date_start'] ?? null);
+        $endDate = $this->date($record['lastdate_end'] ?? $record['date_end'] ?? null);
+        if (null === $startDate || null === $endDate) {
+            return null;
+        }
+
+        return [
+            'id' => 'openagenda:'.$uid,
+            'name' => $this->firstString($record['title_fr'] ?? null),
+            'category' => $this->category($record),
+            'lat' => $coords['lat'],
+            'lon' => $coords['lon'],
+            'startDate' => $startDate,
+            'endDate' => $endDate,
+            'url' => $url,
+            'description' => $this->firstString($record['description_fr'] ?? $record['longdescription_fr'] ?? null),
+            // The dataset carries no reliable numeric admission price; left null.
+            'priceMin' => null,
+            'tags' => $this->tags($record),
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $record
+     */
+    private function category(array $record): string
+    {
+        $keywords = array_map($this->normalize(...), $this->keywords($record));
+        $haystack = implode(' ', $keywords);
+
+        foreach (self::YOUTH_KEYWORDS as $marker) {
+            if (str_contains($haystack, $marker)) {
+                return 'youth';
+            }
+        }
+
+        // An explicit children-only age ceiling is a young-audience signal too.
+        $ageMax = $record['age_max'] ?? null;
+        if (is_numeric($ageMax) && (int) $ageMax > 0 && (int) $ageMax <= 12) {
+            return 'youth';
+        }
+
+        foreach (self::KEYWORD_CATEGORY as $needle => $category) {
+            if (str_contains($haystack, $needle)) {
+                return $category;
+            }
+        }
+
+        return 'event';
+    }
+
+    /**
+     * Curated subset preserved in the row's `tags` jsonb, so a stage label or a
+     * reclassification survives without a re-import. Keys with no value are omitted.
+     *
+     * @param array<string, mixed> $record
+     *
+     * @return array<string, mixed>
+     */
+    private function tags(array $record): array
+    {
+        return array_filter([
+            'keywords' => array_values($this->keywords($record)),
+            'city' => $this->firstString($record['location_city'] ?? null),
+            'postal_code' => $this->firstString($record['location_postalcode'] ?? null),
+            'address' => $this->firstString($record['location_address'] ?? null),
+            'region' => $this->firstString($record['location_region'] ?? null),
+            'image_url' => $this->firstString($record['image'] ?? $record['thumbnail'] ?? null),
+        ], static fn (mixed $value): bool => null !== $value && [] !== $value);
+    }
+
+    /**
+     * @param array<string, mixed> $record
+     *
+     * @return list<string>
+     */
+    private function keywords(array $record): array
+    {
+        $raw = $record['keywords_fr'] ?? $record['keywords'] ?? null;
+        if (\is_string($raw)) {
+            $raw = ['' === $raw ? null : $raw];
+        }
+
+        if (!\is_array($raw)) {
+            return [];
+        }
+
+        return array_values(array_filter($raw, static fn (mixed $v): bool => \is_string($v) && '' !== $v));
+    }
+
+    /**
+     * Coordinates from an Opendatasoft geo point, published either as `{lon, lat}`
+     * (v2.1 JSONL) or as a `[lat, lon]` pair.
+     *
+     * @return array{lat: float, lon: float}|null
+     */
+    private function coordinates(mixed $value): ?array
+    {
+        if (\is_array($value) && isset($value['lat'], $value['lon']) && is_numeric($value['lat']) && is_numeric($value['lon'])) {
+            return ['lat' => (float) $value['lat'], 'lon' => (float) $value['lon']];
+        }
+
+        if (\is_array($value) && is_numeric($value[0] ?? null) && is_numeric($value[1] ?? null)) {
+            return ['lat' => (float) $value[0], 'lon' => (float) $value[1]];
+        }
+
+        return null;
+    }
+
+    /** Date part (YYYY-MM-DD) of an ISO date or datetime ("2026-07-01T18:00:00+02:00" → "2026-07-01"). */
+    private function date(mixed $value): ?string
+    {
+        $string = $this->firstString($value);
+
+        return null !== $string && 1 === preg_match('/^(\d{4}-\d{2}-\d{2})/', $string, $matches) ? $matches[1] : null;
+    }
+
+    private function normalize(string $value): string
+    {
+        $lower = mb_strtolower($value, 'UTF-8');
+
+        return strtr($lower, [
+            'à' => 'a', 'â' => 'a', 'ä' => 'a', 'é' => 'e', 'è' => 'e', 'ê' => 'e', 'ë' => 'e',
+            'î' => 'i', 'ï' => 'i', 'ô' => 'o', 'ö' => 'o', 'ù' => 'u', 'û' => 'u', 'ü' => 'u', 'ç' => 'c',
+        ]);
+    }
+
+    private function firstString(mixed $value): ?string
+    {
+        if (\is_string($value)) {
+            return '' === $value ? null : $value;
+        }
+
+        if (\is_array($value) && \is_string($value[0] ?? null) && '' !== $value[0]) {
+            return $value[0];
+        }
+
+        return null;
+    }
+}

--- a/provisioner/src/OpenAgendaMapper.php
+++ b/provisioner/src/OpenAgendaMapper.php
@@ -122,7 +122,7 @@ final class OpenAgendaMapper
         $haystack = implode(' ', $keywords);
 
         foreach (self::YOUTH_KEYWORDS as $marker) {
-            if (str_contains($haystack, $marker)) {
+            if ($this->containsWord($haystack, $marker)) {
                 return 'youth';
             }
         }
@@ -134,12 +134,23 @@ final class OpenAgendaMapper
         }
 
         foreach (self::KEYWORD_CATEGORY as $needle => $category) {
-            if (str_contains($haystack, $needle)) {
+            if ($this->containsWord($haystack, $needle)) {
                 return $category;
             }
         }
 
         return 'event';
+    }
+
+    /**
+     * Whole-word match on the space-joined keyword haystack. A bare
+     * `str_contains` would misclassify words that merely embed a needle —
+     * "transport" contains "sport", "demarche" contains "marche" — so matching
+     * is anchored to word boundaries.
+     */
+    private function containsWord(string $haystack, string $needle): bool
+    {
+        return 1 === preg_match('/\b'.preg_quote($needle, '/').'\b/u', $haystack);
     }
 
     /**

--- a/provisioner/src/ProvisionCommand.php
+++ b/provisioner/src/ProvisionCommand.php
@@ -45,6 +45,8 @@ final class ProvisionCommand extends Command
 
     private const string DEFAULT_DATATOURISME_DIR = '/data/datatourisme';
 
+    private const string DEFAULT_OPENAGENDA_DIR = '/data/openagenda';
+
     /**
      * Root of the per-zone report directory: `<zonesDir>/<zone>/rejected.tsv` (#886). Under
      * `/data`, which is bind-mounted, so the operator picks the file up on the host — and
@@ -78,6 +80,9 @@ final class ProvisionCommand extends Command
         private readonly string $dataTourismeDir = self::DEFAULT_DATATOURISME_DIR,
         // Built lazily in runDataTourisme() from DATATOURISME_* env when not injected.
         private readonly ?DataTourismeImporter $dataTourismeImporter = null,
+        private readonly string $openAgendaDir = self::DEFAULT_OPENAGENDA_DIR,
+        // Built lazily in resolveOpenAgendaImporter() from OPENAGENDA_* env when not injected.
+        private readonly ?OpenAgendaImporter $openAgendaImporter = null,
         private readonly string $zonesDir = self::DEFAULT_ZONES_DIR,
         private readonly string $lockFile = self::DEFAULT_LOCK_FILE,
         private readonly string $logFile = self::DEFAULT_LOG_FILE,
@@ -165,6 +170,15 @@ final class ProvisionCommand extends Command
             }
 
             $outcomes['osm'] = $this->runOsm($io, $zone, $dryRun, $curatedTable);
+
+            // OpenAgenda events (ADR-051, #984). Events-only, so it does not interleave with
+            // the OSM name gate: it runs entirely after OSM, whose geometry it clips against.
+            // Independent of the other sources' outcomes (ADR-041), and promoted *before* the
+            // DataTourisme finish so the DataTourisme metadata refresh counts its events in the
+            // live totals. Failing here degrades events alone.
+            if (!$dryRun) {
+                $outcomes['openagenda'] = $this->runOpenAgenda($io, $zone['slug']);
+            }
 
             // Deliberately not gated on $outcomes['osm']: a failed OSM refresh must not block a
             // DataTourisme refresh for a zone that is already open (ADR-041). The real
@@ -413,6 +427,77 @@ final class ProvisionCommand extends Command
         $this->logLine('INFO', \sprintf('datatourisme accommodations skipped (unmapped subtype) -> %d', $unmapped));
 
         return Command::SUCCESS;
+    }
+
+    /**
+     * Downloads, stages and promotes the OpenAgenda events for the zone. Skipped
+     * gracefully when OpenAgenda is not configured — OSM and DataTourisme still
+     * provision (ADR-041 continue-on-error).
+     */
+    private function runOpenAgenda(SymfonyStyle $io, string $zoneSlug): int
+    {
+        $importer = $this->resolveOpenAgendaImporter($io);
+        if (!$importer instanceof OpenAgendaImporter) {
+            return Command::SUCCESS;
+        }
+
+        if (!is_dir($this->openAgendaDir) && !mkdir($this->openAgendaDir, 0o755, true) && !is_dir($this->openAgendaDir)) {
+            $io->error(\sprintf('Cannot create OpenAgenda work directory "%s"', $this->openAgendaDir));
+
+            return Command::FAILURE;
+        }
+
+        $io->section('Importing OpenAgenda events');
+
+        try {
+            $promoted = $importer->run($this->openAgendaDir, $zoneSlug);
+        } catch (ImportFailedException $importFailedException) {
+            $this->fail($io, $importFailedException->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        if (!$promoted) {
+            // No registry geometry to clip against: the OSM step did not complete. A skip,
+            // not a failure — the export is national and the next opening re-downloads it.
+            $message = 'OpenAgenda import skipped: the zone has no registry geometry to clip against, so the OSM step did not complete.';
+            $io->warning($message);
+            $this->logLine('INFO', $message);
+
+            return Command::SUCCESS;
+        }
+
+        $io->success('OpenAgenda events imported.');
+        $this->logLine('INFO', \sprintf('openagenda events imported for zone %s', $zoneSlug));
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * The configured importer, or null when OpenAgenda is not set up. Gated on the
+     * dataset (the "flux"): the Opendatasoft public export needs no key, but a private
+     * portal can supply one through OPENAGENDA_API_KEY.
+     */
+    private function resolveOpenAgendaImporter(SymfonyStyle $io): ?OpenAgendaImporter
+    {
+        if ($this->openAgendaImporter instanceof OpenAgendaImporter) {
+            return $this->openAgendaImporter;
+        }
+
+        $dataset = getenv('OPENAGENDA_DATASET') ?: '';
+        if ('' === $dataset) {
+            $io->warning('OpenAgenda import skipped: OPENAGENDA_DATASET is not set.');
+
+            return null;
+        }
+
+        $url = \sprintf('https://public.opendatasoft.com/api/explore/v2.1/catalog/datasets/%s/exports/jsonl', rawurlencode($dataset));
+        $apiKey = getenv('OPENAGENDA_API_KEY') ?: '';
+        if ('' !== $apiKey) {
+            $url .= '?apikey='.rawurlencode($apiKey);
+        }
+
+        return new OpenAgendaImporter($url);
     }
 
     /**

--- a/provisioner/tests/OpenAgendaImporterTest.php
+++ b/provisioner/tests/OpenAgendaImporterTest.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Provisioner\Tests;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Provisioner\Exception\ImportFailedException;
+use Provisioner\OpenAgendaImporter;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\Process\Process;
+
+final class OpenAgendaImporterTest extends TestCase
+{
+    private string $workDir;
+
+    /**
+     * @var list<list<string>>
+     */
+    private array $captured = [];
+
+    protected function setUp(): void
+    {
+        $this->workDir = sys_get_temp_dir().'/oa-importer-'.uniqid('', true);
+        mkdir($this->workDir, 0o755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->workDir.'/*') ?: [] as $file) {
+            unlink($file);
+        }
+
+        if (is_dir($this->workDir)) {
+            rmdir($this->workDir);
+        }
+    }
+
+    /**
+     * A JSONL export with a festival (kept), an undated record and a linkless record
+     * (both dropped by the mapper).
+     */
+    private function jsonlBytes(): string
+    {
+        $lines = [
+            (string) json_encode([
+                'uid' => 12345,
+                'canonicalurl' => 'https://openagenda.com/events/festival-test',
+                'title_fr' => 'Festival test',
+                'keywords_fr' => ['Festival', 'Musique'],
+                'firstdate_begin' => '2026-07-01T18:00:00+02:00',
+                'lastdate_end' => '2026-07-03T23:00:00+02:00',
+                'location_coordinates' => ['lat' => 48.11, 'lon' => -1.68],
+                'location_city' => 'Rennes',
+            ]),
+            // No canonicalurl → dropped (a rider cannot open it).
+            (string) json_encode([
+                'uid' => 2,
+                'title_fr' => 'Sans lien',
+                'firstdate_begin' => '2026-07-01',
+                'lastdate_end' => '2026-07-02',
+                'location_coordinates' => ['lat' => 48.0, 'lon' => -1.0],
+            ]),
+            // No dates → dropped (cannot match a stage day).
+            (string) json_encode([
+                'uid' => 3,
+                'canonicalurl' => 'https://openagenda.com/events/undated',
+                'title_fr' => 'Sans date',
+                'location_coordinates' => ['lat' => 48.0, 'lon' => -1.0],
+            ]),
+        ];
+
+        return implode("\n", $lines)."\n";
+    }
+
+    private function capturingFactory(bool $zoneOpen = true): \Closure
+    {
+        return function (array $command) use ($zoneOpen): Process {
+            /** @var list<string> $cmd */
+            $cmd = $command;
+            $this->captured[] = $cmd;
+
+            if (1 === preg_match("/TO '([^']+)'/", implode(' ', $cmd), $matches) && str_contains($matches[1], 'zone-geometry')) {
+                file_put_contents($matches[1], $zoneOpen ? "1\n" : "0\n");
+            }
+
+            return new Process(['true']);
+        };
+    }
+
+    #[Test]
+    public function streamsTheJsonlExportIntoStagingThenPromotes(): void
+    {
+        $importer = new OpenAgendaImporter(
+            exportUrl: 'https://public.opendatasoft.com/api/explore/v2.1/catalog/datasets/evenements-publics-openagenda/exports/jsonl',
+            httpClient: new MockHttpClient(new MockResponse($this->jsonlBytes())),
+            processFactory: $this->capturingFactory(),
+        );
+
+        self::assertTrue($importer->run($this->workDir, 'bretagne'));
+
+        // 1 staging DDL + 1 \copy + 1 GiST index + 1 zone-geometry read
+        // + 1 report DDL + 1 promotion + 1 staging drop.
+        self::assertCount(7, $this->captured);
+
+        $joined = array_map(static fn (array $c): string => implode(' ', $c), $this->captured);
+
+        $ddl = $joined[0];
+        self::assertStringContainsString('CREATE SCHEMA openagenda_staging_bretagne', $ddl);
+        self::assertStringContainsString('CREATE TABLE openagenda_staging_bretagne.events', $ddl);
+        self::assertStringContainsString("source text NOT NULL DEFAULT 'openagenda'", $ddl);
+
+        self::assertTrue(
+            (bool) array_filter($joined, static fn (string $c): bool => str_contains(
+                $c,
+                '\copy openagenda_staging_bretagne.events (id, name, category, start_date, end_date, url, description, price_min, source, tags, geom)',
+            )),
+            'events are copied with the source column in the column list',
+        );
+
+        // Clipped to the zone, restricted to ids the live table lacks, source stamped.
+        $promotion = array_values(array_filter($joined, static fn (string $c): bool => str_contains($c, '--single-transaction')));
+        self::assertCount(1, $promotion);
+        self::assertStringContainsString('ST_Covers', $promotion[0], 'the national export is clipped to the zone');
+        self::assertStringContainsString("'openagenda'", $promotion[0], 'the promotion report is keyed to the openagenda source');
+
+        // The live tourism schema is never dropped nor renamed; only the staging schema is.
+        $last = end($this->captured);
+        self::assertNotFalse($last);
+        self::assertStringContainsString('DROP SCHEMA IF EXISTS openagenda_staging_bretagne CASCADE', implode(' ', $last));
+        foreach ($joined as $command) {
+            self::assertStringNotContainsString('DROP SCHEMA IF EXISTS tourism CASCADE', $command);
+            self::assertStringNotContainsString('RENAME TO tourism', $command);
+        }
+    }
+
+    #[Test]
+    public function writesOnlyTheLinkedDatedRowsWithSourceOpenagenda(): void
+    {
+        $importer = new OpenAgendaImporter(
+            exportUrl: 'https://public.opendatasoft.com/x',
+            httpClient: new MockHttpClient(new MockResponse($this->jsonlBytes())),
+            processFactory: $this->capturingFactory(),
+        );
+
+        $importer->run($this->workDir, 'bretagne');
+
+        $events = (string) file_get_contents($this->workDir.'/openagenda-events.copy');
+        self::assertSame(1, substr_count($events, "\n"), 'only the linked, dated festival is written');
+
+        $row = explode("\t", rtrim($events, "\n"));
+        self::assertSame('openagenda:12345', $row[0], 'id is namespaced to the source');
+        self::assertSame('Festival test', $row[1]);
+        self::assertSame('festival', $row[2], 'keywords map onto the shared event vocabulary');
+        self::assertSame('2026-07-01', $row[3], 'the date part is extracted from the ISO datetime');
+        self::assertSame('2026-07-03', $row[4]);
+        self::assertSame('https://openagenda.com/events/festival-test', $row[5]);
+        self::assertSame('openagenda', $row[8], 'the source column is stamped openagenda');
+        self::assertStringContainsString('SRID=4326;POINT(-1.6800000 48.1100000)', $events);
+        self::assertStringContainsString('Rennes', $events, 'the city is preserved in tags');
+    }
+
+    #[Test]
+    public function skipsPromotionWhenTheZoneHasNoGeometry(): void
+    {
+        // Same precondition as DataTourisme (#885): no registry geometry, nothing to clip
+        // against, so the run reports a skip rather than promoting a whole country's events.
+        $importer = new OpenAgendaImporter(
+            exportUrl: 'https://public.opendatasoft.com/x',
+            httpClient: new MockHttpClient(new MockResponse($this->jsonlBytes())),
+            processFactory: $this->capturingFactory(zoneOpen: false),
+        );
+
+        self::assertFalse($importer->run($this->workDir, 'bretagne'));
+
+        $joined = array_map(static fn (array $c): string => implode(' ', $c), $this->captured);
+        self::assertSame([], array_values(array_filter($joined, static fn (string $c): bool => str_contains($c, '--single-transaction'))), 'nothing is promoted');
+        $last = end($this->captured);
+        self::assertNotFalse($last);
+        self::assertStringContainsString('DROP SCHEMA IF EXISTS openagenda_staging_bretagne CASCADE', implode(' ', $last), 'the staging schema is still cleaned up');
+    }
+
+    #[Test]
+    public function escapesSpecialCharactersInCopyFields(): void
+    {
+        // A title with tabs/newlines would split or break the COPY row and abort the load
+        // under ON_ERROR_STOP=1.
+        $line = (string) json_encode([
+            'uid' => 'abc',
+            'canonicalurl' => 'https://openagenda.com/e/1',
+            'title_fr' => "Name\twith\ttabs\nand newline\\backslash",
+            'keywords_fr' => ['Concert'],
+            'firstdate_begin' => '2026-08-01',
+            'lastdate_end' => '2026-08-01',
+            'location_coordinates' => ['lat' => 48.0, 'lon' => -1.0],
+        ]);
+
+        $importer = new OpenAgendaImporter(
+            exportUrl: 'https://public.opendatasoft.com/x',
+            httpClient: new MockHttpClient(new MockResponse($line."\n")),
+            processFactory: $this->capturingFactory(),
+        );
+        $importer->run($this->workDir, 'bretagne');
+
+        $events = (string) file_get_contents($this->workDir.'/openagenda-events.copy');
+        self::assertStringNotContainsString("\t\t", $events, 'a literal tab would split into extra columns');
+        self::assertStringContainsString('\t', $events, 'tab escaped as backslash-t');
+        self::assertStringContainsString('\n', $events, 'newline escaped as backslash-n');
+        self::assertStringContainsString('\\\\', $events, 'backslash escaped as double backslash');
+    }
+
+    #[Test]
+    public function downloadFailureRaisesImportFailedException(): void
+    {
+        $importer = new OpenAgendaImporter(
+            exportUrl: 'https://public.opendatasoft.com/x',
+            httpClient: new MockHttpClient(new MockResponse('not found', ['http_code' => 404])),
+            processFactory: $this->capturingFactory(),
+        );
+
+        $this->expectException(ImportFailedException::class);
+        $importer->run($this->workDir, 'bretagne');
+    }
+}

--- a/provisioner/tests/OpenAgendaMapperTest.php
+++ b/provisioner/tests/OpenAgendaMapperTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Provisioner\Tests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Provisioner\OpenAgendaMapper;
+
+final class OpenAgendaMapperTest extends TestCase
+{
+    private OpenAgendaMapper $mapper;
+
+    protected function setUp(): void
+    {
+        $this->mapper = new OpenAgendaMapper();
+    }
+
+    /**
+     * @param array<string, mixed> $extra
+     *
+     * @return array<string, mixed>
+     */
+    private function record(array $extra = []): array
+    {
+        return $extra + [
+            'uid' => 42,
+            'canonicalurl' => 'https://openagenda.com/events/e-42',
+            'title_fr' => 'Un evenement',
+            'firstdate_begin' => '2026-07-01T18:00:00+02:00',
+            'lastdate_end' => '2026-07-03T23:00:00+02:00',
+            'location_coordinates' => ['lat' => 48.11, 'lon' => -1.68],
+        ];
+    }
+
+    #[Test]
+    public function mapsGeoDatesUrlAndTags(): void
+    {
+        $row = $this->mapper->map($this->record([
+            'keywords_fr' => ['Concert'],
+            'description_fr' => 'Un beau concert',
+            'location_city' => 'Rennes',
+            'location_postalcode' => '35000',
+            'image' => 'https://cdn.openagenda.com/e-42.jpg',
+        ]));
+
+        self::assertNotNull($row);
+        self::assertSame('openagenda:42', $row['id']);
+        self::assertSame('Un evenement', $row['name']);
+        self::assertSame('concert', $row['category']);
+        self::assertSame(48.11, $row['lat']);
+        self::assertSame(-1.68, $row['lon']);
+        self::assertSame('2026-07-01', $row['startDate'], 'the date is extracted from the ISO datetime');
+        self::assertSame('2026-07-03', $row['endDate']);
+        self::assertSame('https://openagenda.com/events/e-42', $row['url']);
+        self::assertSame('Un beau concert', $row['description']);
+        self::assertNull($row['priceMin']);
+        self::assertSame(['Concert'], $row['tags']['keywords']);
+        self::assertSame('Rennes', $row['tags']['city']);
+        self::assertSame('35000', $row['tags']['postal_code']);
+        self::assertSame('https://cdn.openagenda.com/e-42.jpg', $row['tags']['image_url']);
+    }
+
+    #[Test]
+    public function dropsARecordWithoutACanonicalUrl(): void
+    {
+        // ADR-051: an event a rider cannot open is noise, so it never reaches the table.
+        self::assertNull($this->mapper->map($this->record(['canonicalurl' => ''])));
+
+        $noUrl = $this->record();
+        unset($noUrl['canonicalurl']);
+        self::assertNull($this->mapper->map($noUrl));
+    }
+
+    #[Test]
+    public function dropsARecordWithoutAUsableDateRange(): void
+    {
+        $noStart = $this->record();
+        unset($noStart['firstdate_begin']);
+        self::assertNull($this->mapper->map($noStart));
+
+        $noEnd = $this->record();
+        unset($noEnd['lastdate_end']);
+        self::assertNull($this->mapper->map($noEnd));
+    }
+
+    #[Test]
+    public function dropsARecordWithoutCoordinates(): void
+    {
+        $noGeo = $this->record();
+        unset($noGeo['location_coordinates']);
+        self::assertNull($this->mapper->map($noGeo));
+    }
+
+    #[Test]
+    public function readsCoordinatesFromALatLonPairToo(): void
+    {
+        $row = $this->mapper->map($this->record(['location_coordinates' => [48.5, 2.3]]));
+
+        self::assertNotNull($row);
+        self::assertSame(48.5, $row['lat']);
+        self::assertSame(2.3, $row['lon']);
+    }
+
+    /**
+     * @param list<string> $keywords
+     */
+    #[Test]
+    #[DataProvider('keywordCategories')]
+    public function normalisesKeywordsOntoTheSharedEventVocabulary(array $keywords, string $expected): void
+    {
+        $row = $this->mapper->map($this->record(['keywords_fr' => $keywords]));
+
+        self::assertNotNull($row);
+        self::assertSame($expected, $row['category']);
+    }
+
+    /**
+     * @return iterable<string, array{list<string>, string}>
+     */
+    public static function keywordCategories(): iterable
+    {
+        yield 'festival' => [['Festival de rue'], 'festival'];
+        yield 'accented concert' => [['Musique électronique'], 'concert'];
+        yield 'exhibition' => [['Exposition de peinture'], 'exhibition'];
+        yield 'sports' => [['Course cycliste'], 'sports'];
+        yield 'fair' => [['Foire aux vins'], 'fair'];
+        yield 'show' => [['Spectacle de danse'], 'show'];
+        yield 'unmapped keyword falls back to the dropped generic' => [['Conférence'], 'event'];
+        yield 'no keyword at all' => [[], 'event'];
+    }
+
+    #[Test]
+    public function youngAudienceIsNormalisedOutsideTheWhitelist(): void
+    {
+        // ADR-051 §3: a source normalises young-audience events to a category the shared
+        // relevance whitelist drops. `youth` is deliberately outside RELEVANT_CATEGORIES,
+        // and audience takes precedence over the topic keyword.
+        $byKeyword = $this->mapper->map($this->record(['keywords_fr' => ['Concert', 'Jeune public']]));
+        self::assertNotNull($byKeyword);
+        self::assertSame('youth', $byKeyword['category']);
+
+        $byAge = $this->mapper->map($this->record(['keywords_fr' => ['Spectacle'], 'age_max' => 6]));
+        self::assertNotNull($byAge);
+        self::assertSame('youth', $byAge['category']);
+    }
+
+    #[Test]
+    public function acceptsAStringUidAndAScalarKeyword(): void
+    {
+        $row = $this->mapper->map($this->record(['uid' => 'abc-1', 'keywords_fr' => 'Festival']));
+
+        self::assertNotNull($row);
+        self::assertSame('openagenda:abc-1', $row['id']);
+        self::assertSame('festival', $row['category']);
+    }
+}

--- a/provisioner/tests/OpenAgendaMapperTest.php
+++ b/provisioner/tests/OpenAgendaMapperTest.php
@@ -130,6 +130,9 @@ final class OpenAgendaMapperTest extends TestCase
         yield 'show' => [['Spectacle de danse'], 'show'];
         yield 'unmapped keyword falls back to the dropped generic' => [['Conférence'], 'event'];
         yield 'no keyword at all' => [[], 'event'];
+        // Word-boundary matching: a needle embedded in a larger word must not match.
+        yield 'transport does not embed-match sport' => [['Transport en commun'], 'event'];
+        yield 'demarche does not embed-match marche' => [['Démarche administrative'], 'event'];
     }
 
     #[Test]

--- a/provisioner/tests/ProvisionCommandTest.php
+++ b/provisioner/tests/ProvisionCommandTest.php
@@ -7,6 +7,7 @@ namespace Provisioner\Tests;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Provisioner\DataTourismeImporter;
+use Provisioner\OpenAgendaImporter;
 use Provisioner\OsmDataDownloader;
 use Provisioner\PostgisImporter;
 use Provisioner\PromotionReport;
@@ -26,6 +27,8 @@ final class ProvisionCommandTest extends TestCase
 
     private string $routingDir;
 
+    private string|false $previousOpenAgendaDataset;
+
     protected function setUp(): void
     {
         $this->tmpDir = sys_get_temp_dir().'/provision-cmd-'.uniqid('', true);
@@ -37,10 +40,19 @@ final class ProvisionCommandTest extends TestCase
         // Default fixture: a routing graph covering France, so the containment check
         // passes unless a test deliberately empties it.
         file_put_contents($this->routingDir.'/france-latest.osm.pbf', 'graph');
+
+        // Keep the OpenAgenda step deterministic: unless a test injects an importer, it
+        // must resolve to "skipped", never to a live export driven by an ambient env var.
+        $this->previousOpenAgendaDataset = getenv('OPENAGENDA_DATASET');
+        putenv('OPENAGENDA_DATASET');
     }
 
     protected function tearDown(): void
     {
+        false === $this->previousOpenAgendaDataset
+            ? putenv('OPENAGENDA_DATASET')
+            : putenv('OPENAGENDA_DATASET='.$this->previousOpenAgendaDataset);
+
         $this->removeDir($this->tmpDir);
     }
 
@@ -67,6 +79,7 @@ final class ProvisionCommandTest extends TestCase
         ?DataTourismeImporter $dataTourismeImporter = null,
         ?string $lockFile = null,
         ?string $routingDir = null,
+        ?OpenAgendaImporter $openAgendaImporter = null,
     ): CommandTester {
         $command = new ProvisionCommand(
             regionsDir: $this->regionsDir,
@@ -78,6 +91,8 @@ final class ProvisionCommandTest extends TestCase
             postgisImporter: $postgisImporter,
             dataTourismeDir: $this->tmpDir.'/datatourisme',
             dataTourismeImporter: $dataTourismeImporter,
+            openAgendaDir: $this->tmpDir.'/openagenda',
+            openAgendaImporter: $openAgendaImporter,
             lockFile: $lockFile ?? $this->tmpDir.'/provision.lock',
             logFile: $this->tmpDir.'/provisioner.log',
             routingPerimeter: new RoutingPerimeter(
@@ -404,6 +419,90 @@ final class ProvisionCommandTest extends TestCase
         $export = array_values(array_filter($osmCommands, static fn (string $c): bool => str_contains($c, 'place-candidates.tsv')));
         self::assertCount(1, $export);
         self::assertStringContainsString('FROM tourism_staging_bretagne.accommodations t', $export[0]);
+    }
+
+    #[Test]
+    public function importsOpenAgendaEventsAfterOsmAndBeforeTheDatatourismeMetadataRefresh(): void
+    {
+        // OpenAgenda is events-only, so it runs entirely after the OSM step whose geometry it
+        // clips against, and before the DataTourisme finish so that finish's metadata refresh
+        // counts the OpenAgenda events in the live totals (ADR-051, #984).
+        /** @var list<string> $log */
+        $log = [];
+        $record = static function (string $step) use (&$log): void {
+            $log[] = $step;
+        };
+        $writeGeometry = static function (string $sql): void {
+            if (1 === preg_match("/TO '([^']+zone-geometry[^']*)'/", $sql, $matches)) {
+                file_put_contents($matches[1], "1\n");
+            }
+        };
+
+        $fluxZip = $this->emptyFluxZip();
+        $dataTourisme = new DataTourismeImporter(
+            fluxUrl: 'https://example.test/flux',
+            httpClient: new MockHttpClient(static fn (): MockResponse => new MockResponse($fluxZip)),
+            processFactory: static function (array $command) use ($record, $writeGeometry): Process {
+                $sql = end($command);
+                if (\is_string($sql) && str_contains($sql, 'INSERT INTO tourism.metadata')) {
+                    $record('datatourisme:promote');
+                } elseif (\is_string($sql) && str_contains($sql, 'CREATE SCHEMA tourism_staging_bretagne')) {
+                    $record('datatourisme:stage');
+                }
+
+                if (\is_string($sql)) {
+                    $writeGeometry($sql);
+                }
+
+                return new Process(['true']);
+            },
+        );
+
+        $openAgenda = new OpenAgendaImporter(
+            exportUrl: 'https://public.opendatasoft.com/x',
+            httpClient: new MockHttpClient(static fn (): MockResponse => new MockResponse("\n")),
+            processFactory: static function (array $command) use ($record, $writeGeometry): Process {
+                if (\in_array('--single-transaction', $command, true)) {
+                    $record('openagenda:promote');
+                }
+
+                $sql = end($command);
+                if (\is_string($sql)) {
+                    $writeGeometry($sql);
+                }
+
+                return new Process(['true']);
+            },
+        );
+
+        $osm = new PostgisImporter(
+            flexStylePath: '/app/osm2pgsql/tier1.lua',
+            processFactory: static function (array $command) use ($record): Process {
+                if (str_contains(implode(' ', $command), 'osm2pgsql')) {
+                    $record('osm:import');
+                }
+
+                return new Process(['true']);
+            },
+        );
+
+        $tester = $this->buildTester(postgisImporter: $osm, dataTourismeImporter: $dataTourisme, openAgendaImporter: $openAgenda);
+
+        self::assertSame(0, $tester->execute(['zone' => 'bretagne'], ['interactive' => false]), $tester->getDisplay());
+
+        self::assertSame(['datatourisme:stage', 'osm:import', 'openagenda:promote', 'datatourisme:promote'], $log);
+        self::assertMatchesRegularExpression('/\x{2713}\s*openagenda/u', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function anUnconfiguredOpenAgendaSourceIsSkippedGracefully(): void
+    {
+        // OPENAGENDA_DATASET is cleared in setUp(); with no importer injected the step must
+        // report a skip and leave the aggregate outcome successful (ADR-041 continue-on-error).
+        $tester = $this->buildTester(postgisImporter: $this->capturingImporter());
+
+        self::assertSame(0, $tester->execute(['zone' => 'bretagne'], ['interactive' => false]), $tester->getDisplay());
+        self::assertStringContainsString('OpenAgenda import skipped', $tester->getDisplay());
     }
 
     #[Test]

--- a/pwa/messages/en.json
+++ b/pwa/messages/en.json
@@ -1115,6 +1115,7 @@
     "description": "Bike Trip Planner uses the following open data sources.",
     "osmCredit": "© OpenStreetMap contributors —",
     "datatourismeCredit": "© DataTourisme —",
+    "openagendaCredit": "© OpenAgenda contributors —",
     "wikidataCredit": "Data under",
     "licenceOuverte": "Licence Ouverte 2.0"
   },
@@ -1151,7 +1152,7 @@
         "title": "Intellectual property",
         "paragraphs": [
           "The Bike Trip Planner source code is distributed under an open-source license; the usage and redistribution terms are available in the GitHub repository.",
-          "Route and mapping data come from third-party sources (OpenStreetMap, DataTourisme, Wikidata) and remain subject to their respective licenses, credited within the application.",
+          "Route and mapping data come from third-party sources (OpenStreetMap, DataTourisme, OpenAgenda, Wikidata) and remain subject to their respective licenses, credited within the application.",
           "Third-party trademarks, logos and content (Komoot, Strava, RideWithGPS, Garmin, Wahoo) remain the property of their respective owners."
         ]
       }

--- a/pwa/messages/fr.json
+++ b/pwa/messages/fr.json
@@ -1115,6 +1115,7 @@
     "description": "Bike Trip Planner utilise les sources de données ouvertes suivantes.",
     "osmCredit": "© les contributeurs OpenStreetMap —",
     "datatourismeCredit": "© DataTourisme —",
+    "openagendaCredit": "© les contributeurs OpenAgenda —",
     "wikidataCredit": "Données sous",
     "licenceOuverte": "Licence Ouverte 2.0"
   },
@@ -1151,7 +1152,7 @@
         "title": "Propriété intellectuelle",
         "paragraphs": [
           "Le code source de Bike Trip Planner est distribué sous licence open-source ; les conditions d'utilisation et de redistribution figurent dans le dépôt GitHub.",
-          "Les données d'itinéraire et cartographiques proviennent de sources tierces (OpenStreetMap, DataTourisme, Wikidata) et restent soumises à leurs licences respectives, créditées sur l'application.",
+          "Les données d'itinéraire et cartographiques proviennent de sources tierces (OpenStreetMap, DataTourisme, OpenAgenda, Wikidata) et restent soumises à leurs licences respectives, créditées sur l'application.",
           "Les marques, logos et contenus appartenant à des tiers (Komoot, Strava, RideWithGPS, Garmin, Wahoo) demeurent la propriété de leurs détenteurs respectifs."
         ]
       }

--- a/pwa/src/components/attribution-footer.tsx
+++ b/pwa/src/components/attribution-footer.tsx
@@ -63,6 +63,21 @@ export function AttributionFooter() {
               </p>
             </li>
             <li>
+              <p className="font-medium">OpenAgenda</p>
+              <p className="text-muted-foreground">
+                {t("openagendaCredit")}{" "}
+                <a
+                  href="https://www.etalab.gouv.fr/licence-ouverte-open-licence"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline hover:text-foreground"
+                  data-testid="attribution-openagenda-link"
+                >
+                  {t("licenceOuverte")}
+                </a>
+              </p>
+            </li>
+            <li>
               <p className="font-medium">Wikidata</p>
               <p className="text-muted-foreground">
                 {t("wikidataCredit")}{" "}

--- a/pwa/tests/mocked/attribution-footer.spec.ts
+++ b/pwa/tests/mocked/attribution-footer.spec.ts
@@ -40,7 +40,7 @@ test.describe("attribution footer", () => {
     await expect(modal).toBeVisible();
   });
 
-  test("modal contains all three data sources", async ({ page }) => {
+  test("modal contains all four data sources", async ({ page }) => {
     await page.goto("/");
     await page.waitForLoadState("networkidle");
 
@@ -53,6 +53,7 @@ test.describe("attribution footer", () => {
     await expect(
       page.getByTestId("attribution-datatourisme-link"),
     ).toBeVisible();
+    await expect(page.getByTestId("attribution-openagenda-link")).toBeVisible();
     await expect(page.getByTestId("attribution-wikidata-link")).toBeVisible();
   });
 


### PR DESCRIPTION
Closes #984.

> ⚠️ **PR empilée sur #987 (`feature/975`).** À merger **après** #987. GitHub retargettera automatiquement sur `main` au squash-merge de #987 ; rebase `--onto` si conflit (voir TRACKING).

## Résumé
Nouvelle source d'événements miroir de DataTourisme, réutilisant tout le socle multi-source de #975.

- **`OpenAgendaImporter`** : `ScopingHttpClient` scopé `https://public.opendatasoft.com/` (max 2 redirections, timeouts), download streaming JSONL parsé ligne à ligne (`fgets`, mémoire constante), COPY vers staging `openagenda_staging_<zone>` (namespace isolé), promotion zone-clippée via `ZonePromotion` avec `source='openagenda'`. Précondition skip-not-fail `zoneHasGeometry` (#885). Ne touche pas `tourism.metadata`.
- **`OpenAgendaMapper`** : keywords OpenAgenda → vocabulaire exact de #975 (festival/concert/exhibition/sports/fair/show) ; jeune public (keyword ou `age_max<=12`) normalisé `youth`, hors `RELEVANT_CATEGORIES` (filtre d'audience partagé ADR-051) ; drop si pas d'URL canonique ou de dates.
- **`ProvisionCommand`** : câblé après l'OSM (besoin géométrie zone), avant la fin DataTourisme ; skip gracieux si `OPENAGENDA_DATASET` absent. Env `OPENAGENDA_DATASET` (+ `OPENAGENDA_API_KEY` optionnel) dans `compose.yaml`.
- **Attribution/docs** : footer + `/legal` + `legal-and-licensing.md` (Licence Ouverte 2.0) + `zone-opening.md` + `secrets-inventory.md`.

## Tests
`OpenAgendaMapperTest`, `OpenAgendaImporterTest` (JSONL→staging→promotion clippée, source stamp, escaping, skip no-geometry, échec download), 2 `ProvisionCommandTest` (ordre osm→openagenda→datatourisme ; skip gracieux). Négatif prouvé (branche jeune-public désactivée → rouge, restauré).

## Vérification (legs QA)
PHP-CS-Fixer `Fixed 0` ; Rector `[OK]` ; PHPStan `[OK] No errors` ; provisioner PHPUnit `223 tests` ; tsc/eslint clean ; prettier OK ; `i18n:check OK: 926 keys` ; markdownlint `0 error` ; `api/tests/Unit 1412 tests` (non-régression).

## Auto-critique
Aucun changement DTO/dep (chemin lecture/dédup = #975). **Recette live `make provision <zone>` = post-merge** (endpoint Opendatasoft non exercé ; URL export confirmée sur la doc ODS v2.1 mais pas jouée end-to-end). Playwright/Functional = CI.

<!-- claude-review-start -->
## Claude Review

**Summary:** Both findings from the previous review round are fixed in commit `5021802`: `OpenAgendaMapper::category()` now matches keywords on word boundaries (`\b...\b/u`) instead of unanchored substrings, closing the "transport"/"sport" and "marche nordique"/"fair" misclassifications, with regression tests added for both cases. The attribution-footer Playwright test now asserts `attribution-openagenda-link` is visible and its title was updated to "all four data sources". No new correctness, security, performance or architecture issues found — the importer correctly mirrors `DataTourismeImporter`'s SSRF-scoped client, streaming/constant-memory parsing, and zone-clip promotion.

**Resolved threads:** Resolved 3 previously open threads (2 on `OpenAgendaMapper.php` category matching — original and a follow-up refinement — and 1 on `attribution-footer.tsx` Playwright coverage), all confirmed fixed by this push.

**Findings by severity:** 0 issues.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Commit reviewed:** `5021802a8873b6ca6a9d6d99252ac75c7d0bc29e`
<!-- claude-review-end -->