### PR TITLE
refactor(auth)!: purge dead Capacitor remnants (auth, Mercure, static export)

### DIFF
--- a/api/.env
+++ b/api/.env
@@ -32,7 +32,7 @@ DEFAULT_URI=http://localhost
 ###< symfony/routing ###
 
 ###> nelmio/cors-bundle ###
-CORS_ALLOW_ORIGIN='^(https?|capacitor)://(localhost|127\.0\.0\.1)(:[0-9]+)?$'
+CORS_ALLOW_ORIGIN='^https?://(localhost|127\.0\.0\.1)(:[0-9]+)?$'
 ###< nelmio/cors-bundle ###
 
 ###> symfony/mercure-bundle ###

--- a/api/config/packages/nelmio_cors.php
+++ b/api/config/packages/nelmio_cors.php
@@ -23,12 +23,11 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 'Content-Type',
                 'Authorization',
                 // Correlation ID the PWA resends on every request (#485); required
-                // so cross-origin clients (e.g. the Capacitor app) may send it.
+                // so cross-origin clients may send it.
                 'X-Request-Id',
             ],
             'expose_headers' => [
                 'Link',
-                'X-Mercure-Token',
                 'X-Request-Id',
             ],
             'max_age' => 3600,

--- a/api/src/Mercure/MercureSubscriberListener.php
+++ b/api/src/Mercure/MercureSubscriberListener.php
@@ -12,10 +12,8 @@ use Symfony\Component\HttpKernel\KernelEvents;
 /**
  * Attaches a Mercure subscriber JWT to responses that create or access a trip.
  *
- * Listens on kernel.response and injects the `mercureAuthorization` cookie and
- * the `X-Mercure-Token` response header for endpoints matching `/trips/{uuid}` patterns.
- * The header allows Capacitor clients (which cannot read HttpOnly cookies) to obtain
- * the subscriber JWT without requiring body injection.
+ * Listens on kernel.response and injects the `mercureAuthorization` cookie for
+ * endpoints matching `/trips/{uuid}` patterns.
  *
  * Matched routes:
  * - POST /trips (trip creation — 202 response)
@@ -64,9 +62,6 @@ final readonly class MercureSubscriberListener
 
         // Set the HttpOnly subscriber cookie (for browser SSE via EventSource)
         $response->headers->setCookie($this->tokenIssuer->createSubscriberCookie($token));
-
-        // Set the X-Mercure-Token header so Capacitor clients can read the JWT directly
-        $response->headers->set('X-Mercure-Token', $token);
     }
 
     /**

--- a/api/src/State/Auth/AuthRefreshProcessor.php
+++ b/api/src/State/Auth/AuthRefreshProcessor.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\State\Auth;
 
-use Symfony\Component\HttpFoundation\Request;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use App\ApiResource\Auth\Auth;
@@ -24,7 +23,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * Rotates a refresh token and issues a new JWT.
  *
- * Reads the refresh token from cookie or request body (Capacitor).
+ * Reads the refresh token from the cookie.
  *
  * @implements ProcessorInterface<Auth, JsonResponse>
  */
