### PR TITLE
docs(runbooks): test the Android APK against a local API over ngrok

### DIFF
--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -25,6 +25,7 @@ Every runbook follows the same four sections:
 | [valhalla-routing-graph.md](valhalla-routing-graph.md) | On-demand routing-graph build + tile upload (routing dataset) |
 | [zone-opening.md](zone-opening.md) | Open or refresh a reference zone, in production and locally (reference dataset) |
 | [zone-opening-corrections.md](zone-opening-corrections.md) | Read what the completeness gate refused and correct it by hand |
+| [mobile-apk-local-testing.md](mobile-apk-local-testing.md) | Build + sideload the Android APK against a local API over ngrok |
 | [oracle-vm-reclaimed.md](oracle-vm-reclaimed.md) | Oracle Always Free instance reclaimed |
 | [incident-template.md](incident-template.md) | Post-mortem template |
 | [release-rollback.md](release-rollback.md) | Roll back a bad deploy via Coolify |

--- a/docs/runbooks/mobile-apk-local-testing.md
+++ b/docs/runbooks/mobile-apk-local-testing.md
@@ -19,7 +19,7 @@ To hit your local API you must **rebuild the APK yourself with the ngrok URL bak
 Reasons to run this:
 
 - You need to validate a native (WebView) behaviour that the web PWA over ngrok does not
-  reproduce (see [mobile browser testing over ngrok](../../pwa/scripts/ngrok-recette.sh)
+  reproduce (see [mobile browser testing over ngrok](../../scripts/ngrok-recette.sh)
   for the web-only, no-rebuild path).
 - You downloaded the Artifacts APK, installed it, and every screen is blank / every API
   call fails — expected, per above.
@@ -46,7 +46,7 @@ Reasons to run this:
    `TRUSTED_HOSTS`, `FRONTEND_URL`; re-run it whenever the ngrok URL rotates):
 
    ```bash
-   pwa/scripts/ngrok-recette.sh abcd-1234.ngrok-free.app
+   scripts/ngrok-recette.sh abcd-1234.ngrok-free.app
    ```
 
    No CORS change is needed: `CORS_ALLOW_ORIGIN` (`api/.env`) already allows the native

--- a/docs/runbooks/mobile-apk-local-testing.md
+++ b/docs/runbooks/mobile-apk-local-testing.md
@@ -1,0 +1,88 @@
+# Runbook: testing the Android APK against a local API over ngrok
+
+You want to run the Capacitor APK on a real phone while the API runs on your dev
+machine, exposed through an ngrok tunnel. This is the procedure.
+
+**The APK from GitHub Artifacts will not work for this.** The mobile build is a
+static export (`output: "export"`, see [ADR-024](../adr/adr-024-mobile-strategy-capacitor.md)):
+there is no Next.js server and none of the web build's `/api/*` rewrite, so the WebView
+calls `NEXT_PUBLIC_API_URL` **directly**, and that value is frozen into the bundle at
+build time. The CI job (`.github/workflows/android.yml`) bakes it from the repo variables
+`NEXT_PUBLIC_API_URL` / `NEXT_PUBLIC_MERCURE_URL`, which are **unset** — so the Artifacts
+APK points at empty/relative URLs (its own `https://localhost` WebView origin) and has no
+usable backend. Nothing in an installed APK is reconfigurable at runtime.
+
+To hit your local API you must **rebuild the APK yourself with the ngrok URL baked in**.
+
+## Symptômes
+
+Reasons to run this:
+
+- You need to validate a native (WebView) behaviour that the web PWA over ngrok does not
+  reproduce (see [mobile browser testing over ngrok](../../pwa/scripts/ngrok-recette.sh)
+  for the web-only, no-rebuild path).
+- You downloaded the Artifacts APK, installed it, and every screen is blank / every API
+  call fails — expected, per above.
+
+## Prérequis
+
+- Android SDK + JDK 21 locally (Android Studio or the command-line tools), so
+  `./gradlew assembleDebug` runs. The repo does **not** commit `pwa/android/`;
+  `npm run build:android` creates it via `npx cap add android` on first run.
+- `adb` to sideload, or transfer the `.apk` to the phone and allow "unknown sources".
+- A running local stack and an ngrok tunnel.
+
+## Procédure
+
+1. **Boot the stack and open the tunnel**, then note the ngrok host:
+
+   ```bash
+   docker compose -f compose.yaml -f compose.recette.yaml up --wait
+   ngrok http https://localhost          # e.g. abcd-1234.ngrok-free.app
+   ```
+
+2. **Point the backend at the ngrok host** (reuses the same script as the web path —
+   sets `SERVER_NAME` to serve both `localhost` and the ngrok domain, `local_certs`,
+   `TRUSTED_HOSTS`, `FRONTEND_URL`; re-run it whenever the ngrok URL rotates):
+
+   ```bash
+   pwa/scripts/ngrok-recette.sh abcd-1234.ngrok-free.app
+   ```
+
+   No CORS change is needed: `CORS_ALLOW_ORIGIN` (`api/.env`) already allows the native
+   WebView origin —
+   `^(https?|capacitor)://(localhost|127\.0\.0\.1)(:[0-9]+)?$` covers both
+   `https://localhost` and `capacitor://localhost`.
+
+3. **Build the APK with the ngrok URL frozen in** (Mercure gets an explicit URL because
+   the native WebView cannot resolve it same-origin):
+
+   ```bash
+   cd pwa
+   NEXT_PUBLIC_API_URL="https://abcd-1234.ngrok-free.app" \
+   NEXT_PUBLIC_MERCURE_URL="https://abcd-1234.ngrok-free.app/.well-known/mercure" \
+     npm run build:android        # build:mobile + cap add/sync android
+   cd android && ./gradlew assembleDebug
+   # APK: pwa/android/app/build/outputs/apk/debug/app-debug.apk
+   ```
+
+4. **Install on the phone** and open the app:
+
+   ```bash
+   adb install -r pwa/android/app/build/outputs/apk/debug/app-debug.apk
+   ```
+
+## Post-action / gotchas
+
+- **ngrok-free rotates the URL on every restart.** Each new tunnel means re-running
+  `ngrok-recette.sh` **and** rebuilding the APK (the URL is frozen in the bundle, unlike
+  the origin-relative web build). A paid ngrok static domain removes the rebuild.
+- **HTTPS is mandatory.** `capacitor.config.ts` sets `allowMixedContent: false` with
+  `androidScheme: "https"`; the API URL must be `https://` (ngrok is).
+- **Auth cookie is cross-site here.** The session cookie is host-only, `Secure`,
+  `SameSite=Lax` ([ADR-023](../adr/adr-023-authentication-strategy.md)). The WebView origin
+  (`https://localhost`) and the API (`https://<ngrok>`) are a cross-site pair, so a `Lax`
+  cookie is not sent on cross-site requests. If native login relies on the cookie rather
+  than a bearer token, this is the first thing that will break — verify the auth flow
+  before blaming the build.
+- **First open shows the ngrok-free interstitial** once; accept it.


