### PR TITLE
feat(mobile): flux changement d'email

### DIFF
--- a/mobile/app.config.js
+++ b/mobile/app.config.js
@@ -22,7 +22,10 @@ module.exports = ({ config }) => ({
       {
         action: 'VIEW',
         autoVerify: true,
-        data: [{ scheme: 'https', host: appLinkHost(), pathPrefix: '/auth/verify' }],
+        data: [
+          { scheme: 'https', host: appLinkHost(), pathPrefix: '/auth/verify' },
+          { scheme: 'https', host: appLinkHost(), pathPrefix: '/account/email-change/verify' },
+        ],
         category: ['BROWSABLE', 'DEFAULT'],
       },
     ],

--- a/mobile/app/account/email-change/verify/[token].tsx
+++ b/mobile/app/account/email-change/verify/[token].tsx
@@ -14,7 +14,8 @@ import { verifyEmailChange } from '../../../../src/hooks/use-email-change';
 // {token}, RequestEmailChangeProcessor) and the PWA route of the same name.
 // The link is sent to the NEW address; opening it while authenticated commits the
 // change (single-use token, atomic server-side). On success the account email is
-// refreshed via GET /users/me so the account screen reflects the new address.
+// refreshed via GET /users/me (best-effort) so the account screen reflects the
+// new address; a refresh failure never masks the successful verification.
 export default function VerifyEmailChangeScreen() {
   const { token } = useLocalSearchParams<{ token: string }>();
   const { refreshEmail } = useAuth();
@@ -30,16 +31,26 @@ export default function VerifyEmailChangeScreen() {
     }
     handled.current = true;
     void (async () => {
+      // Only a verify failure is a real error. A post-verify refreshEmail() throw
+      // (network) must NOT surface as "verification failed" — the email is already
+      // changed server-side; the stale display self-heals on the next mount.
+      let verified: boolean;
       try {
-        if (await verifyEmailChange(token)) {
-          await refreshEmail();
-          router.replace('/(tabs)/account');
-        } else {
-          setFailed(true);
-        }
+        verified = await verifyEmailChange(token);
       } catch {
         setFailed(true);
+        return;
       }
+      if (!verified) {
+        setFailed(true);
+        return;
+      }
+      try {
+        await refreshEmail();
+      } catch {
+        // best-effort, ignore
+      }
+      router.replace('/(tabs)/account');
     })();
   }, [token, refreshEmail, router]);
 

--- a/mobile/app/account/email-change/verify/[token].tsx
+++ b/mobile/app/account/email-change/verify/[token].tsx
@@ -8,11 +8,13 @@ import { useAuth } from '../../../../src/auth/store';
 import { verifyEmailChange } from '../../../../src/hooks/use-email-change';
 
 // Handles the email-change confirmation deep link, for both forms:
-//   App Link      : https://<host>/account/email/verify/<token>
-//   custom scheme : biketripplanner://account/email/verify/<token>
+//   App Link      : https://<host>/account/email-change/verify/<token>
+//   custom scheme : biketripplanner://account/email-change/verify/<token>
+// The path mirrors the backend link ({FRONTEND_URL}/account/email-change/verify/
+// {token}, RequestEmailChangeProcessor) and the PWA route of the same name.
 // The link is sent to the NEW address; opening it while authenticated commits the
 // change (single-use token, atomic server-side). On success the account email is
