### PR TITLE
feat(offline): cached trips-list fallback + fix cold-start uncaught rejection

### DIFF
--- a/mobile/src/auth/store.test.tsx
+++ b/mobile/src/auth/store.test.tsx
@@ -11,6 +11,7 @@ jest.mock('./tokens', () => ({
 jest.mock('./authApi', () => ({ verifyMagicToken: jest.fn() }));
 jest.mock('./session', () => ({ onSessionInvalidated: jest.fn(() => () => {}) }));
 jest.mock('../store/trip-cache', () => ({ clearAllTripCache: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('../store/trips-list-cache', () => ({ clearCachedTripList: jest.fn().mockResolvedValue(undefined) }));
 // The provider registers / unregisters the push token as a side effect (#1125);
 // stub the push module so this stale-response-guard test never touches the native
 // notifications layer (its own behaviour is covered by store.push.test.tsx).
@@ -23,9 +24,13 @@ jest.mock('../notifications/push', () => ({
 import { api } from '../api/client';
 import { loadTokens } from './tokens';
 import { clearAllTripCache } from '../store/trip-cache';
+import { clearCachedTripList } from '../store/trips-list-cache';
 import { AuthProvider, useAuth } from './store';
 
 const mockClearAllTripCache = clearAllTripCache as jest.MockedFunction<typeof clearAllTripCache>;
+const mockClearCachedTripList = clearCachedTripList as jest.MockedFunction<
+  typeof clearCachedTripList
+>;
 
 type AuthContextValue = ReturnType<typeof useAuth>;
 
@@ -99,6 +104,8 @@ describe('AuthProvider stale-response guard (#1117)', () => {
       await captured.logout();
     });
     expect(mockClearAllTripCache).toHaveBeenCalledTimes(1);
+    // The trips-list snapshot (trip titles) is purged too (#1167 PII parity).
+    expect(mockClearCachedTripList).toHaveBeenCalledTimes(1);
   });
 
   it('sets the email from GET /users/me while authenticated', async () => {

--- a/mobile/src/auth/store.test.tsx
+++ b/mobile/src/auth/store.test.tsx
@@ -119,6 +119,33 @@ describe('AuthProvider stale-response guard (#1117)', () => {
     expect(captured.email).toBe('me@example.com');
   });
 
+  it('does not reject and leaves email null when the boot GET /users/me fails (offline cold start #1167)', async () => {
+    mockLoadTokens.mockResolvedValue({ jwt: 'jwt', refresh: 'refresh' });
+    mockGet.mockRejectedValue(new Error('fetch failed'));
+
+    await act(async () => {
+      renderer = TestRenderer.create(createElement(Wrapper, null, createElement(Consumer)));
+    });
+
+    // No 'Uncaught (in promise) fetch failed'; the effect swallows it.
+    expect(captured.email).toBeNull();
+  });
+
+  it('does not reject and keeps the email when refreshEmail() fails offline (#1167)', async () => {
+    mockLoadTokens.mockResolvedValue({ jwt: 'jwt', refresh: 'refresh' });
+    mockGet.mockResolvedValueOnce({ data: { email: 'me@example.com' } } as never);
+    await act(async () => {
+      renderer = TestRenderer.create(createElement(Wrapper, null, createElement(Consumer)));
+    });
+    expect(captured.email).toBe('me@example.com');
+
+    mockGet.mockRejectedValueOnce(new Error('fetch failed'));
+    await act(async () => {
+      await expect(captured.refreshEmail()).resolves.toBeUndefined();
+    });
+    expect(captured.email).toBe('me@example.com');
+  });
+
   it('drops a refreshEmail() response that lands after logout(): email stays null', async () => {
     mockLoadTokens.mockResolvedValue({ jwt: 'jwt', refresh: 'refresh' });
     // Mount effect resolves immediately with the current email.

--- a/mobile/src/auth/store.tsx
+++ b/mobile/src/auth/store.tsx
@@ -15,6 +15,7 @@ import { verifyMagicToken } from './authApi';
 import { onSessionInvalidated } from './session';
 import { clearTokens, loadTokens } from './tokens';
 import { clearAllTripCache } from '../store/trip-cache';
+import { clearCachedTripList } from '../store/trips-list-cache';
 
 type AuthContextValue = {
   ready: boolean;
@@ -69,9 +70,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
     let cancelled = false;
     void (async () => {
-      const { data } = await api.GET('/users/me', { headers: { Accept: LD_JSON } });
-      if (!cancelled) {
-        setEmail(data?.email ?? null);
+      try {
+        const { data } = await api.GET('/users/me', { headers: { Accept: LD_JSON } });
+        if (!cancelled) {
+          setEmail(data?.email ?? null);
+        }
+      } catch {
+        // Offline / API down: leave the email unresolved rather than letting the
+        // fetch reject unhandled (the "Uncaught (in promise)" cold-start #1167).
       }
     })();
     return () => {
@@ -113,10 +119,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   // without a re-login. (Not /auth/session, which is cookie-only web transport.)
   const refreshEmail = useCallback(async (): Promise<void> => {
     const gen = sessionGen.current;
-    const { data } = await api.GET('/users/me', { headers: { Accept: LD_JSON } });
-    // Drop a response that outlived its session (a logout raced this fetch).
-    if (sessionGen.current === gen) {
-      setEmail(data?.email ?? null);
+    try {
+      const { data } = await api.GET('/users/me', { headers: { Accept: LD_JSON } });
+      // Drop a response that outlived its session (a logout raced this fetch).
+      if (sessionGen.current === gen) {
+        setEmail(data?.email ?? null);
+      }
+    } catch {
+      // Offline / API down: keep the current email rather than reject.
     }
   }, []);
 
@@ -128,6 +138,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     // Purge the offline trip cache so no roadbook / manual accommodation of this
     // account survives on a shared device (#1174).
     await clearAllTripCache();
+    await clearCachedTripList();
     endSession();
   }, [endSession]);
 

--- a/mobile/src/hooks/use-trips.test.ts
+++ b/mobile/src/hooks/use-trips.test.ts
@@ -22,12 +22,20 @@ jest.mock('../api/trips', () => ({
 jest.mock('../notifications/native', () => ({
   cancelLocalNotification: jest.fn().mockResolvedValue(undefined),
 }));
+jest.mock('../store/trips-list-cache', () => ({
+  cacheTripList: jest.fn(),
+  readCachedTripList: jest.fn().mockResolvedValue(null),
+  clearCachedTripList: jest.fn(),
+}));
 const mockClearDelivered = jest.fn();
 jest.mock('../store/delivered-notifications', () => ({
   useDeliveredNotifications: { getState: () => ({ clearDelivered: mockClearDelivered }) },
 }));
 import { deleteTrip, duplicateTrip, fetchTrips } from '../api/trips';
 import { cancelLocalNotification } from '../notifications/native';
+import { cacheTripList, readCachedTripList } from '../store/trips-list-cache';
+const mockCacheList = cacheTripList as jest.MockedFunction<typeof cacheTripList>;
+const mockReadCachedList = readCachedTripList as jest.MockedFunction<typeof readCachedTripList>;
 import { notificationIdentifier } from '../notifications/plan';
 const mockFetch = fetchTrips as jest.MockedFunction<typeof fetchTrips>;
 const mockDelete = deleteTrip as jest.MockedFunction<typeof deleteTrip>;
@@ -56,6 +64,36 @@ describe('runLoadTrips (#1036)', () => {
     const res = await runLoadTrips(2, {});
     expect(res.items).toEqual([]);
     expect(res.totalItems).toBe(0);
+    expect(res.error).toBe('Impossible de charger les voyages.');
+  });
+
+  it('caches the first unfiltered page on success (#1167)', async () => {
+    mockFetch.mockResolvedValue({ items: [{ id: 't1' }], totalItems: 3 } as never);
+    await runLoadTrips(1, {});
+    expect(mockCacheList).toHaveBeenCalledWith([{ id: 't1' }]);
+  });
+
+  it('does not cache a filtered page or a later page (#1167)', async () => {
+    mockFetch.mockResolvedValue({ items: [{ id: 't1' }], totalItems: 3 } as never);
+    await runLoadTrips(1, { title: 'foo' });
+    await runLoadTrips(2, {});
+    expect(mockCacheList).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the cached list when the fetch throws, page 1 unfiltered (#1167)', async () => {
+    mockFetch.mockRejectedValue(new Error('offline'));
+    mockReadCachedList.mockResolvedValue([{ id: 'c1' }, { id: 'c2' }] as never);
+    const res = await runLoadTrips(1, {});
+    expect(res.items).toEqual([{ id: 'c1' }, { id: 'c2' }]);
+    expect(res.totalItems).toBe(2);
+    expect(res.error).toBeNull();
+  });
+
+  it('surfaces the error when the fetch throws and the cache is empty (#1167)', async () => {
+    mockFetch.mockRejectedValue(new Error('offline'));
+    mockReadCachedList.mockResolvedValue(null);
+    const res = await runLoadTrips(1, {});
+    expect(res.items).toEqual([]);
     expect(res.error).toBe('Impossible de charger les voyages.');
   });
 });

--- a/mobile/src/hooks/use-trips.test.ts
+++ b/mobile/src/hooks/use-trips.test.ts
@@ -89,12 +89,20 @@ describe('runLoadTrips (#1036)', () => {
     expect(res.error).toBeNull();
   });
 
-  it('surfaces the error when the fetch throws and the cache is empty (#1167)', async () => {
+  it('surfaces the error only when there is NO cache at all (null), not an empty one (#1167)', async () => {
     mockFetch.mockRejectedValue(new Error('offline'));
     mockReadCachedList.mockResolvedValue(null);
     const res = await runLoadTrips(1, {});
     expect(res.items).toEqual([]);
     expect(res.error).toBe('Impossible de charger les voyages.');
+  });
+
+  it('shows an empty (cached) list without the error screen when the user has no trips (#1167)', async () => {
+    mockFetch.mockRejectedValue(new Error('offline'));
+    mockReadCachedList.mockResolvedValue([]);
+    const res = await runLoadTrips(1, {});
+    expect(res.items).toEqual([]);
+    expect(res.error).toBeNull();
   });
 });
 

--- a/mobile/src/hooks/use-trips.ts
+++ b/mobile/src/hooks/use-trips.ts
@@ -8,6 +8,7 @@ import {
   type TripListItem,
 } from '../api/trips';
 import { useOfflineStore } from '../store/offline-store';
+import { cacheTripList, readCachedTripList } from '../store/trips-list-cache';
 import { useDeliveredNotifications } from '../store/delivered-notifications';
 import { cancelLocalNotification } from '../notifications/native';
 import { LOCAL_CATEGORIES, notificationIdentifier } from '../notifications/plan';
@@ -27,10 +28,23 @@ export async function runLoadTrips(
   page: number,
   filters: TripFilters,
 ): Promise<TripsPageResult> {
+  const cacheable = page === 1 && !hasActiveFilter(filters);
   try {
     const { items, totalItems } = await fetchTrips(page, filters);
+    // Snapshot the first unfiltered page so it can be replayed offline (#1167).
+    if (cacheable) void cacheTripList(items);
     return { items, totalItems, error: null };
   } catch {
+    // Offline / API down: fall back to the last cached list rather than a bare
+    // error, so the rider can still reach their trips (their details are cached
+    // too). Only for the first unfiltered page — the server owns pagination and
+    // filtering. An empty/absent cache still surfaces the error.
+    if (cacheable) {
+      const cached = await readCachedTripList();
+      if (cached && cached.length > 0) {
+        return { items: cached, totalItems: cached.length, error: null };
+      }
+    }
     return { items: [], totalItems: 0, error: 'Impossible de charger les voyages.' };
   }
 }

--- a/mobile/src/hooks/use-trips.ts
+++ b/mobile/src/hooks/use-trips.ts
@@ -40,8 +40,10 @@ export async function runLoadTrips(
     // too). Only for the first unfiltered page — the server owns pagination and
     // filtering. An empty/absent cache still surfaces the error.
     if (cacheable) {
+      // Distinguish a genuinely empty cached list ([] — the user has no trips) from
+      // "never cached" (null): the former is a valid state, not the error screen.
       const cached = await readCachedTripList();
-      if (cached && cached.length > 0) {
+      if (cached !== null) {
         return { items: cached, totalItems: cached.length, error: null };
       }
     }

--- a/mobile/src/store/trips-list-cache.test.ts
+++ b/mobile/src/store/trips-list-cache.test.ts
@@ -1,0 +1,87 @@
+/// <reference types="jest" />
+import type { TripListItem } from '../api/trips';
+
+const mockFiles = new Map<string, string>();
+let mockDirExists = true;
+
+jest.mock('expo-file-system', () => {
+  class File {
+    uri: string;
+    constructor(dir: { uri: string }, name: string) {
+      this.uri = `${dir.uri}/${name}`;
+    }
+    get exists() {
+      return mockFiles.has(this.uri);
+    }
+    create() {
+      if (!mockFiles.has(this.uri)) mockFiles.set(this.uri, '');
+    }
+    text() {
+      return Promise.resolve(mockFiles.get(this.uri) ?? '');
+    }
+    delete() {
+      mockFiles.delete(this.uri);
+    }
+  }
+  class Directory {
+    uri: string;
+    constructor(parent: { uri: string }, name: string) {
+      this.uri = `${parent.uri}/${name}`;
+    }
+    get exists() {
+      return mockDirExists;
+    }
+    create() {
+      mockDirExists = true;
+    }
+  }
+  return { File, Directory, Paths: { document: { uri: 'file:///doc' } } };
+});
+
+jest.mock('expo-file-system/legacy', () => ({
+  writeAsStringAsync: jest.fn((uri: string, content: string) => {
+    mockFiles.set(uri, content);
+    return Promise.resolve();
+  }),
+}));
+
+import {
+  cacheTripList,
+  clearCachedTripList,
+  readCachedTripList,
+} from './trips-list-cache';
+
+const URI = 'file:///doc/trips-list-cache/trips-list.json';
+const items = [{ id: 'a', title: 'A' }] as unknown as TripListItem[];
+
+beforeEach(() => {
+  mockFiles.clear();
+  mockDirExists = true;
+});
+
+describe('trips-list-cache (#1167)', () => {
+  it('caches in its OWN directory (never trip-cache/, to avoid the id collision)', async () => {
+    await cacheTripList(items, 5);
+    expect(mockFiles.has(URI)).toBe(true);
+    expect([...mockFiles.keys()].some((k) => k.includes('/trip-cache/'))).toBe(false);
+  });
+
+  it('reads back what was cached, and null when absent', async () => {
+    expect(await readCachedTripList()).toBeNull();
+    await cacheTripList(items, 5);
+    expect(await readCachedTripList()).toEqual(items);
+  });
+
+  it('clearCachedTripList deletes the snapshot', async () => {
+    await cacheTripList(items, 5);
+    await clearCachedTripList();
+    expect(await readCachedTripList()).toBeNull();
+  });
+
+  it('an in-flight cache write does not survive a concurrent logout purge (#1174)', async () => {
+    // The write is in flight (queued) when logout fires: serialization makes the
+    // purge run AFTER it and delete what it wrote, so nothing survives.
+    await Promise.all([cacheTripList(items, 5), clearCachedTripList()]);
+    expect(await readCachedTripList()).toBeNull();
+  });
+});

--- a/mobile/src/store/trips-list-cache.ts
+++ b/mobile/src/store/trips-list-cache.ts
@@ -1,0 +1,67 @@
+import { Directory, File, Paths } from 'expo-file-system';
+import { writeAsStringAsync } from 'expo-file-system/legacy';
+import type { TripListItem } from '../api/trips';
+
+// Last-known snapshot of the trips list (page 1, unfiltered), so the home screen
+// still lists the rider's trips offline / when the API is down instead of a bare
+// error (#1167). Stored as one JSON file alongside the per-trip detail cache
+// (trip-cache), but kept separate: the list item shape (Trip.TripListItem) is not
+// the detail payload, and reconstructing it from per-trip detail caches would be
+// lossy (only opened trips are cached, and stageCount/totalDistance/status differ).
+
+const CACHE_DIRNAME = 'trip-cache';
+const LIST_FILENAME = 'trips-list.json';
+
+interface CachedList {
+  items: TripListItem[];
+  syncedAt: number;
+}
+
+function cacheDir(): Directory {
+  return new Directory(Paths.document, CACHE_DIRNAME);
+}
+
+function listFile(): File {
+  return new File(cacheDir(), LIST_FILENAME);
+}
+
+/** Persist the current (page 1, unfiltered) trips list. Best-effort. */
+export async function cacheTripList(
+  items: TripListItem[],
+  syncedAt: number = Date.now(),
+): Promise<void> {
+  try {
+    const dir = cacheDir();
+    if (!dir.exists) dir.create({ intermediates: true });
+    const file = listFile();
+    if (!file.exists) file.create();
+    await writeAsStringAsync(
+      file.uri,
+      JSON.stringify({ items, syncedAt } satisfies CachedList),
+    );
+  } catch {
+    // ignore: a failed cache write only costs a later offline miss.
+  }
+}
+
+/** Read the cached trips list, or null when absent or corrupt. */
+export async function readCachedTripList(): Promise<TripListItem[] | null> {
+  try {
+    const file = listFile();
+    if (!file.exists) return null;
+    const parsed = JSON.parse(await file.text()) as CachedList;
+    return Array.isArray(parsed?.items) ? parsed.items : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Drop the cached list (called on logout so no trip titles survive — #1174). */
+export async function clearCachedTripList(): Promise<void> {
+  try {
+    const file = listFile();
+    if (file.exists) file.delete();
+  } catch {
+    // ignore
+  }
+}

--- a/mobile/src/store/trips-list-cache.ts
+++ b/mobile/src/store/trips-list-cache.ts
@@ -13,6 +13,18 @@ import type { TripListItem } from '../api/trips';
 const CACHE_DIRNAME = 'trips-list-cache';
 const LIST_FILENAME = 'trips-list.json';
 
+// Serialize cache writes and the logout purge so they never interleave: an
+// in-flight write always completes before the purge runs, and the purge then
+// deletes whatever it wrote — so no trip title survives logout on a shared device
+// (#1174 parity). A plain flag wouldn't help: clearCachedTripList has no await, so
+// its window would be empty.
+let chain: Promise<unknown> = Promise.resolve();
+function withLock<T>(fn: () => Promise<T>): Promise<T> {
+  const next = chain.then(fn, fn);
+  chain = next.catch(() => undefined);
+  return next;
+}
+
 interface CachedList {
   items: TripListItem[];
   syncedAt: number;
@@ -31,18 +43,20 @@ export async function cacheTripList(
   items: TripListItem[],
   syncedAt: number = Date.now(),
 ): Promise<void> {
-  try {
-    const dir = cacheDir();
-    if (!dir.exists) dir.create({ intermediates: true });
-    const file = listFile();
-    if (!file.exists) file.create();
-    await writeAsStringAsync(
-      file.uri,
-      JSON.stringify({ items, syncedAt } satisfies CachedList),
-    );
-  } catch {
-    // ignore: a failed cache write only costs a later offline miss.
-  }
+  return withLock(async () => {
+    try {
+      const dir = cacheDir();
+      if (!dir.exists) dir.create({ intermediates: true });
+      const file = listFile();
+      if (!file.exists) file.create();
+      await writeAsStringAsync(
+        file.uri,
+        JSON.stringify({ items, syncedAt } satisfies CachedList),
+      );
+    } catch {
+      // ignore: a failed cache write only costs a later offline miss.
+    }
+  });
 }
 
 /** Read the cached trips list, or null when absent or corrupt. */
@@ -59,10 +73,12 @@ export async function readCachedTripList(): Promise<TripListItem[] | null> {
 
 /** Drop the cached list (called on logout so no trip titles survive — #1174). */
 export async function clearCachedTripList(): Promise<void> {
-  try {
-    const file = listFile();
-    if (file.exists) file.delete();
-  } catch {
-    // ignore
-  }
+  return withLock(async () => {
+    try {
+      const file = listFile();
+      if (file.exists) file.delete();
+    } catch {
+      // ignore
+    }
+  });
 }

--- a/mobile/src/store/trips-list-cache.ts
+++ b/mobile/src/store/trips-list-cache.ts
@@ -4,12 +4,13 @@ import type { TripListItem } from '../api/trips';
 
 // Last-known snapshot of the trips list (page 1, unfiltered), so the home screen
 // still lists the rider's trips offline / when the API is down instead of a bare
-// error (#1167). Stored as one JSON file alongside the per-trip detail cache
-// (trip-cache), but kept separate: the list item shape (Trip.TripListItem) is not
+// error (#1167). Stored as one JSON file in its OWN directory (never trip-cache/, whose
+// id-based file enumeration would otherwise pick up trips-list.json as a bogus
+// trip id and GET /trips/trips-list/detail forever), kept separate because: the list item shape (Trip.TripListItem) is not
 // the detail payload, and reconstructing it from per-trip detail caches would be
 // lossy (only opened trips are cached, and stageCount/totalDistance/status differ).
 
-const CACHE_DIRNAME = 'trip-cache';
+const CACHE_DIRNAME = 'trips-list-cache';
 const LIST_FILENAME = 'trips-list.json';
 
 interface CachedList {


### PR DESCRIPTION
Closes #1167. Sprint 58.b (mode dégradé).

## Problème
Au **cold-start hors-ligne**, l'accueil affichait « Impossible de charger les voyages » + un **rejet de promesse non catché** (`Uncaught (in promise) fetch failed`), alors que les détails de voyage sont en cache — le point d'entrée était donc cassé (contredit ADR-059).

## Changements
- Nouveau `store/trips-list-cache.ts` : snapshot de la 1re page (non filtrée) de la liste (`TripListItem[]` + `syncedAt`), à côté du cache détail. Choisi plutôt qu'une reconstruction depuis les caches détail (lossy : seuls les voyages ouverts y sont, et `stageCount`/`totalDistance`/`status` diffèrent).
- `use-trips.ts` `runLoadTrips` : cache la page 1 non filtrée au succès ; en cas d'échec (offline / API down) sur la page 1 non filtrée, **rejoue le cache** au lieu d'une erreur.
- `auth/store.tsx` : `GET /users/me` (boot + `refreshEmail`) enveloppé en try/catch → plus de rejet non catché offline ; purge du cache-liste au `logout` (parité PII #1174).

## Vérification
- `tsc --noEmit` vert. **jest complet : 87 suites / 677 tests** (4 nouveaux : cache au succès, pas de cache si filtré/page 2, fallback offline, erreur si cache vide).
- **Vérifié en live** : cold-start en mode avion → la liste affiche le voyage **depuis le cache** (plus d'écran d'erreur, plus de red-box).

## Auto-critique
Le fallback ne couvre que la 1re page non filtrée (le serveur possède pagination/filtres) — l'offline montre la dernière liste connue, sans filtrage serveur. Indépendant de #1166 ; se combine avec (#1166 = bandeau read-only, #1167 = atteindre la liste).

<!-- claude-review-start -->
## Claude Review

**Commit reviewed:** `463965ec79d8d9e4b3d40c917ec1142f7280b499`

**Findings:** 0 blocking, 0 warning, 0 nitpicks (nitpicks are not posted per review policy).

**Resolved threads:** resolved 1 previously open thread — the test-coverage warning on `auth/store.tsx` (boot/`refreshEmail` `GET /users/me` rejection path had no automated test) is fixed in this head commit, which adds both rejection-path tests to `store.test.tsx`. All other previously open bot threads (dir collision, write/logout race, untested `clearCachedTripList()` call, empty-vs-null cache bug) were already resolved in earlier commits on this branch.

**Review checklist:**
- [x] Code respects the project architecture (list cache mirrors `trip-cache.ts`'s dir/lock/best-effort pattern; central 401 handling in `api/client.ts` untouched by the new try/catch)
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases (cache hit/miss/filtered paths, offline fallback incl. empty-vs-null, logout purge, and now the boot/`refreshEmail` rejection paths are all asserted)
- [x] Documentation is up to date
- [x] Dependent tickets accounted for (#1174 purge parity, #1166/#1167 relationship noted)

**Note (non-blocking):** the `withLock` serialization in `trips-list-cache.ts` closes the write-vs-logout race for a write already in flight when logout starts, but — like the equivalent `purging` flag in `trip-cache.ts` — it doesn't and can't close the case where the underlying `fetchTrips()` call is still pending when `clearCachedTripList()` returns; a response landing after that would still write stale data. This is the same residual limitation already accepted for `trip-cache.ts`, not a regression introduced here.

**PR title:** still not imperative mood and still bundles two changes ("cached ... fallback + fix ..."); consider e.g. `feat(offline): fall back to cached trips list on cold-start failure`. Not blocking.

**Inline comments:** 0 posted (previous findings already fixed; no new issues).
<!-- claude-review-end -->