### PR TITLE
feat(api): catégories push serveur + garde abonné SSE + prefs

### DIFF
--- a/api/migrations/Version20260819130000.php
+++ b/api/migrations/Version20260819130000.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Creates the notification_preference table (server-push categories, #1124).
+ *
+ * One row per (user, category) opt-in. Absence of a row means "use the category
+ * default", so only overrides are stored. FK to `user` with ON DELETE CASCADE:
+ * erasing an account drops its preferences.
+ */
+final class Version20260819130000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create notification_preference table (server-push categories, #1124)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE notification_preference (
+            id uuid NOT NULL,
+            user_id uuid NOT NULL,
+            category character varying(255) NOT NULL,
+            enabled boolean NOT NULL,
+            PRIMARY KEY (id)
+        )');
+        $this->addSql('CREATE UNIQUE INDEX uniq_notification_preference_user_category ON notification_preference (user_id, category)');
+        $this->addSql('ALTER TABLE notification_preference ADD CONSTRAINT fk_notification_preference_user FOREIGN KEY (user_id) REFERENCES "user" (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE notification_preference');
+    }
+}

--- a/api/src/ApiResource/Account/NotificationPreference.php
+++ b/api/src/ApiResource/Account/NotificationPreference.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ApiResource\Account;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Put;
+use App\Enum\NotificationCategory;
+use App\State\Account\NotificationPreferenceProvider;
+use App\State\Account\NotificationPreferenceUpdateProcessor;
+
+/**
+ * Per-category server-push opt-in for the authenticated user (#1124).
+ *
+ * - GET /users/me/notification-preferences         the effective opt-in for every
+ *   category (stored override, or the category default when unset).
+ * - PUT /users/me/notification-preferences/{category}  set the opt-in for one
+ *   category. Body: {"enabled": true|false}. An unknown category is 404.
+ *
+ * Defaults: weatherSafety and analysisDone are ON, zoneOpening is OFF (opt-in).
+ * The current user is always resolved from the security token, never a URL id.
+ */
+#[ApiResource(
+    shortName: 'NotificationPreference',
+    operations: [
+        new GetCollection(
+            uriTemplate: '/users/me/notification-preferences',
+            security: "is_granted('ROLE_USER')",
+            provider: NotificationPreferenceProvider::class,
+        ),
+        new Put(
+            uriTemplate: '/users/me/notification-preferences/{category}',
+            security: "is_granted('ROLE_USER')",
+            read: false,
+            processor: NotificationPreferenceUpdateProcessor::class,
+        ),
+    ],
+)]
+final class NotificationPreference
+{
+    public function __construct(
+        #[ApiProperty(identifier: true)]
+        public ?NotificationCategory $category = null,
+        public bool $enabled = false,
+    ) {
+    }
+}

--- a/api/src/ApiResource/Account/NotificationPreference.php
+++ b/api/src/ApiResource/Account/NotificationPreference.php
@@ -11,6 +11,7 @@ use ApiPlatform\Metadata\Put;
 use App\Enum\NotificationCategory;
 use App\State\Account\NotificationPreferenceProvider;
 use App\State\Account\NotificationPreferenceUpdateProcessor;
+use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * Per-category server-push opt-in for the authenticated user (#1124).
@@ -18,7 +19,8 @@ use App\State\Account\NotificationPreferenceUpdateProcessor;
  * - GET /users/me/notification-preferences         the effective opt-in for every
  *   category (stored override, or the category default when unset).
  * - PUT /users/me/notification-preferences/{category}  set the opt-in for one
- *   category. Body: {"enabled": true|false}. An unknown category is 404.
+ *   category. Body: {"enabled": true|false} — `enabled` is required (a body
+ *   omitting it is 422, never a silent opt-out). An unknown category is 404.
  *
  * Defaults: weatherSafety and analysisDone are ON, zoneOpening is OFF (opt-in).
  * The current user is always resolved from the security token, never a URL id.
@@ -44,7 +46,12 @@ final class NotificationPreference
     public function __construct(
         #[ApiProperty(identifier: true)]
         public ?NotificationCategory $category = null,
-        public bool $enabled = false,
+        // Required on PUT: a body omitting it must 422, not silently default to
+        // false and opt the user out of a default-ON category (weatherSafety /
+        // analysisDone). Nullable so a missing field denormalizes to null and trips
+        // NotNull, rather than defaulting to false.
+        #[Assert\NotNull]
+        public ?bool $enabled = null,
     ) {
     }
 }

--- a/api/src/Command/NotifyWeatherSafetyCommand.php
+++ b/api/src/Command/NotifyWeatherSafetyCommand.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Notification\WeatherSafetyNotifier;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Pushes the weather-safety notification for the stages ridden on a target day (#1124).
+ *
+ * No Symfony Scheduler exists in this project, so this is the documented trigger
+ * point: schedule it (cron / Coolify scheduled task) twice a day —
+ *   app:notifications:weather-safety --day=tomorrow   # the evening before
+ *   app:notifications:weather-safety --day=today       # the morning of
+ * Owners who disabled the category, or have no registered device, are skipped.
+ */
+#[AsCommand(
+    name: 'app:notifications:weather-safety',
+    description: 'Push weather + safety notifications for the stages ridden on a target day',
+)]
+final class NotifyWeatherSafetyCommand extends Command
+{
+    public function __construct(
+        private readonly WeatherSafetyNotifier $notifier,
+    ) {
+        parent::__construct();
+    }
+
+    #[\Override]
+    protected function configure(): void
+    {
+        $this->addOption('day', null, InputOption::VALUE_REQUIRED, 'Target day: today | tomorrow | an ISO date (Y-m-d)', 'today');
+    }
+
+    #[\Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $day = $input->getOption('day');
+        \assert(\is_string($day));
+
+        $date = match ($day) {
+            'today' => new \DateTimeImmutable('today', new \DateTimeZone('UTC')),
+            'tomorrow' => new \DateTimeImmutable('tomorrow', new \DateTimeZone('UTC')),
+            default => \DateTimeImmutable::createFromFormat('!Y-m-d', $day, new \DateTimeZone('UTC')) ?: null,
+        };
+
+        if (!$date instanceof \DateTimeImmutable) {
+            $io->error(\sprintf('Invalid --day value: %s. Expected today, tomorrow, or an ISO date (Y-m-d).', $day));
+
+            return Command::INVALID;
+        }
+
+        $count = $this->notifier->notify($date);
+        $io->success(\sprintf('Dispatched %d weather-safety push(es) for %s.', $count, $date->format('Y-m-d')));
+
+        return Command::SUCCESS;
+    }
+}

--- a/api/src/Command/NotifyWeatherSafetyCommand.php
+++ b/api/src/Command/NotifyWeatherSafetyCommand.php
@@ -49,7 +49,7 @@ final class NotifyWeatherSafetyCommand extends Command
         $date = match ($day) {
             'today' => new \DateTimeImmutable('today', new \DateTimeZone('UTC')),
             'tomorrow' => new \DateTimeImmutable('tomorrow', new \DateTimeZone('UTC')),
-            default => \DateTimeImmutable::createFromFormat('!Y-m-d', $day, new \DateTimeZone('UTC')) ?: null,
+            default => $this->parseIsoDate($day),
         };
 
         if (!$date instanceof \DateTimeImmutable) {
@@ -62,5 +62,16 @@ final class NotifyWeatherSafetyCommand extends Command
         $io->success(\sprintf('Dispatched %d weather-safety push(es) for %s.', $count, $date->format('Y-m-d')));
 
         return Command::SUCCESS;
+    }
+
+    /**
+     * Strict ISO parse: createFromFormat silently rolls over impossible dates
+     * (2026-13-40), so reject any value that does not round-trip to itself.
+     */
+    private function parseIsoDate(string $day): ?\DateTimeImmutable
+    {
+        $date = \DateTimeImmutable::createFromFormat('!Y-m-d', $day, new \DateTimeZone('UTC'));
+
+        return false !== $date && $date->format('Y-m-d') === $day ? $date : null;
     }
 }

--- a/api/src/Command/NotifyZoneOpenedCommand.php
+++ b/api/src/Command/NotifyZoneOpenedCommand.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Notification\ZoneOpeningNotifier;
+use Doctrine\DBAL\Connection;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Announces a newly opened reference zone to opted-in users (#1124).
+ *
+ * Zone opening happens in the separate provisioner process ({@see make provision}),
+ * which only writes `osm.zones`; there is no in-process event to hook. This is the
+ * documented trigger: ops runs it right after a zone is promoted. The display name
+ * defaults to the one recorded in `osm.zones` for the slug.
+ *
+ *   app:notifications:zone-opened corse [--name="Corse"]
+ */
+#[AsCommand(
+    name: 'app:notifications:zone-opened',
+    description: 'Announce a newly opened reference zone to opted-in users',
+)]
+final class NotifyZoneOpenedCommand extends Command
+{
+    public function __construct(
+        private readonly ZoneOpeningNotifier $notifier,
+        private readonly Connection $connection,
+    ) {
+        parent::__construct();
+    }
+
+    #[\Override]
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('slug', InputArgument::REQUIRED, 'Zone slug as promoted in osm.zones (e.g. corse)')
+            ->addOption('name', null, InputOption::VALUE_REQUIRED, 'Display name (defaults to the osm.zones name for the slug)');
+    }
+
+    #[\Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $slug = $input->getArgument('slug');
+        \assert(\is_string($slug));
+
+        $name = $input->getOption('name');
+        if (!\is_string($name) || '' === $name) {
+            $name = $this->lookupZoneName($slug);
+        }
+
+        if (null === $name) {
+            $io->error(\sprintf('Unknown zone slug "%s" (not found in osm.zones) and no --name given.', $slug));
+
+            return Command::INVALID;
+        }
+
+        $count = $this->notifier->notify($slug, $name);
+        $io->success(\sprintf('Dispatched %d zone-opening push(es) for "%s".', $count, $name));
+
+        return Command::SUCCESS;
+    }
+
+    private function lookupZoneName(string $slug): ?string
+    {
+        $name = $this->connection->fetchOne('SELECT name FROM osm.zones WHERE slug = :slug', ['slug' => $slug]);
+
+        return \is_string($name) ? $name : null;
+    }
+}

--- a/api/src/Entity/NotificationPreference.php
+++ b/api/src/Entity/NotificationPreference.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Enum\NotificationCategory;
+use App\Repository\NotificationPreferenceRepository;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Per-user opt-in for a server-pushed notification category (#1124).
+ *
+ * One row per (user, category). The absence of a row means "use the category
+ * default" ({@see NotificationCategory::defaultEnabled()}), so a row is only
+ * written when the user overrides that default.
+ */
+#[ORM\Entity(repositoryClass: NotificationPreferenceRepository::class)]
+#[ORM\Table(name: 'notification_preference')]
+#[ORM\UniqueConstraint(name: 'uniq_notification_preference_user_category', columns: ['user_id', 'category'])]
+class NotificationPreference
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'uuid')]
+    private Uuid $id;
+
+    public function __construct(
+        #[ORM\ManyToOne(targetEntity: User::class)]
+        #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+        private User $user,
+        #[ORM\Column(enumType: NotificationCategory::class)]
+        private NotificationCategory $category,
+        #[ORM\Column]
+        private bool $enabled,
+        ?Uuid $id = null,
+    ) {
+        $this->id = $id ?? Uuid::v7();
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getUser(): User
+    {
+        return $this->user;
+    }
+
+    public function getCategory(): NotificationCategory
+    {
+        return $this->category;
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->enabled;
+    }
+
+    public function setEnabled(bool $enabled): self
+    {
+        $this->enabled = $enabled;
+
+        return $this;
+    }
+}

--- a/api/src/Enum/NotificationCategory.php
+++ b/api/src/Enum/NotificationCategory.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enum;
+
+/**
+ * Server-pushed notification categories (#1124).
+ *
+ * Each category has a per-user opt-in stored in {@see \App\Entity\NotificationPreference}.
+ * The default applies when the user has no explicit row: safety and analysis are
+ * ON by default, opened-zone announcements are OFF (opt-in only).
+ */
+enum NotificationCategory: string
+{
+    case WEATHER_SAFETY = 'weatherSafety';
+    case ANALYSIS_DONE = 'analysisDone';
+    case ZONE_OPENING = 'zoneOpening';
+
+    public function defaultEnabled(): bool
+    {
+        return match ($this) {
+            self::WEATHER_SAFETY, self::ANALYSIS_DONE => true,
+            self::ZONE_OPENING => false,
+        };
+    }
+}

--- a/api/src/Mercure/MercureSubscriptionChecker.php
+++ b/api/src/Mercure/MercureSubscriptionChecker.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mercure;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Reads the Mercure hub's subscription API to tell whether a trip's SSE stream
+ * currently has a live subscriber (#1124).
+ *
+ * Used to suppress the `analysisDone` push when the rider is already watching the
+ * trip in real time. The hub exposes `GET /.well-known/mercure/subscriptions/{topic}`
+ * (enabled by the `subscriptions` directive in the Caddy Mercure config); the
+ * request is authorised with a short-lived server-side JWT.
+ *
+ * The hub is reached through the host-locked `mercure.health.client` (ADR-011);
+ * the requested URL is built from the trusted MERCURE_URL and a validated trip id,
+ * never from user input. On any hub error the checker **fails open** (reports no
+ * subscriber) so a transient hub hiccup never silently swallows the notification.
+ */
+final readonly class MercureSubscriptionChecker implements MercureSubscriptionCheckerInterface
+{
+    public function __construct(
+        #[Autowire(service: 'mercure.health.client')]
+        private HttpClientInterface $mercureClient,
+        private MercureTokenIssuer $tokenIssuer,
+        #[Autowire(env: 'MERCURE_URL')]
+        private string $mercureUrl,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function hasActiveSubscriber(string $tripId): bool
+    {
+        $topic = \sprintf('/trips/%s', $tripId);
+        $url = rtrim($this->mercureUrl, '/').'/subscriptions/'.rawurlencode($topic);
+
+        try {
+            $response = $this->mercureClient->request('GET', $url, [
+                'auth_bearer' => $this->tokenIssuer->generateSubscriptionsToken($tripId),
+            ]);
+
+            if (200 !== $response->getStatusCode()) {
+                $this->logger->warning('Mercure subscription API returned {status}, assuming no subscriber.', [
+                    'status' => $response->getStatusCode(),
+                    'tripId' => $tripId,
+                ]);
+
+                return false;
+            }
+
+            /** @var array{subscriptions?: list<array{active?: bool}>} $payload */
+            $payload = $response->toArray();
+        } catch (\Throwable $throwable) {
+            $this->logger->warning('Mercure subscription check failed, assuming no subscriber: {error}', [
+                'error' => $throwable->getMessage(),
+                'tripId' => $tripId,
+            ]);
+
+            return false;
+        }
+
+        foreach ($payload['subscriptions'] ?? [] as $subscription) {
+            if ($subscription['active'] ?? false) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/api/src/Mercure/MercureSubscriptionCheckerInterface.php
+++ b/api/src/Mercure/MercureSubscriptionCheckerInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mercure;
+
+interface MercureSubscriptionCheckerInterface
+{
+    /**
+     * Whether at least one client is currently subscribed to the trip's SSE topic
+     * (`/trips/{tripId}`), read from the Mercure hub's subscription API.
+     */
+    public function hasActiveSubscriber(string $tripId): bool;
+}

--- a/api/src/Mercure/MercureTokenIssuer.php
+++ b/api/src/Mercure/MercureTokenIssuer.php
@@ -57,6 +57,30 @@ final readonly class MercureTokenIssuer
     }
 
     /**
+     * Generates a JWT authorising a read of the hub's subscription API for a trip
+     * topic (#1124). Server-side only (never handed to a client): it lets the
+     * backend ask the hub whether anyone is currently subscribed to the trip's SSE
+     * stream. The `subscribe` claim must cover both the subscription-API URI
+     * template and the trip topic itself.
+     */
+    public function generateSubscriptionsToken(string $tripId): string
+    {
+        $now = new \DateTimeImmutable();
+        $topic = \sprintf('/trips/%s', $tripId);
+
+        $token = $this->jwtConfig->builder()
+            ->issuedAt($now)
+            ->expiresAt($now->modify('+60 seconds'))
+            ->withClaim('mercure', ['subscribe' => [
+                '/.well-known/mercure/subscriptions{/topic}{/subscriber}',
+                $topic,
+            ]])
+            ->getToken($this->jwtConfig->signer(), $this->jwtConfig->signingKey());
+
+        return $token->toString();
+    }
+
+    /**
      * Creates an HttpOnly cookie containing the subscriber JWT.
      *
      * The cookie path is scoped to `/.well-known/mercure` so it is only

--- a/api/src/MessageHandler/AllEnrichmentsCompletedHandler.php
+++ b/api/src/MessageHandler/AllEnrichmentsCompletedHandler.php
@@ -7,6 +7,7 @@ namespace App\MessageHandler;
 use App\ComputationTracker\ComputationTrackerInterface;
 use App\Mercure\TripUpdatePublisherInterface;
 use App\Message\AllEnrichmentsCompleted;
+use App\Notification\AnalysisNotifier;
 use App\Repository\TripRequestRepositoryInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
@@ -17,7 +18,9 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
  * Fired by {@see AbstractTripMessageHandler} once the enrichment gate
  * (issue #299) detects that every initialised computation has settled
  * (`done` or `failed`). It publishes the `TRIP_READY` Mercure event directly
- * so the frontend swaps state atomically with the enriched payload.
+ * so the frontend swaps state atomically with the enriched payload, then asks the
+ * {@see AnalysisNotifier} to push an `analysisDone` notification when no SSE client
+ * is watching the trip (#1124).
  */
 #[AsMessageHandler]
 final readonly class AllEnrichmentsCompletedHandler
@@ -26,6 +29,7 @@ final readonly class AllEnrichmentsCompletedHandler
         private ComputationTrackerInterface $computationTracker,
         private TripUpdatePublisherInterface $publisher,
         private TripRequestRepositoryInterface $tripRequestRepository,
+        private AnalysisNotifier $analysisNotifier,
         private LoggerInterface $logger,
     ) {
     }
@@ -57,5 +61,7 @@ final readonly class AllEnrichmentsCompletedHandler
         $this->publisher->publishTripReady($tripId, $stages, [
             'status' => $statuses,
         ]);
+
+        $this->analysisNotifier->notify($tripId, $statuses);
     }
 }

--- a/api/src/Notification/AnalysisNotifier.php
+++ b/api/src/Notification/AnalysisNotifier.php
@@ -7,6 +7,7 @@ namespace App\Notification;
 use App\Enum\NotificationCategory;
 use App\Mercure\MercureSubscriptionCheckerInterface;
 use App\Repository\TripRequestRepositoryInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * Pushes the `analysisDone` notification once a trip's enrichment pipeline settles
@@ -14,7 +15,8 @@ use App\Repository\TripRequestRepositoryInterface;
  *
  * The guard is the core of the issue: if a Mercure SSE subscriber is live on the
  * trip topic, the frontend already receives the terminal `TRIP_READY` event, so a
- * push would be redundant noise. Anonymous trips (no owner) are never pushed.
+ * push would be redundant noise. Anonymous trips (no owner) are never pushed. The
+ * copy is localised to the trip's locale (falling back to English).
  */
 final readonly class AnalysisNotifier
 {
@@ -22,6 +24,7 @@ final readonly class AnalysisNotifier
         private TripRequestRepositoryInterface $tripRequestRepository,
         private MercureSubscriptionCheckerInterface $subscriptionChecker,
         private NotificationDispatcherInterface $dispatcher,
+        private TranslatorInterface $translator,
     ) {
     }
 
@@ -41,15 +44,14 @@ final readonly class AnalysisNotifier
             return;
         }
 
