### PR TITLE
feat(pwa): progressive geometry hydration + public shared /route (#1104)

### DIFF
--- a/api/src/Entity/TripShare.php
+++ b/api/src/Entity/TripShare.php
@@ -14,6 +14,7 @@ use ApiPlatform\OpenApi\Model\Operation;
 use App\ApiResource\Stage;
 use App\ApiResource\Trip;
 use App\ApiResource\TripDetail;
+use App\ApiResource\TripRoute;
 use App\ApiResource\TripRequest;
 use App\Repository\TripShareRepository;
 use App\State\TripShareCreateProcessor;
@@ -21,6 +22,7 @@ use App\State\TripShareCreateProvider;
 use App\State\TripShareDeleteProcessor;
 use App\State\TripShareGpxProvider;
 use App\State\TripShareProvider;
+use App\State\TripShareRouteProvider;
 use App\State\TripShareShortCodeProvider;
 use App\State\TripShareStageProvider;
 use Doctrine\ORM\Mapping as ORM;
@@ -92,6 +94,15 @@ use Symfony\Component\Uid\Uuid;
             security: 'is_granted("PUBLIC_ACCESS")',
             output: Trip::class,
             provider: TripShareGpxProvider::class, // format-agnostic: also serves .fit
+        ),
+        new Get(
+            uriTemplate: '/s/{shortCode}/route',
+            uriVariables: ['shortCode' => new Link(fromClass: TripShare::class, identifiers: ['shortCode'])],
+            requirements: ['shortCode' => '[A-Za-z0-9_-]+'],
+            openapi: new Operation(summary: 'All-stages geometry for a shared trip (anonymous).'),
+            security: 'is_granted("PUBLIC_ACCESS")',
+            output: TripRoute::class,
+            provider: TripShareRouteProvider::class,
         ),
         new Get(
             uriTemplate: '/s/{shortCode}/stages/{index}{._format}',

--- a/api/src/State/TripShareRouteProvider.php
+++ b/api/src/State/TripShareRouteProvider.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProviderInterface;
+use App\ApiResource\TripRequest;
+use App\ApiResource\TripRoute;
+use App\Entity\TripShare;
+use App\Repository\TripShareRepositoryInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Resolves a short code to the shared trip's route geometry (anonymous). The
+ * public snapshot has no auth token, so it cannot call the authenticated
+ * GET /route; this mirrors it via the short code (ADR-057).
+ *
+ * @implements ProviderInterface<TripRoute>
+ */
+final readonly class TripShareRouteProvider implements ProviderInterface
+{
+    public function __construct(
+        private TripShareRepositoryInterface $tripShareRepository,
+        /** @var ProviderInterface<TripRoute> */
+        #[Autowire(service: TripRouteProvider::class)]
+        private ProviderInterface $tripRouteProvider,
+    ) {
+    }
+
+    /**
+     * @param array{shortCode?: string} $uriVariables
+     * @param array<string, mixed>      $context
+     */
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): TripRoute
+    {
+        $shortCode = $uriVariables['shortCode'] ?? '';
+
+        $share = '' !== $shortCode ? $this->tripShareRepository->findByShortCode($shortCode) : null;
+        if (!$share instanceof TripShare) {
+            throw new NotFoundHttpException('Shared trip not found.');
+        }
+
+        $trip = $share->getTrip();
+        if (!$trip instanceof TripRequest) {
+            throw new NotFoundHttpException('Shared trip not found.');
+        }
+
+        $route = $this->tripRouteProvider->provide($operation, ['id' => (string) $trip->id], $context);
+        \assert($route instanceof TripRoute);
+
+        return $route;
+    }
+}