### PR DESCRIPTION
## Contexte

Comment tester l'APK Capacitor sur un vrai téléphone contre l'API dev locale exposée via ngrok n'était documenté nulle part. ADR-024 décrit la stratégie Capacitor (dual build, CORS `capacitor://`) mais suppose de pointer vers l'API de prod ; rien ne couvre le workflow de test local.

Point clé, non évident et source de perte de temps : **l'APK téléchargé depuis GitHub Artifacts est inutilisable pour ce cas**. Le build mobile est un export statique (`output: "export"`), sans serveur Next ni proxy `/api/*` ; la WebView tape `NEXT_PUBLIC_API_URL` directement, valeur **figée au build**. Les variables de repo `NEXT_PUBLIC_API_URL` / `NEXT_PUBLIC_MERCURE_URL` étant vides, l'APK CI n'a aucun backend. Il faut donc **rebuilder l'APK localement** avec l'URL ngrok gravée dedans.

## Changements

- Nouveau runbook `docs/runbooks/mobile-apk-local-testing.md` : procédure complète (stack + tunnel, `ngrok-recette.sh` pour le backend, build `npm run build:android` avec l'URL ngrok, sideload `adb`).
- Ligne d'index ajoutée dans `docs/runbooks/README.md`.

Gotchas documentés : rotation d'URL ngrok-free (re-run script + rebuild), HTTPS obligatoire (`allowMixedContent: false`), et le cookie de session cross-site (`SameSite=Lax` non envoyé entre origine WebView `https://localhost` et API `https://<ngrok>`) — à surveiller si le login natif s'appuie sur le cookie plutôt qu'un bearer.

## Note conflits

Ajout pur (nouveau runbook + une ligne dans `docs/runbooks/README.md`). PR #995 (restructuration MkDocs) ne touche ni `docs/runbooks/*` ni `docs/adr/*`, donc aucun conflit de contenu quel que soit l'ordre de merge. Seul point de coordination : la nav `mkdocs.yml` de #995 (à laquelle ajouter une ligne **après** son merge — `validation.nav.omitted_files: info` fait que le build ne casse pas entre-temps).

## Vérification

`markdownlint-cli2` sur les deux fichiers : `Summary: 0 error(s)`.

<!-- claude-review-start -->
## Claude Review

**Summary:** Docs-only runbook, well-verified. No new findings — the previously flagged wrong script path (`pwa/scripts/ngrok-recette.sh` vs the real `scripts/ngrok-recette.sh` at repo root) is fixed in the latest commit. Cross-checked every technical claim against the actual code: `CORS_ALLOW_ORIGIN` regex (`api/.env`), `capacitor.config.ts` (`androidScheme: "https"`, `allowMixedContent: false`), `next.config` (`output: "export"` under `BUILD_TARGET=mobile`), `.github/workflows/android.yml` (unset `vars.NEXT_PUBLIC_API_URL`/`NEXT_PUBLIC_MERCURE_URL`), `scripts/ngrok-recette.sh` behavior, `AuthResponseHelper::isCapacitorRequest()` + `SameSite=Lax` cookie logic, and ADR-023/ADR-024 file paths. All match.

**Resolved threads:** Resolved 2 previously open threads (same root cause: wrong script path) that were addressed by the latest commit.

**Findings by severity:** 0 critical, 0 warning, 0 nitpicks.

**Review checklist:**
- [x] Code respects the project architecture (docs-only change, no code)
- [x] SOLID principles and Law of Demeter followed (n/a — docs)
- [x] Design patterns used where appropriate (n/a — docs)
- [x] Tests cover new/changed cases (n/a — docs-only; `markdownlint-cli2` clean, all referenced paths/commands verified against source)
- [x] Documentation is up to date (README.md index line added correctly)
- [x] Dependent tickets accounted for (PR notes coordination point with #995)

**Inline comments:** No inline comments.

**Commit reviewed:** 6dc3f7af759e6718846bd9d5af3c59e7d16ca31e
<!-- claude-review-end -->