### PR TITLE
feat(mobile): optimistic stage deletion (delete stage) — end-to-end proof (#1015)

### DIFF
--- a/mobile/app/trip/[id].tsx
+++ b/mobile/app/trip/[id].tsx
@@ -1,7 +1,8 @@
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import { ActivityIndicator, FlatList, Pressable, StyleSheet, Text, View } from 'react-native';
+import { ActivityIndicator, Alert, FlatList, Pressable, StyleSheet, Text, View } from 'react-native';
 import { useTripLive } from '../../src/hooks/use-trip-live';
 import { useTripStore } from '../../src/store/trip-store';
+import { runDeleteStage } from '../../src/store/delete-stage';
 
 export default function TripRoadbook() {
   const { id } = useLocalSearchParams<{ id: string }>();
@@ -14,8 +15,31 @@ export default function TripRoadbook() {
 
   const title = useTripStore((s) => s.title);
   const stages = useTripStore((s) => s.stages);
+  const isLocked = useTripStore((s) => s.isLocked);
   const loading = useTripStore((s) => s.loading);
   const error = useTripStore((s) => s.error);
+
+  function confirmDelete(index: number): void {
+    Alert.alert('Supprimer cette étape ?', 'Le jour sera fusionné avec l’étape voisine.', [
+      { text: 'Annuler', style: 'cancel' },
+      {
+        text: 'Supprimer',
+        style: 'destructive',
+        onPress: () => {
+          // Optimistic delete + rollback are orchestrated in runDeleteStage; the
+          // authoritative state comes back over SSE (reconciled by core).
+          void runDeleteStage(id, index, useTripStore.getState(), (reason) => {
+            Alert.alert(
+              reason === 'locked' ? 'Voyage démarré' : 'Suppression impossible',
+              reason === 'locked'
+                ? 'Ce voyage a commencé : il est en lecture seule.'
+                : 'La suppression a échoué. Réessayez.',
+            );
+          });
+        },
+      },
+    ]);
+  }
 
   if (loading) {
     return (
@@ -43,18 +67,30 @@ export default function TripRoadbook() {
         data={stages}
         keyExtractor={(_, index) => String(index)}
         ListEmptyComponent={<Text style={styles.empty}>Aucune étape calculée.</Text>}
-        renderItem={({ item }) => (
+        renderItem={({ item, index }) => (
           <View style={styles.row}>
-            <Text style={styles.day}>
-              Jour {item.dayNumber ?? '?'}
-              {item.isRestDay ? ' · repos' : ''}
-            </Text>
-            <Text style={styles.label}>
-              {item.startLabel ?? '?'} → {item.endLabel ?? item.label ?? '?'}
-            </Text>
-            <Text style={styles.meta}>
-              {Math.round(item.distance ?? 0)} km · +{Math.round(item.elevation ?? 0)} m
-            </Text>
+            <View style={styles.rowText}>
+              <Text style={styles.day}>
+                Jour {item.dayNumber ?? '?'}
+                {item.isRestDay ? ' · repos' : ''}
+              </Text>
+              <Text style={styles.label}>
+                {item.startLabel ?? '?'} → {item.endLabel ?? item.label ?? '?'}
+              </Text>
+              <Text style={styles.meta}>
+                {Math.round(item.distance ?? 0)} km · +{Math.round(item.elevation ?? 0)} m
+              </Text>
+            </View>
+            {/* A started trip is read-only (423); hide the action entirely. */}
+            {!isLocked ? (
+              <Pressable
+                accessibilityLabel={`Supprimer le jour ${item.dayNumber ?? index + 1}`}
+                style={styles.deleteButton}
+                onPress={() => confirmDelete(index)}
+              >
+                <Text style={styles.deleteButtonText}>Supprimer</Text>
+              </Pressable>
+            ) : null}
           </View>
         )}
       />
@@ -78,10 +114,15 @@ const styles = StyleSheet.create({
     paddingVertical: 12,
     borderBottomWidth: StyleSheet.hairlineWidth,
     borderBottomColor: '#e5e7eb',
+    flexDirection: 'row',
+    alignItems: 'center',
   },
+  rowText: { flex: 1 },
   day: { fontSize: 16, fontWeight: '600' },
   label: { color: '#374151', marginTop: 2 },
   meta: { color: '#6b7280', marginTop: 2 },
+  deleteButton: { paddingHorizontal: 12, paddingVertical: 6 },
+  deleteButtonText: { color: '#dc2626', fontWeight: '600' },
   error: { color: '#dc2626' },
   empty: { textAlign: 'center', color: '#6b7280', marginTop: 32 },
 });

--- a/mobile/src/api/mercure.ts
+++ b/mobile/src/api/mercure.ts
@@ -37,6 +37,9 @@ export function subscribeToTrip(
 
   const es = new EventSource(url.toString(), {
     headers: { Authorization: `Bearer ${token}` },
+    // Mercure/Caddy streams SSE with `\n` line endings; pin it so react-native-sse
+    // parses deterministically instead of warning it cannot auto-detect them.
+    lineEndingCharacter: '\n',
   });
 
   es.addEventListener('message', (event) => {

--- a/mobile/src/api/trips.ts
+++ b/mobile/src/api/trips.ts
@@ -27,3 +27,18 @@ export async function fetchTripDetail(id: string): Promise<TripDetail | null> {
   }
   return data ?? null;
 }
+
+// Delete a stage (merges it with the adjacent day). The backend recomputes and
+// pushes the authoritative state over SSE; a started trip is rejected with 423
+// (App\State\TripLocker). Returns the raw status so the caller can distinguish a
+// lock (423) from any other failure and roll back its optimistic update.
+export async function deleteStage(
+  tripId: string,
+  index: number,
+): Promise<{ ok: boolean; status: number }> {
+  const { response } = await api.DELETE('/trips/{tripId}/stages/{index}', {
+    params: { path: { tripId, index: String(index) } },
+    headers: ld,
+  });
+  return { ok: response.ok, status: response.status };
+}

--- a/mobile/src/store/delete-stage.test.ts
+++ b/mobile/src/store/delete-stage.test.ts
@@ -1,0 +1,102 @@
+/// <reference types="jest" />
+import type { StageData } from '@btp/core';
+import { runDeleteStage } from './delete-stage';
+import { useTripStore } from './trip-store';
+
+jest.mock('../api/trips', () => ({ deleteStage: jest.fn() }));
+import { deleteStage } from '../api/trips';
+const mockDelete = deleteStage as jest.MockedFunction<typeof deleteStage>;
+
+const P = { lat: 0, lon: 0, ele: 0 };
+
+function stage(dayNumber: number): StageData {
+  return {
+    dayNumber,
+    distance: 50,
+    elevation: 0,
+    elevationLoss: 0,
+    startPoint: P,
+    endPoint: P,
+    geometry: [],
+    label: null,
+    startLabel: null,
+    endLabel: null,
+    weather: null,
+    alerts: [],
+    pois: [],
+    accommodations: [],
+    selectedAccommodation: null,
+    accommodationSearchRadiusKm: 5,
+    isRestDay: false,
+    supplyTimeline: [],
+    events: [],
+  };
+}
+
+const noop = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useTripStore.getState().reset();
+  useTripStore.setState({
+    stages: [stage(1), stage(2), stage(3)],
+    isLocked: false,
+    loading: false,
+  });
+});
+
+describe('runDeleteStage optimistic delete (#1015)', () => {
+  it('removes the stage optimistically and renumbers days on success', async () => {
+    mockDelete.mockResolvedValue({ ok: true, status: 202 });
+
+    await runDeleteStage('t1', 1, useTripStore.getState(), noop);
+
+    const stages = useTripStore.getState().stages;
+    expect(stages).toHaveLength(2);
+    expect(stages.map((s) => s.dayNumber)).toEqual([1, 2]);
+    expect(mockDelete).toHaveBeenCalledWith('t1', 1);
+    expect(noop).not.toHaveBeenCalled();
+  });
+
+  it('rolls back and reports "error" on a non-423 failure', async () => {
+    mockDelete.mockResolvedValue({ ok: false, status: 500 });
+    const onFailure = jest.fn();
+
+    await runDeleteStage('t1', 1, useTripStore.getState(), onFailure);
+
+    expect(useTripStore.getState().stages).toHaveLength(3);
+    expect(useTripStore.getState().stages.map((s) => s.dayNumber)).toEqual([1, 2, 3]);
+    expect(onFailure).toHaveBeenCalledWith('error');
+  });
+
+  it('rolls back and reports "locked" on a 423', async () => {
+    mockDelete.mockResolvedValue({ ok: false, status: 423 });
+    const onFailure = jest.fn();
+
+    await runDeleteStage('t1', 0, useTripStore.getState(), onFailure);
+
+    expect(useTripStore.getState().stages).toHaveLength(3);
+    expect(onFailure).toHaveBeenCalledWith('locked');
+  });
+
+  it('rolls back and reports "error" when the request throws', async () => {
+    mockDelete.mockRejectedValue(new Error('network'));
+    const onFailure = jest.fn();
+
+    await runDeleteStage('t1', 2, useTripStore.getState(), onFailure);
+
+    expect(useTripStore.getState().stages).toHaveLength(3);
+    expect(onFailure).toHaveBeenCalledWith('error');
+  });
+
+  it('does not touch the store or call the API when the trip is locked', async () => {
+    useTripStore.setState({ isLocked: true });
+    const onFailure = jest.fn();
+
+    await runDeleteStage('t1', 1, useTripStore.getState(), onFailure);
+
+    expect(useTripStore.getState().stages).toHaveLength(3);
+    expect(mockDelete).not.toHaveBeenCalled();
+    expect(onFailure).toHaveBeenCalledWith('locked');
+  });
+});

--- a/mobile/src/store/delete-stage.ts
+++ b/mobile/src/store/delete-stage.ts
@@ -1,0 +1,46 @@
+import type { StageData } from '@btp/core';
+import { deleteStage as apiDeleteStage } from '../api/trips';
+
+export type DeleteFailure = 'locked' | 'error';
+
+// The store surface the deletion drives.
+export interface DeleteStageStore {
+  isLocked: boolean;
+  stages: StageData[];
+  deleteStageOptimistic: (index: number) => void;
+  setStages: (stages: StageData[]) => void;
+}
+
+// Optimistic stage deletion (#1015): snapshot -> remove locally -> call the API.
+// On success the authoritative recompute arrives over SSE and reconciles through
+// the core reducers; on failure (including 423 when the trip is locked) the
+// snapshot is restored and the reason reported so the UI can toast. Extracted
+// from the screen so the optimistic/rollback/423 branches are unit-testable.
+export async function runDeleteStage(
+  tripId: string,
+  index: number,
+  store: DeleteStageStore,
+  onFailure: (reason: DeleteFailure) => void,
+): Promise<void> {
+  // A started trip is read-only; skip the optimistic mutation entirely.
+  if (store.isLocked) {
+    onFailure('locked');
+    return;
+  }
+
+  const snapshot = store.stages;
+  store.deleteStageOptimistic(index);
+
+  try {
+    const { ok, status } = await apiDeleteStage(tripId, index);
+    if (!ok) {
+      store.setStages(snapshot);
+      onFailure(status === 423 ? 'locked' : 'error');
+    }
+    // On success, the SSE trip_ready / stage_updated event replaces the
+    // optimistic list with the reconciled authoritative state.
+  } catch {
+    store.setStages(snapshot);
+    onFailure('error');
+  }
+}

--- a/mobile/src/store/trip-store.ts
+++ b/mobile/src/store/trip-store.ts
@@ -50,6 +50,9 @@ interface TripState {
   tripId: string | null;
   title: string | null;
   stages: StageData[];
+  // Trip started (startDate <= today): the backend rejects edits with 423, so the
+  // UI disables them. Read from the /detail payload on hydrate.
+  isLocked: boolean;
   loading: boolean;
   error: string | null;
   // Initial load from a /trips/{id}/detail payload.
@@ -58,6 +61,12 @@ interface TripState {
   applyTripReady: (stages: StageData[]) => void;
   // Mode 2 per-stage event: reconcile a single slice via the shared core reducer.
   applyStageUpdate: (index: number, stage: StageData) => void;
+  // Replace the whole stage list (optimistic rollback restores a snapshot).
+  setStages: (stages: StageData[]) => void;
+  // Optimistic delete: drop a stage and renumber the days, mirroring the web
+  // store. The authoritative state arrives via the SSE reconciliation; on API
+  // failure the caller restores the pre-delete snapshot via setStages.
+  deleteStageOptimistic: (index: number) => void;
   setStatus: (patch: { loading?: boolean; error?: string | null }) => void;
   reset: () => void;
 }
@@ -69,6 +78,7 @@ export const useTripStore = create<TripState>((set, get) => ({
   tripId: null,
   title: null,
   stages: [],
+  isLocked: false,
   loading: true,
   error: null,
   hydrate: (tripId, detail) =>
@@ -76,6 +86,7 @@ export const useTripStore = create<TripState>((set, get) => ({
       tripId,
       title: detail.title ?? null,
       stages: (detail.stages ?? []).map(stageDataFromDetail),
+      isLocked: detail.isLocked ?? false,
       loading: false,
       error: null,
     }),
@@ -83,7 +94,21 @@ export const useTripStore = create<TripState>((set, get) => ({
     set({ stages: reconcileTripReady(get().stages, stages) }),
   applyStageUpdate: (index, stage) =>
     set({ stages: reconcileStageUpdate(get().stages, index, stage).stages }),
+  setStages: (stages) => set({ stages }),
+  deleteStageOptimistic: (index) =>
+    set((state) => ({
+      stages: state.stages
+        .filter((_, i) => i !== index)
+        .map((stage, i) => ({ ...stage, dayNumber: i + 1 })),
+    })),
   setStatus: (patch) => set(patch),
   reset: () =>
-    set({ tripId: null, title: null, stages: [], loading: true, error: null }),
+    set({
+      tripId: null,
+      title: null,
+      stages: [],
+      isLocked: false,
+      loading: true,
+      error: null,
+    }),
 }));


### PR DESCRIPTION
Refs #1015. Base = `main`. Dépend de #1014 (mergé). **Clôture la tranche verticale du Sprint 53.**

## Objectif

Prouver l'**édition optimiste + réconciliation SSE de bout en bout** sur UNE opération réelle : supprimer une étape.

## Contenu

- **`DELETE /trips/{tripId}/stages/{index}`** câblé en optimiste + rollback via le store mince.
- **Store** : `isLocked` (depuis `/detail`), `setStages` (rollback), `deleteStageOptimistic` (splice + renumérotation des jours, comme le store web).
- **`runDeleteStage`** (orchestration testable) : snapshot → suppression optimiste → API ; succès → l'état autoritaire arrive par **SSE** et se réconcilie via les réducteurs `core` ; échec → restauration du snapshot + raison remontée.
- **423 Locked** : voyage démarré (`startDate <= today`, `App\State\TripLocker`) = lecture seule → action masquée quand `isLocked`, et un 423 défensif de l'API rollback aussi avec un toast « locked ».
- **Roadbook** : bouton de suppression par étape (masqué si verrouillé) avec confirmation + Alert d'erreur.

## Vérification (locale, preuves réelles)

| Leg | Résultat |
|-----|----------|
| `tsc --noEmit` (mobile) | ✅ 0 erreur |
| **jest** | ✅ **15/15** (dont 5 nouveaux : optimiste/rollback/423/locked) |
| Test **prouvé faillible** | ✅ retrait du rollback → les 2 tests rollback virent au rouge, puis restauré |
| `expo export --platform android` | ✅ bundle OK |

## Validation device

🔄 À rejouer sur device (même combo ngrok + `SM_A556B` que #1014) : supprimer une étape → disparition optimiste → réconciliation SSE ; couper le réseau → rollback + toast ; voyage démarré → action masquée / 423. Je mets à jour après capture.

## Sortie de sprint

Architecture prouvée de bout en bout : `core` partagé + store RN mince + SSE header + optimiste/rollback/réconciliation, sur un chemin réel. → Go pour élargir (design system, shell, écrans).

## Auto-critique

- **Optimiste sans file d'attente** (contrairement au batch web) : une seule mutation, cohérent avec la tranche « preuve d'architecture » ; l'état autoritaire vient du recalcul SSE.
- **`isLocked` recalculé serveur** (startDate <= today UTC) et lu de `/detail` ; l'action est masquée côté client ET le 423 est géré défensivement (double filet).
- Mobile toujours non gaté par la CI (cf. #1014) — validé local + device.

<!-- claude-review-start -->
## Claude Review

**Findings:** 0 critical, 0 warning, 3 suggestion (non-blocking) — no inline comments posted.

**Review checklist:**
- [x] Code respects the project architecture (thin RN store delegating to `@btp/core` reducers, mirrors the web `deleteStage` splice+renumber pattern)
- [x] SOLID principles and Law of Demeter followed (orchestration extracted into a testable `runDeleteStage`, decoupled from the screen via a narrow `DeleteStageStore` interface)
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases (5 Jest cases: optimistic success, rollback on generic failure, rollback on 423, rollback on thrown error, no-op when locked)
- [ ] Documentation is up to date (code comments are accurate; see TRACKING.md note below)
- [x] Dependent tickets accounted for (#1014 merged prerequisite, #1015 closed by this PR)

**PR title:** minor nit — the description reads as a noun phrase ("optimistic stage deletion … — end-to-end proof") rather than imperative mood required by Conventional Commits (e.g. "wire optimistic stage deletion with SSE reconciliation"). Not blocking.

**Second commit (9e8dc329):** pins `react-native-sse`'s `lineEndingCharacter` to `'\n'` to stop it guessing the line-ending style from Mercure/Caddy's stream. Verified `lineEndingCharacter` is a real `EventSourceOptions` field on `react-native-sse` (not hallucinated) — legitimate, low-risk robustness fix.

**Non-blocking observations** (not filed as inline comments — no small, in-scope fix; noted for awareness only):
- `TRACKING.md`'s Sprint 53 table still marks rows 1-4 (#1011-#1014) as "⏳ À faire" and leaves the PRs column empty, even though #1011/#1012/#1013/#1014 are already merged (#1020/#1021/#1023/#1024). This PR explicitly closes out the sprint ("Clôture la tranche verticale du Sprint 53") but doesn't touch `TRACKING.md` — worth a follow-up pass to mark the whole table (including #1015/this PR) done and check off the manual recette checklist, so the tracker reflects reality.
- After a successful delete that merges into an adjacent stage (`StageDeleteProcessor::mergeWithAdjacent`), the optimistically-spliced list shows the adjacent stage's stale distance/geometry until the SSE `stage_updated`/`trip_ready` event reconciles it, with no loading affordance — the web equivalent sets `processing`/`accommodationScanning` flags for this window. Same tradeoff already acknowledged in the PR's auto-critique (no queue, SSE-only reconciliation); flagging only so it's tracked as the design widens beyond this one proven path.
- `runDeleteStage` collapses every non-423 failure (including the backend's 422 "minimum 2 stages" business rule) into a generic `'error'` reason, which surfaces a "retry" prompt for a condition retrying can't fix. Cosmetic, not a correctness bug.

No security, performance, or architecture issues found. HTTP client usage, auth header injection, and the 423/lock handling all check out against the existing `TripLocker`/`StageDeleteProcessor` contract. Cross-checked the mobile `deleteStage()`/openapi-fetch 202-empty-body path against the pre-existing web `handleDeleteStage` (`pwa/src/hooks/use-trip-planner.ts`), which calls the identical endpoint the same way in production — confirms this isn't a new risk.

Previous bot review minimized (superseded).

Commit reviewed: 9e8dc3299a1beef0e9103be94c35468a9e8617e3
<!-- claude-review-end -->