### PR TITLE
feat(mobile): progressive geometry hydration via GET /route (#1103)

### DIFF
--- a/mobile/src/api/trips.ts
+++ b/mobile/src/api/trips.ts
@@ -78,6 +78,36 @@ export async function fetchTripDetail(id: string): Promise<TripDetail | null> {
   return data ?? null;
 }
 
+// All-stages geometry for the map (ADR-057), fetched on demand off the summary.
+export type TripRoute = components['schemas']['TripRoute.jsonld'];
+
+export async function fetchTripRoute(id: string): Promise<TripRoute | null> {
+  const { data, error } = await api.GET('/trips/{id}/route', {
+    params: { path: { id } },
+  });
+  if (error) {
+    throw new Error('Failed to fetch trip route');
+  }
+  return data ?? null;
+}
+
+// One stage in full (geometry, resupply, accommodations, events, alerts).
+export type StageDetail = components['schemas']['Stage.StageResponse.jsonld'];
+
+export async function fetchStageDetail(
+  tripId: string,
+  index: number,
+): Promise<StageDetail | null> {
+  const { data, error } = await api.GET('/trips/{tripId}/stages/{index}/detail', {
+    params: { path: { tripId, index: String(index) } },
+    headers: ld,
+  });
+  if (error) {
+    throw new Error('Failed to fetch stage detail');
+  }
+  return data ?? null;
+}
+
 // Delete a stage (merges it with the adjacent day). The backend recomputes and
 // pushes the authoritative state over SSE; a started trip is rejected with 423
 // (App\State\TripLocker). Returns the raw status so the caller can distinguish a

--- a/mobile/src/api/trips.ts
+++ b/mobile/src/api/trips.ts
@@ -84,6 +84,7 @@ export type TripRoute = components['schemas']['TripRoute.jsonld'];
 export async function fetchTripRoute(id: string): Promise<TripRoute | null> {
   const { data, error } = await api.GET('/trips/{id}/route', {
     params: { path: { id } },
+    headers: ld,
   });
   if (error) {
     throw new Error('Failed to fetch trip route');

--- a/mobile/src/components/trip/ShareSheet.test.tsx
+++ b/mobile/src/components/trip/ShareSheet.test.tsx
@@ -9,6 +9,9 @@ jest.mock('../../api/trips', () => ({
   getTripShare: jest.fn(),
   createTripShare: jest.fn(),
   revokeTripShare: jest.fn(),
+  // The sheet pulls the route on open (geometry is split off /detail, ADR-057)
+  // so the infographic has a real route line — mock it like the other fetchers.
+  fetchTripRoute: jest.fn().mockResolvedValue(null),
   buildShareUrl: (code: string) => `https://web.example/s/${code}`,
 }));
 jest.mock('expo-clipboard', () => ({ setStringAsync: jest.fn() }));
@@ -17,7 +20,12 @@ jest.mock('../../lib/share-image', () => ({
 }));
 
 import * as Clipboard from 'expo-clipboard';
-import { getTripShare, createTripShare, revokeTripShare } from '../../api/trips';
+import {
+  getTripShare,
+  createTripShare,
+  revokeTripShare,
+  fetchTripRoute,
+} from '../../api/trips';
 import { captureAndShareInfographic } from '../../lib/share-image';
 import i18n from '../../i18n';
 import { useTripStore } from '../../store/trip-store';
@@ -29,6 +37,7 @@ const mockCreate = createTripShare as jest.Mock;
 const mockRevoke = revokeTripShare as jest.Mock;
 const mockClip = Clipboard.setStringAsync as jest.Mock;
 const mockCapture = captureAndShareInfographic as jest.Mock;
+const mockRoute = fetchTripRoute as jest.Mock;
 
 function textOf(node: any): string[] {
   const kids = Array.isArray(node.props.children)
@@ -201,6 +210,38 @@ describe('ShareSheet (#1048)', () => {
       tree.update(<ShareSheet visible onClose={jest.fn()} tripId="t1" />);
     });
     expect(mockGet).toHaveBeenCalledTimes(1);
+  });
+
+  it('pulls the route geometry into the store when opened (ADR-057)', async () => {
+    // The summary omits geometry, and Share is reachable without the map ever
+    // mounting — so opening the sheet must fetch /route or the infographic has a
+    // blank route line.
+    mockGet.mockResolvedValue(null);
+    useTripStore.setState({
+      tripId: 't1',
+      stages: [stage({ dayNumber: 1 })],
+      geometryLoaded: false,
+    });
+    mockRoute.mockResolvedValue({
+      id: 't1',
+      stages: [{ dayNumber: 1, geometry: [{ lat: 45, lon: 6, ele: 800 }] }],
+    });
+
+    await render(<ShareSheet visible onClose={jest.fn()} tripId="t1" />);
+
+    expect(mockRoute).toHaveBeenCalledWith('t1');
+    const s = useTripStore.getState();
+    expect(s.geometryLoaded).toBe(true);
+    expect(s.stages[0]!.geometry).toEqual([{ lat: 45, lon: 6, ele: 800 }]);
+  });
+
+  it('does not fetch the route while the sheet is closed', async () => {
+    mockGet.mockResolvedValue(null);
+    useTripStore.setState({ tripId: 't1', geometryLoaded: false });
+
+    await render(<ShareSheet visible={false} onClose={jest.fn()} tripId="t1" />);
+
+    expect(mockRoute).not.toHaveBeenCalled();
   });
 
   it('keeps the off-screen infographic unmounted while the sheet is just open (idle)', async () => {

--- a/mobile/src/components/trip/ShareSheet.tsx
+++ b/mobile/src/components/trip/ShareSheet.tsx
@@ -20,6 +20,7 @@ import {
 import { useTheme } from '../../theme';
 import type { Theme } from '../../theme';
 import { useTripStore } from '../../store/trip-store';
+import { useTripRoute } from '../../hooks/use-trip-route';
 import {
   buildShareUrl,
   createTripShare,
@@ -42,6 +43,10 @@ interface ShareSheetProps {
 // via clipboard. Restyled to the Spike-UX mockup: read-only link field + accent
 // copy, then a stack of icon "send another way" option rows.
 export function ShareSheet({ visible, onClose, tripId }: ShareSheetProps) {
+  // The summary omits geometry (ADR-057) and the share sheet is reachable from
+  // the roadbook without the map ever mounting; pull the route in when it opens
+  // so the captured infographic has a real route line.
+  useTripRoute({ enabled: visible });
   const { t } = useTranslation();
   const theme = useTheme();
   const s = styles(theme);

--- a/mobile/src/components/trip/StageDetailView.tsx
+++ b/mobile/src/components/trip/StageDetailView.tsx
@@ -39,6 +39,7 @@ import {
 } from './stage-detail';
 import { useTheme } from '../../theme';
 import { useTripStore } from '../../store/trip-store';
+import { useTripRoute } from '../../hooks/use-trip-route';
 import { useOfflineStore } from '../../store/offline-store';
 import { useTripMutations } from '../../hooks/use-trip-mutations';
 import type { MutationFailure } from '../../store/gating';
@@ -52,6 +53,8 @@ import type { MutationFailure } from '../../store/gating';
 // the live store; the stage index is local state so prev/next stays on one
 // mounted screen (no navigation stacking, no SSE re-subscribe).
 export function StageDetailView({ initialIndex }: { initialIndex: number }) {
+  // The summary omits geometry (ADR-057); pull the route in for the mini-map + profile.
+  useTripRoute();
   const { t, i18n } = useTranslation();
   const theme = useTheme();
   const stages = useTripStore((s) => s.stages);

--- a/mobile/src/components/trip/StageDetailView.tsx
+++ b/mobile/src/components/trip/StageDetailView.tsx
@@ -39,7 +39,7 @@ import {
 } from './stage-detail';
 import { useTheme } from '../../theme';
 import { useTripStore } from '../../store/trip-store';
-import { useTripRoute } from '../../hooks/use-trip-route';
+import { useStageDetail } from '../../hooks/use-stage-detail';
 import { useOfflineStore } from '../../store/offline-store';
 import { useTripMutations } from '../../hooks/use-trip-mutations';
 import type { MutationFailure } from '../../store/gating';
@@ -53,8 +53,6 @@ import type { MutationFailure } from '../../store/gating';
 // the live store; the stage index is local state so prev/next stays on one
 // mounted screen (no navigation stacking, no SSE re-subscribe).
 export function StageDetailView({ initialIndex }: { initialIndex: number }) {
-  // The summary omits geometry (ADR-057); pull the route in for the mini-map + profile.
-  useTripRoute();
   const { t, i18n } = useTranslation();
   const theme = useTheme();
   const stages = useTripStore((s) => s.stages);
@@ -76,6 +74,9 @@ export function StageDetailView({ initialIndex }: { initialIndex: number }) {
   // Keep the index valid as stages hydrate / change under us.
   const count = stages.length;
   const safeIndex = clampIndex(index, count);
+  // The summary omits geometry (ADR-057); pull just this stage's detail in for
+  // the mini-map + profile (not the whole route).
+  useStageDetail(safeIndex);
   useEffect(() => {
     if (safeIndex !== index) setIndex(safeIndex);
   }, [safeIndex, index]);

--- a/mobile/src/components/trip/TripMapView.tsx
+++ b/mobile/src/components/trip/TripMapView.tsx
@@ -10,6 +10,7 @@ import { ElevationProfile } from './ElevationProfile';
 import { computeProfileSummary, groupThousands } from './trip-map-summary';
 import { useTheme } from '../../theme';
 import { useTripStore } from '../../store/trip-store';
+import { useTripRoute } from '../../hooks/use-trip-route';
 
 // The map tab: derives the route polyline and markers from the store's stages
 // and hands them to the shared TripMap, or shows the empty state when there is
@@ -18,6 +19,8 @@ import { useTripStore } from '../../store/trip-store';
 // profile surlines the matching stretch on the map. The Spike-UX restyle frames
 // the map full-bleed with a fixed bottom profile panel and a floating ride CTA.
 export function TripMapView() {
+  // The summary omits geometry (ADR-057); pull the route in so the map has a line.
+  useTripRoute();
   const theme = useTheme();
   const { t } = useTranslation();
   const stages = useTripStore((s) => s.stages);

--- a/mobile/src/hooks/use-stage-detail.test.ts
+++ b/mobile/src/hooks/use-stage-detail.test.ts
@@ -1,0 +1,116 @@
+/// <reference types="jest" />
+import { createElement } from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import type { StageData } from '@btp/core';
+import { EMPTY_RESUPPLY } from '@btp/core';
+import { useStageDetail } from './use-stage-detail';
+import { useTripStore } from '../store/trip-store';
+
+jest.mock('../api/trips', () => ({ fetchStageDetail: jest.fn() }));
+import { fetchStageDetail } from '../api/trips';
+const mockDetail = fetchStageDetail as jest.MockedFunction<typeof fetchStageDetail>;
+
+const A = { lat: 1, lon: 1, ele: 0 };
+const B = { lat: 2, lon: 2, ele: 0 };
+
+function stageData(overrides: Partial<StageData> = {}): StageData {
+  return {
+    dayNumber: 1,
+    distance: 50,
+    elevation: 100,
+    elevationLoss: 0,
+    startPoint: A,
+    endPoint: B,
+    geometry: [],
+    label: null,
+    startLabel: null,
+    endLabel: null,
+    weather: null,
+    alerts: [],
+    resupply: EMPTY_RESUPPLY,
+    accommodations: [],
+    selectedAccommodation: null,
+    accommodationSearchRadiusKm: 5,
+    isRestDay: false,
+    supplyTimeline: [],
+    events: [],
+    ...overrides,
+  };
+}
+
+const store = () => useTripStore.getState();
+
+// Probes must be torn down between tests: the store is a global singleton, so a
+// still-mounted effect would re-fire on the next test's setState.
+let renderers: ReturnType<typeof TestRenderer.create>[] = [];
+async function render(index: number): Promise<void> {
+  function Probe() {
+    useStageDetail(index);
+    return null;
+  }
+  await act(async () => {
+    renderers.push(TestRenderer.create(createElement(Probe)));
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useTripStore.getState().reset();
+});
+
+afterEach(() => {
+  act(() => renderers.forEach((r) => r.unmount()));
+  renderers = [];
+});
+
+describe('useStageDetail (ADR-057)', () => {
+  it('fetches one stage detail and merges only its geometry', async () => {
+    useTripStore.setState({
+      tripId: 't1',
+      stages: [stageData({ dayNumber: 1 }), stageData({ dayNumber: 2 })],
+      loading: false,
+    });
+    mockDetail.mockResolvedValue({
+      dayNumber: 2,
+      geometry: [{ lat: 48, lon: 2, ele: 100 }],
+    } as never);
+
+    await render(1);
+
+    expect(mockDetail).toHaveBeenCalledWith('t1', 1);
+    expect(store().stages[0]!.geometry).toEqual([]);
+    expect(store().stages[1]!.geometry).toEqual([{ lat: 48, lon: 2, ele: 100 }]);
+  });
+
+  it('does not fetch when the stage already has geometry', async () => {
+    useTripStore.setState({
+      tripId: 't1',
+      stages: [stageData({ geometry: [{ lat: 48, lon: 2, ele: 100 }] })],
+      loading: false,
+    });
+    await render(0);
+    expect(mockDetail).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch without a trip id', async () => {
+    useTripStore.setState({ stages: [stageData()], loading: false });
+    await render(0);
+    expect(mockDetail).not.toHaveBeenCalled();
+  });
+
+  it('warns (but never throws) when the fetch fails', async () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    useTripStore.setState({
+      tripId: 't1',
+      stages: [stageData()],
+      loading: false,
+    });
+    mockDetail.mockRejectedValue(new Error('boom'));
+
+    await render(0);
+
+    expect(warn).toHaveBeenCalled();
+    expect(store().stages[0]!.geometry).toEqual([]);
+    warn.mockRestore();
+  });
+});

--- a/mobile/src/hooks/use-stage-detail.ts
+++ b/mobile/src/hooks/use-stage-detail.ts
@@ -24,7 +24,10 @@ export function useStageDetail(index: number): void {
           applyStageDetail(index, (detail.geometry ?? []) as StageData['geometry']);
         }
       })
-      .catch(() => {});
+      .catch((error: unknown) => {
+        // Graceful degradation (mini-map/profile stay empty) but not silent.
+        console.warn('Failed to load stage detail geometry', error);
+      });
     return () => {
       cancelled = true;
     };

--- a/mobile/src/hooks/use-stage-detail.ts
+++ b/mobile/src/hooks/use-stage-detail.ts
@@ -1,0 +1,32 @@
+import { useEffect } from 'react';
+import type { StageData } from '@btp/core';
+import { fetchStageDetail } from '../api/trips';
+import { useTripStore } from '../store/trip-store';
+
+// Fetch one stage's full detail (GET /stages/{index}/detail) and merge its
+// geometry into the store, for the stage screen's mini-map + elevation profile.
+// Unlike the map tab (which needs the whole route), the detail screen pulls only
+// its own ~300 points (ADR-057). Gated on that stage already having geometry, so
+// it fetches once per stage and re-fetches when the user navigates to another.
+export function useStageDetail(index: number): void {
+  const tripId = useTripStore((s) => s.tripId);
+  const hasGeometry = useTripStore(
+    (s) => (s.stages[index]?.geometry?.length ?? 0) > 0,
+  );
+  const applyStageDetail = useTripStore((s) => s.applyStageDetail);
+
+  useEffect(() => {
+    if (!tripId || hasGeometry) return;
+    let cancelled = false;
+    void fetchStageDetail(tripId, index)
+      .then((detail) => {
+        if (!cancelled && detail) {
+          applyStageDetail(index, (detail.geometry ?? []) as StageData['geometry']);
+        }
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [tripId, index, hasGeometry, applyStageDetail]);
+}

--- a/mobile/src/hooks/use-trip-route.test.ts
+++ b/mobile/src/hooks/use-trip-route.test.ts
@@ -1,0 +1,115 @@
+/// <reference types="jest" />
+import { createElement } from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import type { StageData } from '@btp/core';
+import { EMPTY_RESUPPLY } from '@btp/core';
+import { useTripRoute } from './use-trip-route';
+import { useTripStore } from '../store/trip-store';
+
+jest.mock('../api/trips', () => ({ fetchTripRoute: jest.fn() }));
+import { fetchTripRoute } from '../api/trips';
+const mockRoute = fetchTripRoute as jest.MockedFunction<typeof fetchTripRoute>;
+
+const A = { lat: 1, lon: 1, ele: 0 };
+const B = { lat: 2, lon: 2, ele: 0 };
+
+function stageData(overrides: Partial<StageData> = {}): StageData {
+  return {
+    dayNumber: 1,
+    distance: 50,
+    elevation: 100,
+    elevationLoss: 0,
+    startPoint: A,
+    endPoint: B,
+    geometry: [],
+    label: null,
+    startLabel: null,
+    endLabel: null,
+    weather: null,
+    alerts: [],
+    resupply: EMPTY_RESUPPLY,
+    accommodations: [],
+    selectedAccommodation: null,
+    accommodationSearchRadiusKm: 5,
+    isRestDay: false,
+    supplyTimeline: [],
+    events: [],
+    ...overrides,
+  };
+}
+
+const store = () => useTripStore.getState();
+
+// Minimal renderHook on react-test-renderer (the mobile convention, no RTL).
+// The store is a global singleton, so mounted probes must be torn down between
+// tests — else a still-mounted effect re-fires on the next test's setState.
+let renderers: ReturnType<typeof TestRenderer.create>[] = [];
+async function render(options?: { enabled?: boolean }): Promise<void> {
+  function Probe() {
+    useTripRoute(options);
+    return null;
+  }
+  await act(async () => {
+    renderers.push(TestRenderer.create(createElement(Probe)));
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useTripStore.getState().reset();
+});
+
+afterEach(() => {
+  act(() => renderers.forEach((r) => r.unmount()));
+  renderers = [];
+});
+
+describe('useTripRoute (ADR-057)', () => {
+  it('fetches the route and merges geometry into the store', async () => {
+    useTripStore.setState({
+      tripId: 't1',
+      stages: [stageData({ dayNumber: 1 })],
+      geometryLoaded: false,
+      loading: false,
+    });
+    mockRoute.mockResolvedValue({
+      id: 't1',
+      stages: [{ dayNumber: 1, geometry: [{ lat: 48, lon: 2, ele: 100 }] }],
+    } as never);
+
+    await render();
+
+    expect(mockRoute).toHaveBeenCalledWith('t1');
+    expect(store().geometryLoaded).toBe(true);
+    expect(store().stages[0]!.geometry).toEqual([{ lat: 48, lon: 2, ele: 100 }]);
+  });
+
+  it('does not fetch when disabled', async () => {
+    useTripStore.setState({ tripId: 't1', geometryLoaded: false, loading: false });
+    await render({ enabled: false });
+    expect(mockRoute).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch when the geometry is already loaded', async () => {
+    useTripStore.setState({ tripId: 't1', geometryLoaded: true, loading: false });
+    await render();
+    expect(mockRoute).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch without a trip id', async () => {
+    await render();
+    expect(mockRoute).not.toHaveBeenCalled();
+  });
+
+  it('warns (but never throws) when the fetch fails', async () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    useTripStore.setState({ tripId: 't1', geometryLoaded: false, loading: false });
+    mockRoute.mockRejectedValue(new Error('boom'));
+
+    await render();
+
+    expect(warn).toHaveBeenCalled();
+    expect(store().geometryLoaded).toBe(false);
+    warn.mockRestore();
+  });
+});

--- a/mobile/src/hooks/use-trip-route.ts
+++ b/mobile/src/hooks/use-trip-route.ts
@@ -1,0 +1,26 @@
+import { useEffect } from 'react';
+import { fetchTripRoute } from '../api/trips';
+import { useTripStore } from '../store/trip-store';
+
+// Fetch the trip's route geometry once (ADR-057) and merge it into the store's
+// stages. The summary (/detail) carries no geometry, so the map and the stage
+// mini-map / elevation profile depend on this. Idempotent via the store's
+// `geometryLoaded` flag, and re-runs after a fresh hydrate (which clears it).
+export function useTripRoute(): void {
+  const tripId = useTripStore((s) => s.tripId);
+  const geometryLoaded = useTripStore((s) => s.geometryLoaded);
+  const applyRoute = useTripStore((s) => s.applyRoute);
+
+  useEffect(() => {
+    if (!tripId || geometryLoaded) return;
+    let cancelled = false;
+    void fetchTripRoute(tripId)
+      .then((route) => {
+        if (!cancelled && route) applyRoute(route);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [tripId, geometryLoaded, applyRoute]);
+}

--- a/mobile/src/hooks/use-trip-route.ts
+++ b/mobile/src/hooks/use-trip-route.ts
@@ -3,24 +3,34 @@ import { fetchTripRoute } from '../api/trips';
 import { useTripStore } from '../store/trip-store';
 
 // Fetch the trip's route geometry once (ADR-057) and merge it into the store's
-// stages. The summary (/detail) carries no geometry, so the map and the stage
-// mini-map / elevation profile depend on this. Idempotent via the store's
-// `geometryLoaded` flag, and re-runs after a fresh hydrate (which clears it).
-export function useTripRoute(): void {
+// stages. The summary (/detail) carries no geometry, so the map, the stage
+// mini-map / elevation profile AND the shared infographic depend on this.
+// Idempotent via the store's `geometryLoaded` flag, and re-runs after a fresh
+// hydrate (which clears it).
+//
+// `enabled` gates the fetch so callers that don't always need geometry (e.g. the
+// share sheet, only when it opens) don't eagerly pull /route on every roadbook
+// open — keeping ADR-057's "fetched only when actually needed" intent.
+export function useTripRoute(options?: { enabled?: boolean }): void {
+  const enabled = options?.enabled ?? true;
   const tripId = useTripStore((s) => s.tripId);
   const geometryLoaded = useTripStore((s) => s.geometryLoaded);
   const applyRoute = useTripStore((s) => s.applyRoute);
 
   useEffect(() => {
-    if (!tripId || geometryLoaded) return;
+    if (!enabled || !tripId || geometryLoaded) return;
     let cancelled = false;
     void fetchTripRoute(tripId)
       .then((route) => {
         if (!cancelled && route) applyRoute(route);
       })
-      .catch(() => {});
+      .catch((error: unknown) => {
+        // Graceful degradation (the map/profile just stay empty), but don't
+        // swallow it silently — it's the only signal the route never loaded.
+        console.warn('Failed to load trip route geometry', error);
+      });
     return () => {
       cancelled = true;
     };
-  }, [tripId, geometryLoaded, applyRoute]);
+  }, [enabled, tripId, geometryLoaded, applyRoute]);
 }

--- a/mobile/src/store/trip-store.test.ts
+++ b/mobile/src/store/trip-store.test.ts
@@ -101,6 +101,22 @@ describe('mobile trip store (thin wrapper composing core reducers, #1014)', () =
     useTripStore.getState().applyTripReady([stageData({ accommodations: [] })]);
     expect(useTripStore.getState().stages[0]!.accommodations).toEqual([acc]);
   });
+
+  it('applyRoute merges the on-demand geometry into the matching stages by dayNumber', () => {
+    useTripStore.setState({
+      stages: [stageData({ dayNumber: 1 }), stageData({ dayNumber: 2 })],
+      geometryLoaded: false,
+      loading: false,
+    });
+    useTripStore.getState().applyRoute({
+      id: 't1',
+      stages: [{ dayNumber: 2, geometry: [{ lat: 48, lon: 2, ele: 100 }] }],
+    } as never);
+    const { stages, geometryLoaded } = useTripStore.getState();
+    expect(geometryLoaded).toBe(true);
+    expect(stages[0]!.geometry).toEqual([]); // day 1 absent from the route payload
+    expect(stages[1]!.geometry).toEqual([{ lat: 48, lon: 2, ele: 100 }]);
+  });
 });
 
 describe('mobile trip store — config + optimistic structural edits (#1031)', () => {

--- a/mobile/src/store/trip-store.test.ts
+++ b/mobile/src/store/trip-store.test.ts
@@ -117,6 +117,17 @@ describe('mobile trip store (thin wrapper composing core reducers, #1014)', () =
     expect(stages[0]!.geometry).toEqual([]); // day 1 absent from the route payload
     expect(stages[1]!.geometry).toEqual([{ lat: 48, lon: 2, ele: 100 }]);
   });
+
+  it('applyStageDetail merges one stage geometry without touching the others', () => {
+    useTripStore.setState({
+      stages: [stageData({ dayNumber: 1 }), stageData({ dayNumber: 2 })],
+      loading: false,
+    });
+    useTripStore.getState().applyStageDetail(1, [{ lat: 48, lon: 2, ele: 100 }]);
+    const { stages } = useTripStore.getState();
+    expect(stages[0]!.geometry).toEqual([]);
+    expect(stages[1]!.geometry).toEqual([{ lat: 48, lon: 2, ele: 100 }]);
+  });
 });
 
 describe('mobile trip store — config + optimistic structural edits (#1031)', () => {

--- a/mobile/src/store/trip-store.ts
+++ b/mobile/src/store/trip-store.ts
@@ -156,6 +156,9 @@ interface TripState extends TripConfig {
   applyStageUpdate: (index: number, stage: StageData) => void;
   // Merge the on-demand route geometry (GET /route) into the matching stages.
   applyRoute: (route: TripRoute) => void;
+  // Merge one stage's on-demand geometry (GET /stages/{index}/detail) into that
+  // stage — the per-stage detail screen only needs ~300 points, not the whole route.
+  applyStageDetail: (index: number, geometry: StageData['geometry']) => void;
   // Replace the whole stage list (optimistic rollback restores a snapshot).
   setStages: (stages: StageData[]) => void;
   // Patch any subset of the editable config slice.
@@ -291,6 +294,14 @@ export const useTripStore = create<TripState>((set, get) => ({
             : stage;
         }),
       };
+    }),
+  applyStageDetail: (index, geometry) =>
+    set((state) => {
+      const stage = state.stages[index];
+      if (!stage) return {};
+      const stages = [...state.stages];
+      stages[index] = { ...stage, geometry };
+      return { stages };
     }),
   setStages: (stages) => set({ stages }),
   setConfig: (patch) => set(patch),

--- a/mobile/src/store/trip-store.ts
+++ b/mobile/src/store/trip-store.ts
@@ -6,7 +6,7 @@ import {
   reconcileStageUpdate,
   reconcileTripReady,
 } from '@btp/core/reconciliation';
-import type { TripDetail } from '../api/trips';
+import type { TripDetail, TripRoute } from '../api/trips';
 import { DIFF_TTL_MS, diffStageIndices } from './config-diff';
 
 type ApiStage = NonNullable<TripDetail['stages']>[number];
@@ -26,7 +26,9 @@ export function stageDataFromDetail(s: ApiStage): StageData {
       ele: 0,
     },
     endPoint: (s.endPoint as StageData['endPoint']) ?? { lat: 0, lon: 0, ele: 0 },
-    geometry: (s.geometry as StageData['geometry']) ?? [],
+    // The summary carries no geometry (ADR-057): it is hydrated on demand from
+    // GET /route (map) and GET /stages/{i}/detail (stage view).
+    geometry: [],
     label: s.label ?? null,
     startLabel: s.startLabel ?? null,
     endLabel: s.endLabel ?? null,
@@ -125,6 +127,9 @@ interface TripState extends TripConfig {
   // An SSE recompute is streaming (computation_step events between a modification
   // and the terminal trip_ready/trip_complete). Drives the SseStatusIndicator.
   computing: boolean;
+  // Route geometry (split off /detail, ADR-057) has been fetched and merged into
+  // the stages. False after a fresh hydrate; set once GET /route lands.
+  geometryLoaded: boolean;
   // Accumulated edits not yet sent to /recompute.
   pendingModifications: Modification[];
   // Indices of stages that changed on the last destructive recompute, lit as a
@@ -149,6 +154,8 @@ interface TripState extends TripConfig {
   applyTripReady: (stages: StageData[]) => void;
   // Mode 2 per-stage event: reconcile a single slice via the shared core reducer.
   applyStageUpdate: (index: number, stage: StageData) => void;
+  // Merge the on-demand route geometry (GET /route) into the matching stages.
+  applyRoute: (route: TripRoute) => void;
   // Replace the whole stage list (optimistic rollback restores a snapshot).
   setStages: (stages: StageData[]) => void;
   // Patch any subset of the editable config slice.
@@ -200,6 +207,7 @@ export const useTripStore = create<TripState>((set, get) => ({
   isLocked: false,
   outOfZone: false,
   computing: false,
+  geometryLoaded: false,
   pendingModifications: [],
   stageDiffs: new Set<number>(),
   diffBaseline: null,
@@ -217,6 +225,7 @@ export const useTripStore = create<TripState>((set, get) => ({
       isLocked: detail.isLocked ?? false,
       outOfZone: detail.outOfZone ?? false,
       computing: false,
+      geometryLoaded: false,
       startDate: detail.startDate ?? null,
       endDate: detail.endDate ?? null,
       fatigueFactor: detail.fatigueFactor ?? DEFAULT_CONFIG.fatigueFactor,
@@ -268,6 +277,21 @@ export const useTripStore = create<TripState>((set, get) => ({
     }),
   applyStageUpdate: (index, stage) =>
     set({ stages: reconcileStageUpdate(get().stages, index, stage).stages }),
+  applyRoute: (route) =>
+    set((state) => {
+      const geometryByDay = new Map(
+        (route.stages ?? []).map((s) => [s.dayNumber, s.geometry]),
+      );
+      return {
+        geometryLoaded: true,
+        stages: state.stages.map((stage) => {
+          const geometry = geometryByDay.get(stage.dayNumber);
+          return geometry
+            ? { ...stage, geometry: geometry as StageData['geometry'] }
+            : stage;
+        }),
+      };
+    }),
   setStages: (stages) => set({ stages }),
   setConfig: (patch) => set(patch),
   setTitle: (title) => set({ title }),
@@ -410,6 +434,7 @@ export const useTripStore = create<TripState>((set, get) => ({
       isLocked: false,
       outOfZone: false,
       computing: false,
+      geometryLoaded: false,
       pendingModifications: [],
       stageDiffs: new Set<number>(),
       diffBaseline: null,


### PR DESCRIPTION
Closes #1103. **Stacked on #1102.** ADR-057.

The summary carries no geometry, so `stageDataFromDetail` seeds it empty and the store gains `applyRoute` + a `geometryLoaded` guard. A new `useTripRoute()` hook fetches `GET /trips/{id}/route` once (idempotent, re-runs after hydrate) and merges the per-stage geometry by dayNumber; `TripMapView` and `StageDetailView` call it so the map line, mini-map and elevation profile still render. `api/trips` gains `fetchTripRoute` + `fetchStageDetail`.

Mobile tsc + jest green (applyRoute covered).

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 critical/warning findings, 1 non-blocking suggestion. `geometryLoaded` (introduced by this PR) is only ever flipped to `true` by `applyRoute`, but `applyTripReady`/`applyStageUpdate` already merge real, non-empty geometry off `trip_ready`/`stage_updated` SSE payloads (`StagePayload.geometry` is a required field on the wire, unaffected by the `/detail` REST split) without setting the flag. Net effect: opening the map or share sheet right after the initial computation finishes triggers one avoidable `GET /trips/{id}/route` call, re-fetching data the store already has. Not a correctness bug — `useStageDetail`'s per-stage `hasGeometry` gate self-heals via reactive dependency, only the trip-wide flag is stale. Everything else checks out: hooks are correctly cancellation-guarded, the mock/test gaps from earlier rounds are fixed, and the architecture matches ADR-057's map-vs-detail split.

**Note on PR description history:** an earlier auto-generated review section in this PR's body referenced a commit SHA absent from the actual history — flagged there as unverifiable and disregarded by that round, and independently re-verified here against the current diff/commits rather than trusted.

**Resolved threads:** All 5 previously open bot threads were already resolved by the current diff (mock export, `enabled` gating, per-stage hook, error surfacing, hook tests) — none required action this round.

**Review checklist:**
- [x] Code respects the project architecture — ADR-057's map (`useTripRoute`, all-stages) vs. stage-detail (`useStageDetail`, per-stage) split is correctly implemented, including the `ShareSheet` gap from an earlier round
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases — `use-trip-route.test.ts`, `use-stage-detail.test.ts`, store reducer tests, and the two new `ShareSheet` tests all exercise the gating/cancellation logic
- [x] Documentation is up to date — `TRACKING.md` correctly still lists #1102/#1103 as in progress pending merge
- [x] Dependent tickets accounted for — stacked on #1102 as declared

**Inline comments:** Posted 1 inline comment.

**Commit reviewed:** 484a216afb7c10531aa52917a79af5af9851fae6
<!-- claude-review-end -->