### PR TITLE
feat(mobile): création par lien + ouverture depuis partage + lancer l'analyse (#1042)

### DIFF
--- a/mobile/app/(tabs)/create.tsx
+++ b/mobile/app/(tabs)/create.tsx
@@ -1,20 +1,219 @@
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useEffect, useState } from 'react';
+import { Alert, Text, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
-import { EmptyState, Screen } from '../../src/components/ui';
-import { Plus } from '../../src/components/ui/icons';
+import { Button, Input, Screen } from '../../src/components/ui';
+import { Route } from '../../src/components/ui/icons';
+import { SseStatusIndicator } from '../../src/components/trip';
 import { useTheme } from '../../src/theme';
+import { isSupportedSourceUrl, runCreateTrip } from '../../src/store/create-trip';
+import { runAnalyze } from '../../src/store/mutations';
+import { useAnalysisFollow } from '../../src/hooks/use-analysis-follow';
+import { useTripStore } from '../../src/store/trip-store';
+import type { MutationFailure } from '../../src/store/gating';
 
-// Presentational placeholder: trip creation is wired to the data layer in a
-// later sprint (#1031 / Sprint 55). The tab exists so the shell matches target.
+type CreateErrorKey =
+  | 'create.errors.offline'
+  | 'create.errors.invalidUrl'
+  | 'create.errors.conflict'
+  | 'create.errors.network'
+  | 'create.errors.generic';
+
+// Map a normalized mutation failure to a create-screen message key. A rejected
+// or unsupported URL comes back as 422/404 (validation / not_found); everything
+// else keeps its transversal wording.
+function failureMessageKey(reason: MutationFailure): CreateErrorKey {
+  switch (reason) {
+    case 'offline':
+      return 'create.errors.offline';
+    case 'validation':
+    case 'not_found':
+      return 'create.errors.invalidUrl';
+    case 'conflict':
+      return 'create.errors.conflict';
+    case 'network':
+      return 'create.errors.network';
+    default:
+      return 'create.errors.generic';
+  }
+}
+
+// Create screen: paste a Komoot / Strava / RideWithGPS link (or open from a
+// share deep link `?link=`) → POST /trips → follow the computation over SSE and
+// launch / re-launch the enrichment analysis. Structured so a second creation
+// method (GPX import / duplication, #1043) slots into the `form` phase without a
+// rewrite: the paste-link block is one self-contained method among future ones.
 export default function Create() {
   const { t } = useTranslation();
   const theme = useTheme();
+  const router = useRouter();
+  const params = useLocalSearchParams<{ link?: string }>();
+
+  const [link, setLink] = useState('');
+  const [touched, setTouched] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [createdId, setCreatedId] = useState<string | null>(null);
+  const [launched, setLaunched] = useState(false);
+  const [analyzing, setAnalyzing] = useState(false);
+  // Bumped on every explicit analysis launch so the SSE follow resets its
+  // progress readout for the new run.
+  const [analyzeNonce, setAnalyzeNonce] = useState(0);
+
+  const follow = useAnalysisFollow(createdId, analyzeNonce);
+
+  // Prefill from a share deep link (biketripplanner://create?link=… or an App
+  // Link routed here). Params can land after mount, so react to them.
+  useEffect(() => {
+    if (typeof params.link === 'string' && params.link.length > 0) {
+      setLink(params.link);
+      setCreatedId(null);
+    }
+  }, [params.link]);
+
+  const trimmed = link.trim();
+  const isValid = isSupportedSourceUrl(trimmed);
+  const showError = touched && trimmed.length > 0 && !isValid;
+
+  async function onSubmit(): Promise<void> {
+    setTouched(true);
+    if (!isValid) return;
+    setSubmitting(true);
+    const id = await runCreateTrip(trimmed, (reason) =>
+      Alert.alert(t('create.createFailedTitle'), t(failureMessageKey(reason))),
+    );
+    setSubmitting(false);
+    if (id) {
+      setCreatedId(id);
+      setLaunched(false);
+    }
+  }
+
+  async function launchAnalysis(id: string): Promise<void> {
+    setAnalyzing(true);
+    setAnalyzeNonce((n) => n + 1);
+    const ok = await runAnalyze(id, useTripStore.getState(), (reason) =>
+      Alert.alert(t('create.analysisFailedTitle'), t(failureMessageKey(reason))),
+    );
+    setAnalyzing(false);
+    if (ok) setLaunched(true);
+  }
+
+  function reset(): void {
+    setCreatedId(null);
+    setLink('');
+    setTouched(false);
+    setLaunched(false);
+  }
+
+  const title = (
+    <View style={{ gap: theme.spacing.sm }}>
+      <Route color={theme.colors.brand} size={32} />
+      <Text
+        style={{
+          color: theme.colors.foreground,
+          fontFamily: theme.fonts.serif,
+          fontSize: 26,
+        }}
+      >
+        {t('create.title')}
+      </Text>
+      <Text
+        style={{
+          color: theme.colors.mutedForeground,
+          fontFamily: theme.fonts.sans,
+          fontSize: 15,
+        }}
+      >
+        {t('create.subtitle')}
+      </Text>
+    </View>
+  );
+
+  if (createdId) {
+    return (
+      <Screen scroll style={{ gap: theme.spacing.lg }}>
+        {title}
+        <View style={{ gap: theme.spacing.md }}>
+          <Text
+            style={{
+              color: theme.colors.foreground,
+              fontFamily: theme.fonts.sansSemibold,
+              fontSize: 18,
+            }}
+          >
+            {t('create.createdTitle')}
+          </Text>
+          <SseStatusIndicator computing={follow.computing} />
+          {follow.computing && follow.total > 0 ? (
+            <Text
+              style={{ color: theme.colors.mutedForeground, fontFamily: theme.fonts.sans }}
+            >
+              {t('create.progress', { completed: follow.completed, total: follow.total })}
+            </Text>
+          ) : null}
+          {follow.done ? (
+            <Text style={{ color: theme.colors.foreground, fontFamily: theme.fonts.sansMedium }}>
+              {t('create.analysisDone')}
+            </Text>
+          ) : null}
+          {follow.failed ? (
+            <Text style={{ color: theme.colors.destructive, fontFamily: theme.fonts.sansMedium }}>
+              {t('create.analysisFailed')}
+            </Text>
+          ) : null}
+          <Button
+            label={launched ? t('create.relaunchAnalysis') : t('create.launchAnalysis')}
+            onPress={() => void launchAnalysis(createdId)}
+            loading={analyzing}
+            fullWidth
+          />
+          <Button
+            label={t('create.openRoadbook')}
+            variant="secondary"
+            onPress={() =>
+              router.push({ pathname: '/trip/[id]', params: { id: createdId } })
+            }
+            fullWidth
+          />
+          <Button label={t('create.newTrip')} variant="ghost" onPress={reset} fullWidth />
+        </View>
+      </Screen>
+    );
+  }
+
   return (
-    <Screen padded={false}>
-      <EmptyState
-        title={t('create.title')}
-        description={t('create.description')}
-        icon={<Plus color={theme.colors.brand} size={40} />}
-      />
+    <Screen scroll style={{ gap: theme.spacing.lg }}>
+      {title}
+      <View style={{ gap: theme.spacing.md }}>
+        <Input
+          label={t('create.linkLabel')}
+          value={link}
+          onChangeText={setLink}
+          onBlur={() => setTouched(true)}
+          placeholder={t('create.linkPlaceholder')}
+          autoCapitalize="none"
+          autoCorrect={false}
+          keyboardType="url"
+          inputMode="url"
+          error={showError ? t('create.errors.invalidUrl') : undefined}
+        />
+        <Text
+          style={{
+            color: theme.colors.mutedForeground,
+            fontFamily: theme.fonts.sans,
+            fontSize: 13,
+          }}
+        >
+          {t('create.supportedHint')}
+        </Text>
+        <Button
+          label={submitting ? t('create.submitting') : t('create.submit')}
+          onPress={() => void onSubmit()}
+          loading={submitting}
+          disabled={!isValid}
+          fullWidth
+        />
+      </View>
     </Screen>
   );
 }

--- a/mobile/src/api/trips.ts
+++ b/mobile/src/api/trips.ts
@@ -258,3 +258,40 @@ export async function deleteTrip(tripId: string): Promise<MutationResult> {
   });
   return { ok: response.ok, status: response.status };
 }
