### PR TITLE
docs(runbooks): fix split ordered lists + expand mobile-apk prerequisites

### DIFF
--- a/docs/adr/adr-030-symfony-ai-adoption.md
+++ b/docs/adr/adr-030-symfony-ai-adoption.md
@@ -89,11 +89,11 @@ Tool calling is consistently ~3× faster (less output to generate — just the t
 
 1. **JSON-Schema leakage into argument values (5 / 20 cases).** The model emits the schema *fragment* in the place of the value:
 
-   ```json
-   {"name":"split_stage","args":{"stage":{"description":"The 1-based index of the stage to split","type":"integer"}}}
-   ```
+    ```json
+    {"name":"split_stage","args":{"stage":{"description":"The 1-based index of the stage to split","type":"integer"}}}
+    ```
 
-   Same prompt, run through the JSON envelope, gives the correct `{"action":"split_stage","params":{"stage":2}}`.
+    Same prompt, run through the JSON envelope, gives the correct `{"action":"split_stage","params":{"stage":2}}`.
 
 2. **Wrong tool selection on conversational prompts (2 / 3 "info" cases).** `Bonjour !` triggers `split_stage(stage=1)`; `Quelle est la différence entre gravel et bikepacking ?` triggers `split_stage(stage=2)`. The JSON envelope correctly returns `info` in all three "info" cases.
 
@@ -118,9 +118,9 @@ These observations are **specific to ~3B-parameter local models**. On a 70B+ mod
 1. `App\Llm\OllamaClient` is rewritten as a thin façade over `Symfony\AI\Platform\PlatformInterface` (Ollama bridge wired through the bundle, pointing to the existing scoped `ollama.client` HTTP client). The `LlmClientInterface` contract is preserved; every caller is untouched. Return shapes remain `['response' => string]` for `generate()` and `['message' => ['content' => string]]` for `chat()` so the existing JSON-envelope flow keeps working.
 2. The dialogue layer **keeps the JSON envelope** (`SystemPrompt/dialogue.txt` + `ChatActionInterpreter`). No `#[AsTool]` classes in production.
 3. **Not adopted (for now):**
-   - `symfony/ai-chat` — `ChatHistoryStore` (Redis hot window) and `TripChatMessage` (PostgreSQL audit with action / GPS / POIs) carry domain semantics that `MessageStoreInterface::save(MessageBag)` cannot express.
-   - `symfony/ai-store` — no current product need for embeddings / vector search; Overpass + regex-based `PoiIntentDetector` covers the in-ride flow.
-   - `symfony/ai-mcp` — no need yet to expose this app as an MCP server.
+    - `symfony/ai-chat` — `ChatHistoryStore` (Redis hot window) and `TripChatMessage` (PostgreSQL audit with action / GPS / POIs) carry domain semantics that `MessageStoreInterface::save(MessageBag)` cannot express.
+    - `symfony/ai-store` — no current product need for embeddings / vector search; Overpass + regex-based `PoiIntentDetector` covers the in-ride flow.
+    - `symfony/ai-mcp` — no need yet to expose this app as an MCP server.
 
 ### Implementation notes
 

--- a/docs/runbooks/base-image-cve-maintenance.md
+++ b/docs/runbooks/base-image-cve-maintenance.md
@@ -29,18 +29,18 @@ only the rows with `Status: fixed`. Triage those; ignore the won't-fix noise.
 ## Procédure
 
 1. Bump the digest of the affected base to the latest published for its tag:
-   - `.docker/php/Dockerfile` — `dunglas/frankenphp:1-php8.5@sha256:...`
-   - `.docker/pwa/Dockerfile` — `node:26@sha256:...`
-   - `.docker/provisioner/Dockerfile` — `php:8.5-cli-bookworm` (tag-pinned; pin a
-     digest here too if reproducibility is needed).
+    - `.docker/php/Dockerfile` — `dunglas/frankenphp:1-php8.5@sha256:...`
+    - `.docker/pwa/Dockerfile` — `node:26@sha256:...`
+    - `.docker/provisioner/Dockerfile` — `php:8.5-cli-bookworm` (tag-pinned; pin a
+      digest here too if reproducibility is needed).
 
-   ```bash
-   docker pull dunglas/frankenphp:1-php8.5
-   docker inspect --format='{{index .RepoDigests 0}}' dunglas/frankenphp:1-php8.5
-   ```
+    ```bash
+    docker pull dunglas/frankenphp:1-php8.5
+    docker inspect --format='{{index .RepoDigests 0}}' dunglas/frankenphp:1-php8.5
+    ```
 
 2. Rebuild and re-scan (`make build` + the Trivy commands above); confirm the
-   `fixed`-status rows dropped.
+    `fixed`-status rows dropped.
 3. Run the full suite (`make test`) — a base bump can shift a system library.
 
 ## Post-action

--- a/docs/runbooks/database-disk-full.md
+++ b/docs/runbooks/database-disk-full.md
@@ -57,33 +57,33 @@ LIMIT 10;
 
 1. **Free obvious wins on disk** (run on the VM, not in the container):
 
-   ```bash
-   docker image prune -af
-   docker container prune -f
-   journalctl --vacuum-size=200M
-   ```
+    ```bash
+    docker image prune -af
+    docker container prune -f
+    journalctl --vacuum-size=200M
+    ```
 
 2. **Reclaim PostgreSQL bloat** on the top offender(s). Prefer non-blocking first:
 
-   ```sql
-   VACUUM (VERBOSE, ANALYZE) stage;
-   VACUUM (VERBOSE, ANALYZE) trip_request;
-   ```
+    ```sql
+    VACUUM (VERBOSE, ANALYZE) stage;
+    VACUUM (VERBOSE, ANALYZE) trip_request;
+    ```
 
-   If bloat persists and a brief lock is acceptable (writes blocked on that table):
+    If bloat persists and a brief lock is acceptable (writes blocked on that table):
 
-   ```sql
-   VACUUM FULL VERBOSE stage;
-   ```
+    ```sql
+    VACUUM FULL VERBOSE stage;
+    ```
 
-   The Messenger transport is Redis-backed (`redis://.../messages`), not Doctrine,
-   so there is no `messenger_messages` table to truncate here — queue pressure is
-   handled in [`redis-out-of-memory.md`](./redis-out-of-memory.md).
+    The Messenger transport is Redis-backed (`redis://.../messages`), not Doctrine,
+    so there is no `messenger_messages` table to truncate here — queue pressure is
+    handled in [`redis-out-of-memory.md`](./redis-out-of-memory.md).
 
 3. **Resize the boot volume** on Oracle Cloud (last resort, requires VM reboot):
-   - OCI console → Compute → Instances → select VM → Boot volume → "Edit" → raise size (free tier ceiling: 200 GB total block storage across all volumes)
-   - SSH into VM and run `sudo /usr/libexec/oci-growfs -y` to extend the filesystem
-   - Coolify auto-restarts the stack after reboot
+    - OCI console → Compute → Instances → select VM → Boot volume → "Edit" → raise size (free tier ceiling: 200 GB total block storage across all volumes)
+    - SSH into VM and run `sudo /usr/libexec/oci-growfs -y` to extend the filesystem
+    - Coolify auto-restarts the stack after reboot
 
 ## Post-action
 

--- a/docs/runbooks/incident-alerting.md
+++ b/docs/runbooks/incident-alerting.md
@@ -54,12 +54,12 @@ The workflow itself authenticates with the built-in `GITHUB_TOKEN` (scope
 ### Rotating `INCIDENT_DISPATCH_TOKEN`
 
 1. GitHub → Settings → Developer settings → Fine-grained tokens → generate new
-   token, same scopes, 90-day expiry.
+    token, same scopes, 90-day expiry.
 2. Update the secret in Settings → Secrets and variables → Actions.
 3. Update the bearer token in:
-   - GlitchTip → project Settings → Alerts → webhook integration
-   - Uptime Kuma → Settings → Notifications → Webhook
-   - UptimeRobot → My Settings → Integrations & API → Webhook
+    - GlitchTip → project Settings → Alerts → webhook integration
+    - Uptime Kuma → Settings → Notifications → Webhook
+    - UptimeRobot → My Settings → Integrations & API → Webhook
 4. Trigger a test dispatch (see below) and confirm an issue is opened.
 5. Revoke the old token.
 
@@ -159,32 +159,32 @@ command must comment on the existing issue (no duplicate).
 
 1. Open the GlitchTip project → **Settings** → **Alerts**.
 2. **Create alert** → trigger condition (e.g. "An event is seen", frequency
-   1 min, environment `production`).
+    1 min, environment `production`).
 3. Action type **Webhook**.
 4. URL: `https://api.github.com/repos/vincentchalamon/bike-trip-planner/dispatches`.
 5. Method `POST`, headers:
-   - `Accept: application/vnd.github+json`
-   - `Authorization: Bearer <INCIDENT_DISPATCH_TOKEN>`
-   - `Content-Type: application/json`
+    - `Accept: application/vnd.github+json`
+    - `Authorization: Bearer <INCIDENT_DISPATCH_TOKEN>`
+    - `Content-Type: application/json`
 6. Body template (GlitchTip supports raw JSON; adjust placeholders to project
-   syntax):
+    syntax):
 
