### PR TITLE
fix(security): purge offline cache at logout, delete RGPD export after share, harden boot

### DIFF
--- a/mobile/src/api/config.test.ts
+++ b/mobile/src/api/config.test.ts
@@ -1,0 +1,45 @@
+/// <reference types="jest" />
+
+// config.ts resolves API_BASE_URL at import time from process.env + __DEV__, so
+// each case toggles those and re-imports the module in isolation (#1174).
+
+const ORIGINAL_ENV = process.env.EXPO_PUBLIC_API_URL;
+const ORIGINAL_DEV = (globalThis as { __DEV__?: boolean }).__DEV__;
+
+function loadConfigWith(opts: { dev: boolean; apiUrl?: string }): typeof import('./config') {
+  (globalThis as { __DEV__?: boolean }).__DEV__ = opts.dev;
+  if (opts.apiUrl === undefined) delete process.env.EXPO_PUBLIC_API_URL;
+  else process.env.EXPO_PUBLIC_API_URL = opts.apiUrl;
+  // WEB_BASE_URL also fails closed in non-dev; give it a value so only the API
+  // URL guard is under test.
+  process.env.EXPO_PUBLIC_WEB_URL = 'https://web.example.org';
+  let mod!: typeof import('./config');
+  jest.isolateModules(() => {
+    mod = require('./config');
+  });
+  return mod;
+}
+
+afterEach(() => {
+  if (ORIGINAL_ENV === undefined) delete process.env.EXPO_PUBLIC_API_URL;
+  else process.env.EXPO_PUBLIC_API_URL = ORIGINAL_ENV;
+  (globalThis as { __DEV__?: boolean }).__DEV__ = ORIGINAL_DEV;
+});
+
+describe('API_BASE_URL https guard (#1174)', () => {
+  it('rejects a non-https API URL in a non-development build', () => {
+    expect(() => loadConfigWith({ dev: false, apiUrl: 'http://api.example.org' })).toThrow(
+      /https/,
+    );
+  });
+
+  it('accepts an https API URL in a non-development build', () => {
+    const { API_BASE_URL } = loadConfigWith({ dev: false, apiUrl: 'https://api.example.org' });
+    expect(API_BASE_URL).toBe('https://api.example.org');
+  });
+
+  it('allows a plaintext URL in development', () => {
+    const { API_BASE_URL } = loadConfigWith({ dev: true, apiUrl: 'http://localhost:8000' });
+    expect(API_BASE_URL).toBe('http://localhost:8000');
+  });
+});

--- a/mobile/src/api/config.ts
+++ b/mobile/src/api/config.ts
@@ -2,7 +2,18 @@
 // documented in README). In dev only, falls back to the shared ngrok tunnel; a
 // non-dev build without the var fails closed rather than shipping a stale ngrok
 // host that a third party could later claim (magic-link tokens / JWTs at stake).
-export const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL ?? getDevFallback();
+export const API_BASE_URL = resolveApiBaseUrl();
+
+function resolveApiBaseUrl(): string {
+  const url = process.env.EXPO_PUBLIC_API_URL ?? getDevFallback();
+  // Fail closed on a plaintext base URL in a shipped build: magic-link tokens and
+  // JWTs travel over this origin, so a non-https host must never ship (#1174). Dev
+  // is exempt (localhost / http tunnels).
+  if (!__DEV__ && !url.startsWith('https://')) {
+    throw new Error('EXPO_PUBLIC_API_URL must be an https URL for non-development builds');
+  }
+  return url;
+}
 
 function getDevFallback(): string {
   if (!__DEV__) {

--- a/mobile/src/auth/authApi.push.test.ts
+++ b/mobile/src/auth/authApi.push.test.ts
@@ -19,13 +19,20 @@ jest.mock('./tokens', () => ({
     order.push('clear');
   }),
 }));
+jest.mock('../store/trip-cache', () => ({
+  clearAllTripCache: jest.fn(async () => {
+    order.push('purge-cache');
+  }),
+}));
 
 import { refreshTokens } from './authApi';
 import { unregisterDeviceToken } from '../notifications/push';
 import { clearTokens } from './tokens';
+import { clearAllTripCache } from '../store/trip-cache';
 
 const unregister = unregisterDeviceToken as jest.Mock;
 const clear = clearTokens as jest.Mock;