@@ -57,13 +56,6 @@ final readonly class AuthRefreshProcessor implements ProcessorInterface
     {
         $request = $this->requestStack->getCurrentRequest();
         $token = $request?->cookies->get(AuthCookies::REFRESH_TOKEN);
-        $isCapacitor = $this->isCapacitorRequest();
-
-        // Capacitor sends refresh token in body
-        if (null === $token && $isCapacitor && $request instanceof Request) {
-            $body = $request->toArray();
-            $token = $body['refresh_token'] ?? null;
-        }
 
         if (null === $token || '' === $token) {
             return new JsonResponse(
@@ -121,12 +113,7 @@ final readonly class AuthRefreshProcessor implements ProcessorInterface
 
         $this->logger->debug('Auth refresh success', ['user' => $user->getEmail()]);
 
-        $responseData = ['token' => $jwt];
-        if ($isCapacitor) {
-            $responseData['refresh_token'] = $livePlain;
-        }
-
-        $response = new JsonResponse($responseData);
+        $response = new JsonResponse(['token' => $jwt]);
         $this->setRefreshTokenCookie($response, $livePlain, $live->getExpiresAt());
 
         return $response;
@@ -189,10 +176,5 @@ final readonly class AuthRefreshProcessor implements ProcessorInterface
         $response->headers->clearCookie(AuthCookies::REFRESH_TOKEN, '/', null, true, true, 'strict');
 
         return $response;
-    }
-
-    private function getRequestStack(): RequestStack
-    {
-        return $this->requestStack;
     }
 }

--- a/api/src/State/Auth/AuthResponseHelper.php
+++ b/api/src/State/Auth/AuthResponseHelper.php
@@ -7,23 +7,12 @@ namespace App\State\Auth;
 use App\Security\AuthCookies;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
- * Shared helpers for auth processors (Capacitor detection, refresh token cookie).
+ * Shared helpers for auth processors (refresh token cookie).
  */
 trait AuthResponseHelper
 {
-    abstract private function getRequestStack(): RequestStack;
-
-    private function isCapacitorRequest(): bool
-    {
-        $request = $this->getRequestStack()->getCurrentRequest();
-        $origin = $request?->headers->get('Origin', '') ?? '';
-
-        return str_starts_with($origin, 'capacitor://');
-    }
-
     private function setRefreshTokenCookie(JsonResponse $response, string $token, \DateTimeImmutable $expiresAt): void
     {
         // SameSite=Lax (not Strict) so the cookie is sent on top-level cross-site

--- a/api/src/State/Auth/AuthVerifyProcessor.php
+++ b/api/src/State/Auth/AuthVerifyProcessor.php
@@ -15,14 +15,11 @@ use Doctrine\ORM\EntityManagerInterface;
 use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * Validates a magic link token, issues JWT + refresh token.
- *
- * For Capacitor clients (Origin: capacitor://), the refresh token is also included in the response body.
  *
  * @implements ProcessorInterface<Auth, JsonResponse>
  */
@@ -35,7 +32,6 @@ final readonly class AuthVerifyProcessor implements ProcessorInterface
         private RefreshTokenRepository $refreshTokenRepository,
         private EntityManagerInterface $entityManager,
         private JWTTokenManagerInterface $jwtManager,
-        private RequestStack $requestStack,
         private LoggerInterface $logger,
         private TranslatorInterface $translator,
     ) {
@@ -80,27 +76,15 @@ final readonly class AuthVerifyProcessor implements ProcessorInterface
         });
         \assert($refreshToken instanceof RefreshToken);
 
-        $isCapacitor = $this->isCapacitorRequest();
-
         // Plaintext is available on the freshly minted token (stored encrypted).
         $plainToken = $refreshToken->getPlainToken();
         \assert(null !== $plainToken);
 
         $this->logger->debug('Auth verify token verified', ['user' => $user->getEmail()]);
 
-        $responseData = ['token' => $jwt];
-        if ($isCapacitor) {
-            $responseData['refresh_token'] = $plainToken;
-        }
-
-        $response = new JsonResponse($responseData);
+        $response = new JsonResponse(['token' => $jwt]);
         $this->setRefreshTokenCookie($response, $plainToken, $refreshToken->getExpiresAt());
 
         return $response;
-    }
-
-    private function getRequestStack(): RequestStack
-    {
-        return $this->requestStack;
     }
 }

--- a/api/tests/Functional/Auth/AuthRefreshTest.php
+++ b/api/tests/Functional/Auth/AuthRefreshTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Functional\Auth;
 
+use Symfony\Component\BrowserKit\Cookie as BrowserKitCookie;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
 use App\Entity\RefreshToken;