+
+// The backend TripRequest requires the whole pacing block, so a fresh trip
+// created from a link ships the schema defaults; the rider tunes pacing later
+// from the roadbook. Mirrors the web create payload (use-trip-planner).
+const CREATE_DEFAULTS = {
+  fatigueFactor: 0.9,
+  elevationPenalty: 50,
+  ebikeMode: false,
+  departureHour: 8,
+  maxDistancePerDay: 80,
+  averageSpeed: 15,
+  enabledAccommodationTypes: [
+    'camp_site',
+    'hostel',
+    'alpine_hut',
+    'chalet',
+    'guest_house',
+    'hotel',
+    'wilderness_hut',
+  ],
+};
+
+/**
+ * Create a trip from a supported source URL (Komoot / Strava / RideWithGPS). The
+ * backend accepts asynchronously (202) and starts parsing + computing the route;
+ * the caller follows the pipeline over SSE. Returns the new trip id (null on
+ * failure) plus the raw status so a rejected / unsupported URL can be classified.
+ */
+export async function createTrip(
+  sourceUrl: string,
+): Promise<{ id: string | null; status: number }> {
+  const { data, response } = await api.POST('/trips', {
+    headers: ldBody,
+    body: { sourceUrl, ...CREATE_DEFAULTS },
+  });
+  return { id: data?.id ?? null, status: response.status };
+}

