### PR TITLE
build(mobile): installable preview build + device install doc (#1033)

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -29,6 +29,67 @@ npx expo run:android      # builds the dev client and installs it on device/emul
 npx expo start --dev-client
 ```
 
+## Installable preview build (device install)
+
+To test an increment on a real phone without keeping Metro + a tunnel running,
+build a standalone, self-contained APK once and install it. Policy is **free +
+local**: builds run on your own machine, no cloud EAS project is required.
+
+There are two paths; pick per need:
+
+| Path | Command | Ships JS bundle? | Needs Metro at runtime? |
+| --- | --- | --- | --- |
+| Dev client (debug) | `npx expo run:android` | no (Metro serves it) | yes |
+| Preview (standalone) | `npm run build:preview` | yes (baked in) | no |
+
+The **preview** build is the one you sideload for offline testing. It reads the
+`preview` profile in [`eas.json`](eas.json) (`distribution: internal`,
+`android.buildType: apk`) and runs the whole build locally via `eas build
+--local`.
+
+```bash
+cd mobile
+
+# EXPO_PUBLIC_API_URL is inlined into the bundle at build time. A non-development
+# build FAILS CLOSED without it (see src/api/config.ts and app.config.js), so it is
+# mandatory here — it also fixes the Android App Link host for the magic link.
+EXPO_PUBLIC_API_URL=https://epidermis-sandlot-headrest.ngrok-free.dev \
+  npm run build:preview
+# -> writes an APK such as build-<timestamp>.apk in mobile/
+```
+
+Notes:
+
+- `eas build --local` generates and reuses a local keystore on first run; you may
+  be prompted to log in to an Expo account for credential storage. No cloud build
+  is submitted.
+- `eas-cli` is not a project dependency; run it with `npx eas-cli ...` if the
+  `eas` binary is not on your `PATH` (`npm run build:preview` calls `eas`
+  directly — prefix with `npx` if needed).
+
+### Install the APK on a device
+
+```bash
+adb install -r build-<timestamp>.apk   # USB debugging enabled, device authorised
+# or copy the .apk to the phone and open it (allow "install unknown apps")
+```
+
+### How the installed app reaches the API
+
+The preview APK talks to whatever host you baked into `EXPO_PUBLIC_API_URL` at
+build time — there is no runtime override, the value is compiled into the JS
+bundle. For a physical device the host must be reachable **from the phone**, not
+just from your laptop:
+
+- **ngrok public URL** (the default above): works over Wi-Fi or cellular, and its
+  HTTPS is what the Android App Link (`/auth/verify`) verifies. Recommended.
+- **A LAN IP** (`http://192.168.x.y:8000`): only works when the phone is on the
+  same network, and cleartext HTTP additionally needs an ATS/`usesCleartext`
+  exception — the ngrok tunnel avoids both problems.
+
+`localhost` never works from a phone: it resolves to the device itself. To repoint
+the app at another environment, rebuild with a different `EXPO_PUBLIC_API_URL`.
+
 ## Pointing at the API (ngrok)
 
 The API base URL is read from `EXPO_PUBLIC_API_URL`. Create `mobile/.env`:

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -63,9 +63,8 @@ Notes:
 - `eas build --local` generates and reuses a local keystore on first run; you may
   be prompted to log in to an Expo account for credential storage. No cloud build
   is submitted.
-- `eas-cli` is not a project dependency; run it with `npx eas-cli ...` if the
-  `eas` binary is not on your `PATH` (`npm run build:preview` calls `eas`
-  directly — prefix with `npx` if needed).
+- `eas-cli` is not a project dependency; `npm run build:preview` runs it through
+  `npx --yes eas-cli`, so it is fetched on demand — nothing to install globally.
 
 ### Install the APK on a device
 

--- a/mobile/eas.json
+++ b/mobile/eas.json
@@ -1,0 +1,19 @@
+{
+  "cli": {
+    "version": ">= 12.0.0",
+    "appVersionSource": "local"
+  },
+  "build": {
+    "preview": {
+      "distribution": "internal",
+      "android": {
+        "buildType": "apk"
+      }
+    },
+    "production": {
+      "android": {
+        "buildType": "app-bundle"
+      }
+    }
+  }
+}

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -31,7 +31,7 @@
     "start": "expo start",
     "android": "expo run:android",
     "ios": "expo run:ios",
-    "build:preview": "eas build --local --platform android --profile preview",
+    "build:preview": "npx --yes eas-cli build --local --platform android --profile preview",
     "web": "expo start --web",
     "typecheck": "tsc --noEmit",
     "test": "jest"

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -31,6 +31,7 @@
     "start": "expo start",
     "android": "expo run:android",
     "ios": "expo run:ios",
+    "build:preview": "eas build --local --platform android --profile preview",
     "web": "expo start --web",
     "typecheck": "tsc --noEmit",
     "test": "jest"


### PR DESCRIPTION
Closes #1033.

## Résumé
Build de preview installable **local et gratuit** (pas d'EAS cloud), par-dessus le socle existant (`expo run:android` dev-client + `EXPO_PUBLIC_API_URL` fail-closed).

- `mobile/eas.json` (nouveau) : profils `preview` (`distribution: internal`, `android.buildType: apk`) et `production` (app-bundle), `cli.appVersionSource: local`. `preview` = APK autonome via `eas build --local`.
- `mobile/package.json` : script `build:preview`. Aucune dépendance ajoutée (`eas-cli` invoqué en `npx`).
- `mobile/README.md` : section "Installable preview build (device install)" — dev-client vs preview, commande de build avec `EXPO_PUBLIC_API_URL` obligatoire, install `adb install`, accès API device (ngrok / LAN IP cleartext).

## Vérification locale
- `npm run typecheck --workspace mobile` → exit 0
- `npm run test --workspace mobile` → 3 suites / 15 tests PASS, exit 0
- eas.json / app.config.js / package.json parse OK
- markdownlint (cible réelle, node_modules exclus) → 0 erreur

## Auto-critique
- **Non vérifiable en local (device requis)** : produire réellement l'APK (`npm run build:preview`, toolchain Android natif + `npx eas-cli`) et l'installer (`adb install`) restent manuels. La CI ne gate pas ce build (pas de job EAS).
- Diff strictement borné à `mobile/` : pas de chevauchement avec #1028 (`userInterfaceStyle`), #1032 (`android.intentFilters`), #1034 (docs/mkdocs).

<!-- claude-review-start -->
## Claude Review

**Summary:** The prior critical finding (`build:preview` invoking `eas` directly instead of via `npx`) is fixed in `c5583526` — no code-level issues remain. One non-blocking documentation gap: `TRACKING.md` still lists #1033 as "⏳ À faire" with no PR link, unlike other in-flight rows that show "🚧 En cours" + the PR reference.

**Resolved threads:** Resolved 1 previously open thread (the `eas-cli`/npx dependency issue), addressed by commit `c5583526`.

**PR title check:** `build(mobile): installable preview build + device install doc (#1033)` — the description is a noun phrase, not imperative mood (e.g. "add installable preview build..."). Minor, non-blocking.

**Findings by severity:** Critical: 0 · Warning: 0 · Suggestion: 1 (TRACKING.md staleness, non-blocking)

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [ ] Tests cover new/changed cases (N/A — build tooling/docs only, no testable logic added)
- [ ] Documentation is up to date (README is accurate; `TRACKING.md` row for #1033 not updated to reflect this open PR)
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

**Commit reviewed:** `c5583526cc8a62f3d47a8c6aa7f7575fd69066d3`
<!-- claude-review-end -->