-   ```json
-   {
-     "event_type": "error_alert",
-     "client_payload": {
-       "issue": {
-         "title": "{{ issue.title }}",
-         "culprit": "{{ issue.culprit }}",
-         "level": "{{ issue.level }}",
-         "count": {{ issue.count }},
-         "web_url": "{{ issue.web_url }}"
-       },
-       "environment": "{{ environment }}",
-       "release": "{{ release }}"
-     }
-   }
-   ```
+    ```json
+    {
+      "event_type": "error_alert",
+      "client_payload": {
+        "issue": {
+          "title": "{{ issue.title }}",
+          "culprit": "{{ issue.culprit }}",
+          "level": "{{ issue.level }}",
+          "count": {{ issue.count }},
+          "web_url": "{{ issue.web_url }}"
+        },
+        "environment": "{{ environment }}",
+        "release": "{{ release }}"
+      }
+    }
+    ```
 
 ### Uptime Kuma
 
@@ -193,23 +193,23 @@ command must comment on the existing issue (no duplicate).
 3. POST URL: `https://api.github.com/repos/vincentchalamon/bike-trip-planner/dispatches`.
 4. Request body: `Custom Body` with:
 
-   ```json
-   {
-     "event_type": "uptime_alert",
-     "client_payload": {
-       "monitor_name": "{{ monitorJSON.name }}",
-       "monitor_url": "{{ monitorJSON.url }}",
-       "status": "{{ status }}",
-       "message": "{{ msg }}",
-       "heartbeat": { "ping": {{ heartbeatJSON.ping }} }
-     }
-   }
-   ```
+    ```json
+    {
+      "event_type": "uptime_alert",
+      "client_payload": {
+        "monitor_name": "{{ monitorJSON.name }}",
+        "monitor_url": "{{ monitorJSON.url }}",
+        "status": "{{ status }}",
+        "message": "{{ msg }}",
+        "heartbeat": { "ping": {{ heartbeatJSON.ping }} }
+      }
+    }
+    ```
 
 5. Additional headers: `Authorization: Bearer <INCIDENT_DISPATCH_TOKEN>`,
