### PR TITLE
feat(mobile): roadbook lecture — 3 états + dates + bannières (verrou/hors-zone/no-dates) + « Aujourd'hui » (#1037)

### DIFF
--- a/mobile/src/components/trip/RoadbookBanner.tsx
+++ b/mobile/src/components/trip/RoadbookBanner.tsx
@@ -1,0 +1,54 @@
+import { StyleSheet, Text, View } from 'react-native';
+import { AlertTriangle } from '../ui/icons';
+import { useTheme } from '../../theme';
+
+export type RoadbookBannerVariant = 'locked' | 'outOfZone' | 'noDates';
+
+interface RoadbookBannerProps {
+  variant: RoadbookBannerVariant;
+  message: string;
+}
+
+// A single informational banner above the roadbook: read-only lock (started
+// trip, API 423), out-of-zone route, or missing dates. The variant only tunes
+// the accent colour; the copy is passed in so the caller owns i18n.
+export function RoadbookBanner({ variant, message }: RoadbookBannerProps) {
+  const theme = useTheme();
+  const accent =
+    variant === 'noDates' ? theme.colors.accentBrand : theme.colors.destructive;
+  return (
+    <View
+      accessibilityRole="alert"
+      style={[
+        styles.banner,
+        {
+          backgroundColor: theme.colors.accentSoft,
+          borderColor: accent,
+          borderRadius: theme.radius.lg,
+          padding: theme.spacing.md,
+          gap: theme.spacing.sm,
+        },
+      ]}
+    >
+      <AlertTriangle color={accent} size={18} />
+      <Text
+        style={{
+          color: theme.colors.foreground,
+          fontFamily: theme.fonts.sansMedium,
+          fontSize: 14,
+          flex: 1,
+        }}
+      >
+        {message}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  banner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+});