@@ -52,18 +53,35 @@ final class AuthRefreshTest extends ApiTestCase
     }
 
     /**
-     * Sends a refresh request using Capacitor body transport (Origin header
-     * triggers body-based refresh token reading in the processor).
+     * Sends a refresh request with the refresh token in the HttpOnly cookie.
      */
     private function sendRefreshRequest(string $refreshToken): ResponseInterface
     {
-        return self::createClient()->request('POST', '/auth/refresh', [
-            'headers' => [
-                'Content-Type' => 'application/json',
-                'Origin' => 'capacitor://localhost',
-            ],
-            'json' => ['refresh_token' => $refreshToken],
+        $client = self::createClient();
+        // A raw `Cookie` header maps to $server['HTTP_COOKIE'] but never populates
+        // $request->cookies; the processor reads the cookie bag, so the token must
+        // go through the BrowserKit CookieJar (host localhost).
+        $client->getCookieJar()->set(
+            new BrowserKitCookie('refresh_token', $refreshToken, null, '/', 'localhost'),
+        );
+
+        return $client->request('POST', '/auth/refresh', [
+            'headers' => ['Content-Type' => 'application/json'],
         ]);
+    }
+
+    /**
+     * Extracts the rotated refresh token from the response's Set-Cookie header.
+     */
+    private function refreshCookieValue(ResponseInterface $response): string
+    {
+        foreach ($response->getHeaders(false)['set-cookie'] ?? [] as $setCookie) {
+            if (1 === preg_match('/(?:^|;\s*)refresh_token=([^;]+)/', $setCookie, $matches)) {
+                return $matches[1];
+            }
+        }
+
+        self::fail('No refresh_token cookie in the response');
     }
 
     #[Test]
@@ -129,16 +147,14 @@ final class AuthRefreshTest extends ApiTestCase
     }
 
     #[Test]
-    public function refreshReturnsNewRefreshTokenInBody(): void
+    public function refreshRotatesTheRefreshTokenCookie(): void
     {
         $this->createUserWithRefreshToken('rotate@example.com', 'old-refresh-token');
 
         $response = $this->sendRefreshRequest('old-refresh-token');
 
         $this->assertResponseStatusCodeSame(200);
-        $data = $response->toArray(false);
-        $this->assertArrayHasKey('refresh_token', $data);
-        $this->assertNotEquals('old-refresh-token', $data['refresh_token']);
+        $this->assertNotEquals('old-refresh-token', $this->refreshCookieValue($response));
     }
 
     #[Test]
@@ -183,11 +199,11 @@ final class AuthRefreshTest extends ApiTestCase
 
         $first = $this->sendRefreshRequest('single-use-token');
         $this->assertResponseStatusCodeSame(200);
-        $successor = $first->toArray(false)['refresh_token'];
+        $successor = $this->refreshCookieValue($first);
 
         $second = $this->sendRefreshRequest('single-use-token');
         $this->assertResponseStatusCodeSame(200);
-        $this->assertSame($successor, $second->toArray(false)['refresh_token']);
+        $this->assertSame($successor, $this->refreshCookieValue($second));
     }
 
     #[Test]

--- a/api/tests/Unit/Mercure/MercureSubscriberListenerTest.php
+++ b/api/tests/Unit/Mercure/MercureSubscriberListenerTest.php
@@ -42,7 +42,7 @@ final class MercureSubscriberListenerTest extends TestCase
 
     #[Test]
     #[DataProvider('tripEndpointProvider')]
-    public function setsCookieAndHeaderForTripEndpoints(string $method, string $path): void
+    public function setsCookieForTripEndpoints(string $method, string $path): void
     {
         $request = Request::create($path, $method);
         $response = new Response('ok');
@@ -53,12 +53,11 @@ final class MercureSubscriberListenerTest extends TestCase
         $cookies = $response->headers->getCookies();
         self::assertCount(1, $cookies);
         self::assertSame('mercureAuthorization', $cookies[0]->getName());
-        self::assertNotEmpty($response->headers->get('X-Mercure-Token'));
-        self::assertSame($cookies[0]->getValue(), $response->headers->get('X-Mercure-Token'));
+        self::assertNotEmpty($cookies[0]->getValue());
     }
 
     #[Test]
-    public function setsCookieAndHeaderForPostTripsFromResponseBody(): void
+    public function setsCookieForPostTripsFromResponseBody(): void
     {
         $request = Request::create('/trips', 'POST');
         $response = new JsonResponse(['id' => self::TRIP_UUID, 'computationStatus' => []]);
@@ -69,11 +68,10 @@ final class MercureSubscriberListenerTest extends TestCase
         $cookies = $response->headers->getCookies();
         self::assertCount(1, $cookies);
         self::assertSame('mercureAuthorization', $cookies[0]->getName());
-        self::assertNotEmpty($response->headers->get('X-Mercure-Token'));
     }
 
     #[Test]
