### PR TITLE
feat(api): split trip read model — summary /detail + /route + /stages/{i}/detail (#1102)

### DIFF
--- a/TRACKING.md
+++ b/TRACKING.md
@@ -1921,9 +1921,9 @@ Inséré entre 56 et 57 (sans renuméroter). Résout la latence d'ouverture d'un
 | Ordre | ID | Titre | Effort | Statut | Dépend de |
 |-------|----|-------|--------|--------|-----------|
 | 1 | [#1099](https://github.com/vincentchalamon/bike-trip-planner/issues/1099) | `resupply` (≤6/étape) remplace les POIs en vrac — **merge en tête, débloque la recette** | M | ⏳ À faire | — |
-| 2 | [#1102](https://github.com/vincentchalamon/bike-trip-planner/issues/1102) | split modèle lecture — résumé (`/trips/{id}`) / détail-étape (`/stages/{index}`) / route (`/route`) | L | ⏳ À faire | #1099 |
-| 3 | [#1103](https://github.com/vincentchalamon/bike-trip-planner/issues/1103) | hydratation progressive du store (`@btp/core` + mobile : lazy détail au tap, route à l'ouverture carte) | M | ⏳ À faire | #1102 |
-| 4 | [#1104](https://github.com/vincentchalamon/bike-trip-planner/issues/1104) | hydratation progressive de la timeline web (squelettes + fetch parallèle borné) | M | ⏳ À faire | #1102, #1099 |
+| 2 | [#1102](https://github.com/vincentchalamon/bike-trip-planner/issues/1102) | split modèle lecture — résumé (`/trips/{id}`) / détail-étape (`/stages/{index}/detail`) / route (`/route`) | L | 🚧 En cours | #1099 |
+| 3 | [#1103](https://github.com/vincentchalamon/bike-trip-planner/issues/1103) | hydratation progressive du store (`@btp/core` + mobile : lazy détail au tap, route à l'ouverture carte) | M | 🚧 En cours | #1102 |
+| 4 | [#1104](https://github.com/vincentchalamon/bike-trip-planner/issues/1104) | hydratation progressive de la timeline web (squelettes + fetch parallèle borné) | M | 🚧 En cours | #1102, #1099 |
 | 5 | [#1105](https://github.com/vincentchalamon/bike-trip-planner/issues/1105) | roadbook (05) résumé-seul + détail d'étape (07) catégorisé conformes aux maquettes | L | ⏳ À faire | #1099, #1102, #1103 |
 | 6 | [#1106](https://github.com/vincentchalamon/bike-trip-planner/issues/1106) | spike Vulcain (`Fields`/Early-Hints) par-dessus le fetch progressif | S | ⏳ À faire | #1102, #1104 |
 

--- a/api/src/ApiResource/Stage.php
+++ b/api/src/ApiResource/Stage.php
@@ -21,6 +21,7 @@ use App\ApiResource\Model\WeatherForecast;
 use App\State\RestDayInsertProcessor;
 use App\State\StageCreateProcessor;
 use App\State\StageDeleteProcessor;
+use App\State\StageDetailProvider;
 use App\State\StageMoveProcessor;
 use App\State\StagePoiWaypointProcessor;
 use App\State\StageProvider;
@@ -48,6 +49,20 @@ use App\State\StageUpdateProcessor;
             openapi: new Operation(summary: 'Download a stage as GPX or FIT file.'),
             security: "is_granted('TRIP_VIEW', request.attributes.get('tripId'))",
             provider: StageProvider::class,
+        ),
+        new Get(
+            // On-demand full stage detail (ADR-057), on a distinct sub-route for the
+            // same reason as the export above: the plain '/stages/{index}' path is the
+            // StageResponse NotExposed IRI and would be shadowed by NotExposedAction.
+            uriTemplate: '/trips/{tripId}/stages/{index}/detail{._format}',
+            uriVariables: [
+                'tripId' => new Link(fromClass: Stage::class),
+                'index' => new Link(toProperty: 'dayNumber', fromClass: Stage::class),
+            ],
+            openapi: new Operation(summary: 'Load one stage in full (geometry, resupply, accommodations, events, classified alerts, weather).'),
+            security: "is_granted('TRIP_VIEW', request.attributes.get('tripId'))",
+            output: StageResponse::class,
+            provider: StageDetailProvider::class,
         ),
         new Post(
             uriTemplate: '/trips/{tripId}/stages{._format}',

--- a/api/src/ApiResource/TripDetail.php
+++ b/api/src/ApiResource/TripDetail.php
@@ -74,6 +74,11 @@ final readonly class TripDetail
                     'elevationLoss' => ['type' => 'number', 'format' => 'float'],
                     'startPoint' => ['type' => 'object', 'properties' => ['lat' => ['type' => 'number'], 'lon' => ['type' => 'number'], 'ele' => ['type' => 'number']]],
                     'endPoint' => ['type' => 'object', 'properties' => ['lat' => ['type' => 'number'], 'lon' => ['type' => 'number'], 'ele' => ['type' => 'number']]],
+                    // Kept in the contract (optional) but omitted from the summary
+                    // serialization (ADR-057): geometry loads on demand via GET /route.
+                    // Declaring it keeps the frontend types stable while the payload
+                    // stays light.
+                    'geometry' => ['type' => 'array', 'items' => ['type' => 'object', 'properties' => ['lat' => ['type' => 'number'], 'lon' => ['type' => 'number'], 'ele' => ['type' => 'number']]]],
                     'label' => ['oneOf' => [['type' => 'string'], ['type' => 'null']]],
                     'startLabel' => ['oneOf' => [['type' => 'string'], ['type' => 'null']]],
                     'endLabel' => ['oneOf' => [['type' => 'string'], ['type' => 'null']]],

--- a/api/src/ApiResource/TripDetail.php
+++ b/api/src/ApiResource/TripDetail.php
@@ -74,7 +74,6 @@ final readonly class TripDetail
                     'elevationLoss' => ['type' => 'number', 'format' => 'float'],
                     'startPoint' => ['type' => 'object', 'properties' => ['lat' => ['type' => 'number'], 'lon' => ['type' => 'number'], 'ele' => ['type' => 'number']]],
                     'endPoint' => ['type' => 'object', 'properties' => ['lat' => ['type' => 'number'], 'lon' => ['type' => 'number'], 'ele' => ['type' => 'number']]],
-                    'geometry' => ['type' => 'array', 'items' => ['type' => 'object', 'properties' => ['lat' => ['type' => 'number'], 'lon' => ['type' => 'number'], 'ele' => ['type' => 'number']]]],
                     'label' => ['oneOf' => [['type' => 'string'], ['type' => 'null']]],
                     'startLabel' => ['oneOf' => [['type' => 'string'], ['type' => 'null']]],
                     'endLabel' => ['oneOf' => [['type' => 'string'], ['type' => 'null']]],

--- a/api/src/ApiResource/TripRoute.php
+++ b/api/src/ApiResource/TripRoute.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ApiResource;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\OpenApi\Model\Operation;
+use App\State\TripRouteProvider;
+
+/**
+ * Route geometry for the whole trip, split off the trip read model (ADR-057):
+ * the map tab fetches it on demand instead of every trip load paying the parse
+ * cost of the decimated points on a months-long trip.
+ */
+#[ApiResource(
+    shortName: 'TripRoute',
+    operations: [
+        new Get(
+            uriTemplate: '/trips/{id}/route',
+            openapi: new Operation(summary: 'All-stages decimated geometry for the map (loaded on demand).'),
+            security: "is_granted('TRIP_VIEW', request.attributes.get('id'))",
+            provider: TripRouteProvider::class,
+        ),
+    ],
+)]
+final readonly class TripRoute
+{
+    /**
+     * @param list<array{dayNumber: int, geometry: list<array{lat: float, lon: float, ele: float}>}> $stages
+     */
+    public function __construct(
+        public string $id,
+        #[ApiProperty(openapiContext: [
+            'type' => 'array',
+            'items' => [
+                'type' => 'object',
+                'properties' => [
+                    'dayNumber' => ['type' => 'integer'],
+                    'geometry' => ['type' => 'array', 'items' => ['type' => 'object', 'properties' => [
+                        'lat' => ['type' => 'number'],
+                        'lon' => ['type' => 'number'],
+                        'ele' => ['type' => 'number'],
+                    ]]],
+                ],
+            ],
+        ])]
+        public array $stages,
+    ) {
+    }
+}

--- a/api/src/State/StageDetailProvider.php
+++ b/api/src/State/StageDetailProvider.php
@@ -8,7 +8,7 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
 use App\ApiResource\StageResponse;
 use App\Mapper\StageResponseMapper;
-use App\Repository\DoctrineTripRequestRepository;
+use App\Repository\TripRequestRepositoryInterface;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
@@ -23,7 +23,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 final readonly class StageDetailProvider implements ProviderInterface
 {
     public function __construct(
-        private DoctrineTripRequestRepository $tripStateManager,
+        private TripRequestRepositoryInterface $tripStateManager,
         private StageResponseMapper $mapper,
     ) {
     }

--- a/api/src/State/StageDetailProvider.php
+++ b/api/src/State/StageDetailProvider.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProviderInterface;
+use App\ApiResource\StageResponse;
+use App\Mapper\StageResponseMapper;
+use App\Repository\DoctrineTripRequestRepository;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Read one stage in full (geometry, resupply, accommodations, events, classified
+ * alerts, weather) — the on-demand half of the split trip read model (ADR-057).
+ * The roadbook loads only the summary; the detail is fetched when a stage opens.
+ *
+ * `index` is the 0-based stage position, matching {@see StageProvider}.
+ *
+ * @implements ProviderInterface<StageResponse>
+ */
+final readonly class StageDetailProvider implements ProviderInterface
+{
+    public function __construct(
+        private DoctrineTripRequestRepository $tripStateManager,
+        private StageResponseMapper $mapper,
+    ) {
+    }
+
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): StageResponse
+    {
+        $tripId = \is_string($uriVariables['tripId'] ?? null) ? $uriVariables['tripId'] : '';
+        $index = \is_numeric($uriVariables['index'] ?? null) ? (int) $uriVariables['index'] : 0;
+
+        $stages = $this->tripStateManager->getStages($tripId) ?? [];
+        if (!isset($stages[$index])) {
+            throw new NotFoundHttpException(\sprintf('Stage at index %d not found.', $index));
+        }
+
+        return $this->mapper->map($stages[$index]);
+    }
+}

--- a/api/src/State/StageDetailProvider.php
+++ b/api/src/State/StageDetailProvider.php
@@ -8,7 +8,7 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
 use App\ApiResource\StageResponse;
 use App\Mapper\StageResponseMapper;
-use App\Repository\TripRequestRepositoryInterface;
+use App\Repository\DoctrineTripRequestRepository;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
@@ -22,8 +22,11 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  */
 final readonly class StageDetailProvider implements ProviderInterface
 {
+    // Persisted stages live in Postgres, but the repository *interface* is
+    // aliased to the Redis (transient) implementation in services.php; inject
+    // the Doctrine repository explicitly, like TripDetailProvider.
     public function __construct(
-        private TripRequestRepositoryInterface $tripStateManager,
+        private DoctrineTripRequestRepository $tripStateManager,
         private StageResponseMapper $mapper,
     ) {
     }

--- a/api/src/State/TripDetailProvider.php
+++ b/api/src/State/TripDetailProvider.php
@@ -167,7 +167,8 @@ final readonly class TripDetailProvider implements ProviderInterface
             'elevationLoss' => $stage->elevationLoss,
             'startPoint' => $this->serializeCoord($stage->startPoint),
             'endPoint' => $this->serializeCoord($stage->endPoint),
-            'geometry' => array_map($this->serializeCoord(...), $stage->geometry),
+            // Geometry is split off to GET /trips/{id}/route (ADR-057): it is the only
+            // O(points) per-stage field, and the roadbook summary never renders it.
             'label' => $stage->label,
             'startLabel' => $stage->startLabel,
             'endLabel' => $stage->endLabel,

--- a/api/src/State/TripRouteProvider.php
+++ b/api/src/State/TripRouteProvider.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProviderInterface;
+use App\ApiResource\Model\Coordinate;
+use App\ApiResource\Stage;
+use App\ApiResource\TripRoute;
+use App\Repository\DoctrineTripRequestRepository;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * @implements ProviderInterface<TripRoute>
+ */
+final readonly class TripRouteProvider implements ProviderInterface
+{
+    public function __construct(
+        private DoctrineTripRequestRepository $tripStateManager,
+    ) {
+    }
+
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): TripRoute
+    {
+        $id = \is_string($uriVariables['id'] ?? null) ? $uriVariables['id'] : '';
+
+        $stages = $this->tripStateManager->getStages($id);
+        if (null === $stages) {
+            throw new NotFoundHttpException(\sprintf('Trip "%s" not found.', $id));
+        }
+
+        return new TripRoute(
+            id: $id,
+            stages: array_map(
+                static fn (Stage $stage): array => [
+                    'dayNumber' => $stage->dayNumber,
+                    'geometry' => array_map(
+                        static fn (Coordinate $c): array => ['lat' => $c->lat, 'lon' => $c->lon, 'ele' => $c->ele],
+                        $stage->geometry,
+                    ),
+                ],
+                $stages,
+            ),
+        );
+    }
+}

--- a/api/src/State/TripRouteProvider.php
+++ b/api/src/State/TripRouteProvider.php
@@ -9,7 +9,7 @@ use ApiPlatform\State\ProviderInterface;
 use App\ApiResource\Model\Coordinate;
 use App\ApiResource\Stage;
 use App\ApiResource\TripRoute;
-use App\Repository\TripRequestRepositoryInterface;
+use App\Repository\DoctrineTripRequestRepository;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
@@ -17,8 +17,11 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  */
 final readonly class TripRouteProvider implements ProviderInterface
 {
+    // Persisted stages live in Postgres, but the repository *interface* is
+    // aliased to the Redis (transient) implementation in services.php; inject
+    // the Doctrine repository explicitly, like TripDetailProvider.
     public function __construct(
-        private TripRequestRepositoryInterface $tripStateManager,
+        private DoctrineTripRequestRepository $tripStateManager,
     ) {
     }
 

--- a/api/src/State/TripRouteProvider.php
+++ b/api/src/State/TripRouteProvider.php
@@ -9,7 +9,7 @@ use ApiPlatform\State\ProviderInterface;
 use App\ApiResource\Model\Coordinate;
 use App\ApiResource\Stage;
 use App\ApiResource\TripRoute;
-use App\Repository\DoctrineTripRequestRepository;
+use App\Repository\TripRequestRepositoryInterface;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
@@ -18,7 +18,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 final readonly class TripRouteProvider implements ProviderInterface
 {
     public function __construct(
-        private DoctrineTripRequestRepository $tripStateManager,
+        private TripRequestRepositoryInterface $tripStateManager,
     ) {
     }
 

--- a/api/tests/Functional/TripDetailTest.php
+++ b/api/tests/Functional/TripDetailTest.php
@@ -559,4 +559,57 @@ final class TripDetailTest extends ApiTestCase
         $this->assertArrayHasKey('resupply', $data);
         $this->assertArrayHasKey('accommodations', $data);
     }
+
+    #[Test]
+    public function routeOfAnotherUsersTripReturns404(): void
+    {
+        // IDOR-DETAIL regression: TRIP_VIEW hides another user's trip as a 404.
+        $repo = $this->seedTrip(self::TRIP_ID);
+        $repo->storeStages(self::TRIP_ID, []);
+
+        ['token' => $otherToken] = $this->createTestUserWithJwt('intruder@example.com');
+
+        $this->client->request('GET', \sprintf('/trips/%s/route', self::TRIP_ID), [
+            'headers' => array_merge(['Accept' => 'application/ld+json'], $this->authHeader($otherToken)),
+        ]);
+
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    #[Test]
+    public function stageDetailOfAnotherUsersTripReturns404(): void
+    {
+        $repo = $this->seedTrip(self::TRIP_ID);
+        $repo->storeStages(self::TRIP_ID, [
+            new StageDto(
+                tripId: self::TRIP_ID,
+                dayNumber: 1,
+                distance: 40.0,
+                elevation: 300.0,
+                startPoint: new Coordinate(45.0, 6.0, 100.0),
+                endPoint: new Coordinate(45.5, 6.5, 200.0),
+            ),
+        ]);
+
+        ['token' => $otherToken] = $this->createTestUserWithJwt('intruder2@example.com');
+
+        $this->client->request('GET', \sprintf('/trips/%s/stages/0/detail', self::TRIP_ID), [
+            'headers' => array_merge(['Accept' => 'application/ld+json'], $this->authHeader($otherToken)),
+        ]);
+
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    #[Test]
+    public function stageDetailOutOfRangeIndexReturns404(): void
+    {
+        $repo = $this->seedTrip(self::TRIP_ID);
+        $repo->storeStages(self::TRIP_ID, []);
+
+        $this->client->request('GET', \sprintf('/trips/%s/stages/0/detail', self::TRIP_ID), [
+            'headers' => array_merge(['Accept' => 'application/ld+json'], $this->authHeader($this->jwtToken)),
+        ]);
+
+        $this->assertResponseStatusCodeSame(404);
+    }
 }

--- a/api/tests/Functional/TripDetailTest.php
+++ b/api/tests/Functional/TripDetailTest.php
@@ -103,7 +103,8 @@ final class TripDetailTest extends ApiTestCase
         $stage = $data['stages'][0];
         $this->assertArrayHasKey('dayNumber', $stage);
         $this->assertArrayHasKey('distance', $stage);
-        $this->assertArrayHasKey('geometry', $stage);
+        // Geometry is split off to GET /trips/{id}/route (ADR-057); the summary omits it.
+        $this->assertArrayNotHasKey('geometry', $stage);
         $this->assertArrayHasKey('alerts', $stage);
         $this->assertArrayHasKey('accommodations', $stage);
         // No cycle routes provisioned in the test DB → stage is not on a network.
@@ -500,5 +501,62 @@ final class TripDetailTest extends ApiTestCase
         $this->client->request('GET', '/trips/01936f6e-0000-7000-8000-000000000001/detail');
 
         $this->assertResponseStatusCodeSame(401);
+    }
+
+    #[Test]
+    public function routeReturnsPerStageGeometry(): void
+    {
+        $repo = $this->seedTrip(self::TRIP_ID);
+        $repo->storeStages(self::TRIP_ID, [
+            new StageDto(
+                tripId: self::TRIP_ID,
+                dayNumber: 1,
+                distance: 40.0,
+                elevation: 300.0,
+                startPoint: new Coordinate(45.0, 6.0, 100.0),
+                endPoint: new Coordinate(45.5, 6.5, 200.0),
+                geometry: [new Coordinate(45.0, 6.0, 100.0), new Coordinate(45.5, 6.5, 200.0)],
+            ),
+        ]);
+
+        $response = $this->client->request('GET', \sprintf('/trips/%s/route', self::TRIP_ID), [
+            'headers' => array_merge(['Accept' => 'application/ld+json'], $this->authHeader($this->jwtToken)),
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $data = $response->toArray(false);
+        $this->assertSame(self::TRIP_ID, $data['id']);
+        $this->assertCount(1, $data['stages']);
+        $this->assertSame(1, $data['stages'][0]['dayNumber']);
+        $this->assertCount(2, $data['stages'][0]['geometry']);
+        $this->assertEqualsWithDelta(45.0, $data['stages'][0]['geometry'][0]['lat'], 0.0001);
+    }
+
+    #[Test]
+    public function stageDetailReturnsTheFullStageIncludingGeometry(): void
+    {
+        $repo = $this->seedTrip(self::TRIP_ID);
+        $repo->storeStages(self::TRIP_ID, [
+            new StageDto(
+                tripId: self::TRIP_ID,
+                dayNumber: 1,
+                distance: 40.0,
+                elevation: 300.0,
+                startPoint: new Coordinate(45.0, 6.0, 100.0),
+                endPoint: new Coordinate(45.5, 6.5, 200.0),
+                geometry: [new Coordinate(45.0, 6.0, 100.0), new Coordinate(45.5, 6.5, 200.0)],
+            ),
+        ]);
+
+        $response = $this->client->request('GET', \sprintf('/trips/%s/stages/0/detail', self::TRIP_ID), [
+            'headers' => array_merge(['Accept' => 'application/ld+json'], $this->authHeader($this->jwtToken)),
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $data = $response->toArray(false);
+        $this->assertSame(1, $data['dayNumber']);
+        $this->assertCount(2, $data['geometry']);
+        $this->assertArrayHasKey('resupply', $data);
+        $this->assertArrayHasKey('accommodations', $data);
     }
 }

--- a/core/schema.d.ts
+++ b/core/schema.d.ts
@@ -1613,6 +1613,11 @@ export interface components {
                     lon?: number;
                     ele?: number;
                 };
+                geometry?: {
+                    lat?: number;
+                    lon?: number;
+                    ele?: number;
+                }[];
                 label?: string | null;
                 startLabel?: string | null;
                 endLabel?: string | null;
@@ -1874,6 +1879,11 @@ export interface components {
                     lon?: number;
                     ele?: number;
                 };
+                geometry?: {
+                    lat?: number;
+                    lon?: number;
+                    ele?: number;
+                }[];
                 label?: string | null;
                 startLabel?: string | null;
                 endLabel?: string | null;

--- a/core/schema.d.ts
+++ b/core/schema.d.ts
@@ -308,6 +308,26 @@ export interface paths {
         patch: operations["api_trips_tripIdstages_indexaccommodation_patch"];
         trace?: never;
     };
+    "/trips/{tripId}/stages/{index}/detail": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Load one stage in full (geometry, resupply, accommodations, events, classified alerts, weather).
+         * @description Load one stage in full (geometry, resupply, accommodations, events, classified alerts, weather).
+         */
+        get: operations["api_trips_tripIdstages_indexdetail_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/trips/{tripId}/stages/{index}/export": {
         parameters: {
             query?: never;
@@ -552,6 +572,26 @@ export interface paths {
          * @description Load trip configuration and persisted stages for frontend hydration.
          */
         get: operations["api_trips_iddetail_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/trips/{id}/route": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * All-stages decimated geometry for the map (loaded on demand).
+         * @description All-stages decimated geometry for the map (loaded on demand).
+         */
+        get: operations["api_trips_idroute_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1573,11 +1613,6 @@ export interface components {
                     lon?: number;
                     ele?: number;
                 };
-                geometry?: {
-                    lat?: number;
-                    lon?: number;
-                    ele?: number;
-                }[];
                 label?: string | null;
                 startLabel?: string | null;
                 endLabel?: string | null;
@@ -1686,6 +1721,22 @@ export interface components {
             type: "accommodation" | "distance" | "dates" | "pacing";
             /** @description Human-readable description for display in the frontend queue panel. */
             label?: string | null;
+        };
+        /**
+         * @description Route geometry for the whole trip, split off the trip read model (ADR-057):
+         *     the map tab fetches it on demand instead of every trip load paying the parse
+         *     cost of the decimated points on a months-long trip.
+         */
+        "TripRoute.jsonld": components["schemas"]["HydraItemBaseSchema"] & {
+            id?: string;
+            stages?: {
+                dayNumber?: number;
+                geometry?: {
+                    lat?: number;
+                    lon?: number;
+                    ele?: number;
+                }[];
+            }[];
         };
         TripShare: {
             /** Format: uuid */
@@ -1823,11 +1874,6 @@ export interface components {
                     lon?: number;
                     ele?: number;
                 };
-                geometry?: {
-                    lat?: number;
-                    lon?: number;
-                    ele?: number;
-                }[];
                 label?: string | null;
                 startLabel?: string | null;
                 endLabel?: string | null;
@@ -2830,6 +2876,53 @@ export interface operations {
             };
         };
     };
+    api_trips_tripIdstages_indexdetail_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Stage identifier */
+                tripId: string;
+                /** @description Stage identifier */
+                index: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Stage resource */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["Stage.StageResponse.jsonld"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["Error.jsonld"];
+                    "application/problem+json": components["schemas"]["Error"];
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["Error.jsonld"];
+                    "application/problem+json": components["schemas"]["Error"];
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
     api_trips_tripIdstages_indexexport_get: {
         parameters: {
             query?: never;
@@ -3720,6 +3813,51 @@ export interface operations {
                 };
                 content: {
                     "application/ld+json": components["schemas"]["TripDetail.jsonld"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["Error.jsonld"];
+                    "application/problem+json": components["schemas"]["Error"];
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["Error.jsonld"];
+                    "application/problem+json": components["schemas"]["Error"];
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    api_trips_idroute_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description TripRoute identifier */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description TripRoute resource */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["TripRoute.jsonld"];
                 };
             };
             /** @description Forbidden */

--- a/docs/adr/adr-057-progressive-trip-loading.md
+++ b/docs/adr/adr-057-progressive-trip-loading.md
@@ -65,11 +65,13 @@ from every read model.
   `elevationLoss`, `isRestDay`, a weather summary, and an alert **count** — no
   geometry, no collections. ~200 B/stage, so it stays instant for a months-long
   trip.
-- **`GET /trips/{tripId}/stages/{index}` — stage detail** (on demand). The full
-  single stage: that stage's geometry, `resupply`, accommodations, events,
+- **`GET /trips/{tripId}/stages/{index}/detail` — stage detail** (on demand). The
+  full single stage: that stage's geometry, `resupply`, accommodations, events,
   classified alerts, weather. The `StageResponse` DTO already models this shape
   (currently `#[NotExposed]`); it is promoted to an exposed operation with a
-  provider. O(1) per stage opened.
+  provider on a `/detail` sub-route (the bare `/stages/{index}` IRI is shadowed by
+  the `NotExposed` `StageResponse`, same reason `/export` uses a sub-route). O(1)
+  per stage opened.
 - **`GET /trips/{id}/route` — route geometry** (on demand). All stages, **geometry
   only**, for the map. The one unavoidable all-stages payload, kept geometry-only
   and fetched **only when the map is actually viewed**.
@@ -83,7 +85,7 @@ from every read model.
   then fetches every stage detail **in parallel with bounded concurrency**
   (HTTP/2-multiplexed over FrankenPHP/Caddy), each row hydrating as its detail
   arrives. **No UI change** — the same timeline, filled progressively. The map
-  uses the route resource. Each `/stages/{index}` is independently cacheable
+  uses the route resource. Each `/stages/{index}/detail` is independently cacheable
   (Redis server-side, browser/CDN client-side) and resumable, unlike one 630 KB
   blob.
 - **SSE reconciliation is unchanged** (ADR-055): Mercure events already target


### PR DESCRIPTION
Closes #1102. **Stack 56.b — base of #1103 → #1104** (ADR-057, atomic replacement of /detail's role).

Geometry is the only O(points) per-stage field and the roadbook summary never renders it, so it moves off the trip load:
- `GET /trips/{id}/detail`: drop stage geometry (light summary).
- `GET /trips/{id}/route` (new): all-stages decimated geometry, on demand for the map.
- `GET /trips/{tripId}/stages/{index}/detail` (new): one stage in full incl geometry, on a distinct sub-route to avoid the NotExposed-IRI shadow (same reason /export uses a sub-route).

Types regenerated. TripDetailTest covers the trimmed /detail + both new endpoints. PHPStan L9 + Functional green.

> Standalone, this PR red-CI's the frontends (geometry removed from /detail type) — that's the stack: #1103 (mobile) and #1104 (web) migrate to progressive hydration. Merge #1102 → #1103 → #1104 in order.

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 critical, 0 warning, 0 suggestion findings.

Both previously-open items are now resolved: the DIP concern on `StageDetailProvider`/`TripRouteProvider` (documented, functional exception matching the `TripDetailProvider`/`TripGpxProvider` precedent — `TripRequestRepositoryInterface` is aliased to the transient Redis implementation) and the ADR-057/`TRACKING.md` path mismatch (fixed by `d117689`, now correctly documenting `/stages/{index}/detail`). IDOR/404 coverage for both new endpoints is in place, mirroring the existing `/detail` tests. All 3 prior review threads were already resolved before this pass; nothing new to resolve.

### Review checklist
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Commit reviewed:** `d11768901fc5d22b597cc4ebd2237fc232f4b1a1`
<!-- claude-review-end -->