-        $failed = \in_array('failed', $statuses, true);
+        $locale = $this->tripRequestRepository->getLocale($tripId) ?? 'en';
+        $key = \in_array('failed', $statuses, true) ? 'failed' : 'done';
 
         $this->dispatcher->dispatch(
             $ownerId,
             NotificationCategory::ANALYSIS_DONE,
-            $failed ? 'Analyse incomplète' : 'Analyse terminée',
-            $failed
-                ? "Certaines étapes de votre voyage n'ont pas pu être analysées. Ouvrez l'app pour vérifier."
-                : "Votre voyage est prêt. Ouvrez l'app pour découvrir les étapes et les alertes.",
+            $this->translator->trans(\sprintf('notification.analysis.%s.title', $key), [], 'notifications', $locale),
+            $this->translator->trans(\sprintf('notification.analysis.%s.body', $key), [], 'notifications', $locale),
             ['tripId' => $tripId],
         );
     }

--- a/api/src/Notification/AnalysisNotifier.php
+++ b/api/src/Notification/AnalysisNotifier.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notification;
+
+use App\Enum\NotificationCategory;
+use App\Mercure\MercureSubscriptionCheckerInterface;
+use App\Repository\TripRequestRepositoryInterface;
+
+/**
+ * Pushes the `analysisDone` notification once a trip's enrichment pipeline settles
+ * (#1124), but only when the rider is NOT already watching the trip in real time.
+ *
+ * The guard is the core of the issue: if a Mercure SSE subscriber is live on the
+ * trip topic, the frontend already receives the terminal `TRIP_READY` event, so a
+ * push would be redundant noise. Anonymous trips (no owner) are never pushed.
+ */
+final readonly class AnalysisNotifier
+{
+    public function __construct(
+        private TripRequestRepositoryInterface $tripRequestRepository,
+        private MercureSubscriptionCheckerInterface $subscriptionChecker,
+        private NotificationDispatcherInterface $dispatcher,
+    ) {
+    }
+
+    /**
+     * @param array<string, string> $statuses per-computation terminal status map
+     */
+    public function notify(string $tripId, array $statuses): void
+    {
+        $ownerId = $this->tripRequestRepository->getOwnerId($tripId);
+        if (null === $ownerId) {
+            return;
+        }
+
+        // Rider is watching the SSE stream: they already got TRIP_READY, so do not
+        // duplicate it as a push.
+        if ($this->subscriptionChecker->hasActiveSubscriber($tripId)) {
+            return;
+        }
+
+        $failed = \in_array('failed', $statuses, true);
+
+        $this->dispatcher->dispatch(
+            $ownerId,
+            NotificationCategory::ANALYSIS_DONE,
+            $failed ? 'Analyse incomplète' : 'Analyse terminée',
+            $failed
+                ? "Certaines étapes de votre voyage n'ont pas pu être analysées. Ouvrez l'app pour vérifier."
+                : "Votre voyage est prêt. Ouvrez l'app pour découvrir les étapes et les alertes.",
+            ['tripId' => $tripId],
+        );
+    }
+}

--- a/api/src/Notification/NotificationDispatcher.php
+++ b/api/src/Notification/NotificationDispatcher.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notification;
+
+use App\Enum\NotificationCategory;
+use App\Message\SendPushNotification;
+use App\Repository\NotificationPreferenceRepositoryInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+/**
+ * Single opt-in gate for every server-pushed category (#1124).
+ *
+ * Checks the user's per-category preference and, when enabled, emits a
+ * {@see SendPushNotification} carrying the category. The push handler resolves the
+ * user's device tokens and no-ops when there is none, so a user with a disabled
+ * category or no registered device is never reached (RGPD).
+ */
+final readonly class NotificationDispatcher implements NotificationDispatcherInterface
+{
+    public function __construct(
+        private MessageBusInterface $messageBus,
+        private NotificationPreferenceRepositoryInterface $preferences,
+    ) {
+    }
+
+    public function dispatch(string $userId, NotificationCategory $category, string $title, string $body, array $data = []): bool
+    {
+        if (!$this->preferences->isEnabled($userId, $category)) {
+            return false;
+        }
+
+        $this->messageBus->dispatch(new SendPushNotification(
+            title: $title,
+            body: $body,
+            userId: $userId,
+            data: $data,
+            category: $category->value,
+        ));
+
+        return true;
+    }
+}

--- a/api/src/Notification/NotificationDispatcherInterface.php
+++ b/api/src/Notification/NotificationDispatcherInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notification;
+
+use App\Enum\NotificationCategory;
+
+interface NotificationDispatcherInterface
+{
+    /**
+     * Dispatches a server push to a user for a category, unless the user has opted
+     * out of that category. Returns whether the push was dispatched.
+     *
+     * @param array<string, string> $data
+     */
+    public function dispatch(string $userId, NotificationCategory $category, string $title, string $body, array $data = []): bool;
+}

--- a/api/src/Notification/WeatherSafetyNotifier.php
+++ b/api/src/Notification/WeatherSafetyNotifier.php
@@ -7,6 +7,7 @@ namespace App\Notification;
 use App\Entity\Stage;
 use App\Enum\NotificationCategory;
 use App\Repository\OwnedTripFinderInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * Pushes the `weatherSafety` notification for the stage a rider tackles on a given
@@ -16,13 +17,15 @@ use App\Repository\OwnedTripFinderInterface;
  * command ({@see \App\Command\NotifyWeatherSafetyCommand}) that ops schedules
  * twice a day: the evening before (`--day=tomorrow`) and the morning of
  * (`--day=today`). Each call notifies every owned trip whose ridden stage lands
- * on the target day, for owners who kept the category enabled.
+ * on the target day, for owners who kept the category enabled. Copy is localised
+ * to the trip's locale (falling back to English).
  */
 final readonly class WeatherSafetyNotifier
 {
     public function __construct(
         private OwnedTripFinderInterface $tripRepository,
         private NotificationDispatcherInterface $dispatcher,
+        private TranslatorInterface $translator,
     ) {
     }
 
@@ -45,11 +48,19 @@ final readonly class WeatherSafetyNotifier
                 continue;
             }
 
+            $locale = '' !== $trip->locale ? $trip->locale : 'en';
+            $title = $this->translator->trans(
+                'notification.weather_safety.title',
+                ['%day%' => $dayNumber, '%headline%' => $this->weatherHeadline($stage, $locale)],
+                'notifications',
+                $locale,
+            );
+
             $dispatched += $this->dispatcher->dispatch(
                 $trip->user->getId()->toRfc4122(),
                 NotificationCategory::WEATHER_SAFETY,
-                \sprintf('Étape J%d — %s', $dayNumber, $this->weatherHeadline($stage)),
-                $this->body($stage),
+                $title,
+                $this->body($stage, $locale),
                 ['tripId' => $trip->id->toRfc4122(), 'dayNumber' => (string) $dayNumber],
             ) ? 1 : 0;
         }
@@ -71,32 +82,43 @@ final readonly class WeatherSafetyNotifier
         return null;
     }
 
-    private function weatherHeadline(Stage $stage): string
+    private function weatherHeadline(Stage $stage, string $locale): string
     {
         $weather = $stage->getWeather();
         if (null === $weather) {
-            return 'météo à venir';
+            return $this->translator->trans('notification.weather_safety.headline.pending', [], 'notifications', $locale);
         }
 
-        $description = \is_string($weather['description'] ?? null) ? $weather['description'] : 'météo';
+        $description = \is_string($weather['description'] ?? null) ? $weather['description'] : '';
         $min = $weather['tempMin'] ?? null;
         $max = $weather['tempMax'] ?? null;
 
-        if (is_numeric($min) && is_numeric($max)) {
-            return \sprintf('%s, %d–%d °C', $description, (int) round((float) $min), (int) round((float) $max));
+        if ('' !== $description && is_numeric($min) && is_numeric($max)) {
+            return $this->translator->trans(
+                'notification.weather_safety.headline.forecast',
+                [
+                    '%description%' => $description,
+                    '%min%' => (int) round((float) $min),
+                    '%max%' => (int) round((float) $max),
+                ],
+                'notifications',
+                $locale,
+            );
         }
 
-        return $description;
+        return '' !== $description
+            ? $description
+            : $this->translator->trans('notification.weather_safety.headline.pending', [], 'notifications', $locale);
     }
 
-    private function body(Stage $stage): string
+    private function body(Stage $stage, string $locale): string
     {
         $alerts = \count($stage->getAlerts());
 
         if (0 === $alerts) {
-            return 'Aucune alerte de sécurité signalée pour cette étape. Bonne route !';
+            return $this->translator->trans('notification.weather_safety.body.none', [], 'notifications', $locale);
         }
 
-        return \sprintf('%d alerte%s de sécurité sur cette étape. Ouvrez l\'app pour les détails.', $alerts, $alerts > 1 ? 's' : '');
+        return $this->translator->trans('notification.weather_safety.body.some', ['%count%' => $alerts], 'notifications', $locale);
     }
 }

--- a/api/src/Notification/WeatherSafetyNotifier.php
+++ b/api/src/Notification/WeatherSafetyNotifier.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notification;
+
+use App\Entity\Stage;
+use App\Enum\NotificationCategory;
+use App\Repository\OwnedTripFinderInterface;
+
+/**
+ * Pushes the `weatherSafety` notification for the stage a rider tackles on a given
+ * day (#1124): the forecast plus the count of safety alerts for that stage.
+ *
+ * There is no Symfony Scheduler in this project, so the trigger is a console
+ * command ({@see \App\Command\NotifyWeatherSafetyCommand}) that ops schedules
+ * twice a day: the evening before (`--day=tomorrow`) and the morning of
+ * (`--day=today`). Each call notifies every owned trip whose ridden stage lands
+ * on the target day, for owners who kept the category enabled.
+ */
+final readonly class WeatherSafetyNotifier
+{
+    public function __construct(
+        private OwnedTripFinderInterface $tripRepository,
+        private NotificationDispatcherInterface $dispatcher,
+    ) {
+    }
+
+    /**
+     * @return int the number of pushes dispatched
+     */
+    public function notify(\DateTimeImmutable $date): int
+    {
+        $day = new \DateTimeImmutable($date->format('Y-m-d'), new \DateTimeZone('UTC'));
+        $dispatched = 0;
+
+        foreach ($this->tripRepository->findOwnedTripsCoveringDate($day) as $trip) {
+            if (in_array(null, [$trip->startDate, $trip->user, $trip->id], true)) {
+                continue;
+            }
+
+            $dayNumber = $trip->startDate->diff($day)->days + 1;
+            $stage = $this->stageOnDay($trip->stages, $dayNumber);
+            if (!$stage instanceof Stage) {
+                continue;
+            }
+
+            $dispatched += $this->dispatcher->dispatch(
+                $trip->user->getId()->toRfc4122(),
+                NotificationCategory::WEATHER_SAFETY,
+                \sprintf('Étape J%d — %s', $dayNumber, $this->weatherHeadline($stage)),
+                $this->body($stage),
+                ['tripId' => $trip->id->toRfc4122(), 'dayNumber' => (string) $dayNumber],
+            ) ? 1 : 0;
+        }
+
+        return $dispatched;
+    }
+
+    /**
+     * @param iterable<Stage> $stages
+     */
+    private function stageOnDay(iterable $stages, int $dayNumber): ?Stage
+    {
+        foreach ($stages as $stage) {
+            if ($stage->getDayNumber() === $dayNumber && !$stage->isRestDay()) {
+                return $stage;
+            }
+        }
+
+        return null;
+    }
+
+    private function weatherHeadline(Stage $stage): string
+    {
+        $weather = $stage->getWeather();
+        if (null === $weather) {
+            return 'météo à venir';
+        }
+
+        $description = \is_string($weather['description'] ?? null) ? $weather['description'] : 'météo';
+        $min = $weather['tempMin'] ?? null;
+        $max = $weather['tempMax'] ?? null;
+
+        if (is_numeric($min) && is_numeric($max)) {
+            return \sprintf('%s, %d–%d °C', $description, (int) round((float) $min), (int) round((float) $max));
+        }
+
+        return $description;
+    }
+
+    private function body(Stage $stage): string
+    {
+        $alerts = \count($stage->getAlerts());
+
+        if (0 === $alerts) {
+            return 'Aucune alerte de sécurité signalée pour cette étape. Bonne route !';
+        }
+
+        return \sprintf('%d alerte%s de sécurité sur cette étape. Ouvrez l\'app pour les détails.', $alerts, $alerts > 1 ? 's' : '');
+    }
+}

