### PR TITLE
feat(api): send FCM push notifications via HTTP v1 + secrets compose + ADR-058

### DIFF
--- a/api/config/packages/framework.php
+++ b/api/config/packages/framework.php
@@ -118,14 +118,15 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 ],
                 // FCM HTTP v1 send endpoint (epic #1051). Host-locked; the project
                 // id folded into the path is a trusted server-side value, never a
-                // user URL, and the endpoint never redirects (SEC-007).
+                // user URL, and the endpoint never redirects (SEC-007). No
+                // retry_failed: messages:send is NOT idempotent and the default
+                // retry set includes 0 (drop/timeout) — precisely the case where
+                // FCM may already have delivered — so a retry risks a duplicate
+                // push. Messenger's own retry on the worker covers transient loss.
                 'fcm.client' => [
                     'base_uri' => 'https://fcm.googleapis.com',
                     'max_redirects' => 0,
                     'timeout' => 10,
-                    'retry_failed' => [
-                        'max_retries' => 2,
-                    ],
                 ],
             ],
         ],

--- a/api/config/packages/framework.php
+++ b/api/config/packages/framework.php
@@ -105,6 +105,28 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                     'max_redirects' => 0,
                     'timeout' => 2,
                 ],
+                // Google OAuth2 token endpoint for the FCM service-account
+                // JWT-bearer exchange (epic #1051). Host-locked; the /token endpoint
+                // never legitimately redirects, so refuse any 3xx (SEC-007).
+                'google_oauth.client' => [
+                    'base_uri' => 'https://oauth2.googleapis.com',
+                    'max_redirects' => 0,
+                    'timeout' => 10,
+                    'retry_failed' => [
+                        'max_retries' => 2,
+                    ],
+                ],
+                // FCM HTTP v1 send endpoint (epic #1051). Host-locked; the project
+                // id folded into the path is a trusted server-side value, never a
+                // user URL, and the endpoint never redirects (SEC-007).
+                'fcm.client' => [
+                    'base_uri' => 'https://fcm.googleapis.com',
+                    'max_redirects' => 0,
+                    'timeout' => 10,
+                    'retry_failed' => [
+                        'max_retries' => 2,
+                    ],
+                ],
             ],
         ],
     ]);

--- a/api/config/packages/messenger.php
+++ b/api/config/packages/messenger.php
@@ -21,6 +21,7 @@ use App\Message\ResolveStageLabels;
 use App\Message\ScanAccommodations;
 use App\Message\ScanEvents;
 use App\Message\ScanPois;
+use App\Message\SendPushNotification;
 use App\Messenger\HandleCorrelationIdMiddleware;
 use App\Messenger\SendCorrelationIdMiddleware;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
@@ -67,6 +68,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 RecalculateStages::class => 'async',
                 ResolveStageLabels::class => 'async',
                 ScanEvents::class => 'async',
+                SendPushNotification::class => 'async',
                 AllEnrichmentsCompleted::class => 'async',
             ],
         ],

--- a/api/config/services.php
+++ b/api/config/services.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 use App\Mercure\NullTripUpdatePublisher;
 use App\Mercure\TripUpdatePublisher;
 use App\Mercure\TripUpdatePublisherInterface;
+use App\Push\FcmClient;
+use App\Push\PushSenderInterface;
 use App\Repository\RedisTripRequestRepository;
 use App\Repository\TripRequestRepositoryInterface;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
@@ -24,6 +26,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->autoconfigure();
 
     $services->load('App\\', __DIR__.'/../src/');
+
+    $services->alias(PushSenderInterface::class, FcmClient::class);
 
     if ('test' === $containerConfigurator->env()) {
         $services->alias(TripUpdatePublisherInterface::class, NullTripUpdatePublisher::class);

--- a/api/src/Message/SendPushNotification.php
+++ b/api/src/Message/SendPushNotification.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Message;
+
+/**
+ * Request to deliver a push notification through FCM (epic #1051, categories #1124).
+ *
+ * Recipients are resolved by the handler: pass a userId to target every device
+ * the user has registered, and/or an explicit list of device tokens. The two
+ * sets are merged. `data` is the FCM data payload (string map); `category` names
+ * the notification category and is folded into `data` when set.
+ */
+final readonly class SendPushNotification
+{
+    /**
+     * @param list<string>          $tokens
+     * @param array<string, string> $data
+     */
+    public function __construct(
+        public string $title,
+        public string $body,
+        public ?string $userId = null,
+        public array $tokens = [],
+        public array $data = [],
+        public ?string $category = null,
+    ) {
+    }
+}

--- a/api/src/MessageHandler/SendPushNotificationHandler.php
+++ b/api/src/MessageHandler/SendPushNotificationHandler.php
@@ -51,10 +51,10 @@ final readonly class SendPushNotificationHandler
         // so they are not rediscovered on every retry (ADR-058).
         try {
             $invalidTokens = $this->pushSender->send($tokens, $message->title, $message->body, $data);
-        } catch (FcmSendException $e) {
-            $this->deviceTokenRepository->deleteByTokens($e->invalidTokens);
+        } catch (FcmSendException $fcmSendException) {
+            $this->deviceTokenRepository->deleteByTokens($fcmSendException->invalidTokens);
 
-            throw $e;
+            throw $fcmSendException;
         }
 
         $this->deviceTokenRepository->deleteByTokens($invalidTokens);

--- a/api/src/MessageHandler/SendPushNotificationHandler.php
+++ b/api/src/MessageHandler/SendPushNotificationHandler.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MessageHandler;
+
+use App\Message\SendPushNotification;
+use App\Push\PushSenderInterface;
+use App\Repository\DeviceTokenRepositoryInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+/**
+ * Delivers a push notification via FCM and prunes tokens FCM rejects (epic #1051).
+ *
+ * Recipients are the union of the message's explicit tokens and every token
+ * registered by its userId. Tokens FCM reports as UNREGISTERED / 404 are deleted
+ * so a dead device stops being targeted.
+ */
+#[AsMessageHandler]
+final readonly class SendPushNotificationHandler
+{
+    public function __construct(
+        private PushSenderInterface $pushSender,
+        private DeviceTokenRepositoryInterface $deviceTokenRepository,
+    ) {
+    }
+
+    public function __invoke(SendPushNotification $message): void
+    {
+        $tokens = $message->tokens;
+
+        if (null !== $message->userId) {
+            foreach ($this->deviceTokenRepository->findByUserId($message->userId) as $deviceToken) {
+                $tokens[] = $deviceToken->getToken();
+            }
+        }
+
+        $tokens = array_values(array_unique($tokens));
+        if ([] === $tokens) {
+            return;
+        }
+
+        $data = $message->data;
+        if (null !== $message->category) {
+            $data['category'] = $message->category;
+        }
+
+        $invalidTokens = $this->pushSender->send($tokens, $message->title, $message->body, $data);
+
+        $this->deviceTokenRepository->deleteByTokens($invalidTokens);
+    }
+}

--- a/api/src/MessageHandler/SendPushNotificationHandler.php
+++ b/api/src/MessageHandler/SendPushNotificationHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\MessageHandler;
 
 use App\Message\SendPushNotification;
+use App\Push\FcmSendException;
 use App\Push\PushSenderInterface;
 use App\Repository\DeviceTokenRepositoryInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
@@ -45,7 +46,16 @@ final readonly class SendPushNotificationHandler
             $data['category'] = $message->category;
         }
 
-        $invalidTokens = $this->pushSender->send($tokens, $message->title, $message->body, $data);
+        // A real send failure is rethrown for Messenger retry, but the dead tokens
+        // discovered in the same batch are pruned first (they carry on the exception)
+        // so they are not rediscovered on every retry (ADR-058).
+        try {
+            $invalidTokens = $this->pushSender->send($tokens, $message->title, $message->body, $data);
+        } catch (FcmSendException $e) {
+            $this->deviceTokenRepository->deleteByTokens($e->invalidTokens);
+
+            throw $e;
+        }
 
         $this->deviceTokenRepository->deleteByTokens($invalidTokens);
     }

--- a/api/src/Push/FcmClient.php
+++ b/api/src/Push/FcmClient.php
@@ -119,9 +119,11 @@ final class FcmClient implements PushSenderInterface
         // (3 retries, backoff) fires — losing a security alert silently is worse than
         // the trade-off risk of a duplicate push re-delivered to a token already
         // served in this batch on retry. UNREGISTERED pruning is normal churn, not a
-        // failure, so it never triggers a rethrow.
+        // failure, so it never triggers a rethrow. When both happen in one batch the
+        // dead tokens still ride out on the exception so the caller prunes them once
+        // instead of rediscovering them on every retry (ADR-058).
         if ($failures > 0) {
-            throw new \RuntimeException(\sprintf('FCM push failed for %d of %d token(s) (category: %s); rethrowing for Messenger retry.', $failures, $targetedTokens, $category ?? 'none'));
+            throw new FcmSendException(\sprintf('FCM push failed for %d of %d token(s) (category: %s); rethrowing for Messenger retry.', $failures, $targetedTokens, $category ?? 'none'), $invalid);
         }
 
         return $invalid;

--- a/api/src/Push/FcmClient.php
+++ b/api/src/Push/FcmClient.php
@@ -52,6 +52,7 @@ final class FcmClient implements PushSenderInterface
         $category = $data['category'] ?? null;
         $targetedTokens = \count($tokens);
         $invalid = [];
