### PR TITLE
feat(offline): static route thumbnail on the map tab when offline

### DIFF
--- a/mobile/src/components/trip/StaticRouteMap.test.tsx
+++ b/mobile/src/components/trip/StaticRouteMap.test.tsx
@@ -2,7 +2,7 @@
 import TestRenderer, { act } from 'react-test-renderer';
 import type { ReactElement } from 'react';
 import { Text } from 'react-native';
-import { Polyline } from 'react-native-svg';
+import { Circle, Polyline } from 'react-native-svg';
 import type { StageData } from '@btp/core';
 import { EMPTY_RESUPPLY } from '@btp/core';
 import i18n from '../../i18n';
@@ -74,5 +74,24 @@ describe('StaticRouteMap (#1168)', () => {
         Array.isArray(n.props.children) ? n.props.children : [n.props.children],
       );
     expect(texts).toContain(i18n.t('trip.map.offlineStatic'));
+  });
+
+  it('draws a Circle per marker, including one off the route bbox (#1168 review)', () => {
+    const stages = [stage()]; // route roughly 48..48.1 / 2..2.1
+    const markers = [
+      { kind: 'accommodation' as const, lon: 2.5, lat: 48.5, name: 'A' }, // outside bbox
+      { kind: 'poi' as const, lon: 2.05, lat: 48.05, name: 'P' },
+    ];
+    const tree = render(
+      <StaticRouteMap stageSegments={buildStageLines(stages)} markers={markers} />,
+    );
+    expect(tree.root.findAllByType(Circle)).toHaveLength(2);
+  });
+
+  it('still frames and draws markers when there is no drawable geometry (rest day)', () => {
+    const markers = [{ kind: 'waypoint' as const, lon: 2, lat: 48, name: 'W' }];
+    const tree = render(<StaticRouteMap stageSegments={[]} markers={markers} />);
+    expect(tree.root.findAllByType(Polyline)).toHaveLength(0);
+    expect(tree.root.findAllByType(Circle)).toHaveLength(1);
   });
 });

--- a/mobile/src/components/trip/StaticRouteMap.test.tsx
+++ b/mobile/src/components/trip/StaticRouteMap.test.tsx
@@ -1,0 +1,78 @@
+/// <reference types="jest" />
+import TestRenderer, { act } from 'react-test-renderer';
+import type { ReactElement } from 'react';
+import { Text } from 'react-native';
+import { Polyline } from 'react-native-svg';
+import type { StageData } from '@btp/core';
+import { EMPTY_RESUPPLY } from '@btp/core';
+import i18n from '../../i18n';
+import { buildStageLines, collectMarkers } from '../map/map-utils';
+import { StaticRouteMap } from './StaticRouteMap';
+
+function stage(over: Partial<StageData> = {}): StageData {
+  const p = (lat: number, lon: number) => ({ lat, lon, ele: 0 });
+  return {
+    dayNumber: 1,
+    distance: 50,
+    elevation: 100,
+    elevationLoss: 0,
+    startPoint: p(48, 2),
+    endPoint: p(48.1, 2.1),
+    geometry: [p(48, 2), p(48.05, 2.05), p(48.1, 2.1)],
+    label: null,
+    startLabel: 'A',
+    endLabel: 'B',
+    weather: null,
+    alerts: [],
+    resupply: EMPTY_RESUPPLY,
+    accommodations: [],
+    selectedAccommodation: null,
+    accommodationSearchRadiusKm: 10,
+    isRestDay: false,
+    supplyTimeline: [],
+    events: [],
+    ...over,
+  };
+}
+
+beforeAll(async () => {
+  await i18n.changeLanguage('fr');
+});
+
+function render(el: ReactElement): any {
+  let tree: any;
+  act(() => {
+    tree = TestRenderer.create(el);
+  });
+  return tree;
+}
+
+describe('StaticRouteMap (#1168)', () => {
+  it('draws one polyline per drawable stage and shows the offline note', () => {
+    const stages = [stage(), stage({ dayNumber: 2 })];
+    const tree = render(
+      <StaticRouteMap
+        stageSegments={buildStageLines(stages)}
+        markers={collectMarkers(stages)}
+      />,
+    );
+    expect(tree.root.findAllByType(Polyline)).toHaveLength(2);
+    const texts = tree.root
+      .findAllByType(Text)
+      .flatMap((n: any) =>
+        Array.isArray(n.props.children) ? n.props.children : [n.props.children],
+      );
+    expect(texts).toContain(i18n.t('trip.map.offlineStatic'));
+  });
+
+  it('renders the offline note even with no geometry (no crash)', () => {
+    const tree = render(<StaticRouteMap stageSegments={[]} markers={[]} />);
+    expect(tree.root.findAllByType(Polyline)).toHaveLength(0);
+    const texts = tree.root
+      .findAllByType(Text)
+      .flatMap((n: any) =>
+        Array.isArray(n.props.children) ? n.props.children : [n.props.children],
+      );
+    expect(texts).toContain(i18n.t('trip.map.offlineStatic'));
+  });
+});

