### PR TITLE
perf(mobile): tree-shake lucide-react-native via imports profonds (#1194)

### DIFF
--- a/mobile/jest.config.js
+++ b/mobile/jest.config.js
@@ -5,6 +5,10 @@ module.exports = {
   // Map the @btp/core workspace subpaths to their TypeScript sources (outside
   // node_modules) so jest-expo's babel transform picks them up (#1014).
   moduleNameMapper: {
+    // icons.ts deep-imports each icon from its ESM build for Metro tree-shaking
+    // (#1194); Jest runs under CommonJS, so redirect those same paths to the
+    // package's CJS build, which needs no transform.
+    '^lucide-react-native/dist/esm/icons/(.*)\\.js$': 'lucide-react-native/dist/cjs/icons/$1.js',
     '^@btp/core/reconciliation$': '<rootDir>/../core/reconciliation.ts',
     '^@btp/core/elevation$': '<rootDir>/../core/elevation.ts',
     '^@btp/core/mercure$': '<rootDir>/../core/mercure.ts',

--- a/mobile/src/components/ui/icons.ts
+++ b/mobile/src/components/ui/icons.ts
@@ -1,81 +1,81 @@
 // Icon parity with the web (lucide). Re-export the curated set the mobile
 // screens use so call sites import from one place. Add icons here as needed.
-// TODO(perf #1194): the barrel re-export pulls the whole `lucide-react-native`
-// icon set (~3300 icons) into the bundle; deep imports would shrink it, but
-// they are not a mechanical rewrite — many names here are legacy aliases
-// resolved through the package's alias map, not the file each icon actually
-// lives in (e.g. `AlertTriangle` -> `dist/esm/icons/triangle-alert.js`,
-// `HelpCircle` -> `dist/esm/icons/circle-question-mark.js`, `MoreVertical` ->
-// `dist/esm/icons/ellipsis-vertical.js`), and that mapping is an internal,
-// version-fragile implementation detail (checked against v0.545.0), not a
-// published contract. Left alone for now; revisit if bundle size becomes a
-// measured problem, ideally with a codemod driven off the package's own
-// alias table rather than a hand-maintained one.
-export {
-  AlertTriangle,
-  ArrowLeft,
-  Bike,
-  Calendar,
-  Check,
-  ChevronRight,
-  CloudRain,
-  Coffee,
-  Copy,
-  Download,
-  FileUp,
-  Inbox,
-  Map,
-  MapPin,
-  Menu,
-  Mountain,
-  Pencil,
-  Plus,
-  RefreshCw,
-  Route,
-  Search,
-  Settings,
-  Tent,
-  Trash2,
-  X,
-} from 'lucide-react-native';
+//
+// Deep-imports each icon from its own `lucide-react-native/dist/esm/icons/*.js`
+// module instead of the package barrel (`lucide-react-native`), which
+// re-exports the full ~3300-icon set and defeats tree-shaking (#1176).
+// Several names below are legacy aliases: the real file lucide ships under
+// differs from the exported name (e.g. `AlertTriangle` lives in
+// `triangle-alert.js`, `HelpCircle` in `circle-question-mark.js`,
+// `MoreVertical` in `ellipsis-vertical.js`). This mapping was read off the
+// package's own barrel (`lucide-react-native/dist/esm/lucide-react-native.js`)
+// for the installed version (v0.545.0) — it is not a published contract, so
+// re-verify it (or regenerate from that barrel) after any lucide-react-native
+// upgrade.
+export { default as AlertTriangle } from 'lucide-react-native/dist/esm/icons/triangle-alert.js';
+export { default as ArrowLeft } from 'lucide-react-native/dist/esm/icons/arrow-left.js';
+export { default as Bike } from 'lucide-react-native/dist/esm/icons/bike.js';
+export { default as Calendar } from 'lucide-react-native/dist/esm/icons/calendar.js';
+export { default as Check } from 'lucide-react-native/dist/esm/icons/check.js';
+export { default as ChevronRight } from 'lucide-react-native/dist/esm/icons/chevron-right.js';
+export { default as CloudRain } from 'lucide-react-native/dist/esm/icons/cloud-rain.js';
+export { default as Coffee } from 'lucide-react-native/dist/esm/icons/coffee.js';
+export { default as Copy } from 'lucide-react-native/dist/esm/icons/copy.js';
+export { default as Download } from 'lucide-react-native/dist/esm/icons/download.js';
+export { default as FileUp } from 'lucide-react-native/dist/esm/icons/file-up.js';
+export { default as Inbox } from 'lucide-react-native/dist/esm/icons/inbox.js';
+export { default as Map } from 'lucide-react-native/dist/esm/icons/map.js';
+export { default as MapPin } from 'lucide-react-native/dist/esm/icons/map-pin.js';
+export { default as Menu } from 'lucide-react-native/dist/esm/icons/menu.js';
+export { default as Mountain } from 'lucide-react-native/dist/esm/icons/mountain.js';
+export { default as Pencil } from 'lucide-react-native/dist/esm/icons/pencil.js';
+export { default as Plus } from 'lucide-react-native/dist/esm/icons/plus.js';
+export { default as RefreshCw } from 'lucide-react-native/dist/esm/icons/refresh-cw.js';
+export { default as Route } from 'lucide-react-native/dist/esm/icons/route.js';
+export { default as Search } from 'lucide-react-native/dist/esm/icons/search.js';
+export { default as Settings } from 'lucide-react-native/dist/esm/icons/settings.js';
+export { default as Tent } from 'lucide-react-native/dist/esm/icons/tent.js';
+export { default as Trash2 } from 'lucide-react-native/dist/esm/icons/trash-2.js';
+export { default as X } from 'lucide-react-native/dist/esm/icons/x.js';
 // Share feature icon (#1048) — appended so the sorted set above stays untouched.
-export { Share2 } from 'lucide-react-native';
+export { default as Share2 } from 'lucide-react-native/dist/esm/icons/share-2.js';
 // Spike-UX restyle: icons used by the redesigned screens (login/create/roadbook/
 // share/map/stage-detail). Appended to keep the sorted set above stable.
-export {
-  CloudSun,
-  FileText,
-  Flag,
-  Gauge,
-  Image as ImageIcon,
-  KeyRound,
-  Link2,
-  Lock,
-  Mail,
-  Minus,
-  MoreVertical,
-} from 'lucide-react-native';
+export { default as CloudSun } from 'lucide-react-native/dist/esm/icons/cloud-sun.js';
+export { default as FileText } from 'lucide-react-native/dist/esm/icons/file-text.js';
+export { default as Flag } from 'lucide-react-native/dist/esm/icons/flag.js';
+export { default as Gauge } from 'lucide-react-native/dist/esm/icons/gauge.js';
+export { default as ImageIcon } from 'lucide-react-native/dist/esm/icons/image.js';
+export { default as KeyRound } from 'lucide-react-native/dist/esm/icons/key-round.js';
+export { default as Link2 } from 'lucide-react-native/dist/esm/icons/link-2.js';
+export { default as Lock } from 'lucide-react-native/dist/esm/icons/lock.js';
+export { default as Mail } from 'lucide-react-native/dist/esm/icons/mail.js';
+export { default as Minus } from 'lucide-react-native/dist/esm/icons/minus.js';
+export { default as MoreVertical } from 'lucide-react-native/dist/esm/icons/ellipsis-vertical.js';
 // Resupply block (#1105): sectioned food/water suggestions.
-export { ShoppingBag } from 'lucide-react-native';
+export { default as ShoppingBag } from 'lucide-react-native/dist/esm/icons/shopping-bag.js';
 // Notifications screen (#1120): permission banner + per-category icons.
-export { Bell, BellOff, CheckCircle2 } from 'lucide-react-native';
+export { default as Bell } from 'lucide-react-native/dist/esm/icons/bell.js';
+export { default as BellOff } from 'lucide-react-native/dist/esm/icons/bell-off.js';
+export { default as CheckCircle2 } from 'lucide-react-native/dist/esm/icons/circle-check.js';
 // Offline map degradation (#1148): discrete "offline map" indicator.
-export { CloudOff } from 'lucide-react-native';
+export { default as CloudOff } from 'lucide-react-native/dist/esm/icons/cloud-off.js';
 // In-ride mode (#1149): help bubble, offline badge, GPS position.
-export { HelpCircle, Navigation, WifiOff } from 'lucide-react-native';
+export { default as HelpCircle } from 'lucide-react-native/dist/esm/icons/circle-question-mark.js';
+export { default as Navigation } from 'lucide-react-native/dist/esm/icons/navigation.js';
+export { default as WifiOff } from 'lucide-react-native/dist/esm/icons/wifi-off.js';
 // In-ride nearby-pois (#1150): the 8 intent chips + POI card affordances
 // (Search/Tent/AlertTriangle already exported above).
-export {
-  Clock,
-  Cross,
-  Droplet,
-  ExternalLink,
-  Phone,
-  ShoppingCart,
-  TrainFront,
-  UtensilsCrossed,
-  Wrench,
-  Zap,
-} from 'lucide-react-native';
+export { default as Clock } from 'lucide-react-native/dist/esm/icons/clock.js';
+export { default as Cross } from 'lucide-react-native/dist/esm/icons/cross.js';
+export { default as Droplet } from 'lucide-react-native/dist/esm/icons/droplet.js';
+export { default as ExternalLink } from 'lucide-react-native/dist/esm/icons/external-link.js';
+export { default as Phone } from 'lucide-react-native/dist/esm/icons/phone.js';
+export { default as ShoppingCart } from 'lucide-react-native/dist/esm/icons/shopping-cart.js';
+export { default as TrainFront } from 'lucide-react-native/dist/esm/icons/train-front.js';
+export { default as UtensilsCrossed } from 'lucide-react-native/dist/esm/icons/utensils-crossed.js';
+export { default as Wrench } from 'lucide-react-native/dist/esm/icons/wrench.js';
+export { default as Zap } from 'lucide-react-native/dist/esm/icons/zap.js';
 // In-ride maquette conformity (#1094): disclaimer banner + detour badge.
-export { CornerUpLeft, Info } from 'lucide-react-native';
+export { default as CornerUpLeft } from 'lucide-react-native/dist/esm/icons/corner-up-left.js';
+export { default as Info } from 'lucide-react-native/dist/esm/icons/info.js';

--- a/mobile/src/theme/shims.d.ts
+++ b/mobile/src/theme/shims.d.ts
@@ -1,3 +1,13 @@
 // react-test-renderer ships no bundled types and has no @types package under
 // this toolchain; the smoke test uses it as an untyped renderer.
 declare module 'react-test-renderer';
+
+// lucide-react-native ships a single combined .d.ts at the package root; the
+// per-icon deep-import paths used by `components/ui/icons.ts` for tree-shaking
+// (#1194) have no declaration files of their own.
+declare module 'lucide-react-native/dist/esm/icons/*.js' {
+  import type { LucideIcon } from 'lucide-react-native';
+
+  const icon: LucideIcon;
+  export default icon;
+}


### PR DESCRIPTION
Closes #1194

Suivi de #1176. Le barrel `icons.ts` re-exportait tout `lucide-react-native` (Metro ne tree-shake pas par défaut).

## Approche : imports profonds par icône
58 `export { default as X } from 'lucide-react-native/dist/esm/icons/<real-file>.js'`, API publique de `icons.ts` inchangée (mêmes noms exportés). Le mapping alias→fichier réel a été **extrait par script du barrel installé** (v0.545.0), pas deviné : `AlertTriangle`→`triangle-alert`, `HelpCircle`→`circle-question-mark`, `MoreVertical`→`ellipsis-vertical`, `CheckCircle2`→`circle-check`, etc.

Option 2 (tree-shaking expérimental Metro/Expo SDK 57) écartée : gated par 2 env vars unstable s'appliquant à tout le bundle, trop large/risqué vs un fix scopé à `icons.ts`.

## Fichiers
- `components/ui/icons.ts` — imports profonds, TODO retiré.
- `theme/shims.d.ts` — shim `declare module 'lucide-react-native/dist/esm/icons/*.js'` typé `LucideIcon` (les imports profonds n'ont pas de .d.ts propre).
- `jest.config.js` — `moduleNameMapper` redirige les imports profonds ESM vers `dist/cjs/icons/*.js` (Jest tourne en CJS).

## Mesure réelle (expo export --platform android, bundle Hermes .hbc, même code via stash)
- Avant : 6 284 180 o
- Après : 4 340 685 o
- **-1 943 495 o, soit -31 %**

## Tests
CI mobile = tsc + jest : `Test Suites: 89 passed` / `Tests: 701 passed`, tsc clean. Aucune dépendance ajoutée.

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 findings (0 critical, 0 warning). Re-verified from scratch: downloaded the real `lucide-react-native@0.545.0` tarball from the npm registry and cross-checked all 57 `icons.ts` name→file mappings against its actual barrel (`dist/esm/lucide-react-native.js`) with a script — every alias (`AlertTriangle`→`triangle-alert`, `HelpCircle`→`circle-question-mark`, `MoreVertical`→`ellipsis-vertical`, `CheckCircle2`→`circle-check`, `TrainFront`→`train-front` as distinct from `TrainFrontTunnel`, etc.) matches exactly, with zero mismatches and every deep-import path present on disk in both `dist/esm/icons/` and `dist/cjs/icons/`. Confirmed the Jest `moduleNameMapper` ESM→CJS redirect is interop-safe: the CJS icon files use plain `module.exports = Icon` (no `__esModule` flag), so Babel's `_interopRequireDefault` correctly synthesizes `.default` as the icon itself. Confirmed `LucideIcon` is a genuine named type export of the package root (`export type { IconNode, LucideIcon, LucideProps }`), so the `theme/shims.d.ts` ambient wildcard module is well-typed. Scope is contained to the `mobile` workspace; no backend/PWA/contract impact.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases (no dedicated mapping test, but the import is statically resolved — a wrong path would hard-fail module resolution in the 701 existing Jest tests exercising these icons, so CI green is real coverage here)
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

_Commit reviewed: 3a05bf31d5caae297f2488d100ab48308e760dbf_
<!-- claude-review-end -->
