### PR TITLE
test(accommodations): couverture jest flux hébergement manuel #1097 (#1182)

### DIFF
--- a/mobile/src/components/trip/manual-accommodation.test.tsx
+++ b/mobile/src/components/trip/manual-accommodation.test.tsx
@@ -1,15 +1,44 @@
 /// <reference types="jest" />
 import TestRenderer, { act } from 'react-test-renderer';
 import type { ReactElement } from 'react';
-import { Text } from 'react-native';
-import type { AccommodationData } from '@btp/core';
+import { Alert, Text } from 'react-native';
+import type { AccommodationData, StageData } from '@btp/core';
+import { EMPTY_RESUPPLY } from '@btp/core';
 import i18n from '../../i18n';
 import { fr } from '../../i18n/resources/fr';
 import { AccommodationBlock } from './AccommodationBlock';
+import { StageDataBlocks } from './StageDataBlocks';
+import { useTripStore } from '../../store/trip-store';
+import { useOfflineStore } from '../../store/offline-store';
 
 // Manual (hors-app) accommodation flow — #1097. The web is covered by
 // pwa/tests/mocked/manual-accommodation.spec.ts; this mirrors it for mobile
 // (CI mobile = tsc + jest). Recette Sprint 58.b (#1182).
+
+// The failure-surfacing tests below drive the real mutation runner
+// (StageDataBlocks -> useTripMutations -> runAddManualAccommodation), so only
+// the HTTP boundary is mocked (mirrors mobile/src/store/mutations.test.ts).
+jest.mock('../../store/trip-cache', () => ({ deleteTripCache: jest.fn() }));
+jest.mock('../../api/trips', () => ({
+  updateTripConfig: jest.fn(),
+  createStage: jest.fn(),
+  updateStageDistance: jest.fn(),
+  moveStage: jest.fn(),
+  insertRestDay: jest.fn(),
+  setStageAccommodation: jest.fn(),
+  addManualAccommodation: jest.fn(),
+  addPoiWaypoint: jest.fn(),
+  scanAccommodations: jest.fn(),
+  applyBatchRecompute: jest.fn(),
+  analyzeTrip: jest.fn(),
+  duplicateTrip: jest.fn(),
+  deleteTrip: jest.fn(),
+}));
+import { addManualAccommodation } from '../../api/trips';
+
+const mockAddManualAccommodation = addManualAccommodation as jest.MockedFunction<
+  typeof addManualAccommodation
+>;
 
 // i18n init is async; make sure French is loaded before rendering (mirrors
 // data-blocks.test.tsx), otherwise t() returns raw keys.
