### PR TITLE
docs(tracking): tickets de conformité maquette (sprints 57-58)

### DIFF
--- a/TRACKING.md
+++ b/TRACKING.md
@@ -1921,6 +1921,8 @@ Ordre de merge recommandé pour les 4 restantes : **#1081 (#1044) → #1085 (#10
 | 1 | [#1049](https://github.com/vincentchalamon/bike-trip-planner/issues/1049) | [epic] écran Compte (réglages, email change, RGPD, early-access, FAQ/légal, onboarding) | L | ⏳ À faire | — | Sprint 54 |
 | 2 | [#1050](https://github.com/vincentchalamon/bike-trip-planner/issues/1050) | [epic] notifications locales (gestion + catégories) | M | ⏳ À faire | — | #1049 |
 | 3 | [#1051](https://github.com/vincentchalamon/bike-trip-planner/issues/1051) | [epic] push serveur FCM (device-token + sender + secrets compose + réception) | L | ⏳ À faire | — | #1050 |
+| 4 | [#1092](https://github.com/vincentchalamon/bike-trip-planner/issues/1092) | design(mobile): écran Compte conforme à la maquette 10-account (+ thème) | S | ⏳ À faire | — | #1049 |
+| 5 | [#1093](https://github.com/vincentchalamon/bike-trip-planner/issues/1093) | design(mobile): écran Notifications conforme à la maquette 11-notifications (+ thème) | S | ⏳ À faire | — | #1050 |
 
 </details>
 
@@ -1935,6 +1937,7 @@ Ordre de merge recommandé pour les 4 restantes : **#1081 (#1044) → #1085 (#10
 |-------|----|-------|--------|--------|-----|-----------|
 | 1 | [#1052](https://github.com/vincentchalamon/bike-trip-planner/issues/1052) | [epic] offline auto-sync (cache voyages à venir/en cours + fraîcheur + dégradation carte) | L | ⏳ À faire | — | Sprint 55 |
 | 2 | [#1053](https://github.com/vincentchalamon/bike-trip-planner/issues/1053) | [epic] in-ride / GPS foreground + nearby-pois | L | ⏳ À faire | — | #1052 |
+| 3 | [#1094](https://github.com/vincentchalamon/bike-trip-planner/issues/1094) | design(mobile): écran In-ride conforme à la maquette 08-in-ride (+ thème) | S | ⏳ À faire | — | #1053 |
 
 </details>
 


### PR DESCRIPTION
## Résumé
Ajoute au TRACKING les tickets de conformité aux maquettes « Mobile — Spike UX » pour les écrans **non encore implémentés** (donc hors du passe de restyle en cours, qui ne couvre que les écrans du sprint 56) :

- **#1092** — écran Compte conforme à `10-account` (Sprint 57, relié à l'épic #1049)
- **#1093** — écran Notifications conforme à `11-notifications` (Sprint 57, relié à #1050)
- **#1094** — écran In-ride conforme à `08-in-ride` (Sprint 58, relié à #1053)

Chacun impose de respecter sa maquette **en appliquant le thème** lors de l'implémentation de l'épic correspondant.

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 critical, 0 warning, 1 minor (title phrasing note). Doc-only change to `TRACKING.md` (2 hunks): adds rows for #1092, #1093 (Sprint 57) and #1094 (Sprint 58). All three referenced issues exist, are open, and titles/links match exactly. Row formatting (columns, status, effort, dependency) is consistent with surrounding table rows.

**PR title check:** minor — description `tickets de conformité maquette (sprints 57-58)` is a noun phrase rather than an imperative verb form per Conventional Commits guidance in CLAUDE.md. Not blocking: matches the precedent set by the prior `docs(tracking)` commit (`3c7eedc`).

**Review checklist:**
- [x] Code respects the project architecture (N/A — docs-only change)
- [x] SOLID principles and Law of Demeter followed (N/A — docs-only change)
- [x] Design patterns used where appropriate (N/A — docs-only change)
- [x] Tests cover new/changed cases (N/A — no code behavior changed)
- [x] Documentation is up to date (this PR *is* the documentation update; content verified against live issues)
- [x] Dependent tickets accounted for (dependency column correctly points to parent epics #1049/#1050/#1053)

**Inline comments:** No inline comments.

_Commit reviewed: 16fdb4aa5f20a6b448f6482b9c12a0450f7e43c4_
<!-- claude-review-end -->