### PR TITLE
feat(mobile): onboarding / tour guidé first-run (#1180)

### DIFF
--- a/mobile/app/(tabs)/_layout.tsx
+++ b/mobile/app/(tabs)/_layout.tsx
@@ -2,6 +2,7 @@ import { Redirect, Tabs } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { Plus, Route, Settings } from '../../src/components/ui/icons';
 import { LoadingState } from '../../src/components/ui';
+import { OnboardingTour } from '../../src/components/onboarding/OnboardingTour';
 import { useTheme } from '../../src/theme';
 import { useAuth } from '../../src/auth/store';
 
@@ -20,38 +21,42 @@ export default function TabsLayout() {
   }
 
   return (
-    <Tabs
-      screenOptions={{
-        headerShown: false,
-        tabBarActiveTintColor: theme.colors.brand,
-        tabBarInactiveTintColor: theme.colors.mutedForeground,
-        tabBarStyle: {
-          backgroundColor: theme.colors.card,
-          borderTopColor: theme.colors.border,
-        },
-      }}
-    >
-      <Tabs.Screen
-        name="create"
-        options={{
-          title: t('nav.create'),
-          tabBarIcon: ({ color, size }) => <Plus color={color} size={size} />,
+    <>
+      <Tabs
+        screenOptions={{
+          headerShown: false,
+          tabBarActiveTintColor: theme.colors.brand,
+          tabBarInactiveTintColor: theme.colors.mutedForeground,
+          tabBarStyle: {
+            backgroundColor: theme.colors.card,
+            borderTopColor: theme.colors.border,
+          },
         }}
-      />
-      <Tabs.Screen
-        name="index"
-        options={{
-          title: t('nav.trips'),
-          tabBarIcon: ({ color, size }) => <Route color={color} size={size} />,
-        }}
-      />
-      <Tabs.Screen
-        name="account"
-        options={{
-          title: t('nav.account'),
-          tabBarIcon: ({ color, size }) => <Settings color={color} size={size} />,
-        }}
-      />
-    </Tabs>
+      >
+        <Tabs.Screen
+          name="create"
+          options={{
+            title: t('nav.create'),
+            tabBarIcon: ({ color, size }) => <Plus color={color} size={size} />,
+          }}
+        />
+        <Tabs.Screen
+          name="index"
+          options={{
+            title: t('nav.trips'),
+            tabBarIcon: ({ color, size }) => <Route color={color} size={size} />,
+          }}
+        />
+        <Tabs.Screen
+          name="account"
+          options={{
+            title: t('nav.account'),
+            tabBarIcon: ({ color, size }) => <Settings color={color} size={size} />,
+          }}
+        />
+      </Tabs>
+      {/* First-run guided tour (once per install); renders null after that. */}
+      <OnboardingTour />
+    </>
   );
 }

--- a/mobile/src/components/onboarding/OnboardingTour.test.tsx
+++ b/mobile/src/components/onboarding/OnboardingTour.test.tsx
@@ -1,0 +1,74 @@
+/// <reference types="jest" />
+import TestRenderer, { act } from 'react-test-renderer';
+import { createElement } from 'react';
+import i18n from '../../i18n';
+import { useOnboarding } from '../../store/onboarding-prefs';
+import { OnboardingTour } from './OnboardingTour';
+
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: jest.fn().mockResolvedValue(null),
+  setItemAsync: jest.fn(),
+}));
+import * as SecureStore from 'expo-secure-store';
+const setItem = SecureStore.setItemAsync as jest.Mock;
+
+let renderer: any;
+async function render(): Promise<any> {
+  await act(async () => {
+    renderer = TestRenderer.create(createElement(OnboardingTour));
+  });
+  return renderer.root;
+}
+
+// The tour's root View carries testID="onboarding-tour"; absent => renders null.
+function isVisible(root: any): boolean {
+  return root.findAllByProps({ testID: 'onboarding-tour' }).length > 0;
+}
+function findSkip(root: any): any {
+  return root.find(
+    (n: any) =>
+      n.props?.accessibilityRole === 'button' &&
+      n.props?.accessibilityLabel === i18n.t('onboarding.skip'),
+  );
+}
+
+beforeAll(async () => {
+  await i18n.changeLanguage('fr');
+});
+
+beforeEach(() => {
+  setItem.mockReset();
+  useOnboarding.setState({ seen: false, hydrated: false });
+});
+
+afterEach(() => {
+  act(() => renderer?.unmount());
+});
+
+describe('OnboardingTour', () => {
+  it('renders on first run once the unset flag has hydrated', async () => {
+    const root = await render();
+    // load() resolved with null -> hydrated, not seen -> the tour shows.
+    expect(useOnboarding.getState()).toMatchObject({ seen: false, hydrated: true });
+    expect(isVisible(root)).toBe(true);
+  });
+
+  it('does not render once the flag is already set', async () => {
+    useOnboarding.setState({ seen: true, hydrated: true });
+    const root = await render();
+    expect(isVisible(root)).toBe(false);
+  });
+
+  it('Skip marks the tour as shown and dismisses it', async () => {
+    const root = await render();
+    expect(isVisible(root)).toBe(true);
+
+    await act(async () => {
+      findSkip(root).props.onPress();
+    });
+
+    expect(useOnboarding.getState().seen).toBe(true);
+    expect(setItem).toHaveBeenCalledWith('btp_onboarding_seen', 'true');
+    expect(isVisible(root)).toBe(false);
+  });
+});

