### PR TITLE
feat(core): réconciliation Mercure complète (tous events SSE) + garde de dérive (#1030)

### DIFF
--- a/core/mercure.ts
+++ b/core/mercure.ts
@@ -412,3 +412,61 @@ export type MercureEvent =
       type: "stage_updated";
       data: { stageIndex: number; stage: EnrichedStagePayload };
     };
+
+/**
+ * Canonical list of every Mercure SSE event `type`. Single source of truth
+ * shared by web and mobile: the web hook (`use-mercure.ts`) dispatches on these,
+ * the pure `reduceMercureEvent` reducer in `reconciliation.ts` reconciles them,
+ * and the drift guard test (`pwa/src/store/mercure-reconciliation.test.ts`)
+ * asserts the three stay in lockstep. Keep alphabetically loose but complete —
+ * {@link MERCURE_EVENT_TYPES_ARE_EXHAUSTIVE} fails the build if a union variant
+ * is added above without being listed here.
+ */
+export const MERCURE_EVENT_TYPES = [
+  "route_parsed",
+  "stages_computed",
+  "weather_fetched",
+  "pois_scanned",
+  "accommodations_found",
+  "events_found",
+  "supply_timeline",
+  "terrain_alerts",
+  "calendar_alerts",
+  "wind_alerts",
+  "bike_shop_alerts",
+  "water_point_alerts",
+  "health_service_alerts",
+  "cultural_poi_alerts",
+  "railway_station_alerts",
+  "border_crossing_alerts",
+  "ferry_alerts",
+  "ford_alerts",
+  "route_segment_recalculated",
+  "trip_complete",
+  "computation_step_completed",
+  "trip_ready",
+  "stage_updated",
+  "validation_error",
+  "computation_error",
+] as const satisfies readonly MercureEvent["type"][];
+
+export type MercureEventType = (typeof MERCURE_EVENT_TYPES)[number];
+
+/**
+ * Compile-time completeness check: if a `MercureEvent` variant exists that is
+ * NOT listed in {@link MERCURE_EVENT_TYPES}, `_Complete` resolves to an object
+ * type and assigning `true` below fails to type-check — so the build breaks the
+ * moment the contract and the canonical list drift apart. (`satisfies` above
+ * already rejects a typo / an entry that is not a real event type.)
+ */
+type _Complete =
+  Exclude<MercureEvent["type"], MercureEventType> extends never
+    ? true
+    : {
+        ERROR_event_types_missing_from_MERCURE_EVENT_TYPES: Exclude<
+          MercureEvent["type"],
+          MercureEventType
+        >;
+      };
+
+export const MERCURE_EVENT_TYPES_ARE_EXHAUSTIVE: _Complete = true;

--- a/core/reconciliation.ts
+++ b/core/reconciliation.ts
@@ -9,7 +9,7 @@
 // endpoint) and #787 (label preservation on a raw resync).
 
 import { DEFAULT_ACCOMMODATION_RADIUS_KM } from "./accommodation-constants";
-import type { EnrichedStagePayload } from "./mercure";
+import type { EnrichedStagePayload, MercureEvent, StagePayload } from "./mercure";
 import type { AlertData, StageData } from "./schemas";
 
 /** A stage alert carrying the client-only `_group` tag added by the store. */
@@ -243,4 +243,518 @@ export function dropStaleDateAlerts(stages: StageData[]): StageData[] {
       (a) => a._group !== "calendar",
     ),
   }));
