### PR TITLE
docs(tracking): sprint 58.b recette + sprint 60 mergé (+ tests #1097 mobile)

### DIFF
--- a/TRACKING.md
+++ b/TRACKING.md
@@ -2062,6 +2062,41 @@ Stratégie retenue — **absorber les feuilles dans `feature/1146`** (évite le 
 
 <details><summary>
 
+## Sprint 58.b — Recette mobile
+
+</summary>
+Findings de la recette mobile complète (24/08/2026, sur device Samsung SM-A556B) : conformité aux maquettes (diff écran par écran vs DesignSync « Mobile — Spike UX »), parité web, bugs, performances, sécurité, offline et **mode dégradé** (offline + API indisponible). Milestone : « Sprint 58.b — Recette » (#12).
+
+**Priorité produit** : le **mode dégradé** (#1166/#1167/#1168) — l'app doit rester utilisable en lecture seule avec un bandeau discret nommant la raison (Internet/API indisponible) et les écritures désactivées.
+
+| Thème | ID | Titre | Type | Effort | Statut |
+|-------|----|-------|------|--------|--------|
+| Mode dégradé | [#1166](https://github.com/vincentchalamon/bike-trip-planner/issues/1166) | read-only proactif + bandeau discret (offline & API indisponible) | Task | L | ⏳ À faire |
+| Offline | [#1167](https://github.com/vincentchalamon/bike-trip-planner/issues/1167) | fallback cache liste des voyages + fix rejet de promesse cold-start | Bug | M | ⏳ À faire |
+| Offline | [#1168](https://github.com/vincentchalamon/bike-trip-planner/issues/1168) | carte hors-ligne en visuel simple (image statique / placeholder) | Task | M | ⏳ À faire |
+| Bug | [#1169](https://github.com/vincentchalamon/bike-trip-planner/issues/1169) | i18n : chaîne EN « View the rough section on the map » | Bug | S | ⏳ À faire |
+| Bug | [#1170](https://github.com/vincentchalamon/bike-trip-planner/issues/1170) | libellé localisé du type d'hébergement (enum brut affiché) | Bug | S | ⏳ À faire |
+| Bug | [#1171](https://github.com/vincentchalamon/bike-trip-planner/issues/1171) | formulaire hébergement manuel masqué par le clavier | Bug | S | ⏳ À faire |
+| Bug | [#1172](https://github.com/vincentchalamon/bike-trip-planner/issues/1172) | mojibake intermittent accents (confirmer prod hors ngrok) | Bug | M | ⏳ À faire |
+| Bug | [#1173](https://github.com/vincentchalamon/bike-trip-planner/issues/1173) | require cycle + keyExtractor instable (Math.random) | Task | S | ⏳ À faire |
+| Sécurité | [#1174](https://github.com/vincentchalamon/bike-trip-planner/issues/1174) | purge cache offline au logout + suppression export RGPD + durcissements | Task | M | ⏳ À faire |
+| Perf | [#1175](https://github.com/vincentchalamon/bike-trip-planner/issues/1175) | écriture cache async + route inchangée non ré-sérialisée | Task | M | ⏳ À faire |
+| Perf | [#1176](https://github.com/vincentchalamon/bike-trip-planner/issues/1176) | mémoïsation listes + tree-shake lucide + carte maintenue montée | Task | M | ⏳ À faire |
+| Parité | [#1177](https://github.com/vincentchalamon/bike-trip-planner/issues/1177) | consultation in-app d'un voyage partagé /s/&lt;code&gt; | Feature | M | ⏳ À faire |
+| Parité | [#1178](https://github.com/vincentchalamon/bike-trip-planner/issues/1178) | undo/redo (parité web + maquette) | Feature | M | ⏳ À faire |
+| Parité | [#1179](https://github.com/vincentchalamon/bike-trip-planner/issues/1179) | câbler applyBatch (file de modifs) + addPoiWaypoint à l'UI | Task | M | ⏳ À faire |
+| Parité | [#1180](https://github.com/vincentchalamon/bike-trip-planner/issues/1180) | onboarding / tour guidé | Feature | M | ⏳ À faire |
+| Design | [#1181](https://github.com/vincentchalamon/bike-trip-planner/issues/1181) | écarts de conformité aux maquettes (diff écran par écran) | Task | M | ⏳ À faire |
+| Tests | [#1182](https://github.com/vincentchalamon/bike-trip-planner/issues/1182) | couverture jest du flux hébergement manuel #1097 | Task | S | 🚧 En cours (tests fournis dans la PR de recette) |
+
+**Recette — ce qui a été vérifié en live (device) :** liste, roadbook, détail d'étape, carte + profil, configuration, compte, notifications, in-ride (8 intents + GPS réel), création ; formulaire hébergement manuel #1097 (entrée + champs). Mode dégradé testé : offline (mode avion, cold + warm) et API indisponible (backend arrêté, Internet OK).
+
+**Note maquettes :** conformité globalement élevée (notifications quasi pixel-parfaites). La maquette `09-trip-config` est **périmée** (liste encore Refuge/Location, retirés au sprint 45 #927) — le device est correct ; mettre à jour la maquette, pas l'app.
+
+</details>
+
+<details><summary>
+
 ## Sprint 59 — Mobile : Release Android + doc
 
 </summary>
@@ -2076,14 +2111,14 @@ Stratégie retenue — **absorber les feuilles dans `feature/1146`** (évite le 
 
 <details><summary>
 
-## Sprint 60 — Hébergement hors-app
+## ✅ Sprint 60 — Hébergement hors-app
 
 </summary>
 Hébergement réservé **hors app** (HomeExchange, AirBnb, Booking, warmshowers, chez l'habitant…) : l'utilisateur le renseigne lui-même. Feature transverse **web + mobile + backend**. Milestone : « Sprint 60 — Hébergement hors-app ».
 
 | Ordre | ID | Titre | Effort | Statut | PRs | Dépend de |
 |-------|----|-------|--------|--------|-----|-----------|
-| 1 | [#1097](https://github.com/vincentchalamon/bike-trip-planner/issues/1097) | feat(accommodations) : saisie manuelle d'un hébergement hors-app (titre, adresse, prix total, lien) — web + mobile | L | 🚧 En cours | [#1163](https://github.com/vincentchalamon/bike-trip-planner/pull/1163) (`feature/1097`) | — |
+| 1 | [#1097](https://github.com/vincentchalamon/bike-trip-planner/issues/1097) | feat(accommodations) : saisie manuelle d'un hébergement hors-app (titre, adresse, prix total, lien) — web + mobile | L | ✅ Mergée | [#1163](https://github.com/vincentchalamon/bike-trip-planner/pull/1163) (`feature/1097`) | — |
 
 **Décisions de conception (arrêtées avant exécution) :**
 

--- a/mobile/src/components/trip/manual-accommodation.test.tsx
+++ b/mobile/src/components/trip/manual-accommodation.test.tsx
@@ -1,0 +1,221 @@
+/// <reference types="jest" />
+import TestRenderer, { act } from 'react-test-renderer';
+import type { ReactElement } from 'react';
+import { Text } from 'react-native';
+import type { AccommodationData } from '@btp/core';
+import i18n from '../../i18n';
+import { fr } from '../../i18n/resources/fr';
+import { AccommodationBlock } from './AccommodationBlock';
+
+// Manual (hors-app) accommodation flow — #1097. The web is covered by
+// pwa/tests/mocked/manual-accommodation.spec.ts; this mirrors it for mobile
+// (CI mobile = tsc + jest). Recette Sprint 58.b (#1182).
+
+// i18n init is async; make sure French is loaded before rendering (mirrors
+// data-blocks.test.tsx), otherwise t() returns raw keys.
+beforeAll(async () => {
+  await i18n.changeLanguage('fr');
+});
+
+function texts(node: any): string[] {
+  return node.root.findAllByType(Text).flatMap((t: any) => {
+    const kids = Array.isArray(t.props.children) ? t.props.children : [t.props.children];
+    return kids.filter((c: unknown): c is string => typeof c === 'string');
+  });
+}
+
+const rendered: any[] = [];
+
+function render(element: ReactElement): any {
+  let out: any;
+  act(() => {
+    out = TestRenderer.create(element);
+  });
+  rendered.push(out);
+  return out;
+}
+
+afterEach(() => {
+  rendered.splice(0).forEach((r) => act(() => r.unmount()));
+});
+
+function acc(overrides: Partial<AccommodationData> = {}): AccommodationData {
+  return {
+    name: 'Camping',
+    type: 'camp_site',
+    lat: 0,
+    lon: 0,
+    estimatedPriceMin: 12,
+    estimatedPriceMax: 20,
+    isExactPrice: false,
+    possibleClosed: false,
+    distanceToEndPoint: 2,
+    source: 'osm',
+    ...overrides,
+  } as AccommodationData;
+}
+
+// Button forwards `label` onto more than one node, so match all and take the
+// first (mirrors data-blocks.test.tsx).
+function btn(tree: any, label: string): any {
+  return tree.root.findAllByProps({ label })[0]!;
+}
+
+function hasBtn(tree: any, label: string): boolean {
+  return tree.root.findAllByProps({ label }).length > 0;
+}
+
+function openForm(tree: any) {
+  act(() => btn(tree, fr.trip.blocks.accommodationAddManual).props.onPress());
+}
+
+function setField(tree: any, placeholder: string, value: string) {
+  act(() => tree.root.findAllByProps({ placeholder })[0]!.props.onChangeText(value));
+}
+
+const P = fr.trip.blocks;
+
+describe('AccommodationBlock — manual (hors-app) entry #1097', () => {
+  it('exposes the add-manual affordance even with an empty candidate list', () => {
+    const tree = render(
+      <AccommodationBlock accommodations={[]} onSelect={jest.fn()} onAddManual={jest.fn()} />,
+    );
+    expect(hasBtn(tree, P.accommodationAddManual)).toBe(true);
+  });
+
+  it('reveals the four-field form and submits the parsed payload', async () => {
+    const onAddManual = jest.fn().mockResolvedValue(true);
+    const tree = render(
+      <AccommodationBlock
+        accommodations={[]}
+        radiusKm={5}
+        onSelect={jest.fn()}
+        onAddManual={onAddManual}
+      />,
+    );
+
+    openForm(tree);
+    // The four #1097 fields are present once the form is open.
+    for (const placeholder of [
+      P.accommodationManualNamePlaceholder,
+      P.accommodationManualAddressPlaceholder,
+      P.accommodationManualPricePlaceholder,
+      P.accommodationManualUrlPlaceholder,
+    ]) {
+      expect(tree.root.findAllByProps({ placeholder }).length).toBeGreaterThan(0);
+    }
+
+    setField(tree, P.accommodationManualNamePlaceholder, 'Gîte Test');
+    setField(tree, P.accommodationManualAddressPlaceholder, 'Grand Place, Lille');
+    setField(tree, P.accommodationManualPricePlaceholder, '45');
+    setField(tree, P.accommodationManualUrlPlaceholder, 'https://ex.fr');
+
+    await act(async () => {
+      await btn(tree, P.accommodationManualSave).props.onPress();
+    });
+
+    expect(onAddManual).toHaveBeenCalledWith({
+      name: 'Gîte Test',
+      address: 'Grand Place, Lille',
+      priceTotal: 45,
+      url: 'https://ex.fr',
+    });
+    // On success the form closes: the add-manual button is back.
+    expect(hasBtn(tree, P.accommodationAddManual)).toBe(true);
+  });
+
+  it('sends a null price and null url when left blank', async () => {
+    const onAddManual = jest.fn().mockResolvedValue(true);
+    const tree = render(
+      <AccommodationBlock accommodations={[]} onSelect={jest.fn()} onAddManual={onAddManual} />,
+    );
+    openForm(tree);
+    setField(tree, P.accommodationManualNamePlaceholder, 'Chez untel');
+    setField(tree, P.accommodationManualAddressPlaceholder, '1 rue de la Paix, Lille');
+
+    await act(async () => {
+      await btn(tree, P.accommodationManualSave).props.onPress();
+    });
+
+    expect(onAddManual).toHaveBeenCalledWith({
+      name: 'Chez untel',
+      address: '1 rue de la Paix, Lille',
+      priceTotal: null,
+      url: null,
+    });
+  });
+
+  it('keeps the form open when the backend rejects the entry (e.g. geocoding 422)', async () => {
+    const onAddManual = jest.fn().mockResolvedValue(false);
+    const tree = render(
+      <AccommodationBlock accommodations={[]} onSelect={jest.fn()} onAddManual={onAddManual} />,
+    );
+    openForm(tree);
+    setField(tree, P.accommodationManualNamePlaceholder, 'Gîte Test');
+    setField(tree, P.accommodationManualAddressPlaceholder, 'Adresse introuvable');
+
+    await act(async () => {
+      await btn(tree, P.accommodationManualSave).props.onPress();
+    });
+
+    expect(onAddManual).toHaveBeenCalledTimes(1);
+    // Form stays open so the user can correct the address.
+    expect(
+      tree.root.findAllByProps({ placeholder: P.accommodationManualNamePlaceholder }).length,
+    ).toBeGreaterThan(0);
+  });
+
+  it('disables the save button until both name and address are filled', () => {
+    const tree = render(
+      <AccommodationBlock accommodations={[]} onSelect={jest.fn()} onAddManual={jest.fn()} />,
+    );
+    openForm(tree);
+    const save = () => btn(tree, P.accommodationManualSave);
+
+    expect(save().props.disabled).toBe(true);
+    setField(tree, P.accommodationManualNamePlaceholder, 'Gîte Test');
+    expect(save().props.disabled).toBe(true); // address still empty
+    setField(tree, P.accommodationManualAddressPlaceholder, 'Grand Place, Lille');
+    expect(save().props.disabled).toBe(false);
+  });
+
+  it('cancel closes the form without submitting', () => {
+    const onAddManual = jest.fn();
+    const tree = render(
+      <AccommodationBlock accommodations={[]} onSelect={jest.fn()} onAddManual={onAddManual} />,
+    );
+    openForm(tree);
+    act(() => btn(tree, P.accommodationManualCancel).props.onPress());
+
+    expect(onAddManual).not.toHaveBeenCalled();
+    expect(
+      tree.root.findAllByProps({ placeholder: P.accommodationManualNamePlaceholder }).length,
+    ).toBe(0);
+    // Back to the add-manual affordance.
+    expect(hasBtn(tree, P.accommodationAddManual)).toBe(true);
+  });
+
+  it('renders a selected manual accommodation with its source badge and no add form', () => {
+    const t = texts(
+      render(
+        <AccommodationBlock
+          accommodations={[]}
+          selectedAccommodation={acc({
+            name: "Chez l'habitant",
+            type: 'other',
+            source: 'manual',
+            isExactPrice: true,
+            estimatedPriceMin: 45,
+            estimatedPriceMax: 45,
+            address: '2 Grand Place, Lille',
+          })}
+          onSelect={jest.fn()}
+          onAddManual={jest.fn()}
+        />,
+      ),
+    );
+    expect(t).toContain("Chez l'habitant");
+    expect(t).toContain(P.accommodationSelected);
+    expect(t.join(' ')).toContain(P.accommodationSourceManual);
+  });
+});


### PR DESCRIPTION
## Contexte
Recette mobile complète (24/08/2026) sur device Samsung SM-A556B (build debug + Metro, backend iso-prod local via ngrok). Ce PR consolide le suivi et livre les premiers tests manquants.

## Contenu
- **`TRACKING.md`**
  - Sprint 60 (#1097, PR #1163) passé en **✅ Mergée** (le retro existait déjà, commit `f615ad0f`).
  - Nouvelle section **Sprint 58.b — Recette** (milestone [#12](https://github.com/vincentchalamon/bike-trip-planner/milestone/12)) listant les 17 tickets issus de la recette (#1166 → #1182).
- **`mobile/.../manual-accommodation.test.tsx`** (nouveau) — couverture jest du flux hébergement manuel hors-app #1097 (refs #1182) : rendu du formulaire (Titre/Adresse/Prix total/Lien), soumission avec payload parsé, prix/lien nuls, rejet backend (form reste ouvert), désactivation du bouton tant que titre+adresse vides, annulation, rendu d'un hébergement manuel sélectionné avec badge source.

## Vérification
- `jest src/components/trip/manual-accommodation.test.tsx` → **7/7 pass**.
- `tsc --noEmit` (workspace mobile) → **exit 0**.
- `make qa` complet non lancé en local (OOM connu, cf. `.claude/local-qa.md`) → délégué à la CI.

## Recette — synthèse
Vérifié en live : liste, roadbook, détail d'étape, carte + profil, configuration, compte, notifications, in-ride (8 intents + GPS réel), création, formulaire #1097. **Mode dégradé** testé (offline mode avion cold+warm, API indisponible backend arrêté). Priorité produit : le mode dégradé read-only (#1166/#1167/#1168).

Tickets créés sous le milestone Sprint 58.b : #1166 #1167 #1168 #1169 #1170 #1171 #1172 #1173 #1174 #1175 #1176 #1177 #1178 #1179 #1180 #1181 #1182.

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 findings (0 critical, 0 warning, 1 informational). Docs + test-only PR: `TRACKING.md` bookkeeping (Sprint 58.b recette section + Sprint 60 marked merged) plus a new mobile Jest suite for the #1097 manual-accommodation flow. The test file was cross-checked line-by-line against `AccommodationBlock.tsx` (form field wiring, `canSubmit`/price-parsing/url-parsing logic, success/failure paths) and against the actual `fr.ts` i18n keys — all assertions match current behavior.

**PR title check:** `docs(tracking): sprint 58.b recette + sprint 60 mergé (+ tests #1097 mobile)` — type/scope are valid, but the description reads as a status announcement rather than an imperative-mood summary (CLAUDE.md requires imperative mood). Informational only, not blocking.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

_Commit reviewed: d73ca6393ab2cb7a530226ae4310251f3454aa4f_
<!-- claude-review-end -->