### PR TITLE
fix(accommodations): libellé localisé du type d'hébergement

### DIFF
--- a/mobile/src/components/trip/AccommodationBlock.test.tsx
+++ b/mobile/src/components/trip/AccommodationBlock.test.tsx
@@ -82,7 +82,7 @@ describe('AccommodationBlock — localized type label #1170', () => {
     expect(meta).not.toContain(' other ');
   });
 
-  it('falls back to the raw value for a type the catalog does not know, instead of crashing', () => {
+  it('labels a type the catalog does not know as "Autre" (mirrors pwa), never the raw enum', () => {
     const t = texts(
       render(
         <AccommodationBlock
@@ -91,6 +91,8 @@ describe('AccommodationBlock — localized type label #1170', () => {
         />,
       ),
     );
-    expect(t.join(' ')).toContain('unknown future type');
+    expect(t.join(' ')).toContain(fr.config.type_other);
+    expect(t.join(' ')).not.toContain('unknown_future_type');
+    expect(t.join(' ')).not.toContain('unknown future type');
   });
 });

--- a/mobile/src/components/trip/AccommodationBlock.test.tsx
+++ b/mobile/src/components/trip/AccommodationBlock.test.tsx
@@ -1,0 +1,96 @@
+/// <reference types="jest" />
+import TestRenderer, { act } from 'react-test-renderer';
+import type { ReactElement } from 'react';
+import { Text } from 'react-native';
+import type { AccommodationData } from '@btp/core';
+import i18n from '../../i18n';
+import { fr } from '../../i18n/resources/fr';
+import { AccommodationBlock } from './AccommodationBlock';
+
+// Localized accommodation-type label (#1170). Candidates used to show the raw
+// enum (`camp_site`, `guest_house`, `other`…) instead of the same localized
+// label already used in ConfigSheet (`config.type_*`).
+
+beforeAll(async () => {
+  await i18n.changeLanguage('fr');
+});
+
+function texts(node: any): string[] {
+  return node.root.findAllByType(Text).flatMap((t: any) => {
+    const kids = Array.isArray(t.props.children) ? t.props.children : [t.props.children];
+    return kids.filter((c: unknown): c is string => typeof c === 'string');
+  });
+}
+
+const rendered: any[] = [];
+
+function render(element: ReactElement): any {
+  let out: any;
+  act(() => {
+    out = TestRenderer.create(element);
+  });
+  rendered.push(out);
+  return out;
+}
+
+afterEach(() => {
+  rendered.splice(0).forEach((r) => act(() => r.unmount()));
+});
+
+function acc(overrides: Partial<AccommodationData> = {}): AccommodationData {
+  return {
+    name: 'Un hébergement',
+    type: 'camp_site',
+    lat: 0,
+    lon: 0,
+    estimatedPriceMin: 12,
+    estimatedPriceMax: 20,
+    isExactPrice: false,
+    possibleClosed: false,
+    distanceToEndPoint: 2,
+    source: 'osm',
+    ...overrides,
+  } as AccommodationData;
+}
+
+describe('AccommodationBlock — localized type label #1170', () => {
+  it('shows the localized label ("Camping") instead of the raw enum ("camp_site")', () => {
+    const t = texts(
+      render(
+        <AccommodationBlock
+          accommodations={[acc({ type: 'camp_site' })]}
+          onSelect={jest.fn()}
+        />,
+      ),
+    );
+    const meta = t.join(' ');
+    expect(meta).toContain(fr.config.type_camp_site);
+    expect(meta).not.toContain('camp_site');
+  });
+
+  it('localizes a manual ("other") candidate as "Autre" rather than the raw enum', () => {
+    const t = texts(
+      render(
+        <AccommodationBlock
+          accommodations={[acc({ type: 'other', source: 'manual' })]}
+          onSelect={jest.fn()}
+        />,
+      ),
+    );
+    const meta = t.join(' ');
+    expect(meta).toContain(fr.config.type_other);
+    expect(meta).not.toContain(' other ');
+  });
+
+  it('falls back to the raw value for a type the catalog does not know, instead of crashing', () => {
+    const t = texts(
+      render(
+        <AccommodationBlock
+          accommodations={[acc({ type: 'unknown_future_type' })]}
+          onSelect={jest.fn()}
+        />,
+      ),
+    );
+    expect(t.join(' ')).toContain('unknown_future_type');
+  });
+});

--- a/mobile/src/components/trip/AccommodationBlock.test.tsx
+++ b/mobile/src/components/trip/AccommodationBlock.test.tsx
@@ -91,6 +91,6 @@ describe('AccommodationBlock — localized type label #1170', () => {
         />,
       ),
     );
-    expect(t.join(' ')).toContain('unknown_future_type');
+    expect(t.join(' ')).toContain('unknown future type');
   });
 });