+}
+
+// ---------------------------------------------------------------------------
+// Full Mercure event reconciliation (#1030)
+//
+// `reduceMercureEvent` is the pure, platform-agnostic mirror of the web hook's
+// `dispatchEvent` router (pwa/src/hooks/use-mercure.ts). Given the current
+// reconcilable state and one SSE event it returns the next state, composing the
+// characterization reducers above (resync / trip_ready / stage_updated /
+// prune). Both stores are meant to feed their SSE stream through this single
+// function so web and mobile never diverge; the drift guard test asserts every
+// event the web hook handles is covered here.
+//
+// UI-only side effects the web hook also performs stay OUT of core by design:
+// toast notifications, block/processing spinners (ADR-043), reverse-geocode
+// label resolution, and the transient `stageDiffs` highlight. Trip-level date
+// bookkeeping (endDate on a trailing-day append) also stays a store concern,
+// as it already is on both platforms.
+// ---------------------------------------------------------------------------
+
+/**
+ * The slice of store state that Mercure events reconcile. A superset of the
+ * fields every current event touches: route totals + source/title metadata,
+ * the stage array, the computation-status map, and the set of stage indices
+ * still recomputing (whose overlay some terminal events clear).
+ */
+export interface ReconciledState {
+  totalDistance: number | null;
+  totalElevation: number | null;
+  totalElevationLoss: number | null;
+  sourceType: string | null;
+  title: string | null;
+  stages: StageData[];
+  computationStatus: Record<string, string>;
+  recomputingStages: Set<number>;
+}
+
+/** Replace `stages[index]` via `patch`; returns the same array if out of range. */
+function patchStage(
+  stages: StageData[],
+  index: number,
+  patch: (stage: StageData) => StageData,
+): StageData[] {
+  const stage = stages[index];
+  if (!stage) return stages;
+  const next = stages.slice();
+  next[index] = patch(stage);
+  return next;
+}
+
+/**
+ * Replace the alerts belonging to `group` on one stage, preserving alerts from
+ * every other producing group. Mirrors the store's `updateStageAlerts` (#649):
+ * grouped, incremental alert updates that never blank another analyzer's output.
+ */
+function replaceStageAlerts(
+  stages: StageData[],
+  index: number,
+  alerts: AlertData[],
+  group: string,
+): StageData[] {
+  return patchStage(stages, index, (stage) => {
+    const kept = (stage.alerts as StageAlert[]).filter(
+      (a) => a._group !== group,
+    );
+    const tagged: StageAlert[] = alerts.map((a) => ({ ...a, _group: group }));
+    return { ...stage, alerts: [...kept, ...tagged] };
+  });
+}
+
+/** Fold a per-stage-index alert map onto the stage array under one group tag. */
+function applyGroupedAlerts(
+  stages: StageData[],
+  grouped: Map<number, AlertData[]>,
+  group: string,
+): StageData[] {
+  let next = stages;
+  for (const [index, alerts] of grouped) {
+    next = replaceStageAlerts(next, index, alerts, group);
+  }
+  return next;
+}
+
+/** Group + normalize a flat alert list keyed by `stageIndex` into `AlertData`. */
+function groupAlerts<T extends { stageIndex: number }>(
+  alerts: T[],
+  toAlert: (alert: T) => AlertData,
+): Map<number, AlertData[]> {
+  const grouped = new Map<number, AlertData[]>();
+  for (const alert of alerts) {
+    const bucket = grouped.get(alert.stageIndex) ?? [];
+    bucket.push(toAlert(alert));
+    grouped.set(alert.stageIndex, bucket);
+  }
+  return grouped;
+}
+
+/**
+ * `stages_computed` merge (legacy progressive path). A partial update
+ * (`affectedIndices`) preserves derived data for untouched stages and resets it
+ * for affected/new ones (keeping alerts + accommodations until their follow-up
+ * events land, #649); a full replace preserves labels/accommodations/radius on
+ * stages whose endpoints did not move. Verbatim from `use-mercure.ts`.
+ */
+function reconcileStagesComputed(
+  existing: StageData[],
+  data: { stages: StagePayload[]; affectedIndices?: number[] },
+): StageData[] {
+  const { affectedIndices } = data;
+
+  if (affectedIndices && affectedIndices.length > 0 && existing.length > 0) {
+    const affected = new Set(affectedIndices);
+    return data.stages.map((s, i) => {
+      const prev = existing[i];
+      if (prev && !affected.has(i)) {
+        return {
+          ...prev,
+          dayNumber: s.dayNumber,
+          distance: s.distance,
+          elevation: s.elevation,
+          elevationLoss: s.elevationLoss ?? 0,
+          startPoint: s.startPoint,
+          endPoint: s.endPoint,
+          geometry: s.geometry,
+          label: s.label,
+        };
+      }
+      return {
+        ...s,
+        elevationLoss: s.elevationLoss ?? 0,
+        geometry: s.geometry,
+        label: s.label,
+        isRestDay: s.isRestDay ?? false,
+        startLabel: null,
+        endLabel: null,
+        weather: null,
+        alerts: prev?.alerts ?? [],
+        pois: [],
+        supplyTimeline: [],
+        events: [],
+        accommodations: prev?.accommodations ?? [],
+        selectedAccommodation: prev?.selectedAccommodation ?? null,
+        accommodationSearchRadiusKm:
+          prev?.accommodationSearchRadiusKm ?? DEFAULT_ACCOMMODATION_RADIUS_KM,
+      };
+    });
+  }
+
+  return data.stages.map((s, i) => {
+    const prev = existing[i];
+    const endMatch =
+      prev &&
+      prev.endPoint.lat === s.endPoint.lat &&
+      prev.endPoint.lon === s.endPoint.lon;
+    const startMatch =
+      prev &&
+      prev.startPoint.lat === s.startPoint.lat &&
+      prev.startPoint.lon === s.startPoint.lon;
+    return {
+      ...s,
+      elevationLoss: s.elevationLoss ?? 0,
+      geometry: s.geometry,
+      label: s.label,
+      isRestDay: s.isRestDay ?? false,
+      startLabel: startMatch ? prev.startLabel : null,
+      endLabel: endMatch ? prev.endLabel : null,
+      weather: null,
+      alerts: [],
+      pois: [],
+      supplyTimeline: [],
+      events: [],
+      accommodations: endMatch ? prev.accommodations : [],
+      accommodationSearchRadiusKm: endMatch
+        ? (prev.accommodationSearchRadiusKm ?? DEFAULT_ACCOMMODATION_RADIUS_KM)
+        : DEFAULT_ACCOMMODATION_RADIUS_KM,
+    };
+  });
+}
+
+/** Empty recomputing set (terminal events clear the overlay). */
+const NO_RECOMPUTING: ReadonlySet<number> = new Set<number>();
+
+/**
+ * Reconcile one Mercure SSE event into the next {@link ReconciledState}. Pure:
+ * never mutates its inputs, returns a new state (data-less/no-op events return
+ * the same reference). The `default` branch is compile-time exhaustive — adding
+ * a new `MercureEvent` variant without a case here fails to type-check.
+ */
+export function reduceMercureEvent(
+  state: ReconciledState,
+  event: MercureEvent,
+): ReconciledState {
+  switch (event.type) {
+    case "route_parsed":
+      return {
+        ...state,
+        totalDistance: event.data.totalDistance,
+        totalElevation: event.data.totalElevation,
+        totalElevationLoss: event.data.totalElevationLoss,
+        sourceType: event.data.sourceType,
+        title: event.data.title ?? state.title,
+      };
+
+    case "stages_computed": {
+      // Mirror the store's setStages: run the resync label-preservation pass on
+      // the merged array, then drop recompute markers that fell out of bounds.
+      const merged = reconcileStagesComputed(state.stages, event.data);
+      const stages = reconcileResync(state.stages, merged);
+      return {
+        ...state,
+        stages,
+        recomputingStages: pruneStaleRecomputing(
+          stages.length,
+          state.recomputingStages,
+        ),
+      };
+    }
+
+    case "weather_fetched": {
+      let stages = state.stages;
+      for (const w of event.data.stages) {
+        const weather = w.weather;
+        if (!weather) continue;
+        const index = stages.findIndex((s) => s.dayNumber === w.dayNumber);
+        if (index !== -1) {
+          stages = patchStage(stages, index, (s) => ({ ...s, weather }));
+        }
+      }
+      return stages === state.stages ? state : { ...state, stages };
+    }
+
+    case "pois_scanned": {
+      let stages = patchStage(state.stages, event.data.stageIndex, (s) => ({
+        ...s,
+        pois: event.data.pois,
+      }));
+      if (event.data.alerts && event.data.alerts.length > 0) {
+        stages = replaceStageAlerts(
+          stages,
+          event.data.stageIndex,
+          event.data.alerts,
+          "pois",
+        );
+      }
+      return { ...state, stages };
+    }
+
+    case "supply_timeline":
+      return {
+        ...state,
+        stages: patchStage(state.stages, event.data.stageIndex, (s) => ({
+          ...s,
+          supplyTimeline: event.data.markers,
+        })),
+      };
+
+    case "accommodations_found": {
+      const { stageIndex, accommodations, searchRadiusKm } = event.data;
+      let stages = patchStage(state.stages, stageIndex, (s) => ({
+        ...s,
+        // Do not clobber a rider's picked accommodation (store parity).
+        accommodations: s.selectedAccommodation ? s.accommodations : accommodations,
+        accommodationSearchRadiusKm:
+          searchRadiusKm !== undefined
+            ? searchRadiusKm
+            : s.accommodationSearchRadiusKm,
+      }));
+      if (event.data.alerts && event.data.alerts.length > 0) {
+        stages = replaceStageAlerts(
+          stages,
+          stageIndex,
+          event.data.alerts,
+          "accommodations",
+        );
+      }
+      return { ...state, stages };
+    }
+
+    case "events_found":
+      return {
+        ...state,
+        stages: patchStage(state.stages, event.data.stageIndex, (s) => ({
+          ...s,
+          events: event.data.events,
+        })),
+      };
+
+    case "terrain_alerts": {
+      let stages = state.stages;
+      for (const [indexStr, alerts] of Object.entries(
+        event.data.alertsByStage,
+      )) {
+        const index = Number(indexStr);
+        if (!Number.isNaN(index)) {
+          stages = replaceStageAlerts(stages, index, alerts, "terrain");
+        }
+      }
+      return { ...state, stages };
+    }
+
+    case "calendar_alerts": {
+      // Full replacement: clear the group on EVERY stage first so a stage that
+      // dropped out of the new set keeps no stale nudge (recette Sunday bug).
+      const cleared = state.stages.map((s) => ({
+        ...s,
+        alerts: (s.alerts as StageAlert[]).filter((a) => a._group !== "calendar"),
+      }));
+      const grouped = groupAlerts(event.data.alerts, (a) => ({
+        code: a.code,
+        type: a.type as AlertData["type"],
+        message: a.message,
+        lat: null,
+        lon: null,
+      }));
+      return { ...state, stages: applyGroupedAlerts(cleared, grouped, "calendar") };
+    }
+
+    case "wind_alerts":
+      return {
+        ...state,
+        stages: replaceStageAlerts(state.stages, 0, event.data.alerts, "wind"),
+      };
+
+    case "bike_shop_alerts": {
+      const grouped = groupAlerts(event.data.alerts, (a) => ({
+        code: a.code,
+        type: a.type as "nudge",
+        message: a.message,
+        lat: null,
+        lon: null,
+      }));
+      return {
+        ...state,
+        stages: applyGroupedAlerts(state.stages, grouped, "bike_shop"),
+      };
+    }
+
+    case "water_point_alerts": {
+      const grouped = groupAlerts(event.data.alerts, (a) => ({
+        code: a.code,
+        type: a.type as "nudge",
+        message: a.message,
+        lat: null,
+        lon: null,
+        source: "water_point",
+      }));
+      return {
+        ...state,
+        stages: applyGroupedAlerts(state.stages, grouped, "water_point"),
+      };
+    }
+
+    case "health_service_alerts": {
+      const grouped = groupAlerts(event.data.alerts, (a) => ({
+        code: a.code,
+        type: a.type as "nudge",
+        message: a.message,
+      }));
+      return {
+        ...state,
+        stages: applyGroupedAlerts(state.stages, grouped, "health_service"),
+      };
+    }
+
+    case "cultural_poi_alerts": {
+      const grouped = groupAlerts(event.data.alerts, (a) => ({
+        code: a.code,
+        type: "nudge" as const,
+        message: a.message,
+        lat: a.lat,
+        lon: a.lon,
+        source: "cultural_poi",
+        poiName: a.poiName,
+        poiType: a.poiType,
+        poiLat: a.poiLat,
+        poiLon: a.poiLon,
+        distanceFromRoute: a.distanceFromRoute,
+        description: a.description,
+        openingHours: a.openingHours,
+        estimatedPrice: a.estimatedPrice,
+        imageUrl: a.imageUrl,
+        wikidataId: a.wikidataId,
+        wikipediaUrl: a.wikipediaUrl,
+      }));
+      return {
+        ...state,
+        stages: applyGroupedAlerts(state.stages, grouped, "cultural_poi"),
+      };
+    }
+
+    case "railway_station_alerts": {
+      const grouped = groupAlerts(event.data.alerts, (a) => ({
+        code: a.code,
+        type: "nudge" as const,
+        message: a.message,
+        lat: a.lat ?? null,
+        lon: a.lon ?? null,
+        source: "railway_station",
+        ...(a.action ? { action: a.action } : {}),
+      }));
+      return {
+        ...state,
+        stages: applyGroupedAlerts(state.stages, grouped, "railway_station"),
+      };
+    }
+
+    case "border_crossing_alerts": {
+      const grouped = groupAlerts(event.data.alerts, (a) => ({
+        code: a.code,
+        type: a.type,
+        message: a.message,
+        lat: a.lat,
+        lon: a.lon,
+        source: "border_crossing",
+        action: a.action,
+      }));
+      return {
+        ...state,
+        stages: applyGroupedAlerts(state.stages, grouped, "border_crossing"),
+      };
+    }
+
+    case "ferry_alerts": {
+      const grouped = groupAlerts(event.data.alerts, (a) => ({
+        code: a.code,
+        type: a.type,
+        message: a.message,
+        lat: a.lat,
+        lon: a.lon,
+        source: "ferry",
+        action: {
+          kind: a.action.kind,
+          label: a.action.label,
+          payload: a.action.payload,
+        },
+      }));
+      return { ...state, stages: applyGroupedAlerts(state.stages, grouped, "ferry") };
+    }
+
+    case "ford_alerts": {
+      const grouped = groupAlerts(event.data.alerts, (a) => ({
+        code: a.code,
+        type: a.type,
+        message: a.message,
+        lat: a.lat,
+        lon: a.lon,
+        source: "ford",
+        action: {
+          kind: a.action.kind,
+          label: a.action.label,
+          payload: a.action.payload,
+        },
+      }));
+      return { ...state, stages: applyGroupedAlerts(state.stages, grouped, "ford") };
+    }
+
+    case "route_segment_recalculated": {
+      let stages = patchStage(state.stages, event.data.stageIndex, (s) => ({
+        ...s,
+        distance: event.data.distance / 1000, // metres → km
+        elevation: event.data.elevationGain,
+        geometry: event.data.coordinates,
+      }));
+      stages = replaceStageAlerts(stages, event.data.stageIndex, [], "cultural_poi");
+      return { ...state, stages, recomputingStages: new Set(NO_RECOMPUTING) };
+    }
+
+    case "trip_complete":
+      return {
+        ...state,
+        computationStatus: event.data.computationStatus,
+        recomputingStages: new Set(NO_RECOMPUTING),
+      };
+
+    case "computation_step_completed":
+      // Mode 1 progress tick only — no data reconciliation (ADR-043).
+      return state;
+
+    case "trip_ready": {
+      const incoming = event.data.stages.map(enrichedPayloadToStageData);
+      return {
+        ...state,
+        stages: reconcileTripReady(state.stages, incoming),
+        computationStatus: event.data.computationStatus,
+        recomputingStages: new Set(NO_RECOMPUTING),
+      };
+    }
+
+    case "stage_updated": {
+      const incoming = enrichedPayloadToStageData(event.data.stage);
+      const { stages } = reconcileStageUpdate(
+        state.stages,
+        event.data.stageIndex,
+        incoming,
+      );
+      const recomputingStages = new Set(state.recomputingStages);
+      recomputingStages.delete(event.data.stageIndex);
+      return { ...state, stages, recomputingStages };
+    }
+
+    case "validation_error":
+      return { ...state, recomputingStages: new Set(NO_RECOMPUTING) };
+
+    case "computation_error":
+      return event.data.retryable
+        ? state
+        : { ...state, recomputingStages: new Set(NO_RECOMPUTING) };
+
+    default: {
+      // Exhaustiveness: every MercureEvent variant must have a case above.
+      const _exhaustive: never = event;
+      return _exhaustive;
+    }
+  }
 }