--- a/api/tests/Unit/State/TripShareRouteProviderTest.php
+++ b/api/tests/Unit/State/TripShareRouteProviderTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\State;
+
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\State\ProviderInterface;
+use App\ApiResource\TripRequest;
+use App\ApiResource\TripRoute;
+use App\Entity\TripShare;
+use App\Repository\TripShareRepositoryInterface;
+use App\State\TripShareRouteProvider;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Uid\Uuid;
+
+#[AllowMockObjectsWithoutExpectations]
+final class TripShareRouteProviderTest extends TestCase
+{
+    private MockObject&TripShareRepositoryInterface $repository;
+
+    /** @var MockObject&ProviderInterface<TripRoute> */
+    private MockObject $tripRouteProvider;
+
+    private TripShareRouteProvider $provider;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->repository = $this->createMock(TripShareRepositoryInterface::class);
+        $this->tripRouteProvider = $this->createMock(ProviderInterface::class);
+        $this->provider = new TripShareRouteProvider($this->repository, $this->tripRouteProvider);
+    }
+
+    #[Test]
+    public function itReturnsRouteForValidShortCode(): void
+    {
+        $tripId = Uuid::v7();
+        $trip = new TripRequest($tripId);
+        $share = new TripShare(trip: $trip);
+
+        $this->repository->expects($this->once())->method('findByShortCode')
+            ->with('Ab3kX9mP')
+            ->willReturn($share);
+
+        $route = new TripRoute((string) $tripId, []);
+        $this->tripRouteProvider->expects($this->once())->method('provide')
+            ->with($this->anything(), ['id' => (string) $tripId])
+            ->willReturn($route);
+
+        $result = $this->provider->provide(new Get(), ['shortCode' => 'Ab3kX9mP']);
+
+        self::assertSame($route, $result);
+    }
+
+    #[Test]
+    public function itThrowsNotFoundForInvalidShortCode(): void
+    {
+        $this->repository->expects($this->once())->method('findByShortCode')->willReturn(null);
+
+        $this->expectException(NotFoundHttpException::class);
+        $this->provider->provide(new Get(), ['shortCode' => 'invalid1']);
+    }
+
+    #[Test]
+    public function itThrowsNotFoundForEmptyShortCode(): void
+    {
+        $this->repository->expects($this->never())->method('findByShortCode');
+
+        $this->expectException(NotFoundHttpException::class);
+        $this->provider->provide(new Get(), []);
+    }
+
+    #[Test]
+    public function itThrowsNotFoundWhenShareHasNoTrip(): void
+    {
+        $share = new TripShare();
+        $this->repository->expects($this->once())->method('findByShortCode')->willReturn($share);
+        $this->tripRouteProvider->expects($this->never())->method('provide');
+
+        $this->expectException(NotFoundHttpException::class);
+        $this->provider->provide(new Get(), ['shortCode' => 'Ab3kX9mP']);
+    }
+}