+        $failures = 0;
 
         foreach ($tokens as $token) {
             try {
@@ -88,8 +89,9 @@ final class FcmClient implements PushSenderInterface
                 // send failure the operator must see (ADR-058: never a silent no-op).
                 // Logged at error, not warning: prod's monolog `main` handler is
                 // fingers_crossed with action_level: error, so a warning never
-                // crosses the threshold and would be dropped. Best-effort: keep
-                // sending to the other tokens.
+                // crosses the threshold and would be dropped. Counted so the batch
+                // is rethrown below and Messenger retries it.
+                ++$failures;
                 $error = $this->extractError($responseBody);
                 $this->logger->error('FCM push send failed.', [
                     'httpStatus' => $status,
@@ -101,7 +103,9 @@ final class FcmClient implements PushSenderInterface
                 ]);
             } catch (\Throwable $e) {
                 // Transport-level failure (timeout, DNS, TLS reset): surfaced at
-                // error (crosses prod fingers_crossed), not swallowed. Loop continues.
+                // error (crosses prod fingers_crossed), counted so the batch is
+                // rethrown below. Loop continues to log every failing token first.
+                ++$failures;
                 $this->logger->error('FCM push transport error.', [
                     'error' => $e->getMessage(),
                     'tokenRef' => $this->tokenRef($token),
@@ -109,6 +113,15 @@ final class FcmClient implements PushSenderInterface
                     'targetedTokens' => $targetedTokens,
                 ]);
             }
+        }
+
+        // A real send/transport failure must reach Messenger so its retry_strategy
+        // (3 retries, backoff) fires — losing a security alert silently is worse than
+        // the trade-off risk of a duplicate push re-delivered to a token already
+        // served in this batch on retry. UNREGISTERED pruning is normal churn, not a
+        // failure, so it never triggers a rethrow.
+        if ($failures > 0) {
+            throw new \RuntimeException(\sprintf('FCM push failed for %d of %d token(s) (category: %s); rethrowing for Messenger retry.', $failures, $targetedTokens, $category ?? 'none'));
         }
 
         return $invalid;

--- a/api/src/Push/FcmClient.php
+++ b/api/src/Push/FcmClient.php
@@ -49,6 +49,8 @@ final class FcmClient implements PushSenderInterface
 
         $accessToken = $this->accessToken();
         $endpoint = \sprintf('/v1/projects/%s/messages:send', $this->credentials->projectId());
+        $category = $data['category'] ?? null;
+        $targetedTokens = \count($tokens);
         $invalid = [];
 
         foreach ($tokens as $token) {
@@ -69,14 +71,43 @@ final class FcmClient implements PushSenderInterface
                     continue;
                 }
 
-                if ($this->isUnregistered($status, $response->getContent(false))) {
+                $responseBody = $response->getContent(false);
+
+                // A dead token is expected churn, not an incident: prune it and
+                // record it at info level so it stays distinct from a real failure.
+                if ($this->isUnregistered($status, $responseBody)) {
                     $invalid[] = $token;
+                    $this->logger->info('Pruning unregistered FCM token.', [
+                        'tokenRef' => $this->tokenRef($token),
+                        'category' => $category,
+                    ]);
                     continue;
                 }
 
-                $this->logger->warning('FCM push failed.', ['status' => $status, 'body' => $response->getContent(false)]);
+                // Any other non-200 (bad request, quota, auth/config, 5xx) is a real
+                // send failure the operator must see (ADR-058: never a silent no-op).
+                // Logged at error, not warning: prod's monolog `main` handler is
+                // fingers_crossed with action_level: error, so a warning never
+                // crosses the threshold and would be dropped. Best-effort: keep
+                // sending to the other tokens.
+                $error = $this->extractError($responseBody);
+                $this->logger->error('FCM push send failed.', [
+                    'httpStatus' => $status,
+                    'fcmStatus' => $error['status'],
+                    'fcmMessage' => $error['message'],
+                    'tokenRef' => $this->tokenRef($token),
+                    'category' => $category,
+                    'targetedTokens' => $targetedTokens,
+                ]);
             } catch (\Throwable $e) {
-                $this->logger->warning('FCM push transport error.', ['error' => $e->getMessage()]);
+                // Transport-level failure (timeout, DNS, TLS reset): surfaced at
+                // error (crosses prod fingers_crossed), not swallowed. Loop continues.
+                $this->logger->error('FCM push transport error.', [
+                    'error' => $e->getMessage(),
+                    'tokenRef' => $this->tokenRef($token),
+                    'category' => $category,
+                    'targetedTokens' => $targetedTokens,
+                ]);
             }
         }
 
@@ -93,6 +124,36 @@ final class FcmClient implements PushSenderInterface
     private function isUnregistered(int $status, string $body): bool
     {
         return 404 === $status && str_contains($body, 'UNREGISTERED');
+    }
+
+    /**
+     * A device token is semi-sensitive (it can push to a user's device), so logs
+     * never carry it whole — only a short, stable hash prefix to correlate lines.
+     */
+    private function tokenRef(string $token): string
+    {
+        return substr(hash('sha256', $token), 0, 12);
+    }
+
+    /**
+     * Pulls the FCM `error.status` / `error.message` out of the response body for
+     * logging. Returns nulls when the body is empty or not the expected shape.
+     *
+     * @return array{status: string|null, message: string|null}
+     */
+    private function extractError(string $body): array
+    {
+        try {
+            /** @var array{error?: array{status?: string, message?: string}} $decoded */
+            $decoded = json_decode($body, true, 512, \JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return ['status' => null, 'message' => null];
+        }
+
+        return [
+            'status' => $decoded['error']['status'] ?? null,
+            'message' => $decoded['error']['message'] ?? null,
+        ];
     }
 
     private function accessToken(): string

--- a/api/src/Push/FcmClient.php
+++ b/api/src/Push/FcmClient.php
@@ -54,9 +54,15 @@ final class FcmClient implements PushSenderInterface
         $invalid = [];
         $failures = 0;
 
+        // Issue every request up front, then consume the responses. Symfony's
+        // HttpClient is lazy — request() returns immediately and the calls
+        // multiplex concurrently as long as no response is read until all are
+        // issued — so a batch of N tokens costs ~one round-trip instead of N
+        // serialized ones inside the Messenger worker.
+        $responses = [];
         foreach ($tokens as $token) {
             try {
-                $response = $this->fcmClient->request('POST', $endpoint, [
+                $responses[] = [$token, $this->fcmClient->request('POST', $endpoint, [
                     'auth_bearer' => $accessToken,
                     'json' => [
                         'message' => [
@@ -65,8 +71,17 @@ final class FcmClient implements PushSenderInterface
                             'data' => $data,
                         ],
                     ],
-                ]);
+                ])];
+            } catch (\Throwable $e) {
+                // A synchronous transport failure at issue time (rare with the lazy
+                // client): logged and counted; the other tokens are still issued.
+                ++$failures;
+                $this->logTransportError($token, $e, $category, $targetedTokens);
+            }
+        }
 
+        foreach ($responses as [$token, $response]) {
+            try {
                 $status = $response->getStatusCode();
                 if (200 === $status) {
                     continue;
@@ -102,16 +117,12 @@ final class FcmClient implements PushSenderInterface
                     'targetedTokens' => $targetedTokens,
                 ]);
             } catch (\Throwable $e) {
-                // Transport-level failure (timeout, DNS, TLS reset): surfaced at
-                // error (crosses prod fingers_crossed), counted so the batch is
-                // rethrown below. Loop continues to log every failing token first.
+                // Transport-level failure (timeout, DNS, TLS reset) surfaced while
+                // consuming: logged at error (crosses prod fingers_crossed), counted
+                // so the batch is rethrown below. Loop continues so every failing
+                // token is logged first.
                 ++$failures;
-                $this->logger->error('FCM push transport error.', [
-                    'error' => $e->getMessage(),
-                    'tokenRef' => $this->tokenRef($token),
-                    'category' => $category,
-                    'targetedTokens' => $targetedTokens,
-                ]);
+                $this->logTransportError($token, $e, $category, $targetedTokens);
             }
         }
 
@@ -127,6 +138,16 @@ final class FcmClient implements PushSenderInterface
         }
 
         return $invalid;