--- a/mobile/src/hooks/use-analysis-follow.test.ts
+++ b/mobile/src/hooks/use-analysis-follow.test.ts
@@ -1,0 +1,64 @@
+/// <reference types="jest" />
+import type { MercureEvent } from '@btp/core/mercure';
+import {
+  INITIAL_FOLLOW_STATE,
+  reduceAnalysisEvent,
+  type AnalysisFollowState,
+} from './use-analysis-follow';
+
+function step(completed: number, total: number): MercureEvent {
+  return {
+    type: 'computation_step_completed',
+    data: { step: 's', category: 'route', completed, total },
+  };
+}
+
+describe('reduceAnalysisEvent', () => {
+  it('tracks progress on a computation step and stays computing', () => {
+    const next = reduceAnalysisEvent(INITIAL_FOLLOW_STATE, step(2, 7));
+    expect(next).toMatchObject({ computing: true, done: false, completed: 2, total: 7 });
+  });
+
+  it('flips done and stops computing on trip_ready', () => {
+    const running: AnalysisFollowState = { ...INITIAL_FOLLOW_STATE, completed: 3, total: 7 };
+    const next = reduceAnalysisEvent(running, {
+      type: 'trip_ready',
+      data: { stages: [], computationStatus: {} },
+    });
+    expect(next).toMatchObject({ computing: false, done: true });
+  });
+
+  it('flips done and stops computing on trip_complete', () => {
+    const next = reduceAnalysisEvent(INITIAL_FOLLOW_STATE, {
+      type: 'trip_complete',
+      data: { computationStatus: {} },
+    });
+    expect(next).toMatchObject({ computing: false, done: true });
+  });
+
+  it('leaves state untouched on a retryable computation_error', () => {
+    const running = reduceAnalysisEvent(INITIAL_FOLLOW_STATE, step(1, 4));
+    const next = reduceAnalysisEvent(running, {
+      type: 'computation_error',
+      data: { computation: 'weather', message: 'x', retryable: true },
+    });
+    expect(next).toBe(running);
+    expect(next.failed).toBe(false);
+  });
+
+  it('marks failed and stops computing on a non-retryable error', () => {
+    const next = reduceAnalysisEvent(INITIAL_FOLLOW_STATE, {
+      type: 'computation_error',
+      data: { computation: 'route', message: 'x', retryable: false },
+    });
+    expect(next).toMatchObject({ computing: false, failed: true });
+  });
+
+  it('ignores unrelated events', () => {
+    const next = reduceAnalysisEvent(INITIAL_FOLLOW_STATE, {
+      type: 'stage_updated',
+      data: { stageIndex: 0, stage: {} as never },
+    });
+    expect(next).toBe(INITIAL_FOLLOW_STATE);
+  });
+});