--- a/mobile/src/components/onboarding/OnboardingTour.test.tsx
+++ b/mobile/src/components/onboarding/OnboardingTour.test.tsx
@@ -31,6 +31,10 @@ function findSkip(root: any): any {
       n.props?.accessibilityLabel === i18n.t('onboarding.skip'),
   );
 }
+// The bottom CTA is a Button rendered with a `label` prop (Suivant / Commencer).
+function findCta(root: any): any {
+  return root.find((n: any) => typeof n.props?.label === 'string' && !!n.props?.onPress);
+}
 
 beforeAll(async () => {
   await i18n.changeLanguage('fr');
@@ -56,6 +60,25 @@ describe('OnboardingTour', () => {
   it('does not render once the flag is already set', async () => {
     useOnboarding.setState({ seen: true, hydrated: true });
     const root = await render();
+    expect(isVisible(root)).toBe(false);
+  });
+
+  it('advances through the steps via Next and finishes (markSeen) on the last (#1202 review)', async () => {
+    const root = await render();
+    // Step 1/3, CTA reads "Suivant".
+    expect(findCta(root).props.label).toBe(i18n.t('onboarding.next'));
+
+    await act(async () => findCta(root).props.onPress()); // -> step 2
+    expect(findCta(root).props.label).toBe(i18n.t('onboarding.next'));
+    await act(async () => findCta(root).props.onPress()); // -> step 3 (last)
+
+    // On the last step the CTA becomes "Commencer" and does not mark seen yet.
+    expect(findCta(root).props.label).toBe(i18n.t('onboarding.start'));
+    expect(useOnboarding.getState().seen).toBe(false);
+
+    await act(async () => findCta(root).props.onPress()); // finish
+    expect(useOnboarding.getState().seen).toBe(true);
+    expect(setItem).toHaveBeenCalledWith('btp_onboarding_seen', 'true');
     expect(isVisible(root)).toBe(false);
   });
 

--- a/mobile/src/components/onboarding/OnboardingTour.tsx
+++ b/mobile/src/components/onboarding/OnboardingTour.tsx
@@ -1,0 +1,147 @@
+import { useEffect, useState } from 'react';
+import { Modal, Pressable, StyleSheet, Text, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { useTheme } from '../../theme/context';
+import { Button } from '../ui';
+import { Navigation, Plus, Route } from '../ui/icons';
+import { useOnboarding } from '../../store/onboarding-prefs';
+
+/**
+ * OnboardingTour — a first-run guided tour (parity with the web driver.js tour).
+ *
+ * Shown once per install, gated on a SecureStore flag (`onboarding-prefs`):
+ * three steps walking through the core mobile workflow — create a trip, follow
+ * the roadbook, ride with the in-ride companion. Skippable at any point; both
+ * Skip and finishing mark the flag so it never shows again. Mounted once, inside
+ * the authenticated tab group.
+ */
+export function OnboardingTour() {
+  const { t } = useTranslation();
+  const theme = useTheme();
+  const hydrated = useOnboarding((s) => s.hydrated);
+  const seen = useOnboarding((s) => s.seen);
+  const markSeen = useOnboarding((s) => s.markSeen);
+  const load = useOnboarding((s) => s.load);
+  const [step, setStep] = useState(0);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const steps = [
+    { Icon: Plus, key: 'create' as const },
+    { Icon: Route, key: 'roadbook' as const },
+    { Icon: Navigation, key: 'ride' as const },
+  ];
+
+  // Wait for hydration (null = flag not read yet) to avoid a flash before we
+  // know whether the tour was already seen.
+  if (!hydrated || seen) return null;
+
+  const isLast = step === steps.length - 1;
+  const { Icon, key } = steps[step];
+
+  return (
+    <Modal visible transparent animationType="fade" onRequestClose={markSeen}>
+      <View style={styles.backdrop} testID="onboarding-tour">
+        <View
+          style={[
+            styles.card,
+            {
+              backgroundColor: theme.colors.card,
+              borderRadius: theme.radius['3xl'],
+              padding: theme.spacing.xl,
+            },
+          ]}
+        >
+          <View style={styles.header}>
+            <Text style={{ color: theme.colors.mutedForeground, fontFamily: theme.fonts.sans, fontSize: 13 }}>
+              {t('onboarding.progress', { current: step + 1, total: steps.length })}
+            </Text>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={t('onboarding.skip')}
+              hitSlop={12}
+              onPress={markSeen}
+            >
+              <Text style={{ color: theme.colors.mutedForeground, fontFamily: theme.fonts.sansMedium, fontSize: 15 }}>
+                {t('onboarding.skip')}
+              </Text>
+            </Pressable>
+          </View>
+
+          <View
+            style={[
+              styles.iconBadge,
+              { backgroundColor: theme.colors.secondary, borderRadius: theme.radius.full },
+            ]}
+          >
+            <Icon color={theme.colors.brand} size={28} />
+          </View>
+
+          <Text
+            style={{
+              color: theme.colors.foreground,
+              fontFamily: theme.fonts.serif,
+              fontSize: 22,
+              marginTop: theme.spacing.base,
+            }}
+          >
+            {t(`onboarding.steps.${key}.title`)}
+          </Text>
+          <Text
+            style={{
+              color: theme.colors.mutedForeground,
+              fontFamily: theme.fonts.sans,
+              fontSize: 15,
+              lineHeight: 22,
+              marginTop: theme.spacing.sm,
+            }}
+          >
+            {t(`onboarding.steps.${key}.description`)}
+          </Text>
+
+          <View style={[styles.dots, { marginVertical: theme.spacing.base }]}>
+            {steps.map((s, i) => (
+              <View
+                key={s.key}
+                style={{
+                  width: i === step ? 20 : 6,
+                  height: 6,
+                  borderRadius: 3,
+                  backgroundColor: i === step ? theme.colors.brand : theme.colors.border,
+                }}
+              />
+            ))}
+          </View>
+
+          <Button
+            label={isLast ? t('onboarding.start') : t('onboarding.next')}
+            fullWidth
+            onPress={() => (isLast ? markSeen() : setStep((s) => s + 1))}
+          />
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 24,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+  },
+  card: { width: '100%', maxWidth: 400 },
+  header: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' },
+  iconBadge: {
+    width: 56,
+    height: 56,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginTop: 12,
+  },
+  dots: { flexDirection: 'row', gap: 6, alignItems: 'center' },
+});

--- a/mobile/src/i18n/resources/en.ts
+++ b/mobile/src/i18n/resources/en.ts
@@ -581,4 +581,27 @@ export const en: typeof fr = {
     failedTitle: 'Export failed',
     failedMessage: 'The export failed. Try again.',
   },
+  onboarding: {
+    skip: 'Skip',
+    next: 'Next',
+    start: 'Get started',
+    progress: 'Step {{current}} / {{total}}',
+    steps: {
+      create: {
+        title: 'Create your trip',
+        description:
+          'Paste a Komoot, Strava or RideWithGPS link, or import a GPX. We split your route into daily stages automatically.',
+      },
+      roadbook: {
+        title: 'Follow your roadbook',
+        description:
+          'For each day: distance, elevation, weather, accommodation and alerts. Tweak a stage and the following days recompute.',
+      },
+      ride: {
+        title: 'Get in the saddle',
+        description:
+          'Out on the road, "In the saddle" shows your position and the useful points around you (water, shelter, resupply), even offline.',
+      },
+    },
+  },
 };

--- a/mobile/src/i18n/resources/fr.ts
+++ b/mobile/src/i18n/resources/fr.ts
@@ -582,4 +582,27 @@ export const fr = {
     failedTitle: 'Export impossible',
     failedMessage: "L'export a échoué. Réessayez.",
   },
+  onboarding: {
+    skip: 'Passer',
+    next: 'Suivant',
+    start: 'Commencer',
+    progress: 'Étape {{current}} / {{total}}',
+    steps: {
+      create: {
+        title: 'Crée ton voyage',
+        description:
+          'Colle un lien Komoot, Strava ou RideWithGPS, ou importe un GPX. On découpe automatiquement ton itinéraire en étapes journalières.',
+      },
+      roadbook: {
+        title: 'Suis ton roadbook',
+        description:
+          'Pour chaque jour : distance, dénivelé, météo, hébergements et alertes. Ajuste une étape et les jours suivants se recalculent.',
+      },
+      ride: {
+        title: 'Passe en selle',
+        description:
+          "Sur le terrain, « En selle » affiche ta position et les points utiles autour de toi (eau, abri, ravito), même hors-ligne.",
+      },
+    },
+  },
 };

--- a/mobile/src/store/onboarding-prefs.test.ts
+++ b/mobile/src/store/onboarding-prefs.test.ts
@@ -1,0 +1,53 @@
+/// <reference types="jest" />
+import * as SecureStore from 'expo-secure-store';
+import { useOnboarding } from './onboarding-prefs';
+
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: jest.fn(),
+  setItemAsync: jest.fn(),
+}));
+
+const getItem = SecureStore.getItemAsync as jest.Mock;
+const setItem = SecureStore.setItemAsync as jest.Mock;
+
+beforeEach(() => {
+  getItem.mockReset();
+  setItem.mockReset();
+  useOnboarding.setState({ seen: false, hydrated: false });
+});
+
+describe('useOnboarding', () => {
+  it('defaults to not-seen before hydration', () => {
+    expect(useOnboarding.getState()).toMatchObject({ seen: false, hydrated: false });
+  });
+
+  it('load hydrates the stored "seen" flag once', async () => {
+    getItem.mockResolvedValue('true');
+    await useOnboarding.getState().load();
+    expect(useOnboarding.getState()).toMatchObject({ seen: true, hydrated: true });
+
+    getItem.mockResolvedValue(null);
+    await useOnboarding.getState().load();
+    // Already hydrated: the second load is a no-op, the stored value is not re-read.
+    expect(getItem).toHaveBeenCalledTimes(1);
+    expect(useOnboarding.getState().seen).toBe(true);
+  });
+
+  it('load treats an unset flag as not-seen (fresh install shows the tour)', async () => {
+    getItem.mockResolvedValue(null);
+    await useOnboarding.getState().load();
+    expect(useOnboarding.getState()).toMatchObject({ seen: false, hydrated: true });
+  });
+
+  it('load survives a storage read failure — shows the tour, never throws', async () => {
+    getItem.mockRejectedValue(new Error('SecureStore unavailable'));
+    await expect(useOnboarding.getState().load()).resolves.toBeUndefined();
+    expect(useOnboarding.getState()).toMatchObject({ seen: false, hydrated: true });
+  });
+
+  it('markSeen persists the flag', () => {
+    useOnboarding.getState().markSeen();
+    expect(useOnboarding.getState().seen).toBe(true);
+    expect(setItem).toHaveBeenCalledWith('btp_onboarding_seen', 'true');
+  });
+});