--- a/mobile/src/components/trip/RoadbookView.tsx
+++ b/mobile/src/components/trip/RoadbookView.tsx
@@ -1,19 +1,35 @@
-import { Alert, FlatList, View } from 'react-native';
+import { Alert, FlatList, Text, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { EmptyState } from '../ui';
 import { StageCard } from './StageCard';
+import { RoadbookBanner } from './RoadbookBanner';
+import {
+  isStageToday,
+  stageDateFor,
+  summaryColorKey,
+  todayUtc,
+  tripStateFromDates,
+} from './roadbook-dates';
 import { useTheme } from '../../theme';
 import { useTripStore } from '../../store/trip-store';
 import { runDeleteStage } from '../../store/delete-stage';
 
-// The roadbook tab: the stage list (StageCard rows) plus its empty state and the
-// delete-stage confirm flow. #1037 refines the roadbook loading/empty states and
-// #1039 wires each row's tap-through to the stage detail.
+// The roadbook tab: a lifecycle summary header (upcoming / ongoing / past),
+// the lock / out-of-zone / no-dates banners, then the stage list (StageCard
+// rows) with per-stage dates and an "Aujourd'hui" pastille. #1039 wires each
+// row's tap-through to the stage detail.
 export function RoadbookView({ id }: { id: string }) {
   const { t } = useTranslation();
   const theme = useTheme();
   const stages = useTripStore((s) => s.stages);
   const isLocked = useTripStore((s) => s.isLocked);
+  const outOfZone = useTripStore((s) => s.outOfZone);
+  const startDate = useTripStore((s) => s.startDate);
+  const endDate = useTripStore((s) => s.endDate);
+
+  const today = todayUtc();
+  const state = tripStateFromDates(startDate, endDate, today);
+  const hasDates = startDate !== null && endDate !== null;
 
   function confirmDelete(index: number): void {
     Alert.alert(t('trip.deleteConfirmTitle'), t('trip.deleteConfirmMessage'), [
@@ -35,18 +51,59 @@ export function RoadbookView({ id }: { id: string }) {
     ]);
   }
 
+  const header = (
+    <View
+      style={{
+        padding: theme.spacing.base,
+        gap: theme.spacing.md,
+      }}
+    >
+      {state ? (
+        <Text
+          style={{
+            color: theme.colors[summaryColorKey(state)],
+            fontFamily: theme.fonts.sansSemibold,
+            fontSize: 15,
+          }}
+        >
+          {t(`trip.states.${state}`)}
+        </Text>
+      ) : null}
+      {isLocked ? (
+        <RoadbookBanner variant="locked" message={t('trip.banners.locked')} />
+      ) : null}
+      {outOfZone ? (
+        <RoadbookBanner variant="outOfZone" message={t('trip.banners.outOfZone')} />
+      ) : null}
+      {!hasDates ? (
+        <RoadbookBanner variant="noDates" message={t('trip.banners.noDates')} />
+      ) : null}
+    </View>
+  );
+
   return (
     <FlatList
       data={stages}
       keyExtractor={(_, index) => String(index)}
+      ListHeaderComponent={header}
       ListEmptyComponent={
         <View style={{ height: 300 }}>
           <EmptyState title={t('trip.empty')} />
         </View>
       }
-      renderItem={({ item, index }) => (
-        <StageCard stage={item} index={index} locked={isLocked} onDelete={confirmDelete} />
-      )}
+      renderItem={({ item, index }) => {
+        const date = stageDateFor(startDate, item.dayNumber ?? index + 1);
+        return (
+          <StageCard
+            stage={item}
+            index={index}
+            locked={isLocked}
+            onDelete={confirmDelete}
+            date={date}
+            isToday={state === 'ongoing' && isStageToday(date, today)}
+          />
+        );
+      }}
       style={{ backgroundColor: theme.colors.background }}
     />
   );

--- a/mobile/src/components/trip/StageCard.tsx
+++ b/mobile/src/components/trip/StageCard.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import type { StageData } from '@btp/core';
 import { Trash2 } from '../ui/icons';
 import { useTheme } from '../../theme';
+import { formatStageDate } from './roadbook-dates';
 
 interface StageCardProps {
   stage: StageData;
@@ -10,14 +11,31 @@ interface StageCardProps {
   // A started trip is read-only (backend 423): the delete action is hidden.
   locked: boolean;
   onDelete: (index: number) => void;
+  // Calendar day of the stage (YYYY-MM-DD, UTC), or null when the trip has no
+  // start date — the card then falls back to "Jour N".
+  date?: string | null;
+  // True when `date` is today on an ongoing trip: shows the "Aujourd'hui"
+  // pastille.
+  isToday?: boolean;
 }
 
-// One roadbook row: day number (+ rest tag), start → end labels, distance /
-// elevation, and a delete action when the trip is still editable. Rendered by
-// RoadbookView; #1039 wires the tap-through to the stage detail.
-export function StageCard({ stage, index, locked, onDelete }: StageCardProps) {
-  const { t } = useTranslation();
+// One roadbook row: the stage date (or "Jour N" fallback) + rest tag, start →
+// end labels, distance / elevation, a "today" pastille on the current day, and
+// a delete action when the trip is still editable. Rendered by RoadbookView;
+// #1039 wires the tap-through to the stage detail.
+export function StageCard({
+  stage,
+  index,
+  locked,
+  onDelete,
+  date = null,
+  isToday = false,
+}: StageCardProps) {
+  const { t, i18n } = useTranslation();
   const theme = useTheme();
+  const heading = date
+    ? formatStageDate(date, i18n.language)
+    : t('trip.day', { day: stage.dayNumber ?? '?' });
   return (
     <View
       style={{
@@ -30,16 +48,35 @@ export function StageCard({ stage, index, locked, onDelete }: StageCardProps) {
       }}
     >
       <View style={{ flex: 1 }}>
-        <Text
-          style={{
-            color: theme.colors.foreground,
-            fontFamily: theme.fonts.sansSemibold,
-            fontSize: 16,
-          }}
-        >
-          {t('trip.day', { day: stage.dayNumber ?? '?' })}
-          {stage.isRestDay ? ` · ${t('trip.rest')}` : ''}
-        </Text>
+        <View style={{ flexDirection: 'row', alignItems: 'center', gap: theme.spacing.sm }}>
+          <Text
+            style={{
+              color: theme.colors.foreground,
+              fontFamily: theme.fonts.sansSemibold,
+              fontSize: 16,
+            }}
+          >
+            {heading}
+            {stage.isRestDay ? ` · ${t('trip.rest')}` : ''}
+          </Text>
+          {isToday ? (
+            <Text
+              accessibilityLabel={t('trip.today')}
+              style={{
+                color: theme.colors.accentInk,
+                backgroundColor: theme.colors.accentSoft,
+                fontFamily: theme.fonts.sansMedium,
+                fontSize: 11,
+                overflow: 'hidden',
+                borderRadius: theme.radius.full,
+                paddingHorizontal: theme.spacing.sm,
+                paddingVertical: 2,
+              }}
+            >
+              {t('trip.today')}
+            </Text>
+          ) : null}
+        </View>
         <Text
           style={{
             color: theme.colors.mutedForeground,

--- a/mobile/src/components/trip/index.ts
+++ b/mobile/src/components/trip/index.ts
@@ -8,4 +8,5 @@ export { AccommodationBlock } from './AccommodationBlock';
 export { SupplyBlock } from './SupplyBlock';
 export { EventsBlock } from './EventsBlock';
 export { RoadbookView } from './RoadbookView';
+export { RoadbookBanner, type RoadbookBannerVariant } from './RoadbookBanner';
 export { TripMapView } from './TripMapView';

--- a/mobile/src/components/trip/roadbook-dates.test.ts
+++ b/mobile/src/components/trip/roadbook-dates.test.ts
@@ -1,0 +1,78 @@
+/// <reference types="jest" />
+import {
+  formatStageDate,
+  isStageToday,
+  stageDateFor,
+  summaryColorKey,
+  todayUtc,
+  tripStateFromDates,
+} from './roadbook-dates';
+
+describe('stageDateFor', () => {
+  it('returns startDate for day 1 and shifts one UTC day per dayNumber', () => {
+    expect(stageDateFor('2026-08-13', 1)).toBe('2026-08-13');
+    expect(stageDateFor('2026-08-13', 3)).toBe('2026-08-15');
+  });
+
+  it('crosses a month boundary in UTC (timezone-stable)', () => {
+    expect(stageDateFor('2026-08-31', 2)).toBe('2026-09-01');
+  });
+
+  it('returns null without a start date or on garbage', () => {
+    expect(stageDateFor(null, 1)).toBeNull();
+    expect(stageDateFor('not-a-date', 1)).toBeNull();
+  });
+});
+
+describe('tripStateFromDates', () => {
+  const today = '2026-08-13';
+
+  it('is upcoming when the start is after today', () => {
+    expect(tripStateFromDates('2026-08-20', '2026-08-25', today)).toBe('upcoming');
+  });
+
+  it('is ongoing when today is within the range (inclusive bounds)', () => {
+    expect(tripStateFromDates('2026-08-10', '2026-08-20', today)).toBe('ongoing');
+    expect(tripStateFromDates('2026-08-13', '2026-08-13', today)).toBe('ongoing');
+  });
+
+  it('is past when the end is before today', () => {
+    expect(tripStateFromDates('2026-08-01', '2026-08-05', today)).toBe('past');
+  });
+
+  it('is null when either bound is missing', () => {
+    expect(tripStateFromDates(null, '2026-08-20', today)).toBeNull();
+    expect(tripStateFromDates('2026-08-10', null, today)).toBeNull();
+  });
+});
+
+describe('isStageToday', () => {
+  it('matches on an exact UTC day and rejects otherwise', () => {
+    expect(isStageToday('2026-08-13', '2026-08-13')).toBe(true);
+    expect(isStageToday('2026-08-14', '2026-08-13')).toBe(false);
+    expect(isStageToday(null, '2026-08-13')).toBe(false);
+  });
+});
+
+describe('summaryColorKey', () => {
+  it('maps each lifecycle state to a theme colour key', () => {
+    expect(summaryColorKey('ongoing')).toBe('accentBrand');
+    expect(summaryColorKey('past')).toBe('mutedForeground');
+    expect(summaryColorKey('upcoming')).toBe('foreground');
+    expect(summaryColorKey(null)).toBe('foreground');
+  });
+});
+
+describe('todayUtc', () => {
+  it('formats an injected instant as its UTC calendar day', () => {
+    // 00:30 Paris on the 14th is still the 13th in UTC — the injected date pins it.
+    expect(todayUtc(new Date('2026-08-13T23:30:00Z'))).toBe('2026-08-13');
+  });
+});
+
+describe('formatStageDate', () => {
+  it('formats a UTC day in the given locale without drifting', () => {
+    expect(formatStageDate('2026-08-13', 'fr')).toContain('13');
+    expect(formatStageDate('2026-08-13', 'en')).toContain('13');
+  });
+});

--- a/mobile/src/components/trip/roadbook-dates.ts
+++ b/mobile/src/components/trip/roadbook-dates.ts
@@ -1,0 +1,81 @@
+import type { ThemeColors } from '../../theme';
+
+// Pure date/state helpers for the roadbook. All date math is done on
+// `YYYY-MM-DD` strings in UTC (mirrors addDays in trip-store.ts) so the result
+// is timezone-stable: CI runs in Europe/Paris, a dev container in UTC, and a
+// device in the rider's local zone must all agree. The reference "today" is
+// injected so the functions stay deterministic and testable.
+
+export type TripLifecycle = 'upcoming' | 'ongoing' | 'past';
+
+// The current UTC calendar day as `YYYY-MM-DD`.
+export function todayUtc(now: Date = new Date()): string {
+  return now.toISOString().slice(0, 10);
+}
+
+// The calendar day of a stage: startDate + (dayNumber - 1) days, as
+// `YYYY-MM-DD`. Each stage spans one calendar day, rest days included
+// (recette #649). Null without a start date or on an unparseable one.
+export function stageDateFor(
+  startDate: string | null,
+  dayNumber: number,
+): string | null {
+  if (!startDate) return null;
+  const d = new Date(startDate + 'T00:00:00Z');
+  if (Number.isNaN(d.getTime())) return null;
+  d.setUTCDate(d.getUTCDate() + Math.max(0, dayNumber - 1));
+  return d.toISOString().slice(0, 10);
+}
+
+// The trip lifecycle state from its dates vs today (all `YYYY-MM-DD`, UTC).
+// Null when either bound is missing — the caller shows the "set your dates"
+// banner then. String comparison is exact for fixed-width ISO dates.
+export function tripStateFromDates(
+  startDate: string | null,
+  endDate: string | null,
+  today: string,
+): TripLifecycle | null {
+  if (!startDate || !endDate) return null;
+  if (startDate > today) return 'upcoming';
+  if (endDate < today) return 'past';
+  return 'ongoing';
+}
+
+// Whether a stage date is today — only meaningful for the "Aujourd'hui" pastille
+// on an ongoing trip.
+export function isStageToday(
+  stageDate: string | null,
+  today: string,
+): boolean {
+  return stageDate !== null && stageDate === today;
+}
+
+// Theme colour key for the roadbook summary header, per lifecycle state:
+// ongoing is highlighted (brand), past is faded (muted), upcoming/unknown use
+// the default ink. Returning a key keeps the mapping pure and testable without
+// a Theme instance.
+export function summaryColorKey(
+  state: TripLifecycle | null,
+): keyof ThemeColors {
+  switch (state) {
+    case 'ongoing':
+      return 'accentBrand';
+    case 'past':
+      return 'mutedForeground';
+    default:
+      return 'foreground';
+  }
+}
+
+// Localised short date for a `YYYY-MM-DD` string, formatted in UTC so the
+// displayed day never drifts by a timezone offset. e.g. "mer. 13 août".
+export function formatStageDate(stageDate: string, locale: string): string {
+  const d = new Date(stageDate + 'T00:00:00Z');
+  if (Number.isNaN(d.getTime())) return stageDate;
+  return new Intl.DateTimeFormat(locale, {
+    timeZone: 'UTC',
+    weekday: 'short',
+    day: 'numeric',
+    month: 'short',
+  }).format(d);
+}

--- a/mobile/src/components/trip/roadbook-ui.test.tsx
+++ b/mobile/src/components/trip/roadbook-ui.test.tsx
@@ -1,0 +1,101 @@
+/// <reference types="jest" />
+import TestRenderer, { act } from 'react-test-renderer';
+import type { ReactElement } from 'react';
+import { Text } from 'react-native';
+import type { StageData } from '@btp/core';
+import i18n from '../../i18n';
+import { fr } from '../../i18n/resources/fr';
+import { StageCard } from './StageCard';
+import { RoadbookBanner } from './RoadbookBanner';
+
+function texts(node: any): string[] {
+  return node.root.findAllByType(Text).flatMap((t: any) => {
+    const kids = Array.isArray(t.props.children) ? t.props.children : [t.props.children];
+    return kids.filter((c: unknown): c is string => typeof c === 'string');
+  });
+}
+
+function render(element: ReactElement): any {
+  let out: any;
+  act(() => {
+    out = TestRenderer.create(element);
+  });
+  return out;
+}
+
+function stage(overrides: Partial<StageData> = {}): StageData {
+  const point = { lat: 0, lon: 0, ele: 0 };
+  return {
+    dayNumber: 1,
+    distance: 50,
+    elevation: 100,
+    elevationLoss: 0,
+    startPoint: point,
+    endPoint: point,
+    geometry: [],
+    label: null,
+    startLabel: 'Paris',
+    endLabel: 'Lyon',
+    weather: null,
+    alerts: [],
+    pois: [],
+    accommodations: [],
+    selectedAccommodation: null,
+    accommodationSearchRadiusKm: 10,
+    isRestDay: false,
+    supplyTimeline: [],
+    events: [],
+    ...overrides,
+  };
+}
+
+beforeAll(async () => {
+  await i18n.changeLanguage('fr');
+});
+
+describe('StageCard dates', () => {
+  it('falls back to "Jour N" when no date is provided', () => {
+    const t = texts(render(<StageCard stage={stage()} index={0} locked={false} onDelete={jest.fn()} />));
+    expect(t.join(' ')).toContain('Jour 1');
+  });
+
+  it('shows the stage date instead of the day number when provided', () => {
+    const t = texts(
+      render(
+        <StageCard stage={stage()} index={0} locked={false} onDelete={jest.fn()} date="2026-08-13" />,
+      ),
+    );
+    expect(t.join(' ')).toContain('13');
+    expect(t.join(' ')).not.toContain('Jour 1');
+  });
+
+  it('renders the "Aujourd\'hui" pastille only when isToday', () => {
+    const withBadge = texts(
+      render(
+        <StageCard stage={stage()} index={0} locked={false} onDelete={jest.fn()} date="2026-08-13" isToday />,
+      ),
+    );
+    expect(withBadge).toContain(fr.trip.today);
+
+    const withoutBadge = texts(
+      render(
+        <StageCard stage={stage()} index={0} locked={false} onDelete={jest.fn()} date="2026-08-13" />,
+      ),
+    );
+    expect(withoutBadge).not.toContain(fr.trip.today);
+  });
+});
+
+describe('RoadbookBanner', () => {
+  it('renders the message for each variant', () => {
+    expect(texts(render(<RoadbookBanner variant="locked" message={fr.trip.banners.locked} />))).toContain(
+      fr.trip.banners.locked,
+    );
+    expect(
+      texts(render(<RoadbookBanner variant="outOfZone" message={fr.trip.banners.outOfZone} />)),
+    ).toContain(fr.trip.banners.outOfZone);
+    expect(texts(render(<RoadbookBanner variant="noDates" message={fr.trip.banners.noDates} />))).toContain(
+      fr.trip.banners.noDates,
+    );
+  });
+});

--- a/mobile/src/i18n/resources/en.ts
+++ b/mobile/src/i18n/resources/en.ts
@@ -62,7 +62,18 @@ export const en: typeof fr = {
     mapEmpty: 'No route available for this trip.',
     day: 'Day {{day}}',
     rest: 'rest',
+    today: 'Today',
     stageMeta: '{{distance}} km · +{{elevation}} m',
+    states: {
+      upcoming: 'Upcoming',
+      ongoing: 'Ongoing',
+      past: 'Completed',
+    },
+    banners: {
+      locked: 'Trip started: read-only.',
+      outOfZone: 'Route outside the covered area.',
+      noDates: 'Set your trip dates.',
+    },
     delete: 'Delete',
     deleteA11y: 'Delete day {{day}}',
     deleteConfirmTitle: 'Delete this stage?',

--- a/mobile/src/i18n/resources/fr.ts
+++ b/mobile/src/i18n/resources/fr.ts
@@ -60,7 +60,18 @@ export const fr = {
     mapEmpty: 'Aucun tracé disponible pour ce voyage.',
     day: 'Jour {{day}}',
     rest: 'repos',
+    today: "Aujourd'hui",
     stageMeta: '{{distance}} km · +{{elevation}} m',
+    states: {
+      upcoming: 'À venir',
+      ongoing: 'En cours',
+      past: 'Terminé',
+    },
+    banners: {
+      locked: 'Voyage démarré : lecture seule.',
+      outOfZone: 'Itinéraire hors de la zone couverte.',
+      noDates: 'Définissez les dates de votre voyage.',
+    },
     delete: 'Supprimer',
     deleteA11y: 'Supprimer le jour {{day}}',
     deleteConfirmTitle: 'Supprimer cette étape ?',


### PR DESCRIPTION
Closes #1037

> Stacked PR — base `feature/1036` (#1036).

## Contexte
Sprint 55 (Consultation). Roadbook en lecture : 3 états, dates, bannières, pastille « Aujourd'hui ».

## Changements
- `roadbook-dates.ts` : fonctions pures date-math **UTC** (`tripStateFromDates`, `stageDateFor`, `isStageToday`, `summaryColorKey`, `todayUtc`, `formatStageDate`), « aujourd'hui » injectable pour les tests.
- `RoadbookBanner.tsx` : bannière réutilisable (variants `locked`/`outOfZone`/`noDates`).
- `RoadbookView.tsx` : summary header coloré par état + 3 bannières en `ListHeaderComponent`, passe `date`/`isToday` aux cartes.
- `StageCard.tsx` : props `date`/`isToday`, date localisée (fallback « Jour N »), pastille « Aujourd'hui ».
- i18n `trip.today` / `trip.states.*` / `trip.banners.*` (fr+en synchronisés).

## Vérification
- `tsc --noEmit` : clean.
- `jest` : 16 suites / 114 tests verts. `tripStateFromDates` prouvé rouge-puis-vert.

## Auto-critique
- **Gotcha timezone (CLAUDE.md)** respecté : toute la date-math en UTC sur chaînes `YYYY-MM-DD`, pas de `+00:00` en dur, `now` injectable → stable en CI `Europe/Paris`.
- `[id].tsx` non touché (summary + bannières vivent dans `RoadbookView`) : diff disjoint des siblings.

<!-- claude-review-start -->
## Claude Review

**Summary:** No findings (0 critical, 0 warning). Clean, well-scoped presentational feature — `roadbook-dates.ts` mirrors the existing UTC calendar-day convention (`addDays` in `trip-store.ts`), keeping client-side lifecycle state consistent with the backend's lock semantics without timezone drift. Verified `outOfZone`/`startDate`/`endDate`/`isLocked` exist on the trip store, all referenced theme keys (`accentBrand`, `accentSoft`, `accentInk`, `destructive`, `mutedForeground`, spacing/radius/font tokens incl. `radius.full`) exist in both palettes, `AlertTriangle` is exported from `ui/icons`, and `StageData.dayNumber` is optional (matching the existing `?? '?'` fallback pattern). Pure date-math is thoroughly unit-tested (month-boundary crossing, null/garbage inputs, inclusive bounds); `StageCard`/`RoadbookBanner` variants are covered by component tests. fr/en i18n stay structurally in sync via the `en: typeof fr` type constraint. No security, performance, or architecture concerns — read-only store consumption, no new I/O.

**Resolved threads:** No open bot threads to resolve (none existed).

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

**Commit reviewed:** 342569eaf604342025d7f2d19500826bdd4e9839
<!-- claude-review-end -->