--- a/mobile/src/hooks/use-analysis-follow.ts
+++ b/mobile/src/hooks/use-analysis-follow.ts
@@ -1,0 +1,97 @@
+import { useEffect, useReducer } from 'react';
+import type { MercureEvent } from '@btp/core/mercure';
+import {
+  fetchMercureToken,
+  subscribeToTrip,
+  type TripSubscription,
+} from '../api/mercure';
+
+// Live state of the computation pipeline for a freshly created / re-analyzed
+// trip, driven by the Mercure SSE stream. `computing` gates the progress badge;
+// `done` flips on the terminal trip_ready / trip_complete; `failed` on a
+// non-retryable computation_error. `completed`/`total` feed a coarse progress
+// readout ("étape 3 / 7") without pulling in the whole roadbook store.
+export interface AnalysisFollowState {
+  computing: boolean;
+  done: boolean;
+  failed: boolean;
+  completed: number;
+  total: number;
+}
+
+export const INITIAL_FOLLOW_STATE: AnalysisFollowState = {
+  computing: true,
+  done: false,
+  failed: false,
+  completed: 0,
+  total: 0,
+};
+
+// Pure SSE-event reducer, mirroring the lifecycle handling in use-trip-live but
+// scoped to progress (no stage reconciliation). Extracted so the state machine
+// is unit-testable without a subscription or a React renderer.
+export function reduceAnalysisEvent(
+  state: AnalysisFollowState,
+  event: MercureEvent,
+): AnalysisFollowState {
+  switch (event.type) {
+    case 'computation_step_completed':
+      return {
+        ...state,
+        computing: true,
+        done: false,
+        completed: event.data.completed,
+        total: event.data.total,
+      };
+    case 'trip_ready':
+    case 'trip_complete':
+      return { ...state, computing: false, done: true };
+    case 'computation_error':
+      // A retryable error means the run is still going; only a terminal one
+      // clears the badge and surfaces the failure.
+      return event.data.retryable
+        ? state
+        : { ...state, computing: false, failed: true };
+    default:
+      return state;
+  }
+}
+
+// Open a Mercure SSE subscription for `tripId` and fold each event into the
+// progress state. Re-subscribes when `tripId` changes (a new create) or when
+// `nonce` bumps (an explicit re-launch of the analysis, to reset progress).
+// Returns undefined-safe state; when `tripId` is null nothing is subscribed.
+export function useAnalysisFollow(
+  tripId: string | null,
+  nonce = 0,
+): AnalysisFollowState {
+  const [state, dispatch] = useReducer(
+    (s: AnalysisFollowState, e: MercureEvent | 'reset') =>
+      e === 'reset' ? INITIAL_FOLLOW_STATE : reduceAnalysisEvent(s, e),
+    INITIAL_FOLLOW_STATE,
+  );
+
+  useEffect(() => {
+    if (!tripId) return;
+    let sub: TripSubscription | undefined;
+    let cancelled = false;
+    dispatch('reset');
+
+    void fetchMercureToken(tripId)
+      .then((token) => {
+        if (cancelled) return;
+        sub = subscribeToTrip(tripId, token, (event) => dispatch(event));
+      })
+      .catch(() => {
+        // Token fetch failed: leave the badge as-is; the roadbook screen still
+        // re-hydrates from /detail when the rider opens it.
+      });
+
+    return () => {
+      cancelled = true;
+      sub?.close();
+    };
+  }, [tripId, nonce]);
+
+  return state;
+}

