### PR TITLE
fix(mobile): trip UX pass — list/roadbook/map conformance (04/05/06)

### DIFF
--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -118,7 +118,6 @@ function TripCard({
       accessibilityRole="button"
       onPress={onOpen}
       style={({ pressed }) => ({
-        flexDirection: 'row',
         overflow: 'hidden',
         borderRadius: theme.radius.xl,
         borderWidth: StyleSheet.hairlineWidth,
@@ -129,8 +128,8 @@ function TripCard({
     >
       <View
         style={{
-          width: 116,
-          alignSelf: 'stretch',
+          height: 92,
+          width: '100%',
           backgroundColor: theme.colors.secondary,
         }}
       >
@@ -168,10 +167,10 @@ function TripCard({
         </View>
       </View>
 
-      <View style={{ flex: 1, padding: theme.spacing.md, justifyContent: 'center' }}>
+      <View style={{ padding: theme.spacing.md }}>
         <Text
           numberOfLines={2}
-          style={{ color: theme.colors.foreground, fontFamily: theme.fonts.serif, fontSize: 17 }}
+          style={{ color: theme.colors.foreground, fontFamily: theme.fonts.serif, fontSize: 16 }}
         >
           {title}
         </Text>

--- a/mobile/app/trip/[id]/index.tsx
+++ b/mobile/app/trip/[id]/index.tsx
@@ -1,6 +1,6 @@
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
-import { type ReactNode, useState } from 'react';
-import { Alert, Modal, Pressable, Text, View } from 'react-native';
+import { type ReactNode, useMemo, useState } from 'react';
+import { Alert, Modal, PanResponder, Pressable, Text, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import {
@@ -33,6 +33,7 @@ import { useTripLive } from '../../../src/hooks/use-trip-live';
 import { useTripMutations } from '../../../src/hooks/use-trip-mutations';
 import type { MutationFailure } from '../../../src/store/gating';
 import { useTripStore } from '../../../src/store/trip-store';
+import { swipeToView } from '../../../src/lib/swipe';
 
 type TripView = 'roadbook' | 'map';
 
@@ -85,8 +86,30 @@ export default function TripRoadbook() {
   const insets = useSafeAreaInsets();
   const [view, setView] = useState<TripView>('roadbook');
   const [configOpen, setConfigOpen] = useState(false);
+  const [configSection, setConfigSection] = useState<'dates' | undefined>(undefined);
   const [shareOpen, setShareOpen] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
+
+  // Horizontal swipe between the roadbook and map tabs, mirroring the segmented
+  // control. Claims only a decisive horizontal gesture so the roadbook's
+  // vertical scroll (and, over the native map, its own pan) keep working.
+  const panResponder = useMemo(
+    () =>
+      PanResponder.create({
+        onMoveShouldSetPanResponder: (_, g) =>
+          Math.abs(g.dx) > 24 && Math.abs(g.dx) > Math.abs(g.dy) * 1.5,
+        onPanResponderRelease: (_, g) => {
+          const next = swipeToView(g.dx);
+          if (next) setView(next);
+        },
+      }),
+    [],
+  );
+
+  function openDatesConfig() {
+    setConfigSection('dates');
+    setConfigOpen(true);
+  }
 
   // Hydrate the shared store from /detail and keep it live via SSE. The child
   // views render straight from the store, so a stage_updated event reconciled by
@@ -131,9 +154,13 @@ export default function TripRoadbook() {
     });
   }
 
+  // Before the trip is hydrated, hide the native header: otherwise it shows the
+  // raw route name ("trip/[id]/index") next to the spinner. The header (title +
+  // ⋯ menu) appears only once the trip is loaded.
   if (loading) {
     return (
       <Screen padded={false}>
+        <Stack.Screen options={{ headerShown: false }} />
         <LoadingState />
       </Screen>
     );
@@ -142,6 +169,7 @@ export default function TripRoadbook() {
   if (error) {
     return (
       <Screen padded={false}>
+        <Stack.Screen options={{ headerShown: false }} />
         <ErrorState title={t('common.error')} description={error} />
       </Screen>
     );
@@ -151,6 +179,7 @@ export default function TripRoadbook() {
     <Screen padded={false}>
       <Stack.Screen
         options={{
+          headerShown: true,
           headerTitle: () => <TripTitleHeader tripId={id} />,
           headerRight: () => (
             <View
@@ -174,11 +203,23 @@ export default function TripRoadbook() {
           ),
         }}
       />
-      <View style={{ padding: theme.spacing.base }}>
+      <View
+        style={{
+          paddingHorizontal: theme.spacing.base,
+          paddingTop: theme.spacing.sm,
+          paddingBottom: theme.spacing.sm,
+        }}
+      >
         <SegmentedControl segments={segments} value={view} onChange={setView} />
       </View>
 
-      {view === 'map' ? <TripMapView /> : <RoadbookView id={id} />}
+      <View style={{ flex: 1 }} {...panResponder.panHandlers}>
+        {view === 'map' ? (
+          <TripMapView />
+        ) : (
+          <RoadbookView id={id} onConfigureDates={openDatesConfig} />
+        )}
+      </View>
 
       <Modal
         visible={menuOpen}
@@ -209,6 +250,7 @@ export default function TripRoadbook() {
               label={t('trip.menu.config')}
               onPress={() => {
                 setMenuOpen(false);
+                setConfigSection(undefined);
                 setConfigOpen(true);
               }}
             />
@@ -267,6 +309,7 @@ export default function TripRoadbook() {
       <ConfigSheet
         tripId={id}
         visible={configOpen}
+        initialSection={configSection}
         onClose={() => setConfigOpen(false)}
       />
       <ShareSheet visible={shareOpen} onClose={() => setShareOpen(false)} tripId={id} />

--- a/mobile/src/components/TripMap.test.tsx
+++ b/mobile/src/components/TripMap.test.tsx
@@ -74,6 +74,23 @@ describe('TripMap', () => {
     expect(findAll(out.root, 'Map')).toHaveLength(0);
   });
 
+  it('renders (framed on the markers) when a stage has markers but no drawable line', () => {
+    // Rest-day case (#1142): the stage carries a single point, so `stageSegments`
+    // is empty (no line to draw) but its location marker remains. The map must
+    // still render and frame on the marker instead of falling through to the
+    // empty state.
+    const out = render(
+      <TripMap
+        stageSegments={[]}
+        markers={[{ kind: 'waypoint', lon: 2.5, lat: 48.5, name: 'Repos' }]}
+      />,
+    );
+    expect(findAll(out.root, 'Map')).toHaveLength(1);
+    expect(findAll(out.root, 'Camera')[0].props.bounds).toEqual(
+      computeBounds([[2.5, 48.5]]),
+    );
+  });
+
   it('feeds the memoized Positron style, then the satellite style once toggled', () => {
     const out = render(<TripMap stageSegments={segsA} />);
     const style = () => findAll(out.root, 'Map')[0].props.mapStyle;

--- a/mobile/src/components/TripMap.test.tsx
+++ b/mobile/src/components/TripMap.test.tsx
@@ -5,7 +5,7 @@ import * as SecureStore from 'expo-secure-store';
 import '../i18n';
 import { useMapPrefs } from '../store/map-prefs';
 import { TripMap } from './TripMap';
-import { computeBounds, POSITRON_STYLE_URL } from './map/map-utils';
+import { computeBounds, POSITRON_STYLE_URL, type StageLine } from './map/map-utils';
 
 jest.mock('expo-secure-store', () => ({
   getItemAsync: jest.fn().mockResolvedValue(null),
@@ -56,6 +56,8 @@ const coordsB: [number, number][] = [
   [5, 44],
   [6, 45],
 ];
+const segsA: StageLine[] = [{ color: 'hsl(25.0, 72%, 48%)', coordinates: coordsA }];
+const segsB: StageLine[] = [{ color: 'hsl(25.0, 72%, 48%)', coordinates: coordsB }];
 
 beforeEach(() => {
   setItem.mockClear();
@@ -68,12 +70,12 @@ beforeEach(() => {
 
 describe('TripMap', () => {
   it('renders the empty state when there is no route', () => {
-    const out = render(<TripMap coordinates={[]} />);
+    const out = render(<TripMap stageSegments={[]} />);
     expect(findAll(out.root, 'Map')).toHaveLength(0);
   });
 
   it('feeds the memoized Positron style, then the satellite style once toggled', () => {
-    const out = render(<TripMap coordinates={coordsA} />);
+    const out = render(<TripMap stageSegments={segsA} />);
     const style = () => findAll(out.root, 'Map')[0].props.mapStyle;
     expect(style()).toBe(POSITRON_STYLE_URL);
 
@@ -94,34 +96,56 @@ describe('TripMap', () => {
     expect(style()).toMatchObject({ version: 8 });
     // ...and the choice is persisted.
     expect(setItem).toHaveBeenCalledWith('btp_map_base', 'satellite');
-    // The route line switches to white for contrast over imagery.
-    expect(byId(out.root, 'Layer', 'route-line')[0].props.paint['line-color']).toBe(
-      '#ffffff',
-    );
+    // The route keeps its data-driven per-stage color on satellite too (stages
+    // stay distinguishable over imagery, like the web map).
+    expect(byId(out.root, 'Layer', 'route-line')[0].props.paint['line-color']).toEqual([
+      'get',
+      'color',
+    ]);
+  });
+
+  it('draws one colored LineString feature per stage', () => {
+    const segs: StageLine[] = [
+      { color: 'hsl(25.0, 72%, 48%)', coordinates: coordsA },
+      { color: 'hsl(162.5, 72%, 48%)', coordinates: coordsB },
+    ];
+    const out = render(<TripMap stageSegments={segs} />);
+    const source = byId(out.root, 'GeoJSONSource', 'route')[0]!;
+    const features = source.props.data.features as {
+      properties: { color: string };
+    }[];
+    // One feature per stage, each carrying its own color, and the single line
+    // layer paints them via ['get', 'color'].
+    expect(features).toHaveLength(2);
+    expect(new Set(features.map((f) => f.properties.color)).size).toBe(2);
+    expect(byId(out.root, 'Layer', 'route-line')[0].props.paint['line-color']).toEqual([
+      'get',
+      'color',
+    ]);
   });
 
   it('re-frames the camera reactively when coordinates change', () => {
-    const out = render(<TripMap coordinates={coordsA} />);
+    const out = render(<TripMap stageSegments={segsA} />);
     const camera = () => findAll(out.root, 'Camera')[0].props;
     expect(camera().bounds).toEqual(computeBounds(coordsA));
 
     // Same (non re-keyed) Camera instance, new coordinates -> new bounds prop.
     act(() => {
-      out.update(<TripMap coordinates={coordsB} />);
+      out.update(<TripMap stageSegments={segsB} />);
     });
     expect(camera().bounds).toEqual(computeBounds(coordsB));
   });
 
   it('draws the highlighted segment only once it has at least two points', () => {
     const out = render(
-      <TripMap coordinates={coordsA} highlightedSegment={[[2, 48]]} />,
+      <TripMap stageSegments={segsA} highlightedSegment={[[2, 48]]} />,
     );
     expect(byId(out.root, 'GeoJSONSource', 'segment-highlight')).toHaveLength(0);
 
     act(() => {
       out.update(
         <TripMap
-          coordinates={coordsA}
+          stageSegments={segsA}
           highlightedSegment={[
             [2, 48],
             [3, 49],
@@ -133,12 +157,12 @@ describe('TripMap', () => {
   });
 
   it('renders the markers layer only when markers are provided', () => {
-    const withoutMarkers = render(<TripMap coordinates={coordsA} />);
+    const withoutMarkers = render(<TripMap stageSegments={segsA} />);
     expect(byId(withoutMarkers.root, 'Layer', 'markers-circle')).toHaveLength(0);
 
     const withMarkers = render(
       <TripMap
-        coordinates={coordsA}
+        stageSegments={segsA}
         markers={[{ kind: 'poi', lon: 2.5, lat: 48.5, name: 'Café' }]}
       />,
     );
@@ -148,7 +172,7 @@ describe('TripMap', () => {
   it('colors the three marker kinds distinctly (poi/accommodation/waypoint)', () => {
     const withMarkers = render(
       <TripMap
-        coordinates={coordsA}
+        stageSegments={segsA}
         markers={[{ kind: 'poi', lon: 2.5, lat: 48.5, name: 'Café' }]}
       />,
     );

--- a/mobile/src/components/TripMap.tsx
+++ b/mobile/src/components/TripMap.tsx
@@ -66,9 +66,20 @@ export function TripMap({
   // once per input change: a fresh reference on each render would defeat the
   // upstream React.memo (Map/Camera/GeoJSONSource) and force a native re-diff.
   const mapStyle = useMemo(() => mapStyleFor(base), [base]);
-  const coordinates = useMemo(
+  const lineCoords = useMemo(
     () => stageSegments.flatMap((s) => s.coordinates),
     [stageSegments],
+  );
+  // Framing / presence coordinates: the route line when there is one, else the
+  // markers as a fallback. A rest day carries a single point (no drawable line,
+  // so `stageSegments` is empty) but still has its location marker — without the
+  // fallback the early return below would hide its detail map entirely (#1142).
+  const coordinates = useMemo(
+    () =>
+      lineCoords.length > 0
+        ? lineCoords
+        : (markers ?? []).map((m) => [m.lon, m.lat] as [number, number]),
+    [lineCoords, markers],
   );
   const bounds = useMemo(() => computeBounds(coordinates), [coordinates]);
   const markerData = useMemo(() => markerCollection(markers ?? []), [markers]);

--- a/mobile/src/components/TripMap.tsx
+++ b/mobile/src/components/TripMap.tsx
@@ -20,6 +20,7 @@ import {
   markerCollection,
   segmentFeature,
   type MapMarker,
+  type StageLine,
 } from './map/map-utils';
 
 // Pixel inset kept around the fitted route so start/end markers are not flush
@@ -27,11 +28,13 @@ import {
 const FIT_PADDING = { top: 48, right: 48, bottom: 48, left: 48 };
 
 export function TripMap({
-  coordinates,
+  stageSegments,
   markers,
   highlightedSegment,
 }: {
-  coordinates: [number, number][];
+  // One colored polyline per stage; the route is drawn stage by stage so each
+  // stands out (see stageColor). Camera framing uses all points flattened.
+  stageSegments: StageLine[];
   markers?: MapMarker[];
   // Ordered [lon, lat] points of a road stretch to surline (e.g. from an alert
   // `navigate` action). Drawn on its own source/layer above the route. Detail /
@@ -63,24 +66,29 @@ export function TripMap({
   // once per input change: a fresh reference on each render would defeat the
   // upstream React.memo (Map/Camera/GeoJSONSource) and force a native re-diff.
   const mapStyle = useMemo(() => mapStyleFor(base), [base]);
+  const coordinates = useMemo(
+    () => stageSegments.flatMap((s) => s.coordinates),
+    [stageSegments],
+  );
   const bounds = useMemo(() => computeBounds(coordinates), [coordinates]);
   const markerData = useMemo(() => markerCollection(markers ?? []), [markers]);
   const segmentData = useMemo(
     () => segmentFeature(highlightedSegment ?? []),
     [highlightedSegment],
   );
+  // One LineString feature per stage, each carrying its color as a data-driven
+  // property so a single layer can paint them via ['get', 'color'] (like the web
+  // map) instead of one flat single-color line.
   const line = useMemo<FeatureCollection>(
     () => ({
       type: 'FeatureCollection',
-      features: [
-        {
-          type: 'Feature',
-          properties: {},
-          geometry: { type: 'LineString', coordinates },
-        },
-      ],
+      features: stageSegments.map((s) => ({
+        type: 'Feature',
+        properties: { color: s.color },
+        geometry: { type: 'LineString', coordinates: s.coordinates },
+      })),
     }),
-    [coordinates],
+    [stageSegments],
   );
   // maplibre-react-native v11: `initialViewState` is applied once at native
   // mount, whereas the top-level `CameraStop` `bounds`/`padding` are reactive —
@@ -102,7 +110,6 @@ export function TripMap({
     );
   }
 
-  const satellite = base === 'satellite';
   const hasSegment = (highlightedSegment?.length ?? 0) >= 2;
 
   return (
@@ -114,8 +121,10 @@ export function TripMap({
             id="route-line"
             type="line"
             layout={{ 'line-join': 'round', 'line-cap': 'round' }}
+            // Per-stage color kept on both bases so stages stay distinguishable
+            // over satellite imagery too (matches the web map).
             paint={{
-              'line-color': satellite ? '#ffffff' : theme.colors.brand,
+              'line-color': ['get', 'color'],
               'line-width': 4,
             }}
           />

--- a/mobile/src/components/map/map-utils.test.ts
+++ b/mobile/src/components/map/map-utils.test.ts
@@ -5,6 +5,7 @@ import {
   alertSegmentToCoords,
   applyZoom,
   buildSatelliteStyle,
+  buildStageLines,
   collectMarkers,
   computeBounds,
   mapStyleFor,
@@ -52,6 +53,36 @@ describe('computeBounds', () => {
       [-1, 50],
     ]);
     expect(bounds).toEqual([-1, 45, 5, 50]);
+  });
+});
+
+describe('buildStageLines', () => {
+  const geom = [
+    { lat: 48, lon: 2, ele: 100 },
+    { lat: 48.1, lon: 2.1, ele: 150 },
+  ];
+
+  it('emits one colored line per drawable stage, in [lon, lat] order', () => {
+    const lines = buildStageLines([
+      stage({ dayNumber: 1, geometry: geom }),
+      stage({ dayNumber: 2, geometry: geom }),
+    ]);
+    expect(lines).toHaveLength(2);
+    expect(lines[0]!.coordinates).toEqual([
+      [2, 48],
+      [2.1, 48.1],
+    ]);
+    // Adjacent stages get distinct colors.
+    expect(lines[0]!.color).not.toBe(lines[1]!.color);
+  });
+
+  it('skips rest days and stages with fewer than two points', () => {
+    const lines = buildStageLines([
+      stage({ dayNumber: 1, geometry: geom }),
+      stage({ dayNumber: 2, isRestDay: true, geometry: geom }),
+      stage({ dayNumber: 3, geometry: [{ lat: 48, lon: 2, ele: 100 }] }),
+    ]);
+    expect(lines).toHaveLength(1);
   });
 });
 

--- a/mobile/src/components/map/map-utils.ts
+++ b/mobile/src/components/map/map-utils.ts
@@ -2,6 +2,7 @@ import type { StageData } from '@btp/core';
 import { resupplyPois } from '@btp/core';
 import type { StyleSpecification } from '@maplibre/maplibre-react-native';
 import type { FeatureCollection } from 'geojson';
+import { stageColor } from './stage-colors';
 
 // The two base maps the map tab can render. Persisted via the map-prefs store.
 export type MapBase = 'map' | 'satellite';
@@ -68,6 +69,25 @@ export function computeBounds(
     if (lat > north) north = lat;
   }
   return [west, south, east, north];
+}
+
+// One drawable stage: its ordered [lon, lat] geometry and the color that sets
+// it apart from its neighbours on the map (see stageColor).
+export interface StageLine {
+  color: string;
+  coordinates: [number, number][];
+}
+
+// Split the route into one colored polyline per stage (mirrors the web map).
+// Rest days and stages too short to draw (< 2 points) are skipped, exactly like
+// the web's buildRouteGeoJSON; the color keys on the stable 1-based `dayNumber`.
+export function buildStageLines(stages: StageData[]): StageLine[] {
+  return stages
+    .filter((s) => !s.isRestDay && (s.geometry?.length ?? 0) >= 2)
+    .map((s) => ({
+      color: stageColor(s.dayNumber),
+      coordinates: s.geometry.map((p) => [p.lon, p.lat] as [number, number]),
+    }));
 }
 
 export type MarkerKind = 'waypoint' | 'poi' | 'accommodation';

--- a/mobile/src/components/map/stage-colors.test.ts
+++ b/mobile/src/components/map/stage-colors.test.ts
@@ -1,0 +1,35 @@
+/// <reference types="jest" />
+import { stageColor } from './stage-colors';
+
+// Parse the hue (degrees) out of an "hsl(H, S%, L%)" string.
+function hueOf(color: string): number {
+  const m = /^hsl\(([\d.]+),/.exec(color);
+  if (!m) throw new Error(`not an hsl() color: ${color}`);
+  return Number(m[1]);
+}
+
+// Shortest angular distance between two hues on the 360deg wheel.
+function hueDistance(a: number, b: number): number {
+  const d = Math.abs(a - b) % 360;
+  return Math.min(d, 360 - d);
+}
+
+describe('stageColor', () => {
+  it('gives N stages N distinct colors', () => {
+    const colors = Array.from({ length: 20 }, (_, i) => stageColor(i + 1));
+    expect(new Set(colors).size).toBe(20);
+  });
+
+  it('keeps adjacent stages well separated in hue (golden-angle rotation)', () => {
+    // Every consecutive pair lands ~137.5deg apart, so no two neighbours read as
+    // similar colors even on a long trip.
+    for (let day = 1; day < 40; day++) {
+      const dist = hueDistance(hueOf(stageColor(day)), hueOf(stageColor(day + 1)));
+      expect(dist).toBeGreaterThan(60);
+    }
+  });
+
+  it('anchors the first stage near the brand orange hue', () => {
+    expect(hueOf(stageColor(1))).toBe(25);
+  });
+});

--- a/mobile/src/components/map/stage-colors.ts
+++ b/mobile/src/components/map/stage-colors.ts
@@ -1,0 +1,26 @@
+// Per-stage line color, mirroring the web map's one-color-per-stage scheme
+// (pwa/src/components/Map/stage-colors.ts) so the mobile map distinguishes each
+// stage the same way. The web ships a fixed 10-hex palette; the mobile theme
+// forbids new raw hexes, and a fixed cycling palette also risks placing
+// look-alike hues on adjacent stages of a long trip (its 1st and 11th stages
+// share a hex, and neighbours like its 10th pink / 11th red read as close).
+//
+// Strategy: compute the hue by rotating the color wheel by the golden angle
+// (~137.5 deg) per stage. Consecutive stages therefore always land far apart on
+// the wheel (circular hue distance ~137.5 deg between neighbours), guaranteeing
+// contrast between adjacent stages for any trip length, and the sequence only
+// starts repeating after hundreds of stages. Saturation/lightness are fixed for
+// legibility over both the light base map and satellite imagery; the base hue is
+// anchored near the theme's warm brand orange (#a8561a) for visual continuity.
+// This computed color is the documented exception to the "no raw hex" rule.
+const GOLDEN_ANGLE = 137.508;
+const BASE_HUE = 25; // ~ brand orange
+const SATURATION = 72;
+const LIGHTNESS = 48;
+
+// `dayNumber` is the web's 1-based stage key; any integer works since the hue
+// wraps mod 360.
+export function stageColor(dayNumber: number): string {
+  const hue = (((BASE_HUE + (dayNumber - 1) * GOLDEN_ANGLE) % 360) + 360) % 360;
+  return `hsl(${hue.toFixed(1)}, ${SATURATION}%, ${LIGHTNESS}%)`;
+}

--- a/mobile/src/components/trip/ConfigSheet.test.tsx
+++ b/mobile/src/components/trip/ConfigSheet.test.tsx
@@ -260,3 +260,26 @@ describe('ConfigSheet slider screen-reader actions', () => {
     expect(allTexts(tree.root)).toContain(t('config.valueKm', { value: 80 }));
   });
 });
+
+describe('ConfigSheet dates deep-link (maquette 05a)', () => {
+  it('schedules a scroll to the dates section when opened with initialSection', () => {
+    const raf = jest
+      .spyOn(global, 'requestAnimationFrame')
+      .mockImplementation((cb: FrameRequestCallback) => {
+        cb(0);
+        return 0;
+      });
+    render(<ConfigSheet tripId="t1" visible initialSection="dates" onClose={jest.fn()} />);
+    expect(raf).toHaveBeenCalled();
+    raf.mockRestore();
+  });
+
+  it('does not scroll when opened without initialSection', () => {
+    const raf = jest
+      .spyOn(global, 'requestAnimationFrame')
+      .mockImplementation(() => 0);
+    render(<ConfigSheet tripId="t1" visible onClose={jest.fn()} />);
+    expect(raf).not.toHaveBeenCalled();
+    raf.mockRestore();
+  });
+});

--- a/mobile/src/components/trip/ConfigSheet.tsx
+++ b/mobile/src/components/trip/ConfigSheet.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
   Alert,
   type AccessibilityActionEvent,
@@ -31,6 +31,9 @@ interface ConfigSheetProps {
   tripId: string;
   visible: boolean;
   onClose: () => void;
+  // Open scrolled to a given section. 'dates' brings the (last) dates section
+  // into view — wired to the roadbook "set your dates" banner (maquette 05a).
+  initialSection?: 'dates';
 }
 
 // The editable pacing slice held as a local draft while the sheet is open, so a
@@ -266,9 +269,15 @@ function SectionTitle({ title, description }: { title: string; description?: str
 // spot (they don't re-split the trip). Pacing and dates are destructive — they
 // regenerate the stage découpage — so committing them goes through a
 // confirmation and arms the post-recompute diff-highlight.
-export function ConfigSheet({ tripId, visible, onClose }: ConfigSheetProps) {
+export function ConfigSheet({
+  tripId,
+  visible,
+  onClose,
+  initialSection,
+}: ConfigSheetProps) {
   const { t } = useTranslation();
   const theme = useTheme();
+  const scrollRef = useRef<ScrollView>(null);
 
   const storeTitle = useTripStore((s) => s.title);
   const isLocked = useTripStore((s) => s.isLocked);
@@ -313,6 +322,12 @@ export function ConfigSheet({ tripId, visible, onClose }: ConfigSheetProps) {
       ebikeMode,
       departureHour,
     });
+    // Bring the dates section (rendered last) into view when the sheet was
+    // opened from the "set your dates" banner. Deferred so the ScrollView has
+    // laid out its content before scrolling.
+    if (initialSection === 'dates') {
+      requestAnimationFrame(() => scrollRef.current?.scrollToEnd({ animated: false }));
+    }
   }, [visible]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const activePreset = getActivePresetKey(
@@ -406,7 +421,11 @@ export function ConfigSheet({ tripId, visible, onClose }: ConfigSheetProps) {
 
   return (
     <Sheet visible={visible} onClose={onClose} title={t('config.title')}>
-      <ScrollView style={{ maxHeight: 460 }} keyboardShouldPersistTaps="handled">
+      <ScrollView
+        ref={scrollRef}
+        style={{ maxHeight: 460 }}
+        keyboardShouldPersistTaps="handled"
+      >
         {/* Title */}
         <SectionTitle title={t('config.titleSection')} />
         <Input

--- a/mobile/src/components/trip/ElevationProfile.tsx
+++ b/mobile/src/components/trip/ElevationProfile.tsx
@@ -10,6 +10,7 @@ import Svg, { Line, Path } from 'react-native-svg';
 import { useTranslation } from 'react-i18next';
 import type { StageData } from '@btp/core';
 import { buildProfilePoints, findClosestProfilePoint } from '@btp/core/elevation';
+import { stageColor } from '../map/stage-colors';
 import { useTheme } from '../../theme';
 
 // SVG viewport constants (mirrors the web profile). The Svg fills its container
@@ -80,6 +81,16 @@ export function ElevationProfile({
     [stages, focusedStageIndex],
   );
   const hasData = points.length >= 2;
+
+  // Map an active-stage index (what ProfilePoint.stageIndex carries) to the
+  // stage's 1-based dayNumber, so each stage's area is filled with the very same
+  // color the map draws its polyline in (see stageColor).
+  const activeDayNumbers = useMemo(
+    () => stages.filter((s) => !s.isRestDay).map((s) => s.dayNumber),
+    [stages],
+  );
+  const colorForStage = (stageIndex: number) =>
+    stageColor(activeDayNumbers[stageIndex] ?? stageIndex + 1);
 
   const { maxDist, displayMinEle, displayMaxEle } = useMemo(() => {
     if (!hasData) return { maxDist: 0, displayMinEle: 0, displayMaxEle: 1000 };
@@ -180,17 +191,20 @@ export function ElevationProfile({
         viewBox={`0 0 ${VW} ${VH}`}
         preserveAspectRatio="none"
       >
-        {stagePaths.map(({ stageIndex, d }) => (
-          <Path
-            key={stageIndex}
-            d={d}
-            fill={theme.colors.brand}
-            fillOpacity={0.35}
-            stroke={theme.colors.brand}
-            strokeWidth={1.5}
-            strokeOpacity={0.8}
-          />
-        ))}
+        {stagePaths.map(({ stageIndex, d }) => {
+          const color = colorForStage(stageIndex);
+          return (
+            <Path
+              key={stageIndex}
+              d={d}
+              fill={color}
+              fillOpacity={0.35}
+              stroke={color}
+              strokeWidth={1.5}
+              strokeOpacity={0.8}
+            />
+          );
+        })}
         {hover !== null ? (
           <Line
             testID="elevation-crosshair"

--- a/mobile/src/components/trip/RoadbookView.test.tsx
+++ b/mobile/src/components/trip/RoadbookView.test.tsx
@@ -16,7 +16,6 @@ jest.mock('../../hooks/use-trip-mutations', () => ({
     addStage: jest.fn(),
     insertRestDay: jest.fn(),
     deleteStage: jest.fn(),
-    updateStageDistance: jest.fn(),
   }),
 }));
 

--- a/mobile/src/components/trip/RoadbookView.test.tsx
+++ b/mobile/src/components/trip/RoadbookView.test.tsx
@@ -4,12 +4,33 @@ import { EMPTY_RESUPPLY } from '@btp/core';
 import type { ReactElement } from 'react';
 import type { StageData } from '@btp/core';
 import i18n from '../../i18n';
+import { fr } from '../../i18n/resources/fr';
 import { useTripStore } from '../../store/trip-store';
+import { todayUtc } from './roadbook-dates';
 
 const mockPush = jest.fn();
 jest.mock('expo-router', () => ({ useRouter: () => ({ push: mockPush }) }));
 
+jest.mock('../../hooks/use-trip-mutations', () => ({
+  useTripMutations: () => ({
+    addStage: jest.fn(),
+    insertRestDay: jest.fn(),
+    deleteStage: jest.fn(),
+    updateStageDistance: jest.fn(),
+  }),
+}));
+
 import { RoadbookView } from './RoadbookView';
+
+function queryByLabel(tree: any, label: string): any {
+  const found = tree.root.findAll(
+    (n: any) => n.props.accessibilityLabel === label,
+  );
+  return found[0] ?? null;
+}
+
+const addStageA11y = fr.trip.edit.addStageA11y.replace('{{day}}', '1');
+const deleteA11y = fr.trip.deleteA11y.replace('{{day}}', '1');
 
 function stage(overrides: Partial<StageData> = {}): StageData {
   const point = { lat: 0, lon: 0, ele: 0 };
@@ -72,5 +93,66 @@ describe('RoadbookView navigation', () => {
     act(() => summary.props.onPress());
 
     expect(mockPush).toHaveBeenCalledWith('/trip/trip-42/stage/1');
+  });
+});
+
+describe('RoadbookView edit affordances by lifecycle', () => {
+  beforeAll(async () => {
+    await i18n.changeLanguage('fr');
+  });
+
+  beforeEach(() => {
+    act(() => {
+      useTripStore.getState().reset();
+      useTripStore.setState({
+        stages: [stage({ dayNumber: 1 }), stage({ dayNumber: 2 })],
+        isLocked: false,
+        loading: false,
+      });
+    });
+  });
+
+  it('shows insertion rows, delete and the in-ride FAB on an editable (undated) trip', () => {
+    const tree = render(<RoadbookView id="t1" />);
+    expect(queryByLabel(tree, addStageA11y)).not.toBeNull();
+    expect(queryByLabel(tree, deleteA11y)).not.toBeNull();
+    expect(queryByLabel(tree, i18n.t('trip.rideCtaA11y'))).not.toBeNull();
+  });
+
+  it('hides every edit affordance when the trip is in the past (read-only)', () => {
+    act(() =>
+      useTripStore.setState({ startDate: '2000-01-01', endDate: '2000-01-02' }),
+    );
+    const tree = render(<RoadbookView id="t1" />);
+    expect(queryByLabel(tree, addStageA11y)).toBeNull();
+    expect(queryByLabel(tree, deleteA11y)).toBeNull();
+    expect(queryByLabel(tree, i18n.t('trip.rideCtaA11y'))).toBeNull();
+  });
+
+  it('hides every edit affordance when the trip is ongoing (read-only)', () => {
+    const today = todayUtc();
+    act(() => useTripStore.setState({ startDate: today, endDate: today }));
+    const tree = render(<RoadbookView id="t1" />);
+    expect(queryByLabel(tree, addStageA11y)).toBeNull();
+    expect(queryByLabel(tree, deleteA11y)).toBeNull();
+    expect(queryByLabel(tree, i18n.t('trip.rideCtaA11y'))).toBeNull();
+  });
+
+  it('hides edit affordances when the backend locked the trip', () => {
+    act(() => useTripStore.setState({ isLocked: true }));
+    const tree = render(<RoadbookView id="t1" />);
+    expect(queryByLabel(tree, addStageA11y)).toBeNull();
+    expect(queryByLabel(tree, deleteA11y)).toBeNull();
+  });
+
+  it('makes the no-dates banner open the dates config when pressed', () => {
+    const onConfigureDates = jest.fn();
+    const tree = render(
+      <RoadbookView id="t1" onConfigureDates={onConfigureDates} />,
+    );
+    const banner = queryByLabel(tree, i18n.t('trip.banners.noDatesA11y'));
+    expect(banner).not.toBeNull();
+    act(() => banner.props.onPress());
+    expect(onConfigureDates).toHaveBeenCalledTimes(1);
   });
 });

--- a/mobile/src/components/trip/RoadbookView.tsx
+++ b/mobile/src/components/trip/RoadbookView.tsx
@@ -172,10 +172,11 @@ export function RoadbookView({
                 isToday={state === 'ongoing' && isStageToday(date, today)}
                 highlighted={stageDiffs.has(index)}
               />
-              {/* Insertion row between stages (and after the last, maquette 05):
-                  hidden when the trip is read-only. Keyed on the preceding
-                  stage's key so a rapid double-tap fires a single mutation. */}
-              {!readOnly ? (
+              {/* Insertion row BETWEEN stages only — never after the last one
+                  (nothing to insert past the destination, like the web). Hidden
+                  when the trip is read-only. Keyed on the preceding stage's key so
+                  a rapid double-tap fires a single mutation. */}
+              {!readOnly && index < stages.length - 1 ? (
                 <StageInsertRow
                   afterIndex={index}
                   day={item.dayNumber ?? index + 1}

--- a/mobile/src/components/trip/RoadbookView.tsx
+++ b/mobile/src/components/trip/RoadbookView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react';
+import { Fragment, useCallback, useRef, useState } from 'react';
 import { Alert, FlatList, Pressable, Text, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { EmptyState } from '../ui';
 import { Bike } from '../ui/icons';
 import { StageCard, stageKey } from './StageCard';
+import { StageInsertRow } from './StageInsertRow';
 import { RoadbookSummary } from './RoadbookSummary';
 import { RoadbookBanner } from './RoadbookBanner';
 import {
@@ -24,7 +25,15 @@ import { useTripMutations } from '../../hooks/use-trip-mutations';
 // the lock / out-of-zone / no-dates banners, then the stage list (StageCard
 // rows) with per-stage dates and an "Aujourd'hui" pastille. #1039 wires each
 // row's tap-through to the stage detail.
-export function RoadbookView({ id }: { id: string }) {
+export function RoadbookView({
+  id,
+  onConfigureDates,
+}: {
+  id: string;
+  // Opens the config sheet scrolled to the dates section (maquette 05a). Wired
+  // to the "set your dates" banner so a rider fixes the missing dates in one tap.
+  onConfigureDates?: () => void;
+}) {
   const { t } = useTranslation();
   const theme = useTheme();
   const insets = useSafeAreaInsets();
@@ -39,6 +48,11 @@ export function RoadbookView({ id }: { id: string }) {
   const today = todayUtc();
   const state = tripStateFromDates(startDate, endDate, today);
   const hasDates = startDate !== null && endDate !== null;
+
+  // Read-only when the backend locked the trip (started, 423) OR the dates put
+  // it in progress / in the past (maquette 05e / 05f): every edit affordance
+  // (insertion pills, delete, distance edit, FAB) is hidden or disabled.
+  const readOnly = isLocked || state === 'ongoing' || state === 'past';
 
   // One failure surface for every inline edit: map the normalized reason to a
   // localized alert (#1044). The runners already handle optimistic apply +
@@ -115,7 +129,17 @@ export function RoadbookView({ id }: { id: string }) {
         <RoadbookBanner variant="outOfZone" message={t('trip.banners.outOfZone')} />
       ) : null}
       {!hasDates ? (
-        <RoadbookBanner variant="noDates" message={t('trip.banners.noDates')} />
+        onConfigureDates ? (
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={t('trip.banners.noDatesA11y')}
+            onPress={onConfigureDates}
+          >
+            <RoadbookBanner variant="noDates" message={t('trip.banners.noDates')} />
+          </Pressable>
+        ) : (
+          <RoadbookBanner variant="noDates" message={t('trip.banners.noDates')} />
+        )
       ) : null}
     </View>
   );
@@ -137,33 +161,50 @@ export function RoadbookView({ id }: { id: string }) {
           const date = stageDateFor(startDate, item.dayNumber ?? index + 1);
           const key = stageKey(item);
           return (
-            <StageCard
-              stage={item}
-              index={index}
-              locked={isLocked}
-              outOfZone={outOfZone}
-              busy={busyKeys.has(key)}
-              onDelete={confirmDelete}
-              onAddStage={() => runGuarded(key, () => mutations.addStage(index))}
-              onAddRestDay={() =>
-                runGuarded(key, () => mutations.insertRestDay(index))
-              }
-              onEditDistance={(_, distance) =>
-                runGuarded(key, () => mutations.updateStageDistance(index, distance))
-              }
-              onPress={(i) => router.push(`/trip/${id}/stage/${i}`)}
-              date={date}
-              isToday={state === 'ongoing' && isStageToday(date, today)}
-              highlighted={stageDiffs.has(index)}
-            />
+            <Fragment>
+              <StageCard
+                stage={item}
+                index={index}
+                locked={readOnly}
+                outOfZone={outOfZone}
+                busy={busyKeys.has(key)}
+                onDelete={confirmDelete}
+                onEditDistance={(_, distance) =>
+                  runGuarded(key, () => mutations.updateStageDistance(index, distance))
+                }
+                onPress={(i) => router.push(`/trip/${id}/stage/${i}`)}
+                date={date}
+                isToday={state === 'ongoing' && isStageToday(date, today)}
+                highlighted={stageDiffs.has(index)}
+              />
+              {/* Insertion row between stages (and after the last, maquette 05):
+                  hidden when the trip is read-only. Keyed on the preceding
+                  stage's key so a rapid double-tap fires a single mutation. */}
+              {!readOnly ? (
+                <StageInsertRow
+                  afterIndex={index}
+                  day={item.dayNumber ?? index + 1}
+                  outOfZone={outOfZone}
+                  busy={busyKeys.has(key)}
+                  onAddStage={() =>
+                    runGuarded(key, () => mutations.addStage(index))
+                  }
+                  onAddRestDay={() =>
+                    runGuarded(key, () => mutations.insertRestDay(index))
+                  }
+                />
+              ) : null}
+            </Fragment>
           );
         }}
         style={{ backgroundColor: theme.colors.background }}
       />
       {/* In-ride FAB (Spike-UX): the in-ride screen is out of scope, so this is a
           deliberate placeholder — disabled, icon-only, dispatches nothing. Lifted
-          above the system nav bar via the bottom safe-area inset. */}
-      {stages.length > 0 ? (
+          above the system nav bar via the bottom safe-area inset. Lives in the
+          roadbook view only, so it never overlays the map/profile tab (#7);
+          hidden in the read-only (started / ongoing / past) view (#6). */}
+      {stages.length > 0 && !readOnly ? (
         <Pressable
           accessibilityRole="button"
           accessibilityLabel={t('trip.rideCtaA11y')}

--- a/mobile/src/components/trip/RoadbookView.tsx
+++ b/mobile/src/components/trip/RoadbookView.tsx
@@ -166,12 +166,7 @@ export function RoadbookView({
                 stage={item}
                 index={index}
                 locked={readOnly}
-                outOfZone={outOfZone}
-                busy={busyKeys.has(key)}
                 onDelete={confirmDelete}
-                onEditDistance={(_, distance) =>
-                  runGuarded(key, () => mutations.updateStageDistance(index, distance))
-                }
                 onPress={(i) => router.push(`/trip/${id}/stage/${i}`)}
                 date={date}
                 isToday={state === 'ongoing' && isStageToday(date, today)}

--- a/mobile/src/components/trip/StageCard.tsx
+++ b/mobile/src/components/trip/StageCard.tsx
@@ -1,28 +1,19 @@
-import { type ReactNode, useEffect, useState } from 'react';
-import { Pressable, Text, TextInput, View } from 'react-native';
+import { Pressable, Text, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import type { StageData } from '@btp/core';
-import {
-  AlertTriangle,
-  Check,
-  CloudSun,
-  Pencil,
-  Trash2,
-  X,
-} from '../ui/icons';
+import { AlertTriangle, CloudSun, Trash2 } from '../ui/icons';
 import { useTheme } from '../../theme';
 import { formatStageDate } from './roadbook-dates';
 
-// A per-stage identity signature used both as the roadbook FlatList key and as
-// the reset trigger for a StageCard's local edit state. Stages carry no stable
-// id and `dayNumber` is renumbered on every structural edit, so a pure index /
-// dayNumber key lets React reuse a row instance for a *different* stage after an
-// insert / rest-day / delete shifts positions — a stale open distance editor
-// would then commit onto the wrong stage. Folding the endpoints in makes the key
-// change whenever a row switches to a different underlying stage (the placeholder
-// spans a single boundary point, so it never collides with the stage it
-// displaces), forcing React to remount that row and tear down the stale editor.
-// dayNumber keeps the key unique across the list (#1044 review).
+// A per-stage identity signature used as the roadbook FlatList key. Stages carry
+// no stable id and `dayNumber` is renumbered on every structural edit, so a pure
+// index / dayNumber key lets React reuse a row instance for a *different* stage
+// after an insert / rest-day / delete shifts positions — the transient diff
+// highlight (#1046) would then paint the wrong row. Folding the endpoints in
+// makes the key change whenever a row switches to a different underlying stage
+// (the placeholder spans a single boundary point, so it never collides with the
+// stage it displaces), forcing React to remount that row. dayNumber keeps the
+// key unique across the list (#1044 review).
 export function stageKey(stage: StageData): string {
   const s = stage.startPoint;
   const e = stage.endPoint;
@@ -32,19 +23,9 @@ export function stageKey(stage: StageData): string {
 interface StageCardProps {
   stage: StageData;
   index: number;
-  // A started trip is read-only (backend 423): every edit action is hidden.
+  // A started trip is read-only (backend 423): the delete action is hidden.
   locked: boolean;
-  // Route outside the covered area: rerouting edits (+stage / distance) are
-  // hidden; a rest day and a delete (no Valhalla reroute) stay available.
-  outOfZone?: boolean;
-  // A structural mutation for this row is in flight (optimistic apply + API
-  // round-trip): every edit control is disabled so a rapid double-tap cannot
-  // dispatch the same insert/edit twice (#1044 review).
-  busy?: boolean;
   onDelete: (index: number) => void;
-  // Commit an edited distance (km) for this stage; the backend re-splits and
-  // streams the authoritative stages over SSE.
-  onEditDistance?: (index: number, distanceKm: number) => void;
   // Calendar day of the stage (YYYY-MM-DD, UTC), or null when the trip has no
   // start date — the card then falls back to "Jour N".
   date?: string | null;
@@ -59,68 +40,17 @@ interface StageCardProps {
   highlighted?: boolean;
 }
 
-// A compact pill action used by the inline edit footer.
-function EditChip({
-  icon,
-  label,
-  onPress,
-  a11yLabel,
-  disabled = false,
-}: {
-  icon: ReactNode;
-  label: string;
-  onPress: () => void;
-  a11yLabel: string;
-  disabled?: boolean;
-}) {
-  const theme = useTheme();
-  return (
-    <Pressable
-      accessibilityRole="button"
-      accessibilityLabel={a11yLabel}
-      accessibilityState={{ disabled }}
-      disabled={disabled}
-      onPress={onPress}
-      hitSlop={6}
-      style={{
-        flexDirection: 'row',
-        alignItems: 'center',
-        gap: theme.spacing.xs,
-        borderWidth: 1,
-        borderColor: theme.colors.accentBrand,
-        backgroundColor: theme.colors.accentSoft,
-        borderRadius: theme.radius.full,
-        paddingHorizontal: theme.spacing.md,
-        paddingVertical: theme.spacing.xs,
-        opacity: disabled ? 0.4 : 1,
-      }}
-    >
-      {icon}
-      <Text
-        style={{
-          color: theme.colors.accentInk,
-          fontFamily: theme.fonts.sansMedium,
-          fontSize: 13,
-        }}
-      >
-        {label}
-      </Text>
-    </Pressable>
-  );
-}
-
 // One roadbook row: the stage date (or "Jour N" fallback) + rest tag, start →
-// end labels, distance / elevation, a "today" pastille on the current day, and
-// an inline edit footer (＋étape / ＋repos / distance / delete) when the trip is
-// still editable (#1044). Rendered by RoadbookView; #1039 wires the tap-through.
+// end labels, distance / elevation, a "today" pastille on the current day, a
+// weather/alerts column and a delete action. The row is a summary that taps
+// through to the stage detail, where per-stage edits (distance) live (#1045);
+// only the delete stays on the card. Rendered by RoadbookView; #1039 wires the
+// tap-through.
 export function StageCard({
   stage,
   index,
   locked,
-  outOfZone = false,
-  busy = false,
   onDelete,
-  onEditDistance,
   date = null,
   isToday = false,
   onPress,
@@ -128,8 +58,6 @@ export function StageCard({
 }: StageCardProps) {
   const { t, i18n } = useTranslation();
   const theme = useTheme();
-  const [editingDistance, setEditingDistance] = useState(false);
-  const [draft, setDraft] = useState('');
   const day = stage.dayNumber ?? index + 1;
   const heading = date
     ? formatStageDate(date, i18n.language)
@@ -144,38 +72,6 @@ export function StageCard({
         stage.endLabel ??
         stage.label ??
         t('trip.day', { day }));
-
-  // Belt-and-suspenders to the stable FlatList key: if the underlying stage this
-  // row renders changes identity (a position shift reused the instance, or SSE
-  // reconciled the stage), drop any open distance editor so it can never commit
-  // a stale draft onto a different stage than the one it was opened on (#1044).
-  const key = stageKey(stage);
-  useEffect(() => {
-    setEditingDistance(false);
-    setDraft('');
-  }, [key]);
-
-  // Distance re-splitting reroutes → hidden out of zone and on a rest day (0 km).
-  const canEditDistance =
-    !locked && !!onEditDistance && !stage.isRestDay && !outOfZone;
-  const showFooter = canEditDistance;
-
-  function startEditDistance(): void {
-    setDraft(String(Math.round(stage.distance ?? 0)));
-    setEditingDistance(true);
-  }
-
-  function commitDistance(): void {
-    // A mutation for this row is already in flight: swallow the tap so a
-    // double-submit cannot dispatch a second update (#1044 review).
-    if (busy) return;
-    const km = Number(draft.replace(',', '.'));
-    // Keep the editor open on an invalid/empty value so the edit is not lost
-    // silently; only close + commit a finite, positive distance.
-    if (!Number.isFinite(km) || km <= 0) return;
-    setEditingDistance(false);
-    onEditDistance?.(index, km);
-  }
 
   const alertCount = stage.alerts?.length ?? 0;
 
@@ -344,74 +240,6 @@ export function StageCard({
         </Pressable>
       ) : null}
       </View>
-      {showFooter ? (
-        <View
-          style={{
-            paddingHorizontal: theme.spacing.base,
-            paddingBottom: theme.spacing.md,
-            gap: theme.spacing.sm,
-          }}
-        >
-          {editingDistance ? (
-            <View style={{ flexDirection: 'row', alignItems: 'center', gap: theme.spacing.sm }}>
-              <TextInput
-                accessibilityLabel={t('trip.edit.editDistanceA11y', { day })}
-                value={draft}
-                onChangeText={setDraft}
-                keyboardType="numeric"
-                autoFocus
-                placeholder={t('trip.edit.distancePlaceholder')}
-                placeholderTextColor={theme.colors.mutedForeground}
-                onSubmitEditing={commitDistance}
-                style={{
-                  flex: 1,
-                  height: 40,
-                  borderWidth: 1,
-                  borderColor: theme.colors.input,
-                  borderRadius: theme.radius.md,
-                  paddingHorizontal: theme.spacing.md,
-                  color: theme.colors.foreground,
-                  backgroundColor: theme.colors.surface,
-                  fontFamily: theme.fonts.mono,
-                  fontSize: 15,
-                }}
-              />
-              <Pressable
-                accessibilityRole="button"
-                accessibilityLabel={t('trip.edit.saveA11y')}
-                accessibilityState={{ disabled: busy }}
-                disabled={busy}
-                onPress={commitDistance}
-                hitSlop={6}
-                style={{ padding: theme.spacing.sm, opacity: busy ? 0.4 : 1 }}
-              >
-                <Check color={theme.colors.brandFill} size={22} />
-              </Pressable>
-              <Pressable
-                accessibilityRole="button"
-                accessibilityLabel={t('trip.edit.cancelA11y')}
-                onPress={() => setEditingDistance(false)}
-                hitSlop={6}
-                style={{ padding: theme.spacing.sm }}
-              >
-                <X color={theme.colors.mutedForeground} size={22} />
-              </Pressable>
-            </View>
-          ) : (
-            <View style={{ flexDirection: 'row', alignItems: 'center', gap: theme.spacing.sm }}>
-              <EditChip
-                icon={<Pencil color={theme.colors.accentBrand} size={14} />}
-                label={t('trip.blocks.distanceKm', {
-                  distance: Math.round(stage.distance ?? 0),
-                })}
-                a11yLabel={t('trip.edit.editDistanceA11y', { day })}
-                onPress={startEditDistance}
-                disabled={busy}
-              />
-            </View>
-          )}
-        </View>
-      ) : null}
     </View>
   );
 }

--- a/mobile/src/components/trip/StageCard.tsx
+++ b/mobile/src/components/trip/StageCard.tsx
@@ -5,10 +5,8 @@ import type { StageData } from '@btp/core';
 import {
   AlertTriangle,
   Check,
-  Coffee,
   CloudSun,
   Pencil,
-  Plus,
   Trash2,
   X,
 } from '../ui/icons';
@@ -44,9 +42,6 @@ interface StageCardProps {
   // dispatch the same insert/edit twice (#1044 review).
   busy?: boolean;
   onDelete: (index: number) => void;
-  // Insert a manual stage / rest day after this row (routing vs non-routing).
-  onAddStage?: (index: number) => void;
-  onAddRestDay?: (index: number) => void;
   // Commit an edited distance (km) for this stage; the backend re-splits and
   // streams the authoritative stages over SSE.
   onEditDistance?: (index: number, distanceKm: number) => void;
@@ -125,8 +120,6 @@ export function StageCard({
   outOfZone = false,
   busy = false,
   onDelete,
-  onAddStage,
-  onAddRestDay,
   onEditDistance,
   date = null,
   isToday = false,
@@ -141,6 +134,16 @@ export function StageCard({
   const heading = date
     ? formatStageDate(date, i18n.language)
     : t('trip.day', { day: stage.dayNumber ?? '?' });
+  // Route title: both endpoints when known, else whichever single label is
+  // resolved, else fall back to the day label — never the "? → ?" placeholder
+  // when nothing is resolved yet.
+  const routeLabel =
+    stage.startLabel && stage.endLabel
+      ? `${stage.startLabel} → ${stage.endLabel}`
+      : (stage.startLabel ??
+        stage.endLabel ??
+        stage.label ??
+        t('trip.day', { day }));
 
   // Belt-and-suspenders to the stable FlatList key: if the underlying stage this
   // row renders changes identity (a position shift reused the instance, or SSE
@@ -155,8 +158,7 @@ export function StageCard({
   // Distance re-splitting reroutes → hidden out of zone and on a rest day (0 km).
   const canEditDistance =
     !locked && !!onEditDistance && !stage.isRestDay && !outOfZone;
-  const showFooter =
-    !locked && (!!onAddStage || !!onAddRestDay || canEditDistance);
+  const showFooter = canEditDistance;
 
   function startEditDistance(): void {
     setDraft(String(Math.round(stage.distance ?? 0)));
@@ -253,7 +255,7 @@ export function StageCard({
                 flexShrink: 1,
               }}
             >
-              {stage.startLabel ?? '?'} → {stage.endLabel ?? stage.label ?? '?'}
+              {routeLabel}
             </Text>
             {isToday ? (
               <Text
@@ -397,35 +399,15 @@ export function StageCard({
             </View>
           ) : (
             <View style={{ flexDirection: 'row', alignItems: 'center', gap: theme.spacing.sm }}>
-              {onAddStage ? (
-                <EditChip
-                  icon={<Plus color={theme.colors.accentBrand} size={14} />}
-                  label={t('trip.edit.addStage')}
-                  a11yLabel={t('trip.edit.addStageA11y', { day })}
-                  onPress={() => onAddStage(index)}
-                  disabled={outOfZone || busy}
-                />
-              ) : null}
-              {onAddRestDay ? (
-                <EditChip
-                  icon={<Coffee color={theme.colors.accentBrand} size={14} />}
-                  label={t('trip.edit.addRestDay')}
-                  a11yLabel={t('trip.edit.addRestDayA11y', { day })}
-                  onPress={() => onAddRestDay(index)}
-                  disabled={busy}
-                />
-              ) : null}
-              {canEditDistance ? (
-                <EditChip
-                  icon={<Pencil color={theme.colors.accentBrand} size={14} />}
-                  label={t('trip.blocks.distanceKm', {
-                    distance: Math.round(stage.distance ?? 0),
-                  })}
-                  a11yLabel={t('trip.edit.editDistanceA11y', { day })}
-                  onPress={startEditDistance}
-                  disabled={busy}
-                />
-              ) : null}
+              <EditChip
+                icon={<Pencil color={theme.colors.accentBrand} size={14} />}
+                label={t('trip.blocks.distanceKm', {
+                  distance: Math.round(stage.distance ?? 0),
+                })}
+                a11yLabel={t('trip.edit.editDistanceA11y', { day })}
+                onPress={startEditDistance}
+                disabled={busy}
+              />
             </View>
           )}
         </View>

--- a/mobile/src/components/trip/StageCard.tsx
+++ b/mobile/src/components/trip/StageCard.tsx
@@ -62,16 +62,14 @@ export function StageCard({
   const heading = date
     ? formatStageDate(date, i18n.language)
     : t('trip.day', { day: stage.dayNumber ?? '?' });
-  // Route title: both endpoints when known, else whichever single label is
-  // resolved, else fall back to the day label — never the "? → ?" placeholder
-  // when nothing is resolved yet.
+  // Route title = the stage's places (start → end), per 05-trip-roadbook. The day
+  // lives in the left badge (`heading`), so the title never repeats "Jour N": when
+  // no label is resolved yet (labels are reverse-geocoded async, ResolveStageLabels)
+  // it degrades to a neutral em-dash, not the day.
   const routeLabel =
     stage.startLabel && stage.endLabel
       ? `${stage.startLabel} → ${stage.endLabel}`
-      : (stage.startLabel ??
-        stage.endLabel ??
-        stage.label ??
-        t('trip.day', { day }));
+      : (stage.startLabel ?? stage.endLabel ?? stage.label ?? '—');
 
   const alertCount = stage.alerts?.length ?? 0;
 

--- a/mobile/src/components/trip/StageDetailView.tsx
+++ b/mobile/src/components/trip/StageDetailView.tsx
@@ -23,7 +23,7 @@ import {
   X,
 } from '../ui/icons';
 import { TripMap } from '../TripMap';
-import { alertSegmentToCoords, collectMarkers } from '../map/map-utils';
+import { alertSegmentToCoords, buildStageLines, collectMarkers } from '../map/map-utils';
 import { ElevationProfile } from './ElevationProfile';
 import { ExportButton } from './ExportButton';
 import { StageDataBlocks, notifyFailure } from './StageDataBlocks';
@@ -99,6 +99,12 @@ export function StageDetailView({ initialIndex }: { initialIndex: number }) {
 
   const coordinates = useMemo(
     () => (stage ? stageGeometryCoords(stage) : []),
+    [stage],
+  );
+  // One colored line for this stage, keyed on its dayNumber, so its color
+  // matches the trip map's stage coloring (see stageColor).
+  const stageSegments = useMemo(
+    () => (stage ? buildStageLines([stage]) : []),
     [stage],
   );
   const markers = useMemo(() => (stage ? collectMarkers([stage]) : []), [stage]);
@@ -232,7 +238,7 @@ export function StageDetailView({ initialIndex }: { initialIndex: number }) {
       <View style={{ height: 220 }}>
         {coordinates.length > 0 ? (
           <TripMap
-            coordinates={coordinates}
+            stageSegments={stageSegments}
             markers={markers}
             highlightedSegment={highlightedSegment}
           />

--- a/mobile/src/components/trip/StageDetailView.tsx
+++ b/mobile/src/components/trip/StageDetailView.tsx
@@ -23,7 +23,8 @@ import {
   X,
 } from '../ui/icons';
 import { TripMap } from '../TripMap';
-import { alertSegmentToCoords, buildStageLines, collectMarkers } from '../map/map-utils';
+import { alertSegmentToCoords, collectMarkers } from '../map/map-utils';
+import { stageColor } from '../map/stage-colors';
 import { ElevationProfile } from './ElevationProfile';
 import { ExportButton } from './ExportButton';
 import { StageDataBlocks, notifyFailure } from './StageDataBlocks';
@@ -102,10 +103,15 @@ export function StageDetailView({ initialIndex }: { initialIndex: number }) {
     [stage],
   );
   // One colored line for this stage, keyed on its dayNumber, so its color
-  // matches the trip map's stage coloring (see stageColor).
+  // matches the trip map's stage coloring (see stageColor). Built directly
+  // (not via buildStageLines, which drops rest days for the multi-stage
+  // overview map) so a rest day's own point(s) still render here.
   const stageSegments = useMemo(
-    () => (stage ? buildStageLines([stage]) : []),
-    [stage],
+    () =>
+      stage && coordinates.length >= 2
+        ? [{ color: stageColor(stage.dayNumber ?? 0), coordinates }]
+        : [],
+    [stage, coordinates],
   );
   const markers = useMemo(() => (stage ? collectMarkers([stage]) : []), [stage]);
   const profileIndex = useMemo(

--- a/mobile/src/components/trip/StageInsertRow.test.tsx
+++ b/mobile/src/components/trip/StageInsertRow.test.tsx
@@ -1,0 +1,77 @@
+/// <reference types="jest" />
+import TestRenderer, { act } from 'react-test-renderer';
+import type { ReactElement } from 'react';
+import i18n from '../../i18n';
+import { fr } from '../../i18n/resources/fr';
+import { StageInsertRow } from './StageInsertRow';
+
+function render(element: ReactElement): any {
+  let out: any;
+  act(() => {
+    out = TestRenderer.create(element);
+  });
+  return out;
+}
+
+function byLabel(tree: any, label: string): any {
+  const found = tree.root.findAll(
+    (n: any) => n.props.accessibilityLabel === label,
+  );
+  return found[0] ?? null;
+}
+
+const addStageA11y = (day: number) =>
+  fr.trip.edit.addStageA11y.replace('{{day}}', String(day));
+const addRestDayA11y = (day: number) =>
+  fr.trip.edit.addRestDayA11y.replace('{{day}}', String(day));
+
+describe('StageInsertRow', () => {
+  beforeAll(async () => {
+    await i18n.changeLanguage('fr');
+  });
+
+  it('calls onAddStage / onAddRestDay with the boundary index', () => {
+    const onAddStage = jest.fn();
+    const onAddRestDay = jest.fn();
+    const tree = render(
+      <StageInsertRow
+        afterIndex={2}
+        day={3}
+        onAddStage={onAddStage}
+        onAddRestDay={onAddRestDay}
+      />,
+    );
+    act(() => byLabel(tree, addStageA11y(3)).props.onPress());
+    act(() => byLabel(tree, addRestDayA11y(3)).props.onPress());
+    expect(onAddStage).toHaveBeenCalledWith(2);
+    expect(onAddRestDay).toHaveBeenCalledWith(2);
+  });
+
+  it('disables ＋étape out of zone but keeps ＋repos enabled', () => {
+    const tree = render(
+      <StageInsertRow
+        afterIndex={0}
+        day={1}
+        outOfZone
+        onAddStage={jest.fn()}
+        onAddRestDay={jest.fn()}
+      />,
+    );
+    expect(byLabel(tree, addStageA11y(1)).props.accessibilityState.disabled).toBe(true);
+    expect(byLabel(tree, addRestDayA11y(1)).props.accessibilityState.disabled).toBe(false);
+  });
+
+  it('disables both pills while a mutation is in flight', () => {
+    const tree = render(
+      <StageInsertRow
+        afterIndex={0}
+        day={1}
+        busy
+        onAddStage={jest.fn()}
+        onAddRestDay={jest.fn()}
+      />,
+    );
+    expect(byLabel(tree, addStageA11y(1)).props.accessibilityState.disabled).toBe(true);
+    expect(byLabel(tree, addRestDayA11y(1)).props.accessibilityState.disabled).toBe(true);
+  });
+});

--- a/mobile/src/components/trip/StageInsertRow.tsx
+++ b/mobile/src/components/trip/StageInsertRow.tsx
@@ -1,0 +1,111 @@
+import { type ReactNode } from 'react';
+import { Pressable, Text, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { Coffee, Plus } from '../ui/icons';
+import { useTheme } from '../../theme';
+
+interface StageInsertRowProps {
+  // Insert after this stage index (matches mutations.addStage / insertRestDay).
+  afterIndex: number;
+  // Day number of the preceding stage, for the a11y labels ("... après le jour N").
+  day: number;
+  // A manual stage is routed via Valhalla → +étape disabled out of zone.
+  outOfZone?: boolean;
+  // A mutation for this boundary is in flight: both pills disabled.
+  busy?: boolean;
+  onAddStage: (afterIndex: number) => void;
+  onAddRestDay: (afterIndex: number) => void;
+}
+
+// A single accent-bordered pill used in the insertion row.
+function InsertPill({
+  icon,
+  label,
+  a11yLabel,
+  onPress,
+  disabled,
+}: {
+  icon: ReactNode;
+  label: string;
+  a11yLabel: string;
+  onPress: () => void;
+  disabled: boolean;
+}) {
+  const theme = useTheme();
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={a11yLabel}
+      accessibilityState={{ disabled }}
+      disabled={disabled}
+      onPress={onPress}
+      hitSlop={6}
+      style={{
+        flex: 1,
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: theme.spacing.xs,
+        borderWidth: 1,
+        borderColor: theme.colors.accentBrand,
+        backgroundColor: theme.colors.accentSoft,
+        borderRadius: theme.radius.full,
+        paddingHorizontal: theme.spacing.md,
+        paddingVertical: theme.spacing.sm,
+        opacity: disabled ? 0.4 : 1,
+      }}
+    >
+      {icon}
+      <Text
+        style={{
+          color: theme.colors.accentInk,
+          fontFamily: theme.fonts.sansMedium,
+          fontSize: 13,
+        }}
+      >
+        {label}
+      </Text>
+    </Pressable>
+  );
+}
+
+// The "＋ Étape / ＋ Jour de repos" insertion row rendered between roadbook stages
+// (maquette 05 `.insert`). Replaces the per-card add pills so a rider inserts at
+// a boundary, not "after a card". Hidden by RoadbookView when the trip is
+// read-only (started / ongoing / past).
+export function StageInsertRow({
+  afterIndex,
+  day,
+  outOfZone = false,
+  busy = false,
+  onAddStage,
+  onAddRestDay,
+}: StageInsertRowProps) {
+  const { t } = useTranslation();
+  const theme = useTheme();
+  return (
+    <View
+      style={{
+        flexDirection: 'row',
+        gap: theme.spacing.sm,
+        marginHorizontal: theme.spacing.base,
+        marginBottom: theme.spacing.md,
+      }}
+    >
+      <InsertPill
+        icon={<Plus color={theme.colors.accentBrand} size={14} />}
+        label={t('trip.edit.addStage')}
+        a11yLabel={t('trip.edit.addStageA11y', { day })}
+        onPress={() => onAddStage(afterIndex)}
+        disabled={outOfZone || busy}
+      />
+      <InsertPill
+        icon={<Coffee color={theme.colors.accentBrand} size={14} />}
+        label={t('trip.edit.addRestDay')}
+        a11yLabel={t('trip.edit.addRestDayA11y', { day })}
+        onPress={() => onAddRestDay(afterIndex)}
+        disabled={busy}
+      />
+    </View>
+  );
+}

--- a/mobile/src/components/trip/TripMapView.test.tsx
+++ b/mobile/src/components/trip/TripMapView.test.tsx
@@ -7,6 +7,14 @@ import '../../i18n';
 import { useTripStore } from '../../store/trip-store';
 import { collectMarkers } from '../map/map-utils';
 
+// Drive the safe-area insets so the layout test can assert the bottom inset is
+// folded into the profile panel's padding (keeping the axis clear of the system
+// navigation bar). Overrides the global zero-inset mock from jest.setup.
+const mockInsets = { top: 0, bottom: 0, left: 0, right: 0 };
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => mockInsets,
+}));
+
 // Capture the props TripMap receives so we can assert the wired markers +
 // highlightedSegment.
 let lastTripMapProps: Record<string, unknown> | null = null;
@@ -105,6 +113,44 @@ describe('TripMapView', () => {
     render(<TripMapView />);
     expect(lastTripMapProps).not.toBeNull();
     expect(lastTripMapProps!.markers).toEqual(collectMarkers([routedStage]));
+  });
+
+  it('forwards one colored stage segment per drawable stage to TripMap', () => {
+    render(<TripMapView />);
+    const segments = lastTripMapProps!.stageSegments as {
+      color: string;
+      coordinates: [number, number][];
+    }[];
+    expect(segments).toHaveLength(1);
+    expect(segments[0]!.coordinates).toEqual([
+      [2, 48],
+      [2.01, 48.01],
+      [2.02, 48.02],
+    ]);
+    expect(segments[0]!.color).toMatch(/^hsl\(/);
+  });
+
+  it('lays out map + profile without a ScrollView and clears the nav bar with the bottom inset', () => {
+    mockInsets.bottom = 34;
+    render(<TripMapView />);
+    // No ScrollView anywhere: the axis must never be scrolled out of view.
+    expect(
+      current!.root.findAll((n: any) => n.type === 'ScrollView'),
+    ).toHaveLength(0);
+    // The profile panel folds the safe-area bottom inset into its padding so the
+    // distance/elevation axis sits above the system navigation bar.
+    const flatten = (style: unknown): Record<string, unknown> =>
+      (Array.isArray(style) ? style : [style])
+        .filter((s) => s && typeof s === 'object')
+        .reduce((acc, s) => Object.assign(acc, s), {} as Record<string, unknown>);
+    const panel = current!.root.findAll(
+      (n: any) => n.type === 'View' && flatten(n.props.style).borderTopColor,
+    )[0]!;
+    const style = flatten(panel.props.style);
+    // paddingBottom = spacing.base + inset(34); proving the inset is added means
+    // it must exceed the inset alone.
+    expect(style.paddingBottom as number).toBeGreaterThan(34);
+    mockInsets.bottom = 0;
   });
 
   it('feeds the profile hover into TripMap as highlightedSegment', () => {

--- a/mobile/src/components/trip/TripMapView.tsx
+++ b/mobile/src/components/trip/TripMapView.tsx
@@ -1,11 +1,11 @@
 import { useMemo, useState } from 'react';
-import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import { profileHighlightSegment } from '@btp/core/elevation';
 import { EmptyState } from '../ui';
-import { Bike } from '../ui/icons';
 import { TripMap } from '../TripMap';
-import { collectMarkers } from '../map/map-utils';
+import { buildStageLines, collectMarkers } from '../map/map-utils';
 import { ElevationProfile } from './ElevationProfile';
 import { computeProfileSummary, groupThousands } from './trip-map-summary';
 import { useTheme } from '../../theme';
@@ -17,26 +17,21 @@ import { useTripRoute } from '../../hooks/use-trip-route';
 // no geometry yet. #1040 adds base-map toggle, markers and fit-bounds; #1041
 // stacks the elevation profile below and shares the hover state so a touch on the
 // profile surlines the matching stretch on the map. The Spike-UX restyle frames
-// the map full-bleed with a fixed bottom profile panel and a floating ride CTA.
+// the map full-bleed with a fixed bottom profile panel (in-ride CTA lives on the
+// Roadbook tab, not here).
 export function TripMapView() {
   // The summary omits geometry (ADR-057); pull the route in so the map has a line.
   useTripRoute();
   const theme = useTheme();
+  const insets = useSafeAreaInsets();
   const { t } = useTranslation();
   const stages = useTripStore((s) => s.stages);
   const [hover, setHover] = useState<{ coordIndex: number; stageIndex: number } | null>(
     null,
   );
 
-  const coordinates = useMemo<[number, number][]>(() => {
-    const coords: [number, number][] = [];
-    for (const stage of stages) {
-      for (const point of stage.geometry ?? []) {
-        coords.push([point.lon, point.lat]);
-      }
-    }
-    return coords;
-  }, [stages]);
+  // One colored polyline per stage so each stage is visually distinct on the map.
+  const stageSegments = useMemo(() => buildStageLines(stages), [stages]);
 
   const markers = useMemo(() => collectMarkers(stages), [stages]);
 
@@ -50,30 +45,23 @@ export function TripMapView() {
     [hover, stages],
   );
 
-  if (coordinates.length === 0) {
+  if (stageSegments.length === 0) {
     return <EmptyState title={t('trip.mapEmpty')} />;
   }
   return (
     <View style={styles.container}>
       <View style={styles.map}>
         <TripMap
-          coordinates={coordinates}
+          stageSegments={stageSegments}
           markers={markers}
           highlightedSegment={highlightedSegment}
         />
-        {/* In-ride FAB: the in-ride screen is out of scope (Sprint 58), so this is
-            a deliberate placeholder — disabled, icon-only, dispatches nothing,
-            like the roadbook FAB. */}
-        <Pressable
-          accessibilityRole="button"
-          accessibilityLabel={t('trip.map.rideCta')}
-          accessibilityState={{ disabled: true }}
-          disabled
-          style={[styles.fab, { backgroundColor: theme.colors.brand }, theme.shadows.medium]}
-        >
-          <Bike size={22} color={theme.colors.primaryForeground} />
-        </Pressable>
       </View>
+      {/* Fixed bottom profile panel: the map (flex:1) takes the remaining height
+          and the panel keeps its intrinsic height (title + SVG + axis), so map +
+          profile + axis always fit without a ScrollView. The safe-area bottom
+          inset is added to the padding so the distance/elevation axis is never
+          hidden under the system navigation bar. */}
       <View
         style={[
           styles.profile,
@@ -82,7 +70,7 @@ export function TripMapView() {
             borderTopColor: theme.colors.border,
             paddingHorizontal: theme.spacing.base,
             paddingTop: theme.spacing.md,
-            paddingBottom: theme.spacing.base,
+            paddingBottom: theme.spacing.base + insets.bottom,
             gap: theme.spacing.sm,
           },
         ]}
@@ -150,16 +138,6 @@ export function TripMapView() {
 const styles = StyleSheet.create({
   container: { flex: 1 },
   map: { flex: 1 },
-  fab: {
-    position: 'absolute',
-    right: 12,
-    bottom: 12,
-    width: 52,
-    height: 52,
-    alignItems: 'center',
-    justifyContent: 'center',
-    borderRadius: 999,
-  },
   profile: { borderTopWidth: StyleSheet.hairlineWidth },
   profileHeader: {
     flexDirection: 'row',

--- a/mobile/src/components/trip/index.ts
+++ b/mobile/src/components/trip/index.ts
@@ -1,4 +1,5 @@
 export { StageCard } from './StageCard';
+export { StageInsertRow } from './StageInsertRow';
 export { SseStatusIndicator } from './SseStatusIndicator';
 export { DataBlock } from './DataBlock';
 export { AlertsBlock } from './AlertsBlock';

--- a/mobile/src/components/trip/roadbook-edit.test.tsx
+++ b/mobile/src/components/trip/roadbook-edit.test.tsx
@@ -95,8 +95,10 @@ describe('RoadbookView inline edit wiring (#1044)', () => {
         stages: [stage(1), stage(2)],
         isLocked: false,
         outOfZone: false,
-        startDate: '2026-08-01',
-        endDate: '2026-08-02',
+        // Undated trip → lifecycle is "unknown", so the roadbook stays editable
+        // regardless of the (real) run date; the insertion rows are rendered.
+        startDate: null,
+        endDate: null,
         loading: false,
       });
     });

--- a/mobile/src/components/trip/roadbook-edit.test.tsx
+++ b/mobile/src/components/trip/roadbook-edit.test.tsx
@@ -2,7 +2,7 @@
 import TestRenderer, { act } from 'react-test-renderer';
 import { EMPTY_RESUPPLY } from '@btp/core';
 import type { ReactElement } from 'react';
-import { Alert, TextInput } from 'react-native';
+import { Alert } from 'react-native';
 import type { StageData } from '@btp/core';
 import i18n from '../../i18n';
 import { useTripStore } from '../../store/trip-store';
@@ -26,7 +26,7 @@ jest.mock('../../api/trips', () => ({
   deleteTrip: jest.fn(),
 }));
 
-import { createStage, insertRestDay, updateStageDistance } from '../../api/trips';
+import { createStage, insertRestDay } from '../../api/trips';
 import { RoadbookView } from './RoadbookView';
 
 const mock = <T extends (...args: never[]) => unknown>(fn: T) =>
@@ -75,7 +75,6 @@ function press(tree: any, label: string): void {
 }
 
 const restDayA11y = () => i18n.t('trip.edit.addRestDayA11y', { day: 1 });
-const distanceA11y = () => i18n.t('trip.edit.editDistanceA11y', { day: 1 });
 const addStageA11y = () => i18n.t('trip.edit.addStageA11y', { day: 1 });
 
 describe('RoadbookView inline edit wiring (#1044)', () => {
@@ -198,57 +197,4 @@ describe('RoadbookView inline edit wiring (#1044)', () => {
     expect(createStage).toHaveBeenCalledTimes(1);
   });
 
-  it('commits an inline distance edit to the API', async () => {
-    mock(updateStageDistance).mockResolvedValue({ ok: true, status: 202 });
-    const tree = render(<RoadbookView id="t1" />);
-
-    press(tree, distanceA11y());
-    const input = tree.root.find(
-      (n: any) => n.props.accessibilityLabel === distanceA11y() && 'value' in n.props,
-    );
-    act(() => input.props.onChangeText('88'));
-    press(tree, i18n.t('trip.edit.saveA11y'));
-
-    await act(async () => {});
-    expect(updateStageDistance).toHaveBeenCalledWith('t1', 0, 88);
-  });
-
-  // An open distance editor must never survive a structural shift bound to a
-  // different stage: with an index-based FlatList key React would reuse the row
-  // instance and the stale draft would commit onto the stage that slid into that
-  // position. Reproduce the shift and assert the editor is torn down (#1044).
-  it('tears down an open distance editor when a stage is inserted before it', () => {
-    const pA = { lat: 48.0, lon: 2.0, ele: 0 };
-    const pB = { lat: 48.5, lon: 2.5, ele: 0 };
-    const pC = { lat: 49.0, lon: 3.0, ele: 0 };
-    const contiguous = (dayNumber: number, start: typeof pA, end: typeof pA) => ({
-      ...stage(dayNumber),
-      startPoint: start,
-      endPoint: end,
-    });
-    act(() => {
-      useTripStore.setState({
-        stages: [contiguous(1, pA, pB), contiguous(2, pB, pC)],
-      });
-    });
-    const tree = render(<RoadbookView id="t1" />);
-
-    // Open the distance editor on the second stage (day 2) and stage a value.
-    const editX = i18n.t('trip.edit.editDistanceA11y', { day: 2 });
-    press(tree, editX);
-    const input = tree.root.findByType(TextInput);
-    act(() => input.props.onChangeText('999'));
-    expect(tree.root.findAllByType(TextInput)).toHaveLength(1);
-
-    // A manual stage inserted before it (placeholder spans the pB boundary)
-    // slides the edited stage down a row.
-    act(() =>
-      useTripStore.getState().insertStageOptimistic(0, contiguous(0, pB, pB)),
-    );
-
-    expect(useTripStore.getState().stages).toHaveLength(3);
-    // The stale editor is gone: no mounted distance input remains, so '999'
-    // can no longer be committed onto the wrong stage.
-    expect(tree.root.findAllByType(TextInput)).toHaveLength(0);
-  });
 });

--- a/mobile/src/components/trip/roadbook-edit.test.tsx
+++ b/mobile/src/components/trip/roadbook-edit.test.tsx
@@ -105,6 +105,19 @@ describe('RoadbookView inline edit wiring (#1044)', () => {
 
   afterEach(() => alertSpy.mockRestore());
 
+  it('renders an insertion row between stages but never after the last one', () => {
+    const tree = render(<RoadbookView id="t1" />);
+    const addStageCount = (day: number) =>
+      tree.root.findAll(
+        (n: any) =>
+          n.props.accessibilityLabel === i18n.t('trip.edit.addStageA11y', { day }) &&
+          typeof n.props.onPress === 'function',
+      ).length;
+    // Two stages → one insertion row (after day 1); nothing past the destination.
+    expect(addStageCount(1)).toBe(1);
+    expect(addStageCount(2)).toBe(0);
+  });
+
   it('applies a rest-day insertion optimistically and calls the API', async () => {
     mock(insertRestDay).mockResolvedValue({ ok: true, status: 202 });
     const tree = render(<RoadbookView id="t1" />);

--- a/mobile/src/components/trip/roadbook-ui.test.tsx
+++ b/mobile/src/components/trip/roadbook-ui.test.tsx
@@ -87,14 +87,6 @@ describe('StageCard dates', () => {
   });
 });
 
-function pressableByLabel(tree: any, label: string): any {
-  return tree.root.find(
-    (node: any) =>
-      node.props.accessibilityLabel === label &&
-      typeof node.props.onPress === 'function',
-  );
-}
-
 function queryByLabel(tree: any, label: string): any {
   const found = tree.root.findAll(
     (node: any) => node.props.accessibilityLabel === label,
@@ -102,26 +94,29 @@ function queryByLabel(tree: any, label: string): any {
   return found[0] ?? null;
 }
 
-describe('StageCard inline edit controls (#1044)', () => {
-  const handlers = () => ({
-    onEditDistance: jest.fn(),
-  });
-
-  it('hides every edit control (including delete) when locked', () => {
-    const h = handlers();
+// The roadbook row is a summary: it taps through to the stage detail (where the
+// distance edit lives, #1045) and only keeps the delete action. No inline edit
+// affordance renders on the card itself.
+describe('StageCard row affordances', () => {
+  it('hides the delete action when locked', () => {
     const tree = render(
-      <StageCard stage={stage()} index={0} locked onDelete={jest.fn()} {...h} />,
+      <StageCard stage={stage()} index={0} locked onDelete={jest.fn()} />,
     );
     expect(queryByLabel(tree, fr.trip.deleteA11y.replace('{{day}}', '1'))).toBeNull();
-    expect(
-      queryByLabel(tree, fr.trip.edit.editDistanceA11y.replace('{{day}}', '1')),
-    ).toBeNull();
   });
 
-  it('hides the distance chip out of zone', () => {
-    const h = handlers();
+  it('shows the delete action when editable', () => {
     const tree = render(
-      <StageCard stage={stage()} index={0} locked={false} outOfZone onDelete={jest.fn()} {...h} />,
+      <StageCard stage={stage()} index={0} locked={false} onDelete={jest.fn()} />,
+    );
+    expect(
+      queryByLabel(tree, fr.trip.deleteA11y.replace('{{day}}', '1')),
+    ).not.toBeNull();
+  });
+
+  it('never renders a distance-edit affordance on the card', () => {
+    const tree = render(
+      <StageCard stage={stage()} index={0} locked={false} onDelete={jest.fn()} />,
     );
     expect(
       queryByLabel(tree, fr.trip.edit.editDistanceA11y.replace('{{day}}', '1')),
@@ -144,60 +139,6 @@ describe('StageCard inline edit controls (#1044)', () => {
     expect(joined).not.toContain('?');
     // Falls back to the day label for the route title.
     expect(joined).toContain('Jour 1');
-  });
-
-  it('hides the distance chip on a rest day', () => {
-    const h = handlers();
-    const tree = render(
-      <StageCard
-        stage={stage({ isRestDay: true })}
-        index={0}
-        locked={false}
-        onDelete={jest.fn()}
-        {...h}
-      />,
-    );
-    expect(
-      queryByLabel(tree, fr.trip.edit.editDistanceA11y.replace('{{day}}', '1')),
-    ).toBeNull();
-  });
-
-  it('edits distance inline: pencil → input → save calls onEditDistance(km)', () => {
-    const h = handlers();
-    const tree = render(
-      <StageCard
-        stage={stage({ distance: 50 })}
-        index={0}
-        locked={false}
-        onDelete={jest.fn()}
-        {...h}
-      />,
-    );
-    const distA11y = fr.trip.edit.editDistanceA11y.replace('{{day}}', '1');
-    act(() => pressableByLabel(tree, distA11y).props.onPress());
-    // The input is seeded with the current rounded distance.
-    const input = queryByLabel(tree, distA11y);
-    expect(input.props.value).toBe('50');
-    act(() => input.props.onChangeText('72'));
-    act(() => pressableByLabel(tree, fr.trip.edit.saveA11y).props.onPress());
-    expect(h.onEditDistance).toHaveBeenCalledWith(0, 72);
-  });
-
-  it('keeps the editor open and does not commit an invalid or empty distance', () => {
-    const h = handlers();
-    const tree = render(
-      <StageCard stage={stage({ distance: 50 })} index={0} locked={false} onDelete={jest.fn()} {...h} />,
-    );
-    const distA11y = fr.trip.edit.editDistanceA11y.replace('{{day}}', '1');
-    act(() => pressableByLabel(tree, distA11y).props.onPress());
-    act(() => queryByLabel(tree, distA11y).props.onChangeText('abc'));
-    act(() => pressableByLabel(tree, fr.trip.edit.saveA11y).props.onPress());
-    expect(h.onEditDistance).not.toHaveBeenCalled();
-    // The editor stays open (the input is still mounted) so the edit is not lost.
-    const input = queryByLabel(tree, distA11y);
-    expect(input).not.toBeNull();
-    expect('value' in input.props).toBe(true);
-    expect(input.props.value).toBe('abc');
   });
 });
 

--- a/mobile/src/components/trip/roadbook-ui.test.tsx
+++ b/mobile/src/components/trip/roadbook-ui.test.tsx
@@ -104,8 +104,6 @@ function queryByLabel(tree: any, label: string): any {
 
 describe('StageCard inline edit controls (#1044)', () => {
   const handlers = () => ({
-    onAddStage: jest.fn(),
-    onAddRestDay: jest.fn(),
     onEditDistance: jest.fn(),
   });
 
@@ -116,41 +114,36 @@ describe('StageCard inline edit controls (#1044)', () => {
     );
     expect(queryByLabel(tree, fr.trip.deleteA11y.replace('{{day}}', '1'))).toBeNull();
     expect(
-      queryByLabel(tree, fr.trip.edit.addStageA11y.replace('{{day}}', '1')),
-    ).toBeNull();
-    expect(
-      queryByLabel(tree, fr.trip.edit.addRestDayA11y.replace('{{day}}', '1')),
+      queryByLabel(tree, fr.trip.edit.editDistanceA11y.replace('{{day}}', '1')),
     ).toBeNull();
   });
 
-  it('calls onAddStage / onAddRestDay with the row index when tapped', () => {
-    const h = handlers();
-    const tree = render(
-      <StageCard stage={stage()} index={2} locked={false} onDelete={jest.fn()} {...h} />,
-    );
-    act(() =>
-      pressableByLabel(tree, fr.trip.edit.addStageA11y.replace('{{day}}', '1')).props.onPress(),
-    );
-    act(() =>
-      pressableByLabel(tree, fr.trip.edit.addRestDayA11y.replace('{{day}}', '1')).props.onPress(),
-    );
-    expect(h.onAddStage).toHaveBeenCalledWith(2);
-    expect(h.onAddRestDay).toHaveBeenCalledWith(2);
-  });
-
-  it('disables ＋étape and hides the distance chip out of zone, keeps ＋repos', () => {
+  it('hides the distance chip out of zone', () => {
     const h = handlers();
     const tree = render(
       <StageCard stage={stage()} index={0} locked={false} outOfZone onDelete={jest.fn()} {...h} />,
     );
-    const addStage = queryByLabel(tree, fr.trip.edit.addStageA11y.replace('{{day}}', '1'));
-    expect(addStage.props.accessibilityState.disabled).toBe(true);
     expect(
       queryByLabel(tree, fr.trip.edit.editDistanceA11y.replace('{{day}}', '1')),
     ).toBeNull();
-    expect(
-      queryByLabel(tree, fr.trip.edit.addRestDayA11y.replace('{{day}}', '1')),
-    ).not.toBeNull();
+  });
+
+  it('never renders the "? → ?" placeholder when no labels are resolved', () => {
+    const t = texts(
+      render(
+        <StageCard
+          stage={stage({ startLabel: null, endLabel: null, label: null })}
+          index={0}
+          locked={false}
+          onDelete={jest.fn()}
+        />,
+      ),
+    );
+    const joined = t.join(' ');
+    expect(joined).not.toContain('? → ?');
+    expect(joined).not.toContain('?');
+    // Falls back to the day label for the route title.
+    expect(joined).toContain('Jour 1');
   });
 
   it('hides the distance chip on a rest day', () => {

--- a/mobile/src/i18n/resources/en.ts
+++ b/mobile/src/i18n/resources/en.ts
@@ -288,6 +288,7 @@ export const en: typeof fr = {
       locked: 'Trip started: read-only.',
       outOfZone: 'Route outside the covered area.',
       noDates: 'Set your trip dates.',
+      noDatesA11y: 'Set the trip dates',
     },
     delete: 'Delete',
     deleteA11y: 'Delete day {{day}}',

--- a/mobile/src/i18n/resources/fr.ts
+++ b/mobile/src/i18n/resources/fr.ts
@@ -287,6 +287,7 @@ export const fr = {
       locked: 'Voyage démarré : lecture seule.',
       outOfZone: 'Itinéraire hors de la zone couverte.',
       noDates: 'Définissez les dates de votre voyage.',
+      noDatesA11y: 'Définir les dates du voyage',
     },
     delete: 'Supprimer',
     deleteA11y: 'Supprimer le jour {{day}}',

--- a/mobile/src/lib/swipe.test.ts
+++ b/mobile/src/lib/swipe.test.ts
@@ -1,0 +1,23 @@
+/// <reference types="jest" />
+import { swipeToView } from './swipe';
+
+describe('swipeToView', () => {
+  it('selects the map on a decisive left swipe', () => {
+    expect(swipeToView(-80)).toBe('map');
+  });
+
+  it('selects the roadbook on a decisive right swipe', () => {
+    expect(swipeToView(80)).toBe('roadbook');
+  });
+
+  it('does nothing below the threshold', () => {
+    expect(swipeToView(-10)).toBeNull();
+    expect(swipeToView(10)).toBeNull();
+    expect(swipeToView(0)).toBeNull();
+  });
+
+  it('honours a custom threshold', () => {
+    expect(swipeToView(30, 20)).toBe('roadbook');
+    expect(swipeToView(30, 60)).toBeNull();
+  });
+});

--- a/mobile/src/lib/swipe.ts
+++ b/mobile/src/lib/swipe.ts
@@ -1,0 +1,15 @@
+// Pure decision for the roadbook/map horizontal swipe: a decisive left swipe
+// (negative dx) selects the map, a decisive right swipe (positive dx) selects
+// the roadbook, anything shorter than the threshold does nothing. Extracted so
+// the gesture wiring stays declarative and the mapping is unit-testable without
+// PanResponder's touch-history internals.
+export type SwipeView = 'roadbook' | 'map';
+
+export function swipeToView(
+  dx: number,
+  threshold = 48,
+): SwipeView | null {
+  if (dx <= -threshold) return 'map';
+  if (dx >= threshold) return 'roadbook';
+  return null;
+}


### PR DESCRIPTION
Passe de conformité UX mobile trouvée en QA device, contre les maquettes Claude Design 04/05/06. Stacked sur #1140 (fix menu ⋮, même écran). **Vérifiée sur device Android** (screenshots à l'appui).

## Liste des voyages (04-trips-list)
- Item restructuré en **carte verticale** : thumbnail pleine largeur en haut (tracé + badge statut bas-gauche + actions dupliquer/supprimer haut-droite), titre + meta (« {dates} · N étapes · km ») dessous.

## Écran voyage — chargement + roadbook (05 / 05a / 05e / 05f)
- **Header masqué au chargement** (plus de « trip/[id]/index » brut ; `headerShown:false` pendant loading/error, spinner plein écran).
- **Espace titre ↔ onglets réduit** (onglets Roadbook/Carte ergonomiquement sous le header).
- **« ? → ? » retiré** : la carte d'étape affiche les lieux si connus, sinon le libellé du jour.
- **Pills « ＋ Étape / ＋ Jour de repos » entre chaque étape** (extraites en `StageInsertRow`).
- **Alerte « Définissez les dates » cliquable** → ouvre la config sur la section dates (`ConfigSheet initialSection="dates"`).
- **Lecture seule en cours/passé** (05e/05f) : insertion/suppression/FAB masqués si le voyage est en cours ou passé (réutilise le lock backend + statut dates).
- **FAB in-ride seulement sur Roadbook** (retiré de la Carte).
- **Swipe horizontal** Roadbook ⇄ Carte (`PanResponder`, sans nouvelle dépendance).
- **Édition de distance retirée de la carte** (doublon du KPI) : elle vit désormais uniquement sur le **détail de l'étape** (#1045). Carte = tap-through + suppression.

## Carte (06-trip-map)
- **Couleurs par étape** (teinte angle-d'or ancrée sur l'orange de marque) : voisines contrastées même sur voyage long ; carte + profil altimétrique alignés.
- **Layout sans scroll** : carte + panneau profil/axe à hauteur fixe, axe visible au-dessus de la barre système (`useSafeAreaInsets`), plus de scroll qui masque l'axe.

## Vérification
typecheck mobile vert ; **461 tests jest verts** (en série) ; QA device sur les 5 écrans (liste, chargement, roadbook, carte, swipe). Aucune dépendance ajoutée.

## Note merge
Base `fix/trip-menu-overlap` (#1140). Consolide 3 branches de travail (ux-list / ux-roadbook / ux-map) mergées sans conflit (fichiers disjoints).

<!-- claude-review-start -->
## Claude Review

**Summary:** Focused mobile-only UX conformance pass (maquettes 04/05/06): trip-list card restructuring, roadbook header/swipe/dates deep-link, per-stage map + elevation-profile coloring, insertion-row extraction, and distance-edit removal from the roadbook card. No blocking findings — the rest-day map regression flagged by the previous review round (stale `buildStageLines` reuse in `StageDetailView`) is fixed correctly in the latest commit (`ab63a444`), and the elevation-profile per-stage coloring correctly mirrors the map's rest-day-filtered stage indexing (verified against `core/elevation.ts`). Good, focused test coverage for every new behavior.

**Resolved threads:** Resolved 1 previously open thread (rest-day map visibility) that was addressed by commit `ab63a444`.

**PR title check:** minor — "trip UX pass — list/roadbook/map conformance (04/05/06)" reads as a noun phrase rather than imperative mood (e.g. "align trip UX with maquettes 04/05/06"). Not blocking.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

**Commit reviewed:** `ab63a444ff449513485382191ed579526c3a0581`
<!-- claude-review-end -->