### PR TITLE
feat(api): register FCM device tokens for the current user

### DIFF
--- a/api/migrations/Version20260819120000.php
+++ b/api/migrations/Version20260819120000.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Creates the device_token table (push-notification registration, epic #1051).
+ *
+ * One row per FCM token, globally unique so a device is bound to a single account
+ * at a time. FK to `user` with ON DELETE CASCADE: erasing an account drops its
+ * device tokens.
+ */
+final class Version20260819120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create device_token table (push-notification registration, epic #1051)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE device_token (
+            id uuid NOT NULL,
+            user_id uuid NOT NULL,
+            token character varying(255) NOT NULL,
+            platform character varying(255) NOT NULL,
+            created_at timestamp(0) without time zone NOT NULL,
+            PRIMARY KEY (id)
+        )');
+        $this->addSql('CREATE UNIQUE INDEX uniq_device_token_token ON device_token (token)');
+        $this->addSql('CREATE INDEX idx_device_token_user ON device_token (user_id)');
+        $this->addSql("COMMENT ON COLUMN device_token.created_at IS '(DC2Type:datetime_immutable)'");
+        $this->addSql('ALTER TABLE device_token ADD CONSTRAINT fk_device_token_user FOREIGN KEY (user_id) REFERENCES "user" (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE device_token');
+    }
+}

--- a/api/src/ApiResource/Account/DeviceToken.php
+++ b/api/src/ApiResource/Account/DeviceToken.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ApiResource\Account;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Delete;
+use ApiPlatform\Metadata\Post;
+use App\Enum\DevicePlatform;
+use App\State\Account\DeviceTokenDeleteProcessor;
+use App\State\Account\DeviceTokenRegisterProcessor;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * Push-notification device-token registration for the authenticated user (epic #1051).
+ *
+ * - POST   /users/me/device-tokens         idempotent upsert of an FCM token bound
+ *   to the current user (re-registering the same token does not duplicate; a token
+ *   held by another account is reassigned). 201 on create, 200 on update.
+ * - DELETE /users/me/device-tokens/{token}  unregister a token owned by the current
+ *   user (a token owned by someone else, or unknown, is masked as 404 per ADR-038).
+ *
+ * The current user is always resolved from the security token, never from a URL
+ * identifier (no IDOR surface).
+ */
+#[ApiResource(
+    shortName: 'DeviceToken',
+    operations: [
+        new Post(
+            uriTemplate: '/users/me/device-tokens',
+            security: "is_granted('ROLE_USER')",
+            output: false,
+            read: false,
+            processor: DeviceTokenRegisterProcessor::class,
+        ),
+        new Delete(
+            uriTemplate: '/users/me/device-tokens/{token}',
+            status: 204,
+            security: "is_granted('ROLE_USER')",
+            output: false,
+            read: false,
+            processor: DeviceTokenDeleteProcessor::class,
+        ),
+    ],
+)]
+final class DeviceToken
+{
+    public function __construct(
+        #[ApiProperty(identifier: true)]
+        #[Assert\NotBlank]
+        #[Assert\Length(max: 255)]
+        public string $token = '',
+        #[Assert\NotNull]
+        public ?DevicePlatform $platform = null,
+        public ?\DateTimeImmutable $createdAt = null,
+    ) {
+    }
+}

--- a/api/src/ApiResource/Account/DeviceToken.php
+++ b/api/src/ApiResource/Account/DeviceToken.php
@@ -22,10 +22,13 @@ use Symfony\Component\Validator\Constraints as Assert;
  *   to the current user (re-registering the same token does not duplicate; a token
  *   held by another account is reassigned). 201 on create, 200 on update.
  * - DELETE /users/me/device-tokens/{token}  unregister a token owned by the current
- *   user (a token owned by someone else, or unknown, is masked as 404 per ADR-038).
+ *   user. The lookup is scoped to the caller's own tokens, so an unknown or foreign
+ *   token is simply "not found" -> 404 (no object-level authorization to mask).
  *
  * The current user is always resolved from the security token, never from a URL
- * identifier (no IDOR surface).
+ * identifier (no IDOR surface). The delete carries the token in the URL path as the
+ * resource identifier — a semi-sensitive value that lands in access logs, an
+ * accepted trade-off (see DeviceTokenDeleteProcessor).
  */
 #[ApiResource(
     shortName: 'DeviceToken',

--- a/api/src/ApiResource/Account/DeviceToken.php
+++ b/api/src/ApiResource/Account/DeviceToken.php
@@ -8,6 +8,8 @@ use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Delete;
 use ApiPlatform\Metadata\Post;
+use ApiPlatform\OpenApi\Model\Operation;
+use ApiPlatform\OpenApi\Model\Response;
 use App\Enum\DevicePlatform;
 use App\State\Account\DeviceTokenDeleteProcessor;
 use App\State\Account\DeviceTokenRegisterProcessor;