--- a/mobile/src/i18n/resources/en.ts
+++ b/mobile/src/i18n/resources/en.ts
@@ -47,8 +47,30 @@ export const en: typeof fr = {
   },
   create: {
     title: 'Create a trip',
-    description:
-      'Paste a Komoot, Strava or RideWithGPS link to generate your roadbook. Coming soon.',
+    subtitle:
+      'Paste a Komoot, Strava or RideWithGPS link to generate your roadbook.',
+    linkLabel: 'Route link',
+    linkPlaceholder: 'https://www.komoot.com/tour/…',
+    supportedHint: 'Komoot (tour / collection), Strava and RideWithGPS.',
+    submit: 'Create trip',
+    submitting: 'Creating…',
+    createdTitle: 'Trip created',
+    launchAnalysis: 'Launch analysis',
+    relaunchAnalysis: 'Re-run analysis',
+    progress: 'Step {{completed}} / {{total}}',
+    analysisDone: 'Analysis complete.',
+    analysisFailed: 'Analysis failed. Try again.',
+    openRoadbook: 'Open roadbook',
+    newTrip: 'New trip',
+    createFailedTitle: 'Creation failed',
+    analysisFailedTitle: 'Analysis failed',
+    errors: {
+      invalidUrl: 'Link not recognized or rejected.',
+      offline: 'You are offline.',
+      conflict: 'Conflict: try again.',
+      network: 'Network error. Check your connection.',
+      generic: 'Something went wrong.',
+    },
   },
   account: {
     title: 'Account',

--- a/mobile/src/i18n/resources/fr.ts
+++ b/mobile/src/i18n/resources/fr.ts
@@ -45,8 +45,30 @@ export const fr = {
   },
   create: {
     title: 'Créer un voyage',
-    description:
-      'Collez un lien Komoot, Strava ou RideWithGPS pour générer votre roadbook. Bientôt disponible.',
+    subtitle:
+      'Collez un lien Komoot, Strava ou RideWithGPS pour générer votre roadbook.',
+    linkLabel: 'Lien du parcours',
+    linkPlaceholder: 'https://www.komoot.com/tour/…',
+    supportedHint: 'Komoot (tour / collection), Strava et RideWithGPS.',
+    submit: 'Créer le voyage',
+    submitting: 'Création…',
+    createdTitle: 'Voyage créé',
+    launchAnalysis: "Lancer l'analyse",
+    relaunchAnalysis: "Relancer l'analyse",
+    progress: 'Étape {{completed}} / {{total}}',
+    analysisDone: 'Analyse terminée.',
+    analysisFailed: "L'analyse a échoué. Réessayez.",
+    openRoadbook: 'Ouvrir le roadbook',
+    newTrip: 'Nouveau voyage',
+    createFailedTitle: 'Création impossible',
+    analysisFailedTitle: 'Analyse impossible',
+    errors: {
+      invalidUrl: 'Lien non reconnu ou refusé.',
+      offline: 'Vous êtes hors ligne.',
+      conflict: 'Conflit : réessayez.',
+      network: 'Erreur réseau. Vérifiez votre connexion.',
+      generic: 'Une erreur est survenue.',
+    },
   },
   account: {
     title: 'Compte',

--- a/mobile/src/store/create-trip.test.ts
+++ b/mobile/src/store/create-trip.test.ts
@@ -1,0 +1,98 @@
+/// <reference types="jest" />
+import {
+  isSupportedSourceUrl,
+  runCreateTrip,
+  SUPPORTED_SOURCE_PATTERNS,
+} from './create-trip';
+import { useOfflineStore } from './offline-store';
+
+jest.mock('../api/trips', () => ({ createTrip: jest.fn() }));
+import { createTrip } from '../api/trips';
+const mockCreate = createTrip as jest.MockedFunction<typeof createTrip>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useOfflineStore.setState({ isOnline: true });
+});
+
+describe('isSupportedSourceUrl (mirrors RouteFetcherRegistry)', () => {
+  const supported = [
+    'https://www.komoot.com/tour/123',
+    'https://www.komoot.com/fr-fr/tour/123',
+    'https://www.komoot.com/collection/45',
+    'https://www.komoot.com/de-de/collection/45',
+    'https://www.strava.com/routes/999',
+    'https://ridewithgps.com/routes/7',
+  ];
+  const unsupported = [
+    '',
+    '   ',
+    'not a url',
+    'http://www.komoot.com/tour/123', // http, not https
+    'https://www.komoot.com/tour/abc', // non-numeric id
+    'https://komoot.com/tour/123', // missing www
+    'https://www.strava.com/activities/999', // wrong path
+    'https://example.com/tour/123',
+    'https://ridewithgps.com/trips/7', // wrong path
+  ];
+
+  it.each(supported)('accepts %s', (url) => {
+    expect(isSupportedSourceUrl(url)).toBe(true);
+  });
+
+  it.each(unsupported)('rejects %s', (url) => {
+    expect(isSupportedSourceUrl(url)).toBe(false);
+  });
+
+  it('trims surrounding whitespace before matching', () => {
+    expect(isSupportedSourceUrl('  https://www.strava.com/routes/1  ')).toBe(true);
+  });
+
+  it('exposes four patterns (komoot tour/collection, strava, rwgps)', () => {
+    expect(SUPPORTED_SOURCE_PATTERNS).toHaveLength(4);
+  });
+});
+
+describe('runCreateTrip', () => {
+  it('returns the new id on success and trims the URL', async () => {
+    mockCreate.mockResolvedValue({ id: 'trip-1', status: 202 });
+    const onFailure = jest.fn();
+
+    const id = await runCreateTrip('  https://www.strava.com/routes/1  ', onFailure);
+
+    expect(id).toBe('trip-1');
+    expect(mockCreate).toHaveBeenCalledWith('https://www.strava.com/routes/1');
+    expect(onFailure).not.toHaveBeenCalled();
+  });
+
+  it('reports "offline" and never calls the API when offline', async () => {
+    useOfflineStore.setState({ isOnline: false });
+    const onFailure = jest.fn();
+
+    const id = await runCreateTrip('https://www.strava.com/routes/1', onFailure);
+
+    expect(id).toBeNull();
+    expect(mockCreate).not.toHaveBeenCalled();
+    expect(onFailure).toHaveBeenCalledWith('offline');
+  });
+
+  it('normalizes a 422 rejection to "validation"', async () => {
+    mockCreate.mockResolvedValue({ id: null, status: 422 });
+    const onFailure = jest.fn();
+
+    const id = await runCreateTrip('https://www.strava.com/routes/1', onFailure);
+
+    expect(id).toBeNull();
+    expect(onFailure).toHaveBeenCalledWith('validation');
+  });
+
+  it('reports "network" when the request throws', async () => {
+    mockCreate.mockRejectedValue(new Error('boom'));
+    const onFailure = jest.fn();
+
+    const id = await runCreateTrip('https://www.strava.com/routes/1', onFailure);
+
+    expect(id).toBeNull();
+    expect(onFailure).toHaveBeenCalledWith('network');
+  });
+});