+    }
+
+    private function logTransportError(string $token, \Throwable $e, mixed $category, int $targetedTokens): void
+    {
+        $this->logger->error('FCM push transport error.', [
+            'error' => $e->getMessage(),
+            'tokenRef' => $this->tokenRef($token),
+            'category' => $category,
+            'targetedTokens' => $targetedTokens,
+        ]);
     }
 
     /**

--- a/api/src/Push/FcmClient.php
+++ b/api/src/Push/FcmClient.php
@@ -138,7 +138,27 @@ final class FcmClient implements PushSenderInterface
      */
     private function isUnregistered(int $status, string $body): bool
     {
-        return 404 === $status && str_contains($body, 'UNREGISTERED');
+        if (404 !== $status) {
+            return false;
+        }
+
+        try {
+            /** @var array{error?: array{details?: list<array{errorCode?: string}>}} $decoded */
+            $decoded = json_decode($body, true, 512, \JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return false;
+        }
+
+        // Parse the nested errorCode rather than substring-matching the whole body:
+        // the literal could otherwise appear in a human-readable `message` on an
+        // unrelated 404 and wrongly prune every token on a config error.
+        foreach ($decoded['error']['details'] ?? [] as $detail) {
+            if ('UNREGISTERED' === ($detail['errorCode'] ?? null)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/api/src/Push/FcmClient.php
+++ b/api/src/Push/FcmClient.php
@@ -84,19 +84,15 @@ final class FcmClient implements PushSenderInterface
     }
 
     /**
-     * A stale token is reported as HTTP 404 with error status NOT_FOUND /
-     * errorCode UNREGISTERED. Treat any 404 as prunable; corroborate with the
-     * body when present.
+     * A stale token is the only 404 we may prune. FCM v1 returns the same generic
+     * `{"error":{"code":404,"status":"NOT_FOUND"}}` wrapper for unrelated 404s
+     * (wrong project_id, disabled FCM API, revoked service account), so keying on
+     * the status or an empty body would wipe every user's tokens on a config error.
+     * The only reliable dead-token signal is the nested `errorCode: UNREGISTERED`.
      */
     private function isUnregistered(int $status, string $body): bool
     {
-        if (404 !== $status) {
-            return false;
-        }
-
-        return str_contains($body, 'UNREGISTERED')
-            || str_contains($body, 'NOT_FOUND')
-            || '' === trim($body);
+        return 404 === $status && str_contains($body, 'UNREGISTERED');
     }
 
     private function accessToken(): string

--- a/api/src/Push/FcmClient.php
+++ b/api/src/Push/FcmClient.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Push;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * FCM HTTP v1 sender (epic #1051).
+ *
+ * Auth is the OAuth2 JWT-bearer service-account flow: a short-lived RS256 JWT is
+ * signed with the service-account private key and exchanged at Google's token
+ * endpoint for an access token, which is then used as a bearer against
+ * `POST /v1/projects/{projectId}/messages:send`. Both outbound hosts are reached
+ * through host-locked scoped clients (SSRF control, ADR-011). HTTP v1 sends one
+ * message per request, so tokens are delivered in a loop and any UNREGISTERED /
+ * 404 token is collected for pruning by the caller.
+ */
+final class FcmClient implements PushSenderInterface
+{
+    private const string OAUTH_SCOPE = 'https://www.googleapis.com/auth/firebase.messaging';
+
+    private const string OAUTH_AUDIENCE = 'https://oauth2.googleapis.com/token';
+
+    private const int TOKEN_TTL = 3600;
+
+    private ?string $accessToken = null;
+
+    private int $accessTokenExpiresAt = 0;
+
+    public function __construct(
+        #[Autowire(service: 'google_oauth.client')]
+        private readonly HttpClientInterface $googleOauthClient,
+        #[Autowire(service: 'fcm.client')]
+        private readonly HttpClientInterface $fcmClient,
+        private readonly FcmCredentials $credentials,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    public function send(array $tokens, string $title, string $body, array $data = []): array
+    {
+        if ([] === $tokens) {
+            return [];
+        }
+
+        $accessToken = $this->accessToken();
+        $endpoint = \sprintf('/v1/projects/%s/messages:send', $this->credentials->projectId());
+        $invalid = [];
+
+        foreach ($tokens as $token) {
+            try {
+                $response = $this->fcmClient->request('POST', $endpoint, [
+                    'auth_bearer' => $accessToken,
+                    'json' => [
+                        'message' => [
+                            'token' => $token,
+                            'notification' => ['title' => $title, 'body' => $body],
+                            'data' => $data,
+                        ],
+                    ],
+                ]);
+
+                $status = $response->getStatusCode();
+                if (200 === $status) {
+                    continue;
+                }
+
+                if ($this->isUnregistered($status, $response->getContent(false))) {
+                    $invalid[] = $token;
+                    continue;
+                }
+
+                $this->logger->warning('FCM push failed.', ['status' => $status, 'body' => $response->getContent(false)]);
+            } catch (\Throwable $e) {
+                $this->logger->warning('FCM push transport error.', ['error' => $e->getMessage()]);
+            }
+        }
+
+        return $invalid;
+    }
+
+    /**
+     * A stale token is reported as HTTP 404 with error status NOT_FOUND /
+     * errorCode UNREGISTERED. Treat any 404 as prunable; corroborate with the
+     * body when present.
+     */
+    private function isUnregistered(int $status, string $body): bool
+    {
+        if (404 !== $status) {
+            return false;
+        }
+
+        return str_contains($body, 'UNREGISTERED')
+            || str_contains($body, 'NOT_FOUND')
+            || '' === trim($body);
+    }
+
+    private function accessToken(): string
+    {
+        if (null !== $this->accessToken && time() < $this->accessTokenExpiresAt) {
+            return $this->accessToken;
+        }
+
+        $assertion = $this->buildAssertion();
+        $response = $this->googleOauthClient->request('POST', '/token', [
+            'body' => [
+                'grant_type' => 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+                'assertion' => $assertion,
+            ],
+        ]);
+
+        /** @var array{access_token?: string, expires_in?: int} $payload */
+        $payload = $response->toArray();
+        if (!isset($payload['access_token'])) {
+            throw new \RuntimeException('FCM token exchange returned no access_token.');
+        }
+
+        $this->accessToken = $payload['access_token'];
+        $this->accessTokenExpiresAt = time() + (($payload['expires_in'] ?? self::TOKEN_TTL) - 60);
+
+        return $this->accessToken;
+    }
+
+    private function buildAssertion(): string
+    {
+        $now = time();
+        $header = ['alg' => 'RS256', 'typ' => 'JWT'];
+        $claims = [
+            'iss' => $this->credentials->clientEmail(),
+            'scope' => self::OAUTH_SCOPE,
+            'aud' => self::OAUTH_AUDIENCE,
+            'iat' => $now,
+            'exp' => $now + self::TOKEN_TTL,
+        ];
+
+        $signingInput = $this->base64UrlEncode($this->jsonEncode($header))
+            .'.'.$this->base64UrlEncode($this->jsonEncode($claims));
+
+        if (false === openssl_sign($signingInput, $signature, $this->credentials->privateKey(), \OPENSSL_ALGO_SHA256)) {
+            throw new \RuntimeException('Failed to sign the FCM JWT assertion.');
+        }
+
+        return $signingInput.'.'.$this->base64UrlEncode($signature);
+    }
+
+    /**
+     * @param array<string, mixed> $value
+     */
+    private function jsonEncode(array $value): string
+    {
+        return json_encode($value, \JSON_THROW_ON_ERROR | \JSON_UNESCAPED_SLASHES);
+    }
+
+    private function base64UrlEncode(string $value): string
+    {
+        return rtrim(strtr(base64_encode($value), '+/', '-_'), '=');
+    }
+}

--- a/api/src/Push/FcmCredentials.php
+++ b/api/src/Push/FcmCredentials.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Push;
+
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * FCM service-account credentials, read from FCM_SERVICE_ACCOUNT_JSON (epic #1051).
+ *
+ * Fail-closed like AccessRequestHmacService: production MUST provide the JSON key
+ * of a Firebase service account. The value is parsed lazily (on first access), so
+ * an empty env only breaks an actual push attempt — the container still boots and
+ * unrelated endpoints (device-token registration) keep working with no secret set.
+ * A missing or malformed key raises a clear error the Messenger worker surfaces,
+ * never a silent no-op.
+ */
+final class FcmCredentials
+{
+    /** @var array{project_id: string, client_email: string, private_key: string}|null */
+    private ?array $decoded = null;
+
+    public function __construct(
+        #[Autowire(env: 'FCM_SERVICE_ACCOUNT_JSON')]
+        private readonly string $serviceAccountJson,
+    ) {
+    }
+
+    public function projectId(): string
+    {
+        return $this->decode()['project_id'];
+    }
+
+    public function clientEmail(): string
+    {
+        return $this->decode()['client_email'];
+    }
+
+    public function privateKey(): string
+    {
+        return $this->decode()['private_key'];
+    }
+
+    /**
+     * @return array{project_id: string, client_email: string, private_key: string}
+     */
+    private function decode(): array
+    {
+        if (null !== $this->decoded) {
+            return $this->decoded;
+        }
+
+        if ('' === trim($this->serviceAccountJson)) {
+            throw new \RuntimeException('FCM_SERVICE_ACCOUNT_JSON must be configured to send push notifications.');
+        }
+
+        try {
+            /** @var array<string, mixed> $data */
+            $data = json_decode($this->serviceAccountJson, true, 512, \JSON_THROW_ON_ERROR);
+        } catch (\JsonException $jsonException) {
+            throw new \RuntimeException('FCM_SERVICE_ACCOUNT_JSON is not valid JSON.', 0, $jsonException);
+        }
+
+        foreach (['project_id', 'client_email', 'private_key'] as $key) {
+            if (!isset($data[$key]) || !\is_string($data[$key]) || '' === $data[$key]) {
+                throw new \RuntimeException(\sprintf('FCM_SERVICE_ACCOUNT_JSON is missing the "%s" field.', $key));
+            }
+        }
+
+        return $this->decoded = [
+            'project_id' => $data['project_id'],
+            'client_email' => $data['client_email'],
+            'private_key' => $data['private_key'],
+        ];
+    }
+}

--- a/api/src/Push/FcmSendException.php
+++ b/api/src/Push/FcmSendException.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Push;
+
+/**
+ * A real FCM send/transport failure that must reach Messenger for retry, while
+ * still carrying the UNREGISTERED tokens discovered in the same batch so the
+ * caller can prune them before rethrowing (ADR-058: dead tokens are pruned once,
+ * not rediscovered on every retry).
+ */
+final class FcmSendException extends \RuntimeException
+{
+    /**
+     * @param list<string> $invalidTokens UNREGISTERED tokens to prune despite the failure
+     */
+    public function __construct(string $message, public readonly array $invalidTokens = [])
+    {
+        parent::__construct($message);
+    }
+}

--- a/api/src/Push/PushSenderInterface.php
+++ b/api/src/Push/PushSenderInterface.php
@@ -14,6 +14,10 @@ interface PushSenderInterface
      *
      * @return list<string> the subset of tokens FCM rejected as permanently
      *                      invalid (UNREGISTERED / 404), to be pruned by the caller
+     *
+     * @throws FcmSendException on a real send/transport failure (for Messenger
+     *                          retry); its `invalidTokens` still carries the dead
+     *                          tokens found in the batch so the caller prunes them
      */
     public function send(array $tokens, string $title, string $body, array $data = []): array;
 }

--- a/api/src/Push/PushSenderInterface.php
+++ b/api/src/Push/PushSenderInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Push;
+
+interface PushSenderInterface
+{
+    /**
+     * Sends one notification to each device token.
+     *
+     * @param list<string>          $tokens
+     * @param array<string, string> $data
+     *
+     * @return list<string> the subset of tokens FCM rejected as permanently
+     *                      invalid (UNREGISTERED / 404), to be pruned by the caller
+     */
+    public function send(array $tokens, string $title, string $body, array $data = []): array;
+}

--- a/api/src/Repository/DeviceTokenRepository.php
+++ b/api/src/Repository/DeviceTokenRepository.php
@@ -28,4 +28,39 @@ final class DeviceTokenRepository extends ServiceEntityRepository implements Dev
     {
         return $this->findOneBy(['token' => $token, 'user' => $user]);
     }
+
+    /**
+     * @return list<DeviceToken>
+     */
+    public function findByUserId(string $userId): array
+    {
+        /** @var list<DeviceToken> $tokens */
+        $tokens = $this->createQueryBuilder('dt')
+            ->andWhere('IDENTITY(dt.user) = :userId')
+            ->setParameter('userId', $userId)
+            ->getQuery()
+            ->getResult();
+
+        return $tokens;
+    }
+
+    /**
+     * Removes every device token whose value is in the given list (FCM reported
+     * them UNREGISTERED / 404). No-op on an empty list.
+     *
+     * @param list<string> $tokens
+     */
+    public function deleteByTokens(array $tokens): void
+    {
+        if ([] === $tokens) {
+            return;
+        }
+
+        $this->createQueryBuilder('dt')
+            ->delete()
+            ->where('dt.token IN (:tokens)')
+            ->setParameter('tokens', $tokens)
+            ->getQuery()
+            ->execute();
+    }
 }

--- a/api/src/Repository/DeviceTokenRepository.php
+++ b/api/src/Repository/DeviceTokenRepository.php
@@ -8,6 +8,7 @@ use App\Entity\DeviceToken;
 use App\Entity\User;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Uid\Uuid;
 
 /**
  * @extends ServiceEntityRepository<DeviceToken>
@@ -37,7 +38,10 @@ final class DeviceTokenRepository extends ServiceEntityRepository implements Dev
         /** @var list<DeviceToken> $tokens */
         $tokens = $this->createQueryBuilder('dt')
             ->andWhere('IDENTITY(dt.user) = :userId')
-            ->setParameter('userId', $userId)
+            // Wrap in Uuid so the parameter round-trips through the `uuid` DBAL type
+            // like every other uuid-column comparison here; a raw string risks a type
+            // error or a silently-never-matching query (ADR-058: no silent no-op).
+            ->setParameter('userId', Uuid::fromString($userId))
             ->getQuery()
             ->getResult();
 

--- a/api/src/Repository/DeviceTokenRepositoryInterface.php
+++ b/api/src/Repository/DeviceTokenRepositoryInterface.php
@@ -17,4 +17,14 @@ interface DeviceTokenRepositoryInterface
      * tokens (no object-level authorization to mask — see DeviceTokenDeleteProcessor).
      */
     public function findOneOwnedByUser(string $token, User $user): ?DeviceToken;
+
+    /**
+     * @return list<DeviceToken>
+     */
+    public function findByUserId(string $userId): array;
+
+    /**
+     * @param list<string> $tokens
+     */
+    public function deleteByTokens(array $tokens): void;
 }

--- a/api/tests/Integration/Repository/DeviceTokenRepositoryIntegrationTest.php
+++ b/api/tests/Integration/Repository/DeviceTokenRepositoryIntegrationTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Repository;
+
+use App\Entity\DeviceToken;
+use App\Entity\User;
+use App\Enum\DevicePlatform;
+use App\Repository\DeviceTokenRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * Integration coverage for the notify-by-userId lookup (#1123): findByUserId binds
+ * the id against the `uuid` FK column, so it must round-trip through real Doctrine /
+ * Postgres — the unit test stubs the QueryBuilder and never validates the parameter
+ * type. A raw-string bind would silently match nothing (ADR-058: no silent no-op).
+ */
+final class DeviceTokenRepositoryIntegrationTest extends KernelTestCase
+{
+    use ResetDatabase;
+
+    private EntityManagerInterface $em;
+
+    private DeviceTokenRepository $repository;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->em = self::getContainer()->get('doctrine.orm.entity_manager');
+        $this->repository = self::getContainer()->get(DeviceTokenRepository::class);
+    }
+
+    #[Test]
+    public function findsOnlyTheGivenUsersTokens(): void
+    {
+        $owner = $this->persistUser('owner@example.com');
+        $other = $this->persistUser('other@example.com');
+        $this->persistToken($owner, 'tok-a', DevicePlatform::ANDROID);
+        $this->persistToken($owner, 'tok-b', DevicePlatform::IOS);
+        $this->persistToken($other, 'tok-c', DevicePlatform::ANDROID);
+
+        $tokens = array_map(
+            static fn (DeviceToken $t): string => $t->getToken(),
+            $this->repository->findByUserId($owner->getId()->toRfc4122()),
+        );
+        sort($tokens);
+
+        self::assertSame(['tok-a', 'tok-b'], $tokens);
+    }
+
+    #[Test]
+    public function returnsAnEmptyListForAUserWithNoTokens(): void
+    {
+        $user = $this->persistUser('empty@example.com');
+
+        self::assertSame([], $this->repository->findByUserId($user->getId()->toRfc4122()));
+    }
+
+    /**
+     * @param non-empty-string $email
+     */
+    private function persistUser(string $email): User
+    {
+        $user = new User($email);
+        $this->em->persist($user);
+        $this->em->flush();
+
+        return $user;
+    }
+
+    private function persistToken(User $user, string $token, DevicePlatform $platform): void
+    {
+        $this->em->persist(new DeviceToken($user, $token, $platform));
+        $this->em->flush();
+    }
+}

--- a/api/tests/Integration/Repository/DeviceTokenRepositoryIntegrationTest.php
+++ b/api/tests/Integration/Repository/DeviceTokenRepositoryIntegrationTest.php
@@ -60,6 +60,41 @@ final class DeviceTokenRepositoryIntegrationTest extends KernelTestCase
         self::assertSame([], $this->repository->findByUserId($user->getId()->toRfc4122()));
     }
 
+    #[Test]
+    public function deleteByTokensRemovesOnlyTheListedTokensAcrossUsers(): void
+    {
+        // Round-trips the IN (:tokens) array binding through real Postgres (the unit
+        // test stubs the QueryBuilder): only the listed tokens go, the rest survive.
+        $a = $this->persistUser('a@example.com');
+        $b = $this->persistUser('b@example.com');
+        $this->persistToken($a, 'dead-1', DevicePlatform::ANDROID);
+        $this->persistToken($a, 'live-1', DevicePlatform::IOS);
+        $this->persistToken($b, 'dead-2', DevicePlatform::ANDROID);
+
+        $this->repository->deleteByTokens(['dead-1', 'dead-2']);
+        $this->em->clear();
+
+        $remaining = array_map(
+            static fn (DeviceToken $t): string => $t->getToken(),
+            $this->em->getRepository(DeviceToken::class)->findAll(),
+        );
+        sort($remaining);
+
+        self::assertSame(['live-1'], $remaining);
+    }
+
+    #[Test]
+    public function deleteByTokensIsANoOpOnAnEmptyList(): void
+    {
+        $user = $this->persistUser('noop@example.com');
+        $this->persistToken($user, 'keep', DevicePlatform::ANDROID);
+
+        $this->repository->deleteByTokens([]);
+        $this->em->clear();
+
+        self::assertCount(1, $this->em->getRepository(DeviceToken::class)->findAll());
+    }
+
     /**
      * @param non-empty-string $email
      */

--- a/api/tests/Unit/MessageHandler/SendPushNotificationHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/SendPushNotificationHandlerTest.php
@@ -9,6 +9,7 @@ use App\Entity\User;
 use App\Enum\DevicePlatform;
 use App\Message\SendPushNotification;
 use App\MessageHandler\SendPushNotificationHandler;
+use App\Push\FcmSendException;
 use App\Push\PushSenderInterface;
 use App\Repository\DeviceTokenRepositoryInterface;
 use PHPUnit\Framework\Attributes\Test;
@@ -57,6 +58,27 @@ final class SendPushNotificationHandlerTest extends TestCase
         $sender->method('send')->willReturn(['dead-token']);
 
         $repository->expects($this->once())->method('deleteByTokens')->with(['dead-token']);
+
+        new SendPushNotificationHandler($sender, $repository)(new SendPushNotification(
+            title: 'T',
+            body: 'B',
+            tokens: ['live-token', 'dead-token'],
+        ));
+    }
+
+    #[Test]
+    public function prunesTheDeadTokensThenRethrowsWhenTheSenderFails(): void
+    {
+        // A real send failure rethrows for Messenger retry, but the dead tokens the
+        // sender found in the same batch (carried on the exception) are pruned first
+        // so they are not rediscovered on every retry (ADR-058).
+        $repository = $this->createMock(DeviceTokenRepositoryInterface::class);
+        $sender = $this->createStub(PushSenderInterface::class);
+        $sender->method('send')->willThrowException(new FcmSendException('boom', ['dead-token']));
+
+        $repository->expects($this->once())->method('deleteByTokens')->with(['dead-token']);
+
+        $this->expectException(FcmSendException::class);
 
         new SendPushNotificationHandler($sender, $repository)(new SendPushNotification(
             title: 'T',

--- a/api/tests/Unit/MessageHandler/SendPushNotificationHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/SendPushNotificationHandlerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\MessageHandler;
+
+use App\Entity\DeviceToken;
+use App\Entity\User;
+use App\Enum\DevicePlatform;
+use App\Message\SendPushNotification;
+use App\MessageHandler\SendPushNotificationHandler;
+use App\Push\PushSenderInterface;
+use App\Repository\DeviceTokenRepositoryInterface;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class SendPushNotificationHandlerTest extends TestCase
+{
+    #[Test]
+    public function resolvesUserTokensMergesExplicitOnesAndFoldsTheCategory(): void
+    {
+        $user = new User('rider@example.com');
+        $repository = $this->createMock(DeviceTokenRepositoryInterface::class);
+        $repository->expects($this->once())->method('findByUserId')->with($user->getId()->toRfc4122())->willReturn([
+            new DeviceToken($user, 'user-token-1', DevicePlatform::ANDROID),
+            new DeviceToken($user, 'user-token-2', DevicePlatform::IOS),
+        ]);
+
+        $sender = $this->createMock(PushSenderInterface::class);
+        $sender->expects($this->once())
+            ->method('send')
+            ->with(
+                ['explicit-token', 'user-token-1', 'user-token-2'],
+                'Titre',
+                'Corps',
+                ['foo' => 'bar', 'category' => 'safety'],
+            )
+            ->willReturn([]);
+
+        $repository->expects($this->once())->method('deleteByTokens')->with([]);
+
+        new SendPushNotificationHandler($sender, $repository)(new SendPushNotification(
+            title: 'Titre',
+            body: 'Corps',
+            userId: $user->getId()->toRfc4122(),
+            tokens: ['explicit-token'],
+            data: ['foo' => 'bar'],
+            category: 'safety',
+        ));
+    }
+
+    #[Test]
+    public function prunesTheTokensTheSenderReportsInvalid(): void
+    {
+        $repository = $this->createMock(DeviceTokenRepositoryInterface::class);
+        $sender = $this->createStub(PushSenderInterface::class);
+        $sender->method('send')->willReturn(['dead-token']);
+
+        $repository->expects($this->once())->method('deleteByTokens')->with(['dead-token']);
+
+        new SendPushNotificationHandler($sender, $repository)(new SendPushNotification(
+            title: 'T',
+            body: 'B',
+            tokens: ['live-token', 'dead-token'],
+        ));
+    }
+
+    #[Test]
+    public function doesNothingWhenThereIsNoRecipient(): void
+    {
+        $repository = $this->createMock(DeviceTokenRepositoryInterface::class);
+        $sender = $this->createMock(PushSenderInterface::class);
+        $sender->expects($this->never())->method('send');
+        $repository->expects($this->never())->method('deleteByTokens');
+
+        new SendPushNotificationHandler($sender, $repository)(new SendPushNotification(title: 'T', body: 'B'));
+    }
+}

--- a/api/tests/Unit/Push/FcmClientTest.php
+++ b/api/tests/Unit/Push/FcmClientTest.php
@@ -57,27 +57,30 @@ final class FcmClientTest extends TestCase
     }
 
     #[Test]
-    public function doesNotPruneOnAGeneric404WithoutUnregistered(): void
+    public function rethrowsWithoutPruningOnAGeneric404WithoutUnregistered(): void
     {
         // A wrong project_id / disabled API / revoked key surfaces as the same
         // generic 404 NOT_FOUND wrapper. Pruning on it would wipe every user's
         // tokens on a config error, so only the nested UNREGISTERED errorCode
-        // may prune — this response must leave the token in place.
+        // may prune. It is a real send failure, so it must rethrow (Messenger
+        // retry) and must never prune the token.
         $oauthClient = new MockHttpClient(new MockResponse((string) json_encode(['access_token' => 'ya29.test', 'expires_in' => 3600])));
         $fcmClient = new MockHttpClient([
             new MockResponse((string) json_encode(['error' => ['code' => 404, 'status' => 'NOT_FOUND', 'message' => 'Requested entity was not found.']]), ['http_code' => 404]),
         ]);
 
-        $invalid = $this->client($oauthClient, $fcmClient)->send(['some-token'], 'T', 'B');
+        $this->expectException(\RuntimeException::class);
 
-        self::assertSame([], $invalid);
+        $this->client($oauthClient, $fcmClient)->send(['some-token'], 'T', 'B');
     }
 
     #[Test]
-    public function logsAWarningAndKeepsTheTokenOnAGenericSendFailure(): void
+    public function rethrowsAndKeepsTheTokenOnAGenericSendFailure(): void
     {
         // A 5xx / bad-request / quota failure is a real incident (ADR-058: never a
-        // silent no-op). It must be logged at warning and must NOT prune the token.
+        // silent no-op). It must be logged at error and rethrown so Messenger retries
+        // the whole message — a lost security alert is worse than a duplicate push.
+        // The token must NOT be pruned (nothing is returned when we rethrow).
         $logger = new class () extends AbstractLogger {
             /** @var list<array{0: mixed, 1: string}> */
             public array $records = [];
@@ -92,17 +95,23 @@ final class FcmClientTest extends TestCase
             new MockResponse((string) json_encode(['error' => ['status' => 'INTERNAL', 'message' => 'backend error']]), ['http_code' => 500]),
         ]);
 
-        $invalid = $this->client($oauthClient, $fcmClient, $logger)->send(['tok'], 'T', 'B', ['category' => 'safety']);
+        $thrown = false;
+        try {
+            $this->client($oauthClient, $fcmClient, $logger)->send(['tok'], 'T', 'B', ['category' => 'safety']);
+        } catch (\RuntimeException) {
+            $thrown = true;
+        }
 
-        self::assertSame([], $invalid);
+        self::assertTrue($thrown, 'send() must rethrow so Messenger retries the message.');
+        // The error log is emitted before the rethrow, and the token is not pruned.
         self::assertTrue($this->loggedError($logger->records, 'FCM push send failed'));
     }
 
     #[Test]
-    public function logsAWarningAndKeepsTheTokenOnATransportError(): void
+    public function rethrowsAndKeepsTheTokenOnATransportError(): void
     {
-        // A transport-level failure (timeout, DNS, TLS reset) is caught, surfaced at
-        // warning, and the send loop continues without pruning the token.
+        // A transport-level failure (timeout, DNS, TLS reset) is caught, logged at
+        // error, then rethrown so Messenger retries the message. The token stays.
         $logger = new class () extends AbstractLogger {
             /** @var list<array{0: mixed, 1: string}> */
             public array $records = [];
@@ -117,9 +126,14 @@ final class FcmClientTest extends TestCase
             throw new TransportException('connection reset');
         });
 
-        $invalid = $this->client($oauthClient, $fcmClient, $logger)->send(['tok'], 'T', 'B');
+        $thrown = false;
+        try {
+            $this->client($oauthClient, $fcmClient, $logger)->send(['tok'], 'T', 'B');
+        } catch (\RuntimeException) {
+            $thrown = true;
+        }
 
-        self::assertSame([], $invalid);
+        self::assertTrue($thrown, 'send() must rethrow so Messenger retries the message.');
         self::assertTrue($this->loggedError($logger->records, 'FCM push transport error'));
     }
 

--- a/api/tests/Unit/Push/FcmClientTest.php
+++ b/api/tests/Unit/Push/FcmClientTest.php
@@ -54,6 +54,23 @@ final class FcmClientTest extends TestCase
     }
 
     #[Test]
