### PR TITLE
feat(mobile): undo/redo des mutations roadbook dans le menu ⋯ (#1178)

### DIFF
--- a/mobile/app/trip/[id]/index.tsx
+++ b/mobile/app/trip/[id]/index.tsx
@@ -14,9 +14,11 @@ import {
   Copy,
   Download,
   MoreVertical,
+  Redo2,
   Settings,
   Share2,
   Trash2,
+  Undo2,
 } from '../../../src/components/ui/icons';
 import {
   ConfigSheet,
@@ -31,6 +33,7 @@ import { useExport } from '../../../src/hooks/use-export';
 import { confirmDeleteTrip } from '../../../src/hooks/use-trips';
 import { useTripLive } from '../../../src/hooks/use-trip-live';
 import { useTripMutations } from '../../../src/hooks/use-trip-mutations';
+import { useUndoRedo } from '../../../src/hooks/use-undo-redo';
 import type { MutationFailure } from '../../../src/store/gating';
 import { useTripStore } from '../../../src/store/trip-store';
 import { readTripCache } from '../../../src/store/trip-cache';
@@ -46,17 +49,21 @@ function MenuItem({
   label,
   onPress,
   danger = false,
+  disabled = false,
 }: {
   icon: ReactNode;
   label: string;
   onPress: () => void;
   danger?: boolean;
+  disabled?: boolean;
 }) {
   const theme = useTheme();
   return (
     <Pressable
       accessibilityRole="button"
       accessibilityLabel={label}
+      accessibilityState={{ disabled }}
+      disabled={disabled}
       onPress={onPress}
       style={{
         flexDirection: 'row',
@@ -64,6 +71,7 @@ function MenuItem({
         gap: theme.spacing.md,
         paddingVertical: theme.spacing.sm,
         paddingHorizontal: theme.spacing.md,
+        opacity: disabled ? 0.4 : 1,
       }}
     >
       {icon}
@@ -148,6 +156,7 @@ export default function TripRoadbook() {
   const onFailure = (reason: MutationFailure) =>
     Alert.alert(t('common.error'), t(`trip.edit.reason.${reason}`));
   const mutations = useTripMutations(id, onFailure);
+  const { canUndo, canRedo, undo, redo } = useUndoRedo();
   const { exportTrip } = useExport(() =>
     Alert.alert(t('export.failedTitle'), t('export.failedMessage')),
   );
@@ -292,6 +301,35 @@ export default function TripRoadbook() {
               ...theme.shadows.strong,
             }}
           >
+            {/* Undo/redo (#1178, maquette roadbook ⋯): restore the previous /
+                next roadbook state. Disabled with empty history and, per the
+                #1166 write gate, while the trip is started or the connection is
+                degraded (offline / API-down). */}
+            <MenuItem
+              icon={<Undo2 color={theme.colors.foreground} size={18} />}
+              label={t('trip.menu.undo')}
+              disabled={!canUndo}
+              onPress={() => {
+                setMenuOpen(false);
+                undo();
+              }}
+            />
+            <MenuItem
+              icon={<Redo2 color={theme.colors.foreground} size={18} />}
+              label={t('trip.menu.redo')}
+              disabled={!canRedo}
+              onPress={() => {
+                setMenuOpen(false);
+                redo();
+              }}
+            />
+            <View
+              style={{
+                height: 1,
+                backgroundColor: theme.colors.border,
+                marginVertical: theme.spacing.xs,
+              }}
+            />
             <MenuItem
               icon={<Settings color={theme.colors.foreground} size={18} />}
               label={t('trip.menu.config')}

--- a/mobile/src/components/ui/icons.ts
+++ b/mobile/src/components/ui/icons.ts
@@ -81,3 +81,6 @@ export { default as CornerUpLeft } from 'lucide-react-native/dist/esm/icons/corn
 export { default as Info } from 'lucide-react-native/dist/esm/icons/info.js';
 // Shared read-only trip view (#1177): read-only banner marker.
 export { default as Eye } from 'lucide-react-native/dist/esm/icons/eye.js';
+// Roadbook undo/redo (#1178): ↶ Annuler / ↷ Rétablir menu items.
+export { default as Undo2 } from 'lucide-react-native/dist/esm/icons/undo-2.js';
+export { default as Redo2 } from 'lucide-react-native/dist/esm/icons/redo-2.js';

--- a/mobile/src/hooks/use-undo-redo.test.ts
+++ b/mobile/src/hooks/use-undo-redo.test.ts
@@ -29,15 +29,33 @@ beforeEach(() => {
   act(() => useTripTemporalStore.getState()._push({ marker: true }));
 });
 
-describe('useUndoRedo (#1178, #1166 write gate)', () => {
-  it('exposes canUndo when online and history exists', () => {
+describe('useUndoRedo (#1178, local-first + #1166 lock gate)', () => {
+  it('exposes canUndo when history exists', () => {
     const { result, unmount } = renderHook();
     expect(result.current.canUndo).toBe(true);
     unmount();
   });
 
-  it('disables and refuses undo/redo while offline', () => {
-    act(() => useOfflineStore.setState({ isOnline: false }));
+  it('stays available offline — undo/redo replay local state, no API call (web parity)', () => {
+    act(() => useOfflineStore.setState({ isOnline: false, apiReachable: false }));
+    const { result, unmount } = renderHook();
+
+    expect(result.current.canUndo).toBe(true);
+    // And it actually runs: the history pointer advances.
+    act(() => result.current.undo());
+    expect(useTripTemporalStore.getState().canUndo).toBe(false);
+    unmount();
+  });
+
+  it('is not blocked by an out-of-zone trip (undo/redo never reroute)', () => {
+    act(() => useTripStore.setState({ outOfZone: true }));
+    const { result, unmount } = renderHook();
+    expect(result.current.canUndo).toBe(true);
+    unmount();
+  });
+
+  it('disables and refuses undo/redo on a locked (started) trip', () => {
+    act(() => useTripStore.setState({ isLocked: true }));
     const { result, unmount } = renderHook();
 
     expect(result.current.canUndo).toBe(false);
@@ -46,20 +64,6 @@ describe('useUndoRedo (#1178, #1166 write gate)', () => {
     // Refused: calling undo does not touch the temporal history.
     act(() => result.current.undo());
     expect(useTripTemporalStore.getState().canUndo).toBe(true);
-    unmount();
-  });
-
-  it('disables undo/redo when the API is unreachable', () => {
-    act(() => useOfflineStore.setState({ apiReachable: false }));
-    const { result, unmount } = renderHook();
-    expect(result.current.canUndo).toBe(false);
-    unmount();
-  });
-
-  it('disables undo/redo on a locked (started) trip', () => {
-    act(() => useTripStore.setState({ isLocked: true }));
-    const { result, unmount } = renderHook();
-    expect(result.current.canUndo).toBe(false);
     unmount();
   });
 });

--- a/mobile/src/hooks/use-undo-redo.test.ts
+++ b/mobile/src/hooks/use-undo-redo.test.ts
@@ -1,0 +1,65 @@
+/// <reference types="jest" />
+import { createElement } from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { useUndoRedo } from './use-undo-redo';
+import { useTripStore, useTripTemporalStore } from '../store/trip-store';
+import { useOfflineStore } from '../store/offline-store';
+
+type UseUndoRedo = ReturnType<typeof useUndoRedo>;
+
+// Minimal renderHook on react-test-renderer (the mobile convention, no RTL).
+function renderHook(): { result: { current: UseUndoRedo }; unmount: () => void } {
+  const result = { current: undefined as unknown as UseUndoRedo };
+  function Probe() {
+    result.current = useUndoRedo();
+    return null;
+  }
+  let renderer!: ReturnType<typeof TestRenderer.create>;
+  act(() => {
+    renderer = TestRenderer.create(createElement(Probe));
+  });
+  return { result, unmount: () => act(() => renderer.unmount()) };
+}
+
+beforeEach(() => {
+  useTripStore.getState().reset();
+  useTripTemporalStore.getState().clear();
+  useOfflineStore.setState({ isOnline: true, apiReachable: true });
+  // Arm a single undoable entry so canUndo would be true absent any gate.
+  act(() => useTripTemporalStore.getState()._push({ marker: true }));
+});
+
+describe('useUndoRedo (#1178, #1166 write gate)', () => {
+  it('exposes canUndo when online and history exists', () => {
+    const { result, unmount } = renderHook();
+    expect(result.current.canUndo).toBe(true);
+    unmount();
+  });
+
+  it('disables and refuses undo/redo while offline', () => {
+    act(() => useOfflineStore.setState({ isOnline: false }));
+    const { result, unmount } = renderHook();
+
+    expect(result.current.canUndo).toBe(false);
+    expect(result.current.canRedo).toBe(false);
+
+    // Refused: calling undo does not touch the temporal history.
+    act(() => result.current.undo());
+    expect(useTripTemporalStore.getState().canUndo).toBe(true);
+    unmount();
+  });
+
+  it('disables undo/redo when the API is unreachable', () => {
+    act(() => useOfflineStore.setState({ apiReachable: false }));
+    const { result, unmount } = renderHook();
+    expect(result.current.canUndo).toBe(false);
+    unmount();
+  });
+
+  it('disables undo/redo on a locked (started) trip', () => {
+    act(() => useTripStore.setState({ isLocked: true }));
+    const { result, unmount } = renderHook();
+    expect(result.current.canUndo).toBe(false);
+    unmount();
+  });
+});

--- a/mobile/src/hooks/use-undo-redo.ts
+++ b/mobile/src/hooks/use-undo-redo.ts
@@ -1,0 +1,37 @@
+import { useTripStore, useTripTemporalStore } from '../store/trip-store';
+import { useOfflineStore } from '../store/offline-store';
+import { evaluateGate } from '../store/gating';
+
+/**
+ * Undo/redo state for the roadbook menu (#1178, parity with the web
+ * `useUndoRedo`). Exposes `canUndo`/`canRedo` plus guarded `undo`/`redo`.
+ *
+ * Undo/redo restore local roadbook state, but the transversal gate (#1166)
+ * treats them as writes: a started trip or a degraded connection (offline /
+ * API-down) disables and refuses them like every other mutation. Out-of-zone
+ * does not block them (they never reroute).
+ */
+export function useUndoRedo() {
+  const canUndoRaw = useTripTemporalStore((s) => s.canUndo);
+  const canRedoRaw = useTripTemporalStore((s) => s.canRedo);
+  const undoRaw = useTripTemporalStore((s) => s.undo);
+  const redoRaw = useTripTemporalStore((s) => s.redo);
+  const isLocked = useTripStore((s) => s.isLocked);
+  const outOfZone = useTripStore((s) => s.outOfZone);
+  const isOnline = useOfflineStore((s) => s.isOnline);
+  const apiReachable = useOfflineStore((s) => s.apiReachable);
+
+  const blocked =
+    evaluateGate({ isLocked, outOfZone, isOnline, apiReachable }, false) !== null;
+
+  return {
+    canUndo: canUndoRaw && !blocked,
+    canRedo: canRedoRaw && !blocked,
+    undo: () => {
+      if (!blocked) undoRaw();
+    },
+    redo: () => {
+      if (!blocked) redoRaw();
+    },
+  };
+}

--- a/mobile/src/hooks/use-undo-redo.ts
+++ b/mobile/src/hooks/use-undo-redo.ts
@@ -1,15 +1,15 @@
 import { useTripStore, useTripTemporalStore } from '../store/trip-store';
-import { useOfflineStore } from '../store/offline-store';
-import { evaluateGate } from '../store/gating';
 
 /**
  * Undo/redo state for the roadbook menu (#1178, parity with the web
  * `useUndoRedo`). Exposes `canUndo`/`canRedo` plus guarded `undo`/`redo`.
  *
- * Undo/redo restore local roadbook state, but the transversal gate (#1166)
- * treats them as writes: a started trip or a degraded connection (offline /
- * API-down) disables and refuses them like every other mutation. Out-of-zone
- * does not block them (they never reroute).
+ * Undo/redo only replay already-in-memory roadbook state (no API call), so —
+ * unlike the write mutations gated by #1166 — they stay available offline / when
+ * the API is down (local-first, web parity): losing them on a connection blip
+ * would be the wrong call for a bikepacking app. A started trip is fully
+ * read-only (423 on every edit), so `isLocked` still disables them; out-of-zone
+ * does not (they never reroute).
  */
 export function useUndoRedo() {
   const canUndoRaw = useTripTemporalStore((s) => s.canUndo);
@@ -17,21 +17,15 @@ export function useUndoRedo() {
   const undoRaw = useTripTemporalStore((s) => s.undo);
   const redoRaw = useTripTemporalStore((s) => s.redo);
   const isLocked = useTripStore((s) => s.isLocked);
-  const outOfZone = useTripStore((s) => s.outOfZone);
-  const isOnline = useOfflineStore((s) => s.isOnline);
-  const apiReachable = useOfflineStore((s) => s.apiReachable);
-
-  const blocked =
-    evaluateGate({ isLocked, outOfZone, isOnline, apiReachable }, false) !== null;
 
   return {
-    canUndo: canUndoRaw && !blocked,
-    canRedo: canRedoRaw && !blocked,
+    canUndo: canUndoRaw && !isLocked,
+    canRedo: canRedoRaw && !isLocked,
     undo: () => {
-      if (!blocked) undoRaw();
+      if (!isLocked) undoRaw();
     },
     redo: () => {
-      if (!blocked) redoRaw();
+      if (!isLocked) redoRaw();
     },
   };
 }

--- a/mobile/src/i18n/resources/en.ts
+++ b/mobile/src/i18n/resources/en.ts
@@ -437,6 +437,8 @@ export const en: typeof fr = {
     },
     menu: {
       open: 'Trip menu',
+      undo: 'Undo',
+      redo: 'Redo',
       config: 'Settings',
       share: 'Share',
       exportGpx: 'Download GPX',

--- a/mobile/src/i18n/resources/fr.ts
+++ b/mobile/src/i18n/resources/fr.ts
@@ -437,6 +437,8 @@ export const fr = {
     },
     menu: {
       open: 'Menu du voyage',
+      undo: 'Annuler',
+      redo: 'Rétablir',
       config: 'Configuration',
       share: 'Partager',
       exportGpx: 'Télécharger GPX',

--- a/mobile/src/store/delete-stage.ts
+++ b/mobile/src/store/delete-stage.ts
@@ -20,6 +20,7 @@ export function runDeleteStage(
       // Deleting merges into the adjacent day (no Valhalla reroute): a lock or
       // offline blocks it, but an out-of-zone trip does not.
       requiresRouting: false,
+      undoable: true,
       optimistic: () => store.deleteStageOptimistic(index),
       rollback: () => store.setStages(snapshot),
       call: () => apiDeleteStage(tripId, index),

--- a/mobile/src/store/mutations.ts
+++ b/mobile/src/store/mutations.ts
@@ -29,6 +29,11 @@ import {
 import { useOfflineStore } from './offline-store';
 import { deleteTripCache } from './trip-cache';
 import type { Modification, TripConfig } from './trip-store';
+import {
+  getUndoableSlice,
+  useTripStore,
+  useTripTemporalStore,
+} from './trip-store';
 
 // The store slice + actions the mutation runners drive. `useTripStore.getState()`
 // satisfies it structurally, so a runner takes a live snapshot (the actions are
@@ -86,6 +91,10 @@ export async function run(
     // accommodation runners use it to trigger a re-scan of the stale candidate
     // list rather than leaving the user stuck on it.
     onConflict?: () => void;
+    // Push a pre-edit undo snapshot before the optimistic apply (roadbook
+    // structural/dates/pacing edits, #1178). Popped on rollback so a failed
+    // mutation leaves no phantom undo entry.
+    undoable?: boolean;
   },
   onFailure: OnFailure,
 ): Promise<boolean> {
@@ -94,11 +103,17 @@ export async function run(
     onFailure(blocked);
     return false;
   }
+  if (opts.undoable) {
+    useTripTemporalStore
+      .getState()
+      ._push(getUndoableSlice(useTripStore.getState()));
+  }
   opts.optimistic?.();
   try {
     const { ok, status } = await opts.call();
     if (!ok) {
       opts.rollback?.();
+      if (opts.undoable) useTripTemporalStore.getState()._pop();
       const reason = normalizeStatus(status);
       if (reason === 'conflict') opts.onConflict?.();
       onFailure(reason);
@@ -107,6 +122,7 @@ export async function run(
     return true;
   } catch {
     opts.rollback?.();
+    if (opts.undoable) useTripTemporalStore.getState()._pop();
     onFailure('network');
     return false;
   }
@@ -146,6 +162,7 @@ export function runUpdateDates(
     ctx,
     {
       requiresRouting: false,
+      undoable: true,
       optimistic: () => ctx.setConfig({ startDate, endDate }),
       rollback: () => ctx.setConfig(snapshot),
       call: () =>
@@ -181,6 +198,7 @@ export function runUpdatePacing(
     ctx,
     {
       requiresRouting: false,
+      undoable: true,
       optimistic: () => ctx.setConfig(pacing),
       rollback: () => ctx.setConfig(snapshot),
       call: () => updateTripConfig(tripId, configPatch(ctx, pacing)),
@@ -247,6 +265,7 @@ export function runInsertRestDay(
     {
       // Inserting a rest day keeps the next startPoint identical: no reroute.
       requiresRouting: false,
+      undoable: true,
       optimistic: () => ctx.insertRestDayOptimistic(afterIndex),
       rollback: () => ctx.setStages(snapshot),
       call: () => insertRestDay(tripId, afterIndex),
@@ -298,6 +317,7 @@ export function runAddStage(
     {
       // A manual stage is routed via Valhalla → blocked out of zone.
       requiresRouting: true,
+      undoable: true,
       optimistic: () => ctx.insertStageOptimistic(afterIndex, placeholder),
       rollback: () => ctx.setStages(snapshot),
       call: () =>
@@ -342,6 +362,7 @@ export function runMoveStage(
     ctx,
     {
       requiresRouting: true,
+      undoable: true,
       optimistic: () => ctx.moveStageOptimistic(fromIndex, toIndex),
       rollback: () => ctx.setStages(snapshot),
       call: () => moveStage(tripId, fromIndex, toIndex),

--- a/mobile/src/store/temporal-middleware.ts
+++ b/mobile/src/store/temporal-middleware.ts
@@ -1,0 +1,86 @@
+import { create } from 'zustand';
+
+// Lightweight temporal (undo/redo) companion store, mirrored from the web
+// (pwa/src/store/temporal-middleware.ts). Web and mobile keep separate copies of
+// this generic undo stack because each binds to its own zustand host store
+// (immer on web, plain zustand here); the shared roadbook *domain* logic (schema
+// + SSE reconciliation) lives in @btp/core, this UI history stack does not.
+//
+// Snapshots are plain JSON-serialisable slices pushed *before* each tracked
+// mutation via `_push()`; `_pop()` drops the last snapshot on optimistic
+// rollback so a failed mutation leaves no phantom undo entry.
+
+const MAX_HISTORY = 50;
+
+export interface TemporalState {
+  canUndo: boolean;
+  canRedo: boolean;
+  undo: () => void;
+  redo: () => void;
+  /** Clears all history (past and future). Call when loading a new trip. */
+  clear: () => void;
+  /** @internal Push a new snapshot onto the past stack (clears redo stack). */
+  _push: (snapshot: unknown) => void;
+  /** @internal Pop the most-recent past entry. Call on optimistic-rollback. */
+  _pop: () => void;
+}
+
+/**
+ * Creates the companion temporal store bound to a host zustand store.
+ *
+ * @param getState - Returns the current tracked-slice value from the host store.
+ * @param setState - Applies a tracked-slice snapshot back to the host store.
+ */
+export function createTemporalStore(
+  getState: () => unknown,
+  setState: (snapshot: unknown) => void,
+) {
+  let past: unknown[] = [];
+  let future: unknown[] = [];
+
+  return create<TemporalState>()((set) => ({
+    canUndo: false,
+    canRedo: false,
+
+    clear: () => {
+      past = [];
+      future = [];
+      set({ canUndo: false, canRedo: false });
+    },
+
+    _push: (snapshot) => {
+      if (past.length >= MAX_HISTORY) {
+        past = past.slice(past.length - MAX_HISTORY + 1);
+      }
+      past = [...past, snapshot];
+      future = [];
+      set({ canUndo: true, canRedo: false });
+    },
+
+    _pop: () => {
+      if (past.length === 0) return;
+      past = past.slice(0, -1);
+      set({ canUndo: past.length > 0 });
+    },
+
+    undo: () => {
+      if (past.length === 0) return;
+      const current = getState();
+      const previous = past[past.length - 1]!;
+      past = past.slice(0, -1);
+      future = [current, ...future];
+      setState(previous);
+      set({ canUndo: past.length > 0, canRedo: true });
+    },
+
+    redo: () => {
+      if (future.length === 0) return;
+      const current = getState();
+      const next = future[0]!;
+      future = future.slice(1);
+      past = [...past, current];
+      setState(next);
+      set({ canUndo: true, canRedo: future.length > 0 });
+    },
+  }));
+}

--- a/mobile/src/store/temporal.test.ts
+++ b/mobile/src/store/temporal.test.ts
@@ -1,0 +1,128 @@
+/// <reference types="jest" />
+import type { StageData } from '@btp/core';
+import { EMPTY_RESUPPLY } from '@btp/core';
+import { runInsertRestDay, runUpdateDates } from './mutations';
+import { runDeleteStage } from './delete-stage';
+import { useTripStore, useTripTemporalStore } from './trip-store';
+import { useOfflineStore } from './offline-store';
+
+jest.mock('./trip-cache', () => ({ deleteTripCache: jest.fn() }));
+
+jest.mock('../api/trips', () => ({
+  updateTripConfig: jest.fn(),
+  insertRestDay: jest.fn(),
+  deleteStage: jest.fn(),
+}));
+
+import { updateTripConfig, insertRestDay, deleteStage } from '../api/trips';
+
+const mock = <T extends (...args: never[]) => unknown>(fn: T) =>
+  fn as unknown as jest.MockedFunction<T>;
+
+const P = { lat: 0, lon: 0, ele: 0 };
+
+function stage(overrides: Partial<StageData> = {}): StageData {
+  return {
+    dayNumber: 1,
+    distance: 50,
+    elevation: 0,
+    elevationLoss: 0,
+    startPoint: P,
+    endPoint: { lat: 1, lon: 1, ele: 0 },
+    geometry: [],
+    label: null,
+    startLabel: null,
+    endLabel: null,
+    weather: null,
+    alerts: [],
+    resupply: EMPTY_RESUPPLY,
+    accommodations: [],
+    selectedAccommodation: null,
+    accommodationSearchRadiusKm: 5,
+    isRestDay: false,
+    supplyTimeline: [],
+    events: [],
+    ...overrides,
+  };
+}
+
+const ctx = () => useTripStore.getState();
+const temporal = () => useTripTemporalStore.getState();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useTripStore.getState().reset();
+  useOfflineStore.setState({ isOnline: true, apiReachable: true });
+  useTripStore.setState({
+    stages: [stage({ dayNumber: 1 }), stage({ dayNumber: 2 })],
+    isLocked: false,
+    outOfZone: false,
+    startDate: '2026-08-01',
+    endDate: '2026-08-02',
+    loading: false,
+  });
+});
+
+describe('roadbook undo/redo (#1178)', () => {
+  it('undo reverts a structural edit and redo re-applies it', async () => {
+    mock(insertRestDay).mockResolvedValue({ ok: true, status: 202 });
+
+    expect(temporal().canUndo).toBe(false);
+
+    await runInsertRestDay('t1', 0, ctx(), jest.fn());
+    expect(useTripStore.getState().stages).toHaveLength(3);
+    expect(temporal().canUndo).toBe(true);
+    expect(temporal().canRedo).toBe(false);
+
+    temporal().undo();
+    expect(useTripStore.getState().stages).toHaveLength(2);
+    expect(temporal().canUndo).toBe(false);
+    expect(temporal().canRedo).toBe(true);
+
+    temporal().redo();
+    expect(useTripStore.getState().stages).toHaveLength(3);
+    expect(temporal().canUndo).toBe(true);
+    expect(temporal().canRedo).toBe(false);
+  });
+
+  it('undo restores the pre-edit dates', async () => {
+    mock(updateTripConfig).mockResolvedValue({ ok: true, status: 202 });
+
+    await runUpdateDates('t1', '2026-09-01', '2026-09-10', ctx(), jest.fn());
+    expect(useTripStore.getState().startDate).toBe('2026-09-01');
+
+    temporal().undo();
+    expect(useTripStore.getState().startDate).toBe('2026-08-01');
+    expect(useTripStore.getState().endDate).toBe('2026-08-02');
+  });
+
+  it('is a no-op with empty history', () => {
+    expect(temporal().canUndo).toBe(false);
+    temporal().undo();
+    expect(useTripStore.getState().stages).toHaveLength(2);
+    expect(temporal().canUndo).toBe(false);
+    expect(temporal().canRedo).toBe(false);
+  });
+
+  it('leaves no phantom undo entry when the mutation fails and rolls back', async () => {
+    mock(deleteStage).mockResolvedValue({ ok: false, status: 422 });
+
+    const ok = await runDeleteStage('t1', 0, ctx(), jest.fn());
+    expect(ok).toBe(false);
+    // Rolled back to the original two stages...
+    expect(useTripStore.getState().stages).toHaveLength(2);
+    // ...and the pushed snapshot was popped, so nothing is undoable.
+    expect(temporal().canUndo).toBe(false);
+  });
+
+  it('does not record undo history for a mutation refused offline', async () => {
+    useOfflineStore.setState({ isOnline: false });
+    const onFailure = jest.fn();
+
+    const ok = await runInsertRestDay('t1', 0, ctx(), onFailure);
+    expect(ok).toBe(false);
+    expect(onFailure).toHaveBeenCalledWith('offline');
+    expect(insertRestDay).not.toHaveBeenCalled();
+    expect(temporal().canUndo).toBe(false);
+  });
+});

--- a/mobile/src/store/trip-store.ts
+++ b/mobile/src/store/trip-store.ts
@@ -8,6 +8,7 @@ import {
 } from '@btp/core/reconciliation';
 import type { TripDetail, TripRoute } from '../api/trips';
 import { DIFF_TTL_MS, diffStageIndices } from './config-diff';
+import { createTemporalStore } from './temporal-middleware';
 
 type ApiStage = NonNullable<TripDetail['stages']>[number];
 
@@ -219,7 +220,9 @@ export const useTripStore = create<TripState>((set, get) => ({
   loading: true,
   error: null,
   ...DEFAULT_CONFIG,
-  hydrate: (tripId, detail) =>
+  hydrate: (tripId, detail) => {
+    // A fresh trip has no undoable history (mirrors the web clearTrip).
+    useTripTemporalStore.getState().clear();
     set({
       tripId,
       title: detail.title ?? null,
@@ -247,7 +250,8 @@ export const useTripStore = create<TripState>((set, get) => ({
       diffConsumedToken: 0,
       loading: false,
       error: null,
-    }),
+    });
+  },
   applyTripReady: (stages) =>
     set((state) => {
       const reconciled = reconcileTripReady(state.stages, stages);
@@ -436,7 +440,8 @@ export const useTripStore = create<TripState>((set, get) => ({
   cancelAllModifications: () => set({ pendingModifications: [] }),
   clearPendingModifications: () => set({ pendingModifications: [] }),
   setStatus: (patch) => set(patch),
-  reset: () =>
+  reset: () => {
+    useTripTemporalStore.getState().clear();
     set({
       tripId: null,
       title: null,
@@ -454,5 +459,59 @@ export const useTripStore = create<TripState>((set, get) => ({
       loading: true,
       error: null,
       ...DEFAULT_CONFIG,
-    }),
+    });
+  },
 }));
+
+/**
+ * The slice tracked by undo/redo: the roadbook stages plus the editable
+ * dates/pacing config. Mirrors the web {@link getUndoableSlice} — deep-cloned
+ * via JSON so no live store reference leaks into the history stack.
+ */
+export interface UndoableSlice {
+  stages: StageData[];
+  startDate: string | null;
+  endDate: string | null;
+  fatigueFactor: number;
+  elevationPenalty: number;
+  maxDistancePerDay: number;
+  averageSpeed: number;
+}
+
+export function getUndoableSlice(state: UndoableSlice): UndoableSlice {
+  return JSON.parse(
+    JSON.stringify({
+      stages: state.stages,
+      startDate: state.startDate,
+      endDate: state.endDate,
+      fatigueFactor: state.fatigueFactor,
+      elevationPenalty: state.elevationPenalty,
+      maxDistancePerDay: state.maxDistancePerDay,
+      averageSpeed: state.averageSpeed,
+    }),
+  ) as UndoableSlice;
+}
+
+/**
+ * Companion temporal store providing undo/redo for the roadbook (#1178, parity
+ * with the web). Undoable mutations push a pre-edit {@link UndoableSlice} via
+ * `_push()` before applying; `undo()` restores it through `setStages` /
+ * `setConfig` (neither re-pushes), reverting the local optimistic state without
+ * re-hitting the API — same semantics as the web temporal store.
+ */
+export const useTripTemporalStore = createTemporalStore(
+  () => getUndoableSlice(useTripStore.getState()),
+  (snapshot) => {
+    const s = snapshot as UndoableSlice;
+    const store = useTripStore.getState();
+    store.setStages(s.stages);
+    store.setConfig({
+      startDate: s.startDate,
+      endDate: s.endDate,
+      fatigueFactor: s.fatigueFactor,
+      elevationPenalty: s.elevationPenalty,
+      maxDistancePerDay: s.maxDistancePerDay,
+      averageSpeed: s.averageSpeed,
+    });
+  },
+);


### PR DESCRIPTION
Closes #1178

⚠️ **Stacked sur #1206 (feature/1179)** — merger #1206 d'abord.
⚠️ **Conflit attendu `icons.ts` avec #1204 (#1194)** : cette PR ajoute `export { Redo2, Undo2 } from 'lucide-react-native'` (barrel), #1204 a converti `icons.ts` en imports profonds. Voir la note d'ordre de merge dans TRACKING (résolution : garder le fichier deep-import de #1194 + ajouter `Undo2`/`Redo2` en imports profonds `undo-2.js`/`redo-2.js`).

## Contenu
Undo/redo des mutations de roadbook, exposé dans le menu (⋯), parité web + maquette (« ↶ Annuler / ↷ Rétablir »), avec états disabled.

- `store/temporal-middleware.ts` (ajout) — factory `createTemporalStore` (piles past/future, `MAX_HISTORY=50`, `_push`/`_pop`/`undo`/`redo`/`clear`), miroir du web.
- `store/trip-store.ts` — `UndoableSlice` + `getUndoableSlice` (clone JSON), companion `useTripTemporalStore` (restaure via `setStages`/`setConfig`, sans re-appel API), `clear()` sur hydrate/reset.
- `store/mutations.ts` — option `undoable` dans le shell `run()` : `_push` avant l'apply optimiste (après le gate), `_pop` au rollback (pas d'entrée fantôme). Undoable : dates, pacing, insert rest day, add stage, move stage.
- `store/delete-stage.ts` — `undoable: true`.
- `hooks/use-undo-redo.ts` (ajout) — combine `canUndo/canRedo` avec le gate #1166 (`evaluateGate`) : locked/offline/API-down désactivent ET refusent ; out-of-zone n'empêche pas (pas de reroute).
- `app/trip/[id]/index.tsx` — 2 `MenuItem` en tête du dropdown ⋯ (prop `disabled` : opacité + `accessibilityState`), icônes `Undo2`/`Redo2`.
- i18n `trip.menu.undo`/`redo` (fr+en).

## @btp/core : non (justifié)
`@btp/core` ne contient aucun store zustand (seulement zod) ; y déplacer le factory imposerait d'ajouter zustand à core. ADR-055 cadre le partage sur le domaine (schéma + réconciliation), pas une pile d'undo UI. Le domaine partagé (StageData/réconciliation) reste importé de core, non dupliqué.

## Tests
`store/temporal.test.ts`, `hooks/use-undo-redo.test.ts` (undo/redo, no-op vide, pas d'entrée fantôme au rollback 422, refus offline/API-down/locked). Prove-it-can-fail vérifié. CI mobile = tsc + jest : tsc clean, `Tests: 723 passed / 93 suites`.

<!-- claude-review-start -->
## Claude Review

**Summary:** Both previously-flagged issues are fixed by the follow-up commit (`094bd06`): `use-undo-redo.ts` now gates only on `isLocked` (connectivity gate removed), matching the web `useUndoRedo` (which has no gate at all besides history state) — confirmed against `pwa/src/hooks/use-undo-redo.ts` and `pwa/src/store/trip-store.ts`. `use-undo-redo.test.ts` now also covers the out-of-zone case. No new findings; this is a mobile-only change (no PHP/API files touched).

**Resolved threads:** Resolved 2 previously open threads that were addressed by the latest push.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [ ] Documentation is up to date (TRACKING.md `#1178` row still `⏳ À faire`, carried over from the previous review — non-blocking, author's call on when to flip it)
- [x] Dependent tickets accounted for

**Inline comments:** No inline comments.

**Commit reviewed:** 094bd064ea9c58ef1dd87638efb137bd9e167259
<!-- claude-review-end -->