--- a/mobile/src/components/trip/StaticRouteMap.tsx
+++ b/mobile/src/components/trip/StaticRouteMap.tsx
@@ -1,0 +1,145 @@
+import { useMemo } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import Svg, { Circle, Polyline } from 'react-native-svg';
+import { useTranslation } from 'react-i18next';
+import { CloudOff } from '../ui/icons';
+import { useTheme } from '../../theme';
+import { computeBounds, type MapMarker, type StageLine } from '../map/map-utils';
+
+// Offline stand-in for the interactive MapLibre view (#1168): base-map tiles need
+// the network, so rather than a blank tile-less canvas (or paying the native
+// MapView init offline), draw a simple static thumbnail of the route — the same
+// stage-colored polylines and markers — fitted into an SVG on a neutral surface,
+// with a discreet "map unavailable offline" note. The elevation profile below
+// stays live (it's local).
+
+const VIEWBOX = 1000;
+const PADDING = 48;
+const INNER = VIEWBOX - PADDING * 2;
+
+const MARKER_RADIUS = 7;
+
+interface StaticRouteMapProps {
+  stageSegments: StageLine[];
+  markers: MapMarker[];
+}
+
+export function StaticRouteMap({ stageSegments, markers }: StaticRouteMapProps) {
+  const theme = useTheme();
+  const { t } = useTranslation();
+
+  // Aspect-preserving projection of every [lon, lat] into the SVG box (y flipped,
+  // since latitude grows upward), so the trace keeps its real shape rather than
+  // stretching to fill.
+  const projected = useMemo(() => {
+    const all = stageSegments.flatMap((s) => s.coordinates);
+    const bounds = computeBounds(all);
+    if (!bounds) return null;
+    const [west, south, east, north] = bounds;
+    const spanX = east - west || 1e-9;
+    const spanY = north - south || 1e-9;
+    const scale = Math.min(INNER / spanX, INNER / spanY);
+    const offsetX = (VIEWBOX - spanX * scale) / 2;
+    const offsetY = (VIEWBOX - spanY * scale) / 2;
+    const project = ([lon, lat]: [number, number]): [number, number] => [
+      offsetX + (lon - west) * scale,
+      offsetY + (north - lat) * scale,
+    ];
+    return {
+      lines: stageSegments
+        .filter((s) => s.coordinates.length > 1)
+        .map((s) => ({
+          color: s.color,
+          points: s.coordinates.map(project).map(([x, y]) => `${x},${y}`).join(' '),
+        })),
+      dots: markers.map((m) => {
+        const [x, y] = project([m.lon, m.lat]);
+        return { x, y, kind: m.kind };
+      }),
+    };
+  }, [stageSegments, markers]);
+
+  const markerColor = (kind: MapMarker['kind']): string =>
+    kind === 'accommodation'
+      ? theme.colors.accentBrand
+      : kind === 'poi'
+        ? theme.colors.successInk
+        : theme.colors.foreground;
+
+  return (
+    <View
+      accessibilityLabel={t('trip.map.offlineStatic')}
+      style={[styles.container, { backgroundColor: theme.colors.muted }]}
+    >
+      {projected ? (
+        <Svg
+          width="100%"
+          height="100%"
+          viewBox={`0 0 ${VIEWBOX} ${VIEWBOX}`}
+          preserveAspectRatio="xMidYMid meet"
+        >
+          {projected.lines.map((l, i) => (
+            <Polyline
+              key={i}
+              points={l.points}
+              fill="none"
+              stroke={l.color}
+              strokeWidth={6}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          ))}
+          {projected.dots.map((d, i) => (
+            <Circle
+              key={i}
+              cx={d.x}
+              cy={d.y}
+              r={MARKER_RADIUS}
+              fill={markerColor(d.kind)}
+              stroke={theme.colors.card}
+              strokeWidth={2}
+            />
+          ))}
+        </Svg>
+      ) : null}
+      <View
+        pointerEvents="none"
+        style={[
+          styles.badge,
+          {
+            backgroundColor: theme.colors.card,
+            borderColor: theme.colors.border,
+            paddingHorizontal: theme.spacing.sm,
+            paddingVertical: theme.spacing.xs,
+            gap: theme.spacing.xs,
+            ...theme.shadows.soft,
+          },
+        ]}
+      >
+        <CloudOff size={14} color={theme.colors.mutedForeground} />
+        <Text
+          style={{
+            color: theme.colors.mutedForeground,
+            fontFamily: theme.fonts.sansMedium,
+            fontSize: 12,
+          }}
+        >
+          {t('trip.map.offlineStatic')}
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, overflow: 'hidden' },
+  badge: {
+    position: 'absolute',
+    bottom: 12,
+    left: 12,
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderRadius: 999,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+});