+    public function doesNotPruneOnAGeneric404WithoutUnregistered(): void
+    {
+        // A wrong project_id / disabled API / revoked key surfaces as the same
+        // generic 404 NOT_FOUND wrapper. Pruning on it would wipe every user's
+        // tokens on a config error, so only the nested UNREGISTERED errorCode
+        // may prune — this response must leave the token in place.
+        $oauthClient = new MockHttpClient(new MockResponse((string) json_encode(['access_token' => 'ya29.test', 'expires_in' => 3600])));
+        $fcmClient = new MockHttpClient([
+            new MockResponse((string) json_encode(['error' => ['code' => 404, 'status' => 'NOT_FOUND', 'message' => 'Requested entity was not found.']]), ['http_code' => 404]),
+        ]);
+
+        $invalid = $this->client($oauthClient, $fcmClient)->send(['some-token'], 'T', 'B');
+
+        self::assertSame([], $invalid);
+    }
+
+    #[Test]
     public function fetchesTheAccessTokenOnlyOnceForABatch(): void
     {
         // One queued OAuth response: a second token exchange would throw, proving

--- a/api/tests/Unit/Push/FcmClientTest.php
+++ b/api/tests/Unit/Push/FcmClientTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Push;
 
 use App\Push\FcmClient;
 use App\Push\FcmCredentials;
+use App\Push\FcmSendException;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\AbstractLogger;
@@ -54,6 +55,27 @@ final class FcmClientTest extends TestCase
         $invalid = $this->client($oauthClient, $fcmClient)->send(['live-token', 'dead-token'], 'T', 'B');
 
         self::assertSame(['dead-token'], $invalid);
+    }
+
+    #[Test]
+    public function carriesTheDeadTokensOnTheExceptionWhenABatchAlsoHasARealFailure(): void
+    {
+        // Mixed batch: one UNREGISTERED (dead) token + one real 500 failure. The
+        // real failure rethrows for Messenger retry, but the dead token must still
+        // ride out on the exception so the caller prunes it once instead of
+        // rediscovering it on every retry (ADR-058).
+        $oauthClient = new MockHttpClient(new MockResponse((string) json_encode(['access_token' => 'ya29.test', 'expires_in' => 3600])));
+        $fcmClient = new MockHttpClient([
+            new MockResponse((string) json_encode(['error' => ['status' => 'NOT_FOUND', 'details' => [['errorCode' => 'UNREGISTERED']]]]), ['http_code' => 404]),
+            new MockResponse((string) json_encode(['error' => ['status' => 'INTERNAL', 'message' => 'backend error']]), ['http_code' => 500]),
+        ]);
+
+        try {
+            $this->client($oauthClient, $fcmClient)->send(['dead-token', 'live-token'], 'T', 'B');
+            self::fail('send() must rethrow on a real failure.');
+        } catch (FcmSendException $e) {
+            self::assertSame(['dead-token'], $e->invalidTokens);
+        }
     }
 
     #[Test]

