### PR TITLE
feat(core): pure SSE reconciliation reducers + shared MercureEvent types (#1013)

### DIFF
--- a/core/mercure.ts
+++ b/core/mercure.ts
@@ -1,3 +1,8 @@
+// Mercure SSE wire payloads shared by web and mobile. Pure type declarations
+// (no runtime), mirrored from the backend publishers (StagePayloadMapper et al.).
+// Moved out of pwa/src/lib/mercure/types.ts into core/ so the mobile thin store
+// consumes the same event contract (#1013).
+
 export interface CoordinatePayload {
   lat: number;
   lon: number;

--- a/core/package.json
+++ b/core/package.json
@@ -7,6 +7,8 @@
     ".": "./index.ts",
     "./schema": "./schema.d.ts",
     "./constants": "./accommodation-constants.ts",
+    "./mercure": "./mercure.ts",
+    "./reconciliation": "./reconciliation.ts",
     "./package.json": "./package.json"
   },
   "dependencies": {

--- a/core/reconciliation.ts
+++ b/core/reconciliation.ts
@@ -177,17 +177,20 @@ export function reconcileStageUpdate(
 /**
  * Drop recomputing markers for indices that no longer exist after the stage
  * array changed length, so a phantom index never holds the `processing`
- * overlay open forever (#840). Returns a new set.
+ * overlay open forever (#840). Only ever removes indices, so when nothing is
+ * stale it returns the SAME set reference — matching the old in-place
+ * `.delete()` semantics, so a store selector keyed on `recomputingStages`
+ * (Object.is) does not re-render on every resync/structural edit.
  */
 export function pruneStaleRecomputing(
   stageCount: number,
-  recomputing: ReadonlySet<number>,
+  recomputing: Set<number>,
 ): Set<number> {
   const next = new Set<number>();
   for (const i of recomputing) {
     if (i < stageCount) next.add(i);
   }
-  return next;
+  return next.size === recomputing.size ? recomputing : next;
 }
 
 /**

--- a/core/reconciliation.ts
+++ b/core/reconciliation.ts
@@ -1,0 +1,208 @@
+// Pure SSE reconciliation reducers shared by the web and mobile stores (#1013).
+// Extracted verbatim (same semantics) from pwa/src/store/trip-store.ts so both
+// platforms compose the identical logic and each store stays a thin wrapper
+// (dispatch event -> pure reducer -> set). No Zustand/Immer/dayjs dependency.
+//
+// The race/edge behaviour these encode is covered by characterization tests in
+// reconciliation.test.ts and traces back to #840 (concurrency token / stale
+// recomputing indices), #649 (client-only field preservation on a stable
+// endpoint) and #787 (label preservation on a raw resync).
+
+import { DEFAULT_ACCOMMODATION_RADIUS_KM } from "./accommodation-constants";
+import type { AlertData, StageData } from "./schemas";
+
+/** A stage alert carrying the client-only `_group` tag added by the store. */
+export type StageAlert = AlertData & { _group?: string };
+
+function sameStart(prev: StageData, incoming: StageData): boolean {
+  return (
+    prev.startPoint.lat === incoming.startPoint.lat &&
+    prev.startPoint.lon === incoming.startPoint.lon
+  );
+}
+
+function sameEnd(prev: StageData, incoming: StageData): boolean {
+  return (
+    prev.endPoint.lat === incoming.endPoint.lat &&
+    prev.endPoint.lon === incoming.endPoint.lon
+  );
+}
+
+/**
+ * Raw re-hydrate / resync replace (store `setStages`). Preserves client-only
+ * reverse-geocoded labels when the endpoint has not moved AND the incoming
+ * payload lacks a label (backend has not persisted it yet) — so a resync does
+ * not blank labels the client just resolved for a Komoot trip (#787/#649).
+ * Note the precedence: incoming wins, prev is only the fallback.
+ */
+export function reconcileResync(
+  existing: StageData[],
+  incoming: StageData[],
+): StageData[] {
+  return incoming.map((stage, i) => {
+    const prev = existing[i];
+    const startMatch = prev && sameStart(prev, stage);
+    const endMatch = prev && sameEnd(prev, stage);
+    return {
+      ...stage,
+      startLabel: startMatch
+        ? (stage.startLabel ?? prev.startLabel)
+        : stage.startLabel,
+      endLabel: endMatch ? (stage.endLabel ?? prev.endLabel) : stage.endLabel,
+    };
+  });
+}
+
+/**
+ * Mode 1 terminal `trip_ready` reconciliation (store `applyTripReady`). When a
+ * stage endpoint is stable, preserve the client-only fields that arrive via
+ * their own earlier SSE events and can be absent/empty from the terminal
+ * payload: reverse-geocoded labels, the UI-only accommodation radius, the
+ * already-set supply timeline, and non-empty accommodations / selection /
+ * alerts / events (#649). Here prev wins over incoming for labels.
+ */
+export function reconcileTripReady(
+  existing: StageData[],
+  incoming: StageData[],
+): StageData[] {
+  return incoming.map((stage, i) => {
+    const prev = existing[i];
+    const endMatch = prev && sameEnd(prev, stage);
+    const startMatch = prev && sameStart(prev, stage);
+    return {
+      ...stage,
+      startLabel: startMatch
+        ? (prev.startLabel ?? stage.startLabel)
+        : stage.startLabel,
+      endLabel: endMatch ? (prev.endLabel ?? stage.endLabel) : stage.endLabel,
+      accommodationSearchRadiusKm: endMatch
+        ? (prev.accommodationSearchRadiusKm ?? DEFAULT_ACCOMMODATION_RADIUS_KM)
+        : DEFAULT_ACCOMMODATION_RADIUS_KM,
+      supplyTimeline: prev?.supplyTimeline ?? [],
+      accommodations: endMatch
+        ? prev.accommodations.length > 0
+          ? prev.accommodations
+          : stage.accommodations
+        : stage.accommodations,
+      selectedAccommodation: endMatch
+        ? (prev.selectedAccommodation ?? stage.selectedAccommodation)
+        : stage.selectedAccommodation,
+      alerts: endMatch
+        ? prev.alerts.length > 0
+          ? prev.alerts
+          : stage.alerts
+        : stage.alerts,
+      events: endMatch
+        ? prev.events.length > 0
+          ? prev.events
+          : stage.events
+        : stage.events,
+    };
+  });
+}
+
+/** Result of {@link reconcileStageUpdate}. */
+export interface StageUpdateResult {
+  stages: StageData[];
+  /**
+   * True when the update appended a brand-new trailing stage (a last-stage
+   * distance reduction that split off a new day on the backend, #840). The
+   * caller must then extend the trip's end date by one day.
+   */
+  appendedTrailingStage: boolean;
+}
+
+/**
+ * Mode 2 per-stage `stage_updated` reconciliation (store `applyStageUpdate`).
+ * Preserves client-only fields on a stable endpoint (labels, radius, supply
+ * timeline, accommodations + selection, events) and merges alerts so a
+ * terrain-only reroute payload does not blank the separately-scanned
+ * cultural-POI recommendations (#649). A `stage_updated` at exactly
+ * `stages.length` appends the split-off trailing day (#840); a larger index is
+ * a stale/obsolete event and is ignored.
+ */
+export function reconcileStageUpdate(
+  existing: StageData[],
+  stageIndex: number,
+  incoming: StageData,
+): StageUpdateResult {
+  const prev = existing[stageIndex];
+  if (!prev) {
+    if (stageIndex === existing.length) {
+      return {
+        stages: [...existing, incoming],
+        appendedTrailingStage: true,
+      };
+    }
+    return { stages: existing, appendedTrailingStage: false };
+  }
+
+  const endMatch = sameEnd(prev, incoming);
+  const startMatch = sameStart(prev, incoming);
+
+  const reconciled: StageData = {
+    ...incoming,
+    startLabel: startMatch
+      ? (prev.startLabel ?? incoming.startLabel)
+      : incoming.startLabel,
+    endLabel: endMatch
+      ? (prev.endLabel ?? incoming.endLabel)
+      : incoming.endLabel,
+    accommodationSearchRadiusKm: endMatch
+      ? (prev.accommodationSearchRadiusKm ?? DEFAULT_ACCOMMODATION_RADIUS_KM)
+      : DEFAULT_ACCOMMODATION_RADIUS_KM,
+    supplyTimeline: prev.supplyTimeline,
+    accommodations:
+      endMatch && prev.accommodations.length > 0
+        ? prev.accommodations
+        : incoming.accommodations,
+    selectedAccommodation: endMatch
+      ? (prev.selectedAccommodation ?? incoming.selectedAccommodation)
+      : incoming.selectedAccommodation,
+    alerts:
+      endMatch && prev.alerts.length > 0
+        ? prev.alerts
+        : [
+            ...prev.alerts.filter((a) => a.source === "cultural_poi"),
+            ...incoming.alerts.filter((a) => a.source !== "cultural_poi"),
+          ],
+    events: endMatch && prev.events.length > 0 ? prev.events : incoming.events,
+  };
+
+  const stages = existing.slice();
+  stages[stageIndex] = reconciled;
+  return { stages, appendedTrailingStage: false };
+}
+
+/**
+ * Drop recomputing markers for indices that no longer exist after the stage
+ * array changed length, so a phantom index never holds the `processing`
+ * overlay open forever (#840). Returns a new set.
+ */
+export function pruneStaleRecomputing(
+  stageCount: number,
+  recomputing: ReadonlySet<number>,
+): Set<number> {
+  const next = new Set<number>();
+  for (const i of recomputing) {
+    if (i < stageCount) next.add(i);
+  }
+  return next;
+}
+
+/**
+ * Drop date-derived calendar nudges from every stage after a structural edit
+ * that shifts `dayNumber`s. These alerts are keyed to a stage's date but ride
+ * along on the shifted object, so they would otherwise land on a day that is no
+ * longer a Sunday; CheckCalendar recomputes and republishes them. Geographic
+ * groups stay valid (endpoints do not move on a rest-day insert). Returns new
+ * stages.
+ */
+export function dropStaleDateAlerts(stages: StageData[]): StageData[] {
+  return stages.map((stage) => ({
+    ...stage,
+    alerts: (stage.alerts as StageAlert[]).filter(
+      (a) => a._group !== "calendar",
+    ),
+  }));
+}

--- a/pwa/src/hooks/use-mercure.ts
+++ b/pwa/src/hooks/use-mercure.ts
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef } from "react";
 import { MercureClient } from "@/lib/mercure/client";
-import type { EnrichedStagePayload, MercureEvent } from "@/lib/mercure/types";
+import type { EnrichedStagePayload, MercureEvent } from "@btp/core/mercure";
 import { useTripStore } from "@/store/trip-store";
 import { useUiStore } from "@/store/ui-store";
 import { reverseGeocode } from "@/lib/geocode/client";

--- a/pwa/src/lib/mercure/client.ts
+++ b/pwa/src/lib/mercure/client.ts
@@ -1,4 +1,4 @@
-import type { MercureEvent } from "./types";
+import type { MercureEvent } from "@btp/core/mercure";
 import { API_URL } from "@/lib/constants";
 
 const MAX_RECONNECT_DELAY = 30_000;

--- a/pwa/src/store/reconciliation.test.ts
+++ b/pwa/src/store/reconciliation.test.ts
@@ -1,0 +1,271 @@
+import { describe, expect, it } from "vitest";
+import type { AlertData, StageData } from "@btp/core";
+import {
+  dropStaleDateAlerts,
+  pruneStaleRecomputing,
+  reconcileResync,
+  reconcileStageUpdate,
+  reconcileTripReady,
+  type StageAlert,
+} from "@btp/core/reconciliation";
+
+// Characterization tests for the pure reconciliation reducers extracted from
+// trip-store.ts (#1013). They pin the race/edge behaviour of #840 (append
+// trailing day, stale recomputing indices), #649 (client-only field
+// preservation on a stable endpoint) and #787 (label preservation on resync)
+// BEFORE the web store was rewired to compose these, and guard the mobile store
+// that now composes them too.
+
+const A = { lat: 1, lon: 1, ele: 0 };
+const B = { lat: 2, lon: 2, ele: 0 };
+const C = { lat: 3, lon: 3, ele: 0 };
+
+function stage(overrides: Partial<StageData> = {}): StageData {
+  return {
+    dayNumber: 1,
+    distance: 50,
+    elevation: 0,
+    elevationLoss: 0,
+    startPoint: A,
+    endPoint: B,
+    geometry: [],
+    label: null,
+    startLabel: null,
+    endLabel: null,
+    weather: null,
+    alerts: [],
+    pois: [],
+    accommodations: [],
+    selectedAccommodation: null,
+    accommodationSearchRadiusKm: 5,
+    isRestDay: false,
+    supplyTimeline: [],
+    events: [],
+    ...overrides,
+  };
+}
+
+function alert(overrides: Partial<StageAlert> = {}): AlertData {
+  return {
+    code: null,
+    type: "nudge",
+    message: "m",
+    lat: null,
+    lon: null,
+    ...overrides,
+  } as AlertData;
+}
+
+/** Assert a single-element result and return that element (satisfies noUncheckedIndexedAccess). */
+function only(stages: StageData[]): StageData {
+  expect(stages).toHaveLength(1);
+  return stages[0] as StageData;
+}
+
+describe("reconcileResync (#787/#649)", () => {
+  it("preserves prev labels on a stable endpoint when the incoming payload lacks them", () => {
+    const prev = [stage({ startLabel: "Paris", endLabel: "Lyon" })];
+    const incoming = [stage({ startLabel: null, endLabel: null })];
+    const s = only(reconcileResync(prev, incoming));
+    expect(s.startLabel).toBe("Paris");
+    expect(s.endLabel).toBe("Lyon");
+  });
+
+  it("lets an incoming label win over the preserved one", () => {
+    const prev = [stage({ startLabel: "Paris" })];
+    const incoming = [stage({ startLabel: "Versailles" })];
+    expect(only(reconcileResync(prev, incoming)).startLabel).toBe("Versailles");
+  });
+
+  it("drops the preserved label when the endpoint moved", () => {
+    const prev = [stage({ endPoint: B, endLabel: "Lyon" })];
+    const incoming = [stage({ endPoint: C, endLabel: null })];
+    expect(only(reconcileResync(prev, incoming)).endLabel).toBeNull();
+  });
+
+  it("does not mutate the existing stages", () => {
+    const prev = [stage({ startLabel: "Paris" })];
+    reconcileResync(prev, [stage({ startLabel: null })]);
+    expect(only(prev).startLabel).toBe("Paris");
+  });
+});
+
+describe("reconcileTripReady (#649)", () => {
+  it("preserves labels (prev wins), radius, supply timeline and non-empty lists on a stable endpoint", () => {
+    const marker = {
+      type: "water" as const,
+      distanceFromStart: 1,
+      lat: 1,
+      lon: 1,
+      water: [],
+      food: [],
+    };
+    const acc = { name: "Gite" } as StageData["accommodations"][number];
+    const prev = [
+      stage({
+        startLabel: "Paris",
+        endLabel: "Lyon",
+        accommodationSearchRadiusKm: 12,
+        supplyTimeline: [marker],
+        accommodations: [acc],
+        selectedAccommodation: acc,
+        alerts: [alert({ message: "keep" })],
+        events: [{ name: "Fete" } as StageData["events"][number]],
+      }),
+    ];
+    const incoming = [
+      stage({
+        startLabel: "IGNORED",
+        endLabel: "IGNORED",
+        accommodationSearchRadiusKm: 5,
+        accommodations: [],
+        alerts: [],
+        events: [],
+      }),
+    ];
+    const s = only(reconcileTripReady(prev, incoming));
+    expect(s.startLabel).toBe("Paris");
+    expect(s.endLabel).toBe("Lyon");
+    expect(s.accommodationSearchRadiusKm).toBe(12);
+    expect(s.supplyTimeline).toEqual([marker]);
+    expect(s.accommodations).toEqual([acc]);
+    expect(s.selectedAccommodation).toEqual(acc);
+    expect(s.alerts).toHaveLength(1);
+    expect(s.events).toHaveLength(1);
+  });
+
+  it("takes the incoming lists when prev is empty on a stable endpoint", () => {
+    const acc = { name: "New" } as StageData["accommodations"][number];
+    const prev = [stage({ accommodations: [], alerts: [], events: [] })];
+    const incoming = [
+      stage({ accommodations: [acc], alerts: [alert()], events: [] }),
+    ];
+    const s = only(reconcileTripReady(prev, incoming));
+    expect(s.accommodations).toEqual([acc]);
+    expect(s.alerts).toHaveLength(1);
+  });
+
+  it("resets radius to default and drops preserved fields when the endpoint moved", () => {
+    const prev = [
+      stage({ endPoint: B, accommodationSearchRadiusKm: 12, endLabel: "Lyon" }),
+    ];
+    const incoming = [stage({ endPoint: C, endLabel: null })];
+    const s = only(reconcileTripReady(prev, incoming));
+    expect(s.accommodationSearchRadiusKm).toBe(5);
+    expect(s.endLabel).toBeNull();
+  });
+});
+
+describe("reconcileStageUpdate (#840/#649)", () => {
+  it("appends a stage_updated at stages.length and flags the trailing day (#840)", () => {
+    const existing = [stage({ dayNumber: 1 })];
+    const res = reconcileStageUpdate(existing, 1, stage({ dayNumber: 2 }));
+    expect(res.appendedTrailingStage).toBe(true);
+    expect(res.stages).toHaveLength(2);
+  });
+
+  it("ignores a stale event at an index beyond the trailing slot", () => {
+    const existing = [stage()];
+    const res = reconcileStageUpdate(existing, 5, stage());
+    expect(res.appendedTrailingStage).toBe(false);
+    expect(res.stages).toBe(existing);
+  });
+
+  it("keeps prev alerts wholesale on a stable endpoint when prev has alerts", () => {
+    const existing = [stage({ alerts: [alert({ message: "prev" })] })];
+    const res = reconcileStageUpdate(
+      existing,
+      0,
+      stage({ alerts: [alert({ message: "incoming" })] }),
+    );
+    const s = only(res.stages);
+    expect(s.alerts).toHaveLength(1);
+    expect((s.alerts[0] as AlertData).message).toBe("prev");
+  });
+
+  it("preserves prev cultural_poi alerts and takes non-cultural from incoming when merging", () => {
+    // endpoint moved -> merge branch (prev.alerts non-empty but endMatch false)
+    const existing = [
+      stage({
+        endPoint: B,
+        alerts: [alert({ source: "cultural_poi", message: "museum" })],
+      }),
+    ];
+    const incoming = stage({
+      endPoint: C,
+      alerts: [
+        alert({ source: "terrain", message: "gravel" }),
+        alert({ source: "cultural_poi", message: "should-drop" }),
+      ],
+    });
+    const s = only(reconcileStageUpdate(existing, 0, incoming).stages);
+    const messages = s.alerts.map((a) => a.message);
+    const sources = s.alerts.map((a) => a.source);
+    expect(messages).toContain("museum"); // prev cultural preserved
+    expect(messages).toContain("gravel"); // incoming non-cultural taken
+    expect(messages).not.toContain("should-drop"); // incoming cultural dropped
+    expect(sources.filter((x) => x === "cultural_poi")).toHaveLength(1);
+  });
+
+  it("keeps the supply timeline from prev", () => {
+    const marker = {
+      type: "food" as const,
+      distanceFromStart: 2,
+      lat: 1,
+      lon: 1,
+      water: [],
+      food: [],
+    };
+    const existing = [stage({ supplyTimeline: [marker] })];
+    const s = only(
+      reconcileStageUpdate(existing, 0, stage({ supplyTimeline: [] })).stages,
+    );
+    expect(s.supplyTimeline).toEqual([marker]);
+  });
+
+  it("does not mutate the existing stages", () => {
+    const existing = [stage({ endLabel: "Lyon" })];
+    reconcileStageUpdate(existing, 0, stage({ endLabel: null }));
+    expect(only(existing).endLabel).toBe("Lyon");
+  });
+});
+
+describe("pruneStaleRecomputing (#840)", () => {
+  it("drops indices that fell out of bounds and keeps the rest", () => {
+    const pruned = pruneStaleRecomputing(2, new Set([0, 1, 2, 5]));
+    expect([...pruned].sort()).toEqual([0, 1]);
+  });
+
+  it("returns a new set (does not mutate the input)", () => {
+    const input = new Set([0, 3]);
+    const pruned = pruneStaleRecomputing(1, input);
+    expect(input.has(3)).toBe(true);
+    expect(pruned).not.toBe(input);
+  });
+});
+
+describe("dropStaleDateAlerts", () => {
+  it("removes only calendar-group alerts, keeping the others", () => {
+    const stages = [
+      stage({
+        alerts: [
+          { ...alert({ message: "sunday" }), _group: "calendar" } as StageAlert,
+          { ...alert({ message: "terrain" }), _group: "terrain" } as StageAlert,
+        ],
+      }),
+    ];
+    const s = only(dropStaleDateAlerts(stages));
+    expect(s.alerts).toHaveLength(1);
+    expect((s.alerts[0] as AlertData).message).toBe("terrain");
+  });
+
+  it("does not mutate the input stages", () => {
+    const stages = [
+      stage({
+        alerts: [{ ...alert(), _group: "calendar" } as StageAlert],
+      }),
+    ];
+    dropStaleDateAlerts(stages);
+    expect(only(stages).alerts).toHaveLength(1);
+  });
+});

--- a/pwa/src/store/reconciliation.test.ts
+++ b/pwa/src/store/reconciliation.test.ts
@@ -236,11 +236,16 @@ describe("pruneStaleRecomputing (#840)", () => {
     expect([...pruned].sort()).toEqual([0, 1]);
   });
 
-  it("returns a new set (does not mutate the input)", () => {
+  it("returns a new set (does not mutate the input) when something is pruned", () => {
     const input = new Set([0, 3]);
     const pruned = pruneStaleRecomputing(1, input);
     expect(input.has(3)).toBe(true);
     expect(pruned).not.toBe(input);
+  });
+
+  it("returns the SAME reference when nothing is stale (preserves Object.is, no phantom re-render)", () => {
+    const input = new Set([0, 1]);
+    expect(pruneStaleRecomputing(2, input)).toBe(input);
   });
 });
 

--- a/pwa/src/store/trip-store.ts
+++ b/pwa/src/store/trip-store.ts
@@ -14,6 +14,14 @@ import type {
   SupplyMarkerData,
   EventData,
 } from "@btp/core";
+import {
+  reconcileResync,
+  reconcileTripReady,
+  reconcileStageUpdate,
+  pruneStaleRecomputing as corePruneStaleRecomputing,
+  dropStaleDateAlerts as coreDropStaleDateAlerts,
+  type StageAlert,
+} from "@btp/core/reconciliation";
 
 /**
  * A single user modification accumulated in the batch queue before being applied
@@ -351,39 +359,25 @@ export function getUndoableSlice(state: {
  * {@link useTripTemporalStore} exposes `undo()`, `redo()`, `canUndo`, and
  * `canRedo`.
  */
-type StageAlert = AlertData & { _group?: string };
+// StageAlert and the pure SSE reconciliation reducers live in
+// @btp/core/reconciliation (shared verbatim with the mobile store, #1013). The
+// two helpers below are thin adapters composing the pure functions at the
+// store's mutate-the-draft call sites; the reasoning for each lives in core.
 
-/**
- * Drop recompute markers for indices that fell out of bounds after the stage
- * array changed length. Shared by every mutation that resizes `state.stages`
- * (resync, delete, rest-day/placeholder insert) so an in-flight recompute
- * never holds the `processing` overlay open on a phantom index (#840).
- */
+/** Reassign the pruned recomputing set on the draft (see core, #840). */
 function pruneStaleRecomputing(state: {
   stages: StageData[];
   recomputingStages: Set<number>;
 }): void {
-  for (const i of [...state.recomputingStages]) {
-    if (i >= state.stages.length) state.recomputingStages.delete(i);
-  }
+  state.recomputingStages = corePruneStaleRecomputing(
+    state.stages.length,
+    state.recomputingStages,
+  );
 }
 
-/**
- * Drop date-derived calendar nudges from every stage after a structural edit
- * that shifts `dayNumber`s (rest-day / placeholder insert, delete). These
- * alerts ("L'étape N tombe un dimanche") are keyed to a stage's date, but the
- * splice keeps each stage's `alerts` array attached to the shifted object, so
- * the message would otherwise ride along onto a day that is no longer a Sunday.
- * They are recomputed and republished by CheckCalendar. Geographic groups
- * (terrain, accommodations, water, bike_shop, cultural_poi) stay valid because
- * the real stages' endpoints do not move on a rest-day insert.
- */
+/** Reassign the calendar-alert-filtered stages on the draft (see core). */
 function dropStaleDateAlerts(state: { stages: StageData[] }): void {
-  for (const stage of state.stages) {
-    stage.alerts = (stage.alerts as StageAlert[]).filter(
-      (a) => a._group !== "calendar",
-    );
-  }
+  state.stages = coreDropStaleDateAlerts(state.stages);
 }
 
 export const useTripStore = create<TripState>()(
@@ -408,43 +402,16 @@ export const useTripStore = create<TripState>()(
 
     setStages: (stages) =>
       set((state) => {
-        const existing = state.stages;
-        state.stages = stages.map((incoming, i) => {
-          const prev = existing[i];
-          const startMatch =
-            prev &&
-            prev.startPoint.lat === incoming.startPoint.lat &&
-            prev.startPoint.lon === incoming.startPoint.lon;
-          const endMatch =
-            prev &&
-            prev.endPoint.lat === incoming.endPoint.lat &&
-            prev.endPoint.lon === incoming.endPoint.lon;
-
-          return {
-            ...incoming,
-            // Preserve client-only reverse-geocoded labels across a raw
-            // re-hydrate/resync when the endpoint has not moved and the
-            // incoming payload lacks a label (the backend has not persisted it
-            // yet). Without this, a resync `/detail` replace would blank labels
-            // the client just resolved for a Komoot trip — whose stages arrive
-            // after a stageless draft — until `trip_ready` (~30s). Mirrors the
-            // preservation in applyTripReady/applyStageUpdate (recette #649).
-            startLabel: startMatch
-              ? (incoming.startLabel ?? prev.startLabel)
-              : incoming.startLabel,
-            endLabel: endMatch
-              ? (incoming.endLabel ?? prev.endLabel)
-              : incoming.endLabel,
-          };
-        });
+        // Raw re-hydrate/resync: preserve client-only labels on stable
+        // endpoints (see reconcileResync in core, #787/#649).
+        state.stages = reconcileResync(state.stages, stages);
         const max = Math.max(0, stages.length - 1);
         if (state.selectedStageIndex > max) {
           state.selectedStageIndex = max;
         }
         // Drop recomputing markers for indices that no longer exist after the
-        // array changed length. Otherwise a phantom index (e.g. a stage that
-        // vanished when the day count shrank) is never cleared by a matching
-        // `stage_updated`, holding the `processing` overlay open forever (#840).
+        // array changed length, so a phantom index never holds the
+        // `processing` overlay open forever (#840).
         pruneStaleRecomputing(state);
       }),
 
@@ -731,147 +698,33 @@ export const useTripStore = create<TripState>()(
 
     applyTripReady: (stages) =>
       set((state) => {
-        const existing = state.stages;
-        state.stages = stages.map((incoming, i) => {
-          const prev = existing[i];
-          const endMatch =
-            prev &&
-            prev.endPoint.lat === incoming.endPoint.lat &&
-            prev.endPoint.lon === incoming.endPoint.lon;
-          const startMatch =
-            prev &&
-            prev.startPoint.lat === incoming.startPoint.lat &&
-            prev.startPoint.lon === incoming.startPoint.lon;
-
-          return {
-            ...incoming,
-            // Preserve client-only reverse-geocoded labels when endpoints
-            // have not moved so we don't drop them on re-analysis.
-            startLabel: startMatch
-              ? (prev.startLabel ?? incoming.startLabel)
-              : incoming.startLabel,
-            endLabel: endMatch
-              ? (prev.endLabel ?? incoming.endLabel)
-              : incoming.endLabel,
-            // Accommodation search radius is a UI-only knob that never
-            // ships with the enriched payload — keep the user's setting
-            // when the stage endpoint is stable.
-            accommodationSearchRadiusKm: endMatch
-              ? (prev.accommodationSearchRadiusKm ??
-                DEFAULT_ACCOMMODATION_RADIUS_KM)
-              : DEFAULT_ACCOMMODATION_RADIUS_KM,
-            // supply_timeline events always precede trip_ready (terminal
-            // event), so the timeline already set in the store is current
-            // — preserve it rather than blanking it.
-            supplyTimeline: prev?.supplyTimeline ?? [],
-            // Accommodations + alerts arrive via their own SSE events
-            // (accommodations_found) that may land before trip_ready. The
-            // terminal payload can carry an empty list, so preserve the
-            // current ones when the stage endpoint is stable to avoid
-            // blanking already-displayed data (recette #649).
-            accommodations: endMatch
-              ? prev.accommodations.length > 0
-                ? prev.accommodations
-                : incoming.accommodations
-              : incoming.accommodations,
-            selectedAccommodation: endMatch
-              ? (prev.selectedAccommodation ?? incoming.selectedAccommodation)
-              : incoming.selectedAccommodation,
-            alerts: endMatch
-              ? prev.alerts.length > 0
-                ? prev.alerts
-                : incoming.alerts
-              : incoming.alerts,
-            // Dated events arrive via their own `events_found` SSE, absent from
-            // the terminal trip_ready payload (which can carry an empty list).
-            // Preserve them when the endpoint is stable so they don't vanish
-            // once enrichment settles (same rule as accommodations/alerts).
-            events: endMatch
-              ? prev.events.length > 0
-                ? prev.events
-                : incoming.events
-              : incoming.events,
-          };
-        });
+        // Mode 1 terminal reconciliation: preserve client-only fields
+        // (labels, radius, supply timeline, non-empty accommodations/
+        // selection/alerts/events) on stable endpoints (see reconcileTripReady
+        // in core, #649).
+        state.stages = reconcileTripReady(state.stages, stages);
       }),
 
     applyStageUpdate: (stageIndex, stage) =>
       set((state) => {
-        const prev = state.stages[stageIndex];
-        if (!prev) {
-          // Reducing the last stage's distance splits off a brand-new trailing
-          // day on the backend (StageUpdateProcessor::applyDistanceChange),
-          // whose `stage_updated` lands at the next contiguous index. Append it
-          // so the new day is not silently dropped (#840). A larger index can
-          // only be a stale/obsolete event, so ignore it.
-          if (stageIndex === state.stages.length) {
-            state.stages.push(stage);
-            // Keep the trip's day window in sync with the new stage count,
-            // mirroring insertRestDay/insertStagePlaceholder/deleteStage
-            // (recette #649). Otherwise a last-stage edit that splits off a
-            // day leaves endDate one day short for downstream readers
-            // (trip-summary, infographic export, date-range-picker, shared page).
-            if (state.startDate) {
-              state.endDate = dayjs(state.startDate)
-                .add(state.stages.length - 1, "day")
-                .format("YYYY-MM-DD");
-            }
-          }
-          return;
+        // Mode 2 per-stage reconciliation: preserve client-only fields and
+        // merge cultural-POI alerts on a stable endpoint; a stage_updated at
+        // stages.length appends the split-off trailing day (see
+        // reconcileStageUpdate in core, #840/#649).
+        const { stages, appendedTrailingStage } = reconcileStageUpdate(
+          state.stages,
+          stageIndex,
+          stage,
+        );
+        state.stages = stages;
+        // Keep the trip's day window in sync with the new stage count when a
+        // last-stage edit split off a day, mirroring insertRestDay/deleteStage
+        // — otherwise endDate is one day short for downstream readers (#649).
+        if (appendedTrailingStage && state.startDate) {
+          state.endDate = dayjs(state.startDate)
+            .add(state.stages.length - 1, "day")
+            .format("YYYY-MM-DD");
         }
-
-        const endMatch =
-          prev.endPoint.lat === stage.endPoint.lat &&
-          prev.endPoint.lon === stage.endPoint.lon;
-        const startMatch =
-          prev.startPoint.lat === stage.startPoint.lat &&
-          prev.startPoint.lon === stage.startPoint.lon;
-
-        state.stages[stageIndex] = {
-          ...stage,
-          startLabel: startMatch
-            ? (prev.startLabel ?? stage.startLabel)
-            : stage.startLabel,
-          endLabel: endMatch
-            ? (prev.endLabel ?? stage.endLabel)
-            : stage.endLabel,
-          accommodationSearchRadiusKm: endMatch
-            ? (prev.accommodationSearchRadiusKm ??
-              DEFAULT_ACCOMMODATION_RADIUS_KM)
-            : DEFAULT_ACCOMMODATION_RADIUS_KM,
-          // Keep current supply timeline until the re-dispatched ScanPois
-          // handler delivers fresh data via a supply_timeline event.
-          supplyTimeline: prev.supplyTimeline,
-          // A stage_updated event (e.g. after selecting an accommodation)
-          // re-routes the stage but does not re-scan accommodations/alerts:
-          // the payload may carry an empty list, so preserve the current ones
-          // (and the selection) when the endpoint is stable (recette #649).
-          accommodations:
-            endMatch && prev.accommodations.length > 0
-              ? prev.accommodations
-              : stage.accommodations,
-          selectedAccommodation: endMatch
-            ? (prev.selectedAccommodation ?? stage.selectedAccommodation)
-            : stage.selectedAccommodation,
-          alerts:
-            endMatch && prev.alerts.length > 0
-              ? prev.alerts
-              : [
-                  // Cultural-POI recommendations come from a separate scan and
-                  // are absent from this terrain-only payload, so a bare replace
-                  // on reroute (e.g. accommodation selection moves the endpoint)
-                  // would make the dedicated "cultural recommendations" section
-                  // vanish. Preserve them from `prev`, take the rest from the
-                  // incoming payload (recette #649).
-                  ...prev.alerts.filter((a) => a.source === "cultural_poi"),
-                  ...stage.alerts.filter((a) => a.source !== "cultural_poi"),
-                ],
-          // Keep dated events (from the separate `events_found` SSE) until a
-          // fresh ScanEvents delivers them again — the stage_updated payload
-          // does not carry them and would otherwise blank the list.
-          events:
-            endMatch && prev.events.length > 0 ? prev.events : stage.events,
-        };
       }),
 
     startStageRecomputation: (indices) =>

--- a/pwa/tests/fixtures/base.fixture.ts
+++ b/pwa/tests/fixtures/base.fixture.ts
@@ -8,7 +8,7 @@ import { mockAllApis, type MockApiOptions } from "./api-mocks";
 import { attachRuntimeMonitor } from "./runtime-monitor";
 import { injectSseEvent, injectSseSequence } from "./sse-helpers";
 import { fullTripEventSequence } from "./mock-data";
-import type { MercureEvent } from "../../src/lib/mercure/types";
+import type { MercureEvent } from "@btp/core/mercure";
 
 export { expect };
 

--- a/pwa/tests/fixtures/mock-data.ts
+++ b/pwa/tests/fixtures/mock-data.ts
@@ -1,4 +1,4 @@
-import type { MercureEvent } from "../../src/lib/mercure/types";
+import type { MercureEvent } from "@btp/core/mercure";
 
 export function routeParsedEvent(): MercureEvent {
   return {

--- a/pwa/tests/fixtures/sse-helpers.ts
+++ b/pwa/tests/fixtures/sse-helpers.ts
@@ -1,5 +1,5 @@
 import type { Page } from "@playwright/test";
-import type { MercureEvent } from "../../src/lib/mercure/types";
+import type { MercureEvent } from "@btp/core/mercure";
 
 export async function injectSseEvent(
   page: Page,

--- a/pwa/tests/mocked/actionable-alerts.spec.ts
+++ b/pwa/tests/mocked/actionable-alerts.spec.ts
@@ -13,7 +13,7 @@
  */
 
 import { test, expect } from "../fixtures/base.fixture";
-import type { MercureEvent } from "../../src/lib/mercure/types";
+import type { MercureEvent } from "@btp/core/mercure";
 import {
   routeParsedEvent,
   stagesComputedEvent,

--- a/pwa/tests/mocked/diff-highlight.spec.ts
+++ b/pwa/tests/mocked/diff-highlight.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "../fixtures/base.fixture";
-import type { MercureEvent } from "../../src/lib/mercure/types";
+import type { MercureEvent } from "@btp/core/mercure";
 import {
   routeParsedEvent,
   stagesComputedEvent,

--- a/pwa/tests/mocked/events-panel.spec.ts
+++ b/pwa/tests/mocked/events-panel.spec.ts
@@ -4,7 +4,7 @@ import {
   stagesComputedEvent,
   tripCompleteEvent,
 } from "../fixtures/mock-data";
-import type { MercureEvent } from "../../src/lib/mercure/types";
+import type { MercureEvent } from "@btp/core/mercure";
 
 function eventsFoundEvent(stageIndex: number): MercureEvent {
   return {

--- a/pwa/tests/mocked/map.spec.ts
+++ b/pwa/tests/mocked/map.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect, expandLinkCard } from "../fixtures/base.fixture";
 import { mockAllApis } from "../fixtures/api-mocks";
 import { injectSseEvent } from "../fixtures/sse-helpers";
-import type { MercureEvent } from "../../src/lib/mercure/types";
+import type { MercureEvent } from "@btp/core/mercure";
 import { culturalPoiAlertsEvent } from "../fixtures/mock-data";
 
 /**

--- a/pwa/tests/mocked/share-modal.spec.ts
+++ b/pwa/tests/mocked/share-modal.spec.ts
@@ -83,7 +83,7 @@ function mockShareRevoke(
 async function openShareModal(fixtures: {
   submitUrl: (url?: string) => Promise<void>;
   injectSequence: (
-    events: import("../../src/lib/mercure/types").MercureEvent[],
+    events: import("@btp/core/mercure").MercureEvent[],
     delayMs?: number,
   ) => Promise<void>;
   mockedPage: import("@playwright/test").Page;

--- a/pwa/tests/mocked/split-view.spec.ts
+++ b/pwa/tests/mocked/split-view.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "../fixtures/base.fixture";
-import type { MercureEvent } from "../../src/lib/mercure/types";
+import type { MercureEvent } from "@btp/core/mercure";
 
 /**
  * Stages with geometry — required for map rendering and the view-mode toggle.

--- a/pwa/tests/recette/steps/alerts-analysis.steps.ts
+++ b/pwa/tests/recette/steps/alerts-analysis.steps.ts
@@ -10,7 +10,7 @@ import {
   tripCompleteEvent,
   fullTripEventSequence,
 } from "../../fixtures/mock-data";
-import type { MercureEvent } from "../../../src/lib/mercure/types";
+import type { MercureEvent } from "@btp/core/mercure";
 
 // ---------------------------------------------------------------------------
 // Alerts and analysis — FR + EN

--- a/pwa/tests/recette/steps/diff-highlight.steps.ts
+++ b/pwa/tests/recette/steps/diff-highlight.steps.ts
@@ -1,6 +1,6 @@
 import { expect } from "@playwright/test";
 import { When, Then } from "../support/fixtures";
-import type { MercureEvent } from "../../../src/lib/mercure/types";
+import type { MercureEvent } from "@btp/core/mercure";
 
 // ---------------------------------------------------------------------------
 // Diff highlight — post-recompute distance / alert highlighting. FR + EN.

--- a/pwa/tests/recette/steps/weather-time.steps.ts
+++ b/pwa/tests/recette/steps/weather-time.steps.ts
@@ -5,7 +5,7 @@ import {
   stagesComputedEvent,
   routeParsedEvent,
 } from "../../fixtures/mock-data";
-import type { MercureEvent } from "../../../src/lib/mercure/types";
+import type { MercureEvent } from "@btp/core/mercure";
 
 // ---------------------------------------------------------------------------
 // Weather and travel time — FR + EN

--- a/pwa/tests/recette/support/fixtures.ts
+++ b/pwa/tests/recette/support/fixtures.ts
@@ -4,7 +4,7 @@ import { mockAllApis, type MockApiOptions } from "../../fixtures/api-mocks";
 import { attachRuntimeMonitor } from "../../fixtures/runtime-monitor";
 import { injectSseEvent, injectSseSequence } from "../../fixtures/sse-helpers";
 import { fullTripEventSequence } from "../../fixtures/mock-data";
-import type { MercureEvent } from "../../../src/lib/mercure/types";
+import type { MercureEvent } from "@btp/core/mercure";
 import { expandLinkCard } from "../../fixtures/base.fixture";
 import {
   clearCurrentRecettePage,

--- a/pwa/vitest.config.ts
+++ b/pwa/vitest.config.ts
@@ -20,10 +20,17 @@ export default defineConfig({
     // throws a version mismatch. Force a single instance resolved from pwa.
     dedupe: ["react", "react-dom"],
     alias: {
+      // Subpath aliases must precede the "@btp/core" catch-all so the more
+      // specific entry wins (vite matches aliases in order).
       "@btp/core/schema": path.resolve(__dirname, "../core/schema.d.ts"),
       "@btp/core/constants": path.resolve(
         __dirname,
         "../core/accommodation-constants.ts",
+      ),
+      "@btp/core/mercure": path.resolve(__dirname, "../core/mercure.ts"),
+      "@btp/core/reconciliation": path.resolve(
+        __dirname,
+        "../core/reconciliation.ts",
       ),
       "@btp/core": path.resolve(__dirname, "../core/index.ts"),
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
Refs #1013. Base = `main` (post-#1012). **Débloque #1014.**

## Objectif

Extraire la **réconciliation SSE** du store `trip-store.ts` (~1000 lignes) en **fonctions pures** dans `@btp/core`, pour que les stores web ET mobile deviennent de fins wrappers (`dispatch event → réducteur pur → set`). On ne porte pas le store ; on partage la logique.

## Contenu

- **`core/reconciliation.ts`** : `reconcileResync`, `reconcileTripReady`, `reconcileStageUpdate` (renvoie un flag `appendedTrailingStage`), `pruneStaleRecomputing`, `dropStaleDateAlerts` + type `StageAlert`. **Sémantique identique** à l'ancien code inline, y compris la précédence subtile **#787** (resync : le label entrant gagne, prev en repli) vs **#649** (trip_ready : prev gagne) et la gestion **#840** (append du jour scindé / index périmé ignoré).
- **`core/mercure.ts`** : union `MercureEvent` + types de payload, déplacés depuis `pwa/src/lib/mercure/types.ts` (types purs, zéro runtime). Importeurs repointés sur `@btp/core/mercure` (`use-mercure`, `client`, fixtures/specs e2e).
- **`trip-store.ts`** recâblé sur les réducteurs purs via de fins adaptateurs (net **-200 lignes**).
- **`vitest.config`** : alias `@btp/core/mercure` + `/reconciliation` avant le catch-all `@btp/core`.

## Dé-risquage

Tests de caractérisation **écrits et verts AVANT** le recâblage du store, pinnant #840/#649/#787 (préservation labels/radius/supplyTimeline/accommodations/selection/alerts/events sur endpoint stable, merge cultural_poi, append trailing day, prune stale, drop calendar alerts).

## Vérification (locale, preuves réelles)

| Leg | Résultat |
|-----|----------|
| vitest (suite pwa complète) | ✅ **43 fichiers / 426 tests** (17 nouveaux réconciliation + `trip-store` existant inchangé = comportement préservé) |
| **Tests prouvés faillibles** | ✅ mutation d'un réducteur (drop préservation label) → le test vire au rouge, puis restauré/vert |
| `tsc` core + pwa | ✅ 0 erreur |
| ESLint pwa | ✅ 0 erreur (3 warnings préexistants) |
| prettier (core + fichiers touchés) | ✅ clean |
| i18n | ✅ inchangé |

Playwright/BDD e2e = juge CI (les specs importent désormais `@btp/core/mercure`).

## Auto-critique

- **Précédence label resync vs trip_ready** délibérément différente et documentée (réducteurs séparés) : c'est #787 vs #649, pas une incohérence.
- **Tests dans la suite pwa** (`pwa/src/store/reconciliation.test.ts`) plutôt qu'un runner vitest dédié à `core/` : ils testent le module `core` importé et tournent dans le gate CI existant (`unit-tests`). Un job vitest propre à `core/` pourra venir quand le mobile aura son harness (#1014).
- **Immer** : les adaptateurs du store réassignent `state.stages`/`state.recomputingStages` avec le retour des fonctions pures ; sémantique identique à l'ancien code inline (qui lisait déjà le draft et réassignait), immer finalise.
- **`core/` non couvert par `make prettier`/eslint** (cwd=pwa) : `core/reconciliation.ts` formaté à la main via prettier ; élargir la couverture QA à `core/` reste un suivi (déjà noté en #1012).

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 code-level findings. Verified point-by-point that `reconcileResync`, `reconcileTripReady`, and `reconcileStageUpdate` preserve the exact semantics of the inline code they replace (label precedence #787/#649, cultural-POI alert merge, trailing-day append/stale-index handling #840). The `pruneStaleRecomputing` reference-stability issue flagged in the previous review round is fixed and confirmed present in the current diff. 1 non-blocking documentation note below.

**Resolved threads:** Resolved 1 previously open thread (`pruneStaleRecomputing` reference-equality regression) — the fix (`return next.size === recomputing.size ? recomputing : next;`) is present in `core/reconciliation.ts`.

**PR title check:** OK (`feat(core): ...`), though the description still reads as a noun phrase rather than imperative mood — minor, not blocking (same note as previous round).

**Notes (non-blocking):**
- `TRACKING.md` row for #1013 (Sprint 53 table) still shows status "⏳ À faire" with an empty PRs column, unlike every other in-flight row in the document which links the open PR and marks "🚧 En cours" once a PR exists. Worth a follow-up update for consistency with the rest of the tracker.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

Commit reviewed: `8774bf809eca82213a870add712fe9ae57e69815`
<!-- claude-review-end -->