### PR TITLE
feat(mobile): carte complète — toggle satellite + markers + fit-bounds + surlignage de segment (#1040)

### DIFF
--- a/mobile/src/components/TripMap.test.tsx
+++ b/mobile/src/components/TripMap.test.tsx
@@ -141,4 +141,18 @@ describe('TripMap', () => {
     );
     expect(byId(withMarkers.root, 'Layer', 'markers-circle')).toHaveLength(1);
   });
+
+  it('colors the three marker kinds distinctly (poi/accommodation/waypoint)', () => {
+    const withMarkers = render(
+      <TripMap
+        coordinates={coordsA}
+        markers={[{ kind: 'poi', lon: 2.5, lat: 48.5, name: 'Café' }]}
+      />,
+    );
+    const layer = byId(withMarkers.root, 'Layer', 'markers-circle')[0]!;
+    // ['match', ['get','kind'], 'poi', <poi>, 'accommodation', <acc>, <waypoint>]
+    const match = layer.props.paint['circle-color'] as unknown[];
+    const [poi, accommodation, waypoint] = [match[3], match[5], match[6]];
+    expect(new Set([poi, accommodation, waypoint]).size).toBe(3);
+  });
 });

--- a/mobile/src/components/TripMap.test.tsx
+++ b/mobile/src/components/TripMap.test.tsx
@@ -1,0 +1,144 @@
+/// <reference types="jest" />
+import TestRenderer, { act } from 'react-test-renderer';
+import type { ReactElement } from 'react';
+import * as SecureStore from 'expo-secure-store';
+import '../i18n';
+import { useMapPrefs } from '../store/map-prefs';
+import { TripMap } from './TripMap';
+import { computeBounds, POSITRON_STYLE_URL } from './map/map-utils';
+
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: jest.fn().mockResolvedValue(null),
+  setItemAsync: jest.fn().mockResolvedValue(undefined),
+}));
+
+// Render the native map components as plain host nodes so the tree records the
+// props TripMap feeds them (mapStyle, camera stop, layer paint, source ids).
+jest.mock('@maplibre/maplibre-react-native', () => {
+  const React = require('react');
+  const make = (name: string) => {
+    const C = ({ children, ...rest }: { children?: unknown }) =>
+      React.createElement(name, rest, children);
+    C.displayName = name;
+    return C;
+  };
+  return {
+    Map: make('Map'),
+    Camera: make('Camera'),
+    GeoJSONSource: make('GeoJSONSource'),
+    Layer: make('Layer'),
+  };
+});
+
+const setItem = SecureStore.setItemAsync as jest.Mock;
+
+function render(element: ReactElement): any {
+  let out: any;
+  act(() => {
+    out = TestRenderer.create(element);
+  });
+  return out;
+}
+
+function findAll(root: any, type: string): any[] {
+  return root.findAll((n: any) => n.type === type);
+}
+
+function byId(root: any, type: string, id: string): any[] {
+  return findAll(root, type).filter((n: any) => n.props.id === id);
+}
+
+const coordsA: [number, number][] = [
+  [2, 48],
+  [3, 49],
+];
+const coordsB: [number, number][] = [
+  [5, 44],
+  [6, 45],
+];
+
+beforeEach(() => {
+  setItem.mockClear();
+  // Pre-hydrated so the mount-time load() is a no-op (no async store write to
+  // chase through act()); these tests drive the base explicitly via the toggle.
+  act(() => {
+    useMapPrefs.setState({ base: 'map', hydrated: true });
+  });
+});
+
+describe('TripMap', () => {
+  it('renders the empty state when there is no route', () => {
+    const out = render(<TripMap coordinates={[]} />);
+    expect(findAll(out.root, 'Map')).toHaveLength(0);
+  });
+
+  it('feeds the memoized Positron style, then the satellite style once toggled', () => {
+    const out = render(<TripMap coordinates={coordsA} />);
+    const style = () => findAll(out.root, 'Map')[0].props.mapStyle;
+    expect(style()).toBe(POSITRON_STYLE_URL);
+
+    act(() => {
+      out.root
+        .find(
+          (n: any) =>
+            n.props.accessibilityRole === 'button' &&
+            typeof n.props.onPress === 'function',
+        )
+        .props.onPress();
+    });
+
+    // Satellite base swaps to the inline Esri raster style object...
+    expect(style()).toMatchObject({ version: 8 });
+    // ...and the choice is persisted.
+    expect(setItem).toHaveBeenCalledWith('btp_map_base', 'satellite');
+    // The route line switches to white for contrast over imagery.
+    expect(byId(out.root, 'Layer', 'route-line')[0].props.paint['line-color']).toBe(
+      '#ffffff',
+    );
+  });
+
+  it('re-frames the camera reactively when coordinates change', () => {
+    const out = render(<TripMap coordinates={coordsA} />);
+    const camera = () => findAll(out.root, 'Camera')[0].props;
+    expect(camera().bounds).toEqual(computeBounds(coordsA));
+
+    // Same (non re-keyed) Camera instance, new coordinates -> new bounds prop.
+    act(() => {
+      out.update(<TripMap coordinates={coordsB} />);
+    });
+    expect(camera().bounds).toEqual(computeBounds(coordsB));
+  });
+
+  it('draws the highlighted segment only once it has at least two points', () => {
+    const out = render(
+      <TripMap coordinates={coordsA} highlightedSegment={[[2, 48]]} />,
+    );
+    expect(byId(out.root, 'GeoJSONSource', 'segment-highlight')).toHaveLength(0);
+
+    act(() => {
+      out.update(
+        <TripMap
+          coordinates={coordsA}
+          highlightedSegment={[
+            [2, 48],
+            [3, 49],
+          ]}
+        />,
+      );
+    });
+    expect(byId(out.root, 'GeoJSONSource', 'segment-highlight')).toHaveLength(1);
+  });
+
+  it('renders the markers layer only when markers are provided', () => {
+    const withoutMarkers = render(<TripMap coordinates={coordsA} />);
+    expect(byId(withoutMarkers.root, 'Layer', 'markers-circle')).toHaveLength(0);
+
+    const withMarkers = render(
+      <TripMap
+        coordinates={coordsA}
+        markers={[{ kind: 'poi', lon: 2.5, lat: 48.5, name: 'Café' }]}
+      />,
+    );
+    expect(byId(withMarkers.root, 'Layer', 'markers-circle')).toHaveLength(1);
+  });
+});

