### PR TITLE
fix(mobile): move screen tests out of the expo-router app/ tree

### DIFF
--- a/mobile/src/screens/__tests__/account-notifications.test.tsx
+++ b/mobile/src/screens/__tests__/account-notifications.test.tsx
@@ -3,10 +3,10 @@ import TestRenderer, { act } from 'react-test-renderer';
 import type { ReactElement } from 'react';
 import { AppState, StyleSheet, Text, View } from 'react-native';
 import * as Notifications from 'expo-notifications';
-import i18n from '../../src/i18n';
-import { lightColors } from '../../src/theme/tokens';
-import { NOTIFICATION_DEFAULTS, selectActiveCount, useNotificationPrefs } from '../../src/store/notification-prefs';
-import AccountNotifications from './notifications';
+import i18n from '../../i18n';
+import { lightColors } from '../../theme/tokens';
+import { NOTIFICATION_DEFAULTS, selectActiveCount, useNotificationPrefs } from '../../store/notification-prefs';
+import AccountNotifications from '../../../app/account/notifications';
 
 jest.mock('expo-secure-store', () => ({
   getItemAsync: jest.fn().mockResolvedValue(null),

--- a/mobile/src/screens/__tests__/trip-detail.test.tsx
+++ b/mobile/src/screens/__tests__/trip-detail.test.tsx
@@ -1,9 +1,9 @@
 /// <reference types="jest" />
 import TestRenderer, { act } from 'react-test-renderer';
 import { Text } from 'react-native';
-import i18n from '../../../src/i18n';
-import { useTripStore } from '../../../src/store/trip-store';
-import TripRoadbook from './index';
+import i18n from '../../i18n';
+import { useTripStore } from '../../store/trip-store';
+import TripRoadbook from '../../../app/trip/[id]/index';
 
 jest.mock('expo-router', () => ({
   Stack: { Screen: () => null },
@@ -11,9 +11,9 @@ jest.mock('expo-router', () => ({
   useRouter: () => ({ back: jest.fn(), push: jest.fn() }),
 }));
 
-jest.mock('../../../src/hooks/use-trip-live', () => ({ useTripLive: jest.fn() }));
+jest.mock('../../hooks/use-trip-live', () => ({ useTripLive: jest.fn() }));
 
-jest.mock('../../../src/components/trip', () => ({
+jest.mock('../../components/trip', () => ({
   ConfigSheet: () => null,
   RoadbookView: () => null,
   ShareSheet: () => null,
@@ -22,8 +22,8 @@ jest.mock('../../../src/components/trip', () => ({
   TripTitleHeader: () => null,
 }));
 
-jest.mock('../../../src/store/trip-cache', () => ({ readTripCache: jest.fn() }));
-import { readTripCache } from '../../../src/store/trip-cache';
+jest.mock('../../store/trip-cache', () => ({ readTripCache: jest.fn() }));
+import { readTripCache } from '../../store/trip-cache';
 const mockReadCache = readTripCache as jest.MockedFunction<typeof readTripCache>;
 
 function texts(node: any): string[] {


### PR DESCRIPTION
## Contexte

Défaut trouvé en **recette device** du Sprint 58. expo-router route par fichier tout `mobile/app/` (aucun `metro.config` pour filtrer). Deux tests Jest y vivaient :

- `app/account/notifications.test.tsx` (Sprint 57, #1120)
- `app/trip/[id]/index.test.tsx` (Sprint 58, fix de revue « synced-ago » de #1147)

Au démarrage, le `require.context` d'expo-router évalue ces modules, qui référencent `jest` au top-level → **`Property 'jest' doesn't exist`** au boot. En dev c'est un LogBox dismissable (l'app démarre derrière), mais en **build release** (jalon Sprint 59) le code de test serait bundlé et l'évaluation eager de ces routes peut crasher.

## Fix

Déplacement des deux tests d'écran **hors de `app/`** (via `git mv`, historique préservé) vers `mobile/src/screens/__tests__/`, non routé par expo-router mais toujours scanné par jest (`jest-expo`). Tous les imports relatifs et chemins `jest.mock()` réécrits en conséquence.

- `app/account/notifications.test.tsx` → `src/screens/__tests__/account-notifications.test.tsx`
- `app/trip/[id]/index.test.tsx` → `src/screens/__tests__/trip-detail.test.tsx`

## Vérification

- `find mobile/app -name '*.test.*' -o -name '*.spec.*'` → **vide**.
- `tsc --noEmit` (mobile) : 0 erreur.
- Suites déplacées : 2 passed / 9 tests (même nombre de `it(...)` qu'avant, aucun mock cassé).
- Suite complète mobile : **83 suites / 630 tests verts**.
- **Re-vérifié sur device** (reload Metro) : l'app démarre sans les erreurs `jest` au boot (cf. recette).

## Auto-critique

- Fix par relocalisation (robuste, idiomatique) plutôt que par override du `require.context` d'expo-router (fragile). Prévient aussi toute récidive : un test sous `src/**/__tests__/` ne sera jamais routé.

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 findings (0 critical, 0 warning). Pure test-file relocation: two Jest suites moved from `mobile/app/` to `mobile/src/screens/__tests__/` to stop expo-router's eager `require.context` from evaluating test-only modules at boot. Relative imports and `jest.mock()` paths were rewritten correctly; verified every referenced source path (`src/i18n`, `src/theme/tokens`, `src/store/notification-prefs`, `src/hooks/use-trip-live`, `src/components/trip`, `src/store/trip-cache`, `src/store/trip-store`, and both `app/` screen components) still resolves. `jest-expo`'s default `testMatch` picks up `__tests__/` directories anywhere in the tree, so the suites remain discovered without config changes. No old test files remain under `mobile/app/`.

**Review checklist:**
- [x] Code respects the project architecture (mobile workspace, ADR-053; no `metro.config` filtering needed per this fix)
- [x] SOLID principles and Law of Demeter followed (N/A — test-only relocation, no logic change)
- [x] Design patterns used where appropriate (relocation over fragile `require.context` override, per PR's own auto-critique — agreed)
- [x] Tests cover new/changed cases (no new behavior; existing 9 `it(...)` cases preserved verbatim across both suites)
- [x] Documentation is up to date (no ADR/TRACKING.md impact — bugfix, not architectural change)
- [x] Dependent tickets accounted for (references #1120, #1147 correctly)

**Inline comments:** No inline comments.

**Commit reviewed:** b06fee55f63d030221bb65b2f8ae241d9bc28eb7
<!-- claude-review-end -->