### PR TITLE
feat(mobile): RGPD export + suppression de compte

### DIFF
--- a/mobile/app/account/delete.tsx
+++ b/mobile/app/account/delete.tsx
@@ -1,5 +1,58 @@
-import { AccountStub } from '../../src/components/account/AccountStub';
+import { useCallback, useState } from 'react';
+import { Alert, Text, View } from 'react-native';
+import { Stack, useRouter } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import { Screen } from '../../src/components/ui';
+import { DeleteAccountForm } from '../../src/components/account/DeleteAccountForm';
+import { deleteAccount } from '../../src/api/account';
+import { useAuth } from '../../src/auth/store';
+import { useTheme } from '../../src/theme';
 
 export default function AccountDelete() {
-  return <AccountStub titleKey="account.deleteTitle" />;
+  const { t } = useTranslation();
+  const theme = useTheme();
+  const router = useRouter();
+  const { logout } = useAuth();
+  const [loading, setLoading] = useState(false);
+
+  const keyword = t('account.delete.keyword');
+
+  const onConfirm = useCallback(async () => {
+    setLoading(true);
+    const ok = await deleteAccount();
+    if (!ok) {
+      setLoading(false);
+      Alert.alert(t('account.deleteTitle'), t('account.delete.failed'));
+      return;
+    }
+    await logout();
+    router.replace('/login');
+  }, [logout, router, t]);
+
+  return (
+    <Screen>
+      <Stack.Screen options={{ headerShown: true, title: t('account.deleteTitle') }} />
+      <View style={{ flex: 1, gap: theme.spacing.lg }}>
+        <Text
+          style={{
+            color: theme.colors.foreground,
+            fontFamily: theme.fonts.sans,
+            fontSize: 15,
+            lineHeight: 22,
+          }}
+        >
+          {t('account.delete.warningBefore')}
+          <Text style={{ fontFamily: theme.fonts.sansSemibold }}>{keyword}</Text>
+          {t('account.delete.warningAfter')}
+        </Text>
+        <DeleteAccountForm
+          keyword={keyword}
+          confirmLabel={t('account.delete.action')}
+          placeholder={keyword}
+          loading={loading}
+          onConfirm={() => void onConfirm()}
+        />
+      </View>
+    </Screen>
+  );
 }

--- a/mobile/app/account/delete.tsx
+++ b/mobile/app/account/delete.tsx
@@ -42,15 +42,17 @@ export default function AccountDelete() {
           }}
         >
           {t('account.delete.warningBefore')}
-          <Text style={{ fontFamily: theme.fonts.sansSemibold }}>{keyword}</Text>
+          <Text style={{ fontFamily: theme.fonts.mono }}>{keyword}</Text>
           {t('account.delete.warningAfter')}
         </Text>
         <DeleteAccountForm
           keyword={keyword}
           confirmLabel={t('account.delete.action')}
+          cancelLabel={t('account.delete.cancel')}
           placeholder={keyword}
           loading={loading}
           onConfirm={() => void onConfirm()}
+          onCancel={() => router.back()}
         />
       </View>
     </Screen>

--- a/mobile/app/account/export.tsx
+++ b/mobile/app/account/export.tsx
@@ -1,5 +1,41 @@
-import { AccountStub } from '../../src/components/account/AccountStub';
+import { useCallback } from 'react';
+import { Alert, Text, View } from 'react-native';
+import { Stack } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import { Button, Screen } from '../../src/components/ui';
+import { useAccountExport } from '../../src/hooks/use-account-export';
+import { useTheme } from '../../src/theme';
 
 export default function AccountExport() {
-  return <AccountStub titleKey="account.exportTitle" />;
+  const { t } = useTranslation();
+  const theme = useTheme();
+
+  const onFailure = useCallback(() => {
+    Alert.alert(t('account.exportTitle'), t('account.export.failed'));
+  }, [t]);
+
+  const { exporting, exportAccount } = useAccountExport(onFailure);
+
+  return (
+    <Screen>
+      <Stack.Screen options={{ headerShown: true, title: t('account.exportTitle') }} />
+      <View style={{ flex: 1, gap: theme.spacing.lg }}>
+        <Text
+          style={{
+            color: theme.colors.mutedForeground,
+            fontFamily: theme.fonts.sans,
+            fontSize: 15,
+            lineHeight: 22,
+          }}
+        >
+          {t('account.export.description')}
+        </Text>
+        <Button
+          label={t('account.export.action')}
+          loading={exporting}
+          onPress={() => void exportAccount()}
+        />
+      </View>
+    </Screen>
+  );
 }

--- a/mobile/app/account/export.tsx
+++ b/mobile/app/account/export.tsx
@@ -1,5 +1,5 @@
-import { useCallback } from 'react';
-import { Alert, Text, View } from 'react-native';
+import { useCallback, useState } from 'react';
+import { Alert, StyleSheet, Text, View } from 'react-native';
 import { Stack } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { Button, Screen } from '../../src/components/ui';