--- a/api/src/Notification/ZoneOpeningNotifier.php
+++ b/api/src/Notification/ZoneOpeningNotifier.php
@@ -6,6 +6,7 @@ namespace App\Notification;
 
 use App\Enum\NotificationCategory;
 use App\Repository\NotificationPreferenceRepositoryInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * Pushes the `zoneOpening` announcement when a new reference zone is opened (#1124).
@@ -14,13 +15,15 @@ use App\Repository\NotificationPreferenceRepositoryInterface;
  * it are targeted — resolved from the preference store, not from a broadcast. Zone
  * opening happens in the separate provisioner process ({@see make provision}), so
  * there is no event to hook: ops triggers the push with a console command
- * ({@see \App\Command\NotifyZoneOpenedCommand}) once a zone is promoted.
+ * ({@see \App\Command\NotifyZoneOpenedCommand}) once a zone is promoted. Copy is
+ * localised to each targeted user's locale (falling back to English).
  */
 final readonly class ZoneOpeningNotifier
 {
     public function __construct(
         private NotificationPreferenceRepositoryInterface $preferences,
         private NotificationDispatcherInterface $dispatcher,
+        private TranslatorInterface $translator,
     ) {
     }
 
@@ -31,12 +34,14 @@ final readonly class ZoneOpeningNotifier
     {
         $dispatched = 0;
 
-        foreach ($this->preferences->findUserIdsEnabled(NotificationCategory::ZONE_OPENING) as $userId) {
+        foreach ($this->preferences->findEnabledUsers(NotificationCategory::ZONE_OPENING) as $user) {
+            $locale = '' !== $user['locale'] ? $user['locale'] : 'en';
+
             $dispatched += $this->dispatcher->dispatch(
-                $userId,
+                $user['id'],
                 NotificationCategory::ZONE_OPENING,
-                'Nouvelle zone disponible',
-                \sprintf('La zone %s est maintenant couverte. Planifiez-y votre prochain voyage !', $zoneName),
+                $this->translator->trans('notification.zone_opening.title', [], 'notifications', $locale),
+                $this->translator->trans('notification.zone_opening.body', ['%zone%' => $zoneName], 'notifications', $locale),
                 ['zoneSlug' => $zoneSlug],
             ) ? 1 : 0;
         }

--- a/api/src/Notification/ZoneOpeningNotifier.php
+++ b/api/src/Notification/ZoneOpeningNotifier.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notification;
+
+use App\Enum\NotificationCategory;
+use App\Repository\NotificationPreferenceRepositoryInterface;
+
+/**
+ * Pushes the `zoneOpening` announcement when a new reference zone is opened (#1124).
+ *
+ * This category is opt-in (OFF by default), so only users who explicitly enabled
+ * it are targeted — resolved from the preference store, not from a broadcast. Zone
+ * opening happens in the separate provisioner process ({@see make provision}), so
+ * there is no event to hook: ops triggers the push with a console command
+ * ({@see \App\Command\NotifyZoneOpenedCommand}) once a zone is promoted.
+ */
+final readonly class ZoneOpeningNotifier
+{
+    public function __construct(
+        private NotificationPreferenceRepositoryInterface $preferences,
+        private NotificationDispatcherInterface $dispatcher,
+    ) {
+    }
+
+    /**
+     * @return int the number of pushes dispatched
+     */
+    public function notify(string $zoneSlug, string $zoneName): int
+    {
+        $dispatched = 0;
+
+        foreach ($this->preferences->findUserIdsEnabled(NotificationCategory::ZONE_OPENING) as $userId) {
+            $dispatched += $this->dispatcher->dispatch(
+                $userId,
+                NotificationCategory::ZONE_OPENING,
+                'Nouvelle zone disponible',
+                \sprintf('La zone %s est maintenant couverte. Planifiez-y votre prochain voyage !', $zoneName),
+                ['zoneSlug' => $zoneSlug],
+            ) ? 1 : 0;
+        }
+
+        return $dispatched;
+    }
+}

--- a/api/src/Repository/DoctrineTripRequestRepository.php
+++ b/api/src/Repository/DoctrineTripRequestRepository.php
@@ -201,7 +201,12 @@ final class DoctrineTripRequestRepository extends ServiceEntityRepository implem
         $floor = $date->modify('-60 days');
 
         /** @var list<TripRequest> $trips */
+        // Fetch-join the stages: stageOnDay() iterates t.stages per trip, so a lazy
+        // OneToMany would fire one SELECT per trip (N+1) on a batch that runs twice
+        // a day over a 60-day window.
         $trips = $this->createQueryBuilder('t')
+            ->leftJoin('t.stages', 's')
+            ->addSelect('s')
             ->andWhere('t.user IS NOT NULL')
             ->andWhere('t.startDate IS NOT NULL')
             ->andWhere('t.startDate <= :date')

--- a/api/src/Repository/DoctrineTripRequestRepository.php
+++ b/api/src/Repository/DoctrineTripRequestRepository.php
@@ -191,10 +191,11 @@ final class DoctrineTripRequestRepository extends ServiceEntityRepository implem
 
     /**
      * Owned trips whose date range covers the given day, for the weather-safety
-     * batch (#1124). Bounded by the trip's own date range (startDate <= day <=
-     * endDate), so it never silently drops a long-haul trip the way a fixed
-     * look-back window would; the caller checks a non-rest stage actually falls on
-     * that day.
+     * batch (#1124). Started on or before the day and not yet ended — a trip whose
+     * `endDate` is still unset counts as not-yet-ended, so an open-ended trip is
+     * kept rather than silently dropped. No fixed look-back window, so a long-haul
+     * trip is never excluded by length; the caller checks a non-rest stage actually
+     * falls on that day.
      *
      * @return list<TripRequest>
      */
@@ -203,15 +204,14 @@ final class DoctrineTripRequestRepository extends ServiceEntityRepository implem
         /** @var list<TripRequest> $trips */
         // Fetch-join the stages: stageOnDay() iterates t.stages per trip, so a lazy
         // OneToMany would fire one SELECT per trip (N+1) on a batch that runs twice
-        // a day. The endDate bound already keeps the scan to trips still running on
-        // the given day, regardless of how long ago they started.
+        // a day.
         $trips = $this->createQueryBuilder('t')
             ->leftJoin('t.stages', 's')
             ->addSelect('s')
             ->andWhere('t.user IS NOT NULL')
             ->andWhere('t.startDate IS NOT NULL')
             ->andWhere('t.startDate <= :date')
-            ->andWhere('t.endDate >= :date')
+            ->andWhere('t.endDate IS NULL OR t.endDate >= :date')
             ->setParameter('date', $date)
             ->getQuery()
             ->getResult();

--- a/api/src/Repository/DoctrineTripRequestRepository.php
+++ b/api/src/Repository/DoctrineTripRequestRepository.php
@@ -191,28 +191,28 @@ final class DoctrineTripRequestRepository extends ServiceEntityRepository implem
 
     /**
      * Owned trips whose date range covers the given day, for the weather-safety
-     * batch (#1124). Bounded to a 60-day look-back so ancient trips are not
-     * scanned; the caller checks a non-rest stage actually falls on that day.
+     * batch (#1124). Bounded by the trip's own date range (startDate <= day <=
+     * endDate), so it never silently drops a long-haul trip the way a fixed
+     * look-back window would; the caller checks a non-rest stage actually falls on
+     * that day.
      *
      * @return list<TripRequest>
      */
     public function findOwnedTripsCoveringDate(\DateTimeImmutable $date): array
     {
-        $floor = $date->modify('-60 days');
-
         /** @var list<TripRequest> $trips */
         // Fetch-join the stages: stageOnDay() iterates t.stages per trip, so a lazy
         // OneToMany would fire one SELECT per trip (N+1) on a batch that runs twice
-        // a day over a 60-day window.
+        // a day. The endDate bound already keeps the scan to trips still running on
+        // the given day, regardless of how long ago they started.
         $trips = $this->createQueryBuilder('t')
             ->leftJoin('t.stages', 's')
             ->addSelect('s')
             ->andWhere('t.user IS NOT NULL')
             ->andWhere('t.startDate IS NOT NULL')
             ->andWhere('t.startDate <= :date')
-            ->andWhere('t.startDate > :floor')
+            ->andWhere('t.endDate >= :date')
             ->setParameter('date', $date)
-            ->setParameter('floor', $floor)
             ->getQuery()
             ->getResult();
 

--- a/api/src/Repository/DoctrineTripRequestRepository.php
+++ b/api/src/Repository/DoctrineTripRequestRepository.php
@@ -32,7 +32,7 @@ use Symfony\Component\Uid\Uuid;
  * @extends ServiceEntityRepository<TripRequest>
  */
 #[AsAlias(TripRequestRepositoryInterface::class)]
-final class DoctrineTripRequestRepository extends ServiceEntityRepository implements TripRequestRepositoryInterface
+final class DoctrineTripRequestRepository extends ServiceEntityRepository implements TripRequestRepositoryInterface, OwnedTripFinderInterface
 {
     private const int CACHE_TTL = 1800; // 30 minutes for transient data
 
@@ -182,6 +182,36 @@ final class DoctrineTripRequestRepository extends ServiceEntityRepository implem
     public function getLocale(string $tripId): ?string
     {
         return $this->findTripRequest($tripId)?->locale;
+    }
+
+    public function getOwnerId(string $tripId): ?string
+    {
+        return $this->findTripRequest($tripId)?->user?->getId()->toRfc4122();
+    }
+
+    /**
+     * Owned trips whose date range covers the given day, for the weather-safety
+     * batch (#1124). Bounded to a 60-day look-back so ancient trips are not
+     * scanned; the caller checks a non-rest stage actually falls on that day.
+     *
+     * @return list<TripRequest>
+     */
+    public function findOwnedTripsCoveringDate(\DateTimeImmutable $date): array
+    {
+        $floor = $date->modify('-60 days');
+
+        /** @var list<TripRequest> $trips */
+        $trips = $this->createQueryBuilder('t')
+            ->andWhere('t.user IS NOT NULL')
+            ->andWhere('t.startDate IS NOT NULL')
+            ->andWhere('t.startDate <= :date')
+            ->andWhere('t.startDate > :floor')
+            ->setParameter('date', $date)
+            ->setParameter('floor', $floor)
+            ->getQuery()
+            ->getResult();
+
+        return $trips;
     }
 
     /** @param list<StageDto> $stages */

--- a/api/src/Repository/NotificationPreferenceRepository.php
+++ b/api/src/Repository/NotificationPreferenceRepository.php
@@ -9,6 +9,7 @@ use App\Entity\User;
 use App\Enum\NotificationCategory;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Uid\Uuid;
 
 /**
  * @extends ServiceEntityRepository<NotificationPreference>
@@ -26,7 +27,10 @@ final class NotificationPreferenceRepository extends ServiceEntityRepository imp
         $preference = $this->createQueryBuilder('np')
             ->andWhere('IDENTITY(np.user) = :userId')
             ->andWhere('np.category = :category')
-            ->setParameter('userId', $userId)
+            // Wrap in Uuid so the parameter round-trips through the `uuid` DBAL type
+            // against the FK column; a raw string risks a type error or a silently-
+            // never-matching query (ADR-058: no silent no-op), like findByUserId.
+            ->setParameter('userId', Uuid::fromString($userId))
             ->setParameter('category', $category)
             ->getQuery()
             ->getOneOrNullResult();

--- a/api/src/Repository/NotificationPreferenceRepository.php
+++ b/api/src/Repository/NotificationPreferenceRepository.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\NotificationPreference;
+use App\Entity\User;
+use App\Enum\NotificationCategory;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<NotificationPreference>
+ */
+final class NotificationPreferenceRepository extends ServiceEntityRepository implements NotificationPreferenceRepositoryInterface
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, NotificationPreference::class);
+    }
+
+    public function isEnabled(string $userId, NotificationCategory $category): bool
+    {
+        /** @var NotificationPreference|null $preference */
+        $preference = $this->createQueryBuilder('np')
+            ->andWhere('IDENTITY(np.user) = :userId')
+            ->andWhere('np.category = :category')
+            ->setParameter('userId', $userId)
+            ->setParameter('category', $category)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return $preference?->isEnabled() ?? $category->defaultEnabled();
+    }
+
+    public function findUserIdsEnabled(NotificationCategory $category): array
+    {
+        /** @var list<array{userId: string}> $rows */
+        $rows = $this->createQueryBuilder('np')
+            ->select('IDENTITY(np.user) AS userId')
+            ->andWhere('np.category = :category')
+            ->andWhere('np.enabled = true')
+            ->setParameter('category', $category)
+            ->getQuery()
+            ->getArrayResult();
+
+        return array_map(static fn (array $row): string => (string) $row['userId'], $rows);
+    }
+
+    public function findOne(User $user, NotificationCategory $category): ?NotificationPreference
+    {
+        return $this->findOneBy(['user' => $user, 'category' => $category]);
+    }
+
+    public function save(NotificationPreference $preference): void
+    {
+        $em = $this->getEntityManager();
+        $em->persist($preference);
+        $em->flush();
+    }
+}

--- a/api/src/Repository/NotificationPreferenceRepository.php
+++ b/api/src/Repository/NotificationPreferenceRepository.php
@@ -34,18 +34,22 @@ final class NotificationPreferenceRepository extends ServiceEntityRepository imp
         return $preference?->isEnabled() ?? $category->defaultEnabled();
     }
 
-    public function findUserIdsEnabled(NotificationCategory $category): array
+    public function findEnabledUsers(NotificationCategory $category): array
     {
-        /** @var list<array{userId: string}> $rows */
+        /** @var list<array{id: string, locale: string}> $rows */
         $rows = $this->createQueryBuilder('np')
-            ->select('IDENTITY(np.user) AS userId')
+            ->select('IDENTITY(np.user) AS id', 'u.locale AS locale')
+            ->join('np.user', 'u')
             ->andWhere('np.category = :category')
             ->andWhere('np.enabled = true')
             ->setParameter('category', $category)
             ->getQuery()
             ->getArrayResult();
 
-        return array_map(static fn (array $row): string => (string) $row['userId'], $rows);
+        return array_map(
+            static fn (array $row): array => ['id' => (string) $row['id'], 'locale' => (string) $row['locale']],
+            $rows,
+        );
     }
 
     public function findOne(User $user, NotificationCategory $category): ?NotificationPreference

--- a/api/src/Repository/NotificationPreferenceRepositoryInterface.php
+++ b/api/src/Repository/NotificationPreferenceRepositoryInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\NotificationPreference;
+use App\Entity\User;
+use App\Enum\NotificationCategory;
+
+interface NotificationPreferenceRepositoryInterface
+{
+    /**
+     * Effective opt-in for a category: the stored value, or the category default
+     * when the user has no explicit row.
+     */
+    public function isEnabled(string $userId, NotificationCategory $category): bool;
+
+    /**
+     * User ids that explicitly enabled a category (used for opt-in categories such
+     * as zone opening, where the default is OFF so only opted-in users are targeted).
+     *
+     * @return list<string>
+     */
+    public function findUserIdsEnabled(NotificationCategory $category): array;
+
+    public function findOne(User $user, NotificationCategory $category): ?NotificationPreference;
+
+    public function save(NotificationPreference $preference): void;
+}

--- a/api/src/Repository/NotificationPreferenceRepositoryInterface.php
+++ b/api/src/Repository/NotificationPreferenceRepositoryInterface.php
@@ -17,12 +17,13 @@ interface NotificationPreferenceRepositoryInterface
     public function isEnabled(string $userId, NotificationCategory $category): bool;
 
     /**
-     * User ids that explicitly enabled a category (used for opt-in categories such
-     * as zone opening, where the default is OFF so only opted-in users are targeted).
+     * Users who explicitly enabled a category (used for opt-in categories such as
+     * zone opening, where the default is OFF so only opted-in users are targeted).
+     * Each row carries the user id and locale so the push can be localised per user.
      *
-     * @return list<string>
+     * @return list<array{id: string, locale: string}>
      */
-    public function findUserIdsEnabled(NotificationCategory $category): array;
+    public function findEnabledUsers(NotificationCategory $category): array;
 
     public function findOne(User $user, NotificationCategory $category): ?NotificationPreference;
 

--- a/api/src/Repository/OwnedTripFinderInterface.php
+++ b/api/src/Repository/OwnedTripFinderInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\ApiResource\TripRequest;
+
+interface OwnedTripFinderInterface
+{
+    /**
+     * Owned (non-anonymous) trips whose date range covers the given day, for the
+     * weather-safety batch (#1124).
+     *
+     * @return list<TripRequest>
+     */
+    public function findOwnedTripsCoveringDate(\DateTimeImmutable $date): array;
+}

--- a/api/src/Repository/RedisTripRequestRepository.php
+++ b/api/src/Repository/RedisTripRequestRepository.php
@@ -313,6 +313,11 @@ final readonly class RedisTripRequestRepository implements TripRequestRepository
         return $value;
     }
 
+    public function getOwnerId(string $tripId): ?string
+    {
+        return $this->getRequest($tripId)?->user?->getId()->toRfc4122();
+    }
+
     private function titleKey(string $tripId): string
     {
         return \sprintf('trip.%s.title', $tripId);

--- a/api/src/Repository/TripRequestRepositoryInterface.php
+++ b/api/src/Repository/TripRequestRepositoryInterface.php
@@ -119,4 +119,10 @@ interface TripRequestRepositoryInterface
     public function storeLocale(string $tripId, string $locale): void;
 
     public function getLocale(string $tripId): ?string;
+
+    /**
+     * The RFC 4122 id of the trip's owner, or null when the trip is anonymous
+     * (no account attached) or does not exist. Used to target server pushes (#1124).
+     */
+    public function getOwnerId(string $tripId): ?string;
 }

--- a/api/src/State/Account/NotificationPreferenceProvider.php
+++ b/api/src/State/Account/NotificationPreferenceProvider.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\State\Account;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProviderInterface;
+use App\ApiResource\Account\NotificationPreference as NotificationPreferenceResource;
+use App\Entity\User;
+use App\Enum\NotificationCategory;
+use App\Repository\NotificationPreferenceRepositoryInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+
+/**
+ * Returns the current user's effective opt-in for every notification category (#1124):
+ * the stored override when present, otherwise the category default.
+ *
+ * @implements ProviderInterface<NotificationPreferenceResource>
+ */
+final readonly class NotificationPreferenceProvider implements ProviderInterface
+{
+    public function __construct(
+        private Security $security,
+        private NotificationPreferenceRepositoryInterface $preferences,
+    ) {
+    }
+
+    /**
+     * @return list<NotificationPreferenceResource>
+     */
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): array
+    {
+        $user = $this->security->getUser();
+        \assert($user instanceof User);
+        $userId = $user->getId()->toRfc4122();
+
+        return array_map(
+            fn (NotificationCategory $category): NotificationPreferenceResource => new NotificationPreferenceResource(
+                $category,
+                $this->preferences->isEnabled($userId, $category),
+            ),
+            NotificationCategory::cases(),
+        );
+    }
+}