--- a/core/schema.d.ts
+++ b/core/schema.d.ts
@@ -660,6 +660,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/s/{shortCode}/route": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * All-stages geometry for a shared trip (anonymous).
+         * @description All-stages geometry for a shared trip (anonymous).
+         */
+        get: operations["api_s_shortCoderoute_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/s/{shortCode}/stages/{index}": {
         parameters: {
             query?: never;
@@ -1980,6 +2000,17 @@ export interface components {
                     possibleClosed?: boolean;
                     distanceToEndPoint?: number;
                 } | null;
+            }[];
+        };
+        "TripShare.TripRoute.jsonld": components["schemas"]["HydraItemBaseSchema"] & {
+            id?: string;
+            stages?: {
+                dayNumber?: number;
+                geometry?: {
+                    lat?: number;
+                    lon?: number;
+                    ele?: number;
+                }[];
             }[];
         };
         "TripShare.jsonld": components["schemas"]["HydraItemBaseSchema"] & {
@@ -4003,6 +4034,51 @@ export interface operations {
                 };
                 content: {
                     "application/gpx+xml": components["schemas"]["TripShare.Trip.gpx"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["Error.jsonld"];
+                    "application/problem+json": components["schemas"]["Error"];
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["Error.jsonld"];
+                    "application/problem+json": components["schemas"]["Error"];
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    api_s_shortCoderoute_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description TripShare identifier */
+                shortCode: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description TripShare resource */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["TripShare.TripRoute.jsonld"];
                 };
             };
             /** @description Forbidden */

--- a/pwa/src/app/(app)/trips/[id]/trip-page.tsx
+++ b/pwa/src/app/(app)/trips/[id]/trip-page.tsx
@@ -145,7 +145,7 @@ function TripLoader({ tripId }: { tripId: string }) {
       // Pull the route geometry split off /detail (ADR-057) and merge it in.
       void fetchTripRoute(tripId)
         .then((route) => {
-          if (route) useTripStore.getState().applyRoute(route);
+          if (!cancelled && route) useTripStore.getState().applyRoute(route);
         })
         .catch(() => {});
 

--- a/pwa/src/app/(app)/trips/[id]/trip-page.tsx
+++ b/pwa/src/app/(app)/trips/[id]/trip-page.tsx
@@ -14,7 +14,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { HydrationBoundary } from "@/components/hydration-boundary";
 import { useTripStore } from "@/store/trip-store";
 import { useUiStore } from "@/store/ui-store";
-import { apiFetch } from "@/lib/api/client";
+import { apiFetch, fetchTripRoute } from "@/lib/api/client";
 import { API_URL } from "@/lib/constants";
 import { resolveStageLabels } from "@/hooks/use-mercure";
 import { EMPTY_RESUPPLY } from "@btp/core";
@@ -112,7 +112,8 @@ function TripLoader({ tripId }: { tripId: string }) {
             lon: 0,
             ele: 0,
           },
-          geometry: (s.geometry as StageData["geometry"]) ?? [],
+          // Summary carries no geometry (ADR-057); fetched via GET /route.
+          geometry: [],
           label: s.label ?? null,
           startLabel: s.startLabel ?? null,
           endLabel: s.endLabel ?? null,
@@ -141,6 +142,12 @@ function TripLoader({ tripId }: { tripId: string }) {
       });
 
       setStages(stages);
+      // Pull the route geometry split off /detail (ADR-057) and merge it in.
+      void fetchTripRoute(tripId)
+        .then((route) => {
+          if (route) useTripStore.getState().applyRoute(route);
+        })
+        .catch(() => {});
 
       if (stages.length > 0) {
         const totalDistance = stages

--- a/pwa/src/app/s/[code]/shared-trip-page.tsx
+++ b/pwa/src/app/s/[code]/shared-trip-page.tsx
@@ -14,7 +14,7 @@ import { HydrationBoundary } from "@/components/hydration-boundary";
 import { SiteChrome } from "@/components/site-chrome";
 import { SharedViewBanner } from "@/components/shared-view-banner";
 import { TripDownloads } from "@/components/trip-downloads";
-import { fetchSharedTrip } from "@/lib/api/client";
+import { fetchSharedTrip, fetchSharedTripRoute } from "@/lib/api/client";
 import { ShareProvider } from "@/lib/share-context";
 import { useUiStore } from "@/store/ui-store";
 import { useTripStore } from "@/store/trip-store";
@@ -85,7 +85,8 @@ function SharedTripLoader({ code }: { code: string }) {
             lon: 0,
             ele: 0,
           },
-          geometry: (s.geometry as StageData["geometry"]) ?? [],
+          // Summary carries no geometry (ADR-057); fetched via GET /route.
+          geometry: [],
           label: (s.label as string) ?? null,
           // Server-persisted reverse-geocoded labels (recette #649 #3c): the
           // anonymous shared view cannot call the auth-gated /geocode endpoint,
@@ -107,6 +108,12 @@ function SharedTripLoader({ code }: { code: string }) {
         }));
 
         setStages(parsedStages);
+        // Pull the route geometry (split off /detail, ADR-057) via the public code.
+        void fetchSharedTripRoute(code)
+          .then((route) => {
+            if (route) useTripStore.getState().applyRoute(route);
+          })
+          .catch(() => {});
         // Hydrate the trip store so that <RoadbookMasterDetail /> (which
         // reads `selectedStageIndex` from the store) works correctly. The
         // store stays local — no `setTrip()` call means no API/PATCH calls

--- a/pwa/src/app/s/[code]/shared-trip-page.tsx
+++ b/pwa/src/app/s/[code]/shared-trip-page.tsx
@@ -109,9 +109,26 @@ function SharedTripLoader({ code }: { code: string }) {
 
         setStages(parsedStages);
         // Pull the route geometry (split off /detail, ADR-057) via the public code.
+        // The page renders this component's local `stages` state, so the geometry
+        // must land there too — the store's applyRoute alone never reaches the map
+        // / elevation profile on the anonymous view.
         void fetchSharedTripRoute(code)
           .then((route) => {
-            if (route) useTripStore.getState().applyRoute(route);
+            if (cancelled || !route) return;
+            useTripStore.getState().applyRoute(route);
+            const geometryByDay = new Map(
+              (route.stages ?? []).map((s) => [
+                s.dayNumber,
+                (s.geometry ?? []) as StageData["geometry"],
+              ]),
+            );
+            setStages((prev) =>
+              prev.map((s) =>
+                geometryByDay.has(s.dayNumber)
+                  ? { ...s, geometry: geometryByDay.get(s.dayNumber)! }
+                  : s,
+              ),
+            );
           })
           .catch(() => {});
         // Hydrate the trip store so that <RoadbookMasterDetail /> (which

--- a/pwa/src/lib/api/client.ts
+++ b/pwa/src/lib/api/client.ts
@@ -855,6 +855,29 @@ export async function fetchSharedTrip(
   return res.json() as Promise<SharedTripDetail>;
 }
 
+// All-stages geometry, split off the trip summary (ADR-057), fetched on demand.
+export type TripRoute = components["schemas"]["TripRoute.jsonld"];
+
+export async function fetchTripRoute(id: string): Promise<TripRoute | null> {
+  const { data, error } = await apiClient.GET("/trips/{id}/route", {
+    params: { path: { id } },
+  });
+  if (error) return null;
+  return data ?? null;
+}
+
+// Public counterpart for the anonymous shared view (no auth token).
+export async function fetchSharedTripRoute(
+  shortCode: string,
+): Promise<TripRoute | null> {
+  const res = await fetch(
+    `${API_URL}/s/${encodeURIComponent(shortCode)}/route`,
+    { headers: { Accept: "application/ld+json" } },
+  );
+  if (!res.ok) return null;
+  return res.json() as Promise<TripRoute>;
+}
+
 /**
  * Download a shared trip as GPX or FIT via short code (anonymous).
  */

--- a/pwa/src/store/trip-store.test.ts
+++ b/pwa/src/store/trip-store.test.ts
@@ -631,3 +631,23 @@ describe("default enabled accommodation types", () => {
     expect(enabled).toEqual([...FILTERABLE_ACCOMMODATION_TYPES]);
   });
 });
