### PR TITLE
ci(changes): recognize mkdocs.yml as a docs-only path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,10 +51,11 @@ jobs:
           # image/doc-only change runs at most the markdown jobs -- never the code/E2E jobs.
           # (.svg stays "code": it can be imported as a component via SVGR.)
           noncode='\.md$|\.(png|jpe?g|gif|webp|avif|ico)$'
-          # Recognised zones. Repo meta files (.git*, .github/** except workflows), the docs/ tree
-          # and the non-code assets above have no code impact. Fail-safe: run the full suite on
-          # non-PR events, on workflow changes, or when a file matches no zone.
-          known='^api/|^provisioner/|^pwa/|^\.docker/|^\.dockerignore$|^compose[^/]*\.yaml$|^\.git|^docs/|'"$noncode"
+          # Recognised zones. Repo meta files (.git*, .github/** except workflows), the docs/ tree,
+          # the MkDocs config (mkdocs.yml, docs-only) and the non-code assets above have no code
+          # impact. Fail-safe: run the full suite on non-PR events, on workflow changes, or when a
+          # file matches no zone.
+          known='^api/|^provisioner/|^pwa/|^\.docker/|^\.dockerignore$|^compose[^/]*\.yaml$|^\.git|^docs/|^mkdocs\.yml$|'"$noncode"
           run_all=false
           if [ "$EVENT_NAME" != "pull_request" ]; then run_all=true; fi
           if printf '%s\n' "$files" | grep -qE '^\.github/workflows/'; then run_all=true; fi
@@ -67,7 +68,7 @@ jobs:
           provisioner=$(flag '^provisioner/')
           pwa=$(flag '^pwa/')
           docker=$(flag '^\.docker/|^\.dockerignore$|^compose[^/]*\.yaml$')
-          if [ "$run_all" = true ] || printf '%s\n' "$files" | grep -qE '\.md$'; then docs=true; else docs=false; fi
+          if [ "$run_all" = true ] || printf '%s\n' "$files" | grep -qE '\.md$|^mkdocs\.yml$'; then docs=true; else docs=false; fi
           if [ "$api" = true ] || [ "$pwa" = true ] || [ "$docker" = true ]; then e2e=true; else e2e=false; fi
 
           {


### PR DESCRIPTION
## Problème
Sur #1002 (doc + `mkdocs.yml` uniquement), **toute la CI** (PHPUnit api/provisioner, PHPStan, Rector, Playwright, APK…) s'est lancée.

## Cause
Le job `changes` classe les fichiers modifiés par zone (`known`) et déclenche le fail-safe `run_all=true` dès qu'un fichier ne matche **aucune** zone. Les `docs/*.md` matchent `^docs/`, mais **`mkdocs.yml`** (config docs à la racine) ne matchait ni `^docs/`, ni `^compose[^/]*\.yaml$` (préfixe `compose`, et extension `.yml` ≠ `.yaml`), ni `\.md$` → fichier « inconnu » → suite complète.

Reproduit :
```
$ printf 'mkdocs.yml\n' | grep -vE "$known"
mkdocs.yml        # → run_all=true
```

## Correctif
- Ajout de `^mkdocs\.yml$` à l'ensemble `known` (plus de fail-safe).
- Ajout de `^mkdocs\.yml$` au déclencheur `docs` (le job docs/markdown-links tourne quand seul `mkdocs.yml` change).

Après patch : `run_all` non déclenché, `api/pwa/provisioner/docker/e2e=false`, `docs=true` → seuls les jobs docs tournent. yamllint OK.

> ℹ️ Cette PR modifie un workflow → le job `changes` force `run_all` pour elle-même (validation complète voulue sur tout changement de workflow). L'effet du correctif se verra sur la **prochaine** PR docs+mkdocs.yml.

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 findings (0 critical, 0 warning). Minimal, correctly-scoped fix to the `changes` job's path-filtering regex.

**Commit reviewed:** `af5e830bf0258fb95ea3d2b1f5baba70d5eb6360`

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed (N/A — CI shell script)
- [x] Design patterns used where appropriate (N/A)
- [x] Tests cover new/changed cases (manually verified via `grep`, per PR description; no dedicated test harness exists for this CI script)
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.
<!-- claude-review-end -->
