### PR TITLE
feat(mobile): écrans statiques FAQ / mentions légales / confidentialité

### DIFF
--- a/mobile/app/account/faq.tsx
+++ b/mobile/app/account/faq.tsx
@@ -1,5 +1,23 @@
-import { AccountStub } from '../../src/components/account/AccountStub';
+import { Stack } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import { Screen } from '../../src/components/ui';
+import { FaqItem } from '../../src/components/account/StaticContent';
 
 export default function AccountFaq() {
-  return <AccountStub titleKey="account.faqTitle" />;
+  const { t } = useTranslation();
+
+  const items = [1, 2, 3, 4, 5] as const;
+
+  return (
+    <Screen scroll>
+      <Stack.Screen options={{ headerShown: true, title: t('account.faqTitle') }} />
+      {items.map((n) => (
+        <FaqItem
+          key={n}
+          question={t(`account.faqContent.q${n}`)}
+          answer={t(`account.faqContent.a${n}`)}
+        />
+      ))}
+    </Screen>
+  );
 }

--- a/mobile/app/account/legal.tsx
+++ b/mobile/app/account/legal.tsx
@@ -1,5 +1,31 @@
-import { AccountStub } from '../../src/components/account/AccountStub';
+import { Text } from 'react-native';
+import { Stack } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import { Screen } from '../../src/components/ui';
+import { ContentSection } from '../../src/components/account/StaticContent';
+import { useTheme } from '../../src/theme';
 
 export default function AccountLegal() {
-  return <AccountStub titleKey="account.legalTitle" />;
+  const { t } = useTranslation();
+  const theme = useTheme();
+
+  return (
+    <Screen scroll>
+      <Stack.Screen options={{ headerShown: true, title: t('account.legalTitle') }} />
+      <Text
+        style={{
+          color: theme.colors.mutedForeground,
+          fontFamily: theme.fonts.sans,
+          fontSize: 12,
+          marginBottom: theme.spacing.md,
+        }}
+      >
+        {t('account.legalContent.lastUpdated')}
+      </Text>
+      <ContentSection title={t('account.legalContent.publisherTitle')} body={t('account.legalContent.publisherBody')} />
+      <ContentSection title={t('account.legalContent.hostTitle')} body={t('account.legalContent.hostBody')} />
+      <ContentSection title={t('account.legalContent.contactTitle')} body={t('account.legalContent.contactBody')} />
+      <ContentSection title={t('account.legalContent.ipTitle')} body={t('account.legalContent.ipBody')} />
+    </Screen>
+  );
 }

--- a/mobile/app/account/privacy.tsx
+++ b/mobile/app/account/privacy.tsx
@@ -1,5 +1,54 @@
-import { AccountStub } from '../../src/components/account/AccountStub';
+import { Text } from 'react-native';
+import { Stack } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import { Screen } from '../../src/components/ui';
+import { ContentSection } from '../../src/components/account/StaticContent';
+import { useTheme } from '../../src/theme';
 
 export default function AccountPrivacy() {
-  return <AccountStub titleKey="account.privacyTitle" />;
+  const { t } = useTranslation();
+  const theme = useTheme();
+
+  return (
+    <Screen scroll>
+      <Stack.Screen options={{ headerShown: true, title: t('account.privacyTitle') }} />
+      <Text
+        style={{
+          color: theme.colors.mutedForeground,
+          fontFamily: theme.fonts.sans,
+          fontSize: 12,
+          marginBottom: theme.spacing.md,
+        }}
+      >
+        {t('account.privacyContent.lastUpdated')}
+      </Text>
+      <ContentSection
+        title={t('account.privacyContent.controllerTitle')}
+        body={t('account.privacyContent.controllerBody')}
+      />
+      <ContentSection title={t('account.privacyContent.basisTitle')} body={t('account.privacyContent.basisBody')} />
+      <ContentSection
+        title={t('account.privacyContent.purposesTitle')}
+        body={t('account.privacyContent.purposesBody')}
+      />
+      <ContentSection title={t('account.privacyContent.dataTitle')} body={t('account.privacyContent.dataBody')} />
+      <ContentSection
+        title={t('account.privacyContent.retentionTitle')}
+        body={t('account.privacyContent.retentionBody')}
+      />
+      <ContentSection title={t('account.privacyContent.rightsTitle')} body={t('account.privacyContent.rightsBody')} />
+      <ContentSection
+        title={t('account.privacyContent.processorsTitle')}
+        body={t('account.privacyContent.processorsBody')}
+      />
+      <ContentSection
+        title={t('account.privacyContent.analyticsTitle')}
+        body={t('account.privacyContent.analyticsBody')}
+      />
+      <ContentSection
+        title={t('account.privacyContent.contactTitle')}
+        body={t('account.privacyContent.contactBody')}
+      />
+    </Screen>
+  );
 }