--- a/mobile/src/store/create-trip.ts
+++ b/mobile/src/store/create-trip.ts
@@ -1,0 +1,51 @@
+import { createTrip } from '../api/trips';
+import { normalizeStatus, type MutationFailure } from './gating';
+import { useOfflineStore } from './offline-store';
+
+/**
+ * Supported source URL patterns, mirroring the backend `RouteFetcherRegistry`
+ * strategies (CLAUDE.md, Security Constraints). The backend stays the source of
+ * truth; these give fast client-side feedback before the POST is sent. Kept in
+ * lockstep with the web `SUPPORTED_SOURCE_PATTERNS`.
+ */
+export const SUPPORTED_SOURCE_PATTERNS: readonly RegExp[] = [
+  /^https:\/\/www\.komoot\.com\/([a-z]{2}-[a-z]{2}\/)?tour\/\d+/,
+  /^https:\/\/www\.komoot\.com\/([a-z]{2}-[a-z]{2}\/)?collection\/\d+/,
+  /^https:\/\/www\.strava\.com\/routes\/\d+/,
+  /^https:\/\/ridewithgps\.com\/routes\/\d+/,
+] as const;
+
+/** Whether a URL matches one of the supported route source patterns. */
+export function isSupportedSourceUrl(value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+  return SUPPORTED_SOURCE_PATTERNS.some((pattern) => pattern.test(trimmed));
+}
+
+/**
+ * Create a trip from a pasted / shared link. Blocked while offline (like every
+ * other mutation, see gating.ts); a backend rejection (invalid or unsupported
+ * URL) is normalized to a {@link MutationFailure}. Returns the new trip id, or
+ * null with the failure reported. Client-side URL validation is the screen's
+ * job — this runner still forwards whatever the backend answers.
+ */
+export async function runCreateTrip(
+  sourceUrl: string,
+  onFailure: (reason: MutationFailure) => void,
+): Promise<string | null> {
+  if (!useOfflineStore.getState().isOnline) {
+    onFailure('offline');
+    return null;
+  }
+  try {
+    const { id, status } = await createTrip(sourceUrl.trim());
+    if (!id) {
+      onFailure(normalizeStatus(status));
+      return null;
+    }
+    return id;
+  } catch {
+    onFailure('network');
+    return null;
+  }
+}