@@ -30,6 +32,47 @@ use Symfony\Component\Validator\Constraints as Assert;
     operations: [
         new Post(
             uriTemplate: '/users/me/device-tokens',
+            // The register processor returns 201 on create and 200 on re-register;
+            // this is the create-path default. Without it API Platform documents
+            // the output:false operation as 204 No Content — wrong on both the
+            // status and the JSON body the typed clients (pwa/mobile) consume.
+            status: 201,
+            openapi: new Operation(
+                responses: [
+                    '201' => new Response(
+                        description: 'Device token registered',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'schema' => [
+                                    'type' => 'object',
+                                    'properties' => [
+                                        'token' => ['type' => 'string'],
+                                        'platform' => ['type' => 'string', 'enum' => ['android', 'ios']],
+                                        'createdAt' => ['type' => 'string', 'format' => 'date-time'],
+                                    ],
+                                ],
+                            ],
+                        ]),
+                    ),
+                    '200' => new Response(
+                        description: 'Device token re-registered (platform refreshed / reassigned)',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'schema' => [
+                                    'type' => 'object',
+                                    'properties' => [
+                                        'token' => ['type' => 'string'],
+                                        'platform' => ['type' => 'string', 'enum' => ['android', 'ios']],
+                                        'createdAt' => ['type' => 'string', 'format' => 'date-time'],
+                                    ],
+                                ],
+                            ],
+                        ]),
+                    ),
+                    '422' => new Response(description: 'Missing or unknown platform'),
+                    '409' => new Response(description: 'Concurrent registration of the same token; retry'),
+                ],
+            ),
             security: "is_granted('ROLE_USER')",
             output: false,
             read: false,

--- a/api/src/Entity/DeviceToken.php
+++ b/api/src/Entity/DeviceToken.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Enum\DevicePlatform;
+use App\Repository\DeviceTokenRepository;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * A push-notification device token registered by a user (epic #1051).
+ *
+ * One row per physical FCM token. The token is globally unique: a device can only
+ * be bound to a single account at a time, so re-registering a token already held
+ * by another user reassigns it (see DeviceTokenRegisterProcessor).
+ */
+#[ORM\Entity(repositoryClass: DeviceTokenRepository::class)]
+#[ORM\Table(name: 'device_token')]
+#[ORM\UniqueConstraint(name: 'uniq_device_token_token', columns: ['token'])]
+#[ORM\Index(name: 'idx_device_token_user', columns: ['user_id'])]
+class DeviceToken
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'uuid')]
+    private Uuid $id;
+
+    #[ORM\Column]
+    private \DateTimeImmutable $createdAt;
+
+    public function __construct(
+        #[ORM\ManyToOne(targetEntity: User::class)]
+        #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+        private User $user,
+        #[ORM\Column(length: 255)]
+        private string $token,
+        #[ORM\Column(enumType: DevicePlatform::class)]
+        private DevicePlatform $platform,
+        ?Uuid $id = null,
+    ) {
+        $this->id = $id ?? Uuid::v7();
+        $this->createdAt = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getUser(): User
+    {
+        return $this->user;
+    }
+
+    public function setUser(User $user): self
+    {
+        $this->user = $user;
+
+        return $this;
+    }
+
+    public function getToken(): string
+    {
+        return $this->token;
+    }
+
+    public function getPlatform(): DevicePlatform
+    {
+        return $this->platform;
+    }
+
+    public function setPlatform(DevicePlatform $platform): self
+    {
+        $this->platform = $platform;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+}

--- a/api/src/Enum/DevicePlatform.php
+++ b/api/src/Enum/DevicePlatform.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enum;
+
+enum DevicePlatform: string
+{
+    case ANDROID = 'android';
+    case IOS = 'ios';
+}

--- a/api/src/Repository/DeviceTokenRepository.php
+++ b/api/src/Repository/DeviceTokenRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Repository;
 
 use App\Entity\DeviceToken;
+use App\Entity\User;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -21,5 +22,10 @@ final class DeviceTokenRepository extends ServiceEntityRepository implements Dev
     public function findOneByToken(string $token): ?DeviceToken
     {
         return $this->findOneBy(['token' => $token]);
+    }
+
+    public function findOneOwnedByUser(string $token, User $user): ?DeviceToken
+    {
+        return $this->findOneBy(['token' => $token, 'user' => $user]);
     }
 }

--- a/api/src/Repository/DeviceTokenRepository.php
+++ b/api/src/Repository/DeviceTokenRepository.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\DeviceToken;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<DeviceToken>
+ */
+final class DeviceTokenRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, DeviceToken::class);
+    }
+
+    public function findOneByToken(string $token): ?DeviceToken
+    {
+        return $this->findOneBy(['token' => $token]);
+    }
+}