--- a/api/tests/Unit/Push/FcmClientTest.php
+++ b/api/tests/Unit/Push/FcmClientTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Push;
+
+use App\Push\FcmClient;
+use App\Push\FcmCredentials;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+final class FcmClientTest extends TestCase
+{
+    #[Test]
+    public function sendsOneMessagePerTokenWithABearerFromTheTokenExchange(): void
+    {
+        $sentBodies = [];
+        $oauthClient = new MockHttpClient(new MockResponse((string) json_encode(['access_token' => 'ya29.test', 'expires_in' => 3600])));
+        $fcmClient = new MockHttpClient(function (string $method, string $url, array $options) use (&$sentBodies): MockResponse {
+            self::assertSame('POST', $method);
+            self::assertStringContainsString('/v1/projects/demo-project/messages:send', $url);
+            self::assertContains('Authorization: Bearer ya29.test', $options['headers']);
+            /** @var array{message: array{token: string, notification: array{title: string, body: string}, data: array<string, string>}} $decoded */
+            $decoded = json_decode((string) $options['body'], true, 512, \JSON_THROW_ON_ERROR);
+            $sentBodies[] = $decoded;
+
+            return new MockResponse('{}');
+        });
+
+        $invalid = $this->client($oauthClient, $fcmClient)->send(['tok-a', 'tok-b'], 'Titre', 'Corps', ['category' => 'safety']);
+
+        self::assertSame([], $invalid);
+        self::assertCount(2, $sentBodies);
+        self::assertSame('tok-a', $sentBodies[0]['message']['token']);
+        self::assertSame('Titre', $sentBodies[0]['message']['notification']['title']);
+        self::assertSame('safety', $sentBodies[0]['message']['data']['category']);
+    }
+
+    #[Test]
+    public function returnsTokensFcmReportsAsUnregisteredForPruning(): void
+    {
+        $oauthClient = new MockHttpClient(new MockResponse((string) json_encode(['access_token' => 'ya29.test', 'expires_in' => 3600])));
+        $fcmClient = new MockHttpClient([
+            new MockResponse('{}'),
+            new MockResponse((string) json_encode(['error' => ['status' => 'NOT_FOUND', 'details' => [['errorCode' => 'UNREGISTERED']]]]), ['http_code' => 404]),
+        ]);
+
+        $invalid = $this->client($oauthClient, $fcmClient)->send(['live-token', 'dead-token'], 'T', 'B');
+
+        self::assertSame(['dead-token'], $invalid);
+    }
+
+    #[Test]
+    public function fetchesTheAccessTokenOnlyOnceForABatch(): void
+    {
+        // One queued OAuth response: a second token exchange would throw, proving
+        // the access token is reused across the two sends.
+        $oauthClient = new MockHttpClient([new MockResponse((string) json_encode(['access_token' => 'ya29.test', 'expires_in' => 3600]))]);
+        $fcmClient = new MockHttpClient([new MockResponse('{}'), new MockResponse('{}')]);
+
+        $invalid = $this->client($oauthClient, $fcmClient)->send(['a', 'b'], 'T', 'B');
+
+        self::assertSame([], $invalid);
+    }
+
+    private function client(MockHttpClient $oauthClient, MockHttpClient $fcmClient): FcmClient
+    {
+        return new FcmClient($oauthClient, $fcmClient, $this->credentials(), new NullLogger());
+    }
+
+    private function credentials(): FcmCredentials
+    {
+        $key = openssl_pkey_new(['private_key_bits' => 2048, 'private_key_type' => \OPENSSL_KEYTYPE_RSA]);
+        self::assertNotFalse($key);
+        openssl_pkey_export($key, $privateKey);
+
+        return new FcmCredentials((string) json_encode([
+            'type' => 'service_account',
+            'project_id' => 'demo-project',
+            'client_email' => 'sa@demo-project.iam.gserviceaccount.com',
+            'private_key' => $privateKey,
+        ]));
+    }
+}