+
+describe("applyRoute (ADR-057 geometry hydration)", () => {
+  it("merges the on-demand geometry into the matching stages by dayNumber", () => {
+    useTripStore.setState({ stages: [makeStage(1), makeStage(2)] });
+    useTripStore.getState().applyRoute({
+      stages: [{ dayNumber: 2, geometry: [{ lat: 48, lon: 2, ele: 100 }] }],
+    });
+    const { stages } = useTripStore.getState();
+    expect(stages[0]!.geometry).toEqual([]); // day 1 absent from the payload
+    expect(stages[1]!.geometry).toEqual([{ lat: 48, lon: 2, ele: 100 }]);
+  });
+
+  it("coerces optional coordinate fields to numbers", () => {
+    useTripStore.setState({ stages: [makeStage(1)] });
+    useTripStore.getState().applyRoute({ stages: [{ dayNumber: 1, geometry: [{ lat: 48 }] }] });
+    expect(useTripStore.getState().stages[0]!.geometry).toEqual([
+      { lat: 48, lon: 0, ele: 0 },
+    ]);
+  });
+});

--- a/pwa/src/store/trip-store.ts
+++ b/pwa/src/store/trip-store.ts
@@ -125,6 +125,14 @@ interface TripState {
     sourceType: string;
     title: string | null;
   }) => void;
+  // Merge the on-demand route geometry (GET /route, split off /detail — ADR-057)
+  // into the matching stages by dayNumber.
+  applyRoute: (route: {
+    stages?: {
+      dayNumber?: number;
+      geometry?: { lat?: number; lon?: number; ele?: number }[];
+    }[];
+  }) => void;
   setStages: (stages: StageData[]) => void;
   updateStageWeather: (dayNumber: number, weather: WeatherData) => void;
   updateStageResupply: (stageIndex: number, resupply: ResupplyData) => void;
