### PR TITLE
feat(mobile): dégradation offline de la carte (tracé + profil, sans tuiles interactives)

### DIFF
--- a/mobile/src/components/TripMap.test.tsx
+++ b/mobile/src/components/TripMap.test.tsx
@@ -143,6 +143,31 @@ describe('TripMap', () => {
     expect(style()).toBe(POSITRON_STYLE_URL);
   });
 
+  it('hides the layer toggle while offline (no tiles to switch)', () => {
+    // Offline, the map is stuck on the tile-less background style regardless of
+    // `base` (see the test above) — the pill would look interactive but do
+    // nothing, so it must not render at all while offline.
+    const out = render(<TripMap stageSegments={segsA} />);
+    const findToggle = () =>
+      out.root.findAll(
+        (n: any) =>
+          n.props.accessibilityRole === 'button' &&
+          n.props.accessibilityLabel === 'Satellite' &&
+          typeof n.props.onPress === 'function',
+      );
+    expect(findToggle()).toHaveLength(1);
+
+    act(() => {
+      useOfflineStore.setState({ isOnline: false });
+    });
+    expect(findToggle()).toHaveLength(0);
+
+    act(() => {
+      useOfflineStore.setState({ isOnline: true });
+    });
+    expect(findToggle()).toHaveLength(1);
+  });
+
   it('draws one colored LineString feature per stage', () => {
     const segs: StageLine[] = [
       { color: 'hsl(25.0, 72%, 48%)', coordinates: coordsA },

--- a/mobile/src/components/TripMap.test.tsx
+++ b/mobile/src/components/TripMap.test.tsx
@@ -4,6 +4,7 @@ import type { ReactElement } from 'react';
 import * as SecureStore from 'expo-secure-store';
 import '../i18n';
 import { useMapPrefs } from '../store/map-prefs';
+import { useOfflineStore } from '../store/offline-store';
 import { TripMap } from './TripMap';
 import { computeBounds, POSITRON_STYLE_URL, type StageLine } from './map/map-utils';
 
@@ -66,6 +67,10 @@ beforeEach(() => {
   act(() => {
     useMapPrefs.setState({ base: 'map', hydrated: true });
   });
+  // Reset so an offline flip in one test never leaks into the next.
+  act(() => {
+    useOfflineStore.setState({ isOnline: true });
+  });
 });
 
 describe('TripMap', () => {
@@ -119,6 +124,23 @@ describe('TripMap', () => {
       'get',
       'color',
     ]);
+  });
+
+  it('degrades to the offline style when useOfflineStore flips offline, then restores online', () => {
+    const out = render(<TripMap stageSegments={segsA} />);
+    const style = () => findAll(out.root, 'Map')[0].props.mapStyle;
+    expect(style()).toBe(POSITRON_STYLE_URL);
+
+    act(() => {
+      useOfflineStore.setState({ isOnline: false });
+    });
+    // Tile-less offline style: no network sources, just a flat background layer.
+    expect(style()).toMatchObject({ sources: {}, layers: [{ type: 'background' }] });
+
+    act(() => {
+      useOfflineStore.setState({ isOnline: true });
+    });
+    expect(style()).toBe(POSITRON_STYLE_URL);
   });
 
   it('draws one colored LineString feature per stage', () => {

--- a/mobile/src/components/TripMap.tsx
+++ b/mobile/src/components/TripMap.tsx
@@ -212,54 +212,56 @@ export function TripMap({
           <Minus size={20} color={theme.colors.foreground} />
         </Pressable>
       </View>
-      <View
-        accessibilityLabel={t('trip.map.toggleA11y')}
-        style={[
-          styles.layers,
-          {
-            backgroundColor: theme.colors.card,
-            borderColor: theme.colors.border,
-            ...theme.shadows.soft,
-          },
-        ]}
-      >
-        {(['map', 'satellite'] as const).map((layer) => {
-          const active = base === layer;
-          return (
-            <Pressable
-              key={layer}
-              accessibilityRole="button"
-              accessibilityState={{ selected: active }}
-              accessibilityLabel={
-                layer === 'map'
-                  ? t('trip.map.layerMap')
-                  : t('trip.map.layerSatellite')
-              }
-              onPress={() => setBase(layer)}
-              style={[
-                styles.layerSegment,
-                active && { backgroundColor: theme.colors.brand },
-              ]}
-            >
-              <Text
-                style={{
-                  color: active
-                    ? theme.colors.primaryForeground
-                    : theme.colors.foreground,
-                  fontFamily: active
-                    ? theme.fonts.sansSemibold
-                    : theme.fonts.sansMedium,
-                  fontSize: 13,
-                }}
+      {isOnline ? (
+        <View
+          accessibilityLabel={t('trip.map.toggleA11y')}
+          style={[
+            styles.layers,
+            {
+              backgroundColor: theme.colors.card,
+              borderColor: theme.colors.border,
+              ...theme.shadows.soft,
+            },
+          ]}
+        >
+          {(['map', 'satellite'] as const).map((layer) => {
+            const active = base === layer;
+            return (
+              <Pressable
+                key={layer}
+                accessibilityRole="button"
+                accessibilityState={{ selected: active }}
+                accessibilityLabel={
+                  layer === 'map'
+                    ? t('trip.map.layerMap')
+                    : t('trip.map.layerSatellite')
+                }
+                onPress={() => setBase(layer)}
+                style={[
+                  styles.layerSegment,
+                  active && { backgroundColor: theme.colors.brand },
+                ]}
               >
-                {layer === 'map'
-                  ? t('trip.map.layerMap')
-                  : t('trip.map.layerSatellite')}
-              </Text>
-            </Pressable>
-          );
-        })}
-      </View>
+                <Text
+                  style={{
+                    color: active
+                      ? theme.colors.primaryForeground
+                      : theme.colors.foreground,
+                    fontFamily: active
+                      ? theme.fonts.sansSemibold
+                      : theme.fonts.sansMedium,
+                    fontSize: 13,
+                  }}
+                >
+                  {layer === 'map'
+                    ? t('trip.map.layerMap')
+                    : t('trip.map.layerSatellite')}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+      ) : null}
     </View>
   );
 }

--- a/mobile/src/components/TripMap.tsx
+++ b/mobile/src/components/TripMap.tsx
@@ -13,6 +13,7 @@ import { useTranslation } from 'react-i18next';
 import { Minus, Plus } from './ui/icons';
 import { useTheme } from '../theme/context';
 import { useMapPrefs } from '../store/map-prefs';
+import { useOfflineStore } from '../store/offline-store';
 import {
   applyZoom,
   computeBounds,
@@ -47,6 +48,7 @@ export function TripMap({
   const base = useMapPrefs((s) => s.base);
   const setBase = useMapPrefs((s) => s.setBase);
   const load = useMapPrefs((s) => s.load);
+  const isOnline = useOfflineStore((s) => s.isOnline);
   const mapRef = useRef<MapRef>(null);
   const cameraRef = useRef<CameraRef>(null);
 
@@ -65,7 +67,13 @@ export function TripMap({
   // Every object/collection handed to the memoized native components is derived
   // once per input change: a fresh reference on each render would defeat the
   // upstream React.memo (Map/Camera/GeoJSONSource) and force a native re-diff.
-  const mapStyle = useMemo(() => mapStyleFor(base), [base]);
+  // Offline: fall back to the tile-less style (theme neutral background) so the
+  // route + markers still render instead of a broken grid of failed tile
+  // requests; back online rebasculates to the normal tiled base.
+  const mapStyle = useMemo(
+    () => mapStyleFor(base, !isOnline, theme.colors.muted),
+    [base, isOnline, theme.colors.muted],
+  );
   const lineCoords = useMemo(
     () => stageSegments.flatMap((s) => s.coordinates),
     [stageSegments],

--- a/mobile/src/components/map/map-utils.test.ts
+++ b/mobile/src/components/map/map-utils.test.ts
@@ -1,9 +1,11 @@
 /// <reference types="jest" />
+import type { StyleSpecification } from '@maplibre/maplibre-react-native';
 import type { StageData } from '@btp/core';
 import { EMPTY_RESUPPLY } from '@btp/core';
 import {
   alertSegmentToCoords,
   applyZoom,
+  buildOfflineStyle,
   buildSatelliteStyle,
   buildStageLines,
   collectMarkers,
@@ -97,6 +99,40 @@ describe('buildSatelliteStyle / mapStyleFor', () => {
   it('returns the Positron URL for map and the satellite style object', () => {
     expect(mapStyleFor('map')).toBe(POSITRON_STYLE_URL);
     expect(typeof mapStyleFor('satellite')).toBe('object');
+  });
+
+  it('degrades offline to a tile-less style with no network source, whatever the base', () => {
+    for (const base of ['map', 'satellite'] as const) {
+      const style = mapStyleFor(base, true, '#123456');
+      expect(typeof style).toBe('object');
+      const spec = style as StyleSpecification;
+      // No tile source of any kind: nothing hits the network offline.
+      expect(spec.sources).toEqual({});
+      expect(spec.layers).toEqual([
+        { id: 'offline-background', type: 'background', paint: { 'background-color': '#123456' } },
+      ]);
+      // The Positron URL and the satellite raster tiles are both gone.
+      expect(JSON.stringify(spec)).not.toContain(SATELLITE_TILE_URL);
+      expect(JSON.stringify(spec)).not.toContain('cartocdn');
+    }
+  });
+
+  it('rebasculates to the tiled base once back online', () => {
+    expect(mapStyleFor('map', false, '#123456')).toBe(POSITRON_STYLE_URL);
+    const sat = mapStyleFor('satellite', false, '#123456') as StyleSpecification;
+    expect(sat.sources['esri-world-imagery']).toMatchObject({ type: 'raster' });
+  });
+});
+
+describe('buildOfflineStyle', () => {
+  it('paints only a background layer, keeping room for local GeoJSON sources', () => {
+    const style = buildOfflineStyle('#abcdef');
+    expect(style.sources).toEqual({});
+    expect(style.layers).toHaveLength(1);
+    expect(style.layers[0]).toMatchObject({
+      type: 'background',
+      paint: { 'background-color': '#abcdef' },
+    });
   });
 });
 

--- a/mobile/src/components/map/map-utils.ts
+++ b/mobile/src/components/map/map-utils.ts
@@ -33,7 +33,30 @@ export function buildSatelliteStyle(): StyleSpecification {
   };
 }
 
-export function mapStyleFor(base: MapBase): string | StyleSpecification {
+// Offline fallback style: a single flat background layer and no network tile
+// source, so the map still mounts and paints the local GeoJSON sources (route +
+// markers, added as children by TripMap) instead of a broken grey grid of failed
+// tile requests. `background` comes from the mobile theme (never a raw hex).
+export function buildOfflineStyle(background: string): StyleSpecification {
+  return {
+    version: 8,
+    sources: {},
+    layers: [
+      { id: 'offline-background', type: 'background', paint: { 'background-color': background } },
+    ],
+  };
+}
+
+// Resolve the MapLibre style for the current base. Offline (offline-store
+// isOnline === false) drops the network-tiled Positron/satellite bases for the
+// tile-less offline style; the local GeoJSON sources still render on top. Back
+// online rebasculates to the normal tiled style.
+export function mapStyleFor(
+  base: MapBase,
+  offline = false,
+  offlineBackground = 'transparent',
+): string | StyleSpecification {
+  if (offline) return buildOfflineStyle(offlineBackground);
   return base === 'satellite' ? buildSatelliteStyle() : POSITRON_STYLE_URL;
 }
 

--- a/mobile/src/components/trip/TripMapView.test.tsx
+++ b/mobile/src/components/trip/TripMapView.test.tsx
@@ -3,8 +3,9 @@ import TestRenderer, { act } from 'react-test-renderer';
 import { EMPTY_RESUPPLY } from '@btp/core';
 import type { ReactElement } from 'react';
 import type { StageData } from '@btp/core';
-import '../../i18n';
+import i18n from '../../i18n';
 import { useTripStore } from '../../store/trip-store';
+import { useOfflineStore } from '../../store/offline-store';
 import { collectMarkers } from '../map/map-utils';
 
 // Drive the safe-area insets so the layout test can assert the bottom inset is
@@ -99,6 +100,13 @@ describe('TripMapView', () => {
     act(() => {
       useTripStore.getState().reset();
       useTripStore.setState({ stages: [routedStage] });
+      useOfflineStore.setState({ isOnline: true });
+    });
+  });
+
+  afterAll(() => {
+    act(() => {
+      useOfflineStore.setState({ isOnline: true });
     });
   });
 
@@ -168,6 +176,24 @@ describe('TripMapView', () => {
       [2, 48],
       [2.01, 48.01],
     ]);
+  });
+
+  it('shows the offline map badge only when connectivity is down', () => {
+    const label = i18n.t('trip.map.offline');
+    const hasBadge = (root: any): boolean =>
+      root.findAll(
+        (n: any) =>
+          n.type === 'Text' &&
+          [].concat(n.props.children).join('') === label,
+      ).length > 0;
+
+    const online = render(<TripMapView />);
+    expect(hasBadge(online!.root)).toBe(false);
+
+    act(() => {
+      useOfflineStore.setState({ isOnline: false });
+    });
+    expect(hasBadge(online!.root)).toBe(true);
   });
 
   it('clears the highlight when the profile reports a release', () => {

--- a/mobile/src/components/trip/TripMapView.tsx
+++ b/mobile/src/components/trip/TripMapView.tsx
@@ -4,12 +4,14 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import { profileHighlightSegment } from '@btp/core/elevation';
 import { EmptyState } from '../ui';
+import { CloudOff } from '../ui/icons';
 import { TripMap } from '../TripMap';
 import { buildStageLines, collectMarkers } from '../map/map-utils';
 import { ElevationProfile } from './ElevationProfile';
 import { computeProfileSummary, groupThousands } from './trip-map-summary';
 import { useTheme } from '../../theme';
 import { useTripStore } from '../../store/trip-store';
+import { useOfflineStore } from '../../store/offline-store';
 import { useTripRoute } from '../../hooks/use-trip-route';
 
 // The map tab: derives the route polyline and markers from the store's stages
@@ -26,6 +28,7 @@ export function TripMapView() {
   const insets = useSafeAreaInsets();
   const { t } = useTranslation();
   const stages = useTripStore((s) => s.stages);
+  const isOnline = useOfflineStore((s) => s.isOnline);
   const [hover, setHover] = useState<{ coordIndex: number; stageIndex: number } | null>(
     null,
   );
@@ -56,6 +59,37 @@ export function TripMapView() {
           markers={markers}
           highlightedSegment={highlightedSegment}
         />
+        {/* Discrete "offline map" indicator: when connectivity drops, TripMap
+            degrades to the tile-less style (route + profile stay local); this
+            badge tells the rider why the base imagery is gone. */}
+        {!isOnline ? (
+          <View
+            pointerEvents="none"
+            accessibilityRole="text"
+            style={[
+              styles.offlineBadge,
+              {
+                backgroundColor: theme.colors.card,
+                borderColor: theme.colors.border,
+                paddingHorizontal: theme.spacing.sm,
+                paddingVertical: theme.spacing.xs,
+                gap: theme.spacing.xs,
+                ...theme.shadows.soft,
+              },
+            ]}
+          >
+            <CloudOff size={14} color={theme.colors.mutedForeground} />
+            <Text
+              style={{
+                color: theme.colors.mutedForeground,
+                fontFamily: theme.fonts.sansMedium,
+                fontSize: 12,
+              }}
+            >
+              {t('trip.map.offline')}
+            </Text>
+          </View>
+        ) : null}
       </View>
       {/* Fixed bottom profile panel: the map (flex:1) takes the remaining height
           and the panel keeps its intrinsic height (title + SVG + axis), so map +
@@ -138,6 +172,15 @@ export function TripMapView() {
 const styles = StyleSheet.create({
   container: { flex: 1 },
   map: { flex: 1 },
+  offlineBadge: {
+    position: 'absolute',
+    bottom: 12,
+    left: 12,
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderRadius: 999,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
   profile: { borderTopWidth: StyleSheet.hairlineWidth },
   profileHeader: {
     flexDirection: 'row',

--- a/mobile/src/components/ui/icons.ts
+++ b/mobile/src/components/ui/icons.ts
@@ -48,3 +48,5 @@ export {
 export { ShoppingBag } from 'lucide-react-native';
 // Notifications screen (#1120): permission banner + per-category icons.
 export { Bell, BellOff, CheckCircle2 } from 'lucide-react-native';
+// Offline map degradation (#1148): discrete "offline map" indicator.
+export { CloudOff } from 'lucide-react-native';

--- a/mobile/src/i18n/resources/en.ts
+++ b/mobile/src/i18n/resources/en.ts
@@ -338,6 +338,7 @@ export const en: typeof fr = {
     map: {
       layerMap: 'Map',
       layerSatellite: 'Satellite',
+      offline: 'Offline map',
       toggleA11y: 'Toggle base map',
       zoomInA11y: 'Zoom in',
       zoomOutA11y: 'Zoom out',

--- a/mobile/src/i18n/resources/fr.ts
+++ b/mobile/src/i18n/resources/fr.ts
@@ -338,6 +338,7 @@ export const fr = {
     map: {
       layerMap: 'Plan',
       layerSatellite: 'Satellite',
+      offline: 'Carte hors-ligne',
       toggleA11y: 'Changer le fond de carte',
       zoomInA11y: 'Zoomer',
       zoomOutA11y: 'Dézoomer',


### PR DESCRIPTION
Ferme #1148 (sous-ticket 3/3 de l'épic #1052, Sprint 58).

⚠️ **PR stackée** — base `feature/1146` (#1151). À merger après #1151. Indépendante de #1147 (diffs disjoints).

## Contenu

Quand `offline-store.isOnline === false`, `TripMap` (maplibre, #1040) ne casse plus sur les tuiles réseau indisponibles : tracé + marqueurs + profil restent affichés sur fond neutre ; retour online → rebascule sur le style tuilé.

- `map-utils.ts` : `buildOfflineStyle(background)` (style MapLibre v8 sans aucune source réseau, un seul layer `background`) + `mapStyleFor(base, offline?, offlineBackground?)`. Les sources GeoJSON (route/markers) sont des enfants de `TripMap`, donc rendues quel que soit le style.
- `TripMap.tsx` : lit `offline-store`, passe `!isOnline` + `theme.colors.muted` (pas de hex brut).
- `TripMapView.tsx` : badge discret « carte hors-ligne » (overlay, tokens thème, icône `CloudOff`), offline uniquement. Profil inchangé.
- i18n fr+en (`trip.map.offline`).

Périmètre : ni `trip-cache`/`use-trip-detail` (#1147) ni `RoadbookView` (#1149) touchés.

## Vérification

- `tsc --noEmit` (mobile) : 0 erreur.
- `jest` (mobile) : 554/554 en run isolé (un premier run montrait les flakes env `account/notifications`/`ShareSheet`, rouges sur `main` aussi).
- Preuve failible : mutation de `mapStyleFor` (offline → style satellite au lieu de tile-less) → test rouge, restauré.
- **Rendu carte offline à valider sur device** (recette manuelle). Playwright/fonctionnel : CI.

## Auto-critique

- Pas de dépendance ajoutée. NB : le `node_modules` du checkout principal était pré-#1146 (netinfo absent) ; matérialisé dans le worktree sans toucher au lockfile — un `npm install` sur `main` après merge de #1151 est souhaitable.
- Le style offline est volontairement minimal (fond uni) : pas de tuiles pré-téléchargées (hors scope épic, cf. ADR-059).

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 critical, 0 warning findings. The offline-degradation logic (`mapStyleFor`/`buildOfflineStyle`), the online/offline transitions, and hiding the now-inert layer toggle while offline are all correctly implemented and covered by tests at every layer (pure `map-utils`, the real `TripMap` component, and the `TripMapView` badge).

Resolved 1 previously open thread that was addressed (layer toggle now hidden while offline, per commit `c2e2323`).

**PR title check:** the title's description ("dégradation offline de la carte...") is a noun phrase, not imperative mood as required by the Conventional Commits convention in `CLAUDE.md` (contrast with this PR's own commit headline, "degrade map offline (...)"). Non-blocking since commits are squashed, but worth adjusting before merge if the PR title is reused as the squash message.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

**Commit reviewed:** `c2e2323d3ff72902700e675f7300f89445ecc06d`
<!-- claude-review-end -->