### PR TITLE
feat(mobile): enregistrement + réception push FCM

### DIFF
--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -3,11 +3,14 @@ import { StatusBar } from 'expo-status-bar';
 import { useTranslation } from 'react-i18next';
 import '../src/i18n';
 import { AuthProvider } from '../src/auth/store';
+import { usePushRouting } from '../src/notifications/use-push-routing';
 import { ThemeProvider, useTheme } from '../src/theme';
 
 function RootNavigator() {
   const { t } = useTranslation();
   const theme = useTheme();
+  // Route notification taps (warm + cold start) to the concerned screen (#1125).
+  usePushRouting();
   return (
     <Stack
       // The header integrates with the theme (light/dark) instead of the default

--- a/mobile/src/auth/authApi.push.test.ts
+++ b/mobile/src/auth/authApi.push.test.ts
@@ -1,0 +1,46 @@
+/// <reference types="jest" />
+
+// Regression (#1125): on a definitively failed refresh, doRefresh must unregister
+// the push token BEFORE clearing the tokens — the DELETE /users/me/device-tokens
+// needs a valid JWT (Authorization), so clearing first would 401 and leave the
+// token alive server-side. The order is asserted via a shared call-order array.
+const order: string[] = [];
+
+jest.mock('../notifications/push', () => ({
+  unregisterDeviceToken: jest.fn(async () => {
+    order.push('unregister');
+  }),
+}));
+jest.mock('./session', () => ({ notifySessionInvalidated: jest.fn() }));
+jest.mock('./tokens', () => ({
+  getRefresh: jest.fn(() => 'refresh-token'),
+  setTokens: jest.fn(async () => undefined),
+  clearTokens: jest.fn(async () => {
+    order.push('clear');
+  }),
+}));
+
+import { refreshTokens } from './authApi';
+import { unregisterDeviceToken } from '../notifications/push';
+import { clearTokens } from './tokens';
+
+const unregister = unregisterDeviceToken as jest.Mock;
+const clear = clearTokens as jest.Mock;
+
+beforeEach(() => {
+  order.length = 0;
+  jest.clearAllMocks();
+  // A rejected refresh drives doRefresh down the definitive-failure branch.
+  globalThis.fetch = jest.fn().mockResolvedValue({ ok: false, json: async () => ({}) });
+});
+
+describe('doRefresh definitive failure (#1125)', () => {
+  it('unregisters the push token before clearing the tokens', async () => {
+    const ok = await refreshTokens();
+
+    expect(ok).toBe(false);
+    expect(unregister).toHaveBeenCalledTimes(1);
+    expect(clear).toHaveBeenCalledTimes(1);
+    expect(order).toEqual(['unregister', 'clear']);
+  });
+});

--- a/mobile/src/auth/authApi.ts
+++ b/mobile/src/auth/authApi.ts
@@ -1,4 +1,5 @@
 import { API_BASE_URL, LD_JSON } from '../api/config';
+import { unregisterDeviceToken } from '../notifications/push';
 import { notifySessionInvalidated } from './session';
 import { clearTokens, getRefresh, setTokens } from './tokens';
 
@@ -59,8 +60,12 @@ async function doRefresh(): Promise<boolean> {
       }
     }
   }
-  // Definitive failure (no refresh token, rejected, or malformed body): wipe the
-  // dead session and signal AuthProvider so the UI redirects to /login.
+  // Definitive failure (no refresh token, rejected, or malformed body): unregister
+  // the push token while the JWT is still valid (the DELETE needs Authorization),
+  // then wipe the dead session and signal AuthProvider so the UI redirects to
+  // /login. Order matters: clearTokens() first would strip the Bearer and the
+  // DELETE would 401, leaving the token alive server-side (#1125).
+  await unregisterDeviceToken().catch(() => undefined);
   await clearTokens();
   notifySessionInvalidated();
   return false;

--- a/mobile/src/auth/store.push.test.tsx
+++ b/mobile/src/auth/store.push.test.tsx
@@ -3,6 +3,7 @@ import TestRenderer, { act } from 'react-test-renderer';
 import { AuthProvider, useAuth } from './store';
 import { registerDeviceToken, unregisterDeviceToken } from '../notifications/push';
 import { verifyMagicToken } from './authApi';
+import { onSessionInvalidated } from './session';
 
 // Wiring test (#1125): the AuthProvider must register the push token on login and
 // unregister it on logout. The push module itself is stubbed — its POST/DELETE