@@ -398,6 +406,24 @@ export const useTripStore = create<TripState>()(
         state.sourceType = data.sourceType;
         if (data.title && state.trip) {
           state.trip.title = data.title;
+        }
+      }),
+
+    applyRoute: (route) =>
+      set((state) => {
+        const geometryByDay = new Map(
+          (route.stages ?? []).map((s) => [
+            s.dayNumber,
+            (s.geometry ?? []).map((p) => ({
+              lat: p.lat ?? 0,
+              lon: p.lon ?? 0,
+              ele: p.ele ?? 0,
+            })),
+          ]),
+        );
+        for (const stage of state.stages) {
+          const geometry = geometryByDay.get(stage.dayNumber);
+          if (geometry) stage.geometry = geometry;
         }
       }),
 


### PR DESCRIPTION
Closes #1104. **Top of the stack (on #1103).** ADR-057.

Web mirror of the mobile split: trip-page + the anonymous shared page seed empty stage geometry and fetch it separately, merging via a new store `applyRoute` (by dayNumber).
- api client: `fetchTripRoute` (auth) + `fetchSharedTripRoute` (public).
- backend: `GET /s/{shortCode}/route` (`TripShareRouteProvider`) so the token-free shared snapshot — which reuses TripDetailProvider and thus lost geometry — can pull it without the authenticated /route.

Web tsc + 458 vitest green; PHPStan L9 + TripShare/TripDetail Functional green. Merging this completes the atomic /detail replacement.

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 critical findings, 0 warning findings, 1 non-blocking suggestion. Both bugs flagged in earlier rounds remain fixed and verified against the current head (`0cdf5610f`): `trip-page.tsx`'s `fetchTripRoute` continuation checks the effect's `cancelled` flag before calling `applyRoute`, and `shared-trip-page.tsx` merges the fetched geometry into its local `stages` state (not just the Zustand store), which is what `MapPanel`/`RoadbookMasterDetail` actually render on the anonymous view. `TripShareRouteProvider` mirrors the established `TripShareGpxProvider` pattern exactly (short-code resolution via `findByShortCode`, which already excludes soft-deleted shares; 404 on unknown/empty code or a share with no trip; delegates to `TripRouteProvider` without re-checking `TRIP_VIEW`, same as the GPX sibling delegates to `TripGpxProvider`), and the `GET /s/{shortCode}/route` ApiResource wiring matches the sibling short-code endpoints (`PUBLIC_ACCESS`, `[A-Za-z0-9_-]+` shortCode). Backend behavior is covered by `TripShareRouteProviderTest` (valid/unknown/empty/no-trip cases); frontend merge logic is covered by `applyRoute` store tests (merge-by-dayNumber + coordinate coercion).

**Suggestion (test-coverage):** `pwa/tests/fixtures/api-mocks.ts` (`mockAllApis`) has no `page.route()` handler for the new `GET /trips/*/route` or `GET /s/*/route` endpoints. Every mocked Playwright spec that renders `trip-page.tsx` or `shared-trip-page.tsx` (e.g. `trip-detail.spec.ts`, `share-page.spec.ts`) will now fire a real, unmocked request for stage geometry on every load; `fetchTripRoute`/`fetchSharedTripRoute` swallow the failure (`.catch(() => {})`), so the spec still passes but map/elevation-profile geometry rendering is silently untested end-to-end (existing mocks like `MOCK_STAGES` embed `geometry` directly on `/detail`, which the app no longer reads). Worth adding a `/route` handler to the shared fixture in a follow-up so geometry-dependent assertions stay meaningful.

**Resolved threads:** All 3 previously open threads were already resolved prior to this review — no action needed this round.

**PR title check:** `feat(pwa): progressive geometry hydration + public shared /route (#1104)` — the description still reads as a noun phrase rather than imperative mood (e.g. `add progressive geometry hydration + public shared /route`), and folds the issue reference into the title itself rather than the body's `Closes #1104`.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

**Commit reviewed:** 0cdf5610f835a0a37491659e55636cfcbe66b5b6
<!-- claude-review-end -->
