### PR TITLE
feat(mobile): cache offline voyages à venir/en cours + fraîcheur + sync arrière-plan

### DIFF
--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import '../src/i18n';
 import { AuthProvider } from '../src/auth/store';
 import { usePushRouting } from '../src/notifications/use-push-routing';
+import { useBackgroundTripSync } from '../src/hooks/use-background-sync';
 import { useConnectivity } from '../src/store/use-connectivity';
 import { ThemeProvider, useTheme } from '../src/theme';
 
@@ -14,6 +15,8 @@ function RootNavigator() {
   usePushRouting();
   // Feed real NetInfo connectivity into the offline store / mutation gate (#1146).
   useConnectivity();
+  // Keep the offline trip cache fresh on return-to-online / app foreground (#1147).
+  useBackgroundTripSync();
   return (
     <Stack
       // The header integrates with the theme (light/dark) instead of the default

--- a/mobile/app/trip/[id]/index.tsx
+++ b/mobile/app/trip/[id]/index.tsx
@@ -1,5 +1,5 @@
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
-import { type ReactNode, useMemo, useState } from 'react';
+import { type ReactNode, useEffect, useMemo, useState } from 'react';
 import { Alert, Modal, PanResponder, Pressable, Text, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
@@ -33,6 +33,8 @@ import { useTripLive } from '../../../src/hooks/use-trip-live';
 import { useTripMutations } from '../../../src/hooks/use-trip-mutations';
 import type { MutationFailure } from '../../../src/store/gating';
 import { useTripStore } from '../../../src/store/trip-store';
+import { readTripCache } from '../../../src/store/trip-cache';
+import { formatFreshness } from '../../../src/lib/freshness';
 import { swipeToView } from '../../../src/lib/swipe';
 
 type TripView = 'roadbook' | 'map';
@@ -120,6 +122,20 @@ export default function TripRoadbook() {
   const computing = useTripStore((s) => s.computing);
   const loading = useTripStore((s) => s.loading);
   const error = useTripStore((s) => s.error);
+
+  // Offline "synced X ago" indicator (#1147): read the cache timestamp once the
+  // trip has loaded (a fresh online load has just re-stamped it).
+  const [syncedAt, setSyncedAt] = useState<number | null>(null);
+  useEffect(() => {
+    if (loading) return;
+    let cancelled = false;
+    void readTripCache(id).then((cached) => {
+      if (!cancelled) setSyncedAt(cached?.syncedAt ?? null);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [id, loading]);
 
   const onFailure = (reason: MutationFailure) =>
     Alert.alert(t('common.error'), t(`trip.edit.reason.${reason}`));
@@ -211,6 +227,21 @@ export default function TripRoadbook() {
         }}
       >
         <SegmentedControl segments={segments} value={view} onChange={setView} />
+        {syncedAt !== null ? (
+          <Text
+            style={{
+              marginTop: theme.spacing.xs,
+              color: theme.colors.mutedForeground,
+              fontFamily: theme.fonts.sans,
+              fontSize: 12,
+              textAlign: 'center',
+            }}
+          >
+            {t('freshness.synced', {
+              ago: formatFreshness(t, syncedAt, Date.now()),
+            })}
+          </Text>
+        ) : null}
       </View>
 
       <View style={{ flex: 1 }} {...panResponder.panHandlers}>

--- a/mobile/src/hooks/use-background-sync.ts
+++ b/mobile/src/hooks/use-background-sync.ts
@@ -1,0 +1,36 @@
+import { useEffect } from 'react';
+import { AppState } from 'react-native';
+import { fetchTripDetail, fetchTripRoute } from '../api/trips';
+import { useOfflineStore } from '../store/offline-store';
+import { syncCachedTrips } from '../store/trip-cache';
+
+// Real dependencies for the background re-sync. Built once: the fetchers are
+// stable module functions and `isOnline` reads the store lazily at call time.
+const deps = {
+  isOnline: () => useOfflineStore.getState().isOnline,
+  fetchDetail: fetchTripDetail,
+  fetchRoute: fetchTripRoute,
+};
+
+// Keep the offline cache of upcoming/ongoing trips fresh (#1147): silently
+// re-fetch every cached trip whenever the device comes back online or the app
+// returns to the foreground. No manual "offline mode" — this just tops up the
+// cache in the background. Wired once at boot in app/_layout.tsx.
+export function useBackgroundTripSync(): void {
+  const isOnline = useOfflineStore((s) => s.isOnline);
+
+  // Coming (back) online: refresh the cache. Also runs on mount when already
+  // online, seeding a fresh sync at launch.
+  useEffect(() => {
+    if (isOnline) void syncCachedTrips(deps);
+  }, [isOnline]);
+
+  // App returns to the foreground: the cache may be stale after time in the
+  // background. syncCachedTrips itself bails out when still offline.
+  useEffect(() => {
+    const sub = AppState.addEventListener('change', (state) => {
+      if (state === 'active') void syncCachedTrips(deps);
+    });
+    return () => sub.remove();
+  }, []);
+}

--- a/mobile/src/hooks/use-trip-detail.test.ts
+++ b/mobile/src/hooks/use-trip-detail.test.ts
@@ -1,18 +1,31 @@
 /// <reference types="jest" />
 import { runLoadTripDetail } from './use-trip-detail';
+import { useOfflineStore } from '../store/offline-store';
 
 jest.mock('../api/trips', () => ({ fetchTripDetail: jest.fn() }));
+jest.mock('../store/trip-cache', () => ({
+  cacheTripDetail: jest.fn(),
+  readTripCache: jest.fn(),
+}));
 import { fetchTripDetail } from '../api/trips';
+import { cacheTripDetail, readTripCache } from '../store/trip-cache';
 const mockDetail = fetchTripDetail as jest.MockedFunction<typeof fetchTripDetail>;
+const mockCache = cacheTripDetail as jest.MockedFunction<typeof cacheTripDetail>;
+const mockReadCache = readTripCache as jest.MockedFunction<typeof readTripCache>;
 
-beforeEach(() => jest.clearAllMocks());
+beforeEach(() => {
+  jest.clearAllMocks();
+  useOfflineStore.getState().setOnline(true);
+  mockReadCache.mockResolvedValue(null);
+});
 
 describe('runLoadTripDetail (#1031)', () => {
-  it('returns the detail on success', async () => {
+  it('returns the detail on success and refreshes the cache', async () => {
     mockDetail.mockResolvedValue({ title: 'Trip' } as never);
     const { detail, error } = await runLoadTripDetail('t1');
     expect(detail).toEqual({ title: 'Trip' });
     expect(error).toBeNull();
+    expect(mockCache).toHaveBeenCalledWith('t1', { title: 'Trip' });
   });
 
   it('reports "Voyage introuvable." when the detail is null', async () => {
@@ -22,9 +35,36 @@ describe('runLoadTripDetail (#1031)', () => {
     expect(error).toBe('Voyage introuvable.');
   });
 
-  it('reports a load error when the fetch throws', async () => {
+  it('reports a load error when the fetch throws and no cache exists', async () => {
     mockDetail.mockRejectedValue(new Error('boom'));
     const { error } = await runLoadTripDetail('t1');
     expect(error).toBe('Impossible de charger le voyage.');
+  });
+});
+
+describe('runLoadTripDetail offline cache (#1147)', () => {
+  it('serves the cache without hitting the network while offline', async () => {
+    useOfflineStore.getState().setOnline(false);
+    mockReadCache.mockResolvedValue({
+      detail: { title: 'Cached' },
+      route: null,
+      syncedAt: 1,
+    } as never);
+    const { detail, error } = await runLoadTripDetail('t1');
+    expect(detail).toEqual({ title: 'Cached' });
+    expect(error).toBeNull();
+    expect(mockDetail).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the cache when the network fetch fails', async () => {
+    mockDetail.mockRejectedValue(new Error('boom'));
+    mockReadCache.mockResolvedValue({
+      detail: { title: 'Cached' },
+      route: null,
+      syncedAt: 1,
+    } as never);
+    const { detail, error } = await runLoadTripDetail('t1');
+    expect(detail).toEqual({ title: 'Cached' });
+    expect(error).toBeNull();
   });
 });

--- a/mobile/src/hooks/use-trip-detail.ts
+++ b/mobile/src/hooks/use-trip-detail.ts
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { fetchTripDetail, type TripDetail } from '../api/trips';
+import { useOfflineStore } from '../store/offline-store';
+import { cacheTripDetail, readTripCache } from '../store/trip-cache';
 
 export interface TripDetailState {
   detail: TripDetail | null;
@@ -9,12 +11,23 @@ export interface TripDetailState {
 // Extracted for unit-testing the async/error branches (mirrors runTripLive).
 // One-shot fetch (no SSE): use it for a read-only preview; the live roadbook
 // hydration + Mercure subscription lives in useTripLive.
+//
+// Offline-aware (#1147): when the device is offline we serve the persisted cache
+// straight away, and a network failure falls back to it too. A successful online
+// load refreshes the cache (upcoming/ongoing trips only — see cacheTripDetail).
 export async function runLoadTripDetail(id: string): Promise<TripDetailState> {
+  if (!useOfflineStore.getState().isOnline) {
+    const cached = await readTripCache(id);
+    if (cached) return { detail: cached.detail, error: null };
+  }
   try {
     const detail = await fetchTripDetail(id);
     if (!detail) return { detail: null, error: 'Voyage introuvable.' };
+    void cacheTripDetail(id, detail);
     return { detail, error: null };
   } catch {
+    const cached = await readTripCache(id);
+    if (cached) return { detail: cached.detail, error: null };
     return { detail: null, error: 'Impossible de charger le voyage.' };
   }
 }

--- a/mobile/src/hooks/use-trip-live.test.ts
+++ b/mobile/src/hooks/use-trip-live.test.ts
@@ -6,19 +6,27 @@ import type { EnrichedStagePayload, MercureEvent } from '@btp/core/mercure';
 import { runTripLive, useTripLive } from './use-trip-live';
 import { useTripStore } from '../store/trip-store';
 import { useDismissedAlerts } from '../store/dismissed-alerts';
+import { useOfflineStore } from '../store/offline-store';
 
 jest.mock('../api/trips', () => ({ fetchTripDetail: jest.fn() }));
 jest.mock('../api/mercure', () => ({
   fetchMercureToken: jest.fn(),
   subscribeToTrip: jest.fn(),
 }));
+jest.mock('../store/trip-cache', () => ({
+  cacheTripDetail: jest.fn(),
+  readTripCache: jest.fn(),
+}));
 
 import { fetchTripDetail } from '../api/trips';
 import { fetchMercureToken, subscribeToTrip } from '../api/mercure';
+import { cacheTripDetail, readTripCache } from '../store/trip-cache';
 
 const mockDetail = fetchTripDetail as jest.MockedFunction<typeof fetchTripDetail>;
 const mockToken = fetchMercureToken as jest.MockedFunction<typeof fetchMercureToken>;
 const mockSubscribe = subscribeToTrip as jest.MockedFunction<typeof subscribeToTrip>;
+const mockCache = cacheTripDetail as jest.MockedFunction<typeof cacheTripDetail>;
+const mockReadCache = readTripCache as jest.MockedFunction<typeof readTripCache>;
 
 const A = { lat: 1, lon: 1, ele: 0 };
 const B = { lat: 2, lon: 2, ele: 0 };
@@ -47,6 +55,10 @@ function apiStage(overrides: Record<string, unknown> = {}) {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const detail = (stages: unknown[]) => ({ title: 'Trip', stages }) as any;
+// A cached entry wrapping the same /detail shape (#1147).
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const detailCache = (stages: unknown[]) =>
+  ({ detail: detail(stages), route: null, syncedAt: 1 }) as any;
 
 function enrichedPayload(): EnrichedStagePayload {
   return {
@@ -74,6 +86,8 @@ beforeEach(() => {
   jest.clearAllMocks();
   useTripStore.getState().reset();
   useDismissedAlerts.getState().reset();
+  useOfflineStore.getState().setOnline(true);
+  mockReadCache.mockResolvedValue(null);
 });
 
 describe('runTripLive orchestration (#1014)', () => {
@@ -156,6 +170,41 @@ describe('runTripLive orchestration (#1014)', () => {
   it('aborts before subscribing when cancelled during the /detail fetch', async () => {
     mockDetail.mockResolvedValue(detail([apiStage()]));
     const sub = await runTripLive('t1', store(), () => true);
+    expect(mockSubscribe).not.toHaveBeenCalled();
+    expect(sub).toBeUndefined();
+  });
+
+  it('caches the /detail payload after a successful online hydrate (#1147)', async () => {
+    mockDetail.mockResolvedValue(detail([apiStage()]));
+    mockToken.mockResolvedValue('jwt');
+    mockSubscribe.mockReturnValue({ close: jest.fn() });
+
+    await runTripLive('t1', store(), notCancelled);
+
+    expect(mockCache).toHaveBeenCalledWith('t1', expect.objectContaining({ title: 'Trip' }));
+  });
+
+  it('hydrates from cache and skips SSE while offline (#1147)', async () => {
+    useOfflineStore.getState().setOnline(false);
+    mockReadCache.mockResolvedValue(detailCache([apiStage()]));
+
+    const sub = await runTripLive('t1', store(), notCancelled);
+
+    expect(store().stages).toHaveLength(1);
+    expect(store().error).toBeNull();
+    expect(mockDetail).not.toHaveBeenCalled();
+    expect(mockSubscribe).not.toHaveBeenCalled();
+    expect(sub).toBeUndefined();
+  });
+
+  it('falls back to cache when /detail fails, without surfacing an error (#1147)', async () => {
+    mockDetail.mockRejectedValue(new Error('offline'));
+    mockReadCache.mockResolvedValue(detailCache([apiStage()]));
+
+    const sub = await runTripLive('t1', store(), notCancelled);
+
+    expect(store().stages).toHaveLength(1);
+    expect(store().error).toBeNull();
     expect(mockSubscribe).not.toHaveBeenCalled();
     expect(sub).toBeUndefined();
   });

--- a/mobile/src/hooks/use-trip-live.ts
+++ b/mobile/src/hooks/use-trip-live.ts
@@ -8,6 +8,8 @@ import {
 } from '../api/mercure';
 import { useTripStore } from '../store/trip-store';
 import { useDismissedAlerts } from '../store/dismissed-alerts';
+import { useOfflineStore } from '../store/offline-store';
+import { cacheTripDetail, readTripCache } from '../store/trip-cache';
 
 // The store actions the orchestration drives.
 export interface TripLiveStore {
@@ -32,13 +34,32 @@ export async function runTripLive(
 ): Promise<TripSubscription | undefined> {
   store.setStatus({ loading: true, error: null });
 
+  // Offline (#1147): hydrate straight from the persisted cache and skip the live
+  // subscription — no network means no /detail and no Mercure token. The route
+  // geometry is pulled separately by useTripRoute (also cache-aware).
+  if (!useOfflineStore.getState().isOnline) {
+    const cached = await readTripCache(id);
+    if (isCancelled()) return undefined;
+    if (cached) {
+      store.hydrate(id, cached.detail);
+      useDismissedAlerts.getState().reset();
+      return undefined;
+    }
+  }
+
   let detail;
   try {
     detail = await fetchTripDetail(id);
   } catch {
-    if (!isCancelled()) {
-      store.setStatus({ loading: false, error: 'Impossible de charger le roadbook.' });
+    // Network failure: fall back to the cache before surfacing an error.
+    const cached = await readTripCache(id);
+    if (isCancelled()) return undefined;
+    if (cached) {
+      store.hydrate(id, cached.detail);
+      useDismissedAlerts.getState().reset();
+      return undefined;
     }
+    store.setStatus({ loading: false, error: 'Impossible de charger le roadbook.' });
     return undefined;
   }
   if (isCancelled()) return undefined;
@@ -46,6 +67,7 @@ export async function runTripLive(
     store.setStatus({ loading: false, error: 'Voyage introuvable.' });
     return undefined;
   }
+  void cacheTripDetail(id, detail);
   store.hydrate(id, detail);
   // Alert dismissals are keyed on dayNumber:code, which collide across trips;
   // clear them when a new trip is loaded so a dismissal on one trip does not hide

--- a/mobile/src/hooks/use-trip-route.test.ts
+++ b/mobile/src/hooks/use-trip-route.test.ts
@@ -3,12 +3,20 @@ import { createElement } from 'react';
 import TestRenderer, { act } from 'react-test-renderer';
 import type { StageData } from '@btp/core';
 import { EMPTY_RESUPPLY } from '@btp/core';
-import { useTripRoute } from './use-trip-route';
+import { runLoadTripRoute, useTripRoute } from './use-trip-route';
 import { useTripStore } from '../store/trip-store';
+import { useOfflineStore } from '../store/offline-store';
 
 jest.mock('../api/trips', () => ({ fetchTripRoute: jest.fn() }));
+jest.mock('../store/trip-cache', () => ({
+  cacheTripRoute: jest.fn(),
+  readTripCache: jest.fn(),
+}));
 import { fetchTripRoute } from '../api/trips';
+import { cacheTripRoute, readTripCache } from '../store/trip-cache';
 const mockRoute = fetchTripRoute as jest.MockedFunction<typeof fetchTripRoute>;
+const mockCacheRoute = cacheTripRoute as jest.MockedFunction<typeof cacheTripRoute>;
+const mockReadCache = readTripCache as jest.MockedFunction<typeof readTripCache>;
 
 const A = { lat: 1, lon: 1, ele: 0 };
 const B = { lat: 2, lon: 2, ele: 0 };
@@ -57,6 +65,8 @@ async function render(options?: { enabled?: boolean }): Promise<void> {
 beforeEach(() => {
   jest.clearAllMocks();
   useTripStore.getState().reset();
+  useOfflineStore.getState().setOnline(true);
+  mockReadCache.mockResolvedValue(null);
 });
 
 afterEach(() => {
@@ -101,15 +111,45 @@ describe('useTripRoute (ADR-057)', () => {
     expect(mockRoute).not.toHaveBeenCalled();
   });
 
-  it('warns (but never throws) when the fetch fails', async () => {
-    const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+  it('leaves the geometry unloaded (never throws) when the fetch fails with no cache', async () => {
     useTripStore.setState({ tripId: 't1', geometryLoaded: false, loading: false });
     mockRoute.mockRejectedValue(new Error('boom'));
 
     await render();
 
-    expect(warn).toHaveBeenCalled();
     expect(store().geometryLoaded).toBe(false);
-    warn.mockRestore();
+  });
+
+  it('caches the route after a successful online fetch (#1147)', async () => {
+    useTripStore.setState({ tripId: 't1', geometryLoaded: false, loading: false });
+    const route = { id: 't1', stages: [{ dayNumber: 1, geometry: [] }] };
+    mockRoute.mockResolvedValue(route as never);
+
+    await render();
+
+    expect(mockCacheRoute).toHaveBeenCalledWith('t1', route);
+  });
+});
+
+describe('runLoadTripRoute offline cache (#1147)', () => {
+  const route = { id: 't1', stages: [{ dayNumber: 1, geometry: [] }] };
+
+  it('serves the cached tracé without hitting the network while offline', async () => {
+    useOfflineStore.getState().setOnline(false);
+    mockReadCache.mockResolvedValue({ detail: {}, route, syncedAt: 1 } as never);
+
+    const result = await runLoadTripRoute('t1');
+
+    expect(result).toEqual(route);
+    expect(mockRoute).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the cached tracé when the network fetch fails', async () => {
+    mockRoute.mockRejectedValue(new Error('boom'));
+    mockReadCache.mockResolvedValue({ detail: {}, route, syncedAt: 1 } as never);
+
+    const result = await runLoadTripRoute('t1');
+
+    expect(result).toEqual(route);
   });
 });

--- a/mobile/src/hooks/use-trip-route.ts
+++ b/mobile/src/hooks/use-trip-route.ts
@@ -1,6 +1,27 @@
 import { useEffect } from 'react';
-import { fetchTripRoute } from '../api/trips';
+import { fetchTripRoute, type TripRoute } from '../api/trips';
 import { useTripStore } from '../store/trip-store';
+import { useOfflineStore } from '../store/offline-store';
+import { cacheTripRoute, readTripCache } from '../store/trip-cache';
+
+// Load the trip's route geometry (ADR-057), offline-aware (#1147): offline we
+// serve the cached tracé, and a network failure falls back to it too; a
+// successful online load refreshes the cache. Never throws — a miss just leaves
+// the map/profile empty (returns null). Extracted so the branches are testable.
+export async function runLoadTripRoute(id: string): Promise<TripRoute | null> {
+  if (!useOfflineStore.getState().isOnline) {
+    const cached = await readTripCache(id);
+    if (cached?.route) return cached.route;
+  }
+  try {
+    const route = await fetchTripRoute(id);
+    if (route) void cacheTripRoute(id, route);
+    return route;
+  } catch {
+    const cached = await readTripCache(id);
+    return cached?.route ?? null;
+  }
+}
 
 // Fetch the trip's route geometry once (ADR-057) and merge it into the store's
 // stages. The summary (/detail) carries no geometry, so the map, the stage
@@ -20,15 +41,9 @@ export function useTripRoute(options?: { enabled?: boolean }): void {
   useEffect(() => {
     if (!enabled || !tripId || geometryLoaded) return;
     let cancelled = false;
-    void fetchTripRoute(tripId)
-      .then((route) => {
-        if (!cancelled && route) applyRoute(route);
-      })
-      .catch((error: unknown) => {
-        // Graceful degradation (the map/profile just stay empty), but don't
-        // swallow it silently — it's the only signal the route never loaded.
-        console.warn('Failed to load trip route geometry', error);
-      });
+    void runLoadTripRoute(tripId).then((route) => {
+      if (!cancelled && route) applyRoute(route);
+    });
     return () => {
       cancelled = true;
     };

--- a/mobile/src/i18n/resources/en.ts
+++ b/mobile/src/i18n/resources/en.ts
@@ -504,6 +504,7 @@ export const en: typeof fr = {
     hoursAgo: '{{count}}h ago',
     yesterday: 'yesterday',
     daysAgo: '{{count}} days ago',
+    synced: 'Synced {{ago}}',
   },
   export: {
     trip: 'Export',

--- a/mobile/src/i18n/resources/fr.ts
+++ b/mobile/src/i18n/resources/fr.ts
@@ -504,6 +504,7 @@ export const fr = {
     hoursAgo: 'il y a {{count}} h',
     yesterday: 'hier',
     daysAgo: 'il y a {{count}} j',
+    synced: 'Synchronisé {{ago}}',
   },
   export: {
     trip: 'Exporter',

--- a/mobile/src/store/mutations.test.ts
+++ b/mobile/src/store/mutations.test.ts
@@ -22,6 +22,10 @@ import {
 import { useTripStore } from './trip-store';
 import { useOfflineStore } from './offline-store';
 
+jest.mock('./trip-cache', () => ({
+  deleteTripCache: jest.fn(),
+}));
+
 jest.mock('../api/trips', () => ({
   updateTripConfig: jest.fn(),
   createStage: jest.fn(),
@@ -51,6 +55,7 @@ import {
   duplicateTrip,
   deleteTrip,
 } from '../api/trips';
+import { deleteTripCache } from './trip-cache';
 
 const mock = <T extends (...args: never[]) => unknown>(fn: T) =>
   fn as unknown as jest.MockedFunction<T>;
@@ -491,5 +496,17 @@ describe('runAnalyze / lifecycle', () => {
     useOfflineStore.setState({ isOnline: true });
     mock(deleteTrip).mockResolvedValue({ ok: true, status: 204 });
     expect(await runDeleteTrip('t1', ctx(), jest.fn())).toBe(true);
+  });
+
+  it('runDeleteTrip evicts the offline cache on successful deletion, not on failure', async () => {
+    useOfflineStore.setState({ isOnline: true });
+
+    mock(deleteTrip).mockResolvedValue({ ok: false, status: 404 });
+    expect(await runDeleteTrip('t1', ctx(), jest.fn())).toBe(false);
+    expect(deleteTripCache).not.toHaveBeenCalled();
+
+    mock(deleteTrip).mockResolvedValue({ ok: true, status: 204 });
+    expect(await runDeleteTrip('t1', ctx(), jest.fn())).toBe(true);
+    expect(deleteTripCache).toHaveBeenCalledWith('t1');
   });
 });

--- a/mobile/src/store/mutations.ts
+++ b/mobile/src/store/mutations.ts
@@ -25,6 +25,7 @@ import {
   type MutationFailure,
 } from './gating';
 import { useOfflineStore } from './offline-store';
+import { deleteTripCache } from './trip-cache';
 import type { Modification, TripConfig } from './trip-store';
 
 // The store slice + actions the mutation runners drive. `useTripStore.getState()`
@@ -543,6 +544,7 @@ export function runDeleteTrip(
         onFailure(normalizeStatus(status));
         return false;
       }
+      void deleteTripCache(tripId);
       return true;
     })
     .catch(() => {

--- a/mobile/src/store/trip-cache.test.ts
+++ b/mobile/src/store/trip-cache.test.ts
@@ -22,6 +22,11 @@ jest.mock('expo-file-system', () => {
       if (!mockFiles.has(this.uri)) mockFiles.set(this.uri, '');
     }
     write(content: string) {
+      // Faithful to expo-file-system's next API: write() requires the file to
+      // already exist (create() must be called first), it does not auto-create.
+      if (!mockFiles.has(this.uri)) {
+        throw new Error(`ENOENT: file does not exist, write '${this.uri}'`);
+      }
       mockFiles.set(this.uri, content);
     }
     text() {
@@ -98,6 +103,15 @@ describe('cacheTripDetail / readTripCache', () => {
     expect(cached?.detail.title).toBe('Trip');
     expect(cached?.syncedAt).toBe(1234);
     expect(cached?.route).toBeNull();
+  });
+
+  it('persists on the very first write for a trip id (no pre-existing file)', async () => {
+    // No prior create()/write() for this id: the mock File.write() throws unless
+    // the file was created first, so this only passes if writeEntry creates it.
+    expect(mockFiles.size).toBe(0);
+    await cacheTripDetail('brand-new', detail(), 999);
+    const cached = await readTripCache('brand-new');
+    expect(cached?.syncedAt).toBe(999);
   });
 
   it('does not cache a past trip', async () => {

--- a/mobile/src/store/trip-cache.test.ts
+++ b/mobile/src/store/trip-cache.test.ts
@@ -1,0 +1,181 @@
+/// <reference types="jest" />
+import type { TripDetail, TripRoute } from '../api/trips';
+
+// In-memory filesystem backing the mocked expo-file-system. Keyed by file uri.
+const mockFiles = new Map<string, string>();
+let mockDirExists = true;
+
+// Minimal File/Directory/Paths doubles matching the expo-file-system next API
+// (create/write/text/exists/delete + Directory.list) used by trip-cache.
+jest.mock('expo-file-system', () => {
+  class File {
+    uri: string;
+    name: string;
+    constructor(dir: { uri: string }, name: string) {
+      this.uri = `${dir.uri}/${name}`;
+      this.name = name;
+    }
+    get exists() {
+      return mockFiles.has(this.uri);
+    }
+    create() {
+      if (!mockFiles.has(this.uri)) mockFiles.set(this.uri, '');
+    }
+    write(content: string) {
+      mockFiles.set(this.uri, content);
+    }
+    text() {
+      return Promise.resolve(mockFiles.get(this.uri) ?? '');
+    }
+    delete() {
+      mockFiles.delete(this.uri);
+    }
+  }
+  class Directory {
+    uri: string;
+    constructor(parent: { uri: string }, name: string) {
+      this.uri = `${parent.uri}/${name}`;
+    }
+    get exists() {
+      return mockDirExists;
+    }
+    create() {
+      mockDirExists = true;
+    }
+    list() {
+      const prefix = `${this.uri}/`;
+      return [...mockFiles.keys()]
+        .filter((uri) => uri.startsWith(prefix))
+        .map((uri) => ({ name: uri.slice(prefix.length) }));
+    }
+  }
+  return { File, Directory, Paths: { document: { uri: 'file:///doc' } } };
+});
+
+import {
+  cacheTripDetail,
+  cacheTripRoute,
+  deleteTripCache,
+  isCacheableTrip,
+  listCachedTripIds,
+  readTripCache,
+  syncCachedTrips,
+} from './trip-cache';
+
+// A fixed "today" so the lifecycle classification is deterministic.
+const TODAY = '2026-08-21';
+
+// Far-future dates so cacheTripDetail (which classifies against the real "today")
+// always sees these as upcoming, regardless of when the suite runs.
+function detail(over: Partial<TripDetail> = {}): TripDetail {
+  return { title: 'Trip', startDate: '2099-09-01', endDate: '2099-09-05', ...over } as TripDetail;
+}
+
+const route = { stages: [{ dayNumber: 1, geometry: [] }] } as unknown as TripRoute;
+
+beforeEach(() => {
+  mockFiles.clear();
+  mockDirExists = true;
+});
+
+describe('isCacheableTrip', () => {
+  it('caches upcoming and ongoing trips', () => {
+    expect(isCacheableTrip('2026-09-01', '2026-09-05', TODAY)).toBe(true); // upcoming
+    expect(isCacheableTrip('2026-08-20', '2026-08-25', TODAY)).toBe(true); // ongoing
+  });
+  it('caches an undated (draft) trip', () => {
+    expect(isCacheableTrip(null, null, TODAY)).toBe(true);
+  });
+  it('excludes a past trip', () => {
+    expect(isCacheableTrip('2026-07-01', '2026-07-10', TODAY)).toBe(false);
+  });
+});
+
+describe('cacheTripDetail / readTripCache', () => {
+  it('writes an upcoming trip and reads it back with a timestamp', async () => {
+    await cacheTripDetail('trip-1', detail(), 1234);
+    const cached = await readTripCache('trip-1');
+    expect(cached?.detail.title).toBe('Trip');
+    expect(cached?.syncedAt).toBe(1234);
+    expect(cached?.route).toBeNull();
+  });
+
+  it('does not cache a past trip', async () => {
+    await cacheTripDetail('past-1', detail({ startDate: '2000-01-01', endDate: '2000-01-05' }));
+    expect(await readTripCache('past-1')).toBeNull();
+  });
+
+  it('evicts a cached trip that has turned past', async () => {
+    await cacheTripDetail('trip-2', detail());
+    expect(await readTripCache('trip-2')).not.toBeNull();
+    await cacheTripDetail('trip-2', detail({ startDate: '2000-01-01', endDate: '2000-01-05' }));
+    expect(await readTripCache('trip-2')).toBeNull();
+  });
+
+  it('rejects an unsafe id (no file escapes the cache dir)', async () => {
+    await cacheTripDetail('../evil', detail());
+    expect(await readTripCache('../evil')).toBeNull();
+    expect(mockFiles.size).toBe(0);
+  });
+
+  it('returns null on a corrupt entry', async () => {
+    mockFiles.set('file:///doc/trip-cache/broken.json', '{not json');
+    expect(await readTripCache('broken')).toBeNull();
+  });
+});
+
+describe('cacheTripRoute', () => {
+  it('attaches geometry to an existing entry and preserves the detail', async () => {
+    await cacheTripDetail('trip-3', detail(), 10);
+    await cacheTripRoute('trip-3', route, 20);
+    const cached = await readTripCache('trip-3');
+    expect(cached?.route).toEqual(route);
+    expect(cached?.detail.title).toBe('Trip');
+    expect(cached?.syncedAt).toBe(20);
+  });
+
+  it('is a no-op when the trip is not already cached', async () => {
+    await cacheTripRoute('missing', route);
+    expect(await readTripCache('missing')).toBeNull();
+  });
+});
+
+describe('listCachedTripIds / deleteTripCache', () => {
+  it('lists cached ids and drops one on delete', async () => {
+    await cacheTripDetail('a', detail());
+    await cacheTripDetail('b', detail());
+    expect((await listCachedTripIds()).sort()).toEqual(['a', 'b']);
+    await deleteTripCache('a');
+    expect(await listCachedTripIds()).toEqual(['b']);
+  });
+});
+
+describe('syncCachedTrips', () => {
+  it('re-fetches cached trips when online and refreshes detail + route', async () => {
+    await cacheTripDetail('trip-4', detail({ title: 'Old' }), 1);
+    const fetchDetail = jest.fn().mockResolvedValue(detail({ title: 'New' }));
+    const fetchRoute = jest.fn().mockResolvedValue(route);
+    await syncCachedTrips({ isOnline: () => true, fetchDetail, fetchRoute });
+    expect(fetchDetail).toHaveBeenCalledWith('trip-4');
+    const cached = await readTripCache('trip-4');
+    expect(cached?.detail.title).toBe('New');
+    expect(cached?.route).toEqual(route);
+  });
+
+  it('bails out and fetches nothing while offline', async () => {
+    await cacheTripDetail('trip-5', detail());
+    const fetchDetail = jest.fn();
+    const fetchRoute = jest.fn();
+    await syncCachedTrips({ isOnline: () => false, fetchDetail, fetchRoute });
+    expect(fetchDetail).not.toHaveBeenCalled();
+  });
+
+  it('swallows a per-trip fetch failure', async () => {
+    await cacheTripDetail('trip-6', detail());
+    const fetchDetail = jest.fn().mockRejectedValue(new Error('offline'));
+    const fetchRoute = jest.fn();
+    await expect(
+      syncCachedTrips({ isOnline: () => true, fetchDetail, fetchRoute }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/mobile/src/store/trip-cache.ts
+++ b/mobile/src/store/trip-cache.ts
@@ -1,0 +1,179 @@
+import { Directory, File, Paths } from 'expo-file-system';
+import type { TripDetail, TripRoute } from '../api/trips';
+import { todayUtc, tripStateFromDates } from '../components/trip/roadbook-dates';
+
+// Persistent offline cache for the trips the rider is likely to open without a
+// connection: the /detail payload plus the static route geometry (#1147). It
+// rides on expo-file-system's document directory (survives restarts, not evicted
+// under storage pressure) rather than SecureStore — the route geometry is far too
+// large for SecureStore's small-value ceiling, and none of this is sensitive.
+//
+// Only upcoming / ongoing (and still-undated) trips are cached; a trip that has
+// turned *past* is evicted and served online-only, which bounds on-device storage
+// (a rider accumulates finished trips indefinitely). The lifecycle classifier is
+// reused from the roadbook rather than duplicated.
+
+export interface CachedTrip {
+  /** The last /detail payload fetched online. */
+  detail: TripDetail;
+  /** The last /route geometry fetched online, or null before the map was opened. */
+  route: TripRoute | null;
+  /** Epoch ms of the last successful online sync (drives "synced X ago"). */
+  syncedAt: number;
+}
+
+const CACHE_DIRNAME = 'trip-cache';
+// Trip ids are backend-issued UUID/ULID-like; reject anything else so a crafted id
+// can never escape the cache directory via the filename.
+const SAFE_ID = /^[A-Za-z0-9_-]+$/;
+
+/**
+ * Whether a trip is eligible for the offline cache: everything except a *past*
+ * trip (upcoming, ongoing, or still-undated). Past trips stay online-only to
+ * bound storage. Reuses {@link tripStateFromDates} instead of re-deriving the
+ * date math.
+ */
+export function isCacheableTrip(
+  startDate: string | null,
+  endDate: string | null,
+  today: string = todayUtc(),
+): boolean {
+  return tripStateFromDates(startDate, endDate, today) !== 'past';
+}
+
+function cacheDir(): Directory {
+  return new Directory(Paths.document, CACHE_DIRNAME);
+}
+
+function cacheFile(id: string): File {
+  return new File(cacheDir(), `${id}.json`);
+}
+
+function ensureDir(): void {
+  const dir = cacheDir();
+  if (!dir.exists) dir.create({ intermediates: true });
+}
+
+// Synchronous write, wrapped so a filesystem error never propagates: the cache is
+// best-effort and the live network path is authoritative.
+function writeEntry(id: string, entry: CachedTrip): void {
+  try {
+    ensureDir();
+    cacheFile(id).write(JSON.stringify(entry));
+  } catch {
+    // ignore: a failed cache write only costs a later offline miss.
+  }
+}
+
+/** Read a trip's cached entry, or null when it is absent or corrupt. */
+export async function readTripCache(id: string): Promise<CachedTrip | null> {
+  if (!SAFE_ID.test(id)) return null;
+  try {
+    const file = cacheFile(id);
+    if (!file.exists) return null;
+    const parsed = JSON.parse(await file.text()) as CachedTrip;
+    if (!parsed || typeof parsed.syncedAt !== 'number' || !parsed.detail) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/** Delete a trip's cache entry (e.g. once it turns past, or on trip deletion). */
+export async function deleteTripCache(id: string): Promise<void> {
+  if (!SAFE_ID.test(id)) return;
+  try {
+    const file = cacheFile(id);
+    if (file.exists) file.delete();
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * Persist (or refresh) a trip's /detail payload and stamp the sync time. A trip
+ * that is no longer cacheable (turned past) is evicted instead. Any existing
+ * route geometry is preserved.
+ */
+export async function cacheTripDetail(
+  id: string,
+  detail: TripDetail,
+  syncedAt: number = Date.now(),
+): Promise<void> {
+  if (!SAFE_ID.test(id)) return;
+  if (!isCacheableTrip(detail.startDate ?? null, detail.endDate ?? null)) {
+    await deleteTripCache(id);
+    return;
+  }
+  const existing = await readTripCache(id);
+  writeEntry(id, { detail, route: existing?.route ?? null, syncedAt });
+}
+
+/**
+ * Attach freshly fetched route geometry to a trip's cache entry and re-stamp the
+ * sync time. No-op when the trip is not already cached (its /detail must be
+ * cached first, which classifies it as cacheable).
+ */
+export async function cacheTripRoute(
+  id: string,
+  route: TripRoute,
+  syncedAt: number = Date.now(),
+): Promise<void> {
+  if (!SAFE_ID.test(id)) return;
+  const existing = await readTripCache(id);
+  if (!existing) return;
+  writeEntry(id, { ...existing, route, syncedAt });
+}
+
+/** Ids of every currently cached trip (drives the background re-sync). */
+export async function listCachedTripIds(): Promise<string[]> {
+  try {
+    const dir = cacheDir();
+    if (!dir.exists) return [];
+    return dir
+      .list()
+      .map((entry) => entry.name)
+      .filter((name) => name.endsWith('.json'))
+      .map((name) => name.slice(0, -'.json'.length))
+      .filter((id) => SAFE_ID.test(id));
+  } catch {
+    return [];
+  }
+}
+
+/** Injectable dependencies for {@link syncCachedTrips} (kept out for testing). */
+export interface SyncDeps {
+  isOnline: () => boolean;
+  fetchDetail: (id: string) => Promise<TripDetail | null>;
+  fetchRoute: (id: string) => Promise<TripRoute | null>;
+}
+
+/**
+ * Silently re-fetch every cached trip's /detail (then /route) so the offline copy
+ * stays fresh. Triggered on return-to-online and app foreground. Best-effort: it
+ * bails out while offline and swallows per-trip failures (still unreachable, or
+ * deleted server-side). A trip that has turned past is evicted by cacheTripDetail.
+ */
+export async function syncCachedTrips(deps: SyncDeps): Promise<void> {
+  if (!deps.isOnline()) return;
+  const ids = await listCachedTripIds();
+  await Promise.all(
+    ids.map(async (id) => {
+      try {
+        const detail = await deps.fetchDetail(id);
+        if (!detail) return;
+        await cacheTripDetail(id, detail);
+        // Only pull the (large) geometry back if the trip is still cached after
+        // the detail refresh — a now-past trip was just evicted.
+        if (await readTripCache(id)) {
+          const route = await deps.fetchRoute(id);
+          if (route) await cacheTripRoute(id, route);
+        }
+      } catch {
+        // ignore this trip; the next sync pass retries.
+      }
+    }),
+  );
+}

--- a/mobile/src/store/trip-cache.ts
+++ b/mobile/src/store/trip-cache.ts
@@ -59,7 +59,9 @@ function ensureDir(): void {
 function writeEntry(id: string, entry: CachedTrip): void {
   try {
     ensureDir();
-    cacheFile(id).write(JSON.stringify(entry));
+    const file = cacheFile(id);
+    if (!file.exists) file.create();
+    file.write(JSON.stringify(entry));
   } catch {
     // ignore: a failed cache write only costs a later offline miss.
   }


### PR DESCRIPTION
Ferme #1147 (sous-ticket 2/3 de l'épic #1052, Sprint 58).

⚠️ **PR stackée** — base `feature/1146` (#1151). À merger après #1151. Conflit i18n trivial attendu avec #1148/#1149 (clés distinctes, additions adjacentes dans `fr.ts`/`en.ts`).

## Contenu

Cache offline persistant des voyages **à venir/en cours** sur `expo-file-system` (document dir, non évincé). Passés jamais cachés (bornage stockage).

- `store/trip-cache.ts` : `isCacheableTrip` (réutilise `tripStateFromDates`, exclut `past`), write-through (`cacheTripDetail`/`cacheTripRoute` avec éviction d'un voyage devenu passé), `readTripCache`, `syncCachedTrips`. Garde anti-traversée de chemin sur l'id, I/O best-effort.
- `hooks/use-background-sync.ts` : re-fetch silencieux au retour online (store) + au foreground (`AppState`), monté dans `_layout.tsx`.
- Lecture offline : `use-trip-live` (chemin réel de l'écran détail — `useTripDetail` n'a aucun consommateur), + `use-trip-detail`/`use-trip-route` : read-through offline, fallback réseau, write-through.
- Indicateur « Synchronisé il y a Xh » (`formatFreshness` de #1146) sur `app/trip/[id]/index.tsx`.
- i18n fr+en (`freshness.synced`).

Périmètre : aucun fichier frère touché (#1148 = TripMap/map-utils, #1149 = RoadbookView). `use-trip-live`/`_layout` non revendiqués ailleurs.

## Vérification

- `tsc --noEmit` (mobile) : 0 erreur.
- `jest` (mobile) : 572/572 (run propre ; flakes env `account/notifications`/`ShareSheet` verts au re-run).
- Preuve failible : mutation de l'exclusion des passés (`isCacheableTrip → true`) → 3 tests rouges, restauré.
- **Consultation offline mode avion à valider sur device** (recette manuelle). Playwright/fonctionnel : CI.

## Auto-critique

- Câblage dans `use-trip-live` (pas seulement les hooks nommés au ticket) : sans ça les critères 2-4 ne s'appliquaient pas à l'écran réel. Assumé et documenté.
- Pas de dépendance ajoutée (`expo-file-system` déjà présent).

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 findings. Both issues from the previous review (missing `File.create()` before `write()`, and `deleteTripCache` never called on trip deletion) are confirmed fixed in `49c8a86`.

**Resolved threads:** Resolved 2 previously open threads that were addressed by commit `49c8a86`.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

Commit reviewed: `49c8a86bc84dd3c49edc5006785f5d832199660a`
<!-- claude-review-end -->