--- a/api/src/State/Account/NotificationPreferenceUpdateProcessor.php
+++ b/api/src/State/Account/NotificationPreferenceUpdateProcessor.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\State\Account;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\ApiResource\Account\NotificationPreference as NotificationPreferenceResource;
+use App\Entity\NotificationPreference;
+use App\Entity\User;
+use App\Enum\NotificationCategory;
+use App\Repository\NotificationPreferenceRepositoryInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Upserts the current user's opt-in for one notification category (#1124).
+ *
+ * The category comes from the URL, the boolean from the body. An unknown category
+ * is 404 (there is no such preference resource). Same user + same value is an
+ * idempotent no-op that still returns the resource.
+ *
+ * @implements ProcessorInterface<NotificationPreferenceResource, NotificationPreferenceResource>
+ */
+final readonly class NotificationPreferenceUpdateProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private Security $security,
+        private NotificationPreferenceRepositoryInterface $preferences,
+    ) {
+    }
+
+    /**
+     * @param NotificationPreferenceResource $data
+     */
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): NotificationPreferenceResource
+    {
+        $user = $this->security->getUser();
+        \assert($user instanceof User);
+
+        $rawCategory = $uriVariables['category'] ?? null;
+        $category = \is_string($rawCategory) ? NotificationCategory::tryFrom($rawCategory) : null;
+        if (null === $category) {
+            throw new NotFoundHttpException();
+        }
+
+        $preference = $this->preferences->findOne($user, $category);
+        if ($preference instanceof NotificationPreference) {
+            $preference->setEnabled($data->enabled);
+        } else {
+            $preference = new NotificationPreference($user, $category, $data->enabled);
+        }
+
+        $this->preferences->save($preference);
+
+        return new NotificationPreferenceResource($category, $preference->isEnabled());
+    }
+}

--- a/api/src/State/Account/NotificationPreferenceUpdateProcessor.php
+++ b/api/src/State/Account/NotificationPreferenceUpdateProcessor.php
@@ -47,11 +47,16 @@ final readonly class NotificationPreferenceUpdateProcessor implements ProcessorI
             throw new NotFoundHttpException();
         }
 
+        // Guaranteed non-null by the resource's #[Assert\NotNull] (validation runs
+        // before this processor): a PUT omitting `enabled` 422s and never reaches here.
+        $enabled = $data->enabled;
+        \assert(null !== $enabled);
+
         $preference = $this->preferences->findOne($user, $category);
         if ($preference instanceof NotificationPreference) {
-            $preference->setEnabled($data->enabled);
+            $preference->setEnabled($enabled);
         } else {
-            $preference = new NotificationPreference($user, $category, $data->enabled);
+            $preference = new NotificationPreference($user, $category, $enabled);
         }
 
         try {

--- a/api/src/State/Account/NotificationPreferenceUpdateProcessor.php
+++ b/api/src/State/Account/NotificationPreferenceUpdateProcessor.php
@@ -11,7 +11,9 @@ use App\Entity\NotificationPreference;
 use App\Entity\User;
 use App\Enum\NotificationCategory;
 use App\Repository\NotificationPreferenceRepositoryInterface;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
@@ -52,7 +54,13 @@ final readonly class NotificationPreferenceUpdateProcessor implements ProcessorI
             $preference = new NotificationPreference($user, $category, $data->enabled);
         }
 
-        $this->preferences->save($preference);
+        try {
+            $this->preferences->save($preference);
+        } catch (UniqueConstraintViolationException) {
+            // A concurrent PUT for the same (user, category) inserted between the
+            // lookup and this flush — same guard as DeviceTokenRegisterProcessor.
+            throw new ConflictHttpException('Notification preference update conflicted with a concurrent request; retry.');
+        }
 
         return new NotificationPreferenceResource($category, $preference->isEnabled());
     }

--- a/api/tests/Functional/Account/NotificationPreferenceTest.php
+++ b/api/tests/Functional/Account/NotificationPreferenceTest.php
@@ -113,4 +113,19 @@ final class NotificationPreferenceTest extends ApiTestCase
 
         $this->assertResponseStatusCodeSame(401);
     }