+const purge = clearAllTripCache as jest.Mock;
 
 beforeEach(() => {
   order.length = 0;
@@ -41,6 +48,11 @@ describe('doRefresh definitive failure (#1125)', () => {
     expect(ok).toBe(false);
     expect(unregister).toHaveBeenCalledTimes(1);
     expect(clear).toHaveBeenCalledTimes(1);
-    expect(order).toEqual(['unregister', 'clear']);
+    expect(order).toEqual(['unregister', 'clear', 'purge-cache']);
+  });
+
+  it('purges the offline trip cache on session invalidation (#1174)', async () => {
+    await refreshTokens();
+    expect(purge).toHaveBeenCalledTimes(1);
   });
 });

--- a/mobile/src/auth/authApi.ts
+++ b/mobile/src/auth/authApi.ts
@@ -2,6 +2,7 @@ import { API_BASE_URL, LD_JSON } from '../api/config';
 import { unregisterDeviceToken } from '../notifications/push';
 import { notifySessionInvalidated } from './session';
 import { clearTokens, getRefresh, setTokens } from './tokens';
+import { clearAllTripCache } from '../store/trip-cache';
 
 // verify / refresh use plain fetch rather than the typed client: both return the
 // token pair ({ token, refresh_token }) in the body, and refresh posts the refresh
@@ -67,6 +68,9 @@ async function doRefresh(): Promise<boolean> {
   // DELETE would 401, leaving the token alive server-side (#1125).
   await unregisterDeviceToken().catch(() => undefined);
   await clearTokens();
+  // Purge the offline trip cache too, so an invalidated session leaves no
+  // roadbook / manual accommodation on the device (#1174).
+  await clearAllTripCache();
   notifySessionInvalidated();
   return false;
 }

--- a/mobile/src/auth/store.test.tsx
+++ b/mobile/src/auth/store.test.tsx
@@ -10,6 +10,7 @@ jest.mock('./tokens', () => ({
 }));
 jest.mock('./authApi', () => ({ verifyMagicToken: jest.fn() }));
 jest.mock('./session', () => ({ onSessionInvalidated: jest.fn(() => () => {}) }));
+jest.mock('../store/trip-cache', () => ({ clearAllTripCache: jest.fn().mockResolvedValue(undefined) }));
 // The provider registers / unregisters the push token as a side effect (#1125);
 // stub the push module so this stale-response-guard test never touches the native
 // notifications layer (its own behaviour is covered by store.push.test.tsx).
@@ -21,7 +22,10 @@ jest.mock('../notifications/push', () => ({
 
 import { api } from '../api/client';
 import { loadTokens } from './tokens';
+import { clearAllTripCache } from '../store/trip-cache';
 import { AuthProvider, useAuth } from './store';
+
+const mockClearAllTripCache = clearAllTripCache as jest.MockedFunction<typeof clearAllTripCache>;
 
 type AuthContextValue = ReturnType<typeof useAuth>;
 
@@ -80,6 +84,21 @@ describe('AuthProvider stale-response guard (#1117)', () => {
     });
 
     expect(captured.email).toBeNull();
+  });
+
+  it('purges the offline trip cache on logout (#1174)', async () => {
+    mockLoadTokens.mockResolvedValue({ jwt: 'jwt', refresh: 'refresh' });
+    mockGet.mockResolvedValue({ data: { email: 'me@example.com' } } as never);
+
+    await act(async () => {
+      renderer = TestRenderer.create(createElement(Wrapper, null, createElement(Consumer)));
+    });
+
+    expect(mockClearAllTripCache).not.toHaveBeenCalled();
+    await act(async () => {
+      await captured.logout();
+    });
+    expect(mockClearAllTripCache).toHaveBeenCalledTimes(1);
   });
 
   it('sets the email from GET /users/me while authenticated', async () => {

--- a/mobile/src/auth/store.tsx
+++ b/mobile/src/auth/store.tsx
@@ -14,6 +14,7 @@ import { registerDeviceToken, subscribeTokenRotation, unregisterDeviceToken } fr
 import { verifyMagicToken } from './authApi';
 import { onSessionInvalidated } from './session';
 import { clearTokens, loadTokens } from './tokens';
+import { clearAllTripCache } from '../store/trip-cache';
 
 type AuthContextValue = {
   ready: boolean;
@@ -124,6 +125,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     // stops receiving this account's pushes (#1125).
     await dropPushToken();
     await clearTokens();
+    // Purge the offline trip cache so no roadbook / manual accommodation of this
+    // account survives on a shared device (#1174).
+    await clearAllTripCache();
     endSession();
   }, [endSession]);
 

--- a/mobile/src/hooks/use-stage-detail.ts
+++ b/mobile/src/hooks/use-stage-detail.ts
@@ -25,8 +25,9 @@ export function useStageDetail(index: number): void {
         }
       })
       .catch((error: unknown) => {
-        // Graceful degradation (mini-map/profile stay empty) but not silent.
-        console.warn('Failed to load stage detail geometry', error);
+        // Graceful degradation (mini-map/profile stay empty) but not silent in
+        // dev; kept out of a shipped build's logs.
+        if (__DEV__) console.warn('Failed to load stage detail geometry', error);
       });
     return () => {
       cancelled = true;

--- a/mobile/src/hooks/use-trip-route.ts
+++ b/mobile/src/hooks/use-trip-route.ts
@@ -21,8 +21,9 @@ export async function runLoadTripRoute(id: string): Promise<TripRoute | null> {
     const cached = await readTripCache(id);
     if (cached?.route) return cached.route;
     // Genuine failure: online (or nothing cached) and the fetch threw. Surface a
-    // diagnostic so a real backend/network error is not swallowed silently.
-    console.warn('Failed to load trip route geometry', error);
+    // diagnostic (dev only) so a real backend/network error is not swallowed
+    // silently, without leaking it to a shipped build's logs.
+    if (__DEV__) console.warn('Failed to load trip route geometry', error);
     return null;
   }
 }

