### PR TITLE
fix(mobile): trip kebab menu overlaps its own button

### DIFF
--- a/mobile/app/trip/[id]/index.tsx
+++ b/mobile/app/trip/[id]/index.tsx
@@ -1,6 +1,7 @@
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
 import { type ReactNode, useState } from 'react';
 import { Alert, Modal, Pressable, Text, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import {
   ErrorState,
@@ -81,6 +82,7 @@ export default function TripRoadbook() {
   const { t } = useTranslation();
   const theme = useTheme();
   const router = useRouter();
+  const insets = useSafeAreaInsets();
   const [view, setView] = useState<TripView>('roadbook');
   const [configOpen, setConfigOpen] = useState(false);
   const [shareOpen, setShareOpen] = useState(false);
@@ -162,7 +164,7 @@ export default function TripRoadbook() {
               <Pressable
                 accessibilityRole="button"
                 accessibilityLabel={t('trip.menu.open')}
-                onPress={() => setMenuOpen(true)}
+                onPress={() => setMenuOpen((open) => !open)}
                 hitSlop={8}
                 style={{ padding: theme.spacing.xs }}
               >
@@ -188,7 +190,10 @@ export default function TripRoadbook() {
           <View
             style={{
               position: 'absolute',
-              top: theme.spacing['3xl'],
+              // Sit just below the header (status bar + ~56dp nav bar). A fixed
+              // 48px from the screen top landed on the ⋮ button itself, so the
+              // button was covered and could never toggle the menu shut.
+              top: insets.top + 56,
               right: theme.spacing.base,
               minWidth: 220,
               backgroundColor: theme.colors.popover,


### PR DESCRIPTION
Bug pré-existant trouvé en QA device (Sprint 57).

## Problème
Sur l'écran détail d'un voyage, le menu ⋮ s'ouvrait par-dessus son propre bouton (positionné à 48px du haut de l'écran, pile sur le ⋮ du header) : re-taper le bouton atteignait le menu au lieu de le fermer.

## Fix
- Dropdown ancré **sous le header** (`insets.top + 56` via `useSafeAreaInsets`) au lieu de `top: 48` depuis l'origine écran.
- Bouton ⋮ en **toggle**.

## Vérification
Testé sur device (Android dev build) : menu sous le header, bouton dégagé, re-tap ferme. typecheck mobile vert.

<!-- claude-review-start -->
## Claude Review

**Summary:** Small, well-scoped device-verified fix — anchors the trip kebab dropdown below the header (`insets.top + 56`) instead of a fixed `top: 48` that overlapped the header button, and makes the button a toggle. Diff is unchanged since the last approved pass (same content, no new commits); no correctness, security, performance, or architecture issues found on re-review.

**PR title check:** the title reads as a bug statement ("trip kebab menu overlaps its own button") rather than imperative mood per Conventional Commits (e.g. `fix(mobile): stop trip kebab menu overlapping its own button`).

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [ ] Tests cover new/changed cases (no regression test for the open/toggle/close interaction — pre-existing gap, thread already resolved)
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments. The two suggestions from prior passes (hard-coded `insets.top + 56` header-height offset vs. `useHeaderHeight()`; missing regression test for open/toggle/close) remain unimplemented in code, but both threads are already resolved and non-blocking — not re-flagged.

Reviewed commit: `fdfb4c20e5f79200b8d62d2166cbdef39e8b27d7`
<!-- claude-review-end -->