-// refreshed from the session so the account screen reflects the new address.
+// refreshed via GET /users/me so the account screen reflects the new address.
 export default function VerifyEmailChangeScreen() {
   const { token } = useLocalSearchParams<{ token: string }>();
   const { refreshEmail } = useAuth();

--- a/mobile/app/account/email.tsx
+++ b/mobile/app/account/email.tsx
@@ -1,5 +1,85 @@
-import { AccountStub } from '../../src/components/account/AccountStub';
+import { Stack } from 'expo-router';
+import { useState } from 'react';
+import { Text, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { Button, Card, Input, Screen } from '../../src/components/ui';
+import { Mail } from '../../src/components/ui/icons';
+import { useTheme } from '../../src/theme';
+import { useEmailChange } from '../../src/hooks/use-email-change';
 
 export default function AccountEmail() {
-  return <AccountStub titleKey="account.emailTitle" />;
+  const { t } = useTranslation();
+  const theme = useTheme();
+  const { busy, sent, error, submit, reset } = useEmailChange();
+  const [email, setEmail] = useState('');
+
+  return (
+    <Screen scroll>
+      <Stack.Screen options={{ headerShown: true, title: t('account.emailTitle') }} />
+      <View style={{ gap: theme.spacing.base }}>
+        <Text
+          style={{
+            color: theme.colors.mutedForeground,
+            fontFamily: theme.fonts.sans,
+            fontSize: 14,
+            lineHeight: 20,
+          }}
+        >
+          {t('account.emailChange.description')}
+        </Text>
+
+        {sent ? (
+          <Card style={{ flexDirection: 'row', gap: theme.spacing.md, alignItems: 'flex-start' }}>
+            <Mail color={theme.colors.accentInk} size={20} />
+            <View style={{ flex: 1, gap: 2 }}>
+              <Text
+                style={{
+                  color: theme.colors.foreground,
+                  fontFamily: theme.fonts.sansSemibold,
+                  fontSize: 15,
+                }}
+              >
+                {t('account.emailChange.sentTitle')}
+              </Text>
+              <Text
+                style={{
+                  color: theme.colors.mutedForeground,
+                  fontFamily: theme.fonts.sans,
+                  fontSize: 13,
+                  lineHeight: 18,
+                }}
+              >
+                {t('account.emailChange.sent', { email: email.trim() })}
+              </Text>
+            </View>
+          </Card>
+        ) : (
+          <>
+            <Input
+              label={t('account.emailChange.label')}
+              placeholder={t('account.emailChange.placeholder')}
+              value={email}
+              onChangeText={(v) => {
+                setEmail(v);
+                if (error) reset();
+              }}
+              error={error ? t('account.emailChange.error') : undefined}
+              leadingIcon={<Mail color={theme.colors.mutedForeground} size={18} />}
+              autoCapitalize="none"
+              autoCorrect={false}
+              keyboardType="email-address"
+            />
+            <Button
+              label={busy ? t('account.emailChange.submitting') : t('account.emailChange.submit')}
+              onPress={() => void submit(email.trim())}
+              loading={busy}
+              disabled={busy || email.trim().length === 0}
+              fullWidth
+              size="lg"
+            />
+          </>
+        )}
+      </View>
+    </Screen>
+  );
 }

--- a/mobile/app/account/email/verify/[token].tsx
+++ b/mobile/app/account/email/verify/[token].tsx
@@ -1,0 +1,65 @@
+import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
+import { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { AlertTriangle } from '../../../../src/components/ui/icons';
+import { ErrorState, LoadingState, Screen } from '../../../../src/components/ui';
+import { useTheme } from '../../../../src/theme';
+import { useAuth } from '../../../../src/auth/store';
+import { verifyEmailChange } from '../../../../src/hooks/use-email-change';
+
+// Handles the email-change confirmation deep link, for both forms:
+//   App Link      : https://<host>/account/email/verify/<token>
+//   custom scheme : biketripplanner://account/email/verify/<token>
+// The link is sent to the NEW address; opening it while authenticated commits the
+// change (single-use token, atomic server-side). On success the account email is
+// refreshed from the session so the account screen reflects the new address.
+export default function VerifyEmailChangeScreen() {
+  const { token } = useLocalSearchParams<{ token: string }>();
+  const { refreshEmail } = useAuth();
+  const { t } = useTranslation();
+  const theme = useTheme();
+  const router = useRouter();
+  const handled = useRef(false);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    if (handled.current || typeof token !== 'string' || token.length === 0) {
+      return;
+    }
+    handled.current = true;
+    void (async () => {
+      try {
+        if (await verifyEmailChange(token)) {
+          await refreshEmail();
+          router.replace('/(tabs)/account');
+        } else {
+          setFailed(true);
+        }
+      } catch {
+        setFailed(true);
+      }
+    })();
+  }, [token, refreshEmail, router]);
+
+  if (failed) {
+    return (
+      <Screen>
+        <Stack.Screen options={{ headerShown: false }} />
+        <ErrorState
+          icon={<AlertTriangle color={theme.colors.destructive} size={40} />}
+          title={t('account.emailChange.verifyFailedTitle')}
+          description={t('account.emailChange.verifyFailedBody')}
+          retryLabel={t('account.emailChange.backToAccount')}
+          onRetry={() => router.replace('/(tabs)/account')}
+        />
+      </Screen>
+    );
+  }
+
+  return (
+    <Screen padded={false}>
+      <Stack.Screen options={{ headerShown: false }} />
+      <LoadingState label={t('account.emailChange.verifying')} />
+    </Screen>
+  );
+}

--- a/mobile/src/auth/store.test.tsx
+++ b/mobile/src/auth/store.test.tsx
@@ -84,4 +84,37 @@ describe('AuthProvider stale-response guard (#1117)', () => {
 
     expect(captured.email).toBe('me@example.com');
   });
+
+  it('drops a refreshEmail() response that lands after logout(): email stays null', async () => {
+    mockLoadTokens.mockResolvedValue({ jwt: 'jwt', refresh: 'refresh' });
+    // Mount effect resolves immediately with the current email.
+    mockGet.mockResolvedValueOnce({ data: { email: 'me@example.com' } } as never);
+
+    await act(async () => {
+      renderer = TestRenderer.create(createElement(Wrapper, null, createElement(Consumer)));
+    });
+    expect(captured.email).toBe('me@example.com');
+
+    // A manual refreshEmail() leaves its GET /users/me in flight.
+    const pending = deferred<{ data?: { email?: string } }>();
+    mockGet.mockReturnValueOnce(pending.promise as never);
+    let refreshPromise!: Promise<void>;
+    await act(async () => {
+      refreshPromise = captured.refreshEmail();
+    });
+
+    // Log out before the refresh response comes back.
+    await act(async () => {
+      await captured.logout();
+    });
+    expect(captured.authenticated).toBe(false);
+
+    // The stale refresh response resolves — the generation guard must ignore it,
+    // so the address is not resurrected after the session ended.
+    await act(async () => {
+      pending.resolve({ data: { email: 'changed@example.com' } });
+      await refreshPromise;
+    });
+    expect(captured.email).toBeNull();
+  });
 });

