### PR TITLE
feat(mobile): store complet (mutations + batch recompute + hooks) + gating (#1031)

### DIFF
--- a/mobile/src/api/trips.ts
+++ b/mobile/src/api/trips.ts
@@ -4,8 +4,28 @@ import type { components } from '@btp/core/schema';
 export type TripListItem = components['schemas']['Trip.TripListItem.jsonld'];
 export type TripDetail = components['schemas']['TripDetail.jsonld'];
 export type Stage = NonNullable<TripDetail['stages']>[number];
+export type Coordinate = components['schemas']['Coordinate'];
+export type TripConfigPatch =
+  components['schemas']['Trip.TripRequest.jsonMergePatch'];
+export type TripModification = components['schemas']['TripModification'];
+
+/** Raw HTTP outcome of a mutating call, so callers can normalize per status. */
+export interface MutationResult {
+  ok: boolean;
+  status: number;
+}
 
 const ld = { Accept: 'application/ld+json' };
+// Body-bearing POSTs negotiate on JSON-LD; PATCHes use JSON Merge Patch (the
+// backend PATCH operations declare `application/merge-patch+json`).
+const ldBody = {
+  Accept: 'application/ld+json',
+  'Content-Type': 'application/ld+json',
+};
+const mergePatch = {
+  Accept: 'application/ld+json',
+  'Content-Type': 'application/merge-patch+json',
+};
 
 export async function fetchTrips(): Promise<TripListItem[]> {
   // openapi-fetch resolves (never rejects) on a non-2xx, returning `error`. Throw
@@ -38,6 +58,173 @@ export async function deleteStage(
 ): Promise<{ ok: boolean; status: number }> {
   const { response } = await api.DELETE('/trips/{tripId}/stages/{index}', {
     params: { path: { tripId, index: String(index) } },
+    headers: ld,
+  });
+  return { ok: response.ok, status: response.status };
+}
+
+// ---------------------------------------------------------------------------
+// Trip-config mutations (#1031). Each returns the raw {ok,status} so a runner
+// can normalize the failure (see gating.ts) and roll back an optimistic edit.
+// ---------------------------------------------------------------------------
+
+/** PATCH trip config (dates / pacing / title / accommodation types). */
+export async function updateTripConfig(
+  tripId: string,
+  body: TripConfigPatch,
+): Promise<MutationResult> {
+  const { response } = await api.PATCH('/trips/{id}', {
+    params: { path: { id: tripId } },
+    headers: mergePatch,
+    body,
+  });
+  return { ok: response.ok, status: response.status };
+}
+
+/** Add a manual stage at `position` (0-based), routed via Valhalla. */
+export async function createStage(
+  tripId: string,
+  body: { position: number; startPoint: Coordinate; endPoint: Coordinate },
+): Promise<MutationResult> {
+  const { response } = await api.POST('/trips/{tripId}/stages', {
+    params: { path: { tripId } },
+    headers: ldBody,
+    body,
+  });
+  return { ok: response.ok, status: response.status };
+}
+
+/** Update a stage's distance (re-splits from this stage onward). */
+export async function updateStageDistance(
+  tripId: string,
+  index: number,
+  distance: number,
+): Promise<MutationResult> {
+  const { response } = await api.PATCH('/trips/{tripId}/stages/{index}', {
+    params: { path: { tripId, index: String(index) } },
+    headers: mergePatch,
+    body: { distance },
+  });
+  return { ok: response.ok, status: response.status };
+}
+
+/** Move a stage to a new position. */
+export async function moveStage(
+  tripId: string,
+  index: number,
+  toIndex: number,
+): Promise<MutationResult> {
+  const { response } = await api.PATCH('/trips/{tripId}/stages/{index}/move', {
+    params: { path: { tripId, index: String(index) } },
+    headers: mergePatch,
+    body: { toIndex },
+  });
+  return { ok: response.ok, status: response.status };
+}
+
+/** Insert a rest day after `index` (dates shift by one day server-side). */
+export async function insertRestDay(
+  tripId: string,
+  index: number,
+): Promise<MutationResult> {
+  const { response } = await api.POST('/trips/{tripId}/stages/{index}/rest-day', {
+    params: { path: { tripId, index: String(index) } },
+    headers: ld,
+  });
+  return { ok: response.ok, status: response.status };
+}
+
+/**
+ * Select (or, with both coords null, deselect) an accommodation for a stage.
+ * A concurrent scan invalidates the list and the backend answers 409.
+ */
+export async function setStageAccommodation(
+  tripId: string,
+  index: number,
+  lat: number | null,
+  lon: number | null,
+): Promise<MutationResult> {
+  const { response } = await api.PATCH(
+    '/trips/{tripId}/stages/{index}/accommodation',
+    {
+      params: { path: { tripId, index: String(index) } },
+      headers: mergePatch,
+      body: { selectedAccommodationLat: lat, selectedAccommodationLon: lon },
+    },
+  );
+  return { ok: response.ok, status: response.status };
+}
+
+/** Insert a cultural POI as a waypoint, re-routing the stage via Valhalla. */
+export async function addPoiWaypoint(
+  tripId: string,
+  index: number,
+  waypointLat: number,
+  waypointLon: number,
+): Promise<MutationResult> {
+  const { response } = await api.POST(
+    '/trips/{tripId}/stages/{index}/poi-waypoint',
+    {
+      params: { path: { tripId, index: String(index) } },
+      headers: ldBody,
+      body: { waypointLat, waypointLon },
+    },
+  );
+  return { ok: response.ok, status: response.status };
+}
+
+/** Re-scan accommodations (all stages, or a single one) with a custom radius. */
+export async function scanAccommodations(
+  tripId: string,
+  radiusKm: number,
+  stageIndex?: number,
+): Promise<MutationResult> {
+  const { response } = await api.POST('/trips/{tripId}/accommodations/scan', {
+    params: { path: { tripId } },
+    headers: ldBody,
+    body: { radiusKm, ...(stageIndex !== undefined && { stageIndex }) },
+  });
+  return { ok: response.ok, status: response.status };
+}
+
+/** Apply a batch of queued modifications in a single recompute pass. */
+export async function applyBatchRecompute(
+  tripId: string,
+  modifications: TripModification[],
+): Promise<MutationResult> {
+  const { response } = await api.POST('/trips/{id}/recompute', {
+    params: { path: { id: tripId } },
+    headers: ldBody,
+    body: { modifications },
+  });
+  return { ok: response.ok, status: response.status };
+}
+
+/** Re-run the full enrichment pipeline (POIs, weather, terrain, …). */
+export async function analyzeTrip(tripId: string): Promise<MutationResult> {
+  const { response } = await api.POST('/trips/{id}/analyze', {
+    params: { path: { id: tripId } },
+    headers: ld,
+  });
+  return { ok: response.ok, status: response.status };
+}
+
+/** Deep-clone a trip. Returns the new trip id, or null on failure. */
+export async function duplicateTrip(tripId: string): Promise<string | null> {
+  const { data, error } = await api.POST('/trips/{id}/duplicate', {
+    params: { path: { id: tripId } },
+    headers: ld,
+  });
+  if (error || !data?.id) {
+    return null;
+  }
+  return data.id;
+}
+
+/** Permanently delete a trip and all its stages. */
+export async function deleteTrip(tripId: string): Promise<MutationResult> {
+  const { response } = await api.DELETE('/trips/{id}', {
+    params: { path: { id: tripId } },
     headers: ld,
   });
   return { ok: response.ok, status: response.status };

--- a/mobile/src/hooks/use-trip-detail.test.ts
+++ b/mobile/src/hooks/use-trip-detail.test.ts
@@ -1,0 +1,30 @@
+/// <reference types="jest" />
+import { runLoadTripDetail } from './use-trip-detail';
+
+jest.mock('../api/trips', () => ({ fetchTripDetail: jest.fn() }));
+import { fetchTripDetail } from '../api/trips';
+const mockDetail = fetchTripDetail as jest.MockedFunction<typeof fetchTripDetail>;
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('runLoadTripDetail (#1031)', () => {
+  it('returns the detail on success', async () => {
+    mockDetail.mockResolvedValue({ title: 'Trip' } as never);
+    const { detail, error } = await runLoadTripDetail('t1');
+    expect(detail).toEqual({ title: 'Trip' });
+    expect(error).toBeNull();
+  });
+
+  it('reports "Voyage introuvable." when the detail is null', async () => {
+    mockDetail.mockResolvedValue(null);
+    const { detail, error } = await runLoadTripDetail('t1');
+    expect(detail).toBeNull();
+    expect(error).toBe('Voyage introuvable.');
+  });
+
+  it('reports a load error when the fetch throws', async () => {
+    mockDetail.mockRejectedValue(new Error('boom'));
+    const { error } = await runLoadTripDetail('t1');
+    expect(error).toBe('Impossible de charger le voyage.');
+  });
+});

--- a/mobile/src/hooks/use-trip-detail.ts
+++ b/mobile/src/hooks/use-trip-detail.ts
@@ -1,0 +1,52 @@
+import { useCallback, useEffect, useState } from 'react';
+import { fetchTripDetail, type TripDetail } from '../api/trips';
+
+export interface TripDetailState {
+  detail: TripDetail | null;
+  error: string | null;
+}
+
+// Extracted for unit-testing the async/error branches (mirrors runTripLive).
+// One-shot fetch (no SSE): use it for a read-only preview; the live roadbook
+// hydration + Mercure subscription lives in useTripLive.
+export async function runLoadTripDetail(id: string): Promise<TripDetailState> {
+  try {
+    const detail = await fetchTripDetail(id);
+    if (!detail) return { detail: null, error: 'Voyage introuvable.' };
+    return { detail, error: null };
+  } catch {
+    return { detail: null, error: 'Impossible de charger le voyage.' };
+  }
+}
+
+// Fetch a single trip's persisted /detail payload once. `reload` re-runs it.
+export function useTripDetail(id: string): {
+  detail: TripDetail | null;
+  loading: boolean;
+  error: string | null;
+  reload: () => void;
+} {
+  const [state, setState] = useState<TripDetailState>({
+    detail: null,
+    error: null,
+  });
+  const [loading, setLoading] = useState(true);
+  const [nonce, setNonce] = useState(0);
+
+  const reload = useCallback(() => setNonce((n) => n + 1), []);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    void runLoadTripDetail(id).then((next) => {
+      if (cancelled) return;
+      setState(next);
+      setLoading(false);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [id, nonce]);
+
+  return { detail: state.detail, loading, error: state.error, reload };
+}

--- a/mobile/src/hooks/use-trip-mutations.ts
+++ b/mobile/src/hooks/use-trip-mutations.ts
@@ -1,0 +1,76 @@
+import { useMemo } from 'react';
+import { useTripStore } from '../store/trip-store';
+import type { MutationContext, OnFailure } from '../store/mutations';
+import { runDeleteStage } from '../store/delete-stage';
+import type { TripConfig } from '../store/trip-store';
+import {
+  runAddPoiWaypoint,
+  runAddStage,
+  runAnalyze,
+  runApplyBatch,
+  runDeleteTrip,
+  runDeselectAccommodation,
+  runDuplicateTrip,
+  runInsertRestDay,
+  runMoveStage,
+  runScanAccommodations,
+  runSelectAccommodation,
+  runUpdateAccommodationTypes,
+  runUpdateDates,
+  runUpdatePacing,
+  runUpdateStageDistance,
+  runUpdateTitle,
+} from '../store/mutations';
+
+type Pacing = Pick<
+  TripConfig,
+  | 'fatigueFactor'
+  | 'elevationPenalty'
+  | 'maxDistancePerDay'
+  | 'averageSpeed'
+  | 'ebikeMode'
+  | 'departureHour'
+>;
+
+// Bind every mutation runner to the live store snapshot + a single failure
+// callback, so an editing screen (Sprint 55/56) calls `mutations.updateDates(...)`
+// without re-assembling the context or the gate each time. The store snapshot is
+// read at call time (actions are stable, the pre-edit `stages` snapshot is taken
+// inside each runner) so a stale closure never rolls back the wrong state.
+export function useTripMutations(tripId: string, onFailure: OnFailure) {
+  return useMemo(() => {
+    const ctx = (): MutationContext => useTripStore.getState();
+    return {
+      updateDates: (startDate: string | null, endDate: string | null) =>
+        runUpdateDates(tripId, startDate, endDate, ctx(), onFailure),
+      updatePacing: (pacing: Pacing) =>
+        runUpdatePacing(tripId, pacing, ctx(), onFailure),
+      updateTitle: (title: string) =>
+        runUpdateTitle(tripId, title, ctx(), onFailure),
+      updateAccommodationTypes: (types: string[]) =>
+        runUpdateAccommodationTypes(tripId, types, ctx(), onFailure),
+      addStage: (afterIndex: number) =>
+        runAddStage(tripId, afterIndex, ctx(), onFailure),
+      deleteStage: (index: number) =>
+        runDeleteStage(tripId, index, ctx(), onFailure),
+      insertRestDay: (afterIndex: number) =>
+        runInsertRestDay(tripId, afterIndex, ctx(), onFailure),
+      moveStage: (fromIndex: number, toIndex: number) =>
+        runMoveStage(tripId, fromIndex, toIndex, ctx(), onFailure),
+      updateStageDistance: (index: number, distance: number) =>
+        runUpdateStageDistance(tripId, index, distance, ctx(), onFailure),
+      selectAccommodation: (stageIndex: number, accIndex: number) =>
+        runSelectAccommodation(tripId, stageIndex, accIndex, ctx(), onFailure),
+      deselectAccommodation: (stageIndex: number) =>
+        runDeselectAccommodation(tripId, stageIndex, ctx(), onFailure),
+      scanAccommodations: (radiusKm: number, stageIndex?: number) =>
+        runScanAccommodations(tripId, radiusKm, stageIndex, ctx(), onFailure),
+      addPoiWaypoint: (stageIndex: number, lat: number, lon: number) =>
+        runAddPoiWaypoint(tripId, stageIndex, lat, lon, ctx(), onFailure),
+      applyBatch: () => runApplyBatch(tripId, ctx(), onFailure),
+      analyze: () => runAnalyze(tripId, ctx(), onFailure),
+      duplicate: () => runDuplicateTrip(tripId, ctx(), onFailure),
+      deleteTrip: () => runDeleteTrip(tripId, ctx(), onFailure),
+    };
+  }, [tripId, onFailure]);
+}

--- a/mobile/src/hooks/use-trips.test.ts
+++ b/mobile/src/hooks/use-trips.test.ts
@@ -1,0 +1,24 @@
+/// <reference types="jest" />
+import { runLoadTrips } from './use-trips';
+
+jest.mock('../api/trips', () => ({ fetchTrips: jest.fn() }));
+import { fetchTrips } from '../api/trips';
+const mockFetch = fetchTrips as jest.MockedFunction<typeof fetchTrips>;
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('runLoadTrips (#1031)', () => {
+  it('returns the list on success', async () => {
+    mockFetch.mockResolvedValue([{ id: 't1' }] as never);
+    const { trips, error } = await runLoadTrips();
+    expect(trips).toHaveLength(1);
+    expect(error).toBeNull();
+  });
+
+  it('returns an empty list + a message when the fetch throws', async () => {
+    mockFetch.mockRejectedValue(new Error('boom'));
+    const { trips, error } = await runLoadTrips();
+    expect(trips).toEqual([]);
+    expect(error).toBe('Impossible de charger les voyages.');
+  });
+});

--- a/mobile/src/hooks/use-trips.ts
+++ b/mobile/src/hooks/use-trips.ts
@@ -1,0 +1,48 @@
+import { useCallback, useEffect, useState } from 'react';
+import { fetchTrips, type TripListItem } from '../api/trips';
+
+export interface TripsState {
+  trips: TripListItem[];
+  error: string | null;
+}
+
+// Extracted so the load/error branch is unit-testable without a React renderer
+// (mirrors runTripLive, #1014). Never throws: a backend failure resolves to an
+// empty list + an error message the caller surfaces.
+export async function runLoadTrips(): Promise<TripsState> {
+  try {
+    return { trips: await fetchTrips(), error: null };
+  } catch {
+    return { trips: [], error: 'Impossible de charger les voyages.' };
+  }
+}
+
+// Load the authenticated user's trip list. `reload` re-runs the fetch (e.g. on
+// pull-to-refresh). Late results are dropped after unmount.
+export function useTrips(): {
+  trips: TripListItem[];
+  loading: boolean;
+  error: string | null;
+  reload: () => void;
+} {
+  const [state, setState] = useState<TripsState>({ trips: [], error: null });
+  const [loading, setLoading] = useState(true);
+  const [nonce, setNonce] = useState(0);
+
+  const reload = useCallback(() => setNonce((n) => n + 1), []);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    void runLoadTrips().then((next) => {
+      if (cancelled) return;
+      setState(next);
+      setLoading(false);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [nonce]);
+
+  return { trips: state.trips, loading, error: state.error, reload };
+}

--- a/mobile/src/store/delete-stage.test.ts
+++ b/mobile/src/store/delete-stage.test.ts
@@ -2,6 +2,7 @@
 import type { StageData } from '@btp/core';
 import { runDeleteStage } from './delete-stage';
 import { useTripStore } from './trip-store';
+import { useOfflineStore } from './offline-store';
 
 jest.mock('../api/trips', () => ({ deleteStage: jest.fn() }));
 import { deleteStage } from '../api/trips';
@@ -38,6 +39,7 @@ const noop = jest.fn();
 beforeEach(() => {
   jest.clearAllMocks();
   useTripStore.getState().reset();
+  useOfflineStore.setState({ isOnline: true });
   useTripStore.setState({
     stages: [stage(1), stage(2), stage(3)],
     isLocked: false,
@@ -79,14 +81,25 @@ describe('runDeleteStage optimistic delete (#1015)', () => {
     expect(onFailure).toHaveBeenCalledWith('locked');
   });
 
-  it('rolls back and reports "error" when the request throws', async () => {
+  it('rolls back and reports "network" when the request throws', async () => {
     mockDelete.mockRejectedValue(new Error('network'));
     const onFailure = jest.fn();
 
     await runDeleteStage('t1', 2, useTripStore.getState(), onFailure);
 
     expect(useTripStore.getState().stages).toHaveLength(3);
-    expect(onFailure).toHaveBeenCalledWith('error');
+    expect(onFailure).toHaveBeenCalledWith('network');
+  });
+
+  it('does not touch the store or call the API when offline', async () => {
+    useOfflineStore.setState({ isOnline: false });
+    const onFailure = jest.fn();
+
+    await runDeleteStage('t1', 1, useTripStore.getState(), onFailure);
+
+    expect(useTripStore.getState().stages).toHaveLength(3);
+    expect(mockDelete).not.toHaveBeenCalled();
+    expect(onFailure).toHaveBeenCalledWith('offline');
   });
 
   it('does not touch the store or call the API when the trip is locked', async () => {

--- a/mobile/src/store/delete-stage.ts
+++ b/mobile/src/store/delete-stage.ts
@@ -1,46 +1,29 @@
-import type { StageData } from '@btp/core';
 import { deleteStage as apiDeleteStage } from '../api/trips';
-
-export type DeleteFailure = 'locked' | 'error';
-
-// The store surface the deletion drives.
-export interface DeleteStageStore {
-  isLocked: boolean;
-  stages: StageData[];
-  deleteStageOptimistic: (index: number) => void;
-  setStages: (stages: StageData[]) => void;
-}
+import { run, type MutationContext, type OnFailure } from './mutations';
 
 // Optimistic stage deletion (#1015): snapshot -> remove locally -> call the API.
 // On success the authoritative recompute arrives over SSE and reconciles through
-// the core reducers; on failure (including 423 when the trip is locked) the
-// snapshot is restored and the reason reported so the UI can toast. Extracted
-// from the screen so the optimistic/rollback/423 branches are unit-testable.
-export async function runDeleteStage(
+// the core reducers; on failure the snapshot is restored and the reason reported
+// so the UI can toast. Now composes the shared `run` shell (#1031) so its gate
+// (423 lock / offline) and rollback discipline match every other mutation; the
+// dedicated wrapper is kept because a screen already consumes it by name.
+export function runDeleteStage(
   tripId: string,
   index: number,
-  store: DeleteStageStore,
-  onFailure: (reason: DeleteFailure) => void,
-): Promise<void> {
-  // A started trip is read-only; skip the optimistic mutation entirely.
-  if (store.isLocked) {
-    onFailure('locked');
-    return;
-  }
-
+  store: MutationContext,
+  onFailure: OnFailure,
+): Promise<boolean> {
   const snapshot = store.stages;
-  store.deleteStageOptimistic(index);
-
-  try {
-    const { ok, status } = await apiDeleteStage(tripId, index);
-    if (!ok) {
-      store.setStages(snapshot);
-      onFailure(status === 423 ? 'locked' : 'error');
-    }
-    // On success, the SSE trip_ready / stage_updated event replaces the
-    // optimistic list with the reconciled authoritative state.
-  } catch {
-    store.setStages(snapshot);
-    onFailure('error');
-  }
+  return run(
+    store,
+    {
+      // Deleting merges into the adjacent day (no Valhalla reroute): a lock or
+      // offline blocks it, but an out-of-zone trip does not.
+      requiresRouting: false,
+      optimistic: () => store.deleteStageOptimistic(index),
+      rollback: () => store.setStages(snapshot),
+      call: () => apiDeleteStage(tripId, index),
+    },
+    onFailure,
+  );
 }

--- a/mobile/src/store/gating.test.ts
+++ b/mobile/src/store/gating.test.ts
@@ -1,0 +1,50 @@
+/// <reference types="jest" />
+import { evaluateGate, normalizeStatus, type GateState } from './gating';
+
+const open: GateState = { isLocked: false, outOfZone: false, isOnline: true };
+
+describe('evaluateGate (transversal mutation gate, #1031)', () => {
+  it('allows a routing mutation when online, unlocked and in zone', () => {
+    expect(evaluateGate(open, true)).toBeNull();
+    expect(evaluateGate(open, false)).toBeNull();
+  });
+
+  it('blocks everything while offline (wins over lock and zone)', () => {
+    expect(
+      evaluateGate({ isLocked: true, outOfZone: true, isOnline: false }, true),
+    ).toBe('offline');
+    expect(evaluateGate({ ...open, isOnline: false }, false)).toBe('offline');
+  });
+
+  it('blocks every mutation on a started (423) trip', () => {
+    expect(evaluateGate({ ...open, isLocked: true }, true)).toBe('locked');
+    expect(evaluateGate({ ...open, isLocked: true }, false)).toBe('locked');
+  });
+
+  it('blocks only routing mutations out of zone', () => {
+    expect(evaluateGate({ ...open, outOfZone: true }, true)).toBe('out_of_zone');
+    // A non-routing mutation (title, dates, pacing, scan) is still allowed.
+    expect(evaluateGate({ ...open, outOfZone: true }, false)).toBeNull();
+  });
+});
+
+describe('normalizeStatus (API error contract, CLAUDE.md)', () => {
+  it('maps 422 to a validation failure (unknown enum → 422, not 400)', () => {
+    expect(normalizeStatus(422)).toBe('validation');
+  });
+
+  it('maps 404 to not_found (object-authz denials are masked as 404)', () => {
+    expect(normalizeStatus(404)).toBe('not_found');
+  });
+
+  it('maps 423 to locked and 409 to conflict', () => {
+    expect(normalizeStatus(423)).toBe('locked');
+    expect(normalizeStatus(409)).toBe('conflict');
+  });
+
+  it('maps status 0 to network and any other status to a generic error', () => {
+    expect(normalizeStatus(0)).toBe('network');
+    expect(normalizeStatus(500)).toBe('error');
+    expect(normalizeStatus(400)).toBe('error');
+  });
+});

--- a/mobile/src/store/gating.ts
+++ b/mobile/src/store/gating.ts
@@ -1,0 +1,69 @@
+// Transversal mutation gating + error normalization shared by every editing
+// mutation (#1031). One source of truth so the store, the mutation runners and
+// (Sprint 55/56) the screens all refuse and classify failures the same way.
+
+/**
+ * Normalized outcome of a blocked or failed mutation. The gate reasons
+ * (`locked` / `out_of_zone` / `offline`) are pre-flight refusals; the rest are
+ * classifications of a backend/network failure (see {@link normalizeStatus}).
+ */
+export type MutationFailure =
+  | 'locked'
+  | 'out_of_zone'
+  | 'offline'
+  | 'validation'
+  | 'not_found'
+  | 'conflict'
+  | 'network'
+  | 'error';
+
+/** The three transversal conditions every mutation is gated on. */
+export interface GateState {
+  /** Trip started (startDate <= today): the backend rejects edits with 423. */
+  isLocked: boolean;
+  /** Route outside the provisioned coverage area: no Valhalla rerouting. */
+  outOfZone: boolean;
+  /** Device connectivity — mutations are disabled while offline. */
+  isOnline: boolean;
+}
+
+/**
+ * Pre-flight gate shared by all mutations. Offline blocks everything; a started
+ * trip (423) is fully read-only; an out-of-zone trip blocks only mutations that
+ * need Valhalla rerouting (`requiresRouting`). Returns the blocking reason, or
+ * `null` when the mutation may proceed. Offline wins over lock wins over zone so
+ * the most fundamental obstacle is reported first.
+ */
+export function evaluateGate(
+  state: GateState,
+  requiresRouting: boolean,
+): 'offline' | 'locked' | 'out_of_zone' | null {
+  if (!state.isOnline) return 'offline';
+  if (state.isLocked) return 'locked';
+  if (requiresRouting && state.outOfZone) return 'out_of_zone';
+  return null;
+}
+
+/**
+ * Classify an HTTP status into a {@link MutationFailure}. Per the API error
+ * contract (CLAUDE.md): object-level authorization denials are masked as 404
+ * (never 403), and an unknown backed-enum value fails denormalization as 422
+ * (not 400). 423 = trip locked, 409 = stale accommodation list. `status === 0`
+ * marks a request that never reached the backend.
+ */
+export function normalizeStatus(status: number): MutationFailure {
+  switch (status) {
+    case 422:
+      return 'validation';
+    case 404:
+      return 'not_found';
+    case 423:
+      return 'locked';
+    case 409:
+      return 'conflict';
+    case 0:
+      return 'network';
+    default:
+      return 'error';
+  }
+}

--- a/mobile/src/store/mutations.test.ts
+++ b/mobile/src/store/mutations.test.ts
@@ -1,15 +1,22 @@
 /// <reference types="jest" />
 import type { StageData } from '@btp/core';
 import {
+  runAddPoiWaypoint,
   runAddStage,
   runAnalyze,
   runApplyBatch,
   runDeleteTrip,
+  runDeselectAccommodation,
   runDuplicateTrip,
+  runInsertRestDay,
+  runMoveStage,
   runScanAccommodations,
   runSelectAccommodation,
+  runUpdateAccommodationTypes,
   runUpdateDates,
+  runUpdatePacing,
   runUpdateStageDistance,
+  runUpdateTitle,
 } from './mutations';
 import { useTripStore } from './trip-store';
 import { useOfflineStore } from './offline-store';
@@ -33,7 +40,10 @@ import {
   updateTripConfig,
   createStage,
   updateStageDistance,
+  moveStage,
+  insertRestDay,
   setStageAccommodation,
+  addPoiWaypoint,
   scanAccommodations,
   applyBatchRecompute,
   analyzeTrip,
@@ -192,6 +202,162 @@ describe('runSelectAccommodation', () => {
     expect(ok).toBe(false);
     expect(onFailure).toHaveBeenCalledWith('conflict');
     expect(useTripStore.getState().stages[0]!.selectedAccommodation).toBeNull();
+  });
+});
+
+describe('config runners (non-routing) — allowed out of zone + rollback', () => {
+  beforeEach(() => useTripStore.setState({ outOfZone: true }));
+
+  const pacing = {
+    fatigueFactor: 0.75,
+    elevationPenalty: 60,
+    maxDistancePerDay: 95,
+    averageSpeed: 21,
+    ebikeMode: true,
+    departureHour: 7,
+  };
+
+  it('runUpdatePacing applies optimistically out of zone', async () => {
+    mock(updateTripConfig).mockResolvedValue({ ok: true, status: 202 });
+    expect(await runUpdatePacing('t1', pacing, ctx(), jest.fn())).toBe(true);
+    expect(useTripStore.getState().averageSpeed).toBe(21);
+    expect(updateTripConfig).toHaveBeenCalled();
+  });
+
+  it('runUpdatePacing rolls back pacing on 422', async () => {
+    const before = useTripStore.getState().averageSpeed;
+    mock(updateTripConfig).mockResolvedValue({ ok: false, status: 422 });
+    const onFailure = jest.fn();
+    expect(await runUpdatePacing('t1', pacing, ctx(), onFailure)).toBe(false);
+    expect(useTripStore.getState().averageSpeed).toBe(before);
+    expect(onFailure).toHaveBeenCalledWith('validation');
+  });
+
+  it('runUpdateTitle applies then rolls back on failure', async () => {
+    mock(updateTripConfig).mockResolvedValue({ ok: true, status: 202 });
+    expect(await runUpdateTitle('t1', 'Corse', ctx(), jest.fn())).toBe(true);
+    expect(useTripStore.getState().title).toBe('Corse');
+
+    const before = useTripStore.getState().title;
+    mock(updateTripConfig).mockResolvedValue({ ok: false, status: 422 });
+    expect(await runUpdateTitle('t1', 'Alpes', ctx(), jest.fn())).toBe(false);
+    expect(useTripStore.getState().title).toBe(before);
+  });
+
+  it('runUpdateAccommodationTypes applies then rolls back on failure', async () => {
+    mock(updateTripConfig).mockResolvedValue({ ok: true, status: 202 });
+    expect(
+      await runUpdateAccommodationTypes('t1', ['hotel'], ctx(), jest.fn()),
+    ).toBe(true);
+    expect(useTripStore.getState().enabledAccommodationTypes).toEqual(['hotel']);
+
+    const before = useTripStore.getState().enabledAccommodationTypes;
+    mock(updateTripConfig).mockResolvedValue({ ok: false, status: 422 });
+    expect(
+      await runUpdateAccommodationTypes('t1', ['rental'], ctx(), jest.fn()),
+    ).toBe(false);
+    expect(useTripStore.getState().enabledAccommodationTypes).toEqual(before);
+  });
+
+  it('runInsertRestDay inserts optimistically out of zone and rolls back on failure', async () => {
+    mock(insertRestDay).mockResolvedValueOnce({ ok: true, status: 202 });
+    expect(await runInsertRestDay('t1', 0, ctx(), jest.fn())).toBe(true);
+    expect(useTripStore.getState().stages).toHaveLength(3);
+    expect(insertRestDay).toHaveBeenCalledWith('t1', 0);
+
+    mock(insertRestDay).mockResolvedValueOnce({ ok: false, status: 409 });
+    expect(await runInsertRestDay('t1', 0, ctx(), jest.fn())).toBe(false);
+    expect(useTripStore.getState().stages).toHaveLength(3); // rolled back to pre-call
+  });
+});
+
+describe('routing runners are refused out of zone (requiresRouting flag)', () => {
+  beforeEach(() => useTripStore.setState({ outOfZone: true }));
+
+  it('runMoveStage', async () => {
+    const onFailure = jest.fn();
+    expect(await runMoveStage('t1', 0, 1, ctx(), onFailure)).toBe(false);
+    expect(onFailure).toHaveBeenCalledWith('out_of_zone');
+    expect(moveStage).not.toHaveBeenCalled();
+    expect(useTripStore.getState().stages).toHaveLength(2);
+  });
+
+  it('runDeselectAccommodation', async () => {
+    const onFailure = jest.fn();
+    expect(await runDeselectAccommodation('t1', 0, ctx(), onFailure)).toBe(false);
+    expect(onFailure).toHaveBeenCalledWith('out_of_zone');
+    expect(setStageAccommodation).not.toHaveBeenCalled();
+  });
+
+  it('runAddPoiWaypoint', async () => {
+    const onFailure = jest.fn();
+    expect(await runAddPoiWaypoint('t1', 0, 1, 2, ctx(), onFailure)).toBe(false);
+    expect(onFailure).toHaveBeenCalledWith('out_of_zone');
+    expect(addPoiWaypoint).not.toHaveBeenCalled();
+  });
+});
+
+describe('runMoveStage (routing) — optimistic + rollback', () => {
+  beforeEach(() => {
+    useTripStore.setState({
+      stages: [
+        stage({ dayNumber: 1, distance: 10 }),
+        stage({ dayNumber: 2, distance: 20 }),
+      ],
+    });
+  });
+
+  it('moves optimistically then calls the API', async () => {
+    mock(moveStage).mockResolvedValue({ ok: true, status: 202 });
+    expect(await runMoveStage('t1', 1, 0, ctx(), jest.fn())).toBe(true);
+    expect(useTripStore.getState().stages.map((s) => s.distance)).toEqual([
+      20, 10,
+    ]);
+    expect(moveStage).toHaveBeenCalledWith('t1', 1, 0);
+  });
+
+  it('rolls back the stage order on 409', async () => {
+    const before = useTripStore.getState().stages.map((s) => s.distance);
+    mock(moveStage).mockResolvedValue({ ok: false, status: 409 });
+    const onFailure = jest.fn();
+    expect(await runMoveStage('t1', 1, 0, ctx(), onFailure)).toBe(false);
+    expect(useTripStore.getState().stages.map((s) => s.distance)).toEqual(before);
+    expect(onFailure).toHaveBeenCalledWith('conflict');
+  });
+});
+
+describe('runDeselectAccommodation (routing) — optimistic + rollback', () => {
+  const acc = { name: 'Gite', lat: 9, lon: 9 } as never;
+
+  beforeEach(() => {
+    useTripStore.setState({
+      stages: [stage({ selectedAccommodation: acc }), stage()],
+    });
+  });
+
+  it('clears the selection optimistically then calls the API with null coords', async () => {
+    mock(setStageAccommodation).mockResolvedValue({ ok: true, status: 202 });
+    expect(await runDeselectAccommodation('t1', 0, ctx(), jest.fn())).toBe(true);
+    expect(useTripStore.getState().stages[0]!.selectedAccommodation).toBeNull();
+    expect(setStageAccommodation).toHaveBeenCalledWith('t1', 0, null, null);
+  });
+
+  it('rolls back the selection on 409', async () => {
+    mock(setStageAccommodation).mockResolvedValue({ ok: false, status: 409 });
+    const onFailure = jest.fn();
+    expect(await runDeselectAccommodation('t1', 0, ctx(), onFailure)).toBe(false);
+    expect(useTripStore.getState().stages[0]!.selectedAccommodation).toEqual(acc);
+    expect(onFailure).toHaveBeenCalledWith('conflict');
+  });
+});
+
+describe('runAddPoiWaypoint (routing) — calls the API in zone', () => {
+  it('adds the waypoint when allowed', async () => {
+    mock(addPoiWaypoint).mockResolvedValue({ ok: true, status: 202 });
+    expect(await runAddPoiWaypoint('t1', 0, 1.5, 2.5, ctx(), jest.fn())).toBe(
+      true,
+    );
+    expect(addPoiWaypoint).toHaveBeenCalledWith('t1', 0, 1.5, 2.5);
   });
 });
 

--- a/mobile/src/store/mutations.test.ts
+++ b/mobile/src/store/mutations.test.ts
@@ -1,0 +1,273 @@
+/// <reference types="jest" />
+import type { StageData } from '@btp/core';
+import {
+  runAddStage,
+  runAnalyze,
+  runApplyBatch,
+  runDeleteTrip,
+  runDuplicateTrip,
+  runScanAccommodations,
+  runSelectAccommodation,
+  runUpdateDates,
+  runUpdateStageDistance,
+} from './mutations';
+import { useTripStore } from './trip-store';
+import { useOfflineStore } from './offline-store';
+
+jest.mock('../api/trips', () => ({
+  updateTripConfig: jest.fn(),
+  createStage: jest.fn(),
+  updateStageDistance: jest.fn(),
+  moveStage: jest.fn(),
+  insertRestDay: jest.fn(),
+  setStageAccommodation: jest.fn(),
+  addPoiWaypoint: jest.fn(),
+  scanAccommodations: jest.fn(),
+  applyBatchRecompute: jest.fn(),
+  analyzeTrip: jest.fn(),
+  duplicateTrip: jest.fn(),
+  deleteTrip: jest.fn(),
+}));
+
+import {
+  updateTripConfig,
+  createStage,
+  updateStageDistance,
+  setStageAccommodation,
+  scanAccommodations,
+  applyBatchRecompute,
+  analyzeTrip,
+  duplicateTrip,
+  deleteTrip,
+} from '../api/trips';
+
+const mock = <T extends (...args: never[]) => unknown>(fn: T) =>
+  fn as unknown as jest.MockedFunction<T>;
+
+const P = { lat: 0, lon: 0, ele: 0 };
+
+function stage(overrides: Partial<StageData> = {}): StageData {
+  return {
+    dayNumber: 1,
+    distance: 50,
+    elevation: 0,
+    elevationLoss: 0,
+    startPoint: P,
+    endPoint: { lat: 1, lon: 1, ele: 0 },
+    geometry: [],
+    label: null,
+    startLabel: null,
+    endLabel: null,
+    weather: null,
+    alerts: [],
+    pois: [],
+    accommodations: [],
+    selectedAccommodation: null,
+    accommodationSearchRadiusKm: 5,
+    isRestDay: false,
+    supplyTimeline: [],
+    events: [],
+    ...overrides,
+  };
+}
+
+const ctx = () => useTripStore.getState();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useTripStore.getState().reset();
+  useOfflineStore.setState({ isOnline: true });
+  useTripStore.setState({
+    stages: [stage({ dayNumber: 1 }), stage({ dayNumber: 2 })],
+    isLocked: false,
+    outOfZone: false,
+    startDate: '2026-08-01',
+    endDate: '2026-08-02',
+    loading: false,
+  });
+});
+
+describe('runUpdateDates (config, non-routing)', () => {
+  it('applies optimistically and sends the full pacing patch on success', async () => {
+    mock(updateTripConfig).mockResolvedValue({ ok: true, status: 202 });
+
+    const ok = await runUpdateDates(
+      't1',
+      '2026-09-01',
+      '2026-09-10',
+      ctx(),
+      jest.fn(),
+    );
+
+    expect(ok).toBe(true);
+    expect(useTripStore.getState().startDate).toBe('2026-09-01');
+    const body = mock(updateTripConfig).mock.calls[0]![1];
+    expect(body.startDate).toBe('2026-09-01');
+    expect(body.fatigueFactor).toBe(useTripStore.getState().fatigueFactor);
+  });
+
+  it('rolls back the optimistic dates and reports "validation" on 422', async () => {
+    mock(updateTripConfig).mockResolvedValue({ ok: false, status: 422 });
+    const onFailure = jest.fn();
+
+    const ok = await runUpdateDates('t1', '2026-09-01', null, ctx(), onFailure);
+
+    expect(ok).toBe(false);
+    expect(useTripStore.getState().startDate).toBe('2026-08-01');
+    expect(onFailure).toHaveBeenCalledWith('validation');
+  });
+});
+
+describe('runAddStage (routing) — gating', () => {
+  it('is refused out of zone without an optimistic edit or API call', async () => {
+    useTripStore.setState({ outOfZone: true });
+    const onFailure = jest.fn();
+
+    const ok = await runAddStage('t1', 0, ctx(), onFailure);
+
+    expect(ok).toBe(false);
+    expect(onFailure).toHaveBeenCalledWith('out_of_zone');
+    expect(useTripStore.getState().stages).toHaveLength(2);
+    expect(createStage).not.toHaveBeenCalled();
+  });
+
+  it('inserts optimistically then calls the API in zone', async () => {
+    mock(createStage).mockResolvedValue({ ok: true, status: 202 });
+
+    const ok = await runAddStage('t1', 0, ctx(), jest.fn());
+
+    expect(ok).toBe(true);
+    expect(useTripStore.getState().stages).toHaveLength(3);
+    expect(createStage).toHaveBeenCalledWith(
+      't1',
+      expect.objectContaining({ position: 1 }),
+    );
+  });
+});
+
+describe('runUpdateStageDistance (routing) — gating branches', () => {
+  it('is refused when the trip is locked (423)', async () => {
+    useTripStore.setState({ isLocked: true });
+    const onFailure = jest.fn();
+
+    const ok = await runUpdateStageDistance('t1', 0, 42, ctx(), onFailure);
+
+    expect(ok).toBe(false);
+    expect(onFailure).toHaveBeenCalledWith('locked');
+    expect(updateStageDistance).not.toHaveBeenCalled();
+  });
+
+  it('is refused while offline', async () => {
+    useOfflineStore.setState({ isOnline: false });
+    const onFailure = jest.fn();
+
+    const ok = await runUpdateStageDistance('t1', 0, 42, ctx(), onFailure);
+
+    expect(ok).toBe(false);
+    expect(onFailure).toHaveBeenCalledWith('offline');
+    expect(updateStageDistance).not.toHaveBeenCalled();
+  });
+
+  it('calls the API when allowed', async () => {
+    mock(updateStageDistance).mockResolvedValue({ ok: true, status: 202 });
+    const ok = await runUpdateStageDistance('t1', 0, 42, ctx(), jest.fn());
+    expect(ok).toBe(true);
+    expect(updateStageDistance).toHaveBeenCalledWith('t1', 0, 42);
+  });
+});
+
+describe('runSelectAccommodation', () => {
+  it('rolls back and reports "conflict" on 409 (stale list)', async () => {
+    useTripStore.setState({
+      stages: [
+        stage({ accommodations: [{ name: 'Gite', lat: 9, lon: 9 } as never] }),
+        stage(),
+      ],
+    });
+    mock(setStageAccommodation).mockResolvedValue({ ok: false, status: 409 });
+    const onFailure = jest.fn();
+
+    const ok = await runSelectAccommodation('t1', 0, 0, ctx(), onFailure);
+
+    expect(ok).toBe(false);
+    expect(onFailure).toHaveBeenCalledWith('conflict');
+    expect(useTripStore.getState().stages[0]!.selectedAccommodation).toBeNull();
+  });
+});
+
+describe('runScanAccommodations (non-routing) — allowed out of zone', () => {
+  it('calls the API even out of zone (scan does not reroute)', async () => {
+    useTripStore.setState({ outOfZone: true });
+    mock(scanAccommodations).mockResolvedValue({ ok: true, status: 202 });
+
+    const ok = await runScanAccommodations('t1', 7, 0, ctx(), jest.fn());
+
+    expect(ok).toBe(true);
+    expect(scanAccommodations).toHaveBeenCalledWith('t1', 7, 0);
+  });
+});
+
+describe('runApplyBatch (recompute queue)', () => {
+  it('no-ops on an empty queue', async () => {
+    const ok = await runApplyBatch('t1', ctx(), jest.fn());
+    expect(ok).toBe(false);
+    expect(applyBatchRecompute).not.toHaveBeenCalled();
+  });
+
+  it('sends the queued modifications and clears the queue on success', async () => {
+    useTripStore.setState({
+      pendingModifications: [
+        { stageIndex: 0, type: 'distance', label: 'd' },
+        { stageIndex: null, type: 'pacing', label: 'p' },
+      ],
+    });
+    mock(applyBatchRecompute).mockResolvedValue({ ok: true, status: 202 });
+
+    const ok = await runApplyBatch('t1', ctx(), jest.fn());
+
+    expect(ok).toBe(true);
+    expect(applyBatchRecompute).toHaveBeenCalledWith(
+      't1',
+      expect.arrayContaining([expect.objectContaining({ type: 'distance' })]),
+    );
+    expect(useTripStore.getState().pendingModifications).toHaveLength(0);
+  });
+});
+
+describe('runAnalyze / lifecycle', () => {
+  it('runAnalyze is refused on a locked trip', async () => {
+    useTripStore.setState({ isLocked: true });
+    const onFailure = jest.fn();
+    const ok = await runAnalyze('t1', ctx(), onFailure);
+    expect(ok).toBe(false);
+    expect(onFailure).toHaveBeenCalledWith('locked');
+    expect(analyzeTrip).not.toHaveBeenCalled();
+  });
+
+  it('runDuplicateTrip is allowed on a locked trip and returns the new id', async () => {
+    useTripStore.setState({ isLocked: true });
+    mock(duplicateTrip).mockResolvedValue('t2');
+    const id = await runDuplicateTrip('t1', ctx(), jest.fn());
+    expect(id).toBe('t2');
+  });
+
+  it('runDuplicateTrip is refused offline', async () => {
+    useOfflineStore.setState({ isOnline: false });
+    const onFailure = jest.fn();
+    const id = await runDuplicateTrip('t1', ctx(), onFailure);
+    expect(id).toBeNull();
+    expect(onFailure).toHaveBeenCalledWith('offline');
+    expect(duplicateTrip).not.toHaveBeenCalled();
+  });
+
+  it('runDeleteTrip is refused offline and succeeds online', async () => {
+    const onFailure = jest.fn();
+    useOfflineStore.setState({ isOnline: false });
+    expect(await runDeleteTrip('t1', ctx(), onFailure)).toBe(false);
+    expect(onFailure).toHaveBeenCalledWith('offline');
+
+    useOfflineStore.setState({ isOnline: true });
+    mock(deleteTrip).mockResolvedValue({ ok: true, status: 204 });
+    expect(await runDeleteTrip('t1', ctx(), jest.fn())).toBe(true);
+  });
+});

--- a/mobile/src/store/mutations.ts
+++ b/mobile/src/store/mutations.ts
@@ -1,0 +1,529 @@
+import type { StageData } from '@btp/core';
+import { DEFAULT_ACCOMMODATION_RADIUS_KM } from '@btp/core/constants';
+import {
+  addPoiWaypoint,
+  analyzeTrip,
+  applyBatchRecompute,
+  createStage,
+  deleteTrip,
+  duplicateTrip,
+  insertRestDay,
+  moveStage,
+  scanAccommodations,
+  setStageAccommodation,
+  updateStageDistance,
+  updateTripConfig,
+  type Coordinate,
+  type MutationResult,
+  type TripConfigPatch,
+} from '../api/trips';
+import {
+  evaluateGate,
+  normalizeStatus,
+  type GateState,
+  type MutationFailure,
+} from './gating';
+import { useOfflineStore } from './offline-store';
+import type { Modification, TripConfig } from './trip-store';
+
+// The store slice + actions the mutation runners drive. `useTripStore.getState()`
+// satisfies it structurally, so a runner takes a live snapshot (the actions are
+// stable, and the pre-edit `stages` snapshot is captured up front for rollback).
+export interface MutationContext extends TripConfig {
+  isLocked: boolean;
+  outOfZone: boolean;
+  title: string | null;
+  stages: StageData[];
+  pendingModifications: Modification[];
+  setStages: (stages: StageData[]) => void;
+  setConfig: (patch: Partial<TripConfig>) => void;
+  setTitle: (title: string) => void;
+  insertRestDayOptimistic: (afterIndex: number) => void;
+  insertStageOptimistic: (afterIndex: number, placeholder: StageData) => void;
+  moveStageOptimistic: (fromIndex: number, toIndex: number) => void;
+  selectAccommodationOptimistic: (
+    stageIndex: number,
+    accIndex: number,
+    nextStageIndex: number | null,
+  ) => void;
+  deselectAccommodationOptimistic: (stageIndex: number) => void;
+  deleteStageOptimistic: (index: number) => void;
+  clearPendingModifications: () => void;
+}
+
+/** Report the outcome of a mutation: null on success, a reason on failure. */
+export type OnFailure = (reason: MutationFailure) => void;
+
+// Build the gate state from the store + the shared offline flag (offline lives
+// in its own store so it is readable without a trip loaded).
+function gateOf(ctx: Pick<MutationContext, 'isLocked' | 'outOfZone'>): GateState {
+  return {
+    isLocked: ctx.isLocked,
+    outOfZone: ctx.outOfZone,
+    isOnline: useOfflineStore.getState().isOnline,
+  };
+}
+
+/**
+ * Shared mutation shell: pre-flight gate → optional optimistic apply → API call
+ * → normalized failure + rollback. Every runner funnels through here so gating,
+ * error classification and the rollback discipline stay identical across screens
+ * (#1031). Returns true only when the backend accepted the mutation.
+ */
+export async function run(
+  ctx: MutationContext,
+  opts: {
+    requiresRouting: boolean;
+    call: () => Promise<MutationResult>;
+    optimistic?: () => void;
+    rollback?: () => void;
+  },
+  onFailure: OnFailure,
+): Promise<boolean> {
+  const blocked = evaluateGate(gateOf(ctx), opts.requiresRouting);
+  if (blocked) {
+    onFailure(blocked);
+    return false;
+  }
+  opts.optimistic?.();
+  try {
+    const { ok, status } = await opts.call();
+    if (!ok) {
+      opts.rollback?.();
+      onFailure(normalizeStatus(status));
+      return false;
+    }
+    return true;
+  } catch {
+    opts.rollback?.();
+    onFailure('network');
+    return false;
+  }
+}
+
+// Assemble a full JSON Merge Patch body from the current config + overrides. The
+// backend PATCH schema requires the whole pacing block, so send it every time.
+function configPatch(
+  ctx: MutationContext,
+  overrides: Partial<TripConfigPatch>,
+): TripConfigPatch {
+  return {
+    fatigueFactor: ctx.fatigueFactor,
+    elevationPenalty: ctx.elevationPenalty,
+    maxDistancePerDay: ctx.maxDistancePerDay,
+    averageSpeed: ctx.averageSpeed,
+    ebikeMode: ctx.ebikeMode,
+    departureHour: ctx.departureHour,
+    enabledAccommodationTypes: ctx.enabledAccommodationTypes,
+    startDate: ctx.startDate,
+    endDate: ctx.endDate,
+    ...overrides,
+  };
+}
+
+// --- Trip-level config (no Valhalla rerouting → requiresRouting: false) -------
+
+export function runUpdateDates(
+  tripId: string,
+  startDate: string | null,
+  endDate: string | null,
+  ctx: MutationContext,
+  onFailure: OnFailure,
+): Promise<boolean> {
+  const snapshot = { startDate: ctx.startDate, endDate: ctx.endDate };
+  return run(
+    ctx,
+    {
+      requiresRouting: false,
+      optimistic: () => ctx.setConfig({ startDate, endDate }),
+      rollback: () => ctx.setConfig(snapshot),
+      call: () =>
+        updateTripConfig(tripId, configPatch(ctx, { startDate, endDate })),
+    },
+    onFailure,
+  );
+}
+
+export function runUpdatePacing(
+  tripId: string,
+  pacing: Pick<
+    TripConfig,
+    | 'fatigueFactor'
+    | 'elevationPenalty'
+    | 'maxDistancePerDay'
+    | 'averageSpeed'
+    | 'ebikeMode'
+    | 'departureHour'
+  >,
+  ctx: MutationContext,
+  onFailure: OnFailure,
+): Promise<boolean> {
+  const snapshot: Partial<TripConfig> = {
+    fatigueFactor: ctx.fatigueFactor,
+    elevationPenalty: ctx.elevationPenalty,
+    maxDistancePerDay: ctx.maxDistancePerDay,
+    averageSpeed: ctx.averageSpeed,
+    ebikeMode: ctx.ebikeMode,
+    departureHour: ctx.departureHour,
+  };
+  return run(
+    ctx,
+    {
+      requiresRouting: false,
+      optimistic: () => ctx.setConfig(pacing),
+      rollback: () => ctx.setConfig(snapshot),
+      call: () => updateTripConfig(tripId, configPatch(ctx, pacing)),
+    },
+    onFailure,
+  );
+}
+
+export function runUpdateAccommodationTypes(
+  tripId: string,
+  types: string[],
+  ctx: MutationContext,
+  onFailure: OnFailure,
+): Promise<boolean> {
+  const snapshot = ctx.enabledAccommodationTypes;
+  return run(
+    ctx,
+    {
+      requiresRouting: false,
+      optimistic: () => ctx.setConfig({ enabledAccommodationTypes: types }),
+      rollback: () => ctx.setConfig({ enabledAccommodationTypes: snapshot }),
+      call: () =>
+        updateTripConfig(
+          tripId,
+          configPatch(ctx, { enabledAccommodationTypes: types }),
+        ),
+    },
+    onFailure,
+  );
+}
+
+export function runUpdateTitle(
+  tripId: string,
+  title: string,
+  ctx: MutationContext,
+  onFailure: OnFailure,
+): Promise<boolean> {
+  const snapshot = ctx.title ?? '';
+  return run(
+    ctx,
+    {
+      requiresRouting: false,
+      optimistic: () => ctx.setTitle(title),
+      rollback: () => ctx.setTitle(snapshot),
+      call: () => updateTripConfig(tripId, configPatch(ctx, { title })),
+    },
+    onFailure,
+  );
+}
+
+// --- Stage structural edits ---------------------------------------------------
+// (runDeleteStage lives in delete-stage.ts, its own thin wrapper from #1015; it
+// composes the same `run` shell so gating/rollback stay identical.)
+
+export function runInsertRestDay(
+  tripId: string,
+  afterIndex: number,
+  ctx: MutationContext,
+  onFailure: OnFailure,
+): Promise<boolean> {
+  const snapshot = ctx.stages;
+  return run(
+    ctx,
+    {
+      // Inserting a rest day keeps the next startPoint identical: no reroute.
+      requiresRouting: false,
+      optimistic: () => ctx.insertRestDayOptimistic(afterIndex),
+      rollback: () => ctx.setStages(snapshot),
+      call: () => insertRestDay(tripId, afterIndex),
+    },
+    onFailure,
+  );
+}
+
+export function runAddStage(
+  tripId: string,
+  afterIndex: number,
+  ctx: MutationContext,
+  onFailure: OnFailure,
+): Promise<boolean> {
+  const prev = ctx.stages[afterIndex];
+  const next = ctx.stages[afterIndex + 1];
+  const startPoint = prev?.endPoint ?? prev?.startPoint;
+  const endPoint = next?.startPoint ?? prev?.endPoint;
+  if (!startPoint || !endPoint) {
+    onFailure('error');
+    return Promise.resolve(false);
+  }
+  const placeholder: StageData = {
+    dayNumber: afterIndex + 2,
+    distance: 0,
+    elevation: 0,
+    elevationLoss: 0,
+    startPoint: { lat: startPoint.lat, lon: startPoint.lon, ele: startPoint.ele },
+    endPoint: { lat: endPoint.lat, lon: endPoint.lon, ele: endPoint.ele },
+    geometry: [],
+    label: null,
+    startLabel: prev?.endLabel ?? null,
+    endLabel: next?.startLabel ?? null,
+    weather: null,
+    alerts: [],
+    pois: [],
+    accommodations: [],
+    selectedAccommodation: null,
+    accommodationSearchRadiusKm: DEFAULT_ACCOMMODATION_RADIUS_KM,
+    isRestDay: false,
+    supplyTimeline: [],
+    events: [],
+  };
+  const snapshot = ctx.stages;
+  const start: Coordinate = { ...startPoint };
+  const end: Coordinate = { ...endPoint };
+  return run(
+    ctx,
+    {
+      // A manual stage is routed via Valhalla → blocked out of zone.
+      requiresRouting: true,
+      optimistic: () => ctx.insertStageOptimistic(afterIndex, placeholder),
+      rollback: () => ctx.setStages(snapshot),
+      call: () =>
+        createStage(tripId, {
+          position: afterIndex + 1,
+          startPoint: start,
+          endPoint: end,
+        }),
+    },
+    onFailure,
+  );
+}
+
+export function runUpdateStageDistance(
+  tripId: string,
+  index: number,
+  distance: number,
+  ctx: MutationContext,
+  onFailure: OnFailure,
+): Promise<boolean> {
+  // No optimistic geometry change: the backend re-splits and streams the
+  // authoritative stages over SSE. Re-splitting reroutes → routing gate.
+  return run(
+    ctx,
+    {
+      requiresRouting: true,
+      call: () => updateStageDistance(tripId, index, distance),
+    },
+    onFailure,
+  );
+}
+
+export function runMoveStage(
+  tripId: string,
+  fromIndex: number,
+  toIndex: number,
+  ctx: MutationContext,
+  onFailure: OnFailure,
+): Promise<boolean> {
+  const snapshot = ctx.stages;
+  return run(
+    ctx,
+    {
+      requiresRouting: true,
+      optimistic: () => ctx.moveStageOptimistic(fromIndex, toIndex),
+      rollback: () => ctx.setStages(snapshot),
+      call: () => moveStage(tripId, fromIndex, toIndex),
+    },
+    onFailure,
+  );
+}
+
+// --- Accommodation ------------------------------------------------------------
+
+export function runSelectAccommodation(
+  tripId: string,
+  stageIndex: number,
+  accIndex: number,
+  ctx: MutationContext,
+  onFailure: OnFailure,
+): Promise<boolean> {
+  const acc = ctx.stages[stageIndex]?.accommodations[accIndex];
+  if (!acc) {
+    onFailure('error');
+    return Promise.resolve(false);
+  }
+  const nextStageIndex =
+    stageIndex + 1 < ctx.stages.length ? stageIndex + 1 : null;
+  const snapshot = ctx.stages;
+  return run(
+    ctx,
+    {
+      // Selecting shifts the stage endpoint → the stage is re-routed.
+      requiresRouting: true,
+      optimistic: () =>
+        ctx.selectAccommodationOptimistic(stageIndex, accIndex, nextStageIndex),
+      rollback: () => ctx.setStages(snapshot),
+      call: () => setStageAccommodation(tripId, stageIndex, acc.lat, acc.lon),
+    },
+    onFailure,
+  );
+}
+
+export function runDeselectAccommodation(
+  tripId: string,
+  stageIndex: number,
+  ctx: MutationContext,
+  onFailure: OnFailure,
+): Promise<boolean> {
+  const snapshot = ctx.stages;
+  return run(
+    ctx,
+    {
+      requiresRouting: true,
+      optimistic: () => ctx.deselectAccommodationOptimistic(stageIndex),
+      rollback: () => ctx.setStages(snapshot),
+      call: () => setStageAccommodation(tripId, stageIndex, null, null),
+    },
+    onFailure,
+  );
+}
+
+export function runScanAccommodations(
+  tripId: string,
+  radiusKm: number,
+  stageIndex: number | undefined,
+  ctx: MutationContext,
+  onFailure: OnFailure,
+): Promise<boolean> {
+  // A scan reads POIs; it does not reroute → no zone gate.
+  return run(
+    ctx,
+    {
+      requiresRouting: false,
+      call: () => scanAccommodations(tripId, radiusKm, stageIndex),
+    },
+    onFailure,
+  );
+}
+
+// --- Route waypoint -----------------------------------------------------------
+
+export function runAddPoiWaypoint(
+  tripId: string,
+  stageIndex: number,
+  lat: number,
+  lon: number,
+  ctx: MutationContext,
+  onFailure: OnFailure,
+): Promise<boolean> {
+  return run(
+    ctx,
+    {
+      requiresRouting: true,
+      call: () => addPoiWaypoint(tripId, stageIndex, lat, lon),
+    },
+    onFailure,
+  );
+}
+
+// --- Batch recompute + analyze ------------------------------------------------
+
+export function runApplyBatch(
+  tripId: string,
+  ctx: MutationContext,
+  onFailure: OnFailure,
+): Promise<boolean> {
+  const mods = ctx.pendingModifications;
+  if (mods.length === 0) return Promise.resolve(false);
+  // A distance or accommodation edit reroutes; a pure dates/pacing batch does not.
+  const requiresRouting = mods.some(
+    (m) => m.type === 'distance' || m.type === 'accommodation',
+  );
+  return run(
+    ctx,
+    {
+      requiresRouting,
+      call: () =>
+        applyBatchRecompute(
+          tripId,
+          mods.map((m) => ({
+            stageIndex: m.stageIndex,
+            type: m.type,
+            label: m.label,
+          })),
+        ),
+    },
+    onFailure,
+  ).then((ok) => {
+    if (ok) ctx.clearPendingModifications();
+    return ok;
+  });
+}
+
+export function runAnalyze(
+  tripId: string,
+  ctx: MutationContext,
+  onFailure: OnFailure,
+): Promise<boolean> {
+  // Re-enrichment (POIs, weather, terrain): no Valhalla reroute.
+  return run(
+    ctx,
+    { requiresRouting: false, call: () => analyzeTrip(tripId) },
+    onFailure,
+  );
+}
+
+// --- Trip lifecycle -----------------------------------------------------------
+
+/**
+ * Duplicate the trip. Allowed on a started (locked) or out-of-zone trip — it
+ * clones rather than edits — but not offline. Returns the new id, or null with
+ * the failure reported.
+ */
+export async function runDuplicateTrip(
+  tripId: string,
+  _ctx: MutationContext,
+  onFailure: OnFailure,
+): Promise<string | null> {
+  if (!useOfflineStore.getState().isOnline) {
+    onFailure('offline');
+    return null;
+  }
+  try {
+    const id = await duplicateTrip(tripId);
+    if (!id) {
+      onFailure('error');
+      return null;
+    }
+    return id;
+  } catch {
+    onFailure('network');
+    return null;
+  }
+}
+
+/** Delete the whole trip. Blocked only while offline (a lock does not apply). */
+export function runDeleteTrip(
+  tripId: string,
+  ctx: MutationContext,
+  onFailure: OnFailure,
+): Promise<boolean> {
+  const online = useOfflineStore.getState().isOnline;
+  if (!online) {
+    onFailure('offline');
+    return Promise.resolve(false);
+  }
+  return deleteTrip(tripId)
+    .then(({ ok, status }) => {
+      if (!ok) {
+        onFailure(normalizeStatus(status));
+        return false;
+      }
+      return true;
+    })
+    .catch(() => {
+      onFailure('network');
+      return false;
+    });
+}

--- a/mobile/src/store/offline-store.ts
+++ b/mobile/src/store/offline-store.ts
@@ -1,0 +1,16 @@
+import { create } from 'zustand';
+
+interface OfflineState {
+  isOnline: boolean;
+  setOnline: (value: boolean) => void;
+}
+
+// Connectivity flag consulted by the mutation gate (see gating.ts). Mirrors the
+// web `offline-store` but stays transport-agnostic: a later sprint wires it to
+// React Native's NetInfo listener; until then it defaults online. Kept in its
+// own store (not trip-store) so it survives trip switches and can be read from
+// the mutation runners without a trip loaded.
+export const useOfflineStore = create<OfflineState>((set) => ({
+  isOnline: true,
+  setOnline: (value) => set({ isOnline: value }),
+}));

--- a/mobile/src/store/trip-store.test.ts
+++ b/mobile/src/store/trip-store.test.ts
@@ -181,6 +181,26 @@ describe('mobile trip store — config + optimistic structural edits (#1031)', (
     expect(s.stages[1]!.startPoint).toEqual({ lat: 9, lon: 9, ele: 0 });
   });
 
+  it('deselectAccommodationOptimistic clears the selection but leaves endPoint for SSE', () => {
+    const acc = { name: 'Gite', lat: 9, lon: 9 } as StageData['accommodations'][number];
+    useTripStore.setState({
+      stages: [
+        stageData({
+          accommodations: [acc],
+          selectedAccommodation: acc,
+          endPoint: { lat: 9, lon: 9, ele: 0 },
+        }),
+      ],
+      loading: false,
+    });
+    useTripStore.getState().deselectAccommodationOptimistic(0);
+    const s = useTripStore.getState();
+    expect(s.stages[0]!.selectedAccommodation).toBeNull();
+    // endPoint stays pinned to the former accommodation until the recompute
+    // reconciles it — documented transient behavior, not reverted here.
+    expect(s.stages[0]!.endPoint).toEqual({ lat: 9, lon: 9, ele: 0 });
+  });
+
   it('queueModification appends then replaces a duplicate (same type+index)', () => {
     const q = () => useTripStore.getState().queueModification;
     q()({ stageIndex: 0, type: 'distance', label: 'a' });

--- a/mobile/src/store/trip-store.test.ts
+++ b/mobile/src/store/trip-store.test.ts
@@ -101,3 +101,95 @@ describe('mobile trip store (thin wrapper composing core reducers, #1014)', () =
     expect(useTripStore.getState().stages[0]!.accommodations).toEqual([acc]);
   });
 });
+
+describe('mobile trip store — config + optimistic structural edits (#1031)', () => {
+  it('hydrates the editable config slice, outOfZone and lock from /detail', () => {
+    useTripStore.getState().hydrate('t1', {
+      title: 'Trip',
+      stages: [],
+      isLocked: true,
+      outOfZone: true,
+      startDate: '2026-08-01',
+      endDate: '2026-08-05',
+      fatigueFactor: 0.7,
+      maxDistancePerDay: 120,
+      enabledAccommodationTypes: ['hotel'],
+    } as unknown as TripDetail);
+    const s = useTripStore.getState();
+    expect(s.isLocked).toBe(true);
+    expect(s.outOfZone).toBe(true);
+    expect(s.startDate).toBe('2026-08-01');
+    expect(s.fatigueFactor).toBe(0.7);
+    expect(s.maxDistancePerDay).toBe(120);
+    expect(s.enabledAccommodationTypes).toEqual(['hotel']);
+  });
+
+  it('insertRestDayOptimistic inserts a rest day, renumbers, extends endDate', () => {
+    useTripStore.setState({
+      stages: [stageData({ dayNumber: 1 }), stageData({ dayNumber: 2 })],
+      startDate: '2026-08-01',
+      endDate: '2026-08-02',
+      loading: false,
+    });
+    useTripStore.getState().insertRestDayOptimistic(0);
+    const s = useTripStore.getState();
+    expect(s.stages.map((x) => x.dayNumber)).toEqual([1, 2, 3]);
+    expect(s.stages[1]!.isRestDay).toBe(true);
+    expect(s.endDate).toBe('2026-08-03');
+  });
+
+  it('insertStageOptimistic splices a placeholder and renumbers', () => {
+    useTripStore.setState({
+      stages: [stageData({ dayNumber: 1 }), stageData({ dayNumber: 2 })],
+      loading: false,
+    });
+    useTripStore.getState().insertStageOptimistic(0, stageData({ distance: 7 }));
+    const s = useTripStore.getState();
+    expect(s.stages).toHaveLength(3);
+    expect(s.stages[1]!.distance).toBe(7);
+    expect(s.stages.map((x) => x.dayNumber)).toEqual([1, 2, 3]);
+  });
+
+  it('moveStageOptimistic reorders and renumbers', () => {
+    useTripStore.setState({
+      stages: [
+        stageData({ dayNumber: 1, distance: 10 }),
+        stageData({ dayNumber: 2, distance: 20 }),
+        stageData({ dayNumber: 3, distance: 30 }),
+      ],
+      loading: false,
+    });
+    useTripStore.getState().moveStageOptimistic(2, 0);
+    const s = useTripStore.getState();
+    expect(s.stages.map((x) => x.distance)).toEqual([30, 10, 20]);
+    expect(s.stages.map((x) => x.dayNumber)).toEqual([1, 2, 3]);
+  });
+
+  it('selectAccommodationOptimistic pins the acc and shifts endpoints', () => {
+    const acc = { name: 'Gite', lat: 9, lon: 9 } as StageData['accommodations'][number];
+    useTripStore.setState({
+      stages: [
+        stageData({ accommodations: [acc] }),
+        stageData({ startPoint: { lat: 0, lon: 0, ele: 0 } }),
+      ],
+      loading: false,
+    });
+    useTripStore.getState().selectAccommodationOptimistic(0, 0, 1);
+    const s = useTripStore.getState();
+    expect(s.stages[0]!.selectedAccommodation).toEqual(acc);
+    expect(s.stages[0]!.endPoint).toEqual({ lat: 9, lon: 9, ele: 0 });
+    expect(s.stages[1]!.startPoint).toEqual({ lat: 9, lon: 9, ele: 0 });
+  });
+
+  it('queueModification appends then replaces a duplicate (same type+index)', () => {
+    const q = () => useTripStore.getState().queueModification;
+    q()({ stageIndex: 0, type: 'distance', label: 'a' });
+    q()({ stageIndex: 1, type: 'distance', label: 'b' });
+    q()({ stageIndex: 0, type: 'distance', label: 'a2' });
+    const mods = useTripStore.getState().pendingModifications;
+    expect(mods).toHaveLength(2);
+    expect(mods[0]!.label).toBe('a2');
+    useTripStore.getState().cancelAllModifications();
+    expect(useTripStore.getState().pendingModifications).toHaveLength(0);
+  });
+});

--- a/mobile/src/store/trip-store.ts
+++ b/mobile/src/store/trip-store.ts
@@ -274,6 +274,11 @@ export const useTripStore = create<TripState>((set, get) => ({
       });
       return { stages };
     }),
+  // Only clears the selection. Unlike selectAccommodationOptimistic we do NOT
+  // revert endPoint / the next startPoint: the pre-selection route endpoint is
+  // not retained here, so the stage stays pinned to the former accommodation
+  // until the SSE recompute streams the authoritative geometry. A transient,
+  // self-healing inconsistency by design (rerouting → requiresRouting: true).
   deselectAccommodationOptimistic: (stageIndex) =>
     set((state) => ({
       stages: state.stages.map((s, i) =>

--- a/mobile/src/store/trip-store.ts
+++ b/mobile/src/store/trip-store.ts
@@ -46,13 +46,80 @@ export function stageDataFromDetail(s: ApiStage): StageData {
   };
 }
 
-interface TripState {
+/**
+ * A single user modification accumulated in the batch queue before being sent
+ * in one `POST /trips/{id}/recompute` pass. Mirrors the web store's shape and
+ * the backend `TripModification` (type ↔ re-dispatched handlers).
+ */
+export interface Modification {
+  /** Zero-based stage index. Null for trip-level changes (dates, pacing). */
+  stageIndex: number | null;
+  type: 'accommodation' | 'distance' | 'dates' | 'pacing';
+  /** Human-readable description for the queue panel. */
+  label: string;
+}
+
+/** Editable pacing / dates / preferences slice, mirrored from the web store. */
+export interface TripConfig {
+  startDate: string | null;
+  endDate: string | null;
+  fatigueFactor: number;
+  elevationPenalty: number;
+  maxDistancePerDay: number;
+  averageSpeed: number;
+  ebikeMode: boolean;
+  departureHour: number;
+  enabledAccommodationTypes: string[];
+}
+
+const DEFAULT_CONFIG: TripConfig = {
+  startDate: null,
+  endDate: null,
+  fatigueFactor: 0.9,
+  elevationPenalty: 50,
+  maxDistancePerDay: 80,
+  averageSpeed: 15,
+  ebikeMode: false,
+  departureHour: 8,
+  enabledAccommodationTypes: [],
+};
+
+// Add `days` to a YYYY-MM-DD / ISO date string, returning YYYY-MM-DD. Used for
+// the optimistic endDate when a structural edit changes the stage count; the
+// authoritative value arrives over SSE. UTC math keeps it timezone-stable.
+function addDays(dateStr: string, days: number): string {
+  const d = new Date(dateStr);
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+// Renumber dayNumbers 1..n after a structural edit.
+function renumber(stages: StageData[]): StageData[] {
+  return stages.map((stage, i) => ({ ...stage, dayNumber: i + 1 }));
+}
+
+// Recompute endDate from startDate + (stageCount - 1) days when a structural
+// edit changed the count (each stage spans one calendar day, rest days
+// included, recette #649). Returns the patch to apply, or {} without a start.
+function endDatePatch(
+  startDate: string | null,
+  stageCount: number,
+): Partial<TripConfig> {
+  if (!startDate) return {};
+  return { endDate: addDays(startDate, Math.max(0, stageCount - 1)) };
+}
+
+interface TripState extends TripConfig {
   tripId: string | null;
   title: string | null;
   stages: StageData[];
   // Trip started (startDate <= today): the backend rejects edits with 423, so the
   // UI disables them. Read from the /detail payload on hydrate.
   isLocked: boolean;
+  // Route outside the provisioned coverage area: editing/rerouting is disabled.
+  outOfZone: boolean;
+  // Accumulated edits not yet sent to /recompute.
+  pendingModifications: Modification[];
   loading: boolean;
   error: string | null;
   // Initial load from a /trips/{id}/detail payload.
@@ -63,30 +130,66 @@ interface TripState {
   applyStageUpdate: (index: number, stage: StageData) => void;
   // Replace the whole stage list (optimistic rollback restores a snapshot).
   setStages: (stages: StageData[]) => void;
-  // Optimistic delete: drop a stage and renumber the days, mirroring the web
-  // store. The authoritative state arrives via the SSE reconciliation; on API
-  // failure the caller restores the pre-delete snapshot via setStages.
+  // Patch any subset of the editable config slice.
+  setConfig: (patch: Partial<TripConfig>) => void;
+  setTitle: (title: string) => void;
+  setIsLocked: (isLocked: boolean) => void;
+  setOutOfZone: (outOfZone: boolean) => void;
+  // Optimistic structural edits (mirror the web store). The authoritative state
+  // arrives via SSE reconciliation; on API failure the caller restores the
+  // pre-edit snapshot via setStages.
   deleteStageOptimistic: (index: number) => void;
+  insertRestDayOptimistic: (afterIndex: number) => void;
+  insertStageOptimistic: (afterIndex: number, placeholder: StageData) => void;
+  moveStageOptimistic: (fromIndex: number, toIndex: number) => void;
+  selectAccommodationOptimistic: (
+    stageIndex: number,
+    accIndex: number,
+    nextStageIndex: number | null,
+  ) => void;
+  deselectAccommodationOptimistic: (stageIndex: number) => void;
+  // Batch queue: replace a duplicate (same type + stageIndex) rather than append.
+  queueModification: (modification: Modification) => void;
+  cancelAllModifications: () => void;
+  clearPendingModifications: () => void;
   setStatus: (patch: { loading?: boolean; error?: string | null }) => void;
   reset: () => void;
 }
 
-// Thin RN store: it holds StageData and delegates every reconciliation to the
-// pure reducers in @btp/core, so the web and mobile stores share one source of
-// truth and this file carries no reconciliation logic of its own (#1014).
+// Thin RN store: it holds StageData + the editable config and delegates every
+// reconciliation to the pure reducers in @btp/core, so the web and mobile stores
+// share one source of truth (#1014). Optimistic structural edits mirror the web
+// store's renumber/date bookkeeping so a mutation reflects immediately; the
+// mutation runners (mutations.ts) drive the API call + rollback (#1031).
 export const useTripStore = create<TripState>((set, get) => ({
   tripId: null,
   title: null,
   stages: [],
   isLocked: false,
+  outOfZone: false,
+  pendingModifications: [],
   loading: true,
   error: null,
+  ...DEFAULT_CONFIG,
   hydrate: (tripId, detail) =>
     set({
       tripId,
       title: detail.title ?? null,
       stages: (detail.stages ?? []).map(stageDataFromDetail),
       isLocked: detail.isLocked ?? false,
+      outOfZone: detail.outOfZone ?? false,
+      startDate: detail.startDate ?? null,
+      endDate: detail.endDate ?? null,
+      fatigueFactor: detail.fatigueFactor ?? DEFAULT_CONFIG.fatigueFactor,
+      elevationPenalty:
+        detail.elevationPenalty ?? DEFAULT_CONFIG.elevationPenalty,
+      maxDistancePerDay:
+        detail.maxDistancePerDay ?? DEFAULT_CONFIG.maxDistancePerDay,
+      averageSpeed: detail.averageSpeed ?? DEFAULT_CONFIG.averageSpeed,
+      ebikeMode: detail.ebikeMode ?? DEFAULT_CONFIG.ebikeMode,
+      departureHour: detail.departureHour ?? DEFAULT_CONFIG.departureHour,
+      enabledAccommodationTypes: detail.enabledAccommodationTypes ?? [],
+      pendingModifications: [],
       loading: false,
       error: null,
     }),
@@ -95,12 +198,102 @@ export const useTripStore = create<TripState>((set, get) => ({
   applyStageUpdate: (index, stage) =>
     set({ stages: reconcileStageUpdate(get().stages, index, stage).stages }),
   setStages: (stages) => set({ stages }),
+  setConfig: (patch) => set(patch),
+  setTitle: (title) => set({ title }),
+  setIsLocked: (isLocked) => set({ isLocked }),
+  setOutOfZone: (outOfZone) => set({ outOfZone }),
   deleteStageOptimistic: (index) =>
+    set((state) => {
+      const stages = renumber(state.stages.filter((_, i) => i !== index));
+      return { stages, ...endDatePatch(state.startDate, stages.length) };
+    }),
+  insertRestDayOptimistic: (afterIndex) =>
+    set((state) => {
+      const after = state.stages[afterIndex];
+      if (!after) return {};
+      const restDay: StageData = {
+        dayNumber: afterIndex + 2,
+        distance: 0,
+        elevation: 0,
+        elevationLoss: 0,
+        startPoint: { ...after.endPoint },
+        endPoint: { ...after.endPoint },
+        geometry: [],
+        label: null,
+        startLabel: after.endLabel ?? null,
+        endLabel: after.endLabel ?? null,
+        weather: null,
+        alerts: [],
+        pois: [],
+        accommodations: [],
+        selectedAccommodation: null,
+        accommodationSearchRadiusKm: DEFAULT_ACCOMMODATION_RADIUS_KM,
+        isRestDay: true,
+        supplyTimeline: [],
+        events: [],
+      };
+      const next = state.stages.slice();
+      next.splice(afterIndex + 1, 0, restDay);
+      const stages = renumber(next);
+      return { stages, ...endDatePatch(state.startDate, stages.length) };
+    }),
+  insertStageOptimistic: (afterIndex, placeholder) =>
+    set((state) => {
+      const next = state.stages.slice();
+      next.splice(afterIndex + 1, 0, placeholder);
+      const stages = renumber(next);
+      return { stages, ...endDatePatch(state.startDate, stages.length) };
+    }),
+  moveStageOptimistic: (fromIndex, toIndex) =>
+    set((state) => {
+      const next = state.stages.slice();
+      const [moved] = next.splice(fromIndex, 1);
+      if (!moved) return {};
+      next.splice(toIndex, 0, moved);
+      return { stages: renumber(next) };
+    }),
+  selectAccommodationOptimistic: (stageIndex, accIndex, nextStageIndex) =>
+    set((state) => {
+      const stage = state.stages[stageIndex];
+      const acc = stage?.accommodations[accIndex];
+      if (!stage || !acc) return {};
+      const endPoint = { lat: acc.lat, lon: acc.lon, ele: 0 };
+      const stages = state.stages.map((s, i) => {
+        if (i === stageIndex) {
+          return {
+            ...s,
+            accommodations: [acc],
+            selectedAccommodation: acc,
+            endPoint,
+          };
+        }
+        if (i === nextStageIndex) {
+          return { ...s, startPoint: endPoint };
+        }
+        return s;
+      });
+      return { stages };
+    }),
+  deselectAccommodationOptimistic: (stageIndex) =>
     set((state) => ({
-      stages: state.stages
-        .filter((_, i) => i !== index)
-        .map((stage, i) => ({ ...stage, dayNumber: i + 1 })),
+      stages: state.stages.map((s, i) =>
+        i === stageIndex ? { ...s, selectedAccommodation: null } : s,
+      ),
     })),
+  queueModification: (modification) =>
+    set((state) => {
+      const i = state.pendingModifications.findIndex(
+        (m) =>
+          m.type === modification.type &&
+          m.stageIndex === modification.stageIndex,
+      );
+      const next = state.pendingModifications.slice();
+      if (i !== -1) next[i] = modification;
+      else next.push(modification);
+      return { pendingModifications: next };
+    }),
+  cancelAllModifications: () => set({ pendingModifications: [] }),
+  clearPendingModifications: () => set({ pendingModifications: [] }),
   setStatus: (patch) => set(patch),
   reset: () =>
     set({
@@ -108,7 +301,10 @@ export const useTripStore = create<TripState>((set, get) => ({
       title: null,
       stages: [],
       isLocked: false,
+      outOfZone: false,
+      pendingModifications: [],
       loading: true,
       error: null,
+      ...DEFAULT_CONFIG,
     }),
 }));


### PR DESCRIPTION
Closes #1031. **Stacked sur #1030** (`feature/1030`) — à merger après #1030.

## Résumé
Store mobile complet + gating transversal, confiné à `mobile/src/{store,hooks,api}/**` (aucun `app/**`, `i18n`, `core`, `components/ui`, `theme`).

- `store/gating.ts` : `evaluateGate` (423 lock / hors-zone / offline) + `normalizeStatus` (**422→validation, 404→not_found, 423→locked, 409→conflict, 0→network** — conforme ADR-038 : 404 non-owner, 422 enum inconnu).
- `store/mutations.ts` : shell `run` (gate → optimiste → API → rollback/normalisation) + runners pour TOUTES les mutations (dates, pacing, titre, types héberg., create/update-distance/move/rest-day/add stage, select/deselect héberg., poi-waypoint, scan, batch `/recompute`, analyze, duplicate, delete trip).
- `store/offline-store.ts` : flag `isOnline` (câblage NetInfo différé).
- `store/trip-store.ts` : slice config éditable + `outOfZone` + `pendingModifications` hydratés depuis `/detail`, réducteurs optimistes (rest-day/insert/move/select/deselect + renumérotation + endDate).
- `store/delete-stage.ts` : refactoré via le shell `run` partagé.
- `hooks/{use-trips,use-trip-detail,use-trip-mutations}.ts` + tests.

## Décisions mobile-adapt
- **Undo/redo abandonné** : pas de middleware temporel (le Ctrl+Z web n'a pas d'équivalent tactile) ; récupération via optimiste + snapshot/rollback par mutation.
- **Batch queue accumulée** : `pendingModifications` (dédup type+stageIndex), envoyée en une passe `/recompute` puis vidée sur succès, en parallèle des PATCH/POST immédiats. Gating routing du batch = `some(distance|accommodation)`.
- **Hors-zone** limité aux mutations qui reroutent (create/move/distance/poi-waypoint/accommodation) ; titre/dates/pacing/scan/duplicate/delete permis hors-zone. Duplicate/delete bloqués seulement par offline (pas éditions).

## Vérification locale (exit codes réels)
- `npm run typecheck --workspace mobile` → exit 0
- `npm run test --workspace mobile` → **7 suites / 50 tests**, exit 0
- `npm run test:ts --workspace pwa` → exit 0 (web intact vis-à-vis de core)
- **Mutation-proofs** : offline / lock / hors-zone / rollback inversés → RED, restaurés → 50 verts.

## Auto-critique
- Pas de deps ajoutées. Le job CI `mobile-checks` ne gate que tsc+jest (arbre RN hors ESLint/Prettier) — vérif = porte CI exacte.
- Wiring des écrans à ces hooks/mutations = Sprint 55 (hors périmètre).
- Stacked : à merger après #1030 ; base = `feature/1030`.

<!-- claude-review-start -->
## Claude Review

**Commit reviewed:** `2baa4645086dddfeafd9f48acad15307d9eb039f`

**Findings:** 0 critical, 0 warning, 0 new suggestions

**PR title check:** `feat(mobile): store complet (mutations + batch recompute + hooks) + gating (#1031)` — the description ("store complet...") is a noun phrase, not imperative mood as required by Conventional Commits (e.g. `feat(mobile): add complete store (mutations + batch recompute + hooks) + gating`). Still unaddressed from previous reviews.

**Review checklist:**
- [x] Code respects the project architecture (mutation flow confined to `mobile/src/{store,hooks,api}/**` as stated in the PR description; shared `run()` gate/rollback shell reused by every runner; `evaluateGate`/`normalizeStatus` match ADR-038's 404/422 contract)
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate (`runDuplicateTrip`/`runDeleteTrip` justifiably bypass the shared `run()` shell since they only need an offline-only gate, not the full lock+zone gate)
- [x] Tests cover new/changed cases — this commit closes the two previously-flagged gaps (`deselectAccommodationOptimistic` reducer test, per-runner gating/rollback coverage for the 7 under-tested runners). Two narrower gaps remain (see note below), unchanged since the prior review.
- [ ] Documentation is up to date — `TRACKING.md`'s `#1031` row is still `⏳ À faire` / `—` for PRs, unlike the established convention (e.g. Sprint 53's `#1015` row was updated to `🚧 En cours` with its PR link while still open). Still unaddressed from previous reviews.
- [x] Dependent tickets accounted for

**Note:** two previously opened threads are still unresolved as of this commit and are left open rather than re-raised — `runApplyBatch`'s dynamic `requiresRouting` derivation has no out-of-zone test, and `useTripMutations` (the hook layer future screens will call) still has zero test coverage of its own.

**Inline comments:** No inline comments.

**Result:** APPROVE
<!-- claude-review-end -->