### PR TITLE
docs(adr): ADR-054/055/056 mobile + README/CLAUDE.md/MkDocs (#1034)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,16 @@ make php-shell          # Bash inside PHP container
 make pwa-shell          # Bash inside Node container
 ```
 
+**Mobile (Expo / React Native) workspace.** The repo is an npm-workspaces monorepo (`core` / `pwa` / `mobile`; see ADR-053). The mobile app is **not** dockerized — it runs natively via Expo, not through the Makefile. Install once from the repo root (`npm install`, which links all workspaces incl. `@btp/core`), then drive the `mobile` workspace with npm:
+
+```bash
+npm run android --workspace mobile     # build & launch on Android device/emulator (expo run:android)
+npm run ios     --workspace mobile     # iOS (expo run:ios)
+npm run start   --workspace mobile     # Expo dev server (expo start)
+npm run typecheck --workspace mobile   # tsc --noEmit
+npm run test    --workspace mobile     # jest (jest-expo)
+```
+
 **Compose layout:** `compose.yaml` is the iso-prod base (read as-is by CI and Coolify); `compose.dev.yaml` layers the dev overrides and is auto-loaded in dev via the Makefile (`COMPOSE_FILE`). Dev and prod run the same FrankenPHP image with Caddy + Mercure embedded — see [ADR-037](docs/adr/adr-037-docker-dev-prod-convergence.md). `make start-dev` runs dev; `make start` / `make build` target prod. **Gotcha:** there is no `compose.prod.yaml` — issues or docs written before ADR-037 may still reference it; the prod/iso-prod stack now lives in `compose.yaml`.
 
 **New runtime secret? Wire it into `compose.yaml`, not just dev/recette.** Compose does not forward an arbitrary Coolify/host env var into a container unless the file references it, and `compose.yaml` is the iso-prod base Coolify reads as-is. A secret added only to `compose.dev.yaml` / `compose.recette.yaml` reaches dev and recette but is **empty in prod** — and a fail-closed service (e.g. `AccessRequestHmacService`, which throws on an empty secret) then 500s on every request. Add the passthrough line `VAR: "${VAR:-}"` to **both** services (`php`, `worker`) in `compose.yaml`, next to `MAILER_DSN` / `REFRESH_TOKEN_ENC_KEY` (Sprint 52 #976: the HMAC secret was wired into dev + recette only and would have 500'd early-access in prod).
@@ -183,6 +193,8 @@ If the extension is absent, fall back to the manual `feature/<dep>` base plus th
 ### Type Contract (Single Source of Truth)
 
 Backend PHP DTOs define the schema → API Platform exports OpenAPI spec → `npm run typegen` (openapi-typescript) generates TypeScript types → openapi-fetch provides type-safe API calls. Schema changes on backend intentionally cause frontend compilation failures to prevent data drift.
+
+The generated types land in the **`@btp/core`** workspace (`core/schema.d.ts`, re-exported via `core/schemas.ts`), the single framework-free package that **both** `pwa` and `mobile` import. `@btp/core` also carries the Mercure wire types (`core/mercure.ts`) and the pure SSE reconciliation reducers (`core/reconciliation.ts`), so web and mobile share one source of truth for both the schema and the reconciliation logic — never re-implement either per platform (ADR-055). The repo is an npm-workspaces monorepo (`core` / `pwa` / `mobile`); see ADR-053.
 
 ### Key Patterns
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,34 @@ See [Getting Started](docs/getting-started.md) for prerequisites and detailed se
 
 ---
 
+## Mobile app
+
+Bike Trip Planner is being repositioned around two surfaces on one API: the web
+app above (discovery, sharing, planning on a large screen) and a **dedicated
+native mobile app** for in-the-field use — offline consultation and in-ride
+navigation ([ADR-053](docs/adr/adr-053-mobile-strategy-native-app.md)).
+
+The codebase is an npm-workspaces monorepo:
+
+| Workspace | Role |
+|---|---|
+| [`core/`](core/) (`@btp/core`) | Framework-free shared package: OpenAPI-derived types, Zod schemas, Mercure wire types, and the pure SSE reconciliation reducers used by both web and mobile |
+| [`pwa/`](pwa/) | Next.js 16 web app |
+| [`mobile/`](mobile/) | Expo / React Native app (Android first, iOS later) |
+
+The mobile foundation is documented in
+[ADR-054 (design system)](docs/adr/adr-054-mobile-design-system.md),
+[ADR-055 (state architecture)](docs/adr/adr-055-mobile-state-architecture.md), and
+[ADR-056 (Mercure header-auth)](docs/adr/adr-056-mercure-header-auth-non-browser.md).
+
+```bash
+npm install                          # install all workspaces from the repo root
+npm run android --workspace mobile   # build & launch on an Android device/emulator (expo run:android)
+npm run start --workspace mobile     # start the Expo dev server
+```
+
+---
+
 ## Documentation
 
 Full documentation is published with MkDocs Material at
@@ -74,7 +102,7 @@ Full documentation is published with MkDocs Material at
 | [External data sources](docs/external-data-sources.md) | OpenStreetMap, DataTourisme, Wikidata |
 | [Contributing](docs/contributing.md) | Development workflow, standards, and tooling |
 | [Deployment](docs/deployment.md) | CI/CD pipeline, required secrets, rollback procedure |
-| [Architecture Decisions](docs/adr/) | 51 ADRs explaining every major technical choice |
+| [Architecture Decisions](docs/adr/) | 56 ADRs explaining every major technical choice |
 | [Runbooks](docs/runbooks/) | On-call playbooks: workers, DB, Redis, Mercure, releases |
 | [Claude Code Tooling](docs/claude-code-tooling.md) | MCP servers, hooks, and skills for AI-assisted development |
 | [Legal & Licensing](docs/legal-and-licensing.md) | Project licence, data attribution, and GDPR posture |

--- a/docs/adr/adr-023-authentication-strategy.md
+++ b/docs/adr/adr-023-authentication-strategy.md
@@ -219,6 +219,8 @@ The API is **client-agnostic**: `/auth/verify` and `/auth/refresh` always return
 
 An earlier Capacitor-specific mechanism (client detection keyed to the WebView's `capacitor://` Origin, a `capacitor://` entry in the `CORS_ALLOW_ORIGIN` allow-list, and an `X-Mercure-Token` response header so the WebView could read the subscriber JWT) has been **removed** as dead code along with the Capacitor client. It is superseded by the client-agnostic body-token + web-BFF design above (#1010) — no client detection is reintroduced.
 
+The native client is no longer hypothetical: the monorepo is materialized as npm workspaces (`core` / `pwa` / `mobile`) and the Expo / React Native app talks to this client-agnostic API directly, keeping the body `refresh_token` in `expo-secure-store` (see [ADR-053](adr-053-mobile-strategy-native-app.md)). The Mercure subscriber JWT — which the browser reads from an HttpOnly cookie the native client cannot — is delivered to the mobile client through a readable-body endpoint on the same no-client-detection principle ([ADR-056](adr-056-mercure-header-auth-non-browser.md)).
+
 ---
 
 ## Technical Implementation

--- a/docs/adr/adr-053-mobile-strategy-native-app.md
+++ b/docs/adr/adr-053-mobile-strategy-native-app.md
@@ -18,14 +18,35 @@ The real driver for going native is **not** aesthetics — a responsive web app 
 
 Build a **dedicated native mobile app**, Android first (iOS later).
 
-- **Leading candidate: React Native + Expo**, to reuse the single type contract (backend DTO → OpenAPI → TS) and the pure domain logic (pacing, Zod validation) across web and mobile in an upcoming monorepo (`apps/{core,web,mobile}`), and to get iOS at low marginal cost. MapLibre React Native mirrors the web's `maplibre-gl`.
+- **Leading candidate: React Native + Expo**, to reuse the single type contract (backend DTO → OpenAPI → TS) and the pure domain logic (pacing, Zod validation) across web and mobile in an upcoming monorepo, and to get iOS at low marginal cost. MapLibre React Native mirrors the web's `maplibre-gl`.
 - **Contingent on a throwaway spike.** The spike first de-risks the **offline vector-tile strategy** (self-hosted OpenMapTiles/Planetiler or PMTiles vs. a paid provider with an offline license) — a go/no-go on the native bet itself — then validates auth, background location, push, and the OpenAPI client from RN. A no-go on offline, or a spike verdict favouring Flutter, revisits the tech choice before any monorepo work.
 - **Push via FCM**, included from the MVP.
 - **Capacitor is abandoned:** its scaffolding (`capacitor.config.ts`, the Android project, the dual `BUILD_TARGET` Next.js export, the `android.yml` workflow) is removed and the web reverts to a plain SSR site.
 
 ## Consequences
 
-- No more "single codebase" shortcut: the native app carries its own UI layer; sharing happens through `apps/core` (types + domain logic), not through React DOM components. This reverses ADR-024's main rationale, which was reasonable when the goal was merely consulting data in a WebView.
+- No more "single codebase" shortcut: the native app carries its own UI layer; sharing happens through the `@btp/core` workspace (types + domain logic), not through React DOM components. This reverses ADR-024's main rationale, which was reasonable when the goal was merely consulting data in a WebView.
 - A new native mobile workstream (and a small backend brick for FCM push).
 - The authentication strategy (ADR-023) now applies to a **native client** rather than a Capacitor WebView. There is **no client detection**: the API is client-agnostic and **always** returns `{ token, refresh_token }` in the response body, setting no cookie. The native client keeps the body refresh token in the platform's secure storage; the web goes through a Next.js **BFF** that holds the refresh token in an HttpOnly SameSite=Lax cookie (#1010).
 - The mobile approach is validated incrementally (spike → MVP), so this ADR states direction; the spike gates the final tech commitment.
+
+## Update (2026-08-13) — monorepo materialized, RN + Expo committed
+
+The direction above is now realized. The spike resolved **in favour of React
+Native + Expo**, and the monorepo is materialized as npm workspaces at the repo
+root — not under an `apps/` prefix:
+
+- **`core/`** (`@btp/core`) — the shared, framework-free package: OpenAPI-derived
+  types and Zod schemas, the Mercure wire types (`core/mercure.ts`), the pure SSE
+  reconciliation reducers (`core/reconciliation.ts`), and shared constants.
+  Consumed by both `pwa/` and `mobile/`.
+- **`pwa/`** — the existing Next.js web app (kept as `pwa` rather than renamed to
+  `web`; a rename was not worth the churn).
+- **`mobile/`** — the Expo / React Native app (`expo-router`, `@maplibre/maplibre-react-native`,
+  `react-native-sse`, `expo-secure-store`).
+
+The mobile foundation is captured in three follow-up ADRs:
+
+- [ADR-054](adr-054-mobile-design-system.md) — mobile design system (tokens mirrored from web, OS-driven dark mode, native fonts).
+- [ADR-055](adr-055-mobile-state-architecture.md) — thin Zustand store composing the shared `@btp/core` reconciliation reducers (optimistic + SSE).
+- [ADR-056](adr-056-mercure-header-auth-non-browser.md) — Mercure header-auth so the non-browser client can subscribe to trip SSE.

--- a/docs/adr/adr-054-mobile-design-system.md
+++ b/docs/adr/adr-054-mobile-design-system.md
@@ -1,0 +1,68 @@
+# ADR-054: Mobile Design System — Tokens Mirrored from Web
+
+- **Status:** Accepted
+- **Date:** 2026-08-13
+- **Depends on:** ADR-053 (Mobile Strategy — Dedicated Native App)
+
+## Context and Problem Statement
+
+The native app (ADR-053) carries its own UI layer — React Native primitives, not
+the web's React DOM + Tailwind + shadcn components. Sharing happens through
+`@btp/core` (types + domain logic), not through rendered components. That leaves
+an open question the web already answered: how does the mobile surface look, and
+how does it stay visually coherent with the web?
+
+The web's visual language is a set of CSS custom properties in
+`pwa/src/app/globals.css`: a warm-paper / ink-charcoal / amber-accent palette
+(`--brand #a8561a`, `--surface #faf7f0`, `--ink #1a1814`), a spacing and radius
+scale, and three Google fonts (**Fraunces** serif, **Inter Tight** sans,
+**JetBrains Mono** mono). Dark mode flips the same semantic tokens under a
+`.dark` class (`--brand #e08040`, `--surface #1a1814`, `--ink #f5f0e8`), keeping
+contrast-safe fill colours distinct from the brighter accent.
+
+React Native has no CSS custom properties, no `.dark` selector, and no
+`next/font`. We need a mobile design system that reproduces the same visual
+identity without copy-pasting hex values ad hoc across screens (which drifts the
+moment the web palette changes).
+
+## Decision
+
+Ship a **single mobile theme module** that mirrors the web tokens, rather than a
+free-form per-screen styling approach.
+
+- **Tokens mirror the web palette.** The mobile theme exposes the same semantic
+  names the web uses (`brand`, `brandHover`, `brandFill`, `surface`, `ink`,
+  `background`, `foreground`, `muted`, `accentBrand`, plus the spacing and radius
+  scales) with the same values. The web `globals.css` remains the source of
+  truth for the palette; the mobile module is a hand-maintained transcription of
+  it (the two are small and change rarely). Components reference the theme, never
+  raw hex.
+- **Dark mode follows the OS colour scheme.** The theme is a light/dark pair
+  selected at runtime via React Native's `useColorScheme()`, reproducing the
+  web's light/dark token flip. Fill colours (`brandFill`) stay distinct from the
+  accent (`brand`) in both schemes for the same WCAG-contrast reason documented
+  in `globals.css` (white-on-accent fails at 2.86:1 in dark mode; the fill uses
+  the darker `#a8561a`).
+- **Fonts loaded natively.** Fraunces, Inter Tight, and JetBrains Mono are
+  bundled and loaded through `expo-font` (rather than `next/font`), so headings,
+  body, and monospaced numerics match the web typographically.
+
+## Consequences
+
+- The palette lives in two places (web CSS + mobile theme). This is deliberate:
+  no build-time token pipeline is worth maintaining for two consumers and a
+  palette that changes a few times a year. A palette edit on the web is a
+  one-line mirror on mobile; ADR-055's shared-`@btp/core` boundary explicitly
+  covers types and domain logic, **not** presentation, so styling is expected to
+  diverge in mechanism while converging in values.
+- Dark mode is automatic (OS-driven) with no in-app toggle initially, matching
+  the field-use context (a rider on a trail wants the system setting honoured).
+- New screens get visual coherence for free by consuming the theme; a screen that
+  hardcodes a colour is a review smell, the mobile equivalent of bypassing a
+  Tailwind token on the web.
+
+## References
+
+- [ADR-053](adr-053-mobile-strategy-native-app.md) — Mobile strategy (native app)
+- `pwa/src/app/globals.css` — web design-token source of truth
+- [Expo Font](https://docs.expo.dev/versions/latest/sdk/font/)

--- a/docs/adr/adr-055-mobile-state-architecture.md
+++ b/docs/adr/adr-055-mobile-state-architecture.md
@@ -1,0 +1,73 @@
+# ADR-055: Mobile State Architecture — Thin Store Composing `@btp/core`
+
+- **Status:** Accepted
+- **Date:** 2026-08-13
+- **Depends on:** ADR-053 (Mobile Strategy — Dedicated Native App), ADR-007 (Frontend Local State Management), ADR-056 (Mercure Header-Auth for Non-Browser Clients)
+
+## Context and Problem Statement
+
+The web frontend manages trip state locally in a Zustand + Immer store (ADR-007):
+the store hydrates from a `/trips/{id}/detail` payload, then reconciles a stream
+of Mercure SSE events into stage slices. That reconciliation is subtle — it
+encodes several hard-won race and edge behaviours: concurrency-token handling for
+stale recomputing indices (#840), client-only field preservation on a stable
+endpoint (#649), and label preservation on a raw resync (#787).
+
+The native app (ADR-053) needs the same live-trip behaviour. Re-implementing the
+reconciliation in a second language/runtime would guarantee drift: a fix landed
+on one platform silently missing from the other, with the two stores diverging
+exactly where the logic is most fragile. The type contract already prevents
+schema drift (backend DTO → OpenAPI → TS); we want the same guarantee for the
+*reconciliation* logic.
+
+## Decision
+
+Make the mobile store a **thin wrapper** that composes the pure reconciliation
+reducers extracted into `@btp/core`, rather than re-deriving the logic.
+
+- **Reconciliation lives in `@btp/core`, once.** `core/reconciliation.ts` holds
+  the pure reducers (`reconcileTripReady`, `reconcileStageUpdate`,
+  `enrichedPayloadToStageData`) extracted verbatim from the web store, with no
+  Zustand/Immer/dayjs dependency. Both platforms import them, so the mapping and
+  race handling can never diverge (#1013/#1014). The Mercure wire types
+  (`MercureEvent` et al.) live alongside in `core/mercure.ts`, shared by both.
+- **The mobile store is a thin Zustand store.** `mobile/src/store/trip-store.ts`
+  holds `StageData[]` plus load/lock status and delegates every reconciliation to
+  the core reducers (`applyTripReady` → `reconcileTripReady`, `applyStageUpdate`
+  → `reconcileStageUpdate`). It carries no reconciliation logic of its own. Immer
+  is not needed: the pure reducers return new state.
+- **Hydrate, then go live.** A single orchestration
+  (`mobile/src/hooks/use-trip-live.ts`) loads the trip from `/detail`, hydrates
+  the store, fetches the per-trip Mercure subscriber token (ADR-056), and opens
+  the SSE subscription. Incoming `trip_ready` / `stage_updated` events are mapped
+  through `enrichedPayloadToStageData` and pushed into the same reducers.
+- **Optimistic mutations with SSE as the authority.** A user edit (e.g. stage
+  deletion) is applied optimistically to the store (drop + renumber days,
+  mirroring the web), the API call runs, and the authoritative state arrives via
+  SSE reconciliation. On API failure the caller restores the pre-mutation
+  snapshot via `setStages`. This is the same optimistic + SSE-reconciled pattern
+  the web uses, now expressed against the shared reducers.
+
+## Consequences
+
+- One reconciliation implementation, two thin stores. A race fix or field-
+  preservation rule is written once in `@btp/core` and both platforms inherit it;
+  the characterization tests in `core/reconciliation.test.ts` guard the semantics
+  for both.
+- The stores differ only in glue (Zustand config, RN vs. web hooks), which is
+  where they *should* differ. Neither store re-derives domain behaviour.
+- `@btp/core` is now the shared source not just for types (schemas, Zod) but for
+  runtime domain logic (reconciliation, accommodation constants). It stays free
+  of any framework/runtime dependency so both a Next.js server bundle and a React
+  Native bundle can consume it.
+- The mobile store deliberately does **not** persist (no offline cache yet):
+  in-memory, hydrated per trip open, matching the web's local-first posture
+  (ADR-007). Offline persistence is a later, separate decision.
+
+## References
+
+- [ADR-053](adr-053-mobile-strategy-native-app.md) — Mobile strategy (native app)
+- [ADR-007](adr-007-frontend-local-state-management-and-reactivity.md) — Frontend local state management
+- [ADR-056](adr-056-mercure-header-auth-non-browser.md) — Mercure header-auth for non-browser clients
+- `core/reconciliation.ts`, `core/mercure.ts` — shared reducers and wire types
+- `mobile/src/store/trip-store.ts`, `mobile/src/hooks/use-trip-live.ts` — thin store and orchestration

--- a/docs/adr/adr-056-mercure-header-auth-non-browser.md
+++ b/docs/adr/adr-056-mercure-header-auth-non-browser.md
@@ -1,0 +1,74 @@
+# ADR-056: Mercure Header-Auth for Non-Browser SSE Clients
+
+- **Status:** Accepted
+- **Date:** 2026-08-13
+- **Depends on:** ADR-023 (Authentication Strategy), ADR-038 (Hide Forbidden as Not Found), ADR-053 (Mobile Strategy — Dedicated Native App)
+
+## Context and Problem Statement
+
+Trip computations run asynchronously and stream their results to the client over
+Mercure SSE. On the web, the browser subscribes to the hub with an HttpOnly
+`mercureAuthorization` cookie: the per-trip subscriber JWT is minted by
+`App\Mercure\MercureTokenIssuer` (HS256, claim `mercure.subscribe: ["/trips/{id}"]`,
+1 h TTL) and set as a cookie by `App\Mercure\MercureSubscriberListener` on the
+trip create/access responses. Keeping the token in an HttpOnly cookie is
+deliberate — it never reaches JavaScript, closing an XSS exfiltration path.
+
+The native app (ADR-053) has the same live-trip requirement but **cannot read
+that cookie**: React Native has no browser cookie jar, and its `EventSource`
+polyfill (`react-native-sse`) subscribes with request headers, not cookies. The
+spike (#1011, `docs/mobile-mercure-auth.md`) confirmed the hub itself is *not*
+cookie-only — the embedded Caddy Mercure module (`subscriber_jwt` + `anonymous`)
+authenticates a subscriber via the cookie **or** an `Authorization: Bearer` header
+**or** an `?authorization=` query parameter, verified against the live dev hub
+with a plain `curl` and no cookie. So no hub change is needed. The gap is
+delivery: the mobile client has no way to *obtain* the subscriber token, because
+it is only ever handed out as the cookie.
+
+## Decision
+
+Add a **readable-body endpoint** that delivers the same per-trip subscriber JWT to
+any authenticated client, and have the native client present it as an
+`Authorization: Bearer` header to the hub. The web's cookie posture is untouched.
+
+- **New resource `GET /trips/{id}/mercure-token`.** `App\ApiResource\MercureToken`
+  (provider `App\State\MercureTokenProvider`) returns `{ token }` in the response
+  body. The token is minted by the same `MercureTokenIssuer`, signed with the same
+  HMAC secret, and scoped to `/trips/{id}` for 1 h — identical to the cookie
+  token, just delivered through a channel a non-browser client can read.
+- **Same object-level authorization as `/detail`.** The operation is guarded by
+  `is_granted('TRIP_VIEW', ...)`, so a non-owner is masked as **404, not 403**
+  (ADR-038, `HideForbiddenAsNotFoundListener`). The token is only ever surfaced to
+  a caller the voter already granted.
+- **Header over query parameter on the client.** React Native sends the token as
+  `Authorization: Bearer <jwt>` (supported by `react-native-sse`'s custom
+  headers). The `?authorization=` query parameter is the documented fallback if a
+  platform strips the header — it is redacted from Caddy access logs — but the
+  header is preferred so the token stays out of URLs.
+- **No client detection, no cookie for mobile.** Consistent with the client-
+  agnostic API (ADR-023): the backend does not sniff who is calling. The web keeps
+  reading its HttpOnly cookie; the mobile client fetches the body token and holds
+  it only in memory for the lifetime of the subscription.
+
+## Consequences
+
+- The mobile app gets real-time trip updates with the same security properties as
+  the web: a short-lived, per-trip, owner-scoped subscriber token, never exposed
+  to a non-owner (masked 404).
+- Two delivery channels for one token (cookie for the browser, body for everyone
+  else). They share the issuer and secret, so there is no second token lifecycle
+  to maintain — only a second way to read the same JWT.
+- The earlier Capacitor-era `X-Mercure-Token` response header (a WebView-specific
+  hack, ADR-023) stays removed; this resource supersedes that need without
+  reintroducing client detection.
+- The subscriber token remains short-lived (1 h). A subscription that outlives it
+  must re-fetch — acceptable for the current session-length trips; token refresh
+  on the live stream is a later concern if sessions get longer.
+
+## References
+
+- [ADR-023](adr-023-authentication-strategy.md) — Authentication strategy (client-agnostic API)
+- [ADR-038](adr-038-hide-forbidden-as-not-found.md) — Hide forbidden as not found
+- [ADR-053](adr-053-mobile-strategy-native-app.md) — Mobile strategy (native app)
+- [Mobile Mercure auth](../mobile-mercure-auth.md) — spike outcome (#1011)
+- `App\ApiResource\MercureToken`, `App\State\MercureTokenProvider` — the readable-body endpoint (#1019)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,6 +72,7 @@ nav:
       - Accommodation tags: accommodations.md
       - Alert engine: alert-engine.md
       - External data sources: external-data-sources.md
+      - Mobile Mercure auth (SSE): mobile-mercure-auth.md
       - DataTourisme flux audit: datatourisme-flux-audit.md
       - AI / LLaMA pipeline (historical): LLaMA.md
   - Guides:
@@ -133,6 +134,9 @@ nav:
       - adr/adr-051-multi-source-events-openagenda-temporal-lifecycle.md
       - adr/adr-052-remove-ai-support.md
       - adr/adr-053-mobile-strategy-native-app.md
+      - adr/adr-054-mobile-design-system.md
+      - adr/adr-055-mobile-state-architecture.md
+      - adr/adr-056-mercure-header-auth-non-browser.md
   - Runbooks:
       - runbooks/README.md
       - runbooks/severity-levels.md


### PR DESCRIPTION
Closes #1034.

## Résumé
**3 ADRs créés** (format adr-053/adr-023, front-matter liste `Status`/`Date`/`Depends on`) :
- `adr-054-mobile-design-system` — tokens miroir web (`globals.css`), dark mode OS, polices Fraunces/Inter Tight/JetBrains Mono. `Depends on: ADR-053`.
- `adr-055-mobile-state-architecture` — store Zustand mince composant les réducteurs purs `@btp/core`, optimiste + SSE. `Depends on: ADR-053, ADR-007, ADR-056`.
- `adr-056-mercure-header-auth-non-browser` — `GET /trips/{id}/mercure-token` (body lisible), header `Authorization: Bearer`, 404 non-owner (ADR-038). Formalise `docs/mobile-mercure-auth.md` + #1019.

**ADRs mis à jour** : `adr-053` (monorepo `core`/`pwa`/`mobile` matérialisé, cross-links 054/055/056), `adr-023` (client natif réel, renvoi ADR-056).

**Autres** : `README.md` (section Mobile + « 51 » → « 56 » ADRs) ; `CLAUDE.md` (note Type Contract `@btp/core` + commandes mobile) ; `mkdocs.yml` (3 ADRs en nav + désorphelinage de `mobile-mercure-auth.md`).

## Vérification locale
- `mkdocs build --strict` (conteneur python + mkdocs-material) → **exit 0**, `Documentation built in 1.28s`
- `make markdownlint` → 112 fichiers, **0 erreur**, exit 0

## Auto-critique
- Les ADRs décrivent le design visé des issues sœurs #1028/#1031/#1019 sans dépendre de leur code — à relire si l'implémentation dévie.
- `TRACKING.md`, `mobile/**`, `core/**` non touchés (hors périmètre, gérés par l'orchestrateur / autres PRs).

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 critical, 0 warning, 1 minor (non-blocking) finding.

### Review checklist
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases (docs-only PR; no code behavior changed)
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

### PR title check
Minor: title description (`ADR-054/055/056 mobile + README/CLAUDE.md/MkDocs (#1034)`) doesn't open with an imperative verb per the Conventional Commits convention in CLAUDE.md. Non-blocking.

### Inline comments
No inline comments.

**Commit reviewed:** 3de419e5d3ea5aee74e0235f03f9ce59e5fab59c
<!-- claude-review-end -->