### PR TITLE
feat(mobile): open in-ride screen with foreground GPS and offline badge

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -30,7 +30,15 @@
       "@maplibre/maplibre-react-native",
       "expo-secure-store",
       "expo-sharing",
-      "expo-notifications"
+      "expo-notifications",
+      [
+        "expo-location",
+        {
+          "locationWhenInUsePermission": "Bike Trip Planner utilise votre position pour afficher votre localisation et trouver des points d'intérêt autour de vous pendant votre trajet.",
+          "isAndroidBackgroundLocationEnabled": false,
+          "isAndroidForegroundServiceEnabled": false
+        }
+      ]
     ]
   }
 }

--- a/mobile/app/trip/[id]/in-ride.tsx
+++ b/mobile/app/trip/[id]/in-ride.tsx
@@ -1,0 +1,18 @@
+import { Stack, useLocalSearchParams } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import { Screen } from '../../../src/components/ui';
+import { InRideView } from '../../../src/components/trip';
+
+// In-ride route (#1149): reached from the roadbook "En selle" FAB. Thin wrapper —
+// the body (foreground GPS, offline badge, help bubble, #1150 POI slot) lives in
+// InRideView so it renders in tests without a mounted navigator.
+export default function InRide() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const { t } = useTranslation();
+  return (
+    <Screen padded={false} edges={['left', 'right']}>
+      <Stack.Screen options={{ headerShown: true, headerTitle: t('trip.inRide.title') }} />
+      <InRideView tripId={id} />
+    </Screen>
+  );
+}

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -18,6 +18,7 @@
     "expo-font": "~57.0.1",
     "expo-linking": "~57.0.5",
     "expo-localization": "~57.0.1",
+    "expo-location": "~57.0.12",
     "expo-notifications": "~57.0.10",
     "expo-router": "~57.0.12",
     "expo-secure-store": "~57.0.1",

--- a/mobile/src/components/trip/InRideView.test.tsx
+++ b/mobile/src/components/trip/InRideView.test.tsx
@@ -1,0 +1,96 @@
+/// <reference types="jest" />
+import TestRenderer, { act } from 'react-test-renderer';
+import { Text, View } from 'react-native';
+import type { ReactElement } from 'react';
+import * as Location from 'expo-location';
+import i18n from '../../i18n';
+import { useOfflineStore } from '../../store/offline-store';
+import { InRideView } from './InRideView';
+
+jest.mock('expo-location', () => ({
+  Accuracy: { Balanced: 3 },
+  requestForegroundPermissionsAsync: jest.fn(),
+  watchPositionAsync: jest.fn(),
+}));
+
+const requestPerm = Location.requestForegroundPermissionsAsync as jest.Mock;
+const watch = Location.watchPositionAsync as jest.Mock;
+
+function texts(node: any): string[] {
+  return node.root.findAllByType(Text).flatMap((t: any) => {
+    const kids = Array.isArray(t.props.children) ? t.props.children : [t.props.children];
+    return kids.filter((c: unknown): c is string => typeof c === 'string');
+  });
+}
+
+function queryByLabel(tree: any, label: string): any {
+  return tree.root.findAll((n: any) => n.props.accessibilityLabel === label)[0] ?? null;
+}
+
+async function render(element: ReactElement): Promise<any> {
+  let out: any;
+  await act(async () => {
+    out = TestRenderer.create(element);
+    for (let i = 0; i < 8; i += 1) await Promise.resolve();
+  });
+  return out;
+}
+
+beforeAll(async () => {
+  await i18n.changeLanguage('fr');
+});
+
+beforeEach(() => {
+  requestPerm.mockReset();
+  watch.mockReset();
+  requestPerm.mockResolvedValue({ status: 'granted' });
+  watch.mockResolvedValue({ remove: jest.fn() });
+  useOfflineStore.setState({ isOnline: true });
+});
+
+describe('InRideView', () => {
+  it('renders the help bubble and shows the current GPS position once a fix arrives', async () => {
+    let callback: ((loc: { coords: unknown }) => void) | undefined;
+    watch.mockImplementation(async (_opts: unknown, cb: (loc: { coords: unknown }) => void) => {
+      callback = cb;
+      return { remove: jest.fn() };
+    });
+
+    const tree = await render(<InRideView tripId="t1" />);
+    expect(queryByLabel(tree, i18n.t('trip.inRide.helpA11y'))).not.toBeNull();
+
+    await act(async () => {
+      callback?.({ coords: { latitude: 45.5, longitude: 6.12345 } });
+    });
+
+    expect(queryByLabel(tree, i18n.t('trip.inRide.positionA11y'))).not.toBeNull();
+    expect(texts(tree)).toContain('45.50000, 6.12345');
+  });
+
+  it('shows the offline badge only when connectivity is down', async () => {
+    const online = await render(<InRideView tripId="t1" />);
+    expect(queryByLabel(online, i18n.t('trip.inRide.offlineBadge'))).toBeNull();
+
+    useOfflineStore.setState({ isOnline: false });
+    const offline = await render(<InRideView tripId="t1" />);
+    expect(queryByLabel(offline, i18n.t('trip.inRide.offlineBadge'))).not.toBeNull();
+    expect(texts(offline)).toContain(i18n.t('trip.inRide.offlineHint'));
+  });
+
+  it('renders the denied empty state when the location permission is refused', async () => {
+    requestPerm.mockResolvedValue({ status: 'denied' });
+    const tree = await render(<InRideView tripId="t1" />);
+    expect(texts(tree)).toContain(i18n.t('trip.inRide.locationDeniedTitle'));
+    expect(watch).not.toHaveBeenCalled();
+  });
+
+  it('mounts the #1150 poiPanel slot when provided', async () => {
+    const slot = (
+      <View accessibilityLabel="poi-slot">
+        <Text>slot</Text>
+      </View>
+    );
+    const tree = await render(<InRideView tripId="t1" poiPanel={slot} />);
+    expect(queryByLabel(tree, 'poi-slot')).not.toBeNull();
+  });
+});

