### PR TITLE
fix(early-access): stop verify-link loop + use FRONTEND_URL for the email link

### DIFF
--- a/api/src/State/AccessRequestCreateProcessor.php
+++ b/api/src/State/AccessRequestCreateProcessor.php
@@ -48,8 +48,8 @@ final readonly class AccessRequestCreateProcessor implements ProcessorInterface
         private AccessRequestHmacService $hmacService,
         #[Autowire(service: 'limiter.access_request_ip')]
         private RateLimiterFactory $accessRequestIpLimiter,
-        #[Autowire(env: 'BACKEND_URL')]
-        private string $backendUrl = 'https://localhost',
+        #[Autowire(env: 'FRONTEND_URL')]
+        private string $frontendUrl = 'https://localhost',
         #[Autowire(env: 'MAILER_SENDER_EMAIL')]
         private string $senderEmail = 'noreply@bike-trip-planner.com',
     ) {
@@ -102,11 +102,15 @@ final readonly class AccessRequestCreateProcessor implements ProcessorInterface
             return new JsonResponse(['message' => $neutralMessage], Response::HTTP_ACCEPTED);
         }
 
-        // Generate HMAC-signed verification URL
+        // Generate HMAC-signed verification URL. It points at the FRONTEND route
+        // (like the magic-link and email-change emails): the /access-requests/verify
+        // page then calls the backend via fetch. Using FRONTEND_URL means the link
+        // uses the public origin (e.g. the ngrok host in mobile testing) instead of
+        // the internal https://localhost.
         $payload = $this->hmacService->generatePayload($email);
         $verifyUrl = \sprintf(
             '%s/access-requests/verify?email=%s&expires=%d&signature=%s',
-            rtrim($this->backendUrl, '/'),
+            rtrim($this->frontendUrl, '/'),
             urlencode($payload['email']),
             $payload['expires'],
             $payload['signature'],

--- a/pwa/src/app/access-requests/verify/verify-page.tsx
+++ b/pwa/src/app/access-requests/verify/verify-page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef } from "react";
-import { useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { Loader2 } from "lucide-react";
 import { API_URL } from "@/lib/constants";
@@ -12,9 +12,13 @@ import { API_URL } from "@/lib/constants";
  * When the user clicks the verification link in their email, they land here
  * at /access-requests/verify?email=...&expires=...&signature=...
  *
- * This page forwards the query params to the backend GET /access-requests/verify
- * endpoint, which validates the HMAC, marks the access request as verified, and
- * redirects to {FRONTEND_URL}?access=confirmed.
+ * This page `fetch`es the backend GET /access-requests/verify endpoint (which
+ * validates the HMAC and marks the access request as verified), then navigates
+ * client-side to /?access=confirmed. It uses `fetch` rather than a full-page
+ * navigation on purpose: the backend route shares this URL, and Caddy routes any
+ * `text/html` navigation back to the PWA — a browser redirect to the same path
+ * would loop forever. A `fetch` does not send an html Accept header, so it reaches
+ * the PHP controller instead.
  *
  * The landing page then reads the ?access=confirmed param and shows a
  * confirmation message.
@@ -22,26 +26,41 @@ import { API_URL } from "@/lib/constants";
 export default function VerifyPage() {
   const t = useTranslations("earlyAccess");
   const searchParams = useSearchParams();
-  const redirectStarted = useRef(false);
+  const router = useRouter();
+  const verifyStarted = useRef(false);
 
   useEffect(() => {
-    if (redirectStarted.current) return;
-    redirectStarted.current = true;
+    if (verifyStarted.current) return;
+    verifyStarted.current = true;
 
     const email = searchParams.get("email");
     const expires = searchParams.get("expires");
     const signature = searchParams.get("signature");
 
     if (!email || !expires || !signature) {
-      window.location.replace(`${window.location.origin}/`);
+      router.replace("/");
       return;
     }
 
     const params = new URLSearchParams({ email, expires, signature });
-    window.location.replace(
-      `${API_URL}/access-requests/verify?${params.toString()}`,
-    );
-  }, [searchParams]);
+    const verify = async () => {
+      try {
+        // Reach the PHP controller with a `fetch` (Accept: */*): it does NOT
+        // match Caddy's `@pwa` (text/html) route, so it hits the backend.
+        // A full-page navigation to this same-origin path would instead be
+        // routed back to this page by Caddy — an infinite loop.
+        await fetch(`${API_URL}/access-requests/verify?${params.toString()}`, {
+          credentials: "include",
+        });
+      } catch {
+        // Anti-enumeration: land on the same confirmation regardless of outcome.
+      } finally {
+        router.replace("/?access=confirmed");
+      }
+    };
+
+    void verify();
+  }, [searchParams, router]);
 
   return (
     <div


### PR DESCRIPTION
Retours de recette post-Sprint 52, points 3 & 4.

## Point 3 — boucle infinie au clic sur le lien de vérification

**Cause :** la page front `access-requests/verify` faisait un `window.location.replace()` vers `/access-requests/verify` (même origine). Le Caddyfile route toute navigation `text/html` vers la PWA (jamais le contrôleur PHP) → la page rebondissait sur elle-même à l'infini. Le garde `useRef` ne protège que dans un même montage, or chaque navigation repart d'un document neuf.

**Fix :** la page appelle désormais le backend en **`fetch`** (dont l'en-tête `Accept` n'est pas `text/html`, donc il atteint le contrôleur PHP), puis fait un `router.replace("/?access=confirmed")` côté client — même schéma que le flux magic-link (`auth/verify/[token]`). Plus de navigation pleine page, plus de boucle.

## Point 4 — l'email contenait `localhost` au lieu de l'URL ngrok

**Cause :** le processor bâtissait le lien depuis `BACKEND_URL` (jamais passé dans compose, figé à `https://localhost` ; la procédure ngrok ne règle que `FRONTEND_URL`).

**Fix :** le lien est construit depuis **`FRONTEND_URL`** et pointe vers la route **front** `/access-requests/verify` (comme les emails magic-link et email-change). Il utilise donc l'origine publique (l'hôte ngrok en test mobile). `BACKEND_URL` devient inutilisé.

## Vérification

- `tsc` / `eslint` / `prettier` : OK sur la page modifiée.
- `php-cs-fixer` (0 correction) + `phpstan` (0 erreur) sur le backend.
- PHPUnit `tests/Functional/AccessRequest` : **24/24** (processor + contrôleur, aucune régression).

## À finaliser (manuel)

`BACKEND_URL` est maintenant inutilisé. La ligne `BACKEND_URL=https://localhost` doit être retirée de `api/.env` (fichier protégé côté environnement, non modifiable par l'agent) — voir commentaire ci-dessous.

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 critical, 0 warning, 1 non-blocking suggestion.

**Commit reviewed:** `f598b5565077af13e17558aa8cce0e6a6e7b52f2`

**Checklist:**
- [x] Code respects the project architecture (stateless backend, `FRONTEND_URL`/`API_URL` split via Caddy `Accept`-header routing, mirrors the existing magic-link pattern)
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate (no unjustified quick-and-dirty)
- [ ] Tests cover new/changed cases — no test asserts the verify email link's host (see inline comment)
- [x] Documentation is up to date (inline comments explain the Caddy routing rationale)
- [x] Dependent tickets accounted for

**Inline comments:** Posted 1 inline comment.
<!-- claude-review-end -->