### PR TITLE
fix(accommodations): keep the manual accommodation form above the keyboard

### DIFF
--- a/mobile/src/components/trip/StageDetailView.tsx
+++ b/mobile/src/components/trip/StageDetailView.tsx
@@ -164,7 +164,10 @@ export function StageDetailView({ initialIndex }: { initialIndex: number }) {
     // without the keyboard eating it first.
     <KeyboardAvoidingView
       style={styles.fill}
-      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      // Android already resizes the window (Expo default softwareKeyboardLayoutMode
+      // = adjustResize), so a `behavior` there would double-compensate; only iOS
+      // needs padding. keyboardShouldPersistTaps on the ScrollView covers both.
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
     >
       <ScrollView
         style={{ backgroundColor: theme.colors.background }}

--- a/mobile/src/components/trip/StageDetailView.tsx
+++ b/mobile/src/components/trip/StageDetailView.tsx
@@ -1,5 +1,7 @@
 import { type ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
 import {
+  KeyboardAvoidingView,
+  Platform,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -155,10 +157,20 @@ export function StageDetailView({ initialIndex }: { initialIndex: number }) {
   }
 
   return (
-    <ScrollView
-      style={{ backgroundColor: theme.colors.background }}
-      contentContainerStyle={{ paddingBottom: theme.spacing.xl }}
+    // The manual-accommodation form (AccommodationBlock) sits deep in this
+    // scroll; without a KeyboardAvoidingView the keyboard covers its fields
+    // and the "Ajouter" button on both platforms (#1171). `keyboardShouldPersistTaps`
+    // lets the still-visible "Ajouter"/"Annuler" buttons register a tap
+    // without the keyboard eating it first.
+    <KeyboardAvoidingView
+      style={styles.fill}
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
     >
+      <ScrollView
+        style={{ backgroundColor: theme.colors.background }}
+        contentContainerStyle={{ paddingBottom: theme.spacing.xl }}
+        keyboardShouldPersistTaps="handled"
+      >
       <View
         style={[
           styles.topbar,
@@ -386,7 +398,8 @@ export function StageDetailView({ initialIndex }: { initialIndex: number }) {
           }
         />
       </View>
-    </ScrollView>
+      </ScrollView>
+    </KeyboardAvoidingView>
   );
 }
 
@@ -749,6 +762,7 @@ function SurfaceBar({
 }
 
 const styles = StyleSheet.create({
+  fill: { flex: 1 },
   topbar: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/mobile/src/components/trip/stage-detail.test.tsx
+++ b/mobile/src/components/trip/stage-detail.test.tsx
@@ -2,7 +2,7 @@
 import TestRenderer, { act } from 'react-test-renderer';
 import { EMPTY_RESUPPLY } from '@btp/core';
 import type { ReactElement } from 'react';
-import { KeyboardAvoidingView, ScrollView, Text, TextInput } from 'react-native';
+import { KeyboardAvoidingView, Platform, ScrollView, Text, TextInput } from 'react-native';
 import type { StageData } from '@btp/core';
 import i18n from '../../i18n';
 import { fr } from '../../i18n/resources/fr';
@@ -198,19 +198,31 @@ describe('StageDetailView', () => {
     expect(t).toContain('Étape 1 / 2');
   });
 
-  it('wraps the screen scroll in a KeyboardAvoidingView with tap-through (#1171)', () => {
+  it('sets KeyboardAvoidingView behavior per platform, with tap-through (#1171)', () => {
+    // jest-expo runs the whole suite under a single (iOS) Platform.OS, so assert
+    // both branches by overriding it: padding on iOS, none on Android (adjustResize
+    // already handles it — a regression reintroducing behavior="height" is caught).
     useTripStore.setState({ tripId: 't1', stages: [stage()], startDate: null, loading: false });
-    const tree = render(<StageDetailView initialIndex={0} />);
-    // The keyboard-avoiding wrapper keeps the manual accommodation form (and its
-    // Add/Cancel buttons) reachable when the keyboard is open; a refactor dropping
-    // it would silently re-break #1171.
-    // KeyboardAvoidingView is present; its `behavior` is platform-specific
-    // (padding on iOS, undefined on Android where adjustResize already handles it).
-    expect(tree.root.findByType(KeyboardAvoidingView)).toBeTruthy();
-    const tapThrough = tree.root
-      .findAllByType(ScrollView)
-      .some((s: any) => s.props.keyboardShouldPersistTaps === 'handled');
-    expect(tapThrough).toBe(true);
+    const inspect = (os: 'ios' | 'android') => {
+      const replaced = jest.replaceProperty(Platform, 'OS', os);
+      let t!: ReturnType<typeof TestRenderer.create>;
+      act(() => {
+        t = TestRenderer.create(<StageDetailView initialIndex={0} />);
+      });
+      const behavior = t.root.findByType(KeyboardAvoidingView).props.behavior;
+      const tapThrough = t.root
+        .findAllByType(ScrollView)
+        .some((s: any) => s.props.keyboardShouldPersistTaps === 'handled');
+      act(() => t.unmount());
+      replaced.restore();
+      return { behavior, tapThrough };
+    };
+    const ios = inspect('ios');
+    const android = inspect('android');
+    expect(ios.behavior).toBe('padding');
+    expect(android.behavior).toBeUndefined();
+    expect(ios.tapThrough).toBe(true);
+    expect(android.tapThrough).toBe(true);
   });
 
   it('advances to the next stage and bounds prev/next at the extremities', () => {

--- a/mobile/src/components/trip/stage-detail.test.tsx
+++ b/mobile/src/components/trip/stage-detail.test.tsx
@@ -2,7 +2,7 @@
 import TestRenderer, { act } from 'react-test-renderer';
 import { EMPTY_RESUPPLY } from '@btp/core';
 import type { ReactElement } from 'react';
-import { Text, TextInput } from 'react-native';
+import { KeyboardAvoidingView, ScrollView, Text, TextInput } from 'react-native';
 import type { StageData } from '@btp/core';
 import i18n from '../../i18n';
 import { fr } from '../../i18n/resources/fr';
@@ -196,6 +196,19 @@ describe('StageDetailView', () => {
     expect(t).toContain('800 m'); // D+
     expect(t).toContain('600 m'); // D-
     expect(t).toContain('Étape 1 / 2');
+  });
+
+  it('wraps the screen scroll in a KeyboardAvoidingView with tap-through (#1171)', () => {
+    useTripStore.setState({ tripId: 't1', stages: [stage()], startDate: null, loading: false });
+    const tree = render(<StageDetailView initialIndex={0} />);
+    // The keyboard-avoiding wrapper keeps the manual accommodation form (and its
+    // Add/Cancel buttons) reachable when the keyboard is open; a refactor dropping
+    // it would silently re-break #1171.
+    expect(tree.root.findByType(KeyboardAvoidingView).props.behavior).toBeDefined();
+    const tapThrough = tree.root
+      .findAllByType(ScrollView)
+      .some((s: any) => s.props.keyboardShouldPersistTaps === 'handled');
+    expect(tapThrough).toBe(true);
   });
 
   it('advances to the next stage and bounds prev/next at the extremities', () => {

--- a/mobile/src/components/trip/stage-detail.test.tsx
+++ b/mobile/src/components/trip/stage-detail.test.tsx
@@ -204,7 +204,9 @@ describe('StageDetailView', () => {
     // The keyboard-avoiding wrapper keeps the manual accommodation form (and its
     // Add/Cancel buttons) reachable when the keyboard is open; a refactor dropping
     // it would silently re-break #1171.
-    expect(tree.root.findByType(KeyboardAvoidingView).props.behavior).toBeDefined();
+    // KeyboardAvoidingView is present; its `behavior` is platform-specific
+    // (padding on iOS, undefined on Android where adjustResize already handles it).
+    expect(tree.root.findByType(KeyboardAvoidingView)).toBeTruthy();
     const tapThrough = tree.root
       .findAllByType(ScrollView)
       .some((s: any) => s.props.keyboardShouldPersistTaps === 'handled');


### PR DESCRIPTION
Closes #1171. Sprint 58.b (recette).

## Problème
Le formulaire d'ajout manuel d'hébergement était masqué par le clavier ; la vue ne scrollait pas le champ focus.

## Changement
`mobile/src/components/trip/StageDetailView.tsx` : le `ScrollView` racine de l'écran (vraie cause) est enveloppé dans un `KeyboardAvoidingView` (`padding` iOS / `height` Android) + `keyboardShouldPersistTaps="handled"` pour garder Ajouter/Annuler cliquables clavier ouvert. `AccommodationBlock.tsx` **inchangé** (zéro conflit avec #1170).

## Vérification (mobile-only ; comportement clavier réel non testable en jest)
- `tsc --noEmit` : vert. Tests AccommodationBlock/manual/data-blocks : 54/54.

## Auto-critique
Fix à la racine (ScrollView de l'écran) plutôt que dans le composant enfant → moins de risque et pas de duplication de KeyboardAvoidingView. À valider en live sur device.

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 critical, 0 warning, 0 suggestion, 0 note. All previously raised points (Android `adjustResize` double-compensation avoided via `behavior={Platform.OS === 'ios' ? 'padding' : undefined}`, and the platform-parametrized regression test) remain correctly addressed in the current head commit.

**Resolved threads:** All 3 previously open threads were already resolved prior to this review pass; none required re-opening.

### Review checklist
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date (TRACKING.md status for #1171 follows the repo's merge-time update convention, not per-PR — no action needed)
- [x] Dependent tickets accounted for (#1170/AccommodationBlock confirmed unchanged, no conflict — verified `AccommodationBlock.tsx` has no `KeyboardAvoidingView`/`ScrollView` of its own)

**Inline comments:** No inline comments.

**Commit reviewed:** eeddcb5729acea1d3a6f9abff97de4eeba28bae2
<!-- claude-review-end -->