### PR TITLE
spike(mobile): confirm Mercure header auth for RN subscribers (#1011)

### DIFF
--- a/docs/mobile-mercure-auth.md
+++ b/docs/mobile-mercure-auth.md
@@ -1,0 +1,65 @@
+# Mobile Mercure auth (SSE for non-browser subscribers)
+
+Spike outcome for [#1011](https://github.com/vincentchalamon/bike-trip-planner/issues/1011).
+Establishes how the Expo/React Native app subscribes to the Mercure hub in real
+time, since the web subscribes with an httpOnly cookie that React Native cannot use.
+
+## Finding: the hub is not cookie-only
+
+The embedded Caddy Mercure module (`.docker/php/Caddyfile`) is configured with
+`subscriber_jwt` and `anonymous`. It authenticates a subscriber via any of the
+standard Mercure channels, in order of preference:
+
+1. `mercureAuthorization` httpOnly cookie — used by browsers so the JWT never
+   reaches JS (XSS protection). **Not usable from React Native.**
+2. `Authorization: Bearer <jwt>` request header.
+3. `?authorization=<jwt>` query parameter.
+
+Both (2) and (3) were confirmed against the live dev hub: a non-browser subscriber
+(plain `curl`, no cookie) received a published event. **No Caddy/hub change is
+required** for the mobile client.
+
+### Reproduction
+
+Subscriber and publisher JWTs are HS256, signed with `MERCURE_JWT_SECRET`
+(`MERCURE_JWT_KEY` in compose; dev default `!ChangeThisMercureHubJWTSecretKey!`).
+
+```bash
+# mint an HS256 JWT with the given payload (dev secret)
+KEY='!ChangeThisMercureHubJWTSecretKey!'
+b64url(){ openssl base64 -A | tr '+/' '-_' | tr -d '='; }
+mkjwt(){ h=$(printf '%s' '{"alg":"HS256","typ":"JWT"}' | b64url); p=$(printf '%s' "$1" | b64url); \
+  echo "$h.$p.$(printf '%s' "$h.$p" | openssl dgst -sha256 -hmac "$KEY" -binary | b64url)"; }
+
+SUB=$(mkjwt '{"mercure":{"subscribe":["*"]}}')
+PUB=$(mkjwt '{"mercure":{"publish":["*"]}}')
+
+# subscribe with the header (background), then publish
+curl -sk -N --max-time 6 -H "Authorization: Bearer $SUB" \
+  'https://localhost/.well-known/mercure?topic=https%3A%2F%2Fexample.com%2Ftest' &
+curl -sk -X POST -H "Authorization: Bearer $PUB" \
+  --data-urlencode 'topic=https://example.com/test' \
+  --data-urlencode 'data={"event":"trip"}' \
+  https://localhost/.well-known/mercure
+# -> the subscriber prints: data: {"event":"trip"}
+```
+
+## Retained mechanism for #1014
+
+Use the **`Authorization: Bearer` header** (`react-native-sse` supports custom
+headers on its `EventSource` polyfill). The `?authorization=` query parameter is
+the documented fallback if a platform strips the header; it is redacted from access
+logs by the Caddyfile, but prefer the header so the token stays out of URLs.
+
+## Gap to close before #1014 (backend)
+
+The per-trip subscriber JWT already exists — `App\Mercure\MercureTokenIssuer`
+mints it (HS256, claim `mercure.subscribe: ["/trips/{id}"]`, 1 h TTL) and
+`App\Mercure\MercureSubscriberListener` attaches it. But it is delivered **only**
+as the httpOnly `mercureAuthorization` cookie, on the trip create/access responses.
+React Native cannot read that cookie, so the mobile client has no way to obtain the
+token to put in the header.
+
+A backend change is therefore required before #1014: deliver the same subscriber
+token through a channel a non-browser client can read, without weakening the web's
+cookie posture. Tracked in [#1019](https://github.com/vincentchalamon/bike-trip-planner/issues/1019).


### PR DESCRIPTION
Closes #1011.

## Résultat du spike

- **Le hub Mercure n'est pas cookie-only.** Le module Caddy (`subscriber_jwt` + `anonymous`) authentifie un abonné non-navigateur via `Authorization: Bearer <jwt>` **et** `?authorization=<jwt>`. Vérifié par curl contre le hub dev : un abonné sans cookie reçoit bien un event publié. **Aucun changement Caddy nécessaire.**
- **Mécanisme retenu pour #1014 :** header `Authorization: Bearer` (`react-native-sse` supporte les headers custom), query-param en fallback documenté.
- **Gap backend à combler avant #1014 :** le JWT subscriber par-voyage n'est livré qu'en cookie httpOnly (`MercureTokenIssuer` / `MercureSubscriberListener`), illisible en RN. Ouvert en **#1019** (endpoint dédié renvoyant le token dans le corps, sans toucher la posture cookie du web).

## Contenu

Doc `docs/mobile-mercure-auth.md` : finding + reproduction curl + mécanisme retenu + gap.

## Auto-critique

- **Spike = doc uniquement**, pas de code applicatif : le changement backend identifié est délibérément sorti en #1019 (traité avant #1014), conforme à l'AC de #1011 (« si adaptation backend nécessaire → issue ouverte »).
- L'approche recommandée en #1019 (endpoint dédié) évite de faire rippler le DTO `/detail` partagé dans le typegen `core` pendant #1012/#1013.
- Vérif locale : `markdownlint-cli2` sur la doc = 0 issue.

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 blocking findings, 2 non-blocking notes. Docs-only spike PR — factual claims in `docs/mobile-mercure-auth.md` were cross-checked against `MercureTokenIssuer`, `MercureSubscriberListener`, and `.docker/php/Caddyfile` and are accurate (HS256, `mercure.subscribe` claim, 1h TTL, `subscriber_jwt`+`anonymous`, query-param redaction). The dev-only secret used in the reproduction curl script is the existing committed default, already fail-closed guarded against prod use in `entrypoint.sh` (SEC-004) — not a new leak.

**PR title check:** `spike(mobile): ...` — `spike` is not a valid Conventional Commits type in this project (`feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`). Consider `docs(mobile): confirm Mercure header auth for RN subscribers (#1011)`.

**Notes (non-blocking):**
- `TRACKING.md` (Sprint 53 table) still lists #1011 as "⏳ À faire" with no PR reference, and doesn't yet list #1019 (opened by this spike). Worth a follow-up update so sprint tracking reflects the spike's outcome.

### Review checklist

- [x] Code respects the project architecture (docs-only change, N/A)
- [x] SOLID principles and Law of Demeter followed (N/A — no code)
- [x] Design patterns used where appropriate (N/A — no code)
- [x] Tests cover new/changed cases (N/A — spike doc, no behavior change)
- [ ] Documentation is up to date (TRACKING.md not updated for #1011/#1019 — see note above)
- [x] Dependent tickets accounted for (#1019 opened, #1014 gap documented)

**Inline comments:** No inline comments.

_Reviewed commit: b7d8841aaa6b0c881bb9f6d30bb26d823e22794e_
<!-- claude-review-end -->