### PR TITLE
feat(mobile): consultation in-app d'un voyage partagé /s/<code> (#1177)

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -19,7 +19,21 @@
         "backgroundImage": "./assets/android-icon-background.png",
         "monochromeImage": "./assets/android-icon-monochrome.png"
       },
-      "predictiveBackGestureEnabled": false
+      "predictiveBackGestureEnabled": false,
+      "intentFilters": [
+        {
+          "action": "VIEW",
+          "autoVerify": true,
+          "data": [
+            {
+              "scheme": "https",
+              "host": "biketrip.mooo.com",
+              "pathPrefix": "/s/"
+            }
+          ],
+          "category": ["BROWSABLE", "DEFAULT"]
+        }
+      ]
     },
     "web": {
       "favicon": "./assets/favicon.png"

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -35,6 +35,8 @@ function RootNavigator() {
       <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
       <Stack.Screen name="trip/[id]/index" />
       <Stack.Screen name="trip/[id]/stage/[index]" />
+      {/* Anonymous shared-trip consultation, opened via the /s/<code> App Link. */}
+      <Stack.Screen name="s/[code]" />
       <Stack.Screen name="auth/verify/[token]" options={{ headerShown: false }} />
     </Stack>
   );

--- a/mobile/app/s/[code].tsx
+++ b/mobile/app/s/[code].tsx
@@ -1,0 +1,177 @@
+import { Stack, useLocalSearchParams } from 'expo-router';
+import { useEffect, useMemo, useState } from 'react';
+import { Alert, PanResponder, Pressable, Text, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import {
+  ErrorState,
+  LoadingState,
+  Screen,
+  SegmentedControl,
+  type Segment,
+} from '../../src/components/ui';
+import { Download, Eye } from '../../src/components/ui/icons';
+import { RoadbookView, TripMapView } from '../../src/components/trip';
+import { useTheme } from '../../src/theme';
+import { useSharedTrip } from '../../src/hooks/use-shared-trip';
+import { confirmExportFormat, writeAndShare } from '../../src/hooks/use-export';
+import {
+  fetchSharedTripExport,
+  tripExportFileName,
+  type ExportFormat,
+} from '../../src/api/trips';
+import { useTripStore } from '../../src/store/trip-store';
+import { swipeToView } from '../../src/lib/swipe';
+
+type TripView = 'roadbook' | 'map';
+
+// Anonymous read-only consultation of a shared trip (#1177), reached via the
+// `/s/<code>` App Link (see app.json intentFilters) or the custom scheme. Mirrors
+// the web shared page (pwa's shared-trip-page): roadbook + map + downloads, a
+// permanent "shared view / read only" banner, and no edit affordances at all.
+export default function SharedTrip() {
+  const { code } = useLocalSearchParams<{ code: string }>();
+  const { t } = useTranslation();
+  const theme = useTheme();
+  const [view, setView] = useState<TripView>('roadbook');
+  const [hasViewedMap, setHasViewedMap] = useState(false);
+  useEffect(() => {
+    if (view === 'map') setHasViewedMap(true);
+  }, [view]);
+
+  useSharedTrip(code);
+
+  const title = useTripStore((s) => s.title);
+  const loading = useTripStore((s) => s.loading);
+  const error = useTripStore((s) => s.error);
+  const resolvedTitle = title ?? t('sharePage.title');
+
+  const panResponder = useMemo(
+    () =>
+      PanResponder.create({
+        onMoveShouldSetPanResponder: (_, g) =>
+          Math.abs(g.dx) > 24 && Math.abs(g.dx) > Math.abs(g.dy) * 1.5,
+        onPanResponderRelease: (_, g) => {
+          const next = swipeToView(g.dx);
+          if (next) setView(next);
+        },
+      }),
+    [],
+  );
+
+  async function download(format: ExportFormat) {
+    try {
+      const bytes = await fetchSharedTripExport(code, format);
+      await writeAndShare(bytes, tripExportFileName(resolvedTitle, format), format);
+    } catch {
+      Alert.alert(t('export.failedTitle'), t('export.failedMessage'));
+    }
+  }
+
+  const segments: readonly Segment<TripView>[] = [
+    { value: 'roadbook', label: t('trip.segmentRoadbook') },
+    { value: 'map', label: t('trip.segmentMap') },
+  ];
+
+  if (loading) {
+    return (
+      <Screen padded={false}>
+        <Stack.Screen options={{ headerShown: false }} />
+        <LoadingState />
+      </Screen>
+    );
+  }
+
+  // Any load error on the anonymous view means the link is invalid or revoked —
+  // there is nothing the visitor can do but head back, so a single copy covers it.
+  if (error) {
+    return (
+      <Screen padded={false}>
+        <Stack.Screen options={{ title: t('sharePage.title') }} />
+        <ErrorState
+          title={t('sharePage.title')}
+          description={t('sharePage.error')}
+        />
+      </Screen>
+    );
+  }
+
+  return (
+    <Screen padded={false}>
+      <Stack.Screen
+        options={{
+          headerShown: true,
+          title: resolvedTitle,
+          headerRight: () => (
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={t('sharePage.download')}
+              onPress={() =>
+                confirmExportFormat({
+                  title: t('sharePage.download'),
+                  gpxLabel: t('export.gpx'),
+                  fitLabel: t('export.fit'),
+                  cancelLabel: t('export.cancel'),
+                  onSelect: (format) => void download(format),
+                })
+              }
+              hitSlop={8}
+              style={{ padding: theme.spacing.xs }}
+            >
+              <Download color={theme.colors.foreground} size={22} />
+            </Pressable>
+          ),
+        }}
+      />
+
+      {/* Permanent read-only banner — mirrors the web SharedViewBanner. */}
+      <View
+        accessibilityRole="header"
+        style={{
+          flexDirection: 'row',
+          alignItems: 'center',
+          gap: theme.spacing.sm,
+          marginHorizontal: theme.spacing.base,
+          marginTop: theme.spacing.sm,
+          padding: theme.spacing.md,
+          borderRadius: theme.radius.lg,
+          backgroundColor: theme.colors.accentSoft,
+        }}
+      >
+        <Eye color={theme.colors.accentBrand} size={18} />
+        <Text
+          style={{
+            color: theme.colors.foreground,
+            fontFamily: theme.fonts.sansMedium,
+            fontSize: 14,
+            flex: 1,
+          }}
+        >
+          {t('sharePage.readOnlyBanner')}
+        </Text>
+      </View>
+
+      <View
+        style={{
+          paddingHorizontal: theme.spacing.base,
+          paddingTop: theme.spacing.sm,
+          paddingBottom: theme.spacing.sm,
+        }}
+      >
+        <SegmentedControl segments={segments} value={view} onChange={setView} />
+      </View>
+
+      <View style={{ flex: 1 }} {...panResponder.panHandlers}>
+        {/* Keep both tabs mounted once opened (perf, mirrors trip/[id]); the map
+            only mounts after its first open. Geometry is applied from the public
+            /route by useSharedTrip, so TripMapView's own /route fetch stays off
+            (its useTripRoute is gated on the store's tripId, left null here). */}
+        <View style={{ flex: 1, display: view === 'map' ? 'flex' : 'none' }}>
+          {hasViewedMap ? <TripMapView /> : null}
+        </View>
+        <View style={{ flex: 1, display: view === 'roadbook' ? 'flex' : 'none' }}>
+          <RoadbookView id={code} readOnly />
+        </View>
+      </View>
+    </Screen>
+  );
+}

--- a/mobile/src/api/trips.test.ts
+++ b/mobile/src/api/trips.test.ts
@@ -2,6 +2,9 @@
 jest.mock('./client', () => ({ api: { GET: jest.fn(), POST: jest.fn() } }));
 import { api } from './client';
 import {
+  fetchSharedTrip,
+  fetchSharedTripExport,
+  fetchSharedTripRoute,
   fetchStageExport,
   fetchTripExport,
   fetchTrips,
@@ -156,5 +159,49 @@ describe('fetchStageExport (#1047)', () => {
       response: { ok: false },
     } as never);
     await expect(fetchStageExport('trip-1', 2, 'gpx')).rejects.toThrow('Failed to export stage');
+  });
+});
+
+describe('anonymous share fetches (#1177)', () => {
+  it('fetchSharedTrip requests /s/{shortCode} and returns the payload, null on error', async () => {
+    mockGet.mockResolvedValueOnce({ data: { title: 't' }, error: undefined } as never);
+    await expect(fetchSharedTrip('AB12cd')).resolves.toEqual({ title: 't' });
+    expect(mockGet).toHaveBeenCalledWith('/s/{shortCode}', {
+      params: { path: { shortCode: 'AB12cd' } },
+      headers: { Accept: 'application/ld+json' },
+    });
+
+    mockGet.mockResolvedValueOnce({ data: undefined, error: { detail: 'boom' } } as never);
+    await expect(fetchSharedTrip('AB12cd')).resolves.toBeNull();
+  });
+
+  it('fetchSharedTripRoute requests /s/{shortCode}/route and returns null on error', async () => {
+    mockGet.mockResolvedValueOnce({ data: { points: [] }, error: undefined } as never);
+    await expect(fetchSharedTripRoute('AB12cd')).resolves.toEqual({ points: [] });
+    expect(mockGet).toHaveBeenCalledWith('/s/{shortCode}/route', {
+      params: { path: { shortCode: 'AB12cd' } },
+      headers: { Accept: 'application/ld+json' },
+    });
+
+    mockGet.mockResolvedValueOnce({ data: undefined, error: { detail: 'boom' } } as never);
+    await expect(fetchSharedTripRoute('AB12cd')).resolves.toBeNull();
+  });
+
+  it('fetchSharedTripExport hits the literal .gpx/.fit path and throws on failure', async () => {
+    const bytes = new ArrayBuffer(4);
+    mockGet.mockResolvedValueOnce({ data: bytes, error: undefined, response: { ok: true } } as never);
+    await expect(fetchSharedTripExport('AB12cd', 'gpx')).resolves.toBe(bytes);
+    expect(mockGet).toHaveBeenCalledWith('/s/{shortCode}.gpx', {
+      params: { path: { shortCode: 'AB12cd' } },
+      headers: { Accept: 'application/gpx+xml' },
+      parseAs: 'arrayBuffer',
+    });
+
+    mockGet.mockResolvedValueOnce({
+      data: undefined,
+      error: { detail: 'boom' },
+      response: { ok: false },
+    } as never);
+    await expect(fetchSharedTripExport('AB12cd', 'fit')).rejects.toThrow('Failed to export shared trip');
   });
 });

