### PR TITLE
feat(mobile): offline foundation + cache (epic #1052) — NetInfo, freshness, ADR-059

### DIFF
--- a/docs/adr/adr-059-mobile-offline-auto-sync.md
+++ b/docs/adr/adr-059-mobile-offline-auto-sync.md
@@ -64,10 +64,12 @@ The connectivity flag stays in its own single-purpose store, separate from the
 trip store, so it survives trip switches and is readable from the mutation
 runners with no trip loaded — consistent with ADR-055's split of transient
 device state from trip state. The freshness helper is a pure `lib` function like
-`dates.ts`: no store coupling, injectable clock, fully testable. Persistence of
-the cached trips themselves is deliberately **not** decided here (it is #1147);
-this ADR only guarantees the store API and the freshness contract those tickets
-build on.
+`dates.ts`: no store coupling, injectable clock, fully testable. This ADR fixes
+the store API and the freshness contract; the persistence of the cached trips
+themselves is implemented by #1147 (expo-file-system) and the offline map
+degradation by #1148, both building on this foundation. The three land together
+as epic #1052 (the sub-tickets share the `feature/1146` base), so a reader of the
+merged history sees the whole offline engine, not just the contract.
 
 ## Alternatives considered
 

--- a/docs/adr/adr-059-mobile-offline-auto-sync.md
+++ b/docs/adr/adr-059-mobile-offline-auto-sync.md
@@ -18,8 +18,8 @@ a screen load with no network simply fails.
 
 We need to decide **what** is cached, **how fresh** the rider is told the cache
 is, **when** it syncs, and **how much** offline surface the app exposes — before
-building the persistence (#1147), the sync engine (#1148), and the offline map
-degradation (#1149) on top. This ADR fixes those boundaries and lands the first
+building the persistence (#1147), the sync engine (#1147), and the offline map
+degradation (#1148) on top. This ADR fixes those boundaries and lands the first
 brick: real connectivity feeding the store.
 
 ## Decision
@@ -51,12 +51,12 @@ is not a user-managed feature.
   `isInternetReachable`, emitted while NetInfo is still probing, is treated as
   online so the mutation gate does not flap). The store keeps its stable API
   (`isOnline` / `setOnline`) and stays transport-agnostic: no cache logic lives in
-  it, so #1147/#1148/#1149 consume the same store without reshaping it.
+  it, so #1147/#1148 consume the same store without reshaping it.
 - **Offline map is degraded, not interactive.** With no network the map shows the
   **route trace and the elevation profile** from cached data; it does **not**
   serve interactive raster/vector tiles (no pan-to-load, no satellite layer). Tile
   caching is out of scope — the rider gets orientation, not a full basemap. Full
-  degradation mechanics are #1149.
+  degradation mechanics are #1148.
 
 ## State architecture fit (ADR-055)
 
@@ -98,7 +98,7 @@ merged history sees the whole offline engine, not just the contract.
   the jest suite (no test imports it).
 - The offline perimeter (non-past trips), the freshness contract (pure helper +
   `freshness.*` i18n keys), and the stable `offline-store` API are now fixed
-  points that #1147 (persistence), #1148 (background sync), and #1149 (offline
+  points that #1147 (persistence), #1147 (background sync), and #1148 (offline
   map) build on without renegotiation.
 - Offline map is trace + profile only; a full offline basemap remains out of
   scope.

--- a/docs/adr/adr-059-mobile-offline-auto-sync.md
+++ b/docs/adr/adr-059-mobile-offline-auto-sync.md
@@ -94,8 +94,8 @@ merged history sees the whole offline engine, not just the contract.
   (`offline` reason) instead of hitting the network and failing — the intended
   Sprint 55 behaviour finally has an input.
 - A new mobile dependency (`@react-native-community/netinfo`, SDK-57 aligned) is
-  added; CI gates mobile on tsc + jest only, and the listener is not exercised by
-  the jest suite (no test imports it).
+  added; CI gates mobile on tsc + jest only. The NetInfo → `isOnline` mapping is
+  covered by `mobile/src/store/use-connectivity.test.ts` (3-state + cleanup).
 - The offline perimeter (non-past trips), the freshness contract (pure helper +
   `freshness.*` i18n keys), and the stable `offline-store` API are now fixed
   points that #1147 (persistence), #1147 (background sync), and #1148 (offline

--- a/docs/adr/adr-059-mobile-offline-auto-sync.md
+++ b/docs/adr/adr-059-mobile-offline-auto-sync.md
@@ -1,0 +1,102 @@
+# ADR-059: Mobile Offline Auto-Sync
+
+- **Status:** Accepted
+- **Date:** 2026-08-21
+- **Depends on:** ADR-053 (Mobile Strategy — Dedicated Native App), ADR-055 (Mobile State Architecture), #1040 (Mobile map), Sprint 55 (Trip consultation)
+
+## Context and Problem Statement
+
+A bikepacker consults the roadbook where there is no signal: a col, a forest, a
+foreign SIM with no data. The native app (ADR-053) must therefore show an
+upcoming or in-progress trip — stages, elevation profile, weather, accommodation,
+map trace — with the device fully offline, and reconcile silently when
+connectivity returns. Today the consultation stack (Sprint 55) is online-only:
+`mobile/src/store/offline-store.ts` exposes `isOnline` / `setOnline` and the
+mutation gate (`mobile/src/store/gating.ts`) already refuses edits while offline,
+but nothing feeds the flag — it is hardcoded `true`, so the gate never fires and
+a screen load with no network simply fails.
+
+We need to decide **what** is cached, **how fresh** the rider is told the cache
+is, **when** it syncs, and **how much** offline surface the app exposes — before
+building the persistence (#1147), the sync engine (#1148), and the offline map
+degradation (#1149) on top. This ADR fixes those boundaries and lands the first
+brick: real connectivity feeding the store.
+
+## Decision
+
+Offline is **automatic and invisible**: the app caches the trips that matter,
+syncs them in the background, and tells the rider only how fresh the data is. It
+is not a user-managed feature.
+
+- **Cache perimeter = upcoming and in-progress trips only.** Past trips are
+  **online-only**. A rider needs offline data for the trip they are about to ride
+  or are riding, never for an archive; bounding the cache to non-past trips keeps
+  device storage predictable and the sync set small. A trip transitioning to past
+  drops out of the cache on the next sync.
+- **Freshness is surfaced, not managed.** Each cached trip carries a last-sync
+  timestamp, rendered as a relative "synchronised X ago" label
+  (`mobile/src/lib/freshness.ts`: "à l'instant" / "il y a N h" / "hier" /
+  "il y a N j"). The helper is **pure** — the reference `now` is injected, never
+  read from `Date.now()` internally — so the buckets are deterministic and unit
+  tested. This is the only offline status the rider sees.
+- **Background sync, no manual control.** Syncing is a background concern; there
+  is **no** "download for offline", "cached" toggle, or manual pin in the UI. The
+  rider never decides what is offline — the perimeter rule does. This keeps the
+  consultation UI (Sprint 55) unchanged for the online case.
+- **Real connectivity into the existing store.** `offline-store` is wired to
+  `@react-native-community/netinfo`: a boot-time listener
+  (`mobile/src/store/use-connectivity.ts`, mounted in `app/_layout.tsx` with
+  cleanup on unmount) maps NetInfo state to the flag —
+  `isConnected === true && isInternetReachable !== false` (a `null`
+  `isInternetReachable`, emitted while NetInfo is still probing, is treated as
+  online so the mutation gate does not flap). The store keeps its stable API
+  (`isOnline` / `setOnline`) and stays transport-agnostic: no cache logic lives in
+  it, so #1147/#1148/#1149 consume the same store without reshaping it.
+- **Offline map is degraded, not interactive.** With no network the map shows the
+  **route trace and the elevation profile** from cached data; it does **not**
+  serve interactive raster/vector tiles (no pan-to-load, no satellite layer). Tile
+  caching is out of scope — the rider gets orientation, not a full basemap. Full
+  degradation mechanics are #1149.
+
+## State architecture fit (ADR-055)
+
+The connectivity flag stays in its own single-purpose store, separate from the
+trip store, so it survives trip switches and is readable from the mutation
+runners with no trip loaded — consistent with ADR-055's split of transient
+device state from trip state. The freshness helper is a pure `lib` function like
+`dates.ts`: no store coupling, injectable clock, fully testable. Persistence of
+the cached trips themselves is deliberately **not** decided here (it is #1147);
+this ADR only guarantees the store API and the freshness contract those tickets
+build on.
+
+## Alternatives considered
+
+- **Cache every trip, including past ones.** Rejected: unbounded device storage
+  for data a rider will almost never open offline. Non-past trips are the only set
+  with an offline use case; the perimeter rule is the storage bound.
+- **A manual "make available offline" toggle per trip.** Rejected: it pushes a
+  storage-management chore onto the rider and contradicts the "invisible offline"
+  goal. The perimeter rule decides automatically; freshness is the only surfaced
+  signal.
+- **Absolute last-sync timestamp ("synchronised at 14:32").** Rejected in favour
+  of a relative label: "il y a 3 h" answers "can I trust this?" without the rider
+  doing date arithmetic, and reads correctly across timezones while travelling.
+- **Offline interactive tiles (bundled or cached basemap).** Rejected for this
+  epic: the storage and licensing cost of a tile cache dwarfs the value of a
+  trace and profile for orientation. Revisit if riders ask for a real offline
+  basemap.
+
+## Consequences
+
+- The mutation gate now fires for real: with the device offline, edits are refused
+  (`offline` reason) instead of hitting the network and failing — the intended
+  Sprint 55 behaviour finally has an input.
+- A new mobile dependency (`@react-native-community/netinfo`, SDK-57 aligned) is
+  added; CI gates mobile on tsc + jest only, and the listener is not exercised by
+  the jest suite (no test imports it).
+- The offline perimeter (non-past trips), the freshness contract (pure helper +
+  `freshness.*` i18n keys), and the stable `offline-store` API are now fixed
+  points that #1147 (persistence), #1148 (background sync), and #1149 (offline
+  map) build on without renegotiation.
+- Offline map is trace + profile only; a full offline basemap remains out of
+  scope.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -139,6 +139,7 @@ nav:
       - adr/adr-056-mercure-header-auth-non-browser.md
       - adr/adr-057-progressive-trip-loading.md
       - adr/adr-058-push-fcm.md
+      - adr/adr-059-mobile-offline-auto-sync.md
   - Runbooks:
       - runbooks/README.md
       - runbooks/severity-levels.md

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import '../src/i18n';
 import { AuthProvider } from '../src/auth/store';
 import { usePushRouting } from '../src/notifications/use-push-routing';
+import { useConnectivity } from '../src/store/use-connectivity';
 import { ThemeProvider, useTheme } from '../src/theme';
 
 function RootNavigator() {
@@ -11,6 +12,8 @@ function RootNavigator() {
   const theme = useTheme();
   // Route notification taps (warm + cold start) to the concerned screen (#1125).
   usePushRouting();
+  // Feed real NetInfo connectivity into the offline store / mutation gate (#1146).
+  useConnectivity();
   return (
     <Stack
       // The header integrates with the theme (light/dark) instead of the default

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import '../src/i18n';
 import { AuthProvider } from '../src/auth/store';
 import { usePushRouting } from '../src/notifications/use-push-routing';
+import { useBackgroundTripSync } from '../src/hooks/use-background-sync';
 import { useConnectivity } from '../src/store/use-connectivity';
 import { ThemeProvider, useTheme } from '../src/theme';
 
@@ -14,6 +15,8 @@ function RootNavigator() {
   usePushRouting();
   // Feed real NetInfo connectivity into the offline store / mutation gate (#1146).
   useConnectivity();
+  // Keep the offline trip cache fresh on return-to-online / app foreground (#1147).
+  useBackgroundTripSync();
   return (
     <Stack
       // The header integrates with the theme (light/dark) instead of the default

--- a/mobile/app/trip/[id]/index.test.tsx
+++ b/mobile/app/trip/[id]/index.test.tsx
@@ -1,0 +1,78 @@
+/// <reference types="jest" />
+import TestRenderer, { act } from 'react-test-renderer';
+import { Text } from 'react-native';
+import i18n from '../../../src/i18n';
+import { useTripStore } from '../../../src/store/trip-store';
+import TripRoadbook from './index';
+
+jest.mock('expo-router', () => ({
+  Stack: { Screen: () => null },
+  useLocalSearchParams: () => ({ id: 'trip-1' }),
+  useRouter: () => ({ back: jest.fn(), push: jest.fn() }),
+}));
+
+jest.mock('../../../src/hooks/use-trip-live', () => ({ useTripLive: jest.fn() }));
+
+jest.mock('../../../src/components/trip', () => ({
+  ConfigSheet: () => null,
+  RoadbookView: () => null,
+  ShareSheet: () => null,
+  SseStatusIndicator: () => null,
+  TripMapView: () => null,
+  TripTitleHeader: () => null,
+}));
+
+jest.mock('../../../src/store/trip-cache', () => ({ readTripCache: jest.fn() }));
+import { readTripCache } from '../../../src/store/trip-cache';
+const mockReadCache = readTripCache as jest.MockedFunction<typeof readTripCache>;
+
+function texts(node: any): string[] {
+  return node.root.findAllByType(Text).flatMap((t: any) => {
+    const kids = Array.isArray(t.props.children) ? t.props.children : [t.props.children];
+    return kids.filter((c: unknown): c is string => typeof c === 'string');
+  });
+}
+
+async function render(): Promise<any> {
+  let tree!: ReturnType<typeof TestRenderer.create>;
+  await act(async () => {
+    tree = TestRenderer.create(<TripRoadbook />);
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  return tree;
+}
+
+beforeAll(async () => {
+  await i18n.changeLanguage('fr');
+});
+
+beforeEach(() => {
+  mockReadCache.mockReset();
+  useTripStore.setState({
+    title: 'Traversée des Alpes',
+    computing: false,
+    loading: false,
+    error: null,
+  });
+});
+
+describe('TripRoadbook screen — synced freshness badge (#1147)', () => {
+  it('shows the "synced X ago" badge when the cache has a syncedAt', async () => {
+    mockReadCache.mockResolvedValue({
+      detail: { title: 'Traversée des Alpes' },
+      route: null,
+      syncedAt: Date.now(),
+    } as never);
+
+    const tree = await render();
+    expect(texts(tree).some((label) => label.startsWith('Synchronisé'))).toBe(true);
+  });
+
+  it('hides the badge when the cache resolves without a syncedAt (cache miss)', async () => {
+    mockReadCache.mockResolvedValue(null);
+
+    const tree = await render();
+    expect(texts(tree).some((label) => label.startsWith('Synchronisé'))).toBe(false);
+  });
+});

--- a/mobile/app/trip/[id]/index.tsx
+++ b/mobile/app/trip/[id]/index.tsx
@@ -1,5 +1,5 @@
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
-import { type ReactNode, useMemo, useState } from 'react';
+import { type ReactNode, useEffect, useMemo, useState } from 'react';
 import { Alert, Modal, PanResponder, Pressable, Text, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
@@ -33,6 +33,8 @@ import { useTripLive } from '../../../src/hooks/use-trip-live';
 import { useTripMutations } from '../../../src/hooks/use-trip-mutations';
 import type { MutationFailure } from '../../../src/store/gating';
 import { useTripStore } from '../../../src/store/trip-store';
+import { readTripCache } from '../../../src/store/trip-cache';
+import { formatFreshness } from '../../../src/lib/freshness';
 import { swipeToView } from '../../../src/lib/swipe';
 
 type TripView = 'roadbook' | 'map';
@@ -120,6 +122,20 @@ export default function TripRoadbook() {
   const computing = useTripStore((s) => s.computing);
   const loading = useTripStore((s) => s.loading);
   const error = useTripStore((s) => s.error);
+
+  // Offline "synced X ago" indicator (#1147): read the cache timestamp once the
+  // trip has loaded (a fresh online load has just re-stamped it).
+  const [syncedAt, setSyncedAt] = useState<number | null>(null);
+  useEffect(() => {
+    if (loading) return;
+    let cancelled = false;
+    void readTripCache(id).then((cached) => {
+      if (!cancelled) setSyncedAt(cached?.syncedAt ?? null);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [id, loading]);
 
   const onFailure = (reason: MutationFailure) =>
     Alert.alert(t('common.error'), t(`trip.edit.reason.${reason}`));
@@ -211,6 +227,21 @@ export default function TripRoadbook() {
         }}
       >
         <SegmentedControl segments={segments} value={view} onChange={setView} />
+        {syncedAt !== null ? (
+          <Text
+            style={{
+              marginTop: theme.spacing.xs,
+              color: theme.colors.mutedForeground,
+              fontFamily: theme.fonts.sans,
+              fontSize: 12,
+              textAlign: 'center',
+            }}
+          >
+            {t('freshness.synced', {
+              ago: formatFreshness(t, syncedAt, Date.now()),
+            })}
+          </Text>
+        ) : null}
       </View>
 
       <View style={{ flex: 1 }} {...panResponder.panHandlers}>

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -9,6 +9,7 @@
     "@expo-google-fonts/jetbrains-mono": "^0.4.1",
     "@maplibre/maplibre-react-native": "^11.3.6",
     "@react-native-community/datetimepicker": "^9.1.0",
+    "@react-native-community/netinfo": "12.0.1",
     "expo": "~57.0.12",
     "expo-clipboard": "~57.0.1",
     "expo-constants": "~57.0.10",

--- a/mobile/src/components/TripMap.test.tsx
+++ b/mobile/src/components/TripMap.test.tsx
@@ -4,6 +4,7 @@ import type { ReactElement } from 'react';
 import * as SecureStore from 'expo-secure-store';
 import '../i18n';
 import { useMapPrefs } from '../store/map-prefs';
+import { useOfflineStore } from '../store/offline-store';
 import { TripMap } from './TripMap';
 import { computeBounds, POSITRON_STYLE_URL, type StageLine } from './map/map-utils';
 
@@ -66,6 +67,10 @@ beforeEach(() => {
   act(() => {
     useMapPrefs.setState({ base: 'map', hydrated: true });
   });
+  // Reset so an offline flip in one test never leaks into the next.
+  act(() => {
+    useOfflineStore.setState({ isOnline: true });
+  });
 });
 
 describe('TripMap', () => {
@@ -119,6 +124,48 @@ describe('TripMap', () => {
       'get',
       'color',
     ]);
+  });
+
+  it('degrades to the offline style when useOfflineStore flips offline, then restores online', () => {
+    const out = render(<TripMap stageSegments={segsA} />);
+    const style = () => findAll(out.root, 'Map')[0].props.mapStyle;
+    expect(style()).toBe(POSITRON_STYLE_URL);
+
+    act(() => {
+      useOfflineStore.setState({ isOnline: false });
+    });
+    // Tile-less offline style: no network sources, just a flat background layer.
+    expect(style()).toMatchObject({ sources: {}, layers: [{ type: 'background' }] });
+
+    act(() => {
+      useOfflineStore.setState({ isOnline: true });
+    });
+    expect(style()).toBe(POSITRON_STYLE_URL);
+  });
+
+  it('hides the layer toggle while offline (no tiles to switch)', () => {
+    // Offline, the map is stuck on the tile-less background style regardless of
+    // `base` (see the test above) — the pill would look interactive but do
+    // nothing, so it must not render at all while offline.
+    const out = render(<TripMap stageSegments={segsA} />);
+    const findToggle = () =>
+      out.root.findAll(
+        (n: any) =>
+          n.props.accessibilityRole === 'button' &&
+          n.props.accessibilityLabel === 'Satellite' &&
+          typeof n.props.onPress === 'function',
+      );
+    expect(findToggle()).toHaveLength(1);
+
+    act(() => {
+      useOfflineStore.setState({ isOnline: false });
+    });
+    expect(findToggle()).toHaveLength(0);
+
+    act(() => {
+      useOfflineStore.setState({ isOnline: true });
+    });
+    expect(findToggle()).toHaveLength(1);
   });
 
   it('draws one colored LineString feature per stage', () => {

--- a/mobile/src/components/TripMap.tsx
+++ b/mobile/src/components/TripMap.tsx
@@ -13,6 +13,7 @@ import { useTranslation } from 'react-i18next';
 import { Minus, Plus } from './ui/icons';
 import { useTheme } from '../theme/context';
 import { useMapPrefs } from '../store/map-prefs';
+import { useOfflineStore } from '../store/offline-store';
 import {
   applyZoom,
   computeBounds,
@@ -47,6 +48,7 @@ export function TripMap({
   const base = useMapPrefs((s) => s.base);
   const setBase = useMapPrefs((s) => s.setBase);
   const load = useMapPrefs((s) => s.load);
+  const isOnline = useOfflineStore((s) => s.isOnline);
   const mapRef = useRef<MapRef>(null);
   const cameraRef = useRef<CameraRef>(null);
 
@@ -65,7 +67,13 @@ export function TripMap({
   // Every object/collection handed to the memoized native components is derived
   // once per input change: a fresh reference on each render would defeat the
   // upstream React.memo (Map/Camera/GeoJSONSource) and force a native re-diff.
-  const mapStyle = useMemo(() => mapStyleFor(base), [base]);
+  // Offline: fall back to the tile-less style (theme neutral background) so the
+  // route + markers still render instead of a broken grid of failed tile
+  // requests; back online rebasculates to the normal tiled base.
+  const mapStyle = useMemo(
+    () => mapStyleFor(base, !isOnline, theme.colors.muted),
+    [base, isOnline, theme.colors.muted],
+  );
   const lineCoords = useMemo(
     () => stageSegments.flatMap((s) => s.coordinates),
     [stageSegments],
@@ -204,54 +212,56 @@ export function TripMap({
           <Minus size={20} color={theme.colors.foreground} />
         </Pressable>
       </View>
-      <View
-        accessibilityLabel={t('trip.map.toggleA11y')}
-        style={[
-          styles.layers,
-          {
-            backgroundColor: theme.colors.card,
-            borderColor: theme.colors.border,
-            ...theme.shadows.soft,
-          },
-        ]}
-      >
-        {(['map', 'satellite'] as const).map((layer) => {
-          const active = base === layer;
-          return (
-            <Pressable
-              key={layer}
-              accessibilityRole="button"
-              accessibilityState={{ selected: active }}
-              accessibilityLabel={
-                layer === 'map'
-                  ? t('trip.map.layerMap')
-                  : t('trip.map.layerSatellite')
-              }
-              onPress={() => setBase(layer)}
-              style={[
-                styles.layerSegment,
-                active && { backgroundColor: theme.colors.brand },
-              ]}
-            >
-              <Text
-                style={{
-                  color: active
-                    ? theme.colors.primaryForeground
-                    : theme.colors.foreground,
-                  fontFamily: active
-                    ? theme.fonts.sansSemibold
-                    : theme.fonts.sansMedium,
-                  fontSize: 13,
-                }}
+      {isOnline ? (
+        <View
+          accessibilityLabel={t('trip.map.toggleA11y')}
+          style={[
+            styles.layers,
+            {
+              backgroundColor: theme.colors.card,
+              borderColor: theme.colors.border,
+              ...theme.shadows.soft,
+            },
+          ]}
+        >
+          {(['map', 'satellite'] as const).map((layer) => {
+            const active = base === layer;
+            return (
+              <Pressable
+                key={layer}
+                accessibilityRole="button"
+                accessibilityState={{ selected: active }}
+                accessibilityLabel={
+                  layer === 'map'
+                    ? t('trip.map.layerMap')
+                    : t('trip.map.layerSatellite')
+                }
+                onPress={() => setBase(layer)}
+                style={[
+                  styles.layerSegment,
+                  active && { backgroundColor: theme.colors.brand },
+                ]}
               >
-                {layer === 'map'
-                  ? t('trip.map.layerMap')
-                  : t('trip.map.layerSatellite')}
-              </Text>
-            </Pressable>
-          );
-        })}
-      </View>
+                <Text
+                  style={{
+                    color: active
+                      ? theme.colors.primaryForeground
+                      : theme.colors.foreground,
+                    fontFamily: active
+                      ? theme.fonts.sansSemibold
+                      : theme.fonts.sansMedium,
+                    fontSize: 13,
+                  }}
+                >
+                  {layer === 'map'
+                    ? t('trip.map.layerMap')
+                    : t('trip.map.layerSatellite')}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+      ) : null}
     </View>
   );
 }

--- a/mobile/src/components/map/map-utils.test.ts
+++ b/mobile/src/components/map/map-utils.test.ts
@@ -1,9 +1,11 @@
 /// <reference types="jest" />
+import type { StyleSpecification } from '@maplibre/maplibre-react-native';
 import type { StageData } from '@btp/core';
 import { EMPTY_RESUPPLY } from '@btp/core';
 import {
   alertSegmentToCoords,
   applyZoom,
+  buildOfflineStyle,
   buildSatelliteStyle,
   buildStageLines,
   collectMarkers,
@@ -97,6 +99,40 @@ describe('buildSatelliteStyle / mapStyleFor', () => {
   it('returns the Positron URL for map and the satellite style object', () => {
     expect(mapStyleFor('map')).toBe(POSITRON_STYLE_URL);
     expect(typeof mapStyleFor('satellite')).toBe('object');
+  });
+
+  it('degrades offline to a tile-less style with no network source, whatever the base', () => {
+    for (const base of ['map', 'satellite'] as const) {
+      const style = mapStyleFor(base, true, '#123456');
+      expect(typeof style).toBe('object');
+      const spec = style as StyleSpecification;
+      // No tile source of any kind: nothing hits the network offline.
+      expect(spec.sources).toEqual({});
+      expect(spec.layers).toEqual([
+        { id: 'offline-background', type: 'background', paint: { 'background-color': '#123456' } },
+      ]);
+      // The Positron URL and the satellite raster tiles are both gone.
+      expect(JSON.stringify(spec)).not.toContain(SATELLITE_TILE_URL);
+      expect(JSON.stringify(spec)).not.toContain('cartocdn');
+    }
+  });
+
+  it('rebasculates to the tiled base once back online', () => {
+    expect(mapStyleFor('map', false, '#123456')).toBe(POSITRON_STYLE_URL);
+    const sat = mapStyleFor('satellite', false, '#123456') as StyleSpecification;
+    expect(sat.sources['esri-world-imagery']).toMatchObject({ type: 'raster' });
+  });
+});
+
+describe('buildOfflineStyle', () => {
+  it('paints only a background layer, keeping room for local GeoJSON sources', () => {
+    const style = buildOfflineStyle('#abcdef');
+    expect(style.sources).toEqual({});
+    expect(style.layers).toHaveLength(1);
+    expect(style.layers[0]).toMatchObject({
+      type: 'background',
+      paint: { 'background-color': '#abcdef' },
+    });
   });
 });
 

--- a/mobile/src/components/map/map-utils.ts
+++ b/mobile/src/components/map/map-utils.ts
@@ -33,7 +33,30 @@ export function buildSatelliteStyle(): StyleSpecification {
   };
 }
 
-export function mapStyleFor(base: MapBase): string | StyleSpecification {
+// Offline fallback style: a single flat background layer and no network tile
+// source, so the map still mounts and paints the local GeoJSON sources (route +
+// markers, added as children by TripMap) instead of a broken grey grid of failed
+// tile requests. `background` comes from the mobile theme (never a raw hex).
+export function buildOfflineStyle(background: string): StyleSpecification {
+  return {
+    version: 8,
+    sources: {},
+    layers: [
+      { id: 'offline-background', type: 'background', paint: { 'background-color': background } },
+    ],
+  };
+}
+
+// Resolve the MapLibre style for the current base. Offline (offline-store
+// isOnline === false) drops the network-tiled Positron/satellite bases for the
+// tile-less offline style; the local GeoJSON sources still render on top. Back
+// online rebasculates to the normal tiled style.
+export function mapStyleFor(
+  base: MapBase,
+  offline = false,
+  offlineBackground = 'transparent',
+): string | StyleSpecification {
+  if (offline) return buildOfflineStyle(offlineBackground);
   return base === 'satellite' ? buildSatelliteStyle() : POSITRON_STYLE_URL;
 }
 

--- a/mobile/src/components/trip/TripMapView.test.tsx
+++ b/mobile/src/components/trip/TripMapView.test.tsx
@@ -3,8 +3,9 @@ import TestRenderer, { act } from 'react-test-renderer';
 import { EMPTY_RESUPPLY } from '@btp/core';
 import type { ReactElement } from 'react';
 import type { StageData } from '@btp/core';
-import '../../i18n';
+import i18n from '../../i18n';
 import { useTripStore } from '../../store/trip-store';
+import { useOfflineStore } from '../../store/offline-store';
 import { collectMarkers } from '../map/map-utils';
 
 // Drive the safe-area insets so the layout test can assert the bottom inset is
@@ -99,6 +100,13 @@ describe('TripMapView', () => {
     act(() => {
       useTripStore.getState().reset();
       useTripStore.setState({ stages: [routedStage] });
+      useOfflineStore.setState({ isOnline: true });
+    });
+  });
+
+  afterAll(() => {
+    act(() => {
+      useOfflineStore.setState({ isOnline: true });
     });
   });
 
@@ -168,6 +176,24 @@ describe('TripMapView', () => {
       [2, 48],
       [2.01, 48.01],
     ]);
+  });
+
+  it('shows the offline map badge only when connectivity is down', () => {
+    const label = i18n.t('trip.map.offline');
+    const hasBadge = (root: any): boolean =>
+      root.findAll(
+        (n: any) =>
+          n.type === 'Text' &&
+          [].concat(n.props.children).join('') === label,
+      ).length > 0;
+
+    const online = render(<TripMapView />);
+    expect(hasBadge(online!.root)).toBe(false);
+
+    act(() => {
+      useOfflineStore.setState({ isOnline: false });
+    });
+    expect(hasBadge(online!.root)).toBe(true);
   });
 
   it('clears the highlight when the profile reports a release', () => {

--- a/mobile/src/components/trip/TripMapView.tsx
+++ b/mobile/src/components/trip/TripMapView.tsx
@@ -4,12 +4,14 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import { profileHighlightSegment } from '@btp/core/elevation';
 import { EmptyState } from '../ui';
+import { CloudOff } from '../ui/icons';
 import { TripMap } from '../TripMap';
 import { buildStageLines, collectMarkers } from '../map/map-utils';
 import { ElevationProfile } from './ElevationProfile';
 import { computeProfileSummary, groupThousands } from './trip-map-summary';
 import { useTheme } from '../../theme';
 import { useTripStore } from '../../store/trip-store';
+import { useOfflineStore } from '../../store/offline-store';
 import { useTripRoute } from '../../hooks/use-trip-route';
 
 // The map tab: derives the route polyline and markers from the store's stages
@@ -26,6 +28,7 @@ export function TripMapView() {
   const insets = useSafeAreaInsets();
   const { t } = useTranslation();
   const stages = useTripStore((s) => s.stages);
+  const isOnline = useOfflineStore((s) => s.isOnline);
   const [hover, setHover] = useState<{ coordIndex: number; stageIndex: number } | null>(
     null,
   );
@@ -56,6 +59,37 @@ export function TripMapView() {
           markers={markers}
           highlightedSegment={highlightedSegment}
         />
+        {/* Discrete "offline map" indicator: when connectivity drops, TripMap
+            degrades to the tile-less style (route + profile stay local); this
+            badge tells the rider why the base imagery is gone. */}
+        {!isOnline ? (
+          <View
+            pointerEvents="none"
+            accessibilityRole="text"
+            style={[
+              styles.offlineBadge,
+              {
+                backgroundColor: theme.colors.card,
+                borderColor: theme.colors.border,
+                paddingHorizontal: theme.spacing.sm,
+                paddingVertical: theme.spacing.xs,
+                gap: theme.spacing.xs,
+                ...theme.shadows.soft,
+              },
+            ]}
+          >
+            <CloudOff size={14} color={theme.colors.mutedForeground} />
+            <Text
+              style={{
+                color: theme.colors.mutedForeground,
+                fontFamily: theme.fonts.sansMedium,
+                fontSize: 12,
+              }}
+            >
+              {t('trip.map.offline')}
+            </Text>
+          </View>
+        ) : null}
       </View>
       {/* Fixed bottom profile panel: the map (flex:1) takes the remaining height
           and the panel keeps its intrinsic height (title + SVG + axis), so map +
@@ -138,6 +172,15 @@ export function TripMapView() {
 const styles = StyleSheet.create({
   container: { flex: 1 },
   map: { flex: 1 },
+  offlineBadge: {
+    position: 'absolute',
+    bottom: 12,
+    left: 12,
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderRadius: 999,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
   profile: { borderTopWidth: StyleSheet.hairlineWidth },
   profileHeader: {
     flexDirection: 'row',

--- a/mobile/src/components/ui/icons.ts
+++ b/mobile/src/components/ui/icons.ts
@@ -48,3 +48,5 @@ export {
 export { ShoppingBag } from 'lucide-react-native';
 // Notifications screen (#1120): permission banner + per-category icons.
 export { Bell, BellOff, CheckCircle2 } from 'lucide-react-native';
+// Offline map degradation (#1148): discrete "offline map" indicator.
+export { CloudOff } from 'lucide-react-native';

--- a/mobile/src/hooks/use-background-sync.test.ts
+++ b/mobile/src/hooks/use-background-sync.test.ts
@@ -1,0 +1,114 @@
+/// <reference types="jest" />
+import { createElement } from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { AppState } from 'react-native';
+import { useBackgroundTripSync } from './use-background-sync';
+import { useOfflineStore } from '../store/offline-store';
+
+jest.mock('../api/trips', () => ({ fetchTripDetail: jest.fn(), fetchTripRoute: jest.fn() }));
+jest.mock('../store/trip-cache', () => ({ syncCachedTrips: jest.fn() }));
+import { syncCachedTrips } from '../store/trip-cache';
+const mockSync = syncCachedTrips as jest.MockedFunction<typeof syncCachedTrips>;
+
+function Harness(): null {
+  useBackgroundTripSync();
+  return null;
+}
+
+const mounted: ReturnType<typeof TestRenderer.create>[] = [];
+
+async function mount(): Promise<{ unmount: () => void }> {
+  let renderer!: ReturnType<typeof TestRenderer.create>;
+  await act(async () => {
+    renderer = TestRenderer.create(createElement(Harness));
+  });
+  mounted.push(renderer);
+  return { unmount: () => act(() => renderer.unmount()) };
+}
+
+beforeEach(() => {
+  mockSync.mockClear();
+  mockSync.mockResolvedValue(undefined);
+  useOfflineStore.setState({ isOnline: true });
+});
+
+// Each test mounts its own Harness; unmount it so the next test's store
+// updates don't re-render a stale tree outside act().
+afterEach(() => {
+  act(() => {
+    mounted.splice(0).forEach((renderer) => renderer.unmount());
+  });
+});
+
+describe('useBackgroundTripSync (#1147)', () => {
+  it('re-syncs when isOnline flips false -> true', async () => {
+    useOfflineStore.setState({ isOnline: false });
+    await mount();
+    mockSync.mockClear();
+
+    await act(async () => {
+      useOfflineStore.setState({ isOnline: true });
+    });
+    expect(mockSync).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not re-sync when isOnline flips true -> false', async () => {
+    await mount();
+    mockSync.mockClear();
+
+    await act(async () => {
+      useOfflineStore.setState({ isOnline: false });
+    });
+    expect(mockSync).not.toHaveBeenCalled();
+  });
+
+  it('re-syncs when AppState becomes active', async () => {
+    let listener: (state: string) => void = () => {};
+    const addSpy = jest.spyOn(AppState, 'addEventListener').mockImplementation((_event, cb) => {
+      listener = cb as (state: string) => void;
+      return { remove: jest.fn() } as never;
+    });
+
+    await mount();
+    mockSync.mockClear();
+
+    await act(async () => {
+      listener('active');
+    });
+    expect(mockSync).toHaveBeenCalledTimes(1);
+
+    addSpy.mockRestore();
+  });
+
+  it('does not re-sync for other AppState transitions', async () => {
+    let listener: (state: string) => void = () => {};
+    const addSpy = jest.spyOn(AppState, 'addEventListener').mockImplementation((_event, cb) => {
+      listener = cb as (state: string) => void;
+      return { remove: jest.fn() } as never;
+    });
+
+    await mount();
+    mockSync.mockClear();
+
+    await act(async () => {
+      listener('background');
+    });
+    expect(mockSync).not.toHaveBeenCalled();
+
+    addSpy.mockRestore();
+  });
+
+  it('removes the AppState listener on unmount', async () => {
+    const removeSpy = jest.fn();
+    const addSpy = jest
+      .spyOn(AppState, 'addEventListener')
+      .mockImplementation(() => ({ remove: removeSpy }) as never);
+
+    const { unmount } = await mount();
+    expect(removeSpy).not.toHaveBeenCalled();
+    unmount();
+    expect(removeSpy).toHaveBeenCalledTimes(1);
+
+    addSpy.mockRestore();
+  });
+});

--- a/mobile/src/hooks/use-background-sync.ts
+++ b/mobile/src/hooks/use-background-sync.ts
@@ -1,0 +1,36 @@
+import { useEffect } from 'react';
+import { AppState } from 'react-native';
+import { fetchTripDetail, fetchTripRoute } from '../api/trips';
+import { useOfflineStore } from '../store/offline-store';
+import { syncCachedTrips } from '../store/trip-cache';
+
+// Real dependencies for the background re-sync. Built once: the fetchers are
+// stable module functions and `isOnline` reads the store lazily at call time.
+const deps = {
+  isOnline: () => useOfflineStore.getState().isOnline,
+  fetchDetail: fetchTripDetail,
+  fetchRoute: fetchTripRoute,
+};
+
+// Keep the offline cache of upcoming/ongoing trips fresh (#1147): silently
+// re-fetch every cached trip whenever the device comes back online or the app
+// returns to the foreground. No manual "offline mode" — this just tops up the
+// cache in the background. Wired once at boot in app/_layout.tsx.
+export function useBackgroundTripSync(): void {
+  const isOnline = useOfflineStore((s) => s.isOnline);
+
+  // Coming (back) online: refresh the cache. Also runs on mount when already
+  // online, seeding a fresh sync at launch.
+  useEffect(() => {
+    if (isOnline) void syncCachedTrips(deps);
+  }, [isOnline]);
+
+  // App returns to the foreground: the cache may be stale after time in the
+  // background. syncCachedTrips itself bails out when still offline.
+  useEffect(() => {
+    const sub = AppState.addEventListener('change', (state) => {
+      if (state === 'active') void syncCachedTrips(deps);
+    });
+    return () => sub.remove();
+  }, []);
+}

--- a/mobile/src/hooks/use-trip-detail.test.ts
+++ b/mobile/src/hooks/use-trip-detail.test.ts
@@ -1,18 +1,31 @@
 /// <reference types="jest" />
 import { runLoadTripDetail } from './use-trip-detail';
+import { useOfflineStore } from '../store/offline-store';
 
 jest.mock('../api/trips', () => ({ fetchTripDetail: jest.fn() }));
+jest.mock('../store/trip-cache', () => ({
+  cacheTripDetail: jest.fn(),
+  readTripCache: jest.fn(),
+}));
 import { fetchTripDetail } from '../api/trips';
+import { cacheTripDetail, readTripCache } from '../store/trip-cache';
 const mockDetail = fetchTripDetail as jest.MockedFunction<typeof fetchTripDetail>;
+const mockCache = cacheTripDetail as jest.MockedFunction<typeof cacheTripDetail>;
+const mockReadCache = readTripCache as jest.MockedFunction<typeof readTripCache>;
 
-beforeEach(() => jest.clearAllMocks());
+beforeEach(() => {
+  jest.clearAllMocks();
+  useOfflineStore.getState().setOnline(true);
+  mockReadCache.mockResolvedValue(null);
+});
 
 describe('runLoadTripDetail (#1031)', () => {
-  it('returns the detail on success', async () => {
+  it('returns the detail on success and refreshes the cache', async () => {
     mockDetail.mockResolvedValue({ title: 'Trip' } as never);
     const { detail, error } = await runLoadTripDetail('t1');
     expect(detail).toEqual({ title: 'Trip' });
     expect(error).toBeNull();
+    expect(mockCache).toHaveBeenCalledWith('t1', { title: 'Trip' });
   });
 
   it('reports "Voyage introuvable." when the detail is null', async () => {
@@ -22,9 +35,36 @@ describe('runLoadTripDetail (#1031)', () => {
     expect(error).toBe('Voyage introuvable.');
   });
 
-  it('reports a load error when the fetch throws', async () => {
+  it('reports a load error when the fetch throws and no cache exists', async () => {
     mockDetail.mockRejectedValue(new Error('boom'));
     const { error } = await runLoadTripDetail('t1');
     expect(error).toBe('Impossible de charger le voyage.');
+  });
+});
+
+describe('runLoadTripDetail offline cache (#1147)', () => {
+  it('serves the cache without hitting the network while offline', async () => {
+    useOfflineStore.getState().setOnline(false);
+    mockReadCache.mockResolvedValue({
+      detail: { title: 'Cached' },
+      route: null,
+      syncedAt: 1,
+    } as never);
+    const { detail, error } = await runLoadTripDetail('t1');
+    expect(detail).toEqual({ title: 'Cached' });
+    expect(error).toBeNull();
+    expect(mockDetail).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the cache when the network fetch fails', async () => {
+    mockDetail.mockRejectedValue(new Error('boom'));
+    mockReadCache.mockResolvedValue({
+      detail: { title: 'Cached' },
+      route: null,
+      syncedAt: 1,
+    } as never);
+    const { detail, error } = await runLoadTripDetail('t1');
+    expect(detail).toEqual({ title: 'Cached' });
+    expect(error).toBeNull();
   });
 });

--- a/mobile/src/hooks/use-trip-detail.ts
+++ b/mobile/src/hooks/use-trip-detail.ts
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { fetchTripDetail, type TripDetail } from '../api/trips';
+import { useOfflineStore } from '../store/offline-store';
+import { cacheTripDetail, readTripCache } from '../store/trip-cache';
 
 export interface TripDetailState {
   detail: TripDetail | null;
@@ -9,12 +11,23 @@ export interface TripDetailState {
 // Extracted for unit-testing the async/error branches (mirrors runTripLive).
 // One-shot fetch (no SSE): use it for a read-only preview; the live roadbook
 // hydration + Mercure subscription lives in useTripLive.
+//
+// Offline-aware (#1147): when the device is offline we serve the persisted cache
+// straight away, and a network failure falls back to it too. A successful online
+// load refreshes the cache (upcoming/ongoing trips only — see cacheTripDetail).
 export async function runLoadTripDetail(id: string): Promise<TripDetailState> {
+  if (!useOfflineStore.getState().isOnline) {
+    const cached = await readTripCache(id);
+    if (cached) return { detail: cached.detail, error: null };
+  }
   try {
     const detail = await fetchTripDetail(id);
     if (!detail) return { detail: null, error: 'Voyage introuvable.' };
+    void cacheTripDetail(id, detail);
     return { detail, error: null };
   } catch {
+    const cached = await readTripCache(id);
+    if (cached) return { detail: cached.detail, error: null };
     return { detail: null, error: 'Impossible de charger le voyage.' };
   }
 }

--- a/mobile/src/hooks/use-trip-live.test.ts
+++ b/mobile/src/hooks/use-trip-live.test.ts
@@ -6,19 +6,27 @@ import type { EnrichedStagePayload, MercureEvent } from '@btp/core/mercure';
 import { runTripLive, useTripLive } from './use-trip-live';
 import { useTripStore } from '../store/trip-store';
 import { useDismissedAlerts } from '../store/dismissed-alerts';
+import { useOfflineStore } from '../store/offline-store';
 
 jest.mock('../api/trips', () => ({ fetchTripDetail: jest.fn() }));
 jest.mock('../api/mercure', () => ({
   fetchMercureToken: jest.fn(),
   subscribeToTrip: jest.fn(),
 }));
+jest.mock('../store/trip-cache', () => ({
+  cacheTripDetail: jest.fn(),
+  readTripCache: jest.fn(),
+}));
 
 import { fetchTripDetail } from '../api/trips';
 import { fetchMercureToken, subscribeToTrip } from '../api/mercure';
+import { cacheTripDetail, readTripCache } from '../store/trip-cache';
 
 const mockDetail = fetchTripDetail as jest.MockedFunction<typeof fetchTripDetail>;
 const mockToken = fetchMercureToken as jest.MockedFunction<typeof fetchMercureToken>;
 const mockSubscribe = subscribeToTrip as jest.MockedFunction<typeof subscribeToTrip>;
+const mockCache = cacheTripDetail as jest.MockedFunction<typeof cacheTripDetail>;
+const mockReadCache = readTripCache as jest.MockedFunction<typeof readTripCache>;
 
 const A = { lat: 1, lon: 1, ele: 0 };
 const B = { lat: 2, lon: 2, ele: 0 };
@@ -47,6 +55,10 @@ function apiStage(overrides: Record<string, unknown> = {}) {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const detail = (stages: unknown[]) => ({ title: 'Trip', stages }) as any;
+// A cached entry wrapping the same /detail shape (#1147).
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const detailCache = (stages: unknown[]) =>
+  ({ detail: detail(stages), route: null, syncedAt: 1 }) as any;
 
 function enrichedPayload(): EnrichedStagePayload {
   return {
@@ -74,6 +86,8 @@ beforeEach(() => {
   jest.clearAllMocks();
   useTripStore.getState().reset();
   useDismissedAlerts.getState().reset();
+  useOfflineStore.getState().setOnline(true);
+  mockReadCache.mockResolvedValue(null);
 });
 
 describe('runTripLive orchestration (#1014)', () => {
@@ -156,6 +170,41 @@ describe('runTripLive orchestration (#1014)', () => {
   it('aborts before subscribing when cancelled during the /detail fetch', async () => {
     mockDetail.mockResolvedValue(detail([apiStage()]));
     const sub = await runTripLive('t1', store(), () => true);
+    expect(mockSubscribe).not.toHaveBeenCalled();
+    expect(sub).toBeUndefined();
+  });
+
+  it('caches the /detail payload after a successful online hydrate (#1147)', async () => {
+    mockDetail.mockResolvedValue(detail([apiStage()]));
+    mockToken.mockResolvedValue('jwt');
+    mockSubscribe.mockReturnValue({ close: jest.fn() });
+
+    await runTripLive('t1', store(), notCancelled);
+
+    expect(mockCache).toHaveBeenCalledWith('t1', expect.objectContaining({ title: 'Trip' }));
+  });
+
+  it('hydrates from cache and skips SSE while offline (#1147)', async () => {
+    useOfflineStore.getState().setOnline(false);
+    mockReadCache.mockResolvedValue(detailCache([apiStage()]));
+
+    const sub = await runTripLive('t1', store(), notCancelled);
+
+    expect(store().stages).toHaveLength(1);
+    expect(store().error).toBeNull();
+    expect(mockDetail).not.toHaveBeenCalled();
+    expect(mockSubscribe).not.toHaveBeenCalled();
+    expect(sub).toBeUndefined();
+  });
+
+  it('falls back to cache when /detail fails, without surfacing an error (#1147)', async () => {
+    mockDetail.mockRejectedValue(new Error('offline'));
+    mockReadCache.mockResolvedValue(detailCache([apiStage()]));
+
+    const sub = await runTripLive('t1', store(), notCancelled);
+
+    expect(store().stages).toHaveLength(1);
+    expect(store().error).toBeNull();
     expect(mockSubscribe).not.toHaveBeenCalled();
     expect(sub).toBeUndefined();
   });

--- a/mobile/src/hooks/use-trip-live.ts
+++ b/mobile/src/hooks/use-trip-live.ts
@@ -8,6 +8,8 @@ import {
 } from '../api/mercure';
 import { useTripStore } from '../store/trip-store';
 import { useDismissedAlerts } from '../store/dismissed-alerts';
+import { useOfflineStore } from '../store/offline-store';
+import { cacheTripDetail, readTripCache } from '../store/trip-cache';
 
 // The store actions the orchestration drives.
 export interface TripLiveStore {
@@ -32,13 +34,32 @@ export async function runTripLive(
 ): Promise<TripSubscription | undefined> {
   store.setStatus({ loading: true, error: null });
 
+  // Offline (#1147): hydrate straight from the persisted cache and skip the live
+  // subscription — no network means no /detail and no Mercure token. The route
+  // geometry is pulled separately by useTripRoute (also cache-aware).
+  if (!useOfflineStore.getState().isOnline) {
+    const cached = await readTripCache(id);
+    if (isCancelled()) return undefined;
+    if (cached) {
+      store.hydrate(id, cached.detail);
+      useDismissedAlerts.getState().reset();
+      return undefined;
+    }
+  }
+
   let detail;
   try {
     detail = await fetchTripDetail(id);
   } catch {
-    if (!isCancelled()) {
-      store.setStatus({ loading: false, error: 'Impossible de charger le roadbook.' });
+    // Network failure: fall back to the cache before surfacing an error.
+    const cached = await readTripCache(id);
+    if (isCancelled()) return undefined;
+    if (cached) {
+      store.hydrate(id, cached.detail);
+      useDismissedAlerts.getState().reset();
+      return undefined;
     }
+    store.setStatus({ loading: false, error: 'Impossible de charger le roadbook.' });
     return undefined;
   }
   if (isCancelled()) return undefined;
@@ -46,6 +67,7 @@ export async function runTripLive(
     store.setStatus({ loading: false, error: 'Voyage introuvable.' });
     return undefined;
   }
+  void cacheTripDetail(id, detail);
   store.hydrate(id, detail);
   // Alert dismissals are keyed on dayNumber:code, which collide across trips;
   // clear them when a new trip is loaded so a dismissal on one trip does not hide

--- a/mobile/src/hooks/use-trip-route.test.ts
+++ b/mobile/src/hooks/use-trip-route.test.ts
@@ -3,12 +3,20 @@ import { createElement } from 'react';
 import TestRenderer, { act } from 'react-test-renderer';
 import type { StageData } from '@btp/core';
 import { EMPTY_RESUPPLY } from '@btp/core';
-import { useTripRoute } from './use-trip-route';
+import { runLoadTripRoute, useTripRoute } from './use-trip-route';
 import { useTripStore } from '../store/trip-store';
+import { useOfflineStore } from '../store/offline-store';
 
 jest.mock('../api/trips', () => ({ fetchTripRoute: jest.fn() }));
+jest.mock('../store/trip-cache', () => ({
+  cacheTripRoute: jest.fn(),
+  readTripCache: jest.fn(),
+}));
 import { fetchTripRoute } from '../api/trips';
+import { cacheTripRoute, readTripCache } from '../store/trip-cache';
 const mockRoute = fetchTripRoute as jest.MockedFunction<typeof fetchTripRoute>;
+const mockCacheRoute = cacheTripRoute as jest.MockedFunction<typeof cacheTripRoute>;
+const mockReadCache = readTripCache as jest.MockedFunction<typeof readTripCache>;
 
 const A = { lat: 1, lon: 1, ele: 0 };
 const B = { lat: 2, lon: 2, ele: 0 };
@@ -57,6 +65,8 @@ async function render(options?: { enabled?: boolean }): Promise<void> {
 beforeEach(() => {
   jest.clearAllMocks();
   useTripStore.getState().reset();
+  useOfflineStore.getState().setOnline(true);
+  mockReadCache.mockResolvedValue(null);
 });
 
 afterEach(() => {
@@ -101,15 +111,45 @@ describe('useTripRoute (ADR-057)', () => {
     expect(mockRoute).not.toHaveBeenCalled();
   });
 
-  it('warns (but never throws) when the fetch fails', async () => {
-    const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+  it('leaves the geometry unloaded (never throws) when the fetch fails with no cache', async () => {
     useTripStore.setState({ tripId: 't1', geometryLoaded: false, loading: false });
     mockRoute.mockRejectedValue(new Error('boom'));
 
     await render();
 
-    expect(warn).toHaveBeenCalled();
     expect(store().geometryLoaded).toBe(false);
-    warn.mockRestore();
+  });
+
+  it('caches the route after a successful online fetch (#1147)', async () => {
+    useTripStore.setState({ tripId: 't1', geometryLoaded: false, loading: false });
+    const route = { id: 't1', stages: [{ dayNumber: 1, geometry: [] }] };
+    mockRoute.mockResolvedValue(route as never);
+
+    await render();
+
+    expect(mockCacheRoute).toHaveBeenCalledWith('t1', route);
+  });
+});
+
+describe('runLoadTripRoute offline cache (#1147)', () => {
+  const route = { id: 't1', stages: [{ dayNumber: 1, geometry: [] }] };
+
+  it('serves the cached tracé without hitting the network while offline', async () => {
+    useOfflineStore.getState().setOnline(false);
+    mockReadCache.mockResolvedValue({ detail: {}, route, syncedAt: 1 } as never);
+
+    const result = await runLoadTripRoute('t1');
+
+    expect(result).toEqual(route);
+    expect(mockRoute).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the cached tracé when the network fetch fails', async () => {
+    mockRoute.mockRejectedValue(new Error('boom'));
+    mockReadCache.mockResolvedValue({ detail: {}, route, syncedAt: 1 } as never);
+
+    const result = await runLoadTripRoute('t1');
+
+    expect(result).toEqual(route);
   });
 });

--- a/mobile/src/hooks/use-trip-route.test.ts
+++ b/mobile/src/hooks/use-trip-route.test.ts
@@ -114,10 +114,14 @@ describe('useTripRoute (ADR-057)', () => {
   it('leaves the geometry unloaded (never throws) when the fetch fails with no cache', async () => {
     useTripStore.setState({ tripId: 't1', geometryLoaded: false, loading: false });
     mockRoute.mockRejectedValue(new Error('boom'));
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
     await render();
 
     expect(store().geometryLoaded).toBe(false);
+    // A genuine failure (no cache to fall back to) keeps a diagnostic signal.
+    expect(warn).toHaveBeenCalledWith('Failed to load trip route geometry', expect.any(Error));
+    warn.mockRestore();
   });
 
   it('caches the route after a successful online fetch (#1147)', async () => {
@@ -147,9 +151,13 @@ describe('runLoadTripRoute offline cache (#1147)', () => {
   it('falls back to the cached tracé when the network fetch fails', async () => {
     mockRoute.mockRejectedValue(new Error('boom'));
     mockReadCache.mockResolvedValue({ detail: {}, route, syncedAt: 1 } as never);
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
     const result = await runLoadTripRoute('t1');
 
     expect(result).toEqual(route);
+    // Cache served the trace: this is not a genuine failure, no diagnostic.
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
   });
 });

--- a/mobile/src/hooks/use-trip-route.ts
+++ b/mobile/src/hooks/use-trip-route.ts
@@ -1,6 +1,27 @@
 import { useEffect } from 'react';
-import { fetchTripRoute } from '../api/trips';
+import { fetchTripRoute, type TripRoute } from '../api/trips';
 import { useTripStore } from '../store/trip-store';
+import { useOfflineStore } from '../store/offline-store';
+import { cacheTripRoute, readTripCache } from '../store/trip-cache';
+
+// Load the trip's route geometry (ADR-057), offline-aware (#1147): offline we
+// serve the cached tracé, and a network failure falls back to it too; a
+// successful online load refreshes the cache. Never throws — a miss just leaves
+// the map/profile empty (returns null). Extracted so the branches are testable.
+export async function runLoadTripRoute(id: string): Promise<TripRoute | null> {
+  if (!useOfflineStore.getState().isOnline) {
+    const cached = await readTripCache(id);
+    if (cached?.route) return cached.route;
+  }
+  try {
+    const route = await fetchTripRoute(id);
+    if (route) void cacheTripRoute(id, route);
+    return route;
+  } catch {
+    const cached = await readTripCache(id);
+    return cached?.route ?? null;
+  }
+}
 
 // Fetch the trip's route geometry once (ADR-057) and merge it into the store's
 // stages. The summary (/detail) carries no geometry, so the map, the stage
@@ -20,15 +41,9 @@ export function useTripRoute(options?: { enabled?: boolean }): void {
   useEffect(() => {
     if (!enabled || !tripId || geometryLoaded) return;
     let cancelled = false;
-    void fetchTripRoute(tripId)
-      .then((route) => {
-        if (!cancelled && route) applyRoute(route);
-      })
-      .catch((error: unknown) => {
-        // Graceful degradation (the map/profile just stay empty), but don't
-        // swallow it silently — it's the only signal the route never loaded.
-        console.warn('Failed to load trip route geometry', error);
-      });
+    void runLoadTripRoute(tripId).then((route) => {
+      if (!cancelled && route) applyRoute(route);
+    });
     return () => {
       cancelled = true;
     };

--- a/mobile/src/hooks/use-trip-route.ts
+++ b/mobile/src/hooks/use-trip-route.ts
@@ -17,9 +17,13 @@ export async function runLoadTripRoute(id: string): Promise<TripRoute | null> {
     const route = await fetchTripRoute(id);
     if (route) void cacheTripRoute(id, route);
     return route;
-  } catch {
+  } catch (error: unknown) {
     const cached = await readTripCache(id);
-    return cached?.route ?? null;
+    if (cached?.route) return cached.route;
+    // Genuine failure: online (or nothing cached) and the fetch threw. Surface a
+    // diagnostic so a real backend/network error is not swallowed silently.
+    console.warn('Failed to load trip route geometry', error);
+    return null;
   }
 }
 

--- a/mobile/src/i18n/resources/en.ts
+++ b/mobile/src/i18n/resources/en.ts
@@ -338,6 +338,7 @@ export const en: typeof fr = {
     map: {
       layerMap: 'Map',
       layerSatellite: 'Satellite',
+      offline: 'Offline map',
       toggleA11y: 'Toggle base map',
       zoomInA11y: 'Zoom in',
       zoomOutA11y: 'Zoom out',

--- a/mobile/src/i18n/resources/en.ts
+++ b/mobile/src/i18n/resources/en.ts
@@ -504,6 +504,7 @@ export const en: typeof fr = {
     hoursAgo: '{{count}}h ago',
     yesterday: 'yesterday',
     daysAgo: '{{count}} days ago',
+    synced: 'Synced {{ago}}',
   },
   export: {
     trip: 'Export',

--- a/mobile/src/i18n/resources/en.ts
+++ b/mobile/src/i18n/resources/en.ts
@@ -499,6 +499,12 @@ export const en: typeof fr = {
     fr: 'Français',
     en: 'English',
   },
+  freshness: {
+    justNow: 'just now',
+    hoursAgo: '{{count}}h ago',
+    yesterday: 'yesterday',
+    daysAgo: '{{count}} days ago',
+  },
   export: {
     trip: 'Export',
     stage: 'Export',

--- a/mobile/src/i18n/resources/fr.ts
+++ b/mobile/src/i18n/resources/fr.ts
@@ -338,6 +338,7 @@ export const fr = {
     map: {
       layerMap: 'Plan',
       layerSatellite: 'Satellite',
+      offline: 'Carte hors-ligne',
       toggleA11y: 'Changer le fond de carte',
       zoomInA11y: 'Zoomer',
       zoomOutA11y: 'Dézoomer',

--- a/mobile/src/i18n/resources/fr.ts
+++ b/mobile/src/i18n/resources/fr.ts
@@ -504,6 +504,7 @@ export const fr = {
     hoursAgo: 'il y a {{count}} h',
     yesterday: 'hier',
     daysAgo: 'il y a {{count}} j',
+    synced: 'Synchronisé {{ago}}',
   },
   export: {
     trip: 'Exporter',

--- a/mobile/src/i18n/resources/fr.ts
+++ b/mobile/src/i18n/resources/fr.ts
@@ -499,6 +499,12 @@ export const fr = {
     fr: 'Français',
     en: 'English',
   },
+  freshness: {
+    justNow: "à l'instant",
+    hoursAgo: 'il y a {{count}} h',
+    yesterday: 'hier',
+    daysAgo: 'il y a {{count}} j',
+  },
   export: {
     trip: 'Exporter',
     stage: 'Exporter',

--- a/mobile/src/lib/freshness.test.ts
+++ b/mobile/src/lib/freshness.test.ts
@@ -1,0 +1,47 @@
+/// <reference types="jest" />
+import i18n from '../i18n';
+import { formatFreshness } from './freshness';
+
+const NOW = Date.parse('2026-08-21T12:00:00Z');
+const ago = (ms: number): number => NOW - ms;
+
+const HOUR = 3_600_000;
+const DAY = 86_400_000;
+
+describe('formatFreshness', () => {
+  beforeAll(async () => {
+    await i18n.changeLanguage('fr');
+  });
+
+  it('reads "à l\'instant" under an hour', () => {
+    expect(formatFreshness(i18n.t, ago(0), NOW)).toBe("à l'instant");
+    expect(formatFreshness(i18n.t, ago(59 * 60_000), NOW)).toBe("à l'instant");
+  });
+
+  it('reads "il y a N h" within the day', () => {
+    expect(formatFreshness(i18n.t, ago(HOUR), NOW)).toBe('il y a 1 h');
+    expect(formatFreshness(i18n.t, ago(5 * HOUR), NOW)).toBe('il y a 5 h');
+    expect(formatFreshness(i18n.t, ago(23 * HOUR), NOW)).toBe('il y a 23 h');
+  });
+
+  it('reads "hier" the day after', () => {
+    expect(formatFreshness(i18n.t, ago(DAY), NOW)).toBe('hier');
+    expect(formatFreshness(i18n.t, ago(2 * DAY - 1), NOW)).toBe('hier');
+  });
+
+  it('reads "il y a N j" beyond', () => {
+    expect(formatFreshness(i18n.t, ago(2 * DAY), NOW)).toBe('il y a 2 j');
+    expect(formatFreshness(i18n.t, ago(9 * DAY), NOW)).toBe('il y a 9 j');
+  });
+
+  it('treats a future last-sync (clock skew) as "à l\'instant"', () => {
+    expect(formatFreshness(i18n.t, NOW + HOUR, NOW)).toBe("à l'instant");
+  });
+
+  it('localises in English', async () => {
+    await i18n.changeLanguage('en');
+    expect(formatFreshness(i18n.t, ago(3 * HOUR), NOW)).toBe('3h ago');
+    expect(formatFreshness(i18n.t, ago(2 * DAY), NOW)).toBe('2 days ago');
+    await i18n.changeLanguage('fr');
+  });
+});

--- a/mobile/src/lib/freshness.ts
+++ b/mobile/src/lib/freshness.ts
@@ -1,0 +1,23 @@
+// Human "synchronised X ago" label for the offline cache (ADR-059). Pure and
+// fully injectable: it never reads the clock itself — the caller passes both the
+// last-sync timestamp and the reference `now` (ms epoch) — so the buckets are
+// deterministic under test. The wording is delegated to i18next: the helper only
+// decides the bucket and the count, the `freshness.*` keys hold the copy.
+import type { TFunction } from 'i18next';
+
+const HOUR_MS = 3_600_000;
+const DAY_MS = 86_400_000;
+
+/**
+ * Freshness label from a last-sync timestamp and an injected `now` (both ms
+ * epoch): "à l'instant" under an hour, "il y a N h" within the day, "hier" the
+ * day after, "il y a N j" beyond. A last-sync in the future (clock skew) reads as
+ * "à l'instant".
+ */
+export function formatFreshness(t: TFunction, lastSyncMs: number, nowMs: number): string {
+  const diff = nowMs - lastSyncMs;
+  if (diff < HOUR_MS) return t('freshness.justNow');
+  if (diff < DAY_MS) return t('freshness.hoursAgo', { count: Math.floor(diff / HOUR_MS) });
+  if (diff < 2 * DAY_MS) return t('freshness.yesterday');
+  return t('freshness.daysAgo', { count: Math.floor(diff / DAY_MS) });
+}

--- a/mobile/src/store/mutations.test.ts
+++ b/mobile/src/store/mutations.test.ts
@@ -22,6 +22,10 @@ import {
 import { useTripStore } from './trip-store';
 import { useOfflineStore } from './offline-store';
 
+jest.mock('./trip-cache', () => ({
+  deleteTripCache: jest.fn(),
+}));
+
 jest.mock('../api/trips', () => ({
   updateTripConfig: jest.fn(),
   createStage: jest.fn(),
@@ -51,6 +55,7 @@ import {
   duplicateTrip,
   deleteTrip,
 } from '../api/trips';
+import { deleteTripCache } from './trip-cache';
 
 const mock = <T extends (...args: never[]) => unknown>(fn: T) =>
   fn as unknown as jest.MockedFunction<T>;
@@ -491,5 +496,17 @@ describe('runAnalyze / lifecycle', () => {
     useOfflineStore.setState({ isOnline: true });
     mock(deleteTrip).mockResolvedValue({ ok: true, status: 204 });
     expect(await runDeleteTrip('t1', ctx(), jest.fn())).toBe(true);
+  });
+
+  it('runDeleteTrip evicts the offline cache on successful deletion, not on failure', async () => {
+    useOfflineStore.setState({ isOnline: true });
+
+    mock(deleteTrip).mockResolvedValue({ ok: false, status: 404 });
+    expect(await runDeleteTrip('t1', ctx(), jest.fn())).toBe(false);
+    expect(deleteTripCache).not.toHaveBeenCalled();
+
+    mock(deleteTrip).mockResolvedValue({ ok: true, status: 204 });
+    expect(await runDeleteTrip('t1', ctx(), jest.fn())).toBe(true);
+    expect(deleteTripCache).toHaveBeenCalledWith('t1');
   });
 });

--- a/mobile/src/store/mutations.ts
+++ b/mobile/src/store/mutations.ts
@@ -25,6 +25,7 @@ import {
   type MutationFailure,
 } from './gating';
 import { useOfflineStore } from './offline-store';
+import { deleteTripCache } from './trip-cache';
 import type { Modification, TripConfig } from './trip-store';
 
 // The store slice + actions the mutation runners drive. `useTripStore.getState()`
@@ -543,6 +544,7 @@ export function runDeleteTrip(
         onFailure(normalizeStatus(status));
         return false;
       }
+      void deleteTripCache(tripId);
       return true;
     })
     .catch(() => {

--- a/mobile/src/store/trip-cache.test.ts
+++ b/mobile/src/store/trip-cache.test.ts
@@ -152,6 +152,22 @@ describe('cacheTripRoute', () => {
     await cacheTripRoute('missing', route);
     expect(await readTripCache('missing')).toBeNull();
   });
+
+  it('does not drop the route when a route write races a detail refresh (#1148)', async () => {
+    // Trip already cached from a prior open.
+    await cacheTripDetail('race', detail(), 1);
+    // Route write and a detail refresh fire concurrently, route first. Without
+    // per-id serialization the detail refresh reads the pre-route entry and its
+    // write clobbers the freshly attached route (lost update) — the offline
+    // trace vanishes. The lock makes the detail write see the route write.
+    await Promise.all([
+      cacheTripRoute('race', route, 2),
+      cacheTripDetail('race', detail({ title: 'Refreshed' }), 3),
+    ]);
+    const cached = await readTripCache('race');
+    expect(cached?.route).toEqual(route);
+    expect(cached?.detail.title).toBe('Refreshed');
+  });
 });
 
 describe('listCachedTripIds / deleteTripCache', () => {

--- a/mobile/src/store/trip-cache.test.ts
+++ b/mobile/src/store/trip-cache.test.ts
@@ -1,0 +1,195 @@
+/// <reference types="jest" />
+import type { TripDetail, TripRoute } from '../api/trips';
+
+// In-memory filesystem backing the mocked expo-file-system. Keyed by file uri.
+const mockFiles = new Map<string, string>();
+let mockDirExists = true;
+
+// Minimal File/Directory/Paths doubles matching the expo-file-system next API
+// (create/write/text/exists/delete + Directory.list) used by trip-cache.
+jest.mock('expo-file-system', () => {
+  class File {
+    uri: string;
+    name: string;
+    constructor(dir: { uri: string }, name: string) {
+      this.uri = `${dir.uri}/${name}`;
+      this.name = name;
+    }
+    get exists() {
+      return mockFiles.has(this.uri);
+    }
+    create() {
+      if (!mockFiles.has(this.uri)) mockFiles.set(this.uri, '');
+    }
+    write(content: string) {
+      // Faithful to expo-file-system's next API: write() requires the file to
+      // already exist (create() must be called first), it does not auto-create.
+      if (!mockFiles.has(this.uri)) {
+        throw new Error(`ENOENT: file does not exist, write '${this.uri}'`);
+      }
+      mockFiles.set(this.uri, content);
+    }
+    text() {
+      return Promise.resolve(mockFiles.get(this.uri) ?? '');
+    }
+    delete() {
+      mockFiles.delete(this.uri);
+    }
+  }
+  class Directory {
+    uri: string;
+    constructor(parent: { uri: string }, name: string) {
+      this.uri = `${parent.uri}/${name}`;
+    }
+    get exists() {
+      return mockDirExists;
+    }
+    create() {
+      mockDirExists = true;
+    }
+    list() {
+      const prefix = `${this.uri}/`;
+      return [...mockFiles.keys()]
+        .filter((uri) => uri.startsWith(prefix))
+        .map((uri) => ({ name: uri.slice(prefix.length) }));
+    }
+  }
+  return { File, Directory, Paths: { document: { uri: 'file:///doc' } } };
+});
+
+import {
+  cacheTripDetail,
+  cacheTripRoute,
+  deleteTripCache,
+  isCacheableTrip,
+  listCachedTripIds,
+  readTripCache,
+  syncCachedTrips,
+} from './trip-cache';
+
+// A fixed "today" so the lifecycle classification is deterministic.
+const TODAY = '2026-08-21';
+
+// Far-future dates so cacheTripDetail (which classifies against the real "today")
+// always sees these as upcoming, regardless of when the suite runs.
+function detail(over: Partial<TripDetail> = {}): TripDetail {
+  return { title: 'Trip', startDate: '2099-09-01', endDate: '2099-09-05', ...over } as TripDetail;
+}
+
+const route = { stages: [{ dayNumber: 1, geometry: [] }] } as unknown as TripRoute;
+
+beforeEach(() => {
+  mockFiles.clear();
+  mockDirExists = true;
+});
+
+describe('isCacheableTrip', () => {
+  it('caches upcoming and ongoing trips', () => {
+    expect(isCacheableTrip('2026-09-01', '2026-09-05', TODAY)).toBe(true); // upcoming
+    expect(isCacheableTrip('2026-08-20', '2026-08-25', TODAY)).toBe(true); // ongoing
+  });
+  it('caches an undated (draft) trip', () => {
+    expect(isCacheableTrip(null, null, TODAY)).toBe(true);
+  });
+  it('excludes a past trip', () => {
+    expect(isCacheableTrip('2026-07-01', '2026-07-10', TODAY)).toBe(false);
+  });
+});
+
+describe('cacheTripDetail / readTripCache', () => {
+  it('writes an upcoming trip and reads it back with a timestamp', async () => {
+    await cacheTripDetail('trip-1', detail(), 1234);
+    const cached = await readTripCache('trip-1');
+    expect(cached?.detail.title).toBe('Trip');
+    expect(cached?.syncedAt).toBe(1234);
+    expect(cached?.route).toBeNull();
+  });
+
+  it('persists on the very first write for a trip id (no pre-existing file)', async () => {
+    // No prior create()/write() for this id: the mock File.write() throws unless
+    // the file was created first, so this only passes if writeEntry creates it.
+    expect(mockFiles.size).toBe(0);
+    await cacheTripDetail('brand-new', detail(), 999);
+    const cached = await readTripCache('brand-new');
+    expect(cached?.syncedAt).toBe(999);
+  });
+
+  it('does not cache a past trip', async () => {
+    await cacheTripDetail('past-1', detail({ startDate: '2000-01-01', endDate: '2000-01-05' }));
+    expect(await readTripCache('past-1')).toBeNull();
+  });
+
+  it('evicts a cached trip that has turned past', async () => {
+    await cacheTripDetail('trip-2', detail());
+    expect(await readTripCache('trip-2')).not.toBeNull();
+    await cacheTripDetail('trip-2', detail({ startDate: '2000-01-01', endDate: '2000-01-05' }));
+    expect(await readTripCache('trip-2')).toBeNull();
+  });
+
+  it('rejects an unsafe id (no file escapes the cache dir)', async () => {
+    await cacheTripDetail('../evil', detail());
+    expect(await readTripCache('../evil')).toBeNull();
+    expect(mockFiles.size).toBe(0);
+  });
+
+  it('returns null on a corrupt entry', async () => {
+    mockFiles.set('file:///doc/trip-cache/broken.json', '{not json');
+    expect(await readTripCache('broken')).toBeNull();
+  });
+});
+
+describe('cacheTripRoute', () => {
+  it('attaches geometry to an existing entry and preserves the detail', async () => {
+    await cacheTripDetail('trip-3', detail(), 10);
+    await cacheTripRoute('trip-3', route, 20);
+    const cached = await readTripCache('trip-3');
+    expect(cached?.route).toEqual(route);
+    expect(cached?.detail.title).toBe('Trip');
+    expect(cached?.syncedAt).toBe(20);
+  });
+
+  it('is a no-op when the trip is not already cached', async () => {
+    await cacheTripRoute('missing', route);
+    expect(await readTripCache('missing')).toBeNull();
+  });
+});
+
+describe('listCachedTripIds / deleteTripCache', () => {
+  it('lists cached ids and drops one on delete', async () => {
+    await cacheTripDetail('a', detail());
+    await cacheTripDetail('b', detail());
+    expect((await listCachedTripIds()).sort()).toEqual(['a', 'b']);
+    await deleteTripCache('a');
+    expect(await listCachedTripIds()).toEqual(['b']);
+  });
+});
+
+describe('syncCachedTrips', () => {
+  it('re-fetches cached trips when online and refreshes detail + route', async () => {
+    await cacheTripDetail('trip-4', detail({ title: 'Old' }), 1);
+    const fetchDetail = jest.fn().mockResolvedValue(detail({ title: 'New' }));
+    const fetchRoute = jest.fn().mockResolvedValue(route);
+    await syncCachedTrips({ isOnline: () => true, fetchDetail, fetchRoute });
+    expect(fetchDetail).toHaveBeenCalledWith('trip-4');
+    const cached = await readTripCache('trip-4');
+    expect(cached?.detail.title).toBe('New');
+    expect(cached?.route).toEqual(route);
+  });
+
+  it('bails out and fetches nothing while offline', async () => {
+    await cacheTripDetail('trip-5', detail());
+    const fetchDetail = jest.fn();
+    const fetchRoute = jest.fn();
+    await syncCachedTrips({ isOnline: () => false, fetchDetail, fetchRoute });
+    expect(fetchDetail).not.toHaveBeenCalled();
+  });
+
+  it('swallows a per-trip fetch failure', async () => {
+    await cacheTripDetail('trip-6', detail());
+    const fetchDetail = jest.fn().mockRejectedValue(new Error('offline'));
+    const fetchRoute = jest.fn();
+    await expect(
+      syncCachedTrips({ isOnline: () => true, fetchDetail, fetchRoute }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/mobile/src/store/trip-cache.ts
+++ b/mobile/src/store/trip-cache.ts
@@ -1,0 +1,181 @@
+import { Directory, File, Paths } from 'expo-file-system';
+import type { TripDetail, TripRoute } from '../api/trips';
+import { todayUtc, tripStateFromDates } from '../components/trip/roadbook-dates';
+
+// Persistent offline cache for the trips the rider is likely to open without a
+// connection: the /detail payload plus the static route geometry (#1147). It
+// rides on expo-file-system's document directory (survives restarts, not evicted
+// under storage pressure) rather than SecureStore — the route geometry is far too
+// large for SecureStore's small-value ceiling, and none of this is sensitive.
+//
+// Only upcoming / ongoing (and still-undated) trips are cached; a trip that has
+// turned *past* is evicted and served online-only, which bounds on-device storage
+// (a rider accumulates finished trips indefinitely). The lifecycle classifier is
+// reused from the roadbook rather than duplicated.
+
+export interface CachedTrip {
+  /** The last /detail payload fetched online. */
+  detail: TripDetail;
+  /** The last /route geometry fetched online, or null before the map was opened. */
+  route: TripRoute | null;
+  /** Epoch ms of the last successful online sync (drives "synced X ago"). */
+  syncedAt: number;
+}
+
+const CACHE_DIRNAME = 'trip-cache';
+// Trip ids are backend-issued UUID/ULID-like; reject anything else so a crafted id
+// can never escape the cache directory via the filename.
+const SAFE_ID = /^[A-Za-z0-9_-]+$/;
+
+/**
+ * Whether a trip is eligible for the offline cache: everything except a *past*
+ * trip (upcoming, ongoing, or still-undated). Past trips stay online-only to
+ * bound storage. Reuses {@link tripStateFromDates} instead of re-deriving the
+ * date math.
+ */
+export function isCacheableTrip(
+  startDate: string | null,
+  endDate: string | null,
+  today: string = todayUtc(),
+): boolean {
+  return tripStateFromDates(startDate, endDate, today) !== 'past';
+}
+
+function cacheDir(): Directory {
+  return new Directory(Paths.document, CACHE_DIRNAME);
+}
+
+function cacheFile(id: string): File {
+  return new File(cacheDir(), `${id}.json`);
+}
+
+function ensureDir(): void {
+  const dir = cacheDir();
+  if (!dir.exists) dir.create({ intermediates: true });
+}
+
+// Synchronous write, wrapped so a filesystem error never propagates: the cache is
+// best-effort and the live network path is authoritative.
+function writeEntry(id: string, entry: CachedTrip): void {
+  try {
+    ensureDir();
+    const file = cacheFile(id);
+    if (!file.exists) file.create();
+    file.write(JSON.stringify(entry));
+  } catch {
+    // ignore: a failed cache write only costs a later offline miss.
+  }
+}
+
+/** Read a trip's cached entry, or null when it is absent or corrupt. */
+export async function readTripCache(id: string): Promise<CachedTrip | null> {
+  if (!SAFE_ID.test(id)) return null;
+  try {
+    const file = cacheFile(id);
+    if (!file.exists) return null;
+    const parsed = JSON.parse(await file.text()) as CachedTrip;
+    if (!parsed || typeof parsed.syncedAt !== 'number' || !parsed.detail) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/** Delete a trip's cache entry (e.g. once it turns past, or on trip deletion). */
+export async function deleteTripCache(id: string): Promise<void> {
+  if (!SAFE_ID.test(id)) return;
+  try {
+    const file = cacheFile(id);
+    if (file.exists) file.delete();
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * Persist (or refresh) a trip's /detail payload and stamp the sync time. A trip
+ * that is no longer cacheable (turned past) is evicted instead. Any existing
+ * route geometry is preserved.
+ */
+export async function cacheTripDetail(
+  id: string,
+  detail: TripDetail,
+  syncedAt: number = Date.now(),
+): Promise<void> {
+  if (!SAFE_ID.test(id)) return;
+  if (!isCacheableTrip(detail.startDate ?? null, detail.endDate ?? null)) {
+    await deleteTripCache(id);
+    return;
+  }
+  const existing = await readTripCache(id);
+  writeEntry(id, { detail, route: existing?.route ?? null, syncedAt });
+}
+
+/**
+ * Attach freshly fetched route geometry to a trip's cache entry and re-stamp the
+ * sync time. No-op when the trip is not already cached (its /detail must be
+ * cached first, which classifies it as cacheable).
+ */
+export async function cacheTripRoute(
+  id: string,
+  route: TripRoute,
+  syncedAt: number = Date.now(),
+): Promise<void> {
+  if (!SAFE_ID.test(id)) return;
+  const existing = await readTripCache(id);
+  if (!existing) return;
+  writeEntry(id, { ...existing, route, syncedAt });
+}
+
+/** Ids of every currently cached trip (drives the background re-sync). */
+export async function listCachedTripIds(): Promise<string[]> {
+  try {
+    const dir = cacheDir();
+    if (!dir.exists) return [];
+    return dir
+      .list()
+      .map((entry) => entry.name)
+      .filter((name) => name.endsWith('.json'))
+      .map((name) => name.slice(0, -'.json'.length))
+      .filter((id) => SAFE_ID.test(id));
+  } catch {
+    return [];
+  }
+}
+
+/** Injectable dependencies for {@link syncCachedTrips} (kept out for testing). */
+export interface SyncDeps {
+  isOnline: () => boolean;
+  fetchDetail: (id: string) => Promise<TripDetail | null>;
+  fetchRoute: (id: string) => Promise<TripRoute | null>;
+}
+
+/**
+ * Silently re-fetch every cached trip's /detail (then /route) so the offline copy
+ * stays fresh. Triggered on return-to-online and app foreground. Best-effort: it
+ * bails out while offline and swallows per-trip failures (still unreachable, or
+ * deleted server-side). A trip that has turned past is evicted by cacheTripDetail.
+ */
+export async function syncCachedTrips(deps: SyncDeps): Promise<void> {
+  if (!deps.isOnline()) return;
+  const ids = await listCachedTripIds();
+  await Promise.all(
+    ids.map(async (id) => {
+      try {
+        const detail = await deps.fetchDetail(id);
+        if (!detail) return;
+        await cacheTripDetail(id, detail);
+        // Only pull the (large) geometry back if the trip is still cached after
+        // the detail refresh — a now-past trip was just evicted.
+        if (await readTripCache(id)) {
+          const route = await deps.fetchRoute(id);
+          if (route) await cacheTripRoute(id, route);
+        }
+      } catch {
+        // ignore this trip; the next sync pass retries.
+      }
+    }),
+  );
+}

--- a/mobile/src/store/trip-cache.ts
+++ b/mobile/src/store/trip-cache.ts
@@ -41,6 +41,19 @@ export function isCacheableTrip(
   return tripStateFromDates(startDate, endDate, today) !== 'past';
 }
 
+// Per-id mutation lock: cacheTripDetail and cacheTripRoute are read-modify-write
+// on the same file, fired from independent unordered effects (roadbook vs map).
+// Without serialization a detail refresh can read the pre-route entry and clobber
+// a freshly attached route (lost update) — losing the offline trace. Chaining the
+// mutations per id makes each one see the previous write.
+const pending = new Map<string, Promise<unknown>>();
+function withLock<T>(id: string, fn: () => Promise<T>): Promise<T> {
+  const prior = pending.get(id) ?? Promise.resolve();
+  const next = prior.then(fn, fn);
+  pending.set(id, next.catch(() => undefined));
+  return next;
+}
+
 function cacheDir(): Directory {
   return new Directory(Paths.document, CACHE_DIRNAME);
 }
@@ -105,12 +118,14 @@ export async function cacheTripDetail(
   syncedAt: number = Date.now(),
 ): Promise<void> {
   if (!SAFE_ID.test(id)) return;
-  if (!isCacheableTrip(detail.startDate ?? null, detail.endDate ?? null)) {
-    await deleteTripCache(id);
-    return;
-  }
-  const existing = await readTripCache(id);
-  writeEntry(id, { detail, route: existing?.route ?? null, syncedAt });
+  return withLock(id, async () => {
+    if (!isCacheableTrip(detail.startDate ?? null, detail.endDate ?? null)) {
+      await deleteTripCache(id);
+      return;
+    }
+    const existing = await readTripCache(id);
+    writeEntry(id, { detail, route: existing?.route ?? null, syncedAt });
+  });
 }
 
 /**
@@ -124,9 +139,11 @@ export async function cacheTripRoute(
   syncedAt: number = Date.now(),
 ): Promise<void> {
   if (!SAFE_ID.test(id)) return;
-  const existing = await readTripCache(id);
-  if (!existing) return;
-  writeEntry(id, { ...existing, route, syncedAt });
+  return withLock(id, async () => {
+    const existing = await readTripCache(id);
+    if (!existing) return;
+    writeEntry(id, { ...existing, route, syncedAt });
+  });
 }
 
 /** Ids of every currently cached trip (drives the background re-sync). */

--- a/mobile/src/store/use-connectivity.test.ts
+++ b/mobile/src/store/use-connectivity.test.ts
@@ -1,0 +1,77 @@
+/// <reference types="jest" />
+import { createElement } from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { useConnectivity } from './use-connectivity';
+import { useOfflineStore } from './offline-store';
+
+type NetInfoState = { isConnected: boolean | null; isInternetReachable: boolean | null };
+type NetInfoListener = (state: NetInfoState) => void;
+
+const mockUnsubscribe = jest.fn();
+let mockCapturedListener: NetInfoListener | undefined;
+
+jest.mock('@react-native-community/netinfo', () => ({
+  __esModule: true,
+  default: {
+    addEventListener: jest.fn((listener: NetInfoListener) => {
+      mockCapturedListener = listener;
+      return mockUnsubscribe;
+    }),
+  },
+}));
+
+function Harness(): null {
+  useConnectivity();
+  return null;
+}
+
+async function mount(): Promise<{ unmount: () => void }> {
+  let renderer!: ReturnType<typeof TestRenderer.create>;
+  await act(async () => {
+    renderer = TestRenderer.create(createElement(Harness));
+  });
+  return { unmount: () => act(() => renderer.unmount()) };
+}
+
+function emit(state: NetInfoState): void {
+  act(() => mockCapturedListener!(state));
+}
+
+beforeEach(() => {
+  mockUnsubscribe.mockClear();
+  mockCapturedListener = undefined;
+  useOfflineStore.setState({ isOnline: true });
+});
+
+describe('useConnectivity — NetInfo to isOnline three-state mapping (#1146)', () => {
+  it('treats isInternetReachable: null (still probing) as online', async () => {
+    await mount();
+    emit({ isConnected: true, isInternetReachable: null });
+    expect(useOfflineStore.getState().isOnline).toBe(true);
+  });
+
+  it('treats isInternetReachable: false as offline', async () => {
+    await mount();
+    emit({ isConnected: true, isInternetReachable: false });
+    expect(useOfflineStore.getState().isOnline).toBe(false);
+  });
+
+  it('treats isInternetReachable: true as online', async () => {
+    await mount();
+    emit({ isConnected: true, isInternetReachable: true });
+    expect(useOfflineStore.getState().isOnline).toBe(true);
+  });
+
+  it('treats isConnected: false as offline regardless of reachability', async () => {
+    await mount();
+    emit({ isConnected: false, isInternetReachable: null });
+    expect(useOfflineStore.getState().isOnline).toBe(false);
+  });
+
+  it('unsubscribes the NetInfo listener on unmount', async () => {
+    const { unmount } = await mount();
+    expect(mockUnsubscribe).not.toHaveBeenCalled();
+    unmount();
+    expect(mockUnsubscribe).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mobile/src/store/use-connectivity.ts
+++ b/mobile/src/store/use-connectivity.ts
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+import NetInfo from '@react-native-community/netinfo';
+import { useOfflineStore } from './offline-store';
+
+// Bridges real device connectivity (NetInfo) into the offline store consumed by
+// the mutation gate (gating.ts). Online means a usable internet path: connected
+// AND not explicitly unreachable — `isInternetReachable` is null while NetInfo is
+// still probing, which we treat as online rather than flapping the gate. Wired
+// once at boot in app/_layout.tsx; the effect unsubscribes on unmount.
+export function useConnectivity(): void {
+  const setOnline = useOfflineStore((s) => s.setOnline);
+  useEffect(() => {
+    const unsubscribe = NetInfo.addEventListener((state) => {
+      setOnline(state.isConnected === true && state.isInternetReachable !== false);
+    });
+    return unsubscribe;
+  }, [setOnline]);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "@expo-google-fonts/jetbrains-mono": "^0.4.1",
         "@maplibre/maplibre-react-native": "^11.3.6",
         "@react-native-community/datetimepicker": "^9.1.0",
+        "@react-native-community/netinfo": "12.0.1",
         "expo": "~57.0.12",
         "expo-clipboard": "~57.0.1",
         "expo-constants": "~57.0.10",
@@ -6928,6 +6929,16 @@
         "react-native-windows": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@react-native-community/netinfo": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-12.0.1.tgz",
+      "integrity": "sha512-P/3caXIvfYSJG8AWJVefukg+ZGRPs+M4Lp3pNJtgcTYoJxCjWrKQGNnCkj/Cz//zWa/avGed0i/wzm0T8vV2IQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": ">=0.59"
       }
     },
     "node_modules/@react-native-masked-view/masked-view": {


### PR DESCRIPTION
Sous-tickets de l'épic **#1052** (offline auto-sync, Sprint 58), regroupés sur `feature/1146`.

> **Périmètre réel de cette PR vers `main`** : la stratégie de merge choisie absorbe les feuilles dans `feature/1146`, donc ce diff contient **plus que la seule fondation #1146** :
> - **#1146** (fondation) : connectivité NetInfo → `offline-store`, helper de fraîcheur, ADR-059.
> - **#1154 / #1147** (cache) : **déjà mergé** dans `feature/1146` (persistance expo-file-system, « synchronisé il y a Xh », sync arrière-plan).
> - **#1153 / #1148** (carte offline) : à merger dans `feature/1146` avant celle-ci (cf. runbook TRACKING #1159).
>
> L'ADR-059 a été reformulé en conséquence : la fondation, la persistance (#1147) et la dégradation carte (#1148) atterrissent ensemble comme épic #1052.

## Contenu #1146 (fondation)

- **Connectivité réelle** : hook `use-connectivity.ts` branche `@react-native-community/netinfo` sur `offline-store` (`isConnected === true && isInternetReachable !== false`, le `null` "en cours de sonde" = online), monté au boot dans `app/_layout.tsx` avec cleanup. Test unitaire du mapping 3 états + cleanup.
- **Fraîcheur** : helper pur `lib/freshness.ts` (clock injectée) → libellé i18n « à l'instant / il y a N h / hier / il y a N j », clés fr+en.
- **ADR-059** : périmètre cache (à venir/en cours only), fraîcheur exposée, sync arrière-plan, dégradation carte offline ; alternatives rejetées documentées.

## DEPS_CHANGED

`@react-native-community/netinfo@12.0.1` (aligné SDK 57), lock synchronisé.

## Vérification

- `tsc --noEmit` (mobile) : 0 erreur.
- `jest` (mobile) : vert ; flakes env `account/notifications`/`ShareSheet` documentés (verts en isolation).
- Tests prouvés failibles (freshness, mapping NetInfo).
- **Playwright / fonctionnel : responsabilité CI.**

## Revue Phase 4

- Ajout du test unitaire NetInfo→`isOnline` (3 états) demandé en revue.
- ADR-059 réconcilié avec le périmètre réel (épic landing).

## Stack

Base du spine `feature/1149 → feature/1150 → feature/1094`. Ordre de merge complet : PR #1159 (TRACKING).

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 critical/warning-level findings, 0 nitpicks suppressed. Full independent re-review of the diff (mobile-only: connectivity, freshness helper, offline trip cache, offline map degradation, ADR-059) found no new correctness, security, performance, or architecture issues. Every issue raised in the previous review round (NetInfo mapping untested, ADR scope contradicting the shipped code, cache write race, silenced route-fetch failure, ADR issue-number contradiction, stale test-coverage note, `useBackgroundTripSync`/"Synced X ago" untested) was independently re-verified as fixed in the current code (`withLock` serialization in `trip-cache.ts`, restored `console.warn` in `use-trip-route.ts`, reconciled ADR-059 numbering/scope, `use-background-sync.test.ts`, `mobile/app/trip/[id]/index.test.tsx`).

**Resolved threads:** all previously open bot threads were already resolved as of this pass — nothing new to resolve. 5 prior bot reviews were dismissed/minimized to declutter.

**PR title check:** `feat(mobile): offline foundation + cache (epic #1052) — NetInfo, freshness, ADR-059` — the description is not in imperative mood (Conventional Commits expects a verb, e.g. "add offline foundation + cache…"). Non-blocking.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

**Commit reviewed:** `ba741912f8dcc40349812775c52141fd7a83d9b9`
<!-- claude-review-end -->