### PR TITLE
fix(i18n): send Accept-Language from the mobile client

### DIFF
--- a/mobile/src/api/client.test.ts
+++ b/mobile/src/api/client.test.ts
@@ -5,6 +5,7 @@ jest.mock('../auth/tokens', () => ({ getJwt: jest.fn() }));
 jest.mock('../auth/authApi', () => ({ refreshTokens: jest.fn() }));
 import { getJwt } from '../auth/tokens';
 import { refreshTokens } from '../auth/authApi';
+import i18n from '../i18n';
 
 const mockGetJwt = getJwt as jest.MockedFunction<typeof getJwt>;
 const mockRefresh = refreshTokens as jest.MockedFunction<typeof refreshTokens>;
@@ -33,6 +34,22 @@ describe('authMiddleware request headers', () => {
     const request = new Request('https://api.test/trips');
     await onRequest(request);
     expect(request.headers.get('X-Client-Platform')).toBe('mobile');
+  });
+
+  // Regression (#1169): RN's fetch never sends Accept-Language on its own, so a
+  // trip created from the app was always analyzed server-side in the backend's
+  // default locale (en) regardless of the app's own French UI.
+  it('carries the app locale as Accept-Language so backend-rendered alert text matches the UI language', async () => {
+    mockGetJwt.mockReturnValue('jwt');
+    await i18n.changeLanguage('fr');
+    const request = new Request('https://api.test/trips');
+    await onRequest(request);
+    expect(request.headers.get('Accept-Language')).toBe('fr');
+    await i18n.changeLanguage('en');
+    const englishRequest = new Request('https://api.test/trips');
+    await onRequest(englishRequest);
+    expect(englishRequest.headers.get('Accept-Language')).toBe('en');
+    await i18n.changeLanguage('fr');
   });
 });
 

--- a/mobile/src/api/client.ts
+++ b/mobile/src/api/client.ts
@@ -3,6 +3,7 @@ import type { paths } from '@btp/core/schema';
 import { API_BASE_URL } from './config';
 import { getJwt } from '../auth/tokens';
 import { refreshTokens } from '../auth/authApi';
+import i18n from '../i18n';
 
 const RETRY_HEADER = 'X-Native-Retry';
 
@@ -26,6 +27,10 @@ export const authMiddleware: Middleware = {
     // the request's Accept-Encoding to `identity` when it sees it, disabling
     // compression for mobile only (web/PWA clients keep it). See .docker/php/Caddyfile.
     request.headers.set('X-Client-Platform', 'mobile');
+    // Without this, the server falls back to its own default (en) for every
+    // backend-rendered string (alert messages/actions) regardless of the app's
+    // own French UI (#1169) — RN's fetch does not send Accept-Language itself.
+    request.headers.set('Accept-Language', i18n.language);
     pendingRetries.set(request, request.clone());
     return request;
   },


### PR DESCRIPTION
Closes #1169. Sprint 58.b (recette).

## Problème
« View the rough section on the map » (et tout texte d'alerte rendu backend) apparaissait en **anglais** dans l'UI FR mobile. Cause réelle : le client mobile n'envoyait **jamais** `Accept-Language`, donc le backend analysait chaque trip avec le défaut `en` (`getPreferredLanguage`), indépendamment de la langue de l'app.

## Changement
`mobile/src/api/client.ts` : `authMiddleware.onRequest` pose `Accept-Language: i18n.language`. Test de régression `client.test.ts`.

## Vérification (mobile-only ; Playwright/fonctionnel = CI)
- `tsc --noEmit` : vert.
- jest complet : 645/645. `client.test.ts` : 8/8.

## Auto-critique
Fix plus large qu'un simple libellé (corrige tout le texte serveur), au bon endroit (header transport). Les 2 flakes connus (ShareSheet/account-notifications, timeout) sont indépendants.

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 findings (0 critical, 0 warning). Small, well-scoped fix — the mobile client now forwards `i18n.language` as `Accept-Language` on every request, matching the backend's `getPreferredLanguage(['en', 'fr'])` negotiation. Values are constrained to `'fr' | 'en'` throughout (device-locale default, `LocaleSwitcher`), so no locale-format mismatch. Regression test covers both `fr` and `en`.

**PR title check:** conforms to Conventional Commits.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

**Commit reviewed:** e5d11654edc6e7d4540c43409548bf3f702b7ab4
<!-- claude-review-end -->
