### PR TITLE
docs(tracking): track sprint 55 stacked prs and merge order

### DIFF
--- a/TRACKING.md
+++ b/TRACKING.md
@@ -1827,13 +1827,37 @@ Fondation de tous les écrans. Deux pistes : **UI** (device-vérifiée) et **dat
 
 | Ordre | ID | Titre | Effort | Statut | PRs | Dépend de |
 |-------|----|-------|--------|--------|-----|-----------|
-| 1 | [#1035](https://github.com/vincentchalamon/bike-trip-planner/issues/1035) | composants trip-screen partagés (stage card, blocs data/jour, statut SSE) | M | ⏳ À faire | — | #1028, #1031 |
-| 2 | [#1036](https://github.com/vincentchalamon/bike-trip-planner/issues/1036) | liste des voyages (pagination + filtres titre/dates + suppression) | M | ⏳ À faire | — | #1031 |
-| 3 | [#1037](https://github.com/vincentchalamon/bike-trip-planner/issues/1037) | roadbook lecture — 3 états + dates + bannières + « Aujourd'hui » | M | ⏳ À faire | — | #1035 |
-| 4 | [#1038](https://github.com/vincentchalamon/bike-trip-planner/issues/1038) | données par jour — alertes (rejet + dédup) + événements + météo + POI + héberg. + ravito | L | ⏳ À faire | — | #1035, #1030 |
-| 5 | [#1039](https://github.com/vincentchalamon/bike-trip-planner/issues/1039) | détail d'étape plein écran + navigation | M | ⏳ À faire | — | #1035, #1040, #1041 |
-| 6 | [#1040](https://github.com/vincentchalamon/bike-trip-planner/issues/1040) | carte complète — tuiles/satellite + markers + fit-bounds + surlignage segment | L | ⏳ À faire | — | #1031 |
-| 7 | [#1041](https://github.com/vincentchalamon/bike-trip-planner/issues/1041) | profil altimétrique (react-native-svg) + hover synchronisé | M | ⏳ À faire | — | #1040 |
+| 1 | [#1035](https://github.com/vincentchalamon/bike-trip-planner/issues/1035) | composants trip-screen partagés (stage card, blocs data/jour, statut SSE) | M | 🚧 En cours | [#1068](https://github.com/vincentchalamon/bike-trip-planner/pull/1068) `feature/1035` | #1028, #1031 |
+| 2 | [#1036](https://github.com/vincentchalamon/bike-trip-planner/issues/1036) | liste des voyages (pagination + filtres titre/dates + suppression) | M | 🚧 En cours | [#1069](https://github.com/vincentchalamon/bike-trip-planner/pull/1069) `feature/1036` | #1031 |
+| 3 | [#1037](https://github.com/vincentchalamon/bike-trip-planner/issues/1037) | roadbook lecture — 3 états + dates + bannières + « Aujourd'hui » | M | 🚧 En cours | [#1070](https://github.com/vincentchalamon/bike-trip-planner/pull/1070) `feature/1037` | #1035 |
+| 4 | [#1038](https://github.com/vincentchalamon/bike-trip-planner/issues/1038) | données par jour — alertes (rejet + dédup) + événements + météo + POI + héberg. + ravito | L | 🚧 En cours | [#1071](https://github.com/vincentchalamon/bike-trip-planner/pull/1071) `feature/1038` | #1035, #1030 |
+| 5 | [#1039](https://github.com/vincentchalamon/bike-trip-planner/issues/1039) | détail d'étape plein écran + navigation | M | 🚧 En cours | [#1074](https://github.com/vincentchalamon/bike-trip-planner/pull/1074) `feature/1039` | #1035, #1040, #1041 |
+| 6 | [#1040](https://github.com/vincentchalamon/bike-trip-planner/issues/1040) | carte complète — tuiles/satellite + markers + fit-bounds + surlignage segment | L | 🚧 En cours | [#1072](https://github.com/vincentchalamon/bike-trip-planner/pull/1072) `feature/1040` | #1031 |
+| 7 | [#1041](https://github.com/vincentchalamon/bike-trip-planner/issues/1041) | profil altimétrique (react-native-svg) + hover synchronisé | M | 🚧 En cours | [#1073](https://github.com/vincentchalamon/bike-trip-planner/pull/1073) `feature/1041` | #1040 |
+
+### Ordre de merge et conflits attendus
+
+Livré en **stack GitHub linéaire unique** ([stack #1075](https://github.com/vincentchalamon/bike-trip-planner/pull/1075), `gh stack`) : chaque PR est basée sur la précédente, mergeable **bottom-up d'un coup**. `#1035` extrait d'abord les composants trip-screen pour rendre les diffs des frères **disjoints par construction** — d'où **aucun conflit interne** au stack (rebases de linéarisation propres, vérifiés : tip combiné `feature/1039` vert, tsc + 178 tests jest).
+
+**Ordre de merge (bottom → top), à respecter strictement :**
+
+| # | PR | Branche | Base | Fichiers principaux (disjoints) |
+|---|----|---------|------|---------------------------------|
+| 1 | #1068 | `feature/1035` | `main` | `mobile/src/components/trip/*` (fondation), `app/trip/[id].tsx`, `trip-store.ts`, `use-trip-live.ts` |
+| 2 | #1069 | `feature/1036` | `feature/1035` | `app/(tabs)/index.tsx`, `api/trips.ts`, `hooks/use-trips.ts` |
+| 3 | #1070 | `feature/1037` | `feature/1036` | `RoadbookView.tsx`, `StageCard.tsx`, `roadbook-dates.ts`, `RoadbookBanner.tsx` |
+| 4 | #1071 | `feature/1038` | `feature/1037` | 6 `*Block.tsx`, `StageDataBlocks.tsx`, `alert-utils.ts`, `store/dismissed-alerts.ts` |
+| 5 | #1072 | `feature/1040` | `feature/1038` | `TripMap.tsx`, `components/map/*`, `store/map-prefs.ts` |
+| 6 | #1073 | `feature/1041` | `feature/1040` | `core/elevation.ts`, `ElevationProfile.tsx`, `TripMapView.tsx` |
+| 7 | #1074 | `feature/1039` | `feature/1041` | `app/trip/[id]/index.tsx` (+ `stage/[index].tsx`), `StageDetailView.tsx` |
+
+**Zones partagées et arbitrage (déjà résolu dans le stack, à re-appliquer si conflit lors d'un merge séquentiel classique) :**
+- **i18n `fr.ts`/`en.ts`** — touchés par toutes les PRs, en **ajout additif** sous des sous-namespaces distincts (`trip.sse`, `trip.blocks`, `trip.states`/`banners`, `trip.map`, `trip.stageDetail`…). Conflit trivial : **garder les deux jeux de clés**, fr et en synchronisés.
+- **`StageCard.tsx`** — chrome par #1037 (date/pastille/labels/delete), body par #1038 (`StageDataBlocks`), `onPress` résumé par #1039. Arbitrage : **cumuler**, ne jamais retirer le chrome #1037 ni les data-blocks #1038.
+- **`TripMapView.tsx`** — markers par #1040, pilotage du highlight (hover profil) par #1041. Arbitrage : **cumuler** ; `TripMap.tsx`/`map-utils.ts` restent la source (#1040).
+- **`app/trip/[id].tsx` → `app/trip/[id]/index.tsx`** — #1039 convertit le fichier en dossier (contenu préservé, imports reprofondis). Doit rester **en haut du stack** (dernier merge).
+
+**Point de suivi (non bloquant) :** le câblage complet action d'alerte `navigate` → surlignage carte est exposé côté données (`onAlertNavigate`, #1038) et côté carte (`highlightedSegment`, #1040) ; le fil hover profil↔carte est branché dans `TripMapView` (#1041). Le routage `navigate` depuis le roadbook (segment Carte) vers le highlight reste à finaliser (candidat Sprint 56 ou follow-up consultation).
 
 </details>
 

--- a/TRACKING.md
+++ b/TRACKING.md
@@ -1852,6 +1852,7 @@ Livré en **stack GitHub linéaire unique** ([stack #1075](https://github.com/vi
 | 7 | #1074 | `feature/1039` | `feature/1041` | `app/trip/[id]/index.tsx` (+ `stage/[index].tsx`), `StageDetailView.tsx` |
 
 **Zones partagées et arbitrage (déjà résolu dans le stack, à re-appliquer si conflit lors d'un merge séquentiel classique) :**
+
 - **i18n `fr.ts`/`en.ts`** — touchés par toutes les PRs, en **ajout additif** sous des sous-namespaces distincts (`trip.sse`, `trip.blocks`, `trip.states`/`banners`, `trip.map`, `trip.stageDetail`…). Conflit trivial : **garder les deux jeux de clés**, fr et en synchronisés.
 - **`StageCard.tsx`** — chrome par #1037 (date/pastille/labels/delete), body par #1038 (`StageDataBlocks`), `onPress` résumé par #1039. Arbitrage : **cumuler**, ne jamais retirer le chrome #1037 ni les data-blocks #1038.
 - **`TripMapView.tsx`** — markers par #1040, pilotage du highlight (hover profil) par #1041. Arbitrage : **cumuler** ; `TripMap.tsx`/`map-utils.ts` restent la source (#1040).

--- a/TRACKING.md
+++ b/TRACKING.md
@@ -1837,7 +1837,7 @@ Fondation de tous les écrans. Deux pistes : **UI** (device-vérifiée) et **dat
 
 ### Ordre de merge et conflits attendus
 
-Livré en **stack GitHub linéaire unique** ([stack #1075](https://github.com/vincentchalamon/bike-trip-planner/pull/1075), `gh stack`) : chaque PR est basée sur la précédente, mergeable **bottom-up d'un coup**. `#1035` extrait d'abord les composants trip-screen pour rendre les diffs des frères **disjoints par construction** — d'où **aucun conflit interne** au stack (rebases de linéarisation propres, vérifiés : tip combiné `feature/1039` vert, tsc + 178 tests jest).
+Livré en **stack GitHub linéaire unique** (`gh stack`, PRs #1068-#1074) : chaque PR est basée sur la précédente, mergeable **bottom-up d'un coup**. `#1035` extrait d'abord les composants trip-screen pour rendre les diffs des frères **disjoints par construction** — d'où **aucun conflit interne** au stack (rebases de linéarisation propres, vérifiés : tip combiné `feature/1039` vert, tsc + 178 tests jest).
 
 **Ordre de merge (bottom → top), à respecter strictement :**
 


### PR DESCRIPTION
## Contexte
Suivi du Sprint 55 (Mobile : Consultation) implémenté via `/sprint 55`.

## Changements
- Les 7 issues (#1035-#1041) passent en 🚧 En cours avec leur PR + branche.
- Ajout de la section **« Ordre de merge et conflits attendus »** : stack GitHub linéaire unique [#1075](https://github.com/vincentchalamon/bike-trip-planner/pull/1075) (`gh stack`), table d'ordre de merge bottom-up, zones partagées + arbitrage (i18n additif, `StageCard`/`TripMapView` cumulés, conversion `[id].tsx`→dossier en dernier), et un point de suivi non bloquant (routage `navigate`→highlight carte).

Livré en stack : chaque PR basée sur la précédente, mergeable d'un coup bottom-up. Tip combiné `feature/1039` vert (tsc + 178 tests jest).

<!-- claude-review-start -->
## Claude Review

**Summary:** Docs-only change (TRACKING.md). The previously flagged dead `#1075` link has been dropped and replaced with `PRs #1068-#1074`. Merge-order table re-checked against the live PRs' actual head/base branches — still consistent (PR #1074's base now shows `main` instead of `feature/1041` because its parent branch was merged and deleted in the interim, which is expected post-merge retargeting, not a documentation defect). No new findings.

**Resolved threads:** Resolved 1 previously open thread (dead `#1075` link, now fixed).

**Findings by severity:**
- Issue: 0
- Warning: 0
- Suggestion: 0

**Review checklist:**
- [x] Code respects the project architecture (docs-only change, N/A)
- [x] SOLID principles and Law of Demeter followed (N/A, docs-only)
- [x] Design patterns used where appropriate (N/A, docs-only)
- [x] Tests cover new/changed cases (N/A, TRACKING.md is documentation)
- [x] Documentation is up to date (dead `#1075` link fixed; merge-order table matches live PR state)
- [x] Dependent tickets accounted for (merge order table matches the 7 live PRs' actual head/base branches)

**Inline comments:** No inline comments.

**Commit reviewed:** 47de01f1bdca3c8647cf7dcfef4c8b1f38aa1971
<!-- claude-review-end -->