--- a/mobile/src/api/trips.ts
+++ b/mobile/src/api/trips.ts
@@ -510,3 +510,63 @@ export function buildShareUrl(shortCode: string): string {
   const base = WEB_BASE_URL.replace(/\/+$/, '');
   return `${base}/s/${encodeURIComponent(shortCode)}`;
 }
+
+// ---------------------------------------------------------------------------
+// Anonymous shared-trip consultation (#1177). The `/s/<code>` endpoints require
+// no auth (the JWT header, when present, is simply ignored server-side), and
+// serve a read-only projection of the trip. Mirrors the web's fetchSharedTrip /
+// fetchSharedTripRoute / downloadSharedTripFile (pwa's api/client).
+// ---------------------------------------------------------------------------
+
+export type SharedTripDetail = components['schemas']['TripShare.TripDetail.jsonld'];
+
+/** Fetch a shared trip via its short code. Null when invalid / revoked. */
+export async function fetchSharedTrip(
+  shortCode: string,
+): Promise<SharedTripDetail | null> {
+  const { data, error } = await api.GET('/s/{shortCode}', {
+    params: { path: { shortCode } },
+    headers: ld,
+  });
+  if (error) {
+    return null;
+  }
+  return data ?? null;
+}
+
+/** Fetch a shared trip's all-stages geometry (ADR-057), by short code. */
+export async function fetchSharedTripRoute(
+  shortCode: string,
+): Promise<TripRoute | null> {
+  const { data, error } = await api.GET('/s/{shortCode}/route', {
+    params: { path: { shortCode } },
+    headers: ld,
+  });
+  if (error) {
+    return null;
+  }
+  return data ?? null;
+}
+
+// The share downloads sit at `/s/{shortCode}.gpx` / `.fit` (literal suffix in the
+// OpenAPI paths, unlike the auth'd exports which negotiate on Accept).
+const SHARED_EXPORT_PATH: Record<ExportFormat, '/s/{shortCode}.gpx' | '/s/{shortCode}.fit'> = {
+  gpx: '/s/{shortCode}.gpx',
+  fit: '/s/{shortCode}.fit',
+};
+
+/** Download a shared trip as GPX/FIT via short code (all stages merged). */
+export async function fetchSharedTripExport(
+  shortCode: string,
+  format: ExportFormat,
+): Promise<ArrayBuffer> {
+  const { data, error, response } = await api.GET(SHARED_EXPORT_PATH[format], {
+    params: { path: { shortCode } },
+    headers: { Accept: EXPORT_ACCEPT[format] },
+    parseAs: 'arrayBuffer',
+  });
+  if (error || !response.ok) {
+    throw new Error('Failed to export shared trip');
+  }
+  return data;
+}