--- a/api/tests/Unit/Push/FcmClientTest.php
+++ b/api/tests/Unit/Push/FcmClientTest.php
@@ -8,7 +8,10 @@ use App\Push\FcmClient;
 use App\Push\FcmCredentials;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\AbstractLogger;
+use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\Exception\TransportException;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
 
@@ -71,6 +74,73 @@ final class FcmClientTest extends TestCase
     }
 
     #[Test]
+    public function logsAWarningAndKeepsTheTokenOnAGenericSendFailure(): void
+    {
+        // A 5xx / bad-request / quota failure is a real incident (ADR-058: never a
+        // silent no-op). It must be logged at warning and must NOT prune the token.
+        $logger = new class () extends AbstractLogger {
+            /** @var list<array{0: mixed, 1: string}> */
+            public array $records = [];
+
+            public function log($level, string|\Stringable $message, array $context = []): void
+            {
+                $this->records[] = [$level, (string) $message];
+            }
+        };
+        $oauthClient = new MockHttpClient(new MockResponse((string) json_encode(['access_token' => 'ya29.test', 'expires_in' => 3600])));
+        $fcmClient = new MockHttpClient([
+            new MockResponse((string) json_encode(['error' => ['status' => 'INTERNAL', 'message' => 'backend error']]), ['http_code' => 500]),
+        ]);
+
+        $invalid = $this->client($oauthClient, $fcmClient, $logger)->send(['tok'], 'T', 'B', ['category' => 'safety']);
+
+        self::assertSame([], $invalid);
+        self::assertTrue($this->loggedError($logger->records, 'FCM push send failed'));
+    }
+
+    #[Test]
+    public function logsAWarningAndKeepsTheTokenOnATransportError(): void
+    {
+        // A transport-level failure (timeout, DNS, TLS reset) is caught, surfaced at
+        // warning, and the send loop continues without pruning the token.
+        $logger = new class () extends AbstractLogger {
+            /** @var list<array{0: mixed, 1: string}> */
+            public array $records = [];
+
+            public function log($level, string|\Stringable $message, array $context = []): void
+            {
+                $this->records[] = [$level, (string) $message];
+            }
+        };
+        $oauthClient = new MockHttpClient(new MockResponse((string) json_encode(['access_token' => 'ya29.test', 'expires_in' => 3600])));
+        $fcmClient = new MockHttpClient(static function (): MockResponse {
+            throw new TransportException('connection reset');
+        });
+
+        $invalid = $this->client($oauthClient, $fcmClient, $logger)->send(['tok'], 'T', 'B');
+
+        self::assertSame([], $invalid);
+        self::assertTrue($this->loggedError($logger->records, 'FCM push transport error'));
+    }
+
+    /**
+     * Prod's monolog `main` handler is fingers_crossed with action_level: error,
+     * so a real FCM failure must be logged at error to cross the threshold.
+     *
+     * @param list<array{0: mixed, 1: string}> $records
+     */
+    private function loggedError(array $records, string $needle): bool
+    {
+        foreach ($records as [$level, $message]) {
+            if ('error' === $level && str_contains($message, $needle)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    #[Test]
     public function fetchesTheAccessTokenOnlyOnceForABatch(): void
     {
         // One queued OAuth response: a second token exchange would throw, proving
@@ -83,9 +153,9 @@ final class FcmClientTest extends TestCase
         self::assertSame([], $invalid);
     }
 
-    private function client(MockHttpClient $oauthClient, MockHttpClient $fcmClient): FcmClient
+    private function client(MockHttpClient $oauthClient, MockHttpClient $fcmClient, ?LoggerInterface $logger = null): FcmClient
     {
-        return new FcmClient($oauthClient, $fcmClient, $this->credentials(), new NullLogger());
+        return new FcmClient($oauthClient, $fcmClient, $this->credentials(), $logger ?? new NullLogger());
     }
 
     private function credentials(): FcmCredentials

--- a/api/tests/Unit/Push/FcmClientTest.php
+++ b/api/tests/Unit/Push/FcmClientTest.php
@@ -73,8 +73,8 @@ final class FcmClientTest extends TestCase
         try {
             $this->client($oauthClient, $fcmClient)->send(['dead-token', 'live-token'], 'T', 'B');
             self::fail('send() must rethrow on a real failure.');
-        } catch (FcmSendException $e) {
-            self::assertSame(['dead-token'], $e->invalidTokens);
+        } catch (FcmSendException $fcmSendException) {
+            self::assertSame(['dead-token'], $fcmSendException->invalidTokens);
         }
     }
 

--- a/api/tests/Unit/Push/FcmCredentialsTest.php
+++ b/api/tests/Unit/Push/FcmCredentialsTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Push;
+
+use App\Push\FcmCredentials;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class FcmCredentialsTest extends TestCase
+{
+    #[Test]
+    public function failsClosedOnAnEmptyKey(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageIsOrContains('FCM_SERVICE_ACCOUNT_JSON must be configured');
+
+        new FcmCredentials('')->projectId();
+    }
+
+    #[Test]
+    public function failsClosedOnAMissingField(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageIsOrContains('is missing the "client_email" field');
+
+        new FcmCredentials((string) json_encode(['project_id' => 'p', 'private_key' => 'k']))->clientEmail();
+    }
+
+    #[Test]
+    public function exposesTheDecodedFields(): void
+    {
+        $credentials = new FcmCredentials((string) json_encode([
+            'project_id' => 'demo-project',
+            'client_email' => 'sa@demo.iam.gserviceaccount.com',
+            'private_key' => '-----BEGIN PRIVATE KEY-----',
+        ]));
+
+        self::assertSame('demo-project', $credentials->projectId());
+        self::assertSame('sa@demo.iam.gserviceaccount.com', $credentials->clientEmail());
+    }
+}

--- a/api/tests/Unit/Repository/DeviceTokenRepositoryTest.php
+++ b/api/tests/Unit/Repository/DeviceTokenRepositoryTest.php
@@ -94,7 +94,9 @@ final class DeviceTokenRepositoryTest extends TestCase
 
         self::assertSame([$token], $result);
         self::assertSame('IDENTITY(dt.user) = :userId', $this->andWhereDql);
-        self::assertSame($userId, $this->parameters['userId']);
+        // Bound as a Uuid (not the raw string) so it round-trips through the `uuid`
+        // DBAL type against the FK column.
+        self::assertEquals(Uuid::fromString($userId), $this->parameters['userId']);
     }
 
     #[Test]

--- a/api/tests/Unit/Repository/DeviceTokenRepositoryTest.php
+++ b/api/tests/Unit/Repository/DeviceTokenRepositoryTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Repository;
+
+use App\Entity\DeviceToken;
+use App\Entity\User;
+use App\Enum\DevicePlatform;
+use App\Repository\DeviceTokenRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Query;
+use Doctrine\ORM\QueryBuilder;
+use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\Stub;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+#[CoversClass(DeviceTokenRepository::class)]
+final class DeviceTokenRepositoryTest extends TestCase
+{
+    private DeviceTokenRepository $repository;
+
+    /** @var QueryBuilder&Stub */
+    private QueryBuilder $queryBuilder;
+
+    /** @var Query&Stub */
+    private Query $query;
+
+    /** @var array<string, mixed> */
+    private array $parameters = [];
+
+    private ?string $deleteDql = null;
+
+    private ?string $whereDql = null;
+
+    private ?string $andWhereDql = null;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->parameters = [];
+
+        $entityManager = $this->createStub(EntityManagerInterface::class);
+        $entityManager->method('getClassMetadata')->willReturn(new ClassMetadata(DeviceToken::class));
+
+        $registry = $this->createStub(ManagerRegistry::class);
+        $registry->method('getManagerForClass')->willReturn($entityManager);
+
+        $this->query = $this->createStub(Query::class);
+
+        $this->queryBuilder = $this->createStub(QueryBuilder::class);
+        $this->queryBuilder->method('select')->willReturnSelf();
+        $this->queryBuilder->method('from')->willReturnSelf();
+        $this->queryBuilder->method('delete')->willReturnCallback(function (): QueryBuilder {
+            $this->deleteDql = 'delete';
+
+            return $this->queryBuilder;
+        });
+        $this->queryBuilder->method('where')->willReturnCallback(function (string $dql): QueryBuilder {
+            $this->whereDql = $dql;
+
+            return $this->queryBuilder;
+        });
+        $this->queryBuilder->method('andWhere')->willReturnCallback(function (string $dql): QueryBuilder {
+            $this->andWhereDql = $dql;
+
+            return $this->queryBuilder;
+        });
+        $this->queryBuilder->method('setParameter')->willReturnCallback(function (string $key, mixed $value): QueryBuilder {
+            $this->parameters[$key] = $value;
+
+            return $this->queryBuilder;
+        });
+        $this->queryBuilder->method('getQuery')->willReturn($this->query);
+
+        $entityManager->method('createQueryBuilder')->willReturn($this->queryBuilder);
+
+        $this->repository = new DeviceTokenRepository($registry);
+    }
+
+    #[Test]
+    public function findByUserIdFiltersOnTheUserIdentityAndReturnsTheResult(): void
+    {
+        $user = new User('rider@example.com');
+        $token = new DeviceToken($user, 'tok-1', DevicePlatform::ANDROID);
+        $this->query->method('getResult')->willReturn([$token]);
+
+        $userId = Uuid::v7()->toRfc4122();
+        $result = $this->repository->findByUserId($userId);
+
+        self::assertSame([$token], $result);
+        self::assertSame('IDENTITY(dt.user) = :userId', $this->andWhereDql);
+        self::assertSame($userId, $this->parameters['userId']);
+    }
+
+    #[Test]
+    public function deleteByTokensBuildsABulkDeleteBoundToTheTokenList(): void
+    {
+        $this->query->method('execute')->willReturn(2);
+
+        $this->repository->deleteByTokens(['dead-1', 'dead-2']);
+
+        self::assertSame('delete', $this->deleteDql);
+        self::assertSame('dt.token IN (:tokens)', $this->whereDql);
+        self::assertSame(['dead-1', 'dead-2'], $this->parameters['tokens']);
+    }
+
+    #[Test]
+    public function deleteByTokensIsANoOpOnAnEmptyList(): void
+    {
+        // No queued execute(): building a query would fail the stub, so an empty
+        // list must short-circuit before touching the query builder.
+        $this->repository->deleteByTokens([]);
+
+        self::assertNull($this->deleteDql);
+        self::assertSame([], $this->parameters);
+    }
+}

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -28,6 +28,9 @@ services:
       # empty secret; dev needs a non-empty value or AccessRequestHmacService
       # throws at instantiation and the confirmation email is never sent.
       ACCESS_REQUEST_HMAC_SECRET: dev-access-request-hmac-secret