--- a/mobile/src/components/trip/StaticRouteMap.tsx
+++ b/mobile/src/components/trip/StaticRouteMap.tsx
@@ -32,7 +32,10 @@ export function StaticRouteMap({ stageSegments, markers }: StaticRouteMapProps) 
   // since latitude grows upward), so the trace keeps its real shape rather than
   // stretching to fill.
   const projected = useMemo(() => {
-    const all = stageSegments.flatMap((s) => s.coordinates);
+    const all = [
+      ...stageSegments.flatMap((s) => s.coordinates),
+      ...markers.map((m) => [m.lon, m.lat] as [number, number]),
+    ];
     const bounds = computeBounds(all);
     if (!bounds) return null;
     const [west, south, east, north] = bounds;
@@ -59,12 +62,14 @@ export function StaticRouteMap({ stageSegments, markers }: StaticRouteMapProps) 
     };
   }, [stageSegments, markers]);
 
+  // Match TripMap's circle-color tokens so a marker keeps its color between the
+  // live map and this offline thumbnail (#1168 review).
   const markerColor = (kind: MapMarker['kind']): string =>
     kind === 'accommodation'
-      ? theme.colors.accentBrand
+      ? theme.colors.brand
       : kind === 'poi'
-        ? theme.colors.successInk
-        : theme.colors.foreground;
+        ? theme.colors.accentInk
+        : theme.colors.primary;
 
   return (
     <View

--- a/mobile/src/components/trip/TripMapView.test.tsx
+++ b/mobile/src/components/trip/TripMapView.test.tsx
@@ -178,8 +178,8 @@ describe('TripMapView', () => {
     ]);
   });
 