--- a/mobile/src/store/onboarding-prefs.ts
+++ b/mobile/src/store/onboarding-prefs.ts
@@ -1,0 +1,36 @@
+import { create } from 'zustand';
+import * as SecureStore from 'expo-secure-store';
+
+// SecureStore key (alnum/._- only). Rides on SecureStore like the theme/base-map
+// choices rather than pulling in AsyncStorage — it's the only KV the app ships.
+const KEY = 'btp_onboarding_seen';
+
+interface OnboardingState {
+  // Whether the guided tour has already been shown (persisted, once per install).
+  seen: boolean;
+  hydrated: boolean;
+  markSeen: () => void;
+  load: () => Promise<void>;
+}
+
+// Persisted "guided tour already shown" flag. `markSeen` is fire-and-forget so
+// dismissing the tour stays synchronous; `load()` hydrates once at mount.
+export const useOnboarding = create<OnboardingState>((set, get) => ({
+  seen: false,
+  hydrated: false,
+  markSeen: () => {
+    set({ seen: true });
+    void SecureStore.setItemAsync(KEY, 'true');
+  },
+  load: async () => {
+    if (get().hydrated) return;
+    try {
+      const stored = await SecureStore.getItemAsync(KEY);
+      set({ seen: stored === 'true', hydrated: true });
+    } catch {
+      // Storage unavailable (fresh install, cleared store): show the tour rather
+      // than crash — it's a one-time nicety, never critical state.
+      set({ seen: false, hydrated: true });
+    }
+  },
+}));