### PR DESCRIPTION
Closes #1042

## Résumé
Écran Créer complet (mobile) : coller un lien (Komoot tour/collection, Strava, RideWithGPS) avec validation client-side contre les regexes de sources supportées, `POST /trips`, suivi SSE de l'analyse, lancer/relancer (`POST /trips/{id}/analyze`), et ouverture depuis lien de partage (`?link=` deep link `biketripplanner://`).

## Détails
- `create.tsx` refait en écran extensible (structure prévue pour l'ajout de l'import GPX par #1043, stacké).
- `create-trip.ts` : `SUPPORTED_SOURCE_PATTERNS` + `isSupportedSourceUrl` (miroir `RouteFetcherRegistry`), `runCreateTrip` (gate offline + normalisation d'erreur).
- `use-analysis-follow.ts` : suivi SSE + reducer pur testable.
- Réutilise `analyzeTrip`/`runAnalyze` (#1031), pas de doublon.

## Auto-critique
- Analyse non auto-déclenchée après création (aligné web : `analyze` = ré-enrichissement manuel Phase 2 ; Phase 1 démarre au POST).
- Deep link géré via param `?link=` sans intent-filter App Link dédié (`app.config.ts` non modifié — hors périmètre).
- « Testé device » non couvert par la CI (Expo hors Docker, gate = tsc + jest) — à valider par l'utilisateur.

## Vérification
`tsc --noEmit` clean ; jest : 248 tests verts. Nouveaux tests prouvés faillibles (mutation `isSupportedSourceUrl` / `reduceAnalysisEvent`).

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 critical, 0 warning, 1 suggestion. No security, correctness or architecture issues found; schema/gate usage checked against `core/schema.d.ts` and `mutations.ts` and is consistent. One PR-title nonconformance noted below.

**PR title check:** the title's description (`création par lien + ouverture depuis partage + lancer l'analyse (#1042)`) is a noun-phrase list, not imperative mood — the squashed commit message would fail Conventional Commits. Compare the commit headline on this branch, which is correctly imperative in English (`create trip by link + open from share + launch analysis…`).

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [ ] Documentation is up to date — `TRACKING.md` row for #1042 (Sprint 56) still shows `⏳ À faire` / no PR link
- [x] Dependent tickets accounted for

**Inline comments:** Posted 1 inline comment.

_Commit reviewed: 9b29d655aface0586b79a53463c57f97891574d7_
<!-- claude-review-end -->