-   `Accept: application/vnd.github+json`.
+    `Accept: application/vnd.github+json`.
 6. Attach the notification to every monitor (default behaviour when "Apply on
-   all existing monitors" is checked).
+    all existing monitors" is checked).
 
 ### UptimeRobot
 
@@ -218,22 +218,22 @@ command must comment on the existing issue (no duplicate).
 3. URL to notify: `https://api.github.com/repos/vincentchalamon/bike-trip-planner/dispatches`.
 4. POST value (JSON):
 
-   ```json
-   {
-     "event_type": "uptime_alert",
-     "client_payload": {
-       "monitor_name": "*monitorFriendlyName*",
-       "monitor_url": "*monitorURL*",
-       "status": "*alertTypeFriendlyName*",
-       "message": "*alertDetails*",
-       "responseTime": *responseTime*
-     }
-   }
-   ```
+    ```json
+    {
+      "event_type": "uptime_alert",
+      "client_payload": {
+        "monitor_name": "*monitorFriendlyName*",
+        "monitor_url": "*monitorURL*",
+        "status": "*alertTypeFriendlyName*",
+        "message": "*alertDetails*",
+        "responseTime": *responseTime*
+      }
+    }
+    ```
 
 5. Send as JSON: **Yes**. Custom HTTP headers:
-   - `Authorization: Bearer <INCIDENT_DISPATCH_TOKEN>`
-   - `Accept: application/vnd.github+json`
+    - `Authorization: Bearer <INCIDENT_DISPATCH_TOKEN>`
+    - `Accept: application/vnd.github+json`
 6. Attach the integration to the `/api/healthz` external monitor.
 
 ## Troubleshooting

--- a/docs/runbooks/mercure-disconnected.md
+++ b/docs/runbooks/mercure-disconnected.md
@@ -39,26 +39,26 @@ new EventSource('/.well-known/mercure?topic=' + encodeURIComponent('https://exam
 
 1. **Restart the hub** — Mercure is embedded in the `php` edge, so restart `php` (idempotent):
 
-   ```bash
-   docker compose restart php
-   ```
+    ```bash
+    docker compose restart php
+    ```
 
 2. **If the JWT secret rotated**, regenerate it across services. The publisher key lives in the PHP container, the subscriber key in the PWA build. Both must share `MERCURE_JWT_SECRET`:
 
-   ```bash
-   docker compose exec php php -r 'echo bin2hex(random_bytes(32))."\n";'
-   ```
+    ```bash
+    docker compose exec php php -r 'echo bin2hex(random_bytes(32))."\n";'
+    ```
 
-   Update the Coolify environment for `php` and `pwa`, then redeploy. Mismatched keys produce silent 401s with no obvious symptom beyond reconnect loops.
+    Update the Coolify environment for `php` and `pwa`, then redeploy. Mismatched keys produce silent 401s with no obvious symptom beyond reconnect loops.
 
 3. **Reset reconnect state on the PWA** — the Mercure client (`pwa/src/lib/mercure/client.ts`) backs off exponentially. After a hub restart, ask users to refresh; the `use-mercure` hook will re-subscribe automatically.
 
 4. **Check the edge** — the Caddy reverse-proxy and the Mercure hub both run inside the `php` (FrankenPHP) container. If routing looks wrong:
 
-   ```bash
-   docker compose logs --tail=100 php | grep -i mercure
-   docker compose restart php
-   ```
+    ```bash
+    docker compose logs --tail=100 php | grep -i mercure
+    docker compose restart php
+    ```
 
 ## Post-action
 

--- a/docs/runbooks/mobile-apk-local-testing.md
+++ b/docs/runbooks/mobile-apk-local-testing.md
@@ -26,51 +26,65 @@ Reasons to run this:
 
 ## Prérequis
 
-- Android SDK + JDK 21 locally (Android Studio or the command-line tools), so
-  `./gradlew assembleDebug` runs. The repo does **not** commit `pwa/android/`;
+- **Node.js 26 + npm**, with the `pwa/` dependencies installed (`cd pwa && npm ci`). The
+  Capacitor CLI (`@capacitor/cli`, `@capacitor/android`) comes from the dev dependencies —
+  no separate global install.
+- **Android SDK + build-tools + JDK 21** locally (Android Studio or the command-line tools),
+  so `./gradlew assembleDebug` runs. The repo does **not** commit `pwa/android/`;
   `npm run build:android` creates it via `npx cap add android` on first run.
-- `adb` to sideload, or transfer the `.apk` to the phone and allow "unknown sources".
-- A running local stack and an ngrok tunnel.
+- **`adb`** on PATH to sideload, or transfer the `.apk` to the phone and allow "unknown
+  sources".
+- **A physical Android device** (ADR-024 targets the Samsung Galaxy S20 FE) **or an emulator**,
+  with **USB debugging** enabled for `adb install`.
+- **Docker + Docker Compose**, running the **recette** stack. `make start-recette` is the
+  equivalent of the raw `docker compose` command in step 1 and also provisions the JWT
+  keypair (`ensure-jwt-recette`).
+- **ngrok installed with an account/authtoken** configured. The free tier works but the
+  tunnel URL rotates on every restart and shows a one-time interstitial (see gotchas below).
+- **HTTPS end to end.** `capacitor.config.ts` sets `androidScheme: "https"` +
+  `allowMixedContent: false`, so the API URL must be `https://` (ngrok provides it). The
+  ngrok URL is frozen into the bundle at build time via `NEXT_PUBLIC_API_URL` /
+  `NEXT_PUBLIC_MERCURE_URL` (step 3) — rebuild the APK whenever it rotates.
 
 ## Procédure
 
 1. **Boot the stack and open the tunnel**, then note the ngrok host:
 
-   ```bash
-   docker compose -f compose.yaml -f compose.recette.yaml up --wait
-   ngrok http https://localhost          # e.g. abcd-1234.ngrok-free.app
-   ```
+    ```bash
+    docker compose -f compose.yaml -f compose.recette.yaml up --wait
+    ngrok http https://localhost          # e.g. abcd-1234.ngrok-free.app
+    ```
 
 2. **Point the backend at the ngrok host** (reuses the same script as the web path —
-   sets `SERVER_NAME` to serve both `localhost` and the ngrok domain, `local_certs`,
-   `TRUSTED_HOSTS`, `FRONTEND_URL`; re-run it whenever the ngrok URL rotates):
+    sets `SERVER_NAME` to serve both `localhost` and the ngrok domain, `local_certs`,
+    `TRUSTED_HOSTS`, `FRONTEND_URL`; re-run it whenever the ngrok URL rotates):
 
-   ```bash
-   scripts/ngrok-recette.sh abcd-1234.ngrok-free.app
-   ```
+    ```bash
+    scripts/ngrok-recette.sh abcd-1234.ngrok-free.app
+    ```
 
-   No CORS change is needed: `CORS_ALLOW_ORIGIN` (`api/.env`) already allows the native
-   WebView origin —
-   `^(https?|capacitor)://(localhost|127\.0\.0\.1)(:[0-9]+)?$` covers both
-   `https://localhost` and `capacitor://localhost`.
+    No CORS change is needed: `CORS_ALLOW_ORIGIN` (`api/.env`) already allows the native
+    WebView origin —
+    `^(https?|capacitor)://(localhost|127\.0\.0\.1)(:[0-9]+)?$` covers both
+    `https://localhost` and `capacitor://localhost`.
 
 3. **Build the APK with the ngrok URL frozen in** (Mercure gets an explicit URL because
-   the native WebView cannot resolve it same-origin):
+    the native WebView cannot resolve it same-origin):
 
-   ```bash
-   cd pwa
-   NEXT_PUBLIC_API_URL="https://abcd-1234.ngrok-free.app" \
-   NEXT_PUBLIC_MERCURE_URL="https://abcd-1234.ngrok-free.app/.well-known/mercure" \
-     npm run build:android        # build:mobile + cap add/sync android
-   cd android && ./gradlew assembleDebug
-   # APK: pwa/android/app/build/outputs/apk/debug/app-debug.apk
-   ```
+    ```bash
+    cd pwa
+    NEXT_PUBLIC_API_URL="https://abcd-1234.ngrok-free.app" \
+    NEXT_PUBLIC_MERCURE_URL="https://abcd-1234.ngrok-free.app/.well-known/mercure" \
+      npm run build:android        # build:mobile + cap add/sync android
+    cd android && ./gradlew assembleDebug
+    # APK: pwa/android/app/build/outputs/apk/debug/app-debug.apk
+    ```
 
 4. **Install on the phone** and open the app:
 
-   ```bash
-   adb install -r pwa/android/app/build/outputs/apk/debug/app-debug.apk
-   ```
+    ```bash
+    adb install -r pwa/android/app/build/outputs/apk/debug/app-debug.apk
+    ```
 
 ## Post-action / gotchas
 

--- a/docs/runbooks/redis-out-of-memory.md
+++ b/docs/runbooks/redis-out-of-memory.md
@@ -44,50 +44,50 @@ docker compose exec redis redis-cli --scan --pattern 'in_ride_poi:*' | wc -l
 
 1. **Drain the failed transport** (often the largest unbounded queue):
 
-   ```bash
-   docker compose exec php bin/console messenger:failed:show
-   docker compose exec php bin/console messenger:failed:remove --all
-   ```
+    ```bash
+    docker compose exec php bin/console messenger:failed:show
+    docker compose exec php bin/console messenger:failed:remove --all
+    ```
 
 2. **Selective flush** of external API caches (preserves Messenger state):
 
-   ```bash
-   docker compose exec php bin/console cache:pool:clear \
-     cache.osm cache.weather cache.route_fetch cache.routing cache.trip_chat
-   ```
+    ```bash
+    docker compose exec php bin/console cache:pool:clear \
+      cache.osm cache.weather cache.route_fetch cache.routing cache.trip_chat
+    ```
 
-   Note: `cache.app` (Symfony default pool) does **not** include the project's
-   external API caches — clearing it would only purge framework metadata
-   (Doctrine result cache, etc.) and would not reclaim Redis memory.
+    Note: `cache.app` (Symfony default pool) does **not** include the project's
+    external API caches — clearing it would only purge framework metadata
+    (Doctrine result cache, etc.) and would not reclaim Redis memory.
 
-   Or targeted scan + delete from the Redis CLI:
+    Or targeted scan + delete from the Redis CLI:
 
-   ```bash
-   docker compose exec redis redis-cli --scan --pattern 'osm:*' | \
-     xargs -r docker compose exec -T redis redis-cli DEL
-   ```
+    ```bash
+    docker compose exec redis redis-cli --scan --pattern 'osm:*' | \
+      xargs -r docker compose exec -T redis redis-cli DEL
+    ```
 
 3. **Full reset** of Messenger transports + trip state (drops in-flight computations):
 
-   ```bash
-   make flush-queue
-   ```
+    ```bash
+    make flush-queue
+    ```
 
 4. **Verify eviction policy** (per ADR-022, transient caches should use `allkeys-lru`):
 
-   ```bash
-   docker compose exec redis redis-cli CONFIG SET maxmemory-policy allkeys-lru
-   ```
+    ```bash
+    docker compose exec redis redis-cli CONFIG SET maxmemory-policy allkeys-lru
+    ```
 
-   Persist the change in `compose.yaml` (Redis `command:`) — `CONFIG SET` does not survive a restart.
+    Persist the change in `compose.yaml` (Redis `command:`) — `CONFIG SET` does not survive a restart.
 
 5. **Raise `maxmemory`** as a stopgap if the VM has free RAM:
 
-   ```bash
-   docker compose exec redis redis-cli CONFIG SET maxmemory 512mb
-   ```
+    ```bash
+    docker compose exec redis redis-cli CONFIG SET maxmemory 512mb
+    ```
 
-   Then update `compose.yaml` and redeploy via Coolify so the change is persisted.
+    Then update `compose.yaml` and redeploy via Coolify so the change is persisted.
 
 ## Post-action
 

--- a/docs/runbooks/release-rollback.md
+++ b/docs/runbooks/release-rollback.md
@@ -32,28 +32,28 @@ Check GlitchTip releases page — confirm the new release SHA is associated with
 ## Procédure
 
 1. **Rollback containers via Coolify** (fast path, ~30 s):
-   - Application → Deployments → previous green deployment → "Redeploy"
-   - Coolify recreates containers from the cached image of that commit. No image rebuild needed.
+    - Application → Deployments → previous green deployment → "Redeploy"
+    - Coolify recreates containers from the cached image of that commit. No image rebuild needed.
 
 2. **Verify the smoke test**:
 
-   ```bash
-   curl -sS https://<prod-host>/api/healthz
-   curl -sS https://<prod-host>/api/health | jq
-   ```
+    ```bash
+    curl -sS https://<prod-host>/api/healthz
+    curl -sS https://<prod-host>/api/health | jq
+    ```
 
 3. **Handle migrations**. Doctrine migrations are forward-only by default. Three scenarios:
 
-   - **Additive migration only** (new column, new table) — leave the schema as-is. The old image ignores the new column; verify there is no NOT NULL without default that would break inserts.
-   - **Destructive migration shipped** (dropped column, renamed table) — the old image will crash. Revert the schema manually:
+    - **Additive migration only** (new column, new table) — leave the schema as-is. The old image ignores the new column; verify there is no NOT NULL without default that would break inserts.
+    - **Destructive migration shipped** (dropped column, renamed table) — the old image will crash. Revert the schema manually:
 
-     ```bash
-     docker compose exec php bin/console doctrine:migrations:execute --down "DoctrineMigrations\\VersionYYYYMMDDHHMMSS"
-     ```
+      ```bash
+      docker compose exec php bin/console doctrine:migrations:execute --down "DoctrineMigrations\\VersionYYYYMMDDHHMMSS"
+      ```
 
-     Only attempt this if a `down()` exists; otherwise restore from the most recent PostgreSQL backup.
+      Only attempt this if a `down()` exists; otherwise restore from the most recent PostgreSQL backup.
 
-   - **Data migration** (UPDATE rows) — generally non-reversible; assess data loss and decide whether to keep the new image patched-forward instead of rolling back.
+    - **Data migration** (UPDATE rows) — generally non-reversible; assess data loss and decide whether to keep the new image patched-forward instead of rolling back.
 
 4. **Inform users** via the status page if downtime exceeded 5 min.
 

--- a/docs/runbooks/secrets-rotation.md
+++ b/docs/runbooks/secrets-rotation.md
@@ -35,8 +35,8 @@ Pour tout secret sauf cas spécifiques (cf. section suivante) :
 1. **Révoquer immédiatement** côté provider (Backblaze, Resend, Anthropic, GitHub PAT…). Couper l'accès en premier, regénérer ensuite.
 2. **Générer une nouvelle valeur** côté provider, scope minimal (ex. B2 : limiter au bucket `btp-backups`).
 3. **Mettre à jour** la localisation source listée dans [secrets-inventory.md](secrets-inventory.md) :
-   - Coolify env → UI ou `coolify env set`
-   - GitHub secret → `gh secret set <NAME>` ou UI repo settings
+    - Coolify env → UI ou `coolify env set`
+    - GitHub secret → `gh secret set <NAME>` ou UI repo settings
 4. **Redéployer** si runtime secret : tag `vX.Y.Z+1-rotation` ou re-trigger `deploy.yml` manuellement.
 5. **Vérifier** : `curl https://<host>/api/healthz` + `curl https://<host>/api/health` verts ; pour CI secret, déclencher le workflow concerné.
 6. **Tracer** dans un commentaire de l'issue d'incident liée (`incident-template.md`) : qui, quand, quel secret, raison.
@@ -49,9 +49,9 @@ La rotation **ne re-chiffre pas** l'historique des backups : trop coûteux, et l
 
 1. Sur un poste de confiance, hors-ligne si possible :
 
-   ```bash
-   age-keygen -o age-key-$(date +%Y%m%d).txt
-   ```
+    ```bash
+    age-keygen -o age-key-$(date +%Y%m%d).txt
+    ```
 
 2. Dans **Bitwarden vault** : **renommer l'item courant** `bike-trip-planner / age private key` en `bike-trip-planner / age private key legacy YYYYMMDD` (date de la dernière utilisation comme clé courante). **Créer un nouvel item** `bike-trip-planner / age private key` (nom canonique conservé) contenant la nouvelle clé privée. Le bootstrap DR cherche toujours le nom canonique ; les items `legacy *` ne servent qu'à restaurer les dumps antérieurs et doivent être conservés indéfiniment.
 3. Mettre à jour `AGE_RECIPIENT` dans Coolify (env du service `backup`) avec la nouvelle clé publique.
@@ -65,17 +65,17 @@ Invalide toutes les sessions en cours (refresh tokens DB inclus, car la vérific
 
 1. Sur la VM, dans le container `php` éphémère :
 
-   ```bash
-   docker compose exec php bin/console lexik:jwt:generate-keypair --overwrite
-   ```
+    ```bash
+    docker compose exec php bin/console lexik:jwt:generate-keypair --overwrite
+    ```
 
-   Cela écrit les PEM dans `/app/config/jwt/` (espace de travail du container). Les chemins runtime (`/etc/bike-trip-planner/jwt/*.pem`) sont **montés depuis l'hôte** ; extraire les fichiers générés :
+    Cela écrit les PEM dans `/app/config/jwt/` (espace de travail du container). Les chemins runtime (`/etc/bike-trip-planner/jwt/*.pem`) sont **montés depuis l'hôte** ; extraire les fichiers générés :
 
-   ```bash
-   docker cp php:/app/config/jwt/private.pem /etc/bike-trip-planner/jwt/private.pem
-   docker cp php:/app/config/jwt/public.pem  /etc/bike-trip-planner/jwt/public.pem
-   chmod 600 /etc/bike-trip-planner/jwt/private.pem
-   ```
+    ```bash
+    docker cp php:/app/config/jwt/private.pem /etc/bike-trip-planner/jwt/private.pem
+    docker cp php:/app/config/jwt/public.pem  /etc/bike-trip-planner/jwt/public.pem
+    chmod 600 /etc/bike-trip-planner/jwt/private.pem
+    ```
 
 2. Mettre à jour `JWT_PASSPHRASE` dans Coolify (utiliser la passphrase saisie lors de la regen).
 3. Redéployer la stack pour que `php` et `worker` rechargent les secrets Docker.
@@ -97,10 +97,10 @@ Downtime ~30 s acceptable. Faire en heure creuse.
 
 1. Sur la VM :
 
-   ```bash
-   docker compose exec database psql -U "$DATABASE_USERNAME" -d "$DATABASE_NAME" -c \
-     "ALTER USER \"$DATABASE_USERNAME\" WITH PASSWORD '<NEW_PASSWORD>';"
-   ```
+    ```bash
+    docker compose exec database psql -U "$DATABASE_USERNAME" -d "$DATABASE_NAME" -c \
+      "ALTER USER \"$DATABASE_USERNAME\" WITH PASSWORD '<NEW_PASSWORD>';"
+    ```
 
 2. Mettre à jour `DATABASE_PASSWORD` dans Coolify env.
 3. Redéployer (Coolify) — `php`, `worker`, `backup` reprennent la nouvelle valeur via le DSN.

--- a/docs/runbooks/valhalla-overpass-rebuild.md
+++ b/docs/runbooks/valhalla-overpass-rebuild.md
@@ -37,27 +37,27 @@ docker compose exec valhalla ls -lh /custom_files
 
 1. **Restart the service first.** It only mmaps `valhalla_tiles.tar`, so a bad load is often fixed without a rebuild:
 
-   ```bash
-   docker compose restart valhalla
-   ```
+    ```bash
+    docker compose restart valhalla
+    ```
 
 2. **Rebuild the graph** when the tiles are genuinely corrupted. On a workstation, not in production (hours, uncapped memory):
 
-   ```bash
-   docker volume rm <project>_valhalla-tiles   # destructive: drops tiles AND the extracts
-   make routing-build france                   # add every country of the perimeter
-   make routing-up
-   ```
+    ```bash
+    docker volume rm <project>_valhalla-tiles   # destructive: drops tiles AND the extracts
+    make routing-build france                   # add every country of the perimeter
+    make routing-up
+    ```
 
-   In production, do not rebuild: re-upload a known-good `valhalla_tiles.tar` per steps 4-6 of [valhalla-routing-graph.md](valhalla-routing-graph.md).
+    In production, do not rebuild: re-upload a known-good `valhalla_tiles.tar` per steps 4-6 of [valhalla-routing-graph.md](valhalla-routing-graph.md).
 
 3. **Re-warm caches** by issuing a known-good routing request:
 
-   ```bash
-   docker compose exec php curl -sS -X POST http://valhalla:8002/route \
-     -H 'Content-Type: application/json' \
-     -d '{"locations":[{"lat":50.63,"lon":3.06},{"lat":50.64,"lon":3.07}],"costing":"bicycle"}'
-   ```
+    ```bash
+    docker compose exec php curl -sS -X POST http://valhalla:8002/route \
+      -H 'Content-Type: application/json' \
+      -d '{"locations":[{"lat":50.63,"lon":3.06},{"lat":50.64,"lon":3.07}],"costing":"bicycle"}'
+    ```
 
 4. **Reference data** — POI / accommodation / event data is no longer fetched from Overpass at runtime; it is served from the local `osm` / `tourism` PostGIS schemas populated by the `provisioner` (ADR-040). If those queries return nothing, it is a provisioning gap, not a routing one: open or re-open the zone concerned (`make provision <zone>`, which loads OSM + DataTourisme for that one zone) rather than rebuilding tiles here. See [zone-opening.md](zone-opening.md); the two datasets share nothing (ADR-049).
 

--- a/docs/runbooks/worker-stuck.md
+++ b/docs/runbooks/worker-stuck.md
@@ -43,30 +43,30 @@ docker compose logs --tail=200 php
 
 1. **Retry transient failures** — if the `failed` transport contains messages that should succeed (external API blip):
 
-   ```bash
-   docker compose exec php bin/console messenger:failed:retry --force
-   ```
+    ```bash
+    docker compose exec php bin/console messenger:failed:retry --force
+    ```
 
 2. **Restart workers gracefully** — sends `SIGTERM`, current message finishes, Redis visibility timeout prevents double-processing:
 
-   ```bash
-   docker compose exec php bin/console messenger:stop-workers
-   docker compose restart php
-   ```
+    ```bash
+    docker compose exec php bin/console messenger:stop-workers
+    docker compose restart php
+    ```
 
 3. **Drop poison messages** — only after copying the payload to the incident issue:
 
-   ```bash
-   docker compose exec php bin/console messenger:failed:remove <id>
-   ```
+    ```bash
+    docker compose exec php bin/console messenger:failed:remove <id>
+    ```
 
 4. **Last resort — full flush** (drops in-flight trip computations; users must retry from the PWA):
 
-   ```bash
-   make flush-queue
-   ```
+    ```bash
+    make flush-queue
+    ```
 
-   This stops workers, runs `app:messenger:clear --all`, and purges the `cache.trip_state` pool.
+    This stops workers, runs `app:messenger:clear --all`, and purges the `cache.trip_state` pool.
 
 ## Post-action
 


### PR DESCRIPTION
Retours de recette post-Sprint 52, points 1 & 2.

## Point 1 — listes numérotées rendues « 1., 1., 1. »

**Cause :** sous MkDocs (python-markdown, **sans `sane_lists`**), un bloc de niveau bloc (fence, paragraphe) placé après une ligne vide sous un item de liste doit être indenté à **4 espaces** pour rester dans l'item. Les runbooks l'indentaient à **3 espaces** (largeur du marqueur `1. `) → python-markdown scindait la liste en plusieurs `<ol>` d'un seul item, et faute de `sane_lists` chaque fragment redémarrait à « 1. ».

**Preuve (build MkDocs) :** la page `mobile-apk-local-testing` générait **4 `<ol>`** pour une procédure de 4 étapes ; après correctif → **1 `<ol>`** séquentiel. Idem sur les autres runbooks (les pages multi-procédures conservent un `<ol>` par procédure réelle : secrets-rotation 5, incident-alerting 4, release-rollback 2 = Diagnostic + Procédure).

**Fix :** ré-indentation du contenu de niveau bloc sous les items (fences **et** paragraphes de continuation) de 3 → 4 espaces, en préservant l'indentation relative interne (les fences imbriqués sous sous-puces restent cohérents). 11 fichiers (10 runbooks + 1 ADR).

## Point 2 — prérequis du runbook mobile-apk

Section `## Prérequis` de `mobile-apk-local-testing.md` étoffée : Node.js 26 + deps `pwa/`, Android SDK/build-tools + JDK 21, `adb`, appareil/émulateur + débogage USB, Docker + Compose recette (`make start-recette` + clés JWT), ngrok + authtoken, HTTPS + `NEXT_PUBLIC_*` figés au build.

## Vérification

- `mkdocs build --strict` : OK, aucun warning.
- Chaque procédure logique = un seul `<ol>` séquentiel (vérifié dans le HTML généré, avant/après).
- `markdownlint-cli2` (image de `make qa`) : 0 erreur sur les 22 fichiers.

Docs-only, aucune modification de code.

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 new findings. The 3 previously-flagged regressions (out-of-scope fenced blocks shifted despite sitting outside any list item) are all fixed in the current commit — verified directly against the live file contents, not just the diff.

**Review checklist:**
- [x] Code respects the project architecture (N/A — docs-only)
- [x] SOLID principles and Law of Demeter followed (N/A — docs-only)
- [x] Design patterns used where appropriate (N/A — docs-only)
- [x] Tests cover new/changed cases (N/A — docs-only; `mkdocs build --strict` + `markdownlint-cli2` evidence provided in PR description)
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Resolved threads:** Resolved 3 previously open threads that were addressed (`incident-alerting.md` diagram alignment, `incident-alerting.md` JSON schema indentation, `database-disk-full.md` SQL alignment).

**Inline comments:** No inline comments.

Reviewed commit: `1303dff96aa60104901de5a3c3faf3178043ad77`
<!-- claude-review-end -->