### PR DESCRIPTION
Closes #1180

Tour guidé mobile (parité web `onboarding-tour.tsx`), skippable, affiché une seule fois par installation.

## Contenu
- `store/onboarding-prefs.ts` — Zustand + expo-secure-store (clé `btp_onboarding_seen`), calqué sur theme-prefs/map-prefs (aucune nouvelle dépendance).
- `components/onboarding/OnboardingTour.tsx` — overlay Modal 3 étapes (créer un voyage / roadbook / en selle), Passer + Suivant/Commencer, dots de progression.
- Montage unique dans `(tabs)/_layout.tsx`, branche authentifiée uniquement (jamais sur login/loading).
- i18n fr+en (bloc `onboarding.*`, parité vérifiée par i18n.test.ts).

## Résilience
`load()` try/catch : échec de lecture (fresh install / store vidé) ⇒ tour affiché, pas de crash. Skip / Commencer / back Android marquent la flag.

## Auto-critique
- Persistance par installation (secure-store), pas par compte : réinitialiser le tour = réinstaller. Aligné sur le web (localStorage).
- App Link/deep-link non concernés ici.

## Tests
- `onboarding-prefs.test.ts` + `OnboardingTour.test.tsx` (8 tests). Prove-it-can-fail vérifié sur « Skip marks the tour as shown ».
- CI mobile = tsc + jest : `Test Suites: 91 passed` / `Tests: 709 passed`, tsc clean.
- Playwright/Functional = hors périmètre mobile (CI).

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 critical, 0 warning, 0 suggestion. The previously-flagged test gap (step-advancement / finish-on-last path) is now covered.

**Resolved threads:** Resolved 1 previously open thread (step-advancement/finish-on-last test coverage — addressed by the `test(mobile): cover onboarding step advancement + finish-on-last` commit).

**Review checklist:**
- [x] Code respects the project architecture (mobile-only Zustand store, follows `theme-prefs.ts`/`map-prefs.ts` SecureStore convention — including the fire-and-forget `SecureStore.setItemAsync` write pattern)
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate (no unjustified quick-and-dirty)
- [x] Tests cover new/changed cases (initial render, already-seen, step advancement, finish-on-last, Skip, and store-level load/hydration/failure paths)
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**PR title:** `feat(mobile): onboarding / tour guidé first-run (#1180)` — description isn't imperative mood and mixes fr/en (`tour guidé`); non-blocking since commits are squashed on merge, but consider `feat(mobile): add first-run onboarding tour`.

**Commit reviewed:** 079758a2692f74dab1fd20f0452d3023268d34be

**Inline comments:** No inline comments.
<!-- claude-review-end -->