+      # Push notifications (epic #1051). Empty in dev: FcmCredentials fails closed
+      # only on an actual send, so unrelated endpoints keep working with no key.
+      FCM_SERVICE_ACCOUNT_JSON: "${FCM_SERVICE_ACCOUNT_JSON:-}"
       LOCK_DSN: redis://redis:6379
       # See https://xdebug.org/docs/all_settings#mode
       XDEBUG_MODE: "${XDEBUG_MODE:-off}"
@@ -62,6 +65,9 @@ services:
       APP_ENV: dev
       MAILER_DSN: smtp://mailcatcher:1025
       ACCESS_REQUEST_HMAC_SECRET: dev-access-request-hmac-secret
+      # Push notifications (epic #1051). Empty in dev: FcmCredentials fails closed
+      # only on an actual send, so unrelated endpoints keep working with no key.
+      FCM_SERVICE_ACCOUNT_JSON: "${FCM_SERVICE_ACCOUNT_JSON:-}"
       LOCK_DSN: redis://redis:6379
       XDEBUG_MODE: "${XDEBUG_MODE:-off}"
       JWT_SECRET_KEY: /app/config/jwt/private.pem

--- a/compose.recette.yaml
+++ b/compose.recette.yaml
@@ -37,6 +37,9 @@ x-recette-env: &recette-env
   # Non-empty secret so AccessRequestHmacService boots (ADR-029): the early-access
   # confirmation email is signed with it. Prod stays fail-closed on the empty default.
   ACCESS_REQUEST_HMAC_SECRET: recette-access-request-hmac-secret
+  # Push notifications (epic #1051). Empty in recette: FcmCredentials fails closed
+  # only on an actual send, so the rest of the stack boots without a real FCM key.
+  FCM_SERVICE_ACCOUNT_JSON: "${FCM_SERVICE_ACCOUNT_JSON:-}"
 
 services:
   php:

--- a/compose.yaml
+++ b/compose.yaml
@@ -71,6 +71,10 @@ services:
       FRONTEND_URL: "${FRONTEND_URL:-https://localhost}"
       MAILER_DSN: "${MAILER_DSN:-}"
       ACCESS_REQUEST_HMAC_SECRET: "${ACCESS_REQUEST_HMAC_SECRET:-}"
+      # FCM service-account JSON key for push notifications (epic #1051). Forwarded
+      # from the Coolify/host env; empty here so FcmCredentials fails closed rather
+      # than sending with a bogus key. Only the SendPushNotification worker reads it.
+      FCM_SERVICE_ACCOUNT_JSON: "${FCM_SERVICE_ACCOUNT_JSON:-}"
       # Error tracking (P1.1 / ADR-031). Leave SENTRY_DSN empty to disable.
       SENTRY_DSN: "${SENTRY_DSN:-}"
       APP_RELEASE: "${APP_RELEASE:-}"
@@ -160,6 +164,10 @@ services:
       FRONTEND_URL: "${FRONTEND_URL:-https://localhost}"
       MAILER_DSN: "${MAILER_DSN:-}"
       ACCESS_REQUEST_HMAC_SECRET: "${ACCESS_REQUEST_HMAC_SECRET:-}"
+      # FCM service-account JSON key for push notifications (epic #1051). Forwarded
+      # from the Coolify/host env; empty here so FcmCredentials fails closed rather
+      # than sending with a bogus key. Only the SendPushNotification worker reads it.
+      FCM_SERVICE_ACCOUNT_JSON: "${FCM_SERVICE_ACCOUNT_JSON:-}"
       # Error tracking (P1.1 / ADR-031). Leave SENTRY_DSN empty to disable.
       SENTRY_DSN: "${SENTRY_DSN:-}"
       APP_RELEASE: "${APP_RELEASE:-}"

