### PR TITLE
fix(mobile): mojibake accents — décoder le retry JSON en UTF-8 (#1172)

### DIFF
--- a/mobile/src/api/client.test.ts
+++ b/mobile/src/api/client.test.ts
@@ -147,6 +147,33 @@ describe('authMiddleware 401 retry (#1032)', () => {
     expect(await result!.json()).toEqual({ title: 'Entre Sensée et Escaut' });
   });
 
+  // Regression (#1172 review): RFC 7807 errors come back as application/problem+json
+  // (rfc_7807_compliant_errors is on). A 422/409 replayed on the retry carries an
+  // accented French constraint message, so it must take the text branch too.
+  it('rebuilds an application/problem+json retry body from text (#1172)', async () => {
+    mockGetJwt.mockReturnValue('fresh-jwt');
+    mockRefresh.mockResolvedValue(true);
+    const textSpy = jest
+      .fn()
+      .mockResolvedValue(JSON.stringify({ detail: "L'adresse est déjà utilisée" }));
+    const arrayBufferSpy = jest.fn();
+    (globalThis.fetch as jest.Mock).mockResolvedValue({
+      status: 422,
+      statusText: 'Unprocessable Entity',
+      headers: new Headers({ 'Content-Type': 'application/problem+json; charset=utf-8' }),
+      text: textSpy,
+      arrayBuffer: arrayBufferSpy,
+    });
+
+    const request = new Request('https://api.test/trips');
+    await onRequest(request);
+    const result = await onResponse(request, new Response(null, { status: 401 }));
+
+    expect(textSpy).toHaveBeenCalledTimes(1);
+    expect(arrayBufferSpy).not.toHaveBeenCalled();
+    expect(await result!.json()).toEqual({ detail: "L'adresse est déjà utilisée" });
+  });
+
   it('does not replay when the refresh fails', async () => {
     mockGetJwt.mockReturnValue('stale-jwt');
     mockRefresh.mockResolvedValue(false);

--- a/mobile/src/api/client.test.ts
+++ b/mobile/src/api/client.test.ts
@@ -119,6 +119,34 @@ describe('authMiddleware 401 retry (#1032)', () => {
     expect(resultBytes).toEqual(bytes);
   });
 
+  // Regression (#1172): a JSON body retried after a 401 must be rebuilt from a
+  // UTF-8 STRING (`.text()`), not an ArrayBuffer — rebuilding from bytes makes RN's
+  // Response.json() decode UTF-8 as Latin-1, mojibaking accented titles
+  // ("Entre Sensée et Escaut" -> "Entre SensÃ©e et Escaut") on a cold-start
+  // GET /trips whose expired token triggers this retry path.
+  it('rebuilds a JSON retry body from text so accented UTF-8 survives (#1172)', async () => {
+    mockGetJwt.mockReturnValue('fresh-jwt');
+    mockRefresh.mockResolvedValue(true);
+    const textSpy = jest.fn().mockResolvedValue(JSON.stringify({ title: 'Entre Sensée et Escaut' }));
+    const arrayBufferSpy = jest.fn();
+    (globalThis.fetch as jest.Mock).mockResolvedValue({
+      status: 200,
+      statusText: 'OK',
+      headers: new Headers({ 'Content-Type': 'application/ld+json; charset=utf-8' }),
+      text: textSpy,
+      arrayBuffer: arrayBufferSpy,
+    });
+
+    const request = new Request('https://api.test/trips');
+    await onRequest(request);
+    const result = await onResponse(request, new Response(null, { status: 401 }));
+
+    // JSON is decoded as text, never through the byte round-trip that mojibakes it.
+    expect(textSpy).toHaveBeenCalledTimes(1);
+    expect(arrayBufferSpy).not.toHaveBeenCalled();
+    expect(await result!.json()).toEqual({ title: 'Entre Sensée et Escaut' });
+  });
+
   it('does not replay when the refresh fails', async () => {
     mockGetJwt.mockReturnValue('stale-jwt');
     mockRefresh.mockResolvedValue(false);

--- a/mobile/src/api/client.ts
+++ b/mobile/src/api/client.ts
@@ -66,15 +66,18 @@ export const authMiddleware: Middleware = {
     useOfflineStore.getState().setApiReachable(retried.status < 500);
     // Rebuild the retried response with the global `Response` constructor so it
     // passes openapi-fetch's `instanceof Response` check (same realm as the check).
-    // Rebuild TEXT payloads (JSON/LD+JSON/text) from a UTF-8 STRING via `.text()`:
-    // rebuilding them from an ArrayBuffer makes RN's `Response.json()/.text()` decode
-    // the bytes as Latin-1, mojibaking accented content on a retried request — a
-    // cold-start GET /trips whose expired token triggers this path renders "Sensée"
-    // as "SensÃ©e" (#1172). BINARY payloads (e.g. a #1047 FIT / GPX export retried
-    // after a mid-download token refresh) must keep their raw bytes, so those keep
-    // the ArrayBuffer round-trip, which a `.text()` decode would corrupt.
+    // Rebuild TEXT payloads (any JSON flavor or text/*) from a UTF-8 STRING via
+    // `.text()`: rebuilding them from an ArrayBuffer makes RN's `Response.json()/
+    // .text()` decode the bytes as Latin-1, mojibaking accented content on a retried
+    // request — a cold-start GET /trips whose expired token triggers this path
+    // renders "Sensée" as "SensÃ©e" (#1172). The `+json` suffix match also covers
+    // `application/problem+json` (RFC 7807 errors — a 422/409 replayed on the retry
+    // carries accented French constraint messages) and `application/merge-patch+json`.
+    // BINARY payloads (e.g. a #1047 FIT / GPX export retried after a mid-download
+    // token refresh) must keep their raw bytes, so those keep the ArrayBuffer
+    // round-trip, which a `.text()` decode would corrupt.
     const contentType = retried.headers.get('Content-Type') ?? '';
-    const isText = /^(application\/(json|ld\+json)|text\/)/i.test(contentType);
+    const isText = /^(text\/|application\/(?:[\w.-]+\+)?json)/i.test(contentType);
     const body = isText ? await retried.text() : await retried.arrayBuffer();
     return new Response(body, {
       status: retried.status,

--- a/mobile/src/api/client.ts
+++ b/mobile/src/api/client.ts
@@ -60,17 +60,22 @@ export const authMiddleware: Middleware = {
     if (jwt) {
       retry.headers.set('Authorization', `Bearer ${jwt}`);
     }
-    // Rebuild the retried response with the global `Response` constructor so it
-    // passes openapi-fetch's `instanceof Response` check (same realm as the check).
-    // Read via arrayBuffer(), not text(): a text round-trip re-encodes the body as
-    // UTF-8, corrupting any binary payload (e.g. a #1047 FIT export retried after
-    // a mid-download token refresh). arrayBuffer preserves the raw bytes for both
-    // binary and text content.
     const retried = await fetch(retry);
     // Re-evaluate on the retried response — it, not the original 401, is what
     // surfaces to the caller and drives the degraded-mode banner (#1166).
     useOfflineStore.getState().setApiReachable(retried.status < 500);
-    const body = await retried.arrayBuffer();
+    // Rebuild the retried response with the global `Response` constructor so it
+    // passes openapi-fetch's `instanceof Response` check (same realm as the check).
+    // Rebuild TEXT payloads (JSON/LD+JSON/text) from a UTF-8 STRING via `.text()`:
+    // rebuilding them from an ArrayBuffer makes RN's `Response.json()/.text()` decode
+    // the bytes as Latin-1, mojibaking accented content on a retried request — a
+    // cold-start GET /trips whose expired token triggers this path renders "Sensée"
+    // as "SensÃ©e" (#1172). BINARY payloads (e.g. a #1047 FIT / GPX export retried
+    // after a mid-download token refresh) must keep their raw bytes, so those keep
+    // the ArrayBuffer round-trip, which a `.text()` decode would corrupt.
+    const contentType = retried.headers.get('Content-Type') ?? '';
+    const isText = /^(application\/(json|ld\+json)|text\/)/i.test(contentType);
+    const body = isText ? await retried.text() : await retried.arrayBuffer();
     return new Response(body, {
       status: retried.status,
       statusText: retried.statusText,


### PR DESCRIPTION
Closes #1172

## Root cause (le vrai, diagnostiqué en live)
Le mojibake intermittent des accents sur « Mes voyages » (« Entre Sensée et Escaut » → « Entre SensÃ©e et Escaut ») **ne vient ni de la compression Caddy (#1161) ni de ngrok**. Vérifié en iso-prod local :
- La base stocke le titre en UTF-8 correct.
- L'API renvoie les octets corrects (`C3 A9`), `charset=utf-8`, **sans** compression pour le mobile (`X-Client-Platform: mobile` → Caddy `identity`) — **direct ET via ngrok**.
- Pourtant le device affiche `Ã©` → la corruption est **dans l'app**.

Isolé sur device : au **cold-start**, le token a expiré → le 1er `GET /trips` part en 401 → refresh → **retry**. Ce chemin (`authMiddleware.onResponse`) reconstruisait la réponse via `new Response(arrayBuffer)` (choisi pour préserver l'export FIT binaire, #1047). Or `Response.json()/.text()` de RN décode un corps **ArrayBuffer en Latin-1** → `é` (C3 A9) devient `Ã©`. Un pull-to-refresh (token frais, pas de 401) réaffiche « Sensée » correctement → d'où l'« intermittent ».

## Fix
Dans le retry, reconstruire les payloads **texte** (`application/json`, `application/ld+json`, `text/*`) depuis une **string UTF-8** via `.text()` ; garder le round-trip **ArrayBuffer** uniquement pour le **binaire** (FIT/GPX) → #1047 reste byte-for-byte.

## Note
#1161 (exclusion compression mobile via `X-Client-Platform`) reste une défense valable (le natif ne doit pas recevoir de zstd/br), mais ce n'était pas la cause du mojibake. Aucun changement Caddy ici.

## Tests
- Nouveau test déterministe : un retry JSON lit `.text()` (jamais `.arrayBuffer()`) et `result.json()` rend l'accent intact ; le test binaire #1047 reste vert (arrayBuffer).
- Prove-it-can-fail : avec l'ancien code (arrayBuffer pour tout), `.text()` n'est pas appelé → rouge.
- CI mobile = tsc + jest : tsc clean, `client.test` 13/13. Suite complète 741/743 (les 2 rouges = `ShareSheet`/`account-notifications`, flakes de timeout sous charge, verts en isolation — hors périmètre).

<!-- claude-review-start -->
## Claude Review

**Summary:** 0 blocking findings. The previously flagged `application/problem+json` gap is fixed (content-type check now matches any `+json` suffix, with a dedicated regression test). 2 non-blocking notes below.

**Review checklist:**
- [x] Code respects the project architecture
- [x] SOLID principles and Law of Demeter followed
- [x] Design patterns used where appropriate
- [x] Tests cover new/changed cases
- [ ] Documentation is up to date — `TRACKING.md` Sprint 58.b note for #1172 (~line 2002) still says this was "not a code bug, stale APK, no fix needed"; worth updating on merge to avoid contradicting this PR's real root cause and fix
- [x] Dependent tickets accounted for

**Notes (non-blocking):**
- PR title `fix(mobile): mojibake accents — décoder le retry JSON en UTF-8 (#1172)` isn't in imperative mood (Conventional Commits) — the actual commit headline (`decode retried JSON as UTF-8 text, not raw bytes`) reads better and is already available if the title needs to change before merge.
- `TRACKING.md` (Sprint 58.b, #1172 row and the earlier "no code fix" note) should be reconciled with this PR's diagnosis once merged.

**Commit reviewed:** 2cfc647d4df1ff45ee65fe15d8e7adb5414e6c85

<!-- claude-review-end -->