--- a/mobile/src/auth/store.test.tsx
+++ b/mobile/src/auth/store.test.tsx
@@ -1,0 +1,87 @@
+/// <reference types="jest" />
+import TestRenderer, { act } from 'react-test-renderer';
+import { createElement, type ReactNode } from 'react';
+
+jest.mock('../api/client', () => ({ api: { GET: jest.fn(), POST: jest.fn() } }));
+jest.mock('./tokens', () => ({
+  loadTokens: jest.fn(),
+  clearTokens: jest.fn().mockResolvedValue(undefined),
+  getJwt: jest.fn(),
+}));
+jest.mock('./authApi', () => ({ verifyMagicToken: jest.fn() }));
+jest.mock('./session', () => ({ onSessionInvalidated: jest.fn(() => () => {}) }));
+
+import { api } from '../api/client';
+import { loadTokens } from './tokens';
+import { AuthProvider, useAuth } from './store';
+
+type AuthContextValue = ReturnType<typeof useAuth>;
+
+const mockGet = api.GET as jest.MockedFunction<typeof api.GET>;
+const mockLoadTokens = loadTokens as jest.MockedFunction<typeof loadTokens>;
+
+beforeEach(() => jest.clearAllMocks());
+
+function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void } {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+describe('AuthProvider stale-response guard (#1117)', () => {
+  let captured: AuthContextValue;
+  let renderer: ReturnType<typeof TestRenderer.create>;
+
+  function Consumer() {
+    captured = useAuth();
+    return null;
+  }
+
+  function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(AuthProvider, null, children);
+  }
+
+  afterEach(() => act(() => renderer?.unmount()));
+
+  it('drops a GET /users/me response that lands after logout(): email stays null', async () => {
+    mockLoadTokens.mockResolvedValue({ jwt: 'jwt', refresh: 'refresh' });
+    const pending = deferred<{ data?: { email?: string } }>();
+    mockGet.mockReturnValue(pending.promise as never);
+
+    await act(async () => {
+      renderer = TestRenderer.create(createElement(Wrapper, null, createElement(Consumer)));
+    });
+
+    // Authenticated → the email effect fired GET /users/me (still in flight).
+    expect(captured.authenticated).toBe(true);
+    expect(mockGet).toHaveBeenCalledWith('/users/me', { headers: { Accept: 'application/ld+json' } });
+    expect(captured.email).toBeNull();
+
+    // Log out before the profile response comes back.
+    await act(async () => {
+      await captured.logout();
+    });
+    expect(captured.authenticated).toBe(false);
+
+    // The stale profile response now resolves — the cancel guard must ignore it.
+    await act(async () => {
+      pending.resolve({ data: { email: 'stale@example.com' } });
+      await pending.promise;
+    });
+
+    expect(captured.email).toBeNull();
+  });
+
+  it('sets the email from GET /users/me while authenticated', async () => {
+    mockLoadTokens.mockResolvedValue({ jwt: 'jwt', refresh: 'refresh' });
+    mockGet.mockResolvedValue({ data: { email: 'me@example.com' } } as never);
+
+    await act(async () => {
+      renderer = TestRenderer.create(createElement(Wrapper, null, createElement(Consumer)));
+    });
+
+    expect(captured.email).toBe('me@example.com');
+  });
+});

