### PR TITLE
chore(sprint-53): retro — worktree-agent isolation gotcha + mobile CI gate

### DIFF
--- a/.docker/ngrok-host-rewrite.yml
+++ b/.docker/ngrok-host-rewrite.yml
@@ -1,0 +1,10 @@
+# ngrok traffic policy — équivalent de l'ancien `--host-header=rewrite`.
+# Réécrit le Host de la requête forwardée à l'upstream vers `localhost`, pour que
+# le Caddy du stack dev (SERVER_NAME=localhost, TRUSTED_HOSTS ^localhost|php$)
+# accepte les requêtes arrivant via le domaine ngrok.
+on_http_request:
+  - actions:
+      - type: add-headers
+        config:
+          headers:
+            host: localhost

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
       api: ${{ steps.filter.outputs.api }}
       provisioner: ${{ steps.filter.outputs.provisioner }}
       pwa: ${{ steps.filter.outputs.pwa }}
+      mobile: ${{ steps.filter.outputs.mobile }}
       docker: ${{ steps.filter.outputs.docker }}
       docs: ${{ steps.filter.outputs.docs }}
       e2e: ${{ steps.filter.outputs.e2e }}
@@ -55,7 +56,7 @@ jobs:
           # the MkDocs config (mkdocs.yml, docs-only) and the non-code assets above have no code
           # impact. Fail-safe: run the full suite on non-PR events, on workflow changes, or when a
           # file matches no zone.
-          known='^api/|^provisioner/|^pwa/|^core/|^package\.json$|^package-lock\.json$|^\.npmrc$|^\.docker/|^\.dockerignore$|^compose[^/]*\.yaml$|^\.git|^docs/|^mkdocs\.yml$|'"$noncode"
+          known='^api/|^provisioner/|^pwa/|^core/|^mobile/|^package\.json$|^package-lock\.json$|^\.npmrc$|^\.docker/|^\.dockerignore$|^compose[^/]*\.yaml$|^\.git|^docs/|^mkdocs\.yml$|'"$noncode"
           run_all=false
           if [ "$EVENT_NAME" != "pull_request" ]; then run_all=true; fi
           if printf '%s\n' "$files" | grep -qE '^\.github/workflows/'; then run_all=true; fi
@@ -70,6 +71,9 @@ jobs:
           # manifests (package.json/-lock, .npmrc) affect the web build, so any of
           # them exercises the pwa jobs (and, via e2e below, Playwright).
           pwa=$(flag '^pwa/|^core/|^package\.json$|^package-lock\.json$|^\.npmrc$')
+          # mobile consumes core/ and the shared schema, and the root workspace
+          # manifests drive its install, so any of them exercises the mobile job.
+          mobile=$(flag '^mobile/|^core/|^package\.json$|^package-lock\.json$|^\.npmrc$')
           docker=$(flag '^\.docker/|^\.dockerignore$|^compose[^/]*\.yaml$')
           if [ "$run_all" = true ] || printf '%s\n' "$files" | grep -qE '\.md$|^mkdocs\.yml$'; then docs=true; else docs=false; fi
           if [ "$api" = true ] || [ "$pwa" = true ] || [ "$docker" = true ]; then e2e=true; else e2e=false; fi
@@ -78,6 +82,7 @@ jobs:
             echo "api=$api"
             echo "provisioner=$provisioner"
             echo "pwa=$pwa"
+            echo "mobile=$mobile"
             echo "docker=$docker"
             echo "docs=$docs"
             echo "e2e=$e2e"
@@ -880,3 +885,26 @@ jobs:
         run: npm ci
       - name: Run unit tests with coverage
         run: npm run test:unit --workspace pwa -- --coverage
+
+  mobile-checks:
+    name: Mobile (tsc + jest)
+    needs: changes
+    if: >-
+      !cancelled() &&
+      (needs.changes.outputs.mobile == 'true' || needs.changes.result == 'failure')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: "26"
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Run TypeScript Check
+        run: npm run typecheck --workspace mobile
+      - name: Run jest
+        run: npm run test --workspace mobile

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,8 @@ docker compose --profile provisioning run --rm provisioner corse --allow-unroute
 /close [sprint-number]              # Close a sprint: clean worktrees/branches, update main, retrospective
 ```
 
+**Worktree-agent isolation is not guaranteed — pre-create the worktree and pin the agent to it.** In Sprint 53 (#1012) an agent launched with `isolation: "worktree"` lost its isolation: instead of working in a dedicated worktree it edited the **main checkout** directly, leaving an incomplete WIP uncommitted on `main` that had to be rescued (`git switch -c feature/<n>` carrying the dirty tree, then reset `main` clean). The reliable pattern (used for #1019 right after, no mishap): **create the worktree yourself first** — `git worktree add -b feature/<n> ../<repo>-<n> main` — then launch a non-isolated agent whose prompt names the absolute worktree path and states, as hard rules: `cd` there first, work ONLY there, never touch the main checkout, and never run `git worktree`/`git switch`/`git checkout <branch>` (verify `git rev-parse --abbrev-ref HEAD` is the expected branch and STOP if not). Review the agent's diff before pushing.
+
 ### GitHub Automation
 
 Claude can also be triggered directly from GitHub:


### PR DESCRIPTION
Rétrospective Sprint 53 (2 items retenus) :

1. **CLAUDE.md — isolation worktree-agent** : gotcha ancré sur #1012 (l'agent `isolation: worktree` a édité le checkout principal). Parade validée en #1019 : pré-créer le worktree + prompt strict (path absolu, ne jamais toucher main, pas de git switch).
2. **ci.yml — gate mobile** : nouveau job `Mobile (tsc + jest)` + entrée `mobile/` dans le filtre `changes`. Avant, un diff `mobile/` tombait dans `run_all` (fail-safe) sans checks mobile dédiés ; désormais `mobile/` (et `core/`/manifests racine) déclenche tsc + jest mobile.

Vérif : markdownlint CLAUDE.md 0 issue ; `ci.yml` YAML valide (job `mobile-checks` + output `mobile` présents). Le job mobile fera `npm ci` racine puis `npm run typecheck/test --workspace mobile`.

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 critical, 0 warning, 1 info (PR title wording) findings.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases (new `mobile-checks` CI job wired to existing `typecheck`/`test` scripts in `mobile/package.json`)
- [x] Documentation is up to date (CLAUDE.md retro entry, `.docker/ngrok-host-rewrite.yml` self-documented)
- [x] Dependent tickets accounted for (retro on #1012 gotcha, mirrors #1019 fix pattern)

**Notes:**
- PR title `chore(sprint-53): retro — worktree-agent isolation gotcha + mobile CI gate` — the description is not strictly in imperative mood (starts with the noun "retro"). Non-blocking.
- `ci.yml` mobile filter/job additions verified consistent with the existing `pwa` filter/job pattern (regex, `needs.changes.result == 'failure'` fail-safe, Node setup, script names match `mobile/package.json`).
- No debug leftovers, no security-sensitive code paths touched (docs + CI + a dev-only ngrok traffic-policy file).

Commit reviewed: e79759bdf6897f8f49c6c8abf563f674b847439e
<!-- claude-review-end -->
