### PR TITLE
docs: set mkdocs site_url and fix four dead external links in ADRs

### DIFF
--- a/docs/adr/adr-001-global-architecture-and-separation-of-concerns.md
+++ b/docs/adr/adr-001-global-architecture-and-separation-of-concerns.md
@@ -297,4 +297,4 @@ Husky).
 * [API Platform Documentation: State Providers & Processors](https://api-platform.com/docs/core/state-providers/)
 * [API Platform Documentation: Without Doctrine](https://www.google.com/search?q=https://api-platform.com/docs/core/data-providers/%23custom-state-provider)
 * [Caddy: The Ultimate Server](https://caddyserver.com/)
-* [Zustand Documentation - Persist Middleware](https://docs.pmnd.rs/zustand/integrations/persisting-store-data)
+* [Zustand Documentation - Persist Middleware](https://github.com/pmndrs/zustand#persist-middleware)

--- a/docs/adr/adr-017-valhalla-routing-engine-and-self-hosted-overpass-integration.md
+++ b/docs/adr/adr-017-valhalla-routing-engine-and-self-hosted-overpass-integration.md
@@ -526,5 +526,5 @@ The gis-ops Docker image detects PBF changes on startup and rebuilds tiles autom
 - [ADR-015: Dynamic Engine Management Design Pattern](adr-015-dynamic-engine-management-design-pattern.md) — Registry/interface patterns
 - [Valhalla Documentation](https://valhalla.github.io/valhalla/)
 - [gis-ops/docker-valhalla](https://github.com/gis-ops/docker-valhalla) — Docker image used
-- [wiktorn/overpass-api](https://github.com/wiktorn/docker-overpass-api) — Docker image used
+- [wiktorn/Overpass-API](https://github.com/wiktorn/Overpass-API) — Docker image used
 - [Geofabrik Downloads — Nord-Pas-de-Calais](https://download.geofabrik.de/europe/france/nord-pas-de-calais.html)

--- a/docs/adr/adr-022-persistent-storage-strategy.md
+++ b/docs/adr/adr-022-persistent-storage-strategy.md
@@ -200,6 +200,6 @@ Redis remains fully operational throughout the migration for Messenger transport
 ## Sources
 
 - [PostgreSQL JSONB Documentation](https://www.postgresql.org/docs/18/datatype-json.html)
-- [Doctrine ORM 3.x Documentation](https://www.doctrine-project.org/projects/doctrine-orm/en/3.4/index.html)
+- [Doctrine ORM 3.x Documentation](https://www.doctrine-project.org/projects/doctrine-orm/en/current/index.html)
 - [Zenstruck Foundry](https://github.com/zenstruck/foundry)
 - [Pomm Project (archived)](https://github.com/pomm-project/Foundation) — last activity 2020

--- a/docs/adr/adr-028-ollama-llama-integration.md
+++ b/docs/adr/adr-028-ollama-llama-integration.md
@@ -236,7 +236,7 @@ two-pass pipeline, JSON-mode contract, and model roles above are unchanged.
 - [ADR-014: Alert Extensibility](adr-014-alert-extensibility.md)
 - [ADR-027: Gate Mechanism and Two-Phase Pipeline](adr-027-gate-mechanism-two-phase-pipeline.md)
 - [Ollama documentation — JSON mode](https://github.com/ollama/ollama/blob/main/docs/api.md#generate-a-completion)
-- [Ollama documentation — `num_ctx` parameter](https://github.com/ollama/ollama/blob/main/docs/modelfile.md#parameter)
+- [Ollama documentation — `num_ctx` parameter](https://docs.ollama.com/modelfile)
 - [Meta LLaMA 3 model card](https://github.com/meta-llama/llama-models)
 - Issue #297 — ADR-027 Ollama/LLaMA architecture (this ADR, renumbered to 028)
 - Issue #375 — v2 arbitration: AI always active (decision update)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/squidfunk/mkdocs-material/refs/heads/master/docs/schema.json
 site_name: Bike Trip Planner
+site_url: https://vincentchalamon.github.io/bike-trip-planner/
 site_description: A bikepacking trip planner — smart pacing, safety alerts, and accommodation suggestions from a Komoot URL or a GPX file.
 site_author: Vincent Chalamon
 repo_name: vincentchalamon/bike-trip-planner


### PR DESCRIPTION
Suite à l'activation de GitHub Pages (<https://vincentchalamon.github.io/bike-trip-planner/>) et la vérification du site publié.

## 1. `site_url` manquant → sitemap vide
`mkdocs.yml` n'avait pas de `site_url`, donc MkDocs générait un `sitemap.xml` **vide** (pas d'URLs canoniques, rien à indexer). Ajout de `site_url: https://vincentchalamon.github.io/bike-trip-planner/`. Après correctif : `mkdocs build --strict` peuple le sitemap avec **86 URLs** (0 auparavant).

## 2. Quatre liens externes morts (HTTP 404) dans des ADR historiques
Rot externe pré-existant (pas introduit par le restructure MkDocs), URLs de remplacement toutes vérifiées 200 :

| ADR | Avant (404) | Après (200) |
|-----|-------------|-------------|
| adr-001 | `docs.pmnd.rs/zustand/integrations/persisting-store-data` | `github.com/pmndrs/zustand#persist-middleware` |
| adr-017 | `github.com/wiktorn/docker-overpass-api` | `github.com/wiktorn/Overpass-API` |
| adr-022 | `doctrine-orm/en/3.4/index.html` | `doctrine-orm/en/current/index.html` |
| adr-028 | `github.com/ollama/ollama/blob/main/docs/modelfile.md#parameter` | `docs.ollama.com/modelfile` |

Les autres remontées de la vérif (`medium.com` ×3, `claude.ai/code`) sont des 403 anti-bot, pas des liens morts → laissées.

## Vérif
Liens/ancres internes : 0 cassé (106 fichiers). `mkdocs build --strict` vert. markdownlint 0 erreur sur les 4 ADR. Les 85 pages publiées répondaient déjà 200.

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 findings (0 critical, 0 warning, 0 nit). Docs-only change (mkdocs.yml `site_url` + 4 dead-link fixes in ADRs). All four replacement URLs independently re-verified live and returning 200 with the expected content.

**Review checklist:**
- [x] Code respects the project architecture (N/A — docs only)
- [x] SOLID principles and Law of Demeter followed (N/A — docs only)
- [x] Design patterns used where appropriate (N/A — docs only)
- [x] Tests cover new/changed cases (N/A — no testable behavior; link/anchor checks reported green in the PR description)
- [x] Documentation is up to date (this PR *is* the doc fix)
- [x] Dependent tickets accounted for (none referenced)

**Inline comments:** No inline comments.

Reviewed commit: `f0d37cd`
<!-- claude-review-end -->