--- a/mobile/src/lib/fs-share.test.ts
+++ b/mobile/src/lib/fs-share.test.ts
@@ -66,14 +66,17 @@ describe('writeAndShareFile temp-file cleanup (#1174)', () => {
     expect(fileOps).toContain('delete');
   });
 
-  it('does not share (nor delete) when the platform cannot share', async () => {
+  it('deletes the temp file (without sharing) when the platform cannot share', async () => {
     mockIsAvailable.mockResolvedValue(false);
 
     await expect(
       writeAndShareFile(new ArrayBuffer(4), 'trip.gpx', 'application/gpx+xml'),
     ).rejects.toThrow('Sharing is not available on this device');
 
+    // The file is already written to the cache by this point, so it must be
+    // cleaned up even though sharing never happened (#1174 — no unencrypted
+    // RGPD/GPX export left lingering on emulators where sharing is unavailable).
     expect(mockShare).not.toHaveBeenCalled();
-    expect(fileOps).not.toContain('delete');
+    expect(fileOps).toContain('delete');
   });
 });

--- a/mobile/src/lib/fs-share.test.ts
+++ b/mobile/src/lib/fs-share.test.ts
@@ -79,4 +79,21 @@ describe('writeAndShareFile temp-file cleanup (#1174)', () => {
     expect(mockShare).not.toHaveBeenCalled();
     expect(fileOps).toContain('delete');
   });
+
+  it('deletes the temp file when write() itself throws (quota/IO)', async () => {
+    mockIsAvailable.mockResolvedValue(true);
+    const { File } = jest.requireMock('expo-file-system');
+    jest.spyOn(File.prototype, 'write').mockImplementationOnce(() => {
+      fileOps.push('write');
+      throw new Error('quota exceeded');
+    });
+
+    await expect(
+      writeAndShareFile(new ArrayBuffer(4), 'account-export.json', 'application/json'),
+    ).rejects.toThrow('quota exceeded');
+
+    // The (partially) created file must be cleaned up even though the write failed.
+    expect(mockShare).not.toHaveBeenCalled();
+    expect(fileOps).toContain('delete');
+  });
 });

