### PR TITLE
feat(mobile): câbler applyBatch (file de modifs) + addPoiWaypoint à l'UI (#1179)

### DIFF
--- a/mobile/src/components/TripMap.tsx
+++ b/mobile/src/components/TripMap.tsx
@@ -19,6 +19,7 @@ import {
   computeBounds,
   mapStyleFor,
   markerCollection,
+  poiFromPressFeatures,
   segmentFeature,
   type MapMarker,
   type StageLine,
@@ -32,6 +33,7 @@ export function TripMap({
   stageSegments,
   markers,
   highlightedSegment,
+  onSelectPoi,
 }: {
   // One colored polyline per stage; the route is drawn stage by stage so each
   // stands out (see stageColor). Camera framing uses all points flattened.
@@ -42,6 +44,10 @@ export function TripMap({
   // alerts pilot this later; use alertSegmentToCoords() to adapt an alert
   // action's [lat, lon] segment.
   highlightedSegment?: [number, number][];
+  // Tap on a POI marker → the tapped POI (name + coords), so the caller can open
+  // the "add to itinerary" popover (#1179). Omitted where the map is read-only:
+  // the marker source then carries no onPress and taps are inert.
+  onSelectPoi?: (poi: MapMarker) => void;
 }) {
   const theme = useTheme();
   const { t } = useTranslation();
@@ -159,7 +165,16 @@ export function TripMap({
           </GeoJSONSource>
         ) : null}
         {markerData.features.length > 0 ? (
-          <GeoJSONSource id="markers" data={markerData}>
+          <GeoJSONSource
+            id="markers"
+            data={markerData}
+            {...(onSelectPoi && {
+              onPress: (e: { nativeEvent: { features: GeoJSON.Feature[] } }) => {
+                const poi = poiFromPressFeatures(e.nativeEvent.features);
+                if (poi) onSelectPoi(poi);
+              },
+            })}
+          >
             <Layer
               id="markers-circle"
               type="circle"

--- a/mobile/src/components/map/map-utils.ts
+++ b/mobile/src/components/map/map-utils.ts
@@ -172,6 +172,22 @@ export function collectMarkers(stages: StageData[]): MapMarker[] {
   return markers;
 }
 
+// Pick the tapped POI out of a marker-source press event's features (the ordered
+// GeoJSON features under the touch, highest z-index first). Only POI markers are
+// addable as a route waypoint (#1179), so accommodation/waypoint taps resolve to
+// null and no popover opens. Kept pure so TripMap's native onPress stays a
+// one-liner and this is unit-testable without a native map.
+export function poiFromPressFeatures(
+  features: GeoJSON.Feature[] | undefined,
+): MapMarker | null {
+  const poi = (features ?? []).find(
+    (f) => f.properties?.kind === 'poi' && f.geometry?.type === 'Point',
+  );
+  if (!poi || poi.geometry.type !== 'Point') return null;
+  const [lon, lat] = poi.geometry.coordinates as [number, number];
+  return { kind: 'poi', lon, lat, name: String(poi.properties?.name ?? '') };
+}
+
 export function markerCollection(markers: MapMarker[]): FeatureCollection {
   return {
     type: 'FeatureCollection',

--- a/mobile/src/components/trip/ModificationQueue.test.tsx
+++ b/mobile/src/components/trip/ModificationQueue.test.tsx
@@ -1,0 +1,189 @@
+/// <reference types="jest" />
+import TestRenderer, { act } from 'react-test-renderer';
+import { EMPTY_RESUPPLY } from '@btp/core';
+import type { ReactElement } from 'react';
+import { Alert, Text } from 'react-native';
+import type { StageData } from '@btp/core';
+import i18n from '../../i18n';
+import { useTripStore } from '../../store/trip-store';
+import { useOfflineStore } from '../../store/offline-store';
+
+jest.mock('expo-router', () => ({ useRouter: () => ({ push: jest.fn() }) }));
+
+jest.mock('../../api/trips', () => ({
+  deleteStage: jest.fn(),
+  createStage: jest.fn(),
+  updateStageDistance: jest.fn(),
+  moveStage: jest.fn(),
+  insertRestDay: jest.fn(),
+  setStageAccommodation: jest.fn(),
+  addPoiWaypoint: jest.fn(),
+  scanAccommodations: jest.fn(),
+  applyBatchRecompute: jest.fn(),
+  analyzeTrip: jest.fn(),
+  updateTripConfig: jest.fn(),
+  duplicateTrip: jest.fn(),
+  deleteTrip: jest.fn(),
+}));
+
+import { applyBatchRecompute } from '../../api/trips';
+import { RoadbookView } from './RoadbookView';
+import type { Modification } from '../../store/trip-store';
+
+const mock = <T extends (...args: never[]) => unknown>(fn: T) =>
+  fn as unknown as jest.MockedFunction<T>;
+
+function stage(dayNumber: number): StageData {
+  return {
+    dayNumber,
+    distance: 50,
+    elevation: 100,
+    elevationLoss: 0,
+    startPoint: { lat: 0, lon: 0, ele: 0 },
+    endPoint: { lat: 1, lon: 1, ele: 0 },
+    geometry: [],
+    label: null,
+    startLabel: 'Paris',
+    endLabel: 'Lyon',
+    weather: null,
+    alerts: [],
+    resupply: EMPTY_RESUPPLY,
+    accommodations: [],
+    selectedAccommodation: null,
+    accommodationSearchRadiusKm: 10,
+    isRestDay: false,
+    supplyTimeline: [],
+    events: [],
+  };
+}
+
+const MODS: Modification[] = [
+  { stageIndex: 0, type: 'distance', label: 'Jour 1 · distance' },
+  { stageIndex: null, type: 'dates', label: 'Dates' },
+];
+
+function render(element: ReactElement): any {
+  let out: any;
+  act(() => {
+    out = TestRenderer.create(element);
+  });
+  return out;
+}
+
+// Find the Button (role=button) whose rendered label matches `text`.
+function buttonByLabel(tree: any, text: string): any {
+  return tree.root.findAll(
+    (n: any) =>
+      n.props.accessibilityRole === 'button' &&
+      typeof n.props.onPress === 'function' &&
+      n
+        .findAllByType(Text)
+        .some((txt: any) =>
+          (Array.isArray(txt.props.children)
+            ? txt.props.children
+            : [txt.props.children]
+          ).includes(text),
+        ),
+  )[0];
+}
+
+const applyLabel = () => i18n.t('trip.modificationQueue.applyAll');
+const cancelLabel = () => i18n.t('trip.modificationQueue.cancel');
+
+describe('RoadbookView modification queue wiring (#1179)', () => {
+  let alertSpy: jest.SpyInstance;
+
+  beforeAll(async () => {
+    await i18n.changeLanguage('fr');
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+    act(() => {
+      useTripStore.getState().reset();
+      useOfflineStore.setState({ isOnline: true, apiReachable: true });
+      useTripStore.setState({
+        stages: [stage(1), stage(2)],
+        isLocked: false,
+        outOfZone: false,
+        startDate: null,
+        endDate: null,
+        loading: false,
+        pendingModifications: MODS,
+      });
+    });
+  });
+
+  afterEach(() => alertSpy.mockRestore());
+
+  it('hides the panel when the queue is empty', () => {
+    act(() => useTripStore.setState({ pendingModifications: [] }));
+    const tree = render(<RoadbookView id="t1" />);
+    expect(
+      tree.root.findAll(
+        (n: any) =>
+          n.props.accessibilityLabel === i18n.t('trip.modificationQueue.panelA11y'),
+      ),
+    ).toHaveLength(0);
+  });
+
+  it('lists the pending modifications with a pluralized count', () => {
+    const tree = render(<RoadbookView id="t1" />);
+    const panel = tree.root.find(
+      (n: any) =>
+        n.props.accessibilityLabel === i18n.t('trip.modificationQueue.panelA11y'),
+    );
+    const strings = panel
+      .findAllByType(Text)
+      .flatMap((n: any) =>
+        Array.isArray(n.props.children) ? n.props.children : [n.props.children],
+      );
+    expect(strings).toContain(
+      i18n.t('trip.modificationQueue.title', { count: 2 }),
+    );
+    expect(strings).toContain('Jour 1 · distance');
+    expect(strings).toContain('Dates');
+  });
+
+  it('applies the whole queue in one recompute (runApplyBatch) and clears it', async () => {
+    mock(applyBatchRecompute).mockResolvedValue({ ok: true, status: 202 });
+    const tree = render(<RoadbookView id="t1" />);
+
+    act(() => buttonByLabel(tree, applyLabel()).props.onPress());
+    await act(async () => {});
+
+    expect(applyBatchRecompute).toHaveBeenCalledWith('t1', [
+      { stageIndex: 0, type: 'distance', label: 'Jour 1 · distance' },
+      { stageIndex: null, type: 'dates', label: 'Dates' },
+    ]);
+    // A successful batch clears the queue.
+    expect(useTripStore.getState().pendingModifications).toHaveLength(0);
+  });
+
+  it('clears the queue without a recompute on cancel', () => {
+    const tree = render(<RoadbookView id="t1" />);
+    act(() => buttonByLabel(tree, cancelLabel()).props.onPress());
+    expect(applyBatchRecompute).not.toHaveBeenCalled();
+    expect(useTripStore.getState().pendingModifications).toHaveLength(0);
+  });
+
+  it('refuses the batch in degraded (offline) mode: apply disabled, no recompute', async () => {
+    act(() => useOfflineStore.setState({ isOnline: false }));
+    const tree = render(<RoadbookView id="t1" />);
+
+    const apply = buttonByLabel(tree, applyLabel());
+    // UI-level: the action reports itself disabled in read-only / degraded mode.
+    expect(apply.props.accessibilityState.disabled).toBe(true);
+
+    // Gate-level: even if the press slips through, the transversal gate (#1166)
+    // refuses the write — no recompute leaves the device, the failure is surfaced.
+    act(() => apply.props.onPress());
+    await act(async () => {});
+    expect(applyBatchRecompute).not.toHaveBeenCalled();
+    expect(alertSpy).toHaveBeenCalledWith(
+      i18n.t('trip.edit.failedTitle'),
+      i18n.t('trip.edit.reason.offline'),
+    );
+  });
+});

--- a/mobile/src/components/trip/ModificationQueue.tsx
+++ b/mobile/src/components/trip/ModificationQueue.tsx
@@ -1,0 +1,153 @@
+import { StyleSheet, Text, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { Button } from '../ui';
+import { Clock, Route } from '../ui/icons';
+import { useTheme } from '../../theme';
+import { useTripStore } from '../../store/trip-store';
+
+// Rough backend recompute seconds per modification, mirrored from the web
+// ModificationQueue heuristic (observed p50 durations): a batch shows the rider
+// why grouping edits saves round-trips.
+const SECONDS_PER_MODIFICATION: Record<string, number> = {
+  accommodation: 5,
+  distance: 15,
+  dates: 8,
+  pacing: 10,
+};
+
+// Past this many estimated seconds we show "~1 min" rather than an exact count.
+const MAX_DISPLAY_SECONDS = 59;
+
+// Floating panel surfaced once one or more edits are queued (store
+// pendingModifications). Mirrors pwa's modification-queue.tsx: the pending list,
+// an estimated recompute time and two actions — "Apply and recompute" (one
+// grouped POST /recompute via runApplyBatch) and "Cancel" (clears the queue).
+// Auto-hides when the queue is empty. Disabled in the roadbook's read-only /
+// degraded state so the batch write can't fire offline / API-down (#1166, #1179).
+export function ModificationQueue({
+  onApply,
+  onCancel,
+  applying = false,
+  disabled = false,
+  bottomOffset = 16,
+}: {
+  onApply: () => void;
+  onCancel: () => void;
+  applying?: boolean;
+  disabled?: boolean;
+  // Distance from the bottom edge; the caller lifts it above the system nav bar
+  // (safe-area inset) so it never sits under the home indicator.
+  bottomOffset?: number;
+}) {
+  const { t } = useTranslation();
+  const theme = useTheme();
+  const pending = useTripStore((s) => s.pendingModifications);
+
+  if (pending.length === 0) return null;
+
+  const totalSeconds = pending.reduce(
+    (sum, m) => sum + (SECONDS_PER_MODIFICATION[m.type] ?? 5),
+    0,
+  );
+  const estimate =
+    totalSeconds > MAX_DISPLAY_SECONDS
+      ? t('trip.modificationQueue.estimatedMinute')
+      : t('trip.modificationQueue.estimatedSeconds', { seconds: totalSeconds });
+
+  return (
+    <View
+      accessibilityLabel={t('trip.modificationQueue.panelA11y')}
+      style={[
+        styles.panel,
+        {
+          bottom: bottomOffset,
+          backgroundColor: theme.colors.card,
+          borderColor: theme.colors.border,
+          borderRadius: theme.radius.xl,
+          padding: theme.spacing.base,
+          gap: theme.spacing.sm,
+          ...theme.shadows.medium,
+        },
+      ]}
+    >
+      <View style={styles.header}>
+        <Route color={theme.colors.brand} size={16} />
+        <Text
+          style={{
+            color: theme.colors.foreground,
+            fontFamily: theme.fonts.sansSemibold,
+            fontSize: 14,
+          }}
+        >
+          {t('trip.modificationQueue.title', { count: pending.length })}
+        </Text>
+      </View>
+
+      <View style={{ gap: theme.spacing.xs }}>
+        {pending.map((m, i) => (
+          <View key={`${m.type}-${m.stageIndex ?? 'trip'}-${i}`} style={styles.row}>
+            <View style={[styles.dot, { backgroundColor: theme.colors.brand }]} />
+            <Text
+              style={{
+                color: theme.colors.mutedForeground,
+                fontFamily: theme.fonts.sans,
+                fontSize: 13,
+                flex: 1,
+              }}
+            >
+              {m.label}
+            </Text>
+          </View>
+        ))}
+      </View>
+
+      <View style={styles.estimate}>
+        <Clock color={theme.colors.mutedIcon} size={13} />
+        <Text
+          style={{
+            color: theme.colors.mutedForeground,
+            fontFamily: theme.fonts.mono,
+            fontSize: 12,
+          }}
+        >
+          {estimate}
+        </Text>
+      </View>
+
+      <View style={styles.actions}>
+        <Button
+          label={t('trip.modificationQueue.cancel')}
+          variant="ghost"
+          size="sm"
+          disabled={applying}
+          onPress={onCancel}
+        />
+        <Button
+          label={
+            applying
+              ? t('trip.modificationQueue.applying')
+              : t('trip.modificationQueue.applyAll')
+          }
+          size="sm"
+          loading={applying}
+          disabled={disabled || applying}
+          onPress={onApply}
+        />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  panel: {
+    position: 'absolute',
+    left: 16,
+    right: 16,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  header: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+  row: { flexDirection: 'row', alignItems: 'flex-start', gap: 6 },
+  dot: { width: 6, height: 6, borderRadius: 3, marginTop: 6 },
+  estimate: { flexDirection: 'row', alignItems: 'center', gap: 6 },
+  actions: { flexDirection: 'row', justifyContent: 'flex-end', gap: 8 },
+});

--- a/mobile/src/components/trip/PoiWaypointPopover.tsx
+++ b/mobile/src/components/trip/PoiWaypointPopover.tsx
@@ -1,0 +1,99 @@
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { Button } from '../ui';
+import { MapPin, Plus, X } from '../ui/icons';
+import { useTheme } from '../../theme';
+import type { MapMarker } from '../map/map-utils';
+
+// Popover shown when a POI marker on the stage map is tapped (#1179), mirroring
+// pwa's poi-popover.tsx "add to itinerary" affordance: the POI name/type, an
+// "Add to itinerary" action (routes the stage through the POI via
+// runAddPoiWaypoint) and a close button. `disabled` gates the add in the
+// roadbook's read-only / degraded state — the reroute needs the API and the zone.
+export function PoiWaypointPopover({
+  poi,
+  onAdd,
+  onClose,
+  disabled = false,
+}: {
+  poi: MapMarker;
+  onAdd: () => void;
+  onClose: () => void;
+  disabled?: boolean;
+}) {
+  const { t } = useTranslation();
+  const theme = useTheme();
+  const name = poi.name || t('trip.poiWaypoint.type');
+
+  return (
+    <View
+      style={[
+        styles.card,
+        {
+          backgroundColor: theme.colors.card,
+          borderColor: theme.colors.border,
+          borderRadius: theme.radius.xl,
+          padding: theme.spacing.base,
+          gap: theme.spacing.sm,
+          ...theme.shadows.medium,
+        },
+      ]}
+    >
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={t('trip.poiWaypoint.close')}
+        onPress={onClose}
+        hitSlop={8}
+        style={styles.close}
+      >
+        <X color={theme.colors.mutedForeground} size={18} />
+      </Pressable>
+
+      <View style={styles.head}>
+        <MapPin color={theme.colors.accentInk} size={18} />
+        <View style={{ flex: 1 }}>
+          <Text
+            numberOfLines={2}
+            style={{
+              color: theme.colors.foreground,
+              fontFamily: theme.fonts.serif,
+              fontSize: 15,
+            }}
+          >
+            {name}
+          </Text>
+          <Text
+            style={{
+              color: theme.colors.mutedForeground,
+              fontFamily: theme.fonts.sansMedium,
+              fontSize: 12,
+            }}
+          >
+            {t('trip.poiWaypoint.type')}
+          </Text>
+        </View>
+      </View>
+
+      <Button
+        label={t('trip.poiWaypoint.add')}
+        size="sm"
+        fullWidth
+        disabled={disabled}
+        icon={<Plus color="#ffffff" size={16} />}
+        onPress={onAdd}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    position: 'absolute',
+    left: 12,
+    right: 12,
+    bottom: 12,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  close: { position: 'absolute', top: 8, right: 8, zIndex: 1 },
+  head: { flexDirection: 'row', alignItems: 'flex-start', gap: 8, paddingRight: 24 },
+});

--- a/mobile/src/components/trip/RoadbookView.tsx
+++ b/mobile/src/components/trip/RoadbookView.tsx
@@ -9,6 +9,7 @@ import { StageCard, stageKey } from './StageCard';
 import { StageInsertRow } from './StageInsertRow';
 import { RoadbookSummary } from './RoadbookSummary';
 import { RoadbookBanner } from './RoadbookBanner';
+import { ModificationQueue } from './ModificationQueue';
 import { useOfflineStore } from '../../store/offline-store';
 import {
   isStageToday,
@@ -21,6 +22,10 @@ import { useTheme } from '../../theme';
 import { useTripStore } from '../../store/trip-store';
 import type { MutationFailure } from '../../store/gating';
 import { useTripMutations } from '../../hooks/use-trip-mutations';
+
+// Stable in-flight key for the grouped "apply and recompute" action, so a
+// double-tap on it fires a single runApplyBatch (same guard as the insert rows).
+const BATCH_KEY = 'apply-batch';
 
 // The roadbook tab: a lifecycle summary header (upcoming / ongoing / past),
 // the lock / out-of-zone / no-dates banners, then the stage list (StageCard
@@ -51,6 +56,7 @@ export function RoadbookView({
   const apiReachable = useOfflineStore((s) => s.apiReachable);
   const startDate = useTripStore((s) => s.startDate);
   const endDate = useTripStore((s) => s.endDate);
+  const cancelAllModifications = useTripStore((s) => s.cancelAllModifications);
 
   const today = todayUtc();
   const state = tripStateFromDates(startDate, endDate, today);
@@ -260,6 +266,17 @@ export function RoadbookView({
           <Bike color={theme.colors.primaryForeground} size={22} />
         </Pressable>
       ) : null}
+      {/* Grouped modification queue (#1179): surfaces when edits are queued in the
+          store, applies them in one recompute (runApplyBatch) or clears them.
+          Auto-hides when empty; the apply is disabled in the read-only / degraded
+          state so the batch write never fires offline / API-down (#1166). */}
+      <ModificationQueue
+        applying={busyKeys.has(BATCH_KEY)}
+        disabled={readOnly}
+        bottomOffset={insets.bottom + theme.spacing.lg}
+        onApply={() => runGuarded(BATCH_KEY, () => mutations.applyBatch())}
+        onCancel={cancelAllModifications}
+      />
     </View>
   );
 }

--- a/mobile/src/components/trip/StageDetailView.tsx
+++ b/mobile/src/components/trip/StageDetailView.tsx
@@ -25,7 +25,12 @@ import {
   X,
 } from '../ui/icons';
 import { TripMap } from '../TripMap';
-import { alertSegmentToCoords, collectMarkers } from '../map/map-utils';
+import { PoiWaypointPopover } from './PoiWaypointPopover';
+import {
+  alertSegmentToCoords,
+  collectMarkers,
+  type MapMarker,
+} from '../map/map-utils';
 import { stageColor } from '../map/stage-colors';
 import { ElevationProfile } from './ElevationProfile';
 import { ExportButton } from './ExportButton';
@@ -74,6 +79,8 @@ export function StageDetailView({ initialIndex }: { initialIndex: number }) {
   >(undefined);
   const [editingDistance, setEditingDistance] = useState(false);
   const [draft, setDraft] = useState('');
+  // POI marker tapped on the stage map → its "add to itinerary" popover (#1179).
+  const [selectedPoi, setSelectedPoi] = useState<MapMarker | null>(null);
 
   // Keep the index valid as stages hydrate / change under us.
   const count = stages.length;
@@ -91,6 +98,7 @@ export function StageDetailView({ initialIndex }: { initialIndex: number }) {
     setHighlightedSegment(undefined);
     setEditingDistance(false);
     setDraft('');
+    setSelectedPoi(null);
   }, [safeIndex]);
 
   const onFailure = useCallback(
@@ -145,6 +153,12 @@ export function StageDetailView({ initialIndex }: { initialIndex: number }) {
     apiReachable &&
     !outOfZone &&
     !stage.isRestDay;
+
+  // Adding a POI as a route waypoint reroutes the stage via Valhalla, so it needs
+  // the same live-write conditions as a distance edit (and the trip zone). A rest
+  // day has no route to reroute — it renders no map, so no gating needed there.
+  const canAddWaypoint =
+    tripId !== null && !isLocked && isOnline && apiReachable && !outOfZone;
 
   function startEditDistance(): void {
     setDraft(String(stats.distanceKm));
@@ -260,11 +274,29 @@ export function StageDetailView({ initialIndex }: { initialIndex: number }) {
 
       <View style={{ height: 220 }}>
         {coordinates.length > 0 ? (
-          <TripMap
-            stageSegments={stageSegments}
-            markers={markers}
-            highlightedSegment={highlightedSegment}
-          />
+          <>
+            <TripMap
+              stageSegments={stageSegments}
+              markers={markers}
+              highlightedSegment={highlightedSegment}
+              onSelectPoi={canAddWaypoint ? setSelectedPoi : undefined}
+            />
+            {selectedPoi ? (
+              <PoiWaypointPopover
+                poi={selectedPoi}
+                disabled={!canAddWaypoint}
+                onAdd={() => {
+                  void mutations.addPoiWaypoint(
+                    safeIndex,
+                    selectedPoi.lat,
+                    selectedPoi.lon,
+                  );
+                  setSelectedPoi(null);
+                }}
+                onClose={() => setSelectedPoi(null)}
+              />
+            ) : null}
+          </>
         ) : (
           <View style={{ flex: 1 }}>
             <EmptyState title={t('trip.mapEmpty')} />

--- a/mobile/src/components/trip/StageDetailView.tsx
+++ b/mobile/src/components/trip/StageDetailView.tsx
@@ -156,9 +156,11 @@ export function StageDetailView({ initialIndex }: { initialIndex: number }) {
 
   // Adding a POI as a route waypoint reroutes the stage via Valhalla, so it needs
   // the same live-write conditions as a distance edit (and the trip zone). A rest
-  // day has no route to reroute — it renders no map, so no gating needed there.
+  // day has no route to reroute, yet its own point(s) still render on this map
+  // (stageSegments is built directly, not via buildStageLines), so exclude it
+  // explicitly — otherwise a POI tap on a rest day would fire addPoiWaypoint.
   const canAddWaypoint =
-    tripId !== null && !isLocked && isOnline && apiReachable && !outOfZone;
+    tripId !== null && !isLocked && isOnline && apiReachable && !outOfZone && !stage.isRestDay;
 
   function startEditDistance(): void {
     setDraft(String(stats.distanceKm));

--- a/mobile/src/components/trip/poi-waypoint.test.tsx
+++ b/mobile/src/components/trip/poi-waypoint.test.tsx
@@ -281,4 +281,15 @@ describe('StageDetailView add-POI-waypoint wiring (#1179)', () => {
     expect(markersSource(tree).props.onPress).toBeUndefined();
     expect(addPoiWaypoint).not.toHaveBeenCalled();
   });
+
+  it('offers no POI affordance on a rest day (no route to reroute) (#1179 review)', () => {
+    // A rest day still renders its own point on this map, but has no route to
+    // reroute — canAddWaypoint must exclude it, leaving the markers inert.
+    act(() =>
+      useTripStore.setState({ stages: [{ ...stageWithGeometry(), isRestDay: true }] }),
+    );
+    const tree = render(<StageDetailView initialIndex={0} />);
+    expect(markersSource(tree).props.onPress).toBeUndefined();
+    expect(addPoiWaypoint).not.toHaveBeenCalled();
+  });
 });

--- a/mobile/src/components/trip/poi-waypoint.test.tsx
+++ b/mobile/src/components/trip/poi-waypoint.test.tsx
@@ -1,0 +1,284 @@
+/// <reference types="jest" />
+import TestRenderer, { act } from 'react-test-renderer';
+import { EMPTY_RESUPPLY } from '@btp/core';
+import type { ReactElement } from 'react';
+import { Alert, Text } from 'react-native';
+import * as SecureStore from 'expo-secure-store';
+import type { StageData } from '@btp/core';
+import i18n from '../../i18n';
+import { useTripStore } from '../../store/trip-store';
+import { useOfflineStore } from '../../store/offline-store';
+import { useMapPrefs } from '../../store/map-prefs';
+import { poiFromPressFeatures } from '../map/map-utils';
+import { PoiWaypointPopover } from './PoiWaypointPopover';
+
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: jest.fn().mockResolvedValue(null),
+  setItemAsync: jest.fn().mockResolvedValue(undefined),
+}));
+
+// Native map stubbed as plain host nodes so the props TripMap feeds each source
+// (incl. the markers source's onPress) are recorded on the tree.
+jest.mock('@maplibre/maplibre-react-native', () => {
+  const React = require('react');
+  const make = (name: string) => {
+    const C = ({ children, ...rest }: { children?: unknown }) =>
+      React.createElement(name, rest, children);
+    C.displayName = name;
+    return C;
+  };
+  return {
+    Map: make('Map'),
+    Camera: make('Camera'),
+    GeoJSONSource: make('GeoJSONSource'),
+    Layer: make('Layer'),
+  };
+});
+
+jest.mock('../../api/trips', () => ({
+  fetchStageDetail: jest.fn().mockResolvedValue(undefined),
+  addPoiWaypoint: jest.fn(),
+  updateStageDistance: jest.fn(),
+  setStageAccommodation: jest.fn(),
+  scanAccommodations: jest.fn(),
+  addManualAccommodation: jest.fn(),
+  applyBatchRecompute: jest.fn(),
+  analyzeTrip: jest.fn(),
+  updateTripConfig: jest.fn(),
+  createStage: jest.fn(),
+  deleteStage: jest.fn(),
+  insertRestDay: jest.fn(),
+  moveStage: jest.fn(),
+  duplicateTrip: jest.fn(),
+  deleteTrip: jest.fn(),
+}));
+
+import { addPoiWaypoint } from '../../api/trips';
+import { TripMap } from '../TripMap';
+import { StageDetailView } from './StageDetailView';
+
+const mock = <T extends (...args: never[]) => unknown>(fn: T) =>
+  fn as unknown as jest.MockedFunction<T>;
+
+function render(element: ReactElement): any {
+  let out: any;
+  act(() => {
+    out = TestRenderer.create(element);
+  });
+  return out;
+}
+
+function buttonByLabel(root: any, text: string): any {
+  return root.findAll(
+    (n: any) =>
+      n.props.accessibilityRole === 'button' &&
+      typeof n.props.onPress === 'function' &&
+      n
+        .findAllByType(Text)
+        .some((txt: any) =>
+          (Array.isArray(txt.props.children)
+            ? txt.props.children
+            : [txt.props.children]
+          ).includes(text),
+        ),
+  )[0];
+}
+
+const poiFeature = (
+  name: string,
+  lon: number,
+  lat: number,
+): GeoJSON.Feature => ({
+  type: 'Feature',
+  properties: { kind: 'poi', name },
+  geometry: { type: 'Point', coordinates: [lon, lat] },
+});
+
+describe('poiFromPressFeatures', () => {
+  it('extracts the tapped POI (name + coords)', () => {
+    expect(poiFromPressFeatures([poiFeature('Fontaine', 3, 45)])).toEqual({
+      kind: 'poi',
+      name: 'Fontaine',
+      lon: 3,
+      lat: 45,
+    });
+  });
+
+  it('ignores non-POI markers (waypoint / accommodation) and empty presses', () => {
+    const waypoint: GeoJSON.Feature = {
+      type: 'Feature',
+      properties: { kind: 'waypoint', name: 'Lyon' },
+      geometry: { type: 'Point', coordinates: [4, 45] },
+    };
+    expect(poiFromPressFeatures([waypoint])).toBeNull();
+    expect(poiFromPressFeatures([])).toBeNull();
+    expect(poiFromPressFeatures(undefined)).toBeNull();
+  });
+});
+
+describe('PoiWaypointPopover', () => {
+  beforeAll(async () => {
+    await i18n.changeLanguage('fr');
+  });
+
+  const poi = { kind: 'poi' as const, name: 'Fontaine', lon: 3, lat: 45 };
+
+  it('adds and closes via its actions', () => {
+    const onAdd = jest.fn();
+    const onClose = jest.fn();
+    const tree = render(
+      <PoiWaypointPopover poi={poi} onAdd={onAdd} onClose={onClose} />,
+    );
+
+    act(() => buttonByLabel(tree.root, i18n.t('trip.poiWaypoint.add')).props.onPress());
+    expect(onAdd).toHaveBeenCalledTimes(1);
+
+    const close = tree.root.find(
+      (n: any) =>
+        n.props.accessibilityLabel === i18n.t('trip.poiWaypoint.close') &&
+        typeof n.props.onPress === 'function',
+    );
+    act(() => close.props.onPress());
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables the add action when gated', () => {
+    const tree = render(
+      <PoiWaypointPopover poi={poi} onAdd={jest.fn()} onClose={jest.fn()} disabled />,
+    );
+    const add = buttonByLabel(tree.root, i18n.t('trip.poiWaypoint.add'));
+    expect(add.props.accessibilityState.disabled).toBe(true);
+  });
+});
+
+describe('TripMap POI selection wiring', () => {
+  beforeEach(() => {
+    act(() => {
+      useMapPrefs.setState({ base: 'map', hydrated: true });
+      useOfflineStore.setState({ isOnline: true });
+    });
+  });
+
+  const markers = [{ kind: 'poi' as const, lon: 3, lat: 45, name: 'Fontaine' }];
+  const segs = [{ color: 'hsl(25, 72%, 48%)', coordinates: [[2, 48], [3, 49]] as [number, number][] }];
+
+  it('calls onSelectPoi with the tapped POI when the markers source is pressed', () => {
+    const onSelectPoi = jest.fn();
+    const out = render(
+      <TripMap stageSegments={segs} markers={markers} onSelectPoi={onSelectPoi} />,
+    );
+    const source = out.root.find(
+      (n: any) => n.type === 'GeoJSONSource' && n.props.id === 'markers',
+    );
+    expect(typeof source.props.onPress).toBe('function');
+    act(() =>
+      source.props.onPress({ nativeEvent: { features: [poiFeature('Fontaine', 3, 45)] } }),
+    );
+    expect(onSelectPoi).toHaveBeenCalledWith({
+      kind: 'poi',
+      name: 'Fontaine',
+      lon: 3,
+      lat: 45,
+    });
+  });
+
+  it('leaves the markers source non-interactive when onSelectPoi is omitted', () => {
+    const out = render(<TripMap stageSegments={segs} markers={markers} />);
+    const source = out.root.find(
+      (n: any) => n.type === 'GeoJSONSource' && n.props.id === 'markers',
+    );
+    expect(source.props.onPress).toBeUndefined();
+  });
+});
+
+describe('StageDetailView add-POI-waypoint wiring (#1179)', () => {
+  let alertSpy: jest.SpyInstance;
+
+  function stageWithGeometry(): StageData {
+    return {
+      dayNumber: 1,
+      distance: 50,
+      elevation: 800,
+      elevationLoss: 600,
+      startPoint: { lat: 48, lon: 2, ele: 0 },
+      endPoint: { lat: 49, lon: 3, ele: 0 },
+      geometry: [
+        { lat: 48, lon: 2, ele: 0 },
+        { lat: 49, lon: 3, ele: 0 },
+      ],
+      label: null,
+      startLabel: 'Paris',
+      endLabel: 'Lyon',
+      weather: null,
+      alerts: [],
+      resupply: EMPTY_RESUPPLY,
+      accommodations: [],
+      selectedAccommodation: null,
+      accommodationSearchRadiusKm: 10,
+      isRestDay: false,
+      supplyTimeline: [],
+      events: [],
+    };
+  }
+
+  beforeAll(async () => {
+    await i18n.changeLanguage('fr');
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (SecureStore.setItemAsync as jest.Mock).mockClear();
+    alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+    act(() => {
+      useTripStore.getState().reset();
+      useMapPrefs.setState({ base: 'map', hydrated: true });
+      useOfflineStore.setState({ isOnline: true, apiReachable: true });
+      useTripStore.setState({
+        tripId: 't1',
+        stages: [stageWithGeometry()],
+        isLocked: false,
+        outOfZone: false,
+        startDate: null,
+        endDate: null,
+        loading: false,
+      });
+    });
+  });
+
+  afterEach(() => alertSpy.mockRestore());
+
+  function markersSource(tree: any): any {
+    return tree.root.find(
+      (n: any) => n.type === 'GeoJSONSource' && n.props.id === 'markers',
+    );
+  }
+
+  it('opens the popover on a POI tap and reroutes via runAddPoiWaypoint', async () => {
+    mock(addPoiWaypoint).mockResolvedValue({ ok: true, status: 202 });
+    const tree = render(<StageDetailView initialIndex={0} />);
+
+    // Tap a POI marker on the stage map.
+    act(() =>
+      markersSource(tree).props.onPress({
+        nativeEvent: { features: [poiFeature('Fontaine', 3.1, 45.2)] },
+      }),
+    );
+    // Confirm from the popover.
+    act(() =>
+      buttonByLabel(tree.root, i18n.t('trip.poiWaypoint.add')).props.onPress(),
+    );
+    await act(async () => {});
+
+    // index is String()-ified in the API layer; the runner passed stage 0 + coords.
+    expect(addPoiWaypoint).toHaveBeenCalledWith('t1', 0, 45.2, 3.1);
+  });
+
+  it('offers no POI affordance in degraded (offline) mode', () => {
+    act(() => useOfflineStore.setState({ isOnline: false }));
+    const tree = render(<StageDetailView initialIndex={0} />);
+    // Read-only: the markers source carries no onPress, so a tap is inert and no
+    // reroute can be dispatched.
+    expect(markersSource(tree).props.onPress).toBeUndefined();
+    expect(addPoiWaypoint).not.toHaveBeenCalled();
+  });
+});

--- a/mobile/src/i18n/resources/en.ts
+++ b/mobile/src/i18n/resources/en.ts
@@ -356,6 +356,22 @@ export const en: typeof fr = {
       profileAxisPoint: '{{distance}} km · {{ele}} m',
       profileAxisMax: '{{ele}} m max',
     },
+    modificationQueue: {
+      panelA11y: 'Pending modifications',
+      title_one: '1 pending modification',
+      title_other: '{{count}} pending modifications',
+      estimatedSeconds: 'Estimated time: ~{{seconds}} s',
+      estimatedMinute: 'Estimated time: ~1 min',
+      applyAll: 'Apply and recompute',
+      cancel: 'Cancel',
+      applying: 'Applying…',
+    },
+    poiWaypoint: {
+      type: 'Point of interest',
+      add: 'Add to itinerary',
+      addA11y: 'Add {{name}} to itinerary',
+      close: 'Close',
+    },
     blocks: {
       distanceKm: '{{distance}} km',
       alerts: 'Alerts',

--- a/mobile/src/i18n/resources/en.ts
+++ b/mobile/src/i18n/resources/en.ts
@@ -369,7 +369,6 @@ export const en: typeof fr = {
     poiWaypoint: {
       type: 'Point of interest',
       add: 'Add to itinerary',
-      addA11y: 'Add {{name}} to itinerary',
       close: 'Close',
     },
     blocks: {

--- a/mobile/src/i18n/resources/fr.ts
+++ b/mobile/src/i18n/resources/fr.ts
@@ -356,6 +356,22 @@ export const fr = {
       profileAxisPoint: '{{distance}} km · {{ele}} m',
       profileAxisMax: '{{ele}} m max',
     },
+    modificationQueue: {
+      panelA11y: 'Modifications en attente',
+      title_one: '1 modification en attente',
+      title_other: '{{count}} modifications en attente',
+      estimatedSeconds: 'Temps estimé : ~{{seconds}} s',
+      estimatedMinute: 'Temps estimé : ~1 min',
+      applyAll: 'Appliquer et recalculer',
+      cancel: 'Annuler',
+      applying: 'Application…',
+    },
+    poiWaypoint: {
+      type: "Point d'intérêt",
+      add: "Ajouter à l'itinéraire",
+      addA11y: "Ajouter {{name}} à l'itinéraire",
+      close: 'Fermer',
+    },
     blocks: {
       distanceKm: '{{distance}} km',
       alerts: 'Alertes',

--- a/mobile/src/i18n/resources/fr.ts
+++ b/mobile/src/i18n/resources/fr.ts
@@ -369,7 +369,6 @@ export const fr = {
     poiWaypoint: {
       type: "Point d'intérêt",
       add: "Ajouter à l'itinéraire",
-      addA11y: "Ajouter {{name}} à l'itinéraire",
       close: 'Fermer',
     },
     blocks: {


### PR DESCRIPTION
Closes #1179

Deux mutations du store (`runApplyBatch`, `runAddPoiWaypoint`) existaient sans UI. Câblées en réutilisant strictement les runners existants (aucune logique de mutation réimplémentée).

## File de modifications (applyBatch)
- `components/trip/ModificationQueue.tsx` (ajout) — panneau flottant listant `pendingModifications`, temps de recalcul estimé, « Appliquer et recalculer » (`runApplyBatch` groupé) + « Annuler ». Auto-masqué à vide. Calque de `pwa/.../modification-queue.tsx`.
- Monté dans `RoadbookView.tsx` : Apply via le garde in-flight existant (`runGuarded`, clé `apply-batch`), Cancel via `cancelAllModifications`, `disabled={readOnly}` en dégradé.
- **Parité** : comme le web (seul un hook de test alimente la file, les éditions réelles partant immédiatement), aucun producteur en flux normal n'est ajouté — cela exigerait de restructurer le dispatch du store, ce que l'overlap #1178 (undo/redo stacké) interdit. Le panneau est exposé et branché à `runApplyBatch`, s'affiche dès que `queueModification` alimente le store.

## Waypoint POI depuis la carte (addPoiWaypoint)
- `PoiWaypointPopover.tsx` (ajout, calque de `poi-popover.tsx`) : nom du POI + « Ajouter à l'itinéraire ».
- `TripMap.tsx` : prop `onSelectPoi` sur le `onPress` de la source `markers` ; helper pur `poiFromPressFeatures` dans `map-utils.ts` (ignore waypoint/hébergement).
- `StageDetailView.tsx` : tap marqueur POI → popover → `addPoiWaypoint(stageIndex, lat, lon)`. Garde `canAddWaypoint` (tripId, non verrouillé, online, apiReachable, en zone) : hors ligne, `onSelectPoi` non passé ⇒ affordance inerte.

Les deux écritures exigent le rerouting et restent bloquées par le gate transversal #1166 hors ligne / API down.

## i18n
`trip.modificationQueue.*`, `trip.poiWaypoint.*` (fr + en).

## Tests
`ModificationQueue.test.tsx`, `poi-waypoint.test.tsx` (helper, popover, câblage TripMap, intégration StageDetailView, cas dégradé). Prove-it-can-fail vérifié. CI mobile = tsc + jest : tsc clean, `Tests: 714 passed / 91 suites`.

## Overlap
#1178 (undo/redo) sera stacké sur cette branche (store + menu roadbook).

<!-- claude-review-start -->
## Claude Review

**Findings:** 0 blocking, 1 non-blocking (1 total)

The 2 previously open threads were already resolved on a prior push (`canAddWaypoint` now excludes `isRestDay`; the orphaned `poiWaypoint.addA11y` i18n key was dropped from `en.ts`/`fr.ts`) — no action needed this pass. One new non-blocking finding: the new `ModificationQueue` panel and the "in-ride" FAB in `RoadbookView.tsx` share the same absolute bottom offset and will overlap once `pendingModifications` is non-empty in production (currently latent — no real producer calls `queueModification` yet).

### Review checklist
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [x] Documentation is up to date
- [x] Dependent tickets accounted for

**Commit reviewed:** b8052299538b5ad0f9d34dca23790a4c738a37cc
<!-- claude-review-end -->