+
+    #[Test]
+    public function putWithoutAnEnabledFieldIsRejectedAndDoesNotSilentlyDisable(): void
+    {
+        // A body omitting `enabled` must 422 (Assert\NotNull), not default to false
+        // and silently opt the user out of a default-ON category.
+        $fixtures = $this->createUser('prefs-missing-enabled@example.com');
+
+        self::createClient()->request('PUT', '/users/me/notification-preferences/weatherSafety', [
+            'headers' => ['Content-Type' => 'application/ld+json', 'Authorization' => 'Bearer '.$fixtures['jwt']],
+            'json' => [],
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+    }
 }

--- a/api/tests/Functional/Account/NotificationPreferenceTest.php
+++ b/api/tests/Functional/Account/NotificationPreferenceTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Account;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+use Zenstruck\Foundry\Test\Factories;
+
+#[ResetDatabase]
+final class NotificationPreferenceTest extends ApiTestCase
+{
+    use Factories;
+
+    #[\Override]
+    public static function setUpBeforeClass(): void
+    {
+        self::$alwaysBootKernel = false;
+    }
+
+    private function getEntityManager(): EntityManagerInterface
+    {
+        return self::getContainer()->get('doctrine.orm.entity_manager');
+    }
+
+    /**
+     * @param non-empty-string $email
+     *
+     * @return array{user: User, jwt: string}
+     */
+    private function createUser(string $email): array
+    {
+        $em = $this->getEntityManager();
+        $user = new User($email);
+        $em->persist($user);
+        $em->flush();
+
+        /** @var JWTTokenManagerInterface $jwtManager */
+        $jwtManager = self::getContainer()->get('lexik_jwt_authentication.jwt_manager');
+
+        return ['user' => $user, 'jwt' => $jwtManager->create($user)];
+    }
+
+    #[Test]
+    public function listReturnsTheThreeCategoriesWithTheirDefaults(): void
+    {
+        $fixtures = $this->createUser('prefs-list@example.com');
+
+        $response = self::createClient()->request('GET', '/users/me/notification-preferences', [
+            'headers' => ['Authorization' => 'Bearer '.$fixtures['jwt']],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+
+        $members = $response->toArray(false)['hydra:member'] ?? $response->toArray(false)['member'] ?? [];
+        $byCategory = [];
+        foreach ($members as $member) {
+            $byCategory[$member['category']] = $member['enabled'];
+        }
+
+        $this->assertSame(
+            ['weatherSafety' => true, 'analysisDone' => true, 'zoneOpening' => false],
+            $byCategory,
+        );
+    }
+
+    #[Test]
+    public function putTogglesACategoryAndTheChangePersists(): void
+    {
+        $fixtures = $this->createUser('prefs-put@example.com');
+        $client = self::createClient();
+
+        $client->request('PUT', '/users/me/notification-preferences/zoneOpening', [
+            'headers' => ['Content-Type' => 'application/ld+json', 'Authorization' => 'Bearer '.$fixtures['jwt']],
+            'json' => ['enabled' => true],
+        ]);
+        $this->assertResponseIsSuccessful();
+
+        $response = $client->request('GET', '/users/me/notification-preferences', [
+            'headers' => ['Authorization' => 'Bearer '.$fixtures['jwt']],
+        ]);
+        $members = $response->toArray(false)['hydra:member'] ?? $response->toArray(false)['member'] ?? [];
+        $byCategory = [];
+        foreach ($members as $member) {
+            $byCategory[$member['category']] = $member['enabled'];
+        }
+
+        $this->assertTrue($byCategory['zoneOpening']);
+    }
+
+    #[Test]
+    public function putOnAnUnknownCategoryIs404(): void
+    {
+        $fixtures = $this->createUser('prefs-unknown@example.com');
+
+        self::createClient()->request('PUT', '/users/me/notification-preferences/bogus', [
+            'headers' => ['Content-Type' => 'application/ld+json', 'Authorization' => 'Bearer '.$fixtures['jwt']],
+            'json' => ['enabled' => true],
+        ]);
+
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    #[Test]
+    public function anonymousAccessIsRejected(): void
+    {
+        self::createClient()->request('GET', '/users/me/notification-preferences');
+
+        $this->assertResponseStatusCodeSame(401);
+    }
+}

--- a/api/tests/Integration/Notification/NotificationDispatcherIntegrationTest.php
+++ b/api/tests/Integration/Notification/NotificationDispatcherIntegrationTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Notification;
+
+use App\Entity\NotificationPreference;
+use App\Entity\User;
+use App\Enum\NotificationCategory;
+use App\Message\SendPushNotification;
+use App\Notification\NotificationDispatcher;
+use App\Repository\NotificationPreferenceRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * Wires NotificationDispatcher to the REAL NotificationPreferenceRepository (#1124):
+ * the dispatcher's opt-in gate runs the repository's `IDENTITY(np.user) = :userId`
+ * lookup against real Postgres, which the stubbed unit test cannot exercise. Guards
+ * that a regression in that lookup (e.g. the uuid-binding) would surface here.
+ */
+final class NotificationDispatcherIntegrationTest extends KernelTestCase
+{
+    use ResetDatabase;
+
+    private EntityManagerInterface $em;
+
+    private NotificationPreferenceRepository $repository;
+
+    /** @var list<SendPushNotification> */
+    private array $dispatched = [];
+
+    private NotificationDispatcher $dispatcher;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->em = self::getContainer()->get('doctrine.orm.entity_manager');
+        $this->repository = self::getContainer()->get(NotificationPreferenceRepository::class);
+
+        $this->dispatched = [];
+        $record = function (SendPushNotification $message): void {
+            $this->dispatched[] = $message;
+        };
+        $bus = new readonly class ($record) implements MessageBusInterface {
+            /** @param \Closure(SendPushNotification): void $record */
+            public function __construct(private \Closure $record)
+            {
+            }
+
+            public function dispatch(object $message, array $stamps = []): Envelope
+            {
+                \assert($message instanceof SendPushNotification);
+                ($this->record)($message);
+
+                return new Envelope($message);
+            }
+        };
+        $this->dispatcher = new NotificationDispatcher($bus, $this->repository);
+    }
+
+    #[Test]
+    public function dispatchesWhenTheStoredPreferenceEnablesTheCategory(): void
+    {
+        $user = $this->persistUser('on@example.com');
+        // ZONE_OPENING defaults to off, so only an explicit opt-in enables it.
+        $this->repository->save(new NotificationPreference($user, NotificationCategory::ZONE_OPENING, true));
+
+        $sent = $this->dispatcher->dispatch(
+            $user->getId()->toRfc4122(),
+            NotificationCategory::ZONE_OPENING,
+            'Titre',
+            'Corps',
+        );
+
+        self::assertTrue($sent);
+        self::assertCount(1, $this->dispatched);
+        self::assertSame('zoneOpening', $this->dispatched[0]->category);
+    }
+
+    #[Test]
+    public function doesNotDispatchWhenTheStoredPreferenceDisablesTheCategory(): void
+    {
+        $user = $this->persistUser('off@example.com');
+        $this->repository->save(new NotificationPreference($user, NotificationCategory::WEATHER_SAFETY, false));
+
+        $sent = $this->dispatcher->dispatch(
+            $user->getId()->toRfc4122(),
+            NotificationCategory::WEATHER_SAFETY,
+            'Titre',
+            'Corps',
+        );
+
+        self::assertFalse($sent);
+        self::assertSame([], $this->dispatched);
+    }
+
+    /**
+     * @param non-empty-string $email
+     */
+    private function persistUser(string $email): User
+    {
+        $user = new User($email);
+        $this->em->persist($user);
+        $this->em->flush();
+
+        return $user;
+    }
+}

--- a/api/tests/Integration/Repository/NotificationPreferenceRepositoryTest.php
+++ b/api/tests/Integration/Repository/NotificationPreferenceRepositoryTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Repository;
+
+use App\Entity\NotificationPreference;
+use App\Entity\User;
+use App\Enum\NotificationCategory;
+use App\Repository\NotificationPreferenceRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * Integration coverage for the per-category opt-in store (#1124): the default
+ * fallback when no row exists, the stored override, and the opted-in user lookup.
+ */
+final class NotificationPreferenceRepositoryTest extends KernelTestCase
+{
+    use ResetDatabase;
+
+    private EntityManagerInterface $em;
+
+    private NotificationPreferenceRepository $repository;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->em = self::getContainer()->get('doctrine.orm.entity_manager');
+        $this->repository = self::getContainer()->get(NotificationPreferenceRepository::class);
+    }
+
+    #[Test]
+    public function fallsBackToTheCategoryDefaultWhenNoRowExists(): void
+    {
+        $user = $this->persistUser('default@example.com');
+        $userId = $user->getId()->toRfc4122();
+
+        self::assertTrue($this->repository->isEnabled($userId, NotificationCategory::WEATHER_SAFETY));
+        self::assertTrue($this->repository->isEnabled($userId, NotificationCategory::ANALYSIS_DONE));
+        self::assertFalse($this->repository->isEnabled($userId, NotificationCategory::ZONE_OPENING));
+    }
+
+    #[Test]
+    public function aStoredOverrideWins(): void
+    {
+        $user = $this->persistUser('override@example.com');
+        $userId = $user->getId()->toRfc4122();
+
+        $this->repository->save(new NotificationPreference($user, NotificationCategory::WEATHER_SAFETY, false));
+        $this->repository->save(new NotificationPreference($user, NotificationCategory::ZONE_OPENING, true));
+
+        self::assertFalse($this->repository->isEnabled($userId, NotificationCategory::WEATHER_SAFETY));
+        self::assertTrue($this->repository->isEnabled($userId, NotificationCategory::ZONE_OPENING));
+    }
+
+    #[Test]
+    public function findsOnlyUsersWhoExplicitlyOptedIntoACategory(): void
+    {
+        $optedIn = $this->persistUser('in@example.com');
+        $optedOut = $this->persistUser('out@example.com');
+        $this->persistUser('untouched@example.com');
+
+        $this->repository->save(new NotificationPreference($optedIn, NotificationCategory::ZONE_OPENING, true));
+        $this->repository->save(new NotificationPreference($optedOut, NotificationCategory::ZONE_OPENING, false));
+
+        $ids = $this->repository->findUserIdsEnabled(NotificationCategory::ZONE_OPENING);
+
+        self::assertSame([$optedIn->getId()->toRfc4122()], $ids);
+    }
+
+    /**
+     * @param non-empty-string $email
+     */
+    private function persistUser(string $email): User
+    {
+        $user = new User($email);
+        $this->em->persist($user);
+        $this->em->flush();
+
+        return $user;
+    }
+}

--- a/api/tests/Integration/Repository/NotificationPreferenceRepositoryTest.php
+++ b/api/tests/Integration/Repository/NotificationPreferenceRepositoryTest.php
@@ -57,26 +57,28 @@ final class NotificationPreferenceRepositoryTest extends KernelTestCase
     }
 
     #[Test]
-    public function findsOnlyUsersWhoExplicitlyOptedIntoACategory(): void
+    public function findsOnlyUsersWhoExplicitlyOptedIntoACategoryWithTheirLocale(): void
     {
-        $optedIn = $this->persistUser('in@example.com');
-        $optedOut = $this->persistUser('out@example.com');
-        $this->persistUser('untouched@example.com');
+        $optedIn = $this->persistUser('in@example.com', 'en');
+        $optedOut = $this->persistUser('out@example.com', 'fr');
+        $this->persistUser('untouched@example.com', 'fr');
 
         $this->repository->save(new NotificationPreference($optedIn, NotificationCategory::ZONE_OPENING, true));
         $this->repository->save(new NotificationPreference($optedOut, NotificationCategory::ZONE_OPENING, false));
 
-        $ids = $this->repository->findUserIdsEnabled(NotificationCategory::ZONE_OPENING);
+        $users = $this->repository->findEnabledUsers(NotificationCategory::ZONE_OPENING);
 
-        self::assertSame([$optedIn->getId()->toRfc4122()], $ids);
+        self::assertSame([['id' => $optedIn->getId()->toRfc4122(), 'locale' => 'en']], $users);
     }
 
     /**
      * @param non-empty-string $email
      */
-    private function persistUser(string $email): User
+    private function persistUser(string $email, string $locale = 'fr'): User
     {
         $user = new User($email);
+        $user->setLocale($locale);
+
         $this->em->persist($user);
         $this->em->flush();
 

--- a/api/tests/Integration/Repository/OwnedTripFinderTest.php
+++ b/api/tests/Integration/Repository/OwnedTripFinderTest.php
@@ -14,10 +14,11 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Foundry\Test\ResetDatabase;
 
 /**
- * Integration coverage for the weather-safety batch lookup (#1124): the boundary
- * logic of findOwnedTripsCoveringDate (startDate <= date, strict 60-day floor) and
- * the exclusion of anonymous and undated trips. Only exercised through stubs
- * elsewhere, so an off-by-one on the floor or a dropped filter would go undetected.
+ * Integration coverage for the weather-safety batch lookup (#1124): the coverage
+ * logic of findOwnedTripsCoveringDate (startDate <= date <= endDate, including a
+ * long-haul trip that started well over two months ago) and the exclusion of
+ * ended, future, undated and anonymous trips. Only exercised through stubs
+ * elsewhere, so a dropped filter would go undetected.
  */
 final class OwnedTripFinderTest extends KernelTestCase
 {
@@ -35,21 +36,24 @@ final class OwnedTripFinderTest extends KernelTestCase
     }
 
     #[Test]
-    public function returnsOnlyOwnedDatedTripsWhoseStartFallsInTheClosedOpenWindow(): void
+    public function returnsOnlyOwnedDatedTripsWhoseRangeCoversTheDay(): void
     {
         $date = new \DateTimeImmutable('2026-06-15');
         $owner = $this->persistUser('owner@example.com');
 
-        // Inside the (floor, date] window.
-        $onDate = $this->persistTrip($owner, $date);                          // upper bound, inclusive
-        $midWindow = $this->persistTrip($owner, $date->modify('-30 days'));
-        $justAfterFloor = $this->persistTrip($owner, $date->modify('-59 days'));
+        // Covering the day (startDate <= date <= endDate).
+        $startsOnDate = $this->persistTrip($owner, $date, $date->modify('+5 days'));
+        $midTrip = $this->persistTrip($owner, $date->modify('-3 days'), $date->modify('+2 days'));
+        $endsOnDate = $this->persistTrip($owner, $date->modify('-4 days'), $date);
+        // The regression case: a long-haul trip that started 90 days ago and still
+        // runs — a fixed 60-day look-back would have silently dropped it.
+        $longHaul = $this->persistTrip($owner, $date->modify('-90 days'), $date->modify('+10 days'));
 
-        // Outside it, one reason each.
-        $this->persistTrip($owner, $date->modify('-60 days'));   // exactly the floor: excluded (strict >)
-        $this->persistTrip($owner, $date->modify('+1 day'));     // future start: excluded (<= date)
-        $this->persistTrip($owner, null);                        // undated: excluded
-        $this->persistTrip(null, $date);                         // anonymous: excluded
+        // Not covering the day, one reason each.
+        $this->persistTrip($owner, $date->modify('-10 days'), $date->modify('-1 day')); // already ended
+        $this->persistTrip($owner, $date->modify('+1 day'), $date->modify('+5 days'));  // starts tomorrow
+        $this->persistTrip($owner, null, null);                                          // undated
+        $this->persistTrip(null, $date, $date->modify('+3 days'));                       // anonymous
 
         $ids = array_map(
             static fn (TripRequest $t): string => $t->id?->toRfc4122() ?? '',
@@ -57,19 +61,19 @@ final class OwnedTripFinderTest extends KernelTestCase
         );
         sort($ids);
 
-        $expected = [$onDate->id, $midWindow->id, $justAfterFloor->id];
+        $expected = [$startsOnDate->id, $midTrip->id, $endsOnDate->id, $longHaul->id];
         $expected = array_map(static fn (?Uuid $id): string => $id?->toRfc4122() ?? '', $expected);
         sort($expected);
 
         self::assertSame($expected, $ids);
     }
 
-    private function persistTrip(?User $user, ?\DateTimeImmutable $startDate): TripRequest
+    private function persistTrip(?User $user, ?\DateTimeImmutable $startDate, ?\DateTimeImmutable $endDate): TripRequest
     {
         $trip = new TripRequest();
         $trip->user = $user;
         $trip->startDate = $startDate;
-        $trip->endDate = $startDate instanceof \DateTimeImmutable ? $startDate->modify('+3 days') : null;
+        $trip->endDate = $endDate;
         $trip->sourceUrl = 'https://www.komoot.com/tour/123456789';
 
         $this->em->persist($trip);

--- a/api/tests/Integration/Repository/OwnedTripFinderTest.php
+++ b/api/tests/Integration/Repository/OwnedTripFinderTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Repository;
+
+use Symfony\Component\Uid\Uuid;
+use App\ApiResource\TripRequest;
+use App\Entity\User;
+use App\Repository\DoctrineTripRequestRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * Integration coverage for the weather-safety batch lookup (#1124): the boundary
+ * logic of findOwnedTripsCoveringDate (startDate <= date, strict 60-day floor) and
+ * the exclusion of anonymous and undated trips. Only exercised through stubs
+ * elsewhere, so an off-by-one on the floor or a dropped filter would go undetected.
+ */
+final class OwnedTripFinderTest extends KernelTestCase
+{
+    use ResetDatabase;
+
+    private EntityManagerInterface $em;
+
+    private DoctrineTripRequestRepository $repository;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->em = self::getContainer()->get('doctrine.orm.entity_manager');
+        $this->repository = self::getContainer()->get(DoctrineTripRequestRepository::class);
+    }
+
+    #[Test]
+    public function returnsOnlyOwnedDatedTripsWhoseStartFallsInTheClosedOpenWindow(): void
+    {
+        $date = new \DateTimeImmutable('2026-06-15');
+        $owner = $this->persistUser('owner@example.com');
+
+        // Inside the (floor, date] window.
+        $onDate = $this->persistTrip($owner, $date);                          // upper bound, inclusive
+        $midWindow = $this->persistTrip($owner, $date->modify('-30 days'));
+        $justAfterFloor = $this->persistTrip($owner, $date->modify('-59 days'));
+
+        // Outside it, one reason each.
+        $this->persistTrip($owner, $date->modify('-60 days'));   // exactly the floor: excluded (strict >)
+        $this->persistTrip($owner, $date->modify('+1 day'));     // future start: excluded (<= date)
+        $this->persistTrip($owner, null);                        // undated: excluded
+        $this->persistTrip(null, $date);                         // anonymous: excluded
+
+        $ids = array_map(
+            static fn (TripRequest $t): string => $t->id?->toRfc4122() ?? '',
+            $this->repository->findOwnedTripsCoveringDate($date),
+        );
+        sort($ids);
+
+        $expected = [$onDate->id, $midWindow->id, $justAfterFloor->id];
+        $expected = array_map(static fn (?Uuid $id): string => $id?->toRfc4122() ?? '', $expected);
+        sort($expected);
+
+        self::assertSame($expected, $ids);
+    }
+
+    private function persistTrip(?User $user, ?\DateTimeImmutable $startDate): TripRequest
+    {
+        $trip = new TripRequest();
+        $trip->user = $user;
+        $trip->startDate = $startDate;
+        $trip->endDate = $startDate instanceof \DateTimeImmutable ? $startDate->modify('+3 days') : null;
+        $trip->sourceUrl = 'https://www.komoot.com/tour/123456789';
+
+        $this->em->persist($trip);
+        $this->em->flush();
+
+        return $trip;
+    }
+
+    /**
+     * @param non-empty-string $email
+     */
+    private function persistUser(string $email): User
+    {
+        $user = new User($email);
+
+        $this->em->persist($user);
+        $this->em->flush();
+
+        return $user;
+    }
+}

--- a/api/tests/Integration/Repository/OwnedTripFinderTest.php
+++ b/api/tests/Integration/Repository/OwnedTripFinderTest.php
@@ -15,10 +15,10 @@ use Zenstruck\Foundry\Test\ResetDatabase;
 
 /**
  * Integration coverage for the weather-safety batch lookup (#1124): the coverage
- * logic of findOwnedTripsCoveringDate (startDate <= date <= endDate, including a
- * long-haul trip that started well over two months ago) and the exclusion of
- * ended, future, undated and anonymous trips. Only exercised through stubs
- * elsewhere, so a dropped filter would go undetected.
+ * logic of findOwnedTripsCoveringDate (started on/before the day and not yet ended,
+ * including a long-haul trip started months ago and an open-ended trip with no
+ * endDate) and the exclusion of ended, future, undated and anonymous trips. Only
+ * exercised through stubs elsewhere, so a dropped filter would go undetected.
  */
 final class OwnedTripFinderTest extends KernelTestCase
 {
@@ -48,10 +48,13 @@ final class OwnedTripFinderTest extends KernelTestCase
         // The regression case: a long-haul trip that started 90 days ago and still
         // runs — a fixed 60-day look-back would have silently dropped it.
         $longHaul = $this->persistTrip($owner, $date->modify('-90 days'), $date->modify('+10 days'));
+        // Open-ended (startDate set, endDate null) counts as not-yet-ended.
+        $openEnded = $this->persistTrip($owner, $date->modify('-2 days'), null);
 
         // Not covering the day, one reason each.
         $this->persistTrip($owner, $date->modify('-10 days'), $date->modify('-1 day')); // already ended
         $this->persistTrip($owner, $date->modify('+1 day'), $date->modify('+5 days'));  // starts tomorrow
+        $this->persistTrip($owner, $date->modify('+1 day'), null);                       // open-ended, future start
         $this->persistTrip($owner, null, null);                                          // undated
         $this->persistTrip(null, $date, $date->modify('+3 days'));                       // anonymous
 
@@ -61,7 +64,7 @@ final class OwnedTripFinderTest extends KernelTestCase
         );
         sort($ids);
 
-        $expected = [$startsOnDate->id, $midTrip->id, $endsOnDate->id, $longHaul->id];
+        $expected = [$startsOnDate->id, $midTrip->id, $endsOnDate->id, $longHaul->id, $openEnded->id];
         $expected = array_map(static fn (?Uuid $id): string => $id?->toRfc4122() ?? '', $expected);
         sort($expected);
 

--- a/api/tests/Unit/Command/NotifyWeatherSafetyCommandTest.php
+++ b/api/tests/Unit/Command/NotifyWeatherSafetyCommandTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Command;
+
+use App\Command\NotifyWeatherSafetyCommand;
+use App\Notification\NotificationDispatcherInterface;
+use App\Notification\WeatherSafetyNotifier;
+use App\Repository\OwnedTripFinderInterface;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class NotifyWeatherSafetyCommandTest extends TestCase
+{
+    #[Test]
+    public function todayIsAccepted(): void
+    {
+        $tester = new CommandTester($this->command());
+
+        self::assertSame(Command::SUCCESS, $tester->execute(['--day' => 'today']));
+        self::assertStringContainsString('Dispatched 0 weather-safety', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function tomorrowIsAccepted(): void
+    {
+        $tester = new CommandTester($this->command());
+
+        self::assertSame(Command::SUCCESS, $tester->execute(['--day' => 'tomorrow']));
+    }
+
+    #[Test]
+    public function anIsoDateIsAccepted(): void
+    {
+        $tester = new CommandTester($this->command());
+
+        self::assertSame(Command::SUCCESS, $tester->execute(['--day' => '2026-08-20']));
+        self::assertStringContainsString('2026-08-20', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function aBogusDayIsRejected(): void
+    {
+        $tester = new CommandTester($this->command());
+
+        self::assertSame(Command::INVALID, $tester->execute(['--day' => 'nope']));
+        self::assertStringContainsString('Invalid --day', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function anImpossibleIsoDateIsRejected(): void
+    {
+        $tester = new CommandTester($this->command());
+
+        self::assertSame(Command::INVALID, $tester->execute(['--day' => '2026-13-40']));
+    }
+
+    private function command(): NotifyWeatherSafetyCommand
+    {
+        $finder = $this->createStub(OwnedTripFinderInterface::class);
+        $finder->method('findOwnedTripsCoveringDate')->willReturn([]);
+
+        $notifier = new WeatherSafetyNotifier(
+            $finder,
+            $this->createStub(NotificationDispatcherInterface::class),
+            $this->createStub(TranslatorInterface::class),
+        );
+
+        return new NotifyWeatherSafetyCommand($notifier);
+    }
+}

--- a/api/tests/Unit/Command/NotifyZoneOpenedCommandTest.php
+++ b/api/tests/Unit/Command/NotifyZoneOpenedCommandTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Command;
+
+use App\Command\NotifyZoneOpenedCommand;
+use App\Notification\NotificationDispatcherInterface;
+use App\Notification\ZoneOpeningNotifier;
+use App\Repository\NotificationPreferenceRepositoryInterface;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class NotifyZoneOpenedCommandTest extends TestCase
+{
+    #[Test]
+    public function usesTheExplicitNameAndSkipsTheZoneLookup(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->never())->method('fetchOne');
+
+        $tester = new CommandTester($this->command($connection));
+        $status = $tester->execute(['slug' => 'corse', '--name' => 'Corse']);
+
+        self::assertSame(Command::SUCCESS, $status);
+        self::assertStringContainsString('Corse', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function fallsBackToTheZoneNameFromOsmZones(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())
+            ->method('fetchOne')
+            ->with($this->stringContains('osm.zones'), ['slug' => 'corse'])
+            ->willReturn('Corse');
+
+        $tester = new CommandTester($this->command($connection));
+        $status = $tester->execute(['slug' => 'corse']);
+
+        self::assertSame(Command::SUCCESS, $status);
+        self::assertStringContainsString('Corse', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function rejectsAnUnknownZoneWithoutAnExplicitName(): void
+    {
+        $connection = $this->createStub(Connection::class);
+        $connection->method('fetchOne')->willReturn(false);
+
+        $tester = new CommandTester($this->command($connection));
+        $status = $tester->execute(['slug' => 'atlantis']);
+
+        self::assertSame(Command::INVALID, $status);
+        self::assertStringContainsString('Unknown zone', $tester->getDisplay());
+    }
+
+    private function command(Connection $connection): NotifyZoneOpenedCommand
+    {
+        $preferences = $this->createStub(NotificationPreferenceRepositoryInterface::class);
+        $preferences->method('findEnabledUsers')->willReturn([]);
+
+        $notifier = new ZoneOpeningNotifier(
+            $preferences,
+            $this->createStub(NotificationDispatcherInterface::class),
+            $this->createStub(TranslatorInterface::class),
+        );
+
+        return new NotifyZoneOpenedCommand($notifier, $connection);
+    }
+}

--- a/api/tests/Unit/Enum/NotificationCategoryTest.php
+++ b/api/tests/Unit/Enum/NotificationCategoryTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Enum;
+
+use App\Enum\NotificationCategory;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class NotificationCategoryTest extends TestCase
+{
+    #[Test]
+    public function safetyAndAnalysisAreOnByDefaultZoneOpeningIsOff(): void
+    {
+        self::assertTrue(NotificationCategory::WEATHER_SAFETY->defaultEnabled());
+        self::assertTrue(NotificationCategory::ANALYSIS_DONE->defaultEnabled());
+        self::assertFalse(NotificationCategory::ZONE_OPENING->defaultEnabled());
+    }
+
+    #[Test]
+    public function wireValuesMatchTheClientContract(): void
+    {
+        self::assertSame('weatherSafety', NotificationCategory::WEATHER_SAFETY->value);
+        self::assertSame('analysisDone', NotificationCategory::ANALYSIS_DONE->value);
+        self::assertSame('zoneOpening', NotificationCategory::ZONE_OPENING->value);
+    }
+}

--- a/api/tests/Unit/Mercure/MercureSubscriptionCheckerTest.php
+++ b/api/tests/Unit/Mercure/MercureSubscriptionCheckerTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Mercure;
+
+use App\Mercure\MercureSubscriptionChecker;
+use App\Mercure\MercureTokenIssuer;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+
+final class MercureSubscriptionCheckerTest extends TestCase
+{
+    private const string TRIP_ID = '0192a1b2-c3d4-7e5f-8a9b-0c1d2e3f4a5b';
+
+    private const string MERCURE_URL = 'http://php/.well-known/mercure';
+
+    #[Test]
+    public function reportsAnActiveSubscriberAndQueriesTheTopicEndpointWithABearer(): void
+    {
+        $captured = null;
+        $client = new MockHttpClient(function (string $method, string $url, array $options) use (&$captured): MockResponse {
+            $captured = ['method' => $method, 'url' => $url, 'options' => $options];
+
+            return new MockResponse((string) json_encode(['subscriptions' => [['active' => false], ['active' => true]]]));
+        });
+
+        self::assertTrue($this->checker($client)->hasActiveSubscriber(self::TRIP_ID));
+
+        self::assertNotNull($captured);
+        self::assertSame('GET', $captured['method']);
+        self::assertSame(
+            self::MERCURE_URL.'/subscriptions/'.rawurlencode('/trips/'.self::TRIP_ID),
+            $captured['url'],
+        );
+        $authHeaders = array_filter(
+            $captured['options']['headers'],
+            static fn (string $header): bool => str_starts_with($header, 'Authorization: Bearer '),
+        );
+        self::assertCount(1, $authHeaders, 'the subscription request must carry a bearer JWT');
+    }
+
+    #[Test]
+    public function reportsNoSubscriberWhenTheListIsEmpty(): void
+    {
+        $client = new MockHttpClient(new MockResponse((string) json_encode(['subscriptions' => []])));
+
+        self::assertFalse($this->checker($client)->hasActiveSubscriber(self::TRIP_ID));
+    }
+
+    #[Test]
+    public function failsOpenOnAHubError(): void
+    {
+        $client = new MockHttpClient(new MockResponse('nope', ['http_code' => 503]));
+
+        self::assertFalse($this->checker($client)->hasActiveSubscriber(self::TRIP_ID));
+    }
+
+    #[Test]
+    public function failsOpenOnATransportError(): void
+    {
+        $client = new MockHttpClient(static function (): MockResponse {
+            throw new class () extends \RuntimeException implements TransportExceptionInterface {};
+        });
+
+        self::assertFalse($this->checker($client)->hasActiveSubscriber(self::TRIP_ID));
+    }
+
+    private function checker(MockHttpClient $client): MercureSubscriptionChecker
+    {
+        return new MercureSubscriptionChecker($client, $this->tokenIssuer(), self::MERCURE_URL, new NullLogger());
+    }
+
+    private function tokenIssuer(): MercureTokenIssuer
+    {
+        return new MercureTokenIssuer('a-test-mercure-secret-that-is-long-enough');
+    }
+}

--- a/api/tests/Unit/Mercure/MercureTokenIssuerTest.php
+++ b/api/tests/Unit/Mercure/MercureTokenIssuerTest.php
@@ -50,6 +50,39 @@ final class MercureTokenIssuerTest extends TestCase
     }
 
     #[Test]
+    public function generateSubscriptionsTokenScopesSubscribeToSubscriptionsApiAndTripTopic(): void
+    {
+        $token = $this->issuer->generateSubscriptionsToken('trip-uuid-1234');
+
+        $parts = explode('.', $token);
+        self::assertCount(3, $parts);
+
+        $payload = json_decode(base64_decode(strtr($parts[1], '-_', '+/')), true);
+        self::assertIsArray($payload);
+        self::assertArrayHasKey('mercure', $payload);
+        self::assertSame([
+            '/.well-known/mercure/subscriptions{/topic}{/subscriber}',
+            '/trips/trip-uuid-1234',
+        ], $payload['mercure']['subscribe']);
+    }
+
+    #[Test]
+    public function generateSubscriptionsTokenExpiresInAboutSixtySeconds(): void
+    {
+        $before = time();
+        $token = $this->issuer->generateSubscriptionsToken('trip-uuid-1234');
+        $after = time();
+
+        $parts = explode('.', $token);
+        $payload = json_decode(base64_decode(strtr($parts[1], '-_', '+/')), true);
+
+        self::assertIsArray($payload);
+        self::assertArrayHasKey('exp', $payload);
+        self::assertGreaterThanOrEqual($before + 60, (int) $payload['exp']);
+        self::assertLessThanOrEqual($after + 61, (int) $payload['exp']);
+    }
+
+    #[Test]
     public function createSubscriberCookieReturnsHttpOnlyCookie(): void
     {
         $token = $this->issuer->generateSubscriberToken('trip-uuid-1234');

--- a/api/tests/Unit/MessageHandler/AllEnrichmentsCompletedHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/AllEnrichmentsCompletedHandlerTest.php
@@ -8,8 +8,11 @@ use App\ApiResource\Model\Coordinate;
 use App\ApiResource\Stage;
 use App\ComputationTracker\ComputationTrackerInterface;
 use App\Mercure\TripUpdatePublisherInterface;
+use App\Mercure\MercureSubscriptionCheckerInterface;
 use App\Message\AllEnrichmentsCompleted;
 use App\MessageHandler\AllEnrichmentsCompletedHandler;
+use App\Notification\AnalysisNotifier;
+use App\Notification\NotificationDispatcherInterface;
 use App\Repository\TripRequestRepositoryInterface;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -57,6 +60,7 @@ final class AllEnrichmentsCompletedHandlerTest extends TestCase
             $tracker,
             $publisher,
             $tripStateManager,
+            $this->noopAnalysisNotifier(),
             new NullLogger(),
         );
 
@@ -80,6 +84,7 @@ final class AllEnrichmentsCompletedHandlerTest extends TestCase
             $tracker,
             $publisher,
             $tripStateManager,
+            $this->noopAnalysisNotifier(),
             new NullLogger(),
         );
 
@@ -111,9 +116,26 @@ final class AllEnrichmentsCompletedHandlerTest extends TestCase
             $tracker,
             $publisher,
             $tripStateManager,
+            $this->noopAnalysisNotifier(),
             new NullLogger(),
         );
 
         $handler(new AllEnrichmentsCompleted($tripId));
+    }
+
+    /**
+     * A no-op notifier (anonymous trip => nothing pushed); the analysis-push path
+     * is covered on its own in {@see \App\Tests\Unit\Notification\AnalysisNotifierTest}.
+     */
+    private function noopAnalysisNotifier(): AnalysisNotifier
+    {
+        $tripRepository = $this->createStub(TripRequestRepositoryInterface::class);
+        $tripRepository->method('getOwnerId')->willReturn(null);
+
+        return new AnalysisNotifier(
+            $tripRepository,
+            $this->createStub(MercureSubscriptionCheckerInterface::class),
+            $this->createStub(NotificationDispatcherInterface::class),
+        );
     }
 }

--- a/api/tests/Unit/MessageHandler/AllEnrichmentsCompletedHandlerTest.php
+++ b/api/tests/Unit/MessageHandler/AllEnrichmentsCompletedHandlerTest.php
@@ -17,6 +17,7 @@ use App\Repository\TripRequestRepositoryInterface;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * Validates the gate's terminal handler: once every enrichment settles it
@@ -136,6 +137,7 @@ final class AllEnrichmentsCompletedHandlerTest extends TestCase
             $tripRepository,
             $this->createStub(MercureSubscriptionCheckerInterface::class),
             $this->createStub(NotificationDispatcherInterface::class),
+            $this->createStub(TranslatorInterface::class),
         );
     }
 }

--- a/api/tests/Unit/Notification/AnalysisNotifierTest.php
+++ b/api/tests/Unit/Notification/AnalysisNotifierTest.php
@@ -14,6 +14,8 @@ use PHPUnit\Framework\TestCase;
 
 final class AnalysisNotifierTest extends TestCase
 {
+    use NotificationTranslatorTrait;
+
     private const string TRIP_ID = '0192a1b2-c3d4-7e5f-8a9b-0c1d2e3f4a5b';
 
     private const string OWNER_ID = '0192a1b2-c3d4-7e5f-8a9b-000000000001';
@@ -24,9 +26,10 @@ final class AnalysisNotifierTest extends TestCase
         // Guard under test: an active SSE subscriber means the rider already got
         // TRIP_READY, so no push. Removing the guard makes this assertion fail.
         $notifier = new AnalysisNotifier(
-            $this->tripRepository(self::OWNER_ID),
+            $this->tripRepository(self::OWNER_ID, 'fr'),
             $this->subscriptionChecker(true),
             $dispatcher = $this->createMock(NotificationDispatcherInterface::class),
+            $this->notificationTranslator(),
         );
 
         $dispatcher->expects($this->never())->method('dispatch');
@@ -38,9 +41,10 @@ final class AnalysisNotifierTest extends TestCase
     public function pushesTheDoneNotificationWhenNoSubscriberIsWatching(): void
     {
         $notifier = new AnalysisNotifier(
-            $this->tripRepository(self::OWNER_ID),
+            $this->tripRepository(self::OWNER_ID, 'fr'),
             $this->subscriptionChecker(false),
             $dispatcher = $this->createMock(NotificationDispatcherInterface::class),
+            $this->notificationTranslator(),
         );
 
         $dispatcher->expects($this->once())
@@ -58,12 +62,33 @@ final class AnalysisNotifierTest extends TestCase
     }
 
     #[Test]
+    public function localisesTheCopyToTheTripLocale(): void
+    {
+        // Proves the trip locale is resolved and routed to the translator: an
+        // English trip must get English copy, not the default French.
+        $notifier = new AnalysisNotifier(
+            $this->tripRepository(self::OWNER_ID, 'en'),
+            $this->subscriptionChecker(false),
+            $dispatcher = $this->createMock(NotificationDispatcherInterface::class),
+            $this->notificationTranslator(),
+        );
+
+        $dispatcher->expects($this->once())
+            ->method('dispatch')
+            ->with(self::OWNER_ID, NotificationCategory::ANALYSIS_DONE, 'Analysis complete', $this->stringContains('ready'), $this->anything())
+            ->willReturn(true);
+
+        $notifier->notify(self::TRIP_ID, ['weather' => 'done']);
+    }
+
+    #[Test]
     public function pushesTheIncompleteVariantWhenAComputationFailed(): void
     {
         $notifier = new AnalysisNotifier(
-            $this->tripRepository(self::OWNER_ID),
+            $this->tripRepository(self::OWNER_ID, 'fr'),
             $this->subscriptionChecker(false),
             $dispatcher = $this->createMock(NotificationDispatcherInterface::class),
+            $this->notificationTranslator(),
         );
 
         $dispatcher->expects($this->once())
@@ -81,9 +106,10 @@ final class AnalysisNotifierTest extends TestCase
         $checker->expects($this->never())->method('hasActiveSubscriber');
 
         $notifier = new AnalysisNotifier(
-            $this->tripRepository(null),
+            $this->tripRepository(null, 'fr'),
             $checker,
             $dispatcher = $this->createMock(NotificationDispatcherInterface::class),
+            $this->notificationTranslator(),
         );
 
         $dispatcher->expects($this->never())->method('dispatch');
@@ -91,10 +117,11 @@ final class AnalysisNotifierTest extends TestCase
         $notifier->notify(self::TRIP_ID, ['weather' => 'done']);
     }
 
-    private function tripRepository(?string $ownerId): TripRequestRepositoryInterface
+    private function tripRepository(?string $ownerId, string $locale): TripRequestRepositoryInterface
     {
         $repository = $this->createStub(TripRequestRepositoryInterface::class);
         $repository->method('getOwnerId')->willReturn($ownerId);
+        $repository->method('getLocale')->willReturn($locale);
 
         return $repository;
     }

--- a/api/tests/Unit/Notification/AnalysisNotifierTest.php
+++ b/api/tests/Unit/Notification/AnalysisNotifierTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Notification;
+
+use App\Enum\NotificationCategory;
+use App\Mercure\MercureSubscriptionCheckerInterface;
+use App\Notification\AnalysisNotifier;
+use App\Notification\NotificationDispatcherInterface;
+use App\Repository\TripRequestRepositoryInterface;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class AnalysisNotifierTest extends TestCase
+{
+    private const string TRIP_ID = '0192a1b2-c3d4-7e5f-8a9b-0c1d2e3f4a5b';
+
+    private const string OWNER_ID = '0192a1b2-c3d4-7e5f-8a9b-000000000001';
+
+    #[Test]
+    public function doesNotPushWhenAnSseSubscriberIsWatchingTheTrip(): void
+    {
+        // Guard under test: an active SSE subscriber means the rider already got
+        // TRIP_READY, so no push. Removing the guard makes this assertion fail.
+        $notifier = new AnalysisNotifier(
+            $this->tripRepository(self::OWNER_ID),
+            $this->subscriptionChecker(true),
+            $dispatcher = $this->createMock(NotificationDispatcherInterface::class),
+        );
+
+        $dispatcher->expects($this->never())->method('dispatch');
+
+        $notifier->notify(self::TRIP_ID, ['weather' => 'done']);
+    }
+
+    #[Test]
+    public function pushesTheDoneNotificationWhenNoSubscriberIsWatching(): void
+    {
+        $notifier = new AnalysisNotifier(
+            $this->tripRepository(self::OWNER_ID),
+            $this->subscriptionChecker(false),
+            $dispatcher = $this->createMock(NotificationDispatcherInterface::class),
+        );
+
+        $dispatcher->expects($this->once())
+            ->method('dispatch')
+            ->with(
+                self::OWNER_ID,
+                NotificationCategory::ANALYSIS_DONE,
+                'Analyse terminée',
+                $this->stringContains('prêt'),
+                ['tripId' => self::TRIP_ID],
+            )
+            ->willReturn(true);
+
+        $notifier->notify(self::TRIP_ID, ['weather' => 'done', 'terrain' => 'done']);
+    }
+
+    #[Test]
+    public function pushesTheIncompleteVariantWhenAComputationFailed(): void
+    {
+        $notifier = new AnalysisNotifier(
+            $this->tripRepository(self::OWNER_ID),
+            $this->subscriptionChecker(false),
+            $dispatcher = $this->createMock(NotificationDispatcherInterface::class),
+        );
+
+        $dispatcher->expects($this->once())
+            ->method('dispatch')
+            ->with(self::OWNER_ID, NotificationCategory::ANALYSIS_DONE, 'Analyse incomplète', $this->anything(), $this->anything())
+            ->willReturn(true);
+
+        $notifier->notify(self::TRIP_ID, ['weather' => 'done', 'terrain' => 'failed']);
+    }
+
+    #[Test]
+    public function doesNothingForAnAnonymousTrip(): void
+    {
+        $checker = $this->createMock(MercureSubscriptionCheckerInterface::class);
+        $checker->expects($this->never())->method('hasActiveSubscriber');
+
+        $notifier = new AnalysisNotifier(
+            $this->tripRepository(null),
+            $checker,
+            $dispatcher = $this->createMock(NotificationDispatcherInterface::class),
+        );
+
+        $dispatcher->expects($this->never())->method('dispatch');
+
+        $notifier->notify(self::TRIP_ID, ['weather' => 'done']);
+    }
+
+    private function tripRepository(?string $ownerId): TripRequestRepositoryInterface
+    {
+        $repository = $this->createStub(TripRequestRepositoryInterface::class);
+        $repository->method('getOwnerId')->willReturn($ownerId);
+
+        return $repository;
+    }
+
+    private function subscriptionChecker(bool $hasSubscriber): MercureSubscriptionCheckerInterface
+    {
+        $checker = $this->createStub(MercureSubscriptionCheckerInterface::class);
+        $checker->method('hasActiveSubscriber')->willReturn($hasSubscriber);
+
+        return $checker;
+    }
+}

--- a/api/tests/Unit/Notification/NotificationDispatcherTest.php
+++ b/api/tests/Unit/Notification/NotificationDispatcherTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Notification;
+
+use App\Enum\NotificationCategory;
+use App\Message\SendPushNotification;
+use App\Notification\NotificationDispatcher;
+use App\Repository\NotificationPreferenceRepositoryInterface;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final class NotificationDispatcherTest extends TestCase
+{
+    private const string USER_ID = '0192a1b2-c3d4-7e5f-8a9b-000000000001';
+
+    #[Test]
+    public function dispatchesAPushWhenTheCategoryIsEnabled(): void
+    {
+        $preferences = $this->createStub(NotificationPreferenceRepositoryInterface::class);
+        $preferences->method('isEnabled')->willReturn(true);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->once())
+            ->method('dispatch')
+            ->with($this->callback(function (SendPushNotification $message): bool {
+                self::assertSame(self::USER_ID, $message->userId);
+                self::assertSame('analysisDone', $message->category);
+                self::assertSame('Titre', $message->title);
+                self::assertSame(['tripId' => 'abc'], $message->data);
+
+                return true;
+            }))
+            ->willReturnCallback(static fn (SendPushNotification $message): Envelope => new Envelope($message));
+
+        $dispatcher = new NotificationDispatcher($bus, $preferences);
+        $sent = $dispatcher->dispatch(self::USER_ID, NotificationCategory::ANALYSIS_DONE, 'Titre', 'Corps', ['tripId' => 'abc']);
+
+        self::assertTrue($sent);
+    }
+
+    #[Test]
+    public function doesNotDispatchWhenTheCategoryIsDisabled(): void
+    {
+        $preferences = $this->createStub(NotificationPreferenceRepositoryInterface::class);
+        $preferences->method('isEnabled')->willReturn(false);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->never())->method('dispatch');
+
+        $dispatcher = new NotificationDispatcher($bus, $preferences);
+        $sent = $dispatcher->dispatch(self::USER_ID, NotificationCategory::ZONE_OPENING, 'Titre', 'Corps');
+
+        self::assertFalse($sent);
+    }
+}

--- a/api/tests/Unit/Notification/NotificationTranslatorTrait.php
+++ b/api/tests/Unit/Notification/NotificationTranslatorTrait.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Notification;
+
+use Symfony\Component\Translation\Loader\YamlFileLoader;
+use Symfony\Component\Translation\Translator;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * Builds a translator backed by the real `notifications` catalogues so the notifier
+ * unit tests assert the actual localised copy (and catch a wrong/missing locale).
+ */
+trait NotificationTranslatorTrait
+{
+    private function notificationTranslator(): TranslatorInterface
+    {
+        $dir = \dirname(__DIR__, 3).'/translations';
+
+        $translator = new Translator('en');
+        $translator->addLoader('yaml', new YamlFileLoader());
+        $translator->addResource('yaml', $dir.'/notifications.en.yaml', 'en', 'notifications');
+        $translator->addResource('yaml', $dir.'/notifications.fr.yaml', 'fr', 'notifications');
+
+        return $translator;
+    }
+}

--- a/api/tests/Unit/Notification/WeatherSafetyNotifierTest.php
+++ b/api/tests/Unit/Notification/WeatherSafetyNotifierTest.php
@@ -17,11 +17,13 @@ use Symfony\Component\Uid\Uuid;
 
 final class WeatherSafetyNotifierTest extends TestCase
 {
+    use NotificationTranslatorTrait;
+
     #[Test]
     public function pushesTheRiddenStageForTheTargetDay(): void
     {
         $day = new \DateTimeImmutable('2026-08-20', new \DateTimeZone('UTC'));
-        $trip = $this->trip(new \DateTimeImmutable('2026-08-18', new \DateTimeZone('UTC')));
+        $trip = $this->trip(new \DateTimeImmutable('2026-08-18', new \DateTimeZone('UTC')), 'fr');
         $ownerId = $trip->user?->getId()->toRfc4122();
         $tripId = $trip->id?->toRfc4122();
 
@@ -35,36 +37,61 @@ final class WeatherSafetyNotifierTest extends TestCase
                 $ownerId,
                 NotificationCategory::WEATHER_SAFETY,
                 $this->stringContains('Étape J3'),
-                $this->stringContains('1 alerte'),
+                $this->stringContains('1 alerte de sécurité'),
                 ['tripId' => $tripId, 'dayNumber' => '3'],
             )
             ->willReturn(true);
 
-        $count = new WeatherSafetyNotifier($this->finder([$trip]), $dispatcher)->notify($day);
+        $count = new WeatherSafetyNotifier($this->finder([$trip]), $dispatcher, $this->notificationTranslator())->notify($day);
 
         self::assertSame(1, $count);
+    }
+
+    #[Test]
+    public function localisesTheCopyToTheTripLocale(): void
+    {
+        // Proves the trip locale reaches the translator: an English trip must get
+        // English copy ("Day 3 — ...", "2 safety alerts"), not the default French.
+        $day = new \DateTimeImmutable('2026-08-20', new \DateTimeZone('UTC'));
+        $trip = $this->trip(new \DateTimeImmutable('2026-08-18', new \DateTimeZone('UTC')), 'en');
+        $trip->addStage($this->stage($trip, dayNumber: 3, restDay: false, weather: ['description' => 'Sunny', 'tempMin' => 12.0, 'tempMax' => 24.0], alerts: [['code' => 'a'], ['code' => 'b']]));
+
+        $dispatcher = $this->createMock(NotificationDispatcherInterface::class);
+        $dispatcher->expects($this->once())
+            ->method('dispatch')
+            ->with(
+                $this->anything(),
+                NotificationCategory::WEATHER_SAFETY,
+                $this->stringContains('Day 3'),
+                $this->stringContains('2 safety alerts'),
+                $this->anything(),
+            )
+            ->willReturn(true);
+
+        new WeatherSafetyNotifier($this->finder([$trip]), $dispatcher, $this->notificationTranslator())->notify($day);
     }
 
     #[Test]
     public function skipsATripWhoseTargetDayIsARestDay(): void
     {
         $day = new \DateTimeImmutable('2026-08-20', new \DateTimeZone('UTC'));
-        $trip = $this->trip(new \DateTimeImmutable('2026-08-18', new \DateTimeZone('UTC')));
+        $trip = $this->trip(new \DateTimeImmutable('2026-08-18', new \DateTimeZone('UTC')), 'fr');
         $trip->addStage($this->stage($trip, dayNumber: 3, restDay: true, weather: null, alerts: []));
 
         $dispatcher = $this->createMock(NotificationDispatcherInterface::class);
         $dispatcher->expects($this->never())->method('dispatch');
 
-        $count = new WeatherSafetyNotifier($this->finder([$trip]), $dispatcher)->notify($day);
+        $count = new WeatherSafetyNotifier($this->finder([$trip]), $dispatcher, $this->notificationTranslator())->notify($day);
 
         self::assertSame(0, $count);
     }
 
-    private function trip(\DateTimeImmutable $startDate): TripRequest
+    private function trip(\DateTimeImmutable $startDate, string $locale): TripRequest
     {
         $trip = new TripRequest(Uuid::v7());
         $trip->user = new User('rider@example.com');
         $trip->startDate = $startDate;
+        $trip->locale = $locale;
 
         return $trip;
     }

--- a/api/tests/Unit/Notification/WeatherSafetyNotifierTest.php
+++ b/api/tests/Unit/Notification/WeatherSafetyNotifierTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Notification;
+
+use App\ApiResource\TripRequest;
+use App\Entity\Stage;
+use App\Entity\User;
+use App\Enum\NotificationCategory;
+use App\Notification\NotificationDispatcherInterface;
+use App\Notification\WeatherSafetyNotifier;
+use App\Repository\OwnedTripFinderInterface;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+final class WeatherSafetyNotifierTest extends TestCase
+{
+    #[Test]
+    public function pushesTheRiddenStageForTheTargetDay(): void
+    {
+        $day = new \DateTimeImmutable('2026-08-20', new \DateTimeZone('UTC'));
+        $trip = $this->trip(new \DateTimeImmutable('2026-08-18', new \DateTimeZone('UTC')));
+        $ownerId = $trip->user?->getId()->toRfc4122();
+        $tripId = $trip->id?->toRfc4122();
+
+        // Day 3 = 2026-08-20 (start 08-18 + 2). One weather + one alert.
+        $trip->addStage($this->stage($trip, dayNumber: 3, restDay: false, weather: ['description' => 'Ensoleillé', 'tempMin' => 12.0, 'tempMax' => 24.0], alerts: [['code' => 'wind_headwind']]));
+
+        $dispatcher = $this->createMock(NotificationDispatcherInterface::class);
+        $dispatcher->expects($this->once())
+            ->method('dispatch')
+            ->with(
+                $ownerId,
+                NotificationCategory::WEATHER_SAFETY,
+                $this->stringContains('Étape J3'),
+                $this->stringContains('1 alerte'),
+                ['tripId' => $tripId, 'dayNumber' => '3'],
+            )
+            ->willReturn(true);
+
+        $count = new WeatherSafetyNotifier($this->finder([$trip]), $dispatcher)->notify($day);
+
+        self::assertSame(1, $count);
+    }
+
+    #[Test]
+    public function skipsATripWhoseTargetDayIsARestDay(): void
+    {
+        $day = new \DateTimeImmutable('2026-08-20', new \DateTimeZone('UTC'));
+        $trip = $this->trip(new \DateTimeImmutable('2026-08-18', new \DateTimeZone('UTC')));
+        $trip->addStage($this->stage($trip, dayNumber: 3, restDay: true, weather: null, alerts: []));
+
+        $dispatcher = $this->createMock(NotificationDispatcherInterface::class);
+        $dispatcher->expects($this->never())->method('dispatch');
+
+        $count = new WeatherSafetyNotifier($this->finder([$trip]), $dispatcher)->notify($day);
+
+        self::assertSame(0, $count);
+    }
+
+    private function trip(\DateTimeImmutable $startDate): TripRequest
+    {
+        $trip = new TripRequest(Uuid::v7());
+        $trip->user = new User('rider@example.com');
+        $trip->startDate = $startDate;
+
+        return $trip;
+    }
+
+    /**
+     * @param array<string, mixed>|null  $weather
+     * @param list<array<string, mixed>> $alerts
+     */
+    private function stage(TripRequest $trip, int $dayNumber, bool $restDay, ?array $weather, array $alerts): Stage
+    {
+        $stage = new Stage($trip);
+        $stage->setDayNumber($dayNumber)->setIsRestDay($restDay)->setWeather($weather)->setAlerts($alerts);
+
+        return $stage;
+    }
+
+    /**
+     * @param list<TripRequest> $trips
+     */
+    private function finder(array $trips): OwnedTripFinderInterface
+    {
+        $finder = $this->createStub(OwnedTripFinderInterface::class);
+        $finder->method('findOwnedTripsCoveringDate')->willReturn($trips);
+
+        return $finder;
+    }
+}

--- a/api/tests/Unit/Notification/ZoneOpeningNotifierTest.php
+++ b/api/tests/Unit/Notification/ZoneOpeningNotifierTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Notification;
+
+use App\Enum\NotificationCategory;
+use App\Notification\NotificationDispatcherInterface;
+use App\Notification\ZoneOpeningNotifier;
+use App\Repository\NotificationPreferenceRepositoryInterface;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class ZoneOpeningNotifierTest extends TestCase
+{
+    #[Test]
+    public function pushesOnlyToUsersWhoOptedIntoZoneOpening(): void
+    {
+        $preferences = $this->createMock(NotificationPreferenceRepositoryInterface::class);
+        $preferences->expects($this->once())
+            ->method('findUserIdsEnabled')
+            ->with(NotificationCategory::ZONE_OPENING)
+            ->willReturn(['user-a', 'user-b']);
+
+        $dispatcher = $this->createMock(NotificationDispatcherInterface::class);
+        $dispatcher->expects($this->exactly(2))
+            ->method('dispatch')
+            ->with(
+                $this->logicalOr('user-a', 'user-b'),
+                NotificationCategory::ZONE_OPENING,
+                'Nouvelle zone disponible',
+                $this->stringContains('Corse'),
+                ['zoneSlug' => 'corse'],
+            )
+            ->willReturn(true);
+
+        $count = new ZoneOpeningNotifier($preferences, $dispatcher)->notify('corse', 'Corse');
+
+        self::assertSame(2, $count);
+    }
+
+    #[Test]
+    public function pushesToNobodyWhenNoUserOptedIn(): void
+    {
+        $preferences = $this->createStub(NotificationPreferenceRepositoryInterface::class);
+        $preferences->method('findUserIdsEnabled')->willReturn([]);
+
+        $dispatcher = $this->createMock(NotificationDispatcherInterface::class);
+        $dispatcher->expects($this->never())->method('dispatch');
+
+        $count = new ZoneOpeningNotifier($preferences, $dispatcher)->notify('corse', 'Corse');
+
+        self::assertSame(0, $count);
+    }
+}

--- a/api/tests/Unit/Notification/ZoneOpeningNotifierTest.php
+++ b/api/tests/Unit/Notification/ZoneOpeningNotifierTest.php
@@ -13,42 +13,49 @@ use PHPUnit\Framework\TestCase;
 
 final class ZoneOpeningNotifierTest extends TestCase
 {
+    use NotificationTranslatorTrait;
+
     #[Test]
-    public function pushesOnlyToUsersWhoOptedIntoZoneOpening(): void
+    public function pushesOnlyToOptedInUsersEachInTheirOwnLocale(): void
     {
         $preferences = $this->createMock(NotificationPreferenceRepositoryInterface::class);
         $preferences->expects($this->once())
-            ->method('findUserIdsEnabled')
+            ->method('findEnabledUsers')
             ->with(NotificationCategory::ZONE_OPENING)
-            ->willReturn(['user-a', 'user-b']);
+            ->willReturn([
+                ['id' => 'user-fr', 'locale' => 'fr'],
+                ['id' => 'user-en', 'locale' => 'en'],
+            ]);
 
+        $calls = [];
         $dispatcher = $this->createMock(NotificationDispatcherInterface::class);
         $dispatcher->expects($this->exactly(2))
             ->method('dispatch')
-            ->with(
-                $this->logicalOr('user-a', 'user-b'),
-                NotificationCategory::ZONE_OPENING,
-                'Nouvelle zone disponible',
-                $this->stringContains('Corse'),
-                ['zoneSlug' => 'corse'],
-            )
-            ->willReturn(true);
+            ->willReturnCallback(function (string $userId, NotificationCategory $category, string $title, string $body) use (&$calls): bool {
+                $calls[$userId] = ['title' => $title, 'body' => $body];
 
-        $count = new ZoneOpeningNotifier($preferences, $dispatcher)->notify('corse', 'Corse');
+                return true;
+            });
+
+        $count = new ZoneOpeningNotifier($preferences, $dispatcher, $this->notificationTranslator())->notify('corse', 'Corse');
 
         self::assertSame(2, $count);
+        self::assertSame('Nouvelle zone disponible', $calls['user-fr']['title']);
+        self::assertStringContainsString('La zone Corse est maintenant couverte', $calls['user-fr']['body']);
+        self::assertSame('New zone available', $calls['user-en']['title']);
+        self::assertStringContainsString('The Corse zone is now covered', $calls['user-en']['body']);
     }
 
     #[Test]
     public function pushesToNobodyWhenNoUserOptedIn(): void
     {
         $preferences = $this->createStub(NotificationPreferenceRepositoryInterface::class);
-        $preferences->method('findUserIdsEnabled')->willReturn([]);
+        $preferences->method('findEnabledUsers')->willReturn([]);
 
         $dispatcher = $this->createMock(NotificationDispatcherInterface::class);
         $dispatcher->expects($this->never())->method('dispatch');
 
-        $count = new ZoneOpeningNotifier($preferences, $dispatcher)->notify('corse', 'Corse');
+        $count = new ZoneOpeningNotifier($preferences, $dispatcher, $this->notificationTranslator())->notify('corse', 'Corse');
 
         self::assertSame(0, $count);
     }

--- a/api/tests/Unit/State/NotificationPreferenceUpdateProcessorTest.php
+++ b/api/tests/Unit/State/NotificationPreferenceUpdateProcessorTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\State;
+
+use ApiPlatform\Metadata\Put;
+use App\ApiResource\Account\NotificationPreference as NotificationPreferenceResource;
+use App\Entity\User;
+use App\Enum\NotificationCategory;
+use App\Repository\NotificationPreferenceRepositoryInterface;
+use App\State\Account\NotificationPreferenceUpdateProcessor;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
+
+#[AllowMockObjectsWithoutExpectations]
+final class NotificationPreferenceUpdateProcessorTest extends TestCase
+{
+    private MockObject&Security $security;
+
+    private MockObject&NotificationPreferenceRepositoryInterface $preferences;
+
+    private NotificationPreferenceUpdateProcessor $processor;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->security = $this->createMock(Security::class);
+        $this->preferences = $this->createMock(NotificationPreferenceRepositoryInterface::class);
+
+        $this->processor = new NotificationPreferenceUpdateProcessor($this->security, $this->preferences);
+    }
+
+    #[Test]
+    public function itThrows409OnConcurrentInsertRaceCondition(): void
+    {
+        $this->security->method('getUser')->willReturn(new User('race@example.com'));
+
+        // No preference yet: the processor takes the create path.
+        $this->preferences->expects($this->once())->method('findOne')->willReturn(null);
+
+        // A concurrent PUT for the same (user, category) inserted first: the flush
+        // inside save() hits the unique constraint. The processor must translate it
+        // to a 409, not let a 500 leak (same guard as DeviceTokenRegisterProcessor).
+        $uniqueException = $this->getMockBuilder(UniqueConstraintViolationException::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->preferences->expects($this->once())->method('save')->willThrowException($uniqueException);
+
+        $this->expectException(ConflictHttpException::class);
+        $this->processor->process(
+            new NotificationPreferenceResource(NotificationCategory::WEATHER_SAFETY, true),
+            new Put(),
+            ['category' => 'weatherSafety'],
+        );
+    }
+}

--- a/api/translations/notifications.en.yaml
+++ b/api/translations/notifications.en.yaml
@@ -1,0 +1,19 @@
+notification:
+  analysis:
+    done:
+      title: "Analysis complete"
+      body: "Your trip is ready. Open the app to explore the stages and alerts."
+    failed:
+      title: "Analysis incomplete"
+      body: "Some stages of your trip could not be analysed. Open the app to check."
+  weather_safety:
+    title: "Day %day% — %headline%"
+    headline:
+      pending: "forecast pending"
+      forecast: "%description%, %min%–%max% °C"
+    body:
+      none: "No safety alerts for this stage. Enjoy the ride!"
+      some: "{1}%count% safety alert on this stage. Open the app for details.|]1,Inf[%count% safety alerts on this stage. Open the app for details."
+  zone_opening:
+    title: "New zone available"
+    body: "The %zone% zone is now covered. Plan your next trip there!"

--- a/api/translations/notifications.fr.yaml
+++ b/api/translations/notifications.fr.yaml
@@ -1,0 +1,19 @@
+notification:
+  analysis:
+    done:
+      title: "Analyse terminée"
+      body: "Votre voyage est prêt. Ouvrez l'app pour découvrir les étapes et les alertes."
+    failed:
+      title: "Analyse incomplète"
+      body: "Certaines étapes de votre voyage n'ont pas pu être analysées. Ouvrez l'app pour vérifier."
+  weather_safety:
+    title: "Étape J%day% — %headline%"
+    headline:
+      pending: "météo à venir"
+      forecast: "%description%, %min%–%max% °C"
+    body:
+      none: "Aucune alerte de sécurité signalée pour cette étape. Bonne route !"
+      some: "{1}%count% alerte de sécurité sur cette étape. Ouvrez l'app pour les détails.|]1,Inf[%count% alertes de sécurité sur cette étape. Ouvrez l'app pour les détails."
+  zone_opening:
+    title: "Nouvelle zone disponible"
+    body: "La zone %zone% est maintenant couverte. Planifiez-y votre prochain voyage !"

--- a/core/schema.d.ts
+++ b/core/schema.d.ts
@@ -288,6 +288,46 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/users/me/notification-preferences": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Retrieves the collection of NotificationPreference resources.
+         * @description Retrieves the collection of NotificationPreference resources.
+         */
+        get: operations["api_usersmenotification-preferences_get_collection"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/users/me/notification-preferences/{category}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * Replaces the NotificationPreference resource.
+         * @description Replaces the NotificationPreference resource.
+         */
+        put: operations["api_usersmenotification-preferences_category_put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/trips/{tripId}/stages": {
         parameters: {
             query?: never;
@@ -1272,6 +1312,38 @@ export interface components {
          */
         "MercureToken.jsonld": components["schemas"]["HydraItemBaseSchema"] & {
             token?: string;
+        };
+        /**
+         * @description Per-category server-push opt-in for the authenticated user (#1124).
+         *
+         *     - GET /users/me/notification-preferences         the effective opt-in for every
+         *       category (stored override, or the category default when unset).
+         *     - PUT /users/me/notification-preferences/{category}  set the opt-in for one
+         *       category. Body: {"enabled": true|false}. An unknown category is 404.
+         *
+         *     Defaults: weatherSafety and analysisDone are ON, zoneOpening is OFF (opt-in).
+         *     The current user is always resolved from the security token, never a URL id.
+         */
+        NotificationPreference: {
+            /** @enum {string|null} */
+            category?: "weatherSafety" | "analysisDone" | "zoneOpening" | null;
+            enabled?: boolean;
+        };
+        /**
+         * @description Per-category server-push opt-in for the authenticated user (#1124).
+         *
+         *     - GET /users/me/notification-preferences         the effective opt-in for every
+         *       category (stored override, or the category default when unset).
+         *     - PUT /users/me/notification-preferences/{category}  set the opt-in for one
+         *       category. Body: {"enabled": true|false}. An unknown category is 404.
+         *
+         *     Defaults: weatherSafety and analysisDone are ON, zoneOpening is OFF (opt-in).
+         *     The current user is always resolved from the security token, never a URL id.
+         */
+        "NotificationPreference.jsonld": components["schemas"]["HydraItemBaseSchema"] & {
+            /** @enum {string|null} */
+            category?: "weatherSafety" | "analysisDone" | "zoneOpening" | null;
+            enabled?: boolean;
         };
         "PoiSuggestionDto.jsonld": {
             /** @description Display name of the POI. */
@@ -2915,6 +2987,114 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+        };
+    };
+    "api_usersmenotification-preferences_get_collection": {
+        parameters: {
+            query?: {
+                /** @description The collection page number */
+                page?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description NotificationPreference collection */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["HydraCollectionBaseSchema"] & {
+                        member: components["schemas"]["NotificationPreference.jsonld"][];
+                    };
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["Error.jsonld"];
+                    "application/problem+json": components["schemas"]["Error"];
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    "api_usersmenotification-preferences_category_put": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description NotificationPreference identifier */
+                category: string;
+            };
+            cookie?: never;
+        };
+        /** @description The updated NotificationPreference resource */
+        requestBody: {
+            content: {
+                "application/ld+json": components["schemas"]["NotificationPreference"];
+            };
+        };
+        responses: {
+            /** @description NotificationPreference resource updated */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["NotificationPreference.jsonld"];
+                };
+            };
+            /** @description Invalid input */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["Error.jsonld"];
+                    "application/problem+json": components["schemas"]["Error"];
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["Error.jsonld"];
+                    "application/problem+json": components["schemas"]["Error"];
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["Error.jsonld"];
+                    "application/problem+json": components["schemas"]["Error"];
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description An error occurred */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/ld+json": components["schemas"]["ConstraintViolation.jsonld"];
+                    "application/problem+json": components["schemas"]["ConstraintViolation"];
+                    "application/json": components["schemas"]["ConstraintViolation"];
+                };
             };
         };
     };

--- a/core/schema.d.ts
+++ b/core/schema.d.ts
@@ -1319,7 +1319,8 @@ export interface components {
          *     - GET /users/me/notification-preferences         the effective opt-in for every
          *       category (stored override, or the category default when unset).
          *     - PUT /users/me/notification-preferences/{category}  set the opt-in for one
-         *       category. Body: {"enabled": true|false}. An unknown category is 404.
+         *       category. Body: {"enabled": true|false} — `enabled` is required (a body
+         *       omitting it is 422, never a silent opt-out). An unknown category is 404.
          *
          *     Defaults: weatherSafety and analysisDone are ON, zoneOpening is OFF (opt-in).
          *     The current user is always resolved from the security token, never a URL id.
@@ -1327,7 +1328,7 @@ export interface components {
         NotificationPreference: {
             /** @enum {string|null} */
             category?: "weatherSafety" | "analysisDone" | "zoneOpening" | null;
-            enabled?: boolean;
+            enabled: boolean | null;
         };
         /**
          * @description Per-category server-push opt-in for the authenticated user (#1124).
@@ -1335,7 +1336,8 @@ export interface components {
          *     - GET /users/me/notification-preferences         the effective opt-in for every
          *       category (stored override, or the category default when unset).
          *     - PUT /users/me/notification-preferences/{category}  set the opt-in for one
-         *       category. Body: {"enabled": true|false}. An unknown category is 404.
+         *       category. Body: {"enabled": true|false} — `enabled` is required (a body
+         *       omitting it is 422, never a silent opt-out). An unknown category is 404.
          *
          *     Defaults: weatherSafety and analysisDone are ON, zoneOpening is OFF (opt-in).
          *     The current user is always resolved from the security token, never a URL id.
@@ -1343,7 +1345,7 @@ export interface components {
         "NotificationPreference.jsonld": components["schemas"]["HydraItemBaseSchema"] & {
             /** @enum {string|null} */
             category?: "weatherSafety" | "analysisDone" | "zoneOpening" | null;
-            enabled?: boolean;
+            enabled: boolean | null;
         };
         "PoiSuggestionDto.jsonld": {
             /** @description Display name of the POI. */

--- a/docs/adr/adr-058-push-fcm.md
+++ b/docs/adr/adr-058-push-fcm.md
@@ -67,14 +67,41 @@ with an OAuth2 service-account flow, over host-locked scoped HTTP clients.
 a token held by another account reassigns it. Account erasure cascades the rows;
 FCM-side pruning removes tokens the transport reports dead.
 
-## Categories, opt-in, and permission (planned — #1124)
+## Categories, opt-in, and permission (implemented — #1124)
 
-This ADR lands the transport; notification **categories** and their user-facing
-controls are #1124. The message already carries a `category` field (folded into
-the FCM `data` payload) so the client can route to the right Android channel / iOS
-category, but the catalogue of categories, the per-category opt-in, and the
-**opt-in per opened zone** (a rider subscribes to announcements for the zones they
-ride) are deferred to that issue.
+This ADR lands the transport; #1124 builds the **categories** on top of it. The
+`category` field of `SendPushNotification` (folded into the FCM `data` payload) now
+names one of three server-pushed categories (`App\Enum\NotificationCategory`):
+
+- **`weatherSafety`** — the forecast + safety-alert count for the stage a rider
+  tackles on a given day. Recurring by nature, but there is no Symfony Scheduler in
+  the project, so the trigger is a console command,
+  `app:notifications:weather-safety --day=today|tomorrow`, scheduled by ops twice a
+  day (evening before + morning of). Default **ON**.
+- **`analysisDone`** — pushed when a trip's enrichment pipeline settles, from
+  `AllEnrichmentsCompletedHandler` via `App\Notification\AnalysisNotifier`, **only
+  when no Mercure SSE subscriber is live** on the trip topic (`/trips/{id}`): if the
+  rider is watching, they already receive `TRIP_READY`, so a push would be
+  redundant. Liveness is read from the hub's subscription API
+  (`GET /.well-known/mercure/subscriptions/{topic}`, enabled by the `subscriptions`
+  Caddy directive) through the host-locked `mercure.health.client`; on any hub error
+  the check **fails open** (push proceeds) so a hiccup never swallows the notice.
+  Default **ON**.
+- **`zoneOpening`** — announcement when a new reference zone is opened. **Opt-in,
+  default OFF.** Zone opening lives in the separate provisioner process (only writes
+  `osm.zones`), so ops triggers `app:notifications:zone-opened <slug>`, which targets
+  only the users who explicitly enabled the category.
+
+**Server-side preference storage.** A dedicated `notification_preference` entity
+(one row per `(user, category)`, unique, `ON DELETE CASCADE`) holds overrides; the
+absence of a row means the category default. `NotificationDispatcher` is the single
+opt-in gate every category passes through, and the push handler only ever resolves
+tokens for the targeted user, so a user with the category disabled or no registered
+device is never reached (RGPD). Preferences are read/written by the user at
+`GET /users/me/notification-preferences` and
+`PUT /users/me/notification-preferences/{category}` (frontend controls: #1125).
+The **per-opened-zone** granularity (subscribing to specific zones rather than the
+global `zoneOpening` opt-in) remains deferred.
 
 - **Permission is the device's, not the server's.** The OS prompt (POST_NOTIFICATIONS
   on Android 13+, the iOS authorization prompt) is requested client-side; the


### PR DESCRIPTION
Ferme #1124. Stacké sur #1123 (base `feature/1123`). Épic #1051.

## Résumé
- Entité `NotificationPreference` (user, category, enabled, unique (user,category), cascade delete) + migration. Absence de ligne = défaut catégorie. ApiResource `GET /users/me/notification-preferences` + `PUT .../{category}`.
- `NotificationDispatcher` : gate unique (pref + bus) → émet `SendPushNotification`. RGPD : pref off ou pas de device = jamais poussé.
- **`analysisDone`** : `MercureSubscriptionChecker` (API subscriptions du hub via client host-locké + JWT court) — push SEULEMENT si aucun abonné SSE actif. Fail-open. Branché dans `AllEnrichmentsCompletedHandler` via `AnalysisNotifier`.
- **`weatherSafety`** : commande `app:notifications:weather-safety --day=today|tomorrow` (à cronner soir/matin ; pas de Scheduler dans le projet).
- **`zoneOpening`** : opt-in OFF par défaut, commande `app:notifications:zone-opened <slug>`, cible les users ayant activé la catégorie.

## Vérification
- PHPStan L9 OK ; PHPUnit 1392 + 4 fonctionnels ; markdownlint 0.
- Garde SSE prouvée (neutralisée → `doesNotPushWhenAnSseSubscriberIsWatching` casse) puis restaurée.
- `core/schema.d.ts` régénéré (DTO_CHANGED, additif).

## Auto-critique
- Déclencheurs météo/zone = commandes à cronner côté ops (pas de Scheduler Symfony).
- Détection abonné SSE fail-open (push en trop plutôt que raté).
- La synchro fine des prefs depuis le mobile (#1125) peut désormais consommer `PUT /users/me/notification-preferences/{category}` — follow-up.

<!-- claude-review-start -->
## Claude Review

**Summary:** Independent re-review of the full diff at commit `156ab211b76f537f2eae7acadab09043872a5d84` (current PR HEAD), reading source directly rather than trusting the review section previously embedded in this PR body. Every issue raised across the prior bot review rounds (i18n gaps in the three notifiers, the `stages` N+1 in `findOwnedTripsCoveringDate`, missing command tests, the raw-string uuid bind in `NotificationPreferenceRepository::isEnabled`, the missing upsert race guard in `NotificationPreferenceUpdateProcessor`, the 60-day look-back floor, and the missing "PUT without `enabled`" test) is independently confirmed fixed in the current code, including the last-found issue — the `endDate` bound in `DoctrineTripRequestRepository::findOwnedTripsCoveringDate` now correctly treats a null `endDate` as not-yet-ended (`OwnedTripFinderTest::returnsOnlyOwnedDatedTripsWhoseRangeCoversTheDay` covers the open-ended case). No new blocking issues found in this pass.

**PR title check:** Title (`feat(api): catégories push serveur + garde abonné SSE + prefs`) uses a French noun-phrase description rather than an English imperative per the Git Conventions doc, but this matches the established, already-merged convention for this repo (#1144, #1141, #1132, #1131, #1129, #1127) — not flagged as blocking.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

Commit reviewed: `156ab211b76f537f2eae7acadab09043872a5d84`
<!-- claude-review-end -->