--- a/mobile/src/api/config.ts
+++ b/mobile/src/api/config.ts
@@ -28,3 +28,8 @@ function getWebDevFallback(): string {
 // The API is client-agnostic and negotiates on JSON-LD only (auth tokens travel in
 // the body). Every mutating call sends and accepts application/ld+json.
 export const LD_JSON = 'application/ld+json';
+
+// Contact email shown in the account help screens (FAQ/legal/privacy — #1119).
+// Mirrors the pwa's CONTACT_EMAIL (src/lib/constants.ts): each self-hosted
+// instance can override it, no fail-closed behaviour needed (display-only).
+export const CONTACT_EMAIL = process.env.EXPO_PUBLIC_CONTACT_EMAIL ?? 'contact@example.org';

--- a/mobile/src/components/account/StaticContent.test.tsx
+++ b/mobile/src/components/account/StaticContent.test.tsx
@@ -1,0 +1,20 @@
+/// <reference types="jest" />
+import { withContactEmail } from './StaticContent';
+import { CONTACT_EMAIL } from '../../api/config';
+
+describe('withContactEmail (#1119 review fix)', () => {
+  it('substitutes the __CONTACT_EMAIL__ token with CONTACT_EMAIL', () => {
+    expect(withContactEmail('Contact us at: __CONTACT_EMAIL__.')).toBe(
+      `Contact us at: ${CONTACT_EMAIL}.`,
+    );
+  });
+
+  it('substitutes every occurrence of the token', () => {
+    const body = '__CONTACT_EMAIL__ first, __CONTACT_EMAIL__ again.';
+    expect(withContactEmail(body)).toBe(`${CONTACT_EMAIL} first, ${CONTACT_EMAIL} again.`);
+  });
+
+  it('leaves text without the token unchanged', () => {
+    expect(withContactEmail('No token here.')).toBe('No token here.');
+  });
+});

--- a/mobile/src/components/account/StaticContent.tsx
+++ b/mobile/src/components/account/StaticContent.tsx
@@ -1,10 +1,18 @@
 import { Text, View } from 'react-native';
 import { Card } from '../ui';
 import { useTheme } from '../../theme';
+import { CONTACT_EMAIL } from '../../api/config';
 
 // Shared building blocks for the static account content screens (FAQ, legal
 // notice, privacy policy — #1119): a titled text section and a Q/A pair,
 // each rendered inside its own Card.
+
+// Substitutes the `__CONTACT_EMAIL__` token in legal/privacy copy with
+// CONTACT_EMAIL. Mirrors the pwa's withContactEmail (legal-page.tsx), adapted
+// to a single body string instead of a paragraph array.
+export function withContactEmail(body: string): string {
+  return body.replace(/__CONTACT_EMAIL__/g, CONTACT_EMAIL);
+}
 
 export function ContentSection({ title, body }: { title: string; body: string }) {
   const theme = useTheme();
@@ -23,7 +31,7 @@ export function ContentSection({ title, body }: { title: string; body: string })
       <Text
         style={{ color: theme.colors.mutedForeground, fontFamily: theme.fonts.sans, fontSize: 14, lineHeight: 21 }}
       >
-        {body}
+        {withContactEmail(body)}
       </Text>
     </Card>
   );

--- a/mobile/src/components/account/StaticContent.tsx
+++ b/mobile/src/components/account/StaticContent.tsx
@@ -1,0 +1,50 @@
+import { Text, View } from 'react-native';
+import { Card } from '../ui';
+import { useTheme } from '../../theme';
+
+// Shared building blocks for the static account content screens (FAQ, legal
+// notice, privacy policy — #1119): a titled text section and a Q/A pair,
+// each rendered inside its own Card.
+
+export function ContentSection({ title, body }: { title: string; body: string }) {
+  const theme = useTheme();
+  return (
+    <Card style={{ marginBottom: theme.spacing.md }}>
+      <Text
+        style={{
+          color: theme.colors.foreground,
+          fontFamily: theme.fonts.sansSemibold,
+          fontSize: 16,
+          marginBottom: theme.spacing.sm,
+        }}
+      >
+        {title}
+      </Text>
+      <Text
+        style={{ color: theme.colors.mutedForeground, fontFamily: theme.fonts.sans, fontSize: 14, lineHeight: 21 }}
+      >
+        {body}
+      </Text>
+    </Card>
+  );
+}
+
+export function FaqItem({ question, answer }: { question: string; answer: string }) {
+  const theme = useTheme();
+  return (
+    <Card style={{ marginBottom: theme.spacing.md }}>
+      <View style={{ gap: theme.spacing.sm }}>
+        <Text
+          style={{ color: theme.colors.foreground, fontFamily: theme.fonts.sansSemibold, fontSize: 15 }}
+        >
+          {question}
+        </Text>
+        <Text
+          style={{ color: theme.colors.mutedForeground, fontFamily: theme.fonts.sans, fontSize: 14, lineHeight: 21 }}
+        >
+          {answer}
+        </Text>
+      </View>
+    </Card>
+  );
+}

--- a/mobile/src/i18n/resources/en.ts
+++ b/mobile/src/i18n/resources/en.ts
@@ -145,6 +145,63 @@ export const en: typeof fr = {
         'This confirmation link is no longer valid. Start a new email change from your account.',
       backToAccount: 'Back to account',
     },
+    faqContent: {
+      q1: 'What is bikepacking?',
+      a1: 'Bikepacking means travelling by bike over several days, self-supported, either camping along the way or staying in accommodation. Bike Trip Planner automatically splits your route into daily stages tailored to your profile.',
+      q2: 'What is the roadbook?',
+      a2: 'The roadbook is the day-by-day view of your trip: distance, elevation, suggested accommodation, weather and alerts for each stage. It updates automatically after a recompute.',
+      q3: 'How do notifications work?',
+      a3: 'Notifications let you know about important events on your trips (recompute finished, weather alert, etc.). You can manage which categories are enabled from Account > Notifications.',
+      q4: 'How do I change my account information?',
+      a4: 'Go to Account to change your email address, language, theme, or export/delete your data.',
+      q5: 'What happens if my trip has already started?',
+      a5: "A started trip becomes read-only: date or stage changes are no longer possible, to keep the already-computed data consistent.",
+    },
+    legalContent: {
+      lastUpdated: 'Last updated: 29 May 2026',
+      publisherTitle: 'Publisher',
+      publisherBody:
+        'Bike Trip Planner is an open-source project published by Vincent Chalamon.\n\nThe source code is available on GitHub under an open-source license: https://github.com/vincentchalamon/bike-trip-planner\n\nPublication director: Vincent Chalamon.',
+      hostTitle: 'Host',
+      hostBody:
+        'The application is hosted by the operator of this instance.\n\nThe exact details of the host can be provided on request at the contact address below.',
+      contactTitle: 'Contact',
+      contactBody:
+        "For any question about the site or to exercise your rights, contact us at: contact@example.org.\n\nYou can also open an issue on the project's GitHub repository.",
+      ipTitle: 'Intellectual property',
+      ipBody:
+        'The Bike Trip Planner source code is distributed under an open-source license; the usage and redistribution terms are available in the GitHub repository.\n\nRoute and mapping data come from third-party sources (OpenStreetMap, DataTourisme, OpenAgenda, Wikidata) and remain subject to their respective licenses, credited within the application.\n\nThird-party trademarks, logos and content (Komoot, Strava, RideWithGPS, Garmin, Wahoo) remain the property of their respective owners.',
+    },
+    privacyContent: {
+      lastUpdated: 'Last updated: 29 May 2026',
+      controllerTitle: 'Data controller',
+      controllerBody:
+        'The data controller is the publisher of Bike Trip Planner (see the legal notice).\n\nFor any question about your personal data, contact us at: contact@example.org.',
+      basisTitle: 'Legal basis',
+      basisBody:
+        'Processing of your email address is based on the performance of the service you request (magic-link sign-in and account management), under Article 6(1)(b) GDPR.\n\nAnonymous audience measurement is based on our legitimate interest in improving the service, without prejudice to your rights and freedoms (Article 6(1)(f) GDPR).',
+      purposesTitle: 'Purposes',
+      purposesBody:
+        'Your data is used to authenticate you, save and restore your trips, and compute route analyses (pacing, alerts, accommodation, weather).\n\nAnonymous audience measurement is used solely to understand overall usage of the service and improve its usability.',
+      dataTitle: 'Data collected',
+      dataBody:
+        'Account: your email address, required for magic-link sign-in.\n\nTrips: your trip configuration (title, dates, rider profile, stages, selected accommodation) is stored so you can access it from any device.\n\nRoute data: imported raw GPS points are cached temporarily (Redis) and then deleted automatically.\n\nNo sensitive data is collected, and no data is sold to third parties.',
+      retentionTitle: 'Retention period',
+      retentionBody:
+        'Your account and trips are kept for as long as your account is active. You may request their deletion at any time; deletion triggers an immediate and irreversible anonymisation of your account.\n\nRaw cached route data is kept for a maximum of 24 hours.\n\nAnonymous audience measurement data is aggregated and cannot be used to re-identify you.',
+      rightsTitle: 'Your rights',
+      rightsBody:
+        'In accordance with the GDPR, you have the right of access, rectification, erasure, restriction, objection and portability of your data.\n\nTo exercise these rights, contact us at: contact@example.org. We respond within one month.\n\nYou also have the right to lodge a complaint with your supervisory authority (in France, the CNIL — www.cnil.fr).',
+      processorsTitle: 'Processors',
+      processorsBody:
+        'Infrastructure hosting: a cloud provider chosen by the operator of this instance.\n\nSending sign-in emails: a transactional email delivery provider.\n\nOpen-data sources queried for analysis (OpenStreetMap, weather forecasts): no identifying personal data is transmitted to them.',
+      analyticsTitle: 'Audience measurement (Plausible)',
+      analyticsBody:
+        'We use Plausible Analytics, a privacy-friendly audience measurement solution, self-hosted on the same infrastructure as the application.\n\nPlausible sets no cookies and uses no fingerprinting techniques. No data is shared with third parties for advertising purposes.\n\nIP addresses and user agents (browser) are anonymised and never stored; no data can be used to identify you or track you across sites.\n\nPurpose: to understand, in aggregate, which pages are visited and overall usage in order to improve the service. Retention: aggregated statistics only, no individual data.\n\nNo consent banner is required because no personal data is collected; you nevertheless retain the objection rights described above.',
+      contactTitle: 'Contact',
+      contactBody:
+        'For any question about this privacy policy, write to us at: contact@example.org.\n\nThis policy may be updated; the last-updated date is shown at the top of this page.',
+    },
   },
   trip: {
     title: 'Roadbook',

--- a/mobile/src/i18n/resources/en.ts
+++ b/mobile/src/i18n/resources/en.ts
@@ -167,7 +167,7 @@ export const en: typeof fr = {
         'The application is hosted by the operator of this instance.\n\nThe exact details of the host can be provided on request at the contact address below.',
       contactTitle: 'Contact',
       contactBody:
-        "For any question about the site or to exercise your rights, contact us at: contact@example.org.\n\nYou can also open an issue on the project's GitHub repository.",
+        "For any question about the site or to exercise your rights, contact us at: __CONTACT_EMAIL__.\n\nYou can also open an issue on the project's GitHub repository.",
       ipTitle: 'Intellectual property',
       ipBody:
         'The Bike Trip Planner source code is distributed under an open-source license; the usage and redistribution terms are available in the GitHub repository.\n\nRoute and mapping data come from third-party sources (OpenStreetMap, DataTourisme, OpenAgenda, Wikidata) and remain subject to their respective licenses, credited within the application.\n\nThird-party trademarks, logos and content (Komoot, Strava, RideWithGPS, Garmin, Wahoo) remain the property of their respective owners.',
@@ -176,7 +176,7 @@ export const en: typeof fr = {
       lastUpdated: 'Last updated: 29 May 2026',
       controllerTitle: 'Data controller',
       controllerBody:
-        'The data controller is the publisher of Bike Trip Planner (see the legal notice).\n\nFor any question about your personal data, contact us at: contact@example.org.',
+        'The data controller is the publisher of Bike Trip Planner (see the legal notice).\n\nFor any question about your personal data, contact us at: __CONTACT_EMAIL__.',
       basisTitle: 'Legal basis',
       basisBody:
         'Processing of your email address is based on the performance of the service you request (magic-link sign-in and account management), under Article 6(1)(b) GDPR.\n\nAnonymous audience measurement is based on our legitimate interest in improving the service, without prejudice to your rights and freedoms (Article 6(1)(f) GDPR).',
@@ -191,7 +191,7 @@ export const en: typeof fr = {
         'Your account and trips are kept for as long as your account is active. You may request their deletion at any time; deletion triggers an immediate and irreversible anonymisation of your account.\n\nRaw cached route data is kept for a maximum of 24 hours.\n\nAnonymous audience measurement data is aggregated and cannot be used to re-identify you.',
       rightsTitle: 'Your rights',
       rightsBody:
-        'In accordance with the GDPR, you have the right of access, rectification, erasure, restriction, objection and portability of your data.\n\nTo exercise these rights, contact us at: contact@example.org. We respond within one month.\n\nYou also have the right to lodge a complaint with your supervisory authority (in France, the CNIL — www.cnil.fr).',
+        'In accordance with the GDPR, you have the right of access, rectification, erasure, restriction, objection and portability of your data.\n\nTo exercise these rights, contact us at: __CONTACT_EMAIL__. We respond within one month.\n\nYou also have the right to lodge a complaint with your supervisory authority (in France, the CNIL — www.cnil.fr).',
       processorsTitle: 'Processors',
       processorsBody:
         'Infrastructure hosting: a cloud provider chosen by the operator of this instance.\n\nSending sign-in emails: a transactional email delivery provider.\n\nOpen-data sources queried for analysis (OpenStreetMap, weather forecasts): no identifying personal data is transmitted to them.',
@@ -200,7 +200,7 @@ export const en: typeof fr = {
         'We use Plausible Analytics, a privacy-friendly audience measurement solution, self-hosted on the same infrastructure as the application.\n\nPlausible sets no cookies and uses no fingerprinting techniques. No data is shared with third parties for advertising purposes.\n\nIP addresses and user agents (browser) are anonymised and never stored; no data can be used to identify you or track you across sites.\n\nPurpose: to understand, in aggregate, which pages are visited and overall usage in order to improve the service. Retention: aggregated statistics only, no individual data.\n\nNo consent banner is required because no personal data is collected; you nevertheless retain the objection rights described above.',
       contactTitle: 'Contact',
       contactBody:
-        'For any question about this privacy policy, write to us at: contact@example.org.\n\nThis policy may be updated; the last-updated date is shown at the top of this page.',
+        'For any question about this privacy policy, write to us at: __CONTACT_EMAIL__.\n\nThis policy may be updated; the last-updated date is shown at the top of this page.',
     },
   },
   trip: {

--- a/mobile/src/i18n/resources/fr.ts
+++ b/mobile/src/i18n/resources/fr.ts
@@ -165,7 +165,7 @@ export const fr = {
         "L'application est hébergée par l'opérateur de cette instance.\n\nLes coordonnées exactes de l'hébergeur peuvent être communiquées sur demande à l'adresse de contact ci-dessous.",
       contactTitle: 'Contact',
       contactBody:
-        'Pour toute question relative au site ou pour exercer tes droits, tu peux nous contacter à l\'adresse : contact@example.org.\n\nTu peux également ouvrir une issue sur le dépôt GitHub du projet.',
+        "Pour toute question relative au site ou pour exercer tes droits, tu peux nous contacter à l'adresse : __CONTACT_EMAIL__.\n\nTu peux également ouvrir une issue sur le dépôt GitHub du projet.",
       ipTitle: 'Propriété intellectuelle',
       ipBody:
         "Le code source de Bike Trip Planner est distribué sous licence open-source ; les conditions d'utilisation et de redistribution figurent dans le dépôt GitHub.\n\nLes données d'itinéraire et cartographiques proviennent de sources tierces (OpenStreetMap, DataTourisme, OpenAgenda, Wikidata) et restent soumises à leurs licences respectives, créditées sur l'application.\n\nLes marques, logos et contenus appartenant à des tiers (Komoot, Strava, RideWithGPS, Garmin, Wahoo) demeurent la propriété de leurs détenteurs respectifs.",
@@ -174,7 +174,7 @@ export const fr = {
       lastUpdated: 'Dernière mise à jour : 29 mai 2026',
       controllerTitle: 'Responsable du traitement',
       controllerBody:
-        "Le responsable du traitement des données est l'éditeur de Bike Trip Planner (voir les mentions légales).\n\nPour toute question relative à tes données personnelles, contacte-nous à : contact@example.org.",
+        "Le responsable du traitement des données est l'éditeur de Bike Trip Planner (voir les mentions légales).\n\nPour toute question relative à tes données personnelles, contacte-nous à : __CONTACT_EMAIL__.",
       basisTitle: 'Base légale',
       basisBody:
         "Le traitement de ton adresse email repose sur l'exécution du service que tu demandes (connexion par lien magique et gestion de ton compte), au sens de l'article 6.1.b du RGPD.\n\nLa mesure d'audience anonyme repose sur notre intérêt légitime à améliorer le service, sans préjudice pour tes droits et libertés (article 6.1.f du RGPD).",
@@ -189,7 +189,7 @@ export const fr = {
         'Ton compte et tes voyages sont conservés tant que ton compte est actif. Tu peux demander leur suppression à tout moment ; la suppression entraîne une anonymisation immédiate et irréversible de ton compte.\n\nLes données de tracé brutes en cache sont conservées au maximum 24 heures.\n\nLes données de mesure d\'audience anonyme sont agrégées et ne permettent pas de te réidentifier.',
       rightsTitle: 'Tes droits',
       rightsBody:
-        "Conformément au RGPD, tu disposes d'un droit d'accès, de rectification, d'effacement, de limitation, d'opposition et de portabilité de tes données.\n\nPour exercer ces droits, contacte-nous à : contact@example.org. Nous répondons dans un délai d'un mois.\n\nTu as également le droit d'introduire une réclamation auprès de la CNIL (www.cnil.fr).",
+        "Conformément au RGPD, tu disposes d'un droit d'accès, de rectification, d'effacement, de limitation, d'opposition et de portabilité de tes données.\n\nPour exercer ces droits, contacte-nous à : __CONTACT_EMAIL__. Nous répondons dans un délai d'un mois.\n\nTu as également le droit d'introduire une réclamation auprès de la CNIL (www.cnil.fr).",
       processorsTitle: 'Sous-traitants',
       processorsBody:
         "Hébergement de l'infrastructure : prestataire cloud choisi par l'opérateur de cette instance.\n\nEnvoi des emails de connexion : prestataire d'envoi d'emails transactionnels.\n\nSources de données ouvertes interrogées pour l'analyse (OpenStreetMap, prévisions météo) : aucune donnée personnelle identifiante ne leur est transmise.",
@@ -198,7 +198,7 @@ export const fr = {
         "Nous utilisons Plausible Analytics, une solution de mesure d'audience respectueuse de la vie privée, auto-hébergée sur la même infrastructure que l'application.\n\nPlausible ne dépose aucun cookie et n'utilise aucune technique d'empreinte numérique (fingerprinting). Aucune donnée n'est partagée avec des tiers à des fins publicitaires.\n\nLes adresses IP et les agents utilisateurs (navigateur) sont anonymisés et ne sont jamais stockés ; aucune donnée ne permet de t'identifier ou de te suivre entre les sites.\n\nFinalité : comprendre de façon agrégée les pages consultées et l'usage global afin d'améliorer le service. Rétention : statistiques agrégées uniquement, aucune donnée individuelle.\n\nAucune bannière de consentement n'est requise car aucune donnée personnelle n'est collectée ; tu conserves néanmoins tes droits d'opposition décrits ci-dessus.",
       contactTitle: 'Contact',
       contactBody:
-        'Pour toute question relative à cette politique de confidentialité, écris-nous à : contact@example.org.\n\nCette politique peut être mise à jour ; la date de dernière mise à jour figure en haut de cette page.',
+        "Pour toute question relative à cette politique de confidentialité, écris-nous à : __CONTACT_EMAIL__.\n\nCette politique peut être mise à jour ; la date de dernière mise à jour figure en haut de cette page.",
     },
   },
   trip: {

--- a/mobile/src/i18n/resources/fr.ts
+++ b/mobile/src/i18n/resources/fr.ts
@@ -143,6 +143,63 @@ export const fr = {
         'Ce lien de confirmation n’est plus valide. Relancez un changement d’adresse depuis votre compte.',
       backToAccount: 'Retour au compte',
     },
+    faqContent: {
+      q1: "Qu'est-ce que le bikepacking ?",
+      a1: "Le bikepacking consiste à voyager à vélo sur plusieurs jours en autonomie, avec son matériel de bivouac ou en hébergement. Bike Trip Planner découpe automatiquement ton parcours en étapes journalières adaptées à ton profil.",
+      q2: "Qu'est-ce que le roadbook ?",
+      a2: "Le roadbook est la vue jour par jour de ton voyage : distance, dénivelé, hébergements suggérés, météo et alertes pour chaque étape. Il se met à jour automatiquement après un recalcul.",
+      q3: 'Comment fonctionnent les notifications ?',
+      a3: 'Les notifications te préviennent des événements importants sur tes voyages (recalcul terminé, alerte météo, etc.). Tu peux gérer les catégories activées depuis Compte > Notifications.',
+      q4: 'Comment modifier les informations de mon compte ?',
+      a4: 'Rends-toi dans Compte pour changer ton adresse email, ta langue, ton thème, ou exporter/supprimer tes données.',
+      q5: 'Que se passe-t-il si mon voyage a déjà démarré ?',
+      a5: 'Un voyage démarré passe en lecture seule : les modifications de dates ou d\'étapes ne sont plus possibles pour préserver la cohérence des données déjà calculées.',
+    },
+    legalContent: {
+      lastUpdated: 'Dernière mise à jour : 29 mai 2026',
+      publisherTitle: 'Éditeur',
+      publisherBody:
+        'Bike Trip Planner est un projet open-source édité par Vincent Chalamon.\n\nLe code source est publié sur GitHub sous licence libre : https://github.com/vincentchalamon/bike-trip-planner\n\nDirecteur de la publication : Vincent Chalamon.',
+      hostTitle: 'Hébergeur',
+      hostBody:
+        "L'application est hébergée par l'opérateur de cette instance.\n\nLes coordonnées exactes de l'hébergeur peuvent être communiquées sur demande à l'adresse de contact ci-dessous.",
+      contactTitle: 'Contact',
+      contactBody:
+        'Pour toute question relative au site ou pour exercer tes droits, tu peux nous contacter à l\'adresse : contact@example.org.\n\nTu peux également ouvrir une issue sur le dépôt GitHub du projet.',
+      ipTitle: 'Propriété intellectuelle',
+      ipBody:
+        "Le code source de Bike Trip Planner est distribué sous licence open-source ; les conditions d'utilisation et de redistribution figurent dans le dépôt GitHub.\n\nLes données d'itinéraire et cartographiques proviennent de sources tierces (OpenStreetMap, DataTourisme, OpenAgenda, Wikidata) et restent soumises à leurs licences respectives, créditées sur l'application.\n\nLes marques, logos et contenus appartenant à des tiers (Komoot, Strava, RideWithGPS, Garmin, Wahoo) demeurent la propriété de leurs détenteurs respectifs.",
+    },
+    privacyContent: {
+      lastUpdated: 'Dernière mise à jour : 29 mai 2026',
+      controllerTitle: 'Responsable du traitement',
+      controllerBody:
+        "Le responsable du traitement des données est l'éditeur de Bike Trip Planner (voir les mentions légales).\n\nPour toute question relative à tes données personnelles, contacte-nous à : contact@example.org.",
+      basisTitle: 'Base légale',
+      basisBody:
+        "Le traitement de ton adresse email repose sur l'exécution du service que tu demandes (connexion par lien magique et gestion de ton compte), au sens de l'article 6.1.b du RGPD.\n\nLa mesure d'audience anonyme repose sur notre intérêt légitime à améliorer le service, sans préjudice pour tes droits et libertés (article 6.1.f du RGPD).",
+      purposesTitle: 'Finalités',
+      purposesBody:
+        "Tes données sont utilisées pour t'authentifier, sauvegarder et restituer tes voyages, et calculer les analyses d'itinéraire (pacing, alertes, hébergements, météo).\n\nLa mesure d'audience anonyme sert uniquement à comprendre l'usage global du service et à en améliorer l'ergonomie.",
+      dataTitle: 'Données collectées',
+      dataBody:
+        "Compte : ton adresse email, nécessaire à la connexion par lien magique.\n\nVoyages : la configuration de tes voyages (titre, dates, profil cycliste, étapes, hébergements sélectionnés) est conservée pour te permettre d'y accéder depuis n'importe quel appareil.\n\nDonnées de tracé : les points GPS bruts importés sont conservés temporairement en cache (Redis) puis supprimés automatiquement.\n\nAucune donnée sensible n'est collectée, et aucune donnée n'est revendue à des tiers.",
+      retentionTitle: 'Durée de conservation',
+      retentionBody:
+        'Ton compte et tes voyages sont conservés tant que ton compte est actif. Tu peux demander leur suppression à tout moment ; la suppression entraîne une anonymisation immédiate et irréversible de ton compte.\n\nLes données de tracé brutes en cache sont conservées au maximum 24 heures.\n\nLes données de mesure d\'audience anonyme sont agrégées et ne permettent pas de te réidentifier.',
+      rightsTitle: 'Tes droits',
+      rightsBody:
+        "Conformément au RGPD, tu disposes d'un droit d'accès, de rectification, d'effacement, de limitation, d'opposition et de portabilité de tes données.\n\nPour exercer ces droits, contacte-nous à : contact@example.org. Nous répondons dans un délai d'un mois.\n\nTu as également le droit d'introduire une réclamation auprès de la CNIL (www.cnil.fr).",
+      processorsTitle: 'Sous-traitants',
+      processorsBody:
+        "Hébergement de l'infrastructure : prestataire cloud choisi par l'opérateur de cette instance.\n\nEnvoi des emails de connexion : prestataire d'envoi d'emails transactionnels.\n\nSources de données ouvertes interrogées pour l'analyse (OpenStreetMap, prévisions météo) : aucune donnée personnelle identifiante ne leur est transmise.",
+      analyticsTitle: "Mesure d'audience (Plausible)",
+      analyticsBody:
+        "Nous utilisons Plausible Analytics, une solution de mesure d'audience respectueuse de la vie privée, auto-hébergée sur la même infrastructure que l'application.\n\nPlausible ne dépose aucun cookie et n'utilise aucune technique d'empreinte numérique (fingerprinting). Aucune donnée n'est partagée avec des tiers à des fins publicitaires.\n\nLes adresses IP et les agents utilisateurs (navigateur) sont anonymisés et ne sont jamais stockés ; aucune donnée ne permet de t'identifier ou de te suivre entre les sites.\n\nFinalité : comprendre de façon agrégée les pages consultées et l'usage global afin d'améliorer le service. Rétention : statistiques agrégées uniquement, aucune donnée individuelle.\n\nAucune bannière de consentement n'est requise car aucune donnée personnelle n'est collectée ; tu conserves néanmoins tes droits d'opposition décrits ci-dessus.",
+      contactTitle: 'Contact',
+      contactBody:
+        'Pour toute question relative à cette politique de confidentialité, écris-nous à : contact@example.org.\n\nCette politique peut être mise à jour ; la date de dernière mise à jour figure en haut de cette page.',
+    },
   },
   trip: {
     title: 'Roadbook',


### PR DESCRIPTION
Ferme #1119. Stacked sur #1116 (base `feature/1116`). Épic #1049.

## Résumé
- `account/faq.tsx` (5 Q/R via `FaqItem`), `account/legal.tsx`, `account/privacy.tsx` : contenu réel, `Screen` + topbar retour + `Card`.
- Wording légal/confidentialité repris tel quel du `pwa` (`pwa/messages/{fr,en}.json`, clés `legal`/`privacy`).
- Composant partagé `StaticContent.tsx` (`ContentSection`, `FaqItem`).
- i18n sous-namespaces distincts `account.{faqContent,legalContent,privacyContent}.*` (n'écrase pas les labels de nav).

## Hors scope (documenté)
- Onboarding first-run : pas de ligne « aide » dans le squelette #1116 → non ajouté (contrat : ne pas toucher `account.tsx`).

## Vérification
- typecheck vert ; 430/430 jest (3 timeouts flaky pré-existants trips/create/ShareSheet, verts en isolation).

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 critical, 0 warning, 0 informational findings. The prior review's architecture finding (contact email hardcoded instead of the instance-configurable `__CONTACT_EMAIL__` pattern) was fixed by the second commit — `CONTACT_EMAIL` now lives in `mobile/src/api/config.ts` (backed by `EXPO_PUBLIC_CONTACT_EMAIL`, mirroring the pwa's `withContactEmail`/`constants.ts`), applied via `withContactEmail()` in `StaticContent.tsx`, and covered by a new unit test. Verified: i18n key parity between `fr.ts`/`en.ts` is exact for all three new namespaces (`faqContent`, `legalContent`, `privacyContent`); `Screen`'s `scroll` prop exists and is used correctly; `AccountStub` remains correctly in use by the three still-in-scope-elsewhere sibling stub routes (delete/export/notifications). No debug leftovers, no dead code, no security or performance concerns (display-only, no new user input, no HTTP/XML surface touched).

**Resolved threads:** the one previous bot thread (contact-email hardcoding) is already resolved/outdated on GitHub, matching the fix in the second commit — no further action needed.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases — `withContactEmail` substitution is unit-tested; `FaqItem`/`ContentSection`/screens have no render tests, consistent with the pre-existing `AccountStub` precedent in this codebase.
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

Commit reviewed: 39d259f816346b1a8b6224b074f564e213a41cae
<!-- claude-review-end -->