### PR TITLE
refactor(mobile): break client/authApi/push require cycle + stabilize keyExtractor

### DIFF
--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -342,7 +342,7 @@ export default function Trips() {
       ) : (
         <FlatList
           data={trips}
-          keyExtractor={(item) => item.id ?? String(Math.random())}
+          keyExtractor={(item, index) => item.id ?? String(index)}
           contentContainerStyle={{
             padding: theme.spacing.base,
             paddingTop: theme.spacing.md,

--- a/mobile/src/notifications/push.test.ts
+++ b/mobile/src/notifications/push.test.ts
@@ -1,7 +1,6 @@
 /// <reference types="jest" />
 import { Platform } from 'react-native';
 import * as Notifications from 'expo-notifications';
-import { api } from '../api/client';
 import { registerDeviceToken, subscribeTokenRotation, unregisterDeviceToken } from './push';
 
 jest.mock('expo-notifications', () => ({
@@ -12,15 +11,11 @@ jest.mock('expo-notifications', () => ({
   addPushTokenListener: jest.fn(() => ({ remove: jest.fn() })),
 }));
 
-jest.mock('../api/client', () => ({
-  api: { POST: jest.fn().mockResolvedValue({}), DELETE: jest.fn().mockResolvedValue({}) },
-}));
+jest.mock('../auth/tokens', () => ({ getJwt: jest.fn(() => 'jwt') }));
 
 const getPerms = Notifications.getPermissionsAsync as jest.Mock;
 const reqPerms = Notifications.requestPermissionsAsync as jest.Mock;
 const getToken = Notifications.getDevicePushTokenAsync as jest.Mock;
-const post = api.POST as jest.Mock;
-const del = api.DELETE as jest.Mock;
 
 const expectedPlatform =
   Platform.OS === 'android' ? 'android' : Platform.OS === 'ios' ? 'ios' : null;
@@ -29,20 +24,17 @@ beforeEach(() => {
   jest.clearAllMocks();
   getPerms.mockResolvedValue({ granted: true });
   getToken.mockResolvedValue({ type: 'android', data: 'fcm-token-abc' });
-  // clearAllMocks resets call records but not implementations; restore the happy
-  // path so a per-test mockRejectedValue does not leak into the next test.
-  post.mockResolvedValue({});
-  del.mockResolvedValue({});
+  globalThis.fetch = jest.fn().mockResolvedValue(new Response(null, { status: 200 }));
 });
 
 describe('registerDeviceToken', () => {
   it('POSTs the native token + platform when permission is granted', async () => {
     await registerDeviceToken();
-    expect(post).toHaveBeenCalledTimes(1);
-    expect(post).toHaveBeenCalledWith(
-      '/users/me/device-tokens',
-      expect.objectContaining({ body: { token: 'fcm-token-abc', platform: expectedPlatform } }),
-    );
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const [url, init] = (fetch as jest.Mock).mock.calls[0];
+    expect(url).toMatch(/\/users\/me\/device-tokens$/);
+    expect(init).toMatchObject({ method: 'POST', headers: expect.objectContaining({ Authorization: 'Bearer jwt' }) });
+    expect(JSON.parse(init.body)).toEqual({ token: 'fcm-token-abc', platform: expectedPlatform });
   });
 
   it('requests permission when not yet granted, then registers', async () => {
@@ -50,51 +42,52 @@ describe('registerDeviceToken', () => {
     reqPerms.mockResolvedValue({ granted: true });
     await registerDeviceToken();
     expect(reqPerms).toHaveBeenCalledTimes(1);
-    expect(post).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledTimes(1);
   });
 
   it('is a silent no-op when permission is denied', async () => {
     getPerms.mockResolvedValue({ granted: false });
     reqPerms.mockResolvedValue({ granted: false });
     await registerDeviceToken();
-    expect(post).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
   });
 
   it('resolves without throwing and skips the POST when the permission API itself throws', async () => {
     getPerms.mockRejectedValue(new Error('no Google Play Services'));
     await expect(registerDeviceToken()).resolves.toBeUndefined();
-    expect(post).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
   });
 
   it('resolves without throwing when the POST rejects (offline/timeout)', async () => {
-    post.mockRejectedValue(new Error('network error'));
+    (fetch as jest.Mock).mockRejectedValue(new Error('network error'));
     await expect(registerDeviceToken()).resolves.toBeUndefined();
-    expect(post).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledTimes(1);
   });
 });
 
 describe('unregisterDeviceToken', () => {
   it('DELETEs the token registered this session', async () => {
     await registerDeviceToken();
+    (fetch as jest.Mock).mockClear();
     await unregisterDeviceToken();
-    expect(del).toHaveBeenCalledWith(
-      '/users/me/device-tokens/{token}',
-      expect.objectContaining({ params: { path: { token: 'fcm-token-abc' } } }),
-    );
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const [url, init] = (fetch as jest.Mock).mock.calls[0];
+    expect(url).toMatch(/\/users\/me\/device-tokens\/fcm-token-abc$/);
+    expect(init).toMatchObject({ method: 'DELETE', headers: expect.objectContaining({ Authorization: 'Bearer jwt' }) });
   });
 
   it('is a no-op when nothing was registered', async () => {
     // Fresh module state guaranteed by clearing the registered token first.
     await unregisterDeviceToken();
     await unregisterDeviceToken();
-    expect(del).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
   });
 });
 
 describe('subscribeTokenRotation', () => {
   it('re-registers when the OS emits a rotated token', async () => {
     await registerDeviceToken();
-    post.mockClear();
+    (fetch as jest.Mock).mockClear();
     subscribeTokenRotation();
     const listener = (Notifications.addPushTokenListener as jest.Mock).mock.calls[0][0];
     listener({ type: 'android', data: 'fcm-token-rotated' });
@@ -102,6 +95,6 @@ describe('subscribeTokenRotation', () => {
     // fetch microtasks before asserting the POST landed.
     await new Promise((r) => setImmediate(r));
     await new Promise((r) => setImmediate(r));
-    expect(post).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledTimes(1);
   });
 });

--- a/mobile/src/notifications/push.ts
+++ b/mobile/src/notifications/push.ts
@@ -1,12 +1,20 @@
 import * as Notifications from 'expo-notifications';
 import { Platform } from 'react-native';
-import { api } from '../api/client';
-import { LD_JSON } from '../api/config';
+import { API_BASE_URL, LD_JSON } from '../api/config';
+import { getJwt } from '../auth/tokens';
 
 // Server-driven push (#1125): register this device's native FCM (Android) / APNs
 // (iOS) token with the backend so it can target the user, and route an incoming
 // notification to the right screen. Distinct from on-device local triggers
 // (#1121, `notifications/local.*` if present) — this file only owns the push leg.
+//
+// Uses plain fetch rather than the typed API client (../api/client): that module
+// imports authApi.ts for its 401-retry middleware, and authApi.ts imports this
+// file's unregisterDeviceToken for its own definitive-failure cleanup (#1125) —
+// routing through the typed client here would close the three into a require
+// cycle (#1173). Both calls below run right after a login/rotation or with a
+// still-valid JWT just before logout, so the typed client's refresh-and-retry
+// middleware has nothing to add.
 
 type DevicePlatform = 'android' | 'ios' | null;
 
@@ -55,6 +63,11 @@ async function fetchDeviceToken(): Promise<string | null> {
   }
 }
 
+function authHeader(): Record<string, string> {
+  const jwt = getJwt();
+  return jwt ? { Authorization: `Bearer ${jwt}` } : {};
+}
+
 // Idempotent upsert of this device's token for the current user. Safe to call on
 // every login and on rotation: the backend dedupes by token (schema comment) and
 // reassigns a token held by another account.
@@ -63,9 +76,10 @@ export async function registerDeviceToken(): Promise<void> {
   if (!token) return;
   registeredToken = token;
   try {
-    await api.POST('/users/me/device-tokens', {
-      body: { token, platform: devicePlatform() },
-      headers: { 'Content-Type': LD_JSON, Accept: LD_JSON },
+    await fetch(`${API_BASE_URL}/users/me/device-tokens`, {
+      method: 'POST',
+      headers: { 'Content-Type': LD_JSON, Accept: LD_JSON, ...authHeader() },
+      body: JSON.stringify({ token, platform: devicePlatform() }),
     });
   } catch {
     // Best-effort: register is fired fire-and-forget from the auth store, so a
@@ -81,9 +95,9 @@ export async function unregisterDeviceToken(): Promise<void> {
   const token = registeredToken;
   if (!token) return;
   registeredToken = null;
-  await api.DELETE('/users/me/device-tokens/{token}', {
-    params: { path: { token } },
-    headers: { Accept: LD_JSON },
+  await fetch(`${API_BASE_URL}/users/me/device-tokens/${encodeURIComponent(token)}`, {
+    method: 'DELETE',
+    headers: { Accept: LD_JSON, ...authHeader() },
   });
 }
 


### PR DESCRIPTION
Closes #1173. Sprint 58.b (recette).

## Changements
1. **Require cycle** `client.ts → authApi.ts → push.ts → client.ts` cassé en retirant l'edge `push.ts → client.ts` : `registerDeviceToken`/`unregisterDeviceToken` utilisent un `fetch()` direct + `getJwt()` (même pattern que `verify`/`refresh` dans `authApi.ts`). Appels best-effort, jamais dépendants du retry-401 du client typé. `push.test.ts` réécrit pour mocker `global.fetch`.
2. **keyExtractor** `mobile/app/(tabs)/index.tsx` : `item.id ?? String(index)` au lieu de `String(Math.random())` (diff limité à cette ligne → pas de conflit avec #1176).

## Vérification
- `tsc --noEmit` : vert. Suites concernées : 19/19. `expo export --platform android` : **aucun warning `Require cycle`**.

## Auto-critique
Alternatives (module tiers pour `api`, `require()` différé) écartées avec justification (Metro détecte le cycle même en require intra-fonction). Runtime inchangé.

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 findings (0 critical, 0 warning). Independently traced the import graph: `push.ts` now only imports `../api/config` and `../auth/tokens`, neither of which reaches back into `client.ts` or `authApi.ts` — the `client.ts → authApi.ts → push.ts → client.ts` require cycle is genuinely broken. Confirmed the bypass-typed-client pattern mirrors the existing, documented precedent in `authApi.ts` (`verify`/`refresh`). Auth header construction, `encodeURIComponent` on the path param, and best-effort error semantics are preserved at parity with the previous typed-client calls; both call sites of `unregisterDeviceToken` (`authApi.ts` `doRefresh`, `store.tsx` `dropPushToken`) already wrap it in `.catch()`. `keyExtractor` fix is a strict improvement (stable index fallback vs. `Math.random()`). Tests were updated in lockstep with the implementation; no debug leftovers or TRACKING.md drift (status bookkeeping is handled by separate `docs(tracking)` PRs in this sprint, confirmed against #1183/#1191).

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

Commit reviewed: `b013217cfa3b190d7e3f2ec2f619bccea8a74f18`
<!-- claude-review-end -->