--- a/docs/adr/adr-058-push-fcm.md
+++ b/docs/adr/adr-058-push-fcm.md
@@ -1,0 +1,114 @@
+# ADR-058: Push Notifications via Firebase Cloud Messaging (HTTP v1)
+
+- **Status:** Accepted
+- **Date:** 2026-08-19
+- **Depends on:** ADR-011 (Security — SSRF Prevention), ADR-022 (Persistent Storage Strategy), ADR-023 (Authentication Strategy), ADR-053 (Mobile Strategy — Dedicated Native App)
+
+## Context and Problem Statement
+
+The native app (ADR-053) needs to reach the rider when the app is backgrounded or
+closed: an in-ride safety alert, a stage recomputed while offline, an opened-zone
+announcement. Mercure SSE (ADR-056) only delivers while a subscription is live, so
+it cannot wake a suspended app. Both target platforms (Android, iOS) deliver
+out-of-app notifications through **Firebase Cloud Messaging (FCM)** — on iOS, FCM
+is the documented bridge to APNs. We need one server-side channel that fans a
+notification out to every device a user registered.
+
+The device side already exists: `App\Entity\DeviceToken` (epic #1051, #1122)
+stores one row per physical FCM token, globally unique, bound to a single account,
+registered/unregistered through `/account/device-tokens`. What is missing is the
+**sender**: how the backend authenticates to FCM, delivers a message, and reacts
+to a token FCM reports as dead.
+
+## Decision
+
+Send through the **FCM HTTP v1 API** from an async Messenger handler, authenticated
+with an OAuth2 service-account flow, over host-locked scoped HTTP clients.
+
+- **FCM HTTP v1, not the legacy API.** The legacy `fcm.googleapis.com/fcm/send`
+  server-key API is deprecated and shut down. HTTP v1
+  (`POST /v1/projects/{projectId}/messages:send`) is the supported surface: one
+  message per request, structured `notification` + `data` payload, per-token
+  delivery.
+- **OAuth2 JWT-bearer service-account auth.** Credentials are a Firebase
+  service-account JSON key. `App\Push\FcmClient` signs a short-lived RS256 JWT
+  (`openssl_sign`, no third-party JWT library), exchanges it at
+  `oauth2.googleapis.com/token` for an access token (cached in-process until just
+  before expiry), and presents that token as a bearer to the send endpoint.
+- **Host-locked scoped clients (ADR-011).** The token endpoint and the send
+  endpoint each get a dedicated `scoped_client` (`google_oauth.client`,
+  `fcm.client`), `max_redirects: 0` (SEC-007 — neither endpoint legitimately
+  redirects, so a 3xx must never pivot to an internal host). The project id folded
+  into the send path is a trusted server-side value, never a user URL.
+- **Async through Messenger.** `App\Message\SendPushNotification` (plain DTO:
+  title, body, optional `userId`, optional explicit token list, `data` map,
+  `category`) is routed to the existing `async` transport. The handler resolves
+  the recipient set (union of the explicit tokens and every token registered by
+  `userId`), sends, and never blocks a request thread.
+- **Dead-token pruning at the source of truth.** FCM reports a stale token as
+  HTTP 404 (`UNREGISTERED` / `NOT_FOUND`). `FcmClient` collects those tokens and
+  the handler deletes them via `DeviceTokenRepository::deleteByTokens()`, so a
+  device that uninstalled or rotated its token stops being targeted. This is the
+  only self-healing path — there is no separate reaper.
+- **Fail-closed credentials (like `AccessRequestHmacService`).** The service
+  account is read from `FCM_SERVICE_ACCOUNT_JSON`. `App\Push\FcmCredentials`
+  parses it **lazily**: an absent or malformed key raises a clear error only when a
+  push is actually attempted, so the container still boots and unrelated endpoints
+  (device-token registration) keep working with no key set. Production MUST provide
+  the key; dev/recette leave it empty on purpose. The passthrough is wired into
+  **both** `php` and `worker` in `compose.yaml` (the iso-prod base Coolify reads),
+  so it is not silently empty in prod.
+
+## Data model — device token
+
+`DeviceToken` is unchanged by this ADR (introduced in #1122): `id` (UUID v7),
+`user` (ManyToOne, `ON DELETE CASCADE`), `token` (unique), `platform`
+(`android` / `ios`), `createdAt` (UTC). One row per physical token; re-registering
+a token held by another account reassigns it. Account erasure cascades the rows;
+FCM-side pruning removes tokens the transport reports dead.
+
+## Categories, opt-in, and permission (planned — #1124)
+
+This ADR lands the transport; notification **categories** and their user-facing
+controls are #1124. The message already carries a `category` field (folded into
+the FCM `data` payload) so the client can route to the right Android channel / iOS
+category, but the catalogue of categories, the per-category opt-in, and the
+**opt-in per opened zone** (a rider subscribes to announcements for the zones they
+ride) are deferred to that issue.
+
+- **Permission is the device's, not the server's.** The OS prompt (POST_NOTIFICATIONS
+  on Android 13+, the iOS authorization prompt) is requested client-side; the
+  backend only ever sends to a token the client chose to register. A user who
+  never grants permission has no token row, so is never targeted.
+- **RGPD.** A device token is personal data (it identifies a device bound to an
+  account). It is stored only after the user registers it, deleted on unregister,
+  pruned when FCM reports it dead, and cascade-deleted on account erasure
+  (ADR — RGPD account erasure = immediate anonymisation). No notification content
+  is persisted server-side beyond the transient Messenger envelope.
+
+## Alternatives considered
+
+- **A push library (`kreait/firebase-php`, `google/auth`).** Rejected for now: the
+  v1 flow we need is a JWT sign + two HTTP POSTs. A library would pull its own
+  Guzzle client, bypassing the mandated scoped-client SSRF discipline (ADR-011),
+  to save ~30 lines of `openssl_sign` + base64url. Not worth the dependency and the
+  SSRF exception. Revisit if we need topic messaging, condition targeting, or the
+  batch APIs.
+- **Web Push (VAPID) instead of FCM.** Rejected: the product is a native app
+  (ADR-053, the PWA was removed). Native delivery on iOS goes through APNs, for
+  which FCM is the documented bridge; a second Web Push stack would be dead weight.
+- **Synchronous send in the request thread.** Rejected: FCM latency and per-token
+  fan-out would block API responses, and a transient FCM error would surface as a
+  request failure. Messenger gives retry + failure transport for free (ADR-043).
+
+## Consequences
+
+- The backend can wake a suspended app for safety and trip-state events, reusing
+  the existing async worker pool and the device-token store.
+- Dead tokens are pruned as a side effect of sending, so the store self-heals with
+  no reaper cron.
+- A new runtime secret (`FCM_SERVICE_ACCOUNT_JSON`) must be provisioned in prod; if
+  absent, pushes fail closed (worker error, Messenger retry then dead-letter) while
+  the rest of the API is unaffected.
+- Categories, per-category opt-in, and per-zone subscription are still to build
+  (#1124); this ADR is the transport they will sit on.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -137,6 +137,8 @@ nav:
       - adr/adr-054-mobile-design-system.md
       - adr/adr-055-mobile-state-architecture.md
       - adr/adr-056-mercure-header-auth-non-browser.md
+      - adr/adr-057-progressive-trip-loading.md
+      - adr/adr-058-push-fcm.md
   - Runbooks:
       - runbooks/README.md
       - runbooks/severity-levels.md


### PR DESCRIPTION
Ferme #1123. Stacked sur #1122 (base `feature/1122`). Épic #1051.

## Résumé
- `Message/SendPushNotification` (routé `async`) + `MessageHandler/SendPushNotificationHandler` (résout les tokens user, purge les invalides).
- `Push/FcmClient` : OAuth2 JWT-bearer service-account, **signature RS256 openssl pur (aucune lib ajoutée)**, envoi via clients HTTP scopés (SEC-007, max_redirects 0), détection UNREGISTERED/404.
- `Push/FcmCredentials` : `FCM_SERVICE_ACCOUNT_JSON`, **fail-closed lazy** (container bootable sans clé, erreur à l'envoi).
- `DeviceTokenRepositoryInterface` (mockable, repo final).
- Secrets compose : passthrough `FCM_SERVICE_ACCOUNT_JSON: "${FCM_SERVICE_ACCOUNT_JSON:-}"` dans **php ET worker** de `compose.yaml` + overrides dev/recette.
- ADR-058 (FCM HTTP v1, catégories #1124, opt-in zone, RGPD). Nav mkdocs corrigée (+ adr-057 oublié par #1115).

## Vérification
- CS-Fixer 0 ; Rector autofixes committés ; PHPStan L9 OK ; PHPUnit 1373 OK ; markdownlint 0.
- Purge des tokens invalides prouvée (retrait → test casse) puis restaurée.

## Auto-critique
- Le câblage des catégories métier sur le sender arrive dans #1124.

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 critical, 0 warning, 0 suggestion findings. The one open suggestion from the previous pass — `FcmClient::send()` serializing one FCM round-trip per token instead of letting `HttpClientInterface` multiplex the batch — is fixed on this commit: requests are now issued up front and consumed in a second pass, so a batch costs ~one round-trip. Architecture (host-locked scoped HTTP clients, fail-closed lazy credentials, `PushSenderInterface` abstraction, dead-token pruning carried on `FcmSendException` so it survives a Messenger retry), security (SEC-007 redirect/timeout limits, no plaintext token logging, no unvalidated external input on this transport-only PR), and test coverage (unit + integration, including the mixed dead-token/real-failure batch case) are solid.

**Resolved threads:** resolved 1 previously open thread that this commit addressed (the multiplexing suggestion above).

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Findings:** None.

**Inline comments:** No inline comments.

**Commit reviewed:** `2099c27e4c5acc7670194138cc28ef09b7ece1f5`
<!-- claude-review-end -->