@@ -9,12 +9,19 @@ import { useTheme } from '../../src/theme';
 export default function AccountExport() {
   const { t } = useTranslation();
   const theme = useTheme();
+  const [exported, setExported] = useState(false);
 
   const onFailure = useCallback(() => {
     Alert.alert(t('account.exportTitle'), t('account.export.failed'));
   }, [t]);
 
   const { exporting, exportAccount } = useAccountExport(onFailure);
+
+  const onExport = useCallback(async () => {
+    setExported(false);
+    const ok = await exportAccount();
+    if (ok) setExported(true);
+  }, [exportAccount]);
 
   return (
     <Screen>
@@ -33,8 +40,27 @@ export default function AccountExport() {
         <Button
           label={t('account.export.action')}
           loading={exporting}
-          onPress={() => void exportAccount()}
+          onPress={() => void onExport()}
         />
+        {exported ? (
+          <View
+            accessibilityRole="alert"
+            style={{
+              backgroundColor: theme.colors.successSoft,
+              borderColor: theme.colors.successBorder,
+              borderWidth: StyleSheet.hairlineWidth,
+              borderRadius: theme.radius.md,
+              paddingVertical: theme.spacing.md,
+              paddingHorizontal: theme.spacing.base,
+            }}
+          >
+            <Text
+              style={{ color: theme.colors.successInk, fontFamily: theme.fonts.sansMedium, fontSize: 14 }}
+            >
+              {t('account.export.success')}
+            </Text>
+          </View>
+        ) : null}
       </View>
     </Screen>
   );

--- a/mobile/src/api/account.test.ts
+++ b/mobile/src/api/account.test.ts
@@ -1,0 +1,27 @@
+/// <reference types="jest" />
+const mockDelete = jest.fn();
+
+jest.mock('./client', () => ({ api: { DELETE: (...args: unknown[]) => mockDelete(...args) } }));
+
+import { deleteAccount } from './account';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('deleteAccount', () => {
+  it('resolves true on a 204 response', async () => {
+    mockDelete.mockResolvedValue({ response: { ok: true, status: 204 } });
+    expect(await deleteAccount()).toBe(true);
+  });
+
+  it('resolves false on a non-ok response', async () => {
+    mockDelete.mockResolvedValue({ response: { ok: false, status: 403 } });
+    expect(await deleteAccount()).toBe(false);
+  });
+
+  it('resolves false (never throws) when the request rejects (offline/timeout)', async () => {
+    mockDelete.mockRejectedValue(new Error('Network request failed'));
+    await expect(deleteAccount()).resolves.toBe(false);
+  });
+});

--- a/mobile/src/api/account.ts
+++ b/mobile/src/api/account.ts
@@ -1,0 +1,30 @@
+import { api } from './client';
+import { LD_JSON } from './config';
+
+// GDPR account endpoints (backend Sprint 52): portability + right to erasure.
+
+/** Stable file name for the shared export archive (backend sends JSON-LD). */
+export const ACCOUNT_EXPORT_FILENAME = 'bike-trip-planner-data.json';
+
+/**
+ * Download the RGPD archive (profile + trips) as raw bytes. The endpoint returns
+ * `application/ld+json` with `Content-Disposition: attachment`; read it as an
+ * ArrayBuffer (not JSON) so the exact server payload is written to the shared
+ * file untouched, mirroring the trip export plumbing (#1047).
+ */
+export async function fetchAccountExport(): Promise<ArrayBuffer> {
+  const { data, error, response } = await api.GET('/users/me/export', {
+    headers: { Accept: LD_JSON },
+    parseAs: 'arrayBuffer',
+  });
+  if (error || !response.ok) {
+    throw new Error('Failed to export account');
+  }
+  return data;
+}
+
+/** Anonymise the account (204). Never throws: resolves to false on any failure. */
+export async function deleteAccount(): Promise<boolean> {
+  const { response } = await api.DELETE('/users/me', { headers: { Accept: LD_JSON } });
+  return response.ok;
+}

--- a/mobile/src/api/account.ts
+++ b/mobile/src/api/account.ts
@@ -23,8 +23,14 @@ export async function fetchAccountExport(): Promise<ArrayBuffer> {
   return data;
 }
 
-/** Anonymise the account (204). Never throws: resolves to false on any failure. */
+// Anonymise the account (204). Never throws: resolves to false on any failure,
+// including a network rejection (offline/timeout) where `api.DELETE` rejects
+// before any response — otherwise the caller's button stays stuck in `loading`.
 export async function deleteAccount(): Promise<boolean> {
-  const { response } = await api.DELETE('/users/me', { headers: { Accept: LD_JSON } });
-  return response.ok;
+  try {
+    const { response } = await api.DELETE('/users/me', { headers: { Accept: LD_JSON } });
+    return response.ok;
+  } catch {
+    return false;
+  }
 }

--- a/mobile/src/components/account/DeleteAccountForm.test.tsx
+++ b/mobile/src/components/account/DeleteAccountForm.test.tsx
@@ -1,10 +1,14 @@
 /// <reference types="jest" />
 import TestRenderer, { act } from 'react-test-renderer';
 import type { ReactElement } from 'react';
-import { TextInput } from 'react-native';
+import { Text, TextInput } from 'react-native';
 import { DeleteAccountForm } from './DeleteAccountForm';
 
 type Tree = ReturnType<typeof TestRenderer.create>;
+type Instance = ReturnType<Tree['root']['find']>;
+
+const CONFIRM = 'Supprimer';
+const CANCEL = 'Annuler';
 
 function render(element: ReactElement): Tree {
   let out!: Tree;
@@ -14,10 +18,23 @@ function render(element: ReactElement): Tree {
   return out;
 }
 
+// Locate a Button (Pressable) by the label text it renders, so the two buttons
+// (Cancel / Delete) are told apart without relying on order.
+function buttonByLabel(tree: Tree, label: string): Instance {
+  const btn = tree.root
+    .findAll((n: Instance) => n.props.accessibilityRole === 'button')
+    .find((b: Instance) =>
+      b.findAllByType(Text).some((t: Instance) => {
+        const kids = Array.isArray(t.props.children) ? t.props.children : [t.props.children];
+        return kids.includes(label);
+      }),
+    );
+  if (!btn) throw new Error(`button "${label}" not found`);
+  return btn;
+}
+
 function confirmDisabled(tree: Tree): boolean {
-  return Boolean(
-    tree.root.findByProps({ accessibilityRole: 'button' }).props.accessibilityState.disabled,
-  );
+  return Boolean(buttonByLabel(tree, CONFIRM).props.accessibilityState.disabled);
 }
 
 function type(tree: Tree, text: string): void {
@@ -26,12 +43,22 @@ function type(tree: Tree, text: string): void {
   });
 }
 
+function form(overrides: Partial<Parameters<typeof DeleteAccountForm>[0]> = {}): ReactElement {
+  return (
+    <DeleteAccountForm
+      keyword="SUPPRIMER"
+      confirmLabel={CONFIRM}
+      cancelLabel={CANCEL}
+      onConfirm={jest.fn()}
+      onCancel={jest.fn()}
+      {...overrides}
+    />
+  );
+}
+
 describe('DeleteAccountForm', () => {
   it('keeps the confirm button disabled until the keyword is typed exactly', () => {
-    const onConfirm = jest.fn();
-    const tree = render(
-      <DeleteAccountForm keyword="SUPPRIMER" confirmLabel="Supprimer" onConfirm={onConfirm} />,
-    );
+    const tree = render(form());
 
     // Empty input: disabled.
     expect(confirmDisabled(tree)).toBe(true);
@@ -51,14 +78,22 @@ describe('DeleteAccountForm', () => {
 
   it('fires onConfirm only once armed', () => {
     const onConfirm = jest.fn();
-    const tree = render(
-      <DeleteAccountForm keyword="SUPPRIMER" confirmLabel="Supprimer" onConfirm={onConfirm} />,
-    );
+    const tree = render(form({ onConfirm }));
 
     type(tree, 'SUPPRIMER');
     act(() => {
-      tree.root.findByProps({ accessibilityRole: 'button' }).props.onPress();
+      buttonByLabel(tree, CONFIRM).props.onPress();
     });
     expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires onCancel from the cancel button without any input', () => {
+    const onCancel = jest.fn();
+    const tree = render(form({ onCancel }));
+
+    act(() => {
+      buttonByLabel(tree, CANCEL).props.onPress();
+    });
+    expect(onCancel).toHaveBeenCalledTimes(1);
   });
 });

--- a/mobile/src/components/account/DeleteAccountForm.test.tsx
+++ b/mobile/src/components/account/DeleteAccountForm.test.tsx
@@ -1,0 +1,64 @@
+/// <reference types="jest" />
+import TestRenderer, { act } from 'react-test-renderer';
+import type { ReactElement } from 'react';
+import { TextInput } from 'react-native';
+import { DeleteAccountForm } from './DeleteAccountForm';
+
+type Tree = ReturnType<typeof TestRenderer.create>;
+
+function render(element: ReactElement): Tree {
+  let out!: Tree;
+  act(() => {
+    out = TestRenderer.create(element);
+  });
+  return out;
+}
+
+function confirmDisabled(tree: Tree): boolean {
+  return Boolean(
+    tree.root.findByProps({ accessibilityRole: 'button' }).props.accessibilityState.disabled,
+  );
+}
+
+function type(tree: Tree, text: string): void {
+  act(() => {
+    tree.root.findByType(TextInput).props.onChangeText(text);
+  });
+}
+
+describe('DeleteAccountForm', () => {
+  it('keeps the confirm button disabled until the keyword is typed exactly', () => {
+    const onConfirm = jest.fn();
+    const tree = render(
+      <DeleteAccountForm keyword="SUPPRIMER" confirmLabel="Supprimer" onConfirm={onConfirm} />,
+    );
+
+    // Empty input: disabled.
+    expect(confirmDisabled(tree)).toBe(true);
+
+    // Partial / near match: still disabled.
+    type(tree, 'SUPPRI');
+    expect(confirmDisabled(tree)).toBe(true);
+    type(tree, 'supprimer');
+    expect(confirmDisabled(tree)).toBe(true);
+    type(tree, 'SUPPRIMER ');
+    expect(confirmDisabled(tree)).toBe(true);
+
+    // Exact match: enabled.
+    type(tree, 'SUPPRIMER');
+    expect(confirmDisabled(tree)).toBe(false);
+  });
+
+  it('fires onConfirm only once armed', () => {
+    const onConfirm = jest.fn();
+    const tree = render(
+      <DeleteAccountForm keyword="SUPPRIMER" confirmLabel="Supprimer" onConfirm={onConfirm} />,
+    );
+
+    type(tree, 'SUPPRIMER');
+    act(() => {
+      tree.root.findByProps({ accessibilityRole: 'button' }).props.onPress();
+    });
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mobile/src/components/account/DeleteAccountForm.tsx
+++ b/mobile/src/components/account/DeleteAccountForm.tsx
@@ -1,0 +1,50 @@
+import { useState } from 'react';
+import { View } from 'react-native';
+import { Button, Input } from '../ui';
+import { useTheme } from '../../theme';
+
+interface DeleteAccountFormProps {
+  keyword: string;
+  confirmLabel: string;
+  placeholder?: string;
+  inputLabel?: string;
+  loading?: boolean;
+  onConfirm: () => void;
+}
+
+// Keyword-confirmation form (maquette 10-account). The danger button stays
+// disabled until the typed value matches `keyword` exactly; extracted from the
+// screen so the guard is unit-testable without router/auth providers.
+export function DeleteAccountForm({
+  keyword,
+  confirmLabel,
+  placeholder,
+  inputLabel,
+  loading = false,
+  onConfirm,
+}: DeleteAccountFormProps) {
+  const theme = useTheme();
+  const [value, setValue] = useState('');
+  const armed = value === keyword;
+
+  return (
+    <View style={{ gap: theme.spacing.md }}>
+      <Input
+        label={inputLabel}
+        value={value}
+        onChangeText={setValue}
+        placeholder={placeholder}
+        autoCapitalize="characters"
+        autoCorrect={false}
+        autoComplete="off"
+      />
+      <Button
+        label={confirmLabel}
+        variant="destructive"
+        disabled={!armed}
+        loading={loading}
+        onPress={onConfirm}
+      />
+    </View>
+  );
+}

--- a/mobile/src/components/account/DeleteAccountForm.tsx
+++ b/mobile/src/components/account/DeleteAccountForm.tsx
@@ -6,10 +6,12 @@ import { useTheme } from '../../theme';
 interface DeleteAccountFormProps {
   keyword: string;
   confirmLabel: string;
+  cancelLabel: string;
   placeholder?: string;
   inputLabel?: string;
   loading?: boolean;
   onConfirm: () => void;
+  onCancel: () => void;
 }
 
 // Keyword-confirmation form (maquette 10-account). The danger button stays
@@ -18,10 +20,12 @@ interface DeleteAccountFormProps {
 export function DeleteAccountForm({
   keyword,
   confirmLabel,
+  cancelLabel,
   placeholder,
   inputLabel,
   loading = false,
   onConfirm,
+  onCancel,
 }: DeleteAccountFormProps) {
   const theme = useTheme();
   const [value, setValue] = useState('');
@@ -38,13 +42,23 @@ export function DeleteAccountForm({
         autoCorrect={false}
         autoComplete="off"
       />
-      <Button
-        label={confirmLabel}
-        variant="destructive"
-        disabled={!armed}
-        loading={loading}
-        onPress={onConfirm}
-      />
+      <View style={{ flexDirection: 'row', gap: theme.spacing.md }}>
+        <Button
+          label={cancelLabel}
+          variant="outline"
+          onPress={onCancel}
+          disabled={loading}
+          style={{ flex: 1 }}
+        />
+        <Button
+          label={confirmLabel}
+          variant="destructive"
+          disabled={!armed}
+          loading={loading}
+          onPress={onConfirm}
+          style={{ flex: 1 }}
+        />
+      </View>
     </View>
   );
 }

--- a/mobile/src/hooks/use-account-export.test.ts
+++ b/mobile/src/hooks/use-account-export.test.ts
@@ -1,0 +1,100 @@
+/// <reference types="jest" />
+import { createElement } from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+
+const mockCreate = jest.fn();
+const mockWrite = jest.fn();
+
+jest.mock('expo-file-system', () => ({
+  Paths: { cache: 'file:///cache' },
+  File: jest.fn().mockImplementation(() => ({
+    create: mockCreate,
+    write: mockWrite,
+    get uri() {
+      return 'file:///cache/bike-trip-planner-data.json';
+    },
+  })),
+}));
+
+const mockIsAvailable = jest.fn();
+const mockShareAsync = jest.fn();
+jest.mock('expo-sharing', () => ({
+  isAvailableAsync: (...args: unknown[]) => mockIsAvailable(...args),
+  shareAsync: (...args: unknown[]) => mockShareAsync(...args),
+}));
+
+jest.mock('../api/account', () => ({
+  ACCOUNT_EXPORT_FILENAME: 'bike-trip-planner-data.json',
+  fetchAccountExport: jest.fn(),
+}));
+
+import { fetchAccountExport } from '../api/account';
+import { runAccountExport, useAccountExport, type UseAccountExport } from './use-account-export';
+
+const mockFetch = fetchAccountExport as jest.MockedFunction<typeof fetchAccountExport>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockIsAvailable.mockResolvedValue(true);
+  mockWrite.mockResolvedValue(undefined);
+  mockShareAsync.mockResolvedValue(undefined);
+  mockFetch.mockResolvedValue(new ArrayBuffer(8));
+});
+
+describe('runAccountExport', () => {
+  it('fetches, writes and shares the archive', async () => {
+    const ok = await runAccountExport();
+    expect(ok).toBe(true);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockWrite).toHaveBeenCalledTimes(1);
+    expect(mockShareAsync).toHaveBeenCalledWith('file:///cache/bike-trip-planner-data.json', {
+      mimeType: 'application/json',
+    });
+  });
+
+  it('resolves false when the fetch fails', async () => {
+    mockFetch.mockRejectedValue(new Error('network'));
+    expect(await runAccountExport()).toBe(false);
+    expect(mockShareAsync).not.toHaveBeenCalled();
+  });
+
+  it('resolves false when sharing is unavailable', async () => {
+    mockIsAvailable.mockResolvedValue(false);
+    expect(await runAccountExport()).toBe(false);
+    expect(mockShareAsync).not.toHaveBeenCalled();
+  });
+});
+
+describe('useAccountExport', () => {
+  function harness(onFailure: () => void): { current: UseAccountExport } {
+    const ref: { current: UseAccountExport } = { current: null as unknown as UseAccountExport };
+    function Probe() {
+      ref.current = useAccountExport(onFailure);
+      return null;
+    }
+    act(() => {
+      TestRenderer.create(createElement(Probe));
+    });
+    return ref;
+  }
+
+  it('calls onFailure when the export fails', async () => {
+    mockFetch.mockRejectedValue(new Error('boom'));
+    const onFailure = jest.fn();
+    const hook = harness(onFailure);
+    await act(async () => {
+      await hook.current.exportAccount();
+    });
+    expect(onFailure).toHaveBeenCalledTimes(1);
+    expect(hook.current.exporting).toBe(false);
+  });
+
+  it('does not call onFailure on success', async () => {
+    const onFailure = jest.fn();
+    const hook = harness(onFailure);
+    await act(async () => {
+      await hook.current.exportAccount();
+    });
+    expect(onFailure).not.toHaveBeenCalled();
+  });
+});

--- a/mobile/src/hooks/use-account-export.test.ts
+++ b/mobile/src/hooks/use-account-export.test.ts
@@ -78,23 +78,27 @@ describe('useAccountExport', () => {
     return ref;
   }
 
-  it('calls onFailure when the export fails', async () => {
+  it('calls onFailure and resolves false when the export fails', async () => {
     mockFetch.mockRejectedValue(new Error('boom'));
     const onFailure = jest.fn();
     const hook = harness(onFailure);
+    let result: boolean | undefined;
     await act(async () => {
-      await hook.current.exportAccount();
+      result = await hook.current.exportAccount();
     });
+    expect(result).toBe(false);
     expect(onFailure).toHaveBeenCalledTimes(1);
     expect(hook.current.exporting).toBe(false);
   });
 
-  it('does not call onFailure on success', async () => {
+  it('resolves true and does not call onFailure on success', async () => {
     const onFailure = jest.fn();
     const hook = harness(onFailure);
+    let result: boolean | undefined;
     await act(async () => {
-      await hook.current.exportAccount();
+      result = await hook.current.exportAccount();
     });
+    expect(result).toBe(true);
     expect(onFailure).not.toHaveBeenCalled();
   });
 });

--- a/mobile/src/hooks/use-account-export.ts
+++ b/mobile/src/hooks/use-account-export.ts
@@ -34,20 +34,22 @@ export async function runAccountExport(): Promise<boolean> {
 
 export interface UseAccountExport {
   exporting: boolean;
-  exportAccount: () => Promise<void>;
+  exportAccount: () => Promise<boolean>;
 }
 
 // Tracks the single in-flight export so the button can show a spinner; calls
 // `onFailure` when the export could not complete (network error or no share
-// target on the device).
+// target on the device). Resolves to the outcome so the caller can also surface
+// an in-app success confirmation.
 export function useAccountExport(onFailure: () => void): UseAccountExport {
   const [exporting, setExporting] = useState(false);
 
-  const exportAccount = useCallback(async () => {
+  const exportAccount = useCallback(async (): Promise<boolean> => {
     setExporting(true);
     const ok = await runAccountExport();
     setExporting(false);
     if (!ok) onFailure();
+    return ok;
   }, [onFailure]);
 
   return { exporting, exportAccount };

--- a/mobile/src/hooks/use-account-export.ts
+++ b/mobile/src/hooks/use-account-export.ts
@@ -1,23 +1,16 @@
 import { useCallback, useState } from 'react';
-import { File, Paths } from 'expo-file-system';
-import * as Sharing from 'expo-sharing';
 import { ACCOUNT_EXPORT_FILENAME, fetchAccountExport } from '../api/account';
+import { writeAndShareFile } from '../lib/fs-share';
 
 // Not to be confused with `use-export.ts` (trip/stage GPX/FIT export). This hook
 // handles the RGPD account archive (profile + trips as a single JSON file).
 
 const JSON_MIME = 'application/json';
 
-// Write the fetched bytes to a cache file and hand it to the native share sheet.
-// Awaits the write before sharing (see the ordering note in use-export.ts).
+// Write the fetched bytes to a cache file and hand it to the native share sheet
+// (shared plumbing in fs-share.ts, same as the trip GPX/FIT export).
 export async function writeAndShareAccount(bytes: ArrayBuffer): Promise<void> {
-  const file = new File(Paths.cache, ACCOUNT_EXPORT_FILENAME);
-  file.create({ intermediates: true, overwrite: true });
-  await file.write(new Uint8Array(bytes));
-  if (!(await Sharing.isAvailableAsync())) {
-    throw new Error('Sharing is not available on this device');
-  }
-  await Sharing.shareAsync(file.uri, { mimeType: JSON_MIME });
+  return writeAndShareFile(bytes, ACCOUNT_EXPORT_FILENAME, JSON_MIME);
 }
 
 // Fetch + write + share the archive. Never throws: resolves to false on failure

--- a/mobile/src/hooks/use-account-export.ts
+++ b/mobile/src/hooks/use-account-export.ts
@@ -1,0 +1,54 @@
+import { useCallback, useState } from 'react';
+import { File, Paths } from 'expo-file-system';
+import * as Sharing from 'expo-sharing';
+import { ACCOUNT_EXPORT_FILENAME, fetchAccountExport } from '../api/account';
+
+// Not to be confused with `use-export.ts` (trip/stage GPX/FIT export). This hook
+// handles the RGPD account archive (profile + trips as a single JSON file).
+
+const JSON_MIME = 'application/json';
+
+// Write the fetched bytes to a cache file and hand it to the native share sheet.
+// Awaits the write before sharing (see the ordering note in use-export.ts).
+export async function writeAndShareAccount(bytes: ArrayBuffer): Promise<void> {
+  const file = new File(Paths.cache, ACCOUNT_EXPORT_FILENAME);
+  file.create({ intermediates: true, overwrite: true });
+  await file.write(new Uint8Array(bytes));
+  if (!(await Sharing.isAvailableAsync())) {
+    throw new Error('Sharing is not available on this device');
+  }
+  await Sharing.shareAsync(file.uri, { mimeType: JSON_MIME });
+}
+
+// Fetch + write + share the archive. Never throws: resolves to false on failure
+// so the caller can surface it (mirrors runExportTrip).
+export async function runAccountExport(): Promise<boolean> {
+  try {
+    const bytes = await fetchAccountExport();
+    await writeAndShareAccount(bytes);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export interface UseAccountExport {
+  exporting: boolean;
+  exportAccount: () => Promise<void>;
+}
+
+// Tracks the single in-flight export so the button can show a spinner; calls
+// `onFailure` when the export could not complete (network error or no share
+// target on the device).
+export function useAccountExport(onFailure: () => void): UseAccountExport {
+  const [exporting, setExporting] = useState(false);
+
+  const exportAccount = useCallback(async () => {
+    setExporting(true);
+    const ok = await runAccountExport();
+    setExporting(false);
+    if (!ok) onFailure();
+  }, [onFailure]);
+
+  return { exporting, exportAccount };
+}

--- a/mobile/src/hooks/use-export.ts
+++ b/mobile/src/hooks/use-export.ts
@@ -1,7 +1,5 @@
 import { useCallback, useState } from 'react';
 import { Alert } from 'react-native';
-import { File, Paths } from 'expo-file-system';
-import * as Sharing from 'expo-sharing';
 import {
   fetchStageExport,
   fetchTripExport,
@@ -9,6 +7,7 @@ import {
   tripExportFileName,
   type ExportFormat,
 } from '../api/trips';
+import { writeAndShareFile } from '../lib/fs-share';
 
 const MIME_TYPES: Record<ExportFormat, string> = {
   gpx: 'application/gpx+xml',
@@ -16,23 +15,13 @@ const MIME_TYPES: Record<ExportFormat, string> = {
 };
 
 // Write the fetched bytes to a cache file and hand it to the native share sheet
-// (save to Files / send to another app). Extracted so the write+share plumbing is
-// unit-testable without a device (mocks expo-file-system / expo-sharing). Awaits
-// the write before sharing: `File#write` is currently a synchronous JSI call in
-// expo-file-system, but awaiting it here is a no-op on that value and keeps the
-// write→share ordering correct if a future SDK makes it return a Promise.
+// (shared plumbing in fs-share.ts, same as the RGPD account export).
 export async function writeAndShare(
   bytes: ArrayBuffer,
   filename: string,
   format: ExportFormat,
 ): Promise<void> {
-  const file = new File(Paths.cache, filename);
-  file.create({ intermediates: true, overwrite: true });
-  await file.write(new Uint8Array(bytes));
-  if (!(await Sharing.isAvailableAsync())) {
-    throw new Error('Sharing is not available on this device');
-  }
-  await Sharing.shareAsync(file.uri, { mimeType: MIME_TYPES[format] });
+  return writeAndShareFile(bytes, filename, MIME_TYPES[format]);
 }
 
 // Fetch + write + share the whole trip. Never throws: resolves to false on

--- a/mobile/src/i18n/resources/en.ts
+++ b/mobile/src/i18n/resources/en.ts
@@ -205,6 +205,7 @@ export const en: typeof fr = {
     export: {
       description: 'Download a JSON archive of your profile and trips (GDPR portability).',
       action: 'Export my data',
+      success: 'Data exported via the share sheet.',
       failed: 'Export failed. Try again.',
     },
     delete: {
@@ -212,6 +213,7 @@ export const en: typeof fr = {
       keyword: 'DELETE',
       warningAfter: ' to confirm.',
       action: 'Permanently delete my account',
+      cancel: 'Cancel',
       failed: 'Deletion failed. Try again.',
     },
   },

--- a/mobile/src/i18n/resources/en.ts
+++ b/mobile/src/i18n/resources/en.ts
@@ -202,6 +202,18 @@ export const en: typeof fr = {
       contactBody:
         'For any question about this privacy policy, write to us at: __CONTACT_EMAIL__.\n\nThis policy may be updated; the last-updated date is shown at the top of this page.',
     },
+    export: {
+      description: 'Download a JSON archive of your profile and trips (GDPR portability).',
+      action: 'Export my data',
+      failed: 'Export failed. Try again.',
+    },
+    delete: {
+      warningBefore: 'Irreversible action: your trips and data will be anonymised. Type ',
+      keyword: 'DELETE',
+      warningAfter: ' to confirm.',
+      action: 'Permanently delete my account',
+      failed: 'Deletion failed. Try again.',
+    },
   },
   notifications: {
     title: 'Notifications',

--- a/mobile/src/i18n/resources/fr.ts
+++ b/mobile/src/i18n/resources/fr.ts
@@ -200,6 +200,19 @@ export const fr = {
       contactBody:
         "Pour toute question relative à cette politique de confidentialité, écris-nous à : __CONTACT_EMAIL__.\n\nCette politique peut être mise à jour ; la date de dernière mise à jour figure en haut de cette page.",
     },
+    export: {
+      description:
+        'Télécharge une archive JSON de ton profil et de tes voyages (portabilité RGPD).',
+      action: 'Exporter mes données',
+      failed: "L'export a échoué. Réessaie.",
+    },
+    delete: {
+      warningBefore: 'Action irréversible : tes voyages et données seront anonymisés. Tape ',
+      keyword: 'SUPPRIMER',
+      warningAfter: ' pour confirmer.',
+      action: 'Supprimer définitivement mon compte',
+      failed: 'La suppression a échoué. Réessaie.',
+    },
   },
   notifications: {
     title: 'Notifications',

--- a/mobile/src/i18n/resources/fr.ts
+++ b/mobile/src/i18n/resources/fr.ts
@@ -204,6 +204,7 @@ export const fr = {
       description:
         'Télécharge une archive JSON de ton profil et de tes voyages (portabilité RGPD).',
       action: 'Exporter mes données',
+      success: 'Données exportées via la feuille de partage.',
       failed: "L'export a échoué. Réessaie.",
     },
     delete: {
@@ -211,6 +212,7 @@ export const fr = {
       keyword: 'SUPPRIMER',
       warningAfter: ' pour confirmer.',
       action: 'Supprimer définitivement mon compte',
+      cancel: 'Annuler',
       failed: 'La suppression a échoué. Réessaie.',
     },
   },

--- a/mobile/src/lib/fs-share.ts
+++ b/mobile/src/lib/fs-share.ts
@@ -1,0 +1,24 @@
+import { File, Paths } from 'expo-file-system';
+import * as Sharing from 'expo-sharing';
+
+// Write the fetched bytes to a cache file and hand it to the native share sheet
+// (save to Files / send to another app). Shared by the trip GPX/FIT export
+// (use-export.ts) and the RGPD account archive (use-account-export.ts) so the
+// write→share ordering fix lives in one place. Awaits the write before sharing:
+// `File#write` is currently a synchronous JSI call in expo-file-system, but
+// awaiting it is a no-op on that value and keeps the ordering correct if a future
+// SDK makes it return a Promise. Extracted so it is unit-testable without a device
+// (mocks expo-file-system / expo-sharing).
+export async function writeAndShareFile(
+  bytes: ArrayBuffer,
+  filename: string,
+  mimeType: string,
+): Promise<void> {
+  const file = new File(Paths.cache, filename);
+  file.create({ intermediates: true, overwrite: true });
+  await file.write(new Uint8Array(bytes));
+  if (!(await Sharing.isAvailableAsync())) {
+    throw new Error('Sharing is not available on this device');
+  }
+  await Sharing.shareAsync(file.uri, { mimeType });
+}


### PR DESCRIPTION
Ferme #1118. Stacked sur #1116 (base `feature/1116`). Épic #1049.

## Résumé
- Export : `GET /users/me/export` → share sheet natif (`expo-sharing`/`expo-file-system` déjà présents), hook `use-account-export.ts` (distinct de `use-export.ts`).
- Suppression : `DeleteAccountForm` avec confirmation par mot-clé exact « SUPPRIMER » (bouton danger `disabled={!armed}`), succès → `DELETE /users/me` → `logout()` → `/login`.
- API `mobile/src/api/account.ts` (`fetchAccountExport`, `deleteAccount`).
- i18n `account.export.*` / `account.delete.*` fr/en (pas de collision avec les labels de nav).

## Vérification
- typecheck vert ; 437/437 jest ; garde du bouton prouvée (disabled forcé → test casse) puis restaurée.

## Contrat respecté
- `account.tsx` non édité ; `auth/store.tsx` lu seul (`logout()`).

<!-- claude-review-start -->
## Claude Review

**Summary:** Re-review — 0 new findings. Both issues from the previous round are verified fixed in the current head: `deleteAccount()` now catches the network-rejection case (commit `04ebfee`), and the `writeAndShareAccount`/`writeAndShare` duplication was extracted into a shared `lib/fs-share.ts` (commit `ec4e404`). Confirmed against the current diff: both `/users/me/export` (GET) and `/users/me` (DELETE) exist in the generated `@btp/core` type contract; `deleteAccount`/`runAccountExport` never throw and mirror the established `runDeleteTrip`/trip-export contracts; `parseAs: 'arrayBuffer'` matches `fetchTripExport`/`fetchStageExport`; all referenced theme tokens (`successSoft`/`successBorder`/`successInk`, etc.) and UI component props (`Button` variants, `Input`'s passthrough) resolve; the destructive/export buttons are guarded against double-submit by `Button`'s own `disabled || loading`; i18n keys don't collide, and the confirmation keyword is correctly localized (`SUPPRIMER` fr / `DELETE` en) rather than hardcoded. Test coverage (api/hook/form) is thorough, and CI's `Mobile (tsc + jest)` check passes.

Non-blocking maintainability note (outside this PR's diff, so not diff-commentable): `mobile/src/components/account/AccountStub.tsx` is now fully dead code — every account sub-route (`email`, `export`, `delete`, `faq`, `legal`, `privacy`, `notifications`) has its own screen and nothing imports `AccountStub` anymore. Worth deleting in a follow-up.

**Resolved threads:** both previously-open threads were already resolved before this pass (verified still fixed, left as-is). 2 stale inline review comments minimized as outdated; all 7 prior bot reviews were already dismissed.

**PR title check:** OK — `feat(mobile): RGPD export + suppression de compte` follows `<type>(<scope>): <description>`.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date — `TRACKING.md` correctly tracks #1118/PR #1132 (`🚧 En cours`) and documents this PR's fix rounds.
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments (0 new findings; the one observation above is outside this PR's diff).

**Commit reviewed:** `ec4e40423c16c8936fb71bea2f145aa824878dd4`
<!-- claude-review-end -->