### PR TITLE
perf(mobile): memoize roadbook/trips list rows and keep the map mounted

### DIFF
--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from 'expo-router';
-import { useState } from 'react';
+import { memo, useCallback, useState } from 'react';
 import {
   ActivityIndicator,
   Alert,
@@ -78,9 +78,9 @@ interface TripCardProps {
   item: TripListItem;
   theme: Theme;
   duplicatingId: string | null;
-  onOpen: () => void;
-  onDelete: () => void;
-  onDuplicate: () => void;
+  onOpen: (item: TripListItem) => void;
+  onDelete: (item: TripListItem) => void;
+  onDuplicate: (item: TripListItem) => void | Promise<void>;
   duplicateA11y: string;
   deleteA11y: string;
   statusLabel: string;
@@ -88,7 +88,11 @@ interface TripCardProps {
   subtitle: string;
 }
 
-function TripCard({
+// Memoized (perf #1176): `renderItem` passes stable top-level callbacks
+// (bound by the parent to the item they act on internally, not re-wrapped
+// per row) so a row skips re-rendering when an unrelated part of the trips
+// list re-renders.
+const TripCard = memo(function TripCard({
   item,
   theme,
   duplicatingId,
@@ -117,7 +121,7 @@ function TripCard({
   return (
     <Pressable
       accessibilityRole="button"
-      onPress={onOpen}
+      onPress={() => onOpen(item)}
       style={({ pressed }) => ({
         overflow: 'hidden',
         borderRadius: theme.radius.xl,
@@ -151,7 +155,7 @@ function TripCard({
             accessibilityState={{ disabled: duplicating }}
             disabled={duplicating}
             hitSlop={8}
-            onPress={onDuplicate}
+            onPress={() => void onDuplicate(item)}
             style={iconBtn}
           >
             <Copy color={theme.colors.mutedForeground} size={16} />
@@ -160,7 +164,7 @@ function TripCard({
             accessibilityRole="button"
             accessibilityLabel={deleteA11y}
             hitSlop={8}
-            onPress={onDelete}
+            onPress={() => onDelete(item)}
             style={iconBtn}
           >
             <Trash2 color={theme.colors.destructive} size={16} />
@@ -189,7 +193,7 @@ function TripCard({
       </View>
     </Pressable>
   );
-}
+});
 
 export default function Trips() {
   const { t, i18n } = useTranslation();
@@ -223,30 +227,51 @@ export default function Trips() {
   // firing two POST /trips/{id}/duplicate (each would clone the trip again).
   const [duplicatingId, setDuplicatingId] = useState<string | null>(null);
 
-  function onDelete(item: TripListItem): void {
-    confirmDeleteTrip({
-      title: t('trips.deleteConfirmTitle'),
-      message: t('trips.deleteConfirmMessage', {
-        title: item.title ?? t('trips.untitled'),
-      }),
-      cancel: t('trips.cancel'),
-      confirm: t('trips.delete'),
-      onConfirm: () => {
-        void remove(item.id ?? '');
-      },
-    });
-  }
+  // Stable across renders (perf #1176): passed straight through as `TripCard`
+  // props so a memoized row doesn't re-render just because these closures got
+  // recreated.
+  const onOpen = useCallback(
+    (item: TripListItem) =>
+      router.push({ pathname: '/trip/[id]', params: { id: item.id ?? '' } }),
+    [router],
+  );
 
-  async function onDuplicate(item: TripListItem): Promise<void> {
-    const id = item.id ?? '';
-    if (duplicatingId === id) return; // re-entrance guard: a duplication is in flight
-    setDuplicatingId(id);
-    const newId = await duplicate(id);
-    setDuplicatingId(null);
-    if (!newId) {
-      Alert.alert(t('trips.duplicateFailedTitle'), t('trips.duplicateFailed'));
-    }
-  }
+  const onDelete = useCallback(
+    (item: TripListItem): void => {
+      confirmDeleteTrip({
+        title: t('trips.deleteConfirmTitle'),
+        message: t('trips.deleteConfirmMessage', {
+          title: item.title ?? t('trips.untitled'),
+        }),
+        cancel: t('trips.cancel'),
+        confirm: t('trips.delete'),
+        onConfirm: () => {
+          void remove(item.id ?? '');
+        },
+      });
+    },
+    [t, remove],
+  );
+
+  // Note: unlike `onOpen`/`onDelete`, this one is *not* fully stable — it
+  // depends on `duplicatingId` for the re-entrance guard (a `setState`
+  // functional updater cannot double as a synchronous read: the updater runs
+  // on React's next flush, not inline, so checking a flag it sets right after
+  // calling `setDuplicatingId` would always see the pre-update value).
+  // Correctness over the last bit of memoization here.
+  const onDuplicate = useCallback(
+    async (item: TripListItem): Promise<void> => {
+      const id = item.id ?? '';
+      if (duplicatingId === id) return; // a duplication for this trip is already in flight
+      setDuplicatingId(id);
+      const newId = await duplicate(id);
+      setDuplicatingId(null);
+      if (!newId) {
+        Alert.alert(t('trips.duplicateFailedTitle'), t('trips.duplicateFailed'));
+      }
+    },
+    [duplicatingId, duplicate, t],
+  );
 
   function subtitleOf(item: TripListItem): string {
     const parts = [
@@ -387,11 +412,9 @@ export default function Trips() {
                 statusLabel={t(`trips.status.${statusOf(item)}`)}
                 duplicateA11y={t('trips.duplicateA11y', { title: displayTitle })}
                 deleteA11y={t('trips.deleteA11y', { title: displayTitle })}
-                onOpen={() =>
-                  router.push({ pathname: '/trip/[id]', params: { id: item.id ?? '' } })
-                }
-                onDelete={() => onDelete(item)}
-                onDuplicate={() => void onDuplicate(item)}
+                onOpen={onOpen}
+                onDelete={onDelete}
+                onDuplicate={onDuplicate}
               />
             );
           }}

--- a/mobile/app/trip/[id]/index.tsx
+++ b/mobile/app/trip/[id]/index.tsx
@@ -245,11 +245,19 @@ export default function TripRoadbook() {
       </View>
 
       <View style={{ flex: 1 }} {...panResponder.panHandlers}>
-        {view === 'map' ? (
+        {/* Both tabs stay mounted (perf #1176): MapLibre's native view is
+            expensive to tear down and recreate (GPU textures, tile cache), so
+            swapping it out on every Roadbook<->Carte toggle re-pays that cost
+            each time. Hiding the inactive one via `display: none` keeps a
+            single long-lived map instance for the trip's lifetime, at the
+            cost of the roadbook's FlatList also staying mounted (and
+            subscribed) while the map tab is active. */}
+        <View style={{ flex: 1, display: view === 'map' ? 'flex' : 'none' }}>
           <TripMapView />
-        ) : (
+        </View>
+        <View style={{ flex: 1, display: view === 'roadbook' ? 'flex' : 'none' }}>
           <RoadbookView id={id} onConfigureDates={openDatesConfig} />
-        )}
+        </View>
       </View>
 
       <Modal

--- a/mobile/app/trip/[id]/index.tsx
+++ b/mobile/app/trip/[id]/index.tsx
@@ -87,6 +87,14 @@ export default function TripRoadbook() {
   const router = useRouter();
   const insets = useSafeAreaInsets();
   const [view, setView] = useState<TripView>('roadbook');
+  // Mount TripMapView only once the Map tab is first opened, then keep it mounted
+  // (never re-mount). Gating the first mount preserves ADR-057's "route fetched
+  // only when the map is actually viewed" — TripMapView calls useTripRoute()
+  // unconditionally — while still avoiding the expensive native re-mount (#1176).
+  const [hasViewedMap, setHasViewedMap] = useState(view === 'map');
+  useEffect(() => {
+    if (view === 'map') setHasViewedMap(true);
+  }, [view]);
   const [configOpen, setConfigOpen] = useState(false);
   const [configSection, setConfigSection] = useState<'dates' | undefined>(undefined);
   const [shareOpen, setShareOpen] = useState(false);
@@ -245,15 +253,15 @@ export default function TripRoadbook() {
       </View>
 
       <View style={{ flex: 1 }} {...panResponder.panHandlers}>
-        {/* Both tabs stay mounted (perf #1176): MapLibre's native view is
-            expensive to tear down and recreate (GPU textures, tile cache), so
-            swapping it out on every Roadbook<->Carte toggle re-pays that cost
-            each time. Hiding the inactive one via `display: none` keeps a
-            single long-lived map instance for the trip's lifetime, at the
-            cost of the roadbook's FlatList also staying mounted (and
-            subscribed) while the map tab is active. */}
+        {/* Once opened, both tabs stay mounted (perf #1176): MapLibre's native
+            view is expensive to tear down and recreate (GPU textures, tile
+            cache), so swapping it out on every Roadbook<->Carte toggle re-pays
+            that cost each time. Hiding the inactive one via `display: none`
+            keeps a single long-lived map instance. The map is only mounted
+            after its first open (`hasViewedMap`) so a rider who never taps
+            "Carte" never triggers TripMapView's eager /route fetch (ADR-057). */}
         <View style={{ flex: 1, display: view === 'map' ? 'flex' : 'none' }}>
-          <TripMapView />
+          {hasViewedMap ? <TripMapView /> : null}
         </View>
         <View style={{ flex: 1, display: view === 'roadbook' ? 'flex' : 'none' }}>
           <RoadbookView id={id} onConfigureDates={openDatesConfig} />

--- a/mobile/src/components/trip/RoadbookView.tsx
+++ b/mobile/src/components/trip/RoadbookView.tsx
@@ -86,16 +86,31 @@ export function RoadbookView({
     [],
   );
 
-  function confirmDelete(index: number): void {
-    Alert.alert(t('trip.deleteConfirmTitle'), t('trip.deleteConfirmMessage'), [
-      { text: t('trip.cancel'), style: 'cancel' },
-      {
-        text: t('trip.delete'),
-        style: 'destructive',
-        onPress: () => void mutations.deleteStage(index),
-      },
-    ]);
-  }
+  // Stable across renders (perf #1176): passed straight through as `StageCard`'s
+  // `onDelete` prop, so a memoized row doesn't re-render just because this
+  // closure got recreated.
+  const confirmDelete = useCallback(
+    (index: number): void => {
+      Alert.alert(t('trip.deleteConfirmTitle'), t('trip.deleteConfirmMessage'), [
+        { text: t('trip.cancel'), style: 'cancel' },
+        {
+          text: t('trip.delete'),
+          style: 'destructive',
+          onPress: () => void mutations.deleteStage(index),
+        },
+      ]);
+    },
+    [t, mutations],
+  );
+
+  // Stable across renders (perf #1176): same reasoning as `confirmDelete`,
+  // for `StageCard`'s `onPress` (tap-through to the stage detail).
+  const openStage = useCallback(
+    (index: number): void => {
+      router.push(`/trip/${id}/stage/${index}`);
+    },
+    [router, id],
+  );
 
   const header = (
     <View
@@ -167,7 +182,7 @@ export function RoadbookView({
                 index={index}
                 locked={readOnly}
                 onDelete={confirmDelete}
-                onPress={(i) => router.push(`/trip/${id}/stage/${i}`)}
+                onPress={openStage}
                 date={date}
                 isToday={state === 'ongoing' && isStageToday(date, today)}
                 highlighted={stageDiffs.has(index)}

--- a/mobile/src/components/trip/StageCard.tsx
+++ b/mobile/src/components/trip/StageCard.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { Pressable, Text, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import type { StageData } from '@btp/core';
@@ -46,7 +47,13 @@ interface StageCardProps {
 // through to the stage detail, where per-stage edits (distance) live (#1045);
 // only the delete stays on the card. Rendered by RoadbookView; #1039 wires the
 // tap-through.
-export function StageCard({
+// Memoized (perf #1176): the roadbook FlatList re-renders every row on any
+// store update unless the row's own props are referentially stable. `stage`
+// is structurally shared by the store's Immer reducers (unchanged stages
+// keep their object identity), so a plain shallow-prop memo skips the rows
+// the update didn't touch — as long as the callers pass stable callbacks
+// (see RoadbookView).
+export const StageCard = memo(function StageCard({
   stage,
   index,
   locked,
@@ -240,4 +247,4 @@ export function StageCard({
       </View>
     </View>
   );
-}
+});

--- a/mobile/src/components/ui/icons.ts
+++ b/mobile/src/components/ui/icons.ts
@@ -1,5 +1,16 @@
 // Icon parity with the web (lucide). Re-export the curated set the mobile
 // screens use so call sites import from one place. Add icons here as needed.
+// TODO(perf #1176): the barrel re-export pulls the whole `lucide-react-native`
+// icon set (~3300 icons) into the bundle; deep imports would shrink it, but
+// they are not a mechanical rewrite — many names here are legacy aliases
+// resolved through the package's alias map, not the file each icon actually
+// lives in (e.g. `AlertTriangle` -> `dist/esm/icons/triangle-alert.js`,
+// `HelpCircle` -> `dist/esm/icons/circle-question-mark.js`, `MoreVertical` ->
+// `dist/esm/icons/ellipsis-vertical.js`), and that mapping is an internal,
+// version-fragile implementation detail (checked against v0.545.0), not a
+// published contract. Left alone for now; revisit if bundle size becomes a
+// measured problem, ideally with a codemod driven off the package's own
+// alias table rather than a hand-maintained one.
 export {
   AlertTriangle,
   ArrowLeft,

--- a/mobile/src/components/ui/icons.ts
+++ b/mobile/src/components/ui/icons.ts
@@ -1,6 +1,6 @@
 // Icon parity with the web (lucide). Re-export the curated set the mobile
 // screens use so call sites import from one place. Add icons here as needed.
-// TODO(perf #1176): the barrel re-export pulls the whole `lucide-react-native`
+// TODO(perf #1194): the barrel re-export pulls the whole `lucide-react-native`
 // icon set (~3300 icons) into the bundle; deep imports would shrink it, but
 // they are not a mechanical rewrite — many names here are legacy aliases
 // resolved through the package's alias map, not the file each icon actually

--- a/mobile/src/screens/__tests__/trip-detail.test.tsx
+++ b/mobile/src/screens/__tests__/trip-detail.test.tsx
@@ -18,7 +18,7 @@ jest.mock('../../components/trip', () => ({
   RoadbookView: () => null,
   ShareSheet: () => null,
   SseStatusIndicator: () => null,
-  TripMapView: () => null,
+  TripMapView: jest.fn(() => null),
   TripTitleHeader: () => null,
 }));
 
@@ -74,5 +74,33 @@ describe('TripRoadbook screen — synced freshness badge (#1147)', () => {
 
     const tree = await render();
     expect(texts(tree).some((label) => label.startsWith('Synchronisé'))).toBe(false);
+  });
+});
+
+describe('TripRoadbook screen — lazy map mount (#1176, ADR-057)', () => {
+  it('mounts TripMapView only after the Map tab is opened, then keeps it mounted', async () => {
+    mockReadCache.mockResolvedValue(null);
+    const { TripMapView } = jest.requireMock('../../components/trip');
+    TripMapView.mockClear();
+
+    const tree = await render();
+    // Roadbook is the default view: the map — and its eager useTripRoute() /route
+    // fetch — must NOT mount for a rider who never taps "Carte" (ADR-057).
+    expect(TripMapView).not.toHaveBeenCalled();
+    expect(tree.root.findAllByType(TripMapView).length).toBe(0);
+
+    // Open the Map tab via the SegmentedControl.
+    const segmented = tree.root.findAll((n: any) => Array.isArray(n.props?.segments))[0];
+    await act(async () => {
+      segmented.props.onChange('map');
+    });
+    expect(TripMapView).toHaveBeenCalled();
+    expect(tree.root.findAllByType(TripMapView).length).toBe(1);
+
+    // Switch back to Roadbook: the map stays mounted (never torn down / re-mounted).
+    await act(async () => {
+      segmented.props.onChange('roadbook');
+    });
+    expect(tree.root.findAllByType(TripMapView).length).toBe(1);
   });
 });


### PR DESCRIPTION
Closes #1176. Sprint 58.b (recette) — perf (impact MOYEN). **Stacked sur #1173 (PR #1187)** — overlap `mobile/app/(tabs)/index.tsx` (régions disjointes : #1173 = ligne `keyExtractor`, cette PR = `TripCard`/`renderItem`).

## Changements
- `React.memo` sur `StageCard` et `TripCard` ; callbacks `onPress`/`confirmDelete` (RoadbookView) et `onOpen`/`onDelete`/`onDuplicate` (trips) stabilisés via `useCallback`.
- Carte MapLibre maintenue montée : bascule Roadbook⇄Carte via `display:'none'` au lieu de montage/démontage (évite de recréer la vue native).
- `lucide-react-native` tree-shake : **laissé** (TODO documenté) — plusieurs icônes utilisées sont des alias legacy dont le fichier réel diffère du nom (`AlertTriangle`→`triangle-alert`, etc.) ; renommage non mécanique, fragile entre versions.

## Vérification
- `tsc --noEmit` : vert (après rebase sur #1173). jest complet : 644/644.

## Ordre de merge
Merger **#1173 (PR #1187) avant** cette PR. Après merge de #1173, GitHub retargette celle-ci sur `main` ; rebaser avec `--onto` (droppe les commits de #1173 déjà squashés).

## Auto-critique
Un garde-fou de ré-entrance sur `onDuplicate` a dû garder `duplicatingId` dans ses deps (callback non totalement stable pour ce cas, correct et commenté) — sinon `trips.test.tsx` échouait (duplicate x2).

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 critical/warning findings. Re-verified the memoization chain (`React.memo` on `TripCard`/`StageCard`, `useCallback`-stabilized handlers, `theme` module-level constants, `useTripMutations`'s stable `useMemo` return) and the lazy-map-mount gate against ADR-057 — all correctly wired, consistent with the prior pass. The last commit closed out the one open suggestion by pointing the tree-shake TODO at a real, open follow-up issue (#1194).

**Resolved threads:** Resolved 1 previously open thread (maintainability: tree-shake TODO now references tracked issue #1194 instead of the closing #1176). The other 2 threads (architecture: lazy-map-mount gate; test-coverage: regression test) were already resolved.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

**Commit reviewed:** `3e2b27d111bb073bbc14e11011a9c7601e148d77`
<!-- claude-review-end -->