--- a/mobile/src/lib/fs-share.test.ts
+++ b/mobile/src/lib/fs-share.test.ts
@@ -1,0 +1,79 @@
+/// <reference types="jest" />
+
+// Track lifecycle calls on the temp export file so the "delete after share" fix
+// (#1174) can be asserted without a device.
+const fileOps: string[] = [];
+
+jest.mock('expo-file-system', () => {
+  class File {
+    uri: string;
+    constructor(_dir: unknown, name: string) {
+      this.uri = `file:///cache/${name}`;
+    }
+    create() {
+      fileOps.push('create');
+    }
+    write() {
+      fileOps.push('write');
+    }
+    delete() {
+      fileOps.push('delete');
+    }
+  }
+  return { File, Paths: { cache: { uri: 'file:///cache' } } };
+});
+
+jest.mock('expo-sharing', () => ({
+  isAvailableAsync: jest.fn(),
+  shareAsync: jest.fn(),
+}));
+
+import * as Sharing from 'expo-sharing';
+import { writeAndShareFile } from './fs-share';
+
+const mockIsAvailable = Sharing.isAvailableAsync as jest.MockedFunction<
+  typeof Sharing.isAvailableAsync
+>;
+const mockShare = Sharing.shareAsync as jest.MockedFunction<typeof Sharing.shareAsync>;
+
+beforeEach(() => {
+  fileOps.length = 0;
+  jest.clearAllMocks();
+});
+
+describe('writeAndShareFile temp-file cleanup (#1174)', () => {
+  it('deletes the temp export file after a successful share', async () => {
+    mockIsAvailable.mockResolvedValue(true);
+    mockShare.mockResolvedValue(undefined as never);
+
+    await writeAndShareFile(new ArrayBuffer(4), 'account-export.json', 'application/json');
+
+    expect(mockShare).toHaveBeenCalledWith('file:///cache/account-export.json', {
+      mimeType: 'application/json',
+    });
+    // Written, then deleted once the share sheet returned.
+    expect(fileOps).toEqual(['create', 'write', 'delete']);
+  });
+
+  it('still deletes the temp file when sharing throws', async () => {
+    mockIsAvailable.mockResolvedValue(true);
+    mockShare.mockRejectedValue(new Error('share cancelled'));
+
+    await expect(
+      writeAndShareFile(new ArrayBuffer(4), 'trip.gpx', 'application/gpx+xml'),
+    ).rejects.toThrow('share cancelled');
+
+    expect(fileOps).toContain('delete');
+  });
+
+  it('does not share (nor delete) when the platform cannot share', async () => {
+    mockIsAvailable.mockResolvedValue(false);
+
+    await expect(
+      writeAndShareFile(new ArrayBuffer(4), 'trip.gpx', 'application/gpx+xml'),
+    ).rejects.toThrow('Sharing is not available on this device');
+
+    expect(mockShare).not.toHaveBeenCalled();
+    expect(fileOps).not.toContain('delete');
+  });
+});

