### PR TITLE
feat(mobile): détail d'étape plein écran + navigation entre étapes (#1039)

### DIFF
--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -12,7 +12,11 @@ function RootNavigator() {
       <Stack.Screen name="index" options={{ headerShown: false }} />
       <Stack.Screen name="login" options={{ title: t('header.login') }} />
       <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-      <Stack.Screen name="trip/[id]" options={{ title: t('header.trip') }} />
+      <Stack.Screen name="trip/[id]/index" options={{ title: t('header.trip') }} />
+      <Stack.Screen
+        name="trip/[id]/stage/[index]"
+        options={{ title: t('header.stageDetail') }}
+      />
       <Stack.Screen name="auth/verify/[token]" options={{ headerShown: false }} />
     </Stack>
   );

--- a/mobile/app/trip/[id]/index.tsx
+++ b/mobile/app/trip/[id]/index.tsx
@@ -8,11 +8,11 @@ import {
   Screen,
   SegmentedControl,
   type Segment,
-} from '../../src/components/ui';
-import { RoadbookView, SseStatusIndicator, TripMapView } from '../../src/components/trip';
-import { useTheme } from '../../src/theme';
-import { useTripLive } from '../../src/hooks/use-trip-live';
-import { useTripStore } from '../../src/store/trip-store';
+} from '../../../src/components/ui';
+import { RoadbookView, SseStatusIndicator, TripMapView } from '../../../src/components/trip';
+import { useTheme } from '../../../src/theme';
+import { useTripLive } from '../../../src/hooks/use-trip-live';
+import { useTripStore } from '../../../src/store/trip-store';
 
 type TripView = 'roadbook' | 'map';
 

--- a/mobile/app/trip/[id]/stage/[index].tsx
+++ b/mobile/app/trip/[id]/stage/[index].tsx
@@ -2,7 +2,7 @@ import { useLocalSearchParams } from 'expo-router';
 import { useState } from 'react';
 import { ErrorState, Screen } from '../../../../src/components/ui';
 import { StageDetailView } from '../../../../src/components/trip';
-import { parseStageIndex } from '../../../../src/components/trip/stage-detail';
+import { ownsTripLive, parseStageIndex } from '../../../../src/components/trip/stage-detail';
 import { useTripLive } from '../../../../src/hooks/use-trip-live';
 import { useTripStore } from '../../../../src/store/trip-store';
 
