### PR TITLE
fix(mobile): sortir les tests d'écran de app/ (expo-router les chargeait comme routes)

### DIFF
--- a/mobile/src/screens/create.test.tsx
+++ b/mobile/src/screens/create.test.tsx
@@ -1,7 +1,7 @@
 /// <reference types="jest" />
 import TestRenderer, { act } from 'react-test-renderer';
 import { createElement } from 'react';
-import i18n from '../../src/i18n';
+import i18n from '../i18n';
 
 // create.tsx pulls in the trip barrel (SseStatusIndicator), which transitively
 // imports the native maplibre module — stub it so jest can load the screen.
@@ -17,13 +17,13 @@ jest.mock('expo-router', () => ({
   useRouter: () => ({ push: jest.fn() }),
 }));
 
-jest.mock('../../src/hooks/use-analysis-follow', () => {
-  const actual = jest.requireActual('../../src/hooks/use-analysis-follow');
+jest.mock('../hooks/use-analysis-follow', () => {
+  const actual = jest.requireActual('../hooks/use-analysis-follow');
   return { ...actual, useAnalysisFollow: () => actual.INITIAL_FOLLOW_STATE };
 });
 
-jest.mock('../../src/store/create-trip', () => {
-  const actual = jest.requireActual('../../src/store/create-trip');
+jest.mock('../store/create-trip', () => {
+  const actual = jest.requireActual('../store/create-trip');
   return {
     ...actual,
     runCreateTrip: jest.fn(),
@@ -31,8 +31,8 @@ jest.mock('../../src/store/create-trip', () => {
     pickGpxFile: jest.fn(),
   };
 });
-import { pickGpxFile, runCreateTrip, runUploadGpx } from '../../src/store/create-trip';
-import Create from './create';
+import { pickGpxFile, runCreateTrip, runUploadGpx } from '../store/create-trip';
+import Create from '../../app/(tabs)/create';
 
 const mockRunCreate = runCreateTrip as jest.MockedFunction<typeof runCreateTrip>;
 const mockRunUpload = runUploadGpx as jest.MockedFunction<typeof runUploadGpx>;

--- a/mobile/src/screens/trips.test.tsx
+++ b/mobile/src/screens/trips.test.tsx
@@ -2,17 +2,17 @@
 import TestRenderer, { act } from 'react-test-renderer';
 import { createElement } from 'react';
 import { Alert } from 'react-native';
-import i18n from '../../src/i18n';
-import type { UseTrips } from '../../src/hooks/use-trips';
+import i18n from '../i18n';
+import type { UseTrips } from '../hooks/use-trips';
 
 jest.mock('expo-router', () => ({ useRouter: () => ({ push: jest.fn() }) }));
 
-jest.mock('../../src/hooks/use-trips', () => {
-  const actual = jest.requireActual('../../src/hooks/use-trips');
+jest.mock('../hooks/use-trips', () => {
+  const actual = jest.requireActual('../hooks/use-trips');
   return { ...actual, useTrips: jest.fn() };
 });
-import { useTrips } from '../../src/hooks/use-trips';
-import Trips from './index';
+import { useTrips } from '../hooks/use-trips';
+import Trips from '../../app/(tabs)/index';
 
 const mockUseTrips = useTrips as jest.MockedFunction<typeof useTrips>;
 


### PR DESCRIPTION
## Contexte
Finding remonté en **test sur device réel** (Galaxy A55, dev build via `expo run:android` + backend en dev exposé via ngrok) après le sprint 56.

## Bug
`mobile/app/(tabs)/create.test.tsx` et `mobile/app/(tabs)/index.test.tsx` (ajoutés par #1043) vivaient **sous `app/`** : expo-router (routing par fichiers) les traitait comme des **routes**. Conséquences au runtime :
- leur `jest.mock(...)` de top-level s'exécutait dans l'app → **red-box `Uncaught Error: Property 'jest' doesn't exist`** au démarrage ;
- warnings `Route "./(tabs)/create.test.tsx" is missing the required default export` et routes fantômes `/create` / `/index` en doublon.

Invisible en CI : `jest` (les exécute normalement) et `tsc` passaient au vert ; seul le rendu device le révélait.

## Fix
Déplacement des deux fichiers vers `mobile/src/screens/` (`create.test.tsx`, `trips.test.tsx`) — hors de `app/`, conforme à la convention du repo (tous les autres tests vivent sous `src/`). Imports relatifs réajustés (`../../src/*` → `../*`, import de l'écran → `../../app/(tabs)/*`).

## Vérification
- `tsc --noEmit` : clean.
- `jest` : 42 suites / 366 tests verts (les 2 tests déplacés inclus).
- **Device** : plus de red-box ; écrans Créer / Voyages / Roadbook rendus correctement ; header à 3 actions (export/config/partage) OK ; panneau config OK ; création de lien public (round-trip API via ngrok) OK.

## Auto-critique
- Pas de garde automatique contre une future recolocation de test sous `app/`. Possible suivi : un lint/CI check (`find mobile/app -name '*.test.*'` non vide → échec) ou activer l'ignore natif d'expo-router. Hors périmètre de ce hotfix.

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 critical, 0 warning, 0 nitpick findings. Clean mechanical fix — two test files relocated from `mobile/app/(tabs)/` to `mobile/src/screens/` with correctly adjusted relative imports; verified no stale references to the old paths elsewhere in the repo.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases (no new behavior; existing tests relocated and re-verified: `tsc`, `jest`, device)
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

**Commit reviewed:** `d29f030e2bd552a9a28a9c0a91c60b648c0e0d2d`
<!-- claude-review-end -->