--- a/mobile/src/lib/fs-share.ts
+++ b/mobile/src/lib/fs-share.ts
@@ -17,10 +17,12 @@ export async function writeAndShareFile(
   const file = new File(Paths.cache, filename);
   file.create({ intermediates: true, overwrite: true });
   await file.write(new Uint8Array(bytes));
-  if (!(await Sharing.isAvailableAsync())) {
-    throw new Error('Sharing is not available on this device');
-  }
   try {
+    // Checked inside the try so the finally still deletes the (already-written)
+    // temp file when sharing is unavailable — the normal case on some emulators.
+    if (!(await Sharing.isAvailableAsync())) {
+      throw new Error('Sharing is not available on this device');
+    }
     await Sharing.shareAsync(file.uri, { mimeType });
   } finally {
     // Delete the temp export once the share sheet is done. It matters most for the

--- a/mobile/src/lib/fs-share.ts
+++ b/mobile/src/lib/fs-share.ts
@@ -20,5 +20,16 @@ export async function writeAndShareFile(
   if (!(await Sharing.isAvailableAsync())) {
     throw new Error('Sharing is not available on this device');
   }
-  await Sharing.shareAsync(file.uri, { mimeType });
+  try {
+    await Sharing.shareAsync(file.uri, { mimeType });
+  } finally {
+    // Delete the temp export once the share sheet is done. It matters most for the
+    // RGPD account archive (profile, email, every trip) which must not linger in
+    // the cache dir, but GPX/FIT exports are cleaned up the same way (#1174).
+    try {
+      file.delete();
+    } catch {
+      // ignore: best-effort cleanup of the temp export file.
+    }
+  }
 }

--- a/mobile/src/lib/fs-share.ts
+++ b/mobile/src/lib/fs-share.ts
@@ -15,11 +15,13 @@ export async function writeAndShareFile(
   mimeType: string,
 ): Promise<void> {
   const file = new File(Paths.cache, filename);
-  file.create({ intermediates: true, overwrite: true });
-  await file.write(new Uint8Array(bytes));
   try {
-    // Checked inside the try so the finally still deletes the (already-written)
-    // temp file when sharing is unavailable — the normal case on some emulators.
+    // create()/write() are inside the try so the finally still deletes a
+    // partially-written temp file if write() throws (quota/IO), and the
+    // isAvailableAsync() check is here too so an unavailable platform (the normal
+    // case on some emulators) still triggers cleanup of the already-written file.
+    file.create({ intermediates: true, overwrite: true });
+    await file.write(new Uint8Array(bytes));
     if (!(await Sharing.isAvailableAsync())) {
       throw new Error('Sharing is not available on this device');
     }

--- a/mobile/src/store/trip-cache.test.ts
+++ b/mobile/src/store/trip-cache.test.ts
@@ -71,6 +71,7 @@ import { writeAsStringAsync } from 'expo-file-system/legacy';
 import {
   cacheTripDetail,
   cacheTripRoute,
+  clearAllTripCache,
   deleteTripCache,
   isCacheableTrip,
   listCachedTripIds,
@@ -324,6 +325,24 @@ describe('listCachedTripIds / deleteTripCache', () => {
     expect((await listCachedTripIds()).sort()).toEqual(['a', 'b']);
     await deleteTripCache('a');
     expect(await listCachedTripIds()).toEqual(['b']);
+  });
+});
+
+describe('clearAllTripCache (#1174)', () => {
+  it('purges every cached trip', async () => {
+    await cacheTripDetail('a', detail());
+    await cacheTripDetail('b', detail());
+    await cacheTripRoute('b', route);
+    expect((await listCachedTripIds()).length).toBe(2);
+    await clearAllTripCache();
+    expect(await listCachedTripIds()).toEqual([]);
+    expect(await readTripCache('a')).toBeNull();
+    expect(await readTripCache('b')).toBeNull();
+  });
+
+  it('is a no-op when nothing is cached', async () => {
+    await expect(clearAllTripCache()).resolves.toBeUndefined();
+    expect(await listCachedTripIds()).toEqual([]);
   });
 });
 

--- a/mobile/src/store/trip-cache.test.ts
+++ b/mobile/src/store/trip-cache.test.ts
@@ -344,6 +344,14 @@ describe('clearAllTripCache (#1174)', () => {
     await expect(clearAllTripCache()).resolves.toBeUndefined();
     expect(await listCachedTripIds()).toEqual([]);
   });
+
+  it('does not resurrect a first-time write racing a concurrent purge (#1174)', async () => {
+    // 'fresh' is not yet on disk, so it's not in listCachedTripIds() and its
+    // write is only stopped by the `purging` flag in writeFile — deleting that
+    // guard makes this fail.
+    await Promise.all([cacheTripDetail('fresh', detail()), clearAllTripCache()]);
+    expect(await readTripCache('fresh')).toBeNull();
+  });
 });
 
 describe('syncCachedTrips', () => {

--- a/mobile/src/store/trip-cache.ts
+++ b/mobile/src/store/trip-cache.ts
@@ -239,6 +239,16 @@ export async function cacheTripRoute(
   });
 }
 
+/**
+ * Delete every cached trip. Called on logout and on out-of-band session
+ * invalidation so a shared device leaves no offline roadbook / manual
+ * accommodation (title, address, price, link) behind for the next account (#1174).
+ */
+export async function clearAllTripCache(): Promise<void> {
+  const ids = await listCachedTripIds();
+  await Promise.all(ids.map((id) => deleteTripCache(id)));
+}
+
 /** Ids of every currently cached trip (drives the background re-sync). */
 export async function listCachedTripIds(): Promise<string[]> {
   try {

--- a/mobile/src/store/trip-cache.ts
+++ b/mobile/src/store/trip-cache.ts
@@ -74,6 +74,12 @@ function withLock<T>(id: string, fn: () => Promise<T>): Promise<T> {
   return next;
 }
 
+// Set while clearAllTripCache runs so a write that has already passed its per-id
+// lock — e.g. a first-time cache for an id not yet in listCachedTripIds() — still
+// no-ops instead of resurrecting data for an account that was just purged on a
+// shared device (#1174).
+let purging = false;
+
 function cacheDir(): Directory {
   return new Directory(Paths.document, CACHE_DIRNAME);
 }
@@ -98,6 +104,9 @@ function ensureDir(): void {
 // synchronously, so `.exists` can't tell a successful write from a swallowed
 // failure — callers that must confirm a write (route migration) need this signal.
 async function writeFile(file: File, content: string): Promise<boolean> {
+  // A purge in progress wins over any in-flight write, including one already past
+  // its per-id lock, so logout leaves nothing behind (#1174).
+  if (purging) return false;
   try {
     ensureDir();
     if (!file.exists) file.create();
@@ -245,11 +254,17 @@ export async function cacheTripRoute(
  * accommodation (title, address, price, link) behind for the next account (#1174).
  */
 export async function clearAllTripCache(): Promise<void> {
-  const ids = await listCachedTripIds();
-  // Go through the same per-id lock as cacheTripDetail/cacheTripRoute: an
-  // in-flight write from an unordered effect must not land after the delete and
-  // resurrect a purged account's data on a shared device (#1174).
-  await Promise.all(ids.map((id) => withLock(id, () => deleteTripCache(id))));
+  // `purging` blocks writes that are already past their per-id lock (incl. a
+  // first-time cache for an id not yet listed); the per-id `withLock` chains the
+  // deletes after any write that hasn't started yet. Together they guarantee no
+  // cache file survives logout on a shared device (#1174).
+  purging = true;
+  try {
+    const ids = await listCachedTripIds();
+    await Promise.all(ids.map((id) => withLock(id, () => deleteTripCache(id))));
+  } finally {
+    purging = false;
+  }
 }
 
 /** Ids of every currently cached trip (drives the background re-sync). */

--- a/mobile/src/store/trip-cache.ts
+++ b/mobile/src/store/trip-cache.ts
@@ -246,7 +246,10 @@ export async function cacheTripRoute(
  */
 export async function clearAllTripCache(): Promise<void> {
   const ids = await listCachedTripIds();
-  await Promise.all(ids.map((id) => deleteTripCache(id)));
+  // Go through the same per-id lock as cacheTripDetail/cacheTripRoute: an
+  // in-flight write from an unordered effect must not land after the delete and
+  // resurrect a purged account's data on a shared device (#1174).
+  await Promise.all(ids.map((id) => withLock(id, () => deleteTripCache(id))));
 }
 
 /** Ids of every currently cached trip (drives the background re-sync). */


### PR DESCRIPTION
Closes #1174. Sprint 58.b (recette) — audit sécurité.

## Changements
- **M1** `trip-cache.ts` : `clearAllTripCache()` (additif) ; appelé depuis `logout()` (`auth/store.tsx`) et le chemin session invalidée (`authApi.ts` `doRefresh`). Chemin d'écriture intact (partage avec #1175).
- **M2** `lib/fs-share.ts` : `Sharing.shareAsync` en try/finally + `file.delete()` best-effort (archive RGPD + exports GPX/FIT).
- **Durcissements** : `api/config.ts` rejette une `EXPO_PUBLIC_API_URL` non-`https` hors `__DEV__` ; `console.warn` gardés `__DEV__` (`use-trip-route.ts`, `use-stage-detail.ts`).

## Vérification
- `tsc --noEmit` : vert. Suites impactées : 30/30 ; 4 fixes prouvés load-bearing (mutation → échec → restauration).

## Hors périmètre
Durcissement du custom-scheme magic-link (refonte routage deep-link) laissé à un ticket dédié, comme suggéré dans l'issue.

## Auto-critique
Purge additive → conflit trivial attendu avec #1175 (qui possède le chemin d'écriture de `trip-cache.ts`).

<!-- claude-review-start -->
## Claude Review

**Summary:** Solid, well-tested mobile-only security hardening. The four commits iteratively close every leak raised in earlier review passes: the temp-export file (RGPD archive / GPX / FIT) is now deleted in all four outcomes (success, share-cancel, sharing-unavailable, write-failure) via a `try/finally` that wraps `create()`/`write()` too; the offline trip cache purge on logout/session-invalidation is serialized through the existing per-id `withLock`, and a `purging` flag additionally closes the narrower race where a first-time write for an id not yet listed could otherwise land after the purge — with a dedicated regression test (`does not resurrect a first-time write racing a concurrent purge`) that would fail if that flag were removed. `console.warn` calls are gated `__DEV__` and the API base URL now fails closed on a non-https origin outside dev. No blocking findings this pass.

One narrow, non-blocking edge case (raised on a previous pass, not re-flagged as blocking): `purging` (`trip-cache.ts`) is a plain boolean, not a counter, so two *overlapping* `clearAllTripCache()` calls (e.g. `logout()` racing `doRefresh()`'s session-invalidation path — nothing dedups these two triggers) could have the first call's `finally` reset `purging = false` while the second is still mid-purge, reopening the same first-time-write window for an id neither call's snapshot captured. Requires two concurrent purge triggers to hit; worth a follow-up but not a reason to block this PR.

**Resolved threads:** All 9 prior bot review threads on this PR are already resolved on GitHub; none needed re-resolving this pass.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments (no new findings).

**Commit reviewed:** `3bd94918164bbf58f03ad3c01f107edbd9c58fb1`
<!-- claude-review-end -->