--- a/core/reconciliation.ts
+++ b/core/reconciliation.ts
@@ -366,8 +366,8 @@ function reconcileStagesComputed(
           elevationLoss: s.elevationLoss ?? 0,
           startPoint: s.startPoint,
           endPoint: s.endPoint,
-          geometry: s.geometry,
-          label: s.label,
+          geometry: s.geometry ?? prev.geometry,
+          label: s.label ?? prev.label,
         };
       }
       return {

--- a/core/reconciliation.ts
+++ b/core/reconciliation.ts
@@ -373,8 +373,8 @@ function reconcileStagesComputed(
       return {
         ...s,
         elevationLoss: s.elevationLoss ?? 0,
-        geometry: s.geometry,
-        label: s.label,
+        geometry: s.geometry ?? [],
+        label: s.label ?? null,
         isRestDay: s.isRestDay ?? false,
         startLabel: null,
         endLabel: null,
@@ -404,8 +404,8 @@ function reconcileStagesComputed(
     return {
       ...s,
       elevationLoss: s.elevationLoss ?? 0,
-      geometry: s.geometry,
-      label: s.label,
+      geometry: s.geometry ?? [],
+      label: s.label ?? null,
       isRestDay: s.isRestDay ?? false,
       startLabel: startMatch ? prev.startLabel : null,
       endLabel: endMatch ? prev.endLabel : null,

--- a/pwa/src/store/mercure-reconciliation.test.ts
+++ b/pwa/src/store/mercure-reconciliation.test.ts
@@ -358,6 +358,149 @@ describe("reduceMercureEvent — alert groups", () => {
     expect(alert.action?.kind).toBe("navigate");
     expect(alert.action?.payload).toEqual({ lat: 4, lon: 5 });
   });
+
+  // Field-mapping coverage for the remaining groups: each must land on the
+  // right stage, carry its `_group` tag, and preserve the mapped message /
+  // source / action — a swapped mapping would otherwise only be caught by the
+  // no-fallthrough smoke test, which stays green on a wrong field.
+  it("bike_shop_alerts tags the stage alert with the bike_shop group", () => {
+    const next = reduceMercureEvent(baseState({ stages: [stage()] }), {
+      type: "bike_shop_alerts",
+      data: {
+        alerts: [
+          { stageIndex: 0, dayNumber: 1, code: "BS", type: "nudge", message: "Vélociste" },
+        ],
+      },
+    });
+    const a = next.stages[0]!.alerts[0] as StageAlert;
+    expect(a._group).toBe("bike_shop");
+    expect(a.message).toBe("Vélociste");
+  });
+
+  it("water_point_alerts maps the water_point source and group", () => {
+    const next = reduceMercureEvent(baseState({ stages: [stage()] }), {
+      type: "water_point_alerts",
+      data: {
+        alerts: [
+          { stageIndex: 0, dayNumber: 1, code: "WP", type: "nudge", message: "Fontaine" },
+        ],
+        waterPointsByStage: [],
+      },
+    });
+    const a = next.stages[0]!.alerts[0] as StageAlert;
+    expect(a._group).toBe("water_point");
+    expect(a.source).toBe("water_point");
+  });
+
+  it("health_service_alerts tags the stage alert with the health_service group", () => {
+    const next = reduceMercureEvent(baseState({ stages: [stage()] }), {
+      type: "health_service_alerts",
+      data: {
+        alerts: [
+          { stageIndex: 0, dayNumber: 1, code: "HS", type: "nudge", message: "Pharmacie" },
+        ],
+      },
+    });
+    const a = next.stages[0]!.alerts[0] as StageAlert;
+    expect(a._group).toBe("health_service");
+    expect(a.message).toBe("Pharmacie");
+  });
+
+  it("cultural_poi_alerts maps the cultural_poi source and poi metadata", () => {
+    const next = reduceMercureEvent(baseState({ stages: [stage()] }), {
+      type: "cultural_poi_alerts",
+      data: {
+        alerts: [
+          {
+            stageIndex: 0,
+            dayNumber: 1,
+            code: "CP",
+            type: "nudge",
+            message: "Musée",
+            lat: 1,
+            lon: 1,
+            poiName: "Louvre",
+            poiType: "museum",
+            poiLat: 1,
+            poiLon: 1,
+            distanceFromRoute: 120,
+          },
+        ],
+      },
+    });
+    const a = next.stages[0]!.alerts[0] as StageAlert;
+    expect(a._group).toBe("cultural_poi");
+    expect(a.source).toBe("cultural_poi");
+    expect(a.poiName).toBe("Louvre");
+  });
+
+  it("railway_station_alerts maps the source and optional navigate action", () => {
+    const next = reduceMercureEvent(baseState({ stages: [stage()] }), {
+      type: "railway_station_alerts",
+      data: {
+        alerts: [
+          {
+            stageIndex: 0,
+            dayNumber: 1,
+            code: "RS",
+            type: "nudge",
+            message: "Gare",
+            action: { kind: "navigate", label: "Voir", payload: { lat: 1, lon: 2 } },
+          },
+        ],
+      },
+    });
+    const a = next.stages[0]!.alerts[0] as StageAlert;
+    expect(a._group).toBe("railway_station");
+    expect(a.source).toBe("railway_station");
+    expect(a.action?.payload).toEqual({ lat: 1, lon: 2 });
+  });
+
+  it("border_crossing_alerts maps the source and action", () => {
+    const next = reduceMercureEvent(baseState({ stages: [stage()] }), {
+      type: "border_crossing_alerts",
+      data: {
+        alerts: [
+          {
+            stageIndex: 0,
+            dayNumber: 1,
+            code: "BC",
+            type: "nudge",
+            message: "Frontière",
+            action: { kind: "navigate", label: "Voir", payload: { lat: 3, lon: 4 } },
+            lat: 3,
+            lon: 4,
+          },
+        ],
+      },
+    });
+    const a = next.stages[0]!.alerts[0] as StageAlert;
+    expect(a._group).toBe("border_crossing");
+    expect(a.source).toBe("border_crossing");
+  });
+
+  it("ford_alerts maps the ford source and action", () => {
+    const next = reduceMercureEvent(baseState({ stages: [stage()] }), {
+      type: "ford_alerts",
+      data: {
+        alerts: [
+          {
+            stageIndex: 0,
+            dayNumber: 1,
+            code: "FD",
+            type: "warning",
+            message: "Gué",
+            action: { kind: "navigate", label: "Voir", payload: { lat: 5, lon: 6 } },
+            lat: 5,
+            lon: 6,
+          },
+        ],
+      },
+    });
+    const a = next.stages[0]!.alerts[0] as StageAlert;
+    expect(a._group).toBe("ford");
+    expect(a.source).toBe("ford");
+  });
 });
 
 describe("reduceMercureEvent — structural / terminal events", () => {

--- a/pwa/src/store/mercure-reconciliation.test.ts
+++ b/pwa/src/store/mercure-reconciliation.test.ts
@@ -1,0 +1,556 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import type { AlertData, StageData } from "@btp/core";
+import type {
+  EnrichedStagePayload,
+  MercureEvent,
+  MercureEventType,
+} from "@btp/core/mercure";
+import { MERCURE_EVENT_TYPES } from "@btp/core/mercure";
+import {
+  reduceMercureEvent,
+  type ReconciledState,
+  type StageAlert,
+} from "@btp/core/reconciliation";
+
+// #1030 — full Mercure event reconciliation. Companion to reconciliation.test.ts
+// (which pins the extracted characterization reducers): here we cover the pure
+// `reduceMercureEvent` router that mirrors pwa/src/hooks/use-mercure.ts for
+// EVERY event, plus a drift guard (in the spirit of AlertDocumentationTest) that
+// fails loudly if the web hook and the shared core contract fall out of sync.
+
+const A = { lat: 1, lon: 1, ele: 0 };
+const B = { lat: 2, lon: 2, ele: 0 };
+const C = { lat: 3, lon: 3, ele: 0 };
+
+function stage(overrides: Partial<StageData> = {}): StageData {
+  return {
+    dayNumber: 1,
+    distance: 50,
+    elevation: 0,
+    elevationLoss: 0,
+    startPoint: A,
+    endPoint: B,
+    geometry: [],
+    label: null,
+    startLabel: null,
+    endLabel: null,
+    weather: null,
+    alerts: [],
+    pois: [],
+    accommodations: [],
+    selectedAccommodation: null,
+    accommodationSearchRadiusKm: 5,
+    isRestDay: false,
+    supplyTimeline: [],
+    events: [],
+    ...overrides,
+  };
+}
+
+function baseState(overrides: Partial<ReconciledState> = {}): ReconciledState {
+  return {
+    totalDistance: null,
+    totalElevation: null,
+    totalElevationLoss: null,
+    sourceType: null,
+    title: null,
+    stages: [],
+    computationStatus: {},
+    recomputingStages: new Set<number>(),
+    ...overrides,
+  };
+}
+
+function enriched(
+  overrides: Partial<EnrichedStagePayload> = {},
+): EnrichedStagePayload {
+  return {
+    dayNumber: 1,
+    distance: 50,
+    elevation: 0,
+    elevationLoss: 0,
+    startPoint: A,
+    endPoint: B,
+    geometry: [],
+    label: null,
+    weather: null,
+    alerts: [],
+    pois: [],
+    accommodations: [],
+    selectedAccommodation: null,
+    events: [],
+    ...overrides,
+  };
+}
+
+const weather = {
+  icon: "sun",
+  description: "clear",
+  tempMin: 10,
+  tempMax: 20,
+  windSpeed: 5,
+  windDirection: "N",
+  precipitationProbability: 0,
+  humidity: 50,
+  comfortIndex: 100,
+  relativeWindDirection: "unknown" as const,
+};
+
+describe("reduceMercureEvent — trip-level events", () => {
+  it("route_parsed writes route totals, source and title", () => {
+    const next = reduceMercureEvent(baseState(), {
+      type: "route_parsed",
+      data: {
+        totalDistance: 120,
+        totalElevation: 800,
+        totalElevationLoss: 700,
+        sourceType: "komoot",
+        title: "Vercors",
+      },
+    });
+    expect(next.totalDistance).toBe(120);
+    expect(next.totalElevation).toBe(800);
+    expect(next.totalElevationLoss).toBe(700);
+    expect(next.sourceType).toBe("komoot");
+    expect(next.title).toBe("Vercors");
+  });
+
+  it("route_parsed keeps the previous title when the payload omits it", () => {
+    const next = reduceMercureEvent(baseState({ title: "Kept" }), {
+      type: "route_parsed",
+      data: {
+        totalDistance: 1,
+        totalElevation: 1,
+        totalElevationLoss: 1,
+        sourceType: "gpx",
+        title: null,
+      },
+    });
+    expect(next.title).toBe("Kept");
+  });
+
+  it("trip_complete stores the status and clears recomputing markers", () => {
+    const next = reduceMercureEvent(
+      baseState({ recomputingStages: new Set([0, 1]) }),
+      { type: "trip_complete", data: { computationStatus: { weather: "done" } } },
+    );
+    expect(next.computationStatus).toEqual({ weather: "done" });
+    expect(next.recomputingStages.size).toBe(0);
+  });
+
+  it("validation_error clears recomputing markers", () => {
+    const next = reduceMercureEvent(
+      baseState({ recomputingStages: new Set([2]) }),
+      { type: "validation_error", data: { code: "x", message: "bad" } },
+    );
+    expect(next.recomputingStages.size).toBe(0);
+  });
+
+  it("computation_error clears recomputing only when not retryable", () => {
+    const retry = reduceMercureEvent(
+      baseState({ recomputingStages: new Set([0]) }),
+      {
+        type: "computation_error",
+        data: { computation: "weather", message: "e", retryable: true },
+      },
+    );
+    expect(retry.recomputingStages.size).toBe(1);
+
+    const fatal = reduceMercureEvent(
+      baseState({ recomputingStages: new Set([0]) }),
+      {
+        type: "computation_error",
+        data: { computation: "weather", message: "e", retryable: false },
+      },
+    );
+    expect(fatal.recomputingStages.size).toBe(0);
+  });
+
+  it("computation_step_completed is a no-op (same state reference)", () => {
+    const state = baseState();
+    const next = reduceMercureEvent(state, {
+      type: "computation_step_completed",
+      data: { step: "s", category: "route", completed: 1, total: 3 },
+    });
+    expect(next).toBe(state);
+  });
+});
+
+describe("reduceMercureEvent — per-stage enrichment", () => {
+  it("weather_fetched sets weather on the stage matching dayNumber", () => {
+    const state = baseState({ stages: [stage({ dayNumber: 1 }), stage({ dayNumber: 2 })] });
+    const next = reduceMercureEvent(state, {
+      type: "weather_fetched",
+      data: { stages: [{ dayNumber: 2, weather }] },
+    });
+    expect(next.stages[0]!.weather).toBeNull();
+    expect(next.stages[1]!.weather).toEqual(weather);
+  });
+
+  it("pois_scanned sets pois and tags optional alerts with the pois group", () => {
+    const state = baseState({ stages: [stage()] });
+    const next = reduceMercureEvent(state, {
+      type: "pois_scanned",
+      data: {
+        stageIndex: 0,
+        pois: [{ name: "Fort", category: "castle", lat: 1, lon: 1, distanceFromStart: 3 }],
+        alerts: [{ type: "nudge", message: "poi", lat: null, lon: null }],
+      },
+    });
+    expect(next.stages[0]!.pois).toHaveLength(1);
+    expect((next.stages[0]!.alerts[0] as StageAlert)._group).toBe("pois");
+  });
+
+  it("supply_timeline replaces the stage markers", () => {
+    const marker = {
+      type: "water" as const,
+      distanceFromStart: 1,
+      lat: 1,
+      lon: 1,
+      water: [],
+      food: [],
+    };
+    const next = reduceMercureEvent(baseState({ stages: [stage()] }), {
+      type: "supply_timeline",
+      data: { stageIndex: 0, markers: [marker] },
+    });
+    expect(next.stages[0]!.supplyTimeline).toEqual([marker]);
+  });
+
+  it("events_found replaces the stage events", () => {
+    const next = reduceMercureEvent(baseState({ stages: [stage()] }), {
+      type: "events_found",
+      data: {
+        stageIndex: 0,
+        events: [
+          {
+            name: "Fete",
+            type: "festival",
+            lat: 1,
+            lon: 1,
+            startDate: "2026-08-01",
+            endDate: "2026-08-02",
+            url: null,
+            description: null,
+            priceMin: null,
+            distanceToEndPoint: 0,
+            source: "openagenda",
+            wikidataId: null,
+          },
+        ],
+      },
+    });
+    expect(next.stages[0]!.events).toHaveLength(1);
+  });
+
+  it("accommodations_found sets accommodations and radius, but not over a rider's selection", () => {
+    const acc = { name: "Gite" } as StageData["accommodations"][number];
+    const state = baseState({ stages: [stage(), stage({ selectedAccommodation: acc, accommodations: [acc] })] });
+    const next = reduceMercureEvent(state, {
+      type: "accommodations_found",
+      data: {
+        stageIndex: 0,
+        accommodations: [{ name: "New" } as StageData["accommodations"][number]],
+        searchRadiusKm: 12,
+      },
+    });
+    expect(next.stages[0]!.accommodations).toHaveLength(1);
+    expect(next.stages[0]!.accommodationSearchRadiusKm).toBe(12);
+
+    const kept = reduceMercureEvent(state, {
+      type: "accommodations_found",
+      data: {
+        stageIndex: 1,
+        accommodations: [{ name: "Ignored" } as StageData["accommodations"][number]],
+      },
+    });
+    expect(kept.stages[1]!.accommodations).toEqual([acc]);
+  });
+});
+
+describe("reduceMercureEvent — alert groups", () => {
+  it("terrain_alerts fans alertsByStage onto the matching stages under the terrain group", () => {
+    const state = baseState({ stages: [stage(), stage()] });
+    const next = reduceMercureEvent(state, {
+      type: "terrain_alerts",
+      data: {
+        alertsByStage: {
+          "1": [{ type: "warning", message: "gravel", lat: null, lon: null }],
+        },
+      },
+    });
+    expect(next.stages[0]!.alerts).toHaveLength(0);
+    expect(next.stages[1]!.alerts).toHaveLength(1);
+    expect((next.stages[1]!.alerts[0] as StageAlert)._group).toBe("terrain");
+  });
+
+  it("alert groups coexist: a later group never blanks another analyzer's alerts", () => {
+    let state = baseState({ stages: [stage()] });
+    state = reduceMercureEvent(state, {
+      type: "terrain_alerts",
+      data: { alertsByStage: { "0": [{ type: "warning", message: "t", lat: null, lon: null }] } },
+    });
+    state = reduceMercureEvent(state, {
+      type: "wind_alerts",
+      data: { alerts: [{ type: "nudge", message: "w", lat: null, lon: null }] },
+    });
+    const sources = state.stages[0]!.alerts.map((a) => (a as StageAlert)._group).sort();
+    expect(sources).toEqual(["terrain", "wind"]);
+  });
+
+  it("calendar_alerts is a full replacement: a stage dropped from the new set loses its stale nudge", () => {
+    const stale: StageAlert = {
+      type: "nudge",
+      message: "Sunday",
+      lat: null,
+      lon: null,
+      _group: "calendar",
+    };
+    const state = baseState({
+      stages: [stage(), stage({ alerts: [{ ...stale }] })],
+    });
+    const next = reduceMercureEvent(state, {
+      type: "calendar_alerts",
+      data: {
+        alerts: [
+          {
+            stageIndex: 0,
+            dayNumber: 1,
+            code: "SUNDAY",
+            type: "nudge",
+            message: "Sunday now here",
+            date: "2026-08-02",
+          },
+        ],
+      },
+    });
+    expect(next.stages[0]!.alerts).toHaveLength(1);
+    expect(next.stages[1]!.alerts).toHaveLength(0);
+  });
+
+  it("action-bearing alert groups carry their server-built action and source tag", () => {
+    const action = {
+      kind: "navigate" as const,
+      label: "Voir",
+      payload: { lat: 4, lon: 5 },
+    };
+    const next = reduceMercureEvent(baseState({ stages: [stage()] }), {
+      type: "ferry_alerts",
+      data: {
+        alerts: [
+          {
+            stageIndex: 0,
+            dayNumber: 1,
+            code: "FERRY",
+            type: "warning",
+            message: "bac",
+            action,
+            lat: 4,
+            lon: 5,
+          },
+        ],
+      },
+    });
+    const alert = next.stages[0]!.alerts[0] as AlertData;
+    expect(alert.source).toBe("ferry");
+    expect(alert.action?.kind).toBe("navigate");
+    expect(alert.action?.payload).toEqual({ lat: 4, lon: 5 });
+  });
+});
+
+describe("reduceMercureEvent — structural / terminal events", () => {
+  it("route_segment_recalculated rewrites geometry (m→km), drops cultural_poi alerts and clears recomputing", () => {
+    const cultural: StageAlert = {
+      type: "nudge",
+      message: "museum",
+      lat: null,
+      lon: null,
+      _group: "cultural_poi",
+    };
+    const terrain: StageAlert = {
+      type: "warning",
+      message: "gravel",
+      lat: null,
+      lon: null,
+      _group: "terrain",
+    };
+    const state = baseState({
+      stages: [stage({ alerts: [{ ...cultural }, { ...terrain }] })],
+      recomputingStages: new Set([0]),
+    });
+    const next = reduceMercureEvent(state, {
+      type: "route_segment_recalculated",
+      data: {
+        stageIndex: 0,
+        reason: "detour",
+        distance: 42000,
+        elevationGain: 300,
+        duration: 3600,
+        coordinates: [C],
+      },
+    });
+    expect(next.stages[0]!.distance).toBe(42);
+    expect(next.stages[0]!.elevation).toBe(300);
+    expect(next.stages[0]!.geometry).toEqual([C]);
+    const messages = next.stages[0]!.alerts.map((a) => a.message);
+    expect(messages).toEqual(["gravel"]);
+    expect(next.recomputingStages.size).toBe(0);
+  });
+
+  it("stages_computed (full replace) preserves labels on a stable endpoint and prunes stale recomputing", () => {
+    const state = baseState({
+      stages: [stage({ endLabel: "Lyon", startLabel: "Paris" })],
+      recomputingStages: new Set([0, 3]),
+    });
+    const next = reduceMercureEvent(state, {
+      type: "stages_computed",
+      data: {
+        stages: [
+          {
+            dayNumber: 1,
+            distance: 60,
+            elevation: 100,
+            elevationLoss: 90,
+            startPoint: A,
+            endPoint: B,
+            geometry: [],
+            label: null,
+          },
+        ],
+      },
+    });
+    expect(next.stages[0]!.startLabel).toBe("Paris");
+    expect(next.stages[0]!.endLabel).toBe("Lyon");
+    expect([...next.recomputingStages]).toEqual([0]);
+  });
+
+  it("trip_ready delegates to reconcileTripReady, stores status and clears recomputing", () => {
+    const acc = { name: "Gite" } as StageData["accommodations"][number];
+    const state = baseState({
+      stages: [stage({ endLabel: "Lyon", accommodations: [acc] })],
+      recomputingStages: new Set([0]),
+    });
+    const next = reduceMercureEvent(state, {
+      type: "trip_ready",
+      data: {
+        stages: [enriched({ label: null, accommodations: [] })],
+        computationStatus: { all: "done" },
+      },
+    });
+    // reconcileTripReady preserves the prev label + non-empty accommodations on a stable endpoint.
+    expect(next.stages[0]!.endLabel).toBe("Lyon");
+    expect(next.stages[0]!.accommodations).toEqual([acc]);
+    expect(next.computationStatus).toEqual({ all: "done" });
+    expect(next.recomputingStages.size).toBe(0);
+  });
+
+  it("stage_updated delegates to reconcileStageUpdate and removes the index from recomputing", () => {
+    const state = baseState({
+      stages: [stage({ dayNumber: 1, endLabel: "Lyon" })],
+      recomputingStages: new Set([0, 1]),
+    });
+    const next = reduceMercureEvent(state, {
+      type: "stage_updated",
+      data: { stageIndex: 0, stage: enriched({ dayNumber: 1, label: null }) },
+    });
+    expect(next.stages[0]!.endLabel).toBe("Lyon"); // preserved on stable endpoint
+    expect([...next.recomputingStages]).toEqual([1]);
+  });
+});
+
+describe("reduceMercureEvent — purity", () => {
+  it("does not mutate the input state's stages or recomputing set", () => {
+    const stages = [stage()];
+    const recomputingStages = new Set([0]);
+    const state = baseState({ stages, recomputingStages });
+    reduceMercureEvent(state, {
+      type: "pois_scanned",
+      data: { stageIndex: 0, pois: [{ name: "x", category: "c", lat: 1, lon: 1, distanceFromStart: 0 }] },
+    });
+    reduceMercureEvent(state, { type: "trip_complete", data: { computationStatus: {} } });
+    expect(state.stages[0]!.pois).toHaveLength(0);
+    expect(recomputingStages.has(0)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Drift guard — keeps the @btp/core contract in sync web <-> mobile.
+//
+// In the spirit of api/tests/Unit/AlertDocumentationTest.php: no hand-kept map.
+// It reads the web hook's switch and asserts, in BOTH directions, that the set
+// of events it dispatches equals the canonical MERCURE_EVENT_TYPES that the
+// core reducer covers. A new SSE event added to the contract or the web hook
+// without wiring the shared reducer (or vice versa) fails here loudly. The
+// core reducer's own exhaustiveness (its `never` default) and the compile-time
+// MERCURE_EVENT_TYPES_ARE_EXHAUSTIVE assertion cover the type-level direction.
+// ---------------------------------------------------------------------------
+describe("Mercure contract drift guard (#1030)", () => {
+  // vitest runs with cwd = the pwa workspace root.
+  const useMercurePath = resolve(process.cwd(), "src/hooks/use-mercure.ts");
+  const source = readFileSync(useMercurePath, "utf8");
+  const handledInHook = new Set(
+    [...source.matchAll(/^\s*case\s+"([a-z_]+)":/gm)].map((m) => m[1]!),
+  );
+  const canonical = new Set<string>(MERCURE_EVENT_TYPES);
+
+  it("every event dispatched by use-mercure.ts is a canonical core event", () => {
+    const orphanInHook = [...handledInHook].filter((t) => !canonical.has(t));
+    expect(orphanInHook, "web hook handles events not in @btp/core").toEqual([]);
+  });
+
+  it("every canonical core event is dispatched by use-mercure.ts", () => {
+    const missingFromHook = [...canonical].filter((t) => !handledInHook.has(t));
+    expect(missingFromHook, "@btp/core events not handled by the web hook").toEqual([]);
+  });
+
+  it("the core reducer handles every canonical event at runtime (no fallthrough)", () => {
+    const stubData: Record<MercureEventType, unknown> = {
+      route_parsed: {
+        totalDistance: 0,
+        totalElevation: 0,
+        totalElevationLoss: 0,
+        sourceType: "gpx",
+        title: null,
+      },
+      stages_computed: { stages: [] },
+      weather_fetched: { stages: [] },
+      pois_scanned: { stageIndex: 0, pois: [] },
+      accommodations_found: { stageIndex: 0, accommodations: [] },
+      events_found: { stageIndex: 0, events: [] },
+      supply_timeline: { stageIndex: 0, markers: [] },
+      terrain_alerts: { alertsByStage: {} },
+      calendar_alerts: { alerts: [] },
+      wind_alerts: { alerts: [] },
+      bike_shop_alerts: { alerts: [] },
+      water_point_alerts: { alerts: [], waterPointsByStage: [] },
+      health_service_alerts: { alerts: [] },
+      cultural_poi_alerts: { alerts: [] },
+      railway_station_alerts: { alerts: [] },
+      border_crossing_alerts: { alerts: [] },
+      ferry_alerts: { alerts: [] },
+      ford_alerts: { alerts: [] },
+      route_segment_recalculated: {
+        stageIndex: 0,
+        reason: "",
+        distance: 0,
+        elevationGain: 0,
+        duration: 0,
+        coordinates: [],
+      },
+      trip_complete: { computationStatus: {} },
+      computation_step_completed: { step: "", category: "route", completed: 0, total: 0 },
+      trip_ready: { stages: [], computationStatus: {} },
+      stage_updated: { stageIndex: 0, stage: enriched() },
+      validation_error: { code: "", message: "" },
+      computation_error: { computation: "", message: "", retryable: false },
+    };
+
+    for (const type of MERCURE_EVENT_TYPES) {
+      const event = { type, data: stubData[type] } as MercureEvent;
+      const next = reduceMercureEvent(baseState(), event);
+      expect(Array.isArray(next.stages), `reducer returned no state for ${type}`).toBe(true);
+    }
+  });
+});

--- a/pwa/src/store/mercure-reconciliation.test.ts
+++ b/pwa/src/store/mercure-reconciliation.test.ts
@@ -426,6 +426,54 @@ describe("reduceMercureEvent — structural / terminal events", () => {
     expect([...next.recomputingStages]).toEqual([0]);
   });
 
+  it("stages_computed (partial update) keeps the derived label on an unaffected stage when the payload omits it", () => {
+    // Mirrors use-mercure.ts:90 (`label: s.label ?? existing.label`): on the
+    // unaffected branch a null payload label must NOT blank the reverse-geocoded
+    // label already on the stage; only the affected stage is replaced.
+    const state = baseState({
+      stages: [
+        stage({ dayNumber: 1, label: "Col du Galibier" }),
+        stage({ dayNumber: 2, label: "Briançon" }),
+      ],
+      recomputingStages: new Set([1]),
+    });
+    const next = reduceMercureEvent(state, {
+      type: "stages_computed",
+      data: {
+        affectedIndices: [1],
+        stages: [
+          {
+            dayNumber: 1,
+            distance: 61,
+            elevation: 100,
+            elevationLoss: 90,
+            startPoint: A,
+            endPoint: B,
+            geometry: [],
+            label: null,
+          },
+          {
+            dayNumber: 2,
+            distance: 40,
+            elevation: 10,
+            elevationLoss: 5,
+            startPoint: B,
+            endPoint: C,
+            geometry: [],
+            label: "Névache",
+          },
+        ],
+      },
+    });
+    // Unaffected stage: core field updated, derived label preserved.
+    expect(next.stages[0]!.distance).toBe(61);
+    expect(next.stages[0]!.label).toBe("Col du Galibier");
+    // Affected stage: fully replaced by the payload.
+    expect(next.stages[1]!.label).toBe("Névache");
+    // In-range recomputing marker is kept (pruning only drops out-of-range).
+    expect([...next.recomputingStages]).toEqual([1]);
+  });
+
   it("trip_ready delegates to reconcileTripReady, stores status and clears recomputing", () => {
     const acc = { name: "Gite" } as StageData["accommodations"][number];
     const state = baseState({


### PR DESCRIPTION
Closes #1030.

## Résumé
La réconciliation partagée `@btp/core` couvre désormais **tous** les events Mercure SSE (25 types), plus seulement le sous-ensemble Sprint 53, avec une garde de dérive web↔mobile.

- `core/mercure.ts` : registre canonique `MERCURE_EVENT_TYPES` (25) + `MercureEventType`, avec assertion de complétude au compile (`MERCURE_EVENT_TYPES_ARE_EXHAUSTIVE`) — le build casse si une variante de l'union `MercureEvent` est ajoutée sans être listée.
- `core/reconciliation.ts` : réducteur pur `reduceMercureEvent(state, event)` + `ReconciledState`, miroir case-par-case de `pwa/src/hooks/use-mercure.ts` (route_parsed, stages_computed, weather, pois, accommodations, events, supply_timeline, 11 `*_alerts`, route_segment_recalculated, trip_complete/ready, stage_updated, computation_*, validation_error). Compose les réducteurs existants + `enrichedPayloadToStageData`. Switch exhaustif (`never` par défaut). Effets UI (toasts, spinners ADR-043, reverse-geocode, stageDiffs, endDate) laissés hors core par design.
- `pwa/src/store/mercure-reconciliation.test.ts` (nouveau, 23 tests) : comportement par event, pureté, et la **garde de dérive** (esprit `AlertDocumentationTest`) qui parse les `case` de `use-mercure.ts` et vérifie l'égalité bidirectionnelle avec `MERCURE_EVENT_TYPES` + boucle runtime.

Additif pur (signatures inchangées) → aucun recâblage du store web/mobile ; les 18 tests `reconciliation.test.ts` (#840/#649/#787) restent verts.

## Vérification locale (exit codes réels)
- vitest (reconciliation + nouveau fichier) → **41 passed**, exit 0
- `test:ts` pwa (tsc) → exit 0
- `lint` pwa → 0 errors (3 warnings préexistants hors périmètre), exit 0
- `typecheck` mobile → exit 0 (compile contre le nouveau core)
- **Mutation-proof** : retrait `case "wind_alerts"` de use-mercure.ts → garde RED ; `distance/1000`→`distance` → cas RED ; restaurés, 41/41 verts.

## Auto-critique
- Les effets UI hors-core sont un choix assumé (documenté) : le store consommateur reste responsable des toasts/spinners.
- Base de la stack Wave 2 : #1031 (store complet) branche sur cette PR.

<!-- claude-review-start -->
## Claude Review

**Summary:** Both outstanding items from the previous pass — the `geometry`/`label` fallback gap on the affected/new-stage and full-replace branches of `reconcileStagesComputed`, and the missing field-mapping tests for 7 of 13 alert-group branches — are fixed in the latest commit (`f7a3dead`). Verified line-by-line against `pwa/src/hooks/use-mercure.ts`: all `stages_computed` branches now carry the same `?? []` / `?? null` fallbacks as the web hook, and every alert-group case (`bike_shop`, `water_point`, `health_service`, `cultural_poi`, `railway_station`, `border_crossing`, `ford`, plus the previously-covered ones) has a dedicated behavioral test. No new findings.

**Resolved threads:** Resolved 3 previously open threads that were addressed (the affected-branch and full-replace `geometry`/`label` fallbacks, and the 7 missing alert-group tests).

**PR title check:** the title is still a noun phrase ("réconciliation Mercure complète...") rather than an imperative description, as required by this repo's Conventional Commits convention. Consider: `feat(core): compléter la réconciliation Mercure (tous events SSE) + garde de dérive (#1030)`.

**Review checklist:**
- [x] Code respects the project architecture (pure, platform-agnostic reducer; additive only; no store rewiring, as documented)
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate (reducer pattern, compile-time exhaustiveness guard)
- [x] Tests cover new/changed cases (all 25 event types + all 13 alert groups have dedicated assertions; drift guard covers type-level and runtime exhaustiveness)
- [x] Documentation is up to date (JSDoc on new exports)
- [ ] Dependent tickets accounted for — `TRACKING.md` still lists #1030 as "⏳ À faire" with no PR reference, even though this open PR closes it

**Inline comments:** No inline comments.

Commit reviewed: `f7a3dead096cdc6ab4829042e0d80c5de2434732`
<!-- claude-review-end -->