@@ -68,6 +69,28 @@ describe('AuthProvider push wiring', () => {
 
     await act(async () => {
       await auth.logout();
+    });
+
+    expect(unregister).toHaveBeenCalledTimes(1);
+  });
+
+  it('unregisters the device token when the session is invalidated', async () => {
+    // Capture the callback the provider hands to onSessionInvalidated so we can
+    // fire it as an out-of-band refresh failure would.
+    let onInvalidated: (() => void) | undefined;
+    (onSessionInvalidated as jest.Mock).mockImplementation((cb: () => void) => {
+      onInvalidated = cb;
+      return () => undefined;
+    });
+    verify.mockResolvedValue(true);
+    await mount();
+    await act(async () => {
+      await auth.verify('magic-token');
+    });
+
+    await act(async () => {
+      onInvalidated?.();
+      await Promise.resolve();
     });
 
     expect(unregister).toHaveBeenCalledTimes(1);

--- a/mobile/src/auth/store.push.test.tsx
+++ b/mobile/src/auth/store.push.test.tsx
@@ -74,9 +74,11 @@ describe('AuthProvider push wiring', () => {
     expect(unregister).toHaveBeenCalledTimes(1);
   });
 
-  it('unregisters the device token when the session is invalidated', async () => {
+  it('flips authenticated to false on session invalidation without unregistering (#1125)', async () => {
     // Capture the callback the provider hands to onSessionInvalidated so we can
-    // fire it as an out-of-band refresh failure would.
+    // fire it as an out-of-band refresh failure would. Unregister now happens in
+    // doRefresh (while the JWT is still valid), NOT here — by the time this fires
+    // the JWT is already cleared, so a DELETE would 401.
     let onInvalidated: (() => void) | undefined;
     (onSessionInvalidated as jest.Mock).mockImplementation((cb: () => void) => {
       onInvalidated = cb;
@@ -87,12 +89,14 @@ describe('AuthProvider push wiring', () => {
     await act(async () => {
       await auth.verify('magic-token');
     });
+    expect(auth.authenticated).toBe(true);
 
     await act(async () => {
       onInvalidated?.();
       await Promise.resolve();
     });
 
-    expect(unregister).toHaveBeenCalledTimes(1);
+    expect(auth.authenticated).toBe(false);
+    expect(unregister).not.toHaveBeenCalled();
   });
 });

--- a/mobile/src/auth/store.push.test.tsx
+++ b/mobile/src/auth/store.push.test.tsx
@@ -1,0 +1,75 @@
+/// <reference types="jest" />
+import TestRenderer, { act } from 'react-test-renderer';
+import { AuthProvider, useAuth } from './store';
+import { registerDeviceToken, unregisterDeviceToken } from '../notifications/push';
+import { verifyMagicToken } from './authApi';
+
+// Wiring test (#1125): the AuthProvider must register the push token on login and
+// unregister it on logout. The push module itself is stubbed — its POST/DELETE
+// behaviour is covered by push.test.ts.
+jest.mock('../notifications/push', () => ({
+  registerDeviceToken: jest.fn().mockResolvedValue(undefined),
+  unregisterDeviceToken: jest.fn().mockResolvedValue(undefined),
+  subscribeTokenRotation: jest.fn(() => ({ remove: jest.fn() })),
+}));
+
+jest.mock('./authApi', () => ({ verifyMagicToken: jest.fn() }));
+jest.mock('./tokens', () => ({
+  loadTokens: jest.fn().mockResolvedValue({ jwt: null, refresh: null }),
+  clearTokens: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('./session', () => ({ onSessionInvalidated: jest.fn(() => () => undefined) }));
+jest.mock('../api/client', () => ({
+  api: { GET: jest.fn().mockResolvedValue({ data: { email: 'a@b.co' } }) },
+}));
+
+const register = registerDeviceToken as jest.Mock;
+const unregister = unregisterDeviceToken as jest.Mock;
+const verify = verifyMagicToken as jest.Mock;
+
+let auth: ReturnType<typeof useAuth>;
+function Capture() {
+  auth = useAuth();
+  return null;
+}
+
+async function mount() {
+  await act(async () => {
+    TestRenderer.create(
+      <AuthProvider>
+        <Capture />
+      </AuthProvider>,
+    );
+    await Promise.resolve();
+  });
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('AuthProvider push wiring', () => {
+  it('registers the device token on login', async () => {
+    verify.mockResolvedValue(true);
+    await mount();
+    expect(register).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await auth.verify('magic-token');
+    });
+
+    expect(register).toHaveBeenCalledTimes(1);
+  });
+
+  it('unregisters the device token on logout', async () => {
+    verify.mockResolvedValue(true);
+    await mount();
+    await act(async () => {
+      await auth.verify('magic-token');
+    });
+
+    await act(async () => {
+      await auth.logout();
+    });
+
+    expect(unregister).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mobile/src/auth/store.test.tsx
+++ b/mobile/src/auth/store.test.tsx
@@ -10,6 +10,14 @@ jest.mock('./tokens', () => ({
 }));
 jest.mock('./authApi', () => ({ verifyMagicToken: jest.fn() }));
 jest.mock('./session', () => ({ onSessionInvalidated: jest.fn(() => () => {}) }));
+// The provider registers / unregisters the push token as a side effect (#1125);
+// stub the push module so this stale-response-guard test never touches the native
+// notifications layer (its own behaviour is covered by store.push.test.tsx).
+jest.mock('../notifications/push', () => ({
+  registerDeviceToken: jest.fn().mockResolvedValue(undefined),
+  unregisterDeviceToken: jest.fn().mockResolvedValue(undefined),
+  subscribeTokenRotation: jest.fn(() => ({ remove: jest.fn() })),
+}));
 
 import { api } from '../api/client';
 import { loadTokens } from './tokens';

--- a/mobile/src/auth/store.tsx
+++ b/mobile/src/auth/store.tsx
@@ -27,9 +27,10 @@ type AuthContextValue = {
 
 const AuthContext = createContext<AuthContextValue | null>(null);
 
-// Best-effort push-token unregister, shared by explicit logout and out-of-band
-// session invalidation (#1125). On invalidation the JWT may already be cleared,
-// so the DELETE can fail server-side — swallow it so it never blocks teardown.
+// Best-effort push-token unregister for explicit logout, while the JWT is still
+// valid. Out-of-band session invalidation unregisters in doRefresh (before it
+// clears the tokens), not here — by the time onSessionInvalidated fires the JWT
+// is already gone, so a DELETE here would 401 (#1125).
 function dropPushToken(): Promise<void> {
   return unregisterDeviceToken().catch(() => undefined);
 }
@@ -87,17 +88,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return () => rotation.remove();
   }, [authenticated]);
 
-  // A refresh that definitively fails clears the tokens outside React; unregister
-  // the push token (so an expired session stops receiving pushes) and flip the
-  // state so the (tabs) guard redirects to /login instead of 401'ing forever.
-  useEffect(
-    () =>
-      onSessionInvalidated(() => {
-        void dropPushToken();
-        endSession();
-      }),
-    [endSession],
-  );
+  // A refresh that definitively fails clears the tokens outside React (after
+  // unregistering the push token, in doRefresh). Flip the state so the (tabs)
+  // guard redirects to /login instead of 401'ing forever.
+  useEffect(() => onSessionInvalidated(endSession), [endSession]);
 
   const requestLink = useCallback(async (email: string): Promise<boolean> => {
     const { response } = await api.POST('/auth/request-link', {

--- a/mobile/src/auth/store.tsx
+++ b/mobile/src/auth/store.tsx
@@ -27,6 +27,13 @@ type AuthContextValue = {
 
 const AuthContext = createContext<AuthContextValue | null>(null);
 
+// Best-effort push-token unregister, shared by explicit logout and out-of-band
+// session invalidation (#1125). On invalidation the JWT may already be cleared,
+// so the DELETE can fail server-side — swallow it so it never blocks teardown.
+function dropPushToken(): Promise<void> {
+  return unregisterDeviceToken().catch(() => undefined);
+}
+
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [ready, setReady] = useState(false);
   const [authenticated, setAuthenticated] = useState(false);
@@ -80,9 +87,17 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return () => rotation.remove();
   }, [authenticated]);
 
-  // A refresh that definitively fails clears the tokens outside React; flip the
+  // A refresh that definitively fails clears the tokens outside React; unregister
+  // the push token (so an expired session stops receiving pushes) and flip the
   // state so the (tabs) guard redirects to /login instead of 401'ing forever.
-  useEffect(() => onSessionInvalidated(endSession), [endSession]);
+  useEffect(
+    () =>
+      onSessionInvalidated(() => {
+        void dropPushToken();
+        endSession();
+      }),
+    [endSession],
+  );
 
   const requestLink = useCallback(async (email: string): Promise<boolean> => {
     const { response } = await api.POST('/auth/request-link', {
@@ -112,9 +127,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const logout = useCallback(async (): Promise<void> => {
     // Unregister the push token while the JWT is still valid, so a shared device
-    // stops receiving this account's pushes (#1125). Best-effort: a failure must
-    // not block logout.
-    await unregisterDeviceToken().catch(() => undefined);
+    // stops receiving this account's pushes (#1125).
+    await dropPushToken();
     await clearTokens();
     endSession();
   }, [endSession]);

--- a/mobile/src/auth/store.tsx
+++ b/mobile/src/auth/store.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react';
 import { api } from '../api/client';
 import { LD_JSON } from '../api/config';
+import { registerDeviceToken, subscribeTokenRotation, unregisterDeviceToken } from '../notifications/push';
 import { verifyMagicToken } from './authApi';
 import { onSessionInvalidated } from './session';
 import { clearTokens, loadTokens } from './tokens';
@@ -69,6 +70,16 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     };
   }, [authenticated]);
 
+  // Register this device's push token once authenticated (fresh login or a
+  // restored session), and re-register on OS token rotation (#1125). Silent no-op
+  // when push permission is absent.
+  useEffect(() => {
+    if (!authenticated) return;
+    void registerDeviceToken();
+    const rotation = subscribeTokenRotation();
+    return () => rotation.remove();
+  }, [authenticated]);
+
   // A refresh that definitively fails clears the tokens outside React; flip the
   // state so the (tabs) guard redirects to /login instead of 401'ing forever.
   useEffect(() => onSessionInvalidated(endSession), [endSession]);
@@ -100,6 +111,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const logout = useCallback(async (): Promise<void> => {
+    // Unregister the push token while the JWT is still valid, so a shared device
+    // stops receiving this account's pushes (#1125). Best-effort: a failure must
+    // not block logout.
+    await unregisterDeviceToken().catch(() => undefined);
     await clearTokens();
     endSession();
   }, [endSession]);

--- a/mobile/src/notifications/push-routing.test.ts
+++ b/mobile/src/notifications/push-routing.test.ts
@@ -1,0 +1,25 @@
+/// <reference types="jest" />
+import { resolvePushRoute } from './push-routing';
+
+describe('resolvePushRoute', () => {
+  it('routes a stage-scoped payload to the stage screen', () => {
+    expect(resolvePushRoute({ tripId: 't1', stageIndex: 3 })).toBe('/trip/t1/stage/3');
+    expect(resolvePushRoute({ tripId: 't1', stageIndex: '0' })).toBe('/trip/t1/stage/0');
+  });
+
+  it('routes a trip-scoped payload to the roadbook', () => {
+    expect(resolvePushRoute({ tripId: 't1', category: 'analysisDone' })).toBe('/trip/t1');
+  });
+
+  it('routes a zone-opening announcement to the create tab', () => {
+    expect(resolvePushRoute({ category: 'zoneOpening' })).toBe('/(tabs)/create');
+  });
+
+  it('returns null when nothing is actionable', () => {
+    expect(resolvePushRoute(null)).toBeNull();
+    expect(resolvePushRoute(undefined)).toBeNull();
+    expect(resolvePushRoute({})).toBeNull();
+    expect(resolvePushRoute({ category: 'weatherSafety' })).toBeNull();
+    expect(resolvePushRoute({ stageIndex: 2 })).toBeNull();
+  });
+});

--- a/mobile/src/notifications/push-routing.ts
+++ b/mobile/src/notifications/push-routing.ts
@@ -1,0 +1,30 @@
+import type { Href } from 'expo-router';
+
+// Shape of the `data` payload the backend attaches to a push. Every field is
+// optional; routing degrades to null when nothing actionable is present. The
+// backend keys on the same three server-push categories as the prefs store
+// (weatherSafety, analysisDone, zoneOpening).
+export type PushData = {
+  category?: string;
+  tripId?: string;
+  stageIndex?: string | number;
+};
+
+// Map a notification payload to the in-app route to open on tap. Pure, so it is
+// unit-testable without a navigator. Most specific target wins: a stage-scoped
+// payload opens the stage, a trip-scoped one the roadbook, a zone-opening
+// announcement the trip-creation tab (where a newly-opened region is usable).
+export function resolvePushRoute(data: PushData | null | undefined): Href | null {
+  if (!data) return null;
+  const stage = data.stageIndex;
+  if (data.tripId && stage != null && `${stage}` !== '') {
+    return `/trip/${data.tripId}/stage/${stage}` as Href;
+  }
+  if (data.tripId) {
+    return `/trip/${data.tripId}` as Href;
+  }
+  if (data.category === 'zoneOpening') {
+    return '/(tabs)/create' as Href;
+  }
+  return null;
+}

--- a/mobile/src/notifications/push.test.ts
+++ b/mobile/src/notifications/push.test.ts
@@ -55,6 +55,12 @@ describe('registerDeviceToken', () => {
     await registerDeviceToken();
     expect(post).not.toHaveBeenCalled();
   });
+
+  it('resolves without throwing and skips the POST when the permission API itself throws', async () => {
+    getPerms.mockRejectedValue(new Error('no Google Play Services'));
+    await expect(registerDeviceToken()).resolves.toBeUndefined();
+    expect(post).not.toHaveBeenCalled();
+  });
 });
 
 describe('unregisterDeviceToken', () => {

--- a/mobile/src/notifications/push.test.ts
+++ b/mobile/src/notifications/push.test.ts
@@ -1,0 +1,91 @@
+/// <reference types="jest" />
+import { Platform } from 'react-native';
+import * as Notifications from 'expo-notifications';
+import { api } from '../api/client';
+import { registerDeviceToken, subscribeTokenRotation, unregisterDeviceToken } from './push';
+
+jest.mock('expo-notifications', () => ({
+  setNotificationHandler: jest.fn(),
+  getPermissionsAsync: jest.fn(),
+  requestPermissionsAsync: jest.fn(),
+  getDevicePushTokenAsync: jest.fn(),
+  addPushTokenListener: jest.fn(() => ({ remove: jest.fn() })),
+}));
+
+jest.mock('../api/client', () => ({
+  api: { POST: jest.fn().mockResolvedValue({}), DELETE: jest.fn().mockResolvedValue({}) },
+}));
+
+const getPerms = Notifications.getPermissionsAsync as jest.Mock;
+const reqPerms = Notifications.requestPermissionsAsync as jest.Mock;
+const getToken = Notifications.getDevicePushTokenAsync as jest.Mock;
+const post = api.POST as jest.Mock;
+const del = api.DELETE as jest.Mock;
+
+const expectedPlatform =
+  Platform.OS === 'android' ? 'android' : Platform.OS === 'ios' ? 'ios' : null;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  getPerms.mockResolvedValue({ granted: true });
+  getToken.mockResolvedValue({ type: 'android', data: 'fcm-token-abc' });
+});
+
+describe('registerDeviceToken', () => {
+  it('POSTs the native token + platform when permission is granted', async () => {
+    await registerDeviceToken();
+    expect(post).toHaveBeenCalledTimes(1);
+    expect(post).toHaveBeenCalledWith(
+      '/users/me/device-tokens',
+      expect.objectContaining({ body: { token: 'fcm-token-abc', platform: expectedPlatform } }),
+    );
+  });
+
+  it('requests permission when not yet granted, then registers', async () => {
+    getPerms.mockResolvedValue({ granted: false });
+    reqPerms.mockResolvedValue({ granted: true });
+    await registerDeviceToken();
+    expect(reqPerms).toHaveBeenCalledTimes(1);
+    expect(post).toHaveBeenCalledTimes(1);
+  });
+
+  it('is a silent no-op when permission is denied', async () => {
+    getPerms.mockResolvedValue({ granted: false });
+    reqPerms.mockResolvedValue({ granted: false });
+    await registerDeviceToken();
+    expect(post).not.toHaveBeenCalled();
+  });
+});
+
+describe('unregisterDeviceToken', () => {
+  it('DELETEs the token registered this session', async () => {
+    await registerDeviceToken();
+    await unregisterDeviceToken();
+    expect(del).toHaveBeenCalledWith(
+      '/users/me/device-tokens/{token}',
+      expect.objectContaining({ params: { path: { token: 'fcm-token-abc' } } }),
+    );
+  });
+
+  it('is a no-op when nothing was registered', async () => {
+    // Fresh module state guaranteed by clearing the registered token first.
+    await unregisterDeviceToken();
+    await unregisterDeviceToken();
+    expect(del).not.toHaveBeenCalled();
+  });
+});
+
+describe('subscribeTokenRotation', () => {
+  it('re-registers when the OS emits a rotated token', async () => {
+    await registerDeviceToken();
+    post.mockClear();
+    subscribeTokenRotation();
+    const listener = (Notifications.addPushTokenListener as jest.Mock).mock.calls[0][0];
+    listener({ type: 'android', data: 'fcm-token-rotated' });
+    // The listener re-registers fire-and-forget; flush the permission + token
+    // fetch microtasks before asserting the POST landed.
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+    expect(post).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mobile/src/notifications/push.test.ts
+++ b/mobile/src/notifications/push.test.ts
@@ -29,6 +29,10 @@ beforeEach(() => {
   jest.clearAllMocks();
   getPerms.mockResolvedValue({ granted: true });
   getToken.mockResolvedValue({ type: 'android', data: 'fcm-token-abc' });
+  // clearAllMocks resets call records but not implementations; restore the happy
+  // path so a per-test mockRejectedValue does not leak into the next test.
+  post.mockResolvedValue({});
+  del.mockResolvedValue({});
 });
 
 describe('registerDeviceToken', () => {
@@ -60,6 +64,12 @@ describe('registerDeviceToken', () => {
     getPerms.mockRejectedValue(new Error('no Google Play Services'));
     await expect(registerDeviceToken()).resolves.toBeUndefined();
     expect(post).not.toHaveBeenCalled();
+  });
+
+  it('resolves without throwing when the POST rejects (offline/timeout)', async () => {
+    post.mockRejectedValue(new Error('network error'));
+    await expect(registerDeviceToken()).resolves.toBeUndefined();
+    expect(post).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/mobile/src/notifications/push.ts
+++ b/mobile/src/notifications/push.ts
@@ -36,13 +36,17 @@ function devicePlatform(): DevicePlatform {
 // null when permission is absent or the OS cannot mint one (e.g. a simulator
 // without push support): registration is then a silent no-op.
 async function fetchDeviceToken(): Promise<string | null> {
-  const current = await Notifications.getPermissionsAsync();
-  const granted = current.granted || (await Notifications.requestPermissionsAsync()).granted;
-  if (!granted) return null;
   try {
+    const current = await Notifications.getPermissionsAsync();
+    const granted = current.granted || (await Notifications.requestPermissionsAsync()).granted;
+    if (!granted) return null;
     const { data } = await Notifications.getDevicePushTokenAsync();
     return typeof data === 'string' ? data : null;
   } catch {
+    // The permission API itself throws on some builds (Android without Google
+    // Play Services, custom ROMs, emulators), not just getDevicePushTokenAsync.
+    // register is fired fire-and-forget from the auth store, so an unhandled
+    // rejection would crash it — keep the whole path a silent no-op.
     return null;
   }
 }

--- a/mobile/src/notifications/push.ts
+++ b/mobile/src/notifications/push.ts
@@ -16,15 +16,19 @@ let registeredToken: string | null = null;
 
 // Foreground presentation: the OS suppresses banners while the app is in the
 // foreground unless a handler opts in. Service pushes (weather, analysis) are
-// worth showing; badges stay off (no unread-count model).
-Notifications.setNotificationHandler({
-  handleNotification: async () => ({
-    shouldShowBanner: true,
-    shouldShowList: true,
-    shouldPlaySound: true,
-    shouldSetBadge: false,
-  }),
-});
+// worth showing; badges stay off (no unread-count model). Called once at app
+// start (usePushRouting) rather than at import, so pulling this module in for
+// register/unregister carries no side effect (keeps the auth store unit-testable).
+export function configurePushPresentation(): void {
+  Notifications.setNotificationHandler({
+    handleNotification: async () => ({
+      shouldShowBanner: true,
+      shouldShowList: true,
+      shouldPlaySound: true,
+      shouldSetBadge: false,
+    }),
+  });
+}
 
 function devicePlatform(): DevicePlatform {
   if (Platform.OS === 'android') return 'android';

--- a/mobile/src/notifications/push.ts
+++ b/mobile/src/notifications/push.ts
@@ -1,0 +1,82 @@
+import * as Notifications from 'expo-notifications';
+import { Platform } from 'react-native';
+import { api } from '../api/client';
+import { LD_JSON } from '../api/config';
+
+// Server-driven push (#1125): register this device's native FCM (Android) / APNs
+// (iOS) token with the backend so it can target the user, and route an incoming
+// notification to the right screen. Distinct from on-device local triggers
+// (#1121, `notifications/local.*` if present) — this file only owns the push leg.
+
+type DevicePlatform = 'android' | 'ios' | null;
+
+// Token registered this session, kept so logout can DELETE it without re-querying
+// the OS (permission may already be gone). Also gates the rotation listener.
+let registeredToken: string | null = null;
+
+// Foreground presentation: the OS suppresses banners while the app is in the
+// foreground unless a handler opts in. Service pushes (weather, analysis) are
+// worth showing; badges stay off (no unread-count model).
+Notifications.setNotificationHandler({
+  handleNotification: async () => ({
+    shouldShowBanner: true,
+    shouldShowList: true,
+    shouldPlaySound: true,
+    shouldSetBadge: false,
+  }),
+});
+
+function devicePlatform(): DevicePlatform {
+  if (Platform.OS === 'android') return 'android';
+  if (Platform.OS === 'ios') return 'ios';
+  return null;
+}
+
+// Obtain the native device token the backend `DeviceToken` entity stores. Returns
+// null when permission is absent or the OS cannot mint one (e.g. a simulator
+// without push support): registration is then a silent no-op.
+async function fetchDeviceToken(): Promise<string | null> {
+  const current = await Notifications.getPermissionsAsync();
+  const granted = current.granted || (await Notifications.requestPermissionsAsync()).granted;
+  if (!granted) return null;
+  try {
+    const { data } = await Notifications.getDevicePushTokenAsync();
+    return typeof data === 'string' ? data : null;
+  } catch {
+    return null;
+  }
+}
+
+// Idempotent upsert of this device's token for the current user. Safe to call on
+// every login and on rotation: the backend dedupes by token (schema comment) and
+// reassigns a token held by another account.
+export async function registerDeviceToken(): Promise<void> {
+  const token = await fetchDeviceToken();
+  if (!token) return;
+  registeredToken = token;
+  await api.POST('/users/me/device-tokens', {
+    body: { token, platform: devicePlatform() },
+    headers: { 'Content-Type': LD_JSON, Accept: LD_JSON },
+  });
+}
+
+// Remove this device's token on logout so a shared device stops receiving the
+// previous user's pushes. Must run while the JWT is still valid (before
+// clearTokens). No-op when nothing was registered this session.
+export async function unregisterDeviceToken(): Promise<void> {
+  const token = registeredToken;
+  if (!token) return;
+  registeredToken = null;
+  await api.DELETE('/users/me/device-tokens/{token}', {
+    params: { path: { token } },
+    headers: { Accept: LD_JSON },
+  });
+}
+
+// FCM/APNs rotate tokens out of band; re-register when the OS emits a new one so
+// the backend never targets a dead token. Only acts once a session is registered.
+export function subscribeTokenRotation(): { remove: () => void } {
+  return Notifications.addPushTokenListener(() => {
+    if (registeredToken) void registerDeviceToken();
+  });
+}

--- a/mobile/src/notifications/push.ts
+++ b/mobile/src/notifications/push.ts
@@ -58,10 +58,16 @@ export async function registerDeviceToken(): Promise<void> {
   const token = await fetchDeviceToken();
   if (!token) return;
   registeredToken = token;
-  await api.POST('/users/me/device-tokens', {
-    body: { token, platform: devicePlatform() },
-    headers: { 'Content-Type': LD_JSON, Accept: LD_JSON },
-  });
+  try {
+    await api.POST('/users/me/device-tokens', {
+      body: { token, platform: devicePlatform() },
+      headers: { 'Content-Type': LD_JSON, Accept: LD_JSON },
+    });
+  } catch {
+    // Best-effort: register is fired fire-and-forget from the auth store, so a
+    // network reject (offline/timeout) must not crash it. Registration retries
+    // on the next login/rotation. Symmetric to unregisterDeviceToken.
+  }
 }
 
 // Remove this device's token on logout so a shared device stops receiving the

--- a/mobile/src/notifications/use-push-routing.ts
+++ b/mobile/src/notifications/use-push-routing.ts
@@ -1,16 +1,19 @@
 import { useEffect } from 'react';
 import { useRouter } from 'expo-router';
 import * as Notifications from 'expo-notifications';
+import { configurePushPresentation } from './push';
 import { resolvePushRoute, type PushData } from './push-routing';
 
 // Install the notification-tap listeners and navigate to the mapped route.
 // Handles both the warm path (tap while running/backgrounded) and the cold
-// path (app opened by tapping a notification while it was killed). Foreground
-// presentation is owned by the handler in `push.ts`. Mount once, near the root.
+// path (app opened by tapping a notification while it was killed). Also sets the
+// foreground presentation handler (owned by push.ts). Mount once, near the root.
 export function usePushRouting(): void {
   const router = useRouter();
 
   useEffect(() => {
+    configurePushPresentation();
+
     const go = (data: unknown) => {
       const route = resolvePushRoute(data as PushData);
       if (route) router.push(route);

--- a/mobile/src/notifications/use-push-routing.ts
+++ b/mobile/src/notifications/use-push-routing.ts
@@ -1,0 +1,31 @@
+import { useEffect } from 'react';
+import { useRouter } from 'expo-router';
+import * as Notifications from 'expo-notifications';
+import { resolvePushRoute, type PushData } from './push-routing';
+
+// Install the notification-tap listeners and navigate to the mapped route.
+// Handles both the warm path (tap while running/backgrounded) and the cold
+// path (app opened by tapping a notification while it was killed). Foreground
+// presentation is owned by the handler in `push.ts`. Mount once, near the root.
+export function usePushRouting(): void {
+  const router = useRouter();
+
+  useEffect(() => {
+    const go = (data: unknown) => {
+      const route = resolvePushRoute(data as PushData);
+      if (route) router.push(route);
+    };
+
+    // Cold start: the notification whose tap launched the app.
+    void Notifications.getLastNotificationResponseAsync().then((response) => {
+      if (response) go(response.notification.request.content.data);
+    });
+
+    // Warm: tap while the app is already running.
+    const sub = Notifications.addNotificationResponseReceivedListener((response) => {
+      go(response.notification.request.content.data);
+    });
+
+    return () => sub.remove();
+  }, [router]);
+}


### PR DESCRIPTION
Ferme #1125. Volet **mobile** du push FCM : enregistrement du token de l'appareil auprès du backend + routage des notifications entrantes vers le bon écran.

Rebasée sur `main` après le merge de la stack backend (#1128/#1136/#1137), donc réduite à son périmètre propre (les écrans Notifications/compte, RGPD, etc. étant déjà arrivés via #1141/#1132/#1144).

## Contenu (6 commits, mobile only)
- `notifications/push.ts` : `registerDeviceToken` (upsert idempotent, POST /users/me/device-tokens), `unregisterDeviceToken` (DELETE au logout, tant que le JWT est valide), `subscribeTokenRotation` (re-register sur rotation OS), `configurePushPresentation` (handler premier plan, appelé au démarrage — pas à l'import, pour rester testable).
- `notifications/push-routing.ts` + `use-push-routing.ts` : résolution + navigation au tap (cold/warm), monté une fois près de la racine.
- `auth/store.tsx` : register à l'authentification, unregister au logout ; unregister avant clearTokens sur invalidation de session (dans doRefresh, tant que le JWT est valide).

## Vérification
- `tsc --noEmit` vert, mes suites push/store vertes (19 tests).
- Suite mobile complète : seuls échouent les 2 tests **déjà flaky sur `main`** dans l'environnement local (notifications/ShareSheet) — identique au baseline `origin/main`, non lié à cette PR.

<!-- claude-review-start -->
## Claude Review

**Summary:** All previously-flagged issues are now fixed. The session-invalidation push-token unregister now actually reaches the server: `authApi.ts`'s `doRefresh()` calls `unregisterDeviceToken().catch(() => undefined)` before `clearTokens()`, so the `DELETE` fires with a still-valid JWT instead of 401'ing silently after the token cache was wiped — with a new `authApi.push.test.ts` asserting the call order. The stale-response `cancelled` guard on the `GET /users/me` effect also now has explicit regression coverage in `store.test.tsx` (logout-races-response and refreshEmail-races-response cases). No new correctness, security, or performance issues found in this pass; scope stays mobile-only (register/unregister/rotation, tap routing, foreground presentation moved out of module-import side effect into `configurePushPresentation()`).

**Resolved threads:** Resolved 3 previously open bot threads, now addressed by the current diff:
- Session-invalidation unregister timing bug (JWT already wiped) — fixed in `authApi.ts`.
- Session-invalidation unregister missing entirely — fixed in `authApi.ts`.
- Stale-response `cancelled` guard untested — fixed in `store.test.tsx`.

7 previous bot reviews dismissed/minimized as superseded.

**PR title check:** `feat(mobile): enregistrement + réception push FCM` — description is a French nominal phrase, not imperative mood (e.g. "register device + route push notifications").

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments — no new code-level findings this pass.

**Commit reviewed:** `1176182ea52fd0ebdb9bfd47e9a0a67f59ffb37d`
<!-- claude-review-end -->