@@ -217,5 +246,84 @@ describe('AccommodationBlock — manual (hors-app) entry #1097', () => {
     expect(t).toContain("Chez l'habitant");
     expect(t).toContain(P.accommodationSelected);
     expect(t.join(' ')).toContain(P.accommodationSourceManual);
+  });
+});
+
+function stageFixture(overrides: Partial<StageData> = {}): StageData {
+  const p = { lat: 0, lon: 0, ele: 0 };
+  return {
+    dayNumber: 1,
+    distance: 50,
+    elevation: 0,
+    elevationLoss: 0,
+    startPoint: p,
+    endPoint: p,
+    geometry: [],
+    label: null,
+    startLabel: 'A',
+    endLabel: 'B',
+    weather: null,
+    alerts: [],
+    resupply: EMPTY_RESUPPLY,
+    accommodations: [],
+    selectedAccommodation: null,
+    accommodationSearchRadiusKm: 5,
+    isRestDay: false,
+    supplyTimeline: [],
+    events: [],
+    ...overrides,
+  } as StageData;
+}
+
+// Wires the manual form all the way through the real mutation runner (not just
+// AccommodationBlock's `onAddManual` prop), so the actionable 422 message
+// (StageDataBlocks' Alert.alert wiring, mirroring the web's visible error text
+// in manual-accommodation.spec.ts) is actually exercised, not merely implied by
+// "the form stayed open".
+describe('StageDataBlocks — manual accommodation 422 surfacing (#1097)', () => {
+  beforeEach(() => {
+    useTripStore.setState({ tripId: 't1', isLocked: false, outOfZone: false });
+    useOfflineStore.setState({ isOnline: true, apiReachable: true });
+  });
+
+  afterEach(() => {
+    // Runs before the top-level unmount afterEach (inner describes fire first),
+    // so the store reset must itself be wrapped — the tree is still mounted.
+    act(() => {
+      useTripStore.getState().reset();
+      useOfflineStore.setState({ isOnline: true, apiReachable: true });
+    });
+    jest.clearAllMocks();
+  });
+
+  it('surfaces the actionable geocode-failure alert on a 422, without crashing', async () => {
+    mockAddManualAccommodation.mockResolvedValue({ ok: false, status: 422 });
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+
+    const tree = render(<StageDataBlocks stage={stageFixture()} stageIndex={0} />);
+    openForm(tree);
+    setField(tree, P.accommodationManualNamePlaceholder, 'Gîte Test');
+    setField(tree, P.accommodationManualAddressPlaceholder, 'Adresse introuvable');
+
+    await act(async () => {
+      await btn(tree, P.accommodationManualSave).props.onPress();
+    });
+
+    expect(mockAddManualAccommodation).toHaveBeenCalledWith('t1', 0, {
+      name: 'Gîte Test',
+      address: 'Adresse introuvable',
+      priceTotal: null,
+      url: null,
+    });
+    expect(alertSpy).toHaveBeenCalledWith(
+      fr.trip.accommodationGeocodeFailedTitle,
+      fr.trip.accommodationGeocodeFailedMessage,
+    );
+    // The form is still there (no crash, correctable in place).
+    expect(
+      tree.root.findAllByProps({ placeholder: P.accommodationManualNamePlaceholder }).length,
+    ).toBeGreaterThan(0);
+
+    alertSpy.mockRestore();
   });
 });


### PR DESCRIPTION
Closes #1182

La couverture initiale du flux manuel hors-app (#1097) avait déjà atterri sur main via #1183 (`manual-accommodation.test.tsx`, 7 tests sur `AccommodationBlock`). Ce ticket complète le trou restant.

## Ajout
Aucun des tests existants n'exerçait le **message d'erreur visible** sur un géocodage 422 (ils vérifiaient seulement que le formulaire restait ouvert). Ce message vit un niveau au-dessus, dans `StageDataBlocks.onAddManual` : `Alert.alert(trip.accommodationGeocodeFailedTitle, ...Message)` sur reason `'validation'` (analogue mobile du texte web « Adresse introuvable… »).

Nouveau test pilotant la vraie stack `StageDataBlocks → useTripMutations → runAddManualAccommodation` (mock `api/trips` + `trip-cache` uniquement), spy sur `Alert.alert`, assertion sur titre/message FR exacts avec un 422 mocké.

## Prove-it-can-fail
Vérifié : suppression de la branche `reason === 'validation'` ⇒ test rouge ; restauré ⇒ vert. (Idem sur les assertions de payload.)

## Tests
CI mobile = tsc + jest : `Test Suites: 89 passed` / `Tests: 702 passed`, tsc clean. (Deux suites sans rapport — ShareSheet, account-notifications — flakent sur timeout sous charge pleine ; vertes en isolation et au re-run complet. Contention de ressources pré-existante, hors périmètre.)

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 findings (0 critical, 0 warning). Test-only PR, no code-level issues found.

**Verification performed:** Ran the full mobile suite locally (`npx jest` in `mobile/`) — `Test Suites: 89 passed, 89 total`, `Tests: 702 passed, 702 total`, and `tsc --noEmit` clean, matching the PR's claimed numbers exactly. Traced the new test's wiring (`StageDataBlocks` → `useTripMutations` → `runAddManualAccommodation` → `api/trips`) against `mutations.ts`/`gating.ts` to confirm the 422→`'validation'` mapping and gate evaluation are exercised correctly, and confirmed the `api/trips` mock list and store setState/reset pattern mirror the existing `mutations.test.ts` and `data-blocks.test.tsx` precedents.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

_Reviewed commit: 71ed15c_
<!-- claude-review-end -->