### PR TITLE
fix(i18n): render public pages dynamically to fix NextIntl static errors (#977)

### DIFF
--- a/pwa/src/app/layout.tsx
+++ b/pwa/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Fraunces, Inter_Tight, JetBrains_Mono } from "next/font/google";
 import { getLocale, getMessages, getTranslations } from "next-intl/server";
+import { unstable_rethrow } from "next/navigation";
 import { DEFAULT_LOCALE } from "@/i18n/locale";
 import { SITE_URL } from "@/lib/constants";
 import "./globals.css";
@@ -34,9 +35,10 @@ export async function generateMetadata(): Promise<Metadata> {
     const t = await getTranslations("layout");
     title = t("title");
     description = t("description");
-  } catch {
-    // Static export prerendering: next-intl server context unavailable — keep
-    // the English defaults above.
+  } catch (error) {
+    unstable_rethrow(error);
+    // Vraie erreur uniquement : les bailouts framework (cookies()) sont relancés
+    // pour que Next marque la route dynamique. On garde les valeurs par défaut.
   }
 
   // Open Graph / Twitter Card on every page (audit 35.2 SEO-003). `metadataBase`
@@ -73,8 +75,9 @@ export default async function RootLayout({
   try {
     locale = await getLocale();
     messages = await getMessages();
-  } catch {
-    // Static export prerendering: next-intl server context unavailable
+  } catch (error) {
+    unstable_rethrow(error);
+    // Vraie erreur uniquement : repli sur la locale par défaut.
     locale = DEFAULT_LOCALE;
     messages = (await import(`../../messages/${DEFAULT_LOCALE}.json`)).default;
   }


### PR DESCRIPTION
Closes #977.

## Problème

`pwa/src/i18n/request.ts` lit le cookie `locale` via `cookies()`. Les deux `try/catch` de `pwa/src/app/layout.tsx` **avalaient** le bailout `cookies()` → Next ne marquait pas la route dynamique → les pages `(public)` (`faq`/`legal`/`privacy`) étaient figées en `fr` statique → divergence serveur/client au runtime sous un cookie `locale=en` (« switched to client rendering », `useTranslations` lève avant le montage du provider).

## Fix

`unstable_rethrow(error)` en tête des deux `catch` de `layout.tsx` : le bailout framework est relancé (→ Next marque les pages dynamiques, elles respectent le cookie `locale`), tandis que le repli `fr` reste pour les vraies erreurs. Un seul fichier modifié.

**Pourquoi c'est sûr maintenant** (le fix `unstable_rethrow` de #989 avait été reverté) : le 500 prod de #989 venait du rethrow **combiné au SSG forcé des routes verify** (`generateStaticParams` → `__placeholder`). Ce SSG a été supprimé avec le retrait du build mobile Capacitor (#1007 / #1008) — plus aucune page SSG à casser.

## Vérification

`npm run build` (Next 16.3.0, standalone) — table des routes :

```
├ ƒ /faq
├ ƒ /legal
├ ƒ /privacy
...
○  (Static)   prerendered as static content
ƒ  (Dynamic)  server-rendered on demand
```

`/faq` · `/legal` · `/privacy` sont désormais **ƒ (Dynamic)** (statiques avant le fix → confirme la cause). `tsc --noEmit`, `eslint`, `prettier --check` : verts.

> Conséquence assumée : ces 3 pages publiques deviennent dynamiques (comme `(app)` et `/`), la locale étant portée par un cookie. Un suivi séparé pourra les re-statiques si besoin SEO/cache (locale sans cookie).
> Playwright E2E : CI = gate.

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 critical, 0 blocking issues, 2 findings (test coverage, docs consistency). The `unstable_rethrow` fix is correct and matches Next.js 16's documented pattern for re-raising the `cookies()` dynamic-API bailout; verified against `next/navigation` semantics and confirmed against the build output showing `/faq`, `/legal`, `/privacy` now `ƒ (Dynamic)`. Confirmed the `generateStaticParams`/`__placeholder` scaffolding that caused the #989 prod 500 was indeed removed in #1007/#1008, so the safety argument in the PR description holds.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [ ] Tests cover new/changed cases — no automated regression test for the locale-cookie/public-page scenario (see finding below)
- [ ] Documentation is up to date — TRACKING.md row for #977 still points at closed PR #989
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments (findings below apply to files outside this diff — TRACKING.md and the Playwright specs — so they're summarized here instead).

**Findings:**
1. **suggestion (test-coverage):** This exact bug (`cookies()` bailout swallowed on `(public)` pages) has now been fixed and reverted once already (#989, reverted for a different but related reason). None of `pwa/tests/mocked/faq.spec.ts` or `legal-privacy.spec.ts` set a non-default `locale` cookie — they only assert the French default. The issue's own acceptance criteria call for loading `/faq`, `/legal`, `/privacy` with `locale=en` and asserting no error overlay/hydration mismatch. Given the history of this code path, a Playwright regression test asserting `/faq` (and `/legal`, `/privacy`) render correctly under `context.addCookies([{ name: "locale", value: "en", ... }])` would catch a future re-introduction of the swallow bug that CI would otherwise miss (`tsc`/`eslint`/`build` don't exercise runtime hydration).
2. **suggestion (docs):** `TRACKING.md` line 1702 still lists #977 as `❌ Non implémentée` referencing the closed PR #989. Once this merges, that row should be updated to reference #1009 and reflect the resolved status, per the project's own consistency convention (Sprint 52 table + narrative both mention #989's revert).

Commit reviewed: `23d372d8fcf4f00ab1ee53e992b8c458ccc63808`
<!-- claude-review-end -->