--- a/api/src/Repository/DeviceTokenRepository.php
+++ b/api/src/Repository/DeviceTokenRepository.php
@@ -11,7 +11,7 @@ use Doctrine\Persistence\ManagerRegistry;
 /**
  * @extends ServiceEntityRepository<DeviceToken>
  */
-final class DeviceTokenRepository extends ServiceEntityRepository
+final class DeviceTokenRepository extends ServiceEntityRepository implements DeviceTokenRepositoryInterface
 {
     public function __construct(ManagerRegistry $registry)
     {

--- a/api/src/Repository/DeviceTokenRepositoryInterface.php
+++ b/api/src/Repository/DeviceTokenRepositoryInterface.php
@@ -5,8 +5,16 @@ declare(strict_types=1);
 namespace App\Repository;
 
 use App\Entity\DeviceToken;
+use App\Entity\User;
 
 interface DeviceTokenRepositoryInterface
 {
     public function findOneByToken(string $token): ?DeviceToken;
+
+    /**
+     * The given token, but only if it belongs to the given user. Scopes the lookup
+     * to the caller's own tokens so the delete path never reasons about foreign
+     * tokens (no object-level authorization to mask — see DeviceTokenDeleteProcessor).
+     */
+    public function findOneOwnedByUser(string $token, User $user): ?DeviceToken;
 }

--- a/api/src/Repository/DeviceTokenRepositoryInterface.php
+++ b/api/src/Repository/DeviceTokenRepositoryInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\DeviceToken;
+
+interface DeviceTokenRepositoryInterface
+{
+    public function findOneByToken(string $token): ?DeviceToken;
+}

--- a/api/src/State/Account/DeviceTokenDeleteProcessor.php
+++ b/api/src/State/Account/DeviceTokenDeleteProcessor.php
@@ -20,10 +20,20 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 /**
  * Unregisters an FCM device token owned by the current user (epic #1051).
  *
- * The token is resolved from the URL, never from a body. A token that does not
- * exist OR belongs to another account is masked as 404 (ADR-038): object-level
- * authorization failures are indistinguishable from a missing resource, so a
- * caller cannot probe which tokens exist for other users.
+ * Like every other `/users/me` operation, the resource is scoped to the current
+ * user resolved from the security token: the lookup only ever considers the
+ * caller's own tokens (`findOneOwnedByUser`), so a token that is unknown OR owned
+ * by someone else is simply "not among your tokens" -> 404. There is no
+ * object-level authorization decision here to mask, so this does not scatter the
+ * ADR-038 policy into a processor (which that ADR rejects); a non-owner still
+ * cannot tell a foreign token from a missing one, and a foreign token is never
+ * touched.
+ *
+ * The token rides in the URL path as the resource identifier. It is a
+ * semi-sensitive per-device value, so it lands in access logs — an accepted
+ * trade-off (there is no exposure without an attacker already holding the token);
+ * the alternative, a body-carrying unregister action, is not worth the divergence
+ * from REST identity here.
  *
  * @implements ProcessorInterface<DeviceTokenResource, JsonResponse>
  */
@@ -47,11 +57,11 @@ final readonly class DeviceTokenDeleteProcessor implements ProcessorInterface
 
         $token = $uriVariables['token'] ?? '';
         \assert(\is_string($token));
-        $deviceToken = $this->deviceTokenRepository->findOneByToken($token);
 
-        // Unknown token or one owned by another account: both masked as 404 so a
-        // non-owner cannot distinguish the two (ADR-038).
-        if (!$deviceToken instanceof DeviceToken || !$deviceToken->getUser()->getId()->equals($user->getId())) {
+        // Scoped to the caller's own tokens: unknown or foreign both resolve to null
+        // -> 404, without the processor ever comparing owners.
+        $deviceToken = $this->deviceTokenRepository->findOneOwnedByUser($token, $user);
+        if (!$deviceToken instanceof DeviceToken) {
             throw new NotFoundHttpException();
         }
 

--- a/api/src/State/Account/DeviceTokenDeleteProcessor.php
+++ b/api/src/State/Account/DeviceTokenDeleteProcessor.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\State\Account;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\ApiResource\Account\DeviceToken as DeviceTokenResource;
+use App\Entity\DeviceToken;
+use App\Entity\User;
+use App\Repository\DeviceTokenRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Unregisters an FCM device token owned by the current user (epic #1051).
+ *
+ * The token is resolved from the URL, never from a body. A token that does not
+ * exist OR belongs to another account is masked as 404 (ADR-038): object-level
+ * authorization failures are indistinguishable from a missing resource, so a
+ * caller cannot probe which tokens exist for other users.
+ *
+ * @implements ProcessorInterface<DeviceTokenResource, JsonResponse>
+ */
+final readonly class DeviceTokenDeleteProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private Security $security,
+        private EntityManagerInterface $entityManager,
+        private DeviceTokenRepository $deviceTokenRepository,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @param DeviceTokenResource $data
+     */
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): JsonResponse
+    {
+        $user = $this->security->getUser();
+        \assert($user instanceof User);
+
+        $token = $uriVariables['token'] ?? '';
+        \assert(\is_string($token));
+        $deviceToken = $this->deviceTokenRepository->findOneByToken($token);
+
+        // Unknown token or one owned by another account: both masked as 404 so a
+        // non-owner cannot distinguish the two (ADR-038).
+        if (!$deviceToken instanceof DeviceToken || !$deviceToken->getUser()->getId()->equals($user->getId())) {
+            throw new NotFoundHttpException();
+        }
+
+        $this->entityManager->remove($deviceToken);
+        $this->entityManager->flush();
+
+        $this->logger->info('Device token unregistered', ['user' => $user->getId()->toRfc4122()]);
+
+        return new JsonResponse(null, Response::HTTP_NO_CONTENT);
+    }
+}

--- a/api/src/State/Account/DeviceTokenDeleteProcessor.php
+++ b/api/src/State/Account/DeviceTokenDeleteProcessor.php
@@ -9,7 +9,7 @@ use ApiPlatform\State\ProcessorInterface;
 use App\ApiResource\Account\DeviceToken as DeviceTokenResource;
 use App\Entity\DeviceToken;
 use App\Entity\User;
-use App\Repository\DeviceTokenRepository;
+use App\Repository\DeviceTokenRepositoryInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
@@ -32,7 +32,7 @@ final readonly class DeviceTokenDeleteProcessor implements ProcessorInterface
     public function __construct(
         private Security $security,
         private EntityManagerInterface $entityManager,
-        private DeviceTokenRepository $deviceTokenRepository,
+        private DeviceTokenRepositoryInterface $deviceTokenRepository,
         private LoggerInterface $logger,
     ) {
     }

--- a/api/src/State/Account/DeviceTokenRegisterProcessor.php
+++ b/api/src/State/Account/DeviceTokenRegisterProcessor.php
@@ -9,7 +9,7 @@ use ApiPlatform\State\ProcessorInterface;
 use App\ApiResource\Account\DeviceToken as DeviceTokenResource;
 use App\Entity\DeviceToken;
 use App\Entity\User;
-use App\Repository\DeviceTokenRepository;
+use App\Repository\DeviceTokenRepositoryInterface;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
@@ -33,7 +33,7 @@ final readonly class DeviceTokenRegisterProcessor implements ProcessorInterface
     public function __construct(
         private Security $security,
         private EntityManagerInterface $entityManager,
-        private DeviceTokenRepository $deviceTokenRepository,
+        private DeviceTokenRepositoryInterface $deviceTokenRepository,
         private LoggerInterface $logger,
     ) {
     }

--- a/api/src/State/Account/DeviceTokenRegisterProcessor.php
+++ b/api/src/State/Account/DeviceTokenRegisterProcessor.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\State\Account;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\ApiResource\Account\DeviceToken as DeviceTokenResource;
+use App\Entity\DeviceToken;
+use App\Entity\User;
+use App\Repository\DeviceTokenRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Idempotent upsert of an FCM device token for the current user (epic #1051).
+ *
+ * Registering a token the current user already holds updates its platform in
+ * place (200, no duplicate). A token globally unknown is created (201). A token
+ * currently bound to ANOTHER account is reassigned to the current user (200):
+ * one physical device belongs to a single account at a time.
+ *
+ * @implements ProcessorInterface<DeviceTokenResource, JsonResponse>
+ */
+final readonly class DeviceTokenRegisterProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private Security $security,
+        private EntityManagerInterface $entityManager,
+        private DeviceTokenRepository $deviceTokenRepository,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @param DeviceTokenResource $data
+     */
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): JsonResponse
+    {
+        $user = $this->security->getUser();
+        \assert($user instanceof User);
+        \assert(null !== $data->platform);
+
+        $deviceToken = $this->deviceTokenRepository->findOneByToken($data->token);
+
+        if ($deviceToken instanceof DeviceToken) {
+            // Re-registration: refresh the platform and (re)bind to the current
+            // user. Same user + same platform is a no-op that still returns 200.
+            $deviceToken->setUser($user)->setPlatform($data->platform);
+            $status = Response::HTTP_OK;
+        } else {
+            $deviceToken = new DeviceToken($user, $data->token, $data->platform);
+            $this->entityManager->persist($deviceToken);
+            $status = Response::HTTP_CREATED;
+        }
+
+        $this->entityManager->flush();
+
+        $this->logger->info('Device token registered', ['user' => $user->getId()->toRfc4122(), 'platform' => $data->platform->value]);
+
+        return new JsonResponse(
+            [
+                'token' => $deviceToken->getToken(),
+                'platform' => $deviceToken->getPlatform()->value,
+                'createdAt' => $deviceToken->getCreatedAt()->format(\DateTimeInterface::ATOM),
+            ],
+            $status,
+        );
+    }
+}

--- a/api/src/State/Account/DeviceTokenRegisterProcessor.php
+++ b/api/src/State/Account/DeviceTokenRegisterProcessor.php
@@ -10,11 +10,13 @@ use App\ApiResource\Account\DeviceToken as DeviceTokenResource;
 use App\Entity\DeviceToken;
 use App\Entity\User;
 use App\Repository\DeviceTokenRepository;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
 
 /**
  * Idempotent upsert of an FCM device token for the current user (epic #1051).
@@ -58,7 +60,16 @@ final readonly class DeviceTokenRegisterProcessor implements ProcessorInterface
             $status = Response::HTTP_CREATED;
         }
 
-        $this->entityManager->flush();
+        try {
+            $this->entityManager->flush();
+        } catch (UniqueConstraintViolationException) {
+            // A concurrent request inserted the same token between the lookup and
+            // this flush. The endpoint is idempotent, so a retry resolves to the
+            // update path — surface a 409 rather than a 500.
+            $this->logger->debug('Device token registration lost a concurrent-create race', ['user' => $user->getId()->toRfc4122()]);
+
+            throw new ConflictHttpException('Device token registration conflicted with a concurrent request; retry.');
+        }
 
         $this->logger->info('Device token registered', ['user' => $user->getId()->toRfc4122(), 'platform' => $data->platform->value]);
 

--- a/api/tests/Functional/Account/DeviceTokenTest.php
+++ b/api/tests/Functional/Account/DeviceTokenTest.php
@@ -175,8 +175,9 @@ final class DeviceTokenTest extends ApiTestCase
     #[Test]
     public function deleteTokenOfAnotherUserReturns404AndDoesNotDeleteIt(): void
     {
-        // Object-level authorization is masked as 404, never 403 (ADR-038): a
-        // non-owner cannot distinguish a foreign token from a missing one.
+        // The delete is scoped to the caller's own tokens, so a foreign token is
+        // "not found" -> 404 (indistinguishable from a missing one) and is never
+        // touched.
         $owner = $this->createUser('token-owner@example.com');
         $attacker = $this->createUser('token-attacker@example.com');
         $this->persistToken($owner['user'], 'fcm-not-yours', DevicePlatform::ANDROID);

--- a/api/tests/Functional/Account/DeviceTokenTest.php
+++ b/api/tests/Functional/Account/DeviceTokenTest.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Account;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\DeviceToken;
+use App\Entity\User;
+use App\Enum\DevicePlatform;
+use Doctrine\ORM\EntityManagerInterface;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+use Zenstruck\Foundry\Test\Factories;
+
+#[ResetDatabase]
+final class DeviceTokenTest extends ApiTestCase
+{
+    use Factories;
+
+    #[\Override]
+    public static function setUpBeforeClass(): void
+    {
+        self::$alwaysBootKernel = false;
+    }
+
+    private function getEntityManager(): EntityManagerInterface
+    {
+        return self::getContainer()->get('doctrine.orm.entity_manager');
+    }
+
+    /**
+     * @param non-empty-string $email
+     *
+     * @return array{user: User, jwt: string}
+     */
+    private function createUser(string $email): array
+    {
+        $em = $this->getEntityManager();
+
+        $user = new User($email);
+        $em->persist($user);
+        $em->flush();
+
+        /** @var JWTTokenManagerInterface $jwtManager */
+        $jwtManager = self::getContainer()->get('lexik_jwt_authentication.jwt_manager');
+
+        return ['user' => $user, 'jwt' => $jwtManager->create($user)];
+    }
+
+    private function persistToken(User $user, string $token, DevicePlatform $platform): DeviceToken
+    {
+        $em = $this->getEntityManager();
+        $entity = new DeviceToken($user, $token, $platform);
+        $em->persist($entity);
+        $em->flush();
+
+        return $entity;
+    }
+
+    private function countTokens(): int
+    {
+        return $this->getEntityManager()->getRepository(DeviceToken::class)->count([]);
+    }
+
+    #[Test]
+    public function registerNewTokenReturns201(): void
+    {
+        $fixtures = $this->createUser('register@example.com');
+
+        $response = self::createClient()->request('POST', '/users/me/device-tokens', [
+            'headers' => ['Content-Type' => 'application/ld+json', 'Authorization' => 'Bearer '.$fixtures['jwt']],
+            'json' => ['token' => 'fcm-token-abc', 'platform' => 'android'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(201);
+
+        $body = $response->toArray(false);
+        $this->assertSame('fcm-token-abc', $body['token']);
+        $this->assertSame('android', $body['platform']);
+        // createdAt is stored and rendered in UTC (offset +00:00), regardless of
+        // the server timezone (CI runs Europe/Paris).
+        $this->assertStringEndsWith('+00:00', $body['createdAt']);
+
+        $this->assertSame(1, $this->countTokens());
+    }
+
+    #[Test]
+    public function reRegisterSameTokenReturns200AndDoesNotDuplicate(): void
+    {
+        $fixtures = $this->createUser('reregister@example.com');
+        $this->persistToken($fixtures['user'], 'fcm-dupe', DevicePlatform::ANDROID);
+
+        self::createClient()->request('POST', '/users/me/device-tokens', [
+            'headers' => ['Content-Type' => 'application/ld+json', 'Authorization' => 'Bearer '.$fixtures['jwt']],
+            'json' => ['token' => 'fcm-dupe', 'platform' => 'ios'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertSame(1, $this->countTokens(), 're-registering the same token must not duplicate');
+
+        $em = $this->getEntityManager();
+        $em->clear();
+
+        $reloaded = $em->getRepository(DeviceToken::class)->findOneBy(['token' => 'fcm-dupe']);
+        $this->assertInstanceOf(DeviceToken::class, $reloaded);
+        $this->assertSame(DevicePlatform::IOS, $reloaded->getPlatform(), 'platform must be updated in place');
+    }
+
+    #[Test]
+    public function reRegisterTokenOfAnotherUserReassignsIt(): void
+    {
+        $owner = $this->createUser('previous-owner@example.com');
+        $newOwner = $this->createUser('new-owner@example.com');
+        $this->persistToken($owner['user'], 'fcm-shared-device', DevicePlatform::ANDROID);
+
+        self::createClient()->request('POST', '/users/me/device-tokens', [
+            'headers' => ['Content-Type' => 'application/ld+json', 'Authorization' => 'Bearer '.$newOwner['jwt']],
+            'json' => ['token' => 'fcm-shared-device', 'platform' => 'android'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertSame(1, $this->countTokens());
+
+        $em = $this->getEntityManager();
+        $em->clear();
+
+        $reloaded = $em->getRepository(DeviceToken::class)->findOneBy(['token' => 'fcm-shared-device']);
+        $this->assertInstanceOf(DeviceToken::class, $reloaded);
+        $this->assertTrue($reloaded->getUser()->getId()->equals($newOwner['user']->getId()), 'token must be reassigned to the new owner');
+    }
+
+    #[Test]
+    public function registerRequiresAuthentication(): void
+    {
+        self::createClient()->request('POST', '/users/me/device-tokens', [
+            'headers' => ['Content-Type' => 'application/ld+json'],
+            'json' => ['token' => 'fcm-anon', 'platform' => 'android'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(401);
+    }
+
+    #[Test]
+    public function registerWithUnknownPlatformReturns422(): void
+    {
+        // An unknown backed-enum value fails denormalization and surfaces as 422
+        // (a validation violation), never 400 (ADR / API Platform 4.3 contract).
+        $fixtures = $this->createUser('bad-platform@example.com');
+
+        self::createClient()->request('POST', '/users/me/device-tokens', [
+            'headers' => ['Content-Type' => 'application/ld+json', 'Authorization' => 'Bearer '.$fixtures['jwt']],
+            'json' => ['token' => 'fcm-bad', 'platform' => 'windows-phone'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+        $this->assertSame(0, $this->countTokens());
+    }
+
+    #[Test]
+    public function deleteReturns204(): void
+    {
+        $fixtures = $this->createUser('unregister@example.com');
+        $this->persistToken($fixtures['user'], 'fcm-to-delete', DevicePlatform::IOS);
+
+        self::createClient()->request('DELETE', '/users/me/device-tokens/fcm-to-delete', [
+            'headers' => ['Authorization' => 'Bearer '.$fixtures['jwt']],
+        ]);
+
+        $this->assertResponseStatusCodeSame(204);
+        $this->assertSame(0, $this->countTokens());
+    }
+
+    #[Test]
+    public function deleteTokenOfAnotherUserReturns404AndDoesNotDeleteIt(): void
+    {
+        // Object-level authorization is masked as 404, never 403 (ADR-038): a
+        // non-owner cannot distinguish a foreign token from a missing one.
+        $owner = $this->createUser('token-owner@example.com');
+        $attacker = $this->createUser('token-attacker@example.com');
+        $this->persistToken($owner['user'], 'fcm-not-yours', DevicePlatform::ANDROID);
+
+        self::createClient()->request('DELETE', '/users/me/device-tokens/fcm-not-yours', [
+            'headers' => ['Authorization' => 'Bearer '.$attacker['jwt']],
+        ]);
+
+        $this->assertResponseStatusCodeSame(404);
+
+        // The foreign token must survive: the rightful owner can still use it.
+        $em = $this->getEntityManager();
+        $em->clear();
+        $this->assertNotNull($em->getRepository(DeviceToken::class)->findOneBy(['token' => 'fcm-not-yours']), 'a foreign token must never be deleted by a non-owner');
+    }
+
+    #[Test]
+    public function deleteUnknownTokenReturns404(): void
+    {
+        $fixtures = $this->createUser('delete-unknown@example.com');
+
+        self::createClient()->request('DELETE', '/users/me/device-tokens/fcm-does-not-exist', [
+            'headers' => ['Authorization' => 'Bearer '.$fixtures['jwt']],
+        ]);
+
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    #[Test]
+    public function deleteRequiresAuthentication(): void
+    {
+        self::createClient()->request('DELETE', '/users/me/device-tokens/fcm-anon');
+
+        $this->assertResponseStatusCodeSame(401);
+    }
+}

--- a/api/tests/Unit/State/DeviceTokenRegisterProcessorTest.php
+++ b/api/tests/Unit/State/DeviceTokenRegisterProcessorTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\State;
+
+use ApiPlatform\Metadata\Post;
+use App\ApiResource\Account\DeviceToken as DeviceTokenResource;
+use App\Entity\User;
+use App\Enum\DevicePlatform;
+use App\Repository\DeviceTokenRepositoryInterface;
+use App\State\Account\DeviceTokenRegisterProcessor;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
+
+#[AllowMockObjectsWithoutExpectations]
+final class DeviceTokenRegisterProcessorTest extends TestCase
+{
+    private MockObject&Security $security;
+
+    private MockObject&EntityManagerInterface $entityManager;
+
+    private MockObject&DeviceTokenRepositoryInterface $deviceTokenRepository;
+
+    private DeviceTokenRegisterProcessor $processor;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->security = $this->createMock(Security::class);
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+        $this->deviceTokenRepository = $this->createMock(DeviceTokenRepositoryInterface::class);
+
+        $this->processor = new DeviceTokenRegisterProcessor(
+            $this->security,
+            $this->entityManager,
+            $this->deviceTokenRepository,
+            $this->createStub(LoggerInterface::class),
+        );
+    }
+
+    #[Test]
+    public function itThrows409OnConcurrentInsertRaceCondition(): void
+    {
+        $this->security->method('getUser')->willReturn(new User('race@example.com'));
+
+        // No token found: the processor takes the create path and persists a new row.
+        $this->deviceTokenRepository->expects($this->once())->method('findOneByToken')->willReturn(null);
+        $this->entityManager->expects($this->once())->method('persist');
+
+        // A concurrent request inserted the same token first: flush hits the unique
+        // constraint. The processor must translate it to a 409, not let a 500 leak.
+        $uniqueException = $this->getMockBuilder(UniqueConstraintViolationException::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->entityManager->expects($this->once())->method('flush')->willThrowException($uniqueException);
+
+        $this->expectException(ConflictHttpException::class);
+        $this->processor->process(new DeviceTokenResource('fcm-race', DevicePlatform::ANDROID), new Post());
+    }
+}

--- a/core/schema.d.ts
+++ b/core/schema.d.ts
@@ -188,6 +188,46 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/users/me/device-tokens": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Creates a DeviceToken resource.
+         * @description Creates a DeviceToken resource.
+         */
+        post: operations["api_usersmedevice-tokens_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/users/me/device-tokens/{token}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Removes the DeviceToken resource.
+         * @description Removes the DeviceToken resource.
+         */
+        delete: operations["api_usersmedevice-tokens_token_delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/users/me/email-change": {
         parameters: {
             query?: never;
@@ -1025,6 +1065,25 @@ export interface components {
             lat?: number;
             lon?: number;
             ele?: number;
+        };
+        /**
+         * @description Push-notification device-token registration for the authenticated user (epic #1051).
+         *
+         *     - POST   /users/me/device-tokens         idempotent upsert of an FCM token bound
+         *       to the current user (re-registering the same token does not duplicate; a token
+         *       held by another account is reassigned). 201 on create, 200 on update.
+         *     - DELETE /users/me/device-tokens/{token}  unregister a token owned by the current
+         *       user (a token owned by someone else, or unknown, is masked as 404 per ADR-038).
+         *
+         *     The current user is always resolved from the security token, never from a URL
+         *     identifier (no IDOR surface).
+         */
+        DeviceToken: {
+            token: string;
+            /** @enum {string|null} */
+            platform: "android" | "ios" | null;
+            /** Format: date-time */
+            createdAt?: string | null;
         };
         /**
          * @description Email-change-by-magic-link flow for the authenticated user (#777).
@@ -2570,6 +2629,105 @@ export interface operations {
                     "application/ld+json": components["schemas"]["ConstraintViolation.jsonld"];
                     "application/problem+json": components["schemas"]["ConstraintViolation"];
                     "application/json": components["schemas"]["ConstraintViolation"];
+                };
+            };
+        };
+    };
+    "api_usersmedevice-tokens_post": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description The new DeviceToken resource */
+        requestBody: {
+            content: {
+                "application/ld+json": components["schemas"]["DeviceToken"];
+            };
+        };
+        responses: {
+            /** @description DeviceToken resource created */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Invalid input */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["Error.jsonld"];
+                    "application/problem+json": components["schemas"]["Error"];
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["Error.jsonld"];
+                    "application/problem+json": components["schemas"]["Error"];
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description An error occurred */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["ConstraintViolation.jsonld"];
+                    "application/problem+json": components["schemas"]["ConstraintViolation"];
+                    "application/json": components["schemas"]["ConstraintViolation"];
+                };
+            };
+        };
+    };
+    "api_usersmedevice-tokens_token_delete": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description DeviceToken identifier */
+                token: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description DeviceToken resource deleted */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["Error.jsonld"];
+                    "application/problem+json": components["schemas"]["Error"];
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["Error.jsonld"];
+                    "application/problem+json": components["schemas"]["Error"];
+                    "application/json": components["schemas"]["Error"];
                 };
             };
         };

--- a/core/schema.d.ts
+++ b/core/schema.d.ts
@@ -1073,10 +1073,13 @@ export interface components {
          *       to the current user (re-registering the same token does not duplicate; a token
          *       held by another account is reassigned). 201 on create, 200 on update.
          *     - DELETE /users/me/device-tokens/{token}  unregister a token owned by the current
-         *       user (a token owned by someone else, or unknown, is masked as 404 per ADR-038).
+         *       user. The lookup is scoped to the caller's own tokens, so an unknown or foreign
+         *       token is simply "not found" -> 404 (no object-level authorization to mask).
          *
          *     The current user is always resolved from the security token, never from a URL
-         *     identifier (no IDOR surface).
+         *     identifier (no IDOR surface). The delete carries the token in the URL path as the
+         *     resource identifier — a semi-sensitive value that lands in access logs, an
+         *     accepted trade-off (see DeviceTokenDeleteProcessor).
          */
         DeviceToken: {
             token: string;

--- a/core/schema.d.ts
+++ b/core/schema.d.ts
@@ -2647,12 +2647,35 @@ export interface operations {
             };
         };
         responses: {
-            /** @description DeviceToken resource created */
-            204: {
+            /** @description Device token re-registered (platform refreshed / reassigned) */
+            200: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": {
+                        token?: string;
+                        /** @enum {string} */
+                        platform?: "android" | "ios";
+                        /** Format: date-time */
+                        createdAt?: string;
+                    };
+                };
+            };
+            /** @description Device token registered */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        token?: string;
+                        /** @enum {string} */
+                        platform?: "android" | "ios";
+                        /** Format: date-time */
+                        createdAt?: string;
+                    };
+                };
             };
             /** @description Invalid input */
             400: {
@@ -2676,7 +2699,14 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
-            /** @description An error occurred */
+            /** @description Concurrent registration of the same token; retry */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Missing or unknown platform */
             422: {
                 headers: {
                     [name: string]: unknown;


### PR DESCRIPTION
Ferme #1122. Fondation de l'épic #1051 (push FCM).

## Résumé
- Entité `DeviceToken` (uuid v7, token unique, platform enum, ManyToOne User, createdAt) + repository + migration.
- ApiResource `Account/DeviceToken` : `POST /users/me/device-tokens` (upsert idempotent 201/200), `DELETE /users/me/device-tokens/{token}` (204).
- Processors register/delete liés à l'utilisateur courant.
- Enum `DevicePlatform` (android|ios).

## Contrat de test
- Non-owner → **404** (ADR-038), jamais 403 (prouvé par sabotage/restore de la garde).
- `platform` inconnu → **422** (denormalization enum).
- Dates en UTC explicite (CI Europe/Paris).

## Vérification
- PHPStan L9 : OK. PHPUnit : 1373 tests OK (dont 9 device-token). CS-Fixer/Rector : clean.
- `core/schema.d.ts` régénéré (ADR-053/055).

## Auto-critique
- Le sender FCM et le câblage des catégories arrivent dans #1123/#1124 (stack).

<!-- claude-review-start -->
## Claude Review

**Summary:** The final commit (`15e23171`) regenerates `core/schema.d.ts`, and it now matches the current `DeviceToken` ApiResource docblock word-for-word, closing the one finding left open from the previous round. No new correctness, security, performance, or architecture issues found in this round; the device-token upsert/reassign design, the ADR-038-compliant scoped-lookup delete (avoiding a voter entirely rather than masking an `AccessDeniedException`), and the 409-on-race handling are all sound and covered by tests.

**Resolved threads:** Resolved 1 previously open thread (`core/schema.d.ts` staleness relative to the `041af0b` docblock rewrite — confirmed fixed by `15e23171`).

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

Commit reviewed: 15e23171037ae8b6c58eee175490e3a0279eac73
<!-- claude-review-end -->