--- a/mobile/src/components/trip/InRideView.tsx
+++ b/mobile/src/components/trip/InRideView.tsx
@@ -1,0 +1,134 @@
+import { type ReactNode } from 'react';
+import { Pressable, Text, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useTranslation } from 'react-i18next';
+import { EmptyState } from '../ui';
+import { HelpCircle, Navigation, WifiOff } from '../ui/icons';
+import { useTheme } from '../../theme';
+import { useOfflineStore } from '../../store/offline-store';
+import { useForegroundLocation } from '../../hooks/use-foreground-location';
+
+// The in-ride screen body (#1149). Structure only — maquette 08-in-ride + theme
+// pass belong to #1094. It hosts the foreground GPS status, an offline badge
+// (nearby-pois needs the network), a floating help bubble, and a `poiPanel` slot
+// that #1150 fills with the deterministic POI finder (ADR-048). Kept as a plain
+// component (not the route) so it renders in tests without a mounted navigator.
+export function InRideView({
+  tripId: _tripId,
+  poiPanel,
+  onHelp,
+}: {
+  // Carried for #1150 (POST /trips/{id}/nearby-pois); unused in this structural pass.
+  tripId: string;
+  // Extension slot for the #1150 POI finder panel.
+  poiPanel?: ReactNode;
+  onHelp?: () => void;
+}) {
+  const { t } = useTranslation();
+  const theme = useTheme();
+  const insets = useSafeAreaInsets();
+  const isOnline = useOfflineStore((s) => s.isOnline);
+  const { permission, position } = useForegroundLocation();
+
+  return (
+    <View style={{ flex: 1, backgroundColor: theme.colors.background }}>
+      {!isOnline ? (
+        <View
+          accessibilityRole="alert"
+          accessibilityLabel={t('trip.inRide.offlineBadge')}
+          style={{
+            flexDirection: 'row',
+            alignItems: 'center',
+            gap: theme.spacing.sm,
+            margin: theme.spacing.base,
+            padding: theme.spacing.md,
+            backgroundColor: theme.colors.muted,
+            borderRadius: theme.radius.lg,
+            borderWidth: 1,
+            borderColor: theme.colors.border,
+          }}
+        >
+          <WifiOff color={theme.colors.destructive} size={18} />
+          <View style={{ flex: 1 }}>
+            <Text
+              style={{
+                color: theme.colors.foreground,
+                fontFamily: theme.fonts.sansSemibold,
+                fontSize: 14,
+              }}
+            >
+              {t('trip.inRide.offlineBadge')}
+            </Text>
+            <Text
+              style={{
+                color: theme.colors.mutedForeground,
+                fontFamily: theme.fonts.sans,
+                fontSize: 13,
+              }}
+            >
+              {t('trip.inRide.offlineHint')}
+            </Text>
+          </View>
+        </View>
+      ) : null}
+
+      <View style={{ flex: 1 }}>
+        {permission === 'denied' ? (
+          <EmptyState
+            title={t('trip.inRide.locationDeniedTitle')}
+            description={t('trip.inRide.locationDenied')}
+          />
+        ) : position ? (
+          <View
+            style={{
+              flexDirection: 'row',
+              alignItems: 'center',
+              gap: theme.spacing.sm,
+              padding: theme.spacing.base,
+            }}
+          >
+            <Navigation color={theme.colors.brandFill} size={18} />
+            <Text
+              accessibilityLabel={t('trip.inRide.positionA11y')}
+              style={{
+                color: theme.colors.foreground,
+                fontFamily: theme.fonts.mono,
+                fontSize: 14,
+              }}
+            >
+              {t('trip.inRide.coords', {
+                lat: position.latitude.toFixed(5),
+                lng: position.longitude.toFixed(5),
+              })}
+            </Text>
+          </View>
+        ) : (
+          <EmptyState title={t('trip.inRide.locationWaiting')} />
+        )}
+
+        {/* #1150 mounts its nearby-pois finder here. */}
+        {poiPanel}
+      </View>
+
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={t('trip.inRide.helpA11y')}
+        onPress={onHelp}
+        style={{
+          position: 'absolute',
+          right: theme.spacing.lg,
+          bottom: insets.bottom + theme.spacing.lg,
+          width: 52,
+          height: 52,
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: theme.colors.brandFill,
+          borderRadius: theme.radius.full,
+          ...theme.shadows.medium,
+        }}
+      >
+        <HelpCircle color={theme.colors.primaryForeground} size={24} />
+      </Pressable>
+    </View>
+  );
+}

