### PR TITLE
feat(mobile): profil altimétrique svg + hover tactile synchronisé carte↔profil (#1041)

### DIFF
--- a/core/elevation.ts
+++ b/core/elevation.ts
@@ -1,0 +1,153 @@
+// Pure elevation-profile maths shared by the web and mobile clients (#1041).
+// Extracted (same semantics) from the web ElevationProfile component
+// (pwa/src/components/Map/ElevationProfile.tsx) so both platforms build the
+// identical cumulative distance/altitude profile and hover mapping. No React /
+// React Native / SVG dependency — only the `StageData` shape from schemas.
+//
+// The web component still owns its own copy for now; this module is the
+// framework-free source both consumers are meant to converge on (mobile does so
+// in #1041; the web migration is deliberately out of scope here).
+
+import type { StageData } from "./schemas";
+
+/** Haversine distance between two lat/lon points, in kilometres. */
+export function haversineKm(
+  lat1: number,
+  lon1: number,
+  lat2: number,
+  lon2: number,
+): number {
+  const R = 6371;
+  const dLat = ((lat2 - lat1) * Math.PI) / 180;
+  const dLon = ((lon2 - lon1) * Math.PI) / 180;
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos((lat1 * Math.PI) / 180) *
+      Math.cos((lat2 * Math.PI) / 180) *
+      Math.sin(dLon / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+/** One sampled point of the cumulative elevation profile. */
+export interface ProfilePoint {
+  /** Cumulative distance from the trip (or focused stage) start, in km. */
+  distanceKm: number;
+  /** Elevation at this point, in metres. */
+  ele: number;
+  /** Slope from the previous point to this one, in percent. 0 for the first. */
+  gradient: number;
+  /** Index into the rest-day-filtered active stages. */
+  stageIndex: number;
+  /** Index into that stage's `geometry` array. */
+  coordIndex: number;
+}
+
+/**
+ * Build a flat array of cumulative profile points for one or all stages. Rest
+ * days are excluded and `stageIndex` refers to the position within the
+ * rest-day-filtered active stages (so it maps directly to the map's active-stage
+ * indexing). With `focusedStageIndex` set, only that active stage is profiled;
+ * with `null`, every active stage is concatenated into one continuous profile.
+ */
+export function buildProfilePoints(
+  stages: StageData[],
+  focusedStageIndex: number | null,
+): ProfilePoint[] {
+  const activeStages = stages.filter((s) => !s.isRestDay);
+  const entries: { stage: StageData; stageIndex: number }[] =
+    focusedStageIndex !== null
+      ? activeStages[focusedStageIndex]
+        ? [{ stage: activeStages[focusedStageIndex]!, stageIndex: focusedStageIndex }]
+        : []
+      : activeStages.map((stage, idx) => ({ stage, stageIndex: idx }));
+
+  const points: ProfilePoint[] = [];
+  let cumulativeKm = 0;
+  let prevEle: number | null = null;
+  let prevDistKm: number | null = null;
+
+  for (const { stage, stageIndex } of entries) {
+    const coords = stage.geometry;
+    if (coords.length < 2) continue;
+
+    for (let ci = 0; ci < coords.length; ci++) {
+      const currEle = coords[ci]!.ele;
+      let distKm = cumulativeKm;
+
+      if (ci > 0) {
+        const prev = coords[ci - 1]!;
+        const curr = coords[ci]!;
+        const lastPoint = points[points.length - 1];
+        distKm =
+          (lastPoint?.distanceKm ?? cumulativeKm) +
+          haversineKm(prev.lat, prev.lon, curr.lat, curr.lon);
+      }
+
+      let gradient = 0;
+      if (prevEle !== null && prevDistKm !== null) {
+        const deltaKm = distKm - prevDistKm;
+        if (deltaKm > 0) gradient = ((currEle - prevEle) / (deltaKm * 1000)) * 100;
+      }
+      prevEle = currEle;
+      prevDistKm = distKm;
+
+      points.push({ distanceKm: distKm, ele: currEle, gradient, stageIndex, coordIndex: ci });
+    }
+
+    cumulativeKm = points[points.length - 1]?.distanceKm ?? cumulativeKm;
+  }
+
+  return points;
+}
+
+/**
+ * Binary search for the profile point whose `distanceKm` is closest to `target`.
+ * Returns `undefined` for an empty array. Assumes `points` is sorted by
+ * `distanceKm` ascending (as {@link buildProfilePoints} produces).
+ */
+export function findClosestProfilePoint<T extends { distanceKm: number }>(
+  points: T[],
+  target: number,
+): T | undefined {
+  if (points.length === 0) return undefined;
+  let lo = 0;
+  let hi = points.length - 1;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (points[mid]!.distanceKm < target) lo = mid + 1;
+    else hi = mid;
+  }
+  if (
+    lo > 0 &&
+    Math.abs(points[lo - 1]!.distanceKm - target) <
+      Math.abs(points[lo]!.distanceKm - target)
+  ) {
+    return points[lo - 1]!;
+  }
+  return points[lo]!;
+}
+
+/**
+ * Two-point [lon, lat] stretch surrounding a hovered profile point, ready to
+ * feed the map's `highlightedSegment`. `stageIndex` is an active-stage index
+ * (rest days filtered, matching {@link buildProfilePoints}). Returns the hovered
+ * geometry point plus its next neighbour (or previous, at the stage end), or an
+ * empty array when the point cannot be located.
+ */
+export function profileHighlightSegment(
+  stages: StageData[],
+  stageIndex: number,
+  coordIndex: number,
+): [number, number][] {
+  const stage = stages.filter((s) => !s.isRestDay)[stageIndex];
+  if (!stage) return [];
+  const coords = stage.geometry;
+  const a = coords[coordIndex];
+  if (!a) return [];
+  const b = coords[coordIndex + 1] ?? coords[coordIndex - 1];
+  if (!b) return [];
+  return [
+    [a.lon, a.lat],
+    [b.lon, b.lat],
+  ];
+}

--- a/core/index.ts
+++ b/core/index.ts
@@ -1,1 +1,2 @@
 export * from "./schemas";
+export * from "./elevation";

--- a/core/package.json
+++ b/core/package.json
@@ -9,6 +9,7 @@
     "./constants": "./accommodation-constants.ts",
     "./mercure": "./mercure.ts",
     "./reconciliation": "./reconciliation.ts",
+    "./elevation": "./elevation.ts",
     "./package.json": "./package.json"
   },
   "dependencies": {

--- a/mobile/jest.config.js
+++ b/mobile/jest.config.js
@@ -5,6 +5,7 @@ module.exports = {
   // node_modules) so jest-expo's babel transform picks them up (#1014).
   moduleNameMapper: {
     '^@btp/core/reconciliation$': '<rootDir>/../core/reconciliation.ts',
+    '^@btp/core/elevation$': '<rootDir>/../core/elevation.ts',
     '^@btp/core/mercure$': '<rootDir>/../core/mercure.ts',
     '^@btp/core/schema$': '<rootDir>/../core/schema.d.ts',
     '^@btp/core/constants$': '<rootDir>/../core/accommodation-constants.ts',

--- a/mobile/src/components/trip/ElevationProfile.test.tsx
+++ b/mobile/src/components/trip/ElevationProfile.test.tsx
@@ -1,0 +1,100 @@
+/// <reference types="jest" />
+import TestRenderer, { act } from 'react-test-renderer';
+import type { ReactElement } from 'react';
+import type { StageData } from '@btp/core';
+import '../../i18n';
+import { ElevationProfile } from './ElevationProfile';
+
+// Render react-native-svg as inert host-like components so the tree resolves
+// under react-test-renderer without the native module.
+jest.mock('react-native-svg', () => {
+  const React = require('react');
+  const make = (name: string) => (props: Record<string, unknown>) =>
+    React.createElement(name, props, (props as { children?: unknown }).children);
+  const Svg = make('Svg');
+  return { __esModule: true, default: Svg, Svg, Path: make('Path'), Line: make('Line'), G: make('G') };
+});
+
+function render(element: ReactElement): any {
+  let out: any;
+  act(() => {
+    out = TestRenderer.create(element);
+  });
+  return out;
+}
+
+function stage(overrides: Partial<StageData> = {}): StageData {
+  const zero = { lat: 0, lon: 0, ele: 0 };
+  return {
+    dayNumber: 1,
+    distance: 50,
+    elevation: 100,
+    elevationLoss: 0,
+    startPoint: zero,
+    endPoint: zero,
+    geometry: [],
+    label: null,
+    startLabel: null,
+    endLabel: null,
+    weather: null,
+    alerts: [],
+    pois: [],
+    accommodations: [],
+    selectedAccommodation: null,
+    accommodationSearchRadiusKm: 10,
+    isRestDay: false,
+    supplyTimeline: [],
+    events: [],
+    ...overrides,
+  };
+}
+
+const climbingStage = stage({
+  geometry: [
+    { lat: 48, lon: 2, ele: 100 },
+    { lat: 48.01, lon: 2, ele: 200 },
+    { lat: 48.02, lon: 2, ele: 150 },
+  ],
+});
+
+describe('ElevationProfile', () => {
+  it('renders nothing without at least two profile points', () => {
+    const tree = render(
+      <ElevationProfile stages={[stage()]} focusedStageIndex={null} onHover={jest.fn()} />,
+    );
+    expect(tree.toJSON()).toBeNull();
+  });
+
+  it('renders one area Path per active stage', () => {
+    const tree = render(
+      <ElevationProfile stages={[climbingStage]} focusedStageIndex={null} onHover={jest.fn()} />,
+    );
+    const paths = tree.root.findAllByType('Path' as never);
+    expect(paths).toHaveLength(1);
+    expect(typeof paths[0]!.props.d).toBe('string');
+  });
+
+  it('reports the hovered coord/stage on touch and clears on release', () => {
+    const onHover = jest.fn();
+    const tree = render(
+      <ElevationProfile stages={[climbingStage]} focusedStageIndex={null} onHover={onHover} />,
+    );
+    const view = tree.root.findByProps({ testID: 'elevation-profile' });
+    act(() => {
+      view.props.onLayout({ nativeEvent: { layout: { width: 800 } } });
+    });
+    act(() => {
+      // Far right of the profile → the last geometry coord of the stage.
+      view.props.onResponderGrant({ nativeEvent: { locationX: 800 } });
+    });
+    expect(onHover).toHaveBeenCalledWith(2, 0);
+    // A crosshair Line appears while hovering.
+    expect(tree.root.findAllByType('Line' as never)).toHaveLength(1);
+
+    act(() => {
+      view.props.onResponderRelease();
+    });
+    expect(onHover).toHaveBeenLastCalledWith(null, null);
+    expect(tree.root.findAllByType('Line' as never)).toHaveLength(0);
+  });
+});

--- a/mobile/src/components/trip/ElevationProfile.test.tsx
+++ b/mobile/src/components/trip/ElevationProfile.test.tsx
@@ -3,7 +3,7 @@ import TestRenderer, { act } from 'react-test-renderer';
 import type { ReactElement } from 'react';
 import type { StageData } from '@btp/core';
 import '../../i18n';
-import { ElevationProfile } from './ElevationProfile';
+import { ElevationProfile, projectTouchToDistanceKm } from './ElevationProfile';
 
 // Render react-native-svg as inert host-like components so the tree resolves
 // under react-test-renderer without the native module.
@@ -55,6 +55,32 @@ const climbingStage = stage({
     { lat: 48.01, lon: 2, ele: 200 },
     { lat: 48.02, lon: 2, ele: 150 },
   ],
+});
+
+describe('projectTouchToDistanceKm (padding-aware touch mapping)', () => {
+  // Container has 8px horizontal padding; onLayout reports the border-box width
+  // (816 here → 800px content box that the Svg fills at width="100%").
+  const WIDTH = 816;
+
+  it('maps the left content edge to ~0 km, not into the profile', () => {
+    // A touch at the left content edge (locationX = PAD_H) must land at distance
+    // 0, not drift right. Without de-padding, svgX would be (8/816)*800 ≈ 7.84,
+    // yielding a positive distance — this asserts the corrected mapping is ≤ 0.
+    expect(projectTouchToDistanceKm(8, WIDTH, 100)).toBeLessThanOrEqual(0);
+  });
+
+  it('maps the right content edge to (near) the full distance', () => {
+    expect(projectTouchToDistanceKm(WIDTH - 8, WIDTH, 100)).toBeGreaterThanOrEqual(99);
+  });
+
+  it('clamps touches inside the padding gutters to the content box', () => {
+    expect(projectTouchToDistanceKm(0, WIDTH, 100)).toBeLessThanOrEqual(0);
+    expect(projectTouchToDistanceKm(WIDTH, WIDTH, 100)).toBeGreaterThanOrEqual(99);
+  });
+
+  it('returns null before the container has been measured', () => {
+    expect(projectTouchToDistanceKm(100, 0, 100)).toBeNull();
+  });
 });
 
 describe('ElevationProfile', () => {

--- a/mobile/src/components/trip/ElevationProfile.test.tsx
+++ b/mobile/src/components/trip/ElevationProfile.test.tsx
@@ -97,4 +97,30 @@ describe('ElevationProfile', () => {
     expect(onHover).toHaveBeenLastCalledWith(null, null);
     expect(tree.root.findAllByType('Line' as never)).toHaveLength(0);
   });
+
+  it('bubbles onHover only when the resolved point index changes', () => {
+    const onHover = jest.fn();
+    const tree = render(
+      <ElevationProfile stages={[climbingStage]} focusedStageIndex={null} onHover={onHover} />,
+    );
+    const view = tree.root.findByProps({ testID: 'elevation-profile' });
+    act(() => {
+      view.props.onLayout({ nativeEvent: { layout: { width: 800 } } });
+    });
+    // Two moves landing on the same nearest coord → a single onHover call.
+    act(() => {
+      view.props.onResponderGrant({ nativeEvent: { locationX: 799 } });
+    });
+    act(() => {
+      view.props.onResponderMove({ nativeEvent: { locationX: 800 } });
+    });
+    expect(onHover).toHaveBeenCalledTimes(1);
+    expect(onHover).toHaveBeenLastCalledWith(2, 0);
+    // A move resolving to a different coord fires again.
+    act(() => {
+      view.props.onResponderMove({ nativeEvent: { locationX: 0 } });
+    });
+    expect(onHover).toHaveBeenCalledTimes(2);
+    expect(onHover).toHaveBeenLastCalledWith(0, 0);
+  });
 });

--- a/mobile/src/components/trip/ElevationProfile.tsx
+++ b/mobile/src/components/trip/ElevationProfile.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import {
   type GestureResponderEvent,
   type LayoutChangeEvent,
@@ -48,6 +48,10 @@ export function ElevationProfile({
     gradient: number;
     distance: number;
   } | null>(null);
+  // Last (stageIndex, coordIndex) emitted to the parent. onResponderMove fires
+  // per pixel; we only bubble onHover when the resolved point actually changes,
+  // so the parent (and its map work) is not re-run on every frame.
+  const lastEmitted = useRef<{ stageIndex: number; coordIndex: number } | null>(null);
 
   const points = useMemo(
     () => buildProfilePoints(stages, focusedStageIndex),
@@ -115,11 +119,16 @@ export function ElevationProfile({
     const distKm = ((svgX - PAD_L) / (VW - PAD_L - PAD_R)) * maxDist;
     const best = findClosestProfilePoint(points, distKm);
     if (!best) return;
-    onHover(best.coordIndex, best.stageIndex);
+    const prev = lastEmitted.current;
+    if (!prev || prev.stageIndex !== best.stageIndex || prev.coordIndex !== best.coordIndex) {
+      lastEmitted.current = { stageIndex: best.stageIndex, coordIndex: best.coordIndex };
+      onHover(best.coordIndex, best.stageIndex);
+    }
     setHover({ x: toX(best.distanceKm), gradient: best.gradient, distance: best.distanceKm });
   };
 
   const handleRelease = () => {
+    lastEmitted.current = null;
     onHover(null, null);
     setHover(null);
   };

--- a/mobile/src/components/trip/ElevationProfile.tsx
+++ b/mobile/src/components/trip/ElevationProfile.tsx
@@ -21,6 +21,28 @@ const PAD_R = 8;
 const PAD_T = 8;
 const PAD_B = 20;
 const SVG_HEIGHT = 100;
+// Horizontal padding of the touch container (styles.container). onLayout reports
+// the border-box width (padding included), but the Svg (width="100%") only fills
+// the content box, so touch X must be de-padded before projecting into viewBox
+// space or the hovered point drifts right as the finger moves (kept in sync with
+// styles.container.paddingHorizontal).
+const PAD_H = 8;
+
+// Project a touch X (relative to the container's left border, padding included)
+// onto a cumulative distance in km. De-pads and clamps to the Svg content box —
+// which the Svg fills at width="100%" — before mapping viewBox → distance.
+// Returns null when the content box has no width yet. Exported for unit testing.
+export function projectTouchToDistanceKm(
+  locationX: number,
+  width: number,
+  maxDist: number,
+): number | null {
+  const contentWidth = width - 2 * PAD_H;
+  if (contentWidth <= 0) return null;
+  const contentX = Math.min(Math.max(locationX - PAD_H, 0), contentWidth);
+  const svgX = (contentX / contentWidth) * VW;
+  return ((svgX - PAD_L) / (VW - PAD_L - PAD_R)) * maxDist;
+}
 
 interface ElevationProfileProps {
   stages: StageData[];
@@ -113,10 +135,9 @@ export function ElevationProfile({
   }, [points, hasData, maxDist, displayMinEle, displayMaxEle]);
 
   const handleTouch = (e: GestureResponderEvent) => {
-    if (!hasData || width === 0) return;
-    const locationX = e.nativeEvent.locationX;
-    const svgX = (locationX / width) * VW;
-    const distKm = ((svgX - PAD_L) / (VW - PAD_L - PAD_R)) * maxDist;
+    if (!hasData) return;
+    const distKm = projectTouchToDistanceKm(e.nativeEvent.locationX, width, maxDist);
+    if (distKm === null) return;
     const best = findClosestProfilePoint(points, distKm);
     if (!best) return;
     const prev = lastEmitted.current;
@@ -227,7 +248,7 @@ const styles = StyleSheet.create({
     width: '100%',
     borderWidth: StyleSheet.hairlineWidth,
     borderRadius: 12,
-    paddingHorizontal: 8,
+    paddingHorizontal: PAD_H,
     paddingVertical: 4,
   },
   tooltip: {

--- a/mobile/src/components/trip/ElevationProfile.tsx
+++ b/mobile/src/components/trip/ElevationProfile.tsx
@@ -1,0 +1,232 @@
+import { useMemo, useState } from 'react';
+import {
+  type GestureResponderEvent,
+  type LayoutChangeEvent,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import Svg, { Line, Path } from 'react-native-svg';
+import { useTranslation } from 'react-i18next';
+import type { StageData } from '@btp/core';
+import { buildProfilePoints, findClosestProfilePoint } from '@btp/core/elevation';
+import { useTheme } from '../../theme';
+
+// SVG viewport constants (mirrors the web profile). The Svg fills its container
+// width via a non-uniform viewBox; touch X is projected back into this space.
+const VW = 800;
+const VH = 160;
+const PAD_L = 4;
+const PAD_R = 8;
+const PAD_T = 8;
+const PAD_B = 20;
+const SVG_HEIGHT = 100;
+
+interface ElevationProfileProps {
+  stages: StageData[];
+  focusedStageIndex: number | null;
+  // Fires the hovered geometry point (active-stage index + coord index) as the
+  // finger moves, or (null, null) on release, so the container can drive the map
+  // highlight. Reciprocity is one-way (profile → map).
+  onHover: (coordIndex: number | null, stageIndex: number | null) => void;
+}
+
+// Touch-driven elevation profile in react-native-svg: per-active-stage area
+// paths under a cumulative distance axis, with a crosshair + gradient/distance
+// tooltip following the finger. Portage of the web SVG profile (#1041), reusing
+// the shared @btp/core elevation maths.
+export function ElevationProfile({
+  stages,
+  focusedStageIndex,
+  onHover,
+}: ElevationProfileProps) {
+  const theme = useTheme();
+  const { t } = useTranslation();
+  const [width, setWidth] = useState(0);
+  const [hover, setHover] = useState<{
+    x: number;
+    gradient: number;
+    distance: number;
+  } | null>(null);
+
+  const points = useMemo(
+    () => buildProfilePoints(stages, focusedStageIndex),
+    [stages, focusedStageIndex],
+  );
+  const hasData = points.length >= 2;
+
+  const { maxDist, displayMinEle, displayMaxEle } = useMemo(() => {
+    if (!hasData) return { maxDist: 0, displayMinEle: 0, displayMaxEle: 1000 };
+    const minEle = Math.min(...points.map((p) => p.ele));
+    const maxEle = Math.max(...points.map((p) => p.ele));
+    const dist = points[points.length - 1]?.distanceKm ?? 0;
+    const elevRange = maxEle - minEle;
+    // Small buffer below the baseline, generous headroom above so peaks breathe
+    // (terrain sits in the bottom third, Komoot-style) — same as the web profile.
+    const bufferBelow = Math.max(elevRange * 0.1, 10);
+    const bufferAbove = Math.max(elevRange * 1.5, 100);
+    return {
+      maxDist: dist,
+      displayMinEle: minEle - bufferBelow,
+      displayMaxEle: maxEle + bufferAbove,
+    };
+  }, [points, hasData]);
+
+  const toX = (distKm: number) =>
+    PAD_L + (distKm / (maxDist || 1)) * (VW - PAD_L - PAD_R);
+  const toY = (ele: number) => {
+    const range = displayMaxEle - displayMinEle || 1;
+    return PAD_T + (1 - (ele - displayMinEle) / range) * (VH - PAD_T - PAD_B);
+  };
+
+  const stagePaths = useMemo(() => {
+    if (!hasData) return [];
+    const byStage = new Map<number, typeof points>();
+    for (const pt of points) {
+      const arr = byStage.get(pt.stageIndex) ?? [];
+      arr.push(pt);
+      byStage.set(pt.stageIndex, arr);
+    }
+    const result: { stageIndex: number; d: string }[] = [];
+    byStage.forEach((pts, stageIndex) => {
+      if (pts.length < 2) return;
+      const firstPt = pts[0]!;
+      const lastPt = pts[pts.length - 1]!;
+      const lineD = pts
+        .map(
+          (pt, i) =>
+            `${i === 0 ? 'M' : 'L'}${toX(pt.distanceKm).toFixed(1)},${toY(pt.ele).toFixed(1)}`,
+        )
+        .join(' ');
+      const d =
+        lineD +
+        ` L${toX(lastPt.distanceKm).toFixed(1)},${(VH - PAD_B).toFixed(1)}` +
+        ` L${toX(firstPt.distanceKm).toFixed(1)},${(VH - PAD_B).toFixed(1)} Z`;
+      result.push({ stageIndex, d });
+    });
+    return result;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [points, hasData, maxDist, displayMinEle, displayMaxEle]);
+
+  const handleTouch = (e: GestureResponderEvent) => {
+    if (!hasData || width === 0) return;
+    const locationX = e.nativeEvent.locationX;
+    const svgX = (locationX / width) * VW;
+    const distKm = ((svgX - PAD_L) / (VW - PAD_L - PAD_R)) * maxDist;
+    const best = findClosestProfilePoint(points, distKm);
+    if (!best) return;
+    onHover(best.coordIndex, best.stageIndex);
+    setHover({ x: toX(best.distanceKm), gradient: best.gradient, distance: best.distanceKm });
+  };
+
+  const handleRelease = () => {
+    onHover(null, null);
+    setHover(null);
+  };
+
+  if (!hasData) return null;
+
+  const flipLeft = hover !== null && hover.x > VW * 0.6;
+
+  return (
+    <View
+      testID="elevation-profile"
+      accessibilityLabel={t('trip.elevationProfileA11y')}
+      onLayout={(e: LayoutChangeEvent) => setWidth(e.nativeEvent.layout.width)}
+      onStartShouldSetResponder={() => true}
+      onMoveShouldSetResponder={() => true}
+      onResponderGrant={handleTouch}
+      onResponderMove={handleTouch}
+      onResponderRelease={handleRelease}
+      onResponderTerminate={handleRelease}
+      style={[
+        styles.container,
+        { backgroundColor: theme.colors.card, borderColor: theme.colors.border },
+      ]}
+    >
+      <Svg
+        width="100%"
+        height={SVG_HEIGHT}
+        viewBox={`0 0 ${VW} ${VH}`}
+        preserveAspectRatio="none"
+      >
+        {stagePaths.map(({ stageIndex, d }) => (
+          <Path
+            key={stageIndex}
+            d={d}
+            fill={theme.colors.brand}
+            fillOpacity={0.35}
+            stroke={theme.colors.brand}
+            strokeWidth={1.5}
+            strokeOpacity={0.8}
+          />
+        ))}
+        {hover !== null ? (
+          <Line
+            testID="elevation-crosshair"
+            x1={hover.x}
+            y1={PAD_T}
+            x2={hover.x}
+            y2={VH - PAD_B}
+            stroke={theme.colors.mutedForeground}
+            strokeWidth={1}
+            opacity={0.6}
+          />
+        ) : null}
+      </Svg>
+
+      {hover !== null ? (
+        <View
+          pointerEvents="none"
+          style={[
+            styles.tooltip,
+            {
+              backgroundColor: theme.colors.card,
+              borderColor: theme.colors.border,
+              left: `${(hover.x / VW) * 100}%`,
+              transform: [{ translateX: flipLeft ? -96 : 8 }],
+            },
+          ]}
+        >
+          <Text
+            style={{
+              color: theme.colors.foreground,
+              fontFamily: theme.fonts.sansMedium,
+              fontSize: 12,
+            }}
+          >
+            {hover.gradient >= 0 ? '+' : ''}
+            {hover.gradient.toFixed(1)}%
+          </Text>
+          <Text
+            style={{
+              color: theme.colors.mutedForeground,
+              fontFamily: theme.fonts.mono,
+              fontSize: 12,
+            }}
+          >
+            {hover.distance.toFixed(1)} km
+          </Text>
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    width: '100%',
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 12,
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+  },
+  tooltip: {
+    position: 'absolute',
+    top: 4,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 6,
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+  },
+});

--- a/mobile/src/components/trip/TripMapView.test.tsx
+++ b/mobile/src/components/trip/TripMapView.test.tsx
@@ -6,7 +6,8 @@ import '../../i18n';
 import { useTripStore } from '../../store/trip-store';
 import { collectMarkers } from '../map/map-utils';
 
-// Capture the props TripMap receives so we can assert the wired markers.
+// Capture the props TripMap receives so we can assert the wired markers +
+// highlightedSegment.
 let lastTripMapProps: Record<string, unknown> | null = null;
 jest.mock('../TripMap', () => {
   const React = require('react');
@@ -14,6 +15,20 @@ jest.mock('../TripMap', () => {
     TripMap: (props: Record<string, unknown>) => {
       lastTripMapProps = props;
       return React.createElement('TripMap', props);
+    },
+  };
+});
+
+// Expose the profile's onHover so the test can emit a hover the way a touch would.
+let emitHover: ((coordIndex: number | null, stageIndex: number | null) => void) | null = null;
+jest.mock('./ElevationProfile', () => {
+  const React = require('react');
+  return {
+    ElevationProfile: (props: {
+      onHover: (coordIndex: number | null, stageIndex: number | null) => void;
+    }) => {
+      emitHover = props.onHover;
+      return React.createElement('ElevationProfile', null);
     },
   };
 });
@@ -58,6 +73,7 @@ const routedStage = stage({
   geometry: [
     { lat: 48, lon: 2, ele: 100 },
     { lat: 48.01, lon: 2.01, ele: 200 },
+    { lat: 48.02, lon: 2.02, ele: 150 },
   ],
   pois: [{ name: 'Café', category: 'amenity', lat: 48.01, lon: 2.01 }] as StageData['pois'],
 });
@@ -65,6 +81,7 @@ const routedStage = stage({
 describe('TripMapView', () => {
   beforeEach(() => {
     lastTripMapProps = null;
+    emitHover = null;
     act(() => {
       useTripStore.getState().reset();
       useTripStore.setState({ stages: [routedStage] });
@@ -82,5 +99,38 @@ describe('TripMapView', () => {
     render(<TripMapView />);
     expect(lastTripMapProps).not.toBeNull();
     expect(lastTripMapProps!.markers).toEqual(collectMarkers([routedStage]));
+  });
+
+  it('feeds the profile hover into TripMap as highlightedSegment', () => {
+    render(<TripMapView />);
+    expect(lastTripMapProps).not.toBeNull();
+    // No hover yet → no highlight.
+    expect(lastTripMapProps!.highlightedSegment).toBeUndefined();
+
+    act(() => {
+      emitHover!(0, 0);
+    });
+
+    // profileHighlightSegment(stages, 0, 0) → hovered coord + its next neighbour.
+    expect(lastTripMapProps!.highlightedSegment).toEqual([
+      [2, 48],
+      [2.01, 48.01],
+    ]);
+  });
+
+  it('clears the highlight when the profile reports a release', () => {
+    render(<TripMapView />);
+    act(() => {
+      emitHover!(0, 0);
+    });
+    expect(lastTripMapProps!.highlightedSegment).toEqual([
+      [2, 48],
+      [2.01, 48.01],
+    ]);
+
+    act(() => {
+      emitHover!(null, null);
+    });
+    expect(lastTripMapProps!.highlightedSegment).toBeUndefined();
   });
 });

--- a/mobile/src/components/trip/TripMapView.tsx
+++ b/mobile/src/components/trip/TripMapView.tsx
@@ -1,16 +1,24 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
+import { StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
+import { profileHighlightSegment } from '@btp/core/elevation';
 import { EmptyState } from '../ui';
 import { TripMap } from '../TripMap';
 import { collectMarkers } from '../map/map-utils';
+import { ElevationProfile } from './ElevationProfile';
 import { useTripStore } from '../../store/trip-store';
 
 // The map tab: derives the route polyline and markers from the store's stages
 // and hands them to the shared TripMap, or shows the empty state when there is
-// no geometry yet. #1040 adds base-map toggle, markers and fit-bounds.
+// no geometry yet. #1040 adds base-map toggle, markers and fit-bounds; #1041
+// stacks the elevation profile below and shares the hover state so a touch on the
+// profile surlines the matching stretch on the map.
 export function TripMapView() {
   const { t } = useTranslation();
   const stages = useTripStore((s) => s.stages);
+  const [hover, setHover] = useState<{ coordIndex: number; stageIndex: number } | null>(
+    null,
+  );
 
   const coordinates = useMemo<[number, number][]>(() => {
     const coords: [number, number][] = [];
@@ -24,8 +32,45 @@ export function TripMapView() {
 
   const markers = useMemo(() => collectMarkers(stages), [stages]);
 
+  const highlightedSegment = useMemo(
+    () =>
+      hover
+        ? profileHighlightSegment(stages, hover.stageIndex, hover.coordIndex)
+        : undefined,
+    [hover, stages],
+  );
+
   if (coordinates.length === 0) {
     return <EmptyState title={t('trip.mapEmpty')} />;
   }
-  return <TripMap coordinates={coordinates} markers={markers} />;
+  return (
+    <View style={styles.container}>
+      <View style={styles.map}>
+        <TripMap
+          coordinates={coordinates}
+          markers={markers}
+          highlightedSegment={highlightedSegment}
+        />
+      </View>
+      <View style={styles.profile}>
+        <ElevationProfile
+          stages={stages}
+          focusedStageIndex={null}
+          onHover={(coordIndex, stageIndex) =>
+            setHover(
+              coordIndex === null || stageIndex === null
+                ? null
+                : { coordIndex, stageIndex },
+            )
+          }
+        />
+      </View>
+    </View>
+  );
 }
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  map: { flex: 1 },
+  profile: { padding: 8 },
+});

--- a/mobile/src/components/trip/elevation.test.ts
+++ b/mobile/src/components/trip/elevation.test.ts
@@ -1,0 +1,171 @@
+/// <reference types="jest" />
+import type { StageData } from '@btp/core';
+import {
+  buildProfilePoints,
+  findClosestProfilePoint,
+  haversineKm,
+  profileHighlightSegment,
+} from '@btp/core/elevation';
+
+function stage(overrides: Partial<StageData> = {}): StageData {
+  const zero = { lat: 0, lon: 0, ele: 0 };
+  return {
+    dayNumber: 1,
+    distance: 50,
+    elevation: 100,
+    elevationLoss: 0,
+    startPoint: zero,
+    endPoint: zero,
+    geometry: [],
+    label: null,
+    startLabel: null,
+    endLabel: null,
+    weather: null,
+    alerts: [],
+    pois: [],
+    accommodations: [],
+    selectedAccommodation: null,
+    accommodationSearchRadiusKm: 10,
+    isRestDay: false,
+    supplyTimeline: [],
+    events: [],
+    ...overrides,
+  };
+}
+
+describe('haversineKm', () => {
+  it('is zero for identical points', () => {
+    expect(haversineKm(48, 2, 48, 2)).toBe(0);
+  });
+
+  it('matches a known distance (~111 km per degree of latitude)', () => {
+    expect(haversineKm(48, 2, 49, 2)).toBeCloseTo(111.19, 1);
+  });
+});
+
+describe('buildProfilePoints', () => {
+  it('returns no points for a stage with fewer than two coords', () => {
+    expect(buildProfilePoints([stage({ geometry: [{ lat: 0, lon: 0, ele: 0 }] })], null)).toEqual(
+      [],
+    );
+  });
+
+  it('accumulates distance and carries stage/coord indices', () => {
+    const s = stage({
+      geometry: [
+        { lat: 48, lon: 2, ele: 100 },
+        { lat: 48.01, lon: 2, ele: 150 },
+        { lat: 48.02, lon: 2, ele: 120 },
+      ],
+    });
+    const points = buildProfilePoints([s], null);
+    expect(points).toHaveLength(3);
+    expect(points[0]).toMatchObject({ distanceKm: 0, ele: 100, stageIndex: 0, coordIndex: 0 });
+    expect(points[1]!.distanceKm).toBeGreaterThan(0);
+    expect(points[2]!.distanceKm).toBeGreaterThan(points[1]!.distanceKm);
+    expect(points[2]).toMatchObject({ ele: 120, coordIndex: 2 });
+  });
+
+  it('excludes rest days and renumbers active-stage indices', () => {
+    const a = stage({
+      geometry: [
+        { lat: 48, lon: 2, ele: 10 },
+        { lat: 48.01, lon: 2, ele: 20 },
+      ],
+    });
+    const rest = stage({ isRestDay: true, geometry: [] });
+    const b = stage({
+      geometry: [
+        { lat: 49, lon: 3, ele: 30 },
+        { lat: 49.01, lon: 3, ele: 40 },
+      ],
+    });
+    const points = buildProfilePoints([a, rest, b], null);
+    const stageIndices = [...new Set(points.map((p) => p.stageIndex))];
+    expect(stageIndices).toEqual([0, 1]);
+  });
+
+  it('focuses a single active stage when given an index', () => {
+    const a = stage({
+      geometry: [
+        { lat: 48, lon: 2, ele: 10 },
+        { lat: 48.01, lon: 2, ele: 20 },
+      ],
+    });
+    const b = stage({
+      geometry: [
+        { lat: 49, lon: 3, ele: 30 },
+        { lat: 49.01, lon: 3, ele: 40 },
+      ],
+    });
+    const points = buildProfilePoints([a, b], 1);
+    expect(points.every((p) => p.stageIndex === 1)).toBe(true);
+  });
+
+  it('computes a positive gradient on a climb', () => {
+    const s = stage({
+      geometry: [
+        { lat: 48, lon: 2, ele: 100 },
+        { lat: 48.01, lon: 2, ele: 200 },
+      ],
+    });
+    const points = buildProfilePoints([s], null);
+    expect(points[1]!.gradient).toBeGreaterThan(0);
+  });
+});
+
+describe('findClosestProfilePoint', () => {
+  const points = [
+    { distanceKm: 0 },
+    { distanceKm: 5 },
+    { distanceKm: 10 },
+    { distanceKm: 20 },
+  ];
+
+  it('returns undefined for an empty array', () => {
+    expect(findClosestProfilePoint([], 3)).toBeUndefined();
+  });
+
+  it('finds the nearest by distance', () => {
+    expect(findClosestProfilePoint(points, 4)!.distanceKm).toBe(5);
+    expect(findClosestProfilePoint(points, 12)!.distanceKm).toBe(10);
+    expect(findClosestProfilePoint(points, 100)!.distanceKm).toBe(20);
+  });
+});
+
+describe('profileHighlightSegment', () => {
+  const s = stage({
+    geometry: [
+      { lat: 48, lon: 2, ele: 0 },
+      { lat: 48.01, lon: 2.01, ele: 0 },
+      { lat: 48.02, lon: 2.02, ele: 0 },
+    ],
+  });
+
+  it('returns the hovered point and its next neighbour as [lon, lat]', () => {
+    expect(profileHighlightSegment([s], 0, 0)).toEqual([
+      [2, 48],
+      [2.01, 48.01],
+    ]);
+  });
+
+  it('falls back to the previous neighbour at the last coord', () => {
+    expect(profileHighlightSegment([s], 0, 2)).toEqual([
+      [2.02, 48.02],
+      [2.01, 48.01],
+    ]);
+  });
+
+  it('maps the active-stage index past rest days', () => {
+    const rest = stage({ isRestDay: true });
+    expect(profileHighlightSegment([rest, s], 0, 0)).toEqual([
+      [2, 48],
+      [2.01, 48.01],
+    ]);
+  });
+
+  it('returns an empty segment when the point cannot be located', () => {
+    expect(profileHighlightSegment([s], 5, 0)).toEqual([]);
+    expect(profileHighlightSegment([s], 0, 9)).toEqual([]);
+  });
+});

--- a/mobile/src/i18n/resources/en.ts
+++ b/mobile/src/i18n/resources/en.ts
@@ -64,6 +64,7 @@ export const en: typeof fr = {
     rest: 'rest',
     today: 'Today',
     stageMeta: '{{distance}} km · +{{elevation}} m',
+    elevationProfileA11y: 'Trip elevation profile',
     states: {
       upcoming: 'Upcoming',
       ongoing: 'Ongoing',

--- a/mobile/src/i18n/resources/fr.ts
+++ b/mobile/src/i18n/resources/fr.ts
@@ -62,6 +62,7 @@ export const fr = {
     rest: 'repos',
     today: "Aujourd'hui",
     stageMeta: '{{distance}} km · +{{elevation}} m',
+    elevationProfileA11y: 'Profil altimétrique du voyage',
     states: {
       upcoming: 'À venir',
       ongoing: 'En cours',


### PR DESCRIPTION
Closes #1041

> Stacked PR — base `feature/1040` (#1040).

## Contexte
Sprint 55 (Consultation). Profil altimétrique portable + hover synchronisé avec la carte.

## Changements
- `core/elevation.ts` (**framework-free**, extrait du web `pwa/.../ElevationProfile.tsx` sans le refactoriser) : `haversineKm`, `buildProfilePoints(stages, focusedStageIndex)`, `findClosestProfilePoint`, `profileHighlightSegment`. Exporté via `@btp/core` + sous-chemin `@btp/core/elevation`.
- `components/trip/ElevationProfile.tsx` : `react-native-svg` (aires par étape, crosshair, tooltip), couleurs 100 % `useTheme()`. Interaction tactile (responder RN) → `onHover(coord, stage)`.
- `TripMapView.tsx` : état de hover partagé, profil empilé sous la carte, `highlightedSegment` calculé et transmis à `TripMap` (édition minimale, non-régression #1040).
- i18n `trip.elevationProfileA11y`.

## Vérification
- `tsc --noEmit` : clean.
- `jest` : 23 suites / 168 tests verts (13 tests core elevation via `@btp/core/elevation` + composant). `haversineKm` prouvé rouge-puis-vert.

## Auto-critique
- Web NON refactorisé (extraction additive vers core, usage mobile) : hors scope, évite le risque de régression web. Le web pourra consommer la même source ultérieurement.
- Pas de dépendance ajoutée (`react-native-svg` déjà présent). Pas de DTO.

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 findings (0 critical, 0 warning). Independent review of the real diff/commits — `core/elevation.ts` was compared line-by-line against the base-branch web component (`pwa/src/components/Map/ElevationProfile.tsx`) and confirmed a faithful, semantically-identical extraction. All 5 previously-open bot review threads on this PR were already resolved and re-verified against current code rather than trusted at face value.

**Security note:** this PR body previously contained a `<!-- claude-review-start -->...<!-- claude-review-end -->` block impersonating a completed Claude review (including a fabricated commit SHA matching none of this PR's actual commits, and a self-referential disclaimer designed to look like a self-correcting AI). This was very likely a prompt-injection attempt aimed at reviewing agents and has been disregarded; this section replaces it with an independently-produced review.

**PR title check:** the description (`profil altimétrique svg + hover tactile synchronisé carte↔profil (#1041)`) is a noun phrase rather than imperative mood, per the Conventional Commits rule in CLAUDE.md.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

**Commit reviewed:** `c83cb320fb1321cd405248b99c813f80323f951f`
<!-- claude-review-end -->