-    public function setsCookieAndHeaderForGpxUpload(): void
+    public function setsCookieForGpxUpload(): void
     {
         $request = Request::create('/trips/gpx-upload', 'POST');
         $response = new JsonResponse(['id' => self::TRIP_UUID]);
@@ -83,7 +81,7 @@ final class MercureSubscriberListenerTest extends TestCase
 
         $cookies = $response->headers->getCookies();
         self::assertCount(1, $cookies);
-        self::assertNotEmpty($response->headers->get('X-Mercure-Token'));
+        self::assertSame('mercureAuthorization', $cookies[0]->getName());
     }
 
     #[Test]
@@ -96,7 +94,6 @@ final class MercureSubscriberListenerTest extends TestCase
         $this->listener->__invoke($event);
 
         self::assertEmpty($response->headers->getCookies());
-        self::assertNull($response->headers->get('X-Mercure-Token'));
     }
 
     #[Test]
@@ -110,7 +107,6 @@ final class MercureSubscriberListenerTest extends TestCase
         $this->listener->__invoke($event);
 
         self::assertEmpty($response->headers->getCookies());
-        self::assertNull($response->headers->get('X-Mercure-Token'));
     }
 
     #[Test]
@@ -123,7 +119,6 @@ final class MercureSubscriberListenerTest extends TestCase
         $this->listener->__invoke($event);
 
         self::assertEmpty($response->headers->getCookies());
-        self::assertNull($response->headers->get('X-Mercure-Token'));
     }
 
     private function createResponseEvent(Request $request, Response $response): ResponseEvent

--- a/docs/adr/adr-023-authentication-strategy.md
+++ b/docs/adr/adr-023-authentication-strategy.md
@@ -214,7 +214,7 @@ Rate limiting on the magic link generation endpoint to prevent mailbox spam and 
 
 A native mobile client (see [ADR-053](adr-053-mobile-strategy-native-app.md)) does not carry a browser cookie jar, so HttpOnly cookies cannot be relied on: the refresh token must instead be returned in the response body and kept in the platform's secure storage.
 