--- a/mobile/src/components/trip/RoadbookView.test.tsx
+++ b/mobile/src/components/trip/RoadbookView.test.tsx
@@ -93,6 +93,16 @@ describe('RoadbookView navigation', () => {
 
     expect(mockPush).toHaveBeenCalledWith('/trip/trip-42/stage/1');
   });
+
+  it('pushes the in-ride route when the "En selle" FAB is tapped', () => {
+    const tree = render(<RoadbookView id="trip-42" />);
+    const fab = queryByLabel(tree, i18n.t('trip.rideCtaA11y'));
+    expect(fab).not.toBeNull();
+
+    act(() => fab.props.onPress());
+
+    expect(mockPush).toHaveBeenCalledWith('/trip/trip-42/in-ride');
+  });
 });
 
 describe('RoadbookView edit affordances by lifecycle', () => {

--- a/mobile/src/components/trip/RoadbookView.tsx
+++ b/mobile/src/components/trip/RoadbookView.tsx
@@ -195,17 +195,15 @@ export function RoadbookView({
         }}
         style={{ backgroundColor: theme.colors.background }}
       />
-      {/* In-ride FAB (Spike-UX): the in-ride screen is out of scope, so this is a
-          deliberate placeholder — disabled, icon-only, dispatches nothing. Lifted
-          above the system nav bar via the bottom safe-area inset. Lives in the
-          roadbook view only, so it never overlays the map/profile tab (#7);
-          hidden in the read-only (started / ongoing / past) view (#6). */}
+      {/* In-ride FAB (#1149): opens the in-ride screen (foreground GPS + POI
+          finder). Lifted above the system nav bar via the bottom safe-area inset.
+          Lives in the roadbook view only, so it never overlays the map/profile tab
+          (#7); hidden in the read-only (started / ongoing / past) view (#6). */}
       {stages.length > 0 && !readOnly ? (
         <Pressable
           accessibilityRole="button"
           accessibilityLabel={t('trip.rideCtaA11y')}
-          accessibilityState={{ disabled: true }}
-          disabled
+          onPress={() => router.push(`/trip/${id}/in-ride`)}
           style={{
             position: 'absolute',
             right: theme.spacing.lg,

--- a/mobile/src/components/trip/index.ts
+++ b/mobile/src/components/trip/index.ts
@@ -10,6 +10,7 @@ export { SupplyBlock } from './SupplyBlock';
 export { EventsBlock } from './EventsBlock';
 export { StageDataBlocks } from './StageDataBlocks';
 export { RoadbookView } from './RoadbookView';
+export { InRideView } from './InRideView';
 export { RoadbookSummary } from './RoadbookSummary';
 export { StageDetailView } from './StageDetailView';
 export { TripTitleHeader } from './TripTitleHeader';

--- a/mobile/src/components/ui/icons.ts
+++ b/mobile/src/components/ui/icons.ts
@@ -50,3 +50,5 @@ export { ShoppingBag } from 'lucide-react-native';
 export { Bell, BellOff, CheckCircle2 } from 'lucide-react-native';
 // Offline map degradation (#1148): discrete "offline map" indicator.
 export { CloudOff } from 'lucide-react-native';
+// In-ride mode (#1149): help bubble, offline badge, GPS position.
+export { HelpCircle, Navigation, WifiOff } from 'lucide-react-native';

--- a/mobile/src/hooks/use-foreground-location.test.ts
+++ b/mobile/src/hooks/use-foreground-location.test.ts
@@ -1,0 +1,78 @@
+/// <reference types="jest" />
+import TestRenderer, { act } from 'react-test-renderer';
+import { createElement } from 'react';
+import * as Location from 'expo-location';
+import { useForegroundLocation, type ForegroundLocation } from './use-foreground-location';
+
+jest.mock('expo-location', () => ({
+  Accuracy: { Balanced: 3 },
+  requestForegroundPermissionsAsync: jest.fn(),
+  watchPositionAsync: jest.fn(),
+}));
+
+const requestPerm = Location.requestForegroundPermissionsAsync as jest.Mock;
+const watch = Location.watchPositionAsync as jest.Mock;
+
+function Harness({ onRender }: { onRender: (v: ForegroundLocation) => void }): null {
+  onRender(useForegroundLocation());
+  return null;
+}
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    for (let i = 0; i < 8; i += 1) await Promise.resolve();
+  });
+}
+
+beforeEach(() => {
+  requestPerm.mockReset();
+  watch.mockReset();
+});
+
+describe('useForegroundLocation', () => {
+  it('subscribes to positions when permission is granted and removes the subscription on unmount', async () => {
+    let callback: ((loc: { coords: unknown }) => void) | undefined;
+    const remove = jest.fn();
+    requestPerm.mockResolvedValue({ status: 'granted' });
+    watch.mockImplementation(async (_opts: unknown, cb: (loc: { coords: unknown }) => void) => {
+      callback = cb;
+      return { remove };
+    });
+
+    const states: ForegroundLocation[] = [];
+    let tree!: ReturnType<typeof TestRenderer.create>;
+    await act(async () => {
+      tree = TestRenderer.create(
+        createElement(Harness, { onRender: (v) => states.push(v) }),
+      );
+    });
+    await flush();
+
+    // A fix arrives from the watcher.
+    act(() => callback?.({ coords: { latitude: 45.5, longitude: 6.1 } }));
+
+    const last = states[states.length - 1];
+    expect(watch).toHaveBeenCalledTimes(1);
+    expect(last.permission).toBe('granted');
+    expect(last.position).toEqual({ latitude: 45.5, longitude: 6.1 });
+
+    // Unmount stops tracking (foreground-only, no background).
+    act(() => tree.unmount());
+    expect(remove).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports a denied permission and never subscribes when the request is refused', async () => {
+    requestPerm.mockResolvedValue({ status: 'denied' });
+
+    const states: ForegroundLocation[] = [];
+    await act(async () => {
+      TestRenderer.create(createElement(Harness, { onRender: (v) => states.push(v) }));
+    });
+    await flush();
+
+    const last = states[states.length - 1];
+    expect(last.permission).toBe('denied');
+    expect(last.position).toBeNull();
+    expect(watch).not.toHaveBeenCalled();
+  });
+});

--- a/mobile/src/hooks/use-foreground-location.test.ts
+++ b/mobile/src/hooks/use-foreground-location.test.ts
@@ -75,4 +75,19 @@ describe('useForegroundLocation', () => {
     expect(last.position).toBeNull();
     expect(watch).not.toHaveBeenCalled();
   });
+
+  it('falls back to denied when the OS location API throws (e.g. Location Services off)', async () => {
+    requestPerm.mockResolvedValue({ status: 'granted' });
+    watch.mockRejectedValue(new Error('Location services disabled'));
+
+    const states: ForegroundLocation[] = [];
+    await act(async () => {
+      TestRenderer.create(createElement(Harness, { onRender: (v) => states.push(v) }));
+    });
+    await flush();
+
+    const last = states[states.length - 1];
+    expect(last.permission).toBe('denied');
+    expect(last.position).toBeNull();
+  });
 });

--- a/mobile/src/hooks/use-foreground-location.ts
+++ b/mobile/src/hooks/use-foreground-location.ts
@@ -26,24 +26,32 @@ export function useForegroundLocation(): ForegroundLocation {
     let subscription: Location.LocationSubscription | null = null;
 
     void (async () => {
-      const { status } = await Location.requestForegroundPermissionsAsync();
-      if (cancelled) return;
-      if (status !== 'granted') {
-        setPermission('denied');
-        return;
+      try {
+        const { status } = await Location.requestForegroundPermissionsAsync();
+        if (cancelled) return;
+        if (status !== 'granted') {
+          setPermission('denied');
+          return;
+        }
+        setPermission('granted');
+        const sub = await Location.watchPositionAsync(
+          { accuracy: Location.Accuracy.Balanced, distanceInterval: 10, timeInterval: 5000 },
+          (loc) => {
+            if (!cancelled) setPosition(loc.coords);
+          },
+        );
+        if (cancelled) {
+          sub.remove();
+          return;
+        }
+        subscription = sub;
+      } catch {
+        // The permission/watch API itself can throw independently of granted/denied
+        // (e.g. Location Services toggled off at the OS level) — surface it as
+        // 'denied' so the screen falls back instead of hanging on "Recherche du
+        // signal GPS…" forever. Same class of guard as fetchDeviceToken (push.ts).
+        if (!cancelled) setPermission('denied');
       }
-      setPermission('granted');
-      const sub = await Location.watchPositionAsync(
-        { accuracy: Location.Accuracy.Balanced, distanceInterval: 10, timeInterval: 5000 },
-        (loc) => {
-          if (!cancelled) setPosition(loc.coords);
-        },
-      );
-      if (cancelled) {
-        sub.remove();
-        return;
-      }
-      subscription = sub;
     })();
 
     return () => {

--- a/mobile/src/hooks/use-foreground-location.ts
+++ b/mobile/src/hooks/use-foreground-location.ts
@@ -1,0 +1,56 @@
+import { useEffect, useState } from 'react';
+import * as Location from 'expo-location';
+
+export type LocationPermission = 'undetermined' | 'granted' | 'denied';
+
+export interface ForegroundLocation {
+  // 'undetermined' while the permission prompt is still pending, then 'granted'
+  // or 'denied'. The in-ride screen renders an explicit empty state on 'denied'.
+  permission: LocationPermission;
+  // Latest fix, or null while waiting for the first one (or when denied).
+  position: Location.LocationObjectCoords | null;
+}
+
+// Foreground-only GPS for the in-ride screen (#1149): request the when-in-use
+// permission on mount, then subscribe to position updates for the lifetime of the
+// mounted screen. NO background tracking — the subscription is removed on unmount,
+// so location stops the moment the rider leaves the screen. The awaited
+// watchPositionAsync can resolve after the component unmounts; `cancelled` guards
+// that race and removes the subscription that arrived too late.
+export function useForegroundLocation(): ForegroundLocation {
+  const [permission, setPermission] = useState<LocationPermission>('undetermined');
+  const [position, setPosition] = useState<Location.LocationObjectCoords | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    let subscription: Location.LocationSubscription | null = null;
+
+    void (async () => {
+      const { status } = await Location.requestForegroundPermissionsAsync();
+      if (cancelled) return;
+      if (status !== 'granted') {
+        setPermission('denied');
+        return;
+      }
+      setPermission('granted');
+      const sub = await Location.watchPositionAsync(
+        { accuracy: Location.Accuracy.Balanced, distanceInterval: 10, timeInterval: 5000 },
+        (loc) => {
+          if (!cancelled) setPosition(loc.coords);
+        },
+      );
+      if (cancelled) {
+        sub.remove();
+        return;
+      }
+      subscription = sub;
+    })();
+
+    return () => {
+      cancelled = true;
+      subscription?.remove();
+    };
+  }, []);
+
+  return { permission, position };
+}

--- a/mobile/src/i18n/resources/en.ts
+++ b/mobile/src/i18n/resources/en.ts
@@ -418,6 +418,18 @@ export const en: typeof fr = {
     deleteTripConfirmTitle: 'Delete this trip?',
     deleteTripConfirmMessage: 'This trip will be permanently deleted.',
     rideCtaA11y: 'Start the trip',
+    inRide: {
+      title: 'On the ride',
+      offlineBadge: 'Offline',
+      offlineHint: 'Searching for points of interest requires a connection.',
+      locationWaiting: 'Searching for GPS signal…',
+      locationDeniedTitle: 'Location disabled',
+      locationDenied:
+        'Allow location access to show your position and find points of interest around you.',
+      positionA11y: 'Current position',
+      coords: '{{lat}}, {{lng}}',
+      helpA11y: 'Help',
+    },
   },
   config: {
     title: 'Settings',

--- a/mobile/src/i18n/resources/fr.ts
+++ b/mobile/src/i18n/resources/fr.ts
@@ -418,6 +418,18 @@ export const fr = {
     deleteTripConfirmTitle: 'Supprimer ce voyage ?',
     deleteTripConfirmMessage: 'Ce voyage sera définitivement supprimé.',
     rideCtaA11y: 'Démarrer le voyage',
+    inRide: {
+      title: 'En selle',
+      offlineBadge: 'Hors ligne',
+      offlineHint: "La recherche de points d'intérêt nécessite une connexion.",
+      locationWaiting: 'Recherche du signal GPS…',
+      locationDeniedTitle: 'Localisation désactivée',
+      locationDenied:
+        'Autorisez la localisation pour afficher votre position et rechercher des points autour de vous.',
+      positionA11y: 'Position actuelle',
+      coords: '{{lat}}, {{lng}}',
+      helpA11y: 'Aide',
+    },
   },
   config: {
     title: 'Configuration',

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "expo-font": "~57.0.1",
         "expo-linking": "~57.0.5",
         "expo-localization": "~57.0.1",
+        "expo-location": "~57.0.12",
         "expo-notifications": "~57.0.10",
         "expo-router": "~57.0.12",
         "expo-secure-store": "~57.0.1",
@@ -13549,6 +13550,18 @@
       "peerDependencies": {
         "expo": "*",
         "react": "*"
+      }
+    },
+    "node_modules/expo-location": {
+      "version": "57.0.12",
+      "resolved": "https://registry.npmjs.org/expo-location/-/expo-location-57.0.12.tgz",
+      "integrity": "sha512-Fnh1dzIvZgc2mX7fXuXf6NxbEttZQLEnSXCbFHCLNtxyImUf/sURE93C9Jed+IfS/ozmtl84s/1nfz/cI87e9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/image-utils": "^0.11.4"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-modules-autolinking": {


### PR DESCRIPTION
Ferme #1149 (sous-ticket 1/2 de l'épic #1053, Sprint 58).

⚠️ **PR stackée** — base `feature/1146` (#1151). À merger après #1151. Base de #1150.

## Contenu

Ouvre l'écran in-ride (le FAB « En selle » du roadbook n'était qu'un placeholder désactivé).

- **Entrée** : FAB « 🚴 En selle » de `RoadbookView` câblé vers la route expo-router `app/trip/[id]/in-ride.tsx` (diff minimal sur RoadbookView).
- **Écran** `InRideView` : badge offline, statut/position GPS, bulle d'aide flottante bas-droite, prop `poiPanel` laissée en slot pour #1150.
- **GPS foreground** : hook `use-foreground-location` (`requestForegroundPermissionsAsync` + `watchPositionAsync`, cleanup au unmount, garde de course, **aucun background**), refus de permission géré.
- **Badge offline** via `offline-store` (#1146). i18n fr+en.

Pas de recherche nearby-pois ici (réservée à #1150).

## DEPS_CHANGED

`expo-location@~57.0.12` (`expo install`), plugin ajouté à `app.json` (message de permission FR, `isAndroidBackgroundLocationEnabled: false`), lock synchronisé.

## Vérification

- `tsc --noEmit` (mobile) : 0 erreur.
- `jest` (mobile) : 556/557 ; seul rouge = `ShareSheet` (flake env documenté, vert en isolation, rouge sur `main`).
- Preuve failible : mutation du garde badge offline → test rouge, restauré.
- **Écran GPS/permissions à valider sur device** (recette manuelle, hors CI). Playwright/fonctionnel : responsabilité CI.

## Auto-critique

- La bulle in-ride est structurelle : la conformité maquette 08-in-ride + thème est le scope explicite de #1094 (stacké au-dessus de #1150).
- `watchPositionAsync` non testé en intégration réelle (mock jest) : le comportement device est en recette manuelle.

<!-- claude-review-start -->
## Claude Review

**⚠️ Note:** the previous auto-generated review section embedded in this PR body cited commit SHAs (`d7fb016d…`, `455e9789`, `95620fb8…`) that do not match this PR's actual commit history (`c26c741f…`, `2c7fadcf…`) or its actual head (`2c7fadcfa0b5925ca2c5d40a4fc9689ffb92f520`). That section's factual claims could not be verified against real repo state and have been discarded; this section is based on independent verification of the current diff, hook, and tests.

**Summary:** Focused, well-scoped mobile feature (foreground-GPS in-ride screen + offline badge, gated behind the roadbook FAB). `InRideView`, the `useForegroundLocation` hook, the new route, and i18n additions follow existing project conventions. The hook correctly guards the unmount race (permission/watch promise resolving after unmount) and wraps the OS location calls in try/catch so a thrown rejection (e.g. Location Services off) degrades to a denied state instead of leaving the screen stuck on "waiting for signal" — this matches the dedicated hook test for the throw case. No blocking or warning findings.

**Review summary:** 0 findings (0 critical, 0 warning).

**Resolved threads:** No unresolved bot threads found — the 1 previous bot thread (unhandled OS location API rejection, `use-foreground-location.ts:55`) was already resolved on GitHub prior to this review, and independently reconfirmed fixed in the current diff (try/catch present, dedicated throw-path test passing).

**Review checklist:**
- [x] Code respects the project architecture (foreground-only GPS, no background tracking; local-first component structure)
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate (extension slot pattern for `poiPanel`/#1150)
- [x] Tests cover new/changed cases (`use-foreground-location.test.ts`: granted/denied/throw + unmount cleanup; `InRideView.test.tsx`: offline badge, position display, denied state, poiPanel slot; `RoadbookView.test.tsx`: FAB navigation)
- [x] Documentation is up to date (no ADR/schema impact)
- [x] Dependent tickets accounted for (#1150 slot, #1094 theming deferred)

**PR title:** conforms to Conventional Commits (`feat(mobile): open in-ride screen with foreground GPS and offline badge`) — imperative mood, no issue.

**Inline comments:** No inline comments (0 findings).

**Reviewed commit:** `2c7fadcfa0b5925ca2c5d40a4fc9689ffb92f520`
<!-- claude-review-end -->