### PR TITLE
perf(offline): async trip-cache writes + skip unchanged route re-serialization

### DIFF
--- a/mobile/src/store/trip-cache.test.ts
+++ b/mobile/src/store/trip-cache.test.ts
@@ -145,6 +145,21 @@ describe('cacheTripDetail / readTripCache', () => {
     expect(cached?.syncedAt).toBe(7);
   });
 
+  it('migrates a legacy embedded route into the split file on a detail-only refresh (no drop)', async () => {
+    // Pre-split cache: route embedded in <id>.json, no <id>.route.json yet.
+    mockFiles.set(
+      META_URI('mig'),
+      JSON.stringify({ detail: detail(), route, syncedAt: 7 }),
+    );
+    expect(mockFiles.has(ROUTE_URI('mig'))).toBe(false);
+    // A detail-only refresh must NOT drop the previously-cached geometry.
+    await cacheTripDetail('mig', detail(), 8);
+    expect(mockFiles.has(ROUTE_URI('mig'))).toBe(true);
+    const cached = await readTripCache('mig');
+    expect(cached?.route).toEqual(route);
+    expect(cached?.syncedAt).toBe(8);
+  });
+
   it('does not cache a past trip', async () => {
     await cacheTripDetail('past-1', detail({ startDate: '2000-01-01', endDate: '2000-01-05' }));
     expect(await readTripCache('past-1')).toBeNull();

--- a/mobile/src/store/trip-cache.test.ts
+++ b/mobile/src/store/trip-cache.test.ts
@@ -218,6 +218,23 @@ describe('cacheTripRoute', () => {
     expect(await readTripCache('missing')).toBeNull();
   });
 
+  it('keeps the legacy route in the meta when its own route write fails (no silent drop)', async () => {
+    // Pre-split cache (route embedded in the meta), then a map open triggers
+    // cacheTripRoute whose split-file write fails: the geometry must survive.
+    mockFiles.set(
+      META_URI('r2'),
+      JSON.stringify({ detail: detail(), route, syncedAt: 7 }),
+    );
+    const other = { stages: [{ dayNumber: 2, geometry: [[3, 4]] }] } as unknown as TripRoute;
+    writeMock.mockImplementationOnce((uri: string, content: string) => {
+      if (uri === ROUTE_URI('r2')) return Promise.reject(new Error('disk full'));
+      mockFiles.set(uri, content);
+      return Promise.resolve();
+    });
+    await cacheTripRoute('r2', other, 8);
+    expect((await readTripCache('r2'))?.route).toEqual(route);
+  });
+
   it('does not rewrite the route file on a detail-only refresh (#1175)', async () => {
     await cacheTripDetail('t', detail(), 1);
     await cacheTripRoute('t', route, 2);

--- a/mobile/src/store/trip-cache.test.ts
+++ b/mobile/src/store/trip-cache.test.ts
@@ -266,6 +266,21 @@ describe('cacheTripRoute', () => {
     expect(cached?.detail.title).toBe('Refreshed');
   });
 
+  it('does not READ the large route file on a steady-state detail refresh (#1175 perf)', async () => {
+    await cacheTripDetail('t', detail(), 1);
+    await cacheTripRoute('t', route, 2); // split-file cache, no legacy route in meta
+    const { File } = jest.requireMock('expo-file-system');
+    const textSpy = jest.spyOn(File.prototype, 'text');
+    await cacheTripDetail('t', detail({ title: 'Refreshed' }), 3);
+    // The migration path must stay gated on a legacy route: a post-split refresh
+    // reads only the meta, never the (~6300-point) route file.
+    const routeReads = (textSpy.mock.instances as { uri: string }[]).filter((f) =>
+      f.uri.endsWith('.route.json'),
+    ).length;
+    textSpy.mockRestore();
+    expect(routeReads).toBe(0);
+  });
+
   it('skips the route write when the geometry is unchanged but re-stamps syncedAt (#1175)', async () => {
     await cacheTripDetail('t', detail(), 1);
     await cacheTripRoute('t', route, 2);

--- a/mobile/src/store/trip-cache.test.ts
+++ b/mobile/src/store/trip-cache.test.ts
@@ -179,6 +179,26 @@ describe('cacheTripDetail / readTripCache', () => {
     expect(cached?.route).toEqual(route);
   });
 
+  it('re-attempts a failed migration on the next refresh (empty stub is not "migrated")', async () => {
+    mockFiles.set(
+      META_URI('stub'),
+      JSON.stringify({ detail: detail(), route, syncedAt: 7 }),
+    );
+    // 1st refresh: migration write fails → empty stub left on disk, route kept in meta.
+    writeMock.mockImplementationOnce((uri: string, content: string) => {
+      if (uri === ROUTE_URI('stub')) return Promise.reject(new Error('disk full'));
+      mockFiles.set(uri, content);
+      return Promise.resolve();
+    });
+    await cacheTripDetail('stub', detail(), 8);
+    expect(mockFiles.get(ROUTE_URI('stub'))).toBe(''); // empty stub from create()
+    expect((await readTripCache('stub'))?.route).toEqual(route);
+    // 2nd refresh: the stub's content ('') != the route, so migration retries and
+    // now succeeds — the route must NOT be dropped by trusting `.exists`.
+    await cacheTripDetail('stub', detail(), 9);
+    expect((await readTripCache('stub'))?.route).toEqual(route);
+  });
+
   it('does not cache a past trip', async () => {
     await cacheTripDetail('past-1', detail({ startDate: '2000-01-01', endDate: '2000-01-05' }));
     expect(await readTripCache('past-1')).toBeNull();

--- a/mobile/src/store/trip-cache.test.ts
+++ b/mobile/src/store/trip-cache.test.ts
@@ -160,6 +160,25 @@ describe('cacheTripDetail / readTripCache', () => {
     expect(cached?.syncedAt).toBe(8);
   });
 
+  it('keeps the legacy route in the meta when the migration write fails (no silent drop)', async () => {
+    mockFiles.set(
+      META_URI('mig2'),
+      JSON.stringify({ detail: detail(), route, syncedAt: 7 }),
+    );
+    // Fail the route-file migration write specifically (disk full / native error).
+    // create() still leaves an empty file on disk, so `.exists` would lie —
+    // only writeFile's return value can confirm the write actually landed.
+    writeMock.mockImplementationOnce((uri: string, content: string) => {
+      if (uri === ROUTE_URI('mig2')) return Promise.reject(new Error('disk full'));
+      mockFiles.set(uri, content);
+      return Promise.resolve();
+    });
+    await cacheTripDetail('mig2', detail(), 8);
+    // Route not persisted to the split file, but preserved via the meta fallback.
+    const cached = await readTripCache('mig2');
+    expect(cached?.route).toEqual(route);
+  });
+
   it('does not cache a past trip', async () => {
     await cacheTripDetail('past-1', detail({ startDate: '2000-01-01', endDate: '2000-01-05' }));
     expect(await readTripCache('past-1')).toBeNull();

--- a/mobile/src/store/trip-cache.test.ts
+++ b/mobile/src/store/trip-cache.test.ts
@@ -57,6 +57,17 @@ jest.mock('expo-file-system', () => {
   return { File, Directory, Paths: { document: { uri: 'file:///doc' } } };
 });
 
+// trip-cache now writes via the legacy async writer; back it with the same
+// in-memory filesystem and expose it as a jest.fn so tests can assert what got
+// (re)written.
+jest.mock('expo-file-system/legacy', () => ({
+  writeAsStringAsync: jest.fn((uri: string, content: string) => {
+    mockFiles.set(uri, content);
+    return Promise.resolve();
+  }),
+}));
+
+import { writeAsStringAsync } from 'expo-file-system/legacy';
 import {
   cacheTripDetail,
   cacheTripRoute,
@@ -77,10 +88,14 @@ function detail(over: Partial<TripDetail> = {}): TripDetail {
 }
 
 const route = { stages: [{ dayNumber: 1, geometry: [] }] } as unknown as TripRoute;
+const writeMock = writeAsStringAsync as jest.Mock;
+const ROUTE_URI = (id: string) => `file:///doc/trip-cache/${id}.route.json`;
+const META_URI = (id: string) => `file:///doc/trip-cache/${id}.json`;
 
 beforeEach(() => {
   mockFiles.clear();
   mockDirExists = true;
+  writeMock.mockClear();
 });
 
 describe('isCacheableTrip', () => {
@@ -106,12 +121,28 @@ describe('cacheTripDetail / readTripCache', () => {
   });
 
   it('persists on the very first write for a trip id (no pre-existing file)', async () => {
-    // No prior create()/write() for this id: the mock File.write() throws unless
-    // the file was created first, so this only passes if writeEntry creates it.
+    // No prior create()/write() for this id: writeFile must create the file
+    // before the async write for the entry to land.
     expect(mockFiles.size).toBe(0);
     await cacheTripDetail('brand-new', detail(), 999);
     const cached = await readTripCache('brand-new');
     expect(cached?.syncedAt).toBe(999);
+  });
+
+  it('writes asynchronously via writeAsStringAsync', async () => {
+    await cacheTripDetail('async-1', detail(), 1);
+    expect(writeMock).toHaveBeenCalledWith(META_URI('async-1'), expect.any(String));
+  });
+
+  it('reads back a legacy single-file entry with an embedded route', async () => {
+    // Cache written before the detail/route split embedded the route in <id>.json.
+    mockFiles.set(
+      META_URI('legacy'),
+      JSON.stringify({ detail: detail(), route, syncedAt: 7 }),
+    );
+    const cached = await readTripCache('legacy');
+    expect(cached?.route).toEqual(route);
+    expect(cached?.syncedAt).toBe(7);
   });
 
   it('does not cache a past trip', async () => {
@@ -151,6 +182,36 @@ describe('cacheTripRoute', () => {
   it('is a no-op when the trip is not already cached', async () => {
     await cacheTripRoute('missing', route);
     expect(await readTripCache('missing')).toBeNull();
+  });
+
+  it('does not rewrite the route file on a detail-only refresh (#1175)', async () => {
+    await cacheTripDetail('t', detail(), 1);
+    await cacheTripRoute('t', route, 2);
+    writeMock.mockClear();
+    await cacheTripDetail('t', detail({ title: 'Refreshed' }), 3);
+    expect(writeMock.mock.calls.some(([uri]) => uri === ROUTE_URI('t'))).toBe(false);
+    const cached = await readTripCache('t');
+    expect(cached?.route).toEqual(route);
+    expect(cached?.detail.title).toBe('Refreshed');
+  });
+
+  it('skips the route write when the geometry is unchanged but re-stamps syncedAt (#1175)', async () => {
+    await cacheTripDetail('t', detail(), 1);
+    await cacheTripRoute('t', route, 2);
+    writeMock.mockClear();
+    await cacheTripRoute('t', route, 3); // identical geometry
+    expect(writeMock.mock.calls.some(([uri]) => uri === ROUTE_URI('t'))).toBe(false);
+    expect((await readTripCache('t'))?.syncedAt).toBe(3);
+  });
+
+  it('rewrites the route file when the geometry actually changed', async () => {
+    await cacheTripDetail('t', detail(), 1);
+    await cacheTripRoute('t', route, 2);
+    writeMock.mockClear();
+    const other = { stages: [{ dayNumber: 1, geometry: [[1, 2]] }] } as unknown as TripRoute;
+    await cacheTripRoute('t', other, 3);
+    expect(writeMock.mock.calls.some(([uri]) => uri === ROUTE_URI('t'))).toBe(true);
+    expect((await readTripCache('t'))?.route).toEqual(other);
   });
 
   it('does not drop the route when a route write races a detail refresh (#1148)', async () => {

--- a/mobile/src/store/trip-cache.ts
+++ b/mobile/src/store/trip-cache.ts
@@ -176,27 +176,29 @@ export async function cacheTripDetail(
       await deleteTripCache(id);
       return;
     }
-    // Migrate a legacy embedded route into the split file, and only drop it from
-    // the meta once the write actually landed. Confirm via the route file's
-    // CONTENT, not `.exists`: create() leaves an empty stub behind when a prior
-    // write failed, so `.exists` would falsely report the route as migrated and
-    // let a later refresh drop it from the meta too (data lost from both places).
-    // Mirrors cacheTripRoute's content check; keep the route in the meta otherwise.
+    // Migrate a legacy embedded route into the split file (only when one is
+    // actually present — the steady-state, post-split path never touches the large
+    // route file). Confirm the migration via the route file's CONTENT, not
+    // `.exists`: create() leaves an empty stub behind when a prior write failed, so
+    // `.exists` would falsely report it migrated and let a later refresh drop it
+    // from the meta too. Keep the route in the meta as a fallback until it lands.
     const existing = await readMeta(id);
-    const routeHandle = routeFile(id);
-    const serialized = existing?.route ? JSON.stringify(existing.route) : null;
-    const previousRoute = routeHandle.exists ? await routeHandle.text() : null;
-    const migrated =
-      serialized === null ||
-      previousRoute === serialized ||
-      (await writeFile(routeHandle, serialized));
-    const legacyRoute = migrated ? undefined : existing?.route;
+    const legacyRoute = existing?.route;
+    let survivingLegacyRoute: TripRoute | null | undefined;
+    if (legacyRoute) {
+      const routeHandle = routeFile(id);
+      const serialized = JSON.stringify(legacyRoute);
+      const previousRoute = routeHandle.exists ? await routeHandle.text() : null;
+      const migrated =
+        previousRoute === serialized || (await writeFile(routeHandle, serialized));
+      survivingLegacyRoute = migrated ? undefined : legacyRoute;
+    }
     await writeFile(
       metaFile(id),
       JSON.stringify({
         detail,
         syncedAt,
-        ...(legacyRoute ? { route: legacyRoute } : {}),
+        ...(survivingLegacyRoute ? { route: survivingLegacyRoute } : {}),
       } satisfies CachedMeta),
     );
   });

--- a/mobile/src/store/trip-cache.ts
+++ b/mobile/src/store/trip-cache.ts
@@ -94,13 +94,18 @@ function ensureDir(): void {
 // Asynchronous write, wrapped so a filesystem error never propagates: the cache is
 // best-effort and the live network path is authoritative. create() is kept because
 // it is a known offline fix (#1147) that guarantees the target exists before write.
-async function writeFile(file: File, content: string): Promise<void> {
+// Returns whether the write actually landed: create() puts an empty file on disk
+// synchronously, so `.exists` can't tell a successful write from a swallowed
+// failure — callers that must confirm a write (route migration) need this signal.
+async function writeFile(file: File, content: string): Promise<boolean> {
   try {
     ensureDir();
     if (!file.exists) file.create();
     await writeAsStringAsync(file.uri, content);
+    return true;
   } catch {
     // ignore: a failed cache write only costs a later offline miss.
+    return false;
   }
 }
 
@@ -175,15 +180,16 @@ export async function cacheTripDetail(
     // split route file before overwriting the meta, so a detail-only refresh
     // never silently drops a previously-cached geometry (readTripCache's
     // "compat mono-fichier" fallback stays honoured).
+    // Migrate a legacy embedded route into the split file, and only drop it from
+    // the meta once that write actually landed (writeFile's return, not `.exists`
+    // — create() makes an empty file appear even when the write then fails). If
+    // the migration write didn't land, keep the route in the meta as a fallback.
     const existing = await readMeta(id);
-    if (existing?.route && !routeFile(id).exists) {
-      await writeFile(routeFile(id), JSON.stringify(existing.route));
-    }
-    // Only drop the legacy embedded route from the meta once the migration write
-    // is confirmed on disk: writeFile swallows errors, so re-check existence and
-    // keep the route in the meta as a fallback if the split-file write didn't land.
-    const legacyRoute =
-      existing?.route && !routeFile(id).exists ? existing.route : undefined;
+    const migrated =
+      !existing?.route ||
+      routeFile(id).exists ||
+      (await writeFile(routeFile(id), JSON.stringify(existing.route)));
+    const legacyRoute = migrated ? undefined : existing?.route;
     await writeFile(
       metaFile(id),
       JSON.stringify({

--- a/mobile/src/store/trip-cache.ts
+++ b/mobile/src/store/trip-cache.ts
@@ -177,14 +177,19 @@ export async function cacheTripDetail(
       return;
     }
     // Migrate a legacy embedded route into the split file, and only drop it from
-    // the meta once that write actually landed (writeFile's return, not `.exists`
-    // — create() makes an empty file appear even when the write then fails). If
-    // the migration write didn't land, keep the route in the meta as a fallback.
+    // the meta once the write actually landed. Confirm via the route file's
+    // CONTENT, not `.exists`: create() leaves an empty stub behind when a prior
+    // write failed, so `.exists` would falsely report the route as migrated and
+    // let a later refresh drop it from the meta too (data lost from both places).
+    // Mirrors cacheTripRoute's content check; keep the route in the meta otherwise.
     const existing = await readMeta(id);
+    const routeHandle = routeFile(id);
+    const serialized = existing?.route ? JSON.stringify(existing.route) : null;
+    const previousRoute = routeHandle.exists ? await routeHandle.text() : null;
     const migrated =
-      !existing?.route ||
-      routeFile(id).exists ||
-      (await writeFile(routeFile(id), JSON.stringify(existing.route)));
+      serialized === null ||
+      previousRoute === serialized ||
+      (await writeFile(routeHandle, serialized));
     const legacyRoute = migrated ? undefined : existing?.route;
     await writeFile(
       metaFile(id),

--- a/mobile/src/store/trip-cache.ts
+++ b/mobile/src/store/trip-cache.ts
@@ -1,4 +1,9 @@
 import { Directory, File, Paths } from 'expo-file-system';
+// The next File API's write() is synchronous (blocks the JS thread while the whole
+// ~6300-point geometry is serialized and flushed). The legacy writeAsStringAsync is
+// the only async writer expo-file-system exposes, so heavy cache writes run off the
+// UI thread (#1175).
+import { writeAsStringAsync } from 'expo-file-system/legacy';
 import type { TripDetail, TripRoute } from '../api/trips';
 import { todayUtc, tripStateFromDates } from '../components/trip/roadbook-dates';
 
@@ -7,6 +12,11 @@ import { todayUtc, tripStateFromDates } from '../components/trip/roadbook-dates'
 // rides on expo-file-system's document directory (survives restarts, not evicted
 // under storage pressure) rather than SecureStore — the route geometry is far too
 // large for SecureStore's small-value ceiling, and none of this is sensitive.
+//
+// Detail and route live in two separate files per trip (`<id>.json` and
+// `<id>.route.json`): a /detail refresh must not re-parse and re-serialize the
+// large geometry just to preserve it, and a re-sync must not rewrite an unchanged
+// route (#1175).
 //
 // Only upcoming / ongoing (and still-undated) trips are cached; a trip that has
 // turned *past* is evicted and served online-only, which bounds on-device storage
@@ -22,7 +32,17 @@ export interface CachedTrip {
   syncedAt: number;
 }
 
+// On-disk shape of the `<id>.json` file. `route` is only present in legacy
+// single-file caches written before the detail/route split; new writes never
+// embed it (it lives in `<id>.route.json`).
+interface CachedMeta {
+  detail: TripDetail;
+  syncedAt: number;
+  route?: TripRoute | null;
+}
+
 const CACHE_DIRNAME = 'trip-cache';
+const ROUTE_SUFFIX = '.route.json';
 // Trip ids are backend-issued UUID/ULID-like; reject anything else so a crafted id
 // can never escape the cache directory via the filename.
 const SAFE_ID = /^[A-Za-z0-9_-]+$/;
@@ -58,8 +78,12 @@ function cacheDir(): Directory {
   return new Directory(Paths.document, CACHE_DIRNAME);
 }
 
-function cacheFile(id: string): File {
+function metaFile(id: string): File {
   return new File(cacheDir(), `${id}.json`);
+}
+
+function routeFile(id: string): File {
+  return new File(cacheDir(), `${id}${ROUTE_SUFFIX}`);
 }
 
 function ensureDir(): void {
@@ -67,26 +91,25 @@ function ensureDir(): void {
   if (!dir.exists) dir.create({ intermediates: true });
 }
 
-// Synchronous write, wrapped so a filesystem error never propagates: the cache is
-// best-effort and the live network path is authoritative.
-function writeEntry(id: string, entry: CachedTrip): void {
+// Asynchronous write, wrapped so a filesystem error never propagates: the cache is
+// best-effort and the live network path is authoritative. create() is kept because
+// it is a known offline fix (#1147) that guarantees the target exists before write.
+async function writeFile(file: File, content: string): Promise<void> {
   try {
     ensureDir();
-    const file = cacheFile(id);
     if (!file.exists) file.create();
-    file.write(JSON.stringify(entry));
+    await writeAsStringAsync(file.uri, content);
   } catch {
     // ignore: a failed cache write only costs a later offline miss.
   }
 }
 
-/** Read a trip's cached entry, or null when it is absent or corrupt. */
-export async function readTripCache(id: string): Promise<CachedTrip | null> {
-  if (!SAFE_ID.test(id)) return null;
+/** Read a trip's `<id>.json` metadata (detail + syncedAt), without the geometry. */
+async function readMeta(id: string): Promise<CachedMeta | null> {
   try {
-    const file = cacheFile(id);
+    const file = metaFile(id);
     if (!file.exists) return null;
-    const parsed = JSON.parse(await file.text()) as CachedTrip;
+    const parsed = JSON.parse(await file.text()) as CachedMeta;
     if (!parsed || typeof parsed.syncedAt !== 'number' || !parsed.detail) {
       return null;
     }
@@ -96,12 +119,36 @@ export async function readTripCache(id: string): Promise<CachedTrip | null> {
   }
 }
 
+/** Read a trip's `<id>.route.json` geometry, or null when absent or corrupt. */
+async function readRoute(id: string): Promise<TripRoute | null> {
+  try {
+    const file = routeFile(id);
+    if (!file.exists) return null;
+    return JSON.parse(await file.text()) as TripRoute;
+  } catch {
+    return null;
+  }
+}
+
+/** Read a trip's cached entry, or null when it is absent or corrupt. */
+export async function readTripCache(id: string): Promise<CachedTrip | null> {
+  if (!SAFE_ID.test(id)) return null;
+  const meta = await readMeta(id);
+  if (!meta) return null;
+  // Prefer the split route file; fall back to a legacy embedded route so a cache
+  // written before the split still surfaces its geometry.
+  const route = (await readRoute(id)) ?? meta.route ?? null;
+  return { detail: meta.detail, route, syncedAt: meta.syncedAt };
+}
+
 /** Delete a trip's cache entry (e.g. once it turns past, or on trip deletion). */
 export async function deleteTripCache(id: string): Promise<void> {
   if (!SAFE_ID.test(id)) return;
   try {
-    const file = cacheFile(id);
-    if (file.exists) file.delete();
+    const meta = metaFile(id);
+    if (meta.exists) meta.delete();
+    const route = routeFile(id);
+    if (route.exists) route.delete();
   } catch {
     // ignore
   }
@@ -109,8 +156,9 @@ export async function deleteTripCache(id: string): Promise<void> {
 
 /**
  * Persist (or refresh) a trip's /detail payload and stamp the sync time. A trip
- * that is no longer cacheable (turned past) is evicted instead. Any existing
- * route geometry is preserved.
+ * that is no longer cacheable (turned past) is evicted instead. The route file is
+ * left untouched, so a detail refresh never re-parses or re-serializes the
+ * geometry (#1175).
  */
 export async function cacheTripDetail(
   id: string,
@@ -123,15 +171,16 @@ export async function cacheTripDetail(
       await deleteTripCache(id);
       return;
     }
-    const existing = await readTripCache(id);
-    writeEntry(id, { detail, route: existing?.route ?? null, syncedAt });
+    await writeFile(metaFile(id), JSON.stringify({ detail, syncedAt } satisfies CachedMeta));
   });
 }
 
 /**
  * Attach freshly fetched route geometry to a trip's cache entry and re-stamp the
  * sync time. No-op when the trip is not already cached (its /detail must be
- * cached first, which classifies it as cacheable).
+ * cached first, which classifies it as cacheable). The (large) geometry is only
+ * rewritten when it actually changed; the sync time is re-stamped regardless
+ * (#1175).
  */
 export async function cacheTripRoute(
   id: string,
@@ -140,9 +189,13 @@ export async function cacheTripRoute(
 ): Promise<void> {
   if (!SAFE_ID.test(id)) return;
   return withLock(id, async () => {
-    const existing = await readTripCache(id);
-    if (!existing) return;
-    writeEntry(id, { ...existing, route, syncedAt });
+    const meta = await readMeta(id);
+    if (!meta) return;
+    const serialized = JSON.stringify(route);
+    const file = routeFile(id);
+    const previous = file.exists ? await file.text() : null;
+    if (previous !== serialized) await writeFile(file, serialized);
+    await writeFile(metaFile(id), JSON.stringify({ detail: meta.detail, syncedAt } satisfies CachedMeta));
   });
 }
 
@@ -154,7 +207,7 @@ export async function listCachedTripIds(): Promise<string[]> {
     return dir
       .list()
       .map((entry) => entry.name)
-      .filter((name) => name.endsWith('.json'))
+      .filter((name) => name.endsWith('.json') && !name.endsWith(ROUTE_SUFFIX))
       .map((name) => name.slice(0, -'.json'.length))
       .filter((id) => SAFE_ID.test(id));
   } catch {
@@ -185,8 +238,9 @@ export async function syncCachedTrips(deps: SyncDeps): Promise<void> {
         if (!detail) return;
         await cacheTripDetail(id, detail);
         // Only pull the (large) geometry back if the trip is still cached after
-        // the detail refresh — a now-past trip was just evicted.
-        if (await readTripCache(id)) {
+        // the detail refresh — a now-past trip was just evicted. Check the meta
+        // file directly rather than reading (and parsing) the whole entry.
+        if (metaFile(id).exists) {
           const route = await deps.fetchRoute(id);
           if (route) await cacheTripRoute(id, route);
         }

--- a/mobile/src/store/trip-cache.ts
+++ b/mobile/src/store/trip-cache.ts
@@ -171,6 +171,14 @@ export async function cacheTripDetail(
       await deleteTripCache(id);
       return;
     }
+    // Migrate a legacy embedded route (pre-split mono-file cache) into the
+    // split route file before overwriting the meta, so a detail-only refresh
+    // never silently drops a previously-cached geometry (readTripCache's
+    // "compat mono-fichier" fallback stays honoured).
+    const existing = await readMeta(id);
+    if (existing?.route && !routeFile(id).exists) {
+      await writeFile(routeFile(id), JSON.stringify(existing.route));
+    }
     await writeFile(metaFile(id), JSON.stringify({ detail, syncedAt } satisfies CachedMeta));
   });
 }

--- a/mobile/src/store/trip-cache.ts
+++ b/mobile/src/store/trip-cache.ts
@@ -275,10 +275,11 @@ export async function syncCachedTrips(deps: SyncDeps): Promise<void> {
         const detail = await deps.fetchDetail(id);
         if (!detail) return;
         await cacheTripDetail(id, detail);
-        // Only pull the (large) geometry back if the trip is still cached after
-        // the detail refresh — a now-past trip was just evicted. Check the meta
-        // file directly rather than reading (and parsing) the whole entry.
-        if (metaFile(id).exists) {
+        // Only pull the (large) geometry back if the trip is still validly cached
+        // after the detail refresh — a now-past trip was just evicted, and a failed
+        // meta write leaves an empty stub whose `.exists` lies. readMeta validates
+        // the content (syncedAt/detail), so we don't fetch a route for a non-entry.
+        if (await readMeta(id)) {
           const route = await deps.fetchRoute(id);
           if (route) await cacheTripRoute(id, route);
         }

--- a/mobile/src/store/trip-cache.ts
+++ b/mobile/src/store/trip-cache.ts
@@ -179,7 +179,19 @@ export async function cacheTripDetail(
     if (existing?.route && !routeFile(id).exists) {
       await writeFile(routeFile(id), JSON.stringify(existing.route));
     }
-    await writeFile(metaFile(id), JSON.stringify({ detail, syncedAt } satisfies CachedMeta));
+    // Only drop the legacy embedded route from the meta once the migration write
+    // is confirmed on disk: writeFile swallows errors, so re-check existence and
+    // keep the route in the meta as a fallback if the split-file write didn't land.
+    const legacyRoute =
+      existing?.route && !routeFile(id).exists ? existing.route : undefined;
+    await writeFile(
+      metaFile(id),
+      JSON.stringify({
+        detail,
+        syncedAt,
+        ...(legacyRoute ? { route: legacyRoute } : {}),
+      } satisfies CachedMeta),
+    );
   });
 }
 

--- a/mobile/src/store/trip-cache.ts
+++ b/mobile/src/store/trip-cache.ts
@@ -176,10 +176,6 @@ export async function cacheTripDetail(
       await deleteTripCache(id);
       return;
     }
-    // Migrate a legacy embedded route (pre-split mono-file cache) into the
-    // split route file before overwriting the meta, so a detail-only refresh
-    // never silently drops a previously-cached geometry (readTripCache's
-    // "compat mono-fichier" fallback stays honoured).
     // Migrate a legacy embedded route into the split file, and only drop it from
     // the meta once that write actually landed (writeFile's return, not `.exists`
     // — create() makes an empty file appear even when the write then fails). If

--- a/mobile/src/store/trip-cache.ts
+++ b/mobile/src/store/trip-cache.ts
@@ -220,8 +220,19 @@ export async function cacheTripRoute(
     const serialized = JSON.stringify(route);
     const file = routeFile(id);
     const previous = file.exists ? await file.text() : null;
-    if (previous !== serialized) await writeFile(file, serialized);
-    await writeFile(metaFile(id), JSON.stringify({ detail: meta.detail, syncedAt } satisfies CachedMeta));
+    // Same confirm-before-drop as cacheTripDetail: only clear a legacy embedded
+    // route from the meta once the split-file write actually landed, so a failed
+    // route write on a pre-split cache doesn't lose the geometry from both places.
+    const landed = previous === serialized || (await writeFile(file, serialized));
+    const legacyRoute = landed ? undefined : meta.route;
+    await writeFile(
+      metaFile(id),
+      JSON.stringify({
+        detail: meta.detail,
+        syncedAt,
+        ...(legacyRoute ? { route: legacyRoute } : {}),
+      } satisfies CachedMeta),
+    );
   });
 }
 


### PR DESCRIPTION
Closes #1175. Sprint 58.b (recette) — perf (impact HAUT).

## Changements (`mobile/src/store/trip-cache.ts`)
- **Écriture async** : `writeAsStringAsync` (`expo-file-system/legacy` — la nouvelle API `File.write` est sync-only en v57). `ensureDir()` + `create()` avant write conservés (#1147).
- **Plus de ré-sérialisation de la route inchangée** : split en deux fichiers par voyage — `<id>.json` (`{detail, syncedAt}`) et `<id>.route.json` (géométrie). `cacheTripDetail` n'écrit plus que le meta ; `cacheTripRoute` compare la géométrie et saute l'écriture si identique (gros gain sur `syncCachedTrips`).
- **Non-régression** : `readTripCache` garde le shape public `CachedTrip` + fallback route legacy (compat mono-fichier) ; `deleteTripCache` supprime les deux fichiers ; `listCachedTripIds` exclut `.route.json` ; verrou par id conservé.

## Vérification
- `tsc --noEmit` : vert. `trip-cache.test.ts` : 21/21 (test guard prouvé load-bearing).

## Ordre de merge
Partage `trip-cache.ts` avec #1174 (PR #1188, purge additive `clearAllTripCache`). **Merger cette PR (#1175) avant #1188** : elle possède le chemin d'écriture/structure ; la purge de #1174 réutilise l'API publique (`deleteTripCache`/`listCachedTripIds`) et se rebase par-dessus.

## Auto-critique
Le split de fichiers change le layout du cache sur disque : le fallback legacy couvre les caches existants ; l'éviction (#1147/#1155) supprime bien les deux fichiers.

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 blocking findings, 0 warnings. The last hardening pass (gating the route-file touch in `cacheTripDetail` on an actual legacy route being present) fixes the previously-flagged unconditional read of the large split route file — a post-split `/detail` refresh now reads only the small meta file, matching the PR's stated goal. The confirm-before-drop migration logic (content comparison over `.exists`, empty-stub retry) is exercised end-to-end by `trip-cache.test.ts`.

**Resolved threads:** Resolved 1 previously open thread (`trip-cache.ts:203`, unconditional read of the route file on every `cacheTripDetail` call) — the current head commit applies exactly the suggested fix (route-file touch now gated behind `existing?.route`). All other prior bot threads were already resolved.

**PR title check:** `perf(offline): async trip-cache writes + skip unchanged route re-serialization` — description reads as a noun phrase rather than imperative mood; non-blocking but worth tightening before merge.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [ ] Documentation is up to date — `TRACKING.md` still lists #1175 as "⏳ À faire"; non-blocking if updated at sprint close
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

**Commit reviewed:** `721f0b1e8c6e42fee61d24b53e46cf08c34f9fd5`
<!-- claude-review-end -->