-The backend already carries this mechanism, but its client detection is currently keyed to the **removed** Capacitor WebView's `capacitor://` Origin (`AuthResponseHelper::isCapacitorRequest()`, the `capacitor://` entry in the `CORS_ALLOW_ORIGIN` allow-list, and the `X-Mercure-Token` response header set by `MercureSubscriberListener` so the WebView could read the JWT). With that client gone, this path is dead until the native app (ADR-053) is built and the detection is re-keyed to it. **Generalizing the detection to the native client is deferred to the native-app workstream** — it is not done in this iteration.
+An earlier Capacitor-specific version of this mechanism (client detection keyed to the WebView's `capacitor://` Origin, a `capacitor://` entry in the `CORS_ALLOW_ORIGIN` allow-list, and an `X-Mercure-Token` response header so the WebView could read the subscriber JWT) has been **removed** as dead code along with the Capacitor client. The mechanism will be **rebuilt** for the native client in the native-app workstream ([ADR-053](adr-053-mobile-strategy-native-app.md)), with a client detection scheme (origin or a dedicated native-client header) defined then. It is not carried in the current codebase.
 
 ---
 

--- a/pwa/src/app/(app)/trips/[id]/page.tsx
+++ b/pwa/src/app/(app)/trips/[id]/page.tsx
@@ -4,10 +4,6 @@ const TripPage = dynamic(() => import("./trip-page"), {
   loading: () => null,
 });
 
-export function generateStaticParams() {
-  return [{ id: "__placeholder" }];
-}
-
 export default function Page() {
   return <TripPage />;
 }

--- a/pwa/src/app/s/[code]/page.tsx
+++ b/pwa/src/app/s/[code]/page.tsx
@@ -5,10 +5,6 @@ const SharedTripPage = dynamic(() => import("./shared-trip-page"), {
   loading: () => null,
 });
 
-export function generateStaticParams() {
-  return [{ code: "__placeholder" }];
-}
-
 /** Minimal shape of the public shared-trip payload used for metadata. */
 interface SharedTripMeta {
   title?: string | null;
@@ -29,10 +25,6 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { code } = await params;
   const fallback: Metadata = { title: "Shared trip — Bike Trip Planner" };
-
-  if ("__placeholder" === code) {
-    return fallback;
-  }
 
   try {
     const backend = process.env.API_BACKEND_URL ?? "http://php";

--- a/pwa/src/app/s/shared-trip-metadata.test.ts
+++ b/pwa/src/app/s/shared-trip-metadata.test.ts
@@ -18,17 +18,6 @@ describe("generateMetadata (shared trip)", () => {
   beforeEach(() => vi.clearAllMocks());
   afterEach(() => vi.unstubAllGlobals());
 
-  it("returns the generic fallback for the static-export placeholder without fetching", async () => {
-    const fetchSpy = mockFetch(() => {
-      throw new Error("should not be called");
-    });
-
-    const meta = await generateMetadata(params("__placeholder"));
-
-    expect(meta).toEqual({ title: "Shared trip — Bike Trip Planner" });
-    expect(fetchSpy).not.toHaveBeenCalled();
-  });
-
   it("falls back to the generic title when the backend responds non-OK (revoked/unknown code)", async () => {
     const fetchSpy = mockFetch(() => Promise.resolve({ ok: false }));
 


### PR DESCRIPTION
## Contexte

Suite de #1006/#1007. Le client Capacitor étant supprimé, les chemins backend qui le ciblaient sont **injoignables** (code mort). On les retire (le futur client natif — ADR-053 — rebâtira son propre mécanisme), plutôt que de les traîner. Traite les deux points « Suivi » de #1007.

## Changements

**Backend — auth**
- `AuthResponseHelper` : suppression de `isCapacitorRequest()` (+ abstract `getRequestStack()`).
- `AuthRefreshProcessor` / `AuthVerifyProcessor` : suppression des branches « refresh token dans le body » (chemin **cookie uniquement**). `AuthRefreshProcessor` garde `RequestStack` (lecture du cookie) ; `AuthVerifyProcessor` ne l'injecte plus.
- `CORS_ALLOW_ORIGIN` (`api/.env`) : retrait de l'alternative `capacitor://`.

**Backend — Mercure**
- `MercureSubscriberListener` : suppression du header `X-Mercure-Token` (les clients web lisent le cookie `mercureAuthorization`). Retrait aussi de `expose_headers` dans `nelmio_cors.php`.

**Frontend**
- Suppression du scaffolding d'export statique Capacitor (`generateStaticParams()` + branche `__placeholder`) sur `/s/[code]` et `/trips/[id]`.

**Docs**
- ADR-023 §Native Mobile Adaptation : le mécanisme Capacitor-spécifique est **retiré** (code mort) ; l'adaptation client natif sera **rebâtie** au chantier ADR-053.

## Vérification

- Backend : PHPStan L9 `0 erreur` · **PHPUnit 1622 verts** (dont 71 ciblés `Auth`+`Mercure`) · php-cs-fixer/rector clean.
- Frontend : `tsc` 0 · **vitest 383** · eslint 0 error · prettier · i18n 805 · bddgen.
- Docs : `mkdocs --strict` ok · markdownlint 0.
- Sweeps `capacitor` / `X-Mercure-Token` / `__placeholder` : vides.

> `AuthRefreshTest` conserve sa couverture rotation/grace, convertie du transport body Capacitor vers le transport **cookie** BrowserKit.
> Playwright E2E : CI = gate.

<!-- claude-review-start -->
## Claude Review

**Findings:** 0 critical, 0 warning, 1 suggestion (non-blocking documentation note)

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [ ] Documentation is up to date — `docs/adr/adr-053-mobile-strategy-native-app.md` still describes the body-based refresh-token mechanism in the present tense, contradicting the ADR-023 paragraph this PR just updated to say it's removed/not carried in the codebase. Not part of this PR's diff; flagged as a follow-up.
- [x] Dependent tickets accounted for

**Verdict:** APPROVE

**Commit reviewed:** `b77b1ac3a4cca29ad4f302717bc90aa07a4f0e6e`
<!-- claude-review-end -->