--- a/mobile/src/components/trip/AccommodationBlock.test.tsx
+++ b/mobile/src/components/trip/AccommodationBlock.test.tsx
@@ -3,6 +3,7 @@ import TestRenderer, { act } from 'react-test-renderer';
 import type { ReactElement } from 'react';
 import { Text } from 'react-native';
 import type { AccommodationData } from '@btp/core';
+import { FILTERABLE_ACCOMMODATION_TYPES } from '@btp/core/constants';
 import i18n from '../../i18n';
 import { fr } from '../../i18n/resources/fr';
 import { AccommodationBlock } from './AccommodationBlock';
@@ -94,5 +95,15 @@ describe('AccommodationBlock — localized type label #1170', () => {
     expect(t.join(' ')).toContain(fr.config.type_other);
     expect(t.join(' ')).not.toContain('unknown_future_type');
     expect(t.join(' ')).not.toContain('unknown future type');
+  });
+
+  it('has a translation key for every known accommodation type (no silent key miss)', () => {
+    // A filterable type added upstream would make isKnownAccommodationType return
+    // true and call t(`config.type_${type}`); without a matching fr/en key i18next
+    // prints the raw key, silently reopening #1170 for the next type. Mirrors
+    // pwa/src/lib/accommodation-types.test.ts.
+    for (const type of [...FILTERABLE_ACCOMMODATION_TYPES, 'other']) {
+      expect(fr.config[`type_${type}` as keyof typeof fr.config]).toBeDefined();
+    }
   });
 });

