### PR TITLE
docs(adr): ADR-057 chargement progressif + Sprint 56.b

### DIFF
--- a/TRACKING.md
+++ b/TRACKING.md
@@ -1911,6 +1911,28 @@ Ordre de merge recommandé pour les 4 restantes : **#1081 (#1044) → #1085 (#10
 
 <details><summary>
 
+## Sprint 56.b — Mobile + Web : Chargement progressif & perf (ADR-057)
+
+</summary>
+Inséré entre 56 et 57 (sans renuméroter). Résout la latence d'ouverture d'un voyage (#1099) puis découpe le modèle de lecture monolithique en résumé / détail-étape / route, avec hydratation progressive du store (web + mobile). Voir [ADR-057](docs/adr/adr-057-progressive-trip-loading.md). Milestone : « Sprint 56.b ».
+
+**Cause racine #1099** : `/trips/{id}/detail` émet tous les POIs du corridor (mesuré : 5 457 POIs / ~1.18 MB sur un trip 2 étapes ; la géométrie ne pèse que ~28 KB) → `JSON.parse` Hermes bloque ~20 s avant tout rendu, puis `PoiBlock` non virtualisé monte des milliers de vues. Le diagnostic initial (« géométrie ») était faux.
+
+| Ordre | ID | Titre | Effort | Statut | Dépend de |
+|-------|----|-------|--------|--------|-----------|
+| 1 | [#1099](https://github.com/vincentchalamon/bike-trip-planner/issues/1099) | `resupply` (≤6/étape) remplace les POIs en vrac — **merge en tête, débloque la recette** | M | ⏳ À faire | — |
+| 2 | [#1102](https://github.com/vincentchalamon/bike-trip-planner/issues/1102) | split modèle lecture — résumé (`/trips/{id}`) / détail-étape (`/stages/{index}`) / route (`/route`) | L | ⏳ À faire | #1099 |
+| 3 | [#1103](https://github.com/vincentchalamon/bike-trip-planner/issues/1103) | hydratation progressive du store (`@btp/core` + mobile : lazy détail au tap, route à l'ouverture carte) | M | ⏳ À faire | #1102 |
+| 4 | [#1104](https://github.com/vincentchalamon/bike-trip-planner/issues/1104) | hydratation progressive de la timeline web (squelettes + fetch parallèle borné) | M | ⏳ À faire | #1102, #1099 |
+| 5 | [#1105](https://github.com/vincentchalamon/bike-trip-planner/issues/1105) | roadbook (05) résumé-seul + détail d'étape (07) catégorisé conformes aux maquettes | L | ⏳ À faire | #1099, #1102, #1103 |
+| 6 | [#1106](https://github.com/vincentchalamon/bike-trip-planner/issues/1106) | spike Vulcain (`Fields`/Early-Hints) par-dessus le fetch progressif | S | ⏳ À faire | #1102, #1104 |
+
+**Contrat** : `/detail` **remplacé** (pré-release, pas de dépréciation) ; `pois` retiré, `resupply` ajouté ; réconciliation SSE inchangée (par étape, ADR-055) ; types OpenAPI régénérés → dérive de compilation intentionnelle sur pwa + mobile. **Vulcain** = surcouche d'optimisation (spike #1106), pas une fondation — Server Push déprécié navigateur, la base reste le fetch HTTP/2 multiplexé.
+
+</details>
+
+<details><summary>
+
 ## Sprint 57 — Mobile : Compte + Notifications (+ push FCM)
 
 </summary>

--- a/docs/adr/adr-057-progressive-trip-loading.md
+++ b/docs/adr/adr-057-progressive-trip-loading.md
@@ -44,7 +44,7 @@ categorized **`resupply`** suggestion per stage from the existing lunch estimati
 (`riderTimeEstimator` + `LUNCH_NUDGE_DISTANCE_KM`, already in `ScanPoisHandler`)
 and route-distance positioning:
 
-```
+```text
 resupply: {
   foodAtLunch:     Poi[≤2],   // best food shops near the estimated lunch stop
   waterMorning:    Poi|null,  // one water point between start and lunch

--- a/docs/adr/adr-057-progressive-trip-loading.md
+++ b/docs/adr/adr-057-progressive-trip-loading.md
@@ -1,0 +1,145 @@
+# ADR-057: Progressive Trip Loading — Summary / Stage-Detail / Route Split
+
+- **Status:** Accepted
+- **Date:** 2026-08-19
+- **Depends on:** ADR-055 (Mobile State Architecture — Thin Store), ADR-007 (Frontend Local State Management), ADR-040 (Local-First Reference Data — PostGIS), ADR-053 (Mobile Strategy — Native App)
+
+## Context and Problem Statement
+
+A trip is loaded through a single `GET /trips/{id}/detail` (`TripDetailProvider`)
+that serializes **every stage in full** in one payload: geometry, weather, alerts,
+events, accommodations, and the raw POI set from the local-first corridor read
+(ADR-040). Measured on a real 2-stage trip, that payload is **1.18 MB dominated
+by 5 457 POI objects** (one stage alone ships 3 901 POIs / 831 KB); geometry is
+only ~28 KB. On the mobile Hermes engine the `JSON.parse` of that object graph
+blocks the roadbook for ~20 s before any render (#1099), and the non-virtualized
+`PoiBlock` then mounts thousands of native views.
+
+Two structural problems compound:
+
+1. **POIs are shipped in bulk.** The roadbook and stage-detail screens never need
+   thousands of anonymous POIs; the product only wants a handful of *resupply
+   suggestions* per stage. The corridor read is an internal computation input, not
+   a client payload.
+2. **The single-payload model does not scale with trip duration.** Even after the
+   POIs are cut, geometry stays bundled and grows linearly: a 3-week trip is ~21
+   stages × ~300 decimated points ≈ **6 300 geometry objects** — the same
+   object-count order as today's POI bloat, so the parse ceiling simply moves from
+   POIs to geometry. A weekend trip is fine; a multi-week trip is not.
+
+The platforms consume the trip differently: **mobile shows one stage detail at a
+time** (naturally lazy), while **web renders the whole detailed timeline at once**.
+Any split must serve both without forcing a web UI redesign, and must preserve the
+shared thin-store + per-stage SSE reconciliation model (ADR-055).
+
+## Decision
+
+Split the trip read model into **three resources by concern**, and **hydrate the
+store progressively** instead of in one blocking payload.
+
+### 1. Resupply replaces raw POIs (both platforms)
+
+The corridor POI set stops being a client payload. The backend computes a small,
+categorized **`resupply`** suggestion per stage from the existing lunch estimation
+(`riderTimeEstimator` + `LUNCH_NUDGE_DISTANCE_KM`, already in `ScanPoisHandler`)
+and route-distance positioning:
+
+```
+resupply: {
+  foodAtLunch:     Poi[≤2],   // best food shops near the estimated lunch stop
+  waterMorning:    Poi|null,  // one water point between start and lunch
+  waterAfternoon:  Poi|null,  // one water point between lunch and arrival
+  foodAtArrival:   Poi[≤2],   // best food shops at the arrival
+}
+```
+
+At most **6 POIs/stage** instead of thousands. These are explicitly *suggestions*
+(a short help note says so on both UIs); there is no "widen radius" for resupply —
+the user who wants more searches an external map. The raw `pois` field is dropped
+from every read model.
+
+### 2. Three read resources
+
+- **`GET /trips/{id}` — roadbook summary** (always, initial load). Per-stage
+  summary only: `dayNumber`, `startLabel`/`endLabel`, `distance`, `elevation`,
+  `elevationLoss`, `isRestDay`, a weather summary, and an alert **count** — no
+  geometry, no collections. ~200 B/stage, so it stays instant for a months-long
+  trip.
+- **`GET /trips/{tripId}/stages/{index}` — stage detail** (on demand). The full
+  single stage: that stage's geometry, `resupply`, accommodations, events,
+  classified alerts, weather. The `StageResponse` DTO already models this shape
+  (currently `#[NotExposed]`); it is promoted to an exposed operation with a
+  provider. O(1) per stage opened.
+- **`GET /trips/{id}/route` — route geometry** (on demand). All stages, **geometry
+  only**, for the map. The one unavoidable all-stages payload, kept geometry-only
+  and fetched **only when the map is actually viewed**.
+
+### 3. Progressive hydration
+
+- **Mobile** loads the summary on open, fetches a stage's detail on tap, and
+  fetches the route when the Map tab opens. It parses one stage's object graph at
+  a time — the #1099 ceiling disappears.
+- **Web** loads the summary, renders the timeline with a **skeleton per row**,
+  then fetches every stage detail **in parallel with bounded concurrency**
+  (HTTP/2-multiplexed over FrankenPHP/Caddy), each row hydrating as its detail
+  arrives. **No UI change** — the same timeline, filled progressively. The map
+  uses the route resource. Each `/stages/{index}` is independently cacheable
+  (Redis server-side, browser/CDN client-side) and resumable, unlike one 630 KB
+  blob.
+- **SSE reconciliation is unchanged** (ADR-055): Mercure events already target
+  individual stages by index, so they reconcile whatever slices are currently
+  loaded. The shared `@btp/core` reducers keep both stores in step.
+
+### 4. Vulcain is a layered optimization, not a foundation
+
+[Vulcain](https://vulcain.rocks) is in-stack (API Platform native support, Caddy
+module) and designed for exactly this client-driven fetch shape. But its headline
+mechanism, **HTTP/2 Server Push, is deprecated in browsers** (Chrome removed it in
+2022), so the "push linked resources" win no longer lands on the web. The parts
+that remain current — **`Fields` sparse fieldsets** (one `/stages/{index}`
+resource, web asking for all fields, mobile for the summary subset, avoiding two
+contract shapes) and `Link` / `103 Early Hints` preloading — are worth a **short
+spike** in Phase 2. The baseline that ships regardless is the client-driven
+**parallel progressive fetch** above; Vulcain layers on top only if the spike
+shows a clear win. We do **not** build the loading model on Server Push.
+
+## Consequences
+
+- Trip open no longer parses a monolithic payload; the roadbook is bounded by
+  stage *count*, not stage *content*, and stays fast at any trip length.
+- Two→three read resources; the store gains per-stage loading states (skeletons on
+  web, on-tap load on mobile). The write/mutation paths and the existing
+  accommodation expand-scan (`AccommodationScanProcessor`) are unaffected.
+- Per-stage HTTP caching replaces one uncacheable blob — better CDN/Redis reuse,
+  parallelism, and resumability.
+- The OpenAPI contract changes (drop `pois`, add `resupply`, expose the stage and
+  route resources); `@btp/core` types regenerate and both platforms adapt in the
+  same pass — intentional compile-time drift (per the type-contract principle).
+- Since the app is pre-release, `/trips/{id}/detail` is **replaced**, not kept in
+  parallel; no deprecation window.
+- The corridor POI read (ADR-040) stays an internal computation input feeding
+  resupply selection and the resupply/lunch nudges — only its *exposure* changes.
+
+## Alternatives Considered
+
+- **Single capped `/detail` (Phase 1 only).** Cap POIs to resupply but keep
+  geometry bundled. Fixes #1099 for weekend/1-week trips but leaves the geometry
+  ceiling for multi-week trips. Rejected as the end state; it is effectively the
+  first increment of this decision.
+- **Vulcain Server Push as the loading mechanism.** Rejected: browser Server Push
+  is deprecated, so it cannot be the foundation.
+- **Single streamed response (NDJSON / chunked).** Flush summary first, then each
+  stage. Rejected: complicates typed store hydration and openapi-fetch consumption
+  for little gain over cacheable per-stage resources.
+- **GraphQL field selection.** Rejected: outside the current REST + openapi-fetch
+  contract model; disproportionate for one read path.
+
+## References
+
+- [ADR-055](adr-055-mobile-state-architecture.md) — Thin store + shared reconciliation
+- [ADR-040](adr-040-local-first-reference-data-postgis.md) — Local-first reference data (POI/water corridor reads)
+- [ADR-007](adr-007-frontend-local-state-management-and-reactivity.md) — Frontend local state
+- `api/src/State/TripDetailProvider.php`, `api/src/ApiResource/TripDetail.php` — current single payload
+- `api/src/ApiResource/StageResponse.php` — per-stage DTO to expose
+- `api/src/MessageHandler/ScanPoisHandler.php` — lunch estimation reused for resupply
+- Issue #1099 — trip-open latency root cause (POI payload)


### PR DESCRIPTION
## Contexte

Suite au diagnostic de la latence d'ouverture d'un voyage sur mobile (#1099) : la cause racine n'est **pas** la géométrie mais les **POIs du corridor émis en vrac** dans `/trips/{id}/detail` (mesuré : 5 457 POIs / ~1.18 MB sur un trip 2 étapes ; géométrie ~28 KB). Le `JSON.parse` Hermes bloque ~20 s avant tout rendu.

## Décision (ADR-057, Accepted)

Split du modèle de lecture monolithique en **3 ressources par préoccupation** + **hydratation progressive** du store (web + mobile) :

- `GET /trips/{id}` — résumé roadbook (pas de géométrie/collections).
- `GET /trips/{tripId}/stages/{index}` — détail d'une étape à la demande (`StageResponse`, aujourd'hui `#[NotExposed]`, exposé).
- `GET /trips/{id}/route` — géométrie du tracé seule, pour la carte.

`resupply` (≤6 suggestions/étape) remplace le champ `pois`. Réconciliation SSE inchangée (par étape, ADR-055). **Vulcain** = surcouche d'optimisation (spike), pas une fondation (Server Push déprécié navigateur).

## Phasage

Bloc unique **Sprint 56.b** (inséré entre 56 et 57, sans renuméroter). Le ticket #1099 (resupply) merge **en tête** pour débloquer la recette avant le split d'endpoints.

## Contenu

- `docs/adr/adr-057-progressive-trip-loading.md`
- `TRACKING.md` : section Sprint 56.b (tickets #1099, #1102, #1103, #1104, #1105, #1106).

> Note : à merger de préférence après #1095 et #1098 (autres PRs docs touchant TRACKING) — éditions non chevauchantes, auto-mergeables.

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 findings (0 critical, 0 warning). Docs-only change (new ADR-057 + TRACKING.md Sprint 56.b entry) — no application code touched, so the security/performance/architecture code checklist doesn't apply. Re-verified all factual claims independently against current code/tracker state: `StageResponse` is `#[NotExposed]`, `ScanPoisHandler` defines `LUNCH_NUDGE_DISTANCE_KM` and injects `RiderTimeEstimatorInterface`, `TripDetailProvider`/`TripDetail`/`AccommodationScanProcessor` all exist as referenced, ADR-057 is next-in-sequence after ADR-056, and Sprint 56.b is correctly inserted between Sprint 56 and Sprint 57 with table formatting matching sibling sections. All six linked issues (#1099, #1102–#1106) exist, are open, and match the described scope/order/dependencies. The second commit's fenced-code-block language fix (MD040) is confirmed applied (` ```text `).

**Resolved threads:** none (no open threads to resolve).

**PR title check:** `docs(adr): ADR-057 chargement progressif + Sprint 56.b` — the description still lacks an imperative verb (e.g. `docs(adr): add ADR-057 for progressive trip loading + Sprint 56.b`). Non-blocking for a docs PR that gets squash-merged.

**Review checklist:**
- [x] Code respects the project architecture (N/A — docs only; ADR content is consistent with ADR-055/ADR-040/ADR-053/ADR-007)
- [x] SOLID principles and Law of Demeter followed (N/A — no code)
- [x] Design patterns used where appropriate (N/A — no code)
- [x] Tests cover new/changed cases (N/A — docs only, no behavior change)
- [x] Documentation is up to date (ADR + TRACKING.md consistent with each other and with linked issues)
- [x] Dependent tickets accounted for (#1099, #1102–#1106 all exist, open, and match described scope/order)

**Inline comments:** No inline comments.

_Reviewed commit: 920d2cc58824757ef213e802a82f80b44ba64303_
<!-- claude-review-end -->