--- a/mobile/src/auth/store.tsx
+++ b/mobile/src/auth/store.tsx
@@ -11,6 +11,7 @@ type AuthContextValue = {
   email: string | null;
   requestLink: (email: string) => Promise<boolean>;
   verify: (token: string) => Promise<boolean>;
+  refreshEmail: () => Promise<void>;
   logout: () => Promise<void>;
 };
 
@@ -69,14 +70,21 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return ok;
   }, []);
 
+  // Re-read the account email from the session — called after an email change is
+  // committed so the account screen reflects the new address without a re-login.
+  const refreshEmail = useCallback(async (): Promise<void> => {
+    const { data } = await api.GET('/auth/session', { headers: { Accept: LD_JSON } });
+    setEmail(data?.email ?? null);
+  }, []);
+
   const logout = useCallback(async (): Promise<void> => {
     await clearTokens();
     setAuthenticated(false);
   }, []);
 
   const value = useMemo<AuthContextValue>(
-    () => ({ ready, authenticated, email, requestLink, verify, logout }),
-    [ready, authenticated, email, requestLink, verify, logout],
+    () => ({ ready, authenticated, email, requestLink, verify, refreshEmail, logout }),
+    [ready, authenticated, email, requestLink, verify, refreshEmail, logout],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/mobile/src/auth/store.tsx
+++ b/mobile/src/auth/store.tsx
@@ -1,4 +1,13 @@
-import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
 import { api } from '../api/client';
 import { LD_JSON } from '../api/config';
 import { verifyMagicToken } from './authApi';
@@ -21,6 +30,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [ready, setReady] = useState(false);
   const [authenticated, setAuthenticated] = useState(false);
   const [email, setEmail] = useState<string | null>(null);
+  // Bumped on every session teardown (logout / invalidation). An in-flight
+  // GET /users/me captures the generation at call time and only writes back if it
+  // still matches — so a response landing after logout can't resurrect `email`.
+  const sessionGen = useRef(0);
+  const endSession = useCallback(() => {
+    sessionGen.current += 1;
+    setAuthenticated(false);
+  }, []);
 
   useEffect(() => {
     void (async () => {
@@ -54,7 +71,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   // A refresh that definitively fails clears the tokens outside React; flip the
   // state so the (tabs) guard redirects to /login instead of 401'ing forever.
-  useEffect(() => onSessionInvalidated(() => setAuthenticated(false)), []);
+  useEffect(() => onSessionInvalidated(endSession), [endSession]);
 
   const requestLink = useCallback(async (email: string): Promise<boolean> => {
     const { response } = await api.POST('/auth/request-link', {
@@ -74,14 +91,18 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   // email change is committed so the account screen reflects the new address
   // without a re-login. (Not /auth/session, which is cookie-only web transport.)
   const refreshEmail = useCallback(async (): Promise<void> => {
+    const gen = sessionGen.current;
     const { data } = await api.GET('/users/me', { headers: { Accept: LD_JSON } });
-    setEmail(data?.email ?? null);
+    // Drop a response that outlived its session (a logout raced this fetch).
+    if (sessionGen.current === gen) {
+      setEmail(data?.email ?? null);
+    }
   }, []);
 
   const logout = useCallback(async (): Promise<void> => {
     await clearTokens();
-    setAuthenticated(false);
-  }, []);
+    endSession();
+  }, [endSession]);
 
   const value = useMemo<AuthContextValue>(
     () => ({ ready, authenticated, email, requestLink, verify, refreshEmail, logout }),

--- a/mobile/src/auth/store.tsx
+++ b/mobile/src/auth/store.tsx
@@ -70,10 +70,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return ok;
   }, []);
 
-  // Re-read the account email from the session — called after an email change is
-  // committed so the account screen reflects the new address without a re-login.
+  // Re-read the account email from GET /users/me (JWT Bearer) — called after an
+  // email change is committed so the account screen reflects the new address
+  // without a re-login. (Not /auth/session, which is cookie-only web transport.)
   const refreshEmail = useCallback(async (): Promise<void> => {
-    const { data } = await api.GET('/auth/session', { headers: { Accept: LD_JSON } });
+    const { data } = await api.GET('/users/me', { headers: { Accept: LD_JSON } });
     setEmail(data?.email ?? null);
   }, []);
 

--- a/mobile/src/hooks/use-email-change.test.ts
+++ b/mobile/src/hooks/use-email-change.test.ts
@@ -1,11 +1,26 @@
 /// <reference types="jest" />
 jest.mock('../api/client', () => ({ api: { POST: jest.fn() } }));
+import TestRenderer, { act } from 'react-test-renderer';
+import { createElement } from 'react';
 import { api } from '../api/client';
-import { requestEmailChange, verifyEmailChange } from './use-email-change';
+import {
+  requestEmailChange,
+  verifyEmailChange,
+  useEmailChange,
+  type UseEmailChange,
+} from './use-email-change';
 
 const mockPost = api.POST as jest.MockedFunction<typeof api.POST>;
 
 beforeEach(() => jest.clearAllMocks());
+
+function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void } {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
 
 describe('requestEmailChange (#1117)', () => {
   it('POSTs the new address to /users/me/email-change and returns true on 202', async () => {
@@ -37,5 +52,72 @@ describe('verifyEmailChange (#1117)', () => {
       body: { newEmail: '', token: 'tok-123' },
       headers: { 'Content-Type': 'application/ld+json', Accept: 'application/ld+json' },
     });
+  });
+});
+
+describe('useEmailChange state machine (#1117)', () => {
+  let captured: UseEmailChange;
+  let renderer: ReturnType<typeof TestRenderer.create>;
+
+  function Harness() {
+    captured = useEmailChange();
+    return null;
+  }
+
+  function render() {
+    act(() => {
+      renderer = TestRenderer.create(createElement(Harness));
+    });
+  }
+
+  afterEach(() => act(() => renderer?.unmount()));
+
+  it('toggles busy while in flight, then flips sent on success', async () => {
+    const d = deferred<{ response: { ok: boolean } }>();
+    mockPost.mockReturnValue(d.promise as never);
+    render();
+
+    expect(captured.busy).toBe(false);
+    expect(captured.sent).toBe(false);
+
+    act(() => {
+      void captured.submit('new@example.com');
+    });
+    expect(captured.busy).toBe(true);
+
+    await act(async () => {
+      d.resolve({ response: { ok: true } });
+      await d.promise;
+    });
+
+    expect(captured.busy).toBe(false);
+    expect(captured.sent).toBe(true);
+    expect(captured.error).toBe(false);
+  });
+
+  it('sets error (not sent) when the request is rejected', async () => {
+    mockPost.mockResolvedValue({ response: { ok: false } } as never);
+    render();
+
+    await act(async () => {
+      await captured.submit('bad');
+    });
+
+    expect(captured.error).toBe(true);
+    expect(captured.sent).toBe(false);
+    expect(captured.busy).toBe(false);
+  });
+
+  it('clears the error via reset (e.g. on the next keystroke)', async () => {
+    mockPost.mockResolvedValue({ response: { ok: false } } as never);
+    render();
+
+    await act(async () => {
+      await captured.submit('bad');
+    });
+    expect(captured.error).toBe(true);
+
+    act(() => captured.reset());
+    expect(captured.error).toBe(false);
   });
 });

--- a/mobile/src/hooks/use-email-change.test.ts
+++ b/mobile/src/hooks/use-email-change.test.ts
@@ -1,0 +1,41 @@
+/// <reference types="jest" />
+jest.mock('../api/client', () => ({ api: { POST: jest.fn() } }));
+import { api } from '../api/client';
+import { requestEmailChange, verifyEmailChange } from './use-email-change';
+
+const mockPost = api.POST as jest.MockedFunction<typeof api.POST>;
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('requestEmailChange (#1117)', () => {
+  it('POSTs the new address to /users/me/email-change and returns true on 202', async () => {
+    mockPost.mockResolvedValue({ response: { ok: true } } as never);
+
+    const ok = await requestEmailChange('new@example.com');
+
+    expect(ok).toBe(true);
+    expect(mockPost).toHaveBeenCalledWith('/users/me/email-change', {
+      body: { newEmail: 'new@example.com' },
+      headers: { 'Content-Type': 'application/ld+json', Accept: 'application/ld+json' },
+    });
+  });
+
+  it('returns false when the request is rejected', async () => {
+    mockPost.mockResolvedValue({ response: { ok: false } } as never);
+    expect(await requestEmailChange('bad')).toBe(false);
+  });
+});
+
+describe('verifyEmailChange (#1117)', () => {
+  it('POSTs the token to /users/me/email-change/verify and returns true on 204', async () => {
+    mockPost.mockResolvedValue({ response: { ok: true } } as never);
+
+    const ok = await verifyEmailChange('tok-123');
+
+    expect(ok).toBe(true);
+    expect(mockPost).toHaveBeenCalledWith('/users/me/email-change/verify', {
+      body: { newEmail: '', token: 'tok-123' },
+      headers: { 'Content-Type': 'application/ld+json', Accept: 'application/ld+json' },
+    });
+  });
+});

--- a/mobile/src/hooks/use-email-change.ts
+++ b/mobile/src/hooks/use-email-change.ts
@@ -1,0 +1,68 @@
+import { useCallback, useState } from 'react';
+import { api } from '../api/client';
+import { LD_JSON } from '../api/config';
+
+// Email-change-by-magic-link flow (backend #777). Two steps:
+//   1. requestEmailChange(newEmail) -> POST /users/me/email-change (202): a
+//      confirmation link is sent to the NEW address.
+//   2. verifyEmailChange(token)     -> POST /users/me/email-change/verify (204):
+//      consume the single-use token from that link and commit the new email.
+// The user is resolved from the JWT server-side, so both calls require an
+// authenticated session (the deep link opens the app while logged in).
+
+export async function requestEmailChange(newEmail: string): Promise<boolean> {
+  const { response } = await api.POST('/users/me/email-change', {
+    body: { newEmail },
+    headers: { 'Content-Type': LD_JSON, Accept: LD_JSON },
+  });
+  return response.ok;
+}
+
+// The verify operation shares the EmailChange schema (newEmail is required by the
+// type), but only `token` is validated server-side in the verify group; newEmail
+// is ignored, so we send it empty to satisfy the generated body type.
+export async function verifyEmailChange(token: string): Promise<boolean> {
+  const { response } = await api.POST('/users/me/email-change/verify', {
+    body: { newEmail: '', token },
+    headers: { 'Content-Type': LD_JSON, Accept: LD_JSON },
+  });
+  return response.ok;
+}
+
+export interface UseEmailChange {
+  busy: boolean;
+  sent: boolean;
+  error: boolean;
+  submit: (newEmail: string) => Promise<void>;
+  reset: () => void;
+}
+
+// Drives the request screen: a single in-flight request with sent/error feedback.
+export function useEmailChange(): UseEmailChange {
+  const [busy, setBusy] = useState(false);
+  const [sent, setSent] = useState(false);
+  const [error, setError] = useState(false);
+
+  const submit = useCallback(async (newEmail: string) => {
+    setBusy(true);
+    setError(false);
+    try {
+      if (await requestEmailChange(newEmail)) {
+        setSent(true);
+      } else {
+        setError(true);
+      }
+    } catch {
+      setError(true);
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+
+  const reset = useCallback(() => {
+    setSent(false);
+    setError(false);
+  }, []);
+
+  return { busy, sent, error, submit, reset };
+}

--- a/mobile/src/i18n/resources/en.ts
+++ b/mobile/src/i18n/resources/en.ts
@@ -129,6 +129,22 @@ export const en: typeof fr = {
     faqTitle: 'FAQ',
     legalTitle: 'Legal notice',
     privacyTitle: 'Privacy',
+    emailChange: {
+      description:
+        'Enter your new email address. A confirmation link will be sent to it; the change only takes effect once you open that link.',
+      label: 'New email address',
+      placeholder: 'you@example.com',
+      submit: 'Send confirmation link',
+      submitting: 'Sending…',
+      error: 'Could not send the link. Check the address and try again.',
+      sentTitle: 'Link sent',
+      sent: 'A confirmation link was sent to {{email}}. Open it to confirm the change.',
+      verifying: 'Confirming the email change…',
+      verifyFailedTitle: 'Invalid or expired link',
+      verifyFailedBody:
+        'This confirmation link is no longer valid. Start a new email change from your account.',
+      backToAccount: 'Back to account',
+    },
   },
   trip: {
     title: 'Roadbook',

--- a/mobile/src/i18n/resources/fr.ts
+++ b/mobile/src/i18n/resources/fr.ts
@@ -127,6 +127,22 @@ export const fr = {
     faqTitle: 'FAQ',
     legalTitle: 'Mentions légales',
     privacyTitle: 'Confidentialité',
+    emailChange: {
+      description:
+        'Saisissez votre nouvelle adresse e-mail. Un lien de confirmation y sera envoyé ; le changement ne prend effet qu’une fois ce lien ouvert.',
+      label: 'Nouvelle adresse e-mail',
+      placeholder: 'vous@exemple.com',
+      submit: 'Envoyer le lien de confirmation',
+      submitting: 'Envoi…',
+      error: 'Impossible d’envoyer le lien. Vérifiez l’adresse et réessayez.',
+      sentTitle: 'Lien envoyé',
+      sent: 'Un lien de confirmation a été envoyé à {{email}}. Ouvrez-le pour valider le changement.',
+      verifying: 'Validation du changement d’adresse…',
+      verifyFailedTitle: 'Lien invalide ou expiré',
+      verifyFailedBody:
+        'Ce lien de confirmation n’est plus valide. Relancez un changement d’adresse depuis votre compte.',
+      backToAccount: 'Retour au compte',
+    },
   },
   trip: {
     title: 'Roadbook',

--- a/mobile/src/screens/email-change-verify.test.tsx
+++ b/mobile/src/screens/email-change-verify.test.tsx
@@ -66,6 +66,17 @@ describe('VerifyEmailChangeScreen (#1117)', () => {
     expect(textInTree(tree, i18n.t('account.emailChange.verifyFailedTitle'))).toBe(true);
   });
 
+  it('still redirects (no error state) when refreshEmail throws after a successful verify', async () => {
+    mockVerify.mockResolvedValue(true);
+    mockRefreshEmail.mockRejectedValue(new Error('network'));
+
+    const tree = await render();
+
+    expect(mockVerify).toHaveBeenCalledWith('tok-123');
+    expect(mockReplace).toHaveBeenCalledWith('/(tabs)/account');
+    expect(textInTree(tree, i18n.t('account.emailChange.verifyFailedTitle'))).toBe(false);
+  });
+
   it('runs the verify exactly once even across re-renders (ref guard)', async () => {
     mockVerify.mockResolvedValue(true);
 

--- a/mobile/src/screens/email-change-verify.test.tsx
+++ b/mobile/src/screens/email-change-verify.test.tsx
@@ -1,0 +1,79 @@
+/// <reference types="jest" />
+import TestRenderer, { act } from 'react-test-renderer';
+import { createElement } from 'react';
+import { Text } from 'react-native';
+import i18n from '../i18n';
+
+const mockReplace = jest.fn();
+let mockParams: { token?: string } = { token: 'tok-123' };
+jest.mock('expo-router', () => ({
+  useLocalSearchParams: () => mockParams,
+  useRouter: () => ({ replace: mockReplace }),
+  Stack: { Screen: () => null },
+}));
+
+jest.mock('../hooks/use-email-change', () => ({ verifyEmailChange: jest.fn() }));
+import { verifyEmailChange } from '../hooks/use-email-change';
+const mockVerify = verifyEmailChange as jest.MockedFunction<typeof verifyEmailChange>;
+
+const mockRefreshEmail = jest.fn();
+jest.mock('../auth/store', () => ({ useAuth: () => ({ refreshEmail: mockRefreshEmail }) }));
+
+import VerifyEmailChangeScreen from '../../app/account/email-change/verify/[token]';
+
+beforeAll(async () => {
+  await i18n.changeLanguage('fr');
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockParams = { token: 'tok-123' };
+});
+
+function textInTree(tree: ReturnType<typeof TestRenderer.create>, value: string): boolean {
+  return tree.root.findAllByType(Text).some((n: { props: { children?: unknown } }) => {
+    const kids = Array.isArray(n.props.children) ? n.props.children : [n.props.children];
+    return kids.join('').includes(value);
+  });
+}
+
+async function render(): Promise<ReturnType<typeof TestRenderer.create>> {
+  let tree!: ReturnType<typeof TestRenderer.create>;
+  await act(async () => {
+    tree = TestRenderer.create(createElement(VerifyEmailChangeScreen));
+  });
+  return tree;
+}
+
+describe('VerifyEmailChangeScreen (#1117)', () => {
+  it('commits the change on success: refreshes the email then redirects to the account tab', async () => {
+    mockVerify.mockResolvedValue(true);
+
+    await render();
+
+    expect(mockVerify).toHaveBeenCalledWith('tok-123');
+    expect(mockRefreshEmail).toHaveBeenCalledTimes(1);
+    expect(mockReplace).toHaveBeenCalledWith('/(tabs)/account');
+  });
+
+  it('shows the error state and does not redirect when the token is rejected', async () => {
+    mockVerify.mockResolvedValue(false);
+
+    const tree = await render();
+
+    expect(mockRefreshEmail).not.toHaveBeenCalled();
+    expect(mockReplace).not.toHaveBeenCalled();
+    expect(textInTree(tree, i18n.t('account.emailChange.verifyFailedTitle'))).toBe(true);
+  });
+
+  it('runs the verify exactly once even across re-renders (ref guard)', async () => {
+    mockVerify.mockResolvedValue(true);
+
+    const tree = await render();
+    await act(async () => {
+      tree.update(createElement(VerifyEmailChangeScreen));
+    });
+
+    expect(mockVerify).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Ferme #1117. Stacked sur #1116 (base `feature/1116`). Épic #1049.

## Résumé
- Hook `use-email-change` : `POST /users/me/email-change` (202) + `POST /users/me/email-change/verify` (204).
- Écran `account/email.tsx` (remplace le stub) + deep-link `account/email/verify/[token].tsx` (calqué sur `auth/verify/[token].tsx`).
- `AuthProvider.refreshEmail()` (additif) pour rafraîchir l'email après verify.
- i18n `account.emailChange.*` fr/en.

## Écart signalé
`account.email` est déjà un label string (#1116) → sous-clés placées sous `account.emailChange.*` pour éviter la collision. Le body verify envoie `newEmail: ''` (schema le rend requis, backend ne valide que `token` en groupe verify) — à surveiller côté contrat.

## Vérification
- typecheck vert ; test hook (POST émis) prouvé par sabotage/restore.
- Échec `ShareSheet.test` = flaky pré-existant (vert en isolation), non lié.

<!-- claude-review-start -->
## Claude Review

**Summary:** Solid, well-tested mobile email-change flow. The prior review pass's remaining open issue — `refreshEmail()` lacking a stale-response cancellation guard — is now fixed by the last commit (`sessionGen` generation counter, bumped on logout/session-invalidation, checked before `setEmail` in `refreshEmail()`), and is covered by a new test in `store.test.tsx`. Independently verified that the verify-endpoint's empty `newEmail` (flagged by the author as a contract risk) is not a bug: `EmailChange`'s validation groups scope all `newEmail` constraints to `email-change:request` only, the verify operation validates against `email-change:verify` exclusively, and `VerifyEmailChangeProcessor` never reads `$data->newEmail` (it derives the new email from the stored token). No new findings.

**Resolved threads:** Resolved 1 previously open thread (`refreshEmail()` cancellation guard) that was addressed by commit `6f08608`.

**PR title check:** `feat(mobile): flux changement d'email` — description is a noun phrase, not imperative mood.

**Findings by severity:**
- Critical: 0
- Warning: 0
- Nitpick: 0 (not reported per review policy)

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Commit reviewed:** `6f08608144792c62b3153dfed9ae047e4b87bbc3`
<!-- claude-review-end -->
