### PR TITLE
feat(infra): App Links (Caddy assetlinks + dev/recette assoc + 401 retry test) (#1032)

### DIFF
--- a/.docker/php/Caddyfile
+++ b/.docker/php/Caddyfile
@@ -84,7 +84,7 @@
                     '*.json*', '*.html', '*.csv', '*.yml', '*.yaml', '*.xml'
                 )
             )
-            || path('/favicon.ico', '/manifest.json', '/robots.txt', '/sitemap*', '/_next*', '/__next*')
+            || path('/favicon.ico', '/manifest.json', '/robots.txt', '/sitemap*', '/_next*', '/__next*', '/.well-known/assetlinks.json')
             || query({'_rsc': '*'})`
 
         # Content-Security-Policy (audit 35.2 SEC-001), scoped to the PWA so the

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -104,6 +104,12 @@ services:
       # Mercure hub the browser subscribes to. Point it at the tunnel origin to
       # get live SSE updates on mobile; the localhost default is fine on desktop.
       NEXT_PUBLIC_MERCURE_URL: "${NEXT_PUBLIC_MERCURE_URL:-https://localhost/.well-known/mercure}"
+      # Android App Links (ADR-053): serve the DEBUG keystore association so a dev
+      # build (installed via `expo run:android`) verifies the https App Link against
+      # the tunnel/localhost host. Prod stays empty (compose.yaml) until the release
+      # signing-cert fingerprint is added (Sprint 59).
+      ANDROID_APP_PACKAGE: "${ANDROID_APP_PACKAGE:-coop.lestilleuls.biketripplanner}"
+      ANDROID_SHA256_CERT_FINGERPRINTS: "${ANDROID_SHA256_CERT_FINGERPRINTS:-FA:C6:17:45:DC:09:03:78:6F:B9:ED:E6:2A:96:2B:39:9F:73:48:F0:BB:6F:89:9B:83:32:66:75:91:03:3B:9C}"
     # npm workspace: mount the repo root so the `core/` workspace resolves and the
     # root lockfile drives `npm install`. node_modules is hoisted to the root; the
     # web build cache stays under pwa/.next.

--- a/compose.recette.yaml
+++ b/compose.recette.yaml
@@ -47,6 +47,15 @@ services:
     environment:
       <<: *recette-env
 
+  pwa:
+    environment:
+      # Android App Links (ADR-053): recette is exercised on-device (via ngrok)
+      # with a DEBUG build, so it must serve the debug keystore association for the
+      # https App Link to verify. Prod (compose.yaml) stays empty until the release
+      # signing-cert fingerprint is added (Sprint 59).
+      ANDROID_APP_PACKAGE: "${ANDROID_APP_PACKAGE:-coop.lestilleuls.biketripplanner}"
+      ANDROID_SHA256_CERT_FINGERPRINTS: "${ANDROID_SHA256_CERT_FINGERPRINTS:-FA:C6:17:45:DC:09:03:78:6F:B9:ED:E6:2A:96:2B:39:9F:73:48:F0:BB:6F:89:9B:83:32:66:75:91:03:3B:9C}"
+
   mailcatcher:
     # Pinned by digest: schickling/mailcatcher has no versioned tags, and the
     # mutable tag would let an upstream rebuild change the HTTP API recette-seed.sh relies on.

--- a/mobile/src/api/client.test.ts
+++ b/mobile/src/api/client.test.ts
@@ -1,0 +1,94 @@
+/// <reference types="jest" />
+import { authMiddleware } from './client';
+
+jest.mock('../auth/tokens', () => ({ getJwt: jest.fn() }));
+jest.mock('../auth/authApi', () => ({ refreshTokens: jest.fn() }));
+import { getJwt } from '../auth/tokens';
+import { refreshTokens } from '../auth/authApi';
+
+const mockGetJwt = getJwt as jest.MockedFunction<typeof getJwt>;
+const mockRefresh = refreshTokens as jest.MockedFunction<typeof refreshTokens>;
+
+// The middleware callback params carry many fields openapi-fetch fills in; only
+// `request`/`response` matter here, so cast the partial shapes.
+const onRequest = (request: Request) => (authMiddleware.onRequest as never as (p: { request: Request }) => unknown)({ request });
+const onResponse = (request: Request, response: Response) =>
+  (authMiddleware.onResponse as never as (p: { request: Request; response: Response }) => Promise<Response | undefined>)({
+    request,
+    response,
+  });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  globalThis.fetch = jest.fn();
+});
+
+describe('authMiddleware 401 retry (#1032)', () => {
+  it('refreshes the token and replays the request with the new JWT on a 401', async () => {
+    mockGetJwt.mockReturnValueOnce('stale-jwt').mockReturnValue('fresh-jwt');
+    mockRefresh.mockResolvedValue(true);
+    (globalThis.fetch as jest.Mock).mockResolvedValue(
+      new Response('{"ok":true}', { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    );
+
+    const request = new Request('https://api.test/trips/1');
+    await onRequest(request);
+    expect(request.headers.get('Authorization')).toBe('Bearer stale-jwt');
+
+    const result = await onResponse(request, new Response(null, { status: 401 }));
+
+    expect(mockRefresh).toHaveBeenCalledTimes(1);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    const retried = (globalThis.fetch as jest.Mock).mock.calls[0][0] as Request;
+    expect(retried.headers.get('Authorization')).toBe('Bearer fresh-jwt');
+    expect(retried.headers.get('X-Native-Retry')).toBe('1');
+    expect(result).toBeInstanceOf(Response);
+    expect(result?.status).toBe(200);
+  });
+
+  it('does not replay when the refresh fails', async () => {
+    mockGetJwt.mockReturnValue('stale-jwt');
+    mockRefresh.mockResolvedValue(false);
+
+    const request = new Request('https://api.test/trips/1');
+    await onRequest(request);
+    const result = await onResponse(request, new Response(null, { status: 401 }));
+
+    expect(mockRefresh).toHaveBeenCalledTimes(1);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(result).toBeUndefined();
+  });
+
+  it('never refreshes on an already-retried request (no loop)', async () => {
+    mockGetJwt.mockReturnValue('stale-jwt');
+
+    const request = new Request('https://api.test/trips/1', { headers: { 'X-Native-Retry': '1' } });
+    await onRequest(request);
+    const result = await onResponse(request, new Response(null, { status: 401 }));
+
+    expect(mockRefresh).not.toHaveBeenCalled();
+    expect(result).toBeUndefined();
+  });
+
+  it('never refreshes on an auth-endpoint 401', async () => {
+    mockGetJwt.mockReturnValue('stale-jwt');
+
+    const request = new Request('https://api.test/auth/verify');
+    await onRequest(request);
+    const result = await onResponse(request, new Response(null, { status: 401 }));
+
+    expect(mockRefresh).not.toHaveBeenCalled();
+    expect(result).toBeUndefined();
+  });
+
+  it('leaves a non-401 response unchanged', async () => {
+    mockGetJwt.mockReturnValue('jwt');
+
+    const request = new Request('https://api.test/trips/1');
+    await onRequest(request);
+    const result = await onResponse(request, new Response('{}', { status: 200 }));
+
+    expect(mockRefresh).not.toHaveBeenCalled();
+    expect(result).toBeUndefined();
+  });
+});

--- a/mobile/src/api/client.ts
+++ b/mobile/src/api/client.ts
@@ -11,7 +11,7 @@ const RETRY_HEADER = 'X-Native-Retry';
 // cannot clone in onResponse; the mutating calls in #1014/#1015 would break there.
 const pendingRetries = new WeakMap<Request, Request>();
 
-const authMiddleware: Middleware = {
+export const authMiddleware: Middleware = {
   async onRequest({ request }) {
     const jwt = getJwt();
     if (jwt) {


### PR DESCRIPTION
Closes #1032.

## Résumé
Constat : l'essentiel du scope était déjà en `main` (livré par #1010/#1014/#1018) — route PWA `/.well-known/assetlinks.json`, passthrough `ANDROID_*` sur `compose.yaml`, `android.intentFilters` `autoVerify` dans `mobile/app.config.js`, middleware retry 401. Cette PR livre les 3 trous restants :

1. **`.docker/php/Caddyfile`** : ajoute `/.well-known/assetlinks.json` au matcher `@pwa`. Avant, ce chemin `.json` était exclu du reverse-proxy PWA et tombait sur l'API PHP en 404 ; désormais servi par la PWA.
2. **`compose.dev.yaml` / `compose.recette.yaml`** (service `pwa`) : valeurs de l'association keystore **debug** (`coop.lestilleuls.biketripplanner` + empreinte SHA-256), en `${VAR:-<défaut>}`. Dev/recette servent une vraie assetlinks ; **prod reste vide `[]`** jusqu'à l'empreinte de release (Sprint 59), conforme au commentaire de `compose.yaml`.
3. **`mobile/src/api/client.ts`** : `authMiddleware` exporté (seam de test). **`mobile/src/api/client.test.ts`** (nouveau, 5 cas) : refresh+replay avec nouveau JWT + header `X-Native-Retry`, pas de replay si refresh échoue, pas de boucle sur requête déjà retentée, pas de refresh sur `/auth/`, 401 seul déclencheur.

## Vérification locale
- `npm run typecheck --workspace mobile` → exit 0
- `npm run test --workspace mobile` → 4 suites / 20 tests, exit 0
- `docker compose config` (base / +dev / +recette) → exit 0 ; rendu : dev/recette exposent l'empreinte debug, prod `""`
- **Mutation-proof** : inversion de `if (!refreshed)` → 2 tests rouges ; restauré → vert.

## Auto-critique
- **Non vérifiable en local (device requis, à ta charge)** : `adb shell pm verify-app-links --re-verify` + `pm get-app-links` une fois la PWA dev/recette servie via ngrok ; ouverture d'un vrai magic-link https à TTL court dans l'app native.
- **Sprint 59** : ajouter l'empreinte de **release** à `compose.yaml` (prod) pour la vérification sur build store.
- Pas de chevauchement `app.json` avec #1028 (je n'ai pas dupliqué `intentFilters` dans `app.json`, `app.config.js` fait foi).

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 findings (0 critical, 0 warning). Scoped, minimal diff that closes the 3 remaining gaps for App Links; each change was cross-checked against the code it depends on (assetlinks route, ADR-053, existing Expo Router intent filter) and matches.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**PR title:** minor Conventional Commits nit — description isn't imperative-mood/lowercase (`App Links (Caddy assetlinks + dev/recette assoc + 401 retry test) (#1032)`), not blocking.

**Inline comments:** No inline comments.

**Reviewed commit:** c4110da04b5c82666987dbe3c40bc271ee5c5141
<!-- claude-review-end -->