--- a/mobile/src/components/TripMap.tsx
+++ b/mobile/src/components/TripMap.tsx
@@ -64,15 +64,13 @@ export function TripMap({
     [coordinates],
   );
   // maplibre-react-native v11: `initialViewState` is applied once at native
-  // mount, whereas the top-level `CameraStop` props (bounds/padding, center/zoom)
-  // are reactive — feeding `bounds` here re-frames the camera whenever the
-  // coordinates change (e.g. prev/next stage on the detail screen, #1074).
+  // mount, whereas the top-level `CameraStop` `bounds`/`padding` are reactive —
+  // feeding `bounds` here re-frames the camera whenever the coordinates change
+  // (e.g. prev/next stage on the detail screen, #1074). `bounds` is only null for
+  // empty coordinates, which the early return below renders before this is used.
   const cameraStop = useMemo(
-    () =>
-      bounds
-        ? { bounds, padding: FIT_PADDING }
-        : { center: coordinates[0], zoom: 8 },
-    [bounds, coordinates],
+    () => ({ bounds: bounds ?? undefined, padding: FIT_PADDING }),
+    [bounds],
   );
 
   if (coordinates.length === 0) {

--- a/mobile/src/components/TripMap.tsx
+++ b/mobile/src/components/TripMap.tsx
@@ -121,8 +121,11 @@ export function TripMap({
                 'circle-color': [
                   'match',
                   ['get', 'kind'],
+                  // Three visually distinct fills: accentBrand aliases brand to the
+                  // same hex, so poi uses accentInk to stay distinguishable from
+                  // accommodation (brand) and waypoint (primary).
                   'poi',
-                  theme.colors.accentBrand,
+                  theme.colors.accentInk,
                   'accommodation',
                   theme.colors.brand,
                   theme.colors.primary,

--- a/mobile/src/components/TripMap.tsx
+++ b/mobile/src/components/TripMap.tsx
@@ -1,26 +1,59 @@
+import { useEffect } from 'react';
 import type { FeatureCollection } from 'geojson';
 import { Camera, GeoJSONSource, Layer, Map } from '@maplibre/maplibre-react-native';
-import { StyleSheet, Text, View } from 'react-native';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { useTheme } from '../theme/context';
+import { useMapPrefs } from '../store/map-prefs';
+import {
+  computeBounds,
+  mapStyleFor,
+  markerCollection,
+  segmentFeature,
+  type MapMarker,
+} from './map/map-utils';
 
-// Same Carto Positron style the web frontend uses.
-const STYLE_URL = 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json';
+// Pixel inset kept around the fitted route so start/end markers are not flush
+// against the viewport edges.
+const FIT_PADDING = { top: 48, right: 48, bottom: 48, left: 48 };
 
-function centerOf(coords: [number, number][]): [number, number] {
-  const sum = coords.reduce<[number, number]>(
-    (acc, [lon, lat]) => [acc[0] + lon, acc[1] + lat],
-    [0, 0],
-  );
-  return [sum[0] / coords.length, sum[1] / coords.length];
-}
+export function TripMap({
+  coordinates,
+  markers,
+  highlightedSegment,
+}: {
+  coordinates: [number, number][];
+  markers?: MapMarker[];
+  // Ordered [lon, lat] points of a road stretch to surline (e.g. from an alert
+  // `navigate` action). Drawn on its own source/layer above the route. Detail /
+  // alerts pilot this later; use alertSegmentToCoords() to adapt an alert
+  // action's [lat, lon] segment.
+  highlightedSegment?: [number, number][];
+}) {
+  const theme = useTheme();
+  const { t } = useTranslation();
+  const base = useMapPrefs((s) => s.base);
+  const toggle = useMapPrefs((s) => s.toggle);
+  const load = useMapPrefs((s) => s.load);
 
-export function TripMap({ coordinates }: { coordinates: [number, number][] }) {
+  useEffect(() => {
+    void load();
+  }, [load]);
+
   if (coordinates.length === 0) {
     return (
       <View style={styles.empty}>
-        <Text>Aucun tracé disponible pour ce voyage.</Text>
+        <Text style={{ color: theme.colors.mutedForeground }}>
+          {t('trip.mapEmpty')}
+        </Text>
       </View>
     );
   }
+
+  const satellite = base === 'satellite';
+  const bounds = computeBounds(coordinates);
+  const markerData = markerCollection(markers ?? []);
+  const hasSegment = (highlightedSegment?.length ?? 0) >= 2;
 
   const line: FeatureCollection = {
     type: 'FeatureCollection',
@@ -34,21 +67,96 @@ export function TripMap({ coordinates }: { coordinates: [number, number][] }) {
   };
 
   return (
-    <Map style={styles.map} mapStyle={STYLE_URL}>
-      <Camera initialViewState={{ center: centerOf(coordinates), zoom: 8 }} />
-      <GeoJSONSource id="route" data={line}>
-        <Layer
-          id="route-line"
-          type="line"
-          layout={{ 'line-join': 'round', 'line-cap': 'round' }}
-          paint={{ 'line-color': '#2563eb', 'line-width': 4 }}
+    <View style={styles.container}>
+      <Map style={styles.map} mapStyle={mapStyleFor(base)}>
+        <Camera
+          initialViewState={
+            bounds
+              ? { bounds, padding: FIT_PADDING }
+              : { center: coordinates[0], zoom: 8 }
+          }
         />
-      </GeoJSONSource>
-    </Map>
+        <GeoJSONSource id="route" data={line}>
+          <Layer
+            id="route-line"
+            type="line"
+            layout={{ 'line-join': 'round', 'line-cap': 'round' }}
+            paint={{
+              'line-color': satellite ? '#ffffff' : theme.colors.brand,
+              'line-width': 4,
+            }}
+          />
+        </GeoJSONSource>
+        {hasSegment ? (
+          <GeoJSONSource
+            id="segment-highlight"
+            data={segmentFeature(highlightedSegment ?? [])}
+          >
+            <Layer
+              id="segment-highlight-line"
+              type="line"
+              layout={{ 'line-join': 'round', 'line-cap': 'round' }}
+              paint={{ 'line-color': theme.colors.destructive, 'line-width': 7 }}
+            />
+          </GeoJSONSource>
+        ) : null}
+        {markerData.features.length > 0 ? (
+          <GeoJSONSource id="markers" data={markerData}>
+            <Layer
+              id="markers-circle"
+              type="circle"
+              paint={{
+                'circle-radius': 6,
+                'circle-color': [
+                  'match',
+                  ['get', 'kind'],
+                  'poi',
+                  theme.colors.accentBrand,
+                  'accommodation',
+                  theme.colors.brand,
+                  theme.colors.primary,
+                ],
+                'circle-stroke-width': 2,
+                'circle-stroke-color': '#ffffff',
+              }}
+            />
+          </GeoJSONSource>
+        ) : null}
+      </Map>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={t('trip.map.toggleA11y')}
+        onPress={toggle}
+        style={[
+          styles.toggle,
+          { backgroundColor: theme.colors.card, borderColor: theme.colors.border },
+        ]}
+      >
+        <Text
+          style={[
+            styles.toggleText,
+            { color: theme.colors.foreground, fontFamily: theme.fonts.sansMedium },
+          ]}
+        >
+          {satellite ? t('trip.map.layerMap') : t('trip.map.layerSatellite')}
+        </Text>
+      </Pressable>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  container: { flex: 1 },
   map: { flex: 1 },
   empty: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  toggle: {
+    position: 'absolute',
+    top: 12,
+    right: 12,
+    paddingVertical: 8,
+    paddingHorizontal: 14,
+    borderRadius: 999,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  toggleText: { fontSize: 13 },
 });

--- a/mobile/src/components/TripMap.tsx
+++ b/mobile/src/components/TripMap.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import type { FeatureCollection } from 'geojson';
 import { Camera, GeoJSONSource, Layer, Map } from '@maplibre/maplibre-react-native';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
@@ -40,6 +40,41 @@ export function TripMap({
     void load();
   }, [load]);
 
+  // Every object/collection handed to the memoized native components is derived
+  // once per input change: a fresh reference on each render would defeat the
+  // upstream React.memo (Map/Camera/GeoJSONSource) and force a native re-diff.
+  const mapStyle = useMemo(() => mapStyleFor(base), [base]);
+  const bounds = useMemo(() => computeBounds(coordinates), [coordinates]);
+  const markerData = useMemo(() => markerCollection(markers ?? []), [markers]);
+  const segmentData = useMemo(
+    () => segmentFeature(highlightedSegment ?? []),
+    [highlightedSegment],
+  );
+  const line = useMemo<FeatureCollection>(
+    () => ({
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          properties: {},
+          geometry: { type: 'LineString', coordinates },
+        },
+      ],
+    }),
+    [coordinates],
+  );
+  // maplibre-react-native v11: `initialViewState` is applied once at native
+  // mount, whereas the top-level `CameraStop` props (bounds/padding, center/zoom)
+  // are reactive — feeding `bounds` here re-frames the camera whenever the
+  // coordinates change (e.g. prev/next stage on the detail screen, #1074).
+  const cameraStop = useMemo(
+    () =>
+      bounds
+        ? { bounds, padding: FIT_PADDING }
+        : { center: coordinates[0], zoom: 8 },
+    [bounds, coordinates],
+  );
+
   if (coordinates.length === 0) {
     return (
       <View style={styles.empty}>
@@ -51,31 +86,12 @@ export function TripMap({
   }
 
   const satellite = base === 'satellite';
-  const bounds = computeBounds(coordinates);
-  const markerData = markerCollection(markers ?? []);
   const hasSegment = (highlightedSegment?.length ?? 0) >= 2;
-
-  const line: FeatureCollection = {
-    type: 'FeatureCollection',
-    features: [
-      {
-        type: 'Feature',
-        properties: {},
-        geometry: { type: 'LineString', coordinates },
-      },
-    ],
-  };
 
   return (
     <View style={styles.container}>
-      <Map style={styles.map} mapStyle={mapStyleFor(base)}>
-        <Camera
-          initialViewState={
-            bounds
-              ? { bounds, padding: FIT_PADDING }
-              : { center: coordinates[0], zoom: 8 }
-          }
-        />
+      <Map style={styles.map} mapStyle={mapStyle}>
+        <Camera {...cameraStop} />
         <GeoJSONSource id="route" data={line}>
           <Layer
             id="route-line"
@@ -88,10 +104,7 @@ export function TripMap({
           />
         </GeoJSONSource>
         {hasSegment ? (
-          <GeoJSONSource
-            id="segment-highlight"
-            data={segmentFeature(highlightedSegment ?? [])}
-          >
+          <GeoJSONSource id="segment-highlight" data={segmentData}>
             <Layer
               id="segment-highlight-line"
               type="line"

--- a/mobile/src/components/map/map-utils.test.ts
+++ b/mobile/src/components/map/map-utils.test.ts
@@ -1,0 +1,148 @@
+/// <reference types="jest" />
+import type { StageData } from '@btp/core';
+import {
+  alertSegmentToCoords,
+  buildSatelliteStyle,
+  collectMarkers,
+  computeBounds,
+  mapStyleFor,
+  markerCollection,
+  POSITRON_STYLE_URL,
+  SATELLITE_TILE_URL,
+  segmentFeature,
+} from './map-utils';
+
+function stage(overrides: Partial<StageData> = {}): StageData {
+  const zero = { lat: 0, lon: 0, ele: 0 };
+  return {
+    dayNumber: 1,
+    distance: 50,
+    elevation: 100,
+    elevationLoss: 0,
+    startPoint: zero,
+    endPoint: zero,
+    geometry: [],
+    label: null,
+    startLabel: null,
+    endLabel: null,
+    weather: null,
+    alerts: [],
+    pois: [],
+    accommodations: [],
+    selectedAccommodation: null,
+    accommodationSearchRadiusKm: 10,
+    isRestDay: false,
+    supplyTimeline: [],
+    events: [],
+    ...overrides,
+  };
+}
+
+describe('computeBounds', () => {
+  it('returns null for no coordinates', () => {
+    expect(computeBounds([])).toBeNull();
+  });
+
+  it('frames every coordinate as [west, south, east, north]', () => {
+    const bounds = computeBounds([
+      [2, 48],
+      [5, 45],
+      [-1, 50],
+    ]);
+    expect(bounds).toEqual([-1, 45, 5, 50]);
+  });
+});
+
+describe('buildSatelliteStyle / mapStyleFor', () => {
+  it('wraps the Esri World Imagery tiles in a raster style', () => {
+    const style = buildSatelliteStyle();
+    const source = style.sources['esri-world-imagery'];
+    expect(source).toMatchObject({ type: 'raster', tiles: [SATELLITE_TILE_URL] });
+    expect(style.layers[0]).toMatchObject({ type: 'raster', source: 'esri-world-imagery' });
+  });
+
+  it('returns the Positron URL for map and the satellite style object', () => {
+    expect(mapStyleFor('map')).toBe(POSITRON_STYLE_URL);
+    expect(typeof mapStyleFor('satellite')).toBe('object');
+  });
+});
+
+describe('collectMarkers', () => {
+  it('emits the trip start waypoint, each end waypoint, POIs and accommodations', () => {
+    const s = stage({
+      startPoint: { lat: 48, lon: 2, ele: 0 },
+      endPoint: { lat: 45, lon: 5, ele: 0 },
+      startLabel: 'Paris',
+      endLabel: 'Lyon',
+      pois: [{ name: 'Château', category: 'castle', lat: 46, lon: 3 }],
+      accommodations: [
+        { name: 'Gîte', type: 'guest_house', lat: 45.1, lon: 5.1, estimatedPriceMin: 40, estimatedPriceMax: 60, isExactPrice: false, possibleClosed: false, distanceToEndPoint: 0, source: 'osm' },
+      ],
+    });
+    const markers = collectMarkers([s]);
+    expect(markers).toEqual([
+      { kind: 'waypoint', lon: 2, lat: 48, name: 'Paris' },
+      { kind: 'waypoint', lon: 5, lat: 45, name: 'Lyon' },
+      { kind: 'poi', lon: 3, lat: 46, name: 'Château' },
+      { kind: 'accommodation', lon: 5.1, lat: 45.1, name: 'Gîte' },
+    ]);
+  });
+
+  it('drops null-island placeholder waypoints', () => {
+    expect(collectMarkers([stage()])).toEqual([]);
+  });
+
+  it('keeps only the selected accommodation once chosen', () => {
+    const s = stage({
+      endPoint: { lat: 45, lon: 5, ele: 0 },
+      accommodations: [
+        { name: 'A', type: 'hotel', lat: 45, lon: 5, estimatedPriceMin: 0, estimatedPriceMax: 0, isExactPrice: false, possibleClosed: false, distanceToEndPoint: 0, source: 'osm' },
+        { name: 'B', type: 'hotel', lat: 45, lon: 5, estimatedPriceMin: 0, estimatedPriceMax: 0, isExactPrice: false, possibleClosed: false, distanceToEndPoint: 0, source: 'osm' },
+      ],
+      selectedAccommodation: { name: 'A', type: 'hotel', lat: 45, lon: 5, estimatedPriceMin: 0, estimatedPriceMax: 0, isExactPrice: false, possibleClosed: false, distanceToEndPoint: 0, source: 'osm' },
+    });
+    const accommodations = collectMarkers([s]).filter((m) => m.kind === 'accommodation');
+    expect(accommodations).toEqual([{ kind: 'accommodation', lon: 5, lat: 45, name: 'A' }]);
+  });
+
+  it('emits the start waypoint only for the first stage', () => {
+    const a = stage({ startPoint: { lat: 48, lon: 2, ele: 0 }, endPoint: { lat: 45, lon: 5, ele: 0 } });
+    const b = stage({ startPoint: { lat: 45, lon: 5, ele: 0 }, endPoint: { lat: 44, lon: 6, ele: 0 } });
+    const waypoints = collectMarkers([a, b]).filter((m) => m.kind === 'waypoint');
+    // start(a) + end(a) + end(b) — start(b) is NOT re-emitted.
+    expect(waypoints).toHaveLength(3);
+  });
+});
+
+describe('markerCollection', () => {
+  it('carries the kind in feature properties', () => {
+    const fc = markerCollection([{ kind: 'poi', lon: 3, lat: 46, name: 'X' }]);
+    expect(fc.features[0]).toMatchObject({
+      properties: { kind: 'poi', name: 'X' },
+      geometry: { type: 'Point', coordinates: [3, 46] },
+    });
+  });
+});
+
+describe('alertSegmentToCoords / segmentFeature', () => {
+  it('swaps [lat, lon] to [lon, lat]', () => {
+    expect(
+      alertSegmentToCoords([
+        [48, 2],
+        [45, 5],
+      ]),
+    ).toEqual([
+      [2, 48],
+      [5, 45],
+    ]);
+  });
+
+  it('builds a LineString only when there are at least two points', () => {
+    expect(segmentFeature([[2, 48]]).features).toEqual([]);
+    const fc = segmentFeature([
+      [2, 48],
+      [5, 45],
+    ]);
+    expect(fc.features[0]).toMatchObject({ geometry: { type: 'LineString' } });
+  });
+});

--- a/mobile/src/components/map/map-utils.ts
+++ b/mobile/src/components/map/map-utils.ts
@@ -1,0 +1,153 @@
+import type { StageData } from '@btp/core';
+import type { StyleSpecification } from '@maplibre/maplibre-react-native';
+import type { FeatureCollection } from 'geojson';
+
+// The two base maps the map tab can render. Persisted via the map-prefs store.
+export type MapBase = 'map' | 'satellite';
+
+// Carto Positron — same vector style the web frontend uses.
+export const POSITRON_STYLE_URL =
+  'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json';
+
+export const SATELLITE_TILE_URL =
+  'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}';
+
+// Esri World Imagery raster tiles, wrapped in a minimal MapLibre style so the
+// satellite base needs no vendor style.json dependency.
+export function buildSatelliteStyle(): StyleSpecification {
+  return {
+    version: 8,
+    sources: {
+      'esri-world-imagery': {
+        type: 'raster',
+        tiles: [SATELLITE_TILE_URL],
+        tileSize: 256,
+        attribution: 'Esri, Maxar, Earthstar Geographics',
+      },
+    },
+    layers: [
+      { id: 'esri-world-imagery', type: 'raster', source: 'esri-world-imagery' },
+    ],
+  };
+}
+
+export function mapStyleFor(base: MapBase): string | StyleSpecification {
+  return base === 'satellite' ? buildSatelliteStyle() : POSITRON_STYLE_URL;
+}
+
+// Bounding box of all coordinates as [west, south, east, north] (MapLibre's
+// LngLatBounds), or null when there is nothing to frame. Feeds the Camera so it
+// fits the whole route rather than a fixed center/zoom.
+export function computeBounds(
+  coords: [number, number][],
+): [number, number, number, number] | null {
+  if (coords.length === 0) return null;
+  let west = Infinity;
+  let south = Infinity;
+  let east = -Infinity;
+  let north = -Infinity;
+  for (const [lon, lat] of coords) {
+    if (lon < west) west = lon;
+    if (lon > east) east = lon;
+    if (lat < south) south = lat;
+    if (lat > north) north = lat;
+  }
+  return [west, south, east, north];
+}
+
+export type MarkerKind = 'waypoint' | 'poi' | 'accommodation';
+
+export interface MapMarker {
+  kind: MarkerKind;
+  lon: number;
+  lat: number;
+  name: string;
+}
+
+// The store seeds missing endpoints with {lat:0, lon:0} (see stageDataFromDetail
+// and the rest-day placeholder), so drop null-island points to avoid a marker in
+// the Gulf of Guinea.
+function isPlaceholder(lat: number, lon: number): boolean {
+  return lat === 0 && lon === 0;
+}
+
+// Flatten the stages into map markers: the trip start waypoint, every stage end
+// waypoint, all POIs, and each stage's accommodations (the selected one alone
+// once a choice is made). Icons/colours are applied by the map layer, keyed on
+// `kind`.
+export function collectMarkers(stages: StageData[]): MapMarker[] {
+  const markers: MapMarker[] = [];
+  stages.forEach((stage, i) => {
+    const start = stage.startPoint;
+    if (i === 0 && start && !isPlaceholder(start.lat, start.lon)) {
+      markers.push({
+        kind: 'waypoint',
+        lon: start.lon,
+        lat: start.lat,
+        name: stage.startLabel ?? '',
+      });
+    }
+    const end = stage.endPoint;
+    if (end && !isPlaceholder(end.lat, end.lon)) {
+      markers.push({
+        kind: 'waypoint',
+        lon: end.lon,
+        lat: end.lat,
+        name: stage.endLabel ?? '',
+      });
+    }
+    for (const poi of stage.pois) {
+      markers.push({ kind: 'poi', lon: poi.lon, lat: poi.lat, name: poi.name });
+    }
+    const accommodations = stage.selectedAccommodation
+      ? [stage.selectedAccommodation]
+      : stage.accommodations;
+    for (const acc of accommodations) {
+      markers.push({
+        kind: 'accommodation',
+        lon: acc.lon,
+        lat: acc.lat,
+        name: acc.name,
+      });
+    }
+  });
+  return markers;
+}
+
+export function markerCollection(markers: MapMarker[]): FeatureCollection {
+  return {
+    type: 'FeatureCollection',
+    features: markers.map((m) => ({
+      type: 'Feature',
+      properties: { kind: m.kind, name: m.name },
+      geometry: { type: 'Point', coordinates: [m.lon, m.lat] },
+    })),
+  };
+}
+
+// Convert an alert action `segment` (list of [lat, lon] tuples, core #982) to the
+// [lon, lat] order MapLibre expects. Callers (stage detail / alerts) feed the
+// result to TripMap's `highlightedSegment` prop.
+export function alertSegmentToCoords(
+  segment: [number, number][],
+): [number, number][] {
+  return segment.map(([lat, lon]) => [lon, lat]);
+}
+
+// A one-LineString FeatureCollection for the highlighted stretch, or an empty
+// collection when there is nothing (or too little) to draw.
+export function segmentFeature(coords: [number, number][]): FeatureCollection {
+  return {
+    type: 'FeatureCollection',
+    features:
+      coords.length >= 2
+        ? [
+            {
+              type: 'Feature',
+              properties: {},
+              geometry: { type: 'LineString', coordinates: coords },
+            },
+          ]
+        : [],
+  };
+}

--- a/mobile/src/components/trip/TripMapView.test.tsx
+++ b/mobile/src/components/trip/TripMapView.test.tsx
@@ -1,0 +1,86 @@
+/// <reference types="jest" />
+import TestRenderer, { act } from 'react-test-renderer';
+import type { ReactElement } from 'react';
+import type { StageData } from '@btp/core';
+import '../../i18n';
+import { useTripStore } from '../../store/trip-store';
+import { collectMarkers } from '../map/map-utils';
+
+// Capture the props TripMap receives so we can assert the wired markers.
+let lastTripMapProps: Record<string, unknown> | null = null;
+jest.mock('../TripMap', () => {
+  const React = require('react');
+  return {
+    TripMap: (props: Record<string, unknown>) => {
+      lastTripMapProps = props;
+      return React.createElement('TripMap', props);
+    },
+  };
+});
+
+import { TripMapView } from './TripMapView';
+
+let current: ReturnType<typeof TestRenderer.create> | null = null;
+function render(element: ReactElement): any {
+  act(() => {
+    current = TestRenderer.create(element);
+  });
+  return current;
+}
+
+function stage(overrides: Partial<StageData> = {}): StageData {
+  const zero = { lat: 0, lon: 0, ele: 0 };
+  return {
+    dayNumber: 1,
+    distance: 50,
+    elevation: 100,
+    elevationLoss: 0,
+    startPoint: zero,
+    endPoint: zero,
+    geometry: [],
+    label: null,
+    startLabel: null,
+    endLabel: null,
+    weather: null,
+    alerts: [],
+    pois: [],
+    accommodations: [],
+    selectedAccommodation: null,
+    accommodationSearchRadiusKm: 10,
+    isRestDay: false,
+    supplyTimeline: [],
+    events: [],
+    ...overrides,
+  };
+}
+
+const routedStage = stage({
+  geometry: [
+    { lat: 48, lon: 2, ele: 100 },
+    { lat: 48.01, lon: 2.01, ele: 200 },
+  ],
+  pois: [{ name: 'Café', category: 'amenity', lat: 48.01, lon: 2.01 }] as StageData['pois'],
+});
+
+describe('TripMapView', () => {
+  beforeEach(() => {
+    lastTripMapProps = null;
+    act(() => {
+      useTripStore.getState().reset();
+      useTripStore.setState({ stages: [routedStage] });
+    });
+  });
+
+  afterEach(() => {
+    act(() => {
+      current?.unmount();
+    });
+    current = null;
+  });
+
+  it('derives the markers from the store stages and forwards them to TripMap', () => {
+    render(<TripMapView />);
+    expect(lastTripMapProps).not.toBeNull();
+    expect(lastTripMapProps!.markers).toEqual(collectMarkers([routedStage]));
+  });
+});

--- a/mobile/src/components/trip/TripMapView.tsx
+++ b/mobile/src/components/trip/TripMapView.tsx
@@ -2,11 +2,12 @@ import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { EmptyState } from '../ui';
 import { TripMap } from '../TripMap';
+import { collectMarkers } from '../map/map-utils';
 import { useTripStore } from '../../store/trip-store';
 
-// The map tab: derives the route polyline from the store's stages and hands it to
-// the shared TripMap, or shows the empty state when there is no geometry yet.
-// #1040 layers markers (accommodations, POIs, alerts) onto this view.
+// The map tab: derives the route polyline and markers from the store's stages
+// and hands them to the shared TripMap, or shows the empty state when there is
+// no geometry yet. #1040 adds base-map toggle, markers and fit-bounds.
 export function TripMapView() {
   const { t } = useTranslation();
   const stages = useTripStore((s) => s.stages);
@@ -21,8 +22,10 @@ export function TripMapView() {
     return coords;
   }, [stages]);
 
+  const markers = useMemo(() => collectMarkers(stages), [stages]);
+
   if (coordinates.length === 0) {
     return <EmptyState title={t('trip.mapEmpty')} />;
   }
-  return <TripMap coordinates={coordinates} />;
+  return <TripMap coordinates={coordinates} markers={markers} />;
 }

--- a/mobile/src/i18n/resources/en.ts
+++ b/mobile/src/i18n/resources/en.ts
@@ -86,6 +86,11 @@ export const en: typeof fr = {
     sse: {
       computing: 'Computing…',
     },
+    map: {
+      layerMap: 'Map',
+      layerSatellite: 'Satellite',
+      toggleA11y: 'Toggle base map',
+    },
     blocks: {
       distanceKm: '{{distance}} km',
       alerts: 'Alerts',

--- a/mobile/src/i18n/resources/fr.ts
+++ b/mobile/src/i18n/resources/fr.ts
@@ -84,6 +84,11 @@ export const fr = {
     sse: {
       computing: 'Calcul en cours…',
     },
+    map: {
+      layerMap: 'Plan',
+      layerSatellite: 'Satellite',
+      toggleA11y: 'Changer le fond de carte',
+    },
     blocks: {
       distanceKm: '{{distance}} km',
       alerts: 'Alertes',

--- a/mobile/src/store/map-prefs.test.ts
+++ b/mobile/src/store/map-prefs.test.ts
@@ -1,0 +1,54 @@
+/// <reference types="jest" />
+import * as SecureStore from 'expo-secure-store';
+import { useMapPrefs } from './map-prefs';
+
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: jest.fn(),
+  setItemAsync: jest.fn(),
+}));
+
+const getItem = SecureStore.getItemAsync as jest.Mock;
+const setItem = SecureStore.setItemAsync as jest.Mock;
+
+beforeEach(() => {
+  getItem.mockReset();
+  setItem.mockReset();
+  useMapPrefs.setState({ base: 'map', hydrated: false });
+});
+
+describe('useMapPrefs', () => {
+  it('defaults to the map base', () => {
+    expect(useMapPrefs.getState().base).toBe('map');
+  });
+
+  it('persists the choice on setBase', () => {
+    useMapPrefs.getState().setBase('satellite');
+    expect(useMapPrefs.getState().base).toBe('satellite');
+    expect(setItem).toHaveBeenCalledWith('btp_map_base', 'satellite');
+  });
+
+  it('toggle flips between map and satellite', () => {
+    useMapPrefs.getState().toggle();
+    expect(useMapPrefs.getState().base).toBe('satellite');
+    useMapPrefs.getState().toggle();
+    expect(useMapPrefs.getState().base).toBe('map');
+  });
+
+  it('load hydrates the stored satellite choice once', async () => {
+    getItem.mockResolvedValue('satellite');
+    await useMapPrefs.getState().load();
+    expect(useMapPrefs.getState()).toMatchObject({ base: 'satellite', hydrated: true });
+
+    getItem.mockResolvedValue('map');
+    await useMapPrefs.getState().load();
+    // Already hydrated: the second load is a no-op, the stored value is not re-read.
+    expect(getItem).toHaveBeenCalledTimes(1);
+    expect(useMapPrefs.getState().base).toBe('satellite');
+  });
+
+  it('load falls back to map for an unknown stored value', async () => {
+    getItem.mockResolvedValue(null);
+    await useMapPrefs.getState().load();
+    expect(useMapPrefs.getState().base).toBe('map');
+  });
+});

--- a/mobile/src/store/map-prefs.ts
+++ b/mobile/src/store/map-prefs.ts
@@ -1,0 +1,33 @@
+import { create } from 'zustand';
+import * as SecureStore from 'expo-secure-store';
+import type { MapBase } from '../components/map/map-utils';
+
+// SecureStore key (alnum/._- only). SecureStore is the only KV the mobile app
+// ships (it also backs the auth tokens), so the base-map choice rides along
+// there rather than pulling in AsyncStorage.
+const KEY = 'btp_map_base';
+
+interface MapPrefsState {
+  base: MapBase;
+  hydrated: boolean;
+  setBase: (base: MapBase) => void;
+  toggle: () => void;
+  load: () => Promise<void>;
+}
+
+// Persisted base-map choice (Positron plan vs Esri satellite). The write is
+// fire-and-forget so the toggle stays synchronous; `load()` hydrates once.
+export const useMapPrefs = create<MapPrefsState>((set, get) => ({
+  base: 'map',
+  hydrated: false,
+  setBase: (base) => {
+    set({ base });
+    void SecureStore.setItemAsync(KEY, base);
+  },
+  toggle: () => get().setBase(get().base === 'satellite' ? 'map' : 'satellite'),
+  load: async () => {
+    if (get().hydrated) return;
+    const stored = await SecureStore.getItemAsync(KEY);
+    set({ base: stored === 'satellite' ? 'satellite' : 'map', hydrated: true });
+  },
+}));


### PR DESCRIPTION
Closes #1040

> Stacked PR — base `feature/1038` (#1038). Note : dépend fonctionnellement de #1035 (store) ; placé au-dessus de #1038 dans le stack car fichiers disjoints (carte vs blocs data).

## Contexte
Sprint 55 (Consultation). Segment Carte de l'écran voyage.

## Changements
- `components/map/map-utils.ts` (pur, testé) : `computeBounds`, `collectMarkers`, `mapStyleFor`, `buildSatelliteStyle` (raster Esri World Imagery), `alertSegmentToCoords` ([lat,lon] core → [lon,lat] MapLibre).
- `store/map-prefs.ts` : toggle tuiles map (Carto Positron) / satellite (Esri) **persisté** via `expo-secure-store` (KV déjà embarqué — pas de dépendance ajoutée).
- `TripMap.tsx` : refonte (toggle, markers GeoJSON `circle` data-driven, fit-bounds via `Camera.bounds`, source/layer `segment-highlight` distincts). Prop **`highlightedSegment?: [number, number][]`** exposée.
- `TripMapView.tsx` : dérive et passe les markers. i18n `trip.map.*` (fr+en synchronisés).

## Vérification
- `tsc --noEmit` : clean.
- `jest` : 152 tests verts sur le tip combiné (map-utils + map-prefs inclus). `computeBounds` prouvé rouge-puis-vert.

## Auto-critique
- Markers rendus en une couche GeoJSON `circle` (perf) plutôt qu'en annotations natives.
- `TripMapView.tsx` partagé avec #1041 (conteneur) : #1041 y pilote le highlight, `TripMap.tsx`/`map-utils.ts` restent la source. Pas de DTO, pas de dépendance.

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 critical, 0 warning, 0 suggestion. Independently reviewed `map-utils.ts`, `map-prefs.ts`, `TripMap.tsx`, `TripMapView.tsx`, and the tests/i18n additions against the pinned versions in `mobile/package.json` (`@maplibre/maplibre-react-native@^11.3.6`, `expo-secure-store@~57.0.1`, `zustand@^5.0.2`). Independently fetched the `v11.3.6` docs/examples from the upstream repo to verify `Camera`'s `bounds`/`padding` shapes: `LngLatBounds` is a flat `[west, south, east, north]` tuple and `padding` is `{top, right, bottom, left}` — both match `computeBounds()`/`FIT_PADDING` exactly. The POI/accommodation color collision fix (`accentInk` vs `brand`/`primary`) was verified against `theme/tokens.ts`: all three hexes are distinct in both light and dark themes. The `isPlaceholder({lat:0,lon:0})` rationale was verified against `stageDataFromDetail` in `trip-store.ts`. No debug leftovers, no new TODO/FIXME, no unvalidated input, no HTTP-client/XXE concerns (satellite tiles are fetched client-side by MapLibre, not proxied through a backend HTTP client). The previously-flagged `TripMapView.tsx` markers-wiring test gap is now covered by `TripMapView.test.tsx` (added in `9101903`).

**Resolved threads:** Resolved 1 previously open thread (`TripMapView.tsx` markers-derivation test coverage), addressed by the latest commit.

**PR title check:** Not a Conventional Commits `<type>(<scope>): <imperative description>` per the letter of the convention (noun phrase, not imperative), but this matches the established pattern across this project's prior merged `feat(mobile)` PRs (e.g. #1061, #1063) — not flagged.

**Review checklist:**
- [x] Code respects the project architecture (local-first, `@btp/core` shared types, no new dependency)
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate (pure `map-utils.ts` helpers, memoized derived values, Zustand pref store)
- [x] Tests cover new/changed cases (`map-utils.test.ts`, `map-prefs.test.ts`, `TripMap.test.tsx`, `TripMapView.test.tsx` all present)
- [x] Documentation is up to date (i18n fr/en kept in sync)
- [x] Dependent tickets accounted for (`highlightedSegment` prop deliberately left unwired, per PR description, for #1041)

**Inline comments:** No inline comments.

**Commit reviewed:** `9101903b69a6ba2b518f7525659a4a5651dcd683`
<!-- claude-review-end -->