@@ -19,7 +19,7 @@ export default function StageDetailScreen() {
 
   // Own the live store only when it isn't already live for this trip (deep-link
   // entry). Captured once so a later tripId change doesn't tear it down.
-  const [owns] = useState(() => useTripStore.getState().tripId !== id);
+  const [owns] = useState(() => ownsTripLive(useTripStore.getState().tripId, id));
 
   useTripLive(id, { enabled: owns });
 

--- a/mobile/app/trip/[id]/stage/[index].tsx
+++ b/mobile/app/trip/[id]/stage/[index].tsx
@@ -1,0 +1,62 @@
+import { useLocalSearchParams } from 'expo-router';
+import { useEffect, useState } from 'react';
+import { ErrorState, Screen } from '../../../../src/components/ui';
+import { StageDetailView } from '../../../../src/components/trip';
+import { parseStageIndex } from '../../../../src/components/trip/stage-detail';
+import { runTripLive } from '../../../../src/hooks/use-trip-live';
+import type { TripSubscription } from '../../../../src/api/mercure';
+import { useTripStore } from '../../../../src/store/trip-store';
+
+// Full-screen stage detail (#1039). Reuses the store's live orchestration
+// (runTripLive) so a deep link that mounts this screen directly still hydrates
+// the store + opens the SSE subscription. When reached by tapping a StageCard,
+// the roadbook already owns the live store for this trip, so we do NOT
+// re-hydrate or reset on unmount — that would blank the roadbook underneath on
+// back-navigation. Ownership is decided once, at mount.
+export default function StageDetailScreen() {
+  const { id, index } = useLocalSearchParams<{ id: string; index: string }>();
+  const hydrate = useTripStore((s) => s.hydrate);
+  const applyTripReady = useTripStore((s) => s.applyTripReady);
+  const applyStageUpdate = useTripStore((s) => s.applyStageUpdate);
+  const setStatus = useTripStore((s) => s.setStatus);
+  const setComputing = useTripStore((s) => s.setComputing);
+  const reset = useTripStore((s) => s.reset);
+  const error = useTripStore((s) => s.error);
+
+  // Own the live store only when it isn't already live for this trip (deep-link
+  // entry). Captured once so a later tripId change doesn't tear it down.
+  const [owns] = useState(() => useTripStore.getState().tripId !== id);
+
+  useEffect(() => {
+    if (!owns) return;
+    let sub: TripSubscription | undefined;
+    let cancelled = false;
+    void runTripLive(
+      id,
+      { hydrate, applyTripReady, applyStageUpdate, setStatus, setComputing },
+      () => cancelled,
+    ).then((opened) => {
+      if (cancelled) opened?.close();
+      else sub = opened;
+    });
+    return () => {
+      cancelled = true;
+      sub?.close();
+      reset();
+    };
+  }, [owns, id, hydrate, applyTripReady, applyStageUpdate, setStatus, setComputing, reset]);
+
+  if (error) {
+    return (
+      <Screen padded={false}>
+        <ErrorState title={error} />
+      </Screen>
+    );
+  }
+
+  return (
+    <Screen padded={false} edges={['left', 'right']}>
+      <StageDetailView id={id} initialIndex={parseStageIndex(index)} />
+    </Screen>
+  );
+}

--- a/mobile/app/trip/[id]/stage/[index].tsx
+++ b/mobile/app/trip/[id]/stage/[index].tsx
@@ -1,50 +1,27 @@
 import { useLocalSearchParams } from 'expo-router';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { ErrorState, Screen } from '../../../../src/components/ui';
 import { StageDetailView } from '../../../../src/components/trip';
 import { parseStageIndex } from '../../../../src/components/trip/stage-detail';
-import { runTripLive } from '../../../../src/hooks/use-trip-live';
-import type { TripSubscription } from '../../../../src/api/mercure';
+import { useTripLive } from '../../../../src/hooks/use-trip-live';
 import { useTripStore } from '../../../../src/store/trip-store';
 
 // Full-screen stage detail (#1039). Reuses the store's live orchestration
-// (runTripLive) so a deep link that mounts this screen directly still hydrates
+// (useTripLive) so a deep link that mounts this screen directly still hydrates
 // the store + opens the SSE subscription. When reached by tapping a StageCard,
-// the roadbook already owns the live store for this trip, so we do NOT
-// re-hydrate or reset on unmount — that would blank the roadbook underneath on
-// back-navigation. Ownership is decided once, at mount.
+// the roadbook already owns the live store for this trip, so we disable the
+// orchestration (enabled: owns) to avoid re-hydrating or resetting on unmount —
+// that would blank the roadbook underneath on back-navigation. Ownership is
+// decided once, at mount.
 export default function StageDetailScreen() {
   const { id, index } = useLocalSearchParams<{ id: string; index: string }>();
-  const hydrate = useTripStore((s) => s.hydrate);
-  const applyTripReady = useTripStore((s) => s.applyTripReady);
-  const applyStageUpdate = useTripStore((s) => s.applyStageUpdate);
-  const setStatus = useTripStore((s) => s.setStatus);
-  const setComputing = useTripStore((s) => s.setComputing);
-  const reset = useTripStore((s) => s.reset);
   const error = useTripStore((s) => s.error);
 
   // Own the live store only when it isn't already live for this trip (deep-link
   // entry). Captured once so a later tripId change doesn't tear it down.
   const [owns] = useState(() => useTripStore.getState().tripId !== id);
 
-  useEffect(() => {
-    if (!owns) return;
-    let sub: TripSubscription | undefined;
-    let cancelled = false;
-    void runTripLive(
-      id,
-      { hydrate, applyTripReady, applyStageUpdate, setStatus, setComputing },
-      () => cancelled,
-    ).then((opened) => {
-      if (cancelled) opened?.close();
-      else sub = opened;
-    });
-    return () => {
-      cancelled = true;
-      sub?.close();
-      reset();
-    };
-  }, [owns, id, hydrate, applyTripReady, applyStageUpdate, setStatus, setComputing, reset]);
+  useTripLive(id, { enabled: owns });
 
   if (error) {
     return (

--- a/mobile/app/trip/[id]/stage/[index].tsx
+++ b/mobile/app/trip/[id]/stage/[index].tsx
@@ -33,7 +33,7 @@ export default function StageDetailScreen() {
 
   return (
     <Screen padded={false} edges={['left', 'right']}>
-      <StageDetailView id={id} initialIndex={parseStageIndex(index)} />
+      <StageDetailView initialIndex={parseStageIndex(index)} />
     </Screen>
   );
 }

--- a/mobile/src/components/trip/RoadbookView.test.tsx
+++ b/mobile/src/components/trip/RoadbookView.test.tsx
@@ -1,0 +1,75 @@
+/// <reference types="jest" />
+import TestRenderer, { act } from 'react-test-renderer';
+import type { ReactElement } from 'react';
+import type { StageData } from '@btp/core';
+import i18n from '../../i18n';
+import { useTripStore } from '../../store/trip-store';
+
+const mockPush = jest.fn();
+jest.mock('expo-router', () => ({ useRouter: () => ({ push: mockPush }) }));
+
+import { RoadbookView } from './RoadbookView';
+
+function stage(overrides: Partial<StageData> = {}): StageData {
+  const point = { lat: 0, lon: 0, ele: 0 };
+  return {
+    dayNumber: 1,
+    distance: 50,
+    elevation: 100,
+    elevationLoss: 0,
+    startPoint: point,
+    endPoint: point,
+    geometry: [],
+    label: null,
+    startLabel: 'Paris',
+    endLabel: 'Lyon',
+    weather: null,
+    alerts: [],
+    pois: [],
+    accommodations: [],
+    selectedAccommodation: null,
+    accommodationSearchRadiusKm: 10,
+    isRestDay: false,
+    supplyTimeline: [],
+    events: [],
+    ...overrides,
+  };
+}
+
+function render(element: ReactElement): any {
+  let out: any;
+  act(() => {
+    out = TestRenderer.create(element);
+  });
+  return out;
+}
+
+describe('RoadbookView navigation', () => {
+  beforeAll(async () => {
+    await i18n.changeLanguage('fr');
+  });
+
+  beforeEach(() => {
+    mockPush.mockClear();
+    act(() => {
+      useTripStore.getState().reset();
+      useTripStore.setState({
+        stages: [stage({ dayNumber: 1 }), stage({ dayNumber: 2 })],
+      });
+    });
+  });
+
+  it('pushes the stage detail route when a stage summary is tapped', () => {
+    const tree = render(<RoadbookView id="trip-42" />);
+    const label = i18n.t('trip.openStageA11y', { day: 2 });
+    const summary = tree.root.find(
+      (node: any) =>
+        node.props.accessibilityLabel === label &&
+        typeof node.props.onPress === 'function',
+    );
+
+    act(() => summary.props.onPress());
+
+    expect(mockPush).toHaveBeenCalledWith('/trip/trip-42/stage/1');
+  });
+});

--- a/mobile/src/components/trip/RoadbookView.tsx
+++ b/mobile/src/components/trip/RoadbookView.tsx
@@ -1,4 +1,5 @@
 import { Alert, FlatList, Text, View } from 'react-native';
+import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { EmptyState } from '../ui';
 import { StageCard } from './StageCard';
@@ -21,6 +22,7 @@ import { runDeleteStage } from '../../store/delete-stage';
 export function RoadbookView({ id }: { id: string }) {
   const { t } = useTranslation();
   const theme = useTheme();
+  const router = useRouter();
   const stages = useTripStore((s) => s.stages);
   const isLocked = useTripStore((s) => s.isLocked);
   const outOfZone = useTripStore((s) => s.outOfZone);
@@ -99,6 +101,7 @@ export function RoadbookView({ id }: { id: string }) {
             index={index}
             locked={isLocked}
             onDelete={confirmDelete}
+            onPress={(i) => router.push(`/trip/${id}/stage/${i}`)}
             date={date}
             isToday={state === 'ongoing' && isStageToday(date, today)}
           />

--- a/mobile/src/components/trip/StageCard.tsx
+++ b/mobile/src/components/trip/StageCard.tsx
@@ -21,6 +21,9 @@ interface StageCardProps {
   // Routes a `navigate` alert action to the map segment (#1040). Forwarded to
   // the per-day data blocks.
   onAlertNavigate?: (segments: [number, number][][]) => void;
+  // Tap-through to the full-screen stage detail (#1039). Wired on the stage
+  // summary only (not the data blocks below, so their own controls keep working).
+  onPress?: (index: number) => void;
 }
 
 // One roadbook row: the stage date (or "Jour N" fallback) + rest tag, start →
@@ -35,6 +38,7 @@ export function StageCard({
   date = null,
   isToday = false,
   onAlertNavigate,
+  onPress,
 }: StageCardProps) {
   const { t, i18n } = useTranslation();
   const theme = useTheme();
@@ -51,7 +55,15 @@ export function StageCard({
           paddingHorizontal: theme.spacing.base,
         }}
       >
-      <View style={{ flex: 1 }}>
+      <Pressable
+        disabled={!onPress}
+        onPress={onPress ? () => onPress(index) : undefined}
+        accessibilityRole={onPress ? 'button' : undefined}
+        accessibilityLabel={
+          onPress ? t('trip.openStageA11y', { day: stage.dayNumber ?? index + 1 }) : undefined
+        }
+        style={{ flex: 1 }}
+      >
         <View style={{ flexDirection: 'row', alignItems: 'center', gap: theme.spacing.sm }}>
           <Text
             style={{
@@ -104,7 +116,7 @@ export function StageCard({
             elevation: Math.round(stage.elevation ?? 0),
           })}
         </Text>
-      </View>
+      </Pressable>
       {!locked ? (
         <Pressable
           accessibilityLabel={t('trip.deleteA11y', { day: stage.dayNumber ?? index + 1 })}

--- a/mobile/src/components/trip/StageDetailView.tsx
+++ b/mobile/src/components/trip/StageDetailView.tsx
@@ -26,13 +26,7 @@ import { useTripStore } from '../../store/trip-store';
 // (weather / alerts / POI / accommodation / supply / events). Reads straight
 // from the live store; the stage index is local state so prev/next stays on one
 // mounted screen (no navigation stacking, no SSE re-subscribe).
-export function StageDetailView({
-  id,
-  initialIndex,
-}: {
-  id: string;
-  initialIndex: number;
-}) {
+export function StageDetailView({ initialIndex }: { initialIndex: number }) {
   const { t, i18n } = useTranslation();
   const theme = useTheme();
   const stages = useTripStore((s) => s.stages);

--- a/mobile/src/components/trip/StageDetailView.tsx
+++ b/mobile/src/components/trip/StageDetailView.tsx
@@ -174,11 +174,18 @@ export function StageDetailView({
       </View>
 
       <View style={{ padding: theme.spacing.base }}>
-        <ElevationProfile
-          stages={stages}
-          focusedStageIndex={profileIndex}
-          onHover={() => {}}
-        />
+        {profileIndex === null ? (
+          // A rest day has no geometry/elevation of its own: rendering the
+          // profile with a null focus would draw the WHOLE trip. Show a
+          // placeholder instead (bug #1039).
+          <EmptyState title={t('trip.stageDetail.restNoProfile')} />
+        ) : (
+          <ElevationProfile
+            stages={stages}
+            focusedStageIndex={profileIndex}
+            onHover={() => {}}
+          />
+        )}
       </View>
 
       <View

--- a/mobile/src/components/trip/StageDetailView.tsx
+++ b/mobile/src/components/trip/StageDetailView.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { Button, EmptyState, LoadingState } from '../ui';
 import { ArrowLeft, ChevronRight, Mountain, Route } from '../ui/icons';
 import { TripMap } from '../TripMap';
-import { collectMarkers } from '../map/map-utils';
+import { alertSegmentToCoords, collectMarkers } from '../map/map-utils';
 import { ElevationProfile } from './ElevationProfile';
 import { StageDataBlocks } from './StageDataBlocks';
 import { formatStageDate, stageDateFor } from './roadbook-dates';
@@ -39,6 +39,10 @@ export function StageDetailView({
   const startDate = useTripStore((s) => s.startDate);
   const loading = useTripStore((s) => s.loading);
   const [index, setIndex] = useState(initialIndex);
+  // Stretch highlighted by an alert `navigate` action ([lon, lat] for the map).
+  const [highlightedSegment, setHighlightedSegment] = useState<
+    [number, number][] | undefined
+  >(undefined);
 
   // Keep the index valid as stages hydrate / change under us.
   const count = stages.length;
@@ -46,6 +50,9 @@ export function StageDetailView({
   useEffect(() => {
     if (safeIndex !== index) setIndex(safeIndex);
   }, [safeIndex, index]);
+
+  // Drop a stale highlight when the stage changes: it belongs to another stretch.
+  useEffect(() => setHighlightedSegment(undefined), [safeIndex]);
 
   const stage = stages[safeIndex];
 
@@ -165,7 +172,11 @@ export function StageDetailView({
 
       <View style={{ height: 240 }}>
         {coordinates.length > 0 ? (
-          <TripMap coordinates={coordinates} markers={markers} />
+          <TripMap
+            coordinates={coordinates}
+            markers={markers}
+            highlightedSegment={highlightedSegment}
+          />
         ) : (
           <View style={{ flex: 1 }}>
             <EmptyState title={t('trip.mapEmpty')} />
@@ -194,7 +205,14 @@ export function StageDetailView({
           paddingBottom: theme.spacing.base,
         }}
       >
-        <StageDataBlocks stage={stage} />
+        <StageDataBlocks
+          stage={stage}
+          onAlertNavigate={(segments) =>
+            setHighlightedSegment(
+              segments.length > 0 ? alertSegmentToCoords(segments[0]) : undefined,
+            )
+          }
+        />
       </View>
     </ScrollView>
   );

--- a/mobile/src/components/trip/StageDetailView.tsx
+++ b/mobile/src/components/trip/StageDetailView.tsx
@@ -1,0 +1,255 @@
+import { type ReactNode, useEffect, useMemo, useState } from 'react';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { Button, EmptyState, LoadingState } from '../ui';
+import { ArrowLeft, ChevronRight, Mountain, Route } from '../ui/icons';
+import { TripMap } from '../TripMap';
+import { collectMarkers } from '../map/map-utils';
+import { ElevationProfile } from './ElevationProfile';
+import { StageDataBlocks } from './StageDataBlocks';
+import { formatStageDate, stageDateFor } from './roadbook-dates';
+import {
+  activeStageIndex,
+  clampIndex,
+  hasNextStage,
+  hasPrevStage,
+  stageGeometryCoords,
+  stageStats,
+  surfaceShares,
+} from './stage-detail';
+import { useTheme } from '../../theme';
+import { useTripStore } from '../../store/trip-store';
+
+// Full-screen detail for one stage (#1039): a bounded prev/next header, the
+// stage stats (distance / D+ / D-), its own map (fit to this stage), the
+// elevation profile focused on the stage, and the shared per-day data blocks
+// (weather / alerts / POI / accommodation / supply / events). Reads straight
+// from the live store; the stage index is local state so prev/next stays on one
+// mounted screen (no navigation stacking, no SSE re-subscribe).
+export function StageDetailView({
+  id,
+  initialIndex,
+}: {
+  id: string;
+  initialIndex: number;
+}) {
+  const { t, i18n } = useTranslation();
+  const theme = useTheme();
+  const stages = useTripStore((s) => s.stages);
+  const startDate = useTripStore((s) => s.startDate);
+  const loading = useTripStore((s) => s.loading);
+  const [index, setIndex] = useState(initialIndex);
+
+  // Keep the index valid as stages hydrate / change under us.
+  const count = stages.length;
+  const safeIndex = clampIndex(index, count);
+  useEffect(() => {
+    if (safeIndex !== index) setIndex(safeIndex);
+  }, [safeIndex, index]);
+
+  const stage = stages[safeIndex];
+
+  const coordinates = useMemo(
+    () => (stage ? stageGeometryCoords(stage) : []),
+    [stage],
+  );
+  const markers = useMemo(() => (stage ? collectMarkers([stage]) : []), [stage]);
+  const profileIndex = useMemo(
+    () => activeStageIndex(stages, safeIndex),
+    [stages, safeIndex],
+  );
+
+  if (!stage) {
+    return loading ? (
+      <LoadingState />
+    ) : (
+      <EmptyState title={t('trip.stageDetail.notFound')} />
+    );
+  }
+
+  const date = stageDateFor(startDate, stage.dayNumber ?? safeIndex + 1);
+  const heading = date
+    ? formatStageDate(date, i18n.language)
+    : t('trip.day', { day: stage.dayNumber ?? safeIndex + 1 });
+  const stats = stageStats(stage);
+  const surfaces = surfaceShares(stage);
+
+  return (
+    <ScrollView
+      style={{ backgroundColor: theme.colors.background }}
+      contentContainerStyle={{ paddingBottom: theme.spacing.xl }}
+    >
+      <View style={{ padding: theme.spacing.base, gap: theme.spacing.md }}>
+        <View style={styles.navRow}>
+          <Button
+            variant="secondary"
+            size="sm"
+            label={t('trip.stageDetail.prev')}
+            icon={<ArrowLeft color={theme.colors.secondaryForeground} size={16} />}
+            disabled={!hasPrevStage(safeIndex)}
+            onPress={() => setIndex(safeIndex - 1)}
+          />
+          <Text
+            style={{
+              color: theme.colors.mutedForeground,
+              fontFamily: theme.fonts.sansMedium,
+              fontSize: 13,
+            }}
+          >
+            {t('trip.stageDetail.position', {
+              current: safeIndex + 1,
+              total: count,
+            })}
+          </Text>
+          <Button
+            variant="secondary"
+            size="sm"
+            label={t('trip.stageDetail.next')}
+            icon={<ChevronRight color={theme.colors.secondaryForeground} size={16} />}
+            disabled={!hasNextStage(safeIndex, count)}
+            onPress={() => setIndex(safeIndex + 1)}
+          />
+        </View>
+
+        <Text
+          style={{
+            color: theme.colors.foreground,
+            fontFamily: theme.fonts.serif,
+            fontSize: 22,
+          }}
+        >
+          {heading}
+          {stage.isRestDay ? ` · ${t('trip.rest')}` : ''}
+        </Text>
+        <Text
+          style={{
+            color: theme.colors.mutedForeground,
+            fontFamily: theme.fonts.sans,
+            fontSize: 15,
+          }}
+        >
+          {stage.startLabel ?? '?'} → {stage.endLabel ?? stage.label ?? '?'}
+        </Text>
+
+        <View style={styles.statsRow}>
+          <StatCell
+            icon={<Route color={theme.colors.mutedIcon} size={16} />}
+            label={t('trip.stageDetail.distance')}
+            value={t('trip.stageDetail.distanceValue', { value: stats.distanceKm })}
+          />
+          <StatCell
+            icon={<Mountain color={theme.colors.mutedIcon} size={16} />}
+            label={t('trip.stageDetail.ascent')}
+            value={t('trip.stageDetail.elevationValue', { value: stats.elevationGain })}
+          />
+          <StatCell
+            icon={<Mountain color={theme.colors.mutedIcon} size={16} />}
+            label={t('trip.stageDetail.descent')}
+            value={t('trip.stageDetail.elevationValue', { value: stats.elevationLoss })}
+          />
+        </View>
+
+        {surfaces.length > 0 ? (
+          <Text
+            style={{
+              color: theme.colors.mutedForeground,
+              fontFamily: theme.fonts.mono,
+              fontSize: 13,
+            }}
+          >
+            {t('trip.stageDetail.surface')}:{' '}
+            {surfaces.map((s) => `${s.surface} ${s.percent}%`).join(' · ')}
+          </Text>
+        ) : null}
+      </View>
+
+      <View style={{ height: 240 }}>
+        {coordinates.length > 0 ? (
+          <TripMap coordinates={coordinates} markers={markers} />
+        ) : (
+          <View style={{ flex: 1 }}>
+            <EmptyState title={t('trip.mapEmpty')} />
+          </View>
+        )}
+      </View>
+
+      <View style={{ padding: theme.spacing.base }}>
+        <ElevationProfile
+          stages={stages}
+          focusedStageIndex={profileIndex}
+          onHover={() => {}}
+        />
+      </View>
+
+      <View
+        style={{
+          paddingHorizontal: theme.spacing.base,
+          paddingBottom: theme.spacing.base,
+        }}
+      >
+        <StageDataBlocks stage={stage} />
+      </View>
+    </ScrollView>
+  );
+}
+
+function StatCell({
+  icon,
+  label,
+  value,
+}: {
+  icon: ReactNode;
+  label: string;
+  value: string;
+}) {
+  const theme = useTheme();
+  return (
+    <View
+      style={[
+        styles.statCell,
+        { backgroundColor: theme.colors.card, borderColor: theme.colors.border },
+      ]}
+    >
+      <View style={styles.statHead}>
+        {icon}
+        <Text
+          style={{
+            color: theme.colors.mutedForeground,
+            fontFamily: theme.fonts.sansMedium,
+            fontSize: 12,
+          }}
+        >
+          {label}
+        </Text>
+      </View>
+      <Text
+        style={{
+          color: theme.colors.foreground,
+          fontFamily: theme.fonts.mono,
+          fontSize: 15,
+        }}
+      >
+        {value}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  navRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 8,
+  },
+  statsRow: { flexDirection: 'row', gap: 8 },
+  statCell: {
+    flex: 1,
+    gap: 4,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+  },
+  statHead: { flexDirection: 'row', alignItems: 'center', gap: 6 },
+});

--- a/mobile/src/components/trip/index.ts
+++ b/mobile/src/components/trip/index.ts
@@ -9,5 +9,6 @@ export { SupplyBlock } from './SupplyBlock';
 export { EventsBlock } from './EventsBlock';
 export { StageDataBlocks } from './StageDataBlocks';
 export { RoadbookView } from './RoadbookView';
+export { StageDetailView } from './StageDetailView';
 export { RoadbookBanner, type RoadbookBannerVariant } from './RoadbookBanner';
 export { TripMapView } from './TripMapView';

--- a/mobile/src/components/trip/stage-detail.test.tsx
+++ b/mobile/src/components/trip/stage-detail.test.tsx
@@ -175,7 +175,7 @@ describe('StageDetailView', () => {
       startDate: null,
       loading: false,
     });
-    const t = texts(render(<StageDetailView id="t1" initialIndex={0} />)).join(' ');
+    const t = texts(render(<StageDetailView initialIndex={0} />)).join(' ');
     expect(t).toContain('Paris');
     expect(t).toContain('Lyon');
     expect(t).toContain('50 km');
@@ -194,7 +194,7 @@ describe('StageDetailView', () => {
       startDate: null,
       loading: false,
     });
-    const tree = render(<StageDetailView id="t1" initialIndex={0} />);
+    const tree = render(<StageDetailView initialIndex={0} />);
     const prev = () => navButton(tree, fr.trip.stageDetail.prev);
     const next = () => navButton(tree, fr.trip.stageDetail.next);
 
@@ -220,7 +220,7 @@ describe('StageDetailView', () => {
       startDate: null,
       loading: false,
     });
-    const t = texts(render(<StageDetailView id="t1" initialIndex={1} />));
+    const t = texts(render(<StageDetailView initialIndex={1} />));
     expect(t).toContain(fr.trip.stageDetail.restNoProfile);
   });
 
@@ -231,13 +231,13 @@ describe('StageDetailView', () => {
       startDate: null,
       loading: false,
     });
-    const t = texts(render(<StageDetailView id="t1" initialIndex={0} />));
+    const t = texts(render(<StageDetailView initialIndex={0} />));
     expect(t).not.toContain(fr.trip.stageDetail.restNoProfile);
   });
 
   it('shows the not-found placeholder for an out-of-range stage', () => {
     useTripStore.setState({ tripId: 't1', stages: [], loading: false });
-    const t = texts(render(<StageDetailView id="t1" initialIndex={0} />));
+    const t = texts(render(<StageDetailView initialIndex={0} />));
     expect(t).toContain(fr.trip.stageDetail.notFound);
   });
 });

--- a/mobile/src/components/trip/stage-detail.test.tsx
+++ b/mobile/src/components/trip/stage-detail.test.tsx
@@ -1,0 +1,211 @@
+/// <reference types="jest" />
+import TestRenderer, { act } from 'react-test-renderer';
+import type { ReactElement } from 'react';
+import { Text } from 'react-native';
+import type { StageData } from '@btp/core';
+import i18n from '../../i18n';
+import { fr } from '../../i18n/resources/fr';
+import { StageDetailView } from './StageDetailView';
+import { useTripStore } from '../../store/trip-store';
+import {
+  activeStageIndex,
+  clampIndex,
+  hasNextStage,
+  hasPrevStage,
+  parseStageIndex,
+  stageGeometryCoords,
+  stageStats,
+  surfaceShares,
+} from './stage-detail';
+
+// maplibre is native; stub it so StageDetailView's TripMap import resolves under
+// react-test-renderer (react-native-svg is left real — the lucide icons render
+// through it).
+jest.mock('@maplibre/maplibre-react-native', () => ({
+  Camera: () => null,
+  GeoJSONSource: ({ children }: { children?: unknown }) => children ?? null,
+  Layer: () => null,
+  Map: ({ children }: { children?: unknown }) => children ?? null,
+}));
+
+function textOf(node: any): string[] {
+  const kids = Array.isArray(node.props.children) ? node.props.children : [node.props.children];
+  return kids.filter((c: unknown): c is string => typeof c === 'string');
+}
+
+function texts(node: any): string[] {
+  return node.root.findAllByType(Text).flatMap(textOf);
+}
+
+// Locate a nav Button (role="button") by its visible label — robust to the order
+// findAllByProps returns nodes in.
+function navButton(tree: any, label: string): any {
+  return tree.root
+    .findAllByProps({ accessibilityRole: 'button' })
+    .find((b: any) => b.findAllByType(Text).some((tx: any) => textOf(tx).includes(label)));
+}
+
+let lastTree: any;
+function render(element: ReactElement): any {
+  act(() => {
+    lastTree = TestRenderer.create(element);
+  });
+  return lastTree;
+}
+
+function stage(overrides: Partial<StageData> = {}): StageData {
+  const point = { lat: 0, lon: 0, ele: 0 };
+  return {
+    dayNumber: 1,
+    distance: 50,
+    elevation: 800,
+    elevationLoss: 600,
+    startPoint: point,
+    endPoint: point,
+    geometry: [],
+    label: null,
+    startLabel: 'Paris',
+    endLabel: 'Lyon',
+    weather: null,
+    alerts: [],
+    pois: [],
+    accommodations: [],
+    selectedAccommodation: null,
+    accommodationSearchRadiusKm: 10,
+    isRestDay: false,
+    supplyTimeline: [],
+    events: [],
+    ...overrides,
+  };
+}
+
+beforeAll(async () => {
+  await i18n.changeLanguage('fr');
+});
+
+afterEach(() => {
+  act(() => {
+    lastTree?.unmount();
+    lastTree = undefined;
+    useTripStore.getState().reset();
+  });
+});
+
+describe('stage-detail helpers', () => {
+  it('parses the route index param, defaulting to 0 on garbage', () => {
+    expect(parseStageIndex('3')).toBe(3);
+    expect(parseStageIndex(undefined)).toBe(0);
+    expect(parseStageIndex('-2')).toBe(0);
+    expect(parseStageIndex('x')).toBe(0);
+  });
+
+  it('clamps an index into the stage range', () => {
+    expect(clampIndex(5, 3)).toBe(2);
+    expect(clampIndex(-1, 3)).toBe(0);
+    expect(clampIndex(0, 0)).toBe(0);
+  });
+
+  it('bounds prev/next at the extremities', () => {
+    expect(hasPrevStage(0)).toBe(false);
+    expect(hasPrevStage(1)).toBe(true);
+    expect(hasNextStage(2, 3)).toBe(false);
+    expect(hasNextStage(1, 3)).toBe(true);
+  });
+
+  it('rounds per-stage stats', () => {
+    expect(stageStats(stage({ distance: 50.4, elevation: 812.6, elevationLoss: 599.5 }))).toEqual({
+      distanceKm: 50,
+      elevationGain: 813,
+      elevationLoss: 600,
+    });
+  });
+
+  it('maps an absolute index to the rest-day-filtered active index', () => {
+    const stages = [
+      stage({ isRestDay: false }),
+      stage({ isRestDay: true }),
+      stage({ isRestDay: false }),
+    ];
+    expect(activeStageIndex(stages, 0)).toBe(0);
+    expect(activeStageIndex(stages, 1)).toBeNull(); // rest day
+    expect(activeStageIndex(stages, 2)).toBe(1); // skips the rest day
+    expect(activeStageIndex(stages, 9)).toBeNull(); // out of bounds
+  });
+
+  it('projects geometry to [lon, lat] pairs', () => {
+    const s = stage({
+      geometry: [
+        { lat: 45, lon: 4, ele: 100 },
+        { lat: 46, lon: 5, ele: 200 },
+      ],
+    });
+    expect(stageGeometryCoords(s)).toEqual([
+      [4, 45],
+      [5, 46],
+    ]);
+  });
+
+  it('computes surface shares as rounded percentages, largest first', () => {
+    const s = stage({
+      surfaceBreakdown: [
+        { surface: 'gravel', lengthMeters: 2000 },
+        { surface: 'paved', lengthMeters: 8000 },
+      ],
+    });
+    expect(surfaceShares(s)).toEqual([
+      { surface: 'paved', percent: 80 },
+      { surface: 'gravel', percent: 20 },
+    ]);
+    expect(surfaceShares(stage())).toEqual([]);
+  });
+});
+
+describe('StageDetailView', () => {
+  it('renders the stage stats, labels and position', () => {
+    useTripStore.setState({
+      tripId: 't1',
+      stages: [stage({ startLabel: 'Paris', endLabel: 'Lyon' }), stage({ dayNumber: 2 })],
+      startDate: null,
+      loading: false,
+    });
+    const t = texts(render(<StageDetailView id="t1" initialIndex={0} />)).join(' ');
+    expect(t).toContain('Paris');
+    expect(t).toContain('Lyon');
+    expect(t).toContain('50 km');
+    expect(t).toContain('800 m'); // D+
+    expect(t).toContain('600 m'); // D-
+    expect(t).toContain('Étape 1 / 2');
+  });
+
+  it('advances to the next stage and bounds prev/next at the extremities', () => {
+    useTripStore.setState({
+      tripId: 't1',
+      stages: [
+        stage({ dayNumber: 1, startLabel: 'A', endLabel: 'B' }),
+        stage({ dayNumber: 2, startLabel: 'B', endLabel: 'C' }),
+      ],
+      startDate: null,
+      loading: false,
+    });
+    const tree = render(<StageDetailView id="t1" initialIndex={0} />);
+    const prev = () => navButton(tree, fr.trip.stageDetail.prev);
+    const next = () => navButton(tree, fr.trip.stageDetail.next);
+
+    // At the first stage: prev disabled, next enabled.
+    expect(prev().props.accessibilityState.disabled).toBe(true);
+    expect(next().props.accessibilityState.disabled).toBe(false);
+
+    act(() => next().props.onPress());
+
+    expect(texts(tree).join(' ')).toContain('Étape 2 / 2');
+    // Now at the last stage: prev enabled, next disabled.
+    expect(prev().props.accessibilityState.disabled).toBe(false);
+    expect(next().props.accessibilityState.disabled).toBe(true);
+  });
+
+  it('shows the not-found placeholder for an out-of-range stage', () => {
+    useTripStore.setState({ tripId: 't1', stages: [], loading: false });
+    const t = texts(render(<StageDetailView id="t1" initialIndex={0} />));
+    expect(t).toContain(fr.trip.stageDetail.notFound);
+  });
+});

--- a/mobile/src/components/trip/stage-detail.test.tsx
+++ b/mobile/src/components/trip/stage-detail.test.tsx
@@ -203,6 +203,31 @@ describe('StageDetailView', () => {
     expect(next().props.accessibilityState.disabled).toBe(true);
   });
 
+  it('shows a placeholder instead of the whole-trip profile on a rest day (#1039)', () => {
+    useTripStore.setState({
+      tripId: 't1',
+      stages: [
+        stage({ dayNumber: 1, isRestDay: false }),
+        stage({ dayNumber: 2, isRestDay: true }),
+      ],
+      startDate: null,
+      loading: false,
+    });
+    const t = texts(render(<StageDetailView id="t1" initialIndex={1} />));
+    expect(t).toContain(fr.trip.stageDetail.restNoProfile);
+  });
+
+  it('renders the elevation profile on a riding day, not the rest placeholder (#1039)', () => {
+    useTripStore.setState({
+      tripId: 't1',
+      stages: [stage({ dayNumber: 1, isRestDay: false })],
+      startDate: null,
+      loading: false,
+    });
+    const t = texts(render(<StageDetailView id="t1" initialIndex={0} />));
+    expect(t).not.toContain(fr.trip.stageDetail.restNoProfile);
+  });
+
   it('shows the not-found placeholder for an out-of-range stage', () => {
     useTripStore.setState({ tripId: 't1', stages: [], loading: false });
     const t = texts(render(<StageDetailView id="t1" initialIndex={0} />));

--- a/mobile/src/components/trip/stage-detail.test.tsx
+++ b/mobile/src/components/trip/stage-detail.test.tsx
@@ -12,6 +12,7 @@ import {
   clampIndex,
   hasNextStage,
   hasPrevStage,
+  ownsTripLive,
   parseStageIndex,
   stageGeometryCoords,
   stageStats,
@@ -130,6 +131,12 @@ describe('stage-detail helpers', () => {
     expect(activeStageIndex(stages, 1)).toBeNull(); // rest day
     expect(activeStageIndex(stages, 2)).toBe(1); // skips the rest day
     expect(activeStageIndex(stages, 9)).toBeNull(); // out of bounds
+  });
+
+  it('owns the live store only on a deep-link entry (different tripId)', () => {
+    expect(ownsTripLive('42', '42')).toBe(false); // roadbook already live
+    expect(ownsTripLive(null, '42')).toBe(true); // deep link, store empty
+    expect(ownsTripLive('7', '42')).toBe(true); // live for another trip
   });
 
   it('projects geometry to [lon, lat] pairs', () => {

--- a/mobile/src/components/trip/stage-detail.ts
+++ b/mobile/src/components/trip/stage-detail.ts
@@ -12,6 +12,14 @@ export function parseStageIndex(raw: string | undefined): number {
   return Number.isFinite(n) && n >= 0 ? n : 0;
 }
 
+// Whether this screen should own the live store: true only on a deep-link entry,
+// where the store isn't already live for this trip. When reached by tapping a
+// StageCard the roadbook already owns it (same tripId), so we return false to
+// avoid re-hydrating or resetting on unmount (which would blank the roadbook).
+export function ownsTripLive(currentTripId: string | null, routeTripId: string): boolean {
+  return currentTripId !== routeTripId;
+}
+
 // Clamp an index into [0, count-1]; 0 when there are no stages.
 export function clampIndex(index: number, count: number): number {
   if (count <= 0) return 0;

--- a/mobile/src/components/trip/stage-detail.ts
+++ b/mobile/src/components/trip/stage-detail.ts
@@ -1,0 +1,80 @@
+import type { StageData } from '@btp/core';
+
+// Pure derivations for the full-screen stage detail (#1039). Kept framework-free
+// so the navigation bounds, per-stage stats and geometry are unit-tested without
+// a React renderer.
+
+// Parse the `[index]` route param into a non-negative integer (defaults to 0 on
+// a malformed value). Bounds against the stage count are applied separately by
+// clampIndex once the store is hydrated.
+export function parseStageIndex(raw: string | undefined): number {
+  const n = Number.parseInt(raw ?? '', 10);
+  return Number.isFinite(n) && n >= 0 ? n : 0;
+}
+
+// Clamp an index into [0, count-1]; 0 when there are no stages.
+export function clampIndex(index: number, count: number): number {
+  if (count <= 0) return 0;
+  return Math.min(Math.max(index, 0), count - 1);
+}
+
+export function hasPrevStage(index: number): boolean {
+  return index > 0;
+}
+
+export function hasNextStage(index: number, count: number): boolean {
+  return index < count - 1;
+}
+
+export interface StageStats {
+  distanceKm: number;
+  elevationGain: number;
+  elevationLoss: number;
+}
+
+// Rounded per-stage stats for the detail header.
+export function stageStats(stage: StageData): StageStats {
+  return {
+    distanceKm: Math.round(stage.distance ?? 0),
+    elevationGain: Math.round(stage.elevation ?? 0),
+    elevationLoss: Math.round(stage.elevationLoss ?? 0),
+  };
+}
+
+// This stage's geometry as MapLibre [lon, lat] pairs (TripMap fits its bounds).
+export function stageGeometryCoords(stage: StageData): [number, number][] {
+  return (stage.geometry ?? []).map((p) => [p.lon, p.lat]);
+}
+
+// Map an absolute stage index to its position within the rest-day-filtered
+// active stages — the index buildProfilePoints() expects as focusedStageIndex.
+// Returns null when the stage is a rest day (no profile) or out of bounds.
+export function activeStageIndex(
+  stages: StageData[],
+  index: number,
+): number | null {
+  const stage = stages[index];
+  if (!stage || stage.isRestDay) return null;
+  let active = 0;
+  for (let i = 0; i < index; i++) {
+    if (!stages[i]!.isRestDay) active++;
+  }
+  return active;
+}
+
+export interface SurfaceShare {
+  surface: string;
+  percent: number;
+}
+
+// Convert the optional per-stage surface breakdown (metres per OSM surface tag)
+// into rounded percentages, largest first. Empty when the backend hasn't emitted
+// the field yet (forward-compatible, see StageDataSchema).
+export function surfaceShares(stage: StageData): SurfaceShare[] {
+  const segments = stage.surfaceBreakdown ?? [];
+  const total = segments.reduce((sum, s) => sum + s.lengthMeters, 0);
+  if (total <= 0) return [];
+  return segments
+    .map((s) => ({ surface: s.surface, percent: Math.round((s.lengthMeters / total) * 100) }))
+    .sort((a, b) => b.percent - a.percent);
+}

--- a/mobile/src/components/trip/trip-components.test.tsx
+++ b/mobile/src/components/trip/trip-components.test.tsx
@@ -83,6 +83,63 @@ describe('StageCard', () => {
       tree.root.findAllByProps({ accessibilityLabel: fr.trip.deleteA11y.replace('{{day}}', '1') }),
     ).toHaveLength(0);
   });
+
+  it('fires onPress(index) when the summary is tapped (#1039)', () => {
+    const onPress = jest.fn();
+    const tree = render(
+      <StageCard stage={stage()} index={3} locked={false} onDelete={jest.fn()} onPress={onPress} />,
+    );
+    act(() => {
+      tree.root
+        .findByProps({ accessibilityLabel: fr.trip.openStageA11y.replace('{{day}}', '1') })
+        .props.onPress();
+    });
+    expect(onPress).toHaveBeenCalledWith(3);
+  });
+
+  it('routes the delete action to onDelete, never onPress (#1037)', () => {
+    const onPress = jest.fn();
+    const onDelete = jest.fn();
+    const tree = render(
+      <StageCard stage={stage()} index={2} locked={false} onDelete={onDelete} onPress={onPress} />,
+    );
+    act(() => {
+      tree.root
+        .findByProps({ accessibilityLabel: fr.trip.deleteA11y.replace('{{day}}', '1') })
+        .props.onPress();
+    });
+    expect(onDelete).toHaveBeenCalledWith(2);
+    expect(onPress).not.toHaveBeenCalled();
+  });
+
+  it('wires the tap-through to the summary only, not the data blocks (#1038)', () => {
+    const onPress = jest.fn();
+    const tree = render(
+      <StageCard stage={stage()} index={0} locked={false} onDelete={jest.fn()} onPress={onPress} />,
+    );
+    // Exactly one press trigger navigates: the summary. The data blocks below
+    // carry their own controls and are not wired to open the stage detail.
+    const openLabel = fr.trip.openStageA11y.replace('{{day}}', '1');
+    const triggers = tree.root.findAll(
+      (n: any) =>
+        n.props?.accessibilityLabel === openLabel && typeof n.props?.onPress === 'function',
+    );
+    expect(triggers).toHaveLength(1);
+  });
+
+  it('is not pressable when onPress is absent (disabled)', () => {
+    const tree = render(<StageCard stage={stage()} index={0} locked={false} onDelete={jest.fn()} />);
+    // No open-stage button is exposed…
+    const openLabel = fr.trip.openStageA11y.replace('{{day}}', '1');
+    const triggers = tree.root.findAll(
+      (n: any) =>
+        n.props?.accessibilityLabel === openLabel && typeof n.props?.onPress === 'function',
+    );
+    expect(triggers).toHaveLength(0);
+    // …and the summary is rendered disabled.
+    const disabled = tree.root.findAll((n: any) => n.props?.disabled === true);
+    expect(disabled).toHaveLength(1);
+  });
 });
 
 describe('AlertsBlock', () => {

--- a/mobile/src/hooks/use-trip-live.test.ts
+++ b/mobile/src/hooks/use-trip-live.test.ts
@@ -1,6 +1,8 @@
 /// <reference types="jest" />
+import { createElement } from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
 import type { EnrichedStagePayload, MercureEvent } from '@btp/core/mercure';
-import { runTripLive } from './use-trip-live';
+import { runTripLive, useTripLive } from './use-trip-live';
 import { useTripStore } from '../store/trip-store';
 import { useDismissedAlerts } from '../store/dismissed-alerts';
 
@@ -219,5 +221,51 @@ describe('computing state machine driven by SSE', () => {
       data: { computation: 'weather', message: 'transient', retryable: true },
     });
     expect(store().computing).toBe(true);
+  });
+});
+
+// Minimal renderHook on react-test-renderer (the mobile convention, no RTL).
+async function renderUseTripLive(
+  id: string,
+  options?: { enabled?: boolean },
+): Promise<{ unmount: () => void }> {
+  function Probe() {
+    useTripLive(id, options);
+    return null;
+  }
+  let renderer!: ReturnType<typeof TestRenderer.create>;
+  await act(async () => {
+    renderer = TestRenderer.create(createElement(Probe));
+  });
+  return { unmount: () => act(() => renderer.unmount()) };
+}
+
+describe('useTripLive enabled gate (#1039)', () => {
+  it('runs no orchestration and never resets on unmount when enabled=false', async () => {
+    // The tap-through case: the roadbook already owns the live store for this
+    // trip; the detail screen must not re-hydrate nor reset() on back-nav.
+    useTripStore.setState({ tripId: 't1', stages: [apiStage()] as never });
+
+    const { unmount } = await renderUseTripLive('t1', { enabled: false });
+    expect(mockDetail).not.toHaveBeenCalled();
+
+    unmount();
+    // reset() would null tripId and empty stages — assert it didn't fire.
+    expect(store().tripId).toBe('t1');
+    expect(store().stages).toHaveLength(1);
+  });
+
+  it('runs the orchestration and resets on unmount when enabled (default)', async () => {
+    mockDetail.mockResolvedValue(detail([apiStage()]));
+    mockToken.mockResolvedValue('jwt');
+    mockSubscribe.mockReturnValue({ close: jest.fn() });
+
+    const { unmount } = await renderUseTripLive('t1');
+    expect(mockDetail).toHaveBeenCalledWith('t1');
+    expect(store().tripId).toBe('t1');
+
+    unmount();
+    expect(store().tripId).toBeNull();
+    expect(store().stages).toHaveLength(0);
   });
 });

--- a/mobile/src/hooks/use-trip-live.ts
+++ b/mobile/src/hooks/use-trip-live.ts
@@ -85,7 +85,12 @@ export async function runTripLive(
 }
 
 // Loads a trip into the shared store and keeps it live via Mercure SSE.
-export function useTripLive(id: string): void {
+// `options.enabled` (default true) gates the whole orchestration: when false,
+// nothing is subscribed and the store is never reset on unmount — the caller
+// already owns the live store (e.g. the stage detail reached by tap-through,
+// where a reset would blank the roadbook mounted underneath).
+export function useTripLive(id: string, options?: { enabled?: boolean }): void {
+  const enabled = options?.enabled ?? true;
   const hydrate = useTripStore((s) => s.hydrate);
   const applyTripReady = useTripStore((s) => s.applyTripReady);
   const applyStageUpdate = useTripStore((s) => s.applyStageUpdate);
@@ -94,6 +99,7 @@ export function useTripLive(id: string): void {
   const reset = useTripStore((s) => s.reset);
 
   useEffect(() => {
+    if (!enabled) return;
     let sub: TripSubscription | undefined;
     let cancelled = false;
 
@@ -111,5 +117,5 @@ export function useTripLive(id: string): void {
       sub?.close();
       reset();
     };
-  }, [id, hydrate, applyTripReady, applyStageUpdate, setStatus, setComputing, reset]);
+  }, [enabled, id, hydrate, applyTripReady, applyStageUpdate, setStatus, setComputing, reset]);
 }

--- a/mobile/src/i18n/resources/en.ts
+++ b/mobile/src/i18n/resources/en.ts
@@ -14,6 +14,7 @@ export const en: typeof fr = {
   header: {
     login: 'Sign in',
     trip: 'Roadbook',
+    stageDetail: 'Stage',
   },
   login: {
     brand: 'Bike Trip Planner',
@@ -65,6 +66,19 @@ export const en: typeof fr = {
     today: 'Today',
     stageMeta: '{{distance}} km · +{{elevation}} m',
     elevationProfileA11y: 'Trip elevation profile',
+    openStageA11y: 'Open day {{day}} details',
+    stageDetail: {
+      notFound: 'Stage not found.',
+      prev: 'Previous',
+      next: 'Next',
+      position: 'Stage {{current}} / {{total}}',
+      distance: 'Distance',
+      ascent: 'Ascent',
+      descent: 'Descent',
+      distanceValue: '{{value}} km',
+      elevationValue: '{{value}} m',
+      surface: 'Surface',
+    },
     states: {
       upcoming: 'Upcoming',
       ongoing: 'Ongoing',

--- a/mobile/src/i18n/resources/en.ts
+++ b/mobile/src/i18n/resources/en.ts
@@ -78,6 +78,7 @@ export const en: typeof fr = {
       distanceValue: '{{value}} km',
       elevationValue: '{{value}} m',
       surface: 'Surface',
+      restNoProfile: 'No elevation profile for a rest day.',
     },
     states: {
       upcoming: 'Upcoming',

--- a/mobile/src/i18n/resources/fr.ts
+++ b/mobile/src/i18n/resources/fr.ts
@@ -76,6 +76,7 @@ export const fr = {
       distanceValue: '{{value}} km',
       elevationValue: '{{value}} m',
       surface: 'Surface',
+      restNoProfile: 'Pas de profil altimétrique pour un jour de repos.',
     },
     states: {
       upcoming: 'À venir',

--- a/mobile/src/i18n/resources/fr.ts
+++ b/mobile/src/i18n/resources/fr.ts
@@ -12,6 +12,7 @@ export const fr = {
   header: {
     login: 'Connexion',
     trip: 'Roadbook',
+    stageDetail: 'Étape',
   },
   login: {
     brand: 'Bike Trip Planner',
@@ -63,6 +64,19 @@ export const fr = {
     today: "Aujourd'hui",
     stageMeta: '{{distance}} km · +{{elevation}} m',
     elevationProfileA11y: 'Profil altimétrique du voyage',
+    openStageA11y: 'Ouvrir le détail du jour {{day}}',
+    stageDetail: {
+      notFound: 'Étape introuvable.',
+      prev: 'Précédent',
+      next: 'Suivant',
+      position: 'Étape {{current}} / {{total}}',
+      distance: 'Distance',
+      ascent: 'Dénivelé +',
+      descent: 'Dénivelé -',
+      distanceValue: '{{value}} km',
+      elevationValue: '{{value}} m',
+      surface: 'Surface',
+    },
     states: {
       upcoming: 'À venir',
       ongoing: 'En cours',


### PR DESCRIPTION
Closes #1039

> Stacked PR — **sommet du stack**, base `feature/1041` (#1041). Hérite #1035 + #1040 + #1041.

## Contexte
Sprint 55 (Consultation). Écran détail d'étape plein écran + navigation prev/next + tap-through depuis le roadbook.

## Changements
- **Route** : `mobile/app/trip/[id].tsx` → `mobile/app/trip/[id]/index.tsx` (contenu préservé, imports corrigés) ; nouvelle route `mobile/app/trip/[id]/stage/[index].tsx`. Route roadbook `/trip/[id]` inchangée.
- `StageDetailView.tsx` : header prev/next borné + position, titre (date/labels), stats (distance/D+/D-), surface, carte de l'étape (géométrie filtrée + fit-bounds), profil focalisé (`ElevationProfile`), blocs data (`StageDataBlocks`). Index en state local → prev/next sans re-navigation ni re-souscription SSE.
- `stage-detail.ts` (pur, testé) : `parseStageIndex`, `clampIndex`, `hasPrev/NextStage`, `stageStats`, `stageGeometryCoords`, `activeStageIndex` (mappe l'index absolu → index actif filtré des jours de repos attendu par `buildProfilePoints`), `surfaceShares`.
- `StageCard.onPress` (seul le résumé devient Pressable, pas les data-blocks ni le delete), `RoadbookView` route au tap. `_layout.tsx` : déclaration des routes.

## Vérification
- `tsc --noEmit` : clean.
- `jest` : 24 suites / 178 tests verts. `hasNextStage` prouvé rouge-puis-vert.

## Auto-critique
- Le store n'est ré-approprié (`runTripLive`) qu'en **deep-link** (`tripId !== id`), décidé une fois au montage : évite un `reset()` au retour arrière qui blanchirait le roadbook resté monté dessous.
- **Non-régression #1037/#1038** : `StageCard` — seul le résumé devient Pressable via `disabled={!onPress}`, le bouton supprimer et les data-blocks restent des siblings intacts. Pas de DTO, pas de dépendance.

<!-- claude-review-start -->
## Claude Review

**Summary:** Mobile-only change (no backend touched), well-scoped and well-tested. This pass closes out the review: the last open finding (untested `enabled` gate on `useTripLive`) is now fixed. No new findings.

**Resolved threads:** Resolved 1 previously open thread that was addressed (`useTripLive`'s `enabled` gate now covered by two tests in `use-trip-live.test.ts`, commit `4847716`).

**PR title check:** `feat(mobile): détail d'étape plein écran + navigation entre étapes (#1039)` — the description is a noun phrase, not imperative mood as required by `CLAUDE.md`'s Git Conventions (e.g. "ajoute le détail d'étape plein écran…"). Non-blocking, flagged per process (unchanged since previous pass).

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Findings:** None outstanding.

**Inline comments:** No inline comments.

**Commit reviewed:** 484771646d475033163a7bb51a0651dc936681a1
<!-- claude-review-end -->