-  it('shows the offline map badge only when connectivity is down', () => {
-    const label = i18n.t('trip.map.offline');
+  it('swaps in the static route map with an offline note when connectivity drops (#1168)', () => {
+    const label = i18n.t('trip.map.offlineStatic');
     const hasBadge = (root: any): boolean =>
       root.findAll(
         (n: any) =>

--- a/mobile/src/components/trip/TripMapView.tsx
+++ b/mobile/src/components/trip/TripMapView.tsx
@@ -4,8 +4,8 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import { profileHighlightSegment } from '@btp/core/elevation';
 import { EmptyState } from '../ui';
-import { CloudOff } from '../ui/icons';
 import { TripMap } from '../TripMap';
+import { StaticRouteMap } from './StaticRouteMap';
 import { buildStageLines, collectMarkers } from '../map/map-utils';
 import { ElevationProfile } from './ElevationProfile';
 import { computeProfileSummary, groupThousands } from './trip-map-summary';
@@ -54,42 +54,18 @@ export function TripMapView() {
   return (
     <View style={styles.container}>
       <View style={styles.map}>
-        <TripMap
-          stageSegments={stageSegments}
-          markers={markers}
-          highlightedSegment={highlightedSegment}
-        />
-        {/* Discrete "offline map" indicator: when connectivity drops, TripMap
-            degrades to the tile-less style (route + profile stay local); this
-            badge tells the rider why the base imagery is gone. */}
-        {!isOnline ? (
-          <View
-            pointerEvents="none"
-            accessibilityRole="text"
-            style={[
-              styles.offlineBadge,
-              {
-                backgroundColor: theme.colors.card,
-                borderColor: theme.colors.border,
-                paddingHorizontal: theme.spacing.sm,
-                paddingVertical: theme.spacing.xs,
-                gap: theme.spacing.xs,
-                ...theme.shadows.soft,
-              },
-            ]}
-          >
-            <CloudOff size={14} color={theme.colors.mutedForeground} />
-            <Text
-              style={{
-                color: theme.colors.mutedForeground,
-                fontFamily: theme.fonts.sansMedium,
-                fontSize: 12,
-              }}
-            >
-              {t('trip.map.offline')}
-            </Text>
-          </View>
-        ) : null}
+        {/* Offline: base-map tiles need the network, so swap the interactive
+            MapLibre view for a static route thumbnail (#1168) rather than a blank
+            tile-less canvas. The elevation profile below stays live. */}
+        {isOnline ? (
+          <TripMap
+            stageSegments={stageSegments}
+            markers={markers}
+            highlightedSegment={highlightedSegment}
+          />
+        ) : (
+          <StaticRouteMap stageSegments={stageSegments} markers={markers} />
+        )}
       </View>
       {/* Fixed bottom profile panel: the map (flex:1) takes the remaining height
           and the panel keeps its intrinsic height (title + SVG + axis), so map +

--- a/mobile/src/components/trip/TripMapView.tsx
+++ b/mobile/src/components/trip/TripMapView.tsx
@@ -148,15 +148,6 @@ export function TripMapView() {
 const styles = StyleSheet.create({
   container: { flex: 1 },
   map: { flex: 1 },
-  offlineBadge: {
-    position: 'absolute',
-    bottom: 12,
-    left: 12,
-    flexDirection: 'row',
-    alignItems: 'center',
-    borderRadius: 999,
-    borderWidth: StyleSheet.hairlineWidth,
-  },
   profile: { borderTopWidth: StyleSheet.hairlineWidth },
   profileHeader: {
     flexDirection: 'row',

--- a/mobile/src/i18n/resources/en.ts
+++ b/mobile/src/i18n/resources/en.ts
@@ -342,6 +342,7 @@ export const en: typeof fr = {
       layerMap: 'Map',
       layerSatellite: 'Satellite',
       offline: 'Offline map',
+      offlineStatic: 'Map unavailable offline — route shown.',
       toggleA11y: 'Toggle base map',
       zoomInA11y: 'Zoom in',
       zoomOutA11y: 'Zoom out',

--- a/mobile/src/i18n/resources/en.ts
+++ b/mobile/src/i18n/resources/en.ts
@@ -341,7 +341,6 @@ export const en: typeof fr = {
     map: {
       layerMap: 'Map',
       layerSatellite: 'Satellite',
-      offline: 'Offline map',
       offlineStatic: 'Map unavailable offline — route shown.',
       toggleA11y: 'Toggle base map',
       zoomInA11y: 'Zoom in',

--- a/mobile/src/i18n/resources/fr.ts
+++ b/mobile/src/i18n/resources/fr.ts
@@ -341,7 +341,6 @@ export const fr = {
     map: {
       layerMap: 'Plan',
       layerSatellite: 'Satellite',
-      offline: 'Carte hors-ligne',
       offlineStatic: 'Carte indisponible hors-ligne — tracé affiché.',
       toggleA11y: 'Changer le fond de carte',
       zoomInA11y: 'Zoomer',

--- a/mobile/src/i18n/resources/fr.ts
+++ b/mobile/src/i18n/resources/fr.ts
@@ -342,6 +342,7 @@ export const fr = {
       layerMap: 'Plan',
       layerSatellite: 'Satellite',
       offline: 'Carte hors-ligne',
+      offlineStatic: 'Carte indisponible hors-ligne — tracé affiché.',
       toggleA11y: 'Changer le fond de carte',
       zoomInA11y: 'Zoomer',
       zoomOutA11y: 'Dézoomer',


### PR DESCRIPTION
Closes #1168. Sprint 58.b (mode dégradé).

## Problème
Hors-ligne, les tuiles de fond de carte ne chargent pas : l'onglet Carte tombait sur un fond MapLibre vide (et payait l'init native pour rien).

## Changements
- Nouveau `StaticRouteMap.tsx` : dessine un **thumbnail statique** du tracé — polylignes colorées par étape + marqueurs, projetées (aspect-preserving) dans un SVG sur fond neutre — avec une note discrète « **Carte indisponible hors-ligne — tracé affiché** ».
- `TripMapView` : `isOnline ? <TripMap/> : <StaticRouteMap/>` (le profil altimétrique reste live, local). Ancien badge inline retiré (porté par StaticRouteMap).
- i18n FR/EN : `trip.map.offlineStatic`.

## Vérification
- `tsc --noEmit` vert. jest : StaticRouteMap 2/2 (une polyligne par étape + note ; pas de crash sans géométrie), TripMapView mis à jour (swap offline). Suite complète verte (le seul rouge = flake connu ShareSheet, passe isolé 8/8).
- **Vérifié en live sur device** (mode avion) : le tracé statique 2 étapes + marqueurs + note s'affiche, profil altimétrique conservé, **sans red-box**.

## Auto-critique
Le premier jet utilisait des clés marqueurs `kind-lon-lat` → collision aux jonctions d'étapes (points partagés) → « two children with the same key ». Corrigé (clés par index) et re-vérifié en live. Indépendant de #1166/#1167 (complète le lot mode dégradé).

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 findings. All 4 previously-flagged issues (bounds ignoring markers, marker-color drift vs. the live map, orphaned i18n key, missing marker-rendering test) and the 1 orphaned-style follow-up (`offlineBadge` in `TripMapView.tsx`) are fixed in this revision. No new correctness, security, or performance issues found.

Resolved 1 previously open thread that was addressed (orphaned `offlineBadge` style).

**PR title check:** still non-conforming — "static route thumbnail on the map tab when offline" is a noun phrase, not imperative mood. Consider e.g. `feat(offline): show a static route thumbnail on the map tab when offline`.

### Review checklist
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [ ] Documentation is up to date (TRACKING.md #1168 row still shows "⏳ À faire"; sibling rows in the same sprint table flip to "✅ Mergée (#PR)" on merge)
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

Commit reviewed: 9fca18d5171bbb671832541c4983009148b08dcd
<!-- claude-review-end -->