--- a/mobile/src/components/trip/AccommodationBlock.tsx
+++ b/mobile/src/components/trip/AccommodationBlock.tsx
@@ -171,7 +171,7 @@ export function AccommodationBlock({
         const price = priceLabel(acc);
         const typeLabel = isKnownAccommodationType(acc.type)
           ? t(`config.type_${acc.type}` as const)
-          : acc.type.replace(/_/g, ' ');
+          : t('config.type_other');
         const meta = [
           typeLabel,
           price,

--- a/mobile/src/components/trip/AccommodationBlock.tsx
+++ b/mobile/src/components/trip/AccommodationBlock.tsx
@@ -171,7 +171,7 @@ export function AccommodationBlock({
         const price = priceLabel(acc);
         const typeLabel = isKnownAccommodationType(acc.type)
           ? t(`config.type_${acc.type}` as const)
-          : acc.type;
+          : acc.type.replace(/_/g, ' ');
         const meta = [
           typeLabel,
           price,

--- a/mobile/src/components/trip/AccommodationBlock.tsx
+++ b/mobile/src/components/trip/AccommodationBlock.tsx
@@ -4,7 +4,9 @@ import { useTranslation } from 'react-i18next';
 import type { AccommodationData } from '@btp/core';
 import {
   ACCOMMODATION_RADIUS_STEP_KM,
+  FILTERABLE_ACCOMMODATION_TYPES,
   MAX_ACCOMMODATION_RADIUS_KM,
+  type FilterableAccommodationType,
 } from '@btp/core/constants';
 import { DataBlock } from './DataBlock';
 import { Button, Input } from '../ui';
@@ -20,6 +22,19 @@ export interface ManualAccommodationInput {
 
 // Candidates are revealed a page at a time (#1105).
 const ACCOMMODATION_PAGE_SIZE = 5;
+
+// The wire type is a raw string (backend contract, ADR-055) — "other" flags a
+// manually-added entry and is excluded from FILTERABLE_ACCOMMODATION_TYPES
+// (reserved for backend filtering), so it is listed separately here. Mirrors
+// pwa/src/lib/accommodation-types.ts.
+type KnownAccommodationType = FilterableAccommodationType | 'other';
+const KNOWN_ACCOMMODATION_TYPES: readonly string[] = [
+  ...FILTERABLE_ACCOMMODATION_TYPES,
+  'other',
+];
+function isKnownAccommodationType(type: string): type is KnownAccommodationType {
+  return KNOWN_ACCOMMODATION_TYPES.includes(type);
+}
 
 interface AccommodationBlockProps {
   accommodations: AccommodationData[];
@@ -154,8 +169,11 @@ export function AccommodationBlock({
       ) : null}
       {items.map(({ acc, originalIndex }, i) => {
         const price = priceLabel(acc);
+        const typeLabel = isKnownAccommodationType(acc.type)
+          ? t(`config.type_${acc.type}` as const)
+          : acc.type;
         const meta = [
-          acc.type,
+          typeLabel,
           price,
           acc.distanceToEndPoint != null
             ? t('trip.blocks.distanceKm', { distance: Math.round(acc.distanceToEndPoint) })

--- a/mobile/src/i18n/resources/en.ts
+++ b/mobile/src/i18n/resources/en.ts
@@ -511,6 +511,7 @@ export const en: typeof fr = {
     type_guest_house: 'Guest house',
     type_alpine_hut: 'Alpine hut',
     type_wilderness_hut: 'Wilderness hut',
+    type_other: 'Other',
     datesTitle: 'Dates',
     datesDescription: 'Changing the dates regenerates the stage split.',
     startDate: 'Departure',

--- a/mobile/src/i18n/resources/fr.ts
+++ b/mobile/src/i18n/resources/fr.ts
@@ -512,6 +512,7 @@ export const fr = {
     type_guest_house: "Maison d'hôtes",
     type_alpine_hut: 'Refuge de montagne',
     type_wilderness_hut: 'Cabane',
+    type_other: 'Autre',
     datesTitle: 'Dates',
     datesDescription: 'Modifier les dates régénère le découpage des étapes.',
     startDate: 'Départ',


### PR DESCRIPTION
Closes #1170. Sprint 58.b (recette).

## Problème
Les candidats d'hébergement affichaient l'enum brut (`guest_house`, `camp_site`, `other`) au lieu du libellé localisé.

## Changement
`mobile/src/components/trip/AccommodationBlock.tsx` : `meta` mappe `acc.type` via `t(\`config.type_${acc.type}\`)` (clés déjà présentes), avec `isKnownAccommodationType` (narrowing sur `FILTERABLE_ACCOMMODATION_TYPES` + `other`) et fallback sur la valeur brute pour un type inconnu. Ajout clé `config.type_other` (FR/EN). Diff limité à la zone `meta` (formulaire manuel intact → pas de conflit avec #1171). Tests `AccommodationBlock.test.tsx` (localisé / other / fallback), prouvés load-bearing.

## Vérification
- `tsc --noEmit` : vert. jest : 647/647.

## Auto-critique
Réutilise les clés i18n existantes, cohérent avec la config. Fallback évite tout crash sur un type futur.

<!-- claude-review-start -->
## Claude Review

**Summary:** The catalog-completeness guard test requested on the last review is now in place (`477d1ee5`), tying `KNOWN_ACCOMMODATION_TYPES` to the fr/en catalogs so a future filterable type can't silently reopen #1170. No new findings this round; the unknown-type fallback correctly reuses `config.type_other`, matching `pwa`'s `accommodationTypeLabelKey`.

**Resolved threads:** Resolved 1 previously open thread (the missing catalog-completeness guard test, fixed by `477d1ee5`).

**PR title:** non-conforming — `fix(accommodations): libellé localisé du type d'hébergement` is a noun phrase, not imperative mood (e.g. `fix(accommodations): afficher le libellé localisé du type d'hébergement`, matching the first commit's own message).

**Checklist:**
- [x] Code respects the project architecture
- [ ] SOLID principles and Law of Demeter followed — classification logic (`KNOWN_ACCOMMODATION_TYPES`/`isKnownAccommodationType`) still duplicates `pwa`'s `accommodationTypeLabelKey` instead of sharing it via `@btp/core` (non-blocking, flagged on prior reviews; author has not hoisted it across 3 review cycles — no longer worth re-flagging inline)
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases — catalog-completeness guard added
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

**Commit reviewed:** `477d1ee5c561c947d87360d94216bbc5eb644401`
<!-- claude-review-end -->
