### PR TITLE
fix(mobile): findings de test device — encodage, statut i18n, picker GPX, UX partage

### DIFF
--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -160,7 +160,7 @@ export default function Trips() {
               subtitle={t('trips.meta', {
                 stages: item.stageCount ?? 0,
                 distance: Math.round(item.totalDistance ?? 0),
-                status: item.status ?? 'draft',
+                status: t(`trips.status.${item.status ?? 'draft'}`),
               })}
               right={
                 <View style={{ flexDirection: 'row', gap: theme.spacing.xs }}>

--- a/mobile/src/api/client.test.ts
+++ b/mobile/src/api/client.test.ts
@@ -23,6 +23,18 @@ beforeEach(() => {
   globalThis.fetch = jest.fn();
 });
 
+describe('authMiddleware request headers', () => {
+  // Regression (#1090 device): RN advertises `zstd, br, gzip`; the server then
+  // picks zstd/br which okhttp does not transparently decode, mojibaking accented
+  // titles. Pinning `identity` keeps bodies decodable — must not be refactored away.
+  it('pins Accept-Encoding to identity on every request', async () => {
+    mockGetJwt.mockReturnValue('jwt');
+    const request = new Request('https://api.test/trips');
+    await onRequest(request);
+    expect(request.headers.get('Accept-Encoding')).toBe('identity');
+  });
+});
+
 describe('authMiddleware 401 retry (#1032)', () => {
   it('refreshes the token and replays the request with the new JWT on a 401', async () => {
     mockGetJwt.mockReturnValueOnce('stale-jwt').mockReturnValue('fresh-jwt');

--- a/mobile/src/api/client.test.ts
+++ b/mobile/src/api/client.test.ts
@@ -26,12 +26,13 @@ beforeEach(() => {
 describe('authMiddleware request headers', () => {
   // Regression (#1090 device): RN advertises `zstd, br, gzip`; the server then
   // picks zstd/br which okhttp does not transparently decode, mojibaking accented
-  // titles. Pinning `identity` keeps bodies decodable — must not be refactored away.
-  it('pins Accept-Encoding to identity on every request', async () => {
+  // titles. Pinning `gzip` (which okhttp does decode) keeps bodies decodable AND
+  // compressed — must not be refactored away.
+  it('pins Accept-Encoding to gzip on every request', async () => {
     mockGetJwt.mockReturnValue('jwt');
     const request = new Request('https://api.test/trips');
     await onRequest(request);
-    expect(request.headers.get('Accept-Encoding')).toBe('identity');
+    expect(request.headers.get('Accept-Encoding')).toBe('gzip');
   });
 });
 

--- a/mobile/src/api/client.test.ts
+++ b/mobile/src/api/client.test.ts
@@ -26,13 +26,12 @@ beforeEach(() => {
 describe('authMiddleware request headers', () => {
   // Regression (#1090 device): RN advertises `zstd, br, gzip`; the server then
   // picks zstd/br which okhttp does not transparently decode, mojibaking accented
-  // titles. Pinning `gzip` (which okhttp does decode) keeps bodies decodable AND
-  // compressed — must not be refactored away.
-  it('pins Accept-Encoding to gzip on every request', async () => {
+  // titles. Pinning `identity` keeps bodies decodable — must not be refactored away.
+  it('pins Accept-Encoding to identity on every request', async () => {
     mockGetJwt.mockReturnValue('jwt');
     const request = new Request('https://api.test/trips');
     await onRequest(request);
-    expect(request.headers.get('Accept-Encoding')).toBe('gzip');
+    expect(request.headers.get('Accept-Encoding')).toBe('identity');
   });
 });
 

--- a/mobile/src/api/client.ts
+++ b/mobile/src/api/client.ts
@@ -17,12 +17,13 @@ export const authMiddleware: Middleware = {
     if (jwt) {
       request.headers.set('Authorization', `Bearer ${jwt}`);
     }
-    // Force an uncompressed body. RN's networking advertises `zstd, br, gzip`, and
-    // the server (Caddy) then picks zstd/br — which okhttp does not transparently
-    // decode, leaving the body decoded as Latin-1 (UTF-8 `é` C3A9 -> "Ã©"). Pinning
-    // `identity` keeps accented titles intact; API payloads are small so the extra
-    // bytes are negligible.
-    request.headers.set('Accept-Encoding', 'identity');
+    // Pin `gzip`. Left to itself RN advertises `zstd, br, gzip`; the server (Caddy)
+    // then picks zstd/br, which okhttp does not decode, leaving the body read as
+    // Latin-1 (UTF-8 `é` C3A9 -> "Ã©"). Pinning a single encoding okhttp *does*
+    // decode fixes the mojibake while keeping responses compressed — `identity`
+    // also fixes it but ships TripDetail's full per-stage geometry uncompressed
+    // (~5x larger over cellular). gzip is decoded transparently on device.
+    request.headers.set('Accept-Encoding', 'gzip');
     pendingRetries.set(request, request.clone());
     return request;
   },

--- a/mobile/src/api/client.ts
+++ b/mobile/src/api/client.ts
@@ -17,6 +17,12 @@ export const authMiddleware: Middleware = {
     if (jwt) {
       request.headers.set('Authorization', `Bearer ${jwt}`);
     }
+    // Force an uncompressed body. RN's networking advertises `zstd, br, gzip`, and
+    // the server (Caddy) then picks zstd/br — which okhttp does not transparently
+    // decode, leaving the body decoded as Latin-1 (UTF-8 `é` C3A9 -> "Ã©"). Pinning
+    // `identity` keeps accented titles intact; API payloads are small so the extra
+    // bytes are negligible.
+    request.headers.set('Accept-Encoding', 'identity');
     pendingRetries.set(request, request.clone());
     return request;
   },

--- a/mobile/src/api/client.ts
+++ b/mobile/src/api/client.ts
@@ -17,13 +17,12 @@ export const authMiddleware: Middleware = {
     if (jwt) {
       request.headers.set('Authorization', `Bearer ${jwt}`);
     }
-    // Pin `gzip`. Left to itself RN advertises `zstd, br, gzip`; the server (Caddy)
-    // then picks zstd/br, which okhttp does not decode, leaving the body read as
-    // Latin-1 (UTF-8 `é` C3A9 -> "Ã©"). Pinning a single encoding okhttp *does*
-    // decode fixes the mojibake while keeping responses compressed — `identity`
-    // also fixes it but ships TripDetail's full per-stage geometry uncompressed
-    // (~5x larger over cellular). gzip is decoded transparently on device.
-    request.headers.set('Accept-Encoding', 'gzip');
+    // Force an uncompressed body. RN's networking advertises `zstd, br, gzip`, and
+    // the server (Caddy) then picks zstd/br — which okhttp does not transparently
+    // decode, leaving the body decoded as Latin-1 (UTF-8 `é` C3A9 -> "Ã©"). Pinning
+    // `identity` keeps accented titles intact; API payloads are small so the extra
+    // bytes are negligible.
+    request.headers.set('Accept-Encoding', 'identity');
     pendingRetries.set(request, request.clone());
     return request;
   },

--- a/mobile/src/components/trip/ShareSheet.test.tsx
+++ b/mobile/src/components/trip/ShareSheet.test.tsx
@@ -166,14 +166,24 @@ describe('ShareSheet (#1048)', () => {
     expect(button(tree, 'Texte copié')).toBeTruthy();
   });
 
-  it('shares the infographic PNG via the capture helper', async () => {
+  it('captures + shares the infographic once mounted, without touching the link buttons', async () => {
     mockGet.mockResolvedValue(null);
 
     const tree = await render(
       <ShareSheet visible onClose={jest.fn()} tripId="t1" />,
     );
+    // Idle: the expensive off-screen infographic is not mounted.
+    expect(tree.root.findAllByType(ShareInfographic)).toHaveLength(0);
+
     await press(button(tree, "Partager l'image"));
+    // Pressing mounts it; capture fires after the layout timeout.
+    expect(tree.root.findAllByType(ShareInfographic)).toHaveLength(1);
+    await act(async () => {
+      jest.advanceTimersByTime(50);
+    });
     expect(mockCapture).toHaveBeenCalledTimes(1);
+    // Once done it unmounts again (no idle SSE-update cost).
+    expect(tree.root.findAllByType(ShareInfographic)).toHaveLength(0);
   });
 
   it('fetches the existing share only once across re-renders (hasFetched guard)', async () => {
@@ -191,20 +201,14 @@ describe('ShareSheet (#1048)', () => {
     expect(mockGet).toHaveBeenCalledTimes(1);
   });
 
-  it('does not mount the off-screen infographic until opened once (hasOpened guard)', async () => {
+  it('keeps the off-screen infographic unmounted while the sheet is just open (idle)', async () => {
     mockGet.mockResolvedValue(null);
 
-    // Never opened: the expensive off-screen ShareInfographic stays unmounted,
-    // so its useMemo pipeline never runs on SSE stage updates.
+    // Opening the sheet must NOT mount the expensive infographic — it only mounts
+    // during a capture — so its useMemo pipeline never runs on idle SSE updates.
     const tree = await render(
-      <ShareSheet visible={false} onClose={jest.fn()} tripId="t1" />,
+      <ShareSheet visible onClose={jest.fn()} tripId="t1" />,
     );
     expect(tree.root.findAllByType(ShareInfographic)).toHaveLength(0);
-
-    // Opening mounts it (so handleShareImage can capture it).
-    await act(async () => {
-      tree.update(<ShareSheet visible onClose={jest.fn()} tripId="t1" />);
-    });
-    expect(tree.root.findAllByType(ShareInfographic)).toHaveLength(1);
   });
 });

--- a/mobile/src/components/trip/ShareSheet.test.tsx
+++ b/mobile/src/components/trip/ShareSheet.test.tsx
@@ -176,10 +176,13 @@ describe('ShareSheet (#1048)', () => {
     expect(tree.root.findAllByType(ShareInfographic)).toHaveLength(0);
 
     await press(button(tree, "Partager l'image"));
-    // Pressing mounts it; capture fires after the layout timeout.
-    expect(tree.root.findAllByType(ShareInfographic)).toHaveLength(1);
+    // Pressing mounts it; capture fires from the off-screen view's onLayout.
+    const infographic = tree.root.findByType(ShareInfographic);
+    expect(infographic).toBeTruthy();
     await act(async () => {
-      jest.advanceTimersByTime(50);
+      infographic.parent!.props.onLayout({
+        nativeEvent: { layout: { x: 0, y: 0, width: 1, height: 1 } },
+      });
     });
     expect(mockCapture).toHaveBeenCalledTimes(1);
     // Once done it unmounts again (no idle SSE-update cost).

--- a/mobile/src/components/trip/ShareSheet.tsx
+++ b/mobile/src/components/trip/ShareSheet.tsx
@@ -36,21 +36,19 @@ export function ShareSheet({ visible, onClose, tripId }: ShareSheetProps) {
 
   const [shareUrl, setShareUrl] = useState<string | null>(null);
   const [hasFetched, setHasFetched] = useState(false);
-  // The off-screen infographic runs an expensive useMemo pipeline (projectRoute
-  // flattens every stage's decimated geometry, budget/difficulty calcs). RN's
-  // Modal keeps children mounted when hidden, so gate the render on "opened at
-  // least once" — mirrors the web ShareModal's `if (!open) return` — to avoid
-  // paying that cost on every SSE stage update for riders who never open Share.
-  const [hasOpened, setHasOpened] = useState(visible);
   const [busy, setBusy] = useState(false);
+  // Image capture has its own busy flag so its spinner doesn't also light up the
+  // link buttons (which read `busy`). The off-screen infographic runs an
+  // expensive useMemo pipeline (projectRoute flattens every stage's decimated
+  // geometry, budget/difficulty calcs); RN's Modal keeps children mounted when
+  // hidden, so instead of paying that cost on open / every SSE update we mount it
+  // only for the duration of a capture (`capturing`), keeping the sheet snappy.
+  const [imageBusy, setImageBusy] = useState(false);
+  const [capturing, setCapturing] = useState(false);
   const [linkCopied, setLinkCopied] = useState(false);
   const [textCopied, setTextCopied] = useState(false);
 
   const infographicRef = useRef<RNView>(null);
-
-  useEffect(() => {
-    if (visible) setHasOpened(true);
-  }, [visible]);
 
   // Fetch the active share once, the first time the sheet opens.
   useEffect(() => {
@@ -127,14 +125,32 @@ export function ShareSheet({ visible, onClose, tripId }: ShareSheetProps) {
     await Share.share({ message: buildText() });
   }, [buildText]);
 
-  const handleShareImage = useCallback(async () => {
-    setBusy(true);
-    try {
-      await captureAndShareInfographic(infographicRef, title);
-    } finally {
-      setBusy(false);
-    }
-  }, [title]);
+  // Mount the off-screen infographic, then capture it once it has laid out.
+  const handleShareImage = useCallback(() => {
+    setImageBusy(true);
+    setCapturing(true);
+  }, []);
+
+  useEffect(() => {
+    if (!capturing) return;
+    let cancelled = false;
+    // Let the just-mounted off-screen infographic lay out before captureRef reads
+    // it (a frame is enough; a small timeout is a safe cross-device margin).
+    const handle = setTimeout(async () => {
+      try {
+        await captureAndShareInfographic(infographicRef, title);
+      } finally {
+        if (!cancelled) {
+          setCapturing(false);
+          setImageBusy(false);
+        }
+      }
+    }, 50);
+    return () => {
+      cancelled = true;
+      clearTimeout(handle);
+    };
+  }, [capturing, title]);
 
   return (
     <Sheet visible={visible} onClose={onClose} title={t('share.title')}>
@@ -189,8 +205,8 @@ export function ShareSheet({ visible, onClose, tripId }: ShareSheetProps) {
           label={t('share.shareImage')}
           variant="secondary"
           size="sm"
-          loading={busy}
-          onPress={() => void handleShareImage()}
+          loading={imageBusy}
+          onPress={handleShareImage}
         />
 
         {/* Formatted text */}
@@ -213,9 +229,10 @@ export function ShareSheet({ visible, onClose, tripId }: ShareSheetProps) {
         </View>
       </ScrollView>
 
-      {/* Off-screen infographic captured to PNG by handleShareImage. Only
-          mounted after Share has been opened once (see hasOpened). */}
-      {hasOpened && (
+      {/* Off-screen infographic captured to PNG by handleShareImage. Mounted only
+          while a capture is in progress (see capturing) so the sheet stays snappy
+          and the expensive render never runs on idle SSE updates. */}
+      {capturing && (
         <View style={styles.offscreen} pointerEvents="none">
           <ShareInfographic
             ref={infographicRef}

--- a/mobile/src/components/trip/ShareSheet.tsx
+++ b/mobile/src/components/trip/ShareSheet.tsx
@@ -49,6 +49,9 @@ export function ShareSheet({ visible, onClose, tripId }: ShareSheetProps) {
   const [textCopied, setTextCopied] = useState(false);
 
   const infographicRef = useRef<RNView>(null);
+  // Guards the one-shot capture: set on press, consumed by the off-screen view's
+  // onLayout so a screenshot fires exactly once, only after real layout.
+  const captureArmedRef = useRef(false);
 
   // Fetch the active share once, the first time the sheet opens.
   useEffect(() => {
@@ -125,32 +128,26 @@ export function ShareSheet({ visible, onClose, tripId }: ShareSheetProps) {
     await Share.share({ message: buildText() });
   }, [buildText]);
 
-  // Mount the off-screen infographic, then capture it once it has laid out.
+  // Mount the off-screen infographic; the actual capture fires from its onLayout
+  // (see runCapture) so we never race layout on a slow device / heavier trip.
   const handleShareImage = useCallback(() => {
     setImageBusy(true);
+    captureArmedRef.current = true;
     setCapturing(true);
   }, []);
 
-  useEffect(() => {
-    if (!capturing) return;
-    let cancelled = false;
-    // Let the just-mounted off-screen infographic lay out before captureRef reads
-    // it (a frame is enough; a small timeout is a safe cross-device margin).
-    const handle = setTimeout(async () => {
-      try {
-        await captureAndShareInfographic(infographicRef, title);
-      } finally {
-        if (!cancelled) {
-          setCapturing(false);
-          setImageBusy(false);
-        }
-      }
-    }, 50);
-    return () => {
-      cancelled = true;
-      clearTimeout(handle);
-    };
-  }, [capturing, title]);
+  // Triggered by the off-screen infographic's onLayout — once it has actually
+  // laid out — not a timer. Guarded to fire exactly once per press.
+  const runCapture = useCallback(async () => {
+    if (!captureArmedRef.current) return;
+    captureArmedRef.current = false;
+    try {
+      await captureAndShareInfographic(infographicRef, title);
+    } finally {
+      setCapturing(false);
+      setImageBusy(false);
+    }
+  }, [title]);
 
   return (
     <Sheet visible={visible} onClose={onClose} title={t('share.title')}>
@@ -233,7 +230,11 @@ export function ShareSheet({ visible, onClose, tripId }: ShareSheetProps) {
           while a capture is in progress (see capturing) so the sheet stays snappy
           and the expensive render never runs on idle SSE updates. */}
       {capturing && (
-        <View style={styles.offscreen} pointerEvents="none">
+        <View
+          style={styles.offscreen}
+          pointerEvents="none"
+          onLayout={() => void runCapture()}
+        >
           <ShareInfographic
             ref={infographicRef}
             title={title}

--- a/mobile/src/i18n/resources/en.ts
+++ b/mobile/src/i18n/resources/en.ts
@@ -47,6 +47,11 @@ export const en: typeof fr = {
     duplicateA11y: 'Duplicate {{title}}',
     duplicateFailedTitle: 'Duplication failed',
     duplicateFailed: 'Duplication failed. Try again.',
+    status: {
+      draft: 'draft',
+      analyzing: 'analyzing',
+      analyzed: 'analyzed',
+    },
   },
   create: {
     title: 'Create a trip',

--- a/mobile/src/i18n/resources/fr.ts
+++ b/mobile/src/i18n/resources/fr.ts
@@ -45,6 +45,11 @@ export const fr = {
     duplicateA11y: 'Dupliquer {{title}}',
     duplicateFailedTitle: 'Duplication impossible',
     duplicateFailed: 'La duplication a échoué. Réessayez.',
+    status: {
+      draft: 'brouillon',
+      analyzing: 'analyse en cours',
+      analyzed: 'analysé',
+    },
   },
   create: {
     title: 'Créer un voyage',

--- a/mobile/src/store/create-trip.test.ts
+++ b/mobile/src/store/create-trip.test.ts
@@ -122,6 +122,16 @@ describe('pickGpxFile (#1043)', () => {
     });
   });
 
+  it('restricts the picker to GPX/XML mime types (not */*)', async () => {
+    mockPick.mockResolvedValue({ canceled: true, assets: null } as never);
+    await pickGpxFile();
+    expect(mockPick).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: ['application/gpx+xml', 'application/xml', 'text/xml', 'application/octet-stream'],
+      }),
+    );
+  });
+
   it('returns null when the user cancels the picker', async () => {
     mockPick.mockResolvedValue({ canceled: true, assets: null } as never);
     expect(await pickGpxFile()).toBeNull();

--- a/mobile/src/store/create-trip.ts
+++ b/mobile/src/store/create-trip.ts
@@ -52,17 +52,24 @@ export async function runCreateTrip(
 }
 
 /**
- * Open the system file picker for a single GPX file. Returns the picked asset,
- * or null when the user cancels (mobile-adapt of the web drag&drop). The GPX
- * mime type is not reliably reported across platforms, so we accept any file and
- * let the backend validate the extension/content. A picker rejection (denied
- * permission, or a second pick launched while one is in flight — rejected on
- * some platforms) is treated as a cancel (null), never a thrown rejection.
+ * Open the system file picker restricted to GPX files. Returns the picked asset,
+ * or null when the user cancels (mobile-adapt of the web drag&drop). GPX has no
+ * universal mime type across platforms (Android often reports a `.gpx` as
+ * `application/octet-stream`), so we pass the known GPX/XML types plus
+ * octet-stream to narrow the picker without hiding real `.gpx` files; the backend
+ * still validates extension/content. A picker rejection (denied permission, or a
+ * second pick launched while one is in flight — rejected on some platforms) is
+ * treated as a cancel (null), never a thrown rejection.
  */
 export async function pickGpxFile(): Promise<GpxFile | null> {
   try {
     const result = await DocumentPicker.getDocumentAsync({
-      type: '*/*',
+      type: [
+        'application/gpx+xml',
+        'application/xml',
+        'text/xml',
+        'application/octet-stream',
+      ],
       copyToCacheDirectory: true,
       multiple: false,
     });


### PR DESCRIPTION
> **PR stackée** sur #1089 (base `fix/mobile-route-test-colocation`). À merger après #1089.

Findings remontés lors du **test sur device réel** (Galaxy A55, dev build + backend ngrok) et vérifiés sur le device.

## Corrections
1. **Encodage / mojibake** (`api/client.ts`) — les titres accentués s'affichaient « Entre SensA©e et Escaut » au premier chargement de la liste. Cause : RN annonce `Accept-Encoding: zstd, br, gzip`, Caddy répond en **zstd**, qu'okhttp ne décode pas de façon transparente → corps décodé en Latin-1 (`é` C3A9 → « Ã© »). Fix : forcer `Accept-Encoding: identity` sur le client mobile. **Vérifié device** : titre « Sensée » correct, réponse `Content-Encoding: none`.
2. **Statut non traduit** (`(tabs)/index.tsx` + i18n) — « analyzed » affiché brut dans le méta de la liste. Ajout de `trips.status.{draft,analyzing,analyzed}` et rendu via `t()`. **Vérifié device** : « analysé ».
3. **Picker GPX** (`store/create-trip.ts`) — le file picker acceptait `*/*`. Restreint aux MIME `application/gpx+xml` / `application/xml` / `text/xml` / `application/octet-stream` (GPX n'a pas de MIME universel sur Android → octet-stream conservé pour ne pas masquer les `.gpx`).
4. **UX partage** (`ShareSheet.tsx`) :
   - Le loader de « Partager l'image » s'affichait aussi sur « Créer un lien » (état `busy` partagé) → état `imageBusy` dédié.
   - Le panneau mettait ~3 s à s'ouvrir : l'infographie hors-écran se montait à l'ouverture. Elle n'est désormais montée **que le temps de la capture** (`capturing`) → ouverture instantanée, plus aucun coût de rendu sur les updates SSE au repos.

## Vérification
- `tsc --noEmit` clean ; `jest` 42 suites / 366 tests verts (tests ShareSheet mis à jour).
- **Device** : mojibake et statut confirmés corrigés à l'écran ; partage + création de lien fonctionnels.

## Hors périmètre (suivi)
- **Lenteur ~20 s à l'ouverture d'un voyage** : l'API est rapide (`/detail` ~350 ms) — la lenteur est côté client et **en grande partie un artefact du dev build** (Metro, non minifié). À re-mesurer sur un build release avant d'en faire un finding perf.
- **Lien « http://localhost:3000... »** au lieu de l'URL publique : artefact d'environnement de test (`EXPO_PUBLIC_WEB_URL` non défini → fallback dev localhost:3000), pas un bug applicatif.
- **Design des popups / scroll du sheet partage / conformité maquettes** : nécessite les maquettes (voir message).

<!-- claude-review-start -->
## Claude Review

**Findings:** 0 blocking, 0 non-blocking. The prior blocking finding (final commit swapped the device-verified `Accept-Encoding: identity` fix for `gzip`, which would likely break body decoding app-wide on Android) has been resolved — the latest commit (`4a748d9f`) reverts that change back to `identity`, matching the original device-verified fix, and a regression test (`client.test.ts`) now locks the header value in. The GPX picker MIME restriction and ShareSheet capture-on-`onLayout` changes are correctly targeted, covered by tests, and consistent with the architecture (no ORM/backend coupling issues, Zustand/local-first patterns respected on the store side).

**Resolved threads:** Resolved 1 previously open bot thread (the `gzip` vs `identity` regression on `mobile/src/api/client.ts`), confirmed fixed by the revert commit. 4 previous bot reviews minimized/dismissed as part of this pass.

**PR title:** `fix(mobile): findings de test device — encodage, statut i18n, picker GPX, UX partage` — reads as a noun-phrase summary rather than imperative mood (Git Conventions in CLAUDE.md). Non-blocking.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

Commit reviewed: `4a748d9f28f0271072e0d997ff90485e3422dc0d`
<!-- claude-review-end -->