--- a/mobile/src/components/trip/RoadbookView.tsx
+++ b/mobile/src/components/trip/RoadbookView.tsx
@@ -207,7 +207,7 @@ export function RoadbookView({
                 index={index}
                 locked={readOnly}
                 onDelete={confirmDelete}
-                onPress={openStage}
+                onPress={forceReadOnly ? undefined : openStage}
                 date={date}
                 isToday={state === 'ongoing' && isStageToday(date, today)}
                 highlighted={stageDiffs.has(index)}

--- a/mobile/src/components/trip/RoadbookView.tsx
+++ b/mobile/src/components/trip/RoadbookView.tsx
@@ -29,11 +29,15 @@ import { useTripMutations } from '../../hooks/use-trip-mutations';
 export function RoadbookView({
   id,
   onConfigureDates,
+  readOnly: forceReadOnly = false,
 }: {
   id: string;
   // Opens the config sheet scrolled to the dates section (maquette 05a). Wired
   // to the "set your dates" banner so a rider fixes the missing dates in one tap.
   onConfigureDates?: () => void;
+  // Force the whole view read-only regardless of lock/date/connectivity state —
+  // the single high-level gate the anonymous shared consultation flips (#1177).
+  readOnly?: boolean;
 }) {
   const { t } = useTranslation();
   const theme = useTheme();
@@ -64,7 +68,11 @@ export function RoadbookView({
       ? 'apiUnavailable'
       : null;
   const readOnly =
-    isLocked || state === 'ongoing' || state === 'past' || degradedReason !== null;
+    forceReadOnly ||
+    isLocked ||
+    state === 'ongoing' ||
+    state === 'past' ||
+    degradedReason !== null;
 
   // One failure surface for every inline edit: map the normalized reason to a
   // localized alert (#1044). The runners already handle optimistic apply +

--- a/mobile/src/components/ui/icons.ts
+++ b/mobile/src/components/ui/icons.ts
@@ -79,3 +79,5 @@ export { default as Zap } from 'lucide-react-native/dist/esm/icons/zap.js';
 // In-ride maquette conformity (#1094): disclaimer banner + detour badge.
 export { default as CornerUpLeft } from 'lucide-react-native/dist/esm/icons/corner-up-left.js';
 export { default as Info } from 'lucide-react-native/dist/esm/icons/info.js';
+// Shared read-only trip view (#1177): read-only banner marker.
+export { default as Eye } from 'lucide-react-native/dist/esm/icons/eye.js';

--- a/mobile/src/hooks/use-shared-trip.ts
+++ b/mobile/src/hooks/use-shared-trip.ts
@@ -1,0 +1,115 @@
+import { useEffect } from 'react';
+import type { StageData } from '@btp/core';
+import {
+  fetchSharedTrip,
+  fetchSharedTripRoute,
+  type SharedTripDetail,
+  type TripDetail,
+} from '../api/trips';
+import { stageDataFromDetail, useTripStore } from '../store/trip-store';
+
+// The store actions the shared consultation drives. A read-only subset of the
+// live orchestration (no SSE reconciliation): the shared view never mutates.
+export interface SharedTripStore {
+  reset: ReturnType<typeof useTripStore.getState>['reset'];
+  setStages: ReturnType<typeof useTripStore.getState>['setStages'];
+  setConfig: ReturnType<typeof useTripStore.getState>['setConfig'];
+  setTitle: ReturnType<typeof useTripStore.getState>['setTitle'];
+  setIsLocked: ReturnType<typeof useTripStore.getState>['setIsLocked'];
+  setOutOfZone: ReturnType<typeof useTripStore.getState>['setOutOfZone'];
+  setStatus: ReturnType<typeof useTripStore.getState>['setStatus'];
+  applyRoute: ReturnType<typeof useTripStore.getState>['applyRoute'];
+}
+
+// The shared stage DTO is structurally the trip /detail stage; reuse the store's
+// mapper. (The DTO carries no `id`/live fields the mapper reads, only geometry &
+// summary, so the cast is safe — same field names as TripDetail.stages.)
+type SharedStage = NonNullable<SharedTripDetail['stages']>[number];
+
+/**
+ * Hydrate the shared store from `/s/<code>` then merge the on-demand geometry
+ * from `/s/<code>/route`, read-only. Extracted from the hook so the async / error
+ * branches are unit-testable without a React renderer.
+ *
+ * Unlike {@link runTripLive}, the store's `tripId` is left null on purpose: the
+ * anonymous client must never issue an auth-gated `/trips/{id}/route` call, and
+ * `useTripRoute` (fired eagerly by the map tab) is gated on `tripId`, so a null
+ * id keeps the map off the private endpoint — the geometry it needs is applied
+ * here from the public `/route` instead.
+ */
+export async function runSharedTrip(
+  code: string,
+  store: SharedTripStore,
+  isCancelled: () => boolean,
+): Promise<void> {
+  store.reset();
+  store.setStatus({ loading: true, error: null });
+
+  const detail = await fetchSharedTrip(code);
+  if (isCancelled()) return;
+  if (!detail) {
+    store.setStatus({ loading: false, error: 'notFound' });
+    return;
+  }
+
+  const stages: StageData[] = (detail.stages ?? []).map((s) =>
+    stageDataFromDetail(s as SharedStage as NonNullable<TripDetail['stages']>[number]),
+  );
+  store.setStages(stages);
+  store.setTitle(detail.title ?? '');
+  store.setIsLocked(detail.isLocked ?? false);
+  store.setOutOfZone(detail.outOfZone ?? false);
+  store.setConfig({
+    startDate: detail.startDate ?? null,
+    endDate: detail.endDate ?? null,
+    fatigueFactor: detail.fatigueFactor ?? 0.9,
+    elevationPenalty: detail.elevationPenalty ?? 50,
+    maxDistancePerDay: detail.maxDistancePerDay ?? 80,
+    averageSpeed: detail.averageSpeed ?? 15,
+  });
+  store.setStatus({ loading: false, error: null });
+
+  // Geometry (ADR-057) is split off the summary; pull it via the public code and
+  // merge it into the stages so the map/profile render a line. A miss just leaves
+  // an empty map — never fatal.
+  const route = await fetchSharedTripRoute(code);
+  if (isCancelled() || !route) return;
+  store.applyRoute(route);
+}
+
+// Loads a shared trip into the store for a read-only consultation. Resets the
+// store on unmount so leaving the shared page never leaks stages into a fresh
+// planner session (mirrors the web shared page's clearTrip cleanup).
+export function useSharedTrip(code: string): void {
+  const reset = useTripStore((s) => s.reset);
+  const setStages = useTripStore((s) => s.setStages);
+  const setConfig = useTripStore((s) => s.setConfig);
+  const setTitle = useTripStore((s) => s.setTitle);
+  const setIsLocked = useTripStore((s) => s.setIsLocked);
+  const setOutOfZone = useTripStore((s) => s.setOutOfZone);
+  const setStatus = useTripStore((s) => s.setStatus);
+  const applyRoute = useTripStore((s) => s.applyRoute);
+
+  useEffect(() => {
+    let cancelled = false;
+    void runSharedTrip(
+      code,
+      { reset, setStages, setConfig, setTitle, setIsLocked, setOutOfZone, setStatus, applyRoute },
+      () => cancelled,
+    );
+    return () => {
+      cancelled = true;
+      reset();
+    };
+  }, [
+    code,
+    reset,
+    setStages,
+    setConfig,
+    setTitle,
+    setIsLocked,
+    setOutOfZone,
+    setStatus,
+    applyRoute,
+  ]);
+}

--- a/mobile/src/i18n/resources/en.ts
+++ b/mobile/src/i18n/resources/en.ts
@@ -565,6 +565,13 @@ export const en: typeof fr = {
     fr: 'Français',
     en: 'English',
   },
+  sharePage: {
+    title: 'Shared trip',
+    loading: 'Loading shared trip...',
+    error: 'This share link is invalid or has been revoked.',
+    readOnlyBanner: 'Shared view — read only',
+    download: 'Download',
+  },
   freshness: {
     justNow: 'just now',
     hoursAgo: '{{count}}h ago',

--- a/mobile/src/i18n/resources/fr.ts
+++ b/mobile/src/i18n/resources/fr.ts
@@ -566,6 +566,13 @@ export const fr = {
     fr: 'Français',
     en: 'English',
   },
+  sharePage: {
+    title: 'Voyage partagé',
+    loading: 'Chargement du voyage partagé...',
+    error: 'Ce lien de partage est invalide ou a été révoqué.',
+    readOnlyBanner: 'Vue partagée — lecture seule',
+    download: 'Télécharger',
+  },
   freshness: {
     justNow: "à l'instant",
     hoursAgo: 'il y a {{count}} h',

--- a/mobile/src/screens/shared-trip.test.tsx
+++ b/mobile/src/screens/shared-trip.test.tsx
@@ -132,6 +132,18 @@ describe('Shared trip screen (#1177) — read-only consultation', () => {
     expect(findByA11yLabel(root, i18n.t('trip.rideCtaA11y'))).toHaveLength(0);
   });
 
+  it('does not let a stage row tap through to the auth-gated live flow (#1177 review)', async () => {
+    // A shared stage card must be inert: no onPress → no button role, no
+    // open-stage a11y label. Otherwise tapping pushes /trip/<shareCode>/stage/...
+    // and hits the authenticated /trips/{id}/detail with the share code as an id.
+    mockFetch.mockResolvedValue(SHARED_DETAIL);
+
+    const root = await render();
+
+    expect(findByA11yLabel(root, i18n.t('trip.openStageA11y', { day: 1 }))).toHaveLength(0);
+    expect(findByA11yLabel(root, i18n.t('trip.openStageA11y', { day: 2 }))).toHaveLength(0);
+  });
+
   it('renders the invalid/revoked error copy when the link does not resolve', async () => {
     mockFetch.mockResolvedValue(null);
 

--- a/mobile/src/screens/shared-trip.test.tsx
+++ b/mobile/src/screens/shared-trip.test.tsx
@@ -1,0 +1,142 @@
+/// <reference types="jest" />
+import TestRenderer, { act } from 'react-test-renderer';
+import { createElement } from 'react';
+import i18n from '../i18n';
+
+// The share screen pulls in the trip barrel (TripMapView/RoadbookView), which
+// transitively imports the native maplibre module — stub it so jest can load.
+jest.mock('@maplibre/maplibre-react-native', () => ({
+  Camera: () => null,
+  GeoJSONSource: ({ children }: { children?: unknown }) => children ?? null,
+  Layer: () => null,
+  Map: ({ children }: { children?: unknown }) => children ?? null,
+}));
+
+jest.mock('expo-router', () => ({
+  Stack: { Screen: () => null },
+  useLocalSearchParams: () => ({ code: 'AB12cd' }),
+  useRouter: () => ({ push: jest.fn(), back: jest.fn() }),
+}));
+
+// Mock only the anonymous share fetches; keep every real trip-api export so the
+// mutation hooks RoadbookView loads still resolve.
+jest.mock('../api/trips', () => {
+  const actual = jest.requireActual('../api/trips');
+  return {
+    ...actual,
+    fetchSharedTrip: jest.fn(),
+    fetchSharedTripRoute: jest.fn(),
+    fetchSharedTripExport: jest.fn(),
+  };
+});
+import { fetchSharedTrip, fetchSharedTripRoute } from '../api/trips';
+import { useTripStore } from '../store/trip-store';
+import SharedTrip from '../../app/s/[code]';
+
+const mockFetch = fetchSharedTrip as jest.MockedFunction<typeof fetchSharedTrip>;
+const mockFetchRoute = fetchSharedTripRoute as jest.MockedFunction<
+  typeof fetchSharedTripRoute
+>;
+
+const SHARED_DETAIL = {
+  title: 'Tour du Vercors',
+  startDate: '2026-06-01T00:00:00+00:00',
+  endDate: '2026-06-02T00:00:00+00:00',
+  isLocked: false,
+  outOfZone: false,
+  stages: [
+    {
+      dayNumber: 1,
+      distance: 42,
+      elevation: 500,
+      elevationLoss: 480,
+      startPoint: { lat: 45, lon: 5, ele: 200 },
+      endPoint: { lat: 45.1, lon: 5.1, ele: 220 },
+      isRestDay: false,
+    },
+    {
+      dayNumber: 2,
+      distance: 38,
+      elevation: 300,
+      elevationLoss: 320,
+      startPoint: { lat: 45.1, lon: 5.1, ele: 220 },
+      endPoint: { lat: 45.2, lon: 5.2, ele: 210 },
+      isRestDay: false,
+    },
+  ],
+} as unknown as Awaited<ReturnType<typeof fetchSharedTrip>>;
+
+function allTexts(root: any): string[] {
+  return root
+    .findAll((n: any) => typeof n.type === 'string' && n.type === 'Text')
+    .flatMap((n: any) => {
+      const c = n.props?.children;
+      return typeof c === 'string' ? [c] : [];
+    });
+}
+
+function findByA11yLabel(root: any, label: string): any[] {
+  return root.findAll((n: any) => n.props?.accessibilityLabel === label);
+}
+
+let renderer: any;
+async function render(): Promise<any> {
+  await act(async () => {
+    renderer = TestRenderer.create(createElement(SharedTrip));
+  });
+  return renderer.root;
+}
+
+beforeAll(async () => {
+  await i18n.changeLanguage('fr');
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockFetchRoute.mockResolvedValue(null);
+  useTripStore.getState().reset();
+});
+
+afterEach(() => {
+  act(() => renderer?.unmount());
+});
+
+describe('Shared trip screen (#1177) — read-only consultation', () => {
+  it('fetches the trip via the share short code and hydrates the store', async () => {
+    mockFetch.mockResolvedValue(SHARED_DETAIL);
+
+    await render();
+
+    expect(mockFetch).toHaveBeenCalledWith('AB12cd');
+    expect(useTripStore.getState().title).toBe('Tour du Vercors');
+    expect(useTripStore.getState().stages).toHaveLength(2);
+    // tripId stays null so the map never hits the auth-gated /trips/{id}/route.
+    expect(useTripStore.getState().tripId).toBeNull();
+  });
+
+  it('shows the "shared view / read only" banner', async () => {
+    mockFetch.mockResolvedValue(SHARED_DETAIL);
+
+    const root = await render();
+
+    expect(allTexts(root)).toContain(i18n.t('sharePage.readOnlyBanner'));
+  });
+
+  it('exposes no edit affordances (no insert rows, no in-ride FAB)', async () => {
+    mockFetch.mockResolvedValue(SHARED_DETAIL);
+
+    const root = await render();
+
+    // Two stages would render a "+étape" insert row between them if editable.
+    expect(allTexts(root)).not.toContain(i18n.t('trip.edit.addStage'));
+    expect(findByA11yLabel(root, i18n.t('trip.rideCtaA11y'))).toHaveLength(0);
+  });
+
+  it('renders the invalid/revoked error copy when the link does not resolve', async () => {
+    mockFetch.mockResolvedValue(null);
+
+    const root = await render();
+
+    expect(allTexts(root)).toContain(i18n.t('sharePage.error'));
+  });
+});


### PR DESCRIPTION
Closes #1177

⚠️ **Stacked sur #1204 (feature/1194)** — overlap unique sur `icons.ts` (export `Eye`), résolu en import profond dans le style tree-shaké de #1194. Merger #1204 d'abord.

## Contenu
Nouvelle route mobile lecture seule `app/s/[code].tsx`, équivalent du web `shared-trip-page.tsx` : bandeau permanent « Vue partagée — lecture seule » (icône Eye), bascule Roadbook/Carte (SegmentedControl + swipe), téléchargements GPX/FIT. Réutilise `RoadbookView` et `TripMapView`.

## Fichiers
- `app/s/[code].tsx` (ajout) — écran.
- `src/hooks/use-shared-trip.ts` (ajout) — hydrate le store depuis `/s/<code>` puis fusionne `/s/<code>/route`. Read-only, pas de SSE. `tripId` reste **null** volontairement pour empêcher `useTripRoute` de taper l'endpoint auth-gated `/trips/{id}/route` (la géométrie vient du `/route` public).
- `src/api/trips.ts` — `fetchSharedTrip`/`fetchSharedTripRoute`/`fetchSharedTripExport` sur les paths existants `/s/{shortCode}`, `/s/{shortCode}/route`, `/s/{shortCode}.gpx|.fit`. Aucun endpoint inventé.
- `components/trip/RoadbookView.tsx` — prop `readOnly?` (un seul gate haut niveau, menu header intact, compatible #1178).
- `app/_layout.tsx` — `Stack.Screen name="s/[code]"`.
- `app.json` — App Link Android (intentFilters autoVerify, host prod, pathPrefix /s/).
- i18n fr+en (`sharePage.*`).

## Deep link — différé
App Link Android câblé (`app.json`). **Différé** : la vérification complète du domaine nécessite un `assetlinks.json` sous `/.well-known/` avec le SHA-256 de la clé de release (dépend du build signé — Sprint 59). iOS non câblé à ce stade. Le scheme custom `biketripplanner://s/<code>` fonctionne déjà via Expo Router.

## Auto-critique
- Lecture seule garantie côté client (pas de mutation, `tripId=null`) ; l'autorisation reste côté API (endpoints publics `/s/`).
- Pas de reconnexion SSE (vue figée), cohérent avec une vue partagée.

## Tests
`src/screens/shared-trip.test.tsx` (4 tests, dont read-only + bandeau). Prove-it-can-fail vérifié. CI mobile = tsc + jest : tsc clean, `Tests: 705` (dont parité i18n). Note : `ShareSheet.test.tsx` flake sur timeout en run complet sous charge — verte en isolation (`8 passed`), pré-existant, sans rapport.

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 critical, 0 warnings, 0 nitpicks. Both previously-flagged issues are now fixed: the stage-card tap-through bug (fixed in `8f777c50`) and the missing unit tests for the anonymous share fetch functions (fixed in `7e8b1ce8`, which adds `api.GET`-mocked tests for `fetchSharedTrip`/`fetchSharedTripRoute`/`fetchSharedTripExport` in `trips.test.ts`, mirroring the existing `fetchTrips`/`fetchStageExport` coverage). No new correctness, security, performance, or architecture issues found in this diff.

**Resolved threads:** Resolved 1 previously open thread (test-coverage on `mobile/src/api/trips.ts`) that was addressed by the latest commit.

**PR title:** still does not follow Conventional Commits — description is a noun phrase, not imperative mood (`consultation in-app d'un voyage partagé /s/<code>`).

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

Reviewed commit: 7e8b1ce8a0030d1ba9608f751cf41f873fb2d9e3
<!-- claude-review-end -->